### PR TITLE
fix(ui): Targets table fits-content layout + global cell-clip + global font lock

### DIFF
--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -299,7 +299,10 @@
   flex: 1 1 auto;
   min-height: 0;
   overflow-y: auto;
-  overflow-x: hidden;
+  /* Scroll horizontally instead of clipping the rightmost column: the table
+     carries a min-width floor (see .alm-targets-table) so columns never shrink
+     below their content; below that floor the table scrolls. */
+  overflow-x: auto;
 }
 
 /* Sticky header so column labels/sort controls stay visible while scrolling. */

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -310,28 +310,35 @@
 .alm-targets-table {
   table-layout: fixed;
   width: 100%;
+  /* Floor so every column stays at least as wide as its content. Below this the
+     scroll container (.alm-targets-table__scroll, overflow-x:auto) scrolls
+     horizontally instead of squeezing/clipping the last columns. The column
+     percentages below are tuned so each fits its content at this width. */
+  min-width: 1180px;
 }
 
-/* Designation: auto (fills all remaining width after fixed cols are subtracted). */
-.alm-targets-col--designation { width: 50%; }
+/* Designation: widest column, but not so wide it starves the Filters column
+   (which holds up to 7 band badges). Tuned down from 50% so filter badges fit
+   on a single line and rows stay one row tall. */
+.alm-targets-col--designation { width: 16%; }
 
 /* Type pill: "open cluster" is the longest label at ~10ch; header is "Type". */
-.alm-targets-col--type { width: 6%; }
+.alm-targets-col--type { width: 11.5%; }
 
 /* Max alt: "Max alt" header + "90°" value — short numeric. */
-.alm-targets-col--maxalt { width: 4%; }
+.alm-targets-col--maxalt { width: 7%; }
 
 /* Sparkline: fixed narrow column (SVG is 64px wide, cell adds padding). */
-.alm-targets-col--spark { width: 5%; }
+.alm-targets-col--spark { width: 7%; }
 
 /* Visible: "●tonight" / "○low" indicator. */
-.alm-targets-col--visible { width: 4.5%; }
+.alm-targets-col--visible { width: 8.5%; }
 
 /* Opposition: date stub "—" for now; leave room for "Jan 2026" once live. */
-.alm-targets-col--opposition { width: 5.5%; }
+.alm-targets-col--opposition { width: 9%; }
 
 /* Sessions: numeric stub "—". */
-.alm-targets-col--sessions { width: 4.5%; }
+.alm-targets-col--sessions { width: 8%; }
 
 /* Opposition cell: right-aligned tabular numeric (mirrors max-alt style). */
 .alm-targets-cell--opposition {
@@ -343,9 +350,9 @@
 /* === spec 044: Lunar dist, Filters, Imaging time columns + filter badges === */
 
 /* Column widths (task 044) — fixed layout prevents per-page shift. */
-.alm-targets-col--lunardist { width: 5%; }
-.alm-targets-col--filters   { width: 7.5%; }
-.alm-targets-col--imagingtime { width: 6%; }
+.alm-targets-col--lunardist { width: 6%; }
+.alm-targets-col--filters   { width: 15%; }
+.alm-targets-col--imagingtime { width: 7.5%; }
 
 /* Lunar dist cell: tabular numeric, muted (mock value). */
 .alm-targets-cell--lunardist {
@@ -560,8 +567,7 @@
  * Filter badges run together — increase gap from sp-1 to sp-2.
  * These override the values set in the spec 044 block in components.css. */
 
-.alm-targets-col--lunardist  { width: 5%; }
-/* imagingtime stays at its spec-044 width (6%); the override here was a no-op. */
+.alm-targets-col--lunardist  { width: 6.5%; }
 
 /* task 5: add readable spacing between filter badges (was alm-sp-1 = 4px). */
 .alm-filter-badges { gap: var(--alm-sp-2); }
@@ -606,7 +612,7 @@
  * client-side in localStorage only. See useFavourites.ts. */
 
 /* Extra column for the star (sits leftmost, before Designation). */
-.alm-targets-col--star { width: 2%; }
+.alm-targets-col--star { width: 4.5%; }
 
 /* Star toggle button: tiny, borderless, centred in its cell. */
 .alm-targets-star {

--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -164,12 +164,24 @@
   border-bottom: 1px solid var(--alm-border);
   background: var(--alm-surface);
   white-space: nowrap;
+  /* Fixed-layout columns: truncate the header instead of clipping it mid-glyph
+     or letting it spill. Columns carry a title= tooltip with the full label. */
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .alm-table td {
   padding: var(--alm-sp-2) var(--alm-sp-3);
   border-bottom: 1px solid var(--alm-border-subtle);
   font-size: var(--alm-text-sm);
   vertical-align: middle;
+  /* Keep cell content within its column box: with table-layout:fixed an
+     un-clipped cell (e.g. a Type pill) visually overflows into the next column
+     and wide content can push the last column off-screen. Clip + ellipsis.
+     Cells that must wrap (e.g. the Targets filter-badge strip) opt back in via
+     `white-space: normal` on their own class. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .alm-table td.mono { font-family: var(--alm-font-mono); font-size: var(--alm-text-xs); }
 .alm-table td.num { font-variant-numeric: tabular-nums; text-align: right; }

--- a/apps/desktop/src/styles/reset.css
+++ b/apps/desktop/src/styles/reset.css
@@ -16,6 +16,17 @@ body {
   font-feature-settings: 'tnum' 1;
 }
 
+/* Global font enforcement (product decision): the UI font family is defined
+   ONCE here and may NOT be overridden by any page, component, utility class, or
+   inline object. This neutralizes ad-hoc `font-family` overrides (e.g. monospace
+   on date/timestamp cells) that rendered inconsistently. Digit alignment is
+   preserved via the inherited `tnum` feature above — use `font-variant-numeric:
+   tabular-nums` where needed, NOT a different font family. Only weight/size/
+   variant may vary per element. */
+*, *::before, *::after {
+  font-family: var(--alm-font-sans) !important;
+}
+
 img, picture, video, canvas, svg { display: block; max-width: 100%; }
 input, button, textarea, select { font: inherit; }
 button { cursor: pointer; }

--- a/scripts/win-native-dev.ps1
+++ b/scripts/win-native-dev.ps1
@@ -55,4 +55,8 @@ Write-Host "Watch:       $(if ($NoPolling) { 'native notifications' } else { 'po
 Write-Host "Starting tauri dev... (first build compiles the Rust workspace; later builds are incremental)"
 
 Set-Location $desktop
-pnpm tauri dev
+# Merge the dev-only overlay (src-tauri/tauri.dev.conf.json) which enables
+# withGlobalTauri for the MCP Bridge plugin's webview channel. withGlobalTauri
+# MUST stay out of the base tauri.conf.json (production security surface); it is
+# applied here in dev only — mirrors the `just dev` invocation.
+pnpm tauri dev --config src-tauri/tauri.dev.conf.json


### PR DESCRIPTION
Redesign-UI fixes, layered on `redesign-ui-platevault`. Verified live via the Tauri MCP at the 1100px min window (every check below is from the running app).

## Changes
1. **Global table cell-clip** (`primitives.css`) — `.alm-table` cells get `white-space: nowrap; overflow: hidden; text-overflow: ellipsis`. Fixes Type pills overlapping Max-alt and wide content pushing the last column off-screen; headers ellipsize instead of hard-clipping.
2. **Targets table fits-content** (`merges-2/3.css`) — scroll container `overflow-x: hidden → auto`, table `min-width: 1180px` floor, and per-column widths tuned to **measured** content so each column is ≥ its content. Below the floor the table scrolls horizontally instead of cutting off Sessions. Removed a stale duplicate `--lunardist` override. Verified `clippedCount: 0` on Targets and on Sessions/Projects/Calibration/Inbox.
3. **Global font lock** (`reset.css`) — `*, *::before, *::after { font-family: var(--alm-font-sans) !important }` so no page/class/object can override the UI font (date/timestamp cells were rendering in monospace and looked inconsistent). Digit alignment preserved via the inherited `tnum` feature. Verified 0 elements render in monospace afterward.
4. **Dev launch fix** (`win-native-dev.ps1`) — pass `--config src-tauri/tauri.dev.conf.json` so the dev-only `withGlobalTauri` overlay applies (required by the MCP Bridge webview channel); mirrors `just dev`. `withGlobalTauri` stays out of the base `tauri.conf.json`.

## Notes
- Base is `redesign-ui-platevault` (these touch redesign-only CSS).
- The ~40 now-inert `var(--alm-font-mono)` declarations are neutralized by the global lock (harmless dead CSS; can be swept separately).