### PR TITLE
test(ipc): guard against command name/payload-casing drift + migration plan

### DIFF
--- a/apps/desktop/src/api/commands.bindings-guard.test.ts
+++ b/apps/desktop/src/api/commands.bindings-guard.test.ts
@@ -1,0 +1,109 @@
+/**
+ * IPC conformance guard for the hand-written wrappers in `commands.ts`.
+ *
+ * These wrappers call `invoke('<name>', <payload>)` with hand-written command
+ * names and payload shapes. The generated tauri-specta bindings
+ * (`bindings/index.ts`) are the AUTHORITATIVE source of what the real backend
+ * accepts. Two whole classes of bug have shipped because the wrappers drifted
+ * from the bindings and mock mode hid it:
+ *
+ *   1. Dotted / renamed / typo'd command names → "command not found" on the
+ *      real backend (e.g. `target.get` instead of `target_get`).
+ *   2. snake_case payload keys the camelCase backend rejects (e.g. `scan_depth`
+ *      instead of `scanDepth`), making the whole arg fail to deserialize.
+ *
+ * This test fails CI on both, so the next drift is caught on Linux instead of
+ * during a manual Windows session.
+ *
+ * NOTE: the payload-casing check only covers INLINE object literals passed to
+ * invoke(). Pass-through payloads (`invoke('x', args)`) are not statically
+ * inspectable here — the durable fix for those is the generated-bindings
+ * migration (see docs/development/ipc-wrapper-migration.md).
+ */
+import { describe, it, expect } from 'vitest';
+// Vite `?raw` string imports (typed via vite/client) — avoids node:fs so this
+// typechecks without @types/node.
+import commandsSrc from './commands.ts?raw';
+import bindingsSrc from '../bindings/index.ts?raw';
+
+/** All command names the generated bindings actually register. */
+function registeredCommands(): Set<string> {
+  const names = new Set<string>();
+  const re = /__TAURI_INVOKE\(\s*"([a-zA-Z0-9_.]+)"/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(bindingsSrc)) !== null) names.add(m[1]);
+  return names;
+}
+
+/** Every `invoke<...>('name', ...)` call site in commands.ts. */
+function invokedCommands(): string[] {
+  const names: string[] = [];
+  const re = /\binvoke<[^>]*>\(\s*'([a-zA-Z0-9_.]+)'/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(commandsSrc)) !== null) names.push(m[1]);
+  return names;
+}
+
+/**
+ * Spans of text that are the argument list of each `invoke<...>(...)` call,
+ * with the leading command-string literal stripped. Used to scan inline
+ * payload object literals for snake_case keys.
+ */
+function invokeArgSpans(): string[] {
+  const spans: string[] = [];
+  const re = /\binvoke<[^>]*>\(/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(commandsSrc)) !== null) {
+    let depth = 0;
+    let i = m.index + m[0].length - 1; // at the '('
+    const start = i + 1;
+    for (; i < commandsSrc.length; i++) {
+      const c = commandsSrc[i];
+      if (c === '(') depth++;
+      else if (c === ')') {
+        depth--;
+        if (depth === 0) break;
+      }
+    }
+    spans.push(commandsSrc.slice(start, i));
+  }
+  return spans;
+}
+
+describe('commands.ts IPC conformance guard', () => {
+  // spec-021 dev-tools commands are compile-time gated behind the `dev-tools`
+  // cargo feature (default off), so they are intentionally absent from the
+  // default generated bindings. They are still real commands in dev builds.
+  const FEATURE_GATED = /^dev_/;
+
+  it('every invoked command name is registered in the generated bindings', () => {
+    const registered = registeredCommands();
+    expect(registered.size).toBeGreaterThan(50); // sanity: bindings parsed
+    const unknown = [...new Set(invokedCommands())]
+      .filter((n) => !FEATURE_GATED.test(n))
+      .filter((n) => !registered.has(n));
+    expect(unknown, `unknown/unregistered command names in commands.ts: ${unknown.join(', ')}`).toEqual(
+      [],
+    );
+  });
+
+  it('no dotted command names are invoked (must be snake_case)', () => {
+    const dotted = [...new Set(invokedCommands())].filter((n) => n.includes('.'));
+    expect(dotted, `dotted command names (use snake_case): ${dotted.join(', ')}`).toEqual([]);
+  });
+
+  it('no snake_case keys in inline invoke() payload literals', () => {
+    // Object-literal key like `scan_depth:` (allow optional `?`). The backend is
+    // camelCase, so any underscore key in a payload is a bug.
+    const keyRe = /\b([a-z][a-zA-Z0-9]*_[a-zA-Z0-9_]*)\??\s*:/g;
+    const offenders: string[] = [];
+    for (const span of invokeArgSpans()) {
+      let m: RegExpExecArray | null;
+      while ((m = keyRe.exec(span)) !== null) offenders.push(m[1]);
+    }
+    expect(
+      [...new Set(offenders)],
+      `snake_case keys in inline invoke payloads (use camelCase): ${[...new Set(offenders)].join(', ')}`,
+    ).toEqual([]);
+  });
+});

--- a/docs/development/ipc-wrapper-migration.md
+++ b/docs/development/ipc-wrapper-migration.md
@@ -1,0 +1,54 @@
+# IPC wrapper → generated-bindings migration (planned)
+
+## Why
+
+`apps/desktop/src/api/commands.ts` holds ~90 hand-written `invoke('<name>', <payload>)`
+wrappers. The generated tauri-specta bindings (`apps/desktop/src/bindings/index.ts`,
+`export const commands`) are the authoritative description of every command's name and
+payload shape. The hand-written wrappers drift from them, and **mock mode hides the
+drift** — bugs only surface on a real Windows build. Two classes have shipped:
+
+1. **Dotted/renamed command names** → "command not found" (e.g. `target.get` vs `target_get`).
+2. **snake_case payload keys** the camelCase backend rejects (e.g. `scan_depth` vs `scanDepth`),
+   which makes the whole command argument fail to deserialize.
+
+Fixed instances: PRs #263, #264 (8 commands). Regression guard: `commands.bindings-guard.test.ts`.
+
+## Why it isn't a quick mechanical swap
+
+The generated bindings import `invoke` **directly** from `@tauri-apps/api/core`:
+
+```ts
+// bindings/index.ts (generated — do not edit)
+import { invoke as __TAURI_INVOKE } from "@tauri-apps/api/core";
+```
+
+The hand-written `invoke()` in `commands.ts` is a **switcher** that the rest of the app
+depends on:
+
+- routes to `mocks.ts` `mockInvoke` when `VITE_USE_MOCKS` (all mock-driven dev + most tests),
+- routes through `_invokeOverride` for the spec-021 dev-tools recording proxy.
+
+So naively deleting the wrappers and calling `commands.*` directly would **bypass mock mode
+and the dev recorder** for all 56 caller files. That's an architectural change, not a rename.
+
+## Proposed approach (own spec, after Windows validation)
+
+1. Configure tauri-specta to emit its invoke import from our switcher instead of tauri core
+   (e.g. generate `import { invoke as __TAURI_INVOKE } from "@/api/ipc"`), where `@/api/ipc`
+   exports the mock/override/real switcher currently inside `commands.ts`. Verify on a real build.
+2. With the switcher preserved, incrementally replace hand-written wrappers with re-exports of
+   the generated `commands.*` (unwrapping the `Result`-style `typedError` return into the
+   throw-on-error contract callers expect). Keep the `@/api/commands` public surface stable so
+   callers and test mocks don't all have to change at once.
+3. Once all wrappers delegate, optionally repoint callers directly at the generated bindings and
+   retire the wrapper layer.
+
+Until then: the guard test blocks the two known drift classes, and any new command should be
+added by calling the generated binding, not by hand-writing a new `invoke('...')` string.
+
+## Known dead plumbing (remove during the migration, not live bugs)
+
+- `approvePlan` wrapper — no caller anywhere; its `delete_acknowledged` reaches nothing.
+- `listSessions` / `listCalibrationMasters` `filters`/`sort`/`group_by` args — no caller passes
+  them and `sessions_list` is still a fixture stub (real list + filtering is spec-029 work).


### PR DESCRIPTION
Follow-up to the IPC casing audit (#264). Adds a CI guard so the two drift classes (unregistered/dotted command names; snake_case inline payload keys) fail on Linux instead of during a Windows session. Documents the full wrapper→generated-bindings migration as its own spec (the generated bindings bypass the mock layer + dev recorder, so it's architectural, not mechanical).

Gaps #1/#2 from the audit turned out to be **dead plumbing, not live bugs** (`approvePlan` has no caller; `sessions_list` is a fixture stub and no caller passes filters) — documented for cleanup during the migration rather than fixed against a stub.

typecheck + vitest (581) green.