### PR TITLE
refactor: move plans screens to generated type-safe IPC bindings

### DIFF
--- a/apps/desktop/src/features/plans/PlanProtectionGate.test.tsx
+++ b/apps/desktop/src/features/plans/PlanProtectionGate.test.tsx
@@ -8,37 +8,44 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { PlanProtectionGate } from './PlanProtectionGate';
-import type { PlanProtectionCheckResponse } from '@/api/commands';
+import type { PlanProtectionCheckResponse } from '@/bindings/index';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
+//
+// The component calls the generated bindings (`commands.*`) directly (spec 037),
+// so we mock at the dispatch layer (`@/bindings/index`) and return generated
+// `Result`-shaped values that the real `unwrap` in the component translates.
 
-vi.mock('@/api/commands', () => ({
-  planProtectionCheck: vi.fn(),
-  protectionPlanAcknowledged: vi.fn(),
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    planProtectionCheckCmd: vi.fn(),
+    protectionPlanAcknowledged: vi.fn(),
+  },
 }));
 
-import { planProtectionCheck, protectionPlanAcknowledged } from '@/api/commands';
+import { commands } from '@/bindings/index';
 
-const mockCheck = vi.mocked(planProtectionCheck);
-const mockAck = vi.mocked(protectionPlanAcknowledged);
+const mockCheck = vi.mocked(commands.planProtectionCheckCmd);
+const mockAck = vi.mocked(commands.protectionPlanAcknowledged);
+
+/** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-function makeCheckResponse(
-  overrides: Partial<PlanProtectionCheckResponse> = {},
-): PlanProtectionCheckResponse {
-  return {
+function makeCheckResponse(overrides: Partial<PlanProtectionCheckResponse> = {}) {
+  return ok<PlanProtectionCheckResponse>({
     planId: 'plan-1',
     hasProtectedItems: false,
     protectedItems: [],
     nonBlockingSummary: { normalCount: 0, unprotectedCount: 0 },
     ...overrides,
-  };
+  });
 }
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockAck.mockResolvedValue('audit-id-1');
+  mockAck.mockResolvedValue(ok('audit-id-1'));
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/features/plans/PlanProtectionGate.tsx
+++ b/apps/desktop/src/features/plans/PlanProtectionGate.tsx
@@ -10,8 +10,9 @@
 import { useEffect, useState, useCallback } from 'react';
 import { Pill, Btn } from '@/ui';
 import { m } from '@/lib/i18n';
-import { planProtectionCheck, protectionPlanAcknowledged } from '@/api/commands';
-import type { ProtectedPlanItem, PlanProtectionCheckResponse } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { ProtectedPlanItem, PlanProtectionCheckResponse } from '@/bindings/index';
 
 interface PlanProtectionGateProps {
   planId: string;
@@ -36,7 +37,9 @@ export function PlanProtectionGate({ planId, onAcknowledgedChange }: PlanProtect
 
   const load = useCallback(() => {
     setLoadState('loading');
-    planProtectionCheck(planId)
+    commands
+      .planProtectionCheckCmd(planId)
+      .then(unwrap)
       .then((resp) => {
         setCheckResult(resp);
         setLoadState('ready');
@@ -57,12 +60,14 @@ export function PlanProtectionGate({ planId, onAcknowledgedChange }: PlanProtect
   const handleAcknowledge = useCallback(
     async (item: ProtectedPlanItem) => {
       try {
-        await protectionPlanAcknowledged(
-          planId,
-          item.itemId,
-          item.sourceId ?? null,
-          item.level,
-          item.reason,
+        unwrap(
+          await commands.protectionPlanAcknowledged(
+            planId,
+            item.itemId,
+            item.sourceId ?? null,
+            item.level,
+            item.reason,
+          ),
         );
         setAcknowledged((prev) => {
           const next = new Set(prev);

--- a/apps/desktop/src/features/plans/planApply.ts
+++ b/apps/desktop/src/features/plans/planApply.ts
@@ -1,0 +1,39 @@
+/**
+ * Plan-apply IPC helper (spec 037 caller migration).
+ *
+ * Bridges the optional `onEvent` subscriber onto the `tauri::ipc::Channel`
+ * required by the generated `commands.plansApplyReal` signature (spec 042 US16,
+ * T240) and unwraps the generated `Result` into the throw-on-error contract.
+ *
+ * This glue previously lived in the hand-written `@/api/commands` wrapper; it is
+ * moved here (not dropped — FR-004) so the call site uses the generated binding
+ * directly while keeping the Channel-bridging behaviour.
+ */
+
+import { Channel } from '@tauri-apps/api/core';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { OperationEvent, PlanApplyResponse } from '@/bindings/index';
+
+export async function applyPlan(args: {
+  id: string;
+  approvalToken?: string;
+  /**
+   * Optional live long-operation subscriber. When supplied, the backend streams
+   * `OperationEvent`s over the channel: a `Started` event, per-item
+   * `progress`/`item_applied`/`item_failed` events, then a terminal
+   * `completed`/`failed` event. The durable DB audit trail is unaffected — the
+   * channel is the live UI projection only.
+   */
+  onEvent?: (event: OperationEvent) => void;
+}): Promise<PlanApplyResponse> {
+  const channel = new Channel<OperationEvent>();
+  if (args.onEvent) {
+    const handler = args.onEvent;
+    channel.onmessage = (event) => handler(event);
+  }
+  // `plansApplyReal(planId, approvalToken, onEvent)` requires a token; when
+  // absent we default to '' which the backend rejects — the real flow supplies
+  // the token from `plansApprove.approvalToken`.
+  return unwrap(await commands.plansApplyReal(args.id, args.approvalToken ?? '', channel));
+}

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -11,7 +11,7 @@
  */
 
 import { useCallback, useState } from 'react';
-import { applyPlan } from '@/api/commands';
+import { applyPlan } from './planApply';
 import type { OperationEvent, PlanApplyResponse } from '@/bindings/index';
 
 export interface PlanApplyProgress {


### PR DESCRIPTION
## Summary
- Migrates the plans feature (protection gate, apply-progress) off the hand-written `@/api/commands` wrappers onto the generated, type-safe IPC bindings (`commands.*` + `unwrap`). No user-visible behavior change.
- Channel-bridging glue for plan apply is moved into `features/plans/planApply.ts` (not dropped) so the call site uses the generated `plansApplyReal` binding directly.

## Verification
- plans vitest: 8/8 pass
- tsc: clean
- eslint: 0 errors

## Spec Context
- Spec: 037 (IPC wrapper removal) — Phase 3 caller migration, plans area
- Branch: 037-plans-ipc