### PR TITLE
fix(setup): persist wizard processing-tool config to the backend

### DIFF
--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -76,6 +76,17 @@ vi.mock('@/api/commands', () => ({
   // if the Scan step is reached during tests that navigate that far.
   inboxScanFolder: vi.fn().mockResolvedValue({ rootId: 'root-mock', items: [] }),
   inboxClassify: vi.fn().mockResolvedValue(null),
+  // Processing-tool persistence: called in handleFinish before completeFirstRun.
+  toolUpdate: vi.fn().mockResolvedValue({
+    id: 'pixinsight',
+    name: 'PixInsight',
+    enabled: false,
+    configured: false,
+    available: false,
+    supportsOpenFolder: false,
+    autoDetected: false,
+    executablePath: null,
+  }),
 }));
 
 // Mock @tauri-apps/api/core to prevent any accidental live invoke.
@@ -417,5 +428,70 @@ describe('SetupWizard 5-step flow', () => {
       expect(pathElements).toHaveLength(1);
     });
     expect(screen.getByText(/1 folder selected/i)).toBeInTheDocument();
+  });
+
+  it('persists wizard processing-tool config to the backend when finishing', async () => {
+    // Access the mocked module to spy on calls.
+    const commands = await import('@/api/commands');
+    vi.mocked(commands.toolUpdate).mockClear();
+    vi.mocked(commands.completeFirstRun).mockClear();
+
+    // Seed at the Confirm step (step 3) with PixInsight enabled+pathed and
+    // Siril disabled, so we can verify both tools are sent to toolUpdate.
+    const seeded = {
+      currentStep: 3,
+      sources: [
+        { path: '/astro/lights', kind: 'light_frames', scanDepth: 'recursive' },
+        { path: '/astro/projects', kind: 'project', scanDepth: 'recursive' },
+      ],
+      catalogSettings: { selectedCatalogIds: [] },
+      tools: {
+        pixinsight: { enabled: true, path: '/Applications/PixInsight/PixInsight.app' },
+        siril: { enabled: false, path: null },
+      },
+    };
+    window.localStorage.setItem(WIZARD_STORAGE_KEY, JSON.stringify(seeded));
+
+    renderWizard();
+
+    // Confirm step renders.
+    expect(screen.getByText(/ready to go/i)).toBeInTheDocument();
+
+    // Advance to the Scan step by clicking "Start scan →".
+    const startScanBtn = screen.getByRole('button', { name: /start scan/i });
+    await act(async () => {
+      fireEvent.click(startScanBtn);
+      // Give flushToDB (mocked registerRootBatch) time to resolve.
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // StepScan mounts and immediately calls inboxScanFolder for each source.
+    // The mock resolves synchronously, so after a tick the scan is 'done'
+    // and the Finish button becomes enabled.
+    const finishBtn = await screen.findByTestId('finish-button');
+    await waitFor(() => expect(finishBtn).not.toBeDisabled());
+
+    await act(async () => {
+      fireEvent.click(finishBtn);
+      await new Promise((r) => setTimeout(r, 0));
+    });
+
+    // handleFinish (non-mock path: VITE_USE_MOCKS='false') must call toolUpdate
+    // once per tool before completeFirstRun.
+    await waitFor(() => expect(vi.mocked(commands.toolUpdate)).toHaveBeenCalledTimes(2));
+
+    expect(vi.mocked(commands.toolUpdate)).toHaveBeenCalledWith({
+      id: 'pixinsight',
+      enabled: true,
+      path: '/Applications/PixInsight/PixInsight.app',
+    });
+    expect(vi.mocked(commands.toolUpdate)).toHaveBeenCalledWith({
+      id: 'siril',
+      enabled: false,
+      path: null,
+    });
+
+    // completeFirstRun must be called exactly once, after the tool updates.
+    expect(vi.mocked(commands.completeFirstRun)).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -3,7 +3,7 @@ import { useNavigate } from '@tanstack/react-router';
 import { WizardShell } from '@/ui/WizardShell';
 import { Btn } from '@/ui/Btn';
 import { setPreference } from '@/data/preferences';
-import { completeFirstRun } from '@/api/commands';
+import { completeFirstRun, toolUpdate } from '@/api/commands';
 import {
   StepSourceFolders,
   StepTools,
@@ -267,6 +267,14 @@ export function SetupWizard() {
     setIsFinishing(true);
     try {
       if (!isMockMode) {
+        // Persist processing-tool config from the wizard so Settings →
+        // Processing Tools reflects whatever the user set in Step 2.
+        const toolEntries: Array<{ id: string; enabled: boolean; path: string | null }> = [
+          { id: 'pixinsight', enabled: state.tools.pixinsight.enabled, path: state.tools.pixinsight.path },
+          { id: 'siril', enabled: state.tools.siril.enabled, path: state.tools.siril.path },
+        ];
+        await Promise.all(toolEntries.map((t) => toolUpdate({ id: t.id, enabled: t.enabled, path: t.path })));
+
         await completeFirstRun();
       }
 


### PR DESCRIPTION
## Problem

The setup wizard's Processing Tools step (step 2) lets users enable PixInsight/Siril and set binary paths, but \`handleFinish\` only called \`completeFirstRun()\` — it never persisted the tools to the backend. Settings → Processing Tools (which reads \`tools_list\`) therefore showed no configured tools after setup.

## Fix

In \`handleFinish\`, before calling \`completeFirstRun()\`, call \`toolUpdate\` for each tool (\`pixinsight\`, \`siril\`) with the wizard's \`ToolsState\` values. Guarded by the same \`\!isMockMode\` check as \`completeFirstRun\` so mock-mode and tests are unaffected.

## Mapping

\`ToolsState.pixinsight/siril { enabled, path }\` → \`UpdateProcessingTool { id, enabled, path }\`

Tool IDs are the stable lowercase identifiers seeded in the backend (\`pixinsight\`, \`siril\`), matching what \`toolProfileList\` returns.

## ProcessingTools.tsx

No changes required — it already calls \`toolProfileList()\` on mount to read \`tools_list\`, so it automatically reflects the persisted values after setup completes.

## Gates

- \`just typecheck\` — clean
- \`pnpm vitest run\` — 628 tests, 0 failures (14 in SetupWizard.test.tsx, up from 13)
- New test: seeds wizard with PixInsight enabled + path, drives through confirm→scan→finish, asserts \`toolUpdate\` called twice (once per tool) with correct payloads, and \`completeFirstRun\` called once after.