### PR TITLE
feat: watch each project's own output folder for processing results

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -92,6 +92,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "workflow_artifacts",
  "workflow_profiles",
 ]
 
@@ -1294,6 +1295,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
+ "workflow_artifacts",
  "workflow_profiles",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }
 persistence_db = { path = "../../../crates/persistence/db" }
+workflow_artifacts = { path = "../../../crates/workflow/artifacts" }
 serde = { workspace = true }
 serde_json.workspace = true
 specta = { workspace = true }

--- a/apps/desktop/src-tauri/src/commands/artifacts.rs
+++ b/apps/desktop/src-tauri/src/commands/artifacts.rs
@@ -1,19 +1,23 @@
-//! Processing artifact Tauri commands (spec 012 TX01).
+//! Processing artifact Tauri commands (spec 012 TX01/T008).
 //!
 //! ## Commands
 //!
-//! - `artifact.list`           — list observed artifacts for a project, grouped by tool launch.
-//! - `artifact.classify`       — apply / clear a manual classification override.
-//! - `artifact.mark_resolved`  — mark a missing artifact as user-resolved.
+//! - `artifact.list`             — list observed artifacts for a project, grouped by tool launch.
+//! - `artifact.classify`         — apply / clear a manual classification override.
+//! - `artifact.mark_resolved`    — mark a missing artifact as user-resolved.
+//! - `artifact.watcher.attach`   — attach the live filesystem watcher for a project (T008).
+//! - `artifact.watcher.detach`   — detach it (project drawer close lifecycle, T008).
 
 use app_core::artifact;
 use contracts_core::tools::{
     ArtifactClassifyRequest, ArtifactClassifyResponse, ArtifactListRequest, ArtifactListResponse,
-    ArtifactMarkResolvedRequest,
+    ArtifactMarkResolvedRequest, ArtifactWatcherRequest,
 };
+use sqlx::SqlitePool;
 use tauri::State;
 
 use crate::commands::lifecycle::AppState;
+use crate::watcher::ArtifactWatcherRegistry;
 use contracts_core::ContractError;
 
 // ── artifact.list ─────────────────────────────────────────────────────────────
@@ -97,4 +101,49 @@ pub async fn artifact_mark_resolved(
     )
     .await
     .map_err(ContractError::internal)
+}
+
+// ── artifact.watcher.attach / artifact.watcher.detach ────────────────────────
+
+/// `artifact.watcher.attach` — attach the live filesystem watcher for a
+/// project's output folder (spec 012 T008: project drawer open lifecycle).
+///
+/// Idempotent: attaching an already-attached project is a no-op. Runs an
+/// on-attach reconciliation pass first so files written while detached are
+/// still detected.
+///
+/// # Errors
+/// Returns `Err(ContractError)` on DB failure or if the watcher cannot be
+/// started. An unavailable output folder (e.g. a removed drive) is NOT an
+/// error — attach succeeds and simply does not watch until a later retry.
+#[tauri::command]
+#[specta::specta]
+pub async fn artifact_watcher_attach(
+    pool: State<'_, SqlitePool>,
+    state: State<'_, AppState>,
+    registry: State<'_, ArtifactWatcherRegistry>,
+    request: ArtifactWatcherRequest,
+) -> Result<(), ContractError> {
+    tracing::debug!("artifact.watcher.attach project={}", request.project_id);
+    crate::watcher::attach_project_watcher(&pool, &state.bus, &registry, &request.project_id)
+        .await
+        .map_err(ContractError::internal)
+}
+
+/// `artifact.watcher.detach` — detach the live filesystem watcher for a
+/// project (spec 012 T008: project drawer close lifecycle).
+///
+/// Idempotent: detaching an unattached project is a silent no-op.
+///
+/// # Errors
+/// Never fails; the `Result` return type matches the shared command shape.
+#[tauri::command]
+#[specta::specta]
+pub async fn artifact_watcher_detach(
+    registry: State<'_, ArtifactWatcherRegistry>,
+    request: ArtifactWatcherRequest,
+) -> Result<(), ContractError> {
+    tracing::debug!("artifact.watcher.detach project={}", request.project_id);
+    crate::watcher::detach_project_watcher(&registry, &request.project_id).await;
+    Ok(())
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -15,7 +15,10 @@ use sqlx::SqlitePool;
 use tauri::Manager;
 use tauri_specta::{collect_commands, Builder};
 
-use crate::commands::artifacts::{artifact_classify, artifact_list, artifact_mark_resolved};
+use crate::commands::artifacts::{
+    artifact_classify, artifact_list, artifact_mark_resolved, artifact_watcher_attach,
+    artifact_watcher_detach,
+};
 use crate::commands::audit::{audit_export, audit_list};
 use crate::commands::calibration::{
     calibration_masters_get, calibration_masters_list, calibration_match_assign,
@@ -337,6 +340,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         artifact_list,
         artifact_classify,
         artifact_mark_resolved,
+        artifact_watcher_attach,
+        artifact_watcher_detach,
         // manifests + notes (spec 024)
         manifest_list,
         manifest_get,
@@ -537,6 +542,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         artifact_list,
         artifact_classify,
         artifact_mark_resolved,
+        artifact_watcher_attach,
+        artifact_watcher_detach,
         // manifests + notes (spec 024)
         manifest_list,
         manifest_get,
@@ -707,8 +714,11 @@ pub fn run_app(app: tauri::App, pool: SqlitePool) {
     // spec 024: manifest auto-generation on workflow-run completion.
     // The JoinHandle is intentionally dropped — the task runs independently.
     drop(app_core::project_manifests::spawn_workflow_run_subscriber(pool.clone(), bus.clone()));
-    // spec 012: artifact filesystem watcher → artifact.detected + artifact.classified events.
-    crate::watcher::spawn_artifact_watcher(pool.clone(), bus.clone());
+    // spec 012 T008: per-project artifact filesystem watchers, attached/detached
+    // via the `artifact.watcher.attach`/`artifact.watcher.detach` commands as the
+    // project drawer opens/closes. No watcher runs until a project is attached.
+    let artifact_watcher_registry = crate::watcher::new_artifact_watcher_registry();
+    app.manage(artifact_watcher_registry);
 
     // spec 018 T020: emit a settings.snapshot at session start, then every 5 minutes.
     // This gives the audit log a durable record of the active configuration even when

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -6,14 +6,20 @@
 //! `stop_watcher` shuts the watcher down and the forwarding task exits on the
 //! next loop iteration when the broadcast channel is closed.
 
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::sync::Arc;
+
 use camino::Utf8PathBuf;
 
 use audit::bus::EventBus;
-use fs_inventory::artifact_watcher::{start_artifact_watcher, ArtifactEventKind};
+use fs_inventory::artifact_watcher::{start_artifact_watcher, ArtifactEventKind, WatcherGuard};
 use fs_inventory::watcher::{InboxFileEvent, SharedWatcherService};
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter};
-use time::OffsetDateTime;
+use time::{format_description::well_known::Rfc3339, OffsetDateTime};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
 
 /// Start watching the given inbox paths and forward events to the Tauri webview.
 ///
@@ -74,89 +80,251 @@ pub async fn stop_watcher(watcher_service: SharedWatcherService) {
     svc.stop();
 }
 
-// ── Artifact watcher (spec 012, FR-009, spec 033 T028) ────────────────────────
+// ── Artifact watcher (spec 012, FR-009, T008) ──────────────────────────────────
+//
+// One OS watcher per *active* project, attached when the project drawer opens
+// and detached when it closes (plan.md §Sequencing: "One watcher per active
+// project... This bounds the number of OS watchers, which is a scarce
+// resource on macOS and Windows"). A global always-on watcher over every
+// registered library root was tried first and dropped: it never bounded the
+// OS-watcher count, watched entire drives recursively regardless of whether
+// any project was open, and stamped the *library root* id onto
+// `ProcessingArtifact.project_id` (never the real project). Re-attaching runs
+// an on-attach reconciliation pass first (T005's `reconcile`) so files written
+// while detached are still picked up (spec 012 edge case).
 
-/// Spawn the artifact watcher loop.
+/// A single project's live watcher + its event-forwarding task.
+pub struct ArtifactWatcherEntry {
+    /// Kept alive only to hold the OS watcher open; dropping it stops watching
+    /// and closes the event channel, which ends `forward_task`.
+    _guard: WatcherGuard,
+    forward_task: JoinHandle<()>,
+}
+
+/// Registry of per-project artifact watchers, keyed by `project_id`.
 ///
-/// 1. Loads all registered library-root paths from the DB.
-/// 2. Starts the debounced watcher over those paths.
-/// 3. For each `Created` / `Modified` event: calls `artifact::detect` → emits
-///    both `artifact.detected` (existing) and `artifact.classified` (new, T028).
+/// Managed as Tauri state so `artifact_watcher_attach`/`artifact_watcher_detach`
+/// commands can look up and mutate it.
+pub type ArtifactWatcherRegistry = Arc<Mutex<HashMap<String, ArtifactWatcherEntry>>>;
+
+/// Construct an empty registry (call once at app startup and `app.manage()` it).
+#[must_use]
+pub fn new_artifact_watcher_registry() -> ArtifactWatcherRegistry {
+    Arc::new(Mutex::new(HashMap::new()))
+}
+
+/// Derive the stable `[a-z][a-z0-9_]*` tool id from a project's display `tool`
+/// field (data-model.md §`WorkflowBinding` resolution rule). Mirrors the
+/// frontend's `toolIdFromProjectTool` in `features/projects/tool-launch.ts`:
+/// `"PixInsight"` → `"pixinsight"`, `"Planetary Suite"` → `"planetary_suite"`.
+fn tool_id_from_project_tool(project_tool: &str) -> String {
+    project_tool.to_lowercase().split_whitespace().collect::<Vec<_>>().join("_")
+}
+
+/// Non-recursive directory listing of real files only.
 ///
-/// Runs as a fire-and-forget tokio task.  Errors loading roots or starting the
-/// watcher are logged and the task exits cleanly without panicking.
-pub fn spawn_artifact_watcher(pool: SqlitePool, bus: EventBus) {
-    tokio::spawn(async move {
-        // Load all registered library roots.
-        let roots = match persistence_db::repositories::inventory::list_all_roots(&pool).await {
-            Ok(r) => r,
-            Err(e) => {
-                tracing::warn!("artifact watcher: could not load library roots: {e}");
-                return;
-            }
-        };
-
-        // DB `current_path` is a `String` (UTF-8 by construction); building a
-        // `Utf8PathBuf` is lossless. DB representation is unchanged.
-        let paths: Vec<Utf8PathBuf> = roots
-            .iter()
-            .map(|r| Utf8PathBuf::from(&r.current_path))
-            .filter(|p| p.exists())
-            .collect();
-
-        if paths.is_empty() {
-            tracing::debug!("artifact watcher: no registered library roots found; not watching");
-            return;
+/// Constitution: never follows symlinks (no per-root opt-in exists for
+/// project output folders in v1), and never recurses (matches the
+/// single-level contract `workflow_artifacts::reconciler::reconcile` already
+/// exercises in its unit tests).
+fn real_read_dir(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let entries =
+        std::fs::read_dir(dir).map_err(|e| format!("read_dir({}) failed: {e}", dir.display()))?;
+    let mut out = Vec::new();
+    for entry in entries.flatten() {
+        let Ok(file_type) = entry.file_type() else { continue };
+        if file_type.is_symlink() || !file_type.is_file() {
+            continue;
         }
+        out.push(entry.path());
+    }
+    Ok(out)
+}
 
-        let (mut rx, _guard) = match start_artifact_watcher(&paths, 256) {
-            Ok(pair) => pair,
-            Err(e) => {
-                tracing::warn!("artifact watcher: failed to start: {e}");
-                return;
+/// Real (size, mtime) probe. Uses `symlink_metadata` and rejects symlinks
+/// explicitly — belt-and-suspenders alongside `real_read_dir`'s filter.
+fn real_metadata(path: &Path) -> Option<(u64, std::time::SystemTime)> {
+    let meta = std::fs::symlink_metadata(path).ok()?;
+    if meta.file_type().is_symlink() {
+        return None;
+    }
+    let modified = meta.modified().ok()?;
+    Some((meta.len(), modified))
+}
+
+/// Run the on-attach reconciliation pass (T005): scan `project_root`,
+/// transition DB rows that are `Gone`/`Seen`, and `detect` any `new_files`.
+///
+/// Split out of [`attach_project_watcher`] to keep that function's line count
+/// within the workspace lint budget; it has no independent lifecycle of its
+/// own (always called immediately before the live watcher starts).
+async fn run_attach_reconciliation(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+    project_root: &Path,
+    tool_id: &str,
+    ext_refs: &[&str],
+) -> Result<(), String> {
+    let known_rows = persistence_db::repositories::artifacts::list_artifacts_for_project(
+        pool,
+        project_id,
+        &["present"],
+    )
+    .await
+    .map_err(|e| format!("{e}"))?;
+    let known_paths: Vec<String> = known_rows.iter().map(|r| r.path.clone()).collect();
+
+    let report = workflow_artifacts::reconcile(
+        project_root,
+        &known_paths,
+        ext_refs,
+        &real_read_dir,
+        &real_metadata,
+    )
+    .map_err(|e| format!("reconcile failed: {e}"))?;
+
+    for (rel_path, outcome) in report.existing {
+        let Some(row) = known_rows.iter().find(|r| r.path == rel_path) else { continue };
+        match outcome {
+            workflow_artifacts::ReconcileOutcome::Gone => {
+                if let Err(e) =
+                    app_core::artifact::mark_missing(pool, bus, project_id, &row.id, &row.path)
+                        .await
+                {
+                    tracing::warn!("artifact watcher: mark_missing failed for {}: {e}", row.path);
+                }
             }
-        };
+            workflow_artifacts::ReconcileOutcome::Seen => {
+                if let Err(e) =
+                    persistence_db::repositories::artifacts::touch_artifact(pool, &row.id).await
+                {
+                    tracing::warn!("artifact watcher: touch_artifact failed for {}: {e}", row.path);
+                }
+            }
+        }
+    }
 
-        tracing::info!("artifact watcher: watching {} root(s)", roots.len());
+    for new_file in report.new_files {
+        let path_str = new_file.absolute_path.to_string_lossy().into_owned();
+        let detected_at = OffsetDateTime::from(new_file.file_mtime)
+            .format(&Rfc3339)
+            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+        let size_bytes = i64::try_from(new_file.size_bytes).unwrap_or(i64::MAX);
+        if let Err(e) = app_core::artifact::detect(
+            pool,
+            bus,
+            project_id,
+            &path_str,
+            tool_id,
+            size_bytes,
+            &detected_at,
+            &detected_at,
+        )
+        .await
+        {
+            tracing::warn!("artifact watcher: reconcile detect failed for {path_str}: {e}");
+        }
+    }
 
+    Ok(())
+}
+
+/// Attach a live filesystem watcher for `project_id`'s output folder
+/// (currently `Project.path`; source-view folders are out of scope, see
+/// `tool_launch::launch`'s identical v1 simplification).
+///
+/// Idempotent: attaching an already-attached project is a no-op (guards
+/// against duplicate mount effects, e.g. React `StrictMode`).
+///
+/// Runs an on-attach reconciliation pass (T005) before starting the live
+/// watcher so files written while detached are still detected, then emits
+/// `artifact.detected`/`artifact.missing` for the reconciliation results
+/// exactly as the live watcher would.
+///
+/// # Errors
+/// Returns `Err(String)` if the project cannot be loaded or the watcher
+/// cannot be started. An unavailable output folder (e.g. a removed external
+/// drive) is NOT an error — it logs and returns `Ok(())` so the caller can
+/// retry later (spec 012 edge case).
+pub async fn attach_project_watcher(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    registry: &ArtifactWatcherRegistry,
+    project_id: &str,
+) -> Result<(), String> {
+    let mut reg = registry.lock().await;
+    if reg.contains_key(project_id) {
+        return Ok(());
+    }
+
+    let project = persistence_db::repositories::projects::get_project(pool, project_id)
+        .await
+        .map_err(|e| format!("{e}"))?;
+
+    let project_root = PathBuf::from(&project.path);
+    if !project_root.is_dir() {
+        tracing::warn!(
+            "artifact watcher: project {project_id} output folder unavailable: {}",
+            project.path
+        );
+        return Ok(());
+    }
+
+    let tool_id = tool_id_from_project_tool(&project.tool);
+    let extensions = app_core::tool_launch::read_watch_extensions(pool, &tool_id).await;
+    let ext_refs: Vec<&str> = extensions.iter().map(String::as_str).collect();
+
+    // ── On-attach reconciliation pass (T005) ───────────────────────────────
+    run_attach_reconciliation(pool, bus, project_id, &project_root, &tool_id, &ext_refs).await?;
+
+    // ── Start the live per-project watcher ─────────────────────────────────
+    let root_utf8 = Utf8PathBuf::from_path_buf(project_root)
+        .map_err(|_| format!("project path is not valid UTF-8: {}", project.path))?;
+
+    let (mut rx, guard) = start_artifact_watcher(std::slice::from_ref(&root_utf8), 256)
+        .map_err(|e| format!("failed to start artifact watcher: {e}"))?;
+
+    let task_pool = pool.clone();
+    let task_bus = bus.clone();
+    let task_project_id = project_id.to_owned();
+    let task_tool_id = tool_id.clone();
+    let task_extensions = extensions.clone();
+    let forward_task = tokio::spawn(async move {
         while let Some(evt) = rx.recv().await {
-            // Only handle create/modify — removals are handled by reconciliation.
+            // Only handle create/modify — removals are handled by the
+            // on-attach reconciliation pass, matching the existing T005 design.
             if evt.kind == ArtifactEventKind::Removed {
                 continue;
             }
 
-            // `evt.path` is `Utf8PathBuf` — a faithful UTF-8 string, no lossy step.
+            let file_name = evt.path.file_name().unwrap_or_default();
+            let ext_refs: Vec<&str> = task_extensions.iter().map(String::as_str).collect();
+            if !workflow_artifacts::extension_allowed(file_name, &ext_refs) {
+                continue;
+            }
+
             let path_str = evt.path.as_str().to_owned();
-
-            // Attempt to find which root this path belongs to (for project_id).
-            // For watcher events we derive project_id from the root that owns the
-            // path. The root id is used as the project_id key here because at the
-            // filesystem level we don't yet have the artifact-project mapping.
-            let project_id = roots
-                .iter()
-                .find(|r| evt.path.starts_with(&r.current_path))
-                .map_or_else(|| "unknown".to_owned(), |r| r.id.clone());
-
             let now = OffsetDateTime::now_utc()
-                .format(&time::format_description::well_known::Rfc3339)
+                .format(&Rfc3339)
                 .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
 
-            // Call detect — this emits both artifact.detected AND artifact.classified
-            // (spec 033 T028: the classified event is now emitted inside detect).
             match app_core::artifact::detect(
-                &pool,
-                &bus,
-                &project_id,
+                &task_pool,
+                &task_bus,
+                &task_project_id,
                 &path_str,
-                "filesystem",
-                0, // size unknown at watch time; reconciliation fills it
+                &task_tool_id,
+                0, // size unknown at watch time; the next reconciliation fills it
                 &now,
                 &now,
             )
             .await
             {
                 Ok(_) => {
-                    tracing::debug!("artifact watcher: detected {path_str}");
+                    tracing::debug!(
+                        "artifact watcher: detected {path_str} (project {task_project_id})"
+                    );
                 }
                 Err(e) => {
                     tracing::debug!("artifact watcher: detect failed for {path_str}: {e}");
@@ -164,6 +332,23 @@ pub fn spawn_artifact_watcher(pool: SqlitePool, bus: EventBus) {
             }
         }
 
-        tracing::debug!("artifact watcher: channel closed, exiting");
+        tracing::debug!("artifact watcher: channel closed for project {task_project_id}");
     });
+
+    tracing::info!("artifact watcher: attached for project {project_id} ({})", project.path);
+    reg.insert(project_id.to_owned(), ArtifactWatcherEntry { _guard: guard, forward_task });
+    Ok(())
+}
+
+/// Detach the live filesystem watcher for `project_id`, if attached.
+///
+/// Idempotent: detaching an unattached (or already-detached) project is a
+/// silent no-op.
+pub async fn detach_project_watcher(registry: &ArtifactWatcherRegistry, project_id: &str) {
+    let mut reg = registry.lock().await;
+    if let Some(entry) = reg.remove(project_id) {
+        entry.forward_task.abort();
+        // Dropping `_guard` here (end of scope) stops the OS watcher.
+        tracing::info!("artifact watcher: detached for project {project_id}");
+    }
 }

--- a/apps/desktop/src-tauri/tests/bindings.rs
+++ b/apps/desktop/src-tauri/tests/bindings.rs
@@ -254,6 +254,8 @@ fn exports_typescript_bindings() {
         "artifact_list",
         "artifact_classify",
         "artifact_mark_resolved",
+        "artifact_watcher_attach",
+        "artifact_watcher_detach",
         // manifests / notes / prepared views
         "manifest_list",
         "manifest_get",

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -888,6 +888,14 @@ export async function mockInvoke(
       return { planId: 'mock-plan-regen-001', unresolvedItemCount: 0 };
     }
 
+    // spec 012 T008: watcher attach/detach — no real filesystem watching in
+    // mock mode; the project drawer's mount/unmount effect still calls these,
+    // so they must resolve rather than throw "unknown mock command".
+    case 'artifact_watcher_attach':
+    case 'artifact_watcher_detach': {
+      return null;
+    }
+
     // ── Equipment CRUD (spec 030) ───────────────────────────────────────────
 
     case 'equipment_cameras_create': {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1323,6 +1323,30 @@ export const commands = {
 	 */
 	artifactMarkResolved: (request: ArtifactMarkResolvedRequest) => typedError<null, ContractError_Serialize>(__TAURI_INVOKE("artifact_mark_resolved", { request })),
 	/**
+	 *  `artifact.watcher.attach` — attach the live filesystem watcher for a
+	 *  project's output folder (spec 012 T008: project drawer open lifecycle).
+	 * 
+	 *  Idempotent: attaching an already-attached project is a no-op. Runs an
+	 *  on-attach reconciliation pass first so files written while detached are
+	 *  still detected.
+	 * 
+	 *  # Errors
+	 *  Returns `Err(ContractError)` on DB failure or if the watcher cannot be
+	 *  started. An unavailable output folder (e.g. a removed drive) is NOT an
+	 *  error — attach succeeds and simply does not watch until a later retry.
+	 */
+	artifactWatcherAttach: (request: ArtifactWatcherRequest) => typedError<null, ContractError_Serialize>(__TAURI_INVOKE("artifact_watcher_attach", { request })),
+	/**
+	 *  `artifact.watcher.detach` — detach the live filesystem watcher for a
+	 *  project (spec 012 T008: project drawer close lifecycle).
+	 * 
+	 *  Idempotent: detaching an unattached project is a silent no-op.
+	 * 
+	 *  # Errors
+	 *  Never fails; the `Result` return type matches the shared command shape.
+	 */
+	artifactWatcherDetach: (request: ArtifactWatcherRequest) => typedError<null, ContractError_Serialize>(__TAURI_INVOKE("artifact_watcher_detach", { request })),
+	/**
 	 *  `project.manifest.list` — list manifest snapshots for a project.
 	 * 
 	 *  Returns summaries ordered newest first, with cursor-based pagination.
@@ -1631,6 +1655,15 @@ export type ArtifactSummary = {
 	/**  `rule` | `manual_override` | `fallback` */
 	classificationSource: string,
 	sizeBytes: number,
+};
+
+/**
+ *  Request DTO for `artifact.watcher.attach` / `artifact.watcher.detach`
+ *  (spec 012 T008): wires the filesystem watcher to the project drawer
+ *  open/close lifecycle.
+ */
+export type ArtifactWatcherRequest = {
+	projectId: string,
 };
 
 export type AssetType = "file_record" | "acquisition_session" | "calibration_session" | "project" | "prepared_source" | "processing_artifact" | "filesystem_plan" | "data_source" | 
@@ -7263,6 +7296,12 @@ export type ToolProfileSummary = {
 	autoDetected: boolean,
 	/**  Current executable path (from Settings). `None` when not configured. */
 	executablePath: string | null,
+	/**
+	 *  Effective artifact-watch extension allow-list (spec 012 T007b): the
+	 *  per-tool Settings override when configured, else
+	 *  `workflow_artifacts::DEFAULT_WATCH_EXTENSIONS`.
+	 */
+	watchExtensions: string[],
 };
 
 /**  Tour completion state tracking. */
@@ -7401,6 +7440,12 @@ export type UpdateProcessingTool = {
 	id: string,
 	path: string | null,
 	enabled: boolean,
+	/**
+	 *  Custom artifact-watch extension allow-list (spec 012 T007b, R-ExtAllow).
+	 *  `None` leaves the existing setting (or default) unchanged. Entries MUST
+	 *  start with `.` (e.g. `.xisf`).
+	 */
+	watchExtensions?: string[] | null,
 };
 
 export type UpdateTelescope = {

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -59,6 +59,9 @@ import {
   useToolProfiles,
   useToolLaunch,
 } from './tool-launch';
+// spec 012 T008: filesystem artifact watcher, attached/detached with this
+// drawer's own mount lifecycle.
+import { useProjectArtifactWatcher } from './artifacts';
 import type { ProjectSourceDto_Deserialize } from '@/bindings/index';
 // Secondary sections (Notes, Manifests, Calibration, Source views, Outputs,
 // Cleanup) have moved to ProjectBottomDetail (task #104 — bottom panel).
@@ -147,6 +150,10 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
   const [editOpen, setEditOpen] = useState(false);
   const [channelWorking, setChannelWorking] = useState(false);
   const [transitionWorking, setTransitionWorking] = useState(false);
+
+  // spec 012 T008: attach the project's filesystem artifact watcher for as
+  // long as this drawer is open; detaches on close/project switch.
+  useProjectArtifactWatcher(projectId);
 
   // spec 011: tool launch (hooks must be called unconditionally)
   const projectToolStr = typeof project?.tool === 'string' ? project.tool : '';

--- a/apps/desktop/src/features/projects/artifacts.ts
+++ b/apps/desktop/src/features/projects/artifacts.ts
@@ -1,10 +1,13 @@
 /**
- * Artifact store helpers — spec 012 T020/T022/T023.
+ * Artifact store helpers — spec 012 T008/T020/T022/T023.
  *
  * Provides:
  * - `useArtifacts(projectId)` — reactive query over `artifact.list`.
  * - `useArtifactClassify()` — mutation hook wrapping `artifact.classify`.
  * - `useArtifactMarkResolved()` — mutation hook wrapping `artifact.mark_resolved`.
+ * - `useProjectArtifactWatcher(projectId)` — attaches the filesystem watcher on
+ *   mount and detaches it on unmount/projectId change (T008: project drawer
+ *   open/close lifecycle).
  * - `groupArtifactsByLaunch()` — pure grouping helper for the accordion (T023).
  */
 
@@ -18,6 +21,7 @@ import type {
   ArtifactClassifyRequest,
   ArtifactClassifyResponse,
   ArtifactMarkResolvedRequest,
+  ArtifactWatcherRequest,
 } from '@/bindings/index';
 import { errMessage } from '@/lib/errors';
 
@@ -36,6 +40,14 @@ async function artifactClassify(
 
 async function artifactMarkResolved(request: ArtifactMarkResolvedRequest): Promise<void> {
   unwrap(await commands.artifactMarkResolved(request));
+}
+
+async function artifactWatcherAttach(request: ArtifactWatcherRequest): Promise<void> {
+  unwrap(await commands.artifactWatcherAttach(request));
+}
+
+async function artifactWatcherDetach(request: ArtifactWatcherRequest): Promise<void> {
+  unwrap(await commands.artifactWatcherDetach(request));
 }
 
 // ── Grouping types ─────────────────────────────────────────────────────────────
@@ -153,6 +165,41 @@ export function useArtifacts(projectId: string): ArtifactsState {
   }, [projectId, tick]);
 
   return { artifacts, loading, error, reload };
+}
+
+// ── useProjectArtifactWatcher ─────────────────────────────────────────────────
+
+/**
+ * Attach the project's filesystem artifact watcher on mount, detach it on
+ * unmount or when `projectId` changes (spec 012 T008).
+ *
+ * This mirrors the project drawer's own mount lifecycle: `ProjectDetailContent`
+ * only exists while a project is selected, so the effect naturally fires once
+ * per drawer-open and cleans up on drawer-close/project-switch. Attach runs an
+ * on-attach reconciliation pass on the backend before starting the live watch,
+ * so files written while the drawer was closed are still detected.
+ *
+ * Best-effort: attach/detach failures are logged, not surfaced as UI errors —
+ * artifact observation is a background enhancement, not a blocking operation.
+ */
+export function useProjectArtifactWatcher(projectId: string): void {
+  useEffect(() => {
+    if (!projectId) return undefined;
+
+    let cancelled = false;
+    artifactWatcherAttach({ projectId }).catch((err: unknown) => {
+      if (!cancelled) {
+        console.warn('artifact watcher attach failed', errMessage(err));
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      artifactWatcherDetach({ projectId }).catch((err: unknown) => {
+        console.warn('artifact watcher detach failed', errMessage(err));
+      });
+    };
+  }, [projectId]);
 }
 
 // ── useArtifactClassify ────────────────────────────────────────────────────────

--- a/apps/desktop/src/features/projects/tool-launch.test.ts
+++ b/apps/desktop/src/features/projects/tool-launch.test.ts
@@ -74,6 +74,7 @@ function makeProfile(overrides: Partial<ToolProfileSummary> = {}): ToolProfileSu
     enabled: true,
     autoDetected: false,
     executablePath: '/usr/bin/pixinsight',
+    watchExtensions: ['.xisf', '.fits'],
     ...overrides,
   };
 }

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -26,6 +26,7 @@ fs_executor = { path = "../../fs/executor" }
 patterns = { path = "../../patterns" }
 persistence_db = { path = "../../persistence/db" }
 project_structure = { path = "../../project/structure" }
+workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
 camino = { workspace = true }
 dashmap = { workspace = true }

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -67,6 +67,28 @@ fn key_auto_detected(tool_id: &str) -> String {
     format!("tools.{tool_id}.auto_detected")
 }
 
+/// Settings key for `tools.<tool_id>.watch_extensions` (spec 012 T007b).
+fn key_watch_extensions(tool_id: &str) -> String {
+    format!("tools.{tool_id}.watch_extensions")
+}
+
+/// Read the configured artifact-watch extension allow-list for a tool
+/// (spec 012 T007b / R-ExtAllow).
+///
+/// Falls back to `workflow_artifacts::DEFAULT_WATCH_EXTENSIONS` when unset,
+/// empty, or malformed.
+pub async fn read_watch_extensions(pool: &SqlitePool, tool_id: &str) -> Vec<String> {
+    let raw = settings_repo::get_raw(pool, &key_watch_extensions(tool_id)).await.ok().flatten();
+    let configured: Option<Vec<String>> = raw.and_then(|v| {
+        let arr = v.as_array()?;
+        let exts: Vec<String> = arr.iter().filter_map(|e| e.as_str().map(str::to_owned)).collect();
+        (!exts.is_empty()).then_some(exts)
+    });
+    configured.unwrap_or_else(|| {
+        workflow_artifacts::DEFAULT_WATCH_EXTENSIONS.iter().map(|s| (*s).to_owned()).collect()
+    })
+}
+
 /// Read a nullable string setting value.
 async fn read_string_setting(pool: &SqlitePool, key: &str) -> Option<String> {
     settings_repo::get_raw(pool, key)
@@ -373,6 +395,7 @@ pub async fn list_profiles(pool: &SqlitePool) -> Result<ToolProfileListResponse,
             && executable_path.as_deref().is_some_and(|p| std::path::Path::new(p).exists());
         let enabled = read_bool_setting(pool, &key_enabled(profile.id), true).await;
         let auto_detected = read_bool_setting(pool, &key_auto_detected(profile.id), false).await;
+        let watch_extensions = read_watch_extensions(pool, profile.id).await;
 
         tools.push(ToolProfileSummary {
             id: profile.id.to_owned(),
@@ -383,6 +406,7 @@ pub async fn list_profiles(pool: &SqlitePool) -> Result<ToolProfileListResponse,
             enabled,
             auto_detected,
             executable_path,
+            watch_extensions,
         });
     }
     Ok(ToolProfileListResponse { tools })
@@ -424,6 +448,24 @@ pub async fn update_tool(
         .await
         .map_err(|e| format!("{e}"))?;
 
+    // spec 012 T007b: persist a custom watch-extensions allow-list, when supplied.
+    if let Some(ref extensions) = req.watch_extensions {
+        for ext in extensions {
+            if !ext.starts_with('.') {
+                return Err(format!(
+                    "watch_extensions entries must start with '.'; got '{ext}' for tool '{}'",
+                    req.id
+                ));
+            }
+        }
+        let value = serde_json::Value::Array(
+            extensions.iter().cloned().map(serde_json::Value::String).collect(),
+        );
+        settings_repo::set_raw(pool, &key_watch_extensions(&req.id), &value)
+            .await
+            .map_err(|e| format!("{e}"))?;
+    }
+
     // Return updated summary
     let executable_path = read_string_setting(pool, &key_executable_path(&req.id)).await;
     let configured = executable_path.as_deref().is_some_and(|p| !p.trim().is_empty());
@@ -432,6 +474,7 @@ pub async fn update_tool(
     let auto_detected = read_bool_setting(pool, &key_auto_detected(&req.id), false).await;
     let name = seed::find(&req.id).map_or_else(|| req.id.clone(), |p| p.name.to_owned());
     let supports_open_folder = seed::find(&req.id).is_some_and(|p| p.supports_open_folder);
+    let watch_extensions = read_watch_extensions(pool, &req.id).await;
 
     Ok(ToolProfileSummary {
         id: req.id,
@@ -442,6 +485,7 @@ pub async fn update_tool(
         enabled: req.enabled,
         auto_detected,
         executable_path,
+        watch_extensions,
     })
 }
 
@@ -713,6 +757,7 @@ mod tests {
                 id: "pixinsight".to_owned(),
                 path: Some(exe.to_owned()),
                 enabled: true,
+                watch_extensions: None,
             },
         )
         .await

--- a/crates/app/core/tests/tools_artifacts_integration.rs
+++ b/crates/app/core/tests/tools_artifacts_integration.rs
@@ -106,6 +106,7 @@ async fn list_profiles_round_trips_through_real_db() {
             id: first_id.clone(),
             path: Some(fake_exe_str.clone()),
             enabled: true,
+            watch_extensions: None,
         },
     )
     .await
@@ -139,7 +140,12 @@ async fn update_tool_persists_disabled_state() {
     // Disable it (no path change).
     let summary = tool_launch::update_tool(
         pool,
-        UpdateProcessingTool { id: tool_id.clone(), path: None, enabled: false },
+        UpdateProcessingTool {
+            id: tool_id.clone(),
+            path: None,
+            enabled: false,
+            watch_extensions: None,
+        },
     )
     .await
     .expect("update_tool disable");
@@ -244,6 +250,7 @@ async fn launch_wiring_with_fake_spawner_persists_row() {
             id: "pixinsight".to_owned(),
             path: Some(fake_exe_str.clone()),
             enabled: true,
+            watch_extensions: None,
         },
     )
     .await

--- a/crates/contracts/core/src/tools.rs
+++ b/crates/contracts/core/src/tools.rs
@@ -29,6 +29,11 @@ pub struct UpdateProcessingTool {
     pub id: String,
     pub path: Option<String>,
     pub enabled: bool,
+    /// Custom artifact-watch extension allow-list (spec 012 T007b, R-ExtAllow).
+    /// `None` leaves the existing setting (or default) unchanged. Entries MUST
+    /// start with `.` (e.g. `.xisf`).
+    #[serde(default)]
+    pub watch_extensions: Option<Vec<String>>,
 }
 
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
@@ -61,6 +66,10 @@ pub struct ToolProfileSummary {
     pub auto_detected: bool,
     /// Current executable path (from Settings). `None` when not configured.
     pub executable_path: Option<String>,
+    /// Effective artifact-watch extension allow-list (spec 012 T007b): the
+    /// per-tool Settings override when configured, else
+    /// `workflow_artifacts::DEFAULT_WATCH_EXTENSIONS`.
+    pub watch_extensions: Vec<String>,
 }
 
 // ── tool.launch ───────────────────────────────────────────────────────────────
@@ -230,5 +239,14 @@ pub struct ArtifactClassifyResponse {
 #[serde(rename_all = "camelCase")]
 pub struct ArtifactMarkResolvedRequest {
     pub artifact_id: String,
+    pub project_id: String,
+}
+
+/// Request DTO for `artifact.watcher.attach` / `artifact.watcher.detach`
+/// (spec 012 T008): wires the filesystem watcher to the project drawer
+/// open/close lifecycle.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct ArtifactWatcherRequest {
     pub project_id: String,
 }

--- a/specs/011-processing-tool-launch/contracts/tool.profile.list.json
+++ b/specs/011-processing-tool-launch/contracts/tool.profile.list.json
@@ -27,7 +27,8 @@
         "available",
         "supportsOpenFolder",
         "enabled",
-        "autoDetected"
+        "autoDetected",
+        "watchExtensions"
       ],
       "additionalProperties": false,
       "properties": {
@@ -57,6 +58,11 @@
         "autoDetected": {
           "type": "boolean",
           "description": "True when the current executablePath came from R2 discovery and has not been explicitly saved by the user yet."
+        },
+        "watchExtensions": {
+          "type": "array",
+          "items": { "type": "string", "pattern": "^\\.[a-zA-Z0-9]+$" },
+          "description": "Spec 012 T007b (R-ExtAllow): the effective artifact-watch extension allow-list for this tool — a per-tool Settings override when configured, else the workflow_artifacts DEFAULT_WATCH_EXTENSIONS default."
         }
       }
     },

--- a/specs/012-processing-artifact-observation/spec.md
+++ b/specs/012-processing-artifact-observation/spec.md
@@ -19,13 +19,28 @@ rules), migration `0025_artifacts.sql`, repository
 `crates/app/lifecycle/src/artifact.rs` (`detect`/`list`/`classify_override`/
 `mark_resolved`/`mark_missing`/`reattribute`/`complete_run`) are in place, with
 Tauri commands (`artifact_list`/`classify`/`mark_resolved`) + generated
-bindings, a live notify-rs OS watcher (`crates/fs/inventory/src/artifact_watcher.rs`,
-wired at `src-tauri/src/lib.rs`), and the `ToolLaunchesAccordion` drawer UI.
+bindings, a live notify-rs OS watcher (`crates/fs/inventory/src/artifact_watcher.rs`),
+and the `ToolLaunchesAccordion` drawer component.
 Detection, classification, override, missing-state, attribution, persistence,
-contracts, and Tauri wiring all exist (T008's notify-rs watcher, marked deferred
-in tasks.md, is in fact done). Remaining open items are peripheral: integration/
-e2e/contract tests, a research doc, cross-spec sign-off (011/017/024), and a
-per-profile `watch_extensions` override (blocked on spec 018) — not core build.
+and contracts all exist.
+
+**Correction (2026-07-04, WP-012-A)**: a prior revision of this note claimed
+"T008's notify-rs watcher, marked deferred in tasks.md, is in fact done" —
+that was inaccurate. What existed was a single always-on watcher spawned once
+at app startup over every registered library root (never per-project,
+never attached/detached, and it stamped the *library root* id onto
+`ProcessingArtifact.project_id`, not the real project). T008 (drawer
+attach/detach lifecycle) and T007b (`watch_extensions` setting) were
+genuinely open; both are now implemented: a per-project
+`ArtifactWatcherRegistry` attached via `artifact.watcher.attach`/detached via
+`artifact.watcher.detach` from `ProjectDetailContent`'s own mount lifecycle
+(runs the T005 on-attach reconciliation pass first), and a
+`tools.<tool_id>.watch_extensions` Settings key applied by both the live
+watcher and reconciliation. Remaining open items are still peripheral:
+integration/e2e/contract tests, a research doc, cross-spec sign-off
+(011/017/024), and mounting `ToolLaunchesAccordion` into the drawer UI (T023
+is checked in tasks.md but the component is not actually rendered anywhere —
+see WP-012-A handover) — not core build.
 
 ## User Scenarios & Testing *(mandatory)*
 

--- a/specs/012-processing-artifact-observation/tasks.md
+++ b/specs/012-processing-artifact-observation/tasks.md
@@ -43,13 +43,23 @@ and `size_bytes`.
       `artifact.missing`, `artifact.recovered`, `artifact.user_resolved`,
       `artifact.classify.override`, `artifact.classify.override.cleared`,
       `workflow.run_completed` added to `crates/audit/src/event_bus.rs`.
-- [ ] **T007b** Add `watch_extensions` field to `WorkflowProfile`
-      schema. DEFERRED — `DEFAULT_WATCH_EXTENSIONS` constant in
-      `watcher.rs` provides the default; per-profile override via spec
-      018 settings ripple not yet wired.
-- [ ] **T008** Wire watcher attach/detach to project drawer lifecycle
-      events in the desktop app. DEFERRED — needs OS watcher runtime
-      (notify-rs) and Tauri window lifecycle hooks (GUI runtime needed).
+- [x] **T007b** Add `watch_extensions` field to `WorkflowProfile`
+      schema. `tools.<tool_id>.watch_extensions` Settings key, read/write via
+      `app_core::tool_launch::read_watch_extensions` +
+      `update_tool`/`list_profiles`, defaulting to `DEFAULT_WATCH_EXTENSIONS`;
+      exposed on `ToolProfileSummary`/`UpdateProcessingTool` and applied by
+      both the live watcher and the on-attach reconciliation pass (T008).
+      — `crates/app/core/src/tool_launch.rs`; `crates/contracts/core/src/tools.rs`
+- [x] **T008** Wire watcher attach/detach to project drawer lifecycle
+      events in the desktop app. Replaced the always-on global watcher (which
+      watched entire library roots and stamped the wrong `project_id`) with a
+      per-project `ArtifactWatcherRegistry`, attached/detached via new
+      `artifact.watcher.attach`/`artifact.watcher.detach` commands called from
+      `useProjectArtifactWatcher` inside `ProjectDetailContent`'s mount
+      lifecycle (attach on open, detach on close/project switch). Attach runs
+      the T005 on-attach reconciliation pass first.
+      — `apps/desktop/src-tauri/src/watcher.rs`; `apps/desktop/src-tauri/src/commands/artifacts.rs`;
+        `apps/desktop/src/features/projects/artifacts.ts`; `apps/desktop/src/features/projects/ProjectDetail.tsx`
 - [ ] **T009** Integration test: drop a known-good file into a fixture
       output folder. DEFERRED — requires notify-rs watcher runtime (GUI).
 - [ ] **T010** Integration test: delete file → rescan → expect `missing`.


### PR DESCRIPTION
## Summary
- The app now attaches a filesystem watcher scoped to a project's own output folder only while that project is open (was previously a single always-on watcher over every registered library drive, which also mis-attributed detected files to the wrong project). Detach happens automatically when the project view closes or you switch projects, and reopening rescans the folder so nothing written while it was closed is missed.
- Added a per-tool "watch these file extensions" setting (defaults to the existing built-in list) so which output file types get picked up can be tuned per processing tool.

## Spec Context
- Spec: 012
- Branch: impl-012a-watcher-attribution-v2