### PR TITLE
fix: wizard duplicate-name banner persistence + SessionSourcePicker undefined-target guard

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -548,6 +548,7 @@
   "projects_wizard_summary_lights_label": "Lights",
   "projects_wizard_summary_selected": "Selected",
   "projects_wizard_summary_title": "Project summary",
+  "projects_wizard_target_unresolved": "Unresolved target",
   "projects_wizard_token_example_title": "Example: {example}",
   "projects_wizard_toolbar_title": "New project —",
   "projects_wizard_total_integration": "Total integration:",

--- a/apps/desktop/src/app/StatusBar.tsx
+++ b/apps/desktop/src/app/StatusBar.tsx
@@ -24,8 +24,9 @@ function formatCount(n: number): string {
  * The global totals come from `useStatusSummary()` → `commands.statusSummary()`
  * (the real `LibraryStats` DTO: sessions / projects / calibration sets /
  * targets). There is no library-wide image/file count in the contract yet (the
- * Advanced settings "Records" line is hardcoded), so the image total is a STUB
- * placeholder until the metadata-ingest pipeline exposes one.
+ * Advanced settings "Records" line is hardcoded); rather than show a fabricated
+ * or dev-status-leaking placeholder (fix ef364dfc), the image total is simply
+ * omitted from this bar until the metadata-ingest pipeline exposes a real count.
  */
 export function StatusBar() {
   const { toggle } = useLogPanel();
@@ -61,8 +62,9 @@ export function StatusBar() {
 
       {/* CENTER — GLOBAL library inventory (stable across routes, task #87).
           Sessions / projects / calibration masters / targets are real totals
-          from the status_summary contract. Images is a STUB until a library-wide
-          file count lands in the metadata pipeline. */}
+          from the status_summary contract. No images/file total is shown here —
+          there is no library-wide count in the contract yet, and a fabricated
+          or dev-status placeholder was deliberately removed (fix ef364dfc). */}
       <div className="alm-statusbar__lib" data-testid="statusbar-library-stats">
         <span title={m.status_sessions_title()}>
           {formatCount(status.sessionCount)} {m.status_sessions_label()}

--- a/apps/desktop/src/features/projects/SessionSourcePicker.test.tsx
+++ b/apps/desktop/src/features/projects/SessionSourcePicker.test.tsx
@@ -134,4 +134,43 @@ describe('SessionSourcePicker', () => {
       expect(screen.getByText('All sessions are already linked to this project.')).toBeInTheDocument();
     });
   });
+
+  it('renders a fallback instead of crashing when sessionKey.target is undefined', async () => {
+    mockSessionsList.mockResolvedValue({
+      status: 'ok',
+      data: [
+        session({
+          id: 'sess-unresolved',
+          // The contract types `target` as `string`, but a session whose
+          // target never resolved can still reach the UI with it missing —
+          // exercise that runtime shape directly, not just the type.
+          sessionKey: {
+            target: undefined as unknown as string,
+            filter: 'Ha',
+            binning: '1',
+            gain: '100',
+            night: '2026-06-01',
+          },
+        }),
+      ],
+    });
+
+    expect(() => renderPicker()).not.toThrow();
+
+    await waitFor(() => {
+      expect(screen.getByText(/Unresolved target \/ Ha \/ 2026-06-01/)).toBeInTheDocument();
+    });
+
+    // Selecting the row and typing into the target filter must not throw
+    // either (the original crash was `undefined.toLowerCase()` in the filter
+    // predicate).
+    expect(() => {
+      fireEvent.change(screen.getByPlaceholderText(/Filter by target/i), { target: { value: 'anything' } });
+    }).not.toThrow();
+    expect(screen.queryByText(/Unresolved target \/ Ha/)).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByPlaceholderText(/Filter by target/i), { target: { value: '' } });
+    const checkbox = screen.getByRole('checkbox', { name: /Unresolved target session/i });
+    expect(() => fireEvent.click(checkbox)).not.toThrow();
+  });
 });

--- a/apps/desktop/src/features/projects/SessionSourcePicker.tsx
+++ b/apps/desktop/src/features/projects/SessionSourcePicker.tsx
@@ -65,7 +65,11 @@ export function SessionSourcePicker({
 
   const filtered = useMemo(() => {
     return sessions.filter((s) => {
-      if (filterTarget && !s.sessionKey.target.toLowerCase().includes(filterTarget.toLowerCase())) return false;
+      // sessionKey.target can be undefined for a session whose target never
+      // resolved (contract says `string`, but that's a best-effort backend
+      // guarantee — defend the UI so an unresolved session doesn't crash the
+      // whole picker, it just never matches a target filter).
+      if (filterTarget && !(s.sessionKey.target ?? '').toLowerCase().includes(filterTarget.toLowerCase())) return false;
       if (filterFilter && !s.sessionKey.filter.toLowerCase().includes(filterFilter.toLowerCase())) return false;
       return true;
     });
@@ -153,32 +157,39 @@ export function SessionSourcePicker({
         </div>
 
         {/* Rows */}
-        {filtered.map((session) => (
-
-          <label
-            key={session.id}
-            className={'alm-source-picker__row' + (selectedSessionIds.includes(session.id) ? ' alm-source-picker__row--selected' : '')}
-          >
-            <Checkbox.Root
-              className="alm-checkbox"
-              checked={selectedSessionIds.includes(session.id)}
-              onCheckedChange={() => toggleSession(session.id)}
-              aria-label={m.projects_wizard_select_session_aria({ target: session.sessionKey.target })}
+        {filtered.map((session) => {
+          // Defensive fallback: a session whose target never resolved can
+          // reach the UI with `sessionKey.target` undefined even though the
+          // contract types it as `string` — render a disclosed placeholder
+          // instead of crashing (`undefined.toLowerCase()` et al) or silently
+          // showing a blank cell.
+          const targetLabel = session.sessionKey.target || m.projects_wizard_target_unresolved();
+          return (
+            <label
+              key={session.id}
+              className={'alm-source-picker__row' + (selectedSessionIds.includes(session.id) ? ' alm-source-picker__row--selected' : '')}
             >
-              <Checkbox.Indicator className="alm-checkbox__indicator">
-                &#x2713;
-              </Checkbox.Indicator>
-            </Checkbox.Root>
-            <span>
-              {session.sessionKey.target} / {session.sessionKey.filter} / {session.sessionKey.night}
-            </span>
-            <span>{session.frameCount}</span>
-            <span>{formatIntegration(session.totalIntegrationSeconds ?? 0)}</span>
-            <span className="alm-source-picker__train-id">
-              {session.opticalTrainId.slice(0, 8)}
-            </span>
-          </label>
-        ))}
+              <Checkbox.Root
+                className="alm-checkbox"
+                checked={selectedSessionIds.includes(session.id)}
+                onCheckedChange={() => toggleSession(session.id)}
+                aria-label={m.projects_wizard_select_session_aria({ target: targetLabel })}
+              >
+                <Checkbox.Indicator className="alm-checkbox__indicator">
+                  &#x2713;
+                </Checkbox.Indicator>
+              </Checkbox.Root>
+              <span>
+                {targetLabel} / {session.sessionKey.filter} / {session.sessionKey.night}
+              </span>
+              <span>{session.frameCount}</span>
+              <span>{formatIntegration(session.totalIntegrationSeconds ?? 0)}</span>
+              <span className="alm-source-picker__train-id">
+                {session.opticalTrainId.slice(0, 8)}
+              </span>
+            </label>
+          );
+        })}
 
         {filtered.length === 0 && (
           <div className="alm-source-picker__empty">

--- a/apps/desktop/src/features/projects/wizard/WizardPage.duplicateNameBanner.test.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.duplicateNameBanner.test.tsx
@@ -1,0 +1,170 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Regression test for the backlog defect: "Wizard duplicate-name error banner
+ * not persisting."
+ *
+ * Root cause: `handleCreate()` sets `createError` AND jumps `currentStep` back
+ * to 0. Because `StepName` is only mounted while `currentStep === 0`, going
+ * from step 5 (Review) back to step 0 remounts it fresh. `StepName`'s resync
+ * effect (`reset(data)`, added for "Reset wizard" support) fires react-hook-
+ * form's `watch()` subscription even though the values are unchanged from
+ * `defaultValues` — which called `onChange()` back up to `WizardPage`, which
+ * unconditionally cleared the just-set `createError` via
+ * `clearNameToolCreateError()`. The banner was set and cleared inside the same
+ * remount, so the user saw it flash (or not at all) instead of persisting.
+ *
+ * This test uses the REAL `StepName` (unlike WizardPage.test.tsx, which stubs
+ * it) so the remount/reset interaction actually reproduces the bug.
+ */
+
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn().mockReturnValue(undefined),
+}));
+
+vi.mock('@/features/projects/store', () => ({
+  callCreateProject: vi.fn(),
+}));
+
+vi.mock('@/shared/toast', () => ({
+  addToast: vi.fn(),
+}));
+
+const { mockListProjects } = vi.hoisted(() => ({ mockListProjects: vi.fn() }));
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...original,
+    commands: {
+      ...original.commands,
+      projectsList: mockListProjects,
+    },
+  };
+});
+
+// Stub every step EXCEPT StepName — the real StepName is what remounts and
+// fires the spurious reset()-driven onChange that caused the original bug.
+vi.mock('./StepSources', () => ({
+  StepSources: ({ onChange }: { onChange: (d: { selectedSessionIds: string[] }) => void }) => (
+    <div data-testid="step-sources">
+      <button onClick={() => onChange({ selectedSessionIds: ['sess-001', 'sess-002'] })}>
+        Select sessions
+      </button>
+    </div>
+  ),
+}));
+
+vi.mock('./StepCalibration', () => ({
+  StepCalibration: () => <div data-testid="step-calibration" />,
+}));
+
+vi.mock('./StepViews', () => ({
+  StepViews: () => <div data-testid="step-views" />,
+}));
+
+vi.mock('./StepLayout', () => ({
+  StepLayout: () => <div data-testid="step-layout" />,
+}));
+
+vi.mock('./StepReview', () => ({
+  StepReview: () => <div data-testid="step-review">Review your plan</div>,
+}));
+
+vi.mock('@/ui', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/ui')>();
+  return {
+    ...actual,
+    WizardShell: ({ children, summary }: { children: React.ReactNode; summary?: React.ReactNode }) => (
+      <div data-testid="wizard-shell">
+        <div data-testid="wizard-summary">{summary}</div>
+        <div data-testid="wizard-content">{children}</div>
+      </div>
+    ),
+    Btn: ({ children, onClick, disabled, 'data-testid': testid }: React.ButtonHTMLAttributes<HTMLButtonElement> & { 'data-testid'?: string }) => (
+      <button onClick={onClick} disabled={disabled} data-testid={testid}>{children}</button>
+    ),
+  };
+});
+
+import React from 'react';
+import { WizardPage } from './WizardPage';
+
+const EXISTING_PROJECT = {
+  id: 'proj-existing',
+  name: 'Existing Project',
+  tool: 'PixInsight' as const,
+  lifecycle: 'active' as const,
+  path: 'projects/existing',
+  notes: null,
+  channelDrift: false,
+  sourceCount: 0,
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  blockedReasonKind: null,
+  blockedReasonNote: null,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  localStorage.removeItem('alm-project-wizard-draft');
+  mockListProjects.mockResolvedValue({ status: 'ok', data: [EXISTING_PROJECT] });
+});
+
+async function advanceToReview(nameValue: string) {
+  const nameInput = screen.getByLabelText('Project name');
+  fireEvent.change(nameInput, { target: { value: nameValue } });
+
+  fireEvent.click(screen.getByText(/Next: sources/i));
+  await waitFor(() => expect(screen.getByTestId('step-sources')).toBeInTheDocument());
+  fireEvent.click(screen.getByText('Select sessions'));
+  await waitFor(() => expect(screen.getByTestId('step-sources')).toBeInTheDocument());
+
+  fireEvent.click(screen.getByText(/Next: calibration/i));
+  await waitFor(() => expect(screen.getByTestId('step-calibration')).toBeInTheDocument());
+  fireEvent.click(screen.getByText(/Next: source views/i));
+  await waitFor(() => expect(screen.getByTestId('step-views')).toBeInTheDocument());
+  fireEvent.click(screen.getByText(/Next: naming/i));
+  await waitFor(() => expect(screen.getByTestId('step-layout')).toBeInTheDocument());
+  fireEvent.click(screen.getByText(/Next: review/i));
+  await waitFor(() => expect(screen.getByTestId('step-review')).toBeInTheDocument());
+}
+
+describe('WizardPage duplicate-name banner persistence (backlog defect)', () => {
+  it('keeps the duplicate-name banner visible after StepName remounts on step 0, and only clears it once the name actually changes', async () => {
+    render(<WizardPage />);
+    // Same name, different case — the pre-check is case-insensitive.
+    await advanceToReview('existing project');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wizard-create-btn'));
+    });
+
+    // Routed back to step 0 with the banner visible.
+    await waitFor(() => {
+      expect(screen.getByLabelText('Project name')).toBeInTheDocument();
+      expect(screen.getByRole('alert')).toHaveTextContent(/already exists/i);
+    });
+
+    // Give any pending microtasks/effects (including StepName's remount
+    // resync effect) a chance to run — this is exactly where the bug used to
+    // clear the banner without any user action.
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    // The banner must still be visible — nothing the user did should have
+    // cleared it yet.
+    expect(screen.getByRole('alert')).toHaveTextContent(/already exists/i);
+
+    // Now the user actually edits the name to a non-colliding value — this
+    // SHOULD clear the banner.
+    const nameInput = screen.getByLabelText('Project name');
+    fireEvent.change(nameInput, { target: { value: 'A Brand New Name' } });
+
+    await waitFor(() => {
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -113,12 +113,29 @@ export function WizardPage() {
     saveDraft(wizardData);
   }, [currentStep, wizardData]);
 
-  // Clear a stale name/tool create-error once the user edits the field it was
-  // attached to (the corresponding backend rule may no longer apply). Done
-  // inline in the StepName onChange handler below rather than via an effect
-  // watching wizardData.name, so this stays a direct response to the edit.
-  function clearNameToolCreateError(): void {
-    setCreateError((prev) => (prev && (prev.field === 'name' || prev.field === 'tool') ? null : prev));
+  // Clear a stale name/tool create-error once the user actually edits the
+  // field it is attached to (the corresponding backend rule may no longer
+  // apply). `next` is compared against the wizardData snapshot captured when
+  // this error was raised — NOT just "onChange fired" — because StepName is
+  // only mounted while on step 0: routing back here after a duplicate-name
+  // rejection remounts it fresh, and its resync effect calls react-hook-form's
+  // `reset(data)` to restore the draft. That `reset()` itself notifies the
+  // same `watch()` subscription that drives this onChange, with values
+  // IDENTICAL to what's already in `wizardData` — no user action involved. An
+  // unconditional clear here nulled the just-set banner before the user ever
+  // saw it (the reported "flashes and clears" bug). Only a genuine change to
+  // the field the error is attached to should dismiss it.
+  function clearNameToolCreateError(next: StepNameData): void {
+    setCreateError((prev) => {
+      if (!prev) return prev;
+      if (prev.field === 'name') {
+        return next.name.trim() !== wizardData.name.name.trim() ? null : prev;
+      }
+      if (prev.field === 'tool') {
+        return next.workflowProfile !== wizardData.name.workflowProfile ? null : prev;
+      }
+      return prev;
+    });
   }
 
   // Step validation — devSkip bypasses all gates so you can walk through without data
@@ -411,8 +428,8 @@ export function WizardPage() {
           <StepName
             data={wizardData.name}
             onChange={(name) => {
+              clearNameToolCreateError(name);
               setWizardData({ ...wizardData, name });
-              clearNameToolCreateError();
             }}
             serverError={
               createError && (createError.field === 'name' || createError.field === 'tool')


### PR DESCRIPTION
## Summary

- **Wizard duplicate-name banner not persisting.** Root cause: `handleCreate()` in `apps/desktop/src/features/projects/wizard/WizardPage.tsx` sets the create-error banner and jumps `currentStep` back to 0. `StepName` is only mounted while on step 0, so this remounts it fresh; its resync effect calls react-hook-form's `reset(data)`, which itself fires the same `watch()` subscription that drives `onChange` — with values identical to what's already in state, no user action involved. The wizard's `onChange` handler cleared the banner unconditionally on every `onChange` call, so the just-set error was nulled inside the same remount (the reported "flashes and clears" symptom). Fixed by only clearing the `name`/`tool` create-error once the edited field's value genuinely differs from what triggered it. Regression test: `apps/desktop/src/features/projects/wizard/WizardPage.duplicateNameBanner.test.tsx` (mounts the real `StepName`, unlike `WizardPage.test.tsx` which stubs it, so the remount/reset interaction actually reproduces the bug).

- **`SessionSourcePicker` fragility on undefined `sessionKey.target`.** `apps/desktop/src/features/projects/SessionSourcePicker.tsx` called `.toLowerCase()` on `sessionKey.target` unconditionally in the target-filter predicate, and interpolated it directly into row text / aria-labels. A session whose target never resolved can reach the UI with `target` undefined even though the contract types it as `string` (there was already a comment in `api/mocks.ts` referencing this exact prior crash). Now falls back to an "Unresolved target" label (new `projects_wizard_target_unresolved` i18n key) for filtering, row display, and the checkbox aria-label instead of throwing. Regression test added to `SessionSourcePicker.test.tsx`.

- **Stub assessment (outputs list / images count):**
  - **Outputs list** (`apps/desktop/src/features/projects/OutputsCleanupSections.tsx`) — **honest stub**. Renders a teaching `EmptyState` ("No accepted outputs yet") when the backend has no accepted-output model yet; the section header explicitly documents "STUB DATA POLICY (constitution principle II — no fabricated data)" and a test locks in the empty-state behavior. No change needed.
  - **Images count** (`apps/desktop/src/app/StatusBar.tsx`) — the global images stat isn't silently faked (no "0 images" shown); it was already **completely removed from the UI** in a prior deliberate commit (`ef364dfc`, "clarify pass — strip dev-status leaks... from user-facing copy"), but the surrounding comments still claimed it rendered as a "STUB placeholder." Cleaned up the stale comments to match reality; did **not** re-add UI, since that would relitigate a recent, intentional product decision and the underlying library-wide image count still requires backend/metadata-pipeline work outside this lane's scope.
  - **#54 target-linkage** and **#58 AltitudeSparkline** — left untouched per instructions (owned by spec-051 US2 and spec 044/047 respectively).

## Test plan
- [x] `just typecheck` (frontend + contracts packages)
- [x] `pnpm --filter @astro-plan/desktop lint` (0 errors; pre-existing warning count unchanged by these files)
- [x] `pnpm --filter @astro-plan/desktop test` (full vitest suite, 131 files / 1247 tests green in isolation; two unrelated GuidedOverlay/devSurface tests are pre-existing timeout flakes under heavy concurrent load in this shared sandbox — confirmed to pass reliably when run standalone, not touched by this change)
- [x] New regression tests: `WizardPage.duplicateNameBanner.test.tsx`, plus an added case in `SessionSourcePicker.test.tsx`