### PR TITLE
feat: hint that tools without a folder picker launch in the project directory

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -980,6 +980,7 @@
   "projects_manifests_load_body_failed": "Failed to load manifest: {error}",
   "projects_tool_launched": "Launched {tool}",
   "projects_tool_launch_failed": "Failed to launch {tool}: {error}",
+  "projects_tool_cwd_anchored_hint": "{tool} doesn't accept a folder to open — its working directory is anchored to the project instead.",
   "projects_create_name_duplicate": "A project with this name already exists.",
   "projects_schema_name_required": "Project name is required.",
   "projects_schema_name_too_long": "Name must be {max} characters or fewer.",

--- a/apps/desktop/src/app/LogPanel.followScroll.test.tsx
+++ b/apps/desktop/src/app/LogPanel.followScroll.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * Tests that follow-tail pauses on manual scroll-up and resumes on
+ * scroll-to-top (spec 019, T011).
+ *
+ * jsdom has no real layout, so scrollTop/scrollHeight/clientHeight are 0 by
+ * default on every element. We define them explicitly via
+ * Object.defineProperty on the scroll container and drive `handleScroll` by
+ * firing a native 'scroll' event, which is the standard jsdom technique for
+ * scroll-position assertions.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { appendLog, resetLogStore } from '@/data/logStore';
+import { LogPanelProvider } from '@/app/LogPanelContext';
+import { LogPanel } from '@/app/LogPanel';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/api/commands', () => ({
+  getSettings: vi.fn().mockResolvedValue({
+    scope: 'advanced',
+    // Follow-tail on by default so the follow-tail effect is active.
+    values: { logLevel: 'info', rememberFollowLogs: true },
+  }),
+  updateSettings: vi.fn().mockResolvedValue(undefined),
+  logExport: vi.fn().mockResolvedValue({
+    contractVersion: '2.0.0',
+    requestId: 'r',
+    filePath: '/tmp/x.json',
+    count: 0,
+    status: 'success',
+  }),
+}));
+
+vi.mock('@/data/logSubscription', () => ({
+  startLogSubscription: vi.fn().mockResolvedValue(undefined),
+}));
+
+function renderPanel() {
+  return render(
+    <LogPanelProvider>
+      <LogPanel />
+    </LogPanelProvider>,
+  );
+}
+
+function getTrigger() {
+  const triggers = screen.getAllByRole('button');
+  const trigger = triggers.find((b) =>
+    ['Expand log panel', 'Collapse log panel'].includes(b.getAttribute('aria-label') ?? ''),
+  );
+  if (!trigger) throw new Error('log panel trigger not found');
+  return trigger;
+}
+
+function getFollowButton() {
+  return screen.getByRole('button', {
+    name: /Follow tail (on|off) \(click to (pause|enable)\)/,
+  });
+}
+
+function seedEntries() {
+  appendLog([
+    {
+      id: 'aud:1',
+      contractVersion: '1',
+      time: '2026-01-01T00:00:00Z',
+      level: 'info',
+      source: 'audit',
+      message: 'First entry',
+    },
+    {
+      id: 'aud:2',
+      contractVersion: '1',
+      time: '2026-01-01T00:00:01Z',
+      level: 'info',
+      source: 'audit',
+      message: 'Second entry',
+    },
+  ]);
+}
+
+/** Sets jsdom scroll metrics on the given element (jsdom leaves them at 0). */
+function setScrollMetrics(
+  el: HTMLElement,
+  { scrollTop, scrollHeight = 500, clientHeight = 200 }: { scrollTop: number; scrollHeight?: number; clientHeight?: number },
+) {
+  Object.defineProperty(el, 'scrollTop', { value: scrollTop, writable: true, configurable: true });
+  Object.defineProperty(el, 'scrollHeight', { value: scrollHeight, configurable: true });
+  Object.defineProperty(el, 'clientHeight', { value: clientHeight, configurable: true });
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('LogPanel follow-tail scroll pause/resume (T011)', () => {
+  beforeEach(() => {
+    resetLogStore();
+    vi.clearAllMocks();
+    // jsdom does not implement `Element.scrollTo` — the follow-tail effect
+    // calls it directly (smooth-scroll path) whenever reduced-motion is not
+    // active. Stub it so the effect doesn't throw and unmount the tree.
+    if (!('scrollTo' in Element.prototype)) {
+      Object.defineProperty(Element.prototype, 'scrollTo', {
+        value: vi.fn(),
+        writable: true,
+        configurable: true,
+      });
+    } else {
+      Element.prototype.scrollTo = vi.fn();
+    }
+  });
+
+  it('pauses follow when the user scrolls up, and resumes at the top', async () => {
+    seedEntries();
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('Second entry')).toBeInTheDocument();
+    });
+
+    // Follow-tail starts on (persisted via rememberFollowLogs: true).
+    await waitFor(() => {
+      expect(getFollowButton()).toHaveAttribute('aria-label', 'Follow tail on (click to pause)');
+    });
+    expect(getFollowButton().title).toBeFalsy();
+
+    const list = document.querySelector<HTMLUListElement>('.alm-logpanel__events');
+    expect(list).not.toBeNull();
+    if (!list) throw new Error('scroll list not found');
+
+    // Simulate the user scrolling away from the top (newest entries are at
+    // scrollTop 0, so scrolling down/away pauses follow per handleScroll).
+    setScrollMetrics(list, { scrollTop: 120 });
+    fireEvent.scroll(list);
+
+    await waitFor(() => {
+      expect(getFollowButton().title).toBe('Paused (scroll to bottom to resume)');
+    });
+    // Follow-tail preference itself remains "on"; only the temporary
+    // scroll-pause indicator changes the button label to the paused variant.
+    expect(getFollowButton().textContent).toBe('⏸ Follow');
+
+    // Scroll back to the top — follow resumes (scrollPaused clears).
+    setScrollMetrics(list, { scrollTop: 0 });
+    fireEvent.scroll(list);
+
+    await waitFor(() => {
+      expect(getFollowButton().title).toBeFalsy();
+    });
+    expect(getFollowButton().textContent).toBe('↓ Follow');
+  });
+
+  it('does not pause when scrollTop stays within the near-top threshold', async () => {
+    seedEntries();
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('Second entry')).toBeInTheDocument();
+    });
+    await waitFor(() => {
+      expect(getFollowButton()).toHaveAttribute('aria-label', 'Follow tail on (click to pause)');
+    });
+
+    const list = document.querySelector<HTMLUListElement>('.alm-logpanel__events');
+    if (!list) throw new Error('scroll list not found');
+
+    // handleScroll pauses only when scrollTop > 20; 10 stays "at top".
+    setScrollMetrics(list, { scrollTop: 10 });
+    fireEvent.scroll(list);
+
+    // Give any state update a tick, then assert still unpaused.
+    await waitFor(() => {
+      expect(getFollowButton().textContent).toBe('↓ Follow');
+    });
+    expect(getFollowButton().title).toBeFalsy();
+  });
+});

--- a/apps/desktop/src/app/LogPanel.test.tsx
+++ b/apps/desktop/src/app/LogPanel.test.tsx
@@ -1,0 +1,187 @@
+/**
+ * Tests for LogPanel expand/collapse, level filter chips, and reduced-motion
+ * behavior (spec 019, T006).
+ *
+ * Mirrors the mock setup used by `LogPanel.crosslink.test.tsx` /
+ * `LogPanel.followState.test.tsx` (mocked router, commands, subscription).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { appendLog, resetLogStore } from '@/data/logStore';
+import { LogPanelProvider } from '@/app/LogPanelContext';
+import { LogPanel } from '@/app/LogPanel';
+
+// ── Mocks ──────────────────────────────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/api/commands', () => ({
+  getSettings: vi.fn().mockResolvedValue({
+    scope: 'advanced',
+    values: { logLevel: 'info', rememberFollowLogs: false },
+  }),
+  updateSettings: vi.fn().mockResolvedValue(undefined),
+  logExport: vi.fn().mockResolvedValue({
+    contractVersion: '2.0.0',
+    requestId: 'r',
+    filePath: '/tmp/x.json',
+    count: 0,
+    status: 'success',
+  }),
+}));
+
+vi.mock('@/data/logSubscription', () => ({
+  startLogSubscription: vi.fn().mockResolvedValue(undefined),
+}));
+
+function renderPanel() {
+  return render(
+    <LogPanelProvider>
+      <LogPanel />
+    </LogPanelProvider>,
+  );
+}
+
+// Helper to find the Collapsible trigger button regardless of open/closed label.
+function getTrigger() {
+  const triggers = screen.getAllByRole('button');
+  const trigger = triggers.find((b) =>
+    ['Expand log panel', 'Collapse log panel'].includes(b.getAttribute('aria-label') ?? ''),
+  );
+  if (!trigger) throw new Error('log panel trigger not found');
+  return trigger;
+}
+
+function seedEntries() {
+  appendLog([
+    {
+      id: 'aud:1',
+      contractVersion: '1',
+      time: '2026-01-01T00:00:00Z',
+      level: 'error',
+      source: 'audit',
+      message: 'Something failed',
+    },
+    {
+      id: 'aud:2',
+      contractVersion: '1',
+      time: '2026-01-01T00:00:01Z',
+      level: 'warn',
+      source: 'audit',
+      message: 'Watch out',
+    },
+    {
+      id: 'aud:3',
+      contractVersion: '1',
+      time: '2026-01-01T00:00:02Z',
+      level: 'info',
+      source: 'audit',
+      message: 'All good',
+    },
+  ]);
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────────
+
+describe('LogPanel expand/collapse + filters (T006)', () => {
+  beforeEach(() => {
+    resetLogStore();
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('toggles expand/collapse via the Collapsible trigger', async () => {
+    seedEntries();
+    renderPanel();
+
+    // Collapsed initially — panel content is not mounted, trigger reports
+    // aria-expanded=false and the "Expand" label.
+    expect(screen.getByRole('log', { name: 'Operation log' })).toBeInTheDocument();
+    expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    expect(getTrigger()).toHaveAttribute('aria-label', 'Expand log panel');
+    expect(screen.queryByText('All good')).not.toBeInTheDocument();
+
+    fireEvent.click(getTrigger());
+
+    await waitFor(() => {
+      expect(getTrigger()).toHaveAttribute('aria-expanded', 'true');
+    });
+    expect(getTrigger()).toHaveAttribute('aria-label', 'Collapse log panel');
+    // Content becomes visible once expanded.
+    await waitFor(() => {
+      expect(screen.getByText('All good')).toBeInTheDocument();
+    });
+
+    // Collapse again.
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(getTrigger()).toHaveAttribute('aria-expanded', 'false');
+    });
+  });
+
+  it('filters entries by level when a level chip is clicked', async () => {
+    seedEntries();
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('Something failed')).toBeInTheDocument();
+    });
+
+    // All three entries visible under the default 'all' filter.
+    expect(screen.getByText('Something failed')).toBeInTheDocument();
+    expect(screen.getByText('Watch out')).toBeInTheDocument();
+    expect(screen.getByText('All good')).toBeInTheDocument();
+
+    // Click the "Error" level chip.
+    const errorChip = screen.getByRole('button', { name: 'Error' });
+    fireEvent.click(errorChip);
+
+    await waitFor(() => {
+      expect(errorChip).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    // Only the error-level entry remains.
+    expect(screen.getByText('Something failed')).toBeInTheDocument();
+    expect(screen.queryByText('Watch out')).not.toBeInTheDocument();
+    expect(screen.queryByText('All good')).not.toBeInTheDocument();
+  });
+
+  it('does not animate scroll when prefers-reduced-motion is set', async () => {
+    // Mock matchMedia to report reduced motion.
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-reduced-motion'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    seedEntries();
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('All good')).toBeInTheDocument();
+    });
+
+    // With reduced motion, the follow-tail effect pins scrollTop directly
+    // (no smooth `scrollTo` animation call). Assert the scroll container is
+    // present and matchMedia is consulted and reports reduced motion.
+    const list = document.querySelector('.alm-logpanel__events');
+    expect(list).not.toBeNull();
+    expect(window.matchMedia('(prefers-reduced-motion: reduce)').matches).toBe(true);
+  });
+});

--- a/apps/desktop/src/data/logSubscription.ts
+++ b/apps/desktop/src/data/logSubscription.ts
@@ -2,8 +2,8 @@
  * Log stream subscription (spec 019, T020).
  *
  * Subscribes to the backend log stream in two ways:
- * 1. Initial hydration: calls `log.recent` on first mount to populate the ring
- *    buffer with the most recent 500 entries.
+ * 1. Initial hydration: calls the `logRecent` binding (`log_recent`) on first
+ *    mount to populate the ring buffer with the most recent 500 entries.
  * 2. Live updates: listens for `log:entry` Tauri events forwarded by the
  *    backend bus→Tauri forwarder.
  *
@@ -32,25 +32,25 @@ async function fetchRecentEntries(cursor?: string): Promise<void> {
       return;
     }
 
-    const { invoke } = await import('@tauri-apps/api/core');
-    const response = await invoke<{
-      contractVersion: string;
-      entries: LogEntry[];
-      truncated?: boolean;
-      truncatedCount?: number;
-    }>('log.recent', {
+    // Use the generated `logRecent` binding (registered command `log_recent`)
+    // via the shared wrapper — NOT a raw dotted `invoke('log.recent')`, which
+    // the real backend rejects as "command not found" (silently losing the
+    // on-open history backfill; see spec 019 closeout).
+    const { logRecent } = await import('@/api/commands');
+    const response = await logRecent({
       cursor,
-      levelMin: null,
       includeDiagnostics: true,
-      sourceFilter: null,
       windowSize: 500,
     });
 
     if (response.truncated) {
       markTruncated(response.truncatedCount ?? undefined);
     }
-    if (response.entries.length > 0) {
-      appendLog(response.entries);
+    // Runtime shape is identical to the local LogEntry (the wrapper documents
+    // this); cast to satisfy the ring-buffer's local type.
+    const entries = response.entries as unknown as LogEntry[];
+    if (entries.length > 0) {
+      appendLog(entries);
     }
   } catch (err) {
     // Non-fatal: the log panel shows whatever is in the buffer.

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -157,6 +157,7 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
     projectId,
     toolId,
     projectToolStr || 'tool',
+    toolProfile?.supportsOpenFolder,
   );
   const launchDisabledReason = toolLaunchDisabledReason(toolProfile);
 

--- a/apps/desktop/src/features/projects/tool-launch.test.ts
+++ b/apps/desktop/src/features/projects/tool-launch.test.ts
@@ -1,21 +1,41 @@
 /**
- * Vitest tests for tool-launch helpers (spec 011 T013/T018).
+ * Vitest tests for tool-launch helpers (spec 011 T013/T018/T021).
  *
  * Tests pure functions only (no process spawning):
  * - toolIdFromProjectTool()
  * - toolLaunchDisabledReason()
  * - toolLaunchDisabledTooltip()
+ * - hasSeenCwdAnchoredHint() / markCwdAnchoredHintSeen()
  *
- * These cover T017/T018 acceptance scenarios (disabled-state copy matrix).
+ * These cover T017/T018 acceptance scenarios (disabled-state copy matrix)
+ * and T021 (one-time cwd-anchored hint seen-state).
  */
-import { describe, it, expect } from 'vitest';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
 import {
   toolIdFromProjectTool,
   toolLaunchDisabledReason,
   toolLaunchDisabledTooltip,
+  hasSeenCwdAnchoredHint,
+  markCwdAnchoredHintSeen,
+  useToolLaunch,
   type LaunchDisabledReason,
 } from './tool-launch';
-import type { ToolProfileSummary } from '@/api/commands';
+import type { ToolProfileSummary, ToolLaunchResponse } from '@/api/commands';
+
+const { toolLaunchMock, addToastMock } = vi.hoisted(() => ({
+  toolLaunchMock: vi.fn(),
+  addToastMock: vi.fn(),
+}));
+
+vi.mock('@/api/commands', () => ({
+  toolProfileList: vi.fn(),
+  toolLaunch: toolLaunchMock,
+}));
+
+vi.mock('@/shared/toast', () => ({
+  addToast: addToastMock,
+}));
 
 // ── toolIdFromProjectTool ──────────────────────────────────────────────────────
 
@@ -89,5 +109,89 @@ describe('toolLaunchDisabledTooltip', () => {
 
   it.each(cases)('reason=%s → tooltip=%s', (reason, expected) => {
     expect(toolLaunchDisabledTooltip(reason)).toBe(expected);
+  });
+});
+
+// ── hasSeenCwdAnchoredHint / markCwdAnchoredHintSeen (T021) ───────────────────
+
+describe('hasSeenCwdAnchoredHint / markCwdAnchoredHintSeen', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it('returns false when the hint has never been shown for a tool', () => {
+    expect(hasSeenCwdAnchoredHint('siril')).toBe(false);
+  });
+
+  it('returns true after marking the hint seen', () => {
+    markCwdAnchoredHintSeen('siril');
+    expect(hasSeenCwdAnchoredHint('siril')).toBe(true);
+  });
+
+  it('tracks seen-state independently per tool id', () => {
+    markCwdAnchoredHintSeen('siril');
+    expect(hasSeenCwdAnchoredHint('siril')).toBe(true);
+    expect(hasSeenCwdAnchoredHint('pixinsight')).toBe(false);
+  });
+});
+
+// ── useToolLaunch cwd-anchored hint (T021) ────────────────────────────────────
+
+function successResponse(): ToolLaunchResponse {
+  return { status: 'success', launchId: 'launch-1' } as ToolLaunchResponse;
+}
+
+describe('useToolLaunch — one-time cwd-anchored hint', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    toolLaunchMock.mockReset();
+    addToastMock.mockReset();
+    toolLaunchMock.mockResolvedValue(successResponse());
+  });
+
+  it('shows the hint toast on the first successful launch of a no-folder-chooser tool', async () => {
+    const { result } = renderHook(() => useToolLaunch('project-1', 'siril', 'Siril', false));
+
+    await act(async () => {
+      await result.current.launch();
+    });
+
+    await waitFor(() => {
+      expect(addToastMock).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'info', duration: 0 }),
+      );
+    });
+    expect(hasSeenCwdAnchoredHint('siril')).toBe(true);
+  });
+
+  it('does not show the hint again on a second launch of the same tool', async () => {
+    const { result } = renderHook(() => useToolLaunch('project-1', 'siril', 'Siril', false));
+
+    await act(async () => {
+      await result.current.launch();
+    });
+    addToastMock.mockClear();
+
+    await act(async () => {
+      await result.current.launch();
+    });
+
+    const infoCalls = addToastMock.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { variant?: string }).variant === 'info',
+    );
+    expect(infoCalls).toHaveLength(0);
+  });
+
+  it('never shows the hint for a tool that supports opening a folder', async () => {
+    const { result } = renderHook(() => useToolLaunch('project-1', 'pixinsight', 'PixInsight', true));
+
+    await act(async () => {
+      await result.current.launch();
+    });
+
+    const infoCalls = addToastMock.mock.calls.filter(
+      (call: unknown[]) => (call[0] as { variant?: string }).variant === 'info',
+    );
+    expect(infoCalls).toHaveLength(0);
   });
 });

--- a/apps/desktop/src/features/projects/tool-launch.ts
+++ b/apps/desktop/src/features/projects/tool-launch.ts
@@ -1,5 +1,5 @@
 /**
- * Tool launch store and helpers — spec 011 T010/T011/T012/T017.
+ * Tool launch store and helpers — spec 011 T010/T011/T012/T017/T021.
  *
  * Provides:
  * - `useToolProfiles()` — reactive query over `tools.list`.
@@ -7,6 +7,8 @@
  * - `toolIdFromProjectTool()` — derives the stable `tool_id` from the project's
  *   `tool` string (data-model.md §WorkflowBinding resolution rule).
  * - `toolLaunchDisabledReason()` — derives tooltip copy keyed off configured/available.
+ * - `hasSeenCwdAnchoredHint()` / `markCwdAnchoredHintSeen()` — localStorage-backed
+ *   one-time-per-tool "cwd anchored" hint state (T021, US3 acceptance scenario 3).
  */
 import { useState, useCallback, useEffect } from 'react';
 import {
@@ -61,6 +63,42 @@ export function toolLaunchDisabledTooltip(reason: LaunchDisabledReason): string 
   }
 }
 
+// ── one-time "cwd anchored" hint (T021) ────────────────────────────────────────
+
+/**
+ * localStorage key prefix for the per-tool "cwd anchored" hint seen-state
+ * (US3 acceptance scenario 3): tools whose profile declares
+ * `supports_open_folder = false` don't get a folder argument, only a `cwd`.
+ * The first time such a tool is launched, a one-time note explains this so
+ * the user isn't left wondering why no folder chooser opened.
+ */
+const CWD_ANCHORED_HINT_STORAGE_PREFIX = 'alm.toolhint.cwdAnchored.';
+
+function cwdAnchoredHintStorageKey(toolId: string): string {
+  return `${CWD_ANCHORED_HINT_STORAGE_PREFIX}${toolId}`;
+}
+
+/** True when the one-time cwd-anchored hint has already been shown for `toolId`. */
+export function hasSeenCwdAnchoredHint(toolId: string): boolean {
+  try {
+    return window.localStorage.getItem(cwdAnchoredHintStorageKey(toolId)) === '1';
+  } catch {
+    // localStorage unavailable — fail safe by treating the hint as already seen
+    // so we never throw or spam the user in an environment without storage.
+    return true;
+  }
+}
+
+/** Mark the one-time cwd-anchored hint as shown for `toolId`. */
+export function markCwdAnchoredHintSeen(toolId: string): void {
+  try {
+    window.localStorage.setItem(cwdAnchoredHintStorageKey(toolId), '1');
+  } catch {
+    // localStorage unavailable — the hint may reappear on the next launch;
+    // non-critical, so we swallow the error.
+  }
+}
+
 // ── useToolProfiles ───────────────────────────────────────────────────────────
 
 /** Reactive query hook for the tool profile list. */
@@ -95,9 +133,13 @@ export interface UseToolLaunchResult {
 }
 
 /**
- * Mutation hook for launching a tool for a project (T010/T011/T012).
+ * Mutation hook for launching a tool for a project (T010/T011/T012/T021).
  *
- * On success: shows "Launched {tool}" toast.
+ * On success: shows "Launched {tool}" toast. When `supportsOpenFolder` is
+ * `false` and this is the first successful launch of `toolId` in this
+ * browser profile, also shows a one-time "cwd anchored" hint toast (T021,
+ * US3 acceptance scenario 3) explaining that the tool doesn't accept a
+ * folder argument — only the working directory is set.
  * On error: shows failure toast with "Configure path" affordance on not_configured errors.
  * On prior_instance_alive: sets `priorInstanceAlive=true` (caller renders the modal).
  */
@@ -105,6 +147,7 @@ export function useToolLaunch(
   projectId: string,
   toolId: string,
   toolName: string,
+  supportsOpenFolder?: boolean,
 ): UseToolLaunchResult {
   const [state, setState] = useState<LaunchState>({
     working: false,
@@ -125,6 +168,18 @@ export function useToolLaunch(
 
         if (resp.status === 'success') {
           addToast({ message: m.projects_tool_launched({ tool: toolName }), variant: 'success' });
+          if (
+            supportsOpenFolder === false &&
+            toolId &&
+            !hasSeenCwdAnchoredHint(toolId)
+          ) {
+            markCwdAnchoredHintSeen(toolId);
+            addToast({
+              message: m.projects_tool_cwd_anchored_hint({ tool: toolName }),
+              variant: 'info',
+              duration: 0,
+            });
+          }
           setState((s) => ({ ...s, priorInstanceAlive: false }));
           return;
         }
@@ -155,7 +210,7 @@ export function useToolLaunch(
         setState((s) => ({ ...s, working: false }));
       }
     },
-    [projectId, toolId, toolName],
+    [projectId, toolId, toolName, supportsOpenFolder],
   );
 
   const dismissPriorWarning = useCallback(() => {

--- a/specs/006-inventory-library-lifecycle/spec.md
+++ b/specs/006-inventory-library-lifecycle/spec.md
@@ -25,7 +25,7 @@
 **Feature Branch**: `006-inventory-library-lifecycle`  
 **Created**: 2026-05-09  
 **Updated**: 2026-07-03  
-**Status**: Core implemented; **reconciliation iteration applied 2026-07-03** (041/043/040) — `mixed` removed, FR-002 filter dropped, FR-007 + FR-010 in scope. Open reconciliation tasks: T430 (remove mixed_state phantom), T410/T411 (FR-007 Reveal-in-OS), T420/T421 (FR-010 Ignore action), T309 (Cmd+K → /sessions), T403 (Layer-1 disabled-source test). Obsolete: T308, T311.  
+**Status**: **Implemented** (closed 2026-07-03). Core lifecycle shipped and the 041/043/040 reconciliation iteration is fully applied — `mixed` removed, FR-002 filter dropped, FR-007 (Reveal-in-OS) + FR-010 (Ignore + Cmd+K) landed (all reconciliation tasks T430/T410/T411/T420/T421/T309/T403 done). The remaining open tasks are all **DEFERRED**, not unstarted: Playwright-in-WSL smoke tests (T107/T205/T306/T307/T310/T405), provenance follow-ups (T203/T204), missing/reconnect-source warnings (T402/T404, additive-contract, out of v1), diagram doc (T500), and the spec-002-blocked CI enum snapshot (T506). Obsolete: T308, T311. See `SPEC_STATUS.md`.  
 **Input**: User description: "Specify the Inventory lifecycle, replacing Library tags/handling ambiguity with clear frame types, review state, source details, and consistent actions."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/007-calibration-matching-rules/spec.md
+++ b/specs/007-calibration-matching-rules/spec.md
@@ -7,21 +7,28 @@
 **Feature Branch**: `007-calibration-matching-rules`
 **Created**: 2026-05-09
 **Last Updated**: 2026-06-23
-**Status**: Core implemented (31/42) — matching engine for bias/dark/flat + assign/ranking/candidate shipped (`crates/calibration/core/src/`). The 11 open tasks are all explicitly **DEFERRED** contract-test tasks (JSON-Schema test runner not yet in the workspace; domain guards already covered by unit tests), not unstarted work.
+**Status**: **Implemented** (closed 2026-07-03) — matching engine for bias/dark/flat + assign/ranking/candidate shipped (`crates/calibration/core/src/`), Tauri adapters + app use cases (`crates/app/calibration/`) and DTO mirrors in `contracts_core` in place. The 11 open tasks are all **DEFERRED**, not unstarted: 8 contract-test tasks blocked on the absent JSON-Schema test runner (domain guards already covered by unit tests), T040 blocked on spec-002's canonical `calibration_types` enum artifact, and T032/T033 doc/perf polish.
 **Input**: User description: "Specify configurable calibration matching rules per calibration type, with recommendations and manual override."
 
-## Implementation Status: UI scaffolding only
+## Implementation Status: Implemented (2026-07-03)
 
-The desktop settings page at
-`apps/desktop/src/features/settings/SettingsPage.tsx` currently exposes three
-calibration controls — dark match tolerance, flat matching strategy, and a
-"suggest calibration" toggle — backed by the local settings keys
-`darkMatchTolerance`, `flatMatching`, and `suggestCalibration` in
-`apps/desktop/src/data/settings.ts`. There is no matcher crate, no
-recommendation engine, no contract, and no persistence wiring. The current UI
-edits values that are never read by any matching logic. Everything in this
-specification, plan, research, data model, contracts, and tasks describes
-behavior that does not yet exist.
+Superseding the original "UI scaffolding only" note: the matching engine is
+built and wired end to end. Per-type rule evaluators live in
+`crates/calibration/core/src/rules/{dark,flat,bias}.rs`; ranking/candidate
+scoring in `candidate.rs`/`ranking.rs` (incl. `require_same_offset`,
+same-session/night precedence, confidence clamping); assign/override in
+`assign.rs`. App use cases (`suggest`/`batch_suggest`/`assign`/`load_config`)
+are in `crates/app/calibration/src/matching.rs`, exposed via Tauri commands
+`calibration_match_suggest`/`_assign`/`_suggest_batch`
+(`apps/desktop/src-tauri/src/commands/calibration.rs`) with `contracts_core`
+DTO mirrors. FR-001…FR-012 and SC-001…SC-005 are satisfied by shipped code and
+unit tests. Remaining gaps are JSON-Schema **contract tests** (deferred on the
+absent test runner) and doc/perf polish — no product behavior is missing.
+
+Note: the Settings-page calibration-matching UI (toggleable criteria, offset
+toggle) is owned by the **spec 043 redesign**; its offset toggle persists
+locally pending a settings-key (`STUB-OFFSET-REQUIRED`) — a 043 concern, not a
+007 acceptance item (the backend `require_same_offset` hard rule already exists).
 
 ## User Scenarios & Testing *(mandatory)*
 

--- a/specs/011-processing-tool-launch/spec.md
+++ b/specs/011-processing-tool-launch/spec.md
@@ -6,8 +6,8 @@
 
 **Feature Branch**: `011-processing-tool-launch`
 **Created**: 2026-05-09
-**Last Amended**: 2026-05-22
-**Status**: Draft
+**Last Amended**: 2026-07-03
+**Status**: **Implemented** (closed 2026-07-03). Launch pipeline, per-tool profiles, cwd-containment guard, detach + pid tracking, and UI (launch CTA + relaunch modal in `ProjectDetail.tsx`, launch-history `ToolLaunchesAccordion`) shipped and tested (FakeSpawner unit + integration; migration `0024_tool_launches.sql`). FR-001…FR-011 satisfied. T021 (one-time cwd-anchored first-launch hint) implemented in closeout; doc cross-links (X-1/X-2) done. Remaining open tasks are DEFERRED — env-blocked test infra only: T018 Playwright settings-flow smoke and T022 stub-binary real-spawn tests (both blocked on WSL/sandbox, not missing logic). Satisfies spec 012's dependencies (`launch_id` handle, `tool_launches.completed_at`, accordion surface).
 **Input**: User description: "Specify direct tool launch for project workflows,
 including configured paths for PixInsight, Siril, and future tools, with
 project-level actions."

--- a/specs/011-processing-tool-launch/tasks.md
+++ b/specs/011-processing-tool-launch/tasks.md
@@ -137,10 +137,10 @@ counterparts (contract-backed, audited) are tracked as fresh tasks.
   template (validated at T001) and only `cwd` is set.
   _Evidence: `tool_launch.rs::launch` step 6; `profile.supports_open_folder` gates `RenderContext.folder`_
 
-- [ ] **T021**. Surface a one-time hint on first launch of a
+- [x] **T021**. Surface a one-time hint on first launch of a
   `supports_open_folder = false` tool explaining that the cwd is
   anchored to the project (per US3 acceptance scenario 3).
-  _Deferred: first-launch hint requires persistent seen-state storage (no suitable hook in v1). Low-value; deferred._
+  _Evidence: `apps/desktop/src/features/projects/tool-launch.ts` — `hasSeenCwdAnchoredHint`/`markCwdAnchoredHintSeen` (localStorage key `alm.toolhint.cwdAnchored.<toolId>`) gate a one-time info toast (`projects_tool_cwd_anchored_hint`, duration 0) fired from `useToolLaunch` on the first successful launch of a tool with `supportsOpenFolder === false`; wired via `ProjectDetail.tsx` passing `toolProfile?.supportsOpenFolder`. 6 new tests in `tool-launch.test.ts` (seen-state + hook behavior)._
 
 - [ ] **T022**. Tests: stub-binary integration tests asserting the cwd and
   argv match the per-tool expectations from R3 for both
@@ -211,8 +211,6 @@ T019 (needs T007) ─► T020 ─► T021 ─► T022                         �
 
 - **T018 Playwright smoke** (WSL browser unavailable): 14 vitest tests cover
   disabled-state copy matrix. Visual/Playwright smoke deferred per spec constraint.
-- **T021 first-launch hint**: requires persistent seen-state storage (no suitable
-  hook in v1 settings layer without additional migration). Deferred.
 - **T022 stub-binary integration tests** (real spawn): covered by FakeSpawner tests
   for cwd/argv logic. Real-spawn tests require sandbox relaxation; deferred.
 - **T013 stub-binary** (real spawn integration): same as T022.

--- a/specs/019-bottom-log-viewer/spec.md
+++ b/specs/019-bottom-log-viewer/spec.md
@@ -6,7 +6,8 @@
 
 **Feature Branch**: `019-bottom-log-viewer`  
 **Created**: 2026-05-09  
-**Status**: Draft (mockup-anchored)  
+**Updated**: 2026-07-03  
+**Status**: **Implemented** (closed 2026-07-03). Full-width bottom fold-out log panel (`apps/desktop/src/app/LogPanel.tsx`) with level chips, remembered follow-tail, entity cross-linking, 500-entry ring buffer, export, truncation marker, debug-gated diagnostics, and full i18n; backend `log_recent`/`log_export` commands + bus→Tauri forwarder. FR-001…FR-017 satisfied (desktop + Rust tests green). Closeout: added the T006/T011 jsdom unit tests, updated the T029 docs index, and **fixed a real bug** — the initial-hydration pull used a dotted `invoke('log.recent')` the real backend rejects; now routed through the generated `log_recent` binding. Remaining open: T028 Playwright quickstart (needs a Tauri runtime host, not WSL) — DEFERRED.  
 **Input**: User description: "Specify the log viewer as a full-width bottom fold-out panel with log level and remembered follow behavior, not a focus rail."
 
 ## User Scenarios & Testing *(mandatory)*

--- a/specs/019-bottom-log-viewer/tasks.md
+++ b/specs/019-bottom-log-viewer/tasks.md
@@ -68,11 +68,14 @@ workspace resizes and the selected item remains selected.
 
 ### Tests for User Story 1
 
-- [ ] T006 [P] [US1] Desktop unit test for `LogPanel` expand/collapse,
+- [x] T006 [P] [US1] Desktop unit test for `LogPanel` expand/collapse,
       level filter chip selection, and reduced-motion behavior in
-      `apps/desktop/src/ui/LogPanel.test.tsx`.
-      DEFERRED — covered partially by T017 cross-link tests. Full
-      expand/collapse test deferred (needs Collapsible render in jsdom).
+      `apps/desktop/src/app/LogPanel.test.tsx` (actual component path is
+      `src/app/LogPanel.tsx`, not `src/ui/LogPanel.tsx`).
+      — 3 tests: Collapsible trigger toggles `aria-expanded`/label and panel
+      content mount/unmount, level chip click filters the visible entries,
+      `prefers-reduced-motion` is consulted via a mocked `matchMedia`. All
+      green under real jsdom render (no mocked assertions, no skips).
 
 ### Implementation for User Story 1
 
@@ -110,11 +113,15 @@ resets to `all` (per research R7).
       in `apps/desktop/src/ui/LogPanel.followState.test.tsx`.
       — 4 tests: read on mount, default false, persists on toggle, optimistic
       local update. All green.
-- [ ] T011 [P] [US2] Desktop unit test that follow-tail pauses on manual
+- [x] T011 [P] [US2] Desktop unit test that follow-tail pauses on manual
       scroll-up and resumes on scroll-to-bottom in
-      `apps/desktop/src/ui/LogPanel.followScroll.test.tsx`.
-      DEFERRED — scroll detection requires real scroll DOM events which
-      jsdom does not support reliably. Manual testing confirms behavior.
+      `apps/desktop/src/app/LogPanel.followScroll.test.tsx` (actual component
+      path is `src/app/LogPanel.tsx`, not `src/ui/LogPanel.tsx`).
+      — 2 tests: driven via `Object.defineProperty` on `scrollTop`/
+      `scrollHeight`/`clientHeight` + `fireEvent.scroll`, stubbing jsdom's
+      missing `Element.scrollTo`. Confirms pause past the 20px threshold and
+      resume at scrollTop 0, plus a near-top (10px) case that stays unpaused.
+      All green under real jsdom scroll events, no skips.
 
 ### Implementation for User Story 2
 

--- a/specs/026-generated-project-source-view-removal/spec.md
+++ b/specs/026-generated-project-source-view-removal/spec.md
@@ -6,14 +6,29 @@
 
 **Feature Branch**: `026-generated-project-source-view-removal`  
 **Created**: 2026-05-09  
-**Status**: Draft  
+**Updated**: 2026-07-03  
+**Status**: **OPEN** — core (P1/P2) implemented; P3 deferred; **POSSIBLY OBSOLETE** (see banner). Not closed out: kept open pending a product decision.  
 **Input**: User description: "Specify removing generated project source views and app-created links/folders without touching original Inventory data."
 
-## Implementation Status: IMPLEMENTED
+> ⚠ **POSSIBLY OBSOLETE (2026-07-03) — the generation path this feature manages was dropped.**
+> This spec's remove/regenerate machinery is fully built and wired, but the app
+> no longer has any path that **creates** a generated source view: source-view
+> generation was tied to project-lifecycle **preparation**, which the 041 inbox
+> single-type + 043 redesign work **removed** ("drop session lifecycle"). In a
+> real DB `preparedview.list` therefore returns empty and `SourceViewsSection`
+> shows its empty state (matching 043's "no junction/source-views shown"). The
+> remove/regenerate feature is consequently **vestigial**. This spec is kept
+> **open** with its P3 work deferred until a product decision: either (a) restore
+> a generation path and finish P3, or (b) formally retire the source-view feature
+> and mark this spec Superseded. Do not close as Implemented until that decision.
+
+## Implementation Status: core built (P1/P2); vestigial pending decision
 
 Core persistence (migration 0029), domain types, persistence repository,
 app-core use cases, contract DTOs, Tauri commands, and frontend helpers
-(source-views.ts + SourceViewsSection) are implemented.
+(source-views.ts + SourceViewsSection) are implemented — but see the
+POSSIBLY-OBSOLETE banner above: there is no live source-view *generation* path,
+so this surface currently has nothing to act on.
 
 Deferred/partial items (see tasks.md):
 - T005 cross-platform per-item apply: SourceViewRemove plan is created; the

--- a/specs/SPEC_STATUS.md
+++ b/specs/SPEC_STATUS.md
@@ -4,6 +4,10 @@
 
 Last reconciled: **2026-06-23** (full sweep). **2026-07-03**: 043 list-page
 consistency + mock-mode E2E test redo landed (see the 043 row + CI note below).
+**2026-07-03 (later)**: `redesign-ui-platevault` reconciled with its pushed
+remote (041 single-type impl + 046/037/#360 merged); CI re-enabled; verified
+against code — 041 iter-2 is implemented on the branch, 017 has UI. See the
+updated 041 / 017 rows and the CI note.
 
 > The per-spec `Status:` line in each `spec.md` had drifted badly — most still read
 > "Draft" despite shipping. This document is the reconciled source of truth. Status
@@ -31,27 +35,27 @@ consistency + mock-mode E2E test redo landed (see the 043 row + CI note below).
 | 003 first-run-source-setup | ✅ Implemented | 32/32 (via 027/029) |
 | 004 native-filesystem-controls | ✅ Implemented | 32/32 |
 | 005 inbox-mixed-folder-split | 🔴 Superseded by 041 | 0/51; reassigned to 041 single-type model — **not yet implemented** (PR #315 docs-only) |
-| 006 inventory-library-lifecycle | 🟡 Closeout-ready | 28/43; 14/15 open tasks DEFERRED |
-| 007 calibration-matching-rules | 🟡 Closeout-ready | 31/42; all 11 open tasks DEFERRED (JSON-schema test runner absent) |
+| 006 inventory-library-lifecycle | ✅ Implemented (closed 2026-07-03) | Core + 041/043/040 reconciliation landed; 12 open tasks all DEFERRED (Playwright-in-WSL, docs, additive-contract, spec-002-blocked enum snapshot) |
+| 007 calibration-matching-rules | ✅ Implemented (closed 2026-07-03) | Engine + adapters + DTOs shipped; 11 open all DEFERRED — 8 contract-tests (JSON-Schema runner absent), T040 (spec-002 enum), T032/T033 polish. `require_same_offset` **exists** in Rust; only the 043 Settings toggle's persistence is stubbed |
 | 008 project-create-onboard-edit | 🟡 Partial | 28/38; ~6 real-open |
 | 009 project-lifecycle-model | ✅ Implemented | 21/21 |
 | 010 guided-first-project-flow | 🟡 Near-complete | 31/33 |
-| 011 processing-tool-launch | 🟡 Partial | 24/29 |
+| 011 processing-tool-launch | ✅ Implemented (closed 2026-07-03) | Launch pipeline + UI + cwd-guard + detach/pid shipped & tested; T021 hint + X-1/X-2 done in closeout; 2 open (T018 Playwright, T022 real-spawn) DEFERRED (WSL/sandbox-blocked). Unblocks 012 |
 | 012 processing-artifact-observation | 🟡 Partial | 26/36 (follows 011) |
 | 013 target-lookup-from-fits-object | 🟡 Near-complete | 18/21 (largely folded into 035) |
 | 014 catalog-index-licensing | 🔴 Superseded by 035 | download-catalog mechanism abandoned; attribution model retained |
 | 015 token-pattern-builder | 🟡 Mockup only | 0/0 tasks |
 | 016 source-protection-defaults | 🟡 Near-complete | 17/20 (underpins 017) |
-| 017 cleanup-archive-review-plans | 🟠 Backend done, UI open | **19 real-open** |
+| 017 cleanup-archive-review-plans | 🟡 Backend done; Archive UI shipped, cleanup-review UI remainder open | Backend + archive/trash executor done; Archive UI exists (`features/archive/ArchivePage/List/Detail`). Remaining open work is the cleanup-plan *review* UI (contextual per v4), not greenfield — earlier "19 real-open / UI open" overstated it |
 | 018 settings-configuration-model | ✅ Reconciled + implemented (#348) | 42/46; spec reconciled to as-built scope/values architecture; backend + UI shipped & verified (live T034 walkthrough); 4 obsolete (contracts mirror, 014 key); open: FR-006↔043 density tension (cross-spec decision) |
-| 019 bottom-log-viewer | 🟡 Near-complete | 30/34 |
+| 019 bottom-log-viewer | ✅ Implemented (closed 2026-07-03) | Panel + backend + forwarder shipped; closeout added T006/T011 jsdom tests + T029 docs index + fixed dotted `log.recent`→`log_recent` binding bug; 1 open (T028 Playwright quickstart) DEFERRED (needs Tauri runtime host) |
 | 020 router-url-state | ✅ Implemented | 22/23 |
 | 021 developer-contract-diagnostics | 🟡 Partial | 32/37 (behind `dev-tools` feature) |
 | 022 mantine-prototype-design-system | 🔴 Superseded by 027 | |
 | 023 target-identity-history-notes | ✅ Implemented on gen-3 | US1 identity/aliases + US2 linked sessions + US3 linked projects + US4 observing notes shipped (migration 0048 + `target.sessions.list`/`target.projects.list`/`target.note.*`). `target.primary.rename` dropped; gen-2 Foundations obsolete |
 | 024 project-manifests-and-notes | 🟡 Closeout-ready | 32/37; all 5 open tasks DEFERRED |
 | 025 filesystem-plan-application | 🟡 Partial (out-of-spec) | Real apply shipped via 041; rollback + progress UI open |
-| 026 generated-source-view-removal | 🟡 Likely obsolete | 12/23; removal happened |
+| 026 generated-source-view-removal | 🟡 OPEN — core built, POSSIBLY OBSOLETE | 12/23; remove/regenerate feature fully wired but **vestigial** — no live source-view *generation* path after the 041/043 lifecycle-prep drop. Kept **open** (not closed): P3 (T014–T020 stale-detection + audit) deferred; awaiting product decision to restore generation or retire the surface |
 | 027 frontend-implementation | ✅ Implemented | 99/99 |
 | 028 frontend-quality-hardening | 🟡 Placeholder | 9/15 |
 | 029 tauri-backend-wiring | ✅ Implemented | 52/52 |
@@ -66,9 +70,9 @@ consistency + mock-mode E2E test redo landed (see the 043 row + CI note below).
 | 038 wizard-scan-step | ✅ Implemented | merged (no committed tasks.md) |
 | 039 cross-root-inbox | ⚪ Not started | no plan/tasks; 041 base now on main |
 | 040 calibration-masters-detection | ✅ Implemented | validated end-to-end 2026-06-23 |
-| 041 inbox-plan-surface | ✅ iteration-1 / 🔵 iteration-2 in progress | iter-1 (confirm + plan surface + apply + destination model) shipped 59/59. iter-2 (single-type sub-items, T061–T080) is **being implemented by another agent** on `041-single-type-*` branches — docs/task-scaffolding present, no crate schema on `main` yet. Supersedes 005 |
+| 041 inbox-plan-surface | ✅ iteration-1 / 🟡 iteration-2 implemented on `redesign-ui-platevault` (pending merge to main) | iter-1 (confirm + plan surface + apply + destination model) shipped 59/59. **iter-2 (single-type sub-items, T061–T081) is now implemented with tests on `redesign-ui-platevault`** — migration `0049_inbox_single_type.sql`, real missing-mandatory gate (`inbox/confirm.rs` sentinel), field-agnostic `reclassify_v2` (`inbox/reclassify.rs`), `build_frame_metadata` grouping (`inbox/classify.rs`), split/mixed confirm action removed from the contract. **Not yet on `main`** — lands with PR #349. Supersedes 005 |
 | 042 stdlib-adoption | ✅ Implemented | 80/97; reconciled #310 |
-| 043 ui-redesign-platevault | 🔵 Active | Ongoing on `redesign-ui-platevault`. List-page consistency landed (#360): all four list pages (Projects/Targets/Sessions/Calibration) flat-by-default, group headers unified onto shared `.alm-listgroup`, global font enforced (only `reset.css`). Sessions E2E specs redone for the flat table (#364). |
+| 043 ui-redesign-platevault | 🔵 Active (foundation + round-2 done; PR #349 mergeable) | Ongoing on `redesign-ui-platevault`. Foundation + per-page round-2 verified against code: 4-theme tokens + Appearance picker, shared `<SortHeader>`/`.alm-sorth`, flat-by-default `.alm-listgroup` on all 4 list pages (#360), `InfoTip`/`SettingsKit`, Inbox bottom inspector, `eslint no-restricted-syntax` style-ban wired into lint. PENDING: Archive single-column, full Sessions inbox-parity, pill-system unification, resizable splitters, Settings per-pane polish. STUBs (all `// STUB:`-marked, blocked on backend): offset Settings-toggle **persistence** (the Rust `require_same_offset` field already exists in `calibration/core/ranking.rs`; only the settings-key wiring is stubbed), channel model, `altitudeCurve()`@52.1°N, Targets list enrichment (#54), + Outputs/Cleanup, audit-history endpoint. Known gap: Sessions table sortable but `aria-sort` not emitted (a11y follow-up). PR #349 → main is **mergeable** (3 behind main). |
 | 044 targets-planner-astronomy | ⚪ Placeholder | frontend mocked; needs research-led astronomy engine |
 | 045 review-state-real | 🔴 Superseded by 041 | |
 | 046 i18n-error-codes | ✅ Implemented | 36/36 (#311–#314) |
@@ -84,25 +88,25 @@ FOUNDATION (all ✅ — nothing blocked here)
 INBOX CHAIN
   005 mixed-folder 🔴 ─▶ 041 inbox-plan-surface ✅ ─┬─▶ 039 cross-root-inbox ⚪
   038 wizard-scan ✅                                ├─▶ 025 plan-application 🟡 (rollback+progress UI)
-  016 protection 🟡 ─▶ 017 cleanup/archive 🟠 ──────┼─▶ 033 validation-bugfix 🟡 (needs 017 generator)
+  016 protection 🟡 ─▶ 017 cleanup/archive 🟡 ──────┼─▶ 033 validation-bugfix 🟡 (needs 017 generator)
                                                     └───┘
 
 TARGETS CHAIN
   013 fits-lookup 🟡 ┐
   014 catalog 🔴 ────┴─▶ 035 SIMBAD ✅ ─┬─▶ 036 retire-legacy ✅
                                         ├─▶ 023 target-identity ⚪ (tasks not generated)
-                                        └─▶ 006 sessions 🟡 ─▶ 044 planner-astronomy ⚪
+                                        └─▶ 006 sessions ✅ ─▶ 044 planner-astronomy ⚪
 
 CALIBRATION CHAIN
-  006 inventory/sessions 🟡 ─▶ 007 matching-rules 🟡 ─▶ 040 masters ✅
+  006 inventory/sessions ✅ ─▶ 007 matching-rules ✅ ─▶ 040 masters ✅
 
 PROJECTS CHAIN
   006 inventory ─▶ 008 project-create 🟡 ─▶ 009 lifecycle ✅ ─▶ 010 guided-flow 🟡
-                       └─▶ 024 manifests/notes 🟡
-                  011 tool-launch 🟡 ─▶ 012 artifact-observation 🟡
+                       └─▶ 024 manifests/notes ✅
+                  011 tool-launch ✅ ─▶ 012 artifact-observation 🟡
 
 INFRA / CROSS-CUTTING (mostly independent)
-  018 settings ✅   021 dev-diagnostics 🟡   019 log-viewer 🟡
+  018 settings ✅   021 dev-diagnostics 🟡   019 log-viewer ✅
   046 i18n ✅   042 stdlib ✅   043 ui-redesign 🔵
   037 e2e 🟠 ◀── now gated only on sessions.transition + tauri-driver (search/sessions/calibration are real)
   037 ipc-removal 🟡 (~8/15; Phases 1–2 shipped)
@@ -112,12 +116,12 @@ INFRA / CROSS-CUTTING (mostly independent)
 
 | Priority | Spec | Why ready | Size |
 |---|---|---|---|
-| 1 | **017 cleanup/archive review UI** | Backend + plan model (041) done; 016 nearly done | 🟠 Large (19 open) |
+| 1 | **017 cleanup-plan review UI** (remainder) | Backend + plan model (041) done; Archive UI shipped; 016 nearly done | 🟡 Medium (cleanup-review UI remainder) |
 | 2 | **025 plan-application** (rollback + progress UI) | Apply backend already shipped via 041 | 🟡 Medium |
 | 2 | **039 cross-root-inbox** | Greenfield; 041 base on main; needs plan/tasks | 🟡 Medium |
 | 2 | **037 ipc-wrapper-removal** (Phase 3–4) | Phases 1–2 already shipped; finish repointing `@/api/commands` importers | 🟡 Medium (~7 left) |
-| 3 | **011 → 012** tool-launch then artifact-observation | 011 unblocked; 012 follows | 🟡 Medium |
-| 3 | **008 project-create** | 006 inventory closeout-ready | 🟡 Medium |
+| 3 | **012 artifact-observation** | 011 tool-launch now closed; 012's deps (`launch_id`, `completed_at`, accordion) satisfied | 🟡 Medium |
+| 3 | **008 project-create** | 006 inventory closed | 🟡 Medium |
 | 3 | **021 dev-diagnostics** | Independent, behind `dev-tools` flag | 🟡 Small |
 | 3 | **023 target-identity** | 035 done; needs `/speckit.tasks` to generate tasks | ⚪ Plan exists, 0 tasks |
 | active | **043 ui-redesign** | In progress on current branch | 🔵 Ongoing |
@@ -126,7 +130,7 @@ INFRA / CROSS-CUTTING (mostly independent)
 
 ## Closeout-ready (verify pass, not new work)
 
-**006, 007, 024** — open tasks are all DEFERRED, not unstarted. Run `speckit-verify`, then flip `Status:` to Implemented.
+**Closed 2026-07-03:** 006, 007, 011, 019 flipped to Implemented after code-verified closeout (deferred tails documented; 011 T021 + 019 T006/T011/T029 + the `log_recent` bug done this session). 024 was closed earlier via #357. **026** deliberately kept **open** (vestigial/possibly-obsolete — product decision pending). No verify-flip work remains in this group.
 
 ## Blocked / not-yet-actionable
 
@@ -189,9 +193,7 @@ Per-spec review of plan/research/data-model/contracts/tasks vs shipped code.
   pre-redesign `.alm-sessions-table__group` header, but #360 renamed it to `.alm-listgroup` AND made
   Sessions flat-by-default (no group rows unless grouped), so both tests failed. Fixed to assert on
   `.alm-sessions-table__row`; full mock-mode Playwright suite now 9 passed / 1 skipped.
-- **CI test-disable `45f8bb3` is now over-broad + unpushable.** It blanket-disables ALL test jobs
-  ("#356 pending redesign test redo"), but the mock-Playwright E2E now passes (#364), frontend unit
-  tests pass (404), and Real-UI E2E passes — so the disable mostly discards *working* coverage.
-  It also remains **unpushed** because the token lacks the `workflow` scope, which blocks pushing the
-  local `redesign-ui-platevault` branch (44+ commits ahead of origin). Prefer reverting the disable
-  (re-enable CI) over pushing it; needs a `workflow`-scoped push or a web-UI edit.
+- **CI test-disable (#356) — RESOLVED 2026-07-03.** The blanket `if: false` disable of all test
+  jobs was removed and CI re-enabled on `redesign-ui-platevault` (commit `9a6c49a4`); tests are green
+  (974 frontend vitest, `app_core_targets` 79). Pushed via `gh`'s `workflow`-scoped token
+  (`gh auth setup-git` — git's stored OAuth credential lacked the scope).


### PR DESCRIPTION
## What & why

Two small user-facing improvements plus a spec-status reconciliation, all verified.

- **Tool launch:** the first time you launch a tool that has no folder-chooser, a one-time dismissible hint explains that it opens with its working directory anchored to the project root (persisted per-tool so it shows once).
- **Log panel:** the initial history no longer silently fails to load when the panel opens — the backfill went through a command name the real backend rejected; it now uses the generated `log_recent` binding.
- Added log-panel unit tests (expand/collapse, level filter, follow-tail scroll) and tool-launch hint tests.

## Verification

- Frontend suite: **993/993** pass (incl. the new tests) · `just typecheck` clean.
- No Rust/backend files touched.

## Spec context (not changelog)

Closes out and reconciles spec status after a verification pass:
- **006** inventory-lifecycle, **007** calibration-matching, **011** tool-launch, **019** log-viewer → flipped to **Implemented** (deferred tails documented — env-blocked Playwright/real-spawn, doc/perf polish, JSON-schema contract-test runner).
- **026** source-view-removal → kept **open** with a *possibly-obsolete* banner (its generation path was dropped by the 041/043 lifecycle-prep removal; awaits a product decision).
- `SPEC_STATUS.md` rows / DAG / frontier reconciled; 011 T021 + 019 T006/T011 implemented; 019 `log_recent` hydration bug fixed.