### PR TITLE
fix: consistent localized labels for object types, plan summaries, tooltips, and theme mode

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -15,6 +15,7 @@
   "projects_tool_unknown": "Unknown tool",
   "projects_toollaunch_label": "Launch {id}…",
   "projects_toollaunch_unattributed": "Unattributed",
+  "projects_toollaunch_low_confidence": "{kind} (low confidence)",
   "projects_create_tool_pixinsight_desc": "WBPP, StarAlignment, integration",
   "projects_create_tool_siril_desc": "Free open-source stacking",
   "settings_density_compact_desc": "24px row height — fits more rows on screen",
@@ -1138,6 +1139,96 @@
   "inbox_kind_flat": "Flat",
   "inbox_kind_light": "Light",
   "inbox_kind_master": "Master",
+  "inbox_frametype_count_light": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} light",
+        "countPlural=other": "{count} lights"
+      }
+    }
+  ],
+  "inbox_frametype_count_dark": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} dark",
+        "countPlural=other": "{count} darks"
+      }
+    }
+  ],
+  "inbox_frametype_count_flat": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} flat",
+        "countPlural=other": "{count} flats"
+      }
+    }
+  ],
+  "inbox_frametype_count_bias": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} bias",
+        "countPlural=other": "{count} biases"
+      }
+    }
+  ],
+  "inbox_frametype_count_dark_flat": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} dark flat",
+        "countPlural=other": "{count} dark flats"
+      }
+    }
+  ],
+  "inbox_frametype_count_master": [
+    {
+      "declarations": [
+        "input count",
+        "local countPlural = count: plural"
+      ],
+      "selectors": [
+        "countPlural"
+      ],
+      "match": {
+        "countPlural=one": "{count} master",
+        "countPlural=other": "{count} masters"
+      }
+    }
+  ],
   "inbox_master_row_label": "{type} master",
   "inbox_state_classified": "classified",
   "inbox_state_master_fallback": "master",
@@ -1266,6 +1357,10 @@
   "settings_density_comfortable": "Comfortable",
   "settings_density_spacious": "Spacious",
   "settings_general_theme_system": "System",
+  "settings_theme_mode_auto_dark": "auto · dark",
+  "settings_theme_mode_auto_light": "auto · light",
+  "settings_theme_mode_dark": "dark",
+  "settings_theme_mode_light": "light",
   "projects_lifecycle_prepare": "Prepare",
   "projects_lifecycle_mark_processing": "Mark as Processing",
   "projects_lifecycle_revert_ready": "Revert to Ready",

--- a/apps/desktop/src/api/commands.ts
+++ b/apps/desktop/src/api/commands.ts
@@ -141,7 +141,7 @@ import type {
 // IPC dispatch + the dev-tools recording override live in the shared switcher
 // (spec 037, api/ipc.ts) so these wrappers and the generated bindings use one
 // dispatcher. Re-exported to keep the `@/api/commands` public surface stable.
-import { invoke, unwrap, setInvokeOverride } from './ipc';
+import { unwrap, setInvokeOverride } from './ipc';
 export { setInvokeOverride };
 
 import { commands } from '@/bindings';

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -247,6 +247,33 @@ function pluralLabel(singular: string, count: number): string {
   return singular.endsWith('s') ? singular : `${singular}s`;
 }
 
+/**
+ * Localized "{count} <frame type>" count-variant thunks for the KNOWN canonical
+ * frame-type bucket keys (see `FRAME_TYPE_KEYWORDS`/`normalizeFrameTypeHint`:
+ * light/dark/flat/bias/dark flat/master). Render-time thunks (spec 046 #8) so
+ * they re-read the active locale on each call rather than resolving once at
+ * module scope.
+ */
+const FRAMETYPE_COUNT_LABEL_FNS: Record<string, (count: number) => string> = {
+  light: (count) => m.inbox_frametype_count_light({ count }),
+  dark: (count) => m.inbox_frametype_count_dark({ count }),
+  flat: (count) => m.inbox_frametype_count_flat({ count }),
+  bias: (count) => m.inbox_frametype_count_bias({ count }),
+  'dark flat': (count) => m.inbox_frametype_count_dark_flat({ count }),
+  master: (count) => m.inbox_frametype_count_master({ count }),
+};
+
+/**
+ * Localized "{count} <frame type>" label for a plan summary bucket. Returns
+ * the count-variant message for a KNOWN canonical frame-type key; returns
+ * `null` for unknown values (e.g. the `actionLabel(...).toLowerCase()`
+ * fallback for an unrecognised frame type) so the caller falls back to the
+ * existing `pluralLabel` behaviour, which is already localized at its source.
+ */
+function frameTypeCountLabel(frameType: string, count: number): string | null {
+  return FRAMETYPE_COUNT_LABEL_FNS[frameType]?.(count) ?? null;
+}
+
 /** One collapsed summary line: "N <frametype> → <destination tail>". */
 export interface PlanGroupSummaryLine {
   /** Stable key for the row. */
@@ -289,7 +316,10 @@ function buildGroupSummary(
     .map(([key, b]) => ({
       key,
       count: b.count,
-      frameType: pluralLabel(b.frameType, b.count),
+      // Kept SINGULAR (not pluralised here) so the JSX consumer can key off
+      // the canonical value to pick a localized count-variant message for a
+      // known frame type, falling back to `pluralLabel` for unknown ones.
+      frameType: b.frameType,
       destinationShort: shortDestination(b.destinationFull),
       destinationFull: b.destinationFull,
     }));
@@ -697,21 +727,37 @@ export function PlanPanel({
                         frameType: l.frameType,
                         count: l.count,
                       }))
-                  ).map((entry, i) => (
-                    <span key={entry.key} className="alm-plan-panel__summary-type">
-                      {i > 0 && (
-                        <span className="alm-plan-panel__summary-sep" aria-hidden="true">
-                          ·{' '}
-                        </span>
-                      )}
-                      <span className="alm-plan-panel__summary-type-count">
-                        {entry.count}
-                      </span>{' '}
-                      <span className="alm-plan-panel__summary-type-name">
-                        {pluralLabel(entry.frameType, entry.count)}
+                  ).map((entry, i) => {
+                    // A KNOWN canonical frame type (light/dark/flat/bias/dark
+                    // flat/master) gets a localized count-variant message that
+                    // already embeds the number — render it as one node. An
+                    // UNKNOWN frame type (e.g. the `actionLabel(...)` fallback)
+                    // keeps the existing count + `pluralLabel` rendering.
+                    const knownLabel = frameTypeCountLabel(entry.frameType, entry.count);
+                    return (
+                      <span key={entry.key} className="alm-plan-panel__summary-type">
+                        {i > 0 && (
+                          <span className="alm-plan-panel__summary-sep" aria-hidden="true">
+                            ·{' '}
+                          </span>
+                        )}
+                        {knownLabel !== null ? (
+                          <span className="alm-plan-panel__summary-type-name">
+                            {knownLabel}
+                          </span>
+                        ) : (
+                          <>
+                            <span className="alm-plan-panel__summary-type-count">
+                              {entry.count}
+                            </span>{' '}
+                            <span className="alm-plan-panel__summary-type-name">
+                              {pluralLabel(entry.frameType, entry.count)}
+                            </span>
+                          </>
+                        )}
                       </span>
-                    </span>
-                  ))}
+                    );
+                  })}
                 </span>
 
                 {/* Col 4: destination (aligned across all plans). In-place

--- a/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
+++ b/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
@@ -61,7 +61,11 @@ function ArtifactRow({ artifact, projectId, onResolved }: ArtifactRowProps) {
       {/* Kind badge */}
       <span
         className={`artifact-kind-badge artifact-kind-${artifact.kind} alm-tool-launches__kind-badge` + (isFallback ? ' alm-tool-launches__kind-badge--fallback' : '')}
-        title={`${artifact.kind}${isFallback ? ' (low confidence)' : ''}`}
+        title={
+          isFallback
+            ? m.projects_toollaunch_low_confidence({ kind: artifact.kind })
+            : artifact.kind
+        }
       >
         {artifact.kind}
       </span>

--- a/apps/desktop/src/features/settings/General.tsx
+++ b/apps/desktop/src/features/settings/General.tsx
@@ -49,8 +49,13 @@ export function General() {
                 </span>
                 <span className="alm-theme-swatch__name">{t.label()}</span>
                 <span className="alm-theme-swatch__mode">
-                  {/* eslint-disable-next-line alm/no-user-string -- theme discriminants compared, not displayed */}
-                  {t.id === 'system' ? `auto · ${resolved.includes('dark') ? 'dark' : 'light'}` : t.mode}
+                  {t.id === 'system'
+                    ? resolved.includes('dark')
+                      ? m.settings_theme_mode_auto_dark()
+                      : m.settings_theme_mode_auto_light()
+                    : t.mode === 'dark'
+                      ? m.settings_theme_mode_dark()
+                      : m.settings_theme_mode_light()}
                 </span>
               </button>
             );

--- a/apps/desktop/src/features/targets/TargetList.tsx
+++ b/apps/desktop/src/features/targets/TargetList.tsx
@@ -1,9 +1,10 @@
 import { useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type { TargetListItem } from '@/bindings/index';
+import type { TargetListItem, TargetObjectType } from '@/bindings/index';
 import { ListSidebar } from '@/components';
 import { Pill, SegControl } from '@/ui';
 import { m } from '@/lib/i18n';
+import { objectTypeLabel } from '@/components/TargetSearch/objectType';
 
 /**
  * Estimated row height (px) for the virtualizer's initial measurement.
@@ -35,9 +36,9 @@ function matchesSearch(t: TargetListItem, query: string): boolean {
   );
 }
 
-/** Formats the objectType string into a readable label. */
+/** Formats the objectType string into a readable, localized label. */
 function formatType(objectType: string): string {
-  return objectType.replace(/_/g, ' ');
+  return objectTypeLabel(objectType as TargetObjectType);
 }
 
 export function TargetList({ targets, selected, onSelect }: Props) {

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -62,9 +62,10 @@
 
 import { useMemo, useRef } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import type { TargetListItem } from '@/bindings/index';
+import type { TargetListItem, TargetObjectType } from '@/bindings/index';
 import { Pill } from '@/ui';
 import { SortHeader } from '@/components';
+import { objectTypeLabel } from '@/components/TargetSearch/objectType';
 import { catalogueOf, catalogueLabel } from './planner-catalog';
 import { rowAltitudeFor, USABLE_ALT_DEG, type RowAltitude } from './planner-altitude';
 import { AltitudeSparkline } from './AltitudeSparkline';
@@ -115,9 +116,9 @@ export const DEFAULT_TARGET_SORT: TargetSort = { col: 'designation', dir: 'asc' 
 export type TargetGroupBy = 'catalogue' | 'type';
 export const DEFAULT_TARGET_GROUP_BY: TargetGroupBy = 'catalogue';
 
-/** Formats the objectType string into a readable label. */
+/** Formats the objectType string into a readable, localized label. */
 export function formatType(objectType: string): string {
-  return objectType.replace(/_/g, ' ');
+  return objectTypeLabel(objectType as TargetObjectType);
 }
 
 /** Resolve the group key + display headline for a target under `groupBy`. */


### PR DESCRIPTION
## Summary
- Target **Type** column, group-by-type headers, and object pills now use the shared localized object-type labels (proper casing like "Emission nebula", fully translatable) instead of a local underscore-stripping helper.
- Inbox **plan-summary** frame-type counts ("12 lights · 21 darks"), the tool-launch **low-confidence tooltip**, and the Settings **theme-mode** subtitle are now localized.
- Removed an unused import that was leaving the branch's lint red.

## Verify
tsc 0 · eslint 0 errors (was 1) · unit tests 544 pass, 1 pre-existing unrelated failure (`CreateProjectDialog … canonicalTargetId`, already failing on the base from the in-flight IPC-bindings migration — not introduced here) · mock-E2E 9 pass / 1 skip.

## Spec Context
- Spec: 046
- Branch: 046-residue-merge