### PR TITLE
fix(e2e): harden the project-wizard journey against windows first-render stalls

### DIFF
--- a/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
+++ b/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 use anyhow::Context;
 use common::{write_minimal_fits, E2eApp};
 use serde_json::json;
-use thirtyfour::By;
+use thirtyfour::{By, WebElement};
 
 const UI_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -152,6 +152,83 @@ async fn setup_project_library_and_one_session(app: &E2eApp) -> anyhow::Result<s
     Ok(project_root_path)
 }
 
+/// Poll for the wizard's `#project-name` input, with ONE full-page-reload
+/// fallback if it hasn't appeared within `first_attempt` — the recovery for a
+/// windows-only, self-recovering flake first sighted across three separate CI
+/// runs (different branches + `main`; latest sample: `main` run for commit
+/// `1ac2ea2b`, job `85493169943`, 22/23 passed, both retries red then green
+/// on rerun): `no #project-name input found / no such element` right at
+/// `.../#/projects/new`.
+///
+/// An earlier investigation (spec-037 fix-lane, batch before #467) read
+/// `WizardPage.tsx`/`StepName.tsx` end to end and found no logic bug —
+/// `currentStep` initializes to `0` synchronously, `StepName` renders
+/// unconditionally with `id="project-name"`, and the route lands correctly.
+/// That, plus the "always windows-latest, always self-recovers" signature,
+/// points at a first-paint stall on a cold WebView2 renderer rather than a
+/// route/gate race: `goto_route` never does a full page load (the app uses
+/// HASH history, so navigating only mutates `location.hash`), so if
+/// WebView2's first paint after that in-place hash change stalls, nothing in
+/// this harness's existing waits (`wait_document_ready`, `wait_bridge_ready`)
+/// would catch it — both already report ready; only the next paint is stuck.
+/// A single `driver.refresh()` forces a genuine full page reload, which gives
+/// the router (and the WebView2 renderer) a clean start; re-settling via
+/// `wait_document_ready` + `wait_bridge_ready` before retrying the poll
+/// mirrors the exact sequence `E2eApp::launch` and `goto_route` already rely
+/// on elsewhere in this harness, so the reload path is proven machinery, not
+/// a new mechanism. On a genuine failure (not just a slow first paint) the
+/// reload changes nothing and the second poll still times out, which is then
+/// reported with full diagnostics rather than the bare original message.
+async fn find_project_name_input_with_reload_retry(app: &E2eApp) -> anyhow::Result<WebElement> {
+    let first_attempt_timeout = Duration::from_secs(10);
+    let deadline = tokio::time::Instant::now() + first_attempt_timeout;
+    loop {
+        if let Ok(el) = app.driver.find(By::Id("project-name")).await {
+            return Ok(el);
+        }
+        if tokio::time::Instant::now() >= deadline {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(150)).await;
+    }
+
+    // Not there after 10s of polling: attempt the one-shot reload recovery.
+    app.driver.refresh().await.context("page refresh after a #project-name stall failed")?;
+    app.wait_document_ready(Duration::from_secs(10))
+        .await
+        .context("document.readyState never settled after the #project-name reload retry")?;
+    app.wait_bridge_ready(Duration::from_secs(15))
+        .await
+        .context("__ALM_E2E__ bridge never re-armed after the #project-name reload retry")?;
+
+    match app.find_waiting(By::Id("project-name"), "the wizard's #project-name input").await {
+        Ok(el) => Ok(el),
+        Err(original_err) => {
+            let url = app
+                .driver
+                .current_url()
+                .await
+                .map_or_else(|_| "<unknown>".to_owned(), |u| u.to_string());
+            let body_html: String = app
+                .driver
+                .execute(
+                    "return document.body ? document.body.outerHTML.slice(0, 4096) : '<no body>';",
+                    vec![],
+                )
+                .await
+                .ok()
+                .and_then(|ret| ret.convert::<String>().ok())
+                .unwrap_or_else(|| "<failed to read document.body.outerHTML>".to_owned());
+            let ui_diag = app.dump_ui_diagnostics().await;
+            Err(anyhow::anyhow!(
+                "no #project-name input found even after a reload retry \
+                 (current URL: {url}); body outerHTML sample: {body_html}; \
+                 dump_ui_diagnostics: {ui_diag:#}; original poll error: {original_err}"
+            ))
+        }
+    }
+}
+
 /// Drive the wizard's Name -> Sources -> Calibration -> Views -> Naming ->
 /// Review steps for a given project `name`, ending with a click on the real
 /// Create button (`data-testid="wizard-create-btn"`) — real DOM interaction
@@ -159,9 +236,9 @@ async fn setup_project_library_and_one_session(app: &E2eApp) -> anyhow::Result<s
 async fn run_wizard_to_create(app: &E2eApp, name: &str) -> anyhow::Result<()> {
     // Poll for the wizard's Name step to actually mount: it opens
     // asynchronously after the navigation, same route/render race
-    // `E2eApp::find_waiting` documents.
-    let name_input = app
-        .find_waiting(By::Id("project-name"), "the wizard's #project-name input")
+    // `E2eApp::find_waiting` documents — plus a bounded one-shot reload
+    // recovery for the windows-only first-paint stall (see the helper's doc).
+    let name_input = find_project_name_input_with_reload_retry(app)
         .await
         .context("no #project-name input found")?;
     name_input.clear().await?;


### PR DESCRIPTION
## Summary

- `projects_ui_wizard_creates_real_folders_and_blocks_duplicate_name` has flaked intermittently on `windows-latest` in Layer-2 real-UI E2E CI, failing with `Error: no #project-name input found / no such element` right after landing on `.../#/projects/new`. 3 sightings across different branches + `main`, all windows-only, both retries red when it strikes, and it always self-recovers on the next unrelated run. Latest sample: `main` run for `1ac2ea2b`, job `85493169943` (22/23 tests passed).
- An earlier investigation read `WizardPage.tsx`/`StepName.tsx` end to end and found no logic bug — `currentStep` initializes to `0` synchronously, `StepName` renders unconditionally with `id="project-name"`, and the route lands correctly — concluding this is CI timing noise rather than a real defect.
- This harness's router uses hash history, so `goto_route` never performs a full page load — it only mutates `location.hash` and waits for `document.readyState`/the `__ALM_E2E__` bridge. That leaves a gap: neither wait proves the *route's own component tree* has painted, and on a cold WebView2 renderer that first paint can stall in a way neither existing signal catches.
- Fix: add a bounded, evidence-based recovery instead of a longer blind timeout. Poll for `#project-name` for 10s (matching the harness's other short polls); if it hasn't appeared, force ONE full page reload via `driver.refresh()`, re-settle with the harness's own proven `wait_document_ready` + `wait_bridge_ready` sequence (the same one `E2eApp::launch`/`goto_route` already rely on), then retry the poll for the remainder of the standard timeout. A genuine failure (not just a slow first paint) is unaffected by the reload and still times out — but now the failure carries the current URL, a `document.body.outerHTML` sample, and `dump_ui_diagnostics()` so a fourth sighting self-documents instead of repeating the same bare message.

## Test plan

- [x] `cargo test -p e2e_tests --no-run` — compiles clean
- [x] `cargo clippy -p e2e_tests --all-targets -- -D warnings` — no issues
- [x] `cargo fmt --all -- --check` — clean
- [ ] Observe the next few `windows-latest` Layer-2 E2E runs for this journey to confirm the flake no longer reproduces (test is `#[ignore]`d and only runs via `e2e.yml --run-ignored all`, so it isn't exercised by a plain local `cargo test`)