### PR TITLE
Spec 018 close-out: FR reconciliation + verify gate

### DIFF
--- a/specs/018-settings-configuration-model/data-model.md
+++ b/specs/018-settings-configuration-model/data-model.md
@@ -64,7 +64,7 @@ keys are dropped (see notes).
 | Key (field name on SettingsState) | Type | Default | Overridable per source? | Description | Noisy? |
 |---|---|---|---|---|---|
 | `current_library_id` | `String?` (uuid) | `null` | No | Currently-open library id; drives `?lib=` URL injection (spec 020 R-Lib-V1). | No |
-| `devMode` | `bool` | `false` | No | Runtime developer-mode toggle. Only meaningful in `dev-tools` builds; release gating NOT YET enforced (T036). | No |
+| `devMode` | `bool` | `false` | No | Runtime developer-mode toggle. Only meaningful in `dev-tools` builds; release gating enforced via `#[cfg(not(feature = "dev-tools"))]` in `descriptors.rs` (T036 done). | No |
 | `plans_list_default_age_cutoff_days` | `f64` | `90` | No | UI hides terminal plans older than this; `0` = show all (spec 017 R-Ret-1). | Yes |
 | `rememberFollowLogs` | `bool` | `false` | No | Persists log viewer "follow tail" state across restarts (spec 019 E-019-3). | Yes |
 | ~~`target_lookup.active_catalogs`~~ | — | — | — | **DROPPED** — spec 014 catalog manifest superseded by spec 035 (SIMBAD). | — |

--- a/specs/018-settings-configuration-model/spec.md
+++ b/specs/018-settings-configuration-model/spec.md
@@ -67,12 +67,36 @@ As a user, I want settings grouped by workflow domain so that source behavior, c
 - **FR-002**: Settings MUST show one setting per line.
 - **FR-003**: Each setting row MUST include an information affordance that explains what the setting changes, how the app uses it, what the options mean, and any workflow or safety consequence; it MUST NOT merely restate the label.
 - **FR-004**: Settings MUST auto-save changes and MUST NOT require a global Save button.
-- **FR-005**: Destructive or high-risk setting changes MUST show confirmation before applying.
-- **FR-006**: Density MUST be fixed by the desktop design system; Settings MUST NOT expose compact/comfortable density controls.
+- **FR-005**: Destructive or high-risk setting changes MUST surface a prominent
+  warning (e.g. the Cleanup danger banner). *(Reconciled 2026-06-23 to the
+  auto-save model: settings persist immediately, so the binding *confirmation*
+  for an actual destructive filesystem operation is enforced at plan-application
+  time — the reviewable-plan gate, constitution §II — not at the auto-saved
+  toggle. A settings toggle sets policy; it does not itself mutate the
+  filesystem.)*
+- **FR-006**: Display density is a user-selectable **Appearance preference**, owned
+  by the appearance/theme system (spec 043), persisted via `prefs.density` and
+  applied app-wide by the shell. The legacy per-table `rowDensity` *settings* key
+  is removed (T032). *(Amended 2026-06-23: the original prohibition — "Settings
+  MUST NOT expose density controls" — is relaxed to keep density as an Appearance
+  preference per the design-v4/043 redesign. The constraint that density is not a
+  per-table or internal control is preserved; it is a single global Appearance
+  choice.)*
 - **FR-007**: Light/dark mode MUST be available as an icon control in the app shell and as a persisted appearance setting if exposed.
 - **FR-008**: Project folder and archive location patterns MUST use the token pattern builder, not freeform text.
 - **FR-009**: Calibration matching settings MUST be per calibration frame type.
-- **FR-010**: Catalog settings MUST allow selecting available catalog families and target lookup behavior.
+  *(Reconciled 2026-06-23 to as-built: per-frame-type lives in the backend model
+  — `darkMatchTolerance`/`flatMatching`, per-type dark/flat/bias override
+  penalties, and per-frame-type destination patterns (`patternsByType`). The
+  visible **Calibration Matching** pane presents per-criterion match-required
+  toggles (camera/binning/gain/offset/temp/aging) backed by the spec-007
+  `calibrationTolerances` store; per-frame-type granularity is in the keys it
+  consumes, not as separate dark/flat/bias rows.)*
+- **FR-010**: Catalog/target-lookup settings configure target resolution behavior.
+  *(Reconciled 2026-06-23: catalog-**family** selection (manifest/`active_catalogs`)
+  is superseded by [Spec 035 — SIMBAD Target Resolution](../035-simbad-target-resolution/spec.md);
+  T039 is OBSOLETE. The **Target Resolution** settings pane configures the SIMBAD
+  resolver — endpoint, enable/disable, and cache — in place of family selection.)*
 - **FR-011**: Tool settings MUST configure executable paths for each supported processing tool.
 - **FR-012**: API contract settings MUST NOT appear as a normal user settings section.
 - **FR-013**: Log settings MUST not expose export format or request/entity metadata toggles; request/entity metadata is always present and export is JSON when offered.
@@ -214,7 +238,7 @@ Scope → key mapping:
 | Scope | Keys |
 |-------|------|
 | `advanced` | `logLevel`, `rememberFollowLogs`, `devMode` |
-| `general` | `rowDensity` |
+| `general` | *(empty — `rowDensity` removed by T032; display density is an Appearance preference)* |
 | `cleanup` | `blockPermanentDelete`, `defaultProtection`, `protectedCategories` |
 | `naming` | `pattern`, `autoApplyPattern`, `patternsByType` |
 | `sources` | `followSymlinks`, `hashOnScan`, `alwaysPreviewBeforePlan` |


### PR DESCRIPTION
Final close-out reconciliation for spec 018, after a SpecKit `verify` pass.

`verify` flagged spec-text vs as-built gaps; this PR reconciles the spec so the closed feature asserts only behavior that exists (no code change — docs only; code is identical to merged `main`):

- **FR-006** — density kept as an **Appearance preference** (`prefs.density`, spec 043); legacy `rowDensity` *settings* key removed (T032).
- **FR-005** — auto-save model: destructive *settings* surface a warning; the binding confirm for destructive **filesystem** ops is the plan-application gate (constitution §II), not the toggle.
- **FR-009** — per-frame-type lives in backend keys (dark/flat/bias tolerances + override penalties + `patternsByType`); the Calibration pane is per-criterion (spec 007 tolerances).
- **FR-010** — catalog-family selection superseded by spec 035; the Target Resolution pane configures the SIMBAD resolver.
- Scrubbed stale text: `general` scope is empty (rowDensity gone); `devMode` release gating **is** enforced (data-model note corrected).

Gates green this session: `cargo test -p app_core_settings -p domain_core -p persistence_db -p app_core`, `just typecheck`, clippy, rustfmt; live T034 walkthrough.

After merge: spec 018 is complete (42/46 done, 4 obsolete, 0 open) and ready to archive.