### PR TITLE
feat(setup): collapsible scan-result accordions + min window size; Lane→Extension

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -16,8 +16,8 @@
         "title": "Astro Library Manager",
         "width": 1280,
         "height": 820,
-        "minWidth": 1280,
-        "minHeight": 800
+        "minWidth": 1100,
+        "minHeight": 720
       }
     ],
     "security": {

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -7,7 +7,7 @@
  * (same pattern as SetupWizard.test.tsx).
  */
 
-import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Hoisted mocks ────────────────────────────────────────────────────────────
@@ -91,6 +91,13 @@ function renderStep(overrides: Partial<StepScanProps> = {}) {
   );
 }
 
+/** Click the source header button to expand its accordion panel. */
+function expandSource(path: string) {
+  const sourceEl = screen.getByTestId(`scan-source-${path}`);
+  const header = sourceEl.querySelector('[role="button"]') as HTMLElement;
+  fireEvent.click(header);
+}
+
 // ── Tests ────────────────────────────────────────────────────────────────────
 
 beforeEach(() => {
@@ -145,8 +152,87 @@ describe('StepScan', () => {
     });
   });
 
+  describe('accordion — collapsed by default', () => {
+    it('table rows are hidden by default before the accordion is expanded', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      // Wait for scan to finish — compact count summary appears in the header
+      await waitFor(() => {
+        expect(within(screen.getByTestId('scan-source-/astro/lights')).getByText(/1 folder/)).toBeInTheDocument();
+      });
+
+      // Table row must NOT be visible — accordion is still collapsed
+      expect(screen.queryByTestId('scan-item-item-001')).not.toBeInTheDocument();
+    });
+
+    it('reveals table rows after clicking the source header', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(within(screen.getByTestId('scan-source-/astro/lights')).getByText(/1 folder/)).toBeInTheDocument();
+      });
+
+      expandSource('/astro/lights');
+
+      expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
+    });
+
+    it('shows ▸ when collapsed and ▾ when expanded', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(within(screen.getByTestId('scan-source-/astro/lights')).getByText(/1 folder/)).toBeInTheDocument();
+      });
+
+      const sourceEl = screen.getByTestId('scan-source-/astro/lights');
+      expect(sourceEl).toHaveTextContent('▸');
+      expect(sourceEl).not.toHaveTextContent('▾');
+
+      expandSource('/astro/lights');
+
+      expect(sourceEl).toHaveTextContent('▾');
+      expect(sourceEl).not.toHaveTextContent('▸');
+    });
+
+    it('collapses again on second click', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(within(screen.getByTestId('scan-source-/astro/lights')).getByText(/1 folder/)).toBeInTheDocument();
+      });
+
+      expandSource('/astro/lights');
+      expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
+
+      expandSource('/astro/lights');
+      expect(screen.queryByTestId('scan-item-item-001')).not.toBeInTheDocument();
+    });
+
+    it('does not show a chevron while source is still scanning', () => {
+      mockInboxScanFolder.mockReturnValue(new Promise(() => {}));
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      const sourceEl = screen.getByTestId('scan-source-/astro/lights');
+      expect(sourceEl.querySelector('[role="button"]')).not.toBeInTheDocument();
+      expect(sourceEl).not.toHaveTextContent('▸');
+    });
+  });
+
   describe('done state with detections', () => {
-    it('shows detected items and frame-type breakdown when scan completes', async () => {
+    it('shows detected items and frame-type breakdown when scan completes (after expanding)', async () => {
       mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
       mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
 
@@ -154,9 +240,13 @@ describe('StepScan', () => {
 
       // Wait for scan to complete
       await waitFor(() => {
-        expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
+        expect(within(screen.getByTestId('scan-source-/astro/lights')).getByText(/1 folder/)).toBeInTheDocument();
       });
 
+      // Must expand the accordion to see the detail panel
+      expandSource('/astro/lights');
+
+      expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
       // Item path visible
       expect(screen.getByText('2025-10-10/NGC7000')).toBeInTheDocument();
       // Breakdown kinds visible (light=16, dark=2)
@@ -256,10 +346,13 @@ describe('StepScan', () => {
         expect(screen.getByText(/disk read error/i)).toBeInTheDocument();
       });
 
-      // Second source should still complete: item detected
+      // Second source completes — wait for compact count summary, then expand
       await waitFor(() => {
-        expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
+        expect(within(screen.getByTestId('scan-source-/astro/projects')).getByText(/1 folder/)).toBeInTheDocument();
       });
+
+      expandSource('/astro/projects');
+      expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
     });
 
     it('enables Finish even when a source has errored (FR-005)', async () => {

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -84,6 +84,7 @@ interface SourceSummaryProps {
 
 function SourceSummary({ state }: SourceSummaryProps) {
   const { source, phase, items, classifications, error } = state;
+  const [expanded, setExpanded] = useState(false);
 
   const totalItems = items.length;
   const totalFiles = items.reduce((acc, it) => acc + it.fileCount, 0);
@@ -102,19 +103,68 @@ function SourceSummary({ state }: SourceSummaryProps) {
   );
   const cell = { padding: 'var(--alm-sp-1) var(--alm-sp-2)', textAlign: 'left' } as const;
 
+  // The detail panel (chips + table) is expandable only when scan is done and
+  // there are items to show.
+  const isExpandable = phase === 'done' && totalItems > 0;
+
+  // Compact count summary for the always-visible header line.
+  const countSummary =
+    phase === 'done' && totalItems > 0
+      ? `${totalItems} folder${totalItems !== 1 ? 's' : ''} · ${totalFiles} file${totalFiles !== 1 ? 's' : ''}`
+      : null;
+
   return (
     <div
       data-testid={`scan-source-${source.path}`}
       style={{
         border: '1px solid var(--alm-border)',
         borderRadius: 'var(--alm-radius-md)',
-        padding: 'var(--alm-sp-4)',
         marginBottom: 'var(--alm-sp-3)',
         background: 'var(--alm-surface)',
+        overflow: 'hidden',
       }}
     >
-      {/* Header row */}
-      <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--alm-sp-3)', marginBottom: 'var(--alm-sp-2)' }}>
+      {/* ── Always-visible header row ─────────────────────────────────────── */}
+      <div
+        role={isExpandable ? 'button' : undefined}
+        tabIndex={isExpandable ? 0 : undefined}
+        aria-expanded={isExpandable ? expanded : undefined}
+        onClick={isExpandable ? () => setExpanded((v) => !v) : undefined}
+        onKeyDown={
+          isExpandable
+            ? (e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  setExpanded((v) => !v);
+                }
+              }
+            : undefined
+        }
+        style={{
+          display: 'flex',
+          alignItems: 'center',
+          gap: 'var(--alm-sp-3)',
+          padding: 'var(--alm-sp-4)',
+          cursor: isExpandable ? 'pointer' : 'default',
+          userSelect: 'none',
+        }}
+      >
+        {/* Chevron — only shown when expandable */}
+        {isExpandable && (
+          <span
+            aria-hidden="true"
+            style={{
+              fontSize: 'var(--alm-text-xs)',
+              color: 'var(--alm-text-muted)',
+              flexShrink: 0,
+              lineHeight: 1,
+            }}
+          >
+            {expanded ? '▾' : '▸'}
+          </span>
+        )}
+
+        {/* Source path */}
         <span
           style={{
             flex: 1,
@@ -126,47 +176,90 @@ function SourceSummary({ state }: SourceSummaryProps) {
         >
           {source.path}
         </span>
+
+        {/* Kind label (muted, small) */}
+        <span
+          style={{
+            fontSize: 'var(--alm-text-xs)',
+            color: 'var(--alm-text-muted)',
+            flexShrink: 0,
+          }}
+        >
+          {source.kind.replace('_', ' ')}
+        </span>
+
+        {/* Compact count summary */}
+        {countSummary && (
+          <span
+            style={{
+              fontSize: 'var(--alm-text-xs)',
+              color: 'var(--alm-text-secondary)',
+              flexShrink: 0,
+            }}
+          >
+            {countSummary}
+          </span>
+        )}
+
+        {/* Phase pill */}
         <Pill variant={phasePillVariant(phase)}>{phaseLabel(phase)}</Pill>
       </div>
 
-      {/* Kind label */}
-      <div style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)', marginBottom: 'var(--alm-sp-2)' }}>
-        {source.kind.replace('_', ' ')}
-      </div>
-
-      {/* Error state */}
+      {/* ── Always-visible transient states (below header, outside collapse) ── */}
+      {/* These are small/short and don't benefit from collapse. */}
       {phase === 'error' && error && (
-        <p style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-error)', margin: 0 }}>
+        <p
+          style={{
+            fontSize: 'var(--alm-text-sm)',
+            color: 'var(--alm-text-error)',
+            margin: 0,
+            padding: '0 var(--alm-sp-4) var(--alm-sp-4)',
+          }}
+        >
           {error}
         </p>
       )}
 
-      {/* Scanning state */}
       {phase === 'scanning' && (
-        <p style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-secondary)', margin: 0 }}>
+        <p
+          style={{
+            fontSize: 'var(--alm-text-sm)',
+            color: 'var(--alm-text-secondary)',
+            margin: 0,
+            padding: '0 var(--alm-sp-4) var(--alm-sp-4)',
+          }}
+        >
           Scanning…
         </p>
       )}
 
-      {/* Done: empty state */}
       {phase === 'done' && totalItems === 0 && (
         <p
           data-testid="scan-empty"
-          style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-muted)', margin: 0 }}
+          style={{
+            fontSize: 'var(--alm-text-sm)',
+            color: 'var(--alm-text-muted)',
+            margin: 0,
+            padding: '0 var(--alm-sp-4) var(--alm-sp-4)',
+          }}
         >
           Nothing detected in this folder.
         </p>
       )}
 
-      {/* Done: detection summary */}
-      {phase === 'done' && totalItems > 0 && (
-        <div>
-          <div style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-secondary)', marginBottom: 'var(--alm-sp-2)' }}>
-            {totalItems} folder{totalItems !== 1 ? 's' : ''} detected
-            {totalFiles > 0 ? ` · ${totalFiles} file${totalFiles !== 1 ? 's' : ''}` : ''}
-          </div>
+      {/* ── Collapsible detail panel (chips + table) ─────────────────────── */}
+      {isExpandable && expanded && (
+        <div style={{ padding: '0 var(--alm-sp-4) var(--alm-sp-4)' }}>
+          {/* Kind-count chips */}
           {kindCounts.size > 0 && (
-            <div style={{ display: 'flex', flexWrap: 'wrap', gap: 'var(--alm-sp-2)' }}>
+            <div
+              style={{
+                display: 'flex',
+                flexWrap: 'wrap',
+                gap: 'var(--alm-sp-2)',
+                marginBottom: 'var(--alm-sp-3)',
+              }}
+            >
               {Array.from(kindCounts.entries()).map(([kind, count]) => (
                 <span
                   key={kind}
@@ -184,10 +277,10 @@ function SourceSummary({ state }: SourceSummaryProps) {
               ))}
             </div>
           )}
+
           {/* Scrollable metadata table of detected ingestion groups */}
           <div
             style={{
-              marginTop: 'var(--alm-sp-3)',
               maxHeight: 280,
               overflowY: 'auto',
               border: '1px solid var(--alm-border-subtle)',
@@ -213,7 +306,7 @@ function SourceSummary({ state }: SourceSummaryProps) {
                 >
                   <th style={cell}>Folder</th>
                   <th style={cell}>Files</th>
-                  <th style={cell}>Lane</th>
+                  <th style={cell}>Extension</th>
                   <th style={cell}>Detected types</th>
                 </tr>
               </thead>
@@ -343,8 +436,15 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }
         </p>
       ) : (
         <>
-          {/* Per-source results */}
-          <div style={{ marginBottom: 'var(--alm-sp-4)' }}>
+          {/* Per-source results — scrollable container so N sources don't grow the page */}
+          <div
+            style={{
+              flex: 1,
+              minHeight: 0,
+              overflowY: 'auto',
+              marginBottom: 'var(--alm-sp-4)',
+            }}
+          >
             {sourceStates.map((s) => (
               <SourceSummary key={s.source.path} state={s} />
             ))}


### PR DESCRIPTION
## Summary

- **Collapsible accordion for scan results**: each `SourceSummary` is now collapsed by default. The always-visible header shows a chevron (▸/▾), source path, kind label (muted), a compact count chip (`N folders · M files`) once done, and the phase Pill. Clicking the header toggles the detail panel (kind-count chips + scrollable metadata table). Transient states (scanning spinner, error, empty-state) remain always-visible outside the collapse. No chevron is rendered while still scanning.

- **Lane → Extension**: the scan metadata table column header `Lane` is renamed to `Extension` (cell values unchanged).

- **Minimum window size**: `tauri.conf.json` main window `minWidth`/`minHeight` updated from 1280×800 → **1100×720**. The scan step's per-source list is wrapped in a `flex:1; min-height:0; overflow-y:auto` container so content scrolls within the available area at minimum window size rather than growing the page.

## Test changes

- Added `accordion — collapsed by default` describe block (5 new tests: collapsed default, reveal on click, ▸/▾ chevron toggling, collapse on second click, no chevron while scanning).
- Updated two existing tests (`done state with detections` + FR-005 multi-source) to expand the accordion before asserting table rows.
- Added `within()` scoping on the wait for the compact count chip to avoid ambiguous matches with the scan-summary paragraph.
- All 609 tests pass; typecheck clean.

## Test plan

- [ ] `just typecheck` → clean
- [ ] `cd apps/desktop && pnpm vitest run` → 609 pass, 0 fail
- [ ] Launch the app, run the setup wizard to the Scan step — each source renders collapsed with path, kind, and Pill visible
- [ ] Click a source header — accordion expands showing kind chips + table; column header reads "Extension"
- [ ] Click again — accordion collapses
- [ ] Resize window down to 1100×720 — content area scrolls, wizard footer stays pinned