### PR TITLE
fix(targets): wire Add target (SIMBAD resolve) and list search

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -136,6 +136,68 @@ export async function mockInvoke<T>(
       const { targetDetail } = await import('@/data/fixtures/targets');
       return targetDetail as T;
     }
+
+    // ── gen-3 target commands (spec 036) ──────────────────────────────────────
+    case 'target_list': {
+      return [
+        { id: 'tgt-m31', effectiveLabel: 'M 31', primaryDesignation: 'M 31', objectType: 'galaxy' },
+        { id: 'tgt-ngc7000', effectiveLabel: 'NGC 7000', primaryDesignation: 'NGC 7000', objectType: 'emission_nebula' },
+      ] as T;
+    }
+    case 'target_get': {
+      const req = (_args as { req?: { targetId?: string } } | undefined)?.req;
+      return {
+        id: req?.targetId ?? 'tgt-m31',
+        primaryDesignation: 'M 31',
+        effectiveLabel: 'M 31',
+        displayAlias: null,
+        objectType: 'galaxy',
+        raDeg: 10.68,
+        decDeg: 41.27,
+        simbadOid: 1_234_567,
+        source: 'resolved',
+        aliases: [],
+      } as T;
+    }
+    case 'target_search': {
+      const req = (_args as { req?: { query?: string } } | undefined)?.req;
+      const q = (req?.query ?? '').toLowerCase();
+      const allSuggestions = [
+        { targetId: 'tgt-m31', primaryDesignation: 'M 31', commonName: 'Andromeda Galaxy', objectType: 'galaxy', matchedAlias: 'Andromeda', source: 'seed' },
+        { targetId: 'tgt-ngc7000', primaryDesignation: 'NGC 7000', commonName: null, objectType: 'emission_nebula', matchedAlias: 'North America Nebula', source: 'seed' },
+      ];
+      const suggestions = q
+        ? allSuggestions.filter(
+            (s) =>
+              s.primaryDesignation.toLowerCase().includes(q) ||
+              (s.commonName?.toLowerCase().includes(q) ?? false) ||
+              (s.matchedAlias?.toLowerCase().includes(q) ?? false),
+          )
+        : allSuggestions;
+      return { contractVersion: '1.0', requestId: crypto.randomUUID(), suggestions } as T;
+    }
+    case 'target_resolve': {
+      const req = (_args as { req?: { query?: string } } | undefined)?.req;
+      const query = req?.query ?? 'M 31';
+      return {
+        contractVersion: '1.0',
+        requestId: crypto.randomUUID(),
+        status: 'resolved',
+        target: {
+          targetId: `tgt-resolved-${Date.now()}`,
+          primaryDesignation: query,
+          commonName: null,
+          objectType: 'other',
+          source: 'resolved',
+          raDeg: 0,
+          decDeg: 0,
+          simbadOid: null,
+        },
+        unresolvedReason: null,
+        error: null,
+      } as T;
+    }
+
     case 'projects_list': {
       // spec 008 real shape: ProjectSummaryDto[]
       const { mockProjectSummaries } = await import('@/data/fixtures/projects');

--- a/apps/desktop/src/components/ListSidebar.tsx
+++ b/apps/desktop/src/components/ListSidebar.tsx
@@ -2,16 +2,26 @@ import type { ReactNode } from 'react';
 
 export interface ListSidebarProps {
   placeholder?: string;
+  /** Controlled search value. When provided, the input is controlled. */
+  searchValue?: string;
+  /** Called when the user types in the search box. */
+  onSearchChange?: (value: string) => void;
   controls?: ReactNode;
   footer?: ReactNode;
   children: ReactNode;
 }
 
-export function ListSidebar({ placeholder, controls, footer, children }: ListSidebarProps) {
+export function ListSidebar({ placeholder, searchValue, onSearchChange, controls, footer, children }: ListSidebarProps) {
   return (
     <div className="alm-list-sidebar">
       <div className="alm-list-sidebar__search">
-        <input type="text" placeholder={placeholder || 'Search...'} />
+        <input
+          type="text"
+          placeholder={placeholder || 'Search...'}
+          value={searchValue ?? ''}
+          onChange={onSearchChange ? (e) => onSearchChange(e.target.value) : undefined}
+          aria-label={placeholder || 'Search'}
+        />
       </div>
       {controls && <div className="alm-list-sidebar__controls">{controls}</div>}
       <div className="alm-list-sidebar__list">{children}</div>

--- a/apps/desktop/src/features/targets/AddTargetDialog.test.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.test.tsx
@@ -1,0 +1,248 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * AddTargetDialog tests — G fix ("Add target" opens SIMBAD resolve flow).
+ *
+ * Tests:
+ *  1. Dialog is hidden by default.
+ *  2. Selecting a suggestion shows the "selected target" confirmation view.
+ *  3. "Add target" button calls resolveTarget with the suggestion's primaryDesignation.
+ *  4. On resolved status, onAdded is called with the resolved targetId and dialog closes.
+ *  5. On unresolved status, an inline error is shown and onAdded is NOT called.
+ *  6. On resolveTarget rejection, an error message renders.
+ *  7. "Change" resets back to the search view.
+ *  8. Confirm button is disabled when no suggestion is pending.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockSearchTargets, mockResolveTarget } = vi.hoisted(() => ({
+  mockSearchTargets: vi.fn(),
+  mockResolveTarget: vi.fn(),
+}));
+
+vi.mock('@/api/commands', () => ({
+  searchTargets: mockSearchTargets,
+  resolveTarget: mockResolveTarget,
+  TARGET_SEARCH_CONTRACT_VERSION: '1.0',
+}));
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn().mockRejectedValue(new Error('no tauri in tests')),
+}));
+
+import { AddTargetDialog } from './AddTargetDialog';
+import type { TargetSuggestion } from '@/api/commands';
+
+const M31: TargetSuggestion = {
+  targetId: 'tgt-m31',
+  primaryDesignation: 'M 31',
+  commonName: 'Andromeda Galaxy',
+  objectType: 'galaxy',
+  matchedAlias: 'Andromeda',
+  source: 'seed',
+};
+
+function resolved(targetId: string) {
+  return {
+    contractVersion: '1.0',
+    requestId: 'r',
+    status: 'resolved' as const,
+    target: {
+      targetId,
+      primaryDesignation: 'M 31',
+      commonName: null,
+      objectType: 'galaxy',
+      source: 'resolved',
+      raDeg: 10.68,
+      decDeg: 41.27,
+      simbadOid: null,
+    },
+    unresolvedReason: null,
+    error: null,
+  };
+}
+
+function unresolved(reason = 'unknown') {
+  return {
+    contractVersion: '1.0',
+    requestId: 'r',
+    status: 'unresolved' as const,
+    target: null,
+    unresolvedReason: reason,
+    error: null,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Default: search returns M31
+  mockSearchTargets.mockResolvedValue({
+    contractVersion: '1.0',
+    requestId: 'r',
+    suggestions: [M31],
+  });
+  mockResolveTarget.mockResolvedValue(resolved('tgt-m31'));
+});
+
+describe('AddTargetDialog', () => {
+  it('1. dialog is hidden when open=false', () => {
+    render(
+      <AddTargetDialog open={false} onClose={vi.fn()} onAdded={vi.fn()} />,
+    );
+    // Dialog.Popup not in the DOM when closed
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('2. selecting a suggestion shows the confirmation view', async () => {
+    render(
+      <AddTargetDialog open onClose={vi.fn()} onAdded={vi.fn()} />,
+    );
+
+    // Type in search box to trigger suggestions
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M 31' } });
+    });
+
+    // Wait for the suggestion to appear
+    await waitFor(() => {
+      expect(screen.getByText('M 31')).toBeInTheDocument();
+    });
+
+    // Click the suggestion
+    const option = screen.getByRole('option', { name: /M 31/i });
+    fireEvent.mouseDown(option);
+
+    // Confirmation view should show selected target pill
+    await waitFor(() => {
+      expect(screen.getByText('Selected target')).toBeInTheDocument();
+      expect(screen.getByText('Change')).toBeInTheDocument();
+    });
+  });
+
+  it('3. confirm calls resolveTarget with the primaryDesignation', async () => {
+    const onAdded = vi.fn();
+    render(<AddTargetDialog open onClose={vi.fn()} onAdded={onAdded} />);
+
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M 31' } });
+    });
+
+    await waitFor(() => screen.getByRole('option', { name: /M 31/i }));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /M 31/i }));
+
+    await waitFor(() => screen.getByText('Change'));
+
+    const confirmBtn = screen.getByRole('button', { name: /Add target/i });
+    await act(async () => {
+      fireEvent.click(confirmBtn);
+    });
+
+    await waitFor(() => {
+      expect(mockResolveTarget).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'M 31', override: null }),
+      );
+    });
+  });
+
+  it('4. resolved status calls onAdded with the target id', async () => {
+    const onAdded = vi.fn();
+    const onClose = vi.fn();
+    mockResolveTarget.mockResolvedValue(resolved('tgt-m31-persisted'));
+
+    render(<AddTargetDialog open onClose={onClose} onAdded={onAdded} />);
+
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M 31' } });
+    });
+    await waitFor(() => screen.getByRole('option', { name: /M 31/i }));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /M 31/i }));
+    await waitFor(() => screen.getByText('Change'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add target/i }));
+    });
+
+    await waitFor(() => {
+      expect(onAdded).toHaveBeenCalledWith('tgt-m31-persisted');
+    });
+  });
+
+  it('5. unresolved status shows error and does not call onAdded', async () => {
+    const onAdded = vi.fn();
+    mockResolveTarget.mockResolvedValue(unresolved('unknown'));
+
+    render(<AddTargetDialog open onClose={vi.fn()} onAdded={onAdded} />);
+
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M 31' } });
+    });
+    await waitFor(() => screen.getByRole('option', { name: /M 31/i }));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /M 31/i }));
+    await waitFor(() => screen.getByText('Change'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add target/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+
+  it('6. resolveTarget rejection shows an error message', async () => {
+    const onAdded = vi.fn();
+    mockResolveTarget.mockRejectedValue(new Error('network_error'));
+
+    render(<AddTargetDialog open onClose={vi.fn()} onAdded={onAdded} />);
+
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M 31' } });
+    });
+    await waitFor(() => screen.getByRole('option', { name: /M 31/i }));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /M 31/i }));
+    await waitFor(() => screen.getByText('Change'));
+
+    await act(async () => {
+      fireEvent.click(screen.getByRole('button', { name: /Add target/i }));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(onAdded).not.toHaveBeenCalled();
+  });
+
+  it('7. Change button resets back to search view', async () => {
+    render(<AddTargetDialog open onClose={vi.fn()} onAdded={vi.fn()} />);
+
+    const input = screen.getByRole('combobox');
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'M 31' } });
+    });
+    await waitFor(() => screen.getByRole('option', { name: /M 31/i }));
+    fireEvent.mouseDown(screen.getByRole('option', { name: /M 31/i }));
+    await waitFor(() => screen.getByText('Change'));
+
+    fireEvent.click(screen.getByText('Change'));
+
+    // Should return to search view
+    await waitFor(() => {
+      expect(screen.getByRole('combobox')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('Selected target')).not.toBeInTheDocument();
+  });
+
+  it('8. confirm button is disabled when no suggestion is pending', () => {
+    render(<AddTargetDialog open onClose={vi.fn()} onAdded={vi.fn()} />);
+    // No suggestion selected — confirm button should be disabled
+    const confirmBtn = screen.getByRole('button', { name: /Add target/i });
+    expect(confirmBtn).toBeDisabled();
+  });
+});

--- a/apps/desktop/src/features/targets/AddTargetDialog.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.tsx
@@ -1,0 +1,153 @@
+/**
+ * AddTargetDialog — spec 036 "Add target" action.
+ *
+ * Lets the user search for an astronomical target (via the existing
+ * TargetSearch / SIMBAD two-phase pipeline) and confirm a selection, which
+ * resolves + persists a `canonical_target` via `target.resolve`.  On success
+ * the dialog closes and calls `onAdded(targetId)` so the page can reload
+ * the list and navigate to the new target.
+ *
+ * Reuses `TargetSearch` (spec 035 US1/US3) unchanged.  No new backend
+ * commands are required: `target.search` supplies suggestions and
+ * `target.resolve` persists the canonical row.
+ */
+
+import { useState, useCallback } from 'react';
+import { Dialog } from '@base-ui-components/react/dialog';
+import { Btn, Pill } from '@/ui';
+import { TargetSearch } from '@/components';
+import { resolveTarget, TARGET_SEARCH_CONTRACT_VERSION } from '@/api/commands';
+import type { TargetSuggestion } from '@/api/commands';
+
+export interface AddTargetDialogProps {
+  open: boolean;
+  onClose: () => void;
+  /** Called after the target has been resolved and persisted, with its id. */
+  onAdded: (targetId: string) => void;
+}
+
+export function AddTargetDialog({ open, onClose, onAdded }: AddTargetDialogProps) {
+  const [pending, setPending] = useState<TargetSuggestion | null>(null);
+  const [resolving, setResolving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setPending(null);
+    setResolving(false);
+    setError(null);
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (isOpen: boolean) => {
+      if (!isOpen) {
+        reset();
+        onClose();
+      }
+    },
+    [onClose, reset],
+  );
+
+  const handleSelect = useCallback((s: TargetSuggestion) => {
+    setPending(s);
+    setError(null);
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!pending) return;
+    setResolving(true);
+    setError(null);
+    try {
+      const res = await resolveTarget({
+        contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+        requestId: crypto.randomUUID(),
+        query: pending.primaryDesignation,
+        override: null,
+      });
+      if (res.status === 'resolved' && res.target) {
+        handleOpenChange(false);
+        onAdded(res.target.targetId);
+      } else {
+        setError(
+          `Could not resolve target "${pending.primaryDesignation}". Try a different name.`,
+        );
+      }
+    } catch (err: unknown) {
+      const code = typeof err === 'string' ? err : (err as Error)?.message ?? 'unknown';
+      setError(`Failed to add target (${code}).`);
+    } finally {
+      setResolving(false);
+    }
+  }, [pending, handleOpenChange, onAdded]);
+
+  return (
+    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Backdrop className="alm-confirm-overlay__backdrop" />
+        <Dialog.Popup
+          className="alm-confirm-overlay"
+          aria-label="Add target"
+          style={{ maxWidth: 480 }}
+        >
+          <div className="alm-confirm-overlay__header">
+            <Dialog.Title className="alm-confirm-overlay__title">Add target</Dialog.Title>
+            <Dialog.Description className="alm-confirm-overlay__description">
+              Search for an astronomical target to add it to your library.
+            </Dialog.Description>
+          </div>
+
+          <div
+            className="alm-confirm-overlay__body"
+            style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-4)' }}
+          >
+            {pending ? (
+              <div>
+                <span className="alm-field-label">Selected target</span>
+                <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--alm-sp-2)' }}>
+                  <Pill variant="accent">{pending.primaryDesignation}</Pill>
+                  {pending.commonName && (
+                    <span className="alm-field-hint">{pending.commonName}</span>
+                  )}
+                  <Btn type="button" variant="ghost" onClick={reset}>
+                    Change
+                  </Btn>
+                </div>
+              </div>
+            ) : (
+              <TargetSearch
+                label="Search for a target"
+                placeholder="e.g. M31, NGC 224, Andromeda"
+                onSelect={handleSelect}
+                autoFocus
+              />
+            )}
+
+            {error && (
+              <span role="alert" className="alm-field-error">
+                {error}
+              </span>
+            )}
+          </div>
+
+          <div className="alm-confirm-overlay__footer">
+            <Btn
+              type="button"
+              variant="ghost"
+              onClick={() => handleOpenChange(false)}
+              disabled={resolving}
+            >
+              Cancel
+            </Btn>
+            <Btn
+              type="button"
+              variant="primary"
+              disabled={!pending || resolving}
+              onClick={() => void handleConfirm()}
+            >
+              {resolving ? 'Adding…' : 'Add target'}
+            </Btn>
+          </div>
+        </Dialog.Popup>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/apps/desktop/src/features/targets/TargetList.tsx
+++ b/apps/desktop/src/features/targets/TargetList.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import type { TargetListItem } from '@/api/commands';
 import { ListSidebar, ListItem } from '@/components';
 import { Pill } from '@/ui';
@@ -8,10 +9,23 @@ interface Props {
   onSelect: (id: string) => void;
 }
 
+function matchesSearch(t: TargetListItem, query: string): boolean {
+  const q = query.toLowerCase();
+  return (
+    t.primaryDesignation.toLowerCase().includes(q) ||
+    t.effectiveLabel.toLowerCase().includes(q)
+  );
+}
+
 export function TargetList({ targets, selected, onSelect }: Props) {
+  const [search, setSearch] = useState('');
+  const filtered = search.trim() ? targets.filter((t) => matchesSearch(t, search.trim())) : targets;
+
   return (
     <ListSidebar
       placeholder="Search targets..."
+      searchValue={search}
+      onSearchChange={setSearch}
       controls={
         <>
           <select defaultValue="name">
@@ -19,9 +33,9 @@ export function TargetList({ targets, selected, onSelect }: Props) {
           </select>
         </>
       }
-      footer={`${targets.length} items`}
+      footer={`${filtered.length} items`}
     >
-      {targets.map((t) => (
+      {filtered.map((t) => (
         <ListItem
           key={t.id}
           selected={selected === t.id}

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -11,6 +11,10 @@
  *  6. effectiveLabel from backend renders in the detail pane.
  *  7. Shows error state when listTargets rejects.
  *  8. Target count appears in the subtitle.
+ *  H1. Search input filters the target list by primaryDesignation.
+ *  H2. Search input filters by effectiveLabel.
+ *  H3. Clearing search restores the full list.
+ *  G1. "Add target" button opens the add dialog.
  */
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
@@ -18,14 +22,19 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Hoist mocks ───────────────────────────────────────────────────────────────
 
-const { mockListTargets, mockGetTargetDetail } = vi.hoisted(() => ({
+const { mockListTargets, mockGetTargetDetail, mockSearchTargets, mockResolveTarget } = vi.hoisted(() => ({
   mockListTargets: vi.fn(),
   mockGetTargetDetail: vi.fn(),
+  mockSearchTargets: vi.fn(),
+  mockResolveTarget: vi.fn(),
 }));
 
 vi.mock('@/api/commands', () => ({
   listTargets: mockListTargets,
   getTargetDetail: mockGetTargetDetail,
+  searchTargets: mockSearchTargets,
+  resolveTarget: mockResolveTarget,
+  TARGET_SEARCH_CONTRACT_VERSION: '1.0',
   addTargetAlias: vi.fn().mockResolvedValue({ alias: { id: 'a', alias: 'x', kind: 'user' } }),
   removeTargetAlias: vi.fn().mockResolvedValue({ removed: true }),
   setDisplayAlias: vi.fn().mockResolvedValue({}),
@@ -86,6 +95,8 @@ beforeEach(() => {
   mockSelectedId.current = undefined;
   mockListTargets.mockResolvedValue(listItems);
   mockGetTargetDetail.mockResolvedValue(makeDetail());
+  mockSearchTargets.mockResolvedValue({ contractVersion: '1.0', requestId: 'r', suggestions: [] });
+  mockResolveTarget.mockResolvedValue({ contractVersion: '1.0', requestId: 'r', status: 'unresolved', target: null, unresolvedReason: 'offline', error: null });
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -152,6 +163,59 @@ describe('TargetsPage', () => {
     render(<TargetsPage />);
     await waitFor(() =>
       expect(screen.getByText('2 targets')).toBeInTheDocument(),
+    );
+  });
+
+  // ── H: Search filters ──────────────────────────────────────────────────────
+
+  it('H1. search input filters by primaryDesignation', async () => {
+    render(<TargetsPage />);
+    await waitFor(() => screen.getByText('NGC 7000'));
+
+    const searchInput = screen.getByPlaceholderText('Search targets...');
+    fireEvent.change(searchInput, { target: { value: 'NGC' } });
+
+    // NGC 7000 matches; M 31 does not
+    expect(screen.getByText('NGC 7000')).toBeInTheDocument();
+    expect(screen.queryByText('M 31')).not.toBeInTheDocument();
+  });
+
+  it('H2. search input filters by effectiveLabel (case-insensitive)', async () => {
+    render(<TargetsPage />);
+    await waitFor(() => screen.getByText('M 31'));
+
+    const searchInput = screen.getByPlaceholderText('Search targets...');
+    fireEvent.change(searchInput, { target: { value: 'm 31' } });
+
+    expect(screen.getByText('M 31')).toBeInTheDocument();
+    expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+  });
+
+  it('H3. clearing search restores the full list', async () => {
+    render(<TargetsPage />);
+    await waitFor(() => screen.getByText('NGC 7000'));
+
+    const searchInput = screen.getByPlaceholderText('Search targets...');
+    fireEvent.change(searchInput, { target: { value: 'NGC' } });
+    expect(screen.queryByText('M 31')).not.toBeInTheDocument();
+
+    fireEvent.change(searchInput, { target: { value: '' } });
+    expect(screen.getByText('NGC 7000')).toBeInTheDocument();
+    expect(screen.getByText('M 31')).toBeInTheDocument();
+  });
+
+  // ── G: Add target button ───────────────────────────────────────────────────
+
+  it('G1. "Add target" button opens the add dialog', async () => {
+    render(<TargetsPage />);
+    await waitFor(() => screen.getByText('NGC 7000'));
+
+    const addBtn = screen.getByRole('button', { name: /Add target/i });
+    fireEvent.click(addBtn);
+
+    // Dialog should open — the dialog element itself should be present
+    await waitFor(() =>
+      expect(screen.getByRole('dialog', { name: /Add target/i })).toBeInTheDocument(),
     );
   });
 });

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -18,6 +18,7 @@ import { PageShell, ListDetailLayout, TopActionBar } from '@/components';
 import { Btn, EmptyState } from '@/ui';
 import { TargetList } from './TargetList';
 import { TargetDetailV2 } from './TargetDetailV2';
+import { AddTargetDialog } from './AddTargetDialog';
 
 type ListState =
   | { status: 'loading' }
@@ -28,6 +29,7 @@ export function TargetsPage() {
   const { selected } = useSearch({ from: '/shell/targets' });
   const navigate = useNavigate({ from: '/targets' });
   const [listState, setListState] = useState<ListState>({ status: 'loading' });
+  const [addOpen, setAddOpen] = useState(false);
 
   const load = useCallback(() => {
     setListState({ status: 'loading' });
@@ -43,11 +45,24 @@ export function TargetsPage() {
   const onSelect = (id: string) =>
     navigate({ search: (prev) => ({ ...prev, selected: id }) });
 
+  const handleAdded = useCallback(
+    (targetId: string) => {
+      load();
+      void navigate({ search: (prev) => ({ ...prev, selected: targetId }) });
+    },
+    [load, navigate],
+  );
+
   const targets = listState.status === 'loaded' ? listState.items : [];
   const count = listState.status === 'loaded' ? listState.items.length : '…';
 
   return (
     <PageShell>
+      <AddTargetDialog
+        open={addOpen}
+        onClose={() => setAddOpen(false)}
+        onAdded={handleAdded}
+      />
       <ListDetailLayout
         topBar={
           <TopActionBar
@@ -57,7 +72,7 @@ export function TargetsPage() {
               selected ? (
                 <Btn size="sm" variant="primary">New project</Btn>
               ) : (
-                <Btn size="sm">Add target</Btn>
+                <Btn size="sm" onClick={() => setAddOpen(true)}>Add target</Btn>
               )
             }
           />


### PR DESCRIPTION
## Summary

Fixes two broken behaviors on the Targets page (spec 036 gen-3).

**G — Add target was inert.**
The button had no `onClick` and no dialog behind it. Added `AddTargetDialog` which reuses the existing `TargetSearch` component (spec-035 SIMBAD two-phase pipeline: `target.search` for typeahead, `target.resolve` to persist). On confirm, `target.resolve` is called; on `status === "resolved"` the dialog closes, the list reloads, and the page navigates to the new target's detail. No new backend commands were added.

**H — Search box did nothing.**
`ListSidebar` rendered a static uncontrolled `<input>` (no `value`/`onChange`). Added `searchValue`/`onSearchChange` controlled props to `ListSidebar`. `TargetList` now holds `search` state, filters the loaded list client-side on `primaryDesignation` and `effectiveLabel` (case-insensitive), and passes the value to `ListSidebar`. Footer count reflects filtered results.

**Mocks:** `target_list`, `target_get`, `target_search`, and `target_resolve` handlers added to `mocks.ts` so both flows work under `VITE_USE_MOCKS`.

## Files changed

- `apps/desktop/src/components/ListSidebar.tsx` — add `searchValue`/`onSearchChange` controlled props
- `apps/desktop/src/features/targets/TargetList.tsx` — add local search state + client-side filter
- `apps/desktop/src/features/targets/TargetsPage.tsx` — wire Add target button + `AddTargetDialog`
- `apps/desktop/src/features/targets/AddTargetDialog.tsx` — new dialog (reuses `TargetSearch` + `resolveTarget`)
- `apps/desktop/src/api/mocks.ts` — add gen-3 target command mock handlers
- `apps/desktop/src/features/targets/TargetsPage.test.tsx` — 4 new tests (H1/H2/H3 search, G1 dialog opens)
- `apps/desktop/src/features/targets/AddTargetDialog.test.tsx` — 8 new tests for Add target dialog

## Gate results

- `just typecheck` — clean
- `cd apps/desktop && pnpm vitest run` — 621 passed, 0 failed (12 in `TargetsPage.test.tsx`, 8 in `AddTargetDialog.test.tsx`, all existing tests green)

## Ambiguities / for review

- **Add target: resolve-and-persist vs navigate-only.** The implementation calls `target.resolve` on confirm, which persists the `canonical_target` row via the backend. If the intent is instead to navigate to a new-target form and only persist on final save, the dialog body can be simplified to just call `onAdded` directly with the selected suggestion's `targetId` after a lighter upsert. Left as resolve-and-persist since that matches the spec-035 project-creation flow and the task description.
- **Search scope.** Currently client-side filtering on `primaryDesignation`/`effectiveLabel` from the loaded `target_list`. The `target.search` SIMBAD pipeline is used only for Add target (SIMBAD suggestions). If the list search should instead call `target.search` to surface targets not yet in the library, that's a separate concern and would require persisting first.