### PR TITLE
test: add real end-to-end Calibration masters journeys

### DIFF
--- a/apps/desktop/src/features/calibration/MastersTable.tsx
+++ b/apps/desktop/src/features/calibration/MastersTable.tsx
@@ -330,6 +330,7 @@ export function MastersTable({
     const isAging = master.ageDays > agingThresholdDays;
     const kindStr = master.kind.toLowerCase();
     return {
+      _testid: `master-row-${master.id}`,
       _rowClassName:
         'alm-calib-table__row' + (selected === master.id ? ' alm-calib-table__row--selected' : ''),
       _onClick: () => onSelect(master.id),

--- a/crates/e2e-tests/tests/calibration_ui_journeys.rs
+++ b/crates/e2e-tests/tests/calibration_ui_journeys.rs
@@ -1,0 +1,233 @@
+//! Spec 037 Layer-2 real-UI journeys — Calibration masters (batch #3 of the
+//! coverage-matrix "Batched plan", Journey 8): masters-ingest-as-individual-
+//! items and the Calibration page's kind-conditional master detail, promoted
+//! from `docs/development/windows-journeys/journey-08-calibration-masters-matching.md`.
+//!
+//! Spec 040 (calibration master detection) shipped without a `plan.md`/
+//! `tasks.md` (a documented deviation) and had the least automated scrutiny
+//! of any recently-shipped backend feature before this file.
+//!
+//! ## Documented, real gap found while authoring this file (NOT fixed here)
+//!
+//! Journey-08's Tests 3-5 (ranked-candidate matching view, assign/cancel,
+//! offset-tolerance affecting live matching) describe a
+//! `MatchCandidatesPanel` (`apps/desktop/src/features/calibration/
+//! MatchCandidatesPanel.tsx`) UI. That component is fully implemented and
+//! unit-tested (`MatchCandidatesPanel.test.tsx`, jsdom) but **no page mounts
+//! it** — `git grep MatchCandidatesPanel apps/desktop/src` outside its own
+//! test finds no importer, and `CalibrationPage.tsx` (read in full while
+//! authoring this file) renders only `MastersTable` + `MasterDetail`, never
+//! the match panel. `CalibrationMatchPanel.tsx` (`features/projects/`, a
+//! DIFFERENT, read-only component wired into the project detail page) even
+//! says in its own doc comment "assignment is done from the Calibration page
+//! (CalibrationPage + MasterDetail)" — that wiring does not exist in the
+//! code as of this writing. This is a real product gap, not a test gap: the
+//! matching/assign UI is unreachable from the real app today, so it cannot
+//! be promoted to a Layer-2 UI journey without a product wiring fix first.
+//! Flagged in the coverage matrix rather than faked here.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{write_minimal_fits, E2eApp};
+use serde_json::json;
+
+const UI_TIMEOUT: Duration = Duration::from_secs(20);
+
+async fn register_calibration_root(app: &E2eApp) -> anyhow::Result<(tempfile::TempDir, String)> {
+    let root_dir = tempfile::tempdir()?;
+    let register: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({
+                "path": root_dir.path().to_string_lossy(),
+                "category": "calibration",
+                "scanSettings": null,
+            }),
+        )
+        .await?;
+    let root_id = register["sourceId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("roots.register returned no sourceId: {register}"))?
+        .to_owned();
+    let _: serde_json::Value = app
+        .invoke(
+            "sources_set_organization_state",
+            json!({ "sourceId": root_id, "organizationState": "unorganized" }),
+        )
+        .await?;
+    Ok((root_dir, root_id))
+}
+
+/// Test 1 (journey-08): a folder with a master dark AND a master bias — real
+/// WBPP-style `IMAGETYP = "Master Dark"` / `"Master Bias"` headers, detected
+/// by the real `PixInsightDetector`
+/// (`crates/calibration/master-detect/src/pixinsight.rs`) — materializes as
+/// TWO individual real Inbox items, never one ambiguous folder aggregate.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    let (root_dir, _root_id) = register_calibration_root(&app).await?;
+    write_minimal_fits(
+        root_dir.path(),
+        "master_dark_001.fits",
+        "Master Dark",
+        None,
+        None,
+        Some("2026-01-05T12:00:00"),
+    )?;
+    write_minimal_fits(
+        root_dir.path(),
+        "master_bias_001.fits",
+        "Master Bias",
+        None,
+        None,
+        Some("2026-01-05T12:00:00"),
+    )?;
+
+    app.goto_route("/inbox").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.click_by_aria_label("Rescan all roots").await?;
+    app.wait_testid_prefix_present("inbox-item-", UI_TIMEOUT).await?;
+
+    let rows = app.find_all_testid_prefix("inbox-item-").await?;
+    anyhow::ensure!(
+        rows.len() >= 2,
+        "expected the master dark + master bias to appear as 2 individual real \
+         Inbox items (not one folder aggregate), found {}",
+        rows.len()
+    );
+    let mut saw_master_label = 0usize;
+    for row in &rows {
+        let text = row.text().await.unwrap_or_default().to_lowercase();
+        if text.contains("master") {
+            saw_master_label += 1;
+        }
+    }
+    anyhow::ensure!(
+        saw_master_label >= 2,
+        "expected each master item's row to carry a real 'N master' label \
+         (`inbox_master_row_label`), got {saw_master_label} of {} rows",
+        rows.len()
+    );
+
+    app.shutdown().await
+}
+
+/// Test 2 (journey-08): confirming + applying a master bias item via the real
+/// Inbox UI registers it as a real `CalibrationMaster` row on the real
+/// Calibration page (`master-row-<id>` — added as a thin, additive test hook
+/// on `MastersTable.tsx`, mirroring the existing `inbox-item-<id>` row-testid
+/// convention already used by `InboxList.tsx`), and the kind-conditional
+/// Temperature property (only meaningful when `fingerprint.tempC` is present)
+/// is genuinely OMITTED from the master's detail — not a fabricated number —
+/// because this fixture carries no temperature header.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn calibration_ui_confirmed_master_shows_kind_conditional_detail() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    let (root_dir, _root_id) = register_calibration_root(&app).await?;
+    write_minimal_fits(
+        root_dir.path(),
+        "master_bias_002.fits",
+        "Master Bias",
+        None,
+        None,
+        Some("2026-01-06T12:00:00"),
+    )?;
+
+    app.goto_route("/inbox").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.click_by_aria_label("Rescan all roots").await?;
+    let item_id = app.testid_suffix("inbox-item-").await?;
+    app.click_testid(&format!("inbox-item-{item_id}")).await?;
+    app.wait_testid_enabled("inbox-confirm-btn", UI_TIMEOUT).await.map_err(|e| {
+        anyhow::anyhow!(
+            "expected the single master-bias item to classify single_type and enable Confirm: {e}"
+        )
+    })?;
+    app.click_testid("inbox-confirm-btn").await?;
+
+    app.wait_testid("inbox-review-plans-btn", UI_TIMEOUT).await?;
+    app.click_testid("inbox-review-plans-btn").await?;
+    app.wait_testid("plan-panel", UI_TIMEOUT).await?;
+    app.click_testid("plan-apply-all").await?;
+
+    // Real backend read: confirm the master really registered
+    // (`calibration.masters.list`), and use its real id to find the real DOM
+    // row on the Calibration page below — never a fixture id.
+    let masters: serde_json::Value = app
+        .invoke_until("calibration_masters_list", json!({}), UI_TIMEOUT, |v: &serde_json::Value| {
+            v.as_array().is_some_and(|a| !a.is_empty())
+        })
+        .await?;
+    let master = masters
+        .as_array()
+        .and_then(|a| {
+            a.iter().find(|m| m["kind"].as_str().unwrap_or_default().eq_ignore_ascii_case("bias"))
+        })
+        .ok_or_else(|| {
+            anyhow::anyhow!("expected a real bias master in calibration.masters.list: {masters}")
+        })?;
+    let master_id = master["id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("master has no id: {master}"))?
+        .to_owned();
+
+    app.goto_route("/calibration").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.wait_testid(&format!("master-row-{master_id}"), UI_TIMEOUT).await.map_err(|e| {
+        anyhow::anyhow!(
+            "expected the real master {master_id} as its own row on the Calibration page: {e}"
+        )
+    })?;
+
+    // Select it: `MasterDetail` mounts in the right-side detail pane.
+    app.click_testid(&format!("master-row-{master_id}")).await?;
+
+    // Wait for the detail pane to actually render (the "Kind" property is
+    // ALWAYS present, unconditionally) before asserting anything is absent —
+    // otherwise a not-yet-rendered pane would trivially "pass" the absence
+    // check below.
+    let deadline = tokio::time::Instant::now() + UI_TIMEOUT;
+    loop {
+        if page_contains_text(&app, "Kind").await? {
+            break;
+        }
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "MasterDetail never rendered its 'Kind' property within {UI_TIMEOUT:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    // Now assert the kind-conditional Temperature row is genuinely absent
+    // (fp.tempC is null for this fixture — `MasterDetail.tsx` omits the whole
+    // property row rather than rendering a fabricated dash/number).
+    anyhow::ensure!(
+        !page_contains_text(&app, "Temperature").await?,
+        "expected the Temperature property row to be omitted (not a dash) for a master with no tempC"
+    );
+
+    app.shutdown().await
+}
+
+/// `true` if any element on the current page contains the exact text
+/// `needle` — a coarse but real DOM check for a property LABEL that should
+/// be conditionally absent (`MasterDetail.tsx` omits the whole `PropertyDef`
+/// entry rather than rendering a dash when `fp.tempC` is null).
+async fn page_contains_text(app: &E2eApp, needle: &str) -> anyhow::Result<bool> {
+    use thirtyfour::error::WebDriverErrorInner;
+    let xpath = format!("//*[text()[contains(., '{needle}')]]");
+    match app.driver.find(thirtyfour::By::XPath(&xpath)).await {
+        Ok(_) => Ok(true),
+        Err(e) if matches!(e.as_inner(), WebDriverErrorInner::NoSuchElement(_)) => Ok(false),
+        Err(e) => Err(e.into()),
+    }
+}

--- a/crates/e2e-tests/tests/calibration_ui_journeys.rs
+++ b/crates/e2e-tests/tests/calibration_ui_journeys.rs
@@ -75,6 +75,50 @@ async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
     app.complete_first_run_gate().await
 }
 
+/// Seed the FIRST scan of `root_id` through the invoke bridge — mirrors
+/// `inbox_ui_journeys.rs`'s `seed_initial_scan` (same root cause it
+/// documents, CI run 28766017315): the Inbox page's "Rescan all roots"
+/// button derives the set of roots it scans from the CURRENT item list
+/// (`InboxPage.tsx`'s `roots` `useMemo`, deduped by `item.rootId`), and
+/// `useInboxRescan` (`store.ts`) is a real no-op — it never calls
+/// `inbox.scan.folder` — whenever that derived list is empty:
+/// `if (roots.length === 0) { onComplete(); return; }`. A calibration root
+/// registered via `roots_register` has never been scanned, so the item list
+/// is empty on first mount, "Rescan all roots" derives zero roots to ping,
+/// and no `inbox-item-*` row can EVER appear no matter how long a journey
+/// waits — this is what made both journeys below rely on a real button click
+/// that could never do the one thing the assertion needs. One bridge-side
+/// `inbox.scan.folder` (mirroring the first-run wizard's own scan step, which
+/// WebDriver can't drive because it needs the native folder picker) seeds the
+/// list so the real Rescan click that follows exercises a root the page
+/// actually knows about, exactly like `inbox_ui_journeys.rs` already does.
+async fn seed_initial_scan(
+    app: &E2eApp,
+    root_id: &str,
+    root_dir: &std::path::Path,
+) -> anyhow::Result<()> {
+    let scan: serde_json::Value = app
+        .invoke(
+            "inbox_scan_folder",
+            json!({
+                "req": {
+                    "rootId": root_id,
+                    "rootAbsolutePath": root_dir.to_string_lossy(),
+                    "followSymlinks": false,
+                }
+            }),
+        )
+        .await?;
+    let items = scan["items"]
+        .as_array()
+        .ok_or_else(|| anyhow::anyhow!("inbox.scan.folder returned no items array: {scan}"))?;
+    anyhow::ensure!(
+        !items.is_empty(),
+        "expected the seed inbox.scan.folder to discover the fixture master file(s): {scan}"
+    );
+    Ok(())
+}
+
 async fn register_calibration_root(app: &E2eApp) -> anyhow::Result<(tempfile::TempDir, String)> {
     let root_dir = tempfile::tempdir()?;
     let register: serde_json::Value = app
@@ -112,7 +156,7 @@ async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<(
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
     settle_first_run_redirect(&app).await?;
 
-    let (root_dir, _root_id) = register_calibration_root(&app).await?;
+    let (root_dir, root_id) = register_calibration_root(&app).await?;
     complete_first_run(&app).await?;
     write_minimal_fits(
         root_dir.path(),
@@ -130,11 +174,23 @@ async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<(
         None,
         Some("2026-01-05T12:00:00"),
     )?;
+    seed_initial_scan(&app, &root_id, root_dir.path()).await?;
 
     app.goto_route("/inbox").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
     app.click_by_aria_label("Rescan all roots").await?;
-    app.wait_testid_prefix_present("inbox-item-", UI_TIMEOUT).await?;
+    if let Err(e) = app.wait_testid_prefix_present("inbox-item-", UI_TIMEOUT).await {
+        let backend_items: serde_json::Value = app
+            .invoke("inbox_list", json!({}))
+            .await
+            .unwrap_or_else(|err| json!({ "invoke_error": err.to_string() }));
+        let ui_diagnostics = app.dump_ui_diagnostics().await;
+        let console_log = app.dump_console_log().await;
+        anyhow::bail!(
+            "{e} (backend inbox.list={backend_items}, ui_diagnostics={ui_diagnostics}, \
+             console_log={console_log})"
+        );
+    }
 
     let rows = app.find_all_testid_prefix("inbox-item-").await?;
     anyhow::ensure!(
@@ -175,7 +231,7 @@ async fn calibration_ui_confirmed_master_shows_kind_conditional_detail() -> anyh
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
     settle_first_run_redirect(&app).await?;
 
-    let (root_dir, _root_id) = register_calibration_root(&app).await?;
+    let (root_dir, root_id) = register_calibration_root(&app).await?;
     complete_first_run(&app).await?;
     write_minimal_fits(
         root_dir.path(),
@@ -185,10 +241,23 @@ async fn calibration_ui_confirmed_master_shows_kind_conditional_detail() -> anyh
         None,
         Some("2026-01-06T12:00:00"),
     )?;
+    seed_initial_scan(&app, &root_id, root_dir.path()).await?;
 
     app.goto_route("/inbox").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
     app.click_by_aria_label("Rescan all roots").await?;
+    if let Err(e) = app.wait_testid_prefix_present("inbox-item-", UI_TIMEOUT).await {
+        let backend_items: serde_json::Value = app
+            .invoke("inbox_list", json!({}))
+            .await
+            .unwrap_or_else(|err| json!({ "invoke_error": err.to_string() }));
+        let ui_diagnostics = app.dump_ui_diagnostics().await;
+        let console_log = app.dump_console_log().await;
+        anyhow::bail!(
+            "{e} (backend inbox.list={backend_items}, ui_diagnostics={ui_diagnostics}, \
+             console_log={console_log})"
+        );
+    }
     let item_id = app.testid_suffix("inbox-item-").await?;
     app.click_testid(&format!("inbox-item-{item_id}")).await?;
     app.wait_testid_enabled("inbox-confirm-btn", UI_TIMEOUT).await.map_err(|e| {

--- a/crates/e2e-tests/tests/calibration_ui_journeys.rs
+++ b/crates/e2e-tests/tests/calibration_ui_journeys.rs
@@ -35,6 +35,46 @@ use serde_json::json;
 
 const UI_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Wait for the index route's async first-run redirect to land on `/setup`
+/// BEFORE navigating anywhere (mirrors `inbox_ui_journeys.rs`'s
+/// `settle_first_run_redirect`). A fresh DB (the harness resets it every
+/// launch) makes `checkFirstRunComplete` redirect `/` → `/setup` from an
+/// async `beforeLoad`; if a journey `goto_route`s while that redirect is
+/// still pending, the late-resolving redirect can yank the app off the
+/// target route.
+async fn settle_first_run_redirect(app: &E2eApp) -> anyhow::Result<()> {
+    app.wait_url_contains("/setup", Duration::from_secs(15))
+        .await
+        .map(drop)
+        .map_err(|e| anyhow::anyhow!("expected a fresh DB to redirect to /setup: {e}"))
+}
+
+/// Registers a disposable `light_frames` root and a disposable `project`
+/// root: `firstrun.complete` (which [`E2eApp::complete_first_run_gate`]
+/// issues) specifically requires one of EACH of those two categories — a
+/// `calibration` root (this file's actual test subject) does not satisfy
+/// either precondition (`crates/persistence/db/src/repositories/first_run.rs`).
+/// Every journey below registers this pair alongside its calibration root so
+/// `goto_route` to a Shell-wrapped page (`/inbox`, `/calibration`) doesn't get
+/// bounced back to `/setup` by `Shell.tsx`'s client-side `setupCompleted` gate.
+async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
+    let raw_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": raw_dir.path().to_string_lossy(), "category": "light_frames", "scanSettings": null }),
+        )
+        .await?;
+    let project_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": project_dir.path().to_string_lossy(), "category": "project", "scanSettings": null }),
+        )
+        .await?;
+    app.complete_first_run_gate().await
+}
+
 async fn register_calibration_root(app: &E2eApp) -> anyhow::Result<(tempfile::TempDir, String)> {
     let root_dir = tempfile::tempdir()?;
     let register: serde_json::Value = app
@@ -70,8 +110,10 @@ async fn register_calibration_root(app: &E2eApp) -> anyhow::Result<(tempfile::Te
 async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    settle_first_run_redirect(&app).await?;
 
     let (root_dir, _root_id) = register_calibration_root(&app).await?;
+    complete_first_run(&app).await?;
     write_minimal_fits(
         root_dir.path(),
         "master_dark_001.fits",
@@ -131,8 +173,10 @@ async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<(
 async fn calibration_ui_confirmed_master_shows_kind_conditional_detail() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    settle_first_run_redirect(&app).await?;
 
     let (root_dir, _root_id) = register_calibration_root(&app).await?;
+    complete_first_run(&app).await?;
     write_minimal_fits(
         root_dir.path(),
         "master_bias_002.fits",

--- a/crates/e2e-tests/tests/calibration_ui_journeys.rs
+++ b/crates/e2e-tests/tests/calibration_ui_journeys.rs
@@ -157,7 +157,6 @@ async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<(
     settle_first_run_redirect(&app).await?;
 
     let (root_dir, root_id) = register_calibration_root(&app).await?;
-    complete_first_run(&app).await?;
     write_minimal_fits(
         root_dir.path(),
         "master_dark_001.fits",
@@ -174,7 +173,20 @@ async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<(
         None,
         Some("2026-01-05T12:00:00"),
     )?;
+    // Seed BEFORE `complete_first_run` — mirrors `inbox_ui_journeys.rs`'s
+    // ordering exactly. `complete_first_run` -> `complete_first_run_gate`
+    // does a real `driver.refresh()` (full page reload) to make the
+    // `setupCompleted` localStorage write visible to the cached preferences
+    // module. Calling the bridge-side seed invoke AFTER that refresh (as an
+    // earlier revision of this file did) races the reload: CI run
+    // 28808954263 (ubuntu-latest) hit `__ALM_E2E__ bridge missing` on the
+    // seed invoke, then a JS execution error on retry — a classic
+    // WebDriver-vs-navigation race, not a build flake (12/14 other bridge-
+    // using tests in the same job/build passed). Seeding first keeps the
+    // invoke on the ORIGINAL page load, well after the initial
+    // `wait_bridge_ready`, with no refresh in between.
     seed_initial_scan(&app, &root_id, root_dir.path()).await?;
+    complete_first_run(&app).await?;
 
     app.goto_route("/inbox").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
@@ -232,7 +244,6 @@ async fn calibration_ui_confirmed_master_shows_kind_conditional_detail() -> anyh
     settle_first_run_redirect(&app).await?;
 
     let (root_dir, root_id) = register_calibration_root(&app).await?;
-    complete_first_run(&app).await?;
     write_minimal_fits(
         root_dir.path(),
         "master_bias_002.fits",
@@ -241,7 +252,12 @@ async fn calibration_ui_confirmed_master_shows_kind_conditional_detail() -> anyh
         None,
         Some("2026-01-06T12:00:00"),
     )?;
+    // Seed BEFORE `complete_first_run` — see the matching comment in
+    // `calibration_ui_masters_ingest_as_individual_items` for why: the
+    // gate's internal `driver.refresh()` must not land between the initial
+    // `wait_bridge_ready` and this invoke.
     seed_initial_scan(&app, &root_id, root_dir.path()).await?;
+    complete_first_run(&app).await?;
 
     app.goto_route("/inbox").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -228,7 +228,7 @@ everything neither automated layer reaches.
 | 5 Project lifecycle | ✅ | 🟡 transition + ledger only, no UI | 🟡 transition button only (pill-refresh `test.skip`) | `windows-journeys/journey-05-project-lifecycle.md` |
 | 6 Cleanup scan→review→apply | ✅ | ✅ `cleanup_plan_review` now applies past `approved` via `plans.apply.direct` + asserts the real FS move + audit (2026-07-05) | ❌ none | `windows-journeys/journey-06-cleanup-scan-apply.md` |
 | 7 Archive → delete | ✅ (backend only) | ✅ `archive_lifecycle_apply_trash_permanent_delete` (`archive_journeys.rs`, NEW 2026-07-05): real apply + `archive.list` + `archive.send_to_trash`/`archive.permanently_delete` metadata + `blockPermanentDelete` gate | ❌ none | `windows-journeys/journey-07-archive-delete.md` |
-| 8 Calibration masters → matching | ✅ | 🟡 `calibration.match.suggest` shape only | ❌ none | `windows-journeys/journey-08-calibration-masters-matching.md` |
+| 8 Calibration masters → matching | ✅ | 🟡 real-UI (`calibration_ui_journeys.rs`): masters ingest as individual items + kind-conditional detail (Tests 1/2). Matching/assign UI (Tests 3-5) found UNREACHABLE from the real app during this pass — see finding below, not automatable until fixed | ❌ none | `windows-journeys/journey-08-calibration-masters-matching.md` |
 | 9 Targets & planning | ✅ (backend only) | ❌ **none at all** | ❌ **none at all** | `windows-journeys/journey-09-targets-planning.md` |
 | 10 Settings/appearance/i18n | ✅ | 🟡 route-load smoke only | ❌ none | `windows-journeys/journey-10-settings-appearance-i18n.md` |
 
@@ -314,9 +314,24 @@ just test the mock, not the product:
    `plans.apply.direct` and asserts the real filesystem mutation + audit
    record.
 3. **Calibration masters ingest → Calibration page → matching → assign**
-   (Journey 8, spec 040) — real UI-level masters flow beyond today's
-   `calibration.match.suggest`-only proof; spec 040 has the least automated
-   scrutiny of any recently-shipped backend feature.
+   (Journey 8, spec 040) — DONE for the reachable half (2026-07-05,
+   `crates/e2e-tests/tests/calibration_ui_journeys.rs`): masters ingest as
+   individual real Inbox items (not a folder aggregate) and confirmed
+   masters appear as their own real Calibration-page row with genuinely
+   kind-conditional detail (a property is OMITTED, not dash-faked, when its
+   fingerprint field is null). Added a thin, additive `master-row-<id>`
+   test-hook to `MastersTable.tsx` (mirrors `InboxList`'s existing
+   `inbox-item-<id>` convention) since no per-row testid existed.
+   **FINDING (real product gap, not fixed here)**: the matching/assign UI
+   (Tests 3-5 — ranked candidates, assign/cancel, offset-tolerance) is
+   `MatchCandidatesPanel.tsx`, fully implemented and unit-tested, but **no
+   page mounts it** — `CalibrationPage.tsx` renders only `MastersTable` +
+   `MasterDetail`. `CalibrationMatchPanel.tsx` (a different, read-only
+   component on the project detail page) says in its own doc comment
+   "assignment is done from the Calibration page (CalibrationPage +
+   MasterDetail)", which is not true of the code as of this writing. This
+   makes Tests 3-5 unreachable from the real app and therefore
+   un-automatable at Layer 2 until product wiring lands.
 4. **Source-view generation** (spec 049) — generate/regenerate a
    WBPP-profile source view and assert real symlinks/junctions exist on
    disk with the correct per-tool layout; real OS-specific filesystem


### PR DESCRIPTION
## Summary
- Adds automated end-to-end tests that drive the real Calibration/Inbox screens for the calibration-master workflow, closing part of a gap where this area (shipped without its own plan/tasks doc) had the least automated scrutiny of any recently-shipped feature.
- Covers: dropping several calibration master files (dark/bias) in one folder shows up as separate, individually-labelled entries rather than one ambiguous folder row; confirming and applying a master file registers it as its own row on the Calibration page, and its detail view correctly omits fields that don't apply to that master's kind instead of showing fabricated values.
- Adds a small, additive test identifier to the Calibration masters table row (no behavior change) so tests can reliably find a specific master's row.

**Real gap found while writing these tests (not fixed here, flagged for follow-up):** the ranked-candidate matching/assign screen exists in the code and has its own unit tests, but no page in the app currently shows it — it's unreachable by a real user today. This is called out in the spec's coverage tracking doc.

## Test plan
- [x] `cargo test -p e2e_tests --no-run` (compile-only; these tests only run in CI's dedicated end-to-end workflow, which needs a real app window)
- [x] `cargo clippy -p e2e_tests --tests --all-targets -- -D warnings`
- [x] `cargo fmt -p e2e_tests -- --check`
- [x] `pnpm vitest run` on the touched Calibration table test files (still passing)
- [x] `pnpm eslint` on the touched frontend file (no new warnings/errors)
- [ ] CI end-to-end workflow (3-OS matrix) runs the new tests for real

Note: this branch re-rooted from `origin/main` before the sibling Inbox-journeys PR (#457) merged, so it carries an identical copy of that PR's additive test-helper changes to `crates/e2e-tests/tests/common/mod.rs`. Whichever of the two merges second should see a no-op diff for that file.

## Spec Context
- Spec: 037
- Branch: 037-ui-journeys-calibration