### PR TITLE
docs(spec 040): calibration master detection (extensible detector crate)

### DIFF
--- a/.specify/feature.json
+++ b/.specify/feature.json
@@ -1,3 +1,3 @@
 {
-  "feature_directory": "specs/039-cross-root-inbox"
+  "feature_directory": "specs/040-calibration-masters-detection"
 }

--- a/specs/040-calibration-masters-detection/checklists/requirements.md
+++ b/specs/040-calibration-masters-detection/checklists/requirements.md
@@ -1,0 +1,19 @@
+# Specification Quality Checklist: Calibration master detection
+
+**Created**: 2026-06-19 | **Feature**: [spec.md](../spec.md)
+
+## Content Quality
+- [x] Research-grounded (Siril STACKCNT/_stacked; PixInsight IMAGETYP-master + path) — see research.md
+- [x] Extensible detector architecture decided (dedicated crate + trait + registry)
+- [x] Mandatory sections completed
+
+## Requirement Completeness
+- [x] No [NEEDS CLARIFICATION] markers
+- [x] Requirements testable; success criteria measurable
+- [x] Edge cases (sub vs master, OFFSET->bias, name fallback) covered
+- [x] Scope bounded (matching/reuse out; per-sub display out)
+- [x] Constitution IV (research-led metadata rules) satisfied; calibration logic kept out of domain crate
+
+## Feature Readiness
+- [x] FRs have acceptance criteria
+- [x] New tool = one detector impl (SC-004)

--- a/specs/040-calibration-masters-detection/research.md
+++ b/specs/040-calibration-masters-detection/research.md
@@ -1,0 +1,58 @@
+# Research: calibration master detection
+
+## How tools label a calibration master
+
+### Siril (FITS)
+- `IMAGETYP` stays the **base type**: `LIGHT` / `DARK` / `BIAS` / `OFFSET` (= bias) / `FLAT` — **never** "master".
+- A master is identified by **`STACKCNT` > 1** (number of frames integrated; written/updated during stacking) and the **`_stacked.fit`** filename convention (`LIVETIME` is also updated).
+- Sources: https://siril.org/tutorials/tuto-manual/ , https://siril.org/faq/
+
+### PixInsight / WBPP (XISF, also FITS)
+- WBPP-created masters carry `IMAGETYP` **containing "master"** (e.g. `Master Dark`).
+- WBPP's own re-detection: `IMAGETYP` contains "master" → else fall back to **"master" in the path/filename** (e.g. `masterDarks/`, `masterDark.xisf`).
+- Masters from raw `ImageIntegration` (not WBPP) may have neither and rely on the path/name fallback; `NCOMBINE` may be present.
+- Sources: https://pixinsight.com/forum/index.php?threads/scrpt-wbp.16660/ , Landmann preprocessing guide.
+
+### Conclusion
+Master-ness is **tool-specific** and cannot be a single keyword check. It must be a set of per-tool detectors combined by OR. Base frame type comes from `IMAGETYP` regardless of master-ness; masters are distinguished from each other by **filter + exposure**.
+
+## Architecture decision: a dedicated, extensible detector crate
+
+**Decision**: a new narrow library crate `crates/calibration/master-detect` exposing a pluggable detector system so new tools are trivial to add.
+
+```rust
+/// Inputs a detector inspects (derived from extracted metadata + file location).
+pub struct DetectInput<'a> {
+    pub imagetyp: Option<&'a str>,     // raw IMAGETYP value
+    pub stack_count: Option<u32>,      // STACKCNT or NCOMBINE
+    pub file_name: &'a str,
+    pub rel_path: &'a str,
+}
+
+pub struct MasterDetection {
+    pub frame_type: FrameType,         // base type (Dark/Bias/Flat/Light/DarkFlat); OFFSET→Bias
+    pub is_master: bool,
+    pub detector: &'static str,        // provenance — which detector matched
+}
+
+pub trait MasterDetector: Send + Sync {
+    fn id(&self) -> &'static str;
+    /// Some(..) if this detector recognizes the file as a (master) calibration frame.
+    fn detect(&self, input: &DetectInput) -> Option<MasterDetection>;
+}
+
+pub fn detectors() -> Vec<Box<dyn MasterDetector>>;          // registry (ordered)
+pub fn detect_master(input: &DetectInput) -> Option<MasterDetection>; // first match wins
+```
+
+**Detectors (initial):**
+- `SirilDetector` — base type from `IMAGETYP` (dark/bias/offset→bias/flat/light); `is_master` if `stack_count > 1` **||** `file_name`/`rel_path` contains `_stacked` **||** contains `master`.
+- `PixInsightDetector` — base type from `IMAGETYP` (after stripping "master"); `is_master` if `imagetyp` contains `master` **||** path/name contains `master` **||** `_stacked`.
+
+(Per the user's shorthand: `siril_detection -> STACKCNT & IMAGETYP=dark/bias/flat || _stacked || master`; `pixinsight_detection -> IMAGETYP="Master" & IMAGETYP=dark/flat/bias || master || _stacked`.)
+
+Overlap between detectors is fine — `detect_master` returns the first match and records which detector fired (provenance, per constitution §II confidence/attribution). Adding a future tool = one new `impl MasterDetector` added to `detectors()`.
+
+**Crate boundaries**: depends only on `metadata/core` (for `FrameType` + a base-type parser) — NOT on `domain/core` (calibration logic stays out of the domain crate) and NOT on persistence/UI. Pure, fast unit tests with table-driven fixtures per tool.
+
+**`STACKCNT` threshold (decided)**: `> 1` (strict) — a single frame with STACKCNT=1 is not a master.

--- a/specs/040-calibration-masters-detection/spec.md
+++ b/specs/040-calibration-masters-detection/spec.md
@@ -1,0 +1,73 @@
+# Feature Specification: Calibration master detection
+
+**Feature Branch**: `040-calibration-masters-detection`
+
+**Created**: 2026-06-19
+
+**Status**: Draft
+
+**Input**: Detect calibration masters from XISF and FITS metadata via an extensible per-tool detector system; classify base frame type + an `isMaster` flag; distinguish masters by filter/exposure; show masters as individual items in the inbox and surface them on the Calibration page. (Sub-frames stay folder-grouped.)
+
+## Background
+
+XISF/FITS files are already scanned and frame-typed (`IMAGETYP` → Light/Dark/Bias/Flat/DarkFlat). Gaps found in validation:
+- **Masters aren't recognized**: tools mark masters differently (see research.md) — Siril keeps the base `IMAGETYP` and uses `STACKCNT`/`_stacked`; PixInsight/WBPP uses `IMAGETYP` containing "master" + a path fallback. The current normalization has no notion of a master, so masters are mis-/un-classified.
+- **No frame-vs-master distinction** in the model.
+- **Folder grouping** hides individual masters (each leaf folder is one inbox item).
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — XISF/FITS masters are detected as masters (P1)
+A user with PixInsight XISF masters (`IMAGETYP=Master Dark`) and/or Siril FITS masters (`IMAGETYP=DARK`, `STACKCNT>1`, `*_stacked.fit`) sees them recognized as calibration **masters** of the right type.
+
+**Independent Test**: feed representative XISF (PixInsight) and FITS (Siril) master fixtures through detection → each yields `{frame_type, is_master:true, detector}`; a single sub-frame yields `is_master:false`.
+
+**Acceptance Scenarios**:
+1. **Given** an XISF with `IMAGETYP="Master Dark"`, **When** detected, **Then** `frame_type=Dark, is_master=true` (PixInsight detector).
+2. **Given** a FITS with `IMAGETYP="DARK"` + `STACKCNT=30`, **When** detected, **Then** `frame_type=Dark, is_master=true` (Siril detector).
+3. **Given** a file named `masterFlat_Ha.xisf` with no master IMAGETYP, **When** detected, **Then** `is_master=true` via the path/name fallback.
+4. **Given** a single dark sub (`IMAGETYP=DARK`, no STACKCNT/master), **When** detected, **Then** `is_master=false`.
+
+### User Story 2 — Masters shown individually with their metadata (P1)
+Masters appear as **individual entries** (not a folder lump) in the inbox/imported list, each labeled by type + filter + exposure (e.g. "Master Dark · 300s", "Master Flat · Ha"). Sub-frames stay folder-grouped.
+
+**Independent Test**: a calibration folder with 3 different masters (dark 300s, flat Ha, flat OIII) + a folder of dark subs → the inbox shows 3 master items + 1 grouped subs item.
+
+**Acceptance Scenarios**:
+1. **Given** several masters in one folder, **When** scanned, **Then** each is its own inbox item distinguished by filter/exposure.
+2. **Given** a folder of sub-frames, **When** scanned, **Then** they remain a single grouped item.
+
+### User Story 3 — Masters surface on the Calibration page (P2)
+On confirm/ingest, detected masters are registered so they appear on the **Calibration masters page**.
+
+**Independent Test**: confirm a detected master in the inbox → it appears in `calibration_masters_list` / the Calibration page.
+
+## Requirements *(mandatory)*
+
+- **FR-001**: A dedicated extensible crate `crates/calibration/master-detect` provides a `MasterDetector` trait + registry + `detect_master(input)` (see research.md). Adding a tool = one new detector impl.
+- **FR-002**: Ship `SirilDetector` and `PixInsightDetector` per research.md (Siril: STACKCNT>1 / `_stacked` / name; PixInsight: IMAGETYP "master" / path / name). Base frame type from `IMAGETYP` (OFFSET→Bias); STACKCNT threshold `>1`.
+- **FR-003**: The crate depends only on `metadata/core`; no domain/persistence/UI deps. Table-driven unit tests per detector (XISF + FITS fixtures), including negative (sub-frame) cases.
+- **FR-004**: Classification (inbox `classify`) uses `detect_master` to set base frame type + an `is_master` flag; the metadata model carries `is_master` (and the matching detector for provenance).
+- **FR-005**: Masters are emitted as **individual items** keyed by content + (type, filter, exposure); sub-frames keep the existing folder grouping.
+- **FR-006**: Inbox/imported list shows masters individually with type + filter + exposure.
+- **FR-007**: On confirm, masters are registered into the calibration masters store and appear on the Calibration page.
+- **FR-008**: Mock mode exercises the new master items + list.
+
+## Success Criteria *(mandatory)*
+
+- **SC-001**: PixInsight XISF + Siril FITS master fixtures are each detected as masters of the correct type; sub-frames are not.
+- **SC-002**: A folder with N distinct masters shows N individual inbox items distinguished by filter/exposure.
+- **SC-003**: Confirming a master makes it appear on the Calibration page.
+- **SC-004**: A new tool detector can be added by implementing `MasterDetector` + registering it (no changes to callers).
+- **SC-005**: cargo + typecheck + vitest green; the detector crate has per-tool unit tests.
+
+## Scope
+
+**In scope**: the detector crate + Siril/PixInsight detectors; wiring detection into classification; per-master individual items + metadata display; surfacing masters to the Calibration page.
+
+**Out of scope**: deep XISF/FITS binary parsing beyond the header fields already extracted; calibration *matching/reuse* policy (separate); per-sub-frame display for non-masters.
+
+## Assumptions
+
+- The existing FITS/XISF extractors already surface (or can cheaply surface) `IMAGETYP`, `STACKCNT`/`NCOMBINE`, filter, exposure; if `STACKCNT`/`NCOMBINE` isn't extracted yet, the extractors add it.
+- "Master distinguished by filter/exposure" uses already-extracted metadata.


### PR DESCRIPTION
Research-grounded spec (Siril: STACKCNT>1/_stacked, base IMAGETYP; PixInsight/WBPP: IMAGETYP contains 'master' + path fallback). New `crates/calibration/master-detect` with a `MasterDetector` trait + registry + Siril/PixInsight detectors; wire `is_master` into classification; masters shown individually (filter/exposure) + surfaced on the Calibration page. Spec/research/checklist only — implementation follows.