### PR TITLE
fix: wire archive.plan.generate to a real UI entry point

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1082,6 +1082,8 @@
   "projects_toast_reinfer_failed": "Re-infer failed.",
   "projects_toast_dismiss_failed": "Dismiss failed.",
   "projects_toast_plan_required": "A filesystem plan is required before this transition. Create or approve a plan first.",
+  "projects_archive_generate_failed": "Could not generate the archive plan.",
+  "projects_archive_review_title": "Review archive plan",
   "projects_toast_transition_failed": "Transition failed.",
   "projects_toast_transitioned": "Project {state}.",
   "projects_toast_archived_readonly": "This project is archived. Notes cannot be edited.",
@@ -2056,6 +2058,21 @@
       "match": {
         "pp=one": "{count} file · {size}",
         "pp=other": "{count} files · {size}"
+      }
+    }
+  ],
+  "projects_archive_plan_created_toast": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "Archive plan created with {count} item — review before anything is moved.",
+        "pp=other": "Archive plan created with {count} items — review before anything is moved."
       }
     }
   ],

--- a/apps/desktop/src/features/archive/store.ts
+++ b/apps/desktop/src/features/archive/store.ts
@@ -16,6 +16,7 @@ import type {
   AuditEntry,
   ArchiveSendToTrashResponse,
   ArchivePermanentlyDeleteResponse,
+  GenerateArchivePlanResult,
 } from '@/bindings/index';
 
 // Local IPC helpers — mirror the `unwrap()` pattern used by projects/store.ts.
@@ -38,6 +39,10 @@ async function sendToTrash(planId: string): Promise<ArchiveSendToTrashResponse> 
 
 async function permanentlyDelete(planId: string): Promise<ArchivePermanentlyDeleteResponse> {
   return unwrap(await commands.archivePermanentlyDelete(planId, 'DELETE'));
+}
+
+async function generateArchivePlan(projectId: string): Promise<GenerateArchivePlanResult> {
+  return unwrap(await commands.archivePlanGenerate(projectId, null));
 }
 
 // Query state shape (matches the projects/store.ts QueryState<T> surface).
@@ -94,5 +99,17 @@ export function usePermanentlyDelete() {
     onSuccess: () => {
       void queryClient.invalidateQueries({ queryKey: queryKeys.archive.list() });
     },
+  });
+}
+
+/**
+ * Materialise a reviewable whole-project archive plan (spec 017 US2/WP-B).
+ * The ONLY UI entry point that calls `archive.plan.generate` — previously
+ * the completed→archived lifecycle transition dead-ended on a "create or
+ * approve a plan first" toast with no route to actually create one.
+ */
+export function useGenerateArchivePlan() {
+  return useMutation<GenerateArchivePlanResult, Error, string>({
+    mutationFn: generateArchivePlan,
   });
 }

--- a/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
@@ -1,0 +1,164 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * ProjectDetail archive-plan wiring tests (spec 017 US2/WP-B UI-gap fix).
+ *
+ * `archive.plan.generate` previously had zero UI callers: the completed →
+ * archived transition dead-ended on a "create or approve a plan first" info
+ * toast with no way to actually create the plan (the flow only worked driven
+ * over the dev bridge). Verifies that a plan.required refusal on the
+ * archived edge now:
+ *
+ * 1. still surfaces the exact info toast (unchanged, still plan-gated —
+ *    no silent lifecycle flip);
+ * 2. calls `archive.plan.generate` for the project (the shared
+ *    `useGenerateArchivePlan` mutation);
+ * 3. opens the shared `PlanReviewOverlay` with the returned plan id;
+ * 4. surfaces an error toast (and no overlay) when generation itself fails.
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  invoke: vi.fn(),
+}));
+
+vi.mock('./store', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./store')>();
+  return {
+    ...original,
+    useProjectDetail: vi.fn(),
+    callTransitionLifecycle: vi.fn(),
+    callReinferChannels: vi.fn(),
+    callDismissChannelDrift: vi.fn(),
+  };
+});
+
+vi.mock('@/shared/toast', () => ({
+  addToast: vi.fn(),
+}));
+
+const { mockGenerateArchivePlan } = vi.hoisted(() => ({
+  mockGenerateArchivePlan: vi.fn(),
+}));
+
+vi.mock('@/features/archive/store', () => ({
+  useGenerateArchivePlan: () => ({ mutateAsync: mockGenerateArchivePlan, isPending: false }),
+}));
+
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: ({ planId, open }: { planId: string | null; open: boolean }) =>
+    open ? <div data-testid="archive-plan-review-stub">{planId}</div> : null,
+}));
+
+import { ProjectDetailContent } from './ProjectDetail';
+import * as store from './store';
+import { addToast } from '@/shared/toast';
+import type { ProjectDetailDto } from '@/bindings/index';
+
+const mockProject: ProjectDetailDto = {
+  id: 'proj-001',
+  name: 'NGC 7000',
+  tool: 'PixInsight',
+  lifecycle: 'completed',
+  path: 'projects/NGC7000',
+  notes: null,
+  channelDrift: { hasNewSources: false, suggestedAction: 'dismiss' },
+  sources: [],
+  channels: [],
+  createdAt: '2026-06-01T00:00:00Z',
+  updatedAt: '2026-06-10T00:00:00Z',
+};
+
+function setupStore(project: Partial<ProjectDetailDto> = {}) {
+  vi.mocked(store.useProjectDetail).mockReturnValue({
+    data: { ...mockProject, ...project },
+    loading: false,
+    error: undefined,
+  });
+}
+
+describe('ProjectDetail archive plan generation (spec 017 US2/WP-B)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('generates and opens the review overlay when the Archive transition returns plan.required', async () => {
+    setupStore({ lifecycle: 'completed' });
+    vi.mocked(store.callTransitionLifecycle).mockResolvedValue({
+      status: 'error',
+      contractVersion: '2.0.0',
+      requestId: 'req-1',
+      error: { code: 'plan.required', message: 'Plan required' },
+    });
+    mockGenerateArchivePlan.mockResolvedValue({
+      planId: 'plan-archive-1',
+      itemCount: 3,
+      protectedItemCount: 0,
+    });
+
+    render(<ProjectDetailContent projectId="proj-001" />);
+    fireEvent.click(screen.getByTestId('transition-btn-archived'));
+
+    // Still plan-gated: the exact info toast fires (no silent lifecycle flip).
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'info' }),
+      );
+    });
+
+    // ...and it now actually generates the plan for this project.
+    await waitFor(() => {
+      expect(mockGenerateArchivePlan).toHaveBeenCalledWith('proj-001');
+    });
+
+    // ...and opens the shared review/apply overlay with the returned plan id.
+    await waitFor(() => {
+      expect(screen.getByTestId('archive-plan-review-stub')).toHaveTextContent(
+        'plan-archive-1',
+      );
+    });
+  });
+
+  it('does not generate a plan for a plan-required refusal on a different edge', async () => {
+    setupStore({ lifecycle: 'ready' });
+    vi.mocked(store.callTransitionLifecycle).mockResolvedValue({
+      status: 'error',
+      contractVersion: '2.0.0',
+      requestId: 'req-2',
+      error: { code: 'plan.required', message: 'Plan required' },
+    });
+
+    render(<ProjectDetailContent projectId="proj-001" />);
+    fireEvent.click(screen.getByTestId('transition-btn-prepared'));
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'info' }),
+      );
+    });
+    expect(mockGenerateArchivePlan).not.toHaveBeenCalled();
+    expect(screen.queryByTestId('archive-plan-review-stub')).not.toBeInTheDocument();
+  });
+
+  it('surfaces an error toast and keeps the overlay closed when plan generation fails', async () => {
+    setupStore({ lifecycle: 'completed' });
+    vi.mocked(store.callTransitionLifecycle).mockResolvedValue({
+      status: 'error',
+      contractVersion: '2.0.0',
+      requestId: 'req-3',
+      error: { code: 'plan.required', message: 'Plan required' },
+    });
+    mockGenerateArchivePlan.mockRejectedValue(new Error('db failure'));
+
+    render(<ProjectDetailContent projectId="proj-001" />);
+    fireEvent.click(screen.getByTestId('transition-btn-archived'));
+
+    await waitFor(() => {
+      expect(addToast).toHaveBeenCalledWith(
+        expect.objectContaining({ variant: 'error' }),
+      );
+    });
+    expect(screen.queryByTestId('archive-plan-review-stub')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
@@ -38,6 +38,16 @@ vi.mock('@/shared/toast', () => ({
   addToast: vi.fn(),
 }));
 
+// Archive plan generation + review overlay have dedicated coverage in
+// ProjectDetail.archive-plan.test.tsx; stub them here so this file's
+// unrelated assertions don't need a QueryClientProvider.
+vi.mock('@/features/archive/store', () => ({
+  useGenerateArchivePlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: () => null,
+}));
+
 import { ProjectDetailContent } from './ProjectDetail';
 import * as store from './store';
 import type { ProjectDetailDto } from '@/bindings/index';

--- a/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
@@ -36,6 +36,16 @@ vi.mock('@/shared/toast', () => ({
   addToast: vi.fn(),
 }));
 
+// Archive plan generation + review overlay have dedicated coverage in
+// ProjectDetail.archive-plan.test.tsx; stub them here so this file's
+// unrelated lifecycle assertions don't need a QueryClientProvider.
+vi.mock('@/features/archive/store', () => ({
+  useGenerateArchivePlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: () => null,
+}));
+
 import { ProjectDetailContent } from './ProjectDetail';
 import * as store from './store';
 import { addToast } from '@/shared/toast';

--- a/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
@@ -32,6 +32,16 @@ vi.mock('@/shared/toast', () => ({
   useToasts: () => ({ toasts: [], dismiss: vi.fn(), add: vi.fn() }),
 }));
 
+// Archive plan generation + review overlay have dedicated coverage in
+// ProjectDetail.archive-plan.test.tsx; stub them here so this file's
+// unrelated assertions don't need a QueryClientProvider.
+vi.mock('@/features/archive/store', () => ({
+  useGenerateArchivePlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: () => null,
+}));
+
 // ── Imports ───────────────────────────────────────────────────────────────────
 
 import { ProjectDetailContent } from './ProjectDetail';

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -30,6 +30,8 @@
 import { useState } from 'react';
 import { m } from '@/lib/i18n';
 import { revealLabel } from '@/lib/reveal-label';
+import { queryKeys } from '@/data/queryKeys';
+import { queryClient as sharedQueryClient } from '@/data/queryClient';
 import {
   DetailHeader,
   DetailPane,
@@ -53,6 +55,8 @@ import { addToast } from '@/shared/toast';
 import { BlockedBanner } from './BlockedBanner';
 import type { BlockedReason, RecoveryEdge } from './BlockedBanner';
 import { lifecycleFooterActions, isPlanRequiredError } from './lifecycle-actions';
+import { useGenerateArchivePlan } from '@/features/archive/store';
+import { PlanReviewOverlay } from '@/features/plans/PlanReviewOverlay';
 // spec 011: tool launch CTA
 import {
   toolIdFromProjectTool,
@@ -149,6 +153,11 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
   const [editOpen, setEditOpen] = useState(false);
   const [channelWorking, setChannelWorking] = useState(false);
   const [transitionWorking, setTransitionWorking] = useState(false);
+  // Archive plan generation (spec 017 US2/WP-B) — the completed→archived
+  // transition is plan-gated; this is the UI entry point that actually
+  // creates the reviewable plan the toast below points the user to.
+  const generateArchivePlan = useGenerateArchivePlan();
+  const [archiveReviewPlanId, setArchiveReviewPlanId] = useState<string | null>(null);
 
   // spec 012 T008: attach the project's filesystem artifact watcher for as
   // long as this drawer is open; detaches on close/project switch.
@@ -216,7 +225,11 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
 
   /**
    * Handle a lifecycle transition. Surfaces plan.required as an info toast
-   * directing the user to the plan flow (US3-4 / US3-5).
+   * directing the user to the plan flow (US3-4 / US3-5). For the
+   * completed/blocked → archived edge specifically, a generator command
+   * (`archive.plan.generate`) exists, so a refusal here also generates the
+   * plan and opens the shared review/apply overlay — previously this edge
+   * dead-ended on the toast with no way to actually create the plan.
    */
   const handleTransition = async (
     nextState: ProjectLifecycleState,
@@ -238,6 +251,9 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
           message: m.projects_toast_plan_required(),
           variant: 'info',
         });
+        if (nextState === 'archived') {
+          void handleGenerateArchivePlan();
+        }
       } else if (resp.status === 'error') {
         addToast({
           message: resp.error?.message ?? m.projects_toast_transition_refused(),
@@ -249,6 +265,32 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
     } finally {
       setTransitionWorking(false);
     }
+  };
+
+  /**
+   * Generate a reviewable whole-project archive plan (`archive.plan.generate`)
+   * and open the shared {@link PlanReviewOverlay} for review + apply. This is
+   * the ONLY UI entry point for the command — previously it had zero callers
+   * and the flow only worked driven over the dev bridge.
+   */
+  const handleGenerateArchivePlan = async () => {
+    try {
+      const res = await generateArchivePlan.mutateAsync(projectId);
+      addToast({
+        message: m.projects_archive_plan_created_toast({ count: res.itemCount }),
+        variant: 'info',
+      });
+      setArchiveReviewPlanId(res.planId);
+    } catch {
+      addToast({ message: m.projects_archive_generate_failed(), variant: 'error' });
+    }
+  };
+
+  /** After the archive plan applies, the project's lifecycle flips server-side
+   * (C5 — applying an origin=archive plan is the one legitimate path to
+   * `archived`); refresh the detail query so the UI reflects it. */
+  const handleArchivePlanApplied = () => {
+    void sharedQueryClient.invalidateQueries({ queryKey: queryKeys.projects.detail(projectId) });
   };
 
   /** Handle blocked resolve — dispatches the recovery edge from BlockedBanner. */
@@ -584,6 +626,18 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
           <EditProjectPane project={project} onClose={() => setEditOpen(false)} />
         </div>
       )}
+
+      {/* ── Archive plan review overlay (spec 017 US2/WP-B) ──────────────────
+          Opens automatically when the plan-gated Archive transition refuses
+          with plan.required; shares the same review → approve → apply kit as
+          the cleanup flow. */}
+      <PlanReviewOverlay
+        planId={archiveReviewPlanId}
+        open={archiveReviewPlanId !== null}
+        onClose={() => setArchiveReviewPlanId(null)}
+        title={m.projects_archive_review_title()}
+        onApplied={handleArchivePlanApplied}
+      />
     </DetailPane>
   );
 }


### PR DESCRIPTION
## Summary
- `archive_plan_generate` had zero UI callers — the completed→archived transition was plan-gated but the app shipped no control that ever called it, so a user could not archive a project from the shipped UI (only via the dev bridge). See `e2e-agentic-test/017-cleanup-archive-review-plans/archive-lifecycle/scenario.md` (KNOWN UI GAP note, Test 1.2).
- When the Archive transition button (`transition-btn-archived`) refuses with `plan.required`, `ProjectDetail` now also generates the archive plan (`useGenerateArchivePlan`, new hook in `features/archive/store.ts`, generated `commands.archivePlanGenerate` binding) and opens the shared `PlanReviewOverlay` (protection gate → approve → apply with live progress) — the same reusable kit the cleanup flow already uses.
- The existing plan-gated behavior (exact info toast, no silent lifecycle flip) is unchanged; this only adds the missing route into the plan flow the toast points to.
- Paraglide i18n keys added for the new toast/overlay copy; no raw strings.

## Test plan
- [x] `pnpm vitest run` on the touched ProjectDetail/OutputsCleanupSections/archive test files — new `ProjectDetail.archive-plan.test.tsx` covers generate+open on the archived edge, no-op on other plan-required edges, and error-toast-on-generate-failure.
- [x] `pnpm run typecheck` (apps/desktop) — clean.
- [x] `eslint` on all touched files — clean.
- [ ] Real-UI E2E — macos-latest (known flaky/best-effort per #434; ignore per instructions).