### PR TITLE
feat(037): migrate shell area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -3,7 +3,8 @@ import { m } from '@/lib/i18n';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { Command } from 'cmdk';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
-import { searchGlobal, getSettings } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import { openInNewWindow } from '@/lib/window';
 import { useHotkeys } from '@/lib/useHotkeys';
 import type { SearchResult } from '@/bindings/types';
@@ -52,7 +53,9 @@ export function CommandPalette() {
   // Load devMode from backend settings on mount (spec 021 T013).
   useEffect(() => {
     let cancelled = false;
-    getSettings({ scope: 'advanced' })
+    commands
+      .settingsGet('advanced')
+      .then(unwrap)
       .then((data) => {
         if (cancelled) return;
         const vals = data.values as Record<string, unknown>;
@@ -88,9 +91,12 @@ export function CommandPalette() {
     const controller = new AbortController();
     // Debounce search by 200ms to avoid excessive API calls
     const timeoutId = setTimeout(() => {
-      void searchGlobal({ query }).then((r) => {
-        if (!controller.signal.aborted) setResults(r);
-      });
+      void commands
+        .searchGlobal(query)
+        .then(unwrap)
+        .then((r) => {
+          if (!controller.signal.aborted) setResults(r);
+        });
     }, 200);
     return () => {
       clearTimeout(timeoutId);

--- a/apps/desktop/src/app/LogPanel.tsx
+++ b/apps/desktop/src/app/LogPanel.tsx
@@ -25,7 +25,8 @@ import {
   type LogEntrySource,
 } from '@/data/logStore';
 import { startLogSubscription } from '@/data/logSubscription';
-import { logExport } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import type { LevelFilter } from './LogPanelContext';
 import { errMessage } from '@/lib/errors';
 import { formatTimeOfDay } from '@/lib/datetime';
@@ -221,12 +222,9 @@ export function LogPanel() {
         return;
       }
 
-      await logExport({
-        requestId,
-        filePath,
-        format: 'json',
-        includeDiagnostics: showDiagnostics,
-      });
+      unwrap(
+        await commands.logExport(requestId, filePath, 'json', null, null, null, showDiagnostics),
+      );
     } catch (err) {
       setExportError(errMessage(err));
     }

--- a/apps/desktop/src/app/LogPanelContext.tsx
+++ b/apps/desktop/src/app/LogPanelContext.tsx
@@ -17,7 +17,8 @@ import {
   useCallback,
   type ReactNode,
 } from 'react';
-import { getSettings, updateSettings } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import type { LogLevel, LogEntrySource } from '@/data/logStore';
 
 export type LevelFilter = 'all' | LogLevel;
@@ -59,7 +60,9 @@ export function LogPanelProvider({ children }: { children: ReactNode }) {
 
   // Load persisted settings on mount (T012, T032).
   useEffect(() => {
-    getSettings({ scope: 'advanced' })
+    commands
+      .settingsGet('advanced')
+      .then(unwrap)
       .then((data) => {
         const vals = data.values as Record<string, unknown>;
         if (vals?.logLevel && typeof vals.logLevel === 'string') {
@@ -88,7 +91,7 @@ export function LogPanelProvider({ children }: { children: ReactNode }) {
   const setFollowLogs = useCallback((v: boolean) => {
     setFollowLogsState(v);
     // Persist via settings.update (spec 018).
-    void updateSettings({ scope: 'advanced', values: { rememberFollowLogs: v } });
+    void commands.settingsUpdate('advanced', { rememberFollowLogs: v }).then(unwrap);
   }, []);
 
   return (

--- a/apps/desktop/src/bindings/aliases.ts
+++ b/apps/desktop/src/bindings/aliases.ts
@@ -24,12 +24,15 @@ export type {
   TargetOpError_Serialize as TargetOpError,
 
   // ── SIMBAD resolution (spec 035) ──────────────────────────────────────────
-  TargetSearchRequest_Serialize as TargetSearchRequest,
-  TargetSearchResponse_Deserialize as TargetSearchResponse,
-  TargetSuggestion_Deserialize as TargetSuggestion,
-  TargetResolveSimbadRequest_Serialize as TargetResolveSimbadRequest,
-  TargetResolveSimbadResponse_Deserialize as TargetResolveSimbadResponse,
-  ResolvedTarget_Deserialize as ResolvedTarget,
+  // Request params → _Deserialize (what the backend deserializes from us);
+  // response payloads → _Serialize (what the backend serializes back to us).
+  // These 6 were inverted (spec 037 fix): see command signatures in ./index.
+  TargetSearchRequest_Deserialize as TargetSearchRequest,
+  TargetSearchResponse_Serialize as TargetSearchResponse,
+  TargetSuggestion_Serialize as TargetSuggestion,
+  TargetResolveSimbadRequest_Deserialize as TargetResolveSimbadRequest,
+  TargetResolveSimbadResponse_Serialize as TargetResolveSimbadResponse,
+  ResolvedTarget_Serialize as ResolvedTarget,
 
   // ── Manifests (spec 026 / 008) ─────────────────────────────────────────────
   ManifestListRequest_Deserialize as ManifestListRequest,

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
@@ -22,14 +22,27 @@ const { mockSearchTargets, mockResolveTarget } = vi.hoisted(() => ({
   mockResolveTarget: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  searchTargets: mockSearchTargets,
-  resolveTarget: mockResolveTarget,
-  TARGET_SEARCH_CONTRACT_VERSION: '1.0',
+// Mock the generated bindings: adapt each hoisted mock's raw response into the
+// generated `{ status: 'ok', data }` Result shape the real `unwrap` consumes,
+// so the existing mockResolvedValue/mockRejectedValue sites stay unchanged.
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetSearch: (req: unknown) =>
+      Promise.resolve(mockSearchTargets(req)).then((data) => ({ status: 'ok', data })),
+    targetResolve: (req: unknown) =>
+      Promise.resolve(mockResolveTarget(req)).then((data) => ({ status: 'ok', data })),
+  },
+}));
+
+vi.mock('@/api/ipc', () => ({
+  unwrap: <T,>(r: { status: string; data?: T; error?: unknown }) => {
+    if (r.status === 'error') throw r.error;
+    return r.data as T;
+  },
 }));
 
 import { TargetSearch } from './TargetSearch';
-import type { TargetSuggestion, ResolvedTarget } from '@/api/commands';
+import type { TargetSuggestion, ResolvedTarget } from '@/bindings/aliases';
 
 /** Build an `unresolved` resolve response (the offline / disabled default). */
 function unresolved(reason = 'offline') {

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
@@ -45,12 +45,9 @@ import { useCallback, useEffect, useId, useMemo, useRef, useState } from 'react'
 import { Combobox } from '@base-ui-components/react/combobox';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useDebouncedCallback } from 'use-debounce';
-import {
-  searchTargets,
-  resolveTarget,
-  TARGET_SEARCH_CONTRACT_VERSION,
-} from '@/api/commands';
-import type { TargetSuggestion, ResolvedTarget } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { TargetSuggestion, ResolvedTarget } from '@/bindings/aliases';
 import type { TargetCatalogId, TargetObjectType } from '@/bindings/index';
 import { Pill } from '@/ui';
 import { m } from '@/lib/i18n';
@@ -62,6 +59,12 @@ import {
 } from './objectType';
 
 // ── Constants ────────────────────────────────────────────────────────────────
+
+/**
+ * Contract version for the target.search / target.resolve requests. Moved here
+ * off the retired @/api/commands wrapper (spec 037 FR-004: move, not drop).
+ */
+const TARGET_SEARCH_CONTRACT_VERSION = '1.0';
 
 const DEBOUNCE_MS = 300;
 const DEFAULT_LIMIT = 20;
@@ -228,14 +231,16 @@ export function TargetSearch({
 
       // ── Phase 1: local seed + cache (instant) ──────────────────────────────
       try {
-        const res = await searchTargets({
-          contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
-          requestId: crypto.randomUUID(),
-          query: trimmed,
-          catalogFilter: effectiveCatalogFilter,
-          typeFilter: effectiveTypeFilter,
-          limit,
-        });
+        const res = unwrap(
+          await commands.targetSearch({
+            contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+            requestId: crypto.randomUUID(),
+            query: trimmed,
+            catalogFilter: effectiveCatalogFilter,
+            typeFilter: effectiveTypeFilter,
+            limit,
+          }),
+        );
         if (!isCurrent()) return; // superseded — drop stale result
         setSuggestions(res.suggestions);
       } catch {
@@ -253,20 +258,21 @@ export function TargetSearch({
 
       setResolving(true);
       try {
-        const res = await resolveTarget({
-          contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
-          requestId: crypto.randomUUID(),
-          query: trimmed,
-          override: null,
-        });
+        const res = unwrap(
+          await commands.targetResolve({
+            contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+            requestId: crypto.randomUUID(),
+            query: trimmed,
+            override: null,
+          }),
+        );
         // Cancel-in-flight guard: a newer query must not be overwritten.
         if (!isCurrent()) return;
         if (res.status === 'resolved' && res.target) {
           // Merge against the current list (the Phase-1 local hits for this
           // generation) so the long-tail row is appended, never duplicated.
-          setSuggestions((prev) =>
-            mergeDedupe(prev, resolvedToSuggestion(res.target as ResolvedTarget)),
-          );
+          const resolved = res.target;
+          setSuggestions((prev) => mergeDedupe(prev, resolvedToSuggestion(resolved)));
         }
         // `unresolved` (unknown / offline / resolver-disabled) is non-fatal:
         // leave the local hits untouched and surface no error (FR-011/FR-015).
@@ -317,12 +323,14 @@ export function TargetSearch({
       setOverriding(s.targetId);
       setError(null);
       try {
-        const res = await resolveTarget({
-          contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
-          requestId: crypto.randomUUID(),
-          query: trimmed,
-          override: { targetId: s.targetId },
-        });
+        const res = unwrap(
+          await commands.targetResolve({
+            contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+            requestId: crypto.randomUUID(),
+            query: trimmed,
+            override: { targetId: s.targetId },
+          }),
+        );
         const result: TargetSuggestion =
           res.status === 'resolved' && res.target
             ? resolvedToSuggestion(res.target)

--- a/apps/desktop/src/ui/LogPanel.crosslink.test.tsx
+++ b/apps/desktop/src/ui/LogPanel.crosslink.test.tsx
@@ -20,13 +20,18 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-vi.mock('@/api/commands', () => ({
-  getSettings: vi.fn().mockResolvedValue({
-    scope: 'advanced',
-    values: { logLevel: 'info', rememberFollowLogs: false },
-  }),
-  updateSettings: vi.fn().mockResolvedValue(undefined),
-  logExport: vi.fn().mockResolvedValue({ contractVersion: '2.0.0', requestId: 'r', filePath: '/tmp/x.json', count: 0, status: 'success' }),
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: vi.fn().mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'advanced', values: { logLevel: 'info', rememberFollowLogs: false } },
+    }),
+    settingsUpdate: vi.fn().mockResolvedValue({ status: 'ok', data: null }),
+    logExport: vi.fn().mockResolvedValue({
+      status: 'ok',
+      data: { contractVersion: '2.0.0', requestId: 'r', filePath: '/tmp/x.json', count: 0, status: 'success' },
+    }),
+  },
 }));
 
 vi.mock('@/data/logSubscription', () => ({

--- a/apps/desktop/src/ui/LogPanel.followState.test.tsx
+++ b/apps/desktop/src/ui/LogPanel.followState.test.tsx
@@ -17,9 +17,15 @@ const mockGetSettings = vi.fn().mockResolvedValue({
 });
 const mockUpdateSettings = vi.fn().mockResolvedValue(undefined);
 
-vi.mock('@/api/commands', () => ({
-  getSettings: (...args: unknown[]) => mockGetSettings(...args),
-  updateSettings: (...args: unknown[]) => mockUpdateSettings(...args),
+// Adapt each hoisted mock's raw settings payload into the generated
+// `{ status: 'ok', data }` Result the real `unwrap` consumes (spec 037).
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: (...args: unknown[]) =>
+      Promise.resolve(mockGetSettings(...args)).then((data) => ({ status: 'ok', data })),
+    settingsUpdate: (...args: unknown[]) =>
+      Promise.resolve(mockUpdateSettings(...args)).then((data) => ({ status: 'ok', data })),
+  },
 }));
 
 // ── Test helper component ─────────────────────────────────────────────────────
@@ -56,7 +62,7 @@ describe('LogPanel follow state (T010)', () => {
     await waitFor(() => {
       expect(getByTestId('follow-state').textContent).toBe('on');
     });
-    expect(mockGetSettings).toHaveBeenCalledWith({ scope: 'advanced' });
+    expect(mockGetSettings).toHaveBeenCalledWith('advanced');
   });
 
   it('defaults to follow=false when settings returns false', async () => {
@@ -94,9 +100,8 @@ describe('LogPanel follow state (T010)', () => {
     fireEvent.click(getByRole('button', { name: 'toggle' }));
 
     await waitFor(() => {
-      expect(mockUpdateSettings).toHaveBeenCalledWith({
-        scope: 'advanced',
-        values: { rememberFollowLogs: true },
+      expect(mockUpdateSettings).toHaveBeenCalledWith('advanced', {
+        rememberFollowLogs: true,
       });
     });
   });


### PR DESCRIPTION
## Summary
Spec 037 Phase-3 caller migration for the **shell** area: repoints off the hand-written `@/api/commands` `invoke()` wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`), eliminating the IPC name/payload drift-bug class.

app-shell (CommandPalette, LogPanel/Context, TargetSearch + ui/components tests). Includes the bindings/aliases.ts SIMBAD Serialize/Deserialize direction fix.

Verified locally: `tsc --noEmit` clean; area vitest green; `eslint` 0 errors (pre-existing warnings only). Follows the merged calibration (#359) / plans (#368) / sessions (#369) pattern.

## Spec Context
- Spec: 037
- Branch: 037-shell