### PR TITLE
docs: PlateVault user manual

### DIFF
--- a/docs/manual/01-getting-started.md
+++ b/docs/manual/01-getting-started.md
@@ -122,8 +122,9 @@ From each card you can:
   touched — this only removes the registration." Deletion is refused while
   other records (sessions, projects, plans) still depend on that root.
 
-Every card also offers a reveal action using your platform's native wording
-(**Show in File Explorer** on Windows, **Reveal in Finder** on macOS).
+Folder selection throughout the app uses your operating system's native
+pickers rather than ad-hoc dialogs; reveal actions elsewhere open your
+system's file manager.
 
 ## Source protection defaults
 

--- a/docs/manual/01-getting-started.md
+++ b/docs/manual/01-getting-started.md
@@ -1,0 +1,155 @@
+# Getting started
+
+The first time you launch PlateVault, it knows nothing about your library.
+The setup wizard fixes that: it asks where your data lives, which processing
+tools you use, and a few defaults — then runs an initial scan. Your files are
+never moved or copied during setup; the wizard only builds an index. As the
+confirmation step puts it: "The scan only reads file headers and builds an
+index — your files stay exactly where they are. **Nothing is moved or
+modified.**"
+
+## The setup wizard
+
+The wizard runs on first launch (or after **Restart first-run setup**, see
+below). The header shows your progress as "Setup · Step 1 of 5".
+
+[screenshot: setup wizard on Step 1 with the four source folder categories]
+
+### Step 1 — Source Folders ("Where does your data live?")
+
+Add the folders where your light frames, calibration frames, projects, and
+incoming captures are stored. Four categories are shown as compact cards:
+
+- **Light frames** (required)
+- **Calibration frames** (optional)
+- **Project** outputs (optional)
+- **Inbox** (optional) — the drop folder where new captures land before they
+  are sorted.
+
+Use **+ Add folder…** on a category to pick a directory with your operating
+system's native folder picker. For each folder you also choose its
+organization state:
+
+- **Already organized** — files stay in place; PlateVault will only catalogue
+  them (see [Catalogue-in-place](./02-inbox.md#confirming-catalogue-in-place)).
+- **Needs organizing** — files will be moved into a library structure when
+  you confirm them from the Inbox.
+
+The Inbox category has no such choice — an inbox is unorganized by
+definition. You can also pick the scan depth for each folder (**Recursive**
+or **Single level**). Duplicate paths are rejected inline ("This directory is
+already added" / "This directory is registered under {kind}"). Nothing is
+registered yet at this step — it is a working list you can still edit.
+
+### Step 2 — Processing Tools
+
+PlateVault detects installed processing tools (**PixInsight**, **Siril**)
+automatically and shows their status (**Detected** / **Not detected**). You
+can enable a tool, point at its executable with **Select binary…**, or
+**Redetect**. This step is skippable: "You can skip this step. Tool
+configuration can be changed later in Settings."
+
+### Step 3 — Configuration
+
+A few defaults you can change later in Settings:
+
+- **Appearance / theme** — the app's color theme (see
+  [Settings → Appearance](./08-settings.md#appearance)).
+- Display density — **Compact**, **Comfortable**, or **Spacious**.
+- **Default source protection** — the "protection level applied to newly
+  added source folders. Protected sources are skipped by cleanup plans unless
+  explicitly approved." If in doubt, leave this on its protective default;
+  you can relax it per source later. The safety implications are explained in
+  [The safety model](./09-safety-model.md#protected-sources).
+
+### Step 4 — Confirm ("Ready to go")
+
+A summary of your folders and tools. This is the point where things become
+real: pressing **Start scan →** registers your folders as library roots and
+starts the initial scan. The step also spells out what happens next: your
+selected folders are registered as library roots, an initial scan reads file
+headers to build the index, and light frames are grouped into acquisition
+sessions.
+
+If a required folder type is missing, the wizard blocks here: "Cannot
+complete setup: missing required folder types — {kinds}. Go back to Step 1 to
+add them."
+
+### Step 5 — Scan ("Scanning your library")
+
+Each registered folder is scanned and detected files are listed by folder,
+format, and detected type. An empty folder is fine — it simply completes with
+nothing detected. **Finish** only becomes available once every source's scan
+has finished.
+
+[screenshot: setup wizard Step 5 with per-folder scan results]
+
+Finishing lands you on the Inbox. Setup completion sticks: the next launch
+goes straight to the app.
+
+### Restarting setup later
+
+**Settings → Advanced → Restart first-run setup** reopens the wizard: "This
+reopens the source setup wizard and clears its completed status. Your
+existing sources will be pre-filled for you to review and adjust — nothing is
+deleted." This is a confirm-gated control, distinct from the guided-tour
+restart button.
+
+## Managing data sources over time
+
+After setup, your registered folders live under **Settings → Data Sources**,
+one card per root, with its category (**Raw**, **Calibration**, **Project**,
+**Inbox**), path, and last-scanned date.
+
+[screenshot: Settings → Data Sources with several source cards]
+
+From each card you can:
+
+- **Rescan** — pick up files added to the folder since the last scan.
+- **Remap…** — for a folder whose drive letter or mount point changed. The
+  **Remap root** dialog shows the **Current path**, lets you enter a **New
+  path**, and **Verify** checks a sample of known files at the new location
+  (marking each **Found** or **Not found**) without touching anything. Only
+  after verification does **Apply remap** re-point PlateVault's record.
+  PlateVault never moves files to follow a remap — it updates its own
+  bookkeeping only.
+- **Disable** / **Enable** — temporarily exclude a source: "The source will
+  be excluded from scans and ingest until re-enabled. Its history is kept."
+  Disabled sources show a **Disabled** pill; re-enabling needs no
+  confirmation.
+- **Delete** — un-register a source permanently. The confirmation is
+  explicit about scope: "…will no longer be tracked. Files on disk are never
+  touched — this only removes the registration." Deletion is refused while
+  other records (sessions, projects, plans) still depend on that root.
+
+Every card also offers a reveal action using your platform's native wording
+(**Show in File Explorer** on Windows, **Reveal in Finder** on macOS).
+
+## Source protection defaults
+
+The default protection level you chose in Step 3 lives under
+**Settings → Cleanup → Source Protection** (**Default protection**:
+**Protected**, **Normal**, or **Unprotected**). It "controls the starting
+protection level assigned to newly ingested sources" — protected sources are
+skipped by cleanup plans unless you explicitly approve their inclusion during
+plan review. You can override the level per source from its Data Sources
+card. Details in [The safety model](./09-safety-model.md#protected-sources).
+
+> **Note:** an earlier design described an eight-step wizard (with separate
+> welcome, per-category, catalog-download, and tool-detection steps). The
+> shipped wizard is the five-step flow described above; if you find older
+> screenshots or notes referring to eight steps, they describe a design that
+> never shipped.
+
+## Related journeys
+
+- [Journey 1 — First-run setup → data sources](../product/user-journeys.md#journey-1--first-run-setup--data-sources)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/003-first-run-source-setup/wizard-fresh-db-journey/scenario.md`
+- `e2e-agentic-test/003-first-run-source-setup/restart-first-run/scenario.md`
+- `e2e-agentic-test/003-first-run-source-setup/data-sources-remap-rescan/scenario.md`
+- `e2e-agentic-test/003-first-run-source-setup/data-sources-disable-delete/scenario.md`
+- `e2e-agentic-test/004-native-filesystem-controls/picker-reveal-controls/scenario.md`
+- `e2e-agentic-test/016-source-protection-defaults/protection-defaults-take-effect/scenario.md`

--- a/docs/manual/02-inbox.md
+++ b/docs/manual/02-inbox.md
@@ -1,0 +1,145 @@
+# The Inbox
+
+The Inbox is the single gate through which files enter your library. Whether
+new captures land in a drop folder that needs sorting, or you point PlateVault
+at a folder you have already organized by hand, the flow is the same: scan,
+review the classification, fix anything the file headers didn't say, and
+confirm. Confirming never moves a file by itself — it produces a reviewable
+plan, and only applying that plan changes anything on disk (see
+[The safety model](./09-safety-model.md)).
+
+[screenshot: the Inbox with several classified items and the status bar breakdown]
+
+## Scanning and classification
+
+**Rescan** picks up new folders and files under your registered inbox and
+library roots. Detected items appear in the queue with their frame type
+(**Light**, **Dark**, **Flat**, **Bias**, **Master**), filter, exposure, and
+file counts, read from the FITS/XISF headers.
+
+A folder that mixes frame types — say lights and darks together, or two
+different exposure lengths — is never shown as one ambiguous item. It splits
+into several single-type items (for example `light · Ha · 300s`,
+`light · Ha · 120s`, `dark · 300s`), each still visibly grouped back to its
+shared source folder. The status bar's per-type breakdown always matches the
+real contents of the queue.
+
+You can search the queue (**Search detections…**), filter by file type
+(**FITS** / **Video**) and kind, group by dimensions such as target,
+frame type, exposure, or source (**Group by**, with a second level:
+"Group: {label} · then: {label}"), and sort any column.
+
+Selecting an item shows its **Detection details**: classification,
+per-file metadata (**Object**, **Exposure**, **Gain**, **Temp**, **Binning**,
+raw `IMAGETYP`), and where each file would go.
+
+## Needs review — the missing-metadata gate
+
+Some metadata is mandatory before a file can be filed correctly — most
+commonly the filter for a light frame, or the target when there is no filter
+and no coordinates in the header. When something mandatory is missing:
+
+- A danger panel names exactly what is missing: "Missing required
+  attribute(s): {attrs}", with the summary "{count} files missing required
+  attribute(s) for their destination — confirm disabled. Assign the missing
+  value(s) in “Needs review” above, then confirm."
+- Affected rows get a "needs {attrs}" badge.
+- **Confirm to inventory** is disabled — and this is not just a grayed-out
+  button: the backend independently refuses a confirm attempt for the same
+  reason, so there is no way to sneak an incomplete file past the gate.
+
+[screenshot: an item in the Needs review state with the missing-attributes banner]
+
+### Fixing it: bulk reclassify
+
+Select the affected files and use the bulk override controls to set the
+missing value — **Frame type**, filter (e.g. `Ha`), **Exposure (s)**, or
+**Binning** (e.g. `2x2`) — then **Apply to selected ({count})**. Reclassifying
+only rewrites PlateVault's own index: the files' bytes are never touched, and
+your override survives a rescan. Once resolved, the item re-partitions into a
+clean single-type item and **Confirm to inventory** re-enables.
+
+> **Not yet available:** the reclassify controls currently cover the common
+> fields listed above. A fully generic per-property editor (any path-relevant
+> attribute) exists under the hood but has no UI yet.
+
+## Confirming — move mode
+
+Confirming a classified item from an unorganized source (an inbox, or a root
+you marked **Needs organizing**) produces a *move plan*:
+
+1. Press **Confirm to inventory** (or **Confirm all ({count})** for the whole
+   queue; bulk confirm skips items that still need review and tells you so).
+2. If more than one library root can host this frame type, PlateVault asks
+   you to pick: "**Choose a destination library root** — More than one
+   library root can host {category} frames. Pick where these files should go
+   to generate the plan." With exactly one valid root, it is chosen
+   automatically. With none, the confirm refuses: "No library root is
+   registered for this frame type."
+3. A toast confirms: "Plan created ({count} items). Review below before
+   applying." The item stays in the queue, now marked "plan open" — it does
+   not disappear.
+
+Each planned file's destination is resolved from your per-frame-type folder
+pattern (for example `{target}/{filter}/{date}/light/` — configurable under
+[Settings → Naming](./08-settings.md#naming--folder-structure)) and shown in
+full before anything happens.
+
+## Confirming — catalogue-in-place
+
+Files under a root you marked **Already organized** go through exactly the
+same classification and needs-review gate, but confirming produces a
+*catalogue plan* instead: every action is "catalogue in place", the plan
+reports zero moves, and no destination picker appears — there is nothing to
+pick, because the files are staying put. Applying such a plan only writes the
+files' identity and metadata into PlateVault's index; on disk, nothing
+changes byte-for-byte. Afterwards the files appear in derived views such as
+[Sessions](./03-sessions.md).
+
+The deciding factor between move and catalogue is the *root's* organization
+state — chosen when you registered it — not the frame type or file kind.
+
+## Reviewing and applying plans
+
+Open plans collect in the **Review plans** section. Each plan row shows its
+**Composition** (for example "{count} catalogued in place" or
+"{moved} moved · {inPlace} catalogued in place") and lets you inspect every
+action before committing.
+
+- For plans that remove source files, you choose where they go: "Where should
+  removed source files go?" — **Archive folder** or **System Trash**, with
+  the honest hint "Archive keeps a recoverable copy; Trash is unrecoverable."
+- **Apply** (or **Apply all** / **Apply selected ({count})**) executes the
+  plan with live progress ("{applied} of {total}"). Success shows
+  "Plan applied."; a failure reports exactly how far it got: "Apply failed
+  after {applied} applied, {failed} failed."
+- **Discard** throws the plan away without touching disk: "Plan discarded.
+  Item is available for re-confirmation."
+
+[screenshot: the Review plans section with one plan expanded showing per-file destinations]
+
+Safety behaviors you can rely on here:
+
+- A **stale plan** — the source files changed on disk after you confirmed —
+  refuses to apply: "Source files changed — discard and re-confirm to
+  regenerate this plan."
+- A destination collision is refused rather than silently overwritten, and
+  the refusal itself is written to the [audit log](./09-safety-model.md#the-audit-log).
+- Two plans cannot race each other over the same files: "Another plan is
+  currently working on the same files or folders. Wait for it to finish,
+  then try again."
+
+## Related journeys
+
+- [Journey 2 — Ingest → review/reclassify → confirm (move mode)](../product/user-journeys.md#journey-2--ingest--reviewreclassify--confirm-move-mode)
+- [Journey 3 — Ingest → confirm (catalogue-in-place)](../product/user-journeys.md#journey-3--ingest--confirm-catalogue-in-place)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/041-inbox-plan-surface/mixed-folder-single-type-subitems/scenario.md`
+- `e2e-agentic-test/041-inbox-plan-surface/missing-mandatory-gate/scenario.md`
+- `e2e-agentic-test/041-inbox-plan-surface/reclassify-field-agnostic/scenario.md`
+- `e2e-agentic-test/041-inbox-plan-surface/confirm-move-vs-catalogue/scenario.md`
+- `e2e-agentic-test/041-inbox-plan-surface/plan-overlay-apply-audit/scenario.md`
+- `e2e-agentic-test/025-filesystem-plan-application/plan-overlap-guard/scenario.md`
+- `e2e-agentic-test/journeys/grand-inbox-journey/scenario.md`

--- a/docs/manual/03-sessions.md
+++ b/docs/manual/03-sessions.md
@@ -1,0 +1,65 @@
+# Sessions
+
+A session is a night's worth of acquisition for one target/filter/camera
+combination. In PlateVault, sessions are a *derived view*: they are computed
+from the inventory you have already confirmed and applied through the
+[Inbox](./02-inbox.md), and they update automatically. There is nothing to
+create, approve, or maintain here — which is exactly the point.
+
+[screenshot: the Sessions page with the calendar timeline and the sessions table]
+
+## Where sessions come from
+
+- Before you confirm and apply anything, Sessions shows nothing for that
+  data. Sessions are derived from confirmed inventory only — never from raw,
+  unreviewed scans.
+- The moment an inbox plan applies, the corresponding session(s) appear, with
+  frame counts matching what was actually moved or catalogued.
+- Rescanning the inbox never duplicates a session or drags one back into a
+  "pending" state: the view is deterministic over your confirmed metadata.
+
+You may notice what is *not* here: no Confirm, Reject, Ignore, or Re-open
+buttons, and no review-state badges. An earlier design had a full session
+review lifecycle; it was deliberately removed. The confirm gate you already
+passed in the Inbox is the only gate — Sessions is a read view, and its
+simplicity is intentional.
+
+## Reading the list
+
+The table shows one row per session: **Night**, **Target**, **Filter**,
+**Camera**, **Frames**, **Integration**, and **Projects** (which projects use
+this session as a source). Above it:
+
+- **Search** ("Search target, filter, camera…") narrows the list as you type.
+- The **Filter:** bar (**+ add**) pins structured filters — by **Target**,
+  **Filter**, **Camera**, or **Month** — each removable individually.
+- Grouping collects sessions by target, filter, camera, or month.
+- A calendar timeline strip visualizes your imaging nights; each night shows
+  its total frame count.
+
+Every column sorts, and "No sessions match the current filters." tells you
+when your filters are the reason the list looks empty.
+
+## Session details
+
+Selecting a row opens the detail pane: the session's **Night**, target,
+filter, camera fingerprint details (gain, sensor temperature, binning,
+exposure), **Total integration**, **Confirmed by** (which inbox confirmation
+produced it), and **Linked projects**. **Reveal in OS** opens the session's
+source folder in your system's file manager.
+
+[screenshot: session detail pane with fingerprint details and linked projects]
+
+> **Not yet available:** interaction parity with the Inbox list — the same
+> dropdown filters, grouping-hint footer, and screen-reader sort
+> announcements — is still being finished. The Sessions list is functionally
+> complete, but some of these refinements arrive with a pending update.
+
+## Related journeys
+
+- [Journey 4 — Sessions review (derived groupings, live membership)](../product/user-journeys.md#journey-4--sessions-review-derived-groupings-live-membership)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/041-inbox-plan-surface/sessions-derived-inventory/scenario.md`
+- `e2e-agentic-test/043-sessions-parity/sessions-inbox-parity/scenario.md`

--- a/docs/manual/04-projects.md
+++ b/docs/manual/04-projects.md
@@ -1,0 +1,127 @@
+# Projects
+
+A project collects the acquisition sessions you intend to process together —
+"NGC 7000 in narrowband", say — and tracks everything around the processing
+run PlateVault itself never performs: the sources, the generated
+documentation (manifests), your notes, the launch into PixInsight or Siril,
+and the output files your tool writes.
+
+[screenshot: a project detail page with channels, sources, and outputs]
+
+## Creating a project
+
+**Create project** opens the **New project** flow:
+
+- **Project name** — required, up to 120 characters (placeholder:
+  "e.g. NGC 7000 Narrowband"). A name that already exists — in any letter
+  case — is flagged inline right at the field: "A project with this name
+  already exists." Creation is blocked until you change it.
+- **Folder path** — where the project's working folder lives, relative to
+  your project library root (placeholder: `projects/my-project`). A path
+  another project already uses is refused: "Another project already uses
+  this folder path."
+- **Target (optional)** — search your catalog ("e.g. M31, NGC 224,
+  Andromeda") to link the project to a target.
+- A processing-tool profile — **PixInsight** ("WBPP, StarAlignment,
+  integration") or **Siril** ("Free open-source stacking").
+- **Notes (optional)**.
+
+On success, PlateVault creates the project's on-disk folder structure
+(`lights/`, `darks/`, `flats/`, and so on) automatically. This is the one
+plan in the app that auto-applies — because every action in it is a folder
+*creation*, never a move, copy, or delete of your files — and it still leaves
+a plan row and an audit record behind. If a file already occupies a spot
+where a folder should go, creation still succeeds, the toast says so, and
+that folder plan stays available for review instead of being silently
+skipped.
+
+> **Not yet available:** a fix is pending for a bug where new project folders
+> could be created under the app's own working directory instead of your
+> registered project library. Until it lands, double-check where a new
+> project's folders were created.
+
+## Attaching and removing sources
+
+In the project's **Edit** pane, **Add sources** opens a picker showing only
+sessions that are confirmed *and* not yet linked ("All sessions are already
+linked to this project." when there is nothing left to add). You cannot
+attach unconfirmed inbox data — if it is not in [Sessions](./03-sessions.md),
+it cannot be a project source.
+
+Removing a source is immediate, except for the last one: removing the final
+confirmed source would drop the project back to an incomplete state, so it is
+refused with "You can't remove the last confirmed source." An archived
+project refuses edits outright: "This project is archived and cannot be
+edited."
+
+The project detail's per-channel (per-filter) breakdown shows real numbers —
+actual sub-frame counts and total integration time computed from the attached
+sessions, formatted as hours and minutes. When you add sources after a
+channel review, a banner points it out ("New sources were added since the
+last channel review.") with a **Re-infer channels** action.
+
+## Manifests and notes
+
+The **Manifests** section is the project's append-only paper trail. Every
+lifecycle-relevant change — **Project created**, **Source changed**,
+**Lifecycle transition**, **Workflow run**, **Cleanup applied** — appends a
+new manifest snapshot. Manifests are generated documentation and are never
+overwritten, so you can always see what the project looked like at each point
+in its history. **Reveal** opens the manifest file in your file manager.
+
+**Notes** are freehand text, auto-saved a few seconds after you stop typing
+("Saved"), with a live byte counter and a hard size cap ("Note exceeds the
+{max}-byte limit."). Notes on an archived project are read-only.
+
+[screenshot: the Manifests list with several snapshots and their reasons]
+
+## Launching your processing tool
+
+With the tool's executable configured (see
+[Settings → Processing Tools](./08-settings.md#processing-tools)),
+**Open in {tool}** launches it for this project — "Launched PixInsight" — and
+changes nothing about the project's state. Three honest refusals to know
+about:
+
+- **Tool path not configured** / **Tool executable missing** — fix the path
+  in Settings via the **Configure** link.
+- If the project's working directory would resolve *outside* every
+  registered library root, the launch is refused. This containment check
+  prevents a misconfigured project from pointing a tool at an unrelated part
+  of your disk.
+- If the operating system itself fails to start the process, that is
+  reported plainly ("Failed to launch {tool}: {error}") rather than silently
+  swallowed.
+
+Launching again while the tool may already be open asks first: "{tool} may
+already be open for this project. Open another instance?"
+
+## Observing outputs (artifacts)
+
+While a project is open, PlateVault watches its output folder — only that
+folder, never your whole library — and records new files as artifacts with a
+kind (**Intermediates** / **Masters** / **Finals**) and a confidence level.
+Low-confidence classifications are labeled as such ("{kind} (low
+confidence)"), unrecognized files show as "Unattributed", and you can
+override a classification manually (marked "(manual)"). Files written while
+the project was closed are picked up the next time you open it.
+
+PlateVault never modifies or deletes an artifact file itself — reclaiming
+space from stale intermediates is what
+[Cleanup](./05-cleanup-and-archive.md) is for.
+
+## Related journeys
+
+- [Journey 5 — Project lifecycle: create → attach sources → manifests/notes → tool launch → artifacts](../product/user-journeys.md#journey-5--project-lifecycle-create--attach-sources--manifestsnotes--tool-launch--artifacts)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/008-project-create-onboard-edit/create-wizard-field-errors/scenario.md`
+- `e2e-agentic-test/008-project-create-onboard-edit/edit-project-sources/scenario.md`
+- `e2e-agentic-test/008-project-create-onboard-edit/per-channel-integration-time/scenario.md`
+- `e2e-agentic-test/008-project-create-onboard-edit/project-mkdir-auto-apply/scenario.md`
+- `e2e-agentic-test/008-project-create-onboard-edit/project-path-root-anchoring/scenario.md`
+- `e2e-agentic-test/024-project-manifests-and-notes/manifests-notes-reveal-labels/scenario.md`
+- `e2e-agentic-test/011-processing-tool-launch/tool-launch-containment/scenario.md`
+- `e2e-agentic-test/012-processing-artifact-observation/artifact-attribution/scenario.md`
+- `e2e-agentic-test/journeys/full-project-lifecycle/scenario.md`

--- a/docs/manual/05-cleanup-and-archive.md
+++ b/docs/manual/05-cleanup-and-archive.md
@@ -1,0 +1,135 @@
+# Cleanup and archive
+
+Processing runs leave behind intermediate files you no longer need once the
+final image is done, and finished projects eventually deserve to move out of
+the active library. Both operations are, by nature, the most dangerous things
+a library manager can do — so PlateVault wraps both in the same
+scan → review → apply discipline, and never deletes anything outright as a
+first step. The full rationale lives in
+[The safety model](./09-safety-model.md); this chapter shows the workflow.
+
+## Cleanup: scan → review → apply
+
+Cleanup lives on the project detail page, in the **Cleanup preview** section.
+
+### 1. Scan (read-only)
+
+**Scan for cleanup candidates** previews what could be reclaimed: "Scan this
+project to preview cleanup candidates. Scanning is read-only — nothing is
+removed without explicit plan approval." Candidates are grouped by kind
+(**Intermediates**, **Masters**, **Finals**) with per-file **Size** and
+classification **Confidence**, and a running "{size} reclaimable" total.
+
+Protected items appear locked and unselectable, labeled
+"Protected — never proposed for cleanup", with the reason spelled out (for
+example "Master calibration frames are protected and excluded from cleanup
+plans"). A project with nothing to clean says so: "**No cleanup candidates** —
+The cleanup policy keeps every data type, or no processing artifacts have
+been observed for this project."
+
+[screenshot: cleanup preview with grouped candidates and the reclaimable total]
+
+### 2. Generate the plan
+
+Choose the **Destructive destination**:
+
+- **Archive folder** (default) — "App-managed archive folder — reversible
+  until you empty it".
+- **System trash** — "OS-native recycle bin / trash".
+
+Then press **Generate cleanup plan**. Only now does a real, reviewable plan
+exist — and the destination is fixed into it, shown read-only from here on.
+
+### 3. Review and apply
+
+The **Review cleanup plan** overlay lists every affected item, one row per
+file, and opens with the reassurance that matters: "Nothing has been changed
+on disk. Review every proposed item below; applying requires explicit
+approval."
+
+If the plan touches protected items, each one must be individually
+acknowledged (**Acknowledge**, tracked as "{done} of {total} require
+acknowledgement") before **Approve & apply** becomes clickable. You can
+always walk away with **Discard plan** — disk untouched either way.
+
+Applying shows live progress ("Applying {applied} of {total}…") and finishes
+with "Cleanup plan applied." Files move to your chosen destination — when
+that is the Archive folder, nothing is deleted at all. Re-scanning afterwards
+shows the cleaned files gone from the candidate list. An empty plan cannot be
+approved.
+
+[screenshot: the Review cleanup plan overlay with a protected item awaiting acknowledgement]
+
+> **Not yet available:** a pre-flight free-space check ("would this fit at
+> the destination?") is not implemented yet — the plan's required-bytes
+> figure currently always reads zero.
+
+## Archiving a finished project
+
+Archiving moves a completed project's files into an app-managed archive
+folder, and it is the *only* way a project's lifecycle reaches `archived`:
+
+1. Pressing "Archive" on a completed project is **refused** unless an
+   archive plan already exists and has been applied — "A filesystem plan is
+   required before this transition. Create or approve a plan first." The app
+   never silently flips a lifecycle state.
+2. The archive plan goes through the same review overlay as cleanup —
+   protected items acknowledged, approve, apply. The files move into the
+   app-managed archive folder, and only then does the project flip to
+   `archived`. Its Edit pane becomes read-only: "This project is archived.
+   Settings are read-only."
+
+> **Not yet available — important:** there is currently **no button in the
+> app that generates an archive plan**. The archive workflow's review and
+> apply machinery is fully in place, and the "Archive" action correctly
+> refuses until a plan exists — but creating that plan has no UI entry point
+> yet. Until it ships, archiving cannot be completed from the UI alone.
+
+## The Archive page
+
+The **Archive** page lists archived projects ("Projects appear here after
+they're archived.") with search ("Search archive…"), an "archived" status
+pill, and per-item details: **Original path**, **Size on disk**, **Archived**
+date, **Reason**, and a real per-item **Audit history**.
+
+From here you can send an archived item further along:
+
+- **Send to trash** — moves the archived files to the OS recycle bin.
+- **Delete permanently** — the strongest action in the app, guarded
+  accordingly: "This permanently deletes the archived files for {name}. Type
+  DELETE to confirm — this cannot be undone." Anything other than the literal
+  word `DELETE` leaves the button disabled.
+
+The reveal action uses your platform's native label (**Show in File
+Explorer** on Windows) and is disabled when there is nothing on disk to
+reveal.
+
+[screenshot: the Archive page with an item selected showing its audit history]
+
+> **Not yet available:**
+>
+> - **Restore** (un-archive) is deferred by design: moving files back is a
+>   filesystem mutation, so it needs its own reviewable plan generator, which
+>   does not exist yet. The Restore control ships hidden or disabled rather
+>   than pretending to work.
+> - The Archive page covers **projects only**. There is no master or target
+>   archival concept, and no Sessions tab — sessions no longer have a
+>   lifecycle to archive (see [Sessions](./03-sessions.md)).
+> - Some layout polish (single-column page, richer list) is still pending;
+>   the core plan-gated archive → trash → delete flow works without it.
+
+One documented deviation worth knowing: archive plans move files into an
+app-managed folder (`.astro-plan-archive/<planId>/`) rather than a
+user-patterned destination, so that trash and delete can reliably find an
+item's files later.
+
+## Related journeys
+
+- [Journey 6 — Cleanup: scan → review → apply](../product/user-journeys.md#journey-6--cleanup-scan--review--apply)
+- [Journey 7 — Archive → (delete from archive)](../product/user-journeys.md#journey-7--archive--delete-from-archive)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/017-cleanup-archive-review-plans/cleanup-scan-review-apply/scenario.md`
+- `e2e-agentic-test/017-cleanup-archive-review-plans/archive-lifecycle/scenario.md`
+- `e2e-agentic-test/journeys/full-project-lifecycle/scenario.md` (Phases E–F)

--- a/docs/manual/05-cleanup-and-archive.md
+++ b/docs/manual/05-cleanup-and-archive.md
@@ -100,9 +100,10 @@ From here you can send an archived item further along:
   DELETE to confirm — this cannot be undone." Anything other than the literal
   word `DELETE` leaves the button disabled.
 
-The reveal action uses your platform's native label (**Show in File
-Explorer** on Windows) and is disabled when there is nothing on disk to
-reveal.
+A reveal button (**Reveal in Explorer** in the current build; platform-native
+wording such as **Show in File Explorer** / **Reveal in Finder** arrives with
+a pending update) opens the item's location, and is disabled when there is
+nothing on disk to reveal.
 
 [screenshot: the Archive page with an item selected showing its audit history]
 

--- a/docs/manual/06-calibration.md
+++ b/docs/manual/06-calibration.md
@@ -1,0 +1,86 @@
+# Calibration
+
+PlateVault tracks your *master* calibration frames — master darks, flats, and
+bias — as individually identified library items, and matches them against the
+acquisition sessions that need them. It does not build masters (that is your
+processing tool's job); it makes sure that when you sit down to calibrate,
+the right master for each session is one confident suggestion away.
+
+## Getting masters into the library
+
+Master calibration files enter through the same [Inbox](./02-inbox.md)
+pipeline as everything else. A folder containing several master files — say
+two darks, a flat, and a bias — classifies as separate individual items, not
+one folder-level blob. Each item carries its own kind and fingerprint: gain,
+sensor temperature, exposure, binning, and filter where relevant. Confirm and
+apply as usual, and each master lands in the calibration store.
+
+## The Calibration page
+
+The **Calibration** page shows one row per master file, grouped by kind
+(**DARKS**, **FLATS**, **BIAS**) or by camera, searchable ("Search camera,
+kind, filter…") and sortable (including by age). Fingerprint columns are
+kind-conditional: a bias has no meaningful temperature or exposure, so those
+cells show a dash — by design, not as missing data. Master *light* frames
+never appear here.
+
+[screenshot: the Calibration page with masters grouped by kind]
+
+Selecting a master opens its detail rail: **Master fingerprint** (kind,
+exposure, temperature, sensor mode), **Reuse policy**, and **Usage stats**
+(**Sessions matched**, **Projects linked**, or "unused"). An older master
+shows an aging chip ("aging {days}d"). Actions include **Use in project**,
+**Replace master**, and a native reveal (**Reveal in Explorer**).
+
+## Matching masters to sessions
+
+The **Compatible sessions** panel answers "what can this master calibrate?":
+
+- Select a master and PlateVault ranks candidate sessions, each shown with
+  real context — target, filter, night, frame count — never opaque IDs.
+- Sessions that fail a *hard rule* (wrong camera, wrong gain…) are shown with
+  a mismatch indicator rather than silently hidden: "Hard-rule mismatch:
+  {dims}. Confirm to force-assign." You can **Force-assign** if you know
+  better, but you have to say so explicitly.
+- Softer disagreements lower confidence instead of blocking, and ambiguity
+  is flagged: "Multiple sessions at similar confidence — review before
+  assigning."
+- Flats get an extra honesty check on rotation: "Rotation differs by {deg}° —
+  flat may not be valid for these lights."
+
+Assigning is always advisory-then-confirm: **Assign** proposes, **Confirm
+assign** records it (with usage counts updated); cancelling changes nothing.
+No match is ever applied automatically.
+
+[screenshot: compatible sessions panel with ranked candidates and one mismatch indicator]
+
+If nothing matches, the panel says why and where to go: "No acquisition
+sessions matched this master's fingerprint. Adjust tolerances in
+Settings → Calibration."
+
+## Tolerances
+
+**Settings → Calibration → Matching criteria** controls what "matching"
+means, per field (**Camera**, **Gain**, **Offset**, **Sensor temp**,
+**Binning**, **Dark / bias age**): whether the field is required for a match,
+its tolerance (e.g. degrees Celsius for sensor temperature, days for master
+age), and its severity — as the pane explains, "Toggle a field off to exclude
+it from matching (e.g. ignore gain). Soft/warn fields never block a match —
+they only lower confidence." The **Offset** tolerance, for example, controls
+whether sessions taken at a different sensor offset can still match a master.
+Changes persist across restarts and take effect immediately in the matching
+panel.
+
+> **Note:** the Calibration page covers dark, flat, and bias masters. More
+> exotic kinds (dark-flats, bad-pixel maps) are not surfaced in this version —
+> by design.
+
+## Related journeys
+
+- [Journey 8 — Calibration: ingest cal frames → masters → matching](../product/user-journeys.md#journey-8--calibration-ingest-cal-frames--masters--matching)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/040-calibration-masters/masters-detection-individual-items/scenario.md`
+- `e2e-agentic-test/007-calibration-matching/match-suggest-assign-tolerances/scenario.md`
+- `e2e-agentic-test/journeys/calibration-journey-ingest-to-match/scenario.md`

--- a/docs/manual/07-targets-and-planning.md
+++ b/docs/manual/07-targets-and-planning.md
@@ -1,0 +1,108 @@
+# Targets and planning
+
+The **Targets** page is your catalog: thousands of deep-sky objects seeded
+out of the box, searchable by any name they go by, enriched with your own
+aliases and observing notes, and linked to the sessions and projects that
+image them. It also carries a *planner* view — columns answering "what should
+I shoot tonight?" — and this chapter is candid about which of those numbers
+are real astronomy today and which are still placeholders.
+
+## Browsing the catalog
+
+The list is virtualized, so scrolling stays smooth across thousands of rows.
+You can:
+
+- **Search** by designation or any alias — "M31" and "Andromeda" find the
+  same row.
+- Filter by **Catalogues** (Messier, NGC, IC, Caldwell, Sharpless, Barnard,
+  LBN, LDN) and by object type (**Galaxy**, **Emission nebula**, **Globular
+  cluster**, and so on).
+- Sort any column — one active sort indicator at a time.
+- Group rows, for example by **Object type** or catalogue.
+- Star targets (☆ — "Add to My Targets") to collect favourites under the
+  **My Targets** view.
+
+[screenshot: the Targets page with search results and planner columns]
+
+## Adding targets and SIMBAD lookups
+
+**Add target** ("Search for an astronomical target to add it to your
+library.") searches locally first — offline, against the bundled seed
+catalog. Confirming a match persists exactly one canonical row; re-adding the
+same object never creates a duplicate.
+
+For an object outside the seed, PlateVault resolves the name on demand
+against the SIMBAD astronomical database (network required) and caches the
+answer for next time. If SIMBAD is unreachable or the name does not resolve,
+the dialog says so inline — 'Could not resolve target "{query}". Try a
+different name.' — rather than fabricating a row. Online lookups can be
+disabled entirely under Settings (Catalogs pane), leaving only the seed and
+local cache.
+
+## Target detail: identity, aliases, notes
+
+A target's detail page shows its real identity data — **Designation**, object
+type, **RA / Dec**, **Constellation**, **Magnitude**, source, and catalog IDs
+such as the **SIMBAD OID** — plus:
+
+- **Aliases** — catalog-provided aliases are fixed; your own ("Add user
+  alias…") can be added and removed freely, and a user alias immediately
+  becomes searchable in the list. "Only user-added aliases can be removed."
+- **Display label** — choose which name the list shows for this target
+  ("Not set — showing primary designation").
+- **Observing notes** — freehand, saved with visible confirmation
+  ("Saved").
+- Linked sessions and projects, with **+ New project here** as a shortcut.
+
+[screenshot: target detail with identity, aliases, and observing notes]
+
+## The planner columns — what is real today
+
+The planner-shaped columns — **Max alt**, **Tonight** (altitude sparkline),
+**Visible**, **Opposition**, **Lunar** (Moon separation), recommended
+filters, and **Img time** — are where you must read the fine print:
+
+> **Not yet available (honest-stub warning):** in the current build these
+> columns are **not computed from real coordinates, tonight's date, or your
+> observer location**. They are deterministic placeholders derived from each
+> target's designation — stable across reloads, deliberately disclosed as
+> approximate in their tooltips, but *not astronomically meaningful*. The
+> **Opposition** and Sessions columns render as a dash. The target detail's
+> altitude graph is titled with its fixed placeholder latitude
+> ("Tonight · ~{lat}°N") for the same reason, and its Coverage/Transit
+> sections are explicit stub notes.
+>
+> Real astronomy is on its way in two tracks:
+>
+> - **Moon separation, filter recommendations, and Opposition** are
+>   implemented and awaiting merge (spec 047) — once that lands, the
+>   **Lunar** column, tonight's recommended filter set, and the next
+>   opposition date become real ephemeris-driven values.
+> - **Altitude columns** (Max alt, Tonight, Visible, Img time) follow under
+>   spec 044, which brings the full astronomy engine and observer-location
+>   support.
+
+Two related notes:
+
+- The **Target Planner** settings pane already exposes a real tunable — the
+  usable-altitude threshold (0–90°, default 30°) — which the planner columns
+  will honor; see [Settings](./08-settings.md#target-planner).
+- **My Targets** favourites are currently stored locally in the app's
+  browser storage, not in your library database — they will not follow you
+  across machines and may not survive certain resets.
+
+The design principle behind all of this: a stub must never be mistakable for
+real astronomical data. If a planner number ever looks concrete but cannot be
+traced to your location and the current date, that is a bug worth reporting —
+not a feature.
+
+## Related journeys
+
+- [Journey 9 — Targets & planning (what's real today vs. 044/047-pending)](../product/user-journeys.md#journey-9--targets--planning-whats-real-today-vs-044047-pending)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/035-targets-catalog/list-search-aliases-sort/scenario.md`
+- `e2e-agentic-test/035-targets-catalog/simbad-resolve-on-demand/scenario.md`
+- `e2e-agentic-test/023-target-identity/detail-identity-aliases-notes/scenario.md`
+- `e2e-agentic-test/044-planner-stubs/planner-columns-visibly-stubs/scenario.md` (the authority on the real-vs-stub boundary)

--- a/docs/manual/08-settings.md
+++ b/docs/manual/08-settings.md
@@ -1,0 +1,152 @@
+# Settings
+
+Settings groups twelve panes into three sections — **Library**,
+**Processing**, and **Application**. Every pane auto-saves as you change it;
+there is no global Save button anywhere in the app.
+
+[screenshot: the Settings page with the three-section pane navigation]
+
+## Library
+
+### Data Sources
+
+"Library roots the app indexes. Files are read in read-only mode; nothing is
+modified outside an approved plan." Covered in depth in
+[Getting started](./01-getting-started.md#managing-data-sources-over-time):
+add, rescan, remap, disable/enable, and delete registered roots.
+
+### Equipment
+
+"Cameras, telescopes, and optical trains used across your sessions."
+**Cameras**, **Telescopes**, **Filters** (categorized **Broadband**,
+**Narrowband**, **Dual-band**, **Custom**, **Other**), and **Optical Trains**
+that combine them with a focal length. Items detected from your file headers
+are tagged **Auto-detected**; your own entries are **Manual**. An item still
+referenced by an optical train cannot be removed until you edit that train.
+
+### Ingestion
+
+"Controls how the app scans source folders and groups newly discovered
+files."
+
+- **Scan defaults** — **Scan on startup** ("Scan all roots each time the
+  application opens.").
+- **Follow symbolic links** — "Disabled by default to prevent scan loops."
+- **Follow NTFS junctions** — for Windows libraries using junctions to
+  external drives.
+- **File hashing** — **Hashing mode**: "Lazy defers hashing until a feature
+  needs it (e.g. duplicate detection). Eager hashes every file on first
+  scan. Off disables hashing entirely."
+
+> **Not yet available:** these ingestion values persist and survive a
+> restart, but the scan pipeline does not consume them yet — changing them
+> has no effect on scanning behavior in the current build.
+
+### Naming & Structure
+
+"Token patterns used when files are confirmed from Inbox to Inventory." Build
+a destination folder pattern per frame type (including master kinds) from
+tokens, literals, and separators — e.g. `{target}/{filter}/{date}/light/` —
+with a live preview against real values, warnings for problems such as
+consecutive separators, and an explicit note of which tokens fell back to
+defaults. An empty pattern means the built-in default. This is the pattern
+the [Inbox](./02-inbox.md#confirming--move-mode) resolves destinations from.
+
+### Target Resolution
+
+"How object names in your files are resolved to canonical targets — online
+SIMBAD resolution plus the bundled seed and local cache." Toggle **Online
+SIMBAD resolution** ("Targets not in the bundled seed or local cache are
+resolved on demand from SIMBAD, then cached." — or, when off, "Online
+resolution is off — only the bundled seed and local cache are used. Unknown
+objects are marked unresolved."), tune the **SIMBAD endpoint**, **Request
+timeout (s)**, and **Typeahead debounce (ms)**, and choose which catalogues
+the Planner filter shows by default.
+
+### Target Planner
+
+"Observation planning preferences — altitude threshold and filter visibility
+settings for the Planner table." The **Usable altitude threshold (°)**
+(0–90, default 30) is the "minimum elevation above the horizon (in degrees)
+considered acceptable for imaging" and drives the Visible-tonight and
+imaging-time columns of the [Targets](./07-targets-and-planning.md) table.
+Out-of-range input is clamped. (Until the planner columns switch from
+placeholders to real astronomy, the threshold's visible effect is limited —
+see the honest-stub warning in that chapter.)
+
+## Processing
+
+### Processing Tools
+
+"Configure executable paths and directory templates for each processing
+tool." Each tool (PixInsight, Siril) shows its detection status
+(**Available** / **Missing**), its executable path, and **Re-detect**. This is
+where **Open in {tool}** on a [project](./04-projects.md#launching-your-processing-tool)
+gets its executable from.
+
+### Calibration Matching
+
+"Tolerances and requirements for automatic calibration frame matching." The
+**Matching criteria** table is described in
+[Calibration → Tolerances](./06-calibration.md#tolerances).
+
+### Cleanup
+
+"Default actions for each data type when a cleanup plan is generated after
+processing." Also home of **Source Protection**: the **Default protection**
+level (**Protected** / **Normal** / **Unprotected**) applied to newly
+ingested sources — see [The safety model](./09-safety-model.md#protected-sources).
+
+## Application
+
+### Appearance
+
+"Theme, font size, and display density."
+
+- **Theme** — four named themes shown as live preview swatches: **Warm
+  Clay** (light), **Warm Slate** (light), **Observatory** (dark), and
+  **Espresso** (dark), plus **System**, which follows your OS light/dark
+  preference ("auto · dark" / "auto · light"). Switching applies instantly,
+  no reload, and survives a restart.
+- **Display Density** — **Compact (24px row)**, **Comfortable (32px row)**
+  (default), **Spacious (40px row)**.
+- **Font Size** — **Small (13px)**, **Default (14px)**, **Large (16px)**.
+
+[screenshot: the Appearance pane with the four theme swatches]
+
+> **Not yet available:** the **Font Size** control is currently visual-only
+> within this pane — it does not yet change text size elsewhere in the app.
+
+### Advanced
+
+"Logging level, database information, and reset options."
+
+- **Logging** — **Log level** (**Error** / **Warn** / **Info** / **Debug**):
+  "Controls application log verbosity. Debug emits diagnostic detail; Info
+  is the default; Warn and Error progressively quieter." See
+  [Troubleshooting](./10-troubleshooting.md#the-log-panel).
+- **Database** — engine, location, size, schema version, record counts, and
+  **Export database**.
+- **Guided Tour** — **Restart guided flow** replays the first-project
+  walkthrough.
+- **Source Setup Wizard** — **Restart first-run setup** reopens the setup
+  wizard with your sources pre-filled (confirm-gated; "nothing is deleted").
+  Note this is distinct from the guided-tour restart above it.
+- **Danger Zone** — **Reset preferences**: "Resets all UI preferences
+  (theme, density, font size) to defaults. Library roots, equipment, and
+  session data are not affected."
+
+### Audit Log
+
+"Searchable history of every state change, plan application, and system
+event." Described in
+[The safety model → The audit log](./09-safety-model.md#the-audit-log).
+
+## Related journeys
+
+- [Journey 10 — Settings, appearance, and i18n](../product/user-journeys.md#journey-10--settings-appearance-and-i18n)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/018-settings-configuration-model/appearance-themes/scenario.md`
+- `e2e-agentic-test/018-settings-configuration-model/panes-and-persistence/scenario.md`

--- a/docs/manual/09-safety-model.md
+++ b/docs/manual/09-safety-model.md
@@ -1,0 +1,173 @@
+# The safety model
+
+Your image library is years of clear nights, cold fingers, and disk space.
+PlateVault's most important feature is not a button — it is a promise about
+what the app will never do with those files. This chapter explains that
+promise precisely, because trust you cannot verify is just hope.
+
+## The five guarantees
+
+1. **Your files stay yours, where they are.** PlateVault indexes your
+   library in place. It never copies your images into a private store, and
+   cataloguing an already-organized folder changes nothing on disk —
+   byte-for-byte. Even removing a registered source only deletes
+   PlateVault's *registration*: "Files on disk are never touched — this only
+   removes the registration."
+2. **Every mutation is a plan you review first.** No move, copy, archive, or
+   delete ever happens as a side effect of clicking something. Confirming an
+   inbox item, generating a cleanup plan, requesting an archive — all of
+   these *propose*. Only approving and applying a plan executes.
+3. **Nothing is overwritten silently.** A destination collision is refused,
+   not resolved by guessing — and the refusal itself is recorded.
+4. **Destructive means recoverable first.** Cleanup and archive move files
+   to an archive folder or the system trash; permanent deletion is a
+   separate, later, deliberately awkward step.
+5. **Everything leaves a record.** Every attempted action and its outcome —
+   including refusals and failures — is written to the audit log.
+
+## Reviewable plans
+
+A plan is a complete, itemized list of filesystem actions, shown to you
+before anything runs. The review overlay opens with the sentence that defines
+the whole model:
+
+> "Nothing has been changed on disk. Review every proposed item below;
+> applying requires explicit approval."
+
+Every row shows the item, the action, the source path, and its protection
+status. You have exactly two ways out: **Approve & apply**, or **Discard
+plan** — and discarding is always safe, because a plan that was never applied
+never touched anything.
+
+[screenshot: the plan review overlay with per-item actions and protection column]
+
+Plans are also defensive about the world changing underneath them:
+
+- **Staleness.** If the source files change on disk between confirm and
+  apply, the plan refuses to run: "Source files changed — discard and
+  re-confirm to regenerate this plan." And if the *plan* changed after you
+  reviewed it: "The plan changed since you reviewed it. Review it again."
+- **Overlap.** Two plans cannot operate on the same files at once: "Another
+  plan is currently working on the same files or folders. Wait for it to
+  finish, then try again."
+- **Emptiness.** "This plan has no items to apply." — an empty plan cannot
+  be approved, so there is no such thing as a rubber-stamp apply.
+- **Approval is not optional.** Attempting to apply an unapproved plan is
+  refused: "Approve the plan before applying it."
+
+These are not merely disabled buttons. The same rules are enforced again by
+the application core when an action is actually attempted — so a UI glitch, a
+stray click, or an automation script cannot slip past them.
+
+## No silent overwrite
+
+When a planned action would land on a path that already exists, PlateVault
+refuses that action rather than overwriting, reports it, and records the
+refusal in the audit log. The same conservatism applies in reverse: when
+creating a project's folder structure, a file already sitting where a folder
+should go doesn't get clobbered — creation succeeds around it, tells you, and
+leaves the folder plan for review.
+
+The one mutation that auto-applies — the mkdir-only plan that scaffolds a new
+project's folders — is the exception that proves the rule: every action in it
+creates an empty directory, none can touch a user file, and it still leaves
+both a plan row and an audit record behind.
+
+## Archive before delete
+
+Destruction in PlateVault is a staircase, not a trapdoor:
+
+1. **Cleanup** defaults to the **Archive folder** — "App-managed archive
+   folder — reversible until you empty it". Choosing **System trash**
+   instead is explicit, with its own honest hint ("OS-native recycle bin /
+   trash"), and in the Inbox the difference is spelled out: "Archive keeps a
+   recoverable copy; Trash is unrecoverable."
+2. Archived items remain listed, searchable, and auditable on the
+   [Archive page](./05-cleanup-and-archive.md#the-archive-page).
+3. **Send to trash** moves archived files to the OS recycle bin — still
+   recoverable by your operating system.
+4. **Delete permanently** is the only irreversible step, and it demands you
+   type the literal word `DELETE`: "This permanently deletes the archived
+   files for {name}. Type DELETE to confirm — this cannot be undone." A
+   click-through cannot do it; muscle memory cannot do it.
+
+Lifecycle states follow the same discipline. A project only becomes
+`archived` through an applied archive plan — the transition is otherwise
+refused: "A filesystem plan is required before this transition. Create or
+approve a plan first."
+
+## Protected sources
+
+Protection is a per-source safety level that decides how hard cleanup has to
+work to touch a file:
+
+- **Protected** — "Cleanup plans require explicit approval for this
+  source's files." Protected items surface in scans as locked
+  ("Protected — never proposed for cleanup"), and if one is ever included in
+  a plan, it must be individually acknowledged during review — tracked as
+  "{done} of {total} require acknowledgement" — before **Approve & apply**
+  unlocks. You cannot approve-and-miss a protected file by accident.
+- **Normal** — "Standard plan review applies; no extra acknowledgement
+  required."
+- **Unprotected** — "Destructive plan actions proceed without additional
+  confirmation."
+
+Some categories are protected wholesale by policy — for example "Master
+calibration frames are protected and excluded from cleanup plans". The
+default level for newly ingested sources is yours to set
+([Settings → Cleanup → Source Protection](./08-settings.md#cleanup)), with
+per-source overrides on each Data Sources card ("Inherits global default"
+until you change it). A plan blocked by protection says so plainly: "This
+plan is blocked by a protected item. Resolve the protection first."
+
+## The audit log
+
+**Settings → Audit Log** is the app's memory of everything it did — and
+everything it declined to do. Every event carries a **Timestamp**, **Event**,
+**Entity**, **Actor**, and **Outcome** — and the outcomes are honest:
+**applied**, **ok**, **refused**, **failed**, **paused**. Refusals are
+first-class events, not silent no-ops: a lifecycle transition denied for lack
+of a plan is recorded as "Transition {fromState} → {toState} for {entityType}
+requires an approved filesystem plan".
+
+You can search ("Search events, entities, details…"), filter by date range,
+page through history, and **Export** the log to a file. Projects add their
+own layer on top: every lifecycle-relevant change appends an immutable
+[manifest snapshot](./04-projects.md#manifests-and-notes), never rewriting an
+earlier one.
+
+[screenshot: the Audit Log pane showing a mix of applied and refused events]
+
+## Inference is labeled, always
+
+Wherever PlateVault infers instead of reads — classifying an artifact as an
+intermediate or master, matching a calibration frame, resolving a target
+name — the inference carries a confidence level and says so ("{kind} (low
+confidence)", "Unattributed", mismatch indicators, "approximate" tooltips on
+planner placeholders). A guess presented as a fact would be a safety bug;
+see [Targets and planning](./07-targets-and-planning.md#the-planner-columns--what-is-real-today)
+for the strictest application of that rule.
+
+## What this means in practice
+
+You can explore PlateVault fearlessly. Scans are read-only. Reviews are
+read-only. Confirmations create proposals. The only moments your disk changes
+are the ones where you pressed an explicit apply on a plan you could read in
+full — and if you are ever unsure what happened, the audit log will tell you,
+including the things that were refused on your behalf.
+
+## Related journeys
+
+The safety model is woven through every journey rather than being one of its
+own — see especially:
+
+- [Journey 2 — Ingest → review/reclassify → confirm (move mode)](../product/user-journeys.md#journey-2--ingest--reviewreclassify--confirm-move-mode) (stale plans, collision refusal)
+- [Journey 6 — Cleanup: scan → review → apply](../product/user-journeys.md#journey-6--cleanup-scan--review--apply) (protection acknowledgement)
+- [Journey 7 — Archive → (delete from archive)](../product/user-journeys.md#journey-7--archive--delete-from-archive) (plan-gated lifecycle, typed DELETE)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/025-filesystem-plan-application/plan-overlap-guard/scenario.md`
+- `e2e-agentic-test/016-source-protection-defaults/protection-defaults-take-effect/scenario.md`
+- `e2e-agentic-test/041-inbox-plan-surface/plan-overlay-apply-audit/scenario.md`
+- `e2e-agentic-test/audit-log/` (audit surface scenarios)

--- a/docs/manual/10-troubleshooting.md
+++ b/docs/manual/10-troubleshooting.md
@@ -1,0 +1,120 @@
+# Troubleshooting
+
+PlateVault reports problems in plain language, never as raw codes. This
+chapter lists the messages you are most likely to meet, what each one means,
+and what to do — plus where to look (the log panel, the audit log) when the
+message alone doesn't explain enough.
+
+## Common messages and what to do
+
+### Setup and data sources
+
+| Message | What it means / what to do |
+|---|---|
+| "This directory is already registered" | You already added this folder as a source. Check **Settings → Data Sources**. |
+| "This directory is registered under a different category" | The folder is already a source of another kind (e.g. Calibration vs Raw). Use it where it is registered, or delete that registration first. |
+| "This directory does not exist" / "This path is not a directory" | The path is wrong, or the drive isn't mounted. If a drive moved, use **Remap…** instead of re-adding. |
+| "Cannot read this directory — check permissions" | PlateVault can't read the folder. Fix filesystem permissions and retry. |
+| "This source still has related records (sessions, plan items, or inbox items) and can't be deleted." | Deleting a source is refused while other records depend on it. This protects your history; disable the source instead if you just want it out of the way. |
+| "Finish the initial setup before using this feature." | The first-run wizard hasn't been completed. See [Getting started](./01-getting-started.md). |
+| "macOS has quarantined this app. Approve it in System Settings, then try again." | macOS Gatekeeper blocked the app. Approve it under System Settings → Privacy & Security. |
+
+### Inbox and confirmation
+
+| Message | What it means / what to do |
+|---|---|
+| "This item is missing the details needed to plan a move." | The missing-metadata gate. Assign the missing value(s) via bulk reclassify — see [The Inbox](./02-inbox.md#needs-review--the-missing-metadata-gate). |
+| "Choose a destination library before continuing." / "A destination library is required for this move." | More than one root can host this frame type — pick one in the destination picker. |
+| "No library root is registered for this frame type." | Nothing can receive these files. Register a suitable library root under **Settings → Data Sources**. |
+| "This item already has an open plan. Review or cancel it first." | You confirmed this item earlier. Find the plan under **Review plans** and apply or discard it. |
+| "This classification is out of date. Re-scan to refresh it." | The folder changed since PlateVault classified it. **Rescan**. |
+| "This file could be more than one type — confirm how to classify it." | Headers were ambiguous. Assign the frame type yourself. |
+
+### Plans
+
+| Message | What it means / what to do |
+|---|---|
+| "Approve the plan before applying it." | Plans require explicit approval — open the review overlay and approve. |
+| "The plan changed since you reviewed it. Review it again." | The plan's contents changed after your review; re-review before applying. |
+| "Source files changed — discard and re-confirm to regenerate this plan." | The plan went stale. Discard, then confirm the item again. |
+| "Another plan is currently working on the same files or folders. Wait for it to finish, then try again." | Overlap protection — plans never race each other. |
+| "This plan is blocked by a protected item. Resolve the protection first." | A protected file is in the plan. Acknowledge it during review, or change the source's protection level. See [The safety model](./09-safety-model.md#protected-sources). |
+| "Something already exists at the destination." / "A file or folder with that name already exists here." | Collision refusal — PlateVault never overwrites. Resolve the conflict on disk or adjust your naming pattern. |
+| "This plan has no items to apply." | An empty plan can't be approved. Select at least one item before generating. |
+| "The destination folder doesn't exist." / "Couldn't write to that location — check permissions." | Filesystem problems at the destination. Verify the drive is mounted and writable. |
+
+### Projects and tools
+
+| Message | What it means / what to do |
+|---|---|
+| "A project with this name already exists." / "That name is already in use." | Names are unique regardless of letter case. Pick another. |
+| "You can't remove the last confirmed source." | A project must keep at least one confirmed source; add a replacement before removing this one. |
+| "This project is archived and cannot be edited." / "This project is read-only and can't be changed." | Archived projects are read-only by design. |
+| "A filesystem plan is required before this transition. Create or approve a plan first." | Lifecycle transitions that imply file moves (like archiving) are plan-gated. See [Cleanup and archive](./05-cleanup-and-archive.md#archiving-a-finished-project). |
+| "Tool path not configured" / "Tool executable missing" | Set the executable under **Settings → Processing Tools**. |
+| "Couldn't launch the external tool." / "Failed to launch {tool}: {error}" | The OS could not start the process — check the path points at a runnable executable. |
+| "The confirmation text doesn't match." | Typed confirmations (like `DELETE`) must match exactly, including case. |
+
+### Targets
+
+| Message | What it means / what to do |
+|---|---|
+| 'Could not resolve target "{query}". Try a different name.' | Not in the seed catalog and SIMBAD couldn't resolve it (or you're offline / online resolution is disabled). Check **Settings → Target Resolution**. |
+| "That alias already exists for this target." / "Only user-added aliases can be removed." | Alias bookkeeping rules — catalog aliases are fixed; yours are editable. |
+
+### General
+
+| Message | What it means / what to do |
+|---|---|
+| "Something went wrong. Please try again." | The generic fallback. If it repeats, check the log panel (below) and gather support data. |
+| "Couldn't reach the local database. Please try again." / "Couldn't read from the local database. Please try again." | The app's local database hiccuped. Restart the app; if persistent, check disk health and free space. |
+| "A file read/write error occurred. Please try again." | A low-level I/O error — often a disconnected external drive. |
+
+If you ever see a raw untranslated code or key instead of a sentence like the
+ones above, that itself is a bug worth reporting.
+
+## The log panel
+
+The **Activity** panel — the collapsible strip at the bottom of the window —
+is your live view of what the app is doing. It is a layout participant, not
+an overlay: expanding it shrinks the content area rather than covering your
+work.
+
+[screenshot: the expanded Activity log panel with severity chips]
+
+- Severity chips filter by **Error** / **Warn** / **Info** / **Debug**.
+- Sources are restricted to a fixed, known set — the panel never shows
+  arbitrary noise.
+- **Diagnostics** detail only appears once the log level is set to **Debug**
+  (**Settings → Advanced → Log level**).
+- **Follow** keeps the newest entries in view; scrolling up pauses it.
+- **Export** writes the currently visible log window to a JSON file.
+- "History gap — {count} entries older than this point are no longer
+  retained." is normal: the panel keeps a bounded window, not forever.
+
+## Gathering support data
+
+When reporting a problem, three exports tell most of the story:
+
+1. **The log panel's JSON export** (set **Log level** to **Debug** first,
+   reproduce the issue, then **Export**).
+2. **The audit log export** (**Settings → Audit Log → Export**) — shows what
+   was applied, refused, or failed, with timestamps.
+3. **Database facts** from **Settings → Advanced → Database** (size, schema
+   version, record counts) — and **Export database** if asked for it.
+   The database contains only metadata about your files, never the images
+   themselves.
+
+Include your OS, the app version, and — for anything involving moves or
+cleanup — the plan you were applying and whether the source folders live on
+an external drive.
+
+## Related journeys
+
+- [Journey 10 — Settings, appearance, and i18n](../product/user-journeys.md#journey-10--settings-appearance-and-i18n) (log panel, i18n guarantees)
+
+Click-by-click scenario scripts:
+
+- `e2e-agentic-test/019-bottom-log-viewer/severity-filter-and-sources/scenario.md`
+- `e2e-agentic-test/019-bottom-log-viewer/event-source-class/scenario.md`
+- `e2e-agentic-test/046-i18n-error-codes/no-raw-keys-and-translated-errors/scenario.md`

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -1,0 +1,52 @@
+# PlateVault user manual
+
+PlateVault is a local-first desktop app for organizing an astrophotography
+library. It catalogs your FITS/XISF frames, maps them to targets, sessions,
+and projects, prepares inputs for processing tools such as PixInsight/WBPP,
+and plans filesystem changes — moves, archives, cleanup — as reviewable plans
+that you approve before anything happens on disk.
+
+Two things PlateVault will never do:
+
+- **Process your images.** Calibration, registration, integration, and
+  editing belong to PixInsight/WBPP (or another processing tool). PlateVault
+  organizes, documents, and prepares; your processing tool processes.
+- **Change files behind your back.** Every move, copy, archive, or delete is
+  proposed as a plan first, applied only when you approve it, and recorded in
+  the audit log. See [The safety model](./09-safety-model.md).
+
+## Chapters
+
+| # | Chapter | What it covers |
+|---|---------|----------------|
+| 1 | [Getting started](./01-getting-started.md) | First-run setup wizard, registering data sources, protection defaults, managing sources over time |
+| 2 | [The Inbox](./02-inbox.md) | Scanning for new files, reviewing and reclassifying items, the metadata gate, confirming (move or catalogue-in-place), applying plans |
+| 3 | [Sessions](./03-sessions.md) | Acquisition sessions as a derived, always-current view; filtering, grouping, notes |
+| 4 | [Projects](./04-projects.md) | Creating projects, attaching sources, manifests and notes, launching a processing tool, tracking output artifacts |
+| 5 | [Cleanup and archive](./05-cleanup-and-archive.md) | Reclaiming disk space safely, archiving finished projects, deleting from the archive |
+| 6 | [Calibration](./06-calibration.md) | Master frames, fingerprint columns, matching masters to sessions, tolerances |
+| 7 | [Targets and planning](./07-targets-and-planning.md) | The target catalog, SIMBAD lookups, aliases and notes, and what the planner columns show today |
+| 8 | [Settings](./08-settings.md) | Every settings pane: appearance and themes, data sources, ingestion, planner tunables, and more |
+| 9 | [The safety model](./09-safety-model.md) | Reviewable plans, no silent overwrites, the audit log, archive-before-delete, protected sources |
+| 10 | [Troubleshooting](./10-troubleshooting.md) | Common error messages and what they mean, the log panel, gathering support data |
+
+## Conventions used in this manual
+
+- **Bold text in quotes** matches the app's on-screen labels exactly — for
+  example, the **Rescan** button on the Inbox page.
+- Screenshots are marked as placeholders like
+  `[screenshot: the Inbox with a plan open]` until captured.
+- Features that are designed but not yet available in the current build are
+  called out in **Not yet available** notes rather than silently omitted.
+- Each chapter ends with a **Related journeys** section linking to the
+  product-level walkthroughs in
+  [`docs/product/user-journeys.md`](../product/user-journeys.md) and the
+  click-by-click scenario scripts under `e2e-agentic-test/`.
+
+## Where to start
+
+New install? Read [Getting started](./01-getting-started.md), then
+[The Inbox](./02-inbox.md) — those two chapters take you from an empty
+database to files catalogued in your library. If you want to understand why
+PlateVault asks for review so often before touching your files, read
+[The safety model](./09-safety-model.md) first.


### PR DESCRIPTION
## Summary

End-user manual for PlateVault under `docs/manual/` — documentation only, no product code changes.

- `README.md` — index, conventions, reading order
- `01-getting-started.md` — first-run wizard (5 steps), data-source management (rescan/remap/disable/delete), protection defaults
- `02-inbox.md` — scan, single-type item classification, bulk reclassify, missing-mandatory gate, move vs catalogue-in-place, plan review/apply
- `03-sessions.md` — derived groupings, live membership, filters/grouping/calendar, deliberate absence of review controls
- `04-projects.md` — create/edit, sources, per-channel numbers, manifests, notes, tool launch (containment), artifact observation
- `05-cleanup-and-archive.md` — scan→review→apply, archive lifecycle, trash/typed-DELETE; explicit note on the missing archive-plan-generation UI and deferred Restore
- `06-calibration.md` — masters as individual items, kind-conditional columns, matching/force-assign, tolerance settings
- `07-targets-and-planning.md` — catalog, SIMBAD resolve-on-demand, aliases/notes; honest-stub section for planner columns (047 pending merge, 044 altitude columns pending)
- `08-settings.md` — all 12 panes incl. the four themes (Warm Clay / Warm Slate / Observatory / Espresso), planner threshold, ingestion caveat
- `09-safety-model.md` — the trust story: reviewable plans, no silent overwrite, archive-before-delete, protection acknowledgement, audit log
- `10-troubleshooting.md` — exact translated error messages grouped by area, the Activity log panel, support-data gathering

## Conventions

- UI labels quoted verbatim from `apps/desktop/messages/en.json`; verified against `apps/desktop/src/features/*` where the journeys doc and code disagreed.
- Screenshots are `[screenshot: …]` TODO placeholders.
- Every chapter ends with "Related journeys" links into `docs/product/user-journeys.md` (PR #425) plus `e2e-agentic-test/` scenario paths.
- Known gaps stated as "Not yet available" notes (archive-plan UI, Restore, planner astronomy, font-size wiring, ingestion settings not consumed, favourites in localStorage).

## Gap-freshness notes vs the journeys doc (2026-07-04 snapshot)

PRs #404 (Data Sources disable/delete), #405 (protection defaults), #408 (plan overlap guard), #411/#413 (project folders, cleanup review UI) have merged into the base since the journeys doc snapshot — the manual documents these as shipped. Still pending and documented as such: #414 (project folder location fix), #415 (aria-sort, archive polish, platform-native reveal labels), spec 047 branch, spec 044.

Depends on PR #425 for the `docs/product/user-journeys.md` link targets (links are correct once it merges; harmless before).