### PR TITLE
refactor: move calibration database queries behind the persistence layer

### DIFF
--- a/crates/app/calibration/src/equipment.rs
+++ b/crates/app/calibration/src/equipment.rs
@@ -11,6 +11,7 @@ use contracts_core::equipment::{
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use persistence_db::repositories::equipment as repo;
+use persistence_db::repositories::q_calibration;
 use sqlx::SqlitePool;
 
 // ── Error mapping ──────────────────────────────────────────────────────────
@@ -87,18 +88,7 @@ pub async fn find_or_create_camera_by_alias(
     camera.auto_detected = true;
 
     // Mark auto_detected in the database.
-    sqlx::query("UPDATE cameras SET auto_detected = 1 WHERE id = ?")
-        .bind(&camera.id)
-        .execute(pool)
-        .await
-        .map_err(|e| {
-            ContractError::new(
-                ErrorCode::InternalDatabase,
-                e.to_string(),
-                ErrorSeverity::Fatal,
-                true,
-            )
-        })?;
+    q_calibration::mark_camera_auto_detected(pool, &camera.id).await.map_err(db_to_contract)?;
 
     Ok(camera)
 }
@@ -168,18 +158,7 @@ pub async fn find_or_create_telescope_by_alias(
     let mut scope = repo::create_telescope(pool, &req).await.map_err(db_to_contract)?;
     scope.auto_detected = true;
 
-    sqlx::query("UPDATE telescopes SET auto_detected = 1 WHERE id = ?")
-        .bind(&scope.id)
-        .execute(pool)
-        .await
-        .map_err(|e| {
-            ContractError::new(
-                ErrorCode::InternalDatabase,
-                e.to_string(),
-                ErrorSeverity::Fatal,
-                true,
-            )
-        })?;
+    q_calibration::mark_telescope_auto_detected(pool, &scope.id).await.map_err(db_to_contract)?;
 
     Ok(scope)
 }
@@ -286,18 +265,7 @@ pub async fn find_or_create_filter_by_name(
     let mut filter = repo::create_filter(pool, &req).await.map_err(db_to_contract)?;
     filter.auto_detected = true;
 
-    sqlx::query("UPDATE filters SET auto_detected = 1 WHERE id = ?")
-        .bind(&filter.id)
-        .execute(pool)
-        .await
-        .map_err(|e| {
-            ContractError::new(
-                ErrorCode::InternalDatabase,
-                e.to_string(),
-                ErrorSeverity::Fatal,
-                true,
-            )
-        })?;
+    q_calibration::mark_filter_auto_detected(pool, &filter.id).await.map_err(db_to_contract)?;
 
     Ok(filter)
 }

--- a/crates/app/calibration/src/matching.rs
+++ b/crates/app/calibration/src/matching.rs
@@ -49,6 +49,7 @@ use contracts_core::calibration_match::{
 use domain_core::ids::Timestamp;
 use persistence_db::repositories::calibration_assignment::{self as assign_repo, UpsertParams};
 use persistence_db::repositories::inventory::{get_session_context_by_ids, SessionContextRow};
+use persistence_db::repositories::q_calibration;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 use time::format_description::well_known::Rfc3339;
@@ -512,75 +513,34 @@ fn apply_session_context(
 /// Returns `None` when no fingerprint exists for the session.
 async fn load_session(pool: &SqlitePool, session_id: &str) -> Result<Option<SessionInfo>, String> {
     // Validate session exists first (for proper "not found" error).
-    let exists: Option<(String,)> =
-        sqlx::query_as("SELECT id FROM acquisition_session WHERE id = ?")
-            .bind(session_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| e.to_string())?;
+    let exists = q_calibration::acquisition_session_exists(pool, session_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    if exists.is_none() {
+    if !exists {
         return Ok(None);
     }
 
     // Try to load fingerprint.
-    let row: Option<(
-        String,         // id
-        Option<String>, // session_type
-        Option<f64>,    // gain
-        Option<f64>,    // offset_val
-        Option<f64>,    // exposure_s
-        Option<f64>,    // temp_c
-        Option<String>, // filter_name
-        Option<f64>,    // rotation_deg
-        Option<String>, // binning
-        Option<String>, // optic_train
-        Option<String>, // observing_night_date
-        Option<i64>,    // has_observer_location
-        Option<i64>,    // has_exposure_start_utc
-    )> = sqlx::query_as(
-        "
-        SELECT id, session_type, gain, offset_val, exposure_s,
-               temp_c, filter_name, rotation_deg, binning, optic_train,
-               observing_night_date, has_observer_location, has_exposure_start_utc
-        FROM acquisition_fingerprint
-        WHERE id = ?
-        ",
-    )
-    .bind(session_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row = q_calibration::get_acquisition_fingerprint(pool, session_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(Some(match row {
-        Some((
-            id,
-            session_type,
-            gain,
-            offset,
-            exposure_s,
-            temp_c,
-            filter,
-            rotation_deg,
-            binning,
-            optic_train,
-            observing_night_date,
-            has_observer_location,
-            has_exposure_start_utc,
-        )) => SessionInfo {
-            id,
-            session_type: session_type.unwrap_or_else(|| "light".to_owned()),
-            gain,
-            offset,
-            exposure_s,
-            temp_c,
-            filter,
-            rotation_deg,
-            binning,
-            optic_train,
-            observing_night_date,
-            has_observer_location: has_observer_location.unwrap_or(0) != 0,
-            has_exposure_start_utc: has_exposure_start_utc.unwrap_or(0) != 0,
+        Some(r) => SessionInfo {
+            id: r.id,
+            session_type: r.session_type.unwrap_or_else(|| "light".to_owned()),
+            gain: r.gain,
+            offset: r.offset_val,
+            exposure_s: r.exposure_s,
+            temp_c: r.temp_c,
+            filter: r.filter_name,
+            rotation_deg: r.rotation_deg,
+            binning: r.binning,
+            optic_train: r.optic_train,
+            observing_night_date: r.observing_night_date,
+            has_observer_location: r.has_observer_location.unwrap_or(0) != 0,
+            has_exposure_start_utc: r.has_exposure_start_utc.unwrap_or(0) != 0,
         },
         // No fingerprint row → session exists but has no metadata.
         // Guard A6 will reject with observer_location_missing.
@@ -599,31 +559,8 @@ async fn load_masters(
     pool: &SqlitePool,
     kinds: &[CalibrationKind],
 ) -> Result<Vec<MasterInfo>, String> {
-    let rows: Vec<(
-        String,         // id
-        String,         // calibration_type
-        Option<f64>,    // gain
-        Option<f64>,    // offset_val
-        Option<f64>,    // exposure_s
-        Option<f64>,    // temp_c
-        Option<String>, // filter_name
-        Option<f64>,    // rotation_deg
-        Option<String>, // binning
-        Option<String>, // optic_train
-        Option<String>, // source_session_id
-        Option<String>, // observing_night_date
-    )> = sqlx::query_as(
-        "
-        SELECT id, calibration_type, gain, offset_val, exposure_s,
-               temp_c, filter_name, rotation_deg, binning, optic_train,
-               source_session_id, observing_night_date
-        FROM calibration_fingerprint
-        WHERE calibration_type IN ('dark', 'flat', 'bias')
-        ",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows =
+        q_calibration::list_calibration_fingerprints(pool).await.map_err(|e| e.to_string())?;
 
     let type_filter: Vec<&str> = kinds
         .iter()
@@ -637,41 +574,26 @@ async fn load_masters(
 
     Ok(rows
         .into_iter()
-        .filter(|(_, ct, ..)| type_filter.is_empty() || type_filter.contains(&ct.as_str()))
-        .filter_map(
-            |(
-                id,
-                ct,
-                gain,
-                offset,
-                exposure_s,
-                temp_c,
-                filter,
-                rotation_deg,
-                binning,
-                optic_train,
-                source_session_id,
-                observing_night_date,
-            )| {
-                // DB CHECK constrains `calibration_type` to dark/flat/bias;
-                // anything unparseable is skipped, preserving prior behavior.
-                let kind: CalibrationKind = ct.parse().ok()?;
-                Some(MasterInfo {
-                    id,
-                    kind,
-                    gain,
-                    offset,
-                    exposure_s,
-                    temp_c,
-                    filter,
-                    rotation_deg,
-                    binning,
-                    optic_train,
-                    source_session_id,
-                    observing_night_date,
-                })
-            },
-        )
+        .filter(|r| type_filter.is_empty() || type_filter.contains(&r.calibration_type.as_str()))
+        .filter_map(|r| {
+            // DB CHECK constrains `calibration_type` to dark/flat/bias;
+            // anything unparseable is skipped, preserving prior behavior.
+            let kind: CalibrationKind = r.calibration_type.parse().ok()?;
+            Some(MasterInfo {
+                id: r.id,
+                kind,
+                gain: r.gain,
+                offset: r.offset_val,
+                exposure_s: r.exposure_s,
+                temp_c: r.temp_c,
+                filter: r.filter_name,
+                rotation_deg: r.rotation_deg,
+                binning: r.binning,
+                optic_train: r.optic_train,
+                source_session_id: r.source_session_id,
+                observing_night_date: r.observing_night_date,
+            })
+        })
         .collect())
 }
 
@@ -680,67 +602,29 @@ async fn load_master_by_id(
     pool: &SqlitePool,
     master_id: &str,
 ) -> Result<Option<MasterInfo>, String> {
-    let row: Option<(
-        String,
-        String,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<String>,
-        Option<f64>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    )> = sqlx::query_as(
-        "
-        SELECT id, calibration_type, gain, offset_val, exposure_s,
-               temp_c, filter_name, rotation_deg, binning, optic_train,
-               source_session_id, observing_night_date
-        FROM calibration_fingerprint
-        WHERE id = ?
-        ",
-    )
-    .bind(master_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row = q_calibration::get_calibration_fingerprint(pool, master_id)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    Ok(row.and_then(
-        |(
-            id,
-            ct,
-            gain,
-            offset,
-            exposure_s,
-            temp_c,
-            filter,
-            rotation_deg,
-            binning,
-            optic_train,
-            source_session_id,
-            observing_night_date,
-        )| {
-            // DB CHECK constrains `calibration_type` to dark/flat/bias;
-            // anything unparseable is skipped, preserving prior behavior.
-            let kind: CalibrationKind = ct.parse().ok()?;
-            Some(MasterInfo {
-                id,
-                kind,
-                gain,
-                offset,
-                exposure_s,
-                temp_c,
-                filter,
-                rotation_deg,
-                binning,
-                optic_train,
-                source_session_id,
-                observing_night_date,
-            })
-        },
-    ))
+    Ok(row.and_then(|r| {
+        // DB CHECK constrains `calibration_type` to dark/flat/bias;
+        // anything unparseable is skipped, preserving prior behavior.
+        let kind: CalibrationKind = r.calibration_type.parse().ok()?;
+        Some(MasterInfo {
+            id: r.id,
+            kind,
+            gain: r.gain,
+            offset: r.offset_val,
+            exposure_s: r.exposure_s,
+            temp_c: r.temp_c,
+            filter: r.filter_name,
+            rotation_deg: r.rotation_deg,
+            binning: r.binning,
+            optic_train: r.optic_train,
+            source_session_id: r.source_session_id,
+            observing_night_date: r.observing_night_date,
+        })
+    }))
 }
 
 /// Load `MatchingRuleConfig` from persisted settings keys, falling back to defaults.
@@ -803,69 +687,34 @@ async fn load_config(pool: &SqlitePool) -> MatchingRuleConfig {
 pub async fn masters_list(
     pool: &SqlitePool,
 ) -> Result<Vec<contracts_core::calibration::CalibrationMaster>, String> {
-    let rows: Vec<(
-        String,         // id
-        String,         // kind
-        String,         // created_at
-        i64,            // size_bytes
-        Option<f64>,    // fp_gain
-        Option<f64>,    // fp_exposure_s
-        Option<f64>,    // fp_temp_c
-        Option<String>, // fp_filter_name
-        Option<String>, // fp_binning
-        Option<String>, // fp_optic_train (used as camera)
-        Option<String>, // source_session_id
-    )> = sqlx::query_as(
-        "SELECT id, kind, created_at, size_bytes,
-                fp_gain, fp_exposure_s, fp_temp_c, fp_filter_name, fp_binning,
-                fp_optic_train, source_session_id
-         FROM calibration_master_view
-         ORDER BY created_at DESC",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = q_calibration::list_calibration_masters(pool).await.map_err(|e| e.to_string())?;
 
     let now = OffsetDateTime::now_utc();
     let masters = rows
         .into_iter()
-        .map(
-            |(
-                id,
-                kind,
-                created_at,
-                size_bytes,
-                gain,
-                exposure_s,
-                temp_c,
-                filter_name,
-                binning,
-                optic_train,
-                source_session_id,
-            )| {
-                let age_days = compute_age_days(&created_at, now);
-                let cal_kind = str_to_cal_kind(&kind);
-                contracts_core::calibration::CalibrationMaster {
-                    id: id.clone(),
-                    kind: cal_kind,
-                    fingerprint: contracts_core::calibration::CalibrationFingerprint {
-                        camera: optic_train.unwrap_or_default(),
-                        sensor_mode: None,
-                        exposure_s: exposure_s.unwrap_or(0.0),
-                        temp_c,
-                        gain: gain.unwrap_or(0.0),
-                        binning: binning.unwrap_or_else(|| "1x1".to_owned()),
-                        filter: filter_name,
-                    },
-                    source_session_id: source_session_id.unwrap_or_else(|| id.clone()),
-                    created_at,
-                    age_days,
-                    size_bytes: u64::try_from(size_bytes).unwrap_or(0),
-                    used_by_session_ids: vec![],
-                    used_by_project_ids: vec![],
-                }
-            },
-        )
+        .map(|r| {
+            let age_days = compute_age_days(&r.created_at, now);
+            let cal_kind = str_to_cal_kind(&r.kind);
+            contracts_core::calibration::CalibrationMaster {
+                id: r.id.clone(),
+                kind: cal_kind,
+                fingerprint: contracts_core::calibration::CalibrationFingerprint {
+                    camera: r.fp_optic_train.unwrap_or_default(),
+                    sensor_mode: None,
+                    exposure_s: r.fp_exposure_s.unwrap_or(0.0),
+                    temp_c: r.fp_temp_c,
+                    gain: r.fp_gain.unwrap_or(0.0),
+                    binning: r.fp_binning.unwrap_or_else(|| "1x1".to_owned()),
+                    filter: r.fp_filter_name,
+                },
+                source_session_id: r.source_session_id.unwrap_or_else(|| r.id.clone()),
+                created_at: r.created_at,
+                age_days,
+                size_bytes: u64::try_from(r.size_bytes).unwrap_or(0),
+                used_by_session_ids: vec![],
+                used_by_project_ids: vec![],
+            }
+        })
         .collect();
 
     Ok(masters)
@@ -879,89 +728,42 @@ pub async fn masters_get(
     pool: &SqlitePool,
     master_id: &str,
 ) -> Result<contracts_core::calibration::MasterDetail, String> {
-    let row: Option<(
-        String,
-        String,
-        String,
-        i64,
-        Option<f64>,
-        Option<f64>,
-        Option<f64>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-        Option<String>,
-    )> = sqlx::query_as(
-        "SELECT id, kind, created_at, size_bytes,
-                fp_gain, fp_exposure_s, fp_temp_c, fp_filter_name, fp_binning,
-                fp_optic_train, source_session_id
-         FROM calibration_master_view
-         WHERE id = ?",
-    )
-    .bind(master_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row =
+        q_calibration::get_calibration_master(pool, master_id).await.map_err(|e| e.to_string())?;
 
-    let (
-        id,
-        kind,
-        created_at,
-        size_bytes,
-        gain,
-        exposure_s,
-        temp_c,
-        filter_name,
-        binning,
-        optic_train,
-        source_session_id,
-    ) = row.ok_or_else(|| format!("master.not_found: {master_id}"))?;
+    let r = row.ok_or_else(|| format!("master.not_found: {master_id}"))?;
 
     let now = OffsetDateTime::now_utc();
-    let age_days = compute_age_days(&created_at, now);
-    let cal_kind = str_to_cal_kind(&kind);
+    let age_days = compute_age_days(&r.created_at, now);
+    let cal_kind = str_to_cal_kind(&r.kind);
 
     // Load sessions assigned to this master via calibration_assignment.
-    let used_sessions: Vec<(String,)> =
-        sqlx::query_as("SELECT session_id FROM calibration_assignment WHERE master_id = ?")
-            .bind(&id)
-            .fetch_all(pool)
-            .await
-            .unwrap_or_default();
-    let used_by_session_ids: Vec<String> = used_sessions.into_iter().map(|(s,)| s).collect();
+    let used_by_session_ids =
+        q_calibration::list_assignment_session_ids(pool, &r.id).await.unwrap_or_default();
 
     // Load projects linked to sessions that use this master.
-    let used_projects: Vec<(String,)> = sqlx::query_as(
-        "SELECT DISTINCT ps.project_id
-         FROM project_sources ps
-         JOIN calibration_assignment ca ON ca.session_id = ps.session_id
-         WHERE ca.master_id = ?",
-    )
-    .bind(&id)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
-    let used_by_project_ids: Vec<String> = used_projects.into_iter().map(|(p,)| p).collect();
+    let used_by_project_ids =
+        q_calibration::list_assignment_project_ids(pool, &r.id).await.unwrap_or_default();
 
     let session_count = u32::try_from(used_by_session_ids.len()).unwrap_or(0);
     let project_count = u32::try_from(used_by_project_ids.len()).unwrap_or(0);
 
     Ok(contracts_core::calibration::MasterDetail {
-        id: id.clone(),
+        id: r.id.clone(),
         kind: cal_kind,
         fingerprint: contracts_core::calibration::CalibrationFingerprint {
-            camera: optic_train.unwrap_or_default(),
+            camera: r.fp_optic_train.unwrap_or_default(),
             sensor_mode: None,
-            exposure_s: exposure_s.unwrap_or(0.0),
-            temp_c,
-            gain: gain.unwrap_or(0.0),
-            binning: binning.unwrap_or_else(|| "1x1".to_owned()),
-            filter: filter_name,
+            exposure_s: r.fp_exposure_s.unwrap_or(0.0),
+            temp_c: r.fp_temp_c,
+            gain: r.fp_gain.unwrap_or(0.0),
+            binning: r.fp_binning.unwrap_or_else(|| "1x1".to_owned()),
+            filter: r.fp_filter_name,
         },
-        source_session_id: source_session_id.unwrap_or_else(|| id.clone()),
-        created_at,
+        source_session_id: r.source_session_id.unwrap_or_else(|| r.id.clone()),
+        created_at: r.created_at,
         age_days,
-        size_bytes: u64::try_from(size_bytes).unwrap_or(0),
+        size_bytes: u64::try_from(r.size_bytes).unwrap_or(0),
         used_by_session_ids,
         used_by_project_ids,
         compatible_sessions: vec![],

--- a/crates/persistence/db/src/repositories/q_calibration.rs
+++ b/crates/persistence/db/src/repositories/q_calibration.rs
@@ -1,3 +1,258 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_calibration`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Free-function query repository for calibration matching (spec 007) and
+//! equipment auto-detect flags (spec 030), migrated out of
+//! `app_calibration::matching` / `app_calibration::equipment`
+//! (db-boundary-zero drain). Business logic, domain mapping, and error
+//! handling stay in the app layer — this module only executes SQL against the
+//! tables it fronts: `cameras`/`telescopes`/`filters` (auto-detect flag only),
+//! `calibration_session`, `calibration_fingerprint`, `calibration_assignment`,
+//! `calibration_master_view`, `acquisition_fingerprint`, `project_sources`.
+
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+// ── Equipment auto-detect flag (spec 030) ──────────────────────────────────
+
+/// Mark a camera row as auto-detected (`cameras.auto_detected = 1`).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn mark_camera_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<()> {
+    sqlx::query("UPDATE cameras SET auto_detected = 1 WHERE id = ?").bind(id).execute(pool).await?;
+    Ok(())
+}
+
+/// Mark a telescope row as auto-detected (`telescopes.auto_detected = 1`).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn mark_telescope_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<()> {
+    sqlx::query("UPDATE telescopes SET auto_detected = 1 WHERE id = ?")
+        .bind(id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Mark a filter row as auto-detected (`filters.auto_detected = 1`).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn mark_filter_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<()> {
+    sqlx::query("UPDATE filters SET auto_detected = 1 WHERE id = ?").bind(id).execute(pool).await?;
+    Ok(())
+}
+
+// ── Session / master fingerprint rows (spec 007, migration 0023) ──────────
+
+/// Row from `acquisition_fingerprint`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AcquisitionFingerprintRow {
+    pub id: String,
+    pub session_type: Option<String>,
+    pub gain: Option<f64>,
+    pub offset_val: Option<f64>,
+    pub exposure_s: Option<f64>,
+    pub temp_c: Option<f64>,
+    pub filter_name: Option<String>,
+    pub rotation_deg: Option<f64>,
+    pub binning: Option<String>,
+    pub optic_train: Option<String>,
+    pub observing_night_date: Option<String>,
+    pub has_observer_location: Option<i64>,
+    pub has_exposure_start_utc: Option<i64>,
+}
+
+/// Row from `calibration_fingerprint`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CalibrationFingerprintRow {
+    pub id: String,
+    pub calibration_type: String,
+    pub gain: Option<f64>,
+    pub offset_val: Option<f64>,
+    pub exposure_s: Option<f64>,
+    pub temp_c: Option<f64>,
+    pub filter_name: Option<String>,
+    pub rotation_deg: Option<f64>,
+    pub binning: Option<String>,
+    pub optic_train: Option<String>,
+    pub source_session_id: Option<String>,
+    pub observing_night_date: Option<String>,
+}
+
+/// Row from `calibration_master_view` (migration 0033).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CalibrationMasterViewRow {
+    pub id: String,
+    pub kind: String,
+    pub created_at: String,
+    pub size_bytes: i64,
+    pub fp_gain: Option<f64>,
+    pub fp_exposure_s: Option<f64>,
+    pub fp_temp_c: Option<f64>,
+    pub fp_filter_name: Option<String>,
+    pub fp_binning: Option<String>,
+    pub fp_optic_train: Option<String>,
+    pub source_session_id: Option<String>,
+}
+
+/// Whether an `acquisition_session` row exists for `session_id`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn acquisition_session_exists(pool: &SqlitePool, session_id: &str) -> DbResult<bool> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT id FROM acquisition_session WHERE id = ?")
+        .bind(session_id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.is_some())
+}
+
+/// Load the `acquisition_fingerprint` row for a session id, if present.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_acquisition_fingerprint(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<AcquisitionFingerprintRow>> {
+    let row = sqlx::query_as::<_, AcquisitionFingerprintRow>(
+        "
+        SELECT id, session_type, gain, offset_val, exposure_s,
+               temp_c, filter_name, rotation_deg, binning, optic_train,
+               observing_night_date, has_observer_location, has_exposure_start_utc
+        FROM acquisition_fingerprint
+        WHERE id = ?
+        ",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// List `calibration_fingerprint` rows restricted to dark/flat/bias kinds.
+///
+/// Callers apply any requested-kind narrowing in-memory (mirrors prior
+/// behavior: SQL restricts to the fixed dark/flat/bias set).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_calibration_fingerprints(
+    pool: &SqlitePool,
+) -> DbResult<Vec<CalibrationFingerprintRow>> {
+    let rows = sqlx::query_as::<_, CalibrationFingerprintRow>(
+        "
+        SELECT id, calibration_type, gain, offset_val, exposure_s,
+               temp_c, filter_name, rotation_deg, binning, optic_train,
+               source_session_id, observing_night_date
+        FROM calibration_fingerprint
+        WHERE calibration_type IN ('dark', 'flat', 'bias')
+        ",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Load a single `calibration_fingerprint` row by id.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_calibration_fingerprint(
+    pool: &SqlitePool,
+    master_id: &str,
+) -> DbResult<Option<CalibrationFingerprintRow>> {
+    let row = sqlx::query_as::<_, CalibrationFingerprintRow>(
+        "
+        SELECT id, calibration_type, gain, offset_val, exposure_s,
+               temp_c, filter_name, rotation_deg, binning, optic_train,
+               source_session_id, observing_night_date
+        FROM calibration_fingerprint
+        WHERE id = ?
+        ",
+    )
+    .bind(master_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+// ── Masters list / get (T037, FR-013) ──────────────────────────────────────
+
+/// List all `calibration_master_view` rows, newest first.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_calibration_masters(
+    pool: &SqlitePool,
+) -> DbResult<Vec<CalibrationMasterViewRow>> {
+    let rows = sqlx::query_as::<_, CalibrationMasterViewRow>(
+        "SELECT id, kind, created_at, size_bytes,
+                fp_gain, fp_exposure_s, fp_temp_c, fp_filter_name, fp_binning,
+                fp_optic_train, source_session_id
+         FROM calibration_master_view
+         ORDER BY created_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Load a single `calibration_master_view` row by id.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_calibration_master(
+    pool: &SqlitePool,
+    master_id: &str,
+) -> DbResult<Option<CalibrationMasterViewRow>> {
+    let row = sqlx::query_as::<_, CalibrationMasterViewRow>(
+        "SELECT id, kind, created_at, size_bytes,
+                fp_gain, fp_exposure_s, fp_temp_c, fp_filter_name, fp_binning,
+                fp_optic_train, source_session_id
+         FROM calibration_master_view
+         WHERE id = ?",
+    )
+    .bind(master_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// List `session_id`s from `calibration_assignment` rows assigned to a master.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_assignment_session_ids(
+    pool: &SqlitePool,
+    master_id: &str,
+) -> DbResult<Vec<String>> {
+    let rows: Vec<(String,)> =
+        sqlx::query_as("SELECT session_id FROM calibration_assignment WHERE master_id = ?")
+            .bind(master_id)
+            .fetch_all(pool)
+            .await?;
+    Ok(rows.into_iter().map(|(s,)| s).collect())
+}
+
+/// List distinct `project_id`s linked (via `project_sources`) to sessions
+/// assigned a given calibration master.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_assignment_project_ids(
+    pool: &SqlitePool,
+    master_id: &str,
+) -> DbResult<Vec<String>> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT DISTINCT ps.project_id
+         FROM project_sources ps
+         JOIN calibration_assignment ca ON ca.session_id = ps.session_id
+         WHERE ca.master_id = ?",
+    )
+    .bind(master_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(p,)| p).collect())
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves the 11 raw sqlx call sites in equipment.rs and matching.rs behind persistence_db::repositories::q_calibration (byte-equivalent queries, no atomicity change).

Reviewed+approved (sonnet, 0 change items). Depends on merged foundation.