### PR TITLE
feat(037): migrate inbox area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/features/inbox/InboxControls.tsx
+++ b/apps/desktop/src/features/inbox/InboxControls.tsx
@@ -16,7 +16,7 @@
  */
 
 import type { DimensionAccessor } from './grouping';
-import type { InboxListItem } from '@/api/commands';
+import type { InboxListItem } from '@/bindings/index';
 import { m } from '@/lib/i18n';
 
 // ── Grouping dimension registry ─────────────────────────────────────────────────

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -22,7 +22,7 @@
 
 import { Popover } from "@base-ui-components/react/popover";
 import { useState } from "react";
-import type { InboxFileMetadata, InboxItemSummary } from "@/api/commands";
+import type { InboxFileMetadata_Serialize as InboxFileMetadata, InboxItemSummary } from "@/bindings/index";
 import type { PropertyDef } from "@/components";
 import { DetailPanel, PropertyTable } from "@/components";
 import { errMessage } from "@/lib/errors";

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -19,7 +19,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
-import type { InboxListItem } from '@/api/commands';
+import type { InboxListItem } from '@/bindings/index';
 import { Table, type TableColumn, type TableRow } from '@/ui';
 import { SortHeader } from '@/components';
 import { groupByDimensions, type GroupNode } from './grouping';

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -34,8 +34,9 @@
 
 import { useNavigate, useSearch } from "@tanstack/react-router";
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { listRoots } from "@/api/commands";
-import type { InboxConfirmDestination } from "@/api/commands";
+import { commands } from "@/bindings/index";
+import { unwrap } from "@/api/ipc";
+import type { InboxConfirmDestination } from "@/bindings/index";
 import { useSetPageStatus } from "@/app/PageStatusContext";
 import { FilterToolbar, ListPageLayout, PageTopBar } from "@/components";
 import { usePlanApplyProgress } from "@/features/plans/usePlanApplyProgress";
@@ -232,7 +233,9 @@ export function InboxPage() {
 	const [selectedDestRootId, setSelectedDestRootId] = useState("");
 	useEffect(() => {
 		let alive = true;
-		listRoots()
+		commands
+			.rootsList()
+			.then(unwrap)
 			.then((rs) => {
 				if (!alive) return;
 				setDestRoots(

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.reclassify.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.reclassify.test.tsx
@@ -13,8 +13,8 @@
  *    correctly — regression guard.
  *
  * Mocking pattern mirrors InboxDetail.test.tsx:
- * - Mock '@/api/commands' (inboxReclassify vi.fn()) so the real store hook
- *   picks it up; classifyStore.invalidateAll() is harmless in jsdom.
+ * - Mock '@/bindings/index' (commands.inboxReclassify vi.fn()) so the real
+ *   store hook picks it up; classifyStore.invalidateAll() is harmless in jsdom.
  * - Render InboxDetail directly with fixture props — no InboxPage wrapper
  *   (avoids OOM from the full page tree).
  */
@@ -46,11 +46,17 @@ const mockInboxReclassify = vi.fn().mockResolvedValue({
   remainingUnclassified: 2,
 });
 
-vi.mock('@/api/commands', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('@/api/commands')>();
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/bindings/index')>();
   return {
     ...mod,
-    inboxReclassify: (...args: unknown[]) => mockInboxReclassify(...args),
+    commands: {
+      ...mod.commands,
+      inboxReclassify: async (...args: unknown[]) => ({
+        status: 'ok',
+        data: await mockInboxReclassify(...args),
+      }),
+    },
   };
 });
 

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.test.tsx
@@ -7,7 +7,7 @@
  * InboxDetail never fetches — it renders the data it receives.
  *
  * InboxFileMetadata is the generated Specta type (camelCase), re-exported via
- * '@/api/commands' (spec 041 US2/FR-010 — wired in T019):
+ * '@/bindings/index' (spec 041 US2/FR-010 — wired in T019):
  *   relativeFilePath, frameTypeEffective, imageTyp, filter, exposureS, binningX,
  *   binningY, gain (string), temperatureC, object, dateObs, instrume, telescop,
  *   naxis1, naxis2, stackCount, isMaster, overrideStale
@@ -17,8 +17,8 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { fireEvent, render as rtlRender, screen } from "@testing-library/react";
 import type React from "react";
 import { describe, expect, it, vi } from "vitest";
-import type { InboxFileMetadata } from "@/api/commands";
 import type {
+	InboxFileMetadata_Serialize as InboxFileMetadata,
 	InboxClassifyResponse_Serialize as InboxClassifyResponse,
 	InboxItemSummary_Serialize as InboxItemSummary,
 } from "@/bindings";
@@ -37,14 +37,20 @@ function render(ui: React.ReactElement) {
 }
 
 // ── Mock reclassify hook ─────────────────────────────────────────────────────
-vi.mock("@/api/commands", async (importOriginal) => {
-	const mod = await importOriginal<typeof import("@/api/commands")>();
+vi.mock("@/bindings/index", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("@/bindings/index")>();
 	return {
 		...mod,
-		inboxReclassify: vi.fn().mockResolvedValue({
-			inboxItemId: "item-001",
-			remainingUnclassified: 0,
-		}),
+		commands: {
+			...mod.commands,
+			inboxReclassify: vi.fn().mockResolvedValue({
+				status: "ok",
+				data: {
+					inboxItemId: "item-001",
+					remainingUnclassified: 0,
+				},
+			}),
+		},
 	};
 });
 

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
@@ -22,7 +22,7 @@ import { InboxList } from '../InboxList';
 import { FilterToolbar } from '@/components';
 import { useGrouping } from '@/lib/use-grouping';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from '../InboxControls';
-import type { InboxListItem } from '@/api/commands';
+import type { InboxListItem } from '@/bindings/index';
 
 // ── Harness ───────────────────────────────────────────────────────────────────
 // Mirrors InboxPage's wiring: useGrouping owns the grouping state,

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.virtualization.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.virtualization.test.tsx
@@ -26,7 +26,7 @@ import { InboxList } from '../InboxList';
 import { FilterToolbar } from '@/components';
 import { useGrouping } from '@/lib/use-grouping';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from '../InboxControls';
-import type { InboxListItem } from '@/api/commands';
+import type { InboxListItem } from '@/bindings/index';
 
 // Harness mirroring InboxPage: useGrouping + FilterToolbar.grouping feed InboxList.
 function Harness({ items }: { items: InboxListItem[] }) {

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
@@ -54,11 +54,13 @@ const {
 	mockAddToast: vi.fn(),
 }));
 
-vi.mock("@/api/commands", () => ({
-	inboxClassify: mockInboxClassify,
-	inboxConfirm: mockInboxConfirm,
-	inboxReclassify: mockInboxReclassify,
-	inboxScanFolder: mockInboxScanFolder,
+vi.mock("@/bindings/index", () => ({
+	commands: {
+		inboxClassify: mockInboxClassify,
+		inboxConfirm: mockInboxConfirm,
+		inboxReclassify: mockInboxReclassify,
+		inboxScanFolder: mockInboxScanFolder,
+	},
 }));
 
 vi.mock("@/shared/toast", () => ({
@@ -96,11 +98,8 @@ vi.stubEnv("VITE_USE_MOCKS", "true");
 
 // ── Fixtures ──────────────────────────────────────────────────────────────
 
-import type {
-	InboxClassifyResponse,
-	InboxItemSummary,
-	InboxListItem,
-} from "@/api/commands";
+import type { InboxItemSummary, InboxListItem } from "@/bindings/index";
+import type { InboxClassifyResponse } from "@/bindings/aliases";
 
 const mixedClassification: InboxClassifyResponse = {
 	inboxItemId: "item-001",
@@ -201,10 +200,13 @@ describe("InboxDetail", () => {
 
 	it("fires reclassify with correct payload when override applied", async () => {
 		mockInboxReclassify.mockResolvedValue({
-			inboxItemId: "item-001",
-			updatedType: "mixed",
-			remainingUnclassified: 0,
-			appliedCount: 1,
+			status: "ok",
+			data: {
+				inboxItemId: "item-001",
+				updatedType: "mixed",
+				remainingUnclassified: 0,
+				appliedCount: 1,
+			},
 		});
 
 		render(

--- a/apps/desktop/src/features/inbox/__tests__/InboxStatsSummary.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxStatsSummary.test.tsx
@@ -20,8 +20,8 @@ const { mockInboxStats } = vi.hoisted(() => ({
   mockInboxStats: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  inboxStats: mockInboxStats,
+vi.mock('@/bindings/index', () => ({
+  commands: { inboxStats: mockInboxStats },
 }));
 
 vi.stubEnv('VITE_USE_MOCKS', 'true');
@@ -92,7 +92,7 @@ describe('useInboxStats hook', () => {
   });
 
   it('calls inboxStats on mount and returns the response as data', async () => {
-    mockInboxStats.mockResolvedValue(statsWithTypes);
+    mockInboxStats.mockResolvedValue({ status: 'ok', data: statsWithTypes });
 
     const { result } = renderHook(() => useInboxStats());
 

--- a/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
@@ -22,16 +22,18 @@ function makeWrapper() {
   return { queryClient, wrapper };
 }
 import { InboxList } from '../InboxList';
-import type { InboxListItem, InboxListResponse } from '@/api/commands';
+import type { InboxListItem, InboxListResponse } from '@/bindings/index';
 
 // ── sync mock registered at module level (required by vitest hoisting) ────────
 
-vi.mock('@/api/commands', () => ({
-  inboxList: vi.fn(),
-  inboxScanFolder: vi.fn(),
-  inboxClassify: vi.fn(),
-  inboxConfirm: vi.fn(),
-  inboxReclassify: vi.fn(),
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    inboxList: vi.fn(),
+    inboxScanFolder: vi.fn(),
+    inboxClassify: vi.fn(),
+    inboxConfirm: vi.fn(),
+    inboxReclassify: vi.fn(),
+  },
 }));
 
 // ── fixtures ──────────────────────────────────────────────────────────────────
@@ -148,8 +150,11 @@ describe('T039-3: useInboxList hook (FR-001)', () => {
   });
 
   it('returns items after loading', async () => {
-    const { inboxList } = await import('@/api/commands');
-    (inboxList as ReturnType<typeof vi.fn>).mockResolvedValue(multiRootResponse);
+    const { commands } = await import('@/bindings/index');
+    (commands.inboxList as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: 'ok',
+      data: multiRootResponse,
+    });
 
     const { useInboxList } = await import('../store');
     const { wrapper } = makeWrapper();
@@ -162,9 +167,9 @@ describe('T039-3: useInboxList hook (FR-001)', () => {
   });
 
   it('refresh triggers a re-fetch', async () => {
-    const { inboxList } = await import('@/api/commands');
-    const mockFn = inboxList as ReturnType<typeof vi.fn>;
-    mockFn.mockResolvedValue(multiRootResponse);
+    const { commands } = await import('@/bindings/index');
+    const mockFn = commands.inboxList as ReturnType<typeof vi.fn>;
+    mockFn.mockResolvedValue({ status: 'ok', data: multiRootResponse });
 
     const { useInboxList } = await import('../store');
     const { wrapper } = makeWrapper();
@@ -188,10 +193,10 @@ describe('T039-4: useInboxRescan (FR-005)', () => {
   });
 
   it('calls inboxScanFolder once per unique root', async () => {
-    const { inboxScanFolder } = await import('@/api/commands');
-    (inboxScanFolder as ReturnType<typeof vi.fn>).mockResolvedValue({
-      rootId: 'root-001',
-      items: [],
+    const { commands } = await import('@/bindings/index');
+    (commands.inboxScanFolder as ReturnType<typeof vi.fn>).mockResolvedValue({
+      status: 'ok',
+      data: { rootId: 'root-001', items: [] },
     });
 
     const { useInboxRescan } = await import('../store');
@@ -206,13 +211,13 @@ describe('T039-4: useInboxRescan (FR-005)', () => {
       await result.current.rescan();
     });
 
-    expect((inboxScanFolder as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
+    expect((commands.inboxScanFolder as ReturnType<typeof vi.fn>).mock.calls.length).toBe(2);
     expect(onComplete).toHaveBeenCalledOnce();
   });
 
   it('calls onComplete even when a root errors (offline root graceful failure)', async () => {
-    const { inboxScanFolder } = await import('@/api/commands');
-    (inboxScanFolder as ReturnType<typeof vi.fn>).mockRejectedValue(
+    const { commands } = await import('@/bindings/index');
+    (commands.inboxScanFolder as ReturnType<typeof vi.fn>).mockRejectedValue(
       new Error('root offline'),
     );
 

--- a/apps/desktop/src/features/inbox/__tests__/inbox.wave3.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.wave3.test.tsx
@@ -16,20 +16,26 @@
 
 import { render as rtlRender, screen } from "@testing-library/react";
 import { describe, expect, it, vi } from "vitest";
-import type { InboxListItem } from "@/api/commands";
+import type { InboxListItem } from "@/bindings/index";
 
 import { InboxList } from "../InboxList";
 
 // ── Mock reclassify (still imported transitively via InboxList store) ─────────
 
-vi.mock("@/api/commands", async (importOriginal) => {
-	const mod = await importOriginal<typeof import("@/api/commands")>();
+vi.mock("@/bindings/index", async (importOriginal) => {
+	const mod = await importOriginal<typeof import("@/bindings/index")>();
 	return {
 		...mod,
-		inboxReclassify: vi.fn().mockResolvedValue({
-			inboxItemId: "item-001",
-			remainingUnclassified: 0,
-		}),
+		commands: {
+			...mod.commands,
+			inboxReclassify: vi.fn().mockResolvedValue({
+				status: "ok",
+				data: {
+					inboxItemId: "item-001",
+					remainingUnclassified: 0,
+				},
+			}),
+		},
 	};
 });
 

--- a/apps/desktop/src/features/inbox/__tests__/useInboxPlanBreakdowns.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/useInboxPlanBreakdowns.test.tsx
@@ -22,8 +22,8 @@ const { mockInboxClassify } = vi.hoisted(() => ({
   mockInboxClassify: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  inboxClassify: mockInboxClassify,
+vi.mock('@/bindings/index', () => ({
+  commands: { inboxClassify: mockInboxClassify },
 }));
 
 import { useInboxPlanBreakdowns } from '../store';
@@ -58,15 +58,19 @@ describe('useInboxPlanBreakdowns (#98)', () => {
   it('fetches a classify per target and maps the breakdown by item id (incl. an UNSELECTED item)', async () => {
     mockInboxClassify.mockImplementation((req: { inboxItemId: string }) => {
       if (req.inboxItemId === 'a') {
-        return Promise.resolve(
-          classifyResponse('a', [
+        return Promise.resolve({
+          status: 'ok',
+          data: classifyResponse('a', [
             { kind: 'bias', count: 10 },
             { kind: 'dark', count: 16 },
             { kind: 'flat', count: 15 },
           ]),
-        );
+        });
       }
-      return Promise.resolve(classifyResponse('b', [{ kind: 'light', count: 30 }]));
+      return Promise.resolve({
+        status: 'ok',
+        data: classifyResponse('b', [{ kind: 'light', count: 30 }]),
+      });
     });
 
     const targets: InboxBreakdownTarget[] = [
@@ -98,7 +102,7 @@ describe('useInboxPlanBreakdowns (#98)', () => {
   });
 
   it('omits an item whose classify returns an empty breakdown', async () => {
-    mockInboxClassify.mockResolvedValue(classifyResponse('a', []));
+    mockInboxClassify.mockResolvedValue({ status: 'ok', data: classifyResponse('a', []) });
     const targets: InboxBreakdownTarget[] = [
       { inboxItemId: 'a', rootAbsolutePath: '/lib/root-a' },
     ];

--- a/apps/desktop/src/features/inbox/inboxStatsFromItems.test.ts
+++ b/apps/desktop/src/features/inbox/inboxStatsFromItems.test.ts
@@ -10,7 +10,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { deriveInboxStats } from './inboxStatsFromItems';
-import type { InboxListItem } from '@/api/commands';
+import type { InboxListItem } from '@/bindings/index';
 
 function folder(id: string, frameType: string | null, files: number): InboxListItem {
   return {

--- a/apps/desktop/src/features/inbox/inboxStatsFromItems.ts
+++ b/apps/desktop/src/features/inbox/inboxStatsFromItems.ts
@@ -16,7 +16,7 @@
  * used by the InboxList header and footer.
  */
 
-import type { InboxListItem, InboxStatsResponse, InboxStatsPerType } from '@/api/commands';
+import type { InboxListItem, InboxStatsResponse, InboxStatsPerType } from '@/bindings/index';
 
 /** Bucket key for a folder/master whose frame type is unknown or spans types. */
 const MIXED_KEY = 'mixed';

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -13,28 +13,12 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useQuery, useQueries, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/data/queryKeys";
-import {
-  inboxScanFolder,
-  inboxClassify,
-  inboxConfirm,
-  inboxList,
-  inboxItemMetadata,
-  inboxReclassify,
-  inboxPlan,
-  inboxPlanApply,
-  inboxPlanApplyAll,
-  inboxPlanCancel,
-  listOpenInboxPlans,
-  applySelectedInboxPlans,
-  inboxStats,
-} from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import type {
-  InboxClassifyResponse,
-  InboxConfirmResponse,
   InboxListItem,
   InboxListResponse,
-  InboxReclassifyResponse,
-  InboxFileMetadata,
+  InboxConfirmResponse,
   InboxScanFolderResponse,
   InboxApplyAllResponse,
   InboxPlanCancelResponse,
@@ -46,7 +30,12 @@ import type {
   InboxStatsResponse,
   InboxStatsPerType,
   InboxStatsTotals,
-} from '@/api/commands';
+  InboxFileMetadata_Serialize as InboxFileMetadata,
+} from '@/bindings/index';
+import type {
+  InboxClassifyResponse,
+  InboxReclassifyResponse,
+} from '@/bindings/aliases';
 
 export type {
   InboxFileMetadata,
@@ -81,13 +70,15 @@ export function useInboxClassification(
     : `${rootAbsolutePath}|${inboxItemId}`;
   const { data, isFetching, error } = useQuery<InboxClassifyResponse>({
     queryKey: [queryKeys.inbox.list('all')[0], "classify", key],
-    queryFn: () => {
+    queryFn: async () => {
       const [rootPath, itemId, forceStr] = key.split("|");
-      return inboxClassify({
-        inboxItemId: itemId,
-        rootAbsolutePath: rootPath,
-        forceRescan: forceStr === "force",
-      });
+      return unwrap(
+        await commands.inboxClassify({
+          inboxItemId: itemId,
+          rootAbsolutePath: rootPath,
+          forceRescan: forceStr === "force",
+        }),
+      );
     },
     enabled: !!inboxItemId && !!rootAbsolutePath,
   });
@@ -128,12 +119,14 @@ export function useInboxPlanBreakdowns(
       const key = `${t.rootAbsolutePath}|${t.inboxItemId}`;
       return {
         queryKey: [queryKeys.inbox.list("all")[0], "classify", key],
-        queryFn: () =>
-          inboxClassify({
-            inboxItemId: t.inboxItemId,
-            rootAbsolutePath: t.rootAbsolutePath,
-            forceRescan: false,
-          }),
+        queryFn: async () =>
+          unwrap(
+            await commands.inboxClassify({
+              inboxItemId: t.inboxItemId,
+              rootAbsolutePath: t.rootAbsolutePath,
+              forceRescan: false,
+            }),
+          ),
         enabled: !!t.inboxItemId && !!t.rootAbsolutePath,
         // Breakdown is stable for an unchanged folder — avoid re-fetch churn.
         staleTime: 30_000,
@@ -172,7 +165,8 @@ export function useInboxPlanBreakdowns(
 export function useInboxScan(rootId: string, rootAbsolutePath: string) {
   const { data, isFetching, error } = useQuery<InboxScanFolderResponse>({
     queryKey: [queryKeys.inbox.list('all')[0], "scan", rootId, rootAbsolutePath],
-    queryFn: () => inboxScanFolder({ rootId, rootAbsolutePath, followSymlinks: false }),
+    queryFn: async () =>
+      unwrap(await commands.inboxScanFolder({ rootId, rootAbsolutePath, followSymlinks: false })),
     enabled: !!rootId && !!rootAbsolutePath,
   });
   return { data, loading: isFetching, error: error ?? undefined };
@@ -190,7 +184,7 @@ export function useInboxList() {
   const listKey = queryKeys.inbox.list('all');
   const { data, isFetching, error } = useQuery<InboxListResponse>({
     queryKey: listKey,
-    queryFn: () => inboxList(),
+    queryFn: async () => unwrap(await commands.inboxList()),
   });
   const refresh = useCallback(() => {
     void queryClient.invalidateQueries({ queryKey: listKey });
@@ -271,13 +265,15 @@ export function useInboxConfirm() {
     }) => {
       setState({ loading: true, result: null, error: null, errorCode: null, errorDetails: null });
       try {
-        const result = await inboxConfirm({
-          inboxItemId: args.inboxItemId,
-          contentSignature: args.contentSignature,
-          rootAbsolutePath: args.rootAbsolutePath,
-          destructiveDestination: args.destructiveDestination ?? null,
-          rootId: args.rootId ?? null,
-        });
+        const result = unwrap(
+          await commands.inboxConfirm({
+            inboxItemId: args.inboxItemId,
+            contentSignature: args.contentSignature,
+            rootAbsolutePath: args.rootAbsolutePath,
+            destructiveDestination: args.destructiveDestination ?? null,
+            rootId: args.rootId ?? null,
+          }),
+        );
         setState({ loading: false, result, error: null, errorCode: null, errorDetails: null });
         // Invalidate the inbox list so it refreshes after confirmation.
         // Use queryKeys.inbox.list(rootId) prefix — ['inbox'] covers both the
@@ -321,7 +317,11 @@ export function useInboxReclassify(inboxItemId: string) {
     async (overrides: Array<{ filePath: string; frameType?: string | null; filter?: string | null; exposureS?: number | null; binning?: string | null }>) => {
       setState({ loading: true, result: null, error: null });
       try {
-        const result = await inboxReclassify({ inboxItemId, overrides });
+        const result = unwrap(
+          await commands.inboxReclassify(
+            { inboxItemId, overrides } as Parameters<typeof commands.inboxReclassify>[0],
+          ),
+        );
         setState({ loading: false, result, error: null });
         // Invalidate all classification cache entries so the UI refreshes.
         void queryClient.invalidateQueries({
@@ -356,7 +356,10 @@ export interface InboxItemMetadataState {
 export function useInboxItemMetadata(itemId: string | null): InboxItemMetadataState {
   const { data, isFetching, error } = useQuery<InboxFileMetadata[]>({
     queryKey: queryKeys.inbox.metadata(itemId ?? '__none__'),
-    queryFn: () => inboxItemMetadata(itemId as string),
+    queryFn: async () => {
+      const resp = unwrap(await commands.inboxItemMetadata({ inboxItemId: itemId as string }));
+      return resp.files;
+    },
     enabled: itemId != null,
   });
 
@@ -390,8 +393,14 @@ export function useInboxRescan(
     setState({ loading: true, error: null });
     try {
       await Promise.all(
-        roots.map((r) =>
-          inboxScanFolder({ rootId: r.rootId, rootAbsolutePath: r.rootAbsolutePath, followSymlinks: false }),
+        roots.map(async (r) =>
+          unwrap(
+            await commands.inboxScanFolder({
+              rootId: r.rootId,
+              rootAbsolutePath: r.rootAbsolutePath,
+              followSymlinks: false,
+            }),
+          ),
         ),
       );
       setState({ loading: false, error: null });
@@ -428,7 +437,7 @@ export function useInboxPlan(inboxItemId: string) {
     }
     setState((s) => ({ ...s, loading: true, error: null }));
     try {
-      const plan = await inboxPlan(inboxItemId);
+      const plan = unwrap(await commands.inboxPlan(inboxItemId));
       setState({ plan, loading: false, error: null });
     } catch (e: unknown) {
       const msg = String(e);
@@ -458,7 +467,7 @@ export function useInboxPlanApply() {
     async (inboxItemId: string): Promise<PlanApplyResponse | null> => {
       setState({ loading: true, error: null });
       try {
-        const result = await inboxPlanApply(inboxItemId);
+        const result = unwrap(await commands.inboxPlanApply(inboxItemId));
         setState({ loading: false, error: null });
         return result;
       } catch (e: unknown) {
@@ -479,7 +488,7 @@ export function useInboxPlanApplyAll() {
   const applyAll = useCallback(async (): Promise<InboxApplyAllResponse | null> => {
     setState({ loading: true, error: null });
     try {
-      const result = await inboxPlanApplyAll();
+      const result = unwrap(await commands.inboxPlanApplyAll());
       setState({ loading: false, error: null });
       return result;
     } catch (e: unknown) {
@@ -499,7 +508,7 @@ export function useInboxPlanCancel() {
     async (inboxItemId: string): Promise<InboxPlanCancelResponse | null> => {
       setState({ loading: true, error: null });
       try {
-        const result = await inboxPlanCancel(inboxItemId);
+        const result = unwrap(await commands.inboxPlanCancel(inboxItemId));
         setState({ loading: false, error: null });
         return result;
       } catch (e: unknown) {
@@ -539,7 +548,9 @@ export function useOpenInboxPlans() {
   useEffect(() => {
     let cancelled = false;
     setState((s) => ({ ...s, loading: true, error: null }));
-    listOpenInboxPlans()
+    commands
+      .inboxPlanListOpen()
+      .then(unwrap)
       .then((resp) => {
         if (!cancelled) setState({ data: resp, loading: false, error: null });
       })
@@ -567,7 +578,7 @@ export function useApplySelectedInboxPlans() {
     async (inboxItemIds: string[]): Promise<InboxApplyAllResponse | null> => {
       setState({ loading: true, error: null });
       try {
-        const result = await applySelectedInboxPlans(inboxItemIds);
+        const result = unwrap(await commands.inboxPlanApplySelected({ inboxItemIds }));
         setState({ loading: false, error: null });
         return result;
       } catch (e: unknown) {
@@ -605,7 +616,9 @@ export function useInboxStats() {
   useEffect(() => {
     let cancelled = false;
     setState((s) => ({ ...s, loading: true, error: null }));
-    inboxStats()
+    commands
+      .inboxStats()
+      .then(unwrap)
       .then((resp) => {
         if (!cancelled) setState({ data: resp, loading: false, error: null });
       })


### PR DESCRIPTION
## Summary
Spec 037 Phase-3 caller migration for the **inbox** area: repoints off the hand-written `@/api/commands` `invoke()` wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`), eliminating the IPC name/payload drift-bug class.

inbox feature (16 files; scan/classify/confirm/plan/reclassify + 9 test files).

Verified locally: `tsc --noEmit` clean; area vitest green; `eslint` 0 errors (pre-existing warnings only). Follows the merged calibration (#359) / plans (#368) / sessions (#369) pattern.

## Spec Context
- Spec: 037
- Branch: 037-inbox