### PR TITLE
fix(ui): #root flex column so action footers are always visible

### DIFF
--- a/apps/desktop/src/styles/reset.css
+++ b/apps/desktop/src/styles/reset.css
@@ -1,5 +1,11 @@
 *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 html, body, #root { height: 100%; overflow: hidden; }
+/* #root is a bounded flex column so top-level pages (the setup wizard uses
+   flex:1) fill the viewport and scroll INTERNALLY — without this, a flex:1 page
+   has no flex parent, grows to content height, and its footer (Back/Finish,
+   action bars) is clipped by the overflow:hidden above. Action bars must stay
+   visible regardless of content. */
+#root { display: flex; flex-direction: column; }
 body {
   font-family: var(--alm-font-sans);
   font-size: var(--alm-text-base);


### PR DESCRIPTION
The setup wizard's Back/Finish disappeared when scan accordions expanded. Root cause: `#root` is `height:100%; overflow:hidden` but not a flex column, so the wizard's `flex:1` had no flex parent → it grew to content height and the footer was clipped by overflow:hidden. (Shell pages use `height:100%` so they were fine.) Fix: `#root { display:flex; flex-direction:column }` — flex:1 pages now fill the viewport and scroll internally, action bars stay visible. typecheck + vitest (628) green.