### PR TITLE
fix: file watcher and move operations no longer follow symlinks or Windows junctions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,6 +169,7 @@ dependencies = [
  "calibration_master_detect",
  "camino",
  "contracts_core",
+ "fs_pathsafe",
  "hex",
  "metadata_core",
  "metadata_fits",
@@ -1912,6 +1913,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "domain_core",
+ "fs_pathsafe",
  "path-clean",
  "serde",
  "serde_json",
@@ -1936,11 +1938,19 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "domain_core",
+ "fs_pathsafe",
  "notify",
  "serde",
  "serde_json",
  "tempfile",
  "tokio",
+]
+
+[[package]]
+name = "fs_pathsafe"
+version = "0.1.0"
+dependencies = [
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/domain/core",
   "crates/fs/executor",
   "crates/fs/inventory",
+  "crates/fs/pathsafe",
   "crates/metadata/core",
   "crates/metadata/fits",
   "crates/metadata/video",

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -285,7 +285,11 @@ pub async fn attach_project_watcher(
     let root_utf8 = Utf8PathBuf::from_path_buf(project_root)
         .map_err(|_| format!("project path is not valid UTF-8: {}", project.path))?;
 
-    let (mut rx, guard) = start_artifact_watcher(std::slice::from_ref(&root_utf8), 256)
+    // Constitution §II: never follow symlinks/junctions unless explicitly
+    // enabled per root; project output folders have no per-root override
+    // surface yet, so they default to the safe gate (matches
+    // `start_watcher`'s inbox gating above).
+    let (mut rx, guard) = start_artifact_watcher(std::slice::from_ref(&root_utf8), 256, false)
         .map_err(|e| format!("failed to start artifact watcher: {e}"))?;
 
     let task_pool = pool.clone();

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -13,6 +13,7 @@ app_core_targets = { path = "../targets" }
 audit = { path = "../../audit" }
 calibration_master_detect = { path = "../../calibration/master-detect" }
 contracts_core = { path = "../../contracts/core" }
+fs_pathsafe = { path = "../../fs/pathsafe" }
 metadata_core = { path = "../../metadata/core" }
 metadata_fits = { path = "../../metadata/fits" }
 metadata_video = { path = "../../metadata/video" }

--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -287,17 +287,19 @@ fn scan_dir(
         }
 
         let Ok(file_type) = entry.file_type() else { continue };
+        // Reparse-aware check (symlink + Windows junction) shared with
+        // fs_inventory/fs_executor — see `fs_pathsafe` (duplication-and-
+        // abstraction audit T1-a).
+        let is_link = fs_pathsafe::is_link_or_junction(&path);
 
-        if file_type.is_symlink() && !options.follow_symlinks {
-            // Constitution §I: skip symlinks unless explicitly enabled.
+        if is_link && !options.follow_symlinks {
+            // Constitution §I: skip symlinks/junctions unless explicitly enabled.
             continue;
         }
 
-        if file_type.is_dir()
-            || (file_type.is_symlink() && options.follow_symlinks && path.is_dir())
-        {
+        if file_type.is_dir() || (is_link && options.follow_symlinks && path.is_dir()) {
             subdirs.push(path);
-        } else if file_type.is_file() || (file_type.is_symlink() && options.follow_symlinks) {
+        } else if file_type.is_file() || (is_link && options.follow_symlinks) {
             let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_ascii_lowercase();
 
             if is_fits_extension(&ext) {
@@ -507,5 +509,44 @@ mod tests {
         let items = scan_root(tmp.path(), &ScanOptions::default()).unwrap();
         assert_eq!(items.len(), 1);
         assert!(items[0].masters.is_empty(), "dummy file cannot be a master");
+    }
+
+    /// Constitution §I regression: a symlinked subdirectory reachable from the
+    /// scan root must not be traversed unless `follow_symlinks` is enabled.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_subdir_not_traversed_by_default() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tmpdir();
+        let real_target = tmp.path().join("real_target");
+        fs::create_dir_all(&real_target).unwrap();
+        write_file(&real_target, "hidden.fits", b"hidden");
+
+        let scan_root_dir = tmp.path().join("scan_root");
+        fs::create_dir_all(&scan_root_dir).unwrap();
+        symlink(&real_target, scan_root_dir.join("linked")).unwrap();
+
+        let items = scan_root(&scan_root_dir, &ScanOptions::default()).unwrap();
+        assert!(items.is_empty(), "must not see files behind an un-enabled symlink");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_subdir_traversed_when_follow_symlinks_enabled() {
+        use std::os::unix::fs::symlink;
+
+        let tmp = tmpdir();
+        let real_target = tmp.path().join("real_target");
+        fs::create_dir_all(&real_target).unwrap();
+        write_file(&real_target, "visible.fits", b"visible");
+
+        let scan_root_dir = tmp.path().join("scan_root");
+        fs::create_dir_all(&scan_root_dir).unwrap();
+        symlink(&real_target, scan_root_dir.join("linked")).unwrap();
+
+        let options = ScanOptions { follow_symlinks: true };
+        let items = scan_root(&scan_root_dir, &options).unwrap();
+        assert_eq!(items.len(), 1, "symlinked subdir is traversed when explicitly enabled");
     }
 }

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../../domain/core" }
+fs_pathsafe = { path = "../pathsafe" }
 camino = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/fs/executor/src/ops/link_op.rs
+++ b/crates/fs/executor/src/ops/link_op.rs
@@ -55,8 +55,10 @@ pub fn create_link(
     }
 
     match kind {
-        Materialization::Symlink => create_symlink(source, destination)
-            .map_err(|e| PlanItemFailure::from_io(&e, "create symlink")),
+        Materialization::Symlink => {
+            fs_pathsafe::create_symlink(source.as_std_path(), destination.as_std_path())
+                .map_err(|e| PlanItemFailure::from_io(&e, "create symlink"))
+        }
         Materialization::Hardlink => std::fs::hard_link(source, destination)
             .map_err(|e| PlanItemFailure::from_io(&e, "create hardlink")),
         Materialization::Copy => std::fs::copy(source, destination)
@@ -67,21 +69,6 @@ pub fn create_link(
             "junction materialization is not yet implemented by this executor",
         )),
     }
-}
-
-#[cfg(unix)]
-fn create_symlink(source: &Utf8Path, destination: &Utf8Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(source, destination)
-}
-
-#[cfg(windows)]
-fn create_symlink(source: &Utf8Path, destination: &Utf8Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_file(source, destination)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn create_symlink(_source: &Utf8Path, _destination: &Utf8Path) -> std::io::Result<()> {
-    Err(std::io::Error::other("symlink not supported on this platform"))
 }
 
 #[cfg(test)]

--- a/crates/fs/executor/src/ops/path_gate.rs
+++ b/crates/fs/executor/src/ops/path_gate.rs
@@ -76,31 +76,18 @@ pub fn resolve_and_validate(
         // there can be no symlink for a non-existent path component.
         match current.symlink_metadata() {
             Ok(meta) => {
-                if meta.file_type().is_symlink() {
+                // Shared reparse-aware classification (symlink + Windows
+                // FILE_ATTRIBUTE_REPARSE_POINT junction check) — see
+                // `fs_pathsafe` for the one implementation both this gate and
+                // `fs_inventory` walk against.
+                if fs_pathsafe::is_link_or_junction_metadata(&meta) {
                     return Err(PlanItemFailure::with_code(
                         FailureCode::SymlinkComponent,
                         format!(
-                            "path component '{current}' is a symlink; \
+                            "path component '{current}' is a symlink or junction; \
                              refusing to traverse (link-following is disabled for this root)"
                         ),
                     ));
-                }
-                #[cfg(windows)]
-                {
-                    // On Windows, junctions report as dirs but with reparse points.
-                    // The `trash` crate handles junctions separately; we detect via
-                    // the FILE_ATTRIBUTE_REPARSE_POINT attribute.
-                    use std::os::windows::fs::MetadataExt;
-                    const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
-                    if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
-                        return Err(PlanItemFailure::with_code(
-                            FailureCode::SymlinkComponent,
-                            format!(
-                                "path component '{current}' is a junction/reparse-point; \
-                                 refusing to traverse"
-                            ),
-                        ));
-                    }
                 }
             }
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => {

--- a/crates/fs/executor/src/run.rs
+++ b/crates/fs/executor/src/run.rs
@@ -83,6 +83,37 @@ pub struct ItemProgressEvent {
     pub audit_reason: Option<String>,
 }
 
+impl ItemProgressEvent {
+    /// Build a terminal-transition event with the rollback fields at their
+    /// non-rollback defaults (`rollback_attempted: false`,
+    /// `rollback_outcome: NotApplicable`, `rollback_message: None`).
+    ///
+    /// Covers every executor-loop transition that never invokes rollback
+    /// (skip, gate refusal, stale, protected, success); the one site that
+    /// carries a real rollback outcome (a failed mutation) builds the struct
+    /// directly instead.
+    #[must_use]
+    pub fn terminal(
+        item_id: impl Into<String>,
+        prior_state: impl Into<String>,
+        new_state: impl Into<String>,
+        failure: Option<PlanItemFailure>,
+        audit_reason: Option<String>,
+    ) -> Self {
+        Self {
+            item_id: item_id.into(),
+            prior_state: prior_state.into(),
+            new_state: new_state.into(),
+            at: Timestamp::now_iso(),
+            failure,
+            rollback_attempted: false,
+            rollback_outcome: RollbackOutcome::NotApplicable,
+            rollback_message: None,
+            audit_reason,
+        }
+    }
+}
+
 /// Final outcome of an `execute_plan` call.
 #[derive(Clone, Debug)]
 pub enum ApplyOutcome {
@@ -331,17 +362,13 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
         if skip_set.take(&item.id) {
             tracing::debug!(item_id = %item.id, "user-skipped item");
             callbacks
-                .on_item_progress(ItemProgressEvent {
-                    item_id: item.id.clone(),
-                    prior_state: "pending".to_owned(),
-                    new_state: "skipped".to_owned(),
-                    at: Timestamp::now_iso(),
-                    failure: None,
-                    rollback_attempted: false,
-                    rollback_outcome: RollbackOutcome::NotApplicable,
-                    rollback_message: None,
-                    audit_reason: None,
-                })
+                .on_item_progress(ItemProgressEvent::terminal(
+                    item.id.clone(),
+                    "pending",
+                    "skipped",
+                    None,
+                    None,
+                ))
                 .await;
             counts.skipped += 1;
             continue;
@@ -361,17 +388,13 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
                 ),
             );
             callbacks
-                .on_item_progress(ItemProgressEvent {
-                    item_id: item.id.clone(),
-                    prior_state: "pending".to_owned(),
-                    new_state: "refused".to_owned(),
-                    at: Timestamp::now_iso(),
-                    failure: Some(failure),
-                    rollback_attempted: false,
-                    rollback_outcome: RollbackOutcome::NotApplicable,
-                    rollback_message: None,
-                    audit_reason: Some("destructive_unconfirmed".to_owned()),
-                })
+                .on_item_progress(ItemProgressEvent::terminal(
+                    item.id.clone(),
+                    "pending",
+                    "refused",
+                    Some(failure),
+                    Some("destructive_unconfirmed".to_owned()),
+                ))
                 .await;
             counts.failed += 1;
             continue;
@@ -388,17 +411,13 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
                     let audit_reason = gate_failure.code.as_str().to_owned();
                     let triggers_pause = gate_failure.code.triggers_pause();
                     callbacks
-                        .on_item_progress(ItemProgressEvent {
-                            item_id: item.id.clone(),
-                            prior_state: "applying".to_owned(),
-                            new_state: "refused".to_owned(),
-                            at: Timestamp::now_iso(),
-                            failure: Some(gate_failure),
-                            rollback_attempted: false,
-                            rollback_outcome: RollbackOutcome::NotApplicable,
-                            rollback_message: None,
-                            audit_reason: Some(audit_reason),
-                        })
+                        .on_item_progress(ItemProgressEvent::terminal(
+                            item.id.clone(),
+                            "applying",
+                            "refused",
+                            Some(gate_failure),
+                            Some(audit_reason),
+                        ))
                         .await;
                     counts.failed += 1;
                     if triggers_pause {
@@ -428,17 +447,13 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
                 let failure_clone = stale_failure.clone();
 
                 callbacks
-                    .on_item_progress(ItemProgressEvent {
-                        item_id: item.id.clone(),
-                        prior_state: "applying".to_owned(),
-                        new_state: "stale".to_owned(),
-                        at: Timestamp::now_iso(),
-                        failure: Some(failure_clone),
-                        rollback_attempted: false,
-                        rollback_outcome: RollbackOutcome::NotApplicable,
-                        rollback_message: None,
-                        audit_reason: Some("stale".to_owned()),
-                    })
+                    .on_item_progress(ItemProgressEvent::terminal(
+                        item.id.clone(),
+                        "applying",
+                        "stale",
+                        Some(failure_clone),
+                        Some("stale".to_owned()),
+                    ))
                     .await;
 
                 counts.failed += 1;
@@ -462,17 +477,13 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
                 format!("item {} is protected by source policy", item.id),
             );
             callbacks
-                .on_item_progress(ItemProgressEvent {
-                    item_id: item.id.clone(),
-                    prior_state: "applying".to_owned(),
-                    new_state: "failed".to_owned(),
-                    at: Timestamp::now_iso(),
-                    failure: Some(failure),
-                    rollback_attempted: false,
-                    rollback_outcome: RollbackOutcome::NotApplicable,
-                    rollback_message: None,
-                    audit_reason: Some("protected".to_owned()),
-                })
+                .on_item_progress(ItemProgressEvent::terminal(
+                    item.id.clone(),
+                    "applying",
+                    "failed",
+                    Some(failure),
+                    Some("protected".to_owned()),
+                ))
                 .await;
             counts.failed += 1;
             continue;
@@ -506,17 +517,13 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
         match op_result {
             Ok(()) => {
                 callbacks
-                    .on_item_progress(ItemProgressEvent {
-                        item_id: item.id.clone(),
-                        prior_state: "applying".to_owned(),
-                        new_state: "succeeded".to_owned(),
-                        at: Timestamp::now_iso(),
-                        failure: None,
-                        rollback_attempted: false,
-                        rollback_outcome: RollbackOutcome::NotApplicable,
-                        rollback_message: None,
-                        audit_reason: None,
-                    })
+                    .on_item_progress(ItemProgressEvent::terminal(
+                        item.id.clone(),
+                        "applying",
+                        "succeeded",
+                        None,
+                        None,
+                    ))
                     .await;
                 counts.succeeded += 1;
             }

--- a/crates/fs/inventory/Cargo.toml
+++ b/crates/fs/inventory/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 camino = { workspace = true }
 domain_core = { path = "../../domain/core" }
+fs_pathsafe = { path = "../pathsafe" }
 notify = "7"
 serde = { workspace = true }
 serde_json.workspace = true

--- a/crates/fs/inventory/src/artifact_watcher.rs
+++ b/crates/fs/inventory/src/artifact_watcher.rs
@@ -21,9 +21,11 @@
 
 use std::sync::Arc;
 
-use camino::{Utf8Path, Utf8PathBuf};
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use camino::Utf8PathBuf;
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use tokio::sync::mpsc;
+
+use crate::notify_bridge::SimpleEventKind;
 
 /// A filesystem event forwarded to the async consumer.
 #[derive(Clone, Debug)]
@@ -42,6 +44,16 @@ pub enum ArtifactEventKind {
     Removed,
 }
 
+impl From<SimpleEventKind> for ArtifactEventKind {
+    fn from(kind: SimpleEventKind) -> Self {
+        match kind {
+            SimpleEventKind::Created => Self::Created,
+            SimpleEventKind::Modified => Self::Modified,
+            SimpleEventKind::Removed => Self::Removed,
+        }
+    }
+}
+
 /// RAII guard that keeps the watcher alive.
 ///
 /// Drop this to stop watching and close the channel.
@@ -52,6 +64,15 @@ pub struct WatcherGuard {
 
 /// Start the filesystem watcher over `paths`.
 ///
+/// `follow_symlinks` gates traversal (constitution "MUST NOT follow symlinks
+/// or junctions unless explicitly enabled per root", duplication-and-
+/// abstraction audit T1-a): when `false`, each path is walked ourselves via
+/// [`fs_pathsafe::real_dirs_under`] and every real (non-link) subdirectory is
+/// watched individually with `RecursiveMode::NonRecursive`, mirroring
+/// [`crate::watcher::WatcherService::start`]. When `true`, a single
+/// `RecursiveMode::Recursive` watch per path is used (the OS watcher may then
+/// follow links under it).
+///
 /// Returns an `mpsc::Receiver` and a `WatcherGuard`.  Drop the guard to stop.
 ///
 /// # Errors
@@ -61,6 +82,7 @@ pub struct WatcherGuard {
 pub fn start_artifact_watcher(
     paths: &[Utf8PathBuf],
     channel_capacity: usize,
+    follow_symlinks: bool,
 ) -> Result<(mpsc::Receiver<ArtifactFileEvent>, WatcherGuard), String> {
     let (tx, rx) = mpsc::channel::<ArtifactFileEvent>(channel_capacity);
     let tx = Arc::new(tx);
@@ -69,36 +91,38 @@ pub fn start_artifact_watcher(
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
         let Ok(event) = res else { return };
 
-        let kind = match event.kind {
-            EventKind::Create(_) => ArtifactEventKind::Created,
-            EventKind::Modify(_) => ArtifactEventKind::Modified,
-            EventKind::Remove(_) => ArtifactEventKind::Removed,
-            _ => return,
+        let Some(simple_kind) = crate::notify_bridge::classify(event.kind) else {
+            return;
         };
+        let kind = ArtifactEventKind::from(simple_kind);
 
-        for path in event.paths {
-            // `notify` yields `std::path::PathBuf`; convert losslessly. A
-            // non-UTF-8 path is skipped (not lossy-converted) so downstream
-            // detection never receives a corrupted path. Constitution §I.
-            let Some(utf8) = Utf8Path::from_path(&path) else {
-                eprintln!(
-                    "fs_inventory::artifact_watcher: skipping non-UTF-8 path: {}",
-                    path.to_string_lossy()
-                );
+        for path in &event.paths {
+            let Some(utf8) =
+                crate::notify_bridge::utf8_path_or_skip(path, "fs_inventory::artifact_watcher")
+            else {
                 continue;
             };
             if utf8.is_dir() {
                 continue;
             }
-            let _ = handler_tx.try_send(ArtifactFileEvent { path: utf8.to_owned(), kind });
+            let _ = handler_tx.try_send(ArtifactFileEvent { path: utf8, kind });
         }
     })
     .map_err(|e| format!("failed to create artifact watcher: {e}"))?;
 
     for path in paths {
-        watcher
-            .watch(path.as_std_path(), RecursiveMode::Recursive)
-            .map_err(|e| format!("failed to watch {path}: {e}"))?;
+        if follow_symlinks {
+            watcher
+                .watch(path.as_std_path(), RecursiveMode::Recursive)
+                .map_err(|e| format!("failed to watch {path}: {e}"))?;
+            continue;
+        }
+
+        for dir in fs_pathsafe::real_dirs_under(path.as_std_path(), false) {
+            watcher
+                .watch(&dir, RecursiveMode::NonRecursive)
+                .map_err(|e| format!("failed to watch {}: {e}", dir.display()))?;
+        }
     }
 
     let guard = WatcherGuard { _watcher: watcher, _tx: tx };
@@ -111,8 +135,11 @@ mod tests {
 
     #[test]
     fn start_on_nonexistent_path_returns_error() {
-        let result =
-            start_artifact_watcher(&[Utf8PathBuf::from("/nonexistent/path/for/watcher/test")], 16);
+        let result = start_artifact_watcher(
+            &[Utf8PathBuf::from("/nonexistent/path/for/watcher/test")],
+            16,
+            false,
+        );
         assert!(result.is_err(), "expected error for nonexistent path");
     }
 
@@ -120,7 +147,7 @@ mod tests {
     async fn start_on_temp_dir_succeeds_and_guard_drops_cleanly() {
         let dir = tempfile::tempdir().unwrap();
         let root = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
-        let (mut rx, guard) = start_artifact_watcher(&[root], 16).unwrap();
+        let (mut rx, guard) = start_artifact_watcher(&[root], 16, false).unwrap();
 
         drop(guard);
 
@@ -135,7 +162,8 @@ mod tests {
         // Canonicalize so emitted event paths match `file_path` (macOS reports
         // /private/var/... while tempdir() returns /var/...).
         let root = Utf8PathBuf::from_path_buf(dir.path().canonicalize().unwrap()).unwrap();
-        let (mut rx, _guard) = start_artifact_watcher(std::slice::from_ref(&root), 64).unwrap();
+        let (mut rx, _guard) =
+            start_artifact_watcher(std::slice::from_ref(&root), 64, false).unwrap();
 
         let file_path = root.join("test_artifact.xisf");
         std::fs::write(&file_path, b"data").unwrap();
@@ -150,5 +178,35 @@ mod tests {
             }
         };
         assert!(received, "expected ArtifactFileEvent for the created file");
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn symlinked_subtree_is_not_traversed_unless_enabled() {
+        use std::os::unix::fs::symlink;
+
+        let dir = tempfile::tempdir().unwrap();
+        let canonical_root = dir.path().canonicalize().unwrap();
+        let real_target = canonical_root.join("real_target");
+        std::fs::create_dir_all(&real_target).unwrap();
+
+        let scan_root = canonical_root.join("scan_root");
+        std::fs::create_dir_all(&scan_root).unwrap();
+        symlink(&real_target, scan_root.join("linked")).unwrap();
+        let scan_root_utf8 = Utf8PathBuf::from_path_buf(scan_root).unwrap();
+
+        let (mut rx, _guard) =
+            start_artifact_watcher(std::slice::from_ref(&scan_root_utf8), 64, false).unwrap();
+
+        // A file written behind the un-enabled symlink must never surface an
+        // event — the watcher was never attached to that subtree.
+        std::fs::write(real_target.join("hidden.fits"), b"data").unwrap();
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+        let received = tokio::time::timeout_at(deadline, rx.recv()).await;
+        assert!(
+            received.is_err(),
+            "must not observe an event for a file behind an un-enabled symlink"
+        );
     }
 }

--- a/crates/fs/inventory/src/capability.rs
+++ b/crates/fs/inventory/src/capability.rs
@@ -30,25 +30,10 @@ fn probe_symlink(dir: &Utf8Path) -> bool {
     let target = dir.join(".astro-plan-symlink-probe-target");
     let link = dir.join(".astro-plan-symlink-probe-link");
     let wrote = std::fs::write(&target, b"probe").is_ok();
-    let ok = wrote && create_symlink_file(&target, &link).is_ok();
+    let ok = wrote && fs_pathsafe::create_symlink(target.as_std_path(), link.as_std_path()).is_ok();
     let _ = std::fs::remove_file(&link);
     let _ = std::fs::remove_file(&target);
     ok
-}
-
-#[cfg(unix)]
-fn create_symlink_file(target: &Utf8Path, link: &Utf8Path) -> std::io::Result<()> {
-    std::os::unix::fs::symlink(target, link)
-}
-
-#[cfg(windows)]
-fn create_symlink_file(target: &Utf8Path, link: &Utf8Path) -> std::io::Result<()> {
-    std::os::windows::fs::symlink_file(target, link)
-}
-
-#[cfg(not(any(unix, windows)))]
-fn create_symlink_file(_target: &Utf8Path, _link: &Utf8Path) -> std::io::Result<()> {
-    Err(std::io::Error::other("symlink not supported on this platform"))
 }
 
 fn probe_hardlink(dir: &Utf8Path) -> bool {

--- a/crates/fs/inventory/src/lib.rs
+++ b/crates/fs/inventory/src/lib.rs
@@ -3,8 +3,8 @@
 pub mod artifact_watcher;
 pub mod capability;
 pub mod drive_scope;
+mod notify_bridge;
 pub mod reconcile;
-pub mod symlink_gate;
 pub mod watcher;
 
 pub const CRATE_NAME: &str = "fs_inventory";

--- a/crates/fs/inventory/src/notify_bridge.rs
+++ b/crates/fs/inventory/src/notify_bridge.rs
@@ -1,0 +1,81 @@
+//! Shared `notify`-event classification + UTF-8-safe path conversion, used by
+//! both [`crate::watcher`] and [`crate::artifact_watcher`] (duplication-and-
+//! abstraction audit Tier 3).
+
+use camino::{Utf8Path, Utf8PathBuf};
+use notify::EventKind;
+
+/// The three event kinds both watcher event enums distinguish. `notify`
+/// event kinds outside these three (Access, Other, ...) are not forwarded.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub(crate) enum SimpleEventKind {
+    Created,
+    Modified,
+    Removed,
+}
+
+/// Classify a raw `notify::EventKind` into the shared 3-way kind, or `None`
+/// for event kinds neither watcher forwards (e.g. `Access`).
+pub(crate) fn classify(kind: EventKind) -> Option<SimpleEventKind> {
+    match kind {
+        EventKind::Create(_) => Some(SimpleEventKind::Created),
+        EventKind::Modify(_) => Some(SimpleEventKind::Modified),
+        EventKind::Remove(_) => Some(SimpleEventKind::Removed),
+        _ => None,
+    }
+}
+
+/// Convert a `notify`-yielded `std::path::Path` to a faithful UTF-8 path, or
+/// `None` if it cannot be represented as one.
+///
+/// `notify` yields `std::path::PathBuf`, which can be non-UTF-8 on a raw
+/// disk. We never lossy-convert (that would corrupt a path that later
+/// crosses the IPC boundary as a wire string) — a non-UTF-8 path is skipped
+/// with a `diagnostic_source`-tagged stderr diagnostic instead. Constitution
+/// §I (Local-First custody): never silently mangle a user path.
+pub(crate) fn utf8_path_or_skip(
+    path: &std::path::Path,
+    diagnostic_source: &str,
+) -> Option<Utf8PathBuf> {
+    if let Some(utf8) = Utf8Path::from_path(path) {
+        Some(utf8.to_owned())
+    } else {
+        eprintln!(
+            "{diagnostic_source}: skipping non-UTF-8 path (cannot emit faithful UTF-8 event): {}",
+            path.to_string_lossy()
+        );
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn classify_maps_create_modify_remove() {
+        assert_eq!(
+            classify(EventKind::Create(notify::event::CreateKind::File)),
+            Some(SimpleEventKind::Created)
+        );
+        assert_eq!(
+            classify(EventKind::Modify(notify::event::ModifyKind::Any)),
+            Some(SimpleEventKind::Modified)
+        );
+        assert_eq!(
+            classify(EventKind::Remove(notify::event::RemoveKind::File)),
+            Some(SimpleEventKind::Removed)
+        );
+    }
+
+    #[test]
+    fn classify_ignores_other_kinds() {
+        assert_eq!(classify(EventKind::Access(notify::event::AccessKind::Any)), None);
+    }
+
+    #[test]
+    fn utf8_path_or_skip_converts_valid_utf8() {
+        let p = std::path::Path::new("/tmp/valid.fits");
+        assert_eq!(utf8_path_or_skip(p, "test"), Some(Utf8PathBuf::from("/tmp/valid.fits")));
+    }
+}

--- a/crates/fs/inventory/src/reconcile.rs
+++ b/crates/fs/inventory/src/reconcile.rs
@@ -12,12 +12,12 @@
 //! is the walk + diff primitive those triggers will call into.
 //!
 //! Symlink/junction gating (spec 048 T004/R6) is applied via
-//! [`crate::symlink_gate::real_files_under`] so a linked subtree is never
+//! [`fs_pathsafe::real_files_under`] so a linked subtree is never
 //! traversed unless the root has explicitly enabled it.
 
 use std::path::{Path, PathBuf};
 
-use crate::symlink_gate::real_files_under;
+use fs_pathsafe::real_files_under;
 
 /// One inventoried frame's identity + expected size, as recorded in
 /// `file_record` for the root being reconciled.
@@ -88,7 +88,7 @@ impl ReconcileReport {
 /// against disk.
 ///
 /// This function performs **read-only** filesystem access (`stat`/`readdir`
-/// via [`crate::symlink_gate::real_files_under`]) and never mutates a file.
+/// via [`fs_pathsafe::real_files_under`]) and never mutates a file.
 /// Symlinked/junction subtrees are never traversed unless
 /// `follow_symlinks` is `true` for this root (spec 048 R6/FR-017).
 ///

--- a/crates/fs/inventory/src/watcher.rs
+++ b/crates/fs/inventory/src/watcher.rs
@@ -9,10 +9,12 @@
 
 use std::sync::Arc;
 
-use camino::{Utf8Path, Utf8PathBuf};
-use notify::{Event, EventKind, RecommendedWatcher, RecursiveMode, Watcher};
+use camino::Utf8PathBuf;
+use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
+
+use crate::notify_bridge::SimpleEventKind;
 
 /// Events emitted by the watcher service.
 #[derive(Clone, Debug, Serialize, Deserialize)]
@@ -44,17 +46,14 @@ impl PathEventKind {
     }
 }
 
-/// Diagnostic sink for a non-UTF-8 watcher path that cannot be represented as a
-/// faithful UTF-8 wire string. We deliberately do **not** lossy-convert; the
-/// event is dropped. The lossy `to_string_lossy` rendering is used here only for
-/// the human-readable diagnostic, never for the emitted payload.
-fn tracing_skip_non_utf8(path: &std::path::Path) {
-    // `fs_inventory` has no `tracing` dependency; emit a stderr diagnostic so the
-    // skip is observable without corrupting the wire payload.
-    eprintln!(
-        "fs_inventory::watcher: skipping non-UTF-8 path (cannot emit faithful UTF-8 event): {}",
-        path.to_string_lossy()
-    );
+impl From<SimpleEventKind> for PathEventKind {
+    fn from(kind: SimpleEventKind) -> Self {
+        match kind {
+            SimpleEventKind::Created => Self::Added,
+            SimpleEventKind::Removed => Self::Removed,
+            SimpleEventKind::Modified => Self::Modified,
+        }
+    }
 }
 
 /// Manages a filesystem watcher scoped to inbox directories.
@@ -92,7 +91,7 @@ impl WatcherService {
     /// `follow_symlinks` gates traversal (spec 048 T004, constitution "MUST
     /// NOT follow symlinks or junctions unless explicitly enabled per
     /// root"): when `false` (the default for inbox folders), each path is
-    /// walked ourselves via [`crate::symlink_gate::real_dirs_under`] and every
+    /// walked ourselves via [`fs_pathsafe::real_dirs_under`] and every
     /// real (non-link) subdirectory is watched individually with
     /// `RecursiveMode::NonRecursive`, so a linked subtree is never traversed
     /// at the OS level. When `true`, the previous behaviour is preserved: a
@@ -114,36 +113,19 @@ impl WatcherService {
                 return;
             };
 
-            // `notify` yields `std::path::PathBuf`, which can be non-UTF-8 on a
-            // raw disk. We convert each path losslessly via `Utf8Path::from_path`.
-            // A non-UTF-8 path is *skipped* (not lossy-converted): we cannot emit
-            // a faithful UTF-8 wire string for it, so the event is dropped with a
-            // diagnostic rather than corrupting the path. Constitution §I: never
-            // silently mangle a user path.
-            let make = |kind: PathEventKind, paths: &[std::path::PathBuf]| {
-                paths
-                    .iter()
-                    .filter_map(|p| {
-                        if let Some(utf8) = Utf8Path::from_path(p) {
-                            Some(kind.into_event(utf8.as_str().to_owned()))
-                        } else {
-                            tracing_skip_non_utf8(p);
-                            None
-                        }
-                    })
-                    .collect::<Vec<InboxFileEvent>>()
+            let Some(simple_kind) = crate::notify_bridge::classify(event.kind) else {
+                return;
             };
+            let kind = PathEventKind::from(simple_kind);
 
-            let events: Vec<InboxFileEvent> = match event.kind {
-                EventKind::Create(_) => make(PathEventKind::Added, &event.paths),
-                EventKind::Remove(_) => make(PathEventKind::Removed, &event.paths),
-                EventKind::Modify(_) => make(PathEventKind::Modified, &event.paths),
-                _ => Vec::new(),
-            };
-
-            for evt in events {
+            for path in &event.paths {
+                let Some(utf8) =
+                    crate::notify_bridge::utf8_path_or_skip(path, "fs_inventory::watcher")
+                else {
+                    continue;
+                };
                 // Ignore send errors — they mean no subscribers are active.
-                let _ = tx.send(evt);
+                let _ = tx.send(kind.into_event(utf8.into_string()));
             }
         })
         .map_err(|e| format!("failed to create filesystem watcher: {e}"))?;
@@ -156,7 +138,7 @@ impl WatcherService {
                 continue;
             }
 
-            for dir in crate::symlink_gate::real_dirs_under(path.as_std_path(), false) {
+            for dir in fs_pathsafe::real_dirs_under(path.as_std_path(), false) {
                 watcher
                     .watch(&dir, RecursiveMode::NonRecursive)
                     .map_err(|e| format!("failed to watch {}: {e}", dir.display()))?;

--- a/crates/fs/pathsafe/Cargo.toml
+++ b/crates/fs/pathsafe/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "fs_pathsafe"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+
+[lib]
+path = "src/lib.rs"
+
+[dev-dependencies]
+tempfile.workspace = true
+
+[lints]
+workspace = true

--- a/crates/fs/pathsafe/src/lib.rs
+++ b/crates/fs/pathsafe/src/lib.rs
@@ -1,34 +1,60 @@
-//! Per-root symlink/junction gating (spec 048 T004).
+//! Reparse-aware link/junction detection + safe directory/file walking,
+//! shared by `fs_inventory` and `fs_executor` (duplication-and-abstraction
+//! audit T1-a).
 //!
 //! Constitution product constraint: "The product MUST avoid following
 //! symlinks or junctions during scans unless the user explicitly enables that
-//! behavior for a root". This module is the single place that decides whether
-//! a filesystem entry is a link that should be skipped, and provides a
-//! link-aware directory walker used both by live watches
-//! ([`crate::watcher::WatcherService::start`]) and by the raw-frame reconcile
-//! walker (spec 048 US2/T003+).
+//! behavior for a root". This crate is the single place that decides whether
+//! a filesystem entry is a link that should be skipped, and provides
+//! link-aware directory/file walkers plus a reparse-aware `create_symlink`
+//! dispatch.
 //!
-//! Detection is a plain `symlink_metadata().file_type().is_symlink()` check.
-//! On Windows this also covers NTFS junctions/mount points — modern Rust
-//! standard library reports directory junctions as symlinks via
-//! `is_symlink()` because both are surfaced as reparse points. Where that is
-//! not the case for an exotic reparse point kind, the walker still won't
-//! *recurse* into an unexpected reparse point because `read_dir` on it will
-//! either fail or return the junction's target contents, which is exactly
-//! the traversal we must avoid — callers should treat any doubt as "skip".
+//! Detection combines `symlink_metadata().file_type().is_symlink()` with an
+//! explicit Windows `FILE_ATTRIBUTE_REPARSE_POINT` check. Modern Rust
+//! reports NTFS junctions as symlinks via `is_symlink()` because both are
+//! surfaced as reparse points, but the explicit attribute check is defence
+//! in depth for reparse-point kinds `is_symlink()` might not classify as a
+//! symlink — callers should treat any doubt as "skip".
 
-use std::fs;
+use std::fs::{self, Metadata};
+use std::io;
 use std::path::{Path, PathBuf};
 
 /// Returns `true` when `path` is a symlink or (on Windows) a junction /
-/// reparse-point directory, as reported by `symlink_metadata`.
+/// reparse-point entry, as reported by `symlink_metadata`.
 ///
 /// Uses `symlink_metadata` (not `metadata`) so the check inspects the entry
 /// itself rather than following it — inspecting a link's target would defeat
-/// the purpose of the gate.
+/// the purpose of the gate. A path that cannot be stat'd (missing,
+/// permission denied, race) is reported as "not a link" — callers that need
+/// to distinguish a stat failure from "not a link" should stat the path
+/// themselves and call [`is_link_or_junction_metadata`] instead.
 #[must_use]
-pub fn is_link(path: &Path) -> bool {
-    fs::symlink_metadata(path).is_ok_and(|m| m.file_type().is_symlink())
+pub fn is_link_or_junction(path: &Path) -> bool {
+    fs::symlink_metadata(path).is_ok_and(|m| is_link_or_junction_metadata(&m))
+}
+
+/// Classify already-fetched [`Metadata`] (from `symlink_metadata`, never
+/// `metadata`) as a symlink or junction/reparse-point.
+///
+/// Split out from [`is_link_or_junction`] so callers that already hold a
+/// `symlink_metadata()` result (e.g. a per-component path walk that also
+/// needs to distinguish "not found" from "other stat error") can classify it
+/// without a second stat syscall.
+#[must_use]
+pub fn is_link_or_junction_metadata(meta: &Metadata) -> bool {
+    if meta.file_type().is_symlink() {
+        return true;
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::MetadataExt;
+        const FILE_ATTRIBUTE_REPARSE_POINT: u32 = 0x0400;
+        if meta.file_attributes() & FILE_ATTRIBUTE_REPARSE_POINT != 0 {
+            return true;
+        }
+    }
+    false
 }
 
 /// Recursively collect every real (non-link) directory under `root`,
@@ -49,7 +75,7 @@ pub fn real_dirs_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
     if follow_symlinks {
         return vec![root.to_path_buf()];
     }
-    if is_link(root) {
+    if is_link_or_junction(root) {
         return Vec::new();
     }
 
@@ -62,7 +88,7 @@ pub fn real_dirs_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if is_link(&path) {
+            if is_link_or_junction(&path) {
                 continue;
             }
             if path.is_dir() {
@@ -85,7 +111,7 @@ pub fn real_dirs_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
 pub fn real_files_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
     let mut files = Vec::new();
 
-    if !follow_symlinks && is_link(root) {
+    if !follow_symlinks && is_link_or_junction(root) {
         return files;
     }
 
@@ -96,7 +122,7 @@ pub fn real_files_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
         };
         for entry in entries.flatten() {
             let path = entry.path();
-            if !follow_symlinks && is_link(&path) {
+            if !follow_symlinks && is_link_or_junction(&path) {
                 continue;
             }
             if path.is_dir() {
@@ -110,6 +136,32 @@ pub fn real_files_under(root: &Path, follow_symlinks: bool) -> Vec<PathBuf> {
     files
 }
 
+/// Create a symlink from `source` to `destination`, pointing at a **file**
+/// (`std::os::windows::fs::symlink_file` on Windows — this crate does not
+/// yet materialize directory junctions; see `Materialization::Junction`
+/// callers).
+///
+/// # Errors
+///
+/// Returns the underlying `io::Error` from the platform symlink call, or an
+/// "unsupported platform" error on targets that are neither unix nor
+/// windows.
+pub fn create_symlink(source: &Path, destination: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        std::os::unix::fs::symlink(source, destination)
+    }
+    #[cfg(windows)]
+    {
+        std::os::windows::fs::symlink_file(source, destination)
+    }
+    #[cfg(not(any(unix, windows)))]
+    {
+        let _ = (source, destination);
+        Err(io::Error::other("symlink not supported on this platform"))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -117,7 +169,7 @@ mod tests {
     #[test]
     fn plain_directory_is_not_a_link() {
         let dir = tempfile::tempdir().unwrap();
-        assert!(!is_link(dir.path()));
+        assert!(!is_link_or_junction(dir.path()));
     }
 
     #[test]
@@ -147,6 +199,19 @@ mod tests {
         assert!(files.contains(&dir.path().join("top.fits")));
     }
 
+    #[test]
+    fn create_symlink_roundtrip() {
+        let dir = tempfile::tempdir().unwrap();
+        let target = dir.path().join("target.fits");
+        let link = dir.path().join("link.fits");
+        std::fs::write(&target, b"data").unwrap();
+
+        create_symlink(&target, &link).unwrap();
+
+        assert!(is_link_or_junction(&link));
+        assert_eq!(std::fs::read(&link).unwrap(), b"data");
+    }
+
     #[cfg(unix)]
     #[test]
     fn symlinked_directory_is_detected_and_skipped() {
@@ -162,7 +227,7 @@ mod tests {
         let link_path = scan_root.join("link_to_target");
         symlink(&real_target, &link_path).unwrap();
 
-        assert!(is_link(&link_path));
+        assert!(is_link_or_junction(&link_path));
 
         // The linked subdirectory must not be descended into.
         let dirs = real_dirs_under(&scan_root, false);
@@ -191,5 +256,44 @@ mod tests {
         // will itself follow links) — verify that contract explicitly.
         let dirs = real_dirs_under(&scan_root, true);
         assert_eq!(dirs, vec![scan_root.clone()]);
+    }
+
+    /// Windows-only: a directory junction (`mklink /J`) is a reparse point
+    /// that is NOT reported by `is_symlink()` on some toolchains — this is
+    /// exactly the gap the explicit `FILE_ATTRIBUTE_REPARSE_POINT` check in
+    /// [`is_link_or_junction_metadata`] closes. Creates the junction via the
+    /// `mklink` shell builtin (no admin privilege required for junctions,
+    /// unlike symlinks) rather than adding a dependency for one test.
+    #[cfg(windows)]
+    #[test]
+    fn junction_directory_is_detected_and_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let real_target = dir.path().join("real_target");
+        std::fs::create_dir_all(&real_target).unwrap();
+        std::fs::write(real_target.join("hidden.fits"), b"data").unwrap();
+
+        let scan_root = dir.path().join("scan_root");
+        std::fs::create_dir_all(&scan_root).unwrap();
+        let junction_path = scan_root.join("junction_to_target");
+
+        let status = std::process::Command::new("cmd")
+            .args([
+                "/C",
+                "mklink",
+                "/J",
+                junction_path.to_str().unwrap(),
+                real_target.to_str().unwrap(),
+            ])
+            .status()
+            .expect("mklink invocation failed");
+        assert!(status.success(), "mklink /J failed to create the test junction");
+
+        assert!(is_link_or_junction(&junction_path));
+
+        let dirs = real_dirs_under(&scan_root, false);
+        assert!(!dirs.contains(&junction_path));
+
+        let files = real_files_under(&scan_root, false);
+        assert!(files.is_empty(), "must not see files behind an un-enabled junction");
     }
 }


### PR DESCRIPTION
## Summary
- Closes a gap where the per-project artifact watcher and file-move/link operations could follow symlinks and Windows junctions instead of treating them as protected boundaries, preventing writes from escaping outside a project's intended folder.
- Extracts the reparse-point safety checks into a dedicated internal crate so scanning, the filesystem executor, and the watcher share one gating implementation.

## Spec Context
Run: run-dab, node: n1_pathsafe.