### PR TITLE
feat(037): migrate sessions area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/features/sessions/SessionDetail.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.tsx
@@ -11,7 +11,7 @@
  * the freed space lets the attribute table use both columns.
  */
 
-import type { InventorySession } from '@/api/commands';
+import type { InventorySession } from '@/bindings/index';
 import {
   DetailPane,
   DetailPanel,

--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -40,8 +40,8 @@ import {
 } from './store';
 import { addToast } from '@/shared/toast';
 import { m } from '@/lib/i18n';
-import { revealInventoryPath } from '@/api/commands';
-import type { InventorySource } from '@/api/commands';
+import { revealInventoryPath } from './revealInventory';
+import type { InventorySource } from '@/bindings/index';
 import type { ReviewFilter } from '@/lib/route-contract';
 import { REVIEW_FILTERS } from '@/lib/route-contract';
 import { sessionStateLabel } from '@/lib/lifecycle';

--- a/apps/desktop/src/features/sessions/SessionsTable.tsx
+++ b/apps/desktop/src/features/sessions/SessionsTable.tsx
@@ -15,7 +15,7 @@
 
 import { useMemo, type ReactNode } from 'react';
 import { AlertTriangle } from 'lucide-react';
-import type { InventorySource, InventorySession } from '@/api/commands';
+import type { InventorySource, InventorySession } from '@/bindings/index';
 import { Table, Pill } from '@/ui';
 import { SortHeader } from '@/components';
 import { m } from '@/lib/i18n';

--- a/apps/desktop/src/features/sessions/__tests__/SessionsPage.inventory.test.tsx
+++ b/apps/desktop/src/features/sessions/__tests__/SessionsPage.inventory.test.tsx
@@ -9,7 +9,7 @@
  * (PageTopBar + FilterToolbar). The legacy frame-type filter was removed
  * (sessions are light frames). These tests target the new components.
  *
- * Tests (jsdom, mock @/api/commands and @/features/sessions/store):
+ * Tests (jsdom, mock @/features/sessions/store):
  *
  * 1. SessionsTable renders a target group header for each distinct target.
  * 2. SessionsTable renders session rows with target/filter content.
@@ -25,19 +25,14 @@
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import type { InventorySource, InventorySession } from '@/api/commands';
+import type { InventorySource, InventorySession } from '@/bindings/index';
 
 // ── Hoist mocks ───────────────────────────────────────────────────────────────
+// The store hook is fully mocked below, so the real IPC layer never runs; we
+// only need the toast spy here (spec 037: no @/api/commands mock required).
 
-const { mockInventoryList, mockInventorySessionReview, mockAddToast } = vi.hoisted(() => ({
-  mockInventoryList: vi.fn(),
-  mockInventorySessionReview: vi.fn(),
+const { mockAddToast } = vi.hoisted(() => ({
   mockAddToast: vi.fn(),
-}));
-
-vi.mock('@/api/commands', () => ({
-  inventoryList: mockInventoryList,
-  inventorySessionReview: mockInventorySessionReview,
 }));
 
 vi.mock('@/shared/toast', () => ({

--- a/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
+++ b/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
@@ -14,7 +14,7 @@ const { mockNativeReveal } = vi.hoisted(() => ({
 
 // Mock the generated bindings surface and the ipc unwrap so we assert exactly
 // what revealInventoryPath forwards to the native command.
-vi.mock('@/bindings', () => ({
+vi.mock('@/bindings/index', () => ({
   commands: { nativeReveal: mockNativeReveal },
 }));
 
@@ -27,7 +27,7 @@ vi.mock('@/api/ipc', () => ({
   setInvokeOverride: vi.fn(),
 }));
 
-import { revealInventoryPath } from '@/api/commands';
+import { revealInventoryPath } from '@/features/sessions/revealInventory';
 
 interface RevealArg {
   requestId: string;

--- a/apps/desktop/src/features/sessions/revealInventory.ts
+++ b/apps/desktop/src/features/sessions/revealInventory.ts
@@ -1,0 +1,27 @@
+/**
+ * Sessions "Reveal in OS" IPC helper (spec 037 caller migration).
+ *
+ * Moves the inventory-row reveal glue off the hand-written `@/api/commands`
+ * wrapper onto the generated `commands.nativeReveal` binding (FR-004: the
+ * behaviour is moved, not dropped). The native reveal is tagged with an
+ * `inventory_row` audit context so spec-004 / spec-006 FR-007 audit
+ * correlation is preserved, and the generated `Result` is unwrapped into the
+ * throw-on-error contract the caller toasts on.
+ */
+
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+
+export async function revealInventoryPath(args: {
+  path: string;
+  sessionId?: string;
+}): Promise<void> {
+  unwrap(
+    await commands.nativeReveal({
+      requestId: crypto.randomUUID(),
+      path: args.path,
+      entityKind: 'inventory_row',
+      entityId: args.sessionId ?? null,
+    }),
+  );
+}

--- a/apps/desktop/src/features/sessions/store.ts
+++ b/apps/desktop/src/features/sessions/store.ts
@@ -8,18 +8,36 @@
 import { useState, useCallback } from "react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/data/queryKeys";
-import { inventoryList, inventorySessionReview } from "@/api/commands";
+import { commands } from "@/bindings/index";
+import { unwrap } from "@/api/ipc";
 import type {
   InventoryListResponse,
   InventoryListRequest,
   InventorySessionReviewRequest,
   InventorySessionReviewResponse,
   InventoryFrameType,
-} from "@/api/commands";
+} from "@/bindings/index";
 import { errMessage } from '@/lib/errors';
 
 export type { InventoryListResponse, InventorySessionReviewResponse };
-export type { InventorySource, InventorySession } from "@/api/commands";
+export type { InventorySource, InventorySession } from "@/bindings/index";
+
+// Local IPC helpers — migrated off the hand-written @/api/commands wrappers
+// (spec 037) onto the generated bindings. unwrap() turns the generated Result
+// into the throw-on-error contract the hooks below rely on.
+async function inventoryList(req: InventoryListRequest): Promise<InventoryListResponse> {
+  return unwrap(await commands.inventoryList(req as Parameters<typeof commands.inventoryList>[0]));
+}
+
+async function inventorySessionReview(
+  req: InventorySessionReviewRequest,
+): Promise<InventorySessionReviewResponse> {
+  return unwrap(
+    await commands.inventorySessionReview(
+      req as Parameters<typeof commands.inventorySessionReview>[0],
+    ),
+  );
+}
 
 // Filters shape
 


### PR DESCRIPTION
## Spec 037 — Phase-3 caller migration: `features/sessions`

Repoints the Sessions/Inventory feature off the hand-written `@/api/commands` IPC wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`).

### Changes
- **store.ts** — `inventoryList` / `inventorySessionReview` now call `commands.*` and `unwrap` the generated `Result`; types sourced from `@/bindings/index`.
- **revealInventory.ts** (new) — moves the inventory-row native-reveal glue off the wrapper (**FR-004 move-not-drop**), preserving the `inventory_row` audit tag via `commands.nativeReveal`.
- **SessionsPage / SessionsTable / SessionDetail** — type-only imports repointed to `@/bindings/index`; page imports `revealInventoryPath` locally.
- **tests** — mock `@/bindings/index` + `@/features/sessions/revealInventory` instead of `@/api/commands`.

### Verification (from `apps/desktop/`)
- `tsc -p tsconfig.json --noEmit` → clean
- `VITE_USE_MOCKS=true vitest run src/features/sessions/` → **57/57 pass**
- `eslint src/features/sessions/` → **0 errors** (4 pre-existing warnings, none on changed lines)

Follows the calibration (#359) / plans (#368) reference pattern. No `@/api/commands` importers remain in `features/sessions`.