### PR TITLE
ci(release): use shared release App instead of NIGHTWATCH_APP_*

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -44,20 +44,21 @@ jobs:
       tag_name: ${{ steps.release.outputs.tag_name }}
       release_body: ${{ steps.release.outputs.body }}
     steps:
-      # Mint a short-lived GitHub App installation token from the org-owned
-      # `nightwatch-astro-ci` app (contents:write + pull_requests:write). This
-      # is the cross-org-correct identity: unlike a personal PAT it needs no
-      # org approval and no lifetime management, and unlike the default
-      # GITHUB_TOKEN its releases/tags DO trigger downstream workflows
-      # (release-gate on `push: tags`) and its PR checks are not held as
-      # `action_required`. Requires the NIGHTWATCH_APP_ID / _PRIVATE_KEY org
-      # secrets to be visible to this repo and the app installed on it.
+      # Mint a short-lived GitHub App installation token from the shared org
+      # release app (contents:write + pull_requests:write). This is the
+      # cross-org-correct identity: unlike a personal PAT it needs no org
+      # approval and no lifetime management, and unlike the default GITHUB_TOKEN
+      # its releases/tags DO trigger downstream workflows (release-gate on
+      # `push: tags`) and its PR checks are not held as `action_required`.
+      # Credentials are provisioned org-wide (visibility=all):
+      #   RELEASE_APP_CLIENT_ID  — Actions variable
+      #   RELEASE_APP_PRIVATE_KEY — Actions secret
       - name: Mint release-please app token
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
-          private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+          app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - name: Run release-please
         id: release


### PR DESCRIPTION
## Summary

- Replaces `secrets.NIGHTWATCH_APP_ID` / `secrets.NIGHTWATCH_APP_PRIVATE_KEY` in the `Mint release-please app token` step of `release-please.yml` with the shared org-wide release App credentials already provisioned on the `nightwatch-astro` org (visibility=all).
- `app-id` now reads from `vars.RELEASE_APP_CLIENT_ID` (Actions variable); `private-key` now reads from `secrets.RELEASE_APP_PRIVATE_KEY` (Actions secret).
- The step `id: app-token` and all downstream `steps.app-token.outputs.token` references are unchanged.
- `release-gate.yml` has no `create-github-app-token` step and required no changes.
- `actionlint` passes with no errors.

## Why

Consolidates credential management onto the shared org release App so this repo no longer needs its own `NIGHTWATCH_APP_*` secrets. The old `NIGHTWATCH_APP_ID` and `NIGHTWATCH_APP_PRIVATE_KEY` secrets are now unused and can be removed from org/repo secret settings at any time.

## Test plan

- [ ] CI on this PR passes (the workflow itself is not triggered on PRs, but any lint/syntax gates should be green)
- [ ] After merge, the next push to `main` triggers `release-please.yml` and the `Mint release-please app token` step succeeds using `vars.RELEASE_APP_CLIENT_ID` + `secrets.RELEASE_APP_PRIVATE_KEY`