### PR TITLE
fix(inbox): manage SqlitePool so the Inbox scan pipeline works on a real backend

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -587,6 +587,12 @@ pub fn run_app(app: tauri::App, pool: SqlitePool) {
         });
     }
 
+    // Inbox + inventory commands take `State<'_, SqlitePool>` directly (rather
+    // than via AppState), so the raw pool must be managed too. Without this they
+    // fail at runtime with "state not managed for field `pool`" — which is why
+    // the Inbox scan/classify pipeline only ever worked under mock mode.
+    app.manage(pool.clone());
+
     let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
     let state = AppState::new(repo, bus);
 


### PR DESCRIPTION
## Summary
- Every `inbox_*` and `inventory_*` command takes `State<'_, SqlitePool>`, but only `AppState` + `CallBuffer` were `.manage()`'d — the raw pool was never managed.
- On a real backend this failed with `state not managed for field 'pool'`, so Inbox scan/classify/confirm + inventory only ever worked under mock mode.
- Surfaced by the spec-038 wizard scan step (the first real runtime caller of `inbox_scan_folder`).

## Fix
`app.manage(pool.clone())` before the pool is moved into the repository. `cargo check` clean.