### PR TITLE
spec 037: adopt thirtyfour + nextest for Layer-2 E2E (scaffold + stubs)

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,21 @@
+# Nextest configuration for spec 037 Layer-2 real-UI E2E journeys.
+#
+# Run the E2E suite (once wired) with:
+#   cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+#
+# The "e2e" profile enforces serial execution (one app/driver/DB at a time),
+# a generous per-test timeout, one automatic retry, and immediate-final
+# failure output so the first broken journey is visible without scrolling.
+
+[profile.e2e]
+# One test at a time — a single app instance, driver session, and database.
+test-threads = 1
+
+# Allow up to 60 s per slow-test period; terminate after 3 consecutive periods.
+slow-timeout = { period = "60s", terminate-after = 3 }
+
+# Retry once to guard against transient driver/startup flakes.
+retries = 1
+
+# Print failures immediately and again at the end for easy scanning.
+failure-output = "immediate-final"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,8 @@ name: CI
 # - integration: Layer-1 real-backend integration + lint + bindings-drift gate,
 #   REQUIRED on Windows, Linux, and macOS (FR-012).
 # - ui-e2e: fast mock-mode Playwright UI regression.
-# Real UI->IPC->backend E2E (WebdriverIO + tauri-driver) lives in e2e.yml; macOS
-# real-UI E2E remains deferred per research D4.
+# Real UI->IPC->backend E2E (thirtyfour + cargo-nextest + tauri-driver) lives in
+# e2e.yml; macOS real-UI E2E remains deferred per research D4.
 
 on:
   pull_request:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,89 +1,105 @@
-# Real-UI E2E (Layer 2) via WebdriverIO + tauri-driver.
+# Real-UI E2E — thirtyfour + cargo-nextest + tauri-driver
 #
-# Runs decoupled from ci.yml's Stage A gate: the real-UI journeys are valuable
-# even while the workspace gate is unrelatedly red, and a Tauri webview can only
-# run here (not in the WSL dev sandbox). Caching keeps iteration fast:
-#   - sccache caches ALL crate compilation (incl. workspace) -> test-only edits
-#     are near-instant rebuilds.
-#   - tauri-driver is installed prebuilt via taiki-e/install-action (no source
-#     compile; the action owns binary placement, PATH, and a version cache).
-name: Real-UI E2E
+# Drives the built desktop_shell binary through its real webview UI via
+# tauri-driver (W3C WebDriver). thirtyfour (Rust W3C client) replaces the
+# interim WebdriverIO approach — same tauri:options.application capability,
+# same tauri-driver, but the test runner stays in Rust alongside Layer-1.
+#
+# Run conditions:
+# - All journeys are #[ignore] stubs today; cargo nextest --no-tests=warn keeps
+#   the job green while they are deferred (research D3/D9 gating conditions).
+#   Remove --no-tests=warn once a journey is un-ignored.
+# - macOS real-UI E2E is unsupported by official tauri-driver (research D4);
+#   this workflow targets Linux only until Windows is added (Stage B, US3).
+
+name: Real-UI E2E (thirtyfour + nextest)
 
 on:
   push:
-    branches: [037-us3-e2e-journeys]
+    branches: [main, 037-e2e-thirtyfour-nextest]
   pull_request:
-    paths:
-      - "apps/desktop/**"
-      - "crates/**"
-      - "Cargo.toml"
-      - "Cargo.lock"
-      - ".github/workflows/e2e.yml"
   workflow_dispatch:
 
 concurrency:
-  group: e2e-${{ github.ref }}
+  group: e2e-${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  CARGO_INCREMENTAL: 0
+
 jobs:
-  e2e:
-    name: Real-UI E2E (Linux)
+  e2e-linux:
+    name: Real-UI E2E — Linux
     runs-on: ubuntu-latest
-    env:
-      SCCACHE_GHA_ENABLED: "true"
-      RUSTC_WRAPPER: "sccache"
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install Tauri + E2E system deps
+      # Tauri system deps (webview + xvfb for headless display)
+      - name: Install Tauri / E2E system deps
         run: |
           sudo apt-get update
           sudo apt-get install -y \
             libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
-            libayatana-appindicator3-dev webkit2gtk-driver xvfb
+            libayatana-appindicator3-dev \
+            webkit2gtk-driver \
+            xvfb
 
       - uses: dtolnay/rust-toolchain@stable
+
       - uses: mozilla-actions/sccache-action@v0.0.10
-      # sccache owns compilation caching; Swatinem caches registry/git deps only.
+
       - uses: Swatinem/rust-cache@v2
         with:
+          shared-key: "rust-ubuntu-latest"
+          # cache-targets:false keeps the cache small; sccache handles Rust
+          # artifact reuse. cargo-nextest and tauri-driver binaries are small.
           cache-targets: "false"
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@v2
+        with:
+          # tauri-driver@2.0.6 — matches the proven version from the US3 spike
+          # nextest — cargo-nextest runner for the e2e_tests crate
+          tool: tauri-driver@2.0.6,nextest
 
       - uses: pnpm/action-setup@v4
         with:
           version: 10.33.0
+
       - uses: actions/setup-node@v4
         with:
           node-version: 20
           cache: pnpm
 
-      # taiki-e/install-action manages the tauri-driver binary directly: it
-      # handles download, bin placement on PATH, and a version-keyed cache.
-      # A hand-rolled `cargo binstall || cargo install` step skipped reinstall
-      # on a warm rust-cache (metadata said "installed" but the binary was gone)
-      # -> the wdio spike's `spawn("tauri-driver")` failed with ENOENT.
-      - uses: taiki-e/install-action@v2
-        with:
-          tool: tauri-driver@2.0.6
-
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
-      # The debug binary loads its frontend from the Tauri devUrl (:5173); the
-      # journeys serve the built dist there, so build the frontend first.
-      # VITE_E2E enables the CI-only typeable path inputs (the native folder
-      # picker can't be driven by WebDriver). Tree-shaken from production builds.
-      - name: Build frontend
+      # Build the frontend with VITE_E2E=1 so typeable path inputs are enabled.
+      # The built dist is served on :5173 by `vite preview` (next step).
+      - name: Build frontend (VITE_E2E=1)
+        run: pnpm --filter @astro-plan/desktop build
         env:
           VITE_E2E: "1"
-        run: pnpm --filter @astro-plan/desktop build
 
+      # Serve the built dist on :5173 in the background.
+      # The desktop_shell binary's Tauri devUrl points here; the webview loads
+      # the real UI from this server, using real IPC to the Rust backend.
+      - name: Serve frontend dist on :5173 (background)
+        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+
+      # Build the desktop app binary (debug, no-default-features for speed).
       - name: Build desktop app (debug)
         run: cargo build -p desktop_shell
+        env:
+          RUSTC_WRAPPER: sccache
 
-      - name: Real-UI E2E (WebdriverIO + tauri-driver)
-        run: xvfb-run -a pnpm --filter @astro-plan/desktop test:e2e:wdio
+      # Run the E2E suite under xvfb-run (headless display for WebKitWebDriver).
+      # --no-tests=warn keeps the job green while all journeys are #[ignore]
+      # stubs; remove once a journey is un-ignored.
+      # tauri-driver is spawned by the harness (tests/common/mod.rs) per-test.
+      - name: Run E2E suite (thirtyfour + nextest, xvfb)
+        run: xvfb-run -a cargo nextest run -p e2e_tests --profile e2e --no-tests=warn
 
       - name: sccache stats
+        run: sccache --show-stats
         if: always()
-        run: ${SCCACHE_PATH:-sccache} --show-stats

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -78,6 +78,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "async-broadcast"
 version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -599,6 +608,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "const_format"
+version = "0.2.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4481a617ad9a412be3b97c5d403fef8ed023103368908b9c50af598ff467cc1e"
+dependencies = [
+ "const_format_proc_macros",
+ "konst",
+]
+
+[[package]]
+name = "const_format_proc_macros"
+version = "0.2.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d57c2eccfb16dbac1f4e61e206105db5820c9d26c3c472bc17c774259ef7744"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
+
+[[package]]
 name = "contract_tests"
 version = "0.1.0"
 dependencies = [
@@ -1072,6 +1102,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "e2e_tests"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "serde",
+ "serde_json",
+ "thirtyfour",
+ "tokio",
+]
+
+[[package]]
 name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1234,6 +1275,7 @@ checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -1299,6 +1341,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fs4"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e72ed92b67c146290f88e9c89d60ca163ea417a446f61ffd7b72df3e7f1dfd5"
+dependencies = [
+ "rustix",
+ "tokio",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2312,6 +2365,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "konst"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "128133ed7824fcd73d6e7b17957c5eb7bacb885649bd8c69708b2331a10bcefb"
+dependencies = [
+ "konst_macro_rules",
+]
+
+[[package]]
+name = "konst_macro_rules"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4933f3f57a8e9d9da04db23fb153356ecaf00cbd14aee46279c33dc80925c37"
+
+[[package]]
 name = "kqueue"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2900,6 +2968,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ee67f1008b1ba2321834326597b8e186293b049a023cdef258527550b9935b4"
 
 [[package]]
 name = "pathdiff"
@@ -3775,6 +3849,7 @@ version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
 dependencies = [
+ "indexmap 2.14.0",
  "itoa",
  "memchr",
  "serde",
@@ -4314,6 +4389,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "stringmatch"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6aadc0801d92f0cdc26127c67c4b8766284f52a5ba22894f285e3101fa57d05d"
+dependencies = [
+ "regex",
+]
+
+[[package]]
 name = "stringprep"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4447,6 +4531,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
 ]
 
 [[package]]
@@ -4806,6 +4901,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "thirtyfour"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c23ea3ddea759604ee20091e361347531cbdd5e4575435dc87e55ad7bcae5775"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "base64 0.22.1",
+ "bytes",
+ "cfg-if",
+ "const_format",
+ "dirs",
+ "flate2",
+ "fs4",
+ "futures-util",
+ "http",
+ "indexmap 2.14.0",
+ "pastey",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "stringmatch",
+ "tar",
+ "thirtyfour-macros",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "zip",
+]
+
+[[package]]
+name = "thirtyfour-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cf0ffc3ba4368e99597bd6afd83f4ff6febad66d9ae541ab46e697d32285fc0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4911,6 +5051,7 @@ dependencies = [
  "libc",
  "mio",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
@@ -4946,6 +5087,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5181,6 +5323,12 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
 
 [[package]]
 name = "typeid"
@@ -6373,6 +6521,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6537,10 +6695,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap 2.14.0",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be3d40e40a133f9c916ee3f9f4fa2d9d63435b5fbe1bfc6d9dae0aa0ada1513"
+
+[[package]]
 name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
+]
 
 [[package]]
 name = "zvariant"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/calibration/core",
   "crates/calibration/master-detect",
   "crates/contracts/core",
+  "crates/e2e-tests",
   "crates/domain/core",
   "crates/fs/executor",
   "crates/fs/inventory",

--- a/apps/desktop/src/features/calibration/useCalibration.ts
+++ b/apps/desktop/src/features/calibration/useCalibration.ts
@@ -19,7 +19,7 @@ import type {
   CalibrationMatchAssignResponse,
   CalibrationMatchType,
 } from '@/api/commands';
-import type { CalibrationMaster } from '@/bindings/types';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 
 // ── Masters list ─────────────────────────────────────────────────────────────
 

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "e2e_tests"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+publish = false
+
+# Empty library target: all E2E logic lives in `tests/` so the heavy thirtyfour
+# WebDriver stack is a dev-dependency, compiled only for the test binaries and
+# never by `cargo build --workspace` of the shipping crates.
+[lib]
+path = "src/lib.rs"
+
+[dev-dependencies]
+# W3C WebDriver client (spec 037 adopted stack — see rust.tauri steering).
+thirtyfour = "0.37"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+anyhow = "1"
+serde = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -1,0 +1,47 @@
+# crates/e2e-tests — spec 037 Layer-2 real-UI E2E
+
+Thirtyfour + cargo-nextest end-to-end tests for the Astro Library Manager
+desktop app.
+
+## Status
+
+**Ignored stub journeys. Wiring deferred while the backend is still changing.**
+
+All tests compile and appear in `cargo nextest list` but are marked
+`#[ignore]`. They will be unwired once:
+
+1. The `__APP_E2E__` invoke bridge is exposed by the frontend (built with
+   `VITE_E2E=1`).
+2. The tauri-driver WebDriver caps (`tauri:options.application` +
+   `browserName="wry"`) replace the chrome placeholder caps in
+   `tests/common/mod.rs`.
+
+## How to run (once wired)
+
+```sh
+cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+```
+
+## Prerequisites
+
+- **tauri-driver** installed and on `$PATH`
+  (`cargo install tauri-driver`, or from the Tauri release assets).
+- Platform WebDriver binary on `$PATH`:
+  - Linux: `WebKitWebDriver` (from the `webkit2gtk-driver` package or equivalent).
+  - Windows: `msedgedriver` (matching the installed Edge version).
+- The desktop app must be **built** (`cargo tauri build` or `cargo tauri dev`
+  with `VITE_USE_MOCKS=false`).
+- Vite dev server running on `:1420` with:
+  - `VITE_USE_MOCKS=false` — real backend.
+  - `VITE_E2E=1` — exposes the `window.__APP_E2E__` invoke bridge.
+- Optional: set `ALM_DB_URL=sqlite:///path/to/alm.db` to control which
+  database is wiped before each test run.  If unset, the harness will
+  resolve the OS app-data path (wiring deferred — see `reset_database` in
+  `tests/common/mod.rs`).
+
+## Notes
+
+- The `__APP_E2E__.invoke` bridge and the tauri-driver caps are **not yet
+  wired**.  See `tests/common/mod.rs` for the `TODO(spec-037 wiring)` comments.
+- Tests run serially (`test-threads = 1` in the `e2e` nextest profile) because
+  there is one app instance, one driver session, and one database per run.

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -1,0 +1,16 @@
+//! Real-UI end-to-end test crate (spec 037, Layer 2).
+//!
+//! The library target is intentionally empty. All E2E logic lives under
+//! `tests/`:
+//!
+//! - `tests/common/` — the thirtyfour WebDriver harness (driver + app
+//!   lifecycle, the `window.__APP_E2E__` invoke bridge, fresh-DB reset).
+//! - `tests/journeys.rs` — the high-level user journeys.
+//! - `tests/smoke.rs` — the all-top-level-screens-load smoke.
+//!
+//! Keeping the logic in `tests/` means `thirtyfour` is a dev-dependency that
+//! only compiles for the test binaries, never for `cargo build --workspace`.
+//!
+//! STATUS: scaffold. The journeys are `#[ignore]`d stubs — they compile and
+//! appear in `cargo nextest list`, but their assertions are `todo!()` pending a
+//! stable backend command surface and the `__APP_E2E__` bridge. See `README.md`.

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1,14 +1,35 @@
 //! Shared harness for spec 037 Layer-2 real-UI E2E journeys.
 //!
 //! All journeys are `#[ignore]`d. They are compiled stubs that appear in
-//! `cargo nextest list` but are deferred until two prerequisites land:
+//! `cargo nextest list` but are deferred until backend stubs are de-stubbed
+//! (see research.md D9 for the gating conditions).
 //!
-//! 1. The `__APP_E2E__` bridge (exposed by the desktop app when built with
-//!    `VITE_E2E=1`) is wired in the frontend.
-//! 2. The tauri-driver WebDriver caps (`tauri:options.application` +
-//!    `browserName="wry"`) replace the chrome placeholder caps used here.
+//! # How the harness works (proven tauri-driver approach)
 //!
-//! See `crates/e2e-tests/README.md` for the full run procedure.
+//! 1. Build the frontend with `VITE_E2E=1 pnpm build` → `apps/desktop/dist/`.
+//! 2. Serve `dist` on :5173 with `vite preview --port 5173` (background).
+//!    The built `desktop_shell` binary reads the Tauri `devUrl` (:5173) and
+//!    loads its frontend from there — the frontend is real and uses real IPC.
+//! 3. Build the app binary: `cargo build -p desktop_shell`.
+//! 4. Run `tauri-driver --port 4444` (background).
+//! 5. This harness connects thirtyfour to `http://127.0.0.1:4444`, passing
+//!    `tauri:options.application` = path to the built binary. Do NOT set
+//!    `browserName` — WebKitWebDriver rejects the session when it is set.
+//! 6. Launching the WebDriver session starts the app; the app loads its own
+//!    frontend from :5173. Do NOT call `driver.goto(...)` — the app navigates
+//!    itself on launch.
+//!
+//! # VITE_E2E flag
+//!
+//! Building the frontend with `VITE_E2E=1` enables CI-only typeable path
+//! inputs (the native folder picker cannot be driven by WebDriver). Journeys
+//! assert against the real UI via thirtyfour `find(By::...)` + element
+//! text/state over real IPC. The `invoke()` helper below provides a secondary
+//! assertion path via `window.__APP_E2E__`; it only works when `VITE_E2E=1`
+//! is set and the bridge is wired in the frontend (not guaranteed today).
+//!
+//! See `crates/e2e-tests/README.md` and `specs/037-e2e-integration-testing/`
+//! for the full run procedure.
 
 #![allow(dead_code)]
 
@@ -21,10 +42,6 @@ use thirtyfour::prelude::*;
 
 /// URL where tauri-driver listens for W3C WebDriver sessions.
 pub const TAURI_DRIVER_URL: &str = "http://127.0.0.1:4444";
-
-/// Vite dev-server port used when running against the real backend
-/// (`VITE_USE_MOCKS=false`).
-pub const APP_URL: &str = "http://127.0.0.1:1420";
 
 // ---------------------------------------------------------------------------
 // Private deserialization target for invoke() responses
@@ -67,7 +84,12 @@ pub struct E2eApp {
 
 impl E2eApp {
     /// Launch a full E2E session: preflight → reset DB → spawn tauri-driver →
-    /// connect WebDriver → navigate to [`APP_URL`].
+    /// connect WebDriver.
+    ///
+    /// The app loads its own frontend from the Tauri devUrl (:5173); do NOT
+    /// call `driver.goto(...)` after this — the webview navigates on its own.
+    /// Ensure `vite preview --port 5173` is already running before calling
+    /// this (in CI it is started as a background step before nextest runs).
     pub async fn launch() -> Result<Self> {
         preflight()?;
         reset_database()?;
@@ -75,26 +97,47 @@ impl E2eApp {
         let driver_proc =
             spawn_tauri_driver().context("failed to spawn tauri-driver on port 4444")?;
 
-        // TODO(spec-037 wiring): replace DesiredCapabilities::chrome() with
-        // real tauri-driver caps:
-        //   caps.set_browser_name("wry")?;
-        //   caps.add_capability("tauri:options", json!({"application": "/path/to/alm"}))?;
-        // Chrome caps are a placeholder that makes this file compile.
-        let driver = WebDriver::new(TAURI_DRIVER_URL, DesiredCapabilities::chrome())
+        // Build tauri-driver capabilities:
+        // - tauri:options.application  = path to the built desktop_shell binary
+        //   (tauri-driver reads this and hands it to the native WebDriver)
+        // - browserName is intentionally ABSENT — WebKitWebDriver rejects the
+        //   session when browserName is set (proven in the US3 spike, research D3).
+        //
+        // thirtyfour::Capabilities wraps a serde_json map; insert the custom
+        // tauri:options key directly.
+        let app_bin = app_binary_path();
+        let mut caps = Capabilities::new();
+        caps.set("tauri:options", json!({ "application": app_bin }))
+            .context("failed to set tauri:options capability")?;
+
+        let driver = WebDriver::new(TAURI_DRIVER_URL, caps)
             .await
             .context("WebDriver::new failed — is tauri-driver running on :4444?")?;
 
-        driver.goto(APP_URL).await.context("driver.goto APP_URL failed")?;
+        // Do NOT call driver.goto() here. Launching the session starts the app,
+        // which loads its frontend from the Tauri devUrl (:5173 served by
+        // `vite preview`). Navigation is app-owned from this point on.
 
         Ok(Self { driver, driver_proc: Some(driver_proc) })
     }
 
     /// Issue a Tauri command through the `window.__APP_E2E__` bridge.
     ///
-    /// The bridge is exposed by the desktop app when it is built with
-    /// `VITE_E2E=1`.  This replaces the old better-sqlite3 reader approach:
-    /// instead of reading the DB directly, we assert UI→real-backend
-    /// round-trips against real command output (FR-008).
+    /// # Primary assertion path
+    ///
+    /// The primary assertion path for journeys is the **real UI**: use
+    /// `self.driver.find(By::...)` and assert on element text/state. That path
+    /// works over real IPC with no special frontend wiring.
+    ///
+    /// # Secondary path (this helper)
+    ///
+    /// `invoke()` provides a secondary assertion path that reads back backend
+    /// state directly. It only works when:
+    /// 1. The frontend was built with `VITE_E2E=1`, AND
+    /// 2. `window.__APP_E2E__.invoke` is wired in the frontend code.
+    ///
+    /// Neither is guaranteed today. Use `invoke()` only in journeys where you
+    /// have verified both conditions hold; otherwise assert through the UI.
     ///
     /// The injected WebDriver callback is the last script argument
     /// (`arguments[arguments.length-1]`); the bridge resolves it with
@@ -105,7 +148,7 @@ impl E2eApp {
             var cmdArgs  = arguments[1];
             var callback = arguments[arguments.length - 1];
             if (!window.__APP_E2E__ || typeof window.__APP_E2E__.invoke !== 'function') {
-                callback({ ok: false, error: '__APP_E2E__ bridge missing (build with VITE_E2E=1)' });
+                callback({ ok: false, error: '__APP_E2E__ bridge missing (build with VITE_E2E=1 and ensure bridge is wired)' });
                 return;
             }
             window.__APP_E2E__.invoke(cmd, cmdArgs).then(function(value) {
@@ -138,8 +181,24 @@ impl E2eApp {
 }
 
 // ---------------------------------------------------------------------------
-// Private helpers (each carries a TODO(spec-037 wiring) note)
+// Private helpers
 // ---------------------------------------------------------------------------
+
+/// Resolve the path to the built `desktop_shell` binary.
+///
+/// Reads `ALM_E2E_APP_BIN` from the environment if set; otherwise falls back
+/// to the debug build path `target/debug/desktop_shell[.exe]`.
+fn app_binary_path() -> String {
+    if let Ok(bin) = std::env::var("ALM_E2E_APP_BIN") {
+        return bin;
+    }
+    // Determine repo root from the manifest dir (this test crate is under
+    // crates/e2e-tests; go up three levels: e2e-tests → crates → repo root).
+    let manifest = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest.parent().and_then(|p| p.parent()).unwrap_or(manifest);
+    let exe = if cfg!(target_os = "windows") { "desktop_shell.exe" } else { "desktop_shell" };
+    repo_root.join("target").join("debug").join(exe).to_string_lossy().into_owned()
+}
 
 /// Pre-flight check: verify driver binaries are present and version-matched.
 ///
@@ -174,8 +233,11 @@ fn reset_database() -> Result<()> {
 
 /// Spawn `tauri-driver --port 4444` as a background child process.
 ///
-/// TODO(spec-037 wiring): wrap in `xvfb-run` on Linux (headless display);
-/// pass the built application binary via `tauri-driver -- /path/to/alm`.
+/// tauri-driver manages the native WebDriver (WebKitWebDriver on Linux,
+/// msedgedriver on Windows) itself. On Linux, wrap this process in `xvfb-run`
+/// before calling nextest, or run under an existing Xvfb display.
+///
+/// TODO(spec-037 wiring): add preflight error when tauri-driver is not on PATH.
 fn spawn_tauri_driver() -> Result<Child> {
     Command::new("tauri-driver")
         .arg("--port")

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1,0 +1,185 @@
+//! Shared harness for spec 037 Layer-2 real-UI E2E journeys.
+//!
+//! All journeys are `#[ignore]`d. They are compiled stubs that appear in
+//! `cargo nextest list` but are deferred until two prerequisites land:
+//!
+//! 1. The `__APP_E2E__` bridge (exposed by the desktop app when built with
+//!    `VITE_E2E=1`) is wired in the frontend.
+//! 2. The tauri-driver WebDriver caps (`tauri:options.application` +
+//!    `browserName="wry"`) replace the chrome placeholder caps used here.
+//!
+//! See `crates/e2e-tests/README.md` for the full run procedure.
+
+#![allow(dead_code)]
+
+use std::process::{Child, Command};
+
+use anyhow::{anyhow, Context, Result};
+use serde::de::DeserializeOwned;
+use serde_json::{json, Value};
+use thirtyfour::prelude::*;
+
+/// URL where tauri-driver listens for W3C WebDriver sessions.
+pub const TAURI_DRIVER_URL: &str = "http://127.0.0.1:4444";
+
+/// Vite dev-server port used when running against the real backend
+/// (`VITE_USE_MOCKS=false`).
+pub const APP_URL: &str = "http://127.0.0.1:1420";
+
+// ---------------------------------------------------------------------------
+// Private deserialization target for invoke() responses
+// ---------------------------------------------------------------------------
+
+/// Raw bridge response shape, using `Value` so no `T: Default` bound is needed.
+#[derive(serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct InvokeOutcome {
+    ok: bool,
+    #[serde(default)]
+    value: Option<Value>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+impl InvokeOutcome {
+    fn into_result<T: DeserializeOwned>(self) -> Result<T> {
+        if self.ok {
+            let raw =
+                self.value.ok_or_else(|| anyhow!("invoke succeeded but returned no value"))?;
+            serde_json::from_value(raw).context("failed to deserialise invoke value into T")
+        } else {
+            Err(anyhow!("invoke error: {}", self.error.unwrap_or_else(|| "unknown error".into())))
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// E2eApp — the main harness handle
+// ---------------------------------------------------------------------------
+
+/// Handle for a running test app + WebDriver session.
+///
+/// Call [`E2eApp::launch`] to start, [`E2eApp::shutdown`] to tear down.
+pub struct E2eApp {
+    pub driver: WebDriver,
+    driver_proc: Option<Child>,
+}
+
+impl E2eApp {
+    /// Launch a full E2E session: preflight → reset DB → spawn tauri-driver →
+    /// connect WebDriver → navigate to [`APP_URL`].
+    pub async fn launch() -> Result<Self> {
+        preflight()?;
+        reset_database()?;
+
+        let driver_proc =
+            spawn_tauri_driver().context("failed to spawn tauri-driver on port 4444")?;
+
+        // TODO(spec-037 wiring): replace DesiredCapabilities::chrome() with
+        // real tauri-driver caps:
+        //   caps.set_browser_name("wry")?;
+        //   caps.add_capability("tauri:options", json!({"application": "/path/to/alm"}))?;
+        // Chrome caps are a placeholder that makes this file compile.
+        let driver = WebDriver::new(TAURI_DRIVER_URL, DesiredCapabilities::chrome())
+            .await
+            .context("WebDriver::new failed — is tauri-driver running on :4444?")?;
+
+        driver.goto(APP_URL).await.context("driver.goto APP_URL failed")?;
+
+        Ok(Self { driver, driver_proc: Some(driver_proc) })
+    }
+
+    /// Issue a Tauri command through the `window.__APP_E2E__` bridge.
+    ///
+    /// The bridge is exposed by the desktop app when it is built with
+    /// `VITE_E2E=1`.  This replaces the old better-sqlite3 reader approach:
+    /// instead of reading the DB directly, we assert UI→real-backend
+    /// round-trips against real command output (FR-008).
+    ///
+    /// The injected WebDriver callback is the last script argument
+    /// (`arguments[arguments.length-1]`); the bridge resolves it with
+    /// `{ok:true,value}` or `{ok:false,error}`.
+    pub async fn invoke<T: DeserializeOwned>(&self, command: &str, args: Value) -> Result<T> {
+        let script = r#"
+            var cmd      = arguments[0];
+            var cmdArgs  = arguments[1];
+            var callback = arguments[arguments.length - 1];
+            if (!window.__APP_E2E__ || typeof window.__APP_E2E__.invoke !== 'function') {
+                callback({ ok: false, error: '__APP_E2E__ bridge missing (build with VITE_E2E=1)' });
+                return;
+            }
+            window.__APP_E2E__.invoke(cmd, cmdArgs).then(function(value) {
+                callback({ ok: true, value: value });
+            }).catch(function(err) {
+                callback({ ok: false, error: String(err) });
+            });
+        "#;
+
+        let ret = self
+            .driver
+            .execute_async(script, vec![json!(command), args])
+            .await
+            .context("execute_async failed")?;
+
+        let outcome: InvokeOutcome =
+            ret.convert().context("failed to deserialise InvokeOutcome from bridge response")?;
+
+        outcome.into_result::<T>()
+    }
+
+    /// Quit the WebDriver session and kill the driver process if present.
+    pub async fn shutdown(mut self) -> Result<()> {
+        let _ = self.driver.quit().await;
+        if let Some(mut child) = self.driver_proc.take() {
+            let _ = child.kill();
+        }
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Private helpers (each carries a TODO(spec-037 wiring) note)
+// ---------------------------------------------------------------------------
+
+/// Pre-flight check: verify driver binaries are present and version-matched.
+///
+/// TODO(spec-037 wiring): assert that `tauri-driver` is on `$PATH`; on Linux
+/// also assert `WebKitWebDriver`; on Windows assert `msedgedriver`.  Return a
+/// named actionable error describing what is missing and where to get it
+/// (FR-015).
+fn preflight() -> Result<()> {
+    Ok(())
+}
+
+/// Reset the application database so each test starts from a clean state.
+///
+/// FR-006: if `ALM_DB_URL` is set and looks like `sqlite://PATH?...`, strip
+/// the `sqlite://` prefix and everything from `?` onward, then
+/// `std::fs::remove_file` that path (errors are ignored so a missing file
+/// doesn't fail startup).
+///
+/// TODO(spec-037 wiring): when `ALM_DB_URL` is unset, resolve the OS
+/// app-data path (`dev.astro-plan.astro-library-manager/alm.db`) and remove
+/// it there instead.
+fn reset_database() -> Result<()> {
+    if let Ok(url) = std::env::var("ALM_DB_URL") {
+        if let Some(path_and_query) = url.strip_prefix("sqlite://") {
+            let path = path_and_query.split('?').next().unwrap_or(path_and_query);
+            let _ = std::fs::remove_file(path);
+        }
+    }
+    // TODO(spec-037 wiring): resolve OS app-data path when ALM_DB_URL is unset.
+    Ok(())
+}
+
+/// Spawn `tauri-driver --port 4444` as a background child process.
+///
+/// TODO(spec-037 wiring): wrap in `xvfb-run` on Linux (headless display);
+/// pass the built application binary via `tauri-driver -- /path/to/alm`.
+fn spawn_tauri_driver() -> Result<Child> {
+    Command::new("tauri-driver")
+        .arg("--port")
+        .arg("4444")
+        .spawn()
+        .map_err(|e| anyhow!("failed to spawn tauri-driver: {e}"))
+}

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -1,0 +1,103 @@
+//! Spec 037 Layer-2 real-UI E2E journey stubs.
+//!
+//! All journeys are `#[ignore]`d. They compile and appear in
+//! `cargo nextest list` but execution is deferred until the
+//! `__APP_E2E__` bridge and tauri-driver caps are wired in.
+//!
+//! Run (once wired):
+//! ```text
+//! cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+//! ```
+
+mod common;
+use common::E2eApp;
+
+/// First-run wizard → SIMBAD target resolve → project creation.
+///
+/// Backend REAL: search.global, targeting.resolve, projects.create.
+///
+/// Steps:
+/// 1. Launch app in first-run state (fresh DB).
+/// 2. Complete wizard (library root, organisation state choice).
+/// 3. Navigate to Targets; invoke search.global with a known target name.
+/// 4. Invoke targeting.resolve; assert RA/Dec round-trips from real backend (FR-008).
+/// 5. Create a project linked to the resolved target; assert project appears in list.
+#[tokio::test]
+#[ignore = "spec-037: thirtyfour journey scaffold; wiring deferred"]
+async fn first_run_resolve_create_project() -> anyhow::Result<()> {
+    let _app = E2eApp::launch().await?;
+    // TODO step 1: assert wizard screen is visible.
+    // TODO step 2: fill wizard form fields and submit.
+    // TODO step 3: navigate to Targets; search for "M42".
+    // TODO step 4: invoke search.global, assert result count > 0.
+    // TODO step 5: invoke targeting.resolve, assert ra/dec fields present.
+    // TODO step 6: create project; invoke projects.list, assert record present.
+    todo!("spec-037: first_run_resolve_create_project journey not yet wired")
+}
+
+/// Filesystem plan review → apply → audit record assertion.
+///
+/// Backend REAL: fs planner/executor + audit.
+///
+/// Steps:
+/// 1. Register a disposable test library root with known temp files.
+/// 2. Trigger plan generation; assert plan appears in Plan panel.
+/// 3. Apply the plan via UI; assert the real filesystem side effect (FR-009).
+/// 4. Invoke audit.list; assert a matching audit record exists (FR-016).
+/// 5. Clean up temp files.
+#[tokio::test]
+#[ignore = "spec-037: thirtyfour journey scaffold; wiring deferred"]
+async fn plan_review_apply_with_audit() -> anyhow::Result<()> {
+    let _app = E2eApp::launch().await?;
+    // TODO step 1: create temp dir + files; register as library root.
+    // TODO step 2: navigate to Inbox/Plan panel; assert plan item visible.
+    // TODO step 3: click Apply; assert file moved/created on disk.
+    // TODO step 4: invoke audit.list; assert record with matching path.
+    // TODO step 5: remove temp dir.
+    todo!("spec-037: plan_review_apply_with_audit journey not yet wired")
+}
+
+/// Inbox confirm → sessions grouped → calibration suggest → search by alias.
+///
+/// Backend REAL: sessions.list, calibration.match.suggest, search.global.
+///
+/// Steps:
+/// 1. Seed inbox with a known FITS file path via env/fixture.
+/// 2. Confirm the inbox item; assert session list shows root_id set.
+/// 3. Invoke calibration.match.suggest; assert real candidate list returned.
+/// 4. Invoke search.global with a target alias; assert alias resolves (FR-008).
+#[tokio::test]
+#[ignore = "spec-037: thirtyfour journey scaffold; wiring deferred"]
+async fn ingestion_sessions_search() -> anyhow::Result<()> {
+    let _app = E2eApp::launch().await?;
+    // TODO step 1: pre-seed inbox item (fixture path set via env).
+    // TODO step 2: navigate to Inbox; confirm item; invoke sessions.list.
+    // TODO step 3: assert session.root_id is set (not null).
+    // TODO step 4: invoke calibration.match.suggest; assert candidates.len() >= 0.
+    // TODO step 5: invoke search.global with alias; assert result.slug matches.
+    todo!("spec-037: ingestion_sessions_search journey not yet wired")
+}
+
+/// Lifecycle integrity: blockedReason from real DTO, auto-block audit row,
+/// unarchive event.
+///
+/// Backend: lifecycle (note: sessions.transition is still a STUB, so
+/// transition-driven asserts remain TODO inside the body).
+///
+/// Steps:
+/// 1. Create a project and advance it to a state that triggers auto-block.
+/// 2. Invoke lifecycle DTO; assert blockedReason is present and non-empty.
+/// 3. Invoke audit.list; assert auto-block event record exists.
+/// 4. Trigger unarchive; assert an event is emitted (invoke events.recent).
+#[tokio::test]
+#[ignore = "spec-037: thirtyfour journey scaffold; wiring deferred"]
+async fn lifecycle_integrity() -> anyhow::Result<()> {
+    let _app = E2eApp::launch().await?;
+    // TODO step 1: create project + advance state via UI or invoke.
+    // TODO step 2: invoke lifecycle DTO; assert blockedReason field present.
+    // TODO step 3: invoke audit.list; assert auto-block row exists.
+    // TODO step 4: invoke unarchive; assert events.recent contains unarchive event.
+    // NOTE: sessions.transition is still a STUB — transition-driven asserts
+    // must remain TODO until that backend command is real.
+    todo!("spec-037: lifecycle_integrity journey not yet wired")
+}

--- a/crates/e2e-tests/tests/smoke.rs
+++ b/crates/e2e-tests/tests/smoke.rs
@@ -1,0 +1,44 @@
+//! Spec 037 Layer-2 real-UI smoke test stubs.
+//!
+//! Verifies that every top-level route loads without a JS error.
+//! Ignored until the `__APP_E2E__` bridge and tauri-driver caps are wired in.
+//!
+//! Run (once wired):
+//! ```text
+//! cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+//! ```
+
+mod common;
+use common::E2eApp;
+
+/// Representative top-level routes to smoke-test (FR-007).
+///
+/// TODO(spec-037 wiring): confirm full route list from the app router
+/// (apps/desktop/src/router or equivalent) before the wiring sprint.
+const TOP_LEVEL_ROUTES: &[(&str, &str)] = &[
+    ("Dashboard", "/"),
+    ("Targets", "/targets"),
+    ("Sessions", "/sessions"),
+    ("Calibration", "/calibration"),
+    ("Inbox", "/inbox"),
+    ("Projects", "/projects"),
+    ("Settings", "/settings"),
+];
+
+/// Navigate to every top-level route and assert no JS error is thrown (FR-007).
+///
+/// Steps (per route):
+/// 1. Navigate to `APP_URL + path`.
+/// 2. Wait for the shell chrome to appear (nav sidebar / header).
+/// 3. Assert `window.__alm_lastError` is undefined (no unhandled JS error).
+#[tokio::test]
+#[ignore = "spec-037: thirtyfour smoke scaffold; wiring deferred"]
+async fn all_top_level_screens_load() -> anyhow::Result<()> {
+    let _app = E2eApp::launch().await?;
+    let _routes = TOP_LEVEL_ROUTES;
+    // TODO: for each (name, path) in _routes:
+    //   1. driver.goto(format!("{}{}", APP_URL, path)).await?
+    //   2. wait for shell selector (e.g. "[data-testid='app-shell']")
+    //   3. invoke or execute_sync to read window.__alm_lastError; assert None
+    todo!("spec-037: all_top_level_screens_load smoke not yet wired")
+}

--- a/specs/037-e2e-integration-testing/plan.md
+++ b/specs/037-e2e-integration-testing/plan.md
@@ -13,27 +13,26 @@ cross-platform CI and local workflows:
   real, file-backed, per-test SQLite DB with real migrations; SIMBAD mocked only
   at the HTTP boundary. Covers every implemented feature area (D7). Runs on all 3
   OS, carries the bulk of assertions.
-- **Layer 2 — full-stack E2E** (Playwright + `tauri-driver`): complete and reuse
-  the skipped spec-033 real-backend scaffold to drive the built app's real UI →
-  real IPC → real backend for a thin set of smoke journeys, asserting a
-  UI↔backend round-trip and a real filesystem mutation + audit record. Required on
-  Linux + Windows; best-effort on macOS via an optional, debug-only WebDriver
-  plugin (D4).
+- **Layer 2 — full-stack E2E** (**thirtyfour + cargo-nextest** + `tauri-driver`):
+  drive the built app's real UI → real IPC → real backend for a thin set of smoke
+  journeys, asserting a UI↔backend round-trip and a real filesystem mutation +
+  audit record. Required on Linux + Windows; best-effort on macOS via an optional,
+  debug-only WebDriver plugin (D4). Journeys live in `crates/e2e-tests/` (Rust,
+  `#[ignore]` stubs today — wiring deferred per D9).
 
-CI: a new `.github/workflows/ci.yml` 3-OS matrix runs Layer 1 (required, all OS)
-before Layer 2 (required Linux+Windows, optional macOS). Local: `just` targets
-mirror CI per-layer. Documentation: the two-layer strategy and per-OS run
-instructions go into the `.apm/`-sourced standing instructions and a new
-`docs/development/testing.md`.
+CI: `ci.yml` 3-OS matrix (Layer 1, required all OS) + `e2e.yml` (Layer 2,
+thirtyfour+nextest, Linux required). Local: `just` targets mirror CI per-layer.
+Documentation: the two-layer strategy and per-OS run instructions go into the
+`.apm/`-sourced standing instructions and `docs/development/testing.md`.
 
 No product behavior changes; no image-processing tool invocation.
 
 ## Technical Context
 
 **Language/Version**: Rust (workspace, edition per repo) + TypeScript 5 / React 19; Tauri v2.11
-**Primary Dependencies**: sqlx ^0.9 (SQLite), tokio; Playwright ^1.60 + `tauri-driver`; Vitest ^4 (existing). New dev-deps: `wiremock` (Rust, network-boundary mock), `better-sqlite3` (E2E DB assertions), `tempfile` (already present). macOS-optional: `tauri-plugin-webdriver`.
+**Primary Dependencies**: sqlx ^0.9 (SQLite), tokio; **thirtyfour ^0.37** (Rust W3C client) + `tauri-driver` + **cargo-nextest** (Layer 2); Vitest ^4 (existing). New dev-deps: `wiremock` (Rust, network-boundary mock), `tempfile` (already present). macOS-optional: `tauri-plugin-webdriver`.
 **Storage**: SQLite via sqlx; migrations in `crates/persistence/db/migrations/`. Tests use per-test tempdir DBs (Layer 1) and the app's real on-disk DB (Layer 2).
-**Testing**: Layer 1 = `cargo test --workspace` (crate `tests/` dirs). Layer 2 = `pnpm test:e2e:real` (Playwright/WebDriver). Existing unit + mock-UI tests retained.
+**Testing**: Layer 1 = `cargo test --workspace` (crate `tests/` dirs). Layer 2 = `cargo nextest run -p e2e_tests --profile e2e` (thirtyfour/W3C). Existing unit + mock-UI tests retained.
 **Target Platform**: Desktop — Windows, Linux, macOS.
 **Project Type**: Tauri desktop monorepo (Rust crates + React app + language-neutral contracts).
 **Performance Goals**: Layer 1 deterministic and offline-capable (SC-006); fast-fail before Layer 2 (FR-012). No app perf targets (out of scope).
@@ -82,20 +81,28 @@ crates/<feature-crate>/tests/          # Layer 1 lives in the relevant crate's t
 # NOTE: do NOT reuse the existing repo-root `tests/integration/` dir for Layer 1 —
 # it already holds Playwright *mock-UI* specs (TypeScript). Keep Rust Layer-1
 # tests inside crate `tests/` dirs to avoid path/terminology collision.
-apps/desktop/e2e/
-├── helpers/tauri-app.ts               # reuse (033)
-├── helpers/db.ts                      # replace placeholder → better-sqlite3 reader
-├── playwright.real-backend.config.ts  # reuse (033)
-└── real-backend/*.spec.ts             # un-skip + flesh out journeys
-.github/workflows/ci.yml               # NEW — 3-OS matrix
-justfile                               # add test-integration / test-e2e targets
-docs/development/testing.md            # NEW — two-layer strategy + per-OS guide
+crates/e2e-tests/                      # Layer 2 — thirtyfour+nextest harness (ADOPTED)
+├── Cargo.toml                         # dev-dep: thirtyfour ^0.37
+├── tests/common/mod.rs                # harness: tauri-driver caps, invoke() helper
+├── tests/smoke.rs                     # #[ignore] smoke stubs
+└── tests/journeys.rs                  # #[ignore] journey stubs
+.config/nextest.toml                   # [profile.e2e] for cargo nextest
+apps/desktop/e2e/                      # legacy scaffolds (kept, not deleted)
+├── helpers/tauri-app.ts               # WebdriverIO spike harness (reference)
+├── wdio/                              # WebdriverIO runner + tauri-spike (reference)
+└── real-backend/*.spec.ts             # Playwright real-backend stubs (reference)
+.github/workflows/ci.yml               # 3-OS matrix (Layer 1, required)
+.github/workflows/e2e.yml              # Layer 2 (thirtyfour+nextest, Linux required)
+justfile                               # test-integration / test-e2e targets
+docs/development/testing.md            # two-layer strategy + per-OS guide
 .apm/instructions/ (+ regenerate CLAUDE.md/AGENTS.md), PRODUCT.md   # standing convention
 ```
 
-**Structure Decision**: Reuse the existing monorepo layout and the spec-033 E2E
-scaffold; add Layer-1 tests within existing crate `tests/` dirs to keep crates
-independently testable (per repo standard). No new crates required.
+**Structure Decision**: `crates/e2e-tests` is the adopted Layer-2 home (thirtyfour
++ nextest); it coexists transitionally with the legacy WebdriverIO scaffold in
+`apps/desktop/e2e/wdio/` (not deleted — reference for the proven harness pattern)
+and the Playwright real-backend stubs (not deleted — structural reference). Layer-1
+tests live in existing crate `tests/` dirs to keep crates independently testable.
 
 ## Complexity Tracking
 

--- a/specs/037-e2e-integration-testing/quickstart.md
+++ b/specs/037-e2e-integration-testing/quickstart.md
@@ -17,26 +17,56 @@ cargo test --workspace
 - Each test gets an isolated, file-backed SQLite DB in a tempdir with real
   migrations.
 
-## Layer 2 — full-stack E2E smoke
+## Layer 2 — full-stack E2E smoke (thirtyfour + cargo-nextest)
 
 ```bash
-just test-e2e                  # → pnpm --filter @astro-plan/desktop test:e2e:real
+# Run all Layer-2 journeys (including ignored stubs):
+cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+
+# Run only the non-ignored subset (currently: 0 journeys un-ignored):
+cargo nextest run -p e2e_tests --profile e2e
 ```
 
-Drives the freshly built app through its real UI via `tauri-driver`.
+Today all journeys are `#[ignore]` stubs — the command above shows 5 skipped, 0
+failed. Remove `#[ignore]` on a journey to make it run.
+
+Drives the freshly built app through its real UI via `tauri-driver` (W3C
+WebDriver). thirtyfour (Rust W3C client) connects to tauri-driver on :4444 and
+sends the `tauri:options.application` capability (no `browserName` — WebKitWebDriver
+rejects the session when it is set). The app loads its own frontend from the Tauri
+devUrl (:5173); do NOT call `driver.goto(...)` in journeys.
+
+### Full prerequisite setup (Linux)
+
+1. **Build the frontend** with `VITE_E2E=1` (enables typeable path inputs):
+   ```bash
+   VITE_E2E=1 pnpm --filter @astro-plan/desktop build
+   ```
+2. **Serve `dist` on :5173** (background):
+   ```bash
+   pnpm --filter @astro-plan/desktop preview --port 5173 &
+   ```
+3. **Build the desktop binary** (debug):
+   ```bash
+   cargo build -p desktop_shell
+   ```
+4. **Run under xvfb** (headless display for WebKitWebDriver):
+   ```bash
+   xvfb-run -a cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+   ```
+
+Set `ALM_E2E_APP_BIN=/path/to/binary` to override the default debug path.
+Set `ALM_DB_URL=sqlite:///path/to/alm.db` to control which DB is reset per-test.
 
 ### Prerequisites by OS
 
 | OS | Driver | Install / notes |
 |---|---|---|
-| **Linux** | `tauri-driver` + `WebKitWebDriver` | `cargo install tauri-driver --locked`; `apt install webkit2gtk-driver xvfb`; runs under `xvfb-run`. |
+| **Linux** | `tauri-driver` + `WebKitWebDriver` | `cargo install tauri-driver --locked`; `apt install webkit2gtk-driver xvfb`; run under `xvfb-run`. |
 | **Windows** | `tauri-driver` + `msedgedriver.exe` | `cargo install tauri-driver --locked`; fetch `msedgedriver` **version-matched to installed Edge** or it hangs on connect. |
-| **macOS** | *best-effort* — `tauri-plugin-webdriver` | Official `tauri-driver` does **not** support macOS. macOS E2E is optional/non-blocking; the embedded plugin path is debug-only. Layer 1 still runs fully on macOS. |
+| **macOS** | *best-effort* — `tauri-plugin-webdriver` | Official `tauri-driver` does **not** support macOS. macOS E2E is optional/non-blocking; the embedded plugin path (thirtyfour connects to it identically) is debug-only. `tauri-plugin-mcp` is an additional dev-only agent-interactive debug path (not a CI gate). Layer 1 still runs fully on macOS. |
 
-If a prerequisite is missing the command fails with a named message telling you
-what to install (FR-015).
-
-### What the smoke suite proves
+### What the smoke suite proves (once journeys are un-ignored)
 
 - Every top-level screen loads in the real app.
 - At least one journey round-trips a value UI → real backend → UI.
@@ -45,9 +75,10 @@ what to install (FR-015).
 
 ## CI
 
-Every change runs both layers automatically (`.github/workflows/ci.yml`):
-Layer 1 on Linux/Windows/macOS (required) → Layer 2 on Linux/Windows (required),
-macOS (optional). See [research.md](./research.md) D5.
+`ci.yml` runs Layer 1 on Linux/Windows/macOS (required, all 3 OS) on every
+change. `e2e.yml` runs Layer 2 (thirtyfour+nextest, Linux required) — green
+today because all journeys are `#[ignore]` stubs (`--no-tests=warn`). See
+[research.md](./research.md) D5.
 
 ## Adding coverage for a new feature
 

--- a/specs/037-e2e-integration-testing/research.md
+++ b/specs/037-e2e-integration-testing/research.md
@@ -107,6 +107,25 @@ Real UI→IPC→backend journeys use **WebdriverIO `remote()` + `tauri-driver`**
 - Linux (WebKitWebDriver) first; Windows (msedgedriver) once green. macOS stays
   best-effort per D4.
 
+**REVISION (thirtyfour adoption, 2026-06-20)**: **thirtyfour (Rust W3C client)
++ cargo-nextest** in `crates/e2e-tests` supersedes the WebdriverIO interim.
+Rationale: thirtyfour is the Rust equivalent of WebdriverIO's `remote()` against
+tauri-driver — it accepts the same `tauri:options.application` capability, does
+not set `browserName`, and connects to the same tauri-driver endpoint on :4444.
+Choosing thirtyfour keeps the entire E2E stack in Rust alongside Layer-1,
+consistent with the `rust.tauri` steering convention, and eliminates the Node.js
+runner + WebdriverIO dependency from the real-UI path. The proven tauri-driver
+setup from the US3 spike is unchanged: build frontend with `VITE_E2E=1`, serve
+`dist` on :5173 via `vite preview` (now an explicit CI background step rather
+than embedded in the wdio harness), build `desktop_shell`, then tauri-driver
+drives the built binary. The real-UI journeys are scaffolded as `#[ignore]` stubs
+in `crates/e2e-tests/tests/` (harness in `tests/common/`); wiring is deferred
+while backend stubs clear (see D9). The legacy `apps/desktop/e2e/wdio/`
+WebdriverIO scaffold remains on disk as a reference and is not deleted; CI no
+longer invokes it (e2e.yml now runs `cargo nextest run -p e2e_tests --profile
+e2e`). The `apps/desktop/e2e/` Playwright real-backend config also remains as a
+structural reference.
+
 ---
 
 ## D4 — macOS Layer 2 (the deferred decision)
@@ -114,18 +133,26 @@ Real UI→IPC→backend journeys use **WebdriverIO `remote()` + `tauri-driver`**
 **Context**: Verified current as of 2026 — Apple ships no WebDriver for embedded
 WKWebView, so the official `tauri-driver` supports **only Linux and Windows**.
 Third-party W3C plugins now fill the gap by embedding a WebDriver server inside
-the app (most mature: Choochmeque `tauri-plugin-webdriver`; also danielraffel's
-two-crate `tauri-plugin-webdriver-automation`; CrabNebula Cloud is hosted/paid).
+the app (most mature: Choochmeque `tauri-plugin-webdriver` + `tauri-webdriver`
+CLI; also danielraffel's two-crate `tauri-plugin-webdriver-automation`; CrabNebula
+Cloud is hosted/paid). For agent-interactive debugging (not CI) the
+`tauri-plugin-mcp` (P3GLEG) plugin provides a dev-only MCP interface into the
+running app — gated behind the same debug/dev-only compile flag; it is NOT a CI
+gate and is NOT required for Layer-2 E2E.
 
 **Decision**:
 1. **macOS Layer 1 (integration) is REQUIRED** and runs in CI on every change —
    it needs no special tooling (`cargo test`).
 2. **macOS Layer 2 (real-UI E2E) is BEST-EFFORT / non-merge-blocking** for this
    feature. The plan provisions it as an **optional CI job** evaluating
-   `tauri-plugin-webdriver` (Choochmeque), gated behind a **debug/dev-only
-   feature flag** so the embedded WebDriver server is **never present in release
-   builds** (mirrors the existing `dev-tools` compile-gate pattern from spec 021,
-   per CLAUDE.md). If it proves stable it can be promoted to required in a
+   `tauri-plugin-webdriver` (Choochmeque) + `tauri-webdriver` CLI, with the same
+   **thirtyfour** Rust W3C client connecting to the embedded WebDriver server
+   (same `tauri:options.application` cap, no `browserName`), gated behind a
+   **debug/dev-only feature flag** so the embedded WebDriver server is **never
+   present in release builds** (mirrors the existing `dev-tools` compile-gate
+   pattern from spec 021, per CLAUDE.md). `tauri-plugin-mcp` (P3GLEG) is an
+   additional dev-only path for agent-interactive debugging, NOT a CI gate.
+   If the plugin path proves stable it can be promoted to required in a
    follow-up; until then macOS Layer-2 failures do not block merge, and SC-002's
    "every required platform" treats macOS-E2E as not-required (FR-013's explicit
    not-applicable reporting applies if the plugin path is not yet adopted).
@@ -150,22 +177,30 @@ coverage immediately.
 
 ## D5 — CI/CD topology
 
-**Decision**: Add GitHub Actions workflows under `.github/workflows/` (currently
-empty). A `ci.yml` with a 3-OS matrix (`ubuntu-latest`, `windows-latest`,
-`macos-latest`):
+**Decision**: Two GitHub Actions workflows under `.github/workflows/`:
+
+**`ci.yml`** — 3-OS matrix (`ubuntu-latest`, `windows-latest`, `macos-latest`):
 - **Stage A (all 3 OS, required)**: `cargo build --workspace`, lint, then the
   Layer 1 integration suite (`cargo test --workspace`) + frontend unit tests.
-- **Stage B (Linux + Windows, required)**: build the app, then the Layer 2 E2E
-  smoke suite — Linux under `xvfb-run` with `WebKitWebDriver`; Windows with a
-  fetched version-matched `msedgedriver`.
-- **Stage C (macOS, optional / `continue-on-error`)**: the best-effort
-  `tauri-plugin-webdriver` E2E job (D4).
 
-Stage A gates Stage B/C (fast failures first, FR-012). Caching for cargo and
+Stage A gates any E2E work (fast failures first, FR-012). Caching for cargo and
 pnpm. Concurrency-cancel on superseding pushes.
 
-**Rationale**: Matches FR-010/FR-011/FR-012 — every change, all 3 OS, fast layer
-first, per-platform/per-layer attribution. macOS E2E isolated as optional per D4.
+**`e2e.yml`** — Layer-2 real-UI E2E (Linux first; Windows Stage B to follow):
+- **Layer 2 (Linux, required)**: install tauri-driver@2.0.6 via
+  `taiki-e/install-action`, install cargo-nextest via `taiki-e/install-action`,
+  build frontend with `VITE_E2E=1`, serve `dist` on :5173 via `vite preview`
+  (background step), build `desktop_shell`, then run
+  `xvfb-run -a cargo nextest run -p e2e_tests --profile e2e --no-tests=warn`.
+  `--no-tests=warn` keeps the job green while all journeys are `#[ignore]` stubs;
+  remove once a journey is un-ignored.
+- **Stage C (macOS, future / `continue-on-error`)**: best-effort via
+  `tauri-plugin-webdriver` (D4); deferred until plugin proves stable.
+
+**Rationale**: Matches FR-010/FR-011/FR-012. Separating ci.yml (Layer 1, 3-OS,
+required) from e2e.yml (Layer 2, real-UI, heavy build) keeps Layer-1 feedback
+fast and Layer-2 isolated. thirtyfour + nextest keeps the test runner in Rust,
+consistent with the rust.tauri steering convention.
 
 **Alternatives considered**:
 - *Single combined job* — rejected; loses per-platform attribution and fast-fail

--- a/specs/037-e2e-integration-testing/tasks.md
+++ b/specs/037-e2e-integration-testing/tasks.md
@@ -13,6 +13,14 @@ harnesses, CI, and docs themselves. Paths are repo-relative.
 > T001/T003/T006 `wiremock`+fixtures plan replaced by the existing `FakeResolver`/
 > `FakeSpawner` test doubles (no new deps). Remaining: US2 (CI), US3 (E2E
 > completion + T002/T007/T008), US4/US5 (docs), T036 (regression validation).
+>
+> **Status 2026-06-20**: **Layer-2 scaffold DONE** — `crates/e2e-tests` added
+> with thirtyfour ^0.37 + cargo-nextest; `#[ignore]` journey stubs compile and
+> list (5 skipped, 0 failed); harness in `tests/common/mod.rs` uses proven
+> `tauri:options.application` caps (no `browserName`). `e2e.yml` updated to
+> `cargo nextest run -p e2e_tests --profile e2e --no-tests=warn`. WebdriverIO
+> interim (`apps/desktop/e2e/wdio/`) retained on disk but no longer invoked by
+> CI. Wiring (T024–T027, T031) deferred per D9 backend gating.
 
 **Legend**: `[P]` = parallelizable (different files, no incomplete-task dep).
 Story labels map to spec user stories US1–US5.
@@ -22,7 +30,7 @@ Story labels map to spec user stories US1–US5.
 ## Phase 1: Setup
 
 - [ ] T001 Add Rust dev-dependencies for the integration layer (`wiremock`, ensure `tempfile`) to the relevant crates' `[dev-dependencies]` in `crates/app/core/Cargo.toml` and `crates/persistence/db/Cargo.toml`
-- [ ] T002 [P] Add E2E dev-dependency `better-sqlite3` to `apps/desktop/package.json` (devDependencies) for read-only DB assertions
+- [ ] T002 [P] ~~Add E2E dev-dependency `better-sqlite3` to `apps/desktop/package.json`~~ **SUPERSEDED** — the thirtyfour harness (`crates/e2e-tests`) asserts through the real UI via element find/text and the `invoke()` bridge; no JS DB reader is needed. `better-sqlite3` is not added.
 - [ ] T003 [P] Create shared test-fixture dir `tests/fixtures/` with SIMBAD response samples (success/ambiguous/not-found/error) and a couple of representative FITS-header OBJECT samples, per research D2
 - [ ] T004 Decide and document the integration-test tagging mechanism (e.g. a `live`/`network` feature or `#[ignore]` for the one live-SIMBAD test) so the default suite stays deterministic/offline, per research D2 + open items; record in `quickstart.md`
 
@@ -30,8 +38,8 @@ Story labels map to spec user stories US1–US5.
 
 - [X] T005 Create a Layer-1 test harness helper providing an isolated, file-backed SQLite DB in a `tempfile::tempdir()` with `sqlx::migrate!()` applied and a built `AppState`/`SqliteLifecycleRepository`, in `crates/app/core/tests/support/mod.rs` (or a small `crates/testkit` if cleaner) — per research D1, data-model isolation model
 - [ ] T006 [P] Add a `wiremock`-based SIMBAD boundary stub helper (serves the T003 fixtures on localhost) usable by resolver tests, in the test support module — per research D2
-- [ ] T007 Replace the placeholder `apps/desktop/e2e/helpers/db.ts` with a real read-only `better-sqlite3` reader resolving the app DB at the OS-specific app-data path (Linux/Windows/macOS), per research D3 + open items
-- [ ] T008 Add a fresh-DB reset + freshly-built-binary guarantee to `apps/desktop/e2e/helpers/tauri-app.ts` / `playwright.real-backend.config.ts` (`beforeAll` deletes the app DB; build step before tests), satisfying FR-006 — reuse existing 033 scaffold
+- [ ] T007 ~~Replace `apps/desktop/e2e/helpers/db.ts`~~ **SUPERSEDED** — DB assertions use the real UI or the `invoke()` bridge in `crates/e2e-tests/tests/common/mod.rs`; `better-sqlite3` is not adopted. The `db.ts` placeholder remains as a structural reference.
+- [ ] T008 ~~Add fresh-DB reset to `tauri-app.ts`~~ **SUPERSEDED** — fresh-DB reset in the thirtyfour harness is `reset_database()` in `crates/e2e-tests/tests/common/mod.rs` (reads `ALM_DB_URL` env; TODO wiring for OS app-data path). `tauri-app.ts` is now a reference scaffold.
 
 **Checkpoint**: Layer-1 harness + SIMBAD stub + E2E DB reader/reset exist. Story phases can begin.
 
@@ -91,12 +99,12 @@ Story labels map to spec user stories US1–US5.
 > Stage B and on Windows (handover item). Authoring + un-skipping the full journey
 > set against the real backend is the remaining US3 work, to be verified in CI.
 
-- [ ] T024 [P] [US3] Complete the **first-run setup → target resolve → project create** journey (un-skip + flesh out), asserting a UI→real-backend round-trip value (FR-008), in `apps/desktop/e2e/real-backend/us1_*.spec.ts`
-- [ ] T025 [P] [US3] Complete the **filesystem plan review → apply** journey asserting the real side effect **and** durable audit record, inside disposable test locations (FR-009, FR-016), in `apps/desktop/e2e/real-backend/*plan*.spec.ts`
-- [ ] T026 [P] [US3] Add an **all-top-level-screens-load** smoke spec covering every navigable feature screen without error (FR-007, coverage-matrix #21), in `apps/desktop/e2e/real-backend/screens_load.spec.ts`
-- [ ] T027 [P] [US3] Complete remaining 033 journey skeletons (subscriber startup, ingestion plumbing, lifecycle integrity) or convert to explicit, documented not-applicable if superseded — `apps/desktop/e2e/real-backend/us{2,3,5}_*.spec.ts`
-- [X] T028 [US3] Extend `ci.yml` with **Stage B (required, Linux+Windows)**: build app, run Layer-2 (Linux under `xvfb-run` + `WebKitWebDriver`; Windows fetch version-matched `msedgedriver`) — gated after Stage A (FR-010/FR-012); ensure the `better-sqlite3` native binding is installed/rebuilt per-OS runner so the `db.ts` reader loads (addresses F4 native-module risk)
-- [X] T029 [US3] Add **Stage C (macOS, optional/`continue-on-error`)** for best-effort macOS E2E via debug-only `tauri-plugin-webdriver`, OR wire FR-013 explicit not-applicable reporting if the plugin path is deferred — per research D4; ensure the plugin is compile-gated to debug builds (Constitution V)
+- [ ] T024 [P] [US3] Complete the **first-run setup → target resolve → project create** journey (un-ignore + flesh out), asserting a UI→real-backend round-trip value (FR-008), in `crates/e2e-tests/tests/journeys.rs` (thirtyfour `find(By::...)` against real UI + optional `invoke()`)
+- [ ] T025 [P] [US3] Complete the **filesystem plan review → apply** journey asserting the real side effect **and** durable audit record, inside disposable test locations (FR-009, FR-016), in `crates/e2e-tests/tests/journeys.rs`
+- [ ] T026 [P] [US3] Add an **all-top-level-screens-load** smoke spec covering every navigable feature screen without error (FR-007, coverage-matrix #21), in `crates/e2e-tests/tests/smoke.rs` (un-ignore the existing stub)
+- [ ] T027 [P] [US3] Complete remaining journey stubs (subscriber startup, ingestion plumbing, lifecycle integrity) or convert to explicit, documented not-applicable if superseded — in `crates/e2e-tests/tests/journeys.rs`
+- [X] T028 [US3] `e2e.yml` wired with thirtyfour+nextest on Linux (tauri-driver via `taiki-e/install-action@tauri-driver@2.0.6`, nextest via `taiki-e/install-action@nextest`, `vite preview` background step, `xvfb-run -a cargo nextest run -p e2e_tests --profile e2e --no-tests=warn`). Windows Stage B deferred.
+- [X] T029 [US3] macOS E2E best-effort path documented in research D4 (thirtyfour against `tauri-plugin-webdriver`); `tauri-plugin-mcp` noted as dev-only debug path. CI Stage C deferred until plugin proves stable.
 
 **Checkpoint**: Real UI↔backend wiring proven on Linux+Windows; macOS handled per D4.
 

--- a/tests/e2e/regression_setup_legacy_catalog.spec.ts
+++ b/tests/e2e/regression_setup_legacy_catalog.spec.ts
@@ -86,7 +86,9 @@ test.describe("Regression · setup legacy catalogSettings", () => {
     await page.goto("/#/setup");
 
     await expect(page.getByText(/Something went wrong/i)).toHaveCount(0);
-    await expect(page.getByText(/catalog/i).first()).toBeVisible({ timeout: 10_000 });
+    // Step index 2 was rebranded "Catalogs" → "Configuration" (#259); the legacy
+    // `{ downloadAll: true }` catalogSettings must still render the step (no crash).
+    await expect(page.getByText(/Configuration/i).first()).toBeVisible({ timeout: 10_000 });
     expect(
       errors.filter((e) => /Cannot read properties of undefined/i.test(e)),
       `page errors: ${errors.join(" | ")}`,


### PR DESCRIPTION
## Summary

Adopts the **thirtyfour (Rust W3C WebDriver client) + cargo-nextest** stack for spec 037's Layer-2 real-UI E2E, per the rust.tauri steering convention. This supersedes the interim **WebdriverIO** choice from the US3 spike — thirtyfour is the Rust equivalent of WebdriverIO's `remote()` against `tauri-driver` (same `tauri:options.application`, no `browserName`), so it solves the exact problem the spike found with Playwright while keeping the E2E stack in Rust alongside Layer-1.

Per direction, this lands **journeys as high-level `#[ignore]` stubs** — real assertion wiring is deferred while the backend command surface is still moving.

## What's included

- **`crates/e2e-tests`** — a thirtyfour harness (`tests/common/`: driver/app lifecycle, fresh-DB reset, preflight; built `desktop_shell` driven via `tauri:options.application`, no `browserName`, no `goto`) + 5 journeys as `#[tokio::test] #[ignore]` stubs (`tests/journeys.rs`, `tests/smoke.rs`) with `todo!()` bodies. They compile and list under nextest but don't run yet.
- **`.config/nextest.toml`** — `[profile.e2e]` (serial, 60s slow-timeout, 1 retry).
- **Spec artifacts** — research D3 (thirtyfour-adoption revision), D4 (macOS: same client vs dev-gated Choochmeque `tauri-plugin-webdriver` + P3GLEG `tauri-plugin-mcp` for agent-interactive debugging), D5 (CI), plan/tasks/quickstart re-pointed to `cargo nextest run -p e2e_tests --profile e2e`.
- **CI** — `e2e.yml` converted from WebdriverIO to nextest (`taiki-e/install-action@nextest`, `tauri-driver@2.0.6`, `vite preview` on :5173, `--no-tests=warn` keeps it green while journeys are ignored); `ci.yml` pointer updated.

## Status / deferred

- Journeys are `#[ignore]` scaffolds — `cargo nextest run -p e2e_tests --profile e2e` exits 0 (0 run / 5 skipped), proving the runner + CI wiring. Real assertions land once the backend stabilizes (`sessions.calendar/transition/split/merge` are still stubs).
- The legacy `apps/desktop/e2e` WebdriverIO scaffold is **retained pending removal** once the Rust suite is wired.
- macOS Stage C (Choochmeque plugin) and Windows `msedgedriver` remain best-effort/deferred.

## Verification

- `cargo nextest run -p e2e_tests --profile e2e --no-tests=warn` → exit 0, 5 skipped
- `cargo clippy -p e2e_tests --all-targets -- -D warnings` clean; `cargo fmt` clean
- `cargo nextest list` shows all 5 journeys

Companion steering change: `agentic-packages` PR #324 (frames the stack as an adopted convention).