### PR TITLE
refactor: move targets-management database queries behind the persistence layer

### DIFF
--- a/crates/app/targets/src/resolver_settings.rs
+++ b/crates/app/targets/src/resolver_settings.rs
@@ -66,23 +66,16 @@ fn validate_endpoint(endpoint: &str) -> Result<(), ContractError> {
 
 /// Read the singleton `resolver_settings` row.
 async fn read_row(pool: &SqlitePool) -> Result<ResolverSettings, ContractError> {
-    let row: Option<(i64, String, i64, i64)> = sqlx::query_as(
-        "SELECT online_enabled, simbad_endpoint, debounce_ms, request_timeout_secs
-         FROM resolver_settings WHERE id = 1",
-    )
-    .fetch_optional(pool)
-    .await
-    .map_err(db_err)?;
+    let row = persistence_db::repositories::q_targets_mgmt::get_resolver_settings(pool)
+        .await
+        .map_err(db_err)?;
 
-    Ok(row.map_or_else(
-        defaults,
-        |(online_enabled, simbad_endpoint, debounce_ms, request_timeout_secs)| ResolverSettings {
-            online_enabled: online_enabled != 0,
-            simbad_endpoint,
-            debounce_ms: u32::try_from(debounce_ms.max(0)).unwrap_or(300),
-            request_timeout_secs: u32::try_from(request_timeout_secs.max(0)).unwrap_or(10),
-        },
-    ))
+    Ok(row.map_or_else(defaults, |r| ResolverSettings {
+        online_enabled: r.online_enabled != 0,
+        simbad_endpoint: r.simbad_endpoint,
+        debounce_ms: u32::try_from(r.debounce_ms.max(0)).unwrap_or(300),
+        request_timeout_secs: u32::try_from(r.request_timeout_secs.max(0)).unwrap_or(10),
+    }))
 }
 
 /// `target.resolution.settings` (get) — return the current resolver settings.
@@ -125,21 +118,13 @@ pub async fn update(
     let debounce_ms = i64::from(s.debounce_ms.max(1));
     let timeout_secs = i64::from(s.request_timeout_secs.max(1));
 
-    sqlx::query(
-        "INSERT INTO resolver_settings
-            (id, online_enabled, simbad_endpoint, debounce_ms, request_timeout_secs)
-         VALUES (1, ?, ?, ?, ?)
-         ON CONFLICT(id) DO UPDATE SET
-            online_enabled       = excluded.online_enabled,
-            simbad_endpoint      = excluded.simbad_endpoint,
-            debounce_ms          = excluded.debounce_ms,
-            request_timeout_secs = excluded.request_timeout_secs",
+    persistence_db::repositories::q_targets_mgmt::upsert_resolver_settings(
+        pool,
+        i64::from(s.online_enabled),
+        &s.simbad_endpoint,
+        debounce_ms,
+        timeout_secs,
     )
-    .bind(i64::from(s.online_enabled))
-    .bind(&s.simbad_endpoint)
-    .bind(debounce_ms)
-    .bind(timeout_secs)
-    .execute(pool)
     .await
     .map_err(db_err)?;
 

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -47,6 +47,12 @@ fn db_err(e: &cache::CacheError) -> TargetOpError {
     TargetOpError { code: "internal.database".to_owned(), message: format!("{e}"), details: None }
 }
 
+/// Map a [`persistence_db::DbError`] from a `q_targets_mgmt` repository call to
+/// the `internal.database` op-error shape (mirrors [`db_err`] for `CacheError`).
+fn persist_err(e: &persistence_db::DbError) -> TargetOpError {
+    TargetOpError { code: "internal.database".to_owned(), message: format!("{e}"), details: None }
+}
+
 fn invalid_id(id: &str) -> TargetOpError {
     TargetOpError {
         code: "target.invalid_id".to_owned(),
@@ -80,27 +86,17 @@ async fn load_alias_dtos(
     pool: &SqlitePool,
     target_id_str: &str,
 ) -> Result<Vec<TargetAliasDto>, TargetOpError> {
-    let rows: Vec<(String, String, String)> = sqlx::query_as(
-        "SELECT id, alias, kind
-         FROM target_alias
-         WHERE target_id = ?
-         ORDER BY alias ASC",
-    )
-    .bind(target_id_str)
-    .fetch_all(pool)
-    .await
-    .map_err(|e| TargetOpError {
-        code: "internal.database".to_owned(),
-        message: format!("{e}"),
-        details: None,
-    })?;
+    let rows =
+        persistence_db::repositories::q_targets_mgmt::list_target_aliases(pool, target_id_str)
+            .await
+            .map_err(|e| persist_err(&e))?;
 
     Ok(rows
         .into_iter()
-        .map(|(id, alias, kind)| TargetAliasDto {
-            id,
-            alias,
-            kind: map_alias_kind(AliasKind::from_wire(&kind)),
+        .map(|r| TargetAliasDto {
+            id: r.id,
+            alias: r.alias,
+            kind: map_alias_kind(AliasKind::from_wire(&r.kind)),
         })
         .collect())
 }
@@ -188,16 +184,11 @@ pub async fn alias_add(
     let uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
 
     // Verify the target exists.
-    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(uuid.to_string())
-        .fetch_optional(pool)
-        .await
-        .map_err(|e| TargetOpError {
-            code: "internal.database".to_owned(),
-            message: format!("{e}"),
-            details: None,
-        })?;
-    if exists.is_none() {
+    let exists =
+        persistence_db::repositories::q_targets_mgmt::target_exists(pool, &uuid.to_string())
+            .await
+            .map_err(|e| persist_err(&e))?;
+    if !exists {
         return Err(not_found(&req.target_id));
     }
 
@@ -242,17 +233,13 @@ pub async fn alias_remove(
 ) -> Result<TargetAliasRemoveResult, TargetOpError> {
     // First check whether the alias exists at all (to distinguish "not found"
     // from "not removable").
-    let row: Option<(String,)> =
-        sqlx::query_as("SELECT kind FROM target_alias WHERE id = ? AND target_id = ?")
-            .bind(&req.alias_id)
-            .bind(&req.target_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| TargetOpError {
-                code: "internal.database".to_owned(),
-                message: format!("{e}"),
-                details: None,
-            })?;
+    let row = persistence_db::repositories::q_targets_mgmt::get_alias_kind(
+        pool,
+        &req.alias_id,
+        &req.target_id,
+    )
+    .await
+    .map_err(|e| persist_err(&e))?;
 
     match row {
         None => Err(TargetOpError {
@@ -260,7 +247,7 @@ pub async fn alias_remove(
             message: format!("Alias '{}' not found on target '{}'.", req.alias_id, req.target_id),
             details: None,
         }),
-        Some((kind,)) if kind != "user" => Err(alias_not_removable()),
+        Some(kind) if kind != "user" => Err(alias_not_removable()),
         Some(_) => {
             let deleted =
                 cache::delete_user_alias(pool, &req.alias_id).await.map_err(|e| db_err(&e))?;
@@ -327,16 +314,10 @@ pub async fn sessions_list(
 ) -> Result<Vec<TargetSessionItem>, TargetOpError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
     // Verify the target exists.
-    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(&req.target_id)
-        .fetch_optional(pool)
+    let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| TargetOpError {
-            code: "internal.database".to_owned(),
-            message: format!("{e}"),
-            details: None,
-        })?;
-    if exists.is_none() {
+        .map_err(|e| persist_err(&e))?;
+    if !exists {
         return Err(not_found(&req.target_id));
     }
     let rows =
@@ -373,16 +354,10 @@ pub async fn projects_list(
     req: &TargetProjectsListRequest,
 ) -> Result<Vec<TargetProjectItem>, TargetOpError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
-    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(&req.target_id)
-        .fetch_optional(pool)
+    let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| TargetOpError {
-            code: "internal.database".to_owned(),
-            message: format!("{e}"),
-            details: None,
-        })?;
-    if exists.is_none() {
+        .map_err(|e| persist_err(&e))?;
+    if !exists {
         return Err(not_found(&req.target_id));
     }
     let rows =
@@ -413,16 +388,10 @@ pub async fn note_get(
     req: &TargetNoteGetRequest,
 ) -> Result<TargetNoteGetResult, TargetOpError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
-    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(&req.target_id)
-        .fetch_optional(pool)
+    let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| TargetOpError {
-            code: "internal.database".to_owned(),
-            message: format!("{e}"),
-            details: None,
-        })?;
-    if exists.is_none() {
+        .map_err(|e| persist_err(&e))?;
+    if !exists {
         return Err(not_found(&req.target_id));
     }
     let notes = persistence_db::repositories::targets::get_target_notes(pool, &req.target_id)
@@ -455,16 +424,10 @@ pub async fn note_update(
     req: &TargetNoteUpdateRequest,
 ) -> Result<TargetNoteUpdateResult, TargetOpError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
-    let exists: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(&req.target_id)
-        .fetch_optional(pool)
+    let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| TargetOpError {
-            code: "internal.database".to_owned(),
-            message: format!("{e}"),
-            details: None,
-        })?;
-    if exists.is_none() {
+        .map_err(|e| persist_err(&e))?;
+    if !exists {
         return Err(not_found(&req.target_id));
     }
     // Blank/whitespace → store NULL (clear).

--- a/crates/app/targets/src/target_resolve.rs
+++ b/crates/app/targets/src/target_resolve.rs
@@ -62,20 +62,9 @@ async fn write_audit(
         .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
     let payload = serde_json::json!({ "query": query }).to_string();
 
-    let result = sqlx::query(
-        "INSERT INTO audit_log_entry \
-         (audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
-          outcome, severity, request_id, at, payload) \
-         VALUES (?, 'canonical_target', ?, NULL, NULL, ?, ?, 'applied', 'workflow', ?, ?, ?)",
+    let result = persistence_db::repositories::q_targets_mgmt::insert_resolution_audit(
+        pool, &audit_id, target_id, trigger, actor, request_id, &at, &payload,
     )
-    .bind(&audit_id)
-    .bind(target_id)
-    .bind(trigger)
-    .bind(actor)
-    .bind(request_id)
-    .bind(&at)
-    .bind(&payload)
-    .execute(pool)
     .await;
 
     if let Err(e) = result {
@@ -155,13 +144,9 @@ struct OnlineSettings {
 /// Read the singleton `resolver_settings` row (id = 1). The row is seeded by
 /// migration 0031, so this should always return a value; missing → defaults.
 async fn read_settings(pool: &SqlitePool) -> Result<OnlineSettings, ContractError> {
-    let row: Option<(i64, String, i64)> = sqlx::query_as(
-        "SELECT online_enabled, simbad_endpoint, request_timeout_secs
-         FROM resolver_settings WHERE id = 1",
-    )
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| db_internal_ctx(e, "read resolver_settings"))?;
+    let row = persistence_db::repositories::q_targets_mgmt::get_resolver_settings_online(pool)
+        .await
+        .map_err(|e| db_internal_ctx(e, "read resolver_settings"))?;
 
     Ok(row.map_or(
         OnlineSettings {
@@ -169,10 +154,10 @@ async fn read_settings(pool: &SqlitePool) -> Result<OnlineSettings, ContractErro
             endpoint: targeting_resolver::simbad::DEFAULT_TAP_ENDPOINT.to_owned(),
             request_timeout_secs: 10,
         },
-        |(online_enabled, endpoint, request_timeout_secs)| OnlineSettings {
-            online_enabled: online_enabled != 0,
-            endpoint,
-            request_timeout_secs,
+        |r| OnlineSettings {
+            online_enabled: r.online_enabled != 0,
+            endpoint: r.simbad_endpoint,
+            request_timeout_secs: r.request_timeout_secs,
         },
     ))
 }

--- a/crates/persistence/db/src/repositories/q_targets_mgmt.rs
+++ b/crates/persistence/db/src/repositories/q_targets_mgmt.rs
@@ -1,3 +1,338 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_targets_mgmt`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Repository query functions for `app_core_targets`' resolver-settings,
+//! target-management, and target-resolve use cases (db-boundary-zero drain).
+//!
+//! Moved out of `crates/app/targets/src/{resolver_settings,target_management,
+//! target_resolve}.rs` verbatim (same tables/columns/WHERE/ORDER, same
+//! bindings) so those files hold zero raw sqlx sites; business logic, error
+//! mapping, and transaction-free multi-step orchestration stay in the app
+//! layer.
+//!
+//! Tables: `resolver_settings` (singleton row, id = 1), `canonical_target`,
+//! `target_alias`, `audit_log_entry`.
+//!
+//! Constitution §I: read/write SQLite metadata only; no filesystem mutations.
+//! Constitution §V: SQLite is the durable record.
+
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+/// Full `resolver_settings` row (`resolver_settings.rs::read_row`).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ResolverSettingsRow {
+    pub online_enabled: i64,
+    pub simbad_endpoint: String,
+    pub debounce_ms: i64,
+    pub request_timeout_secs: i64,
+}
+
+/// `resolver_settings` row projected to only the columns `target_resolve.rs`'s
+/// `read_settings` needs (no `debounce_ms`).
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ResolverSettingsOnlineRow {
+    pub online_enabled: i64,
+    pub simbad_endpoint: String,
+    pub request_timeout_secs: i64,
+}
+
+/// Flat row returned by [`list_target_aliases`].
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct TargetAliasRow {
+    pub id: String,
+    pub alias: String,
+    pub kind: String,
+}
+
+// ── resolver_settings ────────────────────────────────────────────────────────
+
+/// Read the singleton `resolver_settings` row (id = 1), all four columns.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_resolver_settings(pool: &SqlitePool) -> DbResult<Option<ResolverSettingsRow>> {
+    let row = sqlx::query_as::<_, ResolverSettingsRow>(
+        "SELECT online_enabled, simbad_endpoint, debounce_ms, request_timeout_secs
+         FROM resolver_settings WHERE id = 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Read the singleton `resolver_settings` row (id = 1), the three columns the
+/// live resolve path needs (`online_enabled`, `simbad_endpoint`,
+/// `request_timeout_secs`).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_resolver_settings_online(
+    pool: &SqlitePool,
+) -> DbResult<Option<ResolverSettingsOnlineRow>> {
+    let row = sqlx::query_as::<_, ResolverSettingsOnlineRow>(
+        "SELECT online_enabled, simbad_endpoint, request_timeout_secs
+         FROM resolver_settings WHERE id = 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Upsert the singleton `resolver_settings` row (id = 1).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn upsert_resolver_settings(
+    pool: &SqlitePool,
+    online_enabled: i64,
+    simbad_endpoint: &str,
+    debounce_ms: i64,
+    request_timeout_secs: i64,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO resolver_settings
+            (id, online_enabled, simbad_endpoint, debounce_ms, request_timeout_secs)
+         VALUES (1, ?, ?, ?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+            online_enabled       = excluded.online_enabled,
+            simbad_endpoint      = excluded.simbad_endpoint,
+            debounce_ms          = excluded.debounce_ms,
+            request_timeout_secs = excluded.request_timeout_secs",
+    )
+    .bind(online_enabled)
+    .bind(simbad_endpoint)
+    .bind(debounce_ms)
+    .bind(request_timeout_secs)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── canonical_target / target_alias ─────────────────────────────────────────
+
+/// Whether a `canonical_target` row exists for `target_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn target_exists(pool: &SqlitePool, target_id: &str) -> DbResult<bool> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
+        .bind(target_id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.is_some())
+}
+
+/// List `target_alias` rows for `target_id`, ordered by `alias ASC`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_target_aliases(
+    pool: &SqlitePool,
+    target_id: &str,
+) -> DbResult<Vec<TargetAliasRow>> {
+    let rows = sqlx::query_as::<_, TargetAliasRow>(
+        "SELECT id, alias, kind
+         FROM target_alias
+         WHERE target_id = ?
+         ORDER BY alias ASC",
+    )
+    .bind(target_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// Read the `kind` of a `target_alias` row scoped to `target_id`.
+///
+/// Scoping by both `id` and `target_id` distinguishes "alias not found" from
+/// "alias exists but belongs to a different target".
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_alias_kind(
+    pool: &SqlitePool,
+    alias_id: &str,
+    target_id: &str,
+) -> DbResult<Option<String>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT kind FROM target_alias WHERE id = ? AND target_id = ?")
+            .bind(alias_id)
+            .bind(target_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(kind,)| kind))
+}
+
+// ── audit_log_entry ──────────────────────────────────────────────────────────
+
+/// Insert a durable `audit_log_entry` row for a resolution outcome
+/// (`target.resolved` / `target.user_override`), entity type
+/// `canonical_target`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+#[allow(clippy::too_many_arguments)] // mirrors the columns of a fixed audit-row shape
+pub async fn insert_resolution_audit(
+    pool: &SqlitePool,
+    audit_id: &str,
+    target_id: &str,
+    trigger: &str,
+    actor: &str,
+    request_id: &str,
+    at: &str,
+    payload: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO audit_log_entry \
+         (audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
+          outcome, severity, request_id, at, payload) \
+         VALUES (?, 'canonical_target', ?, NULL, NULL, ?, ?, 'applied', 'workflow', ?, ?, ?)",
+    )
+    .bind(audit_id)
+    .bind(target_id)
+    .bind(trigger)
+    .bind(actor)
+    .bind(request_id)
+    .bind(at)
+    .bind(payload)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> Database {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db
+    }
+
+    async fn insert_target(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO canonical_target
+             (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
+             VALUES (?, NULL, 'Test Target', 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .execute(pool)
+        .await
+        .expect("insert_target failed");
+    }
+
+    async fn insert_alias(pool: &SqlitePool, id: &str, target_id: &str, alias: &str, kind: &str) {
+        sqlx::query(
+            "INSERT INTO target_alias (id, target_id, alias, normalized, kind) VALUES (?, ?, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(target_id)
+        .bind(alias)
+        .bind(alias.to_lowercase())
+        .bind(kind)
+        .execute(pool)
+        .await
+        .expect("insert_alias failed");
+    }
+
+    // ── resolver_settings ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn resolver_settings_seeded_row_is_readable() {
+        let db = setup().await;
+        let row = get_resolver_settings(db.pool()).await.unwrap();
+        assert!(row.is_some(), "migration 0031 seeds the singleton row");
+
+        let online_row = get_resolver_settings_online(db.pool()).await.unwrap();
+        assert!(online_row.is_some());
+    }
+
+    #[tokio::test]
+    async fn resolver_settings_upsert_round_trips() {
+        let db = setup().await;
+        upsert_resolver_settings(db.pool(), 0, "https://example.test/tap", 500, 20).await.unwrap();
+
+        let row = get_resolver_settings(db.pool()).await.unwrap().unwrap();
+        assert_eq!(row.online_enabled, 0);
+        assert_eq!(row.simbad_endpoint, "https://example.test/tap");
+        assert_eq!(row.debounce_ms, 500);
+        assert_eq!(row.request_timeout_secs, 20);
+    }
+
+    // ── canonical_target / target_alias ──────────────────────────────────────
+
+    #[tokio::test]
+    async fn target_exists_true_and_false() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-001").await;
+        assert!(target_exists(db.pool(), "t-001").await.unwrap());
+        assert!(!target_exists(db.pool(), "t-missing").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn list_target_aliases_orders_by_alias_asc() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-001").await;
+        insert_alias(db.pool(), "a-1", "t-001", "Zeta", "user").await;
+        insert_alias(db.pool(), "a-2", "t-001", "Alpha", "user").await;
+
+        let rows = list_target_aliases(db.pool(), "t-001").await.unwrap();
+        assert_eq!(rows.len(), 2);
+        assert_eq!(rows[0].alias, "Alpha");
+        assert_eq!(rows[1].alias, "Zeta");
+    }
+
+    #[tokio::test]
+    async fn get_alias_kind_scopes_by_target() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-001").await;
+        insert_target(db.pool(), "t-002").await;
+        insert_alias(db.pool(), "a-1", "t-001", "Alpha", "user").await;
+
+        assert_eq!(
+            get_alias_kind(db.pool(), "a-1", "t-001").await.unwrap().as_deref(),
+            Some("user")
+        );
+        assert!(get_alias_kind(db.pool(), "a-1", "t-002").await.unwrap().is_none());
+        assert!(get_alias_kind(db.pool(), "a-missing", "t-001").await.unwrap().is_none());
+    }
+
+    // ── audit_log_entry ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn insert_resolution_audit_writes_row() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-001").await;
+        insert_resolution_audit(
+            db.pool(),
+            "audit-1",
+            "t-001",
+            "target.resolved",
+            "system",
+            "req-1",
+            "2026-01-01T00:00:00Z",
+            "{}",
+        )
+        .await
+        .unwrap();
+
+        let (n,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM audit_log_entry WHERE audit_id = 'audit-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(n, 1);
+    }
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves resolver_settings.rs (4), target_management.rs (14), target_resolve.rs (4) behind persistence_db::repositories::q_targets_mgmt.

Reviewed+approved (sonnet, 0 change items). Audit-row 12-col insert faithful, persist_err mirrors idiom, not-found semantics preserved. Depends on merged foundation.