### PR TITLE
feat: window position/size memory, native menu bar, and a diagnostics log file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-appender",
  "tracing-subscriber",
  "uuid",
  "workflow_artifacts",
@@ -5906,6 +5907,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "symlink"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7973cce6668464ea31f176d85b13c7ab3bba2cb3b77a2ed26abd7801688010a"
+
+[[package]]
 name = "syn"
 version = "1.0.109"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7027,6 +7034,19 @@ dependencies = [
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-appender"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "050686193eb999b4bb3bc2acfa891a13da00f79734704c4b8b4ef1a10b368a3c"
+dependencies = [
+ "crossbeam-channel",
+ "symlink",
+ "thiserror 2.0.18",
+ "time",
+ "tracing-subscriber",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -96,6 +96,7 @@ time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
 trash = "5.2"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "fs"] }
 tracing = "0.1"
+tracing-appender = "0.2.5"
 uuid = { version = "1", features = ["serde", "v4"] }
 # Spec 042 stdlib adoption (not yet wired — pinned for staged per-story adoption):
 anyhow = "1"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -53,6 +53,8 @@ thiserror = { workspace = true }
 time = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
+# Rotating diagnostics log file (spec 051 US7, T041/T042) — alongside stderr.
+tracing-appender = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
 

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -11,6 +11,7 @@
     "opener:allow-reveal-item-in-dir",
     "mcp-bridge:default",
     "updater:default",
-    "process:default"
+    "process:default",
+    "window-state:default"
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -613,6 +613,114 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
     ])
 }
 
+/// Menu id for the native "Settings…" application-menu item (spec 051 US5).
+const MENU_ID_SETTINGS: &str = "menu-settings";
+
+/// Enforce the min-size floor (spec 051 US4, T029) after
+/// `tauri-plugin-window-state` restores a persisted size, in case a prior
+/// app version persisted a smaller size than the current `tauri.conf.json`
+/// `minWidth`/`minHeight` (1100x720) — mirrors the `astro-up` reference's own
+/// explicit post-restore clamp (research.md's cited `lib.rs` excerpt).
+fn enforce_min_window_size(window: &tauri::WebviewWindow) {
+    const MIN_WIDTH: u32 = 1100;
+    const MIN_HEIGHT: u32 = 720;
+
+    if let Ok(size) = window.inner_size() {
+        let w = size.width.max(MIN_WIDTH);
+        let h = size.height.max(MIN_HEIGHT);
+        if w != size.width || h != size.height {
+            if let Err(e) = window.set_size(tauri::Size::Physical(tauri::PhysicalSize::new(w, h))) {
+                tracing::warn!("failed to enforce minimum window size: {e:?}");
+            } else {
+                tracing::info!(width = w, height = h, "enforced minimum window size");
+            }
+        }
+    }
+}
+
+/// Off-screen-position fallback (spec 051 US4, T030/FR-013): if the restored
+/// position has no overlap with any currently-connected display (e.g. a
+/// second monitor the window was on has since been disconnected), recenter
+/// the window instead of leaving it stranded off-screen.
+fn recenter_if_offscreen(window: &tauri::WebviewWindow) {
+    let (Ok(pos), Ok(size), Ok(monitors)) =
+        (window.outer_position(), window.outer_size(), window.available_monitors())
+    else {
+        return;
+    };
+
+    let win_right = pos.x + i32::try_from(size.width).unwrap_or(i32::MAX);
+    let win_bottom = pos.y + i32::try_from(size.height).unwrap_or(i32::MAX);
+
+    let on_screen = monitors.iter().any(|m| {
+        let mp = m.position();
+        let ms = m.size();
+        let mon_right = mp.x + i32::try_from(ms.width).unwrap_or(i32::MAX);
+        let mon_bottom = mp.y + i32::try_from(ms.height).unwrap_or(i32::MAX);
+        // Any overlap between the window rect and this monitor's rect.
+        pos.x < mon_right && win_right > mp.x && pos.y < mon_bottom && win_bottom > mp.y
+    });
+
+    if !on_screen {
+        if let Err(e) = window.center() {
+            tracing::warn!("failed to recenter off-screen window: {e:?}");
+        } else {
+            tracing::info!("restored window position was off-screen; recentered");
+        }
+    }
+}
+
+/// Build the native application menu (spec 051 US5, T032): an App submenu
+/// (About, Settings, Quit), a Window submenu, and a standard Edit submenu
+/// (copy/cut/paste/select-all/undo/redo). The "Settings…" item has no native
+/// dialog of its own — its click is handled by `on_menu_event` in
+/// `build_app()`, which emits a frontend event for the existing Settings
+/// route to handle (T033: reuse existing UI, no new native dialog).
+fn build_native_menu(app: &tauri::App<tauri::Wry>) -> tauri::Result<tauri::menu::Menu<tauri::Wry>> {
+    use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
+
+    let about = PredefinedMenuItem::about(app, Some("About PlateVault"), None)?;
+    let settings =
+        MenuItem::with_id(app, MENU_ID_SETTINGS, "Settings…", true, Some("CmdOrCtrl+,"))?;
+    let quit = PredefinedMenuItem::quit(app, None)?;
+    let app_menu = Submenu::with_items(
+        app,
+        "PlateVault",
+        true,
+        &[
+            &about,
+            &PredefinedMenuItem::separator(app)?,
+            &settings,
+            &PredefinedMenuItem::separator(app)?,
+            &quit,
+        ],
+    )?;
+
+    let edit_menu = Submenu::with_items(
+        app,
+        "Edit",
+        true,
+        &[
+            &PredefinedMenuItem::undo(app, None)?,
+            &PredefinedMenuItem::redo(app, None)?,
+            &PredefinedMenuItem::separator(app)?,
+            &PredefinedMenuItem::cut(app, None)?,
+            &PredefinedMenuItem::copy(app, None)?,
+            &PredefinedMenuItem::paste(app, None)?,
+            &PredefinedMenuItem::select_all(app, None)?,
+        ],
+    )?;
+
+    let window_menu = Submenu::with_items(
+        app,
+        "Window",
+        true,
+        &[&PredefinedMenuItem::minimize(app, None)?, &PredefinedMenuItem::close_window(app, None)?],
+    )?;
+
+    Menu::with_items(app, &[&app_menu, &edit_menu, &window_menu])
+}
+
 /// Build the Tauri [`App`] **without** starting the event loop.
 ///
 /// The returned handle exposes the platform path resolver (needed to locate
@@ -655,6 +763,12 @@ pub fn build_app() -> tauri::App {
                 tracing::warn!("single-instance redirect: no `main` window found to focus");
             }
         }))
+        // Spec 051 US4 (T027): window-state persistence. Registered right
+        // after single-instance so a redirected second launch (which never
+        // creates a window of its own) never touches this plugin's store
+        // file. `window-state:default` is granted in
+        // `capabilities/default.json` (T028).
+        .plugin(tauri_plugin_window_state::Builder::default().build())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         // Spec 051 US10 (T056): signed auto-update plugin. `updater:default` +
@@ -665,7 +779,21 @@ pub fn build_app() -> tauri::App {
         // then `check_for_app_update` will only ever see "updater
         // unavailable" or a verification failure, never a real update.
         .plugin(tauri_plugin_updater::Builder::new().build())
-        .plugin(tauri_plugin_process::init());
+        .plugin(tauri_plugin_process::init())
+        // Spec 051 US7 (T041): diagnostics log file. `skip_logger()` is
+        // required here — this app already installs a global `tracing`
+        // subscriber (in `main.rs`, right after `build_app()` returns, once
+        // the platform log directory is resolvable) that owns the single
+        // process-wide `log`-facade logger slot via `tracing-subscriber`'s
+        // default `tracing-log` bridge feature. Without `skip_logger()`, this
+        // plugin would try to install a SECOND global logger and panic/lose
+        // the race (FR-021's "not duplicated or dropped" requirement). With
+        // it, the plugin still registers its `log` Tauri command (so
+        // `@tauri-apps/plugin-log` calls from the frontend reach the ambient
+        // logger), it just never owns that logger itself — the rotating file
+        // target itself is `main.rs`'s `tracing_appender` layer, not this
+        // plugin's own (skipped) fern dispatch.
+        .plugin(tauri_plugin_log::Builder::new().skip_logger().build());
 
     // Tauri MCP bridge plugin (@hypothesi tauri-plugin-mcp-bridge) — dev/debug
     // builds only. Runs a WebSocket server on 0.0.0.0:9223 that the
@@ -690,9 +818,52 @@ pub fn build_app() -> tauri::App {
         tb = tb.plugin(tauri_plugin_webdriver::init());
     }
 
-    tb.invoke_handler(builder.invoke_handler())
+    tb
+        // Spec 051 US5 (T033): the native "Settings" menu item has no native
+        // dialog of its own — emit a frontend event and let the existing
+        // Settings route handle navigation, matching the reference pattern
+        // of reusing existing UI rather than inventing new native dialogs.
+        .on_menu_event(|app, event| {
+            if event.id() == MENU_ID_SETTINGS {
+                if let Some(window) = app.get_webview_window("main") {
+                    if let Err(e) = window.emit("menu:open-settings", ()) {
+                        tracing::warn!("failed to emit menu:open-settings: {e:?}");
+                    }
+                }
+            }
+            // Quit (T034): `PredefinedMenuItem::quit` already calls
+            // `app.exit(0)` internally — no separate handling needed here.
+            // This app has no existing close-confirmation logic to bypass
+            // (verified: no `on_window_event`/`CloseRequested` handler exists
+            // anywhere in this crate), so Quit is a plain, un-gated exit.
+        })
+        .invoke_handler(builder.invoke_handler())
         .setup(move |app| {
             builder.mount_events(app);
+
+            // Spec 051 US4 (T029/T030): enforce the min-size floor and
+            // off-screen fallback after tauri-plugin-window-state restores a
+            // persisted size/position — it may restore geometry from a prior
+            // app version or a since-disconnected monitor.
+            if let Some(window) = app.get_webview_window("main") {
+                enforce_min_window_size(&window);
+                recenter_if_offscreen(&window);
+            }
+
+            // Spec 051 US5 (T032): native application menu — App submenu
+            // (About/Settings/Quit), Window submenu, and a standard Edit
+            // submenu (copy/cut/paste/select-all/undo/redo). Does not touch
+            // any existing native/React context-menu code path (T035 — none
+            // exists in this crate to touch).
+            match build_native_menu(app) {
+                Ok(menu) => {
+                    if let Err(e) = app.set_menu(menu) {
+                        tracing::warn!("failed to set native application menu: {e:?}");
+                    }
+                }
+                Err(e) => tracing::warn!("failed to build native application menu: {e:?}"),
+            }
+
             Ok(())
         })
         .build(tauri::generate_context!())

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -4,25 +4,85 @@
 use desktop_shell::{build_app, run_app};
 use persistence_db::Database;
 use tauri::Manager;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::util::SubscriberInitExt;
+use tracing_subscriber::Layer;
+
+/// Delete rotated log files older than `max_age_days` (spec 051 US7, T042 —
+/// the log directory must never grow unbounded, SC-006). Best-effort: a
+/// failure to read the directory or remove a given file is logged and
+/// otherwise ignored, never fatal to startup.
+fn prune_old_logs(log_dir: &std::path::Path, max_age_days: u64) {
+    let Ok(entries) = std::fs::read_dir(log_dir) else { return };
+    let max_age = std::time::Duration::from_secs(max_age_days * 24 * 60 * 60);
+    let now = std::time::SystemTime::now();
+
+    for entry in entries.flatten() {
+        let path = entry.path();
+        let Ok(metadata) = entry.metadata() else { continue };
+        if !metadata.is_file() {
+            continue;
+        }
+        let Ok(modified) = metadata.modified() else { continue };
+        let Ok(age) = now.duration_since(modified) else { continue };
+        if age > max_age {
+            if let Err(e) = std::fs::remove_file(&path) {
+                tracing::warn!(path = %path.display(), "failed to prune old log file: {e:?}");
+            }
+        }
+    }
+}
 
 #[tokio::main]
 async fn main() {
-    // Initialise structured logging before anything else so startup `tracing`
-    // events (seed load, migrations) and downstream `tracing::error!` audit
-    // signals reach stderr. Honours `RUST_LOG`; defaults to `info`.
-    // `try_init` is used so a pre-existing subscriber (e.g. in a test harness)
-    // does not cause a panic.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info")),
-        )
-        .try_init();
-
-    // Build the Tauri app first so we can access the platform path resolver.
-    // The event loop is NOT started yet — that happens in `run_app` after the
-    // database is ready.
+    // Build the Tauri app first so we can access the platform path resolver
+    // (needed to locate the log directory before initialising tracing, and
+    // the SQLite database path below). The event loop is NOT started yet —
+    // that happens in `run_app` after the database is ready.
     let app = build_app();
+
+    // Spec 051 US7 (T041/T042): structured logging with both a stderr target
+    // (unchanged behavior, FR-021) and a rotating daily file target
+    // alongside it (FR-022). `tracing_subscriber` owns the single global
+    // `tracing`/`log`-facade logger slot for the whole process — see the
+    // `tauri_plugin_log::Builder::new().skip_logger()` comment in
+    // `build_app()` for why the plugin does not also try to install one.
+    {
+        let log_dir = app
+            .path()
+            .app_log_dir()
+            .unwrap_or_else(|_| std::env::temp_dir().join("plate-vault-logs"));
+        let _ = std::fs::create_dir_all(&log_dir);
+
+        // Prune before creating today's writer so a just-rotated file from a
+        // prior run doesn't briefly exist alongside an already-stale one.
+        prune_old_logs(&log_dir, 14);
+
+        let file_appender = tracing_appender::rolling::daily(&log_dir, "plate-vault.log");
+        let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
+        // Leak the guard so the background writer thread lives for the
+        // entire process (dropping it would stop flushing to the file).
+        std::mem::forget(guard);
+
+        let env_filter = || {
+            tracing_subscriber::EnvFilter::try_from_default_env()
+                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("info"))
+        };
+
+        // `try_init` (via `try_init()` below) so a pre-existing subscriber
+        // (e.g. a test harness) does not cause a panic.
+        let _ = tracing_subscriber::registry()
+            .with(tracing_subscriber::fmt::layer().with_filter(env_filter()))
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .with_ansi(false)
+                    .with_writer(non_blocking)
+                    .with_filter(env_filter()),
+            )
+            .try_init();
+
+        tracing::info!(log_dir = %log_dir.display(), "diagnostics log file initialised");
+    }
 
     // Resolve the SQLite URL.
     //

--- a/apps/desktop/src/app/Shell.tsx
+++ b/apps/desktop/src/app/Shell.tsx
@@ -61,6 +61,37 @@ function ShellInner() {
     return () => stopUpdateSubscription();
   }, []);
 
+  // Spec 051 US5 (T033): native "Settings…" application-menu item — no
+  // native dialog of its own, so the backend emits an event and this
+  // listener navigates to the existing Settings route. In mock/test mode
+  // (VITE_USE_MOCKS=true) there's no native menu to listen for, matching the
+  // convention already used by logSubscription.ts/updateSubscription.ts.
+  useEffect(() => {
+    if (import.meta.env.VITE_USE_MOCKS === 'true') return undefined;
+
+    let unlisten: (() => void) | undefined;
+    let cancelled = false;
+    void (async () => {
+      try {
+        const { listen } = await import('@tauri-apps/api/event');
+        const fn = await listen('menu:open-settings', () => {
+          void navigate({ to: '/settings' });
+        });
+        if (cancelled) {
+          fn();
+        } else {
+          unlisten = fn;
+        }
+      } catch (err) {
+        console.warn('[Shell] menu:open-settings listen failed:', err);
+      }
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
+  }, [navigate]);
+
   return (
     <div className={`alm-frame density-${prefs.density}`}>
       <div className="alm-frame__body">

--- a/specs/051-tauri-shell-integration/tasks.md
+++ b/specs/051-tauri-shell-integration/tasks.md
@@ -247,28 +247,28 @@ and produced exactly one audit event.
 
 **Independent Test**: Resize/move, quit, relaunch, confirm restoration.
 
-- [ ] T027 [US4] Register `tauri_plugin_window_state::Builder::default().build()`
+- [x] T027 [US4] Register `tauri_plugin_window_state::Builder::default().build()`
       in `build_app()`, after single-instance (US1) so a redirected second
       launch never touches window-state's own store file for a window it
       isn't actually creating.
-- [ ] T028 [US4] Add the plugin's required capability grant(s) (e.g.
+- [x] T028 [US4] Add the plugin's required capability grant(s) (e.g.
       `window-state:default`, if the plugin exposes any webview-invokable
       surface — verify at implementation time) to
       `apps/desktop/src-tauri/capabilities/default.json`.
-- [ ] T029 [US4] Confirm/enforce the minimum-size floor
+- [x] T029 [US4] Confirm/enforce the minimum-size floor
       (`minWidth`/`minHeight` = 1100x720, already in `tauri.conf.json`) is
       still respected after the plugin restores a persisted size — add an
       explicit clamp in `build_app()`/`setup()` if the plugin does not already
       guarantee this (mirrors the `astro-up` reference's own explicit
       min-size enforcement after window-state restore — see research.md's
       cited `lib.rs` excerpt).
-- [ ] T030 [US4] Add the off-screen-position fallback (US4 AS3, FR-013): on
+- [x] T030 [US4] Add the off-screen-position fallback (US4 AS3, FR-013): on
       restore, if the persisted position is fully outside all current
       display bounds, reset to a centered/default position rather than
       accepting the plugin's raw restore (verify whether the plugin already
       handles this natively before adding app-level logic — avoid duplicating
       built-in behavior).
-- [ ] T031 [US4] Manual verification across at least two of the three
+- [ ] T031 [US4] **Deferred to manual verification.** Manual verification across at least two of the three
       platforms: resize/move/maximize, restart, confirm restoration (SC-004);
       disconnect a second monitor the window was on, restart, confirm
       on-screen fallback.
@@ -285,14 +285,14 @@ menu.
 **Independent Test**: Open the native menu on each platform; confirm entries
 and Edit-menu copy/paste/select-all work.
 
-- [ ] T032 [US5] Build a `tauri::menu::Menu` in `build_app()`/`setup()` using
+- [x] T032 [US5] Build a `tauri::menu::Menu` in `build_app()`/`setup()` using
       `tauri::menu::{Menu, Submenu, PredefinedMenuItem, MenuItem}`: an
       App/PlateVault submenu (About, Settings, separator, Quit), a Window
       submenu (`PredefinedMenuItem::minimize`, `close_window`, etc., following
       the platform default set), and an Edit submenu
       (`PredefinedMenuItem::copy`, `paste`, `select_all`, `undo`/`redo` if
       appropriate for platform convention).
-- [ ] T033 [US5] Wire the About and Settings menu items to whatever
+- [x] T033 [US5] Wire the About and Settings menu items to whatever
       in-app navigation/dialog already exists for those surfaces (emit a
       frontend event the app shell already listens for, or open the existing
       Settings route) — reuse existing UI, do not build a new About dialog if
@@ -300,13 +300,16 @@ and Edit-menu copy/paste/select-all work.
       native `about` `PredefinedMenuItem` (OS-provided About panel) as the
       placeholder rather than inventing new in-app UI (out of this spec's
       scope to design an About screen).
-- [ ] T034 [US5] Wire Quit to the same shutdown path as the existing
+- [x] T034 [US5] Wire Quit to the same shutdown path as the existing
       window-close control (FR-016) — verify no bypass of any existing
       close-confirmation logic (check for one before assuming none exists).
-- [ ] T035 [US5] Explicitly verify (no code expected) that this task group
+      Verified: this crate has no `on_window_event`/`CloseRequested` handler
+      anywhere, so `PredefinedMenuItem::quit`'s default `app.exit(0)` has
+      nothing to bypass.
+- [x] T035 [US5] Explicitly verify (no code expected) that this task group
       does **not** touch any existing native/React context-menu code path
-      (FR-017, US5 AS4).
-- [ ] T036 [US5] Manual verification on macOS (global menu bar, Cmd+Q/Cmd+,
+      (FR-017, US5 AS4). Verified: no context-menu code exists in this crate.
+- [ ] T036 [US5] **Deferred to manual verification.** Manual verification on macOS (global menu bar, Cmd+Q/Cmd+,
       conventions), Windows, and Linux: menu presence, Edit-menu
       copy/paste/select-all in a focused text field, Quit behavior.
 
@@ -359,7 +362,7 @@ runtime check.
 **Independent Test**: Run the app, locate the log file, confirm rotation and
 readability.
 
-- [ ] T041 [US7] Register `tauri_plugin_log::Builder::new()` in `build_app()`
+- [x] T041 [US7] Register `tauri_plugin_log::Builder::new()` in `build_app()`
       configured with **both** a stdout target and a rotating file target
       (`tauri_plugin_log::Target::new(TargetKind::LogDir { file_name: None })`
       or equivalent, with a size/age-based `RotationStrategy`), so existing
@@ -370,15 +373,32 @@ readability.
       messages are not duplicated or dropped — research the plugin's
       `tracing`-bridge feature flag at implementation time (research.md §c
       notes `2.8.0` "includes... tracing support").
-- [ ] T042 [US7] Confirm the rotation policy is enforced (max file size and/or
+      **Implementation deviation, documented**: the vendored `tauri-plugin-log
+      2.8.0` declares a `tracing` Cargo feature but does not actually wire it
+      into any code path (verified by reading the vendored crate source) —
+      enabling it would still install fern's own global `log::logger()`,
+      which directly conflicts with `tracing-subscriber`'s own `tracing-log`
+      bridge (both want the single process-wide `log` logger slot). Resolved
+      by registering `tauri_plugin_log::Builder::new().skip_logger().build()`
+      (so the plugin still exists as a registered plugin, and its `log` Tauri
+      command / `@tauri-apps/plugin-log` JS API still work against the
+      ambient logger) while the actual rotating file target is a
+      `tracing_appender::rolling::daily` layer composed directly into
+      `main.rs`'s `tracing_subscriber::registry()`, alongside the unchanged
+      stderr `fmt` layer — avoiding the dual-global-logger conflict entirely
+      while still satisfying the goal (stdout preserved, rotating file
+      exists, single source of truth for every `tracing::`/`log::` call).
+- [x] T042 [US7] Confirm the rotation policy is enforced (max file size and/or
       max file count) so the log directory never grows unbounded (FR-022,
-      SC-006).
-- [ ] T043 [P] [US7] Document the per-platform log location (already recorded
+      SC-006). Implemented as: `tracing_appender::rolling::daily` (one file
+      per day) plus an explicit age-based prune (`prune_old_logs`, 14-day
+      retention) run on every startup before the day's writer is created.
+- [ ] T043 [P] [US7] **Skipped (optional, not required by any FR)**. Document the per-platform log location (already recorded
       in plan.md's platform-differences table) in whatever in-app "About" or
       "Diagnostics" surface exists (or the native About panel from T033, if a
       "reveal log folder" affordance is added — optional nice-to-have, not
       required by any FR).
-- [ ] T044 [US7] Manual verification on all three platforms: run the app,
+- [ ] T044 [US7] **Deferred to manual verification.** Manual verification on all three platforms: run the app,
       locate the log file at the documented location, confirm readable
       recent entries and confirm the SQLite audit trail is unaffected/unchanged
       (FR-023).


### PR DESCRIPTION
## Summary
This adds three related pieces of native desktop polish: the app now remembers window size/position across restarts, has a proper native application menu (About/Settings/Quit plus standard Edit commands), and writes a rotating diagnostics log file alongside its existing console output.

## What's new
- Window size, position, and maximized state now survive quitting and relaunching the app; if a remembered position ends up fully off-screen (e.g. a second monitor was disconnected), the window recenters instead of appearing unreachable. A minimum window size is still enforced after restoring.
- A native application menu now exists (PlateVault/Edit/Window), including a "Settings…" item that opens the existing Settings page, an About panel, and Quit — plus standard Edit-menu copy/paste/select-all/undo/redo support in text fields.
- A rotating, dated log file is now written to the platform's standard app-log location (in addition to the existing console output), automatically pruned after 14 days so it never grows unbounded — useful for sharing diagnostics when reporting a problem.

## Test plan
- [x] `cargo test -p desktop_shell` (49 passed)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` (clean)
- [x] `cargo fmt --all --check` (clean)
- [x] `just check-generated` (bindings unaffected — no new IPC commands)
- [x] `pnpm --filter @astro-plan/desktop typecheck`
- [x] `pnpm --filter @astro-plan/desktop vitest run` (1254/1254)
- [x] `pnpm --filter @astro-plan/desktop exec eslint` on touched files (clean)
- [ ] Manual verification across Windows/macOS/Linux (window restore, menu presence/Edit commands, log file location) — deferred, noted in tasks.md; this machine could not reliably run the full Playwright E2E suite (shared-runner resource contention unrelated to this change).

## Notes for reviewers
- `tauri-plugin-log` 2.8.0 declares a `tracing` Cargo feature but doesn't actually wire it into any code path (checked the vendored source) — enabling it would still install a second competing global logger against `tracing-subscriber`'s own bridge. Registered the plugin with `skip_logger()` instead (so its JS-facing `log()` API still works) and implemented the actual rotating file via `tracing_appender` composed directly into the existing `tracing_subscriber` setup. Details in the commit message and `tasks.md`.

## Spec Context
- Spec: 051
- Branch: 051-us4-us5-us7-shell-polish