### PR TITLE
feat(046 #7): standardize plurals on inlang variants + alm/no-js-plural rule

### DIFF
--- a/apps/desktop/eslint-rules/no-user-string.js
+++ b/apps/desktop/eslint-rules/no-user-string.js
@@ -378,8 +378,55 @@ const rule = {
   },
 };
 
+// alm/no-js-plural (spec 046 task #7). Flags JS-side pluralization — a ternary
+// whose branches are a lone plural suffix and empty string, e.g.
+// `count !== 1 ? 's' : ''` (inline) or `{ suffix: n === 1 ? '' : 's' }` (param).
+// This bakes English plural rules into code; the message catalog can't localize
+// them. Use an inlang plural VARIANT message instead
+// (declarations/selectors/match → Intl.PluralRules), called m.<key>({ count }).
+/** @type {import('eslint').Rule.RuleModule} */
+const noJsPlural = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Disallow JS-side pluralization (lone suffix ternaries); use an inlang plural variant message.",
+    },
+    schema: [],
+    messages: {
+      jsPlural:
+        "JS-side pluralization {{text}} bakes English plural rules into code. Use an inlang plural variant message (declarations/selectors/match) called as m.<key>({ count }). If genuinely not a plural, add `// eslint-disable-next-line alm/no-js-plural -- <reason>`.",
+    },
+  },
+  create(context) {
+    const PLURAL = new Set(["s", "es", "ies"]);
+    return {
+      ConditionalExpression(node) {
+        const branches = [node.consequent, node.alternate];
+        if (
+          !branches.every(
+            (b) => b.type === "Literal" && typeof b.value === "string",
+          )
+        ) {
+          return;
+        }
+        const vals = branches.map((b) => b.value);
+        const isSuffixOrEmpty = (v) => v === "" || PLURAL.has(v);
+        if (vals.every(isSuffixOrEmpty) && vals.some((v) => PLURAL.has(v))) {
+          context.report({
+            node,
+            messageId: "jsPlural",
+            data: { text: `\`${vals.map((v) => v || "∅").join("/")}\`` },
+          });
+        }
+      },
+    };
+  },
+};
+
 export default {
   rules: {
     "no-user-string": rule,
+    "no-js-plural": noJsPlural,
   },
 };

--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -48,6 +48,9 @@ export default tseslint.config(
     ],
     rules: {
       'alm/no-user-string': 'error',
+      // JS-side pluralization ('s'/'es' suffix ternaries) bakes English plural
+      // rules into code; use inlang plural variant messages instead (spec 046 #7).
+      'alm/no-js-plural': 'error',
     },
   },
 

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -684,7 +684,21 @@
   "setup_scan_phase_pending": "Pending",
   "setup_scan_scanning": "Scanning…",
   "setup_scan_summary_empty": "No folders detected. You can add more sources in Settings.",
-  "setup_scan_summary_found": "{count} folder{suffix} detected across all sources. Head to the Inbox to review and approve.",
+  "setup_scan_summary_found": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} folder detected across all sources. Head to the Inbox to review and approve.",
+        "pp=other": "{count} folders detected across all sources. Head to the Inbox to review and approve."
+      }
+    }
+  ],
   "setup_sources_add_folder_aria": "Add {kind} folder",
   "setup_sources_add_e2e": "Add by path (E2E)",
   "setup_sources_e2e_path_aria": "E2E {kind} path",
@@ -733,7 +747,21 @@
   "setup_wizard_continue_to": "Continue to {label} →",
   "setup_wizard_finish": "Finish",
   "setup_wizard_finishing": "Finishing…",
-  "setup_wizard_folder_count": "{count} folder{suffix} selected",
+  "setup_wizard_folder_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} folder selected",
+        "pp=other": "{count} folders selected"
+      }
+    }
+  ],
   "setup_wizard_registering": "Registering…",
   "setup_wizard_start_scan": "Start scan →",
   "setup_wizard_step_label": "Setup · Step {step} of {total}",
@@ -817,7 +845,21 @@
   "inbox_toast_confirm_failed": "Confirm failed: {message}",
   "inbox_toast_bulk_partial": "{success} confirmed; {fail} skipped (mixed, missing metadata, or needs root pick).",
   "inbox_toast_bulk_all_need_review": "Bulk confirm: all items need review (mixed folders or missing metadata).",
-  "inbox_toast_bulk_confirmed": "{success} item{suffix} confirmed — review plans below.",
+  "inbox_toast_bulk_confirmed": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} item confirmed — review plans below.",
+        "pp=other": "{count} items confirmed — review plans below."
+      }
+    }
+  ],
   "inbox_toast_plans_partial": "{applied} plan(s) applied; {failed} failed.",
   "inbox_toast_plans_applying": "{count} plan(s) are being applied.",
   "inbox_toast_all_plans_partial": "{applied} plans applied; {failed} failed.",
@@ -1276,6 +1318,186 @@
       "match": {
         "p=one": "Confirm all {count} classified item",
         "p=other": "Confirm all {count} classified items"
+      }
+    }
+  ],
+  "calibration_usage_sessions": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} session",
+        "pp=other": "{count} sessions"
+      }
+    }
+  ],
+  "calibration_usage_projects": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} project",
+        "pp=other": "{count} projects"
+      }
+    }
+  ],
+  "inbox_count_folders": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} folder",
+        "pp=other": "{count} folders"
+      }
+    }
+  ],
+  "inbox_count_masters": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} master",
+        "pp=other": "{count} masters"
+      }
+    }
+  ],
+  "plan_count_label": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} plan",
+        "pp=other": "{count} plans"
+      }
+    }
+  ],
+  "action_count_label": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} action",
+        "pp=other": "{count} actions"
+      }
+    }
+  ],
+  "projects_cleanup_candidate_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "Cleanup would review {count} candidate for archive or trash. Nothing is removed without explicit plan approval.",
+        "pp=other": "Cleanup would review {count} candidates for archive or trash. Nothing is removed without explicit plan approval."
+      }
+    }
+  ],
+  "projects_source_views_inventory_ref_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} inventory ref",
+        "pp=other": "{count} inventory refs"
+      }
+    }
+  ],
+  "settings_auditlog_event_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} event",
+        "pp=other": "{count} events"
+      }
+    }
+  ],
+  "settings_naming_unknown_tokens": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "Unknown token",
+        "pp=other": "Unknown tokens"
+      }
+    }
+  ],
+  "setup_scan_folder_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} folder",
+        "pp=other": "{count} folders"
+      }
+    }
+  ],
+  "setup_scan_file_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} file",
+        "pp=other": "{count} files"
       }
     }
   ]

--- a/apps/desktop/src/features/calibration/MastersList.tsx
+++ b/apps/desktop/src/features/calibration/MastersList.tsx
@@ -33,12 +33,12 @@ function kindLabel(kind: string): Kind | null {
  * No STUB needed — these are real fields. Renders "3 sessions · 1 project",
  * collapsing to the non-zero parts, or "unused" when nothing references it.
  */
-function usageSummary(m: CalibrationMaster): string {
-  const sessions = (m.usedBySessionIds ?? []).length;
-  const projects = (m.usedByProjectIds ?? []).length;
+function usageSummary(master: CalibrationMaster): string {
+  const sessions = (master.usedBySessionIds ?? []).length;
+  const projects = (master.usedByProjectIds ?? []).length;
   const parts: string[] = [];
-  if (sessions > 0) parts.push(`${sessions} session${sessions === 1 ? '' : 's'}`);
-  if (projects > 0) parts.push(`${projects} project${projects === 1 ? '' : 's'}`);
+  if (sessions > 0) parts.push(m.calibration_usage_sessions({ count: sessions }));
+  if (projects > 0) parts.push(m.calibration_usage_projects({ count: projects }));
   return parts.length > 0 ? parts.join(' · ') : 'unused';
 }
 

--- a/apps/desktop/src/features/calibration/MastersTable.tsx
+++ b/apps/desktop/src/features/calibration/MastersTable.tsx
@@ -124,12 +124,12 @@ function cameraCell(m: CalibrationMaster): string {
  * `usedBySessionIds` / `usedByProjectIds`. Renders "3 sessions · 1 project",
  * collapsing to the non-zero parts, or "unused" when nothing references it.
  */
-function usageSummary(m: CalibrationMaster): string {
-  const sessions = (m.usedBySessionIds ?? []).length;
-  const projects = (m.usedByProjectIds ?? []).length;
+function usageSummary(master: CalibrationMaster): string {
+  const sessions = (master.usedBySessionIds ?? []).length;
+  const projects = (master.usedByProjectIds ?? []).length;
   const parts: string[] = [];
-  if (sessions > 0) parts.push(`${sessions} session${sessions === 1 ? '' : 's'}`);
-  if (projects > 0) parts.push(`${projects} project${projects === 1 ? '' : 's'}`);
+  if (sessions > 0) parts.push(m.calibration_usage_sessions({ count: sessions }));
+  if (projects > 0) parts.push(m.calibration_usage_projects({ count: projects }));
   return parts.length > 0 ? parts.join(' · ') : 'unused';
 }
 

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -445,8 +445,7 @@ export function InboxPage() {
 		} else {
 			addToast({
 				message: m.inbox_toast_bulk_confirmed({
-					success: String(successCount),
-					suffix: successCount !== 1 ? "s" : "",
+					count: successCount,
 				}),
 				variant: "info",
 			});
@@ -688,9 +687,9 @@ export function InboxPage() {
 		if (listLoading) return m.common_loading();
 		const parts: string[] = [];
 		if (folderCount > 0)
-			parts.push(`${folderCount} folder${folderCount !== 1 ? "s" : ""}`);
+			parts.push(m.inbox_count_folders({ count: folderCount }));
 		if (masterCount > 0)
-			parts.push(`${masterCount} master${masterCount !== 1 ? "s" : ""}`);
+			parts.push(m.inbox_count_masters({ count: masterCount }));
 		const base = parts.length > 0 ? parts.join(" · ") : "0 detections";
 		return isCapped ? `${base} (first ${listData?.limit ?? 500})` : base;
 	}, [listLoading, folderCount, masterCount, isCapped, listData?.limit]);

--- a/apps/desktop/src/features/inbox/PlanApprovalOverlay.tsx
+++ b/apps/desktop/src/features/inbox/PlanApprovalOverlay.tsx
@@ -40,7 +40,7 @@ export function PlanApprovalOverlay({
 
   const subtitle =
     plans.length > 0
-      ? `${plans.length} plan${plans.length !== 1 ? 's' : ''} · ${totalActions} action${totalActions !== 1 ? 's' : ''}`
+      ? `${m.plan_count_label({ count: plans.length })} · ${m.action_count_label({ count: totalActions })}`
       : undefined;
 
   return (

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -557,10 +557,7 @@ export function PlanPanel({
             className="alm-plan-panel__count-summary"
             data-testid="plan-total-count"
           >
-            {/* eslint-disable-next-line alm/no-user-string -- plural suffix fragments; ICU plurals not supported by the message-format plugin */}
-            {plans.length} plan{plans.length !== 1 ? 's' : ''} · {totalActions} action
-            {/* eslint-disable-next-line alm/no-user-string -- plural suffix fragment; ICU plurals unsupported by the message-format plugin */}
-            {totalActions !== 1 ? 's' : ''}
+            {m.plan_count_label({ count: plans.length })} · {m.action_count_label({ count: totalActions })}
           </span>
         </div>
         <div

--- a/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
+++ b/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
@@ -131,8 +131,7 @@ export function CleanupPreviewSection({ preview, defaultOpen = true }: CleanupPr
           {preview ? (
             // STUB: this branch is currently unreachable (preview is always
             // undefined). Kept so wiring is trivial once the backend lands.
-            // eslint-disable-next-line alm/no-user-string -- lone plural suffix in unreachable STUB copy pending backend preview model
-            <span className="alm-project-detail__cleanup-note">{`Cleanup would review ${preview.candidateCount} candidate${preview.candidateCount === 1 ? '' : 's'} for archive or trash. Nothing is removed without explicit plan approval.`}</span>
+            <span className="alm-project-detail__cleanup-note">{m.projects_cleanup_candidate_count({ count: preview.candidateCount })}</span>
           ) : (
             <span className="alm-project-detail__cleanup-note">
               {m.projects_cleanup_no_preview()}

--- a/apps/desktop/src/features/projects/SourceViewsSection.tsx
+++ b/apps/desktop/src/features/projects/SourceViewsSection.tsx
@@ -181,9 +181,7 @@ export function SourceViewsSection({ projectId, onPlanCreated, defaultOpen = tru
               {view.items.length > 0 && (
                 <details className="text-xs text-muted alm-source-views__refs-details">
                   <summary className="alm-source-views__refs-summary">
-                    {view.items.length} {m.projects_source_views_inventory_ref()}
-                    {/* eslint-disable-next-line alm/no-user-string -- lone plural suffix */}
-                    {view.items.length !== 1 ? 's' : ''}
+                    {m.projects_source_views_inventory_ref_count({ count: view.items.length })}
                   </summary>
                   <ul
                     className="alm-source-views__refs-list"

--- a/apps/desktop/src/features/settings/AuditLog.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.tsx
@@ -124,8 +124,8 @@ export function AuditLog() {
         {/* Pagination */}
         <div className="alm-audit-log__pagination">
           <span className="alm-audit-log__page-count">
-            {/* eslint-disable-next-line alm/no-user-string -- plural composite: count + page + total JS expressions cannot be split into a single catalog key without ICU plural support */}
-            {filtered.length} event{filtered.length !== 1 ? 's' : ''} &middot; page {page + 1} of {totalPages}
+            {/* eslint-disable-next-line alm/no-user-string -- pagination separator fragments "· page X of Y" are structural, not translatable copy */}
+            {m.settings_auditlog_event_count({ count: filtered.length })} &middot; page {page + 1} of {totalPages}
           </span>
           <div className="alm-audit-log__page-btns">
             <Btn size="sm" variant="ghost" onClick={() => setPage(Math.max(0, page - 1))} disabled={page === 0}>

--- a/apps/desktop/src/features/settings/NamingStructure.tsx
+++ b/apps/desktop/src/features/settings/NamingStructure.tsx
@@ -178,15 +178,15 @@ function validatePatternString(value: string): string | null {
 	if (value.trim() === "") return null; // empty = use default
 	const unknown: string[] = [];
 	const re = /\{([^}]*)\}/g;
-	let m: RegExpExecArray | null;
-	while ((m = re.exec(value)) !== null) {
-		const token = m[1];
+	let match: RegExpExecArray | null;
+	while ((match = re.exec(value)) !== null) {
+		const token = match[1];
 		if (!VALID_PATTERN_TOKENS.has(token as (typeof AVAILABLE_TOKENS)[number])) {
 			unknown.push(token);
 		}
 	}
 	if (unknown.length > 0) {
-		return `Unknown token${unknown.length > 1 ? "s" : ""}: ${unknown.map((t) => `{${t}}`).join(", ")}`;
+		return `${m.settings_naming_unknown_tokens({ count: unknown.length })}: ${unknown.map((t) => `{${t}}`).join(", ")}`;
 	}
 	return null;
 }

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -355,7 +355,7 @@ export function SetupWizard() {
       {/* Folder count summary on source step */}
       {step === 0 && totalFolders > 0 && (
         <span className="alm-setup-wizard__folder-count">
-          {m.setup_wizard_folder_count({ count: totalFolders, suffix: totalFolders !== 1 ? 's' : '' })}
+          {m.setup_wizard_folder_count({ count: totalFolders })}
         </span>
       )}
       {isOnScanStep ? (

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -129,7 +129,7 @@ function SourceSummary({ state }: SourceSummaryProps) {
   // Compact count summary for the always-visible header line.
   const countSummary =
     phase === 'done' && totalItems > 0
-      ? `${totalItems} folder${totalItems !== 1 ? 's' : ''} · ${totalFiles} file${totalFiles !== 1 ? 's' : ''}`
+      ? `${m.setup_scan_folder_count({ count: totalItems })} · ${m.setup_scan_file_count({ count: totalFiles })}`
       : null;
 
   return (
@@ -402,7 +402,7 @@ export function StepScan({ sources, flushResult, onAllDoneChange }: StepScanProp
               className="alm-setup-scan__summary"
             >
               {totalDetected > 0
-                ? m.setup_scan_summary_found({ count: totalDetected, suffix: totalDetected !== 1 ? 's' : '' })
+                ? m.setup_scan_summary_found({ count: totalDetected })
                 : m.setup_scan_summary_empty()}
             </p>
           )}

--- a/apps/desktop/src/lib/no-user-string.rule.test.ts
+++ b/apps/desktop/src/lib/no-user-string.rule.test.ts
@@ -155,6 +155,23 @@ describe('alm/no-user-string', () => {
     expect(out.filter((m) => m.ruleId === 'alm/no-user-string')).toHaveLength(0);
   });
 
+  it('alm/no-js-plural flags lone-suffix pluralization ternaries', () => {
+    const linter = new Linter();
+    const run = (code: string) =>
+      linter.verify(code, {
+        plugins: { alm: plugin },
+        languageOptions: { parserOptions: { ecmaVersion: 'latest', sourceType: 'module' } },
+        rules: { 'alm/no-js-plural': 'error' },
+      });
+    // inline JSX-suffix + suffix-param forms → flagged
+    expect(run("const a = n !== 1 ? 's' : '';").filter((m) => m.ruleId === 'alm/no-js-plural')).toHaveLength(1);
+    expect(run("f({ suffix: n === 1 ? '' : 's' });").filter((m) => m.ruleId === 'alm/no-js-plural')).toHaveLength(1);
+    expect(run("const a = n === 1 ? '' : 'es';").filter((m) => m.ruleId === 'alm/no-js-plural')).toHaveLength(1);
+    // full-word ternaries and non-plural ternaries → NOT flagged
+    expect(run("const a = ok ? 'Save' : 'Cancel';").filter((m) => m.ruleId === 'alm/no-js-plural')).toHaveLength(0);
+    expect(run("const a = n === 1 ? 'item' : 'items';").filter((m) => m.ruleId === 'alm/no-js-plural')).toHaveLength(0);
+  });
+
   it('ignores pure-interpolation / machine template literals (no letters)', () => {
     const out = lint(`
       function P({ a, b, id }) {


### PR DESCRIPTION
Adds the alm/no-js-plural lint rule (+ tests, enabled as error) and migrates all 19 JS-pluralization sites to inlang plural variant messages (Intl.PluralRules). 12 new variant keys + 3 existing keys converted from {suffix} params. Fixes 2 shadowing bugs (local m vs i18n m). eslint 0, tsc 0, 930 tests.