### PR TITLE
fix(ux): restyle Confirm step; remove target-resolution summary + 'not scanned'

### DIFF
--- a/apps/desktop/src/features/setup/steps/StepConfirm.tsx
+++ b/apps/desktop/src/features/setup/steps/StepConfirm.tsx
@@ -1,5 +1,5 @@
+import type { ReactNode } from 'react';
 import { Pill } from '@/ui/Pill';
-import { Box } from '@/ui/Box';
 import type { SourcesState } from '../sources-store';
 import { SOURCE_KIND_LABELS, getMissingRequiredKinds, getSourcesByKind, ALL_SOURCE_KINDS } from '../sources-store';
 import type { CatalogSettings } from './StepCatalogs';
@@ -7,6 +7,7 @@ import type { ToolsState } from './StepTools';
 
 export interface StepConfirmProps {
   sources: SourcesState;
+  /** Retained for wizard-state compatibility; not shown on Confirm. */
   catalogSettings: CatalogSettings;
   tools: ToolsState;
   isSubmitting: boolean;
@@ -17,10 +18,30 @@ const TOOL_LABELS: Record<keyof ToolsState, string> = {
   siril: 'Siril',
 };
 
+// A titled section, matching the Configuration step's layout (no card chrome).
+function Section({ title, children }: { title: string; children: ReactNode }) {
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-3)' }}>
+      <div
+        style={{
+          fontWeight: 'var(--alm-weight-semibold)',
+          fontSize: 'var(--alm-text-sm)',
+        }}
+      >
+        {title}
+      </div>
+      {children}
+    </div>
+  );
+}
+
 /**
- * Step 4 -- Confirm.
- * Summary of all configuration with blocked-finish logic when required
- * folders are missing.
+ * Step 4 — Confirm.
+ *
+ * Summary of what setup will register (source folders + processing tools) and
+ * what happens next, with blocked-finish when required folders are missing.
+ * System settings (e.g. target resolution) are NOT shown here — they live in the
+ * Configuration step / Settings.
  */
 export function StepConfirm({
   sources,
@@ -31,109 +52,166 @@ export function StepConfirm({
   const missingKinds = getMissingRequiredKinds(sources);
   const totalFolders = sources.length;
 
-  const enabledTools = (Object.keys(TOOL_LABELS) as Array<keyof ToolsState>)
-    .filter((key) => tools[key].enabled);
+  const enabledTools = (Object.keys(TOOL_LABELS) as Array<keyof ToolsState>).filter(
+    (key) => tools[key].enabled,
+  );
 
-  // Group sources by kind for display
   const kindsWithFolders = ALL_SOURCE_KINDS.filter(
     (kind) => getSourcesByKind(sources, kind).length > 0,
   );
 
   return (
-    <div className="alm-step-confirm">
-      {/* Sources summary */}
-      <Box title={`Library sources (${totalFolders} folder${totalFolders !== 1 ? 's' : ''})`}>
-        <div className="alm-step-confirm__sources">
-          {kindsWithFolders.map((kind) => {
-            const kindEntries = getSourcesByKind(sources, kind);
-            return (
-              <div key={kind} className="alm-step-confirm__source-group">
-                <div className="alm-step-confirm__source-kind">
+    <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-5)' }}>
+      <Section title={`Source folders (${totalFolders} folder${totalFolders !== 1 ? 's' : ''})`}>
+        {kindsWithFolders.length > 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-4)' }}>
+            {kindsWithFolders.map((kind) => (
+              <div
+                key={kind}
+                style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-1)' }}
+              >
+                <div
+                  style={{
+                    fontSize: 'var(--alm-text-2xs)',
+                    fontWeight: 'var(--alm-weight-semibold)',
+                    letterSpacing: '0.04em',
+                    textTransform: 'uppercase',
+                    color: 'var(--alm-text-muted)',
+                  }}
+                >
                   {SOURCE_KIND_LABELS[kind]}
                 </div>
-                {kindEntries.map((entry, j) => (
-                  <div key={j} className="alm-step-confirm__source-entry">
-                    <span className="alm-step-confirm__source-path">
+                {getSourcesByKind(sources, kind).map((entry, j) => (
+                  <div
+                    key={j}
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      justifyContent: 'space-between',
+                      gap: 'var(--alm-sp-3)',
+                    }}
+                  >
+                    <span
+                      className="alm-mono"
+                      style={{
+                        flex: 1,
+                        minWidth: 0,
+                        fontSize: 'var(--alm-text-sm)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
                       {entry.path}
                     </span>
-                    <Pill variant="neutral">Not scanned</Pill>
-                    <span className="alm-step-confirm__source-depth">
+                    <span
+                      style={{
+                        whiteSpace: 'nowrap',
+                        fontSize: 'var(--alm-text-xs)',
+                        color: 'var(--alm-text-muted)',
+                      }}
+                    >
                       {entry.scanDepth === 'recursive' ? 'Recursive' : 'Single level'}
                     </span>
                   </div>
                 ))}
               </div>
-            );
-          })}
-          {kindsWithFolders.length === 0 && (
-            <div className="alm-step-confirm__empty">
-              No folders configured (you can add them later in Settings)
-            </div>
-          )}
-        </div>
-      </Box>
+            ))}
+          </div>
+        ) : (
+          <div style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-sm)' }}>
+            No folders configured (you can add them later in Settings).
+          </div>
+        )}
+      </Section>
 
-      {/* Tools summary */}
-      <Box title={`Processing tools (${enabledTools.length} enabled)`}>
-        <div className="alm-step-confirm__tools">
-          {enabledTools.length > 0 ? (
-            enabledTools.map((key) => (
-              <div key={key} className="alm-step-confirm__tool-entry">
-                <span className="alm-step-confirm__tool-name">{TOOL_LABELS[key]}</span>
+      <Section title={`Processing tools (${enabledTools.length} enabled)`}>
+        {enabledTools.length > 0 ? (
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-2)' }}>
+            {enabledTools.map((key) => (
+              <div
+                key={key}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  justifyContent: 'space-between',
+                  gap: 'var(--alm-sp-3)',
+                }}
+              >
+                <span style={{ fontWeight: 'var(--alm-weight-semibold)' }}>{TOOL_LABELS[key]}</span>
                 {tools[key].path ? (
-                  <>
-                    <span className="alm-step-confirm__tool-path">{tools[key].path}</span>
+                  <span
+                    style={{
+                      display: 'flex',
+                      alignItems: 'center',
+                      gap: 'var(--alm-sp-2)',
+                      minWidth: 0,
+                    }}
+                  >
+                    <span
+                      className="alm-mono"
+                      style={{
+                        fontSize: 'var(--alm-text-xs)',
+                        color: 'var(--alm-text-muted)',
+                        overflow: 'hidden',
+                        textOverflow: 'ellipsis',
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      {tools[key].path}
+                    </span>
                     <Pill variant="ok">OK</Pill>
-                  </>
+                  </span>
                 ) : (
                   <Pill variant="warn">No path set</Pill>
                 )}
               </div>
-            ))
-          ) : (
-            <span className="alm-step-confirm__muted">No tools enabled</span>
-          )}
-        </div>
-      </Box>
-
-      {/* Target resolution summary */}
-      <Box title="Target resolution">
-        <div className="alm-step-confirm__catalogs">
-          Targets resolve on demand from SIMBAD, backed by a bundled seed and a
-          local cache. You can toggle online resolution in Settings → Target
-          Resolution.
-        </div>
-      </Box>
-
-      {/* What happens next */}
-      <Box title="What happens next">
-        <div className="alm-step-confirm__next">
-          <p>When you complete setup, the app will:</p>
-          <ul className="alm-step-confirm__next-list">
-            <li>Register all selected folders as library roots</li>
-            <li>Initial scan will begin after setup</li>
-            <li>Extract metadata from every file header</li>
-            <li>Group light frames into acquisition sessions</li>
-          </ul>
-          <div className="alm-step-confirm__safety-note">
-            <strong>Nothing is moved or modified.</strong> The scan only reads file
-            headers and builds an index. Your files stay exactly where they are.
+            ))}
           </div>
-        </div>
-      </Box>
+        ) : (
+          <div style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-sm)' }}>
+            No tools enabled.
+          </div>
+        )}
+      </Section>
 
-      {/* Blocked-finish warning */}
+      <Section title="What happens next">
+        <ul
+          style={{
+            margin: 0,
+            paddingLeft: 'var(--alm-sp-5)',
+            display: 'flex',
+            flexDirection: 'column',
+            gap: 'var(--alm-sp-1)',
+            fontSize: 'var(--alm-text-sm)',
+          }}
+        >
+          <li>Your selected folders are registered as library roots.</li>
+          <li>An initial scan runs after setup, reading file headers to build the index.</li>
+          <li>Light frames are grouped into acquisition sessions.</li>
+        </ul>
+        <div
+          style={{
+            fontSize: 'var(--alm-text-sm)',
+            color: 'var(--alm-text-muted)',
+          }}
+        >
+          <strong>Nothing is moved or modified.</strong> The scan only reads file headers and
+          builds an index — your files stay exactly where they are.
+        </div>
+      </Section>
+
       {missingKinds.length > 0 && (
-        <div className="alm-step-confirm__blocked">
+        <div className="alm-step-confirm__blocked" role="alert">
           Cannot complete setup: missing required folder types —{' '}
-          {missingKinds.map((k) => SOURCE_KIND_LABELS[k]).join(', ')}.
-          Go back to Step 1 to add them.
+          {missingKinds.map((k) => SOURCE_KIND_LABELS[k]).join(', ')}. Go back to Step 1 to add
+          them.
         </div>
       )}
 
       {isSubmitting && (
-        <div className="alm-step-confirm__submitting">
-          Registering roots and starting scan...
+        <div style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-sm)' }}>
+          Registering roots and starting scan…
         </div>
       )}
     </div>


### PR DESCRIPTION
Validation feedback on the wizard Confirm page:
1. **Layout not updated** — it was the only step using `<Box>` + `alm-step-confirm__*` classes that have no CSS (siblings use styled `alm-step-sources__*`). Rewritten with the same inline-styled sections as the Configuration step.
2. **'Not scanned' pill removed** — nothing can be scanned before setup completes; scanning runs after (Inbox). No scan-during-wizard option (would block setup on large libraries). Each source now shows its scan depth.
3. **'Target resolution' summary removed** — system settings don't belong on Confirm; they live in the Configuration step / Settings.

typecheck + vitest (578) green.