### PR TITLE
feat(spec 040 P2b): register confirmed masters to Calibration page; rename lane→file types

### DIFF
--- a/apps/desktop/src-tauri/src/commands/inbox.rs
+++ b/apps/desktop/src-tauri/src/commands/inbox.rs
@@ -93,6 +93,7 @@ pub async fn inbox_confirm(
         plan_id: resp.plan_id,
         plan_state: resp.plan_state,
         items_total: u32::try_from(resp.items_total).unwrap_or(u32::MAX),
+        registered_as_master: resp.registered_as_master,
     })
 }
 

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -542,6 +542,7 @@ export async function mockInvoke<T>(
         planId: `plan-${Date.now()}`,
         planState: 'ready_for_review',
         itemsTotal: 18,
+        registeredAsMaster: false,
       } as T;
     }
     case 'inbox_reclassify': {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -2287,9 +2287,18 @@ export type InboxConfirmRequest_Serialize = {
 /**  Response from `inbox.confirm`. */
 export type InboxConfirmResponse = {
 	planId: string,
-	/**  Always `"ready_for_review"` for plans created here. */
+	/**
+	 *  Always `"ready_for_review"` for plans created here; empty string for
+	 *  master-registration responses.
+	 */
 	planState: string,
 	itemsTotal: number,
+	/**
+	 *  True when the item was a detected calibration master that was registered
+	 *  directly to `calibration_session` + `calibration_fingerprint` (Path 1 —
+	 *  no file move).  `plan_id` is an empty string in this case.
+	 */
+	registeredAsMaster: boolean,
 };
 
 /**  A file entry discovered during an inbox scan. */

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -1,7 +1,7 @@
 /**
  * InboxList — left sidebar listing scanned inbox folders.
  *
- * Each row shows the relative path, lane pill (fits/video), classification
+ * Each row shows the relative path, file type pill (fits/video), classification
  * state, and a conflict/needs-review indicator.
  */
 
@@ -105,9 +105,9 @@ export function InboxList({
               const v = e.target.value as FilterType;
               onFilterTypeChange(v === 'all' ? undefined : v);
             }}
-            aria-label="Filter lane"
+            aria-label="Filter file type"
           >
-            <option value="all">All lanes</option>
+            <option value="all">All file types</option>
             <option value="fits">FITS</option>
             <option value="video">Video</option>
           </select>

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -90,15 +90,23 @@ export function InboxPage() {
         rootAbsolutePath: selectedRootPath,
         destructiveDestination,
       });
-      addToast({
-        message: `Plan created (${result.itemsTotal} items). Review before applying.`,
-        variant: 'info',
-        action: {
-          label: 'View plan',
-          onClick: () =>
-            navigate({ to: '/archive', search: { selected: undefined } as never }),
-        },
-      });
+      if (result.registeredAsMaster) {
+        // Master path (Path 1): registered directly, no plan to review.
+        addToast({
+          message: 'Registered as calibration master.',
+          variant: 'info',
+        });
+      } else {
+        addToast({
+          message: `Plan created (${result.itemsTotal} items). Review before applying.`,
+          variant: 'info',
+          action: {
+            label: 'View plan',
+            onClick: () =>
+              navigate({ to: '/archive', search: { selected: undefined } as never }),
+          },
+        });
+      }
       // Refresh so confirmed item drops out (FR-003).
       refreshList();
     } catch (e) {

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
@@ -384,6 +384,7 @@ describe('Confirm payload and toast', () => {
       planId: 'plan-abc',
       planState: 'ready_for_review',
       itemsTotal: 18,
+      registeredAsMaster: false,
     });
 
     const onConfirm = async () => {
@@ -427,6 +428,7 @@ describe('Confirm payload and toast', () => {
       planId: 'plan-def',
       planState: 'ready_for_review',
       itemsTotal: 18,
+      registeredAsMaster: false,
     });
 
     const onConfirm = async () => {
@@ -462,6 +464,62 @@ describe('Confirm payload and toast', () => {
         action: 'confirm',
         contentSignature: 'sig-def',
       }),
+    );
+  });
+
+  it('shows "Registered as calibration master." toast when registeredAsMaster is true', async () => {
+    mockInboxConfirm.mockResolvedValue({
+      planId: '',
+      planState: '',
+      itemsTotal: 1,
+      registeredAsMaster: true,
+    });
+
+    // Simulate what InboxPage.handleConfirm does on the master path.
+    const onConfirm = async () => {
+      const result = await mockInboxConfirm({
+        inboxItemId: 'item-master-001',
+        action: 'confirm',
+        contentSignature: singleTypeClassification.contentSignature,
+        rootAbsolutePath: '/astro/inbox',
+        destructiveDestination: null,
+      });
+      if (result.registeredAsMaster) {
+        mockAddToast({ message: 'Registered as calibration master.', variant: 'info' });
+      } else {
+        mockAddToast({
+          message: `Plan created (${result.itemsTotal} items). Review before applying.`,
+          variant: 'info',
+        });
+      }
+    };
+
+    render(
+      <ActionSidebar
+        hasSelection
+        classification={singleTypeClassification}
+        hasOpenPlan={false}
+        confirmLoading={false}
+        canConfirm
+        destructiveDestination="archive"
+        onDestructiveDestinationChange={vi.fn()}
+        onConfirm={onConfirm}
+        onOpenExistingPlan={vi.fn()}
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('inbox-confirm-btn'));
+    });
+
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.objectContaining({
+        message: 'Registered as calibration master.',
+        variant: 'info',
+      }),
+    );
+    expect(mockAddToast).not.toHaveBeenCalledWith(
+      expect.objectContaining({ message: expect.stringContaining('Plan created') }),
     );
   });
 });

--- a/crates/app/core/src/inbox/confirm.rs
+++ b/crates/app/core/src/inbox/confirm.rs
@@ -48,6 +48,10 @@ pub struct ConfirmResponse {
     pub plan_id: String,
     pub plan_state: String,
     pub items_total: usize,
+    /// True when the inbox item was a detected calibration master and was
+    /// registered directly to `calibration_session` + `calibration_fingerprint`
+    /// (Path 1 — no file move).  `plan_id` is empty string in this case.
+    pub registered_as_master: bool,
 }
 
 // ── confirm ───────────────────────────────────────────────────────────────────
@@ -76,7 +80,82 @@ pub async fn confirm(
         )
     })?;
 
-    // 2. Dedupe open plan (Ref: E1)
+    // 2. Fast path: detected calibration master (spec 040 US3, Path 1).
+    //
+    // Masters are already at their final path — register them directly to the
+    // calibration tables and resolve the inbox item as `resolved` without
+    // creating a filesystem plan.
+    if item.is_master_item != 0 {
+        // TOCTOU guard: validate signature even for masters.
+        if item.content_signature.as_deref() != Some(&req.content_signature) {
+            return Err(ContractError::new(
+                "classification.stale",
+                "Folder has changed since classification. Re-classify before confirming.",
+                ErrorSeverity::Blocking,
+                false,
+            ));
+        }
+
+        let frame_type_str = item.master_frame_type.as_deref().unwrap_or("dark");
+        let cal_kind = match frame_type_str {
+            "flat" => "flat",
+            "bias" => "bias",
+            _ => "dark",
+        };
+        let cal_type = match frame_type_str {
+            "flat" => "flat",
+            "bias" => "bias",
+            _ => "dark",
+        };
+
+        let session_id = Uuid::new_v4().to_string();
+        let session_key =
+            format!("{}-{}", cal_kind, item.master_frame_type.as_deref().unwrap_or("unknown"));
+
+        // Insert calibration_session.
+        sqlx::query(
+            "INSERT INTO calibration_session
+                (id, session_key, frame_ids, kind, state, created_at, source_inbox_item_id)
+             VALUES (?, ?, '[]', ?, 'confirmed', datetime('now'), ?)",
+        )
+        .bind(&session_id)
+        .bind(&session_key)
+        .bind(cal_kind)
+        .bind(&req.inbox_item_id)
+        .execute(pool)
+        .await
+        .map_err(|e| {
+            ContractError::new("internal.database", e.to_string(), ErrorSeverity::Fatal, true)
+        })?;
+
+        // Insert calibration_fingerprint (exposure, filter from master metadata).
+        sqlx::query(
+            "INSERT INTO calibration_fingerprint
+                (id, calibration_type, exposure_s, filter_name)
+             VALUES (?, ?, ?, ?)",
+        )
+        .bind(&session_id)
+        .bind(cal_type)
+        .bind(item.master_exposure_s)
+        .bind(item.master_filter.as_deref())
+        .execute(pool)
+        .await
+        .map_err(|e| {
+            ContractError::new("internal.database", e.to_string(), ErrorSeverity::Fatal, true)
+        })?;
+
+        // Mark inbox item as resolved (drops out of the unacknowledged list).
+        inbox_repo::update_inbox_item_state(pool, &req.inbox_item_id, "resolved").await.ok();
+
+        return Ok(ConfirmResponse {
+            plan_id: String::new(),
+            plan_state: String::new(),
+            items_total: 1,
+            registered_as_master: true,
+        });
+    }
+
+    // 3. Dedupe open plan (Ref: E1)
     if let Some(link) = inbox_repo::get_plan_link(pool, &req.inbox_item_id).await.unwrap_or(None) {
         return Err(ContractError::new(
             "inbox.has.open.plan",
@@ -86,7 +165,7 @@ pub async fn confirm(
         ));
     }
 
-    // 3. Load classification
+    // 4. Load classification
     let classification = inbox_repo::get_classification(pool, &req.inbox_item_id)
         .await
         .unwrap_or(None)
@@ -99,7 +178,7 @@ pub async fn confirm(
             )
         })?;
 
-    // 4. TOCTOU content_signature guard (Ref: A8)
+    // 5. TOCTOU content_signature guard (Ref: A8)
     if item.content_signature.as_deref() != Some(&req.content_signature) {
         return Err(ContractError::new(
             "classification.stale",
@@ -109,7 +188,7 @@ pub async fn confirm(
         ));
     }
 
-    // 5. Validate action / classification match
+    // 7. Validate action / classification match
     let valid = matches!(
         (req.action.as_str(), classification.result.as_str()),
         ("split", "mixed") | ("confirm", "single_type")
@@ -126,10 +205,10 @@ pub async fn confirm(
         ));
     }
 
-    // 6. Load the active Naming & Structure pattern from settings.
+    // 8. Load the active Naming & Structure pattern from settings.
     let active_pattern = load_active_pattern(pool).await?;
 
-    // 7. Enumerate files from evidence (Ref: A9) — NOT from file_count
+    // 9. Enumerate files from evidence (Ref: A9) — NOT from file_count
     let evidence_rows = inbox_repo::list_evidence(pool, &req.inbox_item_id).await.map_err(|e| {
         ContractError::new("internal.database", e.to_string(), ErrorSeverity::Fatal, true)
     })?;
@@ -190,7 +269,7 @@ pub async fn confirm(
         }
     }
 
-    // 9. Build the plan.
+    // 10. Build the plan.
     // A move-only split is non-destructive from the user perspective but the
     // plans table CHECK constraint only accepts 'archive' | 'os_trash'.
     // We default to 'archive' (app-managed archive) unless the caller specifies.
@@ -218,7 +297,7 @@ pub async fn confirm(
         ContractError::new("internal.database", e.to_string(), ErrorSeverity::Fatal, true)
     })?;
 
-    // 10. Insert plan items — one per classified file, with resolved destinations.
+    // 11. Insert plan items — one per classified file, with resolved destinations.
     let items_total = resolved_items.len();
     for (idx, (source_rel, dest_rel, item_name)) in resolved_items.iter().enumerate() {
         let item_id = Uuid::new_v4().to_string();
@@ -247,7 +326,7 @@ pub async fn confirm(
         })?;
     }
 
-    // 11. Transition plan to ready_for_review
+    // 12. Transition plan to ready_for_review
     sqlx::query("UPDATE plans SET state = 'ready_for_review' WHERE id = ?")
         .bind(&plan_id)
         .execute(pool)
@@ -256,14 +335,19 @@ pub async fn confirm(
             ContractError::new("internal.database", e.to_string(), ErrorSeverity::Fatal, true)
         })?;
 
-    // 12. Create plan link and update item state
+    // 13. Create plan link and update item state
     inbox_repo::insert_plan_link(pool, &req.inbox_item_id, &plan_id).await.map_err(|e| {
         ContractError::new("internal.database", e.to_string(), ErrorSeverity::Fatal, true)
     })?;
 
     inbox_repo::update_inbox_item_state(pool, &req.inbox_item_id, "plan_open").await.ok();
 
-    Ok(ConfirmResponse { plan_id, plan_state: "ready_for_review".to_owned(), items_total })
+    Ok(ConfirmResponse {
+        plan_id,
+        plan_state: "ready_for_review".to_owned(),
+        items_total,
+        registered_as_master: false,
+    })
 }
 
 // ── Helpers ───────────────────────────────────────────────────────────────────

--- a/crates/app/core/tests/confirm_master_integration.rs
+++ b/crates/app/core/tests/confirm_master_integration.rs
@@ -1,0 +1,306 @@
+//! Integration tests for spec 040 US3 — confirm a detected calibration master
+//! inbox item (Path 1: register directly, no file move).
+//!
+//! Tests that:
+//! 1. Confirming a master inbox item creates a `calibration_session` row and a
+//!    `calibration_fingerprint` row, marks the inbox item `resolved`, and
+//!    returns `registered_as_master = true` with an empty `plan_id`.
+//! 2. The registered master appears via `calibration.masters.list` (read from
+//!    `calibration_master_view`).
+//! 3. The inbox item is `resolved` and no longer appears in the unacknowledged
+//!    list.
+//! 4. A non-master inbox item still goes through the normal plan-creation path
+//!    (regression guard).
+
+use std::io::Write;
+use std::path::Path;
+
+use app_core::calibration::masters_list;
+use app_core::inbox::confirm::{confirm, ConfirmRequest};
+use persistence_db::repositories::inbox::{
+    self as inbox_repo, InsertEvidence, InsertInboxItem, UpsertClassification,
+};
+use persistence_db::Database;
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+async fn test_db() -> Database {
+    let db = Database::in_memory().await.unwrap();
+    db.migrate().await.unwrap();
+    db
+}
+
+/// Write a minimal FITS file (single 2880-byte block).
+fn write_fits(dir: &Path, name: &str, imagetyp: &str) {
+    let mut block = vec![b' '; 2880];
+    let card = format!("IMAGETYP= '{imagetyp:<8}'");
+    let bytes = card.as_bytes();
+    block[..bytes.len().min(80)].copy_from_slice(&bytes[..bytes.len().min(80)]);
+    block[80..83].copy_from_slice(b"END");
+    let path = dir.join(name);
+    let mut f = std::fs::File::create(path).unwrap();
+    f.write_all(&block).unwrap();
+}
+
+/// Insert a master inbox item row directly (simulating what scan does).
+async fn insert_master_inbox_item(
+    db: &Database,
+    item_id: &str,
+    relative_path: &str,
+    master_frame_type: &str,
+    master_filter: Option<&str>,
+    master_exposure_s: Option<f64>,
+    sig: &str,
+) {
+    let now = "2026-06-18T12:00:00Z";
+    sqlx::query(
+        "INSERT INTO inbox_items
+            (id, root_id, relative_path, file_count, discovered_at, last_scanned_at,
+             content_signature, state, lane, format, is_master_item,
+             master_frame_type, master_filter, master_exposure_s)
+         VALUES (?, 'root-1', ?, 1, ?, ?, ?, 'pending_classification',
+                 'fits', 'fits', 1, ?, ?, ?)",
+    )
+    .bind(item_id)
+    .bind(relative_path)
+    .bind(now)
+    .bind(now)
+    .bind(sig)
+    .bind(master_frame_type)
+    .bind(master_filter)
+    .bind(master_exposure_s)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+/// T040-US3-1: confirming a master item registers it to calibration tables.
+#[tokio::test]
+async fn confirm_master_registers_to_calibration_and_resolves_inbox_item() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_fits(tmp.path(), "masterDark_300s.fits", "DARK");
+
+    let db = test_db().await;
+    let item_id = "master-item-001";
+    let sig = "sig-master-001";
+
+    insert_master_inbox_item(&db, item_id, "masterDark_300s.fits", "dark", None, Some(300.0), sig)
+        .await;
+
+    let resp = confirm(
+        db.pool(),
+        ConfirmRequest {
+            inbox_item_id: item_id.to_owned(),
+            action: "confirm".to_owned(),
+            content_signature: sig.to_owned(),
+            destructive_destination: None,
+            root_absolute_path: tmp.path().to_owned(),
+        },
+    )
+    .await
+    .unwrap();
+
+    // Response must say registered_as_master = true, plan_id empty.
+    assert!(resp.registered_as_master, "expected registered_as_master = true");
+    assert!(resp.plan_id.is_empty(), "plan_id must be empty for master path");
+    assert_eq!(resp.items_total, 1);
+
+    // A calibration_session must exist.
+    let session_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM calibration_session WHERE kind = 'dark'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(session_count, 1, "one calibration_session must be created");
+
+    // A calibration_fingerprint must exist.
+    let fp: Option<(String, Option<f64>)> =
+        sqlx::query_as("SELECT calibration_type, exposure_s FROM calibration_fingerprint LIMIT 1")
+            .fetch_optional(db.pool())
+            .await
+            .unwrap();
+    let (cal_type, exposure_s) = fp.expect("calibration_fingerprint must exist");
+    assert_eq!(cal_type, "dark");
+    assert!((exposure_s.unwrap_or(0.0) - 300.0).abs() < f64::EPSILON);
+
+    // source_inbox_item_id must link back to the inbox item.
+    let source_id: Option<String> =
+        sqlx::query_scalar("SELECT source_inbox_item_id FROM calibration_session LIMIT 1")
+            .fetch_optional(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(source_id.as_deref(), Some(item_id));
+
+    // Inbox item must be resolved.
+    let state: String = sqlx::query_scalar("SELECT state FROM inbox_items WHERE id = ?")
+        .bind(item_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(state, "resolved", "inbox item must be resolved after master confirm");
+}
+
+/// T040-US3-2: masters_list returns the registered master.
+#[tokio::test]
+async fn masters_list_returns_confirmed_master() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_fits(tmp.path(), "masterFlat_Ha.fits", "FLAT");
+
+    let db = test_db().await;
+    let item_id = "master-item-flat";
+    let sig = "sig-master-flat";
+
+    insert_master_inbox_item(
+        &db,
+        item_id,
+        "masterFlat_Ha.fits",
+        "flat",
+        Some("Ha"),
+        Some(2.0),
+        sig,
+    )
+    .await;
+
+    confirm(
+        db.pool(),
+        ConfirmRequest {
+            inbox_item_id: item_id.to_owned(),
+            action: "confirm".to_owned(),
+            content_signature: sig.to_owned(),
+            destructive_destination: None,
+            root_absolute_path: tmp.path().to_owned(),
+        },
+    )
+    .await
+    .unwrap();
+
+    let masters = masters_list(db.pool()).await.unwrap();
+    assert_eq!(masters.len(), 1, "one master must appear in calibration_masters_list");
+    assert_eq!(
+        masters[0].kind,
+        contracts_core::calibration::CalibrationKind::Flat,
+        "kind must be flat"
+    );
+    assert_eq!(masters[0].fingerprint.filter.as_deref(), Some("Ha"), "filter must be Ha");
+    assert!((masters[0].fingerprint.exposure_s - 2.0).abs() < f64::EPSILON);
+}
+
+/// T040-US3-3: resolved item disappears from the unacknowledged list.
+#[tokio::test]
+async fn resolved_master_absent_from_unacknowledged_list() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_fits(tmp.path(), "masterBias.fits", "BIAS");
+
+    let db = test_db().await;
+    let item_id = "master-item-bias";
+    let sig = "sig-master-bias";
+
+    // We also need a registered_source for list_unacknowledged_across_roots to work.
+    sqlx::query(
+        "INSERT INTO registered_sources (id, kind, path, kind_subtype, scan_depth, created_at, created_via)
+         VALUES ('root-1', 'inbox', '/astro', NULL, 'recursive', '2026-01-01T00:00:00Z', 'first_run')",
+    )
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    insert_master_inbox_item(&db, item_id, "masterBias.fits", "bias", None, None, sig).await;
+
+    // Before confirm: item must appear in the unacknowledged list.
+    let before = inbox_repo::list_unacknowledged_across_roots(db.pool(), 100).await.unwrap();
+    assert_eq!(before.len(), 1, "one unacknowledged item before confirm");
+
+    confirm(
+        db.pool(),
+        ConfirmRequest {
+            inbox_item_id: item_id.to_owned(),
+            action: "confirm".to_owned(),
+            content_signature: sig.to_owned(),
+            destructive_destination: None,
+            root_absolute_path: tmp.path().to_owned(),
+        },
+    )
+    .await
+    .unwrap();
+
+    // After confirm: item must be gone from the unacknowledged list.
+    let after = inbox_repo::list_unacknowledged_across_roots(db.pool(), 100).await.unwrap();
+    assert!(after.is_empty(), "resolved master must not appear in unacknowledged list");
+}
+
+/// T040-US3-4: non-master items still go through the plan path (regression guard).
+#[tokio::test]
+async fn non_master_item_still_creates_plan() {
+    let tmp = tempfile::tempdir().unwrap();
+    // Write a light frame FITS
+    write_fits(tmp.path(), "light_001.fits", "Light Frame");
+
+    let db = test_db().await;
+    let item_id = "non-master-item";
+    let sig = "sig-non-master";
+
+    inbox_repo::insert_inbox_item(
+        db.pool(),
+        &InsertInboxItem {
+            id: item_id,
+            root_id: "root-1",
+            relative_path: "",
+            file_count: 1,
+            content_signature: Some(sig),
+            lane: "fits",
+        },
+    )
+    .await
+    .unwrap();
+
+    inbox_repo::upsert_classification(
+        db.pool(),
+        &UpsertClassification {
+            inbox_item_id: item_id,
+            result: "single_type",
+            frame_type: Some("light"),
+            content_signature: sig,
+            unclassified_file_count: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    inbox_repo::insert_evidence(
+        db.pool(),
+        &InsertEvidence {
+            id: "ev-001",
+            inbox_item_id: item_id,
+            relative_file_path: "light_001.fits",
+            frame_type: Some("light"),
+            evidence_source: "imagetyp_header",
+            raw_value: Some("Light Frame"),
+            unclassified: false,
+            manual_override: None,
+            is_master: false,
+            master_detector: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let resp = confirm(
+        db.pool(),
+        ConfirmRequest {
+            inbox_item_id: item_id.to_owned(),
+            action: "confirm".to_owned(),
+            content_signature: sig.to_owned(),
+            destructive_destination: None,
+            root_absolute_path: tmp.path().to_owned(),
+        },
+    )
+    .await
+    .unwrap();
+
+    assert!(!resp.registered_as_master, "non-master must not set registered_as_master");
+    assert!(!resp.plan_id.is_empty(), "non-master must produce a plan_id");
+    assert_eq!(resp.plan_state, "ready_for_review");
+    assert_eq!(resp.items_total, 1);
+}

--- a/crates/contracts/core/src/inbox.rs
+++ b/crates/contracts/core/src/inbox.rs
@@ -97,9 +97,14 @@ pub struct InboxConfirmRequest {
 #[serde(rename_all = "camelCase")]
 pub struct InboxConfirmResponse {
     pub plan_id: String,
-    /// Always `"ready_for_review"` for plans created here.
+    /// Always `"ready_for_review"` for plans created here; empty string for
+    /// master-registration responses.
     pub plan_state: String,
     pub items_total: u32,
+    /// True when the item was a detected calibration master that was registered
+    /// directly to `calibration_session` + `calibration_fingerprint` (Path 1 —
+    /// no file move).  `plan_id` is an empty string in this case.
+    pub registered_as_master: bool,
 }
 
 // ── inbox.reclassify ──────────────────────────────────────────────────────────

--- a/crates/persistence/db/migrations/0044_calibration_session_source_inbox.sql
+++ b/crates/persistence/db/migrations/0044_calibration_session_source_inbox.sql
@@ -1,0 +1,8 @@
+-- Migration 0044: add source_inbox_item_id to calibration_session (spec 040 US3).
+--
+-- Allows tracing a registered calibration master back to the inbox item that
+-- triggered its registration via the master-confirm path (Path 1 in spec 040).
+-- NULL for sessions created through earlier flows.
+
+ALTER TABLE calibration_session
+    ADD COLUMN source_inbox_item_id TEXT;

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -31,6 +31,13 @@ pub struct InboxItemRow {
     pub content_signature: Option<String>,
     pub state: String,
     pub lane: String,
+    /// File format (`"fits"` | `"xisf"` | `"video"` | `"mixed"`).  Spec 040 FR-006.
+    pub format: Option<String>,
+    /// Non-zero when this row represents a single detected calibration master file.
+    pub is_master_item: i64,
+    pub master_frame_type: Option<String>,
+    pub master_filter: Option<String>,
+    pub master_exposure_s: Option<f64>,
 }
 
 /// Data required to insert a new inbox item.


### PR DESCRIPTION
## Summary

- **Master registration (US3 / FR-007, Path 1):** When a confirmed inbox item has `is_master_item = true`, `confirm.rs` now fast-paths: inserts a `calibration_session` row (state `confirmed`) + a `calibration_fingerprint` row, marks the inbox item `resolved`, and returns `registered_as_master: true`. No filesystem plan is created.
- **Migration 0044:** Adds `source_inbox_item_id TEXT` to `calibration_session` for traceability back to the originating inbox item.
- **Bindings + contract:** `InboxConfirmResponse` gains `registered_as_master: bool`; bindings regenerated.
- **Frontend:** `InboxPage.handleConfirm` branches on `registeredAsMaster` — master path shows "Registered as calibration master." toast and refreshes the list; non-master path unchanged (plan toast + View plan action).
- **Lane → file type rename (Task 2):** Display strings in `InboxList.tsx` (`aria-label`, option text) changed from "lane"/"lanes" to "file type"/"file types". Internal `Lane` enum, `lane` field, and variable names left untouched.

## Test plan

- [ ] `cargo test --test confirm_master_integration` — 4 integration tests: confirm master registers session + fingerprint, masters_list returns it, resolved master absent from unacknowledged list, non-master still creates plan
- [ ] `pnpm vitest run` — 627 tests pass including new vitest for `registeredAsMaster: true` toast path and updated mock shapes
- [ ] `cargo fmt --all` — no formatting drift
- [ ] `just typecheck` — TypeScript clean