### PR TITLE
feat(spec 023): close out — enforce 16 KB note cap + FR-006 reconcile + mark Closed

### DIFF
--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -110,6 +110,8 @@ function errorMessage(err: TargetOpError, fallback: string): string {
       return 'Target not found.';
     case 'target.invalid_id':
       return 'Invalid target ID.';
+    case 'note.content_too_large':
+      return m.err_note_content_too_large();
     default:
       return fallback;
   }
@@ -870,6 +872,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
               placeholder={m.targets_detail_notes_placeholder()}
               value={notesDraft}
               rows={5}
+              maxLength={16384}
               disabled={notesSaving}
               onChange={(e) => {
                 setNotesDraft(e.target.value);

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -28,6 +28,11 @@ use domain_core::ids::Timestamp;
 use targeting_resolver::cache::{self, CachedTarget, TargetListRow};
 use targeting_resolver::AliasKind;
 
+// ── Constants ─────────────────────────────────────────────────────────────────
+
+/// Maximum UTF-8 byte length for a target observing note (FR-004 / spec 023).
+const MAX_NOTE_BYTES: usize = 16_384;
+
 // ── Error helpers ────────────────────────────────────────────────────────────
 
 fn not_found(id: &str) -> TargetOpError {
@@ -435,6 +440,8 @@ pub async fn note_get(
 ///
 /// Empty or whitespace-only `notes` clears the field (stores NULL).
 /// Returns the stored value after the update.
+/// Notes exceeding 16 384 UTF-8 bytes (after trimming) are rejected with
+/// `note.content_too_large` (FR-004).
 ///
 /// Emits a `target.note.updated` audit event after a successful DB write.
 /// Bus publish failures are logged at `warn` but do NOT fail the operation.
@@ -442,7 +449,7 @@ pub async fn note_get(
 /// # Errors
 ///
 /// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
-/// or `internal.database`.
+/// `note.content_too_large`, or `internal.database`.
 pub async fn note_update(
     pool: &SqlitePool,
     bus: &EventBus,
@@ -463,6 +470,17 @@ pub async fn note_update(
     }
     // Blank/whitespace → store NULL (clear).
     let trimmed = req.notes.trim();
+    // FR-004: reject notes exceeding 16 KB UTF-8.
+    if trimmed.len() > MAX_NOTE_BYTES {
+        return Err(TargetOpError {
+            code: "note.content_too_large".to_owned(),
+            message: format!(
+                "Note body exceeds the 16 384-byte limit ({} bytes supplied).",
+                trimmed.len()
+            ),
+            details: None,
+        });
+    }
     let stored: Option<&str> = if trimmed.is_empty() { None } else { Some(trimmed) };
     let updated =
         persistence_db::repositories::targets::set_target_notes(pool, &req.target_id, stored)
@@ -1046,5 +1064,72 @@ mod tests {
         };
         let err = note_update(db.pool(), &bus, &req).await.unwrap_err();
         assert_eq!(err.code, "target.not_found");
+    }
+
+    // ── SC-003 / US4-AS3: note survives alias mutations ───────────────────────
+
+    /// A stored note must be unchanged after a user alias is added and then
+    /// removed on the same target (SC-003 / US4-AS3).
+    #[tokio::test]
+    async fn note_survives_alias_add_and_remove() {
+        let db = setup().await;
+        let id = seed_m31(&db).await;
+        let bus = make_bus(&db);
+
+        // Step 1: store a note.
+        let upd = TargetNoteUpdateRequest {
+            target_id: id.to_string(),
+            notes: "Best viewed in autumn.".to_owned(),
+        };
+        note_update(db.pool(), &bus, &upd).await.unwrap();
+
+        // Step 2: add a user alias.
+        let add_req =
+            TargetAliasAddRequest { target_id: id.to_string(), alias: "Andromeda".to_owned() };
+        let added = alias_add(db.pool(), &add_req).await.unwrap();
+
+        // Step 3: remove that alias.
+        let rem_req =
+            TargetAliasRemoveRequest { target_id: id.to_string(), alias_id: added.alias.id };
+        alias_remove(db.pool(), &rem_req).await.unwrap();
+
+        // Step 4: note must still be intact.
+        let get_req = TargetNoteGetRequest { target_id: id.to_string() };
+        let result = note_get(db.pool(), &get_req).await.unwrap();
+        assert_eq!(
+            result.notes.as_deref(),
+            Some("Best viewed in autumn."),
+            "SC-003: note must survive alias add + remove"
+        );
+    }
+
+    // ── FR-004: 16 KB note size cap ───────────────────────────────────────────
+
+    /// A note exceeding 16 384 UTF-8 bytes (after trimming) must be rejected
+    /// with error code `note.content_too_large` (FR-004).
+    #[tokio::test]
+    async fn note_update_over_16kb_rejected() {
+        let db = setup().await;
+        let id = seed_m31(&db).await;
+        let bus = make_bus(&db);
+
+        // 16 385 ASCII bytes (one byte over the 16 384-byte cap).
+        let oversized = "x".repeat(MAX_NOTE_BYTES + 1);
+        let req = TargetNoteUpdateRequest { target_id: id.to_string(), notes: oversized };
+        let err = note_update(db.pool(), &bus, &req).await.unwrap_err();
+        assert_eq!(err.code, "note.content_too_large", "FR-004: notes >16 KB must be rejected");
+    }
+
+    /// A note exactly at the 16 384-byte limit must be accepted.
+    #[tokio::test]
+    async fn note_update_exactly_16kb_accepted() {
+        let db = setup().await;
+        let id = seed_m31(&db).await;
+        let bus = make_bus(&db);
+
+        let at_limit = "x".repeat(MAX_NOTE_BYTES);
+        let req = TargetNoteUpdateRequest { target_id: id.to_string(), notes: at_limit.clone() };
+        let result = note_update(db.pool(), &bus, &req).await.unwrap();
+        assert_eq!(result.notes.as_deref(), Some(at_limit.as_str()));
     }
 }

--- a/specs/023-target-identity-history-notes/spec.md
+++ b/specs/023-target-identity-history-notes/spec.md
@@ -11,9 +11,13 @@
 > - **`target.primary.rename` is DROPPED** (out of scope; the contract is orphaned).
 >
 > The Foundations tasks below (new `target_alias` table, `target_id` FKs, `primary_designation` column) are
-> **obsolete** — superseded by the 035/036 gen-3 model. Known gap: linked-project rows deep-link to
-> `/projects` without selecting a specific project (the projects route keys `selected` on a numeric index,
-> not the canonical_target UUID) — follow-up.
+> **obsolete** — superseded by the 035/036 gen-3 model.
+>
+> **Closed out 2026-06-23.** Caveats resolved: note edits now emit a `target.note.updated` audit event;
+> the projects route was migrated to UUID-keyed `selected` (parseString), so linked-project rows now open
+> the right project. FR-004's 16 KB note cap is enforced (`note.content_too_large`). `speckit-verify` passed
+> (FR-009 dropped + SC-002 nav reversal are sanctioned scope changes; FR-005/FR-007 observing-plan refs
+> remain deferred / out of scope).
 
 > **See Spec 030**: UI implementation of this feature must follow
 > [Spec 030 — UI Audit & Revision](../030-ui-audit-revision/spec.md)
@@ -22,7 +26,7 @@
 **Feature Branch**: `023-target-identity-history-notes`  
 **Created**: 2026-05-09  
 **Updated**: 2026-06-23  
-**Status**: Implemented on gen-3 — US1–US4 shipped (identity/aliases + linked sessions/projects + observing notes); `target.primary.rename` dropped. See banner.  
+**Status**: **Closed (2026-06-23)** — US1–US4 shipped on gen-3 + caveats resolved + `speckit-verify` passed. `target.primary.rename` dropped; FR-005/FR-007 observing-plan refs deferred. See banner.  
 **Input**: User description: "Specify target identity, aliases, target history, observing-plan references, and notes as bounded follow-on features beyond FITS OBJECT lookup."
 
 ## Implementation Status: NOT IMPLEMENTED
@@ -194,9 +198,16 @@ alias. Then remove alias `NGC 224` (success).
 - **FR-001**: Target identity MUST be a durable record separate from raw FITS `OBJECT` hints.
 - **FR-002**: Target aliases and catalog identifiers MUST be stored as structured references.
 - **FR-003**: Target detail MUST show linked sessions and projects contextually.
-- **FR-004**: Target notes MUST be editable (max 16 KB UTF-8; A6) and auditable.
-- **FR-005**: Observing-plan references MUST be contextual links, not primary navigation.
-- **FR-006**: Manual target corrections MUST preserve the original hint and provenance.
+- **FR-004**: Target notes MUST be editable (max 16 KB UTF-8; A6) and auditable. *(gen-3: enforced — the
+  16 KB cap returns `note.content_too_large`; edits emit the `target.note.updated` audit event.)*
+- **FR-005**: Observing-plan references MUST be contextual links, not primary navigation. *(deferred — no
+  observing-plan surface exists yet; R5 out of scope.)*
+- **FR-006**: Manual target corrections MUST preserve the original hint and provenance. *(gen-3: satisfied
+  structurally — the original SIMBAD `primary_designation` is immutable and always visible (it is the
+  `effectiveLabel` fallback), resolution provenance is carried by `canonical_target.source`
+  (`seed`/`resolved`/`user-override`, spec 035), and user aliases are purely **additive** — adding or
+  removing a `kind='user'` alias cannot destroy or overwrite the original designation. There is no
+  destructive "rename" path: `target.primary.rename` was dropped in favour of an additive `display_alias`.)*
 - **FR-007**: Missing observing-plan references MUST warn without deleting historical records.
 - **FR-008**: Users MUST be able to remove an alias from a target (`target.alias.remove`), with `alias.is_primary` error when the alias is also the primary designation.
 - **FR-009**: Users MUST be able to rename the primary designation by promoting an existing alias (`target.primary.rename`), which demotes the prior primary to alias status.

--- a/specs/023-target-identity-history-notes/tasks.md
+++ b/specs/023-target-identity-history-notes/tasks.md
@@ -5,7 +5,10 @@
 Tasks are grouped by user story so each story can be developed and tested
 independently.
 
-> **Implementation status (2026-06-23): IMPLEMENTED on gen-3.** The task list below was authored against
+> **Status (2026-06-23): CLOSED.** US1–US4 shipped on gen-3, caveats resolved (note-edit audit event,
+> UUID project deep-link, 16 KB note cap enforced via `note.content_too_large`, SC-003 test added), and
+> `speckit-verify` passed (FR-009 dropped + SC-002 nav reversal sanctioned; FR-005/FR-007 deferred).
+> The task list below was authored against
 > the retired gen-2 model; it has been delivered on the spec-035/036 gen-3 `canonical_target` model instead:
 > - **US1 (identity + aliases)** — `target.get`, `target.alias.add/remove` shipped on gen-3.
 > - **US2 (linked sessions)** — `target.sessions.list` (filters `acquisition_session.canonical_target_id`)

--- a/specs/SPEC_STATUS.md
+++ b/specs/SPEC_STATUS.md
@@ -47,7 +47,7 @@ Last reconciled: **2026-06-23** (after the 035 / 040 / 041 / 046 iteration waves
 | 020 router-url-state | ✅ Implemented | 22/23 |
 | 021 developer-contract-diagnostics | 🟡 Partial | 32/37 (behind `dev-tools` feature) |
 | 022 mantine-prototype-design-system | 🔴 Superseded by 027 | |
-| 023 target-identity-history-notes | ✅ Implemented on gen-3 | US1 identity/aliases + US2 linked sessions + US3 linked projects + US4 observing notes shipped (migration 0048 + `target.sessions.list`/`target.projects.list`/`target.note.*`). `target.primary.rename` dropped; gen-2 Foundations obsolete |
+| 023 target-identity-history-notes | ✅ **Closed** | US1–US4 shipped on gen-3 (migration 0048 + `target.sessions.list`/`target.projects.list`/`target.note.*`) + caveats (note-edit audit event, UUID project deep-link, 16 KB note cap) + `speckit-verify` passed. `target.primary.rename` dropped; FR-005/FR-007 deferred |
 | 024 project-manifests-and-notes | 🟡 Closeout-ready | 32/37; all 5 open tasks DEFERRED |
 | 025 filesystem-plan-application | 🟡 Partial (out-of-spec) | Real apply shipped via 041; rollback + progress UI open |
 | 026 generated-source-view-removal | 🟡 Likely obsolete | 12/23; removal happened |


### PR DESCRIPTION
Formal closeout of spec 023 after `speckit-verify` (verdict: ready to close, no hard blockers; 2 small deltas reconciled here).

## Code
- **FR-004 16 KB note cap enforced** — `note_update` rejects >16 KB with `note.content_too_large` (error code + i18n key already existed, matching the projects note path); textarea `maxLength` added.
- **SC-003 test** — asserts a stored note survives an alias add + remove; plus 16 KB boundary tests (16384 accepted, 16385 rejected).
- Anti-nav regression tests (T007/X-3) confirmed already correct (they expect Targets IS primary nav).

## Spec
- **FR-006 reconciled** to the gen-3 provenance model: the original SIMBAD `primary_designation` is immutable + always visible (`effectiveLabel` fallback), provenance is carried by `canonical_target.source` (035), and user aliases are additive — there's no destructive rename, so the original hint can't be lost.
- Stale US3 deep-link banner updated (fixed in #351 — UUID-keyed `selected`).
- **Status → Closed**; `tasks.md` + `SPEC_STATUS.md` updated.

## Gates (scoped — workspace `just test` is red on `main` for pre-existing `desktop_shell` stubs)
`app_core_targets` 82 · `persistence_db` 155 · clippy/fmt clean · tsc clean · vitest 362 (targets + projects).

🤖 Generated with [Claude Code](https://claude.com/claude-code)