### PR TITLE
docs(windows): switch WSL↔Windows bridge mechanics to mirrored networking

### DIFF
--- a/.mcp.tauri.env.example
+++ b/.mcp.tauri.env.example
@@ -2,9 +2,10 @@
 # `tauri` MCP server (/mcp reconnect, or restart Claude).
 #
 # The @hypothesi tauri MCP bridge (tauri-plugin-mcp-bridge) serves a WebSocket on
-# the app side (port from MCP_BRIDGE_PORT in .mcp.json, default 9223). When the
-# app runs on Windows and Claude runs in WSL, set this to the WSL default-gateway
-# IP so the MCP server can reach the bridge:
-#   ip route show default | awk '{print $3}'
-# When app and MCP server share a host, use localhost.
+# the app side (port from MCP_BRIDGE_PORT in .mcp.json, default 9223).
+# localhost works in every supported topology: same-host, and Windows-app +
+# WSL-Claude — WSL runs in mirrored networking mode (networkingMode=mirrored in
+# .wslconfig), so localhost reaches Windows services directly. The old NAT
+# default-gateway-IP workaround (ip route show default) is obsolete; only set a
+# non-localhost host here for a remote machine or a non-mirrored WSL install.
 MCP_BRIDGE_HOST=localhost

--- a/docs/development/windows-journeys/journey-01-first-run-setup.md
+++ b/docs/development/windows-journeys/journey-01-first-run-setup.md
@@ -56,9 +56,10 @@
 - Launch with the dev overlay so the bridge is live:
   `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge is
   `#[cfg(debug_assertions)]`, WebSocket on `0.0.0.0:9223`).
-- Connect via `driver_session host=<WSL↔Windows gateway IP> port=9223`
-  (`ip route show default` on the WSL side gives the gateway; firewall
-  already allows 9223).
+- Connect via `driver_session host=localhost port=9223` — WSL runs in
+  mirrored networking mode (`networkingMode=mirrored` in `.wslconfig`), so
+  `localhost` reaches Windows services directly; the old NAT gateway-IP
+  lookup (`ip route show default`) is obsolete. Firewall already allows 9223.
 - Prefer `webview_execute_js` → `window.__TAURI__.core.invoke('<snake_command>', {args})`
   to call a backend command directly; `ipc_execute_command` rejects many real
   commands.

--- a/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
+++ b/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
@@ -47,7 +47,7 @@
   `pnpm install` with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional, for programmatic driving): launch with
   `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge on
-  `0.0.0.0:9223`), connect with `driver_session host=<gateway> port=9223`,
+  `0.0.0.0:9223`), connect with `driver_session host=localhost port=9223`,
   invoke commands via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`. Native folder
   pickers still need `VITE_E2E=1` stand-ins (see Journey 1's doc for the

--- a/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
+++ b/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
@@ -37,7 +37,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 
 ## Preconditions

--- a/docs/development/windows-journeys/journey-04-sessions-review.md
+++ b/docs/development/windows-journeys/journey-04-sessions-review.md
@@ -43,7 +43,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 
 ## Preconditions

--- a/docs/development/windows-journeys/journey-05-project-lifecycle.md
+++ b/docs/development/windows-journeys/journey-05-project-lifecycle.md
@@ -46,7 +46,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 
 ## Preconditions

--- a/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
+++ b/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
@@ -49,7 +49,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 
 ## Preconditions

--- a/docs/development/windows-journeys/journey-07-archive-delete.md
+++ b/docs/development/windows-journeys/journey-07-archive-delete.md
@@ -47,7 +47,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`. Note: as of
   2026-07-05 no shipped UI button generates an archive plan yet — you may
   need to invoke `archive_plan_generate` directly via the bridge (see below)

--- a/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
+++ b/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
@@ -46,7 +46,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 
 ## Preconditions

--- a/docs/development/windows-journeys/journey-09-targets-planning.md
+++ b/docs/development/windows-journeys/journey-09-targets-planning.md
@@ -62,7 +62,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`. There is no
   known backend command to fake an ObserverSite for this pre-#440 test —
   don't try to force Test 6c until #440 actually merges.

--- a/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
+++ b/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
@@ -43,7 +43,7 @@
   with `$env:CI="true"`, relaunch.
 - Tauri MCP bridge (optional): `cargo tauri dev --config
   src-tauri\tauri.dev.conf.json` (bridge WS on `0.0.0.0:9223`), connect with
-  `driver_session host=<gateway> port=9223`, invoke via `webview_execute_js` →
+  `driver_session host=localhost port=9223`, invoke via `webview_execute_js` →
   `window.__TAURI__.core.invoke('<snake_command>', {args})`.
 
 ## Preconditions

--- a/docs/development/windows-native-rust-dev.md
+++ b/docs/development/windows-native-rust-dev.md
@@ -13,11 +13,15 @@ reasons:
    `\\wsl$\…` / `\\wsl.localhost\…` path as a working directory (`cmd.exe`
    refuses UNC CWDs; many tools break). So you cannot drive the build from
    Windows against the WSL filesystem.
-2. **WSL↔Windows networking problem.** A Vite dev server bound inside WSL is
-   often unreachable from a Windows browser under NAT networking (`localhost`
-   forwarding is flaky/absent), so the browser-preview path is unreliable.
+2. **WSL↔Windows networking** — historical: under NAT networking a Vite dev
+   server bound inside WSL was often unreachable from a Windows browser.
+   This host now runs WSL in **mirrored networking mode**
+   (`networkingMode=mirrored` in `.wslconfig`), so `localhost` is shared in
+   both directions and this reason no longer applies — but note the flip
+   side: WSL and Windows now share one port space, so a stray WSL process on
+   `:5173` (or `:9223`) directly conflicts with the Windows app's ports.
 
-The fix that eliminates **both**: keep a **second checkout on a native Windows
+Reason 1 alone still mandates the fix: keep a **second checkout on a native Windows
 NTFS drive** (e.g. `C:\dev\astro-plan`) and build/run there. node, cargo, Vite,
 and the WebView2 window are all Windows-native — nothing crosses the WSL
 boundary. The WSL copy stays as the canonical repo; the Windows copy is the
@@ -186,4 +190,4 @@ Get-Process desktop_shell,cargo,rustc -ErrorAction SilentlyContinue | Stop-Proce
 | `link.exe`/`cl` “not found” at the Rust link step | Install VS Build Tools 2022 “Desktop development with C++”. |
 | WSL-side edits don’t hot-reload | Ensure `CHOKIDAR_USEPOLLING=true` (default in the launch script). |
 | Keeping the two checkouts in sync | Treat WSL as canonical: `git push origin main` from WSL, then on Windows `git fetch origin; git reset --hard origin/main` (the mirror tree is often dirty/divergent so a plain `git pull` won't fast-forward — `git stash` first to keep any local mods). **Do NOT** pull the Windows checkout from the WSL repo over a `\\wsl.localhost\…` UNC path: `node`/`pnpm` fail over UNC and git is flaky there. Keep all git + node + cargo on the native `C:\` filesystem. |
-| `tauri dev` fails with `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL … Exit status 4294967295` | The `beforeDevCommand` (Vite) couldn't bind `:5173`. A Vite dev server left running **inside WSL** on `:5173` is forwarded to Windows `localhost:5173`, and Vite uses `strictPort`. Kill the WSL `:5173` server (`lsof -ti :5173 \| xargs kill`) before launching on Windows, or change the port. |
+| `tauri dev` fails with `ERR_PNPM_RECURSIVE_RUN_FIRST_FAIL … Exit status 4294967295` | The `beforeDevCommand` (Vite) couldn't bind `:5173`. Under mirrored networking WSL and Windows share one port space, so a Vite dev server left running **inside WSL** on `:5173` occupies the port outright, and Vite uses `strictPort`. Kill the WSL `:5173` server (`lsof -ti :5173 \| xargs kill`) before launching on Windows, or change the port. |


### PR DESCRIPTION
WSL on this host now runs `networkingMode=mirrored` (`.wslconfig`), so `localhost` reaches Windows services directly in both directions.

## Changes
- All 10 `docs/development/windows-journeys/journey-*.md` runbooks: connect via `driver_session host=localhost port=9223` — the NAT default-gateway-IP lookup (`ip route show default`) is obsolete.
- `.mcp.tauri.env.example`: comment updated; `MCP_BRIDGE_HOST=localhost` now covers the Windows-app + WSL-Claude topology too.
- `docs/development/windows-native-rust-dev.md`: the NAT-unreachability rationale for the two-checkout mirror is marked historical (the UNC path problem alone still mandates it), and noted the flip side — WSL and Windows now share one port space, so a stray WSL process on :5173/:9223 conflicts directly.

Docs-only; CI fast-pass expected. Part of the release-finishing campaign (Phase 0a); unblocks the tauri-mcp validation run.