### PR TITLE
feat(ux): populate first-run Configuration step with real defaults

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -52,6 +52,7 @@ const mockPreferences: AppPreferences = {
   sessionsView: 'list',
   tourCompleted: { step1: false, step2: false, step3: false },
   setupCompleted: false,
+  defaultScanDepth: 'recursive',
 };
 
 // Review items are loaded from the wireframe-aligned fixture file (review.queue case below).

--- a/apps/desktop/src/bindings/types.ts
+++ b/apps/desktop/src/bindings/types.ts
@@ -82,6 +82,8 @@ export interface AppPreferences {
   sessionsView: 'list' | 'calendar';
   tourCompleted: { step1: boolean; step2: boolean; step3: boolean };
   setupCompleted: boolean;
+  /** Default scan depth applied to newly added source folders (first-run config). */
+  defaultScanDepth: 'recursive' | 'single';
 }
 
 export interface SourceMap {

--- a/apps/desktop/src/data/preferences.ts
+++ b/apps/desktop/src/data/preferences.ts
@@ -17,6 +17,7 @@ const defaults: AppPreferences = {
   sessionsView: 'list',
   tourCompleted: { step1: false, step2: false, step3: false },
   setupCompleted: false,
+  defaultScanDepth: 'recursive',
 };
 
 function notify(): void {

--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -69,6 +69,9 @@ vi.mock('@/api/commands', () => ({
   updateResolverSettings: vi.fn().mockImplementation((settings) =>
     Promise.resolve({ contractVersion: '1.0', requestId: 'r', settings }),
   ),
+  // Configuration step also reads/writes the default source-protection setting.
+  getSettings: vi.fn().mockResolvedValue({ values: { defaultProtection: 'protected' } }),
+  updateSettings: vi.fn().mockResolvedValue(undefined),
 }));
 
 // Mock @tauri-apps/api/core to prevent any accidental live invoke.

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { WizardShell } from '@/ui/WizardShell';
 import { Btn } from '@/ui/Btn';
-import { setPreference } from '@/data/preferences';
+import { setPreference, getPreferences } from '@/data/preferences';
 import { completeFirstRun } from '@/api/commands';
 import {
   StepSourceFolders,
@@ -152,7 +152,7 @@ export function SetupWizard() {
       if (validationError) {
         setState((prev) => ({
           ...prev,
-          sources: addSource(prev.sources, kind, path),
+          sources: addSource(prev.sources, kind, path, getPreferences().defaultScanDepth),
         }));
         setErrors((prev) => ({
           ...prev,
@@ -163,7 +163,7 @@ export function SetupWizard() {
 
       setState((prev) => ({
         ...prev,
-        sources: addSource(prev.sources, kind, path),
+        sources: addSource(prev.sources, kind, path, getPreferences().defaultScanDepth),
       }));
       // Clear any error for this index
       setErrors((prev) => {

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
@@ -1,23 +1,27 @@
 /// <reference types="@testing-library/jest-dom" />
 /**
- * StepCatalogs tests — spec 035 (repurposed first-run "Target resolution" step).
+ * StepCatalogs tests — first-run "Configuration" step.
  *
- * The step no longer downloads catalogs (spec-014 backend removed). It now shows
- * the SIMBAD online-resolution toggle plus an explanatory note. These tests
- * confirm the new content and the absence of any catalog-download affordance.
+ * The step no longer downloads catalogs (spec-014 backend removed). It is now a
+ * small Configuration screen: SIMBAD online-resolution toggle, display density,
+ * default source protection, default scan depth, and a disabled theme control.
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockGet, mockUpdate } = vi.hoisted(() => ({
+const { mockGet, mockUpdate, mockGetSettings, mockUpdateSettings } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockUpdate: vi.fn(),
+  mockGetSettings: vi.fn(),
+  mockUpdateSettings: vi.fn(),
 }));
 
 vi.mock('@/api/commands', () => ({
   getResolverSettings: mockGet,
   updateResolverSettings: mockUpdate,
+  getSettings: mockGetSettings,
+  updateSettings: mockUpdateSettings,
 }));
 
 import { StepCatalogs, DEFAULT_CATALOG_SETTINGS } from './StepCatalogs';
@@ -25,6 +29,8 @@ import { StepCatalogs, DEFAULT_CATALOG_SETTINGS } from './StepCatalogs';
 beforeEach(() => {
   mockGet.mockReset();
   mockUpdate.mockReset();
+  mockGetSettings.mockReset();
+  mockUpdateSettings.mockReset();
   mockGet.mockResolvedValue({
     contractVersion: '1.0',
     requestId: 'r',
@@ -35,31 +41,40 @@ beforeEach(() => {
       requestTimeoutSecs: 10,
     },
   });
+  mockGetSettings.mockResolvedValue({ values: { defaultProtection: 'protected' } });
+  mockUpdateSettings.mockResolvedValue(undefined);
 });
 
-describe('StepCatalogs (Target resolution)', () => {
+function renderStep() {
+  return render(
+    <StepCatalogs settings={DEFAULT_CATALOG_SETTINGS} onSettingsChange={vi.fn()} />,
+  );
+}
+
+describe('StepCatalogs (Configuration)', () => {
   it('renders the SIMBAD online-resolution toggle', async () => {
-    render(
-      <StepCatalogs settings={DEFAULT_CATALOG_SETTINGS} onSettingsChange={vi.fn()} />,
-    );
+    renderStep();
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
-    expect(
-      screen.getByLabelText('Enable online SIMBAD resolution'),
-    ).toBeInTheDocument();
+    expect(screen.getByLabelText('Enable online SIMBAD resolution')).toBeInTheDocument();
   });
 
-  it('explains on-demand SIMBAD resolution with a bundled seed', () => {
-    render(
-      <StepCatalogs settings={DEFAULT_CATALOG_SETTINGS} onSettingsChange={vi.fn()} />,
-    );
-    expect(screen.getAllByText(/SIMBAD/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/bundled seed/i).length).toBeGreaterThan(0);
+  it('renders the display density, protection, and scan-depth controls', async () => {
+    renderStep();
+    await waitFor(() => expect(mockGetSettings).toHaveBeenCalled());
+    expect(screen.getByLabelText('Default source protection')).toBeInTheDocument();
+    expect(screen.getByLabelText('Default scan depth')).toBeInTheDocument();
+    // DensitySelector exposes a radio group labelled "Display density".
+    expect(screen.getByRole('radiogroup', { name: /display density/i })).toBeInTheDocument();
+  });
+
+  it('shows a disabled theme control marked coming soon', () => {
+    renderStep();
+    const theme = screen.getByLabelText('Theme (coming soon)') as HTMLSelectElement;
+    expect(theme).toBeDisabled();
   });
 
   it('shows no catalog-download affordance', () => {
-    render(
-      <StepCatalogs settings={DEFAULT_CATALOG_SETTINGS} onSettingsChange={vi.fn()} />,
-    );
+    renderStep();
     expect(screen.queryByRole('button', { name: /download/i })).toBeNull();
   });
 });

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -1,18 +1,22 @@
-// First-run wizard: "Target resolution" step (spec 035, repurposed).
+// First-run wizard: "Configuration" step.
 //
-// This step previously downloaded hosted catalog files (spec 014). That backend
-// surface has been removed: targets now resolve on demand from SIMBAD, backed by
-// a bundled seed of popular catalogues and a growing local cache. The wizard
-// step slot is retained (first_run_state.last_step CHECK still includes
-// 'catalogs' — no migration), but its content is now the SIMBAD
-// online-resolution toggle plus a short explanatory note.
+// Originally the spec-014 catalog-download step; that backend was removed (spec
+// 035 — targets resolve on demand from SIMBAD + a bundled seed + local cache).
+// The step slot is retained (first_run_state.last_step CHECK still includes
+// 'catalogs' — no migration) and repurposed as a small first-run Configuration
+// screen: a few defaults the user can set up front (all changeable later in
+// Settings).
 
+import { useEffect, useState, type ReactNode } from 'react';
 import { ResolverSettingsControl } from '@/features/settings/ResolverSettingsControl';
+import { DensitySelector } from '@/features/settings/DensitySelector';
+import { usePreference } from '@/data/preferences';
+import { getSettings, updateSettings } from '@/api/commands';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 //
 // Kept for compatibility with SetupWizard state persistence and StepConfirm.
-// `downloadAll` is now an inert legacy flag — nothing is downloaded.
+// `downloadAll` is an inert legacy flag — nothing is downloaded.
 
 export interface CatalogSettings {
   /** Legacy flag retained for state-shape compatibility; no longer used. */
@@ -28,35 +32,150 @@ export interface StepCatalogsProps {
   onSettingsChange: (settings: CatalogSettings) => void;
 }
 
-// ── StepCatalogs (Target resolution) ────────────────────────────────────────
+type DefaultProtection = 'protected' | 'normal' | 'unprotected';
+
+// ── Default source protection (spec 018, persisted via the settings backend) ──
+
+function DefaultProtectionControl() {
+  const [value, setValue] = useState<DefaultProtection>('protected');
+
+  useEffect(() => {
+    let cancelled = false;
+    getSettings({ scope: 'cleanup' })
+      .then((data) => {
+        const vals = data?.values as Record<string, unknown> | undefined;
+        const v = vals?.defaultProtection;
+        if (!cancelled && typeof v === 'string') setValue(v as DefaultProtection);
+      })
+      .catch(() => {
+        // Backend unavailable — keep the default.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onChange = (v: DefaultProtection) => {
+    setValue(v);
+    void updateSettings({ scope: 'cleanup', values: { defaultProtection: v } }).catch(() => {});
+  };
+
+  return (
+    <select
+      className="alm-select"
+      value={value}
+      aria-label="Default source protection"
+      onChange={(e) => onChange(e.target.value as DefaultProtection)}
+      style={{ height: 28 }}
+    >
+      <option value="protected">Protected</option>
+      <option value="normal">Normal</option>
+      <option value="unprotected">Unprotected</option>
+    </select>
+  );
+}
+
+// ── Default scan depth (frontend preference; applied to newly added folders) ──
+
+function DefaultScanDepthControl() {
+  const [scanDepth, setScanDepth] = usePreference('defaultScanDepth');
+  return (
+    <select
+      className="alm-select"
+      value={scanDepth}
+      aria-label="Default scan depth"
+      onChange={(e) => setScanDepth(e.target.value as 'recursive' | 'single')}
+      style={{ height: 28 }}
+    >
+      <option value="recursive">Recursive (include subfolders)</option>
+      <option value="single">Single folder only</option>
+    </select>
+  );
+}
+
+// ── A labelled config row: title + control on one line, description below ──────
+
+function ConfigOption({
+  title,
+  description,
+  control,
+}: {
+  title: string;
+  description: string;
+  control: ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-2)' }}>
+      <div
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'space-between',
+          gap: 'var(--alm-sp-3)',
+        }}
+      >
+        <span style={{ fontWeight: 'var(--alm-weight-semibold)', whiteSpace: 'nowrap' }}>
+          {title}
+        </span>
+        {control}
+      </div>
+      <div className="alm-settings__row-desc">{description}</div>
+    </div>
+  );
+}
+
+// ── StepCatalogs (Configuration) ──────────────────────────────────────────────
 
 /**
- * Step 3 — Target resolution.
+ * Step 3 — Configuration.
  *
- * Shows the SIMBAD online-resolution toggle (reusing the Settings control) and
- * explains that targets resolve on demand with a bundled seed + local cache.
- * The step never blocks Finish.
+ * A few first-run defaults: online SIMBAD resolution, display density, default
+ * source protection, and default scan depth. All are changeable later in
+ * Settings; the step never blocks Finish.
  */
 export function StepCatalogs(_props: StepCatalogsProps) {
   return (
-    <div className="alm-step-catalogs">
+    <div
+      className="alm-step-catalogs"
+      style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-5)' }}
+    >
       <p className="alm-step-catalogs__intro">
-        Astro Library Manager identifies the targets in your files by resolving
-        each object name against{' '}
-        <strong>SIMBAD</strong> (CDS, Université de Strasbourg). Common objects
-        come from a <strong>bundled seed</strong> of popular catalogues and a
-        growing <strong>local cache</strong>, so they resolve instantly with no
-        network call. Less-common objects are looked up on demand when you are
-        online, then cached.
+        Set a few defaults to get started. You can change all of these any time in
+        Settings.
       </p>
 
+      {/* Online SIMBAD resolution (label + toggle on one line, desc below). */}
       <ResolverSettingsControl compact />
 
-      <div className="alm-step-catalogs__note">
-        You can change this any time in Settings → Target Resolution. With online
-        resolution off, only the bundled seed and local cache are used; unknown
-        objects are marked unresolved and can be retried later.
-      </div>
+      {/* Display density — DensitySelector renders its own legend + radios. */}
+      <DensitySelector />
+
+      <ConfigOption
+        title="Default source protection"
+        description="Protection level applied to newly added source folders. Protected sources are skipped by cleanup plans unless explicitly approved."
+        control={<DefaultProtectionControl />}
+      />
+
+      <ConfigOption
+        title="Default scan depth"
+        description="Whether newly added source folders are scanned recursively (including subfolders) or as a single folder."
+        control={<DefaultScanDepthControl />}
+      />
+
+      <ConfigOption
+        title="Appearance / theme"
+        description="Light / dark theme is coming soon — the app currently uses a single light theme."
+        control={
+          <select
+            className="alm-select"
+            disabled
+            aria-label="Theme (coming soon)"
+            style={{ height: 28 }}
+          >
+            <option>Light (coming soon)</option>
+          </select>
+        }
+      />
     </div>
   );
 }


### PR DESCRIPTION
Follows the Configuration rebrand (#259) with actual first-run options (Windows-validation feedback #2c):
- **Display density** (reuses DensitySelector — fully wired).
- **Default source protection** (persisted via `settings_update` scope 'cleanup').
- **Default scan depth** (new `AppPreferences.defaultScanDepth`; applied to newly added source folders).
- **Appearance/theme**: a **disabled 'coming soon'** control — the app has no theme applier or dark-mode tokens yet, so a working theme is its own feature (not a fake toggle).

typecheck + vitest (578) green.