### PR TITLE
test: add real end-to-end Settings journeys (auto-save, theme persistence)

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -121,6 +121,17 @@ pub struct E2eApp {
     driver_proc: Option<Child>,
 }
 
+/// How much persisted state [`E2eApp::launch_with`] wipes before spawning
+/// the app process. See [`E2eApp::launch`] vs [`E2eApp::relaunch`].
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum ResetScope {
+    /// Wipe DB + webview storage + window-state (a fresh journey).
+    Full,
+    /// Wipe DB + window-state, but keep webview storage (localStorage) —
+    /// simulates a real app restart within one journey.
+    PreserveWebviewStorage,
+}
+
 impl E2eApp {
     /// Launch a full E2E session: preflight → reset DB → spawn the
     /// `tauri-webdriver` CLI proxy → create the WebDriver session with a
@@ -155,9 +166,41 @@ impl E2eApp {
     /// The app auto-loads its frontend from the Tauri `devUrl` on launch, so
     /// no `driver.goto(...)` call is needed here (see module docs).
     pub async fn launch() -> Result<Self> {
+        Self::launch_with(ResetScope::Full).await
+    }
+
+    /// Simulate a real app restart WITHIN one journey: a fresh WebDriver
+    /// session + a fresh `desktop_shell` process, but WITHOUT wiping the
+    /// webview's persisted web storage (localStorage & co).
+    ///
+    /// [`Self::launch`] always calls `reset_webview_storage()` so that
+    /// state set by one journey (test function) can't leak into the NEXT
+    /// journey's fresh [`Self::launch`] — those are different real OS user
+    /// profiles' worth of isolation, correctly enforced. But a journey that
+    /// wants to prove something actually SURVIVES a real app relaunch (e.g.
+    /// `settings_journeys.rs`'s theme persistence test) must call this
+    /// instead of `launch()` for its second call: calling `launch()` again
+    /// wipes the very localStorage state the journey is trying to prove
+    /// persisted, which is a harness bug, not a product one (windows-only
+    /// symptom: only WebView2's `EBWebView` wipe path in
+    /// `reset_webview_storage()` actually deletes real localStorage files —
+    /// the Linux `localstorage`/`storage` paths don't match WebKitGTK's real
+    /// storage location, so the same call was already a no-op there).
+    ///
+    /// Still resets the database and window-state store (same as `launch()`)
+    /// — those are unrelated to the webview storage this exists to preserve,
+    /// and journeys that use this (see `settings_journeys.rs`) already expect
+    /// a fresh DB / first-run gate after "relaunching".
+    pub async fn relaunch() -> Result<Self> {
+        Self::launch_with(ResetScope::PreserveWebviewStorage).await
+    }
+
+    async fn launch_with(scope: ResetScope) -> Result<Self> {
         preflight()?;
         reset_database()?;
-        reset_webview_storage();
+        if matches!(scope, ResetScope::Full) {
+            reset_webview_storage();
+        }
         reset_window_state();
 
         let mut driver_proc = spawn_tauri_webdriver()

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1028,6 +1028,78 @@ impl E2eApp {
             .with_context(|| format!("is_selected() on aria-label={label:?} failed"))
     }
 
+    /// Close the app's window gracefully (round 3, fix-464-theme) before
+    /// falling through to the ordinary [`Self::shutdown`] teardown, so a
+    /// value written to `localStorage` right before this call actually
+    /// survives a following [`Self::relaunch`].
+    ///
+    /// [`Self::shutdown`]'s `driver.quit()` makes the `tauri-webdriver` CLI
+    /// force-kill the app process — the CLI's only handle on the app's
+    /// lifetime (see `blocking_session_delete`'s doc). CI evidence (run
+    /// 28808552431, then run 28810006837 even with a 1s pre-kill flush
+    /// delay) shows this reliably loses a `localStorage` write on Windows:
+    /// the raw value read back after a relaunch was `null`, not merely
+    /// stale — WebView2 commits `localStorage` to its on-disk LevelDB-backed
+    /// store on a graceful shutdown, not on a timer, so a delay before an
+    /// abrupt kill cannot save it.
+    ///
+    /// Triggers a REAL native window close — `@tauri-apps/api/window`'s
+    /// `getCurrentWindow().close()` (dynamically imported the same way
+    /// `apps/desktop/src/data/theme.ts`'s `syncNativeWindowTheme` already
+    /// does), not DOM's bare `window.close()` (a no-op for a top-level
+    /// window in most engines). This app has no `on_window_event`/
+    /// `CloseRequested` handler (`apps/desktop/src-tauri/src/lib.rs`), so
+    /// closing the only window exits the process the same way the native
+    /// Quit menu item's `app.exit(0)` does (`lib.rs`'s `on_menu_event`) —
+    /// real-user fidelity, not a synthetic teardown path.
+    ///
+    /// Polls for the `__ALM_E2E__` bridge to actually disappear (proof the
+    /// window/process tore down) rather than trusting the `close()` promise
+    /// resolved before the OS finished reaping the process, then hands off
+    /// to [`Self::shutdown`] — by then the app is normally already gone, so
+    /// that call is just cleaning up the (already-dead) CLI session and
+    /// freeing port 4444, not the thing that kills the app.
+    ///
+    /// Falls back to [`Self::shutdown`]'s abrupt kill if the graceful close
+    /// doesn't complete within the deadline (e.g. the dynamic import fails
+    /// outside a real Tauri runtime) — best-effort, never hangs a journey.
+    pub async fn graceful_shutdown(self) -> Result<()> {
+        let script = r#"
+            var callback = arguments[arguments.length - 1];
+            import('@tauri-apps/api/window').then(function (mod) {
+                return mod.getCurrentWindow().close();
+            }).then(function () {
+                callback(true);
+            }).catch(function () {
+                callback(false);
+            });
+        "#;
+        let _: bool = self
+            .driver
+            .execute_async(script, vec![])
+            .await
+            .ok()
+            .and_then(|ret| ret.convert::<bool>().ok())
+            .unwrap_or(false);
+
+        // Proof the window/process actually tore down: once it has, WebDriver
+        // commands against the now-gone window/session fail — treat any
+        // error the same as an explicit "bridge gone" (`Ok(false)`).
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            match self.bridge_ready().await {
+                Ok(false) | Err(_) => break,
+                Ok(true) if Instant::now() >= deadline => break,
+                Ok(true) => tokio::time::sleep(Duration::from_millis(100)).await,
+            }
+        }
+        // Small extra margin for the OS to finish reaping the process right
+        // after the window/webview teardown completes.
+        tokio::time::sleep(Duration::from_millis(200)).await;
+
+        self.shutdown().await
+    }
+
     /// Quit the WebDriver session and kill the `tauri-webdriver` CLI process
     /// if present. Quitting the session (a `DELETE /session/{id}` through the
     /// CLI) makes the CLI terminate the app process it launched on our

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -38,7 +38,30 @@ use thirtyfour::By;
 
 const UI_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Wait for the index route's async first-run redirect to land on `/setup`
+/// BEFORE navigating anywhere (mirrors `inbox_ui_journeys.rs`'s
+/// `settle_first_run_redirect`). A fresh DB (the harness resets it every
+/// launch) makes `checkFirstRunComplete` redirect `/` → `/setup` from an
+/// async `beforeLoad`; if a journey `goto_route`s while that redirect is
+/// still pending, the late-resolving redirect can yank the app off the
+/// target route.
+async fn settle_first_run_redirect(app: &E2eApp) -> anyhow::Result<()> {
+    app.wait_url_contains("/setup", Duration::from_secs(15))
+        .await
+        .map(drop)
+        .map_err(|e| anyhow::anyhow!("expected a fresh DB to redirect to /setup: {e}"))
+}
+
+/// Registers BOTH a raw (`light_frames`) and a `project` root:
+/// [`E2eApp::complete_first_run_gate`] requires at least one of each, and
+/// routing through the real gate (not a bare `firstrun_complete` invoke)
+/// also clears the Shell's separate `setupCompleted` localStorage flag — a
+/// journey that only calls the backend command still gets bounced to
+/// `/setup` on every subsequent `goto_route` (`inbox_ui_journeys.rs`'s
+/// `register_project_root`/`complete_first_run_gate` pairing is the proven
+/// pattern this mirrors).
 async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
+    settle_first_run_redirect(app).await?;
     let raw_dir = tempfile::tempdir()?;
     let _: serde_json::Value = app
         .invoke(
@@ -46,8 +69,14 @@ async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
             json!({ "path": raw_dir.path().to_string_lossy(), "category": "light_frames", "scanSettings": null }),
         )
         .await?;
-    let _: serde_json::Value = app.invoke("firstrun_complete", json!({})).await?;
-    Ok(())
+    let project_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": project_dir.path().to_string_lossy(), "category": "project", "scanSettings": null }),
+        )
+        .await?;
+    app.complete_first_run_gate().await
 }
 
 /// Test 1 (journey-10): the Ingestion pane has NO global "Save" button
@@ -124,11 +153,12 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
         // swatch, matched by its visible name (the swatch button's full text
         // also includes its light/dark mode label, so an exact-match helper
         // would be wrong here — use `contains`).
+        // Poll for the swatch to actually mount: it opens asynchronously
+        // after the navigation, same route/render race `E2eApp::find_waiting`
+        // documents.
         let xpath = "//button[contains(., 'Espresso')]";
-        app.driver
-            .find(By::XPath(xpath))
-            .await
-            .context("no 'Espresso' theme swatch button found")?
+        app.find_waiting(By::XPath(xpath), "the 'Espresso' theme swatch button")
+            .await?
             .click()
             .await
             .context("click the Espresso theme swatch failed")?;
@@ -177,10 +207,11 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
     app2.goto_route("/settings?pane=general").await?;
     app2.wait_bridge_ready(Duration::from_secs(15)).await?;
     let espresso_swatch = app2
-        .driver
-        .find(By::XPath("//button[contains(., 'Espresso')]"))
-        .await
-        .context("no 'Espresso' theme swatch button found after relaunch")?;
+        .find_waiting(
+            By::XPath("//button[contains(., 'Espresso')]"),
+            "the 'Espresso' theme swatch button after relaunch",
+        )
+        .await?;
     let pressed = espresso_swatch
         .attr("aria-pressed")
         .await

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -183,6 +183,36 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
             "expected the theme to apply live with no reload, got data-theme={theme:?}"
         );
 
+        // Diagnostic (round 2, fix-464-theme): confirm the write actually
+        // landed in `localStorage` itself, not just the derived `data-theme`
+        // attribute — rules out "never written" as a cause of a later
+        // relaunch failure.
+        let stored: serde_json::Value = app
+            .driver
+            .execute("return window.localStorage.getItem('alm.theme')", vec![])
+            .await
+            .context("failed to read localStorage['alm.theme'] before shutdown")?
+            .convert()
+            .context("failed to deserialise localStorage['alm.theme'] before shutdown")?;
+        anyhow::ensure!(
+            stored == serde_json::json!("espresso-dark"),
+            "expected localStorage['alm.theme']=\"espresso-dark\" to be written before \
+             shutdown, got {stored:?}"
+        );
+
+        // `E2eApp::shutdown()` force-kills the app process (the CLI's only
+        // handle on the app's lifetime — see `blocking_session_delete`'s
+        // doc), rather than closing the window gracefully. Chromium/WebView2
+        // commits `localStorage` writes to its on-disk store asynchronously
+        // (a background-sequence flush, not synchronous-per-write), so an
+        // abrupt process kill immediately after a write can lose it before
+        // it reaches disk — a documented WebView2/Chromium characteristic,
+        // and a plausible reason this journey is Windows-only-flaky even
+        // with a real, unwiped webview profile (WebKitGTK's flush timing
+        // differs). Give the background flush a moment to complete before
+        // killing the process.
+        tokio::time::sleep(Duration::from_millis(1000)).await;
+
         app.shutdown().await?;
     }
 
@@ -198,6 +228,21 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
     let app2 = E2eApp::relaunch().await?;
     app2.wait_bridge_ready(Duration::from_secs(30)).await?;
 
+    // Diagnostic (round 2, fix-464-theme): read the RAW localStorage value
+    // directly, in addition to the derived `data-theme` attribute. If this
+    // is `null`, the write was lost between processes (harness/OS-level
+    // storage loss). If it's still `"espresso-dark"` but `data-theme` below
+    // reverted to the default, the value survived fine and the bug is a
+    // product-code race in `initAppearance()`/`applyTheme()` reading
+    // localStorage before hydration completes — a very different fix.
+    let stored_after_relaunch: serde_json::Value = app2
+        .driver
+        .execute("return window.localStorage.getItem('alm.theme')", vec![])
+        .await
+        .context("failed to read localStorage['alm.theme'] after relaunch")?
+        .convert()
+        .context("failed to deserialise localStorage['alm.theme'] after relaunch")?;
+
     let theme_after_relaunch: String = app2
         .driver
         .execute("return document.documentElement.getAttribute('data-theme')", vec![])
@@ -208,7 +253,9 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
     anyhow::ensure!(
         theme_after_relaunch == "espresso-dark",
         "expected the theme choice to survive a full app relaunch (localStorage), \
-         got data-theme={theme_after_relaunch:?}"
+         got data-theme={theme_after_relaunch:?} (raw localStorage['alm.theme']={stored_after_relaunch:?} \
+         — null means the value never made it to disk/the new process; \
+         \"espresso-dark\" means it survived but something ignored it at boot)"
     );
 
     // Confirm the Settings UI itself reflects the persisted choice too (not

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -1,0 +1,194 @@
+//! Spec 037 Layer-2 real-UI journeys — Settings auto-save + theme persistence
+//! (batch #11 of the coverage-matrix "Batched plan", Journey 10). Promotes
+//! two of `docs/development/windows-journeys/journey-10-settings-appearance-i18n.md`'s
+//! Tests: #1 (pane grouping / no global Save) + #4 (a setting persists
+//! through the real backend) combined into one journey, and #2 (theme
+//! applies live and survives a restart) as a second.
+//!
+//! Deliberately scoped to these two: they're real, cheap, deterministic UI
+//! state/persistence checks with no native OS dialogs involved — the
+//! "lowest filesystem-mutation risk" batch per the coverage matrix. The
+//! remaining Tests (ingestion-settings-persist-across-restart, altitude
+//! clamp, log-panel layout/export, 1100x720 layout convention, translated
+//! backend-error surfacing, command palette, sidebar persistence) are left
+//! as documented follow-ups — several need either a scrollable content
+//! fixture or a real backend-rejected action reachable without a native
+//! dialog, which would meaningfully grow this file's scope.
+//!
+//! Note on `E2eApp::launch()` and cross-session persistence: `launch()`
+//! calls `reset_database()` (wipes the SQLite DB) on every call, so a
+//! backend-persisted setting (e.g. Ingestion's toggles, which round-trip
+//! through `ingestion.settings.get`/`update` into the same DB) CANNOT be
+//! proven to survive a relaunch across two `E2eApp::launch()` calls in this
+//! harness — the DB reset would erase it regardless of whether the real app
+//! would have kept it. Only `localStorage`-backed state (e.g. the theme
+//! choice, `apps/desktop/src/data/theme.ts`) is unaffected by
+//! `reset_database()` and can honestly prove cross-relaunch persistence
+//! here; the ingestion-settings-persist-across-restart scenario (journey-10
+//! Test 4) is left as a follow-up for that reason, not an oversight.
+
+mod common;
+
+use std::time::Duration;
+
+use anyhow::Context;
+use common::E2eApp;
+use serde_json::json;
+use thirtyfour::By;
+
+const UI_TIMEOUT: Duration = Duration::from_secs(20);
+
+async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
+    let raw_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": raw_dir.path().to_string_lossy(), "category": "light_frames", "scanSettings": null }),
+        )
+        .await?;
+    let _: serde_json::Value = app.invoke("firstrun_complete", json!({})).await?;
+    Ok(())
+}
+
+/// Test 1 (journey-10): the Ingestion pane has NO global "Save" button
+/// anywhere, and toggling a real field auto-saves through the real backend
+/// (`ingestion.settings.update`) without any explicit save action — proven
+/// by a fresh `ingestion.settings.get` read reflecting the change.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn settings_ui_ingestion_toggle_autosaves_no_global_save_button() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    complete_first_run(&app).await?;
+
+    app.goto_route("/settings?pane=ingestion").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+
+    anyhow::ensure!(
+        app.count_buttons_with_text("Save").await? == 0,
+        "expected NO global 'Save' button on a settings pane (auto-save-only convention, spec 018)"
+    );
+
+    // Real backend precondition: `followSymlinks` defaults to false.
+    let before: serde_json::Value = app.invoke("ingestion_settings_get", json!({})).await?;
+    anyhow::ensure!(
+        before["followSymlinks"] == json!(false),
+        "expected the real default followSymlinks=false before toggling: {before}"
+    );
+    anyhow::ensure!(
+        !app.checkbox_checked_by_aria_label("Follow symbolic links").await?,
+        "expected the real checkbox to start unchecked, matching the backend default"
+    );
+
+    // Real DOM interaction: toggle it. No save button exists — this is the
+    // only action a real user could take to change the value.
+    app.click_by_aria_label("Follow symbolic links").await?;
+    anyhow::ensure!(
+        app.checkbox_checked_by_aria_label("Follow symbolic links").await?,
+        "expected the real checkbox to reflect the toggle immediately"
+    );
+
+    // Real backend round-trip: confirm the auto-save actually persisted,
+    // with no Save click anywhere in this journey.
+    let after: serde_json::Value = app
+        .invoke_until("ingestion_settings_get", json!({}), UI_TIMEOUT, |v: &serde_json::Value| {
+            v["followSymlinks"] == json!(true)
+        })
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("expected the toggle to auto-save to the real backend: {e}")
+        })?;
+    anyhow::ensure!(after["followSymlinks"] == json!(true), "unexpected persisted value: {after}");
+
+    app.shutdown().await
+}
+
+/// Test 2 (journey-10): switching the theme applies live (`<html
+/// data-theme>` changes with no reload) and survives a full app relaunch —
+/// the ONE piece of Settings state this harness can honestly prove survives
+/// a relaunch, since theme choice is `localStorage`-backed
+/// (`apps/desktop/src/data/theme.ts`) and therefore untouched by
+/// `E2eApp::launch()`'s per-session `reset_database()` (see module docs).
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow::Result<()> {
+    {
+        let app = E2eApp::launch().await?;
+        app.wait_bridge_ready(Duration::from_secs(30)).await?;
+        complete_first_run(&app).await?;
+
+        app.goto_route("/settings?pane=general").await?;
+        app.wait_bridge_ready(Duration::from_secs(15)).await?;
+
+        // "Espresso" (`THEMES` id `espresso-dark`) — a real, non-default theme
+        // swatch, matched by its visible name (the swatch button's full text
+        // also includes its light/dark mode label, so an exact-match helper
+        // would be wrong here — use `contains`).
+        let xpath = "//button[contains(., 'Espresso')]";
+        app.driver
+            .find(By::XPath(xpath))
+            .await
+            .context("no 'Espresso' theme swatch button found")?
+            .click()
+            .await
+            .context("click the Espresso theme swatch failed")?;
+
+        // Live apply: no reload needed.
+        let theme: String = app
+            .driver
+            .execute("return document.documentElement.getAttribute('data-theme')", vec![])
+            .await
+            .context("failed to read document.documentElement's data-theme")?
+            .convert()
+            .context("failed to deserialise data-theme")?;
+        anyhow::ensure!(
+            theme == "espresso-dark",
+            "expected the theme to apply live with no reload, got data-theme={theme:?}"
+        );
+
+        app.shutdown().await?;
+    }
+
+    // Relaunch: a fresh WebDriver session + a fresh `desktop_shell` process.
+    // `reset_database()` wipes the SQLite DB (first-run state), but the
+    // theme choice lives in the SAME OS webview profile's localStorage and
+    // is applied by `initAppearance()` at boot, before routing/first-run
+    // even resolves — so it should already be set the instant the bridge is
+    // ready, with no navigation needed.
+    let app2 = E2eApp::launch().await?;
+    app2.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    let theme_after_relaunch: String = app2
+        .driver
+        .execute("return document.documentElement.getAttribute('data-theme')", vec![])
+        .await
+        .context("failed to read document.documentElement's data-theme after relaunch")?
+        .convert()
+        .context("failed to deserialise data-theme after relaunch")?;
+    anyhow::ensure!(
+        theme_after_relaunch == "espresso-dark",
+        "expected the theme choice to survive a full app relaunch (localStorage), \
+         got data-theme={theme_after_relaunch:?}"
+    );
+
+    // Confirm the Settings UI itself reflects the persisted choice too (not
+    // just the raw DOM attribute).
+    complete_first_run(&app2).await?;
+    app2.goto_route("/settings?pane=general").await?;
+    app2.wait_bridge_ready(Duration::from_secs(15)).await?;
+    let espresso_swatch = app2
+        .driver
+        .find(By::XPath("//button[contains(., 'Espresso')]"))
+        .await
+        .context("no 'Espresso' theme swatch button found after relaunch")?;
+    let pressed = espresso_swatch
+        .attr("aria-pressed")
+        .await
+        .context("failed to read aria-pressed on the Espresso swatch")?;
+    anyhow::ensure!(
+        pressed.as_deref() == Some("true"),
+        "expected the Espresso swatch to show aria-pressed=true after relaunch, got {pressed:?}"
+    );
+
+    app2.shutdown().await
+}

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -202,18 +202,18 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
 
         // `E2eApp::shutdown()` force-kills the app process (the CLI's only
         // handle on the app's lifetime — see `blocking_session_delete`'s
-        // doc), rather than closing the window gracefully. Chromium/WebView2
-        // commits `localStorage` writes to its on-disk store asynchronously
-        // (a background-sequence flush, not synchronous-per-write), so an
-        // abrupt process kill immediately after a write can lose it before
-        // it reaches disk — a documented WebView2/Chromium characteristic,
-        // and a plausible reason this journey is Windows-only-flaky even
-        // with a real, unwiped webview profile (WebKitGTK's flush timing
-        // differs). Give the background flush a moment to complete before
-        // killing the process.
-        tokio::time::sleep(Duration::from_millis(1000)).await;
-
-        app.shutdown().await?;
+        // doc). CI evidence (round 2, fix-464-theme: CI run 28810006837) is
+        // that this reliably LOSES a `localStorage` write on Windows — the
+        // raw value read back after a relaunch was `null`, not merely stale
+        // — and a delay before the kill (tried in that round) does not save
+        // it: WebView2 commits `localStorage` to its on-disk LevelDB-backed
+        // store on a graceful shutdown, not on a timer, so nothing short of
+        // an actual graceful close preserves it. Use
+        // `E2eApp::graceful_shutdown()` instead, which closes the window for
+        // real (`getCurrentWindow().close()`) before tearing the session
+        // down — real-user fidelity, and the only path that gives WebView2 a
+        // normal teardown to flush during.
+        app.graceful_shutdown().await?;
     }
 
     // Relaunch: a fresh WebDriver session + a fresh `desktop_shell` process,

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -15,17 +15,18 @@
 //! fixture or a real backend-rejected action reachable without a native
 //! dialog, which would meaningfully grow this file's scope.
 //!
-//! Note on `E2eApp::launch()` and cross-session persistence: `launch()`
-//! calls `reset_database()` (wipes the SQLite DB) on every call, so a
+//! Note on cross-session persistence and `E2eApp::launch()`/`relaunch()`:
+//! both reset the SQLite DB on every call (`reset_database()`), so a
 //! backend-persisted setting (e.g. Ingestion's toggles, which round-trip
 //! through `ingestion.settings.get`/`update` into the same DB) CANNOT be
-//! proven to survive a relaunch across two `E2eApp::launch()` calls in this
-//! harness — the DB reset would erase it regardless of whether the real app
-//! would have kept it. Only `localStorage`-backed state (e.g. the theme
-//! choice, `apps/desktop/src/data/theme.ts`) is unaffected by
-//! `reset_database()` and can honestly prove cross-relaunch persistence
-//! here; the ingestion-settings-persist-across-restart scenario (journey-10
-//! Test 4) is left as a follow-up for that reason, not an oversight.
+//! proven to survive a relaunch in this harness — the DB reset would erase
+//! it regardless of whether the real app would have kept it. Only
+//! `localStorage`-backed state (e.g. the theme choice,
+//! `apps/desktop/src/data/theme.ts`) survives a `relaunch()` (unlike a
+//! second `launch()`, which also wipes webview storage) and can honestly
+//! prove cross-relaunch persistence here; the
+//! ingestion-settings-persist-across-restart scenario (journey-10 Test 4) is
+//! left as a follow-up for that reason, not an oversight.
 
 mod common;
 
@@ -185,13 +186,16 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
         app.shutdown().await?;
     }
 
-    // Relaunch: a fresh WebDriver session + a fresh `desktop_shell` process.
-    // `reset_database()` wipes the SQLite DB (first-run state), but the
-    // theme choice lives in the SAME OS webview profile's localStorage and
-    // is applied by `initAppearance()` at boot, before routing/first-run
-    // even resolves — so it should already be set the instant the bridge is
-    // ready, with no navigation needed.
-    let app2 = E2eApp::launch().await?;
+    // Relaunch: a fresh WebDriver session + a fresh `desktop_shell` process,
+    // via `E2eApp::relaunch()` (NOT `launch()` — `launch()` wipes the
+    // webview's persisted storage on every call, which would erase the very
+    // localStorage state this journey is trying to prove survives a real
+    // app restart). `reset_database()` still wipes the SQLite DB (first-run
+    // state), but the theme choice lives in the SAME OS webview profile's
+    // localStorage and is applied by `initAppearance()` at boot, before
+    // routing/first-run even resolves — so it should already be set the
+    // instant the bridge is ready, with no navigation needed.
+    let app2 = E2eApp::relaunch().await?;
     app2.wait_bridge_ready(Duration::from_secs(30)).await?;
 
     let theme_after_relaunch: String = app2

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -90,7 +90,13 @@ async fn settings_ui_ingestion_toggle_autosaves_no_global_save_button() -> anyho
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
     complete_first_run(&app).await?;
 
-    app.goto_route("/settings?pane=ingestion").await?;
+    // The active pane is a real PATH param (`settingsPaneRoute`, path
+    // `/settings/$pane` — `apps/desktop/src/app/router.tsx`), read via
+    // `useParams` in `SettingsPage.tsx`, NOT a `?pane=` query string; the
+    // query-string form silently falls back to the default 'sources' pane
+    // (CI: "Follow symbolic links" never appeared — the Ingestion pane
+    // never actually mounted).
+    app.goto_route("/settings/ingestion").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
 
     anyhow::ensure!(
@@ -146,7 +152,7 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
         app.wait_bridge_ready(Duration::from_secs(30)).await?;
         complete_first_run(&app).await?;
 
-        app.goto_route("/settings?pane=general").await?;
+        app.goto_route("/settings/general").await?;
         app.wait_bridge_ready(Duration::from_secs(15)).await?;
 
         // "Espresso" (`THEMES` id `espresso-dark`) — a real, non-default theme
@@ -204,7 +210,7 @@ async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow
     // Confirm the Settings UI itself reflects the persisted choice too (not
     // just the raw DOM attribute).
     complete_first_run(&app2).await?;
-    app2.goto_route("/settings?pane=general").await?;
+    app2.goto_route("/settings/general").await?;
     app2.wait_bridge_ready(Duration::from_secs(15)).await?;
     let espresso_swatch = app2
         .find_waiting(

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -230,7 +230,7 @@ everything neither automated layer reaches.
 | 7 Archive → delete | ✅ (backend only) | ✅ `archive_lifecycle_apply_trash_permanent_delete` (`archive_journeys.rs`, NEW 2026-07-05): real apply + `archive.list` + `archive.send_to_trash`/`archive.permanently_delete` metadata + `blockPermanentDelete` gate | ❌ none | `windows-journeys/journey-07-archive-delete.md` |
 | 8 Calibration masters → matching | ✅ | 🟡 real-UI (`calibration_ui_journeys.rs`): masters ingest as individual items + kind-conditional detail (Tests 1/2). Matching/assign UI (Tests 3-5) found UNREACHABLE from the real app during this pass — see finding below, not automatable until fixed | ❌ none | `windows-journeys/journey-08-calibration-masters-matching.md` |
 | 9 Targets & planning | ✅ (backend only) | ❌ **none at all** | ❌ **none at all** | `windows-journeys/journey-09-targets-planning.md` |
-| 10 Settings/appearance/i18n | ✅ | 🟡 route-load smoke only | ❌ none | `windows-journeys/journey-10-settings-appearance-i18n.md` |
+| 10 Settings/appearance/i18n | ✅ | 🟡 real-UI (`settings_journeys.rs`): no-global-Save + real auto-save round-trip, theme live-apply + cross-relaunch persistence. Remaining sub-tests (altitude clamp, log-panel layout/export, 1100×720 convention, translated backend errors, command palette, sidebar persistence) still route-load-smoke only | ❌ none | `windows-journeys/journey-10-settings-appearance-i18n.md` |
 
 Legend: ✅ solid coverage at that layer · 🟡 partial/IPC-only/smoke-only ·
 ❌ none. Layer-1 "✅" means the backend logic is real-tested; it says
@@ -373,8 +373,16 @@ just test the mock, not the product:
     containment, artifact watcher; tool-launch and the watcher specifically
     need Layer-2 (a real process/filesystem watcher), not the mock layer.
 11. **Settings + layout-convention + i18n regression guard** (Journey 10) —
-    lowest filesystem-mutation risk; the 1100×720 layout convention and
-    no-raw-error-code checks are cheap, cross-cutting regression guards.
+    PARTIALLY DONE (2026-07-05, `crates/e2e-tests/tests/settings_journeys.rs`):
+    no-global-Save-button + real auto-save round-trip (Test 1), and theme
+    live-apply + real cross-relaunch persistence (Test 2, using the
+    `localStorage`-backed theme choice — the one piece of Settings state this
+    harness's per-launch `reset_database()` doesn't erase, so it's the only
+    honest way to prove relaunch persistence here). Still open as follow-up:
+    the 1100×720 layout convention and no-raw-error-code checks are cheap,
+    cross-cutting regression guards worth adding next; altitude clamp,
+    log-panel layout/export, command palette, and sidebar persistence remain
+    unautomated too.
 
 See `docs/development/windows-journeys/journey-0{1..9,10}-*.md` for the
 click-by-click manual scripts covering all of the above until each is


### PR DESCRIPTION
## Summary
- Adds automated end-to-end tests that drive the real Settings screen, closing part of a gap where this area had no automated coverage beyond confirming the page loads.
- Covers: the Ingestion settings pane has no global "Save" button anywhere and a toggle auto-saves through the real backend as soon as it's changed; and switching the app's theme applies instantly with no reload, and the chosen theme is still active after fully restarting the app.

## Test plan
- [x] `cargo test -p e2e_tests --no-run` (compile-only; these tests only run in CI's dedicated end-to-end workflow, which needs a real app window)
- [x] `cargo clippy -p e2e_tests --tests --all-targets -- -D warnings`
- [x] `cargo fmt -p e2e_tests -- --check`
- [ ] CI end-to-end workflow (3-OS matrix) runs the new tests for real

Note: like the sibling Calibration/Targets PRs (#458/#463), this branch carries an identical copy of the shared test-helper additions to `crates/e2e-tests/tests/common/mod.rs` from PR #457, since it was re-rooted from `origin/main` before that PR merged. Whichever merges last should see a no-op diff for that file.

## Spec Context
- Spec: 037
- Branch: 037-ui-journeys-settings