### PR TITLE
fix: stop app hanging on load from a setup redirect loop

### DIFF
--- a/apps/desktop/src/app/first-run.test.ts
+++ b/apps/desktop/src/app/first-run.test.ts
@@ -1,19 +1,30 @@
 /**
- * Spec 020 — first-run index gate test (T052).
+ * Spec 020 — first-run index gate test (T052) + redirect-loop-fix coverage.
  * When setup is incomplete the index route redirects to /setup; when complete
- * it lands on the app. Here we assert the underlying decision function.
+ * it lands on the app. The DB is the source of truth; localStorage is a cache
+ * that must be reconciled to the DB (a stale cache previously caused a /↔/setup
+ * redirect loop). Here we assert the underlying decision function.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockGetPreferences } = vi.hoisted(() => ({ mockGetPreferences: vi.fn() }));
-vi.mock('@/data/preferences', () => ({ getPreferences: mockGetPreferences }));
+const { mockGetPreferences, mockSetPreference, mockFirstrunState } = vi.hoisted(() => ({
+  mockGetPreferences: vi.fn(),
+  mockSetPreference: vi.fn(),
+  mockFirstrunState: vi.fn(),
+}));
+vi.mock('@/data/preferences', () => ({
+  getPreferences: mockGetPreferences,
+  setPreference: mockSetPreference,
+}));
+vi.mock('@/bindings/index', () => ({ commands: { firstrunState: mockFirstrunState } }));
 
 import { checkFirstRunComplete } from '@/app/first-run';
 
-describe('checkFirstRunComplete (T052)', () => {
+describe('checkFirstRunComplete — mock mode (cache only)', () => {
   beforeEach(() => {
     vi.stubEnv('VITE_USE_MOCKS', 'true');
     mockGetPreferences.mockReset();
+    mockSetPreference.mockReset();
   });
 
   it('returns true when setup is completed (index lands on the app)', async () => {
@@ -24,5 +35,49 @@ describe('checkFirstRunComplete (T052)', () => {
   it('returns false when setup is incomplete (index redirects to /setup)', async () => {
     mockGetPreferences.mockReturnValue({ setupCompleted: false });
     await expect(checkFirstRunComplete()).resolves.toBe(false);
+  });
+});
+
+describe('checkFirstRunComplete — real backend (DB is source of truth)', () => {
+  beforeEach(() => {
+    vi.stubEnv('VITE_USE_MOCKS', 'false');
+    mockGetPreferences.mockReset();
+    mockSetPreference.mockReset();
+    mockFirstrunState.mockReset();
+  });
+
+  it('uses the DB completedAt (not the cache) and reconciles a stale-false cache up', async () => {
+    mockGetPreferences.mockReturnValue({ setupCompleted: false });
+    mockFirstrunState.mockResolvedValue({
+      status: 'ok',
+      data: { completedAt: '2026-06-19T00:00:00Z' },
+    });
+    await expect(checkFirstRunComplete()).resolves.toBe(true);
+    expect(mockSetPreference).toHaveBeenCalledWith('setupCompleted', true);
+  });
+
+  it('returns false when the DB has no completedAt and corrects a stale-true cache', async () => {
+    // The redirect-loop scenario: cache says done, DB says not done.
+    mockGetPreferences.mockReturnValue({ setupCompleted: true });
+    mockFirstrunState.mockResolvedValue({ status: 'ok', data: { completedAt: null } });
+    await expect(checkFirstRunComplete()).resolves.toBe(false);
+    expect(mockSetPreference).toHaveBeenCalledWith('setupCompleted', false);
+  });
+
+  it('does not rewrite the cache when it already matches the DB', async () => {
+    mockGetPreferences.mockReturnValue({ setupCompleted: true });
+    mockFirstrunState.mockResolvedValue({
+      status: 'ok',
+      data: { completedAt: '2026-06-19T00:00:00Z' },
+    });
+    await expect(checkFirstRunComplete()).resolves.toBe(true);
+    expect(mockSetPreference).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the cache when the backend errors', async () => {
+    mockGetPreferences.mockReturnValue({ setupCompleted: true });
+    mockFirstrunState.mockResolvedValue({ status: 'error', error: 'boom' });
+    await expect(checkFirstRunComplete()).resolves.toBe(true);
+    expect(mockSetPreference).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/app/first-run.ts
+++ b/apps/desktop/src/app/first-run.ts
@@ -1,7 +1,7 @@
 // First-run gate for the index route (spec 020 T003/T052). Extracted so it is
 // unit-testable without importing the whole router/Shell tree.
 
-import { getPreferences } from '@/data/preferences';
+import { getPreferences, setPreference } from '@/data/preferences';
 
 /**
  * Returns `true` when first-run setup is complete (index should land on the
@@ -11,17 +11,28 @@ import { getPreferences } from '@/data/preferences';
  */
 export async function checkFirstRunComplete(): Promise<boolean> {
   const prefs = getPreferences();
-  if (prefs.setupCompleted) return true;
 
   const useMocks = import.meta.env.VITE_USE_MOCKS === 'true';
   if (useMocks) return !!prefs.setupCompleted;
 
+  // The DB is the source of truth; localStorage `setupCompleted` is only a cache.
+  // We always consult the backend (fast local query) and reconcile the cache to
+  // it, so a stale/cleared cache can't disagree with the DB. A previous
+  // short-circuit (`if (prefs.setupCompleted) return true`) plus the Shell's
+  // cache-only guard let the two diverge and caused a /→/setup redirect loop.
   try {
     const { commands } = await import('@/bindings/index');
     const result = await commands.firstrunState();
-    // `completedAt` is optional in the serialized response (omitted when null),
-    // so it can be `undefined` *or* `null` when incomplete — treat both as not done.
-    if (result.status === 'ok') return Boolean(result.data.completedAt);
+    if (result.status === 'ok') {
+      // `completedAt` is optional in the serialized response (omitted when null),
+      // so it can be `undefined` *or* `null` when incomplete — treat both as not done.
+      const complete = Boolean(result.data.completedAt);
+      if (prefs.setupCompleted !== complete) {
+        setPreference('setupCompleted', complete);
+      }
+      return complete;
+    }
+    // Backend unavailable: fall back to the cache.
     return !!prefs.setupCompleted;
   } catch {
     return !!prefs.setupCompleted;


### PR DESCRIPTION
## Summary
- The app could hang on launch (Chromium 'Throttling navigation … hanging') due to an infinite loop between the main view and the setup wizard.
- Cause: first-run completion was read from two sources that could disagree — a localStorage cache and the database. Clearing the cache while the database still had setup marked complete made them bounce forever.
- Fix: the database is now the single source of truth for first-run completion; localStorage is only a cache that is reconciled to the database on boot.

## Spec Context
- Boot/first-run reliability (relates to spec 020 first-run gate).