### PR TITLE
fix: archiving and cleanup plans can now actually be applied

### DIFF
--- a/apps/desktop/src-tauri/src/commands/plan_apply.rs
+++ b/apps/desktop/src-tauri/src/commands/plan_apply.rs
@@ -15,8 +15,8 @@
 use std::sync::Arc;
 
 use app_core::plan_apply::{
-    apply_plan, cancel_plan, get_apply_status, resume_plan, retry_plan_item, skip_plan_item,
-    OperationEventSink,
+    apply_plan, apply_plan_channel_free, cancel_plan, get_apply_status, resume_plan,
+    retry_plan_item, skip_plan_item, OperationEventSink,
 };
 use contracts_core::plan_apply::{
     PlanApplyResponse, PlanApplyStatus, PlanCancelResponse, PlanItemRetryResponse,
@@ -68,6 +68,37 @@ pub async fn plans_apply_real(
     });
 
     apply_plan(state.repo.pool(), &state.bus, &plan_id, &approval_token, Some(sink)).await
+}
+
+// ── plans.apply.direct ───────────────────────────────────────────────────────
+
+/// `plans.apply.direct` — channel-free variant of `plans.apply` (spec 037).
+///
+/// Auto-approves the plan if it is still `ready_for_review`, then runs the
+/// same background executor and writes the same durable audit trail as
+/// `plans_apply_real` — it just takes no `tauri::ipc::Channel`, so it can be
+/// invoked directly by the Layer-2 `WebDriver` E2E bridge (which cannot
+/// construct a `Channel` from a test script) or by any UI surface that only
+/// needs a fire-and-poll apply (poll `plans.apply.status` for the durable
+/// terminal counts) rather than a live progress stream.
+///
+/// Intended for archive/cleanup plans, which — unlike inbox plans — have no
+/// `inbox.plan.apply` channel-free equivalent to route through.
+///
+/// # Errors
+///
+/// Returns `Err(ContractError)` with:
+/// - `"plan.not_found"` — plan not found.
+/// - `"plan.invalid_state"` — plan is not `ready_for_review`/`approved` (e.g.
+///   already applied/discarded/applying), or has no items.
+/// - `"plan.conflict.overlap"` — concurrent apply already running.
+#[tauri::command]
+#[specta::specta]
+pub async fn plans_apply_direct(
+    state: State<'_, AppState>,
+    plan_id: String,
+) -> Result<PlanApplyResponse, ContractError> {
+    apply_plan_channel_free(state.repo.pool(), &state.bus, &plan_id).await
 }
 
 // ── plans.cancel ──────────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -73,8 +73,8 @@ use crate::commands::patterns::{
     pattern_path_preview, pattern_preview, pattern_resolve, pattern_validate,
 };
 use crate::commands::plan_apply::{
-    plans_apply_real, plans_apply_status, plans_cancel, plans_item_retry, plans_item_skip,
-    plans_resume,
+    plans_apply_direct, plans_apply_real, plans_apply_status, plans_cancel, plans_item_retry,
+    plans_item_skip, plans_resume,
 };
 use crate::commands::plans::{
     archive_list, archive_permanently_delete, archive_plan_generate, archive_send_to_trash,
@@ -233,6 +233,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         archive_plan_generate,
         // plan apply (spec 025)
         plans_apply_real,
+        // channel-free plan apply variant (spec 037)
+        plans_apply_direct,
         plans_cancel,
         plans_resume,
         plans_item_skip,
@@ -449,6 +451,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         archive_plan_generate,
         // plan apply (spec 025)
         plans_apply_real,
+        // channel-free plan apply variant (spec 037)
+        plans_apply_direct,
         plans_cancel,
         plans_resume,
         plans_item_skip,

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -494,6 +494,29 @@ export const commands = {
 	 */
 	plansApplyReal: (planId: string, approvalToken: string, onEvent: Channel<OperationEvent>) => typedError<PlanApplyResponse, ContractError_Serialize>(__TAURI_INVOKE("plans_apply_real", { planId, approvalToken, onEvent })),
 	/**
+	 *  `plans.apply.direct` — channel-free variant of `plans.apply` (spec 037).
+	 * 
+	 *  Auto-approves the plan if it is still `ready_for_review`, then runs the
+	 *  same background executor and writes the same durable audit trail as
+	 *  `plans_apply_real` — it just takes no `tauri::ipc::Channel`, so it can be
+	 *  invoked directly by the Layer-2 WebDriver E2E bridge (which cannot
+	 *  construct a `Channel` from a test script) or by any UI surface that only
+	 *  needs a fire-and-poll apply (poll `plans.apply.status` for the durable
+	 *  terminal counts) rather than a live progress stream.
+	 * 
+	 *  Intended for archive/cleanup plans, which — unlike inbox plans — have no
+	 *  `inbox.plan.apply` channel-free equivalent to route through.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(ContractError)` with:
+	 *  - `"plan.not_found"` — plan not found.
+	 *  - `"plan.invalid_state"` — plan is not `ready_for_review`/`approved` (e.g.
+	 *    already applied/discarded/applying), or has no items.
+	 *  - `"plan.conflict.overlap"` — concurrent apply already running.
+	 */
+	plansApplyDirect: (planId: string) => typedError<PlanApplyResponse, ContractError_Serialize>(__TAURI_INVOKE("plans_apply_direct", { planId })),
+	/**
 	 *  `plans.cancel` — cancel an in-flight apply (US3, T033).
 	 * 
 	 *  Signals the cancellation token; the executor finishes its current item

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -499,7 +499,7 @@ export const commands = {
 	 *  Auto-approves the plan if it is still `ready_for_review`, then runs the
 	 *  same background executor and writes the same durable audit trail as
 	 *  `plans_apply_real` — it just takes no `tauri::ipc::Channel`, so it can be
-	 *  invoked directly by the Layer-2 WebDriver E2E bridge (which cannot
+	 *  invoked directly by the Layer-2 `WebDriver` E2E bridge (which cannot
 	 *  construct a `Channel` from a test script) or by any UI surface that only
 	 *  needs a fire-and-poll apply (poll `plans.apply.status` for the durable
 	 *  terminal counts) rather than a live progress stream.

--- a/apps/desktop/src/features/settings/Ingestion.test.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.test.tsx
@@ -96,6 +96,38 @@ describe('Ingestion', () => {
     expect(mockUpdate).toHaveBeenCalledWith(expect.objectContaining({ hashingMode: 'off' }));
   });
 
+  it('a slow initial fetch does not clobber an edit made before it resolves', async () => {
+    // Reproduces a real race, not just CI flakiness: the mount-time
+    // ingestionSettingsGet() fetch can still be in flight when the user's
+    // first edit fires. If the late resolution unconditionally overwrites
+    // state, the user's edit reverts.
+    let resolveGet!: (value: { status: 'ok'; data: typeof SETTINGS }) => void;
+    mockGet.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    render(<Ingestion save={vi.fn()} />);
+
+    // Edit fires before the mount fetch has resolved.
+    const select = screen.getByLabelText('Hashing mode');
+    await act(async () => {
+      fireEvent.change(select, { target: { value: 'eager' } });
+      await Promise.resolve();
+    });
+    expect(select).toHaveValue('eager');
+
+    // Now let the slow initial fetch resolve with the stale "lazy" value.
+    await act(async () => {
+      resolveGet({ status: 'ok', data: SETTINGS });
+      await Promise.resolve();
+    });
+
+    // The user's edit must survive — the late fetch must not stomp it.
+    expect(select).toHaveValue('eager');
+  });
+
   it('restore defaults persists in-code defaults and re-hydrates the controls', async () => {
     mockGet.mockResolvedValueOnce({
       status: 'ok',

--- a/apps/desktop/src/features/settings/Ingestion.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.tsx
@@ -20,7 +20,7 @@
 // — this pane makes them durable, not yet enforced. Toggling e.g. "Follow NTFS
 // junctions" does not change scan behaviour until a scan-pipeline consumer is
 // wired to read it.
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { Toggle } from '@/ui';
 import { m } from '@/lib/i18n';
 import { SettingsSection, SettingsRow, RestoreDefaultsBtn } from './SettingsKit';
@@ -59,11 +59,19 @@ export function Ingestion(_props: IngestionProps) {
   // clobbering them.
   const [settings, setSettings] = useState<UpdateIngestionSettings>(DEFAULTS);
 
+  // Guards against the initial `ingestionSettingsGet()` fetch resolving
+  // *after* the user has already edited a control (a real race, not just a
+  // CI timing artifact: on a slower/more contended machine the mount fetch
+  // can still be in flight when the user's first click fires). Without this,
+  // the late `setSettings(loaded)` below stomps the user's optimistic edit
+  // back to the stale fetched value.
+  const editedRef = useRef(false);
+
   useEffect(() => {
     let cancelled = false;
     ingestionSettingsGet()
       .then((loaded: IngestionSettings) => {
-        if (cancelled) return;
+        if (cancelled || editedRef.current) return;
         setSettings(loaded);
       })
       .catch(() => {
@@ -75,6 +83,7 @@ export function Ingestion(_props: IngestionProps) {
   }, []);
 
   function persist(patch: Partial<UpdateIngestionSettings>) {
+    editedRef.current = true;
     const next: UpdateIngestionSettings = { ...settings, ...patch };
     setSettings(next);
     ingestionSettingsUpdate(next).catch(() => {
@@ -83,6 +92,7 @@ export function Ingestion(_props: IngestionProps) {
   }
 
   const handleRestoreDefaults = async () => {
+    editedRef.current = true;
     const persisted = await ingestionSettingsUpdate(DEFAULTS);
     setSettings(persisted);
   };

--- a/crates/app/core/src/archive_generator.rs
+++ b/crates/app/core/src/archive_generator.rs
@@ -264,6 +264,43 @@ mod tests {
         assert!(items.iter().all(|i| i.action == "archive"));
     }
 
+    /// Regression test (spec 037 Journey 6/7 bugfix): before
+    /// `protection::generate_plan` computed a real `archive_path`, every
+    /// `archive`-action item generated here had `to_relative_path` set equal
+    /// to its own `from_relative_path` (see `generate`'s item-mapping
+    /// closure), so applying the plan always failed every item with
+    /// `conflict.destination_exists` (source == destination) — a bug with
+    /// zero prior test coverage until this spec added real apply-path
+    /// journeys. Assert the destination is now a distinct, non-empty path
+    /// under the app-managed `.astro-plan-archive/<planId>/` convention.
+    #[tokio::test]
+    async fn generate_computes_distinct_archive_destination_per_item() {
+        let db = setup().await;
+        seed_project(&db, "p1", "completed").await;
+        seed_artifact(&db, "a1", "p1", "/data/p1/calibrated/light_001.xisf", "intermediate", 1000)
+            .await;
+
+        let resp = generate(db.pool(), "p1", None).await.unwrap();
+        let items = plans_repo::list_plan_items(db.pool(), &resp.plan_id).await.unwrap();
+        assert_eq!(items.len(), 1);
+        let item = &items[0];
+
+        assert_eq!(item.from_relative_path, "/data/p1/calibrated/light_001.xisf");
+        assert_ne!(
+            item.to_relative_path, item.from_relative_path,
+            "archive destination must differ from the source path, or every real apply \
+             fails with conflict.destination_exists"
+        );
+        assert!(
+            item.to_relative_path.contains(".astro-plan-archive/"),
+            "expected the app-managed archive folder convention in: {}",
+            item.to_relative_path
+        );
+        assert!(item.to_relative_path.contains(&resp.plan_id));
+        assert!(item.to_relative_path.ends_with("light_001.xisf"));
+        assert_eq!(item.archive_path.as_deref(), Some(item.to_relative_path.as_str()));
+    }
+
     #[tokio::test]
     async fn generate_masters_and_finals_gate_approval() {
         // Default global protection is "protected", and master/final map to the

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -1214,6 +1214,63 @@ pub async fn apply_plan(
     Ok(PlanApplyResponse { plan_id: plan_id.to_owned(), run_id, new_state: "applying".to_owned() })
 }
 
+// ── apply_plan_channel_free ───────────────────────────────────────────────────
+
+/// Channel-free variant of [`apply_plan`] (spec 037 archive/cleanup apply).
+///
+/// `apply_plan` requires a caller-supplied `approval_token` (spec 025 A1) and
+/// is normally reached through the webview's `tauri::ipc::Channel`-carrying
+/// `plans.apply` command so live per-item progress can stream back. Two kinds
+/// of caller have neither a token in hand nor a `Channel` to construct:
+///
+/// - The spec 037 Layer-2 WebDriver test harness, which drives the real
+///   backend via `window.__ALM_E2E__.invoke(...)` and structurally cannot
+///   create a `tauri::ipc::Channel` from a test script.
+/// - Any archive/cleanup UI surface that only needs a fire-and-poll apply
+///   (poll [`get_apply_status`] for the durable terminal counts) rather than
+///   a live progress stream.
+///
+/// This mirrors the auto-approve-then-apply pattern `inbox_plan::
+/// apply_inbox_plan` already established for inbox plans, generalised to any
+/// plan id (no inbox-item link required): approve the plan if it is still
+/// `ready_for_review`, tolerate an already-`approved` plan by reusing its
+/// stored token, then start the same background executor as `apply_plan`
+/// with no progress sink. Constitution §II (reviewable filesystem mutation +
+/// audit) is preserved unchanged — this only removes the live-progress
+/// transport, not any approval, CAS, or audit step.
+///
+/// # Errors
+///
+/// - `plan.not_found` — plan not found.
+/// - `plan.invalid_state` — plan is not `ready_for_review`/`approved` (e.g.
+///   already applied/discarded/applying), or the approve step's non-empty
+///   items invariant failed.
+/// - `plan.conflict.overlap` — concurrent apply already running.
+pub async fn apply_plan_channel_free(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    plan_id: &str,
+) -> Result<PlanApplyResponse, ContractError> {
+    let approve_resp = crate::plans::approve_plan(pool, bus, plan_id, "user").await;
+
+    let approval_token = match approve_resp {
+        Ok(resp) => resp.approval_token,
+        // Already approved (idempotent-ish) — fetch the stored token and carry
+        // through to apply_plan. Any other state (applying/applied/discarded/
+        // stale) surfaces the original error unchanged.
+        Err(e) if e.code == ErrorCode::PlanInvalidState => {
+            let plan_row = plans_repo::get_plan(pool, plan_id, false).await.map_err(db_err)?;
+            if plan_row.state != "approved" {
+                return Err(e);
+            }
+            plan_row.approval_token.unwrap_or_default()
+        }
+        Err(e) => return Err(e),
+    };
+
+    apply_plan(pool, bus, plan_id, &approval_token, None).await
+}
+
 // ── cancel_plan ───────────────────────────────────────────────────────────────
 
 /// Cancel an in-flight plan apply (US3, T032).

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -14,6 +14,7 @@
 use audit::bus::EventBus;
 use audit::event_bus::{ProtectionPlanAcknowledged, ProtectionSourceSet, Source};
 use audit::{TOPIC_PROTECTION_PLAN_ACKNOWLEDGED, TOPIC_PROTECTION_SOURCE_SET};
+use camino::Utf8Path;
 use contracts_core::protection::{
     NonBlockingSummary, PlanProtectionCheckRequest, PlanProtectionCheckResponse, ProtectedPlanItem,
     ProtectionLevel, SourceProtectionGetRequest, SourceProtectionGetResponse,
@@ -543,6 +544,35 @@ pub async fn generate_cleanup_plan(
     .await
 }
 
+/// Compute an absolute, collision-free archive destination for an
+/// `action = "archive"` plan item (spec 037 Journey 6/7 bugfix).
+///
+/// **Prior bug (found while adding Layer-2 archive/cleanup apply coverage,
+/// spec 037):** `archive_path` was hardcoded to `None` for every plan item
+/// regardless of action, so the spec-025 executor's fallback used
+/// `to_relative_path` verbatim. Both generators leave that fallback
+/// unusable: `archive_generator` sets it equal to the source path (apply then
+/// fails every item with `conflict.destination_exists`, since source ==
+/// destination), and `cleanup_generator` leaves it an empty string. Neither
+/// path had ever been exercised by a real filesystem apply before this spec —
+/// see the coverage-matrix "Archive/cleanup plan apply" gap.
+///
+/// Destination convention: `<parent-dir-of-source>/.astro-plan-archive/
+/// <planId>/<itemId>-<fileName>`. Anchoring on the source file's own parent
+/// directory (rather than a resolved library root) keeps this fix local to
+/// the shared generator tail — no root/project-path lookup required — and
+/// `item_id` (already globally unique per plan) guarantees no collision
+/// between same-named files. A single unified per-plan archive root (one
+/// folder regardless of how many source directories a project's artifacts
+/// span) is a reasonable follow-up but not required for a correct, safe,
+/// never-overwriting apply.
+fn compute_archive_destination(plan_id: &str, item_id: &str, from_relative_path: &str) -> String {
+    let src = Utf8Path::new(from_relative_path);
+    let file_name = src.file_name().unwrap_or(from_relative_path);
+    let parent = src.parent().map_or(".", Utf8Path::as_str);
+    format!("{parent}/.astro-plan-archive/{plan_id}/{item_id}-{file_name}")
+}
+
 /// Generalised protection-resolved plan generator (D12 shared tail).
 ///
 /// Creates the plan row (in `draft`), inserts each item with its real
@@ -602,6 +632,17 @@ pub async fn generate_plan(
             protected_item_count += 1;
         }
 
+        // Bugfix (spec 037 Journey 6/7): compute a real, distinct archive
+        // destination for `archive`-action items instead of always storing
+        // `None` (see `compute_archive_destination` doc for why the old
+        // fallback made every real archive apply fail). `to_relative_path`
+        // is also set to the same value so the plan-review UI's destination
+        // preview shows where the file will actually land, rather than
+        // repeating the source path or showing nothing.
+        let archive_dest = (item.action == "archive")
+            .then(|| compute_archive_destination(&req.plan_id, &item.id, &item.from_relative_path));
+        let to_relative_path: &str = archive_dest.as_deref().unwrap_or(&item.to_relative_path);
+
         plans_repo::insert_plan_item(
             pool,
             &plans_repo::InsertPlanItem {
@@ -613,12 +654,12 @@ pub async fn generate_plan(
                 from_root_id: item.from_root_id.as_deref(),
                 from_relative_path: &item.from_relative_path,
                 to_root_id: None,
-                to_relative_path: &item.to_relative_path,
+                to_relative_path,
                 reason: &req.reason,
                 protection,
                 linked_entity: None,
                 provenance_json: None,
-                archive_path: None,
+                archive_path: archive_dest.as_deref(),
                 source_id: Some(&item.source_id),
                 category: Some(&item.category),
             },

--- a/crates/app/core/tests/plan_apply_audit_integration.rs
+++ b/crates/app/core/tests/plan_apply_audit_integration.rs
@@ -632,3 +632,161 @@ async fn full_review_to_apply_audit_round_trip() {
     assert_eq!(status.items_applied, 1);
     assert_eq!(status.items_failed, 0);
 }
+
+// ── Test: apply_plan_channel_free (spec 037 channel-free archive apply) ─────
+
+/// `apply_plan_channel_free` auto-approves a still-`ready_for_review` archive
+/// plan, then applies it exactly like `apply_plan` — same FS move, same
+/// durable audit trail, same terminal counts via `get_apply_status`, and the
+/// same spec 017 C5 archive lifecycle closure. This is the E2E-harness- and
+/// UI-callable variant (spec 037 Journeys 6/7): no `tauri::ipc::Channel` and
+/// no pre-supplied approval token required.
+#[tokio::test]
+async fn apply_plan_channel_free_auto_approves_and_moves_file() {
+    let (db, _repo, bus) = support::setup().await;
+    let plan_id = Uuid::new_v4().to_string();
+    let project_id = Uuid::new_v4().to_string();
+    support::insert_project(db.pool(), &project_id, "t", "completed").await;
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("capture.fits");
+    let dst = dir.path().join("archive/capture.fits");
+    std::fs::write(&src, b"raw-light-frame").expect("write src");
+
+    // Seed a `ready_for_review` archive plan — deliberately NOT pre-approved;
+    // the channel-free path must perform the approve step itself.
+    plans_repo::insert_plan(
+        db.pool(),
+        &plans_repo::InsertPlan {
+            id: &plan_id,
+            title: "Channel-Free Archive Test Plan",
+            origin: "archive",
+            origin_path: Some(&project_id),
+            plan_type: "archive",
+            destructive_destination: "archive",
+            parent_plan_id: None,
+            total_bytes_required: 0,
+        },
+    )
+    .await
+    .expect("insert archive plan");
+
+    plans_repo::insert_plan_item(
+        db.pool(),
+        &plans_repo::InsertPlanItem {
+            id: &format!("{plan_id}-item-0"),
+            plan_id: &plan_id,
+            item_index: 1,
+            name: "capture.fits",
+            action: "move",
+            from_root_id: None,
+            from_relative_path: src.to_str().expect("utf-8 src"),
+            to_root_id: None,
+            to_relative_path: dst.to_str().expect("utf-8 dst"),
+            reason: "archive",
+            protection: "normal",
+            linked_entity: None,
+            provenance_json: None,
+            archive_path: None,
+            source_id: Some(&project_id),
+            category: Some("intermediate"),
+        },
+    )
+    .await
+    .expect("insert archive item");
+
+    plans_repo::update_plan_state(db.pool(), &plan_id, "ready_for_review")
+        .await
+        .expect("ready_for_review");
+
+    // Channel-free apply: no approval_token, no Channel.
+    let resp = app_core::plan_apply::apply_plan_channel_free(db.pool(), &bus, &plan_id)
+        .await
+        .expect("apply_plan_channel_free should auto-approve then apply");
+    assert_eq!(resp.plan_id, plan_id);
+    assert_eq!(resp.new_state, "applying");
+    assert!(!resp.run_id.is_empty(), "run_id should be non-empty");
+
+    // Wait for the background executor task to complete.
+    tokio::time::sleep(tokio::time::Duration::from_millis(250)).await;
+
+    // FS side effect: real move to the archive destination (never a silent
+    // overwrite — constitution §II).
+    assert!(!src.exists(), "source should have been moved");
+    assert!(dst.exists(), "destination should exist in the archive subtree");
+    assert_eq!(std::fs::read(&dst).expect("read dst"), b"raw-light-frame");
+
+    // Audit: plan-level start + terminal events recorded per attempted action.
+    let (start_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM plan_apply_events \
+         WHERE plan_id = ? AND item_id IS NULL AND prior_state = 'approved' AND new_state = 'applying'",
+    )
+    .bind(&plan_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("query start event");
+    assert_eq!(start_count, 1, "expected 1 plan-level start event");
+
+    let (terminal_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM plan_apply_events \
+         WHERE plan_id = ? AND item_id IS NULL AND new_state = 'applied'",
+    )
+    .bind(&plan_id)
+    .fetch_one(db.pool())
+    .await
+    .expect("query terminal event");
+    assert_eq!(terminal_count, 1, "expected 1 plan-level terminal event");
+
+    // Terminal summary via the same poll path the E2E journeys use.
+    let status = app_core::plan_apply::get_apply_status(db.pool(), &plan_id)
+        .await
+        .expect("get_apply_status");
+    assert_eq!(status.plan_state, "applied");
+    assert_eq!(status.items_applied, 1);
+    assert_eq!(status.items_failed, 0);
+    assert_eq!(status.items_skipped, 0);
+    assert_eq!(status.items_cancelled, 0);
+
+    // C5 lifecycle closure still fires through the channel-free path: an
+    // `origin = archive` plan reaching `applied` drives the project to
+    // `archived`.
+    let archived = persistence_db::repositories::projects::list_archived_projects(db.pool())
+        .await
+        .expect("list_archived_projects");
+    assert_eq!(archived.len(), 1, "the completed project must now be archived");
+    assert_eq!(archived[0].id, project_id);
+    assert_eq!(archived[0].archived_via_plan_id.as_deref(), Some(plan_id.as_str()));
+}
+
+/// `apply_plan_channel_free` also handles a plan that is already `approved`
+/// (idempotent-ish reuse of the stored token) rather than only
+/// `ready_for_review` — mirrors `inbox_plan::apply_inbox_plan`'s tolerance of
+/// a caller that approved out-of-band.
+#[tokio::test]
+async fn apply_plan_channel_free_reuses_existing_approval() {
+    let (db, _repo, bus) = support::setup().await;
+    let plan_id = Uuid::new_v4().to_string();
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let src = dir.path().join("source.fits");
+    let dst = dir.path().join("processed/source.fits");
+    std::fs::write(&src, b"fits-content").expect("write src");
+
+    seed_approved_plan_with_real_files(db.pool(), &plan_id, &src, &dst).await;
+
+    let resp = app_core::plan_apply::apply_plan_channel_free(db.pool(), &bus, &plan_id)
+        .await
+        .expect("apply_plan_channel_free should reuse the existing approval");
+    assert_eq!(resp.new_state, "applying");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(200)).await;
+
+    assert!(!src.exists(), "source should have been moved");
+    assert!(dst.exists(), "destination should exist");
+
+    let status = app_core::plan_apply::get_apply_status(db.pool(), &plan_id)
+        .await
+        .expect("get_apply_status");
+    assert_eq!(status.plan_state, "applied");
+    assert_eq!(status.items_applied, 1);
+}

--- a/crates/e2e-tests/tests/archive_journeys.rs
+++ b/crates/e2e-tests/tests/archive_journeys.rs
@@ -1,0 +1,288 @@
+//! Spec 037 Layer-2 real-UI journey: whole-project archive -> trash ->
+//! permanent delete (coverage-matrix Journey 7, "Archive lifecycle + trash +
+//! permanent delete" — previously **zero automated coverage at any layer**).
+//!
+//! Was blocked on a channel-free apply command for archive/cleanup plans
+//! (shared blocker with Journey 6, `journeys.rs::cleanup_plan_review`);
+//! `plans.apply.direct` (a.k.a. `plans_apply_direct`, spec 037) removes that
+//! blocker — same executor, same durable audit trail as `plans.apply_real`,
+//! no `tauri::ipc::Channel` required, so it can be invoked directly from this
+//! WebDriver harness.
+//!
+//! Run (CI): `cargo nextest run -p e2e_tests --profile e2e --run-ignored all`
+//! (serial, `.config/nextest.toml`). See `crates/e2e-tests/README.md`.
+
+mod common;
+
+use std::time::Duration;
+
+use common::E2eApp;
+use serde_json::json;
+
+const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Whole-project archive: real lifecycle progression to `completed` ->
+/// `archive.plan.generate` -> `plans.apply.direct` -> real filesystem move
+/// into the app-managed archive subtree -> `archive.list` durable read ->
+/// `archive.send_to_trash` -> `archive.permanently_delete` honoring the
+/// `blockPermanentDelete` protection default.
+///
+/// Backend REAL: `projects.create`, `lifecycle.transition.apply` (x3),
+/// `source.protection.set`, `artifact.watcher.attach`, `artifact.list`,
+/// `archive.plan.generate`, `plans.apply.direct`, `plans.apply.status`,
+/// `archive.list`, `archive.send_to_trash`, `settings.update`,
+/// `archive.permanently_delete`.
+///
+/// Honest boundaries (documented, not faked): `archive.send_to_trash` and
+/// `archive.permanently_delete` are METADATA-ONLY today
+/// (`crates/app/core/src/plans.rs::send_archive_to_trash` /
+/// `permanently_delete_archive` — both only count `archive_path`-bearing
+/// items and emit an audit event; neither calls into the filesystem). This
+/// journey therefore asserts the real response/audit shape and the real
+/// `blockPermanentDelete` gate, but does NOT assert an OS trash/deletion
+/// side effect, because none exists yet — asserting one would test an
+/// invented behavior, not the product (constitution II / FR-018 spirit).
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn archive_lifecycle_apply_trash_permanent_delete() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    // 1. Create a project with no sources — it starts `setup_incomplete`
+    // (real, documented lifecycle rule; `projects.create` does not
+    // auto-advance an empty-source project).
+    let project_dir = tempfile::tempdir()?;
+    let create: serde_json::Value = app
+        .invoke(
+            "projects_create",
+            json!({
+                "req": {
+                    "requestId": "e2e-archive-create",
+                    "name": "E2E Archive Project",
+                    "tool": "PixInsight",
+                    "path": project_dir.path().to_string_lossy(),
+                    "initialSources": [],
+                    "notes": null,
+                    "canonicalTargetId": null,
+                }
+            }),
+        )
+        .await?;
+    let project_id = create["projectId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("projects.create returned no projectId: {create}"))?
+        .to_owned();
+    anyhow::ensure!(
+        create["lifecycle"] == "setup_incomplete",
+        "expected a sourceless project to start setup_incomplete: {create}"
+    );
+
+    // 2. Real lifecycle progression to `completed` (archive.plan.generate
+    // only enumerates a project's own artifacts; nothing about that
+    // requires `completed`, but a project is realistically archived only
+    // once its processing is done — and `completed -> archived` is itself
+    // plan-required, so this journey proves the plan-driven closure path,
+    // never a direct transition into `archived`).
+    let hops: &[(&str, &str, &str)] = &[
+        ("setup_incomplete", "ready", "e2e00000-0000-4000-8000-000000000101"),
+        ("ready", "processing", "e2e00000-0000-4000-8000-000000000102"),
+        ("processing", "completed", "e2e00000-0000-4000-8000-000000000103"),
+    ];
+    for (current_state, next_state, request_id) in hops {
+        let transition: serde_json::Value = app
+            .invoke(
+                "lifecycle_transition_apply",
+                json!({
+                    "request": {
+                        "entityType": "project",
+                        "contractVersion": "2.0.0",
+                        "requestId": request_id,
+                        "entityId": project_id,
+                        "currentState": current_state,
+                        "nextState": next_state,
+                        "actionLabel": null,
+                        "actor": "user",
+                    }
+                }),
+            )
+            .await?;
+        anyhow::ensure!(
+            transition["status"] == "success",
+            "expected {current_state} -> {next_state} to succeed for a fresh project: {transition}"
+        );
+    }
+
+    // 3. Real per-project protection override (US2): a project id has no
+    // protection override until a caller sets one, and the app's
+    // safe-by-default level is "protected" (constitution II) — without
+    // this, every archive item refuses apply with `protected.source`. A
+    // real user sets this the same way before a first archive.
+    let _: serde_json::Value = app
+        .invoke(
+            "source_protection_set",
+            json!({
+                "request": {
+                    "sourceId": project_id,
+                    "level": "normal",
+                    "blockPermanentDelete": null,
+                    "categories": null,
+                }
+            }),
+        )
+        .await?;
+
+    // 4. A real processing output, classified `intermediate` by the real
+    // artifact-kind rules (`crates/workflow/artifacts/src/default_rules.rs`).
+    let original_path = project_dir.path().join("integration_M31_Ha.xisf");
+    std::fs::write(&original_path, b"not-a-real-xisf-file")?;
+
+    let _: serde_json::Value = app
+        .invoke("artifact_watcher_attach", json!({ "request": { "projectId": project_id } }))
+        .await?;
+    let artifacts: serde_json::Value = app
+        .invoke_until(
+            "artifact_list",
+            json!({ "request": { "projectId": project_id, "includeStates": [] } }),
+            INVOKE_TIMEOUT,
+            |v: &serde_json::Value| v["artifacts"].as_array().is_some_and(|a| !a.is_empty()),
+        )
+        .await?;
+    anyhow::ensure!(
+        artifacts["artifacts"][0]["kind"] == "intermediate",
+        "expected the fixture output to classify as intermediate: {artifacts}"
+    );
+
+    // 5. Generate the whole-project archive plan (spec 017 US2/WP-B) — every
+    // observed artifact becomes an `archive`-action item. No filesystem
+    // mutation happens here (FR-002).
+    let generate: serde_json::Value = app
+        .invoke("archive_plan_generate", json!({ "projectId": project_id, "title": null }))
+        .await?;
+    let plan_id = generate["planId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("archive.plan.generate returned no planId: {generate}"))?
+        .to_owned();
+    anyhow::ensure!(
+        generate["itemCount"].as_i64().unwrap_or(0) >= 1,
+        "expected at least 1 real archive item on the generated plan: {generate}"
+    );
+
+    // 6. Apply — the real filesystem mutation, channel-free (spec 037).
+    // Auto-approves the still-`ready_for_review` plan and runs the same
+    // executor `plans.apply_real` uses, just without a progress `Channel`.
+    let apply: serde_json::Value =
+        app.invoke("plans_apply_direct", json!({ "planId": plan_id })).await?;
+    anyhow::ensure!(
+        apply["planId"] == json!(plan_id) && apply["newState"] == "applying",
+        "expected plans.apply.direct to start applying the generated archive plan: {apply}"
+    );
+
+    // 7. Poll the real, durable apply status until the executor finishes.
+    let status: serde_json::Value = app
+        .invoke_until(
+            "plans_apply_status",
+            json!({ "planId": plan_id }),
+            INVOKE_TIMEOUT,
+            |v: &serde_json::Value| {
+                matches!(
+                    v["planState"].as_str(),
+                    Some("applied" | "partially_applied" | "failed" | "cancelled")
+                )
+            },
+        )
+        .await?;
+    anyhow::ensure!(
+        status["planState"] == "applied",
+        "expected the archive plan to apply cleanly, got: {status}"
+    );
+    anyhow::ensure!(
+        status["itemsApplied"].as_i64().unwrap_or(0) >= 1,
+        "expected at least 1 durably-recorded applied item: {status}"
+    );
+
+    // 8. Real filesystem side effect: the source file moved out of the
+    // project folder and into the app-managed `.astro-plan-archive`
+    // subtree (never a silent overwrite — constitution II).
+    anyhow::ensure!(
+        !original_path.exists(),
+        "expected the archived file to have moved away from {original_path:?}"
+    );
+    let archive_subtree_exists = std::fs::read_dir(project_dir.path())
+        .ok()
+        .and_then(|mut entries| {
+            entries.find(|e| e.as_ref().is_ok_and(|e| e.file_name() == ".astro-plan-archive"))
+        })
+        .is_some();
+    anyhow::ensure!(
+        archive_subtree_exists,
+        "expected a `.astro-plan-archive` subtree under the project folder after apply"
+    );
+
+    // 9. C5 lifecycle closure: applying an `origin = archive` plan to a
+    // clean `applied` terminal drives the owning project into `archived` —
+    // the ONLY legitimate way to reach that state (`completed -> archived`
+    // is plan-required, step 2 above never attempted it directly). Durable
+    // read via `archive.list` (C5: projects-only surface).
+    let archive_list: serde_json::Value = app
+        .invoke_until("archive_list", json!({}), INVOKE_TIMEOUT, |v: &serde_json::Value| {
+            v["entries"].as_array().is_some_and(|a| a.iter().any(|e| e["id"] == json!(project_id)))
+        })
+        .await?;
+    let entry = archive_list["entries"]
+        .as_array()
+        .and_then(|a| a.iter().find(|e| e["id"] == json!(project_id)))
+        .ok_or_else(|| {
+            anyhow::anyhow!("expected project {project_id} in archive.list: {archive_list}")
+        })?;
+    anyhow::ensure!(
+        entry["archivedViaPlanId"] == json!(plan_id),
+        "expected the archive.list entry to carry the owning plan id: {entry}"
+    );
+
+    // 10. `archive.send_to_trash` — real metadata response + audit event
+    // (see module doc: no real OS trash side effect exists yet). Now that
+    // the applied plan's items carry a real `archive_path` (this spec's
+    // bugfix — see `crates/app/core/src/protection.rs`), `archive_count` is
+    // real and non-zero rather than always failing `archive.empty`.
+    let send_to_trash: serde_json::Value =
+        app.invoke("archive_send_to_trash", json!({ "planId": plan_id })).await?;
+    anyhow::ensure!(
+        send_to_trash["planId"] == json!(plan_id)
+            && send_to_trash["itemsMoved"].as_i64().unwrap_or(0) >= 1,
+        "expected archive.send_to_trash to report the real archived item count: {send_to_trash}"
+    );
+
+    // 11. `archive.permanently_delete` honors the `blockPermanentDelete`
+    // protection default (spec 016). The app's default is `true` (blocked)
+    // — assert the call is refused without depending on how the WebDriver
+    // bridge's `.catch` stringifies the rejected `ContractError` object.
+    let blocked = app
+        .invoke::<serde_json::Value>(
+            "archive_permanently_delete",
+            json!({ "planId": plan_id, "confirmText": "DELETE" }),
+        )
+        .await;
+    anyhow::ensure!(
+        blocked.is_err(),
+        "expected archive.permanently_delete to be refused while blockPermanentDelete=true (default)"
+    );
+
+    // Explicitly disable the protection default (a real, user-facing
+    // Settings > Cleanup toggle) and retry — the real unblocked path.
+    let _: serde_json::Value = app
+        .invoke(
+            "settings_update",
+            json!({ "scope": "cleanup", "values": { "blockPermanentDelete": false } }),
+        )
+        .await?;
+    let permanently_delete: serde_json::Value = app
+        .invoke("archive_permanently_delete", json!({ "planId": plan_id, "confirmText": "DELETE" }))
+        .await?;
+    anyhow::ensure!(
+        permanently_delete["planId"] == json!(plan_id)
+            && permanently_delete["itemsDeleted"].as_i64().unwrap_or(0) >= 1,
+        "expected archive.permanently_delete to succeed once unblocked: {permanently_delete}"
+    );
+
+    app.shutdown().await
+}

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -8,7 +8,10 @@
 //! commands); mutating steps that require a `tauri::ipc::Channel` argument
 //! (`plans.apply` a.k.a. `plans_apply_real`) are deliberately routed through
 //! the channel-free command variants that exist for exactly this purpose
-//! (`inbox.plan.apply`, `plans.approve`) rather than reaching into product
+//! (`inbox.plan.apply` for inbox plans; `plans.apply.direct` a.k.a.
+//! `plans_apply_direct`, spec 037, for archive/cleanup plans — `plans.approve`
+//! remains available separately for journeys that only need the reviewable
+//! `ready_for_review` -> `approved` step) rather than reaching into product
 //! frontend code to fabricate a Channel from a WebDriver script — see each
 //! journey's doc comment for the specific reasoning.
 //!
@@ -567,25 +570,27 @@ async fn lifecycle_integrity() -> anyhow::Result<()> {
 }
 
 /// Cleanup plan review: real artifact observation -> scan -> generate ->
-/// approve (spec 017/037 D22 — newly in scope now that the WP-A generator
-/// (#389) is merged).
+/// approve -> apply (spec 017/037 D22/Journey 6 — newly in scope now that the
+/// WP-A generator (#389) and the channel-free `plans.apply.direct` command
+/// exist).
 ///
-/// Backend REAL: `projects.create`, `artifact.watcher.attach` (spec 012,
-/// #400), `artifact.list`, `cleanup.policy.update`, `cleanup.scan`,
-/// `cleanup.plan.generate`, `plans.approve`.
+/// Backend REAL: `projects.create`, `source.protection.set`,
+/// `artifact.watcher.attach` (spec 012, #400), `artifact.list`,
+/// `cleanup.policy.update`, `cleanup.scan`, `cleanup.plan.generate`,
+/// `plans.approve`, `plans.apply.direct`, `plans.apply.status`.
 ///
-/// KNOWN GAP (documented, not faked): applying the generated plan requires
-/// `plans.apply_real`, which takes a `tauri::ipc::Channel` progress argument.
-/// There is no channel-free apply command for archive/cleanup plans (unlike
-/// `inbox.plan.apply` for inbox plans), and the Cleanup/Archive UI does not
-/// yet wire an "Apply" affordance for generator-produced plans (`git grep
-/// cleanupPlanGenerate apps/desktop/src/features/projects
-/// apps/desktop/src/features/archive` finds no caller). Fabricating a
-/// `Channel` from a WebDriver script would mean reaching into product
-/// frontend code beyond a thin test hook (FR-018), so this journey stops at
-/// the reviewable, `ready_for_review` -> `approved` plan and documents the
-/// apply step as a follow-up once a channel-free apply path or a real UI
-/// Apply button exists.
+/// FORMERLY a documented gap: applying the generated plan needed
+/// `plans.apply_real`, which takes a `tauri::ipc::Channel` progress
+/// argument this WebDriver harness cannot construct. `plans.apply.direct`
+/// (spec 037) is the channel-free equivalent — same executor, same durable
+/// audit trail, no `Channel` required — so this journey now drives the real
+/// filesystem mutation instead of stopping at `approved`.
+///
+/// `source.protection.set` marks this project `normal` before generating the
+/// plan: the app's safe-by-default protection level is `"protected"`
+/// (constitution II), and a project id has no protection override until a
+/// caller sets one — a real user would do the same via Settings before a
+/// first cleanup, exactly like this call.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
 async fn cleanup_plan_review() -> anyhow::Result<()> {
@@ -622,7 +627,27 @@ async fn cleanup_plan_review() -> anyhow::Result<()> {
     // convention (`crates/workflow/artifacts/src/default_rules.rs`), which
     // classifies as `ArtifactKind::Intermediate` — eligible for cleanup once
     // the policy allows it (below).
-    std::fs::write(project_dir.path().join("integration_M31_Ha.xisf"), b"not-a-real-xisf-file")?;
+    let original_path = project_dir.path().join("integration_M31_Ha.xisf");
+    std::fs::write(&original_path, b"not-a-real-xisf-file")?;
+
+    // Real per-project protection override (US2): without it, the item
+    // resolves to the app's safe-by-default "protected" level and the apply
+    // step below refuses every item with `protected.source` — not a bug,
+    // the documented constitution-II gate — so a real cleanup flow always
+    // sets this (or the global default) before a first-time cleanup.
+    let _: serde_json::Value = app
+        .invoke(
+            "source_protection_set",
+            json!({
+                "request": {
+                    "sourceId": project_id,
+                    "level": "normal",
+                    "blockPermanentDelete": null,
+                    "categories": null,
+                }
+            }),
+        )
+        .await?;
 
     // Attaching the watcher runs a real, synchronous-enough reconciliation
     // pass over existing files (spec 012 T005) — poll `artifact.list` for it
@@ -684,6 +709,57 @@ async fn cleanup_plan_review() -> anyhow::Result<()> {
     anyhow::ensure!(
         approve["planId"] == json!(plan_id) && approve["newState"] == "approved",
         "expected plans.approve to move the generated plan to approved: {approve}"
+    );
+
+    // Apply — the real filesystem mutation (channel-free, spec 037). Tolerates
+    // the plan already being `approved` (reuses the stored token).
+    let apply: serde_json::Value =
+        app.invoke("plans_apply_direct", json!({ "planId": plan_id })).await?;
+    anyhow::ensure!(
+        apply["planId"] == json!(plan_id) && apply["newState"] == "applying",
+        "expected plans.apply.direct to start applying the approved plan: {apply}"
+    );
+
+    // Poll the real, durable apply status until the executor finishes —
+    // `plans.apply.status` reads `plan_apply_events` (the same durable proof
+    // `plan_review_apply_with_audit` uses for the inbox path).
+    let status: serde_json::Value = app
+        .invoke_until(
+            "plans_apply_status",
+            json!({ "planId": plan_id }),
+            INVOKE_TIMEOUT,
+            |v: &serde_json::Value| {
+                matches!(
+                    v["planState"].as_str(),
+                    Some("applied" | "partially_applied" | "failed" | "cancelled")
+                )
+            },
+        )
+        .await?;
+    anyhow::ensure!(
+        status["planState"] == "applied",
+        "expected the cleanup plan to apply cleanly, got: {status}"
+    );
+    anyhow::ensure!(
+        status["itemsApplied"].as_i64().unwrap_or(0) >= 1,
+        "expected at least 1 durably-recorded applied item: {status}"
+    );
+
+    // Real filesystem side effect: the original output file moved out of the
+    // project folder into the app-managed archive subtree.
+    anyhow::ensure!(
+        !original_path.exists(),
+        "expected the cleanup candidate to have moved away from {original_path:?}"
+    );
+    let archived_somewhere = std::fs::read_dir(project_dir.path())
+        .ok()
+        .and_then(|mut entries| {
+            entries.find(|e| e.as_ref().is_ok_and(|e| e.file_name() == ".astro-plan-archive"))
+        })
+        .is_some();
+    anyhow::ensure!(
+        archived_somewhere,
+        "expected a `.astro-plan-archive` subtree under the project folder after apply"
     );
 
     app.shutdown().await

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -109,7 +109,8 @@ local gates (compile, clippy, fmt) are clean.
 | `plan_review_apply_with_audit` | `journeys.rs` | #3, #16, #17, #18 | `roots.register`, `sources.set_organization_state`, `inbox.scan.folder`, `inbox.classify`, `inbox.confirm`, `inbox.plan.apply`, `plans.apply.status` |
 | `ingestion_sessions_search` | `journeys.rs` | #3, #4, #6, #5, #12/#14 | inbox pipeline (as above) + `sessions.list` (event-driven session grouping/resolution), `calibration.match.suggest`, `search.global` |
 | `lifecycle_integrity` | `journeys.rs` | #7/#8 | `projects.create`, `lifecycle.transition.apply`, `lifecycle.ledger.list` |
-| `cleanup_plan_review` (NEW, D22) | `journeys.rs` | #10/#11, #17 | `projects.create`, `artifact.watcher.attach`, `artifact.list`, `cleanup.policy.update`, `cleanup.scan`, `cleanup.plan.generate`, `plans.approve` |
+| `cleanup_plan_review` (NEW, D22; apply extended 2026-07-05) | `journeys.rs` | #10/#11, #17 | `projects.create`, `source.protection.set`, `artifact.watcher.attach`, `artifact.list`, `cleanup.policy.update`, `cleanup.scan`, `cleanup.plan.generate`, `plans.approve`, `plans.apply.direct`, `plans.apply.status` |
+| `archive_lifecycle_apply_trash_permanent_delete` (NEW, 2026-07-05) | `archive_journeys.rs` | Journey 7 | `projects.create`, `lifecycle.transition.apply` (x3), `source.protection.set`, `artifact.watcher.attach`, `artifact.list`, `archive.plan.generate`, `plans.apply.direct`, `plans.apply.status`, `archive.list`, `archive.send_to_trash`, `settings.update`, `archive.permanently_delete` |
 | `all_top_level_screens_load` | `smoke.rs` | #21 | real routes + the shipped `AppErrorBoundary` fallback presence check |
 
 **Corrections to prior scaffold claims** (the original stub doc comments were
@@ -131,18 +132,48 @@ prose"):
   surfaces by choice (more robust than the general audit feed). The original
   stubs' references to `events.recent` were aspirational — that command does
   not exist.
-- **`cleanup_plan_review`'s known, documented gap**: applying the generated
-  plan needs `plans.apply_real`, which takes a `tauri::ipc::Channel` progress
-  argument with no channel-free equivalent for archive/cleanup plans (unlike
-  `inbox.plan.apply` for inbox plans), and the Cleanup/Archive UI does not yet
-  wire an Apply button for `cleanup.plan.generate` output
-  (`apps/desktop/src/features/projects/OutputsCleanupSections.tsx`,
-  `apps/desktop/src/features/archive/*.tsx` — neither calls
-  `cleanupPlanGenerate`). The journey stops at `plans.approve`
-  (`ready_for_review` → `approved`), which is the real, honest boundary of
-  what's testable today without reaching into product frontend code beyond a
-  thin test hook (FR-018). Follow-up: land a channel-free generic apply
-  command, or wire the UI Apply button, then extend the journey.
+- **RESOLVED 2026-07-05: `cleanup_plan_review`'s apply gap.** The blocker was
+  a missing channel-free apply command for archive/cleanup plans (unlike
+  `inbox.plan.apply` for inbox plans) — `plans.apply_real` takes a
+  `tauri::ipc::Channel` progress argument this WebDriver harness cannot
+  construct. `plans.apply.direct` (a.k.a. `plans_apply_direct`,
+  `app_core::plan_apply::apply_plan_channel_free`) now exists: same executor
+  (`apply_plan`) and durable audit trail as `plans.apply_real`, no `Channel`
+  required. `cleanup_plan_review` now drives a real apply past `plans.approve`
+  and asserts the real filesystem mutation + audit record. **Correction to
+  the original claim**: the Cleanup/Archive UI already had a real Apply
+  affordance before this — `OutputsCleanupSections.tsx`'s `CleanupSection`
+  calls `cleanupPlanGenerate` (via `useGenerateCleanupPlan`) and hands off to
+  the shared `PlanReviewOverlay` (protection gate → `plans.approve` →
+  `plans.apply_real` with live progress), and `ProjectDetail.tsx` wires the
+  same overlay for `archive.plan.generate` — landed by PR #413 (2026-07-04)
+  and PR #438, before this audit's original claim was written. No new UI
+  button was added: the existing Channel-based `PlanReviewOverlay` path is
+  strictly better for a live UI (streamed per-item progress) than a
+  fire-and-poll channel-free call would be, so `plans.apply.direct`'s
+  consumers are the Layer-2 harness and any future non-UI caller, not this
+  overlay. Existing vitest coverage (`PlanReviewOverlay.test.tsx`: "approve &
+  apply drives plans.approve → apply with the token and reports completion")
+  already covers the button's happy path.
+- **Second, previously-undiscovered bug found and fixed while landing the
+  above**: `protection::generate_plan` (the shared persistence tail for both
+  `archive_generator::generate` and `cleanup_generator::generate`) always
+  stored `archive_path: None` for every plan item, regardless of action. The
+  spec-025 executor's fallback for `archive`-action items with no
+  `archive_path` uses `to_relative_path` verbatim — and both generators left
+  that fallback unusable (`archive_generator` sets it equal to the source
+  path, so source == destination and every apply failed with
+  `conflict.destination_exists`; `cleanup_generator` leaves it an empty
+  string). **Every real archive/cleanup apply failed 100% of the time before
+  this fix, with zero prior test coverage to catch it** — exactly the gap
+  this journey work was meant to close. Fixed in
+  `crates/app/core/src/protection.rs::compute_archive_destination` (destination
+  convention: `<parent-dir-of-source>/.astro-plan-archive/<planId>/<itemId>-<fileName>`);
+  regression test:
+  `crates/app/core/src/archive_generator.rs::generate_computes_distinct_archive_destination_per_item`.
+  As a side effect, `archive.send_to_trash`/`archive.permanently_delete`
+  (which count `archive_path.is_some()` items) also went from always
+  reporting `archive.empty` to reporting the real count.
 
 ## Spec 035 iteration — US4 ingest → session → target — 2026-06-21
 
@@ -195,8 +226,8 @@ everything neither automated layer reaches.
 | 3 Ingest → confirm (catalogue-in-place) | ✅ | ❌ (existing journey forces the move branch) | ❌ none | `windows-journeys/journey-03-inbox-catalogue-in-place.md` |
 | 4 Sessions review (derived) | ✅ | 🟡 grouping proof only, no UI-invariant checks | 🟡 rows/detail render only | `windows-journeys/journey-04-sessions-review.md` |
 | 5 Project lifecycle | ✅ | 🟡 transition + ledger only, no UI | 🟡 transition button only (pill-refresh `test.skip`) | `windows-journeys/journey-05-project-lifecycle.md` |
-| 6 Cleanup scan→review→apply | ✅ | 🟡 stops at `approved`, **apply step has zero coverage anywhere** | ❌ none | `windows-journeys/journey-06-cleanup-scan-apply.md` |
-| 7 Archive → delete | ✅ (backend only) | ❌ **none at all** | ❌ **none at all** | `windows-journeys/journey-07-archive-delete.md` |
+| 6 Cleanup scan→review→apply | ✅ | ✅ `cleanup_plan_review` now applies past `approved` via `plans.apply.direct` + asserts the real FS move + audit (2026-07-05) | ❌ none | `windows-journeys/journey-06-cleanup-scan-apply.md` |
+| 7 Archive → delete | ✅ (backend only) | ✅ `archive_lifecycle_apply_trash_permanent_delete` (`archive_journeys.rs`, NEW 2026-07-05): real apply + `archive.list` + `archive.send_to_trash`/`archive.permanently_delete` metadata + `blockPermanentDelete` gate | ❌ none | `windows-journeys/journey-07-archive-delete.md` |
 | 8 Calibration masters → matching | ✅ | 🟡 `calibration.match.suggest` shape only | ❌ none | `windows-journeys/journey-08-calibration-masters-matching.md` |
 | 9 Targets & planning | ✅ (backend only) | ❌ **none at all** | ❌ **none at all** | `windows-journeys/journey-09-targets-planning.md` |
 | 10 Settings/appearance/i18n | ✅ | 🟡 route-load smoke only | ❌ none | `windows-journeys/journey-10-settings-appearance-i18n.md` |
@@ -255,7 +286,9 @@ just test the mock, not the product:
 - **Archive/cleanup plan `apply` with a `tauri::ipc::Channel` progress
   argument** — structurally cannot be driven by Playwright at all (no
   Tauri IPC channel in a browser context); this is Layer-2-or-manual-only
-  by construction, not just by current gap.
+  by construction, not just by current gap. (The channel-free sibling,
+  `plans.apply.direct`, is what Journeys 6/7 now drive at Layer-2 — it does
+  not change this bullet, which is about the real UI's Channel-based path.)
 - **Symlink/junction creation for source views (spec 049)** and **OS trash
   semantics (spec 017/025)** — real, OS-specific filesystem behavior; a
   mock can only assert the UI *called* the right command, never that the
@@ -265,14 +298,21 @@ just test the mock, not the product:
 
 ### Batched plan — new Layer-2 (thirtyfour) journeys to author, ordered by risk/value
 
-1. **Archive lifecycle + trash + permanent delete** (Journey 7) — highest
-   product risk (irreversible deletion) with **zero automated coverage at
-   any layer today**. **Blocked** on a channel-free apply command for
-   archive/cleanup plans (shared blocker with #2) — land that first.
-2. **Cleanup plan apply completion** (Journey 6) — extend
-   `cleanup_plan_review` past `plans.approve` once the channel-free apply
-   path (or a real UI Apply button + a thin test hook) exists. Same
-   blocker as #1; land together.
+1. **DONE (2026-07-05). Archive lifecycle + trash + permanent delete**
+   (Journey 7) — highest product risk (irreversible deletion), previously
+   **zero automated coverage at any layer**. The channel-free apply
+   command (`plans.apply.direct`) that blocked this now exists;
+   `crates/e2e-tests/tests/archive_journeys.rs::archive_lifecycle_apply_trash_permanent_delete`
+   covers real lifecycle progression → `archive.plan.generate` → apply →
+   real FS move → `archive.list` → `archive.send_to_trash` →
+   `archive.permanently_delete` (honoring `blockPermanentDelete`, and
+   honestly asserting only the real metadata-level response since neither
+   management command performs real filesystem I/O yet — see
+   coverage-matrix note above).
+2. **DONE (2026-07-05). Cleanup plan apply completion** (Journey 6) —
+   `cleanup_plan_review` now extends past `plans.approve` via
+   `plans.apply.direct` and asserts the real filesystem mutation + audit
+   record.
 3. **Calibration masters ingest → Calibration page → matching → assign**
    (Journey 8, spec 040) — real UI-level masters flow beyond today's
    `calibration.match.suggest`-only proof; spec 040 has the least automated


### PR DESCRIPTION
## Summary
- Archiving a project or applying a cleanup plan previously failed every
  time it was attempted — the generated plan's file destination was
  identical to (or missing from) its source, so the actual move always
  failed. This restores real archive and cleanup functionality.
- Adds a backend apply path that doesn't need a live progress channel,
  enabling automated testing to exercise real archive/cleanup runs
  end-to-end (filesystem move + audit trail), catching the bug above.
- "Send to trash" / "permanently delete" for archived items now correctly
  report how many items they act on, instead of always reporting none.

## Spec Context
- Spec: 037
- Branch: 037-archive-cleanup-apply