### PR TITLE
fix: recover detected output files that were invisible to projects, cleanup, and archive plans

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -727,6 +727,28 @@ pub fn run_app(app: tauri::App, pool: SqlitePool) {
     // project drawer opens/closes. No watcher runs until a project is attached.
     let artifact_watcher_registry = crate::watcher::new_artifact_watcher_registry();
     app.manage(artifact_watcher_registry);
+    // spec 012 (WP-012-A): one-time, idempotent fix-up for `processing_artifacts`
+    // rows the retired global root watcher (pre-#400) keyed by a library-root id
+    // instead of the owning project's id. Runs once per app start, before any
+    // per-project watcher attaches and records new (correctly-attributed) rows.
+    {
+        let fixup_pool = pool.clone();
+        tokio::spawn(async move {
+            match app_core::artifact::reattribute_root_keyed_artifacts(&fixup_pool).await {
+                Ok((fixed, unmatched)) => {
+                    if fixed > 0 || unmatched > 0 {
+                        tracing::info!(
+                            "artifact re-attribution fix-up: {fixed} row(s) corrected, \
+                             {unmatched} row(s) left flagged (no matching project)"
+                        );
+                    }
+                }
+                Err(e) => {
+                    tracing::warn!("artifact re-attribution fix-up failed: {e:?}");
+                }
+            }
+        });
+    }
 
     // spec 018 T020: emit a settings.snapshot at session start, then every 5 minutes.
     // This gives the audit log a durable record of the active configuration even when

--- a/crates/app/core/tests/tools_artifacts_integration.rs
+++ b/crates/app/core/tests/tools_artifacts_integration.rs
@@ -285,3 +285,282 @@ async fn launch_wiring_with_fake_spawner_persists_row() {
 
     assert_eq!(count, 1, "expected 1 tool_launches row with outcome='spawned', found {count}");
 }
+
+/// Like `insert_projects_row`, but with a caller-supplied `name` so a single
+/// test can register more than one project (the `projects` table has a
+/// `UNIQUE(name)` constraint that the shared helper's hardcoded name would
+/// otherwise violate).
+async fn insert_named_project_row(pool: &sqlx::SqlitePool, name: &str, path: &str) -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+         VALUES (?, ?, 'PixInsight', 'setup_incomplete', ?, NULL, 0, \
+                 '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+    )
+    .bind(&id)
+    .bind(name)
+    .bind(path)
+    .execute(pool)
+    .await
+    .expect("insert named projects row");
+    id
+}
+
+// ── WP-012-A: path → project attribution (watcher mis-attribution fix) ───────
+//
+// The retired global artifact watcher (spec 033 T028, replaced by #400's
+// per-project watchers) watched entire registered library roots, not a
+// single project's output folder, and stored the watched ROOT's id as
+// `project_id` verbatim — a placeholder that never matched a real
+// project, so watcher-detected artifacts never surfaced in `artifact.list` /
+// the Tool Launches accordion. These tests exercise the real DB-backed
+// resolver (`artifact::resolve_project_id_for_path`) and the one-time
+// re-attribution fix-up (`artifact::reattribute_root_keyed_artifacts`) for
+// pre-existing mis-keyed rows.
+
+/// A root can contain multiple projects; the resolver must pick the project
+/// that actually owns the path (longest-prefix match), not just any project
+/// under the same root.
+#[tokio::test]
+async fn resolve_project_id_for_path_picks_the_owning_project_under_a_shared_root() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    let root_dir = tempfile::tempdir().expect("tempdir");
+    let root_path = root_dir.path().to_str().expect("utf-8").to_owned();
+    insert_library_root(pool, &root_path).await;
+
+    let m31_dir = root_dir.path().join("projects").join("M31");
+    let ngc7000_dir = root_dir.path().join("projects").join("NGC7000");
+    std::fs::create_dir_all(&m31_dir).expect("mkdir project M31");
+    std::fs::create_dir_all(&ngc7000_dir).expect("mkdir project NGC7000");
+
+    let m31_project_id =
+        insert_named_project_row(pool, "M31 Project", m31_dir.to_str().expect("utf-8")).await;
+    let ngc7000_project_id =
+        insert_named_project_row(pool, "NGC7000 Project", ngc7000_dir.to_str().expect("utf-8"))
+            .await;
+
+    let artifact_path = ngc7000_dir.join("MasterFlat_bin1x1.xisf");
+    std::fs::write(&artifact_path, b"fake").expect("write artifact file");
+
+    let resolved =
+        artifact::resolve_project_id_for_path(pool, artifact_path.to_str().expect("utf-8"))
+            .await
+            .expect("resolve_project_id_for_path");
+
+    assert_eq!(
+        resolved,
+        Some(ngc7000_project_id),
+        "must resolve to the project actually owning the path, not {m31_project_id}"
+    );
+}
+
+/// A path that falls under a registered root but outside every registered
+/// project's folder must resolve to `None` — the resolver must never
+/// fabricate an attribution.
+#[tokio::test]
+async fn resolve_project_id_for_path_returns_none_when_no_project_claims_it() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    let root_dir = tempfile::tempdir().expect("tempdir");
+    let root_path = root_dir.path().to_str().expect("utf-8").to_owned();
+    insert_library_root(pool, &root_path).await;
+
+    let project_dir = root_dir.path().join("projects").join("M31");
+    std::fs::create_dir_all(&project_dir).expect("mkdir project");
+    insert_projects_row(pool, project_dir.to_str().expect("utf-8")).await;
+
+    // A file living directly under the root, outside any project folder
+    // (e.g. still-unsorted inbox content).
+    let unsorted_dir = root_dir.path().join("unsorted");
+    std::fs::create_dir_all(&unsorted_dir).expect("mkdir unsorted");
+    let stray_path = unsorted_dir.join("random.fits");
+    std::fs::write(&stray_path, b"fake").expect("write stray file");
+
+    let resolved = artifact::resolve_project_id_for_path(pool, stray_path.to_str().expect("utf-8"))
+        .await
+        .expect("resolve_project_id_for_path");
+
+    assert!(resolved.is_none(), "path outside every project must not resolve to any project");
+}
+
+/// End-to-end regression guard for the original bug: simulating the fixed
+/// watcher flow (resolve, then detect) must persist the artifact under the
+/// real project id — never under the root's id.
+#[tokio::test]
+async fn watcher_flow_attributes_artifact_to_real_project_not_root_id() {
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+
+    let root_dir = tempfile::tempdir().expect("tempdir");
+    let root_path = root_dir.path().to_str().expect("utf-8").to_owned();
+    insert_library_root(pool, &root_path).await;
+    let root_id: String = sqlx::query_scalar("SELECT id FROM library_root WHERE current_path = ?")
+        .bind(&root_path)
+        .fetch_one(pool)
+        .await
+        .expect("read back root id");
+
+    let project_dir = root_dir.path().join("projects").join("M31");
+    std::fs::create_dir_all(&project_dir).expect("mkdir project");
+    let project_id = insert_projects_row(pool, project_dir.to_str().expect("utf-8")).await;
+
+    let artifact_path = project_dir.join("MasterDark_bin1x1.xisf");
+    std::fs::write(&artifact_path, b"fake").expect("write artifact file");
+    let path_str = artifact_path.to_str().expect("utf-8").to_owned();
+
+    // Mirror the watcher's fixed flow: resolve first, then call detect with
+    // the resolved id (never the root id).
+    let resolved_project_id = artifact::resolve_project_id_for_path(pool, &path_str)
+        .await
+        .expect("resolve_project_id_for_path")
+        .expect("a project should own this path");
+    assert_eq!(resolved_project_id, project_id);
+    assert_ne!(resolved_project_id, root_id, "must never attribute to the root's id");
+
+    artifact::detect(
+        pool,
+        &bus,
+        &resolved_project_id,
+        &path_str,
+        "pixinsight",
+        4096,
+        "2026-07-03T09:58:00Z",
+        "2026-07-03T10:00:00Z",
+    )
+    .await
+    .expect("artifact::detect");
+
+    let artifacts = artifact::list(pool, &project_id, &[]).await.expect("artifact::list");
+    assert_eq!(artifacts.len(), 1);
+    assert_eq!(artifacts[0].project_id, project_id);
+
+    // Querying by the (wrong) root id must return nothing — proving the
+    // artifact is NOT hidden under the root id anymore.
+    let under_root = artifact::list(pool, &root_id, &[]).await.expect("artifact::list");
+    assert!(under_root.is_empty(), "artifact must not be attributed to the root id");
+}
+
+/// One-time re-attribution fix-up: a legacy row keyed by the ROOT's id (the
+/// pre-fix bug) must be corrected to the real project id, and a second pass
+/// must be a no-op (idempotent).
+#[tokio::test]
+async fn reattribute_root_keyed_artifacts_fixes_legacy_rows_idempotently() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    let root_dir = tempfile::tempdir().expect("tempdir");
+    let root_path = root_dir.path().to_str().expect("utf-8").to_owned();
+    insert_library_root(pool, &root_path).await;
+    let root_id: String = sqlx::query_scalar("SELECT id FROM library_root WHERE current_path = ?")
+        .bind(&root_path)
+        .fetch_one(pool)
+        .await
+        .expect("read back root id");
+
+    let project_dir = root_dir.path().join("projects").join("M31");
+    std::fs::create_dir_all(&project_dir).expect("mkdir project");
+    let project_id = insert_projects_row(pool, project_dir.to_str().expect("utf-8")).await;
+
+    let artifact_path = project_dir.join("MasterDark_bin1x1.xisf");
+    std::fs::write(&artifact_path, b"fake").expect("write artifact file");
+    let path_str = artifact_path.to_str().expect("utf-8").to_owned();
+
+    // Simulate a legacy row created by the pre-fix watcher: project_id is
+    // actually the root's id.
+    let artifact_id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO processing_artifacts \
+         (id, project_id, tool_launch_id, path, kind, tool, detected_at, last_seen_at, state, \
+          classification_confidence, classification_source, size_bytes, file_mtime, content_hash) \
+         VALUES (?, ?, NULL, ?, 'intermediate', 'pixinsight', '2026-07-01T00:00:00Z', \
+                 '2026-07-01T00:00:00Z', 'present', 0.1, 'fallback', 4096, \
+                 '2026-07-01T00:00:00Z', NULL)",
+    )
+    .bind(&artifact_id)
+    .bind(&root_id)
+    .bind(&path_str)
+    .execute(pool)
+    .await
+    .expect("insert legacy mis-keyed artifact row");
+
+    // First pass: must correct the row.
+    let (fixed, unmatched) = artifact::reattribute_root_keyed_artifacts(pool)
+        .await
+        .expect("reattribute_root_keyed_artifacts");
+    assert_eq!(fixed, 1, "expected exactly one legacy row to be corrected");
+    assert_eq!(unmatched, 0);
+
+    let (stored_project_id,): (String,) =
+        sqlx::query_as("SELECT project_id FROM processing_artifacts WHERE id = ?")
+            .bind(&artifact_id)
+            .fetch_one(pool)
+            .await
+            .expect("read back artifact row");
+    assert_eq!(stored_project_id, project_id, "row must now be keyed to the real project");
+
+    // Second pass: idempotent no-op — the row is no longer root-keyed.
+    let (fixed_again, unmatched_again) = artifact::reattribute_root_keyed_artifacts(pool)
+        .await
+        .expect("reattribute_root_keyed_artifacts (second pass)");
+    assert_eq!(fixed_again, 0, "second pass must not re-touch an already-corrected row");
+    assert_eq!(unmatched_again, 0);
+}
+
+/// A legacy root-keyed row whose path no longer matches any registered
+/// project must be left as-is (not deleted) and reported as unmatched.
+#[tokio::test]
+async fn reattribute_root_keyed_artifacts_leaves_unmatched_rows_in_place() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+
+    let root_dir = tempfile::tempdir().expect("tempdir");
+    let root_path = root_dir.path().to_str().expect("utf-8").to_owned();
+    insert_library_root(pool, &root_path).await;
+    let root_id: String = sqlx::query_scalar("SELECT id FROM library_root WHERE current_path = ?")
+        .bind(&root_path)
+        .fetch_one(pool)
+        .await
+        .expect("read back root id");
+
+    // No project registered at all — the stray path can never resolve.
+    let stray_dir = root_dir.path().join("unsorted");
+    std::fs::create_dir_all(&stray_dir).expect("mkdir unsorted");
+    let stray_path = stray_dir.join("random.fits");
+    std::fs::write(&stray_path, b"fake").expect("write stray file");
+    let stray_path_str = stray_path.to_str().expect("utf-8").to_owned();
+
+    let artifact_id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO processing_artifacts \
+         (id, project_id, tool_launch_id, path, kind, tool, detected_at, last_seen_at, state, \
+          classification_confidence, classification_source, size_bytes, file_mtime, content_hash) \
+         VALUES (?, ?, NULL, ?, 'intermediate', 'pixinsight', '2026-07-01T00:00:00Z', \
+                 '2026-07-01T00:00:00Z', 'present', 0.1, 'fallback', 4096, \
+                 '2026-07-01T00:00:00Z', NULL)",
+    )
+    .bind(&artifact_id)
+    .bind(&root_id)
+    .bind(&stray_path_str)
+    .execute(pool)
+    .await
+    .expect("insert legacy mis-keyed artifact row");
+
+    let (fixed, unmatched) = artifact::reattribute_root_keyed_artifacts(pool)
+        .await
+        .expect("reattribute_root_keyed_artifacts");
+    assert_eq!(fixed, 0);
+    assert_eq!(unmatched, 1, "unresolvable row must be flagged, not silently dropped");
+
+    // The row must still exist, untouched (still root-keyed) — not deleted.
+    let (stored_project_id,): (String,) =
+        sqlx::query_as("SELECT project_id FROM processing_artifacts WHERE id = ?")
+            .bind(&artifact_id)
+            .fetch_one(pool)
+            .await
+            .expect("row must still exist");
+    assert_eq!(stored_project_id, root_id, "unmatched row must be left as-is, not deleted");
+}

--- a/crates/app/lifecycle/src/artifact.rs
+++ b/crates/app/lifecycle/src/artifact.rs
@@ -9,6 +9,12 @@
 //! - [`reconcile`]      — on-attach rescan: detect new files + mark gone files as missing.
 //! - [`reattribute`]    — back-fill `tool_launch_id` after a new `tool.launch` event (T022b).
 //! - [`complete_run`]   — set `ToolLaunch.completed_at` and emit `workflow.run_completed` (T022c).
+//! - [`resolve_project_id_for_path`] — path→project attribution by
+//!   longest-prefix match against registered project roots (spec 012,
+//!   package WP-012-A).
+//! - [`reattribute_root_keyed_artifacts`] — one-time idempotent startup
+//!   fix-up for rows the retired global watcher (pre-#400) keyed by
+//!   library-root id instead of project id (WP-012-A).
 //!
 //! ## Architecture
 //!
@@ -33,13 +39,16 @@ use audit::event_bus::{
 };
 use domain_core::ids::{new_id, Timestamp};
 use sqlx::SqlitePool;
+use std::path::{Path, PathBuf};
 use time::OffsetDateTime;
 use workflow_artifacts::{
-    attribute, classify, default_artifact_rules, ArtifactKind, LaunchRef,
-    DEFAULT_ATTRIBUTION_WINDOW,
+    attribute, classify, default_artifact_rules, resolve_project_for_path, ArtifactKind, LaunchRef,
+    ProjectPathRef, DEFAULT_ATTRIBUTION_WINDOW,
 };
 
 use persistence_db::repositories::artifacts::{self as repo, ArtifactRow, InsertArtifact};
+use persistence_db::repositories::inventory::list_all_roots;
+use persistence_db::repositories::projects::list_projects;
 use persistence_db::repositories::tool_launches::{self as tl_repo};
 
 use contracts_core::tools::ArtifactSummary;
@@ -48,6 +57,125 @@ use contracts_core::tools::ArtifactSummary;
 
 fn parse_dt(s: &str) -> Option<OffsetDateTime> {
     OffsetDateTime::parse(s, &time::format_description::well_known::Rfc3339).ok()
+}
+
+/// Canonicalize `p`, falling back to `p` unchanged when canonicalization
+/// fails (path does not exist yet, permission error, etc). Mirrors the
+/// existing convention in `app_core::tool_launch`'s cwd-containment check so
+/// the two resolution paths agree on what "under this project" means.
+fn canonicalize_or_self(p: &Path) -> PathBuf {
+    p.canonicalize().unwrap_or_else(|_| p.to_path_buf())
+}
+
+// ── Path → project attribution (spec 012, WP-012-A) ──────────────────────────
+
+/// Resolve the id of the project that owns `artifact_path`, by longest-prefix
+/// match against every registered project's root path.
+///
+/// Used by [`reattribute_root_keyed_artifacts`] to determine the real
+/// `project_id` for rows the retired global watcher (pre-#400) keyed by the
+/// library-root id verbatim (the WP-012-A bug). The live per-project watcher
+/// (`apps/desktop/src-tauri/src/watcher.rs`) no longer needs event-time
+/// resolution — it knows its project at attach time — so this resolver's
+/// remaining runtime consumer is the startup fix-up.
+///
+/// Returns `Ok(None)` when no registered project's root contains the path —
+/// callers MUST NOT fabricate an id in that case; spec 012's data model has
+/// no "unattributed project" placeholder (`processing_artifacts.project_id`
+/// is `NOT NULL`, migration 0025) and its user stories are scoped to "a
+/// project's output folder", so a path outside every known project was never
+/// something this feature promised to track.
+///
+/// # Errors
+/// Returns `Err(String)` on DB failure.
+pub async fn resolve_project_id_for_path(
+    pool: &SqlitePool,
+    artifact_path: &str,
+) -> Result<Option<String>, String> {
+    let projects =
+        list_projects(pool).await.map_err(|e| format!("DB list projects failed: {e}"))?;
+    if projects.is_empty() {
+        return Ok(None);
+    }
+
+    let canon_artifact = canonicalize_or_self(Path::new(artifact_path));
+    let artifact_str = canon_artifact.to_string_lossy().into_owned();
+
+    let refs: Vec<ProjectPathRef> = projects
+        .iter()
+        .map(|p| ProjectPathRef {
+            id: p.id.clone(),
+            path: canonicalize_or_self(Path::new(&p.path)).to_string_lossy().into_owned(),
+        })
+        .collect();
+
+    Ok(resolve_project_for_path(&artifact_str, &refs))
+}
+
+/// One-time, idempotent fix-up for `processing_artifacts` rows that the
+/// pre-fix watcher keyed by a *library root* id instead of the owning
+/// project's id (WP-012-A). A genuine project id is a UUID from
+/// [`domain_core::ids::new_id`] and will never coincide with a
+/// `library_root.id`, so any row whose `project_id` matches a real root id
+/// is unambiguously mis-attributed.
+///
+/// For each such row, re-resolves the owning project from the artifact's
+/// stored path (same algorithm as [`resolve_project_id_for_path`]) and
+/// updates `project_id` in place. Rows whose path no longer matches any
+/// registered project are left untouched (never deleted) and logged via
+/// `tracing::warn` so they stay investigable.
+///
+/// Idempotent: once a row is corrected its `project_id` is a real project id
+/// (not a root id), so a second pass skips it. Safe to run on every app
+/// startup.
+///
+/// Returns `(re_attributed_count, still_unmatched_count)`.
+///
+/// # Errors
+/// Returns `Err(String)` on DB failure.
+pub async fn reattribute_root_keyed_artifacts(pool: &SqlitePool) -> Result<(usize, usize), String> {
+    let roots = list_all_roots(pool).await.map_err(|e| format!("DB list roots failed: {e}"))?;
+    if roots.is_empty() {
+        return Ok((0, 0));
+    }
+    let root_ids: std::collections::HashSet<&str> = roots.iter().map(|r| r.id.as_str()).collect();
+
+    let identities = repo::list_all_artifact_identities(pool)
+        .await
+        .map_err(|e| format!("DB list artifact identities failed: {e}"))?;
+
+    let mut fixed = 0usize;
+    let mut unmatched = 0usize;
+    for identity in identities {
+        if !root_ids.contains(identity.project_id.as_str()) {
+            // Already keyed to a real project (or already fixed by a prior pass).
+            continue;
+        }
+
+        let Some(real_project_id) = resolve_project_id_for_path(pool, &identity.path).await? else {
+            unmatched += 1;
+            tracing::warn!(
+                "artifact re-attribution: artifact {} at '{}' still has a library-root id \
+                 ({}) as project_id and no registered project claims its path; left as-is \
+                 (not deleted)",
+                identity.id,
+                identity.path,
+                identity.project_id
+            );
+            continue;
+        };
+
+        if let Err(e) = repo::set_project_id(pool, &identity.id, &real_project_id).await {
+            tracing::warn!(
+                "artifact re-attribution: failed to update artifact {} to project {}: {e}",
+                identity.id,
+                real_project_id
+            );
+            continue;
+        }
+        fixed += 1;
+    }
+    Ok((fixed, unmatched))
 }
 
 // ── detect ────────────────────────────────────────────────────────────────────

--- a/crates/persistence/db/src/repositories/artifacts.rs
+++ b/crates/persistence/db/src/repositories/artifacts.rs
@@ -250,6 +250,48 @@ pub async fn update_classification(
     Ok(())
 }
 
+/// Minimal `(id, project_id, path)` view of an artifact row, used by the
+/// spec 012 WP-012-A one-time re-attribution fix-up to find rows whose
+/// `project_id` was mistakenly set to a library-root id.
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct ArtifactIdentityRow {
+    pub id: String,
+    pub project_id: String,
+    pub path: String,
+}
+
+/// List every artifact's `(id, project_id, path)` (WP-012-A re-attribution
+/// fix-up input; small enough table that a full scan is fine).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_all_artifact_identities(pool: &SqlitePool) -> DbResult<Vec<ArtifactIdentityRow>> {
+    let rows = sqlx::query_as::<_, ArtifactIdentityRow>(
+        "SELECT id, project_id, path FROM processing_artifacts",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Update only the `project_id` of an artifact row (WP-012-A re-attribution
+/// fix-up). Leaves every other field untouched.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn set_project_id(
+    pool: &SqlitePool,
+    artifact_id: &str,
+    project_id: &str,
+) -> DbResult<()> {
+    sqlx::query("UPDATE processing_artifacts SET project_id = ? WHERE id = ?")
+        .bind(project_id)
+        .bind(artifact_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
 /// Update `tool_launch_id` for attribution (T022/T022b).
 ///
 /// # Errors

--- a/crates/workflow/artifacts/src/lib.rs
+++ b/crates/workflow/artifacts/src/lib.rs
@@ -7,6 +7,8 @@
 //! - `watcher`      — stable-size debounce and extension pre-filter logic.
 //! - `reconciler`   — on-attach rescan comparing disk vs DB rows.
 //! - `attribution`  — tool-launch attribution by app-clock window.
+//! - `project_mapping` — path→project attribution (WP-012-A): longest-prefix
+//!   match of a detected path against known project root paths.
 //!
 //! All filesystem I/O and clock calls are injected via closures/traits so
 //! every module is unit-testable without real fs events or sleeps.
@@ -18,6 +20,7 @@
 pub mod attribution;
 pub mod classifier;
 pub mod default_rules;
+pub mod project_mapping;
 pub mod reconciler;
 pub mod rules;
 pub mod watcher;
@@ -26,6 +29,7 @@ pub mod watcher;
 pub use attribution::{attribute, reattribute_candidates, LaunchRef, DEFAULT_ATTRIBUTION_WINDOW};
 pub use classifier::{classify, ClassificationResult, ClassificationSource};
 pub use default_rules::all as default_artifact_rules;
+pub use project_mapping::{resolve_project_for_path, ProjectPathRef};
 pub use reconciler::{reconcile, NewDetection, ReconcileOutcome, ReconcileReport};
 pub use rules::{ArtifactKind, ArtifactRule, MatchKind};
 pub use watcher::{

--- a/crates/workflow/artifacts/src/project_mapping.rs
+++ b/crates/workflow/artifacts/src/project_mapping.rs
@@ -1,0 +1,199 @@
+//! Path → project attribution (spec 012, package WP-012-A).
+//!
+//! The retired global artifact watcher (spec 033 T028, removed by #400 in
+//! favour of per-project watchers) observed entire registered library roots
+//! and stored the *root's* id as `project_id` (see `watcher.rs` history) —
+//! a placeholder that never matched a real project, so watcher-detected
+//! artifacts were recorded under an id that `artifact.list` and the UI never
+//! queried. Rows written by that watcher still exist in the wild, and any
+//! caller that only has a path (not an already-known project) needs the same
+//! resolution.
+//!
+//! This module is pure (no filesystem or DB access): it takes a candidate
+//! artifact path and a list of project root paths and returns the id of the
+//! project whose root is the longest (most specific / deepest nested)
+//! matching prefix. Callers are responsible for supplying paths in a
+//! comparable form (e.g. both canonicalized, or both raw) — see
+//! `app_core::artifact::resolve_project_id_for_path` for the DB-backed
+//! wrapper used by the startup re-attribution fix-up.
+
+use std::path::{Component, Path, PathBuf};
+
+/// A minimal (id, root path) view of a project needed for path attribution.
+#[derive(Clone, Debug)]
+pub struct ProjectPathRef {
+    pub id: String,
+    pub path: String,
+}
+
+/// Lexically normalize a path string: unify separators to `/` and collapse
+/// `.` / `..` components without touching the filesystem (no `canonicalize`
+/// — this module never does I/O).
+fn lexical_normalize(path: &str) -> PathBuf {
+    let unified = path.replace('\\', "/");
+    let mut out = PathBuf::new();
+    for component in Path::new(&unified).components() {
+        match component {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                out.pop();
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Component-wise, case-insensitive prefix check. Cross-platform safety net
+/// (Constitution / product constraints on case sensitivity): a project root
+/// registered with one case and an artifact path reported by the OS with
+/// different case (common on Windows/macOS default filesystems) must still
+/// resolve, without false-positives from naive string prefixing (e.g.
+/// `/lib/Project` must NOT match `/lib/ProjectX`).
+fn starts_with_ci(child: &Path, root: &Path) -> bool {
+    let mut child_components = child.components();
+    for root_component in root.components() {
+        let Some(child_component) = child_components.next() else {
+            return false;
+        };
+        let root_lower = root_component.as_os_str().to_string_lossy().to_lowercase();
+        let child_lower = child_component.as_os_str().to_string_lossy().to_lowercase();
+        if root_lower != child_lower {
+            return false;
+        }
+    }
+    true
+}
+
+/// Resolve which project (if any) owns `artifact_path`, choosing the
+/// longest-prefix (most deeply nested) match among all candidate project
+/// root paths.
+///
+/// Returns `None` when no project's root contains the path — callers MUST
+/// NOT fabricate an id in that case (see the spec 012 WP-012-A fix notes on
+/// `app_core::artifact::detect`).
+#[must_use]
+pub fn resolve_project_for_path(
+    artifact_path: &str,
+    projects: &[ProjectPathRef],
+) -> Option<String> {
+    let artifact_norm = lexical_normalize(artifact_path);
+
+    let mut best: Option<(usize, &str)> = None;
+    for project in projects {
+        if project.path.trim().is_empty() {
+            continue;
+        }
+        let root_norm = lexical_normalize(&project.path);
+        let depth = root_norm.components().count();
+        if depth == 0 {
+            continue;
+        }
+        let is_match =
+            artifact_norm.starts_with(&root_norm) || starts_with_ci(&artifact_norm, &root_norm);
+        if !is_match {
+            continue;
+        }
+        if best.is_none_or(|(best_depth, _)| depth > best_depth) {
+            best = Some((depth, project.id.as_str()));
+        }
+    }
+    best.map(|(_, id)| id.to_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn proj(id: &str, path: &str) -> ProjectPathRef {
+        ProjectPathRef { id: id.to_owned(), path: path.to_owned() }
+    }
+
+    #[test]
+    fn matches_single_project() {
+        let projects = vec![proj("p1", "/mnt/library/root/projects/M31")];
+        let result = resolve_project_for_path(
+            "/mnt/library/root/projects/M31/output/MasterDark.xisf",
+            &projects,
+        );
+        assert_eq!(result, Some("p1".to_owned()));
+    }
+
+    #[test]
+    fn root_with_multiple_projects_picks_the_owning_one() {
+        let projects = vec![
+            proj("p1", "/mnt/library/root/projects/M31"),
+            proj("p2", "/mnt/library/root/projects/NGC7000"),
+        ];
+        let result = resolve_project_for_path(
+            "/mnt/library/root/projects/NGC7000/output/final.tif",
+            &projects,
+        );
+        assert_eq!(result, Some("p2".to_owned()));
+    }
+
+    #[test]
+    fn nested_projects_pick_longest_prefix() {
+        // A project nested inside another project's folder tree must win
+        // over the shallower ancestor project.
+        let projects = vec![
+            proj("outer", "/mnt/library/root/projects"),
+            proj("inner", "/mnt/library/root/projects/M31/sub-project"),
+        ];
+        let result = resolve_project_for_path(
+            "/mnt/library/root/projects/M31/sub-project/output/final.tif",
+            &projects,
+        );
+        assert_eq!(result, Some("inner".to_owned()));
+    }
+
+    #[test]
+    fn no_match_returns_none() {
+        let projects = vec![proj("p1", "/mnt/library/root/projects/M31")];
+        let result =
+            resolve_project_for_path("/mnt/library/root/inbox/unsorted/random.fits", &projects);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn empty_project_list_returns_none() {
+        let result = resolve_project_for_path("/mnt/library/root/anything.fits", &[]);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn case_insensitive_fallback_matches_windows_style_drift() {
+        let projects = vec![proj("p1", "D:/Astro/Projects/M31")];
+        let result =
+            resolve_project_for_path("d:/astro/projects/m31/output/MasterFlat.xisf", &projects);
+        assert_eq!(result, Some("p1".to_owned()));
+    }
+
+    #[test]
+    fn case_insensitive_fallback_respects_component_boundary() {
+        // "Project" must not prefix-match "ProjectX" just because the
+        // lowercased strings share a prefix — component-wise comparison
+        // must not collapse to raw string starts_with.
+        let projects = vec![proj("p1", "/mnt/library/root/Project")];
+        let result =
+            resolve_project_for_path("/mnt/library/root/ProjectX/output/final.tif", &projects);
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn mixed_separators_are_normalized() {
+        let projects = vec![proj("p1", r"D:\Astro\Projects\M31")];
+        let result = resolve_project_for_path(r"D:\Astro\Projects\M31\output\final.tif", &projects);
+        assert_eq!(result, Some("p1".to_owned()));
+    }
+
+    #[test]
+    fn dotdot_traversal_in_artifact_path_is_normalized_before_matching() {
+        let projects = vec![proj("p1", "/mnt/library/root/projects/M31")];
+        let result = resolve_project_for_path(
+            "/mnt/library/root/projects/other/../M31/output/final.tif",
+            &projects,
+        );
+        assert_eq!(result, Some("p1".to_owned()));
+    }
+}

--- a/specs/012-processing-artifact-observation/tasks.md
+++ b/specs/012-processing-artifact-observation/tasks.md
@@ -60,6 +60,22 @@ and `size_bytes`.
       the T005 on-attach reconciliation pass first.
       — `apps/desktop/src-tauri/src/watcher.rs`; `apps/desktop/src-tauri/src/commands/artifacts.rs`;
         `apps/desktop/src/features/projects/artifacts.ts`; `apps/desktop/src/features/projects/ProjectDetail.tsx`
+- [x] **T008b** (WP-012-A) Repair legacy mis-attributed artifact rows. The
+      retired global watcher (pre-T008) stamped the *library-root* id into
+      `processing_artifacts.project_id`, so those rows never surfaced in
+      `artifact.list`, the Tool Launches accordion, or the spec 017
+      cleanup/archive plan generators (#389/#401, which enumerate by
+      `project_id`). Added a
+      pure longest-prefix path→project resolver (case-insensitive
+      component-wise fallback for Windows case drift) plus a one-time,
+      idempotent startup fix-up that re-keys root-keyed rows to the real
+      owning project and leaves unresolvable rows in place (flagged via
+      `tracing::warn`, never deleted). No schema change needed.
+      — `crates/workflow/artifacts/src/project_mapping.rs` (9 unit tests);
+        `app_core::artifact::{resolve_project_id_for_path, reattribute_root_keyed_artifacts}`;
+        `persistence_db::repositories::artifacts::{list_all_artifact_identities, set_project_id}`;
+        startup spawn in `apps/desktop/src-tauri/src/lib.rs`;
+        5 integration tests in `crates/app/core/tests/tools_artifacts_integration.rs`
 - [ ] **T009** Integration test: drop a known-good file into a fixture
       output folder. DEFERRED — requires notify-rs watcher runtime (GUI).
 - [ ] **T010** Integration test: delete file → rescan → expect `missing`.


### PR DESCRIPTION
## Summary
- Output files detected by an earlier version of the file watcher were recorded under the wrong owner (the library root instead of the project), so they never appeared in a project's Tool Launches list and were skipped by cleanup and archive plan generation.
- On startup the app now runs a one-time, idempotent repair that re-links those rows to the project that actually owns each file (longest-prefix path match, case-insensitive on Windows-style paths). Files whose path no longer belongs to any registered project are left untouched and logged — never deleted, never guessed.
- New detections are unaffected: since the per-project watcher rework they are already attributed correctly at detection time.

## Implementation notes (for curation)
- `workflow_artifacts::project_mapping` — pure longest-prefix path→project resolver (lexical normalization, component-wise case-insensitive fallback); 9 unit tests.
- `app_core::artifact::resolve_project_id_for_path` + `reattribute_root_keyed_artifacts` — DB-backed resolver + startup fix-up; runs before any per-project watcher attaches.
- 5 integration tests in `crates/app/core/tests/tools_artifacts_integration.rs`. No schema change / migration; rows updated in place.
- Reconciled vs #400: the rescue branch's event-time path resolution in `watcher.rs` was dropped as superseded (per-project watchers know their project at attach time); `watcher.rs` is untouched.
- Ticks T008b in `specs/012-processing-artifact-observation/tasks.md`; no previously open task ID is closed (T009/T010/T026 need the GUI watcher runtime).

## Gates
- `cargo fmt` / `cargo clippy --workspace --all-targets -- -D warnings`: pass
- eslint + token checks, `just typecheck`, `just check-generated` (bindings byte-identical): pass
- `cargo test -p workflow_artifacts` (42), `-p app_core_lifecycle -p persistence_db` (237), `-p app_core --test tools_artifacts_integration` (10): pass
- `just lint`'s `pre-commit run --all-files` typos hook fails on pre-existing base content (71 typos in `assets/seed/seed.json` greek-letter aliases + one base test comment) — none in this diff; flagged files verified identical to `origin/redesign-ui-platevault`.

## Spec Context
- Spec: 012
- Branch: impl-012a-attribution-v2