### PR TITLE
ci(e2e): descope macOS Real-UI to workflow_dispatch, harden diagnostics

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -30,14 +30,21 @@
 #   merge-gating is enforced by branch-protection required checks, not a
 #   cross-workflow `needs` (which GitHub only supports for reusable workflows).
 #
-# macOS leg REMOVED: tauri-plugin-webdriver has no working macOS WebDriver on
-# GitHub runners. The `tauri-webdriver` CLI proxy receives `Connection refused
-# (os error 61)` on every attempt until the 120s session deadline — reproduced
-# identically on every recent run (e.g. CI runs 28712192291 and 28712185403),
-# never a per-PR regression. The upstream plugin's own CI
-# (Choochmeque/tauri-plugin-webdriver) also fails its macos-latest leg on
-# essentially every recent run. This is an upstream/runner-side limitation, not
-# fixable in this repo. Linux + Windows is the supported matrix.
+# macOS leg REMOVED from the default matrix: tauri-plugin-webdriver has no
+# working macOS WebDriver on GitHub runners. The `tauri-webdriver` CLI proxy
+# receives `Connection refused (os error 61)` on every attempt until the 120s
+# session deadline — reproduced identically on every recent run (e.g. CI runs
+# 28712192291 and 28712185403), never a per-PR regression. The upstream
+# plugin's own CI (Choochmeque/tauri-plugin-webdriver) also fails its
+# macos-latest leg on essentially every recent run. This is an
+# upstream/runner-side limitation, not fixable in this repo (full audit:
+# issue #489). Linux + Windows is the supported matrix.
+#
+# A `workflow_dispatch` `run_macos` input can still add macos-latest back for
+# a one-off re-test, WITHOUT `continue-on-error` — a genuine red/green signal
+# so a future upstream fix is discoverable, instead of never re-checking.
+# Layer-1 `cargo test --workspace` (ci.yml) stays required on macOS; only this
+# real-UI WebDriver leg is affected.
 
 name: Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)
 
@@ -46,6 +53,13 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+    inputs:
+      run_macos:
+        description: >-
+          Also run the macOS Real-UI leg (best-effort re-test of issue #489 —
+          no continue-on-error, so this is a genuine signal).
+        type: boolean
+        default: false
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
@@ -73,6 +87,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.decide.outputs.run }}
+      os_matrix: ${{ steps.matrix.outputs.os_matrix }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v4
@@ -111,6 +126,19 @@ jobs:
           fi
           echo "run=$run" >> "$GITHUB_OUTPUT"
           echo "e2e changes: run=$run"
+      # macOS only joins the matrix on an explicit workflow_dispatch with
+      # run_macos=true (see header comment, issue #489) — never on
+      # pull_request/push.
+      - id: matrix
+        shell: bash
+        env:
+          RUN_MACOS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_macos == true }}
+        run: |
+          if [ "$RUN_MACOS" = "true" ]; then
+            echo 'os_matrix=["ubuntu-latest","windows-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
+          else
+            echo 'os_matrix=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT"
+          fi
 
   real-ui-e2e:
     name: Real-UI E2E — ${{ matrix.os }}
@@ -118,8 +146,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: ${{ fromJson(needs.changes.outputs.os_matrix) }}
     runs-on: ${{ matrix.os }}
+    # Backstop beyond nextest's own slow-timeout + the 120s app-launch
+    # deadline: observed full-job durations are ~13-20min on ubuntu/windows
+    # (CI runs 29031373925, 29033234950) and highly variable on macOS
+    # (30-60+min, including the 120s-per-attempt launch-failure loop, issue
+    # #489) when it does run via workflow_dispatch — pick a ceiling with
+    # headroom over the worst observed case rather than the typical one.
+    timeout-minutes: ${{ matrix.os == 'macos-latest' && 60 || 45 }}
 
     steps:
       - uses: actions/checkout@v4
@@ -202,6 +237,8 @@ jobs:
         if: runner.os == 'Linux' && needs.changes.outputs.run == 'true'
         run: xvfb-run -a cargo nextest run -p e2e_tests --profile e2e --run-ignored all --no-tests=warn
 
-      - name: Run E2E (Windows)
+      # Also covers macOS when it joins the matrix via workflow_dispatch
+      # run_macos (header comment) — a dedicated step would be identical.
+      - name: Run E2E (Windows / macOS)
         if: runner.os != 'Linux' && needs.changes.outputs.run == 'true'
         run: cargo nextest run -p e2e_tests --profile e2e --run-ignored all --no-tests=warn

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -31,8 +31,11 @@
 
 #![allow(dead_code)]
 
+use std::collections::VecDeque;
+use std::io::{BufRead, BufReader};
 use std::path::{Path, PathBuf};
-use std::process::{Child, Command};
+use std::process::{Child, Command, Stdio};
+use std::sync::{Arc, Mutex};
 use std::time::{Duration, Instant};
 
 use anyhow::{anyhow, Context, Result};
@@ -203,7 +206,7 @@ impl E2eApp {
         }
         reset_window_state();
 
-        let mut driver_proc = spawn_tauri_webdriver()
+        let (mut driver_proc, proc_log) = spawn_tauri_webdriver()
             .context("failed to spawn the tauri-webdriver CLI on port 4444")?;
 
         let app_binary = app_binary_path()?;
@@ -249,8 +252,9 @@ impl E2eApp {
                             format!(
                                 "WebDriver session not created within {LAUNCH_TIMEOUT:?} \
                                  against {TAURI_WEBDRIVER_URL} — is `tauri-webdriver` \
-                                 running, and was {} built with `--features e2e`?",
-                                app_binary.display()
+                                 running, and was {} built with `--features e2e`?\n{}",
+                                app_binary.display(),
+                                proc_log.dump()
                             )
                         });
                     }
@@ -656,6 +660,54 @@ impl E2eApp {
             ),
             Err(e) => json!({ "dump_testid_diagnostics_execute_error": e.to_string() }),
         }
+    }
+
+    /// Force TanStack Query to invalidate + refetch every query whose key has
+    /// `key_json` (a JSON array literal, e.g. `["sessions"]`) as a prefix, via
+    /// the E2E-only `window.__ALM_E2E__.queryClient` bridge
+    /// (`apps/desktop/src/main.tsx`, `VITE_E2E` gate) — the SAME QueryClient
+    /// instance the mounted page reads from, not a page reload.
+    ///
+    /// Exists because `inventory.reconcile.run` has no frontend invalidation
+    /// hook today (documented KNOWN GAP, `inventory_journeys.rs` module docs;
+    /// `docs/development/orchestration-2026-07-06.md` D13e): a query younger
+    /// than its 30s `staleTime` (`apps/desktop/src/data/queryClient.ts`)
+    /// serves its cached value on remount/refocus WITHOUT a network refetch,
+    /// so a `driver.refresh()` alone is only a reliable proof of freshness if
+    /// the reload fully discarded the prior QueryClient's cache — not
+    /// guaranteed on every WebDriver backend (root cause of the cross-PR
+    /// `reconcile_drops_externally_deleted_frame_from_real_ui_count` flake,
+    /// CI evidence: "last seen: Some(\"2\")" persisting the entire 15s wait,
+    /// only possible from a served-stale-cache render, not a fresh backend
+    /// read). Awaits `invalidateQueries`'s returned promise, which TanStack
+    /// Query resolves only once every currently-active matching query's
+    /// refetch settles, so the caller can assert the freshly-rendered DOM
+    /// immediately after this returns. Test-side workaround only — does not
+    /// substitute for the still-open frontend invalidation-wiring follow-up.
+    pub async fn invalidate_query(&self, key_json: &str) -> Result<()> {
+        let script = format!(
+            r#"
+            var callback = arguments[arguments.length - 1];
+            var e2e = window.__ALM_E2E__;
+            if (!e2e || !e2e.queryClient) {{
+                callback({{ ok: false, error: '__ALM_E2E__.queryClient bridge missing (build with VITE_E2E=1)' }});
+                return;
+            }}
+            e2e.queryClient.invalidateQueries({{ queryKey: {key_json} }}).then(function () {{
+                callback({{ ok: true }});
+            }}).catch(function (err) {{
+                callback({{ ok: false, error: String(err) }});
+            }});
+        "#
+        );
+        let outcome: InvokeOutcome = self
+            .driver
+            .execute_async(&script, vec![])
+            .await
+            .context("invalidate_query execute_async failed")?
+            .convert()
+            .context("failed to deserialise invalidate_query result")?;
+        outcome.into_result::<Value>().map(drop)
     }
 
     /// Drain the last ~30 real browser console entries (chromedriver/
@@ -1362,6 +1414,65 @@ fn app_binary_path() -> Result<PathBuf> {
     Ok(workspace_root.join("target").join("debug").join(binary_name))
 }
 
+/// Cap on buffered lines per stream in [`ProcLog`] — [`E2eApp::launch_with`]'s
+/// failure path is the only reader and only cares about the tail of a
+/// [`LAUNCH_TIMEOUT`]-bounded window, so this stays cheap even if the CLI or
+/// app is chatty for the rest of a long-running journey.
+const DIAGNOSTIC_LOG_LINES: usize = 200;
+
+/// Bounded ring-buffer capture of the `tauri-webdriver` CLI child process's
+/// stdout/stderr, drained continuously by background threads (see
+/// [`drain_into`]) — diagnostics only, never read except on a launch failure
+/// in [`E2eApp::launch_with`]. Previously nothing surfaced whether the app
+/// even started on a launch failure (undiagnosable macOS `Connection refused`
+/// runs, issue #489); the CLI's own child (`desktop_shell`) inherits stdio
+/// from the CLI by default, so piping the CLI's streams transitively
+/// captures the app's own console output too, not just the CLI's log.
+struct ProcLog {
+    stdout: Arc<Mutex<VecDeque<String>>>,
+    stderr: Arc<Mutex<VecDeque<String>>>,
+}
+
+impl ProcLog {
+    fn dump(&self) -> String {
+        format!(
+            "--- tauri-webdriver CLI stdout (last {DIAGNOSTIC_LOG_LINES} lines; \
+             desktop_shell inherits this fd by default, so its own console output \
+             normally appears here too) ---\n{}\n\
+             --- tauri-webdriver CLI stderr ---\n{}",
+            Self::render(&self.stdout),
+            Self::render(&self.stderr),
+        )
+    }
+
+    fn render(buf: &Arc<Mutex<VecDeque<String>>>) -> String {
+        let lines = buf.lock().unwrap();
+        if lines.is_empty() {
+            "<empty>".to_owned()
+        } else {
+            lines.iter().cloned().collect::<Vec<_>>().join("\n")
+        }
+    }
+}
+
+/// Spawn a background thread draining `reader` line-by-line into `buf`
+/// (bounded to [`DIAGNOSTIC_LOG_LINES`]). Draining is mandatory, not just for
+/// diagnostics: an unread OS pipe fills and blocks the writing process once
+/// its buffer is full, which would hang the CLI — and therefore the app it
+/// launched — mid-journey, long after a successful launch moved past the
+/// code that reads this buffer's contents.
+fn drain_into<R: std::io::Read + Send + 'static>(reader: R, buf: Arc<Mutex<VecDeque<String>>>) {
+    std::thread::spawn(move || {
+        for line in BufReader::new(reader).lines().map_while(Result::ok) {
+            let mut buf = buf.lock().unwrap();
+            if buf.len() >= DIAGNOSTIC_LOG_LINES {
+                buf.pop_front();
+            }
+            buf.push_back(line);
+        }
+    });
+}
+
 /// Spawn the `tauri-webdriver` CLI proxy as a background child process.
 ///
 /// Mirrors `.github/workflows/e2e.yml`: the CLI is installed once
@@ -1369,19 +1480,36 @@ fn app_binary_path() -> Result<PathBuf> {
 /// session. `--port`/`--native-port` are passed explicitly even though they
 /// match the CLI's and plugin's defaults, so a future default change upstream
 /// doesn't silently break the pairing.
-fn spawn_tauri_webdriver() -> Result<Child> {
-    Command::new("tauri-webdriver")
+///
+/// stdout/stderr are piped (not inherited) and drained into a [`ProcLog`] so
+/// a launch failure can print what the CLI (and transitively, the app it
+/// launched) actually did — see [`ProcLog`]'s docs.
+fn spawn_tauri_webdriver() -> Result<(Child, ProcLog)> {
+    let mut child = Command::new("tauri-webdriver")
         .arg("--port")
         .arg("4444")
         .arg("--native-port")
         .arg("4445")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
         .spawn()
         .map_err(|e| {
             anyhow!(
                 "failed to spawn tauri-webdriver: {e} \
                  (install with `cargo install tauri-webdriver --locked`)"
             )
-        })
+        })?;
+
+    let stdout_buf = Arc::new(Mutex::new(VecDeque::new()));
+    let stderr_buf = Arc::new(Mutex::new(VecDeque::new()));
+    if let Some(stdout) = child.stdout.take() {
+        drain_into(stdout, stdout_buf.clone());
+    }
+    if let Some(stderr) = child.stderr.take() {
+        drain_into(stderr, stderr_buf.clone());
+    }
+
+    Ok((child, ProcLog { stdout: stdout_buf, stderr: stderr_buf }))
 }
 
 /// Reset the application database so each test starts from a clean state.

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -668,25 +668,30 @@ impl E2eApp {
     /// (`apps/desktop/src/main.tsx`, `VITE_E2E` gate) — the SAME QueryClient
     /// instance the mounted page reads from, not a page reload.
     ///
-    /// Exists because `inventory.reconcile.run` has no frontend invalidation
-    /// hook today (documented KNOWN GAP, `inventory_journeys.rs` module docs;
-    /// `docs/development/orchestration-2026-07-06.md` D13e): a query younger
-    /// than its 30s `staleTime` (`apps/desktop/src/data/queryClient.ts`)
-    /// serves its cached value on remount/refocus WITHOUT a network refetch,
-    /// so a `driver.refresh()` alone is only a reliable proof of freshness if
-    /// the reload fully discarded the prior QueryClient's cache — not
-    /// guaranteed on every WebDriver backend (root cause of the cross-PR
+    /// Exists because a query younger than its 30s `staleTime`
+    /// (`apps/desktop/src/data/queryClient.ts`) serves its cached value on
+    /// remount/refocus WITHOUT a network refetch, so a `driver.refresh()`
+    /// alone is only a reliable proof of freshness if the reload fully
+    /// discarded the prior QueryClient's cache — not guaranteed on every
+    /// WebDriver backend (root cause of the cross-PR
     /// `reconcile_drops_externally_deleted_frame_from_real_ui_count` flake,
     /// CI evidence: "last seen: Some(\"2\")" persisting the entire 15s wait,
     /// only possible from a served-stale-cache render, not a fresh backend
     /// read). Awaits `invalidateQueries`'s returned promise, which TanStack
     /// Query resolves only once every currently-active matching query's
     /// refetch settles, so the caller can assert the freshly-rendered DOM
-    /// immediately after this returns. Test-side workaround only — does not
-    /// substitute for the still-open frontend invalidation-wiring follow-up
-    /// (lane nD, PR #517, adds `sessions.all` + `inventory` prefix
-    /// invalidation on reconcile completion); remove this call once that
-    /// lands and `driver.refresh()` alone proves sufficient again.
+    /// immediately after this returns.
+    ///
+    /// Lane nD's frontend reconcile invalidation (PR #517, MERGED) wires
+    /// `sessions.all` + `inventory` prefix invalidation into the real
+    /// "Reconcile" button's click handler
+    /// (`apps/desktop/src/features/settings/DataSources.tsx::handleReconcile`)
+    /// — but this journey triggers `inventory.reconcile.run` directly over
+    /// the invoke bridge (documented KNOWN GAP, no UI trigger for that path),
+    /// which #517's handler never runs. This call is now belt-and-braces
+    /// rather than the only fix for a known-missing product hook; keep it
+    /// until the bridge-triggered path has a few weeks of green CI, then
+    /// re-evaluate whether `driver.refresh()` alone is sufficient.
     pub async fn invalidate_query(&self, key_json: &str) -> Result<()> {
         let script = format!(
             r#"

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -683,7 +683,10 @@ impl E2eApp {
     /// Query resolves only once every currently-active matching query's
     /// refetch settles, so the caller can assert the freshly-rendered DOM
     /// immediately after this returns. Test-side workaround only — does not
-    /// substitute for the still-open frontend invalidation-wiring follow-up.
+    /// substitute for the still-open frontend invalidation-wiring follow-up
+    /// (lane nD, PR #517, adds `sessions.all` + `inventory` prefix
+    /// invalidation on reconcile completion); remove this call once that
+    /// lands and `driver.refresh()` alone proves sufficient again.
     pub async fn invalidate_query(&self, key_json: &str) -> Result<()> {
         let script = format!(
             r#"

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -349,6 +349,9 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
     // WebDriver backend; explicitly invalidating the exact query the picker
     // reads removes the dependency on the reload actually having discarded
     // the 30s-`staleTime` cache (`E2eApp::invalidate_query` doc comment).
+    // Removable once lane nD's frontend reconcile-invalidation (PR #517,
+    // `sessions.all` + `inventory` prefix invalidation on reconcile
+    // completion) lands and `driver.refresh()` alone is sufficient again.
     app.invalidate_query(r#"["sessions"]"#).await?;
 
     let frames_after = app

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -340,6 +340,17 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
         .await?
         .click()
         .await?;
+
+    // Deterministic fix for the cross-PR flake (CI evidence: "last seen:
+    // Some(\"2\")" surviving the full 15s wait — only possible from a
+    // served-stale-cache render, since step 5b above already proved a fresh
+    // backend read returns 1). `driver.refresh()` above is meant to force a
+    // fresh QueryClient, but is not a guaranteed proof of that on every
+    // WebDriver backend; explicitly invalidating the exact query the picker
+    // reads removes the dependency on the reload actually having discarded
+    // the 30s-`staleTime` cache (`E2eApp::invalidate_query` doc comment).
+    app.invalidate_query(r#"["sessions"]"#).await?;
+
     let frames_after = app
         .wait_testid_text(
             &format!("session-picker-frames-{session_id}"),

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -349,9 +349,12 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
     // WebDriver backend; explicitly invalidating the exact query the picker
     // reads removes the dependency on the reload actually having discarded
     // the 30s-`staleTime` cache (`E2eApp::invalidate_query` doc comment).
-    // Removable once lane nD's frontend reconcile-invalidation (PR #517,
-    // `sessions.all` + `inventory` prefix invalidation on reconcile
-    // completion) lands and `driver.refresh()` alone is sufficient again.
+    // Lane nD's frontend reconcile invalidation (PR #517, MERGED) wires this
+    // same invalidation into the real "Reconcile" button's click handler, but
+    // this journey calls `inventory_reconcile_run` directly over the invoke
+    // bridge (no UI trigger for that path, module docs' KNOWN GAP) — #517
+    // does not cover it. Belt-and-braces now rather than the only fix; drop
+    // once the bridge-triggered path has a few weeks of green CI.
     app.invalidate_query(r#"["sessions"]"#).await?;
 
     let frames_after = app


### PR DESCRIPTION
## Summary

- `e2e.yml`: macOS Real-UI removed from the PR/push matrix (issue #489 —
  upstream `tauri-plugin-webdriver` never becomes reachable on
  `macos-latest` runners). Added a `workflow_dispatch` `run_macos` boolean
  input that runs the macOS leg WITHOUT `continue-on-error` — a true
  red/green signal for future upstream re-tests, computed via a new
  `changes` job output (`os_matrix`) consumed by `strategy.matrix.os`.
- `e2e.yml`: added `timeout-minutes` (45 ubuntu/windows, 60 macOS) as a
  job-level backstop beyond nextest's slow-timeout + the 120s launch
  deadline.
- `crates/e2e-tests/tests/common/mod.rs`: `spawn_tauri_webdriver` now pipes
  (rather than inherits) the CLI's stdout/stderr into a bounded ring buffer,
  drained continuously by background threads (mandatory — an unread pipe
  blocks the writer). On a WebDriver session-creation failure, the buffered
  CLI output is dumped in the error context — `desktop_shell` inherits stdio
  from the CLI by default, so this transitively surfaces whether the app
  even started, which nothing did before (the macOS failure was
  undiagnosable).
- Stabilized the intermittent
  `reconcile_drops_externally_deleted_frame_from_real_ui_count` cross-PR
  flake (CI evidence: `text of data-testid=session-picker-frames-<uuid>
  never matched within 15s (last seen: Some("2"))`). Root cause: a
  served-stale-cache render, not a slow backend — the step-5b `sessions_list`
  poll already proves the backend settles to `frameCount=1` before the UI
  reload, so a persisted "2" for the full 15s can only come from
  `SessionSourcePicker`'s query (30s `staleTime`,
  `apps/desktop/src/data/queryClient.ts`) being served from cache without a
  refetch — `inventory.reconcile.run` has no frontend invalidation hook
  (documented KNOWN GAP; also `docs/development/orchestration-2026-07-06.md`
  D13e, where an earlier round added the `driver.refresh()` this test already
  has, evidently not reliably enough). Fixed test-side: force a real refetch
  via the existing E2E-only `window.__ALM_E2E__.queryClient` bridge
  (`E2eApp::invalidate_query`) right before the AFTER read, removing the
  dependency on `driver.refresh()` having fully discarded the prior
  QueryClient's cache. **Does not touch product code** — a frontend
  invalidation-on-reconcile fix is lane `nD`'s item; this test's wait window
  can shrink once that lands.
- `.config/nextest.toml`: left `retries = 1` unchanged — the retry-cost
  concern for macOS was the reason to reconsider it, and macOS no longer
  runs on PRs, so it's moot; nothing else here looked objectively wrong.

## Docs coordination

The removed header comment referenced `docs/development/testing.md`'s
"best-effort on macOS" line — that doc is now stale (should read
"disabled on PRs, `workflow_dispatch` re-test only, tracked in #489").
Lane `nE` owns `testing.md`.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -p e2e_tests --tests --no-deps` (clean)
- [x] `cargo nextest run -p e2e_tests --no-run` (compiles; journeys are
      `#[ignore]`d)
- [x] `actionlint .github/workflows/e2e.yml` (clean) + YAML parse
- [ ] Reconcile journey loop (5-10x) — **not run**: this sandbox shares a
      network namespace with other concurrent agents and port 5173 was
      already bound by another process (a dev server, not `vite preview`)
      outside this container's visibility/control; running against it would
      have been unsafe/meaningless. CI on this PR (ubuntu + windows Real-UI)
      is the flake evidence.