### PR TITLE
test(035): live SIMBAD SC-004 in default suite + retirement/US4 plans

### DIFF
--- a/crates/targeting/tests/simbad_live.rs
+++ b/crates/targeting/tests/simbad_live.rs
@@ -1,27 +1,54 @@
-//! Gated online integration tests against the live SIMBAD CDS service.
+//! Online integration tests against the live SIMBAD CDS service (SC-004).
 //!
-//! These tests require a real network connection to simbad.cds.unistra.fr and
-//! are marked `#[ignore]` so they are excluded from the default `cargo test`
-//! run. Execute them explicitly when network access is available:
-//!
-//! ```text
-//! cargo test -p targeting --test simbad_live -- --ignored
-//! ```
-//!
-//! They exercise the real [`SimbadResolver`] end-to-end: two ADQL round-trips
+//! These exercise the real [`SimbadResolver`] end-to-end: two ADQL round-trips
 //! to the TAP sync endpoint, TSV parsing, alias set construction, and
 //! coordinate/object-type mapping.
 //!
+//! Unlike a `#[ignore]`-gated suite, these run as part of the **default**
+//! `cargo test` so SC-004 has live coverage. To stay deterministic where there
+//! is no network (offline dev, sandboxed CI), each test issues a **single**
+//! resolve via [`resolve_or_skip`] and distinguishes a transient outage
+//! (`Network`/`Timeout`/`Disabled` → log + skip, never fail) from a genuine
+//! data/parse mismatch (→ fail). One network request per test keeps SIMBAD
+//! from rate-limiting the suite. Set `ALM_SKIP_LIVE_SIMBAD=1` to force-skip.
+//!
 //! # Spec 035 coverage
 //!
-//! - **T024**: live SIMBAD round-trip for M 31 (Andromeda Galaxy) and NGC 7000
-//!   (North America Nebula) — verifies canonical identity, plausible ICRS
+//! - **T024 / SC-004**: live SIMBAD round-trip for M 31 (Andromeda Galaxy) and
+//!   NGC 7293 (Helix Nebula) — verifies canonical identity, plausible ICRS
 //!   coordinates, object type, and cross-ID alias set.
 
 use targeting::resolver::simbad::{SimbadConfig, SimbadResolver};
-use targeting::resolver::{AliasKind, ObjectType, Resolver};
+use targeting::resolver::{AliasKind, ObjectType, ResolveError, ResolvedIdentity, Resolver};
 
 // ── helpers ──────────────────────────────────────────────────────────────────
+
+/// Resolve `query` against live SIMBAD with exactly one network request.
+///
+/// Returns `Some(identity)` to proceed with assertions; returns `None` (after
+/// logging) to **skip** when the outage is transient — `ALM_SKIP_LIVE_SIMBAD`
+/// is set, or the resolver reports `Network`/`Timeout`/`Disabled` (offline dev,
+/// sandboxed CI, or a rate-limit hiccup). A genuine data failure
+/// (`NotFound`/`Ambiguous`/`Parse`) **panics**, so real regressions still fail.
+async fn resolve_or_skip(query: &str, test: &str) -> Option<ResolvedIdentity> {
+    if std::env::var_os("ALM_SKIP_LIVE_SIMBAD").is_some() {
+        eprintln!("SKIP {test}: ALM_SKIP_LIVE_SIMBAD set — SC-004 not exercised this run");
+        return None;
+    }
+    let resolver = SimbadResolver::new(&SimbadConfig::default())
+        .expect("SimbadResolver should build from default config");
+    match resolver.resolve(query).await {
+        Ok(identity) => Some(identity),
+        Err(e @ (ResolveError::Network(_) | ResolveError::Timeout(_) | ResolveError::Disabled)) => {
+            eprintln!(
+                "SKIP {test}: live SIMBAD unreachable resolving {query:?} ({e}) — \
+                 SC-004 live assertions not exercised this run"
+            );
+            None
+        }
+        Err(e) => panic!("live SIMBAD resolve of {query:?} failed (non-transient): {e}"),
+    }
+}
 
 /// Assert `actual` is within `tolerance` degrees of `expected`.
 fn assert_deg_approx(label: &str, actual: f64, expected: f64, tolerance: f64) {
@@ -42,8 +69,8 @@ fn has_alias(aliases: &[targeting::resolver::ResolvedAlias], needle: &str) -> bo
 
 /// Live SIMBAD resolution of M 31 (Andromeda Galaxy).
 ///
-/// Requires network access to simbad.cds.unistra.fr — ignored by default.
-/// Run with: `cargo test -p targeting --test simbad_live -- --ignored`
+/// Runs in the default suite; skips gracefully when SIMBAD is unreachable.
+/// Force-skip with `ALM_SKIP_LIVE_SIMBAD=1`.
 ///
 /// Assertions (tolerances generous; SIMBAD coords are precise but we avoid
 /// hard-coding excessive decimal places):
@@ -55,13 +82,10 @@ fn has_alias(aliases: &[targeting::resolver::ResolvedAlias], needle: &str) -> bo
 /// - a `CommonName` alias for "Andromeda Galaxy" is present
 /// - `simbad_oid` is populated (non-None)
 #[tokio::test]
-#[ignore = "requires network access to simbad.cds.unistra.fr; run with --ignored"]
 async fn live_resolve_m31_andromeda_galaxy() {
-    let resolver = SimbadResolver::new(&SimbadConfig::default())
-        .expect("SimbadResolver should build from default config");
-
-    let identity =
-        resolver.resolve("M 31").await.expect("live SIMBAD resolve of 'M 31' must succeed");
+    let Some(identity) = resolve_or_skip("M 31", "live_resolve_m31_andromeda_galaxy").await else {
+        return;
+    };
 
     // Coordinates — ICRS J2000 decimal degrees. M 31 centroid is well-known:
     // ra ≈ 10.6847°, dec ≈ 41.2692°. Tolerance ±0.5° covers any future
@@ -108,8 +132,8 @@ async fn live_resolve_m31_andromeda_galaxy() {
 
 /// Live SIMBAD resolution of NGC 7293 (Helix Nebula).
 ///
-/// Requires network access to simbad.cds.unistra.fr — ignored by default.
-/// Run with: `cargo test -p targeting --test simbad_live -- --ignored`
+/// Runs in the default suite; skips gracefully when SIMBAD is unreachable.
+/// Force-skip with `ALM_SKIP_LIVE_SIMBAD=1`.
 ///
 /// NGC 7293 is classified as `PN` (planetary nebula) in SIMBAD — one of the
 /// most stable object-type assignments in the database. Confirmed live:
@@ -123,13 +147,11 @@ async fn live_resolve_m31_andromeda_galaxy() {
 /// - `simbad_oid` is populated
 /// - alias set is non-empty
 #[tokio::test]
-#[ignore = "requires network access to simbad.cds.unistra.fr; run with --ignored"]
 async fn live_resolve_ngc7293_helix_nebula() {
-    let resolver = SimbadResolver::new(&SimbadConfig::default())
-        .expect("SimbadResolver should build from default config");
-
-    let identity =
-        resolver.resolve("NGC 7293").await.expect("live SIMBAD resolve of 'NGC 7293' must succeed");
+    let Some(identity) = resolve_or_skip("NGC 7293", "live_resolve_ngc7293_helix_nebula").await
+    else {
+        return;
+    };
 
     // Coordinates — Helix Nebula centroid: ra ≈ 337.41°, dec ≈ −20.84°.
     assert_deg_approx("ra_deg", identity.ra_deg, 337.4, 1.0);

--- a/docs/development/legacy-target-table-retirement-plan.md
+++ b/docs/development/legacy-target-table-retirement-plan.md
@@ -1,0 +1,85 @@
+# Legacy target-table retirement plan
+
+**Status:** PLAN ONLY — not executed. This is a sprawling, cross-spec refactor that
+breaks live features if done naively; it needs its own SpecKit feature and a couple
+of product decisions (called out below). Do **not** drop the tables before the
+prerequisite rewrites land.
+
+## Why this exists
+
+Spec 035 introduced a third generation of target storage. Three now coexist:
+
+| Gen | Tables | Migration | Status |
+|-----|--------|-----------|--------|
+| 1 (legacy) | `target` (singular) | 0002 | abandoned — never written by modern code |
+| 2 (spec 013/023) | `targets`, `target_aliases`, `target_catalog_refs`, `catalog_equivalences` | 0017, 0027 | **ACTIVE** — Targets page, catalog load, identity UI |
+| 3 (spec 035, keeper) | `canonical_target`, `target_alias` | 0031, 0033 | keeper |
+
+Goal: retire gen 1 + gen 2, keep gen 3.
+
+## Blast radius (why it is NOT a simple DROP)
+
+Retiring gen 2 breaks these **live** paths unless they are rewritten first:
+
+1. **In-memory catalog** — `crates/targeting/src/load.rs:40,51` reads `targets` +
+   `target_catalog_refs` to build the catalog used by spec-013 `target.lookup` /
+   `target.resolve.fits`. Drop the tables → empty catalog.
+2. **Targets page identity UI (spec 023)** — `crates/app/core/src/target_identity.rs`
+   + `apps/desktop/src-tauri/src/commands/target_identity.rs` expose 5 live commands
+   (`target.get`, `target.note.update`, `target.alias.add/remove`,
+   `target.primary.rename`) that read/write `targets`/`target_aliases`. These back the
+   primary-nav "Targets" page (spec 033 design-v4). Drop → page breaks.
+3. **Inventory projection (spec 006)** — `crates/persistence/db/src/repositories/inventory.rs:137`
+   `LEFT JOIN target t ON t.id = acs.target_id` (gen-1 table) for `target_name`.
+4. **Project / session / source FK columns** — `projects.target_id`,
+   `project_sources.target_id`, `acquisition_session.acq_target_id` (all 0027), plus
+   `acquisition_session.target_id` (0002). Legacy projects may carry `target_id` with
+   no `canonical_target_id`.
+
+`crates/app/core/src/ingest_resolution.rs` and `project_setup.rs` already use gen 3
+only — they are safe.
+
+## Product decisions required (cannot proceed without these)
+
+- **D1 — Target notes.** Gen-3 `canonical_target` has **no `notes` field**; spec-023
+  notes live on `targets.notes`. Decide: add `notes`/`updated_at` to `canonical_target`
+  (or a side `canonical_target_notes` table), or drop the notes feature.
+- **D2 — Primary-designation rename.** Spec-023 `target.primary.rename` edits
+  `targets.primary_designation` freely. Gen 3 derives the primary from
+  `target_alias.kind='designation'` + `canonical_target.primary_designation` sourced
+  from SIMBAD. Decide whether user free-rename of a SIMBAD-canonical target is still
+  allowed, and how it persists (manual-override precedence already exists for
+  resolution; rename is a different axis).
+- **D3 — Targets page.** Confirm the Targets page is rebuilt on gen-3 data (it must be,
+  since its commands get rewritten).
+
+## Dependency-ordered execution (each step ships + is verified before the next)
+
+1. **Catalog load → gen 3.** Rewrite `targeting::load::load_from_db()` to read
+   `canonical_target` + `target_alias`. Keep `target.lookup`/`target.resolve.fits`
+   working off gen 3 (or retire `target.resolve.fits`, already superseded by spec-035
+   `target.resolve` and not called by the frontend).
+2. **Identity commands → gen 3.** Rewrite the 5 `target_identity` use-cases + commands
+   to `canonical_target`/`target_alias` (needs D1/D2). Migrate the Targets page (D3).
+3. **Inventory projection → gen 3.** Repoint `inventory.rs` `target_name` join at the
+   keeper table; backfill/relink `acquisition_session` target ids.
+4. **Project link backfill.** For every `projects.target_id IS NOT NULL AND
+   canonical_target_id IS NULL`, resolve/create the gen-3 `canonical_target` and set
+   `canonical_target_id`. Verify zero remaining before step 6.
+5. **project_sources.target_id audit.** Confirm dead (no reads/writes found) or add a
+   parallel `canonical_target_id` and migrate.
+6. **Retirement migration (e.g. `0034_retire_legacy_targets.sql`).** Append-only. Drop
+   FK columns (`projects.target_id`, `project_sources.target_id`,
+   `acquisition_session.acq_target_id`, `acquisition_session.target_id`) and tables
+   (`target_aliases`, `target_catalog_refs`, `catalog_equivalences`, `targets`,
+   `target`) with `IF EXISTS`. SQLite needs table rebuilds to drop columns.
+7. **Cleanup.** Remove `repositories/targets.rs`, the gen-2 contract DTOs, and dead
+   commands; update specs 013/023/006/008 docs to point at gen 3.
+
+## Recommendation
+
+Run this as a dedicated SpecKit feature (`/speckit.specify` "retire legacy target
+tables, consolidate on spec-035 canonical_target") so D1–D3 get clarified and each
+rewrite step is tasked + verified. Estimated effort: multi-day, not a single PR.
+Executing it blind/unattended would break the Targets page, catalog lookup, and the
+Inbox target column.

--- a/docs/development/us4-ingest-wiring-plan.md
+++ b/docs/development/us4-ingest-wiring-plan.md
@@ -1,0 +1,60 @@
+# US4 ingest grouping — wiring plan (spec 035 gap #2)
+
+**Status:** PLAN ONLY. The resolver seam is built and tested; the blocker is a
+missing per-file ingest pipeline, not the resolver.
+
+## What US4 needs (one-line answer)
+
+A production code path that, for each ingested image file, creates a `file_record`
+row and calls
+`ingest_resolution::associate_or_enqueue(pool, bus, file_record_id, object_raw)`
+with the file's FITS `OBJECT` header value. That pipeline does not exist today.
+
+## What already exists (done, do not rebuild)
+
+- `crates/app/core/src/ingest_resolution.rs` — `associate_or_enqueue` (cache-hit
+  inline / miss → `pending`) + `resolve_pending` drain. Fully unit-tested. Uses
+  gen-3 `canonical_target` only.
+- FITS `OBJECT` extraction — `crates/metadata/fits/src/lib.rs` →
+  `RawFileMetadata.object` (`crates/metadata/core/src/lib.rs:216`). The value is
+  already parsed; today it dead-ends in `crates/app/core/src/inbox/confirm.rs:349-354`
+  where it only feeds naming-pattern token resolution (not the resolver).
+- `file_record` table — defined in migration `0002_lifecycle.sql:26`.
+
+## The real gap
+
+`file_record` is **never written by production code** (only tests insert it). Scanning
+is folder-level: `crates/fs/inventory/src/lib.rs` + `commands/inbox.rs` create
+`inbox_items` (per folder), not per-file rows. So there is no `file_record.id` to pass
+as `image_id`, and no place that currently iterates files-with-metadata at ingest time
+other than the confirm pipeline (which builds plans, not records).
+
+## Minimal wiring once per-file ingest exists
+
+1. When an image file is ingested/confirmed, create its `file_record` row → get `id`.
+2. If `RawFileMetadata.object` is `Some`, call
+   `associate_or_enqueue(pool, bus, &file_record_id, object.trim())`.
+3. Run `resolve_pending` on a background tick to drain cache-miss enqueues
+   (transient/offline stay `pending`, genuine misses → `unresolved`).
+
+Natural hook point: the per-file loop in `inbox/confirm.rs` (it already has the file
+path + extracted `meta.object`), **after** file_record creation is added there.
+
+Estimated wiring once the pipeline exists: a few hours. Building the per-file ingest
+pipeline itself: ~2–3 days.
+
+## Ownership
+
+The missing per-file ingest (file_record creation + lifecycle transitions) is a
+**spec-002 milestone** (spec-002 defines the `file_record` lifecycle states but not the
+process that creates/transitions rows). `0002_lifecycle.sql:32` even notes the
+session↔file relational join was "deferred to T006". US4 should be wired as the final
+small step of that spec-002 ingest work, or a dedicated ingest spec — not inside spec
+035.
+
+## Recommendation
+
+Leave spec-035 US4 as a documented tested seam (current state). Schedule the per-file
+ingest pipeline under spec 002 (or a new ingest spec); add the `associate_or_enqueue`
+call as an explicit task in that spec so the seam gets connected when the producer of
+`file_record.id` lands.


### PR DESCRIPTION
## Summary

Follow-ups after merging spec 035 (#250) and calibration unification (#251).

### SC-004 — live SIMBAD coverage in the default test suite
Removed `#[ignore]` from the M 31 / NGC 7293 live round-trips so SC-004 is actually exercised by `cargo test`. Design keeps it deterministic offline:
- **one** network request per test;
- transient errors (`Network`/`Timeout`/`Disabled`) → graceful skip (logged, not failed) for offline dev / sandboxed CI / rate-limit hiccups;
- genuine data/parse mismatches still **fail**;
- `ALM_SKIP_LIVE_SIMBAD=1` force-skips.

Validated live against SIMBAD CDS (both pass; force-skip path verified).

### Planning docs (no code) for the two remaining spec-035 gaps
- `docs/development/legacy-target-table-retirement-plan.md` — dependency-ordered plan to retire the legacy gen-1 (`target`) and gen-2 (spec-013/023 `targets`/`target_aliases`/…) tables and consolidate on spec-035 `canonical_target`. **Sprawling cross-spec refactor**: it would break the live Targets page (spec 023), catalog load (spec 013), and inventory projection (spec 006) if dropped naively, and needs product decisions (target notes field, primary-rename semantics). Recommended as its own SpecKit feature.
- `docs/development/us4-ingest-wiring-plan.md` — US4 ingest grouping is blocked on a missing per-file `file_record` ingest pipeline (a spec-002 milestone), not the resolver. The resolver seam is built/tested; wiring is a few hours once the per-file producer lands.

## Verification
- `cargo test -p targeting --test simbad_live` — 2 passed (live); force-skip path verified.
- `cargo fmt --all --check` clean.
- Full workspace (`cargo test --workspace`, clippy, typecheck, vitest) green on the merged main base prior to this branch.

## Context
Both #250 and #251 are merged to main. This branch is pure follow-up.