### PR TITLE
fix(ci): make macos-latest Real-UI E2E best-effort, not blocking

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -28,6 +28,21 @@
 # - This workflow runs independently of ci.yml (Layer-1 integration). Ordering /
 #   merge-gating is enforced by branch-protection required checks, not a
 #   cross-workflow `needs` (which GitHub only supports for reusable workflows).
+#
+# macOS is best-effort, not required (see `docs/development/testing.md`'s
+# Layer-2 note: "Required on Windows + Linux; best-effort on macOS (no
+# official WKWebView WebDriver)"). In practice the embedded
+# `tauri-plugin-webdriver` server on `desktop_shell` never becomes reachable
+# on `macos-latest` GitHub runners: the app boots (build succeeds), but the
+# `tauri-webdriver` CLI proxy gets `Connection refused (os error 61)` against
+# the plugin's native port on every attempt until the 120s launch deadline —
+# reproduced identically on every open PR (e.g. CI runs 28712192291 and
+# 28712185403), never a per-PR regression. The plugin's own upstream E2E
+# workflow (Choochmeque/tauri-plugin-webdriver) fails its macos-latest leg on
+# essentially every recent run too, so this is an upstream/runner-side
+# limitation, not something fixable in this repo. `continue-on-error` keeps
+# the leg running — so coverage isn't silently dropped and a future upstream
+# fix is visible — without blocking every PR on it.
 
 name: Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)
 
@@ -58,6 +73,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    # macOS is best-effort (see header comment): a runner-side
+    # tauri-plugin-webdriver connectivity issue, not a per-PR regression.
+    continue-on-error: ${{ matrix.os == 'macos-latest' }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- "Real-UI E2E — macos-latest" fails identically on every open PR (#429, #431, #432, #433): the `tauri-webdriver` CLI proxy gets `Connection refused (os error 61)` against the embedded `tauri-plugin-webdriver` server until the 120s launch deadline — confirmed byte-identical in CI runs 28712192291 and 28712185403.
- This is a runner-side limitation, not a per-PR regression: Linux and Windows pass every time, and the plugin's own upstream E2E workflow (`Choochmeque/tauri-plugin-webdriver`) fails its `macos-latest` leg on essentially every recent run too.
- `docs/development/testing.md` already documents Layer-2 E2E as "Required on Windows + Linux; best-effort on macOS (no official WKWebView WebDriver)" — the workflow just didn't reflect that policy. Added `continue-on-error` for the `macos-latest` matrix leg so it keeps running (coverage stays visible) without blocking every PR.

## Test plan
- [x] YAML validated (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [x] Pre-commit hooks passed (yaml check, secrets scan)
- [ ] Confirm the `real-ui-e2e (macos-latest)` job reports success (not failure) on this PR's own CI run even though the underlying test still fails