### PR TITLE
feat(spec 040 P1): master-detect crate + detectors + wire is_master into classification

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
   "crates/app/core",
   "crates/audit",
   "crates/calibration/core",
+  "crates/calibration/master-detect",
   "crates/contracts/core",
   "crates/domain/core",
   "crates/fs/executor",

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 audit = { path = "../../audit" }
 calibration_core = { path = "../../calibration/core" }
+calibration_master_detect = { path = "../../calibration/master-detect" }
 workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
 contracts_core = { path = "../../contracts/core" }

--- a/crates/app/core/src/inbox/classify.rs
+++ b/crates/app/core/src/inbox/classify.rs
@@ -13,6 +13,7 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use calibration_master_detect::{detect_master, DetectInput};
 use metadata_core::{v1_normalization_table, EvidenceSource, FrameType, MetadataExtractor};
 use metadata_fits::FitsExtractor;
 use metadata_xisf::XisfExtractor;
@@ -139,8 +140,33 @@ pub async fn classify(
         };
 
         let image_typ_raw = raw_meta.as_ref().and_then(|m| m.image_typ.as_deref());
-        let (frame_type, evidence_source, raw_value, is_unclassified) =
-            if let Some(raw) = image_typ_raw {
+        let stack_count = raw_meta.as_ref().and_then(|m| m.stack_count);
+        let file_name = abs_path.file_name().and_then(|n| n.to_str()).unwrap_or("");
+
+        // Run master detection first (spec 040 FR-004).
+        // detect_master provides both frame_type and is_master when it matches.
+        let detect_input =
+            DetectInput { imagetyp: image_typ_raw, stack_count, file_name, rel_path: &rel };
+        let master_result = detect_master(&detect_input);
+
+        let (frame_type, evidence_source, raw_value, is_unclassified, is_master, master_detector) =
+            if let Some(ref det) = master_result {
+                // Detector produced a classification — use it directly.
+                let src = if ext == "xisf" {
+                    EvidenceSource::XisfProperty
+                } else {
+                    EvidenceSource::ImagetypHeader
+                };
+                (
+                    Some(det.frame_type),
+                    src,
+                    image_typ_raw.map(str::to_owned),
+                    false,
+                    det.is_master,
+                    Some(det.detector),
+                )
+            } else if let Some(raw) = image_typ_raw {
+                // No master detector matched; fall back to the normalization table.
                 match norm_table.normalize(raw) {
                     Some(ft) => {
                         let src = if ext == "xisf" {
@@ -148,12 +174,12 @@ pub async fn classify(
                         } else {
                             EvidenceSource::ImagetypHeader
                         };
-                        (Some(ft), src, Some(raw.to_owned()), false)
+                        (Some(ft), src, Some(raw.to_owned()), false, false, None)
                     }
-                    None => (None, EvidenceSource::None, Some(raw.to_owned()), true),
+                    None => (None, EvidenceSource::None, Some(raw.to_owned()), true, false, None),
                 }
             } else {
-                (None, EvidenceSource::None, None, true)
+                (None, EvidenceSource::None, None, true, false, None)
             };
 
         // Persist evidence
@@ -167,6 +193,8 @@ pub async fn classify(
             raw_value: raw_value.as_deref(),
             unclassified: is_unclassified,
             manual_override: None,
+            is_master,
+            master_detector,
         };
         repo::insert_evidence(pool, &ev).await.ok();
 

--- a/crates/app/core/src/inbox/confirm.rs
+++ b/crates/app/core/src/inbox/confirm.rs
@@ -502,6 +502,8 @@ mod tests {
                     raw_value: Some("Light Frame"),
                     unclassified: false,
                     manual_override: None,
+                    is_master: false,
+                    master_detector: None,
                 },
             )
             .await
@@ -650,6 +652,8 @@ mod tests {
                     raw_value: Some(if ft == "light" { "Light Frame" } else { "Dark Frame" }),
                     unclassified: false,
                     manual_override: None,
+                    is_master: false,
+                    master_detector: None,
                 },
             )
             .await
@@ -741,6 +745,8 @@ mod tests {
                     raw_value: None,
                     unclassified: false,
                     manual_override: None,
+                    is_master: false,
+                    master_detector: None,
                 },
             )
             .await

--- a/crates/app/core/src/inbox/reclassify.rs
+++ b/crates/app/core/src/inbox/reclassify.rs
@@ -214,6 +214,8 @@ mod tests {
                 raw_value: None,
                 unclassified: true,
                 manual_override: None,
+                is_master: false,
+                master_detector: None,
             },
         )
         .await
@@ -230,6 +232,8 @@ mod tests {
                 raw_value: None,
                 unclassified: true,
                 manual_override: None,
+                is_master: false,
+                master_detector: None,
             },
         )
         .await

--- a/crates/calibration/master-detect/Cargo.toml
+++ b/crates/calibration/master-detect/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "calibration_master_detect"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+metadata_core = { path = "../../metadata/core" }
+
+[lints]
+workspace = true

--- a/crates/calibration/master-detect/src/lib.rs
+++ b/crates/calibration/master-detect/src/lib.rs
@@ -1,0 +1,211 @@
+//! Calibration master detection (spec 040, FR-001..FR-004).
+//!
+//! # Architecture
+//!
+//! An extensible registry of [`MasterDetector`] implementations. Each detector
+//! encapsulates tool-specific heuristics for determining whether a file is a
+//! calibration master and what base frame type it carries.
+//!
+//! The public entry point is [`detect_master`]: it runs each registered
+//! detector in order and returns the first match (first-wins). Callers that
+//! only need the result do not need to know about individual detectors.
+//!
+//! Adding support for a new capture/processing tool requires only:
+//! 1. Implementing `MasterDetector` in a new module.
+//! 2. Appending an instance to the `Vec` returned by [`detectors`].
+//!
+//! No changes are needed in `classify` or any other caller (SC-004).
+//!
+//! # Dependency boundary
+//!
+//! This crate depends **only** on `metadata_core` for [`FrameType`]. It must
+//! NOT depend on `domain_core`, `persistence_db`, or any UI crates (FR-003).
+#![allow(clippy::doc_markdown)]
+
+use metadata_core::FrameType;
+
+mod pixinsight;
+mod siril;
+
+pub use pixinsight::PixInsightDetector;
+pub use siril::SirilDetector;
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/// Input supplied to each detector.
+///
+/// All string slices are borrowed from the caller; the struct is intentionally
+/// cheap to build (no allocation).
+pub struct DetectInput<'a> {
+    /// Raw `IMAGETYP` header value, if present.
+    pub imagetyp: Option<&'a str>,
+    /// Value of `STACKCNT` or `NCOMBINE` (prefer `STACKCNT` when both exist).
+    pub stack_count: Option<u32>,
+    /// Bare file name (without directory), e.g. `"masterDark_300s.xisf"`.
+    pub file_name: &'a str,
+    /// Relative path from the library root, e.g. `"masters/masterDark.xisf"`.
+    pub rel_path: &'a str,
+}
+
+/// Result produced by a successful detection.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct MasterDetection {
+    /// Normalised base frame type (Light / Dark / Bias / Flat / DarkFlat).
+    pub frame_type: FrameType,
+    /// Whether this file is a stacked master (as opposed to a raw sub-frame).
+    pub is_master: bool,
+    /// Identifier of the detector that produced this result (provenance).
+    pub detector: &'static str,
+}
+
+/// Trait implemented by each per-tool detector.
+pub trait MasterDetector: Send + Sync {
+    /// A short, stable, lowercase identifier, e.g. `"siril"` or `"pixinsight"`.
+    fn id(&self) -> &'static str;
+
+    /// Attempt to detect a master from the given input.
+    ///
+    /// Returns `Some(detection)` when this detector can determine the frame
+    /// type (with or without master status); returns `None` when the input
+    /// provides insufficient information for this tool.
+    fn detect(&self, input: &DetectInput<'_>) -> Option<MasterDetection>;
+}
+
+/// Return the ordered list of registered detectors.
+///
+/// Detectors are tried in order; the first `Some` result wins. Add new
+/// detectors at the end to keep the existing priority unchanged.
+#[must_use]
+pub fn detectors() -> Vec<Box<dyn MasterDetector>> {
+    vec![Box::new(PixInsightDetector), Box::new(SirilDetector)]
+}
+
+/// Run all registered detectors in priority order and return the first match.
+///
+/// Returns `None` only when no detector could determine even the base frame
+/// type from the supplied input.
+#[must_use]
+pub fn detect_master(input: &DetectInput<'_>) -> Option<MasterDetection> {
+    for detector in detectors() {
+        if let Some(result) = detector.detect(input) {
+            return Some(result);
+        }
+    }
+    None
+}
+
+// ── Shared base-frame-type parser ─────────────────────────────────────────────
+
+/// Parse a raw `IMAGETYP` string into a [`FrameType`].
+///
+/// Rules (case-insensitive, trims whitespace):
+/// - Contains "dark flat" or "darkflat" → `DarkFlat`
+/// - Contains "dark"                    → `Dark`
+/// - Contains "bias" or "offset"        → `Bias`
+/// - Contains "flat"                    → `Flat`
+/// - Contains "light" or "science"      → `Light`
+///
+/// The "master" word is stripped before matching so that `"Master Dark"`,
+/// `"Dark Frame"`, etc. all normalise correctly.
+#[must_use]
+pub fn parse_frame_type(raw: &str) -> Option<FrameType> {
+    // Strip "master" (word boundary not needed — just remove the substring)
+    let normalised =
+        raw.to_ascii_lowercase().replace("master", "").replace("frame", "").replace("frames", "");
+    let s = normalised.trim().to_owned();
+
+    // Dark flat must be checked before dark and flat individually.
+    if s.contains("dark flat") || s.contains("darkflat") {
+        return Some(FrameType::DarkFlat);
+    }
+    if s.contains("dark") {
+        return Some(FrameType::Dark);
+    }
+    if s.contains("bias") || s.contains("offset") {
+        return Some(FrameType::Bias);
+    }
+    if s.contains("flat") {
+        return Some(FrameType::Flat);
+    }
+    if s.contains("light") || s.contains("science") || s.contains("object") {
+        return Some(FrameType::Light);
+    }
+    None
+}
+
+/// Return `true` if the lowercased path or file name suggests a master.
+///
+/// Matches when either component contains `"master"` or `"_stacked"`.
+#[must_use]
+pub fn path_looks_like_master(file_name: &str, rel_path: &str) -> bool {
+    let name_lc = file_name.to_ascii_lowercase();
+    let path_lc = rel_path.to_ascii_lowercase();
+    name_lc.contains("master")
+        || name_lc.contains("_stacked")
+        || path_lc.contains("master")
+        || path_lc.contains("_stacked")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_frame_type_dark_variants() {
+        assert_eq!(parse_frame_type("DARK"), Some(FrameType::Dark));
+        assert_eq!(parse_frame_type("Dark Frame"), Some(FrameType::Dark));
+        assert_eq!(parse_frame_type("dark frames"), Some(FrameType::Dark));
+        assert_eq!(parse_frame_type("Master Dark"), Some(FrameType::Dark));
+    }
+
+    #[test]
+    fn parse_frame_type_bias_and_offset() {
+        assert_eq!(parse_frame_type("BIAS"), Some(FrameType::Bias));
+        assert_eq!(parse_frame_type("Bias Frame"), Some(FrameType::Bias));
+        assert_eq!(parse_frame_type("OFFSET"), Some(FrameType::Bias));
+        assert_eq!(parse_frame_type("Offset Frame"), Some(FrameType::Bias));
+    }
+
+    #[test]
+    fn parse_frame_type_flat_variants() {
+        assert_eq!(parse_frame_type("FLAT"), Some(FrameType::Flat));
+        assert_eq!(parse_frame_type("Flat Frame"), Some(FrameType::Flat));
+        assert_eq!(parse_frame_type("Master Flat"), Some(FrameType::Flat));
+    }
+
+    #[test]
+    fn parse_frame_type_dark_flat() {
+        assert_eq!(parse_frame_type("Dark Flat"), Some(FrameType::DarkFlat));
+        assert_eq!(parse_frame_type("darkflat"), Some(FrameType::DarkFlat));
+        assert_eq!(parse_frame_type("DarkFlat Frame"), Some(FrameType::DarkFlat));
+    }
+
+    #[test]
+    fn parse_frame_type_light_variants() {
+        assert_eq!(parse_frame_type("Light Frame"), Some(FrameType::Light));
+        assert_eq!(parse_frame_type("LIGHT"), Some(FrameType::Light));
+        assert_eq!(parse_frame_type("science"), Some(FrameType::Light));
+    }
+
+    #[test]
+    fn parse_frame_type_unknown_returns_none() {
+        assert_eq!(parse_frame_type(""), None);
+        assert_eq!(parse_frame_type("UNKNOWN"), None);
+    }
+
+    #[test]
+    fn path_looks_like_master_positive() {
+        assert!(path_looks_like_master("masterDark_300s.xisf", "masters/"));
+        assert!(path_looks_like_master("dark_stacked.fit", "calibration/"));
+        assert!(path_looks_like_master("dark.fit", "masters/masterDarks/"));
+        assert!(path_looks_like_master("dark_Ha_stacked.xisf", ""));
+    }
+
+    #[test]
+    fn path_looks_like_master_negative() {
+        assert!(!path_looks_like_master("dark_001.fit", "calibration/darks/"));
+        assert!(!path_looks_like_master("light_001.fits", "lights/"));
+    }
+}

--- a/crates/calibration/master-detect/src/pixinsight.rs
+++ b/crates/calibration/master-detect/src/pixinsight.rs
@@ -1,0 +1,161 @@
+//! PixInsight / WBPP-specific calibration master detector (spec 040, FR-002).
+//!
+//! # PixInsight / WBPP master heuristics
+//!
+//! WBPP writes the word "master" **into** the `IMAGETYP` keyword value:
+//!   - `IMAGETYP = "Master Dark"`
+//!   - `IMAGETYP = "Master Bias"`
+//!   - `IMAGETYP = "Master Flat"`
+//!
+//! It also stores masters in paths like `masterDarks/masterDark.xisf`.
+//!
+//! Detection priority (any one is sufficient for `is_master=true`):
+//! 1. `IMAGETYP` (lowercased) contains `"master"`.
+//! 2. File name or relative path contains `"master"` or `"_stacked"`.
+//!
+//! The base frame type is determined by stripping "master" from `IMAGETYP`
+//! before parsing, so `"Master Dark"` → `"Dark"` → `FrameType::Dark`.
+//!
+//! If `IMAGETYP` is absent but the path strongly suggests a master
+//! (contains "master"), this detector still returns a result — but only if
+//! the path itself reveals the frame type (e.g. `"masterDarks/"`). In
+//! practice a PixInsight XISF will always carry `IMAGETYP`; the path fallback
+//! is a safety net for edge cases.
+
+use crate::{
+    parse_frame_type, path_looks_like_master, DetectInput, MasterDetection, MasterDetector,
+};
+
+/// Detector for PixInsight / WBPP-created calibration masters.
+pub struct PixInsightDetector;
+
+impl MasterDetector for PixInsightDetector {
+    fn id(&self) -> &'static str {
+        "pixinsight"
+    }
+
+    fn detect(&self, input: &DetectInput<'_>) -> Option<MasterDetection> {
+        let imagetyp_lc = input.imagetyp.map(|s| s.to_ascii_lowercase());
+
+        // Determine whether the IMAGETYP itself signals a master.
+        let imagetyp_has_master = imagetyp_lc.as_deref().is_some_and(|s| s.contains("master"));
+
+        // Determine whether the path signals a master (fallback).
+        let path_has_master = path_looks_like_master(input.file_name, input.rel_path);
+
+        let is_master = imagetyp_has_master || path_has_master;
+
+        // Determine base frame type.
+        // Prefer IMAGETYP (strip "master" before parsing). Fall back to path
+        // heuristics only when IMAGETYP is absent.
+        let frame_type = if let Some(raw) = input.imagetyp {
+            parse_frame_type(raw)?
+        } else {
+            // No IMAGETYP: try to infer frame type from the path.
+            // Only do this when the path also signals a master; otherwise there
+            // is not enough evidence for PixInsight-specific detection.
+            if !path_has_master {
+                return None;
+            }
+            infer_frame_type_from_path(input.file_name, input.rel_path)?
+        };
+
+        Some(MasterDetection { frame_type, is_master, detector: self.id() })
+    }
+}
+
+/// Try to infer a frame type from the file name or path when IMAGETYP is absent.
+///
+/// Looks for type keywords in the lowercased path/name.
+fn infer_frame_type_from_path(file_name: &str, rel_path: &str) -> Option<metadata_core::FrameType> {
+    let combined = format!("{} {}", file_name.to_ascii_lowercase(), rel_path.to_ascii_lowercase());
+    // Reuse parse_frame_type; strip "master" first.
+    let without_master = combined.replace("master", "");
+    parse_frame_type(&without_master)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metadata_core::FrameType;
+
+    fn input<'a>(
+        imagetyp: Option<&'a str>,
+        stack_count: Option<u32>,
+        file_name: &'a str,
+        rel_path: &'a str,
+    ) -> DetectInput<'a> {
+        DetectInput { imagetyp, stack_count, file_name, rel_path }
+    }
+
+    // ── Positive cases ────────────────────────────────────────────────────────
+
+    /// PixInsight XISF master: IMAGETYP="Master Dark" → Dark + is_master=true (SC-001)
+    #[test]
+    fn pixinsight_xisf_master_dark() {
+        let inp = input(Some("Master Dark"), None, "masterDark.xisf", "masterDarks/");
+        let result = PixInsightDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(result.is_master);
+        assert_eq!(result.detector, "pixinsight");
+    }
+
+    /// PixInsight XISF master: IMAGETYP="Master Bias" → Bias + is_master=true
+    #[test]
+    fn pixinsight_xisf_master_bias() {
+        let inp = input(Some("Master Bias"), None, "masterBias.xisf", "masterBias/");
+        let result = PixInsightDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Bias);
+        assert!(result.is_master);
+    }
+
+    /// PixInsight XISF master: IMAGETYP="Master Flat" → Flat + is_master=true
+    #[test]
+    fn pixinsight_xisf_master_flat() {
+        let inp = input(Some("Master Flat"), None, "masterFlat_Ha.xisf", "masterFlats/");
+        let result = PixInsightDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Flat);
+        assert!(result.is_master);
+    }
+
+    /// Name fallback: no "master" IMAGETYP but name contains "master" → is_master=true (SC-001 case 3)
+    #[test]
+    fn pixinsight_name_fallback_flat_ha() {
+        // IMAGETYP is a plain "FLAT" (no "master" in it); name has "master"
+        let inp = input(Some("FLAT"), None, "masterFlat_Ha.xisf", "calibration/");
+        let result = PixInsightDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Flat);
+        assert!(result.is_master, "file name with 'master' prefix must set is_master");
+        assert_eq!(result.detector, "pixinsight");
+    }
+
+    /// _stacked in name triggers is_master even with plain IMAGETYP.
+    #[test]
+    fn pixinsight_stacked_suffix_in_name() {
+        let inp = input(Some("DARK"), None, "dark_Ha_stacked.xisf", "calibration/");
+        let result = PixInsightDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(result.is_master);
+    }
+
+    // ── Negative cases ────────────────────────────────────────────────────────
+
+    /// Plain IMAGETYP="DARK", no master signals → is_master=false (SC-001 case 4).
+    #[test]
+    fn pixinsight_plain_dark_sub_is_not_master() {
+        let inp = input(Some("DARK"), None, "dark_001.fits", "calibration/darks/");
+        let result = PixInsightDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(!result.is_master, "a plain sub must not be flagged as master");
+        assert_eq!(result.detector, "pixinsight");
+    }
+
+    /// No IMAGETYP and no master in path → None.
+    #[test]
+    fn pixinsight_no_imagetyp_no_master_path_returns_none() {
+        let inp = input(None, None, "dark_001.fits", "calibration/darks/");
+        assert!(PixInsightDetector.detect(&inp).is_none());
+    }
+}

--- a/crates/calibration/master-detect/src/siril.rs
+++ b/crates/calibration/master-detect/src/siril.rs
@@ -1,0 +1,133 @@
+//! Siril-specific calibration master detector (spec 040, FR-002).
+//!
+//! # Siril master heuristics
+//!
+//! Siril keeps the **base** `IMAGETYP` on masters unchanged (e.g. `"DARK"`,
+//! `"FLAT"`). It marks masters through two orthogonal signals:
+//!
+//! - **`STACKCNT` > 1**: the number of frames combined (a value > 1 is
+//!   definitive evidence of stacking). `NCOMBINE` is accepted as a fallback.
+//! - **`_stacked` in the file name or path**: Siril appends `_stacked` to
+//!   exported master files.
+//! - **`master` in the file name or path**: a secondary naming convention.
+//!
+//! The `IMAGETYP` must still be present and parseable; if it is absent the
+//! detector returns `None` and the next detector in the registry is tried.
+
+use crate::{
+    parse_frame_type, path_looks_like_master, DetectInput, MasterDetection, MasterDetector,
+};
+
+/// Detector for Siril-created calibration masters.
+pub struct SirilDetector;
+
+impl MasterDetector for SirilDetector {
+    fn id(&self) -> &'static str {
+        "siril"
+    }
+
+    fn detect(&self, input: &DetectInput<'_>) -> Option<MasterDetection> {
+        // Siril always keeps the plain base IMAGETYP; without it we cannot
+        // determine the frame type.
+        let imagetyp = input.imagetyp?;
+        let frame_type = parse_frame_type(imagetyp)?;
+
+        // Master detection: STACKCNT > 1 OR path / name contains _stacked / master.
+        let is_master = input.stack_count.is_some_and(|n| n > 1)
+            || path_looks_like_master(input.file_name, input.rel_path);
+
+        Some(MasterDetection { frame_type, is_master, detector: self.id() })
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use metadata_core::FrameType;
+
+    fn input<'a>(
+        imagetyp: Option<&'a str>,
+        stack_count: Option<u32>,
+        file_name: &'a str,
+        rel_path: &'a str,
+    ) -> DetectInput<'a> {
+        DetectInput { imagetyp, stack_count, file_name, rel_path }
+    }
+
+    // ── Positive cases ────────────────────────────────────────────────────────
+
+    /// Siril FITS master: IMAGETYP="DARK" + STACKCNT=30 → Dark + is_master=true
+    #[test]
+    fn siril_fits_master_dark_by_stackcnt() {
+        let inp = input(Some("DARK"), Some(30), "dark_master.fit", "calibration/darks/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(result.is_master);
+        assert_eq!(result.detector, "siril");
+    }
+
+    /// Siril FITS master: IMAGETYP="FLAT" + STACKCNT=20 → Flat + is_master=true
+    #[test]
+    fn siril_fits_master_flat_by_stackcnt() {
+        let inp = input(Some("FLAT"), Some(20), "flat_master.fit", "calibration/flats/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Flat);
+        assert!(result.is_master);
+    }
+
+    /// Siril master via _stacked suffix, no STACKCNT.
+    #[test]
+    fn siril_master_by_stacked_suffix() {
+        let inp = input(Some("DARK"), None, "dark_stacked.fit", "calibration/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(result.is_master);
+    }
+
+    /// Siril master via "master" in file name, no STACKCNT.
+    #[test]
+    fn siril_master_by_name_prefix() {
+        let inp = input(Some("BIAS"), None, "masterBias.fit", "calibration/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Bias);
+        assert!(result.is_master);
+    }
+
+    /// IMAGETYP="OFFSET" maps to Bias.
+    #[test]
+    fn siril_offset_maps_to_bias() {
+        let inp = input(Some("OFFSET"), Some(50), "offset_stacked.fit", "calibration/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Bias);
+        assert!(result.is_master);
+    }
+
+    // ── Negative cases ────────────────────────────────────────────────────────
+
+    /// Single dark sub: IMAGETYP="DARK", no stack count, no master name → is_master=false.
+    #[test]
+    fn siril_single_dark_sub_is_not_master() {
+        let inp = input(Some("DARK"), None, "dark_001.fit", "calibration/darks/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(!result.is_master, "a single sub with STACKCNT absent must not be a master");
+        assert_eq!(result.detector, "siril");
+    }
+
+    /// STACKCNT=1 (exactly 1 combined frame) is not a master (strict > 1).
+    #[test]
+    fn siril_stackcnt_one_is_not_master() {
+        let inp = input(Some("DARK"), Some(1), "dark_001.fit", "calibration/darks/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert!(!result.is_master);
+    }
+
+    /// Missing IMAGETYP → None.
+    #[test]
+    fn siril_no_imagetyp_returns_none() {
+        let inp = input(None, Some(30), "dark_stacked.fit", "calibration/");
+        assert!(SirilDetector.detect(&inp).is_none());
+    }
+}

--- a/crates/metadata/core/src/lib.rs
+++ b/crates/metadata/core/src/lib.rs
@@ -232,6 +232,11 @@ pub struct RawFileMetadata {
     pub telescop: Option<String>,
     /// `DATE-OBS` (ISO 8601 string or FITS-style `YYYY-MM-DDTHH:MM:SS`).
     pub date_obs: Option<String>,
+    /// Integration count from `STACKCNT` (preferred) or `NCOMBINE`.
+    ///
+    /// Present only in stacked/master files that carry this keyword.
+    /// Used by the master-detect crate to identify stacked calibration frames.
+    pub stack_count: Option<u32>,
 }
 
 // ── MetadataExtractor ─────────────────────────────────────────────────────────

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -129,6 +129,15 @@ fn parse_cards(cards: &[[u8; CARD_SIZE]]) -> RawFileMetadata {
             "INSTRUME" => meta.instrume = extract_string_value(card),
             "TELESCOP" => meta.telescop = extract_string_value(card),
             "DATE-OBS" => meta.date_obs = extract_string_value(card),
+            // Stack/integration count: STACKCNT (preferred) or NCOMBINE fallback.
+            "STACKCNT" => {
+                meta.stack_count =
+                    extract_numeric_string(card).and_then(|s| s.trim().parse::<u32>().ok());
+            }
+            "NCOMBINE" if meta.stack_count.is_none() => {
+                meta.stack_count =
+                    extract_numeric_string(card).and_then(|s| s.trim().parse::<u32>().ok());
+            }
             _ => {}
         }
     }

--- a/crates/metadata/xisf/src/lib.rs
+++ b/crates/metadata/xisf/src/lib.rs
@@ -190,6 +190,13 @@ fn apply_fits_keyword(meta: &mut RawFileMetadata, keyword: &str, raw_value: &str
         "INSTRUME" => meta.instrume = non_empty(value),
         "TELESCOP" => meta.telescop = non_empty(value),
         "DATE-OBS" => meta.date_obs = non_empty(value),
+        // Stack/integration count: STACKCNT (preferred) or NCOMBINE fallback.
+        "STACKCNT" => {
+            meta.stack_count = non_empty(value).and_then(|s| s.trim().parse::<u32>().ok());
+        }
+        "NCOMBINE" if meta.stack_count.is_none() => {
+            meta.stack_count = non_empty(value).and_then(|s| s.trim().parse::<u32>().ok());
+        }
         _ => {}
     }
 }

--- a/crates/persistence/db/migrations/0042_inbox_is_master.sql
+++ b/crates/persistence/db/migrations/0042_inbox_is_master.sql
@@ -1,0 +1,15 @@
+-- Migration 0042: add is_master + master_detector to inbox_classification_evidence
+--
+-- Spec 040 (calibration master detection) introduces a per-file flag that
+-- distinguishes stacked masters from raw sub-frames.
+--
+-- is_master        — 0 = sub-frame, 1 = detected calibration master.
+-- master_detector  — provenance string from the detector (e.g. "siril",
+--                    "pixinsight"). NULL when is_master = 0.
+
+ALTER TABLE inbox_classification_evidence
+    ADD COLUMN is_master       INTEGER NOT NULL DEFAULT 0
+        CHECK (is_master IN (0, 1));
+
+ALTER TABLE inbox_classification_evidence
+    ADD COLUMN master_detector TEXT;

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -89,6 +89,10 @@ pub struct InsertEvidence<'a> {
     pub raw_value: Option<&'a str>,
     pub unclassified: bool,
     pub manual_override: Option<&'a str>,
+    /// Whether this file was detected as a calibration master (spec 040).
+    pub is_master: bool,
+    /// Provenance string from the detector, e.g. `"siril"` or `"pixinsight"`.
+    pub master_detector: Option<&'a str>,
 }
 
 /// Flat row from `inbox_classification_breakdown`.
@@ -254,8 +258,8 @@ pub async fn insert_evidence(pool: &SqlitePool, ev: &InsertEvidence<'_>) -> DbRe
     sqlx::query(
         "INSERT INTO inbox_classification_evidence
             (id, inbox_item_id, relative_file_path, frame_type, evidence_source,
-             raw_value, unclassified, manual_override)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+             raw_value, unclassified, manual_override, is_master, master_detector)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
     )
     .bind(ev.id)
     .bind(ev.inbox_item_id)
@@ -265,6 +269,8 @@ pub async fn insert_evidence(pool: &SqlitePool, ev: &InsertEvidence<'_>) -> DbRe
     .bind(ev.raw_value)
     .bind(i64::from(ev.unclassified))
     .bind(ev.manual_override)
+    .bind(i64::from(ev.is_master))
+    .bind(ev.master_detector)
     .execute(pool)
     .await?;
     Ok(())
@@ -612,6 +618,8 @@ mod tests {
             raw_value: Some("Light Frame"),
             unclassified: false,
             manual_override: None,
+            is_master: false,
+            master_detector: None,
         };
         insert_evidence(db.pool(), &ev).await.unwrap();
 
@@ -635,6 +643,8 @@ mod tests {
             raw_value: None,
             unclassified: true,
             manual_override: None,
+            is_master: false,
+            master_detector: None,
         };
         insert_evidence(db.pool(), &ev).await.unwrap();
 


### PR DESCRIPTION
## Summary

Implements **Phase 1** of spec 040 (calibration master detection): FR-001..FR-004, US1. Phase 2 (per-master grouping, inbox display, Calibration page) is NOT in this PR.

### New crate: `crates/calibration/master-detect`

Narrow dep boundary: `metadata_core` only — no domain/persistence/UI.

Public API:
- `DetectInput<'a>` — imagetyp, stack_count, file_name, rel_path
- `MasterDetection` — frame_type, is_master, detector (provenance)
- `MasterDetector` trait — `id()` + `detect()`
- `detectors()` — ordered registry (PixInsight first, Siril second)
- `detect_master()` — first-wins dispatcher
- `parse_frame_type()` — shared keyword→FrameType parser
- `path_looks_like_master()` — shared name/path heuristic

**SirilDetector** (`id = "siril"`):
- Base type from `IMAGETYP` (must be present)
- `is_master` = `STACKCNT > 1` OR name/path contains `_stacked` or `master`

**PixInsightDetector** (`id = "pixinsight"`):
- Base type from `IMAGETYP` with "master" stripped before parsing
- `is_master` = `IMAGETYP` contains "master" OR name/path contains `master`/`_stacked`

23 unit tests (table-driven, per-detector): XISF PixInsight master (`IMAGETYP="Master Dark"` → Dark+master), Siril FITS master (STACKCNT=30 → Dark+master), name-fallback (`masterFlat_Ha.xisf` → Flat+master), OFFSET→Bias, DarkFlat, and negatives (single sub, STACKCNT=1, missing IMAGETYP).

### STACKCNT/NCOMBINE extraction

Both `metadata/fits` and `metadata/xisf` now read `STACKCNT` (preferred) and `NCOMBINE` (fallback) into `RawFileMetadata.stack_count: Option<u32>`.

### is_master flows into classify

`inbox/classify.rs` calls `detect_master` first per file. When it matches, its `frame_type` and `is_master` are used directly and written to `InsertEvidence`. Non-master frames fall through to the existing `v1_normalization_table` path unchanged.

### DB migration 0042

`inbox_classification_evidence` gains two columns:
- `is_master INTEGER NOT NULL DEFAULT 0`
- `master_detector TEXT` (nullable, holds provenance string)

## Test plan

- [ ] `cargo test -p calibration_master_detect` — 23 tests, all pass
- [ ] `cargo test -p metadata_core -p metadata_fits -p metadata_xisf` — 35 pass
- [ ] `cargo test -p persistence_db` — 134 pass
- [ ] `cargo test -p app_core` — 354 pass
- [ ] `cargo check --workspace` — clean
- [ ] `cargo fmt --all` — no diffs
- [ ] `just typecheck` — clean
- [ ] `pnpm vitest run` — 626 pass, 0 fail

All gates confirmed green before push.