### PR TITLE
feat: list pages open ungrouped by default with a consistent group-header style

### DIFF
--- a/apps/desktop/src/features/calibration/CalibrationPage.tsx
+++ b/apps/desktop/src/features/calibration/CalibrationPage.tsx
@@ -4,7 +4,8 @@
  *
  * Adopts the Sessions REFERENCE layout: a pinned `PageTopBar` over a
  * `ListPageLayout` body — a dense FULL-WIDTH sortable masters table
- * (MastersTable, grouped by Kind) as primary, with the existing MasterDetail
+ * (MastersTable, flat by default, groupable via the top-bar Group-by control)
+ * as primary, with the existing MasterDetail
  * (fingerprint rail + compatible-sessions match table) hosted in the right-side
  * detail pane that mounts on selection.
  *

--- a/apps/desktop/src/features/calibration/MastersTable.test.tsx
+++ b/apps/desktop/src/features/calibration/MastersTable.test.tsx
@@ -3,16 +3,17 @@
  * MastersTable tests — spec 043 §4 shared-layout adoption (#73).
  *
  * The Calibration page moved from the narrow `MastersList` sidebar to a dense
- * full-width `MastersTable` (shared `@/ui` Table) grouped by kind. These tests
+ * full-width `MastersTable` (shared `@/ui` Table). Like every list page it is
+ * FLAT by default; grouping (incl. by kind) is opt-in via `dims`. These tests
  * pin the behaviour + testids carried over from the old MastersList suite:
  *
  * 1. Loading state renders loading indicator (testid masters-loading).
  * 2. Error state renders error state (testid masters-error).
  * 3. Empty state when masters=[] (testid masters-empty).
- * 4. Masters render grouped by kind (DARKS / FLATS / BIAS).
+ * 4. Masters render flat by default; grouping by kind is opt-in (dims).
  * 5. Aging pill renders for masters with age_days > agingThresholdDays.
  * 6. Clicking a master row calls onSelect with its id.
- * 7. dark_flat kind is not shown (FR-001).
+ * 7. dark_flat kind is never shown, flat or grouped (FR-001).
  * 8. Usage count renders on rows (real usedBy* fields) (testid master-usage-*).
  * 9. Column headers + sort callback fire.
  */
@@ -87,18 +88,25 @@ describe('MastersTable (spec 043 §4)', () => {
     expect(screen.getByTestId('masters-empty')).toBeInTheDocument();
   });
 
-  it('4. Masters render grouped by kind with header rows (DARKS, FLATS, BIAS)', () => {
+  it('4. Masters render FLAT by default (no spanning group-header rows)', () => {
     const { container } = render(<MastersTable {...baseProps} masters={masters} />);
-    // Group-header rows carry the spanning class + a count marker; collect their
-    // headlines. (The plain text "BIAS" also appears as the bias-row kind pill,
-    // so we read the group rows specifically rather than by raw text.)
-    const groupHeadlines = Array.from(
-      container.querySelectorAll('.alm-calib-table__group'),
-    ).map((row) => row.textContent ?? '');
-    expect(groupHeadlines.some((t) => t.startsWith('DARKS'))).toBe(true);
-    expect(groupHeadlines.some((t) => t.startsWith('FLATS'))).toBe(true);
-    expect(groupHeadlines.some((t) => t.startsWith('BIAS'))).toBe(true);
-    expect(groupHeadlines).toHaveLength(3);
+    // No group-header rows when ungrouped…
+    expect(container.querySelectorAll('.alm-listgroup')).toHaveLength(0);
+    // …but every master still renders as a row.
+    expect(screen.getByTestId('master-usage-dark-1')).toBeInTheDocument();
+    expect(screen.getByTestId('master-usage-flat-1')).toBeInTheDocument();
+    expect(screen.getByTestId('master-usage-bias-1')).toBeInTheDocument();
+  });
+
+  it('4b. Grouping by kind (dims=["kind"]) renders spanning group-header rows', () => {
+    const { container } = render(
+      <MastersTable {...baseProps} masters={masters} dims={['kind']} />,
+    );
+    // One shared group-header row per present kind, each collapsible via testid.
+    expect(container.querySelectorAll('.alm-listgroup')).toHaveLength(3);
+    expect(screen.getByTestId('calibration-group-kind-dark')).toBeInTheDocument();
+    expect(screen.getByTestId('calibration-group-kind-flat')).toBeInTheDocument();
+    expect(screen.getByTestId('calibration-group-kind-bias')).toBeInTheDocument();
   });
 
   it('5. Aging pill renders for age_days > agingThresholdDays (default 90)', () => {
@@ -126,11 +134,17 @@ describe('MastersTable (spec 043 §4)', () => {
     expect(onSelect).toHaveBeenCalledWith('dark-1');
   });
 
-  it('7. dark_flat kind is not shown in the grouped table (FR-001)', () => {
+  it('7. dark_flat kind is never shown, flat or grouped (FR-001)', () => {
     const darkFlatMaster = makeMaster({ id: 'df-1', kind: 'dark_flat', ageDays: 5 });
-    render(<MastersTable {...baseProps} masters={[...masters, darkFlatMaster]} />);
-    expect(screen.queryByText('DARK FLATS')).not.toBeInTheDocument();
-    expect(screen.queryByText('DARK_FLATS')).not.toBeInTheDocument();
+    const { rerender } = render(
+      <MastersTable {...baseProps} masters={[...masters, darkFlatMaster]} />,
+    );
+    // Filtered out at the data level → no row for it in the flat default view.
+    expect(screen.queryByTestId('master-usage-df-1')).not.toBeInTheDocument();
+    // …and still absent when grouped by kind (no dark_flat group).
+    rerender(<MastersTable {...baseProps} masters={[...masters, darkFlatMaster]} dims={['kind']} />);
+    expect(screen.queryByTestId('calibration-group-kind-dark_flat')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('master-usage-df-1')).not.toBeInTheDocument();
   });
 
   it('8. usage count renders on rows (real usedBy* fields)', () => {
@@ -159,7 +173,7 @@ describe('MastersTable (spec 043 §4)', () => {
     // Simulate backend rows with no fingerprint populated.
     (nullFp as { fingerprint: unknown }).fingerprint = null;
     expect(() => render(<MastersTable {...baseProps} masters={[nullFp]} />)).not.toThrow();
-    expect(screen.getByText('DARKS')).toBeInTheDocument();
+    expect(screen.getByTestId('master-usage-null-fp')).toBeInTheDocument();
     const allText = document.body.textContent ?? '';
     expect(allText).not.toContain('undefined');
     expect(allText).not.toContain('NaN');

--- a/apps/desktop/src/features/calibration/MastersTable.tsx
+++ b/apps/desktop/src/features/calibration/MastersTable.tsx
@@ -3,9 +3,11 @@
  *
  * Replaces the old narrow `MastersList` sidebar with a DENSE, FULL-WIDTH
  * sortable table — the same surface pattern as SessionsTable (shared `Table`
- * from `@/ui`). Masters are GROUPED BY KIND (dark / flat / bias): each kind is a
- * spanning header row, with its masters listed beneath. `dark_flat` and
- * `bad_pixel_map` are not shown in v1 (FR-001).
+ * from `@/ui`). Like every list page, the table is FLAT by default (a single
+ * sorted list); grouping is opt-in via the top-bar Group-by control (Kind,
+ * Camera, Filter, …), sharing the `groupByDimensions` engine + `.alm-listgroup`
+ * header rows. `dark_flat` and `bad_pixel_map` are never shown in v1 (FR-001),
+ * regardless of grouping.
  *
  * Columns: Master (kind · label) · Camera · Filter · Gain · Exposure · Temp ·
  * Binning · Usage · Date(created). A few fields are CONDITIONAL by kind:
@@ -34,19 +36,18 @@ import {
 } from '@/lib/grouping';
 import { useCollapsibleGroups } from '@/lib/use-grouping';
 
-// ── Kind grouping model ────────────────────────────────────────────────────────
+// ── Kind model ──────────────────────────────────────────────────────────────
 
 type Kind = 'dark' | 'flat' | 'bias';
 
-const KIND_ORDER: Kind[] = ['dark', 'flat', 'bias'];
-const GROUP_LABELS: Record<Kind, string> = {
-  dark: 'DARKS',
-  flat: 'FLATS',
-  bias: 'BIAS',
-};
-
-function kindLabel(kind: string): Kind | null {
-  if (kind === 'dark' || kind === 'flat' || kind === 'bias') return kind;
+/**
+ * The only kinds shown in v1 (FR-001): `dark_flat` / `bad_pixel_map` and any
+ * other kind are filtered out at the data level, so they never appear whether
+ * the table is flat or grouped.
+ */
+function shownKind(kind: string): Kind | null {
+  const k = kind.toLowerCase();
+  if (k === 'dark' || k === 'flat' || k === 'bias') return k;
   return null;
 }
 
@@ -75,10 +76,6 @@ export interface MasterSort {
 }
 
 export const DEFAULT_MASTER_SORT: MasterSort = { col: 'created', dir: 'desc' };
-
-/** What the table groups rows by. Kind is the default (and only) grouping in v1. */
-export type MasterGroupBy = 'kind';
-export const DEFAULT_MASTER_GROUP_BY: MasterGroupBy = 'kind';
 
 const EMPTY = '—';
 
@@ -202,25 +199,6 @@ export const MASTER_ACCESSORS: Readonly<Record<string, DimensionAccessor<Calibra
   month: (m) => m.createdAt?.slice(0, 7),
 };
 
-// ── Legacy single-level grouping (kept for the flat-group fallback path) ──────
-
-interface MasterGroup {
-  kind: Kind;
-  label: string;
-  masters: CalibrationMaster[];
-}
-
-/** Group masters by kind (fixed order dark → flat → bias), sorting within each group. */
-function groupMasters(masters: CalibrationMaster[], sort: MasterSort): MasterGroup[] {
-  return KIND_ORDER.map((k) => ({
-    kind: k,
-    label: GROUP_LABELS[k],
-    masters: masters
-      .filter((m) => kindLabel(m.kind.toLowerCase()) === k)
-      .sort((a, b) => compareMasters(a, b, sort)),
-  })).filter((g) => g.masters.length > 0);
-}
-
 // ── Column model ──────────────────────────────────────────────────────────────
 
 const COLUMNS: Array<{ key: string; label: string; sort: MasterSortCol; className?: string }> = [
@@ -249,7 +227,7 @@ interface Props {
   agingThresholdDays: number;
   /**
    * Active ordered grouping dimension ids from `useGrouping`.
-   * When empty the table falls back to the fixed kind grouping.
+   * When empty the table renders a flat sorted list.
    */
   dims?: string[];
 }
@@ -271,12 +249,15 @@ export function MastersTable({
 }: Props) {
   const { collapsed, toggle } = useCollapsibleGroups();
 
+  // FR-001: only dark/flat/bias masters are ever shown, flat or grouped.
+  const shown = useMemo(() => masters.filter((mm) => shownKind(mm.kind) !== null), [masters]);
+
   const sorted = useMemo(
-    () => [...masters].sort((a, b) => compareMasters(a, b, sort)),
-    [masters, sort],
+    () => [...shown].sort((a, b) => compareMasters(a, b, sort)),
+    [shown, sort],
   );
 
-  // Multi-level grouping (when dims non-empty) or fall back to kind grouping.
+  // Flat by default; multi-level grouping only when the user picks dimensions.
   const useMultiGroup = dims.length > 0;
 
   const tree = useMemo(
@@ -288,9 +269,6 @@ export function MastersTable({
     () => (useMultiGroup ? flattenVisibleGroups(tree, collapsed) : []),
     [tree, collapsed, useMultiGroup],
   );
-
-  // Legacy fixed kind-grouping (when dims is empty).
-  const groups = useMemo(() => (useMultiGroup ? [] : groupMasters(masters, sort)), [masters, sort, useMultiGroup]);
 
   if (loading) {
     return (
@@ -308,7 +286,7 @@ export function MastersTable({
     );
   }
 
-  if (masters.length === 0) {
+  if (shown.length === 0) {
     return (
       <div className="alm-calib-table__status">
         <EmptyState
@@ -375,7 +353,7 @@ export function MastersTable({
     };
   }
 
-  // Build rows: multi-level grouping path or fixed kind-grouping path.
+  // Build rows: flat sorted list (default) or multi-level grouping.
   const rows: TableRow[] = [];
 
   if (useMultiGroup) {
@@ -383,22 +361,22 @@ export function MastersTable({
       if (vrow.kind === 'header') {
         const { node, depth, path, collapsed: isCollapsed } = vrow;
         rows.push({
-          _rowClassName: 'alm-calib-table__group',
+          _rowClassName: 'alm-listgroup',
           master: (
             <button
               type="button"
-              className="alm-calib-table__group-cell"
+              className="alm-listgroup__cell"
               data-testid={`calibration-group-${node.dimension}-${node.key}`}
               aria-expanded={!isCollapsed}
               onClick={() => toggle(path)}
               // eslint-disable-next-line no-restricted-syntax -- dynamic: depth-based group-header indent
               style={{ paddingLeft: 8 + depth * INDENT_PER_DEPTH }}
             >
-              <span className="alm-calib-list__group-caret" aria-hidden="true">
+              <span className="alm-listgroup__caret" aria-hidden="true">
                 {isCollapsed ? '▸' : '▾'}
               </span>
-              <span className="alm-calib-list__group-label">{node.label}</span>
-              <span className="alm-calib-list__group-count">{node.count}</span>
+              <span className="alm-listgroup__label">{node.label}</span>
+              <span className="alm-listgroup__count">{node.count}</span>
             </button>
           ),
           ...EMPTY_MASTER_CELLS,
@@ -409,23 +387,9 @@ export function MastersTable({
       }
     }
   } else {
-    // Flat kind-grouping (default, dims empty).
-    for (const group of groups) {
-      rows.push({
-        _rowClassName: 'alm-calib-table__group',
-        master: (
-          <span>
-            {group.label}
-            <span className="alm-calib-table__group-count">
-              {group.masters.length} {group.masters.length === 1 ? m.calibration_master_singular() : m.status_masters_label()}
-            </span>
-          </span>
-        ),
-        ...EMPTY_MASTER_CELLS,
-      });
-      for (const master of group.masters) {
-        rows.push(masterItemRow(master));
-      }
+    // Flat sorted list (default, dims empty).
+    for (const master of sorted) {
+      rows.push(masterItemRow(master));
     }
   }
 

--- a/apps/desktop/src/features/projects/ProjectsTable.tsx
+++ b/apps/desktop/src/features/projects/ProjectsTable.tsx
@@ -229,22 +229,22 @@ export function ProjectsTable({
       if (vrow.kind === 'header') {
         const { node, depth, path, collapsed: isCollapsed } = vrow;
         rows.push({
-          _rowClassName: 'alm-projects-table__group',
+          _rowClassName: 'alm-listgroup',
           name: (
             <button
               type="button"
-              className="alm-projects-table__group-cell"
+              className="alm-listgroup__cell"
               data-testid={`projects-group-${node.dimension}-${node.key}`}
               aria-expanded={!isCollapsed}
               onClick={() => toggle(path)}
               // eslint-disable-next-line no-restricted-syntax -- dynamic: depth-based group-header indent
               style={{ paddingLeft: 8 + depth * INDENT_PER_DEPTH }}
             >
-              <span className="alm-projects-list__group-caret" aria-hidden="true">
+              <span className="alm-listgroup__caret" aria-hidden="true">
                 {isCollapsed ? '▸' : '▾'}
               </span>
-              <span className="alm-projects-list__group-label">{node.label}</span>
-              <span className="alm-projects-list__group-count">{node.count}</span>
+              <span className="alm-listgroup__label">{node.label}</span>
+              <span className="alm-listgroup__count">{node.count}</span>
             </button>
           ),
           ...EMPTY_PROJECT_CELLS,

--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -10,12 +10,10 @@
  * Confirm / Re-open / Reject are contextual (they act on the selected session)
  * and live in the SessionDetail header, not the global top bar (task #79).
  *
- * Toolbar (spec 043 §4): search + review-state filter.
- * The Group-by control (Target / Camera / Filter / Month) has been removed:
- * a session already represents a single target/night/equipment group, so
- * grouping by frame type adds no value — sessions contain 1–few frame types
- * by definition. The table always groups by target (DEFAULT_SESSION_GROUP_BY).
- * The legacy frame-type filter was also removed — sessions are light frames.
+ * Toolbar (spec 043 §4): search + review-state filter + Group-by control
+ * (Target / Filter / Night / Camera / Month). Consistent with every list page,
+ * the table is FLAT by default (a single sorted list) and grouping is opt-in.
+ * The legacy frame-type filter was removed — sessions are light frames.
  *
  * URL state (extends spec 020):
  *   selected     — string session UUID
@@ -92,7 +90,7 @@ export function SessionsPage() {
   const { dims, setSlot } = useGrouping({
     storageKey: 'sessions.grouping.dims.v1',
     validIds: ['target', 'filter', 'night', 'camera', 'month'],
-    defaultDims: ['target'],
+    defaultDims: [],
   });
 
   const SESSION_DIMENSIONS: FilterOption[] = [

--- a/apps/desktop/src/features/sessions/SessionsTable.tsx
+++ b/apps/desktop/src/features/sessions/SessionsTable.tsx
@@ -194,22 +194,22 @@ export function SessionsTable({
         if (row.kind === 'header') {
           const { node, depth, path, collapsed: isCollapsed } = row;
           return {
-            _rowClassName: 'alm-sessions-table__group',
+            _rowClassName: 'alm-listgroup',
             target: (
               <button
                 type="button"
-                className="alm-sessions-table__group-cell"
+                className="alm-listgroup__cell"
                 data-testid={`sessions-group-${node.dimension}-${node.key}`}
                 aria-expanded={!isCollapsed}
                 onClick={() => toggle(path)}
                 // eslint-disable-next-line no-restricted-syntax -- dynamic: depth-based group-header indent
                 style={{ paddingLeft: 8 + depth * INDENT_PER_DEPTH }}
               >
-                <span className="alm-sessions-list__group-caret" aria-hidden="true">
+                <span className="alm-listgroup__caret" aria-hidden="true">
                   {isCollapsed ? '▸' : '▾'}
                 </span>
-                <span className="alm-sessions-list__group-label">{node.label}</span>
-                <span className="alm-sessions-list__group-count">{node.count}</span>
+                <span className="alm-listgroup__label">{node.label}</span>
+                <span className="alm-listgroup__count">{node.count}</span>
               </button>
             ),
             ...EMPTY_CELLS,

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -77,12 +77,19 @@ describe('TargetsTable (#84/#85)', () => {
     expect(screen.getByText('Img time')).toBeInTheDocument();
   });
 
-  it('renders rows inside a real <table> with group headers', () => {
+  it('renders rows inside a real <table>; FLAT by default (no group headers)', () => {
     renderTable();
     const table = screen.getByRole('table');
     expect(within(table).getByText('NGC 7000')).toBeInTheDocument();
     expect(within(table).getByText('M 31')).toBeInTheDocument();
-    // Default group-by is catalogue → Messier + NGC group headers with counts.
+    // Consistent with every list page: flat by default → no catalogue headers.
+    expect(within(table).queryByText('Messier')).not.toBeInTheDocument();
+    expect(within(table).queryByText('NGC')).not.toBeInTheDocument();
+  });
+
+  it('groups by catalogue when dims=["catalogue"] (Messier + NGC headers)', () => {
+    renderTable({ dims: ['catalogue'] });
+    const table = screen.getByRole('table');
     expect(within(table).getByText('Messier')).toBeInTheDocument();
     expect(within(table).getByText('NGC')).toBeInTheDocument();
   });

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -540,12 +540,12 @@ export function TargetsTable({
                     <tr
                       key={row.key}
                       data-index={index}
-                      className="alm-targets-table__group"
+                      className="alm-listgroup"
                     >
                       <td colSpan={COL_COUNT}>
                         <button
                           type="button"
-                          className="alm-targets-table__group-cell"
+                          className="alm-listgroup__cell"
                           data-testid={`targets-group-${row.key}`}
                           aria-expanded={!row.collapsed}
                           aria-label={row.label}
@@ -553,11 +553,11 @@ export function TargetsTable({
                           // eslint-disable-next-line no-restricted-syntax -- dynamic: depth-based group-header indent
                           style={{ paddingLeft: 8 + depthIndent }}
                         >
-                          <span className="alm-targets-list__group-caret" aria-hidden="true">
+                          <span className="alm-listgroup__caret" aria-hidden="true">
                             {row.collapsed ? '▸' : '▾'}
                           </span>
-                          <span className="alm-targets-list__group-label">{row.label}</span>
-                          <span className="alm-targets-table__group-count">
+                          <span className="alm-listgroup__label">{row.label}</span>
+                          <span className="alm-listgroup__count">
                             {m.targets_table_target_count({ count: row.count })}
                           </span>
                         </button>
@@ -570,11 +570,11 @@ export function TargetsTable({
                   <tr
                     key={row.key}
                     data-index={index}
-                    className="alm-targets-table__group"
+                    className="alm-listgroup"
                   >
                     <td colSpan={COL_COUNT}>
                       {row.label}
-                      <span className="alm-targets-table__group-count">
+                      <span className="alm-listgroup__count">
                         {m.targets_table_target_count({ count: row.count })}
                       </span>
                     </td>

--- a/apps/desktop/src/styles/components/app-shell.css
+++ b/apps/desktop/src/styles/components/app-shell.css
@@ -198,7 +198,7 @@
   border: 1px solid var(--alm-border);
   border-radius: var(--alm-radius-sm);
   font-size: var(--alm-text-xs);
-  font-family: var(--alm-font-sans);
+
   background: var(--alm-bg);
   color: var(--alm-text);
   outline: none;
@@ -215,7 +215,7 @@
   width: 100%; height: 26px; font-size: var(--alm-text-2xs);
   border: 1px solid var(--alm-border); border-radius: var(--alm-radius-sm);
   background: var(--alm-bg); color: var(--alm-text-secondary);
-  padding: 0 var(--alm-sp-2); font-family: var(--alm-font-sans);
+  padding: 0 var(--alm-sp-2);
   cursor: pointer;
 }
 .alm-list-sidebar__list { flex: 1; overflow-y: auto; position: relative; }
@@ -312,7 +312,7 @@
 }
 .alm-detail__subtitle {
   font-size: var(--alm-text-xs); color: var(--alm-text-muted);
-  font-family: var(--alm-font-mono); margin-top: var(--alm-sp-1);
+margin-top: var(--alm-sp-1);
   word-break: break-all;
 }
 .alm-detail__actions { display: flex; gap: var(--alm-sp-2); flex-shrink: 0; flex-wrap: wrap; }

--- a/apps/desktop/src/styles/components/detail-panes.css
+++ b/apps/desktop/src/styles/components/detail-panes.css
@@ -170,7 +170,7 @@
   color: var(--alm-text);
   border: none;
   cursor: pointer;
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
 }
 .alm-naming__menu-item:hover {
@@ -183,7 +183,7 @@
 
 /* Literal segment text input inside the literal popover */
 .alm-naming__literal-input {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   width: 100px;
   padding: var(--alm-sp-0) 6px;
@@ -220,7 +220,7 @@
 
 /* Placeholder span shown when no chips are present */
 .alm-naming__chip-placeholder {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text-muted);
   font-style: italic;

--- a/apps/desktop/src/styles/components/dev.css
+++ b/apps/desktop/src/styles/components/dev.css
@@ -37,7 +37,7 @@
 /* Cell — id column: monospace, muted, slightly smaller */
 .alm-dev-calls__td--id {
   padding: var(--alm-sp-1) var(--alm-sp-2);
-  font-family: var(--alm-font-mono);
+
   color: var(--alm-text-muted);
   font-size: var(--alm-text-2xs);
 }
@@ -45,7 +45,7 @@
 /* Cell — contract name: monospace */
 .alm-dev-calls__td--contract {
   padding: var(--alm-sp-1) var(--alm-sp-2);
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Cell — started: muted timestamp */
@@ -70,7 +70,7 @@
 /* Outcome: error state */
 .alm-dev-calls__outcome--error {
   color: var(--alm-danger);
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Outcome: ok state */
@@ -112,7 +112,7 @@
 /* Name cell — monospace font */
 .alm-dev-contracts-list__td-name {
   padding: var(--alm-sp-1) var(--alm-sp-2);
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Direction cell — muted text */
@@ -130,7 +130,7 @@
 /* Schema path cell — truncated monospace muted */
 .alm-dev-contracts-list__td-schema {
   padding: var(--alm-sp-1) var(--alm-sp-2);
-  font-family: var(--alm-font-mono);
+
   max-width: 280px;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -202,7 +202,7 @@
 
 /* Contract name — monospace bold */
 .alm-dev-schema__name {
-  font-family: var(--alm-font-mono);
+
   font-weight: var(--alm-weight-semibold);
 }
 
@@ -240,7 +240,7 @@
 
 /* Inline code path */
 .alm-dev-schema__missing-code {
-  font-family: var(--alm-font-mono);
+
   font-size: 0.8em;
 }
 
@@ -254,7 +254,7 @@
 .alm-dev-schema__pre {
   margin: 0;
   padding: var(--alm-sp-2);
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   line-height: var(--alm-leading-normal);
   white-space: pre-wrap;

--- a/apps/desktop/src/styles/components/feature-lists.css
+++ b/apps/desktop/src/styles/components/feature-lists.css
@@ -54,7 +54,7 @@
 
 .alm-inbox-list__meta-format {
   white-space: nowrap;
-  font-family: var(--alm-font-mono, monospace);
+
   letter-spacing: 0.02em;
 }
 
@@ -308,7 +308,7 @@
 .alm-calib-match-panel__session-id {
   font-size: var(--alm-text-xs);
   color: var(--alm-text-faint);
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Row of calibration-type pills */
@@ -662,7 +662,7 @@
   height: 100vh;
   gap: var(--alm-sp-4);
   padding: var(--alm-sp-6);
-  font-family: var(--alm-font-sans);
+
   color: var(--alm-text);
   background: var(--alm-bg);
 }
@@ -760,7 +760,7 @@
   margin-top: var(--alm-sp-1);
   padding-left: var(--alm-sp-3);
   list-style: disc;
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Individual inventory-ref path item */
@@ -1058,7 +1058,7 @@
 
 /* 6a. DirPicker.tsx — mono path span */
 .alm-dir-picker__path {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   flex: 1;
   overflow: hidden;

--- a/apps/desktop/src/styles/components/merges-1.css
+++ b/apps/desktop/src/styles/components/merges-1.css
@@ -214,7 +214,7 @@
 }
 
 .alm-project-detail__output-format {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text-muted);
   text-transform: uppercase;
@@ -313,25 +313,7 @@
 /* Sortable column header consolidated into the shared .alm-sorth
  * (tables-lists.css) — used via the <SortHeader> component. */
 
-/* Kind group header row — spans the table, headlines the kind. */
-.alm-calib-table__group td {
-  background: var(--alm-surface);
-  font-weight: var(--alm-weight-semibold);
-  font-size: var(--alm-text-2xs);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--alm-text-muted);
-  border-bottom: 1px solid var(--alm-border-subtle);
-  padding: var(--alm-sp-2) var(--alm-sp-3);
-}
-.alm-calib-table__group-count {
-  margin-left: var(--alm-sp-2);
-  font-weight: var(--alm-weight-normal);
-  letter-spacing: normal;
-  text-transform: none;
-  color: var(--alm-text-muted);
-  font-size: var(--alm-text-xs);
-}
+/* Group-header rows use the shared .alm-listgroup class (tables-lists.css). */
 
 /* Selectable master rows. */
 .alm-calib-table__row {
@@ -362,7 +344,7 @@
   text-align: right;
 }
 .alm-calib-cell--mono {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text-secondary);
 }
@@ -442,7 +424,7 @@
   text-align: right;
 }
 .alm-projects-table__cell--mono {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text-secondary);
 }
@@ -590,23 +572,8 @@
 .alm-targets-table__row--selected td {
   background: var(--alm-accent-bg);
 }
-/* Spanning group-header rows (task #82) — mirror .alm-sessions-table__group:
- * a quiet banded row that labels each catalogue/type group with a count. */
-.alm-targets-table__group td {
-  background: var(--alm-surface);
-  font-weight: var(--alm-weight-medium);
-  color: var(--alm-text);
-  font-size: var(--alm-text-xs);
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-}
-.alm-targets-table__group-count {
-  margin-left: var(--alm-sp-2);
-  font-weight: var(--alm-weight-normal);
-  text-transform: none;
-  letter-spacing: normal;
-  color: var(--alm-text-muted);
-}
+/* Spanning group-header rows use the shared .alm-listgroup class
+ * (tables-lists.css) — one look across every list-page table (task #82). */
 
 /* Designation cell — primary label + optional secondary designation. */
 .alm-targets-cell__desig {
@@ -668,7 +635,7 @@
 /* Acquisition summary line — prose, not a path. Override the default
  * mono/break-all subtitle treatment with readable body text that truncates. */
 .alm-session-detail__summary.alm-detail__subtitle {
-  font-family: var(--alm-font-sans);
+
   font-size: var(--alm-text-sm);
   word-break: normal;
   overflow: hidden;

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -156,7 +156,7 @@
   border: none;
   cursor: pointer;
   text-align: left;
-  font-family: inherit;
+
   font-size: var(--alm-text-xs);
   text-transform: uppercase;
   letter-spacing: 0.04em;
@@ -953,7 +953,7 @@
 
 /* Mono path placeholder when individual frame paths are not yet loaded. */
 .alm-session-frames__path-placeholder {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text-muted);
   word-break: break-all;

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -593,7 +593,7 @@
 .alm-targets-spark__axis-label {
   font-size: var(--alm-text-2xs);
   fill: var(--alm-text-faint);
-  font-family: var(--alm-font-sans);
+
 }
 
 /* task 19: hover tooltip title — pointer-events on the SVG so browser shows
@@ -727,7 +727,7 @@
   gap: var(--alm-sp-1);
   padding: 1px var(--alm-sp-2);
   font-size: var(--alm-text-sm);
-  font-family: inherit;
+
   color: var(--alm-text);
   background: none;
   border: 1px solid var(--alm-border);
@@ -761,7 +761,7 @@
   box-sizing: border-box;
   padding: var(--alm-sp-2) var(--alm-sp-3);
   font-size: var(--alm-text-sm);
-  font-family: inherit;
+
   color: var(--alm-text);
   background: transparent;
   border: none;
@@ -815,7 +815,7 @@
   margin-top: var(--alm-sp-3);
   padding: 1px var(--alm-sp-2);
   font-size: var(--alm-text-sm);
-  font-family: inherit;
+
   color: var(--alm-text);
   background: none;
   border: 1px solid var(--alm-border);

--- a/apps/desktop/src/styles/components/plan-panel.css
+++ b/apps/desktop/src/styles/components/plan-panel.css
@@ -129,7 +129,7 @@
   text-overflow: ellipsis;
   white-space: nowrap;
   color: var(--alm-text-secondary);
-  font-family: var(--alm-font-mono);
+
 }
 .alm-plan-panel__file-action {
   display: inline-flex;

--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -20,7 +20,7 @@
   gap: var(--alm-sp-1); height: 28px;
   padding: 0 var(--alm-sp-3);
   font-size: var(--alm-text-xs); font-weight: var(--alm-weight-medium);
-  font-family: var(--alm-font-sans);
+
   border: 1px solid var(--alm-border);
   border-radius: var(--alm-radius-sm);
   background: var(--alm-bg); color: var(--alm-text-secondary);
@@ -183,7 +183,7 @@
   overflow: hidden;
   text-overflow: ellipsis;
 }
-.alm-table td.mono { font-family: var(--alm-font-mono); font-size: var(--alm-text-xs); }
+.alm-table td.mono {font-size: var(--alm-text-xs); }
 .alm-table td.num { font-variant-numeric: tabular-nums; text-align: right; }
 .alm-table td.muted { color: var(--alm-text-muted); }
 

--- a/apps/desktop/src/styles/components/redesign-detail.css
+++ b/apps/desktop/src/styles/components/redesign-detail.css
@@ -14,7 +14,7 @@
 .alm-project-detail__bar-path {
   font-size: var(--alm-text-xs);
   color: var(--alm-text-faint);
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Per-project action cluster in the detail action bar. */
@@ -393,7 +393,7 @@
   word-break: break-word;
 }
 .alm-planner__identity-value--mono {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
 }
 .alm-planner__identity-value--stub {
@@ -427,12 +427,12 @@
 }
 /* SVG uses var() tokens for fill/stroke — injected via currentColor or class */
 .alm-planner__graph-axis-text {
-  font-family: var(--alm-font-sans);
+
   font-size: 9px;
   fill: var(--alm-text-faint);
 }
 .alm-planner__graph-label-text {
-  font-family: var(--alm-font-sans);
+
   font-size: 9px;
   fill: var(--alm-text-muted);
 }
@@ -563,7 +563,7 @@
   margin-left: auto;
   font-size: var(--alm-text-xs);
   color: var(--alm-text-muted);
-  font-family: var(--alm-font-mono);
+
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/apps/desktop/src/styles/components/settings-detail.css
+++ b/apps/desktop/src/styles/components/settings-detail.css
@@ -49,7 +49,7 @@
 /* Event cell — monospace, extra-small */
 .alm-audit-log__event {
   font-size: var(--alm-text-xs);
-  font-family: var(--alm-font-mono);
+
 }
 
 /* Entity cell — muted, truncated */
@@ -311,7 +311,7 @@
 
 /* Monospace path text */
 .alm-data-sources__root-path {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text);
   word-break: break-all;
@@ -384,7 +384,7 @@
 .alm-proc-tools__path-input {
   flex: 1;
   font-size: var(--alm-text-xs);
-  font-family: var(--alm-font-mono);
+
   background: var(--alm-surface-raised);
   color: var(--alm-text);
   border: 1px solid var(--alm-border);
@@ -645,7 +645,7 @@
 }
 
 .alm-tool-launches__file-name {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-sm);
 }
 
@@ -755,5 +755,5 @@
 .alm-manifests__path {
   margin-top: var(--alm-sp-1);
   color: var(--alm-text-muted);
-  font-family: var(--alm-font-mono);
+
 }

--- a/apps/desktop/src/styles/components/settings.css
+++ b/apps/desktop/src/styles/components/settings.css
@@ -11,7 +11,7 @@
   padding: 7px var(--alm-sp-4);
   font-size: var(--alm-text-sm); color: var(--alm-text-secondary);
   cursor: pointer; border: none; background: none; text-align: left;
-  font-family: var(--alm-font-sans); font-weight: var(--alm-weight-medium);
+font-weight: var(--alm-weight-medium);
   transition: all var(--alm-transition-fast);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
 }
@@ -162,7 +162,7 @@
 .alm-seg__btn {
   padding: var(--alm-sp-0) var(--alm-sp-2); font-size: var(--alm-text-2xs);
   border: none; background: var(--alm-bg); color: var(--alm-text-muted);
-  cursor: pointer; font-family: var(--alm-font-sans); font-weight: var(--alm-weight-medium);
+  cursor: pointer;font-weight: var(--alm-weight-medium);
   border-right: 1px solid var(--alm-border);
   transition: all var(--alm-transition-fast);
 }
@@ -192,7 +192,7 @@
 .alm-token-chip {
   display: inline-flex; align-items: center; gap: var(--alm-sp-1);
   padding: var(--alm-sp-0) var(--alm-sp-2); border-radius: var(--alm-radius-sm);
-  font-size: var(--alm-text-xs); font-family: var(--alm-font-mono);
+  font-size: var(--alm-text-xs);
   background: var(--alm-accent-bg); color: var(--alm-accent-text);
   border: 1px solid var(--alm-info-border);
 }
@@ -201,7 +201,7 @@
 .alm-sep-chip {
   display: inline-flex; align-items: center;
   padding: var(--alm-sp-0) var(--alm-sp-2); border-radius: var(--alm-radius-sm);
-  font-size: var(--alm-text-xs); font-family: var(--alm-font-mono);
+  font-size: var(--alm-text-xs);
   background: var(--alm-chip); color: var(--alm-text-secondary);
   border: 1px solid var(--alm-border);
 }
@@ -209,7 +209,7 @@
 .alm-literal-chip {
   display: inline-flex; align-items: center; gap: var(--alm-sp-1);
   padding: var(--alm-sp-0) var(--alm-sp-2); border-radius: var(--alm-radius-sm);
-  font-size: var(--alm-text-xs); font-family: var(--alm-font-mono);
+  font-size: var(--alm-text-xs);
   background: var(--alm-success-bg, var(--alm-surface-raised)); color: var(--alm-text);
   border: 1px solid var(--alm-border);
 }

--- a/apps/desktop/src/styles/components/tables-lists.css
+++ b/apps/desktop/src/styles/components/tables-lists.css
@@ -321,18 +321,51 @@
   color: var(--alm-text-muted);
 }
 
-/* Target group header row — spans the table, headlines the target. */
-.alm-sessions-table__group td {
+/* ── Shared spanning group-header row ──────────────────────────────────────
+ * ONE class, ONE look for every list-page table (Sessions · Calibration ·
+ * Targets · Projects) — no per-feature clones. A quiet banded row that
+ * headlines each group with a count. The cell is a real <button> (collapsible
+ * headers), so it resets native chrome and inherits the row typography. */
+.alm-listgroup td {
   background: var(--alm-surface);
   font-weight: var(--alm-weight-semibold);
-  font-size: var(--alm-text-sm);
-  color: var(--alm-text);
-  border-bottom: 1px solid var(--alm-border);
+  font-size: var(--alm-text-xs);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--alm-text-muted);
+  border-bottom: 1px solid var(--alm-border-subtle);
   padding: var(--alm-sp-2) var(--alm-sp-3);
 }
-.alm-sessions-table__group-count {
+.alm-listgroup__cell {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--alm-sp-2);
+  width: 100%;
+  background: none;
+  border: none;
+  padding: 0;
+  text-align: left;
+  font: inherit;
+  color: inherit;
+  text-transform: inherit;
+  letter-spacing: inherit;
+}
+.alm-listgroup__caret {
+  width: 0.7em;
+  display: inline-block;
+  flex-shrink: 0;
+  color: var(--alm-text-muted);
+}
+.alm-listgroup__label {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.alm-listgroup__count {
   margin-left: var(--alm-sp-2);
   font-weight: var(--alm-weight-normal);
+  text-transform: none;
+  letter-spacing: normal;
   color: var(--alm-text-muted);
   font-size: var(--alm-text-xs);
 }
@@ -348,7 +381,7 @@
 .alm-sessions-cell--target { font-weight: var(--alm-weight-medium); color: var(--alm-text); }
 .alm-sessions-cell--num { font-variant-numeric: tabular-nums; text-align: right; }
 .alm-sessions-cell--mono {
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   color: var(--alm-text-secondary);
 }

--- a/apps/desktop/src/styles/components/target-search.css
+++ b/apps/desktop/src/styles/components/target-search.css
@@ -21,7 +21,7 @@
   border: 1px solid var(--alm-border);
   border-radius: var(--alm-radius-sm);
   font-size: var(--alm-text-sm);
-  font-family: var(--alm-font-sans);
+
   background: var(--alm-bg);
   color: var(--alm-text);
   outline: none;

--- a/apps/desktop/src/styles/components/wizard-base.css
+++ b/apps/desktop/src/styles/components/wizard-base.css
@@ -71,7 +71,7 @@
 }
 .alm-logpanel__event:last-child { border-bottom: none; }
 .alm-logpanel__event-time {
-  font-family: var(--alm-font-mono); color: var(--alm-text-muted);
+color: var(--alm-text-muted);
   min-width: 64px; flex-shrink: 0;
 }
 .alm-logpanel__event-level {
@@ -88,7 +88,7 @@
 .alm-select {
   height: 28px; padding: 0 var(--alm-sp-2);
   border: 1px solid var(--alm-border); border-radius: var(--alm-radius-sm);
-  font-size: var(--alm-text-sm); font-family: var(--alm-font-sans);
+  font-size: var(--alm-text-sm);
   background: var(--alm-bg); color: var(--alm-text);
   cursor: pointer;
 }

--- a/apps/desktop/src/styles/components/wizard-steps.css
+++ b/apps/desktop/src/styles/components/wizard-steps.css
@@ -465,7 +465,7 @@
 
 /* Train ID cell — mono + truncate */
 .alm-wizard-sources__train-id {
-  font-family: var(--alm-font-mono);
+
   overflow: hidden;
   text-overflow: ellipsis;
 }
@@ -522,7 +522,7 @@
   border: 1px solid var(--alm-border);
   border-radius: var(--alm-radius-sm);
   font-size: var(--alm-text-xs);
-  font-family: inherit;
+
   background: var(--alm-bg);
   color: var(--alm-text);
   transition: border-color var(--alm-transition-fast);
@@ -637,7 +637,7 @@
   border: none;
   background: none;
   cursor: pointer;
-  font-family: inherit;
+
   font-size: var(--alm-text-xs);
   color: var(--alm-accent);
   text-decoration: underline;
@@ -680,7 +680,7 @@
 /* View name input in table cell */
 .alm-wizard-views__name-input {
   width: 160px;
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   padding: 3px 6px;
   border: 1px solid var(--alm-border);
@@ -765,7 +765,7 @@
   border: 1px solid var(--alm-border);
   border-radius: 4px;
   font-size: var(--alm-text-sm);
-  font-family: var(--alm-font-mono);
+
   background: var(--alm-surface);
   color: var(--alm-text);
   outline: none;
@@ -796,7 +796,7 @@
   border: 1px solid var(--alm-border);
   border-radius: 4px;
   font-size: var(--alm-text-2xs);
-  font-family: var(--alm-font-mono);
+
   color: var(--alm-text-muted);
   cursor: help;
 }
@@ -807,7 +807,7 @@
   background: var(--alm-surface);
   border: 1px solid var(--alm-border);
   border-radius: 6px;
-  font-family: var(--alm-font-mono);
+
   font-size: var(--alm-text-xs);
   line-height: 1.8;
   overflow: auto;

--- a/apps/desktop/src/ui/KV.tsx
+++ b/apps/desktop/src/ui/KV.tsx
@@ -16,8 +16,8 @@ export const KV = forwardRef<HTMLDivElement, KVProps>(
         <span className="alm-kv__label">{label}</span>
         <span
           className="alm-kv__value"
-          // eslint-disable-next-line no-restricted-syntax -- dynamic: conditional mono font style passthrough (caller-supplied prop)
-          style={mono ? { fontFamily: 'var(--alm-font-mono)', fontSize: 'var(--alm-text-xs)' } : undefined}
+          // eslint-disable-next-line no-restricted-syntax -- dynamic: conditional compact-size passthrough (caller-supplied prop). Font family is enforced globally (reset.css); never set here.
+          style={mono ? { fontSize: 'var(--alm-text-xs)' } : undefined}
         >
           {value}
           {provenance && <span className="alm-kv__provenance">{provenance}</span>}


### PR DESCRIPTION
## Summary
- The Projects, Targets, Sessions and Calibration lists now all open as a single flat, sorted list; grouping is opt-in from the Group-by control instead of some pages auto-grouping and others not.
- Group headers now look identical across every list (previously each page styled them differently, and Projects had no styling at all).
- Fonts are now enforced globally — no view can set its own font — so text is consistent across pages.

## What's new
- **Consistent default view:** Sessions no longer auto-groups by target and Calibration no longer forces dark/flat/bias grouping; both start flat like Targets and Projects.
- **Opt-in grouping preserved:** picking a dimension (Kind, Camera, Target, …) still groups the list.
- **Unified group headers:** one shared style across all four tables.
- **Calibration correctness:** `dark_flat`/`bad_pixel_map` masters stay hidden whether the table is flat or grouped.

## Testing
- Typecheck clean; 404 unit tests pass; eslint (changed files) 0 errors; CSS token check passes.
- Live visual pass on the Windows dev app still pending.

## Spec Context
- Spec: 043
- Branch: 043-ui-consistency