### PR TITLE
fix(setup): wrap roots_register_batch payload in request envelope (Complete setup)

### DIFF
--- a/apps/desktop/src/api/commands.ts
+++ b/apps/desktop/src/api/commands.ts
@@ -382,7 +382,10 @@ export interface FirstRunRestartResult {
 export async function registerRootBatch(args: {
   sources: BatchSourceEntry[];
 }): Promise<BatchRegisterResult> {
-  return invoke<BatchRegisterResult>('roots_register_batch', args);
+  // The backend command takes a single `request: RegisterSourceBatchRequest`
+  // param, so the payload must be wrapped: { request: { sources } }. Sending
+  // { sources } top-level fails to deserialize on the real backend.
+  return invoke<BatchRegisterResult>('roots_register_batch', { request: args });
 }
 
 export async function completeFirstRun(): Promise<FirstRunCompleteResult> {

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -326,7 +326,9 @@ export async function mockInvoke<T>(
     // ---------- First-Run / Batch Commands ----------
 
     case 'roots_register_batch': {
-      const sources = (_args?.sources as Array<{ kind: string; path: string }>) ?? [];
+      // Payload is { request: { sources } }; tolerate a legacy top-level shape too.
+      const req = (_args?.request as { sources?: Array<{ kind: string; path: string }> }) ?? _args;
+      const sources = (req?.sources as Array<{ kind: string; path: string }>) ?? [];
       return {
         results: sources.map((s, i) => ({
           kind: s.kind,


### PR DESCRIPTION
**Complete setup still fails on the real backend** after #263. Root cause: `roots_register_batch` takes `request: RegisterSourceBatchRequest`, so the payload must be `{ request: { sources } }`; the wrapper sent `{ sources }` top-level → missing `request` field → deserialize fails. (Mock mode hid it; surfaced by the spec-037 Phase 2 agent comparing against the generated binding, which sends `{ request }`.)

Fix: wrapper sends `{ request: args }`; mock reads `request.sources` with a legacy fallback.

typecheck + vitest (584) green.