### PR TITLE
fix: project lifecycle transitions were always rejected by the backend

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -623,10 +623,11 @@ export async function mockInvoke(
     // ---------- Mutation Commands ----------
 
     case 'lifecycle_transition_apply': {
-      // Mock: always succeeds. The request carries the desired nextState inside
-      // `args.request.project.nextState` — echo it back so the UI can update.
-      const req = (_args as { request?: { project?: { nextState?: string; currentState?: string; entityId?: string } } } | undefined)
-        ?.request?.project;
+      // Mock: always succeeds. The request is the canonical FLAT discriminated
+      // envelope (issue #423): `nextState` sits beside the `entityType` tag —
+      // there is no `{ project: {...} }` wrapper. Echo it back for the UI.
+      const req = (_args as { request?: { nextState?: string; currentState?: string; entityId?: string } } | undefined)
+        ?.request;
       return {
         status: 'success',
         contractVersion: '2.0.0',

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -2547,7 +2547,6 @@ export type DataSourceTransitionRequest = DataSourceTransitionRequest_Serialize 
 export type DataSourceTransitionRequest_Deserialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: DataSourceState,
 	nextState: DataSourceState,
@@ -2558,7 +2557,6 @@ export type DataSourceTransitionRequest_Deserialize = {
 export type DataSourceTransitionRequest_Serialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: DataSourceState,
 	nextState: DataSourceState,
@@ -2857,7 +2855,6 @@ export type FileRecordTransitionRequest = FileRecordTransitionRequest_Serialize 
 export type FileRecordTransitionRequest_Deserialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: FileRecordState,
 	nextState: FileRecordState,
@@ -2868,7 +2865,6 @@ export type FileRecordTransitionRequest_Deserialize = {
 export type FileRecordTransitionRequest_Serialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: FileRecordState,
 	nextState: FileRecordState,
@@ -5487,7 +5483,6 @@ export type PlanTransitionRequest = PlanTransitionRequest_Serialize | PlanTransi
 export type PlanTransitionRequest_Deserialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: PlanState,
 	nextState: PlanState,
@@ -5498,7 +5493,6 @@ export type PlanTransitionRequest_Deserialize = {
 export type PlanTransitionRequest_Serialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: PlanState,
 	nextState: PlanState,
@@ -5522,7 +5516,6 @@ export type PreparedSourceTransitionRequest = PreparedSourceTransitionRequest_Se
 export type PreparedSourceTransitionRequest_Deserialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: PreparedSourceState,
 	nextState: PreparedSourceState,
@@ -5533,7 +5526,6 @@ export type PreparedSourceTransitionRequest_Deserialize = {
 export type PreparedSourceTransitionRequest_Serialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: PreparedSourceState,
 	nextState: PreparedSourceState,
@@ -6055,7 +6047,6 @@ export type ProjectTransitionRequest = ProjectTransitionRequest_Serialize | Proj
 export type ProjectTransitionRequest_Deserialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: ProjectState,
 	nextState: ProjectState,
@@ -6066,7 +6057,6 @@ export type ProjectTransitionRequest_Deserialize = {
 export type ProjectTransitionRequest_Serialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: ProjectState,
 	nextState: ProjectState,
@@ -6110,7 +6100,6 @@ export type ProjectionTransitionRequest = ProjectionTransitionRequest_Serialize 
 export type ProjectionTransitionRequest_Deserialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: ProjectionState,
 	nextState: ProjectionState,
@@ -6121,7 +6110,6 @@ export type ProjectionTransitionRequest_Deserialize = {
 export type ProjectionTransitionRequest_Serialize = {
 	contractVersion: string,
 	requestId: string,
-	entityType: string,
 	entityId: string,
 	currentState: ProjectionState,
 	nextState: ProjectionState,

--- a/apps/desktop/src/features/projects/lifecycleTransition.ts
+++ b/apps/desktop/src/features/projects/lifecycleTransition.ts
@@ -3,11 +3,15 @@
  *
  * Moves the `applyProjectLifecycleTransition` glue off the hand-written
  * `@/api/commands` wrapper onto the generated `commands.lifecycleTransitionApply`
- * binding (FR-004: the behaviour is moved, not dropped). The generated
- * `lifecycle.transition.apply` command is a tagged union over entity kind
- * (`{ project: {...} }` | `{ plan: {...} }` | ...); this helper builds the
- * `project` variant and unwraps the generated `Result` into the throw-on-error
- * contract callers expect.
+ * binding (FR-004: the behaviour is moved, not dropped). The wire shape is the
+ * canonical FLAT discriminated envelope from the source-of-truth contract
+ * (`packages/contracts/src/generated/lifecycle.transition.d.ts`): `entityType`
+ * is the serde tag on the backend's `TransitionRequest` and the remaining
+ * fields sit beside it — there is NO `{ project: {...} }` wrapper (issue #423:
+ * the previous wrapped payload was rejected by the backend with
+ * `missing field entityType`). This helper builds the `project` family request
+ * and unwraps the generated `Result` into the throw-on-error contract callers
+ * expect.
  */
 
 import { commands } from '@/bindings/index';
@@ -64,9 +68,16 @@ export interface LifecycleTransitionResponse {
 export async function applyProjectLifecycleTransition(
   req: ProjectLifecycleTransitionRequest,
 ): Promise<LifecycleTransitionResponse> {
+  // The cast is required because tauri-specta renders the internally-tagged
+  // `TransitionRequest` enum as an externally-wrapped union
+  // (`{ project: {...} }`) that does NOT match the serde wire format. The flat
+  // `req` (with its `entityType: 'project'` discriminator) IS the wire truth —
+  // pinned by the backend round-trip tests
+  // (`crates/contracts/core/tests/lifecycle_transition_roundtrip.rs`) and the
+  // spec-037 `lifecycle_integrity` E2E journey.
   return unwrap(
     await commands.lifecycleTransitionApply(
-      { project: req } as Parameters<typeof commands.lifecycleTransitionApply>[0],
+      req as unknown as Parameters<typeof commands.lifecycleTransitionApply>[0],
     ),
   ) as LifecycleTransitionResponse;
 }

--- a/crates/app/core/tests/lifecycle_canonical.rs
+++ b/crates/app/core/tests/lifecycle_canonical.rs
@@ -61,7 +61,6 @@ fn make_project_transition(
     TransitionRequest::Project(ProjectTransitionRequest {
         contract_version: "2.0.0".to_owned(),
         request_id: Uuid::new_v4(),
-        entity_type: "project".to_owned(),
         entity_id: project_id,
         current_state: current,
         next_state: next,

--- a/crates/app/core/tests/transition_apply.rs
+++ b/crates/app/core/tests/transition_apply.rs
@@ -72,7 +72,6 @@ fn project_request(
     TransitionRequest::Project(ProjectTransitionRequest {
         contract_version: "2.0.0".to_owned(),
         request_id: Uuid::new_v4(),
-        entity_type: "project".to_owned(),
         entity_id: id,
         current_state: from,
         next_state: to,

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -605,9 +605,10 @@ fn parse_request(request: TransitionRequest) -> Result<ParsedRequest, String> {
                 TransitionActor::User => "user".to_owned(),
                 TransitionActor::System => "system".to_owned(),
             };
-            let trigger = req.action_label.clone().unwrap_or_else(|| {
-                format!("{}: {} -> {}", req.entity_type, prior_state, next_state)
-            });
+            let trigger = req
+                .action_label
+                .clone()
+                .unwrap_or_else(|| format!("{}: {} -> {}", entity_type, prior_state, next_state));
             Ok(ParsedRequest {
                 request_id: req.request_id,
                 prior_state: prior_state.clone(),
@@ -665,7 +666,6 @@ mod tests {
         TransitionRequest::Project(ProjectTransitionRequest {
             contract_version: "2.0.0".to_owned(),
             request_id: Uuid::new_v4(),
-            entity_type: "project".to_owned(),
             entity_id: Uuid::new_v4(),
             current_state: current,
             next_state: next,

--- a/crates/contracts/core/src/lifecycle.rs
+++ b/crates/contracts/core/src/lifecycle.rs
@@ -180,14 +180,19 @@ pub enum TransitionActor {
 
 // ── Per-family request DTOs ───────────────────────────────────────────────────
 
+// NOTE (issue #423): these structs deliberately carry NO `entity_type` field.
+// The discriminant lives solely in `TransitionRequest`'s `#[serde(tag =
+// "entityType")]` attribute. A previous duplicated `entity_type: String` field
+// made the whole enum impossible to deserialize (serde consumes the tag key
+// during variant dispatch, so the inner struct's required field could never be
+// filled) and made serialization emit `entityType` twice.
 macro_rules! transition_request_base {
-    ($name:ident, $entity_type_str:literal, $state_ty:ty) => {
+    ($name:ident, $state_ty:ty) => {
         #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
         #[serde(rename_all = "camelCase")]
         pub struct $name {
             pub contract_version: String,
             pub request_id: Uuid,
-            pub entity_type: String,
             pub entity_id: Uuid,
             pub current_state: $state_ty,
             pub next_state: $state_ty,
@@ -208,7 +213,6 @@ macro_rules! transition_request_base {
                 Self {
                     contract_version: CONTRACT_VERSION.to_owned(),
                     request_id,
-                    entity_type: $entity_type_str.to_owned(),
                     entity_id,
                     current_state,
                     next_state,
@@ -220,12 +224,12 @@ macro_rules! transition_request_base {
     };
 }
 
-transition_request_base!(ProjectTransitionRequest, "project", ProjectState);
-transition_request_base!(PlanTransitionRequest, "plan", PlanState);
-transition_request_base!(DataSourceTransitionRequest, "data_source", DataSourceState);
-transition_request_base!(PreparedSourceTransitionRequest, "prepared_source", PreparedSourceState);
-transition_request_base!(ProjectionTransitionRequest, "projection", ProjectionState);
-transition_request_base!(FileRecordTransitionRequest, "file_record", FileRecordState);
+transition_request_base!(ProjectTransitionRequest, ProjectState);
+transition_request_base!(PlanTransitionRequest, PlanState);
+transition_request_base!(DataSourceTransitionRequest, DataSourceState);
+transition_request_base!(PreparedSourceTransitionRequest, PreparedSourceState);
+transition_request_base!(ProjectionTransitionRequest, ProjectionState);
+transition_request_base!(FileRecordTransitionRequest, FileRecordState);
 
 // ── Discriminated request enum ────────────────────────────────────────────────
 

--- a/crates/contracts/core/tests/lifecycle_transition_roundtrip.rs
+++ b/crates/contracts/core/tests/lifecycle_transition_roundtrip.rs
@@ -1,0 +1,66 @@
+//! Regression tests for issue #423: `TransitionRequest` must accept the
+//! canonical flat discriminated envelope from the source-of-truth contract
+//! (`packages/contracts/src/generated/lifecycle.transition.d.ts`) and must
+//! round-trip its own serialization.
+//!
+//! A previously duplicated `entity_type` field inside each variant struct
+//! collided with the enum's `#[serde(tag = "entityType")]` (serde consumes the
+//! tag during variant dispatch), which made `lifecycle.transition.apply` /
+//! `.preview` uncallable by any client: single-tag payloads failed with
+//! `missing field entityType`, and Rust-serialized output emitted the key
+//! twice and failed with `duplicate field entityType`.
+
+use contracts_core::lifecycle::{
+    ProjectState, ProjectTransitionRequest, TransitionActor, TransitionRequest,
+};
+use uuid::Uuid;
+
+/// The canonical flat wire shape (single `entityType` discriminator) must
+/// deserialize. This is exactly what the spec-037 Layer-2 E2E journey
+/// `lifecycle_integrity` sends.
+#[test]
+fn canonical_flat_envelope_deserializes() {
+    let json = serde_json::json!({
+        "entityType": "project",
+        "contractVersion": "2.0.0",
+        "requestId": "e2e00000-0000-4000-8000-000000000001",
+        "entityId": "e2e00000-0000-4000-8000-000000000002",
+        "currentState": "setup_incomplete",
+        "nextState": "ready",
+        "actionLabel": null,
+        "actor": "user",
+    });
+
+    let req: TransitionRequest =
+        serde_json::from_value(json).expect("canonical flat envelope must deserialize");
+    let TransitionRequest::Project(project) = req else {
+        panic!("expected the Project variant");
+    };
+    assert_eq!(project.current_state, ProjectState::SetupIncomplete);
+    assert_eq!(project.next_state, ProjectState::Ready);
+    assert_eq!(project.actor, TransitionActor::User);
+}
+
+/// Serialization must emit `entityType` exactly once and deserialize back to
+/// the same value (the #423 failure mode emitted it twice).
+#[test]
+fn serialization_round_trips() {
+    let req = TransitionRequest::Project(ProjectTransitionRequest::new(
+        Uuid::new_v4(),
+        Uuid::new_v4(),
+        ProjectState::SetupIncomplete,
+        ProjectState::Ready,
+        TransitionActor::User,
+    ));
+
+    let json = serde_json::to_string(&req).expect("serialize");
+    assert_eq!(
+        json.matches("\"entityType\"").count(),
+        1,
+        "entityType must appear exactly once on the wire: {json}"
+    );
+
+    let back: TransitionRequest =
+        serde_json::from_str(&json).expect("own serialization must round-trip");
+    assert_eq!(back, req);
+}

--- a/specs/002-data-lifecycle-state-model/contracts/lifecycle.transition.generated.json
+++ b/specs/002-data-lifecycle-state-model/contracts/lifecycle.transition.generated.json
@@ -114,9 +114,6 @@
           "type": "string",
           "format": "uuid"
         },
-        "entityType": {
-          "type": "string"
-        },
         "nextState": {
           "$ref": "#/$defs/DataSourceState"
         },
@@ -128,7 +125,6 @@
       "required": [
         "contractVersion",
         "requestId",
-        "entityType",
         "entityId",
         "currentState",
         "nextState",
@@ -168,9 +164,6 @@
           "type": "string",
           "format": "uuid"
         },
-        "entityType": {
-          "type": "string"
-        },
         "nextState": {
           "$ref": "#/$defs/FileRecordState"
         },
@@ -182,7 +175,6 @@
       "required": [
         "contractVersion",
         "requestId",
-        "entityType",
         "entityId",
         "currentState",
         "nextState",
@@ -235,9 +227,6 @@
           "type": "string",
           "format": "uuid"
         },
-        "entityType": {
-          "type": "string"
-        },
         "nextState": {
           "$ref": "#/$defs/PlanState"
         },
@@ -249,7 +238,6 @@
       "required": [
         "contractVersion",
         "requestId",
-        "entityType",
         "entityId",
         "currentState",
         "nextState",
@@ -288,9 +276,6 @@
           "type": "string",
           "format": "uuid"
         },
-        "entityType": {
-          "type": "string"
-        },
         "nextState": {
           "$ref": "#/$defs/PreparedSourceState"
         },
@@ -302,7 +287,6 @@
       "required": [
         "contractVersion",
         "requestId",
-        "entityType",
         "entityId",
         "currentState",
         "nextState",
@@ -343,9 +327,6 @@
           "type": "string",
           "format": "uuid"
         },
-        "entityType": {
-          "type": "string"
-        },
         "nextState": {
           "$ref": "#/$defs/ProjectState"
         },
@@ -357,7 +338,6 @@
       "required": [
         "contractVersion",
         "requestId",
-        "entityType",
         "entityId",
         "currentState",
         "nextState",
@@ -394,9 +374,6 @@
           "type": "string",
           "format": "uuid"
         },
-        "entityType": {
-          "type": "string"
-        },
         "nextState": {
           "$ref": "#/$defs/ProjectionState"
         },
@@ -408,7 +385,6 @@
       "required": [
         "contractVersion",
         "requestId",
-        "entityType",
         "entityId",
         "currentState",
         "nextState",


### PR DESCRIPTION
## Summary
- Changing a project's lifecycle state (Prepare, Mark as Processing, Mark as Completed, …) never worked: the backend rejected every request due to a serialization contract defect. This fixes the contract so lifecycle transitions apply correctly.

Closes #423. Unblocks PR #403 (spec-037 Real-UI E2E journeys), whose `lifecycle_integrity` journey exposed this and becomes the permanent regression test once both merge.

## Root cause (confirmed by round-trip probe)

`TransitionRequest` (`crates/contracts/core/src/lifecycle.rs`) is internally tagged `#[serde(tag = "entityType")]`, but every variant struct from `transition_request_base!` ALSO declared a required `entity_type` field (renamed to `entityType`). Serde consumes the tag key during variant dispatch, so **no JSON object could satisfy both**:

- canonical flat payload → `missing field entityType`
- the frontend's `{ project: req }` wrapper → `missing field entityType`
- Rust's own serialization emitted `entityType` twice and failed its own round-trip → `duplicate field entityType`

`lifecycle_transition_apply`/`_preview` were therefore uncallable by any client since the spec-002 foundation commit (`d87f9c0b`), including the real UI's project lifecycle buttons.

## Changes

- **contracts_core**: drop the duplicated `entity_type` field from the six per-family request structs — the enum tag is the sole discriminator, matching the canonical flat envelope in the source-of-truth contract (`packages/contracts/src/generated/lifecycle.transition.d.ts`).
- **app_core_lifecycle**: derive the default trigger label from the parsed `EntityType` (same string) instead of the removed DTO field; update the three struct-literal construction sites.
- **generated artifacts**: regenerate `lifecycle.transition.generated.json` + tauri-specta bindings (`just check-generated` steps).
- **frontend**: `lifecycleTransition.ts` now sends the canonical flat payload. Note: tauri-specta still renders the internally-tagged enum as a wrapped union (`{ project: {...} }`) that does not match the serde wire format — the previous code followed that wrong type. The call keeps a documented cast; the wire truth is pinned by tests.
- **mock mode**: `mocks.ts` handler updated to the flat shape.
- **regression tests**: `crates/contracts/core/tests/lifecycle_transition_roundtrip.rs` pins (1) canonical-flat-envelope deserialization (exactly what the E2E journey sends) and (2) serialize→deserialize round-trip with `entityType` appearing exactly once.

## Gates

- `cargo test -p contracts_core` (54 lib + 2 new integration) ✅
- `cargo test -p app_core_lifecycle -p app_core` (all suites, 0 failures) ✅
- `cargo clippy -p contracts_core -p app_core_lifecycle -p app_core --all-targets -- -D warnings` ✅
- `cargo fmt --all --check` ✅
- bindings regen test (`cargo test -p desktop_shell --features dev-tools --test bindings`) ✅, regenerated output committed
- `pnpm typecheck` (desktop) ✅
- vitest: `src/features/projects` (223 tests) + `src/api` (16 tests) ✅

## Follow-up (not in scope)

specta's wrapped-union rendering of internally-tagged enums (`TransitionRequest_Serialize/Deserialize` in `bindings/index.ts`) still mismatches the serde wire format — tracked as the binding-layer note in #423.
