### PR TITLE
fix(inbox): rescan registered roots that have no items yet

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -57,6 +57,7 @@ import type { DestructiveDestination, PendingRootPick } from "./PlanPanel";
 import { buildBreakdownFromActions } from "./PlanPanel";
 import type { InboxBreakdownTarget } from "./store";
 import {
+	mergeRescanRoots,
 	normalizeConfirmError,
 	useApplySelectedInboxPlans,
 	useInboxClassification,
@@ -144,22 +145,47 @@ export function InboxPage() {
 		refreshOpenPlans();
 	}, [refreshList, refreshOpenPlans]);
 
-	// Derive the unique roots from the current item list so rescan knows which
-	// roots to ping (FR-005). Deduplicated by rootId.
-	const roots = useMemo(() => {
-		const seen = new Set<string>();
-		const result: Array<{ rootId: string; rootAbsolutePath: string }> = [];
-		for (const item of items) {
-			if (!seen.has(item.rootId)) {
-				seen.add(item.rootId);
-				result.push({
+	// Registered inbox-category roots (FR-005): rescan must reach every active
+	// registered root, not just ones with existing items — a freshly registered
+	// root has zero items until its first scan, so deriving targets from
+	// `items` alone made "Rescan all roots" silently skip it.
+	const [registeredInboxRoots, setRegisteredInboxRoots] = useState<
+		Array<{ rootId: string; rootAbsolutePath: string }>
+	>([]);
+	useEffect(() => {
+		let alive = true;
+		commands
+			.rootsList()
+			.then(unwrap)
+			.then((rs) => {
+				if (!alive) return;
+				setRegisteredInboxRoots(
+					rs
+						.filter((r) => r.category === "inbox" && r.active)
+						.map((r) => ({ rootId: r.id, rootAbsolutePath: r.path })),
+				);
+			})
+			.catch(() => {
+				/* roots are optional UI sugar — ignore fetch failures */
+			});
+		return () => {
+			alive = false;
+		};
+	}, []);
+
+	// Union of registered inbox roots and any root already surfaced via items
+	// (covers a root whose registration briefly lags an in-flight scan).
+	const roots = useMemo(
+		() =>
+			mergeRescanRoots(
+				registeredInboxRoots,
+				items.map((item) => ({
 					rootId: item.rootId,
 					rootAbsolutePath: item.rootAbsolutePath,
-				});
-			}
-		}
-		return result;
-	}, [items]);
+				})),
+			),
+		[items, registeredInboxRoots],
+	);
 
 	const onRescanComplete = useCallback(() => refreshAll(), [refreshAll]);
 	const { loading: rescanLoading, rescan } = useInboxRescan(

--- a/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
@@ -233,3 +233,43 @@ describe('T039-4: useInboxRescan (FR-005)', () => {
     expect(onComplete).toHaveBeenCalledOnce();
   });
 });
+
+// ── mergeRescanRoots (bugfix: registered root with zero items) ─────────────────
+
+describe('mergeRescanRoots (FR-005 — registered root with no items)', () => {
+  it('includes a registered root that has no items yet', async () => {
+    const { mergeRescanRoots } = await import('../store');
+
+    const registeredRoots = [
+      { rootId: 'root-empty', rootAbsolutePath: '/astro/new-root' },
+    ];
+    const itemRoots: Array<{ rootId: string; rootAbsolutePath: string }> = [];
+
+    expect(mergeRescanRoots(registeredRoots, itemRoots)).toEqual([
+      { rootId: 'root-empty', rootAbsolutePath: '/astro/new-root' },
+    ]);
+  });
+
+  it('dedupes by rootId, preferring the registered-root entry', async () => {
+    const { mergeRescanRoots } = await import('../store');
+
+    const registeredRoots = [
+      { rootId: 'root-001', rootAbsolutePath: '/astro/raw' },
+    ];
+    const itemRoots = [
+      { rootId: 'root-001', rootAbsolutePath: '/astro/raw' },
+      { rootId: 'root-002', rootAbsolutePath: '/astro/legacy' },
+    ];
+
+    expect(mergeRescanRoots(registeredRoots, itemRoots)).toEqual([
+      { rootId: 'root-001', rootAbsolutePath: '/astro/raw' },
+      { rootId: 'root-002', rootAbsolutePath: '/astro/legacy' },
+    ]);
+  });
+
+  it('returns an empty list when nothing is registered and no items exist', async () => {
+    const { mergeRescanRoots } = await import('../store');
+
+    expect(mergeRescanRoots([], [])).toEqual([]);
+  });
+});

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -385,6 +385,34 @@ export interface RescanState {
   error: string | null;
 }
 
+export interface RescanRoot {
+  rootId: string;
+  rootAbsolutePath: string;
+}
+
+/**
+ * Merge registered inbox roots with any root already surfaced via the
+ * current item list, deduped by rootId (registered roots take precedence).
+ *
+ * A freshly registered root has zero items until its first scan, so deriving
+ * rescan targets from the item list alone would silently skip it — this is
+ * why callers must pass the registered-root list, not just item-derived roots.
+ */
+export function mergeRescanRoots(
+  registeredRoots: RescanRoot[],
+  itemRoots: RescanRoot[],
+): RescanRoot[] {
+  const seen = new Set<string>();
+  const result: RescanRoot[] = [];
+  for (const r of [...registeredRoots, ...itemRoots]) {
+    if (!seen.has(r.rootId)) {
+      seen.add(r.rootId);
+      result.push(r);
+    }
+  }
+  return result;
+}
+
 /**
  * Trigger a rescan of all registered roots (FR-005).
  * On completion, calls onComplete so the caller can refresh the list.


### PR DESCRIPTION
## Summary
- The Inbox "Rescan all roots" button silently did nothing for a registered root that had never been scanned (zero items), because it derived its target roots only from the current item list instead of the registered root list.
- Rescan now also includes every active, registered inbox root, so a newly added source gets scanned the first time you click "Rescan all roots".

## Spec Context
Implements the fix within spec 039 (cross-root inbox) FR-005.