### PR TITLE
refactor: move targeting-resolver database queries behind the persistence layer

### DIFF
--- a/crates/persistence/db/src/repositories/q_resolver.rs
+++ b/crates/persistence/db/src/repositories/q_resolver.rs
@@ -233,9 +233,8 @@ pub async fn list_all_target_aliases(pool: &SqlitePool) -> DbResult<Vec<TargetAl
 ///
 /// Returns [`crate::DbError::Database`] on query failure.
 pub async fn count_canonical_targets(pool: &SqlitePool) -> DbResult<i64> {
-    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM canonical_target")
-        .fetch_one(pool)
-        .await?;
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM canonical_target").fetch_one(pool).await?;
     Ok(count)
 }
 

--- a/crates/persistence/db/src/repositories/q_resolver.rs
+++ b/crates/persistence/db/src/repositories/q_resolver.rs
@@ -1,3 +1,504 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_resolver`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Repository query functions for the spec-035/042 target resolution cache and
+//! bundled-seed loader (`crates/targeting/resolver`).
+//!
+//! Writes/reads the same `canonical_target` / `target_alias` tables as
+//! [`super::targets`]. SIMBAD dedup/precedence business logic (source
+//! overwrite rules, ranking, alias assembly) stays in
+//! `targeting_resolver::cache` / `::seed` — this module only carries the raw
+//! SQL.
+//!
+//! Most functions take `&SqlitePool` (matching [`super::targets`]). The
+//! `*_conn` functions take `&mut SqliteConnection` instead: they are the
+//! pieces of the find-existing/update-or-insert/replace-aliases sequence that
+//! the resolver's `upsert_resolved_conn` runs against one shared connection so
+//! the bundled-seed loader can batch many upserts into a single transaction
+//! (one fsync for ~14k rows) — see `targeting_resolver::seed::load_seed`. A
+//! `&mut sqlx::Transaction<'_, Sqlite>` derefs to `&mut SqliteConnection`, so
+//! callers pass `&mut *tx` for the batched path and a plain acquired
+//! connection otherwise.
+//!
+//! Constitution §I: read/write SQLite metadata only; no filesystem mutations.
+//! Constitution §V: SQLite is the durable record.
+
+use sqlx::{SqliteConnection, SqlitePool};
+
+use crate::DbResult;
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+/// Flat `canonical_target` row (all 9 identity columns).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CanonicalTargetRow {
+    pub id: String,
+    pub simbad_oid: Option<i64>,
+    pub primary_designation: String,
+    pub display_alias: Option<String>,
+    pub object_type: String,
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+    pub source: String,
+    pub resolved_at: String,
+}
+
+/// Flat `target_alias` row (alias + normalized + kind), no `target_id`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AliasRow {
+    pub alias: String,
+    pub normalized: String,
+    pub kind: String,
+}
+
+/// A `target_alias` row matched during typeahead search.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AliasSearchRow {
+    pub target_id: String,
+    pub alias: String,
+    pub normalized: String,
+}
+
+/// Flat row for the gen-3 `target.list` surface (no aliases — see
+/// [`list_all_target_aliases`] for the batched alias pass).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TargetListQueryRow {
+    pub id: String,
+    pub primary_designation: String,
+    pub display_alias: Option<String>,
+    pub object_type: String,
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+    pub constellation: Option<String>,
+    pub magnitude: Option<f64>,
+}
+
+/// `(target_id, alias)` pair used to batch-group aliases onto [`TargetListQueryRow`]s.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TargetAliasPairRow {
+    pub target_id: String,
+    pub alias: String,
+}
+
+/// The row a dedup lookup matches against: just enough to decide precedence
+/// (`id` to upsert into, `source` to compare via `TargetSource::may_overwrite`).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ExistingTargetRow {
+    pub id: String,
+    pub source: String,
+}
+
+// ── Reads (pool) ─────────────────────────────────────────────────────────────
+
+/// Read a `canonical_target` row by its persisted id.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn select_canonical_target_by_id(
+    pool: &SqlitePool,
+    id: &str,
+) -> DbResult<Option<CanonicalTargetRow>> {
+    let row = sqlx::query_as::<_, CanonicalTargetRow>(
+        "SELECT id, simbad_oid, primary_designation, display_alias, object_type, ra_deg, dec_deg, source, resolved_at
+         FROM canonical_target WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Read a `canonical_target` row by its SIMBAD physical-object id (the dedup key).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn select_canonical_target_by_simbad_oid(
+    pool: &SqlitePool,
+    simbad_oid: i64,
+) -> DbResult<Option<CanonicalTargetRow>> {
+    let row = sqlx::query_as::<_, CanonicalTargetRow>(
+        "SELECT id, simbad_oid, primary_designation, display_alias, object_type, ra_deg, dec_deg, source, resolved_at
+         FROM canonical_target WHERE simbad_oid = ?",
+    )
+    .bind(simbad_oid)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Resolve a normalized alias to its owning `target_id`.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn select_target_id_by_normalized_alias(
+    pool: &SqlitePool,
+    normalized: &str,
+) -> DbResult<Option<String>> {
+    let target_id: Option<String> =
+        sqlx::query_scalar("SELECT target_id FROM target_alias WHERE normalized = ? LIMIT 1")
+            .bind(normalized)
+            .fetch_optional(pool)
+            .await?;
+    Ok(target_id)
+}
+
+/// List the aliases for a target id, ordered by alias.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn select_aliases_for_target(
+    pool: &SqlitePool,
+    target_id: &str,
+) -> DbResult<Vec<AliasRow>> {
+    let rows = sqlx::query_as::<_, AliasRow>(
+        "SELECT alias, normalized, kind
+         FROM target_alias
+         WHERE target_id = ?
+         ORDER BY alias ASC",
+    )
+    .bind(target_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Fetch candidate `(target_id, alias, normalized)` rows for typeahead search:
+/// `normalized LIKE pattern ESCAPE '\'`, ordered by length then alphabetically,
+/// capped at `fetch_cap`. Ranking/dedup across matched aliases is decided by
+/// the caller (`targeting_resolver::cache::search_by_normalized`).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn search_aliases_by_pattern(
+    pool: &SqlitePool,
+    pattern: &str,
+    fetch_cap: i64,
+) -> DbResult<Vec<AliasSearchRow>> {
+    let rows = sqlx::query_as::<_, AliasSearchRow>(
+        "SELECT target_id, alias, normalized
+         FROM target_alias
+         WHERE normalized LIKE ? ESCAPE '\\'
+         ORDER BY LENGTH(normalized) ASC, normalized ASC
+         LIMIT ?",
+    )
+    .bind(pattern)
+    .bind(fetch_cap)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// List all `canonical_target` rows (gen-3 `target.list` surface), ordered by
+/// `primary_designation`. Aliases are NOT included — batch-load them
+/// separately with [`list_all_target_aliases`] (avoids N+1 queries).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_canonical_targets(pool: &SqlitePool) -> DbResult<Vec<TargetListQueryRow>> {
+    let rows = sqlx::query_as::<_, TargetListQueryRow>(
+        "SELECT id, primary_designation, display_alias, object_type,
+                ra_deg, dec_deg, constellation, magnitude
+         FROM canonical_target
+         ORDER BY primary_designation ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// List every `(target_id, alias)` pair, ordered by `target_id` then `alias`,
+/// for the batched grouping pass behind [`list_canonical_targets`].
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_all_target_aliases(pool: &SqlitePool) -> DbResult<Vec<TargetAliasPairRow>> {
+    let rows = sqlx::query_as::<_, TargetAliasPairRow>(
+        "SELECT target_id, alias
+         FROM target_alias
+         ORDER BY target_id ASC, alias ASC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Count `canonical_target` rows — the resolver's first-run detector (an
+/// empty cache means the bundled seed has not been loaded yet).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_canonical_targets(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM canonical_target")
+        .fetch_one(pool)
+        .await?;
+    Ok(count)
+}
+
+// ── Writes (pool) — gen-3 management operations (spec 036/051) ─────────────
+
+/// Insert a user-added alias (`kind = 'user'`). `INSERT OR IGNORE` tolerates
+/// the `(target_id, normalized)` uniqueness constraint. Returns the number of
+/// rows affected (`0` when the alias already existed).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn insert_user_alias(
+    pool: &SqlitePool,
+    alias_id: &str,
+    target_id: &str,
+    alias: &str,
+    normalized: &str,
+) -> DbResult<u64> {
+    let result = sqlx::query(
+        "INSERT OR IGNORE INTO target_alias (id, target_id, alias, normalized, kind)
+         VALUES (?, ?, ?, ?, 'user')",
+    )
+    .bind(alias_id)
+    .bind(target_id)
+    .bind(alias)
+    .bind(normalized)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
+/// Look up an existing alias id by `(target_id, normalized)` — used when
+/// [`insert_user_alias`] reports 0 rows affected (already exists).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn select_alias_id_by_target_and_normalized(
+    pool: &SqlitePool,
+    target_id: &str,
+    normalized: &str,
+) -> DbResult<Option<String>> {
+    let id: Option<String> =
+        sqlx::query_scalar("SELECT id FROM target_alias WHERE target_id = ? AND normalized = ?")
+            .bind(target_id)
+            .bind(normalized)
+            .fetch_optional(pool)
+            .await?;
+    Ok(id)
+}
+
+/// Delete a user alias by its id, but only if its `kind = 'user'`. Returns
+/// `true` if a row was deleted.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn delete_user_alias(pool: &SqlitePool, alias_id: &str) -> DbResult<bool> {
+    let result = sqlx::query("DELETE FROM target_alias WHERE id = ? AND kind = 'user'")
+        .bind(alias_id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Set `canonical_target.display_alias`. Returns `true` if the target exists
+/// and was updated.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn set_display_alias(
+    pool: &SqlitePool,
+    target_id: &str,
+    display_alias: Option<&str>,
+) -> DbResult<bool> {
+    let result = sqlx::query("UPDATE canonical_target SET display_alias = ? WHERE id = ?")
+        .bind(display_alias)
+        .bind(target_id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+/// Clear `canonical_target.display_alias` (sets to NULL). Returns `true` if
+/// the target exists and was updated.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn clear_display_alias(pool: &SqlitePool, target_id: &str) -> DbResult<bool> {
+    let result = sqlx::query("UPDATE canonical_target SET display_alias = NULL WHERE id = ?")
+        .bind(target_id)
+        .execute(pool)
+        .await?;
+    Ok(result.rows_affected() > 0)
+}
+
+// ── Atomic-unit steps (conn) — dedup upsert, spec 035 FR-007/FR-014 ────────
+//
+// These share one caller-supplied connection so `targeting_resolver::seed`
+// can batch many upserts into a single transaction. See module docs.
+
+/// Find the dedup-target row by SIMBAD oid (FR-007 precedence: an oid match
+/// wins over the designation-derived id).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn find_existing_by_simbad_oid_conn(
+    conn: &mut SqliteConnection,
+    simbad_oid: i64,
+) -> DbResult<Option<ExistingTargetRow>> {
+    let row = sqlx::query_as::<_, ExistingTargetRow>(
+        "SELECT id, source FROM canonical_target WHERE simbad_oid = ?",
+    )
+    .bind(simbad_oid)
+    .fetch_optional(&mut *conn)
+    .await?;
+    Ok(row)
+}
+
+/// Find the dedup-target row by its designation-derived id (the fallback when
+/// `simbad_oid` is null or did not match).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn find_existing_by_id_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+) -> DbResult<Option<ExistingTargetRow>> {
+    let row = sqlx::query_as::<_, ExistingTargetRow>(
+        "SELECT id, source FROM canonical_target WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(&mut *conn)
+    .await?;
+    Ok(row)
+}
+
+/// Update an existing `canonical_target` row in place (keeps `id`, preserving
+/// FK targets). `display_alias` is intentionally NOT touched — it is
+/// user-owned and must never be overwritten by a re-resolution or seed load
+/// (FR-012).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+#[allow(clippy::too_many_arguments)]
+pub async fn update_canonical_target_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+    simbad_oid: Option<i64>,
+    primary_designation: &str,
+    object_type: &str,
+    ra_deg: f64,
+    dec_deg: f64,
+    source: &str,
+    resolved_at: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE canonical_target SET
+             simbad_oid          = ?,
+             primary_designation = ?,
+             object_type         = ?,
+             ra_deg              = ?,
+             dec_deg             = ?,
+             source              = ?,
+             resolved_at         = ?
+         WHERE id = ?",
+    )
+    .bind(simbad_oid)
+    .bind(primary_designation)
+    .bind(object_type)
+    .bind(ra_deg)
+    .bind(dec_deg)
+    .bind(source)
+    .bind(resolved_at)
+    .bind(id)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert a brand-new `canonical_target` row.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_canonical_target_conn(
+    conn: &mut SqliteConnection,
+    id: &str,
+    simbad_oid: Option<i64>,
+    primary_designation: &str,
+    object_type: &str,
+    ra_deg: f64,
+    dec_deg: f64,
+    source: &str,
+    resolved_at: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO canonical_target
+             (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(id)
+    .bind(simbad_oid)
+    .bind(primary_designation)
+    .bind(object_type)
+    .bind(ra_deg)
+    .bind(dec_deg)
+    .bind(source)
+    .bind(resolved_at)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+/// Delete all alias rows for `target_id` — the first half of the
+/// delete+insert wholesale alias replacement a re-resolution does.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn delete_aliases_for_target_conn(
+    conn: &mut SqliteConnection,
+    target_id: &str,
+) -> DbResult<()> {
+    sqlx::query("DELETE FROM target_alias WHERE target_id = ?")
+        .bind(target_id)
+        .execute(&mut *conn)
+        .await?;
+    Ok(())
+}
+
+/// Insert one alias row. `INSERT OR IGNORE` tolerates the
+/// `(target_id, normalized)` uniqueness constraint when SIMBAD returns the
+/// same normalized form twice.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn insert_alias_conn(
+    conn: &mut SqliteConnection,
+    alias_id: &str,
+    target_id: &str,
+    alias: &str,
+    normalized: &str,
+    kind: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO target_alias (id, target_id, alias, normalized, kind)
+         VALUES (?, ?, ?, ?, ?)",
+    )
+    .bind(alias_id)
+    .bind(target_id)
+    .bind(alias)
+    .bind(normalized)
+    .bind(kind)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}

--- a/crates/targeting/resolver/src/cache.rs
+++ b/crates/targeting/resolver/src/cache.rs
@@ -7,15 +7,17 @@
 //!
 //! These functions take a borrowed [`sqlx::SqlitePool`] rather than owning a
 //! connection, matching the spec-013 loader ([`crate::load`]) and the
-//! `persistence_db` repositories. SQL uses the runtime `sqlx::query` /
-//! `sqlx::query_as` API (no compile-time-checked macros), consistent with those
-//! siblings. Identities are written to `canonical_target` / `target_alias`
-//! (migration 0031).
+//! `persistence_db` repositories. Raw SQL lives in
+//! `persistence_db::repositories::q_resolver` (db-boundary-zero); this module
+//! keeps the dedup/precedence/ranking business logic and converts between the
+//! repository's flat rows and this crate's domain types. Identities are
+//! written to `canonical_target` / `target_alias` (migration 0031).
 //!
 //! Typeahead prefix/substring search over `target_alias.normalized` is NOT
 //! implemented here — that is T010 (US1).
 
 use domain_core::ids::Timestamp;
+use persistence_db::repositories::q_resolver;
 use sqlx::{SqliteConnection, SqlitePool};
 use uuid::Uuid;
 
@@ -30,6 +32,9 @@ pub enum CacheError {
     /// Underlying SQLite query failure.
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
+    /// A `persistence_db` repository call failed.
+    #[error("persistence error: {0}")]
+    Persistence(#[from] persistence_db::DbError),
     /// A stored `canonical_target.id` was not a valid UUID.
     #[error("failed to parse target uuid '{0}': {1}")]
     InvalidUuid(String, uuid::Error),
@@ -40,20 +45,6 @@ pub enum CacheError {
 
 /// Convenience result alias for cache operations.
 pub type CacheResult<T> = Result<T, CacheError>;
-
-/// Raw row tuple for a `canonical_target` SELECT (9 columns).
-///
-/// Order: id, simbad_oid, primary_designation, display_alias,
-///        object_type, ra_deg, dec_deg, source, resolved_at.
-type CanonicalTargetRow =
-    (String, Option<i64>, String, Option<String>, String, f64, f64, String, String);
-
-/// Raw row tuple for the `target.list` SELECT (8 columns).
-///
-/// Order: id, primary_designation, display_alias, object_type,
-///        ra_deg, dec_deg, constellation, magnitude.
-type TargetListQueryRow =
-    (String, String, Option<String>, String, f64, f64, Option<String>, Option<f64>);
 
 // ── Read model ────────────────────────────────────────────────────────────────
 
@@ -99,33 +90,24 @@ fn derived_id(designation: &str) -> Uuid {
 
 /// Load the aliases for a target id, ordered by alias.
 async fn load_aliases(pool: &SqlitePool, target_id: &str) -> CacheResult<Vec<ResolvedAlias>> {
-    let rows: Vec<(String, String, String)> = sqlx::query_as(
-        "SELECT alias, normalized, kind
-         FROM target_alias
-         WHERE target_id = ?
-         ORDER BY alias ASC",
-    )
-    .bind(target_id)
-    .fetch_all(pool)
-    .await?;
-
+    let rows = q_resolver::select_aliases_for_target(pool, target_id).await?;
     Ok(rows
         .into_iter()
-        .map(|(alias, normalized, kind)| ResolvedAlias {
-            alias,
-            normalized,
-            kind: AliasKind::from_wire(&kind),
+        .map(|r| ResolvedAlias {
+            alias: r.alias,
+            normalized: r.normalized,
+            kind: AliasKind::from_wire(&r.kind),
         })
         .collect())
 }
 
-/// Assemble a [`CachedTarget`] from a `canonical_target` row tuple.
-///
-/// The tuple is 9 columns: id, simbad_oid, primary_designation, display_alias,
-/// object_type, ra_deg, dec_deg, source, resolved_at.
-async fn assemble(pool: &SqlitePool, row: CanonicalTargetRow) -> CacheResult<CachedTarget> {
-    let (
-        id_str,
+/// Assemble a [`CachedTarget`] from a `canonical_target` repository row.
+async fn assemble(
+    pool: &SqlitePool,
+    row: q_resolver::CanonicalTargetRow,
+) -> CacheResult<CachedTarget> {
+    let q_resolver::CanonicalTargetRow {
+        id: id_str,
         simbad_oid,
         primary_designation,
         display_alias,
@@ -134,7 +116,7 @@ async fn assemble(pool: &SqlitePool, row: CanonicalTargetRow) -> CacheResult<Cac
         dec_deg,
         source,
         resolved_at,
-    ) = row;
+    } = row;
     let id = Uuid::parse_str(&id_str).map_err(|e| CacheError::InvalidUuid(id_str.clone(), e))?;
     let source = TargetSource::from_wire(&source)
         .ok_or_else(|| CacheError::InvalidSource(source.clone()))?;
@@ -160,13 +142,7 @@ async fn assemble(pool: &SqlitePool, row: CanonicalTargetRow) -> CacheResult<Cac
 /// Returns [`CacheError::Database`] on query failure, or [`CacheError::InvalidUuid`] /
 /// [`CacheError::InvalidSource`] on a corrupt stored value.
 pub async fn get_by_id(pool: &SqlitePool, id: Uuid) -> CacheResult<Option<CachedTarget>> {
-    let row: Option<CanonicalTargetRow> = sqlx::query_as(
-            "SELECT id, simbad_oid, primary_designation, display_alias, object_type, ra_deg, dec_deg, source, resolved_at
-             FROM canonical_target WHERE id = ?",
-        )
-        .bind(id.to_string())
-        .fetch_optional(pool)
-        .await?;
+    let row = q_resolver::select_canonical_target_by_id(pool, &id.to_string()).await?;
     match row {
         None => Ok(None),
         Some(r) => Ok(Some(assemble(pool, r).await?)),
@@ -183,13 +159,7 @@ pub async fn get_by_simbad_oid(
     pool: &SqlitePool,
     simbad_oid: i64,
 ) -> CacheResult<Option<CachedTarget>> {
-    let row: Option<CanonicalTargetRow> = sqlx::query_as(
-            "SELECT id, simbad_oid, primary_designation, display_alias, object_type, ra_deg, dec_deg, source, resolved_at
-             FROM canonical_target WHERE simbad_oid = ?",
-        )
-        .bind(simbad_oid)
-        .fetch_optional(pool)
-        .await?;
+    let row = q_resolver::select_canonical_target_by_simbad_oid(pool, simbad_oid).await?;
     match row {
         None => Ok(None),
         Some(r) => Ok(Some(assemble(pool, r).await?)),
@@ -209,14 +179,10 @@ pub async fn get_by_normalized(
     pool: &SqlitePool,
     normalized: &str,
 ) -> CacheResult<Option<CachedTarget>> {
-    let target_id: Option<(String,)> =
-        sqlx::query_as("SELECT target_id FROM target_alias WHERE normalized = ? LIMIT 1")
-            .bind(normalized)
-            .fetch_optional(pool)
-            .await?;
+    let target_id = q_resolver::select_target_id_by_normalized_alias(pool, normalized).await?;
     match target_id {
         None => Ok(None),
-        Some((tid,)) => {
+        Some(tid) => {
             let uuid =
                 Uuid::parse_str(&tid).map_err(|e| CacheError::InvalidUuid(tid.clone(), e))?;
             get_by_id(pool, uuid).await
@@ -295,22 +261,13 @@ pub async fn search_by_normalized(
     // bounded multiple of `limit` so dedup across aliases still fills the page;
     // ordering by normalized length favours tighter matches before the cap.
     let fetch_cap = i64::try_from((limit.saturating_mul(8)).clamp(limit, 2000)).unwrap_or(2000);
-    let rows: Vec<(String, String, String)> = sqlx::query_as(
-        "SELECT target_id, alias, normalized
-         FROM target_alias
-         WHERE normalized LIKE ? ESCAPE '\\'
-         ORDER BY LENGTH(normalized) ASC, normalized ASC
-         LIMIT ?",
-    )
-    .bind(&pattern)
-    .bind(fetch_cap)
-    .fetch_all(pool)
-    .await?;
+    let rows = q_resolver::search_aliases_by_pattern(pool, &pattern, fetch_cap).await?;
 
     // Pick the best (lowest rank, then shortest alias) hit per target_id.
     let mut best_by_target: std::collections::HashMap<String, Best> =
         std::collections::HashMap::new();
-    for (target_id, alias, normalized) in rows {
+    for row in rows {
+        let (target_id, alias, normalized) = (row.target_id, row.alias, row.normalized);
         let rank = if normalized == q {
             RANK_EXACT
         } else if normalized.starts_with(&q) {
@@ -384,30 +341,20 @@ async fn find_existing(
     identity: &ResolvedIdentity,
     derived: &str,
 ) -> CacheResult<Option<ExistingRow>> {
+    fn into_existing_row(row: q_resolver::ExistingTargetRow) -> CacheResult<ExistingRow> {
+        let source = TargetSource::from_wire(&row.source)
+            .ok_or_else(|| CacheError::InvalidSource(row.source.clone()))?;
+        Ok(ExistingRow { id: row.id, source })
+    }
+
     if let Some(oid) = identity.simbad_oid {
-        let row: Option<(String, String)> =
-            sqlx::query_as("SELECT id, source FROM canonical_target WHERE simbad_oid = ?")
-                .bind(oid)
-                .fetch_optional(&mut *conn)
-                .await?;
-        if let Some((id, source)) = row {
-            let source = TargetSource::from_wire(&source)
-                .ok_or_else(|| CacheError::InvalidSource(source.clone()))?;
-            return Ok(Some(ExistingRow { id, source }));
+        if let Some(row) = q_resolver::find_existing_by_simbad_oid_conn(conn, oid).await? {
+            return into_existing_row(row).map(Some);
         }
     }
-    let row: Option<(String, String)> =
-        sqlx::query_as("SELECT id, source FROM canonical_target WHERE id = ?")
-            .bind(derived)
-            .fetch_optional(&mut *conn)
-            .await?;
-    match row {
+    match q_resolver::find_existing_by_id_conn(conn, derived).await? {
         None => Ok(None),
-        Some((id, source)) => {
-            let source = TargetSource::from_wire(&source)
-                .ok_or_else(|| CacheError::InvalidSource(source.clone()))?;
-            Ok(Some(ExistingRow { id, source }))
-        }
+        Some(row) => into_existing_row(row).map(Some),
     }
 }
 
@@ -422,22 +369,17 @@ async fn write_aliases(
     target_id: &str,
     aliases: &[ResolvedAlias],
 ) -> CacheResult<()> {
-    sqlx::query("DELETE FROM target_alias WHERE target_id = ?")
-        .bind(target_id)
-        .execute(&mut *conn)
-        .await?;
+    q_resolver::delete_aliases_for_target_conn(conn, target_id).await?;
     for a in aliases {
         let alias_id = Uuid::new_v4().to_string();
-        sqlx::query(
-            "INSERT OR IGNORE INTO target_alias (id, target_id, alias, normalized, kind)
-             VALUES (?, ?, ?, ?, ?)",
+        q_resolver::insert_alias_conn(
+            conn,
+            &alias_id,
+            target_id,
+            &a.alias,
+            &a.normalized,
+            a.kind.as_wire(),
         )
-        .bind(&alias_id)
-        .bind(target_id)
-        .bind(&a.alias)
-        .bind(&a.normalized)
-        .bind(a.kind.as_wire())
-        .execute(&mut *conn)
         .await?;
     }
     Ok(())
@@ -504,26 +446,17 @@ pub async fn upsert_resolved_conn(
             // Update in place, keeping the existing id (preserve FK targets).
             // display_alias is NOT included — it is user-owned and must never
             // be overwritten by a re-resolution or seed load (FR-012).
-            sqlx::query(
-                "UPDATE canonical_target SET
-                     simbad_oid          = ?,
-                     primary_designation = ?,
-                     object_type         = ?,
-                     ra_deg              = ?,
-                     dec_deg             = ?,
-                     source              = ?,
-                     resolved_at         = ?
-                 WHERE id = ?",
+            q_resolver::update_canonical_target_conn(
+                conn,
+                &row.id,
+                identity.simbad_oid,
+                &identity.primary_designation,
+                identity.object_type.as_wire(),
+                identity.ra_deg,
+                identity.dec_deg,
+                identity.source.as_wire(),
+                &resolved_at,
             )
-            .bind(identity.simbad_oid)
-            .bind(&identity.primary_designation)
-            .bind(identity.object_type.as_wire())
-            .bind(identity.ra_deg)
-            .bind(identity.dec_deg)
-            .bind(identity.source.as_wire())
-            .bind(&resolved_at)
-            .bind(&row.id)
-            .execute(&mut *conn)
             .await?;
             write_aliases(&mut *conn, &row.id, &identity.aliases).await?;
             let id =
@@ -531,20 +464,17 @@ pub async fn upsert_resolved_conn(
             Ok((id, UpsertOutcome::Updated))
         }
         None => {
-            sqlx::query(
-                "INSERT INTO canonical_target
-                     (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+            q_resolver::insert_canonical_target_conn(
+                conn,
+                &derived,
+                identity.simbad_oid,
+                &identity.primary_designation,
+                identity.object_type.as_wire(),
+                identity.ra_deg,
+                identity.dec_deg,
+                identity.source.as_wire(),
+                &resolved_at,
             )
-            .bind(&derived)
-            .bind(identity.simbad_oid)
-            .bind(&identity.primary_designation)
-            .bind(identity.object_type.as_wire())
-            .bind(identity.ra_deg)
-            .bind(identity.dec_deg)
-            .bind(identity.source.as_wire())
-            .bind(&resolved_at)
-            .execute(&mut *conn)
             .await?;
             write_aliases(&mut *conn, &derived, &identity.aliases).await?;
             let id = Uuid::parse_str(&derived)
@@ -591,64 +521,38 @@ pub struct TargetListRow {
 /// Returns [`CacheError::Database`] on query failure, or [`CacheError::InvalidUuid`]
 /// on a corrupt stored id.
 pub async fn list_all(pool: &SqlitePool) -> CacheResult<Vec<TargetListRow>> {
-    let rows: Vec<TargetListQueryRow> = sqlx::query_as(
-        "SELECT id, primary_designation, display_alias, object_type,
-                ra_deg, dec_deg, constellation, magnitude
-         FROM canonical_target
-         ORDER BY primary_designation ASC",
-    )
-    .fetch_all(pool)
-    .await?;
+    let rows = q_resolver::list_canonical_targets(pool).await?;
 
     if rows.is_empty() {
         return Ok(Vec::new());
     }
 
     // Batch-load aliases for all returned targets (avoids N+1 queries).
-    // Returns (target_id, alias) ordered by target_id, then alias.
-    let alias_rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT target_id, alias
-         FROM target_alias
-         ORDER BY target_id ASC, alias ASC",
-    )
-    .fetch_all(pool)
-    .await?;
+    let alias_rows = q_resolver::list_all_target_aliases(pool).await?;
 
     // Group aliases by target_id into a lookup map.
     let mut aliases_by_id: std::collections::HashMap<String, Vec<String>> =
         std::collections::HashMap::new();
-    for (target_id, alias) in alias_rows {
-        aliases_by_id.entry(target_id).or_default().push(alias);
+    for r in alias_rows {
+        aliases_by_id.entry(r.target_id).or_default().push(r.alias);
     }
 
     rows.into_iter()
-        .map(
-            |(
-                id_str,
-                primary_designation,
-                display_alias,
-                object_type,
-                ra_deg,
-                dec_deg,
-                constellation,
-                magnitude,
-            )| {
-                let id = Uuid::parse_str(&id_str)
-                    .map_err(|e| CacheError::InvalidUuid(id_str.clone(), e))?;
-                let aliases = aliases_by_id.remove(&id_str).unwrap_or_default();
-                Ok(TargetListRow {
-                    id,
-                    primary_designation,
-                    display_alias,
-                    object_type,
-                    ra_deg,
-                    dec_deg,
-                    constellation,
-                    magnitude,
-                    aliases,
-                })
-            },
-        )
+        .map(|row| {
+            let id = Uuid::parse_str(&row.id).map_err(|e| CacheError::InvalidUuid(row.id.clone(), e))?;
+            let aliases = aliases_by_id.remove(&row.id).unwrap_or_default();
+            Ok(TargetListRow {
+                id,
+                primary_designation: row.primary_designation,
+                display_alias: row.display_alias,
+                object_type: row.object_type,
+                ra_deg: row.ra_deg,
+                dec_deg: row.dec_deg,
+                constellation: row.constellation,
+                magnitude: row.magnitude,
+                aliases,
+            })
+        })
         .collect()
 }
 
@@ -674,26 +578,16 @@ pub async fn insert_user_alias(
     }
     let alias_id = Uuid::new_v4().to_string();
     let target_id_str = target_id.to_string();
-    let result = sqlx::query(
-        "INSERT OR IGNORE INTO target_alias (id, target_id, alias, normalized, kind)
-         VALUES (?, ?, ?, ?, 'user')",
-    )
-    .bind(&alias_id)
-    .bind(&target_id_str)
-    .bind(alias)
-    .bind(&normalized)
-    .execute(pool)
-    .await?;
+    let rows_affected =
+        q_resolver::insert_user_alias(pool, &alias_id, &target_id_str, alias, &normalized)
+            .await?;
 
-    if result.rows_affected() == 0 {
+    if rows_affected == 0 {
         // Alias already exists — return the existing id.
-        let existing: Option<(String,)> =
-            sqlx::query_as("SELECT id FROM target_alias WHERE target_id = ? AND normalized = ?")
-                .bind(&target_id_str)
-                .bind(&normalized)
-                .fetch_optional(pool)
+        let existing =
+            q_resolver::select_alias_id_by_target_and_normalized(pool, &target_id_str, &normalized)
                 .await?;
-        Ok(existing.map(|(id,)| (id, alias.to_owned())))
+        Ok(existing.map(|id| (id, alias.to_owned())))
     } else {
         Ok(Some((alias_id, alias.to_owned())))
     }
@@ -708,11 +602,7 @@ pub async fn insert_user_alias(
 ///
 /// Returns [`CacheError::Database`] on query failure.
 pub async fn delete_user_alias(pool: &SqlitePool, alias_id: &str) -> CacheResult<bool> {
-    let result = sqlx::query("DELETE FROM target_alias WHERE id = ? AND kind = 'user'")
-        .bind(alias_id)
-        .execute(pool)
-        .await?;
-    Ok(result.rows_affected() > 0)
+    Ok(q_resolver::delete_user_alias(pool, alias_id).await?)
 }
 
 /// Set the `display_alias` column for a target (FR-012).
@@ -730,12 +620,7 @@ pub async fn set_display_alias(
 ) -> CacheResult<bool> {
     let value: Option<&str> =
         if display_alias.trim().is_empty() { None } else { Some(display_alias) };
-    let result = sqlx::query("UPDATE canonical_target SET display_alias = ? WHERE id = ?")
-        .bind(value)
-        .bind(target_id.to_string())
-        .execute(pool)
-        .await?;
-    Ok(result.rows_affected() > 0)
+    Ok(q_resolver::set_display_alias(pool, &target_id.to_string(), value).await?)
 }
 
 /// Clear the `display_alias` column for a target (sets to NULL).
@@ -746,11 +631,7 @@ pub async fn set_display_alias(
 ///
 /// Returns [`CacheError::Database`] on query failure.
 pub async fn clear_display_alias(pool: &SqlitePool, target_id: Uuid) -> CacheResult<bool> {
-    let result = sqlx::query("UPDATE canonical_target SET display_alias = NULL WHERE id = ?")
-        .bind(target_id.to_string())
-        .execute(pool)
-        .await?;
-    Ok(result.rows_affected() > 0)
+    Ok(q_resolver::clear_display_alias(pool, &target_id.to_string()).await?)
 }
 
 #[cfg(test)]

--- a/crates/targeting/resolver/src/cache.rs
+++ b/crates/targeting/resolver/src/cache.rs
@@ -539,7 +539,8 @@ pub async fn list_all(pool: &SqlitePool) -> CacheResult<Vec<TargetListRow>> {
 
     rows.into_iter()
         .map(|row| {
-            let id = Uuid::parse_str(&row.id).map_err(|e| CacheError::InvalidUuid(row.id.clone(), e))?;
+            let id =
+                Uuid::parse_str(&row.id).map_err(|e| CacheError::InvalidUuid(row.id.clone(), e))?;
             let aliases = aliases_by_id.remove(&row.id).unwrap_or_default();
             Ok(TargetListRow {
                 id,
@@ -579,8 +580,7 @@ pub async fn insert_user_alias(
     let alias_id = Uuid::new_v4().to_string();
     let target_id_str = target_id.to_string();
     let rows_affected =
-        q_resolver::insert_user_alias(pool, &alias_id, &target_id_str, alias, &normalized)
-            .await?;
+        q_resolver::insert_user_alias(pool, &alias_id, &target_id_str, alias, &normalized).await?;
 
     if rows_affected == 0 {
         // Alias already exists — return the existing id.

--- a/crates/targeting/resolver/src/seed.rs
+++ b/crates/targeting/resolver/src/seed.rs
@@ -42,6 +42,7 @@
 //! Constitution §I/§V: seed data is metadata only; the SQLite cache is the
 //! durable record and the seed is a reproducible projection into it.
 
+use persistence_db::repositories::q_resolver;
 use serde::{Deserialize, Serialize};
 use sqlx::SqlitePool;
 
@@ -106,6 +107,9 @@ pub enum SeedError {
     /// A query for first-run state failed.
     #[error("database error: {0}")]
     Database(#[from] sqlx::Error),
+    /// A `persistence_db` repository call failed.
+    #[error("persistence error: {0}")]
+    Persistence(#[from] persistence_db::DbError),
 }
 
 impl SeedEntry {
@@ -164,8 +168,7 @@ pub fn bundled() -> Result<SeedAsset, SeedError> {
 ///
 /// Returns [`SeedError::Database`] on query failure.
 pub async fn is_first_run(pool: &SqlitePool) -> Result<bool, SeedError> {
-    let (count,): (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM canonical_target").fetch_one(pool).await?;
+    let count = q_resolver::count_canonical_targets(pool).await?;
     Ok(count == 0)
 }
 


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves cache.rs (38 sites) and seed.rs (1 site) behind persistence_db::repositories::q_resolver.

Reviewed+approved (opus, 0 change items). Transaction batching verified intact, dedup SQL byte-matches, not-found still Ok(None). Depends on merged foundation.