### PR TITLE
refactor(ui): app-wide page layout convention (pinned bars + scrolling content)

### DIFF
--- a/apps/desktop/src/components/ListDetailLayout.tsx
+++ b/apps/desktop/src/components/ListDetailLayout.tsx
@@ -11,8 +11,8 @@ export function ListDetailLayout({ topBar, list, detail, sidebar }: ListDetailLa
   if (sidebar) {
     return (
       <>
-        {topBar}
-        <div className="alm-three-pane" style={{ flex: 1 }}>
+        {topBar && <div className="alm-page__bar">{topBar}</div>}
+        <div className="alm-three-pane">
           {list}
           <div className="alm-three-pane__content">{detail}</div>
           <div className="alm-three-pane__sidebar">{sidebar}</div>
@@ -22,7 +22,7 @@ export function ListDetailLayout({ topBar, list, detail, sidebar }: ListDetailLa
   }
   return (
     <>
-      {topBar}
+      {topBar && <div className="alm-page__bar">{topBar}</div>}
       <div className="alm-two-pane">
         {list}
         <div className="alm-two-pane__detail">{detail}</div>

--- a/apps/desktop/src/components/PageShell.tsx
+++ b/apps/desktop/src/components/PageShell.tsx
@@ -5,5 +5,5 @@ export interface PageShellProps {
 }
 
 export function PageShell({ children }: PageShellProps) {
-  return <div className="alm-frame__main">{children}</div>;
+  return <div className="alm-page">{children}</div>;
 }

--- a/apps/desktop/src/features/setup/SetupPage.tsx
+++ b/apps/desktop/src/features/setup/SetupPage.tsx
@@ -39,11 +39,15 @@ export function SetupPage() {
 
   if (setupCompleted || checking) {
     return (
-      <div style={{ display: 'flex', justifyContent: 'center', alignItems: 'center', flex: 1, color: 'var(--alm-text-muted)' }}>
+      <div className="alm-page" style={{ justifyContent: 'center', alignItems: 'center', color: 'var(--alm-text-muted)' }}>
         Loading…
       </div>
     );
   }
 
-  return <SetupWizard />;
+  return (
+    <div className="alm-page">
+      <SetupWizard />
+    </div>
+  );
 }

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -14,6 +14,23 @@
 .alm-frame { display: flex; flex-direction: column; height: 100%; }
 .alm-frame__body { display: flex; flex: 1; min-height: 0; }
 .alm-frame__main { display: flex; flex-direction: column; flex: 1; min-width: 0; min-height: 0; }
+
+/* === PAGE LAYOUT PRIMITIVES ===
+ * Every route page renders into a bounded flex column (.alm-frame__main).
+ * Use these three classes to enforce: headers always visible, only content scrolls.
+ *
+ * .alm-page        — fills the bounded content area (must be the page root)
+ * .alm-page__bar   — pinned header / toolbar / action-bar; never scrolls
+ * .alm-page__scroll — the ONE scrolling region per pane; holds main content
+ *
+ * Rule: every route page uses .alm-page as its root; all bars/toolbars use
+ * .alm-page__bar (flex-shrink:0); exactly one .alm-page__scroll per scroll
+ * region. Two/three-pane pages: each pane that scrolls is itself a bounded
+ * flex column with its own .alm-page__scroll.
+ */
+.alm-page { display: flex; flex-direction: column; flex: 1; min-height: 0; height: 100%; }
+.alm-page__bar { flex-shrink: 0; }
+.alm-page__scroll { flex: 1; min-height: 0; overflow-y: auto; }
 .alm-frame__statusbar {
   height: var(--alm-statusbar-height);
   background: var(--alm-surface);

--- a/docs/development/layout-convention.md
+++ b/docs/development/layout-convention.md
@@ -1,0 +1,71 @@
+# App-Wide Page Layout Convention
+
+## Problem
+
+The app shell (`Shell.tsx`) renders every route page inside a bounded flex
+column: `<main class="alm-frame__main">` (display:flex; flex-direction:column;
+flex:1; min-height:0). Pages that grow with their content instead of filling
+this bounded area cause toolbars or action bars to scroll out of view or get
+clipped at the minimum window size (1100x720).
+
+## Primitives
+
+Three CSS classes enforce the convention (defined in `styles/components.css`):
+
+| Class | Purpose |
+|---|---|
+| `.alm-page` | Page root. `display:flex; flex-direction:column; flex:1; min-height:0; height:100%`. Fills the bounded `.alm-frame__main` content area. |
+| `.alm-page__bar` | Pinned header / toolbar / action-bar region. `flex-shrink:0`. Never scrolls. |
+| `.alm-page__scroll` | The scrolling region. `flex:1; min-height:0; overflow-y:auto`. Holds the page's main content. |
+
+## Rules
+
+1. Every route page component uses `.alm-page` as its root.
+2. All toolbars, page headers, search bars, and bottom action bars are wrapped
+   in `.alm-page__bar` so they stay visible at all window sizes.
+3. Exactly one `.alm-page__scroll` per scroll region holds the scrolling
+   content. Do not put `overflow-y:auto` on the page root itself.
+4. Two/three-pane pages: each pane that scrolls is itself a bounded flex column
+   with its own scroll region. Pane headers and footers are pinned with
+   `flex-shrink:0`.
+
+## How the convention is applied
+
+`PageShell` (used by every route page) emits `.alm-page`.
+
+`ListDetailLayout` (used by every list+detail page) wraps its `topBar` slot in
+`.alm-page__bar`, then renders the pane container (`alm-two-pane` or
+`alm-three-pane`) which already carries `flex:1; min-height:0; overflow:hidden`
+in CSS. Each pane's detail/content column has its own `overflow-y:auto`.
+
+`WizardShell` (used by setup and project wizards) manages its own bounded flex
+column with an inline pinned footer/nav rail and a `flex:1; overflow:auto`
+content region.
+
+## Minimal example
+
+```tsx
+// A page with a pinned toolbar and scrolling content list.
+function MyPage() {
+  return (
+    <div className="alm-page">
+      <div className="alm-page__bar">
+        <div className="alm-action-bar">
+          <span className="alm-action-bar__title">My Page</span>
+        </div>
+      </div>
+      <div className="alm-page__scroll">
+        {items.map(item => <Row key={item.id} item={item} />)}
+      </div>
+    </div>
+  );
+}
+```
+
+For the standard list+detail pattern use `PageShell` + `ListDetailLayout` +
+`TopActionBar` — the convention is applied automatically.
+
+## Verification
+
+At 1100x720: open any route page, scroll the content list, and confirm that the
+top action bar and any bottom bar remain visible throughout.


### PR DESCRIPTION
## Summary

- Defines three canonical CSS primitives (`.alm-page` / `.alm-page__bar` / `.alm-page__scroll`) in `styles/components.css` so the pinned-bar + bounded-scroll pattern is a named, enforceable convention rather than ad-hoc per-page CSS.
- Updates `PageShell` to emit `.alm-page` instead of the redundant `alm-frame__main` wrapper (Shell's `<main>` already is that class; the wrapper was doubling the bounded-column).
- Updates `ListDetailLayout` to wrap its `topBar` slot in `.alm-page__bar` (`flex-shrink:0`) so the `TopActionBar` is always pinned; both pane containers already carry `flex:1; min-height:0; overflow:hidden` in CSS.
- Fixes `SetupPage` loading state and `SetupWizard` mount to use `.alm-page`.
- Documents the convention in `docs/development/layout-convention.md`.

## Primitives defined

| Class | Rule |
|---|---|
| `.alm-page` | Every route page root. `display:flex; flex-direction:column; flex:1; min-height:0; height:100%`. |
| `.alm-page__bar` | Pinned toolbar / header / action-bar. `flex-shrink:0`. Never scrolls. |
| `.alm-page__scroll` | The one scrolling region per pane. `flex:1; min-height:0; overflow-y:auto`. |

## Pages converted

All eight route pages (Inbox, Targets, Projects, Sessions, Calibration, Archive, Settings, Setup) share `PageShell` → `ListDetailLayout`, so the fix is inherited from those two shared components with no per-page JSX edits. `SetupPage`'s loading state and `SetupWizard` mount are wrapped explicitly in `.alm-page`. `WizardShell` (project + setup wizard steps) was left alone — it already manages its own bounded layout correctly.

## Gate results

- `just typecheck` — clean
- `cd apps/desktop && pnpm vitest run` — 628 pass, 0 fail, no test changes needed

## Test plan

- [ ] Each route at 1100×720: TopActionBar pinned, content scrolls, no horizontal overflow.
- [ ] Setup/Project wizard: nav rail and footer stay pinned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)