### PR TITLE
feat: target favourites now persist in the database

### DIFF
--- a/apps/desktop/src-tauri/src/commands/mod.rs
+++ b/apps/desktop/src-tauri/src/commands/mod.rs
@@ -45,6 +45,7 @@ pub mod search;
 pub mod sessions;
 pub mod settings;
 pub mod status;
+pub mod target_favourites;
 pub mod target_lookup;
 pub mod target_management;
 pub mod targets;

--- a/apps/desktop/src-tauri/src/commands/target_favourites.rs
+++ b/apps/desktop/src-tauri/src/commands/target_favourites.rs
@@ -1,0 +1,72 @@
+//! Target favourites Tauri commands (spec 051 US2).
+//!
+//! ## Commands
+//!
+//! - `targets.favourites.list` — list favourited canonical target ids.
+//! - `targets.favourites.add` — favourite a canonical target.
+//! - `targets.favourites.remove` — unfavourite a canonical target.
+//!
+//! Replaces the `localStorage`-only stub in
+//! `apps/desktop/src/features/targets/useFavourites.ts` with durable,
+//! database-backed state (migration `0061` `target_favourite`).
+#![allow(clippy::doc_markdown)] // spec/domain terminology not suited for backticks
+
+use contracts_core::targets::{
+    TargetFavouriteAddResult, TargetFavouriteRemoveResult, TargetFavouriteRequest,
+    TargetFavouritesListResult, TargetOpError,
+};
+use tauri::State;
+
+use crate::commands::lifecycle::AppState;
+
+// ── targets.favourites.list ──────────────────────────────────────────────────
+
+/// `targets.favourites.list` — list the ids of every currently-favourited
+/// canonical target.
+///
+/// # Errors
+///
+/// Returns `Err(TargetOpError)` with code `internal.database`.
+#[tauri::command]
+#[specta::specta]
+pub async fn target_favourites_list(
+    state: State<'_, AppState>,
+) -> Result<TargetFavouritesListResult, TargetOpError> {
+    tracing::debug!("targets.favourites.list");
+    app_core::target_favourites::list(state.repo.pool()).await
+}
+
+// ── targets.favourites.add ───────────────────────────────────────────────────
+
+/// `targets.favourites.add` — favourite a canonical target. Idempotent.
+///
+/// # Errors
+///
+/// Returns `Err(TargetOpError)` with code `target.not_found` or
+/// `internal.database`.
+#[tauri::command]
+#[specta::specta]
+pub async fn target_favourites_add(
+    state: State<'_, AppState>,
+    req: TargetFavouriteRequest,
+) -> Result<TargetFavouriteAddResult, TargetOpError> {
+    tracing::debug!("targets.favourites.add target_id={}", req.target_id);
+    app_core::target_favourites::add(state.repo.pool(), &req).await
+}
+
+// ── targets.favourites.remove ────────────────────────────────────────────────
+
+/// `targets.favourites.remove` — unfavourite a canonical target. Idempotent.
+///
+/// # Errors
+///
+/// Returns `Err(TargetOpError)` with code `internal.database`.
+#[tauri::command]
+#[specta::specta]
+pub async fn target_favourites_remove(
+    state: State<'_, AppState>,
+    req: TargetFavouriteRequest,
+) -> Result<TargetFavouriteRemoveResult, TargetOpError> {
+    tracing::debug!("targets.favourites.remove target_id={}", req.target_id);
+    app_core::target_favourites::remove(state.repo.pool(), &req).await
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -107,6 +107,9 @@ use crate::commands::settings::{
     settings_source_override_set, settings_update,
 };
 use crate::commands::status::status_summary;
+use crate::commands::target_favourites::{
+    target_favourites_add, target_favourites_list, target_favourites_remove,
+};
 use crate::commands::target_lookup::{
     target_resolution_settings, target_resolution_settings_update, target_resolve, target_search,
 };
@@ -204,6 +207,10 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         target_mgmt_cmds::target_projects_list,
         target_mgmt_cmds::target_note_get,
         target_mgmt_cmds::target_note_update,
+        // target favourites (spec 051 US2)
+        target_favourites_list,
+        target_favourites_add,
+        target_favourites_remove,
         // target resolve (spec 035 — SIMBAD cache-first resolution)
         target_resolve,
         // target search (spec 035, US1)
@@ -420,6 +427,10 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         target_mgmt_cmds::target_projects_list,
         target_mgmt_cmds::target_note_get,
         target_mgmt_cmds::target_note_update,
+        // target favourites (spec 051 US2)
+        target_favourites_list,
+        target_favourites_add,
+        target_favourites_remove,
         // target resolve (spec 035 — SIMBAD cache-first resolution)
         target_resolve,
         // target search (spec 035, US1)

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -278,6 +278,10 @@ let mockCameras: Camera[] = [
   { id: 'cam-002', name: 'ASI533MC Pro', aliases: ['ZWO ASI533MC'], autoDetected: false },
 ];
 
+// Target favourites (spec 051 US2): id → favourited-at timestamp, mirroring
+// the real `target_favourite` table's shape (row presence = favourited).
+const mockFavourites = new Map<string, string>();
+
 let mockTelescopes: Telescope[] = [
   { id: 'tel-001', name: 'Takahashi FSQ-106EDX4', aliases: [], focalLengthMm: 530, autoDetected: false },
   { id: 'tel-002', name: 'William Optics GT81', aliases: [], focalLengthMm: 478, autoDetected: false },
@@ -607,6 +611,22 @@ export async function mockInvoke(
         source: 'resolved',
         aliases: [],
       } satisfies TargetDetailV3_Serialize;
+    }
+    case 'target_favourites_list': {
+      return { targetIds: [...mockFavourites.keys()] };
+    }
+    case 'target_favourites_add': {
+      const req = (_args as { req?: { targetId?: string } } | undefined)?.req;
+      const targetId = req?.targetId ?? '';
+      const favouritedAt = mockFavourites.get(targetId) ?? new Date().toISOString();
+      mockFavourites.set(targetId, favouritedAt);
+      return { targetId, favouritedAt };
+    }
+    case 'target_favourites_remove': {
+      const req = (_args as { req?: { targetId?: string } } | undefined)?.req;
+      const targetId = req?.targetId ?? '';
+      mockFavourites.delete(targetId);
+      return { targetId };
     }
     case 'target_search': {
       const req = (_args as { req?: { query?: string } } | undefined)?.req;

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -258,6 +258,32 @@ export const commands = {
 	 */
 	targetNoteUpdate: (req: TargetNoteUpdateRequest) => typedError<TargetNoteUpdateResult_Serialize, TargetOpError_Serialize>(__TAURI_INVOKE("target_note_update", { req })),
 	/**
+	 *  `targets.favourites.list` — list the ids of every currently-favourited
+	 *  canonical target.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(TargetOpError)` with code `internal.database`.
+	 */
+	targetFavouritesList: () => typedError<TargetFavouritesListResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_favourites_list")),
+	/**
+	 *  `targets.favourites.add` — favourite a canonical target. Idempotent.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(TargetOpError)` with code `target.not_found` or
+	 *  `internal.database`.
+	 */
+	targetFavouritesAdd: (req: TargetFavouriteRequest) => typedError<TargetFavouriteAddResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_favourites_add", { req })),
+	/**
+	 *  `targets.favourites.remove` — unfavourite a canonical target. Idempotent.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(TargetOpError)` with code `internal.database`.
+	 */
+	targetFavouritesRemove: (req: TargetFavouriteRequest) => typedError<TargetFavouriteRemoveResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_favourites_remove", { req })),
+	/**
 	 *  `target.resolve` — cache-first resolution of a designation / common name (or
 	 *  FITS OBJECT value) against the local cache + bundled seed, falling back to
 	 *  SIMBAD on a miss when online resolution is enabled (spec 035).
@@ -7509,6 +7535,29 @@ export type TargetDisplayAliasSetRequest = {
 	targetId: string,
 	/**  Presentation label. Empty/blank is treated as a clear (NULL). */
 	displayAlias: string,
+};
+
+/**  Response for `targets.favourites.add` (spec 051 US2). */
+export type TargetFavouriteAddResult = {
+	targetId: string,
+	/**  ISO-8601 UTC timestamp the target was first favourited. */
+	favouritedAt: string,
+};
+
+/**  Response for `targets.favourites.remove` (spec 051 US2). */
+export type TargetFavouriteRemoveResult = {
+	targetId: string,
+};
+
+/**  Request for `targets.favourites.add` / `targets.favourites.remove` (spec 051 US2). */
+export type TargetFavouriteRequest = {
+	targetId: string,
+};
+
+/**  Response for `targets.favourites.list` (spec 051 US2). */
+export type TargetFavouritesListResult = {
+	/**  Ids of every currently-favourited canonical target. */
+	targetIds: string[],
 };
 
 /**  Request for `target.get` (gen-3). */

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -413,14 +413,12 @@ interface Props {
    */
   guidanceParams?: MoonAvoidanceParams;
   /**
-   * Set of currently-favourited target ids (task #18).
+   * Set of currently-favourited target ids (task #18, spec 051 US2).
    * When provided the star column renders filled for matched ids.
-   * STUB: sourced from localStorage via useFavourites until task #54 lands.
    */
   favouriteIds?: ReadonlySet<string>;
   /**
    * Called when the user clicks the star button in a row (task #18).
-   * STUB: see useFavourites.ts.
    */
   onToggleFavourite?: (targetId: string) => void;
 }

--- a/apps/desktop/src/features/targets/useFavourites.test.ts
+++ b/apps/desktop/src/features/targets/useFavourites.test.ts
@@ -1,73 +1,132 @@
 /**
- * useFavourites.test.ts — unit tests for the client-side favourite/star store
- * (task #18, spec 043).
+ * useFavourites.test.ts — unit tests for the database-backed favourite/star
+ * store (spec 051 US2).
  *
- * Tests the non-hook surface (getFavouriteIds / the toggle function via direct
- * localStorage manipulation) since hooks require renderHook + act and these are
- * simpler to keep pure.  The localStorage shim in vitest.setup.ts provides
- * storage isolation.
- *
- * STUB: favourites are localStorage-only until task #54 lands.
+ * Mocks the generated IPC bindings (`@/bindings/index`'s `commands` object)
+ * instead of `localStorage`/`StorageEvent` — favourites are now backend-backed
+ * state (`targets.favourites.list` / `.add` / `.remove`).
  */
 
-import { beforeEach, describe, it, expect } from 'vitest';
-import { getFavouriteIds, FAVOURITES_STORAGE_KEY } from './useFavourites';
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+import { renderHook, act, waitFor } from '@testing-library/react';
 
-function writeIds(ids: string[]): void {
-  localStorage.setItem(FAVOURITES_STORAGE_KEY, JSON.stringify(ids));
+type MockIpc = (...args: unknown[]) => Promise<unknown>;
+
+const mockTargetFavouritesList = vi.fn<MockIpc>();
+const mockTargetFavouritesAdd = vi.fn<MockIpc>();
+const mockTargetFavouritesRemove = vi.fn<MockIpc>();
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetFavouritesList: (...args: unknown[]) => mockTargetFavouritesList(...args),
+    targetFavouritesAdd: (...args: unknown[]) => mockTargetFavouritesAdd(...args),
+    targetFavouritesRemove: (...args: unknown[]) => mockTargetFavouritesRemove(...args),
+  },
+}));
+
+// Imported after the mock so the module under test picks up the mocked bindings.
+const { useFavourites, getFavouriteIds, __resetFavouritesCacheForTests } = await import(
+  './useFavourites'
+);
+
+function okList(targetIds: string[]) {
+  return Promise.resolve({ status: 'ok', data: { targetIds } });
+}
+
+function okAdd(targetId: string, favouritedAt = '2026-07-06T00:00:00Z') {
+  return Promise.resolve({ status: 'ok', data: { targetId, favouritedAt } });
+}
+
+function okRemove(targetId: string) {
+  return Promise.resolve({ status: 'ok', data: { targetId } });
 }
 
 beforeEach(() => {
-  localStorage.clear();
+  __resetFavouritesCacheForTests();
+  mockTargetFavouritesList.mockReset();
+  mockTargetFavouritesAdd.mockReset();
+  mockTargetFavouritesRemove.mockReset();
+  mockTargetFavouritesList.mockReturnValue(okList([]));
+  mockTargetFavouritesAdd.mockImplementation((...args: unknown[]) => {
+    const { targetId } = args[0] as { targetId: string };
+    return okAdd(targetId);
+  });
+  mockTargetFavouritesRemove.mockImplementation((...args: unknown[]) => {
+    const { targetId } = args[0] as { targetId: string };
+    return okRemove(targetId);
+  });
 });
 
 describe('getFavouriteIds', () => {
-  it('returns an empty set when nothing is stored', () => {
+  it('returns an empty set before the backend fetch resolves', () => {
     const ids = getFavouriteIds();
     expect(ids.size).toBe(0);
-  });
-
-  it('returns the stored ids as a Set', () => {
-    writeIds(['id-a', 'id-b']);
-    const ids = getFavouriteIds();
-    expect(ids.has('id-a')).toBe(true);
-    expect(ids.has('id-b')).toBe(true);
-    expect(ids.size).toBe(2);
-  });
-
-  it('returns an empty set when the stored value is not a JSON array', () => {
-    localStorage.setItem(FAVOURITES_STORAGE_KEY, 'not-json');
-    const ids = getFavouriteIds();
-    expect(ids.size).toBe(0);
-  });
-
-  it('filters out non-string entries from the stored array', () => {
-    localStorage.setItem(FAVOURITES_STORAGE_KEY, JSON.stringify(['id-a', 42, null, 'id-b']));
-    const ids = getFavouriteIds();
-    expect(ids.has('id-a')).toBe(true);
-    expect(ids.has('id-b')).toBe(true);
-    expect(ids.size).toBe(2);
   });
 });
 
-describe('FAVOURITES_STORAGE_KEY', () => {
-  it('is the expected localStorage key', () => {
-    expect(FAVOURITES_STORAGE_KEY).toBe('alm:targets:favourites');
-  });
-});
+describe('useFavourites', () => {
+  it('loads the favourite set from the backend on mount', async () => {
+    mockTargetFavouritesList.mockReturnValue(okList(['id-a', 'id-b']));
 
-describe('round-trip: write to localStorage then read back', () => {
-  it('reads back ids written via JSON directly', () => {
-    writeIds(['uuid-1', 'uuid-2', 'uuid-3']);
-    const ids = getFavouriteIds();
-    expect(ids.size).toBe(3);
-    expect(ids.has('uuid-1')).toBe(true);
-    expect(ids.has('uuid-3')).toBe(true);
+    const { result } = renderHook(() => useFavourites());
+
+    await waitFor(() => expect(result.current.favouriteIds.size).toBe(2));
+    expect(result.current.isFavourite('id-a')).toBe(true);
+    expect(result.current.isFavourite('id-b')).toBe(true);
+    expect(mockTargetFavouritesList).toHaveBeenCalledTimes(1);
   });
 
-  it('an empty stored array gives an empty set', () => {
-    writeIds([]);
-    const ids = getFavouriteIds();
-    expect(ids.size).toBe(0);
+  it('toggle favourites an unfavourited target optimistically then confirms via the backend', async () => {
+    const { result } = renderHook(() => useFavourites());
+    await waitFor(() => expect(mockTargetFavouritesList).toHaveBeenCalled());
+
+    act(() => {
+      result.current.toggle('id-x');
+    });
+
+    // Optimistic update is synchronous.
+    expect(result.current.isFavourite('id-x')).toBe(true);
+
+    await waitFor(() => expect(mockTargetFavouritesAdd).toHaveBeenCalledWith({ targetId: 'id-x' }));
+    expect(result.current.isFavourite('id-x')).toBe(true);
+  });
+
+  it('toggle unfavourites an already-favourited target', async () => {
+    mockTargetFavouritesList.mockReturnValue(okList(['id-y']));
+    const { result } = renderHook(() => useFavourites());
+    await waitFor(() => expect(result.current.isFavourite('id-y')).toBe(true));
+
+    act(() => {
+      result.current.toggle('id-y');
+    });
+
+    expect(result.current.isFavourite('id-y')).toBe(false);
+    await waitFor(() =>
+      expect(mockTargetFavouritesRemove).toHaveBeenCalledWith({ targetId: 'id-y' }),
+    );
+  });
+
+  it('reverts the optimistic add when the backend call fails', async () => {
+    mockTargetFavouritesAdd.mockReturnValue(
+      Promise.resolve({ status: 'error', error: { code: 'internal.database', message: 'boom' } }),
+    );
+    const { result } = renderHook(() => useFavourites());
+    await waitFor(() => expect(mockTargetFavouritesList).toHaveBeenCalled());
+
+    act(() => {
+      result.current.toggle('id-z');
+    });
+    expect(result.current.isFavourite('id-z')).toBe(true);
+
+    await waitFor(() => expect(result.current.isFavourite('id-z')).toBe(false));
+  });
+
+  it('shares the cache across multiple hook mounts', async () => {
+    mockTargetFavouritesList.mockReturnValue(okList(['id-shared']));
+    const a = renderHook(() => useFavourites());
+    const b = renderHook(() => useFavourites());
+
+    await waitFor(() => expect(a.result.current.isFavourite('id-shared')).toBe(true));
+    await waitFor(() => expect(b.result.current.isFavourite('id-shared')).toBe(true));
   });
 });

--- a/apps/desktop/src/features/targets/useFavourites.ts
+++ b/apps/desktop/src/features/targets/useFavourites.ts
@@ -1,100 +1,83 @@
 /**
- * useFavourites — client-side favourite/starred targets (task #18, spec 043).
+ * useFavourites — database-backed favourite/starred targets (spec 051 US2).
  *
- * STUB: favourites are stored in localStorage only.  Real persistence requires
- * the FITS OBJECT → target_id linkage (task #54) so the backend knows which
- * canonical targets have linked sessions/projects.  When #54 lands, replace
- * this module with a backend-backed hook that reads the real "My Targets" set.
+ * Favourites are canonical, database-backed state (`target_favourite` table,
+ * migration `0061`) — see `targets.favourites.list` / `.add` / `.remove` in
+ * `apps/desktop/src-tauri/src/commands/target_favourites.rs`. This replaces
+ * the previous `localStorage`-only stub (task #18, spec 043).
  *
- * localStorage key: 'alm:targets:favourites'
- * Format:           JSON array of canonical target id strings.
+ * The old stub cited task #54 (FITS OBJECT → target_id linkage) as its own
+ * blocker — that citation was specific to *storage location*, which this
+ * feature resolves (favourites are keyed directly off canonical target ids,
+ * independent of any FITS ingest linkage). Task #54 itself is broader than
+ * favourites storage: it also covers the FITS-derived target list backing
+ * `TargetsPage.tsx`'s stub filters and `ProjectsTable.tsx`'s target column
+ * (both still marked STUB pending #54), which this feature does not close.
  *
- * API:
+
+ * API (unchanged shape from the stub):
  *   useFavourites() → { favouriteIds: Set<string>, toggle, isFavourite }
- *   getFavouriteIds()         — non-hook read (for tests / outside React)
- *   FAVOURITES_STORAGE_KEY    — exported for tests
+ *   getFavouriteIds()         — non-hook read (for tests / outside React;
+ *                               returns the current in-memory cache, which is
+ *                               empty until the first backend fetch resolves)
  */
 
-import { useSyncExternalStore, useCallback } from 'react';
+import { useSyncExternalStore, useCallback, useEffect } from 'react';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 
-/** localStorage key under which favourited target ids are stored. */
-export const FAVOURITES_STORAGE_KEY = 'alm:targets:favourites';
+// ── Module-level cache + subscriber wiring ──────────────────────────────────
+//
+// A single shared cache backs every `useFavourites()` mount so all
+// subscribers (e.g. TargetsTable + a detail pane) stay in sync without each
+// mount re-fetching independently.
 
-// ── Storage helpers ────────────────────────────────────────────────────────────
-
-/** Read the raw stored set (empty set on any parse/storage error). */
-function readFromStorage(): ReadonlySet<string> {
-  try {
-    const raw = localStorage.getItem(FAVOURITES_STORAGE_KEY);
-    if (!raw) return new Set();
-    const parsed: unknown = JSON.parse(raw) as unknown;
-    if (!Array.isArray(parsed)) return new Set();
-    return new Set(parsed.filter((v): v is string => typeof v === 'string'));
-  } catch {
-    return new Set();
-  }
-}
-
-/** Persist a new id set and notify all subscribers. */
-function writeToStorage(ids: ReadonlySet<string>): void {
-  try {
-    localStorage.setItem(FAVOURITES_STORAGE_KEY, JSON.stringify([...ids]));
-  } catch {
-    // localStorage unavailable (e.g. tests without shim) — skip persist.
-  }
-  // Notify useSyncExternalStore subscribers across all mounts.
-  try {
-    window.dispatchEvent(
-      new StorageEvent('storage', {
-        key: FAVOURITES_STORAGE_KEY,
-        newValue: JSON.stringify([...ids]),
-      }),
-    );
-  } catch {
-    // Non-browser env; subscribers won't get the push notification but will
-    // re-read on the next render via useSyncExternalStore.
-  }
-  // Also call module-local listeners directly (same-tab updates).
-  for (const fn of listeners) fn();
-}
-
-// ── useSyncExternalStore wiring ────────────────────────────────────────────────
+let cachedIds: ReadonlySet<string> = new Set();
+let hasLoaded = false;
+let inFlightLoad: Promise<void> | null = null;
 
 type Listener = () => void;
 const listeners = new Set<Listener>();
 
+function notify(): void {
+  for (const fn of listeners) fn();
+}
+
 function subscribe(fn: Listener): () => void {
   listeners.add(fn);
-  const onStorage = (e: StorageEvent) => {
-    if (e.key === FAVOURITES_STORAGE_KEY || e.key === null) fn();
-  };
-  window.addEventListener('storage', onStorage);
   return () => {
     listeners.delete(fn);
-    window.removeEventListener('storage', onStorage);
   };
 }
 
-// Stable snapshot reference: useSyncExternalStore requires referential equality
-// between renders when the data hasn't changed.  We keep a module-level cache
-// so the same Set object is returned until a write actually occurs.
-let cachedSnapshot: ReadonlySet<string> = new Set();
-let cachedRaw: string | null = null;
-
 function getSnapshot(): ReadonlySet<string> {
-  try {
-    const raw = localStorage.getItem(FAVOURITES_STORAGE_KEY);
-    if (raw === cachedRaw) return cachedSnapshot;
-    cachedRaw = raw;
-    cachedSnapshot = readFromStorage();
-    return cachedSnapshot;
-  } catch {
-    return cachedSnapshot;
-  }
+  return cachedIds;
 }
 
 function getServerSnapshot(): ReadonlySet<string> {
   return new Set();
+}
+
+/** Fetch the current favourite set from the backend (de-duplicates concurrent calls). */
+function ensureLoaded(): Promise<void> {
+  if (hasLoaded) return Promise.resolve();
+  if (inFlightLoad) return inFlightLoad;
+  inFlightLoad = Promise.resolve()
+    .then(() => commands.targetFavouritesList())
+    .then(unwrap)
+    .then(({ targetIds }) => {
+      cachedIds = new Set(targetIds);
+      hasLoaded = true;
+      notify();
+    })
+    .catch(() => {
+      // Leave the cache empty on failure; a future call may retry via a
+      // fresh mount (hasLoaded stays false).
+    })
+    .finally(() => {
+      inFlightLoad = null;
+    });
+  return inFlightLoad;
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────────
@@ -109,26 +92,50 @@ export interface UseFavouritesResult {
 }
 
 /**
- * React hook: subscribe to the client-side favourite set.
+ * React hook: subscribe to the database-backed favourite set.
  *
  * Provides `toggle` (stable across renders) to star/unstar a target, and
- * `isFavourite` for conditional rendering.
- *
- * STUB — see module header.  Replace with a backend-backed hook when #54 lands.
+ * `isFavourite` for conditional rendering. Applies an optimistic update on
+ * `toggle`, then reconciles with the backend call; a failed call reverts the
+ * optimistic change.
  */
 export function useFavourites(): UseFavouritesResult {
   const favouriteIds = useSyncExternalStore(subscribe, getSnapshot, getServerSnapshot);
 
+  useEffect(() => {
+    void ensureLoaded();
+  }, []);
+
   const toggle = useCallback((targetId: string) => {
-    // Re-read from storage immediately (not from the React snapshot) so rapid
-    // successive clicks on different rows don't race.
-    const current = new Set(readFromStorage());
-    if (current.has(targetId)) {
-      current.delete(targetId);
+    const wasFavourited = cachedIds.has(targetId);
+
+    // Optimistic update.
+    const next = new Set(cachedIds);
+    if (wasFavourited) {
+      next.delete(targetId);
     } else {
-      current.add(targetId);
+      next.add(targetId);
     }
-    writeToStorage(current);
+    cachedIds = next;
+    notify();
+
+    const call = Promise.resolve().then(() =>
+      wasFavourited
+        ? commands.targetFavouritesRemove({ targetId })
+        : commands.targetFavouritesAdd({ targetId }),
+    );
+
+    call.then(unwrap).catch(() => {
+      // Revert the optimistic change on failure.
+      const reverted = new Set(cachedIds);
+      if (wasFavourited) {
+        reverted.add(targetId);
+      } else {
+        reverted.delete(targetId);
+      }
+      cachedIds = reverted;
+      notify();
+    });
   }, []);
 
   const isFavourite = useCallback(
@@ -142,6 +149,20 @@ export function useFavourites(): UseFavouritesResult {
 /**
  * Non-hook read for use outside React (tests, initial render).
  *
- * STUB — see module header.
+ * Returns the current in-memory cache — empty until the first backend fetch
+ * (triggered by a `useFavourites()` mount) resolves.
  */
-export { readFromStorage as getFavouriteIds };
+export function getFavouriteIds(): ReadonlySet<string> {
+  return cachedIds;
+}
+
+/**
+ * Test-only reset of the module-level cache. Not part of the public hook
+ * surface; exported so `useFavourites.test.ts` can isolate cases without
+ * process-per-test isolation.
+ */
+export function __resetFavouritesCacheForTests(): void {
+  cachedIds = new Set();
+  hasLoaded = false;
+  inFlightLoad = null;
+}

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -49,8 +49,8 @@ pub use projects::{
     source_view_generate,
 };
 pub use targets::{
-    ingest_resolution, ingest_sessions, resolver_settings, target_dto, target_management,
-    target_resolve, target_search,
+    ingest_resolution, ingest_sessions, resolver_settings, target_dto, target_favourites,
+    target_management, target_resolve, target_search,
 };
 
 // In-crate modules (file layout under `src/`). These live in `app_core` itself

--- a/crates/app/targets/src/lib.rs
+++ b/crates/app/targets/src/lib.rs
@@ -16,6 +16,7 @@ pub mod ingest_resolution;
 pub mod ingest_sessions;
 pub mod resolver_settings;
 pub mod target_dto;
+pub mod target_favourites;
 pub mod target_management;
 pub mod target_resolve;
 pub mod target_search;

--- a/crates/app/targets/src/target_favourites.rs
+++ b/crates/app/targets/src/target_favourites.rs
@@ -54,12 +54,8 @@ pub async fn add(
     pool: &SqlitePool,
     req: &TargetFavouriteRequest,
 ) -> Result<TargetFavouriteAddResult, TargetOpError> {
-    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(&req.target_id)
-        .fetch_optional(pool)
-        .await
-        .map_err(db_err)?;
-    if exists.is_none() {
+    let exists = target_favourites::target_exists(pool, &req.target_id).await.map_err(db_err)?;
+    if !exists {
         return Err(not_found(&req.target_id));
     }
 
@@ -68,14 +64,12 @@ pub async fn add(
 
     // Re-read the stored favourited_at: a repeat add is a no-op and must
     // reflect the *original* timestamp, not the one just computed above.
-    let stored_at: (String,) =
-        sqlx::query_as("SELECT favourited_at FROM target_favourite WHERE target_id = ?")
-            .bind(&req.target_id)
-            .fetch_one(pool)
-            .await
-            .map_err(db_err)?;
+    let stored_at = target_favourites::get_favourited_at(pool, &req.target_id)
+        .await
+        .map_err(db_err)?
+        .unwrap_or(favourited_at);
 
-    Ok(TargetFavouriteAddResult { target_id: req.target_id.clone(), favourited_at: stored_at.0 })
+    Ok(TargetFavouriteAddResult { target_id: req.target_id.clone(), favourited_at: stored_at })
 }
 
 /// `targets.favourites.remove` — unfavourite a canonical target. Idempotent:

--- a/crates/app/targets/src/target_favourites.rs
+++ b/crates/app/targets/src/target_favourites.rs
@@ -1,0 +1,191 @@
+//! `targets.favourites.list` / `targets.favourites.add` / `targets.favourites.remove`
+//! use cases (spec 051 US2).
+//!
+//! Thin orchestration over the `target_favourite` repository functions
+//! (`persistence_db::repositories::target_favourites`): validates the target
+//! exists (for `add`) and maps repository results to contract DTOs.
+//!
+//! ## Constitution
+//!
+//! - §I No filesystem mutations: read/write SQLite metadata only.
+//! - §V SQLite (`target_favourite`) is the durable record.
+
+use sqlx::SqlitePool;
+
+use contracts_core::targets::{
+    TargetFavouriteAddResult, TargetFavouriteRemoveResult, TargetFavouriteRequest,
+    TargetFavouritesListResult, TargetOpError,
+};
+use domain_core::ids::Timestamp;
+use persistence_db::repositories::target_favourites;
+
+fn db_err(e: impl std::fmt::Display) -> TargetOpError {
+    TargetOpError { code: "internal.database".to_owned(), message: format!("{e}"), details: None }
+}
+
+fn not_found(id: &str) -> TargetOpError {
+    TargetOpError {
+        code: "target.not_found".to_owned(),
+        message: format!("Target '{id}' not found."),
+        details: None,
+    }
+}
+
+/// `targets.favourites.list` — return the ids of every currently-favourited
+/// canonical target.
+///
+/// # Errors
+///
+/// Returns [`TargetOpError`] with code `internal.database`.
+pub async fn list(pool: &SqlitePool) -> Result<TargetFavouritesListResult, TargetOpError> {
+    let target_ids = target_favourites::list_favourites(pool).await.map_err(db_err)?;
+    Ok(TargetFavouritesListResult { target_ids })
+}
+
+/// `targets.favourites.add` — favourite a canonical target. Idempotent: adding
+/// an already-favourited target succeeds with no error and does not reset
+/// `favouritedAt`.
+///
+/// # Errors
+///
+/// Returns [`TargetOpError`] with code `target.not_found` (the id does not
+/// reference an existing `canonical_target` row) or `internal.database`.
+pub async fn add(
+    pool: &SqlitePool,
+    req: &TargetFavouriteRequest,
+) -> Result<TargetFavouriteAddResult, TargetOpError> {
+    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
+        .bind(&req.target_id)
+        .fetch_optional(pool)
+        .await
+        .map_err(db_err)?;
+    if exists.is_none() {
+        return Err(not_found(&req.target_id));
+    }
+
+    let favourited_at = Timestamp::now_iso();
+    target_favourites::add_favourite(pool, &req.target_id, &favourited_at).await.map_err(db_err)?;
+
+    // Re-read the stored favourited_at: a repeat add is a no-op and must
+    // reflect the *original* timestamp, not the one just computed above.
+    let stored_at: (String,) =
+        sqlx::query_as("SELECT favourited_at FROM target_favourite WHERE target_id = ?")
+            .bind(&req.target_id)
+            .fetch_one(pool)
+            .await
+            .map_err(db_err)?;
+
+    Ok(TargetFavouriteAddResult { target_id: req.target_id.clone(), favourited_at: stored_at.0 })
+}
+
+/// `targets.favourites.remove` — unfavourite a canonical target. Idempotent:
+/// removing a target that was never favourited succeeds with no error.
+///
+/// # Errors
+///
+/// Returns [`TargetOpError`] with code `internal.database`.
+pub async fn remove(
+    pool: &SqlitePool,
+    req: &TargetFavouriteRequest,
+) -> Result<TargetFavouriteRemoveResult, TargetOpError> {
+    target_favourites::remove_favourite(pool, &req.target_id).await.map_err(db_err)?;
+    Ok(TargetFavouriteRemoveResult { target_id: req.target_id.clone() })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use persistence_db::Database;
+
+    async fn setup() -> Database {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db
+    }
+
+    async fn insert_target(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO canonical_target
+             (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
+             VALUES (?, NULL, 'Test Target', 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("insert_target failed");
+    }
+
+    #[tokio::test]
+    async fn list_is_empty_when_nothing_favourited() {
+        let db = setup().await;
+        let result = list(db.pool()).await.unwrap();
+        assert!(result.target_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn add_then_list_includes_target() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-001").await;
+
+        let added = add(db.pool(), &TargetFavouriteRequest { target_id: "t-001".to_owned() })
+            .await
+            .unwrap();
+        assert_eq!(added.target_id, "t-001");
+        assert!(!added.favourited_at.is_empty());
+
+        let listed = list(db.pool()).await.unwrap();
+        assert_eq!(listed.target_ids, vec!["t-001".to_owned()]);
+    }
+
+    #[tokio::test]
+    async fn add_unknown_target_returns_not_found() {
+        let db = setup().await;
+        let err = add(db.pool(), &TargetFavouriteRequest { target_id: "missing".to_owned() })
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, "target.not_found");
+    }
+
+    #[tokio::test]
+    async fn add_twice_is_idempotent_and_preserves_original_timestamp() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-002").await;
+
+        let first = add(db.pool(), &TargetFavouriteRequest { target_id: "t-002".to_owned() })
+            .await
+            .unwrap();
+        let second = add(db.pool(), &TargetFavouriteRequest { target_id: "t-002".to_owned() })
+            .await
+            .unwrap();
+
+        assert_eq!(first.favourited_at, second.favourited_at);
+
+        let listed = list(db.pool()).await.unwrap();
+        assert_eq!(listed.target_ids.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn remove_deletes_and_list_no_longer_includes_it() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-003").await;
+        add(db.pool(), &TargetFavouriteRequest { target_id: "t-003".to_owned() }).await.unwrap();
+
+        let removed = remove(db.pool(), &TargetFavouriteRequest { target_id: "t-003".to_owned() })
+            .await
+            .unwrap();
+        assert_eq!(removed.target_id, "t-003");
+
+        let listed = list(db.pool()).await.unwrap();
+        assert!(listed.target_ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn remove_of_never_favourited_id_is_a_noop() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-004").await;
+        let removed = remove(db.pool(), &TargetFavouriteRequest { target_id: "t-004".to_owned() })
+            .await
+            .unwrap();
+        assert_eq!(removed.target_id, "t-004");
+    }
+}

--- a/crates/contracts/core/src/targets.rs
+++ b/crates/contracts/core/src/targets.rs
@@ -356,6 +356,39 @@ pub struct TargetNoteUpdateResult {
     pub notes: Option<String>,
 }
 
+// ── Spec 051 US2 DTOs — target favourites ────────────────────────────────────
+
+/// Response for `targets.favourites.list` (spec 051 US2).
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetFavouritesListResult {
+    /// Ids of every currently-favourited canonical target.
+    pub target_ids: Vec<String>,
+}
+
+/// Request for `targets.favourites.add` / `targets.favourites.remove` (spec 051 US2).
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetFavouriteRequest {
+    pub target_id: String,
+}
+
+/// Response for `targets.favourites.add` (spec 051 US2).
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetFavouriteAddResult {
+    pub target_id: String,
+    /// ISO-8601 UTC timestamp the target was first favourited.
+    pub favourited_at: String,
+}
+
+/// Response for `targets.favourites.remove` (spec 051 US2).
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetFavouriteRemoveResult {
+    pub target_id: String,
+}
+
 // ── Spec 035 DTOs — SIMBAD target resolution ──────────────────────────────────
 //
 // These types implement the three JSON Schema contracts in

--- a/crates/persistence/db/src/repositories/target_favourites.rs
+++ b/crates/persistence/db/src/repositories/target_favourites.rs
@@ -12,6 +12,36 @@ use sqlx::SqlitePool;
 
 use crate::DbResult;
 
+/// Returns `true` when `target_id` references an existing `canonical_target`
+/// row. Used by the `targets.favourites.add` use case to distinguish
+/// `target.not_found` from a genuine database error before inserting.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn target_exists(pool: &SqlitePool, target_id: &str) -> DbResult<bool> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
+        .bind(target_id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.is_some())
+}
+
+/// Read back the stored `favourited_at` for `target_id`, or `None` if the
+/// target is not currently favourited.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_favourited_at(pool: &SqlitePool, target_id: &str) -> DbResult<Option<String>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT favourited_at FROM target_favourite WHERE target_id = ?")
+            .bind(target_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(at,)| at))
+}
+
 /// List the ids of every currently-favourited canonical target, ordered by
 /// `favourited_at DESC` (most recently favourited first).
 ///
@@ -152,6 +182,37 @@ mod tests {
         let db = setup().await;
         let ids = list_favourites(db.pool()).await.unwrap();
         assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn target_exists_true_for_known_target() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-006").await;
+        assert!(target_exists(db.pool(), "t-006").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn target_exists_false_for_unknown_target() {
+        let db = setup().await;
+        assert!(!target_exists(db.pool(), "missing").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn get_favourited_at_returns_none_when_not_favourited() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-007").await;
+        assert!(get_favourited_at(db.pool(), "t-007").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn get_favourited_at_returns_stored_timestamp() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-008").await;
+        add_favourite(db.pool(), "t-008", "2026-07-05T00:00:00Z").await.unwrap();
+        assert_eq!(
+            get_favourited_at(db.pool(), "t-008").await.unwrap().as_deref(),
+            Some("2026-07-05T00:00:00Z")
+        );
     }
 
     #[tokio::test]

--- a/specs/051-tauri-shell-integration/tasks.md
+++ b/specs/051-tauri-shell-integration/tasks.md
@@ -147,27 +147,27 @@ star persists and is visible in the database, not `localStorage`.
 
 ### Tests for User Story 2
 
-- [ ] T014 [P] [US2] `cargo test` for the new repository functions
+- [x] T014 [P] [US2] `cargo test` for the new repository functions
       (`list_favourites`/`add_favourite`/`remove_favourite`): add → present in
       list; add twice → single row, idempotent; remove → absent; remove of a
       never-favourited id → no-op, no error.
-- [ ] T015 [P] [US2] `cargo test` (or an integration test in
+- [x] T015 [P] [US2] `cargo test` (or an integration test in
       `tests/contract`) exercising cascade delete: delete/retire a
       `canonical_target` row that has a favourite → `target_favourite` row is
       gone (FK `ON DELETE CASCADE`).
 
 ### Implementation for User Story 2
 
-- [ ] T016 [US2] Add `targets.favourites.list` / `targets.favourites.add` /
+- [x] T016 [US2] Add `targets.favourites.list` / `targets.favourites.add` /
       `targets.favourites.remove` use-cases in
       `crates/app/targets/src/target_favourites.rs` (new file), calling the
       T006 repository functions; wire `target.not_found` for `add` against an
       unknown id (contracts/operations.md).
-- [ ] T017 [US2] Register the three commands with `tauri-specta` in
+- [x] T017 [US2] Register the three commands with `tauri-specta` in
       `apps/desktop/src-tauri/src/lib.rs`'s command list; regenerate
       `apps/desktop/src/bindings/index.ts` (`cargo test -p desktop_shell`)
       and commit the regenerated bindings.
-- [ ] T018 [US2] Rewrite `apps/desktop/src/features/targets/useFavourites.ts`
+- [x] T018 [US2] Rewrite `apps/desktop/src/features/targets/useFavourites.ts`
       to call the new bindings instead of `localStorage`, **preserving the
       existing public hook shape** (`{ favouriteIds, toggle, isFavourite }`
       plus the non-hook `getFavouriteIds` export) so
@@ -175,7 +175,7 @@ star persists and is visible in the database, not `localStorage`.
       beyond removing the STUB comment. Handle the optimistic-update /
       re-fetch pattern consistent with other backend-backed hooks in this
       codebase.
-- [ ] T019 [P] [US2] Update `apps/desktop/src/features/targets/useFavourites.test.ts`
+- [x] T019 [P] [US2] Update `apps/desktop/src/features/targets/useFavourites.test.ts`
       for the new backend-backed behavior (mock the IPC bindings instead of
       `localStorage`/`StorageEvent`).
 - [ ] T020 [US2] Remove the module-header STUB note in `useFavourites.ts` and


### PR DESCRIPTION
## Summary
- Starred/favourited targets now persist in the app database instead of the browser's local storage, so favourites survive restarts and reinstalls and are visible directly in the database.

## What's new
- Starring or unstarring a target in the Targets view is saved immediately and reliably, with the star updating right away and rolling back automatically if the save fails.

## Spec Context
- Spec: 051
- Branch: 051-us2-favourites-db