### PR TITLE
fix(sessions): persist root_id when ingesting acquisition and calibration sessions

### DIFF
--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -213,9 +213,21 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
     // `frame_ids` instead of the historical `'[]'` placeholder. A resolution
     // failure (destination path not found / stat failure) is logged and
     // leaves `frame_ids` empty — never blocks master registration.
+    //
+    // `resolved_root_id` (spec 006's `calibration_session.root_id`, migration
+    // 0021) is captured from the same lookup and written below — this table
+    // had the identical gap as `acquisition_session` (#470 round 6): the
+    // column existed, `persistence_db::repositories::inventory::
+    // update_calibration_session_root_id` existed to set it, but nothing
+    // ever called the setter or wrote the column at insert time, so every
+    // real calibration master's `root_id` stayed `NULL` (silently decoded as
+    // `""` by sqlx-sqlite, masking the gap from a plain string comparison).
+    let mut resolved_root_id: Option<String> = None;
     let frame_id = match resolve_applied_frame_path(pool, plan_id).await {
         Ok(Some((root_id, relative_path))) => {
-            match write_calibration_frame_record(pool, &root_id, &relative_path).await {
+            let outcome = write_calibration_frame_record(pool, &root_id, &relative_path).await;
+            resolved_root_id = Some(root_id);
+            match outcome {
                 Ok(id) => Some(id),
                 Err(e) => {
                     tracing::warn!(
@@ -246,13 +258,14 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
 
     sqlx::query(
         "INSERT INTO calibration_session
-            (id, session_key, frame_ids, kind, created_at, source_inbox_item_id)
-         VALUES (?, ?, ?, ?, datetime('now'), ?)",
+            (id, session_key, frame_ids, kind, root_id, created_at, source_inbox_item_id)
+         VALUES (?, ?, ?, ?, ?, datetime('now'), ?)",
     )
     .bind(&session_id)
     .bind(&session_key)
     .bind(&frame_ids_json)
     .bind(cal_kind)
+    .bind(&resolved_root_id)
     .bind(&item.id)
     .execute(pool)
     .await
@@ -680,5 +693,23 @@ mod tests {
         assert_eq!(size_bytes, expected_size, "real on-disk size, never 0");
         assert_eq!(stored_root, root_id);
         assert_eq!(stored_rel, rel);
+
+        // Regression for #470 round 6's twin bug: `calibration_session.root_id`
+        // (migration 0021) had the identical never-written gap as
+        // `acquisition_session.root_id` — this test already drives the real
+        // registered_sources → plan-apply → plan_listener path, so it is the
+        // right place to lock the fix in rather than adding a parallel test.
+        let (session_root_id,): (String,) = sqlx::query_as(
+            "SELECT root_id FROM calibration_session WHERE source_inbox_item_id = ?",
+        )
+        .bind(item_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            session_root_id, root_id,
+            "calibration_session.root_id must be set to the real registered source id, not left \
+             empty/unset"
+        );
     }
 }

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -240,8 +240,15 @@ async fn ingest_light_frame(
 
     let (key, has_observer_location) = derive_session_key(&key_target, &meta);
 
-    upsert_session(pool, &key, has_observer_location, canonical_target_id.as_deref(), &image_id)
-        .await?;
+    upsert_session(
+        pool,
+        &key,
+        has_observer_location,
+        canonical_target_id.as_deref(),
+        &image_id,
+        &item.root_id,
+    )
+    .await?;
 
     Ok(FrameOutcome::Ingested)
 }
@@ -364,12 +371,30 @@ fn parse_date_obs(raw: Option<&str>) -> OffsetDateTime {
 ///
 /// Idempotent (R12): the SELECT-by-`session_key` lookup keeps grouping
 /// single-row, and a repeat append of the same frame id is dropped (set-dedup).
+///
+/// `root_id` (R9/T036/FR-012 — spec 006's `acquisition_session.root_id`,
+/// migration 0021) is set on every insert and back-filled with
+/// `COALESCE(root_id, ?)` on every append so a session's first-known root
+/// sticks even across repeat ingests. This closed a real gap (found via
+/// #470's Layer-2 journeys, round 6): `root_id` was never written by this
+/// function at all — the column existed and `persistence_db::repositories::
+/// inventory::update_acquisition_session_root_id` existed to set it (its own
+/// doc comment: "Called when the inbox confirm pipeline resolves the root
+/// for a session"), but nothing ever called it, so every real ingested
+/// session's `root_id` stayed `NULL`. Sqlx-sqlite (this project's version)
+/// silently decodes a `NULL` `TEXT` column into a plain (non-`Option`)
+/// `String` as `""` rather than erroring, so downstream readers that assume
+/// `root_id` is always populated (`app_core_projects::source_view_generate`)
+/// got a real-looking-but-empty id and failed with a confusing
+/// `no_link_kind`/"source root  could not be resolved" (note the double
+/// space) instead of a clear "root never set" error.
 async fn upsert_session(
     pool: &SqlitePool,
     key: &str,
     has_observer_location: bool,
     canonical_target_id: Option<&str>,
     image_id: &str,
+    root_id: &str,
 ) -> Result<(), ContractError> {
     if let Some((id, frame_ids_json, existing_target)) = sqlx::query_as::<
         _,
@@ -391,10 +416,13 @@ async fn upsert_session(
         // Back-fill the link if it resolved this pass and the row had none.
         if existing_target.is_none() && canonical_target_id.is_some() {
             sqlx::query(
-                "UPDATE acquisition_session SET frame_ids = ?, canonical_target_id = ? WHERE id = ?",
+                "UPDATE acquisition_session \
+                 SET frame_ids = ?, canonical_target_id = ?, root_id = COALESCE(root_id, ?) \
+                 WHERE id = ?",
             )
             .bind(&frames_json)
             .bind(canonical_target_id)
+            .bind(root_id)
             .bind(&id)
             .execute(pool)
             .await
@@ -405,12 +433,16 @@ async fn upsert_session(
                 propagate_target_to_projects(pool, &id, target_id).await?;
             }
         } else {
-            sqlx::query("UPDATE acquisition_session SET frame_ids = ? WHERE id = ?")
-                .bind(&frames_json)
-                .bind(&id)
-                .execute(pool)
-                .await
-                .map_err(db_err)?;
+            sqlx::query(
+                "UPDATE acquisition_session \
+                 SET frame_ids = ?, root_id = COALESCE(root_id, ?) WHERE id = ?",
+            )
+            .bind(&frames_json)
+            .bind(root_id)
+            .bind(&id)
+            .execute(pool)
+            .await
+            .map_err(db_err)?;
         }
         return Ok(());
     }
@@ -420,14 +452,15 @@ async fn upsert_session(
     sqlx::query(
         "INSERT INTO acquisition_session
             (id, session_key, target_id, canonical_target_id, has_observer_location,
-             frame_ids, observer_location, created_at)
-         VALUES (?, ?, NULL, ?, ?, ?, NULL, ?)",
+             frame_ids, observer_location, root_id, created_at)
+         VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ?)",
     )
     .bind(&id)
     .bind(key)
     .bind(canonical_target_id)
     .bind(i64::from(has_observer_location))
     .bind(&frames_json)
+    .bind(root_id)
     .bind(OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default())
     .execute(pool)
     .await
@@ -646,6 +679,22 @@ mod tests {
         .unwrap();
     }
 
+    /// Insert a minimal `library_root` row so `acquisition_session.root_id`'s
+    /// FK (migration 0021) is satisfiable in tests that pass a `root_id` to
+    /// `upsert_session`.
+    async fn seed_library_root(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO library_root (id, label, current_path, kind, state, created_at)
+             VALUES (?, ?, ?, 'local', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .bind(id)
+        .bind(format!("/tmp/{id}"))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
     async fn seed_project(pool: &SqlitePool, id: &str) {
         repo_projects::insert_project(
             pool,
@@ -729,13 +778,16 @@ mod tests {
     async fn upsert_session_insert_branch_with_no_linked_project_does_not_error() {
         let db = test_db().await;
         seed_canonical_target(db.pool(), "target-1", "M 31").await;
+        seed_library_root(db.pool(), "root-1").await;
 
         // A brand-new session (INSERT branch of upsert_session) resolves a
         // target immediately; `project_sources` cannot yet reference this
         // session's id (a project can only link an *existing* session in the
         // real UI flow), so there is no linked project. The INSERT-branch
         // propagation call must be a safe no-op, not a panic/error.
-        upsert_session(db.pool(), "sk-1", false, Some("target-1"), "image-1").await.unwrap();
+        upsert_session(db.pool(), "sk-1", false, Some("target-1"), "image-1", "root-1")
+            .await
+            .unwrap();
 
         let (canonical_target_id,): (Option<String>,) = sqlx::query_as(
             "SELECT canonical_target_id FROM acquisition_session WHERE session_key = 'sk-1'",
@@ -746,14 +798,73 @@ mod tests {
         assert_eq!(canonical_target_id.as_deref(), Some("target-1"));
     }
 
+    /// Regression test for #470 round 6: `acquisition_session.root_id`
+    /// (migration 0021) was never written by real ingest — `upsert_session`'s
+    /// INSERT/UPDATE statements simply omitted the column, and the
+    /// `update_acquisition_session_root_id` repo fn that existed specifically
+    /// to set it (T036/FR-012) was never called from anywhere. Every
+    /// downstream reader that assumes `root_id` is populated
+    /// (`app_core_projects::source_view_generate`) got sqlx's silent
+    /// NULL-into-`String` coercion to `""` instead, and failed with a
+    /// confusing `no_link_kind`/"source root  could not be resolved" (double
+    /// space) rather than a clear error.
+    ///
+    /// Registers the root through the REAL `roots.register` repo path
+    /// (`persistence_db::repositories::first_run::register_source`) — a
+    /// `registered_sources` row, NOT a hand-seeded `library_root` row — and
+    /// mirrors it via the same `ensure_library_root` (R9) call the real
+    /// `ingest_light_frame` pipeline makes, so this test exercises the actual
+    /// production root-resolution path rather than a `library_root`-only
+    /// fixture shortcut that would mask the same gap the backend unit test
+    /// for `source_view_generate` originally did.
+    #[tokio::test]
+    async fn upsert_session_persists_root_id_from_a_really_registered_source() {
+        let db = test_db().await;
+
+        let register_req = domain_core::first_run::RegisterSourceRequest {
+            kind: domain_core::first_run::SourceKind::LightFrames,
+            path: "/tmp/e2e-lights".to_owned(),
+            kind_subtype: None,
+            scan_depth: domain_core::first_run::ScanDepth::Recursive,
+            organization_state: domain_core::first_run::OrganizationState::Organized,
+        };
+        let registered =
+            persistence_db::repositories::first_run::register_source(db.pool(), &register_req)
+                .await
+                .unwrap();
+
+        // R9: the same mirroring `ingest_light_frame` performs before ever
+        // calling `upsert_session` — real users hit this via the applied
+        // plan's `to_root_id`, which is a `registered_sources` id.
+        let mirrored_path = ensure_library_root(db.pool(), &registered.source_id).await.unwrap();
+        assert_eq!(mirrored_path.as_deref(), Some("/tmp/e2e-lights"));
+
+        upsert_session(db.pool(), "sk-root-real", false, None, "image-1", &registered.source_id)
+            .await
+            .unwrap();
+
+        let (root_id,): (String,) =
+            sqlx::query_as("SELECT root_id FROM acquisition_session WHERE session_key = ?")
+                .bind("sk-root-real")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            root_id, registered.source_id,
+            "acquisition_session.root_id must be set to the real registered source id, not left \
+             empty/unset"
+        );
+    }
+
     #[tokio::test]
     async fn upsert_session_backfill_branch_propagates_when_project_prelinked() {
         let db = test_db().await;
         seed_canonical_target(db.pool(), "target-1", "M 31").await;
         seed_project(db.pool(), "proj-1").await;
+        seed_library_root(db.pool(), "root-1").await;
 
         // First frame arrives with no resolvable target — session created NULL.
-        upsert_session(db.pool(), "sk-2", false, None, "image-1").await.unwrap();
+        upsert_session(db.pool(), "sk-2", false, None, "image-1", "root-1").await.unwrap();
         let (session_id,): (String,) =
             sqlx::query_as("SELECT id FROM acquisition_session WHERE session_key = 'sk-2'")
                 .fetch_one(db.pool())
@@ -763,7 +874,9 @@ mod tests {
 
         // Second frame in the same session resolves — back-fill branch runs and
         // must propagate to the now-linked project.
-        upsert_session(db.pool(), "sk-2", false, Some("target-1"), "image-2").await.unwrap();
+        upsert_session(db.pool(), "sk-2", false, Some("target-1"), "image-2", "root-1")
+            .await
+            .unwrap();
 
         let got =
             repo_projects::get_project_canonical_target_id(db.pool(), "proj-1").await.unwrap();
@@ -797,7 +910,7 @@ mod tests {
         .unwrap();
 
         // A session with an unresolved (NULL) target, one frame.
-        upsert_session(db.pool(), "sk-3", false, None, "image-1").await.unwrap();
+        upsert_session(db.pool(), "sk-3", false, None, "image-1", "root-1").await.unwrap();
         let (session_id,): (String,) =
             sqlx::query_as("SELECT id FROM acquisition_session WHERE session_key = 'sk-3'")
                 .fetch_one(db.pool())


### PR DESCRIPTION
## Summary

Both `acquisition_session.root_id` and `calibration_session.root_id` (migration 0021, spec 006) were **never written** by the real ingest pipelines, even though:

- The column exists specifically for this purpose — migration 0021's own comment: *"New sessions created by the inbox confirm pipeline (spec 005+) MUST supply the root_id"*.
- A dedicated setter existed for exactly this job — `persistence_db::repositories::inventory::update_acquisition_session_root_id` / `update_calibration_session_root_id` (T036/FR-012), whose own doc comment says *"Called when the inbox confirm pipeline resolves the root for a session"* — but neither was ever called anywhere in the codebase. Dead code.
- `crates/app/targets/src/ingest_sessions.rs::upsert_session`'s INSERT/UPDATE statements for `acquisition_session` simply omitted the column, and `crates/app/inbox/src/plan_listener.rs::register_master_if_applicable`'s `calibration_session` INSERT had the identical omission (it already resolves the master's root_id to write the `file_record`, but never carried that value into the session row).

**sqlx-sqlite decode masking**: confirmed empirically (via a throwaway probe test) that this project's sqlx-sqlite version silently decodes a `NULL` `TEXT` column into a plain (non-`Option`) `String` as `""` rather than erroring. So every downstream reader that assumes `root_id` is populated got a real-looking-but-empty id instead of a clear "root never set" error.

**User impact**: `app_core_projects::source_view_generate` (spec 049 source-view generation) reads `acquisition_session.root_id` to resolve the source root for each planned link item. With `root_id` always empty, real users hit a confusing `no_link_kind` error — `"source root  could not be resolved"` (note the double space from the empty id interpolated into the message) — for every source-view generation from a normally-ingested project. This is a genuine break in a shipped feature for real ingest flows, not an edge case.

**Why the unit-test gap**: `source_view_generate`'s own existing passing unit test seeds `acquisition_session.root_id` directly via a hand-written literal in its test-only INSERT helper, bypassing the real ingest module (`app_core_targets::ingest_sessions`) entirely — so it kept passing regardless of whether the real ingest write path was broken. Found via real end-to-end Layer-2 journeys (spec 037, PR #470) that exercise the actual `roots.register` → `inbox.confirm` → `inbox.plan.apply` → ingest → `sourceview.generate` flow.

Compared directly against `1d0aed9` (spec 041's `registered_sources`-vs-`library_root` root-resolution fix, the closest prior bug in this area): this is a **different** bug in the same subsystem — not a wrong-table lookup (the reader already queries the correct `library_root` table, which R9 mirroring does populate for real roots), but a column that was simply never written at all.

## Changes

- `crates/app/targets/src/ingest_sessions.rs`: `upsert_session` now takes `root_id`, sets it on `INSERT`, and back-fills it via `COALESCE(root_id, ?)` on every append so a session's first-known root sticks across repeat ingests (mirrors the never-wired setter's intent). Adds a regression test that registers the root through the **real** `roots.register` repo path (`persistence_db::repositories::first_run::register_source`) plus the real `ensure_library_root` mirroring step, rather than a `library_root`-only fixture shortcut — the kind of shortcut that masked this gap originally.
- `crates/app/inbox/src/plan_listener.rs`: `register_master_if_applicable` now carries its already-resolved root id into the `calibration_session` INSERT. Extends the existing real-path regression test (`master_item_apply_writes_frame_record_and_frame_ids`, which already drives a real `registered_sources` root through the plan-apply/plan_listener event path) with an assertion that `root_id` is populated, rather than adding a parallel test.

## Test plan

- [x] `cargo test -p app_core_targets` — 97 passed, 0 failed
- [x] `cargo test -p app_core_inbox` — 138 passed, 0 failed
- [x] `cargo build --workspace`
- [x] `cargo clippy -p app_core_targets -p app_core_inbox --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`

## Spec Context

- Related: spec 006 (`acquisition_session`/`calibration_session.root_id`), spec 035 US4 (light ingest), spec 048 (calibration master ingest), spec 049 (source-view generation, where the breakage surfaced)
- Found via: spec 037 Layer-2 E2E journeys, PR #470 (round 6)