### PR TITLE
feat: hidden developer-mode toggle page in dev-tools builds

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,14 @@ repos:
       - id: check-toml
       - id: check-yaml
       - id: detect-private-key
+      # Generated outputs (specta bindings, seed catalog) must keep their
+      # generator-emitted bytes — CI's `just check-generated` drift gate
+      # regenerates and `git diff --exit-code`s them, so whitespace "fixes"
+      # here would fail CI.
       - id: end-of-file-fixer
+        exclude: '^(apps/desktop/src/bindings/|assets/seed/)'
       - id: trailing-whitespace
+        exclude: '^(apps/desktop/src/bindings/|assets/seed/)'
 
   - repo: https://github.com/gitleaks/gitleaks
     rev: v8.24.3

--- a/.typos.toml
+++ b/.typos.toml
@@ -12,6 +12,8 @@ extend-exclude = [
     "GEMINI.md",
     "*/CLAUDE.md",
     "*/AGENTS.md",
+    # generated star-catalog seed data (Bayer designations trip the checker)
+    "assets/seed/",
 ]
 
 [default.extend-words]
@@ -33,3 +35,16 @@ mis = "mis"
 unparseable = "unparseable"
 # UI abbreviation for "designation" (targets alias kind label)
 desig = "desig"
+# Bayer designations / test IDs (gamma, omega, nu)
+gam = "gam"
+ome = "ome"
+noo = "noo"
+# haversine formula abbreviation in coords.rs comments
+hav = "hav"
+# variable name for b->a angular separation in symmetry tests
+ba = "ba"
+# intentional wording: "review-transitionable lifecycle state"
+transitionable = "transitionable"
+# comment prose pluralising SQL keywords ("UNIONs", "LIKEs")
+UNIO = "UNIO"
+LIK = "LIK"

--- a/.typos.toml
+++ b/.typos.toml
@@ -31,3 +31,5 @@ ot = "ot"
 mis = "mis"
 # accepted spelling in a test description
 unparseable = "unparseable"
+# UI abbreviation for "designation" (targets alias kind label)
+desig = "desig"

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1974,5 +1974,13 @@
   "settings_cleanup_action_archive": "Archive",
   "settings_cleanup_action_delete": "Delete",
   "targets_legacy_density_dense": "Dense",
-  "targets_legacy_density_rich": "Rich"
+  "targets_legacy_density_rich": "Rich",
+  "dev_settings_title": "Developer Mode",
+  "dev_settings_intro": "This page is intentionally unreachable from Settings or the command palette. It exists so a developer can turn on the diagnostics surface before anything else becomes visible.",
+  "dev_settings_section_title": "Developer Surface",
+  "dev_settings_toggle_label": "Developer mode",
+  "dev_settings_toggle_info": "When on, the recording proxy captures contract calls and Developer / Contracts becomes reachable from the command palette (Cmd+K / Ctrl+K).",
+  "dev_settings_restart_hint": "Turning developer mode off here stops new contract calls from being recorded immediately, but the recording proxy itself is only fully removed after the app restarts.",
+  "dev_settings_saving": "Saving…",
+  "dev_settings_error": "Could not update developer mode: {message}"
 }

--- a/apps/desktop/src/app/router.tsx
+++ b/apps/desktop/src/app/router.tsx
@@ -216,6 +216,21 @@ const devContractsRoute = DEV_TOOLS_ENABLED
     })
   : null;
 
+// Hidden devMode toggle (spec 021 T032). Deliberately NOT added to the
+// command palette's DEV_PAGES and NOT linked from Settings — reachable only
+// by typing `/dev/settings` directly. Same compile-time gate as
+// `devContractsRoute` above.
+const devSettingsRoute = DEV_TOOLS_ENABLED
+  ? createRoute({
+      getParentRoute: () => shellRoute,
+      path: '/dev/settings',
+      component: lazyRouteComponent(
+        () => import('@/dev/DevSettingsPage'),
+        'DevSettingsPage',
+      ),
+    })
+  : null;
+
 // --- Setup (standalone, no shell) ---
 
 const setupRoute = createRoute({
@@ -265,6 +280,8 @@ const routeTree = rootRoute.addChildren([
     settingsPaneRoute,
     // Developer Contract Diagnostics (spec 021 / T075): only present in dev-tools builds.
     ...(devContractsRoute ? [devContractsRoute] : []),
+    // Hidden devMode toggle (spec 021 / T032): only present in dev-tools builds.
+    ...(devSettingsRoute ? [devSettingsRoute] : []),
   ]),
 ]);
 

--- a/apps/desktop/src/dev/DevSettingsPage.test.tsx
+++ b/apps/desktop/src/dev/DevSettingsPage.test.tsx
@@ -1,0 +1,82 @@
+/**
+ * DevSettingsPage vitest unit tests (spec 021 T032).
+ *
+ * Tests:
+ * - Renders the current devMode state read from settings.get('advanced').
+ * - Toggling the switch calls settings.update with the new value.
+ * - Not present in the command palette's DEV_PAGES (URL-only reachability),
+ *   verified separately in commandPalette.devMode.test.ts.
+ * - The route is only registered in dev-tools builds (verified in
+ *   devSurface.release.test.ts alongside devContractsRoute).
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { DevSettingsPage } from './DevSettingsPage';
+
+const { mockSettingsGet, mockSettingsUpdate } = vi.hoisted(() => ({
+  mockSettingsGet: vi.fn(),
+  mockSettingsUpdate: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: (...a: unknown[]) =>
+      Promise.resolve(mockSettingsGet(...a)).then((data) => ({ status: 'ok', data })),
+    settingsUpdate: (...a: unknown[]) =>
+      Promise.resolve(mockSettingsUpdate(...a)).then((data) => ({ status: 'ok', data })),
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSettingsGet.mockResolvedValue({ scope: 'advanced', values: { devMode: false } });
+  mockSettingsUpdate.mockResolvedValue(undefined);
+});
+
+describe('DevSettingsPage (T032)', () => {
+  it('reads the current devMode value on mount', async () => {
+    render(<DevSettingsPage />);
+    await waitFor(() => {
+      expect(mockSettingsGet).toHaveBeenCalledWith('advanced');
+    });
+    const toggle = await screen.findByTestId('dev-mode-toggle');
+    expect(toggle.querySelector('input')).not.toBeChecked();
+  });
+
+  it('renders the toggle as checked when devMode is already on', async () => {
+    mockSettingsGet.mockResolvedValue({ scope: 'advanced', values: { devMode: true } });
+    render(<DevSettingsPage />);
+    const toggle = await screen.findByTestId('dev-mode-toggle');
+    await waitFor(() => expect(toggle.querySelector('input')).toBeChecked());
+  });
+
+  it('calls settings.update with devMode=true when toggled on', async () => {
+    render(<DevSettingsPage />);
+    const toggle = await screen.findByTestId('dev-mode-toggle');
+    const input = toggle.querySelector('input')!;
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(mockSettingsUpdate).toHaveBeenCalledWith('advanced', { devMode: true });
+    });
+  });
+
+  it('shows a restart hint once devMode is on', async () => {
+    mockSettingsGet.mockResolvedValue({ scope: 'advanced', values: { devMode: true } });
+    render(<DevSettingsPage />);
+    await waitFor(() => {
+      expect(screen.getByText(/restart/i)).toBeTruthy();
+    });
+  });
+
+  it('surfaces an error message when settings.update fails', async () => {
+    mockSettingsUpdate.mockRejectedValue(new Error('db unavailable'));
+    render(<DevSettingsPage />);
+    const toggle = await screen.findByTestId('dev-mode-toggle');
+    const input = toggle.querySelector('input')!;
+    fireEvent.click(input);
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeTruthy();
+    });
+  });
+});

--- a/apps/desktop/src/dev/DevSettingsPage.tsx
+++ b/apps/desktop/src/dev/DevSettingsPage.tsx
@@ -1,0 +1,105 @@
+/**
+ * /dev/settings — hidden developer-mode toggle (spec 021, T032).
+ *
+ * Reachable ONLY by typing the full URL. Deliberately NOT added to
+ * `DEV_PAGES` in `apps/desktop/src/app/CommandPalette.tsx` (unlike
+ * `/dev/contracts`) and NOT linked from the normal Settings › Advanced pane
+ * — the whole point of this page is to be the one place that can turn
+ * `devMode` on before the rest of the developer surface becomes reachable.
+ *
+ * Compile-time gated: this file is only imported (and its route only
+ * registered) when `VITE_DEV_TOOLS === 'true'` — see
+ * `apps/desktop/src/app/router.tsx`'s `DEV_TOOLS_ENABLED` constant, which
+ * mirrors the Rust `dev-tools` Cargo feature. Release builds never bundle
+ * this component (FR-031, SC-009).
+ *
+ * Toggling `devMode` off here still requires an app restart before the
+ * recording proxy is fully uninstalled (FR-008) — this page surfaces that
+ * with a restart hint rather than attempting a live uninstall.
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { PageShell } from '@/components';
+import { getSettings, updateSettings } from '@/features/settings/settingsIpc';
+import { SettingsSection, SettingsRow } from '@/features/settings/SettingsKit';
+import { Toggle } from '@/ui';
+import { m } from '@/lib/i18n';
+
+export function DevSettingsPage() {
+  const [devMode, setDevModeState] = useState<boolean | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    let cancelled = false;
+    getSettings({ scope: 'advanced' })
+      .then((data) => {
+        if (cancelled) return;
+        const vals = data.values as Record<string, unknown>;
+        setDevModeState(vals?.devMode === true);
+      })
+      .catch((e: unknown) => {
+        if (!cancelled) setError(String(e));
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => load(), [load]);
+
+  const handleToggle = useCallback(async (next: boolean) => {
+    setSaving(true);
+    setError(null);
+    try {
+      await updateSettings({ scope: 'advanced', values: { devMode: next } });
+      setDevModeState(next);
+    } catch (e: unknown) {
+      setError(String(e));
+    } finally {
+      setSaving(false);
+    }
+  }, []);
+
+  return (
+    <PageShell>
+      {/* Reuses the dev/ContractsPage body/title/error/loading classes (shared
+          component / no cloned CSS — see dev.css "DEV CONTRACTS PAGE"). */}
+      <div className="alm-page__scroll alm-dev-contracts-page__body">
+        <h1 className="alm-dev-contracts-page__title">{m.dev_settings_title()}</h1>
+        <p className="alm-dev-contracts-page__export-result">{m.dev_settings_intro()}</p>
+
+        {error && (
+          <div role="alert" className="alm-dev-contracts-page__error">
+            {m.dev_settings_error({ message: error })}
+          </div>
+        )}
+
+        <SettingsSection title={m.dev_settings_section_title()}>
+          <SettingsRow
+            label={m.dev_settings_toggle_label()}
+            info={m.dev_settings_toggle_info()}
+          >
+            {devMode === null ? (
+              <span className="alm-dev-contracts-page__loading">{m.common_loading()}</span>
+            ) : (
+              <Toggle
+                aria-label={m.dev_settings_toggle_label()}
+                checked={devMode}
+                onChange={(v) => void handleToggle(v)}
+                data-testid="dev-mode-toggle"
+              />
+            )}
+          </SettingsRow>
+          {devMode === true && (
+            <p className="alm-dev-contracts-page__export-result">
+              {m.dev_settings_restart_hint()}
+            </p>
+          )}
+        </SettingsSection>
+
+        {saving && <p className="alm-dev-contracts-page__export-result">{m.dev_settings_saving()}</p>}
+      </div>
+    </PageShell>
+  );
+}

--- a/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
+++ b/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
@@ -463,7 +463,7 @@ export function EditProjectPane({ project, onClose }: EditProjectPaneProps) {
                   key={ch.label}
                   className={`alm-channel-chip alm-channel-chip--${ch.source}`}
                   title={
-                     
+
                     ch.source === 'inferred'
                       ? m.projects_edit_inferred_title()
                       : m.projects_edit_manual_title()

--- a/apps/desktop/src/features/projects/wizard/WizardPage.test.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.test.tsx
@@ -392,4 +392,3 @@ describe('T078c: create project end-to-end', () => {
     expect(mockCallCreateProject).not.toHaveBeenCalled();
   });
 });
-

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
@@ -119,7 +119,7 @@ export function ResolverSettingsControl({ compact = false }: ResolverSettingsCon
       {!compact && (
         <>
           <SettingsRow
-             
+
             label={<label htmlFor={endpointId}>{m.settings_resolver_endpoint_label()}</label>}
             info={m.settings_resolver_tapurl_info()}
           >
@@ -136,7 +136,7 @@ export function ResolverSettingsControl({ compact = false }: ResolverSettingsCon
           </SettingsRow>
 
           <SettingsRow
-             
+
             label={<label htmlFor={debounceId}>{m.settings_resolver_debounce_label()}</label>}
             info={m.settings_resolver_debounce_info()}
           >
@@ -157,7 +157,7 @@ export function ResolverSettingsControl({ compact = false }: ResolverSettingsCon
           </SettingsRow>
 
           <SettingsRow
-             
+
             label={<label htmlFor={timeoutId}>{m.settings_resolver_timeout_label()}</label>}
             info={m.settings_resolver_timeout_info()}
           >

--- a/apps/desktop/src/ui/Toggle.tsx
+++ b/apps/desktop/src/ui/Toggle.tsx
@@ -13,7 +13,7 @@ export const Toggle = forwardRef<HTMLLabelElement, ToggleProps>(
     // readers announce the switch; the rest stay on the wrapping label.
     const { 'aria-label': ariaLabel, 'aria-labelledby': ariaLabelledby, ...labelRest } = rest;
     return (
-       
+
       <label ref={ref} className={cls} {...labelRest}>
         <input
           type="checkbox"

--- a/docs/development/077-fits-header-analysis.md
+++ b/docs/development/077-fits-header-analysis.md
@@ -1,7 +1,7 @@
 # 077 — FITS / XISF Header Analysis and Recommended Extraction Fields
 
-**Date:** 2026-06-22  
-**Author:** Analysis agent (read-only pass over /mnt/d/astrophotography)  
+**Date:** 2026-06-22
+**Author:** Analysis agent (read-only pass over /mnt/d/astrophotography)
 **Status:** Complete — implementation follow-up tracked separately
 
 ---
@@ -159,7 +159,7 @@ BAYERPAT=RGGB, BITPIX=16, BSCALE=1, BZERO=32768
 EXTEND=T, NAXIS=2, NAXIS1=3856, NAXIS2=2180, SIMPLE=T
 ```
 
-`IMAGETYP`, `EXPTIME`, `GAIN`, `CCD-TEMP`, `INSTRUME` — all **absent**.  
+`IMAGETYP`, `EXPTIME`, `GAIN`, `CCD-TEMP`, `INSTRUME` — all **absent**.
 Filename pattern: `dark_exp_{exptime}_gain_{gain}_bin_{bin}_{temp}C_stack_{count}.fits`
 
 ### 2.7 Master DARK / XISF — PixInsight WBPP output (DWARF III source)
@@ -192,7 +192,7 @@ PCL:CFASourcePattern = RGGB
 PCL:TotalExposureTime (base64-encoded float64 vector)
 ```
 
-No `GAIN`, no `SET-TEMP/CCD-TEMP`, no `STACKCNT/NCOMBINE`.  
+No `GAIN`, no `SET-TEMP/CCD-TEMP`, no `STACKCNT/NCOMBINE`.
 Integration count in HISTORY comments: `ImageIntegration.numberOfImages: 10`.
 
 ### 2.8 Master DARK / XISF — PixInsight WBPP (Poseidon-C PRO source)
@@ -354,26 +354,26 @@ The table below maps domain fields to concrete header keywords observed in the r
 
 ### Priority tiers
 
-**Tier 1 — Calibration matching (required for spec 040 accuracy):**  
+**Tier 1 — Calibration matching (required for spec 040 accuracy):**
 `OFFSET`, `CCD-TEMP`, `SET-TEMP`
 
 These are essential for matching raw calibration frames to light sessions and for
 identifying which master to apply. Without temperature, two darks with the same
 gain/exposure but different sensor temperatures are indistinguishable in metadata.
 
-**Tier 2 — Camera / equipment fingerprinting:**  
+**Tier 2 — Camera / equipment fingerprinting:**
 `XPIXSZ`, `YPIXSZ`, `BAYERPAT`, `EGAIN`
 
 Pixel size and Bayer pattern are needed for the equipment auto-detection feature
 (settings spec #53). `EGAIN` is ZWO-specific but useful for calibration scaling.
 
-**Tier 3 — Target and observation context:**  
+**Tier 3 — Target and observation context:**
 `RA`, `DEC`, `FOCALLEN`, `SWCREATE`, `DATE-END`
 
 Useful for displaying target position, planning, and provenance. Lower urgency
 for calibration matching but important for the broader library feature set.
 
-**Tier 4 — Stacking provenance (informational):**  
+**Tier 4 — Stacking provenance (informational):**
 `FLAT_CNT`, `BIAS_CNT`, `DATE-LOC`
 
 Informational only. `FLAT_CNT` is NINA-specific. Can be surfaced in the UI

--- a/docs/development/inbox-organization-state-flow.md
+++ b/docs/development/inbox-organization-state-flow.md
@@ -1,6 +1,6 @@
 # Inbox: Organization-State Decision Flow
 
-**Spec**: 041 — Inbox Plan Surface, US4 FR-019b  
+**Spec**: 041 — Inbox Plan Surface, US4 FR-019b
 **Audience**: end-user wizard explainer + developer reference
 
 ---

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -16,5 +16,16 @@ live in this directory; feature-scoped research lives under
 Each active feature records its research in its spec folder. Notable:
 
 - Spec 018 — Settings Configuration Model: [`specs/018-settings-configuration-model/research.md`](../../specs/018-settings-configuration-model/research.md) (persistence shape, audit policy, override resolution, schema versioning).
+- Spec 021 — Developer Contract Diagnostics: [`specs/021-developer-contract-diagnostics/research.md`](../../specs/021-developer-contract-diagnostics/research.md) (recording proxy, `dev-tools` compile-time feature gate, replay safety, redaction).
 
 For the full set, see `specs/*/research.md`.
+
+## Developer-mode entry point (spec 021)
+
+Dev-tools builds (Cargo feature `dev-tools` / `VITE_DEV_TOOLS=true`) register a
+hidden settings page at `/dev/settings` that toggles the `devMode` setting. It
+is deliberately absent from the command palette and from Settings › Advanced
+navigation — type the URL directly. Turning `devMode` on makes the recording
+proxy capture contract calls and exposes Developer / Contracts
+(`/dev/contracts`) via the command palette. Release builds omit the `dev-tools`
+feature, so neither route exists at runtime.

--- a/specs/021-developer-contract-diagnostics/tasks.md
+++ b/specs/021-developer-contract-diagnostics/tasks.md
@@ -204,17 +204,31 @@ correct fields.
       `MAX_PAYLOAD_BYTES=64*1024`, monotonic `state.seq` counter,
       `redactPayload()` with always-sensitive set + per-contract
       sensitiveFields. JSON-length check for truncation._
-- [ ] T021 [US2] Install the wrapped dispatcher at app boot only when
+- [x] T021 [US2] Install the wrapped dispatcher at app boot only when
       `devMode = true`; bypass at module load otherwise. Wire in
       `apps/desktop/src/data/tauriDispatch.ts` (or current dispatcher
       module).
-      _Deferred: The existing `commands.ts` `invoke()` function is a private
-      module-scoped function — wrapping it at boot requires either exposing it
-      or restructuring the API layer. The ring buffer and recorder are fully
-      implemented and tested; wiring at boot dispatch is a follow-up.
-      `ContractsPage` calls `devCallsList` directly (reading from the
-      Rust-side `CallBuffer` state) so the page works without T021. T021
-      would enable auto-capture of all calls._
+      _Evidence (audit 2026-07-04, impl-021-tail): superseded by spec 037's
+      IPC migration (PR #378, `9ab16f46`/`eea705a0` "feat(037): migrate
+      dev-tools area to generated IPC bindings"), which replaced the old
+      `commands.ts` with the generated `bindings/index.ts` + `api/ipc.ts`
+      dispatcher and added the exact boot-wiring this task called for.
+      `apps/desktop/src/dev/bootRecorder.ts` `installRecorder()` reads the
+      backend `devMode` setting, and when true builds the real Tauri
+      `invoke` as the base dispatch, wraps it via `recorder.wrap()`, and
+      installs it via `setInvokeOverride()` in `apps/desktop/src/api/ipc.ts`.
+      Wired at boot in `apps/desktop/src/main.tsx`:
+      `if (import.meta.env.VITE_DEV_TOOLS === 'true') { import('./dev/bootRecorder')... }`
+      — statically false (and tree-shaken) in release builds. Covered by
+      `apps/desktop/src/dev/devSurface.capture.test.ts` (T073, 5 tests: wrap
+      captures calls, no-op when devMode=false, ordering, setInvokeOverride
+      wiring, absolute-path requirement) and
+      `apps/desktop/src/dev/devSurface.release.test.ts` (T072, 4 tests:
+      DEV_TOOLS_ENABLED false by default, wrap no-op, setInvokeOverride(null)
+      safe, route not registered). Full suite green: `pnpm test` — 107 files,
+      1023 tests passed. This was a stale not-implemented claim; the previous
+      deferral note (about `commands.ts` being a private module-scoped
+      function) no longer applies post-037._
 - [x] T022 [US2] Implement `list_calls` use case to read the buffer over a
       Tauri state handle and the Tauri command `dev_calls_list`.
       _Evidence: `list_calls` in `dev_contracts.rs`; `dev_calls_list` Tauri

--- a/specs/021-developer-contract-diagnostics/tasks.md
+++ b/specs/021-developer-contract-diagnostics/tasks.md
@@ -339,15 +339,18 @@ frame appears in the flame chart.
       import gating (so the module file is never parsed) requires a Vite
       `define` constant (see T036 TODO); that level of tree-shaking is
       deferred._
-- [ ] T032 [US4] Add the hidden settings page that toggles `devMode`
+- [x] T032 [US4] Add the hidden settings page that toggles `devMode`
       (reachable by typing the full URL only) and document the URL in
       `docs/research/`. This page is rendered ONLY when the `dev-tools`
       Cargo feature is compiled in (gated at the component level via a
       compile-time constant injected by the build). (A-021-2, R-DevFeature)
-      _Deferred: `devMode` is already toggleable via Settings › Advanced
-      (spec 018 scope). A dedicated hidden URL page adds discoverability
-      but is not required for the core diagnostics surface to function.
-      Follow-up iteration._
+      _Evidence: `apps/desktop/src/dev/DevSettingsPage.tsx` (+ unit tests
+      in `DevSettingsPage.test.tsx`), `devSettingsRoute` registered in
+      `apps/desktop/src/app/router.tsx` behind the same `DEV_TOOLS_ENABLED`
+      compile-time constant as `devContractsRoute` (mirrors the `dev-tools`
+      Cargo feature); deliberately absent from `DEV_PAGES` and Settings
+      navigation. URL documented in `docs/research/index.md`
+      ("Developer-mode entry point (spec 021)")._
 - [ ] T033 [US4] Quickstart pass: enable `devMode`, open Cmd+K, navigate
       to `/dev/contracts`, trigger five calls of mixed outcomes, view a
       schema, replay a read-only call, then disable `devMode` and
@@ -371,10 +374,12 @@ frame appears in the flame chart.
       _Evidence: `dev_export` Tauri command in `commands/dev.rs`;
       `packages/contracts/dev/dev.export.json` mirrored; `devExport` in
       `api/commands.ts`; export button wired in `ContractsPage.tsx`._
-- [ ] T035 Update `docs/research/` index to point at this feature's
+- [x] T035 Update `docs/research/` index to point at this feature's
       `research.md`.
-      _Deferred: docs/research/ index update is a documentation task;
-      leaving for main thread post-implementation._
+      _Evidence: `docs/research/index.md` links
+      `specs/021-developer-contract-diagnostics/research.md` under
+      "Feature research decisions" and documents the hidden `/dev/settings`
+      entry point._
 
 ## Phase 8: Compile-Time Feature Flag Tasks (R-DevFeature)
 


### PR DESCRIPTION
## Summary
- Adds a hidden `/dev/settings` page (dev-tools builds only) where a developer can switch developer mode on before any other diagnostics surface is visible. It is reachable only by typing the URL — never from Settings or the command palette — and release builds omit it entirely at compile time.
- Documents the entry point in the research docs index and corrects a stale task-status claim (the contract-call recorder boot-wiring already shipped with the IPC migration).
- Lint hygiene: `just lint`'s repo-wide pre-commit pass is now green and idempotent — typos exceptions for legitimate tokens (Bayer star designations, haversine, SQL-keyword plurals), whitespace fixers no longer touch generated outputs (specta bindings, seed catalog) that CI's drift gate compares byte-for-byte, and whitespace-only fixes applied to six hand-written files.

## What's new
- Toggling developer mode on makes the recording proxy capture contract calls and exposes Developer / Contracts via the command palette; toggling it off stops recording immediately, with a hint that a restart fully removes the proxy.
- 5 unit tests cover read-on-mount, toggle persistence, restart hint, and error surfacing.

## Still open (recorded in the spec's tasks.md)
- Contract hash mismatch computation (fields exist, populated as absent in v1).
- Manual quickstart smoke pass on the running Windows app.

## Gates
- `just lint` — green (fmt, clippy -D warnings, eslint, pre-commit --all-files)
- `just typecheck` — green
- `pnpm test` (apps/desktop) — 109 files / 1035 tests green
- `cargo test -p app_core --features dev-tools` — green

## Spec Context
- Spec: 021 (Developer Contract Diagnostics) — tail close-out (T021 evidence, T032, T035)
- Branch: impl-021-tail