### PR TITLE
fix(ux): tool picker selects binary; rebrand resolution step to Configuration

### DIFF
--- a/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
@@ -77,21 +77,50 @@ export function ResolverSettingsControl({ compact = false }: ResolverSettingsCon
 
   return (
     <>
-      <div className="alm-settings__row">
-        <div className="alm-settings__row-label">Online SIMBAD resolution</div>
-        <div className="alm-settings__row-content">
-          <Toggle
-            checked={settings.onlineEnabled}
-            aria-label="Enable online SIMBAD resolution"
-            onChange={(v) => void persist({ onlineEnabled: v })}
-          />
+      {compact ? (
+        // First-run Configuration step: label + toggle on one line, description
+        // below the control (not beside it).
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-2)' }}>
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'space-between',
+              gap: 'var(--alm-sp-3)',
+            }}
+          >
+            <span style={{ fontWeight: 'var(--alm-weight-semibold)', whiteSpace: 'nowrap' }}>
+              Online SIMBAD resolution
+            </span>
+            <Toggle
+              checked={settings.onlineEnabled}
+              aria-label="Enable online SIMBAD resolution"
+              onChange={(v) => void persist({ onlineEnabled: v })}
+            />
+          </div>
           <div className="alm-settings__row-desc">
             {settings.onlineEnabled
               ? 'Targets not in the bundled seed or local cache are resolved on demand from SIMBAD, then cached.'
               : 'Online resolution is off — only the bundled seed and local cache are used. Unknown objects are marked unresolved.'}
           </div>
         </div>
-      </div>
+      ) : (
+        <div className="alm-settings__row">
+          <div className="alm-settings__row-label">Online SIMBAD resolution</div>
+          <div className="alm-settings__row-content">
+            <Toggle
+              checked={settings.onlineEnabled}
+              aria-label="Enable online SIMBAD resolution"
+              onChange={(v) => void persist({ onlineEnabled: v })}
+            />
+            <div className="alm-settings__row-desc">
+              {settings.onlineEnabled
+                ? 'Targets not in the bundled seed or local cache are resolved on demand from SIMBAD, then cached.'
+                : 'Online resolution is off — only the bundled seed and local cache are used. Unknown objects are marked unresolved.'}
+            </div>
+          </div>
+        </div>
+      )}
 
       {!compact && (
         <>

--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -280,7 +280,7 @@ describe('SetupWizard 4-step flow', () => {
 
     // Click Continue — should advance to Catalogs step
     fireEvent.click(continueBtn);
-    expect(screen.getByRole('heading', { name: /target resolution/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /configuration/i })).toBeInTheDocument();
   });
 
   it('allows Step 3 (Catalogs) to advance without changes', async () => {
@@ -304,7 +304,7 @@ describe('SetupWizard 4-step flow', () => {
     renderWizard();
 
     // We should be on the Catalogs step (heading)
-    expect(screen.getByRole('heading', { name: /target resolution/i })).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /configuration/i })).toBeInTheDocument();
     expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
 
     // Continue should be enabled

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -46,9 +46,9 @@ const STEPS = [
     description: 'Configure the astrophotography processing tools installed on your system.',
   },
   {
-    label: 'Resolution',
-    heading: 'Target resolution',
-    description: 'How object names in your files are resolved to known astronomical targets.',
+    label: 'Configuration',
+    heading: 'Configuration',
+    description: 'Set a few defaults now — you can change all of these later in Settings.',
   },
   {
     label: 'Confirm',

--- a/apps/desktop/src/features/setup/steps/StepTools.tsx
+++ b/apps/desktop/src/features/setup/steps/StepTools.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Btn } from '@/ui/Btn';
 import { Pill } from '@/ui/Pill';
 import { Toggle } from '@/ui/Toggle';
-import { useDirectoryPicker } from '@/shared/native/picker';
+import { useFilePicker } from '@/shared/native/picker';
 
 export interface ToolConfig {
   enabled: boolean;
@@ -246,10 +246,15 @@ function ToolPathPicker({
   path: string | null;
   onPathChange: (path: string | null) => void;
 }) {
-  const { pick, loading } = useDirectoryPicker();
+  const { pick, loading } = useFilePicker();
 
   const handleChoose = async () => {
-    const result = await pick();
+    // The processing tool's executable is a file (e.g. PixInsight.exe /
+    // pixinsight / Siril), not a directory — pick the binary, not a folder.
+    const result = await pick([
+      { name: 'Executable', extensions: ['exe', 'app', 'bin'] },
+      { name: 'All files', extensions: ['*'] },
+    ]);
     if (result.path) {
       onPathChange(result.path);
     }
@@ -284,8 +289,13 @@ function ToolPathPicker({
         {path ?? 'No path set'}
       </span>
       {path && <Pill variant="ok">OK</Pill>}
-      <Btn size="sm" onClick={handleChoose} disabled={loading}>
-        {loading ? 'Choosing…' : `Choose ${toolName}…`}
+      <Btn
+        size="sm"
+        onClick={handleChoose}
+        disabled={loading}
+        aria-label={`Select ${toolName} binary`}
+      >
+        {loading ? 'Choosing…' : 'Select binary…'}
       </Btn>
     </>
   );


### PR DESCRIPTION
Windows-validation feedback:
1. Processing-tool 'Choose {tool}…' opened a **directory** picker → now uses the **file picker** and is labeled **'Select binary…'** (the tool path is an executable, not a folder).
2. First-run resolution step rebranded **'Resolution' → 'Configuration'**; the online-resolution toggle now shows label + toggle on one line with the description below (was cramped). Step will host more first-run defaults (follow-up).

typecheck + vitest (577) green.