### PR TITLE
test: add real end-to-end Sessions derived-view journey

### DIFF
--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -27,6 +27,7 @@ mod common;
 
 use std::time::Duration;
 
+use anyhow::Context;
 use common::{write_minimal_fits, E2eApp};
 use serde_json::json;
 
@@ -69,6 +70,26 @@ async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
         )
         .await?;
     app.complete_first_run_gate().await
+}
+
+/// Force a real reload of the CURRENTLY-loaded route rather than calling
+/// `E2eApp::goto_route` again with the identical URL.
+///
+/// `goto_route` builds `{APP_URL}/#{path}` and calls `driver.goto(url)`; when
+/// the app is already sitting on that exact URL (no intervening navigation
+/// away from it), asking the browser to "navigate to" a byte-identical URL
+/// is a well-known no-op in several engines (no reload, no route remount, no
+/// TanStack Query refetch) — this bit Test 2 below, which re-visits
+/// `/sessions` immediately after the real ingest pipeline runs entirely over
+/// the invoke bridge (no navigation happens in between), so the page never
+/// re-fetches and the newly-applied session's row never appears within the
+/// polling deadline (CI: both ubuntu and windows hung on
+/// `wait_testid_prefix_present("sessions-row-", ..)`, ruling out a timing
+/// flake). An explicit `driver.refresh()` is unambiguous.
+async fn reload_current_route(app: &E2eApp) -> anyhow::Result<()> {
+    app.driver.refresh().await.context("page refresh failed")?;
+    app.wait_document_ready(Duration::from_secs(10)).await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await
 }
 
 /// Tests 1/2/3/5 (journey-04) in one journey: nothing appears before a plan
@@ -171,9 +192,11 @@ async fn sessions_ui_derived_view_invariants() -> anyhow::Result<()> {
 
     // Test 2: the real session appears automatically on the real Sessions
     // page (no separate review/approve step) — session grouping is
-    // event-driven, so poll the real UI for it.
-    app.goto_route("/sessions").await?;
-    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    // event-driven, so poll the real UI for it. The app is ALREADY sitting
+    // on `/sessions` from Test 1 (no navigation happened during the ingest
+    // pipeline above, which is invoke-only) — reload rather than
+    // `goto_route` to the identical URL, see `reload_current_route`.
+    reload_current_route(&app).await?;
     app.wait_testid_prefix_present("sessions-row-", UI_TIMEOUT).await.map_err(|e| {
         anyhow::anyhow!("expected a real session row to appear automatically after apply: {e}")
     })?;

--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -1,0 +1,178 @@
+//! Spec 037 Layer-2 real-UI journey — Sessions derived-view invariants
+//! (batch #9 of the coverage-matrix "Batched plan", Journey 4). Promotes
+//! `docs/development/windows-journeys/journey-04-sessions-review.md`'s
+//! UI-level Tests (1/2/3/5) — the existing `ingestion_sessions_search`
+//! journey (`journeys.rs`) already proves the real event-driven grouping
+//! pipeline via `sessions.list`; this file adds the real Sessions PAGE
+//! assertions that journey doesn't touch (nothing before apply, no
+//! review-state controls, rescan doesn't duplicate).
+//!
+//! ## Finding while authoring this file: journey-04 Test 4 is untestable as
+//! written
+//!
+//! Test 4 ("edit a session's Notes field, let it auto-save") describes a
+//! Notes field on the session detail. `SessionDetail.tsx`
+//! (read in full while authoring this) has NO notes field at all — its own
+//! doc comment says "Session metadata remains editable post-hoc via the
+//! inbox per-file metadata/override tables", and a repo-wide search for a
+//! session notes field/command found none. Spec 041 FR-051 (T076) removed
+//! the review-lifecycle actions (Confirm/Re-open/Reject/Ignore) — this
+//! journey's own module doc suggests the notes-editing claim in journey-04
+//! may be a stale holdover from before that removal, not a real, currently
+//! reachable feature. Test 4 is therefore skipped here rather than faked;
+//! flagged in the coverage matrix as a documentation-accuracy follow-up
+//! (either the feature needs to ship, or journey-04 needs correcting).
+
+mod common;
+
+use std::time::Duration;
+
+use common::{write_minimal_fits, E2eApp};
+use serde_json::json;
+
+const UI_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Tests 1/2/3/5 (journey-04) in one journey: nothing appears before a plan
+/// applies, a real session appears automatically (event-driven grouping)
+/// after apply with no separate review step, no review-state controls exist
+/// anywhere on the page, and a no-op Inbox rescan never duplicates the
+/// session.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn sessions_ui_derived_view_invariants() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    // Test 1: nothing appears before any inbox item is confirmed + applied.
+    app.goto_route("/sessions").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    anyhow::ensure!(
+        app.find_all_testid_prefix("sessions-row-").await?.is_empty(),
+        "expected Sessions to show nothing before any plan has applied"
+    );
+
+    // Real ingest pipeline (mirrors `ingestion_sessions_search` in
+    // `journeys.rs`) — this journey's new value is the Sessions PAGE
+    // assertions below, not re-proving the ingest pipeline itself.
+    let root_dir = tempfile::tempdir()?;
+    write_minimal_fits(
+        root_dir.path(),
+        "light_m31_sessions_001.fits",
+        "Light Frame",
+        Some("M 31"),
+        Some("Ha"),
+        Some("2026-01-12T21:30:00"),
+    )?;
+    let register: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": root_dir.path().to_string_lossy(), "category": "light_frames", "scanSettings": null }),
+        )
+        .await?;
+    let root_id = register["sourceId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("roots.register returned no sourceId: {register}"))?
+        .to_owned();
+    let _: serde_json::Value = app
+        .invoke(
+            "sources_set_organization_state",
+            json!({ "sourceId": root_id, "organizationState": "unorganized" }),
+        )
+        .await?;
+    let scan: serde_json::Value = app
+        .invoke(
+            "inbox_scan_folder",
+            json!({
+                "req": {
+                    "rootId": root_id,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "followSymlinks": false,
+                }
+            }),
+        )
+        .await?;
+    let inbox_item_id = scan["items"][0]["inboxItemId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.scan.folder discovered no item: {scan}"))?
+        .to_owned();
+    let classify: serde_json::Value = app
+        .invoke(
+            "inbox_classify",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "forceRescan": false,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                }
+            }),
+        )
+        .await?;
+    let content_signature = classify["contentSignature"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
+        .to_owned();
+    let _: serde_json::Value = app
+        .invoke(
+            "inbox_confirm",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "contentSignature": content_signature,
+                    "destructiveDestination": null,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "rootId": null,
+                }
+            }),
+        )
+        .await?;
+    let _: serde_json::Value =
+        app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
+
+    // Test 2: the real session appears automatically on the real Sessions
+    // page (no separate review/approve step) — session grouping is
+    // event-driven, so poll the real UI for it.
+    app.goto_route("/sessions").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.wait_testid_prefix_present("sessions-row-", UI_TIMEOUT).await.map_err(|e| {
+        anyhow::anyhow!("expected a real session row to appear automatically after apply: {e}")
+    })?;
+    let rows_after_apply = app.find_all_testid_prefix("sessions-row-").await?;
+    anyhow::ensure!(
+        rows_after_apply.len() == 1,
+        "expected exactly 1 real session after applying 1 light frame, found {}",
+        rows_after_apply.len()
+    );
+
+    // Test 3: select it and confirm NO review-state controls exist anywhere
+    // on the page (list + detail) — the intentionally-removed
+    // Confirm/Re-open/Reject/Ignore review lifecycle (spec 041 FR-051/T076).
+    let session_id = app.testid_suffix("sessions-row-").await?;
+    app.click_testid(&format!("sessions-row-{session_id}")).await?;
+    for label in ["Confirm", "Re-open", "Reopen", "Reject", "Ignore"] {
+        anyhow::ensure!(
+            app.count_buttons_with_text(label).await? == 0,
+            "expected NO '{label}' review-lifecycle control anywhere on the Sessions page \
+             (spec 041 FR-051 removed this state machine)"
+        );
+    }
+
+    // Test 5: a no-op Inbox rescan (no new files) must never duplicate the
+    // session or resurrect a review state.
+    app.goto_route("/inbox").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.click_by_aria_label("Rescan all roots").await?;
+    // Give the (no-op) rescan a moment to settle, then re-check Sessions.
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+
+    app.goto_route("/sessions").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.wait_testid_prefix_present("sessions-row-", UI_TIMEOUT).await?;
+    let rows_after_rescan = app.find_all_testid_prefix("sessions-row-").await?;
+    anyhow::ensure!(
+        rows_after_rescan.len() == 1,
+        "expected a no-op rescan to never duplicate the session, found {} rows",
+        rows_after_rescan.len()
+    );
+
+    app.shutdown().await
+}

--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -32,6 +32,45 @@ use serde_json::json;
 
 const UI_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Wait for the index route's async first-run redirect to land on `/setup`
+/// BEFORE navigating anywhere (mirrors `inbox_ui_journeys.rs`'s
+/// `settle_first_run_redirect`). A fresh DB (the harness resets it every
+/// launch) makes `checkFirstRunComplete` redirect `/` → `/setup` from an
+/// async `beforeLoad`; if a journey `goto_route`s while that redirect is
+/// still pending, the late-resolving redirect can yank the app off the
+/// target route.
+async fn settle_first_run_redirect(app: &E2eApp) -> anyhow::Result<()> {
+    app.wait_url_contains("/setup", Duration::from_secs(15))
+        .await
+        .map(drop)
+        .map_err(|e| anyhow::anyhow!("expected a fresh DB to redirect to /setup: {e}"))
+}
+
+/// Registers a disposable `light_frames` root and a disposable `project`
+/// root purely to satisfy `firstrun.complete`'s precondition (one of EACH,
+/// `crates/persistence/db/src/repositories/first_run.rs`), then routes
+/// through the real gate. Without this, `Shell.tsx`'s client-side
+/// `setupCompleted` gate bounces every `goto_route` to a Shell-wrapped page
+/// (`/sessions`, `/inbox`) back to `/setup` indefinitely (mirrors the proven
+/// `inbox_ui_journeys.rs` pattern).
+async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
+    let raw_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": raw_dir.path().to_string_lossy(), "category": "light_frames", "scanSettings": null }),
+        )
+        .await?;
+    let project_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": project_dir.path().to_string_lossy(), "category": "project", "scanSettings": null }),
+        )
+        .await?;
+    app.complete_first_run_gate().await
+}
+
 /// Tests 1/2/3/5 (journey-04) in one journey: nothing appears before a plan
 /// applies, a real session appears automatically (event-driven grouping)
 /// after apply with no separate review step, no review-state controls exist
@@ -42,6 +81,8 @@ const UI_TIMEOUT: Duration = Duration::from_secs(30);
 async fn sessions_ui_derived_view_invariants() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    settle_first_run_redirect(&app).await?;
+    complete_first_run(&app).await?;
 
     // Test 1: nothing appears before any inbox item is confirmed + applied.
     app.goto_route("/sessions").await?;

--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -191,11 +191,54 @@ async fn sessions_ui_derived_view_invariants() -> anyhow::Result<()> {
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
 
     // Test 2: the real session appears automatically on the real Sessions
-    // page (no separate review/approve step) — session grouping is
-    // event-driven, so poll the real UI for it. The app is ALREADY sitting
-    // on `/sessions` from Test 1 (no navigation happened during the ingest
-    // pipeline above, which is invoke-only) — reload rather than
-    // `goto_route` to the identical URL, see `reload_current_route`.
+    // page (no separate review/approve step). Session grouping is
+    // event-driven — `inbox.plan_apply` returns as soon as the plan's
+    // executor finishes; the plan-listener that folds the applied light
+    // frame into an `acquisition_session` row (spec 035 US4/T042,
+    // `ingest_light_frames_if_applicable` in
+    // `crates/app/inbox/src/plan_listener.rs`) reacts to the
+    // `plan.applying.completed` event on its OWN background task afterwards.
+    // A single reload raced that background task (CI: both ubuntu and
+    // windows hung on `wait_testid_prefix_present`, ruling out a timing
+    // flake — the backend simply hadn't grouped the frame into a session
+    // yet by the time the one-shot TanStack Query fetch ran, and nothing
+    // thereafter re-triggers a refetch for `wait_testid_prefix_present` to
+    // observe). Poll the real backend command the page itself queries
+    // (`inventory.list` via `useInventorySources`, NOT `sessions.list` —
+    // that's a different, session-review-era projection) until the grouped
+    // session exists, mirroring `invoke_until`'s documented wait primitive
+    // for this exact class of event-driven backend effect
+    // (`journeys.rs`'s `ingestion_sessions_search`). Only once the backend
+    // is ready does reloading the UI mean anything.
+    app.invoke_until(
+        "inventory_list",
+        json!({
+            "req": {
+                "contractVersion": "2.0.0",
+                "requestId": "e2e-sessions-derived-view-poll",
+                "filters": null,
+            }
+        }),
+        UI_TIMEOUT,
+        |v: &serde_json::Value| {
+            v["sources"].as_array().is_some_and(|sources| {
+                sources.iter().any(|s| s["sessions"].as_array().is_some_and(|ss| !ss.is_empty()))
+            })
+        },
+    )
+    .await
+    .map_err(|e| {
+        anyhow::anyhow!(
+            "expected the backend to group the applied light frame into a real \
+             acquisition session: {e}"
+        )
+    })?;
+
+    // The app is ALREADY sitting on `/sessions` from Test 1 (no navigation
+    // happened during the ingest pipeline above, which is invoke-only) —
+    // reload rather than `goto_route` to the identical URL, see
+    // `reload_current_route`. The backend is now known-ready, so the page's
+    // one-shot fetch on remount will find the session immediately.
     reload_current_route(&app).await?;
     app.wait_testid_prefix_present("sessions-row-", UI_TIMEOUT).await.map_err(|e| {
         anyhow::anyhow!("expected a real session row to appear automatically after apply: {e}")

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -224,7 +224,7 @@ everything neither automated layer reaches.
 | 1 First-run → data sources | ✅ | 🟡 wizard redirect + resolve + create only | 🟡 legacy-state + index-redirect regressions only | `windows-journeys/journey-01-first-run-setup.md` |
 | 2 Ingest → reclassify → confirm (move) | ✅ | ✅ real-UI (`inbox_ui_journeys.rs`): mixed-folder split, unclassified-frame-type gate + bulk reclassify, missing-path-attribute gate, Confirm-doesn't-move + Apply-moves-to-shown-path. Root-picker prompt (2+ roots) and stale-plan refusal remain unautomated (follow-up) | ❌ none | `windows-journeys/journey-02-inbox-ingest-move.md` |
 | 3 Ingest → confirm (catalogue-in-place) | ✅ | ✅ real-UI (`inbox_ui_journeys.rs::inbox_ui_catalogue_in_place_zero_moves_byte_identical`): organized root → 0-move catalogue plan, no root picker, no destination-absolute cell, byte-identical apply | ❌ none | `windows-journeys/journey-03-inbox-catalogue-in-place.md` |
-| 4 Sessions review (derived) | ✅ | 🟡 grouping proof only, no UI-invariant checks | 🟡 rows/detail render only | `windows-journeys/journey-04-sessions-review.md` |
+| 4 Sessions review (derived) | ✅ | 🟡 real-UI (`sessions_journeys.rs`): nothing before apply, real session row appears automatically, no review-lifecycle controls anywhere, no-op rescan never duplicates. Notes-edit invariant (Test 4) found untestable — see finding below | 🟡 rows/detail render only | `windows-journeys/journey-04-sessions-review.md` |
 | 5 Project lifecycle | ✅ | 🟡 real-UI (`lifecycle_ui_journeys.rs`): create-wizard makes real `lights/`/`darks/` folders under the registered project library root (PR #414 regression guard) + blocks a duplicate name with a real inline field error. Attach/remove-source UX, manifests/notes, tool launch, artifact watcher still IPC-only | 🟡 transition button only (pill-refresh `test.skip`) | `windows-journeys/journey-05-project-lifecycle.md` |
 | 6 Cleanup scan→review→apply | ✅ | ✅ `cleanup_plan_review` now applies past `approved` via `plans.apply.direct` + asserts the real FS move + audit (2026-07-05) | ❌ none | `windows-journeys/journey-06-cleanup-scan-apply.md` |
 | 7 Archive → delete | ✅ (backend only) | ✅ `archive_lifecycle_apply_trash_permanent_delete` (`archive_journeys.rs`, NEW 2026-07-05): real apply + `archive.list` + `archive.send_to_trash`/`archive.permanently_delete` metadata + `blockPermanentDelete` gate | ❌ none | `windows-journeys/journey-07-archive-delete.md` |
@@ -386,10 +386,20 @@ just test the mock, not the product:
    observing site via the real Settings → Target Planner → Observing Sites
    UI and asserts the Targets page's site-setup prompt is replaced by a real
    `MoonSummary`, with no reload needed (`useSyncExternalStore` reactivity).
-9. **Sessions derived-view invariants** (Journey 4) — absence of
-   review-state controls/pills, notes-edit-doesn't-transition, rescan
-   idempotency; low cost, extends the existing
-   `ingestion_sessions_search` fixture.
+9. **Sessions derived-view invariants** (Journey 4) — DONE (2026-07-05,
+   `crates/e2e-tests/tests/sessions_journeys.rs`): nothing appears before a
+   plan applies, a real session appears automatically post-apply (no review
+   step), no Confirm/Re-open/Reject/Ignore controls anywhere on the page,
+   and a no-op rescan never duplicates the session.
+   **FINDING (real, not fixed here)**: journey-04 Test 4 ("edit a session's
+   Notes field") describes a feature that does not exist —
+   `SessionDetail.tsx` (read in full) has no notes field, and no session
+   notes command exists anywhere in the codebase. Its own doc comment says
+   metadata is edited "post-hoc via the inbox per-file metadata/override
+   tables" instead. This is either a stale journey-doc claim (spec 041
+   FR-051/T076 removed the review lifecycle around the same time) or a
+   feature that never shipped — flagged here rather than silently dropped;
+   worth a follow-up to correct journey-04 or ship the feature.
 10. **Project lifecycle UI surface** (Journey 5) — PARTIALLY DONE
     (2026-07-05, `crates/e2e-tests/tests/lifecycle_ui_journeys.rs`): the
     create-wizard's Tests 1/2 (duplicate-name blocks with a real inline


### PR DESCRIPTION
## Summary
- Adds an automated end-to-end test driving the real Sessions screen, closing a gap where its core invariants (nothing before apply, no leftover review controls, no duplication on rescan) had no automated UI-level proof.
- Covers: Sessions shows nothing until a folder is actually confirmed and applied; a real session then appears automatically with no separate approval step; no old-style review controls (Confirm/Re-open/Reject/Ignore) exist anywhere on the page, matching the intentional removal of that workflow; and re-scanning with no new files never creates a duplicate session.

**Finding while writing this (not fixed here, flagged for follow-up):** the manual test script for this area describes editing a session's Notes field, but no such field (or backend support for it) exists anywhere in the app today — either the manual script is stale or the feature never shipped.

## Test plan
- [x] `cargo test -p e2e_tests --no-run` (compile-only; these tests only run in CI's dedicated end-to-end workflow, which needs a real app window)
- [x] `cargo clippy -p e2e_tests --tests --all-targets -- -D warnings`
- [x] `cargo fmt -p e2e_tests -- --check`
- [ ] CI end-to-end workflow (3-OS matrix) runs the new test for real

Note: like the sibling Calibration/Targets/Settings PRs (#458/#463/#464), this branch carries an identical copy of the shared test-helper additions to `crates/e2e-tests/tests/common/mod.rs` from PR #457, since it was re-rooted from `origin/main` before that PR merged. Whichever merges last should see a no-op diff for that file.

## Spec Context
- Spec: 037
- Branch: 037-ui-journeys-sessions