### PR TITLE
fix(setup): Complete setup fails — camelCase scanDepth in register payload

### DIFF
--- a/apps/desktop/src/api/commands.ts
+++ b/apps/desktop/src/api/commands.ts
@@ -361,7 +361,8 @@ export async function completeTourStep(args: { step: string }): Promise<void> {
 export interface BatchSourceEntry {
   kind: string;
   path: string;
-  scan_depth?: string;
+  // Backend RegisterSourceRequest is camelCase — must be `scanDepth`.
+  scanDepth: string;
 }
 
 export interface BatchRegisterResult {

--- a/apps/desktop/src/features/setup/sources-store.ts
+++ b/apps/desktop/src/features/setup/sources-store.ts
@@ -208,7 +208,9 @@ export async function flushToDB(sources: SourcesState): Promise<FlushResult> {
       sources: validSources.map((s) => ({
         kind: s.kind,
         path: s.path,
-        scan_depth: s.scanDepth,
+        // Backend RegisterSourceRequest is camelCase — must be `scanDepth`,
+        // not `scan_depth`, or the whole batch arg fails to deserialize.
+        scanDepth: s.scanDepth,
       })),
     });
 


### PR DESCRIPTION
**Complete setup did nothing** — console showed `Some source registrations failed: (4) [...]`.

Root cause: `flushToDB` sent `{ kind, path, scan_depth }` but the backend `RegisterSourceRequest` is `#[serde(rename_all = "camelCase")]` and requires **`scanDepth`**. The missing required field made the entire `roots_register_batch` arg fail to deserialize on the real backend → all registrations failed (mock mode hid it — same class as the dotted-command bug).

Fix: send `scanDepth`; make `BatchSourceEntry.scanDepth` required so typecheck catches it.

typecheck + vitest (578) green.