### PR TITLE
chore(persistence): standardize JSON-column codec on sqlx::types::Json and dedup equipment CRUD

### DIFF
--- a/crates/persistence/db/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/db/src/repositories/calibration_assignment.rs
@@ -8,6 +8,7 @@
 //! other repositories in this crate that do not require a sqlx offline cache.
 
 use domain_core::ids::Timestamp;
+use sqlx::types::Json;
 use sqlx::SqlitePool;
 
 use crate::{DbError, DbResult};
@@ -74,11 +75,9 @@ fn row_to_struct(
 /// Replaces any existing row for the same `(session_id, calibration_type)` pair.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
-/// Returns [`DbError::Serialise`] if `mismatched_dimensions` cannot be serialised.
+/// Returns [`DbError::Database`] on query failure (including JSON encoding
+/// of `mismatched_dimensions`, encoded via `sqlx::types::Json`).
 pub async fn upsert(pool: &SqlitePool, params: UpsertParams<'_>) -> DbResult<()> {
-    let mismatch_json =
-        serde_json::to_string(params.mismatched_dimensions).map_err(DbError::Serialise)?;
     let at = params.assigned_at.map_or_else(Timestamp::now_iso, str::to_owned);
     let override_int = i64::from(params.was_override);
 
@@ -102,7 +101,7 @@ pub async fn upsert(pool: &SqlitePool, params: UpsertParams<'_>) -> DbResult<()>
     .bind(params.master_id)
     .bind(params.confidence)
     .bind(override_int)
-    .bind(&mismatch_json)
+    .bind(Json(params.mismatched_dimensions))
     .bind(&at)
     .execute(pool)
     .await
@@ -232,6 +231,8 @@ mod tests {
         assert_eq!(row.id, "assign-002");
         assert_eq!(row.master_id, "master-002");
         assert!(row.was_override);
+        // Round-trips through the `sqlx::types::Json` write-side codec.
+        assert_eq!(parse_mismatched_dimensions(&row.mismatched_dimensions), override_dims);
     }
 
     #[tokio::test]
@@ -269,6 +270,14 @@ mod tests {
     #[tokio::test]
     async fn parse_mismatched_dimensions_empty() {
         let dims = parse_mismatched_dimensions("[]");
+        assert!(dims.is_empty());
+    }
+
+    /// Graceful-degradation site (spec `n4_jsoncodec`): a corrupt
+    /// `mismatched_dimensions` cell must degrade to empty, not panic/propagate.
+    #[tokio::test]
+    async fn parse_mismatched_dimensions_corrupt_degrades_to_empty() {
+        let dims = parse_mismatched_dimensions("not valid json");
         assert!(dims.is_empty());
     }
 }

--- a/crates/persistence/db/src/repositories/equipment.rs
+++ b/crates/persistence/db/src/repositories/equipment.rs
@@ -46,6 +46,16 @@ fn encode_aliases(aliases: &[String]) -> String {
     serde_json::to_string(aliases).unwrap_or_else(|_| "[]".to_owned())
 }
 
+/// Shared NotFound-check for every `update_*`/`delete_*` below: all four
+/// entity kinds (Camera/Telescope/OpticalTrain/Filter) key their mutation on
+/// `id` and treat "no row touched" as `DbError::NotFound`.
+fn ensure_row_affected(rows_affected: u64, entity: &str, id: &str) -> DbResult<()> {
+    if rows_affected == 0 {
+        return Err(DbError::NotFound(format!("{entity} {id} not found")));
+    }
+    Ok(())
+}
+
 // ── Camera ──────────────────────────────────────────────────────────────────
 
 /// List all cameras.
@@ -108,9 +118,7 @@ pub async fn update_camera(pool: &SqlitePool, req: &UpdateCamera) -> DbResult<Ca
         .execute(pool)
         .await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("camera {} not found", req.id)));
-    }
+    ensure_row_affected(result.rows_affected(), "camera", &req.id)?;
 
     // Fetch the full row to return auto_detected.
     let row: (i32,) = sqlx::query_as("SELECT auto_detected FROM cameras WHERE id = ?")
@@ -134,11 +142,7 @@ pub async fn update_camera(pool: &SqlitePool, req: &UpdateCamera) -> DbResult<Ca
 pub async fn delete_camera(pool: &SqlitePool, id: &str) -> DbResult<()> {
     let result = sqlx::query("DELETE FROM cameras WHERE id = ?").bind(id).execute(pool).await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("camera {id} not found")));
-    }
-
-    Ok(())
+    ensure_row_affected(result.rows_affected(), "camera", id)
 }
 
 /// Find a camera by alias. Searches the JSON aliases array using LIKE.
@@ -242,9 +246,7 @@ pub async fn update_telescope(pool: &SqlitePool, req: &UpdateTelescope) -> DbRes
     .execute(pool)
     .await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("telescope {} not found", req.id)));
-    }
+    ensure_row_affected(result.rows_affected(), "telescope", &req.id)?;
 
     let row: (i32,) = sqlx::query_as("SELECT auto_detected FROM telescopes WHERE id = ?")
         .bind(&req.id)
@@ -268,11 +270,7 @@ pub async fn update_telescope(pool: &SqlitePool, req: &UpdateTelescope) -> DbRes
 pub async fn delete_telescope(pool: &SqlitePool, id: &str) -> DbResult<()> {
     let result = sqlx::query("DELETE FROM telescopes WHERE id = ?").bind(id).execute(pool).await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("telescope {id} not found")));
-    }
-
-    Ok(())
+    ensure_row_affected(result.rows_affected(), "telescope", id)
 }
 
 /// Find a telescope by alias. Searches the JSON aliases array.
@@ -385,9 +383,7 @@ pub async fn update_optical_train(
     .execute(pool)
     .await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("optical train {} not found", req.id)));
-    }
+    ensure_row_affected(result.rows_affected(), "optical train", &req.id)?;
 
     Ok(OpticalTrain {
         id: req.id.clone(),
@@ -407,11 +403,7 @@ pub async fn delete_optical_train(pool: &SqlitePool, id: &str) -> DbResult<()> {
     let result =
         sqlx::query("DELETE FROM optical_trains WHERE id = ?").bind(id).execute(pool).await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("optical train {id} not found")));
-    }
-
-    Ok(())
+    ensure_row_affected(result.rows_affected(), "optical train", id)
 }
 
 // ── Filter ──────────────────────────────────────────────────────────────────
@@ -476,9 +468,7 @@ pub async fn update_filter(pool: &SqlitePool, req: &UpdateFilter) -> DbResult<Fi
         .execute(pool)
         .await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("filter {} not found", req.id)));
-    }
+    ensure_row_affected(result.rows_affected(), "filter", &req.id)?;
 
     let row: (i32,) = sqlx::query_as("SELECT auto_detected FROM filters WHERE id = ?")
         .bind(&req.id)
@@ -501,11 +491,7 @@ pub async fn update_filter(pool: &SqlitePool, req: &UpdateFilter) -> DbResult<Fi
 pub async fn delete_filter(pool: &SqlitePool, id: &str) -> DbResult<()> {
     let result = sqlx::query("DELETE FROM filters WHERE id = ?").bind(id).execute(pool).await?;
 
-    if result.rows_affected() == 0 {
-        return Err(DbError::NotFound(format!("filter {id} not found")));
-    }
-
-    Ok(())
+    ensure_row_affected(result.rows_affected(), "filter", id)
 }
 
 // ── Tests ───────────────────────────────────────────────────────────────────
@@ -589,6 +575,26 @@ mod tests {
         let pool = setup_db().await;
         let result = delete_camera(&pool, "nonexistent").await;
         assert!(result.is_err());
+    }
+
+    /// `aliases` is a named graceful-degradation site (spec `n4_jsoncodec`,
+    /// duplication-and-abstraction-audit.md T2-d): a row with a corrupt
+    /// `aliases` cell (hand-edited DB) must still list, with an empty
+    /// alias list, not fail the whole query.
+    #[tokio::test]
+    async fn list_cameras_degrades_on_corrupt_aliases_cell() {
+        let pool = setup_db().await;
+        sqlx::query(
+            "INSERT INTO cameras (id, name, aliases, auto_detected, created_at) \
+             VALUES ('cam-corrupt', 'Corrupt Cam', 'not valid json', 0, '2026-01-01T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let cameras = list_cameras(&pool).await.unwrap();
+        let corrupt = cameras.iter().find(|c| c.id == "cam-corrupt").expect("row present");
+        assert!(corrupt.aliases.is_empty(), "corrupt aliases cell must degrade, not error");
     }
 
     // ── Telescope tests ─────────────────────────────────────────────────────

--- a/crates/persistence/db/src/repositories/provenance.rs
+++ b/crates/persistence/db/src/repositories/provenance.rs
@@ -20,10 +20,14 @@ use domain_core::ids::{EntityId, Timestamp};
 ///
 /// Ordered to match the column projection in `load_provenance`:
 /// `id, asset_id, asset_type, field_path, origin, value, captured_at, source_id, replaced_by`.
+/// `value` decodes via `sqlx::types::Json` at fetch time — a malformed cell
+/// fails the whole query (propagates), matching the pre-migration `?` on
+/// `serde_json::from_str` in `row_to_entry`.
 type RawProvenanceTuple =
-    (String, String, String, String, String, String, String, Option<String>, Option<String>);
+    (String, String, String, String, String, Json<Value>, String, Option<String>, Option<String>);
 use domain_core::lifecycle::provenance::{ProvenanceEntry, ProvenanceTag, ProvenancedValue};
 use serde_json::Value;
+use sqlx::types::Json;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use uuid::Uuid;
@@ -44,8 +48,8 @@ pub struct ProvenanceRow {
     pub field_path: String,
     /// Matches `ProvenanceTag` snake_case discriminant.
     pub origin: String,
-    /// Serialized `T`.
-    pub value_json: String,
+    /// Already decoded via `sqlx::types::Json` in the SELECT tuple.
+    pub value: Value,
     /// RFC 3339 timestamp.
     pub captured_at: String,
     pub source_id: Option<String>,
@@ -88,12 +92,11 @@ fn parse_entity_id(s: &str) -> Result<EntityId, DbError> {
 
 /// Convert one raw row into a typed `ProvenanceEntry<Value>`.
 fn row_to_entry(row: &ProvenanceRow) -> DbResult<ProvenanceEntry<Value>> {
-    let value: Value = serde_json::from_str(&row.value_json)?;
     let origin = parse_tag(&row.origin)?;
     let captured_at = parse_timestamp(&row.captured_at)?;
     let source_id = row.source_id.as_deref().map(parse_entity_id).transpose()?;
     Ok(ProvenanceEntry {
-        value,
+        value: row.value.clone(),
         origin,
         captured_at,
         source_id,
@@ -114,9 +117,10 @@ fn row_to_entry(row: &ProvenanceRow) -> DbResult<ProvenanceEntry<Value>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] for SQL failures, [`DbError::Serialise`]
-/// when a stored value cannot be parsed as JSON, and [`DbError::NotFound`]
-/// when stored discriminants/UUIDs/timestamps cannot be decoded.
+/// Returns [`DbError::Database`] for SQL failures (including a stored `value`
+/// that cannot be parsed as JSON — decoded via `sqlx::types::Json` at fetch
+/// time) and [`DbError::NotFound`] when stored discriminants/UUIDs/timestamps
+/// cannot be decoded.
 pub async fn load_provenance(
     pool: &sqlx::SqlitePool,
     entity_id: EntityId,
@@ -144,7 +148,7 @@ pub async fn load_provenance(
                 entity_type,
                 field_path,
                 origin,
-                value_json,
+                Json(value),
                 captured_at,
                 source_id,
                 superseded_by,
@@ -155,7 +159,7 @@ pub async fn load_provenance(
                     entity_type,
                     field_path,
                     origin,
-                    value_json,
+                    value,
                     captured_at,
                     source_id,
                     superseded_by,

--- a/crates/persistence/db/src/repositories/session_snapshot.rs
+++ b/crates/persistence/db/src/repositories/session_snapshot.rs
@@ -7,6 +7,7 @@
 //! current state to "what we knew when we approved this".
 
 use serde_json::Value;
+use sqlx::types::Json;
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
@@ -42,9 +43,8 @@ pub fn should_snapshot(state: &str) -> bool {
 /// hydration.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on insert failure or
-/// [`DbError::Serialise`] when context serialisation fails (caller pre-
-/// serializes via `serde_json::to_string`).
+/// Returns [`DbError::Database`] on insert failure, including JSON encoding
+/// of `context` (encoded via `sqlx::types::Json`).
 pub async fn write_session_snapshot(
     pool: &SqlitePool,
     session_id: &str,
@@ -56,7 +56,6 @@ pub async fn write_session_snapshot(
     context: &Value,
 ) -> DbResult<String> {
     let id = Uuid::new_v4().to_string();
-    let context_json = serde_json::to_string(context)?;
     sqlx::query(
         "INSERT INTO session_snapshot \
          (id, session_id, session_kind, transition_from, transition_to, captured_at, audit_id, context_json) \
@@ -69,7 +68,7 @@ pub async fn write_session_snapshot(
     .bind(transition_to)
     .bind(captured_at)
     .bind(audit_id)
-    .bind(&context_json)
+    .bind(Json(context))
     .execute(pool)
     .await?;
     Ok(id)

--- a/crates/persistence/db/src/repositories/settings.rs
+++ b/crates/persistence/db/src/repositories/settings.rs
@@ -9,6 +9,7 @@ use domain_core::ids::Timestamp;
 use domain_core::settings::{SettingsState, SourceOverride};
 use patterns::{default_pattern, validate_pattern_str, FrameTypeClass};
 use serde_json::Value;
+use sqlx::types::Json;
 use sqlx::SqlitePool;
 
 use crate::{DbError, DbResult};
@@ -29,18 +30,12 @@ pub const PATTERNS_BY_TYPE_KEY: &str = "patternsByType";
 ///
 /// Returns [`DbError::Database`] on query failure.
 pub async fn get_raw(pool: &SqlitePool, key: &str) -> DbResult<Option<Value>> {
-    let row: Option<(String,)> = sqlx::query_as("SELECT value FROM settings WHERE key = ?")
+    let row: Option<(Json<Value>,)> = sqlx::query_as("SELECT value FROM settings WHERE key = ?")
         .bind(key)
         .fetch_optional(pool)
         .await?;
 
-    match row {
-        None => Ok(None),
-        Some((json,)) => {
-            let v = serde_json::from_str(&json)?;
-            Ok(Some(v))
-        }
-    }
+    Ok(row.map(|(Json(v),)| v))
 }
 
 /// Write (upsert) a raw JSON value for a single key.
@@ -50,7 +45,6 @@ pub async fn get_raw(pool: &SqlitePool, key: &str) -> DbResult<Option<Value>> {
 /// Returns [`DbError::Database`] on query failure.
 /// Returns [`DbError::Serialise`] if the value cannot be serialised.
 pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()> {
-    let json = serde_json::to_string(value)?;
     let now = Timestamp::now_iso();
 
     sqlx::query(
@@ -58,7 +52,7 @@ pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()
          ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
     )
     .bind(key)
-    .bind(&json)
+    .bind(Json(value))
     .bind(&now)
     .execute(pool)
     .await?;
@@ -84,15 +78,10 @@ pub async fn delete_key(pool: &SqlitePool, key: &str) -> DbResult<()> {
 ///
 /// Returns [`DbError::Database`] on query failure.
 pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
-    let rows: Vec<(String, String)> =
+    let rows: Vec<(String, Json<Value>)> =
         sqlx::query_as("SELECT key, value FROM settings ORDER BY key ASC").fetch_all(pool).await?;
 
-    rows.into_iter()
-        .map(|(key, json)| {
-            let v = serde_json::from_str(&json)?;
-            Ok((key, v))
-        })
-        .collect()
+    Ok(rows.into_iter().map(|(key, Json(v))| (key, v)).collect())
 }
 
 // ── High-level settings bag ───────────────────────────────────────────────
@@ -345,7 +334,6 @@ pub async fn set_source_override(
     key: &str,
     value: &Value,
 ) -> DbResult<()> {
-    let json = serde_json::to_string(value)?;
     let now = Timestamp::now_iso();
 
     sqlx::query(
@@ -354,7 +342,7 @@ pub async fn set_source_override(
     )
     .bind(source_id)
     .bind(key)
-    .bind(&json)
+    .bind(Json(value))
     .bind(&now)
     .execute(pool)
     .await?;
@@ -372,20 +360,14 @@ pub async fn get_source_override_raw(
     source_id: &str,
     key: &str,
 ) -> DbResult<Option<Value>> {
-    let row: Option<(String,)> =
+    let row: Option<(Json<Value>,)> =
         sqlx::query_as("SELECT value FROM source_overrides WHERE source_id = ? AND key = ?")
             .bind(source_id)
             .bind(key)
             .fetch_optional(pool)
             .await?;
 
-    match row {
-        None => Ok(None),
-        Some((json,)) => {
-            let v = serde_json::from_str(&json)?;
-            Ok(Some(v))
-        }
-    }
+    Ok(row.map(|(Json(v),)| v))
 }
 
 /// List all source overrides for a given source.
@@ -397,24 +379,22 @@ pub async fn list_source_overrides(
     pool: &SqlitePool,
     source_id: &str,
 ) -> DbResult<Vec<SourceOverride>> {
-    let rows: Vec<(String, String, String)> = sqlx::query_as(
+    let rows: Vec<(String, Json<Value>, String)> = sqlx::query_as(
         "SELECT key, value, updated_at FROM source_overrides WHERE source_id = ? ORDER BY key ASC",
     )
     .bind(source_id)
     .fetch_all(pool)
     .await?;
 
-    rows.into_iter()
-        .map(|(key, json, updated_at)| {
-            let v: Value = serde_json::from_str(&json)?;
-            Ok(SourceOverride {
-                source_id: source_id.to_owned(),
-                key,
-                value: domain_core::JsonAny::from(v),
-                updated_at,
-            })
+    Ok(rows
+        .into_iter()
+        .map(|(key, Json(v), updated_at)| SourceOverride {
+            source_id: source_id.to_owned(),
+            key,
+            value: domain_core::JsonAny::from(v),
+            updated_at,
         })
-        .collect()
+        .collect())
 }
 
 #[cfg(test)]
@@ -442,6 +422,40 @@ mod tests {
         set_raw(db.pool(), "logLevel", &value).await.unwrap();
         let loaded = get_raw(db.pool(), "logLevel").await.unwrap();
         assert_eq!(loaded, Some(value));
+    }
+
+    /// Round-trips a nested object/array shape through the `sqlx::types::Json`
+    /// column codec (spec `n4_jsoncodec`) — not just a JSON scalar.
+    #[tokio::test]
+    async fn set_and_get_raw_roundtrip_nested_value() {
+        let db = setup().await;
+        let value = serde_json::json!({
+            "patterns": ["a/{target}/", "b/{filter}/"],
+            "nested": { "enabled": true, "count": 3 },
+        });
+        set_raw(db.pool(), "patternsByType", &value).await.unwrap();
+        let loaded = get_raw(db.pool(), "patternsByType").await.unwrap();
+        assert_eq!(loaded, Some(value));
+    }
+
+    /// A cell that predates or bypasses `set_raw` (hand-edited DB, corrupted
+    /// disk) with syntactically invalid JSON must fail the read, not silently
+    /// substitute a default — `get_raw` is a strict-propagate site (spec
+    /// `n4_jsoncodec`: distinct from the two named lenient sites in
+    /// `equipment.rs`/`artifacts.rs`).
+    #[tokio::test]
+    async fn get_raw_propagates_on_corrupt_cell() {
+        let db = setup().await;
+        sqlx::query("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)")
+            .bind("corrupt")
+            .bind("not valid json")
+            .bind(Timestamp::now_iso())
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let result = get_raw(db.pool(), "corrupt").await;
+        assert!(result.is_err(), "corrupt JSON cell must error, not degrade");
     }
 
     #[tokio::test]

--- a/crates/persistence/db/src/repositories/source_protection.rs
+++ b/crates/persistence/db/src/repositories/source_protection.rs
@@ -6,6 +6,7 @@
 
 use domain_core::ids::Timestamp;
 use serde_json::Value;
+use sqlx::types::Json;
 use sqlx::SqlitePool;
 
 use crate::{DbError, DbResult};
@@ -13,6 +14,12 @@ use crate::{DbError, DbResult};
 // ── Row type ──────────────────────────────────────────────────────────────
 
 /// Raw DB row for `source_protection_state`.
+///
+/// `categories` stays raw `String` (not `sqlx::types::Json`, unlike the other
+/// columns in this file): `crates/app/core::protection::set_source_protection`
+/// reads this field directly with its own lenient `serde_json::from_str`
+/// fallback, so this row's shape is a cross-crate contract this file cannot
+/// unilaterally change.
 #[derive(Clone, Debug, sqlx::FromRow)]
 pub struct SourceProtectionRow {
     pub source_id: String,
@@ -59,10 +66,6 @@ fn parse_categories(json: Option<&str>) -> DbResult<Vec<String>> {
     }
 }
 
-fn encode_categories(cats: &[String]) -> DbResult<String> {
-    serde_json::to_string(cats).map_err(DbError::Serialise)
-}
-
 // ── CRUD ──────────────────────────────────────────────────────────────────
 
 /// Upsert a per-source protection override.
@@ -84,10 +87,7 @@ pub async fn upsert_source_protection(
 ) -> DbResult<()> {
     let now = Timestamp::now_iso();
     let bpd: Option<i64> = block_permanent_delete.map(i64::from);
-    let cats_json: Option<String> = match categories {
-        None => None,
-        Some(c) => Some(encode_categories(c)?),
-    };
+    let cats_json = categories.map(Json);
 
     sqlx::query(
         "INSERT INTO source_protection_state \
@@ -223,20 +223,14 @@ pub async fn get_protection_default(
     scope: &str,
     key: &str,
 ) -> DbResult<Option<serde_json::Value>> {
-    let row: Option<(String,)> =
+    let row: Option<(Json<Value>,)> =
         sqlx::query_as("SELECT value FROM protection_defaults WHERE scope = ? AND key = ?")
             .bind(scope)
             .bind(key)
             .fetch_optional(pool)
             .await?;
 
-    match row {
-        None => Ok(None),
-        Some((json,)) => {
-            let v = serde_json::from_str(&json).map_err(DbError::Serialise)?;
-            Ok(Some(v))
-        }
-    }
+    Ok(row.map(|(Json(v),)| v))
 }
 
 /// Upsert a (scope, key, value) protection default row.
@@ -251,7 +245,6 @@ pub async fn set_protection_default(
     key: &str,
     value: &serde_json::Value,
 ) -> DbResult<()> {
-    let json = serde_json::to_string(value).map_err(DbError::Serialise)?;
     let now = Timestamp::now_iso();
 
     sqlx::query(
@@ -260,7 +253,7 @@ pub async fn set_protection_default(
     )
     .bind(scope)
     .bind(key)
-    .bind(&json)
+    .bind(Json(value))
     .bind(&now)
     .execute(pool)
     .await?;


### PR DESCRIPTION
## Summary
- Standardizes JSON-in-column (de)serialization across settings, source_protection, equipment, provenance, calibration_assignment, and session_snapshot repositories on sqlx::types::Json<T>, preserving existing graceful-degradation behavior on malformed data.
- Deduplicates the equipment CRUD helper.

## Spec Context
Run: run-dab, node: n4_jsoncodec.