### PR TITLE
feat(037): migrate projects area to generated IPC bindings

### DIFF
--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
@@ -15,15 +15,15 @@
 import { render, screen, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-// Mock API commands
-vi.mock('@/api/commands', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/api/commands')>();
+// Mock the calibration-match IPC helper
+vi.mock('./calibrationMatch', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./calibrationMatch')>();
   return { ...original, calibrationMatchSuggestBatch: vi.fn() };
 });
 
 import { CalibrationMatchPanel } from './CalibrationMatchPanel';
-import { calibrationMatchSuggestBatch } from '@/api/commands';
-import type { CalibrationMatchBatchResponse } from '@/api/commands';
+import { calibrationMatchSuggestBatch } from './calibrationMatch';
+import type { CalibrationMatchBatchResponse } from '@/bindings/index';
 
 const SESSION_1 = 'ses-aabbccdd-0001';
 const SESSION_2 = 'ses-aabbccdd-0002';

--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.tsx
@@ -20,8 +20,9 @@
 import { useState, useEffect } from 'react';
 import { Section, Pill, EmptyState } from '@/ui';
 import type { PillVariant } from '@/ui';
-import { calibrationMatchSuggestBatch } from '@/api/commands';
-import type { BatchSessionResultDto, CalibrationMatchType } from '@/api/commands';
+import { calibrationMatchSuggestBatch } from './calibrationMatch';
+import type { CalibrationMatchType } from './calibrationMatch';
+import type { BatchSessionResultDto } from '@/bindings/index';
 import { errMessage } from '@/lib/errors';
 import { m } from '@/lib/i18n';
 

--- a/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
@@ -23,17 +23,6 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
-vi.mock('@/api/commands', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/api/commands')>();
-  return {
-    ...original,
-    applyProjectLifecycleTransition: vi.fn(),
-    getProject008: vi.fn(),
-    reinferProjectChannels: vi.fn(),
-    dismissProjectChannelDrift: vi.fn(),
-  };
-});
-
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {

--- a/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
@@ -19,18 +19,6 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
-// Mock VITE_USE_MOCKS so commands.ts goes through the mocked invoke path
-vi.mock('@/api/commands', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/api/commands')>();
-  return {
-    ...original,
-    applyProjectLifecycleTransition: vi.fn(),
-    getProject008: vi.fn(),
-    reinferProjectChannels: vi.fn(),
-    dismissProjectChannelDrift: vi.fn(),
-  };
-});
-
 // Mock the project detail store
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();

--- a/apps/desktop/src/features/projects/ProjectDetail.manifests.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.manifests.test.tsx
@@ -36,28 +36,23 @@ const {
   mockAddToast: vi.fn(),
 }));
 
-// Mock @/api/commands — spread original so other commands keep working.
-vi.mock('@/api/commands', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/api/commands')>();
+// Mock the generated bindings surface — manifests.ts (spec 037 caller
+// migration) now calls commands.manifestList/manifestGet/noteGet/noteUpdate/
+// manifestRevealInOs directly instead of the old @/api/commands wrappers.
+// Spread the original so other commands (e.g. calibrationMatchSuggestBatch)
+// keep working.
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/bindings/index')>();
   return {
     ...original,
-    listManifests: mockListManifests,
-    getManifest: mockGetManifest,
-    getProjectNote: mockGetProjectNote,
-    updateProjectNote: mockUpdateProjectNote,
-    revealManifestInOs: mockRevealManifestInOs,
-    // Other commands used indirectly by ProjectDetail children
-    applyProjectLifecycleTransition: vi.fn(),
-    getProject008: vi.fn(),
-    reinferProjectChannels: vi.fn(),
-    dismissProjectChannelDrift: vi.fn(),
-    calibrationMatchSuggestBatch: vi.fn().mockResolvedValue({
-      status: 'success',
-      contractVersion: '2.0.0',
-      requestId: 'req-0',
-      results: [],
-    }),
-    listToolProfiles: vi.fn().mockResolvedValue([]),
+    commands: {
+      ...original.commands,
+      manifestList: mockListManifests,
+      manifestGet: mockGetManifest,
+      noteGet: mockGetProjectNote,
+      noteUpdate: mockUpdateProjectNote,
+      manifestRevealInOs: mockRevealManifestInOs,
+    },
   };
 });
 
@@ -119,6 +114,11 @@ const MANIFEST_BODY = {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/** Wrap a fixture as a successful generated-binding `Result` (spec 037). */
+function ok<T>(data: T) {
+  return { status: 'ok' as const, data };
+}
+
 function setupStore(project: Partial<ProjectDetailDto> = {}) {
   vi.mocked(store.useProjectDetail).mockReturnValue({
     data: { ...BASE_PROJECT, ...project },
@@ -142,21 +142,20 @@ function renderDetail(projectId = 'proj-m1') {
 describe('ProjectDetail — manifests accordion (spec 024)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetProjectNote.mockResolvedValue({ projectId: 'proj-m1', content: null });
-    mockListManifests.mockResolvedValue({ manifests: [], nextCursor: null });
-    mockGetManifest.mockResolvedValue({
-      manifest: { ...MANIFEST_SUMMARY, projectId: 'proj-m1', version: 1, body: MANIFEST_BODY },
-    });
-    mockRevealManifestInOs.mockResolvedValue(undefined);
-    mockUpdateProjectNote.mockResolvedValue({
-      projectId: 'proj-m1',
-      updatedAt: '2026-06-01T12:00:00Z',
-    });
+    mockGetProjectNote.mockResolvedValue(ok({ projectId: 'proj-m1', content: null }));
+    mockListManifests.mockResolvedValue(ok({ manifests: [], nextCursor: null }));
+    mockGetManifest.mockResolvedValue(
+      ok({ manifest: { ...MANIFEST_SUMMARY, projectId: 'proj-m1', version: 1, body: MANIFEST_BODY } }),
+    );
+    mockRevealManifestInOs.mockResolvedValue(ok(null));
+    mockUpdateProjectNote.mockResolvedValue(
+      ok({ projectId: 'proj-m1', updatedAt: '2026-06-01T12:00:00Z' }),
+    );
     setupStore();
   });
 
   it('1. shows manifests-empty state when project has no manifests', async () => {
-    mockListManifests.mockResolvedValue({ manifests: [], nextCursor: null });
+    mockListManifests.mockResolvedValue(ok({ manifests: [], nextCursor: null }));
     renderDetail();
     // Manifests section is defaultOpen=true in the bottom panel — no expand needed.
     await waitFor(() => {
@@ -165,10 +164,7 @@ describe('ProjectDetail — manifests accordion (spec 024)', () => {
   });
 
   it('2. renders manifest list when manifests exist', async () => {
-    mockListManifests.mockResolvedValue({
-      manifests: [MANIFEST_SUMMARY],
-      nextCursor: null,
-    });
+    mockListManifests.mockResolvedValue(ok({ manifests: [MANIFEST_SUMMARY], nextCursor: null }));
     renderDetail();
     // Manifests section is defaultOpen=true in the bottom panel — no expand needed.
     await waitFor(() => {
@@ -182,18 +178,17 @@ describe('ProjectDetail — manifests accordion (spec 024)', () => {
   });
 
   it('3. clicking a manifest row loads and shows the body', async () => {
-    mockListManifests.mockResolvedValue({
-      manifests: [MANIFEST_SUMMARY],
-      nextCursor: null,
-    });
-    mockGetManifest.mockResolvedValue({
-      manifest: {
-        ...MANIFEST_SUMMARY,
-        projectId: 'proj-m1',
-        version: 1,
-        body: { ...MANIFEST_BODY, lifecycleState: 'processing' },
-      },
-    });
+    mockListManifests.mockResolvedValue(ok({ manifests: [MANIFEST_SUMMARY], nextCursor: null }));
+    mockGetManifest.mockResolvedValue(
+      ok({
+        manifest: {
+          ...MANIFEST_SUMMARY,
+          projectId: 'proj-m1',
+          version: 1,
+          body: { ...MANIFEST_BODY, lifecycleState: 'processing' },
+        },
+      }),
+    );
     renderDetail();
     // Manifests section is defaultOpen=true in the bottom panel — no expand needed.
     await waitFor(() => {
@@ -211,10 +206,7 @@ describe('ProjectDetail — manifests accordion (spec 024)', () => {
   });
 
   it('4. Reveal button calls revealManifestInOs', async () => {
-    mockListManifests.mockResolvedValue({
-      manifests: [MANIFEST_SUMMARY],
-      nextCursor: null,
-    });
+    mockListManifests.mockResolvedValue(ok({ manifests: [MANIFEST_SUMMARY], nextCursor: null }));
     renderDetail();
     // Manifests section is defaultOpen=true in the bottom panel — no expand needed.
     await waitFor(() => {
@@ -231,10 +223,7 @@ describe('ProjectDetail — manifests accordion (spec 024)', () => {
   });
 
   it('5. Reveal failure shows error toast', async () => {
-    mockListManifests.mockResolvedValue({
-      manifests: [MANIFEST_SUMMARY],
-      nextCursor: null,
-    });
+    mockListManifests.mockResolvedValue(ok({ manifests: [MANIFEST_SUMMARY], nextCursor: null }));
     mockRevealManifestInOs.mockRejectedValue('manifest file not found: /some/path');
     renderDetail();
     // Manifests section is defaultOpen=true in the bottom panel — no expand needed.
@@ -264,20 +253,19 @@ describe('ProjectDetail — manifests accordion (spec 024)', () => {
 describe('ProjectDetail — project notes section (spec 024)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockListManifests.mockResolvedValue({ manifests: [], nextCursor: null });
-    mockGetManifest.mockResolvedValue({
-      manifest: { ...MANIFEST_SUMMARY, projectId: 'proj-m1', version: 1, body: MANIFEST_BODY },
-    });
-    mockRevealManifestInOs.mockResolvedValue(undefined);
-    mockUpdateProjectNote.mockResolvedValue({
-      projectId: 'proj-m1',
-      updatedAt: '2026-06-01T12:00:00Z',
-    });
+    mockListManifests.mockResolvedValue(ok({ manifests: [], nextCursor: null }));
+    mockGetManifest.mockResolvedValue(
+      ok({ manifest: { ...MANIFEST_SUMMARY, projectId: 'proj-m1', version: 1, body: MANIFEST_BODY } }),
+    );
+    mockRevealManifestInOs.mockResolvedValue(ok(null));
+    mockUpdateProjectNote.mockResolvedValue(
+      ok({ projectId: 'proj-m1', updatedAt: '2026-06-01T12:00:00Z' }),
+    );
     setupStore();
   });
 
   it('7. shows "No notes." when project has no notes', async () => {
-    mockGetProjectNote.mockResolvedValue({ projectId: 'proj-m1', content: null });
+    mockGetProjectNote.mockResolvedValue(ok({ projectId: 'proj-m1', content: null }));
     // ProjectNotesSection is rendered inline — check for notes-empty placeholder
     // after the async note fetch resolves.
     renderDetail();
@@ -292,7 +280,7 @@ describe('ProjectDetail — project notes section (spec 024)', () => {
     // receives initialContent as a prop from ProjectDetail, and ProjectDetail
     // currently passes undefined (the component fetches its own data internally),
     // we test the section renders with empty state by default.
-    mockGetProjectNote.mockResolvedValue({ projectId: 'proj-m1', content: null });
+    mockGetProjectNote.mockResolvedValue(ok({ projectId: 'proj-m1', content: null }));
     renderDetail();
     await waitFor(() => {
       expect(screen.getByTestId('notes-empty')).toBeInTheDocument();
@@ -303,7 +291,7 @@ describe('ProjectDetail — project notes section (spec 024)', () => {
   });
 
   it('9. notes section is read-only for archived projects', async () => {
-    mockGetProjectNote.mockResolvedValue({ projectId: 'proj-m1', content: null });
+    mockGetProjectNote.mockResolvedValue(ok({ projectId: 'proj-m1', content: null }));
     setupStore({ lifecycle: 'archived' });
     renderDetail();
     await waitFor(() => {
@@ -314,7 +302,7 @@ describe('ProjectDetail — project notes section (spec 024)', () => {
   });
 
   it('10. listManifests is called with the project id', async () => {
-    mockGetProjectNote.mockResolvedValue({ projectId: 'proj-m1', content: null });
+    mockGetProjectNote.mockResolvedValue(ok({ projectId: 'proj-m1', content: null }));
     renderDetail('proj-m1');
     await waitFor(() => {
       expect(mockListManifests).toHaveBeenCalledWith(

--- a/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
@@ -16,26 +16,6 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockAddToast } = vi.hoisted(() => ({ mockAddToast: vi.fn() }));
 
-vi.mock('@/api/commands', async (importOriginal) => {
-  const original = await importOriginal<typeof import('@/api/commands')>();
-  return {
-    ...original,
-    listManifests: vi.fn().mockResolvedValue({ manifests: [], nextCursor: null }),
-    getProjectNote: vi.fn().mockResolvedValue({ projectId: 'proj-m31', content: null }),
-    applyProjectLifecycleTransition: vi.fn(),
-    getProject008: vi.fn(),
-    reinferProjectChannels: vi.fn(),
-    dismissProjectChannelDrift: vi.fn(),
-    calibrationMatchSuggestBatch: vi.fn().mockResolvedValue({
-      status: 'success',
-      contractVersion: '2.0.0',
-      requestId: 'req-0',
-      results: [],
-    }),
-    listToolProfiles: vi.fn().mockResolvedValue([]),
-  };
-});
-
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {

--- a/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
+++ b/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
@@ -13,7 +13,7 @@
 import { useCallback } from 'react';
 import { basename } from 'pathe';
 import { m } from '@/lib/i18n';
-import type { ArtifactSummary } from '@/api/commands';
+import type { ArtifactSummary } from '@/bindings/index';
 import {
   groupArtifactsByLaunch,
   useArtifacts,

--- a/apps/desktop/src/features/projects/artifacts.test.ts
+++ b/apps/desktop/src/features/projects/artifacts.test.ts
@@ -7,7 +7,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { groupArtifactsByLaunch } from './artifacts';
-import type { ArtifactSummary } from '@/api/commands';
+import type { ArtifactSummary } from '@/bindings/index';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/features/projects/artifacts.ts
+++ b/apps/desktop/src/features/projects/artifacts.ts
@@ -9,15 +9,34 @@
  */
 
 import { useState, useCallback, useEffect } from 'react';
-import {
-  artifactList,
-  artifactClassify,
-  artifactMarkResolved,
-  type ArtifactSummary,
-  type ArtifactListResponse,
-  type ArtifactClassifyRequest,
-} from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type {
+  ArtifactSummary,
+  ArtifactListRequest,
+  ArtifactListResponse,
+  ArtifactClassifyRequest,
+  ArtifactClassifyResponse,
+  ArtifactMarkResolvedRequest,
+} from '@/bindings/index';
 import { errMessage } from '@/lib/errors';
+
+// Local IPC helpers — migrated off the hand-written @/api/commands wrappers
+// (spec 037) onto the generated bindings.
+
+async function artifactList(request: ArtifactListRequest): Promise<ArtifactListResponse> {
+  return unwrap(await commands.artifactList(request));
+}
+
+async function artifactClassify(
+  request: ArtifactClassifyRequest,
+): Promise<ArtifactClassifyResponse> {
+  return unwrap(await commands.artifactClassify(request));
+}
+
+async function artifactMarkResolved(request: ArtifactMarkResolvedRequest): Promise<void> {
+  unwrap(await commands.artifactMarkResolved(request));
+}
 
 // ── Grouping types ─────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/features/projects/calibrationMatch.ts
+++ b/apps/desktop/src/features/projects/calibrationMatch.ts
@@ -1,0 +1,38 @@
+/**
+ * `calibration.match.suggest.batch` IPC helper (spec 037 caller migration).
+ *
+ * Moves the batch-suggest glue off the hand-written `@/api/commands` wrapper
+ * onto the generated `commands.calibrationMatchSuggestBatch` binding
+ * (FR-004: the behaviour is moved, not dropped). Supplies the fixed
+ * `contractVersion` and defaults `calibrationTypes` to `null` when omitted.
+ *
+ * Note: `calibration.match.suggest.batch` supports partial success — the
+ * *transport*-level Result is unwrapped here (throws on IPC/contract error),
+ * but the response's own `status` field ('success' | 'error') carries
+ * per-session batch outcomes and is left for the caller to inspect.
+ */
+
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { CalibrationMatchBatchResponse, CalibrationType } from '@/bindings/index';
+
+export type CalibrationMatchType = CalibrationType;
+
+/**
+ * `calibration.match.suggest.batch` — suggest for multiple sessions in one call.
+ * Supports partial success.
+ */
+export async function calibrationMatchSuggestBatch(args: {
+  requestId: string;
+  sessionIds: string[];
+  calibrationTypes?: CalibrationMatchType[];
+}): Promise<CalibrationMatchBatchResponse> {
+  return unwrap(
+    await commands.calibrationMatchSuggestBatch({
+      contractVersion: '1.0',
+      requestId: args.requestId,
+      sessionIds: args.sessionIds,
+      calibrationTypes: args.calibrationTypes ?? null,
+    }),
+  );
+}

--- a/apps/desktop/src/features/projects/create/CreateProjectDialog.test.tsx
+++ b/apps/desktop/src/features/projects/create/CreateProjectDialog.test.tsx
@@ -26,7 +26,6 @@ const { mockCreateProject, mockListProjects, mockSearchTargets, mockResolveTarge
 
 vi.mock('@/api/commands', () => ({
   createProject: mockCreateProject,
-  listProjects008: mockListProjects,
   updateProject: vi.fn(),
   addProjectSource: vi.fn(),
   removeProjectSource: vi.fn(),
@@ -38,6 +37,17 @@ vi.mock('@/api/commands', () => ({
   resolveTarget: mockResolveTarget,
   TARGET_SEARCH_CONTRACT_VERSION: '1.0',
 }));
+
+// CreateProjectDialog's live duplicate-name check now calls
+// commands.projectsList directly (spec 037 caller migration) instead of the
+// old @/api/commands wrapper.
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...original,
+    commands: { ...original.commands, projectsList: mockListProjects },
+  };
+});
 
 // Mock the store's useCreateProject so it calls our mock
 vi.mock('@/features/projects/store', () => ({
@@ -82,7 +92,7 @@ function renderDialog(open = true) {
 describe('CreateProjectDialog', () => {
   beforeEach(() => {
     mockCreateProject.mockReset();
-    mockListProjects.mockResolvedValue([]);
+    mockListProjects.mockResolvedValue({ status: 'ok', data: [] });
     mockSearchTargets.mockReset();
     mockResolveTarget.mockReset();
     // Default: TargetSearch finds nothing / resolves nothing (no network).
@@ -118,7 +128,7 @@ describe('CreateProjectDialog', () => {
   });
 
   it('shows name required error on submit with empty name', async () => {
-    mockListProjects.mockResolvedValue([]);
+    mockListProjects.mockResolvedValue({ status: 'ok', data: [] });
     renderDialog();
     const submit = screen.getByRole('button', { name: /create project/i });
     await act(async () => {
@@ -130,7 +140,7 @@ describe('CreateProjectDialog', () => {
   });
 
   it('shows path required error on submit with empty path', async () => {
-    mockListProjects.mockResolvedValue([]);
+    mockListProjects.mockResolvedValue({ status: 'ok', data: [] });
     renderDialog();
     const nameInput = screen.getByLabelText(/project name/i);
     fireEvent.change(nameInput, { target: { value: 'Test Project' } });
@@ -145,7 +155,7 @@ describe('CreateProjectDialog', () => {
   });
 
   it('calls onSuccess with result when form submits successfully', async () => {
-    mockListProjects.mockResolvedValue([]);
+    mockListProjects.mockResolvedValue({ status: 'ok', data: [] });
     const successResult = {
       projectId: 'proj-new',
       lifecycle: 'setup_incomplete',
@@ -182,7 +192,7 @@ describe('CreateProjectDialog', () => {
   });
 
   it('sends the selected target as canonicalTargetId (spec 035 US1)', async () => {
-    mockListProjects.mockResolvedValue([]);
+    mockListProjects.mockResolvedValue({ status: 'ok', data: [] });
     mockCreateProject.mockResolvedValue({
       projectId: 'proj-new',
       lifecycle: 'setup_incomplete',
@@ -237,7 +247,7 @@ describe('CreateProjectDialog', () => {
   });
 
   it('shows error message when command returns an error code', async () => {
-    mockListProjects.mockResolvedValue([]);
+    mockListProjects.mockResolvedValue({ status: 'ok', data: [] });
     mockCreateProject.mockRejectedValue('name.duplicate');
 
     renderDialog();

--- a/apps/desktop/src/features/projects/create/CreateProjectDialog.tsx
+++ b/apps/desktop/src/features/projects/create/CreateProjectDialog.tsx
@@ -28,10 +28,11 @@ import { Dialog } from '@base-ui-components/react/dialog';
 import { Btn, RadioGroup, Pill } from '@/ui';
 import type { RadioOption } from '@/ui';
 import { callCreateProject } from '@/features/projects/store';
-import { listProjects008 } from '@/api/commands';
-import type { TargetSuggestion } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { TargetSuggestion } from '@/bindings/aliases';
 import { TargetSearch } from '@/components';
-import type { ProjectCreateResult } from '@/bindings/index';
+import type { ProjectCreateResult, ProjectSummaryDto } from '@/bindings/index';
 import {
   createProjectFormSchema,
   type CreateProjectFormValues,
@@ -100,7 +101,7 @@ export function CreateProjectDialog({ open, onClose, onSuccess }: CreateProjectD
   async function onValid(values: CreateProjectFormValues) {
     const trimmedName = values.name.trim();
     try {
-      const list = await listProjects008();
+      const list: ProjectSummaryDto[] = unwrap(await commands.projectsList(null));
       const dup = list.find((p) => p.name.toLowerCase() === trimmedName.toLowerCase());
       if (dup) {
         setError('name', { type: 'duplicate', message: m.projects_create_name_duplicate() });

--- a/apps/desktop/src/features/projects/lifecycleTransition.ts
+++ b/apps/desktop/src/features/projects/lifecycleTransition.ts
@@ -1,0 +1,72 @@
+/**
+ * Project lifecycle transition IPC helper (spec 037 caller migration).
+ *
+ * Moves the `applyProjectLifecycleTransition` glue off the hand-written
+ * `@/api/commands` wrapper onto the generated `commands.lifecycleTransitionApply`
+ * binding (FR-004: the behaviour is moved, not dropped). The generated
+ * `lifecycle.transition.apply` command is a tagged union over entity kind
+ * (`{ project: {...} }` | `{ plan: {...} }` | ...); this helper builds the
+ * `project` variant and unwraps the generated `Result` into the throw-on-error
+ * contract callers expect.
+ */
+
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type { ProjectState, TransitionActor } from '@/bindings/index';
+
+export type ProjectLifecycleState = ProjectState;
+export type { TransitionActor };
+
+export interface ProjectLifecycleTransitionRequest {
+  contractVersion: string;
+  requestId: string;
+  entityType: 'project';
+  entityId: string;
+  currentState: ProjectLifecycleState;
+  nextState: ProjectLifecycleState;
+  actionLabel?: string;
+  actor: TransitionActor;
+}
+
+export type TransitionErrorCode =
+  | 'transition.refused'
+  | 'entity.not_found'
+  | 'actor.not_authorised'
+  | 'plan.required'
+  | 'plan.not_approved'
+  | 'provenance.unreviewed';
+
+export interface TransitionError {
+  code: TransitionErrorCode;
+  message: string;
+  details?: unknown;
+}
+
+export type TransitionStatus = 'success' | 'noop' | 'error';
+
+export interface LifecycleTransitionResponse {
+  status: TransitionStatus;
+  contractVersion: string;
+  requestId: string;
+  appliedAt?: string;
+  priorState?: string;
+  newState?: string;
+  auditId?: string;
+  planId?: string;
+  error?: TransitionError;
+}
+
+/**
+ * Apply a project lifecycle transition.
+ * Returns the transition response (check response.status for success/error).
+ * Plan-required edges return status='error' with error.code='plan.required'.
+ */
+export async function applyProjectLifecycleTransition(
+  req: ProjectLifecycleTransitionRequest,
+): Promise<LifecycleTransitionResponse> {
+  return unwrap(
+    await commands.lifecycleTransitionApply(
+      { project: req } as Parameters<typeof commands.lifecycleTransitionApply>[0],
+    ),
+  ) as LifecycleTransitionResponse;
+}

--- a/apps/desktop/src/features/projects/manifests.test.ts
+++ b/apps/desktop/src/features/projects/manifests.test.ts
@@ -18,17 +18,21 @@ import {
   MAX_NOTE_BYTES,
 } from './manifests';
 
-// ── Mock updateProjectNote ────────────────────────────────────────────────────
+// ── Mock updateProjectNote (spec 037: mocked at the generated-bindings
+// boundary — manifests.ts now calls commands.noteUpdate directly) ────────────
 
-const { mockUpdateProjectNote } = vi.hoisted(() => ({
-  mockUpdateProjectNote: vi.fn(),
+const { mockNoteUpdate } = vi.hoisted(() => ({
+  mockNoteUpdate: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  listManifests: vi.fn(),
-  getManifest: vi.fn(),
-  updateProjectNote: mockUpdateProjectNote,
-  revealManifestInOs: vi.fn(),
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    manifestList: vi.fn(),
+    manifestGet: vi.fn(),
+    noteUpdate: mockNoteUpdate,
+    noteGet: vi.fn(),
+    manifestRevealInOs: vi.fn(),
+  },
 }));
 
 // ── manifestReasonLabel ───────────────────────────────────────────────────────
@@ -112,13 +116,13 @@ describe('noteContentValid', () => {
 
 describe('saveNote', () => {
   beforeEach(() => {
-    mockUpdateProjectNote.mockReset();
+    mockNoteUpdate.mockReset();
   });
 
   it('returns updatedAt on success', async () => {
-    mockUpdateProjectNote.mockResolvedValue({
-      projectId: 'proj-1',
-      updatedAt: '2026-06-01T12:00:00Z',
+    mockNoteUpdate.mockResolvedValue({
+      status: 'ok',
+      data: { projectId: 'proj-1', updatedAt: '2026-06-01T12:00:00Z' },
     });
     const result = await saveNote('proj-1', 'My notes');
     expect(result.updatedAt).toBe('2026-06-01T12:00:00Z');
@@ -126,25 +130,25 @@ describe('saveNote', () => {
   });
 
   it('returns error code on command failure (string rejection)', async () => {
-    mockUpdateProjectNote.mockRejectedValue('note.content_too_large');
+    mockNoteUpdate.mockRejectedValue('note.content_too_large');
     const result = await saveNote('proj-1', 'x'.repeat(MAX_NOTE_BYTES + 1));
     expect(result.error).toBe('note.content_too_large');
     expect(result.updatedAt).toBeUndefined();
   });
 
   it('returns error message on Error rejection', async () => {
-    mockUpdateProjectNote.mockRejectedValue(new Error('project.read_only'));
+    mockNoteUpdate.mockRejectedValue(new Error('project.read_only'));
     const result = await saveNote('proj-arch', 'Some content');
     expect(result.error).toBe('project.read_only');
   });
 
   it('passes projectId and content to the command', async () => {
-    mockUpdateProjectNote.mockResolvedValue({
-      projectId: 'proj-2',
-      updatedAt: '2026-06-01T12:00:00Z',
+    mockNoteUpdate.mockResolvedValue({
+      status: 'ok',
+      data: { projectId: 'proj-2', updatedAt: '2026-06-01T12:00:00Z' },
     });
     await saveNote('proj-2', 'Content here');
-    expect(mockUpdateProjectNote).toHaveBeenCalledWith({
+    expect(mockNoteUpdate).toHaveBeenCalledWith({
       projectId: 'proj-2',
       content: 'Content here',
     });

--- a/apps/desktop/src/features/projects/manifests.ts
+++ b/apps/desktop/src/features/projects/manifests.ts
@@ -5,25 +5,54 @@
  * ProjectNotesSection. No React imports.
  */
 
-import {
-  listManifests,
-  getManifest,
-  getProjectNote,
-  updateProjectNote,
-  revealManifestInOs,
-} from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import { m } from '@/lib/i18n';
 import type {
-  ManifestListResponse,
-  ManifestGetResponse,
+  ManifestGetRequest,
+  ManifestRevealRequest,
+  ManifestSummaryDto,
+  ProjectNoteGetRequest,
   ProjectNoteGetResult,
+  ProjectNoteUpdateRequest,
   ProjectNoteUpdateResult,
-} from '@/api/commands';
-import type { ManifestSummaryDto } from '@/bindings/index';
+} from '@/bindings/index';
+import type { ManifestListRequest, ManifestListResponse, ManifestGetResponse } from '@/bindings/aliases';
+
+// ── IPC helpers ───────────────────────────────────────────────────────────────
+// Migrated off the hand-written @/api/commands wrappers (spec 037) onto the
+// generated bindings. unwrap() turns the generated Result into the
+// throw-on-error contract ManifestsAccordion / ProjectNotesSection rely on.
+
+/** `project.manifest.list` — list manifest snapshots for a project (spec 024). */
+export async function listManifests(request: ManifestListRequest): Promise<ManifestListResponse> {
+  return unwrap(await commands.manifestList(request));
+}
+
+/** `project.manifest.get` — fetch one manifest with its full structured body (spec 024). */
+export async function getManifest(request: ManifestGetRequest): Promise<ManifestGetResponse> {
+  return unwrap(await commands.manifestGet(request));
+}
+
+/** `project.note.get` — fetch current notes body for a project (spec 024). */
+export async function getProjectNote(req: ProjectNoteGetRequest): Promise<ProjectNoteGetResult> {
+  return unwrap(await commands.noteGet(req));
+}
+
+/** `project.note.update` — replace the project's free-text notes (spec 024). */
+export async function updateProjectNote(
+  req: ProjectNoteUpdateRequest,
+): Promise<ProjectNoteUpdateResult> {
+  return unwrap(await commands.noteUpdate(req));
+}
+
+/** `project.manifest.reveal_in_os` — open the manifest file in the OS file manager (spec 024). */
+export async function revealManifestInOs(request: ManifestRevealRequest): Promise<void> {
+  unwrap(await commands.manifestRevealInOs(request));
+}
 
 // ── Re-exports ────────────────────────────────────────────────────────────────
 
-export { listManifests, getManifest, getProjectNote, updateProjectNote, revealManifestInOs };
 export type {
   ManifestListResponse,
   ManifestGetResponse,

--- a/apps/desktop/src/features/projects/store.ts
+++ b/apps/desktop/src/features/projects/store.ts
@@ -9,21 +9,13 @@
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { queryKeys } from "@/data/queryKeys";
 import { queryClient as sharedQueryClient } from "@/data/queryClient";
-import {
-  listProjects008,
-  getProject008,
-  createProject,
-  updateProject,
-  addProjectSource,
-  removeProjectSource,
-  reinferProjectChannels,
-  dismissProjectChannelDrift,
-  applyProjectLifecycleTransition,
-} from "@/api/commands";
+import { commands } from "@/bindings/index";
+import { unwrap } from "@/api/ipc";
+import { applyProjectLifecycleTransition } from "./lifecycleTransition";
 import type {
   ProjectLifecycleState,
   LifecycleTransitionResponse,
-} from "@/api/commands";
+} from "./lifecycleTransition";
 import type { ProjectSummaryDto, ProjectDetailDto } from "@/bindings/index";
 import type {
   ProjectCreateRequest,
@@ -39,6 +31,54 @@ import type {
   ProjectChannelsDismissDriftRequest,
   ProjectChannelsDismissDriftResult,
 } from "@/bindings/index";
+
+// Local IPC helpers — migrated off the hand-written @/api/commands wrappers
+// (spec 037) onto the generated bindings. unwrap() turns the generated Result
+// into the throw-on-error contract the hooks/helpers below rely on.
+
+async function listProjects008(): Promise<ProjectSummaryDto[]> {
+  return unwrap(await commands.projectsList(null));
+}
+
+async function getProject008(args: { id: string }): Promise<ProjectDetailDto> {
+  return unwrap(await commands.projectsGet(args.id));
+}
+
+async function createProject(req: ProjectCreateRequest): Promise<ProjectCreateResult> {
+  return unwrap(
+    await commands.projectsCreate(req as Parameters<typeof commands.projectsCreate>[0]),
+  );
+}
+
+async function updateProject(req: ProjectUpdateRequest): Promise<ProjectUpdateResult> {
+  return unwrap(
+    await commands.projectsUpdate(req as Parameters<typeof commands.projectsUpdate>[0]),
+  );
+}
+
+async function addProjectSource(
+  req: ProjectSourceAddRequest,
+): Promise<ProjectSourceAddResult> {
+  return unwrap(await commands.projectsSourceAdd(req));
+}
+
+async function removeProjectSource(
+  req: ProjectSourceRemoveRequest,
+): Promise<ProjectSourceRemoveResult> {
+  return unwrap(await commands.projectsSourceRemove(req));
+}
+
+async function reinferProjectChannels(
+  req: ProjectChannelsReinferRequest,
+): Promise<ProjectChannelsReinferResult> {
+  return unwrap(await commands.projectsChannelsReinfer(req));
+}
+
+async function dismissProjectChannelDrift(
+  req: ProjectChannelsDismissDriftRequest,
+): Promise<ProjectChannelsDismissDriftResult> {
+  return unwrap(await commands.projectsChannelsDismissDrift(req));
+}
 
 // Query state shape (matches old QueryState<T> surface for backward compat)
 

--- a/apps/desktop/src/features/projects/tool-launch.test.ts
+++ b/apps/desktop/src/features/projects/tool-launch.test.ts
@@ -21,16 +21,20 @@ import {
   useToolLaunch,
   type LaunchDisabledReason,
 } from './tool-launch';
-import type { ToolProfileSummary, ToolLaunchResponse } from '@/api/commands';
+import type { ToolProfileSummary, ToolLaunchResponse } from '@/bindings/index';
 
 const { toolLaunchMock, addToastMock } = vi.hoisted(() => ({
   toolLaunchMock: vi.fn(),
   addToastMock: vi.fn(),
 }));
 
-vi.mock('@/api/commands', () => ({
-  toolProfileList: vi.fn(),
-  toolLaunch: toolLaunchMock,
+// tool-launch.ts calls commands.toolsList / commands.toolsLaunch + unwrap
+// (spec 037). Mock the generated bindings and let the real unwrap run.
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    toolsList: vi.fn(),
+    toolsLaunch: toolLaunchMock,
+  },
 }));
 
 vi.mock('@/shared/toast', () => ({
@@ -146,7 +150,7 @@ describe('useToolLaunch — one-time cwd-anchored hint', () => {
     localStorage.clear();
     toolLaunchMock.mockReset();
     addToastMock.mockReset();
-    toolLaunchMock.mockResolvedValue(successResponse());
+    toolLaunchMock.mockResolvedValue({ status: 'ok', data: successResponse() });
   });
 
   it('shows the hint toast on the first successful launch of a no-folder-chooser tool', async () => {

--- a/apps/desktop/src/features/projects/tool-launch.ts
+++ b/apps/desktop/src/features/projects/tool-launch.ts
@@ -11,15 +11,27 @@
  *   one-time-per-tool "cwd anchored" hint state (T021, US3 acceptance scenario 3).
  */
 import { useState, useCallback, useEffect } from 'react';
-import {
-  toolProfileList,
-  toolLaunch,
-  type ToolProfileSummary,
-  type ToolLaunchRequest,
-  type ToolLaunchResponse,
-} from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type {
+  ToolProfileSummary,
+  ToolProfileListResponse,
+  ToolLaunchRequest,
+  ToolLaunchResponse,
+} from '@/bindings/index';
 import { addToast } from '@/shared/toast';
 import { m } from '@/lib/i18n';
+
+// Local IPC helpers — migrated off the hand-written @/api/commands wrappers
+// (spec 037) onto the generated bindings.
+
+async function toolProfileList(): Promise<ToolProfileListResponse> {
+  return unwrap(await commands.toolsList());
+}
+
+async function toolLaunch(request: ToolLaunchRequest): Promise<ToolLaunchResponse> {
+  return unwrap(await commands.toolsLaunch(request));
+}
 
 // ── tool_id derivation ────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/features/projects/wizard/StepSources.tsx
+++ b/apps/desktop/src/features/projects/wizard/StepSources.tsx
@@ -3,7 +3,8 @@ import { m } from '@/lib/i18n';
 import { Checkbox } from '@base-ui-components/react/checkbox';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/data/queryKeys';
-import { listSessions } from '@/api/commands';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 
 import { formatIntegration } from '@/lib/format';
 
@@ -19,7 +20,7 @@ export interface StepSourcesProps {
 export function StepSources({ data, onChange }: StepSourcesProps) {
   const { data: sessions, isFetching: loading } = useQuery({
     queryKey: queryKeys.sessions.all(),
-    queryFn: () => listSessions(),
+    queryFn: async () => unwrap(await commands.sessionsList()),
   });
   const [filterTarget, setFilterTarget] = useState('');
   const [filterFilter, setFilterFilter] = useState('');


### PR DESCRIPTION
## Summary
Spec 037 Phase-3 caller migration for the **projects** area: repoints off the hand-written `@/api/commands` `invoke()` wrappers onto the generated, type-safe `commands.*` bindings + `unwrap` (from `@/api/ipc`), eliminating the IPC name/payload drift-bug class.

projects feature (create wizard, manifests, tool-launch, calibration-match; new lifecycleTransition.ts + calibrationMatch.ts glue). Rebased onto current base; resolved manifests.ts + tool-launch.test.ts.

Verified locally: `tsc --noEmit` clean; area vitest green; `eslint` 0 errors (pre-existing warnings only). Follows the merged calibration (#359) / plans (#368) / sessions (#369) pattern.

## Spec Context
- Spec: 037
- Branch: 037-projects