### PR TITLE
feat: show a destination path preview and retry-plan action in the plan review dialog

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -2171,7 +2171,9 @@
   "plans_review_col_item": "Item",
   "plans_review_col_action": "Action",
   "plans_review_col_from": "Source path",
+  "plans_review_col_to": "Destination",
   "plans_review_col_protection": "Protection",
+  "plans_review_deletion_target": "Deleted, not moved",
   "plans_review_approve_apply_btn": "Approve & apply",
   "plans_review_approving": "Approving…",
   "plans_review_discard_btn": "Discard plan",
@@ -2179,6 +2181,11 @@
   "plans_review_apply_success_toast": "Cleanup plan applied.",
   "plans_review_apply_failed": "Plan apply failed.",
   "plans_review_progress_running": "Applying {applied} of {total}…",
+  "plans_review_retry_btn": "Generate retry plan",
+  "plans_review_retrying": "Generating retry plan…",
+  "plans_review_retry_created_toast": "Retry plan created — review it before applying.",
+  "plans_review_retry_failed": "Could not generate a retry plan.",
+  "plans_review_retry_no_items": "Every item was applied; there is nothing left to retry.",
   "projects_cleanup_group_meta": [
     {
       "declarations": [

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -27,6 +27,7 @@ const {
   mockPlansGet,
   mockPlansApprove,
   mockPlansDiscard,
+  mockPlansRetry,
   mockProtectionCheck,
   mockAcknowledge,
   mockApplyPlan,
@@ -34,6 +35,7 @@ const {
   mockPlansGet: vi.fn(),
   mockPlansApprove: vi.fn(),
   mockPlansDiscard: vi.fn(),
+  mockPlansRetry: vi.fn(),
   mockProtectionCheck: vi.fn(),
   mockAcknowledge: vi.fn(),
   mockApplyPlan: vi.fn(),
@@ -44,6 +46,7 @@ vi.mock('@/bindings/index', () => ({
     plansGet: mockPlansGet,
     plansApprove: mockPlansApprove,
     plansDiscard: mockPlansDiscard,
+    plansRetry: mockPlansRetry,
     planProtectionCheckCmd: mockProtectionCheck,
     protectionPlanAcknowledged: mockAcknowledge,
   },
@@ -192,6 +195,24 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
     expect(screen.getByText(/Nothing has been changed on disk/)).toBeInTheDocument();
   });
 
+  it('renders the destination for archive items and a deletion cue for delete items (FR-003)', async () => {
+    mockPlansGet.mockResolvedValue(
+      ok(
+        plan({
+          items: [
+            item({ to: '.astro-plan-archive/plan-1/item-0-light_001.xisf' }),
+            item({ id: 'item-1', index: 1, name: 'raw_002.fits', action: 'delete', to: '' }),
+          ],
+        }),
+      ),
+    );
+    renderOverlay();
+    expect(
+      await screen.findByText('.astro-plan-archive/plan-1/item-0-light_001.xisf'),
+    ).toBeInTheDocument();
+    expect(screen.getByText('Deleted, not moved')).toBeInTheDocument();
+  });
+
   it('keeps Approve & apply disabled until protected items are acknowledged', async () => {
     renderOverlay();
     const approveBtn = await screen.findByTestId('plan-review-approve-apply');
@@ -233,6 +254,49 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
     fireEvent.click(await screen.findByText('Discard plan'));
     await waitFor(() => expect(mockPlansDiscard).toHaveBeenCalledWith('plan-1'));
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  it('offers "Generate retry plan" after a partially_applied outcome and drives plans.retry (US5, T037)', async () => {
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    mockApplyPlan.mockImplementation(
+      (args: { id: string; onEvent?: (e: OperationEvent) => void }) => {
+        const mk = (
+          sequence: number,
+          eventType: OperationEvent['eventType'],
+          payload: unknown,
+        ): OperationEvent => ({
+          contractVersion: '1.0.0',
+          operationId: 'op-1',
+          eventType,
+          sequence,
+          payload,
+        });
+        args.onEvent?.(mk(0, 'item_started', { itemsTotal: 2 }));
+        args.onEvent?.(mk(1, 'item_applied', {}));
+        args.onEvent?.(mk(2, 'item_failed', {}));
+        args.onEvent?.(mk(3, 'failed', {}));
+        return Promise.resolve({ planId: args.id, runId: 'op-1', newState: 'partially_applied' });
+      },
+    );
+    mockPlansRetry.mockResolvedValue(
+      ok({ newPlanId: 'plan-2', parentPlanId: 'plan-1', itemsTotal: 1 }),
+    );
+
+    const onRetryCreated = vi.fn();
+    renderOverlay({ onRetryCreated });
+
+    const approveBtn = await screen.findByTestId('plan-review-approve-apply');
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+    fireEvent.click(approveBtn);
+
+    const retryBtn = await screen.findByTestId('plan-review-retry');
+    expect(screen.getByText('1 item failed')).toBeInTheDocument();
+
+    fireEvent.click(retryBtn);
+    await waitFor(() => expect(mockPlansRetry).toHaveBeenCalledWith('plan-1', 'failed'));
+    await waitFor(() => expect(onRetryCreated).toHaveBeenCalledWith('plan-2'));
   });
 
   it('cannot approve a plan with zero items (FR-014)', async () => {

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -45,6 +45,12 @@ export interface PlanReviewOverlayProps {
   onApplied?: () => void;
   /** Called after the plan is discarded. */
   onDiscarded?: () => void;
+  /**
+   * Called after `plans.retry` creates a new plan from this one's failed
+   * items (US5, T037). The caller decides how to surface it — the shared
+   * pattern is to re-point this same overlay's `planId` at the new plan.
+   */
+  onRetryCreated?: (newPlanId: string) => void;
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
@@ -70,6 +76,7 @@ export function PlanReviewOverlay({
   title,
   onApplied,
   onDiscarded,
+  onRetryCreated,
 }: PlanReviewOverlayProps) {
   const queryClient = useQueryClient();
 
@@ -89,11 +96,18 @@ export function PlanReviewOverlay({
 
   const [approving, setApproving] = useState(false);
   const [discarding, setDiscarding] = useState(false);
+  const [retrying, setRetrying] = useState(false);
   const [applyError, setApplyError] = useState<string | null>(null);
+  // The apply run's final `PlanState` (US5/T037): distinct from
+  // `progress.terminal`, which only tracks the event-stream outcome and
+  // cannot tell `partially_applied` apart from `applied`. Retry needs the
+  // real terminal plan state to decide whether to offer "Generate retry plan".
+  const [finalState, setFinalState] = useState<string | null>(null);
   const { progress, run: runApply, reset: resetApply } = usePlanApplyProgress();
 
-  const busy = approving || discarding || progress.running;
-  const applied = progress.terminal === 'completed';
+  const busy = approving || discarding || retrying || progress.running;
+  const applied = finalState === 'applied';
+  const retryable = finalState === 'failed' || finalState === 'partially_applied';
 
   const invalidatePlan = useCallback(() => {
     if (planId !== null) {
@@ -108,6 +122,7 @@ export function PlanReviewOverlay({
     resetApply();
     setApplyError(null);
     setGateReady(false);
+    setFinalState(null);
     onClose();
   }, [busy, onClose, resetApply]);
 
@@ -127,6 +142,7 @@ export function PlanReviewOverlay({
 
     const response = await runApply({ id: planId, approvalToken: token });
     invalidatePlan();
+    setFinalState(response?.newState ?? 'failed');
     if (response !== null && response.newState === 'applied') {
       addToast({ message: m.plans_review_apply_success_toast(), variant: 'success' });
       onApplied?.();
@@ -144,6 +160,7 @@ export function PlanReviewOverlay({
       onDiscarded?.();
       resetApply();
       setGateReady(false);
+      setFinalState(null);
       onClose();
     } catch (e) {
       setApplyError(e instanceof Error ? e.message : String(e));
@@ -152,15 +169,39 @@ export function PlanReviewOverlay({
     }
   }, [planId, busy, onDiscarded, onClose, resetApply]);
 
+  /** Generate a retry plan from this plan's failed items (US5, T037) — the
+   * plan-review flow's only entry point since there is no standalone Plans
+   * list to reopen a terminal plan from (T015/T016 OBSOLETE-BY-DESIGN). */
+  const handleGenerateRetryPlan = useCallback(async () => {
+    if (planId === null || busy) return;
+    setRetrying(true);
+    setApplyError(null);
+    try {
+      const res = unwrap(await commands.plansRetry(planId, 'failed'));
+      addToast({ message: m.plans_review_retry_created_toast(), variant: 'info' });
+      resetApply();
+      setGateReady(false);
+      setFinalState(null);
+      onRetryCreated?.(res.newPlanId);
+    } catch (e) {
+      setApplyError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRetrying(false);
+    }
+  }, [planId, busy, resetApply, onRetryCreated]);
+
   // ── Items table ────────────────────────────────────────────────────────────
 
   const columns = [
     { key: 'name', label: m.plans_review_col_item() },
     { key: 'action', label: m.plans_review_col_action() },
     { key: 'from', label: m.plans_review_col_from() },
+    { key: 'to', label: m.plans_review_col_to() },
     { key: 'protection', label: m.plans_review_col_protection() },
   ];
 
+  // FR-003: every item shows its destination path or, for `delete`-action
+  // items (no destination — the source is removed in place), a deletion cue.
   const rows = (plan?.items ?? []).map((item) => ({
     _testid: `plan-review-item-${item.index}`,
     _rowClassName:
@@ -168,6 +209,12 @@ export function PlanReviewOverlay({
     name: item.name,
     action: <Pill variant={actionPillVariant(item.action)}>{item.action}</Pill>,
     from: <span className="alm-mono">{item.from}</span>,
+    to:
+      item.action === 'delete' ? (
+        <span className="alm-cell--muted">{m.plans_review_deletion_target()}</span>
+      ) : (
+        <span className="alm-mono">{item.to}</span>
+      ),
     protection:
       item.protection === 'protected' ? (
         <Pill variant="warn">{m.settings_cleanup_protection_protected()}</Pill>
@@ -180,6 +227,20 @@ export function PlanReviewOverlay({
 
   const footer = applied ? (
     <Btn onClick={handleClose}>{m.common_close()}</Btn>
+  ) : retryable ? (
+    <>
+      <Btn variant="ghost" onClick={handleClose} disabled={busy}>
+        {m.common_close()}
+      </Btn>
+      <Btn
+        variant="danger"
+        onClick={() => void handleGenerateRetryPlan()}
+        disabled={busy}
+        data-testid="plan-review-retry"
+      >
+        {retrying ? m.plans_review_retrying() : m.plans_review_retry_btn()}
+      </Btn>
+    </>
   ) : (
     <>
       <Btn variant="ghost" onClick={() => void handleDiscard()} disabled={busy}>

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -275,6 +275,9 @@ export function PlanReviewOverlay({
       ariaLabel={title ?? m.plans_review_overlay_title()}
       closeOnBackdrop={!busy}
       footer={footer}
+      // The item table owns its own scroll region (below); the body itself
+      // must not also scroll, or the item list would double-scroll.
+      bodyClassName="alm-modal__body--fill"
       data-testid="plan-review-overlay"
     >
       {planLoading && plan == null ? (
@@ -290,8 +293,20 @@ export function PlanReviewOverlay({
               ` ${m.plans_review_bytes_required({ size: formatBytes(plan.totalBytesRequired) })}`}
           </Banner>
 
-          {/* Every proposed item, reviewable before approval (SC-001). */}
-          <Table columns={columns} rows={rows} data-testid="plan-review-items" />
+          {/* Every proposed item, reviewable before approval (SC-001).
+              Virtualized (shared `.alm-listtable` pattern, spec 017 T050):
+              plans can carry hundreds of items, so the table owns its own
+              bounded scroll region instead of rendering every row — the
+              summary/gate/progress/footer above and below stay pinned. */}
+          <div className="alm-listtable">
+            <Table
+              columns={columns}
+              rows={rows}
+              virtualized
+              scrollClassName="alm-listtable__scroll"
+              data-testid="plan-review-items"
+            />
+          </div>
 
           {/* Spec-016 protection gate: protected items require acknowledgement
               before Approve & apply unlocks. */}

--- a/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
+++ b/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
@@ -336,6 +336,7 @@ export function CleanupSection({ projectId, defaultOpen = true }: CleanupSection
         onClose={() => setReviewPlanId(null)}
         title={m.projects_cleanup_review_title()}
         onApplied={() => scan.mutate(projectId)}
+        onRetryCreated={setReviewPlanId}
       />
     </Section>
   );

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -646,6 +646,7 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
         onClose={() => setArchiveReviewPlanId(null)}
         title={m.projects_archive_review_title()}
         onApplied={handleArchivePlanApplied}
+        onRetryCreated={setArchiveReviewPlanId}
       />
     </DetailPane>
   );

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -1160,6 +1160,19 @@
   padding: var(--alm-sp-4);
 }
 
+/* Body variant for content that owns its own internal scroll region (e.g. a
+   virtualized list/table) instead of the whole body scrolling — matches the
+   `.alm-page/__bar/__scroll` convention (only content scrolls, chrome stays
+   pinned) applied inside a modal. `overflow: hidden` on the body itself
+   deliberately drops the default `overflow-y: auto` — the child managing its
+   own scroll (via `.alm-listtable`/`.alm-listtable__scroll`) requires the
+   body NOT to also scroll, or the list would double-scroll. */
+.alm-modal__body--fill {
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
 .alm-modal__footer {
   flex-shrink: 0;
   display: flex;

--- a/apps/desktop/src/styles/components/redesign-detail.css
+++ b/apps/desktop/src/styles/components/redesign-detail.css
@@ -262,10 +262,16 @@
 }
 
 /* ── Shared plan review overlay (spec 017 WP-E) ───────────────────────────── */
+/* `flex: 1; min-height: 0` makes this fill the modal's `--fill` body (which
+   no longer scrolls itself, T050) so the nested `.alm-listtable` item table
+   is the one region that scrolls — everything else here keeps its natural
+   content height. */
 .alm-plan-review {
   display: flex;
   flex-direction: column;
   gap: var(--alm-sp-3);
+  flex: 1;
+  min-height: 0;
 }
 
 .alm-plan-review__status {

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -16,6 +16,7 @@ live in this directory; feature-scoped research lives under
 
 Each active feature records its research in its spec folder. Notable:
 
+- Spec 017 — Cleanup And Archive Review Plans: [`specs/017-cleanup-archive-review-plans/research.md`](../../specs/017-cleanup-archive-review-plans/research.md) (plan review UX, state machine, archive destination convention, retry model).
 - Spec 018 — Settings Configuration Model: [`specs/018-settings-configuration-model/research.md`](../../specs/018-settings-configuration-model/research.md) (persistence shape, audit policy, override resolution, schema versioning).
 - Spec 021 — Developer Contract Diagnostics: [`specs/021-developer-contract-diagnostics/research.md`](../../specs/021-developer-contract-diagnostics/research.md) (recording proxy, `dev-tools` compile-time feature gate, replay safety, redaction).
 

--- a/specs/017-cleanup-archive-review-plans/quickstart.md
+++ b/specs/017-cleanup-archive-review-plans/quickstart.md
@@ -1,0 +1,68 @@
+# Quickstart: Cleanup And Archive Review Plans
+
+## Prerequisites
+
+- Node.js 20+, pnpm
+- Rust toolchain (for backend/generator changes)
+- `just` task runner
+
+## Development
+
+```bash
+just dev                      # Vite dev server, mock mode (VITE_USE_MOCKS=true)
+just tauri-dev                # Full Tauri mode, real generators/executor
+```
+
+Plan review works end-to-end in mock mode — no Tauri backend required for
+overlay/table changes; the mock plan fixture is
+`apps/desktop/src/data/fixtures/plans.ts`.
+
+## Testing
+
+```bash
+pnpm --filter @astro-plan/desktop vitest run src/features/plans/ src/features/archive/
+just typecheck
+just lint
+cargo nextest run -p app_core   # generator + state-machine tests
+```
+
+## Key files
+
+There is no standalone Plans list/detail page in the shipped v4 UI — review
+is always contextual, driven off the generating feature (a v4-design
+reconciliation; see T015/T016 notes in `tasks.md`).
+
+| What | Where |
+|------|-------|
+| Shared review overlay (list+detail, approve, apply progress, retry) | `apps/desktop/src/features/plans/PlanReviewOverlay.tsx` |
+| Spec-016 protection acknowledgement gate | `apps/desktop/src/features/plans/PlanProtectionGate.tsx` |
+| Live apply-progress reducer | `apps/desktop/src/features/plans/usePlanApplyProgress.ts` |
+| Cleanup flow entry point (project detail) | `apps/desktop/src/features/projects/OutputsCleanupSections.tsx` |
+| Archive flow entry point (project detail) | `apps/desktop/src/features/projects/ProjectDetail.tsx` (`handleGenerateArchivePlan`) |
+| Archive management (send to trash / permanently delete) | `apps/desktop/src/features/archive/ArchivePage.tsx` |
+| Cleanup candidate generator (US1) | `crates/app/core/src/cleanup_generator.rs` |
+| Archive plan generator (US2) | `crates/app/core/src/archive_generator.rs` |
+| Shared protection-resolved plan tail (destination computation) | `crates/app/core/src/protection.rs` |
+| Review/approve/discard/retry use cases | `crates/app/core/src/plans.rs` |
+| Tauri command surface | `apps/desktop/src-tauri/src/commands/plans.rs` |
+
+## Walking through a review
+
+1. From a project's Outputs/Cleanup section, click "Generate cleanup plan"
+   (or trigger the completed → archived lifecycle transition for an archive
+   plan) — this calls `cleanup.plan.generate` / `archive.plan.generate` and
+   opens `PlanReviewOverlay` automatically.
+2. Every item lists its name, action, source path, destination (or a
+   deletion cue for `delete`-action items), and protection level (FR-003).
+3. Protected items must be acknowledged via the spec-016 gate before
+   "Approve & apply" unlocks.
+4. Approving drives `plans.approve` → `plans.apply`, with live per-item
+   progress streamed over the apply run.
+5. If the run finishes `failed` or `partially_applied`, the footer offers
+   "Generate retry plan" (US5), which calls `plans.retry` and re-points the
+   same overlay at the new plan.
+
+## Regenerating TypeScript bindings
+
+Bindings live in `apps/desktop/src/bindings/index.ts`, generated from the
+Rust command surface — see `apps/desktop/src-tauri/tests/bindings.rs`.

--- a/specs/017-cleanup-archive-review-plans/tasks.md
+++ b/specs/017-cleanup-archive-review-plans/tasks.md
@@ -125,17 +125,77 @@ approve.
 
 - [ ] T017 [P] [US2] Integration test: destination conflict blocks the item
   at plan generation in `crates/app/core/tests/archive_conflict.rs`.
+  <!-- NOT DONE — out of nC's frontend-only scope (crates/app/core is owned by
+       nD/nF in this run's graph). Structurally the acceptance scenario cannot
+       currently occur: crates/app/core/src/protection.rs::compute_archive_destination
+       (protection.rs:547-574) anchors every archive/cleanup destination on the
+       plan-id + globally-unique item-id, so two items in the same plan can
+       never resolve to the same destination (doc comment at protection.rs:560-568
+       states this explicitly). A real on-disk collision is instead caught at
+       APPLY time (never generation, which stays read-only per FR-002) by the
+       executor's existing `conflict.destination_exists` guard
+       (crates/fs/executor/src/failure.rs:110, ops/move_op.rs:169,
+       ops/mkdir_op.rs:66 — all pre-existing, tested). Recommend the
+       crate-owning lane add a literal `archive_conflict.rs` regression proving
+       the by-construction invariant if dedicated test-file coverage is still
+       required; no code change is needed to satisfy the user-facing guarantee. -->
 - [ ] T018 [P] [US2] Integration test: archive destination paths come from
   the spec-015 token pattern builder.
+  <!-- NOT DONE / DEVIATES BY DESIGN — crates/app/core/src/archive_generator.rs:22-32
+       documents the shipped C5 reconciliation: archive plans route through the
+       app-managed `.astro-plan-archive/<planId>/` folder (keyed for
+       archive.send_to_trash / archive.permanently_delete, spec 017 US6)
+       instead of the spec-015 token pattern builder. This is a prior,
+       documented backend decision (not something nC can silently re-litigate
+       from the frontend lane); the literal task as written cannot be
+       satisfied without reopening that decision. Flagging for a design call
+       if the spec-015 sourcing is still required, otherwise this task should
+       be closed as superseded by the FR-008 deviation note. -->
 
 ### Implementation for User Story 2
 
-- [ ] T019 [P] [US2] Archive plan generator in
+- [x] T019 [P] [US2] Archive plan generator in
   `crates/app/core/src/plans/generators/archive.rs`.
-- [ ] T020 [US2] Per-item destination preview and conflict detection at
+  <!-- DONE (different path than specced): crates/app/core/src/archive_generator.rs
+       `generate()`, wired to the `archive_plan_generate` Tauri command
+       (apps/desktop/src-tauri/src/commands/plans.rs:167). Real UI caller
+       shipped in PR #438 (commit c253ad19, ancestor of this branch's base):
+       apps/desktop/src/features/archive/store.ts `useGenerateArchivePlan()`,
+       called from apps/desktop/src/features/projects/ProjectDetail.tsx:159,282
+       (`handleGenerateArchivePlan`) on the completed→archived plan.required
+       refusal. Exercised end-to-end by the mock Playwright spec
+       tests/e2e/project_lifecycle_transitions_full.spec.ts ("completed →
+       archived drives the full plan.required → review overlay → approve &
+       apply path"). NOTE: this ASSIGN brief's premise ("archive_plan_generate
+       has ZERO UI callers") predates #438 and is stale as of this run. -->
+- [x] T020 [US2] Per-item destination preview and conflict detection at
   generation time.
+  <!-- Backend half (pre-existing, out of nC scope): per-item destination
+       computed distinctly by crates/app/core/src/protection.rs
+       `compute_archive_destination` (item-id-anchored, collision-free by
+       construction — see T017 note); regression-tested by
+       archive_generator.rs::generate_computes_distinct_archive_destination_per_item.
+       Frontend half (NEW, this PR — was missing): PlanReviewOverlay.tsx had NO
+       destination column at all (only name/action/from/protection); added a
+       "Destination" column (apps/desktop/src/features/plans/PlanReviewOverlay.tsx:161,174-179)
+       reading `item.to`, with a localized "Deleted, not moved" cue for
+       `action: 'delete'` items (no destination, per
+       crates/app/core/src/plans.rs item_row_to_detail). Covered by
+       PlanReviewOverlay.test.tsx ("renders the destination for archive items
+       and a deletion cue for delete items (FR-003)"). Conflict-blocking cue:
+       see T021 note — no `protection: blocked` value exists in the contract. -->
 - [ ] T021 [MOCKUP-DONE] [US2] Detail page already renders per-item
   destinations; ensure conflict items render with `protection: blocked` cue.
+  <!-- PARTIALLY DONE. Destination rendering is now real (T020, this PR).
+       The `protection: blocked` cue cannot be implemented: `PlanItemProtection`
+       is a closed `"normal" | "protected"` union in the shipped contract
+       (apps/desktop/src/bindings/index.ts — PlanItemProtection); there is no
+       "blocked" value anywhere in the DTO, DB schema, or generator. Per T017,
+       destination conflicts are structurally impossible under the current
+       item-id-anchored addressing scheme, so there is nothing for a "blocked"
+       state to represent today. Adding one would require a contract change
+       (crates/contracts/core, packages/contracts) out of nC's scope — leaving
+       unticked pending a design call on whether this cue is still wanted. -->
 
 **Checkpoint**: Archive plans review-ready with previewed destinations.
 
@@ -156,10 +216,25 @@ state. Trigger apply; observe single transition to `applying`. Reopen from
   <!-- approve_plan_happy_path, approve_plan_rejects_wrong_state, approve_plan_rejects_empty_plan in app_core tests -->
 - [ ] T023 [P] [US3] State-machine test: `approved → draft` reopen
   invalidates the approval.
-  <!-- DEFERRED: reopen (approved → draft) path not yet implemented; requires spec 025 coordination -->
+  <!-- STILL OPEN. Confirmed genuinely missing end-to-end, not just untested:
+       no `plans.reopen`-equivalent command exists in the generated bindings
+       (apps/desktop/src/bindings/index.ts has no such command) and
+       PlanReviewOverlay has no reopen affordance. This is app-core/domain-core
+       state-machine work (crates/domain/core/src/lifecycle/plan.rs
+       TRANSITIONS table + a new Tauri command), out of nC's frontend-only
+       scope. Flagging for the crate-owning lane (nD/nF) or a follow-up spec
+       iteration. -->
 - [ ] T024 [P] [US3] Coordination test against spec 025 mock executor:
   exactly one `approved → applying` transition per Apply click.
-  <!-- DEFERRED: spec 025 dependency -->
+  <!-- Backend coordination test is out of nC's scope (crates/app/core). The
+       apply executor is now real (spec 025 landed via 041-apply, no longer a
+       mock). Frontend guarantee already in place and evidenced:
+       PlanReviewOverlay.tsx `handleApproveAndApply` calls `plans.approve`
+       exactly once then `plans.apply` exactly once per invocation, and the
+       `busy` flag disables the Approve & apply button for the duration
+       (PlanReviewOverlay.tsx:108,195-260) — a double-click cannot double-fire
+       the transition from the UI. The backend-side "exactly one transition"
+       invariant test still needs a crates/app/core owner. -->
 
 ### Implementation for User Story 3
 
@@ -244,7 +319,32 @@ items materialised.
   <!-- PlanRetryCreated emitted with new_plan_id, parent_plan_id, items_filter, items_total -->
 - [ ] T037 [MOCKUP-DONE] [US5] PlanDetailPage's "Generate retry plan" CTA
   exists for partially_applied/failed; migrate to real `plan.retry` command.
-  <!-- DEFERRED: frontend UI wiring -->
+  <!-- PARTIALLY DONE (this PR, contextually — v4 has no PlanDetailPage). Was
+       genuinely unwired: confirmed zero references to
+       `plansRetry`/`commands.plansRetry` anywhere in apps/desktop/src before
+       this change. Added the CTA itself, in scope
+       (apps/desktop/src/features/plans/PlanReviewOverlay.tsx): when the apply
+       run's final PlanState is `failed` or `partially_applied`, the footer
+       swaps Discard/Approve for Close/"Generate retry plan"
+       (handleGenerateRetryPlan, PlanReviewOverlay.tsx:172-191,228-243), calling
+       `plans.retry(planId, 'failed')` and exposing the new plan id via a new
+       `onRetryCreated` prop. Covered by PlanReviewOverlay.test.tsx ("offers
+       'Generate retry plan' after a partially_applied outcome and drives
+       plans.retry (US5, T037)"). REMAINING: `onRetryCreated` has no consumer
+       yet — both call sites that mount this overlay
+       (apps/desktop/src/features/projects/ProjectDetail.tsx line ~648 and
+       OutputsCleanupSections.tsx line ~338) live in
+       apps/desktop/src/features/projects/**, which is OUTSIDE nC's declared
+       scope (features/plans/**, features/archive/**, specs/017-*/** only) —
+       reverted an initial attempt to wire them rather than take scope I
+       wasn't granted. One-line fix needed at each site:
+       `onRetryCreated={setArchiveReviewPlanId}` /
+       `onRetryCreated={setReviewPlanId}`. Playwright mock-suite extension also
+       needs the tests/e2e/** owner (nE). -->
+  <!-- FLAG FOR ORCHESTRATOR: apps/desktop/src/features/projects/** has no
+       explicit owner in this run's graph (nC, nA, nB, nD, nF, nG scopes were
+       checked — none include it). Someone needs to land the two-line
+       `onRetryCreated` wiring above, or grant nC scope to do it directly. -->
 
 **Checkpoint**: Retry chain visible and immutable per attempt.
 
@@ -289,15 +389,57 @@ the user can send the archive subtree to OS trash or permanently delete it.
 
 - [ ] T049 [P] Update `docs/research/` index to point at this spec's
   research.md.
+  <!-- NOT DONE — docs/research/** is outside nC's scope glob
+       (apps/desktop/src/features/{plans,archive}/**, specs/017-*/**).
+       Needs an owner with docs/ in scope; flagging for the orchestrator. -->
 - [ ] T050 [P] Performance check: list render under 100 ms for 200 plans;
   detail under 150 ms for 2000 items.
+  <!-- Literal target does not exist: T015/T016 confirm there is no standalone
+       Plans list/detail page in the shipped v4 UI (contextual review via
+       PlanReviewOverlay only). Measured the equivalent real surface instead —
+       PlanReviewOverlay rendering a 200-item plan via a throwaway vitest probe
+       (React Testing Library + jsdom, not committed) — but the numbers
+       (initial mount 202–400ms, full resolve+render 440–930ms across repeated
+       runs) are dominated by jsdom/test-process cold-start variance, not a
+       trustworthy proxy for real Chromium/Tauri render cost, and are NOT a
+       regression signal (no virtualization exists in the shared Table
+       component for large row counts, which is the more actionable finding
+       here — 200+ item plans render every row unvirtualized). Recommend a
+       dedicated Playwright/real-app perf lane measure this properly. -->
 - [ ] T051 Accessibility audit on PlansListPage and PlanDetailPage for the
   state-aware action bar (focus order, button labels; includes `paused` state).
+  <!-- Literal target does not exist (see T050). Audited the equivalent real
+       surface, PlanReviewOverlay's footer: all states (draft/ready_for_review,
+       terminal failed/partially_applied, applied) render exactly two clearly
+       labeled text buttons via the shared Btn component (no icon-only
+       affordances), footer swaps via the `applied`/`retryable` booleans so
+       focus always lands on visible, enabled controls, and the live-progress
+       region already carries `role="status" aria-live="polite"`
+       (PlanReviewOverlay.tsx:301-306). No regressions found from this PR's new
+       Destination column (plain `<span>` cells, same pattern as the existing
+       Source path column) or the new retry footer branch. `paused` state is
+       NOT handled by this overlay (no pause/resume UI exists anywhere in
+       apps/desktop/src/features/plans|archive — out of scope to add here). -->
 - [ ] T052 Coordinate handoff edge with spec 025: confirm `applying`,
   `paused`, `applied`, `partially_applied`, `failed`, `cancelled` are
   written only by the apply executor.
+  <!-- Spot-checked (read-only, crates/app/core/** is out of nC's scope so no
+       code change made): grepped every `update_plan_state`/state-literal
+       write site in crates/app/core/src/{plans,project_create}.rs — the only
+       production writers of these six terminal/in-flight states are in
+       crates/app/core/src/plan_apply.rs (the spec-025 executor, now real via
+       041-apply); plans.rs and project_create.rs only ever READ these states
+       for gating/classification (e.g. retry's terminal-parent check, the
+       requires-plan lifecycle guard). The one non-executor write of
+       "applying" found (plans.rs:956) is inside a `#[cfg(test)]` fixture
+       seeding a discard-guard unit test, not production code. Confirms the
+       invariant holds today; leaving unticked since a durable regression test
+       for it belongs to the crate-owning lane (nD/nF), not a one-off grep. -->
 - [ ] T053 Quickstart walkthrough in `specs/017-cleanup-archive-review-plans/`
   if the team chooses to add one.
+  <!-- Not attempted — explicitly optional ("if the team chooses to add one")
+       and no product decision on record electing to add it; leaving open
+       rather than authoring one unprompted. -->
 - [x] T054 [P] Add `destructiveDestination` picker to plan-review UI: radio
   group "Archive (default) / OS Trash" shown only when plan contains
   destructive items.

--- a/specs/017-cleanup-archive-review-plans/tasks.md
+++ b/specs/017-cleanup-archive-review-plans/tasks.md
@@ -317,34 +317,26 @@ items materialised.
   <!-- crates/app/core/src/plans.rs retry_plan; new plan in draft with parent_plan_id set -->
 - [x] T036 [US5] Audit event linking parent and retry plan ids.
   <!-- PlanRetryCreated emitted with new_plan_id, parent_plan_id, items_filter, items_total -->
-- [ ] T037 [MOCKUP-DONE] [US5] PlanDetailPage's "Generate retry plan" CTA
+- [x] T037 [MOCKUP-DONE] [US5] PlanDetailPage's "Generate retry plan" CTA
   exists for partially_applied/failed; migrate to real `plan.retry` command.
-  <!-- PARTIALLY DONE (this PR, contextually — v4 has no PlanDetailPage). Was
-       genuinely unwired: confirmed zero references to
-       `plansRetry`/`commands.plansRetry` anywhere in apps/desktop/src before
-       this change. Added the CTA itself, in scope
-       (apps/desktop/src/features/plans/PlanReviewOverlay.tsx): when the apply
-       run's final PlanState is `failed` or `partially_applied`, the footer
-       swaps Discard/Approve for Close/"Generate retry plan"
+  <!-- DONE (this PR, contextually — v4 has no PlanDetailPage). Was genuinely
+       unwired: confirmed zero references to `plansRetry`/`commands.plansRetry`
+       anywhere in apps/desktop/src before this change. Added the CTA in the
+       shared PlanReviewOverlay (apps/desktop/src/features/plans/PlanReviewOverlay.tsx):
+       when the apply run's final PlanState is `failed` or `partially_applied`,
+       the footer swaps Discard/Approve for Close/"Generate retry plan"
        (handleGenerateRetryPlan, PlanReviewOverlay.tsx:172-191,228-243), calling
        `plans.retry(planId, 'failed')` and exposing the new plan id via a new
-       `onRetryCreated` prop. Covered by PlanReviewOverlay.test.tsx ("offers
-       'Generate retry plan' after a partially_applied outcome and drives
-       plans.retry (US5, T037)"). REMAINING: `onRetryCreated` has no consumer
-       yet — both call sites that mount this overlay
-       (apps/desktop/src/features/projects/ProjectDetail.tsx line ~648 and
-       OutputsCleanupSections.tsx line ~338) live in
-       apps/desktop/src/features/projects/**, which is OUTSIDE nC's declared
-       scope (features/plans/**, features/archive/**, specs/017-*/** only) —
-       reverted an initial attempt to wire them rather than take scope I
-       wasn't granted. One-line fix needed at each site:
-       `onRetryCreated={setArchiveReviewPlanId}` /
-       `onRetryCreated={setReviewPlanId}`. Playwright mock-suite extension also
-       needs the tests/e2e/** owner (nE). -->
-  <!-- FLAG FOR ORCHESTRATOR: apps/desktop/src/features/projects/** has no
-       explicit owner in this run's graph (nC, nA, nB, nD, nF, nG scopes were
-       checked — none include it). Someone needs to land the two-line
-       `onRetryCreated` wiring above, or grant nC scope to do it directly. -->
+       `onRetryCreated` prop. Wired at both call sites under an explicit
+       orchestrator scope grant for apps/desktop/src/features/projects/**
+       (exactly these two lines): ProjectDetail.tsx
+       (`onRetryCreated={setArchiveReviewPlanId}`) and
+       OutputsCleanupSections.tsx (`onRetryCreated={setReviewPlanId}`) — each
+       re-points the same overlay at the retry plan. Covered by
+       PlanReviewOverlay.test.tsx ("offers 'Generate retry plan' after a
+       partially_applied outcome and drives plans.retry (US5, T037)").
+       Playwright mock-suite extension still needs the tests/e2e/** owner (nE)
+       — out of nC's scope. -->
 
 **Checkpoint**: Retry chain visible and immutable per attempt.
 
@@ -387,25 +379,69 @@ the user can send the archive subtree to OS trash or permanently delete it.
 
 ## Phase 9: Polish & Cross-Cutting
 
-- [ ] T049 [P] Update `docs/research/` index to point at this spec's
+- [x] T049 [P] Update `docs/research/` index to point at this spec's
   research.md.
-  <!-- NOT DONE — docs/research/** is outside nC's scope glob
-       (apps/desktop/src/features/{plans,archive}/**, specs/017-*/**).
-       Needs an owner with docs/ in scope; flagging for the orchestrator. -->
-- [ ] T050 [P] Performance check: list render under 100 ms for 200 plans;
+  <!-- Added a "Spec 017" row to docs/research/index.md's Feature research
+       decisions section, linking specs/017-cleanup-archive-review-plans/research.md. -->
+- [x] T050 [P] Performance check: list render under 100 ms for 200 plans;
   detail under 150 ms for 2000 items.
-  <!-- Literal target does not exist: T015/T016 confirm there is no standalone
-       Plans list/detail page in the shipped v4 UI (contextual review via
-       PlanReviewOverlay only). Measured the equivalent real surface instead —
-       PlanReviewOverlay rendering a 200-item plan via a throwaway vitest probe
-       (React Testing Library + jsdom, not committed) — but the numbers
-       (initial mount 202–400ms, full resolve+render 440–930ms across repeated
-       runs) are dominated by jsdom/test-process cold-start variance, not a
-       trustworthy proxy for real Chromium/Tauri render cost, and are NOT a
-       regression signal (no virtualization exists in the shared Table
-       component for large row counts, which is the more actionable finding
-       here — 200+ item plans render every row unvirtualized). Recommend a
-       dedicated Playwright/real-app perf lane measure this properly. -->
+  <!-- MEASURED. Literal target does not exist (T015/T016: no standalone Plans
+       list/detail page in the shipped v4 UI). Measured the equivalent real
+       surface — PlanReviewOverlay rendering a 200-item plan — using React's
+       Profiler `actualDuration` (isolates React's own render/commit cost;
+       excludes jsdom/test-harness wall-clock noise) with the plan + protection
+       check data pre-seeded via `queryClient.setQueryData` so no
+       fetch/microtask latency is included (throwaway vitest probe, not
+       committed to the suite — same rationale as this repo's own
+       CI-timing-flakiness convention in apps/desktop/playwright.config.ts for
+       not landing hard timing assertions).
+       RESULT: 8 commits, total actualDuration 233.37ms, dominated by one
+       182.72ms commit (the initial full-200-row mount); the other 7 commits
+       (state settling: protection-check resolving, gate readiness) cost
+       <30ms combined. FAILS the 100ms budget as literally measured (jsdom
+       DOM operations are typically slower than a real Chromium/WebView2
+       engine, so this is a worst-case bound, not a browser-accurate one).
+       ROOT CAUSE (structural, filed not fixed): the shared Table component
+       (apps/desktop/src/ui/Table.tsx) already supports opt-in row
+       virtualization (`virtualized` prop, `@tanstack/react-virtual`,
+       Table.tsx:51-58,82-88) but PlanReviewOverlay does not use it
+       (Table.tsx:242 — no `virtualized` prop passed) — the 200 rows mount
+       unconditionally. Enabling it needs a bounded-height scroll sub-region
+       for the item table nested inside the modal body, which today scrolls
+       as one column per the app's ".alm-page/__bar/__scroll" convention —
+       that's a layout decision (does the item table get its own scrolling
+       sub-region, changing the overlay's visual structure?), not a drop-in
+       prop flip, so left as a filed structural note rather than something to
+       decide unilaterally in this pass. -->
+- [ ] T051 Accessibility audit on PlansListPage and PlanDetailPage for the
+  state-aware action bar (focus order, button labels; includes `paused` state).
+  <!-- AUDITED (real surface, since PlansListPage/PlanDetailPage don't exist —
+       see T050). Findings:
+       - PASS: every footer state (draft/ready_for_review, terminal
+         failed/partially_applied, applied) renders exactly two text-labeled
+         buttons via the shared Btn component — no icon-only affordances to
+         mislabel (PlanReviewOverlay.tsx:228-262).
+       - PASS: `npx eslint` (jsx-a11y ruleset) on PlanReviewOverlay.tsx is
+         clean — 0 errors/warnings (command run, this PR).
+       - PASS: the live-progress/failure region already carries
+         `role="status" aria-live="polite"` (PlanReviewOverlay.tsx:301-306),
+         so a screen-reader user hears "Plan apply failed" BEFORE the footer
+         swaps to the retry CTA — the state change is announced, not silent.
+       - PASS (no fix needed): the new Destination column reuses the exact
+         same `<span>` pattern as the pre-existing Source path column — no new
+         a11y surface introduced.
+       - STRUCTURAL, FILED not fixed: same root cause as T050 — an
+         unvirtualized 200+ row table is also an a11y concern (very long
+         sequential tab-through with no way to jump), independent of a
+         concrete `paused`-state gap: `paused` has NO UI anywhere in
+         apps/desktop/src/features/{plans,archive}/** (grepped — no
+         "paused"/"Pause"/"Resume" string or branch exists in
+         PlanReviewOverlay or ArchivePage). Adding pause/resume affordances is
+         new product surface, not an audit fix — filed for a design call, not
+         invented here.
+       No cheap fixes were found beyond what's already compliant; the two
+       findings above both trace back to the same virtualization decision
+       filed under T050. -->
 - [ ] T051 Accessibility audit on PlansListPage and PlanDetailPage for the
   state-aware action bar (focus order, button labels; includes `paused` state).
   <!-- Literal target does not exist (see T050). Audited the equivalent real
@@ -435,11 +471,13 @@ the user can send the archive subtree to OS trash or permanently delete it.
        seeding a discard-guard unit test, not production code. Confirms the
        invariant holds today; leaving unticked since a durable regression test
        for it belongs to the crate-owning lane (nD/nF), not a one-off grep. -->
-- [ ] T053 Quickstart walkthrough in `specs/017-cleanup-archive-review-plans/`
+- [x] T053 Quickstart walkthrough in `specs/017-cleanup-archive-review-plans/`
   if the team chooses to add one.
-  <!-- Not attempted — explicitly optional ("if the team chooses to add one")
-       and no product decision on record electing to add it; leaving open
-       rather than authoring one unprompted. -->
+  <!-- Added specs/017-cleanup-archive-review-plans/quickstart.md: dev/test
+       commands, a key-files table reflecting the actual shipped v4
+       architecture (no PlansListPage/PlanDetailPage — contextual review via
+       PlanReviewOverlay only, per T015/T016), and a walkthrough of the
+       generate → review → approve/apply → retry flow. -->
 - [x] T054 [P] Add `destructiveDestination` picker to plan-review UI: radio
   group "Archive (default) / OS Trash" shown only when plan contains
   destructive items.

--- a/specs/017-cleanup-archive-review-plans/tasks.md
+++ b/specs/017-cleanup-archive-review-plans/tasks.md
@@ -383,37 +383,44 @@ the user can send the archive subtree to OS trash or permanently delete it.
   research.md.
   <!-- Added a "Spec 017" row to docs/research/index.md's Feature research
        decisions section, linking specs/017-cleanup-archive-review-plans/research.md. -->
-- [x] T050 [P] Performance check: list render under 100 ms for 200 plans;
+- [ ] T050 [P] Performance check: list render under 100 ms for 200 plans;
   detail under 150 ms for 2000 items.
-  <!-- MEASURED. Literal target does not exist (T015/T016: no standalone Plans
-       list/detail page in the shipped v4 UI). Measured the equivalent real
-       surface — PlanReviewOverlay rendering a 200-item plan — using React's
-       Profiler `actualDuration` (isolates React's own render/commit cost;
-       excludes jsdom/test-harness wall-clock noise) with the plan + protection
-       check data pre-seeded via `queryClient.setQueryData` so no
-       fetch/microtask latency is included (throwaway vitest probe, not
-       committed to the suite — same rationale as this repo's own
-       CI-timing-flakiness convention in apps/desktop/playwright.config.ts for
-       not landing hard timing assertions).
-       RESULT: 8 commits, total actualDuration 233.37ms, dominated by one
-       182.72ms commit (the initial full-200-row mount); the other 7 commits
-       (state settling: protection-check resolving, gate readiness) cost
-       <30ms combined. FAILS the 100ms budget as literally measured (jsdom
-       DOM operations are typically slower than a real Chromium/WebView2
-       engine, so this is a worst-case bound, not a browser-accurate one).
-       ROOT CAUSE (structural, filed not fixed): the shared Table component
-       (apps/desktop/src/ui/Table.tsx) already supports opt-in row
-       virtualization (`virtualized` prop, `@tanstack/react-virtual`,
-       Table.tsx:51-58,82-88) but PlanReviewOverlay does not use it
-       (Table.tsx:242 — no `virtualized` prop passed) — the 200 rows mount
-       unconditionally. Enabling it needs a bounded-height scroll sub-region
-       for the item table nested inside the modal body, which today scrolls
-       as one column per the app's ".alm-page/__bar/__scroll" convention —
-       that's a layout decision (does the item table get its own scrolling
-       sub-region, changing the overlay's visual structure?), not a drop-in
-       prop flip, so left as a filed structural note rather than something to
-       decide unilaterally in this pass. -->
-- [ ] T051 Accessibility audit on PlansListPage and PlanDetailPage for the
+  <!-- RE-MEASURED after enabling virtualization (see T051 fix). UX call made
+       by the orchestrator: gave the item table the shared `.alm-listtable`
+       virtualized pattern (apps/desktop/src/features/plans/PlanReviewOverlay.tsx:294-303,
+       `virtualized` + `scrollClassName="alm-listtable__scroll"`, same pattern
+       as SessionsTable.tsx/InboxList.tsx), a new `.alm-modal__body--fill`
+       Modal-body variant so the body no longer scrolls itself (CSS:
+       merges-3.css `.alm-modal__body--fill`), and `.alm-plan-review` now
+       `flex: 1; min-height: 0` to fill it (redesign-detail.css). Header,
+       summary banner, protection gate, progress, and footer all stay pinned;
+       only the item table scrolls.
+       DETERMINISTIC RESULT (not timing, not flaky): DOM row count for a
+       200-item plan dropped from 200/200 to 64/200 — confirmed via a vitest
+       probe reading `document.querySelectorAll('[data-testid^="plan-review-item-"]')`
+       (jsdom's existing global virtualizer layout shim,
+       apps/desktop/vitest.setup.ts:53-105, gives the `data-virtual-scroll`
+       container a 2000px viewport, so `@tanstack/react-virtual` genuinely
+       windows the list in tests, not just production).
+       TIMING RESULT (honest, not cherry-picked): same React Profiler
+       `actualDuration` methodology as before, 4 runs each, same session:
+       BEFORE (200/200 rows): 232.45, 197.71, 179.25, 135.47ms (mean ≈186ms).
+       AFTER (64/200 rows): 238.41, 154.02, 200.50, 212.48ms (mean ≈201ms).
+       The two ranges overlap — this specific jsdom-Profiler total-duration
+       metric does NOT show a clear win, and NEITHER before nor after
+       consistently meets the literal 100ms budget in this harness. This is
+       expected, not a red flag: jsdom has no real layout/paint pipeline, so
+       the Profiler only measures React's own reconciliation cost, which
+       virtualization's bookkeeping (measuring, spacer math) partly offsets at
+       this list size — the actual mechanism virtualization protects (DOM
+       node count, hence real browser layout/paint/GC cost) is NOT something
+       jsdom can measure, which is exactly why the 200/64 row-count result
+       above is the trustworthy piece of evidence here, not the ms numbers.
+       NOT TICKED per instruction ("tick only if the number actually meets
+       budget") — the literal ms target is not demonstrated met by anything
+       measurable in this sandbox; a real Chromium/Tauri perf pass is still
+       the way to validate the ms budget, same recommendation as before. -->
+- [x] T051 Accessibility audit on PlansListPage and PlanDetailPage for the
   state-aware action bar (focus order, button labels; includes `paused` state).
   <!-- AUDITED (real surface, since PlansListPage/PlanDetailPage don't exist —
        see T050). Findings:
@@ -430,32 +437,19 @@ the user can send the archive subtree to OS trash or permanently delete it.
        - PASS (no fix needed): the new Destination column reuses the exact
          same `<span>` pattern as the pre-existing Source path column — no new
          a11y surface introduced.
-       - STRUCTURAL, FILED not fixed: same root cause as T050 — an
-         unvirtualized 200+ row table is also an a11y concern (very long
-         sequential tab-through with no way to jump), independent of a
-         concrete `paused`-state gap: `paused` has NO UI anywhere in
-         apps/desktop/src/features/{plans,archive}/** (grepped — no
-         "paused"/"Pause"/"Resume" string or branch exists in
-         PlanReviewOverlay or ArchivePage). Adding pause/resume affordances is
-         new product surface, not an audit fix — filed for a design call, not
-         invented here.
-       No cheap fixes were found beyond what's already compliant; the two
-       findings above both trace back to the same virtualization decision
-       filed under T050. -->
-- [ ] T051 Accessibility audit on PlansListPage and PlanDetailPage for the
-  state-aware action bar (focus order, button labels; includes `paused` state).
-  <!-- Literal target does not exist (see T050). Audited the equivalent real
-       surface, PlanReviewOverlay's footer: all states (draft/ready_for_review,
-       terminal failed/partially_applied, applied) render exactly two clearly
-       labeled text buttons via the shared Btn component (no icon-only
-       affordances), footer swaps via the `applied`/`retryable` booleans so
-       focus always lands on visible, enabled controls, and the live-progress
-       region already carries `role="status" aria-live="polite"`
-       (PlanReviewOverlay.tsx:301-306). No regressions found from this PR's new
-       Destination column (plain `<span>` cells, same pattern as the existing
-       Source path column) or the new retry footer branch. `paused` state is
-       NOT handled by this overlay (no pause/resume UI exists anywhere in
-       apps/desktop/src/features/plans|archive — out of scope to add here). -->
+       - FIXED (was STRUCTURAL/filed, now resolved — see T050): the
+         unvirtualized 200+ row table meant a very long sequential tab-through
+         with no way to jump. Enabling `.alm-listtable` virtualization windows
+         the DOM to ~64 rows at a time (confirmed above), directly shrinking
+         the tab-through — same fix as T050, not a separate change.
+       - Still open, correctly NOT built here per explicit instruction:
+         `paused` has NO UI anywhere in apps/desktop/src/features/{plans,archive}/**
+         (grepped — no "paused"/"Pause"/"Resume" string or branch exists in
+         PlanReviewOverlay or ArchivePage). This is new product surface, not
+         an audit fix — routed to the spec-025 apply-executor tail lane per
+         the orchestrator's direction; not built here.
+       No cheap fixes were found beyond what's already compliant; the one
+       structural finding above is now fixed (T050), not just filed. -->
 - [ ] T052 Coordinate handoff edge with spec 025: confirm `applying`,
   `paused`, `applied`, `partially_applied`, `failed`, `cancelled` are
   written only by the apply executor.


### PR DESCRIPTION
## Summary
- The plan review dialog didn't show where a file would end up (or that it would be deleted, not moved) before approving a plan — added a Destination column to the item list.
- Added a "Generate retry plan" action for plans that finished with failures or partial application, so a failed cleanup/archive run can be retried without starting over.

## Spec Context
- Spec: 017
- Branch: orc/nc-017-archive-generator