### PR TITLE
chore: remove dead Design-V2 fixture pages and pin Cleanup TODO to spec 017

### DIFF
--- a/apps/desktop/src/__smoke__.ts
+++ b/apps/desktop/src/__smoke__.ts
@@ -78,9 +78,7 @@ import { MastersList } from '@/features/calibration/MastersList';
 import { MasterDetail } from '@/features/calibration/MasterDetail';
 
 import { TargetsPage } from '@/features/targets/TargetsPage';
-import { TargetDetailPane } from '@/features/targets/TargetDetailPane';
 import { TargetList } from '@/features/targets/TargetList';
-import { CoverageChart } from '@/features/targets/CoverageChart';
 
 import { ProjectsPage } from '@/features/projects/ProjectsPage';
 import { ProjectDetail } from '@/features/projects/ProjectDetail';
@@ -162,9 +160,7 @@ export type SmokeCheck = {
   mastersList: typeof MastersList;
   masterDetail: typeof MasterDetail;
   targetsPage: typeof TargetsPage;
-  targetDetailPane: typeof TargetDetailPane;
   targetList: typeof TargetList;
-  coverageChart: typeof CoverageChart;
   projectsPage: typeof ProjectsPage;
   projectDetail: typeof ProjectDetail;
   wizardPage: typeof WizardPage;

--- a/apps/desktop/src/features/settings/Cleanup.tsx
+++ b/apps/desktop/src/features/settings/Cleanup.tsx
@@ -160,7 +160,7 @@ export function Cleanup({ save }: CleanupProps) {
       </SettingsSection>
 
       {/* Per-type cleanup actions — fixture mockup, not yet wired to backend */}
-      {/* TODO(cleanup-plan-spec): replace CLEANUP_TYPES fixture with backend data */}
+      {/* TODO(spec 017 US2): replace CLEANUP_TYPES fixture with the archive plan generator once it lands */}
       <SettingsSection title={m.settings_cleanup_pertype_title()}>
         {warnedTypes.length > 0 && (
           <Banner variant="danger" className="alm-cleanup__warning">

--- a/apps/desktop/src/features/targets/CoverageChart.tsx
+++ b/apps/desktop/src/features/targets/CoverageChart.tsx
@@ -1,9 +1,0 @@
-// Stub — CoverageChart replaced by CoverageBar (from @/ui) in Design V3.
-// Retained for smoke-test import compatibility.
-export interface CoverageChartProps {
-  coverage: Record<string, number>;
-  recommended: Record<string, number>;
-}
-export function CoverageChart(_props: CoverageChartProps) {
-  return null;
-}

--- a/apps/desktop/src/features/targets/TargetDetailPane.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailPane.tsx
@@ -1,8 +1,0 @@
-// Stub — TargetDetailPane replaced by TargetDetail in Design V3.
-// Retained for smoke-test import compatibility.
-export interface TargetDetailPaneProps {
-  targetId: string;
-}
-export function TargetDetailPane(_props: TargetDetailPaneProps) {
-  return null;
-}


### PR DESCRIPTION
## Summary
- Removes `TargetDetailPane.tsx` and `CoverageChart.tsx`, Design-V2 leftovers already stubbed to `return null` during the Design V3 rewrite and kept alive only by `__smoke__.ts`'s compile-time import check (`TargetDetail.tsx` itself was already removed in #402).
- Drops the corresponding imports/type-usages from `__smoke__.ts`.
- Repoints the `Cleanup.tsx` per-type-actions TODO from the vague `cleanup-plan-spec` placeholder to spec 017 US2 (the archive plan generator), the actual pending backend area per the current sweep. `fixtures/settings.ts` (used elsewhere in Cleanup.tsx) is untouched.

## Test plan
- [x] `pnpm exec tsc --noEmit` (via `pnpm run typecheck`) — clean
- [x] `pnpm run lint` — 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `pnpm exec vitest run src/features/targets src/features/settings` — 25 files / 251 tests passed