### PR TITLE
feat(settings): chip editor for per-type destination patterns

### DIFF
--- a/apps/desktop/src/features/settings/NamingStructure.tsx
+++ b/apps/desktop/src/features/settings/NamingStructure.tsx
@@ -1,36 +1,126 @@
 // spec 015 — Token Pattern Builder: backend-wired resolver, validator, preview.
 // spec 018 — pattern + autoApplyPattern keys persisted via settings transport.
 // spec 041 (T051, FR-026b) — per-frame-type destination patterns.
-import { useState, useEffect, useCallback, useRef } from 'react';
-import { Btn } from '@/ui';
 import {
-  getSettings,
-  patternValidate,
-  patternPreview,
-  updateSettings,
-  type PatternPart,
-  type PatternPreviewResponse,
-} from '@/api/commands';
+	type KeyboardEvent as ReactKeyboardEvent,
+	useCallback,
+	useEffect,
+	useRef,
+	useState,
+} from "react";
+import {
+	getSettings,
+	type PatternPart,
+	type PatternPreviewResponse,
+	patternPreview,
+	patternValidate,
+	updateSettings,
+} from "@/api/commands";
+import { Btn } from "@/ui";
 
 interface NamingStructureProps {
-  save: (scope: string, values: Record<string, unknown>) => void;
+	save: (scope: string, values: Record<string, unknown>) => void;
 }
 
 // ── Token / separator vocabulary ──────────────────────────────────────────────
 
 const AVAILABLE_TOKENS = [
-  'target',
-  'filter',
-  'date',
-  'frame_type',
-  'camera',
-  'exposure',
-  'gain',
-  'binning',
-  'set_temp',
+	"target",
+	"filter",
+	"date",
+	"frame_type",
+	"camera",
+	"exposure",
+	"gain",
+	"binning",
+	"set_temp",
 ] as const;
 
-const SEPARATORS = ['/', '-', '_', ' '] as const;
+const SEPARATORS = ["/", "-", "_", " "] as const;
+
+// ── Per-type path-pattern chip representation ─────────────────────────────────
+//
+// Per-type destination patterns are stored as path strings (e.g.
+// `masters/flats/{filter}/`). We parse them into an ordered list of chips that
+// can be three kinds:
+//   - 'token'   — a `{name}` placeholder, e.g. `{filter}`
+//   - 'literal' — a bare directory segment, e.g. `flats`, `masters`
+//   - 'sep'     — a `/` path separator
+//
+// This is intentionally separate from the `PatternPart` model used by the
+// Project Folder Pattern, which only has 'token' and 'separator' (and its
+// separators include `-`, `_`, ` ` in addition to `/`). Per-type patterns are
+// always path strings, so the only meaningful separator is `/`.
+
+export type PathChipKind = "token" | "literal" | "sep";
+
+export interface PathChip {
+	id: string;
+	kind: PathChipKind;
+	/** For 'token': the token name (without braces). For 'literal': the segment text. For 'sep': always '/'. */
+	value: string;
+}
+
+let _pathChipCounter = 1000;
+function nextPathId(): string {
+	return `pc${(_pathChipCounter++).toString()}`;
+}
+
+/**
+ * Parse a per-type destination pattern string into an ordered list of PathChips.
+ *
+ * The string is split on `/` boundaries. Each part between slashes is either a
+ * `{token}` placeholder or a bare literal segment. The `/` separators become
+ * 'sep' chips. An empty string produces an empty array.
+ *
+ * Examples:
+ *   'masters/flats/{filter}/'  →  [literal:'masters', sep, literal:'flats', sep, token:'filter', sep]
+ *   '{target}/{filter}/{date}/light/'  →  [token:'target', sep, token:'filter', sep, token:'date', sep, literal:'light', sep]
+ */
+export function parsePathPattern(pattern: string): PathChip[] {
+	if (pattern.trim() === "") return [];
+	const chips: PathChip[] = [];
+	// Walk through the string manually so we preserve every `/` as a sep chip.
+	let rest = pattern;
+	while (rest.length > 0) {
+		const slashIdx = rest.indexOf("/");
+		if (slashIdx === -1) {
+			// No more slashes — remaining text is a segment (no trailing sep)
+			const seg = rest;
+			if (seg.startsWith("{") && seg.endsWith("}")) {
+				chips.push({
+					id: nextPathId(),
+					kind: "token",
+					value: seg.slice(1, -1),
+				});
+			} else if (seg !== "") {
+				chips.push({ id: nextPathId(), kind: "literal", value: seg });
+			}
+			break;
+		}
+		// There is a slash at slashIdx
+		const seg = rest.slice(0, slashIdx);
+		if (seg.startsWith("{") && seg.endsWith("}")) {
+			chips.push({ id: nextPathId(), kind: "token", value: seg.slice(1, -1) });
+		} else if (seg !== "") {
+			chips.push({ id: nextPathId(), kind: "literal", value: seg });
+		}
+		chips.push({ id: nextPathId(), kind: "sep", value: "/" });
+		rest = rest.slice(slashIdx + 1);
+	}
+	return chips;
+}
+
+/**
+ * Serialize an ordered list of PathChips back to a per-type destination pattern string.
+ *
+ * token → `{name}`, literal → bare text, sep → `/`. The chips are concatenated directly.
+ */
+export function serializePathPattern(chips: PathChip[]): string {
+	return chips
+		.map((c) => (c.kind === "token" ? `{${c.value}}` : c.value))
+		.join("");
+}
 
 // ── Per-frame-type destination patterns (spec 041 T051, FR-026b) ──────────────
 //
@@ -41,35 +131,35 @@ const SEPARATORS = ['/', '-', '_', ' '] as const;
 // are persisted.
 
 const FRAME_TYPE_CLASSES = [
-  'light',
-  'flat',
-  'dark',
-  'bias',
-  'master_flat',
-  'master_dark',
-  'master_bias',
+	"light",
+	"flat",
+	"dark",
+	"bias",
+	"master_flat",
+	"master_dark",
+	"master_bias",
 ] as const;
 type FrameTypeClass = (typeof FRAME_TYPE_CLASSES)[number];
 
 const FRAME_TYPE_LABELS: Record<FrameTypeClass, string> = {
-  light: 'Light',
-  flat: 'Flat',
-  dark: 'Dark',
-  bias: 'Bias',
-  master_flat: 'Master Flat',
-  master_dark: 'Master Dark',
-  master_bias: 'Master Bias',
+	light: "Light",
+	flat: "Flat",
+	dark: "Dark",
+	bias: "Bias",
+	master_flat: "Master Flat",
+	master_dark: "Master Dark",
+	master_bias: "Master Bias",
 };
 
 // Built-in defaults shown as the placeholder / reset target per type.
 const FRAME_TYPE_DEFAULT_PATTERNS: Record<FrameTypeClass, string> = {
-  light: '{target}/{filter}/{date}/light/',
-  flat: 'flats/{filter}/{date}/',
-  dark: 'darks/{exposure}/',
-  bias: 'bias/',
-  master_flat: 'masters/flats/{filter}/',
-  master_dark: 'masters/darks/{exposure}/',
-  master_bias: 'masters/bias/',
+	light: "{target}/{filter}/{date}/light/",
+	flat: "flats/{filter}/{date}/",
+	dark: "darks/{exposure}/",
+	bias: "bias/",
+	master_flat: "masters/flats/{filter}/",
+	master_dark: "masters/darks/{exposure}/",
+	master_bias: "masters/bias/",
 };
 
 // Valid `{token}` names (mirrors the backend token vocabulary). Literal path
@@ -83,259 +173,551 @@ const VALID_PATTERN_TOKENS = new Set(AVAILABLE_TOKENS);
  * `value.invalid` result remains the source of truth on save.
  */
 function validatePatternString(value: string): string | null {
-  if (value.trim() === '') return null; // empty = use default
-  const unknown: string[] = [];
-  const re = /\{([^}]*)\}/g;
-  let m: RegExpExecArray | null;
-  while ((m = re.exec(value)) !== null) {
-    const token = m[1];
-    if (!VALID_PATTERN_TOKENS.has(token as (typeof AVAILABLE_TOKENS)[number])) {
-      unknown.push(token);
-    }
-  }
-  if (unknown.length > 0) {
-    return `Unknown token${unknown.length > 1 ? 's' : ''}: ${unknown.map((t) => `{${t}}`).join(', ')}`;
-  }
-  return null;
+	if (value.trim() === "") return null; // empty = use default
+	const unknown: string[] = [];
+	const re = /\{([^}]*)\}/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(value)) !== null) {
+		const token = m[1];
+		if (!VALID_PATTERN_TOKENS.has(token as (typeof AVAILABLE_TOKENS)[number])) {
+			unknown.push(token);
+		}
+	}
+	if (unknown.length > 0) {
+		return `Unknown token${unknown.length > 1 ? "s" : ""}: ${unknown.map((t) => `{${t}}`).join(", ")}`;
+	}
+	return null;
 }
 
 // ── Sample metadata for live preview (R-Preview) ─────────────────────────────
 
 const SAMPLE_METADATA = {
-  target: 'NGC7000',
-  filter: 'Ha',
-  date: '2026-04-12',
-  frame_type: 'light' as const,
-  camera: 'ASI2600MM',
-  exposure: '300s',
-  gain: '100',
-  binning: '1x1',
-  set_temp: '-10C',
+	target: "NGC7000",
+	filter: "Ha",
+	date: "2026-04-12",
+	frame_type: "light" as const,
+	camera: "ASI2600MM",
+	exposure: "300s",
+	gain: "100",
+	binning: "1x1",
+	set_temp: "-10C",
 };
 
 // ── Default pattern {target}/{filter}/{date}/{frame_type}/ ────────────────────
 
 const DEFAULT_PATTERN: PatternPart[] = [
-  { id: 'p0', kind: 'token', value: 'target' },
-  { id: 'p1', kind: 'separator', value: '/' },
-  { id: 'p2', kind: 'token', value: 'filter' },
-  { id: 'p3', kind: 'separator', value: '/' },
-  { id: 'p4', kind: 'token', value: 'date' },
-  { id: 'p5', kind: 'separator', value: '/' },
-  { id: 'p6', kind: 'token', value: 'frame_type' },
-  { id: 'p7', kind: 'separator', value: '/' },
+	{ id: "p0", kind: "token", value: "target" },
+	{ id: "p1", kind: "separator", value: "/" },
+	{ id: "p2", kind: "token", value: "filter" },
+	{ id: "p3", kind: "separator", value: "/" },
+	{ id: "p4", kind: "token", value: "date" },
+	{ id: "p5", kind: "separator", value: "/" },
+	{ id: "p6", kind: "token", value: "frame_type" },
+	{ id: "p7", kind: "separator", value: "/" },
 ];
 
 // ── Stable id generation ──────────────────────────────────────────────────────
 
 let _idCounter = 100;
 function nextId(): string {
-  return `pp${(_idCounter++).toString()}`;
+	return `pp${(_idCounter++).toString()}`;
 }
 
 // ── PatternChipsEditor ────────────────────────────────────────────────────────
 
 function PatternChipsEditor({
-  pattern,
-  onChange,
-  errorCode,
-  warnings,
+	pattern,
+	onChange,
+	errorCode,
+	warnings,
 }: {
-  pattern: PatternPart[];
-  onChange: (parts: PatternPart[]) => void;
-  errorCode?: string;
-  warnings: string[];
+	pattern: PatternPart[];
+	onChange: (parts: PatternPart[]) => void;
+	errorCode?: string;
+	warnings: string[];
 }) {
-  const [showTokenMenu, setShowTokenMenu] = useState(false);
-  const [showSepMenu, setShowSepMenu] = useState(false);
+	const [showTokenMenu, setShowTokenMenu] = useState(false);
+	const [showSepMenu, setShowSepMenu] = useState(false);
 
-  const handleRemove = (id: string) => onChange(pattern.filter((p) => p.id !== id));
+	const handleRemove = (id: string) =>
+		onChange(pattern.filter((p) => p.id !== id));
 
-  const handleAddToken = (value: string) => {
-    onChange([...pattern, { id: nextId(), kind: 'token', value }]);
-    setShowTokenMenu(false);
-  };
+	const handleAddToken = (value: string) => {
+		onChange([...pattern, { id: nextId(), kind: "token", value }]);
+		setShowTokenMenu(false);
+	};
 
-  const handleAddSep = (value: string) => {
-    onChange([...pattern, { id: nextId(), kind: 'separator', value }]);
-    setShowSepMenu(false);
-  };
+	const handleAddSep = (value: string) => {
+		onChange([...pattern, { id: nextId(), kind: "separator", value }]);
+		setShowSepMenu(false);
+	};
 
-  return (
-    <div>
-      {/* Chip row */}
-      <div
-        style={{
-          display: 'flex',
-          flexWrap: 'wrap',
-          gap: 'var(--alm-sp-1)',
-          alignItems: 'center',
-          minHeight: 32,
-        }}
-      >
-        {pattern.map((part) => {
-          const isSep = part.kind === 'separator';
-          const label = isSep ? (part.value === ' ' ? '⎵' : part.value) : `{${part.value}}`;
-          return (
-            <span key={part.id} className={isSep ? 'alm-sep-chip' : 'alm-token-chip'}>
-              {label}
-              <span
-                className="alm-token-chip__x"
-                role="button"
-                tabIndex={0}
-                aria-label={`Remove ${label}`}
-                onClick={() => handleRemove(part.id)}
-                onKeyDown={(e) => {
-                  if (e.key === 'Enter') handleRemove(part.id);
-                }}
-              >
-                &times;
-              </span>
-            </span>
-          );
-        })}
+	return (
+		<div>
+			{/* Chip row */}
+			<div
+				style={{
+					display: "flex",
+					flexWrap: "wrap",
+					gap: "var(--alm-sp-1)",
+					alignItems: "center",
+					minHeight: 32,
+				}}
+			>
+				{pattern.map((part) => {
+					const isSep = part.kind === "separator";
+					const label = isSep
+						? part.value === " "
+							? "⎵"
+							: part.value
+						: `{${part.value}}`;
+					return (
+						<span
+							key={part.id}
+							className={isSep ? "alm-sep-chip" : "alm-token-chip"}
+						>
+							{label}
+							<span
+								className="alm-token-chip__x"
+								role="button"
+								tabIndex={0}
+								aria-label={`Remove ${label}`}
+								onClick={() => handleRemove(part.id)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleRemove(part.id);
+								}}
+							>
+								&times;
+							</span>
+						</span>
+					);
+				})}
 
-        {/* Add Token menu */}
-        <div style={{ position: 'relative', display: 'inline-block' }}>
-          <Btn
-            size="sm"
-            onClick={() => {
-              setShowTokenMenu(!showTokenMenu);
-              setShowSepMenu(false);
-            }}
-          >
-            + Token
-          </Btn>
-          {showTokenMenu && (
-            <div
-              style={{
-                position: 'absolute',
-                top: '100%',
-                left: 0,
-                zIndex: 10,
-                background: 'var(--alm-surface)',
-                border: '1px solid var(--alm-border)',
-                borderRadius: 'var(--alm-radius-md)',
-                padding: 'var(--alm-sp-1)',
-                minWidth: 160,
-                boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
-              }}
-            >
-              {AVAILABLE_TOKENS.map((t) => (
-                <button
-                  key={t}
-                  type="button"
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    padding: '4px 8px',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    fontFamily: 'var(--alm-font-mono)',
-                    fontSize: 'var(--alm-text-xs)',
-                    color: 'var(--alm-text)',
-                  }}
-                  onMouseOver={(e) => (e.currentTarget.style.background = 'var(--alm-hover-bg)')}
-                  onMouseOut={(e) => (e.currentTarget.style.background = 'none')}
-                  onClick={() => handleAddToken(t)}
-                >
-                  {`{${t}}`}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+				{/* Add Token menu */}
+				<div style={{ position: "relative", display: "inline-block" }}>
+					<Btn
+						size="sm"
+						onClick={() => {
+							setShowTokenMenu(!showTokenMenu);
+							setShowSepMenu(false);
+						}}
+					>
+						+ Token
+					</Btn>
+					{showTokenMenu && (
+						<div
+							style={{
+								position: "absolute",
+								top: "100%",
+								left: 0,
+								zIndex: 10,
+								background: "var(--alm-surface)",
+								border: "1px solid var(--alm-border)",
+								borderRadius: "var(--alm-radius-md)",
+								padding: "var(--alm-sp-1)",
+								minWidth: 160,
+								boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+							}}
+						>
+							{AVAILABLE_TOKENS.map((t) => (
+								<button
+									key={t}
+									type="button"
+									style={{
+										display: "block",
+										width: "100%",
+										textAlign: "left",
+										padding: "4px 8px",
+										background: "none",
+										border: "none",
+										cursor: "pointer",
+										fontFamily: "var(--alm-font-mono)",
+										fontSize: "var(--alm-text-xs)",
+										color: "var(--alm-text)",
+									}}
+									onMouseOver={(e) =>
+										(e.currentTarget.style.background = "var(--alm-hover-bg)")
+									}
+									onMouseOut={(e) =>
+										(e.currentTarget.style.background = "none")
+									}
+									onClick={() => handleAddToken(t)}
+								>
+									{`{${t}}`}
+								</button>
+							))}
+						</div>
+					)}
+				</div>
 
-        {/* Add Separator menu */}
-        <div style={{ position: 'relative', display: 'inline-block' }}>
-          <Btn
-            size="sm"
-            onClick={() => {
-              setShowSepMenu(!showSepMenu);
-              setShowTokenMenu(false);
-            }}
-          >
-            + Sep
-          </Btn>
-          {showSepMenu && (
-            <div
-              style={{
-                position: 'absolute',
-                top: '100%',
-                left: 0,
-                zIndex: 10,
-                background: 'var(--alm-surface)',
-                border: '1px solid var(--alm-border)',
-                borderRadius: 'var(--alm-radius-md)',
-                padding: 'var(--alm-sp-1)',
-                minWidth: 100,
-                boxShadow: '0 4px 12px rgba(0,0,0,0.12)',
-              }}
-            >
-              {SEPARATORS.map((s) => (
-                <button
-                  key={s}
-                  type="button"
-                  style={{
-                    display: 'block',
-                    width: '100%',
-                    textAlign: 'left',
-                    padding: '4px 8px',
-                    background: 'none',
-                    border: 'none',
-                    cursor: 'pointer',
-                    fontFamily: 'var(--alm-font-mono)',
-                    fontSize: 'var(--alm-text-xs)',
-                    color: 'var(--alm-text)',
-                  }}
-                  onMouseOver={(e) => (e.currentTarget.style.background = 'var(--alm-hover-bg)')}
-                  onMouseOut={(e) => (e.currentTarget.style.background = 'none')}
-                  onClick={() => handleAddSep(s)}
-                >
-                  {s === '/' ? '/ (path separator)' : s === ' ' ? '⎵ (space)' : s}
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
-      </div>
+				{/* Add Separator menu */}
+				<div style={{ position: "relative", display: "inline-block" }}>
+					<Btn
+						size="sm"
+						onClick={() => {
+							setShowSepMenu(!showSepMenu);
+							setShowTokenMenu(false);
+						}}
+					>
+						+ Sep
+					</Btn>
+					{showSepMenu && (
+						<div
+							style={{
+								position: "absolute",
+								top: "100%",
+								left: 0,
+								zIndex: 10,
+								background: "var(--alm-surface)",
+								border: "1px solid var(--alm-border)",
+								borderRadius: "var(--alm-radius-md)",
+								padding: "var(--alm-sp-1)",
+								minWidth: 100,
+								boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+							}}
+						>
+							{SEPARATORS.map((s) => (
+								<button
+									key={s}
+									type="button"
+									style={{
+										display: "block",
+										width: "100%",
+										textAlign: "left",
+										padding: "4px 8px",
+										background: "none",
+										border: "none",
+										cursor: "pointer",
+										fontFamily: "var(--alm-font-mono)",
+										fontSize: "var(--alm-text-xs)",
+										color: "var(--alm-text)",
+									}}
+									onMouseOver={(e) =>
+										(e.currentTarget.style.background = "var(--alm-hover-bg)")
+									}
+									onMouseOut={(e) =>
+										(e.currentTarget.style.background = "none")
+									}
+									onClick={() => handleAddSep(s)}
+								>
+									{s === "/"
+										? "/ (path separator)"
+										: s === " "
+											? "⎵ (space)"
+											: s}
+								</button>
+							))}
+						</div>
+					)}
+				</div>
+			</div>
 
-      {/* Validation feedback */}
-      {errorCode && (
-        <div
-          style={{
-            marginTop: 'var(--alm-sp-1)',
-            fontSize: 'var(--alm-text-xs)',
-            color: 'var(--alm-danger)',
-          }}
-          role="alert"
-        >
-          {errorCode === 'pattern.empty' && 'Pattern is empty — add at least one token.'}
-          {errorCode === 'token.unknown' && 'Pattern contains an unknown token.'}
-          {errorCode && !['pattern.empty', 'token.unknown'].includes(errorCode) &&
-            `Invalid pattern (${errorCode})`}
-        </div>
-      )}
-      {warnings.length > 0 && (
-        <div
-          style={{
-            marginTop: 'var(--alm-sp-1)',
-            fontSize: 'var(--alm-text-xs)',
-            color: 'var(--alm-text-muted)',
-          }}
-        >
-          {warnings.includes('no_path_separator') && (
-            <span>No path separator (/) — all tokens resolve to one flat folder.{' '}</span>
-          )}
-          {warnings.includes('consecutive_separators') && (
-            <span>Consecutive separators detected.{' '}</span>
-          )}
-        </div>
-      )}
-    </div>
-  );
+			{/* Validation feedback */}
+			{errorCode && (
+				<div
+					style={{
+						marginTop: "var(--alm-sp-1)",
+						fontSize: "var(--alm-text-xs)",
+						color: "var(--alm-danger)",
+					}}
+					role="alert"
+				>
+					{errorCode === "pattern.empty" &&
+						"Pattern is empty — add at least one token."}
+					{errorCode === "token.unknown" &&
+						"Pattern contains an unknown token."}
+					{errorCode &&
+						!["pattern.empty", "token.unknown"].includes(errorCode) &&
+						`Invalid pattern (${errorCode})`}
+				</div>
+			)}
+			{warnings.length > 0 && (
+				<div
+					style={{
+						marginTop: "var(--alm-sp-1)",
+						fontSize: "var(--alm-text-xs)",
+						color: "var(--alm-text-muted)",
+					}}
+				>
+					{warnings.includes("no_path_separator") && (
+						<span>
+							No path separator (/) — all tokens resolve to one flat folder.{" "}
+						</span>
+					)}
+					{warnings.includes("consecutive_separators") && (
+						<span>Consecutive separators detected. </span>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ── PerTypePatternChipsEditor ─────────────────────────────────────────────────
+//
+// Chip-based editor for a single per-type destination pattern string.
+// Supports three chip kinds: 'token' ({name}), 'literal' (bare segment),
+// and 'sep' (/). Visually matches PatternChipsEditor but persists as a path
+// string rather than PatternPart[].
+
+function PerTypePatternChipsEditor({
+	chips,
+	onChange,
+	error,
+	defaultPlaceholder,
+	rowId,
+}: {
+	chips: PathChip[];
+	onChange: (chips: PathChip[]) => void;
+	error?: string;
+	defaultPlaceholder: string;
+	rowId: string;
+}) {
+	const [showTokenMenu, setShowTokenMenu] = useState(false);
+	const [literalInput, setLiteralInput] = useState("");
+	const [showLiteralInput, setShowLiteralInput] = useState(false);
+	const literalInputRef = useRef<HTMLInputElement>(null);
+
+	const handleRemove = (id: string) =>
+		onChange(chips.filter((c) => c.id !== id));
+
+	const handleAddToken = (value: string) => {
+		onChange([...chips, { id: nextPathId(), kind: "token", value }]);
+		setShowTokenMenu(false);
+	};
+
+	const handleAddSep = () => {
+		onChange([...chips, { id: nextPathId(), kind: "sep", value: "/" }]);
+	};
+
+	const handleAddLiteral = () => {
+		const trimmed = literalInput.trim();
+		if (trimmed === "") return;
+		onChange([...chips, { id: nextPathId(), kind: "literal", value: trimmed }]);
+		setLiteralInput("");
+		setShowLiteralInput(false);
+	};
+
+	const handleLiteralKeyDown = (e: ReactKeyboardEvent<HTMLInputElement>) => {
+		if (e.key === "Enter") {
+			e.preventDefault();
+			handleAddLiteral();
+		}
+		if (e.key === "Escape") {
+			setShowLiteralInput(false);
+			setLiteralInput("");
+		}
+	};
+
+	// Show placeholder when no chips yet
+	const isEmpty = chips.length === 0;
+
+	return (
+		<div>
+			{/* Chip row */}
+			<div
+				style={{
+					display: "flex",
+					flexWrap: "wrap",
+					gap: "var(--alm-sp-1)",
+					alignItems: "center",
+					minHeight: 32,
+				}}
+			>
+				{isEmpty && (
+					<span
+						style={{
+							fontFamily: "var(--alm-font-mono)",
+							fontSize: "var(--alm-text-xs)",
+							color: "var(--alm-text-muted)",
+							fontStyle: "italic",
+						}}
+					>
+						{defaultPlaceholder}
+					</span>
+				)}
+
+				{chips.map((chip) => {
+					const label =
+						chip.kind === "token"
+							? `{${chip.value}}`
+							: chip.kind === "sep"
+								? "/"
+								: chip.value;
+					const chipClass =
+						chip.kind === "token"
+							? "alm-token-chip"
+							: chip.kind === "sep"
+								? "alm-sep-chip"
+								: "alm-literal-chip";
+					return (
+						<span key={chip.id} className={chipClass}>
+							{label}
+							<span
+								className="alm-token-chip__x"
+								role="button"
+								tabIndex={0}
+								aria-label={`Remove ${label}`}
+								onClick={() => handleRemove(chip.id)}
+								onKeyDown={(e) => {
+									if (e.key === "Enter") handleRemove(chip.id);
+								}}
+							>
+								&times;
+							</span>
+						</span>
+					);
+				})}
+
+				{/* Add Token menu */}
+				<div style={{ position: "relative", display: "inline-block" }}>
+					<Btn
+						size="sm"
+						onClick={() => {
+							setShowTokenMenu(!showTokenMenu);
+							setShowLiteralInput(false);
+						}}
+					>
+						+ Token
+					</Btn>
+					{showTokenMenu && (
+						<div
+							style={{
+								position: "absolute",
+								top: "100%",
+								left: 0,
+								zIndex: 10,
+								background: "var(--alm-surface)",
+								border: "1px solid var(--alm-border)",
+								borderRadius: "var(--alm-radius-md)",
+								padding: "var(--alm-sp-1)",
+								minWidth: 160,
+								boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+							}}
+						>
+							{AVAILABLE_TOKENS.map((t) => (
+								<button
+									key={t}
+									type="button"
+									style={{
+										display: "block",
+										width: "100%",
+										textAlign: "left",
+										padding: "4px 8px",
+										background: "none",
+										border: "none",
+										cursor: "pointer",
+										fontFamily: "var(--alm-font-mono)",
+										fontSize: "var(--alm-text-xs)",
+										color: "var(--alm-text)",
+									}}
+									onMouseOver={(e) =>
+										(e.currentTarget.style.background = "var(--alm-hover-bg)")
+									}
+									onMouseOut={(e) =>
+										(e.currentTarget.style.background = "none")
+									}
+									onClick={() => handleAddToken(t)}
+								>
+									{`{${t}}`}
+								</button>
+							))}
+						</div>
+					)}
+				</div>
+
+				{/* Add / separator */}
+				<Btn size="sm" onClick={handleAddSep}>
+					+ /
+				</Btn>
+
+				{/* Add Literal segment */}
+				<div style={{ position: "relative", display: "inline-block" }}>
+					<Btn
+						size="sm"
+						onClick={() => {
+							setShowLiteralInput(!showLiteralInput);
+							setShowTokenMenu(false);
+							if (!showLiteralInput) {
+								// focus the input on next tick
+								setTimeout(() => literalInputRef.current?.focus(), 0);
+							}
+						}}
+					>
+						+ Literal
+					</Btn>
+					{showLiteralInput && (
+						<div
+							style={{
+								position: "absolute",
+								top: "100%",
+								left: 0,
+								zIndex: 10,
+								background: "var(--alm-surface)",
+								border: "1px solid var(--alm-border)",
+								borderRadius: "var(--alm-radius-md)",
+								padding: "var(--alm-sp-1)",
+								minWidth: 160,
+								boxShadow: "0 4px 12px rgba(0,0,0,0.12)",
+								display: "flex",
+								gap: "var(--alm-sp-1)",
+							}}
+						>
+							<input
+								ref={literalInputRef}
+								type="text"
+								className="alm-input"
+								style={{
+									fontFamily: "var(--alm-font-mono)",
+									fontSize: "var(--alm-text-xs)",
+									width: 100,
+									padding: "2px 6px",
+								}}
+								value={literalInput}
+								placeholder="e.g. flats"
+								spellCheck={false}
+								autoCorrect="off"
+								autoCapitalize="off"
+								aria-label="Literal path segment"
+								onChange={(e) => setLiteralInput(e.target.value)}
+								onKeyDown={handleLiteralKeyDown}
+							/>
+							<button
+								type="button"
+								style={{
+									padding: "2px 8px",
+									background: "var(--alm-accent)",
+									color: "var(--alm-accent-fg)",
+									border: "none",
+									borderRadius: "var(--alm-radius-md)",
+									cursor: "pointer",
+									fontSize: "var(--alm-text-xs)",
+								}}
+								onClick={handleAddLiteral}
+							>
+								Add
+							</button>
+						</div>
+					)}
+				</div>
+			</div>
+
+			{/* Validation / error feedback */}
+			{error && (
+				<div
+					id={`${rowId}-error`}
+					role="alert"
+					style={{
+						marginTop: "var(--alm-sp-1)",
+						fontSize: "var(--alm-text-xs)",
+						color: "var(--alm-danger)",
+					}}
+				>
+					{error}
+				</div>
+			)}
+		</div>
+	);
 }
 
 // ── PerTypeDestinationPatterns (spec 041 T051, FR-026b) ───────────────────────
@@ -345,326 +727,371 @@ function PatternChipsEditor({
 // surface the backend `value.invalid` rejection inline — the parent auto-save
 // swallows write errors.
 
+// Empty chip array sentinel — used to detect "using default" state.
+function chipsAreEmpty(chips: PathChip[]): boolean {
+	return chips.length === 0;
+}
+
+function emptyChipsByClass(): Record<FrameTypeClass, PathChip[]> {
+	const result = {} as Record<FrameTypeClass, PathChip[]>;
+	for (const cls of FRAME_TYPE_CLASSES) result[cls] = [];
+	return result;
+}
+
 function PerTypeDestinationPatterns() {
-  // Override map: class → pattern string. Absent class = built-in default.
-  const [overrides, setOverrides] = useState<Partial<Record<FrameTypeClass, string>>>({});
-  const [backendErrors, setBackendErrors] = useState<Partial<Record<FrameTypeClass, string>>>({});
-  const [loaded, setLoaded] = useState(false);
-  const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Override map: class → chip list. Empty array = built-in default.
+	const [chipsByClass, setChipsByClass] =
+		useState<Record<FrameTypeClass, PathChip[]>>(emptyChipsByClass);
+	const [backendErrors, setBackendErrors] = useState<
+		Partial<Record<FrameTypeClass, string>>
+	>({});
+	const [loaded, setLoaded] = useState(false);
+	const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  // ── Load saved overrides on mount ────────────────────────────────────────
-  useEffect(() => {
-    getSettings({ scope: 'naming' })
-      .then((data) => {
-        const vals = data.values as Record<string, unknown>;
-        const raw = vals.patternsByType;
-        if (raw && typeof raw === 'object') {
-          const next: Partial<Record<FrameTypeClass, string>> = {};
-          for (const cls of FRAME_TYPE_CLASSES) {
-            const v = (raw as Record<string, unknown>)[cls];
-            if (typeof v === 'string') next[cls] = v;
-          }
-          setOverrides(next);
-        }
-      })
-      .catch(() => {
-        // Use defaults on load failure (e.g. in test/mock environment).
-      })
-      .finally(() => setLoaded(true));
-  }, []);
+	// ── Load saved overrides on mount ────────────────────────────────────────
+	useEffect(() => {
+		getSettings({ scope: "naming" })
+			.then((data) => {
+				const vals = data.values as Record<string, unknown>;
+				const raw = vals.patternsByType;
+				if (raw && typeof raw === "object") {
+					const next = emptyChipsByClass();
+					for (const cls of FRAME_TYPE_CLASSES) {
+						const v = (raw as Record<string, unknown>)[cls];
+						if (typeof v === "string" && v.trim() !== "") {
+							next[cls] = parsePathPattern(v);
+						}
+					}
+					setChipsByClass(next);
+				}
+			})
+			.catch(() => {
+				// Use defaults on load failure (e.g. in test/mock environment).
+			})
+			.finally(() => setLoaded(true));
+	}, []);
 
-  // ── Persist the full override map (debounced, captures backend errors) ────
-  const persist = useCallback((next: Partial<Record<FrameTypeClass, string>>) => {
-    if (saveTimer.current) clearTimeout(saveTimer.current);
-    saveTimer.current = setTimeout(() => {
-      // Send only non-empty overrides; an empty/absent class means "default".
-      const payload: Record<string, string> = {};
-      for (const cls of FRAME_TYPE_CLASSES) {
-        const v = next[cls];
-        if (typeof v === 'string' && v.trim() !== '') payload[cls] = v;
-      }
-      void updateSettings({ scope: 'naming', values: { patternsByType: payload } }).then(
-        () => {
-          // Clear any stale backend errors on a successful save.
-          setBackendErrors({});
-        },
-        (err: unknown) => {
-          // Backend rejected at least one pattern (error code value.invalid).
-          // We cannot tell which class from a single string; flag all classes
-          // that currently fail client-side validation, falling back to a
-          // generic banner keyed on the first overridden class.
-          const message = typeof err === 'string' ? err : 'Invalid pattern';
-          const errs: Partial<Record<FrameTypeClass, string>> = {};
-          let attributed = false;
-          for (const cls of FRAME_TYPE_CLASSES) {
-            const v = next[cls];
-            if (typeof v === 'string' && v.trim() !== '' && validatePatternString(v) !== null) {
-              errs[cls] = message;
-              attributed = true;
-            }
-          }
-          if (!attributed) {
-            const firstOverride = FRAME_TYPE_CLASSES.find(
-              (cls) => typeof next[cls] === 'string' && next[cls]!.trim() !== '',
-            );
-            if (firstOverride) errs[firstOverride] = message;
-          }
-          setBackendErrors(errs);
-        },
-      );
-    }, 300);
-  }, []);
+	// ── Persist the full override map (debounced, captures backend errors) ────
+	const persist = useCallback((next: Record<FrameTypeClass, PathChip[]>) => {
+		if (saveTimer.current) clearTimeout(saveTimer.current);
+		saveTimer.current = setTimeout(() => {
+			// Send only non-empty overrides; an empty/absent class means "default".
+			const payload: Record<string, string> = {};
+			for (const cls of FRAME_TYPE_CLASSES) {
+				if (!chipsAreEmpty(next[cls])) {
+					payload[cls] = serializePathPattern(next[cls]);
+				}
+			}
+			void updateSettings({
+				scope: "naming",
+				values: { patternsByType: payload },
+			}).then(
+				() => {
+					// Clear any stale backend errors on a successful save.
+					setBackendErrors({});
+				},
+				(err: unknown) => {
+					// Backend rejected at least one pattern (error code value.invalid).
+					// We cannot tell which class from a single string; flag all classes
+					// that currently fail client-side validation, falling back to a
+					// generic banner keyed on the first overridden class.
+					const message = typeof err === "string" ? err : "Invalid pattern";
+					const errs: Partial<Record<FrameTypeClass, string>> = {};
+					let attributed = false;
+					for (const cls of FRAME_TYPE_CLASSES) {
+						if (!chipsAreEmpty(next[cls])) {
+							const patStr = serializePathPattern(next[cls]);
+							if (validatePatternString(patStr) !== null) {
+								errs[cls] = message;
+								attributed = true;
+							}
+						}
+					}
+					if (!attributed) {
+						const firstOverride = FRAME_TYPE_CLASSES.find(
+							(cls) => !chipsAreEmpty(next[cls]),
+						);
+						if (firstOverride) errs[firstOverride] = message;
+					}
+					setBackendErrors(errs);
+				},
+			);
+		}, 300);
+	}, []);
 
-  const handleChange = (cls: FrameTypeClass, value: string) => {
-    const next = { ...overrides };
-    if (value.trim() === '') {
-      delete next[cls];
-    } else {
-      next[cls] = value;
-    }
-    setOverrides(next);
-    // Clear this class's backend error optimistically; re-validated on save.
-    setBackendErrors((prev) => {
-      if (!(cls in prev)) return prev;
-      const { [cls]: _removed, ...rest } = prev;
-      return rest;
-    });
-    persist(next);
-  };
+	const handleChipsChange = (cls: FrameTypeClass, chips: PathChip[]) => {
+		const next = { ...chipsByClass, [cls]: chips };
+		setChipsByClass(next);
+		// Clear this class's backend error optimistically; re-validated on save.
+		setBackendErrors((prev) => {
+			if (!(cls in prev)) return prev;
+			const { [cls]: _removed, ...rest } = prev;
+			return rest;
+		});
+		persist(next);
+	};
 
-  const handleReset = (cls: FrameTypeClass) => {
-    const next = { ...overrides };
-    delete next[cls];
-    setOverrides(next);
-    setBackendErrors((prev) => {
-      if (!(cls in prev)) return prev;
-      const { [cls]: _removed, ...rest } = prev;
-      return rest;
-    });
-    persist(next);
-  };
+	const handleReset = (cls: FrameTypeClass) => {
+		const next = { ...chipsByClass, [cls]: [] };
+		setChipsByClass(next);
+		setBackendErrors((prev) => {
+			if (!(cls in prev)) return prev;
+			const { [cls]: _removed, ...rest } = prev;
+			return rest;
+		});
+		persist(next);
+	};
 
-  return (
-    <div className="alm-settings__group">
-      <div className="alm-settings__group-title">Per-Type Destination Patterns</div>
-      <div className="alm-settings__row-desc" style={{ marginBottom: 'var(--alm-sp-2)' }}>
-        Destination folder pattern per frame type, applied when confirming inbox
-        items. Leave blank to use the built-in default.
-      </div>
-      {FRAME_TYPE_CLASSES.map((cls) => {
-        const value = overrides[cls] ?? '';
-        const clientError = loaded ? validatePatternString(value) : null;
-        const error = backendErrors[cls] ?? clientError ?? undefined;
-        const isOverridden = value.trim() !== '';
-        const inputId = `naming-pattern-${cls}`;
-        return (
-          <div className="alm-settings__row" key={cls}>
-            <label className="alm-settings__row-label" htmlFor={inputId}>
-              {FRAME_TYPE_LABELS[cls]}
-            </label>
-            <div className="alm-settings__row-content">
-              <div style={{ display: 'flex', alignItems: 'center', gap: 'var(--alm-sp-2)' }}>
-                <input
-                  id={inputId}
-                  type="text"
-                  className="alm-input"
-                  style={{ flex: 1, minWidth: 220, fontFamily: 'var(--alm-font-mono)' }}
-                  value={value}
-                  placeholder={FRAME_TYPE_DEFAULT_PATTERNS[cls]}
-                  spellCheck={false}
-                  autoCorrect="off"
-                  autoCapitalize="off"
-                  aria-invalid={error ? true : undefined}
-                  aria-describedby={error ? `${inputId}-error` : undefined}
-                  data-testid={inputId}
-                  onChange={(e) => handleChange(cls, e.target.value)}
-                />
-                <Btn
-                  size="sm"
-                  disabled={!isOverridden}
-                  data-testid={`naming-pattern-reset-${cls}`}
-                  onClick={() => handleReset(cls)}
-                >
-                  Reset to default
-                </Btn>
-              </div>
-              {error && (
-                <div
-                  id={`${inputId}-error`}
-                  role="alert"
-                  style={{
-                    marginTop: 'var(--alm-sp-1)',
-                    fontSize: 'var(--alm-text-xs)',
-                    color: 'var(--alm-danger)',
-                  }}
-                >
-                  {error}
-                </div>
-              )}
-            </div>
-          </div>
-        );
-      })}
-    </div>
-  );
+	return (
+		<div className="alm-settings__group">
+			<div className="alm-settings__group-title">
+				Per-Type Destination Patterns
+			</div>
+			<div
+				className="alm-settings__row-desc"
+				style={{ marginBottom: "var(--alm-sp-2)" }}
+			>
+				Destination folder pattern per frame type, applied when confirming inbox
+				items. Empty = use the built-in default (shown as placeholder).
+			</div>
+			{FRAME_TYPE_CLASSES.map((cls) => {
+				const chips = chipsByClass[cls];
+				const isOverridden = !chipsAreEmpty(chips);
+				const patternStr = isOverridden ? serializePathPattern(chips) : "";
+				const clientError =
+					loaded && isOverridden ? validatePatternString(patternStr) : null;
+				const error = backendErrors[cls] ?? clientError ?? undefined;
+				const rowId = `naming-pattern-${cls}`;
+				return (
+					<div className="alm-settings__row" key={cls}>
+						<div className="alm-settings__row-label" id={`${rowId}-label`}>
+							{FRAME_TYPE_LABELS[cls]}
+						</div>
+						<div className="alm-settings__row-content">
+							<div
+								style={{
+									display: "flex",
+									alignItems: "flex-start",
+									gap: "var(--alm-sp-2)",
+								}}
+							>
+								<div
+									style={{ flex: 1 }}
+									role="group"
+									aria-labelledby={`${rowId}-label`}
+									data-testid={rowId}
+								>
+									<PerTypePatternChipsEditor
+										chips={chips}
+										onChange={(c) => handleChipsChange(cls, c)}
+										error={error}
+										defaultPlaceholder={FRAME_TYPE_DEFAULT_PATTERNS[cls]}
+										rowId={rowId}
+									/>
+								</div>
+								<Btn
+									size="sm"
+									disabled={!isOverridden}
+									data-testid={`naming-pattern-reset-${cls}`}
+									onClick={() => handleReset(cls)}
+								>
+									Reset to default
+								</Btn>
+							</div>
+						</div>
+					</div>
+				);
+			})}
+		</div>
+	);
 }
 
 // ── NamingStructure ───────────────────────────────────────────────────────────
 
 export function NamingStructure({ save }: NamingStructureProps) {
-  const [pattern, setPattern] = useState<PatternPart[]>(DEFAULT_PATTERN);
-  const [autoApplyPattern, setAutoApplyPattern] = useState(true);
-  const [preview, setPreview] = useState<PatternPreviewResponse | null>(null);
-  const [previewError, setPreviewError] = useState<string | null>(null);
-  const [validateResult, setValidateResult] = useState<{
-    valid: boolean;
-    warnings: string[];
-    errorCode?: string;
-  } | null>(null);
-  const [loaded, setLoaded] = useState(false);
+	const [pattern, setPattern] = useState<PatternPart[]>(DEFAULT_PATTERN);
+	const [autoApplyPattern, setAutoApplyPattern] = useState(true);
+	const [preview, setPreview] = useState<PatternPreviewResponse | null>(null);
+	const [previewError, setPreviewError] = useState<string | null>(null);
+	const [validateResult, setValidateResult] = useState<{
+		valid: boolean;
+		warnings: string[];
+		errorCode?: string;
+	} | null>(null);
+	const [loaded, setLoaded] = useState(false);
 
-  // ── Load saved pattern on mount (spec 018 keys: pattern, autoApplyPattern) ─
-  useEffect(() => {
-    getSettings({ scope: 'naming' })
-      .then((data) => {
-        const vals = data.values as Record<string, unknown>;
-        if (Array.isArray(vals.pattern) && vals.pattern.length > 0) {
-          setPattern(vals.pattern as PatternPart[]);
-        }
-        if (typeof vals.autoApplyPattern === 'boolean') {
-          setAutoApplyPattern(vals.autoApplyPattern);
-        }
-      })
-      .catch(() => {
-        // Use defaults on load failure (e.g. in test/mock environment).
-      })
-      .finally(() => setLoaded(true));
-  }, []);
+	// ── Load saved pattern on mount (spec 018 keys: pattern, autoApplyPattern) ─
+	useEffect(() => {
+		getSettings({ scope: "naming" })
+			.then((data) => {
+				const vals = data.values as Record<string, unknown>;
+				if (Array.isArray(vals.pattern) && vals.pattern.length > 0) {
+					setPattern(vals.pattern as PatternPart[]);
+				}
+				if (typeof vals.autoApplyPattern === "boolean") {
+					setAutoApplyPattern(vals.autoApplyPattern);
+				}
+			})
+			.catch(() => {
+				// Use defaults on load failure (e.g. in test/mock environment).
+			})
+			.finally(() => setLoaded(true));
+	}, []);
 
-  // ── Live validation (T1.3 / T1.4) ────────────────────────────────────────
-  const runValidation = useCallback((parts: PatternPart[]) => {
-    patternValidate(parts)
-      .then((resp) => {
-        setValidateResult({
-          valid: resp.valid,
-          warnings: resp.warnings,
-          errorCode: resp.errorCode,
-        });
-      })
-      .catch(() => {
-        // Ignore validation errors in mock/offline environments.
-      });
-  }, []);
+	// ── Live validation (T1.3 / T1.4) ────────────────────────────────────────
+	const runValidation = useCallback((parts: PatternPart[]) => {
+		patternValidate(parts)
+			.then((resp) => {
+				setValidateResult({
+					valid: resp.valid,
+					warnings: resp.warnings,
+					errorCode: resp.errorCode,
+				});
+			})
+			.catch(() => {
+				// Ignore validation errors in mock/offline environments.
+			});
+	}, []);
 
-  // ── Live preview (T2.2 / T3.11) ─────────────────────────────────────────
-  const runPreview = useCallback((parts: PatternPart[]) => {
-    if (parts.length === 0) {
-      setPreview(null);
-      setPreviewError(null);
-      return;
-    }
-    patternPreview(parts, SAMPLE_METADATA)
-      .then((resp) => {
-        setPreview(resp);
-        setPreviewError(null);
-      })
-      .catch((err: unknown) => {
-        setPreview(null);
-        setPreviewError(typeof err === 'string' ? err : 'Preview unavailable');
-      });
-  }, []);
+	// ── Live preview (T2.2 / T3.11) ─────────────────────────────────────────
+	const runPreview = useCallback((parts: PatternPart[]) => {
+		if (parts.length === 0) {
+			setPreview(null);
+			setPreviewError(null);
+			return;
+		}
+		patternPreview(parts, SAMPLE_METADATA)
+			.then((resp) => {
+				setPreview(resp);
+				setPreviewError(null);
+			})
+			.catch((err: unknown) => {
+				setPreview(null);
+				setPreviewError(typeof err === "string" ? err : "Preview unavailable");
+			});
+	}, []);
 
-  // Run both when pattern changes, after initial load.
-  useEffect(() => {
-    if (!loaded) return;
-    runValidation(pattern);
-    runPreview(pattern);
-  }, [pattern, loaded, runValidation, runPreview]);
+	// Run both when pattern changes, after initial load.
+	useEffect(() => {
+		if (!loaded) return;
+		runValidation(pattern);
+		runPreview(pattern);
+	}, [pattern, loaded, runValidation, runPreview]);
 
-  // ── Handle pattern change ─────────────────────────────────────────────────
-  const handlePatternChange = (parts: PatternPart[]) => {
-    setPattern(parts);
-    // Persist immediately (spec 018 keys — noisy, no audit).
-    save('naming', { pattern: parts, autoApplyPattern });
-  };
+	// ── Handle pattern change ─────────────────────────────────────────────────
+	const handlePatternChange = (parts: PatternPart[]) => {
+		setPattern(parts);
+		// Persist immediately (spec 018 keys — noisy, no audit).
+		save("naming", { pattern: parts, autoApplyPattern });
+	};
 
-  const handleAutoApplyChange = (checked: boolean) => {
-    setAutoApplyPattern(checked);
-    save('naming', { pattern, autoApplyPattern: checked });
-  };
+	const handleAutoApplyChange = (checked: boolean) => {
+		setAutoApplyPattern(checked);
+		save("naming", { pattern, autoApplyPattern: checked });
+	};
 
-  const isValid = validateResult?.valid !== false;
-  const canSave = isValid && pattern.length > 0;
+	const isValid = validateResult?.valid !== false;
+	const canSave = isValid && pattern.length > 0;
 
-  return (
-    <>
-      <div className="alm-settings__group">
-        <div className="alm-settings__group-title">Project Folder Pattern</div>
-        <div className="alm-settings__row">
-          <div className="alm-settings__row-content">
-            <PatternChipsEditor
-              pattern={pattern}
-              onChange={handlePatternChange}
-              errorCode={validateResult?.valid === false ? validateResult.errorCode : undefined}
-              warnings={validateResult?.warnings ?? []}
-            />
-          </div>
-        </div>
-      </div>
+	return (
+		<>
+			<div className="alm-settings__group">
+				<div className="alm-settings__group-title">Project Folder Pattern</div>
+				<div className="alm-settings__row">
+					<div className="alm-settings__row-content">
+						<PatternChipsEditor
+							pattern={pattern}
+							onChange={handlePatternChange}
+							errorCode={
+								validateResult?.valid === false
+									? validateResult.errorCode
+									: undefined
+							}
+							warnings={validateResult?.warnings ?? []}
+						/>
+					</div>
+				</div>
+			</div>
 
-      <PerTypeDestinationPatterns />
+			<PerTypeDestinationPatterns />
 
-      <div className="alm-settings__group">
-        <div className="alm-settings__row">
-          <label className="alm-settings__row-label">
-            <input
-              type="checkbox"
-              checked={autoApplyPattern}
-              onChange={(e) => handleAutoApplyChange(e.target.checked)}
-              style={{ marginRight: 'var(--alm-sp-1)' }}
-            />
-            Auto-apply pattern to new projects without confirmation
-          </label>
-        </div>
-      </div>
+			<div className="alm-settings__group">
+				<div className="alm-settings__row">
+					<label className="alm-settings__row-label">
+						<input
+							type="checkbox"
+							checked={autoApplyPattern}
+							onChange={(e) => handleAutoApplyChange(e.target.checked)}
+							style={{ marginRight: "var(--alm-sp-1)" }}
+						/>
+						Auto-apply pattern to new projects without confirmation
+					</label>
+				</div>
+			</div>
 
-      <div className="alm-settings__group">
-        <div className="alm-settings__group-title">Live Preview</div>
-        <div style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)', marginBottom: 'var(--alm-sp-1)' }}>
-          Sample: NGC7000 / Ha / 2026-04-12 / light
-        </div>
-        {!canSave && (
-          <div
-            style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)', fontStyle: 'italic' }}
-          >
-            — (invalid or empty pattern)
-          </div>
-        )}
-        {previewError && (
-          <div style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-danger)' }}>
-            {previewError}
-          </div>
-        )}
-        {preview && canSave && (
-          <div style={{ display: 'flex', gap: 'var(--alm-sp-3)', alignItems: 'baseline' }}>
-            <code className="alm-mono" style={{ fontSize: 'var(--alm-text-xs)' }}>
-              {preview.missingTokens.length > 0 ? (
-                // Render path with fallback segments dimmed.
-                preview.resolvedPath
-              ) : (
-                preview.resolvedPath
-              )}
-            </code>
-            {preview.missingTokens.length > 0 && (
-              <span
-                style={{ fontSize: 'var(--alm-text-xs)', color: 'var(--alm-text-muted)', fontStyle: 'italic' }}
-              >
-                (fallback used for: {preview.missingTokens.join(', ')})
-              </span>
-            )}
-          </div>
-        )}
-      </div>
-    </>
-  );
+			<div className="alm-settings__group">
+				<div className="alm-settings__group-title">Live Preview</div>
+				<div
+					style={{
+						fontSize: "var(--alm-text-xs)",
+						color: "var(--alm-text-muted)",
+						marginBottom: "var(--alm-sp-1)",
+					}}
+				>
+					Sample: NGC7000 / Ha / 2026-04-12 / light
+				</div>
+				{!canSave && (
+					<div
+						style={{
+							fontSize: "var(--alm-text-xs)",
+							color: "var(--alm-text-muted)",
+							fontStyle: "italic",
+						}}
+					>
+						— (invalid or empty pattern)
+					</div>
+				)}
+				{previewError && (
+					<div
+						style={{
+							fontSize: "var(--alm-text-xs)",
+							color: "var(--alm-danger)",
+						}}
+					>
+						{previewError}
+					</div>
+				)}
+				{preview && canSave && (
+					<div
+						style={{
+							display: "flex",
+							gap: "var(--alm-sp-3)",
+							alignItems: "baseline",
+						}}
+					>
+						<code
+							className="alm-mono"
+							style={{ fontSize: "var(--alm-text-xs)" }}
+						>
+							{preview.missingTokens.length > 0
+								? // Render path with fallback segments dimmed.
+									preview.resolvedPath
+								: preview.resolvedPath}
+						</code>
+						{preview.missingTokens.length > 0 && (
+							<span
+								style={{
+									fontSize: "var(--alm-text-xs)",
+									color: "var(--alm-text-muted)",
+									fontStyle: "italic",
+								}}
+							>
+								(fallback used for: {preview.missingTokens.join(", ")})
+							</span>
+						)}
+					</div>
+				)}
+			</div>
+		</>
+	);
 }

--- a/apps/desktop/src/features/settings/PerTypePatternChips.test.ts
+++ b/apps/desktop/src/features/settings/PerTypePatternChips.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for the per-type destination pattern parse/serialize utilities
+ * introduced in spec 041 (chip-based editor iteration).
+ *
+ * parsePathPattern  — converts a path string → ordered PathChip[]
+ * serializePathPattern — converts PathChip[] → path string (round-trip)
+ *
+ * These two functions form the codec between the backend wire format (a path
+ * string like `masters/flats/{filter}/`) and the UI chip list.  Their
+ * correctness is critical: a bug here would silently corrupt saved patterns.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { PathChip } from "./NamingStructure";
+import { parsePathPattern, serializePathPattern } from "./NamingStructure";
+
+// Helper: extract only kind+value (strip generated ids for equality checks).
+function stripped(chips: PathChip[]): { kind: string; value: string }[] {
+	return chips.map(({ kind, value }) => ({ kind, value }));
+}
+
+describe("parsePathPattern", () => {
+	it("empty string produces empty array", () => {
+		expect(parsePathPattern("")).toEqual([]);
+		expect(parsePathPattern("   ")).toEqual([]);
+	});
+
+	it("literal-only pattern: bias/", () => {
+		expect(stripped(parsePathPattern("bias/"))).toEqual([
+			{ kind: "literal", value: "bias" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("token + sep: {target}/", () => {
+		expect(stripped(parsePathPattern("{target}/"))).toEqual([
+			{ kind: "token", value: "target" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("default Light pattern: {target}/{filter}/{date}/light/", () => {
+		expect(
+			stripped(parsePathPattern("{target}/{filter}/{date}/light/")),
+		).toEqual([
+			{ kind: "token", value: "target" },
+			{ kind: "sep", value: "/" },
+			{ kind: "token", value: "filter" },
+			{ kind: "sep", value: "/" },
+			{ kind: "token", value: "date" },
+			{ kind: "sep", value: "/" },
+			{ kind: "literal", value: "light" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("default MasterFlat pattern: masters/flats/{filter}/", () => {
+		expect(stripped(parsePathPattern("masters/flats/{filter}/"))).toEqual([
+			{ kind: "literal", value: "masters" },
+			{ kind: "sep", value: "/" },
+			{ kind: "literal", value: "flats" },
+			{ kind: "sep", value: "/" },
+			{ kind: "token", value: "filter" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("default MasterDark pattern: masters/darks/{exposure}/", () => {
+		expect(stripped(parsePathPattern("masters/darks/{exposure}/"))).toEqual([
+			{ kind: "literal", value: "masters" },
+			{ kind: "sep", value: "/" },
+			{ kind: "literal", value: "darks" },
+			{ kind: "sep", value: "/" },
+			{ kind: "token", value: "exposure" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("default Dark pattern: darks/{exposure}/", () => {
+		expect(stripped(parsePathPattern("darks/{exposure}/"))).toEqual([
+			{ kind: "literal", value: "darks" },
+			{ kind: "sep", value: "/" },
+			{ kind: "token", value: "exposure" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("pattern without trailing slash: flats/{filter}", () => {
+		expect(stripped(parsePathPattern("flats/{filter}"))).toEqual([
+			{ kind: "literal", value: "flats" },
+			{ kind: "sep", value: "/" },
+			{ kind: "token", value: "filter" },
+		]);
+	});
+
+	it("consecutive slashes produce consecutive sep chips", () => {
+		// Edge case: // → two sep chips with nothing between them
+		expect(stripped(parsePathPattern("//"))).toEqual([
+			{ kind: "sep", value: "/" },
+			{ kind: "sep", value: "/" },
+		]);
+	});
+
+	it("each chip gets a unique id", () => {
+		const chips = parsePathPattern("flats/{filter}/");
+		const ids = chips.map((c) => c.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe("serializePathPattern", () => {
+	it("empty array produces empty string", () => {
+		expect(serializePathPattern([])).toBe("");
+	});
+
+	it("token chip serializes with braces", () => {
+		const chips: PathChip[] = [{ id: "a", kind: "token", value: "filter" }];
+		expect(serializePathPattern(chips)).toBe("{filter}");
+	});
+
+	it("literal chip serializes as bare text", () => {
+		const chips: PathChip[] = [{ id: "a", kind: "literal", value: "flats" }];
+		expect(serializePathPattern(chips)).toBe("flats");
+	});
+
+	it("sep chip serializes as /", () => {
+		const chips: PathChip[] = [{ id: "a", kind: "sep", value: "/" }];
+		expect(serializePathPattern(chips)).toBe("/");
+	});
+
+	it("mixed chips concatenate correctly", () => {
+		const chips: PathChip[] = [
+			{ id: "a", kind: "literal", value: "masters" },
+			{ id: "b", kind: "sep", value: "/" },
+			{ id: "c", kind: "literal", value: "flats" },
+			{ id: "d", kind: "sep", value: "/" },
+			{ id: "e", kind: "token", value: "filter" },
+			{ id: "f", kind: "sep", value: "/" },
+		];
+		expect(serializePathPattern(chips)).toBe("masters/flats/{filter}/");
+	});
+});
+
+describe("parsePathPattern ↔ serializePathPattern round-trip", () => {
+	const DEFAULT_PATTERNS = [
+		"{target}/{filter}/{date}/light/",
+		"flats/{filter}/{date}/",
+		"darks/{exposure}/",
+		"bias/",
+		"masters/flats/{filter}/",
+		"masters/darks/{exposure}/",
+		"masters/bias/",
+	];
+
+	for (const pattern of DEFAULT_PATTERNS) {
+		it(`round-trips: "${pattern}"`, () => {
+			expect(serializePathPattern(parsePathPattern(pattern))).toBe(pattern);
+		});
+	}
+
+	it("custom pattern round-trips: custom/{gain}/{date}/", () => {
+		const pattern = "custom/{gain}/{date}/";
+		expect(serializePathPattern(parsePathPattern(pattern))).toBe(pattern);
+	});
+
+	it("pattern without trailing slash round-trips", () => {
+		const pattern = "flats/{filter}";
+		expect(serializePathPattern(parsePathPattern(pattern))).toBe(pattern);
+	});
+});

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -758,6 +758,14 @@
   background: var(--alm-chip); color: var(--alm-text-secondary);
   border: 1px solid var(--alm-border);
 }
+/* Literal path-segment chip (per-type destination pattern editor) */
+.alm-literal-chip {
+  display: inline-flex; align-items: center; gap: var(--alm-sp-1);
+  padding: 2px var(--alm-sp-2); border-radius: var(--alm-radius-sm);
+  font-size: var(--alm-text-xs); font-family: var(--alm-font-mono);
+  background: var(--alm-success-bg, var(--alm-surface-raised)); color: var(--alm-text);
+  border: 1px solid var(--alm-border);
+}
 
 /* === WIZARD === */
 .alm-wizard { display: flex; flex-direction: column; flex: 1; min-height: 0; }


### PR DESCRIPTION
Addresses UI feedback that per-type destination patterns should be element-based, not a plain text field. Adds a sibling PerTypePatternChipsEditor (token / literal-segment / separator chips) matching the Project Folder Pattern editor, with lossless parse↔serialize to the path-string form. Wire format (patternsByType, plain string map) unchanged; frontend only. tsc 0, vitest 43/43 settings (+24 round-trip tests).