### PR TITLE
docs(e2e): Layer-2 + manual-Windows coverage audit and per-journey cowork scripts

### DIFF
--- a/docs/development/windows-journeys/journey-01-first-run-setup.md
+++ b/docs/development/windows-journeys/journey-01-first-run-setup.md
@@ -1,0 +1,207 @@
+# Windows validation — Journey 1: First-run setup → data sources
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 1 (specs 003/016).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `roots.register`, `firstrun.*`,
+  `sources.set_organization_state`, remap/disable/delete commands.
+- Changed surfaces: the setup wizard (`/setup`, 5 steps: Source Folders →
+  Processing Tools → Configuration → Confirm → Scan) and **Settings → Data
+  Sources**.
+- What this journey proves: a fresh install can register light/calibration/
+  project/inbox folders, finish setup, and keep managing those folders
+  (rescan/remap/disable/delete) without ever silently touching files on disk.
+- Automated coverage baseline today: Layer-2 journey
+  `first_run_resolve_create_project` (`crates/e2e-tests/tests/journeys.rs`)
+  covers the wizard's first-run redirect + a real `target.resolve` +
+  `projects.create`/`projects.list` round-trip — it does **not** drive the
+  wizard's folder-adding UI (native picker) or any Data Sources card action.
+  No Playwright mock-layer spec covers this journey at all (see
+  `docs/development/e2e-mock-coverage-audit-2026-07-05.md` on
+  `research/e2e-mock-coverage-audit`). Everything below except the bare
+  redirect-to-`/setup` behavior is **manual-only today**.
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan` (separate from any WSL/Linux checkout
+  — the app serves from THIS checkout only).
+- Deploy: `cd C:\dev\astro-plan`, `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command (a guard rejects it
+  bundled with other git commands).
+- **Recompile trap**: `git reset --hard` restores file content but leaves an
+  OLD mtime, so cargo thinks nothing changed and skips recompiling — the app
+  silently stays on the old binary (symptom: a command that IS in the code
+  returns "not found"). If you deployed a branch with Rust changes, force a
+  rebuild: `Get-ChildItem <changed-files>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`
+  before relaunching. Frontend-only changes: a hard refresh (Ctrl+R) suffices.
+- **Reset to a fresh first-run** (required for this journey):
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`. Clearing
+  `localStorage` alone is NOT a reset — it causes a `/`↔`/setup` redirect
+  loop. The DB is the first-run source of truth.
+- Launch (detached, native Windows, never over `/mnt/c`):
+  `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  App process = `desktop_shell.exe`; Vite on `localhost:5173`;
+  `VITE_USE_MOCKS=false` (real backend). First launch after a reset
+  recompiles Rust — allow a few minutes.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window (`#root` empty) recovery: restart the dev server; if still
+  blank, run `pnpm install` in `C:\dev\astro-plan` with `$env:CI="true"`, then
+  relaunch.
+
+### Tauri MCP bridge (if driving the app programmatically instead of pure vision)
+- Launch with the dev overlay so the bridge is live:
+  `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge is
+  `#[cfg(debug_assertions)]`, WebSocket on `0.0.0.0:9223`).
+- Connect via `driver_session host=<WSL↔Windows gateway IP> port=9223`
+  (`ip route show default` on the WSL side gives the gateway; firewall
+  already allows 9223).
+- Prefer `webview_execute_js` → `window.__TAURI__.core.invoke('<snake_command>', {args})`
+  to call a backend command directly; `ipc_execute_command` rejects many real
+  commands.
+- **This journey's native folder picker cannot be driven by the bridge.**
+  Relaunch with `VITE_E2E=1` to expose stand-in controls:
+  `data-testid="e2e-path-input-<kind>"` / `e2e-add-path-btn-<kind>`
+  (`kind` ∈ `light_frames`, `calibration`, `project`, `inbox`). Set the path
+  via the input's native value setter + dispatch an `input` event, THEN click
+  the add button in a **separate** call so React commits the state.
+
+## Preconditions
+1. Deploy + reset the DB as above.
+2. Launch the app and wait for the window.
+3. Sanity: the app renders (not a blank window).
+
+## Tests
+
+### Test 1 — Fresh install lands on the setup wizard
+Steps:
+1. With a freshly reset DB, launch the app.
+Expected:
+- The window shows "Setup · Step 1 of 5" (Source Folders).
+FAIL if:
+- The app lands anywhere other than `/setup` (e.g. a blank Inbox).
+
+### Test 2 — Add a Light frames folder via the native picker
+Steps:
+1. On Step 1, click "Add folder" under **Light frames** (required).
+2. Pick any real folder in the OS file browser (or, if using the Tauri MCP
+   bridge, use the `VITE_E2E=1` stand-in input/button for `light_frames`
+   described above).
+3. Choose **organized** or **unorganized** for that folder.
+Expected:
+- The folder appears as a card with the path and your organized/unorganized
+  choice. Nothing is registered with the backend yet — this is a working
+  buffer.
+FAIL if:
+- The picker doesn't open, the path silently drops, or the folder is already
+  registered with the backend before Step 4 (Confirm).
+
+### Test 3 — Confirm step registers and Scan runs
+Steps:
+1. Skip Steps 2–3 (Processing Tools, Configuration) using their skip/default
+   controls.
+2. Reach Step 4 (Confirm) → review the summary of every category you added.
+3. Proceed to Step 5 (Scan).
+Expected:
+- Step 4 only shows a summary; no scan has started yet. Once you proceed,
+  each registered folder scans and reaches a terminal state (including
+  "0 items" for an empty folder); **Finish** enables only once every source
+  is done.
+FAIL if:
+- A scan starts before you leave Step 4, or Finish enables while a source is
+  still scanning.
+
+### Test 4 — Finish lands on Inbox and the completion flag sticks
+Steps:
+1. Click Finish.
+2. Fully quit and relaunch the app (no DB reset).
+Expected:
+- Finish lands on the Inbox page. Relaunching goes straight to Inbox, never
+  back to `/setup`.
+FAIL if:
+- Relaunch re-shows the wizard.
+
+### Test 5 — Data Sources: Rescan
+Steps:
+1. Go to **Settings → Data Sources**.
+2. Click **Rescan** on the registered card.
+Expected:
+- The scan re-runs without re-prompting for a path.
+FAIL if:
+- Rescan asks for a path again, or errors.
+
+### Test 6 — Data Sources: Remap is preview-then-apply, never mutates files
+Steps:
+1. Click **Remap** on a source card.
+2. Paste a different, valid, existing path.
+3. Click **Verify**.
+4. Only after Verify succeeds, click **Apply remap**.
+Expected:
+- Verify samples files at the new path with no file movement. Only Apply
+  remap persists the new path in PlateVault's record.
+FAIL if:
+- Any file on disk moved at any point, or Apply remap is clickable before a
+  successful Verify.
+
+### Test 7 — Data Sources: Disable is reversible, no confirm needed
+Steps:
+1. Click **Disable** on a source card.
+2. Click the same control again to re-enable.
+Expected:
+- Disabling removes the source from Inbox scan/ingest but its history stays
+  visible; re-enabling needs no confirmation dialog.
+FAIL if:
+- Disable requires a confirm step, or disabling hides prior history.
+
+### Test 8 — Data Sources: Delete is registration-only and blocked with dependents
+Steps:
+1. Pick a source that is currently **offline** (or mark one offline) and has
+   no dependent records (sessions/projects). Click **Delete**.
+2. Separately, attempt Delete on a source that DOES have dependent records.
+Expected:
+- Step 1: a confirm appears; confirming un-registers the source. Files on
+  disk are untouched (spot-check in Explorer).
+- Step 2: the Delete button is blocked/disabled with an explanatory message.
+FAIL if:
+- Delete removes files from disk, or succeeds despite dependents.
+
+### Test 9 — "Show in File Explorer" reveal
+Steps:
+1. On a source card, click "Show in File Explorer".
+Expected:
+- Windows Explorer opens at exactly that folder (not a parent directory).
+FAIL if:
+- No Explorer window opens, or it opens the wrong/parent folder.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- A step/command behaves like an old build: confirm you touched changed
+  `.rs` files after `git reset --hard` so cargo actually recompiled.
+- Stuck in a `/`↔`/setup` redirect loop: you cleared `localStorage` instead of
+  resetting the DB — delete `wizard-test.db*` and relaunch.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, capture a
+screenshot and the exact on-screen text / toast.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Fresh-DB → `/setup` redirect, wizard steps 1–5 default path, target
+  resolve, project create** — `automatable`, already covered by
+  `first_run_resolve_create_project`.
+- **Adding a folder via the native OS picker** — `manual only` (native OS
+  dialog; the Layer-2 harness's `VITE_E2E=1` stand-in already substitutes for
+  it in automated runs, so this Test is really validating the *real* OS
+  picker wiring, which the harness cannot do).
+- **Data Sources Rescan / Remap (verify-then-apply) / Disable / Delete /
+  Reveal** — all `automatable` at the IPC-round-trip level (each is a
+  `roots.*` / `sources.*` command), currently **not exercised by any Layer-2
+  journey**. See the batched new-journey plan (item 4 of the audit) — this is
+  flagged there as **"Batch: Data Sources lifecycle ops"**, using the
+  `VITE_E2E=1` stand-in for the one native-picker step it still needs, or
+  seeding the root via a real `roots.register` invoke and driving only the
+  card actions through the UI.

--- a/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
+++ b/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
@@ -1,0 +1,176 @@
+# Windows validation — Journey 2: Ingest → review/reclassify → confirm (move mode)
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 2 (spec 041).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `inbox.scan.folder`, `inbox.classify`,
+  `inbox.confirm`, `inbox.plan.apply`, `plans.apply.status`.
+- Changed surfaces: **Inbox** page (queue, needs-review banners/badges, bulk
+  reclassify control, root-picker prompt, plan review overlay).
+- What this journey proves: a folder of mixed frame types splits into clean
+  single-type items, missing-metadata items are gated from confirming until
+  fixed, confirming only ever creates a reviewable plan (never moves a file
+  by itself), and applying a plan actually moves files to the resolved
+  destination path with a stale-plan refusal if the source changed underneath
+  it.
+- Automated coverage baseline today: Layer-2 journeys
+  `plan_review_apply_with_audit` (register → scan → classify → confirm →
+  apply → poll `plans.apply.status` until `applied` → assert the source file
+  moved) and `ingestion_sessions_search` (same pipeline then session
+  grouping) both drive this journey's REAL backend round-trip, but through
+  the `window.__ALM_E2E__.invoke` bridge, not by clicking through the actual
+  Inbox UI. Mixed-folder splitting, the needs-review banner/badges, the bulk
+  reclassify control, the root-picker prompt, and the stale-plan-refusal UI
+  are **not exercised by any Layer-2 journey nor any Playwright mock spec**
+  (`docs/development/e2e-mock-coverage-audit-2026-07-05.md`, Batch 1) — this
+  document's UI-level Tests are today's only coverage for those.
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: after a reset, cargo may skip rebuilding because the
+  mtime looks unchanged — if you deployed Rust changes, touch the changed
+  `.rs` files (`Get-ChildItem <files>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`)
+  before relaunching. Frontend-only: a hard refresh suffices.
+- Reset to fresh first-run when a Test needs it:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force` (DB is the
+  first-run source of truth; clearing `localStorage` alone causes a redirect
+  loop).
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart the dev server; if still blank,
+  `pnpm install` with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional, for programmatic driving): launch with
+  `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge on
+  `0.0.0.0:9223`), connect with `driver_session host=<gateway> port=9223`,
+  invoke commands via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`. Native folder
+  pickers still need `VITE_E2E=1` stand-ins (see Journey 1's doc for the
+  exact mechanism) if you need to add roots this way instead of by hand.
+
+## Preconditions
+1. Deploy as above.
+2. Ensure setup is complete with one inbox root and one light-frames root
+   registered (run Journey 1's wizard once, or reuse an already-set-up DB).
+3. Prepare test files: drop a folder containing **mixed frame types** (e.g.
+   two light frames + a dark frame) into the inbox folder on disk. Separately
+   prepare one FITS/XISF file with a **missing mandatory field** (no filter
+   AND no target/coordinates) for Test 2.
+4. Sanity: the app renders and Inbox is reachable from the left nav.
+
+## Tests
+
+### Test 1 — Mixed folder splits into single-type items
+Steps:
+1. On **Inbox**, click **Rescan**.
+Expected:
+- The mixed folder materializes as multiple **single-type** items (e.g.
+  `light · Ha · 300s`, `dark · 300s`), each still visibly grouped back to its
+  shared source folder. The status-bar breakdown matches the real contents.
+FAIL if:
+- It shows one ambiguous "mixed" row instead of split single-type items.
+
+### Test 2 — Needs-review gate blocks Confirm
+Steps:
+1. Rescan after dropping the file with a missing mandatory field.
+Expected:
+- A danger banner names exactly what's missing (e.g. "missing filter"),
+  affected rows show a "needs `<attribute>`" badge, and **Confirm** is
+  disabled on that item.
+FAIL if:
+- Confirm is clickable, or the banner is generic/doesn't name the missing
+  field.
+
+### Test 3 — Bulk reclassify resolves the gate
+Steps:
+1. Select the affected row(s) from Test 2.
+2. Open the bulk reclassify control, set the missing value (frame type,
+   filter, exposure, or binning), apply to selection.
+3. Rescan again.
+Expected:
+- The item re-partitions into a clean single-type item, Confirm re-enables,
+  and the override survives the rescan (doesn't revert).
+FAIL if:
+- Confirm stays disabled, or the rescan reverts the override.
+
+### Test 4 — Root-picker prompt vs. auto-select
+Steps:
+1. If you have 2+ registered light-frame roots, click **Confirm** on a light
+   item.
+2. If you only have exactly one valid root, click **Confirm** on a light item
+   instead.
+Expected:
+- Multiple valid roots: a root-picker prompt appears before a plan is
+  generated. Exactly one valid root: no prompt, it's auto-chosen.
+FAIL if:
+- The behavior is reversed (prompts with one root, or silently picks with
+  multiple).
+
+### Test 5 — Confirm never moves a file by itself
+Steps:
+1. Click **Confirm** on a classified item.
+2. Check the source file's location in Explorer immediately after.
+Expected:
+- The item stays visible in the queue, now marked "planned" (does not
+  disappear). The file has NOT moved yet.
+FAIL if:
+- The file already moved before you apply the plan, or the item disappears
+  from the queue on confirm.
+
+### Test 6 — Apply moves the file to the resolved destination
+Steps:
+1. Open the plan review overlay for the confirmed item.
+2. Note the full destination path shown (e.g.
+   `{target}/{filter}/{date}/light/`).
+3. Click Apply.
+4. Verify in Explorer that the file now exists at that exact path and no
+   longer at its original location.
+Expected:
+- The path shown in review matches the file's actual new location exactly.
+FAIL if:
+- The file lands somewhere other than the shown path, or the shown path was
+  never displayed before Apply.
+
+### Test 7 — Stale-plan refusal
+Steps:
+1. Confirm an item (creating a plan) but do NOT apply yet.
+2. Externally modify the source file on disk (e.g. append a byte, or edit its
+   FITS header with another tool).
+3. Try to Apply the existing plan.
+Expected:
+- The apply is refused with a clear message (stale plan / source changed),
+  not silently applied with outdated actions.
+FAIL if:
+- The stale plan applies anyway.
+
+## Troubleshooting
+- Blank window: restart dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- Confirm/Apply behaves like an old build: confirm you touched changed `.rs`
+  files after `git reset --hard`.
+- No inbox root registered: run Journey 1's wizard first (or `roots.register`
+  via the Tauri MCP bridge) before starting this journey's Preconditions.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Register → scan → classify → confirm → apply → durable
+  `plans.apply.status` proof** — `automatable`, already covered by
+  `plan_review_apply_with_audit` (IPC-level, not UI-driven).
+- **Mixed-folder splitting, needs-review banner/badges, bulk reclassify,
+  root-picker prompt vs. auto-select, plan-overlay destination-path display,
+  stale-plan refusal** — all `automatable` in principle (deterministic
+  UI→IPC round-trips) but **zero Layer-2 UI-level coverage today**. See the
+  batched new-journey plan — flagged as **"Batch: Inbox UI-level gate +
+  reclassify + root-picker"**, the single highest-value new Layer-2 journey
+  to add (largest, most mutation-relevant, most completely uncovered at the
+  UI-interaction level, matching Batch 1 of the mock-coverage audit but for
+  the real-backend layer).

--- a/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
+++ b/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
@@ -1,0 +1,126 @@
+# Windows validation — Journey 3: Ingest → confirm (catalogue-in-place)
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 3 (spec 041).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — same `inbox.*` pipeline as Journey 2, but the
+  deciding factor is the root's **organization state** (`organized`).
+- Changed surfaces: Inbox (same UI as Journey 2), plan review overlay.
+- What this journey proves: cataloguing an already-organized folder teaches
+  PlateVault about the files WITHOUT moving a single byte — no
+  destination-root picker appears, the plan reports move-count 0, and the
+  file set/content hashes are byte-identical after apply.
+- Automated coverage baseline today: `plan_review_apply_with_audit`
+  (`crates/e2e-tests/tests/journeys.rs`) registers its fixture root and
+  explicitly flips it to **unorganized** to force a move — so today's
+  Layer-2 coverage exercises the MOVE branch, not catalogue-in-place. This
+  journey's core "organized root → 0 moves, byte-identical files" behavior
+  has **no Layer-2 coverage today** and no Playwright mock coverage either
+  (`docs/development/e2e-mock-coverage-audit-2026-07-05.md`, Journey 3 row).
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: after a reset, touch changed `.rs` files
+  (`Get-ChildItem <files>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`)
+  before relaunching if Rust changed; otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+
+## Preconditions
+1. Deploy as above.
+2. Register a light-frames (or similar) root and explicitly mark it
+   **organized** (either during the setup wizard or via Settings → Data
+   Sources, if an edit-organization-state control is exposed there — if not,
+   register it as organized during first-run setup).
+3. Ensure the folder already contains real, correctly-sorted files with
+   complete metadata (filter/target present) so Journey 2's needs-review gate
+   doesn't interfere.
+4. Note one file's exact byte size and last-modified timestamp in Explorer
+   before you begin, for the byte-identity check in Test 4.
+
+## Tests
+
+### Test 1 — Classification behaves like Journey 2
+Steps:
+1. Rescan the organized root from Inbox.
+Expected:
+- Files classify exactly as in Journey 2 (single-type items; the same
+  needs-review gate applies if metadata is missing).
+FAIL if:
+- Classification differs in a way that suggests organization-state leaked
+  into classification logic itself.
+
+### Test 2 — Confirm produces a catalogue plan, not a move plan
+Steps:
+1. Click **Confirm** on an item from the organized root.
+Expected:
+- The plan reports a move count of **0** and a catalogue count matching the
+  file count. **No destination-root picker** appears (there's nothing to
+  pick — the files stay put).
+FAIL if:
+- A root picker appears, or the move count is non-zero.
+
+### Test 3 — Review overlay shows catalogue actions
+Steps:
+1. Open the plan review overlay for the confirmed item.
+Expected:
+- The overlay lists **catalogue** actions (not move actions), and still
+  shows the Archive-vs-System-Trash destructive-destination control even
+  though these actions don't need it (documented UI consistency choice, not
+  a bug).
+FAIL if:
+- The overlay is missing entirely, or shows move-style actions.
+
+### Test 4 — Apply leaves bytes untouched, files become visible in Sessions
+Steps:
+1. Click Apply.
+2. In Explorer, re-check the same file's size and last-modified timestamp
+   from the Preconditions step.
+3. Open **Sessions** and confirm the corresponding session now appears.
+Expected:
+- The file's size/timestamp/content are unchanged (spot-check by re-opening
+  the file if you have a viewer) — only PlateVault's database now knows
+  about it. It becomes visible in Sessions.
+FAIL if:
+- The file was moved, renamed, or its bytes changed, or it never appears in
+  Sessions after apply.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- A root registered as "unorganized" by mistake will show Journey-2-style
+  move behavior instead of this journey's catalogue behavior — re-register or
+  use the organization-state edit control if available, and re-verify which
+  state the root is actually in before blaming the app.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast, plus the file's size/timestamp before and after for
+Test 4.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Organized-root confirm → 0 moves, catalogue count = file count, no root
+  picker, byte-identical apply** — `automatable` (a straightforward variant
+  of the existing `plan_review_apply_with_audit` journey: register a root,
+  leave it at its default `organized` state instead of flipping it, confirm,
+  apply, then assert `movedCount == 0`, `catalogueCount >= 1`, and that the
+  original file's content hash is unchanged post-apply). **Zero Layer-2
+  coverage today** — flagged in the batched new-journey plan as **"Batch:
+  Catalogue-in-place plan variant"**, a low-effort addition since it reuses
+  almost all of `plan_review_apply_with_audit`'s existing fixture code minus
+  the `sources.set_organization_state` call.

--- a/docs/development/windows-journeys/journey-04-sessions-review.md
+++ b/docs/development/windows-journeys/journey-04-sessions-review.md
@@ -1,0 +1,126 @@
+# Windows validation — Journey 4: Sessions review (derived groupings, live membership)
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 4 (spec 041/045 —
+  derived-inventory model; the prior session-lifecycle state machine was
+  intentionally removed).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `sessions.list` (event-driven grouping
+  after a plan applies), session notes update.
+- Changed surfaces: **Sessions** page (list + detail), no review/approve
+  controls by design.
+- What this journey proves: Sessions is a read-only, always-current
+  derived view over already-confirmed-and-applied inventory — never a
+  place with its own Confirm/Re-open/Reject/Ignore gate — and rescanning
+  never resurrects a review state or duplicates a session.
+- Automated coverage baseline today: Layer-2 journey
+  `ingestion_sessions_search` polls `sessions.list` until a real, resolved,
+  grouped session appears after a plan applies (event-driven
+  `plan_listener` → `ingest_light_frames`), then exercises
+  `calibration.match.suggest` and `search.global` against it — a real
+  IPC-level proof of the grouping pipeline. It does **not** assert the
+  UI-level absence of review controls/pills, notes editing, or
+  rescan-idempotency; the mock-Playwright suite covers `lifecycle_detail.spec.ts`
+  (session rows render, detail opens) but not the "no review controls"
+  assertion either (`docs/development/e2e-mock-coverage-audit-2026-07-05.md`).
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed (`Get-ChildItem <files>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`);
+  otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+
+## Preconditions
+1. Deploy as above.
+2. This journey reuses state — do Journey 2 or 3's ingest→confirm→apply flow
+   first (no fresh DB needed once that's done).
+3. Sanity: Sessions is reachable from the left nav.
+
+## Tests
+
+### Test 1 — Nothing appears before a plan applies
+Steps:
+1. Before confirming/applying any inbox item, open **Sessions**.
+Expected:
+- Sessions shows nothing for that not-yet-applied data.
+FAIL if:
+- A session appears from raw, unreviewed scan data.
+
+### Test 2 — Session appears automatically after apply, with real counts
+Steps:
+1. Complete Journey 2 or 3 (confirm + apply an inbox item).
+2. Return to Sessions.
+Expected:
+- The corresponding session appears automatically, with counts matching what
+  was actually moved/catalogued. There is no separate "review this session"
+  step.
+FAIL if:
+- The session doesn't appear, or requires an extra approve/review action.
+
+### Test 3 — No review-state controls or pills
+Steps:
+1. Open the session list and its detail panel.
+Expected:
+- **No** Confirm, Re-open, Reject, or Ignore controls anywhere, and no
+  review-state pills (e.g. needs-review/candidate).
+FAIL if:
+- Any of those controls or pills appear — this would be a regression of the
+  intentionally-removed session-lifecycle state machine.
+
+### Test 4 — Notes edit doesn't trigger a lifecycle transition
+Steps:
+1. Open a session's detail, edit its Notes field, let it auto-save.
+Expected:
+- The edit saves without any reopen/re-confirm prompt or visible lifecycle
+  transition.
+FAIL if:
+- Editing notes triggers any transition prompt or state change indicator.
+
+### Test 5 — Rescan doesn't duplicate or resurrect review state
+Steps:
+1. Go to Inbox, Rescan (no new files added).
+2. Return to Sessions.
+Expected:
+- No duplicate sessions appear, and no review state reappears.
+FAIL if:
+- A duplicate session appears, or any review-state UI resurfaces.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- No session appears after apply: session grouping is event-driven and can
+  take a moment — wait a few seconds and refresh before treating it as a
+  failure; if it never appears, that IS a failure.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Event-driven session grouping after plan apply (`sessions.list` resolves
+  with real `targetIds`)** — `automatable`, already covered by
+  `ingestion_sessions_search`.
+- **Absence of Confirm/Re-open/Reject/Ignore controls + no review pills,
+  notes-edit-doesn't-transition, rescan-idempotency** — `automatable`
+  (simple DOM-absence + no-op assertions) but **zero Layer-2 or mock
+  coverage today**. Low implementation cost — flagged in the batched
+  new-journey plan as **"Batch: Sessions derived-view invariants"**; a good
+  candidate to fold into an extension of `ingestion_sessions_search` rather
+  than a brand-new journey, since it already reaches a resolved session.

--- a/docs/development/windows-journeys/journey-05-project-lifecycle.md
+++ b/docs/development/windows-journeys/journey-05-project-lifecycle.md
@@ -1,0 +1,178 @@
+# Windows validation — Journey 5: Project lifecycle (create → attach → manifests/notes → tool launch → artifacts)
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 5 (specs 008, 009,
+  012, 024).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `projects.create`,
+  `lifecycle.transition.apply`, `lifecycle.ledger.list`, artifact watcher
+  commands, tool-launch spawn.
+- Changed surfaces: `/projects/new`, project Edit pane, manifests/notes UI,
+  "Open in {tool}" launch button, artifact list.
+- What this journey proves: project creation is duplicate-name-safe and
+  creates real on-disk folders under the registered project library (not the
+  app's working directory — PR #414); attach/remove sources is
+  confirmed-sessions-only with a last-source removal guard; manifests are
+  append-only; tool launch is containment-checked; the artifact watcher only
+  observes the project's own output folder.
+- Automated coverage baseline today: Layer-2 journey `lifecycle_integrity`
+  drives a real `projects.create` (asserting the sourceless project starts
+  `setup_incomplete`), a real `lifecycle.transition.apply` round-trip
+  (accepting `success`/`noop`/`error` as all valid, with a required real
+  error shape on refusal), and a real `lifecycle.ledger.list` read proving a
+  durable ledger row exists. It does **not** drive the create-wizard UI,
+  source attach/remove, manifests/notes, tool launch, or the artifact
+  watcher. The mock-Playwright suite covers only the transition **button** →
+  success-toast case (`lifecycle_transitions.spec.ts`); the post-transition
+  pill re-render test is intentionally `test.skip`'d there pending
+  real-backend coverage, which this manual journey (or a future Layer-2
+  journey) is the closest thing to today.
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed; otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+
+## Preconditions
+1. Deploy as above.
+2. Complete Journeys 2/3 so at least one confirmed session exists to attach.
+3. In Settings → Tools, configure a processing-tool executable path (point at
+   any real `.exe`, e.g. `notepad.exe`, for the launch-spawn test).
+4. Note your registered **project library** root path (from Settings → Data
+   Sources) — you'll verify new folders land under it, not the app's working
+   directory.
+
+## Tests
+
+### Test 1 — Duplicate project name blocks creation with an inline error
+Steps:
+1. Go to `/projects/new`, type a name that already exists (any case).
+Expected:
+- An inline field error appears immediately; creation is blocked from that
+  step (no generic toast instead).
+FAIL if:
+- A generic toast appears instead of an inline field error, or creation
+  proceeds.
+
+### Test 2 — Create with a unique name creates real folders in the right place
+Steps:
+1. Create a project with a unique name.
+2. In Explorer, navigate to your registered project library root, then into
+   the new project's folder.
+Expected:
+- A toast confirms creation. `lights/`, `darks/`, `flats/` (or equivalent)
+  subfolders exist **under the registered project library root**, not under
+  the app's own working directory.
+FAIL if:
+- The folders are missing, or they exist under the wrong root (e.g. next to
+  the `desktop_shell.exe` binary).
+
+### Test 3 — Attach sources: unlinked-confirmed-only, last-source guard
+Steps:
+1. Open the project's Edit pane, click **Add sources**.
+2. Confirm the picker only lists unlinked, already-confirmed sessions (not
+   unconfirmed inbox data).
+3. Attach one, then try to remove it if it's the last remaining source.
+Expected:
+- Step 2: unconfirmed inbox data never appears in the picker. Step 3: an
+  inline confirm reads something like "You can't remove the last confirmed
+  source."
+FAIL if:
+- Unconfirmed data appears in the picker, or the last source removes without
+  any guard.
+
+### Test 4 — Per-channel integration time shows real numbers
+Steps:
+1. With at least one attached session, view the project detail's per-channel
+   (per-filter) breakdown.
+Expected:
+- Real sub-frame counts and total integration time in hours/minutes, not a
+  placeholder dash.
+FAIL if:
+- The breakdown shows a dash/placeholder despite attached data.
+
+### Test 5 — Manifests and notes are append-only / auto-save
+Steps:
+1. Make a lifecycle-relevant change (e.g. change attached sources).
+2. Check the manifests list for a new snapshot.
+3. Type into Notes, stop typing, wait a few seconds.
+Expected:
+- A new manifest snapshot appears (prior ones are never overwritten). Notes
+  auto-save with a live byte counter; no manual Save button exists anywhere
+  on the page.
+FAIL if:
+- A manifest is overwritten instead of appended, or notes require a manual
+  Save action.
+
+### Test 6 — Tool launch spawns and is containment-checked
+Steps:
+1. Click "Open in {tool}" with a valid configured executable.
+2. Check Windows Task Manager for the new process.
+3. If reachable, configure a working directory that resolves outside every
+   registered root, and try launching again.
+Expected:
+- Step 2: the configured executable actually spawns as a new process. Step
+  3: launch refuses with a plain message (not a silent no-op), and the
+  project's lifecycle state is untouched by either outcome.
+FAIL if:
+- Nothing spawns in Task Manager, or an out-of-root launch silently succeeds
+  or silently does nothing without a message.
+
+### Test 7 — Artifact watcher observes only this project's output folder
+Steps:
+1. With the project open, drop a new file into its output folder.
+2. Confirm it's picked up and listed as an artifact with a kind/confidence.
+3. Close the project, drop another file into its output folder while closed,
+   then reopen the project.
+Expected:
+- Step 2: the artifact appears while the project is open. Step 3: the
+  while-closed file is picked up the next time the project reopens.
+  PlateVault never modifies or deletes the artifact file itself.
+FAIL if:
+- The while-open file never appears, or the while-closed file is never
+  picked up on reopen, or the artifact file itself gets modified/deleted.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- Folders land in the wrong place: confirm your registered project library
+  root in Settings → Data Sources before blaming the app — PR #414 fixed the
+  wrong-location bug; if you still see it on `main`, that's a real
+  regression, report it as FAIL.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast, and (for Test 2) the actual Explorer path where
+folders landed.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Sourceless project starts `setup_incomplete`, real
+  `lifecycle.transition.apply` round-trip (success/noop/error all
+  well-formed), real `lifecycle.ledger.list` durable row** —
+  `automatable`, already covered by `lifecycle_integrity`.
+- **Create-wizard duplicate-name inline error, folder-location correctness,
+  attach/remove sources UX, per-channel integration time, manifests/notes
+  UI, tool-launch spawn + containment, artifact watcher** — all
+  `automatable` in principle but **zero Layer-2 coverage today** (and only
+  the single transition-button case has mock-Playwright coverage). Flagged
+  in the batched new-journey plan as **"Batch: Project lifecycle UI
+  surface"** — moderate priority; the tool-launch-spawn and artifact-watcher
+  parts specifically need a real process/filesystem watcher, which only
+  Layer-2 (not the mock layer) can prove.

--- a/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
+++ b/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
@@ -1,0 +1,158 @@
+# Windows validation — Journey 6: Cleanup: scan → review → apply
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 6 (spec
+  017/025).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `artifact.watcher.attach`,
+  `artifact.list`, `cleanup.policy.update`, `cleanup.scan`,
+  `cleanup.plan.generate`, `plans.approve`, and (once a real UI Apply button
+  exists) `plans.apply_real`.
+- Changed surfaces: a project's Outputs/Cleanup section (scan button,
+  candidate list grouped by kind, protection-acknowledgement gate, plan
+  review overlay, apply progress UI).
+- What this journey proves: scanning is read-only (a real preview, no plan
+  yet); a plan is only created by an explicit "Generate cleanup plan" click,
+  with the destructive destination (Archive vs. System trash) fixed at that
+  point; protected items must be explicitly acknowledged before Approve &
+  apply is clickable; applying shows live per-item progress and actually
+  moves files; an empty plan can't be approved.
+- Automated coverage baseline today: Layer-2 journey `cleanup_plan_review`
+  drives a REAL `projects.create` → `artifact.watcher.attach` →
+  `artifact.list` → `cleanup.policy.update` → `cleanup.scan` →
+  `cleanup.plan.generate` → `plans.approve` round-trip and stops at
+  `ready_for_review` → `approved` — it does **not** apply the plan. This is
+  a **documented, known gap**: `plans.apply_real` (the real apply command)
+  takes a `tauri::ipc::Channel` progress argument with no channel-free
+  equivalent for cleanup/archive plans (unlike `inbox.plan.apply` for inbox
+  plans), and the shipped Cleanup/Archive UI does not yet wire an Apply
+  button for `cleanup.plan.generate` output at all — so the actual "Apply"
+  step in this journey (Tests 4–6 below) has **no automated coverage of any
+  kind today**, mock or Layer-2. This document is the only current
+  verification for it.
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed; otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+
+## Preconditions
+1. Deploy as above.
+2. Have a project with real processing outputs of **mixed kind**
+   (intermediate/master/final) — e.g. drop a file named per PixInsight's
+   `integration_*` convention into the project's output folder (classifies as
+   Intermediate) and other files matching Master/Final naming.
+3. Mark at least one output as **protected** (via whatever protection-default
+   or per-item control the app exposes) so Test 3's acknowledgement gate is
+   exercised.
+4. In Settings → Cleanup, ensure Intermediate is opted into Archive (or
+   whichever action you intend to test) so the generator has a real
+   candidate.
+
+## Tests
+
+### Test 1 — Scan is read-only
+Steps:
+1. In the project's Outputs/Cleanup section, click **Scan for cleanup
+   candidates**.
+Expected:
+- A read-only preview appears, grouped by kind (Intermediates/Masters/
+  Finals), protected items shown locked/unselectable, a total reclaimable
+  size shown. Nothing on disk changes.
+FAIL if:
+- Any file moves/changes as a result of scanning alone.
+
+### Test 2 — Generate creates a real plan with a fixed destination
+Steps:
+1. Choose a destructive destination (Archive folder or System trash).
+2. Click **Generate cleanup plan**.
+Expected:
+- This is the point a real, reviewable plan is created. The destination is
+  now fixed and shown read-only in the review overlay from here on.
+FAIL if:
+- The destination remains editable after generation, or no plan is actually
+  created (still just a preview).
+
+### Test 3 — Protection acknowledgement gates Approve
+Steps:
+1. Open the review overlay. If a protected item is included, try clicking
+   **Approve & apply** before acknowledging.
+2. Explicitly acknowledge the protected item, then click Approve & apply.
+Expected:
+- Step 1: Approve & apply stays disabled until protection is acknowledged.
+  Step 2: it becomes clickable only after acknowledgement.
+FAIL if:
+- Approve & apply is clickable while a protected item is unacknowledged.
+
+### Test 4 — Apply shows live progress and actually moves files
+Steps:
+1. With the plan approved, click Apply (or the equivalent apply control if
+   separate from Approve).
+2. Watch for a live "Applying N of M…" indicator.
+3. In Explorer, verify the files landed at the chosen destination (Archive
+   folder) rather than being deleted outright, if Archive was chosen.
+Expected:
+- Live per-item progress is visible during apply; files are moved to the
+  correct destination on disk.
+FAIL if:
+- No progress indicator appears, or files are deleted outright when Archive
+  was the chosen destination, or files don't move at all.
+
+### Test 5 — Re-scan shows applied items gone
+Steps:
+1. After apply, click **Scan for cleanup candidates** again.
+Expected:
+- The applied items no longer appear as candidates.
+FAIL if:
+- They still appear (suggests the apply didn't really happen or the scan
+  doesn't reflect real state).
+
+### Test 6 — Empty plan cannot be approved
+Steps:
+1. Start a new cleanup review, deselect every candidate.
+2. Try to click Approve & apply.
+Expected:
+- The control stays disabled with nothing selected.
+FAIL if:
+- An empty plan can be approved.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- No "Scan for cleanup candidates" button visible at all: confirm you're on a
+  build with PR #413 merged (already the case on `main` as of 2026-07-05).
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast, and (for Test 4) the exact destination folder
+contents in Explorer.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Scan → generate → approve (real artifact detection, real policy, real
+  plan generation, `ready_for_review` → `approved`)** — `automatable`,
+  already covered by `cleanup_plan_review`.
+- **Apply (progress UI, real file move to Archive/Trash, post-apply re-scan,
+  empty-plan block)** — `automatable` in principle, but **blocked** on a
+  real gap: no channel-free apply command exists for cleanup/archive plans,
+  and the UI itself has no wired Apply button for generator output yet.
+  Flagged in the batched new-journey plan as **"Batch: channel-free generic
+  apply + Cleanup Apply-button wiring"** — this is the single blocking
+  prerequisite for extending BOTH this journey and Journey 7 (Archive) to
+  full Layer-2 coverage; until it lands, Tests 4–6 above remain manual-only.

--- a/docs/development/windows-journeys/journey-07-archive-delete.md
+++ b/docs/development/windows-journeys/journey-07-archive-delete.md
@@ -1,0 +1,177 @@
+# Windows validation — Journey 7: Archive → (delete from archive)
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 7 (specs
+  017/025, D15/D24).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `archive.plan.generate`, `plans.approve`,
+  `plans.apply_real`, lifecycle transition to `archived`, trash/permanent
+  delete commands.
+- Changed surfaces: a completed project's Archive action, the review
+  overlay, the **Archive** page (list, Send to trash, Delete permanently,
+  Reveal).
+- What this journey proves: archiving is the ONE legitimate way a project's
+  lifecycle reaches `archived` and is refused without an applied plan first;
+  after archive, the project's Edit pane is read-only; the Archive page shows
+  real audit history with a deliberately narrower scope than a first guess
+  (no Masters/Targets/Sessions tabs, no working Restore); permanent delete
+  requires typing the literal word `DELETE`.
+- Automated coverage baseline today: **this journey has NO Layer-2 coverage
+  and no Playwright mock coverage at all** — confirmed by both
+  `docs/development/verify-on-windows-journeys.md` ("Journeys 7, 9, and 10
+  have no Layer-2 coverage at all") and
+  `docs/development/e2e-mock-coverage-audit-2026-07-05.md` (Journey 7 row:
+  "UNCOVERED"). The only automated signal touching this journey at all is
+  the generic `all_top_level_screens_load` smoke test, which merely confirms
+  the `/archive` route renders without an uncaught error — it asserts
+  nothing about archive/trash/delete behavior. This document is currently
+  the **only verification of any kind** for the archive/trash/permanent-
+  delete flow, which is also the single highest-risk flow in the product
+  (permanent, irreversible file deletion).
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed; otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`. Note: as of
+  2026-07-05 no shipped UI button generates an archive plan yet — you may
+  need to invoke `archive_plan_generate` directly via the bridge (see below)
+  to reach a state the Archive UI action expects, then drive the rest by
+  clicking.
+
+## Preconditions
+1. Deploy as above.
+2. Have a project in the `completed` lifecycle state (drive it there via
+   normal lifecycle transitions from Settings/project detail, or via
+   `lifecycle.transition.apply` through the bridge if there is no UI path).
+3. **CAUTION**: Tests 5–6 permanently move/delete real files. Use disposable
+   test data only — never point this journey at real astrophotography data.
+
+## Tests
+
+### Test 1 — Archive refuses without an applied plan
+Steps:
+1. On the completed project, click **Archive**.
+Expected:
+- The action is refused (an explanatory message, not a silent lifecycle
+  flip). The project's lifecycle state does not change.
+FAIL if:
+- The project silently flips to `archived` with no plan ever generated.
+
+### Test 2 — Generate → review → approve → apply flips lifecycle
+Steps:
+1. Generate the archive plan (there is no shipped UI button for this as of
+   2026-07-05 — invoke `archive_plan_generate` for this project via the
+   Tauri MCP bridge, or use whatever UI entry point exists if one has since
+   shipped).
+2. Review the plan (protected items require the same acknowledgement gate as
+   Cleanup); approve; apply.
+3. Check the project's lifecycle state.
+Expected:
+- Files move into an app-managed archive folder
+  (`.astro-plan-archive/<planId>/` under the project or library root — check
+  in Explorer) and **only then** does the lifecycle flip to `archived`.
+FAIL if:
+- The lifecycle flips before the plan actually applies, or files don't
+  appear at the expected archive path.
+
+### Test 3 — Archived project's Edit pane is read-only
+Steps:
+1. Open the archived project's Edit pane.
+Expected:
+- It's read-only (no editable source/notes/manifest controls).
+FAIL if:
+- Any edit control is still interactive.
+
+### Test 4 — Archive page lists real history with the documented narrower scope
+Steps:
+1. Open the **Archive** page.
+Expected:
+- The archived project is listed with real audit history (not placeholder
+  rows). There is **no** Masters/Targets tab, **no** Sessions tab, and the
+  **Restore** button is hidden or disabled (deferred by design, decision
+  D15) — these are expected absences, not bugs.
+FAIL if:
+- The listed history is placeholder/fake data, or Restore actually works
+  (would indicate an undocumented feature landed without this doc being
+  updated — report as a finding either way).
+
+### Test 5 — Send to trash uses the OS Recycle Bin
+Steps:
+1. On an archived project, click **Send to trash**.
+2. Open the Windows Recycle Bin.
+Expected:
+- The files appear in the Recycle Bin (recoverable), not permanently gone.
+FAIL if:
+- Files are permanently deleted instead of moved to the Recycle Bin, or
+  nothing happens.
+
+### Test 6 — Permanent delete requires the literal word DELETE
+Steps:
+1. On a different archived project (disposable test data only), click
+   **Delete permanently**.
+2. Type a lowercase or partial "delete" first.
+3. Type the exact literal `DELETE`.
+Expected:
+- Step 2: the confirm button stays disabled. Step 3: it enables and, on
+  click, permanently removes the files.
+FAIL if:
+- The button enables on the wrong text, or nothing is actually removed after
+  typing `DELETE` and confirming.
+
+### Test 7 — Reveal uses the OS-native label
+Steps:
+1. On an archive row, look at the reveal control.
+2. If there's nothing to reveal (e.g. after permanent delete), check its
+   disabled state.
+Expected:
+- The label reads "Show in File Explorer" (Windows-native wording, not a
+  generic "explorer" or "Reveal"); it's disabled when nothing exists to
+  reveal.
+FAIL if:
+- A generic/non-native label is shown, or the control is clickable with
+  nothing to reveal.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- No UI button to generate the archive plan: this is a documented, known gap
+  as of 2026-07-05 — use the Tauri MCP bridge to invoke
+  `archive_plan_generate` directly; this is not a bug in your test run.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast. For Tests 5–6, confirm explicitly whether files were
+recoverable (Recycle Bin) or permanently gone, since this is the highest-risk
+journey in the product.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Everything in this journey** — `automatable` in principle (deterministic
+  UI→IPC round-trips over `archive.plan.generate` / `plans.approve` /
+  `plans.apply_real` / OS trash / permanent delete) but **zero Layer-2
+  coverage and zero mock coverage today**. This is the single largest
+  whole-stack gap in the product's automated test coverage, and also the
+  highest product risk (irreversible deletion). Flagged in the batched
+  new-journey plan as **"Batch: Archive lifecycle + trash + permanent
+  delete"**, the top-priority new Layer-2 journey to author — but it shares
+  the SAME blocking prerequisite as Journey 6: no channel-free apply command
+  exists yet for archive plans (`plans.apply_real` needs a
+  `tauri::ipc::Channel`). Recommend landing the channel-free apply path
+  first (shared with Journey 6's gap), then authoring this journey
+  immediately after, given the risk profile.

--- a/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
+++ b/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
@@ -1,0 +1,141 @@
+# Windows validation — Journey 8: Calibration: ingest cal frames → masters → matching
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 8 (spec 040
+  calibration master detection, spec 007 calibration matching).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `calibration_master_detect`,
+  `confirm_master_integration`, `calibration.match.suggest`, assignment
+  commands, Settings → Calibration "Offset tolerance" persistence.
+- Changed surfaces: Inbox (masters ingest as individual items), **Calibration**
+  page (one row per master, kind-conditional fingerprint columns, matching
+  view), Settings → Calibration.
+- What this journey proves: a folder with several master files (darks,
+  flat, bias) classifies as separate individual items (not one folder
+  aggregate); the Calibration page shows kind-conditional columns (a bias's
+  temperature/gain show as a dash by design); matching surfaces ranked
+  candidate sessions with real context and flags hard-rule mismatches rather
+  than hiding them; assignment is advisory/confirmable, never auto-applied;
+  the offset-tolerance setting persists and immediately affects matching.
+- Automated coverage baseline today: Layer-2 journey
+  `ingestion_sessions_search` calls the real `calibration.match.suggest`
+  command and asserts a well-formed response shape (candidates may
+  legitimately be empty since no masters were seeded in that journey's
+  fixture) — it does **not** exercise the master-ingest pipeline itself, the
+  Calibration page's UI, kind-conditional columns, assign/cancel, or the
+  offset-tolerance setting. No Playwright mock spec covers any part of this
+  journey (`docs/development/e2e-mock-coverage-audit-2026-07-05.md`, Batch 4
+  — 7 vitest files exist under `features/calibration/` but no Playwright
+  e2e).
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed; otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+
+## Preconditions
+1. Deploy as above.
+2. Register a calibration root. Prepare files: 2 dark masters (different
+   temperature/gain), 1 flat master, 1 bias master, plus light frames whose
+   gain matches one dark and mismatches the other.
+3. Sanity: Calibration page is reachable from the left nav.
+
+## Tests
+
+### Test 1 — Masters ingest as individual items, not a folder aggregate
+Steps:
+1. Inbox → Rescan the calibration folder.
+Expected:
+- Each master file appears as its own item with its own fingerprint
+  (gain/temperature/binning/filter where relevant) — not one aggregate row
+  for the whole folder.
+FAIL if:
+- The folder collapses into a single ambiguous item.
+
+### Test 2 — Confirm + apply registers masters with kind-conditional columns
+Steps:
+1. Confirm and apply the master items.
+2. Open the **Calibration** page.
+Expected:
+- One row per master file. A bias's temperature/gain columns show a dash
+  (by design, not a bug) since they don't apply to that kind. No master
+  *light* frame appears on this page.
+FAIL if:
+- A master light frame appears here, or dash-by-design columns instead show
+  fabricated-looking numbers.
+
+### Test 3 — Matching surfaces ranked candidates with real context
+Steps:
+1. Select a master (e.g. one of the darks) and open its matching view.
+Expected:
+- Ranked candidate sessions appear with real context: target, filter, night,
+  frame count (not opaque ids). The session whose gain mismatches shows a
+  mismatch indicator rather than being silently hidden.
+FAIL if:
+- Candidates show opaque ids only, or the mismatched session is silently
+  omitted instead of flagged.
+
+### Test 4 — Assignment is advisory and confirmable
+Steps:
+1. Start assigning a master to a session, then click Cancel.
+2. Check the bottom log panel / audit trail for any new entry from the
+   cancel.
+3. Start again and confirm the assignment.
+Expected:
+- Step 1–2: cancelling fires no backend call (no new audit/log entry).
+  Step 3: confirming records the assignment and its usage count increments.
+FAIL if:
+- Cancel still creates a backend record, or confirming doesn't record a
+  usage count.
+
+### Test 5 — Offset tolerance persists and immediately affects matching
+Steps:
+1. Go to Settings → Calibration, change "Offset tolerance".
+2. Restart the app (relaunch, no DB reset).
+3. Return to the matching view for the same master.
+Expected:
+- The new tolerance value persisted across restart, and the matching view
+  immediately reflects it (a previously-mismatched session may now show
+  clean, or vice versa, depending on direction of change).
+FAIL if:
+- The value resets after restart, or the matching view doesn't reflect the
+  change.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- No candidate sessions appear at all: confirm light frames were actually
+  ingested and applied (Journey 2) before opening the matching view.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **`calibration.match.suggest` real round-trip (well-formed response)** —
+  `automatable`, already covered (partially) by `ingestion_sessions_search`.
+- **Masters-as-individual-items ingest, Calibration page kind-conditional
+  columns, ranked matching UI with mismatch indicator, assign/cancel,
+  offset-tolerance persistence + immediate effect** — all `automatable` but
+  **zero Layer-2 coverage today** (also zero mock coverage). Flagged in the
+  batched new-journey plan as **"Batch: Calibration masters ingest +
+  matching UI"** — moderate-high priority since spec 040 shipped without a
+  `plan.md`/`tasks.md` (a documented artifact deviation) and has the least
+  automated scrutiny of any recently-shipped backend feature.

--- a/docs/development/windows-journeys/journey-09-targets-planning.md
+++ b/docs/development/windows-journeys/journey-09-targets-planning.md
@@ -1,0 +1,215 @@
+# Windows validation — Journey 9: Targets & planning
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 9 (specs 023, 035,
+  044 Track B, 047 Track A).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes — real `target.resolve` (SIMBAD/offline seed
+  cache), target CRUD/alias/notes commands. Frontend-only for the astronomy
+  columns (astronomy-engine runs client-side).
+- Changed surfaces: **Targets** page (catalog list, Add target, target
+  detail), the planner's astronomy columns and altitude graph.
+- **CRITICAL, verified against the actual code on 2026-07-05 — read before
+  testing**: spec 047 (Moon phase, per-target lunar separation, filter
+  guidance, opposition) and spec 044 Track B (real per-site altitude,
+  rise/set, imaging time) are both **implemented in code** on `main`
+  (`apps/desktop/src/features/targets/planner-altitude.ts`,
+  `TargetsTable.tsx`, `astro/moon-state.ts`) — but **every one of those real
+  values is gated behind a default "observing site" existing**
+  (`apps/desktop/src/features/targets/site-gate.ts`, spec 047 decision D7),
+  and `readSiteExists()` is **hardcoded to always return `false`** with a
+  `TODO(spec-044)` comment — there is currently **no UI or backend command on
+  `main` that can create an ObserverSite at all** (that ships with spec 044
+  US3 / PR #440, which is **open, not merged**, as of this writing). This
+  means: **on `main` today, the real astronomy your cowork session will
+  actually see rendered is NONE of it** — every target row and the target
+  detail's astronomy will show the "set up your observing site" prompt /
+  the placeholder fallback, no matter how the code looks. Do not be
+  surprised if Tests 6a/6b below show placeholders; that is the CORRECT,
+  expected, verified-against-code behavior right now, not a bug in your
+  test run. Re-run this journey once PR #440 merges to actually exercise the
+  real astronomy path (see Test 6c).
+- Automated coverage baseline today: **this journey has NO Layer-2 coverage
+  and no Playwright mock coverage at all** (confirmed by both
+  `verify-on-windows-journeys.md` and
+  `e2e-mock-coverage-audit-2026-07-05.md`); `all_top_level_screens_load`
+  only proves `/targets` renders without crashing. Spec 047's own task list
+  (`specs/SPEC_STATUS.md` row 80) explicitly defers "T028 verify-on-windows"
+  to "a separate campaign lane" — **this document is that lane.** ~23 vitest
+  component files exist under `features/targets/` (including
+  `__setSiteExistsForTest` seams that exercise the real-astronomy rendering
+  path in isolation, since the real app can't reach it yet) but none of them
+  are a real-backend or real-UI proof.
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed; otherwise a hard refresh suffices (this journey's astronomy
+  columns are pure frontend — a hard refresh is enough for those; target
+  resolve/CRUD are backend, so a full relaunch after a Rust change is
+  required for those Tests).
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`. There is no
+  known backend command to fake an ObserverSite for this pre-#440 test —
+  don't try to force Test 6c until #440 actually merges.
+
+## Preconditions
+1. Deploy as above; complete first-run setup (bundled seed catalog loads
+   automatically).
+2. Network connection available for the SIMBAD resolve-on-demand test.
+3. Sanity: Targets is reachable from the left nav and renders rows.
+
+## Tests
+
+### Test 1 — Catalog list, search, sort
+Steps:
+1. Open **Targets**. Search "M31", then separately search "Andromeda".
+2. Sort by any column.
+Expected:
+- Thousands of rows render with smooth virtualized scroll. Both searches
+  resolve to the same row. Sorting shows a single active sort indicator.
+FAIL if:
+- Either search fails to find the row, or scrolling stutters badly, or more
+  than one sort indicator is active at once.
+
+### Test 2 — Add target (local match, no duplicate)
+Steps:
+1. Click **Add target**, type a name that's in the local seed, confirm.
+2. Repeat with the exact same name.
+Expected:
+- Exactly one row persists after both attempts (re-adding never creates a
+  duplicate).
+FAIL if:
+- A second row appears after re-adding.
+
+### Test 3 — SIMBAD resolve-on-demand (success + failure)
+Steps:
+1. Add a target name NOT in the local seed, with network available.
+2. Separately, try an unresolvable/garbage name (or disconnect network).
+Expected:
+- Step 1: a real SIMBAD lookup happens and the result is cached (adding it
+  again later should resolve instantly/offline).
+  Step 2: an inline "not found"/unreachable message appears — never a
+  fabricated row.
+FAIL if:
+- A row is fabricated for an unresolvable name, or no inline message
+  appears on failure.
+
+### Test 4 — Target detail identity, aliases, notes
+Steps:
+1. Open a target's detail page.
+2. Add a user alias; search for it from the Targets list.
+3. Try removing a catalog-provided alias.
+Expected:
+- Identity fields (designation, type, coordinates, source, catalog id where
+  present) are real. The new alias becomes searchable immediately.
+  Catalog-provided aliases cannot be removed (no delete control, or a
+  disabled one); only user-added ones can be removed.
+FAIL if:
+- A catalog-provided alias can be removed, or a new user alias isn't
+  searchable.
+
+### Test 5 — Favourites is localStorage-only (expected, not a bug)
+Steps:
+1. Toggle "Favourites"/"My Targets" on a target.
+2. Close and reopen the app.
+Expected:
+- It persisted (same browser profile / same app data). This is
+  `localStorage`-only — it will NOT survive a profile reset or follow the
+  user across machines. Confirm this is the actual behavior; it's expected,
+  not a regression.
+FAIL if:
+- It doesn't persist across a normal relaunch (that WOULD be a real
+  regression, since even the localStorage-only implementation should
+  survive a same-machine relaunch).
+
+### Test 6a — Astronomy columns render a disclosed placeholder, not a fabricated value (expected state on `main` today)
+Steps:
+1. On the Targets table, hover/inspect the Max altitude, sparkline,
+   Opposition, Lunar separation, Filters, and Image time columns.
+2. Open a target's detail page and look at the altitude graph.
+Expected (per the Journey facts above — no ObserverSite can exist on `main`
+yet):
+- Every one of these shows a "set up your observing site" prompt or an
+  explicit approximate/placeholder disclosure — **never** a concrete-looking
+  fabricated number with no disclosure. The Sessions column renders a dash.
+FAIL if:
+- Any column renders a concrete-looking value with NO disclosure — this is
+  a constitutional-level failure (a stub must never be mistaken for real
+  data) regardless of whether the underlying value happens to be
+  placeholder or real.
+
+### Test 6b — Confirm the site-setup prompt is the ONLY path shown (regression check)
+Steps:
+1. Look for any way, in the current UI, to create/configure an observing
+   site (wizard step, Settings pane, or a button in the prompt itself).
+Expected:
+- No functional site-creation UI exists yet on `main` (spec 044 US3 / PR #440
+  is still open). If a "set up your site" button exists, clicking it either
+  does nothing yet or navigates to an incomplete pane.
+FAIL if:
+- You find a WORKING site-creation flow that actually flips
+  `readSiteExists()` — if so, this is significant news: it means #440 (or
+  equivalent) landed since this document was written and the whole
+  "gated-off" framing above is stale. Report this explicitly as a finding,
+  re-run Test 6c, and flag this document for an update.
+
+### Test 6c — (Only run after PR #440 merges) Real astronomy renders once a site exists
+Steps:
+1. Create a default observing site via the (now-merged) site-creation UI.
+2. Re-open Targets and a target's detail page.
+Expected:
+- Max altitude, sparkline, Opposition, Lunar separation, Filters, and Image
+  time now compute from the real per-site ephemeris (spec 044 Track B +
+  047 Track A), still with an "approximate" disclosure where the model has
+  known limits, but no longer literal placeholders.
+FAIL if:
+- Values still look like the old hash-derived placeholder pattern (stable
+  across reloads but not reacting to a changed site/date), which would mean
+  the site-gate flip point wasn't actually wired despite #440 merging.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+- If you see real astronomy values on `main` WITHOUT doing anything special
+  in Test 6c's precondition — that itself is a finding (means the site gate
+  changed) — do not assume your test setup is wrong; report it.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. Explicitly call out in your
+report whether Test 6a/6b behaved as documented (gated-off) or whether you
+found working real astronomy on `main` without #440 — that would be
+important, unexpected news either way.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **Everything in this journey** — `automatable` in principle, but **zero
+  Layer-2 coverage and zero mock coverage today**, and spec 047's own task
+  list explicitly defers verify-on-windows to a separate lane (this
+  document). Flagged in the batched new-journey plan as **"Batch: Targets
+  catalog + SIMBAD resolve-on-demand + identity"** (testable today,
+  independent of the site gate) and separately **"Batch: Real planner
+  astronomy end-to-end"** (blocked on PR #440 merging — until then, a
+  Layer-2 journey here could only prove the gated-off prompt renders, not
+  the real astronomy, which is arguably still useful as a regression guard
+  but should be named honestly, e.g. `targets_planner_site_gate_prompt`
+  rather than implying real-astronomy coverage it can't yet provide).
+- The stub-disclosure requirement (Test 6a) is explicitly called out in the
+  product journey doc as safety-critical — this is a good first Layer-2
+  candidate since it's independent of the site-gate blocker: assert that
+  every one of the six astronomy columns and the altitude graph carry a
+  disclosure affordance, regardless of gate state.

--- a/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
+++ b/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
@@ -1,0 +1,188 @@
+# Windows validation — Journey 10: Settings, appearance, and i18n
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+
+## Journey facts (context — you do not act on this section)
+- Product journey: `docs/product/user-journeys.md` Journey 10 (specs
+  018/019/043/046).
+- Branch to test: `main` (unless a specific PR branch was named to you).
+- Touches Rust backend? yes for settings persistence + translated error
+  codes (spec 046); the layout convention and theme switch are frontend-only.
+- Changed surfaces: **Settings** (12 panes / 3 sections), Appearance, bottom
+  log panel, left sidebar, global command palette, every page's pinned
+  header/scrolling-content layout.
+- What this journey proves: every settings pane auto-saves (no global Save
+  button); themes apply live and survive restart; the bottom log panel is a
+  layout participant (shrinks content, never overlays); every user-facing
+  string — including backend error codes — routes through the translation
+  catalog; the 1100×720 minimum layout keeps headers pinned while only
+  content scrolls.
+- Automated coverage baseline today: **this journey has NO Layer-2 coverage
+  and no Playwright mock coverage at all** (confirmed by both
+  `verify-on-windows-journeys.md` and
+  `e2e-mock-coverage-audit-2026-07-05.md`) beyond the generic
+  `all_top_level_screens_load` smoke check that `/settings` renders without
+  crashing. Spec 046 (i18n/error-codes) and spec 043 (redesign/layout
+  convention) are both marked `✅ Implemented` in `specs/SPEC_STATUS.md`,
+  meaning the underlying behavior is real and shipped — it's the UI-level
+  verification of that behavior that has no automated proof at any layer.
+
+## Windows environment mechanics (read once, applies to every Test below)
+
+- Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
+  `git reset --hard origin/main` as its OWN command.
+- **Recompile trap**: touch changed `.rs` files after a reset if Rust
+  changed; otherwise a hard refresh suffices.
+- Reset to fresh first-run if needed:
+  `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`.
+- Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`.
+  Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
+- Blank window recovery: restart dev server; if still blank, `pnpm install`
+  with `$env:CI="true"`, relaunch.
+- Tauri MCP bridge (optional): `cargo tauri dev --config
+  src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
+  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `window.__TAURI__.core.invoke('<snake_command>', {args})`.
+
+## Preconditions
+1. Deploy as above; complete setup with at least one registered source.
+2. Sanity: Settings is reachable from the left nav.
+
+## Tests
+
+### Test 1 — Pane grouping, no global Save
+Steps:
+1. Open **Settings**.
+Expected:
+- 12 panes grouped into Library (Data Sources, Equipment, Ingestion, Naming,
+  Catalogs, Planner), Processing (Tools, Calibration, Cleanup), and
+  Application (General, Advanced, Audit Log). No global "Save" button
+  anywhere — every field auto-saves.
+FAIL if:
+- A global Save button exists, or a field change requires it to persist.
+
+### Test 2 — Theme switch applies live and persists
+Steps:
+1. In Appearance, switch through all 4 named themes plus "System".
+2. After settling on one, fully restart the app.
+Expected:
+- Each theme applies immediately with no reload needed. After restart, the
+  last-chosen theme is still active.
+FAIL if:
+- A theme requires a reload to apply, or resets after restart.
+
+### Test 3 — Font-size is visual-only (expected, not a bug)
+Steps:
+1. Change the Density/Font-size controls in Appearance.
+Expected:
+- Density affects the app; Font-size is confirmed to change nothing outside
+  the settings pane itself (documented limitation, not a regression).
+FAIL if:
+- Font-size actually does nothing you'd expect it not to do differently
+  than documented — i.e. only report FAIL if it does something surprising
+  (like crashing), not for the known no-op.
+
+### Test 4 — Ingestion settings persist without a consuming pipeline (expected)
+Steps:
+1. Toggle symlink-following / hashing-eagerness in the Ingestion pane.
+2. Restart the app.
+Expected:
+- Values persist through the real backend round-trip after restart (no scan
+  pipeline reads them yet — expected, not a bug).
+FAIL if:
+- The values don't persist across restart.
+
+### Test 5 — Target Planner altitude-threshold clamp
+Steps:
+1. In the Planner pane, try setting "usable altitude" outside 0–90.
+2. Set a valid in-range value.
+Expected:
+- Out-of-range input clamps to the valid range. A valid value immediately
+  affects the Targets planner view (see Journey 9's caveats about the
+  site-gate for what "affects" currently means).
+FAIL if:
+- Out-of-range input is accepted as-is.
+
+### Test 6 — Bottom log panel is a layout participant, not an overlay
+Steps:
+1. Expand the bottom log panel.
+2. Filter by each severity chip (Error/Warn/Info/Debug); set the level to
+   Debug.
+3. Export the visible log window.
+Expected:
+- Expanding shrinks the main content area rather than covering it. Deep
+  diagnostics only appear once the level is turned down to Debug. Export
+  produces a JSON file matching only the currently filtered/visible rows.
+FAIL if:
+- The panel overlays content instead of sharing layout space, or export
+  includes rows outside the current filter.
+
+### Test 7 — 1100×720 pinned-header layout convention
+Steps:
+1. Resize the window to exactly 1100×720 (the documented minimum supported
+   size).
+2. Visit several pages (Sessions, Inbox, Projects, Targets) and scroll each
+   page's content.
+Expected:
+- On every page, the header/action bar stays pinned while only the content
+  area scrolls.
+FAIL if:
+- Any page's header scrolls out of view along with the content.
+
+### Test 8 — Translated errors, never a raw code
+Steps:
+1. Trigger a backend error (e.g. attempt an invalid remap path in Data
+   Sources, or another action you know will be rejected).
+Expected:
+- The error banner/toast shows a translated, human-readable message — never
+  a raw backend error code (e.g. something like `E_INVALID_PATH`) or an
+  English-only string leaking through untranslated in a non-English UI
+  configuration if one is set up.
+FAIL if:
+- A raw error code or key leaks into the UI.
+
+### Test 9 — Command palette (Ctrl+K) and keyboard-only navigation
+Steps:
+1. Press Ctrl+K, search for a real target or session by name.
+2. Navigate to it using only the keyboard (no mouse).
+Expected:
+- Live backend-search results appear, and keyboard-only navigation reaches
+  the result end to end.
+FAIL if:
+- Results don't reflect real backend data, or keyboard navigation gets
+  stuck/requires the mouse.
+
+### Test 10 — Sidebar collapse persists
+Steps:
+1. Collapse the left sidebar.
+2. Reload the app.
+Expected:
+- The collapsed state persisted.
+FAIL if:
+- The sidebar resets to expanded after reload.
+
+## Troubleshooting
+- Blank window: restart the dev server; if still blank, `pnpm install` with
+  `$env:CI="true"`, relaunch.
+
+## Report back
+Per Test: PASS / FAIL + one line of what you saw. On FAIL, screenshot + exact
+on-screen text / toast; for Test 7, note the exact window size used.
+
+## E2E-sync (coverage bookkeeping — not for the Windows agent)
+
+- **`/settings` route renders without an uncaught error** — `automatable`,
+  already covered by `all_top_level_screens_load`.
+- **Everything else in this journey (pane grouping/auto-save, theme
+  persistence, ingestion-settings persistence, altitude-threshold clamp, log
+  panel layout/filter/export, 1100×720 convention, translated-error
+  surfacing, command palette, sidebar persistence)** — all `automatable` in
+  principle (deterministic UI state/persistence checks, no native OS
+  dialogs involved) but **zero Layer-2 coverage and zero mock coverage
+  today**. Flagged in the batched new-journey plan as **"Batch: Settings +
+  layout-convention + i18n regression guard"** — lowest filesystem-mutation
+  risk of the 10 journeys, but the layout-convention and no-raw-error-code
+  checks are cross-cutting regression guards worth having cheaply once,
+  since they protect every other journey's perceived trustworthiness too.

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -162,3 +162,160 @@ identity and link a resolved `canonical_target` (FR-016). Folds into areas
 interval task in `apps/desktop/src-tauri/src/lib.rs::run_app` is exercised
 function-by-function at Layer 1 (T046 calls both directly); the live interval
 loop is validated in the Windows real-app E2E loop.
+
+## Unified-main audit — 2026-07-05 (Layer-2 + manual-Windows + mock-layer reconciliation)
+
+Read-heavy audit against `origin/main` post spec-043-redesign convergence
+(PR #349 merged, plus #430/#435/#436/#439/#442/#443 landed after it). No
+product code changed. Confirms the Layer-2 harness described above survived
+the convergence intact and adds the missing cross-reference to the mock
+(Playwright) layer and to the 10 user journeys, including several
+post-convergence features (040, 043, 044, 046, 047, 048, 049) that predate
+this file's existing rows.
+
+**Three test layers now exist; this file previously tracked only two.**
+Layer-2 (`crates/e2e-tests/`, this file, above) and Layer-1 (`cargo test
+--workspace`, above) are unchanged in shape. A third, **mock-Playwright**
+layer (`apps/desktop/tests/e2e/*.spec.ts`, `VITE_USE_MOCKS=true`, run via
+`pnpm --filter @astro-plan/desktop test:e2e`) exists and is now tracked here
+for the first time — see
+`docs/development/e2e-mock-coverage-audit-2026-07-05.md` (branch
+`research/e2e-mock-coverage-audit`) for the full spec-by-spec breakdown. A
+fourth surface, **manual-Windows** (`docs/development/windows-journeys/`,
+this audit's new artifact, plus the pre-existing
+`docs/development/verify-on-windows-journeys.md`), is the catch-all for
+everything neither automated layer reaches.
+
+### Per-journey coverage (10 user journeys, `docs/product/user-journeys.md`)
+
+| Journey | Layer-1 | Layer-2 | Mock-Playwright | Manual-Windows doc |
+|---|:--:|:--:|:--:|---|
+| 1 First-run → data sources | ✅ | 🟡 wizard redirect + resolve + create only | 🟡 legacy-state + index-redirect regressions only | `windows-journeys/journey-01-first-run-setup.md` |
+| 2 Ingest → reclassify → confirm (move) | ✅ | 🟡 IPC round-trip only (no UI interaction) | ❌ none | `windows-journeys/journey-02-inbox-ingest-move.md` |
+| 3 Ingest → confirm (catalogue-in-place) | ✅ | ❌ (existing journey forces the move branch) | ❌ none | `windows-journeys/journey-03-inbox-catalogue-in-place.md` |
+| 4 Sessions review (derived) | ✅ | 🟡 grouping proof only, no UI-invariant checks | 🟡 rows/detail render only | `windows-journeys/journey-04-sessions-review.md` |
+| 5 Project lifecycle | ✅ | 🟡 transition + ledger only, no UI | 🟡 transition button only (pill-refresh `test.skip`) | `windows-journeys/journey-05-project-lifecycle.md` |
+| 6 Cleanup scan→review→apply | ✅ | 🟡 stops at `approved`, **apply step has zero coverage anywhere** | ❌ none | `windows-journeys/journey-06-cleanup-scan-apply.md` |
+| 7 Archive → delete | ✅ (backend only) | ❌ **none at all** | ❌ **none at all** | `windows-journeys/journey-07-archive-delete.md` |
+| 8 Calibration masters → matching | ✅ | 🟡 `calibration.match.suggest` shape only | ❌ none | `windows-journeys/journey-08-calibration-masters-matching.md` |
+| 9 Targets & planning | ✅ (backend only) | ❌ **none at all** | ❌ **none at all** | `windows-journeys/journey-09-targets-planning.md` |
+| 10 Settings/appearance/i18n | ✅ | 🟡 route-load smoke only | ❌ none | `windows-journeys/journey-10-settings-appearance-i18n.md` |
+
+Legend: ✅ solid coverage at that layer · 🟡 partial/IPC-only/smoke-only ·
+❌ none. Layer-1 "✅" means the backend logic is real-tested; it says
+nothing about the UI surface, which is exactly the gap the other columns
+track.
+
+### Post-convergence feature areas not yet in the table above (specs 040/043/044/046/047/048/049)
+
+These shipped after this file's original 22 areas were enumerated and were
+never folded in. Status verified against real code on `main`
+(2026-07-05), not against spec-doc `Status:` headers, which lag behind
+what's actually merged (`specs/SPEC_STATUS.md` itself is stale in places —
+see the finding below).
+
+| Spec | Area | Layer-1 | Layer-2 | Mock | Manual-Windows | Note |
+|---|---|:--:|:--:|:--:|:--:|---|
+| 040 | Calibration master detection | ✅ | 🟡 (suggest only) | ❌ | journey-08 | Shipped without `plan.md`/`tasks.md` (documented deviation); least-scrutinized recent backend feature |
+| 041 | Inbox single-type sub-items / destination model | ✅ | 🟡 (IPC only) | ❌ | journey-02/03 | iteration-2 now on `main` via #349 |
+| 043 | UI redesign (theming, layout convention, `aria-sort`) | n/a | 🟡 (smoke only) | ❌ | journey-10 | Foundation + round-2 shipped; pill-system unification and resizable splitters still pending per SPEC_STATUS |
+| 044 | Targets planner — Track B ephemeris/observer engine | n/a (frontend-only) | ❌ | ❌ | journey-09 | **Compute engine merged (`a395ce93`) but functionally unreachable**: real astronomy is gated behind `useObserverSiteExists()`, and `site-gate.ts::readSiteExists()` is hardcoded `return false` — no site-creation UI/command exists on `main` until PR #440 (spec 044 US3, open) merges. Verify this is still true before reusing this row. |
+| 046 | i18n infrastructure & error-code translation | ✅ | n/a (cross-cutting) | ❌ | journey-10 | `specs/SPEC_STATUS.md`: Implemented, 36/36 |
+| 047 | Targets planner — Track A (Moon/filter/opposition) | ✅ | ❌ | ❌ | journey-09 | Implemented in code but **also gated by the same site-exists check as 044** (spec 047 D7) — see 044 row; spec's own T028 explicitly defers verify-on-windows here |
+| 048 | Per-frame inventory / live session membership | ✅ (partial) | ❌ | ❌ | — (folds into journeys 4/6) | `main` PRs #435/#442 merged; full per-frame-inventory US scope still open |
+| 049 | Source-view generation (symlinks/junctions) | ✅ (partial) | ❌ | ❌ | — (new journey needed, none written this pass) | `main` PR #439 (US1) + #443 (US2 profile layout) merged; junction/symlink behavior is real, OS-specific filesystem behavior a mock layer structurally cannot prove — highest-value Layer-2 candidate of the unlisted specs |
+
+**Finding (verified against code, not spec prose)**: `specs/SPEC_STATUS.md`
+row 77 (044) reads "Track B specced, implementation in progress... T001–T003
+landed" — this is stale; `git log` shows `a395ce93` ("real tonight altitude,
+rise/set, and imaging-time in the Targets planner", #436) already merged to
+`main`, well past T001–T003. Do not use `SPEC_STATUS.md` prose alone to
+judge what's implemented; check the running code (as this audit did for the
+site-gate finding above).
+
+### Layer-2-only flows (cannot be reached by the mock-Playwright layer, ever)
+
+These are backend-driven behaviors the mock layer structurally cannot
+assert, because they require a real Tauri `Channel`, a real filesystem, a
+real async event pipeline, or a real OS integration — mocking them would
+just test the mock, not the product:
+
+- **`plans.apply.status` durable progress polling and the real file-move
+  side effect** (`plan_review_apply_with_audit`) — needs a real filesystem
+  and the real `plan_apply_events` table.
+- **Event-driven session grouping after plan apply**
+  (`ingestion_sessions_search`) — needs the real async `plan_listener` →
+  `ingest_light_frames` pipeline; a mock can fake the end state but not
+  prove the pipeline actually fires.
+- **`lifecycle.transition.apply` + `lifecycle.ledger.list` real DTO
+  round-trip** (`lifecycle_integrity`) — needs the real backend's
+  business-rule engine, not a canned mock response.
+- **`artifact.watcher.attach` real filesystem reconciliation + live watch**
+  (`cleanup_plan_review`) — needs a real directory watcher.
+- **Archive/cleanup plan `apply` with a `tauri::ipc::Channel` progress
+  argument** — structurally cannot be driven by Playwright at all (no
+  Tauri IPC channel in a browser context); this is Layer-2-or-manual-only
+  by construction, not just by current gap.
+- **Symlink/junction creation for source views (spec 049)** and **OS trash
+  semantics (spec 017/025)** — real, OS-specific filesystem behavior; a
+  mock can only assert the UI *called* the right command, never that the
+  junction/trash operation actually succeeded on that OS.
+- **Native OS folder pickers, "Show in File Explorer" reveal, tool-launch
+  process spawn** — real OS integrations outside any webview.
+
+### Batched plan — new Layer-2 (thirtyfour) journeys to author, ordered by risk/value
+
+1. **Archive lifecycle + trash + permanent delete** (Journey 7) — highest
+   product risk (irreversible deletion) with **zero automated coverage at
+   any layer today**. **Blocked** on a channel-free apply command for
+   archive/cleanup plans (shared blocker with #2) — land that first.
+2. **Cleanup plan apply completion** (Journey 6) — extend
+   `cleanup_plan_review` past `plans.approve` once the channel-free apply
+   path (or a real UI Apply button + a thin test hook) exists. Same
+   blocker as #1; land together.
+3. **Calibration masters ingest → Calibration page → matching → assign**
+   (Journey 8, spec 040) — real UI-level masters flow beyond today's
+   `calibration.match.suggest`-only proof; spec 040 has the least automated
+   scrutiny of any recently-shipped backend feature.
+4. **Source-view generation** (spec 049) — generate/regenerate a
+   WBPP-profile source view and assert real symlinks/junctions exist on
+   disk with the correct per-tool layout; real OS-specific filesystem
+   behavior the mock layer can never prove. No journey exists yet.
+5. **Per-frame inventory reconciliation** (spec 048) — raw-frame-vs-disk
+   reconciliation feeding cleanup candidates; extends Journeys 4/6.
+6. **Inbox UI-level gate + reclassify + root-picker** (Journeys 2/3) —
+   mixed-folder splitting, needs-review banner/badges, bulk reclassify,
+   root-picker prompt, stale-plan refusal, and the catalogue-in-place (0
+   moves) variant — all currently proven only at the IPC level, not through
+   real UI interaction. Highest-value UI-interaction gap, but lower risk
+   than #1/#2 since the backend mutation itself is already proven.
+7. **Targets catalog + SIMBAD resolve-on-demand + stub-disclosure guard**
+   (Journey 9) — testable today independent of the site-gate blocker; the
+   stub-disclosure requirement is called out as safety-critical in the
+   product journey doc and has zero coverage at any layer.
+8. **Real planner astronomy end-to-end** (Journey 9, specs 044/047) —
+   **blocked** on PR #440 (site-creation UI) merging; until then any new
+   journey here can only prove the gated-off prompt renders correctly, not
+   real astronomy — name it honestly (e.g.
+   `targets_planner_site_gate_prompt`) rather than implying coverage it
+   can't provide yet.
+9. **Sessions derived-view invariants** (Journey 4) — absence of
+   review-state controls/pills, notes-edit-doesn't-transition, rescan
+   idempotency; low cost, extends the existing
+   `ingestion_sessions_search` fixture.
+10. **Project lifecycle UI surface** (Journey 5) — create-wizard validation,
+    attach/remove-sources UX, manifests/notes autosave, tool-launch spawn +
+    containment, artifact watcher; tool-launch and the watcher specifically
+    need Layer-2 (a real process/filesystem watcher), not the mock layer.
+11. **Settings + layout-convention + i18n regression guard** (Journey 10) —
+    lowest filesystem-mutation risk; the 1100×720 layout convention and
+    no-raw-error-code checks are cheap, cross-cutting regression guards.
+
+See `docs/development/windows-journeys/journey-0{1..9,10}-*.md` for the
+click-by-click manual scripts covering all of the above until each is
+promoted to a real Layer-2 journey, and
+`docs/development/e2e-mock-coverage-audit-2026-07-05.md` for the
+mock-Playwright layer's own parallel batched fix-list (batches 1–7 there
+target the same gaps from the mock-layer side where a mock CAN reach the
+behavior — see the "Layer-2-only flows" section above for which ones a mock
+never will).


### PR DESCRIPTION
## Summary
- Audits the Layer-2 real-UI E2E harness (`crates/e2e-tests/`, 5 `#[ignore]` journeys + `all_top_level_screens_load` smoke, `e2e.yml`) against all 10 user journeys and the post-convergence feature set (specs 040/043/044/046/047/048/049), cross-referencing the mock-Playwright layer's own audit (`research/e2e-mock-coverage-audit` branch).
- Adds one self-contained Windows cowork/computer-use validation script per journey under `docs/development/windows-journeys/journey-NN-*.md`, following the `verify-on-windows` skill's template.
- Updates `specs/037-e2e-integration-testing/contracts/coverage-matrix.md` with a per-journey Layer-1/Layer-2/mock/manual matrix, a "Layer-2-only" flow list, and a risk-ordered batched plan for new Layer-2 journeys.
- Notable finding (verified against code, not spec prose): specs 044 Track B and 047 Track A's real planner astronomy is implemented but currently unreachable in the running app — `site-gate.ts::readSiteExists()` is hardcoded `false` pending PR #440 (site-creation UI). Journey 9's doc documents this precisely so a tester doesn't mistake gated-off placeholders for a regression.
- Docs only — no product code changed. Did not run the heavy WebDriver suite locally (CI's `e2e.yml` already validates it on unified `main`).

## Test plan
- [ ] Docs-only change; no test suite applicable. `e2e.yml`/`ci.yml` should stay green (no product code touched).
- [ ] Reviewer sanity-check: skim one or two `windows-journeys/journey-*.md` files for accuracy against current `main` behavior.