### PR TITLE
feat(037): migrate targets area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/features/targets/AddTargetDialog.test.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.test.tsx
@@ -21,10 +21,21 @@ const { mockSearchTargets, mockResolveTarget } = vi.hoisted(() => ({
   mockResolveTarget: vi.fn(),
 }));
 
+// TargetSearch (a shared component out of this migration's scope) still
+// calls the hand-written wrapper directly — kept mocked here so the child
+// component under test resolves suggestions.
 vi.mock('@/api/commands', () => ({
   searchTargets: mockSearchTargets,
-  resolveTarget: mockResolveTarget,
   TARGET_SEARCH_CONTRACT_VERSION: '1.0',
+}));
+
+/** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetResolve: mockResolveTarget,
+  },
 }));
 
 vi.mock('@tauri-apps/api/core', () => ({
@@ -32,7 +43,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 import { AddTargetDialog } from './AddTargetDialog';
-import type { TargetSuggestion } from '@/api/commands';
+import type { TargetSuggestion } from '@/bindings/index';
 
 const M31: TargetSuggestion = {
   targetId: 'tgt-m31',
@@ -82,7 +93,7 @@ beforeEach(() => {
     requestId: 'r',
     suggestions: [M31],
   });
-  mockResolveTarget.mockResolvedValue(resolved('tgt-m31'));
+  mockResolveTarget.mockResolvedValue(ok(resolved('tgt-m31')));
 });
 
 describe('AddTargetDialog', () => {
@@ -151,7 +162,7 @@ describe('AddTargetDialog', () => {
   it('4. resolved status calls onAdded with the target id', async () => {
     const onAdded = vi.fn();
     const onClose = vi.fn();
-    mockResolveTarget.mockResolvedValue(resolved('tgt-m31-persisted'));
+    mockResolveTarget.mockResolvedValue(ok(resolved('tgt-m31-persisted')));
 
     render(<AddTargetDialog open onClose={onClose} onAdded={onAdded} />);
 
@@ -175,7 +186,7 @@ describe('AddTargetDialog', () => {
 
   it('5. unresolved status shows error and does not call onAdded', async () => {
     const onAdded = vi.fn();
-    mockResolveTarget.mockResolvedValue(unresolved('unknown'));
+    mockResolveTarget.mockResolvedValue(ok(unresolved('unknown')));
 
     render(<AddTargetDialog open onClose={vi.fn()} onAdded={onAdded} />);
 

--- a/apps/desktop/src/features/targets/AddTargetDialog.test.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.test.tsx
@@ -43,7 +43,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 }));
 
 import { AddTargetDialog } from './AddTargetDialog';
-import type { TargetSuggestion } from '@/bindings/index';
+import type { TargetSuggestion } from '@/bindings/aliases';
 
 const M31: TargetSuggestion = {
   targetId: 'tgt-m31',

--- a/apps/desktop/src/features/targets/AddTargetDialog.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.tsx
@@ -19,7 +19,7 @@ import { Btn, Pill } from '@/ui';
 import { TargetSearch } from '@/components';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
-import type { TargetSuggestion } from '@/bindings/index';
+import type { TargetSuggestion } from '@/bindings/aliases';
 
 /** Contract version for the spec-035 `target.*` resolution commands. */
 const TARGET_SEARCH_CONTRACT_VERSION = '1.0';

--- a/apps/desktop/src/features/targets/AddTargetDialog.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.tsx
@@ -17,8 +17,12 @@ import { Dialog } from '@base-ui-components/react/dialog';
 import { m } from '@/lib/i18n';
 import { Btn, Pill } from '@/ui';
 import { TargetSearch } from '@/components';
-import { resolveTarget, TARGET_SEARCH_CONTRACT_VERSION } from '@/api/commands';
-import type { TargetSuggestion } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { TargetSuggestion } from '@/bindings/index';
+
+/** Contract version for the spec-035 `target.*` resolution commands. */
+const TARGET_SEARCH_CONTRACT_VERSION = '1.0';
 
 export interface AddTargetDialogProps {
   open: boolean;
@@ -58,12 +62,12 @@ export function AddTargetDialog({ open, onClose, onAdded }: AddTargetDialogProps
     setResolving(true);
     setError(null);
     try {
-      const res = await resolveTarget({
+      const res = unwrap(await commands.targetResolve({
         contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
         requestId: crypto.randomUUID(),
         query: pending.primaryDesignation,
         override: null,
-      });
+      }));
       if (res.status === 'resolved' && res.target) {
         handleOpenChange(false);
         onAdded(res.target.targetId);

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -60,16 +60,21 @@ const {
   mockUpdateTargetNote: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  getTargetDetail: mockGetTargetDetail,
-  addTargetAlias: mockAddTargetAlias,
-  removeTargetAlias: mockRemoveTargetAlias,
-  setDisplayAlias: mockSetDisplayAlias,
-  clearDisplayAlias: mockClearDisplayAlias,
-  listTargetSessions: mockListTargetSessions,
-  listTargetProjects: mockListTargetProjects,
-  getTargetNote: mockGetTargetNote,
-  updateTargetNote: mockUpdateTargetNote,
+/** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetGet: mockGetTargetDetail,
+    targetAliasAdd: mockAddTargetAlias,
+    targetAliasRemove: mockRemoveTargetAlias,
+    targetDisplayAliasSet: mockSetDisplayAlias,
+    targetDisplayAliasClear: mockClearDisplayAlias,
+    targetSessionsList: mockListTargetSessions,
+    targetProjectsList: mockListTargetProjects,
+    targetNoteGet: mockGetTargetNote,
+    targetNoteUpdate: mockUpdateTargetNote,
+  },
 }));
 
 const mockNavigate = vi.fn();
@@ -116,18 +121,18 @@ function makeDetail(overrides?: {
 beforeEach(() => {
   vi.clearAllMocks();
   mockNavigate.mockResolvedValue(undefined);
-  mockGetTargetDetail.mockResolvedValue(makeDetail());
-  mockAddTargetAlias.mockResolvedValue({
+  mockGetTargetDetail.mockResolvedValue(ok(makeDetail()));
+  mockAddTargetAlias.mockResolvedValue(ok({
     alias: { id: 'alias-user-new', alias: 'New Alias', kind: 'user' },
-  });
-  mockRemoveTargetAlias.mockResolvedValue({ removed: true });
-  mockSetDisplayAlias.mockResolvedValue(makeDetail({ displayAlias: 'My NGC 7000' }));
-  mockClearDisplayAlias.mockResolvedValue(makeDetail({ displayAlias: null }));
+  }));
+  mockRemoveTargetAlias.mockResolvedValue(ok({ removed: true }));
+  mockSetDisplayAlias.mockResolvedValue(ok(makeDetail({ displayAlias: 'My NGC 7000' })));
+  mockClearDisplayAlias.mockResolvedValue(ok(makeDetail({ displayAlias: null })));
   // US2/US3/US4 defaults: empty lists, no notes.
-  mockListTargetSessions.mockResolvedValue([]);
-  mockListTargetProjects.mockResolvedValue([]);
-  mockGetTargetNote.mockResolvedValue({ notes: null });
-  mockUpdateTargetNote.mockResolvedValue({ notes: null });
+  mockListTargetSessions.mockResolvedValue(ok([]));
+  mockListTargetProjects.mockResolvedValue(ok([]));
+  mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
+  mockUpdateTargetNote.mockResolvedValue(ok({ notes: null }));
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -149,7 +154,7 @@ describe('TargetDetailV2', () => {
   });
 
   it('2b. when displayAlias is set, effectiveLabel shows it', async () => {
-    mockGetTargetDetail.mockResolvedValue(makeDetail({ displayAlias: 'My NGC 7000' }));
+    mockGetTargetDetail.mockResolvedValue(ok(makeDetail({ displayAlias: 'My NGC 7000' })));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => {
       const els = screen.getAllByText('My NGC 7000');
@@ -304,7 +309,7 @@ describe('TargetDetailV2', () => {
         { id: 'alias-user-new', alias: 'New Alias', kind: 'user' },
       ],
     });
-    mockGetTargetDetail.mockResolvedValueOnce(makeDetail()).mockResolvedValueOnce(updated);
+    mockGetTargetDetail.mockResolvedValueOnce(ok(makeDetail())).mockResolvedValueOnce(ok(updated));
 
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => screen.getByRole('textbox', { name: /new alias/i }));
@@ -325,7 +330,7 @@ describe('TargetDetailV2', () => {
         { id: 'alias-cn-1', alias: 'North America Nebula', kind: 'common_name' },
       ],
     });
-    mockGetTargetDetail.mockResolvedValueOnce(makeDetail()).mockResolvedValueOnce(updated);
+    mockGetTargetDetail.mockResolvedValueOnce(ok(makeDetail())).mockResolvedValueOnce(ok(updated));
 
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => screen.getByLabelText('Remove alias My Nebula'));
@@ -347,8 +352,8 @@ describe('TargetDetailV2', () => {
 
   it('18. setting display alias updates effectiveLabel', async () => {
     mockGetTargetDetail
-      .mockResolvedValueOnce(makeDetail())
-      .mockResolvedValueOnce(makeDetail({ displayAlias: 'My NGC 7000' }));
+      .mockResolvedValueOnce(ok(makeDetail()))
+      .mockResolvedValueOnce(ok(makeDetail({ displayAlias: 'My NGC 7000' })));
 
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => screen.getByRole('button', { name: /^set$/i }));
@@ -370,8 +375,8 @@ describe('TargetDetailV2', () => {
   });
 
   it('19. clearing display alias reverts effectiveLabel to primaryDesignation', async () => {
-    mockGetTargetDetail.mockResolvedValue(makeDetail({ displayAlias: 'My NGC 7000' }));
-    mockClearDisplayAlias.mockResolvedValue(makeDetail({ displayAlias: null }));
+    mockGetTargetDetail.mockResolvedValue(ok(makeDetail({ displayAlias: 'My NGC 7000' })));
+    mockClearDisplayAlias.mockResolvedValue(ok(makeDetail({ displayAlias: null })));
 
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     // Wait for at least one Edit button (display-alias + notes may both show Edit)
@@ -393,7 +398,7 @@ describe('TargetDetailV2', () => {
   // ── US2: Linked sessions ───────────────────────────────────────────────────
 
   it('20. (US2) sessions empty-state renders "No linked sessions yet."', async () => {
-    mockListTargetSessions.mockResolvedValue([]);
+    mockListTargetSessions.mockResolvedValue(ok([]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getByText(/No linked sessions yet/i)).toBeInTheDocument(),
@@ -401,7 +406,7 @@ describe('TargetDetailV2', () => {
   });
 
   it('21. (US2) linked session rows render date, frameCount, and state', async () => {
-    mockListTargetSessions.mockResolvedValue([
+    mockListTargetSessions.mockResolvedValue(ok([
       {
         id: 'sess-1',
         sessionKey: '{}',
@@ -409,14 +414,14 @@ describe('TargetDetailV2', () => {
         frameCount: 42,
         state: 'confirmed',
       },
-    ]);
+    ]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => expect(screen.getByText(/42 frames/i)).toBeInTheDocument());
     expect(screen.getByText(/confirmed/i)).toBeInTheDocument();
   });
 
   it('22. (US2) clicking session row navigates to /sessions with selected=id', async () => {
-    mockListTargetSessions.mockResolvedValue([
+    mockListTargetSessions.mockResolvedValue(ok([
       {
         id: 'sess-abc',
         sessionKey: '{}',
@@ -424,7 +429,7 @@ describe('TargetDetailV2', () => {
         frameCount: 5,
         state: 'confirmed',
       },
-    ]);
+    ]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => expect(screen.getByText(/5 frames/i)).toBeInTheDocument());
 
@@ -441,7 +446,7 @@ describe('TargetDetailV2', () => {
   // ── US3: Linked projects ───────────────────────────────────────────────────
 
   it('23. (US3) projects empty-state renders "No projects linked."', async () => {
-    mockListTargetProjects.mockResolvedValue([]);
+    mockListTargetProjects.mockResolvedValue(ok([]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getAllByText(/No projects linked/i).length).toBeGreaterThanOrEqual(1),
@@ -449,9 +454,9 @@ describe('TargetDetailV2', () => {
   });
 
   it('24. (US3) linked project rows render name and lifecycle', async () => {
-    mockListTargetProjects.mockResolvedValue([
+    mockListTargetProjects.mockResolvedValue(ok([
       { id: 'proj-1', name: 'Horsehead 2026', lifecycle: 'ready' },
-    ]);
+    ]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getAllByText('Horsehead 2026').length).toBeGreaterThanOrEqual(1),
@@ -460,9 +465,9 @@ describe('TargetDetailV2', () => {
   });
 
   it('25. (US3) clicking project row navigates to /projects with selected=id (mid-page link row)', async () => {
-    mockListTargetProjects.mockResolvedValue([
+    mockListTargetProjects.mockResolvedValue(ok([
       { id: 'proj-1', name: 'Horsehead 2026', lifecycle: 'ready' },
-    ]);
+    ]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getAllByText('Horsehead 2026').length).toBeGreaterThanOrEqual(1),
@@ -480,9 +485,9 @@ describe('TargetDetailV2', () => {
   });
 
   it('25b. (US3) clicking project row in bottom section navigates to /projects with selected=id', async () => {
-    mockListTargetProjects.mockResolvedValue([
+    mockListTargetProjects.mockResolvedValue(ok([
       { id: 'proj-1', name: 'Horsehead 2026', lifecycle: 'ready' },
-    ]);
+    ]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getAllByText('Horsehead 2026').length).toBeGreaterThanOrEqual(1),
@@ -503,7 +508,7 @@ describe('TargetDetailV2', () => {
   // ── US4: Observing notes ───────────────────────────────────────────────────
 
   it('26. (US4) notes empty placeholder renders when no notes', async () => {
-    mockGetTargetNote.mockResolvedValue({ notes: null });
+    mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getByTestId('target-notes-empty')).toBeInTheDocument(),
@@ -512,7 +517,7 @@ describe('TargetDetailV2', () => {
   });
 
   it('27. (US4) existing notes body renders', async () => {
-    mockGetTargetNote.mockResolvedValue({ notes: 'Great transparency last night.' });
+    mockGetTargetNote.mockResolvedValue(ok({ notes: 'Great transparency last night.' }));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
       expect(screen.getByTestId('target-notes-body')).toHaveTextContent(
@@ -522,8 +527,8 @@ describe('TargetDetailV2', () => {
   });
 
   it('28. (US4) edit → save calls updateTargetNote and reflects result', async () => {
-    mockGetTargetNote.mockResolvedValue({ notes: 'Old note' });
-    mockUpdateTargetNote.mockResolvedValue({ notes: 'Updated note' });
+    mockGetTargetNote.mockResolvedValue(ok({ notes: 'Old note' }));
+    mockUpdateTargetNote.mockResolvedValue(ok({ notes: 'Updated note' }));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => screen.getByTestId('target-notes-body'));
 
@@ -548,7 +553,7 @@ describe('TargetDetailV2', () => {
   });
 
   it('29. (US4) edit → cancel restores original notes without calling update', async () => {
-    mockGetTargetNote.mockResolvedValue({ notes: 'Original note' });
+    mockGetTargetNote.mockResolvedValue(ok({ notes: 'Original note' }));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => screen.getByTestId('target-notes-body'));
 
@@ -567,7 +572,7 @@ describe('TargetDetailV2', () => {
   });
 
   it('30. (US4) save error shows banner message', async () => {
-    mockGetTargetNote.mockResolvedValue({ notes: null });
+    mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
     mockUpdateTargetNote.mockRejectedValue(new Error('db error'));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() => screen.getByTestId('target-notes-empty'));

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -27,7 +27,8 @@ import { X } from 'lucide-react';
 import { useNavigate } from '@tanstack/react-router';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
-import type { TargetDetailV3, TargetOpError, TargetListItem } from '@/bindings/index';
+import type { TargetDetailV3, TargetOpError } from '@/bindings/aliases';
+import type { TargetListItem } from '@/bindings/index';
 import type { TargetSessionItem, TargetProjectItem } from '@/bindings';
 import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn } from '@/ui';
@@ -369,7 +370,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
       .targetGet({ targetId })
       .then(unwrap)
       .then((data) => {
-        setLoadState({ status: 'loaded', data });
+        setLoadState({ status: 'loaded', data: data as TargetDetailV3 });
         setDisplayAliasInput(data.displayAlias ?? '');
       })
       .catch(() => {
@@ -479,7 +480,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
       const data = unwrap(
         await commands.targetDisplayAliasSet({ targetId, displayAlias: displayAliasInput.trim() }),
       );
-      setLoadState({ status: 'loaded', data });
+      setLoadState({ status: 'loaded', data: data as TargetDetailV3 });
       setDisplayAliasInput(data.displayAlias ?? '');
       setDisplayAliasEditing(false);
     } catch (err) {
@@ -493,7 +494,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
     setActionError(null);
     try {
       const data = unwrap(await commands.targetDisplayAliasClear({ targetId }));
-      setLoadState({ status: 'loaded', data });
+      setLoadState({ status: 'loaded', data: data as TargetDetailV3 });
       setDisplayAliasInput('');
       setDisplayAliasEditing(false);
     } catch (err) {

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -25,18 +25,9 @@
 import { useState, useEffect, useCallback } from 'react';
 import { X } from 'lucide-react';
 import { useNavigate } from '@tanstack/react-router';
-import {
-  getTargetDetail,
-  addTargetAlias,
-  removeTargetAlias,
-  setDisplayAlias,
-  clearDisplayAlias,
-  listTargetSessions,
-  listTargetProjects,
-  getTargetNote,
-  updateTargetNote,
-} from '@/api/commands';
-import type { TargetDetailV3, TargetOpError, TargetListItem } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { TargetDetailV3, TargetOpError, TargetListItem } from '@/bindings/index';
 import type { TargetSessionItem, TargetProjectItem } from '@/bindings';
 import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn } from '@/ui';
@@ -374,7 +365,9 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
 
   const load = useCallback(() => {
     setLoadState({ status: 'loading' });
-    getTargetDetail({ targetId })
+    commands
+      .targetGet({ targetId })
+      .then(unwrap)
       .then((data) => {
         setLoadState({ status: 'loaded', data });
         setDisplayAliasInput(data.displayAlias ?? '');
@@ -391,7 +384,9 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
   // US2: load linked sessions when targetId changes.
   useEffect(() => {
     setSessionsLoading(true);
-    listTargetSessions({ targetId })
+    commands
+      .targetSessionsList({ targetId })
+      .then(unwrap)
       .then((data) => setSessions(data))
       .catch(() => setSessions([]))
       .finally(() => setSessionsLoading(false));
@@ -400,7 +395,9 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
   // US3: load linked projects when targetId changes.
   useEffect(() => {
     setProjectsLoading(true);
-    listTargetProjects({ targetId })
+    commands
+      .targetProjectsList({ targetId })
+      .then(unwrap)
       .then((data) => setProjects(data))
       .catch(() => setProjects([]))
       .finally(() => setProjectsLoading(false));
@@ -408,9 +405,11 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
 
   // US4: load observing notes when targetId changes.
   useEffect(() => {
-    getTargetNote({ targetId })
+    commands
+      .targetNoteGet({ targetId })
+      .then(unwrap)
       .then(({ notes: n }) => {
-        setNotes(n);
+        setNotes(n ?? null);
         setNotesDraft(n ?? '');
       })
       .catch(() => {
@@ -428,8 +427,8 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
     setNotesSaving(true);
     setNotesError(null);
     try {
-      const { notes: saved } = await updateTargetNote({ targetId, notes: notesDraft });
-      setNotes(saved);
+      const { notes: saved } = unwrap(await commands.targetNoteUpdate({ targetId, notes: notesDraft }));
+      setNotes(saved ?? null);
       setNotesDraft(saved ?? '');
       setNotesEditing(false);
       setNotesSaved(true);
@@ -449,7 +448,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
     }
     setAliasError(null);
     try {
-      await addTargetAlias({ targetId, alias });
+      unwrap(await commands.targetAliasAdd({ targetId, alias }));
       setAliasInput('');
       load();
     } catch (err) {
@@ -463,7 +462,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
     async (aliasId: string) => {
       setActionError(null);
       try {
-        await removeTargetAlias({ targetId, aliasId });
+        unwrap(await commands.targetAliasRemove({ targetId, aliasId }));
         load();
       } catch (err) {
         const e = err as TargetOpError;
@@ -477,7 +476,9 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
   const handleDisplayAliasSet = useCallback(async () => {
     setActionError(null);
     try {
-      const data = await setDisplayAlias({ targetId, displayAlias: displayAliasInput.trim() });
+      const data = unwrap(
+        await commands.targetDisplayAliasSet({ targetId, displayAlias: displayAliasInput.trim() }),
+      );
       setLoadState({ status: 'loaded', data });
       setDisplayAliasInput(data.displayAlias ?? '');
       setDisplayAliasEditing(false);
@@ -491,7 +492,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
   const handleDisplayAliasClear = useCallback(async () => {
     setActionError(null);
     try {
-      const data = await clearDisplayAlias({ targetId });
+      const data = unwrap(await commands.targetDisplayAliasClear({ targetId }));
       setLoadState({ status: 'loaded', data });
       setDisplayAliasInput('');
       setDisplayAliasEditing(false);

--- a/apps/desktop/src/features/targets/TargetList.tsx
+++ b/apps/desktop/src/features/targets/TargetList.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { ListSidebar } from '@/components';
 import { Pill, SegControl } from '@/ui';
 import { m } from '@/lib/i18n';

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -31,28 +31,62 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // ── Hoist mocks ───────────────────────────────────────────────────────────────
 
-const { mockListTargets, mockGetTargetDetail, mockSearchTargets, mockResolveTarget } = vi.hoisted(() => ({
+const {
+  mockListTargets,
+  mockGetTargetDetail,
+  mockSearchTargets,
+  mockResolveTarget,
+  mockAddTargetAlias,
+  mockRemoveTargetAlias,
+  mockSetDisplayAlias,
+  mockClearDisplayAlias,
+  mockListTargetSessions,
+  mockListTargetProjects,
+  mockGetTargetNote,
+  mockUpdateTargetNote,
+} = vi.hoisted(() => ({
   mockListTargets: vi.fn(),
   mockGetTargetDetail: vi.fn(),
   mockSearchTargets: vi.fn(),
   mockResolveTarget: vi.fn(),
+  mockAddTargetAlias: vi.fn(),
+  mockRemoveTargetAlias: vi.fn(),
+  mockSetDisplayAlias: vi.fn(),
+  mockClearDisplayAlias: vi.fn(),
+  mockListTargetSessions: vi.fn(),
+  mockListTargetProjects: vi.fn(),
+  mockGetTargetNote: vi.fn(),
+  mockUpdateTargetNote: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  listTargets: mockListTargets,
-  getTargetDetail: mockGetTargetDetail,
-  searchTargets: mockSearchTargets,
-  resolveTarget: mockResolveTarget,
-  TARGET_SEARCH_CONTRACT_VERSION: '1.0',
-  addTargetAlias: vi.fn().mockResolvedValue({ alias: { id: 'a', alias: 'x', kind: 'user' } }),
-  removeTargetAlias: vi.fn().mockResolvedValue({ removed: true }),
-  setDisplayAlias: vi.fn().mockResolvedValue({}),
-  clearDisplayAlias: vi.fn().mockResolvedValue({}),
-  listTargetSessions: vi.fn().mockResolvedValue([]),
-  listTargetProjects: vi.fn().mockResolvedValue([]),
-  getTargetNote: vi.fn().mockResolvedValue({ notes: null }),
-  updateTargetNote: vi.fn().mockResolvedValue({ notes: null }),
+/** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetList: mockListTargets,
+    targetGet: mockGetTargetDetail,
+    targetSearch: mockSearchTargets,
+    targetResolve: mockResolveTarget,
+    targetAliasAdd: mockAddTargetAlias,
+    targetAliasRemove: mockRemoveTargetAlias,
+    targetDisplayAliasSet: mockSetDisplayAlias,
+    targetDisplayAliasClear: mockClearDisplayAlias,
+    targetSessionsList: mockListTargetSessions,
+    targetProjectsList: mockListTargetProjects,
+    targetNoteGet: mockGetTargetNote,
+    targetNoteUpdate: mockUpdateTargetNote,
+  },
 }));
+
+mockAddTargetAlias.mockResolvedValue(ok({ alias: { id: 'a', alias: 'x', kind: 'user' } }));
+mockRemoveTargetAlias.mockResolvedValue(ok({ removed: true }));
+mockSetDisplayAlias.mockResolvedValue(ok({}));
+mockClearDisplayAlias.mockResolvedValue(ok({}));
+mockListTargetSessions.mockResolvedValue(ok([]));
+mockListTargetProjects.mockResolvedValue(ok([]));
+mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
+mockUpdateTargetNote.mockResolvedValue(ok({ notes: null }));
 
 const mockNavigate = vi.fn();
 const mockSelectedId = { current: undefined as string | undefined };
@@ -106,10 +140,10 @@ function makeDetail() {
 beforeEach(() => {
   vi.clearAllMocks();
   mockSelectedId.current = undefined;
-  mockListTargets.mockResolvedValue(listItems);
-  mockGetTargetDetail.mockResolvedValue(makeDetail());
-  mockSearchTargets.mockResolvedValue({ contractVersion: '1.0', requestId: 'r', suggestions: [] });
-  mockResolveTarget.mockResolvedValue({ contractVersion: '1.0', requestId: 'r', status: 'unresolved', target: null, unresolvedReason: 'offline', error: null });
+  mockListTargets.mockResolvedValue(ok(listItems));
+  mockGetTargetDetail.mockResolvedValue(ok(makeDetail()));
+  mockSearchTargets.mockResolvedValue(ok({ contractVersion: '1.0', requestId: 'r', suggestions: [] }));
+  mockResolveTarget.mockResolvedValue(ok({ contractVersion: '1.0', requestId: 'r', status: 'unresolved', target: null, unresolvedReason: 'offline', error: null }));
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -186,12 +220,12 @@ describe('TargetsPage', () => {
   // ── P: My Targets vs Planner filter (task #40, task #91) ────────────────────
 
   it('P1. "All targets" (default) filters to allowed planner catalogs', async () => {
-    mockListTargets.mockResolvedValue([
+    mockListTargets.mockResolvedValue(ok([
       ...listItems,
       // double-star dump entries that must NOT show in the Planner
       { id: 'hd1', effectiveLabel: 'HD 1', primaryDesignation: 'HD 1', objectType: 'double_star' },
       { id: 'wds1', effectiveLabel: 'WDS J1', primaryDesignation: 'WDS J00057+4549', objectType: 'double_star' },
-    ]);
+    ]));
     render(<TargetsPage />);
     await waitFor(() => expect(screen.getByText('NGC 7000')).toBeInTheDocument());
 

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -43,8 +43,9 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { listTargets } from '@/api/commands';
-import type { TargetListItem } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { TargetListItem } from '@/bindings/index';
 import { PageTopBar, FilterToolbar, ListPageLayout } from '@/components';
 import type { FilterOption } from '@/components';
 import { m } from '@/lib/i18n';
@@ -241,7 +242,9 @@ export function TargetsPage() {
 
   const load = useCallback(() => {
     setListState({ status: 'loading' });
-    listTargets()
+    commands
+      .targetList()
+      .then(unwrap)
       .then((items) => setListState({ status: 'loaded', items }))
       .catch(() => setListState({ status: 'error', message: m.targets_page_error_load() }));
   }, []);

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -18,7 +18,7 @@
 
 import { render, screen, fireEvent, within } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { TargetsTable, DEFAULT_TARGET_SORT } from './TargetsTable';
 
 function item(primaryDesignation: string, objectType = 'other'): TargetListItem {

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -62,7 +62,7 @@
 
 import { useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { Pill } from '@/ui';
 import { SortHeader } from '@/components';
 import { catalogueOf, catalogueLabel } from './planner-catalog';

--- a/apps/desktop/src/features/targets/catalogue-settings.ts
+++ b/apps/desktop/src/features/targets/catalogue-settings.ts
@@ -3,14 +3,16 @@
  *
  * Which catalogues are enabled by default in the Planner is a user setting,
  * persisted through the generic settings backend under the `'catalogues'`
- * scope (`getSettings` / `updateSettings`), value shape `{ enabled: string[] }`.
+ * scope (`commands.settingsGet` / `commands.settingsUpdate`), value shape
+ * `{ enabled: string[] }`.
  *
  * The Planner top bar initializes its catalogue multi-select from this setting;
  * the Settings → Target Resolution pane edits it. Sensible default ON subset is
  * Messier + NGC + IC + Sharpless; the rest (LBN/LDN/Caldwell/Barnard) are off.
  */
 
-import { getSettings, updateSettings } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import { PLANNER_CATALOGS, type CatalogueId } from './planner-catalog';
 
 /** Settings scope for the default-enabled planner catalogues. */
@@ -42,7 +44,7 @@ function coerce(value: unknown): CatalogueId[] {
  */
 export async function loadDefaultCatalogues(): Promise<CatalogueId[]> {
   try {
-    const data = await getSettings({ scope: CATALOGUES_SCOPE });
+    const data = unwrap(await commands.settingsGet(CATALOGUES_SCOPE));
     return coerce(data.values);
   } catch {
     return [...DEFAULT_ENABLED_CATALOGUES];
@@ -51,5 +53,5 @@ export async function loadDefaultCatalogues(): Promise<CatalogueId[]> {
 
 /** Persist the default-enabled catalogues. */
 export async function saveDefaultCatalogues(enabled: readonly CatalogueId[]): Promise<void> {
-  await updateSettings({ scope: CATALOGUES_SCOPE, values: { enabled: [...enabled] } });
+  unwrap(await commands.settingsUpdate(CATALOGUES_SCOPE, { enabled: [...enabled] }));
 }

--- a/apps/desktop/src/features/targets/planner-altitude.test.ts
+++ b/apps/desktop/src/features/targets/planner-altitude.test.ts
@@ -14,7 +14,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import {
   rowAltitudeFor,
   USABLE_ALT_DEG,

--- a/apps/desktop/src/features/targets/planner-altitude.ts
+++ b/apps/desktop/src/features/targets/planner-altitude.ts
@@ -28,7 +28,7 @@
  *     recompute from the Settings → Target Planner control.
  */
 
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { m } from '@/lib/i18n';
 
 /** Placeholder observer latitude — mirrors TargetDetailV2.STUB_OBSERVER_LAT_DEG. */

--- a/apps/desktop/src/features/targets/planner-catalog.test.ts
+++ b/apps/desktop/src/features/targets/planner-catalog.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { filterPlannerCatalog, isPlannerCatalogTarget } from './planner-catalog';
 
 function item(primaryDesignation: string, objectType = 'other'): TargetListItem {

--- a/apps/desktop/src/features/targets/planner-catalog.ts
+++ b/apps/desktop/src/features/targets/planner-catalog.ts
@@ -17,7 +17,7 @@
  * grouping, and so Settings can persist a default-enabled catalogue subset.
  */
 
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { m } from '@/lib/i18n';
 
 /** Stable id for each planner catalogue (persisted in Settings + used as group key). */

--- a/apps/desktop/src/features/targets/target-search.test.ts
+++ b/apps/desktop/src/features/targets/target-search.test.ts
@@ -8,7 +8,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { TargetListItem } from '@/api/commands';
+import type { TargetListItem } from '@/bindings/index';
 import { normalizeDesig, matchesSearch } from './TargetsPage';
 
 function item(


### PR DESCRIPTION
## Summary
Spec 037 Phase-3 caller migration for the **targets** area: repoints off the hand-written `@/api/commands` `invoke()` wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`), eliminating the IPC name/payload drift-bug class.

targets feature (15 files; target identity/history/notes, SIMBAD resolve, catalogue).

Verified locally: `tsc --noEmit` clean; area vitest green; `eslint` 0 errors (pre-existing warnings only). Follows the merged calibration (#359) / plans (#368) / sessions (#369) pattern.

## Spec Context
- Spec: 037
- Branch: 037-targets