### PR TITLE
refactor: drive settings apply/default logic from a shared descriptor table

### DIFF
--- a/crates/app/settings/src/descriptors.rs
+++ b/crates/app/settings/src/descriptors.rs
@@ -1,7 +1,7 @@
 //! Single-source settings descriptor table (US11 T144).
 //!
 //! Before this module, the stable (non-structured-path) settings keys and their
-//! rules were spread across four parallel sites in `settings/mod.rs`:
+//! rules were spread across parallel sites in `lib.rs`:
 //!
 //! - `ALL_V1_KEYS` / `NOISY_KEYS` / `OVERRIDABLE_KEYS` constant lists,
 //! - the `validate_value` per-key `match`,
@@ -9,17 +9,16 @@
 //! - the `apply_value_to_state` per-key `match` (hydration into `SettingsState`).
 //!
 //! This table is the **single registry** of the stable key set together with
-//! each key's audit/override flags and validation rule. The constant lists are
-//! now derived from it, and `validate_value` dispatches on
-//! [`Descriptor::validation`] for stable keys. Behavior — including the exact
-//! `value.invalid` error strings — is byte-identical to the prior hand-written
-//! matches; this is pure consolidation.
-//!
-//! Default values and `SettingsState` field hydration remain in `mod.rs`
-//! because they bind to concrete struct fields rather than to data-expressible
-//! rules; the descriptor table is nonetheless the authoritative key registry
-//! they are checked against by the `descriptor_keys_match_state_defaults` test.
+//! each key's audit/override flags, validation rule, and `SettingsState`
+//! hydration/default accessors. The constant lists are derived from it,
+//! `validate_value` dispatches on [`Descriptor::validation`], and
+//! `apply_value_to_state`/`default_value_for_key` in `lib.rs` dispatch on
+//! [`Descriptor::apply`]/[`Descriptor::default`] for stable keys. Behavior —
+//! including the exact `value.invalid` error strings — is byte-identical to
+//! the prior hand-written matches; this is pure consolidation. Adding a
+//! settings key now means one table entry here, not edits at three sites.
 
+use contracts_core::settings::SettingsState;
 use contracts_core::ContractError;
 use serde_json::Value;
 
@@ -67,12 +66,19 @@ pub(crate) enum ValidationRule {
     CleanupTypeOverrides,
 }
 
-/// A stable settings key plus its audit/override flags and validation rule.
+/// A stable settings key plus its audit/override flags, validation rule, and
+/// `SettingsState` hydration/default accessors.
 pub(crate) struct Descriptor {
     pub key: &'static str,
     pub noisy: bool,
     pub overridable: bool,
     pub validation: ValidationRule,
+    /// Hydrate an already-validated JSON value into this key's `SettingsState` field.
+    /// No-ops on shape mismatch, matching the historical `if let Some/Ok(v) = ...`
+    /// per-key arms (repair/validation already reject bad shapes before this runs).
+    pub apply: fn(Value, &mut SettingsState),
+    /// This key's in-code default, read off a fresh `SettingsState::default()`.
+    pub default: fn(SettingsState) -> Value,
 }
 
 /// The authoritative table of every stable (non-structured-path) v1 settings key.
@@ -85,24 +91,48 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         noisy: true,
         overridable: false,
         validation: ValidationRule::Array,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.pattern = v;
+            }
+        },
+        default: |s| serde_json::to_value(s.pattern).unwrap_or(Value::Null),
     },
     Descriptor {
         key: "autoApplyPattern",
         noisy: false,
         overridable: false,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.auto_apply_pattern = b;
+            }
+        },
+        default: |s| Value::Bool(s.auto_apply_pattern),
     },
     Descriptor {
         key: "alwaysPreviewBeforePlan",
         noisy: false,
         overridable: false,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.always_preview_before_plan = b;
+            }
+        },
+        default: |s| Value::Bool(s.always_preview_before_plan),
     },
     Descriptor {
         key: "followSymlinks",
         noisy: false,
         overridable: true,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.follow_symlinks = b;
+            }
+        },
+        default: |s| Value::Bool(s.follow_symlinks),
     },
     Descriptor {
         key: "hashOnScan",
@@ -112,6 +142,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["lazy", "eager", "off"],
             expected_msg: "must be \"lazy\", \"eager\", or \"off\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.hash_on_scan);
+            }
+        },
+        default: |s| Value::String(s.hash_on_scan),
     },
     Descriptor {
         key: "darkMatchTolerance",
@@ -121,6 +157,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["strict", "loose", "any"],
             expected_msg: "must be \"strict\", \"loose\", or \"any\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.dark_match_tolerance);
+            }
+        },
+        default: |s| Value::String(s.dark_match_tolerance),
     },
     Descriptor {
         key: "flatMatching",
@@ -130,12 +172,24 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["filter-rot", "filter", "manual"],
             expected_msg: "must be \"filter-rot\", \"filter\", or \"manual\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.flat_matching);
+            }
+        },
+        default: |s| Value::String(s.flat_matching),
     },
     Descriptor {
         key: "suggestCalibration",
         noisy: false,
         overridable: false,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.suggest_calibration = b;
+            }
+        },
+        default: |s| Value::Bool(s.suggest_calibration),
     },
     Descriptor {
         key: "logLevel",
@@ -145,12 +199,24 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["error", "warn", "info", "debug"],
             expected_msg: "must be \"error\", \"warn\", \"info\", or \"debug\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.log_level);
+            }
+        },
+        default: |s| Value::String(s.log_level),
     },
     Descriptor {
         key: "rememberFollowLogs",
         noisy: true,
         overridable: false,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.remember_follow_logs = b;
+            }
+        },
+        default: |s| Value::Bool(s.remember_follow_logs),
     },
     Descriptor {
         key: "defaultProtection",
@@ -160,48 +226,94 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["protected", "normal", "unprotected"],
             expected_msg: "must be \"protected\", \"normal\", or \"unprotected\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.default_protection);
+            }
+        },
+        default: |s| Value::String(s.default_protection),
     },
     Descriptor {
         key: "blockPermanentDelete",
         noisy: false,
         overridable: false,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.block_permanent_delete = b;
+            }
+        },
+        default: |s| Value::Bool(s.block_permanent_delete),
     },
     Descriptor {
         key: "protectedCategories",
         noisy: true,
         overridable: false,
         validation: ValidationRule::Array,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.protected_categories = v;
+            }
+        },
+        default: |s| serde_json::to_value(s.protected_categories).unwrap_or(Value::Null),
     },
     Descriptor {
         key: "currentLibraryId",
         noisy: false,
         overridable: false,
         validation: ValidationRule::NullableString,
+        apply: |v, s| {
+            s.current_library_id = v.as_str().map(str::to_owned);
+        },
+        default: |s| s.current_library_id.map_or(Value::Null, Value::String),
     },
     Descriptor {
         key: "devMode",
         noisy: false,
         overridable: false,
         validation: ValidationRule::DevMode,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.dev_mode = b;
+            }
+        },
+        default: |s| Value::Bool(s.dev_mode),
     },
     Descriptor {
         key: "plansListDefaultAgeCutoffDays",
         noisy: true,
         overridable: false,
         validation: ValidationRule::Number,
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.plans_list_default_age_cutoff_days = n;
+            }
+        },
+        default: |s| serde_json::json!(s.plans_list_default_age_cutoff_days),
     },
     Descriptor {
         key: "calibrationDarkTempTolerance",
         noisy: false,
         overridable: false,
         validation: ValidationRule::NumberMinZero,
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.calibration_dark_temp_tolerance = n;
+            }
+        },
+        default: |s| serde_json::json!(s.calibration_dark_temp_tolerance),
     },
     Descriptor {
         key: "calibrationPrefillSuggestion",
         noisy: false,
         overridable: false,
         validation: ValidationRule::Bool,
+        apply: |v, s| {
+            if let Some(b) = v.as_bool() {
+                s.calibration_prefill_suggestion = b;
+            }
+        },
+        default: |s| Value::Bool(s.calibration_prefill_suggestion),
     },
     Descriptor {
         key: "calibrationDarkOverridePenalty",
@@ -213,6 +325,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             msg: "must be a number [0,1]",
             want_msg: "must be in [0, 1]",
         },
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.calibration_dark_override_penalty = n;
+            }
+        },
+        default: |s| serde_json::json!(s.calibration_dark_override_penalty),
     },
     Descriptor {
         key: "calibrationFlatOverridePenalty",
@@ -224,6 +342,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             msg: "must be a number [0,1]",
             want_msg: "must be in [0, 1]",
         },
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.calibration_flat_override_penalty = n;
+            }
+        },
+        default: |s| serde_json::json!(s.calibration_flat_override_penalty),
     },
     Descriptor {
         key: "calibrationBiasOverridePenalty",
@@ -235,6 +359,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             msg: "must be a number [0,1]",
             want_msg: "must be in [0, 1]",
         },
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.calibration_bias_override_penalty = n;
+            }
+        },
+        default: |s| serde_json::json!(s.calibration_bias_override_penalty),
     },
     Descriptor {
         key: "calibrationAgingThresholdDays",
@@ -246,18 +376,41 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             msg: "must be a number",
             want_msg: "must be in [1, 3650]",
         },
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.calibration_aging_threshold_days = n;
+            }
+        },
+        default: |s| serde_json::json!(s.calibration_aging_threshold_days),
     },
     Descriptor {
         key: "imagetypNormalizationUserMappings",
         noisy: false,
         overridable: false,
         validation: ValidationRule::Array,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.imagetyp_normalization_user_mappings = v;
+            }
+        },
+        default: |s| {
+            serde_json::to_value(s.imagetyp_normalization_user_mappings).unwrap_or(Value::Null)
+        },
     },
     Descriptor {
         key: "patternsByType",
         noisy: false,
         overridable: false,
         validation: ValidationRule::PatternsByType,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.patterns_by_type = v;
+            }
+        },
+        // Read-side falls back to per-frame-type built-in defaults, so the
+        // stored default is an empty object (no explicit overrides) — which is
+        // exactly what `SettingsState::default().patterns_by_type` serializes to.
+        default: |s| serde_json::to_value(s.patterns_by_type).unwrap_or(Value::Null),
     },
     // ── Tool watch / attribution (spec 018 T043) ─────────────────────────
     Descriptor {
@@ -265,12 +418,24 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         noisy: false,
         overridable: false,
         validation: ValidationRule::Array,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.tool_watch_extensions = v;
+            }
+        },
+        default: |s| serde_json::to_value(s.tool_watch_extensions).unwrap_or(Value::Null),
     },
     Descriptor {
         key: "toolAttributionWindowHours",
         noisy: false,
         overridable: false,
         validation: ValidationRule::NumberMinZero,
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.tool_attribution_window_hours = n;
+            }
+        },
+        default: |s| serde_json::json!(s.tool_attribution_window_hours),
     },
     // ── Observing sites (spec 044 Track B) ───────────────────────────────
     Descriptor {
@@ -278,18 +443,33 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         noisy: false,
         overridable: false,
         validation: ValidationRule::ObserverSites,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.observing_sites = v;
+            }
+        },
+        default: |s| serde_json::to_value(s.observing_sites).unwrap_or(Value::Null),
     },
     Descriptor {
         key: "observingDefaultSiteId",
         noisy: false,
         overridable: false,
         validation: ValidationRule::NullableString,
+        apply: |v, s| {
+            s.observing_default_site_id = v.as_str().map(str::to_owned);
+        },
+        // Nullable-by-design (no default site until the user/wizard creates one).
+        default: |s| s.observing_default_site_id.map_or(Value::Null, Value::String),
     },
     Descriptor {
         key: "observingActiveSiteId",
         noisy: false,
         overridable: false,
         validation: ValidationRule::NullableString,
+        apply: |v, s| {
+            s.observing_active_site_id = v.as_str().map(str::to_owned);
+        },
+        default: |s| s.observing_active_site_id.map_or(Value::Null, Value::String),
     },
     Descriptor {
         key: "usableAltitudeDeg",
@@ -301,6 +481,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             msg: "must be a number",
             want_msg: "must be in [0, 90]",
         },
+        apply: |v, s| {
+            if let Some(n) = v.as_f64() {
+                s.usable_altitude_deg = n;
+            }
+        },
+        default: |s| serde_json::json!(s.usable_altitude_deg),
     },
     // ── Target planner (spec 047 FR-010) ─────────────────────────────────
     Descriptor {
@@ -308,6 +494,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         noisy: false,
         overridable: false,
         validation: ValidationRule::MoonAvoidanceBands,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.planner_moon_avoidance = v;
+            }
+        },
+        default: |s| serde_json::to_value(s.planner_moon_avoidance).unwrap_or(Value::Null),
     },
     // ── Source Views (spec 049) ──────────────────────────────────────────
     Descriptor {
@@ -318,6 +510,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["hardlink", "symlink", "junction"],
             expected_msg: "must be \"hardlink\", \"symlink\", or \"junction\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.source_view_link_kind_intra_drive);
+            }
+        },
+        default: |s| Value::String(s.source_view_link_kind_intra_drive),
     },
     Descriptor {
         key: "sourceViewLinkKindCrossDrive",
@@ -327,6 +525,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
             allowed: &["symlink", "junction"],
             expected_msg: "must be \"symlink\" or \"junction\"",
         },
+        apply: |v, s| {
+            if let Some(x) = v.as_str() {
+                x.clone_into(&mut s.source_view_link_kind_cross_drive);
+            }
+        },
+        default: |s| Value::String(s.source_view_link_kind_cross_drive),
     },
     // ── Cleanup overrides (spec 051 US3) ─────────────────────────────────
     // Not overridable (no per-source override) and not noisy (every real
@@ -338,6 +542,12 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         noisy: false,
         overridable: false,
         validation: ValidationRule::CleanupTypeOverrides,
+        apply: |v, s| {
+            if let Ok(v) = serde_json::from_value(v) {
+                s.cleanup_type_overrides = v;
+            }
+        },
+        default: |s| serde_json::to_value(s.cleanup_type_overrides).unwrap_or(Value::Null),
     },
 ];
 

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -64,8 +64,10 @@ pub fn is_global_protection_default_key(key: &str) -> bool {
 // ── Settings descriptor table (US11 T144) ────────────────────────────────
 //
 // The stable key registry + per-key rules now live in one place:
-// `descriptors::DESCRIPTORS`. The key set, noisy/overridable membership, and
-// value validation are all derived from that single table.
+// `descriptors::DESCRIPTORS`. The key set, noisy/overridable membership,
+// value validation, `SettingsState` hydration (`apply_value_to_state`), and
+// in-code defaults (`default_value_for_key`) are all derived from that single
+// table.
 mod descriptors;
 
 // ── Ingestion settings (spec 030, package P12) ────────────────────────────
@@ -329,260 +331,36 @@ pub async fn get_settings(
 ///
 /// Unknown keys (structured-path keys like tools.*) are stored in the DB but
 /// not mapped to static SettingsState fields.
-#[allow(clippy::too_many_lines, clippy::assigning_clones)]
 fn apply_value_to_state(key: &str, value: Value, state: &mut SettingsState) {
-    match key {
-        "pattern" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.pattern = v;
-            }
-        }
-        "autoApplyPattern" => {
-            if let Some(v) = value.as_bool() {
-                state.auto_apply_pattern = v;
-            }
-        }
-        "alwaysPreviewBeforePlan" => {
-            if let Some(v) = value.as_bool() {
-                state.always_preview_before_plan = v;
-            }
-        }
-        "followSymlinks" => {
-            if let Some(v) = value.as_bool() {
-                state.follow_symlinks = v;
-            }
-        }
-        "hashOnScan" => {
-            if let Some(v) = value.as_str() {
-                state.hash_on_scan = v.to_owned();
-            }
-        }
-        "darkMatchTolerance" => {
-            if let Some(v) = value.as_str() {
-                state.dark_match_tolerance = v.to_owned();
-            }
-        }
-        "flatMatching" => {
-            if let Some(v) = value.as_str() {
-                state.flat_matching = v.to_owned();
-            }
-        }
-        "suggestCalibration" => {
-            if let Some(v) = value.as_bool() {
-                state.suggest_calibration = v;
-            }
-        }
-        "logLevel" => {
-            if let Some(v) = value.as_str() {
-                state.log_level = v.to_owned();
-            }
-        }
-        "rememberFollowLogs" => {
-            if let Some(v) = value.as_bool() {
-                state.remember_follow_logs = v;
-            }
-        }
-        "defaultProtection" => {
-            if let Some(v) = value.as_str() {
-                state.default_protection = v.to_owned();
-            }
-        }
-        "blockPermanentDelete" => {
-            if let Some(v) = value.as_bool() {
-                state.block_permanent_delete = v;
-            }
-        }
-        "protectedCategories" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.protected_categories = v;
-            }
-        }
-        "currentLibraryId" => {
-            state.current_library_id = value.as_str().map(str::to_owned);
-        }
-        "devMode" => {
-            if let Some(v) = value.as_bool() {
-                state.dev_mode = v;
-            }
-        }
-        "plansListDefaultAgeCutoffDays" => {
-            if let Some(v) = value.as_f64() {
-                state.plans_list_default_age_cutoff_days = v;
-            }
-        }
-        "calibrationDarkTempTolerance" => {
-            if let Some(v) = value.as_f64() {
-                state.calibration_dark_temp_tolerance = v;
-            }
-        }
-        "calibrationPrefillSuggestion" => {
-            if let Some(v) = value.as_bool() {
-                state.calibration_prefill_suggestion = v;
-            }
-        }
-        "calibrationDarkOverridePenalty" => {
-            if let Some(v) = value.as_f64() {
-                state.calibration_dark_override_penalty = v;
-            }
-        }
-        "calibrationFlatOverridePenalty" => {
-            if let Some(v) = value.as_f64() {
-                state.calibration_flat_override_penalty = v;
-            }
-        }
-        "calibrationBiasOverridePenalty" => {
-            if let Some(v) = value.as_f64() {
-                state.calibration_bias_override_penalty = v;
-            }
-        }
-        "calibrationAgingThresholdDays" => {
-            if let Some(v) = value.as_f64() {
-                state.calibration_aging_threshold_days = v;
-            }
-        }
-        "imagetypNormalizationUserMappings" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.imagetyp_normalization_user_mappings = v;
-            }
-        }
-        "patternsByType" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.patterns_by_type = v;
-            }
-        }
-        "toolWatchExtensions" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.tool_watch_extensions = v;
-            }
-        }
-        "toolAttributionWindowHours" => {
-            if let Some(v) = value.as_f64() {
-                state.tool_attribution_window_hours = v;
-            }
-        }
-        "observingSites" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.observing_sites = v;
-            }
-        }
-        "observingDefaultSiteId" => {
-            state.observing_default_site_id = value.as_str().map(str::to_owned);
-        }
-        "observingActiveSiteId" => {
-            state.observing_active_site_id = value.as_str().map(str::to_owned);
-        }
-        "usableAltitudeDeg" => {
-            if let Some(v) = value.as_f64() {
-                state.usable_altitude_deg = v;
-            }
-        }
-        "plannerMoonAvoidance" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.planner_moon_avoidance = v;
-            }
-        }
-        "sourceViewLinkKindIntraDrive" => {
-            if let Some(v) = value.as_str() {
-                state.source_view_link_kind_intra_drive = v.to_owned();
-            }
-        }
-        "sourceViewLinkKindCrossDrive" => {
-            if let Some(v) = value.as_str() {
-                state.source_view_link_kind_cross_drive = v.to_owned();
-            }
-        }
-        "cleanupTypeOverrides" => {
-            if let Ok(v) = serde_json::from_value(value) {
-                state.cleanup_type_overrides = v;
-            }
-        }
-        _ => {
-            // Structured-path keys are not mapped to static SettingsState fields.
-            // Use resolve_setting(key, source_id) to read them individually.
-        }
+    if let Some(descriptor) = descriptors::descriptor_for(key) {
+        (descriptor.apply)(value, state);
     }
+    // Else: structured-path keys are not mapped to static SettingsState
+    // fields. Use resolve_setting(key, source_id) to read them individually.
 }
 
 /// Return the in-code default value for a given key as `serde_json::Value`.
 fn default_value_for_key(key: &str) -> Value {
-    let defaults = SettingsState::default();
-    match key {
-        "pattern" => serde_json::to_value(&defaults.pattern).unwrap_or(Value::Null),
-        "autoApplyPattern" => Value::Bool(defaults.auto_apply_pattern),
-        "alwaysPreviewBeforePlan" => Value::Bool(defaults.always_preview_before_plan),
-        "followSymlinks" => Value::Bool(defaults.follow_symlinks),
-        "hashOnScan" => Value::String(defaults.hash_on_scan),
-        "darkMatchTolerance" => Value::String(defaults.dark_match_tolerance),
-        "flatMatching" => Value::String(defaults.flat_matching),
-        "suggestCalibration" => Value::Bool(defaults.suggest_calibration),
-        "logLevel" => Value::String(defaults.log_level),
-        "rememberFollowLogs" => Value::Bool(defaults.remember_follow_logs),
-        "defaultProtection" => Value::String(defaults.default_protection),
-        "blockPermanentDelete" => Value::Bool(defaults.block_permanent_delete),
-        "protectedCategories" => {
-            serde_json::to_value(&defaults.protected_categories).unwrap_or(Value::Null)
-        }
-        "devMode" => Value::Bool(defaults.dev_mode),
-        "plansListDefaultAgeCutoffDays" => {
-            serde_json::json!(defaults.plans_list_default_age_cutoff_days)
-        }
-        "calibrationDarkTempTolerance" => {
-            serde_json::json!(defaults.calibration_dark_temp_tolerance)
-        }
-        "calibrationPrefillSuggestion" => Value::Bool(defaults.calibration_prefill_suggestion),
-        "calibrationDarkOverridePenalty" => {
-            serde_json::json!(defaults.calibration_dark_override_penalty)
-        }
-        "calibrationFlatOverridePenalty" => {
-            serde_json::json!(defaults.calibration_flat_override_penalty)
-        }
-        "calibrationBiasOverridePenalty" => {
-            serde_json::json!(defaults.calibration_bias_override_penalty)
-        }
-        "calibrationAgingThresholdDays" => {
-            serde_json::json!(defaults.calibration_aging_threshold_days)
-        }
-        "imagetypNormalizationUserMappings" => {
-            serde_json::to_value(&defaults.imagetyp_normalization_user_mappings)
-                .unwrap_or(Value::Null)
-        }
-        // Read-side falls back to per-type/per-frame-type built-in defaults, so
-        // the stored default for both is an empty object (no explicit overrides).
-        "patternsByType" | "cleanupTypeOverrides" => Value::Object(serde_json::Map::new()),
-        "toolWatchExtensions" => {
-            serde_json::to_value(&defaults.tool_watch_extensions).unwrap_or(Value::Null)
-        }
-        "toolAttributionWindowHours" => {
-            serde_json::json!(defaults.tool_attribution_window_hours)
-        }
-        "observingSites" => serde_json::to_value(&defaults.observing_sites).unwrap_or(Value::Null),
-        // Nullable-by-design (no default site until the user/wizard creates one).
-        "observingDefaultSiteId" | "observingActiveSiteId" => Value::Null,
-        "usableAltitudeDeg" => serde_json::json!(defaults.usable_altitude_deg),
-        "plannerMoonAvoidance" => {
-            serde_json::to_value(&defaults.planner_moon_avoidance).unwrap_or(Value::Null)
-        }
-        "sourceViewLinkKindIntraDrive" => Value::String(defaults.source_view_link_kind_intra_drive),
-        "sourceViewLinkKindCrossDrive" => Value::String(defaults.source_view_link_kind_cross_drive),
-        // Structured-path: tools.<id>.bundle_id resolves the seed default
-        // when no user override is stored (spec 018 T042).
-        _ if is_tools_bundle_id_key(key) => {
-            if let Some(tool_id) =
-                key.strip_prefix("tools.").and_then(|r| r.strip_suffix(".bundle_id"))
-            {
-                if let Some(profile) = workflow_profiles::seed::find(tool_id) {
-                    return match profile.bundle_id {
-                        // Known bundle ID from seed (may be wrong on non-macOS; callers
-                        // should prefer the per-OS auto-detected value when available).
-                        Some(id) => Value::String(id.to_owned()),
-                        None => Value::Null,
-                    };
-                }
-            }
-            Value::Null
-        }
-        _ => Value::Null,
+    if let Some(descriptor) = descriptors::descriptor_for(key) {
+        return (descriptor.default)(SettingsState::default());
     }
+    // Structured-path: tools.<id>.bundle_id resolves the seed default
+    // when no user override is stored (spec 018 T042).
+    if is_tools_bundle_id_key(key) {
+        if let Some(tool_id) = key.strip_prefix("tools.").and_then(|r| r.strip_suffix(".bundle_id"))
+        {
+            if let Some(profile) = workflow_profiles::seed::find(tool_id) {
+                return match profile.bundle_id {
+                    // Known bundle ID from seed (may be wrong on non-macOS; callers
+                    // should prefer the per-OS auto-detected value when available).
+                    Some(id) => Value::String(id.to_owned()),
+                    None => Value::Null,
+                };
+            }
+        }
+        return Value::Null;
+    }
+    Value::Null
 }
 
 // ── update_setting ────────────────────────────────────────────────────────
@@ -981,6 +759,31 @@ mod tests {
             } else {
                 assert!(!default.is_null(), "descriptor key {key} has no in-code default");
             }
+        }
+    }
+
+    /// n5_settingstable guard: every descriptor's `apply` and `default`
+    /// accessors agree — applying a key's in-code default onto a fresh
+    /// `SettingsState` and re-serialising it must reproduce that same default
+    /// value at the key's wire name. Catches a mismatched/misspelled field in
+    /// either accessor (they're independently hand-written closures).
+    #[test]
+    fn descriptor_apply_and_default_round_trip() {
+        for key in descriptors::all_keys() {
+            let default_value = default_value_for_key(key);
+            let mut state = SettingsState::default();
+            apply_value_to_state(key, default_value.clone(), &mut state);
+
+            let serialized = serde_json::to_value(&state).expect("state serializes");
+            let obj = serialized.as_object().expect("state is a JSON object");
+            // Missing key means skip_serializing_if hid a None field (e.g.
+            // currentLibraryId) — that's equivalent to an explicit null.
+            let round_tripped = obj.get(key).cloned().unwrap_or(Value::Null);
+
+            assert_eq!(
+                round_tripped, default_value,
+                "{key}: apply(default_value_for_key) must round-trip through SettingsState"
+            );
         }
     }
 


### PR DESCRIPTION
## Summary
- Replaces the settings module's hand-written per-key apply/default-value branches with table-driven lookups against the existing Descriptor definitions, removing duplicated logic without changing behavior.

## Spec Context
Run: run-dab, node: n5_settingstable.