### PR TITLE
refactor: move inbox database queries behind the persistence layer

### DIFF
--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -509,9 +509,7 @@ pub async fn confirm(
     }
 
     // 12. Transition plan to ready_for_review
-    sqlx::query("UPDATE plans SET state = 'ready_for_review' WHERE id = ?")
-        .bind(&plan_id)
-        .execute(pool)
+    plans_repo::update_plan_state(pool, &plan_id, "ready_for_review")
         .await
         .map_err(|e| db_internal_ctx(e, "transition plan to ready_for_review"))?;
 

--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -30,6 +30,10 @@ use audit::event_bus::{
     PlanApplyingCompleted, PlanDiscarded, TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_DISCARDED,
 };
 use persistence_db::repositories::inbox as inbox_repo;
+use persistence_db::repositories::plans as plans_repo;
+use persistence_db::repositories::q_inbox::{
+    self, InsertCalibrationFingerprint, InsertCalibrationSession,
+};
 use sqlx::SqlitePool;
 use tokio::sync::broadcast;
 
@@ -187,13 +191,10 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
     }
 
     // Idempotency guard: skip if a session already references this inbox item.
-    let existing: Option<(String,)> =
-        sqlx::query_as("SELECT id FROM calibration_session WHERE source_inbox_item_id = ? LIMIT 1")
-            .bind(&item.id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| format!("check existing calibration_session: {e}"))?;
-    if existing.is_some() {
+    let exists = q_inbox::calibration_session_exists_for_inbox_item(pool, &item.id)
+        .await
+        .map_err(|e| format!("check existing calibration_session: {e}"))?;
+    if exists {
         return Ok(());
     }
 
@@ -256,31 +257,29 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
         None => "[]".to_owned(),
     };
 
-    sqlx::query(
-        "INSERT INTO calibration_session
-            (id, session_key, frame_ids, kind, root_id, created_at, source_inbox_item_id)
-         VALUES (?, ?, ?, ?, ?, datetime('now'), ?)",
+    q_inbox::insert_calibration_session(
+        pool,
+        &InsertCalibrationSession {
+            id: &session_id,
+            session_key: &session_key,
+            frame_ids_json: &frame_ids_json,
+            kind: cal_kind,
+            root_id: resolved_root_id.as_deref(),
+            source_inbox_item_id: &item.id,
+        },
     )
-    .bind(&session_id)
-    .bind(&session_key)
-    .bind(&frame_ids_json)
-    .bind(cal_kind)
-    .bind(&resolved_root_id)
-    .bind(&item.id)
-    .execute(pool)
     .await
     .map_err(|e| format!("insert calibration_session: {e}"))?;
 
-    sqlx::query(
-        "INSERT INTO calibration_fingerprint
-            (id, calibration_type, exposure_s, filter_name)
-         VALUES (?, ?, ?, ?)",
+    q_inbox::insert_calibration_fingerprint(
+        pool,
+        &InsertCalibrationFingerprint {
+            calibration_session_id: &session_id,
+            calibration_type: cal_kind,
+            exposure_s: item.master_exposure_s,
+            filter_name: item.master_filter.as_deref(),
+        },
     )
-    .bind(&session_id)
-    .bind(cal_kind)
-    .bind(item.master_exposure_s)
-    .bind(item.master_filter.as_deref())
-    .execute(pool)
     .await
     .map_err(|e| format!("insert calibration_fingerprint: {e}"))?;
 
@@ -305,26 +304,21 @@ async fn resolve_applied_frame_path(
     pool: &SqlitePool,
     plan_id: &str,
 ) -> Result<Option<(String, String)>, String> {
-    let row: Option<(Option<String>, String, Option<String>, String)> = sqlx::query_as(
-        "SELECT to_root_id, to_relative_path, from_root_id, from_relative_path
-         FROM plan_items
-         WHERE plan_id = ?
-           AND action IN ('move', 'catalogue')
-           AND item_state = 'succeeded'
-         ORDER BY item_index ASC
-         LIMIT 1",
-    )
-    .bind(plan_id)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| format!("query plan_items: {e}"))?;
-
-    let Some((to_root_id, to_rel, from_root_id, from_rel)) = row else {
+    // `list_plan_items` already orders by item_index ASC; find the first
+    // successful move/catalogue item (same ORDER BY + LIMIT 1 semantics as
+    // the original inline query).
+    let items = plans_repo::list_plan_items(pool, plan_id)
+        .await
+        .map_err(|e| format!("query plan_items: {e}"))?;
+    let Some(row) = items.into_iter().find(|it| {
+        matches!(it.action.as_str(), "move" | "catalogue") && it.item_state == "succeeded"
+    }) else {
         return Ok(None);
     };
-    Ok(match (to_root_id, from_root_id) {
-        (Some(r), _) if !to_rel.is_empty() => Some((r, to_rel)),
-        (_, Some(r)) => Some((r, from_rel)),
+
+    Ok(match (row.to_root_id, row.from_root_id) {
+        (Some(r), _) if !row.to_relative_path.is_empty() => Some((r, row.to_relative_path)),
+        (_, Some(r)) => Some((r, row.from_relative_path)),
         _ => None,
     })
 }

--- a/crates/app/inbox/src/reclassify.rs
+++ b/crates/app/inbox/src/reclassify.rs
@@ -14,6 +14,7 @@ use std::collections::HashMap;
 
 use metadata_core;
 use persistence_db::repositories::inbox::{self as inbox_repo};
+use persistence_db::repositories::q_inbox;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -263,12 +264,9 @@ pub async fn reclassify_v2(
     let source_group_id = match (req.source_group_id, req.inbox_item_id) {
         (Some(sg), _) => {
             // Verify the source group exists.
-            let exists: Option<(String,)> =
-                sqlx::query_as("SELECT id FROM inbox_source_groups WHERE id = ?")
-                    .bind(&sg)
-                    .fetch_optional(pool)
-                    .await
-                    .map_err(|e| db_internal_ctx(e, "look up source group"))?;
+            let exists = q_inbox::get_source_group_by_id(pool, &sg)
+                .await
+                .map_err(|e| db_internal_ctx(e, "look up source group"))?;
             if exists.is_none() {
                 return Err(ContractError::new(
                     ErrorCode::InboxItemNotFound,
@@ -468,17 +466,12 @@ pub async fn reclassify_v2(
                     continue;
                 }
             };
-            sqlx::query(
-                "UPDATE inbox_classification_evidence
-                 SET manual_override = ?,
-                     override_stale  = 0,
-                     evidence_source = 'manual_override'
-                 WHERE inbox_item_id = ? AND relative_file_path = ?",
+            q_inbox::set_manual_override_reset_stale(
+                pool,
+                inbox_item_id,
+                file_path,
+                frame_type_str,
             )
-            .bind(frame_type_str)
-            .bind(inbox_item_id)
-            .bind(file_path)
-            .execute(pool)
             .await
             .map_err(|e| db_internal_ctx(e, "write frameType manual_override"))?;
         } else {
@@ -512,14 +505,11 @@ pub async fn reclassify_v2(
     // file_records Vec that materialize_sub_items expects.
 
     // Fetch source group row for root_id / relative_path / lane.
-    let sg_row: Option<(String, String, Option<String>)> =
-        sqlx::query_as("SELECT root_id, relative_path, lane FROM inbox_source_groups WHERE id = ?")
-            .bind(&source_group_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| db_internal_ctx(e, "fetch source group for re-split"))?;
+    let sg_row = q_inbox::get_source_group_by_id(pool, &source_group_id)
+        .await
+        .map_err(|e| db_internal_ctx(e, "fetch source group for re-split"))?;
 
-    let (root_id, relative_path, lane_opt) = sg_row.ok_or_else(|| {
+    let sg_row = sg_row.ok_or_else(|| {
         ContractError::new(
             ErrorCode::InboxItemNotFound,
             format!("Source group row missing during re-split: {source_group_id}"),
@@ -527,7 +517,8 @@ pub async fn reclassify_v2(
             false,
         )
     })?;
-    let lane = lane_opt.unwrap_or_else(|| "fits".to_owned());
+    let (root_id, relative_path) = (sg_row.root_id, sg_row.relative_path);
+    let lane = sg_row.lane.unwrap_or_else(|| "fits".to_owned());
 
     // Build file_records from persisted metadata. We have no abs paths here
     // (reclassify carries no root path), so we pass an empty file_paths slice

--- a/crates/persistence/db/src/repositories/q_inbox.rs
+++ b/crates/persistence/db/src/repositories/q_inbox.rs
@@ -1,3 +1,160 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_inbox`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! DB-boundary-zero drain: free-fn queries migrated out of
+//! `crates/app/inbox` (`confirm.rs`, `plan_listener.rs`, `reclassify.rs`).
+//!
+//! Queries that matched an existing `repositories::inbox` fn exactly were
+//! left calling that fn directly from the app layer; only genuinely new query
+//! shapes live here. Follows the `inventory.rs`/`targets.rs` free-fn idiom —
+//! no repo struct/trait.
+
+use sqlx::SqlitePool;
+
+use crate::repositories::inbox::InboxSourceGroupRow;
+use crate::DbResult;
+
+// ── inbox_source_groups ─────────────────────────────────────────────────────
+
+/// Fetch one `inbox_source_groups` row by primary key `id`.
+///
+/// Sibling of `repositories::inbox::get_inbox_source_group_by_path` (keyed on
+/// `(root_id, relative_path)` instead); `reclassify_v2` only has the group id
+/// on hand (from `source_group_id` request field or an item lookup).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on connection failure.
+pub async fn get_source_group_by_id(
+    pool: &SqlitePool,
+    id: &str,
+) -> DbResult<Option<InboxSourceGroupRow>> {
+    let row = sqlx::query_as::<_, InboxSourceGroupRow>(
+        "SELECT id, root_id, relative_path, discovered_at, last_scanned_at,
+                content_signature, format, lane, child_count
+         FROM inbox_source_groups
+         WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+// ── inbox_classification_evidence ───────────────────────────────────────────
+
+/// Write a `frameType` correction onto an evidence row and clear its
+/// staleness flag (spec 041 T068 R-13 — the one explicit-correction
+/// exception to fill-missing-only overrides).
+///
+/// Distinct from `repositories::inbox::set_manual_override`: this variant
+/// also resets `override_stale = 0`, matching `reclassify_v2`'s original
+/// inline query exactly.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on connection failure.
+pub async fn set_manual_override_reset_stale(
+    pool: &SqlitePool,
+    inbox_item_id: &str,
+    relative_file_path: &str,
+    frame_type: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE inbox_classification_evidence
+         SET manual_override = ?,
+             override_stale  = 0,
+             evidence_source = 'manual_override'
+         WHERE inbox_item_id = ? AND relative_file_path = ?",
+    )
+    .bind(frame_type)
+    .bind(inbox_item_id)
+    .bind(relative_file_path)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── calibration_session / calibration_fingerprint (master registration) ────
+
+/// Data required to insert a `calibration_session` row for a registered
+/// master (spec 041 US4/T032, spec 048 US1/T012).
+#[derive(Clone, Debug)]
+pub struct InsertCalibrationSession<'a> {
+    pub id: &'a str,
+    pub session_key: &'a str,
+    /// JSON array of `file_record` ids (`"[]"` when the master frame could
+    /// not be resolved to a `file_record`).
+    pub frame_ids_json: &'a str,
+    pub kind: &'a str,
+    pub root_id: Option<&'a str>,
+    pub source_inbox_item_id: &'a str,
+}
+
+/// Data required to insert a `calibration_fingerprint` row.
+#[derive(Clone, Debug)]
+pub struct InsertCalibrationFingerprint<'a> {
+    pub calibration_session_id: &'a str,
+    pub calibration_type: &'a str,
+    pub exposure_s: Option<f64>,
+    pub filter_name: Option<&'a str>,
+}
+
+/// Idempotency guard for master registration: does a `calibration_session`
+/// row already reference this inbox item?
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on connection failure.
+pub async fn calibration_session_exists_for_inbox_item(
+    pool: &SqlitePool,
+    inbox_item_id: &str,
+) -> DbResult<bool> {
+    let existing: Option<(String,)> =
+        sqlx::query_as("SELECT id FROM calibration_session WHERE source_inbox_item_id = ? LIMIT 1")
+            .bind(inbox_item_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(existing.is_some())
+}
+
+/// Insert a `calibration_session` row registering a detected master.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on constraint or connection failure.
+pub async fn insert_calibration_session(
+    pool: &SqlitePool,
+    session: &InsertCalibrationSession<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO calibration_session
+            (id, session_key, frame_ids, kind, root_id, created_at, source_inbox_item_id)
+         VALUES (?, ?, ?, ?, ?, datetime('now'), ?)",
+    )
+    .bind(session.id)
+    .bind(session.session_key)
+    .bind(session.frame_ids_json)
+    .bind(session.kind)
+    .bind(session.root_id)
+    .bind(session.source_inbox_item_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Insert a `calibration_fingerprint` row for a just-created
+/// `calibration_session`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on constraint or connection failure.
+pub async fn insert_calibration_fingerprint(
+    pool: &SqlitePool,
+    fp: &InsertCalibrationFingerprint<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO calibration_fingerprint
+            (id, calibration_type, exposure_s, filter_name)
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(fp.calibration_session_id)
+    .bind(fp.calibration_type)
+    .bind(fp.exposure_s)
+    .bind(fp.filter_name)
+    .execute(pool)
+    .await?;
+    Ok(())
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves confirm.rs (2), plan_listener.rs (8), reclassify.rs (6) behind persistence_db::repositories::q_inbox.

Under review. Opened early for parallel CI per orchestrator; formal merge held for explicit APPROVE.