### PR TITLE
fix(inbox+calibration): repair confirmation panel, reclassify, and master page crash

### DIFF
--- a/apps/desktop/src/api/commands.ts
+++ b/apps/desktop/src/api/commands.ts
@@ -1,6 +1,5 @@
 import type {
   AcquisitionSession,
-  CalibrationMaster,
   Target,
   Project,
   FilesystemPlan,
@@ -10,7 +9,6 @@ import type {
   AppPreferences,
   OperationHandle,
   SessionDetail,
-  MasterDetail,
   TargetDetail,
   ProjectDetail,
   PlanDetail,
@@ -34,6 +32,8 @@ import type {
   InboxReclassifyResponse_Serialize as InboxReclassifyResponse,
   InboxScanFolderRequest,
   InboxScanFolderResponse,
+  CalibrationMaster_Serialize as CalibrationMaster,
+  MasterDetail_Serialize as MasterDetail,
 } from '@/bindings/index';
 export type {
   InboxClassifyRequest,
@@ -136,11 +136,11 @@ export async function listCalibrationMasters(args?: {
   filters?: Record<string, unknown>;
 }): Promise<CalibrationMaster[]> {
   void args; // generated fn takes no args
-  return unwrap(await commands.calibrationMastersList()) as unknown as CalibrationMaster[];
+  return unwrap(await commands.calibrationMastersList()) as CalibrationMaster[];
 }
 
 export async function getCalibrationMaster(args: { id: string }): Promise<MasterDetail> {
-  return unwrap(await commands.calibrationMastersGet(args.id)) as unknown as MasterDetail;
+  return unwrap(await commands.calibrationMastersGet(args.id)) as MasterDetail;
 }
 
 export async function getCalibrationMatches(args: {

--- a/apps/desktop/src/components/ListSidebar.tsx
+++ b/apps/desktop/src/components/ListSidebar.tsx
@@ -20,6 +20,7 @@ export function ListSidebar({ placeholder, searchValue, onSearchChange, controls
           placeholder={placeholder || 'Search...'}
           value={searchValue ?? ''}
           onChange={onSearchChange ? (e) => onSearchChange(e.target.value) : undefined}
+          readOnly={!onSearchChange}
           aria-label={placeholder || 'Search'}
         />
       </div>

--- a/apps/desktop/src/features/calibration/CalibrationPage.tsx
+++ b/apps/desktop/src/features/calibration/CalibrationPage.tsx
@@ -17,7 +17,7 @@ import { useStaleSelectionCleanup } from '@/lib/use-stale-selection';
 import { MastersList } from './MastersList';
 import { MasterDetail } from './MasterDetail';
 import { useCalibrationMasters, useCalibrationSettings } from './useCalibration';
-import type { CalibrationMaster } from '@/bindings/types';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 
 // ── Contextual toolbar actions for the selected master ────────────────────────
 
@@ -27,7 +27,7 @@ interface ContextualAction {
 }
 
 function masterActions(master: CalibrationMaster, agingThresholdDays: number): ContextualAction[] {
-  const isAging = master.age_days > agingThresholdDays;
+  const isAging = master.ageDays > agingThresholdDays;
   const actions: ContextualAction[] = [{ label: 'Use in project', variant: 'primary' }];
   if (isAging) actions.push({ label: 'Replace master', variant: 'danger' });
   actions.push({ label: 'Reveal in Explorer' });
@@ -54,7 +54,7 @@ export function CalibrationPage() {
   const darks = masters.filter((m) => m.kind === 'dark').length;
   const flats = masters.filter((m) => m.kind === 'flat').length;
   const bias = masters.filter((m) => m.kind === 'bias').length;
-  const aging = masters.filter((m) => m.age_days > agingThresholdDays).length;
+  const aging = masters.filter((m) => m.ageDays > agingThresholdDays).length;
 
   const subtitle = loading
     ? 'Loading…'

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -3,7 +3,7 @@
  *
  * Shows master fingerprint facts (from the real CalibrationMaster DTO) and
  * the ranked match candidates panel (from calibration.match.suggest using the
- * master's source_session_id as the anchor session).
+ * master's sourceSessionId as the anchor session).
  *
  * The calibration.match.suggest contract targets *light* sessions, not master
  * sessions. The MatchCandidatesPanel below is surfaced here so that when a user
@@ -12,7 +12,7 @@
  * ProjectDetail.
  */
 
-import type { CalibrationMaster } from '@/bindings/types';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 import {
   DetailPane,
   DetailHeader,
@@ -52,10 +52,10 @@ interface Props {
 // ── Component ─────────────────────────────────────────────────────────────────
 
 export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: Props) {
-  // Use source_session_id as the session anchor for suggest.
+  // Use sourceSessionId as the session anchor for suggest.
   // This is the calibration session that produced the master — we use it
   // to find which other masters would match the same fingerprint.
-  const sessionId = master?.source_session_id ?? undefined;
+  const sessionId = master?.sourceSessionId ?? undefined;
 
   const { response, loading: suggestLoading, error: suggestError, refresh } = useCalibrationSuggest(sessionId);
   const { assigning, assign } = useCalibrationAssign();
@@ -80,8 +80,8 @@ export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: 
     );
   }
 
-  const isAging1Year = master.age_days >= 365;
-  const isAgingWarn = master.age_days > agingThresholdDays && !isAging1Year;
+  const isAging1Year = master.ageDays >= 365;
+  const isAgingWarn = master.ageDays > agingThresholdDays && !isAging1Year;
   const kindStr = master.kind.toString().toLowerCase().replace('_', ' ');
 
   const fp = master.fingerprint;
@@ -89,19 +89,19 @@ export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: 
     { key: 'kind', label: 'Kind', value: kindStr },
     { key: 'camera', label: 'Camera', value: fp.camera },
     { key: 'gain', label: 'Gain', value: String(fp.gain) },
-    { key: 'exposure', label: 'Exposure', value: `${fp.exposure_s}s` },
+    { key: 'exposure', label: 'Exposure', value: `${fp.exposureS}s` },
   ];
-  if (fp.temp_c != null) {
-    properties.push({ key: 'temp', label: 'Temperature', value: `${fp.temp_c}°C` });
+  if (fp.tempC != null) {
+    properties.push({ key: 'temp', label: 'Temperature', value: `${fp.tempC}°C` });
   }
   if (fp.filter) {
     properties.push({ key: 'filter', label: 'Filter', value: fp.filter });
   }
-  if (fp.sensor_mode) {
-    properties.push({ key: 'sensor_mode', label: 'Sensor mode', value: fp.sensor_mode });
+  if (fp.sensorMode) {
+    properties.push({ key: 'sensor_mode', label: 'Sensor mode', value: fp.sensorMode });
   }
   properties.push({ key: 'binning', label: 'Binning', value: fp.binning });
-  properties.push({ key: 'size', label: 'Size', value: fmtBytes(master.size_bytes) });
+  properties.push({ key: 'size', label: 'Size', value: fmtBytes(master.sizeBytes) });
 
   return (
     <DetailPane fill>
@@ -116,18 +116,18 @@ export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: 
           <>
             <Pill variant={kindVariant(kindStr)}>{kindStr.toUpperCase()}</Pill>
             {isAging1Year && <Pill variant="danger">aging &gt; 1 year</Pill>}
-            {isAgingWarn && <Pill variant="warn">aging {master.age_days}d</Pill>}
+            {isAgingWarn && <Pill variant="warn">aging {master.ageDays}d</Pill>}
           </>
         }
-        subtitle={`${kindStr} · ${fmtBytes(master.size_bytes)}`}
+        subtitle={`${kindStr} · ${fmtBytes(master.sizeBytes)}`}
       />
 
       <MetricLine
         metrics={[
-          { value: fmtBytes(master.size_bytes), label: 'on disk' },
-          { value: `${master.age_days}d`, label: 'age' },
-          { value: (master.used_by_session_ids ?? []).length, label: 'sessions' },
-          { value: (master.used_by_project_ids ?? []).length, label: 'projects' },
+          { value: fmtBytes(master.sizeBytes), label: 'on disk' },
+          { value: `${master.ageDays}d`, label: 'age' },
+          { value: (master.usedBySessionIds ?? []).length, label: 'sessions' },
+          { value: (master.usedByProjectIds ?? []).length, label: 'projects' },
         ]}
       />
 
@@ -142,15 +142,15 @@ export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: 
               <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-1)', fontSize: 'var(--alm-text-xs)' }}>
                 <div style={{ color: 'var(--alm-text-secondary)' }}>
                   <span style={{ color: 'var(--alm-text-faint)' }}>Sessions matched</span>{' '}
-                  <strong>{(master.used_by_session_ids ?? []).length}</strong>
+                  <strong>{(master.usedBySessionIds ?? []).length}</strong>
                 </div>
                 <div style={{ color: 'var(--alm-text-secondary)' }}>
                   <span style={{ color: 'var(--alm-text-faint)' }}>Projects linked</span>{' '}
-                  <strong>{(master.used_by_project_ids ?? []).length}</strong>
+                  <strong>{(master.usedByProjectIds ?? []).length}</strong>
                 </div>
                 <div style={{ color: 'var(--alm-text-secondary)' }}>
                   <span style={{ color: 'var(--alm-text-faint)' }}>Created</span>{' '}
-                  {master.created_at.split('T')[0]}
+                  {master.createdAt.split('T')[0]}
                 </div>
               </div>
             </RailCard>

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -126,8 +126,8 @@ export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: 
         metrics={[
           { value: fmtBytes(master.size_bytes), label: 'on disk' },
           { value: `${master.age_days}d`, label: 'age' },
-          { value: master.used_by_session_ids.length, label: 'sessions' },
-          { value: master.used_by_project_ids.length, label: 'projects' },
+          { value: (master.used_by_session_ids ?? []).length, label: 'sessions' },
+          { value: (master.used_by_project_ids ?? []).length, label: 'projects' },
         ]}
       />
 
@@ -142,11 +142,11 @@ export function MasterDetail({ master, prefillSuggestion, agingThresholdDays }: 
               <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-1)', fontSize: 'var(--alm-text-xs)' }}>
                 <div style={{ color: 'var(--alm-text-secondary)' }}>
                   <span style={{ color: 'var(--alm-text-faint)' }}>Sessions matched</span>{' '}
-                  <strong>{master.used_by_session_ids.length}</strong>
+                  <strong>{(master.used_by_session_ids ?? []).length}</strong>
                 </div>
                 <div style={{ color: 'var(--alm-text-secondary)' }}>
                   <span style={{ color: 'var(--alm-text-faint)' }}>Projects linked</span>{' '}
-                  <strong>{master.used_by_project_ids.length}</strong>
+                  <strong>{(master.used_by_project_ids ?? []).length}</strong>
                 </div>
                 <div style={{ color: 'var(--alm-text-secondary)' }}>
                   <span style={{ color: 'var(--alm-text-faint)' }}>Created</span>{' '}

--- a/apps/desktop/src/features/calibration/MastersList.regression.test.tsx
+++ b/apps/desktop/src/features/calibration/MastersList.regression.test.tsx
@@ -28,7 +28,7 @@
 import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import { MastersList } from "./MastersList";
-import type { CalibrationMaster } from "@/bindings/types";
+import type { CalibrationMaster_Serialize as CalibrationMaster } from "@/bindings/index";
 
 // ── Fixtures — null and incomplete fingerprints ────────────────────────────
 
@@ -42,12 +42,12 @@ const masterWithNullFingerprint: CalibrationMaster = {
   id: "reg-r2-null",
   kind: "dark",
   fingerprint: null as unknown as CalibrationMaster["fingerprint"],
-  source_session_id: "ses-001",
-  created_at: "2026-01-01T00:00:00Z",
-  age_days: 45,
-  size_bytes: 64 * 1024 * 1024,
-  used_by_session_ids: [],
-  used_by_project_ids: [],
+  sourceSessionId: "ses-001",
+  createdAt: "2026-01-01T00:00:00Z",
+  ageDays: 45,
+  sizeBytes: 64 * 1024 * 1024,
+  usedBySessionIds: [],
+  usedByProjectIds: [],
 };
 
 /**
@@ -58,12 +58,12 @@ const masterWithUndefinedFingerprint: CalibrationMaster = {
   id: "reg-r2-undef",
   kind: "flat",
   fingerprint: undefined as unknown as CalibrationMaster["fingerprint"],
-  source_session_id: "ses-002",
-  created_at: "2026-02-01T00:00:00Z",
-  age_days: 10,
-  size_bytes: 32 * 1024 * 1024,
-  used_by_session_ids: [],
-  used_by_project_ids: [],
+  sourceSessionId: "ses-002",
+  createdAt: "2026-02-01T00:00:00Z",
+  ageDays: 10,
+  sizeBytes: 32 * 1024 * 1024,
+  usedBySessionIds: [],
+  usedByProjectIds: [],
 };
 
 /**
@@ -75,18 +75,18 @@ const masterWithSparseFingerprint: CalibrationMaster = {
   kind: "bias",
   fingerprint: {
     camera: "ASI2600MM",
-    // gain, temp_c, exposure_s, binning all missing — the original crash site
+    // gain, tempC, exposureS, binning all missing — the original crash site
     gain: undefined as unknown as number,
-    temp_c: undefined as unknown as number,
-    exposure_s: undefined as unknown as number,
+    tempC: undefined as unknown as number,
+    exposureS: undefined as unknown as number,
     binning: undefined as unknown as string,
   },
-  source_session_id: "ses-003",
-  created_at: "2026-03-01T00:00:00Z",
-  age_days: 5,
-  size_bytes: 8 * 1024 * 1024,
-  used_by_session_ids: [],
-  used_by_project_ids: [],
+  sourceSessionId: "ses-003",
+  createdAt: "2026-03-01T00:00:00Z",
+  ageDays: 5,
+  sizeBytes: 8 * 1024 * 1024,
+  usedBySessionIds: [],
+  usedByProjectIds: [],
 };
 
 // ── Tests ──────────────────────────────────────────────────────────────────
@@ -153,16 +153,16 @@ describe("MastersList R-2 regression · null/undefined fingerprints", () => {
       fingerprint: {
         camera: "ASI2600MM",
         gain: 100,
-        temp_c: -10,
-        exposure_s: 300,
+        tempC: -10,
+        exposureS: 300,
         binning: "1x1",
       },
-      source_session_id: "ses-004",
-      created_at: "2026-04-01T00:00:00Z",
-      age_days: 20,
-      size_bytes: 128 * 1024 * 1024,
-      used_by_session_ids: [],
-      used_by_project_ids: [],
+      sourceSessionId: "ses-004",
+      createdAt: "2026-04-01T00:00:00Z",
+      ageDays: 20,
+      sizeBytes: 128 * 1024 * 1024,
+      usedBySessionIds: [],
+      usedByProjectIds: [],
     };
 
     expect(() => {

--- a/apps/desktop/src/features/calibration/MastersList.test.tsx
+++ b/apps/desktop/src/features/calibration/MastersList.test.tsx
@@ -16,38 +16,38 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MastersList } from './MastersList';
-import type { CalibrationMaster } from '@/bindings/types';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 
 function makeMaster(overrides: Partial<CalibrationMaster> & { id: string }): CalibrationMaster {
-  const { id, kind, age_days, fingerprint, ...rest } = overrides;
+  const { id, kind, ageDays, fingerprint, ...rest } = overrides;
   return {
     id,
     kind: (kind ?? 'dark'),
     fingerprint: {
       camera: 'ASI2600MM',
-      exposure_s: 300,
-      temp_c: -10,
+      exposureS: 300,
+      tempC: -10,
       gain: 100,
       binning: '1x1',
       ...(fingerprint ?? {}),
     },
-    source_session_id: 'cal-ses-001',
-    created_at: '2026-01-01T00:00:00Z',
-    age_days: age_days ?? 30,
-    size_bytes: 128 * 1024 * 1024,
-    used_by_session_ids: [],
-    used_by_project_ids: [],
+    sourceSessionId: 'cal-ses-001',
+    createdAt: '2026-01-01T00:00:00Z',
+    ageDays: ageDays ?? 30,
+    sizeBytes: 128 * 1024 * 1024,
+    usedBySessionIds: [],
+    usedByProjectIds: [],
     ...rest,
   };
 }
 
 const masters: CalibrationMaster[] = [
-  makeMaster({ id: 'dark-1', kind: 'dark', age_days: 30 }),
-  makeMaster({ id: 'dark-2', kind: 'dark', age_days: 95 }), // aging
-  makeMaster({ id: 'flat-1', kind: 'flat', age_days: 10, fingerprint: { camera: 'ASI2600MM', exposure_s: 3, gain: 100, binning: '1x1', filter: 'Ha' } }),
-  makeMaster({ id: 'bias-1', kind: 'bias', age_days: 20 }),
+  makeMaster({ id: 'dark-1', kind: 'dark', ageDays: 30 }),
+  makeMaster({ id: 'dark-2', kind: 'dark', ageDays: 95 }), // aging
+  makeMaster({ id: 'flat-1', kind: 'flat', ageDays: 10, fingerprint: { camera: 'ASI2600MM', exposureS: 3, gain: 100, binning: '1x1', filter: 'Ha' } }),
+  makeMaster({ id: 'bias-1', kind: 'bias', ageDays: 20 }),
 ];
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -136,7 +136,7 @@ describe('MastersList (spec 007)', () => {
     const darkFlatMaster = makeMaster({
       id: 'df-1',
       kind: 'dark_flat',
-      age_days: 5,
+      ageDays: 5,
     });
     render(
       <MastersList

--- a/apps/desktop/src/features/calibration/MastersList.tsx
+++ b/apps/desktop/src/features/calibration/MastersList.tsx
@@ -8,7 +8,7 @@
 
 import { ListSidebar, ListItem } from '@/components';
 import { Pill, EmptyState } from '@/ui';
-import type { CalibrationMaster } from '@/bindings/types';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 
 type Kind = 'dark' | 'flat' | 'bias';
 
@@ -94,13 +94,13 @@ export function MastersList({ masters, loading, error, selected, onSelect, aging
         <div key={group.kind}>
           <div className="alm-group-header">{GROUP_LABELS[group.kind]}</div>
           {group.items.map((m) => {
-            const isAging = m.age_days > agingThresholdDays;
+            const isAging = m.ageDays > agingThresholdDays;
             // Fingerprint may be absent on real master rows (e.g. metadata not yet
             // extracted); guard every field rather than assuming it is populated.
             const fp = m.fingerprint;
             const gainStr = fp?.gain != null ? `g${fp.gain}` : '';
-            const tempStr = fp?.temp_c != null ? `${fp.temp_c}°C` : '';
-            const expStr = fp?.exposure_s != null ? `${fp.exposure_s}s` : '';
+            const tempStr = fp?.tempC != null ? `${fp.tempC}°C` : '';
+            const expStr = fp?.exposureS != null ? `${fp.exposureS}s` : '';
             const cameraStr = fp?.camera ? fp.camera.replace('ASI', '') : '';
 
             return (
@@ -137,7 +137,7 @@ export function MastersList({ masters, loading, error, selected, onSelect, aging
                     {isAging && (
                       <>
                         <span className="alm-list-item__meta-sep">·</span>
-                        <Pill variant="warn">aging {m.age_days}d</Pill>
+                        <Pill variant="warn">aging {m.ageDays}d</Pill>
                       </>
                     )}
                   </>

--- a/apps/desktop/src/features/calibration/agingThreshold.test.tsx
+++ b/apps/desktop/src/features/calibration/agingThreshold.test.tsx
@@ -15,27 +15,27 @@ import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MastersList } from './MastersList';
 import { DEFAULT_AGING_THRESHOLD_DAYS } from './useCalibration';
-import type { CalibrationMaster } from '@/bindings/types';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeMaster(id: string, age_days: number): CalibrationMaster {
+function makeMaster(id: string, ageDays: number): CalibrationMaster {
   return {
     id,
     kind: 'dark',
     fingerprint: {
       camera: 'ASI2600MM',
-      exposure_s: 300,
-      temp_c: -10,
+      exposureS: 300,
+      tempC: -10,
       gain: 100,
       binning: '1x1',
     },
-    source_session_id: 'cal-ses-001',
-    created_at: '2026-01-01T00:00:00Z',
-    age_days,
-    size_bytes: 128 * 1024 * 1024,
-    used_by_session_ids: [],
-    used_by_project_ids: [],
+    sourceSessionId: 'cal-ses-001',
+    createdAt: '2026-01-01T00:00:00Z',
+    ageDays,
+    sizeBytes: 128 * 1024 * 1024,
+    usedBySessionIds: [],
+    usedByProjectIds: [],
   };
 }
 
@@ -46,7 +46,7 @@ describe('T056 — aging threshold from persisted settings, not hardcoded', () =
     expect(DEFAULT_AGING_THRESHOLD_DAYS).toBe(90);
   });
 
-  it('2. threshold=90: master with age_days=91 shows aging pill', () => {
+  it('2. threshold=90: master with ageDays=91 shows aging pill', () => {
     const masters = [makeMaster('m-91', 91)];
     render(
       <MastersList
@@ -61,7 +61,7 @@ describe('T056 — aging threshold from persisted settings, not hardcoded', () =
     expect(screen.getByText(/aging 91d/)).toBeInTheDocument();
   });
 
-  it('3. threshold=120: master with age_days=91 does NOT show aging pill', () => {
+  it('3. threshold=120: master with ageDays=91 does NOT show aging pill', () => {
     // This test proves MastersList uses the prop, not a hardcoded 90.
     // Before T059, this would fail because the component always used > 90.
     const masters = [makeMaster('m-91', 91)];

--- a/apps/desktop/src/features/guided/__tests__/eventBridge.test.ts
+++ b/apps/desktop/src/features/guided/__tests__/eventBridge.test.ts
@@ -45,7 +45,8 @@ vi.mock('../store', () => ({
 // ── Helper: emit a simulated Tauri event ──────────────────────────────────────
 
 function emitEvent(topic: string, payload: unknown): void {
-  const fns = listeners.get(topic) ?? [];
+  // The bridge registers listeners under the Tauri-valid (dot→colon) event name.
+  const fns = listeners.get(topic.replace(/\./g, ':')) ?? [];
   for (const fn of fns) {
     fn({ payload });
   }

--- a/apps/desktop/src/features/guided/eventBridge.ts
+++ b/apps/desktop/src/features/guided/eventBridge.ts
@@ -73,7 +73,11 @@ export async function startGuidedEventBridge(): Promise<void> {
     const { listen } = await import('@tauri-apps/api/event');
 
     for (const topic of Object.keys(EVENT_TO_STEP)) {
-      const unlisten = await listen<unknown>(topic, (event) => {
+      // Tauri event names only allow alphanumeric, '-', '/', ':', '_'.
+      // Replace dots with ':' to form a valid Tauri event name while keeping
+      // the original dotted topic for downstream handleDomainEvent routing.
+      const eventName = topic.replace(/\./g, ':');
+      const unlisten = await listen<unknown>(eventName, (event) => {
         handleDomainEvent(topic, event.payload);
       });
       unlisteners.push(unlisten);

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -45,6 +45,7 @@ export function InboxDetail({ item, classification }: InboxDetailProps) {
 
   // Per-file overrides the user has selected but not yet submitted.
   const [pendingOverrides, setPendingOverrides] = useState<Record<string, string>>({});
+  const [applyError, setApplyError] = useState<string | null>(null);
 
   const handleOverrideChange = (filePath: string, frameType: string) => {
     setPendingOverrides((prev) => ({ ...prev, [filePath]: frameType }));
@@ -56,8 +57,13 @@ export function InboxDetail({ item, classification }: InboxDetailProps) {
       frameType,
     }));
     if (overrides.length === 0) return;
-    await reclassify(overrides);
-    setPendingOverrides({});
+    setApplyError(null);
+    try {
+      await reclassify(overrides);
+      setPendingOverrides({});
+    } catch (err) {
+      setApplyError(err instanceof Error ? err.message : String(err));
+    }
   };
 
   const title = item.relativePath || '(root)';
@@ -78,7 +84,7 @@ export function InboxDetail({ item, classification }: InboxDetailProps) {
       destination: entry.destinationPreview ? (
         <code style={{ fontSize: 'var(--alm-text-xs)' }}>{entry.destinationPreview}</code>
       ) : (
-        <span style={{ color: 'var(--alm-text-muted)' }}>—</span>
+        <span style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-xs)' }}>computed on confirm</span>
       ),
       samples: (
         <span style={{ color: 'var(--alm-text-muted)', fontSize: 'var(--alm-text-xs)' }}>
@@ -176,6 +182,9 @@ export function InboxDetail({ item, classification }: InboxDetailProps) {
               {reclassifyLoading ? 'Applying…' : `Apply ${Object.keys(pendingOverrides).length} override${Object.keys(pendingOverrides).length !== 1 ? 's' : ''}`}
             </button>
           </div>
+          {applyError && (
+            <Banner variant="danger" style={{ marginTop: 'var(--alm-sp-2)' }}>{applyError}</Banner>
+          )}
         </Section>
       )}
 

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -168,6 +168,10 @@ export function InboxPage() {
         detail={
           selectedItem ? (
             <InboxDetail
+              // Remount per item so per-item state (pending type overrides) never
+              // leaks across selections — leaked overrides were being sent to the
+              // wrong item's reclassify and rejected as "not found in evidence".
+              key={selectedItem.inboxItemId}
               item={selectedItem}
               rootAbsolutePath={selectedRootPath}
               classification={classification ?? null}

--- a/crates/app/core/src/inbox/classify.rs
+++ b/crates/app/core/src/inbox/classify.rs
@@ -92,15 +92,27 @@ pub async fn classify(
         }
     }
 
-    // 3. Build absolute folder path
+    // 3. Build absolute path for this item.  Sub-frame groups are folders; a
+    //    detected calibration master (spec 040) is a single file.
     let folder_abs = req.root_absolute_path.join(&item.relative_path);
 
-    // 4. Enumerate files in the folder
-    let file_paths = enumerate_fits_files(&folder_abs);
+    // 4. Enumerate the FITS/XISF files to classify.  Master items are one file,
+    //    not a directory, so reading them as a folder finds nothing — enumerate
+    //    the file itself instead (this is why masters were stuck "Loading
+    //    classification" forever).
+    let file_paths = if item.is_master_item != 0 {
+        if folder_abs.is_file() {
+            vec![folder_abs.clone()]
+        } else {
+            Vec::new()
+        }
+    } else {
+        enumerate_fits_files(&folder_abs)
+    };
     if file_paths.is_empty() {
         return Err(ContractError::new(
             "metadata.unreadable",
-            format!("No FITS/XISF files found in folder: {}", folder_abs.display()),
+            format!("No FITS/XISF files found for item: {}", folder_abs.display()),
             ErrorSeverity::Blocking,
             false,
         ));

--- a/crates/app/core/src/inbox/reclassify.rs
+++ b/crates/app/core/src/inbox/reclassify.rs
@@ -7,8 +7,11 @@
 //! Reclassification is NOT permitted while a plan is open (Ref: E1 variant).
 #![allow(clippy::doc_markdown)]
 
+use std::collections::HashMap;
+
 use persistence_db::repositories::inbox::{self as inbox_repo};
 use sqlx::SqlitePool;
+use uuid::Uuid;
 
 use contracts_core::{ContractError, ErrorSeverity};
 
@@ -150,6 +153,38 @@ pub async fn reclassify(
     .await
     .ok();
 
+    // 7. Rebuild breakdown rows so the next classify cache hit returns fresh
+    //    counts and samples (fixes stale/empty breakdown after override apply).
+    //    Group evidence by effective frame type, then upsert one row per type.
+    //    destination_preview is left None — computed on the next force-classify.
+    {
+        let mut groups: HashMap<String, Vec<String>> = HashMap::new();
+        for ev in &updated_evidence {
+            let effective = ev.manual_override.as_deref().or(ev.frame_type.as_deref());
+            if let Some(ft) = effective {
+                groups.entry(ft.to_owned()).or_default().push(ev.relative_file_path.clone());
+            }
+        }
+
+        for (kind, paths) in &groups {
+            let count = i64::try_from(paths.len()).unwrap_or(i64::MAX);
+            let samples: Vec<&str> = paths.iter().take(10).map(String::as_str).collect();
+            let sample_json = serde_json::to_string(&samples).unwrap_or_else(|_| "[]".to_owned());
+            let row_id = Uuid::new_v4().to_string();
+            inbox_repo::upsert_breakdown_row(
+                pool,
+                &row_id,
+                &req.inbox_item_id,
+                kind,
+                count,
+                None,
+                &sample_json,
+            )
+            .await
+            .ok();
+        }
+    }
+
     Ok(ReclassifyResponse {
         inbox_item_id: req.inbox_item_id,
         updated_type,
@@ -290,6 +325,49 @@ mod tests {
 
         assert_eq!(resp.remaining_unclassified, 1);
         assert_eq!(resp.applied_count, 1);
+    }
+
+    /// After applying overrides, `inbox_classification_breakdown` rows must be
+    /// written so that a subsequent `classify` cache-hit returns a non-empty
+    /// breakdown (regression guard for bug 2b).
+    #[tokio::test]
+    async fn reclassify_rebuilds_breakdown_rows() {
+        let db = test_db().await;
+        setup_unclassified_item(&db, "item-recl-bd").await;
+
+        // Apply overrides to both files.
+        reclassify(
+            db.pool(),
+            ReclassifyRequest {
+                inbox_item_id: "item-recl-bd".to_owned(),
+                overrides: vec![
+                    ReclassifyOverride {
+                        file_path: "inbox_folder/mystery_001.fits".to_owned(),
+                        frame_type: "light".to_owned(),
+                    },
+                    ReclassifyOverride {
+                        file_path: "inbox_folder/mystery_002.fits".to_owned(),
+                        frame_type: "dark".to_owned(),
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        // Breakdown rows must now exist and reflect the overrides.
+        let rows = inbox_repo::list_breakdown(db.pool(), "item-recl-bd").await.unwrap();
+        assert_eq!(rows.len(), 2, "one breakdown row per distinct frame type");
+
+        let mut kinds: Vec<&str> = rows.iter().map(|r| r.kind.as_str()).collect();
+        kinds.sort_unstable();
+        assert_eq!(kinds, ["dark", "light"]);
+
+        let light_row = rows.iter().find(|r| r.kind == "light").unwrap();
+        assert_eq!(light_row.count, 1);
+
+        let dark_row = rows.iter().find(|r| r.kind == "dark").unwrap();
+        assert_eq!(dark_row.count, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Bug-fix batch surfaced while exercising the inbox confirm flow on the real backend.

**Inbox confirmation**
- Masters stuck on "Loading classification": classify enumerated the item as a folder, but a detected master is a single file → 0 files → never resolved. Enumerate the file itself for `is_master` items.
- "Apply overrides" failing with "File paths not found in evidence" + inflated count: `InboxDetail` per-item state leaked across selections (InboxPage rendered it without a `key`). Remount per item; also catch the reclassify rejection instead of an unhandled promise.
- Breakdown vanished after applying overrides: `reclassify` updated the classification but never rebuilt `inbox_classification_breakdown`, so the cached re-fetch returned empty. Rebuild breakdown rows (+ regression test).
- Destination preview showed a bare dash → "computed on confirm" (real resolution deferred to the inbox spec).

**Console crashes**
- `eventBridge` dotted Tauri event names (invalid charset) → listen on the dot→colon form.
- Controlled-input warning: `ListSidebar` search input `readOnly` when no onChange.

**Calibration page crash**
- Master views imported legacy snake_case types while the backend serializes camelCase → every field undefined → crash on first `.split()`/`.toString()`. Migrated MasterDetail/MastersList/CalibrationPage/commands to generated `*_Serialize` types + camelCase reads + tightened casts (+ regression tests).

Verified in the real Windows app. Full frontend suite 629 green; `cargo test -p app_core inbox` 39 green.

Known follow-up (separate): Calibration page lists no masters (data/query issue), tracked separately.