### PR TITLE
feat(037): migrate settings area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/features/settings/Advanced.tsx
+++ b/apps/desktop/src/features/settings/Advanced.tsx
@@ -4,7 +4,7 @@
 // spec 010 — Guided flow restart control added (T042).
 import { useState, useEffect } from 'react';
 import { Btn } from '@/ui';
-import { getSettings } from '@/api/commands';
+import { getSettings } from './settingsIpc';
 import { getGuidedState, restartGuidedFlow, type GuidedFlowStateDto } from '@/features/guided/store';
 import { STEP_ORDER } from '@/features/guided/store';
 import { m } from '@/lib/i18n';

--- a/apps/desktop/src/features/settings/CalibrationMatching.tsx
+++ b/apps/desktop/src/features/settings/CalibrationMatching.tsx
@@ -21,8 +21,8 @@ import { SettingsSection, RestoreDefaultsBtn } from './SettingsKit';
 import {
   calibrationTolerancesGet,
   calibrationTolerancesUpdate,
-} from '@/api/commands';
-import type { UpdateCalibrationTolerances } from '@/api/commands';
+} from './settingsIpc';
+import type { UpdateCalibrationTolerances } from './settingsIpc';
 
 interface CalibrationMatchingProps {
   /** Unused in this pane — tolerances use their own IPC commands. Kept for

--- a/apps/desktop/src/features/settings/Cleanup.tsx
+++ b/apps/desktop/src/features/settings/Cleanup.tsx
@@ -8,7 +8,7 @@
 // defaults and the locked/unlocked flags. (T061 FR-024)
 import { useState, useEffect, Fragment } from 'react';
 import { Toggle, SegControl, Pill, Banner } from '@/ui';
-import { getSettings } from '@/api/commands';
+import { getSettings } from './settingsIpc';
 import { CLEANUP_TYPES, CLEANUP_STAGE_ORDER, type CleanupTypeFixture } from '@/data/fixtures/settings';
 import { m } from '@/lib/i18n';
 import { SettingsSection, SettingsRow, RestoreDefaultsBtn } from './SettingsKit';

--- a/apps/desktop/src/features/settings/DataSources.tsx
+++ b/apps/desktop/src/features/settings/DataSources.tsx
@@ -3,7 +3,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { Btn, Pill } from '@/ui';
 import { DirPicker } from '@/ui/DirPicker';
-import { listRoots, registerRoot, startScan, settingsSourceOverrideSet, settingsOverridableKeys } from '@/api/commands';
+import { listRoots, registerRoot, startScan, settingsSourceOverrideSet, settingsOverridableKeys } from './settingsIpc';
 import type { LibraryRoot } from '@/bindings/types';
 import type { RootCategory } from '@/bindings/index';
 import { errMessage } from '@/lib/errors';

--- a/apps/desktop/src/features/settings/NamingStructure.tsx
+++ b/apps/desktop/src/features/settings/NamingStructure.tsx
@@ -15,7 +15,7 @@ import {
 	patternPreview,
 	patternValidate,
 	updateSettings,
-} from "@/api/commands";
+} from "./settingsIpc";
 import { Btn } from "@/ui";
 import { m } from "@/lib/i18n";
 import { SettingsSection, SettingsRow, RestoreDefaultsBtn } from "./SettingsKit";
@@ -854,7 +854,7 @@ export function NamingStructure({ save }: NamingStructureProps) {
 				setValidateResult({
 					valid: resp.valid,
 					warnings: resp.warnings,
-					errorCode: resp.errorCode,
+					errorCode: resp.errorCode ?? undefined,
 				});
 			})
 			.catch(() => {

--- a/apps/desktop/src/features/settings/ProcessingTools.tsx
+++ b/apps/desktop/src/features/settings/ProcessingTools.tsx
@@ -20,7 +20,7 @@ import {
   toolValidatePath,
   toolDiscover,
   type ToolProfileSummary,
-} from '@/api/commands';
+} from './settingsIpc';
 import { m } from '@/lib/i18n';
 import { SettingsSection, SettingsRow } from './SettingsKit';
 

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
@@ -16,9 +16,11 @@ const { mockGet, mockUpdate } = vi.hoisted(() => ({
   mockUpdate: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  getResolverSettings: mockGet,
-  updateResolverSettings: mockUpdate,
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetResolutionSettings: mockGet,
+    targetResolutionSettingsUpdate: mockUpdate,
+  },
 }));
 
 import { ResolverSettingsControl } from './ResolverSettingsControl';
@@ -33,9 +35,15 @@ const SETTINGS = {
 beforeEach(() => {
   mockGet.mockReset();
   mockUpdate.mockReset();
-  mockGet.mockResolvedValue({ contractVersion: '1.0', requestId: 'r', settings: SETTINGS });
-  mockUpdate.mockImplementation((settings: unknown) =>
-    Promise.resolve({ contractVersion: '1.0', requestId: 'r', settings }),
+  mockGet.mockResolvedValue({
+    status: 'ok',
+    data: { contractVersion: '1.0', requestId: 'r', settings: SETTINGS },
+  });
+  mockUpdate.mockImplementation((req: { settings: unknown }) =>
+    Promise.resolve({
+      status: 'ok',
+      data: { contractVersion: '1.0', requestId: 'r', settings: req.settings },
+    }),
   );
 });
 
@@ -61,7 +69,7 @@ describe('ResolverSettingsControl', () => {
     });
 
     expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ onlineEnabled: false }),
+      expect.objectContaining({ settings: expect.objectContaining({ onlineEnabled: false }) }),
     );
   });
 

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
@@ -18,7 +18,7 @@ import {
   getResolverSettings,
   updateResolverSettings,
   type ResolverSettings,
-} from '@/api/commands';
+} from './settingsIpc';
 import { m } from '@/lib/i18n';
 import { SettingsRow } from './SettingsKit';
 

--- a/apps/desktop/src/features/settings/SettingsKit.tsx
+++ b/apps/desktop/src/features/settings/SettingsKit.tsx
@@ -1,6 +1,6 @@
 import { useState, type ReactNode } from 'react';
 import { Btn, InfoTip } from '@/ui';
-import { settingsRestoreDefaults, getSettings } from '@/api/commands';
+import { settingsRestoreDefaults, getSettings } from './settingsIpc';
 import { m } from '@/lib/i18n';
 
 /**

--- a/apps/desktop/src/features/settings/SourceProtectionOverride.test.tsx
+++ b/apps/desktop/src/features/settings/SourceProtectionOverride.test.tsx
@@ -8,19 +8,23 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { SourceProtectionOverride } from './SourceProtectionOverride';
-import type { SourceProtectionGetResponse } from '@/api/commands';
+import type { SourceProtectionGetResponse } from './settingsIpc';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
+// Mocks the generated bindings surface (spec 037) so the real `settingsIpc`
+// wrappers (sourceProtectionGet/Set) run and unwrap the Result envelope.
 
-vi.mock('@/api/commands', () => ({
-  sourceProtectionGet: vi.fn(),
-  sourceProtectionSet: vi.fn(),
+const { mockGet, mockSet } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockSet: vi.fn(),
 }));
 
-import { sourceProtectionGet, sourceProtectionSet } from '@/api/commands';
-
-const mockGet = vi.mocked(sourceProtectionGet);
-const mockSet = vi.mocked(sourceProtectionSet);
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    sourceProtectionGet: mockGet,
+    sourceProtectionSet: mockSet,
+  },
+}));
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
@@ -51,7 +55,7 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('shows Protected pill and Inherits global default badge when inheriting', async () => {
-    mockGet.mockResolvedValue(makeGetResponse({ inheritsDefault: true, level: 'protected' }));
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse({ inheritsDefault: true, level: 'protected' }) });
     render(<SourceProtectionOverride sourceId="src-1" />);
 
     await waitFor(() => {
@@ -61,7 +65,7 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('shows override pill without inherits badge when override is set', async () => {
-    mockGet.mockResolvedValue(makeGetResponse({ inheritsDefault: false, level: 'normal' }));
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse({ inheritsDefault: false, level: 'normal' }) });
     render(<SourceProtectionOverride sourceId="src-1" />);
 
     await waitFor(() => {
@@ -72,7 +76,7 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('shows Override button', async () => {
-    mockGet.mockResolvedValue(makeGetResponse());
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse() });
     render(<SourceProtectionOverride sourceId="src-1" />);
 
     await waitFor(() => {
@@ -81,7 +85,7 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('opens editing mode on Override click', async () => {
-    mockGet.mockResolvedValue(makeGetResponse());
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse() });
     render(<SourceProtectionOverride sourceId="src-1" />);
 
     await waitFor(() => screen.getByRole('button', { name: /Override/i }));
@@ -93,16 +97,19 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('saves override and updates level display', async () => {
-    mockGet.mockResolvedValue(makeGetResponse({ level: 'protected', inheritsDefault: true }));
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse({ level: 'protected', inheritsDefault: true }) });
     mockSet.mockResolvedValue({
-      sourceId: 'src-1',
-      priorLevel: 'protected',
-      newLevel: 'normal',
-      priorBlockPermanentDelete: null,
-      newBlockPermanentDelete: null,
-      priorCategories: null,
-      newCategories: null,
-      auditId: 'audit-1',
+      status: 'ok',
+      data: {
+        sourceId: 'src-1',
+        priorLevel: 'protected',
+        newLevel: 'normal',
+        priorBlockPermanentDelete: null,
+        newBlockPermanentDelete: null,
+        priorCategories: null,
+        newCategories: null,
+        auditId: 'audit-1',
+      },
     });
 
     const onSaved = vi.fn();
@@ -136,7 +143,7 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('shows level hint text for protected level', async () => {
-    mockGet.mockResolvedValue(makeGetResponse({ level: 'protected', inheritsDefault: false }));
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse({ level: 'protected', inheritsDefault: false }) });
     render(<SourceProtectionOverride sourceId="src-1" />);
 
     await waitFor(() => {
@@ -145,7 +152,7 @@ describe('SourceProtectionOverride', () => {
   });
 
   it('can cancel edit without saving', async () => {
-    mockGet.mockResolvedValue(makeGetResponse({ level: 'protected', inheritsDefault: true }));
+    mockGet.mockResolvedValue({ status: 'ok', data: makeGetResponse({ level: 'protected', inheritsDefault: true }) });
     render(<SourceProtectionOverride sourceId="src-1" />);
 
     await waitFor(() => screen.getByRole('button', { name: /Override/i }));

--- a/apps/desktop/src/features/settings/SourceProtectionOverride.tsx
+++ b/apps/desktop/src/features/settings/SourceProtectionOverride.tsx
@@ -11,8 +11,8 @@
 
 import { useEffect, useState, useCallback } from 'react';
 import { Pill, Btn } from '@/ui';
-import { sourceProtectionGet, sourceProtectionSet } from '@/api/commands';
-import type { ProtectionLevel } from '@/api/commands';
+import { sourceProtectionGet, sourceProtectionSet } from './settingsIpc';
+import type { ProtectionLevel } from './settingsIpc';
 import { m } from '@/lib/i18n';
 
 interface SourceProtectionOverrideProps {

--- a/apps/desktop/src/features/settings/settings.test.ts
+++ b/apps/desktop/src/features/settings/settings.test.ts
@@ -6,12 +6,14 @@
  * the two new command wrappers settingsRestoreDefaults / settingsSourceOverrideSet.
  *
  * Mock pattern mirrors ResolverSettingsControl.test.tsx: vi.hoisted() + vi.mock().
+ * Mocks the generated bindings surface (spec 037) so the real `settingsIpc`
+ * wrappers run and their arg-shaping is exercised.
  */
 
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { renderHook, act } from '@testing-library/react';
 
-// ── Mock @/api/commands before any module imports it ─────────────────────────
+// ── Mock the generated bindings surface before any module imports it ─────────
 
 const { mockUpdateSettings, mockSettingsRestoreDefaults, mockSettingsSourceOverrideSet } =
   vi.hoisted(() => ({
@@ -20,21 +22,23 @@ const { mockUpdateSettings, mockSettingsRestoreDefaults, mockSettingsSourceOverr
     mockSettingsSourceOverrideSet: vi.fn(),
   }));
 
-vi.mock('@/api/commands', () => ({
-  updateSettings: mockUpdateSettings,
-  settingsRestoreDefaults: mockSettingsRestoreDefaults,
-  settingsSourceOverrideSet: mockSettingsSourceOverrideSet,
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsUpdate: mockUpdateSettings,
+    settingsRestoreDefaults: mockSettingsRestoreDefaults,
+    settingsSourceOverrideSet: mockSettingsSourceOverrideSet,
+  },
 }));
 
 import { useAutoSave } from './useAutoSave';
-import { settingsRestoreDefaults, settingsSourceOverrideSet } from '@/api/commands';
+import { settingsRestoreDefaults, settingsSourceOverrideSet } from './settingsIpc';
 
 // ── useAutoSave ───────────────────────────────────────────────────────────────
 
 describe('useAutoSave', () => {
   beforeEach(() => {
     vi.useFakeTimers();
-    mockUpdateSettings.mockResolvedValue(undefined);
+    mockUpdateSettings.mockResolvedValue({ status: 'ok', data: null });
   });
 
   afterEach(() => {
@@ -63,7 +67,7 @@ describe('useAutoSave', () => {
 
     // Only one call — the last value in the burst.
     expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
-    expect(mockUpdateSettings).toHaveBeenCalledWith({ scope: 'advanced', values: { logLevel: 'warn' } });
+    expect(mockUpdateSettings).toHaveBeenCalledWith('advanced', { logLevel: 'warn' });
   });
 
   it('does not fire updateSettings before the 300ms window elapses', () => {
@@ -114,7 +118,7 @@ describe('useAutoSave', () => {
       await Promise.resolve();
     });
 
-    expect(mockUpdateSettings).toHaveBeenCalledWith({ scope: 'cleanup', values });
+    expect(mockUpdateSettings).toHaveBeenCalledWith('cleanup', values);
   });
 });
 
@@ -123,9 +127,12 @@ describe('useAutoSave', () => {
 describe('settingsRestoreDefaults', () => {
   beforeEach(() => {
     mockSettingsRestoreDefaults.mockResolvedValue({
-      status: 'success',
-      restored: ['logLevel'],
-      alreadyAtDefault: [],
+      status: 'ok',
+      data: {
+        status: 'success',
+        restored: ['logLevel'],
+        alreadyAtDefault: [],
+      },
     });
   });
 
@@ -135,12 +142,14 @@ describe('settingsRestoreDefaults', () => {
 
   it('calls the generated command with a { keys } object', async () => {
     await settingsRestoreDefaults(['logLevel', 'rememberFollowLogs']);
-    expect(mockSettingsRestoreDefaults).toHaveBeenCalledWith(['logLevel', 'rememberFollowLogs']);
+    expect(mockSettingsRestoreDefaults).toHaveBeenCalledWith({
+      keys: ['logLevel', 'rememberFollowLogs'],
+    });
   });
 
   it('passes an empty array to restore all keys', async () => {
     await settingsRestoreDefaults([]);
-    expect(mockSettingsRestoreDefaults).toHaveBeenCalledWith([]);
+    expect(mockSettingsRestoreDefaults).toHaveBeenCalledWith({ keys: [] });
   });
 
   it('returns the RestoreDefaultsResponse from the backend', async () => {
@@ -158,8 +167,11 @@ describe('settingsRestoreDefaults', () => {
 describe('settingsSourceOverrideSet', () => {
   beforeEach(() => {
     mockSettingsSourceOverrideSet.mockResolvedValue({
-      sourceId: 'root-uuid-1',
-      key: 'hashOnScan',
+      status: 'ok',
+      data: {
+        sourceId: 'root-uuid-1',
+        key: 'hashOnScan',
+      },
     });
   });
 

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -12,9 +12,14 @@
 
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
+// `LibraryRoot` is a plain `_Serialize` re-export in `@/bindings/types` (the
+// facade every settings pane already imports it through), NOT the wider
+// `LibraryRoot_Serialize | LibraryRoot_Deserialize` union `@/bindings/index`
+// exports under the same name — importing the union here would widen
+// `listRoots()`'s return type against DataSources.tsx's `LibraryRoot` state.
+import type { LibraryRoot } from '@/bindings/types';
 import type {
   SettingsData,
-  LibraryRoot,
   RestoreDefaultsResponse,
   SetSourceOverrideResponse,
   CalibrationTolerances,

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -1,0 +1,246 @@
+/**
+ * Settings feature IPC helpers (spec 037 caller migration).
+ *
+ * Moves the Settings pane glue off the hand-written `@/api/commands` wrappers
+ * onto the generated `commands.*` bindings (FR-004: behaviour is moved, not
+ * dropped). `unwrap()` turns each generated `Result` into the throw-on-error
+ * contract the panes already rely on. Every settings pane (Advanced, Cleanup,
+ * DataSources, NamingStructure, ProcessingTools, CalibrationMatching,
+ * SourceProtectionOverride, ResolverSettingsControl, useAutoSave, SettingsKit)
+ * imports from this one module.
+ */
+
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type {
+  SettingsData,
+  LibraryRoot,
+  RestoreDefaultsResponse,
+  SetSourceOverrideResponse,
+  CalibrationTolerances,
+  UpdateCalibrationTolerances,
+  ProtectionLevel,
+  SourceProtectionGetResponse,
+  SourceProtectionSetRequest,
+  SourceProtectionSetResponse,
+  ToolProfileListResponse,
+  ToolProfileSummary,
+  ToolDiscoverRequest,
+  ToolDiscoverResponse,
+  UpdateProcessingTool,
+  ToolPathValidation,
+  PatternPartDto,
+  MetadataBundleDto_Serialize as MetadataBundleDto,
+  PatternValidateResponse_Serialize as PatternValidateResponse,
+  PatternPreviewResponse,
+  ResolverSettings,
+  ResolverSettingsResponse,
+  IpcOperationHandle,
+} from '@/bindings/index';
+
+export type {
+  ProtectionLevel,
+  SourceProtectionGetResponse,
+  SourceProtectionSetRequest,
+  SourceProtectionSetResponse,
+  ToolProfileSummary,
+  ResolverSettings,
+};
+export type { PatternPartDto as PatternPart };
+export type { PatternValidateResponse, PatternPreviewResponse };
+export type { UpdateCalibrationTolerances };
+
+// ── Settings scope read/write (spec 018) ──────────────────────────────────────
+
+export async function getSettings(args: { scope: string }): Promise<SettingsData> {
+  return unwrap(await commands.settingsGet(args.scope));
+}
+
+export async function updateSettings(args: {
+  scope: string;
+  values: Record<string, unknown>;
+}): Promise<void> {
+  unwrap(await commands.settingsUpdate(args.scope, args.values));
+}
+
+/**
+ * `settings.restore-defaults` — restore named keys (or all keys when `keys`
+ * is empty) to their default values (spec 018 T028).
+ */
+export async function settingsRestoreDefaults(
+  keys: string[],
+): Promise<RestoreDefaultsResponse> {
+  return unwrap(await commands.settingsRestoreDefaults({ keys }));
+}
+
+/**
+ * `settings.overridable-keys` — return the authoritative list of stable settings
+ * keys that can be overridden per source root (spec 018 T025).
+ *
+ * Falls back to a hardcoded pair when the command fails (forward-compat).
+ */
+export async function settingsOverridableKeys(): Promise<string[]> {
+  try {
+    return unwrap(await commands.settingsOverridableKeys());
+  } catch {
+    // Fallback for older backends or failed calls — matches the formerly hardcoded list.
+    return ['hashOnScan', 'followSymlinks'];
+  }
+}
+
+/**
+ * `settings.source-override.set` — set a per-source settings override
+ * (spec 018 T025).
+ */
+export async function settingsSourceOverrideSet(args: {
+  sourceId: string;
+  key: string;
+  value: unknown;
+}): Promise<SetSourceOverrideResponse> {
+  return unwrap(
+    await commands.settingsSourceOverrideSet({
+      sourceId: args.sourceId,
+      key: args.key,
+      value: args.value,
+    }),
+  );
+}
+
+// ── Data sources / roots (spec 003) ───────────────────────────────────────────
+
+export async function listRoots(): Promise<LibraryRoot[]> {
+  return unwrap(await commands.rootsList());
+}
+
+export async function registerRoot(args: {
+  path: string;
+  category: string;
+  scanSettings: Record<string, unknown>;
+}): Promise<void> {
+  unwrap(await commands.rootsRegister(args.path, args.category, args.scanSettings));
+}
+
+export async function startScan(args?: { root_ids?: string[] }): Promise<IpcOperationHandle> {
+  // Backend expects camelCase `rootIds`; sending `root_ids` is silently ignored
+  // and scans ALL roots instead of the requested subset.
+  return unwrap(await commands.scanStart(args?.root_ids ?? null));
+}
+
+// ── Calibration tolerances (spec 007) ─────────────────────────────────────────
+
+export async function calibrationTolerancesGet(): Promise<CalibrationTolerances> {
+  return unwrap(await commands.calibrationTolerancesGet());
+}
+
+export async function calibrationTolerancesUpdate(
+  request: UpdateCalibrationTolerances,
+): Promise<CalibrationTolerances> {
+  return unwrap(await commands.calibrationTolerancesUpdate(request));
+}
+
+// ── Source protection (spec 016 US2) ──────────────────────────────────────────
+
+/**
+ * `source.protection.get` — resolve effective protection for a source.
+ * Pass `sourceId: null` to retrieve global defaults.
+ */
+export async function sourceProtectionGet(
+  sourceId: string | null,
+): Promise<SourceProtectionGetResponse> {
+  return unwrap(await commands.sourceProtectionGet(sourceId));
+}
+
+/**
+ * `source.protection.set` — set or replace the protection override for a source
+ * (spec 016 US2, T013). Emits a `protection.source.set` audit event.
+ */
+export async function sourceProtectionSet(
+  request: SourceProtectionSetRequest,
+): Promise<SourceProtectionSetResponse> {
+  return unwrap(
+    await commands.sourceProtectionSet(
+      request as Parameters<typeof commands.sourceProtectionSet>[0],
+    ),
+  );
+}
+
+// ── Processing tools (spec 011) ───────────────────────────────────────────────
+
+export async function toolProfileList(): Promise<ToolProfileListResponse> {
+  return unwrap(await commands.toolsList());
+}
+
+export async function toolUpdate(request: UpdateProcessingTool): Promise<ToolProfileSummary> {
+  return unwrap(await commands.toolsUpdate(request));
+}
+
+export async function toolValidatePath(path: string): Promise<ToolPathValidation> {
+  return unwrap(await commands.toolsValidatePath(path));
+}
+
+export async function toolDiscover(request: ToolDiscoverRequest): Promise<ToolDiscoverResponse> {
+  return unwrap(await commands.toolsDiscover(request));
+}
+
+// ── Naming pattern (spec 015) ─────────────────────────────────────────────────
+
+/**
+ * Validate a pattern structurally (no metadata required).
+ * Never rejects — all error states are in the response body.
+ */
+export async function patternValidate(
+  pattern: PatternPartDto[],
+): Promise<PatternValidateResponse> {
+  return unwrap(await commands.patternValidate({ pattern }));
+}
+
+/**
+ * Preview a pattern against sample metadata for the Settings UI live preview.
+ * Applies the same validation and sanitization pipeline as pattern.resolve.
+ */
+export async function patternPreview(
+  pattern: PatternPartDto[],
+  sampleMetadata: MetadataBundleDto,
+): Promise<PatternPreviewResponse> {
+  return unwrap(
+    await commands.patternPreview(
+      { pattern, sampleMetadata } as Parameters<typeof commands.patternPreview>[0],
+    ),
+  );
+}
+
+// ── SIMBAD resolver settings (spec 035, FR-015) ───────────────────────────────
+
+/** Contract version for the spec-035 `target.resolution.settings` commands. */
+const TARGET_SEARCH_CONTRACT_VERSION = '1.0';
+
+/**
+ * `target.resolution.settings` — read the SIMBAD resolver settings
+ * (online toggle, endpoint, debounce, request timeout) (spec 035, FR-015).
+ */
+export async function getResolverSettings(): Promise<ResolverSettingsResponse> {
+  return unwrap(
+    await commands.targetResolutionSettings({
+      contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+      requestId: crypto.randomUUID(),
+      op: 'get',
+    }),
+  );
+}
+
+/**
+ * `target.resolution.settings.update` — persist new resolver settings
+ * (spec 035, FR-015). Returns the saved settings.
+ */
+export async function updateResolverSettings(
+  settings: ResolverSettings,
+): Promise<ResolverSettingsResponse> {
+  return unwrap(
+    await commands.targetResolutionSettingsUpdate({
+      contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+      requestId: crypto.randomUUID(),
+      op: 'update',
+      settings,
+    }),
+  );
+}

--- a/apps/desktop/src/features/settings/useAutoSave.ts
+++ b/apps/desktop/src/features/settings/useAutoSave.ts
@@ -1,5 +1,5 @@
 import { useRef, useCallback, useState } from 'react';
-import { updateSettings } from '@/api/commands';
+import { updateSettings } from './settingsIpc';
 
 /**
  * Auto-save hook with 300ms debounce.


### PR DESCRIPTION
## Summary
Spec 037 Phase-3 caller migration for the **settings** area: repoints off the hand-written `@/api/commands` `invoke()` wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`), eliminating the IPC name/payload drift-bug class.

settings feature (new settingsIpc.ts glue module; 10 panes + 3 tests migrated).

Verified locally: `tsc --noEmit` clean; area vitest green; `eslint` 0 errors (pre-existing warnings only). Follows the merged calibration (#359) / plans (#368) / sessions (#369) pattern.

## Spec Context
- Spec: 037
- Branch: 037-settings