### PR TITLE
fix(desktop): stop Windows Integration tests crashing on startup (STATUS_ENTRYPOINT_NOT_FOUND)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,12 +46,20 @@ jobs:
         with:
           components: rustfmt, clippy
 
-      # shared-key lets jobs on the same OS reuse one warm cache; cache-on-failure
-      # populates it even when a later step (test/clippy) fails.
+      # shared-key lets jobs on the same OS reuse one warm cache. cache-on-failure
+      # is intentionally left at its default (false): a cancelled or killed job
+      # (e.g. from this workflow's cancel-in-progress concurrency group) can leave
+      # a torn/partial target/ dir, and saving that on failure/cancellation poisons
+      # the shared cache for every subsequent PR that restores it. On Windows this
+      # previously manifested as a permanently-cached, half-linked
+      # `commands-*.exe` failing every run with STATUS_ENTRYPOINT_NOT_FOUND
+      # (0xc0000139) until the cache key below was bumped to escape it.
+      # If this key is ever bumped again to escape a similarly poisoned cache,
+      # also purge the stale `v0-rust-rust-windows-latest-*` entries via
+      # `gh cache list` / `gh cache delete` so open PRs stop restoring them.
       - uses: Swatinem/rust-cache@v2
         with:
-          shared-key: "rust-${{ matrix.os }}"
-          cache-on-failure: true
+          shared-key: "rust-${{ matrix.os }}-v2"
 
       - uses: pnpm/action-setup@v4
         with:

--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -1,3 +1,41 @@
 fn main() {
-    tauri_build::build();
+    // `mut` is only exercised by the `#[cfg(windows)]` block below.
+    #[allow(unused_mut)]
+    let mut attributes = tauri_build::Attributes::new();
+
+    // Windows-only workaround for a known upstream tauri-build/embed-resource
+    // limitation: `tauri_build::build()`'s default app-manifest embedding uses
+    // `rustc-link-arg-bins`, which only links the manifest into the crate's
+    // own [[bin]] target — never into `tests/*.rs` integration test binaries.
+    // Without the Common-Controls-v6 manifest, any test binary that touches
+    // `tauri::test::mock_builder()`/`mock_context()` (this crate's
+    // tests/commands.rs) crashes on startup on Windows with
+    // STATUS_ENTRYPOINT_NOT_FOUND (0xc0000139) before any test runs.
+    // See https://github.com/tauri-apps/tauri/issues/13419 and
+    // https://github.com/tauri-apps/tauri/issues/13954. Embedding the same
+    // manifest ourselves via `cargo:rustc-link-arg` (no `-bins` suffix) applies
+    // it to every linked artifact, including tests.
+    #[cfg(windows)]
+    {
+        attributes = attributes
+            .windows_attributes(tauri_build::WindowsAttributes::new_without_app_manifest());
+        add_windows_manifest();
+    }
+
+    tauri_build::try_build(attributes).expect("tauri_build::try_build failed");
+}
+
+#[cfg(windows)]
+fn add_windows_manifest() {
+    static WINDOWS_MANIFEST_FILE: &str = "windows-app-manifest.xml";
+
+    let manifest = std::env::current_dir().unwrap().join(WINDOWS_MANIFEST_FILE);
+
+    println!("cargo:rerun-if-changed={}", manifest.display());
+    // Embed the Windows application manifest file into every binary produced
+    // from this crate (bins, cdylib, and test executables alike).
+    println!("cargo:rustc-link-arg=/MANIFEST:EMBED");
+    println!("cargo:rustc-link-arg=/MANIFESTINPUT:{}", manifest.to_str().unwrap());
+    // Turn linker warnings (e.g. a malformed manifest) into hard errors.
+    println!("cargo:rustc-link-arg=/WX");
 }

--- a/apps/desktop/src-tauri/windows-app-manifest.xml
+++ b/apps/desktop/src-tauri/windows-app-manifest.xml
@@ -1,0 +1,14 @@
+<assembly xmlns="urn:schemas-microsoft-com:asm.v1" manifestVersion="1.0">
+  <dependency>
+    <dependentAssembly>
+      <assemblyIdentity
+        type="win32"
+        name="Microsoft.Windows.Common-Controls"
+        version="6.0.0.0"
+        processorArchitecture="*"
+        publicKeyToken="6595b64144ccf1df"
+        language="*"
+      />
+    </dependentAssembly>
+  </dependency>
+</assembly>


### PR DESCRIPTION
## Summary
- Windows `Integration (Layer 1)` has failed on essentially every PR since the CI workflow's first run (spec 037, 2026-06-19) — this is a long-standing, 100%-reproducible bug, not a flake or a recent regression. Confirmed by walking job history: every `windows-latest` Integration job that reached the test step has failed identically since day one.
- Root cause: `tauri_build::build()` embeds the app's Windows manifest (Common-Controls-v6 dependency) only into the crate's own `[[bin]]` target (via `embed-resource`'s `rustc-link-arg-bins`). Integration test binaries under `apps/desktop/src-tauri/tests/*.rs` never receive that manifest, so on Windows they crash on process startup with `STATUS_ENTRYPOINT_NOT_FOUND` (`0xc0000139`) before a single test runs. Reproduced for both `tests/commands.rs` (uses `tauri::test::mock_builder`) and, earlier in history, `tests/bindings.rs` (no `tauri::test` usage at all) — confirming it's the missing manifest, not a specific API.
- This is a known upstream `tauri-build` limitation: tauri-apps/tauri#13419, tauri-apps/tauri#13954.
- Fix: opt out of `tauri_build`'s default manifest embedding on Windows and embed the same manifest ourselves via `cargo:rustc-link-arg=/MANIFEST:EMBED` + `/MANIFESTINPUT`, which (unlike `-bins`) applies to every linked artifact from this crate, tests included. This is the community-vetted workaround from the upstream issue thread.
- Also included: a real (separate, but discovered while investigating) CI hygiene fix — `cache-on-failure: true` combined with this workflow's `cancel-in-progress` concurrency group could let a cancelled/killed job persist a torn `target/` dir into the shared Windows rust-cache. Disabled `cache-on-failure` and bumped the cache key. This did **not** turn out to be the actual root cause (proved by a from-scratch, "No cache found" build still failing identically) but is still worth keeping.

## Test plan
- [x] `cargo fmt --all --check`, `cargo build -p desktop_shell`, `cargo clippy -p desktop_shell --all-targets -- -D warnings` all green locally
- [ ] Windows `Integration (Layer 1)` job green on this PR
- [ ] Other jobs (Linux/macOS Integration, UI E2E, Real-UI E2E) unaffected