### PR TITLE
refactor: move projects database queries behind the persistence layer

### DIFF
--- a/crates/app/projects/src/prepared_views.rs
+++ b/crates/app/projects/src/prepared_views.rs
@@ -30,7 +30,7 @@ use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::new_id;
 use domain_core::lifecycle::prepared_source::ALLOWED_PROJECT_STATES_FOR_VIEW_OPS;
 use persistence_db::repositories::{
-    plans as plans_repo, prepared_source_views as views_repo, projects as projects_repo,
+    plans as plans_repo, prepared_source_views as views_repo, projects as projects_repo, q_projects,
 };
 use sqlx::SqlitePool;
 
@@ -318,11 +318,8 @@ pub async fn regenerate_prepared_view(
 
     for item in &items {
         // Check inventory resolution against the file_record table.
-        let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM file_record WHERE id = ?")
-            .bind(&item.inventory_item_id)
-            .fetch_one(pool)
-            .await
-            .unwrap_or(false);
+        let exists =
+            q_projects::file_record_exists(pool, &item.inventory_item_id).await.unwrap_or(false);
 
         if exists {
             resolved_items.push(item);

--- a/crates/app/projects/src/project_setup.rs
+++ b/crates/app/projects/src/project_setup.rs
@@ -49,6 +49,7 @@ use domain_core::project::validate::{
 use persistence_db::repositories::first_run as first_run_repo;
 use persistence_db::repositories::plans as plans_repo;
 use persistence_db::repositories::projects as repo;
+use persistence_db::repositories::q_projects;
 use project_structure::{required_folders, ProcessingTool as StructureTool, MARKER_FILENAME};
 use sqlx::SqlitePool;
 
@@ -486,20 +487,15 @@ pub async fn create(
     // dangling id is rejected rather than silently stored. Spec-035 additive
     // association; absent → stored as NULL (existing behaviour unchanged).
     if let Some(ctid) = req.canonical_target_id.as_deref() {
-        let exists: Option<(String,)> =
-            sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-                .bind(ctid)
-                .fetch_optional(pool)
-                .await
-                .map_err(|e| {
-                    ContractError::new(
-                        ErrorCode::InternalDatabase,
-                        format!("{e}"),
-                        ErrorSeverity::Fatal,
-                        true,
-                    )
-                })?;
-        if exists.is_none() {
+        let exists = q_projects::canonical_target_exists(pool, ctid).await.map_err(|e| {
+            ContractError::new(
+                ErrorCode::InternalDatabase,
+                format!("{e}"),
+                ErrorSeverity::Fatal,
+                true,
+            )
+        })?;
+        if !exists {
             return Err(ContractError::new(
                 ErrorCode::CanonicalTargetNotFound,
                 "The selected target was not found.",

--- a/crates/app/projects/src/source_view_generate.rs
+++ b/crates/app/projects/src/source_view_generate.rs
@@ -49,7 +49,7 @@ use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::new_id;
 use domain_core::source_view::Materialization;
 use patterns::{resolve_pattern_str, MetadataBundle, ResolveError};
-use persistence_db::repositories::{plans as plans_repo, projects as projects_repo};
+use persistence_db::repositories::{plans as plans_repo, projects as projects_repo, q_projects};
 use sqlx::SqlitePool;
 
 use app_core_errors::db_internal_ctx;
@@ -108,14 +108,10 @@ struct FrameRow {
 async fn frames_for_ids(pool: &SqlitePool, ids: &[String]) -> Vec<FrameRow> {
     let mut out = Vec::with_capacity(ids.len());
     for id in ids {
-        if let Ok(Some(row)) = sqlx::query_as::<_, (String, String)>(
-            "SELECT relative_path, state FROM file_record WHERE id = ?",
-        )
-        .bind(id)
-        .fetch_optional(pool)
-        .await
+        if let Ok(Some((relative_path, state))) =
+            q_projects::get_file_record_path_and_state(pool, id).await
         {
-            out.push(FrameRow { id: id.clone(), relative_path: row.0, state: row.1 });
+            out.push(FrameRow { id: id.clone(), relative_path, state });
         }
         // Missing rows are silently absent here — the caller treats an id
         // with no resolved frame as unresolved (FR-019).
@@ -307,18 +303,19 @@ pub async fn generate_source_view(
         );
 
     for src in &sources {
-        let Some((root_id, session_key, frame_ids_json)) =
-            sqlx::query_as::<_, (String, String, String)>(
-                "SELECT root_id, session_key, frame_ids FROM acquisition_session WHERE id = ?",
-            )
-            .bind(&src.inventory_session_id)
-            .fetch_optional(pool)
-            .await
-            .map_err(|e| db_internal_ctx(e, "load acquisition session"))?
+        let Some(session) =
+            q_projects::get_acquisition_session_view(pool, &src.inventory_session_id)
+                .await
+                .map_err(|e| db_internal_ctx(e, "load acquisition session"))?
         else {
             unresolved_refs.push(src.inventory_session_id.clone());
             continue;
         };
+        let q_projects::AcquisitionSessionViewRow {
+            root_id,
+            session_key,
+            frame_ids: frame_ids_json,
+        } = session;
 
         // Resolve the light-frame destination directory once per session
         // (session/night → filter → exposure grouping, US2 AS1): the
@@ -359,13 +356,10 @@ pub async fn generate_source_view(
         }
 
         // 3. Matched calibration (best-effort; not a generation prerequisite — FR-010a).
-        let assignments: Vec<(String, String)> = sqlx::query_as(
-            "SELECT calibration_type, master_id FROM calibration_assignment WHERE session_id = ?",
-        )
-        .bind(&src.inventory_session_id)
-        .fetch_all(pool)
-        .await
-        .unwrap_or_default();
+        let assignments: Vec<(String, String)> =
+            q_projects::list_calibration_assignment_types(pool, &src.inventory_session_id)
+                .await
+                .unwrap_or_default();
 
         if assignments.is_empty() {
             sessions_without_calibration.push(src.inventory_session_id.clone());
@@ -378,13 +372,9 @@ pub async fn generate_source_view(
         );
 
         for (cal_type, master_id) in assignments {
-            let Some((cal_root_id, cal_frame_ids_json)) = sqlx::query_as::<_, (String, String)>(
-                "SELECT root_id, frame_ids FROM calibration_session WHERE id = ?",
-            )
-            .bind(&master_id)
-            .fetch_optional(pool)
-            .await
-            .unwrap_or(None) else {
+            let Some((cal_root_id, cal_frame_ids_json)) =
+                q_projects::get_calibration_session_view(pool, &master_id).await.unwrap_or(None)
+            else {
                 unresolved_refs.push(master_id.clone());
                 continue;
             };

--- a/crates/persistence/db/src/repositories/q_projects.rs
+++ b/crates/persistence/db/src/repositories/q_projects.rs
@@ -1,3 +1,117 @@
-//! Scaffolding stub for the db-boundary-zero drain node owning `q_projects`.
-//! Populated with free-fn repository queries as that node's raw-sqlx sites
-//! are migrated out of production code.
+//! Free-fn repository queries for `crates/app/projects` (db-boundary-zero
+//! drain). These don't fit the existing `projects` / `prepared_source_views`
+//! repositories' query shapes exactly, so they live here rather than being
+//! folded into either.
+
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+/// Whether a `file_record` row exists for `id` (spec 026 regenerate: checks
+/// inventory resolution before re-linking a prepared view item).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn file_record_exists(pool: &SqlitePool, id: &str) -> DbResult<bool> {
+    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM file_record WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await?;
+    Ok(exists)
+}
+
+/// Whether a `canonical_target` row exists for `id` (spec 008/035 project
+/// creation: validates an optional `canonical_target_id` before storing it).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn canonical_target_exists(pool: &SqlitePool, id: &str) -> DbResult<bool> {
+    let row: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
+        .bind(id)
+        .fetch_optional(pool)
+        .await?;
+    Ok(row.is_some())
+}
+
+/// `(relative_path, state)` for a `file_record` row (spec 049 generation:
+/// resolves a session's frame ids to their current path + presence state).
+/// Returns `None` when no row exists.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_file_record_path_and_state(
+    pool: &SqlitePool,
+    id: &str,
+) -> DbResult<Option<(String, String)>> {
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT relative_path, state FROM file_record WHERE id = ?")
+            .bind(id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row)
+}
+
+/// `acquisition_session` fields needed to plan a session's light-frame
+/// destinations (spec 049 generation): source root, night/target key, and
+/// the frame id set.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct AcquisitionSessionViewRow {
+    pub root_id: String,
+    pub session_key: String,
+    pub frame_ids: String,
+}
+
+/// Look up an `acquisition_session` row by id. Returns `None` when no row
+/// exists (an unresolved project-linked source, spec 049 FR-019).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_acquisition_session_view(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<AcquisitionSessionViewRow>> {
+    let row = sqlx::query_as::<_, AcquisitionSessionViewRow>(
+        "SELECT root_id, session_key, frame_ids FROM acquisition_session WHERE id = ?",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// `(calibration_type, master_id)` pairs assigned to a session (spec 049
+/// generation's best-effort calibration match; unordered — callers group by
+/// type into a set).
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_calibration_assignment_types(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Vec<(String, String)>> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT calibration_type, master_id FROM calibration_assignment WHERE session_id = ?",
+    )
+    .bind(session_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+/// `(root_id, frame_ids)` for a `calibration_session` row (spec 049
+/// generation: resolves a matched master's source root + frame id set).
+/// Returns `None` when no row exists.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_calibration_session_view(
+    pool: &SqlitePool,
+    master_id: &str,
+) -> DbResult<Option<(String, String)>> {
+    let row: Option<(String, String)> =
+        sqlx::query_as("SELECT root_id, frame_ids FROM calibration_session WHERE id = ?")
+            .bind(master_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row)
+}


### PR DESCRIPTION
Drain node for db-boundary-zero run (final drain): moves prepared_views.rs (2), project_setup.rs (2), source_view_generate.rs (8) behind persistence_db::repositories::q_projects.

Reviewed+approved (sonnet, 0 change items). 6 queries byte-identical incl. source_view_generate multi-table reads; source_view_verify.rs untouched; 0 residual sites. Depends on merged foundation. Merge queued after desktop (#543).