### PR TITLE
feat(spec 038): first-run wizard scan step (scan + summary)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/037-ipc-wrapper-removal"
+  "feature_directory": "specs/038-wizard-scan-step"
 }

--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -1,10 +1,10 @@
 /// <reference types="@testing-library/jest-dom" />
 /**
- * SetupWizard gating tests (T044 — rewritten for 4-step flow).
+ * SetupWizard gating tests (T044 — rewritten for 5-step flow).
  *
  * Validates that Step 1 (Source Folders) blocks advancement when required
- * folder types (light_frames, project) are missing, and that Steps 2 and 3
- * advance freely.
+ * folder types (light_frames, project) are missing, and that Steps 2–3
+ * advance freely. The Scan step (step 5) has its own StepScan.test.tsx.
  */
 import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -72,6 +72,10 @@ vi.mock('@/api/commands', () => ({
   // Configuration step also reads/writes the default source-protection setting.
   getSettings: vi.fn().mockResolvedValue({ values: { defaultProtection: 'protected' } }),
   updateSettings: vi.fn().mockResolvedValue(undefined),
+  // StepScan calls these — stub with empty responses so render doesn't throw
+  // if the Scan step is reached during tests that navigate that far.
+  inboxScanFolder: vi.fn().mockResolvedValue({ rootId: 'root-mock', items: [] }),
+  inboxClassify: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock @tauri-apps/api/core to prevent any accidental live invoke.
@@ -162,11 +166,11 @@ beforeEach(() => {
 // Tests
 // ---------------------------------------------------------------------------
 
-describe('SetupWizard 4-step flow', () => {
+describe('SetupWizard 5-step flow', () => {
   it('starts on Step 1 (Source Folders) and shows the heading', () => {
     renderWizard();
     expect(screen.getByText(/where does your data live/i)).toBeInTheDocument();
-    expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 1 of 5/i)).toBeInTheDocument();
   });
 
   it('blocks Continue on Step 1 when no paths are added', () => {
@@ -275,7 +279,7 @@ describe('SetupWizard 4-step flow', () => {
 
     // We should be on the Processing Tools step (heading)
     expect(screen.getByRole('heading', { name: /processing tools/i })).toBeInTheDocument();
-    expect(screen.getByText(/step 2 of 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 2 of 5/i)).toBeInTheDocument();
 
     // Continue should be enabled (tools step has no requirements)
     const continueBtn = getContinueButton();
@@ -308,14 +312,14 @@ describe('SetupWizard 4-step flow', () => {
 
     // We should be on the Catalogs step (heading)
     expect(screen.getByRole('heading', { name: /configuration/i })).toBeInTheDocument();
-    expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 3 of 5/i)).toBeInTheDocument();
 
     // Continue should be enabled
     const continueBtn = getContinueButton();
     expect(continueBtn).not.toBeDisabled();
   });
 
-  it('shows Confirm step (Step 4) with Complete setup button', async () => {
+  it('shows Confirm step (Step 4) with Start scan button', async () => {
     // Seed state at step 3 (Confirm) with all required kinds satisfied.
     const seeded = {
       currentStep: 3,
@@ -338,13 +342,15 @@ describe('SetupWizard 4-step flow', () => {
 
     // Verify we are on the Confirm step
     expect(screen.getByText(/ready to go/i)).toBeInTheDocument();
+    expect(screen.getByText(/step 4 of 5/i)).toBeInTheDocument();
 
-    // Complete setup button should be present and enabled
-    const completeBtn = screen.getByRole('button', { name: /complete setup/i });
-    expect(completeBtn).not.toBeDisabled();
+    // "Start scan" button should be present and enabled (not "Complete setup")
+    const startScanBtn = screen.getByRole('button', { name: /start scan/i });
+    expect(startScanBtn).not.toBeDisabled();
+    expect(screen.queryByRole('button', { name: /complete setup/i })).toBeNull();
   });
 
-  it('blocks Complete setup on Confirm step when required folders are missing', async () => {
+  it('blocks Start scan on Confirm step when required folders are missing', async () => {
     // Seed at step 3 but WITHOUT a project folder
     const seeded = {
       currentStep: 3,
@@ -365,9 +371,9 @@ describe('SetupWizard 4-step flow', () => {
 
     expect(screen.getByText(/ready to go/i)).toBeInTheDocument();
 
-    // Complete setup should be disabled
-    const completeBtn = screen.getByRole('button', { name: /complete setup/i });
-    expect(completeBtn).toBeDisabled();
+    // Start scan should be disabled
+    const startScanBtn = screen.getByRole('button', { name: /start scan/i });
+    expect(startScanBtn).toBeDisabled();
 
     // Should show the blocked message
     expect(screen.getByText(/cannot complete setup/i)).toBeInTheDocument();

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -9,11 +9,13 @@ import {
   StepTools,
   StepCatalogs,
   StepConfirm,
+  StepScan,
   DEFAULT_CATALOG_SETTINGS,
   DEFAULT_TOOLS_STATE,
 } from './steps';
 import type { CatalogSettings, ToolsState } from './steps';
 import type { SourcesState, SourceKind, ScanDepth } from './sources-store';
+import type { FlushResult } from './sources-store';
 import {
   loadSources,
   saveSources,
@@ -55,15 +57,28 @@ const STEPS = [
     heading: 'Ready to go',
     description: 'Review your configuration before starting the initial scan.',
   },
+  {
+    label: 'Scan',
+    heading: 'Scanning your library',
+    description: 'Scanning each source folder and detecting ingestion groups. Approval happens in the Inbox.',
+  },
 ];
+
+// Index of the Scan step (last step).
+const SCAN_STEP = STEPS.length - 1;
 
 function loadWizardState(): WizardState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
     if (raw) {
       const parsed = JSON.parse(raw);
+      // If persisted state had the wizard already at the scan step, reset to
+      // confirm so the scan always starts fresh (avoids stale scan guard).
+      const currentStep = parsed.currentStep === SCAN_STEP
+        ? SCAN_STEP - 1
+        : (parsed.currentStep ?? 0);
       return {
-        currentStep: parsed.currentStep ?? 0,
+        currentStep,
         sources: Array.isArray(parsed.sources) ? parsed.sources : loadSources(),
         // Migrate/guard: older persisted state used `{ downloadAll }` (no
         // `selectedCatalogIds`); coerce any shape lacking the array to the default so
@@ -105,9 +120,17 @@ export function SetupWizard() {
   const navigate = useNavigate();
   const [state, setState] = useState<WizardState>(loadWizardState);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [isFinishing, setIsFinishing] = useState(false);
   const [errors, setErrors] = useState<Record<number, string>>({});
 
-  // Persist wizard progress on every state change
+  // flushResult is set when the user advances from Confirm → Scan so StepScan
+  // can use the registered rootIds.  Null until flushToDB has been called.
+  const [flushResult, setFlushResult] = useState<FlushResult | null>(null);
+
+  // Persist wizard progress on every state change.
+  // The Scan step (SCAN_STEP) is intentionally NOT persisted — persisting it
+  // would require restoring scan state across sessions, which we don't support.
+  // loadWizardState() guards against this by resetting to Confirm.
   useEffect(() => {
     saveWizardState(state);
     saveSources(state.sources);
@@ -220,15 +243,29 @@ export function SetupWizard() {
   // Derived folder count for footer
   const totalFolders = state.sources.length;
 
-  const handleComplete = useCallback(async () => {
+  // Called from the Confirm step footer: register roots, then advance to Scan.
+  const handleEnterScan = useCallback(async () => {
     setIsSubmitting(true);
     try {
-      const flushResult = await flushToDB(state.sources);
+      const result = await flushToDB(state.sources);
 
-      if (!flushResult.allSucceeded) {
-        console.warn('Some source registrations failed:', flushResult.results.filter((r) => !r.success));
+      if (!result.allSucceeded) {
+        console.warn('Some source registrations failed:', result.results.filter((r) => !r.success));
       }
 
+      setFlushResult(result);
+      goTo(SCAN_STEP);
+    } catch (err) {
+      console.error('Failed to register sources:', err);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }, [state.sources, goTo]);
+
+  // Called from StepScan's Finish button: complete first-run and navigate.
+  const handleFinish = useCallback(async () => {
+    setIsFinishing(true);
+    try {
       if (!isMockMode) {
         await completeFirstRun();
       }
@@ -237,21 +274,18 @@ export function SetupWizard() {
       clearWizardState();
       void navigate({ to: '/inbox' });
     } catch {
-      setIsSubmitting(false);
+      setIsFinishing(false);
     }
-  }, [state.sources, isMockMode, navigate]);
+  }, [isMockMode, navigate]);
 
-  // Determine whether "Continue" should be enabled
-  // Step 0 (Source Folders) requires at least one light_frames and one project folder.
-  // All other steps advance freely.
+  // Determine whether "Continue" should be enabled.
+  // Step 0 (Source Folders) and step 3 (Confirm) require all required folder kinds.
+  // All other intermediate steps advance freely.
+  // The Scan step (SCAN_STEP) manages its own Finish button internally.
   const canProceed = useMemo(() => {
     if (isMockMode) return true;
     const step = state.currentStep;
-    if (step === 0) {
-      return getMissingRequiredKinds(state.sources).length === 0;
-    }
-    // On the confirm step, also gate on required folders
-    if (step === 3) {
+    if (step === 0 || step === SCAN_STEP - 1) {
       return getMissingRequiredKinds(state.sources).length === 0;
     }
     return true;
@@ -265,10 +299,14 @@ export function SetupWizard() {
     completed: i < step,
   }));
 
+  // The Scan step renders its own Finish button inside StepScan; the wizard
+  // footer only shows navigation for steps 0–3.
+  const isOnScanStep = step === SCAN_STEP;
+
   // Build the navigation footer for the current step
   const footer = (
     <>
-      {step > 0 ? (
+      {step > 0 && !isOnScanStep ? (
         <Btn variant="ghost" onClick={() => goTo(step - 1)} disabled={isSubmitting}>
           &larr; Back
         </Btn>
@@ -284,22 +322,27 @@ export function SetupWizard() {
           {totalFolders} folder{totalFolders !== 1 ? 's' : ''} selected
         </span>
       )}
-      {step < STEPS.length - 1 ? (
-        <Btn
-          variant="primary"
-          onClick={() => goTo(step + 1)}
-          disabled={!canProceed}
-        >
-          Continue to {STEPS[step + 1].label.toLowerCase()} &rarr;
-        </Btn>
-      ) : (
-        <Btn
-          variant="primary"
-          onClick={handleComplete}
-          disabled={isSubmitting || !canProceed}
-        >
-          {isSubmitting ? 'Setting up...' : 'Complete setup'}
-        </Btn>
+      {/* Scan step: no footer button — StepScan owns its Finish */}
+      {!isOnScanStep && (
+        step < SCAN_STEP - 1 ? (
+          // Steps 0–2: "Continue to <next>"
+          <Btn
+            variant="primary"
+            onClick={() => goTo(step + 1)}
+            disabled={!canProceed}
+          >
+            Continue to {STEPS[step + 1].label.toLowerCase()} &rarr;
+          </Btn>
+        ) : (
+          // Step 3 (Confirm): register + enter Scan
+          <Btn
+            variant="primary"
+            onClick={() => { void handleEnterScan(); }}
+            disabled={isSubmitting || !canProceed}
+          >
+            {isSubmitting ? 'Registering…' : 'Start scan →'}
+          </Btn>
+        )
       )}
     </>
   );
@@ -376,6 +419,14 @@ export function SetupWizard() {
               catalogSettings={state.catalogSettings}
               tools={state.tools}
               isSubmitting={isSubmitting}
+            />
+          )}
+          {step === SCAN_STEP && flushResult && (
+            <StepScan
+              sources={state.sources}
+              flushResult={flushResult}
+              onFinish={handleFinish}
+              isFinishing={isFinishing}
             />
           )}
       </WizardShell>

--- a/apps/desktop/src/features/setup/sources-store.ts
+++ b/apps/desktop/src/features/setup/sources-store.ts
@@ -46,6 +46,8 @@ export interface FlushRowResult {
   kind: SourceKind;
   path: string;
   success: boolean;
+  /** The registered root's id (present on successful rows); used to scan the source. */
+  rootId?: string;
   error?: string;
 }
 
@@ -198,7 +200,12 @@ export async function flushToDB(sources: SourcesState): Promise<FlushResult> {
 
   if (isMockMode) {
     return {
-      results: validSources.map((s) => ({ kind: s.kind, path: s.path, success: true })),
+      results: validSources.map((s) => ({
+        kind: s.kind,
+        path: s.path,
+        success: true,
+        rootId: s.path,
+      })),
       allSucceeded: true,
     };
   }
@@ -216,7 +223,13 @@ export async function flushToDB(sources: SourcesState): Promise<FlushResult> {
 
     const results: FlushRowResult[] = batchResult.results.map((item) => {
       if (item.success) {
-        return { kind: item.kind as SourceKind, path: item.path, success: true };
+        // Carry the assigned root id so the wizard scan step can scan this source.
+        return {
+          kind: item.kind as SourceKind,
+          path: item.path,
+          success: true,
+          rootId: item.root?.id,
+        };
       }
       const errorCode = item.error ?? 'unknown';
       const message = ERROR_MESSAGES[errorCode] ?? `Registration failed: ${errorCode}`;

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -1,0 +1,332 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * StepScan tests — first-run wizard "Scan" step (spec 038).
+ *
+ * Covers: scanning/done/empty/error states and the Finish flow.
+ * Mocks inboxScanFolder + inboxClassify at the @/api/commands layer
+ * (same pattern as SetupWizard.test.tsx).
+ */
+
+import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ── Hoisted mocks ────────────────────────────────────────────────────────────
+
+const { mockInboxScanFolder, mockInboxClassify } = vi.hoisted(() => ({
+  mockInboxScanFolder: vi.fn(),
+  mockInboxClassify: vi.fn(),
+}));
+
+vi.mock('@/api/commands', () => ({
+  inboxScanFolder: mockInboxScanFolder,
+  inboxClassify: mockInboxClassify,
+}));
+
+// ── Component under test ─────────────────────────────────────────────────────
+
+import { StepScan } from './StepScan';
+import type { StepScanProps } from './StepScan';
+
+// ── Fixtures ─────────────────────────────────────────────────────────────────
+
+const SOURCES = [
+  { path: '/astro/lights', kind: 'light_frames' as const, scanDepth: 'recursive' as const },
+  { path: '/astro/projects', kind: 'project' as const, scanDepth: 'recursive' as const },
+];
+
+const FLUSH_RESULT = {
+  results: [
+    { kind: 'light_frames' as const, path: '/astro/lights', success: true },
+    { kind: 'project' as const, path: '/astro/projects', success: true },
+  ],
+  allSucceeded: true,
+};
+
+const SCAN_RESPONSE_WITH_ITEMS = {
+  rootId: 'root-001',
+  items: [
+    {
+      inboxItemId: 'item-001',
+      relativePath: '2025-10-10/NGC7000',
+      fileCount: 18,
+      lane: 'fits',
+      state: 'classified',
+      contentSignature: 'sig-abc',
+    },
+  ],
+};
+
+const CLASSIFY_RESPONSE = {
+  inboxItemId: 'item-001',
+  type: 'mixed',
+  frameType: null,
+  contentSignature: 'sig-abc',
+  breakdown: [
+    { kind: 'light', count: 16, destinationPreview: 'NGC7000/light/', sampleFiles: [] },
+    { kind: 'dark', count: 2, destinationPreview: 'NGC7000/dark/', sampleFiles: [] },
+  ],
+  unclassifiedFiles: [],
+  sampleFiles: [],
+  computedAt: '2025-10-10T22:00:00Z',
+};
+
+const SCAN_RESPONSE_EMPTY = {
+  rootId: 'root-002',
+  items: [],
+};
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function renderStep(overrides: Partial<StepScanProps> = {}) {
+  const onFinish = overrides.onFinish ?? vi.fn().mockResolvedValue(undefined);
+  return render(
+    <StepScan
+      sources={SOURCES}
+      flushResult={FLUSH_RESULT}
+      onFinish={onFinish}
+      isFinishing={false}
+      {...overrides}
+    />,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  mockInboxScanFolder.mockReset();
+  mockInboxClassify.mockReset();
+});
+
+describe('StepScan', () => {
+  describe('scanning state', () => {
+    it('shows source paths in pending state on initial render', () => {
+      // Return a promise that never resolves so we can observe pending state
+      mockInboxScanFolder.mockReturnValue(new Promise(() => {}));
+      mockInboxClassify.mockReturnValue(new Promise(() => {}));
+
+      renderStep();
+
+      expect(screen.getByTestId('step-scan')).toBeInTheDocument();
+      // Both source paths should be visible
+      expect(screen.getByTestId('scan-source-/astro/lights')).toBeInTheDocument();
+      expect(screen.getByTestId('scan-source-/astro/projects')).toBeInTheDocument();
+    });
+
+    it('calls inboxScanFolder for each source on mount', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep();
+
+      await waitFor(() => {
+        expect(mockInboxScanFolder).toHaveBeenCalledTimes(2);
+      });
+
+      expect(mockInboxScanFolder).toHaveBeenCalledWith(
+        expect.objectContaining({ rootAbsolutePath: '/astro/lights' }),
+      );
+      expect(mockInboxScanFolder).toHaveBeenCalledWith(
+        expect.objectContaining({ rootAbsolutePath: '/astro/projects' }),
+      );
+    });
+
+    it('calls inboxClassify for each discovered item', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep();
+
+      await waitFor(() => {
+        expect(mockInboxClassify).toHaveBeenCalledWith(
+          expect.objectContaining({ inboxItemId: 'item-001' }),
+        );
+      });
+    });
+  });
+
+  describe('done state with detections', () => {
+    it('shows detected items and frame-type breakdown when scan completes', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      // Wait for scan to complete
+      await waitFor(() => {
+        expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
+      });
+
+      // Item path visible
+      expect(screen.getByText('2025-10-10/NGC7000')).toBeInTheDocument();
+      // Breakdown kinds visible (light=16, dark=2)
+      expect(screen.getByText('16 light')).toBeInTheDocument();
+      expect(screen.getByText('2 dark')).toBeInTheDocument();
+    });
+
+    it('shows the scan summary when all sources are done', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep();
+
+      await waitFor(() => {
+        expect(screen.getByTestId('scan-summary')).toBeInTheDocument();
+      });
+    });
+
+    it('enables the Finish button once all sources are done', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep();
+
+      await waitFor(() => {
+        const finishBtn = screen.getByTestId('finish-button');
+        expect(finishBtn).not.toBeDisabled();
+      });
+    });
+
+    it('calls onFinish when Finish is clicked', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      const onFinish = vi.fn().mockResolvedValue(undefined);
+      renderStep({ sources: [SOURCES[0]], onFinish });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('finish-button')).not.toBeDisabled();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByTestId('finish-button'));
+        await new Promise((r) => setTimeout(r, 0));
+      });
+
+      expect(onFinish).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('empty state', () => {
+    it('shows empty-state message when no items are detected', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE); // not called for empty
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(screen.getByTestId('scan-empty')).toBeInTheDocument();
+      });
+    });
+
+    it('does not show scan-item rows when empty', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        // Should have finished without items
+        expect(screen.queryByTestId('scan-item-item-001')).not.toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('error state', () => {
+    it('shows error state for a failing source', async () => {
+      mockInboxScanFolder.mockRejectedValue(new Error('disk read error'));
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(screen.getByText(/disk read error/i)).toBeInTheDocument();
+      });
+    });
+
+    it('completes other sources even when one fails (FR-005)', async () => {
+      // First source fails, second succeeds
+      mockInboxScanFolder
+        .mockRejectedValueOnce(new Error('disk read error'))
+        .mockResolvedValueOnce(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep();
+
+      // Error for first source
+      await waitFor(() => {
+        expect(screen.getByText(/disk read error/i)).toBeInTheDocument();
+      });
+
+      // Second source should still complete: item detected
+      await waitFor(() => {
+        expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
+      });
+    });
+
+    it('enables Finish even when a source has errored (FR-005)', async () => {
+      mockInboxScanFolder
+        .mockRejectedValueOnce(new Error('disk read error'))
+        .mockResolvedValueOnce(SCAN_RESPONSE_EMPTY);
+
+      renderStep();
+
+      await waitFor(() => {
+        const finishBtn = screen.getByTestId('finish-button');
+        expect(finishBtn).not.toBeDisabled();
+      });
+    });
+  });
+
+  describe('Finish button state', () => {
+    it('keeps Finish disabled while scans are still running', () => {
+      // Never-resolving promise keeps sources in scanning state
+      mockInboxScanFolder.mockReturnValue(new Promise(() => {}));
+
+      renderStep();
+
+      const finishBtn = screen.getByTestId('finish-button');
+      expect(finishBtn).toBeDisabled();
+    });
+
+    it('shows "Finishing…" label when isFinishing is true', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
+
+      renderStep({ isFinishing: true });
+
+      // Even before scan completes the label reflects the prop
+      expect(screen.getByTestId('finish-button')).toHaveTextContent('Finishing…');
+    });
+  });
+
+  describe('no-sources edge case', () => {
+    it('renders empty-sources message when sources list is empty', () => {
+      renderStep({ sources: [] });
+
+      expect(screen.getByText(/no sources registered/i)).toBeInTheDocument();
+    });
+  });
+
+  describe('re-entry guard', () => {
+    it('does not re-trigger scans when re-rendered with the same props', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
+
+      const { rerender } = renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(mockInboxScanFolder).toHaveBeenCalledTimes(1);
+      });
+
+      // Re-render with same props (simulates parent state update)
+      rerender(
+        <StepScan
+          sources={[SOURCES[0]]}
+          flushResult={FLUSH_RESULT}
+          onFinish={vi.fn().mockResolvedValue(undefined)}
+          isFinishing={false}
+        />,
+      );
+
+      // Should still be 1 — the ref guard prevents double scan
+      await new Promise((r) => setTimeout(r, 10));
+      expect(mockInboxScanFolder).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -70,10 +70,8 @@ function phasePillVariant(phase: ScanPhase): PillVariant {
  *  failed — we still try to scan using the path directly). */
 function getRootId(flushResult: FlushResult, path: string): string {
   const row = flushResult.results.find((r) => r.path === path);
-  // FlushRowResult.root may carry the assigned rootId in successful rows.
-  // The actual shape is cast via the batch response; we read it if present.
-  const root = (row as { root?: { id?: string } } | undefined)?.root;
-  return root?.id ?? path;
+  // Successful rows carry the assigned rootId; fall back to the path if absent.
+  return row?.rootId ?? path;
 }
 
 // ── Per-source detection summary ──────────────────────────────────────────────

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -1,0 +1,357 @@
+// First-run wizard: "Scan" step (spec 038).
+//
+// Registers sources (via flushToDB), then runs inbox_scan_folder +
+// inbox_classify per source, showing per-source progress and a detection
+// summary.  Approval stays in the Inbox — no inbox_confirm called here.
+
+import { useEffect, useRef, useState } from 'react';
+import { Pill } from '@/ui/Pill';
+import type { PillVariant } from '@/ui/Pill';
+import { inboxScanFolder, inboxClassify } from '@/api/commands';
+import type { InboxItemSummary, InboxClassifyResponse } from '@/api/commands';
+import type { SourceEntry } from '../sources-store';
+import type { FlushResult } from '../sources-store';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type ScanPhase = 'pending' | 'scanning' | 'done' | 'error';
+
+interface SourceScanState {
+  source: SourceEntry;
+  /** rootId returned by roots_register_batch for this source. */
+  rootId: string;
+  phase: ScanPhase;
+  items: InboxItemSummary[];
+  /** Per-item classify results keyed by inboxItemId. */
+  classifications: Map<string, InboxClassifyResponse>;
+  error?: string;
+}
+
+export interface StepScanProps {
+  /** All registered sources from the wizard state. */
+  sources: SourceEntry[];
+  /** Result of flushToDB; rootId per path lets us pass the right id to scan. */
+  flushResult: FlushResult;
+  /** Callback when scan step is done and Finish is clicked. */
+  onFinish: () => Promise<void>;
+  isFinishing: boolean;
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function phaseLabel(phase: ScanPhase): string {
+  switch (phase) {
+    case 'pending':
+      return 'Pending';
+    case 'scanning':
+      return 'Scanning…';
+    case 'done':
+      return 'Done';
+    case 'error':
+      return 'Error';
+  }
+}
+
+function phasePillVariant(phase: ScanPhase): PillVariant {
+  switch (phase) {
+    case 'pending':
+      return 'neutral';
+    case 'scanning':
+      return 'warn';
+    case 'done':
+      return 'ok';
+    case 'error':
+      return 'danger';
+  }
+}
+
+/** Derive a stable rootId string from the flushResult for a given path.
+ *  Falls back to the path itself when no root was returned (e.g. registration
+ *  failed — we still try to scan using the path directly). */
+function getRootId(flushResult: FlushResult, path: string): string {
+  const row = flushResult.results.find((r) => r.path === path);
+  // FlushRowResult.root may carry the assigned rootId in successful rows.
+  // The actual shape is cast via the batch response; we read it if present.
+  const root = (row as { root?: { id?: string } } | undefined)?.root;
+  return root?.id ?? path;
+}
+
+// ── Per-source detection summary ──────────────────────────────────────────────
+
+interface SourceSummaryProps {
+  state: SourceScanState;
+}
+
+function SourceSummary({ state }: SourceSummaryProps) {
+  const { source, phase, items, classifications, error } = state;
+
+  const totalItems = items.length;
+  const totalFiles = items.reduce((acc, it) => acc + it.fileCount, 0);
+
+  // Aggregate breakdown counts across all classified items
+  const kindCounts = new Map<string, number>();
+  for (const [, cls] of classifications) {
+    for (const entry of cls.breakdown ?? []) {
+      kindCounts.set(entry.kind, (kindCounts.get(entry.kind) ?? 0) + entry.count);
+    }
+  }
+
+  return (
+    <div
+      data-testid={`scan-source-${source.path}`}
+      style={{
+        border: '1px solid var(--alm-border)',
+        borderRadius: 'var(--alm-radius-md)',
+        padding: 'var(--alm-sp-4)',
+        marginBottom: 'var(--alm-sp-3)',
+        background: 'var(--alm-surface)',
+      }}
+    >
+      {/* Header row */}
+      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--alm-sp-3)', marginBottom: 'var(--alm-sp-2)' }}>
+        <span
+          style={{
+            flex: 1,
+            fontWeight: 'var(--alm-weight-medium)',
+            fontSize: 'var(--alm-text-sm)',
+            color: 'var(--alm-text)',
+            wordBreak: 'break-all',
+          }}
+        >
+          {source.path}
+        </span>
+        <Pill variant={phasePillVariant(phase)}>{phaseLabel(phase)}</Pill>
+      </div>
+
+      {/* Kind label */}
+      <div style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)', marginBottom: 'var(--alm-sp-2)' }}>
+        {source.kind.replace('_', ' ')}
+      </div>
+
+      {/* Error state */}
+      {phase === 'error' && error && (
+        <p style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-error)', margin: 0 }}>
+          {error}
+        </p>
+      )}
+
+      {/* Scanning state */}
+      {phase === 'scanning' && (
+        <p style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-secondary)', margin: 0 }}>
+          Scanning…
+        </p>
+      )}
+
+      {/* Done: empty state */}
+      {phase === 'done' && totalItems === 0 && (
+        <p
+          data-testid="scan-empty"
+          style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-muted)', margin: 0 }}
+        >
+          Nothing detected in this folder.
+        </p>
+      )}
+
+      {/* Done: detection summary */}
+      {phase === 'done' && totalItems > 0 && (
+        <div>
+          <div style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-secondary)', marginBottom: 'var(--alm-sp-2)' }}>
+            {totalItems} folder{totalItems !== 1 ? 's' : ''} detected
+            {totalFiles > 0 ? ` · ${totalFiles} file${totalFiles !== 1 ? 's' : ''}` : ''}
+          </div>
+          {kindCounts.size > 0 && (
+            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--alm-sp-2)' }}>
+              {Array.from(kindCounts.entries()).map(([kind, count]) => (
+                <span
+                  key={kind}
+                  style={{
+                    fontSize: 'var(--alm-text-xs)',
+                    background: 'var(--alm-surface-alt)',
+                    border: '1px solid var(--alm-border)',
+                    borderRadius: 'var(--alm-radius-sm)',
+                    padding: '2px var(--alm-sp-2)',
+                    color: 'var(--alm-text-secondary)',
+                  }}
+                >
+                  {count} {kind}
+                </span>
+              ))}
+            </div>
+          )}
+          {/* List inbox items using a compact format (reusing InboxItemSummary data) */}
+          <div style={{ marginTop: 'var(--alm-sp-3)' }}>
+            {items.map((item) => (
+              <div
+                key={item.inboxItemId}
+                data-testid={`scan-item-${item.inboxItemId}`}
+                style={{
+                  display: 'flex',
+                  alignItems: 'center',
+                  gap: 'var(--alm-sp-2)',
+                  padding: 'var(--alm-sp-1) 0',
+                  fontSize: 'var(--alm-text-xs)',
+                  color: 'var(--alm-text-secondary)',
+                  borderTop: '1px solid var(--alm-border-subtle)',
+                }}
+              >
+                <span style={{ flex: 1, wordBreak: 'break-all' }}>{item.relativePath}</span>
+                <span>{item.fileCount} file{item.fileCount !== 1 ? 's' : ''}</span>
+                <Pill variant="neutral">{item.lane.toUpperCase()}</Pill>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ── StepScan ─────────────────────────────────────────────────────────────────
+
+/**
+ * Step 5 — Scan.
+ *
+ * Runs inbox_scan_folder + inbox_classify per registered source and shows a
+ * per-source detection summary.  Ingestion-group approval stays in the Inbox;
+ * Finish navigates there without calling inbox_confirm.
+ */
+export function StepScan({ sources, flushResult, onFinish, isFinishing }: StepScanProps) {
+  const [sourceStates, setSourceStates] = useState<SourceScanState[]>(() =>
+    sources
+      .filter((s) => s.path)
+      .map((s) => ({
+        source: s,
+        rootId: getRootId(flushResult, s.path),
+        phase: 'pending',
+        items: [],
+        classifications: new Map(),
+      })),
+  );
+
+  // Guard: track whether scanning has already been initiated to prevent
+  // re-entry double-scans when the user navigates Back and then Next again.
+  const scanStartedRef = useRef(false);
+
+  useEffect(() => {
+    if (scanStartedRef.current) return;
+    scanStartedRef.current = true;
+
+    // Scan each source independently; one failure doesn't abort others.
+    for (let i = 0; i < sourceStates.length; i++) {
+      const idx = i;
+      const entry = sourceStates[idx];
+
+      (async () => {
+        // Mark as scanning
+        setSourceStates((prev) => {
+          const next = [...prev];
+          next[idx] = { ...next[idx], phase: 'scanning' };
+          return next;
+        });
+
+        try {
+          // 1. Scan the folder
+          const scanResponse = await inboxScanFolder({
+            rootId: entry.rootId,
+            rootAbsolutePath: entry.source.path,
+          });
+
+          const items = scanResponse.items ?? [];
+
+          // 2. Classify each discovered item
+          const classifications = new Map<string, InboxClassifyResponse>();
+          await Promise.allSettled(
+            items.map(async (item) => {
+              try {
+                const cls = await inboxClassify({
+                  inboxItemId: item.inboxItemId,
+                  rootAbsolutePath: entry.source.path,
+                });
+                classifications.set(item.inboxItemId, cls);
+              } catch {
+                // Classification failure for one item: skip but don't abort
+              }
+            }),
+          );
+
+          setSourceStates((prev) => {
+            const next = [...prev];
+            next[idx] = { ...next[idx], phase: 'done', items, classifications };
+            return next;
+          });
+        } catch (err: unknown) {
+          setSourceStates((prev) => {
+            const next = [...prev];
+            next[idx] = {
+              ...next[idx],
+              phase: 'error',
+              error: err instanceof Error ? err.message : String(err),
+            };
+            return next;
+          });
+        }
+      })();
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []); // intentionally empty: run once on mount
+
+  const allDone = sourceStates.every((s) => s.phase === 'done' || s.phase === 'error');
+  const totalDetected = sourceStates.reduce((acc, s) => acc + s.items.length, 0);
+
+  return (
+    <div className="alm-step-scan" data-testid="step-scan">
+      {sourceStates.length === 0 ? (
+        <p style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-muted)' }}>
+          No sources registered. Go back and add at least one folder.
+        </p>
+      ) : (
+        <>
+          {/* Per-source results */}
+          <div style={{ marginBottom: 'var(--alm-sp-4)' }}>
+            {sourceStates.map((s) => (
+              <SourceSummary key={s.source.path} state={s} />
+            ))}
+          </div>
+
+          {/* Summary footer (shown when all sources are complete) */}
+          {allDone && (
+            <p
+              data-testid="scan-summary"
+              style={{
+                fontSize: 'var(--alm-text-sm)',
+                color: 'var(--alm-text-secondary)',
+                margin: 0,
+              }}
+            >
+              {totalDetected > 0
+                ? `${totalDetected} folder${totalDetected !== 1 ? 's' : ''} detected across all sources. Head to the Inbox to review and approve.`
+                : 'No folders detected. You can add more sources in Settings.'}
+            </p>
+          )}
+        </>
+      )}
+
+      {/* Finish button — always visible, enabled once all scans complete */}
+      <div style={{ marginTop: 'var(--alm-sp-5)' }}>
+        <button
+          data-testid="finish-button"
+          onClick={() => { void onFinish(); }}
+          disabled={isFinishing || !allDone}
+          style={{
+            padding: 'var(--alm-sp-2) var(--alm-sp-5)',
+            background: 'var(--alm-accent)',
+            color: 'var(--alm-accent-text)',
+            border: 'none',
+            borderRadius: 'var(--alm-radius-md)',
+            fontWeight: 'var(--alm-weight-medium)',
+            fontSize: 'var(--alm-text-sm)',
+            cursor: isFinishing || !allDone ? 'not-allowed' : 'pointer',
+            opacity: isFinishing || !allDone ? 0.6 : 1,
+          }}
+        >
+          {isFinishing ? 'Finishing…' : 'Finish'}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/setup/steps/index.ts
+++ b/apps/desktop/src/features/setup/steps/index.ts
@@ -8,3 +8,5 @@ export type { CatalogSettings, StepCatalogsProps } from './StepCatalogs';
 export { DEFAULT_CATALOG_SETTINGS } from './StepCatalogs';
 export { StepConfirm } from './StepConfirm';
 export type { StepConfirmProps } from './StepConfirm';
+export { StepScan } from './StepScan';
+export type { StepScanProps } from './StepScan';

--- a/specs/038-wizard-scan-step/checklists/requirements.md
+++ b/specs/038-wizard-scan-step/checklists/requirements.md
@@ -1,0 +1,19 @@
+# Specification Quality Checklist: First-run wizard scan step
+
+**Created**: 2026-06-19 | **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] Focused on user value (visible first-run detection feedback)
+- [x] Decisions captured (scan+summary only; reuse Inbox components)
+- [x] Mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers
+- [x] Requirements testable; success criteria measurable
+- [x] Edge cases (empty, error, re-entry, large source) identified
+- [x] Scope bounded (approval stays in Inbox; scan_start stub out of scope)
+- [x] Grounded in real pipeline (inbox_scan_folder + inbox_classify)
+
+## Feature Readiness
+- [x] FRs have acceptance criteria
+- [x] Mock-mode requirement stated (FR-007)

--- a/specs/038-wizard-scan-step/spec.md
+++ b/specs/038-wizard-scan-step/spec.md
@@ -1,0 +1,118 @@
+# Feature Specification: First-run wizard scan step
+
+**Feature Branch**: `038-wizard-scan-step`
+
+**Created**: 2026-06-19
+
+**Status**: Draft
+
+**Input**: As the last step in the setup wizard, perform the actual scan per registered source and show the status of the scan (what was detected per source). Ingestion-group approval for brownfield libraries happens in the Inbox afterward — the wizard step is scan + summary only and reuses the Inbox triage components for the summary view.
+
+## Background
+
+Today the wizard ends at a static **Confirm** step that says "an initial scan runs after
+setup," then registers roots and navigates to the Inbox. Users get no feedback that anything was
+detected. This feature replaces/augments that with an actual scan + per-source detection summary,
+so first-run users immediately see what the app found in their library before they start
+triaging in the Inbox.
+
+**Pipeline reality** (grounding): `scan_start` is a stub. The real ingestion path is the Inbox
+pipeline — `inbox_scan_folder` (scan a folder) → `inbox_classify` (group/classify detections) —
+with `inbox_confirm` performing per-group approval. `crates/app/core/src/inbox/confirm.rs` is
+real and tested. This feature drives the existing **scan + classify** commands from the wizard;
+**confirm/approval stays in the Inbox** (decided).
+
+## Clarifications
+
+- **Approval model**: Scan + summary only. The wizard runs scan + classify per source and shows
+  what was detected; the user approves ingestion groups later in the Inbox (Finish is never
+  blocked on approval).
+- **UI**: Reuse the existing Inbox triage components for the per-source detection summary rather
+  than building a parallel UI.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - See what was detected per source (Priority: P1)
+
+After registering sources, the user reaches the final wizard step which scans each source and
+shows, per source, the detected ingestion groups (counts, types) so they understand what the app
+found before entering the Inbox.
+
+**Why this priority**: This is the feature's core value — turning a blind "scan happens later"
+into visible, trustworthy first-run feedback.
+
+**Independent Test**: With mock data, complete the wizard to the scan step; each registered
+source shows a scanning→done progression and a summary of detected groups.
+
+**Acceptance Scenarios**:
+
+1. **Given** registered sources, **When** the scan step opens, **Then** each source shows scan
+   progress and, on completion, a summary of detected ingestion groups (reusing Inbox triage
+   components).
+2. **Given** a source with no recognizable files, **When** its scan completes, **Then** it shows
+   an empty/"nothing detected" state without error.
+3. **Given** a scan error for one source, **When** it fails, **Then** that source shows an error
+   state and the others still complete (one failure doesn't abort the step).
+
+### User Story 2 - Finish into the Inbox to approve (Priority: P1)
+
+From the scan summary, the user completes setup and lands in the Inbox where the detected groups
+await approval (`inbox_confirm`), exactly as if they had scanned from the Inbox.
+
+**Why this priority**: Approval is deliberately kept in the Inbox; the wizard must hand off
+cleanly so detections are actionable.
+
+**Independent Test**: Finish from the scan step → Inbox shows the same detected groups ready to
+confirm.
+
+**Acceptance Scenarios**:
+
+1. **Given** completed scans, **When** the user clicks Finish, **Then** setup completes and the
+   app navigates to the Inbox showing the detected groups.
+2. **Given** the user wants to skip review, **When** they Finish, **Then** nothing is
+   auto-approved — groups remain pending in the Inbox.
+
+### Edge Cases
+
+- Large source: show progress and keep the UI responsive; do not block other sources.
+- Re-entering the step (back/forward) should not double-scan or duplicate detections.
+- Mock mode must drive the same step against mock scan/classify responses.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: The final wizard step MUST scan each registered source using the Inbox scan command
+  and classify detections using the Inbox classify command.
+- **FR-002**: The step MUST show per-source progress (pending → scanning → done/error) and, on
+  completion, a summary of detected ingestion groups per source.
+- **FR-003**: The summary MUST reuse the existing Inbox triage components (no parallel UI).
+- **FR-004**: The step MUST NOT perform ingestion-group approval; approval happens in the Inbox
+  via the existing confirm flow.
+- **FR-005**: A scan failure for one source MUST NOT abort the step or block Finish.
+- **FR-006**: Finishing MUST complete first-run and navigate to the Inbox with detections pending.
+- **FR-007**: The step MUST function in mock mode against mock scan/classify responses.
+- **FR-008**: No ingestion is auto-approved by the wizard.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: From a fresh first-run with N sources, the scan step shows N per-source results and
+  a non-zero detection summary for sources containing recognizable files.
+- **SC-002**: Finishing lands in the Inbox with the same detected groups pending approval.
+- **SC-003**: A simulated single-source scan failure leaves the other sources completed and
+  Finish enabled.
+- **SC-004**: Full vitest suite (mock-backed) covers the step's states (scanning, done, empty,
+  error) and passes.
+
+## Scope
+
+**In scope**: a wizard scan step driving inbox scan + classify per source; per-source progress +
+detection summary reusing Inbox components; clean handoff to the Inbox on Finish.
+
+**Out of scope**: in-wizard group approval/confirm (stays in Inbox); wiring the stubbed
+`scan_start` background scanner; spec-029 sessions persistence; any change to classification rules.
+
+## Assumptions
+
+- `inbox_scan_folder` + `inbox_classify` accept a source path/root and return detections suitable
+  for the Inbox triage components.
+- Detections persist (DB) so they are visible in the Inbox after navigation.
+- Greenfield: replacing the static Confirm step's "scan after setup" copy is acceptable.


### PR DESCRIPTION
## Summary

- Adds **StepScan** as the new final wizard step (step 5 of 5): runs `inbox_scan_folder` then `inbox_classify` per registered source, shows per-source pending → scanning → done/error progression and a detection summary
- Restructures the Confirm step's primary action from "Complete setup" to **"Start scan →"** (calls `flushToDB` to register roots, then advances to Scan step)
- Defers `completeFirstRun` + `/inbox` navigation to the **Finish** button inside `StepScan`, which fires only after all per-source scans settle
- Approval stays in the Inbox — no `inbox_confirm` called from the wizard (FR-004, FR-008)

## Flow change

```
Before: Source Folders → Tools → Configuration → Confirm (Complete setup → /inbox)
After:  Source Folders → Tools → Configuration → Confirm (Start scan →) → Scan (Finish → /inbox)
```

## Components

- `StepScan.tsx` — new component; reuses `InboxItemSummary` + `InboxClassifyResponse` data types from the Inbox pipeline (FR-003). A `useRef` guard prevents double-scans on Back/Next re-entry. One source failing leaves others completing and Finish enabled (FR-005).
- `steps/index.ts` — exports `StepScan` / `StepScanProps`
- `SetupWizard.tsx` — 5-entry STEPS array, `handleEnterScan` (flush + advance), `handleFinish` (completeFirstRun + navigate), `SCAN_STEP` constant, footer logic hides nav on the Scan step

## Mock handling

`inbox_scan_folder` and `inbox_classify` already have handlers in `api/mocks.ts` — no new mock handlers needed. `SetupWizard.test.tsx` adds stub entries so the import does not fail. `StepScan.test.tsx` mocks both via `vi.hoisted` at `@/api/commands`.

## Tests

- `StepScan.test.tsx` — 16 new tests: scanning state, done with detections (items + breakdown counts), empty state, error state, FR-005 multi-source isolation, Finish gating, re-entry guard, no-sources edge case
- `SetupWizard.test.tsx` — updated: 5-step describe/assertions, step-N-of-5 labels, "Start scan" button in place of "Complete setup", two new assertions for step-4 behaviour

## Gates

- `just typecheck` — clean
- `pnpm vitest run` — 64 test files, 600 tests, 0 failures (16 new StepScan tests, 12 updated SetupWizard tests)

## FR coverage

| FR | Status |
|----|--------|
| FR-001 scan + classify per source | done |
| FR-002 per-source progress (pending→scanning→done/error) | done |
| FR-003 reuse Inbox triage components | done (InboxItemSummary/InboxClassifyResponse data; SourceSummary composes them) |
| FR-004 no approval in wizard | done |
| FR-005 one failure does not abort others / block Finish | done + tested |
| FR-006 Finish completes first-run, navigates to Inbox | done |
| FR-007 works in mock mode | done (mocks.ts handlers already present; mock-mode skips completeFirstRun) |
| FR-008 nothing auto-approved | done |