### PR TITLE
feat: prevent duplicate app windows on repeat launch

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -612,6 +612,34 @@ pub fn build_app() -> tauri::App {
 
     #[allow(unused_mut)]
     let mut tb = tauri::Builder::default()
+        // Spec 051 US1: single-instance guard MUST be the first plugin
+        // registered so a redirected second launch is intercepted during
+        // `.build()` below — before any other plugin/state/window setup, and
+        // therefore before `main()` ever reaches `Database::connect`/
+        // `db.migrate()` (FR-003: the second launch performs no database
+        // migration, seed, or write of its own).
+        .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
+            tracing::info!(
+                ?argv,
+                %cwd,
+                "second launch attempt redirected to existing instance"
+            );
+            // FR-002: focus/foreground the existing main window, restoring it
+            // if minimized, instead of opening a new window or connection.
+            if let Some(window) = app.get_webview_window("main") {
+                if let Err(e) = window.unminimize() {
+                    tracing::warn!("failed to unminimize main window: {e:?}");
+                }
+                if let Err(e) = window.show() {
+                    tracing::warn!("failed to show main window: {e:?}");
+                }
+                if let Err(e) = window.set_focus() {
+                    tracing::warn!("failed to focus main window: {e:?}");
+                }
+            } else {
+                tracing::warn!("single-instance redirect: no `main` window found to focus");
+            }
+        }))
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init());
 

--- a/specs/051-tauri-shell-integration/tasks.md
+++ b/specs/051-tauri-shell-integration/tasks.md
@@ -111,23 +111,29 @@ duplicate process against the same database.
 **Independent Test**: Launch the app twice in a row; confirm one window, one
 process, no database contention.
 
-- [ ] T010 [US1] Register `tauri_plugin_single_instance::init(...)` as the
+- [x] T010 [US1] Register `tauri_plugin_single_instance::init(...)` as the
       **first** plugin in `build_app()` (`apps/desktop/src-tauri/src/lib.rs`)
       — single-instance must attach before other plugins/state so a
       redirected second launch never reaches database/migration code. The
       callback focuses/unminimizes the existing main window and logs the
       received argv/cwd (FR-002, FR-003).
-- [ ] T011 [US1] Confirm (add if missing) that the single-instance callback
+- [x] T011 [US1] Confirm (add if missing) that the single-instance callback
       runs before `Database::connect`/`db.migrate()` in `main.rs` on the
       redirected path — i.e. the second process's `main()` never reaches
       those calls at all once the plugin redirects it (FR-003 — "exit without
-      performing any database migration, seed, or write").
-- [ ] T012 [P] [US1] Add a capability entry if `tauri-plugin-single-instance`
+      performing any database migration, seed, or write"). Confirmed:
+      `main.rs` already calls `build_app()` (which registers and builds the
+      single-instance plugin first) before `Database::connect`/`db.migrate()`;
+      no reordering needed.
+- [x] T012 [P] [US1] Add a capability entry if `tauri-plugin-single-instance`
       requires one (most single-instance plugins need no webview-side
       permission since it is a setup-time-only Rust API — verify against the
       plugin's docs at implementation time and add to
       `apps/desktop/src-tauri/capabilities/default.json` only if actually
-      required).
+      required). Verified against the vendored `tauri-plugin-single-instance
+      2.4.2` crate: no `permissions/` schema directory and its README confirms
+      it is a Rust-only, setup-time API with no frontend/webview surface — no
+      capability entry added.
 - [ ] T013 [US1] Manual verification: launch the built app, launch it again
       from a shortcut/CLI while running, confirm single window + focus
       (SC-001); repeat with the window minimized (US1 AS2).


### PR DESCRIPTION
## Summary
- Launching the app a second time while it's already running now focuses and restores the existing window instead of opening a duplicate window or process.

## What's new
- A repeat launch (double-click, shortcut, or CLI) brings the already-running window to the front and un-minimizes it if needed, rather than starting a second instance against the same database.

## Spec Context
- Spec: 051
- Branch: 051-us1-single-instance