### PR TITLE
fix(targets): keep the target-search popup subtree mounted

### DIFF
--- a/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
@@ -463,7 +463,31 @@ export function TargetSearch({
           </span>
         )}
 
-        <Combobox.Portal>
+        {/*
+         * `keepMounted`: without it, `Combobox.Portal` only renders its
+         * subtree (status/option elements) once Base UI's internal
+         * store-derived `mounted` flips true — which, per
+         * `useTransitionStatus`, happens synchronously the instant `open`
+         * becomes true, EXCEPT this combobox's `open` is re-derived on every
+         * keystroke (`onInputValueChange` -> `setOpen(true)`), unlike a
+         * click-triggered Dialog/Popover whose `open` only flips once per
+         * interaction. That gives a real-typing-driven open/close cycle far
+         * more chances to race Base UI's own internal open bookkeeping than
+         * a single click does. Windows real-UI E2E (`targets_journeys.rs`,
+         * "M 1" suggestion never rendering within 20s even though
+         * `target.search` is a local, network-free, sub-millisecond seed
+         * lookup) hit exactly that: `aria-expanded`/`data-popup-open` on the
+         * input reported "open", but NO popup content — not even the
+         * always-present idle/no-results/searching `Combobox.Status` line —
+         * ever appeared anywhere in the document, meaning the portal itself
+         * never rendered. `keepMounted` decouples rendering the subtree from
+         * that race: the popup DOM is always present (hidden via the
+         * `hidden` attribute — invisible and inert, so real users never see
+         * anything different) as soon as our OWN `suggestions`/`loading`/
+         * `error` state has something to show, regardless of Base UI's
+         * internal open/mounted timing.
+         */}
+        <Combobox.Portal keepMounted>
           <Combobox.Positioner
             className="alm-target-search__positioner"
             sideOffset={4}


### PR DESCRIPTION
## Summary
- `TargetSearch.tsx`'s combobox (`@base-ui-components/react` Combobox) re-derives its `open` state on every keystroke (`onInputValueChange` -> `setOpen(true)`), unlike a click-triggered Dialog/Popover whose `open` flips once per interaction. That gives Base UI's internal open/`mounted` bookkeeping far more opportunities to race our externally-controlled `open` prop under a real, per-character WebView2-driven typing session.
- Symptom: Windows real-UI E2E (`targets_journeys.rs`, `targets_ui_add_target_no_duplicate_on_reconfirm` + `targets_ui_astronomy_columns_disclose_placeholder_without_site`) never found ANY popup content after typing a bundled designation ("M 1") — not even the always-present idle/no-results/searching `Combobox.Status` line — even though the input's `aria-expanded`/`data-popup-open` reported the combobox open. `target.search` is a local, network-free, sub-millisecond seed lookup ("M 1" / Crab Nebula is confirmed present in the bundled seed), so the backend was never the bottleneck; this is purely a frontend popup-mounting race.
- Root cause (traced into the installed `@base-ui-components/react@1.0.0-rc.0` source): `Combobox.Portal` only renders its subtree once the internal store's `mounted` flag flips true (`shouldRender = mounted || keepMounted || forceMounted`, default `keepMounted=false`). When that race loses on Windows, the trigger still reports "open" but the portal's `mounted` flag never flips, so nothing renders.
- Fix: pass `keepMounted` to `<Combobox.Portal>`. The popup DOM subtree (hidden via the `hidden` attribute when genuinely closed — no visible/behavioral change for real users) now exists as soon as our own `suggestions`/`loading`/`error` state has something to show, independent of that internal open/mounted race.

## Evidence
- CI run `28807257849`, job `85425880947` (`Real-UI E2E — windows-latest`, branch `037-ui-journeys-targets`): 4/4 failures (2 tests × 2 nextest tries) show the identical diagnostic dump — input `value="M 1"`, `aria-expanded="true"`, `data-popup-open=""`, but `error state: absent`, `resolving (SIMBAD phase-2) state: absent`, `generic status line: absent` everywhere in the document.
- Backend seed load confirmed fast (`loaded 13073 bundled target seed entries` within ~6s of boot) and "M 1" confirmed present in `assets/seed/seed.json`, ruling out a backend/search bug.
- The companion fix-lane commit (this PR's commit, cherry-picked from `037-ui-journeys-targets`@`0e251b10`) is already staged on that branch's own PR (#463) so its Windows E2E job can go green; this PR lands the same fix on `main` directly since it's a real Windows user-facing bug, not test-only.

## Test plan
- [x] `pnpm vitest run src/components/TargetSearch/TargetSearch.test.tsx` — 17/17 pass
- [x] `pnpm run typecheck` (apps/desktop) — clean
- [x] `pnpm exec eslint src/components/TargetSearch/TargetSearch.tsx` — 0 errors (1 pre-existing, unrelated `react-hooks/incompatible-library` warning)
- [ ] Windows real-UI E2E confirmation via `037-ui-journeys-targets` (PR #463) picking up this same commit