### PR TITLE
feat: native window chrome now follows the active theme

### DIFF
--- a/apps/desktop/src/data/theme.test.ts
+++ b/apps/desktop/src/data/theme.test.ts
@@ -1,0 +1,113 @@
+/**
+ * theme.test.ts — spec 051 US6 (T039): native window theme sync.
+ *
+ * `applyTheme()` now calls `getCurrentWindow().setTheme(mode)` from
+ * `@tauri-apps/api/window`, gated behind `core.isTauri()` (FR-020 — a no-op
+ * outside Tauri) and wrapped so a throwing/rejecting platform (e.g. Linux
+ * desktop environments per plan.md's platform-differences table) degrades
+ * silently. Covers: all four themes call `setTheme` with the correct
+ * light/dark mode when inside Tauri; nothing is called outside Tauri; a
+ * rejecting `setTheme` never throws out of `applyTheme()`.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const isTauriMock = vi.fn<() => boolean>();
+const setThemeMock = vi.fn<(mode: 'light' | 'dark') => Promise<void>>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock(),
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ setTheme: setThemeMock }),
+}));
+
+// `applyTheme()` reads localStorage (via getThemeChoice) — reset between
+// tests so each case starts from a known theme choice.
+function setStoredChoice(choice: string): void {
+  localStorage.setItem('alm.theme', choice);
+}
+
+/**
+ * syncNativeWindowTheme is fire-and-forget and does two dynamic `import()`s
+ * before calling `setTheme` — each dynamic import adds its own extra
+ * microtask turn beyond a plain `await`, so poll briefly instead of assuming
+ * a fixed number of `Promise.resolve()` flushes settle it.
+ */
+async function waitForCall(fn: ReturnType<typeof vi.fn>): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (fn.mock.calls.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe('applyTheme — native window theme sync (spec 051 US6)', () => {
+  beforeEach(() => {
+    isTauriMock.mockReset();
+    setThemeMock.mockReset();
+    setThemeMock.mockResolvedValue(undefined);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  const CASES: { id: string; mode: 'light' | 'dark' }[] = [
+    { id: 'warm-clay', mode: 'light' },
+    { id: 'warm-slate', mode: 'light' },
+    { id: 'observatory-dark', mode: 'dark' },
+    { id: 'espresso-dark', mode: 'dark' },
+  ];
+
+  for (const { id, mode } of CASES) {
+    it(`calls native setTheme("${mode}") for the ${id} theme when inside Tauri`, async () => {
+      isTauriMock.mockReturnValue(true);
+      setStoredChoice(id);
+
+      const { applyTheme } = await import('./theme');
+      applyTheme();
+      await waitForCall(setThemeMock);
+
+      expect(setThemeMock).toHaveBeenCalledWith(mode);
+    });
+  }
+
+  it('does not call native setTheme outside Tauri (FR-020 no-op)', async () => {
+    isTauriMock.mockReturnValue(false);
+    setStoredChoice('espresso-dark');
+
+    const { applyTheme } = await import('./theme');
+    applyTheme();
+    // Negative assertion — give any (incorrect) async call a few turns to
+    // show up before asserting it never did.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    expect(setThemeMock).not.toHaveBeenCalled();
+  });
+
+  it('degrades silently when native setTheme rejects (FR-020, US6 AS2)', async () => {
+    isTauriMock.mockReturnValue(true);
+    setThemeMock.mockRejectedValue(new Error('unsupported on this desktop environment'));
+    setStoredChoice('warm-clay');
+
+    const { applyTheme } = await import('./theme');
+    expect(() => applyTheme()).not.toThrow();
+    await waitForCall(setThemeMock);
+
+    expect(setThemeMock).toHaveBeenCalledWith('light');
+  });
+
+  it('still sets the data-theme attribute regardless of native sync outcome', async () => {
+    isTauriMock.mockReturnValue(true);
+    setThemeMock.mockRejectedValue(new Error('boom'));
+    setStoredChoice('observatory-dark');
+
+    const { applyTheme } = await import('./theme');
+    applyTheme();
+    await waitForCall(setThemeMock);
+
+    expect(document.documentElement.getAttribute('data-theme')).toBe('observatory-dark');
+  });
+});

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -68,9 +68,36 @@ export function resolveTheme(choice: ThemeChoice = getThemeChoice()): ThemeId {
   return choice;
 }
 
+/**
+ * Sync the native window chrome's light/dark family to the resolved theme
+ * (spec 051 US6, T037/T038). Gated behind `core.isTauri()` (FR-020: a no-op
+ * outside Tauri, e.g. the browser dev server or vitest). Fire-and-forget: a
+ * platform/webview that throws or rejects (Linux desktop environments per
+ * plan.md's platform-differences table) degrades silently — no error is
+ * ever surfaced to the user for a native chrome affordance this minor.
+ */
+function syncNativeWindowTheme(themeId: ThemeId): void {
+  const mode = THEMES.find((t) => t.id === themeId)?.mode ?? 'light';
+
+  void (async () => {
+    try {
+      const { isTauri } = await import('@tauri-apps/api/core');
+      if (!isTauri()) return;
+
+      const { getCurrentWindow } = await import('@tauri-apps/api/window');
+      await getCurrentWindow().setTheme(mode);
+    } catch {
+      // Silently degrade (FR-020, US6 AS2) — native chrome theming is
+      // best-effort and must never surface an error to the user.
+    }
+  })();
+}
+
 export function applyTheme(): void {
   if (typeof document === 'undefined') return;
-  document.documentElement.setAttribute('data-theme', resolveTheme());
+  const resolved = resolveTheme();
+  document.documentElement.setAttribute('data-theme', resolved);
+  syncNativeWindowTheme(resolved);
 }
 
 export function applyDensity(density?: string): void {

--- a/specs/051-tauri-shell-integration/tasks.md
+++ b/specs/051-tauri-shell-integration/tasks.md
@@ -324,7 +324,7 @@ each theme's `mode`.
 **Depends on**: T008 (Foundational `isTauri()` cleanup) so this uses the same
 runtime check.
 
-- [ ] T037 [US6] In `apps/desktop/src/data/theme.ts`, extend `applyTheme()`
+- [x] T037 [US6] In `apps/desktop/src/data/theme.ts`, extend `applyTheme()`
       (or add a sibling called from the same call sites: `initAppearance()`,
       `setThemeChoice()`, and the `prefers-color-scheme` change listener) to
       call `getCurrentWindow().setTheme(mode === 'dark' ? 'dark' : 'light')`
@@ -334,15 +334,15 @@ runtime check.
       ambiguity; the existing `ThemeMeta.mode` field already resolves it
       exactly). Gate the call behind `core.isTauri()` (FR-020 — no-op outside
       Tauri / where unsupported).
-- [ ] T038 [US6] Wrap the `setTheme` call so a platform/webview that throws or
+- [x] T038 [US6] Wrap the `setTheme` call so a platform/webview that throws or
       no-ops (Linux desktop environments per plan.md's platform-differences
       table) degrades silently — no error surfaced to the user (FR-020, US6
       AS2).
-- [ ] T039 [P] [US6] Add/update a vitest confirming `applyTheme()`/theme-switch
+- [x] T039 [P] [US6] Add/update a vitest confirming `applyTheme()`/theme-switch
       calls the native `setTheme` with the correct mode for each of the four
       themes when running under a mocked Tauri environment, and does not call
       it (or calls it as a no-op) outside Tauri.
-- [ ] T040 [US6] Manual verification on Windows, macOS, and at least one
+- [ ] T040 [US6] **Deferred to manual verification.** Manual verification on Windows, macOS, and at least one
       Linux desktop environment: switch each of the four themes, confirm
       native chrome (where rendered) matches light/dark family (SC-005); on
       Linux, confirm the documented no-op is what actually happens (not a


### PR DESCRIPTION
## Summary
- The app window's native title bar / chrome now follows the light or dark mode of whichever of the 4 themes is active, instead of staying in one fixed mode regardless of theme.

## What's new
- Switching themes updates the native window chrome (where the OS renders one) to match, not just the in-app colors.
- Gracefully does nothing on platforms/desktop environments that don't support native theme switching (e.g. some Linux desktops) — no error shown to the user.

## Test plan
- [x] `pnpm --filter @astro-plan/desktop vitest run` (1260/1260, includes new theme-sync coverage for all 4 themes + outside-Tauri + failure-degrades-silently cases)
- [x] `pnpm --filter @astro-plan/desktop typecheck`
- [x] `pnpm --filter @astro-plan/desktop exec eslint` on touched files (clean)
- [ ] Manual verification on Windows/macOS/Linux — deferred (noted in tasks.md as T040), machine this was built on could not run the full Playwright E2E suite reliably (shared-runner resource contention unrelated to this change), so this needs the usual real-app confirmation pass.

## Spec Context
- Spec: 051
- Branch: 051-us6-theme-sync