### PR TITLE
docs(specs): correct 041 iter-2 status + artifact drift audit

### DIFF
--- a/crates/persistence/db/migrations/0047_target_constellation_magnitude.sql
+++ b/crates/persistence/db/migrations/0047_target_constellation_magnitude.sql
@@ -1,4 +1,5 @@
--- Migration 0046: Add constellation and magnitude to canonical_target.
+-- Migration 0047: Add constellation and magnitude to canonical_target.
+-- (Renamed from 0046 to resolve a duplicate-version collision; see PR #317.)
 --
 -- These fields were absent from the original schema (migration 0031).
 -- Both are nullable:

--- a/specs/005-inbox-mixed-folder-split/spec.md
+++ b/specs/005-inbox-mixed-folder-split/spec.md
@@ -2,10 +2,12 @@
 
 > **⚠ SUPERSEDED (2026-06-23) by [Spec 041 — Inbox Plan Surface](../041-inbox-plan-surface/spec.md).**
 > The "detect mixed folder → warn → split into separate Inbox folders → only then move into Inventory"
-> flow specified here was never implemented as written (0/51 tasks). Spec 041's iteration-1 replaced it
-> with a **single-type sub-items at ingest** model (mixed folders split into per-type items at ingest,
-> field-agnostic reclassify, missing-mandatory gate, source-group provenance — landed in PR #315). The
-> mixed-vs-single detection intent here remains the conceptual origin; the implementation lives in 041.
+> flow specified here was never implemented as written (0/51 tasks). Spec 041 is its reassigned home:
+> 041's **single-type sub-items at ingest** model (mixed folders split into per-type items at ingest,
+> field-agnostic reclassify, missing-mandatory gate, source-group provenance) replaces this approach.
+> **Note (2026-06-23):** that single-type model is 041 *iteration-2* and is **spec'd but not yet
+> implemented** — PR #315 merged docs only; no source-group schema/migration exists on `main`. The
+> mixed-vs-single detection intent here remains the conceptual origin; the implementation will live in 041.
 
 > **UI Revised**: The UI design in this spec has been revised by
 > [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md).

--- a/specs/SPEC_STATUS.md
+++ b/specs/SPEC_STATUS.md
@@ -29,7 +29,7 @@ Last reconciled: **2026-06-23** (after the 035 / 040 / 041 / 046 iteration waves
 | 002 data-lifecycle-state-model | ✅ Implemented (review) | 57/57; lifecycle partly *dropped* in inbox redesign — worth a tension review |
 | 003 first-run-source-setup | ✅ Implemented | 32/32 (via 027/029) |
 | 004 native-filesystem-controls | ✅ Implemented | 32/32 |
-| 005 inbox-mixed-folder-split | 🔴 Superseded by 041 | 0/51; replaced by single-type-at-ingest (#315) |
+| 005 inbox-mixed-folder-split | 🔴 Superseded by 041 | 0/51; reassigned to 041 single-type model — **not yet implemented** (PR #315 docs-only) |
 | 006 inventory-library-lifecycle | 🟡 Closeout-ready | 28/43; 14/15 open tasks DEFERRED |
 | 007 calibration-matching-rules | 🟡 Closeout-ready | 31/42; all 11 open tasks DEFERRED (JSON-schema test runner absent) |
 | 008 project-create-onboard-edit | 🟡 Partial | 28/38; ~6 real-open |
@@ -42,7 +42,7 @@ Last reconciled: **2026-06-23** (after the 035 / 040 / 041 / 046 iteration waves
 | 015 token-pattern-builder | 🟡 Mockup only | 0/0 tasks |
 | 016 source-protection-defaults | 🟡 Near-complete | 17/20 (underpins 017) |
 | 017 cleanup-archive-review-plans | 🟠 Backend done, UI open | **19 real-open** |
-| 018 settings-configuration-model | 🟠 Largely open | 18/46 — **28 real-open**, biggest unfinished domain spec |
+| 018 settings-configuration-model | 🟡 Backend largely shipped, tasks.md undercounts | 18/46 ticked but Rust+Tauri settings backend (SQLite migration 0013, restore-defaults, source-override, most scope keys) shipped unticked; genuine gaps = JSON-schema mirror + structured-path keys |
 | 019 bottom-log-viewer | 🟡 Near-complete | 30/34 |
 | 020 router-url-state | ✅ Implemented | 22/23 |
 | 021 developer-contract-diagnostics | 🟡 Partial | 32/37 (behind `dev-tools` feature) |
@@ -60,12 +60,12 @@ Last reconciled: **2026-06-23** (after the 035 / 040 / 041 / 046 iteration waves
 | 033 validation-bugfix-remediation | 🟡 Partial | 83/92; blocked on 017 cleanup generator |
 | 035 simbad-target-resolution | ✅ Implemented | validated end-to-end 2026-06-23 |
 | 036 retire-legacy-targets | ✅ Implemented | PR #255 |
-| 037 e2e-integration-testing | 🟠 Partial / gated | 24/39; Layer-1 + CI Stage A done; real-UI E2E gated on backend stubs |
-| 037 ipc-wrapper-removal | 🟠 Mostly open | 2/15; independent |
+| 037 e2e-integration-testing | 🟠 Partial / gated | 24/39; Layer-1 + CI Stage A done. Gate note is now stale — `search.global`/`sessions.list`/`calibration.masters` graduated to real backends; only `sessions.transition` + tauri-driver wiring remain |
+| 037 ipc-wrapper-removal | 🟡 In progress (~8/15) | tasks.md says 2/15 but Phases 1–2 shipped: `api/ipc.ts` switcher exists, `commands.ts` has 0 invoke literals. Phase 3–4 (repoint 99 `@/api/commands` importers) open |
 | 038 wizard-scan-step | ✅ Implemented | merged (no committed tasks.md) |
 | 039 cross-root-inbox | ⚪ Not started | no plan/tasks; 041 base now on main |
 | 040 calibration-masters-detection | ✅ Implemented | validated end-to-end 2026-06-23 |
-| 041 inbox-plan-surface | ✅ Implemented | 59/59 + iteration-1 (#315); supersedes 005 |
+| 041 inbox-plan-surface | ✅ iteration-1 / 🔵 iteration-2 in progress | iter-1 (confirm + plan surface + apply + destination model) shipped 59/59. iter-2 (single-type sub-items, T061–T080) is **being implemented by another agent** on `041-single-type-*` branches — docs/task-scaffolding present, no crate schema on `main` yet. Supersedes 005 |
 | 042 stdlib-adoption | ✅ Implemented | 80/97; reconciled #310 |
 | 043 ui-redesign-platevault | 🔵 Active | current branch `redesign-ui-platevault` |
 | 044 targets-planner-astronomy | ⚪ Placeholder | frontend mocked; needs research-led astronomy engine |
@@ -103,8 +103,8 @@ PROJECTS CHAIN
 INFRA / CROSS-CUTTING (mostly independent)
   018 settings 🟠   021 dev-diagnostics 🟡   019 log-viewer 🟡
   046 i18n ✅   042 stdlib ✅   043 ui-redesign 🔵
-  037 e2e 🟠 ◀── gated on real backend stubs (search.global / sessions / calibration.masters)
-  037 ipc-removal 🟠 (independent)
+  037 e2e 🟠 ◀── now gated only on sessions.transition + tauri-driver (search/sessions/calibration are real)
+  037 ipc-removal 🟡 (~8/15; Phases 1–2 shipped)
 ```
 
 ## Actionable frontier — what can be worked on now (unblocked)
@@ -115,7 +115,7 @@ INFRA / CROSS-CUTTING (mostly independent)
 | 1 | **017 cleanup/archive review UI** | Backend + plan model (041) done; 016 nearly done | 🟠 Large (19 open) |
 | 2 | **025 plan-application** (rollback + progress UI) | Apply backend already shipped via 041 | 🟡 Medium |
 | 2 | **039 cross-root-inbox** | Greenfield; 041 base on main; needs plan/tasks | 🟡 Medium |
-| 2 | **037 ipc-wrapper-removal** | Independent infra cleanup | 🟡 Medium (2/15) |
+| 2 | **037 ipc-wrapper-removal** (Phase 3–4) | Phases 1–2 already shipped; finish repointing `@/api/commands` importers | 🟡 Medium (~7 left) |
 | 3 | **011 → 012** tool-launch then artifact-observation | 011 unblocked; 012 follows | 🟡 Medium |
 | 3 | **008 project-create** | 006 inventory closeout-ready | 🟡 Medium |
 | 3 | **021 dev-diagnostics** | Independent, behind `dev-tools` flag | 🟡 Small |
@@ -131,7 +131,7 @@ INFRA / CROSS-CUTTING (mostly independent)
 ## Blocked / not-yet-actionable
 
 - **033 validation-bugfix** — dead cleanup-plan path depends on the **017** generator; do 017 first.
-- **037 e2e** — real-UI suite gated on backend stubs (`search.global`, `sessions`, `calibration.masters`) becoming real.
+- **037 e2e** — real-UI suite now gated only on `sessions.transition` becoming real + tauri-driver wiring (`search.global`/`sessions.list`/`calibration.masters` already graduated to real backends).
 - **044 planner-astronomy** — research-gated: needs an astronomy-engine decision (currently mock).
 
 ## Known repo-health issues (2026-06-23)
@@ -143,3 +143,44 @@ INFRA / CROSS-CUTTING (mostly independent)
   (`session_canonical_target` + `target_constellation_magnitude`) broke fresh-install
   startup and every real-backend integration test. The later file was renumbered to `0047`.
   Watch for this class of collision when concurrent branches pick the next migration number.
+- **Coordination (2026-06-23):** the `041-single-type-impl` / `041-single-type-ingest` branches
+  (iteration-2, in progress by another agent) still carry the **old duplicate `0046` pair** — they
+  predate PR #317 and must be rebased onto current `main` before adding a single-type migration,
+  which should take the next free number (≥0048).
+
+## Artifact drift audit (2026-06-23)
+
+Per-spec review of plan/research/data-model/contracts/tasks vs shipped code. Open items
+to fix (none block runtime except the `confirm.rs` bug):
+
+**Code bug (not a doc):**
+- `crates/app/core/src/inbox/confirm.rs:253-258` filters destinations on `archive | os_trash`,
+  but the canonical token is `archive | trash` (migration `0040`). A `trash` destination would
+  be silently dropped. The comment also misstates the CHECK constraint. **Real bug — fix.**
+
+**Stale `os_trash` wire token** (canonical is `trash`; transport contracts are source-of-truth):
+- 017 contracts (`plan.list.json`, `plan.get.json`, `archive.send_to_trash.json`), data-model, research, spec, tasks
+- 025 `contracts/plan.apply.json`, research, plan
+- 016 spec/plan/research
+- 041 `contracts/operations.md:60`
+
+**Stale superseded-approach artifacts (need banners / reconcile):**
+- 013 — `tasks.md` claims "IMPLEMENTED" citing `crates/targeting/src/catalog.rs` + migration `0017`
+  that no longer exist (036 retired them); research builds on the abandoned 014 catalog pipeline.
+  Spec.md banner exists but sub-artifacts contradict it.
+- 023 — spec/tasks/contracts describe the **retired gen-2 target model** (`target_aliases`, `target_id`
+  FKs) and assert "Targets not top-level nav" — both reversed by 035/036. Needs reconcile to gen-3.
+- 002 — research §6.2 documents abandoned `catalog.download.*` topics without a supersession note;
+  session-lifecycle redesign (sessions = derived inventory) not propagated to FRs.
+
+**Contracts lagging Rust DTOs (regenerate):**
+- 008 `project.create.json` missing `canonicalTargetId`; `project.source.add.json` missing `role`/`selection`.
+- 002/007 minor: `confidence`/`mismatchedDimensions` placement, `canonicalTargetId` on session DTO.
+- 006 `inventory.session.review.json` enum missing `"noop"`.
+
+**Wrong references (minor):**
+- 035 `plan.md:115` cites `0046_acq_session_canonical_target.sql`; real file is `0046_session_canonical_target.sql`.
+
+**Artifact-completeness gaps:**
+- 040 shipped (PRs #290/#292/#293) with only spec.md + research.md — no plan/data-model/contracts/tasks.
+- 024 — commands `project.note.get` and `project.manifest.reveal_in_os` shipped without contracts.


### PR DESCRIPTION
Follow-up to the spec-status work, correcting this session's own overstatements after verifying artifacts against shipped code, and recording a per-spec artifact drift audit.

## Corrections (my own earlier edits were wrong)
- **041 iteration-2 (single-type sub-items) is NOT shipped** — PR #315 merged docs only; no `inbox_source_groups` schema/migration on `main` or the `041-single-type-*` branches. (Those branches are an **in-progress lane for another agent**.) Fixed in SPEC_STATUS.md + 005's banner. **Does not touch `041/spec.md`** — that's the active agent's file.
- **037-ipc-wrapper-removal** is ~8/15 (Phases 1–2 shipped: `api/ipc.ts` switcher, 0 invoke literals), not 2/15.
- **037-e2e** gate note stale — `search.global`/`sessions.list`/`calibration.masters` are real backends now; only `sessions.transition` remains stub.
- **018 settings** — backend largely shipped; tasks.md undercounts.
- **0047 migration** — fixed stale internal `Migration 0046:` comment left by the PR #317 rename.

## New: Artifact drift audit (2026-06-23) section in SPEC_STATUS.md
From a per-spec review of plan/research/data-model/contracts/tasks vs code:
- **Real code bug:** `crates/app/core/src/inbox/confirm.rs:253-258` filters on `archive | os_trash` but canonical is `archive | trash` — would drop a `trash` destination.
- **Stale `os_trash` wire tokens** in 016/017/025/041 contracts (canonical = `trash`).
- **Stale superseded-approach artifacts:** 013 (catalog pipeline + retired `0017` tables), 023 (gen-2 target model), 002 (catalog.download topics).
- **Contracts lagging DTOs:** 008 (`canonicalTargetId`, `role`/`selection`), 007/006 minor.
- **Artifact gaps:** 040 (no plan/data-model/contracts/tasks), 024 (2 uncontracted commands).

Docs + one SQL-comment line only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)