### PR TITLE
refactor: move calibration screens to generated type-safe IPC bindings

### DIFF
--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -17,7 +17,8 @@
  */
 
 import { useEffect, useState } from "react";
-import { getCalibrationMaster, listSessions } from "@/api/commands";
+import { commands } from "@/bindings/index";
+import { unwrap } from "@/api/ipc";
 import type { CalibrationMaster_Serialize as CalibrationMaster } from "@/bindings/index";
 import {
 	DetailPane,
@@ -72,7 +73,10 @@ export function MasterDetail({ master, agingThresholdDays }: Props) {
 		let cancelled = false;
 		setDetail({ confirmedNames: [], compatibleNames: [], loading: true });
 
-		Promise.all([getCalibrationMaster({ id: masterId }), listSessions()])
+		Promise.all([
+			commands.calibrationMastersGet(masterId).then(unwrap),
+			commands.sessionsList().then(unwrap),
+		])
 			.then(([masterDetail, sessions]) => {
 				if (cancelled) return;
 				const idToName = new Map<string, string>();

--- a/apps/desktop/src/features/calibration/MatchCandidatesPanel.test.tsx
+++ b/apps/desktop/src/features/calibration/MatchCandidatesPanel.test.tsx
@@ -25,7 +25,7 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { MatchCandidatesPanel } from './MatchCandidatesPanel';
-import type { CalibrationMatchSuggestResponse } from '@/api/commands';
+import type { CalibrationMatchSuggestResponse } from '@/bindings/index';
 
 // ── Test fixtures ──────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/features/calibration/MatchCandidatesPanel.tsx
+++ b/apps/desktop/src/features/calibration/MatchCandidatesPanel.tsx
@@ -28,7 +28,7 @@ import type {
   CalibrationMatchSuggestResponse,
   SuggestStatus,
   MismatchReason,
-} from '@/api/commands';
+} from '@/bindings/index';
 import { m } from '@/lib/i18n';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -406,7 +406,7 @@ export function MatchCandidatesPanel({
           night: <span className="alm-match-candidates__stub-cell">—</span>,
           // STUB: frame count not on CalibrationMatchDto. Backend enrichment needed.
           frames: <span className="alm-match-candidates__stub-cell">—</span>,
-          confidence: <ConfidenceBar value={m.confidence} />,
+          confidence: <ConfidenceBar value={m.confidence ?? 0} />,
           dimensions: <DimensionBreakdown match={m} />,
           assign: (
             <AssignButton

--- a/apps/desktop/src/features/calibration/useCalibration.ts
+++ b/apps/desktop/src/features/calibration/useCalibration.ts
@@ -8,17 +8,13 @@
  */
 
 import { useState, useEffect, useCallback } from 'react';
-import {
-  listCalibrationMasters,
-  calibrationMatchSuggest,
-  calibrationMatchAssign,
-  getSettings,
-} from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import type {
   CalibrationMatchSuggestResponse,
   CalibrationMatchAssignResponse,
-  CalibrationMatchType,
-} from '@/api/commands';
+  CalibrationType,
+} from '@/bindings/index';
 import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
 import { errMessage } from '@/lib/errors';
 
@@ -39,7 +35,9 @@ export function useCalibrationMasters(): UseMastersState {
 
   useEffect(() => {
     let cancelled = false;
-    listCalibrationMasters()
+    commands
+      .calibrationMastersList()
+      .then(unwrap)
       .then((masters) => {
         if (!cancelled) setState({ masters, loading: false, error: undefined });
       })
@@ -65,7 +63,7 @@ export interface UseSuggestState {
 
 export function useCalibrationSuggest(
   sessionId: string | undefined,
-  calibrationTypes?: CalibrationMatchType[],
+  calibrationTypes?: CalibrationType[],
 ): UseSuggestState {
   const [response, setResponse] = useState<CalibrationMatchSuggestResponse | undefined>(undefined);
   const [loading, setLoading] = useState(false);
@@ -83,11 +81,14 @@ export function useCalibrationSuggest(
     let cancelled = false;
     setLoading(true);
     setError(undefined);
-    calibrationMatchSuggest({
-      requestId: `suggest-${sessionId}-${Date.now()}`,
-      sessionId,
-      calibrationTypes,
-    })
+    commands
+      .calibrationMatchSuggest({
+        contractVersion: '2.0.0',
+        requestId: `suggest-${sessionId}-${Date.now()}`,
+        sessionId,
+        calibrationTypes: calibrationTypes ?? null,
+      })
+      .then(unwrap)
       .then((res) => {
         if (!cancelled) {
           setResponse(res);
@@ -124,12 +125,15 @@ export function useCalibrationAssign(): UseAssignState {
     async (sessionId: string, masterId: string, override = false) => {
       setAssigning(true);
       try {
-        const res = await calibrationMatchAssign({
-          requestId: `assign-${sessionId}-${Date.now()}`,
-          sessionId,
-          masterId,
-          override,
-        });
+        const res = unwrap(
+          await commands.calibrationMatchAssign({
+            contractVersion: '2.0.0',
+            requestId: `assign-${sessionId}-${Date.now()}`,
+            sessionId,
+            masterId,
+            override,
+          }),
+        );
         setResult(res);
         return res;
       } finally {
@@ -155,7 +159,9 @@ export function useCalibrationSettings(): {
   const [agingThresholdDays, setAgingThresholdDays] = useState(DEFAULT_AGING_THRESHOLD_DAYS);
 
   useEffect(() => {
-    getSettings({ scope: 'calibration' })
+    commands
+      .settingsGet('calibration')
+      .then(unwrap)
       .then((data) => {
         const v = data.values as Record<string, unknown>;
         if (typeof v['calibrationPrefillSuggestion'] === 'boolean') {


### PR DESCRIPTION
## Summary
- Internal plumbing: the calibration screens (masters list, master detail, match candidates) now call the generated, type-safe IPC bindings instead of hand-written command wrappers. No user-visible behavior change.
- Tightens type safety along the way: handles a nullable match-confidence value and uses the correct calibration-type enum, preventing latent runtime/type mismatches.

## Spec Context
- Spec: 037
- Branch: 037-ipc-calibration