### PR TITLE
fix(setup): use registered source id (not folder path) as scan rootId

### DIFF
--- a/apps/desktop/src/api/commands.registerRootBatch.test.ts
+++ b/apps/desktop/src/api/commands.registerRootBatch.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Regression test for registerRootBatch's response mapping.
+ *
+ * The generated `roots_register_batch` response is `{ status, items: [{ index,
+ * status, sourceId, error }] }` — the assigned source id lives on `sourceId`.
+ * An earlier version cast the response to an invented `{ results: [{ root }] }`
+ * shape and read `item.root?.id`, which was always undefined on the real
+ * backend.  flushToDB then fell back to the folder path as the scan rootId, so
+ * inbox items were written with `root_id = <path>` and never matched the
+ * `registered_sources` JOIN — the Inbox showed nothing.  Mock mode hid it.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { registerRootBatch } from './commands';
+import { setInvokeOverride } from './ipc';
+
+afterEach(() => setInvokeOverride(null));
+
+describe('registerRootBatch maps the generated response shape', () => {
+  it('carries sourceId through as rootId and correlates rows by index', async () => {
+    setInvokeOverride((cmd) => {
+      if (cmd !== 'roots_register_batch') return Promise.resolve(null);
+      return Promise.resolve({
+        status: 'partial',
+        items: [
+          { index: 0, status: 'success', sourceId: 'uuid-capture', error: null },
+          { index: 1, status: 'failure', sourceId: null, error: 'permission_denied' },
+        ],
+      });
+    });
+
+    const out = await registerRootBatch({
+      sources: [
+        { kind: 'capture', path: 'D:/Astro/Captures', scanDepth: 2 },
+        { kind: 'inbox', path: 'D:/Astro/Inbox', scanDepth: 0 },
+      ],
+    });
+
+    expect(out.results).toHaveLength(2);
+    // Successful row carries the registered-source UUID as rootId (NOT the path).
+    expect(out.results[0]).toEqual({
+      kind: 'capture',
+      path: 'D:/Astro/Captures',
+      success: true,
+      rootId: 'uuid-capture',
+      error: undefined,
+    });
+    // Failed row has no rootId and surfaces the error.
+    expect(out.results[1].success).toBe(false);
+    expect(out.results[1].rootId).toBeUndefined();
+    expect(out.results[1].path).toBe('D:/Astro/Inbox');
+    expect(out.results[1].error).toBe('permission_denied');
+  });
+});

--- a/apps/desktop/src/api/commands.ts
+++ b/apps/desktop/src/api/commands.ts
@@ -396,7 +396,9 @@ export interface BatchRegisterResult {
     kind: string;
     path: string;
     success: boolean;
-    root?: LibraryRoot;
+    /** Assigned registered-source id (UUID) on success — used as the scan rootId
+     *  so inbox items JOIN back to `registered_sources`. */
+    rootId?: string;
     error?: string;
   }>;
 }
@@ -421,11 +423,32 @@ export async function registerRootBatch(args: {
 }): Promise<BatchRegisterResult> {
   // The generated rootsRegisterBatch(request) wraps in `{ request }` automatically;
   // pass `{ sources: args.sources }` as the RegisterSourceBatchRequest payload.
-  return unwrap(
+  const resp = unwrap(
     await commands.rootsRegisterBatch({ sources: args.sources } as Parameters<
       typeof commands.rootsRegisterBatch
     >[0]),
-  ) as unknown as BatchRegisterResult;
+  ) as {
+    status: string;
+    items: Array<{ index: number; status: string; sourceId?: string | null; error?: string | null }>;
+  };
+
+  // The real backend response carries per-item results in `items`, correlated to
+  // the request by `index`; the assigned source id is `sourceId`.  Map back to the
+  // wizard's row shape (kind/path come from the request by index) so the scan step
+  // receives the registered-source UUID — not the folder path — as rootId.  Passing
+  // the path made inbox items fail the `registered_sources` JOIN and vanish.
+  const results = (resp.items ?? []).map((item) => {
+    const src = args.sources[item.index];
+    const success = item.status === 'success';
+    return {
+      kind: src?.kind ?? '',
+      path: src?.path ?? '',
+      success,
+      rootId: success ? (item.sourceId ?? undefined) : undefined,
+      error: item.error ?? undefined,
+    };
+  });
+  return { results };
 }
 
 export async function completeFirstRun(): Promise<FirstRunCompleteResult> {

--- a/apps/desktop/src/features/setup/sources-store.ts
+++ b/apps/desktop/src/features/setup/sources-store.ts
@@ -230,7 +230,7 @@ export async function flushToDB(sources: SourcesState): Promise<FlushResult> {
           kind: item.kind as SourceKind,
           path: item.path,
           success: true,
-          rootId: item.root?.id,
+          rootId: item.rootId,
         };
       }
       const errorCode = item.error ?? 'unknown';


### PR DESCRIPTION
## Problem
Wizard-scanned items never appeared in the Inbox. `roots_register_batch` returns `{ status, items: [{ index, status, sourceId, error }] }`, but `registerRootBatch` cast it to an invented `{ results: [{ root }] }` shape and read `item.root?.id` — always undefined on the real backend. `flushToDB` then fell back to the **folder path** as the scan rootId, so `inbox_items` were written with `root_id = <path>` and silently failed the `registered_sources` JOIN in `list_unacknowledged_across_roots` (root_id is a UUID). Mock mode hid it (it also uses the path as rootId).

## Fix
Map the real response shape in the `registerRootBatch` wrapper: correlate items to the request by `index`, carry `sourceId` through as `rootId`, surface per-item errors. Regression test via `setInvokeOverride`.

## Verification
Live Windows DB after a fresh wizard scan: 340 items, **0 orphans** (was 340), inbox query now returns **340** rows (was 0). Confirmed in-app.