### PR TITLE
test: fix flaky settings tests that failed intermittently in CI

### DIFF
--- a/apps/desktop/src/features/settings/CalibrationMatching.test.tsx
+++ b/apps/desktop/src/features/settings/CalibrationMatching.test.tsx
@@ -50,6 +50,18 @@ function offsetToggleInput(): HTMLElement {
   return within(row).getByRole('checkbox');
 }
 
+/** The Camera row's toggle checkbox — used as a hydration marker: tests mock
+ *  `requireSameCamera: false` (differing from the in-code default `true`) so
+ *  waiting for this toggle to become unchecked proves the fetched tolerances
+ *  have been applied. Waiting on the Offset toggle alone is racy, because the
+ *  in-code default (`requireSameOffset: true`) already satisfies "checked"
+ *  before hydration lands. */
+function cameraToggleInput(): HTMLElement {
+  const row = screen.getByText('Camera').closest('tr');
+  if (!row) throw new Error('Camera row not found');
+  return within(row).getByRole('checkbox');
+}
+
 beforeEach(() => {
   vi.clearAllMocks();
 });
@@ -67,11 +79,17 @@ describe('CalibrationMatching — offset match-required persistence', () => {
   });
 
   it('persists the offset toggle via calibration.tolerances.update, not just local state', async () => {
-    mockGet.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: true }) });
+    mockGet.mockResolvedValue({
+      status: 'ok',
+      data: makeTolerances({ requireSameCamera: false, requireSameOffset: true }),
+    });
     mockUpdate.mockResolvedValue({ status: 'ok', data: makeTolerances({ requireSameOffset: false }) });
 
     render(<CalibrationMatching save={vi.fn()} />);
-    await waitFor(() => expect(offsetToggleInput()).toBeChecked());
+    // Wait for hydration (camera flips to the fetched non-default value), not
+    // just the offset toggle — the in-code default already renders it checked.
+    await waitFor(() => expect(cameraToggleInput()).not.toBeChecked());
+    expect(offsetToggleInput()).toBeChecked();
 
     fireEvent.click(offsetToggleInput());
 
@@ -89,7 +107,11 @@ describe('CalibrationMatching — offset match-required persistence', () => {
     mockUpdate.mockResolvedValue({ status: 'ok', data: makeTolerances() });
 
     render(<CalibrationMatching save={vi.fn()} />);
-    await waitFor(() => expect(offsetToggleInput()).toBeChecked());
+    // Hydration marker: camera arrives as false (non-default). Waiting on the
+    // offset toggle alone races the fetch — its in-code default is already
+    // checked, so an early click would persist the *default* camera value.
+    await waitFor(() => expect(cameraToggleInput()).not.toBeChecked());
+    expect(offsetToggleInput()).toBeChecked();
 
     fireEvent.click(offsetToggleInput());
 

--- a/apps/desktop/src/features/settings/Ingestion.test.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.test.tsx
@@ -102,8 +102,9 @@ describe('Ingestion', () => {
       data: { ...SETTINGS, followSymlinks: true, hashingMode: 'eager' },
     });
     render(<Ingestion save={vi.fn()} />);
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
-    expect(screen.getByLabelText('Follow symbolic links')).toBeChecked();
+    // Wait for the fetched (non-default) value to be applied, not merely for
+    // the get call to fire — asserting right after the call races hydration.
+    await waitFor(() => expect(screen.getByLabelText('Follow symbolic links')).toBeChecked());
 
     const restoreBtn = screen.getByText('Restore defaults');
     await act(async () => {


### PR DESCRIPTION
Convoy-blocking flake fix. Integration (Layer 1) has been failing on random platforms across every convoy PR (#390 #396 #402 #404 #407 #408) on:

- `CalibrationMatching.test.tsx > does not persist sibling fields as a side effect of toggling offset`
- `Ingestion.test.tsx > restore defaults persists in-code defaults and re-hydrates the controls`

Root cause (both from the P8/P12 settings work, now on the redesign base): the tests wait on conditions that are already true before hydration — the offset toggle's in-code default is `checked`, and the Ingestion test waited for the get *call* rather than the applied result. Under CI load the click/assertion lands before the mocked fetch applies, so the persisted payload carries default sibling values (`requireSameCamera: true`) and the assertion fails.

Fix: wait on a hydration marker that only becomes true after the fetched data applies (Camera toggle flipping to the mocked non-default `false`; symlinks toggle rendering the fetched `true`). Also hardens the latently-racy 'persists the offset toggle' test.

Test-only change; verified 3x plus a full settings-suite pass locally.