### PR TITLE
test(e2e): project lifecycle mock-E2E coverage (batch 3)

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -75,6 +75,9 @@ import type {
   AuditFilterDto,
   AuditPaginationDto,
   PathPatternPreviewResponse,
+  ProjectNoteGetResult,
+  ProjectNoteUpdateResult,
+  ManifestListResponse_Serialize,
 } from '@/bindings/index';
 
 const delay = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
@@ -465,7 +468,22 @@ export async function mockInvoke(
 
     case 'sessions_list': {
       const { sessions } = await import('@/data/fixtures/sessions');
-      return sessions;
+      // The real `sessions.list` returns the camelCase SessionSummaryDto shape.
+      // The legacy fixture is snake_case (read by SessionsTable); the shared
+      // SessionSourcePicker reads the camelCase fields. Carry BOTH so either
+      // consumer renders in mock mode (previously the picker crashed on
+      // `session.sessionKey.target` when the Edit/wizard source step rendered).
+      return sessions.map((s) => ({
+        ...s,
+        sessionKey: {
+          target: s.session_key.target,
+          filter: s.session_key.filter,
+          night: s.session_key.night,
+        },
+        frameCount: s.frame_count,
+        totalIntegrationSeconds: s.total_integration_seconds,
+        opticalTrainId: s.optical_train_id,
+      }));
     }
     case 'sessions_get': {
       const { sessionDetail } = await import('@/data/fixtures/sessions');
@@ -590,9 +608,14 @@ export async function mockInvoke(
       return mockProjectSummaries;
     }
     case 'projects_get': {
-      // spec 008 real shape: ProjectDetailDto
-      const { mockProjectDetail008 } = await import('@/data/fixtures/projects');
-      return mockProjectDetail008;
+      // spec 008 real shape: ProjectDetailDto. Arg-sensitive so the detail's
+      // lifecycle matches the requested project (mirrors the real backend,
+      // which returns each project's actual lifecycle) — this is what lets the
+      // full lifecycle state machine (ready/prepared/completed/archived/blocked)
+      // be exercised through the UI, not just proj-001's `processing`.
+      const { mockProjectDetailFor } = await import('@/data/fixtures/projects');
+      const id = (_args as { id?: string } | undefined)?.id ?? 'proj-001';
+      return mockProjectDetailFor(id);
     }
     case 'projects_create': {
       // Return a minimal success result; tests override this via vi.mock.
@@ -627,12 +650,56 @@ export async function mockInvoke(
       } satisfies ProjectSourceAddResult_Serialize;
     }
     case 'projects_source_remove': {
-      const req = (_args as { req?: { projectId?: string; projectSourceId?: string } } | undefined)?.req;
+      const req = (_args as { req?: { projectId?: string; projectSourceId?: string; confirmLastSource?: boolean } } | undefined)?.req;
+      // FR-011 last-confirmed-source guard: the backend refuses removing the
+      // final confirmed source unless the caller re-confirms
+      // (`confirm_last_source`). The mock surfaces the exact error contract by
+      // requiring the flag on every removal, so the inline confirm guard flow
+      // in EditProjectPane is exercisable in mock mode. Real per-source-count
+      // discrimination is a Layer-2 concern (needs stateful backend fixtures).
+      if (!req?.confirmLastSource) {
+        return mockContractError(
+          'lifecycle.last_confirmed_source',
+          'Cannot remove the last confirmed source without confirmation.',
+        );
+      }
       return {
         projectId: req?.projectId ?? 'mock-id',
         removedSourceId: req?.projectSourceId ?? 'mock-src',
         auditId: 'mock-audit-id',
       } satisfies ProjectSourceRemoveResult_Serialize;
+    }
+    case 'note_get': {
+      // spec 024 `project.note.get` — persisted free-text notes body.
+      const projectId =
+        (_args as { req?: { projectId?: string } } | undefined)?.req?.projectId ?? 'proj-001';
+      return {
+        projectId,
+        content: 'SHO palette — Ha dominant. Review OIII stretch before integration.',
+      } satisfies ProjectNoteGetResult;
+    }
+    case 'note_update': {
+      // spec 024 `project.note.update` — echoes an updated timestamp on success.
+      const projectId =
+        (_args as { req?: { projectId?: string } } | undefined)?.req?.projectId ?? 'proj-001';
+      return {
+        projectId,
+        updatedAt: new Date().toISOString(),
+      } satisfies ProjectNoteUpdateResult;
+    }
+    case 'manifest_list': {
+      // spec 024 `project.manifest.list` — snapshot history. hasBody:false so
+      // the accordion renders rows without an expandable body fetch.
+      return {
+        manifests: [
+          { id: 'man-001', reason: 'created', timestamp: '2026-05-01T10:00:00Z', path: 'notes/manifest-2026-05-01.md', hasBody: false },
+          { id: 'man-002', reason: 'lifecycle_transition', timestamp: '2026-05-20T22:15:00Z', path: 'notes/manifest-2026-05-20.md', hasBody: false },
+        ],
+        nextCursor: null,
+      } satisfies ManifestListResponse_Serialize;
+    }
+    case 'manifest_reveal_in_os': {
+      return null;
     }
     case 'projects_channels_reinfer': {
       const req = (_args as { req?: { projectId?: string } } | undefined)?.req;

--- a/apps/desktop/src/data/fixtures/projects.ts
+++ b/apps/desktop/src/data/fixtures/projects.ts
@@ -316,6 +316,56 @@ export const mockProjectSummaries: ProjectSummaryDto[] = [
     createdAt: '2026-05-15T12:00:00Z',
     updatedAt: '2026-05-18T18:00:00Z',
   },
+  // Lifecycle-diverse fixtures (Journey 5 full state machine): one project per
+  // remaining lifecycle state so each state's footer transitions — including
+  // the plan-gated edges (completed → archived, ready → prepared, etc.) — can
+  // be exercised through the real UI. `projects.get` (mocks.ts →
+  // mockProjectDetailFor) resolves each to a detail carrying its lifecycle.
+  {
+    id: 'proj-004',
+    name: 'Rosette Nebula HOO',
+    tool: 'PixInsight',
+    lifecycle: 'completed',
+    path: 'projects/Rosette_HOO',
+    notes: 'Final accepted; delivered.',
+    channelDrift: false,
+    sourceCount: 3,
+    createdAt: '2026-04-01T10:00:00Z',
+    updatedAt: '2026-05-01T10:00:00Z',
+  },
+  {
+    id: 'proj-005',
+    name: 'Heart Nebula SHO',
+    tool: 'PixInsight',
+    lifecycle: 'prepared',
+    path: 'projects/Heart_SHO',
+    channelDrift: false,
+    sourceCount: 2,
+    createdAt: '2026-04-05T10:00:00Z',
+    updatedAt: '2026-05-02T10:00:00Z',
+  },
+  {
+    id: 'proj-006',
+    name: 'Veil Nebula (legacy)',
+    tool: 'PixInsight',
+    lifecycle: 'archived',
+    path: 'projects/Veil_2023',
+    channelDrift: false,
+    sourceCount: 2,
+    createdAt: '2023-04-05T10:00:00Z',
+    updatedAt: '2023-06-02T10:00:00Z',
+  },
+  {
+    id: 'proj-007',
+    name: 'Cave Nebula attempt',
+    tool: 'Siril',
+    lifecycle: 'blocked',
+    path: 'projects/Cave_attempt',
+    channelDrift: false,
+    sourceCount: 1,
+    createdAt: '2026-05-05T10:00:00Z',
+    updatedAt: '2026-05-06T10:00:00Z',
+  },
 ];
 
 export const mockProjectDetail008: ProjectDetailDto = {
@@ -358,3 +408,34 @@ export const mockProjectDetail008WithDrift: ProjectDetailDto = {
   ...mockProjectDetail008,
   channelDrift: { hasNewSources: true, suggestedAction: 're_infer' },
 };
+
+/**
+ * Resolve the `projects.get` detail for a given project id (mock mode).
+ *
+ * proj-001 keeps the canonical {@link mockProjectDetail008} body (existing
+ * specs depend on its sources/channels/cleanup wiring). Every other summary
+ * gets a detail with the SAME operational body but its own identity +
+ * lifecycle, so the UI reflects the requested project's real state. Blocked
+ * projects additionally carry a typed blocked reason (FR-020).
+ */
+export function mockProjectDetailFor(id: string): ProjectDetailDto {
+  const summary = mockProjectSummaries.find((p) => p.id === id);
+  if (!summary || id === 'proj-001') return mockProjectDetail008;
+  const base: ProjectDetailDto = {
+    ...mockProjectDetail008,
+    id: summary.id,
+    name: summary.name,
+    tool: summary.tool,
+    lifecycle: summary.lifecycle,
+    path: summary.path,
+    notes: summary.notes ?? null,
+  };
+  if (summary.lifecycle === 'blocked') {
+    return {
+      ...base,
+      blockedReasonKind: 'calibration_unmatched',
+      blockedReasonNote: 'Missing calibration masters for SII filter',
+    };
+  }
+  return base;
+}

--- a/tests/e2e/project_lifecycle_create.spec.ts
+++ b/tests/e2e/project_lifecycle_create.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * Playwright mock-mode: Journey 5 (spec 008 US1 / spec 012) — project creation
+ * wizard, happy path + validation/error path.
+ *
+ * Phase B / batch 3 of the E2E revalidation (docs/development/
+ * e2e-mock-coverage-audit-2026-07-05.md). The pre-existing lifecycle specs only
+ * covered the single processing→completed transition button; the create wizard
+ * (and its duplicate-name inline error) had ZERO mock e2e coverage.
+ *
+ * What this file proves:
+ *  1. "+ New project" opens the multi-step creation wizard (WizardPage) at
+ *     /#/projects/new — the first step is Name & profile.
+ *  2. Happy path: a unique project name walked through all six steps to the
+ *     Review step and created via `projects.create` (mock) surfaces the
+ *     folders-created success toast and returns to the projects list.
+ *  3. Validation/error path: a DUPLICATE name (matching an existing
+ *     `projects.list` entry) is caught by the live pre-check
+ *     (`findDuplicateProjectName`), routes the wizard BACK to the Name step,
+ *     and surfaces the inline `name.duplicate` field error — creation is
+ *     blocked (constitution II: no silent mutation on a bad input).
+ *  4. Empty-name gate: the Review step's Create button is disabled until the
+ *     project has a name.
+ *
+ * Mock wiring (apps/desktop/src/api/mocks.ts):
+ *   projects_list   → mockProjectSummaries (includes "NGC 7000 Narrowband").
+ *   projects_create → { projectId, lifecycle: 'setup_incomplete',
+ *                       scaffoldApplied: true, … } → folders-created toast.
+ *
+ * The wizard runs with VITE_USE_MOCKS=true, whose `devSkip` bypasses the
+ * per-step advance gates so the walk-through does not need real session/
+ * calibration selections.
+ */
+import { test, expect, seedSetupComplete, disableGuidedTourOverlay } from "./support/harness";
+
+// The six wizard "Next" labels in order (StepName → … → Review). Clicking each
+// advances one step; the final step swaps in the Create button.
+const NEXT_LABELS = [
+  "Next: sources →",
+  "Next: calibration →",
+  "Next: source views →",
+  "Next: naming →",
+  "Next: review →",
+];
+
+async function openWizard(page: import("@playwright/test").Page): Promise<void> {
+  seedSetupComplete(page);
+  await page.goto("/#/projects");
+  await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  await disableGuidedTourOverlay(page);
+  await page.getByRole("button", { name: "+ New project" }).click();
+  // Wizard toolbar title confirms we landed on /#/projects/new.
+  await expect(page.getByText(/New project —/)).toBeVisible({ timeout: 8_000 });
+}
+
+test.describe("project lifecycle · creation wizard (spec 008 US1 / Journey 5)", () => {
+  test("happy path: unique name walked through all steps creates the project", async ({
+    page,
+  }) => {
+    await openWizard(page);
+
+    // ── Step 0: Name & profile ────────────────────────────────────────────────
+    const nameInput = page.locator("#project-name");
+    await expect(nameInput).toBeVisible();
+    await nameInput.fill("Pelican Nebula HOO");
+
+    // ── Walk Name → Review (six steps, five Next clicks) ──────────────────────
+    for (const label of NEXT_LABELS) {
+      await page.getByRole("button", { name: label }).click();
+    }
+
+    // ── Review step: Create is enabled (name present) ─────────────────────────
+    const createBtn = page.getByTestId("wizard-create-btn");
+    await expect(createBtn).toBeVisible({ timeout: 5_000 });
+    await expect(createBtn).toBeEnabled();
+
+    await createBtn.click();
+
+    // ── projects.create mock returns scaffoldApplied:true → folders toast; the
+    //     wizard then navigates back to the projects list ──────────────────────
+    await expect(
+      page.getByText(/created — project folders created on disk/i),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  });
+
+  test("validation: a duplicate name is blocked and the wizard bounces back to the Name step", async ({
+    page,
+  }) => {
+    await openWizard(page);
+
+    // Use a name that already exists in projects.list (mockProjectSummaries).
+    await page.locator("#project-name").fill("NGC 7000 Narrowband");
+
+    for (const label of NEXT_LABELS) {
+      await page.getByRole("button", { name: label }).click();
+    }
+
+    // Attempt to create — the live duplicate pre-check (findDuplicateProjectName)
+    // must intercept before any projects.create call.
+    await page.getByTestId("wizard-create-btn").click();
+
+    // Observable outcome (constitution II — no silent mutation on bad input):
+    // creation is BLOCKED and the wizard routes BACK to the Name step. (The
+    // inline name.duplicate error is set but StepName's on-remount RHF reset
+    // fires its watch→onChange, which clears name/tool create-errors, so the
+    // banner is not persistently asserted here — see finding in the batch-3
+    // report.) The proofs: we are on step 1 again, the Review step's Create
+    // button is gone, and no "created" success toast fired.
+    await expect(
+      page.getByRole("heading", { name: /Step 1 · Name & profile/ }),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(page.locator("#project-name")).toHaveValue("NGC 7000 Narrowband");
+    await expect(page.getByTestId("wizard-create-btn")).toHaveCount(0);
+    await expect(page.getByText(/created — project folders created on disk/i)).toHaveCount(0);
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  });
+
+  test("empty-name gate: the Review step's Create button is disabled without a name", async ({
+    page,
+  }) => {
+    await openWizard(page);
+
+    // Do NOT type a name; devSkip lets us advance through the gated steps.
+    for (const label of NEXT_LABELS) {
+      await page.getByRole("button", { name: label }).click();
+    }
+
+    const createBtn = page.getByTestId("wizard-create-btn");
+    await expect(createBtn).toBeVisible({ timeout: 5_000 });
+    await expect(createBtn).toBeDisabled();
+  });
+});

--- a/tests/e2e/project_lifecycle_surfaces.spec.ts
+++ b/tests/e2e/project_lifecycle_surfaces.spec.ts
@@ -1,0 +1,155 @@
+/**
+ * Playwright mock-mode: Journey 5 (spec 008/011/012/024) — project detail
+ * operational surfaces: notes, manifests, outputs (honest empty stub),
+ * per-channel integration time, the tool-launch affordance, and the
+ * attach/remove-sources gating.
+ *
+ * Phase B / batch 3 of the E2E revalidation (docs/development/
+ * e2e-mock-coverage-audit-2026-07-05.md).
+ *
+ * What this file proves:
+ *  1. Notes surface (spec 024): the persisted note body (`project.note.get`)
+ *     renders; the inline editor exposes a textarea with a live byte counter
+ *     against the 16 384-byte cap.
+ *  2. Manifests surface (spec 024): `project.manifest.list` snapshots render as
+ *     rows in the Manifests accordion.
+ *  3. Outputs (spec 043 §4): an HONEST empty state — the backend exposes no
+ *     accepted-output model yet, so the section shows a teaching empty state
+ *     and NEVER fabricated rows (constitution II).
+ *  4. Per-channel integration time (spec 008 P7): the channels palette shows
+ *     each channel's server-aggregated integration hours.
+ *  5. Tool-launch affordance (spec 011): the "Open in {tool}" CTA renders and
+ *     is correctly DISABLED with a "configure path" hint when no tool profile
+ *     is configured (mock mode has none) — no fabricated launch.
+ *  6. Attach-sources (spec 041 FR-051 / spec 008 WP-008-C): the Edit pane's
+ *     "Add sources" toggle reveals the SessionSourcePicker (filtered to
+ *     sessions not already linked). Removing a source triggers the FR-011
+ *     last-confirmed-source guard: an inline confirm step before removal.
+ *
+ * Mock wiring (apps/desktop/src/api/mocks.ts):
+ *   projects_get           → mockProjectDetailFor(id) — proj-001 processing
+ *                            (2 channels: Ha 1.8h, OIII 1.3h), proj-002 ready.
+ *   note_get / note_update → persisted note body + update echo.
+ *   manifest_list          → 2 snapshot rows (created, lifecycle_transition).
+ *   tools_list             → (unhandled) → useToolProfiles degrades to no
+ *                            profile → launch CTA disabled + configure hint.
+ *   projects_source_remove → returns `lifecycle.last_confirmed_source` unless
+ *                            confirmLastSource is set, exercising the guard.
+ */
+import { test, expect, seedSetupComplete } from "./support/harness";
+
+async function selectProject(
+  page: import("@playwright/test").Page,
+  name: string,
+): Promise<void> {
+  const row = page
+    .locator(".alm-projects-table__row")
+    .filter({ hasText: name })
+    .first();
+  await expect(row).toBeVisible({ timeout: 8_000 });
+  await row.click();
+  await expect(page.getByTestId("lifecycle-actions")).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("project lifecycle · detail surfaces (Journey 5)", () => {
+  test("notes surface: persisted body renders; editor shows a byte counter", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+    await selectProject(page, "NGC 7000 Narrowband");
+
+    // Persisted note body (project.note.get) renders.
+    const notesRoot = page.locator(".alm-project-notes__root");
+    await expect(page.getByTestId("notes-body")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("notes-body")).toContainText("SHO palette");
+
+    // Open the inline editor → textarea + live byte counter against the cap.
+    await notesRoot.getByRole("button", { name: "Edit" }).click();
+    await expect(page.getByTestId("notes-textarea")).toBeVisible();
+    const counter = page.getByTestId("notes-byte-counter");
+    await expect(counter).toBeVisible();
+    await expect(counter).toContainText("16,384");
+    await expect(counter).toContainText("bytes");
+  });
+
+  test("manifests, outputs empty stub, channel integration time, and tool-launch affordance", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+    await selectProject(page, "NGC 7000 Narrowband");
+
+    // ── Manifests (project.manifest.list) render as rows ─────────────────────
+    await expect(page.getByTestId("manifests-list")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId("manifest-row-man-001")).toBeVisible();
+    await expect(page.getByTestId("manifest-row-man-002")).toBeVisible();
+
+    // ── Outputs: HONEST empty state, never fabricated rows ───────────────────
+    const outputs = page.getByTestId("project-outputs");
+    await expect(outputs).toBeVisible();
+    await expect(outputs.getByText("No accepted outputs yet")).toBeVisible();
+
+    // ── Per-channel integration time (Ha 1.8h, OIII 1.3h) ────────────────────
+    const channels = page.locator(".alm-project-detail__channels-section");
+    await expect(channels).toBeVisible();
+    await expect(channels.getByText("1.8h")).toBeVisible();
+    await expect(channels.getByText("1.3h")).toBeVisible();
+
+    // ── Tool-launch affordance: rendered but disabled (no profile configured) ─
+    const launchBtn = page.getByTestId("tool-launch-btn");
+    await expect(launchBtn).toBeVisible();
+    await expect(launchBtn).toContainText("Open in PixInsight");
+    await expect(launchBtn).toBeDisabled();
+    // Not-configured hint with a link to the tools settings pane.
+    await expect(page.getByTestId("tool-launch-footer")).toBeVisible();
+  });
+
+  test("attach sources: the Edit pane's Add-sources toggle reveals the session picker", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+    await selectProject(page, "NGC 7000 Narrowband");
+
+    // Open the project Edit pane (header Edit — the first "Edit" in the detail).
+    await page.getByRole("button", { name: "Edit" }).first().click();
+    const editPane = page.getByLabel("Edit project");
+    await expect(editPane).toBeVisible({ timeout: 5_000 });
+
+    // Current linked sources are listed.
+    await expect(editPane.getByText("NGC 7000 Ha 2024-11")).toBeVisible();
+
+    // The Add-sources toggle reveals the shared SessionSourcePicker (filtered to
+    // sessions not already linked to this project).
+    await editPane.getByRole("button", { name: "Add sources" }).click();
+    await expect(editPane.locator(".alm-source-picker")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  });
+
+  test("remove source: the last-confirmed-source guard requires an inline confirm (FR-011)", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+    // proj-002 (ready) is not source-remove-locked, so the Remove affordance is
+    // active — clicking it exercises the guard.
+    await selectProject(page, "M31 LRGB");
+
+    await page.getByRole("button", { name: "Edit" }).first().click();
+    const editPane = page.getByLabel("Edit project");
+    await expect(editPane).toBeVisible({ timeout: 5_000 });
+
+    // Click the first Remove → the mock returns lifecycle.last_confirmed_source,
+    // which the pane surfaces as an inline confirm guard rather than removing.
+    await editPane.getByRole("button", { name: "Remove" }).first().click();
+    await expect(
+      editPane.getByText("You can't remove the last confirmed source."),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // Confirming re-issues the removal with confirm_last_source=true (mock
+    // succeeds); no crash.
+    await editPane.getByRole("button", { name: "Confirm" }).click();
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  });
+});

--- a/tests/e2e/project_lifecycle_transitions_full.spec.ts
+++ b/tests/e2e/project_lifecycle_transitions_full.spec.ts
@@ -1,0 +1,175 @@
+/**
+ * Playwright mock-mode: Journey 5 (spec 008/009/017) — the FULL project
+ * lifecycle state machine, extending the single processing→completed button
+ * already covered by `lifecycle_transitions.spec.ts`.
+ *
+ * Phase B / batch 3 of the E2E revalidation (docs/development/
+ * e2e-mock-coverage-audit-2026-07-05.md).
+ *
+ * What this file proves:
+ *  1. Each lifecycle state surfaces its correct contextual footer transitions
+ *     (spec 009 US3 `lifecycleFooterActions`): ready, prepared, processing,
+ *     completed, archived, blocked. This is driven by the arg-sensitive
+ *     `projects.get` mock (mockProjectDetailFor) so the detail reflects the
+ *     selected project's actual lifecycle.
+ *  2. A non-plan-gated edge (prepared → processing) applies immediately and
+ *     surfaces the success toast (`projects_toast_transitioned`).
+ *  3. A plan-gated NON-archive edge (ready → prepared) returns `plan.required`
+ *     and surfaces the "a filesystem plan is required" info toast WITHOUT
+ *     opening the archive review overlay (that edge has no generator).
+ *  4. The full plan.required review overlay path for completed → archived
+ *     (transition → plan.required → generate archive plan → review overlay →
+ *     protection gate → approve → apply with live progress), reusing the
+ *     shared {@link PlanReviewOverlay} kit (constitution II — reviewable,
+ *     never-silent mutation; the archive lifecycle flip only happens via the
+ *     applied origin=archive plan).
+ *
+ * Mock wiring (apps/desktop/src/api/mocks.ts):
+ *   projects_list             → mockProjectSummaries (proj-001…proj-007, one
+ *                               per lifecycle state).
+ *   projects_get              → mockProjectDetailFor(id) — lifecycle per id.
+ *   lifecycle_transition_apply→ success on non-plan edges; { error.code:
+ *                               'plan.required' } on plan-gated edges
+ *                               (MOCK_PLAN_REQUIRED_EDGES).
+ *   archive_plan_generate     → { planId: 'plan-archive-mock', itemCount: 4,
+ *                               protectedItemCount: 1 }.
+ *   plans_get / plan_protection_check_cmd / plans_approve / plans_apply_real →
+ *                               the shared review→approve→apply chain (same
+ *                               fixtures the cleanup flow exercises).
+ *
+ * The Tauri `Channel` polyfill the approve-and-apply path needs is installed
+ * globally by the shared harness `test` (tests/e2e/support/harness.ts).
+ */
+import { test, expect, seedSetupComplete } from "./support/harness";
+
+async function selectProject(
+  page: import("@playwright/test").Page,
+  name: string,
+): Promise<void> {
+  const row = page
+    .locator(".alm-projects-table__row")
+    .filter({ hasText: name })
+    .first();
+  await expect(row).toBeVisible({ timeout: 8_000 });
+  await row.click();
+  await expect(page.getByTestId("lifecycle-actions")).toBeVisible({ timeout: 5_000 });
+}
+
+test.describe("project lifecycle · full state machine (Journey 5)", () => {
+  test("each state surfaces its correct contextual footer transitions", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+
+    // ready → { Prepare (plan-gated), Mark as Processing }
+    await selectProject(page, "M31 LRGB");
+    await expect(page.getByTestId("transition-btn-prepared")).toHaveText("Prepare");
+    await expect(page.getByTestId("transition-btn-processing")).toHaveText(
+      "Mark as Processing",
+    );
+
+    // prepared → { Mark as Processing, Revert to Ready (plan-gated) }
+    await selectProject(page, "Heart Nebula SHO");
+    await expect(page.getByTestId("transition-btn-processing")).toHaveText(
+      "Mark as Processing",
+    );
+    await expect(page.getByTestId("transition-btn-ready")).toHaveText("Revert to Ready");
+
+    // processing → { Mark as Completed }
+    await selectProject(page, "NGC 7000 Narrowband");
+    await expect(page.getByTestId("transition-btn-completed")).toHaveText(
+      "Mark as Completed",
+    );
+
+    // completed → { Archive (plan-gated), Re-open }
+    await selectProject(page, "Rosette Nebula HOO");
+    await expect(page.getByTestId("transition-btn-archived")).toHaveText("Archive");
+    await expect(page.getByTestId("transition-btn-processing")).toHaveText("Re-open");
+
+    // archived → { Unarchive (plan-gated), Unarchive and Resume (plan-gated) }
+    await selectProject(page, "Veil Nebula (legacy)");
+    await expect(page.getByTestId("transition-btn-ready")).toHaveText("Unarchive");
+    await expect(page.getByTestId("transition-btn-processing")).toHaveText(
+      "Unarchive and Resume",
+    );
+
+    // blocked → BlockedBanner + { Archive (blocked escape) }
+    await selectProject(page, "Cave Nebula attempt");
+    await expect(page.getByTestId("transition-btn-archived")).toHaveText(
+      "Archive (blocked escape)",
+    );
+  });
+
+  test("non-plan edge (prepared → processing) applies immediately with a success toast", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+
+    await selectProject(page, "Heart Nebula SHO");
+    await page.getByTestId("transition-btn-processing").click();
+
+    // projects_toast_transitioned → "Project processing."
+    await expect(page.getByText(/Project processing\./i)).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  });
+
+  test("plan-gated non-archive edge (ready → prepared) surfaces the plan-required info toast, no overlay", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+
+    await selectProject(page, "M31 LRGB");
+    await page.getByTestId("transition-btn-prepared").click();
+
+    await expect(
+      page.getByText(/A filesystem plan is required before this transition/i),
+    ).toBeVisible({ timeout: 5_000 });
+    // ready → prepared has no archive generator, so no review overlay opens.
+    await expect(page.getByTestId("plan-review-overlay")).toHaveCount(0);
+  });
+
+  test("completed → archived drives the full plan.required → review overlay → approve & apply path", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto("/#/projects");
+
+    await selectProject(page, "Rosette Nebula HOO");
+
+    // ── Archive (plan-gated) → plan.required info toast + archive plan created ─
+    await page.getByTestId("transition-btn-archived").click();
+
+    await expect(
+      page.getByText(/A filesystem plan is required before this transition/i),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      page.getByText(/Archive plan created with 4 items — review before anything is moved/i),
+    ).toBeVisible({ timeout: 5_000 });
+
+    // ── The shared review overlay opens with the archive title ────────────────
+    const overlay = page.getByTestId("plan-review-overlay");
+    await expect(overlay).toBeVisible({ timeout: 5_000 });
+    await expect(overlay.getByText("Review archive plan")).toBeVisible();
+    await expect(
+      overlay.getByText(/Nothing has been changed on disk/),
+    ).toBeVisible();
+    // Every proposed item is reviewable before approval (FR-003/SC-001).
+    await expect(overlay.getByTestId("plan-review-items")).toBeVisible();
+
+    // ── Spec-016 protection gate blocks approval until acknowledged ──────────
+    const approveBtn = overlay.getByTestId("plan-review-approve-apply");
+    await expect(approveBtn).toBeDisabled();
+    await overlay.getByRole("button", { name: "Acknowledge" }).click();
+    await expect(approveBtn).toBeEnabled({ timeout: 5_000 });
+
+    // ── Approve & apply → plans.approve → plans.apply, live progress ─────────
+    await approveBtn.click();
+    await expect(overlay.getByTestId("plan-review-progress")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByText("Cleanup plan applied.")).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary

Phase B / Batch 3 of the E2E revalidation: additive Playwright **mock-mode** specs for **Journey 5 (Project Lifecycle)**, on the enriched harness. No product behavior changed — only test files plus faithful mock cases modeled on the real bindings.

Ref: `docs/development/e2e-mock-coverage-audit-2026-07-05.md` (Batch 3).

## New spec files (tests/e2e)

- **`project_lifecycle_create.spec.ts`** — creation wizard: happy path (unique name → all 6 steps → `projects.create` → folders-created toast → back to list); duplicate-name **blocked** (bounces back to the Name step, no create); empty-name Create-button gate.
- **`project_lifecycle_transitions_full.spec.ts`** — full state machine footer transitions per state (ready/prepared/processing/completed/archived/blocked); non-plan edge success toast (prepared→processing); plan-gated non-archive edge info toast (ready→prepared, no overlay); and the **full `plan.required` review overlay path** for completed→archived (transition → generate archive plan → shared `PlanReviewOverlay` → spec-016 protection gate → approve → apply with live progress).
- **`project_lifecycle_surfaces.spec.ts`** — notes body + inline editor byte counter; manifests list; **honest** Outputs empty stub (no fabricated rows); per-channel integration time; tool-launch affordance (disabled + configure hint when unconfigured); attach-sources picker via Edit pane; FR-011 last-confirmed-source removal guard.

All assert rendered UI + i18n, respect the `archive|trash` vocabulary and page-layout conventions.

## Faithful mock additions (apps/desktop/src/api/mocks.ts + fixtures/projects.ts)

- `projects.get` is now **arg-sensitive** (`mockProjectDetailFor`) so each project's detail carries its real lifecycle; added one summary per remaining lifecycle state (completed/prepared/archived/blocked). proj-001's canonical detail is unchanged.
- Added `note.get` / `note.update`, `manifest.list`, `manifest.reveal_in_os`.
- `projects.source_remove` returns `lifecycle.last_confirmed_source` unless `confirmLastSource` is set (exercises the guard UI).
- `sessions.list` now also carries the camelCase `SessionSummaryDto` fields the shared `SessionSourcePicker` reads — it previously **crashed** in mock mode on `session.sessionKey.target`.

## Verification

- `pnpm --filter @astro-plan/desktop test:e2e` — **31 passed, 1 skipped**, run twice.
- `pnpm --filter @astro-plan/desktop typecheck` — clean.
- Projects + api vitest — 253 passed.

## Findings / follow-ups

- **Wizard duplicate-name inline error is not persistent:** creation is correctly blocked and the wizard returns to the Name step, but `StepName`'s on-remount RHF `reset` fires its `watch→onChange`, which clears the name/tool create-error — so the inline banner flashes and vanishes. The test asserts the observable block; the banner persistence looks like a real defect worth a product/UX fix.
- **Tool-launch spawn + artifact watcher** and **stateful per-source-count** last-source discrimination remain **Layer-2** (need a real process/filesystem/backend), as flagged in the audit.