### PR TITLE
fix(ui): scan/inbox copy (drop duplicate approval line; cross-root empty state)

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -166,8 +166,8 @@ export function InboxPage() {
             />
           ) : (
             <EmptyState
-              title="Select a folder"
-              description="Choose an inbox folder to review its classification before confirming."
+              title="Select a detection"
+              description="Pick an item from the list to review its classification before confirming."
             />
           )
         }

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -60,7 +60,7 @@ const STEPS = [
   {
     label: 'Scan',
     heading: 'Scanning your library',
-    description: 'Scanning each source folder and detecting ingestion groups. Approval happens in the Inbox.',
+    description: 'Scanning each source folder and detecting ingestion groups.',
   },
 ];
 


### PR DESCRIPTION
- Remove 'Approval happens in the Inbox.' from the scan-step description (walkthrough covers it).
- Update the Inbox detail empty-state from the stale single-folder copy ('Choose an inbox folder…') to the cross-root model ('Select a detection' / 'Pick an item from the list…').

typecheck + vitest (626) green.