### PR TITLE
fix: source protection setting changes now actually take effect

### DIFF
--- a/apps/desktop/src-tauri/src/commands/plans.rs
+++ b/apps/desktop/src-tauri/src/commands/plans.rs
@@ -168,14 +168,19 @@ pub async fn archive_permanently_delete(
     confirm_text: String,
 ) -> Result<ArchivePermanentlyDeleteResponse, ContractError> {
     // Read blockPermanentDelete from settings (spec 016 protection gate).
-    // We load the setting directly from the settings store rather than caching in AppState.
+    // We load the setting directly from the settings store rather than caching
+    // in AppState. Resolved via `app_core::settings::resolve_setting` (not the
+    // raw `persistence_db::repositories::settings` table) because
+    // `blockPermanentDelete` is a global-protection-default key backed by the
+    // dedicated `protection_defaults` table (spec 016 T-003/T-005) — reading
+    // the legacy generic settings table directly would silently ignore every
+    // value the user actually saved via the Cleanup settings pane.
     let pool = state.repo.pool();
-    let block: bool = persistence_db::repositories::settings::get_raw(pool, "blockPermanentDelete")
+    let block: bool = app_core::settings::resolve_setting(pool, "blockPermanentDelete", None)
         .await
         .ok()
-        .flatten()
         .and_then(|v| v.as_bool())
-        .unwrap_or(false);
+        .unwrap_or(true);
 
     permanently_delete_archive(pool, &state.bus, &plan_id, &confirm_text, block).await
 }

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -12,13 +12,8 @@
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 
 use audit::bus::EventBus;
-use audit::event_bus::{
-    ProtectionDefaultChanged, ProtectionPlanAcknowledged, ProtectionSourceSet, Source,
-};
-use audit::{
-    TOPIC_PROTECTION_DEFAULT_CHANGED, TOPIC_PROTECTION_PLAN_ACKNOWLEDGED,
-    TOPIC_PROTECTION_SOURCE_SET,
-};
+use audit::event_bus::{ProtectionPlanAcknowledged, ProtectionSourceSet, Source};
+use audit::{TOPIC_PROTECTION_PLAN_ACKNOWLEDGED, TOPIC_PROTECTION_SOURCE_SET};
 use contracts_core::protection::{
     NonBlockingSummary, PlanProtectionCheckRequest, PlanProtectionCheckResponse, ProtectedPlanItem,
     ProtectionLevel, SourceProtectionGetRequest, SourceProtectionGetResponse,
@@ -388,16 +383,29 @@ pub async fn acknowledge_protected_item(
 // ── US4: set_global_protection_default ───────────────────────────────────
 
 /// Persist a global protection default and emit a `protection.default.changed`
-/// audit event (T045, FR-018; fixes spec 016 T-003/T-004/T-005).
+/// audit event (T045, FR-018; spec 016 T-003/T-004/T-005).
 ///
-/// `scope` is typically `"global"`. `key` is one of:
+/// `scope` MUST be `"global"` — it is the only scope the desktop settings
+/// save path (`settings.update` with scope `"cleanup"`) ever writes to, and
+/// the only scope `app_core::protection::load_global_protection` reads from.
+/// `key` is one of:
 /// - `"defaultProtection"` — protection level string
 /// - `"blockPermanentDelete"` — boolean
 /// - `"protectedCategories"` — JSON array of category strings
 ///
+/// This delegates to `app_core_settings::update_setting` (re-exported as
+/// `crate::settings`) rather than writing `protection_defaults` directly, so
+/// there is a single implementation of the validation, no-op guard, and
+/// `protection.default.changed` emission shared with the real desktop save
+/// path (`settings.update` Tauri command → `crate::settings::update_setting`).
+/// Kept as a thin wrapper for callers that already depend on this narrower
+/// signature (e.g. this module's own tests).
+///
 /// # Errors
 ///
-/// Returns `ContractError` on DB or audit failure.
+/// Returns `ContractError` with code `"key.unknown"` if `key` is not
+/// `defaultProtection` / `blockPermanentDelete` / `protectedCategories`,
+/// `"value.invalid"` on a type/enum mismatch, or on DB/audit failure.
 pub async fn set_global_protection_default(
     pool: &SqlitePool,
     bus: &EventBus,
@@ -405,28 +413,15 @@ pub async fn set_global_protection_default(
     key: &str,
     value: serde_json::Value,
 ) -> Result<(), ContractError> {
-    // Read prior value for the audit record.
-    let old = prot_repo::get_protection_default(pool, scope, key).await.map_err(db_err)?;
-
-    // Persist the new value.
-    prot_repo::set_protection_default(pool, scope, key, &value).await.map_err(db_err)?;
-
-    // Emit audit event.
-    let changed_at = Timestamp::now_iso();
-    bus.publish(
-        TOPIC_PROTECTION_DEFAULT_CHANGED,
-        Source::User,
-        ProtectionDefaultChanged {
-            scope: scope.to_owned(),
-            key: key.to_owned(),
-            old,
-            new: value,
-            changed_at,
-        },
-    )
-    .await
-    .map_err(bus_err)?;
-
+    debug_assert_eq!(
+        scope, "global",
+        "global protection defaults are only ever stored under scope=\"global\""
+    );
+    let req = contracts_core::settings::SettingsUpdateRequest {
+        key: key.to_owned(),
+        value: contracts_core::JsonAny::from(value),
+    };
+    crate::settings::update_setting(pool, bus, &req).await?;
     Ok(())
 }
 

--- a/crates/app/core/tests/settings_logs_integration.rs
+++ b/crates/app/core/tests/settings_logs_integration.rs
@@ -140,10 +140,16 @@ async fn restore_defaults_reverts_to_default_value() {
 
 // ── T017: noisy key suppression + emit_snapshot ───────────────────────────────
 
-/// Updating a **noisy** key (e.g. `protectedCategories`) must NOT emit a
+/// Updating a **noisy** key (e.g. `rememberFollowLogs`) must NOT emit a
 /// per-change `settings.changed` audit event, while updating a **non-noisy**
 /// key (e.g. `logLevel`) must emit one.  Separately, `emit_snapshot` must
 /// publish a `settings.snapshot` event.
+///
+/// `protectedCategories` is also `noisy` but is deliberately NOT used as the
+/// example here: spec 016 (plan.md E-016-3) carves out a named exception for
+/// it — see `global_protection_default_update_persists_and_emits_protection_event`
+/// below, which asserts it (and its sibling protection-default keys) DOES
+/// emit an audit event despite being noisy.
 #[tokio::test]
 async fn noisy_key_update_does_not_emit_changed_event_non_noisy_does() {
     let (db, _repo, bus) = support::setup().await;
@@ -177,7 +183,14 @@ async fn noisy_key_update_does_not_emit_changed_event_non_noisy_does() {
         "non-noisy logLevel update must emit exactly one settings.changed event"
     );
 
-    // ── noisy key: protectedCategories ───────────────────────────────────
+    // ── noisy key: rememberFollowLogs ─────────────────────────────────────
+    //
+    // `protectedCategories` is ALSO a noisy key, but spec 016 (plan.md
+    // E-016-3) carves out a named exception for it: it must always emit
+    // `protection.default.changed` because it is a global protection default,
+    // not a generic noisy key. See
+    // `global_protection_default_update_persists_and_emits_protection_event`
+    // below for that behaviour.
     let before_noisy: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE topic = ?")
         .bind(TOPIC_SETTINGS_CHANGED)
         .fetch_one(pool)
@@ -185,11 +198,11 @@ async fn noisy_key_update_does_not_emit_changed_event_non_noisy_does() {
         .expect("count query");
 
     let req_noisy = SettingsUpdateRequest {
-        key: "protectedCategories".to_owned(),
-        value: JsonAny::from(serde_json::json!(["lights", "masters", "finals", "raw"])),
+        key: "rememberFollowLogs".to_owned(),
+        value: JsonAny::from(serde_json::json!(true)),
     };
     let resp_noisy =
-        settings::update_setting(pool, &bus, &req_noisy).await.expect("update protectedCategories");
+        settings::update_setting(pool, &bus, &req_noisy).await.expect("update rememberFollowLogs");
     assert_eq!(resp_noisy.status, SettingsUpdateStatus::Success);
     // Noisy: audit_id must be absent.
     assert!(resp_noisy.audit_id.is_none(), "noisy key update must NOT return an audit_id");
@@ -201,7 +214,7 @@ async fn noisy_key_update_does_not_emit_changed_event_non_noisy_does() {
         .expect("count query");
     assert_eq!(
         after_noisy.0, before_noisy.0,
-        "noisy protectedCategories update must NOT emit a settings.changed event"
+        "noisy rememberFollowLogs update must NOT emit a settings.changed event"
     );
 
     // ── emit_snapshot publishes settings.snapshot ─────────────────────────
@@ -223,6 +236,84 @@ async fn noisy_key_update_does_not_emit_changed_event_non_noisy_does() {
         before_snap.0 + 1,
         "emit_snapshot must persist exactly one settings.snapshot event"
     );
+}
+
+// ── spec 016 T-003/T-004/T-005: global protection defaults ──────────────────
+
+/// The three global protection-default keys (`defaultProtection`,
+/// `blockPermanentDelete`, `protectedCategories`) MUST persist to the
+/// dedicated `protection_defaults` table (T-003, migration 0035) and emit
+/// `protection.default.changed` (T-004) when saved through the same
+/// `settings.update` use case the desktop Cleanup settings pane calls
+/// (T-005) — INCLUDING `protectedCategories`, which is marked `noisy` for the
+/// generic `settings.changed` topic (see
+/// `noisy_key_update_does_not_emit_changed_event_non_noisy_does` above) but is
+/// a named exception per plan.md E-016-3.
+#[tokio::test]
+async fn global_protection_default_update_persists_and_emits_protection_event() {
+    use audit::event_bus::TOPIC_PROTECTION_DEFAULT_CHANGED;
+
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+
+    for (key, value) in [
+        ("defaultProtection", serde_json::json!("normal")),
+        ("blockPermanentDelete", serde_json::json!(false)),
+        ("protectedCategories", serde_json::json!(["lights", "masters", "finals", "raw"])),
+    ] {
+        let before: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE topic = ?")
+            .bind(TOPIC_PROTECTION_DEFAULT_CHANGED)
+            .fetch_one(pool)
+            .await
+            .expect("count query");
+
+        let req =
+            SettingsUpdateRequest { key: key.to_owned(), value: JsonAny::from(value.clone()) };
+        let resp = settings::update_setting(pool, &bus, &req)
+            .await
+            .unwrap_or_else(|e| panic!("update {key} must succeed: {e:?}"));
+        assert_eq!(resp.status, SettingsUpdateStatus::Success, "{key} update must succeed");
+        assert!(
+            resp.audit_id.is_some(),
+            "{key} update must emit an audit event (T-004), even though \
+             protectedCategories is marked noisy for the generic topic"
+        );
+
+        let after: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE topic = ?")
+            .bind(TOPIC_PROTECTION_DEFAULT_CHANGED)
+            .fetch_one(pool)
+            .await
+            .expect("count query");
+        assert_eq!(
+            after.0,
+            before.0 + 1,
+            "{key} update must emit exactly one protection.default.changed event"
+        );
+
+        // Persisted to the dedicated protection_defaults table (T-003), not
+        // just the legacy generic settings table — this is what
+        // `app_core::protection::load_global_protection` actually reads, so
+        // this is the assertion that proves the save path is really wired
+        // (T-005) rather than silently landing in a table nobody reads.
+        let stored: (String,) = sqlx::query_as(
+            "SELECT value FROM protection_defaults WHERE scope = 'global' AND key = ?",
+        )
+        .bind(key)
+        .fetch_one(pool)
+        .await
+        .unwrap_or_else(|e| panic!("{key} must be persisted in protection_defaults: {e:?}"));
+        let stored_value: serde_json::Value =
+            serde_json::from_str(&stored.0).expect("stored value must be valid JSON");
+        assert_eq!(stored_value, value, "{key} persisted value must match the update");
+
+        // `resolve_setting` is what `settings.get` AND the safety-critical
+        // `archive.permanently_delete` command use to read `blockPermanentDelete`
+        // — it must reflect the update too, not just the raw table (T-005).
+        let resolved = settings::resolve_setting(pool, key, None)
+            .await
+            .unwrap_or_else(|e| panic!("resolve_setting({key}) must succeed: {e:?}"));
+        assert_eq!(resolved, value, "resolve_setting({key}) must reflect the persisted update");
+    }
 }
 
 // ── log stream: events written by settings surface in recent_entries ──────────

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -17,8 +17,9 @@
 
 use audit::bus::EventBus;
 use audit::event_bus::{
-    SettingsChanged, SettingsRepair, SettingsSnapshot, Source, TOPIC_SETTINGS_CHANGED,
-    TOPIC_SETTINGS_REPAIR, TOPIC_SETTINGS_SNAPSHOT,
+    ProtectionDefaultChanged, SettingsChanged, SettingsRepair, SettingsSnapshot, Source,
+    TOPIC_PROTECTION_DEFAULT_CHANGED, TOPIC_SETTINGS_CHANGED, TOPIC_SETTINGS_REPAIR,
+    TOPIC_SETTINGS_SNAPSHOT,
 };
 use contracts_core::settings::{
     RestoreDefaultsRequest, RestoreDefaultsResponse, RestoreDefaultsStatus,
@@ -27,8 +28,38 @@ use contracts_core::settings::{
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use persistence_db::repositories::settings as repo;
+use persistence_db::repositories::source_protection as protection_repo;
 use serde_json::Value;
 use sqlx::SqlitePool;
+
+// ── Global protection-default keys (spec 016 T-003/T-004/T-005) ─────────────
+//
+// `defaultProtection`, `blockPermanentDelete`, and `protectedCategories` are
+// stable v1 settings keys (see `descriptors::DESCRIPTORS`) but their durable
+// storage is the dedicated `protection_defaults` table (migration 0035)
+// scoped to `"global"`, NOT the generic `settings` table `repo` (aliased
+// above) writes to. `app_core::protection::load_global_protection` — the
+// function the protection resolver and `plan.protection.check` actually
+// read from — prefers `protection_defaults` unconditionally (it is always
+// seeded by migration 0035), so writes that only reach the generic
+// `settings` table are invisible to the resolver. Routing these three keys'
+// global read/write through `protection_repo` here keeps `settings.get`,
+// `settings.update`, and `settings.restore-defaults` in sync with the value
+// the resolver actually uses, and lets their audit trail use the dedicated
+// `protection.default.changed` topic instead of (or in addition to) the
+// generic `settings.changed` topic — including for `protectedCategories`,
+// which is marked `noisy` for the generic no-op-audit policy but is an
+// explicit exception per plan.md E-016-3.
+const GLOBAL_PROTECTION_DEFAULT_SCOPE: &str = "global";
+const GLOBAL_PROTECTION_DEFAULT_KEYS: [&str; 3] =
+    ["defaultProtection", "blockPermanentDelete", "protectedCategories"];
+
+/// Whether `key` is one of the three global protection-default keys backed by
+/// the `protection_defaults` table rather than the generic `settings` table.
+#[must_use]
+pub fn is_global_protection_default_key(key: &str) -> bool {
+    GLOBAL_PROTECTION_DEFAULT_KEYS.contains(&key)
+}
 
 // ── Settings descriptor table (US11 T144) ────────────────────────────────
 //
@@ -545,8 +576,17 @@ pub async fn update_setting(
     let new_value = &req.value.0;
     validate_value(key, new_value)?;
 
-    // 3. Load current stored value (or default).
-    let prior_raw = repo::get_raw(pool, key).await.map_err(db_err)?;
+    let is_protection_default = is_global_protection_default_key(key);
+
+    // 3. Load current stored value (or default). Global protection-default
+    // keys read/write the dedicated `protection_defaults` table (T-005).
+    let prior_raw = if is_protection_default {
+        protection_repo::get_protection_default(pool, GLOBAL_PROTECTION_DEFAULT_SCOPE, key)
+            .await
+            .map_err(db_err)?
+    } else {
+        repo::get_raw(pool, key).await.map_err(db_err)?
+    };
     let prior_value = prior_raw.clone().unwrap_or_else(|| default_value_for_key(key));
 
     // 4. No-op guard.
@@ -561,11 +601,44 @@ pub async fn update_setting(
     }
 
     // 5. Persist.
-    repo::set_raw(pool, key, new_value).await.map_err(db_err)?;
+    if is_protection_default {
+        protection_repo::set_protection_default(
+            pool,
+            GLOBAL_PROTECTION_DEFAULT_SCOPE,
+            key,
+            new_value,
+        )
+        .await
+        .map_err(db_err)?;
+    } else {
+        repo::set_raw(pool, key, new_value).await.map_err(db_err)?;
+    }
 
-    // 6. Emit audit event for non-noisy keys.
+    // 6. Emit audit event. Global protection-default keys ALWAYS emit
+    // `protection.default.changed` (T-004), overriding the noisy-key
+    // no-audit policy — `protectedCategories` is `noisy` for the generic
+    // `settings.changed` topic but is a named exception here (spec 016
+    // plan.md E-016-3: "MUST emit `protection.default.changed` whenever it is
+    // updated").
     let is_noisy = descriptors::is_noisy(key.as_str());
-    let audit_id = if is_noisy {
+    let audit_id = if is_protection_default {
+        let at = Timestamp::now_iso();
+        let evt_id = uuid::Uuid::new_v4().to_string();
+        bus.publish(
+            TOPIC_PROTECTION_DEFAULT_CHANGED,
+            Source::User,
+            ProtectionDefaultChanged {
+                scope: GLOBAL_PROTECTION_DEFAULT_SCOPE.to_owned(),
+                key: key.clone(),
+                old: Some(prior_value.clone()),
+                new: new_value.clone(),
+                changed_at: at,
+            },
+        )
+        .await
+        .map_err(bus_err)?;
+        Some(evt_id)
+    } else if is_noisy {
         None
     } else {
         let at = Timestamp::now_iso();
@@ -636,7 +709,14 @@ pub async fn restore_defaults(
 
     for key in &keys_to_restore {
         let default_val = default_value_for_key(key);
-        let current_raw = repo::get_raw(pool, key).await.map_err(db_err)?;
+        let is_protection_default = is_global_protection_default_key(key);
+        let current_raw = if is_protection_default {
+            protection_repo::get_protection_default(pool, GLOBAL_PROTECTION_DEFAULT_SCOPE, key)
+                .await
+                .map_err(db_err)?
+        } else {
+            repo::get_raw(pool, key).await.map_err(db_err)?
+        };
         let current_val = current_raw.unwrap_or_else(|| default_val.clone());
 
         if settings_value_eq(&current_val, &default_val) {
@@ -645,22 +725,51 @@ pub async fn restore_defaults(
         }
 
         // Write the default value.
-        repo::set_raw(pool, key, &default_val).await.map_err(db_err)?;
+        if is_protection_default {
+            protection_repo::set_protection_default(
+                pool,
+                GLOBAL_PROTECTION_DEFAULT_SCOPE,
+                key,
+                &default_val,
+            )
+            .await
+            .map_err(db_err)?;
+        } else {
+            repo::set_raw(pool, key, &default_val).await.map_err(db_err)?;
+        }
 
         // Emit audit event (even for noisy keys — restore is an explicit action).
+        // Global protection-default keys emit `protection.default.changed`
+        // (T-004) instead of the generic `settings.changed` topic.
         let at = Timestamp::now_iso();
-        bus.publish(
-            TOPIC_SETTINGS_CHANGED,
-            Source::User,
-            SettingsChanged {
-                key: key.clone(),
-                prior_value: current_val,
-                new_value: default_val,
-                at,
-            },
-        )
-        .await
-        .map_err(bus_err)?;
+        if is_protection_default {
+            bus.publish(
+                TOPIC_PROTECTION_DEFAULT_CHANGED,
+                Source::User,
+                ProtectionDefaultChanged {
+                    scope: GLOBAL_PROTECTION_DEFAULT_SCOPE.to_owned(),
+                    key: key.clone(),
+                    old: Some(current_val),
+                    new: default_val,
+                    changed_at: at,
+                },
+            )
+            .await
+            .map_err(bus_err)?;
+        } else {
+            bus.publish(
+                TOPIC_SETTINGS_CHANGED,
+                Source::User,
+                SettingsChanged {
+                    key: key.clone(),
+                    prior_value: current_val,
+                    new_value: default_val,
+                    at,
+                },
+            )
+            .await
+            .map_err(bus_err)?;
+        }
 
         restored.push(key.clone());
     }
@@ -736,8 +845,18 @@ pub async fn resolve_setting(
         }
     }
 
-    // 2. Global setting.
-    if let Some(v) = repo::get_raw(pool, key).await.map_err(db_err)? {
+    // 2. Global setting. Global protection-default keys are resolved from the
+    // dedicated `protection_defaults` table (spec 016 T-005) so this read path
+    // never disagrees with `app_core::protection::load_global_protection`.
+    if is_global_protection_default_key(key) {
+        if let Some(v) =
+            protection_repo::get_protection_default(pool, GLOBAL_PROTECTION_DEFAULT_SCOPE, key)
+                .await
+                .map_err(db_err)?
+        {
+            return Ok(v);
+        }
+    } else if let Some(v) = repo::get_raw(pool, key).await.map_err(db_err)? {
         return Ok(v);
     }
 

--- a/specs/016-source-protection-defaults/tasks.md
+++ b/specs/016-source-protection-defaults/tasks.md
@@ -7,18 +7,71 @@ shipped in `apps/desktop/` and pending only wiring to real persistence.
 
 ## US1 — Set Global Defaults (P1)
 
-- [x] **T-001** `[mockup-done]` Source Protection settings section UI
-  (`apps/desktop/src/features/settings/SettingsPage.tsx::SourceProtectionSection`).
+- [x] **T-001** `[mockup-done]` Source Protection settings section UI.
+  _Note (impl-016-tail): the UI moved from `SettingsPage.tsx::SourceProtectionSection`
+  to `apps/desktop/src/features/settings/Cleanup.tsx` (spec 018 settings
+  refactor) — same two controls (`blockPermanentDelete` toggle,
+  `defaultProtection` select) render there today; path in this task predates
+  that move._
 - [x] **T-002** `[mockup-done]` Settings store keys `defaultProtection`,
-  `blockPermanentDelete`, `protectedCategories`
-  (`apps/desktop/src/data/settings.ts`).
-- [ ] **T-003** Add `GlobalProtectionDefaults` row to persistence
+  `blockPermanentDelete`, `protectedCategories`.
+  _Note (impl-016-tail): `apps/desktop/src/data/settings.ts` no longer exists;
+  the keys now live in the backend `settings`/`protection_defaults` tables via
+  `apps/desktop/src/features/settings/settingsIpc.ts` (`getSettings`/
+  `updateSettings`), read/written for scope `"cleanup"`._
+- [x] **T-003** Add `GlobalProtectionDefaults` row to persistence
   (`crates/persistence/db/`) with migration; seed values match mockup defaults
   (`protected`, `true`, `["lights", "masters", "finals"]`).
-- [ ] **T-004** Implement `protection.default.changed` audit event
+  _Evidence: already present before impl-016-tail — migration
+  `0035_protection_defaults.sql` creates the `protection_defaults` table
+  (scope, key, value, updated_at) and seeds `global`/`defaultProtection` =
+  `"protected"`, `global`/`blockPermanentDelete` = `true`,
+  `global`/`protectedCategories` = `["lights","masters","finals"]`. Verified
+  by `crates/persistence/db/src/repositories/source_protection.rs`'s
+  `get_protection_default`/`set_protection_default` and by the new
+  `global_protection_default_update_persists_and_emits_protection_event` test
+  in `crates/app/core/tests/settings_logs_integration.rs`, which asserts the
+  row round-trips through the `protection_defaults` table by direct SQL query._
+- [x] **T-004** Implement `protection.default.changed` audit event
   (`crates/audit/`) emitted on every settings update.
-- [ ] **T-005** Wire desktop settings save path to the persistence-backed
+  _Evidence: `TOPIC_PROTECTION_DEFAULT_CHANGED` / `ProtectionDefaultChanged`
+  already existed in `crates/audit/src/event_bus.rs`. impl-016-tail wires the
+  emit into the REAL save path: `app_core_settings::update_setting` and
+  `restore_defaults` (`crates/app/settings/src/lib.rs`) now special-case the
+  three global-protection-default keys to emit `protection.default.changed`
+  instead of (or, for `protectedCategories`, in addition to skipping) the
+  generic `settings.changed`/no-emit path — this is the named noisy-key
+  exception from plan.md E-016-3. Prior to this change the event type existed
+  but was only reachable from a direct test call
+  (`app_core::protection::set_global_protection_default`), never from the
+  real `settings.update` Tauri command — i.e. it was never actually emitted
+  on a real settings update. Tested in
+  `global_protection_default_update_persists_and_emits_protection_event`
+  (`crates/app/core/tests/settings_logs_integration.rs`)._
+- [x] **T-005** Wire desktop settings save path to the persistence-backed
   defaults via the application use-case layer.
+  _Evidence/bug fixed (impl-016-tail): before this change,
+  `app_core::protection::load_global_protection` (the function
+  `plan_protection_check`/`get_source_protection`/`generate_cleanup_plan`
+  actually read from) ALWAYS preferred the `protection_defaults` table
+  (unconditionally seeded by migration 0035), while the desktop save path
+  (`Cleanup.tsx` → `settingsIpc.updateSettings` → `settings.update` Tauri
+  command → `app_core_settings::update_setting`) wrote only to the legacy
+  generic `settings` table. Because `protection_defaults` always had a row,
+  `load_global_protection` never observed the user's change — the Cleanup
+  pane's "Restore/Save" round-tripped through `settings.get` (which also read
+  the legacy table) and LOOKED like it worked, but the actual protection
+  resolver used by plan generation silently ignored it. Fixed by making
+  `resolve_setting`/`update_setting`/`restore_defaults` in
+  `crates/app/settings/src/lib.rs` read/write `protection_defaults` for
+  `defaultProtection`/`blockPermanentDelete`/`protectedCategories` instead of
+  the legacy `settings` table, so `settings.get`, `settings.update`, and
+  `settings.restore-defaults` (all already called by the desktop Cleanup
+  pane) now stay in sync with the value the resolver reads.
+  `app_core::protection::set_global_protection_default` was simplified to
+  delegate to this single implementation. No Tauri command signatures or
+  contracts changed — this was purely an application-use-case-layer fix, so
+  no bindings regen was required._
 
 ## US2 — Per-Source Override (P2)
 


### PR DESCRIPTION
## Summary
- Changing the global protection default (level, block-permanent-delete, protected categories) in Settings previously appeared to save, but the plan-safety checks kept using the original seeded values — the save silently had no effect. Saving now correctly updates the value the safety checks read.
- Every change to these defaults is now recorded in the audit log.
- Fixed a related bug where the "permanently delete archive" safety gate could read a stale value for the block-permanent-delete setting.

## Spec Context
- Spec: 016
- Branch: impl-016-tail