### PR TITLE
fix(ui): pin scan-step actions + Settings layout pass

### DIFF
--- a/apps/desktop/src/features/settings/DataSources.tsx
+++ b/apps/desktop/src/features/settings/DataSources.tsx
@@ -73,8 +73,8 @@ export function DataSources({ save: _save }: DataSourcesProps) {
   return (
     <>
       <div className="alm-settings__group">
-        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--alm-sp-3)' }}>
-          <div className="alm-settings__group-title" style={{ marginBottom: 0 }}>Library Roots</div>
+        <div className="alm-settings__group-header">
+          <div className="alm-settings__group-title">Library Roots</div>
           <Btn size="sm" onClick={() => { setShowAdd(true); setAddError(null); }}>
             Add source folder
           </Btn>

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -429,20 +429,29 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }
   const totalDetected = sourceStates.reduce((acc, s) => acc + s.items.length, 0);
 
   return (
-    <div className="alm-step-scan" data-testid="step-scan">
+    <div
+      className="alm-step-scan"
+      data-testid="step-scan"
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        flex: 1,
+        minHeight: 0,
+      }}
+    >
       {sourceStates.length === 0 ? (
         <p style={{ fontSize: 'var(--alm-text-sm)', color: 'var(--alm-text-muted)' }}>
           No sources registered. Go back and add at least one folder.
         </p>
       ) : (
         <>
-          {/* Per-source results — scrollable container so N sources don't grow the page */}
+          {/* Per-source results — scrollable region; expanding accordions scroll here,
+              not the whole wizard page. */}
           <div
             style={{
               flex: 1,
               minHeight: 0,
               overflowY: 'auto',
-              marginBottom: 'var(--alm-sp-4)',
             }}
           >
             {sourceStates.map((s) => (
@@ -450,14 +459,15 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }
             ))}
           </div>
 
-          {/* Summary footer (shown when all sources are complete) */}
+          {/* Summary line (shown when all sources are complete) */}
           {allDone && (
             <p
               data-testid="scan-summary"
               style={{
                 fontSize: 'var(--alm-text-sm)',
                 color: 'var(--alm-text-secondary)',
-                margin: 0,
+                margin: 'var(--alm-sp-3) 0 0',
+                flexShrink: 0,
               }}
             >
               {totalDetected > 0
@@ -468,8 +478,17 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }
         </>
       )}
 
-      {/* Back (correct sources, then re-scan) + Finish (enabled once scans complete) */}
-      <div style={{ marginTop: 'var(--alm-sp-5)', display: 'flex', gap: 'var(--alm-sp-3)' }}>
+      {/* Back / Finish — pinned footer, never scrolls off-screen */}
+      <div
+        style={{
+          flexShrink: 0,
+          marginTop: 'var(--alm-sp-4)',
+          paddingTop: 'var(--alm-sp-4)',
+          borderTop: '1px solid var(--alm-border)',
+          display: 'flex',
+          gap: 'var(--alm-sp-3)',
+        }}
+      >
         <button
           data-testid="back-button"
           onClick={onBack}

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -545,28 +545,32 @@
 /* === SETTINGS === */
 .alm-settings { display: flex; flex: 1; min-height: 0; }
 .alm-settings__nav {
-  width: 200px; flex-shrink: 0;
+  width: 180px; flex-shrink: 0;
   border-right: 1px solid var(--alm-border);
   padding: var(--alm-sp-3) 0;
   overflow-y: auto;
 }
 .alm-settings__nav-item {
   display: block; width: 100%;
-  padding: 6px var(--alm-sp-4);
+  padding: 7px var(--alm-sp-4);
   font-size: var(--alm-text-sm); color: var(--alm-text-secondary);
   cursor: pointer; border: none; background: none; text-align: left;
   font-family: var(--alm-font-sans); font-weight: var(--alm-weight-medium);
   transition: all var(--alm-transition-fast);
+  white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
 .alm-settings__nav-item:hover { background: var(--alm-hover-bg); color: var(--alm-text); }
 .alm-settings__nav-item--active {
   color: var(--alm-text); background: var(--alm-bg);
   font-weight: var(--alm-weight-semibold);
   border-left: 2px solid var(--alm-accent);
+  padding-left: calc(var(--alm-sp-4) - 2px);
 }
 .alm-settings__content {
-  flex: 1; overflow-y: auto; padding: var(--alm-sp-5);
-  max-width: 720px;
+  /* Scroll independently within the two-pane detail column */
+  flex: 1; min-width: 0; overflow-y: auto;
+  padding: var(--alm-sp-5) var(--alm-sp-6) var(--alm-sp-7);
+  max-width: 680px;
 }
 .alm-settings__title {
   font-size: var(--alm-text-xl); font-weight: var(--alm-weight-semibold);
@@ -574,20 +578,24 @@
 }
 .alm-settings__desc {
   font-size: var(--alm-text-sm); color: var(--alm-text-muted);
-  margin-bottom: var(--alm-sp-5);
+  margin: 0 0 var(--alm-sp-5);
+  line-height: 1.6;
 }
-.alm-settings__group { margin-bottom: var(--alm-sp-5); }
+.alm-settings__group { margin-bottom: var(--alm-sp-6); }
+.alm-settings__group:last-child { margin-bottom: 0; }
 .alm-settings__group-title {
-  font-size: var(--alm-text-md); font-weight: var(--alm-weight-semibold);
+  font-size: var(--alm-text-sm); font-weight: var(--alm-weight-semibold);
+  color: var(--alm-text);
   margin-bottom: var(--alm-sp-3);
   padding-bottom: var(--alm-sp-2);
   border-bottom: 1px solid var(--alm-border-subtle);
+  text-transform: uppercase; letter-spacing: 0.05em;
 }
 .alm-settings__group-note {
   font-size: var(--alm-text-xs);
   color: var(--alm-text-muted);
   margin: 0 0 var(--alm-sp-3) 0;
-  line-height: 1.5;
+  line-height: 1.6;
 }
 .alm-attribution__list {
   list-style: none;
@@ -626,16 +634,36 @@
   display: flex; gap: var(--alm-sp-4); align-items: flex-start;
   padding: var(--alm-sp-3) 0;
   border-bottom: 1px solid var(--alm-border-subtle);
+  min-width: 0;
 }
 .alm-settings__row:last-child { border-bottom: none; }
 .alm-settings__row-label {
-  width: 140px; flex-shrink: 0;
+  width: 160px; flex-shrink: 0;
   font-size: var(--alm-text-sm); font-weight: var(--alm-weight-medium);
+  color: var(--alm-text-secondary);
+  padding-top: 4px; /* align with input element vertical centre */
 }
-.alm-settings__row-content { flex: 1; }
+.alm-settings__row-content { flex: 1; min-width: 0; }
 .alm-settings__row-desc {
   font-size: var(--alm-text-xs); color: var(--alm-text-muted);
-  margin-top: var(--alm-sp-1);
+  margin-top: var(--alm-sp-2);
+  line-height: 1.5;
+}
+/* Flex header row inside a group: title on left, action button on right */
+.alm-settings__group-header {
+  display: flex; align-items: center; justify-content: space-between;
+  margin-bottom: var(--alm-sp-3);
+}
+.alm-settings__group-header .alm-settings__group-title { margin-bottom: 0; border-bottom: none; padding-bottom: 0; }
+/* Inline error message for settings save failures */
+.alm-settings__error {
+  font-size: var(--alm-text-xs);
+  color: var(--alm-danger, #dc2626);
+  margin-top: var(--alm-sp-2);
+  padding: var(--alm-sp-2) var(--alm-sp-3);
+  background: var(--alm-danger-bg, rgba(220,38,38,0.08));
+  border-radius: var(--alm-radius-sm);
+  border: 1px solid var(--alm-danger-border, rgba(220,38,38,0.2));
 }
 
 /* Radio group */
@@ -706,7 +734,7 @@
 }
 
 /* === WIZARD === */
-.alm-wizard { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow-y: auto; }
+.alm-wizard { display: flex; flex-direction: column; flex: 1; min-height: 0; }
 .alm-wizard__steps {
   display: flex; gap: 0; padding: var(--alm-sp-4) var(--alm-sp-7);
   border-bottom: 1px solid var(--alm-border);
@@ -729,8 +757,13 @@
 }
 .alm-wizard__step--done { background: var(--alm-ok-bg); color: var(--alm-ok); border-color: var(--alm-ok-border); }
 .alm-wizard__body {
-  flex: 1; padding: var(--alm-sp-5) var(--alm-sp-7);
+  /* Flex column so child steps can use flex:1 + min-height:0 to scroll internally */
+  display: flex; flex-direction: column;
+  flex: 1; min-height: 0;
+  padding: var(--alm-sp-5) var(--alm-sp-7);
   max-width: 720px; margin: 0 auto; width: 100%;
+  /* Horizontal overflow guard for min-window-size */
+  overflow-x: hidden;
 }
 .alm-wizard__footer {
   padding: var(--alm-sp-3) var(--alm-sp-7);


### PR DESCRIPTION
## Summary

- **Task 1 — StepScan pinned footer:** The wizard scan step's root is now a flex column (`flex:1; min-height:0`). The source-accordion list becomes the scrollable region (`flex:1; min-height:0; overflow-y:auto`) so expanding an accordion scrolls *within* that region. The Back/Finish row has `flex-shrink:0` + `border-top` so it is always visible at the bottom regardless of how many accordions are expanded. `.alm-wizard` no longer has `overflow-y:auto` (whole-wizard scrolling removed); `.alm-wizard__body` is now a flex column (`display:flex; flex-direction:column; flex:1; min-height:0`) that passes bounded height down to StepScan.

- **Task 2 — Settings layout pass:** Nav narrowed to 180px with `text-overflow:ellipsis` on items; content gets `padding-bottom:var(--alm-sp-7)` for breathing room and `max-width:680px` (safe at 1100px window since nav is 180px and the two-pane detail already has `min-width:0`). Group titles get uppercase + letter-spacing for visual hierarchy; row-label widened to 160px with muted colour + 4px top padding to align with input mid-line; row-desc gets `line-height:1.5` and extra top margin. New `.alm-settings__group-header` helper class (title on left, action button on right, used by DataSources). New `.alm-settings__error` style (used by ResolverSettingsControl). No data logic touched.

## Verification

- `just typecheck` — clean (0 errors)
- `cd apps/desktop && pnpm vitest run` — 627 passed, 0 failed
- No tests required markup updates (tests assert on `data-testid` and text content, not layout structure)
- No Rust changes

## Spot-check suggestions

- Open wizard → add several sources → advance to Scan step → expand a source accordion with a long table → confirm Back + Finish are visible without scrolling the page
- Open Settings → Data Sources at 1100×720 window → no horizontal scrollbar, nav items truncate cleanly, "Library Roots / Add source folder" header row is aligned
- Check Settings → Target Resolution rows align correctly at label/content boundary