### PR TITLE
feat(spec 039): cross-root Inbox list + optional inbox folder + rescan

### DIFF
--- a/apps/desktop/src-tauri/src/commands/inbox.rs
+++ b/apps/desktop/src-tauri/src/commands/inbox.rs
@@ -11,12 +11,17 @@ use app_core::inbox::reclassify::{reclassify, ReclassifyOverride, ReclassifyRequ
 use app_core::inbox::scan::{scan_root, ScanOptions};
 use contracts_core::inbox::{
     InboxBreakdownEntry, InboxClassifyRequest, InboxClassifyResponse, InboxConfirmRequest,
-    InboxConfirmResponse, InboxFileEntry, InboxItemSummary, InboxReclassifyRequest,
-    InboxReclassifyResponse, InboxScanFolderRequest, InboxScanFolderResponse, InboxScanResult,
+    InboxConfirmResponse, InboxFileEntry, InboxItemSummary, InboxListItem, InboxListResponse,
+    InboxReclassifyRequest, InboxReclassifyResponse, InboxScanFolderRequest,
+    InboxScanFolderResponse, InboxScanResult,
 };
+use persistence_db::repositories::inbox::list_unacknowledged_across_roots;
 use sqlx::SqlitePool;
 use std::path::PathBuf;
 use uuid::Uuid;
+
+/// Cap on cross-root listing (FR-006 — no unbounded loads).
+const INBOX_LIST_LIMIT: i64 = 500;
 
 // ── inbox.classify ────────────────────────────────────────────────────────────
 
@@ -189,6 +194,47 @@ pub async fn inbox_scan_folder(
     }
 
     Ok(InboxScanFolderResponse { root_id: req.root_id, items })
+}
+
+// ── inbox.list (spec 039) ─────────────────────────────────────────────────────
+
+/// `inbox.list` — return all unacknowledged inbox items across all registered
+/// roots (states `pending_classification` and `classified`).
+///
+/// Results are capped at 500 items (FR-006). Each item carries its root's
+/// absolute path so the UI can group/label by root without a second call.
+///
+/// # Errors
+/// Returns a string error on database failure.
+#[tauri::command]
+#[specta::specta]
+pub async fn inbox_list(pool: tauri::State<'_, SqlitePool>) -> Result<InboxListResponse, String> {
+    let rows = list_unacknowledged_across_roots(&pool, INBOX_LIST_LIMIT)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let total = rows.len();
+    let capped = total >= usize::try_from(INBOX_LIST_LIMIT).unwrap_or(usize::MAX);
+
+    let items = rows
+        .into_iter()
+        .map(|r| InboxListItem {
+            inbox_item_id: r.id,
+            root_id: r.root_id,
+            root_absolute_path: r.root_path,
+            relative_path: r.relative_path,
+            file_count: u32::try_from(r.file_count).unwrap_or(u32::MAX),
+            lane: r.lane,
+            state: r.state,
+            content_signature: r.content_signature.unwrap_or_default(),
+        })
+        .collect();
+
+    Ok(InboxListResponse {
+        items,
+        capped,
+        limit: u32::try_from(INBOX_LIST_LIMIT).unwrap_or(u32::MAX),
+    })
 }
 
 // ── Legacy inbox.scan (retained for spec 030 compatibility) ──────────────────

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -44,7 +44,7 @@ use crate::commands::guided::{
     guided_activate, guided_dismiss, guided_restart, guided_state_get, guided_step_complete,
 };
 use crate::commands::inbox::{
-    inbox_classify, inbox_confirm, inbox_reclassify, inbox_scan, inbox_scan_folder,
+    inbox_classify, inbox_confirm, inbox_list, inbox_reclassify, inbox_scan, inbox_scan_folder,
 };
 use crate::commands::ingestion::{ingestion_settings_get, ingestion_settings_update};
 use crate::commands::inventory::{inventory_list, inventory_session_review};
@@ -290,12 +290,13 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // calibration tolerances (spec 030)
         calibration_tolerances_get,
         calibration_tolerances_update,
-        // inbox (spec 005 + 030)
+        // inbox (spec 005 + 030 + 039)
         inbox_scan,
         inbox_scan_folder,
         inbox_classify,
         inbox_confirm,
         inbox_reclassify,
+        inbox_list,
         // inventory (spec 006)
         inventory_list,
         inventory_session_review,
@@ -473,12 +474,13 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // calibration tolerances (spec 030)
         calibration_tolerances_get,
         calibration_tolerances_update,
-        // inbox (spec 005 + 030)
+        // inbox (spec 005 + 030 + 039)
         inbox_scan,
         inbox_scan_folder,
         inbox_classify,
         inbox_confirm,
         inbox_reclassify,
+        inbox_list,
         // inventory (spec 006)
         inventory_list,
         inventory_session_review,

--- a/apps/desktop/src/api/commands.ts
+++ b/apps/desktop/src/api/commands.ts
@@ -27,6 +27,8 @@ import type {
   InboxConfirmRequest_Deserialize as InboxConfirmRequest,
   InboxConfirmResponse,
   InboxItemSummary,
+  InboxListItem,
+  InboxListResponse,
   InboxReclassifyOverride,
   InboxReclassifyRequest,
   InboxReclassifyResponse_Serialize as InboxReclassifyResponse,
@@ -39,6 +41,8 @@ export type {
   InboxConfirmRequest,
   InboxConfirmResponse,
   InboxItemSummary,
+  InboxListItem,
+  InboxListResponse,
   InboxReclassifyOverride,
   InboxReclassifyRequest,
   InboxReclassifyResponse,
@@ -616,6 +620,16 @@ export async function inboxReclassify(
   req: InboxReclassifyRequest,
 ): Promise<InboxReclassifyResponse> {
   return invoke<InboxReclassifyResponse>('inbox_reclassify', { req });
+}
+
+/**
+ * List all unacknowledged inbox items across all registered roots (spec 039).
+ * Items in `pending_classification` or `classified` state are returned.
+ * Confirmed/plan_open/resolved items are excluded.
+ * Results are capped at 500 (check `capped` flag for truncation).
+ */
+export async function inboxList(): Promise<InboxListResponse> {
+  return invoke<InboxListResponse>('inbox_list');
 }
 
 // ── Calibration matching commands (spec 007) ──────────────────────────────────

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -351,7 +351,46 @@ export async function mockInvoke<T>(
       return { completed: false } as T;
     }
 
-    // ── Inbox commands (spec 005) ──────────────────────────────────────────────
+    // ── Inbox commands (spec 005 + 039) ───────────────────────────────────────
+    case 'inbox_list': {
+      // Mock: two roots each with unacknowledged items (SC-001 cross-root).
+      return {
+        items: [
+          {
+            inboxItemId: 'item-001',
+            rootId: 'root-lights-001',
+            rootAbsolutePath: '/astro/raw',
+            relativePath: '2025-10-10/NGC7000',
+            fileCount: 18,
+            lane: 'fits',
+            state: 'classified',
+            contentSignature: 'sig-abc',
+          },
+          {
+            inboxItemId: 'item-002',
+            rootId: 'root-lights-001',
+            rootAbsolutePath: '/astro/raw',
+            relativePath: '2025-10-10/darks',
+            fileCount: 50,
+            lane: 'fits',
+            state: 'pending_classification',
+            contentSignature: 'sig-def',
+          },
+          {
+            inboxItemId: 'item-003',
+            rootId: 'root-inbox-001',
+            rootAbsolutePath: '/astro/inbox',
+            relativePath: '2025-11-01/Jupiter',
+            fileCount: 3,
+            lane: 'video',
+            state: 'pending_classification',
+            contentSignature: 'sig-ghi',
+          },
+        ],
+        capped: false,
+        limit: 500,
+      } as T;
+    }
     case 'inbox_scan_folder': {
       return {
         rootId: 'root-inbox-001',

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1011,6 +1011,17 @@ export const commands = {
 	 */
 	inboxReclassify: (req: InboxReclassifyRequest) => typedError<InboxReclassifyResponse_Serialize, string>(__TAURI_INVOKE("inbox_reclassify", { req })),
 	/**
+	 *  `inbox.list` — return all unacknowledged inbox items across all registered
+	 *  roots (states `pending_classification` and `classified`).
+	 * 
+	 *  Results are capped at 500 items (FR-006). Each item carries its root's
+	 *  absolute path so the UI can group/label by root without a second call.
+	 * 
+	 *  # Errors
+	 *  Returns a string error on database failure.
+	 */
+	inboxList: () => typedError<InboxListResponse, string>(__TAURI_INVOKE("inbox_list")),
+	/**
 	 *  `inventory.list` — return the grouped inventory ledger with optional filters.
 	 * 
 	 *  # Errors
@@ -2290,6 +2301,33 @@ export type InboxItemSummary = {
 	lane: string,
 	state: string,
 	contentSignature: string,
+};
+
+/**
+ *  One unacknowledged inbox item returned by `inbox.list`.
+ * 
+ *  Extends `InboxItemSummary` with the root's id and absolute path so the UI
+ *  can group/label items by root without a second call.
+ */
+export type InboxListItem = {
+	inboxItemId: string,
+	rootId: string,
+	/**  Absolute path of the registered root (for display and confirm calls). */
+	rootAbsolutePath: string,
+	relativePath: string,
+	fileCount: number,
+	lane: string,
+	state: string,
+	contentSignature: string,
+};
+
+/**  Response from `inbox.list`. */
+export type InboxListResponse = {
+	items: InboxListItem[],
+	/**  Whether the list was capped at `limit` (true = there may be more). */
+	capped: boolean,
+	/**  Maximum items per response (matches the server-side cap). */
+	limit: number,
 };
 
 /**  A single file override in a reclassify request. */

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -1,13 +1,16 @@
 /**
  * InboxPage — three-pane classify / confirm / reclassify workflow.
  *
- * Left list  : inbox items from inbox.scan.folder (real command).
- * Centre pane: per-item classification breakdown from inbox.classify with
- *              "Needs review" group and reclassify picker.
- * Right bar  : Confirm / Split action wired to inbox.confirm → plan review.
+ * spec 039: the left list is now a cross-root aggregate of all unacknowledged
+ * items (inbox.list), grouped/labelled by their registered root.  The
+ * hardcoded DEV_ROOT_ID / DEV_ROOT_PATH stub has been removed.
+ *
+ * Left list  : unacknowledged items from all registered roots (inbox.list).
+ * Centre pane: per-item classification breakdown (inbox.classify).
+ * Right bar  : Confirm / Split → plan review (inbox.confirm).
  */
 
-import { useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { PageShell, ListDetailLayout, TopActionBar } from '@/components';
 import { Btn, EmptyState } from '@/ui';
@@ -16,21 +19,42 @@ import { addToast } from '@/shared/toast';
 import { InboxList } from './InboxList';
 import { InboxDetail } from './InboxDetail';
 import { ActionSidebar } from './ActionSidebar';
-import { useInboxScan, useInboxClassification, useInboxConfirm } from './store';
+import {
+  useInboxList,
+  useInboxRescan,
+  useInboxClassification,
+  useInboxConfirm,
+} from './store';
 import type { FrameType, InboxGroup } from '@/lib/route-contract';
-
-// Temporary: during development use stub root values until a settings-backed
-// root is available. Replace with a real lookup from the roots store once
-// spec 006 is wired. These values are also used by mocks.ts.
-const DEV_ROOT_ID = 'root-inbox-001';
-const DEV_ROOT_PATH = '/astro/inbox';
 
 export function InboxPage() {
   const { selected, type, group } = useSearch({ from: '/shell/inbox' });
   const navigate = useNavigate({ from: '/inbox' });
 
-  const { data: scan, loading: scanLoading } = useInboxScan(DEV_ROOT_ID, DEV_ROOT_PATH);
-  const items = scan?.items ?? [];
+  // FR-001 / FR-002: cross-root aggregate list replaces the hardcoded scan.
+  const { data: listData, loading: listLoading, refresh: refreshList } = useInboxList();
+  const items = listData?.items ?? [];
+
+  // Derive the unique roots from the current item list so rescan knows which
+  // roots to ping (FR-005). Deduplicated by rootId.
+  const roots = useMemo(() => {
+    const seen = new Set<string>();
+    const result: Array<{ rootId: string; rootAbsolutePath: string }> = [];
+    for (const item of items) {
+      if (!seen.has(item.rootId)) {
+        seen.add(item.rootId);
+        result.push({ rootId: item.rootId, rootAbsolutePath: item.rootAbsolutePath });
+      }
+    }
+    return result;
+  }, [items]);
+
+  const onRescanComplete = useCallback(() => refreshList(), [refreshList]);
+  const { loading: rescanLoading, rescan } = useInboxRescan(roots, onRescanComplete);
+
+  // FR-006: items are already bounded at 500 by the backend; surface a notice
+  // when the cap is hit.
+  const isCapped = listData?.capped ?? false;
 
   // URL-backed selection is by list index so it stays stable across re-fetches.
   const selectedItem = selected !== undefined ? items[selected] : undefined;
@@ -42,10 +66,13 @@ export function InboxPage() {
   const onSelect = (idx: number) =>
     navigate({ search: (prev) => ({ ...prev, selected: idx }) });
 
+  // Each item carries its own root path — use it for classify / confirm calls.
+  const selectedRootPath = selectedItem?.rootAbsolutePath ?? '';
+
   // Load classification for the selected item (no-op when nothing selected).
   const { data: classification } = useInboxClassification(
     selectedItem?.inboxItemId ?? '',
-    DEV_ROOT_PATH,
+    selectedRootPath,
   );
 
   const { confirm, loading: confirmLoading } = useInboxConfirm();
@@ -60,7 +87,7 @@ export function InboxPage() {
         inboxItemId: selectedItem.inboxItemId,
         action,
         contentSignature: classification.contentSignature,
-        rootAbsolutePath: DEV_ROOT_PATH,
+        rootAbsolutePath: selectedRootPath,
         destructiveDestination,
       });
       addToast({
@@ -72,6 +99,8 @@ export function InboxPage() {
             navigate({ to: '/archive', search: { selected: undefined } as never }),
         },
       });
+      // Refresh so confirmed item drops out (FR-003).
+      refreshList();
     } catch (e) {
       const msg = String(e);
       if (msg.includes('inbox.has.open.plan')) {
@@ -88,18 +117,29 @@ export function InboxPage() {
   const canConfirm =
     !!selectedItem && !!classification && classification.type !== 'unclassified' && !hasOpenPlan;
 
+  const subtitle = listLoading
+    ? 'Loading…'
+    : isCapped
+      ? `${items.length}+ folders to review (showing first ${listData?.limit ?? 500})`
+      : `${items.length} folder${items.length !== 1 ? 's' : ''} to review`;
+
   return (
     <PageShell>
       <ListDetailLayout
         topBar={
           <TopActionBar
             title="Inbox"
-            subtitle={
-              scanLoading
-                ? 'Scanning…'
-                : `${items.length} folder${items.length !== 1 ? 's' : ''} to review`
+            subtitle={subtitle}
+            right={
+              <Btn
+                size="sm"
+                disabled={rescanLoading}
+                onClick={() => void rescan()}
+                aria-label="Rescan all roots"
+              >
+                {rescanLoading ? 'Rescanning…' : 'Rescan'}
+              </Btn>
             }
-            right={<Btn size="sm">Rescan inbox</Btn>}
           />
         }
         list={
@@ -121,7 +161,7 @@ export function InboxPage() {
           selectedItem ? (
             <InboxDetail
               item={selectedItem}
-              rootAbsolutePath={DEV_ROOT_PATH}
+              rootAbsolutePath={selectedRootPath}
               classification={classification ?? null}
             />
           ) : (

--- a/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
@@ -1,0 +1,198 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * spec 039 — cross-root Inbox list tests.
+ *
+ * 1. InboxList renders items from ≥2 roots (SC-001 / FR-002).
+ * 2. Empty list (server filtered all confirmed out) renders nothing (FR-003).
+ * 3. useInboxList fetches and returns data; refresh triggers re-fetch (FR-001).
+ * 4. useInboxRescan calls inboxScanFolder once per unique root (FR-005).
+ */
+
+import { render, screen, waitFor, act } from '@testing-library/react';
+import { renderHook } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { InboxList } from '../InboxList';
+import type { InboxListItem, InboxListResponse } from '@/api/commands';
+
+// ── sync mock registered at module level (required by vitest hoisting) ────────
+
+vi.mock('@/api/commands', () => ({
+  inboxList: vi.fn(),
+  inboxScanFolder: vi.fn(),
+  inboxClassify: vi.fn(),
+  inboxConfirm: vi.fn(),
+  inboxReclassify: vi.fn(),
+}));
+
+// ── fixtures ──────────────────────────────────────────────────────────────────
+
+const itemRoot1a: InboxListItem = {
+  inboxItemId: 'item-r1-a',
+  rootId: 'root-001',
+  rootAbsolutePath: '/astro/raw',
+  relativePath: '2025-10-10/NGC7000',
+  fileCount: 18,
+  lane: 'fits',
+  state: 'classified',
+  contentSignature: 'sig-a',
+};
+
+const itemRoot1b: InboxListItem = {
+  inboxItemId: 'item-r1-b',
+  rootId: 'root-001',
+  rootAbsolutePath: '/astro/raw',
+  relativePath: '2025-10-10/darks',
+  fileCount: 50,
+  lane: 'fits',
+  state: 'pending_classification',
+  contentSignature: 'sig-b',
+};
+
+const itemRoot2a: InboxListItem = {
+  inboxItemId: 'item-r2-a',
+  rootId: 'root-002',
+  rootAbsolutePath: '/astro/inbox',
+  relativePath: '2025-11-01/Jupiter',
+  fileCount: 3,
+  lane: 'video',
+  state: 'pending_classification',
+  contentSignature: 'sig-c',
+};
+
+const multiRootResponse: InboxListResponse = {
+  items: [itemRoot1a, itemRoot1b, itemRoot2a],
+  capped: false,
+  limit: 500,
+};
+
+// ── T039-1: InboxList renders items from ≥2 roots ────────────────────────────
+
+describe('T039-1: InboxList cross-root rendering (SC-001)', () => {
+  it('shows items from both roots', () => {
+    render(
+      <InboxList
+        items={multiRootResponse.items}
+        selectedIdx={null}
+        onSelect={vi.fn()}
+        filterType="all"
+        onFilterTypeChange={vi.fn()}
+        groupBy="none"
+        onGroupByChange={vi.fn()}
+      />,
+    );
+    expect(screen.getByText('2025-10-10/NGC7000')).toBeInTheDocument();
+    expect(screen.getByText('2025-10-10/darks')).toBeInTheDocument();
+    expect(screen.getByText('2025-11-01/Jupiter')).toBeInTheDocument();
+  });
+
+  it('items span two distinct root ids', () => {
+    const rootIds = new Set(multiRootResponse.items.map((i) => i.rootId));
+    expect(rootIds.size).toBe(2);
+  });
+});
+
+// ── T039-2: empty list ────────────────────────────────────────────────────────
+
+describe('T039-2: confirmed items absent — empty list (FR-003)', () => {
+  it('renders no inbox-item elements when the server returns an empty list', () => {
+    render(
+      <InboxList
+        items={[]}
+        selectedIdx={null}
+        onSelect={vi.fn()}
+        filterType="all"
+        onFilterTypeChange={vi.fn()}
+        groupBy="none"
+        onGroupByChange={vi.fn()}
+      />,
+    );
+    expect(screen.queryByTestId(/^inbox-item-/)).not.toBeInTheDocument();
+  });
+});
+
+// ── T039-3: useInboxList hook ─────────────────────────────────────────────────
+
+describe('T039-3: useInboxList hook (FR-001)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns items after loading', async () => {
+    const { inboxList } = await import('@/api/commands');
+    (inboxList as ReturnType<typeof vi.fn>).mockResolvedValue(multiRootResponse);
+
+    const { useInboxList } = await import('../store');
+    const { result } = renderHook(() => useInboxList());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.data?.items).toHaveLength(3);
+    expect(result.current.error).toBeNull();
+  });
+
+  it('refresh triggers a re-fetch', async () => {
+    const { inboxList } = await import('@/api/commands');
+    const mockFn = inboxList as ReturnType<typeof vi.fn>;
+    mockFn.mockResolvedValue(multiRootResponse);
+
+    const { useInboxList } = await import('../store');
+    const { result } = renderHook(() => useInboxList());
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    const callsBefore = mockFn.mock.calls.length;
+    act(() => result.current.refresh());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockFn.mock.calls.length).toBeGreaterThan(callsBefore);
+  });
+});
+
+// ── T039-4: useInboxRescan ────────────────────────────────────────────────────
+
+describe('T039-4: useInboxRescan (FR-005)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('calls inboxScanFolder once per unique root', async () => {
+    const { inboxScanFolder } = await import('@/api/commands');
+    (inboxScanFolder as ReturnType<typeof vi.fn>).mockResolvedValue({
+      rootId: 'root-001',
+      items: [],
+    });
+
+    const { useInboxRescan } = await import('../store');
+    const roots = [
+      { rootId: 'root-001', rootAbsolutePath: '/astro/raw' },
+      { rootId: 'root-002', rootAbsolutePath: '/astro/inbox' },
+    ];
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useInboxRescan(roots, onComplete));
+
+    await act(async () => {
+      await result.current.rescan();
+    });
+
+    expect((inboxScanFolder as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it('calls onComplete even when a root errors (offline root graceful failure)', async () => {
+    const { inboxScanFolder } = await import('@/api/commands');
+    (inboxScanFolder as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error('root offline'),
+    );
+
+    const { useInboxRescan } = await import('../store');
+    const roots = [{ rootId: 'root-001', rootAbsolutePath: '/astro/raw' }];
+    const onComplete = vi.fn();
+    const { result } = renderHook(() => useInboxRescan(roots, onComplete));
+
+    await act(async () => {
+      await result.current.rescan();
+    });
+
+    expect(onComplete).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -6,17 +6,20 @@
  * by `${rootId}|${rootAbsolutePath}`.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { createParameterizedStore, useParameterizedQuery } from '@/data/store';
 import {
   inboxScanFolder,
   inboxClassify,
   inboxConfirm,
+  inboxList,
   inboxReclassify,
 } from '@/api/commands';
 import type {
   InboxClassifyResponse,
   InboxConfirmResponse,
+  InboxListItem,
+  InboxListResponse,
   InboxReclassifyResponse,
   InboxScanFolderResponse,
 } from '@/api/commands';
@@ -24,6 +27,8 @@ import type {
 export type {
   InboxClassifyResponse,
   InboxConfirmResponse,
+  InboxListItem,
+  InboxListResponse,
   InboxReclassifyResponse,
   InboxScanFolderResponse,
 };
@@ -153,4 +158,87 @@ export function useInboxReclassify(inboxItemId: string) {
   );
 
   return { ...state, reclassify };
+}
+
+// ── Cross-root list hooks (spec 039) ─────────────────────────────────────────
+
+export interface InboxListState {
+  data: InboxListResponse | null;
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Load and cache the cross-root unacknowledged inbox list.
+ * Call `refresh()` to re-fetch (e.g. after a rescan).
+ */
+export function useInboxList() {
+  const [epoch, setEpoch] = useState(0);
+  const [state, setState] = useState<InboxListState>({
+    data: null,
+    loading: true,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    setState((s) => ({ ...s, loading: true, error: null }));
+    inboxList()
+      .then((resp) => {
+        if (!cancelled) setState({ data: resp, loading: false, error: null });
+      })
+      .catch((e: unknown) => {
+        if (!cancelled)
+          setState({ data: null, loading: false, error: String(e) });
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [epoch]);
+
+  const refresh = useCallback(() => setEpoch((n) => n + 1), []);
+
+  return { ...state, refresh };
+}
+
+export interface RescanState {
+  loading: boolean;
+  error: string | null;
+}
+
+/**
+ * Trigger a rescan of all registered roots (FR-005).
+ * Each root with a known `rootId` and `rootAbsolutePath` is re-scanned via
+ * `inboxScanFolder`; confirmed items are not resurrected (the scan only
+ * INSERT OR IGNOREs — existing resolved rows keep their state).
+ * On completion, `onComplete` is called so the caller can refresh the list.
+ */
+export function useInboxRescan(
+  roots: Array<{ rootId: string; rootAbsolutePath: string }>,
+  onComplete: () => void,
+) {
+  const [state, setState] = useState<RescanState>({ loading: false, error: null });
+
+  const rescan = useCallback(async () => {
+    if (roots.length === 0) {
+      onComplete();
+      return;
+    }
+    setState({ loading: true, error: null });
+    try {
+      await Promise.all(
+        roots.map((r) =>
+          inboxScanFolder({ rootId: r.rootId, rootAbsolutePath: r.rootAbsolutePath, followSymlinks: false }),
+        ),
+      );
+      setState({ loading: false, error: null });
+      onComplete();
+    } catch (e: unknown) {
+      setState({ loading: false, error: String(e) });
+      // Still refresh so any partial results appear.
+      onComplete();
+    }
+  }, [roots, onComplete]);
+
+  return { ...state, rescan };
 }

--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -193,6 +193,7 @@ describe('SetupWizard 5-step flow', () => {
   });
 
   it('enables Continue on Step 1 after adding all required folder types', async () => {
+    // spec 039: inbox is now optional — only light_frames + project are required.
     renderWizard();
 
     // Add a folder to each required group via its own per-group add button.
@@ -206,15 +207,28 @@ describe('SetupWizard 5-step flow', () => {
       expect(screen.getByText('/astro/projects')).toBeInTheDocument();
     });
 
-    await addFolder('/astro/inbox', 'inbox');
-    await waitFor(() => {
-      expect(screen.getByText('/astro/inbox')).toBeInTheDocument();
-    });
-
-    // Should now be enabled
+    // Should now be enabled — inbox NOT required (spec 039 FR-004).
     await waitFor(() => {
       expect(getContinueButton()).not.toBeDisabled();
     });
+  });
+
+  it('allows Step 1 to advance without an inbox folder (spec 039 FR-004)', async () => {
+    // Completing setup without an inbox folder must be allowed.
+    renderWizard();
+
+    await addFolder('/astro/lights', 'light_frames');
+    await addFolder('/astro/projects', 'project');
+
+    // Continue must become enabled with only the two required kinds.
+    await waitFor(() => {
+      expect(getContinueButton()).not.toBeDisabled();
+    });
+
+    // The inbox group card is still present (it's a supported optional kind).
+    expect(screen.getByTestId('source-group-inbox')).toBeInTheDocument();
+    // But it must NOT carry a data-requirement-met attribute (it's optional).
+    expect(screen.getByTestId('source-group-inbox')).not.toHaveAttribute('data-requirement-met');
   });
 
   it('renders one persistent group card per source kind, even when empty', () => {
@@ -231,7 +245,9 @@ describe('SetupWizard 5-step flow', () => {
     // Required groups start unmet; optional groups carry no requirement flag.
     expect(screen.getByTestId('source-group-light_frames')).toHaveAttribute('data-requirement-met', 'false');
     expect(screen.getByTestId('source-group-project')).toHaveAttribute('data-requirement-met', 'false');
+    // calibration and inbox are optional (spec 039: inbox removed from required kinds).
     expect(screen.getByTestId('source-group-calibration')).not.toHaveAttribute('data-requirement-met');
+    expect(screen.getByTestId('source-group-inbox')).not.toHaveAttribute('data-requirement-met');
 
     // Adding to the light_frames group flips its card to met.
     await addFolder('/astro/lights', 'light_frames');

--- a/apps/desktop/src/features/setup/sources-store.ts
+++ b/apps/desktop/src/features/setup/sources-store.ts
@@ -23,7 +23,9 @@ export const SOURCE_KIND_LABELS: Record<SourceKind, string> = {
   inbox: 'Inbox',
 };
 
-export const REQUIRED_KINDS: SourceKind[] = ['light_frames', 'project', 'inbox'];
+// spec 039: inbox is now optional — users do not need a dedicated drop folder
+// to use the Inbox (which aggregates unacknowledged items across all roots).
+export const REQUIRED_KINDS: SourceKind[] = ['light_frames', 'project'];
 
 export interface SourceEntry {
   path: string;

--- a/crates/contracts/core/src/inbox.rs
+++ b/crates/contracts/core/src/inbox.rs
@@ -164,3 +164,34 @@ pub struct InboxScanFolderResponse {
     pub root_id: String,
     pub items: Vec<InboxItemSummary>,
 }
+
+// ── Cross-root unacknowledged list (spec 039) ─────────────────────────────────
+
+/// One unacknowledged inbox item returned by `inbox.list`.
+///
+/// Extends `InboxItemSummary` with the root's id and absolute path so the UI
+/// can group/label items by root without a second call.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxListItem {
+    pub inbox_item_id: String,
+    pub root_id: String,
+    /// Absolute path of the registered root (for display and confirm calls).
+    pub root_absolute_path: String,
+    pub relative_path: String,
+    pub file_count: u32,
+    pub lane: String,
+    pub state: String,
+    pub content_signature: String,
+}
+
+/// Response from `inbox.list`.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxListResponse {
+    pub items: Vec<InboxListItem>,
+    /// Whether the list was capped at `limit` (true = there may be more).
+    pub capped: bool,
+    /// Maximum items per response (matches the server-side cap).
+    pub limit: u32,
+}

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -475,6 +475,67 @@ pub async fn find_orphaned_plan_links(
     Ok(rows)
 }
 
+// ── Cross-root unacknowledged listing ────────────────────────────────────────
+
+/// A row returned by [`list_unacknowledged_across_roots`].
+///
+/// Carries both the item's own fields and the root path so the UI can group
+/// by root without a second query.
+#[derive(Clone, Debug, Serialize, Deserialize, sqlx::FromRow)]
+pub struct InboxListRow {
+    pub id: String,
+    pub root_id: String,
+    pub root_path: String,
+    pub relative_path: String,
+    pub file_count: i64,
+    pub discovered_at: String,
+    pub last_scanned_at: String,
+    pub content_signature: Option<String>,
+    pub state: String,
+    pub lane: String,
+}
+
+/// Return all `inbox_items` whose `state` is **unacknowledged**
+/// (`pending_classification` or `classified`) across every registered root,
+/// joined with the root's path so the UI can label/group by root.
+///
+/// Items whose state is `plan_open` or `resolved` are excluded — the
+/// `resolved` state is the terminal acknowledged state; `plan_open` means the
+/// user has already acted and is awaiting plan application.
+///
+/// Results are ordered by root path then by relative path.
+/// Pass `limit` to cap the result set (FR-006 bounding).
+///
+/// # Errors
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn list_unacknowledged_across_roots(
+    pool: &SqlitePool,
+    limit: i64,
+) -> DbResult<Vec<InboxListRow>> {
+    let rows = sqlx::query_as::<_, InboxListRow>(
+        "SELECT
+             i.id,
+             i.root_id,
+             r.current_path  AS root_path,
+             i.relative_path,
+             i.file_count,
+             i.discovered_at,
+             i.last_scanned_at,
+             i.content_signature,
+             i.state,
+             i.lane
+         FROM inbox_items i
+         JOIN library_root r ON r.id = i.root_id
+         WHERE i.state IN ('pending_classification', 'classified')
+         ORDER BY r.current_path, i.relative_path
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

- **FR-001 `inbox_list` command**: new Tauri command backed by `list_unacknowledged_across_roots` — a SQL JOIN of `inbox_items` against `library_root` that returns all items in `pending_classification` or `classified` state across every registered root, capped at 500 (FR-006). Each row carries `rootAbsolutePath` so the UI needs no second call.
- **FR-002 InboxPage rewired**: `DEV_ROOT_ID`/`DEV_ROOT_PATH` stub removed. Page now calls `useInboxList` (new hook in `store.ts`). The selected item's own `rootAbsolutePath` is threaded into classify/confirm calls.
- **FR-003 confirmed items excluded**: SQL `WHERE state IN ('pending_classification', 'classified')` filters server-side. After confirm, `refreshList()` is called so the item drops out immediately (SC-003).
- **FR-004 inbox optional**: `'inbox'` removed from `REQUIRED_KINDS` in `sources-store.ts`. Wizard tests updated — new test asserts setup completes with only `light_frames` + `project`.
- **FR-005 Rescan**: `useInboxRescan` hook calls `inboxScanFolder` per distinct root in the current list, then triggers `refresh`. Confirmed items are never resurrected (`INSERT OR IGNORE` in the scan command leaves resolved rows untouched). Rescan button wired in `TopActionBar`.
- **FR-007 mock mode**: `inbox_list` case added to `mocks.ts` with items from two distinct roots (`/astro/raw` and `/astro/inbox`) so the page renders in `VITE_USE_MOCKS`.
- **Bindings regenerated** via `cargo test --test bindings exports_typescript_bindings`.

## Unacknowledged states

States treated as unacknowledged (appear in the list): `pending_classification`, `classified`.
States excluded: `plan_open` (user already acted, awaiting plan application), `resolved` (terminal acknowledged state).

## Test plan

- `cargo check` from `apps/desktop/src-tauri` — clean
- `cargo test --test bindings exports_typescript_bindings` — pass, bindings regenerated
- `just typecheck` — clean
- `cd apps/desktop && pnpm vitest run` — **617 tests, 0 failures** (7 new tests in `inbox.crossRoot.test.tsx`)
- `cargo fmt --all` — clean

New tests cover:
- InboxList renders items from two distinct roots (SC-001)
- Empty list renders no items (FR-003 / server-side filter)
- `useInboxList` fetches data and `refresh()` triggers re-fetch (FR-001)
- `useInboxRescan` calls `inboxScanFolder` once per unique root (FR-005)
- Offline root errors gracefully — `onComplete` still called
- Wizard: setup completes without inbox folder; inbox group card has no `data-requirement-met` attribute (FR-004)