### PR TITLE
ci: add db-boundary ratchet workflow (parked in #384)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,6 +87,14 @@ jobs:
       - name: Rust format
         run: cargo fmt --all --check
 
+      # DB boundary ratchet (parked in PR #384, wired in here): fails if raw
+      # sqlx query/exec sites outside crates/persistence/db exceed the
+      # checked-in baseline. Pure grep, no compile — runs once on Linux only
+      # per the design doc's guidance (docs/development/persistence-layer-hardening.md).
+      - name: DB boundary ratchet
+        if: runner.os == 'Linux'
+        run: just db-boundary
+
       - name: Clippy (workspace, all targets, deny warnings)
         run: cargo clippy --workspace --all-targets -- -D warnings
 


### PR DESCRIPTION
## Summary
- Wires the DB-boundary ratchet (`scripts/check-db-boundary.sh`, added in #384) into CI. The step was parked because the push token lacked `workflow` scope at the time; that's since been fixed.
- Adds a `DB boundary ratchet` step to `.github/workflows/ci.yml`'s `integration` job, right after `cargo fmt --all --check`, running `just db-boundary`. Restricted to `runner.os == 'Linux'` per the design doc's guidance (`docs/development/persistence-layer-hardening.md`) since the check is pure grep and only needs to run once.
- No changes to the ratchet script or baseline itself — #402 already refreshed the baseline; confirmed it still passes on current tip (23 files / 213 production query sites, within baseline).

## Test plan
- [x] `bash scripts/check-db-boundary.sh` passes locally on current tip
- [x] YAML parses cleanly (`yaml.safe_load`)
- [ ] CI green on this PR, including the new ratchet step