### PR TITLE
feat(037): migrate setup area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -51,10 +51,10 @@ vi.mock('@tanstack/react-router', () => ({
 // Catalog manifest fetch resolves to 'failed' so StepCatalogs renders its
 // graceful unavailable state in these gating tests (download flow is covered
 // in StepCatalogs.test.tsx).
+//
+// StepCatalogs' ResolverSettingsControl still reads @/api/commands directly
+// (out of this migration's scope), so those two mocks stay here.
 vi.mock('@/api/commands', () => ({
-  completeFirstRun: vi.fn().mockResolvedValue({ success: true }),
-  registerRoot: vi.fn().mockResolvedValue({ id: 'mock-root', path: '' }),
-  registerRootBatch: vi.fn().mockResolvedValue({ results: [] }),
   // Repurposed "Target resolution" step reads/writes resolver settings.
   getResolverSettings: vi.fn().mockResolvedValue({
     contractVersion: '1.0',
@@ -69,24 +69,59 @@ vi.mock('@/api/commands', () => ({
   updateResolverSettings: vi.fn().mockImplementation((settings) =>
     Promise.resolve({ contractVersion: '1.0', requestId: 'r', settings }),
   ),
-  // Configuration step also reads/writes the default source-protection setting.
-  getSettings: vi.fn().mockResolvedValue({ values: { defaultProtection: 'protected' } }),
-  updateSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+// spec 037: the wizard, sources-store, StepCatalogs, and StepScan now call
+// generated commands.* bindings + unwrap directly. Mock the bindings surface
+// (Result-shaped responses) and let unwrap really unwrap them.
+// vi.hoisted: vi.mock factories below are hoisted above these declarations.
+const {
+  mockToolsUpdate,
+  mockFirstrunComplete,
+  mockRootsRegisterBatch,
+  mockSettingsGet,
+  mockSettingsUpdate,
+  mockInboxScanFolder,
+  mockInboxClassify,
+} = vi.hoisted(() => ({
+  mockToolsUpdate: vi.fn().mockResolvedValue({
+    status: 'ok',
+    data: {
+      id: 'pixinsight',
+      name: 'PixInsight',
+      enabled: false,
+      configured: false,
+      available: false,
+      supportsOpenFolder: false,
+      autoDetected: false,
+      executablePath: null,
+    },
+  }),
+  mockFirstrunComplete: vi.fn().mockResolvedValue({ status: 'ok', data: { success: true } }),
+  mockRootsRegisterBatch: vi.fn().mockResolvedValue({ status: 'ok', data: { status: 'success', items: [] } }),
+  mockSettingsGet: vi.fn().mockResolvedValue({
+    status: 'ok',
+    data: { values: { defaultProtection: 'protected' } },
+  }),
+  mockSettingsUpdate: vi.fn().mockResolvedValue({ status: 'ok', data: null }),
   // StepScan calls these — stub with empty responses so render doesn't throw
   // if the Scan step is reached during tests that navigate that far.
-  inboxScanFolder: vi.fn().mockResolvedValue({ rootId: 'root-mock', items: [] }),
-  inboxClassify: vi.fn().mockResolvedValue(null),
-  // Processing-tool persistence: called in handleFinish before completeFirstRun.
-  toolUpdate: vi.fn().mockResolvedValue({
-    id: 'pixinsight',
-    name: 'PixInsight',
-    enabled: false,
-    configured: false,
-    available: false,
-    supportsOpenFolder: false,
-    autoDetected: false,
-    executablePath: null,
-  }),
+  mockInboxScanFolder: vi.fn().mockResolvedValue({ status: 'ok', data: { rootId: 'root-mock', items: [] } }),
+  // Never actually invoked in these gating tests (scan responses carry no
+  // items), but the module surface must still expose it.
+  mockInboxClassify: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    toolsUpdate: mockToolsUpdate,
+    firstrunComplete: mockFirstrunComplete,
+    rootsRegisterBatch: mockRootsRegisterBatch,
+    settingsGet: mockSettingsGet,
+    settingsUpdate: mockSettingsUpdate,
+    inboxScanFolder: mockInboxScanFolder,
+    inboxClassify: mockInboxClassify,
+  },
 }));
 
 // Mock @tauri-apps/api/core to prevent any accidental live invoke.
@@ -431,10 +466,8 @@ describe('SetupWizard 5-step flow', () => {
   });
 
   it('persists wizard processing-tool config to the backend when finishing', async () => {
-    // Access the mocked module to spy on calls.
-    const commands = await import('@/api/commands');
-    vi.mocked(commands.toolUpdate).mockClear();
-    vi.mocked(commands.completeFirstRun).mockClear();
+    mockToolsUpdate.mockClear();
+    mockFirstrunComplete.mockClear();
 
     // Seed at the Confirm step (step 3) with PixInsight enabled+pathed and
     // Siril disabled, so we can verify both tools are sent to toolUpdate.
@@ -476,22 +509,22 @@ describe('SetupWizard 5-step flow', () => {
       await new Promise((r) => setTimeout(r, 0));
     });
 
-    // handleFinish (non-mock path: VITE_USE_MOCKS='false') must call toolUpdate
-    // once per tool before completeFirstRun.
-    await waitFor(() => expect(vi.mocked(commands.toolUpdate)).toHaveBeenCalledTimes(2));
+    // handleFinish (non-mock path: VITE_USE_MOCKS='false') must call toolsUpdate
+    // once per tool before firstrunComplete.
+    await waitFor(() => expect(mockToolsUpdate).toHaveBeenCalledTimes(2));
 
-    expect(vi.mocked(commands.toolUpdate)).toHaveBeenCalledWith({
+    expect(mockToolsUpdate).toHaveBeenCalledWith({
       id: 'pixinsight',
       enabled: true,
       path: '/Applications/PixInsight/PixInsight.app',
     });
-    expect(vi.mocked(commands.toolUpdate)).toHaveBeenCalledWith({
+    expect(mockToolsUpdate).toHaveBeenCalledWith({
       id: 'siril',
       enabled: false,
       path: null,
     });
 
-    // completeFirstRun must be called exactly once, after the tool updates.
-    expect(vi.mocked(commands.completeFirstRun)).toHaveBeenCalledTimes(1);
+    // firstrunComplete must be called exactly once, after the tool updates.
+    expect(mockFirstrunComplete).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -4,7 +4,8 @@ import { WizardShell } from '@/ui/WizardShell';
 import { Btn } from '@/ui/Btn';
 import { m } from '@/lib/i18n';
 import { setPreference } from '@/data/preferences';
-import { completeFirstRun, toolUpdate } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import {
   StepSourceFolders,
   StepTools,
@@ -298,9 +299,13 @@ export function SetupWizard() {
           { id: 'pixinsight', enabled: state.tools.pixinsight.enabled, path: state.tools.pixinsight.path },
           { id: 'siril', enabled: state.tools.siril.enabled, path: state.tools.siril.path },
         ];
-        await Promise.all(toolEntries.map((t) => toolUpdate({ id: t.id, enabled: t.enabled, path: t.path })));
+        await Promise.all(
+          toolEntries.map(async (t) =>
+            unwrap(await commands.toolsUpdate({ id: t.id, enabled: t.enabled, path: t.path })),
+          ),
+        );
 
-        await completeFirstRun();
+        unwrap(await commands.firstrunComplete());
       }
 
       setPreference('setupCompleted', true);

--- a/apps/desktop/src/features/setup/registerSources.ts
+++ b/apps/desktop/src/features/setup/registerSources.ts
@@ -1,0 +1,60 @@
+/**
+ * Setup wizard source-registration IPC helper (spec 037 caller migration).
+ *
+ * Moves the `roots.register.batch` glue off the hand-written `@/api/commands`
+ * wrapper onto the generated `commands.rootsRegisterBatch` binding (FR-004:
+ * the behaviour is moved, not dropped). The real backend response carries
+ * per-item results in `items`, correlated to the request by `index`; the
+ * assigned source id is `sourceId`. This maps that response back to the
+ * wizard's row shape (kind/path come from the request by index) so the scan
+ * step receives the registered-source UUID — not the folder path — as
+ * rootId. Passing the path made inbox items fail the `registered_sources`
+ * JOIN and vanish.
+ */
+
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+
+export interface BatchSourceEntry {
+  kind: string;
+  path: string;
+  // Backend RegisterSourceRequest is camelCase — must be `scanDepth`.
+  scanDepth: string;
+  /** Required by the backend contract (spec 041 R-7). 'organized' | 'unorganized'. */
+  organizationState: string;
+}
+
+export interface BatchRegisterResult {
+  results: Array<{
+    kind: string;
+    path: string;
+    success: boolean;
+    /** Assigned registered-source id (UUID) on success — used as the scan rootId
+     *  so inbox items JOIN back to `registered_sources`. */
+    rootId?: string;
+    error?: string;
+  }>;
+}
+
+export async function registerRootBatch(args: {
+  sources: BatchSourceEntry[];
+}): Promise<BatchRegisterResult> {
+  const resp = unwrap(
+    await commands.rootsRegisterBatch({ sources: args.sources } as Parameters<
+      typeof commands.rootsRegisterBatch
+    >[0]),
+  );
+
+  const results = (resp.items ?? []).map((item) => {
+    const src = args.sources[item.index];
+    const success = item.status === 'success';
+    return {
+      kind: src?.kind ?? '',
+      path: src?.path ?? '',
+      success,
+      rootId: success ? (item.sourceId ?? undefined) : undefined,
+      error: item.error ?? undefined,
+    };
+  });
+  return { results };
+}

--- a/apps/desktop/src/features/setup/sources-store.ts
+++ b/apps/desktop/src/features/setup/sources-store.ts
@@ -1,4 +1,4 @@
-import { registerRootBatch } from '@/api/commands';
+import { registerRootBatch } from './registerSources';
 import { m } from '@/lib/i18n';
 import { errMessage } from '@/lib/errors';
 

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
@@ -10,18 +10,26 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockGet, mockUpdate, mockGetSettings, mockUpdateSettings } = vi.hoisted(() => ({
+const { mockGet, mockUpdate, mockSettingsGet, mockSettingsUpdate } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockUpdate: vi.fn(),
-  mockGetSettings: vi.fn(),
-  mockUpdateSettings: vi.fn(),
+  mockSettingsGet: vi.fn(),
+  mockSettingsUpdate: vi.fn(),
 }));
 
+// ResolverSettingsControl still reads @/api/commands directly (out of this
+// migration's scope); StepCatalogs itself now calls commands.settingsGet /
+// commands.settingsUpdate + unwrap (spec 037).
 vi.mock('@/api/commands', () => ({
   getResolverSettings: mockGet,
   updateResolverSettings: mockUpdate,
-  getSettings: mockGetSettings,
-  updateSettings: mockUpdateSettings,
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: mockSettingsGet,
+    settingsUpdate: mockSettingsUpdate,
+  },
 }));
 
 import { StepCatalogs, DEFAULT_CATALOG_SETTINGS } from './StepCatalogs';
@@ -29,8 +37,8 @@ import { StepCatalogs, DEFAULT_CATALOG_SETTINGS } from './StepCatalogs';
 beforeEach(() => {
   mockGet.mockReset();
   mockUpdate.mockReset();
-  mockGetSettings.mockReset();
-  mockUpdateSettings.mockReset();
+  mockSettingsGet.mockReset();
+  mockSettingsUpdate.mockReset();
   mockGet.mockResolvedValue({
     contractVersion: '1.0',
     requestId: 'r',
@@ -41,8 +49,8 @@ beforeEach(() => {
       requestTimeoutSecs: 10,
     },
   });
-  mockGetSettings.mockResolvedValue({ values: { defaultProtection: 'protected' } });
-  mockUpdateSettings.mockResolvedValue(undefined);
+  mockSettingsGet.mockResolvedValue({ status: 'ok', data: { values: { defaultProtection: 'protected' } } });
+  mockSettingsUpdate.mockResolvedValue({ status: 'ok', data: null });
 });
 
 function renderStep() {
@@ -60,7 +68,7 @@ describe('StepCatalogs (Configuration)', () => {
 
   it('renders the display density, protection, and scan-depth controls', async () => {
     renderStep();
-    await waitFor(() => expect(mockGetSettings).toHaveBeenCalled());
+    await waitFor(() => expect(mockSettingsGet).toHaveBeenCalled());
     expect(screen.getByLabelText('Default source protection')).toBeInTheDocument();
     expect(screen.getByLabelText('Display density')).toBeInTheDocument();
   });

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -12,7 +12,8 @@ import { ResolverSettingsControl } from '@/features/settings/ResolverSettingsCon
 import { usePreference } from '@/data/preferences';
 import { m } from '@/lib/i18n';
 import type { Density } from '@/bindings/types';
-import { getSettings, updateSettings } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 //
@@ -42,7 +43,8 @@ function DefaultProtectionControl() {
 
   useEffect(() => {
     let cancelled = false;
-    getSettings({ scope: 'cleanup' })
+    commands.settingsGet('cleanup')
+      .then((r) => unwrap(r))
       .then((data) => {
         const vals = data?.values as Record<string, unknown> | undefined;
         const v = vals?.defaultProtection;
@@ -58,7 +60,9 @@ function DefaultProtectionControl() {
 
   const onChange = (v: DefaultProtection) => {
     setValue(v);
-    void updateSettings({ scope: 'cleanup', values: { defaultProtection: v } }).catch(() => {});
+    void commands.settingsUpdate('cleanup', { defaultProtection: v })
+      .then((r) => unwrap(r))
+      .catch(() => {});
   };
 
   return (

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -3,8 +3,9 @@
  * StepScan tests — first-run wizard "Scan" step (spec 038).
  *
  * Covers: scanning/done/empty/error states and the onAllDoneChange callback
- * contract.  Mocks inboxScanFolder + inboxClassify at the @/api/commands layer
- * (same pattern as SetupWizard.test.tsx).
+ * contract.  Mocks commands.inboxScanFolder + commands.inboxClassify at the
+ * generated @/bindings/index layer (spec 037 caller migration; same pattern
+ * as SetupWizard.test.tsx), with unwrap() as the throw-on-error passthrough.
  *
  * NOTE: Back and Finish buttons now live in the SetupWizard footer, not inside
  * StepScan.  Tests for those buttons are in SetupWizard.test.tsx.  This file
@@ -22,10 +23,16 @@ const { mockInboxScanFolder, mockInboxClassify } = vi.hoisted(() => ({
   mockInboxClassify: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  inboxScanFolder: mockInboxScanFolder,
-  inboxClassify: mockInboxClassify,
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    inboxScanFolder: mockInboxScanFolder,
+    inboxClassify: mockInboxClassify,
+  },
 }));
+
+// unwrap() is the real implementation (@/api/ipc) — it throws `result.error`
+// on `{ status: 'error' }`, so a mocked rejection is expressed as a resolved
+// error-status result rather than mockRejectedValue.
 
 // ── Component under test ─────────────────────────────────────────────────────
 
@@ -160,8 +167,8 @@ describe('StepScan', () => {
     });
 
     it('calls inboxScanFolder for each source on mount', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep();
 
@@ -178,8 +185,8 @@ describe('StepScan', () => {
     });
 
     it('calls inboxClassify for each discovered item', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep();
 
@@ -193,8 +200,8 @@ describe('StepScan', () => {
 
   describe('accordion — collapsed by default', () => {
     it('table rows are hidden by default before the accordion is expanded', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -208,8 +215,8 @@ describe('StepScan', () => {
     });
 
     it('reveals table rows after clicking the source header', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -223,8 +230,8 @@ describe('StepScan', () => {
     });
 
     it('shows ▸ when collapsed and ▾ when expanded', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -243,8 +250,8 @@ describe('StepScan', () => {
     });
 
     it('collapses again on second click', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -272,8 +279,8 @@ describe('StepScan', () => {
 
   describe('done state with detections', () => {
     it('shows detected items and frame-type breakdown when scan completes (after expanding)', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -294,8 +301,8 @@ describe('StepScan', () => {
     });
 
     it('renders a Master pill and the frame type for individual masters (spec 040 FR-006)', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_MASTER);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_MASTER });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -315,8 +322,8 @@ describe('StepScan', () => {
     });
 
     it('shows the scan summary when all sources are done', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep();
 
@@ -326,8 +333,8 @@ describe('StepScan', () => {
     });
 
     it('calls onAllDoneChange(true) once all sources finish', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       const onAllDoneChange = vi.fn();
       renderStep({ onAllDoneChange });
@@ -340,8 +347,8 @@ describe('StepScan', () => {
 
   describe('empty state', () => {
     it('shows empty-state message when no items are detected', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE); // not called for empty
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_EMPTY });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE }); // not called for empty
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -351,7 +358,7 @@ describe('StepScan', () => {
     });
 
     it('does not show scan-item rows when empty', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_EMPTY });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -364,7 +371,7 @@ describe('StepScan', () => {
 
   describe('error state', () => {
     it('shows error state for a failing source', async () => {
-      mockInboxScanFolder.mockRejectedValue(new Error('disk read error'));
+      mockInboxScanFolder.mockResolvedValue({ status: 'error', error: new Error('disk read error') });
 
       renderStep({ sources: [SOURCES[0]] });
 
@@ -376,9 +383,9 @@ describe('StepScan', () => {
     it('completes other sources even when one fails (FR-005)', async () => {
       // First source fails, second succeeds
       mockInboxScanFolder
-        .mockRejectedValueOnce(new Error('disk read error'))
-        .mockResolvedValueOnce(SCAN_RESPONSE_WITH_ITEMS);
-      mockInboxClassify.mockResolvedValue(CLASSIFY_RESPONSE);
+        .mockResolvedValueOnce({ status: 'error', error: new Error('disk read error') })
+        .mockResolvedValueOnce({ status: 'ok', data: SCAN_RESPONSE_WITH_ITEMS });
+      mockInboxClassify.mockResolvedValue({ status: 'ok', data: CLASSIFY_RESPONSE });
 
       renderStep();
 
@@ -398,8 +405,8 @@ describe('StepScan', () => {
 
     it('calls onAllDoneChange(true) even when a source has errored (FR-005)', async () => {
       mockInboxScanFolder
-        .mockRejectedValueOnce(new Error('disk read error'))
-        .mockResolvedValueOnce(SCAN_RESPONSE_EMPTY);
+        .mockResolvedValueOnce({ status: 'error', error: new Error('disk read error') })
+        .mockResolvedValueOnce({ status: 'ok', data: SCAN_RESPONSE_EMPTY });
 
       const onAllDoneChange = vi.fn();
       renderStep({ onAllDoneChange });
@@ -433,7 +440,7 @@ describe('StepScan', () => {
 
   describe('re-entry guard', () => {
     it('does not re-trigger scans when re-rendered with the same props', async () => {
-      mockInboxScanFolder.mockResolvedValue(SCAN_RESPONSE_EMPTY);
+      mockInboxScanFolder.mockResolvedValue({ status: 'ok', data: SCAN_RESPONSE_EMPTY });
 
       const { rerender } = renderStep({ sources: [SOURCES[0]] });
 

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -11,7 +11,7 @@ import { m } from '@/lib/i18n';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type { InboxItemSummary } from '@/bindings/index';
-import type { InboxClassifyResponse_Serialize as InboxClassifyResponse } from '@/bindings/index';
+import type { InboxClassifyResponse } from '@/bindings/aliases';
 import type { SourceEntry } from '../sources-store';
 import type { FlushResult } from '../sources-store';
 import { errMessage } from '@/lib/errors';

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -8,8 +8,10 @@ import { useEffect, useRef, useState } from 'react';
 import { Pill } from '@/ui/Pill';
 import type { PillVariant } from '@/ui/Pill';
 import { m } from '@/lib/i18n';
-import { inboxScanFolder, inboxClassify } from '@/api/commands';
-import type { InboxItemSummary, InboxClassifyResponse } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { InboxItemSummary } from '@/bindings/index';
+import type { InboxClassifyResponse_Serialize as InboxClassifyResponse } from '@/bindings/index';
 import type { SourceEntry } from '../sources-store';
 import type { FlushResult } from '../sources-store';
 import { errMessage } from '@/lib/errors';
@@ -323,10 +325,12 @@ export function StepScan({ sources, flushResult, onAllDoneChange }: StepScanProp
 
         try {
           // 1. Scan the folder
-          const scanResponse = await inboxScanFolder({
-            rootId: entry.rootId,
-            rootAbsolutePath: entry.source.path,
-          });
+          const scanResponse = unwrap(
+            await commands.inboxScanFolder({
+              rootId: entry.rootId,
+              rootAbsolutePath: entry.source.path,
+            }),
+          );
 
           const items = scanResponse.items ?? [];
 
@@ -335,10 +339,12 @@ export function StepScan({ sources, flushResult, onAllDoneChange }: StepScanProp
           await Promise.allSettled(
             items.map(async (item) => {
               try {
-                const cls = await inboxClassify({
-                  inboxItemId: item.inboxItemId,
-                  rootAbsolutePath: entry.source.path,
-                });
+                const cls = unwrap(
+                  await commands.inboxClassify({
+                    inboxItemId: item.inboxItemId,
+                    rootAbsolutePath: entry.source.path,
+                  }),
+                );
                 classifications.set(item.inboxItemId, cls);
               } catch {
                 // Classification failure for one item: skip but don't abort

--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.orgstate.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.orgstate.test.tsx
@@ -11,7 +11,7 @@
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // StepSourceFolders uses useDirectoryPicker — stub it so no Tauri bridge is needed.
 vi.mock('@/shared/native', () => ({
@@ -187,21 +187,30 @@ describe('StepSourceFolders — onOrganizationStateChange callback', () => {
 
 // ── Tests: flushToDB includes organizationState in register payload ────────
 
-vi.mock('@/api/commands', () => ({
-  registerRootBatch: vi.fn().mockResolvedValue({ results: [] }),
+// flushToDB (sources-store.ts) delegates registration to registerSources.ts,
+// which calls commands.rootsRegisterBatch + unwrap (spec 037 caller
+// migration) — mock the generated bindings surface, not @/api/commands.
+const { mockRootsRegisterBatch } = vi.hoisted(() => ({
+  mockRootsRegisterBatch: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: { rootsRegisterBatch: mockRootsRegisterBatch },
 }));
 
 vi.stubEnv('VITE_USE_MOCKS', 'false');
 
 describe('flushToDB — organizationState in register payload', () => {
-  it('sends the user-chosen organizationState for non-inbox sources', async () => {
-    const { registerRootBatch } = await import('@/api/commands');
-    vi.mocked(registerRootBatch).mockResolvedValue({ results: [] });
+  beforeEach(() => {
+    mockRootsRegisterBatch.mockReset();
+    mockRootsRegisterBatch.mockResolvedValue({ status: 'ok', data: { status: 'success', items: [] } });
+  });
 
+  it('sends the user-chosen organizationState for non-inbox sources', async () => {
     const sources = addSource([], 'light_frames', '/astro/lights', 'recursive', 'unorganized');
     await flushToDB(sources);
 
-    expect(registerRootBatch).toHaveBeenCalledWith(
+    expect(mockRootsRegisterBatch).toHaveBeenCalledWith(
       expect.objectContaining({
         sources: expect.arrayContaining([
           expect.objectContaining({
@@ -215,15 +224,12 @@ describe('flushToDB — organizationState in register payload', () => {
   });
 
   it('always sends "unorganized" for inbox sources regardless of stored value', async () => {
-    const { registerRootBatch } = await import('@/api/commands');
-    vi.mocked(registerRootBatch).mockResolvedValue({ results: [] });
-
     // Force-add an inbox source — addSource already coerces to unorganized,
     // but we test that flushToDB also enforces it.
     const sources = addSource([], 'inbox', '/astro/inbox', 'recursive');
     await flushToDB(sources);
 
-    expect(registerRootBatch).toHaveBeenCalledWith(
+    expect(mockRootsRegisterBatch).toHaveBeenCalledWith(
       expect.objectContaining({
         sources: expect.arrayContaining([
           expect.objectContaining({
@@ -237,14 +243,11 @@ describe('flushToDB — organizationState in register payload', () => {
   });
 
   it('defaults to "organized" for non-inbox sources when no state is specified', async () => {
-    const { registerRootBatch } = await import('@/api/commands');
-    vi.mocked(registerRootBatch).mockResolvedValue({ results: [] });
-
     // addSource with no explicit organizationState → defaults to 'organized'
     const sources = addSource([], 'project', '/astro/projects', 'recursive');
     await flushToDB(sources);
 
-    expect(registerRootBatch).toHaveBeenCalledWith(
+    expect(mockRootsRegisterBatch).toHaveBeenCalledWith(
       expect.objectContaining({
         sources: expect.arrayContaining([
           expect.objectContaining({


### PR DESCRIPTION
## Summary
Spec 037 Phase-3 caller migration for the **setup** area: repoints off the hand-written `@/api/commands` `invoke()` wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`), eliminating the IPC name/payload drift-bug class.

first-run setup wizard (SetupWizard, steps, sources-store; new registerSources.ts glue).

Verified locally: `tsc --noEmit` clean; area vitest green; `eslint` 0 errors (pre-existing warnings only). Follows the merged calibration (#359) / plans (#368) / sessions (#369) pattern.

## Spec Context
- Spec: 037
- Branch: 037-setup