### PR TITLE
fix(setup): default source folders to recursive; remove Default scan depth config

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -52,7 +52,6 @@ const mockPreferences: AppPreferences = {
   sessionsView: 'list',
   tourCompleted: { step1: false, step2: false, step3: false },
   setupCompleted: false,
-  defaultScanDepth: 'recursive',
 };
 
 // Review items are loaded from the wireframe-aligned fixture file (review.queue case below).

--- a/apps/desktop/src/bindings/types.ts
+++ b/apps/desktop/src/bindings/types.ts
@@ -82,8 +82,6 @@ export interface AppPreferences {
   sessionsView: 'list' | 'calendar';
   tourCompleted: { step1: boolean; step2: boolean; step3: boolean };
   setupCompleted: boolean;
-  /** Default scan depth applied to newly added source folders (first-run config). */
-  defaultScanDepth: 'recursive' | 'single';
 }
 
 export interface SourceMap {

--- a/apps/desktop/src/data/preferences.ts
+++ b/apps/desktop/src/data/preferences.ts
@@ -17,7 +17,6 @@ const defaults: AppPreferences = {
   sessionsView: 'list',
   tourCompleted: { step1: false, step2: false, step3: false },
   setupCompleted: false,
-  defaultScanDepth: 'recursive',
 };
 
 function notify(): void {

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { WizardShell } from '@/ui/WizardShell';
 import { Btn } from '@/ui/Btn';
-import { setPreference, getPreferences } from '@/data/preferences';
+import { setPreference } from '@/data/preferences';
 import { completeFirstRun } from '@/api/commands';
 import {
   StepSourceFolders,
@@ -152,7 +152,7 @@ export function SetupWizard() {
       if (validationError) {
         setState((prev) => ({
           ...prev,
-          sources: addSource(prev.sources, kind, path, getPreferences().defaultScanDepth),
+          sources: addSource(prev.sources, kind, path),
         }));
         setErrors((prev) => ({
           ...prev,
@@ -163,7 +163,7 @@ export function SetupWizard() {
 
       setState((prev) => ({
         ...prev,
-        sources: addSource(prev.sources, kind, path, getPreferences().defaultScanDepth),
+        sources: addSource(prev.sources, kind, path),
       }));
       // Clear any error for this index
       setErrors((prev) => {

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
@@ -62,7 +62,6 @@ describe('StepCatalogs (Configuration)', () => {
     renderStep();
     await waitFor(() => expect(mockGetSettings).toHaveBeenCalled());
     expect(screen.getByLabelText('Default source protection')).toBeInTheDocument();
-    expect(screen.getByLabelText('Default scan depth')).toBeInTheDocument();
     expect(screen.getByLabelText('Display density')).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -94,24 +94,6 @@ function DensityControl() {
   );
 }
 
-// ── Default scan depth (frontend preference; applied to newly added folders) ──
-
-function DefaultScanDepthControl() {
-  const [scanDepth, setScanDepth] = usePreference('defaultScanDepth');
-  return (
-    <select
-      className="alm-select"
-      value={scanDepth}
-      aria-label="Default scan depth"
-      onChange={(e) => setScanDepth(e.target.value as 'recursive' | 'single')}
-      style={{ height: 28 }}
-    >
-      <option value="recursive">Recursive (include subfolders)</option>
-      <option value="single">Single folder only</option>
-    </select>
-  );
-}
-
 // ── A labelled config row: title + control on one line, description below ──────
 
 function ConfigOption({
@@ -171,12 +153,6 @@ export function StepCatalogs(_props: StepCatalogsProps) {
         title="Default source protection"
         description="Protection level applied to newly added source folders. Protected sources are skipped by cleanup plans unless explicitly approved."
         control={<DefaultProtectionControl />}
-      />
-
-      <ConfigOption
-        title="Default scan depth"
-        description="Whether newly added source folders are scanned recursively (including subfolders) or as a single folder."
-        control={<DefaultScanDepthControl />}
       />
 
       <ConfigOption


### PR DESCRIPTION
Validation feedback: per-folder default showed 'single level' (should be recursive), and the 'Default scan depth' Configuration option is redundant since depth is set per-source.

Fix: remove the `defaultScanDepth` preference + its config control; `SetupWizard` now calls `addSource(...)` without it, so new folders use `addSource`'s `recursive` default deterministically (no stale-pref leakage).

typecheck + vitest (584) green.