### PR TITLE
fix(settings): wire library roots + status to real backend; folder-picker add; remove Startools

### DIFF
--- a/apps/desktop/src-tauri/src/commands/roots.rs
+++ b/apps/desktop/src-tauri/src/commands/roots.rs
@@ -1,8 +1,7 @@
 //! Root/scan/equipment commands exposed to the Tauri webview.
 //!
-//! `roots.register` delegates to the real `app_core::first_run` use case
-//! (spec 003). Remaining commands are stubs returning fixture data until
-//! the real persistence layer is wired.
+//! `roots.register` and `roots.list` delegate to the persistence layer.
+//! Remaining commands are stubs until the real persistence layer is wired.
 
 use contracts_core::first_run::{
     RegisterSourceRequest, RegisterSourceResponse, ScanDepth, SourceKind,
@@ -15,15 +14,43 @@ use tauri::State;
 
 use crate::commands::lifecycle::AppState;
 
-/// `roots.list` — returns all registered library roots.
+/// `roots.list` — returns all registered library roots from the database.
+///
+/// Each root's `online` flag reflects whether the path is currently accessible.
 ///
 /// # Errors
-/// Returns `Err(String)` on failure; the stub never fails.
+/// Returns `Err(String)` on database failure.
 #[tauri::command]
 #[specta::specta]
-pub async fn roots_list() -> Result<Vec<LibraryRoot>, String> {
-    tracing::debug!("stub: roots.list");
-    Ok(stub_roots())
+pub async fn roots_list(state: State<'_, AppState>) -> Result<Vec<LibraryRoot>, String> {
+    tracing::debug!("roots.list");
+
+    let sources = persistence_db::repositories::first_run::list_sources(state.repo.pool())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let roots = sources
+        .into_iter()
+        .map(|s| {
+            let online = std::path::Path::new(&s.path).exists();
+            let category = match s.kind {
+                contracts_core::first_run::SourceKind::Calibration => RootCategory::Calibration,
+                contracts_core::first_run::SourceKind::Project => RootCategory::Project,
+                contracts_core::first_run::SourceKind::Inbox => RootCategory::Inbox,
+                contracts_core::first_run::SourceKind::LightFrames => RootCategory::Raw,
+            };
+            LibraryRoot {
+                id: s.source_id,
+                path: s.path,
+                category,
+                online,
+                file_count: 0,
+                last_scanned: None,
+            }
+        })
+        .collect();
+
+    Ok(roots)
 }
 
 /// `roots.register` — register a new library root.
@@ -140,37 +167,4 @@ pub async fn equipment_list() -> Result<Vec<Equipment>, String> {
             aliases: vec!["EQ6R".to_owned()],
         },
     ])
-}
-
-// ---------------------------------------------------------------------------
-// Fixture data
-// ---------------------------------------------------------------------------
-
-fn stub_roots() -> Vec<LibraryRoot> {
-    vec![
-        LibraryRoot {
-            id: "root-001".to_owned(),
-            path: "/astro/raw".to_owned(),
-            category: RootCategory::Raw,
-            online: true,
-            file_count: 1247,
-            last_scanned: Some("2026-05-19T23:30:00Z".to_owned()),
-        },
-        LibraryRoot {
-            id: "root-002".to_owned(),
-            path: "/astro/calibration".to_owned(),
-            category: RootCategory::Calibration,
-            online: true,
-            file_count: 342,
-            last_scanned: Some("2026-05-19T23:30:00Z".to_owned()),
-        },
-        LibraryRoot {
-            id: "root-003".to_owned(),
-            path: "/astro/projects".to_owned(),
-            category: RootCategory::Project,
-            online: true,
-            file_count: 856,
-            last_scanned: Some("2026-05-18T20:00:00Z".to_owned()),
-        },
-    ]
 }

--- a/apps/desktop/src-tauri/src/commands/status.rs
+++ b/apps/desktop/src-tauri/src/commands/status.rs
@@ -1,23 +1,48 @@
 //! Spec 030 status summary command (T023).
 //!
-//! Returns a `StatusSummary` DTO with zeroed counts. Real aggregation from
-//! the database will be wired in a later task.
+//! Returns a `StatusSummary` DTO populated from the database.
 
-use contracts_core::status::{LibraryStats, StatusSummary};
+use std::path::Path;
+
+use contracts_core::status::{LibraryStats, RootHealth, StatusSummary};
+use tauri::State;
+
+use crate::commands::lifecycle::AppState;
 
 /// `status.summary` — returns current library status overview.
 ///
+/// Roots are fetched from `registered_sources`; each root's `online` flag is
+/// set by testing whether its path is currently accessible on the filesystem.
+///
 /// # Errors
-/// Returns `Err(String)` on failure; the stub never fails.
+/// Returns `Err(String)` on database failure.
 #[tauri::command]
 #[specta::specta]
-pub async fn status_summary() -> Result<StatusSummary, String> {
-    tracing::debug!("stub: status.summary");
+pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary, String> {
+    tracing::debug!("status.summary");
+
+    let sources = persistence_db::repositories::first_run::list_sources(state.repo.pool())
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let roots: Vec<RootHealth> = sources
+        .into_iter()
+        .map(|s| {
+            let online = Path::new(&s.path).exists();
+            RootHealth {
+                id: s.source_id,
+                path: s.path,
+                kind: format!("{:?}", s.kind).to_lowercase(),
+                online,
+            }
+        })
+        .collect();
+
     Ok(StatusSummary {
         inbox_count: 0,
         library: LibraryStats { sessions: 0, calibration_sets: 0, targets: 0, projects: 0 },
         cleanup_reclaimable_bytes: 0,
         volumes: vec![],
-        roots: vec![],
+        roots,
     })
 }

--- a/apps/desktop/src/features/projects/create/CreateProjectDialog.tsx
+++ b/apps/desktop/src/features/projects/create/CreateProjectDialog.tsx
@@ -35,7 +35,6 @@ import type { ProjectCreateResult } from '@/bindings/index';
 const TOOL_OPTIONS: RadioOption[] = [
   { value: 'PixInsight', label: 'PixInsight', desc: 'WBPP, StarAlignment, integration' },
   { value: 'Siril', label: 'Siril', desc: 'Free open-source stacking' },
-  { value: 'Planetary Suite', label: 'Planetary Suite', desc: 'Planetary / lunar capture' },
 ];
 
 const MAX_NAME_LEN = 120;
@@ -138,7 +137,7 @@ export function CreateProjectDialog({ open, onClose, onSuccess }: CreateProjectD
       const result = await callCreateProject({
         requestId: crypto.randomUUID(),
         name: name.trim(),
-        tool: tool as 'PixInsight' | 'Siril' | 'Planetary Suite',
+        tool: tool as 'PixInsight' | 'Siril',
         path: path.trim(),
         initialSources: [],
         notes: notes.trim() || undefined,

--- a/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
+++ b/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
@@ -44,10 +44,10 @@ export function EditProjectPane({ project, onClose }: EditProjectPaneProps) {
   const toolLocked = isToolLocked(project.lifecycle);
 
   const [name, setName] = useState(project.name);
-  type ToolValue = 'PixInsight' | 'Siril' | 'Planetary Suite';
-  const [tool, setTool] = useState<ToolValue>(
-    (typeof project.tool === 'string' ? project.tool : 'PixInsight'),
-  );
+  type ToolValue = 'PixInsight' | 'Siril';
+  const toToolValue = (t: string | undefined): ToolValue =>
+    t === 'Siril' ? 'Siril' : 'PixInsight';
+  const [tool, setTool] = useState<ToolValue>(toToolValue(project.tool));
   const [notes, setNotes] = useState(project.notes ?? '');
   const [saving, setSaving] = useState(false);
   const [fieldErrors, setFieldErrors] = useState<Record<string, string>>({});
@@ -58,7 +58,7 @@ export function EditProjectPane({ project, onClose }: EditProjectPaneProps) {
   // Sync if parent project changes (e.g. detail re-fetched)
   useEffect(() => {
     setName(project.name);
-    setTool((typeof project.tool === 'string' ? project.tool : 'PixInsight'));
+    setTool(toToolValue(project.tool));
     setNotes(project.notes ?? '');
     setChannels(project.channels ?? []);
   }, [project]);
@@ -191,7 +191,6 @@ export function EditProjectPane({ project, onClose }: EditProjectPaneProps) {
           >
             <option value="PixInsight">PixInsight</option>
             <option value="Siril">Siril</option>
-            <option value="Planetary Suite">Planetary Suite</option>
           </select>
           {toolLocked && (
             <span id="ep-tool-lock" className="alm-field-hint">

--- a/apps/desktop/src/features/projects/tool-launch.test.ts
+++ b/apps/desktop/src/features/projects/tool-launch.test.ts
@@ -28,14 +28,6 @@ describe('toolIdFromProjectTool', () => {
     expect(toolIdFromProjectTool('Siril')).toBe('siril');
   });
 
-  it('aliases Planetary Suite to the seeded startools profile id', () => {
-    expect(toolIdFromProjectTool('Planetary Suite')).toBe('startools');
-  });
-
-  it('converts StarTools to startools', () => {
-    expect(toolIdFromProjectTool('StarTools')).toBe('startools');
-  });
-
   it('handles already lowercase input', () => {
     expect(toolIdFromProjectTool('pixinsight')).toBe('pixinsight');
   });

--- a/apps/desktop/src/features/projects/tool-launch.ts
+++ b/apps/desktop/src/features/projects/tool-launch.ts
@@ -24,15 +24,10 @@ import { addToast } from '@/shared/toast';
  * Derive the stable `tool_id` from the project's `tool` string.
  *
  * Rule from data-model.md §WorkflowBinding: lowercase source name, replace spaces
- * with `_`. `"PixInsight"` → `"pixinsight"`, `"Siril"` → `"siril"`. The planetary
- * tool's user-facing label is "Planetary Suite" but its seeded profile id is
- * "startools" (bundle com.startools.startools), so it is aliased explicitly to
- * match `crates/workflow/profiles/src/seed.rs`.
+ * with `_`. `"PixInsight"` → `"pixinsight"`, `"Siril"` → `"siril"`.
  */
 export function toolIdFromProjectTool(projectTool: string): string {
-  const normalized = projectTool.toLowerCase().replace(/\s+/g, '_');
-  if (normalized === 'planetary_suite') return 'startools';
-  return normalized;
+  return projectTool.toLowerCase().replace(/\s+/g, '_');
 }
 
 // ── disabled-state copy ───────────────────────────────────────────────────────

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -71,10 +71,10 @@ const PROFILE_LABELS: Record<string, string> = {
 };
 
 // Map wizard workflowProfile to the ProjectTool enum expected by the backend.
-const PROFILE_TO_TOOL: Record<string, 'PixInsight' | 'Siril' | 'Planetary Suite'> = {
+const PROFILE_TO_TOOL: Record<string, 'PixInsight' | 'Siril'> = {
   pixinsight: 'PixInsight',
   siril: 'Siril',
-  planetary: 'Planetary Suite',
+  planetary: 'Siril',
 };
 
 export function WizardPage() {

--- a/apps/desktop/src/features/settings/DataSources.tsx
+++ b/apps/desktop/src/features/settings/DataSources.tsx
@@ -1,55 +1,73 @@
-// TODO(spec 003 (roots/sources)): wire to backend when owning spec implements its command.
-import { useState } from 'react';
+// spec 003 (roots/sources) — wired to real backend via listRoots/registerRoot.
+import { useState, useEffect, useCallback } from 'react';
 import { Btn, Pill } from '@/ui';
-import {
-  DATA_SOURCES,
-  type DataSourceRoot,
-} from '@/data/fixtures/settings';
+import { DirPicker } from '@/ui/DirPicker';
+import { listRoots, registerRoot } from '@/api/commands';
+import type { LibraryRoot } from '@/bindings/types';
 
 interface DataSourcesProps {
   save: (scope: string, values: Record<string, unknown>) => void;
 }
 
-const TYPE_VARIANT: Record<DataSourceRoot['type'], 'ok' | 'info' | 'neutral' | 'warn' | 'ghost'> = {
-  Raw: 'ok',
-  Calibration: 'info',
-  Projects: 'neutral',
-  Inbox: 'warn',
-  Archive: 'ghost',
+type RootCategory = LibraryRoot['category'];
+
+const CATEGORY_VARIANT: Record<RootCategory, 'ok' | 'info' | 'neutral' | 'warn' | 'ghost'> = {
+  raw: 'ok',
+  calibration: 'info',
+  project: 'neutral',
+  inbox: 'warn',
 };
 
-function makeId() {
-  return Date.now();
-}
+const CATEGORY_LABEL: Record<RootCategory, string> = {
+  raw: 'Raw',
+  calibration: 'Calibration',
+  project: 'Project',
+  inbox: 'Inbox',
+};
 
-export function DataSources({ save }: DataSourcesProps) {
-  const [roots, setRoots] = useState<DataSourceRoot[]>(DATA_SOURCES);
+export function DataSources({ save: _save }: DataSourcesProps) {
+  const [roots, setRoots] = useState<LibraryRoot[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [loadError, setLoadError] = useState<string | null>(null);
+
   const [showAdd, setShowAdd] = useState(false);
   const [addingPath, setAddingPath] = useState('');
-  const [addingType, setAddingType] = useState<DataSourceRoot['type']>('Raw');
+  const [addingCategory, setAddingCategory] = useState<RootCategory>('raw');
+  const [addError, setAddError] = useState<string | null>(null);
+  const [adding, setAdding] = useState(false);
 
-  const handleAdd = () => {
+  const loadRoots = useCallback(() => {
+    setLoading(true);
+    setLoadError(null);
+    listRoots()
+      .then((data) => setRoots(data))
+      .catch((err: unknown) => setLoadError(String(err)))
+      .finally(() => setLoading(false));
+  }, []);
+
+  useEffect(() => {
+    loadRoots();
+  }, [loadRoots]);
+
+  const handleAdd = async () => {
     if (!addingPath.trim()) return;
-    const newRoot: DataSourceRoot = {
-      id: makeId(),
-      path: addingPath.trim(),
-      type: addingType,
-      online: true,
-      files: 0,
-      size: '—',
-      lastScan: 'never',
-    };
-    const updated = [...roots, newRoot];
-    setRoots(updated);
-    setAddingPath('');
-    setShowAdd(false);
-    save('roots', { roots: updated });
-  };
-
-  const handleRemove = (id: number) => {
-    const updated = roots.filter((r) => r.id !== id);
-    setRoots(updated);
-    save('roots', { roots: updated });
+    setAdding(true);
+    setAddError(null);
+    try {
+      await registerRoot({
+        path: addingPath.trim(),
+        category: addingCategory,
+        scanSettings: {},
+      });
+      setAddingPath('');
+      setAddingCategory('raw');
+      setShowAdd(false);
+      loadRoots();
+    } catch (err: unknown) {
+      setAddError(String(err));
+    } finally {
+      setAdding(false);
+    }
   };
 
   return (
@@ -57,38 +75,61 @@ export function DataSources({ save }: DataSourcesProps) {
       <div className="alm-settings__group">
         <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--alm-sp-3)' }}>
           <div className="alm-settings__group-title" style={{ marginBottom: 0 }}>Library Roots</div>
-          <Btn size="sm" onClick={() => setShowAdd(true)}>Add source folder</Btn>
+          <Btn size="sm" onClick={() => { setShowAdd(true); setAddError(null); }}>
+            Add source folder
+          </Btn>
         </div>
 
         {showAdd && (
-          <div style={{ display: 'flex', gap: 'var(--alm-sp-2)', marginBottom: 'var(--alm-sp-3)', flexWrap: 'wrap' }}>
-            <input
-              className="alm-input"
-              style={{ flex: 1, minWidth: 240 }}
+          <div style={{ marginBottom: 'var(--alm-sp-3)', display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-2)' }}>
+            <DirPicker
               value={addingPath}
-              onChange={(e) => setAddingPath(e.target.value)}
-              placeholder="e.g. D:\Astrophotography\Raw"
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') handleAdd();
-                if (e.key === 'Escape') setShowAdd(false);
-              }}
-              autoFocus
-              aria-label="Source folder path"
+              onChange={setAddingPath}
+              label="Folder"
+              lastPathKind="inbox"
             />
-            <select
-              className="alm-select"
-              value={addingType}
-              onChange={(e) => setAddingType(e.target.value as DataSourceRoot['type'])}
-              aria-label="Source type"
-            >
-              <option value="Raw">Raw</option>
-              <option value="Calibration">Calibration</option>
-              <option value="Projects">Projects</option>
-              <option value="Inbox">Inbox</option>
-              <option value="Archive">Archive</option>
-            </select>
-            <Btn size="sm" onClick={handleAdd} disabled={!addingPath.trim()}>Add</Btn>
-            <Btn size="sm" variant="ghost" onClick={() => setShowAdd(false)}>Cancel</Btn>
+            <div style={{ display: 'flex', gap: 'var(--alm-sp-2)', flexWrap: 'wrap', alignItems: 'center' }}>
+              <select
+                className="alm-select"
+                value={addingCategory}
+                onChange={(e) => setAddingCategory(e.target.value as RootCategory)}
+                aria-label="Source category"
+              >
+                <option value="raw">Raw</option>
+                <option value="calibration">Calibration</option>
+                <option value="project">Project</option>
+                <option value="inbox">Inbox</option>
+              </select>
+              <Btn size="sm" onClick={handleAdd} disabled={!addingPath.trim() || adding}>
+                {adding ? 'Adding…' : 'Add'}
+              </Btn>
+              <Btn size="sm" variant="ghost" onClick={() => { setShowAdd(false); setAddError(null); setAddingPath(''); }}>
+                Cancel
+              </Btn>
+            </div>
+            {addError && (
+              <div style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-danger, #dc2626)' }}>
+                {addError}
+              </div>
+            )}
+          </div>
+        )}
+
+        {loading && (
+          <div style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-sm)' }}>
+            Loading…
+          </div>
+        )}
+
+        {loadError && (
+          <div style={{ color: 'var(--alm-danger, #dc2626)', fontSize: 'var(--alm-text-xs)' }}>
+            Could not load roots: {loadError}
+          </div>
+        )}
+
+        {!loading && !loadError && roots.length === 0 && (
+          <div style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-sm)' }}>
+            No source folders registered yet. Add one above.
           </div>
         )}
 
@@ -108,37 +149,21 @@ export function DataSources({ save }: DataSourcesProps) {
                   {root.path}
                 </code>
                 <div style={{ display: 'flex', gap: 'var(--alm-sp-1)', flexShrink: 0 }}>
-                  <Pill variant={TYPE_VARIANT[root.type]}>{root.type}</Pill>
-                  <Pill variant={root.online ? 'ok' : 'danger'}>{root.online ? 'Online' : 'Offline'}</Pill>
+                  <Pill variant={CATEGORY_VARIANT[root.category]}>
+                    {CATEGORY_LABEL[root.category]}
+                  </Pill>
+                  <Pill variant={root.online ? 'ok' : 'danger'}>
+                    {root.online ? 'Online' : 'Offline'}
+                  </Pill>
                 </div>
               </div>
-              {root.online && (
-                <div style={{ marginTop: 'var(--alm-sp-2)', fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)', display: 'flex', gap: 'var(--alm-sp-3)' }}>
-                  <span>{typeof root.files === 'number' ? root.files.toLocaleString() : root.files} files</span>
-                  <span>{root.size}</span>
-                  <span>Last scan: {root.lastScan}</span>
+              {root.last_scanned && (
+                <div style={{ marginTop: 'var(--alm-sp-2)', fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)' }}>
+                  Last scan: {root.last_scanned}
                 </div>
               )}
-              <div style={{ marginTop: 'var(--alm-sp-2)', display: 'flex', gap: 'var(--alm-sp-1)' }}>
-                <Btn size="sm" variant="ghost" onClick={() => console.log('reveal', root.path)}>
-                  Reveal
-                </Btn>
-                {!root.online && (
-                  <Btn size="sm" variant="ghost" onClick={() => console.log('remap', root.path)}>
-                    Remap
-                  </Btn>
-                )}
-                <Btn size="sm" variant="ghost" onClick={() => handleRemove(root.id)}>
-                  Remove
-                </Btn>
-              </div>
             </div>
           ))}
-          {roots.length === 0 && (
-            <p style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-sm)' }}>
-              No source folders registered. Click "Add source folder" to get started.
-            </p>
-          )}
         </div>
       </div>
     </>

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -677,11 +677,10 @@ mod tests {
     async fn list_profiles_returns_all_seeds() {
         let db = setup_db().await;
         let resp = list_profiles(db.pool()).await.unwrap();
-        assert_eq!(resp.tools.len(), 3);
+        assert_eq!(resp.tools.len(), 2);
         let ids: Vec<&str> = resp.tools.iter().map(|t| t.id.as_str()).collect();
         assert!(ids.contains(&"pixinsight"));
         assert!(ids.contains(&"siril"));
-        assert!(ids.contains(&"startools"));
     }
 
     #[tokio::test]

--- a/crates/workflow/profiles/src/args.rs
+++ b/crates/workflow/profiles/src/args.rs
@@ -145,8 +145,8 @@ mod tests {
     }
 
     #[test]
-    fn render_planetary_empty_template() {
-        // StarTools has no args template tokens; render should return empty vec.
+    fn render_empty_template() {
+        // An empty args template renders to an empty vec.
         let ctx = RenderContext { folder: Some("/project"), file: None };
         assert_eq!(render(&[], &ctx), Vec::<String>::new());
     }

--- a/crates/workflow/profiles/src/discover.rs
+++ b/crates/workflow/profiles/src/discover.rs
@@ -34,7 +34,6 @@ pub struct DiscoveryResult {
 const MACOS_TOOLS: &[(&str, &str, &str)] = &[
     ("pixinsight", "com.pixinsight.PixInsight", "PixInsight"),
     ("siril", "org.free-astro.siril", "Siril"),
-    ("startools", "com.startools.startools", "StarTools"),
 ];
 
 #[cfg(target_os = "macos")]
@@ -94,7 +93,6 @@ fn applications_scan() -> Vec<DiscoveryResult> {
         ("pixinsight", "PixInsight/PixInsight.app", "PixInsight"),
         ("pixinsight", "PixInsight.app", "PixInsight"),
         ("siril", "Siril.app", "Siril"),
-        ("startools", "StarTools.app", "StarTools"),
     ];
     let mut results: Vec<DiscoveryResult> = Vec::new();
     for dir in &dirs {
@@ -128,16 +126,10 @@ pub fn discover_all() -> Vec<DiscoveryResult> {
         ("siril", "/snap/bin/siril"),
         // Flatpak export wrappers are directly executable (they shell out to `flatpak run`).
         ("siril", "/var/lib/flatpak/exports/bin/org.free_astro.Siril"),
-        ("startools", "/usr/bin/startools"),
-        ("startools", "/usr/local/bin/startools"),
     ];
     let mut results = probe_candidates(candidates);
     // PATH search.
-    results.extend(discover_from_path(&[
-        ("pixinsight", "PixInsight"),
-        ("siril", "siril"),
-        ("startools", "startools"),
-    ]));
+    results.extend(discover_from_path(&[("pixinsight", "PixInsight"), ("siril", "siril")]));
     // `.desktop` registry scan (resolves apps installed to non-standard locations).
     results.extend(desktop_file_discover());
     // Deduplicate: keep first found per tool_id.
@@ -152,8 +144,7 @@ pub fn discover_all() -> Vec<DiscoveryResult> {
 #[cfg(target_os = "linux")]
 fn desktop_file_discover() -> Vec<DiscoveryResult> {
     // (tool_id, lowercase name substring)
-    let tools: &[(&str, &str)] =
-        &[("pixinsight", "pixinsight"), ("siril", "siril"), ("startools", "startools")];
+    let tools: &[(&str, &str)] = &[("pixinsight", "pixinsight"), ("siril", "siril")];
 
     let mut dirs: Vec<PathBuf> = vec![
         PathBuf::from("/usr/share/applications"),
@@ -222,7 +213,6 @@ fn resolve_executable(cmd: &str) -> Option<PathBuf> {
 const WINDOWS_TOOLS: &[(&str, &str, &str, &str)] = &[
     ("pixinsight", "pixinsight", "PixInsight", "PixInsight.exe"),
     ("siril", "siril", "Siril", "siril.exe"),
-    ("startools", "startools", "StarTools", "StarTools.exe"),
 ];
 
 #[cfg(target_os = "windows")]

--- a/crates/workflow/profiles/src/seed.rs
+++ b/crates/workflow/profiles/src/seed.rs
@@ -1,7 +1,7 @@
 //! Seeded processing-tool profiles (spec 011 T002).
 //!
-//! Includes PixInsight, Siril, and Planetary Suite with per-OS bundle IDs
-//! (R-BundleId) and args templates (R3).
+//! Includes PixInsight and Siril with per-OS bundle IDs (R-BundleId) and
+//! args templates (R3).
 //!
 //! `all()` returns a fixed-size array of owned `ToolProfile` values.
 //! `validate_seeds()` is called once at app boot to assert seed integrity.
@@ -30,23 +30,12 @@ fn siril_profile() -> ToolProfile {
     }
 }
 
-fn startools_profile() -> ToolProfile {
-    ToolProfile {
-        id: "startools",
-        name: "StarTools",
-        bundle_id: Some("com.startools.startools"),
-        args_template: vec![],
-        supports_open_folder: false,
-        detach_strategy: DetachStrategy::OpenBundleId,
-    }
-}
-
 /// Return all seeded processing-tool profiles as an owned `Vec`.
 ///
 /// Call `validate_seeds()` at app boot to assert integrity.
 #[must_use]
 pub fn all() -> Vec<ToolProfile> {
-    vec![pixinsight_profile(), siril_profile(), startools_profile()]
+    vec![pixinsight_profile(), siril_profile()]
 }
 
 /// Validate all seed profiles.
@@ -86,16 +75,6 @@ mod tests {
     }
 
     #[test]
-    fn planetary_suite_has_no_folder_token() {
-        let profile = find("startools").expect("startools must be seeded");
-        assert!(!profile.supports_open_folder);
-        assert!(
-            !profile.args_template.contains(&ArgsToken::Folder),
-            "startools must not have {{folder}} token"
-        );
-    }
-
-    #[test]
     fn pixinsight_supports_open_folder() {
         let p = find("pixinsight").expect("pixinsight must be seeded");
         assert!(p.supports_open_folder);
@@ -114,7 +93,7 @@ mod tests {
     }
 
     #[test]
-    fn three_seeds_are_registered() {
-        assert_eq!(all().len(), 3);
+    fn two_seeds_are_registered() {
+        assert_eq!(all().len(), 2);
     }
 }


### PR DESCRIPTION
## Summary

Four related fixes to unwire UI stubs and remove a retired tool option.

**A — \`status_summary\` backend wired**
- \`status.rs\` now takes \`State<'_, AppState>\` and calls \`persistence_db::repositories::first_run::list_sources()\` to populate \`roots: Vec<RootHealth>\`.
- Online flag = \`std::path::Path::new(&s.path).exists()\`.
- \`volumes\` left empty (no volume aggregation yet).

**A — \`roots_list\` also wired**
- \`roots.rs\` \`roots_list()\` stub replaced with same \`list_sources()\` query, mapping \`SourceKind\` → \`RootCategory\`. Unused \`stub_roots()\` fixture deleted.

**B — DataSources.tsx real data**
- Hardcoded \`DATA_SOURCES\` constant and \`DataSourceRoot\` fixture type fully removed.
- Component calls \`listRoots()\` on mount, re-fetches after add; loading/error/empty-state feedback shown.

**C — Native folder picker for add-source**
- Free-text path input replaced with \`DirPicker\` (same \`useDirectoryPicker\`-backed component the setup wizard uses).
- Submits via \`registerRoot()\` with picked path + category dropdown.
- No backend \`roots.remove\` command exists yet; remove deferred.

**E — Startools removed**
- \`seed.rs\`: \`startools_profile()\` removed, seed count 3→2, test updated.
- \`discover.rs\`: startools removed from macOS (MACOS_TOOLS + applications_scan), Linux (candidates, PATH, .desktop), and Windows (WINDOWS_TOOLS).
- \`args.rs\`: Startools test renamed to \`render_empty_template\`.
- \`crates/app/core/src/tool_launch.rs\`: test count 3→2, startools assertion removed.
- \`tool-launch.ts\`: \`planetary_suite→startools\` alias removed; function is now pure lowercase+underscore.
- \`tool-launch.test.ts\`: Planetary Suite / StarTools cases removed.
- \`EditProjectPane\` / \`WizardPage\` / \`CreateProjectDialog\`: Planetary Suite option dropped; \`toToolValue()\` guard coerces legacy stored value to \`'Siril'\`.

## Test plan

- [ ] \`cargo check\` — clean (0 errors 0 warnings)
- [ ] \`just typecheck\` — clean
- [ ] \`pnpm vitest run\` — 602 pass, 0 fail
- [ ] Manual: Settings > Library Roots shows real registered roots, not mock data
- [ ] Manual: Add source folder opens native folder picker (not text box)
- [ ] Manual: Sidebar status shows correct root/online counts
- [ ] Manual: Create/edit project — no Planetary Suite option visible