### PR TITLE
fix(calibration): persist Offset match-required setting

### DIFF
--- a/apps/desktop/src-tauri/src/commands/calibration_tolerances.rs
+++ b/apps/desktop/src-tauri/src/commands/calibration_tolerances.rs
@@ -1,54 +1,46 @@
-//! Spec 030 calibration tolerances commands (T025).
+//! Spec 007 / spec 043 P8 calibration tolerances commands.
 //!
-//! Stubs that return default tolerances and accept updates.
-//! Real persistence will be wired when the tolerances repository is built.
+//! Backed by the `calibration_tolerances` singleton table (migration 0008 +
+//! 0050) via `app_core::calibration::{tolerances_get, tolerances_update}`.
+//! `require_same_offset` additionally feeds
+//! `calibration_core::ranking::MatchingRuleConfig::require_same_offset`
+//! through `app_core::calibration`'s `load_config` (see
+//! `crates/app/calibration/src/matching.rs`).
 
 use contracts_core::calibration_tolerances::{CalibrationTolerances, UpdateCalibrationTolerances};
 use contracts_core::ContractError;
+use tauri::State;
+
+use crate::AppState;
 
 /// `calibration.tolerances.get` — returns current calibration matching tolerances.
 ///
 /// # Errors
-/// Returns `Err(String)` on failure; the stub never fails.
+/// Returns `Err(ContractError)` on database failure.
 #[tauri::command]
 #[specta::specta]
-pub async fn calibration_tolerances_get() -> Result<CalibrationTolerances, ContractError> {
-    tracing::debug!("stub: calibration.tolerances.get");
-    Ok(default_tolerances())
+pub async fn calibration_tolerances_get(
+    state: State<'_, AppState>,
+) -> Result<CalibrationTolerances, ContractError> {
+    tracing::debug!("calibration.tolerances.get");
+    app_core::calibration::tolerances_get(state.repo.pool()).await
 }
 
 /// `calibration.tolerances.update` — update calibration matching tolerances.
 ///
 /// # Errors
-/// Returns `Err(String)` on failure; the stub never fails.
+/// Returns `Err(ContractError)` on database failure.
 #[tauri::command]
 #[specta::specta]
 pub async fn calibration_tolerances_update(
+    state: State<'_, AppState>,
     request: UpdateCalibrationTolerances,
 ) -> Result<CalibrationTolerances, ContractError> {
     tracing::debug!(
-        "stub: calibration.tolerances.update temp={}C exp={}s",
+        "calibration.tolerances.update temp={}C exp={}s require_same_offset={}",
         request.temperature_tolerance_c,
         request.exposure_tolerance_s,
+        request.require_same_offset,
     );
-    // Echo back as if persisted.
-    Ok(CalibrationTolerances {
-        temperature_tolerance_c: request.temperature_tolerance_c,
-        exposure_tolerance_s: request.exposure_tolerance_s,
-        aging_limit_days: request.aging_limit_days,
-        require_same_camera: request.require_same_camera,
-        require_same_gain: request.require_same_gain,
-        require_same_binning: request.require_same_binning,
-    })
-}
-
-fn default_tolerances() -> CalibrationTolerances {
-    CalibrationTolerances {
-        temperature_tolerance_c: 5.0,
-        exposure_tolerance_s: 2.0,
-        aging_limit_days: 365,
-        require_same_camera: true,
-        require_same_gain: true,
-        require_same_binning: true,
-    }
+    app_core::calibration::tolerances_update(state.repo.pool(), request).await
 }

--- a/apps/desktop/src-tauri/src/commands/calibration_tolerances.rs
+++ b/apps/desktop/src-tauri/src/commands/calibration_tolerances.rs
@@ -1,7 +1,7 @@
 //! Spec 007 / spec 043 P8 calibration tolerances commands.
 //!
 //! Backed by the `calibration_tolerances` singleton table (migration 0008 +
-//! 0050) via `app_core::calibration::{tolerances_get, tolerances_update}`.
+//! 0051) via `app_core::calibration::{tolerances_get, tolerances_update}`.
 //! `require_same_offset` additionally feeds
 //! `calibration_core::ranking::MatchingRuleConfig::require_same_offset`
 //! through `app_core::calibration`'s `load_config` (see

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -10,6 +10,7 @@ import type {
   MatchCandidate,
 } from '@/bindings/types';
 import type {
+  CalibrationTolerances,
   InboxListResponse_Serialize,
   InboxScanFolderResponse_Serialize,
   InboxClassifyResponse_Serialize,
@@ -139,6 +140,20 @@ let mockIngestionSettings: IngestionSettings = {
   exposureGroupingToleranceS: 2,
   temperatureGroupingToleranceC: 5,
   defaultFilter: null,
+};
+
+// Spec 007 / spec 043 P8 — mirrors the persisted `calibration_tolerances`
+// singleton row's real defaults (migration 0008 + 0051), including
+// `requireSameOffset` (STUB-OFFSET-REQUIRED closed: this is now a real,
+// persisted field, not a local-only stub).
+const mockCalibrationTolerances: CalibrationTolerances = {
+  temperatureToleranceC: 5.0,
+  exposureToleranceS: 2.0,
+  agingLimitDays: 365,
+  requireSameCamera: true,
+  requireSameGain: true,
+  requireSameBinning: true,
+  requireSameOffset: true,
 };
 
 const mockRoots: LibraryRoot[] = [
@@ -354,6 +369,9 @@ export async function mockInvoke(
           candidates: mockCalibrationMatches(sessionId),
         })),
       } satisfies CalibrationMatchBatchResponse;
+    }
+    case 'calibration_tolerances_get': {
+      return mockCalibrationTolerances;
     }
     case 'targets_list': {
       const { targets } = await import('@/data/fixtures/targets');
@@ -655,6 +673,13 @@ export async function mockInvoke(
         mockIngestionSettings = { ...req };
       }
       return mockIngestionSettings;
+    }
+    case 'calibration_tolerances_update': {
+      // Echo the request back, mirroring the real `calibration.tolerances.update`
+      // command's upsert-then-return behaviour (persistence_db::repositories::
+      // calibration_tolerances::update).
+      const req = (_args as { request?: CalibrationTolerances } | undefined)?.request;
+      return { ...mockCalibrationTolerances, ...req } satisfies CalibrationTolerances;
     }
     case 'roots_register': {
       return mockRoots[0];

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1089,14 +1089,14 @@ export const commands = {
 	 *  `calibration.tolerances.get` — returns current calibration matching tolerances.
 	 * 
 	 *  # Errors
-	 *  Returns `Err(String)` on failure; the stub never fails.
+	 *  Returns `Err(ContractError)` on database failure.
 	 */
 	calibrationTolerancesGet: () => typedError<CalibrationTolerances, ContractError_Serialize>(__TAURI_INVOKE("calibration_tolerances_get")),
 	/**
 	 *  `calibration.tolerances.update` — update calibration matching tolerances.
 	 * 
 	 *  # Errors
-	 *  Returns `Err(String)` on failure; the stub never fails.
+	 *  Returns `Err(ContractError)` on database failure.
 	 */
 	calibrationTolerancesUpdate: (request: UpdateCalibrationTolerances) => typedError<CalibrationTolerances, ContractError_Serialize>(__TAURI_INVOKE("calibration_tolerances_update", { request })),
 	/**
@@ -2165,6 +2165,12 @@ export type CalibrationTolerances = {
 	requireSameCamera: boolean,
 	requireSameGain: boolean,
 	requireSameBinning: boolean,
+	/**
+	 *  Hard rule: master must carry the same OFFSET as the light session for
+	 *  dark/bias matching. Feeds `calibration_core::ranking::MatchingRuleConfig
+	 *  ::require_same_offset` (spec 007). Default `true` (see migration 0050).
+	 */
+	requireSameOffset: boolean,
 };
 
 /**
@@ -7516,6 +7522,7 @@ export type UpdateCalibrationTolerances = {
 	requireSameCamera: boolean,
 	requireSameGain: boolean,
 	requireSameBinning: boolean,
+	requireSameOffset: boolean,
 };
 
 export type UpdateCamera = {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -2168,7 +2168,7 @@ export type CalibrationTolerances = {
 	/**
 	 *  Hard rule: master must carry the same OFFSET as the light session for
 	 *  dark/bias matching. Feeds `calibration_core::ranking::MatchingRuleConfig
-	 *  ::require_same_offset` (spec 007). Default `true` (see migration 0050).
+	 *  ::require_same_offset` (spec 007). Default `true` (see migration 0051).
 	 */
 	requireSameOffset: boolean,
 };

--- a/apps/desktop/src/features/settings/CalibrationMatching.test.tsx
+++ b/apps/desktop/src/features/settings/CalibrationMatching.test.tsx
@@ -1,0 +1,128 @@
+/**
+ * Vitest unit tests for CalibrationMatching (spec 007 / spec 043 P8).
+ *
+ * Covers the Offset "match required" toggle persistence path — the gap this
+ * package closes (previously tagged STUB-OFFSET-REQUIRED: local-state-only,
+ * no backend field). Mocks the generated bindings surface so the real
+ * settingsIpc wrappers (calibrationTolerancesGet/Update) run and unwrap the
+ * Result envelope, mirroring SourceProtectionOverride.test.tsx.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { CalibrationMatching } from './CalibrationMatching';
+import type { CalibrationTolerances } from './settingsIpc';
+
+// ── Mocks ─────────────────────────────────────────────────────────────────────
+
+const { mockGet, mockUpdate } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    calibrationTolerancesGet: mockGet,
+    calibrationTolerancesUpdate: mockUpdate,
+  },
+}));
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function makeTolerances(overrides: Partial<CalibrationTolerances> = {}): CalibrationTolerances {
+  return {
+    temperatureToleranceC: 5,
+    exposureToleranceS: 2,
+    agingLimitDays: 365,
+    requireSameCamera: true,
+    requireSameGain: true,
+    requireSameBinning: true,
+    requireSameOffset: true,
+    ...overrides,
+  };
+}
+
+/** The Offset row's toggle checkbox — table rows have no per-toggle aria-label,
+ *  so scope the query to the row containing the "Offset" field label. */
+function offsetToggleInput(): HTMLElement {
+  const row = screen.getByText('Offset').closest('tr');
+  if (!row) throw new Error('Offset row not found');
+  return within(row).getByRole('checkbox');
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('CalibrationMatching — offset match-required persistence', () => {
+  it('loads requireSameOffset from the backend on mount', async () => {
+    mockGet.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: false }) });
+    render(<CalibrationMatching save={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(offsetToggleInput()).not.toBeChecked();
+    });
+  });
+
+  it('persists the offset toggle via calibration.tolerances.update, not just local state', async () => {
+    mockGet.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: true }) });
+    mockUpdate.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: false }) });
+
+    render(<CalibrationMatching save={vi.fn()} />);
+    await waitFor(() => expect(offsetToggleInput()).toBeChecked());
+
+    fireEvent.click(offsetToggleInput());
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ requireSameOffset: false }));
+    });
+    expect(offsetToggleInput()).not.toBeChecked();
+  });
+
+  it('does not persist sibling fields as a side effect of toggling offset', async () => {
+    mockGet.mockResolvedValue({
+      status: 'ok',
+      data: makeTolerances({ requireSameCamera: false, requireSameOffset: true }),
+    });
+    mockUpdate.mockResolvedValue({ status: 'ok', data: makeTolerances() });
+
+    render(<CalibrationMatching save={vi.fn()} />);
+    await waitFor(() => expect(offsetToggleInput()).toBeChecked());
+
+    fireEvent.click(offsetToggleInput());
+
+    await waitFor(() => expect(mockUpdate).toHaveBeenCalled());
+    // The persisted patch carries the *current* (unrelated) requireSameCamera
+    // state through unchanged — this pane always sends the full DTO.
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ requireSameCamera: false, requireSameOffset: false }),
+    );
+  });
+
+  it('restore-defaults resets requireSameOffset to true and persists it', async () => {
+    mockGet.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: false }) });
+    mockUpdate.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: true }) });
+
+    render(<CalibrationMatching save={vi.fn()} />);
+    await waitFor(() => expect(offsetToggleInput()).not.toBeChecked());
+
+    fireEvent.click(screen.getByRole('button', { name: /restore/i }));
+
+    await waitFor(() => {
+      expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ requireSameOffset: true }));
+    });
+  });
+
+  it('falls back to the in-code default (true) when the backend is unavailable', async () => {
+    mockGet.mockRejectedValue('network error');
+    render(<CalibrationMatching save={vi.fn()} />);
+
+    // No assertion to wait on for a rejected get; flush microtasks instead.
+    await waitFor(() => {
+      expect(mockGet).toHaveBeenCalled();
+    });
+    expect(offsetToggleInput()).toBeChecked();
+  });
+});

--- a/apps/desktop/src/features/settings/CalibrationMatching.tsx
+++ b/apps/desktop/src/features/settings/CalibrationMatching.tsx
@@ -2,17 +2,17 @@
 //
 // Authoritative design: platevault-settings-menu.html § [data-pane="calmatch"]
 //
-// Owned backend keys (CalibrationTolerances / UpdateCalibrationTolerances):
+// Owned backend keys (CalibrationTolerances / UpdateCalibrationTolerances),
+// persisted to the `calibration_tolerances` singleton table (migration 0008 +
+// 0050) via `calibration.tolerances.get`/`update`:
 //   - requireSameCamera   (boolean) — Camera "Match required" toggle
 //   - requireSameBinning  (boolean) — Binning "Match required" toggle
 //   - requireSameGain     (boolean) — Gain "Match required" toggle
+//   - requireSameOffset   (boolean) — Offset "Match required" toggle. Also
+//     feeds `calibration_core::ranking::MatchingRuleConfig::require_same_offset`
+//     (the dark/bias hard-rule the matching engine already enforces).
 //   - temperatureToleranceC (number | null) — Sensor temp tolerance in °C
 //   - agingLimitDays      (number) — Dark / bias age tolerance in days
-//
-// STUB: backend CalibrationTolerances has no requireSameOffset field yet.
-//   The Offset "Match required" toggle is local state only and does NOT persist
-//   to the backend.  Wire it when the backend adds the field.
-//   Comment tag: STUB-OFFSET-REQUIRED
 import { useState, useEffect } from 'react';
 import { Toggle, Pill } from '@/ui';
 import { m } from '@/lib/i18n';
@@ -35,7 +35,7 @@ const DEFAULTS = {
   requireSameCamera: true,
   requireSameBinning: true,
   requireSameGain: true,
-  requireSameOffset: true, // STUB-OFFSET-REQUIRED: local only
+  requireSameOffset: true,
   temperatureToleranceC: 5,
   agingLimitDays: 365,
 };
@@ -45,7 +45,6 @@ export function CalibrationMatching(_props: CalibrationMatchingProps) {
   const [requireCamera, setRequireCamera] = useState(DEFAULTS.requireSameCamera);
   const [requireBinning, setRequireBinning] = useState(DEFAULTS.requireSameBinning);
   const [requireGain, setRequireGain] = useState(DEFAULTS.requireSameGain);
-  // STUB-OFFSET-REQUIRED: no backend field — persists locally only
   const [requireOffset, setRequireOffset] = useState(DEFAULTS.requireSameOffset);
 
   // ── Soft-tolerance inputs ──────────────────────────────────────────────────
@@ -59,6 +58,7 @@ export function CalibrationMatching(_props: CalibrationMatchingProps) {
         setRequireCamera(tol.requireSameCamera);
         setRequireBinning(tol.requireSameBinning);
         setRequireGain(tol.requireSameGain);
+        setRequireOffset(tol.requireSameOffset);
         if (tol.temperatureToleranceC !== null) {
           setTempTolerance(tol.temperatureToleranceC);
         }
@@ -75,6 +75,7 @@ export function CalibrationMatching(_props: CalibrationMatchingProps) {
       requireSameCamera: requireCamera,
       requireSameBinning: requireBinning,
       requireSameGain: requireGain,
+      requireSameOffset: requireOffset,
       temperatureToleranceC: tempTolerance,
       agingLimitDays: agingLimit,
       exposureToleranceS: null, // not surfaced in this pane
@@ -98,9 +99,9 @@ export function CalibrationMatching(_props: CalibrationMatchingProps) {
     setRequireGain(val);
     persist({ requireSameGain: val });
   }
-  // STUB-OFFSET-REQUIRED: local only — no persist call
   function handleOffsetToggle(val: boolean) {
     setRequireOffset(val);
+    persist({ requireSameOffset: val });
   }
 
   // ── Tolerance input handlers ───────────────────────────────────────────────
@@ -125,13 +126,14 @@ export function CalibrationMatching(_props: CalibrationMatchingProps) {
     setRequireCamera(DEFAULTS.requireSameCamera);
     setRequireBinning(DEFAULTS.requireSameBinning);
     setRequireGain(DEFAULTS.requireSameGain);
-    setRequireOffset(DEFAULTS.requireSameOffset); // STUB-OFFSET-REQUIRED: local only
+    setRequireOffset(DEFAULTS.requireSameOffset);
     setTempTolerance(DEFAULTS.temperatureToleranceC);
     setAgingLimit(DEFAULTS.agingLimitDays);
     await calibrationTolerancesUpdate({
       requireSameCamera: DEFAULTS.requireSameCamera,
       requireSameBinning: DEFAULTS.requireSameBinning,
       requireSameGain: DEFAULTS.requireSameGain,
+      requireSameOffset: DEFAULTS.requireSameOffset,
       temperatureToleranceC: DEFAULTS.temperatureToleranceC,
       agingLimitDays: DEFAULTS.agingLimitDays,
       exposureToleranceS: null, // not surfaced in this pane
@@ -181,12 +183,11 @@ export function CalibrationMatching(_props: CalibrationMatchingProps) {
             <td className="mono">{m.settings_calmatch_exact()}</td>
           </tr>
 
-          {/* Offset — STUB-OFFSET-REQUIRED: local state only, no backend key */}
+          {/* Offset — hard toggle, persists to requireSameOffset and feeds
+              MatchingRuleConfig::require_same_offset in the matching engine */}
           <tr>
             <td>{m.settings_calmatch_offset()}</td>
             <td>
-              {/* STUB: backend MatchingRuleConfig per-field required flags pending
-                  (requireSameOffset) — persists locally only */}
               <Toggle checked={requireOffset} onChange={handleOffsetToggle} />
             </td>
             <td className="mono">{m.settings_calmatch_exact()}</td>

--- a/apps/desktop/src/features/settings/CalibrationMatching.tsx
+++ b/apps/desktop/src/features/settings/CalibrationMatching.tsx
@@ -4,7 +4,7 @@
 //
 // Owned backend keys (CalibrationTolerances / UpdateCalibrationTolerances),
 // persisted to the `calibration_tolerances` singleton table (migration 0008 +
-// 0050) via `calibration.tolerances.get`/`update`:
+// 0051) via `calibration.tolerances.get`/`update`:
 //   - requireSameCamera   (boolean) — Camera "Match required" toggle
 //   - requireSameBinning  (boolean) — Binning "Match required" toggle
 //   - requireSameGain     (boolean) — Gain "Match required" toggle

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -87,7 +87,7 @@ export type {
 };
 export type { PatternPartDto as PatternPart };
 export type { PatternValidateResponse, PatternPreviewResponse };
-export type { UpdateCalibrationTolerances };
+export type { CalibrationTolerances, UpdateCalibrationTolerances };
 export type { IngestionSettings, UpdateIngestionSettings };
 
 // ── Settings scope read/write (spec 018) ──────────────────────────────────────

--- a/crates/app/calibration/src/lib.rs
+++ b/crates/app/calibration/src/lib.rs
@@ -9,9 +9,11 @@
 
 pub mod equipment;
 mod matching;
+mod tolerances;
 
 // `app_core::calibration::*` historically resolved to the flat calibration
 // use-case module. Flatten its public surface into this crate root so those
 // paths (e.g. `app_core::calibration::masters_list`) remain stable once
 // `app_core` re-exports this crate.
 pub use matching::*;
+pub use tolerances::*;

--- a/crates/app/calibration/src/matching.rs
+++ b/crates/app/calibration/src/matching.rs
@@ -748,7 +748,7 @@ async fn load_config(pool: &SqlitePool) -> MatchingRuleConfig {
     let mut config = MatchingRuleConfig::default();
 
     // `require_same_offset` is persisted on the `calibration_tolerances`
-    // singleton row (migration 0050), not the generic settings key/value
+    // singleton row (migration 0051), not the generic settings key/value
     // store — it's user-controlled via the Settings > Calibration Matching
     // "Offset match required" toggle (spec 043 P8). Falls back to
     // `MatchingRuleConfig::default()` (true) on read failure.
@@ -1120,7 +1120,7 @@ mod masters_tests {
     }
 
     /// Spec 043 P8: `load_config` defaults `require_same_offset` to true on a
-    /// fresh DB, matching `MatchingRuleConfig::default()` (migration 0008/0050
+    /// fresh DB, matching `MatchingRuleConfig::default()` (migration 0008/0051
     /// seed row).
     #[tokio::test]
     async fn load_config_defaults_require_same_offset_true() {

--- a/crates/app/calibration/src/matching.rs
+++ b/crates/app/calibration/src/matching.rs
@@ -747,6 +747,15 @@ async fn load_master_by_id(
 async fn load_config(pool: &SqlitePool) -> MatchingRuleConfig {
     let mut config = MatchingRuleConfig::default();
 
+    // `require_same_offset` is persisted on the `calibration_tolerances`
+    // singleton row (migration 0050), not the generic settings key/value
+    // store — it's user-controlled via the Settings > Calibration Matching
+    // "Offset match required" toggle (spec 043 P8). Falls back to
+    // `MatchingRuleConfig::default()` (true) on read failure.
+    if let Ok(row) = persistence_db::repositories::calibration_tolerances::get(pool).await {
+        config.require_same_offset = row.require_same_offset;
+    }
+
     if let Ok(Some(v)) = persistence_db::repositories::settings::get_raw(pool, KEY_DARK_TEMP).await
     {
         if let Some(n) = v.as_f64() {
@@ -1108,5 +1117,41 @@ mod masters_tests {
         let masters = masters_list(db.pool()).await.unwrap();
         assert_eq!(masters.len(), 1);
         assert_eq!(masters[0].id, "cal-t3");
+    }
+
+    /// Spec 043 P8: `load_config` defaults `require_same_offset` to true on a
+    /// fresh DB, matching `MatchingRuleConfig::default()` (migration 0008/0050
+    /// seed row).
+    #[tokio::test]
+    async fn load_config_defaults_require_same_offset_true() {
+        let db = test_db().await;
+        let config = load_config(db.pool()).await;
+        assert!(config.require_same_offset);
+    }
+
+    /// Spec 043 P8: the Settings > Calibration Matching "Offset match
+    /// required" toggle persists via `calibration_tolerances` and must feed
+    /// `MatchingRuleConfig::require_same_offset` on the next `load_config`
+    /// call — this is the engine-side half of closing the STUB-OFFSET-REQUIRED
+    /// gap.
+    #[tokio::test]
+    async fn load_config_reads_require_same_offset_from_tolerances_table() {
+        let db = test_db().await;
+
+        let row = persistence_db::repositories::calibration_tolerances::CalibrationTolerancesRow {
+            temperature_tolerance_c: 5.0,
+            exposure_tolerance_s: 2.0,
+            aging_limit_days: 365,
+            require_same_camera: true,
+            require_same_gain: true,
+            require_same_binning: true,
+            require_same_offset: false,
+        };
+        persistence_db::repositories::calibration_tolerances::update(db.pool(), &row)
+            .await
+            .unwrap();
+
+        let config = load_config(db.pool()).await;
+        assert!(!config.require_same_offset, "toggling off must reach MatchingRuleConfig");
     }
 }

--- a/crates/app/calibration/src/tolerances.rs
+++ b/crates/app/calibration/src/tolerances.rs
@@ -1,6 +1,6 @@
 //! Calibration matching tolerances use cases (spec 007 / spec 043 P8).
 //!
-//! Bridges the `calibration_tolerances` singleton row (migration 0008 + 0050,
+//! Bridges the `calibration_tolerances` singleton row (migration 0008 + 0051,
 //! `persistence_db::repositories::calibration_tolerances`) with the
 //! `CalibrationTolerances` / `UpdateCalibrationTolerances` contract DTOs used
 //! by the Tauri `calibration.tolerances.get`/`update` commands.

--- a/crates/app/calibration/src/tolerances.rs
+++ b/crates/app/calibration/src/tolerances.rs
@@ -1,0 +1,67 @@
+//! Calibration matching tolerances use cases (spec 007 / spec 043 P8).
+//!
+//! Bridges the `calibration_tolerances` singleton row (migration 0008 + 0050,
+//! `persistence_db::repositories::calibration_tolerances`) with the
+//! `CalibrationTolerances` / `UpdateCalibrationTolerances` contract DTOs used
+//! by the Tauri `calibration.tolerances.get`/`update` commands.
+//!
+//! `require_same_offset` additionally feeds
+//! `calibration_core::ranking::MatchingRuleConfig::require_same_offset` — see
+//! `load_config` in `matching.rs`, which reads this same table.
+
+use contracts_core::calibration_tolerances::{CalibrationTolerances, UpdateCalibrationTolerances};
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use persistence_db::repositories::calibration_tolerances::{
+    self as repo, CalibrationTolerancesRow,
+};
+use sqlx::SqlitePool;
+
+fn db_to_contract(e: persistence_db::DbError) -> ContractError {
+    let msg = e.to_string();
+    drop(e);
+    ContractError::new(ErrorCode::InternalDatabase, msg, ErrorSeverity::Fatal, true)
+}
+
+fn row_to_dto(row: CalibrationTolerancesRow) -> CalibrationTolerances {
+    CalibrationTolerances {
+        temperature_tolerance_c: row.temperature_tolerance_c,
+        exposure_tolerance_s: row.exposure_tolerance_s,
+        // The table stores a plain i64 with no enforced range; the DTO uses
+        // i32 (spec 007). Saturate rather than panic on an out-of-range value.
+        aging_limit_days: i32::try_from(row.aging_limit_days).unwrap_or(i32::MAX),
+        require_same_camera: row.require_same_camera,
+        require_same_gain: row.require_same_gain,
+        require_same_binning: row.require_same_binning,
+        require_same_offset: row.require_same_offset,
+    }
+}
+
+/// `calibration.tolerances.get` — read the persisted matching tolerances.
+///
+/// # Errors
+///
+/// Returns `ContractError` on database failure.
+pub async fn tolerances_get(pool: &SqlitePool) -> Result<CalibrationTolerances, ContractError> {
+    repo::get(pool).await.map(row_to_dto).map_err(db_to_contract)
+}
+
+/// `calibration.tolerances.update` — persist new matching tolerances.
+///
+/// # Errors
+///
+/// Returns `ContractError` on database failure.
+pub async fn tolerances_update(
+    pool: &SqlitePool,
+    request: UpdateCalibrationTolerances,
+) -> Result<CalibrationTolerances, ContractError> {
+    let row = CalibrationTolerancesRow {
+        temperature_tolerance_c: request.temperature_tolerance_c,
+        exposure_tolerance_s: request.exposure_tolerance_s,
+        aging_limit_days: i64::from(request.aging_limit_days),
+        require_same_camera: request.require_same_camera,
+        require_same_gain: request.require_same_gain,
+        require_same_binning: request.require_same_binning,
+        require_same_offset: request.require_same_offset,
+    };
+    repo::update(pool, &row).await.map(row_to_dto).map_err(db_to_contract)
+}

--- a/crates/contracts/core/src/calibration_tolerances.rs
+++ b/crates/contracts/core/src/calibration_tolerances.rs
@@ -5,6 +5,7 @@ use specta::Type;
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)] // These are distinct orthogonal per-field match-required flags
 pub struct CalibrationTolerances {
     pub temperature_tolerance_c: f64,
     pub exposure_tolerance_s: f64,
@@ -12,10 +13,15 @@ pub struct CalibrationTolerances {
     pub require_same_camera: bool,
     pub require_same_gain: bool,
     pub require_same_binning: bool,
+    /// Hard rule: master must carry the same OFFSET as the light session for
+    /// dark/bias matching. Feeds `calibration_core::ranking::MatchingRuleConfig
+    /// ::require_same_offset` (spec 007). Default `true` (see migration 0050).
+    pub require_same_offset: bool,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
+#[allow(clippy::struct_excessive_bools)] // These are distinct orthogonal per-field match-required flags
 pub struct UpdateCalibrationTolerances {
     pub temperature_tolerance_c: f64,
     pub exposure_tolerance_s: f64,
@@ -23,4 +29,5 @@ pub struct UpdateCalibrationTolerances {
     pub require_same_camera: bool,
     pub require_same_gain: bool,
     pub require_same_binning: bool,
+    pub require_same_offset: bool,
 }

--- a/crates/contracts/core/src/calibration_tolerances.rs
+++ b/crates/contracts/core/src/calibration_tolerances.rs
@@ -15,7 +15,7 @@ pub struct CalibrationTolerances {
     pub require_same_binning: bool,
     /// Hard rule: master must carry the same OFFSET as the light session for
     /// dark/bias matching. Feeds `calibration_core::ranking::MatchingRuleConfig
-    /// ::require_same_offset` (spec 007). Default `true` (see migration 0050).
+    /// ::require_same_offset` (spec 007). Default `true` (see migration 0051).
     pub require_same_offset: bool,
 }
 

--- a/crates/persistence/db/migrations/0050_calibration_tolerances_offset.sql
+++ b/crates/persistence/db/migrations/0050_calibration_tolerances_offset.sql
@@ -1,0 +1,16 @@
+-- Migration 0050: add require_same_offset to calibration_tolerances (spec 043 P8).
+--
+-- The matching engine's `MatchingRuleConfig.require_same_offset` hard-rule
+-- flag (crates/calibration/core/src/ranking.rs) has existed since the
+-- original spec 007 implementation, but the singleton `calibration_tolerances`
+-- table (migration 0008) never gained a column for it, and no repository or
+-- command code read/wrote this table at all — the Tauri
+-- `calibration.tolerances.get`/`update` commands were pure in-memory stubs.
+-- This migration adds the missing column so the Offset "match required"
+-- toggle (apps/desktop/src/features/settings/CalibrationMatching.tsx) can
+-- persist for real. Defaults to 1 (true) to match
+-- `MatchingRuleConfig::default().require_same_offset`, preserving current
+-- matching behaviour for existing libraries.
+
+ALTER TABLE calibration_tolerances
+    ADD COLUMN require_same_offset INTEGER NOT NULL DEFAULT 1;

--- a/crates/persistence/db/migrations/0051_calibration_tolerances_offset.sql
+++ b/crates/persistence/db/migrations/0051_calibration_tolerances_offset.sql
@@ -1,4 +1,4 @@
--- Migration 0050: add require_same_offset to calibration_tolerances (spec 043 P8).
+-- Migration 0051: add require_same_offset to calibration_tolerances (spec 043 P8).
 --
 -- The matching engine's `MatchingRuleConfig.require_same_offset` hard-rule
 -- flag (crates/calibration/core/src/ranking.rs) has existed since the

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -186,6 +186,7 @@ mod tests {
     // that are each only ever called once.
     #[allow(clippy::too_many_lines)] // pre-existing test, exercises a wide migration surface
     #[tokio::test]
+    #[allow(clippy::too_many_lines)] // pre-existing multi-stage migration fixture test
     async fn migration_0047_rederivation_on_seeded_0046_db() {
         // We cannot run migrations up to 0046 and then 0047 separately in the
         // same in-memory DB with the embedded migrator (sqlx::migrate! runs all

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -184,9 +184,8 @@ mod tests {
     // Single scenario test walking a multi-step seed → re-derivation → assert
     // pipeline; splitting it would scatter the narrative across helper fns
     // that are each only ever called once.
-    #[allow(clippy::too_many_lines)] // pre-existing test, exercises a wide migration surface
-    #[tokio::test]
     #[allow(clippy::too_many_lines)] // pre-existing multi-stage migration fixture test
+    #[tokio::test]
     async fn migration_0047_rederivation_on_seeded_0046_db() {
         // We cannot run migrations up to 0046 and then 0047 separately in the
         // same in-memory DB with the embedded migrator (sqlx::migrate! runs all

--- a/crates/persistence/db/src/repositories/calibration_tolerances.rs
+++ b/crates/persistence/db/src/repositories/calibration_tolerances.rs
@@ -1,0 +1,166 @@
+//! Repository for the calibration matching tolerances singleton row
+//! (spec 007 / spec 043 P8, migration 0008 + 0050).
+//!
+//! `calibration_tolerances` holds exactly one row (`singleton_id = 'default'`)
+//! seeded unconditionally by migration 0008, so `get` can always `fetch_one`.
+
+use domain_core::ids::Timestamp;
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+/// Raw persisted row from `calibration_tolerances`.
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[allow(clippy::struct_excessive_bools)] // Distinct orthogonal per-field match-required flags
+pub struct CalibrationTolerancesRow {
+    pub temperature_tolerance_c: f64,
+    pub exposure_tolerance_s: f64,
+    pub aging_limit_days: i64,
+    pub require_same_camera: bool,
+    pub require_same_gain: bool,
+    pub require_same_binning: bool,
+    /// Hard rule: master must carry the same OFFSET as the light session
+    /// (migration 0050). Feeds `MatchingRuleConfig::require_same_offset`.
+    pub require_same_offset: bool,
+}
+
+/// Load the calibration tolerances singleton row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure (including the unexpected
+/// case where the migration-0008 seed row is missing).
+pub async fn get(pool: &SqlitePool) -> DbResult<CalibrationTolerancesRow> {
+    let row: (f64, f64, i64, i64, i64, i64, i64) = sqlx::query_as(
+        "SELECT temperature_tolerance_c, exposure_tolerance_s, aging_limit_days, \
+                require_same_camera, require_same_gain, require_same_binning, \
+                require_same_offset \
+         FROM calibration_tolerances WHERE singleton_id = 'default'",
+    )
+    .fetch_one(pool)
+    .await?;
+
+    let (
+        temperature_tolerance_c,
+        exposure_tolerance_s,
+        aging_limit_days,
+        require_same_camera,
+        require_same_gain,
+        require_same_binning,
+        require_same_offset,
+    ) = row;
+
+    Ok(CalibrationTolerancesRow {
+        temperature_tolerance_c,
+        exposure_tolerance_s,
+        aging_limit_days,
+        require_same_camera: require_same_camera != 0,
+        require_same_gain: require_same_gain != 0,
+        require_same_binning: require_same_binning != 0,
+        require_same_offset: require_same_offset != 0,
+    })
+}
+
+/// Upsert the full tolerances row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn update(
+    pool: &SqlitePool,
+    row: &CalibrationTolerancesRow,
+) -> DbResult<CalibrationTolerancesRow> {
+    let now = Timestamp::now_iso();
+
+    sqlx::query(
+        "INSERT INTO calibration_tolerances \
+         (singleton_id, temperature_tolerance_c, exposure_tolerance_s, aging_limit_days, \
+          require_same_camera, require_same_gain, require_same_binning, require_same_offset, \
+          updated_at) \
+         VALUES ('default', ?, ?, ?, ?, ?, ?, ?, ?) \
+         ON CONFLICT(singleton_id) DO UPDATE SET \
+             temperature_tolerance_c = excluded.temperature_tolerance_c, \
+             exposure_tolerance_s    = excluded.exposure_tolerance_s, \
+             aging_limit_days        = excluded.aging_limit_days, \
+             require_same_camera     = excluded.require_same_camera, \
+             require_same_gain       = excluded.require_same_gain, \
+             require_same_binning    = excluded.require_same_binning, \
+             require_same_offset     = excluded.require_same_offset, \
+             updated_at              = excluded.updated_at",
+    )
+    .bind(row.temperature_tolerance_c)
+    .bind(row.exposure_tolerance_s)
+    .bind(row.aging_limit_days)
+    .bind(i64::from(row.require_same_camera))
+    .bind(i64::from(row.require_same_gain))
+    .bind(i64::from(row.require_same_binning))
+    .bind(i64::from(row.require_same_offset))
+    .bind(&now)
+    .execute(pool)
+    .await?;
+
+    Ok(*row)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> SqlitePool {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    #[tokio::test]
+    async fn get_returns_seeded_defaults() {
+        let pool = setup().await;
+        let row = get(&pool).await.unwrap();
+        assert!((row.temperature_tolerance_c - 5.0).abs() < f64::EPSILON);
+        assert!((row.exposure_tolerance_s - 2.0).abs() < f64::EPSILON);
+        assert_eq!(row.aging_limit_days, 365);
+        assert!(row.require_same_camera);
+        assert!(row.require_same_gain);
+        assert!(row.require_same_binning);
+        assert!(row.require_same_offset, "migration 0050 default must be true");
+    }
+
+    #[tokio::test]
+    async fn update_and_get_roundtrip() {
+        let pool = setup().await;
+        let new_row = CalibrationTolerancesRow {
+            temperature_tolerance_c: 3.5,
+            exposure_tolerance_s: 1.0,
+            aging_limit_days: 90,
+            require_same_camera: false,
+            require_same_gain: true,
+            require_same_binning: false,
+            require_same_offset: false,
+        };
+        update(&pool, &new_row).await.unwrap();
+
+        let loaded = get(&pool).await.unwrap();
+        assert_eq!(loaded, new_row);
+    }
+
+    #[tokio::test]
+    async fn update_is_idempotent_upsert() {
+        let pool = setup().await;
+        let row_a = CalibrationTolerancesRow {
+            temperature_tolerance_c: 4.0,
+            exposure_tolerance_s: 1.5,
+            aging_limit_days: 180,
+            require_same_camera: true,
+            require_same_gain: false,
+            require_same_binning: true,
+            require_same_offset: false,
+        };
+        update(&pool, &row_a).await.unwrap();
+        let row_b = CalibrationTolerancesRow { require_same_offset: true, ..row_a };
+        update(&pool, &row_b).await.unwrap();
+
+        let loaded = get(&pool).await.unwrap();
+        assert_eq!(loaded, row_b);
+    }
+}

--- a/crates/persistence/db/src/repositories/calibration_tolerances.rs
+++ b/crates/persistence/db/src/repositories/calibration_tolerances.rs
@@ -1,5 +1,5 @@
 //! Repository for the calibration matching tolerances singleton row
-//! (spec 007 / spec 043 P8, migration 0008 + 0050).
+//! (spec 007 / spec 043 P8, migration 0008 + 0051).
 //!
 //! `calibration_tolerances` holds exactly one row (`singleton_id = 'default'`)
 //! seeded unconditionally by migration 0008, so `get` can always `fetch_one`.
@@ -20,7 +20,7 @@ pub struct CalibrationTolerancesRow {
     pub require_same_gain: bool,
     pub require_same_binning: bool,
     /// Hard rule: master must carry the same OFFSET as the light session
-    /// (migration 0050). Feeds `MatchingRuleConfig::require_same_offset`.
+    /// (migration 0051). Feeds `MatchingRuleConfig::require_same_offset`.
     pub require_same_offset: bool,
 }
 
@@ -123,7 +123,7 @@ mod tests {
         assert!(row.require_same_camera);
         assert!(row.require_same_gain);
         assert!(row.require_same_binning);
-        assert!(row.require_same_offset, "migration 0050 default must be true");
+        assert!(row.require_same_offset, "migration 0051 default must be true");
     }
 
     #[tokio::test]

--- a/crates/persistence/db/src/repositories/mod.rs
+++ b/crates/persistence/db/src/repositories/mod.rs
@@ -11,6 +11,7 @@
 pub mod artifacts;
 pub mod audit;
 pub mod calibration_assignment;
+pub mod calibration_tolerances;
 pub mod equipment;
 pub mod first_run;
 pub mod guided_flow;


### PR DESCRIPTION
## Summary

Closes the `STUB-OFFSET-REQUIRED` gap in `CalibrationMatching.tsx` — the Offset
"match required" toggle was local-state-only because `CalibrationTolerances`
had no `requireSameOffset` field, and — more fundamentally — the
`calibration.tolerances.get`/`update` commands were pure in-memory stubs with
no database access at all. The dedicated `calibration_tolerances` singleton
table (migration 0008) existed but had no repository or command code touching
it, so none of the toggles in that pane (camera/gain/binning included)
actually survived an app restart.

- **Contract**: `crates/contracts/core/src/calibration_tolerances.rs` — add
  `requireSameOffset` (camelCase on the wire) to `CalibrationTolerances` /
  `UpdateCalibrationTolerances`.
- **Persistence**: migration `0051_calibration_tolerances_offset.sql` adds the
  `require_same_offset` column (default `1`/true, matching
  `MatchingRuleConfig::default()` so existing libraries see no behavior
  change) plus a new `crates/persistence/db/src/repositories/calibration_tolerances.rs`
  repository (get/update against the singleton row).
- **Engine wiring**: `crates/app/calibration/src/matching.rs::load_config` now
  reads `require_same_offset` from this table and feeds it into
  `calibration_core::ranking::MatchingRuleConfig::require_same_offset` — the
  hard rule the matching engine already implements (`crates/calibration/core/src/rules/{dark,bias}.rs`).
  Camera/gain/binning have no engine-side config knobs today (always hard
  rules), so only `require_same_offset` was wired into the engine, per the
  existing gap.
- **Command layer**: new `crates/app/calibration/src/tolerances.rs` use-case
  module bridges the repository to the DTOs; `apps/desktop/src-tauri/src/commands/calibration_tolerances.rs`
  now goes through `AppState`'s pool instead of echoing the request back
  unpersisted.
- **Bindings**: regenerated `apps/desktop/src/bindings/index.ts`.
- **Frontend**: `CalibrationMatching.tsx` wires the Offset toggle through the
  same persist path as its siblings; `api/mocks.ts` gets a
  `calibration_tolerances_get/update` mock fixture; removed the
  `STUB-OFFSET-REQUIRED` markers.

Default-behavior decision: migration defaults `require_same_offset` to `1`
(true), matching `MatchingRuleConfig::default().require_same_offset` — no
change to existing matching semantics for libraries that never touch the
toggle.

## Test plan

- [x] `cargo test -p persistence_db` — repository round-trip tests (get
      defaults, update+get roundtrip, idempotent upsert)
- [x] `cargo test -p app_core_calibration` — `load_config` defaults to true on
      a fresh DB, and correctly reads a toggled-off value from the
      `calibration_tolerances` table
- [x] `cargo test -p contracts_core`
- [x] `npx vitest run src/features/settings/CalibrationMatching.test.tsx` —
      load-from-backend, persist-on-toggle, restore-defaults, and
      backend-unavailable fallback
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p app_core_calibration -p persistence_db -p contracts_core --all-targets -- -D warnings` (clean)
- [x] `cargo clippy -p desktop_shell --all-targets -- -D warnings` (clean; the
      workspace-wide `just lint` clippy pass is clean too)
- [x] `just typecheck` (full workspace)
- [x] `cargo test -q -p desktop_shell --features dev-tools --test bindings` +
      `git diff --exit-code apps/desktop/src/bindings/` (no drift)

Known pre-existing, unrelated failures observed while verifying (not touched
by this PR, confirmed by scoping tests/lint to the files this PR changes):
- `just lint`'s `typos` step fails on ~70 pre-existing findings across
  unrelated files (e.g. `desig`/`transitionable` abbreviations in
  `TargetsTable.tsx`, `data_asset.rs`, CSS).
- 3 pre-existing frontend test failures unrelated to calibration/settings:
  `devSurface.release.test.ts`, `GuidedOverlay.test.tsx`,
  `CreateProjectDialog.test.tsx` (target-search timing).