### PR TITLE
feat: show target, filter, night, and frame count in calibration match candidates

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -49,6 +49,9 @@ import type {
   Filter,
   CreateFilter,
   UpdateFilter,
+  CalibrationMatchSuggestResponse,
+  CalibrationMatchBatchResponse,
+  CalibrationMatchDto_Serialize,
 } from '@/bindings/index';
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -186,6 +189,46 @@ const mockMatchCandidates: MatchCandidate[] = [
 ];
 
 /**
+ * `calibration.match.suggest` / `.suggest.batch` fixtures (spec P9).
+ *
+ * The second candidate deliberately omits every session-context field to
+ * exercise the real-app "—" fallback (no canonical target link / no
+ * fingerprint row) alongside the first candidate's fully-resolved context.
+ */
+function mockCalibrationMatches(sessionId: string): CalibrationMatchDto_Serialize[] {
+  return [
+    {
+      sessionId,
+      masterId: 'master-001',
+      calibrationType: 'dark',
+      confidence: 0.97,
+      dimensionsMatched: [
+        { dimension: 'gain', observed: { value: 100 }, reference: { value: 100 } },
+        { dimension: 'offset', observed: { value: 10 }, reference: { value: 10 } },
+      ],
+      dimensionsMismatched: [],
+      selectionReason: 'same_night',
+      targetName: 'M 31',
+      filter: 'Ha',
+      acquisitionNight: '2026-05-18',
+      frameCount: 42,
+    },
+    {
+      sessionId,
+      masterId: 'master-002',
+      calibrationType: 'dark',
+      confidence: 0.81,
+      dimensionsMatched: [{ dimension: 'gain', observed: { value: 100 }, reference: { value: 100 } }],
+      dimensionsMismatched: [
+        { dimension: 'temperature', reason: 'out_of_tolerance', delta: 3.5 },
+      ],
+      selectionReason: 'compatible_fallback',
+      // Unresolved session context — every P9 field stays absent.
+    },
+  ];
+}
+
+/**
  * Dispatch a mock IPC response for `cmd`.
  *
  * Returns `Promise<unknown>`: the caller (`invoke<T>` in `ipc.ts` /
@@ -224,6 +267,32 @@ export async function mockInvoke(
     }
     case 'calibration_matches': {
       return mockMatchCandidates;
+    }
+    case 'calibration_match_suggest': {
+      const req = (_args as { req?: { requestId?: string; sessionId?: string } } | undefined)?.req;
+      const sessionId = req?.sessionId ?? 'ses-001';
+      return {
+        status: 'success',
+        contractVersion: '2.0.0',
+        requestId: req?.requestId ?? crypto.randomUUID(),
+        suggestStatus: 'match',
+        matches: mockCalibrationMatches(sessionId),
+      } satisfies CalibrationMatchSuggestResponse;
+    }
+    case 'calibration_match_suggest_batch': {
+      const req = (_args as { req?: { requestId?: string; sessionIds?: string[] } } | undefined)?.req;
+      const sessionIds = req?.sessionIds ?? ['ses-001'];
+      return {
+        status: 'success',
+        contractVersion: '1.0',
+        requestId: req?.requestId ?? crypto.randomUUID(),
+        results: sessionIds.map((sessionId) => ({
+          sessionId,
+          calibrationType: 'dark' as const,
+          status: 'match',
+          candidates: mockCalibrationMatches(sessionId),
+        })),
+      } satisfies CalibrationMatchBatchResponse;
     }
     case 'targets_list': {
       const { targets } = await import('@/data/fixtures/targets');

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1968,6 +1968,18 @@ export type CalibrationMatchDto_Deserialize = {
 	dimensionsMatched: MatchedDimDto_Deserialize[],
 	dimensionsMismatched: MismatchedDimDto_Deserialize[],
 	selectionReason: SelectionReason,
+	/**
+	 *  Session context enrichment (spec P9): the light session's resolved
+	 *  target, filter, observing night, and frame count. `None` when the
+	 *  context cannot be resolved (e.g. no canonical target link, no
+	 *  fingerprint row, or the session id is unknown). Populated by
+	 *  `app_core_calibration` as a post-processing step — the pure
+	 *  `calibration_core` matching engine never touches persistence.
+	 */
+	targetName: string | null,
+	filter: string | null,
+	acquisitionNight: string | null,
+	frameCount: number | null,
 };
 
 /**  A ranked calibration master suggestion. */
@@ -1979,6 +1991,18 @@ export type CalibrationMatchDto_Serialize = {
 	dimensionsMatched: MatchedDimDto_Serialize[],
 	dimensionsMismatched: MismatchedDimDto_Serialize[],
 	selectionReason: SelectionReason,
+	/**
+	 *  Session context enrichment (spec P9): the light session's resolved
+	 *  target, filter, observing night, and frame count. `None` when the
+	 *  context cannot be resolved (e.g. no canonical target link, no
+	 *  fingerprint row, or the session id is unknown). Populated by
+	 *  `app_core_calibration` as a post-processing step — the pure
+	 *  `calibration_core` matching engine never touches persistence.
+	 */
+	targetName?: string | null,
+	filter?: string | null,
+	acquisitionNight?: string | null,
+	frameCount?: number | null,
 };
 
 /**  Request DTO for `calibration.match.suggest`. */

--- a/apps/desktop/src/features/calibration/MatchCandidatesPanel.test.tsx
+++ b/apps/desktop/src/features/calibration/MatchCandidatesPanel.test.tsx
@@ -51,6 +51,11 @@ const matchResponse: CalibrationMatchSuggestResponse = {
       ],
       dimensionsMismatched: [],
       selectionReason: 'compatible_fallback',
+      // P9 session-context enrichment — fully resolved.
+      targetName: 'M 31',
+      filter: 'Ha',
+      acquisitionNight: '2026-03-01',
+      frameCount: 12,
     },
     {
       sessionId: 'ses-001',
@@ -65,6 +70,8 @@ const matchResponse: CalibrationMatchSuggestResponse = {
         { dimension: 'temperature', reason: 'out_of_tolerance', delta: 5.2 },
       ],
       selectionReason: 'compatible_fallback',
+      // P9 session-context enrichment — unresolved (e.g. no canonical target
+      // link, no fingerprint row); every field stays absent.
     },
   ],
 };
@@ -278,5 +285,23 @@ describe('MatchCandidatesPanel', () => {
     fireEvent.click(screen.getByTestId('assign-cancel-btn'));
     expect(screen.queryByTestId('assign-confirm-btn')).not.toBeInTheDocument();
     expect(screen.getByTestId(`assign-btn-${MASTER_ID_1}`)).toBeInTheDocument();
+  });
+
+  it('17. renders target/filter/night/frames from the P9 session-context enrichment', () => {
+    renderPanel({ response: matchResponse });
+    expect(screen.getByText('M 31')).toBeInTheDocument();
+    expect(screen.getByText('Ha')).toBeInTheDocument();
+    expect(screen.getByText('2026-03-01')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('18. renders "—" fallback for each context field the backend could not resolve', () => {
+    renderPanel({ response: matchResponse });
+    // Candidate 2 (MASTER_ID_2) has no session-context fields — all four
+    // columns fall back to the shared em-dash placeholder used elsewhere
+    // (e.g. SessionsTable). The fully-resolved candidate 1 renders real
+    // values, so at least one dash-per-field must come from candidate 2.
+    const dashes = screen.getAllByText('—');
+    expect(dashes.length).toBeGreaterThanOrEqual(4);
   });
 });

--- a/apps/desktop/src/features/calibration/MatchCandidatesPanel.tsx
+++ b/apps/desktop/src/features/calibration/MatchCandidatesPanel.tsx
@@ -12,9 +12,12 @@
  *   - Respects `prefillSuggestion` to auto-open confirm prompt on top candidate
  *   - Humanized empty state when no sessions match.
  *
- * Target / Filter / Night / Frames are NOT carried on the suggest DTO
- * (`CalibrationMatchDto` only has sessionId + confidence + dimension breakdown);
- * those cells are marked `// STUB:` until the backend enriches the contract.
+ * Target / Filter / Night / Frames come from the P9 session-context
+ * enrichment on `CalibrationMatchDto` (`targetName` / `filter` /
+ * `acquisitionNight` / `frameCount`, all resolved server-side via a single
+ * batched lookup). Any field the backend could not resolve (e.g. no
+ * canonical target link, no fingerprint row) renders as `—`, matching the
+ * fallback convention used elsewhere (e.g. `SessionsTable.tsx`).
  *
  * No Playwright/visual smoke tests — jsdom unit-tested in MatchCandidatesPanel.test.tsx.
  */
@@ -330,7 +333,7 @@ export function MatchCandidatesPanel({
       );
     }
     const isObserverMissing = code === 'match.observer_location_missing' || response.suggestStatus === 'observer_location_missing';
-     
+
     const isMixedState = response.error?.code === 'session.mixed_state';
     const guardMessage = isObserverMissing
       ? m.calibration_observer_missing_guard()
@@ -407,15 +410,10 @@ export function MatchCandidatesPanel({
               {m.sessionId.length > 12 ? '…' : ''}
             </span>
           ),
-          // STUB: target name not on CalibrationMatchDto (suggest contract).
-          // Backend enrichment needed to resolve sessionId → target.
-          target: <span className="alm-match-candidates__stub-cell">—</span>,
-          // STUB: filter not on CalibrationMatchDto. Backend enrichment needed.
-          filter: <span className="alm-match-candidates__stub-cell">—</span>,
-          // STUB: acquisition night not on CalibrationMatchDto. Backend enrichment needed.
-          night: <span className="alm-match-candidates__stub-cell">—</span>,
-          // STUB: frame count not on CalibrationMatchDto. Backend enrichment needed.
-          frames: <span className="alm-match-candidates__stub-cell">—</span>,
+          target: m.targetName ?? '—',
+          filter: m.filter ?? '—',
+          night: m.acquisitionNight ?? '—',
+          frames: m.frameCount ?? '—',
           confidence: <ConfidenceBar value={m.confidence ?? 0} />,
           dimensions: <DimensionBreakdown match={m} />,
           assign: (

--- a/apps/desktop/src/styles/components/merges-1.css
+++ b/apps/desktop/src/styles/components/merges-1.css
@@ -87,14 +87,6 @@
   text-overflow: ellipsis;
 }
 
-/* Placeholder cell for backend-absent columns (Target / Filter / Night /
- * Frames). Faint em-dash so the column reads as "not yet available" rather
- * than empty/broken. De-stub once the suggest contract carries session
- * enrichment. */
-.alm-match-candidates__stub-cell {
-  color: var(--alm-text-faint);
-}
-
 /* === merged from .cssblocks/projects.css (parallel coder, spec-043) === */
 /* === PROJECTS LIST: rich list rows (spec 043 §4 / task #43) ===
  *

--- a/crates/app/calibration/src/matching.rs
+++ b/crates/app/calibration/src/matching.rs
@@ -42,12 +42,15 @@ use contracts_core::calibration_match::{
     contract_to_kind, kind_to_contract, match_to_dto, AssignErrorDetails, AssignErrorDto,
     AssignedDto, BatchErrorDto, BatchSessionResultDto, CalibrationMatchAssignRequest,
     CalibrationMatchAssignResponse, CalibrationMatchBatchRequest, CalibrationMatchBatchResponse,
-    CalibrationMatchSuggestRequest, CalibrationMatchSuggestResponse, SuggestErrorDto,
-    SuggestStatus, ASSIGN_CONTRACT_VERSION, BATCH_CONTRACT_VERSION, SUGGEST_CONTRACT_VERSION,
+    CalibrationMatchDto, CalibrationMatchSuggestRequest, CalibrationMatchSuggestResponse,
+    SuggestErrorDto, SuggestStatus, ASSIGN_CONTRACT_VERSION, BATCH_CONTRACT_VERSION,
+    SUGGEST_CONTRACT_VERSION,
 };
 use domain_core::ids::Timestamp;
 use persistence_db::repositories::calibration_assignment::{self as assign_repo, UpsertParams};
+use persistence_db::repositories::inventory::{get_session_context_by_ids, SessionContextRow};
 use sqlx::SqlitePool;
+use std::collections::HashMap;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -111,7 +114,16 @@ pub async fn suggest(
                 "ambiguous" => SuggestStatus::Ambiguous,
                 _ => SuggestStatus::NoMatch,
             };
-            let dto_matches: Vec<_> = matches.iter().filter_map(match_to_dto).collect();
+            // P9: enrich with session context (target/filter/night/frame
+            // count) — one batched lookup, not N+1. All candidates share the
+            // same `req.session_id` here (single-session suggest).
+            let session_ctx =
+                load_session_contexts(pool, std::slice::from_ref(&req.session_id)).await;
+            let dto_matches: Vec<_> = matches
+                .iter()
+                .filter_map(match_to_dto)
+                .map(|dto| apply_session_context(dto, &session_ctx))
+                .collect();
             Ok(CalibrationMatchSuggestResponse {
                 status: "success".to_owned(),
                 contract_version: SUGGEST_CONTRACT_VERSION.to_owned(),
@@ -164,6 +176,11 @@ pub async fn batch_suggest(
 
     let masters = load_masters(pool, &types_ref).await?;
 
+    // P9: one batched session-context lookup for the whole request, keyed by
+    // every requested session id — not a per-session (N+1) query inside the
+    // loop below.
+    let session_ctx = load_session_contexts(pool, &req.session_ids).await;
+
     let mut results: Vec<BatchSessionResultDto> = Vec::new();
     let mut errors: Vec<BatchErrorDto> = Vec::new();
 
@@ -207,6 +224,7 @@ pub async fn batch_suggest(
                                         .iter()
                                         .filter(|m| m.calibration_type == *kind)
                                         .filter_map(match_to_dto)
+                                        .map(|dto| apply_session_context(dto, &session_ctx))
                                         .collect();
                                     let kind_matches: Vec<_> = matches
                                         .iter()
@@ -436,6 +454,55 @@ fn error_assign_response(
             details: dimensions.map(|d| AssignErrorDetails { dimensions: d }),
         }),
     }
+}
+
+// ── Session context enrichment (spec P9) ──────────────────────────────────────
+//
+// `calibration_core::suggest` is pure domain (no DB access — see module docs).
+// Target/filter/night/frame-count context is resolved here, in the same layer
+// that already loads sessions and masters from persistence, as a
+// post-processing pass over the DTOs `match_to_dto` produced with those
+// fields left `None`.
+
+/// Batch-load session context for a set of session ids and index it by id.
+///
+/// Always a single query (`persistence_db::repositories::inventory::
+/// get_session_context_by_ids`) regardless of how many ids are requested.
+/// Ids that don't resolve (unknown session, or a session with no context)
+/// are simply absent from the returned map — callers must treat a missing
+/// key the same as "no context available", not an error.
+async fn load_session_contexts(
+    pool: &SqlitePool,
+    session_ids: &[String],
+) -> HashMap<String, SessionContextRow> {
+    // Dedup before querying — batch callers (batch_suggest) may pass the same
+    // id from overlapping calibration types.
+    let mut seen = std::collections::HashSet::new();
+    let unique_ids: Vec<String> =
+        session_ids.iter().filter(|id| seen.insert((*id).clone())).cloned().collect();
+
+    match get_session_context_by_ids(pool, &unique_ids).await {
+        Ok(rows) => rows.into_iter().map(|row| (row.id.clone(), row)).collect(),
+        // A lookup failure degrades to "no context" rather than failing the
+        // whole suggest response — context is presentational, not load-bearing.
+        Err(_) => HashMap::new(),
+    }
+}
+
+/// Apply resolved session context onto a `CalibrationMatchDto`, keyed by
+/// `dto.session_id`. Leaves the DTO's context fields as `None` when the
+/// session id has no entry in `ctx` (unknown session, or missing metadata).
+fn apply_session_context(
+    mut dto: CalibrationMatchDto,
+    ctx: &HashMap<String, SessionContextRow>,
+) -> CalibrationMatchDto {
+    if let Some(row) = ctx.get(&dto.session_id) {
+        dto.target_name = row.target_name.clone();
+        dto.filter = row.filter.clone();
+        dto.acquisition_night = row.acquisition_night.clone();
+        dto.frame_count = u32::try_from(row.frame_count).ok();
+    }
+    dto
 }
 
 // ── DB loading helpers ────────────────────────────────────────────────────────

--- a/crates/app/core/tests/calibration_integration.rs
+++ b/crates/app/core/tests/calibration_integration.rs
@@ -107,6 +107,54 @@ async fn insert_cal_fingerprint(
     .unwrap_or_else(|e| panic!("insert calibration_fingerprint failed: {e}"));
 }
 
+/// Insert a `canonical_target` row and link it to an acquisition session via
+/// `canonical_target_id` (spec P9 context-enrichment source).
+async fn link_canonical_target(
+    pool: &sqlx::SqlitePool,
+    session_id: &str,
+    target_id: &str,
+    designation: &str,
+) {
+    sqlx::query(
+        "INSERT INTO canonical_target \
+         (id, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at) \
+         VALUES (?, ?, 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
+    )
+    .bind(target_id)
+    .bind(designation)
+    .execute(pool)
+    .await
+    .unwrap_or_else(|e| panic!("insert canonical_target failed: {e}"));
+
+    sqlx::query("UPDATE acquisition_session SET canonical_target_id = ? WHERE id = ?")
+        .bind(target_id)
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|e| panic!("link canonical_target_id failed: {e}"));
+}
+
+/// Overwrite `frame_ids` on an acquisition session so the `frame_count`
+/// enrichment (`json_array_length`) resolves to a known value.
+async fn set_frame_ids(pool: &sqlx::SqlitePool, session_id: &str, frame_ids_json: &str) {
+    sqlx::query("UPDATE acquisition_session SET frame_ids = ? WHERE id = ?")
+        .bind(frame_ids_json)
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|e| panic!("set frame_ids failed: {e}"));
+}
+
+/// Set `filter_name` on an `acquisition_fingerprint` row.
+async fn set_filter(pool: &sqlx::SqlitePool, session_id: &str, filter: &str) {
+    sqlx::query("UPDATE acquisition_fingerprint SET filter_name = ? WHERE id = ?")
+        .bind(filter)
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .unwrap_or_else(|e| panic!("set filter_name failed: {e}"));
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 /// Seeding a light session + matching dark master returns candidates via `suggest`.
@@ -289,4 +337,106 @@ async fn batch_suggest_returns_results_and_errors_per_session() {
         errors.iter().any(|e| e.code == "session.not_found"),
         "expected session.not_found error code, got {errors:?}",
     );
+}
+
+/// P9: `suggest` enriches each candidate DTO with session context (target,
+/// filter, observing night, frame count) via one batched lookup, keyed by
+/// `session_id`. A field with no backing data (filter is left unset here)
+/// stays `None` rather than defaulting to a placeholder.
+#[tokio::test]
+async fn suggest_enriches_candidates_with_session_context() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    let session_id = Uuid::new_v4().to_string();
+    let master_id = Uuid::new_v4().to_string();
+    let target_id = Uuid::new_v4().to_string();
+
+    insert_acq_session(pool, &session_id).await;
+    insert_acq_fingerprint(pool, &session_id, 100.0, 10.0, -10.0, "1x1").await;
+    link_canonical_target(pool, &session_id, &target_id, "M 31").await;
+    set_frame_ids(pool, &session_id, r#"["f1","f2","f3","f4"]"#).await;
+
+    insert_cal_session(pool, &master_id, "dark").await;
+    insert_cal_fingerprint(pool, &master_id, "dark", 100.0, 10.0, -10.0, "1x1").await;
+
+    let req = CalibrationMatchSuggestRequest {
+        contract_version: SUGGEST_CONTRACT_VERSION.to_owned(),
+        request_id: Uuid::new_v4().to_string(),
+        session_id: session_id.clone(),
+        calibration_types: Some(vec![CalibrationType::Dark]),
+    };
+
+    let resp = suggest(pool, req).await.expect("suggest should not return Err");
+    let matches = resp.matches.expect("expected Some(matches)");
+
+    let candidate =
+        matches.iter().find(|m| m.master_id == master_id).expect("expected master in candidates");
+    assert_eq!(candidate.target_name.as_deref(), Some("M 31"));
+    // insert_acq_fingerprint hard-codes observing_night_date but leaves
+    // filter_name unset — the enrichment must not fabricate a value.
+    assert_eq!(candidate.acquisition_night.as_deref(), Some("2026-05-01"));
+    assert_eq!(candidate.filter, None, "filter_name was never set — must stay None");
+    assert_eq!(candidate.frame_count, Some(4));
+}
+
+/// P9 batch coverage: known sessions get enriched independently (one linked
+/// to a canonical target, one not), and an id with no matching session at all
+/// neither breaks the batched context lookup nor gets a phantom context row —
+/// it still surfaces through the existing `session.not_found` error path.
+#[tokio::test]
+async fn batch_suggest_enriches_known_sessions_and_ignores_missing_ids() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    let session_a = Uuid::new_v4().to_string();
+    let session_b = Uuid::new_v4().to_string();
+    let master_id = Uuid::new_v4().to_string();
+    let target_id = Uuid::new_v4().to_string();
+    let missing_session = Uuid::new_v4().to_string(); // never inserted → not_found
+
+    // Session A: full context (canonical target + known frame count).
+    insert_acq_session(pool, &session_a).await;
+    insert_acq_fingerprint(pool, &session_a, 50.0, 5.0, -5.0, "1x1").await;
+    link_canonical_target(pool, &session_a, &target_id, "NGC 7000").await;
+    set_frame_ids(pool, &session_a, r#"["f1","f2"]"#).await;
+    set_filter(pool, &session_a, "Ha").await;
+
+    // Session B: matches the same master, but has no canonical_target_id
+    // link — target_name must resolve to None while frame_count (from the
+    // default `frame_ids = '[]'`) still resolves to 0, not None.
+    insert_acq_session(pool, &session_b).await;
+    insert_acq_fingerprint(pool, &session_b, 50.0, 5.0, -5.0, "1x1").await;
+
+    insert_cal_session(pool, &master_id, "bias").await;
+    insert_cal_fingerprint(pool, &master_id, "bias", 50.0, 5.0, -5.0, "1x1").await;
+
+    let req = CalibrationMatchBatchRequest {
+        contract_version: BATCH_CONTRACT_VERSION.to_owned(),
+        request_id: Uuid::new_v4().to_string(),
+        session_ids: vec![session_a.clone(), session_b.clone(), missing_session.clone()],
+        calibration_types: Some(vec![CalibrationType::Bias]),
+    };
+
+    let resp = batch_suggest(pool, req).await.expect("batch_suggest should not return Err");
+    let results = resp.results.expect("expected Some(results)");
+
+    let result_a =
+        results.iter().find(|r| r.session_id == session_a).expect("expected session_a result");
+    let candidates_a = result_a.candidates.as_ref().expect("expected candidates for session_a");
+    assert_eq!(candidates_a[0].target_name.as_deref(), Some("NGC 7000"));
+    assert_eq!(candidates_a[0].filter.as_deref(), Some("Ha"));
+    assert_eq!(candidates_a[0].frame_count, Some(2));
+
+    let result_b =
+        results.iter().find(|r| r.session_id == session_b).expect("expected session_b result");
+    let candidates_b = result_b.candidates.as_ref().expect("expected candidates for session_b");
+    assert_eq!(candidates_b[0].target_name, None, "no canonical_target_id linked → None");
+    assert_eq!(candidates_b[0].frame_count, Some(0), "default frame_ids '[]' → 0, not None");
+
+    // The unresolvable id must not appear anywhere in results and must still
+    // surface via the pre-existing session.not_found error path.
+    assert!(!results.iter().any(|r| r.session_id == missing_session));
+    let errors = resp.errors.expect("expected Some(errors)");
+    assert!(errors.iter().any(|e| e.session_id.as_deref() == Some(&missing_session)));
 }

--- a/crates/contracts/core/src/calibration_match.rs
+++ b/crates/contracts/core/src/calibration_match.rs
@@ -85,6 +85,20 @@ pub struct CalibrationMatchDto {
     pub dimensions_matched: Vec<MatchedDimDto>,
     pub dimensions_mismatched: Vec<MismatchedDimDto>,
     pub selection_reason: SelectionReason,
+    /// Session context enrichment (spec P9): the light session's resolved
+    /// target, filter, observing night, and frame count. `None` when the
+    /// context cannot be resolved (e.g. no canonical target link, no
+    /// fingerprint row, or the session id is unknown). Populated by
+    /// `app_core_calibration` as a post-processing step — the pure
+    /// `calibration_core` matching engine never touches persistence.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acquisition_night: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frame_count: Option<u32>,
 }
 
 // ── calibration.match.suggest ─────────────────────────────────────────────────
@@ -330,6 +344,13 @@ pub fn match_to_dto(m: &CalibrationMatch) -> Option<CalibrationMatchDto> {
         dimensions_matched: m.dimensions_matched.iter().map(matched_dim_to_dto).collect(),
         dimensions_mismatched: m.dimensions_mismatched.iter().map(mismatched_dim_to_dto).collect(),
         selection_reason,
+        // Session context is not known to the pure domain match; the caller
+        // (`app_core_calibration`) enriches these fields via a batched DB
+        // lookup after conversion.
+        target_name: None,
+        filter: None,
+        acquisition_night: None,
+        frame_count: None,
     })
 }
 

--- a/crates/persistence/db/src/repositories/inventory.rs
+++ b/crates/persistence/db/src/repositories/inventory.rs
@@ -228,6 +228,68 @@ pub async fn list_project_links_for_sessions(
     Ok(rows)
 }
 
+/// Session context enrichment row (spec P9): resolved target/filter/night/
+/// frame-count for a light (`acquisition_session`) row, keyed by session id.
+///
+/// `target_name` prefers the user-owned `display_alias` over
+/// `primary_designation` (same effective-label rule as the Targets surface).
+/// `filter` and `acquisition_night` come from `acquisition_fingerprint`
+/// (absent until the metadata extraction pipeline populates a fingerprint
+/// row). `frame_count` is derived from `json_array_length(frame_ids)` and is
+/// always present for a matched row (the column is `NOT NULL DEFAULT '[]'`).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SessionContextRow {
+    pub id: String,
+    pub target_name: Option<String>,
+    pub filter: Option<String>,
+    pub acquisition_night: Option<String>,
+    pub frame_count: i64,
+}
+
+/// Batch-load session context for calibration match-suggest enrichment
+/// (spec P9). One query for the whole `session_ids` set — callers MUST NOT
+/// call this per-row (N+1).
+///
+/// Only `acquisition_session` (light) rows are covered; calibration sessions
+/// have no target/filter/night context to enrich. Ids with no matching row
+/// (unknown session, or a calibration session id) are simply absent from the
+/// returned `Vec` — callers treat a missing id as "no context available".
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_session_context_by_ids(
+    pool: &SqlitePool,
+    session_ids: &[String],
+) -> DbResult<Vec<SessionContextRow>> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let placeholders = vec!["?"; session_ids.len()].join(",");
+    let sql = format!(
+        "SELECT
+             acs.id                                              AS id,
+             COALESCE(ct.display_alias, ct.primary_designation)  AS target_name,
+             af.filter_name                                      AS filter,
+             af.observing_night_date                             AS acquisition_night,
+             json_array_length(acs.frame_ids)                    AS frame_count
+         FROM acquisition_session acs
+         LEFT JOIN canonical_target ct ON ct.id = acs.canonical_target_id
+         LEFT JOIN acquisition_fingerprint af ON af.id = acs.id
+         WHERE acs.id IN ({placeholders})"
+    );
+
+    // SQL is built only from a fixed `?` placeholder count (no user strings
+    // in the text); every id flows through `bind`. Same pattern as the
+    // dynamic `IN (?, …)` lists in `inbox.rs` / `lifecycle.rs`.
+    let mut q = sqlx::query_as::<_, SessionContextRow>(sqlx::AssertSqlSafe(sql));
+    for id in session_ids {
+        q = q.bind(id);
+    }
+    let rows = q.fetch_all(pool).await?;
+    Ok(rows)
+}
+
 /// Set `root_id` on an `acquisition_session` row (T036, FR-012).
 ///
 /// Called when the inbox confirm pipeline resolves the root for a session.
@@ -348,5 +410,98 @@ mod tests {
             .await
             .unwrap();
         assert!(result.is_none());
+    }
+
+    // ── get_session_context_by_ids (spec P9) ──────────────────────────────────
+
+    #[tokio::test]
+    async fn session_context_empty_ids_returns_empty_without_querying() {
+        let db = setup().await;
+        let rows = get_session_context_by_ids(db.pool(), &[]).await.unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn session_context_batches_multiple_ids_in_one_call() {
+        let db = setup().await;
+
+        sqlx::query(
+            "INSERT INTO canonical_target
+                (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at, display_alias)
+             VALUES ('t-1', NULL, 'M 31', 'galaxy', 10.68, 41.27, 'seed', '2026-01-01T00:00:00Z', 'Andromeda')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at, canonical_target_id) \
+             VALUES ('acq-1', 'M31/L/2026-03-01', '[\"f1\",\"f2\",\"f3\"]', '2026-03-01T00:00:00Z', 't-1')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO acquisition_fingerprint (id, filter_name, observing_night_date) \
+             VALUES ('acq-1', 'Ha', '2026-03-01')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        // A second session with no fingerprint and no canonical target link —
+        // context fields resolve to None, but frame_count is still derived.
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
+             VALUES ('acq-2', 'unknown/L/2026-03-02', '[\"f4\"]', '2026-03-02T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let ids = vec!["acq-1".to_owned(), "acq-2".to_owned(), "missing-id".to_owned()];
+        let mut rows = get_session_context_by_ids(db.pool(), &ids).await.unwrap();
+        rows.sort_by(|a, b| a.id.cmp(&b.id));
+
+        // Unknown session ids are simply absent — no error, no phantom row.
+        assert_eq!(rows.len(), 2, "missing-id must not produce a row");
+
+        assert_eq!(rows[0].id, "acq-1");
+        assert_eq!(rows[0].target_name.as_deref(), Some("Andromeda"), "display_alias wins");
+        assert_eq!(rows[0].filter.as_deref(), Some("Ha"));
+        assert_eq!(rows[0].acquisition_night.as_deref(), Some("2026-03-01"));
+        assert_eq!(rows[0].frame_count, 3);
+
+        assert_eq!(rows[1].id, "acq-2");
+        assert_eq!(rows[1].target_name, None);
+        assert_eq!(rows[1].filter, None);
+        assert_eq!(rows[1].acquisition_night, None);
+        assert_eq!(rows[1].frame_count, 1);
+    }
+
+    #[tokio::test]
+    async fn session_context_falls_back_to_primary_designation_without_display_alias() {
+        let db = setup().await;
+
+        sqlx::query(
+            "INSERT INTO canonical_target
+                (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
+             VALUES ('t-2', NULL, 'NGC 7000', 'nebula', 20.0, 30.0, 'seed', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at, canonical_target_id) \
+             VALUES ('acq-3', 'NGC7000/L/2026-04-01', '[]', '2026-04-01T00:00:00Z', 't-2')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let rows = get_session_context_by_ids(db.pool(), &["acq-3".to_owned()]).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].target_name.as_deref(), Some("NGC 7000"));
+        assert_eq!(rows[0].frame_count, 0);
     }
 }


### PR DESCRIPTION
## Summary
- Calibration match candidates now show the actual target, filter, observing night, and frame count for each suggested session — previously these columns always showed a placeholder dash because the data wasn't wired up.
- Fixed a gap where the calibration match-suggestion API had no mock/dev-mode support at all (it would throw "unknown command"); dev/mock mode now returns realistic sample data.

## Test plan
- [x] Backend unit/integration tests (repository batch lookup, single-session suggest, batch suggest with missing session ids)
- [x] Frontend unit tests (real values render, "—" fallback when data is unavailable)
- [x] `cargo fmt` + `cargo clippy --workspace -D warnings` clean
- [x] `just typecheck` clean
- [x] Generated TypeScript bindings regenerated and committed

## Spec Context

Architecture check (required before implementation): inspected `crates/calibration/core/Cargo.toml` — it has zero DB/persistence dependencies (serde, serde_json, uuid, time only), confirming the matching engine stays pure domain. `crates/app/calibration/Cargo.toml` (housing `matching.rs`) already depends on `persistence_db` and is where `suggest`/`batch_suggest` already load session/master data from SQLite. Decision: the new context fields are resolved there as a post-processing pass over the DTOs, keyed by session id. `calibration_core` and `contracts_core::calibration_match::match_to_dto` were not given any new dependency edge — the DTO fields are simply initialized to `None` at construction and filled in afterward.

Batching: one `get_session_context_by_ids` query per `suggest`/`batch_suggest` call (not N+1), using the repo's existing dynamic `IN (?, …)` + `sqlx::AssertSqlSafe` pattern (see `inbox.rs`). `frame_count` uses the existing `json_array_length(frame_ids)` idiom (see `targets.rs`); `target_name` prefers `COALESCE(display_alias, primary_designation)` (existing effective-label rule).

Verification detail: `cargo test -p persistence_db --lib repositories::inventory` (7/7, new batched-lookup coverage including missing/unknown session ids), `cargo test -p app_core_calibration` (5/5, pre-existing), `cargo test -p app_core --test calibration_integration` (6/6, 2 new Layer-1 tests covering full context, partial context, and a nonexistent session id in one batched call), `MatchCandidatesPanel.test.tsx` (18/18, 2 new tests). `pre-commit run --all-files`'s `typos` hook fails, but only on pre-existing repo-wide dictionary false positives (`desig`, `gam`, `ome`, `hav`, `ba`, `noo`, etc. across ~15 files including `assets/seed/seed.json`) — verified none of the flagged lines are in this PR's diff.