### PR TITLE
refactor: move desktop command database queries behind the persistence layer

### DIFF
--- a/apps/desktop/src-tauri/src/commands/inbox.rs
+++ b/apps/desktop/src-tauri/src/commands/inbox.rs
@@ -41,6 +41,10 @@ use persistence_db::repositories::inbox::{
     get_inbox_source_group_by_path, grouping_keys_for_items, link_placeholder_to_source_group,
     list_unacknowledged_across_roots, upsert_inbox_source_group, UpsertSourceGroup,
 };
+use persistence_db::repositories::q_desktop::{
+    get_inbox_master_item_row, get_inbox_placeholder_row, insert_inbox_folder_placeholder,
+    insert_inbox_master_item,
+};
 use sqlx::SqlitePool;
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -394,21 +398,17 @@ async fn persist_folder_placeholder(
             .map_err(|e| ContractError::internal(e.to_string()))?
             .map_or(fallback_sg_id, |row| row.id);
 
-    sqlx::query(
-        "INSERT OR IGNORE INTO inbox_items
-            (id, root_id, relative_path, source_group_id, file_count, discovered_at,
-             last_scanned_at, content_signature, state, lane, format, is_master_item)
-         VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'), ?, 'pending_classification', ?, ?, 0)",
+    insert_inbox_folder_placeholder(
+        pool,
+        &item_id,
+        root_id,
+        &scanned_item.relative_path,
+        &authoritative_sg_id,
+        i64::try_from(persist_file_count).unwrap_or(i64::MAX),
+        &scanned_item.content_signature,
+        scanned_item.lane.as_str(),
+        folder_format_str,
     )
-    .bind(&item_id)
-    .bind(root_id)
-    .bind(&scanned_item.relative_path)
-    .bind(&authoritative_sg_id)
-    .bind(i64::try_from(persist_file_count).unwrap_or(i64::MAX))
-    .bind(&scanned_item.content_signature)
-    .bind(scanned_item.lane.as_str())
-    .bind(folder_format_str)
-    .execute(pool)
     .await
     .map_err(|e| ContractError::internal(e.to_string()))?;
 
@@ -427,38 +427,24 @@ async fn persist_folder_placeholder(
     // the placeholder (`group_key = ''`): once classify has materialized
     // single-type sub-items they share this (root_id, relative_path) and
     // an unscoped lookup would return an arbitrary one of them.
-    let row: Option<(String, String, i64, String, Option<String>, Option<String>)> =
-        sqlx::query_as(
-            "SELECT id, state, file_count, lane, content_signature, format
-             FROM inbox_items
-             WHERE root_id = ? AND relative_path = ? AND group_key = ''",
-        )
-        .bind(root_id)
-        .bind(&scanned_item.relative_path)
-        .fetch_optional(pool)
+    let row = get_inbox_placeholder_row(pool, root_id, &scanned_item.relative_path)
         .await
         .map_err(|e| ContractError::internal(e.to_string()))?;
 
-    Ok(row.map(|(id, state, fc, lane, sig, fmt)| InboxItemSummary {
-        inbox_item_id: id,
+    Ok(row.map(|r| InboxItemSummary {
+        inbox_item_id: r.id,
         relative_path: scanned_item.relative_path.clone(),
-        file_count: u32::try_from(fc).unwrap_or(u32::MAX),
-        lane,
-        format: fmt.unwrap_or_else(|| folder_format_str.to_owned()),
-        state,
-        content_signature: sig.unwrap_or_default(),
+        file_count: u32::try_from(r.file_count).unwrap_or(u32::MAX),
+        lane: r.lane,
+        format: r.format.unwrap_or_else(|| folder_format_str.to_owned()),
+        state: r.state,
+        content_signature: r.content_signature.unwrap_or_default(),
         is_master: false,
         master_frame_type: None,
         master_filter: None,
         master_exposure_s: None,
     }))
 }
-
-/// Row shape for an individual master `inbox_items` lookup: `(id, state,
-/// file_count, lane, content_signature, is_master_item, master_frame_type,
-/// master_filter, master_exposure_s)`.
-type MasterItemRow =
-    (String, String, i64, String, Option<String>, i64, Option<String>, Option<String>, Option<f64>);
 
 /// Insert (or reuse) the individual `inbox_items` row for a single detected
 /// calibration master and return its summary, if the row is present.
@@ -472,50 +458,37 @@ async fn persist_master_item(
     let frame_type_str = format!("{:?}", master.detection.frame_type).to_ascii_lowercase();
     let format_str = master.format.as_str();
 
-    sqlx::query(
-        "INSERT OR IGNORE INTO inbox_items
-            (id, root_id, relative_path, file_count, discovered_at, last_scanned_at,
-             content_signature, state, lane, format, is_master_item,
-             master_frame_type, master_filter, master_exposure_s)
-         VALUES (?, ?, ?, 1, datetime('now'), datetime('now'), '', 'pending_classification',
-                 ?, ?, 1, ?, ?, ?)",
+    insert_inbox_master_item(
+        pool,
+        &master_item_id,
+        root_id,
+        &master.relative_path,
+        lane,
+        format_str,
+        &frame_type_str,
+        master.filter.as_deref(),
+        master.exposure_s,
     )
-    .bind(&master_item_id)
-    .bind(root_id)
-    .bind(&master.relative_path)
-    .bind(lane)
-    .bind(format_str)
-    .bind(&frame_type_str)
-    .bind(&master.filter)
-    .bind(master.exposure_s)
-    .execute(pool)
     .await
     .map_err(|e| ContractError::internal(e.to_string()))?;
 
     // Fetch authoritative row (may have existed from a prior scan).
-    let row: Option<MasterItemRow> = sqlx::query_as(
-        "SELECT id, state, file_count, lane, content_signature,
-                    is_master_item, master_frame_type, master_filter, master_exposure_s
-             FROM inbox_items WHERE root_id = ? AND relative_path = ?",
-    )
-    .bind(root_id)
-    .bind(&master.relative_path)
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| ContractError::internal(e.to_string()))?;
+    let row = get_inbox_master_item_row(pool, root_id, &master.relative_path)
+        .await
+        .map_err(|e| ContractError::internal(e.to_string()))?;
 
-    Ok(row.map(|(id, state, fc, lane, sig, _is_m, mft, mfilt, mexp)| InboxItemSummary {
-        inbox_item_id: id,
+    Ok(row.map(|r| InboxItemSummary {
+        inbox_item_id: r.id,
         relative_path: master.relative_path.clone(),
-        file_count: u32::try_from(fc).unwrap_or(u32::MAX),
-        lane,
+        file_count: u32::try_from(r.file_count).unwrap_or(u32::MAX),
+        lane: r.lane,
         format: format_str.to_owned(),
-        state,
-        content_signature: sig.unwrap_or_default(),
+        state: r.state,
+        content_signature: r.content_signature.unwrap_or_default(),
         is_master: true,
-        master_frame_type: mft,
-        master_filter: mfilt,
-        master_exposure_s: mexp,
+        master_frame_type: r.master_frame_type,
+        master_filter: r.master_filter,
+        master_exposure_s: r.master_exposure_s,
     }))
 }
 

--- a/apps/desktop/src-tauri/src/commands/status.rs
+++ b/apps/desktop/src-tauri/src/commands/status.rs
@@ -9,6 +9,10 @@ use tauri::State;
 
 use crate::commands::lifecycle::AppState;
 use contracts_core::ContractError;
+use persistence_db::repositories::q_desktop::{
+    count_acquisition_sessions, count_calibration_masters, count_canonical_targets, count_projects,
+    count_unacknowledged_inbox_items,
+};
 
 /// `status.summary` — returns current library status overview.
 ///
@@ -44,38 +48,28 @@ pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary,
         .collect();
 
     // Count unacknowledged inbox items (states that need user attention).
-    let inbox_count: u32 = sqlx::query_scalar::<_, i64>(
-        "SELECT COUNT(*) FROM inbox_items i
-         JOIN registered_sources r ON r.id = i.root_id
-         WHERE i.state IN ('pending_classification', 'classified')",
-    )
-    .fetch_one(pool)
-    .await
-    .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
-    .map_err(|e| ContractError::internal(e.to_string()))?;
+    let inbox_count: u32 = count_unacknowledged_inbox_items(pool)
+        .await
+        .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
+        .map_err(|e| ContractError::internal(e.to_string()))?;
 
     // Count real library totals from their authoritative tables.
-    let sessions: u32 = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM acquisition_session")
-        .fetch_one(pool)
+    let sessions: u32 = count_acquisition_sessions(pool)
         .await
         .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
         .map_err(|e| ContractError::internal(e.to_string()))?;
 
-    let calibration_sets: u32 =
-        sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM calibration_master_view")
-            .fetch_one(pool)
-            .await
-            .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
-            .map_err(|e| ContractError::internal(e.to_string()))?;
-
-    let targets: u32 = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM canonical_target")
-        .fetch_one(pool)
+    let calibration_sets: u32 = count_calibration_masters(pool)
         .await
         .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
         .map_err(|e| ContractError::internal(e.to_string()))?;
 
-    let projects: u32 = sqlx::query_scalar::<_, i64>("SELECT COUNT(*) FROM projects")
-        .fetch_one(pool)
+    let targets: u32 = count_canonical_targets(pool)
+        .await
+        .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
+        .map_err(|e| ContractError::internal(e.to_string()))?;
+
+    let projects: u32 = count_projects(pool)
         .await
         .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
         .map_err(|e| ContractError::internal(e.to_string()))?;

--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -16,6 +16,7 @@ use contracts_core::targets::{
     TargetSearchResponse,
 };
 use contracts_core::ContractError;
+use persistence_db::repositories::q_desktop::get_resolver_settings;
 use tauri::State;
 
 use crate::commands::lifecycle::AppState;
@@ -50,14 +51,12 @@ pub async fn target_resolve(
     let pool = state.repo.pool();
 
     // Read settings (incl. online_enabled) to decide whether to build a client.
-    let settings: Option<(i64, String, i64)> = sqlx::query_as(
-        "SELECT online_enabled, simbad_endpoint, request_timeout_secs FROM resolver_settings WHERE id = 1",
-    )
-    .fetch_optional(pool)
-    .await
-    .map_err(|e| ContractError::internal(e.to_string()))?;
-    let (online_enabled, endpoint, timeout_secs) = settings
-        .map_or_else(|| (true, DEFAULT_TAP_ENDPOINT.to_owned(), 10), |(o, e, t)| (o != 0, e, t));
+    let settings =
+        get_resolver_settings(pool).await.map_err(|e| ContractError::internal(e.to_string()))?;
+    let (online_enabled, endpoint, timeout_secs) = settings.map_or_else(
+        || (true, DEFAULT_TAP_ENDPOINT.to_owned(), 10),
+        |r| (r.online_enabled != 0, r.simbad_endpoint, r.request_timeout_secs),
+    );
 
     // FIX-3: when online resolution is disabled, do NOT construct a reqwest/TLS
     // client (it can fail to build, turning an offline-by-config call into an

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -934,16 +934,12 @@ fn spawn_ingest_resolution_drain(pool: SqlitePool, bus: EventBus) {
             tokio::time::sleep(interval).await;
 
             // Read resolver settings (online toggle + endpoint + timeout).
-            let settings: Option<(i64, String, i64)> = sqlx::query_as(
-                "SELECT online_enabled, simbad_endpoint, request_timeout_secs \
-                 FROM resolver_settings WHERE id = 1",
-            )
-            .fetch_optional(&pool)
-            .await
-            .unwrap_or(None);
+            let settings = persistence_db::repositories::q_desktop::get_resolver_settings(&pool)
+                .await
+                .unwrap_or(None);
             let (online_enabled, endpoint, timeout_secs) = settings.map_or_else(
                 || (true, DEFAULT_TAP_ENDPOINT.to_owned(), 10),
-                |(o, e, t)| (o != 0, e, t),
+                |r| (r.online_enabled != 0, r.simbad_endpoint, r.request_timeout_secs),
             );
 
             // When online, build a SimbadResolver (falling back to offline if the

--- a/crates/persistence/db/src/repositories/q_desktop.rs
+++ b/crates/persistence/db/src/repositories/q_desktop.rs
@@ -1,3 +1,395 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_desktop`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Desktop Tauri command repository (db-boundary-zero drain).
+//!
+//! Backs `apps/desktop/src-tauri/src/commands/inbox.rs`,
+//! `commands/status.rs`, `commands/target_lookup.rs`, and the spec 035 US4
+//! ingest-resolution drain in `lib.rs`. Free functions only, mirroring the
+//! `inventory`/`targets` repository idiom (no repo struct/trait).
+
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+// ── inbox.scan.folder support (spec 041 T065) ──────────────────────────────────
+
+/// Insert (or reuse, via `INSERT OR IGNORE`) the folder-level PLACEHOLDER
+/// `inbox_items` row (`group_key = ''`) for a scanned folder, linked to its
+/// source group.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_inbox_folder_placeholder(
+    pool: &SqlitePool,
+    id: &str,
+    root_id: &str,
+    relative_path: &str,
+    source_group_id: &str,
+    file_count: i64,
+    content_signature: &str,
+    lane: &str,
+    format: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO inbox_items
+            (id, root_id, relative_path, source_group_id, file_count, discovered_at,
+             last_scanned_at, content_signature, state, lane, format, is_master_item)
+         VALUES (?, ?, ?, ?, ?, datetime('now'), datetime('now'), ?, 'pending_classification', ?, ?, 0)",
+    )
+    .bind(id)
+    .bind(root_id)
+    .bind(relative_path)
+    .bind(source_group_id)
+    .bind(file_count)
+    .bind(content_signature)
+    .bind(lane)
+    .bind(format)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Folder-placeholder `inbox_items` row shape (`group_key = ''`), scoped by
+/// `(root_id, relative_path)`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct InboxPlaceholderRow {
+    pub id: String,
+    pub state: String,
+    pub file_count: i64,
+    pub lane: String,
+    pub content_signature: Option<String>,
+    pub format: Option<String>,
+}
+
+/// Fetch the authoritative folder-placeholder `inbox_items` row (`group_key =
+/// ''`) for a scanned folder. Scoping to the placeholder avoids returning an
+/// arbitrary single-type sub-item once `classify` has materialized them.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_inbox_placeholder_row(
+    pool: &SqlitePool,
+    root_id: &str,
+    relative_path: &str,
+) -> DbResult<Option<InboxPlaceholderRow>> {
+    let row = sqlx::query_as::<_, InboxPlaceholderRow>(
+        "SELECT id, state, file_count, lane, content_signature, format
+         FROM inbox_items
+         WHERE root_id = ? AND relative_path = ? AND group_key = ''",
+    )
+    .bind(root_id)
+    .bind(relative_path)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Insert (or reuse, via `INSERT OR IGNORE`) the individual `inbox_items` row
+/// for a single detected calibration master.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+#[allow(clippy::too_many_arguments)]
+pub async fn insert_inbox_master_item(
+    pool: &SqlitePool,
+    id: &str,
+    root_id: &str,
+    relative_path: &str,
+    lane: &str,
+    format: &str,
+    frame_type: &str,
+    filter: Option<&str>,
+    exposure_s: Option<f64>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT OR IGNORE INTO inbox_items
+            (id, root_id, relative_path, file_count, discovered_at, last_scanned_at,
+             content_signature, state, lane, format, is_master_item,
+             master_frame_type, master_filter, master_exposure_s)
+         VALUES (?, ?, ?, 1, datetime('now'), datetime('now'), '', 'pending_classification',
+                 ?, ?, 1, ?, ?, ?)",
+    )
+    .bind(id)
+    .bind(root_id)
+    .bind(relative_path)
+    .bind(lane)
+    .bind(format)
+    .bind(frame_type)
+    .bind(filter)
+    .bind(exposure_s)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Individual master-item `inbox_items` row shape, scoped by `(root_id,
+/// relative_path)`.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct InboxMasterItemRow {
+    pub id: String,
+    pub state: String,
+    pub file_count: i64,
+    pub lane: String,
+    pub content_signature: Option<String>,
+    pub is_master_item: i64,
+    pub master_frame_type: Option<String>,
+    pub master_filter: Option<String>,
+    pub master_exposure_s: Option<f64>,
+}
+
+/// Fetch the authoritative `inbox_items` row for an individual master file
+/// (may have existed from a prior scan).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_inbox_master_item_row(
+    pool: &SqlitePool,
+    root_id: &str,
+    relative_path: &str,
+) -> DbResult<Option<InboxMasterItemRow>> {
+    let row = sqlx::query_as::<_, InboxMasterItemRow>(
+        "SELECT id, state, file_count, lane, content_signature,
+                is_master_item, master_frame_type, master_filter, master_exposure_s
+         FROM inbox_items WHERE root_id = ? AND relative_path = ?",
+    )
+    .bind(root_id)
+    .bind(relative_path)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+// ── status.summary (spec 030 T023) ──────────────────────────────────────────────
+
+/// Count unacknowledged inbox items (`pending_classification` or
+/// `classified`) across all registered roots.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_unacknowledged_inbox_items(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM inbox_items i
+         JOIN registered_sources r ON r.id = i.root_id
+         WHERE i.state IN ('pending_classification', 'classified')",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(count)
+}
+
+/// Count all `acquisition_session` rows.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_acquisition_sessions(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM acquisition_session").fetch_one(pool).await?;
+    Ok(count)
+}
+
+/// Count all rows in the `calibration_master_view` projection.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_calibration_masters(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM calibration_master_view").fetch_one(pool).await?;
+    Ok(count)
+}
+
+/// Count all `canonical_target` rows.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_canonical_targets(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM canonical_target").fetch_one(pool).await?;
+    Ok(count)
+}
+
+/// Count all `projects` rows.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_projects(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM projects").fetch_one(pool).await?;
+    Ok(count)
+}
+
+// ── resolver_settings read (spec 035 target.resolve + US4 ingest drain) ───────
+
+/// Singleton `resolver_settings` row (id = 1): online toggle, SIMBAD
+/// endpoint, and request timeout, read by both `target.resolve` and the
+/// background ingest-resolution drain.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct ResolverSettingsRow {
+    pub online_enabled: i64,
+    pub simbad_endpoint: String,
+    pub request_timeout_secs: i64,
+}
+
+/// Fetch the singleton `resolver_settings` row (id = 1).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_resolver_settings(pool: &SqlitePool) -> DbResult<Option<ResolverSettingsRow>> {
+    let row = sqlx::query_as::<_, ResolverSettingsRow>(
+        "SELECT online_enabled, simbad_endpoint, request_timeout_secs \
+         FROM resolver_settings WHERE id = 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> Database {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db
+    }
+
+    #[tokio::test]
+    async fn status_counts_are_zero_on_fresh_db() {
+        let db = setup().await;
+        assert_eq!(count_unacknowledged_inbox_items(db.pool()).await.unwrap(), 0);
+        assert_eq!(count_acquisition_sessions(db.pool()).await.unwrap(), 0);
+        assert_eq!(count_calibration_masters(db.pool()).await.unwrap(), 0);
+        assert_eq!(count_canonical_targets(db.pool()).await.unwrap(), 0);
+        assert_eq!(count_projects(db.pool()).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn resolver_settings_seeded_by_migration_0031() {
+        let db = setup().await;
+        let row = get_resolver_settings(db.pool()).await.unwrap().expect("seeded singleton row");
+        assert_eq!(row.online_enabled, 1, "default online_enabled per migration 0031");
+        assert_eq!(row.request_timeout_secs, 10, "default request_timeout_secs");
+    }
+
+    /// Registers a real `registered_sources` row via `first_run::register_source_batch`
+    /// (same path the desktop scan/inbox code uses) — `inbox_items.root_id` is a
+    /// real FK, and `INSERT OR IGNORE` silently drops rows on FK violation.
+    async fn register_test_root(pool: &sqlx::SqlitePool) -> String {
+        use domain_core::first_run::{
+            OrganizationState, RegisterSourceBatchRequest, RegisterSourceRequest, ScanDepth,
+            SourceKind,
+        };
+        let batch_req = RegisterSourceBatchRequest {
+            sources: vec![RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: "/astro/inbox".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Unorganized,
+            }],
+        };
+        let batch_resp =
+            crate::repositories::first_run::register_source_batch(pool, &batch_req).await.unwrap();
+        batch_resp.items[0].source_id.as_deref().unwrap().to_owned()
+    }
+
+    #[tokio::test]
+    async fn inbox_folder_placeholder_round_trips() {
+        let db = setup().await;
+        let root_id = register_test_root(db.pool()).await;
+        // source_group_id is a real FK (inbox_source_groups.id); INSERT OR
+        // IGNORE silently drops the row on FK/CHECK violation instead of
+        // erroring, so the group must exist first.
+        crate::repositories::inbox::upsert_inbox_source_group(
+            db.pool(),
+            &crate::repositories::inbox::UpsertSourceGroup {
+                id: "sg-1",
+                root_id: &root_id,
+                relative_path: "2026-01-01/Lights",
+                content_signature: Some("sig-abc"),
+                format: Some("fits"),
+                lane: Some("move"),
+            },
+        )
+        .await
+        .unwrap();
+
+        insert_inbox_folder_placeholder(
+            db.pool(),
+            "item-1",
+            &root_id,
+            "2026-01-01/Lights",
+            "sg-1",
+            10,
+            "sig-abc",
+            "fits",
+            "fits",
+        )
+        .await
+        .unwrap();
+
+        let row = get_inbox_placeholder_row(db.pool(), &root_id, "2026-01-01/Lights")
+            .await
+            .unwrap()
+            .expect("row inserted");
+        assert_eq!(row.id, "item-1");
+        assert_eq!(row.state, "pending_classification");
+        assert_eq!(row.file_count, 10);
+        assert_eq!(row.lane, "fits");
+        assert_eq!(row.content_signature.as_deref(), Some("sig-abc"));
+        assert_eq!(row.format.as_deref(), Some("fits"));
+
+        // INSERT OR IGNORE: a second insert with a different id must not
+        // overwrite the original row.
+        insert_inbox_folder_placeholder(
+            db.pool(),
+            "item-2",
+            &root_id,
+            "2026-01-01/Lights",
+            "sg-1",
+            20,
+            "sig-def",
+            "video",
+            "xisf",
+        )
+        .await
+        .unwrap();
+        let row = get_inbox_placeholder_row(db.pool(), &root_id, "2026-01-01/Lights")
+            .await
+            .unwrap()
+            .expect("row still present");
+        assert_eq!(row.id, "item-1", "OR IGNORE keeps the original row");
+    }
+
+    #[tokio::test]
+    async fn inbox_master_item_round_trips() {
+        let db = setup().await;
+        let root_id = register_test_root(db.pool()).await;
+        insert_inbox_master_item(
+            db.pool(),
+            "master-1",
+            &root_id,
+            "2026-01-01/Flats/flat_L_001.fits",
+            "fits",
+            "fits",
+            "flat",
+            Some("L"),
+            Some(2.5),
+        )
+        .await
+        .unwrap();
+
+        let row =
+            get_inbox_master_item_row(db.pool(), &root_id, "2026-01-01/Flats/flat_L_001.fits")
+                .await
+                .unwrap()
+                .expect("row inserted");
+        assert_eq!(row.id, "master-1");
+        assert_eq!(row.file_count, 1);
+        assert_eq!(row.is_master_item, 1);
+        assert_eq!(row.master_frame_type.as_deref(), Some("flat"));
+        assert_eq!(row.master_filter.as_deref(), Some("L"));
+        assert_eq!(row.master_exposure_s, Some(2.5));
+    }
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run: moves inbox.rs (8), status.rs (10), target_lookup.rs (2), lib.rs (2) behind persistence_db::repositories::q_desktop.

Reviewed+approved (sonnet, 0 change items). SQL byte-faithful, get_resolver_settings dedup identical, lib.rs entrypoint untouched beyond the query swap. Depends on merged foundation.