### PR TITLE
fix: green the redesign reconcile-merge (i18n literals + CI gates)

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1227,5 +1227,56 @@
   "plans_gate_normal_items": "{count} normal item(s)",
   "plans_gate_unprotected_items": "{count} unprotected item(s)",
   "projects_open_in": "Open in {tool}",
-  "targets_hours_above": "{hours} h"
+  "targets_hours_above": "{hours} h",
+  "inbox_prop_classification": "Classification",
+  "inbox_lane_video": "video",
+  "inbox_dest_root_label": "Library:",
+  "inbox_dest_root_aria": "Destination library",
+  "inbox_no_file_metadata": "No file metadata",
+  "inbox_col_detection": "Detection",
+  "inbox_no_detections": "No detections.",
+  "inbox_review_plans_title": "Review plans",
+  "inbox_plan_col_plan": "Plan",
+  "inbox_plan_col_composition": "Composition",
+  "inbox_inplace_label": "In place",
+  "inbox_plan_file_count_tooltip_mixed": "{moved} moved · {inPlace} catalogued in place",
+  "inbox_plan_file_count_tooltip_inplace": "{count} catalogued in place",
+  "inbox_destructive_flag": "destructive",
+  "inbox_review_plans_with_count": "Review plans ({count})",
+  "inbox_review_plans": "Review plans",
+  "calibration_session_popover_filter_label": "Filter sessions",
+  "calibration_session_popover_filter_placeholder": "Filter…",
+  "calibration_session_popover_no_matches": "No matches",
+  "calibration_used_by_label": "Used by",
+  "calibration_compatible_label": "Compatible",
+  "inbox_apply_n_overrides": [
+    {
+      "declarations": [
+        "input count",
+        "local p = count: plural"
+      ],
+      "selectors": [
+        "p"
+      ],
+      "match": {
+        "p=one": "Apply 1 override",
+        "p=other": "Apply {count} overrides"
+      }
+    }
+  ],
+  "inbox_confirm_all_classified_aria": [
+    {
+      "declarations": [
+        "input count",
+        "local p = count: plural"
+      ],
+      "selectors": [
+        "p"
+      ],
+      "match": {
+        "p=one": "Confirm all {count} classified item",
+        "p=other": "Confirm all {count} classified items"
+      }
+    }
+  ]
 }

--- a/apps/desktop/src/components/FilterToolbar.tsx
+++ b/apps/desktop/src/components/FilterToolbar.tsx
@@ -127,20 +127,19 @@ function GroupingSelects({ grouping }: { grouping: GroupingControl }) {
         const usedEarlier = new Set(dims.slice(0, slot));
         return (
           <select
-            // eslint-disable-next-line react/no-array-index-key -- fixed-length slot list
             key={slot}
             className="alm-filterbar__select"
             value={value}
             disabled={disabled}
             onChange={(e) => setSlot(slot, e.target.value)}
-            aria-label={slot === 0 ? 'Group by' : `Then group by (level ${slot + 1})`}
+            aria-label={slot === 0 ? m.inbox_group_by_aria() : m.inbox_group_by_level_aria({ level: slot + 1 })}
           >
-            <option value="">{slot === 0 ? 'Group: none' : 'then: —'}</option>
+            <option value="">{slot === 0 ? m.inbox_controls_group_none() : m.inbox_controls_then_none()}</option>
             {dimensions
               .filter((d) => d.value === value || !usedEarlier.has(d.value))
               .map((d) => (
                 <option key={d.value} value={d.value}>
-                  {slot === 0 ? `Group: ${d.label}` : `then: ${d.label}`}
+                  {slot === 0 ? m.inbox_groupby_chip_primary({ label: d.label }) : m.inbox_groupby_chip_secondary({ label: d.label })}
                 </option>
               ))}
           </select>

--- a/apps/desktop/src/components/Modal.tsx
+++ b/apps/desktop/src/components/Modal.tsx
@@ -26,6 +26,7 @@
 
 import { type ReactNode } from 'react';
 import { Dialog } from '@base-ui-components/react/dialog';
+import { m } from '@/lib/i18n';
 
 export type ModalSize = 'sm' | 'md' | 'lg' | 'xl' | 'auto';
 
@@ -110,7 +111,7 @@ export function Modal({
               <span className="alm-modal__subtitle">{subtitle}</span>
             )}
             {!hideClose && (
-              <Dialog.Close className="alm-modal__close" aria-label="Close">
+              <Dialog.Close className="alm-modal__close" aria-label={m.common_close()}>
                 ✕
               </Dialog.Close>
             )}

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -200,11 +200,11 @@ export function MasterDetail({ master, agingThresholdDays }: Props) {
 				{/* Single column with both session popovers stacked vertically. */}
 				<div className="alm-session-detail2__linked alm-session-detail2__linked--stack">
 					<SessionListPopover
-						label="Used by"
+						label={m.calibration_used_by_label()}
 						names={detail.loading ? [] : detail.confirmedNames}
 					/>
 					<SessionListPopover
-						label="Compatible"
+						label={m.calibration_compatible_label()}
 						names={detail.loading ? [] : detail.compatibleNames}
 					/>
 				</div>

--- a/apps/desktop/src/features/calibration/SessionListPopover.tsx
+++ b/apps/desktop/src/features/calibration/SessionListPopover.tsx
@@ -8,6 +8,7 @@
 
 import { Popover } from "@base-ui-components/react/popover";
 import { useId, useRef, useState } from "react";
+import { m } from "@/lib/i18n";
 
 interface Props {
 	label: string;
@@ -27,7 +28,7 @@ export function SessionListPopover({ label, names }: Props) {
 		<div>
 			<div className="alm-session-detail2__head">{label}</div>
 			{names.length === 0 ? (
-				<span className="alm-session-detail2__muted">None</span>
+				<span className="alm-session-detail2__muted">{m.common_none()}</span>
 			) : (
 				<Popover.Root
 					onOpenChange={(open) => {
@@ -45,20 +46,20 @@ export function SessionListPopover({ label, names }: Props) {
 						<Popover.Positioner side="bottom" align="start" sideOffset={4}>
 							<Popover.Popup className="alm-session-popover__popup">
 								<label htmlFor={inputId} className="alm-visually-hidden">
-									Filter sessions
+									{m.calibration_session_popover_filter_label()}
 								</label>
 								<input
 									ref={inputRef}
 									id={inputId}
 									className="alm-session-popover__search"
-									placeholder="Filter…"
-									aria-label="Filter sessions"
+									placeholder={m.calibration_session_popover_filter_placeholder()}
+									aria-label={m.calibration_session_popover_filter_label()}
 									value={query}
 									onChange={(e) => setQuery(e.target.value)}
 								/>
 								<ul className="alm-session-popover__list">
 									{filtered.length === 0 ? (
-										<li className="alm-session-popover__empty">No matches</li>
+										<li className="alm-session-popover__empty">{m.calibration_session_popover_no_matches()}</li>
 									) : (
 										filtered.map((name) => (
 											<li key={name} className="alm-session-popover__item">

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -479,7 +479,7 @@ export function InboxDetail({
 	const detectionProps: PropertyDef[] = [
 		{
 			key: "classification",
-			label: "Classification",
+			label: m.inbox_prop_classification(),
 			value:
 				classType === "single_type"
 					? (classification?.frameType ?? "single_type")
@@ -487,7 +487,7 @@ export function InboxDetail({
 		},
 		{
 			key: "files",
-			label: "Files",
+			label: m.inbox_col_files(),
 			value: classification
 				? String(
 						classification.breakdown?.reduce((s, e) => s + e.count, 0) ||
@@ -499,7 +499,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "target",
-						label: "Target",
+						label: m.inbox_dim_target(),
 						value: repFile.object,
 						source: "fits",
 					} as PropertyDef,
@@ -509,7 +509,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "filter",
-						label: "Filter",
+						label: m.common_filter(),
 						value: repFile.filter,
 						source: "fits",
 					} as PropertyDef,
@@ -519,7 +519,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "exposure",
-						label: "Exposure",
+						label: m.inbox_col_exposure(),
 						value: fmtExposure(repFile.exposureS),
 						source: "fits",
 					} as PropertyDef,
@@ -529,7 +529,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "binning",
-						label: "Binning",
+						label: m.settings_calmatch_binning(),
 						value: fmtBinning(repFile?.binningX, repFile?.binningY),
 						source: "fits",
 					} as PropertyDef,
@@ -539,7 +539,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "gain",
-						label: "Gain",
+						label: m.inbox_col_gain(),
 						value: repFile.gain,
 						source: "fits",
 					} as PropertyDef,
@@ -549,7 +549,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "temp",
-						label: "Sensor temp",
+						label: m.settings_calmatch_sensor_temp(),
 						value: fmtTemp(repFile.temperatureC),
 						source: "fits",
 					} as PropertyDef,
@@ -559,7 +559,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "instrume",
-						label: "Instrument",
+						label: m.inbox_field_instrument(),
 						value: repFile.instrume,
 						source: "fits",
 					} as PropertyDef,
@@ -569,7 +569,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "dims",
-						label: "Dimensions",
+						label: m.inbox_field_dimensions(),
 						value: fmtDimensions(repFile.naxis1, repFile.naxis2),
 						source: "fits",
 					} as PropertyDef,
@@ -579,7 +579,7 @@ export function InboxDetail({
 			? [
 					{
 						key: "date",
-						label: "Night",
+						label: m.sessions_col_night(),
 						value: repFile.dateObs,
 						source: "fits",
 					} as PropertyDef,
@@ -603,7 +603,7 @@ export function InboxDetail({
 					? (classification?.frameType ?? m.inbox_detail_single_fallback())
 					: classType}
 			</Pill>
-			{item.lane === "video" && <Pill variant="ghost">video</Pill>}
+			{item.lane === "video" && <Pill variant="ghost">{m.inbox_lane_video()}</Pill>}
 			{onConfirm && (
 				<Btn
 					size="sm"
@@ -621,15 +621,15 @@ export function InboxDetail({
 			    choose which library the files are placed in (Auto = backend pick). */}
 			{onConfirm && applicableRoots.length > 1 && (
 				<label className="alm-inbox-detail__dest-root">
-					<span className="alm-inbox-detail__dest-root-label">Library:</span>
+					<span className="alm-inbox-detail__dest-root-label">{m.inbox_dest_root_label()}</span>
 					<select
 						className="alm-select alm-select--sm"
 						value={selectedRootId ?? ""}
 						onChange={(e) => onSelectRoot?.(e.target.value)}
-						aria-label="Destination library"
+						aria-label={m.inbox_dest_root_aria()}
 						data-testid="inbox-dest-root-select"
 					>
-						<option value="">Auto</option>
+						<option value="">{m.projects_edit_channels_auto_tag()}</option>
 						{applicableRoots.map((r) => (
 							<option key={r.id} value={r.id}>
 								{basename(r.path)} · {r.category}
@@ -705,12 +705,12 @@ export function InboxDetail({
 
 				{/* Col C: Files — mixed-composition summary + the metadata popover */}
 				<div className="alm-session-detail2__col">
-					<div className="alm-session-detail2__head">Files</div>
+					<div className="alm-session-detail2__head">{m.inbox_col_files()}</div>
 
 					{/* FR-011: compact mixed-composition summary */}
 					{mixedSummary && (
 						<section
-							aria-label="Mixed composition summary"
+							aria-label={m.inbox_mixed_composition_summary_aria()}
 							className="alm-inbox-detail__mixed-summary"
 						>
 							{mixedSummary}
@@ -758,7 +758,7 @@ export function InboxDetail({
 					) : (
 						!mixedSummary && (
 							<span className="alm-session-detail2__muted">
-								No file metadata
+								{m.inbox_no_file_metadata()}
 							</span>
 						)
 					)}
@@ -912,7 +912,7 @@ export function InboxDetail({
 								>
 									{reclassifyLoading
 										? m.common_applying()
-										: `Apply ${Object.keys(pendingOverrides).length} override${Object.keys(pendingOverrides).length !== 1 ? "s" : ""}`}
+										: m.inbox_apply_n_overrides({ count: Object.keys(pendingOverrides).length })}
 								</button>
 							</div>
 						)}

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -136,7 +136,7 @@ export function flattenVisibleTree(
 // ── Columns ──────────────────────────────────────────────────────────────────────
 
 const COLUMNS: TableColumn[] = [
-  { key: 'detection', label: 'Detection' },
+  { key: 'detection', label: m.inbox_col_detection() },
   { key: 'type', label: m.inbox_col_type(), style: { width: '7.5rem' } },
   { key: 'count', label: m.inbox_col_files(), className: 'num', style: { width: '5rem' } },
   {
@@ -258,7 +258,7 @@ export function InboxList({
               // eslint-disable-next-line no-restricted-syntax -- dynamic: nested-group leaf indent
               style={indent ? { paddingLeft: indent } : undefined}
             >
-              {item.relativePath || '(root)'}
+              {item.relativePath || m.inbox_list_root_label()}
             </span>
           ),
           type: (
@@ -268,7 +268,7 @@ export function InboxList({
               {classificationLabel(item)}
             </span>
           ),
-          count: `${item.fileCount} ${item.fileCount !== 1 ? 'files' : 'file'}`,
+          count: `${item.fileCount} ${item.fileCount !== 1 ? m.inbox_list_file_plural() : m.inbox_list_file_singular()}`,
           format: item.isMaster
             ? `${item.masterFrameType ?? 'master'} master`
             : formatTag(item),
@@ -284,7 +284,7 @@ export function InboxList({
   return (
     <div className="alm-inbox-list" data-testid="inbox-list">
       {visualRows.length === 0 ? (
-        <div className="alm-inbox-list__empty">No detections.</div>
+        <div className="alm-inbox-list__empty">{m.inbox_no_detections()}</div>
       ) : (
         <Table
           className="alm-inbox-table"

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -721,7 +721,7 @@ export function InboxPage() {
 					search={{
 						value: search,
 						onChange: setSearch,
-						placeholder: "Search detections…",
+						placeholder: m.inbox_search_placeholder(),
 						ariaLabel: "Search inbox",
 					}}
 					actions={
@@ -752,12 +752,12 @@ export function InboxPage() {
 							size="sm"
 							variant="accent"
 							onClick={() => setPlanOverlayOpen(true)}
-							aria-label={`Review plans (${planCount})`}
+							aria-label={m.inbox_review_plans_with_count({ count: planCount })}
 							data-testid="inbox-review-plans-btn"
 						>
 							{planCount > 0
-								? `Review plans (${planCount})`
-								: "Review plans"}
+								? m.inbox_review_plans_with_count({ count: planCount })
+								: m.inbox_review_plans()}
 						</Btn>
 					)}
 					{/* task 35: bulk-confirm all cleanly-classified items in one action */}
@@ -767,8 +767,12 @@ export function InboxPage() {
 							variant="accent"
 							disabled={!canBulkConfirm}
 							onClick={() => void handleBulkConfirm()}
-							aria-label={`Confirm all ${bulkEligibleItems.length} classified item${bulkEligibleItems.length !== 1 ? "s" : ""}`}
+							aria-label={m.inbox_confirm_all_classified_aria({ count: bulkEligibleItems.length })}
 							data-testid="inbox-bulk-confirm-btn"
+							// Guided-tour target (spec 010/041). The redesign moved the
+							// page-level confirm to this bulk-confirm action; keep the
+							// `inbox.confirm-row` anchor on it so the tour still resolves.
+							data-guide-anchor="inbox.confirm-row"
 						>
 							{bulkConfirmLoading
 								? m.common_confirming()
@@ -782,9 +786,9 @@ export function InboxPage() {
 						size="sm"
 						disabled={rescanLoading}
 						onClick={() => void rescan()}
-						aria-label="Rescan all roots"
+						aria-label={m.inbox_rescan_all_roots_aria()}
 					>
-						{rescanLoading ? "Rescanning…" : "Rescan"}
+						{rescanLoading ? m.common_rescanning() : m.common_rescan()}
 					</Btn>
 				</>
 			}

--- a/apps/desktop/src/features/inbox/PlanApprovalOverlay.tsx
+++ b/apps/desktop/src/features/inbox/PlanApprovalOverlay.tsx
@@ -11,6 +11,7 @@
 
 import { useEffect } from 'react';
 import { Modal } from '@/components';
+import { m } from '@/lib/i18n';
 import { PlanPanel } from './PlanPanel';
 import type { PlanPanelProps } from './PlanPanel';
 import type { InboxOpenPlan } from './store';
@@ -46,10 +47,10 @@ export function PlanApprovalOverlay({
     <Modal
       open={open}
       onClose={onClose}
-      title="Review plans"
+      title={m.inbox_review_plans_title()}
       subtitle={subtitle}
       size="xl"
-      ariaLabel="Review plans"
+      ariaLabel={m.inbox_review_plans_title()}
       data-testid="plan-approval-overlay"
     >
       <PlanPanel plans={plans} totalActions={totalActions} {...rest} />

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -592,10 +592,10 @@ export function PlanPanel({
         {/* Column header — aligns with each plan's group-header grid. */}
         <div className="alm-plan-panel__list-head" aria-hidden="true">
           <span className="alm-plan-panel__group-lead" />
-          <span>Plan</span>
-          <span>Composition</span>
-          <span>Destination</span>
-          <span>Files</span>
+          <span>{m.inbox_plan_col_plan()}</span>
+          <span>{m.inbox_plan_col_composition()}</span>
+          <span>{m.inbox_col_destination()}</span>
+          <span>{m.inbox_col_files()}</span>
           <span />
         </div>
         {plans.map((plan, planIdx) => {
@@ -683,9 +683,9 @@ export function PlanPanel({
                 {/* Col 2: plan / source folder ("(root)" for the library root) */}
                 <span
                   className="alm-plan-panel__group-name"
-                  title={plan.itemName || '(root)'}
+                  title={plan.itemName || m.inbox_list_root_label()}
                 >
-                  {plan.itemName || '(root)'}
+                  {plan.itemName || m.inbox_list_root_label()}
                 </span>
 
                 {/* Col 3: composition breakdown (aligned). */}
@@ -722,7 +722,7 @@ export function PlanPanel({
                 <span className="alm-plan-panel__group-dest">
                   {allInPlace ? (
                     <>
-                      <span className="alm-plan-panel__inplace">In place</span>
+                      <span className="alm-plan-panel__inplace">{m.inbox_inplace_label()}</span>
                       <code
                         className="alm-plan-panel__summary-dest"
                         title={breakdownDest?.full ?? plan.itemName}
@@ -750,11 +750,11 @@ export function PlanPanel({
                   className="alm-plan-panel__group-count"
                   title={
                     moveCount > 0
-                      ? `${moveCount} moved · ${plan.actions.length - moveCount} catalogued in place`
-                      : `${plan.actions.length} catalogued in place`
+                      ? m.inbox_plan_file_count_tooltip_mixed({ moved: moveCount, inPlace: plan.actions.length - moveCount })
+                      : m.inbox_plan_file_count_tooltip_inplace({ count: plan.actions.length })
                   }
                 >
-                  {plan.actions.length} file{plan.actions.length !== 1 ? 's' : ''}
+                  {plan.actions.length}{' '}{plan.actions.length !== 1 ? m.inbox_list_file_plural() : m.inbox_list_file_singular()}
                 </span>
 
                 {/* Col 6: stale badge + per-group apply (live progress) + discard */}
@@ -881,13 +881,13 @@ export function PlanPanel({
                           )}
                           {a.requiresDestructiveConfirm && (
                             <span className="alm-plan-panel__file-flag">
-                              destructive
+                              {m.inbox_destructive_flag()}
                             </span>
                           )}
                         </span>
                         <span className="alm-plan-panel__file-dest">
                           {inPlace ? (
-                            <span className="alm-plan-panel__inplace">In place</span>
+                            <span className="alm-plan-panel__inplace">{m.inbox_inplace_label()}</span>
                           ) : (
                             <>
                               <span

--- a/apps/desktop/src/features/inbox/__tests__/PlanApprovalOverlay.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/PlanApprovalOverlay.test.tsx
@@ -54,7 +54,6 @@ function renderOverlay(props: Partial<Props> & { plans: InboxOpenPlan[] }) {
   const defaults: Props = {
     open: true,
     onClose: vi.fn(),
-    plans: props.plans,
     totalActions: props.plans.reduce((n, p) => n + p.actions.length, 0),
     destructiveDestination: 'archive',
     onDestructiveDestinationChange: vi.fn(),
@@ -69,16 +68,16 @@ function renderOverlay(props: Partial<Props> & { plans: InboxOpenPlan[] }) {
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('PlanApprovalOverlay', () => {
-  let onClose: ReturnType<typeof vi.fn>;
-  let onApplyAll: ReturnType<typeof vi.fn>;
-  let onApplySelected: ReturnType<typeof vi.fn>;
-  let onCancel: ReturnType<typeof vi.fn>;
+  let onClose: ReturnType<typeof vi.fn<() => void>>;
+  let onApplyAll: ReturnType<typeof vi.fn<() => void>>;
+  let onApplySelected: ReturnType<typeof vi.fn<(ids: string[]) => void>>;
+  let onCancel: ReturnType<typeof vi.fn<(id: string) => void>>;
 
   beforeEach(() => {
-    onClose = vi.fn();
-    onApplyAll = vi.fn();
-    onApplySelected = vi.fn();
-    onCancel = vi.fn();
+    onClose = vi.fn<() => void>();
+    onApplyAll = vi.fn<() => void>();
+    onApplySelected = vi.fn<(ids: string[]) => void>();
+    onCancel = vi.fn<(id: string) => void>();
   });
 
   // ── Render ─────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -100,9 +100,9 @@ export const Table = forwardRef<HTMLTableElement, TableProps>(
 
     const head = (
       <thead>
-        {/* eslint-disable-next-line no-restricted-syntax -- dynamic: Table column header style passthrough from caller */}
         <tr>
           {columns.map((c, i) => (
+            // eslint-disable-next-line no-restricted-syntax -- dynamic: caller-provided column header style passthrough
             <th key={i} className={c.className} style={c.style}>
               {c.label}
             </th>


### PR DESCRIPTION
The redesign reconcile-merge (efee4e1) landed on main failing eslint (60),
typecheck (11), and tests (2). This restores all three to green.

- Migrate 58 alm/no-user-string violations the redesign re-introduced (+23 keys,
  incl. 2 inlang plural variants; reused existing keys where possible).
- Fix eslint: misplaced no-restricted-syntax disable (Table.tsx) + orphaned
  react/no-array-index-key disable (FilterToolbar; eslint-plugin-react not configured).
- Fix typecheck: PlanApprovalOverlay.test.tsx (dup prop + typed vi.fn mocks).
- Fix tests: re-attach dropped `inbox.confirm-row` guided-tour anchor to the
  page-level bulk-confirm button.

eslint src/: 0 errors. tsc: 0 errors. 929 frontend tests pass.