### PR TITLE
fix(setup): show calibration master frame type in wizard scan step

### DIFF
--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -85,6 +85,27 @@ const SCAN_RESPONSE_EMPTY = {
   items: [],
 };
 
+// A single detected calibration master file (spec 040 FR-005/FR-006): the item
+// carries its own frame type / exposure rather than relying on the breakdown.
+const SCAN_RESPONSE_WITH_MASTER = {
+  rootId: 'root-003',
+  items: [
+    {
+      inboxItemId: 'master-001',
+      relativePath: 'masters/masterDark_300s.xisf',
+      fileCount: 1,
+      lane: 'xisf',
+      format: 'xisf',
+      state: 'classified',
+      contentSignature: 'sig-master',
+      isMaster: true,
+      masterFrameType: 'dark',
+      masterFilter: null,
+      masterExposureS: 300,
+    },
+  ],
+};
+
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
 function renderStep(overrides: Partial<StepScanProps> = {}) {
@@ -260,6 +281,27 @@ describe('StepScan', () => {
       // Breakdown kinds visible (light=16, dark=2)
       expect(screen.getByText('16 light')).toBeInTheDocument();
       expect(screen.getByText('2 dark')).toBeInTheDocument();
+    });
+
+    it('renders a Master pill and the frame type for individual masters (spec 040 FR-006)', async () => {
+      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_MASTER);
+      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId('scan-source-/astro/lights')).getByText(/1 folder/),
+        ).toBeInTheDocument();
+      });
+
+      expandSource('/astro/lights');
+
+      const row = screen.getByTestId('scan-item-master-001');
+      // "Master" pill in the Folder/File cell
+      expect(within(row).getByText('Master')).toBeInTheDocument();
+      // Frame type + exposure in the Detected types cell (filter null → omitted)
+      expect(within(row).getByText('Master Dark · 300s')).toBeInTheDocument();
     });
 
     it('shows the scan summary when all sources are done', async () => {

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -76,6 +76,24 @@ function getRootId(flushResult: FlushResult, path: string): string {
   return row?.rootId ?? path;
 }
 
+/** Capitalize the first letter (e.g. "dark" → "Dark"). */
+function titleCase(s: string): string {
+  return s.length > 0 ? s[0].toUpperCase() + s.slice(1) : s;
+}
+
+/**
+ * Human label for a detected calibration master item (spec 040 FR-006).
+ * e.g. "Master Dark", "Master Flat · Ha · 120s".  Falls back to a generic
+ * "Master" when the base frame type couldn't be inferred.
+ */
+function masterLabel(item: InboxItemSummary): string {
+  const ft = item.masterFrameType ? `Master ${titleCase(item.masterFrameType)}` : 'Master';
+  const parts = [ft];
+  if (item.masterFilter) parts.push(item.masterFilter);
+  if (item.masterExposureS != null) parts.push(`${item.masterExposureS}s`);
+  return parts.join(' · ');
+}
+
 // ── Per-source detection summary ──────────────────────────────────────────────
 
 interface SourceSummaryProps {
@@ -314,16 +332,31 @@ function SourceSummary({ state }: SourceSummaryProps) {
                 {sortedItems.map((item) => {
                   const breakdown = classifications.get(item.inboxItemId)?.breakdown ?? [];
                   const types = breakdown.map((b) => `${b.count} ${b.kind}`).join(', ');
+                  // Individual calibration masters carry their frame type on the
+                  // item itself (spec 040 FR-006); grouped sub-frame folders rely
+                  // on the classify breakdown instead.
+                  const detectedTypes = item.isMaster ? masterLabel(item) : types || '—';
                   return (
                     <tr
                       key={item.inboxItemId}
                       data-testid={`scan-item-${item.inboxItemId}`}
                       style={{ borderTop: '1px solid var(--alm-border-subtle)' }}
                     >
-                      <td style={{ ...cell, wordBreak: 'break-all' }}>{item.relativePath}</td>
+                      <td style={{ ...cell, wordBreak: 'break-all' }}>
+                        <span
+                          style={{
+                            display: 'inline-flex',
+                            alignItems: 'center',
+                            gap: 'var(--alm-sp-2)',
+                          }}
+                        >
+                          {item.isMaster && <Pill variant="info">Master</Pill>}
+                          {item.relativePath}
+                        </span>
+                      </td>
                       <td style={cell}>{item.fileCount}</td>
                       <td style={cell}>{(item.format ?? item.lane).toUpperCase()}</td>
-                      <td style={cell}>{types || '—'}</td>
+                      <td style={cell}>{detectedTypes}</td>
                     </tr>
                   );
                 })}


### PR DESCRIPTION
## What

The first-run wizard's **Scan** step listed an individually-detected calibration master (spec 040 FR-005/FR-006) as a generic file — its frame type was never surfaced, even though the backend detects it and the data (`isMaster` / `masterFrameType` / `masterFilter` / `masterExposureS`) was already plumbed through the contract and generated bindings onto `InboxItemSummary`.

## Change

`StepScan.tsx` now renders a **Master** pill plus a `Master <Type> · <Filter> · <Exp>s` label in the Detected-types column for master items — matching the pattern the Inbox approval list (`InboxList.tsx`) already uses. Pure frontend; no contract/bindings work needed. Adds a StepScan unit test.

## Verification

- `tsc` clean, StepScan unit tests 20/20.
- Verified in the real Windows Tauri app (fresh first-run wizard): master items now show their type.