### PR TITLE
refactor: move app-core database queries behind the persistence layer

### DIFF
--- a/crates/app/core/src/frame_inventory.rs
+++ b/crates/app/core/src/frame_inventory.rs
@@ -38,15 +38,6 @@ fn internal(msg: impl std::fmt::Display) -> ContractError {
     ContractError::new(ErrorCode::InternalDatabase, msg.to_string(), ErrorSeverity::Fatal, true)
 }
 
-/// Maps a raw `sqlx::Error` (from direct queries in this module) to a
-/// `ContractError`. Distinct from `app_core_errors::db_err`, which maps
-/// `persistence_db::DbError` (the repository-layer error type used by
-/// `get_library_root_path` below).
-#[allow(clippy::needless_pass_by_value)] // used as a `map_err` callback, which owns `sqlx::Error`
-fn sqlx_db_err_owned(e: sqlx::Error) -> ContractError {
-    ContractError::new(ErrorCode::InternalDatabase, e.to_string(), ErrorSeverity::Fatal, true)
-}
-
 /// Raw row shape shared by both list paths.
 struct FrameRow {
     id: String,
@@ -79,24 +70,21 @@ async fn frame_ids_for_session(
     pool: &SqlitePool,
     session_id: &str,
 ) -> Result<Option<(Vec<String>, RawFrameType)>, ContractError> {
-    if let Some((frame_ids_json,)) =
-        sqlx::query_as::<_, (String,)>("SELECT frame_ids FROM acquisition_session WHERE id = ?")
-            .bind(session_id)
-            .fetch_optional(pool)
+    if let Some(frame_ids_json) =
+        persistence_db::repositories::q_core::get_acquisition_session_frame_ids(pool, session_id)
             .await
-            .map_err(sqlx_db_err_owned)?
+            .map_err(db_err)?
     {
         let ids: Vec<String> = serde_json::from_str(&frame_ids_json).unwrap_or_default();
         return Ok(Some((ids, RawFrameType::Light)));
     }
 
-    if let Some((frame_ids_json, kind)) = sqlx::query_as::<_, (String, String)>(
-        "SELECT frame_ids, kind FROM calibration_session WHERE id = ?",
-    )
-    .bind(session_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(sqlx_db_err_owned)?
+    if let Some((frame_ids_json, kind)) =
+        persistence_db::repositories::q_core::get_calibration_session_frame_ids_and_kind(
+            pool, session_id,
+        )
+        .await
+        .map_err(db_err)?
     {
         let ids: Vec<String> = serde_json::from_str(&frame_ids_json).unwrap_or_default();
         return Ok(Some((ids, raw_frame_type_from_calibration_kind(&kind))));
@@ -105,50 +93,28 @@ async fn frame_ids_for_session(
     Ok(None)
 }
 
+fn frame_row_from_repo_row(r: persistence_db::repositories::q_core::FileRecordRow) -> FrameRow {
+    FrameRow {
+        id: r.id,
+        root_id: r.root_id,
+        relative_path: r.relative_path,
+        size_bytes: r.size_bytes,
+        state: r.state,
+    }
+}
+
 async fn rows_by_ids(pool: &SqlitePool, ids: &[String]) -> Result<Vec<FrameRow>, ContractError> {
-    if ids.is_empty() {
-        return Ok(Vec::new());
-    }
-    let mut builder = sqlx::QueryBuilder::new(
-        "SELECT id, root_id, relative_path, size_bytes, state FROM file_record WHERE id IN (",
-    );
-    let mut separated = builder.separated(", ");
-    for id in ids {
-        separated.push_bind(id);
-    }
-    separated.push_unseparated(")");
-    let rows: Vec<(String, String, String, i64, String)> =
-        builder.build_query_as().fetch_all(pool).await.map_err(sqlx_db_err_owned)?;
-    Ok(rows
-        .into_iter()
-        .map(|(id, root_id, relative_path, size_bytes, state)| FrameRow {
-            id,
-            root_id,
-            relative_path,
-            size_bytes,
-            state,
-        })
-        .collect())
+    let rows = persistence_db::repositories::q_core::file_records_by_ids(pool, ids)
+        .await
+        .map_err(db_err)?;
+    Ok(rows.into_iter().map(frame_row_from_repo_row).collect())
 }
 
 async fn rows_by_root(pool: &SqlitePool, root_id: &str) -> Result<Vec<FrameRow>, ContractError> {
-    let rows: Vec<(String, String, String, i64, String)> = sqlx::query_as(
-        "SELECT id, root_id, relative_path, size_bytes, state FROM file_record WHERE root_id = ?",
-    )
-    .bind(root_id)
-    .fetch_all(pool)
-    .await
-    .map_err(sqlx_db_err_owned)?;
-    Ok(rows
-        .into_iter()
-        .map(|(id, root_id, relative_path, size_bytes, state)| FrameRow {
-            id,
-            root_id,
-            relative_path,
-            size_bytes,
-            state,
-        })
-        .collect())
+    let rows = persistence_db::repositories::q_core::file_records_by_root(pool, root_id)
+        .await
+        .map_err(db_err)?;
+    Ok(rows.into_iter().map(frame_row_from_repo_row).collect())
 }
 
 /// Best-effort reverse lookup: which session (if any) references `frame_id`,
@@ -164,24 +130,18 @@ async fn owning_session_frame_type(
 ) -> Result<(Option<String>, RawFrameType), ContractError> {
     let like = format!("%\"{frame_id}\"%");
 
-    if let Some((session_id,)) = sqlx::query_as::<_, (String,)>(
-        "SELECT id FROM acquisition_session WHERE frame_ids LIKE ? LIMIT 1",
-    )
-    .bind(&like)
-    .fetch_optional(pool)
-    .await
-    .map_err(sqlx_db_err_owned)?
+    if let Some(session_id) =
+        persistence_db::repositories::q_core::find_acquisition_session_id_by_frame_like(pool, &like)
+            .await
+            .map_err(db_err)?
     {
         return Ok((Some(session_id), RawFrameType::Light));
     }
 
-    if let Some((session_id, kind)) = sqlx::query_as::<_, (String, String)>(
-        "SELECT id, kind FROM calibration_session WHERE frame_ids LIKE ? LIMIT 1",
-    )
-    .bind(&like)
-    .fetch_optional(pool)
-    .await
-    .map_err(sqlx_db_err_owned)?
+    if let Some((session_id, kind)) =
+        persistence_db::repositories::q_core::find_calibration_session_by_frame_like(pool, &like)
+            .await
+            .map_err(db_err)?
     {
         return Ok((Some(session_id), raw_frame_type_from_calibration_kind(&kind)));
     }
@@ -363,13 +323,9 @@ async fn apply_missing_outcome(
     }
     tally.newly_missing += 1;
     let now = iso_now();
-    sqlx::query(
-        "UPDATE file_record SET state = 'missing', last_seen_at = last_seen_at WHERE id = ?",
-    )
-    .bind(&row.id)
-    .execute(pool)
-    .await
-    .map_err(sqlx_db_err_owned)?;
+    persistence_db::repositories::q_core::mark_file_record_missing(pool, &row.id)
+        .await
+        .map_err(db_err)?;
 
     bus.publish(
         audit::event_bus::TOPIC_FRAME_MISSING,

--- a/crates/app/core/src/search.rs
+++ b/crates/app/core/src/search.rs
@@ -86,48 +86,26 @@ async fn search_targets(pool: &SqlitePool, q: &str) -> Result<Vec<SearchResult>,
     // Include `match_via_alias` to score alias matches correctly.
     let like_pattern = format!("%{q}%");
 
-    // Returns (id, primary_designation, best_alias_normalized_match)
-    let rows: Vec<(String, String, Option<String>)> = sqlx::query_as(
-        // spec 036 reconciliation: query the gen-3 canonical_target / target_alias
-        // tables (the legacy spec-013 targets / target_aliases were retired).
-        "SELECT t.id, COALESCE(t.display_alias, t.primary_designation) AS label,
-                (SELECT ta.alias FROM target_alias ta
-                 WHERE ta.target_id = t.id
-                   AND ta.normalized LIKE ?
-                 LIMIT 1) AS alias_match
-         FROM canonical_target t
-         WHERE LOWER(t.primary_designation) LIKE ?
-            OR EXISTS (
-                SELECT 1 FROM target_alias ta2
-                WHERE ta2.target_id = t.id
-                  AND ta2.normalized LIKE ?
-            )
-         ORDER BY t.primary_designation ASC
-         LIMIT 10",
-    )
-    .bind(&like_pattern)
-    .bind(&like_pattern)
-    .bind(&like_pattern)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::search_targets_by_like(pool, &like_pattern)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .into_iter()
-        .map(|(id, designation, alias_match)| {
+        .map(|row| {
             // Score on both primary designation and alias; take the higher score.
-            let s_primary = score(&designation, q);
-            let s_alias = alias_match.as_deref().map_or(0.0, |a| score(a, q));
+            let s_primary = score(&row.label, q);
+            let s_alias = row.alias_match.as_deref().map_or(0.0, |a| score(a, q));
             let s = s_primary.max(s_alias);
             // All rows came from the SQL LIKE filter so there must be a match.
             // Use a minimum non-zero score for alias-only matches.
             let final_score = if s <= 0.0 { 0.6 } else { s };
             SearchResult {
-                id: id.clone(),
+                id: row.id.clone(),
                 kind: SearchResultKind::Target,
-                label: designation,
-                sublabel: alias_match,
-                route: format!("/targets/{id}"),
+                label: row.label,
+                sublabel: row.alias_match,
+                route: format!("/targets/{}", row.id),
                 score: final_score,
             }
         })
@@ -135,22 +113,18 @@ async fn search_targets(pool: &SqlitePool, q: &str) -> Result<Vec<SearchResult>,
 }
 
 async fn recent_targets(pool: &SqlitePool) -> Result<Vec<SearchResult>, String> {
-    let rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT id, COALESCE(display_alias, primary_designation) FROM canonical_target \
-         ORDER BY resolved_at DESC LIMIT 5",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::recent_targets(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .into_iter()
-        .map(|(id, designation)| SearchResult {
-            id: id.clone(),
+        .map(|row| SearchResult {
+            id: row.id.clone(),
             kind: SearchResultKind::Target,
-            label: designation,
+            label: row.label,
             sublabel: Some("Recent target".to_owned()),
-            route: format!("/targets/{id}"),
+            route: format!("/targets/{}", row.id),
             score: 0.5,
         })
         .collect())
@@ -161,31 +135,23 @@ async fn recent_targets(pool: &SqlitePool) -> Result<Vec<SearchResult>, String> 
 async fn search_sessions(pool: &SqlitePool, q: &str) -> Result<Vec<SearchResult>, String> {
     let like_pattern = format!("%{q}%");
 
-    let rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT id, session_key
-         FROM acquisition_session
-         WHERE LOWER(session_key) LIKE ?
-         ORDER BY created_at DESC
-         LIMIT 10",
-    )
-    .bind(&like_pattern)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::search_sessions_by_like(pool, &like_pattern)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .into_iter()
-        .filter_map(|(id, key)| {
-            let s = score(&key, q);
+        .filter_map(|row| {
+            let s = score(&row.label, q);
             if s <= 0.0 {
                 return None;
             }
             Some(SearchResult {
-                id: id.clone(),
+                id: row.id.clone(),
                 kind: SearchResultKind::Session,
-                label: key,
+                label: row.label,
                 sublabel: None,
-                route: format!("/sessions/{id}"),
+                route: format!("/sessions/{}", row.id),
                 score: s,
             })
         })
@@ -193,24 +159,18 @@ async fn search_sessions(pool: &SqlitePool, q: &str) -> Result<Vec<SearchResult>
 }
 
 async fn recent_sessions(pool: &SqlitePool) -> Result<Vec<SearchResult>, String> {
-    let rows: Vec<(String, String)> = sqlx::query_as(
-        "SELECT id, session_key
-         FROM acquisition_session
-         ORDER BY created_at DESC
-         LIMIT 5",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::recent_sessions(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .into_iter()
-        .map(|(id, key)| SearchResult {
-            id: id.clone(),
+        .map(|row| SearchResult {
+            id: row.id.clone(),
             kind: SearchResultKind::Session,
-            label: key,
+            label: row.label,
             sublabel: Some("Recent session".to_owned()),
-            route: format!("/sessions/{id}"),
+            route: format!("/sessions/{}", row.id),
             score: 0.45,
         })
         .collect())
@@ -221,31 +181,23 @@ async fn recent_sessions(pool: &SqlitePool) -> Result<Vec<SearchResult>, String>
 async fn search_projects(pool: &SqlitePool, q: &str) -> Result<Vec<SearchResult>, String> {
     let like_pattern = format!("%{q}%");
 
-    let rows: Vec<(String, String, String)> = sqlx::query_as(
-        "SELECT id, name, lifecycle
-         FROM projects
-         WHERE LOWER(name) LIKE ?
-         ORDER BY name ASC
-         LIMIT 10",
-    )
-    .bind(&like_pattern)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::search_projects_by_like(pool, &like_pattern)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .into_iter()
-        .filter_map(|(id, name, lifecycle)| {
-            let s = score(&name, q);
+        .filter_map(|row| {
+            let s = score(&row.name, q);
             if s <= 0.0 {
                 return None;
             }
             Some(SearchResult {
-                id: id.clone(),
+                id: row.id.clone(),
                 kind: SearchResultKind::Project,
-                label: name,
-                sublabel: Some(lifecycle),
-                route: format!("/projects/{id}"),
+                label: row.name,
+                sublabel: Some(row.lifecycle),
+                route: format!("/projects/{}", row.id),
                 score: s,
             })
         })
@@ -253,20 +205,18 @@ async fn search_projects(pool: &SqlitePool, q: &str) -> Result<Vec<SearchResult>
 }
 
 async fn recent_projects(pool: &SqlitePool) -> Result<Vec<SearchResult>, String> {
-    let rows: Vec<(String, String)> =
-        sqlx::query_as("SELECT id, name FROM projects ORDER BY created_at DESC LIMIT 5")
-            .fetch_all(pool)
-            .await
-            .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::recent_projects(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
     Ok(rows
         .into_iter()
-        .map(|(id, name)| SearchResult {
-            id: id.clone(),
+        .map(|row| SearchResult {
+            id: row.id.clone(),
             kind: SearchResultKind::Project,
-            label: name,
+            label: row.label,
             sublabel: Some("Recent project".to_owned()),
-            route: format!("/projects/{id}"),
+            route: format!("/projects/{}", row.id),
             score: 0.4,
         })
         .collect())

--- a/crates/app/core/src/sessions.rs
+++ b/crates/app/core/src/sessions.rs
@@ -39,11 +39,6 @@ use contracts_core::sessions::{
 use sqlx::SqlitePool;
 use std::collections::HashMap;
 
-/// One `acquisition_session` row joined with its canonical target (spec 035
-/// US4/T044). Columns: id, session_key, legacy target_id, frame_ids (JSON),
-/// created_at, canonical_target_id, canonical primary designation.
-type SessionRow = (String, String, Option<String>, String, String, Option<String>, Option<String>);
-
 // -- Public use-case functions ------------------------------------------------
 
 /// `sessions.list` -- return all acquisition sessions from real DB rows.
@@ -58,32 +53,17 @@ pub async fn list_sessions(pool: &SqlitePool) -> Result<Vec<AcquisitionSession>,
     // resolved target name (`primary_designation`) surfaces in the read path.
     // `canonical_target_id` (migration 0046) is the spec-035 link; it coexists
     // with the legacy `target_id` (→ old `target` table, left NULL by ingest).
-    let rows: Vec<SessionRow> = sqlx::query_as(
-        "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at,
-                s.canonical_target_id, ct.primary_designation
-         FROM acquisition_session s
-         LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id
-         ORDER BY s.created_at DESC",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let rows = persistence_db::repositories::q_core::list_sessions_joined(pool)
+        .await
+        .map_err(|e| e.to_string())?;
 
     let mut sessions = Vec::with_capacity(rows.len());
-    for (
-        id,
-        session_key_json,
-        target_id,
-        frame_ids_json,
-        _created_at,
-        canonical_target_id,
-        canonical_name,
-    ) in rows
-    {
+    for row in rows {
+        let id = row.id;
         let fp = load_fingerprint(pool, &id).await?;
-        let mut sk = parse_session_key(&session_key_json, fp.as_ref());
+        let mut sk = parse_session_key(&row.session_key, fp.as_ref());
         // Prefer the canonical target's display designation when linked.
-        if let Some(name) = canonical_name.filter(|n| !n.is_empty()) {
+        if let Some(name) = row.canonical_target_name.filter(|n| !n.is_empty()) {
             sk.target = name;
         }
         // Spec 041 FR-051: sessions are derived, already-confirmed inventory —
@@ -94,14 +74,14 @@ pub async fn list_sessions(pool: &SqlitePool) -> Result<Vec<AcquisitionSession>,
         // spec 048 US1: frame_count/total_size_bytes are the ACTIVE (non-missing)
         // file_record members — honest counts/totals, not the raw array length
         // (which may retain `missing` ids in flag-missing mode).
-        let (frame_count, total_size_bytes) = active_frame_summary(pool, &frame_ids_json).await?;
+        let (frame_count, total_size_bytes) = active_frame_summary(pool, &row.frame_ids).await?;
         // TODO(037): total_integration_seconds -- not stored; requires frame-level data.
         let total_integration_seconds = 0.0_f64;
         // TODO(037): metadata -- not stored as structured provenance rows yet.
         let metadata = HashMap::new();
         // Surface the canonical target id (spec 035) when the legacy target_id is
         // absent — ingested sessions link via canonical_target_id (R10).
-        let target_ids = target_id.or(canonical_target_id).into_iter().collect();
+        let target_ids = row.target_id.or(row.canonical_target_id).into_iter().collect();
         let project_ids = load_project_ids(pool, &id).await?;
         // TODO(037): warnings -- not stored; derive from fingerprint in future.
         let warnings = Vec::new();
@@ -130,31 +110,15 @@ pub async fn list_sessions(pool: &SqlitePool) -> Result<Vec<AcquisitionSession>,
 /// # Errors
 /// Returns `Err(String)` on database failure or when the session is absent.
 pub async fn get_session(pool: &SqlitePool, id: &str) -> Result<SessionDetail, String> {
-    let row: Option<SessionRow> = sqlx::query_as(
-        "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at,
-                s.canonical_target_id, ct.primary_designation
-         FROM acquisition_session s
-         LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id
-         WHERE s.id = ?",
-    )
-    .bind(id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row = persistence_db::repositories::q_core::get_session_joined(pool, id)
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| format!("session.not_found: {id}"))?;
 
-    let (
-        id,
-        session_key_json,
-        target_id,
-        frame_ids_json,
-        _created_at,
-        canonical_target_id,
-        canonical_name,
-    ) = row.ok_or_else(|| format!("session.not_found: {id}"))?;
-
+    let id = row.id;
     let fp = load_fingerprint(pool, &id).await?;
-    let mut sk = parse_session_key(&session_key_json, fp.as_ref());
-    if let Some(name) = canonical_name.filter(|n| !n.is_empty()) {
+    let mut sk = parse_session_key(&row.session_key, fp.as_ref());
+    if let Some(name) = row.canonical_target_name.filter(|n| !n.is_empty()) {
         sk.target = name;
     }
     // Spec 041 FR-051: sessions are derived, already-confirmed inventory —
@@ -163,12 +127,12 @@ pub async fn get_session(pool: &SqlitePool, id: &str) -> Result<SessionDetail, S
     // TODO(037): optical_train_id -- fingerprint stores name, not UUID.
     let optical_train_id = fp.as_ref().and_then(|f| f.optic_train.clone()).unwrap_or_default();
     // spec 048 US1: active (non-missing) frame_count/total_size_bytes.
-    let (frame_count, total_size_bytes) = active_frame_summary(pool, &frame_ids_json).await?;
+    let (frame_count, total_size_bytes) = active_frame_summary(pool, &row.frame_ids).await?;
     // TODO(037): total_integration_seconds -- not stored.
     let total_integration_seconds = 0.0_f64;
     // TODO(037): metadata -- not stored as structured provenance rows yet.
     let metadata = HashMap::new();
-    let target_ids = target_id.or(canonical_target_id).into_iter().collect();
+    let target_ids = row.target_id.or(row.canonical_target_id).into_iter().collect();
     let project_ids = load_project_ids(pool, &id).await?;
     // TODO(037): warnings -- not stored.
     let warnings = Vec::new();
@@ -234,26 +198,17 @@ struct Fingerprint {
     observing_night_date: Option<String>,
 }
 
-type FingerprintRow =
-    Option<(Option<f64>, Option<String>, Option<String>, Option<String>, Option<String>)>;
-
 async fn load_fingerprint(pool: &SqlitePool, id: &str) -> Result<Option<Fingerprint>, String> {
-    let row: FingerprintRow = sqlx::query_as(
-        "SELECT gain, filter_name, binning, optic_train, observing_night_date
-         FROM acquisition_fingerprint
-         WHERE id = ?",
-    )
-    .bind(id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| e.to_string())?;
+    let row = persistence_db::repositories::q_core::get_fingerprint(pool, id)
+        .await
+        .map_err(|e| e.to_string())?;
 
-    Ok(row.map(|(gain, filter_name, binning, optic_train, observing_night_date)| Fingerprint {
-        gain,
-        filter_name,
-        binning,
-        optic_train,
-        observing_night_date,
+    Ok(row.map(|r| Fingerprint {
+        gain: r.gain,
+        filter_name: r.filter_name,
+        binning: r.binning,
+        optic_train: r.optic_train,
+        observing_night_date: r.observing_night_date,
     }))
 }
 
@@ -311,31 +266,17 @@ async fn active_frame_summary(
     frame_ids_json: &str,
 ) -> Result<(u32, u64), String> {
     let ids: Vec<String> = serde_json::from_str(frame_ids_json).unwrap_or_default();
-    if ids.is_empty() {
-        return Ok((0, 0));
-    }
-    let mut builder = sqlx::QueryBuilder::new(
-        "SELECT COUNT(*), COALESCE(SUM(size_bytes), 0) FROM file_record WHERE state != 'missing' AND id IN (",
-    );
-    let mut separated = builder.separated(", ");
-    for id in &ids {
-        separated.push_bind(id);
-    }
-    separated.push_unseparated(")");
-    let (count, total): (i64, i64) =
-        builder.build_query_as().fetch_one(pool).await.map_err(|e| e.to_string())?;
+    let (count, total) = persistence_db::repositories::q_core::active_frame_summary(pool, &ids)
+        .await
+        .map_err(|e| e.to_string())?;
     Ok((u32::try_from(count.max(0)).unwrap_or(0), u64::try_from(total.max(0)).unwrap_or(0)))
 }
 
 /// Load project ids linked to a session via `project_sources`.
 async fn load_project_ids(pool: &SqlitePool, session_id: &str) -> Result<Vec<String>, String> {
-    let rows: Vec<(String,)> =
-        sqlx::query_as("SELECT project_id FROM project_sources WHERE inventory_session_id = ?")
-            .bind(session_id)
-            .fetch_all(pool)
-            .await
-            .unwrap_or_default();
-    Ok(rows.into_iter().map(|(p,)| p).collect())
+    Ok(persistence_db::repositories::q_core::project_ids_for_session(pool, session_id)
+        .await
+        .unwrap_or_default())
 }
 
 /// Load calibration matches for a session from `calibration_assignment`.
@@ -343,25 +284,25 @@ async fn load_calibration_matches(
     pool: &SqlitePool,
     session_id: &str,
 ) -> Result<Vec<SessionCalibrationMatch>, String> {
-    let rows: Vec<(String, String, f64, String)> = sqlx::query_as(
-        "SELECT master_id, calibration_type, confidence, mismatched_dimensions
-         FROM calibration_assignment
-         WHERE session_id = ?",
-    )
-    .bind(session_id)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    let rows =
+        persistence_db::repositories::q_core::calibration_matches_for_session(pool, session_id)
+            .await
+            .unwrap_or_default();
 
     Ok(rows
         .into_iter()
-        .map(|(master_id, calibration_type, score, mismatch_json)| {
+        .map(|r| {
             // DB CHECK constrains `calibration_type` to dark/flat/bias; unknown
             // values fall back to Dark, preserving prior behavior.
-            let kind = calibration_type.parse().unwrap_or(CalibrationKind::Dark);
+            let kind = r.calibration_type.parse().unwrap_or(CalibrationKind::Dark);
             let soft_mismatches: Vec<String> =
-                serde_json::from_str(&mismatch_json).unwrap_or_default();
-            SessionCalibrationMatch { master_id, kind, score, soft_mismatches }
+                serde_json::from_str(&r.mismatched_dimensions).unwrap_or_default();
+            SessionCalibrationMatch {
+                master_id: r.master_id,
+                kind,
+                score: r.confidence,
+                soft_mismatches,
+            }
         })
         .collect())
 }
@@ -371,20 +312,13 @@ async fn load_history(
     pool: &SqlitePool,
     session_id: &str,
 ) -> Result<Vec<SessionHistoryEntry>, String> {
-    let rows: Vec<(String, String, String)> = sqlx::query_as(
-        "SELECT at, trigger, actor
-         FROM audit_log_entry
-         WHERE entity_type = 'acquisition_session' AND entity_id = ?
-         ORDER BY at ASC",
-    )
-    .bind(session_id)
-    .fetch_all(pool)
-    .await
-    .unwrap_or_default();
+    let rows = persistence_db::repositories::q_core::session_history(pool, session_id)
+        .await
+        .unwrap_or_default();
 
     Ok(rows
         .into_iter()
-        .map(|(timestamp, event, actor)| SessionHistoryEntry { timestamp, event, actor })
+        .map(|r| SessionHistoryEntry { timestamp: r.at, event: r.trigger, actor: r.actor })
         .collect())
 }
 

--- a/crates/persistence/db/src/repositories/q_core.rs
+++ b/crates/persistence/db/src/repositories/q_core.rs
@@ -1,3 +1,579 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_core`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Free-fn repository queries backing `app_core::frame_inventory`,
+//! `app_core::search`, and `app_core::sessions` (db-boundary-zero drain).
+//!
+//! Grouped by the app-layer module each function set backs. Business logic
+//! (DTO mapping, filtering, presence-state derivation) stays in `app_core`;
+//! this module only executes SQL and returns typed rows.
+
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+// ── frame_inventory ─────────────────────────────────────────────────────────
+
+/// `frame_ids` JSON string for an `acquisition_session`, if it exists.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_acquisition_session_frame_ids(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<String>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT frame_ids FROM acquisition_session WHERE id = ?")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(f,)| f))
+}
+
+/// `(frame_ids, kind)` for a `calibration_session`, if it exists.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_calibration_session_frame_ids_and_kind(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<(String, String)>> {
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT frame_ids, kind FROM calibration_session WHERE id = ?")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row)
+}
+
+/// A `file_record` row (spec 048 per-frame inventory).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FileRecordRow {
+    pub id: String,
+    pub root_id: String,
+    pub relative_path: String,
+    pub size_bytes: i64,
+    pub state: String,
+}
+
+/// `file_record` rows matching a set of ids. Empty `ids` short-circuits
+/// without querying.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn file_records_by_ids(
+    pool: &SqlitePool,
+    ids: &[String],
+) -> DbResult<Vec<FileRecordRow>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT id, root_id, relative_path, size_bytes, state FROM file_record WHERE id IN (",
+    );
+    let mut separated = builder.separated(", ");
+    for id in ids {
+        separated.push_bind(id);
+    }
+    separated.push_unseparated(")");
+    let rows = builder.build_query_as::<FileRecordRow>().fetch_all(pool).await?;
+    Ok(rows)
+}
+
+/// `file_record` rows for a given root.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn file_records_by_root(
+    pool: &SqlitePool,
+    root_id: &str,
+) -> DbResult<Vec<FileRecordRow>> {
+    let rows = sqlx::query_as::<_, FileRecordRow>(
+        "SELECT id, root_id, relative_path, size_bytes, state FROM file_record WHERE root_id = ?",
+    )
+    .bind(root_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Id of the `acquisition_session` whose `frame_ids` JSON array contains a
+/// given frame id, matched via `LIKE`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn find_acquisition_session_id_by_frame_like(
+    pool: &SqlitePool,
+    like_pattern: &str,
+) -> DbResult<Option<String>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT id FROM acquisition_session WHERE frame_ids LIKE ? LIMIT 1")
+            .bind(like_pattern)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(id,)| id))
+}
+
+/// `(session id, kind)` of the `calibration_session` whose `frame_ids` JSON
+/// array contains a given frame id, matched via `LIKE`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn find_calibration_session_by_frame_like(
+    pool: &SqlitePool,
+    like_pattern: &str,
+) -> DbResult<Option<(String, String)>> {
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT id, kind FROM calibration_session WHERE frame_ids LIKE ? LIMIT 1")
+            .bind(like_pattern)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row)
+}
+
+/// Mark a `file_record` row `missing`. Preserves the original call site's
+/// `last_seen_at = last_seen_at` no-op assignment (leaves the column
+/// untouched while still forming a valid `UPDATE`).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn mark_file_record_missing(pool: &SqlitePool, id: &str) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE file_record SET state = 'missing', last_seen_at = last_seen_at WHERE id = ?",
+    )
+    .bind(id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── search ───────────────────────────────────────────────────────────────────
+
+/// Row from the target search query: id, resolved label, and the best
+/// matching alias (if the match came via an alias rather than the primary
+/// designation).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TargetSearchRow {
+    pub id: String,
+    pub label: String,
+    pub alias_match: Option<String>,
+}
+
+/// Search `canonical_target` by primary designation or alias, `like_pattern`
+/// already wrapped in `%...%`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn search_targets_by_like(
+    pool: &SqlitePool,
+    like_pattern: &str,
+) -> DbResult<Vec<TargetSearchRow>> {
+    let rows = sqlx::query_as::<_, TargetSearchRow>(
+        // spec 036 reconciliation: query the gen-3 canonical_target / target_alias
+        // tables (the legacy spec-013 targets / target_aliases were retired).
+        "SELECT t.id, COALESCE(t.display_alias, t.primary_designation) AS label,
+                (SELECT ta.alias FROM target_alias ta
+                 WHERE ta.target_id = t.id
+                   AND ta.normalized LIKE ?
+                 LIMIT 1) AS alias_match
+         FROM canonical_target t
+         WHERE LOWER(t.primary_designation) LIKE ?
+            OR EXISTS (
+                SELECT 1 FROM target_alias ta2
+                WHERE ta2.target_id = t.id
+                  AND ta2.normalized LIKE ?
+            )
+         ORDER BY t.primary_designation ASC
+         LIMIT 10",
+    )
+    .bind(like_pattern)
+    .bind(like_pattern)
+    .bind(like_pattern)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// A generic `(id, label)` row shared by the recent-target, session-search,
+/// recent-session, and recent-project queries.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct IdLabelRow {
+    pub id: String,
+    pub label: String,
+}
+
+/// Most-recently-resolved `canonical_target` rows.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn recent_targets(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
+    let rows = sqlx::query_as::<_, IdLabelRow>(
+        "SELECT id, COALESCE(display_alias, primary_designation) AS label FROM canonical_target \
+         ORDER BY resolved_at DESC LIMIT 5",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Search `acquisition_session` by `session_key`, `like_pattern` already
+/// wrapped in `%...%`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn search_sessions_by_like(
+    pool: &SqlitePool,
+    like_pattern: &str,
+) -> DbResult<Vec<IdLabelRow>> {
+    let rows = sqlx::query_as::<_, IdLabelRow>(
+        "SELECT id, session_key AS label
+         FROM acquisition_session
+         WHERE LOWER(session_key) LIKE ?
+         ORDER BY created_at DESC
+         LIMIT 10",
+    )
+    .bind(like_pattern)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Most-recently-created `acquisition_session` rows.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn recent_sessions(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
+    let rows = sqlx::query_as::<_, IdLabelRow>(
+        "SELECT id, session_key AS label
+         FROM acquisition_session
+         ORDER BY created_at DESC
+         LIMIT 5",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Row from the project search query.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ProjectSearchRow {
+    pub id: String,
+    pub name: String,
+    pub lifecycle: String,
+}
+
+/// Search `projects` by `name`, `like_pattern` already wrapped in `%...%`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn search_projects_by_like(
+    pool: &SqlitePool,
+    like_pattern: &str,
+) -> DbResult<Vec<ProjectSearchRow>> {
+    let rows = sqlx::query_as::<_, ProjectSearchRow>(
+        "SELECT id, name, lifecycle
+         FROM projects
+         WHERE LOWER(name) LIKE ?
+         ORDER BY name ASC
+         LIMIT 10",
+    )
+    .bind(like_pattern)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Most-recently-created `projects` rows.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn recent_projects(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
+    let rows = sqlx::query_as::<_, IdLabelRow>(
+        "SELECT id, name AS label FROM projects ORDER BY created_at DESC LIMIT 5",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+// ── sessions ─────────────────────────────────────────────────────────────────
+
+/// `acquisition_session` row joined with its canonical target (spec 035
+/// US4/T044). Shared by `sessions.list` and `sessions.get`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SessionJoinRow {
+    pub id: String,
+    pub session_key: String,
+    pub target_id: Option<String>,
+    pub frame_ids: String,
+    pub created_at: String,
+    pub canonical_target_id: Option<String>,
+    pub canonical_target_name: Option<String>,
+}
+
+/// All `acquisition_session` rows, newest first.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_sessions_joined(pool: &SqlitePool) -> DbResult<Vec<SessionJoinRow>> {
+    let rows = sqlx::query_as::<_, SessionJoinRow>(
+        "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at,
+                s.canonical_target_id, ct.primary_designation AS canonical_target_name
+         FROM acquisition_session s
+         LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id
+         ORDER BY s.created_at DESC",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// A single `acquisition_session` row by id.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_session_joined(pool: &SqlitePool, id: &str) -> DbResult<Option<SessionJoinRow>> {
+    let row = sqlx::query_as::<_, SessionJoinRow>(
+        "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at,
+                s.canonical_target_id, ct.primary_designation AS canonical_target_name
+         FROM acquisition_session s
+         LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id
+         WHERE s.id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Row from `acquisition_fingerprint` supplementary metadata dimensions.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FingerprintRow {
+    pub gain: Option<f64>,
+    pub filter_name: Option<String>,
+    pub binning: Option<String>,
+    pub optic_train: Option<String>,
+    pub observing_night_date: Option<String>,
+}
+
+/// `acquisition_fingerprint` row for a session, if present.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_fingerprint(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<FingerprintRow>> {
+    let row = sqlx::query_as::<_, FingerprintRow>(
+        "SELECT gain, filter_name, binning, optic_train, observing_night_date
+         FROM acquisition_fingerprint
+         WHERE id = ?",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Active (non-`missing`) `(count, total_size_bytes)` for a set of
+/// `file_record` ids (spec 048 US1, INV-5). Empty `ids` short-circuits to
+/// `(0, 0)` without querying.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn active_frame_summary(pool: &SqlitePool, ids: &[String]) -> DbResult<(i64, i64)> {
+    if ids.is_empty() {
+        return Ok((0, 0));
+    }
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT COUNT(*), COALESCE(SUM(size_bytes), 0) FROM file_record \
+         WHERE state != 'missing' AND id IN (",
+    );
+    let mut separated = builder.separated(", ");
+    for id in ids {
+        separated.push_bind(id);
+    }
+    separated.push_unseparated(")");
+    let (count, total): (i64, i64) = builder.build_query_as().fetch_one(pool).await?;
+    Ok((count, total))
+}
+
+/// `project_id`s linked to a session via `project_sources`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn project_ids_for_session(pool: &SqlitePool, session_id: &str) -> DbResult<Vec<String>> {
+    let ids = sqlx::query_scalar::<_, String>(
+        "SELECT project_id FROM project_sources WHERE inventory_session_id = ?",
+    )
+    .bind(session_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(ids)
+}
+
+/// A `calibration_assignment` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CalibrationAssignmentRow {
+    pub master_id: String,
+    pub calibration_type: String,
+    pub confidence: f64,
+    pub mismatched_dimensions: String,
+}
+
+/// Calibration matches assigned to a session.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn calibration_matches_for_session(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Vec<CalibrationAssignmentRow>> {
+    let rows = sqlx::query_as::<_, CalibrationAssignmentRow>(
+        "SELECT master_id, calibration_type, confidence, mismatched_dimensions
+         FROM calibration_assignment
+         WHERE session_id = ?",
+    )
+    .bind(session_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// A session's `audit_log_entry` history row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AuditHistoryRow {
+    pub at: String,
+    pub trigger: String,
+    pub actor: String,
+}
+
+/// Audit history for a session (`entity_type = 'acquisition_session'`),
+/// oldest first.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn session_history(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Vec<AuditHistoryRow>> {
+    let rows = sqlx::query_as::<_, AuditHistoryRow>(
+        "SELECT at, trigger, actor
+         FROM audit_log_entry
+         WHERE entity_type = 'acquisition_session' AND entity_id = ?
+         ORDER BY at ASC",
+    )
+    .bind(session_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> Database {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db
+    }
+
+    #[tokio::test]
+    async fn frame_ids_absent_session_returns_none() {
+        let db = setup().await;
+        assert!(get_acquisition_session_frame_ids(db.pool(), "no-such").await.unwrap().is_none());
+        assert!(get_calibration_session_frame_ids_and_kind(db.pool(), "no-such")
+            .await
+            .unwrap()
+            .is_none());
+    }
+
+    #[tokio::test]
+    async fn file_records_by_ids_empty_short_circuits() {
+        let db = setup().await;
+        let rows = file_records_by_ids(db.pool(), &[]).await.unwrap();
+        assert!(rows.is_empty());
+    }
+
+    #[tokio::test]
+    async fn active_frame_summary_empty_ids_short_circuits() {
+        let db = setup().await;
+        let (count, total) = active_frame_summary(db.pool(), &[]).await.unwrap();
+        assert_eq!((count, total), (0, 0));
+    }
+
+    #[tokio::test]
+    async fn mark_file_record_missing_updates_state() {
+        let db = setup().await;
+        sqlx::query(
+            "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
+             VALUES ('root-1', 'root-1', '/tmp', 'local', 'active', datetime('now'))",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO file_record \
+                (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
+             VALUES ('f-1', 'root-1', 'a.fits', 100, 't0', 'classified', 't0', 't0')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        mark_file_record_missing(db.pool(), "f-1").await.unwrap();
+
+        let rows = file_records_by_root(db.pool(), "root-1").await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].state, "missing");
+    }
+
+    #[tokio::test]
+    async fn search_and_recent_targets_roundtrip() {
+        let db = setup().await;
+        sqlx::query(
+            "INSERT INTO canonical_target
+                (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at) \
+             VALUES ('t-1', NULL, 'NGC 7000', 'nebula', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let found = search_targets_by_like(db.pool(), "%ngc%").await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].id, "t-1");
+
+        let recent = recent_targets(db.pool()).await.unwrap();
+        assert_eq!(recent.len(), 1);
+        assert_eq!(recent[0].label, "NGC 7000");
+    }
+
+    #[tokio::test]
+    async fn list_and_get_session_joined_roundtrip() {
+        let db = setup().await;
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
+             VALUES ('s-1', '{}', '[]', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let all = list_sessions_joined(db.pool()).await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0].id, "s-1");
+
+        let one = get_session_joined(db.pool(), "s-1").await.unwrap();
+        assert!(one.is_some());
+        assert!(get_session_joined(db.pool(), "missing").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn project_ids_for_session_empty_when_unlinked() {
+        let db = setup().await;
+        let ids = project_ids_for_session(db.pool(), "no-such").await.unwrap();
+        assert!(ids.is_empty());
+    }
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves frame_inventory.rs (13), search.rs (12), sessions.rs (13) behind persistence_db::repositories::q_core.

Reviewed+approved (sonnet, 0 change items). Dynamic IN-list builders preserve empty-id short-circuit, error-mapping equivalent, swallow behavior intact. Depends on merged foundation.