### PR TITLE
feat: unify dark/flat/bias source folders into a single calibration kind

### DIFF
--- a/apps/desktop/src-tauri/src/commands/roots.rs
+++ b/apps/desktop/src-tauri/src/commands/roots.rs
@@ -48,9 +48,7 @@ pub async fn roots_register(
     );
 
     let kind = match category.as_str() {
-        "dark" => SourceKind::Dark,
-        "flat" => SourceKind::Flat,
-        "bias" => SourceKind::Bias,
+        "calibration" => SourceKind::Calibration,
         "project" => SourceKind::Project,
         "inbox" => SourceKind::Inbox,
         // "light_frames" and any unknown category default to LightFrames.

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -4877,8 +4877,15 @@ export type SettingsData = {
 	values: unknown,
 };
 
-/**  Kind of a registered source directory. */
-export type SourceKind = "light_frames" | "dark" | "flat" | "bias" | "project" | "inbox";
+/**
+ *  Kind of a registered source directory.
+ * 
+ *  `Calibration` replaces the former `Dark`, `Flat`, and `Bias` variants.
+ *  Per-image frame type (light / dark / flat / bias) is detected from image
+ *  metadata (FITS `IMAGETYP` header) during scan/ingest — the source-folder
+ *  kind is only a user-facing folder category.
+ */
+export type SourceKind = "light_frames" | "calibration" | "project" | "inbox";
 
 /**  Response DTO for `source.protection.get`. */
 export type SourceProtectionGetResponse = SourceProtectionGetResponse_Serialize | SourceProtectionGetResponse_Deserialize;

--- a/apps/desktop/src/features/setup/sources-store.ts
+++ b/apps/desktop/src/features/setup/sources-store.ts
@@ -2,23 +2,23 @@ import { registerRootBatch } from '@/api/commands';
 
 const STORAGE_KEY = 'alm-setup-wizard-state';
 
-export type SourceKind = 'light_frames' | 'dark' | 'flat' | 'bias' | 'project' | 'inbox';
+// Per-image frame type (light/dark/flat/bias) is detected from image metadata
+// (FITS IMAGETYP header) during scan/ingest — NOT inferred from which source
+// folder the file is in. 'calibration' here is only a user-facing folder
+// category that covers darks, flats, and bias frames together.
+export type SourceKind = 'light_frames' | 'calibration' | 'project' | 'inbox';
 export type ScanDepth = 'recursive' | 'single';
 
 export const ALL_SOURCE_KINDS: SourceKind[] = [
   'light_frames',
-  'dark',
-  'flat',
-  'bias',
+  'calibration',
   'project',
   'inbox',
 ];
 
 export const SOURCE_KIND_LABELS: Record<SourceKind, string> = {
   light_frames: 'Light frames',
-  dark: 'Darks',
-  flat: 'Flats',
-  bias: 'Bias',
+  calibration: 'Calibration frames',
   project: 'Projects',
   inbox: 'Inbox',
 };

--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -270,9 +270,7 @@ pub async fn complete_first_run(
     let sources = repo::list_sources(pool).await.map_err(db_to_contract)?;
     let source_count_by_kind = SourceCountByKind {
         light_frames: sources.iter().filter(|s| s.kind == SourceKind::LightFrames).count(),
-        dark: sources.iter().filter(|s| s.kind == SourceKind::Dark).count(),
-        flat: sources.iter().filter(|s| s.kind == SourceKind::Flat).count(),
-        bias: sources.iter().filter(|s| s.kind == SourceKind::Bias).count(),
+        calibration: sources.iter().filter(|s| s.kind == SourceKind::Calibration).count(),
         project: sources.iter().filter(|s| s.kind == SourceKind::Project).count(),
         inbox: sources.iter().filter(|s| s.kind == SourceKind::Inbox).count(),
     };

--- a/crates/audit/src/event_bus.rs
+++ b/crates/audit/src/event_bus.rs
@@ -68,13 +68,16 @@ pub struct LifecycleTransitionApplied {
 pub const TOPIC_LIFECYCLE_TRANSITION_APPLIED: &str = "lifecycle.transition.applied";
 
 /// Per-kind source counts for the `first_run.completed` audit event.
+///
+/// `calibration` replaces the former `dark`, `flat`, and `bias` fields now
+/// that the source-folder kind is unified into a single `calibration` bucket.
+/// Per-image frame type is detected from image metadata (FITS `IMAGETYP`),
+/// not from the source-folder kind.
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct SourceCountByKind {
     pub light_frames: usize,
-    pub dark: usize,
-    pub flat: usize,
-    pub bias: usize,
+    pub calibration: usize,
     pub project: usize,
     pub inbox: usize,
 }

--- a/crates/contracts/core/src/first_run.rs
+++ b/crates/contracts/core/src/first_run.rs
@@ -11,15 +11,18 @@ use crate::JsonAny;
 // ── Enums ───────────────────────────────────────────────────────────────────
 
 /// Kind of a registered source directory.
+///
+/// `Calibration` replaces the former `Dark`, `Flat`, and `Bias` variants.
+/// Per-image frame type (light / dark / flat / bias) is detected from image
+/// metadata (FITS `IMAGETYP` header) during scan/ingest — the source-folder
+/// kind is only a user-facing folder category.
 #[derive(
     Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Type,
 )]
 #[serde(rename_all = "snake_case")]
 pub enum SourceKind {
     LightFrames,
-    Dark,
-    Flat,
-    Bias,
+    Calibration,
     Project,
     Inbox,
 }
@@ -150,9 +153,7 @@ mod tests {
     #[test]
     fn source_kind_serializes_snake_case() {
         assert_eq!(serde_json::to_value(SourceKind::LightFrames).unwrap(), json!("light_frames"));
-        assert_eq!(serde_json::to_value(SourceKind::Dark).unwrap(), json!("dark"));
-        assert_eq!(serde_json::to_value(SourceKind::Flat).unwrap(), json!("flat"));
-        assert_eq!(serde_json::to_value(SourceKind::Bias).unwrap(), json!("bias"));
+        assert_eq!(serde_json::to_value(SourceKind::Calibration).unwrap(), json!("calibration"));
         assert_eq!(serde_json::to_value(SourceKind::Project).unwrap(), json!("project"));
         assert_eq!(serde_json::to_value(SourceKind::Inbox).unwrap(), json!("inbox"));
     }
@@ -175,6 +176,16 @@ mod tests {
         assert_eq!(value["scanDepth"], json!("recursive"));
         assert_eq!(value["kind"], json!("light_frames"));
         assert!(value.get("kindSubtype").is_none()); // skip_serializing_if
+
+        // Calibration kind serializes as "calibration"
+        let cal_req = RegisterSourceRequest {
+            kind: SourceKind::Calibration,
+            path: "/astro/cals".to_owned(),
+            kind_subtype: None,
+            scan_depth: ScanDepth::Recursive,
+        };
+        let cal_value = serde_json::to_value(cal_req).unwrap();
+        assert_eq!(cal_value["kind"], json!("calibration"));
     }
 
     #[test]

--- a/crates/persistence/db/migrations/0032_unify_calibration_source_kind.sql
+++ b/crates/persistence/db/migrations/0032_unify_calibration_source_kind.sql
@@ -1,0 +1,51 @@
+-- Migration 0032: collapse dark/flat/bias source kinds into a single
+-- 'calibration' kind (spec 030 / feat/unify-calibration-source-kind).
+--
+-- registered_sources.kind changes from the 6-type set
+--   ('light_frames', 'dark', 'flat', 'bias', 'project', 'inbox')
+-- to the unified 4-type set
+--   ('light_frames', 'calibration', 'project', 'inbox').
+--
+-- Per-image frame type (light/dark/flat/bias) is detected from image
+-- metadata (FITS IMAGETYP header) during scan/ingest — NOT inferred from
+-- the source-folder kind. The 'calibration' kind is only a user-facing
+-- folder category.
+--
+-- SQLite does not support ALTER CHECK, so the table is rebuilt.
+
+-- ── Rebuild registered_sources ───────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS registered_sources_new (
+    id           TEXT PRIMARY KEY,
+    kind         TEXT NOT NULL CHECK (kind IN ('light_frames', 'calibration', 'project', 'inbox')),
+    path         TEXT NOT NULL,
+    kind_subtype TEXT,
+    scan_depth   TEXT NOT NULL DEFAULT 'recursive' CHECK (scan_depth IN ('recursive', 'single')),
+    created_at   TEXT NOT NULL,
+    created_via  TEXT NOT NULL CHECK (created_via IN ('first_run', 'settings_add', 'settings_restart')),
+    last_seen_at TEXT,
+    UNIQUE(kind, path)
+);
+
+-- Migrate data: collapse 'dark', 'flat', 'bias' → 'calibration'.
+-- Where multiple rows for the same path differ only in their old kind
+-- (e.g. a path registered separately as 'dark' and as 'flat'), the
+-- UNIQUE(kind, path) constraint on the new table would reject duplicates.
+-- We guard against this by using INSERT OR IGNORE so that only the first
+-- encountered row for each (calibration, path) pair is retained.
+INSERT OR IGNORE INTO registered_sources_new
+    (id, kind, path, kind_subtype, scan_depth, created_at, created_via, last_seen_at)
+SELECT
+    id,
+    CASE kind
+        WHEN 'dark' THEN 'calibration'
+        WHEN 'flat' THEN 'calibration'
+        WHEN 'bias' THEN 'calibration'
+        ELSE kind
+    END,
+    path, kind_subtype, scan_depth, created_at, created_via, last_seen_at
+FROM registered_sources
+ORDER BY created_at ASC;
+
+DROP TABLE registered_sources;
+ALTER TABLE registered_sources_new RENAME TO registered_sources;

--- a/crates/persistence/db/src/repositories/first_run.rs
+++ b/crates/persistence/db/src/repositories/first_run.rs
@@ -25,9 +25,7 @@ fn now_iso() -> String {
 fn source_kind_to_str(kind: SourceKind) -> &'static str {
     match kind {
         SourceKind::LightFrames => "light_frames",
-        SourceKind::Dark => "dark",
-        SourceKind::Flat => "flat",
-        SourceKind::Bias => "bias",
+        SourceKind::Calibration => "calibration",
         SourceKind::Project => "project",
         SourceKind::Inbox => "inbox",
     }
@@ -35,9 +33,7 @@ fn source_kind_to_str(kind: SourceKind) -> &'static str {
 
 fn str_to_source_kind(s: &str) -> SourceKind {
     match s {
-        "dark" => SourceKind::Dark,
-        "flat" => SourceKind::Flat,
-        "bias" => SourceKind::Bias,
+        "calibration" => SourceKind::Calibration,
         "project" => SourceKind::Project,
         "inbox" => SourceKind::Inbox,
         // "light_frames" and any unknown value default to LightFrames.

--- a/specs/030-ui-audit-revision/data-model.md
+++ b/specs/030-ui-audit-revision/data-model.md
@@ -3,24 +3,29 @@
 Changes to the data model required by the UI redesign. Most changes are in
 settings/configuration domain, not core domain entities.
 
-## Source Folder Type Expansion
+## Source Folder Type Unification
 
-The current source folder type enum (`raw`, `calibration`, `project`, `inbox`)
-expands to match the wizard's per-type registration:
+The source folder kind enum is a 4-value set used only as a user-facing folder
+category in the setup wizard and settings. It does NOT determine per-image frame
+type; that is detected from image metadata (FITS `IMAGETYP` header) during
+scan/ingest.
 
 ```
-SourceFolderType:
+SourceFolderKind:
   - light_frames    (was: raw)
-  - dark
-  - flat
-  - bias
+  - calibration     (covers darks, flats, and bias — kind collapsed from 6→4)
   - project
   - inbox
 ```
 
-Migration: existing `raw` entries map to `light_frames`. Existing `calibration`
-entries need user disambiguation (could be dark, flat, or bias). A migration
-prompt or re-registration flow handles this.
+Migration notes:
+- `raw` → `light_frames` (migration 0010).
+- `dark`, `flat`, `bias` → `calibration` (migration 0032). Where the same path
+  was registered under multiple of these kinds, only the earliest entry is kept
+  (INSERT OR IGNORE by `created_at ASC`) and duplicates are silently dropped.
+- Per-image frame type (light / dark / flat / bias) remains authoritative from
+  FITS `IMAGETYP` metadata, so no information is lost by collapsing the folder
+  kind.
 
 ## Equipment Entities
 

--- a/tests/contract/roots_register_batch_test.rs
+++ b/tests/contract/roots_register_batch_test.rs
@@ -23,9 +23,9 @@ fn sample_batch_request() -> RegisterSourceBatchRequest {
                 scan_depth: ScanDepth::Recursive,
             },
             RegisterSourceRequest {
-                kind: SourceKind::Dark,
-                path: "/astro/darks".to_owned(),
-                kind_subtype: Some("dark".to_owned()),
+                kind: SourceKind::Calibration,
+                path: "/astro/cals".to_owned(),
+                kind_subtype: Some("calibration".to_owned()),
                 scan_depth: ScanDepth::Single,
             },
         ],
@@ -114,7 +114,7 @@ fn batch_request_preserves_source_order() {
 
     assert_eq!(sources[0]["kind"], json!("light_frames"));
     assert_eq!(sources[1]["kind"], json!("project"));
-    assert_eq!(sources[2]["kind"], json!("dark"));
+    assert_eq!(sources[2]["kind"], json!("calibration"));
 }
 
 // ── batch status enum ──────────────────────────────────────────────────────

--- a/tests/contract/roots_register_test.rs
+++ b/tests/contract/roots_register_test.rs
@@ -16,9 +16,9 @@ fn sample_request() -> RegisterSourceRequest {
 
 fn sample_request_with_subtype() -> RegisterSourceRequest {
     RegisterSourceRequest {
-        kind: SourceKind::Dark,
-        path: "/astro/darks".to_owned(),
-        kind_subtype: Some("dark".to_owned()),
+        kind: SourceKind::Calibration,
+        path: "/astro/cals".to_owned(),
+        kind_subtype: Some("calibration".to_owned()),
         scan_depth: ScanDepth::Single,
     }
 }
@@ -52,7 +52,7 @@ fn request_with_kind_subtype_includes_field() {
         serde_json::to_value(sample_request_with_subtype()).expect("request should serialize");
     let obj = value.as_object().expect("request should be an object");
 
-    assert_eq!(obj["kindSubtype"], json!("dark"));
+    assert_eq!(obj["kindSubtype"], json!("calibration"));
     assert_eq!(obj["scanDepth"], json!("single"));
 }
 
@@ -62,9 +62,7 @@ fn request_with_kind_subtype_includes_field() {
 fn source_kind_variants_match_contract_enum() {
     let expected = [
         (SourceKind::LightFrames, "light_frames"),
-        (SourceKind::Dark, "dark"),
-        (SourceKind::Flat, "flat"),
-        (SourceKind::Bias, "bias"),
+        (SourceKind::Calibration, "calibration"),
         (SourceKind::Project, "project"),
         (SourceKind::Inbox, "inbox"),
     ];
@@ -80,7 +78,7 @@ fn source_kind_variants_match_contract_enum() {
 
 #[test]
 fn source_kind_roundtrips_from_json() {
-    for variant_str in ["light_frames", "dark", "flat", "bias", "project", "inbox"] {
+    for variant_str in ["light_frames", "calibration", "project", "inbox"] {
         let deserialized: SourceKind =
             serde_json::from_value(json!(variant_str)).unwrap_or_else(|e| {
                 panic!("\"{variant_str}\" should deserialize to SourceKind: {e}");


### PR DESCRIPTION
## Summary

- The source-folder setup wizard no longer asks you to split calibration folders into separate **dark / flat / bias** kinds — they're collapsed into one **"Calibration frames"** source kind (kinds are now `light_frames | calibration | project | inbox`).
- Per-image frame type (light/dark/flat/bias) is still detected from **FITS `IMAGETYP` metadata** at scan/ingest — verified already decoupled from the source-folder kind, so detection is unchanged. The folder kind is just a user-facing category.

## Changes

- Migration `0032_unify_calibration_source_kind.sql` rebuilds `registered_sources` with the 4-kind CHECK and maps existing `dark`/`flat`/`bias` rows → `calibration` (drops duplicate-path collisions, earliest kept).
- Backend `SourceKind` enum, persistence repo, audit source counts, `roots.register` command; frontend `sources-store` + setup wizard; regenerated TS bindings; spec 030 data-model updated.
- The spec-007 **calibration-matching** model (Dark/Flat/Bias) is intentionally **untouched** — that's a separate domain (matching masters to lights).

## Notes

- Migration numbered **0032** to coexist with spec-035's in-flight `0031` on another branch.
- Verified: `cargo build --workspace`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, and `tsc` typecheck all clean/green.
