### PR TITLE
refactor: move targets-ingest database queries behind the persistence layer

### DIFF
--- a/crates/app/targets/src/frame_writer.rs
+++ b/crates/app/targets/src/frame_writer.rs
@@ -14,10 +14,11 @@ use std::path::Path;
 use sqlx::SqlitePool;
 use time::format_description::well_known::Iso8601;
 use time::OffsetDateTime;
-use uuid::Uuid;
 
 use contracts_core::error_code::ErrorCode;
 use contracts_core::{ContractError, ErrorSeverity};
+
+use persistence_db::repositories::q_targets_ingest as repo;
 
 fn db_err(e: impl std::fmt::Display) -> ContractError {
     ContractError::new(ErrorCode::InternalDatabase, e.to_string(), ErrorSeverity::Fatal, true)
@@ -61,50 +62,9 @@ pub async fn upsert_frame_record(
     mtime: &str,
     state: &str,
 ) -> Result<String, ContractError> {
-    if let Some((id,)) = sqlx::query_as::<_, (String,)>(
-        "SELECT id FROM file_record WHERE root_id = ? AND relative_path = ?",
-    )
-    .bind(root_id)
-    .bind(relative_path)
-    .fetch_optional(pool)
-    .await
-    .map_err(db_err)?
-    {
-        sqlx::query(
-            "UPDATE file_record
-             SET state = ?, size_bytes = ?, mtime = ?, last_seen_at = ?
-             WHERE id = ?",
-        )
-        .bind(state)
-        .bind(size_bytes)
-        .bind(mtime)
-        .bind(OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default())
-        .bind(&id)
-        .execute(pool)
+    repo::upsert_file_record(pool, root_id, relative_path, size_bytes, mtime, state)
         .await
-        .map_err(db_err)?;
-        return Ok(id);
-    }
-
-    let id = Uuid::new_v4().to_string();
-    let now = OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default();
-    sqlx::query(
-        "INSERT INTO file_record
-            (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-    )
-    .bind(&id)
-    .bind(root_id)
-    .bind(relative_path)
-    .bind(size_bytes)
-    .bind(mtime)
-    .bind(state)
-    .bind(&now)
-    .bind(&now)
-    .execute(pool)
-    .await
-    .map_err(db_err)?;
-    Ok(id)
+        .map_err(db_err)
 }
 
 #[cfg(test)]

--- a/crates/app/targets/src/ingest_resolution.rs
+++ b/crates/app/targets/src/ingest_resolution.rs
@@ -31,6 +31,7 @@
 use audit::event_bus::{TargetResolveBatchCompleted, TargetResolved};
 use audit::{EventBus, Source};
 use domain_core::ids::Timestamp;
+use persistence_db::repositories::q_targets_ingest as repo;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -77,16 +78,6 @@ pub enum AssociateOutcome {
     Enqueued,
 }
 
-/// A pending ingest-resolution row (the drain's work item). The image is
-/// already linked on the row via `image_id`; the drain only needs the row `id`
-/// (to update state/target), the `object_raw` (to resolve), and `attempts`.
-#[derive(Clone, Debug)]
-struct PendingRow {
-    id: String,
-    object_raw: String,
-    attempts: i64,
-}
-
 // ── enqueue / inline association (T025 + T026 entry point) ──────────────────────
 
 /// Insert a `pending` ingest-resolution row for `(image_id, object_raw)`.
@@ -103,29 +94,16 @@ pub async fn enqueue(
     object_raw: &str,
 ) -> Result<String, ContractError> {
     // Reuse an existing non-terminal row for the same (image, object) if present.
-    let existing: Option<(String,)> = sqlx::query_as(
-        "SELECT id FROM ingest_resolution WHERE image_id = ? AND object_raw = ? LIMIT 1",
-    )
-    .bind(image_id)
-    .bind(object_raw)
-    .fetch_optional(pool)
-    .await
-    .map_err(db_err)?;
-    if let Some((id,)) = existing {
+    if let Some(id) =
+        repo::find_ingest_resolution_id(pool, image_id, object_raw).await.map_err(db_err)?
+    {
         return Ok(id);
     }
 
     let id = Uuid::new_v4().to_string();
-    sqlx::query(
-        "INSERT INTO ingest_resolution (id, image_id, object_raw, state, target_id, attempts)
-         VALUES (?, ?, ?, 'pending', NULL, 0)",
-    )
-    .bind(&id)
-    .bind(image_id)
-    .bind(object_raw)
-    .execute(pool)
-    .await
-    .map_err(db_err)?;
+    repo::insert_ingest_resolution(pool, &id, image_id, object_raw, "pending", None)
+        .await
+        .map_err(db_err)?;
     Ok(id)
 }
 
@@ -177,32 +155,20 @@ async fn write_resolved_row(
     object_raw: &str,
     target_id: &str,
 ) -> Result<(), ContractError> {
-    let existing: Option<(String,)> = sqlx::query_as(
-        "SELECT id FROM ingest_resolution WHERE image_id = ? AND object_raw = ? LIMIT 1",
-    )
-    .bind(image_id)
-    .bind(object_raw)
-    .fetch_optional(pool)
-    .await
-    .map_err(db_err)?;
+    let existing =
+        repo::find_ingest_resolution_id(pool, image_id, object_raw).await.map_err(db_err)?;
 
-    if let Some((id,)) = existing {
-        sqlx::query("UPDATE ingest_resolution SET state = 'resolved', target_id = ? WHERE id = ?")
-            .bind(target_id)
-            .bind(&id)
-            .execute(pool)
-            .await
-            .map_err(db_err)?;
+    if let Some(id) = existing {
+        repo::mark_ingest_resolution_resolved(pool, &id, target_id).await.map_err(db_err)?;
     } else {
-        sqlx::query(
-            "INSERT INTO ingest_resolution (id, image_id, object_raw, state, target_id, attempts)
-             VALUES (?, ?, ?, 'resolved', ?, 0)",
+        repo::insert_ingest_resolution(
+            pool,
+            &Uuid::new_v4().to_string(),
+            image_id,
+            object_raw,
+            "resolved",
+            Some(target_id),
         )
-        .bind(Uuid::new_v4().to_string())
-        .bind(image_id)
-        .bind(object_raw)
-        .bind(target_id)
-        .execute(pool)
         .await
         .map_err(db_err)?;
     }
@@ -250,22 +216,7 @@ pub async fn resolve_pending<R: Resolver + ?Sized>(
     limit: usize,
 ) -> Result<DrainSummary, ContractError> {
     let limit_i = i64::try_from(limit.max(1)).unwrap_or(i64::MAX);
-    let rows: Vec<(String, String, i64)> = sqlx::query_as(
-        "SELECT id, object_raw, attempts
-         FROM ingest_resolution
-         WHERE state = 'pending'
-         ORDER BY rowid ASC
-         LIMIT ?",
-    )
-    .bind(limit_i)
-    .fetch_all(pool)
-    .await
-    .map_err(db_err)?;
-
-    let pending: Vec<PendingRow> = rows
-        .into_iter()
-        .map(|(id, object_raw, attempts)| PendingRow { id, object_raw, attempts })
-        .collect();
+    let pending = repo::list_pending_ingest_resolutions(pool, limit_i).await.map_err(db_err)?;
 
     let considered = pending.len();
     let mut num_resolved = 0usize;
@@ -352,13 +303,7 @@ async fn mark_resolved(
     row_id: &str,
     target_id: &str,
 ) -> Result<(), ContractError> {
-    sqlx::query("UPDATE ingest_resolution SET state = 'resolved', target_id = ? WHERE id = ?")
-        .bind(target_id)
-        .bind(row_id)
-        .execute(pool)
-        .await
-        .map_err(db_err)?;
-    Ok(())
+    repo::mark_ingest_resolution_resolved(pool, row_id, target_id).await.map_err(db_err)
 }
 
 async fn mark_unresolved(
@@ -366,13 +311,7 @@ async fn mark_unresolved(
     row_id: &str,
     attempts: i64,
 ) -> Result<(), ContractError> {
-    sqlx::query("UPDATE ingest_resolution SET state = 'unresolved', attempts = ? WHERE id = ?")
-        .bind(attempts + 1)
-        .bind(row_id)
-        .execute(pool)
-        .await
-        .map_err(db_err)?;
-    Ok(())
+    repo::mark_ingest_resolution_unresolved(pool, row_id, attempts).await.map_err(db_err)
 }
 
 async fn emit_resolved(bus: &EventBus, target: &CachedTarget, query: Option<&str>) {

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -65,6 +65,8 @@ use metadata_core::{MetadataExtractor, RawFileMetadata};
 use metadata_fits::FitsExtractor;
 use metadata_xisf::XisfExtractor;
 use persistence_db::repositories::projects as repo_projects;
+use persistence_db::repositories::q_targets_ingest as repo;
+use persistence_db::repositories::{first_run, inventory};
 use sessions::{session_key, ObserverContext};
 use sqlx::SqlitePool;
 use time::format_description::well_known::Iso8601;
@@ -125,28 +127,17 @@ pub async fn ingest_light_frames(
     // Applied move/catalogue items with a destination root + path. Item type is
     // filtered to light frames below (by reading the FITS header), so calibration
     // moves are excluded even though they share the `move` action.
-    let rows: Vec<(Option<String>, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT to_root_id, to_relative_path, from_root_id, from_relative_path
-         FROM plan_items
-         WHERE plan_id = ?
-           AND action IN ('move', 'catalogue')
-           AND item_state = 'succeeded'
-         ORDER BY item_index ASC",
-    )
-    .bind(plan_id)
-    .fetch_all(pool)
-    .await
-    .map_err(db_err)?;
+    let rows = repo::list_applied_light_plan_items(pool, plan_id).await.map_err(db_err)?;
 
     let mut summary = IngestSummary::default();
 
-    for (to_root_id, to_rel, from_root_id, from_rel) in rows {
+    for row in rows {
         // Catalogue-in-place keeps the file at its source; a move lands it at the
         // destination. Prefer the destination, falling back to the source root
         // when the item carries no `to_root_id` (older/catalogue rows).
-        let (root_id, relative_path) = match (to_root_id, from_root_id) {
-            (Some(r), _) if !to_rel.is_empty() => (r, to_rel),
-            (_, Some(r)) => (r, from_rel),
+        let (root_id, relative_path) = match (row.to_root_id, row.from_root_id) {
+            (Some(r), _) if !row.to_relative_path.is_empty() => (r, row.to_relative_path),
+            (_, Some(r)) => (r, row.from_relative_path),
             _ => continue,
         };
         let item = AppliedItem { root_id, relative_path };
@@ -275,36 +266,21 @@ pub async fn ensure_library_root(
     pool: &SqlitePool,
     root_id: &str,
 ) -> Result<Option<String>, ContractError> {
-    if let Some((path,)) =
-        sqlx::query_as::<_, (String,)>("SELECT current_path FROM library_root WHERE id = ?")
-            .bind(root_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(db_err)?
-    {
+    if let Some(path) = inventory::get_library_root_path(pool, root_id).await.map_err(db_err)? {
         return Ok(Some(path));
     }
 
-    let Some((path,)) =
-        sqlx::query_as::<_, (String,)>("SELECT path FROM registered_sources WHERE id = ?")
-            .bind(root_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(db_err)?
-    else {
+    let Some(path) = first_run::get_source_path(pool, root_id).await.map_err(db_err)? else {
         return Ok(None);
     };
 
     // Mirror into library_root with the SAME id so the file_record FK holds.
-    sqlx::query(
-        "INSERT OR IGNORE INTO library_root (id, label, current_path, kind, state, created_at)
-         VALUES (?, ?, ?, 'local', 'active', ?)",
+    repo::insert_library_root_mirror(
+        pool,
+        root_id,
+        &path,
+        &OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default(),
     )
-    .bind(root_id)
-    .bind(root_id)
-    .bind(&path)
-    .bind(OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default())
-    .execute(pool)
     .await
     .map_err(db_err)?;
 
@@ -396,73 +372,52 @@ async fn upsert_session(
     image_id: &str,
     root_id: &str,
 ) -> Result<(), ContractError> {
-    if let Some((id, frame_ids_json, existing_target)) = sqlx::query_as::<
-        _,
-        (String, String, Option<String>),
-    >(
-        "SELECT id, frame_ids, canonical_target_id FROM acquisition_session WHERE session_key = ?",
-    )
-    .bind(key)
-    .fetch_optional(pool)
-    .await
-    .map_err(db_err)?
+    if let Some(existing) =
+        repo::find_acquisition_session_by_key(pool, key).await.map_err(db_err)?
     {
         let mut frames: BTreeSet<String> =
-            serde_json::from_str(&frame_ids_json).unwrap_or_default();
+            serde_json::from_str(&existing.frame_ids).unwrap_or_default();
         frames.insert(image_id.to_owned());
         let frames_json =
             serde_json::to_string(&frames.into_iter().collect::<Vec<_>>()).map_err(db_err)?;
 
         // Back-fill the link if it resolved this pass and the row had none.
-        if existing_target.is_none() && canonical_target_id.is_some() {
-            sqlx::query(
-                "UPDATE acquisition_session \
-                 SET frame_ids = ?, canonical_target_id = ?, root_id = COALESCE(root_id, ?) \
-                 WHERE id = ?",
-            )
-            .bind(&frames_json)
-            .bind(canonical_target_id)
-            .bind(root_id)
-            .bind(&id)
-            .execute(pool)
-            .await
-            .map_err(db_err)?;
-            // T075/FR-052: newly resolved on this session → propagate to any
-            // linked project.
-            if let Some(target_id) = canonical_target_id {
-                propagate_target_to_projects(pool, &id, target_id).await?;
+        match (existing.canonical_target_id.is_none(), canonical_target_id) {
+            (true, Some(target_id)) => {
+                repo::append_acquisition_session_frames_with_target(
+                    pool,
+                    &existing.id,
+                    &frames_json,
+                    target_id,
+                    root_id,
+                )
+                .await
+                .map_err(db_err)?;
+                // T075/FR-052: newly resolved on this session → propagate to any
+                // linked project.
+                propagate_target_to_projects(pool, &existing.id, target_id).await?;
             }
-        } else {
-            sqlx::query(
-                "UPDATE acquisition_session \
-                 SET frame_ids = ?, root_id = COALESCE(root_id, ?) WHERE id = ?",
-            )
-            .bind(&frames_json)
-            .bind(root_id)
-            .bind(&id)
-            .execute(pool)
-            .await
-            .map_err(db_err)?;
+            _ => {
+                repo::append_acquisition_session_frames(pool, &existing.id, &frames_json, root_id)
+                    .await
+                    .map_err(db_err)?;
+            }
         }
         return Ok(());
     }
 
     let id = Uuid::new_v4().to_string();
     let frames_json = serde_json::to_string(&[image_id]).map_err(db_err)?;
-    sqlx::query(
-        "INSERT INTO acquisition_session
-            (id, session_key, target_id, canonical_target_id, has_observer_location,
-             frame_ids, observer_location, root_id, created_at)
-         VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ?)",
+    repo::insert_acquisition_session(
+        pool,
+        &id,
+        key,
+        canonical_target_id,
+        has_observer_location,
+        &frames_json,
+        root_id,
+        &OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default(),
     )
-    .bind(&id)
-    .bind(key)
-    .bind(canonical_target_id)
-    .bind(i64::from(has_observer_location))
-    .bind(&frames_json)
-    .bind(root_id)
-    .bind(OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default())
-    .execute(pool)
     .await
     .map_err(db_err)?;
 
@@ -522,43 +477,26 @@ async fn propagate_target_to_projects(
 /// Returns [`ContractError`] (`internal.database`) on a query failure.
 pub async fn backfill_session_targets(pool: &SqlitePool) -> Result<usize, ContractError> {
     // Map of image_id → resolved canonical target id (only resolved rows).
-    let resolved: Vec<(String, String)> = sqlx::query_as(
-        "SELECT image_id, target_id
-         FROM ingest_resolution
-         WHERE state = 'resolved' AND target_id IS NOT NULL",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(db_err)?;
+    let resolved = repo::list_resolved_ingest_resolutions(pool).await.map_err(db_err)?;
     if resolved.is_empty() {
         return Ok(0);
     }
-    let resolved: std::collections::HashMap<String, String> = resolved.into_iter().collect();
+    let resolved: std::collections::HashMap<String, String> =
+        resolved.into_iter().map(|r| (r.image_id, r.target_id)).collect();
 
-    let unlinked: Vec<(String, String)> = sqlx::query_as(
-        "SELECT id, frame_ids FROM acquisition_session WHERE canonical_target_id IS NULL",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(db_err)?;
+    let unlinked = repo::list_unlinked_acquisition_sessions(pool).await.map_err(db_err)?;
 
     let mut linked = 0usize;
-    for (session_id, frame_ids_json) in unlinked {
-        let frames: Vec<String> = serde_json::from_str(&frame_ids_json).unwrap_or_default();
+    for session in unlinked {
+        let frames: Vec<String> = serde_json::from_str(&session.frame_ids).unwrap_or_default();
         let Some(target_id) = frames.iter().find_map(|f| resolved.get(f)) else {
             continue;
         };
-        sqlx::query(
-            "UPDATE acquisition_session SET canonical_target_id = ?
-             WHERE id = ? AND canonical_target_id IS NULL",
-        )
-        .bind(target_id)
-        .bind(&session_id)
-        .execute(pool)
-        .await
-        .map_err(db_err)?;
+        repo::set_acquisition_session_canonical_target_if_null(pool, &session.id, target_id)
+            .await
+            .map_err(db_err)?;
         // T075/FR-052: newly resolved via back-fill → propagate.
-        propagate_target_to_projects(pool, &session_id, target_id).await?;
+        propagate_target_to_projects(pool, &session.id, target_id).await?;
         linked += 1;
     }
     Ok(linked)

--- a/crates/persistence/db/src/repositories/q_targets_ingest.rs
+++ b/crates/persistence/db/src/repositories/q_targets_ingest.rs
@@ -1,3 +1,471 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_targets_ingest`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Repository query functions for the spec-035/048 light-frame ingest
+//! pipeline (`app_core_targets::frame_writer` / `ingest_resolution` /
+//! `ingest_sessions`).
+//!
+//! Covers three tables:
+//! - `file_record` — per-frame upsert keyed by UNIQUE `(root_id,
+//!   relative_path)` (spec 048 T002).
+//! - `ingest_resolution` — the async FITS `OBJECT` → `canonical_target`
+//!   resolution queue (spec 035 US4).
+//! - `acquisition_session` — light frames grouped by capture identity
+//!   (spec 035 US4 / spec 041 FR-051/FR-052), plus `plan_items` reads that
+//!   drive ingest and `ingest_resolution` reads that drive back-fill.
+//!
+//! Business logic (session-key derivation, target association, propagation
+//! to linked projects) stays in `app_core_targets`; this module is query/exec
+//! only. `library_root`/`registered_sources` root-path lookups reuse
+//! [`crate::repositories::inventory::get_library_root_path`] and
+//! [`crate::repositories::first_run::get_source_path`] rather than
+//! duplicating them.
+//!
+//! Constitution §I: read/write SQLite metadata only; no filesystem mutations.
+//! Constitution §V: SQLite is the durable record.
+
+use sqlx::SqlitePool;
+use time::format_description::well_known::Iso8601;
+use time::OffsetDateTime;
+use uuid::Uuid;
+
+use crate::DbResult;
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+/// Internal row for the `file_record` id lookup in [`upsert_file_record`].
+#[derive(Debug, Clone, sqlx::FromRow)]
+struct FileRecordIdRow {
+    id: String,
+}
+
+/// A pending `ingest_resolution` row (the drain's work item).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct PendingIngestResolutionRow {
+    pub id: String,
+    pub object_raw: String,
+    pub attempts: i64,
+}
+
+/// Applied `plan_items` row read by [`list_applied_light_plan_items`].
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AppliedPlanItemRow {
+    pub to_root_id: Option<String>,
+    pub to_relative_path: String,
+    pub from_root_id: Option<String>,
+    pub from_relative_path: String,
+}
+
+/// An `acquisition_session` row keyed by `session_key`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AcquisitionSessionByKeyRow {
+    pub id: String,
+    pub frame_ids: String,
+    pub canonical_target_id: Option<String>,
+}
+
+/// A resolved `ingest_resolution` row (`image_id` → `target_id`).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ResolvedIngestResolutionRow {
+    pub image_id: String,
+    pub target_id: String,
+}
+
+/// An `acquisition_session` row with no `canonical_target_id` set yet.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct UnlinkedAcquisitionSessionRow {
+    pub id: String,
+    pub frame_ids: String,
+}
+
+// ── file_record ──────────────────────────────────────────────────────────────
+
+/// Upsert a `file_record` by its UNIQUE `(root_id, relative_path)`, returning
+/// its id. Reuses an existing row's id; (re)writes `state`, `size_bytes`, and
+/// `mtime` to the given values (spec 048 FR-001/FR-002 — callers are expected
+/// to pass the REAL on-disk size, never a `0` placeholder for a present frame).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn upsert_file_record(
+    pool: &SqlitePool,
+    root_id: &str,
+    relative_path: &str,
+    size_bytes: i64,
+    mtime: &str,
+    state: &str,
+) -> DbResult<String> {
+    if let Some(row) = sqlx::query_as::<_, FileRecordIdRow>(
+        "SELECT id FROM file_record WHERE root_id = ? AND relative_path = ?",
+    )
+    .bind(root_id)
+    .bind(relative_path)
+    .fetch_optional(pool)
+    .await?
+    {
+        sqlx::query(
+            "UPDATE file_record
+             SET state = ?, size_bytes = ?, mtime = ?, last_seen_at = ?
+             WHERE id = ?",
+        )
+        .bind(state)
+        .bind(size_bytes)
+        .bind(mtime)
+        .bind(OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default())
+        .bind(&row.id)
+        .execute(pool)
+        .await?;
+        return Ok(row.id);
+    }
+
+    let id = Uuid::new_v4().to_string();
+    let now = OffsetDateTime::now_utc().format(&Iso8601::DEFAULT).unwrap_or_default();
+    sqlx::query(
+        "INSERT INTO file_record
+            (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&id)
+    .bind(root_id)
+    .bind(relative_path)
+    .bind(size_bytes)
+    .bind(mtime)
+    .bind(state)
+    .bind(&now)
+    .bind(&now)
+    .execute(pool)
+    .await?;
+    Ok(id)
+}
+
+// ── ingest_resolution ────────────────────────────────────────────────────────
+
+/// Find an `ingest_resolution` row id for a given `(image_id, object_raw)`
+/// pair (idempotency lookup shared by `enqueue` and the inline-resolve path).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn find_ingest_resolution_id(
+    pool: &SqlitePool,
+    image_id: &str,
+    object_raw: &str,
+) -> DbResult<Option<String>> {
+    let row: Option<(String,)> = sqlx::query_as(
+        "SELECT id FROM ingest_resolution WHERE image_id = ? AND object_raw = ? LIMIT 1",
+    )
+    .bind(image_id)
+    .bind(object_raw)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row.map(|(id,)| id))
+}
+
+/// Insert a new `ingest_resolution` row with `attempts = 0`.
+///
+/// `state` is `"pending"` (enqueue path, `target_id = None`) or `"resolved"`
+/// (inline cache-hit path, `target_id = Some(..)`).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn insert_ingest_resolution(
+    pool: &SqlitePool,
+    id: &str,
+    image_id: &str,
+    object_raw: &str,
+    state: &str,
+    target_id: Option<&str>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO ingest_resolution (id, image_id, object_raw, state, target_id, attempts)
+         VALUES (?, ?, ?, ?, ?, 0)",
+    )
+    .bind(id)
+    .bind(image_id)
+    .bind(object_raw)
+    .bind(state)
+    .bind(target_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Mark an `ingest_resolution` row `resolved`, linking it to `target_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn mark_ingest_resolution_resolved(
+    pool: &SqlitePool,
+    row_id: &str,
+    target_id: &str,
+) -> DbResult<()> {
+    sqlx::query("UPDATE ingest_resolution SET state = 'resolved', target_id = ? WHERE id = ?")
+        .bind(target_id)
+        .bind(row_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Mark an `ingest_resolution` row `unresolved`, incrementing `attempts`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn mark_ingest_resolution_unresolved(
+    pool: &SqlitePool,
+    row_id: &str,
+    attempts: i64,
+) -> DbResult<()> {
+    sqlx::query("UPDATE ingest_resolution SET state = 'unresolved', attempts = ? WHERE id = ?")
+        .bind(attempts + 1)
+        .bind(row_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// List up to `limit` `pending` `ingest_resolution` rows, oldest-inserted
+/// first (`ORDER BY rowid ASC`) — the background drain's work queue.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_pending_ingest_resolutions(
+    pool: &SqlitePool,
+    limit: i64,
+) -> DbResult<Vec<PendingIngestResolutionRow>> {
+    let rows = sqlx::query_as::<_, PendingIngestResolutionRow>(
+        "SELECT id, object_raw, attempts
+         FROM ingest_resolution
+         WHERE state = 'pending'
+         ORDER BY rowid ASC
+         LIMIT ?",
+    )
+    .bind(limit)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// List every `resolved` `ingest_resolution` row (`image_id` → `target_id`),
+/// used by [`ingest_sessions`](super)'s back-fill pass.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_resolved_ingest_resolutions(
+    pool: &SqlitePool,
+) -> DbResult<Vec<ResolvedIngestResolutionRow>> {
+    let rows = sqlx::query_as::<_, ResolvedIngestResolutionRow>(
+        "SELECT image_id, target_id
+         FROM ingest_resolution
+         WHERE state = 'resolved' AND target_id IS NOT NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+// ── plan_items (ingest source) ──────────────────────────────────────────────
+
+/// List applied `move`/`catalogue` plan items for `plan_id`, ordered by
+/// `item_index ASC`. Item type (light vs. calibration) is filtered later by
+/// reading the FITS header at the resolved path.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_applied_light_plan_items(
+    pool: &SqlitePool,
+    plan_id: &str,
+) -> DbResult<Vec<AppliedPlanItemRow>> {
+    let rows = sqlx::query_as::<_, AppliedPlanItemRow>(
+        "SELECT to_root_id, to_relative_path, from_root_id, from_relative_path
+         FROM plan_items
+         WHERE plan_id = ?
+           AND action IN ('move', 'catalogue')
+           AND item_state = 'succeeded'
+         ORDER BY item_index ASC",
+    )
+    .bind(plan_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+// ── library_root mirroring (R9) ─────────────────────────────────────────────
+
+/// Mirror a `registered_sources` row into a `library_root` row with the SAME
+/// id (`kind = 'local'`, `state = 'active'`), so the `file_record.root_id` FK
+/// holds. A no-op (`INSERT OR IGNORE`) when the row already exists.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn insert_library_root_mirror(
+    pool: &SqlitePool,
+    root_id: &str,
+    path: &str,
+    created_at: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO library_root (id, label, current_path, kind, state, created_at)
+         VALUES (?, ?, ?, 'local', 'active', ?)",
+    )
+    .bind(root_id)
+    .bind(root_id)
+    .bind(path)
+    .bind(created_at)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── acquisition_session ──────────────────────────────────────────────────────
+
+/// Find an `acquisition_session` row by its (non-unique lookup index)
+/// `session_key`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn find_acquisition_session_by_key(
+    pool: &SqlitePool,
+    key: &str,
+) -> DbResult<Option<AcquisitionSessionByKeyRow>> {
+    let row = sqlx::query_as::<_, AcquisitionSessionByKeyRow>(
+        "SELECT id, frame_ids, canonical_target_id FROM acquisition_session WHERE session_key = ?",
+    )
+    .bind(key)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Append to an existing `acquisition_session` row, back-filling
+/// `canonical_target_id` (previously unset) and `root_id` (`COALESCE`, sticky
+/// to the first-known root).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn append_acquisition_session_frames_with_target(
+    pool: &SqlitePool,
+    id: &str,
+    frames_json: &str,
+    canonical_target_id: &str,
+    root_id: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE acquisition_session \
+         SET frame_ids = ?, canonical_target_id = ?, root_id = COALESCE(root_id, ?) \
+         WHERE id = ?",
+    )
+    .bind(frames_json)
+    .bind(canonical_target_id)
+    .bind(root_id)
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Append to an existing `acquisition_session` row without touching
+/// `canonical_target_id`; `root_id` is `COALESCE`d in (sticky to the
+/// first-known root).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn append_acquisition_session_frames(
+    pool: &SqlitePool,
+    id: &str,
+    frames_json: &str,
+    root_id: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE acquisition_session \
+         SET frame_ids = ?, root_id = COALESCE(root_id, ?) WHERE id = ?",
+    )
+    .bind(frames_json)
+    .bind(root_id)
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Insert a new `acquisition_session` row. Legacy `target_id`/
+/// `observer_location` columns are always `NULL` (R10 / v1 scope).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_acquisition_session(
+    pool: &SqlitePool,
+    id: &str,
+    key: &str,
+    canonical_target_id: Option<&str>,
+    has_observer_location: bool,
+    frames_json: &str,
+    root_id: &str,
+    created_at: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO acquisition_session
+            (id, session_key, target_id, canonical_target_id, has_observer_location,
+             frame_ids, observer_location, root_id, created_at)
+         VALUES (?, ?, NULL, ?, ?, ?, NULL, ?, ?)",
+    )
+    .bind(id)
+    .bind(key)
+    .bind(canonical_target_id)
+    .bind(i64::from(has_observer_location))
+    .bind(frames_json)
+    .bind(root_id)
+    .bind(created_at)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// List `acquisition_session` rows with no `canonical_target_id` set yet
+/// (spec 035 US4/T043 back-fill candidates).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_unlinked_acquisition_sessions(
+    pool: &SqlitePool,
+) -> DbResult<Vec<UnlinkedAcquisitionSessionRow>> {
+    let rows = sqlx::query_as::<_, UnlinkedAcquisitionSessionRow>(
+        "SELECT id, frame_ids FROM acquisition_session WHERE canonical_target_id IS NULL",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Set `canonical_target_id` on an `acquisition_session` row, only if it is
+/// currently `NULL` (never overwrites an already-linked session).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn set_acquisition_session_canonical_target_if_null(
+    pool: &SqlitePool,
+    session_id: &str,
+    target_id: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE acquisition_session SET canonical_target_id = ?
+         WHERE id = ? AND canonical_target_id IS NULL",
+    )
+    .bind(target_id)
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves the ~44 raw sqlx call sites in frame_writer.rs, ingest_resolution.rs, ingest_sessions.rs behind persistence_db::repositories::q_targets_ingest (byte-equivalent queries, no atomicity change).

Reviewed+approved (sonnet, 0 change items). Depends on merged foundation (persistence/audit split).