### PR TITLE
chore(design-sync): Claude Design sync inputs for PlateVault

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -1,0 +1,68 @@
+# design-sync notes — PlateVault
+
+Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
+
+- **This is an app, not a published component library.** `@astro-plan/desktop` is a
+  private Tauri app with no `main`/`module`/`exports`. The design-system entry is the
+  barrel `apps/desktop/src/ui/index.ts` — run the converter in src-entry mode with
+  `--entry ./apps/desktop/src/ui/index.ts` and `--node-modules apps/desktop/node_modules`.
+- **Component surface** = the 15 primitives exported from `src/ui/index.ts` (Pill, Btn,
+  Section, Box, KV, EmptyState, Table, Banner, Toggle, SegControl, RadioGroup, CoverageBar,
+  Lock, DirPicker, WizardShell, ToastContainer, InfoTip). Feature-level components live in
+  `src/features/*` and are intentionally NOT synced (app screens, not reusable primitives).
+- **Theming**: tokens are `--alm-*` CSS custom properties in `src/styles/tokens.css`.
+  `:root` = default (light); 4 named themes as `[data-theme="warm-slate"|"warm-clay"|
+  "observatory-dark"|"espresso-dark"]` on `<html>`; density via `.density-compact`/
+  `.density-spacious` on `<html>`. `.alm-*` component classes are BEM
+  (`.alm-btn--primary`, `.alm-pill--ok`, …).
+
+- **CSS must be pre-flattened (converter does NOT resolve `@import`).** `cfg.cssEntry`
+  points at `apps/desktop/.ds-css/flattened.css` (gitignored, generated). Regenerate it
+  BEFORE each `package-build.mjs` run — the converter copies it verbatim into
+  `_ds_bundle.css`:
+  ```
+  # aggregate = reset + tokens + components (app load order)
+  node --input-type=module -e "import e from './.ds-sync/node_modules/esbuild/lib/main.js'; \
+    await e.build({entryPoints:['apps/desktop/.ds-css/_aggregate.css'],bundle:true, \
+    outfile:'apps/desktop/.ds-css/flattened.css',loader:{'.css':'css'}})"
+  ```
+  esbuild inlines the relative `@import`s (incl. `components.css` → `components/*.css`
+  partials, the `.alm-*` classes) and keeps the remote Google-Fonts `@import` external.
+  `cfg.tokensGlob` is a NO-OP here (`copyTokens` only reads a `node_modules` `tokensPkg`),
+  so tokens ride inside the flattened `cssEntry` instead. Aggregate + esbuild command are
+  also captured in `.design-sync/rebuild-css.sh`.
+
+- **KV is dropped from previews** (16/17 cards). `isComponentName` treats all-caps names
+  (`^[A-Z][A-Z0-9_]+$`) as constants → `KV` is filtered from the card list. It is STILL in
+  the importable bundle (`window.PlateVault.KV`, 17 exports) — just no preview card. Not
+  worth forking `lib/dts.mjs` for one trivial key-value component.
+- **Fonts are remote** — Inter + JetBrains Mono via a Google Fonts `@import url(...)` at the
+  top of `tokens.css` → validate reports `[FONT_REMOTE]` (informational). Nothing to ship;
+  cards render correctly online, fall back to system fonts offline.
+- **Preview scope = floor cards** (first sync). User will author richer previews by driving
+  the project in claude.ai/design. Every component still ships fully functional (importable
+  bundle + `.d.ts` + `.prompt.md`).
+
+## Known render warns (triaged clean — a warn NOT here is new)
+- `[FONT_REMOTE]` Inter / JetBrains Mono / Cascadia Code — remote Google-Fonts `@import`,
+  by design (see remote-fonts bullet).
+- `[RENDER_BLANK]` on Banner, Box, Btn, CoverageBar, EmptyState, Pill, Section — these
+  render the REAL component with empty default props (a childless button, an empty box),
+  so the PNG is <5KB. Functional, just content-less until real props are supplied.
+- Floor cards on RadioGroup, SegControl, Table, ToastContainer, WizardShell — these are
+  data-driven (they `.map()` over `options`/`segments`/`columns`/`rows`/`steps`); default
+  props give `undefined`, so the honest floor card shows. **Author these five first** when
+  adding rich previews — they benefit most.
+
+## Re-sync risks (watch-list for the next run)
+- **CSS flatten step is mandatory and easy to forget** — if `flattened.css` is stale or
+  missing, `_ds_bundle.css` silently loses the `.alm-*` classes. Always re-run
+  `.design-sync/rebuild-css.sh` before `package-build.mjs`.
+- Tauri/app-context primitives (`DirPicker`, `ToastContainer`) call `@tauri-apps/*` /
+  app context that is absent in headless Chromium — they may floor-card even with an
+  authored preview. Functional-but-placeholder, not broken. If wiring a provider, that's
+  the place to look.
+- The bundle is built from `src/ui` source (not a versioned dist), so any refactor of the
+  barrel or a primitive's props changes the synced contract — rebuild on any `src/ui` change.
+- Remote Google Fonts `@import` means the DS has no shipped `@font-face`; if the app ever
+  self-hosts fonts, add them via `cfg.extraFonts`.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -1,0 +1,29 @@
+{
+  "pkg": "@astro-plan/desktop",
+  "globalName": "PlateVault",
+  "shape": "package",
+  "projectId": "97fa5c7a-8ff3-4331-8f5c-3d5a89635cf4",
+  "srcDir": "src",
+  "tsconfig": "tsconfig.json",
+  "cssEntry": ".ds-css/flattened.css",
+  "readmeHeader": ".design-sync/conventions.md",
+  "componentSrcMap": {
+    "Pill": "src/ui/Pill.tsx",
+    "Btn": "src/ui/Btn.tsx",
+    "Section": "src/ui/Section.tsx",
+    "Box": "src/ui/Box.tsx",
+    "KV": "src/ui/KV.tsx",
+    "EmptyState": "src/ui/EmptyState.tsx",
+    "Table": "src/ui/Table.tsx",
+    "Banner": "src/ui/Banner.tsx",
+    "Toggle": "src/ui/Toggle.tsx",
+    "SegControl": "src/ui/SegControl.tsx",
+    "RadioGroup": "src/ui/RadioGroup.tsx",
+    "CoverageBar": "src/ui/CoverageBar.tsx",
+    "Lock": "src/ui/Lock.tsx",
+    "DirPicker": "src/ui/DirPicker.tsx",
+    "WizardShell": "src/ui/WizardShell.tsx",
+    "ToastContainer": "src/ui/ToastContainer.tsx",
+    "InfoTip": "src/ui/InfoTip.tsx"
+  }
+}

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -1,0 +1,70 @@
+# PlateVault design system — how to build with it
+
+PlateVault is a local-first desktop app for astrophotography library management. Its UI
+is a **token-driven, BEM-class** system: components are plain React styled entirely by CSS
+custom properties and `.alm-*` classes. There is **no styling provider to wrap** — the
+styles ship in `styles.css` (which `@import`s `_ds_bundle.css`); import that once and every
+component and class is styled.
+
+## Theming — set on `<html>`, not via a provider
+
+The default `:root` scope is the light theme. Switch themes by setting a `data-theme`
+attribute on the root element; switch density with a class:
+
+- `data-theme` — `warm-slate`, `warm-clay`, `observatory-dark`, `espresso-dark`
+- density class — `density-compact` or `density-spacious`
+
+Each theme overrides only the raw palette tokens, so everything built with the tokens
+below re-themes automatically. Prefer the two dark themes for a low-light imaging mood.
+
+## Style with `--alm-*` tokens (this is the idiom — use these, don't invent values)
+
+- **Text/ink**: `--alm-ink` (primary), `--alm-ink2`, `--alm-ink3`, `--alm-ink4` (faint)
+- **Surfaces**: `--alm-bg`, `--alm-bg3`, `--alm-chip`, `--alm-hover-bg`, `--alm-selected-bg`
+- **Lines**: `--alm-border`, `--alm-border-subtle`, `--alm-rule`, `--alm-rule2`
+- **Accent**: `--alm-accent`, `--alm-accent-hover`, `--alm-accent-bg`, `--alm-accent-text`,
+  `--alm-on-accent`
+- **Status**: `--alm-ok` / `--alm-danger` / `--alm-info` each with `-bg` and `-border`
+- **Type**: `--alm-font-sans`, `--alm-font-mono`; leading `--alm-leading-tight|normal|relaxed`
+- **Space**: `--alm-sp-0` … `--alm-sp-6` (spacing scale)
+- **Radius**: `--alm-radius-sm|md|lg|pill`
+- **Depth/focus**: `--alm-shadow-sm`, `--alm-focus-ring`
+
+## Component classes (BEM: `.alm-<block>` + `--modifier`)
+
+Prefer the library components below; when writing your own layout glue, reuse these classes:
+
+- `.alm-btn` → `--primary` `--accent` `--danger` `--sm`
+- `.alm-pill` → `--accent` `--ok` `--warn` `--danger` `--info` `--neutral` `--ghost`
+- `.alm-banner` → `--info` `--warn` `--danger`
+- `.alm-toggle`, `.alm-seg`, `.alm-radio` (`.alm-radio-group`, `.alm-radio--active`)
+- `.alm-box`, `.alm-section`, `.alm-kv`, `.alm-empty`, `.alm-coverage`
+
+## Components — `window.PlateVault.*`
+
+Btn, Pill, Banner, Toggle, SegControl, RadioGroup, Table, Box, Section, EmptyState,
+CoverageBar, Lock, DirPicker, WizardShell, InfoTip, ToastContainer, KV. Each component's
+props are in its `<Name>.d.ts` and usage in `<Name>.prompt.md` — read those before
+composing. Data-driven ones (Table, RadioGroup, SegControl, WizardShell) take arrays
+(`columns`/`rows`, `options`, `segments`, `steps`) — always pass real data.
+
+## Where the truth lives
+
+`styles.css` → `_ds_bundle.css` (all `--alm-*` tokens + `.alm-*` classes) is the styling
+source; read it before adding custom CSS. Per-component contracts are the `.d.ts` files.
+
+## One idiomatic snippet
+
+```tsx
+import { Btn, Banner } from 'window.PlateVault'; // provided globally by the DS bundle
+
+<div style={{ display: 'grid', gap: 'var(--alm-sp-3)', padding: 'var(--alm-sp-4)',
+              background: 'var(--alm-bg)', color: 'var(--alm-ink)',
+              fontFamily: 'var(--alm-font-sans)' }}>
+  <Banner variant="info">Calibration frames matched for tonight's session.</Banner>
+  <div style={{ display: 'flex', gap: 'var(--alm-sp-2)' }}>
+    <Btn variant="primary">Review plan</Btn>
+    <button className="alm-btn alm-btn--sm">Later</button>
+  </div>
+</div>
+```

--- a/.design-sync/rebuild-css.sh
+++ b/.design-sync/rebuild-css.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Regenerate the flattened design-system stylesheet that cfg.cssEntry points at.
+# The design-sync converter copies cssEntry VERBATIM (it does not resolve @import),
+# so we pre-flatten reset + tokens + components (the .alm-* classes) into one file.
+# Run this from the repo root BEFORE every `package-build.mjs` run.
+set -euo pipefail
+cd "$(dirname "$0")/.."   # repo root
+
+mkdir -p apps/desktop/.ds-css
+cat > apps/desktop/.ds-css/_aggregate.css <<'CSS'
+@import '../src/styles/reset.css';
+@import '../src/styles/tokens.css';
+@import '../src/styles/components.css';
+CSS
+
+node --input-type=module -e "
+import esbuild from './.ds-sync/node_modules/esbuild/lib/main.js';
+await esbuild.build({
+  entryPoints: ['apps/desktop/.ds-css/_aggregate.css'],
+  bundle: true,
+  outfile: 'apps/desktop/.ds-css/flattened.css',
+  loader: { '.css': 'css' },
+  logLevel: 'warning',
+});
+"
+echo "flattened: $(wc -c < apps/desktop/.ds-css/flattened.css) bytes, \
+$(grep -oc '\.alm-' apps/desktop/.ds-css/flattened.css) .alm- rules"

--- a/.gitignore
+++ b/.gitignore
@@ -371,3 +371,11 @@ apps/desktop/playwright-report/
 
 # Paraglide compiled message catalog (spec 046) — regenerated on build/typecheck
 apps/desktop/src/paraglide/
+
+# design-sync (claude.ai/design) — staged converter, build output, machine state
+.ds-sync/
+ds-bundle/
+.design-sync/.cache/
+.design-sync/learnings/
+.design-sync/node_modules
+apps/desktop/.ds-css/


### PR DESCRIPTION
Adds the reproducible inputs for syncing PlateVault's frontend design system to **Claude Design** (claude.ai/design), so the design agent builds with our real components + `--alm-*` theming instead of generic ones.

## What was synced
- **17 `src/ui` primitives** → importable on `window.PlateVault` (Btn, Pill, Banner, Toggle, SegControl, RadioGroup, Table, Box, Section, EmptyState, CoverageBar, Lock, DirPicker, WizardShell, InfoTip, ToastContainer, KV), built deterministically from real source.
- **Full theming** — all `--alm-*` tokens + `.alm-*` classes + 4 themes (`warm-slate`, `warm-clay`, `observatory-dark`, `espresso-dark`) + density modes.
- Project: https://claude.ai/design/p/97fa5c7a-8ff3-4331-8f5c-3d5a89635cf4

## Files (durable sync inputs only — build output is gitignored)
- `.design-sync/config.json` — package-shape, `src/ui` barrel entry, flattened `cssEntry`, pinned `projectId`.
- `.design-sync/conventions.md` — token/class vocabulary + theme setup; prepended to the DS README and the design agent's prompt.
- `.design-sync/rebuild-css.sh` — pre-flattens `reset + tokens + components` (the converter copies `cssEntry` verbatim and does not resolve `@import`).
- `.design-sync/NOTES.md` — app-not-library entry rationale, KV exclusion, floor-card preview scope, known render warns, re-sync risks.
- `.gitignore` — exclude staged converter + build output.

## Notes
- Previews are **floor cards** (components fully functional; richer previews authored by driving the project in Claude Design).
- **KV** is importable but has no preview card (all-caps name trips the converter's constant filter).
- **RadioGroup / SegControl / Table / WizardShell / ToastContainer** are data-driven — author real props first when enriching.