### PR TITLE
feat(layout): apply .alm-page convention to all shell routes

### DIFF
--- a/apps/desktop/src/dev/ContractsPage.tsx
+++ b/apps/desktop/src/dev/ContractsPage.tsx
@@ -18,6 +18,7 @@ import {
   type ContractCall,
   getSettings,
 } from '@/api/commands';
+import { PageShell } from '@/components';
 import { ContractList } from './ContractList';
 import { CallList } from './CallList';
 import { SchemaViewer } from './SchemaViewer';
@@ -28,7 +29,7 @@ import { pickDirectory } from '@/shared/native/picker';
 function DevModeDisabledStub() {
   return (
     <div
-      className="alm-dev-stub"
+      className="alm-dev-stub alm-page__scroll"
       style={{ padding: 'var(--alm-sp-8)', textAlign: 'center', color: 'var(--alm-text-muted)' }}
       data-testid="dev-disabled-stub"
     >
@@ -142,20 +143,27 @@ export function ContractsPage() {
   // Still loading devMode state.
   if (devMode === null) {
     return (
-      <div style={{ padding: 'var(--alm-sp-8)', color: 'var(--alm-text-muted)' }}>
-        Loading…
-      </div>
+      <PageShell>
+        <div className="alm-page__scroll" style={{ padding: 'var(--alm-sp-8)', color: 'var(--alm-text-muted)' }}>
+          Loading…
+        </div>
+      </PageShell>
     );
   }
 
   // DevMode is off — show stub, do not subscribe to call stream.
   if (!devMode) {
-    return <DevModeDisabledStub />;
+    return (
+      <PageShell>
+        <DevModeDisabledStub />
+      </PageShell>
+    );
   }
 
   return (
+    <PageShell>
     <div
-      className="alm-dev-contracts"
+      className="alm-dev-contracts alm-page__scroll"
       style={{ padding: 'var(--alm-sp-4)', display: 'flex', flexDirection: 'column', gap: 'var(--alm-sp-4)' }}
     >
       <div
@@ -239,5 +247,6 @@ export function ContractsPage() {
         />
       )}
     </div>
+    </PageShell>
   );
 }

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -379,13 +379,10 @@ export function InboxPage() {
           />
         }
         detail={
-          <div className="alm-inbox-center" style={{ display: 'flex', flexDirection: 'column', height: '100%', minHeight: 0 }}>
+          <div className="alm-inbox-center">
             {/* spec 041 US6: stats summary strip — always visible, never scrolls. */}
             {statsData && <InboxStatsSummary stats={statsData} />}
-            <div
-              className="alm-inbox-center__detail"
-              style={{ flex: '1 1 auto', minHeight: 0, overflowY: 'auto' }}
-            >
+            <div className="alm-inbox-center__detail">
               {selectedItem ? (
                 <InboxDetail
                   // Remount per item so per-item state (pending type overrides) never
@@ -407,10 +404,7 @@ export function InboxPage() {
                 exists OR a destination-root pick is pending (US8/FR-029), the
                 latter possible with zero open plans (no plan was created). */}
             {(openPlans.length > 0 || pendingRootPick) && (
-              <div
-                className="alm-inbox-center__plans"
-                style={{ flexShrink: 0, borderTop: '1px solid var(--alm-border)', paddingTop: 'var(--alm-sp-2)' }}
-              >
+              <div className="alm-inbox-center__plans">
                 <PlanPanel
                   plans={openPlans}
                   totalActions={totalActions}

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -285,6 +285,7 @@ export function WizardPage() {
     <div className="alm-page" style={{ display: 'flex', flexDirection: 'column', flex: 1, minHeight: 0 }}>
       {/* Wizard toolbar — styled consistently with other page toolbars */}
       <div
+        className="alm-page__bar"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -292,7 +293,6 @@ export function WizardPage() {
           padding: '0 var(--alm-space-4)',
           height: 'var(--alm-toolbar-height, 44px)',
           borderBottom: '1px solid var(--alm-border)',
-          flexShrink: 0,
         }}
       >
         <span style={{ fontSize: 'var(--alm-text-sm)', fontWeight: 600 }}>
@@ -310,6 +310,7 @@ export function WizardPage() {
 
       {/* Sub-toolbar: workflow profile breadcrumb */}
       <div
+        className="alm-page__bar"
         style={{
           display: 'flex',
           alignItems: 'center',
@@ -318,7 +319,6 @@ export function WizardPage() {
           fontSize: 'var(--alm-text-xs)',
           color: 'var(--alm-text-muted)',
           borderBottom: '1px solid var(--alm-border)',
-          flexShrink: 0,
         }}
       >
         <span>Workflow profile: {profileLabel}</span>

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -268,6 +268,16 @@
 .alm-two-pane { display: flex; flex: 1; min-height: 0; overflow: hidden; }
 .alm-two-pane__detail { flex: 1; overflow-y: auto; min-width: 0; }
 
+/*
+ * Inbox centre column — a sub-pane that manages its own internal scroll so the
+ * stats strip and plan panel stay pinned while only the detail region scrolls.
+ * overflow:hidden suppresses the outer .alm-two-pane__detail scroll so the
+ * inner .alm-inbox-center__detail is the sole scroll container.
+ */
+.alm-inbox-center { display: flex; flex-direction: column; flex: 1; min-height: 0; overflow: hidden; }
+.alm-inbox-center__detail { flex: 1 1 auto; min-height: 0; overflow-y: auto; }
+.alm-inbox-center__plans { flex-shrink: 0; border-top: 1px solid var(--alm-border); padding-top: var(--alm-sp-2); }
+
 /* === THREE-PANE LAYOUT === */
 .alm-three-pane { display: flex; flex: 1; min-height: 0; overflow: hidden; }
 .alm-three-pane__content { flex: 1; overflow-y: auto; min-width: 0; }


### PR DESCRIPTION
Addresses UI feedback that the standard layout wasn't applied everywhere. Most pages already used PageShell/ListDetailLayout (which emit .alm-page); fixes the real gaps: InboxPage nested-scroll (plan panel now pins; class-driven), WizardPage toolbars use .alm-page__bar, and the dev ContractsPage now wraps in PageShell. tsc 0, vitest 714 pass.