### PR TITLE
chore: pin apm dependencies to caret versions

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -4,22 +4,23 @@ description: APM project for Astro Library Manager.
 author: Sjors Robroek
 dependencies:
   apm:
-  - srobroek/agentic-packages/packages/core#main
-  - srobroek/agentic-packages/packages/speckit#main
-  - srobroek/agentic-packages/packages/steering-speckit#main
-  - srobroek/agentic-packages/packages/speckit-dag-hooks#main
-  - srobroek/agentic-packages/packages/language-rust#main
-  - srobroek/agentic-packages/packages/language-typescript#main
-  - srobroek/agentic-packages/packages/frontend#main
-  - srobroek/agentic-packages/packages/quality#main
-  - srobroek/agentic-packages/packages/docs-architecture#main
-  - srobroek/agentic-packages/packages/mcp-playwright#main
-  - srobroek/agentic-packages/packages/mcp-codebase-memory#main
-  - srobroek/agentic-packages/packages/mcp-context7#main
-  - srobroek/agentic-packages/packages/mcp-package-version#main
-  - srobroek/agentic-packages/packages/mcp-repomix#main
-  - wshobson/agents/plugins/database-design
-  - srobroek/agentic-packages/packages/mcp-serena#main
+  - srobroek/agentic-packages/packages/core#^0.4.1
+  - srobroek/agentic-packages/packages/speckit#^0.1.2
+  - srobroek/agentic-packages/packages/steering-speckit#^0.2.1
+  - srobroek/agentic-packages/packages/speckit-dag-hooks#^0.3.2
+  - srobroek/agentic-packages/packages/language-rust#^0.1.2
+  - srobroek/agentic-packages/packages/language-typescript#^0.1.2
+  - srobroek/agentic-packages/packages/frontend#^0.1.2
+  - srobroek/agentic-packages/packages/rust-quality#^0.1.2
+  - srobroek/agentic-packages/packages/typescript-quality#^0.1.2
+  - srobroek/agentic-packages/packages/docs-architecture#^0.1.0
+  - srobroek/agentic-packages/packages/mcp-playwright#^0.1.0
+  - srobroek/agentic-packages/packages/mcp-codebase-memory#^0.1.0
+  - srobroek/agentic-packages/packages/mcp-context7#^0.1.0
+  - srobroek/agentic-packages/packages/mcp-package-version#^0.1.1
+  - srobroek/agentic-packages/packages/mcp-repomix#^0.1.0
+  - wshobson/agents/plugins/database-design#cc37bfdd292ce520ba1c44df7a3a70d5f8137236
+  - srobroek/agentic-packages/packages/mcp-serena#^0.1.0
 includes: auto
 scripts:
   install-agentic-tools: apm install --target claude,codex,agent-skills --update


### PR DESCRIPTION
## What
Pin every agentic-packages dependency to a caret version range (`#^x.y.z`, apm 0.21.0) instead of the mutable `#main` ref.

## Why
`#main` resolution depends on apm's git cache being fresh; a stale cache silently resolves an old commit (this bit us with the speckit-dag-hooks worktree fix). Caret pins resolve to a released version and lock the commit in `apm.lock.yaml` — deterministic, and immune to the stale-`#main`-cache class of bug.

## Notes
- `quality` (retired upstream — split into `rust-quality` + `typescript-quality`) is replaced by both pinned packages.
- The external `wshobson/agents/plugins/database-design` has no semver releases, so it's pinned to commit `cc37bfd`.
- Based on `main`'s dependency set (16 entries). The `041-inbox-plan-surface` branch additionally carries `resume-session` + `mcp-tauri`; those get pinned when that branch lands.