### PR TITLE
docs: reconcile stale spec statuses (tool-launch, artifact-observation, target-lookup, token-pattern)

### DIFF
--- a/specs/011-processing-tool-launch/spec.md
+++ b/specs/011-processing-tool-launch/spec.md
@@ -12,22 +12,24 @@
 including configured paths for PixInsight, Siril, and future tools, with
 project-level actions."
 
-## Implementation Status: CTA visual only
+## Implementation Status: Implemented (2026-07-03)
 
-The `Open in {tool}` button (and the matching row-overflow entry) is wired in
-`apps/desktop/src/features/projects/ProjectsPage.tsx` via
-`projectFooter()` / `rowMenuGroupsForLifecycle()`, but the click handler does
-not yet spawn a process — it dispatches an in-memory `setProjectLifecycle`
-call (or no-ops in row overflow). No tool path is read from settings, no
-project working directory is passed, and no audit record is written. The
-button label, gating, and disabled-state copy on the mockup MUST remain the
-authoritative UX target for this spec; the implementation work covered here is
-behavioural wiring (settings → use case → OS process → audit), not new UI.
+Superseding the original "CTA visual only" note: tool launch is fully wired and
+spawns a real OS process. The launch CTA and relaunch modal live in
+`apps/desktop/src/features/projects/ProjectDetail.tsx` → `useToolLaunch`
+(`tool-launch.ts`); the Tauri command `tools_launch`
+(`apps/desktop/src-tauri/src/commands/tools.rs`) uses the production
+**`RealSpawner`** (`crates/workflow/profiles/src/launch.rs`), which calls
+`std::process::Command::new(executable).spawn()` with platform detach handling
+(Windows `DETACHED_PROCESS`, unix `process_group`), reads the resolved tool
+path, sets the project working directory (cwd-containment guarded), tracks the
+pid, and writes an audit record. FR-001…FR-011 are satisfied and tested
+(FakeSpawner unit + integration; migration `0024_tool_launches.sql`).
 
-**IMPORTANT (E5)**: The mockup's `setProjectLifecycle('processing')` call
-MUST be removed during implementation. Tool launch does NOT mutate project
-lifecycle state. The `ready → processing` transition is a separate explicit
-user action governed by spec 009.
+**E5 (satisfied)**: `setProjectLifecycle('processing')` was removed — tool
+launch does not mutate lifecycle state (zero references remain in
+`features/projects/`); the `ready → processing` transition stays a separate
+explicit user action governed by spec 009.
 
 ## User Scenarios & Testing *(mandatory)*
 

--- a/specs/012-processing-artifact-observation/spec.md
+++ b/specs/012-processing-artifact-observation/spec.md
@@ -10,11 +10,22 @@
 **Status**: Draft  
 **Input**: User description: "Specify how the app observes outputs from PixInsight, Siril, planetary/lunar tools, and future workflow profiles without becoming the processing tool."
 
-## Implementation Status: NOT IMPLEMENTED
+## Implementation Status: Substantially implemented (2026-07-03)
 
-No code lands for this feature. Mockup state for the Tool Launches drawer
-accordion is the only visible surface today (see feature 011 desktop mock).
-Architecture, contracts, and tasks below define the future-build target.
+Superseding the original "NOT IMPLEMENTED" note: the functional core is built.
+Real crate `crates/workflow/artifacts/` (watcher, classifier, reconciler,
+rules), migration `0025_artifacts.sql`, repository
+`crates/persistence/db/src/repositories/artifacts.rs`, and app use-cases in
+`crates/app/lifecycle/src/artifact.rs` (`detect`/`list`/`classify_override`/
+`mark_resolved`/`mark_missing`/`reattribute`/`complete_run`) are in place, with
+Tauri commands (`artifact_list`/`classify`/`mark_resolved`) + generated
+bindings, a live notify-rs OS watcher (`crates/fs/inventory/src/artifact_watcher.rs`,
+wired at `src-tauri/src/lib.rs`), and the `ToolLaunchesAccordion` drawer UI.
+Detection, classification, override, missing-state, attribution, persistence,
+contracts, and Tauri wiring all exist (T008's notify-rs watcher, marked deferred
+in tasks.md, is in fact done). Remaining open items are peripheral: integration/
+e2e/contract tests, a research doc, cross-spec sign-off (011/017/024), and a
+per-profile `watch_extensions` override (blocked on spec 018) — not core build.
 
 ## User Scenarios & Testing *(mandatory)*
 

--- a/specs/015-token-pattern-builder/spec.md
+++ b/specs/015-token-pattern-builder/spec.md
@@ -6,31 +6,28 @@
 
 **Feature Branch**: `015-token-pattern-builder`  
 **Created**: 2026-05-09  
-**Status**: Draft — mockup implemented for builder UI and preview
+**Status**: **Implemented** (2026-07-03) — builder UI + resolver/validator/preview shipped; see below.
 **Input**: User description: "Specify the token-based pattern builder for project folders and archive locations, without freeform path text."
 
-## Implementation Status
+## Implementation Status: Implemented (2026-07-03)
 
-The visual and interactive surface of the builder is already realized in the
-desktop mockup. Logic for resolving a pattern against metadata, validating it
-against OS path rules, and persisting per-source overrides is **not yet
-implemented** and is in scope for this spec.
+Superseding the original "mockup only" note: the builder is shipped end to end.
+The chip-based editor is live in
+`apps/desktop/src/features/settings/NamingStructure.tsx` (`PatternChipsEditor` —
+token + separator chips with add/remove, live validation via `pattern_validate`,
+live preview via `pattern_preview`, save-blocking when invalid). The
+resolver/validator/sanitizer is the `crates/patterns/` crate
+(registry/resolver/validator/sanitize/per_type, ~64 passing tests), exposed
+through `crates/contracts/core/src/patterns.rs` + app orchestration
+(`crates/app/core/src/patterns.rs`) + Tauri commands `pattern_validate` /
+`pattern_resolve` / `pattern_preview`. A full SpecKit artifact set exists
+(plan/research/data-model/contracts/tasks, ~30 tasks — not "0/0"). Deferred
+downstream scope (per-source overrides, session-backed preview aggregation,
+Inbox-confirm consumption) was handed to spec 018.
 
-### Mockup Evidence
-
-- `apps/desktop/src/ui/TokenPattern.tsx` — exports `TokenPatternBuilder`
-  (token + separator chips with add/remove menus), `PatternPreview` (list of
-  sample destination paths with optional frame counts), and `RenderPattern`
-  (inline read-only render of a pattern).
-- `apps/desktop/src/features/settings/SettingsPage.tsx` — `NamingStructureSection`
-  uses `TokenPatternBuilder` for the library default pattern, shows a
-  `PatternPreview` of representative destinations, exposes auto-apply and
-  always-preview toggles, and lists per-source override stubs.
-- `apps/desktop/src/data/mock.ts` — `availableTokens` enumerates the v1 token
-  vocabulary used by the builder.
-- `apps/desktop/src/data/settings.ts` — `SettingsState.pattern: PatternPart[]`
-  is the persisted shape; `DEFAULT_PATTERN` defines the seeded library default
-  (`{target}/{filter}/{date}/{frame_type}/`).
+> Note: the earlier "Mockup Evidence" file references (`ui/TokenPattern.tsx`,
+> `data/mock.ts`, `data/settings.ts`) are obsolete — those files were replaced
+> by the real implementation above during the 027 frontend rewrite.
 
 ### Token Vocabulary (v1)
 

--- a/specs/SPEC_STATUS.md
+++ b/specs/SPEC_STATUS.md
@@ -42,9 +42,9 @@ updated 041 / 017 rows and the CI note.
 | 010 guided-first-project-flow | 🟡 Near-complete | 31/33 |
 | 011 processing-tool-launch | ✅ Implemented (closed 2026-07-03) | Launch pipeline + UI + cwd-guard + detach/pid shipped & tested; T021 hint + X-1/X-2 done in closeout; 2 open (T018 Playwright, T022 real-spawn) DEFERRED (WSL/sandbox-blocked). Unblocks 012 |
 | 012 processing-artifact-observation | 🟡 Partial | 26/36 (follows 011) |
-| 013 target-lookup-from-fits-object | 🟡 Near-complete | 18/21 (largely folded into 035) |
+| 013 target-lookup-from-fits-object | 🔴 Superseded by 035 | Fully subsumed by 035 — every FR/US covered by SIMBAD resolve-on-demand, or its one unique feature (fuzzy variant matching + confidence tiers) deliberately reversed (035 clarification Q4: exact-match only). 3 open tasks are obsolete stubs (spec-014 download pipeline / removed `catalog_equivalences`). Target-identity model retained in `crates/targeting/` |
 | 014 catalog-index-licensing | 🔴 Superseded by 035 | download-catalog mechanism abandoned; attribution model retained |
-| 015 token-pattern-builder | 🟡 Mockup only | 0/0 tasks |
+| 015 token-pattern-builder | ✅ Implemented | Chip-based naming-pattern builder shipped: `crates/patterns/` (registry/resolver/validator/sanitize, ~64 tests) + contracts + Tauri `pattern_validate`/`resolve`/`preview` + live `PatternChipsEditor` in `NamingStructure.tsx` (validate + preview). Full SpecKit artifact set exists (~30 tasks, not "0/0"). Deferred downstream scope (per-source overrides, session-backed preview) handed to spec 018 |
 | 016 source-protection-defaults | 🟡 Near-complete | 17/20 (underpins 017) |
 | 017 cleanup-archive-review-plans | 🟡 Backend done; Archive UI shipped, cleanup-review UI remainder open | Backend + archive/trash executor done; Archive UI exists (`features/archive/ArchivePage/List/Detail`). Remaining open work is the cleanup-plan *review* UI (contextual per v4), not greenfield — earlier "19 real-open / UI open" overstated it |
 | 018 settings-configuration-model | ✅ Reconciled + implemented (#348) | 42/46; spec reconciled to as-built scope/values architecture; backend + UI shipped & verified (live T034 walkthrough); 4 obsolete (contracts mirror, 014 key); open: FR-006↔043 density tension (cross-spec decision) |


### PR DESCRIPTION
Docs-only. Corrects four spec/index inaccuracies found during a verification sweep — no code changes:
- **011** tool-launch: replace stale "CTA visual only" section (it genuinely spawns processes via `RealSpawner`).
- **012** artifact-observation: "NOT IMPLEMENTED" → substantially implemented (crate + notify-rs watcher + accordion UI).
- **013** target-lookup: → Superseded by 035 (fully subsumed; unique fuzzy-match scope deliberately reversed).
- **015** token-pattern-builder: → Implemented (patterns crate + live chip builder); fixes deleted-file references.