### PR TITLE
fix: surface data-integrity and lifecycle errors instead of silently defaulting or mislabeling them

### DIFF
--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -122,11 +122,14 @@ async fn check_duplicate(
 
 fn db_to_contract(e: persistence_db::DbError) -> ContractError {
     let msg = e.to_string();
-    drop(e);
     if msg.contains("UNIQUE constraint failed") {
         ContractError::new(ErrorCode::PathAlreadyRegistered, msg, ErrorSeverity::Warning, false)
     } else {
-        ContractError::new(ErrorCode::InternalDatabase, msg, ErrorSeverity::Fatal, true)
+        // Delegate the non-UNIQUE fallback to the canonical mapper (T1-c) so
+        // `NotFound` is classified `Blocking`/non-retryable instead of the
+        // hand-rolled `Fatal`/`retryable=true` this used to apply to every
+        // variant, including missing rows.
+        crate::errors::db_err(e)
     }
 }
 
@@ -650,6 +653,21 @@ mod tests {
 
         let err = check_duplicate(&pool, "/tmp", SourceKind::Project).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::PathAlreadyRegisteredDifferentKind);
+    }
+
+    /// T1-c: `db_to_contract`'s fallback arm now delegates to the canonical
+    /// `db_err` mapper, so a `NotFound` (missing row) is `Blocking`/
+    /// non-retryable rather than the hand-rolled `Fatal`/`retryable=true`
+    /// this used to apply to every `DbError` variant.
+    #[tokio::test]
+    async fn remove_source_not_found_is_blocking_not_fatal() {
+        let db = persistence_db::Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        let pool = db.pool().clone();
+
+        let err = remove_source(&pool, "does-not-exist").await.unwrap_err();
+        assert_eq!(err.severity, ErrorSeverity::Blocking);
+        assert!(!err.retryable);
     }
 
     #[tokio::test]

--- a/crates/app/core/src/plans.rs
+++ b/crates/app/core/src/plans.rs
@@ -77,19 +77,18 @@ fn db_err(e: persistence_db::DbError) -> ContractError {
 
 // ── Row mapping helpers ───────────────────────────────────────────────────────
 
-fn parse_plan_state(s: &str) -> PlanState {
-    match s {
-        "ready_for_review" => PlanState::ReadyForReview,
-        "approved" => PlanState::Approved,
-        "applying" => PlanState::Applying,
-        "paused" => PlanState::Paused,
-        "applied" => PlanState::Applied,
-        "partially_applied" => PlanState::PartiallyApplied,
-        "failed" => PlanState::Failed,
-        "cancelled" => PlanState::Cancelled,
-        "discarded" => PlanState::Discarded,
-        _ => PlanState::Draft,
-    }
+/// Parses a stored plan-state string via `PlanState`'s `serde` mapping
+/// (`#[serde(rename_all = "snake_case")]`) so an unrecognised/corrupt value
+/// ERRORS instead of silently coercing to `Draft` (audit T1-b).
+fn parse_plan_state(s: &str) -> Result<PlanState, ContractError> {
+    serde_json::from_value(serde_json::Value::String(s.to_owned())).map_err(|e| {
+        ContractError::new(
+            ErrorCode::InternalData,
+            format!("corrupt plan state {s:?}: {e}"),
+            ErrorSeverity::Fatal,
+            false,
+        )
+    })
 }
 
 fn parse_plan_origin(s: &str) -> PlanOrigin {
@@ -156,14 +155,14 @@ fn parse_item_state(s: &str) -> PlanItemState {
     }
 }
 
-fn row_to_summary(row: repo::PlanRow) -> PlanSummary {
-    PlanSummary {
+fn row_to_summary(row: repo::PlanRow) -> Result<PlanSummary, ContractError> {
+    Ok(PlanSummary {
         id: row.id,
         number: row.number,
         title: row.title,
         origin: parse_plan_origin(&row.origin),
         origin_path: row.origin_path,
-        state: parse_plan_state(&row.state),
+        state: parse_plan_state(&row.state)?,
         created_at: row.created_at,
         discarded_at: row.discarded_at,
         items_total: row.items_total,
@@ -176,7 +175,7 @@ fn row_to_summary(row: repo::PlanRow) -> PlanSummary {
         destructive_destination: parse_destructive_destination(&row.destructive_destination),
         plan_type: parse_plan_type(&row.plan_type),
         parent_plan_id: row.parent_plan_id,
-    }
+    })
 }
 
 fn item_row_to_detail(row: repo::PlanItemRow) -> PlanItemDetail {
@@ -253,7 +252,8 @@ pub async fn list_plans(
         .await
         .map_err(db_err)?;
 
-    Ok(PlanListResponse { plans: rows.into_iter().map(row_to_summary).collect() })
+    let plans = rows.into_iter().map(row_to_summary).collect::<Result<Vec<_>, _>>()?;
+    Ok(PlanListResponse { plans })
 }
 
 // ── get_plan ──────────────────────────────────────────────────────────────────
@@ -275,7 +275,7 @@ pub async fn get_plan(pool: &SqlitePool, plan_id: &str) -> Result<PlanDetail, Co
         title: row.title,
         origin: parse_plan_origin(&row.origin),
         origin_path: row.origin_path,
-        state: parse_plan_state(&row.state),
+        state: parse_plan_state(&row.state)?,
         plan_type: parse_plan_type(&row.plan_type),
         destructive_destination: parse_destructive_destination(&row.destructive_destination),
         parent_plan_id: row.parent_plan_id,
@@ -322,7 +322,7 @@ pub async fn approve_plan(
     let row = repo::get_plan(pool, plan_id, false).await.map_err(db_err)?;
 
     // State precondition: must be ready_for_review.
-    let state = parse_plan_state(&row.state);
+    let state = parse_plan_state(&row.state)?;
     if state != PlanState::ReadyForReview {
         return Err(ContractError::new(
             ErrorCode::PlanInvalidState,
@@ -465,7 +465,7 @@ pub async fn discard_plan(
     // Include discarded so the error is "not_found" only for truly missing plans.
     let row = repo::get_plan(pool, plan_id, true).await.map_err(db_err)?;
 
-    let state = parse_plan_state(&row.state);
+    let state = parse_plan_state(&row.state)?;
 
     // Guard: cannot discard while applying or paused.
     if matches!(state, PlanState::Applying | PlanState::Paused) {
@@ -537,7 +537,7 @@ pub async fn retry_plan(
         )
     })?;
 
-    let parent_state = parse_plan_state(&parent.state);
+    let parent_state = parse_plan_state(&parent.state)?;
 
     // Must be terminal.
     if !is_terminal(parent_state) {
@@ -894,6 +894,38 @@ mod tests {
         assert_eq!(detail.id, "p1");
         assert_eq!(detail.items.len(), 1);
         assert_eq!(detail.items[0].name, "file.fits");
+    }
+
+    // ── parse_plan_state (audit T1-b) ────────────────────────────────────────
+
+    #[test]
+    fn parse_plan_state_accepts_every_stored_snake_case_value() {
+        for (raw, expected) in [
+            ("draft", PlanState::Draft),
+            ("ready_for_review", PlanState::ReadyForReview),
+            ("approved", PlanState::Approved),
+            ("applying", PlanState::Applying),
+            ("paused", PlanState::Paused),
+            ("applied", PlanState::Applied),
+            ("partially_applied", PlanState::PartiallyApplied),
+            ("failed", PlanState::Failed),
+            ("cancelled", PlanState::Cancelled),
+            ("discarded", PlanState::Discarded),
+        ] {
+            assert_eq!(parse_plan_state(raw).unwrap(), expected, "for {raw:?}");
+        }
+    }
+
+    #[test]
+    fn parse_plan_state_errors_on_unknown_value_instead_of_defaulting() {
+        // Previously silently coerced to `PlanState::Draft` (T1-b bug). A
+        // `plans.state` CHECK constraint (migration) additionally blocks a
+        // corrupt value from ever being persisted via SQL, so the direct
+        // parser-level regression below is the reachable case; `parse_plan_state`
+        // is still the load-bearing guard against pre-constraint or
+        // out-of-band-corrupted rows.
+        let err = parse_plan_state("bogus_corrupt_state").unwrap_err();
+        assert_eq!(err.code, ErrorCode::InternalData);
     }
 
     // ── approve_plan ──────────────────────────────────────────────────────────

--- a/crates/app/inbox/src/metadata.rs
+++ b/crates/app/inbox/src/metadata.rs
@@ -17,6 +17,7 @@
 
 use std::collections::HashMap;
 
+use app_core_errors::db_err;
 use patterns::{resolve_pattern_str, MetadataBundle};
 use persistence_db::repositories::inbox::{self as repo};
 use persistence_db::repositories::settings as settings_repo;
@@ -54,9 +55,8 @@ pub async fn get_inbox_item_metadata(
 
     // 2. Load the per-file metadata rows + evidence rows, then join in memory by
     //    relative path. Metadata rows are the spine (one per enumerated file).
-    let meta_rows =
-        repo::list_inbox_file_metadata(pool, inbox_item_id).await.map_err(|e| db_err(&e))?;
-    let evidence_rows = repo::list_evidence(pool, inbox_item_id).await.map_err(|e| db_err(&e))?;
+    let meta_rows = repo::list_inbox_file_metadata(pool, inbox_item_id).await.map_err(db_err)?;
+    let evidence_rows = repo::list_evidence(pool, inbox_item_id).await.map_err(db_err)?;
 
     // Index evidence by relative path for O(1) lookup while iterating metadata.
     let evidence_by_path: HashMap<&str, &repo::InboxEvidenceRow> =
@@ -151,10 +151,6 @@ pub async fn get_inbox_item_metadata(
     Ok(files)
 }
 
-fn db_err(e: &persistence_db::DbError) -> ContractError {
-    ContractError::new(ErrorCode::InternalDatabase, e.to_string(), ErrorSeverity::Fatal, true)
-}
-
 /// Compute the mandatory-attribute gate for a file from the already-built DTO
 /// (spec 041 T070 / FR-047 / R-14).
 ///
@@ -211,9 +207,8 @@ async fn missing_path_attributes(
     let Some(ft) = m.frame_type_effective.as_deref() else {
         return Ok(vec!["image type".to_owned()]);
     };
-    let pattern = settings_repo::effective_pattern_for(pool, ft, m.is_master)
-        .await
-        .map_err(|e| db_err(&e))?;
+    let pattern =
+        settings_repo::effective_pattern_for(pool, ft, m.is_master).await.map_err(db_err)?;
     let Some(pattern) = pattern else {
         return Ok(vec!["image type".to_owned()]);
     };

--- a/crates/app/inbox/src/target_recommendations.rs
+++ b/crates/app/inbox/src/target_recommendations.rs
@@ -24,6 +24,7 @@
 //! `app_core_targets::ingest_sessions::propagate_target_to_projects`.
 #![allow(clippy::doc_markdown)] // RA/Dec, FOV, OBJECT are domain terms
 
+use app_core_errors::db_err;
 use persistence_db::repositories::inbox::{self as repo, InboxPointingRow};
 use sqlx::SqlitePool;
 
@@ -43,10 +44,6 @@ use targeting_resolver::cache;
 /// with the whole sky. The use-case accepts an override so callers/settings can
 /// tune it later; this is the baked-in default.
 pub const DEFAULT_FIXED_RADIUS_DEG: f64 = 5.0;
-
-fn db_err(e: &persistence_db::DbError) -> ContractError {
-    ContractError::new(ErrorCode::InternalDatabase, e.to_string(), ErrorSeverity::Fatal, true)
-}
 
 fn not_found(msg: String) -> ContractError {
     ContractError::new(ErrorCode::InboxItemNotFound, msg, ErrorSeverity::Blocking, false)
@@ -83,7 +80,7 @@ pub async fn target_recommendations(
     let item_id = resolve_item_id(pool, target).await?;
 
     // 2. Load per-file pointing + optics for the sub-group.
-    let rows = repo::list_inbox_pointing(pool, &item_id).await.map_err(|e| db_err(&e))?;
+    let rows = repo::list_inbox_pointing(pool, &item_id).await.map_err(db_err)?;
 
     // Display hint only (R-17): first non-blank OBJECT, never used for matching.
     let object_hint = rows
@@ -172,8 +169,7 @@ async fn resolve_item_id(
             Ok(id.clone())
         }
         RecommendationTarget::SourceGroup(sg) => {
-            let ids =
-                repo::list_item_ids_for_source_group(pool, sg).await.map_err(|e| db_err(&e))?;
+            let ids = repo::list_item_ids_for_source_group(pool, sg).await.map_err(db_err)?;
             ids.into_iter()
                 .next()
                 .ok_or_else(|| not_found(format!("no inbox items for source group: {sg}")))

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -528,20 +528,13 @@ fn parse_state(s: &str) -> Option<project::ProjectState> {
     })
 }
 
+/// Parses via `PlanState`'s `serde` mapping (`#[serde(rename_all =
+/// "snake_case")]`) instead of a hand-rolled match, so this stays in sync
+/// with `app_core::plans::parse_plan_state`'s sibling parser rather than
+/// drifting on new variants (audit T1-b). An unrecognised/corrupt value
+/// yields `None`, which `validate_edge` already treats as an invalid edge.
 fn parse_plan(s: &str) -> Option<plan_lifecycle::PlanState> {
-    Some(match s {
-        "draft" => plan_lifecycle::PlanState::Draft,
-        "ready_for_review" => plan_lifecycle::PlanState::ReadyForReview,
-        "approved" => plan_lifecycle::PlanState::Approved,
-        "applying" => plan_lifecycle::PlanState::Applying,
-        "paused" => plan_lifecycle::PlanState::Paused,
-        "applied" => plan_lifecycle::PlanState::Applied,
-        "partially_applied" => plan_lifecycle::PlanState::PartiallyApplied,
-        "failed" => plan_lifecycle::PlanState::Failed,
-        "cancelled" => plan_lifecycle::PlanState::Cancelled,
-        "discarded" => plan_lifecycle::PlanState::Discarded,
-        _ => return None,
-    })
+    serde_json::from_value(serde_json::Value::String(s.to_owned())).ok()
 }
 
 fn parse_file_record(s: &str) -> Option<inventory::InventoryState> {
@@ -672,6 +665,31 @@ mod tests {
             action_label: None,
             actor,
         })
+    }
+
+    // ── parse_plan (audit T1-b sibling parser) ─────────────────────────────
+
+    #[test]
+    fn parse_plan_accepts_every_snake_case_variant() {
+        for (raw, expected) in [
+            ("draft", plan_lifecycle::PlanState::Draft),
+            ("ready_for_review", plan_lifecycle::PlanState::ReadyForReview),
+            ("approved", plan_lifecycle::PlanState::Approved),
+            ("applying", plan_lifecycle::PlanState::Applying),
+            ("paused", plan_lifecycle::PlanState::Paused),
+            ("applied", plan_lifecycle::PlanState::Applied),
+            ("partially_applied", plan_lifecycle::PlanState::PartiallyApplied),
+            ("failed", plan_lifecycle::PlanState::Failed),
+            ("cancelled", plan_lifecycle::PlanState::Cancelled),
+            ("discarded", plan_lifecycle::PlanState::Discarded),
+        ] {
+            assert_eq!(parse_plan(raw), Some(expected), "for {raw:?}");
+        }
+    }
+
+    #[test]
+    fn parse_plan_rejects_unknown_value() {
+        assert_eq!(parse_plan("bogus_corrupt_state"), None);
     }
 
     #[tokio::test]

--- a/crates/persistence/db/src/repositories/lifecycle.rs
+++ b/crates/persistence/db/src/repositories/lifecycle.rs
@@ -183,6 +183,22 @@ fn state_column_for(entity_type: EntityType) -> &'static str {
     }
 }
 
+/// Raw `ledger_view` row, decoded by column name via `#[derive(FromRow)]`
+/// instead of a hand-rolled positional-tuple `query_as` + manual per-field
+/// map (Tier-3 dedup/abstraction audit). `entity_id`/`entity_type` are kept
+/// as plain strings here — parsing them into typed `EntityId`/`EntityType`
+/// is a separate domain concern handled in `list_assets_ledger`.
+#[derive(sqlx::FromRow)]
+struct RawLedgerRow {
+    entity_type: String,
+    entity_id: String,
+    state: String,
+    title: Option<String>,
+    path: Option<String>,
+    project_id: Option<String>,
+    updated_at: Option<String>,
+}
+
 // ── SQLite-backed implementation ──────────────────────────────────────────────
 
 /// SQLite-backed implementation of [`LifecycleRepository`].
@@ -306,19 +322,10 @@ impl LifecycleRepository for SqliteLifecycleRepository {
         // AssertSqlSafe: every dynamic portion above is either a static
         // identifier, a fixed `?` placeholder, or an integer literal derived
         // from typed `u32` filter fields. User-supplied strings flow through
-        // `bind` calls below.
-        let mut q = sqlx::query_as::<
-            _,
-            (
-                String,
-                String,
-                String,
-                Option<String>,
-                Option<String>,
-                Option<String>,
-                Option<String>,
-            ),
-        >(sqlx::AssertSqlSafe(sql));
+        // `bind` calls below. Named-column `FromRow` decoding (vs. a
+        // positional tuple) keeps this immune to the SELECT list being
+        // reordered (T1-d Tier-3).
+        let mut q = sqlx::query_as::<_, RawLedgerRow>(sqlx::AssertSqlSafe(sql));
         for v in &string_binds {
             q = q.bind(v);
         }
@@ -326,26 +333,21 @@ impl LifecycleRepository for SqliteLifecycleRepository {
         let raw = q.fetch_all(&self.pool).await?;
 
         let mut rows = Vec::with_capacity(raw.len());
-        for (et_str, id_str, state, title, path, project_id, updated_at) in raw {
-            let uuid = Uuid::parse_str(&id_str)
-                .map_err(|e| DbError::NotFound(format!("bad uuid {id_str}: {e}")))?;
-            let entity_id = EntityId::from_uuid(uuid);
-            let entity_type = parse_entity_type(&et_str);
-            let project_id = match project_id {
-                Some(s) => Some(EntityId::from_uuid(
-                    Uuid::parse_str(&s)
-                        .map_err(|e| DbError::NotFound(format!("bad project uuid {s}: {e}")))?,
-                )),
+        for r in raw {
+            let entity_id = EntityId::from_uuid(parse_stored_uuid(&r.entity_id)?);
+            let entity_type = parse_entity_type(&r.entity_type);
+            let project_id = match r.project_id {
+                Some(s) => Some(EntityId::from_uuid(parse_stored_uuid(&s)?)),
                 None => None,
             };
             rows.push(LedgerRow {
                 entity_id,
                 entity_type,
-                current_state: state,
-                title,
-                path,
+                current_state: r.state,
+                title: r.title,
+                path: r.path,
                 project_id,
-                updated_at,
+                updated_at: r.updated_at,
             });
         }
 
@@ -547,6 +549,18 @@ fn provenance_asset_type(entity_type: EntityType) -> &'static str {
     }
 }
 
+/// Parses a UUID read back from a stored id column.
+///
+/// A malformed UUID here is row *corruption*, not a missing row — mapping it
+/// to `DbError::NotFound` (as this used to) mislabels a decode failure as
+/// "no such entity". `sqlx::Error::Decode` is the closest existing fit for a
+/// bad-value-in-storage error without adding a new `DbError` variant; the
+/// ideal long-term shape is a dedicated `DbError::Decode` variant (T1-d).
+fn parse_stored_uuid(s: &str) -> DbResult<Uuid> {
+    Uuid::parse_str(s)
+        .map_err(|e| DbError::Database(sqlx::Error::Decode(format!("bad uuid {s}: {e}").into())))
+}
+
 fn parse_entity_type(s: &str) -> EntityType {
     match s {
         "file_record" => EntityType::FileRecord,
@@ -670,5 +684,33 @@ mod tests {
         let repo = InMemoryLifecycleRepository;
         let rows = repo.list_assets_ledger(LedgerFilter::default()).await.unwrap();
         assert!(rows.is_empty());
+    }
+
+    /// T1-d: a malformed stored UUID is row corruption, not a missing row.
+    /// Previously this path mapped to `DbError::NotFound`, mislabeling a
+    /// decode failure as "no such entity"; it must now surface as a
+    /// non-`NotFound` variant instead.
+    #[tokio::test]
+    async fn list_assets_ledger_reports_corrupt_uuid_as_non_notfound() {
+        let db = crate::Database::in_memory().await.expect("in-memory connect");
+        db.migrate().await.expect("migrations");
+        let bus = audit::bus::EventBus::new(db.pool().clone(), 16);
+        let repo = super::SqliteLifecycleRepository::new(db.pool().clone(), bus);
+
+        sqlx::query(
+            "INSERT INTO library_root \
+             (id, label, current_path, kind, state, last_seen_at, created_at) \
+             VALUES ('not-a-uuid', 'lr', '/tmp/lr', 'local', 'active', \
+                     '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let err = repo.list_assets_ledger(LedgerFilter::default()).await.unwrap_err();
+        assert!(
+            !matches!(err, crate::DbError::NotFound(_)),
+            "corrupt uuid must not be reported as NotFound: {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
- Plan lifecycle state parsing now goes through serde instead of silently falling back to a default state on an unrecognized value, so a corrupted or unexpected stored state is reported rather than hidden.
- Corrupt stored UUIDs are now reported as a data-integrity error instead of being mislabeled as "not found", so the underlying corruption is visible instead of looking like a missing record.
- Three hand-rolled database error mappers now delegate to the single canonical error mapper, removing duplicated (and previously inconsistent) error-classification logic.

## Spec Context
Run: run-dab, node: n2_dataintegrity.