### PR TITLE
spec 046 follow-up: catch JSX-child template literals + fix surfaced violations

### DIFF
--- a/apps/desktop/eslint-rules/no-user-string.js
+++ b/apps/desktop/eslint-rules/no-user-string.js
@@ -195,6 +195,49 @@ const rule = {
         }
       },
 
+      // Template literals rendered as a JSX CHILD via an expression container,
+      // e.g. `{ok ? `Applied ${n} items` : `Failed`}`. Mirror of the Literal
+      // child check above. Attribute / object-property / call template literals
+      // are handled by their own visitors, so those contexts are skipped here to
+      // avoid double-reporting.
+      TemplateLiteral(node) {
+        if (!templateHasLetter(node)) return;
+        if (node.parent && node.parent.type === "TaggedTemplateExpression") return;
+        let n = node;
+        let parent = n.parent;
+        while (parent) {
+          if (
+            parent.type === "JSXAttribute" ||
+            parent.type === "CallExpression" ||
+            parent.type === "NewExpression" ||
+            parent.type === "Property"
+          ) {
+            return;
+          }
+          if (parent.type === "JSXExpressionContainer") {
+            const gp = parent.parent;
+            if (gp && (gp.type === "JSXElement" || gp.type === "JSXFragment")) {
+              context.report({
+                node,
+                messageId: "jsxText",
+                data: { text: quote(templatePreview(node)) },
+              });
+            }
+            return;
+          }
+          if (
+            parent.type === "ArrowFunctionExpression" ||
+            parent.type === "FunctionExpression" ||
+            parent.type === "JSXElement" ||
+            parent.type === "JSXFragment"
+          ) {
+            return;
+          }
+          n = parent;
+          parent = n.parent;
+        }
+      },
+
       JSXAttribute(node) {
         const name =
           node.name && node.name.type === "JSXIdentifier"

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1177,5 +1177,55 @@
   "inbox_plan_applied_toast": "Plan applied.",
   "inbox_plan_apply_failed_toast": "Apply failed — please try again.",
   "inbox_apply_plan_live_aria": "Apply plan for {name} with live progress",
-  "inbox_apply_action": "Apply"
+  "inbox_apply_action": "Apply",
+  "inbox_progress_count_of": "{applied} of {total}",
+  "inbox_progress_failed": "Apply failed after {applied} applied, {failed} failed.",
+  "inbox_progress_failed_suffix": ", {failed} failed",
+  "inbox_progress_completed": [
+    {
+      "declarations": [
+        "input applied",
+        "input countText",
+        "local p = applied: plural"
+      ],
+      "selectors": [
+        "p"
+      ],
+      "match": {
+        "p=one": "Applied {countText} item.",
+        "p=other": "Applied {countText} items."
+      }
+    }
+  ],
+  "inbox_progress_running": [
+    {
+      "declarations": [
+        "input applied",
+        "input countText",
+        "input failedText",
+        "local p = applied: plural"
+      ],
+      "selectors": [
+        "p"
+      ],
+      "match": {
+        "p=one": "Applying… {countText} item{failedText}",
+        "p=other": "Applying… {countText} items{failedText}"
+      }
+    }
+  ],
+  "inbox_groupby_chip_primary": "Group: {label}",
+  "inbox_groupby_chip_secondary": "then: {label}",
+  "inbox_needs_attrs": "needs {attrs}",
+  "inbox_n_selected": "{count} selected",
+  "inbox_apply_to_selected": "Apply to selected ({count})",
+  "inbox_confirm_all": "Confirm all ({count})",
+  "inbox_apply_selected_plans": "Apply selected ({count})",
+  "plans_gate_normal_items_sentence": " {count} normal item(s).",
+  "plans_gate_unprotected_items_sentence": " {count} unprotected item(s).",
+  "plans_gate_require_ack": "{done} of {total} require acknowledgement",
+  "plans_gate_normal_items": "{count} normal item(s)",
+  "plans_gate_unprotected_items": "{count} unprotected item(s)",
+  "projects_open_in": "Open in {tool}",
+  "targets_hours_above": "{hours} h"
 }

--- a/apps/desktop/src/features/inbox/InboxControls.tsx
+++ b/apps/desktop/src/features/inbox/InboxControls.tsx
@@ -186,7 +186,7 @@ export function InboxControls({
                 (d) => d.id === value || !usedEarlier.has(d.id),
               ).map((d) => (
                 <option key={d.id} value={d.id}>
-                  {slot === 0 ? `Group: ${d.label}` : `then: ${d.label}`}
+                  {slot === 0 ? m.inbox_groupby_chip_primary({ label: d.label }) : m.inbox_groupby_chip_secondary({ label: d.label })}
                 </option>
               ))}
             </select>

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -413,7 +413,7 @@ export function InboxDetail({
               title={m.inbox_missing_attrs_title({ attrs: missingAttrs.join(', ') })}
               className="alm-inbox-detail__missing-attr-badge"
             >
-              {`needs ${missingAttrs.join(', ')}`}
+              {m.inbox_needs_attrs({ attrs: missingAttrs.join(', ') })}
             </span>
           )}
         </span>
@@ -550,7 +550,7 @@ export function InboxDetail({
               data-testid="reclassify-select-all"
             />
             <span className="alm-inbox-detail__select-all-label">
-              {selectedFiles.size === 0 ? m.common_select_all() : `${selectedFiles.size} selected`}
+              {selectedFiles.size === 0 ? m.common_select_all() : m.inbox_n_selected({ count: selectedFiles.size })}
             </span>
           </div>
           <Table columns={unclassifiedColumns} rows={unclassifiedRows} />
@@ -634,7 +634,7 @@ export function InboxDetail({
               >
                 {reclassifyLoading
                   ? m.common_applying()
-                  : `Apply to selected (${selectedFiles.size})`}
+                  : m.inbox_apply_to_selected({ count: selectedFiles.size })}
               </button>
             </div>
           )}

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -640,7 +640,7 @@ export function InboxPage() {
             >
               {bulkConfirmLoading
                 ? m.common_confirming()
-                : `Confirm all (${bulkEligibleItems.length})`}
+                : m.inbox_confirm_all({ count: bulkEligibleItems.length })}
             </Btn>
           )}
           <Btn

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -582,7 +582,7 @@ export function PlanPanel({
             data-testid="plan-apply-selected"
             aria-label={m.inbox_apply_selected_plans_aria()}
           >
-            {busy ? m.common_applying() : `Apply selected (${selectedArray.length})`}
+            {busy ? m.common_applying() : m.inbox_apply_selected_plans({ count: selectedArray.length })}
           </Btn>
           <Btn
             variant="accent"
@@ -721,19 +721,40 @@ export function PlanPanel({
                   data-testid={`plan-progress-${plan.inboxItemId}`}
                   role="status"
                   aria-live="polite"
-                  style={{
-                    fontSize: 'var(--alm-text-xs)',
-                    color: 'var(--alm-text-secondary)',
-                    marginTop: 'var(--alm-sp-1)',
-                  }}
                 >
-                  {/* eslint-disable alm/no-user-string -- live-progress composite (optional " of {total}" / ", {failed} failed" segments + item plural) from merged spec-042 feature; full catalog migration tracked in spec 046 task #7 (plural variants) */}
-                  {progress.terminal === 'completed'
-                    ? `Applied ${progress.applied}${progress.total != null ? ` of ${progress.total}` : ''} item${progress.applied !== 1 ? 's' : ''}.`
-                    : progress.terminal === 'failed'
-                      ? `Apply failed after ${progress.applied} applied, ${progress.failed} failed.`
-                      : `Applying… ${progress.applied}${progress.total != null ? ` of ${progress.total}` : ''} item${progress.applied !== 1 ? 's' : ''}${progress.failed > 0 ? `, ${progress.failed} failed` : ''}`}
-                  {/* eslint-enable alm/no-user-string */}
+                  {(() => {
+                    // Count label ("N" or "N of M") — kept as a sub-message so the
+                    // "of" connector stays translatable; passed into the plural
+                    // variant messages below as {countText}.
+                    const countText =
+                      progress.total != null
+                        ? m.inbox_progress_count_of({
+                            applied: progress.applied,
+                            total: progress.total,
+                          })
+                        : String(progress.applied);
+                    if (progress.terminal === 'completed') {
+                      return m.inbox_progress_completed({
+                        applied: progress.applied,
+                        countText,
+                      });
+                    }
+                    if (progress.terminal === 'failed') {
+                      return m.inbox_progress_failed({
+                        applied: progress.applied,
+                        failed: progress.failed,
+                      });
+                    }
+                    const failedText =
+                      progress.failed > 0
+                        ? m.inbox_progress_failed_suffix({ failed: progress.failed })
+                        : '';
+                    return m.inbox_progress_running({
+                      applied: progress.applied,
+                      countText,
+                      failedText,
+                    });
+                  })()}
                 </div>
               )}
 

--- a/apps/desktop/src/features/plans/PlanProtectionGate.tsx
+++ b/apps/desktop/src/features/plans/PlanProtectionGate.tsx
@@ -105,8 +105,8 @@ export function PlanProtectionGate({ planId, onAcknowledgedChange }: PlanProtect
     return (
       <div className="alm-plan-gate__status">
         {m.plans_gate_no_protected()}
-        {normalCount > 0 && ` ${normalCount} normal item(s).`}
-        {unprotectedCount > 0 && ` ${unprotectedCount} unprotected item(s).`}
+        {normalCount > 0 && m.plans_gate_normal_items_sentence({ count: normalCount })}
+        {unprotectedCount > 0 && m.plans_gate_unprotected_items_sentence({ count: unprotectedCount })}
       </div>
     );
   }
@@ -123,7 +123,7 @@ export function PlanProtectionGate({ planId, onAcknowledgedChange }: PlanProtect
         style={{ background: allDone ? 'var(--alm-surface)' : 'var(--alm-bg3)' }}
       >
         <Pill variant={allDone ? 'ok' : 'warn'}>
-          {allDone ? m.plans_all_acknowledged() : `${total - doneCount} of ${total} require acknowledgement`}
+          {allDone ? m.plans_all_acknowledged() : m.plans_gate_require_ack({ done: total - doneCount, total })}
         </Pill>
         <span className="alm-plan-gate__summary-label">
           {allDone
@@ -187,12 +187,12 @@ export function PlanProtectionGate({ planId, onAcknowledgedChange }: PlanProtect
         <div className="alm-plan-gate__footer-summary">
           {m.plans_gate_also_in_plan()}{' '}
           {checkResult.nonBlockingSummary.normalCount > 0 &&
-            `${checkResult.nonBlockingSummary.normalCount} normal item(s)`}
+            m.plans_gate_normal_items({ count: checkResult.nonBlockingSummary.normalCount })}
           {checkResult.nonBlockingSummary.normalCount > 0 &&
             checkResult.nonBlockingSummary.unprotectedCount > 0 &&
             ', '}
           {checkResult.nonBlockingSummary.unprotectedCount > 0 &&
-            `${checkResult.nonBlockingSummary.unprotectedCount} unprotected item(s)`}
+            m.plans_gate_unprotected_items({ count: checkResult.nonBlockingSummary.unprotectedCount })}
           {' '}{m.plans_no_ack_required()}
         </div>
       )}

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -379,7 +379,7 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
                 data-testid="tool-launch-btn"
                 data-guide-anchor="project.open-in-tool"
               >
-                {launchState.working ? m.projects_launching() : `Open in ${projectToolStr}`}
+                {launchState.working ? m.projects_launching() : m.projects_open_in({ tool: projectToolStr })}
               </Btn>
             )}
 

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -577,7 +577,7 @@ export function TargetsTable({
                     <span
                       title={m.targets_table_hours_above_title({ hours: alt.hoursAboveUsable.toFixed(1), threshold: usableAltDeg })}
                     >
-                      {alt.hoursAboveUsable > 0 ? `${alt.hoursAboveUsable.toFixed(1)} h` : '—'}
+                      {alt.hoursAboveUsable > 0 ? m.targets_hours_above({ hours: alt.hoursAboveUsable.toFixed(1) }) : '—'}
                     </span>
                   </td>
                   {/* MOCK (#57): linked-session count not on TargetListItem yet. */}

--- a/apps/desktop/src/lib/no-user-string.rule.test.ts
+++ b/apps/desktop/src/lib/no-user-string.rule.test.ts
@@ -133,6 +133,28 @@ describe('alm/no-user-string', () => {
     expect(out.filter((m) => m.ruleId === 'alm/no-user-string')).toHaveLength(1);
   });
 
+  it('flags template literals rendered as a JSX child (ternary expression)', () => {
+    const out = lint(`
+      function P({ ok, n }) {
+        return <div>{ok ? \`Applied \${n} items\` : \`Failed after \${n}\`}</div>;
+      }
+    `);
+    const hits = out.filter((m) => m.ruleId === 'alm/no-user-string');
+    expect(hits).toHaveLength(2);
+    expect(hits.every((m) => m.messageId === 'jsxText')).toBe(true);
+  });
+
+  it('does NOT flag template literals in non-render positions (className, var, throw)', () => {
+    const out = lint(`
+      function P({ id }) {
+        const cls = \`row-\${id} active\`;
+        return <div className={\`wrap-\${id}\`}>{cls.length}</div>;
+      }
+    `);
+    // className \`wrap-\${id}\` is an attribute (machine); cls assignment is a var.
+    expect(out.filter((m) => m.ruleId === 'alm/no-user-string')).toHaveLength(0);
+  });
+
   it('ignores pure-interpolation / machine template literals (no letters)', () => {
     const out = lint(`
       function P({ a, b, id }) {

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -1761,6 +1761,14 @@
 
 /* === PLAN PANEL === */
 
+/* Live long-op apply progress line (spec 042 US16). Token-only; moved off an
+   inline style block to satisfy the no-inline-style gate. */
+.alm-plan-panel__progress {
+  font-size: var(--alm-text-xs);
+  color: var(--alm-text-secondary);
+  margin-top: var(--alm-sp-1);
+}
+
 /* ── Root picker ────────────────────────────────────────────── */
 
 .alm-plan-panel__root-picker {


### PR DESCRIPTION
Follow-up to #311. Closes the last alm/no-user-string blind spot and fixes the
violations the now-running eslint gate surfaces.

- Rule: add a child-position TemplateLiteral visitor (+ regression tests) so
  interpolated JSX-child strings are caught.
- Migrate the 14 strings it surfaces.
- Migrate the PlanPanel live-progress composite to inlang variant messages
  (removes a temporary disable).
- Fix a no-restricted-syntax error (inline style on the progress div from merged
  spec-042 code) — this was failing the eslint CI gate added in #311.

eslint src/: 0 errors. tsc: 0 errors. Frontend tests: 930 passed.