### PR TITLE
feat(setup): Back button on the wizard scan step

### DIFF
--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -427,6 +427,7 @@ export function SetupWizard() {
               flushResult={flushResult}
               onFinish={handleFinish}
               isFinishing={isFinishing}
+              onBack={() => goTo(SCAN_STEP - 1)}
             />
           )}
       </WizardShell>

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -85,6 +85,7 @@ function renderStep(overrides: Partial<StepScanProps> = {}) {
       flushResult={FLUSH_RESULT}
       onFinish={onFinish}
       isFinishing={false}
+      onBack={vi.fn()}
       {...overrides}
     />,
   );
@@ -321,6 +322,7 @@ describe('StepScan', () => {
           flushResult={FLUSH_RESULT}
           onFinish={vi.fn().mockResolvedValue(undefined)}
           isFinishing={false}
+          onBack={vi.fn()}
         />,
       );
 

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -35,6 +35,8 @@ export interface StepScanProps {
   /** Callback when scan step is done and Finish is clicked. */
   onFinish: () => Promise<void>;
   isFinishing: boolean;
+  /** Go back to the review step to correct sources, then re-scan. */
+  onBack: () => void;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -213,7 +215,7 @@ function SourceSummary({ state }: SourceSummaryProps) {
  * per-source detection summary.  Ingestion-group approval stays in the Inbox;
  * Finish navigates there without calling inbox_confirm.
  */
-export function StepScan({ sources, flushResult, onFinish, isFinishing }: StepScanProps) {
+export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }: StepScanProps) {
   const [sourceStates, setSourceStates] = useState<SourceScanState[]>(() =>
     sources
       .filter((s) => s.path)
@@ -329,8 +331,26 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing }: StepSc
         </>
       )}
 
-      {/* Finish button — always visible, enabled once all scans complete */}
-      <div style={{ marginTop: 'var(--alm-sp-5)' }}>
+      {/* Back (correct sources, then re-scan) + Finish (enabled once scans complete) */}
+      <div style={{ marginTop: 'var(--alm-sp-5)', display: 'flex', gap: 'var(--alm-sp-3)' }}>
+        <button
+          data-testid="back-button"
+          onClick={onBack}
+          disabled={isFinishing}
+          style={{
+            padding: 'var(--alm-sp-2) var(--alm-sp-5)',
+            background: 'transparent',
+            color: 'var(--alm-text)',
+            border: '1px solid var(--alm-border)',
+            borderRadius: 'var(--alm-radius-md)',
+            fontWeight: 'var(--alm-weight-medium)',
+            fontSize: 'var(--alm-text-sm)',
+            cursor: isFinishing ? 'not-allowed' : 'pointer',
+            opacity: isFinishing ? 0.6 : 1,
+          }}
+        >
+          &larr; Back to review
+        </button>
         <button
           data-testid="finish-button"
           onClick={() => { void onFinish(); }}


### PR DESCRIPTION
Adds a 'Back to review' button on the spec-038 scan step (beside Finish, disabled while finishing) so users can return to the Confirm step, correct source folders, and re-scan. Requested during validation. typecheck + vitest (604) green.