### PR TITLE
fix: compile translations before running frontend tests in CI

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -7,6 +7,7 @@
     "dev": "vite --host 127.0.0.1",
     "build": "vite build",
     "preview": "vite preview --host 127.0.0.1",
+    "pretest": "pnpm i18n:compile",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:e2e": "playwright test",


### PR DESCRIPTION
## Summary
- CI's frontend unit tests were failing because the Paraglide translation output (`src/paraglide/`, git-ignored and generated) was never built before `vitest` ran, so ~66 test files couldn't resolve `@/paraglide/messages`.
- Adds a `pretest` script that compiles the message catalog first (mirrors the existing `pretypecheck`), so `pnpm test` regenerates translations before running tests.

Verified locally: with `src/paraglide/` deleted (clean-CI state), `pnpm test` regenerates it via the new hook and the suite passes.

## Spec Context
- CI infrastructure fix; not tied to a spec.
- Branch: ci/paraglide-pretest