### PR TITLE
build: adopt cargo-nextest; evaluate biome for JS lint/format

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -32,3 +32,33 @@ fail-fast = false
 
 # Print failures immediately and again at the end for easy scanning.
 failure-output = "immediate-final"
+
+# ---------------------------------------------------------------------------
+# CI profile for the Layer-1 workspace test run (spec: build/adopt-nextest).
+#
+# Used by CI via `cargo nextest run --workspace --profile ci`. Local `just test`
+# uses the built-in "default" profile (fail-fast on, no retries, no JUnit).
+# ---------------------------------------------------------------------------
+[profile.ci]
+# Report every failing test in one run instead of stopping at the first, so a
+# broken CI matrix leg shows the full failure set (matches the workspace
+# `cargo test` behaviour this profile replaces, which ran all test binaries).
+fail-fast = false
+
+# Print failures immediately and again in a trailing summary for easy scanning
+# of long CI logs.
+failure-output = "immediate-final"
+
+# Machine-readable results for CI test reporters. Written to
+# `target/nextest/ci/junit.xml`.
+[profile.ci.junit]
+path = "junit.xml"
+
+# Retry ONLY the real-SQLite integration-test binaries. These live in the
+# `tests/` dirs (kind(test)) of the DB-touching crates and can flake under
+# parallel SQLite file/pool access on loaded CI runners. Unit tests
+# (kind(lib)) are deliberately NOT retried — a red unit test is a real failure
+# and must not be masked by re-running.
+[[profile.ci.overrides]]
+filter = 'kind(test) & (package(persistence_db) | package(app_core) | package(targeting_resolver))'
+retries = 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
       - uses: taiki-e/install-action@v2
         if: needs.changes.outputs.rust == 'true'
         with:
-          tool: just
+          tool: just,nextest
 
       - name: Install JS deps
         if: needs.changes.outputs.frontend == 'true'
@@ -227,17 +227,25 @@ jobs:
         shell: bash
         # CHANGED_FILES is passed via env (never interpolated into the script
         # body) so an attacker-crafted filename cannot inject shell commands.
+        # nextest --profile ci: fail-fast off (report every failing leg), JUnit
+        # output, and retries=2 scoped to the real-SQLite integration binaries
+        # only (see .config/nextest.toml). Unit tests are not retried.
         env:
           CHANGED_FILES: ${{ needs.changes.outputs.all_files }}
         run: |
           args=$(printf '%s' "$CHANGED_FILES" | tr ',' '\n' | bash scripts/ci-affected-crates.sh)
           if [ "$(printf '%s' "$args" | tr -d '[:space:]')" = "ALL" ] || [ -z "$(printf '%s' "$args" | tr -d '[:space:]')" ]; then
             echo "Running full workspace test suite."
-            cargo test --workspace
+            cargo nextest run --workspace --profile ci
           else
             echo "Running scoped tests for: $args"
-            cargo test $args
+            cargo nextest run --profile ci $args
           fi
+
+      # nextest does not run doctests; keep them in a dedicated step.
+      - name: Rust doctests
+        if: needs.changes.outputs.rust == 'true'
+        run: cargo test --workspace --doc
 
       - name: Frontend unit tests
         if: needs.changes.outputs.frontend == 'true'

--- a/docs/development/biome-evaluation-2026-07.md
+++ b/docs/development/biome-evaluation-2026-07.md
@@ -1,0 +1,75 @@
+# Biome evaluation for JS/TS lint + format (2026-07)
+
+**Verdict: do NOT adopt Biome.** Keep ESLint as the sole JS/TS linter; do not
+add a formatter in this pass. This is a reasoned "no", recorded so the question
+isn't re-opened without new information.
+
+## What was evaluated
+
+Whether Biome (v2.4.14) should replace or augment the current frontend lint
+stack for `apps/desktop/src` (337 real source files, excluding generated
+`src/bindings/**` and `src/paraglide/**`).
+
+Full replacement is off the table by construction:
+
+- Biome has **no custom-rule plugin system**, so the spec-046 i18n catalog gate
+  (`alm/no-user-string`) and `alm/no-js-plural` — both in
+  `apps/desktop/eslint-rules/no-user-string.js` — **cannot move**.
+- Biome does **not do type-aware linting** (no TS type program), so the entire
+  `typescript-eslint` `recommendedTypeChecked` layer (`no-floating-promises`,
+  `no-misused-promises`, `no-unsafe-*`, `no-base-to-string`, `require-await`,
+  `only-throw-error`, …) must stay in ESLint.
+- The `no-restricted-syntax` inline-`style={…}` gate uses an esquery AST
+  selector; Biome has no equivalent generic-selector rule, so it stays too.
+- `jsx-a11y` (enforced at **error** across `src/**`) and `react-hooks` are only
+  partially covered by Biome's a11y/correctness rules; parity is not guaranteed.
+
+So the only live question was the **hybrid**: Biome as formatter + fast
+core-lint first pass, with ESLint retained for the custom + type-aware + a11y +
+selector layer.
+
+## Measurements (warm runs, `apps/desktop`)
+
+| Task | Tool | Wall time | Peak RSS |
+|------|------|-----------|----------|
+| Lint `src/` (full gate) | ESLint | **17.25 s** | ~2.0 GB |
+| Lint `src` (core rules only) | Biome | **0.51 s** | ~89 MB |
+| `check` (lint+format+assist) | Biome | 0.77 s | — |
+| `tsc --noEmit` (type program) | tsc | **6.53 s** | — |
+
+ESLint gate result: 0 errors / 223 warnings (green).
+
+## Why the hybrid does not win
+
+**Lint:** Biome is ~34× faster, but only because it runs a *strict subset* of
+the cheap, non-type-aware core rules. Every rule that actually gates this
+repo's CI — the i18n custom rules, the type-aware `@typescript-eslint` layer,
+a11y-at-error, and the inline-style selector — **must remain in ESLint**.
+ESLint's dominant cost is building the TypeScript type program (`tsc` alone is
+6.5 s; ESLint's `projectService` pays that plus per-rule evaluation). Offloading
+the handful of core-style rules Biome could cover removes **none** of that
+fixed cost. Net effect of the hybrid: a second tool + config + CI step for
+~0 s saved on the critical path, plus the ongoing risk of the two tools
+double-firing or disagreeing.
+
+**Format:** There is **no formatter today** (no Prettier, no config). Adopting
+Biome's formatter — even with a config style-matched to the existing code
+(2-space, single quotes, semicolons, trailing commas, always-arrow-parens) —
+still reformats **336 of 337** files (~24k changed lines), driven almost
+entirely by Biome's line-wrapping opinions. Per the task constraint ("if Biome
+formatting would produce a large diff, don't reformat the tree in this PR"),
+that rules out adopting Biome-as-formatter here.
+
+## Deferred option (not done)
+
+Introducing a formatter at all is a genuine gap. If the team later wants one, it
+should be a **separate, dedicated "format the whole tree" PR** (Biome *or*
+Prettier), reviewed as pure churn, not smuggled into a toolchain change. That is
+explicitly out of scope for this change.
+
+## vitest
+
+Already the frontend test runner (`vitest@4.1.7`, `vitest run`). Config
+(`apps/desktop/vitest.config.ts`) is clean — jsdom env, correct
+include/exclude, dev-tools statically false for the release gate. **No changes
+made.**

--- a/justfile
+++ b/justfile
@@ -2,8 +2,11 @@ default:
     @just --list
 
 # Run Rust workspace tests and package tests when present.
+# cargo-nextest runs the unit/integration suite (faster, per-test output);
+# `cargo test --doc` runs doctests, which nextest does not execute.
 test:
-    cargo test --workspace
+    cargo nextest run --workspace
+    cargo test --workspace --doc
     pnpm -r --if-present test
 
 # Lint and format
@@ -93,7 +96,8 @@ speckit-status:
 
 # Run all Rust workspace tests (integration layer).
 test-integration:
-    cargo test --workspace
+    cargo nextest run --workspace
+    cargo test --workspace --doc
 
 # Run end-to-end tests against the real Tauri backend.
 test-e2e:


### PR DESCRIPTION
Two independent toolchain changes, one PR, cleanly separated into two commits.

## JOB 1 — adopt cargo-nextest (commit `bce77b2e`)

Swaps the Rust workspace test run from `cargo test` to `cargo-nextest` (faster,
per-test output, retries + JUnit in CI). nextest was already used for the
Layer-2 E2E suite in `e2e.yml`; this extends it to the Layer-1 workspace run.

- **`.config/nextest.toml`**: new `[profile.ci]` — `fail-fast = false` (report
  every failing matrix leg, matching the old `cargo test --workspace`
  all-binaries behaviour), `failure-output = immediate-final`, and JUnit output
  at `target/nextest/ci/junit.xml`. A single `retries = 2` **override scoped
  only to the real-SQLite integration-test binaries**
  (`kind(test) & (package(persistence_db) | package(app_core) | package(targeting_resolver))`).
  Unit tests (`kind(lib)`) are deliberately **not** retried — a red unit test is
  a real failure.
- **`justfile`**: `just test` and `test-integration` now run
  `cargo nextest run --workspace` **plus** `cargo test --workspace --doc`.
  nextest does not run doctests, and this workspace **has** 4 runnable ones
  (3 in `domain_core`, 1 in `contracts_core`) — verified, they pass.
- **`ci.yml`**: install nextest via `taiki-e/install-action` (`tool: just,nextest`),
  swap the Layer-1 test step for `cargo nextest run --workspace --profile ci`,
  add a dedicated doctest step.

### Local run evidence (nextest 0.9.138, Linux)

| Scope | Result |
|-------|--------|
| `domain_core` + `contracts_core` | 130 passed |
| `persistence_db` (real SQLite) | 222 passed, JUnit written |
| 10 integration crates (app_core, inbox, calibration, projects, lifecycle, settings, targets, targeting_resolver, contract_tests, patterns) | 1042 passed |
| `desktop_shell` (tauri, webview) | 49 passed |
| doctests (`cargo test --doc`) | 4 passed |

The historically-red `desktop_shell` stub tests are **green** on this base, so
nextest is at parity with `cargo test` (no worse) — it runs the same binaries
with better process isolation.

## JOB 2 — biome evaluation (commit `9f79d1a2`) → reasoned NO

Evaluated Biome; **did not integrate**. Full write-up + measurements in
`docs/development/biome-evaluation-2026-07.md`. Summary:

- ESLint full gate: **17.25 s**; Biome core-lint: **0.51 s**; but Biome cannot
  run the rules that actually gate CI (i18n custom `alm/*` rules, type-aware
  `typescript-eslint`, a11y-at-error, the inline-style `no-restricted-syntax`
  selector). ESLint's dominant cost is the TS type program (`tsc` alone = 6.5 s),
  which Biome cannot offload — so the hybrid saves ~0 s on the critical path
  while adding a second tool.
- As a formatter (none exists today): a style-matched Biome still reformats
  **336/337** files (~24k lines), so adopting it would mean a large tree-wide
  diff — out of scope per the task.
- **vitest** confirmed as the frontend runner (`vitest@4.1.7`); config is clean,
  unchanged.

## CI sequencing note re #427

Open PR **#427** ("ci-path-aware") reworks the same `ci.yml` test step to add
changed-crate scoping (`scripts/ci-affected-crates.sh`). It is **not** in this
PR's base (`redesign-ui-platevault`) yet. This PR keeps its `ci.yml` delta
minimal (install line + one step swap + one added doctest step). **Merge order:
land #427 first, then rebase this branch** — the nextest swap is compatible with
#427's affected-crate scoping (`cargo nextest run` accepts the same `-p` args as
`cargo test`), so the rebase is a small manual reconcile of the one test step.

Do not merge — CI shepherd merges.
