### PR TITLE
test: add real end-to-end source-view generation + per-frame inventory journeys

### DIFF
--- a/apps/desktop/src/features/projects/GenerateSourceViewDialog.tsx
+++ b/apps/desktop/src/features/projects/GenerateSourceViewDialog.tsx
@@ -117,7 +117,12 @@ export function GenerateSourceViewDialog({
           <Btn variant="ghost" onClick={onClose} disabled={submitting}>
             {m.common_cancel()}
           </Btn>
-          <Btn variant="primary" onClick={() => void handleSubmit()} disabled={submitting}>
+          <Btn
+            variant="primary"
+            onClick={() => void handleSubmit()}
+            disabled={submitting}
+            data-testid="generate-source-view-submit"
+          >
             {submitting ? m.common_working() : m.projects_source_views_generate_submit_btn()}
           </Btn>
         </>

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -386,7 +386,12 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
         subtitle={undefined}
         actions={
           lifecycle !== 'archived' && (
-            <Btn size="sm" variant="ghost" onClick={() => setEditOpen(true)}>
+            <Btn
+              size="sm"
+              variant="ghost"
+              onClick={() => setEditOpen(true)}
+              data-testid="edit-project-btn"
+            >
               {m.projects_detail_edit_btn()}
             </Btn>
           )

--- a/apps/desktop/src/features/projects/ProjectsTable.tsx
+++ b/apps/desktop/src/features/projects/ProjectsTable.tsx
@@ -174,6 +174,7 @@ export function ProjectsTable({
         'alm-projects-table__row' +
         (project.id === selectedId ? ' alm-projects-table__row--selected' : ''),
       _onClick: () => onSelect(project.id),
+      _testid: `project-row-${project.id}`,
       name: (
         <span
           className="alm-projects-table__name"

--- a/apps/desktop/src/features/projects/SessionSourcePicker.tsx
+++ b/apps/desktop/src/features/projects/SessionSourcePicker.tsx
@@ -168,6 +168,7 @@ export function SessionSourcePicker({
             <label
               key={session.id}
               className={'alm-source-picker__row' + (selectedSessionIds.includes(session.id) ? ' alm-source-picker__row--selected' : '')}
+              data-testid={`session-picker-row-${session.id}`}
             >
               <Checkbox.Root
                 className="alm-checkbox"
@@ -182,7 +183,7 @@ export function SessionSourcePicker({
               <span>
                 {targetLabel} / {session.sessionKey.filter} / {session.sessionKey.night}
               </span>
-              <span>{session.frameCount}</span>
+              <span data-testid={`session-picker-frames-${session.id}`}>{session.frameCount}</span>
               <span>{formatIntegration(session.totalIntegrationSeconds ?? 0)}</span>
               <span className="alm-source-picker__train-id">
                 {session.opticalTrainId.slice(0, 8)}

--- a/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
+++ b/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
@@ -379,6 +379,7 @@ export function EditProjectPane({ project, onClose }: EditProjectPaneProps) {
                 size="sm"
                 variant="ghost"
                 onClick={() => setShowAddSources(true)}
+                data-testid="edit-project-add-sources-toggle"
               >
                 {m.projects_edit_sources_add_btn()}
               </Btn>

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -240,8 +240,15 @@ async fn ingest_light_frame(
 
     let (key, has_observer_location) = derive_session_key(&key_target, &meta);
 
-    upsert_session(pool, &key, has_observer_location, canonical_target_id.as_deref(), &image_id)
-        .await?;
+    upsert_session(
+        pool,
+        &key,
+        has_observer_location,
+        canonical_target_id.as_deref(),
+        &image_id,
+        &item.root_id,
+    )
+    .await?;
 
     Ok(FrameOutcome::Ingested)
 }
@@ -364,12 +371,30 @@ fn parse_date_obs(raw: Option<&str>) -> OffsetDateTime {
 ///
 /// Idempotent (R12): the SELECT-by-`session_key` lookup keeps grouping
 /// single-row, and a repeat append of the same frame id is dropped (set-dedup).
+///
+/// `root_id` (R9/T036/FR-012 — spec 006's `acquisition_session.root_id`,
+/// migration 0021) is set on every insert and back-filled with
+/// `COALESCE(root_id, ?)` on every append so a session's first-known root
+/// sticks even across repeat ingests. This closed a real gap (found via
+/// #470's Layer-2 journeys, round 6): `root_id` was never written by this
+/// function at all — the column existed and `persistence_db::repositories::
+/// inventory::update_acquisition_session_root_id` existed to set it (its own
+/// doc comment: "Called when the inbox confirm pipeline resolves the root
+/// for a session"), but nothing ever called it, so every real ingested
+/// session's `root_id` stayed `NULL`. Sqlx-sqlite (this project's version)
+/// silently decodes a `NULL` `TEXT` column into a plain (non-`Option`)
+/// `String` as `""` rather than erroring, so downstream readers that assume
+/// `root_id` is always populated (`app_core_projects::source_view_generate`)
+/// got a real-looking-but-empty id and failed with a confusing
+/// `no_link_kind`/"source root  could not be resolved" (note the double
+/// space) instead of a clear "root never set" error.
 async fn upsert_session(
     pool: &SqlitePool,
     key: &str,
     has_observer_location: bool,
     canonical_target_id: Option<&str>,
     image_id: &str,
+    root_id: &str,
 ) -> Result<(), ContractError> {
     if let Some((id, frame_ids_json, existing_target)) = sqlx::query_as::<
         _,
@@ -391,10 +416,13 @@ async fn upsert_session(
         // Back-fill the link if it resolved this pass and the row had none.
         if existing_target.is_none() && canonical_target_id.is_some() {
             sqlx::query(
-                "UPDATE acquisition_session SET frame_ids = ?, canonical_target_id = ? WHERE id = ?",
+                "UPDATE acquisition_session \
+                 SET frame_ids = ?, canonical_target_id = ?, root_id = COALESCE(root_id, ?) \
+                 WHERE id = ?",
             )
             .bind(&frames_json)
             .bind(canonical_target_id)
+            .bind(root_id)
             .bind(&id)
             .execute(pool)
             .await
@@ -405,12 +433,16 @@ async fn upsert_session(
                 propagate_target_to_projects(pool, &id, target_id).await?;
             }
         } else {
-            sqlx::query("UPDATE acquisition_session SET frame_ids = ? WHERE id = ?")
-                .bind(&frames_json)
-                .bind(&id)
-                .execute(pool)
-                .await
-                .map_err(db_err)?;
+            sqlx::query(
+                "UPDATE acquisition_session \
+                 SET frame_ids = ?, root_id = COALESCE(root_id, ?) WHERE id = ?",
+            )
+            .bind(&frames_json)
+            .bind(root_id)
+            .bind(&id)
+            .execute(pool)
+            .await
+            .map_err(db_err)?;
         }
         return Ok(());
     }
@@ -420,14 +452,15 @@ async fn upsert_session(
     sqlx::query(
         "INSERT INTO acquisition_session
             (id, session_key, target_id, canonical_target_id, has_observer_location,
-             frame_ids, observer_location, created_at)
-         VALUES (?, ?, NULL, ?, ?, ?, NULL, ?)",
+             frame_ids, observer_location, root_id, created_at)
+         VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ?)",
     )
     .bind(&id)
     .bind(key)
     .bind(canonical_target_id)
     .bind(i64::from(has_observer_location))
     .bind(&frames_json)
+    .bind(root_id)
     .bind(OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default())
     .execute(pool)
     .await
@@ -646,6 +679,22 @@ mod tests {
         .unwrap();
     }
 
+    /// Insert a minimal `library_root` row so `acquisition_session.root_id`'s
+    /// FK (migration 0021) is satisfiable in tests that pass a `root_id` to
+    /// `upsert_session`.
+    async fn seed_library_root(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO library_root (id, label, current_path, kind, state, created_at)
+             VALUES (?, ?, ?, 'local', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(format!("/tmp/{id}"))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
     async fn seed_project(pool: &SqlitePool, id: &str) {
         repo_projects::insert_project(
             pool,
@@ -729,13 +778,16 @@ mod tests {
     async fn upsert_session_insert_branch_with_no_linked_project_does_not_error() {
         let db = test_db().await;
         seed_canonical_target(db.pool(), "target-1", "M 31").await;
+        seed_library_root(db.pool(), "root-1").await;
 
         // A brand-new session (INSERT branch of upsert_session) resolves a
         // target immediately; `project_sources` cannot yet reference this
         // session's id (a project can only link an *existing* session in the
         // real UI flow), so there is no linked project. The INSERT-branch
         // propagation call must be a safe no-op, not a panic/error.
-        upsert_session(db.pool(), "sk-1", false, Some("target-1"), "image-1").await.unwrap();
+        upsert_session(db.pool(), "sk-1", false, Some("target-1"), "image-1", "root-1")
+            .await
+            .unwrap();
 
         let (canonical_target_id,): (Option<String>,) = sqlx::query_as(
             "SELECT canonical_target_id FROM acquisition_session WHERE session_key = 'sk-1'",
@@ -746,14 +798,73 @@ mod tests {
         assert_eq!(canonical_target_id.as_deref(), Some("target-1"));
     }
 
+    /// Regression test for #470 round 6: `acquisition_session.root_id`
+    /// (migration 0021) was never written by real ingest — `upsert_session`'s
+    /// INSERT/UPDATE statements simply omitted the column, and the
+    /// `update_acquisition_session_root_id` repo fn that existed specifically
+    /// to set it (T036/FR-012) was never called from anywhere. Every
+    /// downstream reader that assumes `root_id` is populated
+    /// (`app_core_projects::source_view_generate`) got sqlx's silent
+    /// NULL-into-`String` coercion to `""` instead, and failed with a
+    /// confusing `no_link_kind`/"source root  could not be resolved" (double
+    /// space) rather than a clear error.
+    ///
+    /// Registers the root through the REAL `roots.register` repo path
+    /// (`persistence_db::repositories::first_run::register_source`) — a
+    /// `registered_sources` row, NOT a hand-seeded `library_root` row — and
+    /// mirrors it via the same `ensure_library_root` (R9) call the real
+    /// `ingest_light_frame` pipeline makes, so this test exercises the actual
+    /// production root-resolution path rather than a `library_root`-only
+    /// fixture shortcut that would mask the same gap the backend unit test
+    /// for `source_view_generate` originally did.
+    #[tokio::test]
+    async fn upsert_session_persists_root_id_from_a_really_registered_source() {
+        let db = test_db().await;
+
+        let register_req = domain_core::first_run::RegisterSourceRequest {
+            kind: domain_core::first_run::SourceKind::LightFrames,
+            path: "/tmp/e2e-lights".to_owned(),
+            kind_subtype: None,
+            scan_depth: domain_core::first_run::ScanDepth::Recursive,
+            organization_state: domain_core::first_run::OrganizationState::Organized,
+        };
+        let registered =
+            persistence_db::repositories::first_run::register_source(db.pool(), &register_req)
+                .await
+                .unwrap();
+
+        // R9: the same mirroring `ingest_light_frame` performs before ever
+        // calling `upsert_session` — real users hit this via the applied
+        // plan's `to_root_id`, which is a `registered_sources` id.
+        let mirrored_path = ensure_library_root(db.pool(), &registered.source_id).await.unwrap();
+        assert_eq!(mirrored_path.as_deref(), Some("/tmp/e2e-lights"));
+
+        upsert_session(db.pool(), "sk-root-real", false, None, "image-1", &registered.source_id)
+            .await
+            .unwrap();
+
+        let (root_id,): (String,) =
+            sqlx::query_as("SELECT root_id FROM acquisition_session WHERE session_key = ?")
+                .bind("sk-root-real")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            root_id, registered.source_id,
+            "acquisition_session.root_id must be set to the real registered source id, not left \
+             empty/unset"
+        );
+    }
+
     #[tokio::test]
     async fn upsert_session_backfill_branch_propagates_when_project_prelinked() {
         let db = test_db().await;
         seed_canonical_target(db.pool(), "target-1", "M 31").await;
         seed_project(db.pool(), "proj-1").await;
+        seed_library_root(db.pool(), "root-1").await;
 
         // First frame arrives with no resolvable target — session created NULL.
-        upsert_session(db.pool(), "sk-2", false, None, "image-1").await.unwrap();
+        upsert_session(db.pool(), "sk-2", false, None, "image-1", "root-1").await.unwrap();
         let (session_id,): (String,) =
             sqlx::query_as("SELECT id FROM acquisition_session WHERE session_key = 'sk-2'")
                 .fetch_one(db.pool())
@@ -763,7 +874,9 @@ mod tests {
 
         // Second frame in the same session resolves — back-fill branch runs and
         // must propagate to the now-linked project.
-        upsert_session(db.pool(), "sk-2", false, Some("target-1"), "image-2").await.unwrap();
+        upsert_session(db.pool(), "sk-2", false, Some("target-1"), "image-2", "root-1")
+            .await
+            .unwrap();
 
         let got =
             repo_projects::get_project_canonical_target_id(db.pool(), "proj-1").await.unwrap();
@@ -797,7 +910,7 @@ mod tests {
         .unwrap();
 
         // A session with an unresolved (NULL) target, one frame.
-        upsert_session(db.pool(), "sk-3", false, None, "image-1").await.unwrap();
+        upsert_session(db.pool(), "sk-3", false, None, "image-1", "root-1").await.unwrap();
         let (session_id,): (String,) =
             sqlx::query_as("SELECT id FROM acquisition_session WHERE session_key = 'sk-3'")
                 .fetch_one(db.pool())

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -535,6 +535,48 @@ impl E2eApp {
         }
     }
 
+    /// Generic evidence dump for a failing journey centred on ONE
+    /// `data-testid` element (unlike `dump_ui_diagnostics`, which is
+    /// hardcoded to the Inbox virtualizer/query-key investigation) — e.g. a
+    /// dialog/modal that should have closed after a submit action but is
+    /// still present. Captures whether the element is still in the DOM, its
+    /// (truncated) `outerHTML` — including any inline error banner it may be
+    /// showing — and the buffered `window.__e2eErrors` (uncaught
+    /// `error`/`unhandledrejection` events, `VITE_E2E` listener installed in
+    /// `apps/desktop/src/main.tsx`). Never used for assertions; a failure at
+    /// any step degrades to an inline error string rather than propagating.
+    pub async fn dump_testid_diagnostics(&self, testid: &str) -> Value {
+        let script = format!(
+            r#"
+            var callback = arguments[arguments.length - 1];
+            function truncate(s, n) {{
+                if (typeof s !== 'string') return s;
+                return s.length > n ? s.slice(0, n) + '...[truncated]' : s;
+            }}
+            try {{
+                var el = document.querySelector('[data-testid="{testid}"]');
+                callback({{
+                    ok: true,
+                    value: {{
+                        found: !!el,
+                        outerHtml: truncate(el ? el.outerHTML : null, 8192),
+                        e2eErrors: (window.__e2eErrors || []).slice(-30)
+                    }}
+                }});
+            }} catch (err) {{
+                callback({{ ok: false, error: String(err) }});
+            }}
+        "#
+        );
+
+        match self.driver.execute_async(&script, vec![]).await {
+            Ok(ret) => ret.convert::<Value>().unwrap_or_else(
+                |e| json!({ "dump_testid_diagnostics_decode_error": e.to_string() }),
+            ),
+            Err(e) => json!({ "dump_testid_diagnostics_execute_error": e.to_string() }),
+        }
+    }
+
     /// Drain the last ~30 real browser console entries (chromedriver/
     /// WebView2 `"browser"` log type, W3C `GET /session/{id}/log`) — best
     /// effort. Some WebDriver stacks (notably older Edge/WebView2 driver

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -242,7 +242,26 @@ impl E2eApp {
             window.__ALM_E2E__.invoke(cmd, cmdArgs).then(function(value) {
                 callback({ ok: true, value: value });
             }).catch(function(err) {
-                callback({ ok: false, error: String(err) });
+                // `unwrap()` (`apps/desktop/src/api/ipc.ts`) throws the raw
+                // `ContractError` envelope object on a rejected command, not
+                // a JS `Error` instance — `String(err)` on a plain object
+                // stringifies to the useless "[object Object]" (round 4,
+                // #470: masked a real `no_link_kind` backend error behind
+                // that placeholder). Prefer JSON.stringify so `code`/
+                // `message`/`details` are readable; fall back to
+                // `err.message`/`String(err)` only if JSON serialisation
+                // itself fails or yields nothing useful (e.g. a real `Error`
+                // instance, whose own fields aren't enumerable).
+                var serialized;
+                try {
+                    serialized = JSON.stringify(err);
+                } catch (jsonErr) {
+                    serialized = null;
+                }
+                if (!serialized || serialized === '{}') {
+                    serialized = (err && err.message) ? String(err.message) : String(err);
+                }
+                callback({ ok: false, error: serialized });
             });
         "#;
 

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -553,7 +553,8 @@ impl E2eApp {
 
     // ---------------------------------------------------------------------
     // Real-DOM interaction helpers (additive, shared across per-area UI
-    // journeys — inbox/calibration/targets/sessions/lifecycle/settings).
+    // journeys — inbox/calibration/targets/sessions/lifecycle/settings/
+    // source-view/per-frame-inventory).
     // These drive the ACTUAL rendered `data-testid` elements (click/type/
     // read), never the invoke bridge, so journeys built on them are proving
     // real UI interaction rather than a second copy of the IPC-level tests.
@@ -804,6 +805,41 @@ impl E2eApp {
                         });
                     }
                 }
+            }
+            tokio::time::sleep(Duration::from_millis(150)).await;
+        }
+    }
+
+    /// Poll the text content of the element at `data-testid` until `predicate`
+    /// accepts it or `timeout` elapses — the DOM-read equivalent of
+    /// [`Self::invoke_until`], for asserting a real backend mutation (e.g. a
+    /// reconcile pass) landed in a re-rendered, product-owned element instead
+    /// of only in the IPC response.
+    pub async fn wait_testid_text<P>(
+        &self,
+        testid: &str,
+        timeout: Duration,
+        mut predicate: P,
+    ) -> Result<String>
+    where
+        P: FnMut(&str) -> bool,
+    {
+        let deadline = Instant::now() + timeout;
+        let mut last_seen: Option<String> = None;
+        loop {
+            if let Ok(el) = self.driver.find(By::Css(format!("[data-testid='{testid}']"))).await {
+                if let Ok(text) = el.text().await {
+                    if predicate(&text) {
+                        return Ok(text);
+                    }
+                    last_seen = Some(text);
+                }
+            }
+            if Instant::now() >= deadline {
+                return Err(anyhow!(
+                    "text of data-testid={testid:?} never matched within {timeout:?} \
+                     (last seen: {last_seen:?})"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(150)).await;
         }

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -270,7 +270,12 @@ impl E2eApp {
     ///
     /// # Errors
     /// Returns the last error (invoke failure, or a "predicate never matched"
-    /// message once `timeout` elapses) if the predicate never accepts a value.
+    /// message once `timeout` elapses) if the predicate never accepts a
+    /// value. The timeout variant includes the last successfully-decoded
+    /// (but non-matching) response, truncated, so a caller can see whether
+    /// the backend returned an empty/unrelated result or the expected data
+    /// present-but-unmatched by the predicate (a predicate bug) without a
+    /// second CI round just to add that dump.
     pub async fn invoke_until<T, P>(
         &self,
         command: &str,
@@ -279,23 +284,37 @@ impl E2eApp {
         mut predicate: P,
     ) -> Result<T>
     where
-        T: DeserializeOwned,
+        T: DeserializeOwned + std::fmt::Debug,
         P: FnMut(&T) -> bool,
     {
         let deadline = Instant::now() + timeout;
         let mut last_err: Option<anyhow::Error> = None;
+        let mut last_value: Option<String> = None;
         loop {
             match self.invoke::<T>(command, args.clone()).await {
                 Ok(value) if predicate(&value) => return Ok(value),
-                Ok(_) => {}
+                Ok(value) => {
+                    let dump = format!("{value:?}");
+                    last_value = Some(if dump.len() > 4096 {
+                        format!("{}...[truncated]", &dump[..4096])
+                    } else {
+                        dump
+                    });
+                }
                 Err(e) => last_err = Some(e),
             }
             if Instant::now() >= deadline {
-                return Err(last_err.unwrap_or_else(|| {
-                    anyhow!(
-                        "invoke_until({command}) timed out after {:?} without a matching value",
+                return Err(last_err.unwrap_or_else(|| match &last_value {
+                    Some(v) => anyhow!(
+                        "invoke_until({command}) timed out after {:?} without a matching \
+                         value; last response: {v}",
                         timeout
-                    )
+                    ),
+                    None => anyhow!(
+                        "invoke_until({command}) timed out after {:?} without a matching value \
+                         (never returned successfully)",
+                        timeout
+                    ),
                 }));
             }
             tokio::time::sleep(Duration::from_millis(250)).await;

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -292,6 +292,26 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
         "expected exactly 1 still-present frame: {reconcile}"
     );
 
+    // ── 5b. Poll the SAME backend read the picker uses until it reflects ──
+    // the drop, BEFORE reloading (mirrors the fix for
+    // sessions_ui_derived_view_invariants, `git log 5c4ab4c5`: `inbox.plan
+    // .apply`/`inventory.reconcile.run` returning does not guarantee every
+    // downstream read is immediately consistent — a single page load only
+    // fetches once, and if that one fetch lands before the backend state is
+    // fully settled, nothing thereafter retriggers a refetch for
+    // `wait_testid_text` to catch. `reconcile["present"]/["newlyMissing"]`
+    // above already assert the response shape; this additionally proves
+    // `sessions.list` itself — the exact command the picker queries — has
+    // caught up before the reload below, so the reload's one-shot fetch
+    // cannot race it.
+    app.invoke_until("sessions_list", json!({}), INVOKE_TIMEOUT, |v: &serde_json::Value| {
+        v.as_array().is_some_and(|arr| {
+            arr.iter().any(|s| s["id"] == json!(session_id) && s["frameCount"].as_i64() == Some(1))
+        })
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("sessions.list never settled to frameCount=1 for the reconciled session before the UI reload: {e}"))?;
+
     // ── 6. Real UI (AFTER): a fresh page load re-fetches sessions.list ──
     //
     // `goto_route` only changes the URL fragment on the SAME document — per

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -45,6 +45,41 @@ use serde_json::json;
 
 const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Wait for the index route's async first-run redirect to land on `/setup`
+/// BEFORE navigating anywhere (mirrors `inbox_ui_journeys.rs`'s
+/// `settle_first_run_redirect`). A fresh DB (the harness resets it every
+/// launch) makes `checkFirstRunComplete` redirect `/` → `/setup` from an
+/// async `beforeLoad`; if a journey `goto_route`s while that redirect is
+/// still pending, the late-resolving redirect can yank the app off the
+/// target route.
+async fn settle_first_run_redirect(app: &E2eApp) -> anyhow::Result<()> {
+    app.wait_url_contains("/setup", Duration::from_secs(15))
+        .await
+        .map(drop)
+        .map_err(|e| anyhow::anyhow!("expected a fresh DB to redirect to /setup: {e}"))
+}
+
+/// Registers a disposable `project`-category root purely to satisfy
+/// `firstrun.complete`'s precondition (one `light_frames` root — this
+/// journey's own ingest root satisfies that half — AND one `project` root,
+/// `crates/persistence/db/src/repositories/first_run.rs`), then routes
+/// through the real gate. A `projects.create` Project entity (this journey
+/// creates one below) is a DIFFERENT concept from a registered `project`
+/// source root and does not satisfy this precondition on its own. Without
+/// this, `Shell.tsx`'s client-side `setupCompleted` gate bounces every
+/// `goto_route` to a Shell-wrapped page (`/projects`) back to `/setup`
+/// indefinitely (mirrors the proven `inbox_ui_journeys.rs` pattern).
+async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
+    let project_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": project_dir.path().to_string_lossy(), "category": "project", "scanSettings": null }),
+        )
+        .await?;
+    app.complete_first_run_gate().await
+}
+
 /// External raw-frame deletion → `inventory.reconcile.run` → the real
 /// Add-sources session picker's frame count drops from 2 to 1.
 #[tokio::test]
@@ -52,6 +87,7 @@ const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
 async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    settle_first_run_redirect(&app).await?;
 
     // ── 1. Real ingest precondition: two same-identity light frames group ──
     // into ONE real `acquisition_session` with `frame_count == 2` (same
@@ -202,6 +238,8 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
         .as_str()
         .ok_or_else(|| anyhow::anyhow!("projects.create returned no projectId: {create}"))?
         .to_owned();
+
+    complete_first_run(&app).await?;
 
     // ── 3. Real UI (BEFORE): open the project, open Add sources, read the ──
     // real per-session frame count from the real DOM.

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -293,8 +293,22 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
     );
 
     // ── 6. Real UI (AFTER): a fresh page load re-fetches sessions.list ──
-    // (no stale TanStack Query cache to fight) — the SAME real DOM surface
-    // now reflects the real reconciliation result.
+    //
+    // `goto_route` only changes the URL fragment on the SAME document — per
+    // the HTML fragment-navigation algorithm this never creates a new
+    // Document, so the shared `QueryClient` (30s `staleTime`,
+    // `apps/desktop/src/data/queryClient.ts`) survives across it and the
+    // `sessions.list` query stays cached from the BEFORE read above. A real
+    // `driver.refresh()` (used for the same reason by
+    // `complete_first_run_gate`) forces an actual reload, discarding the
+    // in-memory QueryClient so the SAME real DOM surface is guaranteed to
+    // re-fetch and reflect the real reconciliation result rather than
+    // serving stale cached data.
+    app.driver
+        .refresh()
+        .await
+        .map_err(|e| anyhow::anyhow!("page refresh before the AFTER read failed: {e}"))?;
+    app.wait_document_ready(Duration::from_secs(10)).await?;
     app.goto_route("/projects").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
     app.wait_testid(&format!("project-row-{project_id}"), Duration::from_secs(15))

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -1,0 +1,285 @@
+//! Spec 037 Layer-2 real-UI journey: per-frame inventory reconciliation
+//! (spec 048).
+//!
+//! Real backend REAL: `roots.register`, `inbox.scan.folder`,
+//! `inbox.classify`, `inbox.confirm`, `inbox.plan.apply` (catalogue-in-place),
+//! `projects.create`, `inventory.reconcile.run`
+//! (`apps/desktop/src-tauri/src/commands/inventory_frame.rs`, spec 048 T006).
+//!
+//! Real DOM: the project's "Add sources" session picker
+//! (`SessionSourcePicker`, mounted from `EditProjectPane`) queries
+//! `sessions.list` — the spec-048 T014 active/non-missing `frame_count`
+//! read path (`crates/app/core/src/sessions.rs::active_frame_summary`) — and
+//! renders it per-session. This journey reads that REAL, product-rendered
+//! frame count before and after a real reconcile pass, rather than asserting
+//! only the `inventory.reconcile.run` IPC response.
+//!
+//! Catalogue-in-place: same reasoning as `source_view_journeys.rs` — the
+//! `roots.register` default (`organized`) keeps both fixture files at their
+//! literal on-disk paths, so this journey can delete one of them directly to
+//! simulate a real, external raw-frame loss (the disconnected-drive /
+//! moved-by-another-tool scenario spec 048 exists to detect).
+//!
+//! KNOWN GAP (documented, not faked): `inventory.reconcile.run`,
+//! `inventory.frame.list`, and `inventory.root_config.{get,set}`
+//! have real backend implementations (spec 048 T006) but ZERO frontend
+//! callers today (`git grep -rl inventoryReconcileRun apps/desktop/src`
+//! matches only the generated `bindings/index.ts` file) — there is no
+//! button, setting, or scheduled trigger anywhere in the product UI that
+//! invokes a reconcile pass. This journey therefore triggers the reconcile
+//! pass over the invoke bridge (same convention as `artifact.watcher.attach`
+//! in `journeys.rs::cleanup_plan_review` for a backend surface with no UI
+//! affordance yet) and proves its REAL, UI-visible effect on a genuine
+//! product screen, rather than fabricating a UI trigger that does not exist.
+//!
+//! Run (CI): `cargo nextest run -p e2e_tests --profile e2e --run-ignored all`
+//! (serial, `.config/nextest.toml`). See `crates/e2e-tests/tests/journeys.rs`
+//! module docs and `README.md` for the full local run procedure.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{write_minimal_fits, E2eApp};
+use serde_json::json;
+
+const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// External raw-frame deletion → `inventory.reconcile.run` → the real
+/// Add-sources session picker's frame count drops from 2 to 1.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    // ── 1. Real ingest precondition: two same-identity light frames group ──
+    // into ONE real `acquisition_session` with `frame_count == 2` (same
+    // OBJECT/FILTER/GAIN/BINNING/night, spec 035 US4), catalogued in place so
+    // both files stay at their real, individually-deletable paths.
+    let root_dir = tempfile::tempdir()?;
+    let keep_name = "light_m33_001.fits";
+    let lose_name = "light_m33_002.fits";
+    let keep_path = write_minimal_fits(
+        root_dir.path(),
+        keep_name,
+        "Light Frame",
+        Some("M 33"),
+        Some("Ha"),
+        Some("2026-01-12T22:00:00"),
+    )?;
+    let lose_path = write_minimal_fits(
+        root_dir.path(),
+        lose_name,
+        "Light Frame",
+        Some("M 33"),
+        Some("Ha"),
+        Some("2026-01-12T23:00:00"),
+    )?;
+    anyhow::ensure!(
+        keep_path.exists() && lose_path.exists(),
+        "fixture FITS files were not written"
+    );
+
+    let register: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({
+                "path": root_dir.path().to_string_lossy(),
+                "category": "light_frames",
+                "scanSettings": null,
+            }),
+        )
+        .await?;
+    let root_id = register["sourceId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("roots.register returned no sourceId: {register}"))?
+        .to_owned();
+
+    let scan: serde_json::Value = app
+        .invoke(
+            "inbox_scan_folder",
+            json!({
+                "req": {
+                    "rootId": root_id,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "followSymlinks": false,
+                }
+            }),
+        )
+        .await?;
+    let inbox_item_id = scan["items"][0]["inboxItemId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.scan.folder discovered no item: {scan}"))?
+        .to_owned();
+
+    let classify: serde_json::Value = app
+        .invoke(
+            "inbox_classify",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "forceRescan": false,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                }
+            }),
+        )
+        .await?;
+    let content_signature = classify["contentSignature"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
+        .to_owned();
+
+    let _confirm: serde_json::Value = app
+        .invoke(
+            "inbox_confirm",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "contentSignature": content_signature,
+                    "destructiveDestination": null,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "rootId": null,
+                }
+            }),
+        )
+        .await?;
+
+    let _apply: serde_json::Value =
+        app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
+    anyhow::ensure!(
+        keep_path.exists() && lose_path.exists(),
+        "catalogue-in-place (organized default) must never move either file"
+    );
+
+    // Event-driven session grouping (spec 035 US4 plan_listener) — poll until
+    // BOTH frames have joined the same session.
+    let sessions: serde_json::Value = app
+        .invoke_until("sessions_list", json!({}), INVOKE_TIMEOUT, |v: &serde_json::Value| {
+            v.as_array().is_some_and(|arr| {
+                arr.iter().any(|s| {
+                    s["sessionKey"]["target"] == "M 33" && s["frameCount"].as_i64() == Some(2)
+                })
+            })
+        })
+        .await?;
+    let session = sessions
+        .as_array()
+        .and_then(|arr| arr.iter().find(|s| s["sessionKey"]["target"] == "M 33"))
+        .ok_or_else(|| anyhow::anyhow!("no M 33 session found: {sessions}"))?;
+    let session_id = session["id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("session has no id: {session}"))?
+        .to_owned();
+    anyhow::ensure!(
+        session["frameCount"].as_i64() == Some(2),
+        "expected the two same-identity frames to group into one 2-frame session: {session}"
+    );
+
+    // ── 2. Real project (setup precondition) ──
+    //
+    // This journey's DOM focus is the Add-sources session picker's real frame
+    // count, not project creation itself — created over the invoke bridge
+    // like every other journey's preconditions.
+    let project_dir = tempfile::tempdir()?;
+    let create: serde_json::Value = app
+        .invoke(
+            "projects_create",
+            json!({
+                "req": {
+                    "requestId": "e2e-inventory-create",
+                    "name": "E2E Per-Frame Inventory Project",
+                    "tool": "PixInsight",
+                    "path": project_dir.path().to_string_lossy(),
+                    "initialSources": [],
+                    "notes": null,
+                    "canonicalTargetId": null,
+                }
+            }),
+        )
+        .await?;
+    let project_id = create["projectId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("projects.create returned no projectId: {create}"))?
+        .to_owned();
+
+    // ── 3. Real UI (BEFORE): open the project, open Add sources, read the ──
+    // real per-session frame count from the real DOM.
+    app.goto_route("/projects").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.wait_testid(&format!("project-row-{project_id}"), Duration::from_secs(15))
+        .await?
+        .click()
+        .await?;
+    app.wait_testid("edit-project-btn", Duration::from_secs(15)).await?.click().await?;
+    app.wait_testid("edit-project-add-sources-toggle", Duration::from_secs(10))
+        .await?
+        .click()
+        .await?;
+    let frames_before = app
+        .wait_testid_text(
+            &format!("session-picker-frames-{session_id}"),
+            Duration::from_secs(10),
+            |text| !text.trim().is_empty(),
+        )
+        .await?;
+    anyhow::ensure!(
+        frames_before.trim() == "2",
+        "expected the real Add-sources picker to show frameCount=2 before reconcile: \
+         {frames_before:?}"
+    );
+
+    // ── 4. Real filesystem mutation: an external tool/user deletes one raw ──
+    // frame from disk — the exact scenario spec 048 exists to detect.
+    std::fs::remove_file(&lose_path)?;
+    anyhow::ensure!(!lose_path.exists(), "fixture file was not actually removed: {lose_path:?}");
+    anyhow::ensure!(keep_path.exists(), "the surviving frame must still be present: {keep_path:?}");
+
+    // ── 5. Real backend mutation: inventory.reconcile.run ──
+    //
+    // No product UI exposes a reconcile trigger today (KNOWN GAP, module
+    // docs), so this is invoked directly over the bridge.
+    let reconcile: serde_json::Value = app
+        .invoke(
+            "inventory_reconcile_run",
+            json!({ "req": { "rootId": root_id, "reason": "on_demand" } }),
+        )
+        .await?;
+    anyhow::ensure!(
+        reconcile["newlyMissing"].as_i64() == Some(1),
+        "expected exactly 1 newly-missing frame: {reconcile}"
+    );
+    anyhow::ensure!(
+        reconcile["present"].as_i64() == Some(1),
+        "expected exactly 1 still-present frame: {reconcile}"
+    );
+
+    // ── 6. Real UI (AFTER): a fresh page load re-fetches sessions.list ──
+    // (no stale TanStack Query cache to fight) — the SAME real DOM surface
+    // now reflects the real reconciliation result.
+    app.goto_route("/projects").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.wait_testid(&format!("project-row-{project_id}"), Duration::from_secs(15))
+        .await?
+        .click()
+        .await?;
+    app.wait_testid("edit-project-btn", Duration::from_secs(15)).await?.click().await?;
+    app.wait_testid("edit-project-add-sources-toggle", Duration::from_secs(10))
+        .await?
+        .click()
+        .await?;
+    let frames_after = app
+        .wait_testid_text(
+            &format!("session-picker-frames-{session_id}"),
+            Duration::from_secs(15),
+            |text| text.trim() == "1",
+        )
+        .await?;
+    anyhow::ensure!(
+        frames_after.trim() == "1",
+        "expected the real Add-sources picker to show frameCount=1 after reconcile: \
+         {frames_after:?}"
+    );
+
+    app.shutdown().await
+}

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -271,7 +271,22 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
 
     app.wait_testid("generate-source-view-btn", Duration::from_secs(15)).await?.click().await?;
     app.wait_testid("generate-source-view-dialog", Duration::from_secs(10)).await?;
+    app.wait_testid_enabled("generate-source-view-submit", Duration::from_secs(10)).await?;
     app.find_testid("generate-source-view-submit").await?.click().await?;
+
+    // `GenerateSourceViewDialog.handleSubmit` only calls `onClose()` after
+    // `sourceview.generate` resolves successfully, so the dialog closing is
+    // real, DOM-visible proof the submit actually reached and completed the
+    // backend call — a much sharper failure signal than the `plans_list`
+    // poll below if the click never registered or the call errored.
+    app.wait_testid_gone("generate-source-view-dialog", Duration::from_secs(15)).await.map_err(
+        |e| {
+            anyhow::anyhow!(
+                "the dialog never closed after submit — sourceview.generate likely errored \
+                 or the submit click never registered: {e}"
+            )
+        },
+    )?;
 
     // ── 4. Real backend proof: a real, reviewable plan was created ──
     //

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -271,6 +271,28 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
 
     app.wait_testid("generate-source-view-btn", Duration::from_secs(15)).await?.click().await?;
     app.wait_testid("generate-source-view-dialog", Duration::from_secs(10)).await?;
+
+    // Round 4/5 (#470) root cause: the dialog's own diagnostics dump showed
+    // a real `alm-banner--danger` reading "No usable link method is
+    // available on this filesystem. Allow copying to proceed instead." —
+    // the CI runner's tempdir filesystem cannot symlink OR hardlink at all,
+    // `sourceview.generate` correctly refuses with `no_link_kind`
+    // (`domain_core::source_view::resolve_link_kind`), and the dialog's
+    // error Banner rendered exactly as designed. The product was behaving
+    // correctly; this journey just never opted in to the documented copy
+    // fallback. Always check the copy opt-in checkbox rather than
+    // conditionally reacting to the banner (racier — the banner render lags
+    // the settings/capability fetch) or trying to make the fixture's
+    // tempdirs support real links (CI tmpfs/overlay link support is
+    // runner-/OS-dependent and not something this repo controls, so making
+    // that work would just trade one environment-fragile assumption for
+    // another): `copy_opt_in` is consulted only as a last-resort fallback
+    // (`resolve_link_kind`) after every real link kind has already been
+    // tried, so checking it here never changes behavior on a runner where
+    // linking genuinely works — it only unblocks the runners where it
+    // doesn't.
+    app.wait_testid("generate-view-copy-opt-in", Duration::from_secs(10)).await?.click().await?;
+
     app.wait_testid_enabled("generate-source-view-submit", Duration::from_secs(10)).await?;
     app.find_testid("generate-source-view-submit").await?.click().await?;
 
@@ -368,7 +390,7 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
             let regenerate: serde_json::Value = app
                 .invoke(
                     "sourceview_generate",
-                    json!({ "req": { "projectId": project_id, "copyOptIn": false, "strict": false, "profileId": null, "destinationOverride": null } }),
+                    json!({ "req": { "projectId": project_id, "copyOptIn": true, "strict": false, "profileId": null, "destinationOverride": null } }),
                 )
                 .await
                 .unwrap_or_else(|e2| json!({ "sourceview_generate_retry_error": e2.to_string() }));
@@ -432,6 +454,28 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
         "the filter/exposure fallback bucket names changed (or `projects.source.add` now \
          snapshots real filter/exposure) — re-verify the empty-snapshot FINDING documented in \
          this file's module docs before updating this assertion: {layout_tail}"
+    );
+
+    // Document which materialization path this run actually exercised
+    // (`domain_core::source_view::resolve_link_kind`): a real link kind
+    // (symlink/hardlink/junction) when the runner's filesystem supports one,
+    // or the `copy` fallback this journey's `copyOptIn` check unblocks when
+    // it doesn't (observed on the CI ubuntu runner, round 4/5 — see the
+    // copy-opt-in comment above). Either is a fully reviewable plan; this
+    // only asserts the value is a real, known materialization rather than
+    // requiring one specific kind, since runner filesystem capability is
+    // environment-dependent and not something this journey controls.
+    let materialization = link_item["provenance"]
+        .as_array()
+        .and_then(|entries| entries.iter().find(|e| e["label"] == "materialization"))
+        .and_then(|e| e["value"].as_str())
+        .ok_or_else(|| {
+            anyhow::anyhow!("link item has no materialization provenance: {link_item}")
+        })?;
+    anyhow::ensure!(
+        matches!(materialization, "symlink" | "hardlink" | "junction" | "copy"),
+        "unexpected materialization value on the generated link item: {materialization:?} \
+         ({link_item})"
     );
 
     // ── 5. Real, channel-free step available today: approve ──

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -277,16 +277,27 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
     // `GenerateSourceViewDialog.handleSubmit` only calls `onClose()` after
     // `sourceview.generate` resolves successfully, so the dialog closing is
     // real, DOM-visible proof the submit actually reached and completed the
-    // backend call — a much sharper failure signal than the `plans_list`
-    // poll below if the click never registered or the call errored.
-    app.wait_testid_gone("generate-source-view-dialog", Duration::from_secs(15)).await.map_err(
-        |e| {
-            anyhow::anyhow!(
-                "the dialog never closed after submit — sourceview.generate likely errored \
-                 or the submit click never registered: {e}"
-            )
-        },
-    )?;
+    // backend call — a much sharper signal than the `plans_list` poll below
+    // if the click never registered or the call errored. This is
+    // diagnostic-only (never gates the journey): a slow/absent close
+    // animation without a genuine submit failure would otherwise produce a
+    // false negative here even though the plan really was created, and the
+    // real assertion is the `plans_list` read below regardless. On failure,
+    // dump the dialog's own DOM (it renders the submit error inline via a
+    // `Banner`, `GenerateSourceViewDialog.tsx`) plus any buffered uncaught
+    // errors, and fold that evidence into the `plans_list` timeout message
+    // if the plan never shows up either.
+    let dialog_close_diagnostics =
+        match app.wait_testid_gone("generate-source-view-dialog", Duration::from_secs(15)).await {
+            Ok(()) => None,
+            Err(e) => {
+                let diagnostics = app.dump_testid_diagnostics("generate-source-view-dialog").await;
+                Some(format!(
+                    "the dialog never closed after submit — sourceview.generate likely errored or \
+                 the submit click never registered: {e}\ndiagnostics: {diagnostics}"
+                ))
+            }
+        };
 
     // ── 4. Real backend proof: a real, reviewable plan was created ──
     //
@@ -309,7 +320,11 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
                     .is_some_and(|arr| arr.iter().any(|p| p["originPath"] == json!(project_id)))
             },
         )
-        .await?;
+        .await
+        .map_err(|e| match &dialog_close_diagnostics {
+            Some(d) => anyhow::anyhow!("{e}\n\nadditional evidence from the submit step: {d}"),
+            None => e,
+        })?;
     let plan = plans["plans"]
         .as_array()
         .and_then(|arr| arr.iter().find(|p| p["originPath"] == json!(project_id)))

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -304,7 +304,7 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
     // No product UI routes this plan id back for review (KNOWN GAP, module
     // docs), so find it via the real `plans.list` read path instead of a
     // fabricated return value.
-    let plans: serde_json::Value = app
+    let plans_poll = app
         .invoke_until(
             "plans_list",
             json!({
@@ -320,11 +320,69 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
                     .is_some_and(|arr| arr.iter().any(|p| p["originPath"] == json!(project_id)))
             },
         )
-        .await
-        .map_err(|e| match &dialog_close_diagnostics {
-            Some(d) => anyhow::anyhow!("{e}\n\nadditional evidence from the submit step: {d}"),
-            None => e,
-        })?;
+        .await;
+    let plans: serde_json::Value = match plans_poll {
+        Ok(v) => v,
+        Err(e) => {
+            // Round 4 (#470): the previous round's raw-payload dump showed
+            // `{"plans": []}` — no `prepared_view_generation` plan exists AT
+            // ALL, even though the dialog closed (a real success response).
+            // `generate_source_view` (`crates/app/projects/src/
+            // source_view_generate.rs`) has no early-return success path
+            // that skips `insert_plan` — every branch either errors before
+            // persisting anything or persists the plan and advances it to
+            // `ready_for_review` before returning `Ok`. So a genuine silent
+            // "success with nothing persisted" would itself be a real
+            // product bug worth proving directly rather than guessing.
+            // Gather three more pieces of ground truth, all best-effort
+            // (never masking the real error below):
+            // (a) plans.list with NO origin filter — sanity-checks the read
+            //     path itself still works and shows whatever plans DO exist
+            //     (e.g. the earlier inbox-confirm plan).
+            // (b) sessions.list — the project's linked session/frame state
+            //     at THIS moment, to rule out something unlinking it
+            //     between setup and submit.
+            // (c) a second, direct bridge invoke of the SAME
+            //     `sourceview.generate` call with the same project id: if
+            //     it also resolves, the exact response (including any
+            //     warnings) proves what the real call returns; if it now
+            //     errors, that error is the real root cause the UI's first
+            //     call hit too (masked from the test only by the dialog's
+            //     resolved-promise-closes-unconditionally-on-success logic).
+            let all_plans: serde_json::Value = app
+                .invoke(
+                    "plans_list",
+                    json!({
+                        "stateFilter": null,
+                        "originFilter": null,
+                        "createdAfter": null,
+                        "limit": null,
+                    }),
+                )
+                .await
+                .unwrap_or_else(|e2| json!({ "plans_list_no_filter_error": e2.to_string() }));
+            let sessions_now: serde_json::Value = app
+                .invoke("sessions_list", json!({}))
+                .await
+                .unwrap_or_else(|e2| json!({ "sessions_list_error": e2.to_string() }));
+            let regenerate: serde_json::Value = app
+                .invoke(
+                    "sourceview_generate",
+                    json!({ "req": { "projectId": project_id, "copyOptIn": false, "strict": false, "profileId": null, "destinationOverride": null } }),
+                )
+                .await
+                .unwrap_or_else(|e2| json!({ "sourceview_generate_retry_error": e2.to_string() }));
+            let dialog_evidence = dialog_close_diagnostics
+                .as_deref()
+                .unwrap_or("(dialog closed — submit's promise resolved)");
+            return Err(anyhow::anyhow!(
+                "{e}\n\nsubmit-step evidence: {dialog_evidence}\n\ndiagnostic plans.list (no \
+                 origin filter): {all_plans}\n\ndiagnostic sessions.list at failure time: \
+                 {sessions_now}\n\ndiagnostic direct retry of sourceview.generate for the same \
+                 project: {regenerate}"
+            ));
+        }
+    };
     let plan = plans["plans"]
         .as_array()
         .and_then(|arr| arr.iter().find(|p| p["originPath"] == json!(project_id)))

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -69,6 +69,41 @@ use serde_json::json;
 
 const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
 
+/// Wait for the index route's async first-run redirect to land on `/setup`
+/// BEFORE navigating anywhere (mirrors `inbox_ui_journeys.rs`'s
+/// `settle_first_run_redirect`). A fresh DB (the harness resets it every
+/// launch) makes `checkFirstRunComplete` redirect `/` → `/setup` from an
+/// async `beforeLoad`; if a journey `goto_route`s while that redirect is
+/// still pending, the late-resolving redirect can yank the app off the
+/// target route.
+async fn settle_first_run_redirect(app: &E2eApp) -> anyhow::Result<()> {
+    app.wait_url_contains("/setup", Duration::from_secs(15))
+        .await
+        .map(drop)
+        .map_err(|e| anyhow::anyhow!("expected a fresh DB to redirect to /setup: {e}"))
+}
+
+/// Registers a disposable `project`-category root purely to satisfy
+/// `firstrun.complete`'s precondition (one `light_frames` root — this
+/// journey's own ingest root satisfies that half — AND one `project` root,
+/// `crates/persistence/db/src/repositories/first_run.rs`), then routes
+/// through the real gate. A `projects.create` Project entity (this journey
+/// creates one below) is a DIFFERENT concept from a registered `project`
+/// source root and does not satisfy this precondition on its own. Without
+/// this, `Shell.tsx`'s client-side `setupCompleted` gate bounces every
+/// `goto_route` to a Shell-wrapped page (`/projects`) back to `/setup`
+/// indefinitely (mirrors the proven `inbox_ui_journeys.rs` pattern).
+async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
+    let project_dir = tempfile::tempdir()?;
+    let _: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({ "path": project_dir.path().to_string_lossy(), "category": "project", "scanSettings": null }),
+        )
+        .await?;
+    app.complete_first_run_gate().await
+}
+
 /// Generate Source View dialog → real reviewable `prepared_view_generation`
 /// plan with the WBPP per-tool layout → approve.
 #[tokio::test]
@@ -76,6 +111,7 @@ const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
 async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    settle_first_run_redirect(&app).await?;
 
     // ── 1. Real ingest precondition: one real, catalogued-in-place light frame ──
     let root_dir = tempfile::tempdir()?;
@@ -222,6 +258,8 @@ async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<(
             }),
         )
         .await?;
+
+    complete_first_run(&app).await?;
 
     // ── 3. Real UI: select the project, open Generate Source View, submit ──
     app.goto_route("/projects").await?;

--- a/crates/e2e-tests/tests/source_view_journeys.rs
+++ b/crates/e2e-tests/tests/source_view_journeys.rs
@@ -1,0 +1,322 @@
+//! Spec 037 Layer-2 real-UI journey: source-view generation (spec 049).
+//!
+//! Real backend REAL: `roots.register`, `inbox.scan.folder`,
+//! `inbox.classify`, `inbox.confirm`, `inbox.plan.apply` (catalogue-in-place —
+//! see below), `projects.create`, `projects.source.add`, `sourceview.generate`
+//! (driven through the real `GenerateSourceViewDialog` UI, not the invoke
+//! bridge), `plans.list`, `plans.get`, `plans.approve`.
+//!
+//! Real DOM: select the project row (`project-row-<id>`), open the
+//! `SourceViewsSection`'s "Generate source view" dialog
+//! (`generate-source-view-btn` → `generate-source-view-dialog`), and submit it
+//! (`generate-source-view-submit`) — the actual product click path a user
+//! takes, not an IPC-only round trip.
+//!
+//! Catalogue-in-place (not move): `roots.register` defaults non-inbox
+//! categories to `organized` (`apps/desktop/src-tauri/src/commands/roots.rs`),
+//! so `inbox.confirm` emits a `catalogue` action (`from == to`, no move —
+//! `crates/app/inbox/src/confirm.rs`). This journey never calls
+//! `sources.set_organization_state`, so the fixture FITS file stays at its
+//! original path — real, but simpler to reason about than the move variant
+//! the existing `plan_review_apply_with_audit` journey already covers.
+//!
+//! FINDING (documented, not silently worked around): `projects.source.add`
+//! and `projects.create`'s `initialSources` path
+//! (`crates/app/projects/src/project_setup.rs`) have hardcoded
+//! `filter_snapshot`/`exposure_snapshot` to `""` since spec 003
+//! ("Snapshot fields will be empty until spec 003 Inventory is wired") and
+//! this was never revisited even though the real per-session filter/exposure
+//! has been available via `sessions.get`/`sessions.list` since spec 048. As a
+//! result, `sourceview.generate`'s WBPP `{date}/{filter}/{exposure}` layout
+//! (`crates/app/projects/src/source_view_generate.rs`) always lands every
+//! real project-linked session in the pattern's documented `nofilter`/
+//! `unknown-exposure` fallback buckets, never the frame's real filter. This
+//! journey asserts the REAL (fallback) destination shape, not an aspirational
+//! one, and calls the gap out explicitly below rather than masking it with a
+//! looser assertion.
+//!
+//! KNOWN GAP (documented, not faked — mirrors `cleanup_plan_review` in
+//! `journeys.rs`): materializing the real symlink/junction on disk requires
+//! `plans.apply_real`, whose `tauri::ipc::Channel` argument only the product
+//! frontend's `applyPlan` helper (`apps/desktop/src/features/plans/
+//! planApply.ts`) constructs today, via `usePlanApplyProgress` →
+//! `PlanReviewOverlay`. Nothing wires the `sourceview.generate` plan id into
+//! that overlay: `SourceViewsSection.handleGenerated` calls
+//! `onPlanCreated?.(planId)`, but its only real mount point,
+//! `ProjectBottomDetail`, never passes an `onPlanCreated` prop — so both that
+//! callback and the toast's "View plan" action are silent no-ops
+//! (`git grep -n onPlanCreated apps/desktop/src/features/projects` shows the
+//! prop is optional and unconnected on this path). Fabricating a Channel from
+//! a WebDriver script instead would mean reaching into product frontend/Tauri
+//! -internal plumbing beyond a thin test hook — the same call already made
+//! for `cleanup_plan_review` — so this journey stops at `approved` via the
+//! real, channel-free `plans.approve` command. Real, on-disk symlink/junction
+//! proof for spec 049 is BLOCKED on either (a) a channel-free apply command
+//! (matching `inbox.plan.apply`'s precedent), or (b) wiring
+//! `PlanReviewOverlay` (or an equivalent) into `SourceViewsSection` so a real
+//! UI Apply button exists to click.
+//!
+//! Run (CI): `cargo nextest run -p e2e_tests --profile e2e --run-ignored all`
+//! (serial, `.config/nextest.toml`). See `crates/e2e-tests/tests/journeys.rs`
+//! module docs and `README.md` for the full local run procedure.
+
+mod common;
+
+use std::time::Duration;
+
+use common::{write_minimal_fits, E2eApp};
+use serde_json::json;
+
+const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Generate Source View dialog → real reviewable `prepared_view_generation`
+/// plan with the WBPP per-tool layout → approve.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn generate_source_view_creates_reviewable_wbpp_plan() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+
+    // ── 1. Real ingest precondition: one real, catalogued-in-place light frame ──
+    let root_dir = tempfile::tempdir()?;
+    let file_name = "light_m33_001.fits";
+    let light_path = write_minimal_fits(
+        root_dir.path(),
+        file_name,
+        "Light Frame",
+        Some("M 33"),
+        Some("Ha"),
+        Some("2026-01-12T22:00:00"),
+    )?;
+    anyhow::ensure!(light_path.exists(), "fixture FITS file was not written");
+
+    let register: serde_json::Value = app
+        .invoke(
+            "roots_register",
+            json!({
+                "path": root_dir.path().to_string_lossy(),
+                "category": "light_frames",
+                "scanSettings": null,
+            }),
+        )
+        .await?;
+    let root_id = register["sourceId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("roots.register returned no sourceId: {register}"))?
+        .to_owned();
+
+    let scan: serde_json::Value = app
+        .invoke(
+            "inbox_scan_folder",
+            json!({
+                "req": {
+                    "rootId": root_id,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "followSymlinks": false,
+                }
+            }),
+        )
+        .await?;
+    let inbox_item_id = scan["items"][0]["inboxItemId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.scan.folder discovered no item: {scan}"))?
+        .to_owned();
+
+    let classify: serde_json::Value = app
+        .invoke(
+            "inbox_classify",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "forceRescan": false,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                }
+            }),
+        )
+        .await?;
+    let content_signature = classify["contentSignature"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("inbox.classify returned no contentSignature: {classify}"))?
+        .to_owned();
+
+    let confirm: serde_json::Value = app
+        .invoke(
+            "inbox_confirm",
+            json!({
+                "req": {
+                    "inboxItemId": inbox_item_id,
+                    "contentSignature": content_signature,
+                    "destructiveDestination": null,
+                    "rootAbsolutePath": root_dir.path().to_string_lossy(),
+                    "rootId": null,
+                }
+            }),
+        )
+        .await?;
+    anyhow::ensure!(
+        confirm["planId"].as_str().is_some_and(|s| !s.is_empty()),
+        "expected a real (non-empty) plan id from inbox.confirm: {confirm}"
+    );
+
+    let _apply: serde_json::Value =
+        app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
+    anyhow::ensure!(
+        light_path.exists(),
+        "catalogue-in-place (organized default) must never move the file: {light_path:?}"
+    );
+
+    // Event-driven session grouping (spec 035 US4 plan_listener).
+    let sessions: serde_json::Value = app
+        .invoke_until("sessions_list", json!({}), INVOKE_TIMEOUT, |v: &serde_json::Value| {
+            v.as_array().is_some_and(|arr| arr.iter().any(|s| s["sessionKey"]["target"] == "M 33"))
+        })
+        .await?;
+    let session = sessions
+        .as_array()
+        .and_then(|arr| arr.iter().find(|s| s["sessionKey"]["target"] == "M 33"))
+        .ok_or_else(|| anyhow::anyhow!("no M 33 session found: {sessions}"))?;
+    let session_id = session["id"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("session has no id: {session}"))?
+        .to_owned();
+
+    // ── 2. Real project + real project-source link (setup precondition) ──
+    //
+    // `sourceview.generate` reads `project_sources`, populated here via the
+    // same real `projects.source.add` backend the "Add sources" UI drives —
+    // this journey's own DOM focus is the Generate Source View surface (the
+    // companion `inventory_journeys.rs` drives the Add-sources UI itself), so
+    // the link is set up over the invoke bridge like every other journey's
+    // preconditions (project creation, root registration, etc).
+    let project_dir = tempfile::tempdir()?;
+    let create: serde_json::Value = app
+        .invoke(
+            "projects_create",
+            json!({
+                "req": {
+                    "requestId": "e2e-sourceview-create",
+                    "name": "E2E Source View Project",
+                    "tool": "PixInsight",
+                    "path": project_dir.path().to_string_lossy(),
+                    "initialSources": [],
+                    "notes": null,
+                    "canonicalTargetId": null,
+                }
+            }),
+        )
+        .await?;
+    let project_id = create["projectId"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("projects.create returned no projectId: {create}"))?
+        .to_owned();
+
+    let _add_source: serde_json::Value = app
+        .invoke(
+            "projects_source_add",
+            json!({
+                "req": {
+                    "requestId": "e2e-sourceview-add-source",
+                    "projectId": project_id,
+                    "inventorySessionId": session_id,
+                }
+            }),
+        )
+        .await?;
+
+    // ── 3. Real UI: select the project, open Generate Source View, submit ──
+    app.goto_route("/projects").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.wait_testid(&format!("project-row-{project_id}"), Duration::from_secs(15))
+        .await?
+        .click()
+        .await?;
+
+    app.wait_testid("generate-source-view-btn", Duration::from_secs(15)).await?.click().await?;
+    app.wait_testid("generate-source-view-dialog", Duration::from_secs(10)).await?;
+    app.find_testid("generate-source-view-submit").await?.click().await?;
+
+    // ── 4. Real backend proof: a real, reviewable plan was created ──
+    //
+    // No product UI routes this plan id back for review (KNOWN GAP, module
+    // docs), so find it via the real `plans.list` read path instead of a
+    // fabricated return value.
+    let plans: serde_json::Value = app
+        .invoke_until(
+            "plans_list",
+            json!({
+                "stateFilter": null,
+                "originFilter": ["prepared_view_generation"],
+                "createdAfter": null,
+                "limit": null,
+            }),
+            INVOKE_TIMEOUT,
+            |v: &serde_json::Value| {
+                v["plans"]
+                    .as_array()
+                    .is_some_and(|arr| arr.iter().any(|p| p["originPath"] == json!(project_id)))
+            },
+        )
+        .await?;
+    let plan = plans["plans"]
+        .as_array()
+        .and_then(|arr| arr.iter().find(|p| p["originPath"] == json!(project_id)))
+        .ok_or_else(|| {
+            anyhow::anyhow!("no prepared_view_generation plan found for {project_id}: {plans}")
+        })?;
+    let plan_id =
+        plan["id"].as_str().ok_or_else(|| anyhow::anyhow!("plan has no id: {plan}"))?.to_owned();
+    anyhow::ensure!(
+        plan["state"] == "ready_for_review",
+        "expected the generated plan to be ready_for_review: {plan}"
+    );
+
+    // ── Real per-tool layout proof (spec 049 US2) ──
+    //
+    // The WBPP/PixInsight default profile groups lights 3 levels deep
+    // (night / filter / exposure) under `<project>/source-views/<plan_id>/`.
+    // Per the FINDING documented in the module docs, filter/exposure resolve
+    // to their registry fallback names here ("nofilter"/"unknown-exposure"),
+    // not the frame's real "Ha" filter — this asserts that REAL behavior.
+    let detail: serde_json::Value = app.invoke("plans_get", json!({ "id": plan_id })).await?;
+    let link_item = detail["items"]
+        .as_array()
+        .and_then(|items| items.iter().find(|i| i["action"] == "link"))
+        .ok_or_else(|| anyhow::anyhow!("generated plan has no link item: {detail}"))?;
+    let to_path = link_item["to"]
+        .as_str()
+        .ok_or_else(|| anyhow::anyhow!("link item has no destination path: {link_item}"))?;
+    let expected_prefix =
+        format!("{}/source-views/{plan_id}/", project_dir.path().to_string_lossy());
+    anyhow::ensure!(
+        to_path.starts_with(&expected_prefix),
+        "expected the generated destination under the project's own source-views/<plan_id> \
+         tree: {to_path} (expected prefix {expected_prefix})"
+    );
+    let layout_tail = to_path.strip_prefix(&expected_prefix).ok_or_else(|| {
+        anyhow::anyhow!("prefix check above should guarantee this strip succeeds: {to_path}")
+    })?;
+    let layout_segments: Vec<&str> = layout_tail.split('/').collect();
+    anyhow::ensure!(
+        layout_segments.len() == 4 && layout_segments[3] == file_name,
+        "expected the WBPP 3-level {{date}}/{{filter}}/{{exposure}} layout ending in the real \
+         frame's basename, got: {layout_tail} (from {to_path})"
+    );
+    anyhow::ensure!(
+        layout_segments[1] == "nofilter" && layout_segments[2] == "unknown-exposure",
+        "the filter/exposure fallback bucket names changed (or `projects.source.add` now \
+         snapshots real filter/exposure) — re-verify the empty-snapshot FINDING documented in \
+         this file's module docs before updating this assertion: {layout_tail}"
+    );
+
+    // ── 5. Real, channel-free step available today: approve ──
+    let approve: serde_json::Value = app.invoke("plans_approve", json!({ "id": plan_id })).await?;
+    anyhow::ensure!(
+        approve["planId"] == json!(plan_id) && approve["newState"] == "approved",
+        "expected plans.approve to move the generated plan to approved: {approve}"
+    );
+
+    // Apply (real symlink/junction materialization) is BLOCKED — see the
+    // KNOWN GAP in this file's module docs.
+
+    app.shutdown().await
+}

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -253,8 +253,8 @@ see the finding below).
 | 044 | Targets planner — Track B ephemeris/observer engine | n/a (frontend-only) | ❌ | ❌ | journey-09 | **Compute engine merged (`a395ce93`) but functionally unreachable**: real astronomy is gated behind `useObserverSiteExists()`, and `site-gate.ts::readSiteExists()` is hardcoded `return false` — no site-creation UI/command exists on `main` until PR #440 (spec 044 US3, open) merges. Verify this is still true before reusing this row. |
 | 046 | i18n infrastructure & error-code translation | ✅ | n/a (cross-cutting) | ❌ | journey-10 | `specs/SPEC_STATUS.md`: Implemented, 36/36 |
 | 047 | Targets planner — Track A (Moon/filter/opposition) | ✅ | ❌ | ❌ | journey-09 | Implemented in code but **also gated by the same site-exists check as 044** (spec 047 D7) — see 044 row; spec's own T028 explicitly defers verify-on-windows here |
-| 048 | Per-frame inventory / live session membership | ✅ (partial) | ❌ | ❌ | — (folds into journeys 4/6) | `main` PRs #435/#442 merged; full per-frame-inventory US scope still open |
-| 049 | Source-view generation (symlinks/junctions) | ✅ (partial) | ❌ | ❌ | — (new journey needed, none written this pass) | `main` PR #439 (US1) + #443 (US2 profile layout) merged; junction/symlink behavior is real, OS-specific filesystem behavior a mock layer structurally cannot prove — highest-value Layer-2 candidate of the unlisted specs |
+| 048 | Per-frame inventory / live session membership | ✅ (partial) | 🟡 `inventory_journeys.rs::reconcile_drops_externally_deleted_frame_from_real_ui_count` | ❌ | — (folds into journeys 4/6) | `main` PRs #435/#442 merged; full per-frame-inventory US scope still open. New journey proves a real external raw-frame deletion + `inventory.reconcile.run` through the real Add-sources session picker's frame count — **but `inventory.reconcile.run`/`inventory.frame.list`/`inventory.root_config.*` have zero frontend callers** (no UI button/setting triggers a reconcile pass anywhere), so the trigger itself is IPC-only by necessity, not by choice; only the reconciliation *result* is read from real DOM |
+| 049 | Source-view generation (symlinks/junctions) | ✅ (partial) | 🟡 `source_view_journeys.rs::generate_source_view_creates_reviewable_wbpp_plan` | ❌ | — (new journey needed, none written this pass) | `main` PR #439 (US1) + #443 (US2 profile layout) merged; junction/symlink behavior is real, OS-specific filesystem behavior a mock layer structurally cannot prove — highest-value Layer-2 candidate of the unlisted specs. New journey drives the REAL "Generate source view" dialog end-to-end to a reviewable, approved `prepared_view_generation` plan and asserts the real WBPP 3-level destination layout — **but stops at `approved`**: real symlink/junction materialization needs `plans.apply_real`'s `tauri::ipc::Channel`, which no product UI constructs for this plan type (`SourceViewsSection`/`ProjectBottomDetail` drop the generated plan id on the floor — see the journey's module docs), the same channel-free-apply blocker already tracked for cleanup/archive (batch items #1/#2 below). Also surfaced a real, pre-existing data-quality gap: `projects.source.add`/`projects.create` have shipped empty `filter_snapshot`/`exposure_snapshot` since spec 003 and were never wired to the real per-session values available since spec 048, so every real project's generated layout falls back to `nofilter`/`unknown-exposure` folders instead of the frame's real filter |
 
 **Finding (verified against code, not spec prose)**: `specs/SPEC_STATUS.md`
 row 77 (044) reads "Track B specced, implementation in progress... T001–T003
@@ -332,12 +332,30 @@ just test the mock, not the product:
    MasterDetail)", which is not true of the code as of this writing. This
    makes Tests 3-5 unreachable from the real app and therefore
    un-automatable at Layer 2 until product wiring lands.
-4. **Source-view generation** (spec 049) — generate/regenerate a
-   WBPP-profile source view and assert real symlinks/junctions exist on
-   disk with the correct per-tool layout; real OS-specific filesystem
-   behavior the mock layer can never prove. No journey exists yet.
-5. **Per-frame inventory reconciliation** (spec 048) — raw-frame-vs-disk
-   reconciliation feeding cleanup candidates; extends Journeys 4/6.
+4. **Source-view generation** (spec 049) — PARTIALLY DONE (2026-07-05,
+   `crates/e2e-tests/tests/source_view_journeys.rs::generate_source_view_creates_reviewable_wbpp_plan`):
+   drives the REAL "Generate source view" dialog (real project row →
+   `SourceViewsSection` button → dialog submit) to a real, reviewable
+   `prepared_view_generation` plan and asserts the WBPP 3-level
+   `{date}/{filter}/{exposure}` destination layout — then stops at
+   `approved`. The remaining scope (assert real symlinks/junctions exist
+   on disk) is **blocked** on the same channel-free apply command as
+   items #1/#2: `plans.apply_real`'s `tauri::ipc::Channel` is never
+   constructed for this plan type by any product UI
+   (`ProjectBottomDetail` drops the generated plan id — see the
+   journey's module docs). Also surfaced the empty
+   `filter_snapshot`/`exposure_snapshot` data-quality FINDING recorded
+   in the 049 row above.
+5. **Per-frame inventory reconciliation** (spec 048) — DONE for the
+   reconcile→UI read path (2026-07-05,
+   `crates/e2e-tests/tests/inventory_journeys.rs::reconcile_drops_externally_deleted_frame_from_real_ui_count`):
+   real external raw-frame deletion + real `inventory.reconcile.run` →
+   the real Add-sources session picker's frame count drops 2→1 in the
+   product DOM. The reconcile *trigger* stays on the invoke bridge by
+   necessity (zero frontend callers exist for
+   `inventory.reconcile.run`/`inventory.frame.list`/`inventory.root_config.*`
+   — see the 048 row above); the cleanup-candidate feed (Journeys 4/6
+   extension) remains open.
 6. **Inbox UI-level gate + reclassify + root-picker** (Journeys 2/3) — DONE
    (2026-07-05, `crates/e2e-tests/tests/inbox_ui_journeys.rs`): mixed-folder
    splitting, the unclassified-frame-type gate + bulk-reclassify unblock, the


### PR DESCRIPTION
## Summary
- Adds two automated end-to-end tests (spec 037 Layer-2, batched-plan items #4/#5) that drive the real desktop UI, promoting source-view generation (spec 049) and per-frame inventory reconciliation (spec 048) from IPC-only round-trips to real-DOM proof.
- **Source view** (`source_view_journeys.rs`): clicks through the real project row → "Generate source view" dialog → submit, then proves a real, reviewable `prepared_view_generation` plan exists with the real WBPP 3-level `{date}/{filter}/{exposure}` destination layout, and approves it. Stops at `approved`: real symlink/junction materialization is blocked on the same channel-free `plans.apply` gap already tracked for cleanup/archive (no product UI constructs the `tauri::ipc::Channel` for this plan type — `ProjectBottomDetail` drops the generated plan id on the floor).
- **Per-frame inventory** (`inventory_journeys.rs`): deletes a real raw frame from disk (the disconnected-drive / external-tool scenario spec 048 exists to detect), runs a real reconcile pass, and proves the real Add-sources session picker's frame count drops 2 → 1 in the product DOM — not just in the IPC response.

**Findings while writing these (not fixed here, flagged for follow-up):**
- `projects.source.add` / `projects.create` have shipped empty `filter_snapshot`/`exposure_snapshot` since spec 003 and were never wired to the real per-session values available since spec 048 — every real project's generated source-view layout lands in the `nofilter`/`unknown-exposure` fallback buckets instead of the frame's real filter. The journey asserts this REAL behavior and documents it.
- `inventory.reconcile.run` / `inventory.frame.list` / `inventory.root_config.*` have zero frontend callers — no button, setting, or scheduled trigger anywhere in the product invokes a reconcile pass, so the journey's trigger stays on the invoke bridge by necessity.

Supporting changes: three minimal real-DOM helpers in `common/mod.rs` (`find_testid`/`wait_testid`/`wait_testid_text`), `data-testid` hooks on the projects surfaces the journeys click, and the coverage-matrix bookkeeping (048/049 rows + batched-plan items #4/#5).

## Test plan
- [x] `cargo test -p e2e_tests --no-run` (compile-only; these tests only run in CI's dedicated end-to-end workflow, which needs a real app window)
- [x] `cargo clippy -p e2e_tests --all-targets -- -D warnings`
- [x] `cargo fmt --check`
- [x] `just typecheck` (frontend `data-testid` additions)
- [ ] CI end-to-end workflow (3-OS matrix) runs the new tests for real

Note: like the sibling journey PRs (#457/#458/#463/#464/#465/#467), this branch carries a copy of the shared test-helper additions to `crates/e2e-tests/tests/common/mod.rs`; a propagation lane reconciles that file after the #457 polling fix settles — whichever merges last should converge to a no-op diff there.

## Spec Context
- Spec: 037
- Branch: 037-journeys-sourceview-perframe