### PR TITLE
ci: skip heavy jobs for docs-only changes, scope Rust tests to changed crates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,15 @@ name: CI
 # runs on ALL three OS via tauri-plugin-webdriver (Choochmeque) embedded in
 # desktop_shell under the `e2e` feature flag — no external per-OS WebDriver
 # binary required. WebdriverIO has been retired.
+#
+# Path-aware gating (see the `changes` job): heavy Rust/frontend/E2E steps are
+# skipped for changes that cannot affect them (e.g. docs-only PRs), while every
+# job STILL RUNS and reports success. We deliberately gate *inside* the jobs
+# rather than skipping whole jobs, so each job name keeps reporting a green
+# status check on every PR (this repo's merge flow keys on all status checks
+# being green; a skipped job/workflow would leave a check pending/absent and
+# block the merge). Full-suite triggers (workflows, Cargo/lockfiles, package
+# manifests, justfile, scripts) force everything to run via `force_full`.
 
 on:
   pull_request:
@@ -23,8 +32,95 @@ env:
   CARGO_INCREMENTAL: 0
 
 jobs:
+  # Cheap change-detection gate (dorny/paths-filter). Downstream jobs read its
+  # outputs to decide which heavy steps to run. Outputs:
+  #   rust      — run Rust steps (a *.rs / crate / src-tauri / tests change, OR
+  #               any force_full trigger).
+  #   frontend  — run frontend steps (a TS/TSX/CSS / desktop-src / packages
+  #               change, OR any force_full trigger).
+  #   docs_only — informational: the change touched only docs and nothing that
+  #               drives Rust or frontend (fast-pass path).
+  #   scripts   — a scripts/** change (drives the DB-boundary ratchet).
+  #   all_files — CSV of every changed path, consumed by the changed-crate
+  #               scoping step for `cargo test -p`.
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.decide.outputs.rust }}
+      frontend: ${{ steps.decide.outputs.frontend }}
+      docs_only: ${{ steps.decide.outputs.docs_only }}
+      scripts: ${{ steps.filter.outputs.scripts }}
+      all_files: ${{ steps.filter.outputs.all_files }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          list-files: csv
+          filters: |
+            all:
+              - '**'
+            # force_full: any of these means "run the whole suite" — the build
+            # graph, dependency set, or CI itself may have changed.
+            force_full:
+              - '.github/workflows/**'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '**/package.json'
+              - 'pnpm-lock.yaml'
+              - 'justfile'
+              - 'scripts/**'
+            rust:
+              - 'crates/**'
+              - 'apps/desktop/src-tauri/**'
+              - 'tests/**'
+              - '**/*.rs'
+            frontend:
+              - 'apps/desktop/src/**'
+              - 'apps/desktop/public/**'
+              - 'apps/desktop/index.html'
+              - 'packages/**'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.css'
+            scripts:
+              - 'scripts/**'
+            docs:
+              - 'docs/**'
+              - 'e2e-agentic-test/**'
+              - 'specs/**'
+              - '**/*.md'
+              - '.apm/**'
+              - 'PRODUCT.md'
+              - 'CLAUDE.md'
+              - 'AGENTS.md'
+      - id: decide
+        shell: bash
+        run: |
+          rust=false
+          frontend=false
+          if [ "${{ steps.filter.outputs.force_full }}" = "true" ] || [ "${{ steps.filter.outputs.rust }}" = "true" ]; then
+            rust=true
+          fi
+          if [ "${{ steps.filter.outputs.force_full }}" = "true" ] || [ "${{ steps.filter.outputs.frontend }}" = "true" ]; then
+            frontend=true
+          fi
+          # docs_only: at least one doc changed and nothing drives Rust/frontend.
+          docs_only=false
+          if [ "$rust" = "false" ] && [ "$frontend" = "false" ] && [ "${{ steps.filter.outputs.docs }}" = "true" ]; then
+            docs_only=true
+          fi
+          {
+            echo "rust=$rust"
+            echo "frontend=$frontend"
+            echo "docs_only=$docs_only"
+          } >> "$GITHUB_OUTPUT"
+          echo "changes: rust=$rust frontend=$frontend docs_only=$docs_only scripts=${{ steps.filter.outputs.scripts }}"
+
   integration:
     name: Integration (Layer 1) — ${{ matrix.os }}
+    needs: changes
     strategy:
       fail-fast: false # report each platform distinctly (FR-011)
       matrix:
@@ -35,7 +131,7 @@ jobs:
 
       # Tauri's desktop_shell crate needs system webview libs to build on Linux.
       - name: Install Tauri Linux system deps
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -43,6 +139,7 @@ jobs:
             libayatana-appindicator3-dev
 
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.rust == 'true'
         with:
           components: rustfmt, clippy
 
@@ -58,23 +155,30 @@ jobs:
       # also purge the stale `v0-rust-rust-windows-latest-*` entries via
       # `gh cache list` / `gh cache delete` so open PRs stop restoring them.
       - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.rust == 'true'
         with:
           shared-key: "rust-${{ matrix.os }}-v2"
 
       - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.frontend == 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
+        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: 20
           cache: pnpm
 
+      # `just` drives the DB-boundary ratchet and the generated-drift gate, both
+      # of which run under the Rust lane.
       - uses: taiki-e/install-action@v2
+        if: needs.changes.outputs.rust == 'true'
         with:
           tool: just
 
       - name: Install JS deps
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm install --frozen-lockfile
 
       # --- Fast checks first (FR-012) ---
@@ -82,58 +186,101 @@ jobs:
       # which fails the build on any hardcoded user-facing string (SC-001/SC-002).
       # Without this step the i18n catalog gate has no teeth in CI.
       - name: Frontend ESLint (i18n catalog gate)
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop run lint:eslint
 
       - name: Rust format
+        if: needs.changes.outputs.rust == 'true'
         run: cargo fmt --all --check
+
+      # Self-test the changed-crate scoping helper's mapping/closure logic
+      # (runs once, on Linux, under the Rust lane).
+      - name: Affected-crates helper self-test
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
+        run: bash scripts/ci-affected-crates.sh --self-test
 
       # DB boundary ratchet (parked in PR #384, wired in here): fails if raw
       # sqlx query/exec sites outside crates/persistence/db exceed the
       # checked-in baseline. Pure grep, no compile — runs once on Linux only
       # per the design doc's guidance (docs/development/persistence-layer-hardening.md).
+      # Gated to run whenever Rust or scripts change (skipped on docs-only).
       - name: DB boundary ratchet
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true')
         run: just db-boundary
 
       - name: Clippy (workspace, all targets, deny warnings)
+        if: needs.changes.outputs.rust == 'true'
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       # --- Layer 1: real-backend integration + unit tests ---
       - name: Build workspace
+        if: needs.changes.outputs.rust == 'true'
         run: cargo build --workspace
 
+      # Scope `cargo test` to the changed workspace members plus their
+      # reverse-dependency closure (see scripts/ci-affected-crates.sh). Any
+      # force_full trigger (Cargo.lock, workflows, …) or a rust-relevant file
+      # outside every member yields the full-workspace fallback. Build/clippy
+      # stay workspace-wide — conservative: when in doubt, run more.
       - name: Rust tests (Layer 1 — real SQLite, real migrations)
-        run: cargo test --workspace
+        if: needs.changes.outputs.rust == 'true'
+        shell: bash
+        # CHANGED_FILES is passed via env (never interpolated into the script
+        # body) so an attacker-crafted filename cannot inject shell commands.
+        env:
+          CHANGED_FILES: ${{ needs.changes.outputs.all_files }}
+        run: |
+          args=$(printf '%s' "$CHANGED_FILES" | tr ',' '\n' | bash scripts/ci-affected-crates.sh)
+          if [ "$(printf '%s' "$args" | tr -d '[:space:]')" = "ALL" ] || [ -z "$(printf '%s' "$args" | tr -d '[:space:]')" ]; then
+            echo "Running full workspace test suite."
+            cargo test --workspace
+          else
+            echo "Running scoped tests for: $args"
+            cargo test $args
+          fi
 
       - name: Frontend unit tests
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -r --if-present test
 
       - name: TypeScript typecheck
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm -r --if-present typecheck
 
       # --- Generated contract / binding drift gate (review finding W1) ---
+      # Regenerates Rust->TS bindings and contracts and fails on drift. Compiles
+      # Rust, so it belongs to the Rust lane.
       - name: Generated contract/binding drift
+        if: needs.changes.outputs.rust == 'true'
         run: just check-generated
 
   # Mock-mode UI regression: fast Playwright run (Vite + chromium, mocks on, no
   # backend/Tauri build). The real UI->IPC->backend journeys run in the dedicated
   # WebdriverIO + tauri-driver workflow (e2e.yml). Not gated on `integration` so
   # UI regressions surface even when the Rust workspace gate is unrelatedly red.
+  # Heavy steps skip when the change cannot affect the frontend; the job still
+  # runs and reports success.
   ui-e2e:
     name: UI E2E (mock-mode Playwright)
+    needs: changes
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.frontend == 'true'
         with:
           version: 10.33.0
       - uses: actions/setup-node@v4
+        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: 20
           cache: pnpm
       - name: Install JS deps
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm install --frozen-lockfile
       - name: Install Playwright chromium
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop exec playwright install --with-deps chromium
       - name: Mock-mode UI tests
+        if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop test:e2e

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -51,8 +51,60 @@ env:
   ALM_DB_URL: "sqlite://./e2e-test.db?mode=rwc"
 
 jobs:
+  # Cheap change-detection gate — mirrors ci.yml's `changes` job. Cross-workflow
+  # `needs` is not supported, so each workflow detects changes itself. The E2E
+  # build (frontend + Rust app) is skipped when the change cannot affect either;
+  # the job still runs and reports success so its status check stays green.
+  # `run` is true when a frontend OR Rust change is present, or any full-suite
+  # trigger fires (workflows, Cargo/lockfiles, package manifests, justfile,
+  # scripts).
+  changes:
+    name: Detect changes
+    runs-on: ubuntu-latest
+    outputs:
+      run: ${{ steps.decide.outputs.run }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            force_full:
+              - '.github/workflows/**'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '**/package.json'
+              - 'pnpm-lock.yaml'
+              - 'justfile'
+              - 'scripts/**'
+            rust:
+              - 'crates/**'
+              - 'apps/desktop/src-tauri/**'
+              - 'tests/**'
+              - '**/*.rs'
+            frontend:
+              - 'apps/desktop/src/**'
+              - 'apps/desktop/public/**'
+              - 'apps/desktop/index.html'
+              - 'packages/**'
+              - '**/*.ts'
+              - '**/*.tsx'
+              - '**/*.css'
+      - id: decide
+        shell: bash
+        run: |
+          run=false
+          if [ "${{ steps.filter.outputs.force_full }}" = "true" ] \
+            || [ "${{ steps.filter.outputs.rust }}" = "true" ] \
+            || [ "${{ steps.filter.outputs.frontend }}" = "true" ]; then
+            run=true
+          fi
+          echo "run=$run" >> "$GITHUB_OUTPUT"
+          echo "e2e changes: run=$run"
+
   real-ui-e2e:
     name: Real-UI E2E — ${{ matrix.os }}
+    needs: changes
     strategy:
       fail-fast: false
       matrix:
@@ -65,7 +117,7 @@ jobs:
       # Tauri needs system webview/GTK libs to build on Linux.
       # No webkit2gtk-driver — the plugin replaces the external driver.
       - name: Install Tauri Linux system deps
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && needs.changes.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -74,34 +126,42 @@ jobs:
             xvfb
 
       - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.run == 'true'
 
       - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.run == 'true'
         with:
           shared-key: "rust-e2e-${{ matrix.os }}"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
+        if: needs.changes.outputs.run == 'true'
 
       # Install the tauri-webdriver CLI proxy.
       # It bridges W3C client (:4444) → plugin embedded server (:4445).
       - name: Install tauri-webdriver CLI
+        if: needs.changes.outputs.run == 'true'
         run: cargo install tauri-webdriver --locked
 
       - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.run == 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
+        if: needs.changes.outputs.run == 'true'
         with:
           node-version: 20
           cache: pnpm
 
       - name: Install JS deps
+        if: needs.changes.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       # Build the frontend with VITE_E2E=1 so CI-only typeable path inputs are
       # enabled (the native folder picker cannot be driven by WebDriver).
       - name: Build frontend (VITE_E2E)
+        if: needs.changes.outputs.run == 'true'
         env:
           VITE_E2E: "1"
         run: pnpm --filter @astro-plan/desktop build
@@ -109,20 +169,22 @@ jobs:
       # Serve built dist on :5173 in the background. The app binary reads the
       # Tauri devUrl (:5173) and loads its frontend from there — real IPC.
       - name: Serve frontend dist on :5173
+        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
       # Build the app binary WITH the embedded plugin so tauri-webdriver can
       # connect. The `e2e` feature MUST be absent from release builds.
       - name: Build desktop_shell with e2e feature
+        if: needs.changes.outputs.run == 'true'
         run: cargo build -p desktop_shell --features e2e
 
       # Run the Layer-2 harness (real journeys, serial per .config/nextest.toml).
       # Linux wraps in xvfb-run for a headless display; Windows/macOS run natively.
       - name: Run E2E (Linux — xvfb)
-        if: runner.os == 'Linux'
+        if: runner.os == 'Linux' && needs.changes.outputs.run == 'true'
         run: xvfb-run -a cargo nextest run -p e2e_tests --profile e2e --run-ignored all --no-tests=warn
 
       - name: Run E2E (Windows / macOS)
-        if: runner.os != 'Linux'
+        if: runner.os != 'Linux' && needs.changes.outputs.run == 'true'
         run: cargo nextest run -p e2e_tests --profile e2e --run-ignored all --no-tests=warn

--- a/scripts/ci-affected-crates.sh
+++ b/scripts/ci-affected-crates.sh
@@ -1,0 +1,158 @@
+#!/usr/bin/env bash
+# ci-affected-crates.sh — map changed files to affected Cargo workspace members.
+#
+# Reads a newline-separated list of changed file paths (repo-root-relative) on
+# stdin and prints the set of `-p <crate>` arguments for `cargo test`, covering:
+#   1. every workspace member a changed rust-relevant file lives in, PLUS
+#   2. the reverse-dependency closure of those members (workspace-internal
+#      dependents), so a change to a low-level crate still exercises its
+#      consumers.
+#
+# Conservative fallbacks (print the sentinel `ALL` and exit 0 — caller then runs
+# the full `cargo test --workspace`):
+#   - a rust-relevant changed file that maps to no workspace member, or
+#   - no changed files map to any crate but rust-relevant files changed.
+# Non-rust files (docs, frontend, etc.) on stdin are ignored.
+#
+# Usage:
+#   git diff --name-only BASE...HEAD | scripts/ci-affected-crates.sh
+#   scripts/ci-affected-crates.sh --self-test   # assert the mapping/closure logic
+#
+# Requires: cargo, jq.
+set -euo pipefail
+
+# A file is "rust-relevant" if a change to it could affect a Rust build/test.
+is_rust_relevant() {
+  case "$1" in
+    *.rs) return 0 ;;
+    */Cargo.toml | Cargo.toml) return 0 ;;
+    crates/* | apps/desktop/src-tauri/* | tests/*) return 0 ;;
+    *) return 1 ;;
+  esac
+}
+
+# Emit "<name>\t<repo-relative-dir>" for every workspace member.
+members_tsv() {
+  cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r '
+    .workspace_root as $root
+    | .packages[]
+    | [.name, (.manifest_path | sub("/Cargo.toml$"; "") | sub("^" + $root + "/?"; ""))]
+    | @tsv'
+}
+
+# Emit "<pkg>\t<workspace-internal-dependency>" edges (one per line).
+edges_tsv() {
+  local names_json
+  names_json=$(cargo metadata --no-deps --format-version 1 2>/dev/null \
+    | jq -c '[.packages[].name]')
+  cargo metadata --no-deps --format-version 1 2>/dev/null | jq -r --argjson names "$names_json" '
+    .packages[] as $p
+    | $p.dependencies[]
+    | select(.name as $d | $names | index($d))
+    | [$p.name, .name]
+    | @tsv'
+}
+
+# Compute the affected `-p` args from a newline-separated file list on stdin.
+affected_args() {
+  local files members edges
+  files=$(cat)
+
+  members=$(members_tsv)
+  edges=$(edges_tsv)
+
+  # 1. Direct crates: longest-prefix match of each rust-relevant file to a member dir.
+  local direct="" saw_rust=0 f name dir best_name best_len len
+  while IFS= read -r f; do
+    [ -n "$f" ] || continue
+    is_rust_relevant "$f" || continue
+    saw_rust=1
+    best_name=""; best_len=-1
+    while IFS=$'\t' read -r name dir; do
+      [ -n "$dir" ] || continue
+      case "$f" in
+        "$dir"/*)
+          len=${#dir}
+          if [ "$len" -gt "$best_len" ]; then best_len=$len; best_name=$name; fi
+          ;;
+      esac
+    done <<< "$members"
+    if [ -z "$best_name" ]; then
+      # rust-relevant file outside every member → cannot scope safely.
+      echo "ALL"; return 0
+    fi
+    direct+="$best_name"$'\n'
+  done <<< "$files"
+
+  # No rust-relevant files at all → nothing to test here.
+  if [ "$saw_rust" -eq 0 ]; then return 0; fi
+
+  direct=$(printf '%s' "$direct" | sort -u | sed '/^$/d')
+
+  # 2. Reverse-dependency closure (BFS over dependent edges).
+  local closure="$direct" frontier="$direct" next dep pkg
+  while [ -n "$frontier" ]; do
+    next=""
+    while IFS= read -r name; do
+      [ -n "$name" ] || continue
+      while IFS=$'\t' read -r pkg dep; do
+        if [ "$dep" = "$name" ] && ! grep -qxF "$pkg" <<< "$closure"; then
+          closure+=$'\n'"$pkg"
+          next+="$pkg"$'\n'
+        fi
+      done <<< "$edges"
+    done <<< "$frontier"
+    frontier=$(printf '%s' "$next" | sed '/^$/d')
+  done
+
+  # 3. Emit -p args, sorted & deduped for stable output.
+  printf '%s\n' "$closure" | sort -u | sed '/^$/d' | while IFS= read -r name; do
+    printf -- '-p %s ' "$name"
+  done
+  echo
+}
+
+self_test() {
+  local out fail=0
+  assert_contains() { # <label> <needle> <haystack>
+    if grep -q -- "$2" <<< "$3"; then echo "ok: $1"; else echo "FAIL: $1 (missing '$2' in: $3)"; fail=1; fi
+  }
+  assert_empty() { # <label> <value>
+    if [ -z "$(echo "$2" | tr -d '[:space:]')" ]; then echo "ok: $1"; else echo "FAIL: $1 (expected empty, got: $2)"; fail=1; fi
+  }
+  assert_eq() { # <label> <expected> <actual>
+    if [ "$2" = "$3" ]; then echo "ok: $1"; else echo "FAIL: $1 (expected '$2', got '$3')"; fail=1; fi
+  }
+
+  # A leaf-ish crate change includes itself.
+  out=$(printf 'crates/patterns/src/lib.rs\n' | affected_args)
+  assert_contains "changed crate maps to itself" "-p patterns" "$out"
+
+  # A low-level crate change pulls in dependents (closure > just itself).
+  out=$(printf 'crates/domain/core/src/lib.rs\n' | affected_args)
+  assert_contains "domain_core change includes domain_core" "-p domain_core" "$out"
+  if [ "$(printf '%s' "$out" | grep -o -- '-p' | wc -l)" -gt 1 ]; then
+    echo "ok: domain_core change includes reverse deps"
+  else
+    echo "FAIL: domain_core change should include reverse deps (got: $out)"; fail=1
+  fi
+
+  # Docs-only file list yields no crates.
+  out=$(printf 'docs/x.md\nREADME.md\n' | affected_args)
+  assert_empty "docs-only files yield no crates" "$out"
+
+  # A rust-relevant file outside any member is the conservative ALL sentinel.
+  out=$(printf 'tests/orphan_top_level.rs\n' | affected_args)
+  assert_eq "orphan rust file -> ALL" "ALL" "$(echo "$out" | tr -d '[:space:]')"
+
+  # Mixed docs + one crate: docs ignored, crate scoped.
+  out=$(printf 'docs/x.md\ncrates/patterns/src/lib.rs\n' | affected_args)
+  assert_contains "mixed docs+crate scopes to crate" "-p patterns" "$out"
+
+  [ "$fail" -eq 0 ] && echo "ci-affected-crates self-test: PASS" || { echo "ci-affected-crates self-test: FAIL"; return 1; }
+}
+
+case "${1:-}" in
+  --self-test) self_test ;;
+  *) affected_args ;;
+esac


### PR DESCRIPTION
## What & why

The PR CI was running the **full matrix** (3-OS Rust workspace build+test, frontend unit tests, mock-mode Playwright, real-UI E2E ×3) on *every* `pull_request`, including docs-only PRs — ~35 scenario-doc PRs merged today each burned ~60 CI-minutes for zero code change.

This makes CI **path-aware** without touching branch-protection / merge flow:

- **(a) docs-only** PRs skip all heavy jobs (≈1-2 min: change-detect + fast-exit).
- **(b) Rust tests scope to changed crates** + their reverse-dependency closure.
- **(c) frontend-only** skips the Rust lane; **rust-only** skips the frontend lanes.

## How required-check reporting is preserved (the crux)

The target branch is **unprotected**, so the CI shepherd keys merge-worthiness on **all `statusCheckRollup` entries being green**. A skipped *workflow* (`paths:`/`paths-ignore:`) leaves its checks **pending/absent** → unmergeable; a skipped *job* (`if:` at job level) emits a `SKIPPED` rollup entry that the shepherd may not treat as green.

So: **every job still runs and reports SUCCESS on every PR.** Gating is done *inside* jobs — a cheap `changes` job (dorny/paths-filter@v4) publishes boolean outputs, and each heavy **step** carries `if: needs.changes.outputs.<lane> == 'true'`. On a docs-only PR the matrix jobs do `checkout` + fast-exit and report green. No existing check name changes; one additive green check (`Detect changes`) appears in each workflow.

Check names preserved: `Integration (Layer 1) — {ubuntu,windows,macos}-latest`, `UI E2E (mock-mode Playwright)`, `Real-UI E2E — {ubuntu,windows,macos}-latest`.

## Change detection

`changes` job filters:
- **force_full** (⇒ run everything): `.github/workflows/**`, `**/Cargo.toml`, `Cargo.lock`, `**/package.json`, `pnpm-lock.yaml`, `justfile`, `scripts/**`.
- **rust**: `crates/**`, `apps/desktop/src-tauri/**`, `tests/**`, `**/*.rs`.
- **frontend**: `apps/desktop/src/**`, `apps/desktop/public/**`, `apps/desktop/index.html`, `packages/**`, `**/*.{ts,tsx,css}`.
- **scripts**: `scripts/**` (drives DB-boundary ratchet).
- **docs** (labeling): `docs/**`, `e2e-agentic-test/**`, `specs/**`, `**/*.md`, `.apm/**`, `PRODUCT.md`, `CLAUDE.md`, `AGENTS.md`.

`docs_only = !rust && !frontend && docs-matched`. Run decisions use **positive** signals only, so an unknown/uncategorized file never silently skips Rust *and* isn't misreported as docs-only.

## Changed-crate scoping

`scripts/ci-affected-crates.sh` maps changed files → workspace members (longest-prefix match against `cargo metadata` manifest dirs), then BFS-expands the **reverse-dependency closure** (workspace-internal dependents) and prints `-p <crate>` args for `cargo test`. Conservative fallbacks print `ALL` (⇒ full `cargo test --workspace`): any `force_full` trigger, a rust-relevant file outside every member, or a lockfile/workflow-only change. `cargo build`/`clippy`/`fmt` stay workspace-wide (run more, not less). The helper ships with a `--self-test` (assertions on itself→closure, docs-ignore, orphan→ALL, mixed) that runs as a CI step on Linux. The changed-file list is passed via `env:` (never interpolated into the run body) to avoid filename command-injection.

DB-boundary ratchet runs when Rust **or** scripts change; skipped on docs-only (constraint preserved, not weakened).

## Verification matrix

| Change type | changes job | Rust lane (build/clippy/test) | Frontend lane (eslint/unit/tsc) | mock UI E2E | real-UI E2E ×3 | DB-boundary |
|---|---|---|---|---|---|---|
| **docs-only** | ✅ runs | skip | skip | skip | skip | skip |
| **rust-only** | ✅ runs | ✅ (test scoped to `-p` closure) | skip | skip | ✅ | ✅ |
| **frontend-only** | ✅ runs | skip | ✅ | ✅ | ✅ | skip |
| **mixed rust+fe** | ✅ runs | ✅ | ✅ | ✅ | ✅ | ✅ |
| **force_full** (workflows / Cargo* / package.json / pnpm-lock / justfile / scripts) | ✅ runs | ✅ full `--workspace` | ✅ | ✅ | ✅ | ✅ |
| **push to main** | ✅ runs | per force_full/rust | per frontend | per frontend | per change | per rust/scripts |

Every row: **all job status checks report green** (heavy steps just skip). This PR itself touches only `.github/workflows/**` + `scripts/**` ⇒ **force_full** ⇒ Rust lane fires full workspace, frontend lanes skip — self-demonstrating.

## Reference implementations reviewed

- **astro-up** (`.github/workflows/ci.yml`) — **adopted**: the `changes` + `dorny/paths-filter@v4` structure and per-crate `cargo test -p` scoping (improved here from a hardcoded crate list to a dynamic reverse-dep closure). **Rejected**: its single `ci-ok` aggregate gate + job-level `if:` skip. That model requires branch protection to require *only* the aggregate check; here the branch is unprotected and the shepherd keys on the existing per-job rollup, so job-level skips would emit `SKIPPED` entries and switching to a single gate would need shepherd reconfiguration — out of scope and riskier than in-job step gating.
- **srobroek/bellwether** (`publish-image.yml`) — **adopted**: the cheap-gate-before-expensive-work `needs:` ordering (its `test`→`publish`); here heavy lanes `needs: changes` so nothing expensive starts until the cheap detector has spoken. **Rejected**: nothing else applies (it gates an irreversible image publish on `main` push, not PR fan-out).

Left the sibling `ci-release-please` lane's future workflow untouched; changes here are confined to the existing PR-CI surface (`ci.yml`, `e2e.yml`) + one new script.
