### PR TITLE
feat(spec 023): close caveats — audit note edits + UUID project deep-link

### DIFF
--- a/apps/desktop/src-tauri/src/commands/target_management.rs
+++ b/apps/desktop/src-tauri/src/commands/target_management.rs
@@ -226,5 +226,5 @@ pub async fn target_note_update(
     req: TargetNoteUpdateRequest,
 ) -> Result<TargetNoteUpdateResult, TargetOpError> {
     tracing::debug!("target.note.update target_id={} notes_len={}", req.target_id, req.notes.len());
-    app_core::target_management::note_update(state.repo.pool(), &req).await
+    app_core::target_management::note_update(state.repo.pool(), &state.bus, &req).await
 }

--- a/apps/desktop/src/app/router.tsx
+++ b/apps/desktop/src/app/router.tsx
@@ -23,12 +23,6 @@ import {
   REVIEW_FILTERS,
 } from '@/lib/route-contract';
 
-/** Parse a path-param id to a number; NaN-safe `selected` search for redirects. */
-function selectedSearch(rawId: string): { selected?: number } {
-  const id = Number(rawId);
-  return Number.isFinite(id) ? { selected: id } : {};
-}
-
 /** String `selected` redirect for routes where IDs are UUIDs (e.g. sessions). */
 function selectedSearchString(rawId: string): { selected?: string } {
   return rawId && rawId.trim() !== '' ? { selected: rawId.trim() } : {};
@@ -144,7 +138,9 @@ const projectsRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/projects',
   validateSearch: makeValidateSearch({
-    selected: parseNumber,
+    // spec 023: project IDs are UUIDs (strings). Switched from legacy numeric
+    // index so linked-project deep-links from TargetDetailV2 work correctly.
+    selected: parseString,
     lifecycle: parseCsvEnum(PROJECT_STATES),
   }),
   component: lazyRouteComponent(
@@ -157,7 +153,7 @@ const projectDetailRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/projects/$id',
   beforeLoad: ({ params }) => {
-    throw redirect({ to: '/projects', search: selectedSearch(params.id) });
+    throw redirect({ to: '/projects', search: selectedSearchString(params.id) });
   },
 });
 

--- a/apps/desktop/src/features/projects/ProjectsPage.tsx
+++ b/apps/desktop/src/features/projects/ProjectsPage.tsx
@@ -26,8 +26,8 @@
  * Notes, Manifests, Calibration, Source views, Outputs, and Cleanup preview.
  * Both panels mount when a project is selected and close together.
  *
- * URL state (unchanged router contract):
- *   - `selected`: numeric index into the (unfiltered) list.
+ * URL state:
+ *   - `selected`: project UUID string (spec 023 caveat fix — was numeric index).
  *   - `lifecycle`: CSV state filter.
  */
 
@@ -84,18 +84,15 @@ export function ProjectsPage() {
   const [search, setSearch] = useState('');
   const [sort, setSort] = useState<ProjectSort>(DEFAULT_PROJECT_SORT);
 
-  // Stale-id cleanup: if selected index is out of range, clear it.
-  const selectedIdx = selected ?? 0;
-  const inRange = projects.length > 0 && selected != null && selectedIdx < projects.length;
-  useStaleSelectionCleanup(selected, inRange, () =>
+  // UUID-based selection: find project by id, clear stale ids that no longer exist.
+  const project: ProjectSummaryDto | undefined =
+    selected != null ? projects.find((p) => p.id === selected) : undefined;
+  useStaleSelectionCleanup(selected, project !== undefined || selected == null, () =>
     navigate({ search: (prev) => ({ ...prev, selected: undefined }), replace: true }),
   );
 
-  const project: ProjectSummaryDto | undefined = inRange ? projects[selectedIdx] : undefined;
-
   const onSelect = (id: string) => {
-    const idx = projects.findIndex((p) => p.id === id);
-    if (idx >= 0) void navigate({ search: (prev) => ({ ...prev, selected: idx }) });
+    void navigate({ search: (prev) => ({ ...prev, selected: id }) });
   };
 
   const clearSelection = useCallback(

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -25,7 +25,7 @@
  * 20. (US2) Linked sessions list renders date, frameCount, state.
  * 21. (US2) Clicking session row navigates to /sessions with selected=id.
  * 22. (US3) Linked projects list renders name and lifecycle.
- * 23. (US3) Clicking project row navigates to /projects.
+ * 23. (US3) Clicking project row navigates to /projects with search: { selected: id }.
  * 24. (US4) Observing notes: empty state renders placeholder.
  * 25. (US4) Observing notes: existing notes body renders.
  * 26. (US4) Edit → save calls updateTargetNote and reflects result.
@@ -459,7 +459,7 @@ describe('TargetDetailV2', () => {
     expect(screen.getAllByText('ready').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('25. (US3) clicking project row navigates to /projects', async () => {
+  it('25. (US3) clicking project row navigates to /projects with selected=id (mid-page link row)', async () => {
     mockListTargetProjects.mockResolvedValue([
       { id: 'proj-1', name: 'Horsehead 2026', lifecycle: 'ready' },
     ]);
@@ -472,7 +472,31 @@ describe('TargetDetailV2', () => {
     fireEvent.click(screen.getAllByText('Horsehead 2026')[0].closest('button')!);
 
     await waitFor(() =>
-      expect(mockNavigate).toHaveBeenCalledWith({ to: '/projects' }),
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/projects',
+        search: { selected: 'proj-1' },
+      }),
+    );
+  });
+
+  it('25b. (US3) clicking project row in bottom section navigates to /projects with selected=id', async () => {
+    mockListTargetProjects.mockResolvedValue([
+      { id: 'proj-1', name: 'Horsehead 2026', lifecycle: 'ready' },
+    ]);
+    render(<TargetDetailV2 targetId={TARGET_ID} />);
+    await waitFor(() =>
+      expect(screen.getAllByText('Horsehead 2026').length).toBeGreaterThanOrEqual(1),
+    );
+
+    // Click the last project button (bottom Projects section)
+    const btns = screen.getAllByText('Horsehead 2026').map((el) => el.closest('button')!);
+    fireEvent.click(btns[btns.length - 1]);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith({
+        to: '/projects',
+        search: { selected: 'proj-1' },
+      }),
     );
   });
 

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -698,7 +698,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
                 <li key={p.id} className="alm-planner__link-item">
                   <button
                     className="alm-planner__link-btn"
-                    onClick={() => void navigate({ to: '/projects' })}
+                    onClick={() => void navigate({ to: '/projects', search: { selected: p.id } })}
                   >
                     <span className="alm-planner__link-name">{p.name}</span>
                     <span className="alm-planner__link-state">{p.lifecycle}</span>
@@ -846,7 +846,9 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
               <li key={p.id} className="alm-target-detail__project-item">
                 <button
                   className="alm-target-detail__project-btn"
-                  onClick={() => void navigate({ to: '/projects' })}
+                  onClick={() =>
+                    void navigate({ to: '/projects', search: { selected: p.id } })
+                  }
                 >
                   <span className="alm-target-detail__project-name">{p.name}</span>
                   <span className="alm-target-detail__project-lifecycle">{p.lifecycle}</span>

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -11,6 +11,8 @@
 //! - §III Metadata/identity only — no image processing.
 //! - §V SQLite (resolution cache / canonical_target) is the durable record.
 
+use audit::bus::EventBus;
+use audit::event_bus::{Source, TargetNoteUpdated, TOPIC_TARGET_NOTE_UPDATED};
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -22,6 +24,7 @@ use contracts_core::targets::{
     TargetOpError, TargetProjectItem, TargetProjectsListRequest, TargetSessionItem,
     TargetSessionsListRequest,
 };
+use domain_core::ids::Timestamp;
 use targeting_resolver::cache::{self, CachedTarget, TargetListRow};
 use targeting_resolver::AliasKind;
 
@@ -433,12 +436,16 @@ pub async fn note_get(
 /// Empty or whitespace-only `notes` clears the field (stores NULL).
 /// Returns the stored value after the update.
 ///
+/// Emits a `target.note.updated` audit event after a successful DB write.
+/// Bus publish failures are logged at `warn` but do NOT fail the operation.
+///
 /// # Errors
 ///
 /// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn note_update(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &TargetNoteUpdateRequest,
 ) -> Result<TargetNoteUpdateResult, TargetOpError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
@@ -469,12 +476,30 @@ pub async fn note_update(
         // Should not happen (we verified existence above), but be defensive.
         return Err(not_found(&req.target_id));
     }
+
+    // Emit audit event — bus failure is non-fatal.
+    if let Err(e) = bus
+        .publish(
+            TOPIC_TARGET_NOTE_UPDATED,
+            Source::User,
+            TargetNoteUpdated {
+                target_id: req.target_id.clone(),
+                has_notes: stored.is_some(),
+                at: Timestamp::now_iso(),
+            },
+        )
+        .await
+    {
+        tracing::warn!(target_id = %req.target_id, error = %e, "audit bus publish failed for target.note.updated");
+    }
+
     Ok(TargetNoteUpdateResult { notes: stored.map(str::to_owned) })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use audit::bus::EventBus;
     use persistence_db::Database;
     use targeting_resolver::cache::upsert_resolved;
     use targeting_resolver::ObjectType;
@@ -486,6 +511,10 @@ mod tests {
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         db
+    }
+
+    fn make_bus(db: &Database) -> EventBus {
+        EventBus::with_pool(db.pool().clone())
     }
 
     fn m31() -> ResolvedIdentity {
@@ -955,12 +984,13 @@ mod tests {
     async fn note_update_and_get_roundtrip() {
         let db = setup().await;
         let id = seed_m31(&db).await;
+        let bus = make_bus(&db);
 
         let upd_req = TargetNoteUpdateRequest {
             target_id: id.to_string(),
             notes: "Great seeing.".to_owned(),
         };
-        let upd_result = note_update(db.pool(), &upd_req).await.unwrap();
+        let upd_result = note_update(db.pool(), &bus, &upd_req).await.unwrap();
         assert_eq!(upd_result.notes.as_deref(), Some("Great seeing."));
 
         let get_req = TargetNoteGetRequest { target_id: id.to_string() };
@@ -972,10 +1002,12 @@ mod tests {
     async fn note_update_whitespace_clears_note() {
         let db = setup().await;
         let id = seed_m31(&db).await;
+        let bus = make_bus(&db);
 
         // Set a note first.
         note_update(
             db.pool(),
+            &bus,
             &TargetNoteUpdateRequest { target_id: id.to_string(), notes: "Initial.".to_owned() },
         )
         .await
@@ -984,6 +1016,7 @@ mod tests {
         // Whitespace-only update should clear.
         let clear_result = note_update(
             db.pool(),
+            &bus,
             &TargetNoteUpdateRequest { target_id: id.to_string(), notes: "   ".to_owned() },
         )
         .await
@@ -1006,11 +1039,12 @@ mod tests {
     #[tokio::test]
     async fn note_update_not_found_returns_error() {
         let db = setup().await;
+        let bus = make_bus(&db);
         let req = TargetNoteUpdateRequest {
             target_id: Uuid::new_v4().to_string(),
             notes: "x".to_owned(),
         };
-        let err = note_update(db.pool(), &req).await.unwrap_err();
+        let err = note_update(db.pool(), &bus, &req).await.unwrap_err();
         assert_eq!(err.code, "target.not_found");
     }
 }

--- a/crates/audit/src/event_bus.rs
+++ b/crates/audit/src/event_bus.rs
@@ -696,6 +696,26 @@ pub struct TargetResolveBatchCompleted {
 
 pub const TOPIC_TARGET_RESOLVE_BATCH_COMPLETED: &str = "target.resolve_batch.completed";
 
+// ── Target note audit event (spec 023 US4) ───────────────────────────────────
+
+/// Payload for the `target.note.updated` topic (spec 023, US4).
+///
+/// Emitted after a successful `target.note.update` write.  The note body is
+/// NOT included in the audit payload (privacy); `has_notes` indicates whether
+/// a non-empty note is now stored.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetNoteUpdated {
+    /// Stable canonical target id (UUID string).
+    pub target_id: String,
+    /// `true` when a non-empty note is now stored; `false` when cleared.
+    pub has_notes: bool,
+    /// ISO-8601 timestamp of the write.
+    pub at: String,
+}
+
+pub const TOPIC_TARGET_NOTE_UPDATED: &str = "target.note.updated";
+
 // ── Settings schema migration audit event (spec 018 US5 T031) ────────────────
 
 /// Payload for the `settings.migration` topic (spec 018 US5, T031).


### PR DESCRIPTION
Closes the two follow-ups flagged in #347.

## Caveat 2 — audit event on note update
`target.note.update` now emits `target.note.updated` (`TargetNoteUpdated { targetId, hasNotes, at }` — the note body is intentionally omitted for privacy). The event bus is threaded through the `note_update` use case and supplied from `state.bus` in the command, exactly like `plans`/`settings`/`projects`. Publish failures `warn!` but don't fail the op (mirrors `plan_apply`). Wire shape unchanged → no bindings regen.

## Caveat 1 — project deep-link by UUID
The projects route now keys `selected` on the **project UUID** (`parseString` + `selectedSearchString`), aligning it with sessions/calibration/targets; `ProjectsPage` selects by id instead of numeric index, and the unused numeric `selectedSearch` helper is removed. `TargetDetailV2` linked-project rows navigate with `search: { selected: p.id }`, so clicking a linked project now opens it selected.

## Verification
- `app_core_targets` 79/79; `cargo clippy -p audit -p app_core_targets` clean.
- `vitest` 362/362 (projects + targets); `tsc` clean; `alm/no-user-string` gate clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)