### PR TITLE
chore: add a skill to generate Windows real-app validation scenarios

### DIFF
--- a/.claude/skills/verify-on-windows/SKILL.md
+++ b/.claude/skills/verify-on-windows/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: verify-on-windows
+description: >-
+  Generates a self-contained Windows validation scenario for a code change in
+  the astro-plan / PlateVault repo, to hand to Claude computer-use ("cowork")
+  driving the real Tauri desktop app on Windows. Use after implementing a change
+  that needs real-app verification beyond unit/integration tests — new or changed
+  UI behavior, an IPC/backend command, or an interactive flow. The invoking agent
+  describes exactly what changed (spec/feature, files, Tauri commands, UI
+  surfaces, new user-visible behavior); the skill emits a numbered click-by-click
+  test script with preconditions, exact expected results, and explicit failure
+  signals, plus the Windows dev-app launch/reset/recompile mechanics and the
+  Tauri-MCP-bridge details, and guidance on the matching Layer-2 tauri-driver E2E
+  journey + coverage-matrix update so manual and automated verification stay in
+  sync. Triggers include "verify on windows", "validate on the real app",
+  "generate a cowork/computer-use scenario", "test my change on windows".
+---
+
+# verify-on-windows
+
+Turn "I changed X" into a **scenario document a Windows computer-use agent can
+execute with zero access to this repo's context**. The Windows agent (Claude
+cowork) can only see the running app and the scenario — so the scenario must
+carry every fact it needs.
+
+## When to use
+
+After a change whose correctness depends on the **real running app**: a new/changed
+UI affordance, a Tauri command / IPC round-trip, a navigation or routing change, a
+first-run/reset-sensitive flow. Not for pure-logic changes already covered by
+`cargo test` / vitest — say so and skip.
+
+## Procedure
+
+1. **Collect the change facts** — do not guess; read the diff. Fill every field of
+   the *Change Facts* block (see `references/scenario-template.md`). Minimum:
+   spec/feature id, branch, changed files, each new/changed **user-visible
+   behavior**, and any **Tauri command / IPC** involved (snake_case name + args).
+2. **Classify each behavior**: `manual` (needs human-like click/observe — native
+   dialogs, OS file browser, visual state) vs `automatable` (deterministic
+   UI→IPC→backend round-trip a tauri-driver journey could assert). List both.
+3. **Write the scenario file** by filling `references/scenario-template.md`. One
+   numbered, click-by-click **Test** per changed behavior, each with an exact
+   **Expected** and an explicit **FAIL if** line. Embed the Windows mechanics the
+   agent needs *inline* (branch to pull, how to launch/reset/recompile) — pull the
+   canonical steps from `references/windows-mechanics.md`; never assume the Windows
+   agent knows them.
+4. **Emit E2E-sync guidance**: for every `automatable` behavior, state whether a
+   Layer-2 `tauri-driver` journey should be added (`just test-e2e`) and add/append
+   the row to `specs/037-e2e-integration-testing/contracts/coverage-matrix.md`.
+   For `manual` behaviors, note explicitly that automation is not feasible and why.
+5. **Save + report**: write to
+   `docs/development/windows-validation/<branch-or-spec>-<slug>.md` (committable
+   alongside the PR). Tell the user the path and paste the scenario's **Preconditions**
+   + first Test so they can hand it off immediately.
+
+## Hard rules
+
+- The scenario is **self-contained**: no "see the repo", no task IDs without
+  explanation, no assumed context. If the Windows agent needs a value (a path, a
+  command name, a testid), it must be in the scenario.
+- Every Test has an **observable** Expected and a **FAIL if** — never "verify it
+  works". Prefer states a human/vision agent can see (text, enabled/disabled,
+  a window opening) over internal assertions.
+- **Recompile trap**: if the change touches Rust, the scenario MUST instruct the
+  Windows agent to force a rebuild after `git reset --hard` (mtime trap) — see
+  `references/windows-mechanics.md`. A frontend-only change may skip the Rust
+  rebuild (hard refresh suffices).
+- Keep manual (computer-use) and automated (tauri-driver) coverage **in sync**:
+  every scenario ends with the E2E-sync section, even if it just records "manual
+  only, no journey added".
+
+## References
+
+- `references/windows-mechanics.md` — canonical launch / reset / recompile /
+  Tauri-MCP-bridge / Layer-1&2 test mechanics (source: project memory + `docs/development/testing.md`).
+- `references/scenario-template.md` — the fill-in template (Change Facts →
+  Preconditions → Tests → E2E-sync → Report-back).
+- `references/example-scenario.md` — a complete worked scenario (spec-006 Ignore
+  action + Reveal-in-OS) showing the expected output quality.

--- a/.claude/skills/verify-on-windows/references/example-scenario.md
+++ b/.claude/skills/verify-on-windows/references/example-scenario.md
@@ -1,0 +1,129 @@
+# Worked example
+
+Below is a complete scenario generated for a real change (spec-006: the Ignore
+action + Reveal-in-OS on the Sessions page). It shows the expected output
+quality — every fact the Windows agent needs is inline, every Test is observable,
+and the E2E-sync section keeps manual and automated coverage honest.
+
+The invoking agent produced this after reading its own diff. Two artifacts are
+generated: the **scenario file** (handed to Windows cowork) and the **E2E-sync
+notes** (kept for the PR).
+
+---
+
+## Artifact 1 — the scenario file
+
+_Saved to `docs/development/windows-validation/006-ignore-reveal.md`._
+
+```markdown
+# Windows validation — Ignore a session + Reveal its folder in Explorer
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Change facts (context — you do not act on this section)
+- Spec / feature: 006 inventory-library-lifecycle
+- Branch to test: `006-inventory-reconcile`
+- Touches Rust backend? yes (an enum was removed) · Frontend only? no
+- Tauri commands exercised: `inventory_session_review` (Ignore) and
+  `native_reveal` (Reveal in OS) — both pre-existing.
+- Changed surfaces: the Sessions page (`/sessions`) and its detail panel.
+- What changed for the user: a session now has an **Ignore** button (distinct
+  from Reject) that hides it from the default list but keeps it recoverable, and
+  a **Reveal in OS** button that opens the session's source folder in Windows
+  Explorer. The old frame-type (light/dark/flat/bias) filter was removed.
+
+## Preconditions
+1. Deploy the branch on `C:\dev\astro-plan`:
+   - `git fetch origin`
+   - `git reset --hard origin/006-inventory-reconcile`   (own command)
+   - Rust changed, so force a rebuild (mtime trap):
+     `Get-ChildItem C:\dev\astro-plan\crates\app\core\src\inventory.rs,C:\dev\astro-plan\crates\contracts\core\src\inventory.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`
+2. Launch:
+   `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`
+   Wait for the window (process `desktop_shell.exe`; Vite on localhost:5173). It
+   recompiles Rust on first launch — allow a few minutes.
+3. Reach some sessions: click **Sessions** in the left nav. If the list is empty,
+   add a library root that contains light-frame FITS files (Settings → Data
+   sources → add a light-frames root) and run a scan, then return to Sessions.
+   You need at least one session whose state shows **"Needs review"**.
+4. Sanity: the Sessions list renders with rows (not a blank window).
+
+## Tests
+
+### Test 1 — Ignore hides a session from the default list
+Steps:
+1. On /sessions, click a row whose state is "Needs review". A detail panel opens
+   at the bottom with action buttons in its header.
+2. Note the session's target/name. Click the **Ignore** button.
+Expected:
+- A toast reads **"Session ignored."**
+- The row disappears from the default list (ignored sessions are excluded by
+  default).
+FAIL if:
+- There is no Ignore button, OR clicking it shows an error toast, OR the row
+  stays in the default list, OR the app crashes / goes blank.
+
+### Test 2 — Ignored session is recoverable via Cmd+K
+Steps:
+1. Press **Ctrl+K** to open the command palette.
+2. Type "ignored", select **"Show ignored items"**.
+3. Confirm the session from Test 1 is now listed. Click it, then click **Re-open review**.
+Expected:
+- The palette navigates to the Sessions page filtered to ignored items, and the
+  Test-1 session appears there.
+- After Re-open, it returns to the "Needs review" family and shows in the default
+  list again.
+FAIL if:
+- "Show ignored items" is absent, OR the filtered view is empty / does not show
+  the session, OR Re-open does not restore it.
+
+### Test 3 — Reveal in OS opens the source folder
+Steps:
+1. Select any session. In the detail header, click **Reveal in OS**.
+Expected:
+- A **Windows Explorer** window opens at (or selecting) the session's source
+  folder on disk.
+FAIL if:
+- No Explorer window opens, OR an error toast ("Could not open the location.")
+  appears, OR it opens the wrong/parent path with nothing highlighted.
+
+### Test 4 — No frame-type filter on Sessions
+Steps:
+1. Look at the Sessions toolbar (top of the list).
+Expected:
+- There is a **Review** filter and a search box, and **no** "Frame type"
+  (light/dark/flat/bias) dropdown.
+FAIL if:
+- A frame-type dropdown is present.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, run `pnpm install` in
+  `C:\dev\astro-plan` with `$env:CI="true"`, relaunch.
+- Ignore/Reveal button missing or behaving like the old build: the binary is
+  stale — confirm you touched the two `.rs` files after reset so cargo rebuilt.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast.
+```
+
+---
+
+## Artifact 2 — E2E-sync notes (kept for the PR, not sent to Windows)
+
+- **Ignore action** — `automatable`. Add a Layer-2 `tauri-driver` journey under
+  `tests/e2e/` (or the repo's E2E dir): open /sessions → Ignore a needs-review
+  session → assert it leaves the default list → open Cmd+K "Show ignored" →
+  assert it appears → Re-open → assert it returns. Add a row to
+  `specs/037-e2e-integration-testing/contracts/coverage-matrix.md` under the
+  Sessions area. (Backend already covered by the `sessions_integration.rs`
+  Layer-1 tests; the store dispatch is unit-covered.)
+- **Cmd+K "Show ignored" route** — `automatable`; same journey as above covers it.
+- **Frame-type filter removed** — `automatable`; a simple UI assertion (absence).
+- **Reveal in OS** — `manual only`. `native_reveal` launches an external Explorer
+  window; `tauri-driver` cannot assert an OS-level window. The command wiring is
+  unit-tested (`revealInventory.test.ts` asserts the invoke + args), but the
+  actual OS reveal must be validated by computer-use. Record it as manual so it is
+  not assumed E2E-covered.

--- a/.claude/skills/verify-on-windows/references/scenario-template.md
+++ b/.claude/skills/verify-on-windows/references/scenario-template.md
@@ -1,0 +1,77 @@
+# Scenario template
+
+Fill EVERY bracketed field from the actual diff. Delete guidance in _italics_.
+The output is one markdown file the Windows computer-use agent executes top to
+bottom. Keep the Windows agent's view in mind: it sees only this file + the app.
+
+---
+
+```markdown
+# Windows validation — [change one-liner]
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Change facts (context — you do not act on this section)
+- Spec / feature: [e.g. 006 inventory-library-lifecycle]
+- Branch to test: `[branch]`
+- Touches Rust backend? [yes/no]  ·  Frontend only? [yes/no]
+- New/changed Tauri command(s): [`snake_command(args)` or "none"]
+- Changed surfaces: [routes / components, e.g. /sessions, SessionDetail]
+- What changed for the user (1–3 sentences): [...]
+
+## Preconditions — get the app to the right state
+_Copy only the steps that apply; pull exact commands from windows-mechanics.md._
+1. Deploy the branch on the Windows checkout `C:\dev\astro-plan`:
+   - `git fetch origin`
+   - `git reset --hard origin/[branch]`   (run as its OWN command)
+   - [IF Rust changed] Force rebuild (mtime trap): touch the changed `.rs`
+     files, e.g. `Get-ChildItem [file].rs | ForEach-Object { $_.LastWriteTime = Get-Date }`
+2. [IF a clean first-run is needed] Reset the DB:
+   `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`
+3. Launch: run `run-dev.bat` via PowerShell `Start-Process` (see below). Wait for
+   the window; app process is `desktop_shell.exe`, Vite on `localhost:5173`.
+   - `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`
+4. [IF backend data needed] Seed/prepare: [exact clicks or steps to reach the
+   screen under test — e.g. add a library root, run a scan, open /sessions].
+5. Sanity: the app renders (not a blank window). If blank → see Troubleshooting.
+
+## Tests
+_One block per changed behavior. Numbered clicks. Observable Expected. Explicit FAIL if._
+
+### Test 1 — [behavior name]
+Steps:
+1. [Navigate / click, exact labels or testids]
+2. [...]
+Expected:
+- [Exactly what appears / changes — text, enabled state, a window opening]
+FAIL if:
+- [The concrete wrong outcome — nothing happens, wrong text, error toast, crash]
+
+### Test 2 — [behavior name]
+...
+
+## Troubleshooting
+- Blank window (empty content): restart the dev server; if still blank, run
+  `pnpm install` in `C:\dev\astro-plan` with `$env:CI="true"`, relaunch.
+- A command "not found" / stale behavior after a Rust change: the binary is
+  stale — confirm you touched the `.rs` files after reset so cargo rebuilt.
+
+## Report back
+For each Test: PASS / FAIL + one line of what you saw. On any FAIL, capture a
+screenshot and the exact on-screen text / any toast.
+```
+
+---
+
+## E2E-sync section (goes in YOUR handoff to the user, not the Windows file)
+
+For each changed behavior, record:
+
+- **[behavior]** — `manual` (why automation isn't feasible, e.g. native OS file
+  browser) OR `automatable` → [Layer-2 `tauri-driver` journey to add: file +
+  what it asserts] and the `coverage-matrix.md` row to add/update
+  (`specs/037-e2e-integration-testing/contracts/coverage-matrix.md`).
+
+State plainly if a behavior is manual-only so nobody assumes it's E2E-covered.

--- a/.claude/skills/verify-on-windows/references/windows-mechanics.md
+++ b/.claude/skills/verify-on-windows/references/windows-mechanics.md
@@ -1,0 +1,108 @@
+# Windows verification mechanics (PlateVault / astro-plan)
+
+Canonical, tested steps for running and driving the real Tauri desktop app on
+Windows. Source: project memory (`windows-dev-loop`, `spec-033-windows-verify-loop`,
+`tauri-mcp-windows-verify-mechanics`, `vite-deps-reoptimize-blank-screen`) and
+`docs/development/testing.md`. When you generate a scenario, copy the *relevant*
+steps into it verbatim — the Windows agent has none of this context.
+
+## Checkouts are separate
+
+- WSL repo: `/home/sjors/dev/astro-plan` (where you edit/commit/push).
+- Windows app checkout: `C:\dev\astro-plan` (= `/mnt/c/dev/astro-plan` from WSL).
+- The app serves **from the Windows checkout**. Changes reach it only after
+  **commit → push → `git reset --hard origin/<branch>` on Windows**. Frontend HMR
+  and Rust both build from `C:\dev\astro-plan`.
+
+## Launch (native Windows, never over /mnt/c)
+
+Launch **detached** with `powershell.exe` (not `cmd /mnt/c` — nested-quote escaping
+and a trailing-space-before-`&&` bug corrupt env vars). A `run-dev.bat` at repo
+root holds, each on its own line (no `&&`):
+
+```
+cd /d C:\dev\astro-plan
+set ALM_DB_URL=sqlite://C:\dev\astro-plan\wizard-test.db?mode=rwc
+cargo tauri dev
+```
+
+Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`
+
+- App process = `desktop_shell.exe`; Vite on `localhost:5173`.
+- `.env` has `VITE_USE_MOCKS=false` (real backend).
+- Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+
+## Reset to a clean first-run
+
+The **DB is the first-run source of truth** (clearing localStorage alone causes a
+`/`↔`/setup` redirect loop / navigation-throttle hang). Reset = fresh DB:
+
+```
+Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force
+```
+
+then relaunch. (`ALM_DB_URL` overrides the default `%APPDATA%\dev.astro-plan.astro-library-manager\alm.db`;
+WSL often can't enumerate Windows AppData — verify with PowerShell `Test-Path`.)
+
+## Deploy a branch + the RECOMPILE TRAP
+
+```
+cd C:\dev\astro-plan
+git fetch origin
+git reset --hard origin/<branch>     # run as its OWN command (a guard rejects it bundled with other git)
+```
+
+- **`git reset --hard` restores file content but leaves an OLD mtime**, so cargo
+  thinks the binary is newer and **skips recompiling** — the app stays stale
+  (symptom: a command that IS in the code returns "not found"). After reset,
+  **touch changed `.rs` files** to force a rebuild:
+  `Get-ChildItem <files>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`,
+  then relaunch (`cargo tauri dev` recompiles). Verify binary mtime > source mtime.
+- **Frontend-only change**: a hard refresh (Ctrl+R) suffices — Vite serves from
+  disk on full reload. Rust changes REQUIRE the cargo-tauri-dev relaunch.
+- `pnpm install` alone does NOT recompile Rust; only `cargo tauri dev` does.
+
+## Blank screen (empty #root) recovery
+
+Two Vite/pnpm causes: (1) a mid-session `pnpm install` re-optimized deps → stale
+import graph → restart the dev server; (2) cold Vite start hits the
+`@rollup/rollup-win32-x64-msvc` optional-native bug → `pnpm install` in the
+Windows checkout with `$env:CI="true"`, then relaunch.
+
+## Driving the app programmatically (Tauri MCP bridge) — optional
+
+For an agent that can reach the bridge (vs. pure screen/vision computer-use):
+
+- Launch with the dev overlay so `withGlobalTauri` + the bridge are on:
+  `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge is
+  `#[cfg(debug_assertions)]`, WS on `0.0.0.0:9223`).
+- Connect over WSL↔Windows NAT: `driver_session host=<gateway> port=9223`, where
+  `gateway = ip route show default | awk '{print $3}'` (e.g. 172.23.112.1).
+  Firewall already allows 9223.
+- **Invoke a command directly** (bridge rejects many via `ipc_execute_command`):
+  `webview_execute_js` → `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+- **Native folder pickers can't be driven**: launch with `VITE_E2E=1` to expose
+  `data-testid="e2e-path-input-<kind>"` / `e2e-add-path-btn-<kind>`
+  (kinds: light_frames, calibration, project, inbox). Set the React-controlled
+  input via the native value setter + dispatch `input`, then click the button in a
+  **separate** call so React state commits.
+- Throwaway DB read-only from WSL: python `sqlite3` `file:...?mode=ro&immutable=1`;
+  base64-encode output (grep/tool output otherwise mangles string literals).
+
+## Automated E2E (Layer 2) — the tool the scenario must stay in sync with
+
+- `just test-e2e` runs the built app through its real UI → real IPC → real backend
+  via `tauri-driver` (smoke journeys; required on Windows + Linux). Layer-1
+  (`just test-integration` = `cargo test --workspace`) is real backend + real
+  SQLite, no UI.
+- New features MUST ship real-stack coverage and update the mapping in
+  `specs/037-e2e-integration-testing/contracts/coverage-matrix.md`.
+- WSL has no webview, so the tauri-driver IPC run is validated on Windows / CI
+  Stage B — not in a WSL headless run. (WSL Playwright under `tests/e2e/` is for
+  mocks-backed render smoke only; the Playwright **MCP** browser can't reach
+  WSL-bound servers.)
+
+## Pushing workflow files
+
+Pushing `.github/workflows/*` over HTTPS fails ("OAuth App without workflow
+scope") — push via SSH (`git push git@github.com:...`).


### PR DESCRIPTION
## Summary
- Adds a project-local Claude skill, **verify-on-windows**, that turns "I changed X" into a self-contained validation scenario for Claude computer-use ("cowork") to run against the real Windows Tauri desktop app.
- The scenario is standalone (numbered click-by-click tests, observable expected/fail criteria, the Windows launch/reset/recompile mechanics) so the Windows agent needs no repo access, and it ends with an E2E-sync section that keeps manual checks aligned with the Layer-2 tauri-driver coverage matrix.
- Locally-authored under `.claude/skills/` (APM preserves it; not APM-managed). Ships a worked example (the spec-006 Ignore + Reveal change).

## Spec Context
- Tooling/agent-skill; not tied to a spec.
- Branch: tooling/verify-on-windows-skill