### PR TITLE
feat: accurate live preview for per-frame-type destination folder patterns

### DIFF
--- a/apps/desktop/src-tauri/src/commands/patterns.rs
+++ b/apps/desktop/src-tauri/src/commands/patterns.rs
@@ -1,16 +1,20 @@
-//! Pattern Tauri commands (spec 015, T3.8).
+//! Pattern Tauri commands (spec 015, T3.8; spec 041 package P11).
 //!
-//! Three typed commands:
+//! Four typed commands:
 //! - `pattern.validate`  — structural validation without metadata.
 //! - `pattern.resolve`   — full resolution against a metadata bundle.
 //! - `pattern.preview`   — preview for the Settings UI live preview.
+//! - `pattern.path_preview` — preview a per-type destination **path-string**
+//!   pattern (e.g. `masters/flats/{filter}/`) for the Settings per-frame-type
+//!   destination pattern editor's live preview.
 //!
 //! None of these commands touch the database; they are pure-function wrappers
 //! around `app_core::patterns`.
 
 use contracts_core::patterns::{
-    PatternPreviewRequest, PatternPreviewResponse, PatternResolveRequest, PatternResolveResponse,
-    PatternValidateRequest, PatternValidateResponse,
+    PathPatternPreviewRequest, PathPatternPreviewResponse, PatternPreviewRequest,
+    PatternPreviewResponse, PatternResolveRequest, PatternResolveResponse, PatternValidateRequest,
+    PatternValidateResponse,
 };
 use contracts_core::ContractError;
 
@@ -65,4 +69,23 @@ pub fn pattern_preview(
 ) -> Result<PatternPreviewResponse, ContractError> {
     tracing::debug!("pattern.preview parts={}", request.pattern.len());
     app_core::patterns::preview_pattern(&request)
+}
+
+/// `pattern.path_preview` — resolve a per-type destination **path-string**
+/// pattern against sample metadata, for the Settings per-frame-type
+/// destination pattern editor's live preview (spec 041, package P11).
+///
+/// Returns `PathPatternPreviewResponse { resolved_path, missing_tokens, warnings }`.
+///
+/// # Errors
+///
+/// Returns `Err(String)` with the error code on invalid patterns or paths.
+#[tauri::command]
+#[specta::specta]
+#[allow(clippy::needless_pass_by_value)] // Tauri deserializes the request by value
+pub fn pattern_path_preview(
+    request: PathPatternPreviewRequest,
+) -> Result<PathPatternPreviewResponse, ContractError> {
+    tracing::debug!("pattern.path_preview pattern={}", request.pattern);
+    app_core::patterns::preview_path_pattern(&request)
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -65,7 +65,9 @@ use crate::commands::manifests::{
     manifest_get, manifest_list, manifest_reveal_in_os, note_get, note_update,
 };
 use crate::commands::native::{native_directory_pick, native_file_pick, native_reveal};
-use crate::commands::patterns::{pattern_preview, pattern_resolve, pattern_validate};
+use crate::commands::patterns::{
+    pattern_path_preview, pattern_preview, pattern_resolve, pattern_validate,
+};
 use crate::commands::plan_apply::{
     plans_apply_real, plans_apply_status, plans_cancel, plans_item_retry, plans_item_skip,
     plans_resume,
@@ -257,6 +259,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         pattern_validate,
         pattern_resolve,
         pattern_preview,
+        pattern_path_preview,
         // source protection (spec 016 US2–US4)
         source_protection_get,
         source_protection_set,
@@ -462,6 +465,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         pattern_validate,
         pattern_resolve,
         pattern_preview,
+        pattern_path_preview,
         // source protection (spec 016 US2–US4)
         source_protection_get,
         source_protection_set,

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1182,13 +1182,22 @@ export async function mockInvoke(
     // Mirrors the real resolver's token-substitution + missing-token report
     // for the mock/dev environment. `{token}` names are the v1 registry
     // token names (snake_case); `sampleMetadata` carries the camelCase DTO
-    // field names, so PATH_PREVIEW_TOKEN_FIELDS bridges the two.
+    // field names, so PATH_PREVIEW_TOKEN_FIELDS bridges the two. Errors are
+    // thrown as full ContractError envelopes (code + message + severity +
+    // retryable), matching the real backend, so mock mode exercises the same
+    // `errMessage()` catalog-resolution path as production.
     case 'pattern_path_preview': {
       const req = (_args as { request?: { pattern?: string; sampleMetadata?: Record<string, string | null | undefined> } } | undefined)?.request;
       const pattern = req?.pattern ?? '';
       const sample = req?.sampleMetadata ?? {};
       if (pattern.trim() === '') {
-        throw 'pattern.empty';
+        throw {
+          code: 'pattern.empty',
+          message: 'Pattern is empty.',
+          severity: 'blocking',
+          retryable: false,
+          details: null,
+        };
       }
       const missingTokens: string[] = [];
       const segments = pattern
@@ -1197,7 +1206,17 @@ export async function mockInvoke(
         .map((seg) =>
           seg.replace(/\{([^}]*)\}/g, (_match, token: string) => {
             const field = PATH_PREVIEW_TOKEN_FIELDS[token];
-            const value = field ? sample[field] : undefined;
+            if (!field) {
+              // The real resolver rejects unregistered tokens outright.
+              throw {
+                code: 'token.unknown',
+                message: `Unknown token: ${token}`,
+                severity: 'blocking',
+                retryable: false,
+                details: { token },
+              };
+            }
+            const value = sample[field];
             if (value == null || value === '') {
               missingTokens.push(token);
               return PATH_PREVIEW_TOKEN_FALLBACKS[token] ?? token;

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -57,9 +57,41 @@ import type {
   UpdateIngestionSettings,
   AuditFilterDto,
   AuditPaginationDto,
+  PathPatternPreviewResponse,
 } from '@/bindings/index';
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ── pattern.path_preview token bridge (spec 041 P11) ──────────────────────────
+//
+// Maps a v1 registry `{token}` name (snake_case, as it appears in a per-type
+// destination pattern string) to the camelCase `MetadataBundleDto` field name
+// carried in `sampleMetadata`. Fallbacks mirror `crates/patterns/src/registry.rs`
+// (data-model.md §Errors) so the mock preview matches the real resolver's
+// "missing token" substitution.
+const PATH_PREVIEW_TOKEN_FIELDS: Record<string, string> = {
+  target: 'target',
+  filter: 'filter',
+  date: 'date',
+  frame_type: 'frameType',
+  camera: 'camera',
+  exposure: 'exposure',
+  gain: 'gain',
+  binning: 'binning',
+  set_temp: 'setTemp',
+};
+
+const PATH_PREVIEW_TOKEN_FALLBACKS: Record<string, string> = {
+  target: 'unclassified',
+  filter: 'nofilter',
+  date: 'undated',
+  frame_type: 'unknown',
+  camera: 'unknown-camera',
+  exposure: 'unknown-exposure',
+  gain: 'unknown-gain',
+  binning: '1x1',
+  set_temp: 'untempered',
+};
 
 // --- Inline fixtures for modules not yet created by T015 ---
 //
@@ -1143,6 +1175,41 @@ export async function mockInvoke(
       }
       mockFilters = mockFilters.filter((f) => f.id !== id);
       return null;
+    }
+
+    // ── pattern.path_preview (spec 041 per-type destination patterns, P11) ──
+    //
+    // Mirrors the real resolver's token-substitution + missing-token report
+    // for the mock/dev environment. `{token}` names are the v1 registry
+    // token names (snake_case); `sampleMetadata` carries the camelCase DTO
+    // field names, so PATH_PREVIEW_TOKEN_FIELDS bridges the two.
+    case 'pattern_path_preview': {
+      const req = (_args as { request?: { pattern?: string; sampleMetadata?: Record<string, string | null | undefined> } } | undefined)?.request;
+      const pattern = req?.pattern ?? '';
+      const sample = req?.sampleMetadata ?? {};
+      if (pattern.trim() === '') {
+        throw 'pattern.empty';
+      }
+      const missingTokens: string[] = [];
+      const segments = pattern
+        .split('/')
+        .filter((seg) => seg !== '')
+        .map((seg) =>
+          seg.replace(/\{([^}]*)\}/g, (_match, token: string) => {
+            const field = PATH_PREVIEW_TOKEN_FIELDS[token];
+            const value = field ? sample[field] : undefined;
+            if (value == null || value === '') {
+              missingTokens.push(token);
+              return PATH_PREVIEW_TOKEN_FALLBACKS[token] ?? token;
+            }
+            return value;
+          }),
+        );
+      return {
+        resolvedPath: segments.join('/'),
+        missingTokens,
+        warnings: [],
+      } satisfies PathPatternPreviewResponse;
     }
 
     default:

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -750,6 +750,18 @@ export const commands = {
 	 */
 	patternPreview: (request: PatternPreviewRequest_Deserialize) => typedError<PatternPreviewResponse, ContractError_Serialize>(__TAURI_INVOKE("pattern_preview", { request })),
 	/**
+	 *  `pattern.path_preview` — resolve a per-type destination **path-string**
+	 *  pattern against sample metadata, for the Settings per-frame-type
+	 *  destination pattern editor's live preview (spec 041, package P11).
+	 * 
+	 *  Returns `PathPatternPreviewResponse { resolved_path, missing_tokens, warnings }`.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(String)` with the error code on invalid patterns or paths.
+	 */
+	patternPathPreview: (request: PathPatternPreviewRequest_Deserialize) => typedError<PathPatternPreviewResponse, ContractError_Serialize>(__TAURI_INVOKE("pattern_path_preview", { request })),
+	/**
 	 *  `source.protection.get` — resolve effective protection for a source (US2, T012).
 	 * 
 	 *  If `source_id` is `None`, returns the global defaults.
@@ -4943,6 +4955,63 @@ export type OpticalTrain = {
  *  DB CHECK constraint and the IPC camelCase surface.
  */
 export type OrganizationState = "organized" | "unorganized";
+
+/**
+ *  Request for `pattern.path_preview` — preview a per-type destination
+ *  **path-string** pattern (e.g. `masters/flats/{filter}/`) against sample
+ *  metadata, for the Settings per-frame-type destination pattern editor.
+ * 
+ *  Unlike [`PatternPreviewRequest`] (which carries the `PatternPart[]`
+ *  token/separator model), `pattern` here is a raw path string that may
+ *  interleave `{token}` placeholders with literal directory segments — the
+ *  form produced by [`crate::patterns`] (this module) is not applicable;
+ *  resolution is delegated to `crates/patterns::resolver::resolve_pattern_str`,
+ *  which reuses the v1 token registry as the single token-name authority.
+ */
+export type PathPatternPreviewRequest = PathPatternPreviewRequest_Serialize | PathPatternPreviewRequest_Deserialize;
+
+/**
+ *  Request for `pattern.path_preview` — preview a per-type destination
+ *  **path-string** pattern (e.g. `masters/flats/{filter}/`) against sample
+ *  metadata, for the Settings per-frame-type destination pattern editor.
+ * 
+ *  Unlike [`PatternPreviewRequest`] (which carries the `PatternPart[]`
+ *  token/separator model), `pattern` here is a raw path string that may
+ *  interleave `{token}` placeholders with literal directory segments — the
+ *  form produced by [`crate::patterns`] (this module) is not applicable;
+ *  resolution is delegated to `crates/patterns::resolver::resolve_pattern_str`,
+ *  which reuses the v1 token registry as the single token-name authority.
+ */
+export type PathPatternPreviewRequest_Deserialize = {
+	pattern: string,
+	sampleMetadata: MetadataBundleDto_Deserialize,
+};
+
+/**
+ *  Request for `pattern.path_preview` — preview a per-type destination
+ *  **path-string** pattern (e.g. `masters/flats/{filter}/`) against sample
+ *  metadata, for the Settings per-frame-type destination pattern editor.
+ * 
+ *  Unlike [`PatternPreviewRequest`] (which carries the `PatternPart[]`
+ *  token/separator model), `pattern` here is a raw path string that may
+ *  interleave `{token}` placeholders with literal directory segments — the
+ *  form produced by [`crate::patterns`] (this module) is not applicable;
+ *  resolution is delegated to `crates/patterns::resolver::resolve_pattern_str`,
+ *  which reuses the v1 token registry as the single token-name authority.
+ */
+export type PathPatternPreviewRequest_Serialize = {
+	pattern: string,
+	sampleMetadata: MetadataBundleDto_Serialize,
+};
+
+/**  Successful response for `pattern.path_preview`. */
+export type PathPatternPreviewResponse = {
+	/**  The resolved relative path for display. */
+	resolvedPath: string,
+	/**  Token names resolved via fallback (shown as dim segments in the UI). */
+	missingTokens: string[],
+	warnings: string[],
+};
 
 /**
  *  One element of an ordered token pattern (data-model.md §PatternPart).

--- a/apps/desktop/src/features/settings/NamingStructure.pertype-preview.test.tsx
+++ b/apps/desktop/src/features/settings/NamingStructure.pertype-preview.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * Vitest unit tests for the per-type destination pattern live preview
+ * (spec 041 package P11 — real `pattern.path_preview` backend wiring).
+ *
+ * Covers the i18n-review corrections:
+ *  - a ContractError from the preview command resolves through `errMessage()`
+ *    to its translated catalog entry (e.g. `pattern.empty` → m.err_pattern_empty),
+ *    NOT the generic "preview unavailable" string and NOT the raw code;
+ *  - `missingTokens` from the response is surfaced via
+ *    m.settings_naming_fallback_used, mirroring the top-level preview.
+ *
+ * Mocks the generated bindings surface (spec 037 pattern, same as
+ * SourceProtectionOverride.test.tsx) so the real `settingsIpc` wrappers,
+ * `unwrap()` envelope handling, and `errMessage()` catalog resolution all run.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { NamingStructure } from "./NamingStructure";
+import { m } from "@/lib/i18n";
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { mockSettingsGet, mockSettingsUpdate, mockPatternValidate, mockPatternPreview, mockPatternPathPreview } =
+	vi.hoisted(() => ({
+		mockSettingsGet: vi.fn(),
+		mockSettingsUpdate: vi.fn(),
+		mockPatternValidate: vi.fn(),
+		mockPatternPreview: vi.fn(),
+		mockPatternPathPreview: vi.fn(),
+	}));
+
+vi.mock("@/bindings/index", () => ({
+	commands: {
+		settingsGet: mockSettingsGet,
+		settingsUpdate: mockSettingsUpdate,
+		patternValidate: mockPatternValidate,
+		patternPreview: mockPatternPreview,
+		patternPathPreview: mockPatternPathPreview,
+	},
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** A well-formed ContractError envelope, as the real backend throws it. */
+function contractError(code: string, message: string) {
+	return {
+		code,
+		message,
+		severity: "blocking",
+		retryable: false,
+		details: null,
+	};
+}
+
+function okPathPreview(resolvedPath: string, missingTokens: string[] = []) {
+	return {
+		status: "ok" as const,
+		data: { resolvedPath, missingTokens, warnings: [] },
+	};
+}
+
+beforeEach(() => {
+	vi.clearAllMocks();
+	mockSettingsGet.mockResolvedValue({
+		status: "ok",
+		data: { scope: "naming", values: {} },
+	});
+	mockSettingsUpdate.mockResolvedValue({ status: "ok", data: null });
+	mockPatternValidate.mockResolvedValue({
+		status: "ok",
+		data: { valid: true, warnings: [] },
+	});
+	mockPatternPreview.mockResolvedValue({
+		status: "ok",
+		data: { resolvedPath: "NGC7000/Ha", missingTokens: [], warnings: [] },
+	});
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe("per-type destination pattern preview (P11)", () => {
+	it("renders the backend-resolved sample path per frame-type class", async () => {
+		mockPatternPathPreview.mockResolvedValue(
+			okPathPreview("IC1396/Ha/2024-10-20/light"),
+		);
+		render(<NamingStructure save={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("naming-pattern-light-preview")).toBeTruthy();
+		});
+		expect(
+			screen.getByTestId("naming-pattern-light-preview").textContent,
+		).toContain("IC1396/Ha/2024-10-20/light");
+	});
+
+	it("surfaces missingTokens via the fallback-used catalog message", async () => {
+		mockPatternPathPreview.mockResolvedValue(
+			okPathPreview("flats/nofilter/2024-10-20", ["filter"]),
+		);
+		render(<NamingStructure save={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(screen.getByTestId("naming-pattern-flat-preview")).toBeTruthy();
+		});
+		expect(
+			screen.getByTestId("naming-pattern-flat-preview").textContent,
+		).toContain(m.settings_naming_fallback_used({ tokens: "filter" }));
+	});
+
+	it("resolves a ContractError to its translated catalog message, not the generic fallback", async () => {
+		mockPatternPathPreview.mockResolvedValue({
+			status: "error",
+			error: contractError("pattern.empty", "Pattern is empty."),
+		});
+		render(<NamingStructure save={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByTestId("naming-pattern-light-preview-error"),
+			).toBeTruthy();
+		});
+		const text = screen.getByTestId(
+			"naming-pattern-light-preview-error",
+		).textContent;
+		// The registry entry for pattern.empty — the specific, translated message.
+		expect(text).toBe(m.err_pattern_empty());
+		// NOT the generic "preview unavailable" string...
+		expect(text).not.toBe(m.settings_naming_preview_unavailable());
+		// ...and NOT the raw error code or raw backend diagnostic.
+		expect(text).not.toContain("pattern.empty");
+		expect(text).not.toBe("Pattern is empty.");
+	});
+
+	it("resolves token.unknown to its translated catalog message", async () => {
+		mockPatternPathPreview.mockResolvedValue({
+			status: "error",
+			error: contractError("token.unknown", "Unknown token: telescope"),
+		});
+		render(<NamingStructure save={vi.fn()} />);
+
+		await waitFor(() => {
+			expect(
+				screen.getByTestId("naming-pattern-dark-preview-error"),
+			).toBeTruthy();
+		});
+		expect(
+			screen.getByTestId("naming-pattern-dark-preview-error").textContent,
+		).toBe(m.err_token_unknown());
+	});
+});

--- a/apps/desktop/src/features/settings/NamingStructure.tsx
+++ b/apps/desktop/src/features/settings/NamingStructure.tsx
@@ -1,6 +1,9 @@
 // spec 015 — Token Pattern Builder: backend-wired resolver, validator, preview.
 // spec 018 — pattern + autoApplyPattern keys persisted via settings transport.
 // spec 041 (T051, FR-026b) — per-frame-type destination patterns.
+// package P11 — per-type path-string preview wired to the real `pattern.path_preview`
+// backend command (crates/patterns::resolver::resolve_pattern_str), replacing the
+// former client-side token-substitution stub.
 import {
 	type KeyboardEvent as ReactKeyboardEvent,
 	useCallback,
@@ -12,6 +15,7 @@ import {
 	getSettings,
 	type PatternPart,
 	type PatternPreviewResponse,
+	patternPathPreview,
 	patternPreview,
 	patternValidate,
 	updateSettings,
@@ -210,47 +214,28 @@ const SAMPLE_METADATA = {
 	set_temp: "-10C",
 };
 
-// ── Per-type live preview (client-side token substitution) ────────────────────
+// ── Per-type live preview (package P11: real backend resolver) ───────────────
 //
-// STUB: The canonical resolver lives in the Rust `patterns` crate
-// (`crates/patterns/src/per_type.rs`), but the only Tauri command exposed today
-// (`pattern.preview`) accepts the token/separator `PatternPart[]` model, which
-// cannot represent the literal path segments (e.g. `flats`, `masters`) that
-// per-type destination patterns rely on. Until a path-string preview command is
-// exposed, we resolve the preview client-side by substituting `{token}`
-// placeholders with representative sample values. Literal segments and `/`
-// separators are passed through verbatim. Replace this with the canonical
-// resolver once a path-string `pattern.preview` (or equivalent) command exists.
+// The canonical resolver lives in the Rust `patterns` crate
+// (`crates/patterns/src/resolver.rs::resolve_pattern_str`), which handles the
+// literal path segments (e.g. `flats`, `masters`) that per-type destination
+// patterns rely on, alongside the same sanitization/traversal/reserved-name
+// pipeline used everywhere else. It is exposed via the `pattern.path_preview`
+// Tauri command (`patternPathPreview` in `./settingsIpc`). Sample metadata
+// values are distinct from the top pattern preview's `SAMPLE_METADATA` so the
+// two live previews are visually distinguishable at a glance.
 
-const PER_TYPE_SAMPLE_TOKENS: Record<
-	(typeof AVAILABLE_TOKENS)[number],
-	string
-> = {
+const PER_TYPE_SAMPLE_METADATA = {
 	target: "IC1396",
 	filter: "Ha",
 	date: "2024-10-20",
-	frame_type: "light",
+	frameType: "light",
 	camera: "ASI2600MM",
 	exposure: "300s",
 	gain: "100",
 	binning: "1x1",
-	set_temp: "-10C",
+	setTemp: "-10C",
 };
-
-/**
- * Resolve a per-type destination pattern string into a sample path by replacing
- * each `{token}` with a representative sample value. Unknown tokens are left as
- * a bracketed placeholder so the preview makes the problem visible rather than
- * silently dropping the segment.
- */
-function resolvePerTypePreview(pattern: string): string {
-	if (pattern.trim() === "") return "";
-	return pattern.replace(/\{([^}]*)\}/g, (_match, token: string) => {
-		const sample =
-			PER_TYPE_SAMPLE_TOKENS[token as (typeof AVAILABLE_TOKENS)[number]];
-		return sample ?? `{${token}}`;
-	});
-}
 
 // ── Default pattern {target}/{filter}/{date}/{frame_type}/ ────────────────────
 
@@ -640,6 +625,15 @@ function PerTypeDestinationPatterns() {
 	const [loaded, setLoaded] = useState(false);
 	const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
+	// Per-class live preview, resolved by the real backend `pattern.path_preview`
+	// command (package P11) — keyed by class, `null` while loading/unavailable.
+	const [previewsByClass, setPreviewsByClass] = useState<
+		Partial<Record<FrameTypeClass, string>>
+	>({});
+	const [previewErrorsByClass, setPreviewErrorsByClass] = useState<
+		Partial<Record<FrameTypeClass, string>>
+	>({});
+
 	// ── Load saved overrides on mount ────────────────────────────────────────
 	useEffect(() => {
 		getSettings({ scope: "naming" })
@@ -662,6 +656,54 @@ function PerTypeDestinationPatterns() {
 			})
 			.finally(() => setLoaded(true));
 	}, []);
+
+	// ── Per-class live preview (package P11) ─────────────────────────────────
+	//
+	// Resolves the effective pattern (override or built-in default) for every
+	// class against representative sample metadata via the real resolver. Runs
+	// whenever chips or backend validation errors change, after the initial
+	// load completes. A class with a client- or backend-detected error is
+	// skipped (no preview shown, mirroring the previous stub's behaviour).
+	useEffect(() => {
+		if (!loaded) return;
+		let cancelled = false;
+
+		void (async () => {
+			const nextPreviews: Partial<Record<FrameTypeClass, string>> = {};
+			const nextErrors: Partial<Record<FrameTypeClass, string>> = {};
+
+			await Promise.all(
+				FRAME_TYPE_CLASSES.map(async (cls) => {
+					const chips = chipsByClass[cls];
+					const isOverridden = !chipsAreEmpty(chips);
+					const patternStr = isOverridden ? serializePathPattern(chips) : "";
+					const clientError = isOverridden ? validatePatternString(patternStr) : null;
+					const error = backendErrors[cls] ?? clientError ?? undefined;
+					if (error != null) return; // No preview while the pattern is invalid.
+
+					const effectivePattern = isOverridden
+						? patternStr
+						: FRAME_TYPE_DEFAULT_PATTERNS[cls];
+					try {
+						const resp = await patternPathPreview(effectivePattern, PER_TYPE_SAMPLE_METADATA);
+						nextPreviews[cls] = resp.resolvedPath;
+					} catch (err: unknown) {
+						nextErrors[cls] =
+							typeof err === "string" ? err : m.settings_naming_preview_unavailable();
+					}
+				}),
+			);
+
+			if (!cancelled) {
+				setPreviewsByClass(nextPreviews);
+				setPreviewErrorsByClass(nextErrors);
+			}
+		})();
+
+		return () => {
+			cancelled = true;
+		};
+	}, [chipsByClass, backendErrors, loaded]);
 
 	// ── Persist the full override map (debounced, captures backend errors) ────
 	const persist = useCallback((next: Record<FrameTypeClass, PathChip[]>) => {
@@ -744,14 +786,11 @@ function PerTypeDestinationPatterns() {
 					loaded && isOverridden ? validatePatternString(patternStr) : null;
 				const error = backendErrors[cls] ?? clientError ?? undefined;
 				const rowId = `naming-pattern-${cls}`;
-				// Live preview: resolve the effective pattern (override or
-				// built-in default) against representative sample values. Only
+				// Live preview: resolved by the real backend `pattern.path_preview`
+				// command (package P11) against representative sample metadata. Only
 				// shown when the pattern is free of validation errors.
-				const effectivePattern = isOverridden
-					? patternStr
-					: FRAME_TYPE_DEFAULT_PATTERNS[cls];
-				const previewPath =
-					error == null ? resolvePerTypePreview(effectivePattern) : "";
+				const previewPath = error == null ? (previewsByClass[cls] ?? "") : "";
+				const previewUnavailable = error == null && previewErrorsByClass[cls];
 				return (
 					<SettingsRow
 						key={cls}
@@ -792,6 +831,14 @@ function PerTypeDestinationPatterns() {
 											{m.settings_naming_preview_default()}
 										</span>
 									)}
+								</div>
+							)}
+							{previewUnavailable && (
+								<div
+									className="alm-naming__preview-error"
+									data-testid={`${rowId}-preview-error`}
+								>
+									{previewUnavailable}
 								</div>
 							)}
 

--- a/apps/desktop/src/features/settings/NamingStructure.tsx
+++ b/apps/desktop/src/features/settings/NamingStructure.tsx
@@ -22,6 +22,7 @@ import {
 } from "./settingsIpc";
 import { Btn } from "@/ui";
 import { m } from "@/lib/i18n";
+import { errMessage } from "@/lib/errors";
 import { SettingsSection, SettingsRow, RestoreDefaultsBtn } from "./SettingsKit";
 
 const NAMING_KEYS = ['pattern', 'autoApplyPattern', 'patternsByType'];
@@ -626,9 +627,9 @@ function PerTypeDestinationPatterns() {
 	const saveTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
 	// Per-class live preview, resolved by the real backend `pattern.path_preview`
-	// command (package P11) — keyed by class, `null` while loading/unavailable.
+	// command (package P11) — keyed by class, absent while loading/unavailable.
 	const [previewsByClass, setPreviewsByClass] = useState<
-		Partial<Record<FrameTypeClass, string>>
+		Partial<Record<FrameTypeClass, { path: string; missingTokens: string[] }>>
 	>({});
 	const [previewErrorsByClass, setPreviewErrorsByClass] = useState<
 		Partial<Record<FrameTypeClass, string>>
@@ -669,7 +670,9 @@ function PerTypeDestinationPatterns() {
 		let cancelled = false;
 
 		void (async () => {
-			const nextPreviews: Partial<Record<FrameTypeClass, string>> = {};
+			const nextPreviews: Partial<
+				Record<FrameTypeClass, { path: string; missingTokens: string[] }>
+			> = {};
 			const nextErrors: Partial<Record<FrameTypeClass, string>> = {};
 
 			await Promise.all(
@@ -686,10 +689,15 @@ function PerTypeDestinationPatterns() {
 						: FRAME_TYPE_DEFAULT_PATTERNS[cls];
 					try {
 						const resp = await patternPathPreview(effectivePattern, PER_TYPE_SAMPLE_METADATA);
-						nextPreviews[cls] = resp.resolvedPath;
+						nextPreviews[cls] = {
+							path: resp.resolvedPath,
+							missingTokens: resp.missingTokens,
+						};
 					} catch (err: unknown) {
-						nextErrors[cls] =
-							typeof err === "string" ? err : m.settings_naming_preview_unavailable();
+						// `errMessage` resolves a ContractError code (pattern.empty,
+						// token.unknown, path.traversal, …) to its translated catalog
+						// entry; anything unrecognisable gets the safe generic fallback.
+						nextErrors[cls] = errMessage(err);
 					}
 				}),
 			);
@@ -726,10 +734,11 @@ function PerTypeDestinationPatterns() {
 				},
 				(err: unknown) => {
 					// Backend rejected at least one pattern (error code value.invalid).
-					// We cannot tell which class from a single string; flag all classes
+					// We cannot tell which class from a single payload; flag all classes
 					// that currently fail client-side validation, falling back to a
-					// generic banner keyed on the first overridden class.
-					const message = typeof err === "string" ? err : m.settings_naming_pertype_invalid_pattern();
+					// banner keyed on the first overridden class. `errMessage` resolves
+					// the ContractError code to its translated catalog entry.
+					const message = errMessage(err);
 					const errs: Partial<Record<FrameTypeClass, string>> = {};
 					let attributed = false;
 					for (const cls of FRAME_TYPE_CLASSES) {
@@ -789,7 +798,7 @@ function PerTypeDestinationPatterns() {
 				// Live preview: resolved by the real backend `pattern.path_preview`
 				// command (package P11) against representative sample metadata. Only
 				// shown when the pattern is free of validation errors.
-				const previewPath = error == null ? (previewsByClass[cls] ?? "") : "";
+				const preview = error == null ? previewsByClass[cls] : undefined;
 				const previewUnavailable = error == null && previewErrorsByClass[cls];
 				return (
 					<SettingsRow
@@ -814,18 +823,27 @@ function PerTypeDestinationPatterns() {
 								/>
 							</div>
 
-							{/* Working live preview of the resolved sample path. */}
-							{previewPath !== "" && (
+							{/* Working live preview of the resolved sample path. Announced
+							    politely so screen-reader users hear updates while editing. */}
+							{preview && preview.path !== "" && (
 								<div
 									className="alm-naming__pertype-preview"
+									aria-live="polite"
 									data-testid={`${rowId}-preview`}
 								>
 									<span className="alm-naming__pertype-preview-label">
 										{m.settings_naming_preview_label()}
 									</span>{" "}
 									<code className="alm-mono alm-naming__pertype-preview-code">
-										{previewPath}
+										{preview.path}
 									</code>
+									{preview.missingTokens.length > 0 && (
+										<span className="alm-naming__preview-fallback">
+											{m.settings_naming_fallback_used({
+												tokens: preview.missingTokens.join(", "),
+											})}
+										</span>
+									)}
 									{!isOverridden && (
 										<span className="alm-naming__pertype-preview-default">
 											{m.settings_naming_preview_default()}
@@ -836,6 +854,7 @@ function PerTypeDestinationPatterns() {
 							{previewUnavailable && (
 								<div
 									className="alm-naming__preview-error"
+									role="alert"
 									data-testid={`${rowId}-preview-error`}
 								>
 									{previewUnavailable}

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -40,6 +40,7 @@ import type {
   MetadataBundleDto_Serialize as MetadataBundleDto,
   PatternValidateResponse_Serialize as PatternValidateResponse,
   PatternPreviewResponse,
+  PathPatternPreviewResponse,
   ResolverSettings,
   ResolverSettingsResponse,
   FirstRunRestartResponse,
@@ -86,7 +87,7 @@ export type {
   RemapVerification,
 };
 export type { PatternPartDto as PatternPart };
-export type { PatternValidateResponse, PatternPreviewResponse };
+export type { PatternValidateResponse, PatternPreviewResponse, PathPatternPreviewResponse };
 export type { CalibrationTolerances, UpdateCalibrationTolerances };
 export type { IngestionSettings, UpdateIngestionSettings };
 
@@ -313,6 +314,26 @@ export async function patternPreview(
   return unwrap(
     await commands.patternPreview(
       { pattern, sampleMetadata } as Parameters<typeof commands.patternPreview>[0],
+    ),
+  );
+}
+
+/**
+ * Preview a per-type destination **path-string** pattern (e.g.
+ * `masters/flats/{filter}/`) against sample metadata, for the per-frame-type
+ * destination pattern editor's live preview (spec 041, package P11).
+ *
+ * Unlike `patternPreview` (which resolves the `PatternPart[]` token/separator
+ * model), `pattern` here is a raw path string that may interleave `{token}`
+ * placeholders with literal directory segments.
+ */
+export async function patternPathPreview(
+  pattern: string,
+  sampleMetadata: MetadataBundleDto,
+): Promise<PathPatternPreviewResponse> {
+  return unwrap(
+    await commands.patternPathPreview(
+      { pattern, sampleMetadata } as Parameters<typeof commands.patternPathPreview>[0],
     ),
   );
 }

--- a/crates/app/core/src/patterns.rs
+++ b/crates/app/core/src/patterns.rs
@@ -4,8 +4,11 @@
 //! - `validate_pattern` — structural validation without metadata.
 //! - `resolve_pattern`  — full resolution against a metadata bundle.
 //! - `preview_pattern`  — preview resolution against sample metadata for the UI.
+//! - `preview_path_pattern` — preview resolution of a per-type **path-string**
+//!   pattern (spec 041 destination model, package P11) against sample
+//!   metadata.
 //!
-//! All three delegate to `crates/patterns` and translate domain errors into
+//! All four delegate to `crates/patterns` and translate domain errors into
 //! `ContractError` codes matching the JSON Schemas in
 //! `specs/015-token-pattern-builder/contracts/`.
 
@@ -17,13 +20,14 @@
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 
 use contracts_core::patterns::{
-    PatternPartDto, PatternPreviewRequest, PatternPreviewResponse, PatternResolveRequest,
-    PatternResolveResponse, PatternValidateRequest, PatternValidateResponse,
+    PathPatternPreviewRequest, PathPatternPreviewResponse, PatternPartDto, PatternPreviewRequest,
+    PatternPreviewResponse, PatternResolveRequest, PatternResolveResponse, PatternValidateRequest,
+    PatternValidateResponse,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use patterns::{
     registry::V1_REGISTRY,
-    resolver::{ResolveError, ResolverConfig},
+    resolver::{resolve_pattern_str, ResolveError, ResolverConfig},
     validator::ValidateError,
     PatternPart,
 };
@@ -141,6 +145,35 @@ pub fn preview_pattern(
         missing_tokens: r.missing_tokens,
         warnings: r.warnings,
     })
+}
+
+// ── preview_path_pattern (spec 041 per-type destination patterns, P11) ───────
+
+/// Preview a per-type destination **path-string** pattern (e.g.
+/// `masters/flats/{filter}/`) against sample metadata, for the Settings
+/// per-frame-type destination pattern editor's live preview.
+///
+/// Delegates to `patterns::resolver::resolve_pattern_str`, which reuses
+/// [`V1_REGISTRY`] as the single token-name authority and applies the same
+/// sanitization/traversal/reserved-name/length pipeline as [`resolve_pattern`].
+///
+/// # Errors
+///
+/// Returns `ContractError` for an empty pattern, an unknown `{token}`, or a
+/// resolved path that fails sanitization or length limits — the same error
+/// codes as [`resolve_pattern`].
+#[allow(clippy::result_large_err)]
+pub fn preview_path_pattern(
+    req: &PathPatternPreviewRequest,
+) -> Result<PathPatternPreviewResponse, ContractError> {
+    let metadata = req.sample_metadata.to_bundle();
+    resolve_pattern_str(&req.pattern, &metadata)
+        .map(|r| PathPatternPreviewResponse {
+            resolved_path: r.relative_path,
+            missing_tokens: r.missing_tokens,
+            warnings: r.warnings.iter().map(|w| w.code().to_owned()).collect(),
+        })
+        .map_err(map_resolve_error)
 }
 
 // ── Error mapping ─────────────────────────────────────────────────────────────
@@ -327,5 +360,90 @@ mod tests {
         let resp = preview_pattern(&req).unwrap();
         assert!(resp.missing_tokens.contains(&"filter".to_owned()));
         assert!(resp.resolved_path.contains("nofilter"));
+    }
+
+    // ── preview_path_pattern (spec 041 per-type destination patterns, P11) ──
+
+    #[test]
+    fn path_preview_resolves_master_flat_default() {
+        let req = PathPatternPreviewRequest {
+            pattern: "masters/flats/{filter}/".to_owned(),
+            sample_metadata: MetadataBundleDto {
+                filter: Some("Ha".to_owned()),
+                ..Default::default()
+            },
+        };
+        let resp = preview_path_pattern(&req).unwrap();
+        assert_eq!(resp.resolved_path, "masters/flats/Ha");
+        assert!(resp.missing_tokens.is_empty());
+    }
+
+    #[test]
+    fn path_preview_resolves_light_default_with_literal_segment() {
+        let req = PathPatternPreviewRequest {
+            pattern: "{target}/{filter}/{date}/light/".to_owned(),
+            sample_metadata: MetadataBundleDto {
+                target: Some("M31".to_owned()),
+                filter: Some("Ha".to_owned()),
+                date: Some("2026-06-21".to_owned()),
+                ..Default::default()
+            },
+        };
+        let resp = preview_path_pattern(&req).unwrap();
+        assert_eq!(resp.resolved_path, "M31/Ha/2026-06-21/light");
+        assert!(resp.missing_tokens.is_empty());
+    }
+
+    #[test]
+    fn path_preview_missing_token_falls_back_and_reports() {
+        let req = PathPatternPreviewRequest {
+            pattern: "darks/{exposure}/".to_owned(),
+            sample_metadata: MetadataBundleDto::default(),
+        };
+        let resp = preview_path_pattern(&req).unwrap();
+        assert_eq!(resp.resolved_path, "darks/unknown-exposure");
+        assert!(resp.missing_tokens.contains(&"exposure".to_owned()));
+    }
+
+    #[test]
+    fn path_preview_literal_only_pattern() {
+        let req = PathPatternPreviewRequest {
+            pattern: "bias/".to_owned(),
+            sample_metadata: MetadataBundleDto::default(),
+        };
+        let resp = preview_path_pattern(&req).unwrap();
+        assert_eq!(resp.resolved_path, "bias");
+        assert!(resp.missing_tokens.is_empty());
+    }
+
+    #[test]
+    fn path_preview_empty_pattern_returns_pattern_empty_code() {
+        let req = PathPatternPreviewRequest {
+            pattern: String::new(),
+            sample_metadata: MetadataBundleDto::default(),
+        };
+        let err = preview_path_pattern(&req).unwrap_err();
+        assert_eq!(err.code, ErrorCode::PatternEmpty);
+    }
+
+    #[test]
+    fn path_preview_unknown_token_returns_token_unknown_code() {
+        let req = PathPatternPreviewRequest {
+            pattern: "{telescope}/x/".to_owned(),
+            sample_metadata: MetadataBundleDto::default(),
+        };
+        let err = preview_path_pattern(&req).unwrap_err();
+        assert_eq!(err.code, ErrorCode::TokenUnknown);
+        assert_eq!(err.details.0.get("token").and_then(|t| t.as_str()), Some("telescope"));
+    }
+
+    #[test]
+    fn path_preview_literal_traversal_rejected() {
+        let req = PathPatternPreviewRequest {
+            pattern: "masters/../x/".to_owned(),
+            sample_metadata: MetadataBundleDto::default(),
+        };
+        let err = preview_path_pattern(&req).unwrap_err();
+        assert_eq!(err.code, ErrorCode::PathTraversal);
     }
 }

--- a/crates/contracts/core/src/patterns.rs
+++ b/crates/contracts/core/src/patterns.rs
@@ -5,10 +5,13 @@
 //! `specs/015-token-pattern-builder/contracts/` and are used by the Tauri
 //! command surface in `apps/desktop/src-tauri/src/commands/patterns.rs`.
 //!
-//! Three operations:
+//! Four operations:
 //! - `pattern.validate`  — structural validation without metadata.
 //! - `pattern.resolve`   — full resolution against a metadata bundle.
 //! - `pattern.preview`   — preview resolution against sample metadata for the UI.
+//! - `pattern.path_preview` — preview resolution of a per-type **path-string**
+//!   pattern (spec 041 `{token}`/literal path segments) against sample
+//!   metadata, for the Settings per-frame-type destination pattern editor.
 
 use serde::{Deserialize, Serialize};
 use specta::Type;
@@ -157,6 +160,36 @@ pub struct PatternPreviewRequest {
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct PatternPreviewResponse {
+    /// The resolved relative path for display.
+    pub resolved_path: String,
+    /// Token names resolved via fallback (shown as dim segments in the UI).
+    pub missing_tokens: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+// ── pattern.path_preview (spec 041 per-type destination patterns, package P11) ──
+
+/// Request for `pattern.path_preview` — preview a per-type destination
+/// **path-string** pattern (e.g. `masters/flats/{filter}/`) against sample
+/// metadata, for the Settings per-frame-type destination pattern editor.
+///
+/// Unlike [`PatternPreviewRequest`] (which carries the `PatternPart[]`
+/// token/separator model), `pattern` here is a raw path string that may
+/// interleave `{token}` placeholders with literal directory segments — the
+/// form produced by [`crate::patterns`] (this module) is not applicable;
+/// resolution is delegated to `crates/patterns::resolver::resolve_pattern_str`,
+/// which reuses the v1 token registry as the single token-name authority.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PathPatternPreviewRequest {
+    pub pattern: String,
+    pub sample_metadata: MetadataBundleDto,
+}
+
+/// Successful response for `pattern.path_preview`.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PathPatternPreviewResponse {
     /// The resolved relative path for display.
     pub resolved_path: String,
     /// Token names resolved via fallback (shown as dim segments in the UI).

--- a/crates/patterns/src/resolver.rs
+++ b/crates/patterns/src/resolver.rs
@@ -751,4 +751,91 @@ mod tests {
         let err = resolve_pattern_str("masters/../x/", &bundle).unwrap_err();
         assert!(matches!(err, ResolveError::PathTraversal { .. }));
     }
+
+    // ── resolve_pattern_str: weird separators (spec 041 P11 hardening) ─────
+
+    #[test]
+    fn pattern_str_leading_slash_is_dropped() {
+        // A leading `/` produces one empty leading segment, which is skipped
+        // rather than emitting a leading slash in relative_path.
+        let bundle = meta(&[("filter", "Ha")]);
+        let r = resolve_pattern_str("/flats/{filter}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "flats/Ha");
+        assert!(!r.relative_path.starts_with('/'));
+    }
+
+    #[test]
+    fn pattern_str_double_slash_collapses_empty_segment() {
+        let bundle = meta(&[("filter", "Ha")]);
+        let r = resolve_pattern_str("flats//{filter}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "flats/Ha");
+    }
+
+    #[test]
+    fn pattern_str_only_slashes_is_empty_path() {
+        let bundle = meta(&[]);
+        let r = resolve_pattern_str("///", &bundle).unwrap();
+        assert_eq!(r.relative_path, "");
+        assert!(r.missing_tokens.is_empty());
+    }
+
+    // ── resolve_pattern_str: invalid chars in literal segments ─────────────
+
+    #[test]
+    fn pattern_str_literal_windows_reserved_char_substituted() {
+        // Colon in a literal segment goes through the same sanitize pipeline
+        // as token values: substituted with `_`, not rejected.
+        let bundle = meta(&[]);
+        let r = resolve_pattern_str("weird:name/{exposure}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "weird_name/unknown-exposure");
+    }
+
+    #[test]
+    fn pattern_str_literal_reserved_device_name_rejected() {
+        // A literal path segment matching a Windows reserved device name is
+        // rejected exactly like a resolved token value would be.
+        let bundle = meta(&[]);
+        let err = resolve_pattern_str("masters/CON/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::ReservedName { .. }));
+    }
+
+    #[test]
+    fn pattern_str_literal_unicode_confusable_rejected() {
+        // A mixed-script literal segment (Latin + Cyrillic lookalike) is
+        // rejected by the same confusables check used for token values.
+        let bundle = meta(&[]);
+        // "аbc" — Cyrillic а (U+0430) mixed with Latin "bc".
+        let err = resolve_pattern_str("m\u{0430}sters/bc/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::UnicodeConfusable { .. }));
+    }
+
+    #[test]
+    fn pattern_str_literal_all_dots_segment_dropped() {
+        // A literal segment made entirely of dots is not `.`/`..` (so it
+        // passes the traversal check) but step2's dot-trim collapses it to
+        // empty — it is dropped rather than producing an empty path
+        // component, mirroring the "sanitizes to empty" fallback rule used
+        // for tokens.
+        let bundle = meta(&[("exposure", "300s")]);
+        let r = resolve_pattern_str("masters/.../{exposure}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "masters/300s");
+    }
+
+    #[test]
+    fn pattern_str_literal_dot_or_dotdot_segment_rejected() {
+        // Unlike a run of dots, an exact `.`/`..` literal segment IS caught
+        // by the traversal check (run before the dot-trim so it cannot be
+        // laundered into an empty, silently-dropped segment).
+        let bundle = meta(&[]);
+        let err = resolve_pattern_str("masters/./x/", &bundle).unwrap_err();
+        assert!(matches!(err, ResolveError::PathTraversal { .. }));
+    }
+
+    #[test]
+    fn pattern_str_mixed_literal_and_token_with_invalid_chars() {
+        // A segment interleaving literal text with reserved chars and a token.
+        let bundle = meta(&[("gain", "100")]);
+        let r = resolve_pattern_str("cam:era-{gain}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "cam_era-100");
+    }
 }


### PR DESCRIPTION
## Summary
- The per-frame-type destination pattern editor in Settings > Naming (the section that lets you customize where flats/darks/bias/masters land, e.g. `masters/flats/{filter}/`) now shows a live preview computed by the real path resolver instead of a simplified placeholder — so what you see matches exactly what will happen on disk, including sanitization of unusual characters and reserved names in custom path segments.

## Spec Context
- Implements the outstanding P11 package: wires the existing per-type path-string resolver (`crates/patterns::resolver::resolve_pattern_str`, spec 041 destination model) up to a new `pattern.path_preview` backend command, replacing the client-side token-substitution stub previously used in `NamingStructure.tsx`.
- Adds unit test coverage for edge cases in path resolution: leading/double/trailing slashes, Windows-reserved characters and reserved device names in literal path segments, and Unicode-confusable rejection.

## Test plan
- [x] `cargo test -p patterns` — 96 passed
- [x] `cargo test -p app_core -p contracts_core` — includes new `preview_path_pattern` unit tests
- [x] `cargo clippy -p patterns -p contracts_core -p app_core --all-targets -- -D warnings` — clean
- [x] `cargo build -p desktop_shell --features dev-tools` — clean
- [x] `cargo test -q -p desktop_shell --features dev-tools --test bindings` — bindings regenerated cleanly
- [x] `pnpm -r --if-present typecheck` — clean
- [x] `pnpm exec vitest run src/features/settings` — 52/52 passed
- [x] `pnpm exec eslint` on touched files — 0 errors
- [x] `just check-generated` — clean, no drift