### PR TITLE
fix(inbox): cross-root list joins registered_sources; inbox optional; cleanup + real badge

### DIFF
--- a/apps/desktop/src-tauri/src/commands/status.rs
+++ b/apps/desktop/src-tauri/src/commands/status.rs
@@ -13,6 +13,8 @@ use crate::commands::lifecycle::AppState;
 ///
 /// Roots are fetched from `registered_sources`; each root's `online` flag is
 /// set by testing whether its path is currently accessible on the filesystem.
+/// `inbox_count` reflects the real number of unacknowledged inbox items
+/// (`pending_classification` or `classified`) across all registered sources.
 ///
 /// # Errors
 /// Returns `Err(String)` on database failure.
@@ -21,7 +23,9 @@ use crate::commands::lifecycle::AppState;
 pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary, String> {
     tracing::debug!("status.summary");
 
-    let sources = persistence_db::repositories::first_run::list_sources(state.repo.pool())
+    let pool = state.repo.pool();
+
+    let sources = persistence_db::repositories::first_run::list_sources(pool)
         .await
         .map_err(|e| e.to_string())?;
 
@@ -38,8 +42,19 @@ pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary,
         })
         .collect();
 
+    // Count unacknowledged inbox items (states that need user attention).
+    let inbox_count: u32 = sqlx::query_scalar::<_, i64>(
+        "SELECT COUNT(*) FROM inbox_items i
+         JOIN registered_sources r ON r.id = i.root_id
+         WHERE i.state IN ('pending_classification', 'classified')",
+    )
+    .fetch_one(pool)
+    .await
+    .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
+    .map_err(|e| e.to_string())?;
+
     Ok(StatusSummary {
-        inbox_count: 0,
+        inbox_count,
         library: LibraryStats { sessions: 0, calibration_sets: 0, targets: 0, projects: 0 },
         cleanup_reclaimable_bytes: 0,
         volumes: vec![],

--- a/crates/persistence/db/src/repositories/first_run.rs
+++ b/crates/persistence/db/src/repositories/first_run.rs
@@ -225,10 +225,16 @@ pub async fn list_sources(pool: &SqlitePool) -> DbResult<Vec<RegisterSourceRespo
 
 /// Remove a registered source by ID.
 ///
+/// Also deletes any `inbox_items` whose `root_id` references this source so
+/// that no orphaned rows remain after removal (H1 — no FK cascade in schema).
+///
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if the ID does not exist.
 pub async fn remove_source(pool: &SqlitePool, id: &str) -> DbResult<()> {
+    // Clean up inbox items that belong to this source before removing it.
+    sqlx::query("DELETE FROM inbox_items WHERE root_id = ?").bind(id).execute(pool).await?;
+
     let result =
         sqlx::query("DELETE FROM registered_sources WHERE id = ?").bind(id).execute(pool).await?;
 
@@ -267,12 +273,10 @@ pub async fn get_first_run_state(pool: &SqlitePool) -> DbResult<FirstRunStateRes
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if preconditions are not met (at least one
-/// raw source and one project source must be registered).
+/// light_frames source and one project source must be registered).
 pub async fn complete_first_run(pool: &SqlitePool) -> DbResult<FirstRunCompleteResponse> {
-    // Check preconditions: at least one light_frames + one project + one inbox source.
-    // The inbox is the ingestion entry point for the core classify/split workflow, so it
-    // is mandatory alongside light frames and a project (kept in sync with the frontend
-    // REQUIRED_KINDS gate).
+    // Check preconditions: at least one light_frames + one project source.
+    // Inbox is optional (spec 039 removed it from REQUIRED_KINDS).
     let light_count: (i64,) =
         sqlx::query_as("SELECT COUNT(*) FROM registered_sources WHERE kind = 'light_frames'")
             .fetch_one(pool)
@@ -281,14 +285,10 @@ pub async fn complete_first_run(pool: &SqlitePool) -> DbResult<FirstRunCompleteR
         sqlx::query_as("SELECT COUNT(*) FROM registered_sources WHERE kind = 'project'")
             .fetch_one(pool)
             .await?;
-    let inbox_count: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM registered_sources WHERE kind = 'inbox'")
-            .fetch_one(pool)
-            .await?;
 
-    if light_count.0 == 0 || project_count.0 == 0 || inbox_count.0 == 0 {
+    if light_count.0 == 0 || project_count.0 == 0 {
         return Err(DbError::NotFound(
-            "first_run.incomplete: at least one light_frames, one project, and one inbox source required"
+            "first_run.incomplete: at least one light_frames and one project source required"
                 .to_owned(),
         ));
     }
@@ -451,14 +451,14 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn complete_first_run_requires_raw_and_project() {
+    async fn complete_first_run_requires_light_and_project() {
         let pool = setup_db().await;
 
         // No sources: should fail.
         let result = complete_first_run(&pool).await;
         assert!(result.is_err());
 
-        // Only raw: should fail.
+        // Only light_frames: should fail (project missing).
         let req = RegisterSourceRequest {
             kind: SourceKind::LightFrames,
             path: "/astro/raw".to_owned(),
@@ -469,21 +469,10 @@ mod tests {
         let result = complete_first_run(&pool).await;
         assert!(result.is_err());
 
-        // Add project: still missing inbox, should fail.
+        // Add project: light + project present — inbox is not required (spec 039).
         let req = RegisterSourceRequest {
             kind: SourceKind::Project,
             path: "/astro/projects".to_owned(),
-            kind_subtype: None,
-            scan_depth: ScanDepth::Recursive,
-        };
-        register_source(&pool, &req).await.unwrap();
-        let result = complete_first_run(&pool).await;
-        assert!(result.is_err());
-
-        // Add inbox: now light + project + inbox are present, should succeed.
-        let req = RegisterSourceRequest {
-            kind: SourceKind::Inbox,
-            path: "/astro/inbox".to_owned(),
             kind_subtype: None,
             scan_depth: ScanDepth::Recursive,
         };
@@ -567,5 +556,123 @@ mod tests {
         update_first_run_step(&pool, "processing_tools").await.unwrap();
         let state = get_first_run_state(&pool).await.unwrap();
         assert_eq!(state.last_step, "processing_tools");
+    }
+
+    /// C2: `complete_first_run` must succeed with only light_frames + project
+    /// (no inbox source required — spec 039 removed inbox from REQUIRED_KINDS).
+    #[tokio::test]
+    async fn complete_first_run_succeeds_without_inbox() {
+        let pool = setup_db().await;
+
+        register_source(
+            &pool,
+            &RegisterSourceRequest {
+                kind: SourceKind::LightFrames,
+                path: "/astro/lights".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+            },
+        )
+        .await
+        .unwrap();
+
+        register_source(
+            &pool,
+            &RegisterSourceRequest {
+                kind: SourceKind::Project,
+                path: "/astro/projects".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+            },
+        )
+        .await
+        .unwrap();
+
+        // No inbox registered — must succeed now.
+        let resp = complete_first_run(&pool).await.unwrap();
+        assert!(!resp.completed_at.is_empty(), "completed_at must be set");
+        assert_eq!(resp.registered_source_count, 2);
+
+        let state = get_first_run_state(&pool).await.unwrap();
+        assert_eq!(state.last_step, "complete");
+    }
+
+    /// C2 boundary: still fails when only light_frames is registered (project missing).
+    #[tokio::test]
+    async fn complete_first_run_still_requires_light_and_project() {
+        let pool = setup_db().await;
+
+        register_source(
+            &pool,
+            &RegisterSourceRequest {
+                kind: SourceKind::LightFrames,
+                path: "/astro/lights".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+            },
+        )
+        .await
+        .unwrap();
+
+        let err = complete_first_run(&pool).await;
+        assert!(err.is_err(), "should fail without a project source");
+    }
+
+    /// H1: `remove_source` must delete orphaned `inbox_items` for the removed
+    /// source so no zombie rows remain.
+    #[tokio::test]
+    async fn remove_source_deletes_inbox_items() {
+        use crate::repositories::inbox::{insert_inbox_item, InsertInboxItem};
+
+        let pool = setup_db().await;
+
+        let resp = register_source(
+            &pool,
+            &RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: "/astro/inbox".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+            },
+        )
+        .await
+        .unwrap();
+        let source_id = resp.source_id;
+
+        // Insert an inbox item for this source.
+        insert_inbox_item(
+            &pool,
+            &InsertInboxItem {
+                id: "orphan-item-1",
+                root_id: &source_id,
+                relative_path: "2025-10-01/lights",
+                file_count: 3,
+                content_signature: None,
+                lane: "fits",
+            },
+        )
+        .await
+        .unwrap();
+
+        // Verify it exists.
+        let count_before: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM inbox_items WHERE root_id = ?")
+                .bind(&source_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count_before.0, 1, "inbox item should exist before removal");
+
+        // Remove the source.
+        remove_source(&pool, &source_id).await.unwrap();
+
+        // Inbox items for that root must be gone.
+        let count_after: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM inbox_items WHERE root_id = ?")
+                .bind(&source_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(count_after.0, 0, "inbox items must be deleted with the source");
     }
 }

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -516,7 +516,7 @@ pub async fn list_unacknowledged_across_roots(
         "SELECT
              i.id,
              i.root_id,
-             r.current_path  AS root_path,
+             r.path          AS root_path,
              i.relative_path,
              i.file_count,
              i.discovered_at,
@@ -525,9 +525,9 @@ pub async fn list_unacknowledged_across_roots(
              i.state,
              i.lane
          FROM inbox_items i
-         JOIN library_root r ON r.id = i.root_id
+         JOIN registered_sources r ON r.id = i.root_id
          WHERE i.state IN ('pending_classification', 'classified')
-         ORDER BY r.current_path, i.relative_path
+         ORDER BY r.path, i.relative_path
          LIMIT ?",
     )
     .bind(limit)
@@ -691,5 +691,54 @@ mod tests {
         // Second insert must fail (PK constraint)
         let err = insert_plan_link(db.pool(), "item-7", "plan-inbox-2").await;
         assert!(err.is_err());
+    }
+
+    /// C1 integration test (no mocks): register a real source via
+    /// `register_source_batch`, insert an inbox item for that source's id, then
+    /// call `list_unacknowledged_across_roots` and assert the row comes back
+    /// with the correct `root_path`. Verifies the JOIN hits `registered_sources`
+    /// not the absent `library_root` table.
+    #[tokio::test]
+    async fn list_unacknowledged_joins_registered_sources() {
+        use contracts_core::first_run::{
+            RegisterSourceBatchRequest, RegisterSourceRequest, ScanDepth, SourceKind,
+        };
+
+        let db = test_db().await;
+        let pool = db.pool();
+
+        // Register a source via the real batch function (same path the wizard uses).
+        let batch_req = RegisterSourceBatchRequest {
+            sources: vec![RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: "/astro/inbox".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+            }],
+        };
+        let batch_resp =
+            crate::repositories::first_run::register_source_batch(pool, &batch_req).await.unwrap();
+        let source_id = batch_resp.items[0].source_id.as_deref().unwrap().to_owned();
+
+        // Insert an inbox item pointing at that source id.
+        let item = InsertInboxItem {
+            id: "cross-root-item-1",
+            root_id: &source_id,
+            relative_path: "2025-11-01/lights",
+            file_count: 5,
+            content_signature: Some("sig-cross"),
+            lane: "fits",
+        };
+        insert_inbox_item(pool, &item).await.unwrap();
+
+        // Must return ≥1 row with the correct root_path.
+        let rows = list_unacknowledged_across_roots(pool, 100).await.unwrap();
+        assert_eq!(rows.len(), 1, "expected 1 unacknowledged item");
+        assert_eq!(
+            rows[0].root_path, "/astro/inbox",
+            "root_path must match registered_sources.path"
+        );
+        assert_eq!(rows[0].id, "cross-root-item-1");
+        assert_eq!(rows[0].state, "pending_classification");
     }
 }


### PR DESCRIPTION
## Summary

- **C1 (CRITICAL)**: `list_unacknowledged_across_roots` now JOINs `inbox_items` to `registered_sources` (`r.path AS root_path`) instead of the absent `library_root` table. This was why `inbox_list` always returned `[]` on a real backend — `library_root` is never populated by non-test code.
- **C2 (CRITICAL)**: `complete_first_run` no longer requires an inbox source. Spec 039 removed inbox from frontend `REQUIRED_KINDS`; the DB gate was still checking `inbox_count \!= 0`, making setup un-completable without an inbox folder. Error message updated to match (only light_frames + project required).
- **H1 (HIGH)**: `remove_source` now deletes `inbox_items WHERE root_id = ?` before removing the source row, preventing zombie rows when a root is removed and re-registered with a different id.
- **H2 (HIGH)**: `status_summary` now queries `COUNT(*)` over unacknowledged inbox items (joining `registered_sources`) instead of returning hardcoded `0`, backing the sidebar badge with the real count.

## Changed files

- `crates/persistence/db/src/repositories/inbox.rs` — C1 JOIN fix + C1 integration test (no mocks)
- `crates/persistence/db/src/repositories/first_run.rs` — C2 gate + H1 cleanup; updated existing test; 3 new tests
- `apps/desktop/src-tauri/src/commands/status.rs` — H2 real badge count

## Test plan

- [x] `cargo check -p persistence_db` — clean
- [x] `cargo check` from `apps/desktop/src-tauri` — clean
- [x] `cargo test -p persistence_db` — 134 passed (8 inbox, 12 first_run; all new tests included)
- [x] `cargo fmt --all` — applied, retested
- [x] `just typecheck` — clean
- [x] `pnpm vitest run` — 626 passed, 0 failed