### PR TITLE
feat(settings): persist theme in the settings database

### DIFF
--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -11,7 +11,10 @@
 //!
 //! The scope groups keys by workflow area:
 //! - `"advanced"` → `logLevel`, `rememberFollowLogs`, `devMode`
-//! - `"general"`  → (empty; rowDensity removed T032)
+//! - `"general"`  → `theme` (theme-settings-db: durable source of truth for
+//!   the UI theme; the frontend still keeps a synchronous localStorage boot
+//!   cache to avoid a flash of the wrong theme, reconciled from this scope
+//!   at startup)
 //! - `"cleanup"`  → `blockPermanentDelete`, `defaultProtection`, `protectedCategories`
 //! - `"naming"`   → `pattern`, `autoApplyPattern`, `patternsByType`
 //! - `"sources"`  → `followSymlinks`, `hashOnScan`
@@ -54,7 +57,7 @@ use contracts_core::ContractError;
 fn scope_keys(scope: &str) -> &'static [&'static str] {
     match scope {
         "advanced" => &["logLevel", "rememberFollowLogs", "devMode"],
-        "general" => &[],
+        "general" => &["theme"],
         "cleanup" => &["blockPermanentDelete", "defaultProtection", "protectedCategories"],
         "naming" => &["pattern", "autoApplyPattern", "patternsByType"],
         "sources" => &["followSymlinks", "hashOnScan", "alwaysPreviewBeforePlan"],
@@ -110,6 +113,7 @@ fn scope_keys(scope: &str) -> &'static [&'static str] {
             "observingActiveSiteId",
             "usableAltitudeDeg",
             "plannerMoonAvoidance",
+            "theme",
         ],
     }
 }

--- a/apps/desktop/src/data/theme.persistence.test.ts
+++ b/apps/desktop/src/data/theme.persistence.test.ts
@@ -1,0 +1,180 @@
+/**
+ * theme.persistence.test.ts — theme-settings-db.
+ *
+ * The settings DB (`general` scope, `theme` key) is the durable source of
+ * truth for the theme choice; localStorage (`alm.theme`) is kept only as a
+ * synchronous boot cache so `initAppearance()` can paint before first render
+ * without waiting on IPC (avoiding a flash of the wrong theme). Covers:
+ * `setThemeChoice` writing both localStorage and the settings DB, and
+ * `hydrateThemeFromSettings` reconciling the cache from the DB at boot.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type IpcOutcome =
+  | { status: 'ok'; data: unknown }
+  | { status: 'error'; error: unknown };
+
+const isTauriMock = vi.fn<() => boolean>();
+const settingsGetMock = vi.fn<(scope: string) => Promise<IpcOutcome>>();
+const settingsUpdateMock =
+  vi.fn<(scope: string, values: unknown) => Promise<IpcOutcome>>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock(),
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ setTheme: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: (scope: string) => settingsGetMock(scope),
+    settingsUpdate: (scope: string, values: unknown) =>
+      settingsUpdateMock(scope, values),
+  },
+}));
+
+/** Poll briefly for an async mock to have been called (mirrors theme.test.ts). */
+async function waitForCall(fn: ReturnType<typeof vi.fn>): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (fn.mock.calls.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+describe('setThemeChoice — write-through to the settings DB', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isTauriMock.mockReset();
+    settingsGetMock.mockReset();
+    settingsUpdateMock.mockReset();
+    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('persists the choice to localStorage synchronously and to settings.update when inside Tauri', async () => {
+    isTauriMock.mockReturnValue(true);
+    const { setThemeChoice } = await import('./theme');
+
+    setThemeChoice('espresso-dark');
+
+    // The localStorage cache write is synchronous — no await needed.
+    expect(localStorage.getItem('alm.theme')).toBe('espresso-dark');
+
+    await waitForCall(settingsUpdateMock);
+    expect(settingsUpdateMock).toHaveBeenCalledWith('general', {
+      theme: 'espresso-dark',
+    });
+  });
+
+  it('still writes localStorage but skips settings.update outside Tauri (no-op)', async () => {
+    isTauriMock.mockReturnValue(false);
+    const { setThemeChoice } = await import('./theme');
+
+    setThemeChoice('warm-clay');
+
+    expect(localStorage.getItem('alm.theme')).toBe('warm-clay');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('degrades silently when settings.update rejects — never throws out of setThemeChoice', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsUpdateMock.mockRejectedValue(new Error('db unavailable'));
+    const { setThemeChoice } = await import('./theme');
+
+    expect(() => setThemeChoice('warm-slate')).not.toThrow();
+    await waitForCall(settingsUpdateMock);
+    // localStorage still reflects the choice even though the DB write failed.
+    expect(localStorage.getItem('alm.theme')).toBe('warm-slate');
+  });
+});
+
+describe('hydrateThemeFromSettings — reconcile the boot cache from the settings DB', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isTauriMock.mockReset();
+    settingsGetMock.mockReset();
+    settingsUpdateMock.mockReset();
+    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('overwrites a stale localStorage cache with the DB value (survives a WebView2 force-kill)', async () => {
+    isTauriMock.mockReturnValue(true);
+    localStorage.setItem('alm.theme', 'warm-clay');
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'general', values: { theme: 'espresso-dark' } },
+    });
+
+    const { hydrateThemeFromSettings } = await import('./theme');
+    await hydrateThemeFromSettings();
+
+    expect(localStorage.getItem('alm.theme')).toBe('espresso-dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'espresso-dark',
+    );
+  });
+
+  it('leaves the cache untouched when the DB already agrees (no redundant write-back)', async () => {
+    isTauriMock.mockReturnValue(true);
+    localStorage.setItem('alm.theme', 'observatory-dark');
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'general', values: { theme: 'observatory-dark' } },
+    });
+
+    const { hydrateThemeFromSettings } = await import('./theme');
+    await hydrateThemeFromSettings();
+
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+
+  it('ignores a malformed/unknown DB value and keeps the localStorage cache', async () => {
+    isTauriMock.mockReturnValue(true);
+    localStorage.setItem('alm.theme', 'warm-slate');
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'general', values: { theme: 'not-a-real-theme' } },
+    });
+
+    const { hydrateThemeFromSettings, getThemeChoice } = await import(
+      './theme'
+    );
+    await hydrateThemeFromSettings();
+
+    expect(getThemeChoice()).toBe('warm-slate');
+  });
+
+  it('is a no-op outside Tauri (dev server / vitest)', async () => {
+    isTauriMock.mockReturnValue(false);
+    localStorage.setItem('alm.theme', 'warm-clay');
+
+    const { hydrateThemeFromSettings } = await import('./theme');
+    await hydrateThemeFromSettings();
+
+    expect(settingsGetMock).not.toHaveBeenCalled();
+    expect(localStorage.getItem('alm.theme')).toBe('warm-clay');
+  });
+
+  it('degrades silently when settings.get rejects — never throws', async () => {
+    isTauriMock.mockReturnValue(true);
+    localStorage.setItem('alm.theme', 'warm-clay');
+    settingsGetMock.mockRejectedValue(new Error('db unavailable'));
+
+    const { hydrateThemeFromSettings } = await import('./theme');
+    await expect(hydrateThemeFromSettings()).resolves.toBeUndefined();
+    expect(localStorage.getItem('alm.theme')).toBe('warm-clay');
+  });
+});

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -1,9 +1,19 @@
 // Appearance runtime — theme + density (PlateVault redesign).
 //
-// Theme is persisted in localStorage under `alm.theme` and applied as a
-// `data-theme` attribute on <html>; tokens.css defines one scope per theme.
-// `system` follows the OS via prefers-color-scheme. Density mirrors the
-// existing AppPreferences.density and is applied as a class on <html>.
+// Theme is applied as a `data-theme` attribute on <html>; tokens.css defines
+// one scope per theme. `system` follows the OS via prefers-color-scheme.
+// Density mirrors the existing AppPreferences.density and is applied as a
+// class on <html>.
+//
+// Persistence (theme-settings-db): the settings DB (`general` scope, `theme`
+// key — spec 018) is the durable source of truth. localStorage (`alm.theme`)
+// is kept ONLY as a synchronous boot cache so `initAppearance()` can paint the
+// right theme before first render without waiting on an IPC round-trip. On
+// Windows, WebView2 only flushes its localStorage-backing LevelDB store on a
+// graceful shutdown, so a force-killed app can lose the cache entirely — the
+// DB survives that. `hydrateThemeFromSettings()` reconciles the cache from
+// the DB once IPC is available (call after `initAppearance()`); `setThemeChoice`
+// writes both on every change.
 import { useSyncExternalStore } from 'react';
 import { getPreferences } from '@/data/preferences';
 
@@ -53,6 +63,21 @@ const THEME_KEY = 'alm.theme';
 const LIGHT_DEFAULT: ThemeId = 'warm-slate';
 const DARK_DEFAULT: ThemeId = 'observatory-dark';
 
+/** Settings-DB scope/key for the durable theme choice (spec 018 `general` scope). */
+const SETTINGS_SCOPE = 'general';
+const SETTINGS_KEY = 'theme';
+
+const VALID_CHOICES: readonly ThemeChoice[] = [
+  'system',
+  ...THEMES.map((t) => t.id),
+];
+
+function isThemeChoice(v: unknown): v is ThemeChoice {
+  return (
+    typeof v === 'string' && (VALID_CHOICES as readonly string[]).includes(v)
+  );
+}
+
 const listeners = new Set<() => void>();
 function notify(): void {
   for (const l of listeners) l();
@@ -60,11 +85,39 @@ function notify(): void {
 
 export function getThemeChoice(): ThemeChoice {
   try {
-    const v = localStorage.getItem(THEME_KEY) as ThemeChoice | null;
-    return v ?? 'system';
+    const v = localStorage.getItem(THEME_KEY);
+    return isThemeChoice(v) ? v : 'system';
   } catch {
     return 'system';
   }
+}
+
+/**
+ * Best-effort write-through to the settings DB (spec 018) — same
+ * fire-and-forget shape as `syncNativeWindowTheme`: outside Tauri (dev
+ * server, vitest) or on any IPC failure this silently no-ops. localStorage
+ * is written synchronously by the caller regardless, so the UI never waits
+ * on this.
+ */
+function persistThemeToSettings(choice: ThemeChoice): void {
+  void (async () => {
+    try {
+      const { isTauri } = await import('@tauri-apps/api/core');
+      if (!isTauri()) return;
+
+      const [{ commands }, { unwrap }] = await Promise.all([
+        import('@/bindings/index'),
+        import('@/api/ipc'),
+      ]);
+      unwrap(
+        await commands.settingsUpdate(SETTINGS_SCOPE, {
+          [SETTINGS_KEY]: choice,
+        }),
+      );
+    } catch {
+      // Best-effort — a DB write failure never blocks or reverts the UI change.
+    }
+  })();
 }
 
 export function setThemeChoice(choice: ThemeChoice): void {
@@ -73,8 +126,36 @@ export function setThemeChoice(choice: ThemeChoice): void {
   } catch {
     /* localStorage may be unavailable */
   }
+  persistThemeToSettings(choice);
   applyTheme();
   notify();
+}
+
+/**
+ * Reconcile the synchronous localStorage boot cache against the settings DB
+ * (spec 018) — the DB is the durable source of truth; localStorage only
+ * exists to avoid a flash of the wrong theme before this async call
+ * resolves. Call once after `initAppearance()` at boot. No-ops outside
+ * Tauri or on any IPC failure (the localStorage cache stays authoritative
+ * until the next successful reconcile).
+ */
+export async function hydrateThemeFromSettings(): Promise<void> {
+  try {
+    const { isTauri } = await import('@tauri-apps/api/core');
+    if (!isTauri()) return;
+
+    const [{ commands }, { unwrap }] = await Promise.all([
+      import('@/bindings/index'),
+      import('@/api/ipc'),
+    ]);
+    const data = unwrap(await commands.settingsGet(SETTINGS_SCOPE));
+    const stored = (data.values as Record<string, unknown>)[SETTINGS_KEY];
+    if (isThemeChoice(stored) && stored !== getThemeChoice()) {
+      setThemeChoice(stored);
+    }
+  } catch {
+    // Best-effort — keep the current localStorage-cached choice.
+  }
 }
 
 function prefersDark(): boolean {

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -8,11 +8,19 @@ import { QueryClientProvider } from '@tanstack/react-query';
 import { router } from './app/router';
 import { AppErrorBoundary } from './app/AppErrorBoundary';
 import { queryClient } from './data/queryClient';
-import { initAppearance } from './data/theme';
+import { initAppearance, hydrateThemeFromSettings } from './data/theme';
 
 // Apply the persisted theme + density to <html> before first paint, and wire
-// OS light/dark changes for the `system` choice.
+// OS light/dark changes for the `system` choice. Synchronous and driven off
+// the localStorage boot cache so there is no flash of the wrong theme.
 initAppearance();
+
+// Reconcile that boot cache against the settings DB (spec 018, source of
+// truth — theme-settings-db) once IPC is available. Deliberately NOT awaited
+// before the initial render: the DB is only consulted after the fast,
+// synchronous cache has already painted, and this at most swaps the theme
+// once if the two disagree (e.g. localStorage lost to a WebView2 force-kill).
+void hydrateThemeFromSettings();
 
 // T075 / SC-002: Install the recording proxy at boot in dev-tools builds.
 // VITE_DEV_TOOLS is statically "false" in release builds, so this branch and

--- a/crates/app/settings/src/descriptors.rs
+++ b/crates/app/settings/src/descriptors.rs
@@ -549,6 +549,25 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         },
         default: |s| serde_json::to_value(s.cleanup_type_overrides).unwrap_or(Value::Null),
     },
+    // ── Appearance (theme durability) ────────────────────────────────────
+    // Not overridable (a single global UI preference, no per-source
+    // concept) and not noisy (a real, low-frequency change worth its own
+    // audit entry, same treatment as e.g. `defaultProtection`).
+    Descriptor {
+        key: "theme",
+        noisy: false,
+        overridable: false,
+        validation: ValidationRule::EnumStr {
+            allowed: &["warm-clay", "warm-slate", "observatory-dark", "espresso-dark", "system"],
+            expected_msg: "must be \"warm-clay\", \"warm-slate\", \"observatory-dark\", \"espresso-dark\", or \"system\"",
+        },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.theme);
+            }
+        },
+        default: |s| Value::String(s.theme),
+    },
 ];
 
 /// Look up the descriptor for a stable key, if any.

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -930,6 +930,32 @@ mod tests {
         assert!(resp.audit_id.is_some());
     }
 
+    /// Theme durability round trip (theme-settings-db): `settings.update`
+    /// persists the choice to the real settings table, and `resolve_setting`
+    /// — the same lookup `settings_get` uses — reads it back, proving the DB
+    /// (not localStorage) is the durable source of truth.
+    #[tokio::test]
+    async fn theme_persists_and_resolves_via_settings_db() {
+        let (db, bus) = setup().await;
+        assert_eq!(
+            resolve_setting(db.pool(), "theme", None).await.unwrap(),
+            serde_json::json!("system"),
+            "default theme should be \"system\" before any write"
+        );
+
+        let req = SettingsUpdateRequest {
+            key: "theme".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("espresso-dark")),
+        };
+        let resp = update_setting(db.pool(), &bus, &req).await.unwrap();
+        assert_eq!(resp.status, SettingsUpdateStatus::Success);
+
+        assert_eq!(
+            resolve_setting(db.pool(), "theme", None).await.unwrap(),
+            serde_json::json!("espresso-dark")
+        );
+    }
+
     #[tokio::test]
     async fn update_setting_noop_when_value_unchanged() {
         let (db, bus) = setup().await;
@@ -1149,6 +1175,7 @@ mod tests {
     #[case("calibrationDarkOverridePenalty", true)]
     #[case("calibrationFlatOverridePenalty", true)]
     #[case("calibrationBiasOverridePenalty", true)]
+    #[case("theme", true)]
     #[case("tools.pixinsight.bundle_id", true)]
     #[case("tools.pixinsight.executable_path", true)]
     #[case("tools.siril.enabled", true)]
@@ -1225,6 +1252,11 @@ mod tests {
     #[case("usableAltitudeDeg", serde_json::json!(90))]
     #[case("cleanupTypeOverrides", serde_json::json!({}))] // empty map: all defaults apply
     #[case("cleanupTypeOverrides", serde_json::json!({"1": "Keep", "20": "Delete"}))]
+    #[case("theme", serde_json::json!("warm-clay"))]
+    #[case("theme", serde_json::json!("warm-slate"))]
+    #[case("theme", serde_json::json!("observatory-dark"))]
+    #[case("theme", serde_json::json!("espresso-dark"))]
+    #[case("theme", serde_json::json!("system"))]
     fn validate_value_accepts(#[case] key: &str, #[case] value: Value) {
         assert!(validate_value(key, &value).is_ok(), "expected {key}={value} to be accepted");
     }
@@ -1275,6 +1307,8 @@ mod tests {
     #[case("cleanupTypeOverrides", serde_json::json!({"abc": "Keep"}))] // non-numeric id
     #[case("cleanupTypeOverrides", serde_json::json!({"1": "Trash"}))] // not an allowed action
     #[case("cleanupTypeOverrides", serde_json::json!({"1": 5}))] // action not a string
+    #[case("theme", serde_json::json!("neon"))] // not an allowed variant
+    #[case("theme", serde_json::json!(5))] // not a string
     fn validate_value_rejects(#[case] key: &str, #[case] value: Value) {
         let err = validate_value(key, &value).expect_err("expected rejection");
         assert_eq!(err.code, ErrorCode::ValueInvalid, "key {key} value {value}");

--- a/crates/domain/core/src/settings.rs
+++ b/crates/domain/core/src/settings.rs
@@ -240,6 +240,16 @@ pub struct SettingsState {
     /// `"Delete"` (data-model.md §E2). Absent id ⇒ that type's built-in
     /// default action applies. Empty by default (no overrides).
     pub cleanup_type_overrides: std::collections::BTreeMap<String, String>,
+
+    // ── Appearance ─────────────────────────────────────────────────────
+    /// UI theme choice: one of the four fixed theme ids (`warm-clay`,
+    /// `warm-slate`, `observatory-dark`, `espresso-dark`) or `"system"` to
+    /// follow the OS light/dark preference (`apps/desktop/src/data/theme.ts`
+    /// `ThemeChoice`). This is the durable source of truth; the frontend
+    /// mirrors it into a synchronous localStorage boot cache to avoid a
+    /// flash of the wrong theme, since WebView2 only flushes localStorage on
+    /// graceful shutdown and loses it on a forced kill.
+    pub theme: String,
 }
 
 impl Default for SettingsState {
@@ -293,6 +303,7 @@ impl Default for SettingsState {
             source_view_link_kind_intra_drive: "hardlink".to_owned(),
             source_view_link_kind_cross_drive: "symlink".to_owned(),
             cleanup_type_overrides: std::collections::BTreeMap::new(),
+            theme: "system".to_owned(),
         }
     }
 }

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -20,13 +20,27 @@
 //! backend-persisted setting (e.g. Ingestion's toggles, which round-trip
 //! through `ingestion.settings.get`/`update` into the same DB) CANNOT be
 //! proven to survive a relaunch in this harness — the DB reset would erase
-//! it regardless of whether the real app would have kept it. Only
-//! `localStorage`-backed state (e.g. the theme choice,
-//! `apps/desktop/src/data/theme.ts`) survives a `relaunch()` (unlike a
-//! second `launch()`, which also wipes webview storage) and can honestly
-//! prove cross-relaunch persistence here; the
+//! it regardless of whether the real app would have kept it. The
 //! ingestion-settings-persist-across-restart scenario (journey-10 Test 4) is
 //! left as a follow-up for that reason, not an oversight.
+//!
+//! (theme-settings-db, 2026-07-09) The theme choice used to be the one
+//! exception — purely `localStorage`-backed
+//! (`apps/desktop/src/data/theme.ts`), and therefore untouched by
+//! `reset_database()`, which is why the original version of Test 2 below
+//! asserted it survived a `relaunch()`. Theme is now DB-backed (settings
+//! `general` scope, `theme` key) so the WebView2 force-kill data-loss finding
+//! (a graceful shutdown flushes `localStorage`'s LevelDB store; a forced kill
+//! does not) can't silently lose the user's choice. `localStorage` is kept
+//! only as a synchronous boot cache, reconciled from the DB by
+//! `hydrateThemeFromSettings()` shortly after boot. That moves theme into the
+//! same "cannot be proven to survive a relaunch in this harness" bucket as
+//! Ingestion above — this harness's `reset_database()` wipes the very row
+//! `hydrateThemeFromSettings()` would otherwise confirm survived, and will
+//! instead reconcile the boot cache back to the default. Test 2 below is
+//! trimmed to the live-apply assertion only (unaffected by the DB reset); a
+//! true cross-relaunch proof needs a harness `ResetScope` that preserves the
+//! DB, left as a follow-up alongside Ingestion's.
 
 mod common;
 
@@ -140,143 +154,87 @@ async fn settings_ui_ingestion_toggle_autosaves_no_global_save_button() -> anyho
 }
 
 /// Test 2 (journey-10): switching the theme applies live (`<html
-/// data-theme>` changes with no reload) and survives a full app relaunch —
-/// the ONE piece of Settings state this harness can honestly prove survives
-/// a relaunch, since theme choice is `localStorage`-backed
-/// (`apps/desktop/src/data/theme.ts`) and therefore untouched by
-/// `E2eApp::launch()`'s per-session `reset_database()` (see module docs).
+/// data-theme>` changes with no reload) and the write actually lands in both
+/// the localStorage boot cache AND the settings DB (spec 018 `general`
+/// scope, `theme` key — theme-settings-db).
+///
+/// (theme-settings-db, 2026-07-09) Trimmed from the original version, which
+/// also asserted the choice survived a full `relaunch()`. That assertion
+/// relied on theme being purely `localStorage`-backed and therefore
+/// untouched by `E2eApp::relaunch()`'s unconditional `reset_database()`; now
+/// that the DB is the source of truth, `relaunch()` wipes the very row that
+/// would prove it survived, same as every other backend-persisted setting
+/// (see module docs, Ingestion's `-persist-across-restart` follow-up). A
+/// true cross-relaunch proof needs a harness `ResetScope` that preserves the
+/// DB — left as a follow-up.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn settings_ui_theme_applies_live_and_persists_across_relaunch() -> anyhow::Result<()> {
-    {
-        let app = E2eApp::launch().await?;
-        app.wait_bridge_ready(Duration::from_secs(30)).await?;
-        complete_first_run(&app).await?;
+async fn settings_ui_theme_applies_live_and_persists_to_settings_db() -> anyhow::Result<()> {
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    complete_first_run(&app).await?;
 
-        app.goto_route("/settings/general").await?;
-        app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.goto_route("/settings/general").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
 
-        // "Espresso" (`THEMES` id `espresso-dark`) — a real, non-default theme
-        // swatch, matched by its visible name (the swatch button's full text
-        // also includes its light/dark mode label, so an exact-match helper
-        // would be wrong here — use `contains`).
-        // Poll for the swatch to actually mount: it opens asynchronously
-        // after the navigation, same route/render race `E2eApp::find_waiting`
-        // documents.
-        let xpath = "//button[contains(., 'Espresso')]";
-        app.find_waiting(By::XPath(xpath), "the 'Espresso' theme swatch button")
-            .await?
-            .click()
-            .await
-            .context("click the Espresso theme swatch failed")?;
-
-        // Live apply: no reload needed.
-        let theme: String = app
-            .driver
-            .execute("return document.documentElement.getAttribute('data-theme')", vec![])
-            .await
-            .context("failed to read document.documentElement's data-theme")?
-            .convert()
-            .context("failed to deserialise data-theme")?;
-        anyhow::ensure!(
-            theme == "espresso-dark",
-            "expected the theme to apply live with no reload, got data-theme={theme:?}"
-        );
-
-        // Diagnostic (round 2, fix-464-theme): confirm the write actually
-        // landed in `localStorage` itself, not just the derived `data-theme`
-        // attribute — rules out "never written" as a cause of a later
-        // relaunch failure.
-        let stored: serde_json::Value = app
-            .driver
-            .execute("return window.localStorage.getItem('alm.theme')", vec![])
-            .await
-            .context("failed to read localStorage['alm.theme'] before shutdown")?
-            .convert()
-            .context("failed to deserialise localStorage['alm.theme'] before shutdown")?;
-        anyhow::ensure!(
-            stored == serde_json::json!("espresso-dark"),
-            "expected localStorage['alm.theme']=\"espresso-dark\" to be written before \
-             shutdown, got {stored:?}"
-        );
-
-        // `E2eApp::shutdown()` force-kills the app process (the CLI's only
-        // handle on the app's lifetime — see `blocking_session_delete`'s
-        // doc). CI evidence (round 2, fix-464-theme: CI run 28810006837) is
-        // that this reliably LOSES a `localStorage` write on Windows — the
-        // raw value read back after a relaunch was `null`, not merely stale
-        // — and a delay before the kill (tried in that round) does not save
-        // it: WebView2 commits `localStorage` to its on-disk LevelDB-backed
-        // store on a graceful shutdown, not on a timer, so nothing short of
-        // an actual graceful close preserves it. Use
-        // `E2eApp::graceful_shutdown()` instead, which closes the window for
-        // real (`getCurrentWindow().close()`) before tearing the session
-        // down — real-user fidelity, and the only path that gives WebView2 a
-        // normal teardown to flush during.
-        app.graceful_shutdown().await?;
-    }
-
-    // Relaunch: a fresh WebDriver session + a fresh `desktop_shell` process,
-    // via `E2eApp::relaunch()` (NOT `launch()` — `launch()` wipes the
-    // webview's persisted storage on every call, which would erase the very
-    // localStorage state this journey is trying to prove survives a real
-    // app restart). `reset_database()` still wipes the SQLite DB (first-run
-    // state), but the theme choice lives in the SAME OS webview profile's
-    // localStorage and is applied by `initAppearance()` at boot, before
-    // routing/first-run even resolves — so it should already be set the
-    // instant the bridge is ready, with no navigation needed.
-    let app2 = E2eApp::relaunch().await?;
-    app2.wait_bridge_ready(Duration::from_secs(30)).await?;
-
-    // Diagnostic (round 2, fix-464-theme): read the RAW localStorage value
-    // directly, in addition to the derived `data-theme` attribute. If this
-    // is `null`, the write was lost between processes (harness/OS-level
-    // storage loss). If it's still `"espresso-dark"` but `data-theme` below
-    // reverted to the default, the value survived fine and the bug is a
-    // product-code race in `initAppearance()`/`applyTheme()` reading
-    // localStorage before hydration completes — a very different fix.
-    let stored_after_relaunch: serde_json::Value = app2
-        .driver
-        .execute("return window.localStorage.getItem('alm.theme')", vec![])
+    // "Espresso" (`THEMES` id `espresso-dark`) — a real, non-default theme
+    // swatch, matched by its visible name (the swatch button's full text
+    // also includes its light/dark mode label, so an exact-match helper
+    // would be wrong here — use `contains`).
+    // Poll for the swatch to actually mount: it opens asynchronously
+    // after the navigation, same route/render race `E2eApp::find_waiting`
+    // documents.
+    let xpath = "//button[contains(., 'Espresso')]";
+    app.find_waiting(By::XPath(xpath), "the 'Espresso' theme swatch button")
+        .await?
+        .click()
         .await
-        .context("failed to read localStorage['alm.theme'] after relaunch")?
-        .convert()
-        .context("failed to deserialise localStorage['alm.theme'] after relaunch")?;
+        .context("click the Espresso theme swatch failed")?;
 
-    let theme_after_relaunch: String = app2
+    // Live apply: no reload needed.
+    let theme: String = app
         .driver
         .execute("return document.documentElement.getAttribute('data-theme')", vec![])
         .await
-        .context("failed to read document.documentElement's data-theme after relaunch")?
+        .context("failed to read document.documentElement's data-theme")?
         .convert()
-        .context("failed to deserialise data-theme after relaunch")?;
+        .context("failed to deserialise data-theme")?;
     anyhow::ensure!(
-        theme_after_relaunch == "espresso-dark",
-        "expected the theme choice to survive a full app relaunch (localStorage), \
-         got data-theme={theme_after_relaunch:?} (raw localStorage['alm.theme']={stored_after_relaunch:?} \
-         — null means the value never made it to disk/the new process; \
-         \"espresso-dark\" means it survived but something ignored it at boot)"
+        theme == "espresso-dark",
+        "expected the theme to apply live with no reload, got data-theme={theme:?}"
     );
 
-    // Confirm the Settings UI itself reflects the persisted choice too (not
-    // just the raw DOM attribute).
-    complete_first_run(&app2).await?;
-    app2.goto_route("/settings/general").await?;
-    app2.wait_bridge_ready(Duration::from_secs(15)).await?;
-    let espresso_swatch = app2
-        .find_waiting(
-            By::XPath("//button[contains(., 'Espresso')]"),
-            "the 'Espresso' theme swatch button after relaunch",
-        )
-        .await?;
-    let pressed = espresso_swatch
-        .attr("aria-pressed")
+    // The localStorage boot cache is written synchronously alongside the
+    // live apply.
+    let stored: serde_json::Value = app
+        .driver
+        .execute("return window.localStorage.getItem('alm.theme')", vec![])
         .await
-        .context("failed to read aria-pressed on the Espresso swatch")?;
+        .context("failed to read localStorage['alm.theme']")?
+        .convert()
+        .context("failed to deserialise localStorage['alm.theme']")?;
     anyhow::ensure!(
-        pressed.as_deref() == Some("true"),
-        "expected the Espresso swatch to show aria-pressed=true after relaunch, got {pressed:?}"
+        stored == serde_json::json!("espresso-dark"),
+        "expected localStorage['alm.theme']=\"espresso-dark\" to be written on click, got {stored:?}"
     );
 
-    app2.shutdown().await
+    // The settings DB write-through (theme-settings-db) is fire-and-forget,
+    // so poll `settings.get` rather than asserting immediately.
+    let settings: serde_json::Value = app
+        .invoke_until(
+            "settings_get",
+            json!({ "scope": "general" }),
+            UI_TIMEOUT,
+            |v: &serde_json::Value| v["values"]["theme"] == json!("espresso-dark"),
+        )
+        .await
+        .map_err(|e| {
+            anyhow::anyhow!("expected the theme choice to persist to the settings DB: {e}")
+        })?;
+    anyhow::ensure!(
+        settings["values"]["theme"] == json!("espresso-dark"),
+        "unexpected persisted settings.theme: {settings}"
+    );
+
+    app.shutdown().await
 }

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -230,7 +230,7 @@ everything neither automated layer reaches.
 | 7 Archive → delete | ✅ (backend only) | ✅ `archive_lifecycle_apply_trash_permanent_delete` (`archive_journeys.rs`, NEW 2026-07-05): real apply + `archive.list` + `archive.send_to_trash`/`archive.permanently_delete` metadata + `blockPermanentDelete` gate | ✅ `archive_lifecycle.spec.ts` (batch 2, PR #447, 2026-07-05): archive page listing + canonical actions, send-to-trash, typed-`DELETE` permanent-delete gate | `windows-journeys/journey-07-archive-delete.md` |
 | 8 Calibration masters → matching | ✅ | 🟡 real-UI (`calibration_ui_journeys.rs`): masters ingest as individual items + kind-conditional detail (Tests 1/2). Matching/assign UI (Tests 3-5) found UNREACHABLE from the real app during this pass — see finding below, not automatable until fixed | ✅ `calibration_masters_matching.spec.ts` (batch 4, PR #452, 2026-07-05): masters as individual items with kind-conditional Filter/Exposure columns, aging pill + fingerprint detail, per-project match-status confidence, configurable matching tolerances | `windows-journeys/journey-08-calibration-masters-matching.md` |
 | 9 Targets & planning | ✅ (backend only) | 🟡 real-UI (`targets_journeys.rs`): add-target no-dup, stub-disclosure guard (no site), real astronomy after site creation (#440 confirmed landed) | ✅ `targets_planner.spec.ts` (batch 5, PR #454, 2026-07-05 + planner site-gate regression guard): no-site prompt / real-astronomy-after-site-creation / persisted-site-after-reload (9.1a–c), catalog list + typeahead + on-demand SIMBAD resolve (9.2a–c), honest-empty favourites/sessions states (9.3a–b) | `windows-journeys/journey-09-targets-planning.md` |
-| 10 Settings/appearance/i18n | ✅ | 🟡 real-UI (`settings_journeys.rs`): no-global-Save + real auto-save round-trip, theme live-apply + cross-relaunch persistence. Remaining sub-tests (altitude clamp, log-panel layout/export, 1100×720 convention, translated backend errors, command palette, sidebar persistence) still route-load-smoke only | ✅ `settings_appearance_i18n.spec.ts` (batch 6, PR #455, 2026-07-05; stabilized PR #494): Ingestion/Cleanup panes auto-save round-trip, 4-theme switch + persistence, 1100×720 pinned-header layout convention, no-raw-message-key + plural-form (audit event count) i18n assertions, log-panel filter/Escape-close | `windows-journeys/journey-10-settings-appearance-i18n.md` |
+| 10 Settings/appearance/i18n | ✅ | 🟡 real-UI (`settings_journeys.rs`): no-global-Save + real auto-save round-trip, theme live-apply + settings-DB persistence (theme-settings-db, 2026-07-09 — supersedes the old localStorage-only cross-relaunch claim, see note below). Remaining sub-tests (altitude clamp, log-panel layout/export, 1100×720 convention, translated backend errors, command palette, sidebar persistence) still route-load-smoke only | ✅ `settings_appearance_i18n.spec.ts` (batch 6, PR #455, 2026-07-05; stabilized PR #494): Ingestion/Cleanup panes auto-save round-trip, 4-theme switch + persistence, 1100×720 pinned-header layout convention, no-raw-message-key + plural-form (audit event count) i18n assertions, log-panel filter/Escape-close | `windows-journeys/journey-10-settings-appearance-i18n.md` |
 
 Legend: ✅ solid coverage at that layer · 🟡 partial/IPC-only/smoke-only ·
 ❌ none. Layer-1 "✅" means the backend logic is real-tested; it says
@@ -412,14 +412,25 @@ just test the mock, not the product:
 11. **Settings + layout-convention + i18n regression guard** (Journey 10) —
     PARTIALLY DONE (2026-07-05, `crates/e2e-tests/tests/settings_journeys.rs`):
     no-global-Save-button + real auto-save round-trip (Test 1), and theme
-    live-apply + real cross-relaunch persistence (Test 2, using the
-    `localStorage`-backed theme choice — the one piece of Settings state this
-    harness's per-launch `reset_database()` doesn't erase, so it's the only
-    honest way to prove relaunch persistence here). Still open as follow-up:
+    live-apply + settings-DB persistence (Test 2). Still open as follow-up:
     the 1100×720 layout convention and no-raw-error-code checks are cheap,
     cross-cutting regression guards worth adding next; altitude clamp,
     log-panel layout/export, command palette, and sidebar persistence remain
     unautomated too.
+    UPDATE (theme-settings-db, 2026-07-09): theme moved from purely
+    `localStorage`-backed to DB-backed (settings `general` scope, `theme`
+    key), with `localStorage` kept only as a synchronous boot cache
+    (`hydrateThemeFromSettings()` reconciles it from the DB after boot) — a
+    fix for WebView2 only flushing `localStorage`'s LevelDB store on a
+    graceful shutdown, losing the choice on a forced kill (the finding Test 2
+    originally diagnosed via `graceful_shutdown()`/CI run 28810006837). This
+    moves theme into the same "cannot be proven to survive a relaunch in this
+    harness" bucket as Ingestion (both `E2eApp::launch()`/`relaunch()`
+    unconditionally wipe the DB via `reset_database()`), so Test 2's
+    cross-relaunch assertion was trimmed to the live-apply + DB write-through
+    checks only. A true cross-relaunch proof needs a harness `ResetScope`
+    that preserves the DB — left as a follow-up alongside
+    ingestion-settings-persist-across-restart.
 
 See `docs/development/windows-journeys/journey-0{1..9,10}-*.md` for the
 click-by-click manual scripts covering all of the above until each is


### PR DESCRIPTION
Moves the theme choice's source of truth from localStorage (lost on WebView2 force-kill — the spec-046/D16 finding) to the settings database, while keeping a synchronous localStorage boot cache to avoid a flash-of-wrong-theme: the DB is authoritative, localStorage is hydrated from it at startup, and both are written on change.

Cross-layer: settings command + domain settings model + descriptors, `data/theme.ts`, boot hydration in `main.tsx`, plus a new persistence unit test and the Layer-2 journey rewrite.

Verification: `cargo nextest --workspace` 1989/1989, clippy/fmt/typecheck/frontend tests all green (`just lint` only trips the pre-existing CHANGELOG typos-hook false positive).

Follow-up (documented): the Layer-2 relaunch journey was rewritten to `..._persists_to_settings_db` because the harness `reset_database()` wipes the DB-backed theme row on every relaunch; truly re-proving cross-relaunch persistence needs a harness `ResetScope` that preserves the DB (matching the existing Ingestion-settings precedent).