### PR TITLE
test(e2e): enrich mock harness for backend-driven flows (inbox plan, archive/cleanup generate, Channel polyfill)

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -14,7 +14,21 @@ import type {
   InboxListResponse_Serialize,
   InboxScanFolderResponse_Serialize,
   InboxClassifyResponse_Serialize,
-  InboxConfirmResponse,
+  InboxConfirmResponse_Serialize,
+  InboxConfirmActionsSummary,
+  InboxConfirmDestination,
+  InboxOpenPlansResponse,
+  InboxOpenPlan,
+  InboxPlanAction,
+  InboxPlanView,
+  InboxApplyAllResponse,
+  InboxPlanCancelResponse,
+  InboxStatsResponse,
+  InboxItemMetadataResponse_Serialize,
+  InboxFileMetadata_Serialize,
+  PropertyRegistryEntry_Serialize,
+  GenerateArchivePlanResult,
+  TransitionError_Serialize,
   InboxReclassifyResponse_Serialize,
   TargetListItem,
   TargetDetailV3_Serialize,
@@ -338,6 +352,97 @@ function mockCalibrationMatches(sessionId: string): CalibrationMatchDto_Serializ
     },
   ];
 }
+
+// ── Inbox plan surface (spec 041) — stateful mock ─────────────────────────────
+//
+// `inbox_plan_list_open` previously had no case, so `useOpenInboxPlans` always
+// resolved to `[]` and the top-bar "Review plans" overlay was unreachable in
+// mock mode. These seed plans make the overlay reachable AND make the
+// move-vs-catalogue-in-place distinction observable at the plan-review layer
+// (spec 041 FR-017/FR-018/SC-007):
+//   plan-move-002     → every action is a `move` (unorganized source relocates
+//                       into the library) → PlanPanel renders "→ <dest>".
+//   plan-inplace-org  → every action is a `catalogue` (toPath == fromPath;
+//                       already-organized source, no file moves) → PlanPanel
+//                       renders the "In place · <folder>" label.
+// Apply/cancel MUTATE this array (removing the applied/cancelled plan) so the
+// aggregate surface refresh + auto-close behaviour round-trips like the backend.
+//
+// Shapes are pinned to the generated bindings (`InboxOpenPlan`/`InboxPlanAction`)
+// so a contract change the mock fails to mirror is a compile error.
+
+/** A `move` action: source relocates to a distinct destination path. */
+function mockMoveAction(index: number, file: string): InboxPlanAction {
+  return {
+    index,
+    action: 'move',
+    fromPath: `/astro/raw/2025-10-10/darks/${file}`,
+    toPath: `/astro/library/darks/2025-10-10/${file}`,
+    destinationPreview: 'library/darks/2025-10-10/',
+    requiresDestructiveConfirm: false,
+  };
+}
+
+/** A `catalogue` action: file stays put (toPath == fromPath), no move. */
+function mockCatalogueAction(index: number, file: string): InboxPlanAction {
+  const path = `/astro/library/NGC7000/${file}`;
+  return {
+    index,
+    action: 'catalogue',
+    fromPath: path,
+    toPath: path,
+    destinationPreview: 'library/NGC7000/',
+    requiresDestructiveConfirm: false,
+  };
+}
+
+function seedInboxOpenPlans(): InboxOpenPlan[] {
+  return [
+    {
+      inboxItemId: 'item-002',
+      itemName: '2025-10-10/darks',
+      planId: 'plan-move-002',
+      state: 'plan_open',
+      stale: false,
+      actions: [
+        mockMoveAction(1, 'dark_001.fits'),
+        mockMoveAction(2, 'dark_002.fits'),
+      ],
+    },
+    {
+      inboxItemId: 'item-organized-inplace',
+      itemName: 'Library/NGC7000',
+      planId: 'plan-inplace-org',
+      state: 'plan_open',
+      stale: false,
+      actions: [
+        mockCatalogueAction(1, 'NGC7000_Ha_001.fits'),
+        mockCatalogueAction(2, 'NGC7000_Ha_002.fits'),
+      ],
+    },
+  ];
+}
+
+let mockInboxOpenPlans: InboxOpenPlan[] = seedInboxOpenPlans();
+
+/**
+ * Inbox item ids whose source is already ORGANIZED — `inbox_confirm` produces a
+ * catalogue-in-place result (zero moves) for these, and a move plan otherwise
+ * (spec 041 US4 FR-017/FR-018). Mirrors the backend's per-source
+ * `organization_state` branch. `item-organized-inplace` is the seed plan's item;
+ * confirming it (or any id here) yields the catalogue-in-place shape.
+ */
+const MOCK_ORGANIZED_ITEM_IDS = new Set<string>(['item-organized-inplace']);
+
+/** Plan-required lifecycle edges (mirrors `lifecycle-actions.ts` `requiresPlan`). */
+const MOCK_PLAN_REQUIRED_EDGES = new Set<string>([
+  'ready→prepared',
+  'prepared→ready',
+  'completed→archived',
+  'blocked→archived',
+  'archived→ready',
+  'archived→processing',
+]);
 
 /**
  * Dispatch a mock IPC response for `cmd`.
@@ -670,20 +775,51 @@ export async function mockInvoke(
     // ---------- Mutation Commands ----------
 
     case 'lifecycle_transition_apply': {
-      // Mock: always succeeds. The request is the canonical FLAT discriminated
-      // envelope (issue #423): `nextState` sits beside the `entityType` tag —
-      // there is no `{ project: {...} }` wrapper. Echo it back for the UI.
+      // Arg-sensitive: a plan-required edge (e.g. completed → archived) returns
+      // `status: 'error'` with `error.code: 'plan.required'`, mirroring the
+      // backend — the UI then routes to the plan-create flow (and, for
+      // → archived, calls `archive_plan_generate`). Non-plan edges (e.g.
+      // processing → completed) succeed immediately. The request is the
+      // canonical FLAT discriminated envelope (issue #423): `nextState` sits
+      // beside the `entityType` tag — no `{ project: {...} }` wrapper.
       const req = (_args as { request?: { nextState?: string; currentState?: string; entityId?: string } } | undefined)
         ?.request;
+      const prior = req?.currentState ?? 'processing';
+      const next = req?.nextState ?? 'completed';
+      if (MOCK_PLAN_REQUIRED_EDGES.has(`${prior}→${next}`)) {
+        return {
+          status: 'error',
+          contractVersion: '2.0.0',
+          requestId: crypto.randomUUID(),
+          error: {
+            code: 'plan.required',
+            message: `Transition ${prior} → ${next} requires an approved plan.`,
+            details: null,
+          } satisfies TransitionError_Serialize,
+        } satisfies TransitionResponse_Serialize;
+      }
       return {
         status: 'success',
         contractVersion: '2.0.0',
         requestId: crypto.randomUUID(),
         appliedAt: new Date().toISOString(),
-        priorState: req?.currentState ?? 'processing',
-        newState: req?.nextState ?? 'completed',
+        priorState: prior,
+        newState: next,
         auditId: 'mock-audit-transition',
       } satisfies TransitionResponse_Serialize;
+    }
+
+    case 'archive_plan_generate': {
+      // `archive.plan.generate` — whole-project reviewable archive plan (spec
+      // 017 / constitution II: created in `ready_for_review`, never
+      // auto-applied). Previously ABSENT from the mock switch, so the
+      // completed → archived archive flow dead-ended after the plan.required
+      // toast. One protected item so the spec-016 acknowledge gate is exercised.
+      return {
+        planId: 'plan-archive-mock',
+        itemCount: 4,
+        protectedItemCount: 1,
+      } satisfies GenerateArchivePlanResult;
     }
 
     case 'sessions_split': {
@@ -1071,12 +1207,47 @@ export async function mockInvoke(
       } satisfies InboxClassifyResponse_Serialize;
     }
     case 'inbox_confirm': {
+      // Arg-sensitive: an ORGANIZED source catalogues in place (zero moves —
+      // spec 041 US4/FR-018), an unorganized source produces a move plan
+      // (FR-017). The observable move-vs-catalogue distinction surfaces on the
+      // aggregate plan surface (`inbox_plan_list_open`); the confirm response
+      // itself carries the branch via `actionsSummary`/`organizationState`.
+      const req = (_args as { req?: { inboxItemId?: string; rootAbsolutePath?: string } } | undefined)?.req;
+      const inboxItemId = req?.inboxItemId ?? '';
+      const rootAbsolutePath = req?.rootAbsolutePath ?? '/astro/raw';
+      const organized = MOCK_ORGANIZED_ITEM_IDS.has(inboxItemId);
+      // `itemsTotal` kept at 18 for the existing move-path e2e assertion.
+      const itemsTotal = 18;
+      const actionsSummary: InboxConfirmActionsSummary = organized
+        ? { moveCount: 0, catalogueCount: itemsTotal }
+        : { moveCount: itemsTotal, catalogueCount: 0 };
+      const fromPath = `${rootAbsolutePath}/light_001.fits`;
+      const destinations: InboxConfirmDestination[] = [
+        organized
+          ? {
+              fromPath,
+              toRelativePath: 'light_001.fits',
+              toAbsolutePath: fromPath, // catalogue = no move
+              toRootId: 'root-lights-001',
+              action: 'catalogue',
+            }
+          : {
+              fromPath,
+              toRelativePath: 'darks/2025-10-10/light_001.fits',
+              toAbsolutePath: '/astro/library/darks/2025-10-10/light_001.fits',
+              toRootId: 'root-lights-001',
+              action: 'move',
+            },
+      ];
       return {
         planId: `plan-${Date.now()}`,
         planState: 'ready_for_review',
-        itemsTotal: 18,
+        itemsTotal,
         registeredAsMaster: false,
-      } satisfies InboxConfirmResponse;
+        actionsSummary,
+        organizationState: organized ? 'organized' : 'unorganized',
+        destinations,
+      } satisfies InboxConfirmResponse_Serialize;
     }
     case 'inbox_reclassify': {
       const args = _args as { req: { inboxItemId: string } } | undefined;
@@ -1088,6 +1259,180 @@ export async function mockInvoke(
         appliedCount: 1,
         breakdown: [],
       } satisfies InboxReclassifyResponse_Serialize;
+    }
+
+    // ── Inbox plan surface (spec 041 US2) ─────────────────────────────────────
+    //
+    // These cases were previously ABSENT: every one fell through to `default:
+    // throw new Error('Unknown mock command')`, so the "Review plans" overlay,
+    // per-file metadata popover, and aggregate stats were unreachable in mock
+    // mode. Shapes are pinned to the generated bindings.
+
+    case 'inbox_plan_list_open': {
+      const totalActions = mockInboxOpenPlans.reduce(
+        (sum, p) => sum + p.actions.length,
+        0,
+      );
+      return {
+        plans: mockInboxOpenPlans,
+        totalActions,
+      } satisfies InboxOpenPlansResponse;
+    }
+    case 'inbox_plan': {
+      const inboxItemId = (_args?.inboxItemId as string) ?? '';
+      const plan = mockInboxOpenPlans.find((p) => p.inboxItemId === inboxItemId);
+      if (!plan) {
+        // Mirrors the backend's `inbox.item.no_plan` error branch, which the
+        // hook swallows into an empty state (store.ts `useInboxPlan`).
+        throw 'inbox.item.no_plan';
+      }
+      return {
+        planId: plan.planId,
+        state: plan.state,
+        stale: plan.stale,
+        actions: plan.actions,
+      } satisfies InboxPlanView;
+    }
+    case 'inbox_plan_apply': {
+      // The InboxPage apply-one path streams live progress through
+      // `plans_apply_real` (Channel); this direct binding is retained for
+      // completeness. Removes the applied plan from the aggregate surface.
+      const inboxItemId = (_args?.inboxItemId as string) ?? '';
+      const plan = mockInboxOpenPlans.find((p) => p.inboxItemId === inboxItemId);
+      mockInboxOpenPlans = mockInboxOpenPlans.filter(
+        (p) => p.inboxItemId !== inboxItemId,
+      );
+      return {
+        planId: plan?.planId ?? 'plan-unknown',
+        runId: 'op-inbox-apply-001',
+        newState: 'applied',
+      } satisfies PlanApplyResponse;
+    }
+    case 'inbox_plan_apply_all': {
+      const results = mockInboxOpenPlans.map((p) => ({
+        inboxItemId: p.inboxItemId,
+        planId: p.planId,
+        state: 'applied',
+        error: null,
+      }));
+      mockInboxOpenPlans = [];
+      return { results } satisfies InboxApplyAllResponse;
+    }
+    case 'inbox_plan_apply_selected': {
+      const ids =
+        (_args as { request?: { inboxItemIds?: string[] } } | undefined)?.request
+          ?.inboxItemIds ?? [];
+      const selected = mockInboxOpenPlans.filter((p) =>
+        ids.includes(p.inboxItemId),
+      );
+      const results = selected.map((p) => ({
+        inboxItemId: p.inboxItemId,
+        planId: p.planId,
+        state: 'applied',
+        error: null,
+      }));
+      mockInboxOpenPlans = mockInboxOpenPlans.filter(
+        (p) => !ids.includes(p.inboxItemId),
+      );
+      return { results } satisfies InboxApplyAllResponse;
+    }
+    case 'inbox_plan_cancel': {
+      const inboxItemId = (_args?.inboxItemId as string) ?? '';
+      const plan = mockInboxOpenPlans.find((p) => p.inboxItemId === inboxItemId);
+      mockInboxOpenPlans = mockInboxOpenPlans.filter(
+        (p) => p.inboxItemId !== inboxItemId,
+      );
+      return {
+        inboxItemId,
+        planId: plan?.planId ?? 'plan-unknown',
+        state: 'classified',
+      } satisfies InboxPlanCancelResponse;
+    }
+    case 'inbox_stats': {
+      // Faithful aggregate: 3 folders (item-001/002/003) + 1 master
+      // (item-master-dark), mirroring the `inbox_list` fixture. No component
+      // currently invokes this (the UI derives stats client-side via
+      // `deriveInboxStats`), but future batches can exercise it directly.
+      return {
+        perType: [
+          { frameType: 'dark', folderCount: 0, masterCount: 1, imageCount: 1 },
+          { frameType: 'mixed', folderCount: 3, masterCount: 0, imageCount: 67 },
+        ],
+        totals: { folders: 3, masters: 1, images: 68 },
+      } satisfies InboxStatsResponse;
+    }
+    case 'inbox_item_metadata': {
+      // Per-file extracted metadata for the selected inbox item (spec 041
+      // US2/FR-010). Deliberately carries NO `missingPathAttributes` /
+      // `missingMandatory` so confirm stays enabled in the move-path e2e.
+      const inboxItemId =
+        (_args as { req?: { inboxItemId?: string } } | undefined)?.req
+          ?.inboxItemId ?? 'item-001';
+      const files: InboxFileMetadata_Serialize[] = [
+        {
+          relativeFilePath: 'NGC7000_Ha_001.fits',
+          frameTypeEffective: 'light',
+          imageTyp: 'LIGHT',
+          filter: 'Ha',
+          exposureS: 300,
+          gain: '100',
+          binningX: 1,
+          binningY: 1,
+          temperatureC: -10,
+          object: 'NGC 7000',
+          dateObs: '2025-10-10T22:14:00',
+          instrume: 'ASI2600MM Pro',
+          telescop: 'Esprit 100ED',
+          naxis1: 6248,
+          naxis2: 4176,
+          stackCount: null,
+          isMaster: false,
+          overrideStale: false,
+          missingPathAttributes: [],
+          missingMandatory: [],
+          offset: 10,
+          setTempC: -10,
+          ccdTempC: -10,
+        },
+      ];
+      return {
+        inboxItemId,
+        files,
+      } satisfies InboxItemMetadataResponse_Serialize;
+    }
+    case 'inbox_property_registry': {
+      // Typed property registry (spec 041 R-13/FR-044). No component invokes it
+      // yet; a faithful subset keeps the field-agnostic reclassify editor
+      // mockable for future batches.
+      return [
+        {
+          key: 'frameType',
+          kind: 'enum',
+          unit: null,
+          sourceHeaders: ['IMAGETYP'],
+          overridable: true,
+          appliesTo: ['light', 'dark', 'flat', 'bias'],
+          validation: 'one of: light, dark, flat, bias',
+        },
+        {
+          key: 'exposureS',
+          kind: 'number',
+          unit: 's',
+          sourceHeaders: ['EXPTIME', 'EXPOSURE'],
+          overridable: true,
+          appliesTo: ['light', 'dark', 'flat'],
+          validation: '> 0',
+        },
+        {
+          key: 'filter',
+          kind: 'string',
+          unit: null,
+          sourceHeaders: ['FILTER'],
+          overridable: true,
+          appliesTo: ['light', 'flat'],
+          validation: null,
+        },
+      ] satisfies PropertyRegistryEntry_Serialize[];
     }
 
     // ── Inventory commands (spec 006) ─────────────────────────────────────────

--- a/tests/e2e/cleanup_review.spec.ts
+++ b/tests/e2e/cleanup_review.spec.ts
@@ -49,44 +49,15 @@
  * First-run seeding:
  *   Reads `alm-preferences.setupCompleted` from localStorage.
  */
-import { test, expect } from "@playwright/test";
-
-function seedSetupComplete(page: import("@playwright/test").Page): void {
-  page.addInitScript(() => {
-    window.localStorage.setItem(
-      "alm-preferences",
-      JSON.stringify({ setupCompleted: true }),
-    );
-  });
-}
-
-/**
- * `PlanReviewOverlay`'s approve-and-apply path bridges the live apply
- * progress onto a real `@tauri-apps/api/core` `Channel` (see
- * `features/plans/planApply.ts`). `Channel`'s constructor calls
- * `window.__TAURI_INTERNALS__.transformCallback`, which only exists inside an
- * actual Tauri webview — outside one (this Playwright run drives the plain
- * Vite dev server with no Tauri host, same as `usePlanApplyProgress.test.tsx`
- * needs to shim for jsdom) the constructor throws, the apply call fails
- * before `plans_apply_real` ever streams a mock event, and the overlay shows
- * "Plan apply failed." Shim only the one method `Channel` needs, scoped to
- * this test file via `addInitScript` (no production code changes) — the same
- * minimal shim `usePlanApplyProgress.test.tsx` installs for its jsdom
- * environment.
- */
-function shimTauriChannel(page: import("@playwright/test").Page): void {
-  page.addInitScript(() => {
-    let nextId = 1;
-    (window as unknown as { __TAURI_INTERNALS__: { transformCallback: () => number } }).__TAURI_INTERNALS__ =
-      { transformCallback: () => nextId++ };
-  });
-}
+// The Tauri `Channel` polyfill this journey's approve-and-apply path needs is
+// installed globally by the shared harness `test` (see
+// `tests/e2e/support/harness.ts`) — no per-spec shim required.
+import { test, expect, seedSetupComplete } from "./support/harness";
 
 test.describe("cleanup review (spec 017 WP-E / Journey 6)", () => {
   test("scan → review candidates with confidence + protection → generate plan → protection gate → approve & apply", async ({
     page,
   }) => {
-    shimTauriChannel(page);
     seedSetupComplete(page);
     await page.goto("/#/projects");
 

--- a/tests/e2e/inbox_ingest_confirm.spec.ts
+++ b/tests/e2e/inbox_ingest_confirm.spec.ts
@@ -31,44 +31,18 @@
  *   - `useInboxItemMetadata` always resolves to `[]`, so the per-file FITS
  *     metadata popover and the FR-032 missing-path-attribute gate can never
  *     populate/trigger via this seam.
- * This is a real, fixable gap (add the missing mock cases) — but doing so is
- * a product-code change, out of scope for this additive-test-only batch. Two
- * scenarios are `test.skip`-documented below rather than faked.
+ * ── Harness update (2026-07-05) ──────────────────────────────────────────────
+ * The mock-layer gaps described above are now CLOSED by the shared harness +
+ * enriched `mocks.ts` (`inbox_plan_list_open` seed plans, arg-sensitive
+ * `inbox_confirm`, a first-party Tauri `Channel` polyfill). The two previously
+ * `test.skip`-documented scenarios are un-skipped at the foot of this file.
  */
-import { test, expect } from "@playwright/test";
-
-function seedSetupComplete(page: import("@playwright/test").Page): void {
-	page.addInitScript(() => {
-		window.localStorage.setItem(
-			"alm-preferences",
-			JSON.stringify({ setupCompleted: true }),
-		);
-	});
-}
-
-/**
- * spec 010's guided first-run coach auto-activates whenever
- * `alm-preferences.setupCompleted` is true (any mount runs `activateGuidedFlow`
- * in mock mode, landing on step "inbox.confirm_first"). Its react-joyride
- * spotlight targets `[data-guide-anchor="inbox.confirm-row"]` — the SAME
- * attribute carried by BOTH the per-detection Confirm button and the top-bar
- * bulk-confirm button (InboxDetail.tsx / InboxPage.tsx). Joyride only
- * computes a cutout for the first DOM match, so the OTHER element sharing the
- * selector stays covered by the tour's (real, hit-testable) overlay backdrop —
- * `{ force: true }` alone isn't enough, since Playwright still dispatches the
- * click at the element's screen coordinates and the browser delivers it to
- * whatever is actually on top. Hide the joyride portal outright: it is
- * explicitly documented as non-modal (`blockTargetInteraction: false`,
- * GuidedOverlay.tsx) so this doesn't change the behavior under test, only
- * removes an unrelated onboarding overlay this suite isn't about.
- */
-async function disableGuidedTourOverlay(
-	page: import("@playwright/test").Page,
-): Promise<void> {
-	await page.addStyleTag({
-		content: "#react-joyride-portal { display: none !important; }",
-	});
-}
+import {
+	test,
+	expect,
+	seedSetupComplete,
+	disableGuidedTourOverlay,
+} from "./support/harness";
 
 test.describe("inbox ingest · classify / reclassify / confirm (spec 041)", () => {
 	test("cross-root aggregate list renders with reconciled per-type stats (spec 039 SC-001 / spec 041 US6 FR-021)", async ({
@@ -251,37 +225,85 @@ test.describe("inbox ingest · classify / reclassify / confirm (spec 041)", () =
 		).toBeVisible({ timeout: 5_000 });
 	});
 
-	// ── Documented mock-layer gaps (see file header) — NOT faked ────────────────
+	// ── Previously-skipped mock-layer gaps — now enabled by the enriched harness ─
 
-	test.skip(
-		"plan-approval overlay: review → apply/cancel a generated plan (US1 FR-003/FR-003a/FR-006/FR-007) — requires inbox_plan_list_open/inbox_plan_apply(_all|_selected)/inbox_plan_cancel mock cases that do not exist yet",
-		async () => {
-			// Intentionally skipped: `useOpenInboxPlans` calls `inbox_plan_list_open`,
-			// which has no case in `mockInvoke` (apps/desktop/src/api/mocks.ts) and
-			// throws "Unknown mock command"; the rejection is swallowed into hook
-			// error state, so `openPlans` is always `[]` and the top-bar
-			// "Review plans" trigger never renders in mock mode. Exercising the
-			// PlanApprovalOverlay/PlanPanel apply/cancel/staleness flow needs either
-			// the real backend (Layer-2/tauri-driver) or new mock cases — adding
-			// those mocks is a product-code change outside this additive-tests-only
-			// batch.
-		},
-	);
+	test("plan-approval overlay: review → apply one plan (live progress) → cancel another (US1 FR-003/FR-003a/FR-006/FR-007)", async ({
+		page,
+	}) => {
+		seedSetupComplete(page);
+		await page.goto("/#/inbox");
+		await disableGuidedTourOverlay(page);
+		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
 
-	test.skip(
-		"catalogue-in-place confirm is distinguishable from a move plan (US4 FR-017/FR-018/SC-007) — requires an organizationState:'organized' fixture item and an inbox_confirm mock that branches on it",
-		async () => {
-			// Intentionally skipped: every item in the `inbox_list` mock fixture is
-			// `organizationState: "unorganized"`, and the `inbox_confirm` mock
-			// returns the exact same static response `{ planId, planState:
-			// 'ready_for_review', itemsTotal: 18, registeredAsMaster: false }`
-			// regardless of the confirmed item or its source's organization state.
-			// There is currently no way, at the mock e2e layer, to observe "zero
-			// file movements + a catalogue record" (FR-018) as distinct from the
-			// move-plan path asserted above — both render an identical toast. This
-			// needs either the real backend or a smarter mock (an "organized" fixture
-			// item + branching inbox_confirm logic), which is a product-code change
-			// outside this additive-tests-only batch.
-		},
-	);
+		// The enriched `inbox_plan_list_open` mock seeds two open plans, so the
+		// top-bar "Review plans (2)" trigger now renders (was unreachable before).
+		const reviewBtn = page.getByTestId("inbox-review-plans-btn");
+		await expect(reviewBtn).toBeVisible({ timeout: 8_000 });
+		await expect(reviewBtn).toContainText("Review plans (2)");
+		await reviewBtn.click();
+
+		// The focused plan-approval overlay opens with both seeded plan groups.
+		const overlay = page.getByTestId("plan-approval-overlay");
+		await expect(overlay).toBeVisible({ timeout: 5_000 });
+		await expect(overlay.getByTestId("plan-group-item-002")).toBeVisible();
+		await expect(
+			overlay.getByTestId("plan-group-item-organized-inplace"),
+		).toBeVisible();
+		// Aggregate action count across both plans (2 + 2).
+		await expect(overlay.getByTestId("plan-total-count")).toContainText("4");
+
+		// ── Apply ONE plan with live progress. This drives `plans_apply_real`
+		//    over a real `@tauri-apps/api/core` Channel — proving the first-party
+		//    Channel polyfill lets the streamed OperationEvents reach the UI
+		//    (without it, the Channel ctor throws before any event streams). ──
+		await overlay.getByTestId("plan-apply-one-item-002").click();
+		await expect(page.getByText(/^Plan applied\.$/)).toBeVisible({
+			timeout: 5_000,
+		});
+
+		// ── Cancel the OTHER plan (FR-006). The stateful mock removes it from the
+		//    aggregate surface, so after the refresh its group is gone. ──
+		await overlay.getByTestId("plan-cancel-item-organized-inplace").click();
+		await expect(
+			page.getByText(/Plan discarded\. Item is available for re-confirmation\./i),
+		).toBeVisible({ timeout: 5_000 });
+		await expect(
+			overlay.getByTestId("plan-group-item-organized-inplace"),
+		).toHaveCount(0, { timeout: 5_000 });
+
+		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+	});
+
+	test("catalogue-in-place plan is distinguishable from a move plan in the review overlay (US4 FR-017/FR-018/SC-007)", async ({
+		page,
+	}) => {
+		seedSetupComplete(page);
+		await page.goto("/#/inbox");
+		await disableGuidedTourOverlay(page);
+		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+
+		await page.getByTestId("inbox-review-plans-btn").click();
+		const overlay = page.getByTestId("plan-approval-overlay");
+		await expect(overlay).toBeVisible({ timeout: 5_000 });
+
+		// The MOVE plan (unorganized source, seeded all-`move` actions) renders a
+		// move arrow (`.alm-plan-panel__summary-arrow`) — files relocate (FR-017) —
+		// and carries NO "In place" marker.
+		const movePlan = overlay.getByTestId("plan-group-item-002");
+		await expect(movePlan).toBeVisible();
+		await expect(movePlan.locator(".alm-plan-panel__summary-arrow")).toBeVisible();
+		await expect(movePlan.locator(".alm-plan-panel__inplace")).toHaveCount(0);
+
+		// The CATALOGUE-IN-PLACE plan (organized source, seeded all-`catalogue`
+		// actions where destination == source) is explicitly marked "In place"
+		// (`.alm-plan-panel__inplace`) — zero file movements, a catalogue record
+		// only (FR-018 / SC-007) — with NO move arrow.
+		const inPlacePlan = overlay.getByTestId("plan-group-item-organized-inplace");
+		await expect(inPlacePlan).toBeVisible();
+		await expect(inPlacePlan.locator(".alm-plan-panel__inplace")).toBeVisible();
+		await expect(inPlacePlan.getByText("In place", { exact: true })).toBeVisible();
+		await expect(inPlacePlan.locator(".alm-plan-panel__summary-arrow")).toHaveCount(0);
+
+		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+	});
 });

--- a/tests/e2e/support/harness.ts
+++ b/tests/e2e/support/harness.ts
@@ -1,0 +1,86 @@
+/**
+ * Shared Playwright mock-e2e harness (test/support only — NOT product code).
+ *
+ * Exports a drop-in `test`/`expect` pair that auto-installs a first-party
+ * Tauri `Channel` polyfill on every test's page, plus small seed helpers. This
+ * REPLACES the per-spec `addInitScript` shims (previously duplicated in
+ * `cleanup_review.spec.ts` etc.) with one global init hook.
+ *
+ * ── Channel polyfill: why it's needed, and how it aligns with `core.isTauri()`
+ *
+ * Backend-driven apply flows (`plans_apply_real`, and the inbox apply-one path)
+ * bridge live progress onto a `@tauri-apps/api/core` `Channel`. `Channel`'s
+ * constructor unconditionally calls `window.__TAURI_INTERNALS__.transformCallback`
+ * (see `@tauri-apps/api` `core.js`) — a runtime that only exists inside a real
+ * Tauri webview. Under the plain Vite dev server this Playwright suite drives,
+ * that object is absent, so the constructor throws BEFORE the mock IPC can
+ * stream any event and the apply UI shows "…apply failed".
+ *
+ * The polyfill provides ONLY the one method the `Channel` constructor needs. It
+ * deliberately does NOT set `window.isTauri`, which is the field
+ * `@tauri-apps/api`'s `core.isTauri()` actually reads
+ * (`return !!(globalThis || window).isTauri`). Spec 051 swaps the product-code
+ * `__TAURI_INTERNALS__` sniff in `apps/desktop/src/lib/window.ts` for
+ * `core.isTauri()`; because this harness leaves `window.isTauri` unset,
+ * `core.isTauri()` still correctly returns `false` in the mock env (it is not a
+ * real Tauri host), so the polyfill is orthogonal to — and does not reintroduce
+ * — any product-code environment sniff. The mock invoke layer is selected by
+ * `VITE_USE_MOCKS`, independent of both.
+ */
+
+import { test as base, expect, type Page } from "@playwright/test";
+
+/**
+ * Install the minimal `window.__TAURI_INTERNALS__.transformCallback` the
+ * `@tauri-apps/api/core` `Channel` constructor requires. Runs as an init script
+ * so it is present before any app module (or navigation) evaluates.
+ */
+export async function installTauriChannelPolyfill(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    // Preserve any pre-existing internals object; only supply the one method.
+    const w = window as unknown as {
+      __TAURI_INTERNALS__?: { transformCallback?: (cb: unknown, once?: boolean) => number };
+    };
+    let nextCallbackId = 1;
+    const existing = w.__TAURI_INTERNALS__ ?? {};
+    if (typeof existing.transformCallback !== "function") {
+      existing.transformCallback = () => nextCallbackId++;
+    }
+    w.__TAURI_INTERNALS__ = existing;
+  });
+}
+
+/** Seed first-run as complete so the app lands on real content, not the wizard. */
+export function seedSetupComplete(page: Page): void {
+  page.addInitScript(() => {
+    window.localStorage.setItem(
+      "alm-preferences",
+      JSON.stringify({ setupCompleted: true }),
+    );
+  });
+}
+
+/**
+ * Hide the spec-010 guided-tour joyride portal. It is explicitly non-modal
+ * (`blockTargetInteraction: false`), so hiding it does not change behavior under
+ * test — it only removes an unrelated onboarding overlay whose backdrop can
+ * intercept clicks aimed at elements sharing a `data-guide-anchor` selector.
+ */
+export async function disableGuidedTourOverlay(page: Page): Promise<void> {
+  await page.addStyleTag({
+    content: "#react-joyride-portal { display: none !important; }",
+  });
+}
+
+/**
+ * Drop-in replacement for `@playwright/test`'s `test`: identical, except every
+ * test's `page` has the Tauri `Channel` polyfill installed automatically.
+ */
+export const test = base.extend({
+  page: async ({ page }, use) => {
+    await installTauriChannelPolyfill(page);
+    await use(page);
+  },
+});
+
+export { expect };


### PR DESCRIPTION
## Summary

Foundational E2E-harness work (Option 1 of the mock-coverage decision): enrich the Playwright mock harness so backend-driven flows become mock-testable, lifting the cap the Phase-B batches hit. **Test-harness code only** (mocks + E2E setup) — no product behavior changes.

## What changed

**`apps/desktop/src/api/mocks.ts`** (mock IPC layer)
- Added the previously-missing inbox plan-surface commands, all pinned to the generated `@/bindings` DTO shapes: `inbox_plan_list_open` (seeds two open plans so the *Review plans* overlay is reachable), `inbox_plan`, `inbox_plan_apply` / `_all` / `_selected`, `inbox_plan_cancel` (stateful — apply/cancel mutate the aggregate surface so the overlay round-trips + auto-closes), `inbox_stats`, `inbox_item_metadata`, `inbox_property_registry`.
- `inbox_confirm` is now **arg-sensitive**: an *organized* source catalogues in place (`moveCount:0`, `organizationState:'organized'`, catalogue destinations where dest==source); an *unorganized* source produces a move plan. (`itemsTotal` kept at 18 to preserve the existing move-path assertion.)
- `lifecycle_transition_apply` is now **arg-sensitive**: plan-required edges (e.g. `completed → archived`) return `status:'error'` `code:'plan.required'`; other edges succeed. Added `archive_plan_generate`.

**`tests/e2e/support/harness.ts`** (new)
- First-party Tauri `Channel` polyfill installed **globally** via an extended Playwright `test`, replacing the per-spec `addInitScript` shims. It supplies only `__TAURI_INTERNALS__.transformCallback` (the `Channel` ctor's one need) and deliberately leaves `window.isTauri` unset — so `core.isTauri()` (the direction spec 051 moves product code toward) still returns `false` in the mock env. No product-code environment sniff is reintroduced.
- Consolidates `seedSetupComplete` / `disableGuidedTourOverlay`.

**Un-skipped** the two documented batch-1/2 skips in `inbox_ingest_confirm.spec.ts` (plan-approval overlay review → apply-one-with-live-progress → cancel; catalogue-in-place vs move distinction) and migrated `cleanup_review.spec.ts` off its per-spec Channel shim.

## Newly mockable flows
Inbox plan-approval overlay (list/apply/apply-all/apply-selected/cancel), per-file inbox metadata, inbox stats, inbox property registry, catalogue-in-place vs move confirm branch, lifecycle `plan.required` edges, and whole-project `archive_plan_generate`.

## Verification
- `pnpm --filter @astro-plan/desktop test:e2e` — **20 passed / 1 pre-existing real-backend skip**, run twice (no flake).
- `pnpm typecheck` — clean.
- `pnpm test` (vitest) — 1245 passed. `eslint` on changed source — clean.