### PR TITLE
fix: rewire the real-UI E2E test harness to the current WebDriver stack

### DIFF
--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -8,32 +8,51 @@ desktop app.
 **Ignored stub journeys. Wiring deferred while the backend is still changing.**
 
 All tests compile and appear in `cargo nextest list` but are marked
-`#[ignore]`. They will be unwired once:
+`#[ignore]`. The harness itself (driver launch, `tauri:options.application`
+capability, `__ALM_E2E__` invoke bridge) is wired — see `tests/common/mod.rs`.
+Journeys stay ignored until the backend commands they'd assert against are
+de-stubbed (research D9): `search.global`, `sessions.list`/`get`, and
+`calibration.masters.list`/`get` currently return hardcoded fixture data.
 
-1. The `__APP_E2E__` invoke bridge is exposed by the frontend (built with
-   `VITE_E2E=1`).
-2. The tauri-driver WebDriver caps (`tauri:options.application` +
-   `browserName="wry"`) replace the chrome placeholder caps in
-   `tests/common/mod.rs`.
-
-## How to run (once wired)
+## How to run (once a journey is un-ignored)
 
 ```sh
 cargo nextest run -p e2e_tests --profile e2e --run-ignored all
 ```
 
+## Mechanism
+
+- `desktop_shell` is built with `cargo build -p desktop_shell --features e2e`,
+  which compiles in `tauri-plugin-webdriver` (Choochmeque) — an embedded W3C
+  WebDriver server listening on `127.0.0.1:4445`. Release builds omit the
+  `e2e` feature so the automation surface is never present (Constitution
+  Principle V).
+- The `tauri-webdriver` CLI (`cargo install tauri-webdriver --locked`) proxies
+  `127.0.0.1:4444` to the embedded plugin server on `:4445`, and manages the
+  target app's process lifecycle via the `tauri:options` capability — it does
+  **not** take the app binary as a CLI argument.
+- thirtyfour (this crate's W3C client) connects to the CLI on `:4444` and
+  sends `tauri:options.application` = the built `desktop_shell` binary path in
+  the New Session capabilities. No `browserName` is set.
+- The app loads its own frontend from the Tauri `devUrl` (`:5173`)
+  automatically on launch; the harness does not call `driver.goto(...)` after
+  connecting.
+- `window.__ALM_E2E__.invoke(...)` is the real-IPC invoke bridge exposed by
+  the frontend when built with `VITE_E2E=1` (`apps/desktop/src/main.tsx`).
+
+This mirrors `.github/workflows/e2e.yml` (see `specs/037-e2e-integration-testing/research.md`
+D10 and `quickstart.md`).
+
 ## Prerequisites
 
-- **tauri-driver** installed and on `$PATH`
-  (`cargo install tauri-driver`, or from the Tauri release assets).
-- Platform WebDriver binary on `$PATH`:
-  - Linux: `WebKitWebDriver` (from the `webkit2gtk-driver` package or equivalent).
-  - Windows: `msedgedriver` (matching the installed Edge version).
-- The desktop app must be **built** (`cargo tauri build` or `cargo tauri dev`
-  with `VITE_USE_MOCKS=false`).
-- Vite dev server running on `:1420` with:
+- **tauri-webdriver** installed and on `$PATH`
+  (`cargo install tauri-webdriver --locked`).
+- The `desktop_shell` binary must be **built with the `e2e` feature**:
+  `cargo build -p desktop_shell --features e2e`. Override the binary the
+  harness launches with `ALM_E2E_APP_BIN=/path/to/binary`.
+- Vite dev server / `vite preview` running on `:5173` with:
   - `VITE_USE_MOCKS=false` — real backend.
-  - `VITE_E2E=1` — exposes the `window.__APP_E2E__` invoke bridge.
+  - `VITE_E2E=1` — exposes the `window.__ALM_E2E__` invoke bridge.
 - Optional: set `ALM_DB_URL=sqlite:///path/to/alm.db` to control which
   database is wiped before each test run.  If unset, the harness will
   resolve the OS app-data path (wiring deferred — see `reset_database` in
@@ -41,7 +60,9 @@ cargo nextest run -p e2e_tests --profile e2e --run-ignored all
 
 ## Notes
 
-- The `__APP_E2E__.invoke` bridge and the tauri-driver caps are **not yet
-  wired**.  See `tests/common/mod.rs` for the `TODO(spec-037 wiring)` comments.
+- Old per-OS driver checks (`WebKitWebDriver`/`msedgedriver`) are obsolete —
+  `tauri-plugin-webdriver` replaces them on every OS (research D10). The
+  harness's `preflight()` only checks for the `tauri-webdriver` CLI and the
+  built `desktop_shell` binary.
 - Tests run serially (`test-threads = 1` in the `e2e` nextest profile) because
   there is one app instance, one driver session, and one database per run.

--- a/crates/e2e-tests/src/lib.rs
+++ b/crates/e2e-tests/src/lib.rs
@@ -3,8 +3,8 @@
 //! The library target is intentionally empty. All E2E logic lives under
 //! `tests/`:
 //!
-//! - `tests/common/` — the thirtyfour WebDriver harness (driver + app
-//!   lifecycle, the `window.__APP_E2E__` invoke bridge, fresh-DB reset).
+//! - `tests/common/` — the thirtyfour WebDriver harness (tauri-webdriver CLI
+//!   + app lifecycle, the `window.__ALM_E2E__` invoke bridge, fresh-DB reset).
 //! - `tests/journeys.rs` — the high-level user journeys.
 //! - `tests/smoke.rs` — the all-top-level-screens-load smoke.
 //!
@@ -13,4 +13,5 @@
 //!
 //! STATUS: scaffold. The journeys are `#[ignore]`d stubs — they compile and
 //! appear in `cargo nextest list`, but their assertions are `todo!()` pending a
-//! stable backend command surface and the `__APP_E2E__` bridge. See `README.md`.
+//! stable backend command surface (research D9). The harness itself (driver
+//! launch, capabilities, `__ALM_E2E__` bridge) is wired; see `README.md`.

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1,17 +1,36 @@
 //! Shared harness for spec 037 Layer-2 real-UI E2E journeys.
 //!
 //! All journeys are `#[ignore]`d. They are compiled stubs that appear in
-//! `cargo nextest list` but are deferred until two prerequisites land:
+//! `cargo nextest list` but execution is deferred while the backend commands
+//! they'd assert against are still stubs (research D9) — not because this
+//! harness is unwired.
 //!
-//! 1. The `__APP_E2E__` bridge (exposed by the desktop app when built with
-//!    `VITE_E2E=1`) is wired in the frontend.
-//! 2. The tauri-driver WebDriver caps (`tauri:options.application` +
-//!    `browserName="wry"`) replace the chrome placeholder caps used here.
+//! Mechanism (mirrors `.github/workflows/e2e.yml`, research D10):
+//! - `desktop_shell` is built with `cargo build -p desktop_shell --features
+//!   e2e`, which compiles in `tauri-plugin-webdriver` (Choochmeque) — an
+//!   embedded W3C WebDriver server listening on `127.0.0.1:4445`. Release
+//!   builds omit the `e2e` feature so the automation surface is never present
+//!   (Constitution Principle V).
+//! - The `tauri-webdriver` CLI (`cargo install tauri-webdriver --locked`)
+//!   proxies `127.0.0.1:4444` -> the embedded plugin server on `:4445`, and
+//!   manages the target app's process lifecycle via the `tauri:options`
+//!   capability — it does **not** take the app binary as a CLI argument.
+//! - thirtyfour (this crate's W3C client) connects to the CLI on `:4444` and
+//!   sends `tauri:options.application` = the built `desktop_shell` binary
+//!   path in the New Session capabilities. No `browserName` is set (see
+//!   `quickstart.md`).
+//! - The app loads its own frontend from the Tauri `devUrl` (`:5173`)
+//!   automatically on launch, so the harness does **not** call
+//!   `driver.goto(...)` after connecting.
+//! - `window.__ALM_E2E__.invoke(...)` (exposed by the frontend when built
+//!   with `VITE_E2E=1`, see `apps/desktop/src/main.tsx`) is the real-IPC
+//!   invoke bridge used by [`E2eApp::invoke`].
 //!
 //! See `crates/e2e-tests/README.md` for the full run procedure.
 
 #![allow(dead_code)]
 
+use std::path::PathBuf;
 use std::process::{Child, Command};
 
 use anyhow::{anyhow, Context, Result};
@@ -19,12 +38,18 @@ use serde::de::DeserializeOwned;
 use serde_json::{json, Value};
 use thirtyfour::prelude::*;
 
-/// URL where tauri-driver listens for W3C WebDriver sessions.
-pub const TAURI_DRIVER_URL: &str = "http://127.0.0.1:4444";
+/// URL where the `tauri-webdriver` CLI proxy listens for W3C WebDriver
+/// sessions (`--port`, default `4444`). It forwards to the
+/// `tauri-plugin-webdriver` server embedded in the `desktop_shell` binary on
+/// `127.0.0.1:4445` (`--native-port`, matching `tauri_plugin_webdriver::init()`'s
+/// default in `apps/desktop/src-tauri/src/lib.rs`).
+pub const TAURI_WEBDRIVER_URL: &str = "http://127.0.0.1:4444";
 
-/// Vite dev-server port used when running against the real backend
-/// (`VITE_USE_MOCKS=false`).
-pub const APP_URL: &str = "http://127.0.0.1:1420";
+/// Vite dev-server / `vite preview` port the app's Tauri `devUrl` points at
+/// (`apps/desktop/src-tauri/tauri.conf.json`). The app loads this URL on its
+/// own at launch — do NOT `driver.goto(APP_URL)` after connecting. Kept for
+/// journeys that need to assert the current URL or navigate within the SPA.
+pub const APP_URL: &str = "http://127.0.0.1:5173";
 
 // ---------------------------------------------------------------------------
 // Private deserialization target for invoke() responses
@@ -66,35 +91,43 @@ pub struct E2eApp {
 }
 
 impl E2eApp {
-    /// Launch a full E2E session: preflight → reset DB → spawn tauri-driver →
-    /// connect WebDriver → navigate to [`APP_URL`].
+    /// Launch a full E2E session: preflight → reset DB → spawn the
+    /// `tauri-webdriver` CLI proxy → connect WebDriver with the
+    /// `tauri:options.application` capability pointing at the built
+    /// `desktop_shell` binary.
+    ///
+    /// The app auto-loads its frontend from the Tauri `devUrl` on launch, so
+    /// no `driver.goto(...)` call is needed here (see module docs).
     pub async fn launch() -> Result<Self> {
         preflight()?;
         reset_database()?;
 
-        let driver_proc =
-            spawn_tauri_driver().context("failed to spawn tauri-driver on port 4444")?;
+        let driver_proc = spawn_tauri_webdriver()
+            .context("failed to spawn the tauri-webdriver CLI on port 4444")?;
 
-        // TODO(spec-037 wiring): replace DesiredCapabilities::chrome() with
-        // real tauri-driver caps:
-        //   caps.set_browser_name("wry")?;
-        //   caps.add_capability("tauri:options", json!({"application": "/path/to/alm"}))?;
-        // Chrome caps are a placeholder that makes this file compile.
-        let driver = WebDriver::new(TAURI_DRIVER_URL, DesiredCapabilities::chrome())
-            .await
-            .context("WebDriver::new failed — is tauri-driver running on :4444?")?;
+        let app_binary = app_binary_path()?;
+        let mut caps = Capabilities::new();
+        caps.set("tauri:options", json!({ "application": app_binary.to_string_lossy() }))
+            .context("failed to set the tauri:options.application capability")?;
 
-        driver.goto(APP_URL).await.context("driver.goto APP_URL failed")?;
+        let driver = WebDriver::new(TAURI_WEBDRIVER_URL, caps).await.with_context(|| {
+            format!(
+                "WebDriver::new failed against {TAURI_WEBDRIVER_URL} — is `tauri-webdriver` \
+                 running, and was {} built with `--features e2e`?",
+                app_binary.display()
+            )
+        })?;
 
         Ok(Self { driver, driver_proc: Some(driver_proc) })
     }
 
-    /// Issue a Tauri command through the `window.__APP_E2E__` bridge.
+    /// Issue a Tauri command through the `window.__ALM_E2E__` bridge.
     ///
     /// The bridge is exposed by the desktop app when it is built with
-    /// `VITE_E2E=1`.  This replaces the old better-sqlite3 reader approach:
-    /// instead of reading the DB directly, we assert UI→real-backend
-    /// round-trips against real command output (FR-008).
+    /// `VITE_E2E=1` (see `apps/desktop/src/main.tsx`). This replaces the old
+    /// better-sqlite3 reader approach: instead of reading the DB directly, we
+    /// assert UI→real-backend round-trips against real command output
+    /// (FR-008).
     ///
     /// The injected WebDriver callback is the last script argument
     /// (`arguments[arguments.length-1]`); the bridge resolves it with
@@ -104,11 +137,11 @@ impl E2eApp {
             var cmd      = arguments[0];
             var cmdArgs  = arguments[1];
             var callback = arguments[arguments.length - 1];
-            if (!window.__APP_E2E__ || typeof window.__APP_E2E__.invoke !== 'function') {
-                callback({ ok: false, error: '__APP_E2E__ bridge missing (build with VITE_E2E=1)' });
+            if (!window.__ALM_E2E__ || typeof window.__ALM_E2E__.invoke !== 'function') {
+                callback({ ok: false, error: '__ALM_E2E__ bridge missing (build with VITE_E2E=1)' });
                 return;
             }
-            window.__APP_E2E__.invoke(cmd, cmdArgs).then(function(value) {
+            window.__ALM_E2E__.invoke(cmd, cmdArgs).then(function(value) {
                 callback({ ok: true, value: value });
             }).catch(function(err) {
                 callback({ ok: false, error: String(err) });
@@ -127,7 +160,9 @@ impl E2eApp {
         outcome.into_result::<T>()
     }
 
-    /// Quit the WebDriver session and kill the driver process if present.
+    /// Quit the WebDriver session and kill the `tauri-webdriver` CLI process
+    /// if present. Quitting the session already terminates the app process
+    /// that `tauri-webdriver` launched on our behalf.
     pub async fn shutdown(mut self) -> Result<()> {
         let _ = self.driver.quit().await;
         if let Some(mut child) = self.driver_proc.take() {
@@ -138,17 +173,96 @@ impl E2eApp {
 }
 
 // ---------------------------------------------------------------------------
-// Private helpers (each carries a TODO(spec-037 wiring) note)
+// Private helpers
 // ---------------------------------------------------------------------------
 
-/// Pre-flight check: verify driver binaries are present and version-matched.
-///
-/// TODO(spec-037 wiring): assert that `tauri-driver` is on `$PATH`; on Linux
-/// also assert `WebKitWebDriver`; on Windows assert `msedgedriver`.  Return a
-/// named actionable error describing what is missing and where to get it
-/// (FR-015).
+/// Pre-flight check: verify the `tauri-webdriver` CLI is on `$PATH` and the
+/// `desktop_shell` binary has been built, with a named, actionable error for
+/// each (FR-015). Old per-OS driver checks (`WebKitWebDriver`/`msedgedriver`)
+/// are obsolete since D10 standardized on `tauri-plugin-webdriver` for every
+/// OS — there is no per-OS native driver binary left to check.
 fn preflight() -> Result<()> {
+    check_tauri_webdriver_cli()?;
+    check_app_binary()?;
     Ok(())
+}
+
+/// Verify `tauri-webdriver` is reachable on `$PATH` by attempting to spawn it.
+/// A spawn failure with `NotFound` means the CLI is missing; any other
+/// outcome (including a non-zero exit from an unrecognised flag) means the
+/// binary exists.
+fn check_tauri_webdriver_cli() -> Result<()> {
+    match Command::new("tauri-webdriver").arg("--help").output() {
+        Ok(_) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Err(anyhow!(
+            "the `tauri-webdriver` CLI is not on $PATH.\n\
+             Install it with: cargo install tauri-webdriver --locked\n\
+             (mirrors the \"Install tauri-webdriver CLI\" step in .github/workflows/e2e.yml)"
+        )),
+        Err(e) => Err(e).context("failed to probe for the tauri-webdriver CLI on $PATH"),
+    }
+}
+
+/// Verify the `desktop_shell` binary this harness will launch actually
+/// exists, so a missing build fails with a named error here instead of a
+/// confusing WebDriver session-creation failure.
+fn check_app_binary() -> Result<()> {
+    let path = app_binary_path()?;
+    if path.is_file() {
+        Ok(())
+    } else {
+        Err(anyhow!(
+            "desktop_shell binary not found at {}.\n\
+             Build it with: cargo build -p desktop_shell --features e2e\n\
+             Or point at an existing build with: ALM_E2E_APP_BIN=/path/to/binary",
+            path.display()
+        ))
+    }
+}
+
+/// Resolve the path to the built `desktop_shell` binary.
+///
+/// Mirrors `.github/workflows/e2e.yml`'s "Build desktop_shell with e2e
+/// feature" step (`cargo build -p desktop_shell --features e2e`), which
+/// places the binary at `<workspace_root>/target/debug/desktop_shell[.exe]`.
+/// Override with `ALM_E2E_APP_BIN=/path/to/binary` (documented in
+/// `quickstart.md`) to point at a different build (e.g. a release profile).
+fn app_binary_path() -> Result<PathBuf> {
+    if let Ok(path) = std::env::var("ALM_E2E_APP_BIN") {
+        return Ok(PathBuf::from(path));
+    }
+
+    // CARGO_MANIFEST_DIR is `<workspace_root>/crates/e2e-tests` at compile time.
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let workspace_root = manifest_dir
+        .parent()
+        .and_then(std::path::Path::parent)
+        .ok_or_else(|| anyhow!("failed to resolve workspace root from CARGO_MANIFEST_DIR"))?;
+
+    let binary_name = if cfg!(windows) { "desktop_shell.exe" } else { "desktop_shell" };
+    Ok(workspace_root.join("target").join("debug").join(binary_name))
+}
+
+/// Spawn the `tauri-webdriver` CLI proxy as a background child process.
+///
+/// Mirrors `.github/workflows/e2e.yml`: the CLI is installed once
+/// (`cargo install tauri-webdriver --locked`) and this harness starts it per
+/// session. `--port`/`--native-port` are passed explicitly even though they
+/// match the CLI's and plugin's defaults, so a future default change upstream
+/// doesn't silently break the pairing.
+fn spawn_tauri_webdriver() -> Result<Child> {
+    Command::new("tauri-webdriver")
+        .arg("--port")
+        .arg("4444")
+        .arg("--native-port")
+        .arg("4445")
+        .spawn()
+        .map_err(|e| {
+            anyhow!(
+                "failed to spawn tauri-webdriver: {e} \
+                 (install with `cargo install tauri-webdriver --locked`)"
+            )
+        })
 }
 
 /// Reset the application database so each test starts from a clean state.
@@ -170,16 +284,4 @@ fn reset_database() -> Result<()> {
     }
     // TODO(spec-037 wiring): resolve OS app-data path when ALM_DB_URL is unset.
     Ok(())
-}
-
-/// Spawn `tauri-driver --port 4444` as a background child process.
-///
-/// TODO(spec-037 wiring): wrap in `xvfb-run` on Linux (headless display);
-/// pass the built application binary via `tauri-driver -- /path/to/alm`.
-fn spawn_tauri_driver() -> Result<Child> {
-    Command::new("tauri-driver")
-        .arg("--port")
-        .arg("4444")
-        .spawn()
-        .map_err(|e| anyhow!("failed to spawn tauri-driver: {e}"))
 }

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -1,10 +1,11 @@
 //! Spec 037 Layer-2 real-UI E2E journey stubs.
 //!
 //! All journeys are `#[ignore]`d. They compile and appear in
-//! `cargo nextest list` but execution is deferred until the
-//! `__APP_E2E__` bridge and tauri-driver caps are wired in.
+//! `cargo nextest list` but execution is deferred until the backend commands
+//! they assert against are de-stubbed (research D9). The harness
+//! (`window.__ALM_E2E__` bridge, tauri-webdriver capabilities) is wired.
 //!
-//! Run (once wired):
+//! Run (once un-ignored):
 //! ```text
 //! cargo nextest run -p e2e_tests --profile e2e --run-ignored all
 //! ```

--- a/crates/e2e-tests/tests/smoke.rs
+++ b/crates/e2e-tests/tests/smoke.rs
@@ -1,9 +1,11 @@
 //! Spec 037 Layer-2 real-UI smoke test stubs.
 //!
 //! Verifies that every top-level route loads without a JS error.
-//! Ignored until the `__APP_E2E__` bridge and tauri-driver caps are wired in.
+//! Ignored until the backend commands the other journeys assert against are
+//! de-stubbed (research D9). The harness (`window.__ALM_E2E__` bridge,
+//! tauri-webdriver capabilities) is wired.
 //!
-//! Run (once wired):
+//! Run (once un-ignored):
 //! ```text
 //! cargo nextest run -p e2e_tests --profile e2e --run-ignored all
 //! ```


### PR DESCRIPTION
## Summary

- The real-UI end-to-end test harness (`crates/e2e-tests`) was still built
  against a WebDriver mechanism the project had already abandoned, and checked
  for the wrong frontend bridge name — so it silently drifted out of sync with
  what CI and the shipped app actually do. This rewires it to match.
- No shipped application behavior changes; this only affects internal test
  tooling. All journeys stay `#[ignore]`d — no journey bodies were written.

## What changed

- **Mechanism rewrite** (`crates/e2e-tests/tests/common/mod.rs`):
  `E2eApp::launch()` now spawns the `tauri-webdriver` CLI proxy and connects
  with real `tauri:options.application` capabilities pointing at the built
  `desktop_shell` binary, replacing the old code that spawned the abandoned
  `tauri-driver` binary directly and used `DesiredCapabilities::chrome()` as a
  placeholder.
- Dropped the post-connect `driver.goto(APP_URL)` — the app auto-loads its
  Tauri `devUrl` on launch. Fixed `APP_URL`'s stale port (`1420` → `5173`,
  matching `tauri.conf.json`'s `devUrl` and the port CI serves the preview
  build on).
- **Preflight**: `preflight()` now actually checks (a) the `tauri-webdriver`
  CLI is on `$PATH` and (b) the `desktop_shell` binary has been built
  (`ALM_E2E_APP_BIN` env var override supported) — each with a named,
  actionable error instead of failing later with an opaque WebDriver error.
  The obsolete per-OS `WebKitWebDriver`/`msedgedriver` checks are gone.
- **Naming fix**: renamed `__APP_E2E__` → `__ALM_E2E__` across the Rust harness
  (the actual invoke-bridge JS, plus all doc comments in `common/mod.rs`,
  `lib.rs`, `journeys.rs`, `smoke.rs`) and `README.md`. The frontend
  (`apps/desktop/src/main.tsx`) already assigns `window.__ALM_E2E__` —
  `__APP_E2E__` never existed anywhere in the frontend, so every `invoke()`
  call was unconditionally hitting the "bridge missing" branch. The frontend
  itself is untouched.

## e2e.yml ↔ harness mapping

| `.github/workflows/e2e.yml` step | Harness equivalent |
|---|---|
| `cargo install tauri-webdriver --locked` (one-time, puts CLI on `$PATH`) | `preflight()` verifies it's there; `spawn_tauri_webdriver()` runs it per session |
| `pnpm --filter @astro-plan/desktop build` with `VITE_E2E=1` | developer/CI precondition, documented in `README.md`/`quickstart.md` |
| `pnpm --filter @astro-plan/desktop preview --port 5173 &` | developer/CI precondition; `APP_URL` now correctly points at `:5173` |
| `cargo build -p desktop_shell --features e2e` | `preflight()` verifies the binary exists at the same default path (`target/debug/desktop_shell[.exe]`); `ALM_E2E_APP_BIN` overrides it |
| `cargo nextest run -p e2e_tests --profile e2e --no-tests=warn` | `E2eApp::launch()`: spawns `tauri-webdriver --port 4444 --native-port 4445`, then `WebDriver::new` with `tauri:options.application` capabilities (no `browserName`) |
| embedded plugin server on `127.0.0.1:4445` (`tauri_plugin_webdriver::init()` default) | `--native-port 4445` passed explicitly to `tauri-webdriver` |

## CLI-contract evidence (verified, not guessed)

- `docs.rs/tauri-webdriver` — confirms it's a CLI binary (repo
  `Choochmeque/tauri-webdriver`), flags `--port` (default `4444`),
  `--native-port` (default `4445`), `--native-host` (default `127.0.0.1`);
  installed via `cargo install tauri-webdriver --locked`.
- `github.com/Choochmeque/tauri-webdriver` README — confirms the app binary
  path is supplied via WebDriver New Session capabilities
  (`alwaysMatch.tauri:options.application`), not a CLI argument; no
  `browserName` in the example.
- `github.com/Choochmeque/tauri-plugin-webdriver` — confirms the embedded
  plugin's default port is `4445`/`127.0.0.1`.
- Local vendored source (`thirtyfour-0.37.1/src/web_driver.rs`,
  `.../common/capabilities/desiredcapabilities.rs`) — confirms `WebDriver::new`
  accepts any `Into<Capabilities>`, and `Capabilities::new()` gives a fully
  custom capability map — used instead of `DesiredCapabilities::chrome()`.
- Repo-internal: `specs/037-e2e-integration-testing/research.md` (decisions D9,
  D10) and `quickstart.md` already documented the target design (env var
  `ALM_E2E_APP_BIN`, the capability shape, "do NOT call `driver.goto(...)` in
  journeys") — this PR makes the harness actually match what those docs
  promised.

## e2e.yml changes needed

None. `.github/workflows/e2e.yml` already matches the target design; the
drift was entirely inside `crates/e2e-tests`, which this PR fixes.

## Verification

- `cargo test -p e2e_tests --no-run` — compiles clean.
- `cargo clippy -p e2e_tests --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean (workspace-wide).
- Journeys remain `#[ignore]`d; only stale doc comments in `journeys.rs`/
  `smoke.rs` were touched, no journey bodies were written.
- No TypeScript files changed; `just typecheck` unaffected.

## Test plan

- [ ] CI: `e2e.yml` 3-OS matrix stays green (`--no-tests=warn`, 0 run / N skipped)
- [ ] Reviewer: confirm the capability shape and CLI flags against the cited
      `tauri-webdriver`/`tauri-plugin-webdriver` docs
- [ ] Follow-up (out of scope here): un-ignore journeys once
      `search.global`/`sessions.*`/`calibration.masters.*` are de-stubbed

## Spec Context
- Spec: 037
- Branch: impl-037-harness-rewrite