### PR TITLE
refactor: dedup calibration matching, session key parsing, and target/audit repository queries

### DIFF
--- a/crates/calibration/core/src/assign.rs
+++ b/crates/calibration/core/src/assign.rs
@@ -106,28 +106,35 @@ pub fn evaluate_assign(
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
 /// Collect dimensions with hard-rule violations for the given master type.
+///
+/// Uses [`crate::rules::hard_rule_numeric`] / [`crate::rules::hard_rule_string`]
+/// — the same exact-match-or-exclude policy the `rules::{bias,dark,flat}`
+/// evaluators apply — so an assign override's violation list always agrees
+/// with what `suggest` would have excluded.
 fn collect_hard_violations(session: &SessionInfo, master: &MasterInfo) -> Vec<Dimension> {
+    use crate::rules::{hard_rule_numeric, hard_rule_string};
+
     let mut violations = Vec::new();
     match master.kind {
         CalibrationKind::Dark | CalibrationKind::Bias => {
-            if !exact_f64(session.gain, master.gain) {
+            if !hard_rule_numeric(session.gain, master.gain) {
                 violations.push(Dimension::Gain);
             }
-            if !exact_f64(session.offset, master.offset) {
+            if !hard_rule_numeric(session.offset, master.offset) {
                 violations.push(Dimension::Offset);
             }
         }
         CalibrationKind::Flat => {
-            if !exact_string(session.filter.as_deref(), master.filter.as_deref()) {
+            if !hard_rule_string(session.filter.as_deref(), master.filter.as_deref()) {
                 violations.push(Dimension::Filter);
             }
-            if !exact_string(session.binning.as_deref(), master.binning.as_deref()) {
+            if !hard_rule_string(session.binning.as_deref(), master.binning.as_deref()) {
                 violations.push(Dimension::Binning);
             }
-            if !exact_string(session.optic_train.as_deref(), master.optic_train.as_deref()) {
+            if !hard_rule_string(session.optic_train.as_deref(), master.optic_train.as_deref()) {
                 violations.push(Dimension::OpticTrain);
             }
-            if !exact_f64(session.gain, master.gain) {
+            if !hard_rule_numeric(session.gain, master.gain) {
                 violations.push(Dimension::Gain);
             }
         }
@@ -137,20 +144,6 @@ fn collect_hard_violations(session: &SessionInfo, master: &MasterInfo) -> Vec<Di
         }
     }
     violations
-}
-
-fn exact_f64(lhs: Option<f64>, rhs: Option<f64>) -> bool {
-    match (lhs, rhs) {
-        (Some(lv), Some(rv)) => (lv - rv).abs() < 1e-9,
-        _ => false,
-    }
-}
-
-fn exact_string(lhs: Option<&str>, rhs: Option<&str>) -> bool {
-    match (lhs, rhs) {
-        (Some(lv), Some(rv)) => lv == rv,
-        _ => false,
-    }
 }
 
 fn override_penalty_for(kind: CalibrationKind, config: &MatchingRuleConfig) -> f64 {

--- a/crates/calibration/core/src/rules/bias.rs
+++ b/crates/calibration/core/src/rules/bias.rs
@@ -29,17 +29,10 @@ pub fn evaluate(
     let mut confidence = 1.0_f64;
 
     // ── Hard rule: gain ───────────────────────────────────────────────────────
-    match (session.gain, master.gain) {
-        (Some(sg), Some(mg)) => {
-            if (sg - mg).abs() < 1e-9 {
-                matched.push(MatchedDim::exact(Dimension::Gain));
-            } else {
-                return None;
-            }
-        }
-        _ => {
-            return None;
-        }
+    if crate::rules::hard_rule_numeric(session.gain, master.gain) {
+        matched.push(MatchedDim::exact(Dimension::Gain));
+    } else {
+        return None;
     }
 
     // ── Hard rule: offset (controlled by config.require_same_offset) ─────────
@@ -47,7 +40,7 @@ pub fn evaluate(
     // Mirrors the dark rule: strict by default, relaxable via policy flag.
     match (session.offset, master.offset) {
         (Some(so), Some(mo)) => {
-            if (so - mo).abs() < 1e-9 {
+            if (so - mo).abs() < crate::rules::HARD_RULE_EPSILON {
                 matched.push(MatchedDim::exact(Dimension::Offset));
             } else if config.require_same_offset {
                 return None;

--- a/crates/calibration/core/src/rules/dark.rs
+++ b/crates/calibration/core/src/rules/dark.rs
@@ -27,19 +27,11 @@ pub fn evaluate(
     let mut confidence = 1.0_f64;
 
     // ── Hard rule: gain ───────────────────────────────────────────────────────
-    match (session.gain, master.gain) {
-        (Some(sg), Some(mg)) => {
-            if (sg - mg).abs() < 1e-9 {
-                matched.push(MatchedDim::exact(Dimension::Gain));
-            } else {
-                // Hard rule violation — exclude candidate.
-                return None;
-            }
-        }
-        _ => {
-            // Missing metadata on either side — hard rule cannot be satisfied.
-            return None;
-        }
+    if crate::rules::hard_rule_numeric(session.gain, master.gain) {
+        matched.push(MatchedDim::exact(Dimension::Gain));
+    } else {
+        // Hard rule violation, or missing metadata on either side — exclude.
+        return None;
     }
 
     // ── Hard rule: offset (controlled by config.require_same_offset) ─────────
@@ -50,7 +42,7 @@ pub fn evaluate(
     // and reduces confidence rather than excluding the candidate entirely.
     match (session.offset, master.offset) {
         (Some(so), Some(mo)) => {
-            if (so - mo).abs() < 1e-9 {
+            if (so - mo).abs() < crate::rules::HARD_RULE_EPSILON {
                 matched.push(MatchedDim::exact(Dimension::Offset));
             } else if config.require_same_offset {
                 return None;

--- a/crates/calibration/core/src/rules/flat.rs
+++ b/crates/calibration/core/src/rules/flat.rs
@@ -32,63 +32,34 @@ pub fn evaluate(
     let mut confidence = 1.0_f64;
 
     // ── Hard rule: filter ─────────────────────────────────────────────────────
-    match (&session.filter, &master.filter) {
-        (Some(sf), Some(mf)) => {
-            if sf == mf {
-                matched.push(MatchedDim::exact_string(Dimension::Filter, sf));
-            } else {
-                return None;
-            }
+    match (session.filter.as_deref(), master.filter.as_deref()) {
+        (Some(sf), Some(mf)) if crate::rules::hard_rule_string(Some(sf), Some(mf)) => {
+            matched.push(MatchedDim::exact_string(Dimension::Filter, sf));
         }
-        (None, _) | (_, None) => {
-            // Missing filter metadata — hard rule cannot be satisfied.
-            mismatched.push(MismatchedDim::metadata_missing(Dimension::Filter));
-            return None;
-        }
+        _ => return None,
     }
 
     // ── Hard rule: binning ────────────────────────────────────────────────────
-    match (&session.binning, &master.binning) {
-        (Some(sb), Some(mb)) => {
-            if sb == mb {
-                matched.push(MatchedDim::exact_string(Dimension::Binning, sb));
-            } else {
-                return None;
-            }
+    match (session.binning.as_deref(), master.binning.as_deref()) {
+        (Some(sb), Some(mb)) if crate::rules::hard_rule_string(Some(sb), Some(mb)) => {
+            matched.push(MatchedDim::exact_string(Dimension::Binning, sb));
         }
-        _ => {
-            mismatched.push(MismatchedDim::metadata_missing(Dimension::Binning));
-            return None;
-        }
+        _ => return None,
     }
 
     // ── Hard rule: optic_train ────────────────────────────────────────────────
-    match (&session.optic_train, &master.optic_train) {
-        (Some(st), Some(mt)) => {
-            if st == mt {
-                matched.push(MatchedDim::exact_string(Dimension::OpticTrain, st));
-            } else {
-                return None;
-            }
+    match (session.optic_train.as_deref(), master.optic_train.as_deref()) {
+        (Some(st), Some(mt)) if crate::rules::hard_rule_string(Some(st), Some(mt)) => {
+            matched.push(MatchedDim::exact_string(Dimension::OpticTrain, st));
         }
-        _ => {
-            mismatched.push(MismatchedDim::metadata_missing(Dimension::OpticTrain));
-            return None;
-        }
+        _ => return None,
     }
 
     // ── Hard rule: gain (exact, no tolerance — 2026-05-23 decision) ───────────
-    match (session.gain, master.gain) {
-        (Some(sg), Some(mg)) => {
-            if (sg - mg).abs() < 1e-9 {
-                matched.push(MatchedDim::exact(Dimension::Gain));
-            } else {
-                return None;
-            }
-        }
-        _ => {
-            return None;
-        }
+    if crate::rules::hard_rule_numeric(session.gain, master.gain) {
+        matched.push(MatchedDim::exact(Dimension::Gain));
+    } else {
+        return None;
     }
 
     // ── Soft rule: rotation ───────────────────────────────────────────────────

--- a/crates/calibration/core/src/rules/mod.rs
+++ b/crates/calibration/core/src/rules/mod.rs
@@ -2,3 +2,27 @@
 pub mod bias;
 pub mod dark;
 pub mod flat;
+
+/// Float-equality tolerance for hard-rule numeric dimensions (gain, offset).
+/// Guards against floating-point representation noise from FITS/XISF header
+/// parsing — this is not a tuning knob (unlike the soft-dimension tolerances
+/// in [`crate::ranking::MatchingRuleConfig`]).
+pub const HARD_RULE_EPSILON: f64 = 1e-9;
+
+/// Hard-rule numeric dimension check shared by the gain/offset comparisons in
+/// `bias`/`dark`/`flat` and by `assign::collect_hard_violations`: `true` only
+/// when both values are present and equal within [`HARD_RULE_EPSILON`].
+/// Missing either side always excludes.
+#[must_use]
+pub fn hard_rule_numeric(session_val: Option<f64>, master_val: Option<f64>) -> bool {
+    matches!((session_val, master_val), (Some(s), Some(m)) if (s - m).abs() < HARD_RULE_EPSILON)
+}
+
+/// Hard-rule string dimension check shared by the filter/binning/optic_train
+/// comparisons in `flat` and by `assign::collect_hard_violations`: `true`
+/// only when both values are present and exactly equal. Missing either side
+/// always excludes.
+#[must_use]
+pub fn hard_rule_string(session_val: Option<&str>, master_val: Option<&str>) -> bool {
+    matches!((session_val, master_val), (Some(s), Some(m)) if s == m)
+}

--- a/crates/persistence/db/src/repositories/audit.rs
+++ b/crates/persistence/db/src/repositories/audit.rs
@@ -25,7 +25,7 @@ use crate::DbResult;
 /// One row from `audit_log_entry`, as stored (no enum parsing — that is a
 /// concern of the IPC/contract layer, which maps these strings onto the
 /// `AuditActor`/`AuditOutcome` contract enums).
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, sqlx::FromRow)]
 pub struct AuditLogRow {
     pub audit_id: String,
     pub entity_type: String,
@@ -156,62 +156,12 @@ pub async fn list_audit_entries(
     // fragments in `build_where`; every user-supplied value flows through a
     // `?` placeholder bound below. `limit`/`offset` are integer literals
     // derived from typed `u32` filter fields, never user strings.
-    #[allow(clippy::type_complexity)]
-    let mut q = sqlx::query_as::<
-        _,
-        (
-            String,
-            String,
-            String,
-            Option<String>,
-            Option<String>,
-            String,
-            String,
-            String,
-            String,
-            String,
-            String,
-            Option<String>,
-        ),
-    >(sqlx::AssertSqlSafe(sql));
+    let mut q = sqlx::query_as::<_, AuditLogRow>(sqlx::AssertSqlSafe(sql));
     for v in &binds {
         q = q.bind(v);
     }
 
-    let raw = q.fetch_all(pool).await?;
-
-    Ok(raw
-        .into_iter()
-        .map(
-            |(
-                audit_id,
-                entity_type,
-                entity_id,
-                from_state,
-                to_state,
-                trigger,
-                actor,
-                outcome,
-                severity,
-                request_id,
-                at,
-                payload,
-            )| AuditLogRow {
-                audit_id,
-                entity_type,
-                entity_id,
-                from_state,
-                to_state,
-                trigger,
-                actor,
-                outcome,
-                severity,
-                request_id,
-                at,
-                payload,
-            },
-        )
-        .collect())
+    Ok(q.fetch_all(pool).await?)
 }
 
 /// Count `audit_log_entry` rows matching `filter` (ignores `limit`/`offset`).

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -847,50 +847,48 @@ pub async fn set_overrides(
     };
 
     // Step 3: upsert non-type overrides into inbox_file_overrides.
-    if true {
-        let sg_id = &source_group_id;
-        let now = time::OffsetDateTime::now_utc()
-            .format(&time::format_description::well_known::Rfc3339)
-            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let sg_id = &source_group_id;
+    let now = time::OffsetDateTime::now_utc()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
 
-        // Helper: upsert a single property_key/value pair.
-        // Uses INSERT OR REPLACE so subsequent set_overrides calls overwrite.
-        let upsert_override = |key: &'static str, val: String| {
-            let id = Uuid::new_v4().to_string();
-            let sg = sg_id.clone();
-            let rfp = relative_file_path.to_owned();
-            let ts = now.clone();
-            async move {
-                sqlx::query(
-                    "INSERT INTO inbox_file_overrides \
-                     (id, source_group_id, relative_file_path, property_key, value, \
-                      override_stale, set_at) \
-                     VALUES (?, ?, ?, ?, ?, 0, ?) \
-                     ON CONFLICT(source_group_id, relative_file_path, property_key) \
-                     DO UPDATE SET value = excluded.value, \
-                                   override_stale = 0, \
-                                   set_at = excluded.set_at",
-                )
-                .bind(id)
-                .bind(sg)
-                .bind(rfp)
-                .bind(key)
-                .bind(val)
-                .bind(ts)
-                .execute(pool)
-                .await
-            }
-        };
+    // Helper: upsert a single property_key/value pair.
+    // Uses INSERT OR REPLACE so subsequent set_overrides calls overwrite.
+    let upsert_override = |key: &'static str, val: String| {
+        let id = Uuid::new_v4().to_string();
+        let sg = sg_id.clone();
+        let rfp = relative_file_path.to_owned();
+        let ts = now.clone();
+        async move {
+            sqlx::query(
+                "INSERT INTO inbox_file_overrides \
+                 (id, source_group_id, relative_file_path, property_key, value, \
+                  override_stale, set_at) \
+                 VALUES (?, ?, ?, ?, ?, 0, ?) \
+                 ON CONFLICT(source_group_id, relative_file_path, property_key) \
+                 DO UPDATE SET value = excluded.value, \
+                               override_stale = 0, \
+                               set_at = excluded.set_at",
+            )
+            .bind(id)
+            .bind(sg)
+            .bind(rfp)
+            .bind(key)
+            .bind(val)
+            .bind(ts)
+            .execute(pool)
+            .await
+        }
+    };
 
-        if let Some(f) = filter {
-            upsert_override("filter", f.to_owned()).await?;
-        }
-        if let Some(e) = exposure_s {
-            upsert_override("exposureS", e.to_string()).await?;
-        }
-        if let Some(b) = binning {
-            upsert_override("binning", b.to_owned()).await?;
-        }
+    if let Some(f) = filter {
+        upsert_override("filter", f.to_owned()).await?;
+    }
+    if let Some(e) = exposure_s {
+        upsert_override("exposureS", e.to_string()).await?;
+    }
+    if let Some(b) = binning {
+        upsert_override("binning", b.to_owned()).await?;
     }
 
     Ok(rows > 0)

--- a/crates/persistence/db/src/repositories/q_desktop.rs
+++ b/crates/persistence/db/src/repositories/q_desktop.rs
@@ -197,14 +197,7 @@ pub async fn count_calibration_masters(pool: &SqlitePool) -> DbResult<i64> {
 }
 
 /// Count all `canonical_target` rows.
-///
-/// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
-pub async fn count_canonical_targets(pool: &SqlitePool) -> DbResult<i64> {
-    let count: i64 =
-        sqlx::query_scalar("SELECT COUNT(*) FROM canonical_target").fetch_one(pool).await?;
-    Ok(count)
-}
+pub use super::q_resolver::count_canonical_targets;
 
 /// Count all `projects` rows.
 ///
@@ -220,26 +213,14 @@ pub async fn count_projects(pool: &SqlitePool) -> DbResult<i64> {
 /// Singleton `resolver_settings` row (id = 1): online toggle, SIMBAD
 /// endpoint, and request timeout, read by both `target.resolve` and the
 /// background ingest-resolution drain.
-#[derive(Debug, Clone, sqlx::FromRow)]
-pub struct ResolverSettingsRow {
-    pub online_enabled: i64,
-    pub simbad_endpoint: String,
-    pub request_timeout_secs: i64,
-}
+///
+/// Same query as [`super::q_targets_mgmt::ResolverSettingsOnlineRow`] /
+/// `get_resolver_settings_online`; re-exported here under this module's
+/// established name so `target_lookup.rs`/`lib.rs` are unaffected.
+pub use super::q_targets_mgmt::ResolverSettingsOnlineRow as ResolverSettingsRow;
 
 /// Fetch the singleton `resolver_settings` row (id = 1).
-///
-/// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
-pub async fn get_resolver_settings(pool: &SqlitePool) -> DbResult<Option<ResolverSettingsRow>> {
-    let row = sqlx::query_as::<_, ResolverSettingsRow>(
-        "SELECT online_enabled, simbad_endpoint, request_timeout_secs \
-         FROM resolver_settings WHERE id = 1",
-    )
-    .fetch_optional(pool)
-    .await?;
-    Ok(row)
-}
+pub use super::q_targets_mgmt::get_resolver_settings_online as get_resolver_settings;
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
 

--- a/crates/persistence/db/src/repositories/target_favourites.rs
+++ b/crates/persistence/db/src/repositories/target_favourites.rs
@@ -12,20 +12,10 @@ use sqlx::SqlitePool;
 
 use crate::DbResult;
 
-/// Returns `true` when `target_id` references an existing `canonical_target`
-/// row. Used by the `targets.favourites.add` use case to distinguish
-/// `target.not_found` from a genuine database error before inserting.
-///
-/// # Errors
-///
-/// Returns [`crate::DbError::Database`] on query failure.
-pub async fn target_exists(pool: &SqlitePool, target_id: &str) -> DbResult<bool> {
-    let row: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
-        .bind(target_id)
-        .fetch_optional(pool)
-        .await?;
-    Ok(row.is_some())
-}
+/// Whether a `canonical_target` row exists for `target_id`. Used by the
+/// `targets.favourites.add` use case to distinguish `target.not_found` from a
+/// genuine database error before inserting.
+pub use super::q_targets_mgmt::target_exists;
 
 /// Read back the stored `favourited_at` for `target_id`, or `None` if the
 /// target is not currently favourited.

--- a/crates/sessions/src/key.rs
+++ b/crates/sessions/src/key.rs
@@ -7,7 +7,7 @@
 //! the spec-018 settings field rather than guessing.
 
 use thiserror::Error;
-use time::{Date, Month, OffsetDateTime, UtcOffset};
+use time::{Date, OffsetDateTime, UtcOffset};
 
 /// Observer location subset needed for the night calculation.
 #[derive(Clone, Debug)]
@@ -71,25 +71,8 @@ fn previous_day(d: Date) -> Date {
 }
 
 fn format_date_iso(d: Date) -> String {
-    let month = month_number(d.month());
+    let month = u8::from(d.month());
     format!("{:04}-{:02}-{:02}", d.year(), month, d.day())
-}
-
-const fn month_number(m: Month) -> u8 {
-    match m {
-        Month::January => 1,
-        Month::February => 2,
-        Month::March => 3,
-        Month::April => 4,
-        Month::May => 5,
-        Month::June => 6,
-        Month::July => 7,
-        Month::August => 8,
-        Month::September => 9,
-        Month::October => 10,
-        Month::November => 11,
-        Month::December => 12,
-    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Extracts the shared hard-rule epsilon and match helpers used across the bias/dark/flat calibration rules into one place.
- Replaces a hand-rolled month-number lookup in session key parsing with the time crate's Month conversion.
- Dedups target_exists/count_canonical_targets/resolver-settings queries and simplifies tuple-mapped audit row handling in the persistence layer.

No behavior change.

## Spec Context
Run: run-dab, node: n7_dedup.