### PR TITLE
test: fix flaky TargetDetailV2 linked-sessions test that failed intermittently in CI

### DIFF
--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -33,8 +33,20 @@
  * 28. (US4) Save error shows banner message.
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { configure, render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Windows-CI headroom (same flake class as PR #412's settings hydration races):
+// every test in this file waits on content that only renders after mocked async
+// hydration (detail/sessions/projects/notes effects). The waits are already
+// deterministic — they target non-default, post-hydration content — but the
+// RTL default asyncUtilTimeout (1s) and vitest default testTimeout (5s) are
+// too tight for the very slow windows-latest runners (test 21 flaked there
+// while identical siblings passed). Raise both file-wide instead of per-test
+// so no sibling is left behind on tight defaults. Both settings are scoped to
+// this file (vitest isolates test files; vi.setConfig is per-runtime).
+configure({ asyncUtilTimeout: 10_000 });
+vi.setConfig({ testTimeout: 15_000 });
 
 // ── Hoist mocks ───────────────────────────────────────────────────────────────
 
@@ -415,13 +427,10 @@ describe('TargetDetailV2', () => {
       },
     ]));
     render(<TargetDetailV2 targetId={TARGET_ID} />);
-    // Windows CI runners are slow enough to blow the 5s default here (flaked
-    // in Integration Layer 1 on windows-latest while 22 below passed).
-    await waitFor(
-      () => expect(screen.getByText(/42 frames/i)).toBeInTheDocument(),
-      { timeout: 10_000 },
-    );
-  }, 15_000);
+    // Slow-runner headroom now comes from the file-wide configure/setConfig
+    // above (this test flaked on windows-latest while 22 below passed).
+    await waitFor(() => expect(screen.getByText(/42 frames/i)).toBeInTheDocument());
+  });
 
   it('22. (US2) clicking session row navigates to /sessions with selected=id', async () => {
     mockListTargetSessions.mockResolvedValue(ok([


### PR DESCRIPTION
## Root cause

Test 21 "(US2) linked session rows render date and frameCount" in `apps/desktop/src/features/targets/TargetDetailV2.test.tsx` timed out at vitest's default 5000ms on the very slow windows-latest runners (170s+ environment setup). The waits in this file are already deterministic — every `waitFor` targets non-default, post-hydration content fed by mocked async effects (detail/sessions/projects/notes), so this is not the assert-on-default-state race from PR #412's Camera-toggle case. After making that determinism check, the remaining failure mode is pure slow-hardware headroom: RTL's default `asyncUtilTimeout` (1s) and vitest's default `testTimeout` (5s) are too tight for those runners.

A previous spot-fix bumped only test 21 (`{ timeout: 10_000 }` + per-test `15_000`), leaving every sibling test with the identical shape (22, 24, 25, 25b, 26–30, and the hydration-gated tests 2–19) on tight defaults — the next flake waiting to happen.

## Fix (same remediation class as PR #412)

File-scoped, uniform headroom instead of per-test whack-a-mole:

- `configure({ asyncUtilTimeout: 10_000 })` — every `waitFor`/`findBy*` in the file gets generous polling headroom.
- `vi.setConfig({ testTimeout: 15_000 })` — file-wide Windows-CI test-timeout headroom (commented as such).
- Removed test 21's now-redundant per-test overrides so the file has one source of truth.

Both settings are scoped to this file (vitest isolates test files; `vi.setConfig` is per-runtime).

## Test evidence

- `vitest run src/features/targets/TargetDetailV2.test.tsx`: 32/32 passed.
- `vitest run src/features/targets/`: 150/150 passed, 0 failed suites.
- `pnpm run typecheck` (tsc --noEmit): clean, exit 0.
- `eslint` on the touched file: exit 0; the 3 `no-non-null-assertion` warnings are pre-existing on the base (verified via stash).

Do not merge manually — CI shepherd merges.