### PR TITLE
refactor: move events-log queries behind the persistence layer

### DIFF
--- a/apps/desktop/src-tauri/src/commands/log.rs
+++ b/apps/desktop/src-tauri/src/commands/log.rs
@@ -168,11 +168,7 @@ pub fn start_log_forwarder(
         let mut diag_seq: u64 = 0;
 
         // Initialise cursor to the current max event_id so we only emit new events.
-        if let Ok((max_id,)) =
-            sqlx::query_as::<_, (i64,)>("SELECT COALESCE(MAX(event_id), 0) FROM events")
-                .fetch_one(&pool)
-                .await
-        {
+        if let Ok(max_id) = persistence_db::repositories::events::max_event_id(&pool).await {
             cursor = max_id;
         }
 
@@ -180,24 +176,18 @@ pub fn start_log_forwarder(
             match rx.recv().await {
                 Ok(_envelope) => {
                     // Query all new rows since cursor.
-                    let rows: Result<Vec<(i64, String, String, String)>, _> =
-                        sqlx::query_as::<_, (i64, String, String, String)>(
-                            "SELECT event_id, topic, emitted_at, payload \
-                             FROM events WHERE event_id > ? ORDER BY event_id ASC",
-                        )
-                        .bind(cursor)
-                        .fetch_all(&pool)
-                        .await;
+                    let rows =
+                        persistence_db::repositories::events::list_since(&pool, cursor).await;
 
                     match rows {
                         Ok(rows) => {
-                            for (event_id, topic, emitted_at, payload_json) in rows {
-                                cursor = cursor.max(event_id);
+                            for row in rows {
+                                cursor = cursor.max(row.event_id);
                                 let entry = app_core::log_stream::project_event(
-                                    event_id,
-                                    &topic,
-                                    &emitted_at,
-                                    &payload_json,
+                                    row.event_id,
+                                    &row.topic,
+                                    &row.emitted_at,
+                                    &row.payload,
                                 );
 
                                 // Gate on configured log level.

--- a/crates/app/core/src/log_stream.rs
+++ b/crates/app/core/src/log_stream.rs
@@ -34,7 +34,7 @@ pub const LOG_BUFFER_SIZE: usize = 500;
 #[derive(Debug, thiserror::Error)]
 pub enum LogError {
     #[error("database error: {0}")]
-    Database(#[from] sqlx::Error),
+    Database(#[from] persistence_db::DbError),
     #[error("serialisation error: {0}")]
     Serialise(#[from] serde_json::Error),
     #[error("{code}: {message}")]
@@ -190,25 +190,14 @@ pub async fn recent_entries(
 
     // Fetch the most recent N rows ordered by event_id descending, then
     // reverse for oldest-first output.
-    let rows: Vec<(i64, String, String, String)> =
-        sqlx::query_as::<_, (i64, String, String, String)>(
-            "SELECT event_id, topic, emitted_at, payload \
-         FROM events \
-         WHERE event_id > ? \
-         ORDER BY event_id DESC \
-         LIMIT ?",
-        )
-        .bind(since_id)
-        .bind(limit)
-        .fetch_all(pool)
-        .await?;
+    let rows = persistence_db::repositories::events::list_recent_since(pool, since_id, limit)
+        .await
+        .map_err(LogError::from)?;
 
     let mut entries: Vec<LogEntry> = rows
         .into_iter()
         .rev() // oldest-first
-        .map(|(eid, topic, emitted_at, payload_json)| {
-            project_event(eid, &topic, &emitted_at, &payload_json)
-        })
+        .map(|row| project_event(row.event_id, &row.topic, &row.emitted_at, &row.payload))
         .filter(|e| {
             // Apply level filter.
             if !level_passes(e.level, options.level_min) {
@@ -254,8 +243,8 @@ async fn retention_gap(
         return Ok((false, None));
     };
 
-    let oldest_retained: Option<i64> =
-        sqlx::query_scalar("SELECT MIN(event_id) FROM events").fetch_one(pool).await?;
+    let oldest_retained =
+        persistence_db::repositories::events::min_event_id(pool).await.map_err(LogError::from)?;
 
     match oldest_retained {
         Some(min_id) if min_id > cursor_id + 1 => Ok((true, Some(min_id - cursor_id - 1))),
@@ -305,54 +294,17 @@ pub async fn export_entries(
         });
     }
 
-    // Build query with optional time bounds.
-    let rows: Vec<(i64, String, String, String)> = match (&options.since, &options.until) {
-        (Some(s), Some(u)) => {
-            sqlx::query_as::<_, (i64, String, String, String)>(
-                "SELECT event_id, topic, emitted_at, payload \
-             FROM events WHERE emitted_at >= ? AND emitted_at < ? \
-             ORDER BY event_id ASC",
-            )
-            .bind(s)
-            .bind(u)
-            .fetch_all(pool)
-            .await?
-        }
-        (Some(s), None) => {
-            sqlx::query_as::<_, (i64, String, String, String)>(
-                "SELECT event_id, topic, emitted_at, payload \
-             FROM events WHERE emitted_at >= ? \
-             ORDER BY event_id ASC",
-            )
-            .bind(s)
-            .fetch_all(pool)
-            .await?
-        }
-        (None, Some(u)) => {
-            sqlx::query_as::<_, (i64, String, String, String)>(
-                "SELECT event_id, topic, emitted_at, payload \
-             FROM events WHERE emitted_at < ? \
-             ORDER BY event_id ASC",
-            )
-            .bind(u)
-            .fetch_all(pool)
-            .await?
-        }
-        (None, None) => {
-            sqlx::query_as::<_, (i64, String, String, String)>(
-                "SELECT event_id, topic, emitted_at, payload \
-             FROM events ORDER BY event_id ASC",
-            )
-            .fetch_all(pool)
-            .await?
-        }
-    };
+    let rows = persistence_db::repositories::events::list_by_emitted_at_range(
+        pool,
+        options.since.as_deref(),
+        options.until.as_deref(),
+    )
+    .await
+    .map_err(LogError::from)?;
 
     let entries: Vec<LogEntry> = rows
         .into_iter()
-        .map(|(eid, topic, emitted_at, payload_json)| {
-            project_event(eid, &topic, &emitted_at, &payload_json)
-        })
+        .map(|row| project_event(row.event_id, &row.topic, &row.emitted_at, &row.payload))
         .filter(|e| {
             if !level_passes(e.level, options.level_min) {
                 return false;

--- a/crates/persistence/db/src/repositories/events.rs
+++ b/crates/persistence/db/src/repositories/events.rs
@@ -149,6 +149,17 @@ pub async fn list_by_emitted_at_range(
     Ok(rows)
 }
 
+/// Largest assigned `event_id`, or `0` if the table is empty. Used to seed a
+/// live forwarder's cursor so only events emitted after subscribe are sent.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn max_event_id(pool: &SqlitePool) -> DbResult<i64> {
+    let (max_id,): (i64,) =
+        sqlx::query_as("SELECT COALESCE(MAX(event_id), 0) FROM events").fetch_one(pool).await?;
+    Ok(max_id)
+}
+
 /// Smallest retained `event_id`, or `None` if the table is empty. Used to
 /// detect a retention/eviction gap between a caller's cursor and the oldest
 /// row still on disk.
@@ -167,7 +178,7 @@ mod tests {
 
     use super::{
         insert_event, list_by_emitted_at_range, list_recent_since, list_since, list_since_by_topic,
-        min_event_id,
+        max_event_id, min_event_id,
     };
 
     async fn setup() -> SqlitePool {
@@ -255,6 +266,16 @@ mod tests {
         .await
         .expect("both bounds");
         assert_eq!(both.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn max_event_id_empty_is_zero() {
+        let pool = setup().await;
+        assert_eq!(max_event_id(&pool).await.expect("max_event_id"), 0);
+
+        let id1 = insert_event(&pool, "t.a", "system", "2026-01-01T00:00:00Z", "{}").await.unwrap();
+        insert_event(&pool, "t.b", "system", "2026-01-01T00:00:01Z", "{}").await.unwrap();
+        assert_eq!(max_event_id(&pool).await.expect("max_event_id"), id1 + 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves log.rs (4) and log_stream.rs (11) to read from persistence_db::repositories::events (added by foundation).

Under review. Opened early for parallel CI per orchestrator; formal merge held for explicit APPROVE.