### PR TITLE
docs(specs): banner stale superseded-approach artifacts (013/023/002) + fix 035 filename

### DIFF
--- a/specs/002-data-lifecycle-state-model/research.md
+++ b/specs/002-data-lifecycle-state-model/research.md
@@ -353,6 +353,10 @@ recompute on each event using the dependency graph above.
 
 #### 6.2 Catalog event-bus topics (spec 014)
 
+> **⚠ SUPERSEDED (2026-06-23).** The `catalog.download.*` / `catalog.manifest.*` topics below belong to
+> the spec-014 bundled-catalog pipeline, which was **abandoned** in favour of SIMBAD resolve-on-demand
+> (spec 035). These topics are not emitted by shipped code. Retained for history.
+
 Catalog download and manifest-fetch operations publish the following
 additional topics on the same in-process event bus. These are owned by
 **spec 014** (`crates/targeting/catalogs/download.rs`); they are registered

--- a/specs/013-target-lookup-from-fits-object/research.md
+++ b/specs/013-target-lookup-from-fits-object/research.md
@@ -1,7 +1,7 @@
 # Research: Target Lookup From FITS OBJECT
 
 **Branch**: `013-target-lookup-from-fits-object` | **Date**: 2026-05-20
-**Status**: NOT IMPLEMENTED — research decisions are draft and pending review.
+**Status**: SUPERSEDED (2026-06-23) by [Spec 035 — SIMBAD Target Resolution](../035-simbad-target-resolution/spec.md). The catalog-source/licensing decisions below (built on spec 014's `catalog.download` flow, with no bundled catalog data) are no longer the product direction — SIMBAD resolve-on-demand + a bundled seed index won out. Retained for history.
 
 ## R1. Catalog Sources And Licensing
 

--- a/specs/013-target-lookup-from-fits-object/tasks.md
+++ b/specs/013-target-lookup-from-fits-object/tasks.md
@@ -7,7 +7,14 @@ description: "Tasks for feature 013: Target Lookup From FITS OBJECT"
 **Input**: Design documents from `/specs/013-target-lookup-from-fits-object/`
 **Prerequisites**: spec.md, plan.md, research.md, data-model.md, contracts/
 
-## Implementation Status: IMPLEMENTED (2026-06-11)
+> **⚠ STALE (2026-06-23): superseded by [Spec 035 — SIMBAD Target Resolution](../035-simbad-target-resolution/spec.md).**
+> The "IMPLEMENTED" claim below is no longer true. The cited evidence (`crates/targeting/src/catalog.rs`,
+> `load.rs`, migration `0017_targets.sql`) was **removed** — spec 036 retired the gen-2 `targets`/`0017`
+> tables and the targeting crate now holds only `identity.rs`/`lib.rs`/`normalize.rs`. Lookup from the FITS
+> OBJECT keyword is now served by SIMBAD resolve-on-demand + bundled seed (spec 035), not the spec-014
+> catalog-download pipeline this spec assumed. Treat the tasks below as historical.
+
+## Implementation Status: IMPLEMENTED (2026-06-11) — STALE, see banner above
 
 All core tasks are complete. Deferred tasks are marked below with reasons.
 Verification: `cargo test --workspace` (0 failures), `cargo clippy --workspace

--- a/specs/023-target-identity-history-notes/spec.md
+++ b/specs/023-target-identity-history-notes/spec.md
@@ -1,12 +1,22 @@
 # Feature Specification: Target Identity, History, And Notes
 
+> **⚠ NEEDS RECONCILE (2026-06-23).** This spec predates the target-model rebuild and is contradicted
+> by shipped code on two points: (1) it targets the **retired gen-2 model** (`target_aliases`, `target_id`
+> FKs on sessions/projects, `primary_designation` column) that **spec 036 deleted** — identity now lives
+> in the spec-035 `canonical_target` id-space; (2) its "Targets intentionally **not** a top-level nav"
+> assertion was **reversed by spec 036**, which rebuilt Targets as a primary gen-3 nav page
+> (`apps/desktop/src/features/targets/`). The contracts (`target.alias.add/remove`, `target.primary.rename`)
+> encode the gen-2 API — verify each command still exists post-036 before reusing. Re-scope onto gen-3 + 035
+> before any further work.
+
 > **See Spec 030**: UI implementation of this feature must follow
 > [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
 > for layout, navigation, and component patterns.
 
 **Feature Branch**: `023-target-identity-history-notes`  
 **Created**: 2026-05-09  
-**Status**: Draft  
+**Updated**: 2026-06-23  
+**Status**: Needs reconcile (was: Draft / NOT IMPLEMENTED) — describes retired gen-2 target model; see banner  
 **Input**: User description: "Specify target identity, aliases, target history, observing-plan references, and notes as bounded follow-on features beyond FITS OBJECT lookup."
 
 ## Implementation Status: NOT IMPLEMENTED

--- a/specs/035-simbad-target-resolution/plan.md
+++ b/specs/035-simbad-target-resolution/plan.md
@@ -112,7 +112,7 @@ retired. New operation contracts live in `crates/contracts/core` + `packages/con
 
 ### Migration 0046 — `acquisition_session.canonical_target_id`
 
-`crates/persistence/db/migrations/0046_acq_session_canonical_target.sql`:
+`crates/persistence/db/migrations/0046_session_canonical_target.sql`:
 
 ```sql
 ALTER TABLE acquisition_session ADD COLUMN canonical_target_id TEXT REFERENCES canonical_target(id);

--- a/specs/040-calibration-masters-detection/spec.md
+++ b/specs/040-calibration-masters-detection/spec.md
@@ -8,6 +8,8 @@
 
 **Status**: Implemented — per-tool MasterDetector (PixInsight/Siril), individual master items, format field, confirm→Calibration page (PRs #290/#292/#293). Validated end-to-end 2026-06-23: `calibration_master_detect` 23/23, `confirm_master_integration` 3/3.
 
+> **Artifact deviation (2026-06-23):** this feature shipped with only `spec.md` + `research.md` + `checklists/` — no `plan.md`, `data-model.md`, `contracts/`, or `tasks.md`. Per the constitution's SpecKit quality gates these would normally exist; recorded here as a known deviation (backfill if 040 is reopened).
+
 **Input**: Detect calibration masters from XISF and FITS metadata via an extensible per-tool detector system; classify base frame type + an `isMaster` flag; distinguish masters by filter/exposure; show masters as individual items in the inbox and surface them on the Calibration page. (Sub-frames stay folder-grouped.)
 
 ## Background


### PR DESCRIPTION
Round-2 of the artifact drift remediation: reconcile sub-artifacts that contradict their own specs after the SIMBAD pivot (035) and gen-2 target retirement (036). Doc-only.

- **013** `tasks.md` — "IMPLEMENTED" claim cited `crates/targeting/src/catalog.rs` + migration `0017` that **036 deleted** → STALE banner. `research.md` built on the abandoned 014 `catalog.download` flow → SUPERSEDED banner.
- **023** `spec.md` — describes the **retired gen-2 target model** and asserts "Targets not top-level nav", both reversed by 036 → reconcile banner + status flip.
- **002** `research.md` §6.2 — `catalog.download.*` topics not emitted by shipped code → SUPERSEDED banner.
- **035** `plan.md` — corrected migration filename (`0046_acq_session_canonical_target` → real `0046_session_canonical_target`).
- **040** `spec.md` — recorded the artifact-completeness deviation (shipped without plan/data-model/contracts/tasks).

Contract-vs-DTO field gaps (008/006/007) are already tracked in `SPEC_STATUS.md` (#341); 024's open tasks are already annotated with deferred reasons.

🤖 Generated with [Claude Code](https://claude.com/claude-code)