### PR TITLE
ci: cut redundant CI steps and speed up webdriver install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -219,6 +219,15 @@ jobs:
       # No standalone `cargo build --workspace` step: clippy --all-targets
       # (above, Linux) and nextest (below, every OS) each already build every
       # target they need, so a dedicated build step only duplicated work.
+      # Clippy is Linux-only above, so Windows loses its only all-targets
+      # compile check of non-test code ([[bin]]s, examples) — nextest only
+      # builds through the cfg(test) harness. This repo has real history of
+      # Windows-only bin-vs-test-binary divergence (tauri-build manifest
+      # embed regression -> 0xc0000139), so restore cheap bin-target coverage
+      # on Windows specifically. macOS stays descoped (no comparable history).
+      - name: Windows workspace check (all targets)
+        if: runner.os == 'Windows' && needs.changes.outputs.rust == 'true'
+        run: cargo check --workspace --all-targets
 
       # Scope `cargo test` to the changed workspace members plus their
       # reverse-dependency closure (see scripts/ci-affected-crates.sh). Any

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,8 +189,9 @@ jobs:
         if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop run lint:eslint
 
+      # Formatting is OS-agnostic; running it on all 3 legs is pure redundancy.
       - name: Rust format
-        if: needs.changes.outputs.rust == 'true'
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: cargo fmt --all --check
 
       # Self-test the changed-crate scoping helper's mapping/closure logic
@@ -208,14 +209,16 @@ jobs:
         if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true')
         run: just db-boundary
 
+      # Compilation warnings/lints are OS-agnostic; running clippy on all 3 legs
+      # is pure redundancy — the nextest step below builds the workspace anyway.
       - name: Clippy (workspace, all targets, deny warnings)
-        if: needs.changes.outputs.rust == 'true'
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: cargo clippy --workspace --all-targets -- -D warnings
 
       # --- Layer 1: real-backend integration + unit tests ---
-      - name: Build workspace
-        if: needs.changes.outputs.rust == 'true'
-        run: cargo build --workspace
+      # No standalone `cargo build --workspace` step: clippy --all-targets
+      # (above, Linux) and nextest (below, every OS) each already build every
+      # target they need, so a dedicated build step only duplicated work.
 
       # Scope `cargo test` to the changed workspace members plus their
       # reverse-dependency closure (see scripts/ci-affected-crates.sh). Any
@@ -246,9 +249,10 @@ jobs:
             cargo nextest run --profile ci --no-tests=pass $args
           fi
 
-      # nextest does not run doctests; keep them in a dedicated step.
+      # nextest does not run doctests; keep them in a dedicated step. Doctest
+      # output is OS-agnostic, so Linux-only avoids running it 3x.
       - name: Rust doctests
-        if: needs.changes.outputs.rust == 'true'
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: cargo test --workspace --doc
 
       - name: Frontend unit tests

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -155,11 +155,18 @@ jobs:
       - uses: taiki-e/install-action@nextest
         if: needs.changes.outputs.run == 'true'
 
+      # cargo-binstall fetches a prebuilt tauri-webdriver binary when the
+      # crate publishes one, falling back to `cargo install` (source build)
+      # automatically otherwise — never slower than the plain `cargo install`
+      # this replaces, often much faster.
+      - uses: taiki-e/install-action@cargo-binstall
+        if: needs.changes.outputs.run == 'true'
+
       # Install the tauri-webdriver CLI proxy.
       # It bridges W3C client (:4444) → plugin embedded server (:4445).
       - name: Install tauri-webdriver CLI
         if: needs.changes.outputs.run == 'true'
-        run: cargo install tauri-webdriver --locked
+        run: cargo binstall tauri-webdriver --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
         if: needs.changes.outputs.run == 'true'

--- a/.typos.toml
+++ b/.typos.toml
@@ -12,6 +12,9 @@ extend-exclude = [
     "GEMINI.md",
     "*/CLAUDE.md",
     "*/AGENTS.md",
+    # release-please generated; full of commit-hash substrings that read as
+    # misspellings ("ede"/"caf" fragments of full SHAs)
+    "CHANGELOG.md",
     # generated star-catalog seed data (Bayer designations trip the checker)
     "assets/seed/",
 ]


### PR DESCRIPTION
## Summary
- Drop the standalone `cargo build --workspace` step in ci.yml — `cargo clippy --all-targets` (Linux) and `cargo nextest` (every OS) already build every target they need.
- Run `cargo fmt` / `cargo clippy` / `cargo test --doc` on the Linux leg only instead of all 3 OSes — their output is OS-agnostic.
- e2e.yml: install `tauri-webdriver` via `cargo-binstall` instead of `cargo install` (auto-falls-back to source build if no prebuilt binary exists, so never slower, often much faster).
- Exclude `CHANGELOG.md` from the `typos` pre-commit hook — release-please-generated commit-hash substrings (e.g. `c1f3ede`, `caf5004`) read as misspellings and fail the pre-push hook's full-repo scan on first push of any new branch.

No cache keys touched (see the existing warning comment near ci.yml:~150 about cache-key changes poisoning the Windows target cache — left untouched).

## Before (baseline, wall-clock updatedAt-startedAt via `gh run list`)
ci.yml (rust-touching runs, 3-OS matrix):
- 822s — run 28830142034
- 787s — run 28828351197
- 766s — run 28827257196
- 772s — run 28826219622
- 791s — run 28825978767

e2e.yml (rust-touching runs, 3-OS matrix, includes `cargo install tauri-webdriver` from source on every OS):
- 3885s — run 28830142035
- 3622s — run 28828351238
- 4267s — run 28826219621
- 3397s — run 28825002374
- 3375s — run 28824424953

## Test plan
- [x] `python3 -c "import yaml; yaml.safe_load(open(...))"` — both workflow files valid YAML
- [x] `actionlint` (v1.7.7) — clean on both files
- [x] `pre-commit run typos --files CHANGELOG.md .typos.toml` — passes after the exclude
- [ ] Confirm this PR's own CI run duration against the baseline above