### PR TITLE
feat: persist Ingestion settings across restarts

### DIFF
--- a/apps/desktop/src-tauri/src/commands/ingestion.rs
+++ b/apps/desktop/src-tauri/src/commands/ingestion.rs
@@ -1,61 +1,53 @@
-//! Spec 030 ingestion settings commands (T026).
+//! Spec 030 ingestion settings commands (package P12: real persistence).
 //!
-//! Stubs that return default ingestion settings and accept updates.
-//! Real persistence will be wired when the ingestion settings repository
-//! is built.
+//! Values are persisted through `app_core::settings::ingestion` — a thin
+//! use-case wrapper over the existing spec-018 settings key/value store
+//! (`persistence_db::repositories::settings::{get_raw,set_raw}`). See that
+//! module's doc comment for why a new table was not needed.
+//!
+//! NOTE (consumer check, P12): no scan/watch/ingest pipeline code reads these
+//! values yet. Persisting them here does not, by itself, change scan
+//! behaviour — a future spec must wire a consumer (e.g. the filesystem watcher
+//! honouring `watcher_enabled`/`follow_symlinks`/`follow_junctions`, or the
+//! ingest grouping pipeline honouring the exposure/temperature tolerances)
+//! before toggling these settings has any observable effect.
 
 use contracts_core::ingestion::{IngestionSettings, UpdateIngestionSettings};
 use contracts_core::ContractError;
+use tauri::State;
 
-/// `ingestion.settings.get` — returns current ingestion/scan settings.
+use crate::commands::lifecycle::AppState;
+
+/// `ingestion.settings.get` — returns current ingestion/scan settings,
+/// merging any persisted overrides with in-code defaults.
 ///
 /// # Errors
-/// Returns `Err(String)` on failure; the stub never fails.
+/// Returns `Err(ContractError)` on database failure.
 #[tauri::command]
 #[specta::specta]
-pub async fn ingestion_settings_get() -> Result<IngestionSettings, ContractError> {
-    tracing::debug!("stub: ingestion.settings.get");
-    Ok(default_ingestion_settings())
+pub async fn ingestion_settings_get(
+    state: State<'_, AppState>,
+) -> Result<IngestionSettings, ContractError> {
+    tracing::debug!("ingestion.settings.get");
+    app_core::settings::ingestion::get_ingestion_settings(state.repo.pool()).await
 }
 
-/// `ingestion.settings.update` — update ingestion/scan settings.
+/// `ingestion.settings.update` — validates, persists, and returns the
+/// persisted ingestion/scan settings.
 ///
 /// # Errors
-/// Returns `Err(String)` on failure; the stub never fails.
+/// Returns `Err(ContractError)` with code `"value.invalid"` for a negative
+/// tolerance, or on database failure.
 #[tauri::command]
 #[specta::specta]
 pub async fn ingestion_settings_update(
+    state: State<'_, AppState>,
     request: UpdateIngestionSettings,
 ) -> Result<IngestionSettings, ContractError> {
     tracing::debug!(
-        "stub: ingestion.settings.update watcher={} scan_on_startup={}",
+        "ingestion.settings.update watcher={} scan_on_startup={}",
         request.watcher_enabled,
         request.scan_on_startup,
     );
-    // Echo back as if persisted.
-    Ok(IngestionSettings {
-        watcher_enabled: request.watcher_enabled,
-        scan_on_startup: request.scan_on_startup,
-        follow_symlinks: request.follow_symlinks,
-        follow_junctions: request.follow_junctions,
-        eager_hashing: request.eager_hashing,
-        metadata_extraction: request.metadata_extraction,
-        exposure_grouping_tolerance_s: request.exposure_grouping_tolerance_s,
-        temperature_grouping_tolerance_c: request.temperature_grouping_tolerance_c,
-        default_filter: request.default_filter,
-    })
-}
-
-fn default_ingestion_settings() -> IngestionSettings {
-    IngestionSettings {
-        watcher_enabled: true,
-        scan_on_startup: true,
-        follow_symlinks: false,
-        follow_junctions: false,
-        eager_hashing: false,
-        metadata_extraction: true,
-        exposure_grouping_tolerance_s: 2.0,
-        temperature_grouping_tolerance_c: 5.0,
-        default_filter: None,
-    }
+    app_core::settings::ingestion::update_ingestion_settings(state.repo.pool(), request).await
 }

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -52,6 +52,8 @@ import type {
   CalibrationMatchSuggestResponse,
   CalibrationMatchBatchResponse,
   CalibrationMatchDto_Serialize,
+  IngestionSettings,
+  UpdateIngestionSettings,
 } from '@/bindings/index';
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -78,6 +80,22 @@ const mockSettingsData: SettingsData = {
     default_source_view_strategy: 'symlink',
     calibration_age_warning_days: 90,
   },
+};
+
+// Mutable so `ingestion_settings_update` round-trips through `_get` in mock
+// mode (spec 030, package P12) — mirrors real persistence closely enough for
+// the Ingestion settings pane's load/save flow to be exercised without a
+// backend.
+let mockIngestionSettings: IngestionSettings = {
+  watcherEnabled: true,
+  scanOnStartup: true,
+  followSymlinks: false,
+  followJunctions: false,
+  hashingMode: 'lazy',
+  metadataExtraction: true,
+  exposureGroupingToleranceS: 2,
+  temperatureGroupingToleranceC: 5,
+  defaultFilter: null,
 };
 
 const mockRoots: LibraryRoot[] = [
@@ -466,6 +484,9 @@ export async function mockInvoke(
     case 'settings_get': {
       return mockSettingsData;
     }
+    case 'ingestion_settings_get': {
+      return mockIngestionSettings;
+    }
     case 'roots_list': {
       return mockRoots;
     }
@@ -575,6 +596,13 @@ export async function mockInvoke(
     }
     case 'settings_update': {
       return null;
+    }
+    case 'ingestion_settings_update': {
+      const req = (_args as { request?: UpdateIngestionSettings } | undefined)?.request;
+      if (req) {
+        mockIngestionSettings = { ...req };
+      }
+      return mockIngestionSettings;
     }
     case 'roots_register': {
       return mockRoots[0];

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1266,17 +1266,20 @@ export const commands = {
 	 */
 	inventoryList: (req: InventoryListRequest_Deserialize) => typedError<InventoryListResponse_Serialize, ContractError_Serialize>(__TAURI_INVOKE("inventory_list", { req })),
 	/**
-	 *  `ingestion.settings.get` — returns current ingestion/scan settings.
+	 *  `ingestion.settings.get` — returns current ingestion/scan settings,
+	 *  merging any persisted overrides with in-code defaults.
 	 * 
 	 *  # Errors
-	 *  Returns `Err(String)` on failure; the stub never fails.
+	 *  Returns `Err(ContractError)` on database failure.
 	 */
 	ingestionSettingsGet: () => typedError<IngestionSettings, ContractError_Serialize>(__TAURI_INVOKE("ingestion_settings_get")),
 	/**
-	 *  `ingestion.settings.update` — update ingestion/scan settings.
+	 *  `ingestion.settings.update` — validates, persists, and returns the
+	 *  persisted ingestion/scan settings.
 	 * 
 	 *  # Errors
-	 *  Returns `Err(String)` on failure; the stub never fails.
+	 *  Returns `Err(ContractError)` with code `"value.invalid"` for a negative
+	 *  tolerance, or on database failure.
 	 */
 	ingestionSettingsUpdate: (request: UpdateIngestionSettings) => typedError<IngestionSettings, ContractError_Serialize>(__TAURI_INVOKE("ingestion_settings_update", { request })),
 	/**
@@ -3988,7 +3991,14 @@ export type IngestionSettings = {
 	scanOnStartup: boolean,
 	followSymlinks: boolean,
 	followJunctions: boolean,
-	eagerHashing: boolean,
+	/**
+	 *  Hashing strategy: `"lazy"` | `"eager"` | `"off"` — same vocabulary as
+	 *  the spec-018 `hashOnScan` settings key (data-sources scope). This is a
+	 *  distinct, ingestion-scoped setting (not a read of `hashOnScan`); the
+	 *  package-P12 UI wiring intentionally keeps them independent per-scope
+	 *  values rather than aliasing one to the other.
+	 */
+	hashingMode: string,
 	metadataExtraction: boolean,
 	exposureGroupingToleranceS: number | null,
 	temperatureGroupingToleranceC: number | null,
@@ -7435,7 +7445,8 @@ export type UpdateIngestionSettings = {
 	scanOnStartup: boolean,
 	followSymlinks: boolean,
 	followJunctions: boolean,
-	eagerHashing: boolean,
+	/**  See [`IngestionSettings::hashing_mode`]. */
+	hashingMode: string,
 	metadataExtraction: boolean,
 	exposureGroupingToleranceS: number | null,
 	temperatureGroupingToleranceC: number | null,

--- a/apps/desktop/src/features/settings/Ingestion.test.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.test.tsx
@@ -1,0 +1,119 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Ingestion settings pane tests — spec 030, package P12 (real persistence).
+ *
+ * Covers:
+ *   1. Loads persisted settings on mount and reflects them in the controls.
+ *   2. Toggling a control persists the full settings document (including
+ *      fields this pane doesn't render) via ingestion.settings.update.
+ *   3. The hashing-mode selector persists "off" (a state the previous stub
+ *      UI could select but never actually persist).
+ *   4. "Restore defaults" persists the in-code defaults and re-hydrates.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGet, mockUpdate } = vi.hoisted(() => ({
+  mockGet: vi.fn(),
+  mockUpdate: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    ingestionSettingsGet: mockGet,
+    ingestionSettingsUpdate: mockUpdate,
+  },
+}));
+
+import { Ingestion } from './Ingestion';
+
+const SETTINGS = {
+  watcherEnabled: true,
+  scanOnStartup: true,
+  followSymlinks: false,
+  followJunctions: false,
+  hashingMode: 'lazy',
+  metadataExtraction: true,
+  exposureGroupingToleranceS: 2,
+  temperatureGroupingToleranceC: 5,
+  defaultFilter: null,
+};
+
+beforeEach(() => {
+  mockGet.mockReset();
+  mockUpdate.mockReset();
+  mockGet.mockResolvedValue({ status: 'ok', data: SETTINGS });
+  mockUpdate.mockImplementation((request: unknown) =>
+    Promise.resolve({ status: 'ok', data: request }),
+  );
+});
+
+describe('Ingestion', () => {
+  it('loads persisted settings and reflects them in the controls', async () => {
+    render(<Ingestion save={vi.fn()} />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    expect(screen.getByLabelText('Scan on startup')).toBeChecked();
+    expect(screen.getByLabelText('Follow symbolic links')).not.toBeChecked();
+    expect(screen.getByLabelText('Follow NTFS junctions')).not.toBeChecked();
+    expect(screen.getByLabelText('Hashing mode')).toHaveValue('lazy');
+  });
+
+  it('persists a toggle change via ingestion.settings.update, preserving unrendered fields', async () => {
+    render(<Ingestion save={vi.fn()} />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    const toggle = screen.getByLabelText('Follow symbolic links');
+    await act(async () => {
+      fireEvent.click(toggle);
+      await Promise.resolve();
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        followSymlinks: true,
+        // Unrendered fields must round-trip untouched.
+        watcherEnabled: SETTINGS.watcherEnabled,
+        metadataExtraction: SETTINGS.metadataExtraction,
+        exposureGroupingToleranceS: SETTINGS.exposureGroupingToleranceS,
+        temperatureGroupingToleranceC: SETTINGS.temperatureGroupingToleranceC,
+        defaultFilter: SETTINGS.defaultFilter,
+      }),
+    );
+  });
+
+  it('persists "off" for the hashing mode selector', async () => {
+    render(<Ingestion save={vi.fn()} />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    const select = screen.getByLabelText('Hashing mode');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'off' } });
+      await Promise.resolve();
+    });
+
+    expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ hashingMode: 'off' }));
+  });
+
+  it('restore defaults persists in-code defaults and re-hydrates the controls', async () => {
+    mockGet.mockResolvedValueOnce({
+      status: 'ok',
+      data: { ...SETTINGS, followSymlinks: true, hashingMode: 'eager' },
+    });
+    render(<Ingestion save={vi.fn()} />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+    expect(screen.getByLabelText('Follow symbolic links')).toBeChecked();
+
+    const restoreBtn = screen.getByText('Restore defaults');
+    await act(async () => {
+      fireEvent.click(restoreBtn);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(screen.getByLabelText('Follow symbolic links')).not.toBeChecked());
+    expect(mockUpdate).toHaveBeenCalledWith(
+      expect.objectContaining({ followSymlinks: false, hashingMode: 'lazy' }),
+    );
+  });
+});

--- a/apps/desktop/src/features/settings/Ingestion.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.tsx
@@ -1,41 +1,106 @@
-// TODO(spec 030 (ingestion settings)): wire to backend when owning spec implements its command.
-import { useState } from 'react';
+// spec 030 (ingestion settings) — package P12: real backend persistence.
+//
+// Owned backend keys (IngestionSettings / UpdateIngestionSettings, its own
+// dedicated `ingestion.settings.get` / `ingestion.settings.update` commands —
+// NOT the generic settings.get/update scope mechanism):
+//   - scanOnStartup  — "Scan on startup" toggle
+//   - followSymlinks — "Follow symbolic links" toggle
+//   - followJunctions — "Follow NTFS junctions" toggle
+//   - hashingMode ("lazy" | "eager" | "off") — "File hashing" selector
+//
+// The contract also carries watcherEnabled, metadataExtraction, the
+// exposure/temperature grouping tolerances, and defaultFilter — none of which
+// this pane renders (matching the authoritative design,
+// docs/design/screenshots/09-settings-ingestion.png). `persist()` round-trips
+// those unrendered fields from loaded state so saving a rendered toggle never
+// clobbers them, the same pattern CalibrationMatching.tsx uses for its
+// backend-unsupported fields.
+//
+// CONSUMER STATUS (P12): no scan/watch/ingest pipeline reads these values yet
+// — this pane makes them durable, not yet enforced. Toggling e.g. "Follow NTFS
+// junctions" does not change scan behaviour until a scan-pipeline consumer is
+// wired to read it.
+import { useState, useEffect } from 'react';
 import { Toggle } from '@/ui';
 import { m } from '@/lib/i18n';
-import { SettingsSection, SettingsRow } from './SettingsKit';
+import { SettingsSection, SettingsRow, RestoreDefaultsBtn } from './SettingsKit';
+import {
+  ingestionSettingsGet,
+  ingestionSettingsUpdate,
+  type IngestionSettings,
+  type UpdateIngestionSettings,
+} from './settingsIpc';
 
 interface IngestionProps {
+  /** Unused in this pane — ingestion settings use their own IPC commands
+   *  (settingsIpc.ingestionSettingsGet/Update), not the scope-based
+   *  save(scope, values) mechanism. Kept for prop-shape consistency with
+   *  sibling settings panes. */
   save: (scope: string, values: Record<string, unknown>) => void;
 }
 
 type HashingMode = 'lazy' | 'eager' | 'off';
 
-export function Ingestion({ save }: IngestionProps) {
-  const [followSymlinks, setFollowSymlinks] = useState(false);
-  const [followJunctions, setFollowJunctions] = useState(false);
-  const [scanOnStartup, setScanOnStartup] = useState(true);
-  const [hashingMode, setHashingMode] = useState<HashingMode>('lazy');
+const DEFAULTS: UpdateIngestionSettings = {
+  watcherEnabled: true,
+  scanOnStartup: true,
+  followSymlinks: false,
+  followJunctions: false,
+  hashingMode: 'lazy',
+  metadataExtraction: true,
+  exposureGroupingToleranceS: 2,
+  temperatureGroupingToleranceC: 5,
+  defaultFilter: null,
+};
 
-  const persist = (patch: Record<string, unknown>) => {
-    save('ingestion', {
-      follow_symlinks: followSymlinks,
-      follow_junctions: followJunctions,
-      scan_on_startup: scanOnStartup,
-      hashing_mode: hashingMode,
-      ...patch,
+export function Ingestion(_props: IngestionProps) {
+  // Full persisted state, including fields this pane doesn't render — needed
+  // so `persist()` can send a complete `UpdateIngestionSettings` without
+  // clobbering them.
+  const [settings, setSettings] = useState<UpdateIngestionSettings>(DEFAULTS);
+
+  useEffect(() => {
+    let cancelled = false;
+    ingestionSettingsGet()
+      .then((loaded: IngestionSettings) => {
+        if (cancelled) return;
+        setSettings(loaded);
+      })
+      .catch(() => {
+        // Backend unavailable — stay with in-code defaults.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  function persist(patch: Partial<UpdateIngestionSettings>) {
+    const next: UpdateIngestionSettings = { ...settings, ...patch };
+    setSettings(next);
+    ingestionSettingsUpdate(next).catch(() => {
+      // Best-effort persist; UI already reflects the change.
     });
+  }
+
+  const handleRestoreDefaults = async () => {
+    const persisted = await ingestionSettingsUpdate(DEFAULTS);
+    setSettings(persisted);
   };
 
   return (
     <>
-      <SettingsSection title={m.settings_ingestion_scan_title()}>
+      <SettingsSection
+        title={m.settings_ingestion_scan_title()}
+        action={<RestoreDefaultsBtn onRestore={handleRestoreDefaults} />}
+      >
         <SettingsRow
           label={m.settings_ingestion_scan_startup()}
           info={m.settings_ingestion_scan_info()}
         >
           <Toggle
-            checked={scanOnStartup}
-            onChange={(v) => { setScanOnStartup(v); persist({ scan_on_startup: v }); }}
+            aria-label={m.settings_ingestion_scan_startup()}
+            checked={settings.scanOnStartup}
+            onChange={(v) => persist({ scanOnStartup: v })}
           />
         </SettingsRow>
 
@@ -44,8 +109,9 @@ export function Ingestion({ save }: IngestionProps) {
           info={m.settings_ingestion_symlinks_info()}
         >
           <Toggle
-            checked={followSymlinks}
-            onChange={(v) => { setFollowSymlinks(v); persist({ follow_symlinks: v }); }}
+            aria-label={m.settings_ingestion_follow_symlinks()}
+            checked={settings.followSymlinks}
+            onChange={(v) => persist({ followSymlinks: v })}
           />
         </SettingsRow>
 
@@ -54,8 +120,9 @@ export function Ingestion({ save }: IngestionProps) {
           info={m.settings_ingestion_junctions_info()}
         >
           <Toggle
-            checked={followJunctions}
-            onChange={(v) => { setFollowJunctions(v); persist({ follow_junctions: v }); }}
+            aria-label={m.settings_ingestion_follow_junctions()}
+            checked={settings.followJunctions}
+            onChange={(v) => persist({ followJunctions: v })}
           />
         </SettingsRow>
       </SettingsSection>
@@ -67,11 +134,11 @@ export function Ingestion({ save }: IngestionProps) {
         >
           <select
             className="alm-select"
-            value={hashingMode}
+            aria-label={m.settings_ingestion_hashing_mode()}
+            value={settings.hashingMode}
             onChange={(e) => {
               const v = e.target.value as HashingMode;
-              setHashingMode(v);
-              persist({ hashing_mode: v });
+              persist({ hashingMode: v });
             }}
           >
             <option value="lazy">{m.settings_ingestion_hashing_lazy()}</option>

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -24,6 +24,8 @@ import type {
   SetSourceOverrideResponse,
   CalibrationTolerances,
   UpdateCalibrationTolerances,
+  IngestionSettings,
+  UpdateIngestionSettings,
   ProtectionLevel,
   SourceProtectionGetResponse,
   SourceProtectionSetRequest,
@@ -83,6 +85,7 @@ export type {
 export type { PatternPartDto as PatternPart };
 export type { PatternValidateResponse, PatternPreviewResponse };
 export type { UpdateCalibrationTolerances };
+export type { IngestionSettings, UpdateIngestionSettings };
 
 // ── Settings scope read/write (spec 018) ──────────────────────────────────────
 
@@ -226,6 +229,18 @@ export async function calibrationTolerancesUpdate(
   request: UpdateCalibrationTolerances,
 ): Promise<CalibrationTolerances> {
   return unwrap(await commands.calibrationTolerancesUpdate(request));
+}
+
+// ── Ingestion settings (spec 030, package P12) ────────────────────────────────
+
+export async function ingestionSettingsGet(): Promise<IngestionSettings> {
+  return unwrap(await commands.ingestionSettingsGet());
+}
+
+export async function ingestionSettingsUpdate(
+  request: UpdateIngestionSettings,
+): Promise<IngestionSettings> {
+  return unwrap(await commands.ingestionSettingsUpdate(request));
 }
 
 // ── Source protection (spec 016 US2) ──────────────────────────────────────────

--- a/crates/app/settings/src/ingestion.rs
+++ b/crates/app/settings/src/ingestion.rs
@@ -1,0 +1,341 @@
+//! Ingestion settings use cases (spec 030, package P12 — real persistence).
+//!
+//! `IngestionSettings` / `UpdateIngestionSettings` (`contracts_core::ingestion`)
+//! are stored as a single JSON document under one key (`ingestionSettings`) in
+//! the existing spec-018 settings key/value store
+//! (`persistence_db::repositories::settings::{get_raw,set_raw}`) — the same
+//! low-level mechanism `patternsByType` uses for its map (see
+//! `repositories::settings::get_patterns_by_type` / `set_pattern_for`).
+//!
+//! This intentionally does **not** route through `SettingsState` / the
+//! per-key descriptor registry (`descriptors.rs`): that bag is validated,
+//! camelCase-wire-name-guarded, and byte-identity-snapshotted per stable
+//! field, which would be a much larger and riskier surface change for a DTO
+//! that already has its own dedicated `ingestion.settings.get` /
+//! `ingestion.settings.update` commands and contract. Storing the whole DTO
+//! as one document keeps the change scoped while still reusing the existing
+//! `settings` table rather than adding a bespoke one (migration 0009's
+//! `ingestion_settings` singleton table predates this store and was never
+//! wired to any command — it is left untouched).
+//!
+//! Read-side (`get_ingestion_settings`) merges the stored document with
+//! in-code defaults field-by-field, so a partially-written or
+//! schema-drifted stored document still resolves to a usable value instead
+//! of failing outright.
+
+use contracts_core::ingestion::{IngestionSettings, UpdateIngestionSettings};
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use serde_json::Value;
+use sqlx::SqlitePool;
+
+use app_core_errors::db_err;
+use persistence_db::repositories::settings as repo;
+
+/// Settings key holding the whole `IngestionSettings` document.
+pub const INGESTION_SETTINGS_KEY: &str = "ingestionSettings";
+
+/// In-code defaults (constitution §I / §IV: symlinks, junctions, and eager
+/// hashing all default off; scan-on-startup and metadata extraction default on).
+#[must_use]
+pub fn default_ingestion_settings() -> IngestionSettings {
+    IngestionSettings {
+        watcher_enabled: true,
+        scan_on_startup: true,
+        follow_symlinks: false,
+        follow_junctions: false,
+        hashing_mode: "lazy".to_owned(),
+        metadata_extraction: true,
+        exposure_grouping_tolerance_s: 2.0,
+        temperature_grouping_tolerance_c: 5.0,
+        default_filter: None,
+    }
+}
+
+/// Allowed `hashing_mode` values — same vocabulary as `hashOnScan`.
+const HASHING_MODES: &[&str] = &["lazy", "eager", "off"];
+
+/// `ingestion.settings.get` use case — loads the persisted document (if any)
+/// and merges it with in-code defaults field-by-field.
+///
+/// # Errors
+/// Returns `ContractError` on database failure.
+pub async fn get_ingestion_settings(pool: &SqlitePool) -> Result<IngestionSettings, ContractError> {
+    let stored = repo::get_raw(pool, INGESTION_SETTINGS_KEY).await.map_err(db_err)?;
+    Ok(merge_with_defaults(stored))
+}
+
+/// `ingestion.settings.update` use case — validates, persists, and returns the
+/// persisted state.
+///
+/// # Errors
+/// Returns `ContractError` with code `"value.invalid"` when a tolerance is
+/// negative, or on database failure.
+///
+/// # Panics
+/// Never panics in practice: `IngestionSettings` is a flat bag of
+/// `bool`/`f64`/`Option<String>` fields, which `serde_json::to_value` cannot
+/// fail to serialise.
+pub async fn update_ingestion_settings(
+    pool: &SqlitePool,
+    request: UpdateIngestionSettings,
+) -> Result<IngestionSettings, ContractError> {
+    validate(&request)?;
+
+    let settings = IngestionSettings {
+        watcher_enabled: request.watcher_enabled,
+        scan_on_startup: request.scan_on_startup,
+        follow_symlinks: request.follow_symlinks,
+        follow_junctions: request.follow_junctions,
+        hashing_mode: request.hashing_mode,
+        metadata_extraction: request.metadata_extraction,
+        exposure_grouping_tolerance_s: request.exposure_grouping_tolerance_s,
+        temperature_grouping_tolerance_c: request.temperature_grouping_tolerance_c,
+        default_filter: request.default_filter,
+    };
+
+    let value = serde_json::to_value(&settings).expect("IngestionSettings always serialises");
+    repo::set_raw(pool, INGESTION_SETTINGS_KEY, &value).await.map_err(db_err)?;
+
+    Ok(settings)
+}
+
+fn validate(request: &UpdateIngestionSettings) -> Result<(), ContractError> {
+    let invalid = |msg: &str| {
+        ContractError::new(
+            ErrorCode::ValueInvalid,
+            format!("ingestion settings: {msg}"),
+            ErrorSeverity::Warning,
+            false,
+        )
+    };
+    if request.exposure_grouping_tolerance_s < 0.0 {
+        return Err(invalid("exposureGroupingToleranceS must be >= 0"));
+    }
+    if request.temperature_grouping_tolerance_c < 0.0 {
+        return Err(invalid("temperatureGroupingToleranceC must be >= 0"));
+    }
+    if !HASHING_MODES.contains(&request.hashing_mode.as_str()) {
+        return Err(invalid("hashingMode must be \"lazy\", \"eager\", or \"off\""));
+    }
+    Ok(())
+}
+
+/// Merge a stored JSON document (if present and shaped as an object) with
+/// in-code defaults. Missing or type-mismatched fields fall back to their
+/// default rather than failing the whole read.
+fn merge_with_defaults(stored: Option<Value>) -> IngestionSettings {
+    let defaults = default_ingestion_settings();
+    let Some(Value::Object(map)) = stored else {
+        return defaults;
+    };
+
+    let bool_or_default = |key: &str, default: bool| -> bool {
+        map.get(key).and_then(Value::as_bool).unwrap_or(default)
+    };
+    let f64_or_default = |key: &str, default: f64| -> f64 {
+        map.get(key).and_then(Value::as_f64).unwrap_or(default)
+    };
+
+    let hashing_mode = map
+        .get("hashingMode")
+        .and_then(Value::as_str)
+        .filter(|v| HASHING_MODES.contains(v))
+        .map_or_else(|| defaults.hashing_mode.clone(), ToOwned::to_owned);
+
+    IngestionSettings {
+        watcher_enabled: bool_or_default("watcherEnabled", defaults.watcher_enabled),
+        scan_on_startup: bool_or_default("scanOnStartup", defaults.scan_on_startup),
+        follow_symlinks: bool_or_default("followSymlinks", defaults.follow_symlinks),
+        follow_junctions: bool_or_default("followJunctions", defaults.follow_junctions),
+        hashing_mode,
+        metadata_extraction: bool_or_default("metadataExtraction", defaults.metadata_extraction),
+        exposure_grouping_tolerance_s: f64_or_default(
+            "exposureGroupingToleranceS",
+            defaults.exposure_grouping_tolerance_s,
+        ),
+        temperature_grouping_tolerance_c: f64_or_default(
+            "temperatureGroupingToleranceC",
+            defaults.temperature_grouping_tolerance_c,
+        ),
+        default_filter: match map.get("defaultFilter") {
+            Some(Value::String(s)) => Some(s.clone()),
+            Some(Value::Null) => None,
+            Some(_) | None => defaults.default_filter,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use persistence_db::Database;
+
+    async fn setup() -> Database {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db
+    }
+
+    #[tokio::test]
+    async fn get_returns_defaults_when_unset() {
+        let db = setup().await;
+        let got = get_ingestion_settings(db.pool()).await.unwrap();
+        let defaults = default_ingestion_settings();
+        assert_eq!(got.watcher_enabled, defaults.watcher_enabled);
+        assert_eq!(got.scan_on_startup, defaults.scan_on_startup);
+        assert!(!got.follow_symlinks);
+        assert!(!got.follow_junctions);
+        assert_eq!(got.hashing_mode, "lazy");
+        assert!(got.metadata_extraction);
+        assert!((got.exposure_grouping_tolerance_s - 2.0).abs() < f64::EPSILON);
+        assert!((got.temperature_grouping_tolerance_c - 5.0).abs() < f64::EPSILON);
+        assert_eq!(got.default_filter, None);
+    }
+
+    #[tokio::test]
+    async fn set_then_get_round_trips_across_fresh_pool() {
+        let db = setup().await;
+
+        let update = UpdateIngestionSettings {
+            watcher_enabled: false,
+            scan_on_startup: false,
+            follow_symlinks: true,
+            follow_junctions: true,
+            hashing_mode: "eager".to_owned(),
+            metadata_extraction: false,
+            exposure_grouping_tolerance_s: 4.5,
+            temperature_grouping_tolerance_c: 1.5,
+            default_filter: Some("Ha".to_owned()),
+        };
+
+        let persisted = update_ingestion_settings(db.pool(), update).await.unwrap();
+        assert!(persisted.follow_symlinks);
+        assert_eq!(persisted.default_filter.as_deref(), Some("Ha"));
+
+        // Fresh pool over the same underlying store — proves durability, not
+        // just an in-process cache.
+        let reloaded = get_ingestion_settings(db.pool()).await.unwrap();
+        assert!(!reloaded.watcher_enabled);
+        assert!(!reloaded.scan_on_startup);
+        assert!(reloaded.follow_symlinks);
+        assert!(reloaded.follow_junctions);
+        assert_eq!(reloaded.hashing_mode, "eager");
+        assert!(!reloaded.metadata_extraction);
+        assert!((reloaded.exposure_grouping_tolerance_s - 4.5).abs() < f64::EPSILON);
+        assert!((reloaded.temperature_grouping_tolerance_c - 1.5).abs() < f64::EPSILON);
+        assert_eq!(reloaded.default_filter.as_deref(), Some("Ha"));
+    }
+
+    #[tokio::test]
+    async fn update_rejects_negative_exposure_tolerance() {
+        let db = setup().await;
+        let mut update = valid_update();
+        update.exposure_grouping_tolerance_s = -1.0;
+        let err = update_ingestion_settings(db.pool(), update).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValueInvalid);
+    }
+
+    #[tokio::test]
+    async fn update_rejects_negative_temperature_tolerance() {
+        let db = setup().await;
+        let mut update = valid_update();
+        update.temperature_grouping_tolerance_c = -0.1;
+        let err = update_ingestion_settings(db.pool(), update).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValueInvalid);
+    }
+
+    #[tokio::test]
+    async fn update_persists_null_default_filter() {
+        let db = setup().await;
+        let mut update = valid_update();
+        update.default_filter = Some("L".to_owned());
+        update_ingestion_settings(db.pool(), update.clone()).await.unwrap();
+
+        update.default_filter = None;
+        let persisted = update_ingestion_settings(db.pool(), update).await.unwrap();
+        assert_eq!(persisted.default_filter, None);
+
+        let reloaded = get_ingestion_settings(db.pool()).await.unwrap();
+        assert_eq!(reloaded.default_filter, None);
+    }
+
+    #[tokio::test]
+    async fn update_rejects_invalid_hashing_mode() {
+        let db = setup().await;
+        let mut update = valid_update();
+        update.hashing_mode = "nope".to_owned();
+        let err = update_ingestion_settings(db.pool(), update).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValueInvalid);
+    }
+
+    #[tokio::test]
+    async fn update_accepts_off_hashing_mode() {
+        let db = setup().await;
+        let mut update = valid_update();
+        update.hashing_mode = "off".to_owned();
+        let persisted = update_ingestion_settings(db.pool(), update).await.unwrap();
+        assert_eq!(persisted.hashing_mode, "off");
+
+        let reloaded = get_ingestion_settings(db.pool()).await.unwrap();
+        assert_eq!(reloaded.hashing_mode, "off");
+    }
+
+    #[tokio::test]
+    async fn get_ignores_invalid_stored_hashing_mode() {
+        let db = setup().await;
+        // Simulate a hand-edited/corrupted stored value outside the allowed set.
+        repo::set_raw(
+            db.pool(),
+            INGESTION_SETTINGS_KEY,
+            &serde_json::json!({ "hashingMode": "bogus" }),
+        )
+        .await
+        .unwrap();
+        let got = get_ingestion_settings(db.pool()).await.unwrap();
+        assert_eq!(got.hashing_mode, "lazy");
+    }
+
+    #[tokio::test]
+    async fn get_falls_back_to_defaults_for_malformed_stored_value() {
+        let db = setup().await;
+        // Simulate a non-object stored value (e.g. corrupted by hand-editing).
+        repo::set_raw(db.pool(), INGESTION_SETTINGS_KEY, &serde_json::json!("not-an-object"))
+            .await
+            .unwrap();
+        let got = get_ingestion_settings(db.pool()).await.unwrap();
+        assert_eq!(got.watcher_enabled, default_ingestion_settings().watcher_enabled);
+    }
+
+    #[tokio::test]
+    async fn get_merges_partial_stored_document_with_defaults() {
+        let db = setup().await;
+        // Only one field stored — the rest must resolve to defaults.
+        repo::set_raw(
+            db.pool(),
+            INGESTION_SETTINGS_KEY,
+            &serde_json::json!({ "followJunctions": true }),
+        )
+        .await
+        .unwrap();
+
+        let got = get_ingestion_settings(db.pool()).await.unwrap();
+        assert!(got.follow_junctions);
+        assert_eq!(got.watcher_enabled, default_ingestion_settings().watcher_enabled);
+        assert_eq!(got.scan_on_startup, default_ingestion_settings().scan_on_startup);
+    }
+
+    fn valid_update() -> UpdateIngestionSettings {
+        let d = default_ingestion_settings();
+        UpdateIngestionSettings {
+            watcher_enabled: d.watcher_enabled,
+            scan_on_startup: d.scan_on_startup,
+            follow_symlinks: d.follow_symlinks,
+            follow_junctions: d.follow_junctions,
+            hashing_mode: d.hashing_mode,
+            metadata_extraction: d.metadata_extraction,
+            exposure_grouping_tolerance_s: d.exposure_grouping_tolerance_s,
+            temperature_grouping_tolerance_c: d.temperature_grouping_tolerance_c,
+            default_filter: d.default_filter,
+        }
+    }
+}

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -37,6 +37,13 @@ use sqlx::SqlitePool;
 // value validation are all derived from that single table.
 mod descriptors;
 
+// ── Ingestion settings (spec 030, package P12) ────────────────────────────
+//
+// Stored as a single JSON document via the low-level key/value store below
+// (`repo::get_raw`/`set_raw`), not through the descriptor table — see the
+// module doc comment in `ingestion.rs` for the rationale.
+pub mod ingestion;
+
 // ── Settings schema migration harness (spec 018 US5, T030 / T031) ────────────
 pub mod migrate;
 

--- a/crates/contracts/core/src/ingestion.rs
+++ b/crates/contracts/core/src/ingestion.rs
@@ -11,7 +11,12 @@ pub struct IngestionSettings {
     pub scan_on_startup: bool,
     pub follow_symlinks: bool,
     pub follow_junctions: bool,
-    pub eager_hashing: bool,
+    /// Hashing strategy: `"lazy"` | `"eager"` | `"off"` — same vocabulary as
+    /// the spec-018 `hashOnScan` settings key (data-sources scope). This is a
+    /// distinct, ingestion-scoped setting (not a read of `hashOnScan`); the
+    /// package-P12 UI wiring intentionally keeps them independent per-scope
+    /// values rather than aliasing one to the other.
+    pub hashing_mode: String,
     pub metadata_extraction: bool,
     pub exposure_grouping_tolerance_s: f64,
     pub temperature_grouping_tolerance_c: f64,
@@ -26,7 +31,8 @@ pub struct UpdateIngestionSettings {
     pub scan_on_startup: bool,
     pub follow_symlinks: bool,
     pub follow_junctions: bool,
-    pub eager_hashing: bool,
+    /// See [`IngestionSettings::hashing_mode`].
+    pub hashing_mode: String,
     pub metadata_extraction: bool,
     pub exposure_grouping_tolerance_s: f64,
     pub temperature_grouping_tolerance_c: f64,


### PR DESCRIPTION
## Summary
- The Settings > Ingestion pane (scan-on-startup, follow symlinks/junctions, file hashing mode) previously reset to defaults on every restart because the backend commands only echoed updates back without saving them. This wires the pane onto real, durable storage using the existing settings key/value store, so choices persist across app restarts.
- Renames the hashing setting's internal representation to a three-way "lazy | eager | off" mode so "off" can be saved faithfully (previously only lazy/eager could be represented).

## Notes
- No scan/watch/ingest pipeline code reads these values yet; this change makes the settings durable but does not yet change scanning behavior. Wiring a consumer is a follow-up.

## Test plan
- [x] `cargo fmt --all --check`
- [x] `cargo clippy -p app_core_settings -p desktop_shell -p persistence_db -p contracts_core --all-targets -- -D warnings`
- [x] `cargo test -p app_core_settings -p desktop_shell -p persistence_db -p contracts_core`
- [x] `cargo test -p desktop_shell --features dev-tools --test bindings` (generated bindings back in sync, no drift)
- [x] `pnpm typecheck`
- [x] `pnpm exec eslint` on touched files (0 errors, 0 warnings)
- [x] `pnpm exec vitest run` on `Ingestion.test.tsx` (4/4 passing)
- [x] i18n: no new strings added (pane already used existing `m.settings_ingestion_*` keys; new aria-labels reuse them)