### PR TITLE
fix(setup): render scan-step Back/Finish in the shared wizard footer

### DIFF
--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -262,6 +262,11 @@ export function SetupWizard() {
     }
   }, [state.sources, goTo]);
 
+  // Tracks whether all sources on the Scan step have finished (done/error).
+  // Updated via StepScan's onAllDoneChange callback and used to enable the
+  // Finish button in the shared footer.
+  const [scanComplete, setScanComplete] = useState(false);
+
   // Called from StepScan's Finish button: complete first-run and navigate.
   const handleFinish = useCallback(async () => {
     setIsFinishing(true);
@@ -289,7 +294,8 @@ export function SetupWizard() {
   // Determine whether "Continue" should be enabled.
   // Step 0 (Source Folders) and step 3 (Confirm) require all required folder kinds.
   // All other intermediate steps advance freely.
-  // The Scan step (SCAN_STEP) manages its own Finish button internally.
+  // The Scan step (SCAN_STEP) uses the shared footer Finish button, which is
+  // enabled by scanComplete — canProceed is not consulted for that step.
   const canProceed = useMemo(() => {
     if (isMockMode) return true;
     const step = state.currentStep;
@@ -307,15 +313,19 @@ export function SetupWizard() {
     completed: i < step,
   }));
 
-  // The Scan step renders its own Finish button inside StepScan; the wizard
-  // footer only shows navigation for steps 0–3.
   const isOnScanStep = step === SCAN_STEP;
 
-  // Build the navigation footer for the current step
+  // Build the navigation footer for the current step.
+  // The Scan step (SCAN_STEP) now renders Back + Finish here, consistent with
+  // every other step; StepScan no longer owns its own action buttons.
   const footer = (
     <>
-      {step > 0 && !isOnScanStep ? (
-        <Btn variant="ghost" onClick={() => goTo(step - 1)} disabled={isSubmitting}>
+      {step > 0 ? (
+        <Btn
+          variant="ghost"
+          onClick={() => goTo(isOnScanStep ? SCAN_STEP - 1 : step - 1)}
+          disabled={isSubmitting || isFinishing}
+        >
           &larr; Back
         </Btn>
       ) : (
@@ -330,27 +340,35 @@ export function SetupWizard() {
           {totalFolders} folder{totalFolders !== 1 ? 's' : ''} selected
         </span>
       )}
-      {/* Scan step: no footer button — StepScan owns its Finish */}
-      {!isOnScanStep && (
-        step < SCAN_STEP - 1 ? (
-          // Steps 0–2: "Continue to <next>"
-          <Btn
-            variant="primary"
-            onClick={() => goTo(step + 1)}
-            disabled={!canProceed}
-          >
-            Continue to {STEPS[step + 1].label.toLowerCase()} &rarr;
-          </Btn>
-        ) : (
-          // Step 3 (Confirm): register + enter Scan
-          <Btn
-            variant="primary"
-            onClick={() => { void handleEnterScan(); }}
-            disabled={isSubmitting || !canProceed}
-          >
-            {isSubmitting ? 'Registering…' : 'Start scan →'}
-          </Btn>
-        )
+      {isOnScanStep ? (
+        // Scan step: Finish navigates to /inbox after completing first-run.
+        // Enabled only once all source scans are done (or errored).
+        <Btn
+          data-testid="finish-button"
+          variant="primary"
+          onClick={() => { void handleFinish(); }}
+          disabled={!scanComplete || isFinishing}
+        >
+          {isFinishing ? 'Finishing…' : 'Finish'}
+        </Btn>
+      ) : step < SCAN_STEP - 1 ? (
+        // Steps 0–2: "Continue to <next>"
+        <Btn
+          variant="primary"
+          onClick={() => goTo(step + 1)}
+          disabled={!canProceed}
+        >
+          Continue to {STEPS[step + 1].label.toLowerCase()} &rarr;
+        </Btn>
+      ) : (
+        // Step 3 (Confirm): register + enter Scan
+        <Btn
+          variant="primary"
+          onClick={() => { void handleEnterScan(); }}
+          disabled={isSubmitting || !canProceed}
+        >
+          {isSubmitting ? 'Registering…' : 'Start scan →'}
+        </Btn>
       )}
     </>
   );
@@ -433,9 +451,7 @@ export function SetupWizard() {
             <StepScan
               sources={state.sources}
               flushResult={flushResult}
-              onFinish={handleFinish}
-              isFinishing={isFinishing}
-              onBack={() => goTo(SCAN_STEP - 1)}
+              onAllDoneChange={setScanComplete}
             />
           )}
       </WizardShell>

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -2,12 +2,17 @@
 /**
  * StepScan tests — first-run wizard "Scan" step (spec 038).
  *
- * Covers: scanning/done/empty/error states and the Finish flow.
- * Mocks inboxScanFolder + inboxClassify at the @/api/commands layer
+ * Covers: scanning/done/empty/error states and the onAllDoneChange callback
+ * contract.  Mocks inboxScanFolder + inboxClassify at the @/api/commands layer
  * (same pattern as SetupWizard.test.tsx).
+ *
+ * NOTE: Back and Finish buttons now live in the SetupWizard footer, not inside
+ * StepScan.  Tests for those buttons are in SetupWizard.test.tsx.  This file
+ * tests StepScan's visual states and the `onAllDoneChange` callback that the
+ * footer relies on to enable/disable Finish.
  */
 
-import { render, screen, waitFor, fireEvent, act, within } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Hoisted mocks ────────────────────────────────────────────────────────────
@@ -78,14 +83,12 @@ const SCAN_RESPONSE_EMPTY = {
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function renderStep(overrides: Partial<StepScanProps> = {}) {
-  const onFinish = overrides.onFinish ?? vi.fn().mockResolvedValue(undefined);
+  const onAllDoneChange = overrides.onAllDoneChange ?? vi.fn();
   return render(
     <StepScan
       sources={SOURCES}
       flushResult={FLUSH_RESULT}
-      onFinish={onFinish}
-      isFinishing={false}
-      onBack={vi.fn()}
+      onAllDoneChange={onAllDoneChange}
       {...overrides}
     />,
   );
@@ -265,35 +268,16 @@ describe('StepScan', () => {
       });
     });
 
-    it('enables the Finish button once all sources are done', async () => {
+    it('calls onAllDoneChange(true) once all sources finish', async () => {
       mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
       mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
 
-      renderStep();
+      const onAllDoneChange = vi.fn();
+      renderStep({ onAllDoneChange });
 
       await waitFor(() => {
-        const finishBtn = screen.getByTestId('finish-button');
-        expect(finishBtn).not.toBeDisabled();
+        expect(onAllDoneChange).toHaveBeenCalledWith(true);
       });
-    });
-
-    it('calls onFinish when Finish is clicked', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
-
-      const onFinish = vi.fn().mockResolvedValue(undefined);
-      renderStep({ sources: [SOURCES[0]], onFinish });
-
-      await waitFor(() => {
-        expect(screen.getByTestId('finish-button')).not.toBeDisabled();
-      });
-
-      await act(async () => {
-        fireEvent.click(screen.getByTestId('finish-button'));
-        await new Promise((r) => setTimeout(r, 0));
-      });
-
-      expect(onFinish).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -355,38 +339,30 @@ describe('StepScan', () => {
       expect(screen.getByTestId('scan-item-item-001')).toBeInTheDocument();
     });
 
-    it('enables Finish even when a source has errored (FR-005)', async () => {
+    it('calls onAllDoneChange(true) even when a source has errored (FR-005)', async () => {
       mockInboxScanFolder
         .mockRejectedValueOnce(new Error('disk read error'))
         .mockResolvedValueOnce(SCAN_RESPONSE_EMPTY);
 
-      renderStep();
+      const onAllDoneChange = vi.fn();
+      renderStep({ onAllDoneChange });
 
       await waitFor(() => {
-        const finishBtn = screen.getByTestId('finish-button');
-        expect(finishBtn).not.toBeDisabled();
+        expect(onAllDoneChange).toHaveBeenCalledWith(true);
       });
     });
   });
 
-  describe('Finish button state', () => {
-    it('keeps Finish disabled while scans are still running', () => {
+  describe('onAllDoneChange callback', () => {
+    it('does not call onAllDoneChange(true) while scans are still running', () => {
       // Never-resolving promise keeps sources in scanning state
       mockInboxScanFolder.mockReturnValue(new Promise(() => {}));
 
-      renderStep();
+      const onAllDoneChange = vi.fn();
+      renderStep({ onAllDoneChange });
 
-      const finishBtn = screen.getByTestId('finish-button');
-      expect(finishBtn).toBeDisabled();
-    });
-
-    it('shows "Finishing…" label when isFinishing is true', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
-
-      renderStep({ isFinishing: true });
-
-      // Even before scan completes the label reflects the prop
-      expect(screen.getByTestId('finish-button')).toHaveTextContent('Finishing…');
+      // May be called with false on initial render but must never be called with true
+      expect(onAllDoneChange).not.toHaveBeenCalledWith(true);
     });
   });
 
@@ -413,9 +389,7 @@ describe('StepScan', () => {
         <StepScan
           sources={[SOURCES[0]]}
           flushResult={FLUSH_RESULT}
-          onFinish={vi.fn().mockResolvedValue(undefined)}
-          isFinishing={false}
-          onBack={vi.fn()}
+          onAllDoneChange={vi.fn()}
         />,
       );
 

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -32,11 +32,11 @@ export interface StepScanProps {
   sources: SourceEntry[];
   /** Result of flushToDB; rootId per path lets us pass the right id to scan. */
   flushResult: FlushResult;
-  /** Callback when scan step is done and Finish is clicked. */
-  onFinish: () => Promise<void>;
-  isFinishing: boolean;
-  /** Go back to the review step to correct sources, then re-scan. */
-  onBack: () => void;
+  /**
+   * Called whenever the "all scans done" state changes so the parent can
+   * enable/disable the Finish button that now lives in the wizard footer.
+   */
+  onAllDoneChange: (done: boolean) => void;
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -344,8 +344,12 @@ function SourceSummary({ state }: SourceSummaryProps) {
  * Runs inbox_scan_folder + inbox_classify per registered source and shows a
  * per-source detection summary.  Ingestion-group approval stays in the Inbox;
  * Finish navigates there without calling inbox_confirm.
+ *
+ * Back and Finish buttons are rendered by the shared WizardShell footer in
+ * SetupWizard.  StepScan notifies the parent of scan completion via
+ * `onAllDoneChange` so the footer can enable/disable the Finish button.
  */
-export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }: StepScanProps) {
+export function StepScan({ sources, flushResult, onAllDoneChange }: StepScanProps) {
   const [sourceStates, setSourceStates] = useState<SourceScanState[]>(() =>
     sources
       .filter((s) => s.path)
@@ -428,6 +432,12 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }
   const allDone = sourceStates.every((s) => s.phase === 'done' || s.phase === 'error');
   const totalDetected = sourceStates.reduce((acc, s) => acc + s.items.length, 0);
 
+  // Notify parent whenever the allDone state changes so the footer can
+  // enable/disable the Finish button.
+  useEffect(() => {
+    onAllDoneChange(allDone);
+  }, [allDone, onAllDoneChange]);
+
   return (
     <div
       className="alm-step-scan"
@@ -477,55 +487,6 @@ export function StepScan({ sources, flushResult, onFinish, isFinishing, onBack }
           )}
         </>
       )}
-
-      {/* Back / Finish — pinned footer, never scrolls off-screen */}
-      <div
-        style={{
-          flexShrink: 0,
-          marginTop: 'var(--alm-sp-4)',
-          paddingTop: 'var(--alm-sp-4)',
-          borderTop: '1px solid var(--alm-border)',
-          display: 'flex',
-          gap: 'var(--alm-sp-3)',
-        }}
-      >
-        <button
-          data-testid="back-button"
-          onClick={onBack}
-          disabled={isFinishing}
-          style={{
-            padding: 'var(--alm-sp-2) var(--alm-sp-5)',
-            background: 'transparent',
-            color: 'var(--alm-text)',
-            border: '1px solid var(--alm-border)',
-            borderRadius: 'var(--alm-radius-md)',
-            fontWeight: 'var(--alm-weight-medium)',
-            fontSize: 'var(--alm-text-sm)',
-            cursor: isFinishing ? 'not-allowed' : 'pointer',
-            opacity: isFinishing ? 0.6 : 1,
-          }}
-        >
-          &larr; Back to review
-        </button>
-        <button
-          data-testid="finish-button"
-          onClick={() => { void onFinish(); }}
-          disabled={isFinishing || !allDone}
-          style={{
-            padding: 'var(--alm-sp-2) var(--alm-sp-5)',
-            background: 'var(--alm-accent)',
-            color: 'var(--alm-accent-text)',
-            border: 'none',
-            borderRadius: 'var(--alm-radius-md)',
-            fontWeight: 'var(--alm-weight-medium)',
-            fontSize: 'var(--alm-text-sm)',
-            cursor: isFinishing || !allDone ? 'not-allowed' : 'pointer',
-            opacity: isFinishing || !allDone ? 0.6 : 1,
-          }}
-        >
-          {isFinishing ? 'Finishing…' : 'Finish'}
-        </button>
-      </div>
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- **SetupWizard.tsx**: Added `scanComplete` state. Replaced the `isOnScanStep` guard that suppressed footer buttons with proper Back (ghost) + Finish (primary, `data-testid="finish-button"`) using the shared `Btn` component. Finish is disabled until `onAllDoneChange(true)` fires or while `isFinishing`. Back on the scan step goes to `SCAN_STEP - 1` (Confirm).
- **StepScan.tsx**: Removed `onFinish`, `isFinishing`, `onBack` props and the entire internal button block (bespoke inline-styled `<button>` elements). Added `onAllDoneChange(done: boolean)` prop; called via `useEffect` whenever `allDone` changes so the footer can enable/disable Finish.
- **StepScan.test.tsx**: Replaced tests that clicked `finish-button`/`back-button` testids inside StepScan with tests on the `onAllDoneChange` callback contract. Tests that click Finish via the wizard footer remain in `SetupWizard.test.tsx` (no change needed there — `findByTestId('finish-button')` still works because `Btn` spreads `...rest` onto `<button>`).

## Test plan

- [ ] `just typecheck` — clean (verified)
- [ ] `cd apps/desktop && pnpm vitest run` — 626 pass, 0 fail (verified)
- [ ] No other test files touched; SetupWizard.test.tsx scan-step flow (including the `finish-button` click) passes unchanged