### PR TITLE
test: add real end-to-end project creation wizard journey

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -780,7 +780,7 @@ impl E2eApp {
     /// Polling is the fix — the same wait primitive the `data-testid`
     /// helpers above already use, applied to the aria-label / button-text
     /// locators too.
-    async fn find_waiting(&self, by: By, what: &str) -> Result<WebElement> {
+    pub async fn find_waiting(&self, by: By, what: &str) -> Result<WebElement> {
         let deadline = Instant::now() + DEFAULT_FIND_TIMEOUT;
         loop {
             match self.driver.find(by.clone()).await {
@@ -897,6 +897,92 @@ impl E2eApp {
             ));
         }
         Ok(())
+    }
+
+    /// Fill an `<input>`/`<select>`-less text field located by its exact
+    /// `aria-label` (clear then type) — for real form fields that carry no
+    /// `data-testid` (e.g. `TargetSearch`'s combobox input). Polls for the
+    /// element (via [`Self::find_waiting`]) rather than doing a single
+    /// immediate lookup, so it survives the same route-render race
+    /// `find_waiting` documents.
+    pub async fn fill_by_aria_label(&self, label: &str, value: &str) -> Result<()> {
+        let xpath = format!("//*[@aria-label={}]", escape_string(label));
+        let el = self
+            .find_waiting(By::XPath(&xpath), &format!("element with aria-label={label:?}"))
+            .await?;
+        el.clear().await.with_context(|| format!("clear aria-label={label:?} failed"))?;
+        el.send_keys(value).await.with_context(|| format!("send_keys aria-label={label:?} failed"))
+    }
+
+    /// Click the first `<button>` whose full trimmed text content equals
+    /// `text` exactly — for real controls with no `data-testid` and no
+    /// stable `aria-label` (e.g. Settings' "+ Add site" / "Save" buttons).
+    /// Only safe to use when `text` is unambiguous in the current DOM (no
+    /// two same-labelled buttons visible at once) — callers with an
+    /// ambiguity risk (e.g. a dialog whose confirm button repeats a trigger
+    /// button's label) should scope the search to a container element
+    /// instead via `app.driver.find(...)` + `WebElement::find(...)`. Polls
+    /// for the element (via [`Self::find_waiting`]) rather than doing a
+    /// single immediate lookup, so it survives the same route-render race
+    /// `find_waiting` documents.
+    pub async fn click_button_text(&self, text: &str) -> Result<()> {
+        let xpath = format!("//button[normalize-space(.)={}]", escape_string(text));
+        self.find_waiting(By::XPath(&xpath), &format!("<button> with text {text:?}"))
+            .await?
+            .click()
+            .await
+            .with_context(|| format!("click button text={text:?} failed"))
+    }
+
+    /// Count of elements anywhere on the page whose `title` attribute equals
+    /// `title` exactly — a real, coarse but honest way to assert a specific
+    /// disclosure/placeholder tooltip is (or is not) present, when the
+    /// underlying element carries no `data-testid` (e.g. the Targets table's
+    /// per-row "Opposition date unknown" / "Lunar distance unknown"
+    /// disclosures, spec 047). NOT routed through [`Self::find_waiting`]:
+    /// callers use this to assert an ABSENCE (a zero count is frequently the
+    /// expected, correct result), so polling for presence here would be
+    /// wrong — callers that need to wait for a nonzero count should poll
+    /// this fn themselves.
+    pub async fn count_elements_with_title(&self, title: &str) -> Result<usize> {
+        let xpath = format!("//*[@title={}]", escape_string(title));
+        Ok(self
+            .driver
+            .find_all(By::XPath(&xpath))
+            .await
+            .with_context(|| format!("query for title={title:?} failed"))?
+            .len())
+    }
+
+    /// Count of `<button>`s anywhere on the page whose full trimmed text
+    /// content equals `text` exactly — used as a real, honest "no such
+    /// control exists" check (e.g. proving no global "Save" button exists on
+    /// a settings pane, spec 018's auto-save-only convention). NOT routed
+    /// through [`Self::find_waiting`] for the same reason as
+    /// [`Self::count_elements_with_title`]: a zero count is frequently the
+    /// expected, correct result.
+    pub async fn count_buttons_with_text(&self, text: &str) -> Result<usize> {
+        let xpath = format!("//button[normalize-space(.)={}]", escape_string(text));
+        Ok(self
+            .driver
+            .find_all(By::XPath(&xpath))
+            .await
+            .with_context(|| format!("query for button text={text:?} failed"))?
+            .len())
+    }
+
+    /// Read an `aria-label`ed checkbox's checked state (e.g. a `Toggle`
+    /// component) — real DOM state, not an assumption from response shape.
+    /// Polls for the element (via [`Self::find_waiting`]) rather than doing a
+    /// single immediate lookup, so it survives the same route-render race
+    /// `find_waiting` documents.
+    pub async fn checkbox_checked_by_aria_label(&self, label: &str) -> Result<bool> {
+        let xpath = format!("//*[@aria-label={}]", escape_string(label));
+        self.find_waiting(By::XPath(&xpath), &format!("element with aria-label={label:?}"))
+            .await?
+            .is_selected()
+            .await
+            .with_context(|| format!("is_selected() on aria-label={label:?} failed"))
     }
 
     /// Quit the WebDriver session and kill the `tauri-webdriver` CLI process

--- a/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
+++ b/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
@@ -1,0 +1,249 @@
+//! Spec 037 Layer-2 real-UI journey — Project creation wizard (batch #10 of
+//! the coverage-matrix "Batched plan", Journey 5). Promotes journey-05's
+//! Tests 1/2: duplicate-name inline error (never a generic toast) and
+//! real on-disk folder creation under the REGISTERED PROJECT LIBRARY root
+//! (the exact bug PR #414 fixed — folders used to land next to the app's
+//! own working directory instead).
+//!
+//! Scoped to these two: the wizard's Sources step gates `canAdvance()` on
+//! having at least one selected session (`WizardPage.tsx::canAdvance`, case
+//! 1), so reaching the Review/Create step at all requires a real confirmed
+//! session — this journey builds one via the same real ingest pipeline
+//! `journeys.rs`/`sessions_journeys.rs` use. Tests 3-7 (attach/remove-source
+//! UX, per-channel integration time, manifests/notes autosave, tool-launch
+//! spawn + containment, artifact watcher) are left as documented follow-ups:
+//! several need a configured processing-tool executable or a real process/
+//! filesystem watcher, which would meaningfully grow this file's scope
+//! beyond the wizard-creation flow this journey already exercises.
+
+mod common;
+
+use std::time::Duration;
+
+use anyhow::Context;
+use common::{write_minimal_fits, E2eApp};
+use serde_json::json;
+use thirtyfour::By;
+
+const UI_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Registers a disposable "project" category root (the registered project
+/// LIBRARY the wizard's derived project path is anchored under, per PR
+/// #414), plus one real confirmed session (M 31) so the wizard's Sources
+/// step can advance. Returns the project library root's absolute path.
+async fn setup_project_library_and_one_session(app: &E2eApp) -> anyhow::Result<std::path::PathBuf> {
+    let project_root_dir = tempfile::tempdir()?;
+    let project_root_path = project_root_dir.path().to_path_buf();
+    // Leaked deliberately: the TempDir must outlive this function, but the
+    // journey needs the path for its whole lifetime, not just setup — keep
+    // the directory alive by leaking the guard (acceptable in a short-lived
+    // test process; the OS reclaims it at process exit).
+    std::mem::forget(project_root_dir);
+
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": project_root_path.to_string_lossy(), "category": "project", "scanSettings": null }),
+        )
+        .await?;
+
+    // Real ingest pipeline (mirrors `sessions_journeys.rs`) to get one real
+    // confirmed session with a known target, so the wizard's Sources step
+    // has something real to select.
+    let root_dir = tempfile::tempdir()?;
+    write_minimal_fits(
+        root_dir.path(),
+        "light_m31_wizard_001.fits",
+        "Light Frame",
+        Some("M 31"),
+        Some("Ha"),
+        Some("2026-01-13T21:30:00"),
+    )?;
+    let register: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": root_dir.path().to_string_lossy(), "category": "light_frames", "scanSettings": null }),
+        )
+        .await?;
+    let root_id = register["sourceId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("roots.register returned no sourceId: {register}"))?
+        .to_owned();
+    let _: serde_json::Value = app
+        .invoke(
+            "sources_set_organization_state",
+            json!({ "sourceId": root_id, "organizationState": "unorganized" }),
+        )
+        .await?;
+    let scan: serde_json::Value = app
+        .invoke(
+            "inbox_scan_folder",
+            json!({
+                "req": {
+                    "rootId": root_id,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "followSymlinks": false,
+                }
+            }),
+        )
+        .await?;
+    let inbox_item_id = scan["items"][0]["inboxItemId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.scan.folder discovered no item: {scan}"))?
+        .to_owned();
+    let classify: serde_json::Value = app
+        .invoke(
+            "inbox_classify",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "forceRescan": false,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                }
+            }),
+        )
+        .await?;
+    let content_signature = classify["contentSignature"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
+        .to_owned();
+    let _: serde_json::Value = app
+        .invoke(
+            "inbox_confirm",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "contentSignature": content_signature,
+                    "destructiveDestination": null,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "rootId": null,
+                }
+            }),
+        )
+        .await?;
+    let _: serde_json::Value =
+        app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
+
+    // Session grouping is event-driven — poll the real backend read until it
+    // resolves before the wizard needs it.
+    let _: serde_json::Value = app
+        .invoke_until("sessions_list", json!({}), UI_TIMEOUT, |v: &serde_json::Value| {
+            v.as_array().is_some_and(|arr| {
+                arr.iter().any(|s| s["targetIds"].as_array().is_some_and(|t| !t.is_empty()))
+            })
+        })
+        .await
+        .context("expected the M 31 session to resolve before the wizard needs it")?;
+
+    Ok(project_root_path)
+}
+
+/// Drive the wizard's Name -> Sources -> Calibration -> Views -> Naming ->
+/// Review steps for a given project `name`, ending with a click on the real
+/// Create button (`data-testid="wizard-create-btn"`) — real DOM interaction
+/// throughout, no invoke shortcuts.
+async fn run_wizard_to_create(app: &E2eApp, name: &str) -> anyhow::Result<()> {
+    // Poll for the wizard's Name step to actually mount: it opens
+    // asynchronously after the navigation, same route/render race
+    // `E2eApp::find_waiting` documents.
+    let name_input = app
+        .find_waiting(By::Id("project-name"), "the wizard's #project-name input")
+        .await
+        .context("no #project-name input found")?;
+    name_input.clear().await?;
+    name_input.send_keys(name).await?;
+
+    app.click_button_text("Next: sources →").await?;
+    app.click_by_aria_label("Select M 31 session").await?;
+    app.click_button_text("Next: calibration →").await?;
+    app.click_button_text("Next: source views →").await?;
+    app.click_button_text("Next: naming →").await?;
+    app.click_button_text("Next: review →").await?;
+    app.click_testid("wizard-create-btn").await
+}
+
+/// Tests 1/2 (journey-05): a unique project name creates real `lights/`/
+/// `darks/` subfolders under the REGISTERED PROJECT LIBRARY root (PR #414's
+/// fix — not the app's own working directory), and creating a SECOND
+/// project with the SAME name is blocked with a real inline field error
+/// (never a generic toast), with the wizard returning to the Name step to
+/// show it.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn projects_ui_wizard_creates_real_folders_and_blocks_duplicate_name() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    let project_root = setup_project_library_and_one_session(&app).await?;
+    let _: serde_json::Value = app.invoke("firstrun_complete", json!({})).await?;
+
+    let project_name = "E2E Wizard Project";
+
+    // First creation: real success path.
+    app.goto_route("/projects/new").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    run_wizard_to_create(&app, project_name).await?;
+
+    // Real navigation-away signal: the wizard routes to /projects on success
+    // (`WizardPage.tsx::handleCreate`), never staying on /projects/new.
+    let deadline = tokio::time::Instant::now() + UI_TIMEOUT;
+    loop {
+        let url = app.driver.current_url().await?.to_string();
+        if !url.contains("/projects/new") {
+            break;
+        }
+        anyhow::ensure!(
+            tokio::time::Instant::now() < deadline,
+            "expected the wizard to navigate away from /projects/new after a successful create"
+        );
+        tokio::time::sleep(Duration::from_millis(200)).await;
+    }
+
+    // Test 2: real folders exist under the REGISTERED PROJECT LIBRARY root,
+    // never next to the app binary. `safeName` mirrors
+    // `WizardPage.tsx::handleCreate`'s kebab-case derivation.
+    let safe_name = "e2e-wizard-project";
+    let project_dir = project_root.join(safe_name);
+    anyhow::ensure!(
+        project_dir.join("lights").is_dir(),
+        "expected a real lights/ folder under the registered project library root at {project_dir:?}"
+    );
+    anyhow::ensure!(
+        project_dir.join("darks").is_dir(),
+        "expected a real darks/ folder under the registered project library root at {project_dir:?}"
+    );
+
+    // Test 1: re-create with the exact same name — blocked with a real
+    // inline field error, not a generic toast.
+    app.goto_route("/projects/new").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    run_wizard_to_create(&app, project_name).await?;
+
+    // Poll for the inline field error to render: it appears asynchronously
+    // after the create attempt's real backend round trip, same
+    // route/refetch-render race `E2eApp::find_waiting` documents.
+    let error_el = app
+        .find_waiting(By::Id("project-name-error"), "the #project-name-error field error")
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!(
+                "expected a real inline #project-name-error field error after a duplicate-name \
+                 create attempt (never a generic toast): {e}"
+            )
+        })?;
+    let error_text =
+        error_el.text().await.context("failed to read the duplicate-name error text")?;
+    anyhow::ensure!(
+        error_text.contains("already exists"),
+        "expected the real duplicate-name copy ('A project with this name already exists.'), \
+         got: {error_text:?}"
+    );
+    // The wizard must have returned to the Name step (index 0) to show it —
+    // real proof: the name input is present and still on /projects/new.
+    let url = app.driver.current_url().await?.to_string();
+    anyhow::ensure!(
+        url.contains("/projects/new"),
+        "expected the wizard to stay on /projects/new (Name step) after a blocked duplicate create"
+    );
+
+    app.shutdown().await
+}

--- a/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
+++ b/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
@@ -27,6 +27,20 @@ use thirtyfour::By;
 
 const UI_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Wait for the index route's async first-run redirect to land on `/setup`
+/// BEFORE navigating anywhere (mirrors `inbox_ui_journeys.rs`'s
+/// `settle_first_run_redirect`). A fresh DB (the harness resets it every
+/// launch) makes `checkFirstRunComplete` redirect `/` → `/setup` from an
+/// async `beforeLoad`; if a journey `goto_route`s while that redirect is
+/// still pending, the late-resolving redirect can yank the app off the
+/// target route.
+async fn settle_first_run_redirect(app: &E2eApp) -> anyhow::Result<()> {
+    app.wait_url_contains("/setup", Duration::from_secs(15))
+        .await
+        .map(drop)
+        .map_err(|e| anyhow::anyhow!("expected a fresh DB to redirect to /setup: {e}"))
+}
+
 /// Registers a disposable "project" category root (the registered project
 /// LIBRARY the wizard's derived project path is anchored under, per PR
 /// #414), plus one real confirmed session (M 31) so the wizard's Sources
@@ -173,8 +187,14 @@ async fn run_wizard_to_create(app: &E2eApp, name: &str) -> anyhow::Result<()> {
 async fn projects_ui_wizard_creates_real_folders_and_blocks_duplicate_name() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    settle_first_run_redirect(&app).await?;
     let project_root = setup_project_library_and_one_session(&app).await?;
-    let _: serde_json::Value = app.invoke("firstrun_complete", json!({})).await?;
+    // Route through the real gate (not a bare `firstrun_complete` invoke):
+    // it also clears the Shell's separate `setupCompleted` localStorage
+    // flag, without which every subsequent `goto_route` below would still
+    // get bounced to `/setup` by `Shell.tsx`'s client-side gate (mirrors the
+    // proven `inbox_ui_journeys.rs` pattern).
+    app.complete_first_run_gate().await?;
 
     let project_name = "E2E Wizard Project";
 

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -225,7 +225,7 @@ everything neither automated layer reaches.
 | 2 Ingest → reclassify → confirm (move) | ✅ | ✅ real-UI (`inbox_ui_journeys.rs`): mixed-folder split, unclassified-frame-type gate + bulk reclassify, missing-path-attribute gate, Confirm-doesn't-move + Apply-moves-to-shown-path. Root-picker prompt (2+ roots) and stale-plan refusal remain unautomated (follow-up) | ❌ none | `windows-journeys/journey-02-inbox-ingest-move.md` |
 | 3 Ingest → confirm (catalogue-in-place) | ✅ | ✅ real-UI (`inbox_ui_journeys.rs::inbox_ui_catalogue_in_place_zero_moves_byte_identical`): organized root → 0-move catalogue plan, no root picker, no destination-absolute cell, byte-identical apply | ❌ none | `windows-journeys/journey-03-inbox-catalogue-in-place.md` |
 | 4 Sessions review (derived) | ✅ | 🟡 grouping proof only, no UI-invariant checks | 🟡 rows/detail render only | `windows-journeys/journey-04-sessions-review.md` |
-| 5 Project lifecycle | ✅ | 🟡 transition + ledger only, no UI | 🟡 transition button only (pill-refresh `test.skip`) | `windows-journeys/journey-05-project-lifecycle.md` |
+| 5 Project lifecycle | ✅ | 🟡 real-UI (`lifecycle_ui_journeys.rs`): create-wizard makes real `lights/`/`darks/` folders under the registered project library root (PR #414 regression guard) + blocks a duplicate name with a real inline field error. Attach/remove-source UX, manifests/notes, tool launch, artifact watcher still IPC-only | 🟡 transition button only (pill-refresh `test.skip`) | `windows-journeys/journey-05-project-lifecycle.md` |
 | 6 Cleanup scan→review→apply | ✅ | ✅ `cleanup_plan_review` now applies past `approved` via `plans.apply.direct` + asserts the real FS move + audit (2026-07-05) | ❌ none | `windows-journeys/journey-06-cleanup-scan-apply.md` |
 | 7 Archive → delete | ✅ (backend only) | ✅ `archive_lifecycle_apply_trash_permanent_delete` (`archive_journeys.rs`, NEW 2026-07-05): real apply + `archive.list` + `archive.send_to_trash`/`archive.permanently_delete` metadata + `blockPermanentDelete` gate | ❌ none | `windows-journeys/journey-07-archive-delete.md` |
 | 8 Calibration masters → matching | ✅ | 🟡 `calibration.match.suggest` shape only | ❌ none | `windows-journeys/journey-08-calibration-masters-matching.md` |
@@ -348,8 +348,13 @@ just test the mock, not the product:
    review-state controls/pills, notes-edit-doesn't-transition, rescan
    idempotency; low cost, extends the existing
    `ingestion_sessions_search` fixture.
-10. **Project lifecycle UI surface** (Journey 5) — create-wizard validation,
-    attach/remove-sources UX, manifests/notes autosave, tool-launch spawn +
+10. **Project lifecycle UI surface** (Journey 5) — PARTIALLY DONE
+    (2026-07-05, `crates/e2e-tests/tests/lifecycle_ui_journeys.rs`): the
+    create-wizard's Tests 1/2 (duplicate-name blocks with a real inline
+    field error; a unique name creates real `lights/`/`darks/` folders under
+    the registered project library root — the exact PR #414 regression).
+    Still open as follow-up: attach/remove-sources UX, per-channel
+    integration time, manifests/notes autosave, tool-launch spawn +
     containment, artifact watcher; tool-launch and the watcher specifically
     need Layer-2 (a real process/filesystem watcher), not the mock layer.
 11. **Settings + layout-convention + i18n regression guard** (Journey 10) —


### PR DESCRIPTION
## Summary
- Adds an automated end-to-end test that drives the real project-creation wizard end to end, closing a gap where this flow had no automated UI-level proof.
- Covers: creating a project with a unique name produces real folders (e.g. `lights/`, `darks/`) in the correct place -- under the user's registered project library, never next to the app's own program files (a regression guard for a previously-fixed bug); and trying to create a second project with a name that's already in use is blocked with a clear message right on the name field, never a generic pop-up toast.

## Test plan
- [x] `cargo test -p e2e_tests --no-run` (compile-only; these tests only run in CI's dedicated end-to-end workflow, which needs a real app window)
- [x] `cargo clippy -p e2e_tests --tests --all-targets -- -D warnings`
- [x] `cargo fmt -p e2e_tests -- --check`
- [ ] CI end-to-end workflow (3-OS matrix) runs the new test for real

Note: like the sibling per-area journey PRs (#457/#458/#463/#464/#465), this branch carries an identical copy of the shared test-helper additions to `crates/e2e-tests/tests/common/mod.rs`, since it was re-rooted from `origin/main` before any of them merged. Whichever merges last should see a no-op diff for that file.

## Spec Context
- Spec: 037
- Branch: 037-ui-journeys-lifecycle