### PR TITLE
fix: project creation no longer leaves partial data behind on failure

### DIFF
--- a/crates/app/projects/src/project_setup.rs
+++ b/crates/app/projects/src/project_setup.rs
@@ -303,99 +303,57 @@ async fn anchor_project_path(pool: &SqlitePool, raw: &str) -> Result<String, Con
 
 // ── Folder plan builder (Constitution II) ─────────────────────────────────────
 
-/// Build and persist a reviewable `FilesystemPlan` for the project folder
-/// structure (Constitution II).
-///
-/// Creates one `mkdir` plan item per sub-folder required by the tool
-/// (from `project_structure::required_folders`) and one `write_manifest` item
-/// for the app-owned project marker.  All paths are relative to the project
-/// root path.  The plan is inserted in `draft` state; the caller advances it
-/// through spec 017 review → spec 025 apply.
-///
-/// Returns the plan `id` as a `String`.
-///
-/// # Errors
-///
-/// Returns [`persistence_db::DbError`] on database failure.
-async fn build_folder_plan(
-    pool: &SqlitePool,
-    project_id: &str,
-    project_path: &str,
-    tool_str: &str,
-) -> Result<String, persistence_db::DbError> {
+/// One resolved (not yet persisted) folder-plan item destination.
+struct FolderPlanItemData {
+    id: String,
+    name: String,
+    action: &'static str,
+    to_relative_path: String,
+    reason: &'static str,
+}
+
+/// Resolved (not yet persisted) folder-structure plan for a project
+/// (Constitution II): one `mkdir` item per sub-folder required by the tool
+/// (`project_structure::required_folders`) plus one `write_manifest` item for
+/// the app-owned project marker.
+struct FolderPlanData {
+    plan_id: String,
+    plan_title: String,
+    items: Vec<FolderPlanItemData>,
+}
+
+/// Resolve the folder-structure plan for `project_path`/`tool_str` without
+/// touching the database (pure). The caller borrows these owned strings into
+/// `persistence_db::repositories::plans::{InsertPlan, InsertPlanItem}` for
+/// [`repo::create_project_tx`], which persists the plan (in `draft`, then
+/// advanced to `ready_for_review`) atomically with the rest of project
+/// creation.
+fn build_folder_plan_data(project_path: &str, tool_str: &str) -> FolderPlanData {
     let plan_id = new_id();
     let tool = StructureTool::parse(tool_str).unwrap_or(StructureTool::PixInsight);
     let folders = required_folders(tool);
-
     let plan_title = format!("Create project folder structure: {project_path}");
-    let plan_data = plans_repo::InsertPlan {
-        id: &plan_id,
-        title: &plan_title,
-        origin: "project",
-        origin_path: Some(project_path),
-        plan_type: "project_create",
-        destructive_destination: "archive",
-        parent_plan_id: None,
-        total_bytes_required: 0,
-    };
-    plans_repo::insert_plan(pool, &plan_data).await?;
 
-    // One mkdir item per required sub-folder.
-    for (idx, folder) in folders.iter().enumerate() {
-        let item_id = new_id();
-        let dest = format!("{project_path}/{}", folder.0);
-        let item_data = plans_repo::InsertPlanItem {
-            id: &item_id,
-            plan_id: &plan_id,
-            item_index: i64::try_from(idx).unwrap_or(0),
-            name: &folder.0,
+    let mut items = Vec::with_capacity(folders.len() + 1);
+    for folder in &folders {
+        items.push(FolderPlanItemData {
+            id: new_id(),
+            name: folder.0.clone(),
             action: "mkdir",
-            from_root_id: None,
-            from_relative_path: "",
-            to_root_id: None,
-            to_relative_path: &dest,
+            to_relative_path: format!("{project_path}/{}", folder.0),
             reason: "Create project sub-folder for tool workflow",
-            protection: "normal",
-            linked_entity: Some(project_id),
-            provenance_json: None,
-            archive_path: None,
-            // Project setup items create app-managed folders/files; source protection
-            // does not apply.
-            source_id: None,
-            category: None,
-        };
-        plans_repo::insert_plan_item(pool, &item_data).await?;
+        });
     }
-
     // One write_manifest item for the project marker file.
-    let marker_index = i64::try_from(folders.len()).unwrap_or(0);
-    let marker_dest = format!("{project_path}/{MARKER_FILENAME}");
-    let marker_id = new_id();
-    let marker_item = plans_repo::InsertPlanItem {
-        id: &marker_id,
-        plan_id: &plan_id,
-        item_index: marker_index,
-        name: MARKER_FILENAME,
+    items.push(FolderPlanItemData {
+        id: new_id(),
+        name: MARKER_FILENAME.to_owned(),
         action: "write_manifest",
-        from_root_id: None,
-        from_relative_path: "",
-        to_root_id: None,
-        to_relative_path: &marker_dest,
+        to_relative_path: format!("{project_path}/{MARKER_FILENAME}"),
         reason: "Write app-owned project marker file",
-        protection: "normal",
-        linked_entity: Some(project_id),
-        provenance_json: None,
-        archive_path: None,
-        // Project marker file creation; source protection does not apply.
-        source_id: None,
-        category: None,
-    };
-    plans_repo::insert_plan_item(pool, &marker_item).await?;
+    });
 
-    // Advance to ready_for_review so the plan is visible in the review UI.
-    plans_repo::update_plan_state(pool, &plan_id, "ready_for_review").await?;
-
-    Ok(plan_id)
+    FolderPlanData { plan_id, plan_title, items }
 }
 
 // ── project.create ────────────────────────────────────────────────────────────
@@ -506,7 +464,12 @@ pub async fn create(
         }
     }
 
-    // 5. Persist the project row (setup_incomplete).
+    // 5. Build the project row, initial source links, inferred channels, and
+    //    the Constitution II folder-structure plan (+ items) — every write
+    //    this use case needs — then persist them as ONE atomic unit via
+    //    `create_project_tx`. A mid-sequence database failure previously left
+    //    a half-built project (project row with no sources/channels/plan);
+    //    see `docs/development/duplication-and-abstraction-audit.md` T2-a.
     let insert = repo::InsertProject {
         id: &project_id,
         name: &req.name,
@@ -516,49 +479,107 @@ pub async fn create(
         notes: req.notes.as_deref(),
         canonical_target_id: req.canonical_target_id.as_deref(),
     };
-    repo::insert_project(pool, &insert).await.map_err(db_err)?;
 
-    // 6. Link initial sources (best-effort: if a source is not found in a future
-    //    Inventory table we just skip it for now — spec 003 integration is pending).
-    //    For now, initial_sources lists inventory_session_ids that we trust.
-    let mut source_rows: Vec<repo::ProjectSourceRow> = Vec::new();
-    for inv_id in &req.initial_sources {
-        let src_id = new_id();
-        let src_data = repo::InsertProjectSource {
-            id: &src_id,
-            project_id: &project_id,
-            inventory_session_id: inv_id,
-            // Snapshot fields will be empty until spec 003 Inventory is wired.
-            name_snapshot: "",
-            frames_snapshot: 0,
-            filter_snapshot: "",
-            exposure_snapshot: "",
-            linked_at: &now,
-        };
-        repo::insert_project_source(pool, &src_data).await.map_err(db_err)?;
-        source_rows.push(repo::ProjectSourceRow {
-            id: src_id,
+    // Link initial sources (best-effort: if a source is not found in a future
+    // Inventory table we just skip it for now — spec 003 integration is
+    // pending). For now, initial_sources lists inventory_session_ids that we
+    // trust. Ids are pre-generated so `source_rows` (used for channel
+    // inference and the response DTOs) and `source_data` (borrowed into the
+    // composite insert) can share them without re-querying the DB.
+    let source_ids: Vec<String> = req.initial_sources.iter().map(|_| new_id()).collect();
+    let source_rows: Vec<repo::ProjectSourceRow> = req
+        .initial_sources
+        .iter()
+        .zip(source_ids.iter())
+        .map(|(inv_id, src_id)| repo::ProjectSourceRow {
+            id: src_id.clone(),
             project_id: project_id.clone(),
             inventory_session_id: inv_id.clone(),
+            // Snapshot fields will be empty until spec 003 Inventory is wired.
             name_snapshot: String::new(),
             frames_snapshot: 0,
             filter_snapshot: String::new(),
             exposure_snapshot: String::new(),
             linked_at: now.clone(),
-        });
-    }
+        })
+        .collect();
+    let source_data: Vec<repo::InsertProjectSource> = req
+        .initial_sources
+        .iter()
+        .zip(source_ids.iter())
+        .map(|(inv_id, src_id)| repo::InsertProjectSource {
+            id: src_id,
+            project_id: &project_id,
+            inventory_session_id: inv_id,
+            name_snapshot: "",
+            frames_snapshot: 0,
+            filter_snapshot: "",
+            exposure_snapshot: "",
+            linked_at: &now,
+        })
+        .collect();
 
-    // 7. Infer channels from initial sources.
+    // Infer channels from initial sources.
     let channels = infer_from_sources(&source_rows);
-    persist_channels(pool, &project_id, &channels).await.map_err(db_err)?;
+    let channel_pairs: Vec<(&str, &str)> =
+        channels.iter().map(|c| (c.label.as_str(), c.source.as_str())).collect();
 
-    // 8. Auto-transition setup_incomplete → ready if sources are present.
+    // Constitution II folder-structure plan.
+    let folder_plan = build_folder_plan_data(&project_path, req.tool.as_db_str());
+    let plan_items: Vec<plans_repo::InsertPlanItem> = folder_plan
+        .items
+        .iter()
+        .enumerate()
+        .map(|(idx, item)| plans_repo::InsertPlanItem {
+            id: &item.id,
+            plan_id: &folder_plan.plan_id,
+            item_index: i64::try_from(idx).unwrap_or(0),
+            name: &item.name,
+            action: item.action,
+            from_root_id: None,
+            from_relative_path: "",
+            to_root_id: None,
+            to_relative_path: &item.to_relative_path,
+            reason: item.reason,
+            protection: "normal",
+            linked_entity: Some(&project_id),
+            provenance_json: None,
+            archive_path: None,
+            // Project setup items create app-managed folders/files; source
+            // protection does not apply.
+            source_id: None,
+            category: None,
+        })
+        .collect();
+    let plan_data = plans_repo::InsertPlan {
+        id: &folder_plan.plan_id,
+        title: &folder_plan.plan_title,
+        origin: "project",
+        origin_path: Some(&project_path),
+        plan_type: "project_create",
+        destructive_destination: "archive",
+        parent_plan_id: None,
+        total_bytes_required: 0,
+    };
+
+    let create_input = repo::CreateProjectInput {
+        project: insert,
+        sources: &source_data,
+        channels: &channel_pairs,
+        channels_added_at: &now,
+        plan: plan_data,
+        plan_items: &plan_items,
+    };
+    repo::create_project_tx(pool, &create_input).await.map_err(db_err)?;
+    let plan_id = folder_plan.plan_id;
+
+    // 6. Auto-transition setup_incomplete → ready if sources are present.
     let final_lifecycle = maybe_auto_ready(pool, bus, &project_id, "setup_incomplete")
         .await
         .map_err(db_err)?
         .unwrap_or_else(|| "setup_incomplete".to_owned());
 
-    // 9. Audit.
+    // 7. Audit.
     let audit_id = new_id();
     bus.publish(
         "project.created",
@@ -578,12 +599,6 @@ pub async fn create(
     let channel_totals = channel_totals_by_filter(&source_rows);
     let channel_dtos: Vec<ProjectChannelDto> =
         channels.into_iter().map(|c| channel_dto_from_domain(c, &now, &channel_totals)).collect();
-
-    // 10. Generate the folder-structure FilesystemPlan (Constitution II).
-    //     plan_id is returned so the UI can link to the spec 017 review surface.
-    let plan_id = build_folder_plan(pool, &project_id, &project_path, req.tool.as_db_str())
-        .await
-        .map_err(db_err)?;
 
     Ok(ProjectCreateResult {
         project_id,

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -8,10 +8,7 @@
 //! to the `plans.origin` CHECK (spec 017 C5).
 //! Migration 0061 added `target_favourite` (spec 051 US2).
 
-use std::future::Future;
-use std::pin::Pin;
-
-use sqlx::sqlite::{SqliteConnection, SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
 pub mod operation_state;
 /// Reference pattern for the centralized typed persistence layer (sea-query +
@@ -109,50 +106,9 @@ impl Database {
     }
 }
 
-/// Boxed, `Send` future returned by a [`with_transaction`] closure. A local
-/// alias rather than a `futures`-crate dependency — this is the only shape
-/// [`with_transaction`] needs.
-pub type TxFuture<'c, T> = Pin<Box<dyn Future<Output = DbResult<T>> + Send + 'c>>;
-
-/// Run `f` against one SQLite transaction: commits on `Ok`, rolls back on
-/// `Err` (via `sqlx::Transaction`'s `Drop` impl issuing `ROLLBACK`).
-///
-/// A boundary-safe way to obtain a `&mut SqliteConnection`; `sqlx::Transaction`
-/// itself never leaves `persistence_db` (`scripts/check-db-boundary.sh` seals
-/// `sqlx` to this crate). Suits a transaction body that only needs the
-/// connection itself (or owned/`Copy` captures) — the `for<'c> FnOnce(&'c mut
-/// SqliteConnection) -> TxFuture<'c, _>` bound is universally quantified over
-/// `'c`, so a closure capturing a caller-borrowed `&'a T` cannot satisfy it
-/// (the borrow checker would require `'a: 'static`). Composite `*_tx`
-/// repository functions whose transaction body needs borrowed input (e.g.
-/// `repositories::projects::create_project_tx`) instead open their own
-/// `pool.begin()`/`tx.commit()` directly — see
-/// `docs/development/duplication-and-abstraction-audit.md` T2-a.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] if the transaction cannot be opened or
-/// committed, or propagates `f`'s own error (in which case the transaction is
-/// rolled back).
-pub async fn with_transaction<T, F>(pool: &SqlitePool, f: F) -> DbResult<T>
-where
-    F: for<'c> FnOnce(&'c mut SqliteConnection) -> TxFuture<'c, T>,
-{
-    let mut tx = pool.begin().await?;
-    match f(&mut tx).await {
-        Ok(value) => {
-            tx.commit().await?;
-            Ok(value)
-        }
-        // `tx` is dropped here without a `commit()` call, which sqlx rolls
-        // back automatically.
-        Err(err) => Err(err),
-    }
-}
-
 #[cfg(test)]
 mod tests {
-    use super::{with_transaction, DbError, DbResult, CRATE_NAME};
+    use super::CRATE_NAME;
 
     #[test]
     fn exposes_crate_name() {
@@ -406,67 +362,5 @@ mod tests {
             has_override_filter.is_err(),
             "override_filter column must have been dropped from inbox_classification_evidence by 0047"
         );
-    }
-
-    // ── with_transaction: commit / rollback semantics ──────────────────────
-
-    #[tokio::test]
-    async fn with_transaction_commits_on_ok() {
-        let db = super::Database::in_memory().await.expect("in-memory connect");
-        db.migrate().await.expect("migrations");
-        let pool = db.pool().clone();
-
-        with_transaction(&pool, move |conn| {
-            Box::pin(async move {
-                sqlx::query(
-                    "INSERT INTO plans (id, number, title, origin, state, plan_type, \
-                     destructive_destination, items_total, items_applied, items_failed, \
-                     items_skipped, items_cancelled, items_pending, total_bytes_required, \
-                     created_at) \
-                     VALUES ('p1', 1, 'test', 'cleanup', 'draft', 'cleanup', 'archive', \
-                     0, 0, 0, 0, 0, 0, 0, '2026-01-01T00:00:00Z')",
-                )
-                .execute(&mut *conn)
-                .await?;
-                Ok(())
-            })
-        })
-        .await
-        .expect("with_transaction should commit on Ok");
-
-        let count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM plans").fetch_one(&pool).await.unwrap();
-        assert_eq!(count, 1, "the committed row must be visible after with_transaction returns");
-    }
-
-    #[tokio::test]
-    async fn with_transaction_rolls_back_on_err() {
-        let db = super::Database::in_memory().await.expect("in-memory connect");
-        db.migrate().await.expect("migrations");
-        let pool = db.pool().clone();
-
-        let result: DbResult<()> = with_transaction(&pool, move |conn| {
-            Box::pin(async move {
-                sqlx::query(
-                    "INSERT INTO plans (id, number, title, origin, state, plan_type, \
-                     destructive_destination, items_total, items_applied, items_failed, \
-                     items_skipped, items_cancelled, items_pending, total_bytes_required, \
-                     created_at) \
-                     VALUES ('p1', 1, 'test', 'cleanup', 'draft', 'cleanup', 'archive', \
-                     0, 0, 0, 0, 0, 0, 0, '2026-01-01T00:00:00Z')",
-                )
-                .execute(&mut *conn)
-                .await?;
-                // Force a failure after the write above so the whole transaction
-                // must roll back, not just this statement.
-                Err(DbError::NotFound("forced mid-sequence failure".to_owned()))
-            })
-        })
-        .await;
-
-        assert!(result.is_err(), "with_transaction must propagate the closure's error");
-        let count: i64 =
-            sqlx::query_scalar("SELECT COUNT(*) FROM plans").fetch_one(&pool).await.unwrap();
-        assert_eq!(count, 0, "the earlier write in the same transaction must have rolled back");
     }
 }

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -8,7 +8,10 @@
 //! to the `plans.origin` CHECK (spec 017 C5).
 //! Migration 0061 added `target_favourite` (spec 051 US2).
 
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+use std::future::Future;
+use std::pin::Pin;
+
+use sqlx::sqlite::{SqliteConnection, SqlitePool, SqlitePoolOptions};
 
 pub mod operation_state;
 /// Reference pattern for the centralized typed persistence layer (sea-query +
@@ -106,9 +109,50 @@ impl Database {
     }
 }
 
+/// Boxed, `Send` future returned by a [`with_transaction`] closure. A local
+/// alias rather than a `futures`-crate dependency — this is the only shape
+/// [`with_transaction`] needs.
+pub type TxFuture<'c, T> = Pin<Box<dyn Future<Output = DbResult<T>> + Send + 'c>>;
+
+/// Run `f` against one SQLite transaction: commits on `Ok`, rolls back on
+/// `Err` (via `sqlx::Transaction`'s `Drop` impl issuing `ROLLBACK`).
+///
+/// A boundary-safe way to obtain a `&mut SqliteConnection`; `sqlx::Transaction`
+/// itself never leaves `persistence_db` (`scripts/check-db-boundary.sh` seals
+/// `sqlx` to this crate). Suits a transaction body that only needs the
+/// connection itself (or owned/`Copy` captures) — the `for<'c> FnOnce(&'c mut
+/// SqliteConnection) -> TxFuture<'c, _>` bound is universally quantified over
+/// `'c`, so a closure capturing a caller-borrowed `&'a T` cannot satisfy it
+/// (the borrow checker would require `'a: 'static`). Composite `*_tx`
+/// repository functions whose transaction body needs borrowed input (e.g.
+/// `repositories::projects::create_project_tx`) instead open their own
+/// `pool.begin()`/`tx.commit()` directly — see
+/// `docs/development/duplication-and-abstraction-audit.md` T2-a.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] if the transaction cannot be opened or
+/// committed, or propagates `f`'s own error (in which case the transaction is
+/// rolled back).
+pub async fn with_transaction<T, F>(pool: &SqlitePool, f: F) -> DbResult<T>
+where
+    F: for<'c> FnOnce(&'c mut SqliteConnection) -> TxFuture<'c, T>,
+{
+    let mut tx = pool.begin().await?;
+    match f(&mut tx).await {
+        Ok(value) => {
+            tx.commit().await?;
+            Ok(value)
+        }
+        // `tx` is dropped here without a `commit()` call, which sqlx rolls
+        // back automatically.
+        Err(err) => Err(err),
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use super::CRATE_NAME;
+    use super::{with_transaction, DbError, DbResult, CRATE_NAME};
 
     #[test]
     fn exposes_crate_name() {
@@ -362,5 +406,67 @@ mod tests {
             has_override_filter.is_err(),
             "override_filter column must have been dropped from inbox_classification_evidence by 0047"
         );
+    }
+
+    // ── with_transaction: commit / rollback semantics ──────────────────────
+
+    #[tokio::test]
+    async fn with_transaction_commits_on_ok() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        db.migrate().await.expect("migrations");
+        let pool = db.pool().clone();
+
+        with_transaction(&pool, move |conn| {
+            Box::pin(async move {
+                sqlx::query(
+                    "INSERT INTO plans (id, number, title, origin, state, plan_type, \
+                     destructive_destination, items_total, items_applied, items_failed, \
+                     items_skipped, items_cancelled, items_pending, total_bytes_required, \
+                     created_at) \
+                     VALUES ('p1', 1, 'test', 'cleanup', 'draft', 'cleanup', 'archive', \
+                     0, 0, 0, 0, 0, 0, 0, '2026-01-01T00:00:00Z')",
+                )
+                .execute(&mut *conn)
+                .await?;
+                Ok(())
+            })
+        })
+        .await
+        .expect("with_transaction should commit on Ok");
+
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM plans").fetch_one(&pool).await.unwrap();
+        assert_eq!(count, 1, "the committed row must be visible after with_transaction returns");
+    }
+
+    #[tokio::test]
+    async fn with_transaction_rolls_back_on_err() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        db.migrate().await.expect("migrations");
+        let pool = db.pool().clone();
+
+        let result: DbResult<()> = with_transaction(&pool, move |conn| {
+            Box::pin(async move {
+                sqlx::query(
+                    "INSERT INTO plans (id, number, title, origin, state, plan_type, \
+                     destructive_destination, items_total, items_applied, items_failed, \
+                     items_skipped, items_cancelled, items_pending, total_bytes_required, \
+                     created_at) \
+                     VALUES ('p1', 1, 'test', 'cleanup', 'draft', 'cleanup', 'archive', \
+                     0, 0, 0, 0, 0, 0, 0, '2026-01-01T00:00:00Z')",
+                )
+                .execute(&mut *conn)
+                .await?;
+                // Force a failure after the write above so the whole transaction
+                // must roll back, not just this statement.
+                Err(DbError::NotFound("forced mid-sequence failure".to_owned()))
+            })
+        })
+        .await;
+
+        assert!(result.is_err(), "with_transaction must propagate the closure's error");
+        let count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM plans").fetch_one(&pool).await.unwrap();
+        assert_eq!(count, 0, "the earlier write in the same transaction must have rolled back");
     }
 }

--- a/crates/persistence/db/src/repositories/plans.rs
+++ b/crates/persistence/db/src/repositories/plans.rs
@@ -126,8 +126,9 @@ pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i
 
 /// Connection-level variant of [`insert_plan`]: takes `&mut SqliteConnection`
 /// (works against a plain connection or a `Transaction` deref) so composite
-/// `*_tx` functions elsewhere in this crate can compose it with other writes
-/// in one transaction. See `with_transaction` in the crate root.
+/// `*_tx` functions elsewhere in this crate (e.g.
+/// `repositories::projects::create_project_tx`) can compose it with other
+/// writes in one transaction.
 ///
 /// # Errors
 ///

--- a/crates/persistence/db/src/repositories/plans.rs
+++ b/crates/persistence/db/src/repositories/plans.rs
@@ -7,7 +7,7 @@
 
 use domain_core::ids::Timestamp;
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::{DbError, DbResult};
 
@@ -120,9 +120,25 @@ pub struct InsertPlanItem<'a> {
 ///
 /// Returns [`DbError::Database`] on constraint or connection failure.
 pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i64> {
+    let mut conn = pool.acquire().await?;
+    insert_plan_conn(&mut conn, plan).await
+}
+
+/// Connection-level variant of [`insert_plan`]: takes `&mut SqliteConnection`
+/// (works against a plain connection or a `Transaction` deref) so composite
+/// `*_tx` functions elsewhere in this crate can compose it with other writes
+/// in one transaction. See `with_transaction` in the crate root.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint or connection failure.
+pub(crate) async fn insert_plan_conn(
+    conn: &mut SqliteConnection,
+    plan: &InsertPlan<'_>,
+) -> DbResult<i64> {
     let now = Timestamp::now_iso();
     let number: i64 = sqlx::query_scalar("SELECT COALESCE(MAX(number), 0) + 1 FROM plans")
-        .fetch_one(pool)
+        .fetch_one(&mut *conn)
         .await?;
 
     sqlx::query(
@@ -143,7 +159,7 @@ pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i
     .bind(plan.parent_plan_id)
     .bind(plan.total_bytes_required)
     .bind(&now)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
 
     Ok(number)
@@ -155,6 +171,19 @@ pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i
 ///
 /// Returns [`DbError::Database`] on constraint or connection failure.
 pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> DbResult<()> {
+    let mut conn = pool.acquire().await?;
+    insert_plan_item_conn(&mut conn, item).await
+}
+
+/// Connection-level variant of [`insert_plan_item`]. See [`insert_plan_conn`].
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint or connection failure.
+pub(crate) async fn insert_plan_item_conn(
+    conn: &mut SqliteConnection,
+    item: &InsertPlanItem<'_>,
+) -> DbResult<()> {
     let now = Timestamp::now_iso();
     sqlx::query(
         "INSERT INTO plan_items (
@@ -181,7 +210,7 @@ pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> D
     .bind(item.source_id)
     .bind(item.category)
     .bind(&now)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
 
     // Update items_total and items_pending counters on the parent plan.
@@ -190,7 +219,7 @@ pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> D
          WHERE id = ?",
     )
     .bind(item.plan_id)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
 
     Ok(())
@@ -300,10 +329,25 @@ pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<P
 /// Returns [`DbError::NotFound`] if no plan with `plan_id` exists.
 /// Returns [`DbError::Database`] on connection failure.
 pub async fn update_plan_state(pool: &SqlitePool, plan_id: &str, state: &str) -> DbResult<()> {
+    let mut conn = pool.acquire().await?;
+    update_plan_state_conn(&mut conn, plan_id, state).await
+}
+
+/// Connection-level variant of [`update_plan_state`]. See [`insert_plan_conn`].
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no plan with `plan_id` exists.
+/// Returns [`DbError::Database`] on connection failure.
+pub(crate) async fn update_plan_state_conn(
+    conn: &mut SqliteConnection,
+    plan_id: &str,
+    state: &str,
+) -> DbResult<()> {
     let rows = sqlx::query("UPDATE plans SET state = ? WHERE id = ?")
         .bind(state)
         .bind(plan_id)
-        .execute(pool)
+        .execute(&mut *conn)
         .await?;
 
     if rows.rows_affected() == 0 {

--- a/crates/persistence/db/src/repositories/projects.rs
+++ b/crates/persistence/db/src/repositories/projects.rs
@@ -121,7 +121,7 @@ pub async fn insert_project(pool: &SqlitePool, data: &InsertProject<'_>) -> DbRe
 /// Connection-level variant of [`insert_project`]: takes `&mut SqliteConnection`
 /// (works against a plain connection or a `Transaction` deref) so composite
 /// `*_tx` functions (e.g. [`create_project_tx`]) can compose it with other
-/// writes in one transaction. See `with_transaction` in the crate root.
+/// writes in one transaction.
 ///
 /// # Errors
 ///
@@ -893,14 +893,9 @@ pub struct CreateProjectInput<'a> {
 /// failure rolls back everything; no half-built project is left behind (see
 /// `docs/development/duplication-and-abstraction-audit.md` T2-a).
 ///
-/// Composed via a direct `pool.begin()`/`tx.commit()` (matching every other
-/// multi-statement transaction in this crate, e.g. `plan_apply.rs`,
-/// [`replace_project_channels`]) rather than `crate::with_transaction`: that
-/// combinator's `for<'c> FnOnce(&'c mut SqliteConnection) -> TxFuture<'c, _>`
-/// closure is universally quantified over `'c`, so it cannot soundly capture
-/// `input`'s externally-borrowed `&str` fields (the borrow checker would
-/// require `input: 'static`). `with_transaction` stays available for callers
-/// whose transaction body doesn't need to capture caller-borrowed data.
+/// Composed via a direct `pool.begin()`/`tx.commit()`, matching every other
+/// multi-statement transaction in this crate (e.g. `plan_apply.rs`,
+/// [`replace_project_channels`]).
 ///
 /// # Errors
 ///

--- a/crates/persistence/db/src/repositories/projects.rs
+++ b/crates/persistence/db/src/repositories/projects.rs
@@ -8,8 +8,9 @@
 //! `project_sources` denormalize Inventory data at link time.
 
 use domain_core::ids::Timestamp;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
+use crate::repositories::plans::{self, InsertPlan, InsertPlanItem};
 use crate::{DbError, DbResult};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -113,6 +114,22 @@ type ProjectRowTuple = (
 ///
 /// Returns [`DbError::Database`] on constraint violation or query failure.
 pub async fn insert_project(pool: &SqlitePool, data: &InsertProject<'_>) -> DbResult<String> {
+    let mut conn = pool.acquire().await?;
+    insert_project_conn(&mut conn, data).await
+}
+
+/// Connection-level variant of [`insert_project`]: takes `&mut SqliteConnection`
+/// (works against a plain connection or a `Transaction` deref) so composite
+/// `*_tx` functions (e.g. [`create_project_tx`]) can compose it with other
+/// writes in one transaction. See `with_transaction` in the crate root.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violation or query failure.
+async fn insert_project_conn(
+    conn: &mut SqliteConnection,
+    data: &InsertProject<'_>,
+) -> DbResult<String> {
     let now = Timestamp::now_iso();
     sqlx::query(
         "INSERT INTO projects (id, name, tool, lifecycle, path, notes, canonical_target_id, channel_drift, created_at, updated_at)
@@ -127,7 +144,7 @@ pub async fn insert_project(pool: &SqlitePool, data: &InsertProject<'_>) -> DbRe
     .bind(data.canonical_target_id)
     .bind(&now)
     .bind(&now)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
     Ok(now)
 }
@@ -613,6 +630,20 @@ pub async fn insert_project_source(
     pool: &SqlitePool,
     data: &InsertProjectSource<'_>,
 ) -> DbResult<()> {
+    let mut conn = pool.acquire().await?;
+    insert_project_source_conn(&mut conn, data).await
+}
+
+/// Connection-level variant of [`insert_project_source`]. See
+/// [`insert_project_conn`].
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violation or query failure.
+async fn insert_project_source_conn(
+    conn: &mut SqliteConnection,
+    data: &InsertProjectSource<'_>,
+) -> DbResult<()> {
     sqlx::query(
         "INSERT INTO project_sources
             (id, project_id, inventory_session_id,
@@ -627,7 +658,7 @@ pub async fn insert_project_source(
     .bind(data.filter_snapshot)
     .bind(data.exposure_snapshot)
     .bind(data.linked_at)
-    .execute(pool)
+    .execute(&mut *conn)
     .await?;
     Ok(())
 }
@@ -811,6 +842,100 @@ pub async fn list_project_channels(
         .collect())
 }
 
+/// Insert a single project-channel row (no delete). Only used by
+/// [`create_project_tx`]: a brand-new project has no prior channel rows, so
+/// the delete-then-insert [`replace_project_channels`] does is unnecessary.
+async fn insert_project_channel_conn(
+    conn: &mut SqliteConnection,
+    project_id: &str,
+    label: &str,
+    source: &str,
+    added_at: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO project_channels (project_id, label, source, added_at)
+         VALUES (?, ?, ?, ?)",
+    )
+    .bind(project_id)
+    .bind(label)
+    .bind(source)
+    .bind(added_at)
+    .execute(&mut *conn)
+    .await?;
+    Ok(())
+}
+
+// ── Composite atomic create (T2-a) ──────────────────────────────────────────
+
+/// Input for [`create_project_tx`]: the project row, its initial source
+/// links, inferred channels, and the Constitution II folder-structure plan —
+/// everything `app_projects::project_setup::create` must persist as one
+/// atomic unit.
+///
+/// Folder-plan item resolution (`project_structure::required_folders`) stays
+/// in the app layer; this struct only carries the already-resolved plan rows,
+/// so `persistence_db` does not gain a dependency on `project_structure`.
+pub struct CreateProjectInput<'a> {
+    pub project: InsertProject<'a>,
+    pub sources: &'a [InsertProjectSource<'a>],
+    /// `(label, source)` pairs, already inferred by
+    /// `domain_core::project::channels` (persistence does not infer).
+    pub channels: &'a [(&'a str, &'a str)],
+    /// Timestamp shared by every channel row's `added_at`.
+    pub channels_added_at: &'a str,
+    pub plan: InsertPlan<'a>,
+    pub plan_items: &'a [InsertPlanItem<'a>],
+}
+
+/// Atomically create a project: the project row, its initial source links,
+/// inferred channels, and the Constitution II folder-structure plan (+ items,
+/// advanced to `ready_for_review`) — all in one transaction. A mid-sequence
+/// failure rolls back everything; no half-built project is left behind (see
+/// `docs/development/duplication-and-abstraction-audit.md` T2-a).
+///
+/// Composed via a direct `pool.begin()`/`tx.commit()` (matching every other
+/// multi-statement transaction in this crate, e.g. `plan_apply.rs`,
+/// [`replace_project_channels`]) rather than `crate::with_transaction`: that
+/// combinator's `for<'c> FnOnce(&'c mut SqliteConnection) -> TxFuture<'c, _>`
+/// closure is universally quantified over `'c`, so it cannot soundly capture
+/// `input`'s externally-borrowed `&str` fields (the borrow checker would
+/// require `input: 'static`). `with_transaction` stays available for callers
+/// whose transaction body doesn't need to capture caller-borrowed data.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violation or query failure.
+/// On error the transaction is rolled back and no rows from this call persist.
+pub async fn create_project_tx(pool: &SqlitePool, input: &CreateProjectInput<'_>) -> DbResult<()> {
+    let mut tx = pool.begin().await?;
+
+    insert_project_conn(&mut tx, &input.project).await?;
+
+    for source in input.sources {
+        insert_project_source_conn(&mut tx, source).await?;
+    }
+
+    for (label, source) in input.channels {
+        insert_project_channel_conn(
+            &mut tx,
+            input.project.id,
+            label,
+            source,
+            input.channels_added_at,
+        )
+        .await?;
+    }
+
+    plans::insert_plan_conn(&mut tx, &input.plan).await?;
+    for item in input.plan_items {
+        plans::insert_plan_item_conn(&mut tx, item).await?;
+    }
+    plans::update_plan_state_conn(&mut tx, input.plan.id, "ready_for_review").await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -976,5 +1101,159 @@ mod tests {
         assert_eq!(affected, 1);
         let sources = list_project_sources(db.pool(), "p1").await.unwrap();
         assert!(sources.is_empty());
+    }
+
+    // ── create_project_tx: atomicity (T2-a) ────────────────────────────────
+
+    #[tokio::test]
+    async fn create_project_tx_persists_project_sources_channels_and_plan() {
+        let db = setup().await;
+        let sources = [InsertProjectSource {
+            id: "src-1",
+            project_id: "px",
+            inventory_session_id: "inv-1",
+            name_snapshot: "",
+            frames_snapshot: 0,
+            filter_snapshot: "",
+            exposure_snapshot: "",
+            linked_at: "2026-01-01T00:00:00Z",
+        }];
+        let plan_items = [InsertPlanItem {
+            id: "item-1",
+            plan_id: "plan-x",
+            item_index: 0,
+            name: "lights",
+            action: "mkdir",
+            from_root_id: None,
+            from_relative_path: "",
+            to_root_id: None,
+            to_relative_path: "projects/px/lights",
+            reason: "Create project sub-folder",
+            protection: "normal",
+            linked_entity: Some("px"),
+            provenance_json: None,
+            archive_path: None,
+            source_id: None,
+            category: None,
+        }];
+        let input = CreateProjectInput {
+            project: project_a("px"),
+            sources: &sources,
+            channels: &[("Ha", "inferred")],
+            channels_added_at: "2026-01-01T00:00:00Z",
+            plan: InsertPlan {
+                id: "plan-x",
+                title: "Create project folder structure",
+                origin: "project",
+                origin_path: Some("projects/px"),
+                plan_type: "project_create",
+                destructive_destination: "archive",
+                parent_plan_id: None,
+                total_bytes_required: 0,
+            },
+            plan_items: &plan_items,
+        };
+
+        create_project_tx(db.pool(), &input).await.unwrap();
+
+        let row = get_project(db.pool(), "px").await.unwrap();
+        assert_eq!(row.name, "NGC 7000 NB");
+        let sources = list_project_sources(db.pool(), "px").await.unwrap();
+        assert_eq!(sources.len(), 1);
+        let channels = list_project_channels(db.pool(), "px").await.unwrap();
+        assert_eq!(channels.len(), 1);
+        let plan = crate::repositories::plans::get_plan(db.pool(), "plan-x", false).await.unwrap();
+        assert_eq!(plan.state, "ready_for_review");
+        let items = crate::repositories::plans::list_plan_items(db.pool(), "plan-x").await.unwrap();
+        assert_eq!(items.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn create_project_tx_rolls_back_all_writes_on_mid_sequence_failure() {
+        let db = setup().await;
+        // Two sources sharing the same primary key: the second insert violates
+        // `project_sources.id`'s PRIMARY KEY, forcing a failure *after* the
+        // project row and the first source row have already been written
+        // inside the same transaction.
+        let sources = [
+            InsertProjectSource {
+                id: "dupe-src",
+                project_id: "px",
+                inventory_session_id: "inv-1",
+                name_snapshot: "",
+                frames_snapshot: 0,
+                filter_snapshot: "",
+                exposure_snapshot: "",
+                linked_at: "2026-01-01T00:00:00Z",
+            },
+            InsertProjectSource {
+                id: "dupe-src",
+                project_id: "px",
+                inventory_session_id: "inv-2",
+                name_snapshot: "",
+                frames_snapshot: 0,
+                filter_snapshot: "",
+                exposure_snapshot: "",
+                linked_at: "2026-01-01T00:00:00Z",
+            },
+        ];
+        let plan_items: [InsertPlanItem; 0] = [];
+        let input = CreateProjectInput {
+            project: project_a("px"),
+            sources: &sources,
+            channels: &[("Ha", "inferred")],
+            channels_added_at: "2026-01-01T00:00:00Z",
+            plan: InsertPlan {
+                id: "plan-x",
+                title: "Create project folder structure",
+                origin: "project",
+                origin_path: Some("projects/px"),
+                plan_type: "project_create",
+                destructive_destination: "archive",
+                parent_plan_id: None,
+                total_bytes_required: 0,
+            },
+            plan_items: &plan_items,
+        };
+
+        let err = create_project_tx(db.pool(), &input).await.unwrap_err();
+        assert!(matches!(err, DbError::Database(_)), "expected a UNIQUE constraint violation");
+
+        // Full rollback: neither the project row, the first (successfully
+        // inserted-then-rolled-back) source row, the channel row, nor the plan
+        // row — none of which were ever reached after the failing statement —
+        // may persist.
+        let project_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM projects WHERE id = ?")
+            .bind("px")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(
+            project_count, 0,
+            "the project row must not persist after a mid-sequence failure"
+        );
+
+        let source_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM project_sources WHERE project_id = ?")
+                .bind("px")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(source_count, 0, "no partial source rows may persist");
+
+        let channel_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM project_channels WHERE project_id = ?")
+                .bind("px")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(channel_count, 0, "no channel rows may persist");
+
+        let plan_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM plans WHERE id = ?")
+            .bind("plan-x")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(plan_count, 0, "the plan row (never reached) must not persist");
     }
 }


### PR DESCRIPTION
## Summary
- Project creation now runs as a single atomic database transaction, so a failure partway through no longer leaves an orphaned or partially-created project in the library.
- Removes a leftover unused transaction combinator introduced during this work.

## Spec Context
Run: run-dab, node: n3_atomictx.