### PR TITLE
fix: inbox needs-review items no longer show a misleading "classified" label

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1412,6 +1412,7 @@
   "inbox_master_row_label": "{type} master",
   "inbox_state_classified": "classified",
   "inbox_state_master_fallback": "master",
+  "inbox_state_needs_review": "needs review",
   "inbox_state_pending": "pending",
   "inbox_state_plan_open": "plan open",
   "inbox_state_resolved": "resolved",

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -41,13 +41,31 @@ export const DEFAULT_INBOX_SORT: InboxSort = { col: 'detection', dir: 'asc' };
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /**
+ * `true` for a materialized single-type sub-item that landed in the T070/
+ * FR-047 needs-review sentinel bucket (spec 041 "single-type sub-items"):
+ * one or more files are missing a mandatory attribute (or have no frame
+ * type at all), so the group has no single dominant frame type — the
+ * backend marks this with `groupKey === "__needs_review__"` and a non-empty
+ * `missingMandatory` list (see `crates/app/inbox/src/classify.rs`'s
+ * `SENTINEL_NEEDS_REVIEW`). Both signals are checked because legacy
+ * pre-materialization rows may carry neither.
+ */
+function isNeedsReview(item: InboxListItem): boolean {
+  return item.groupKey === '__needs_review__' || (item.missingMandatory?.length ?? 0) > 0;
+}
+
+/**
  * Classification label shown in the Type column. For classified / plan-open
  * items we show the dominant frame type when available so the column is
- * frame-type-forward rather than state-forward.
+ * frame-type-forward rather than state-forward. A needs-review sub-item has
+ * no dominant frame type by definition — it must show a distinct
+ * "needs review" label, never the raw item `state` (which is otherwise
+ * `classified` at this point and would misleadingly read as fully resolved).
  */
 function classificationLabel(item: InboxListItem): string {
   if (item.isMaster) return item.masterFrameType ?? m.inbox_state_master_fallback();
   if (item.groupFrameType) return item.groupFrameType;
+  if (isNeedsReview(item)) return m.inbox_state_needs_review();
   switch (item.state) {
     case 'pending_classification': return m.inbox_state_pending();
     case 'classified':             return m.inbox_state_classified();
@@ -58,8 +76,9 @@ function classificationLabel(item: InboxListItem): string {
 }
 
 /** CSS colour modifier for the Type cell. */
-function classificationMod(state: string): string {
-  switch (state) {
+function classificationMod(item: InboxListItem): string {
+  if (isNeedsReview(item)) return 'needs_review';
+  switch (item.state) {
     case 'pending_classification': return 'pending';
     case 'classified':             return 'classified';
     case 'plan_open':              return 'plan_open';
@@ -326,7 +345,7 @@ export function InboxList({
         }
         const { item, originalIdx, indent } = row;
         const selected = selectedIdx === originalIdx;
-        const mod = classificationMod(item.state);
+        const mod = classificationMod(item);
         return {
           _testid: `inbox-item-${item.inboxItemId}`,
           _rowClassName: [

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -681,6 +681,10 @@
 .alm-inbox-row__classification--classified { color: var(--alm-info); }
 .alm-inbox-row__classification--plan_open { color: var(--alm-ok); }
 .alm-inbox-row__classification--resolved  { color: var(--alm-ink4); }
+/* T070/FR-047: a materialized sub-item with a missing mandatory attribute
+   (spec 041 needs-review sentinel bucket) — distinct from `classified` so it
+   never reads as fully resolved. */
+.alm-inbox-row__classification--needs_review { color: var(--alm-warn); }
 
 /* ── task 35: bulk-confirm button ───────────────────────────────────────────────
  *

--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -234,19 +234,43 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
             break rows;
         }
         if tokio::time::Instant::now() >= deadline {
-            // CI run 28782673323 (pre round-1 window-state fix, main@9ee504d1)
-            // and run 28786351305 (post-fix, this branch) both fail HERE on
-            // Windows with the identical "found 0" message and near-identical
-            // ~152s duration — the window-state reset changed nothing about
-            // this failure, so its root cause is NOT window geometry. Before
-            // erroring, call `inbox.list` directly through the invoke bridge
-            // (bypassing the UI entirely) so the failure message tells us
-            // whether the backend ever materialized split rows at all (a real
-            // classify/materialize_sub_items regression) or whether they
-            // exist server-side but the UI/list query never surfaced them
-            // after reload (a frontend refetch/race bug) — the two
-            // possibilities need different fixes and neither can be
-            // distinguished from the UI-only signal alone.
+            // Round 6 (fix-inbox-splitrow-label): rounds 3-5 proved the
+            // backend always materializes the right 2 sub-items and that
+            // `InboxList`'s own render pipeline handles the exact captured
+            // Windows payload correctly (`InboxList.windowsSplitPayload.test.
+            // tsx`) — the drop is real-webview-only. Live diagnostics off
+            // failing Windows runs (28807257849, 28807308638) then showed the
+            // SAME instant recording `rows.len() == 0` from this very
+            // `find_all_testid_prefix` check while a `dump_ui_diagnostics`
+            // JS eval gathered moments later (after an intervening
+            // `inbox.list` invoke round-trip) reported `rowCount: 2` for the
+            // identical live page — i.e. the two split rows land in the real
+            // DOM strictly *between* this deadline check and the
+            // diagnostics-gathering that follows it. Bailing on that single
+            // stale reading is exactly the flake: give the in-flight
+            // fetch/render one bounded last chance to land, using the same
+            // check the pass path uses, before treating it as a real
+            // failure. A genuine regression still times out below.
+            let grace_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
+            let mut late_rows = rows;
+            while late_rows.len() < 2 && tokio::time::Instant::now() < grace_deadline {
+                tokio::time::sleep(Duration::from_millis(250)).await;
+                late_rows = app.find_all_testid_prefix("inbox-item-").await.unwrap_or_default();
+            }
+            if late_rows.len() >= 2 {
+                break late_rows;
+            }
+
+            // Still short after the grace window — gather full evidence
+            // before erroring. Before erroring, call `inbox.list` directly
+            // through the invoke bridge (bypassing the UI entirely) so the
+            // failure message tells us whether the backend ever materialized
+            // split rows at all (a real classify/materialize_sub_items
+            // regression) or whether they exist server-side but the UI/list
+            // query never surfaced them after reload (a frontend
+            // refetch/race bug) — the two possibilities need different
+            // fixes and neither can be distinguished from the UI-only
+            // signal alone.
             let backend_items: serde_json::Value = app
                 .invoke("inbox_list", serde_json::json!({}))
                 .await
@@ -267,9 +291,10 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
             let console_log = app.dump_console_log().await;
             anyhow::bail!(
                 "expected the mixed folder to split into >=2 single-type rows in the \
-                 real Inbox list, found {} (current_url={url:?}, backend inbox.list={backend_items}, \
+                 real Inbox list, found {} after a {UI_TIMEOUT:?} deadline + 5s grace \
+                 window (current_url={url:?}, backend inbox.list={backend_items}, \
                  ui_diagnostics={ui_diagnostics}, console_log={console_log})",
-                rows.len()
+                late_rows.len()
             );
         }
         tokio::time::sleep(Duration::from_secs(2)).await;


### PR DESCRIPTION
## Summary
- The Inbox list showed "classified" for detections that actually still need manual review (missing required metadata like frame type), which looked like they were already fully resolved. These rows now show a distinct "needs review" label instead.
- Also stabilized an intermittent Windows-only test failure in the Inbox split-item journey test that was unrelated to product behavior (a timing race in the test's own row-count check).

## Spec Context
Fixes a real UI regression from the spec 041 "single-type sub-items" work: needs-review sentinel rows (`groupKey === "__needs_review__"`) had no `groupFrameType`, so `InboxList`'s classification badge fell back to the item's raw internal state text. Root-cause evidence and full detail are in the PR discussion.