### PR TITLE
fix: target management/favourites errors no longer fail client-side validation

### DIFF
--- a/apps/desktop/src-tauri/src/commands/target_favourites.rs
+++ b/apps/desktop/src-tauri/src/commands/target_favourites.rs
@@ -13,8 +13,9 @@
 
 use contracts_core::targets::{
     TargetFavouriteAddResult, TargetFavouriteRemoveResult, TargetFavouriteRequest,
-    TargetFavouritesListResult, TargetOpError,
+    TargetFavouritesListResult,
 };
+use contracts_core::ContractError;
 use tauri::State;
 
 use crate::commands::lifecycle::AppState;
@@ -26,12 +27,12 @@ use crate::commands::lifecycle::AppState;
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `internal.database`.
+/// Returns `Err(ContractError)` with code `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_favourites_list(
     state: State<'_, AppState>,
-) -> Result<TargetFavouritesListResult, TargetOpError> {
+) -> Result<TargetFavouritesListResult, ContractError> {
     tracing::debug!("targets.favourites.list");
     app_core::target_favourites::list(state.repo.pool()).await
 }
@@ -42,14 +43,14 @@ pub async fn target_favourites_list(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found` or
+/// Returns `Err(ContractError)` with code `target.not_found` or
 /// `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_favourites_add(
     state: State<'_, AppState>,
     req: TargetFavouriteRequest,
-) -> Result<TargetFavouriteAddResult, TargetOpError> {
+) -> Result<TargetFavouriteAddResult, ContractError> {
     tracing::debug!("targets.favourites.add target_id={}", req.target_id);
     app_core::target_favourites::add(state.repo.pool(), &req).await
 }
@@ -60,13 +61,13 @@ pub async fn target_favourites_add(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `internal.database`.
+/// Returns `Err(ContractError)` with code `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_favourites_remove(
     state: State<'_, AppState>,
     req: TargetFavouriteRequest,
-) -> Result<TargetFavouriteRemoveResult, TargetOpError> {
+) -> Result<TargetFavouriteRemoveResult, ContractError> {
     tracing::debug!("targets.favourites.remove target_id={}", req.target_id);
     app_core::target_favourites::remove(state.repo.pool(), &req).await
 }

--- a/apps/desktop/src-tauri/src/commands/target_management.rs
+++ b/apps/desktop/src-tauri/src/commands/target_management.rs
@@ -23,9 +23,10 @@ use contracts_core::targets::{
     TargetAliasAddRequest, TargetAliasAddResult, TargetAliasRemoveRequest, TargetAliasRemoveResult,
     TargetDetailV3, TargetDisplayAliasClearRequest, TargetDisplayAliasSetRequest, TargetGetRequest,
     TargetListItem, TargetNoteGetRequest, TargetNoteGetResult, TargetNoteUpdateRequest,
-    TargetNoteUpdateResult, TargetOpError, TargetProjectItem, TargetProjectsListRequest,
-    TargetSessionItem, TargetSessionsListRequest,
+    TargetNoteUpdateResult, TargetProjectItem, TargetProjectsListRequest, TargetSessionItem,
+    TargetSessionsListRequest,
 };
+use contracts_core::ContractError;
 use tauri::State;
 
 use crate::commands::lifecycle::AppState;
@@ -36,14 +37,14 @@ use crate::commands::lifecycle::AppState;
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_get(
     state: State<'_, AppState>,
     req: TargetGetRequest,
-) -> Result<TargetDetailV3, TargetOpError> {
+) -> Result<TargetDetailV3, ContractError> {
     tracing::debug!("target.get id={}", req.target_id);
     app_core::target_management::get(state.repo.pool(), &req).await
 }
@@ -54,10 +55,10 @@ pub async fn target_get(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `internal.database`.
+/// Returns `Err(ContractError)` with code `internal.database`.
 #[tauri::command]
 #[specta::specta]
-pub async fn target_list(state: State<'_, AppState>) -> Result<Vec<TargetListItem>, TargetOpError> {
+pub async fn target_list(state: State<'_, AppState>) -> Result<Vec<TargetListItem>, ContractError> {
     tracing::debug!("target.list");
     app_core::target_management::list(state.repo.pool()).await
 }
@@ -68,14 +69,14 @@ pub async fn target_list(state: State<'_, AppState>) -> Result<Vec<TargetListIte
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`, `alias.blank`,
+/// Returns `Err(ContractError)` with code `target.not_found`, `alias.blank`,
 /// or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_alias_add(
     state: State<'_, AppState>,
     req: TargetAliasAddRequest,
-) -> Result<TargetAliasAddResult, TargetOpError> {
+) -> Result<TargetAliasAddResult, ContractError> {
     tracing::debug!("target.alias.add target_id={} alias={:?}", req.target_id, req.alias);
     app_core::target_management::alias_add(state.repo.pool(), &req).await
 }
@@ -89,14 +90,14 @@ pub async fn target_alias_add(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `alias.not_found`,
+/// Returns `Err(ContractError)` with code `alias.not_found`,
 /// `alias.not_removable`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_alias_remove(
     state: State<'_, AppState>,
     req: TargetAliasRemoveRequest,
-) -> Result<TargetAliasRemoveResult, TargetOpError> {
+) -> Result<TargetAliasRemoveResult, ContractError> {
     tracing::debug!("target.alias.remove target_id={} alias_id={}", req.target_id, req.alias_id);
     app_core::target_management::alias_remove(state.repo.pool(), &req).await
 }
@@ -110,14 +111,14 @@ pub async fn target_alias_remove(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_display_alias_set(
     state: State<'_, AppState>,
     req: TargetDisplayAliasSetRequest,
-) -> Result<TargetDetailV3, TargetOpError> {
+) -> Result<TargetDetailV3, ContractError> {
     tracing::debug!(
         "target.display_alias.set target_id={} display_alias={:?}",
         req.target_id,
@@ -135,14 +136,14 @@ pub async fn target_display_alias_set(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_display_alias_clear(
     state: State<'_, AppState>,
     req: TargetDisplayAliasClearRequest,
-) -> Result<TargetDetailV3, TargetOpError> {
+) -> Result<TargetDetailV3, ContractError> {
     tracing::debug!("target.display_alias.clear target_id={}", req.target_id);
     app_core::target_management::display_alias_clear(state.repo.pool(), &req).await
 }
@@ -156,14 +157,14 @@ pub async fn target_display_alias_clear(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_sessions_list(
     state: State<'_, AppState>,
     req: TargetSessionsListRequest,
-) -> Result<Vec<TargetSessionItem>, TargetOpError> {
+) -> Result<Vec<TargetSessionItem>, ContractError> {
     tracing::debug!("target.sessions.list target_id={}", req.target_id);
     app_core::target_management::sessions_list(state.repo.pool(), &req).await
 }
@@ -177,14 +178,14 @@ pub async fn target_sessions_list(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_projects_list(
     state: State<'_, AppState>,
     req: TargetProjectsListRequest,
-) -> Result<Vec<TargetProjectItem>, TargetOpError> {
+) -> Result<Vec<TargetProjectItem>, ContractError> {
     tracing::debug!("target.projects.list target_id={}", req.target_id);
     app_core::target_management::projects_list(state.repo.pool(), &req).await
 }
@@ -197,14 +198,14 @@ pub async fn target_projects_list(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_note_get(
     state: State<'_, AppState>,
     req: TargetNoteGetRequest,
-) -> Result<TargetNoteGetResult, TargetOpError> {
+) -> Result<TargetNoteGetResult, ContractError> {
     tracing::debug!("target.note.get target_id={}", req.target_id);
     app_core::target_management::note_get(state.repo.pool(), &req).await
 }
@@ -217,14 +218,14 @@ pub async fn target_note_get(
 ///
 /// # Errors
 ///
-/// Returns `Err(TargetOpError)` with code `target.not_found`,
+/// Returns `Err(ContractError)` with code `target.not_found`,
 /// `target.invalid_id`, or `internal.database`.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_note_update(
     state: State<'_, AppState>,
     req: TargetNoteUpdateRequest,
-) -> Result<TargetNoteUpdateResult, TargetOpError> {
+) -> Result<TargetNoteUpdateResult, ContractError> {
     tracing::debug!("target.note.update target_id={} notes_len={}", req.target_id, req.notes.len());
     app_core::target_management::note_update(state.repo.pool(), &state.bus, &req).await
 }

--- a/apps/desktop/src/bindings/aliases.ts
+++ b/apps/desktop/src/bindings/aliases.ts
@@ -21,7 +21,6 @@ export type {
 
   // ── Targets gen-3 (spec 036) ──────────────────────────────────────────────
   TargetDetailV3_Deserialize as TargetDetailV3,
-  TargetOpError_Serialize as TargetOpError,
 
   // ── SIMBAD resolution (spec 035) ──────────────────────────────────────────
   // Request params → _Deserialize (what the backend deserializes from us);

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -154,27 +154,27 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetGet: (req: TargetGetRequest) => typedError<TargetDetailV3_Serialize, TargetOpError_Serialize>(__TAURI_INVOKE("target_get", { req })),
+	targetGet: (req: TargetGetRequest) => typedError<TargetDetailV3_Serialize, ContractError_Serialize>(__TAURI_INVOKE("target_get", { req })),
 	/**
 	 *  `target.list` — list all canonical targets ordered by primary designation.
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `internal.database`.
+	 *  Returns `Err(ContractError)` with code `internal.database`.
 	 */
-	targetList: () => typedError<TargetListItem_Serialize[], TargetOpError_Serialize>(__TAURI_INVOKE("target_list")),
+	targetList: () => typedError<TargetListItem_Serialize[], ContractError_Serialize>(__TAURI_INVOKE("target_list")),
 	/**
 	 *  `target.alias.add` — add a user alias to a canonical target (gen-3).
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`, `alias.blank`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`, `alias.blank`,
 	 *  or `internal.database`.
 	 */
-	targetAliasAdd: (req: TargetAliasAddRequest) => typedError<TargetAliasAddResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_alias_add", { req })),
+	targetAliasAdd: (req: TargetAliasAddRequest) => typedError<TargetAliasAddResult, ContractError_Serialize>(__TAURI_INVOKE("target_alias_add", { req })),
 	/**
 	 *  `target.alias.remove` — remove a user alias from a canonical target (gen-3).
 	 * 
@@ -183,10 +183,10 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `alias.not_found`,
+	 *  Returns `Err(ContractError)` with code `alias.not_found`,
 	 *  `alias.not_removable`, or `internal.database`.
 	 */
-	targetAliasRemove: (req: TargetAliasRemoveRequest) => typedError<TargetAliasRemoveResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_alias_remove", { req })),
+	targetAliasRemove: (req: TargetAliasRemoveRequest) => typedError<TargetAliasRemoveResult, ContractError_Serialize>(__TAURI_INVOKE("target_alias_remove", { req })),
 	/**
 	 *  `target.display_alias.set` — set the user presentation label (FR-012).
 	 * 
@@ -195,10 +195,10 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetDisplayAliasSet: (req: TargetDisplayAliasSetRequest) => typedError<TargetDetailV3_Serialize, TargetOpError_Serialize>(__TAURI_INVOKE("target_display_alias_set", { req })),
+	targetDisplayAliasSet: (req: TargetDisplayAliasSetRequest) => typedError<TargetDetailV3_Serialize, ContractError_Serialize>(__TAURI_INVOKE("target_display_alias_set", { req })),
 	/**
 	 *  `target.display_alias.clear` — clear the user presentation label (FR-012).
 	 * 
@@ -207,10 +207,10 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetDisplayAliasClear: (req: TargetDisplayAliasClearRequest) => typedError<TargetDetailV3_Serialize, TargetOpError_Serialize>(__TAURI_INVOKE("target_display_alias_clear", { req })),
+	targetDisplayAliasClear: (req: TargetDisplayAliasClearRequest) => typedError<TargetDetailV3_Serialize, ContractError_Serialize>(__TAURI_INVOKE("target_display_alias_clear", { req })),
 	/**
 	 *  `target.sessions.list` — list acquisition sessions linked to a canonical target.
 	 * 
@@ -219,10 +219,10 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetSessionsList: (req: TargetSessionsListRequest) => typedError<TargetSessionItem[], TargetOpError_Serialize>(__TAURI_INVOKE("target_sessions_list", { req })),
+	targetSessionsList: (req: TargetSessionsListRequest) => typedError<TargetSessionItem[], ContractError_Serialize>(__TAURI_INVOKE("target_sessions_list", { req })),
 	/**
 	 *  `target.projects.list` — list projects linked to a canonical target.
 	 * 
@@ -231,10 +231,10 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetProjectsList: (req: TargetProjectsListRequest) => typedError<TargetProjectItem[], TargetOpError_Serialize>(__TAURI_INVOKE("target_projects_list", { req })),
+	targetProjectsList: (req: TargetProjectsListRequest) => typedError<TargetProjectItem[], ContractError_Serialize>(__TAURI_INVOKE("target_projects_list", { req })),
 	/**
 	 *  `target.note.get` — read observing notes for a canonical target.
 	 * 
@@ -242,10 +242,10 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetNoteGet: (req: TargetNoteGetRequest) => typedError<TargetNoteGetResult_Serialize, TargetOpError_Serialize>(__TAURI_INVOKE("target_note_get", { req })),
+	targetNoteGet: (req: TargetNoteGetRequest) => typedError<TargetNoteGetResult_Serialize, ContractError_Serialize>(__TAURI_INVOKE("target_note_get", { req })),
 	/**
 	 *  `target.note.update` — write observing notes for a canonical target.
 	 * 
@@ -253,36 +253,36 @@ export const commands = {
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found`,
+	 *  Returns `Err(ContractError)` with code `target.not_found`,
 	 *  `target.invalid_id`, or `internal.database`.
 	 */
-	targetNoteUpdate: (req: TargetNoteUpdateRequest) => typedError<TargetNoteUpdateResult_Serialize, TargetOpError_Serialize>(__TAURI_INVOKE("target_note_update", { req })),
+	targetNoteUpdate: (req: TargetNoteUpdateRequest) => typedError<TargetNoteUpdateResult_Serialize, ContractError_Serialize>(__TAURI_INVOKE("target_note_update", { req })),
 	/**
 	 *  `targets.favourites.list` — list the ids of every currently-favourited
 	 *  canonical target.
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `internal.database`.
+	 *  Returns `Err(ContractError)` with code `internal.database`.
 	 */
-	targetFavouritesList: () => typedError<TargetFavouritesListResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_favourites_list")),
+	targetFavouritesList: () => typedError<TargetFavouritesListResult, ContractError_Serialize>(__TAURI_INVOKE("target_favourites_list")),
 	/**
 	 *  `targets.favourites.add` — favourite a canonical target. Idempotent.
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `target.not_found` or
+	 *  Returns `Err(ContractError)` with code `target.not_found` or
 	 *  `internal.database`.
 	 */
-	targetFavouritesAdd: (req: TargetFavouriteRequest) => typedError<TargetFavouriteAddResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_favourites_add", { req })),
+	targetFavouritesAdd: (req: TargetFavouriteRequest) => typedError<TargetFavouriteAddResult, ContractError_Serialize>(__TAURI_INVOKE("target_favourites_add", { req })),
 	/**
 	 *  `targets.favourites.remove` — unfavourite a canonical target. Idempotent.
 	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(TargetOpError)` with code `internal.database`.
+	 *  Returns `Err(ContractError)` with code `internal.database`.
 	 */
-	targetFavouritesRemove: (req: TargetFavouriteRequest) => typedError<TargetFavouriteRemoveResult, TargetOpError_Serialize>(__TAURI_INVOKE("target_favourites_remove", { req })),
+	targetFavouritesRemove: (req: TargetFavouriteRequest) => typedError<TargetFavouriteRemoveResult, ContractError_Serialize>(__TAURI_INVOKE("target_favourites_remove", { req })),
 	/**
 	 *  `target.resolve` — cache-first resolution of a designation / common name (or
 	 *  FITS OBJECT value) against the local cache + bundled seed, falling back to
@@ -2978,8 +2978,8 @@ export type ErrorCode = "validation.request_envelope_invalid" | "dev_mode.disabl
 /**  `plan.required` appears in `ContractError` in `transition_use_case.rs`. */
 "plan.required" | 
 /**
- *  Appears in `TargetOpError.code: String` (`target_management.rs`).
- *  Included per task instruction ("include when unsure — superset is safe").
+ *  Reserved: no current call site returns this — `target.alias.add`
+ *  resolves a duplicate idempotently rather than erroring.
  */
 "alias.duplicate" | "alias.blank" | "alias.not_found" | "alias.not_removable" | "target.not_found" | "target.invalid_id" | 
 /**
@@ -7818,25 +7818,6 @@ export type TargetNoteUpdateResult_Serialize = {
  *  Mapped uniformly from SIMBAD `otype`; unknown values map to `Other`.
  */
 export type TargetObjectType = "galaxy" | "planetary_nebula" | "emission_nebula" | "reflection_nebula" | "dark_nebula" | "open_cluster" | "globular_cluster" | "supernova_remnant" | "galaxy_cluster" | "double_star" | "asterism" | "other";
-
-/**  Generic error envelope for target operations (gen-3). */
-export type TargetOpError = TargetOpError_Serialize | TargetOpError_Deserialize;
-
-/**  Generic error envelope for target operations (gen-3). */
-export type TargetOpError_Deserialize = {
-	/**  Error code string (e.g. `"target.not_found"`, `"alias.duplicate"`). */
-	code: string,
-	message: string,
-	details: unknown | null,
-};
-
-/**  Generic error envelope for target operations (gen-3). */
-export type TargetOpError_Serialize = {
-	/**  Error code string (e.g. `"target.not_found"`, `"alias.duplicate"`). */
-	code: string,
-	message: string,
-	details?: unknown | null,
-};
 
 /**
  *  A linked project returned by `target.projects.list` (spec 023 US3).

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -27,7 +27,8 @@ import { X } from 'lucide-react';
 import { useNavigate, Link } from '@tanstack/react-router';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
-import type { TargetDetailV3, TargetOpError } from '@/bindings/aliases';
+import type { TargetDetailV3 } from '@/bindings/aliases';
+import type { ContractError } from '@/lib/errors';
 import type { TargetListItem } from '@/bindings/index';
 import type { TargetSessionItem, TargetProjectItem } from '@/bindings';
 import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
@@ -104,8 +105,8 @@ function fmtDec(deg: number): string {
   return `${sign}${String(dd).padStart(2, '0')}°${String(mm).padStart(2, '0')}′${ss.toFixed(0).padStart(2, '0')}″`;
 }
 
-/** Map TargetOpError.code to a user-readable message. */
-function errorMessage(err: TargetOpError, fallback: string): string {
+/** Map ContractError.code to a user-readable message. */
+function errorMessage(err: ContractError, fallback: string): string {
   switch (err.code) {
     case 'alias.blank':
       return m.targets_detail_alias_blank();
@@ -430,7 +431,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
       setAliasInput('');
       load();
     } catch (err) {
-      const e = err as TargetOpError;
+      const e = err as ContractError;
       setAliasError(errorMessage(e, m.targets_detail_add_alias_failed()));
     }
   }, [targetId, aliasInput, load]);
@@ -443,7 +444,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
         unwrap(await commands.targetAliasRemove({ targetId, aliasId }));
         load();
       } catch (err) {
-        const e = err as TargetOpError;
+        const e = err as ContractError;
         setActionError(errorMessage(e, m.targets_detail_remove_alias_failed()));
       }
     },
@@ -461,7 +462,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
       setDisplayAliasInput(data.displayAlias ?? '');
       setDisplayAliasEditing(false);
     } catch (err) {
-      const e = err as TargetOpError;
+      const e = err as ContractError;
       setActionError(errorMessage(e, m.targets_detail_set_display_alias_failed()));
     }
   }, [targetId, displayAliasInput]);
@@ -475,7 +476,7 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
       setDisplayAliasInput('');
       setDisplayAliasEditing(false);
     } catch (err) {
-      const e = err as TargetOpError;
+      const e = err as ContractError;
       setActionError(errorMessage(e, m.targets_detail_clear_display_alias_failed()));
     }
   }, [targetId]);

--- a/crates/app/targets/src/target_dto.rs
+++ b/crates/app/targets/src/target_dto.rs
@@ -6,7 +6,8 @@
 //! is pure consolidation with no behavior change.
 
 use contracts_core::targets::{TargetObjectType, TargetSource};
-use targeting_resolver::{ObjectType, TargetSource as CacheSource};
+use targeting_resolver::cache::CachedTarget;
+use targeting_resolver::{AliasKind, ObjectType, TargetSource as CacheSource};
 
 /// Map a resolver-domain [`ObjectType`] to the contract [`TargetObjectType`].
 #[must_use]
@@ -35,4 +36,13 @@ pub(crate) fn map_source(s: CacheSource) -> TargetSource {
         CacheSource::Resolved => TargetSource::Resolved,
         CacheSource::UserOverride => TargetSource::UserOverride,
     }
+}
+
+/// Find the common name (a `common_name` alias) for a cached target, if any.
+///
+/// Previously duplicated byte-for-byte in `target_resolve.rs` and
+/// `target_search.rs` (Tier-3 dedup).
+#[must_use]
+pub(crate) fn common_name(target: &CachedTarget) -> Option<String> {
+    target.aliases.iter().find(|a| matches!(a.kind, AliasKind::CommonName)).map(|a| a.alias.clone())
 }

--- a/crates/app/targets/src/target_favourites.rs
+++ b/crates/app/targets/src/target_favourites.rs
@@ -14,21 +14,23 @@ use sqlx::SqlitePool;
 
 use contracts_core::targets::{
     TargetFavouriteAddResult, TargetFavouriteRemoveResult, TargetFavouriteRequest,
-    TargetFavouritesListResult, TargetOpError,
+    TargetFavouritesListResult,
 };
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::Timestamp;
 use persistence_db::repositories::target_favourites;
 
-fn db_err(e: impl std::fmt::Display) -> TargetOpError {
-    TargetOpError { code: "internal.database".to_owned(), message: format!("{e}"), details: None }
+fn db_err(e: impl std::fmt::Display) -> ContractError {
+    ContractError::new(ErrorCode::InternalDatabase, format!("{e}"), ErrorSeverity::Fatal, true)
 }
 
-fn not_found(id: &str) -> TargetOpError {
-    TargetOpError {
-        code: "target.not_found".to_owned(),
-        message: format!("Target '{id}' not found."),
-        details: None,
-    }
+fn not_found(id: &str) -> ContractError {
+    ContractError::new(
+        ErrorCode::TargetNotFound,
+        format!("Target '{id}' not found."),
+        ErrorSeverity::Blocking,
+        false,
+    )
 }
 
 /// `targets.favourites.list` — return the ids of every currently-favourited
@@ -36,8 +38,8 @@ fn not_found(id: &str) -> TargetOpError {
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `internal.database`.
-pub async fn list(pool: &SqlitePool) -> Result<TargetFavouritesListResult, TargetOpError> {
+/// Returns [`ContractError`] with code `internal.database`.
+pub async fn list(pool: &SqlitePool) -> Result<TargetFavouritesListResult, ContractError> {
     let target_ids = target_favourites::list_favourites(pool).await.map_err(db_err)?;
     Ok(TargetFavouritesListResult { target_ids })
 }
@@ -48,12 +50,12 @@ pub async fn list(pool: &SqlitePool) -> Result<TargetFavouritesListResult, Targe
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found` (the id does not
+/// Returns [`ContractError`] with code `target.not_found` (the id does not
 /// reference an existing `canonical_target` row) or `internal.database`.
 pub async fn add(
     pool: &SqlitePool,
     req: &TargetFavouriteRequest,
-) -> Result<TargetFavouriteAddResult, TargetOpError> {
+) -> Result<TargetFavouriteAddResult, ContractError> {
     let exists = target_favourites::target_exists(pool, &req.target_id).await.map_err(db_err)?;
     if !exists {
         return Err(not_found(&req.target_id));
@@ -77,11 +79,11 @@ pub async fn add(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `internal.database`.
+/// Returns [`ContractError`] with code `internal.database`.
 pub async fn remove(
     pool: &SqlitePool,
     req: &TargetFavouriteRequest,
-) -> Result<TargetFavouriteRemoveResult, TargetOpError> {
+) -> Result<TargetFavouriteRemoveResult, ContractError> {
     target_favourites::remove_favourite(pool, &req.target_id).await.map_err(db_err)?;
     Ok(TargetFavouriteRemoveResult { target_id: req.target_id.clone() })
 }
@@ -137,7 +139,7 @@ mod tests {
         let err = add(db.pool(), &TargetFavouriteRequest { target_id: "missing".to_owned() })
             .await
             .unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     #[tokio::test]

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -21,9 +21,9 @@ use contracts_core::targets::{
     TargetAliasRemoveRequest, TargetAliasRemoveResult, TargetDetailV3,
     TargetDisplayAliasClearRequest, TargetDisplayAliasSetRequest, TargetGetRequest, TargetListItem,
     TargetNoteGetRequest, TargetNoteGetResult, TargetNoteUpdateRequest, TargetNoteUpdateResult,
-    TargetOpError, TargetProjectItem, TargetProjectsListRequest, TargetSessionItem,
-    TargetSessionsListRequest,
+    TargetProjectItem, TargetProjectsListRequest, TargetSessionItem, TargetSessionsListRequest,
 };
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::Timestamp;
 use targeting_resolver::cache::{self, CachedTarget, TargetListRow};
 use targeting_resolver::AliasKind;
@@ -35,38 +35,38 @@ const MAX_NOTE_BYTES: usize = 16_384;
 
 // ── Error helpers ────────────────────────────────────────────────────────────
 
-fn not_found(id: &str) -> TargetOpError {
-    TargetOpError {
-        code: "target.not_found".to_owned(),
-        message: format!("Target '{id}' not found."),
-        details: None,
-    }
+fn not_found(id: &str) -> ContractError {
+    ContractError::new(
+        ErrorCode::TargetNotFound,
+        format!("Target '{id}' not found."),
+        ErrorSeverity::Blocking,
+        false,
+    )
 }
 
-fn db_err(e: &cache::CacheError) -> TargetOpError {
-    TargetOpError { code: "internal.database".to_owned(), message: format!("{e}"), details: None }
+/// Map any DB-layer error (`cache::CacheError` or `persistence_db::DbError`) to
+/// the `internal.database` `ContractError` shape. Collapses the previously
+/// byte-identical `db_err`/`persist_err` pair (Tier-3 dedup).
+fn db_err(e: impl std::fmt::Display) -> ContractError {
+    ContractError::new(ErrorCode::InternalDatabase, format!("{e}"), ErrorSeverity::Fatal, true)
 }
 
-/// Map a [`persistence_db::DbError`] from a `q_targets_mgmt` repository call to
-/// the `internal.database` op-error shape (mirrors [`db_err`] for `CacheError`).
-fn persist_err(e: &persistence_db::DbError) -> TargetOpError {
-    TargetOpError { code: "internal.database".to_owned(), message: format!("{e}"), details: None }
+fn invalid_id(id: &str) -> ContractError {
+    ContractError::new(
+        ErrorCode::TargetInvalidId,
+        format!("'{id}' is not a valid target id."),
+        ErrorSeverity::Blocking,
+        false,
+    )
 }
 
-fn invalid_id(id: &str) -> TargetOpError {
-    TargetOpError {
-        code: "target.invalid_id".to_owned(),
-        message: format!("'{id}' is not a valid target id."),
-        details: None,
-    }
-}
-
-fn alias_not_removable() -> TargetOpError {
-    TargetOpError {
-        code: "alias.not_removable".to_owned(),
-        message: "Only user-added aliases (kind='user') can be removed.".to_owned(),
-        details: None,
-    }
+fn alias_not_removable() -> ContractError {
+    ContractError::new(
+        ErrorCode::AliasNotRemovable,
+        "Only user-added aliases (kind='user') can be removed.",
+        ErrorSeverity::Blocking,
+        false,
+    )
 }
 
 // ── Enum mapping ─────────────────────────────────────────────────────────────
@@ -85,11 +85,11 @@ fn map_alias_kind(k: AliasKind) -> ContractAliasKind {
 async fn load_alias_dtos(
     pool: &SqlitePool,
     target_id_str: &str,
-) -> Result<Vec<TargetAliasDto>, TargetOpError> {
+) -> Result<Vec<TargetAliasDto>, ContractError> {
     let rows =
         persistence_db::repositories::q_targets_mgmt::list_target_aliases(pool, target_id_str)
             .await
-            .map_err(|e| persist_err(&e))?;
+            .map_err(db_err)?;
 
     Ok(rows
         .into_iter()
@@ -139,14 +139,14 @@ fn list_row_to_item(row: TargetListRow) -> TargetListItem {
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn get(
     pool: &SqlitePool,
     req: &TargetGetRequest,
-) -> Result<TargetDetailV3, TargetOpError> {
+) -> Result<TargetDetailV3, ContractError> {
     let uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
-    let target = cache::get_by_id(pool, uuid).await.map_err(|e| db_err(&e))?;
+    let target = cache::get_by_id(pool, uuid).await.map_err(db_err)?;
     match target {
         None => Err(not_found(&req.target_id)),
         Some(t) => {
@@ -162,9 +162,9 @@ pub async fn get(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `internal.database`.
-pub async fn list(pool: &SqlitePool) -> Result<Vec<TargetListItem>, TargetOpError> {
-    let rows = cache::list_all(pool).await.map_err(|e| db_err(&e))?;
+/// Returns [`ContractError`] with code `internal.database`.
+pub async fn list(pool: &SqlitePool) -> Result<Vec<TargetListItem>, ContractError> {
+    let rows = cache::list_all(pool).await.map_err(db_err)?;
     Ok(rows.into_iter().map(list_row_to_item).collect())
 }
 
@@ -175,39 +175,41 @@ pub async fn list(pool: &SqlitePool) -> Result<Vec<TargetListItem>, TargetOpErro
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// `alias.blank`, or `internal.database`.
 pub async fn alias_add(
     pool: &SqlitePool,
     req: &TargetAliasAddRequest,
-) -> Result<TargetAliasAddResult, TargetOpError> {
+) -> Result<TargetAliasAddResult, ContractError> {
     let uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
 
     // Verify the target exists.
     let exists =
         persistence_db::repositories::q_targets_mgmt::target_exists(pool, &uuid.to_string())
             .await
-            .map_err(|e| persist_err(&e))?;
+            .map_err(db_err)?;
     if !exists {
         return Err(not_found(&req.target_id));
     }
 
     if req.alias.trim().is_empty() {
-        return Err(TargetOpError {
-            code: "alias.blank".to_owned(),
-            message: "Alias must not be blank.".to_owned(),
-            details: None,
-        });
+        return Err(ContractError::new(
+            ErrorCode::AliasBlank,
+            "Alias must not be blank.",
+            ErrorSeverity::Blocking,
+            false,
+        ));
     }
 
-    let result = cache::insert_user_alias(pool, uuid, &req.alias).await.map_err(|e| db_err(&e))?;
+    let result = cache::insert_user_alias(pool, uuid, &req.alias).await.map_err(db_err)?;
 
     match result {
-        None => Err(TargetOpError {
-            code: "alias.blank".to_owned(),
-            message: "Alias normalizes to empty string.".to_owned(),
-            details: None,
-        }),
+        None => Err(ContractError::new(
+            ErrorCode::AliasBlank,
+            "Alias normalizes to empty string.",
+            ErrorSeverity::Blocking,
+            false,
+        )),
         Some((alias_id, alias_display)) => Ok(TargetAliasAddResult {
             alias: TargetAliasDto {
                 id: alias_id,
@@ -225,12 +227,12 @@ pub async fn alias_add(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `alias.not_found`, `alias.not_removable`,
+/// Returns [`ContractError`] with code `alias.not_found`, `alias.not_removable`,
 /// or `internal.database`.
 pub async fn alias_remove(
     pool: &SqlitePool,
     req: &TargetAliasRemoveRequest,
-) -> Result<TargetAliasRemoveResult, TargetOpError> {
+) -> Result<TargetAliasRemoveResult, ContractError> {
     // First check whether the alias exists at all (to distinguish "not found"
     // from "not removable").
     let row = persistence_db::repositories::q_targets_mgmt::get_alias_kind(
@@ -239,18 +241,18 @@ pub async fn alias_remove(
         &req.target_id,
     )
     .await
-    .map_err(|e| persist_err(&e))?;
+    .map_err(db_err)?;
 
     match row {
-        None => Err(TargetOpError {
-            code: "alias.not_found".to_owned(),
-            message: format!("Alias '{}' not found on target '{}'.", req.alias_id, req.target_id),
-            details: None,
-        }),
+        None => Err(ContractError::new(
+            ErrorCode::AliasNotFound,
+            format!("Alias '{}' not found on target '{}'.", req.alias_id, req.target_id),
+            ErrorSeverity::Blocking,
+            false,
+        )),
         Some(kind) if kind != "user" => Err(alias_not_removable()),
         Some(_) => {
-            let deleted =
-                cache::delete_user_alias(pool, &req.alias_id).await.map_err(|e| db_err(&e))?;
+            let deleted = cache::delete_user_alias(pool, &req.alias_id).await.map_err(db_err)?;
             Ok(TargetAliasRemoveResult { removed: deleted })
         }
     }
@@ -262,15 +264,14 @@ pub async fn alias_remove(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn display_alias_set(
     pool: &SqlitePool,
     req: &TargetDisplayAliasSetRequest,
-) -> Result<TargetDetailV3, TargetOpError> {
+) -> Result<TargetDetailV3, ContractError> {
     let uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
-    let updated =
-        cache::set_display_alias(pool, uuid, &req.display_alias).await.map_err(|e| db_err(&e))?;
+    let updated = cache::set_display_alias(pool, uuid, &req.display_alias).await.map_err(db_err)?;
     if !updated {
         return Err(not_found(&req.target_id));
     }
@@ -282,14 +283,14 @@ pub async fn display_alias_set(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn display_alias_clear(
     pool: &SqlitePool,
     req: &TargetDisplayAliasClearRequest,
-) -> Result<TargetDetailV3, TargetOpError> {
+) -> Result<TargetDetailV3, ContractError> {
     let uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
-    let updated = cache::clear_display_alias(pool, uuid).await.map_err(|e| db_err(&e))?;
+    let updated = cache::clear_display_alias(pool, uuid).await.map_err(db_err)?;
     if !updated {
         return Err(not_found(&req.target_id));
     }
@@ -306,28 +307,24 @@ pub async fn display_alias_clear(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn sessions_list(
     pool: &SqlitePool,
     req: &TargetSessionsListRequest,
-) -> Result<Vec<TargetSessionItem>, TargetOpError> {
+) -> Result<Vec<TargetSessionItem>, ContractError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
     // Verify the target exists.
     let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| persist_err(&e))?;
+        .map_err(db_err)?;
     if !exists {
         return Err(not_found(&req.target_id));
     }
     let rows =
         persistence_db::repositories::targets::list_sessions_for_target(pool, &req.target_id)
             .await
-            .map_err(|e| TargetOpError {
-                code: "internal.database".to_owned(),
-                message: format!("{e}"),
-                details: None,
-            })?;
+            .map_err(db_err)?;
     Ok(rows
         .into_iter()
         .map(|r| TargetSessionItem {
@@ -347,27 +344,23 @@ pub async fn sessions_list(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn projects_list(
     pool: &SqlitePool,
     req: &TargetProjectsListRequest,
-) -> Result<Vec<TargetProjectItem>, TargetOpError> {
+) -> Result<Vec<TargetProjectItem>, ContractError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
     let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| persist_err(&e))?;
+        .map_err(db_err)?;
     if !exists {
         return Err(not_found(&req.target_id));
     }
     let rows =
         persistence_db::repositories::targets::list_projects_for_target(pool, &req.target_id)
             .await
-            .map_err(|e| TargetOpError {
-                code: "internal.database".to_owned(),
-                message: format!("{e}"),
-                details: None,
-            })?;
+            .map_err(db_err)?;
     Ok(rows
         .into_iter()
         .map(|r| TargetProjectItem { id: r.id, name: r.name, lifecycle: r.lifecycle })
@@ -381,26 +374,22 @@ pub async fn projects_list(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// or `internal.database`.
 pub async fn note_get(
     pool: &SqlitePool,
     req: &TargetNoteGetRequest,
-) -> Result<TargetNoteGetResult, TargetOpError> {
+) -> Result<TargetNoteGetResult, ContractError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
     let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| persist_err(&e))?;
+        .map_err(db_err)?;
     if !exists {
         return Err(not_found(&req.target_id));
     }
     let notes = persistence_db::repositories::targets::get_target_notes(pool, &req.target_id)
         .await
-        .map_err(|e| TargetOpError {
-            code: "internal.database".to_owned(),
-            message: format!("{e}"),
-            details: None,
-        })?;
+        .map_err(db_err)?;
     Ok(TargetNoteGetResult { notes })
 }
 
@@ -416,17 +405,17 @@ pub async fn note_get(
 ///
 /// # Errors
 ///
-/// Returns [`TargetOpError`] with code `target.not_found`, `target.invalid_id`,
+/// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
 /// `note.content_too_large`, or `internal.database`.
 pub async fn note_update(
     pool: &SqlitePool,
     bus: &EventBus,
     req: &TargetNoteUpdateRequest,
-) -> Result<TargetNoteUpdateResult, TargetOpError> {
+) -> Result<TargetNoteUpdateResult, ContractError> {
     let _uuid = Uuid::parse_str(&req.target_id).map_err(|_| invalid_id(&req.target_id))?;
     let exists = persistence_db::repositories::q_targets_mgmt::target_exists(pool, &req.target_id)
         .await
-        .map_err(|e| persist_err(&e))?;
+        .map_err(db_err)?;
     if !exists {
         return Err(not_found(&req.target_id));
     }
@@ -434,24 +423,18 @@ pub async fn note_update(
     let trimmed = req.notes.trim();
     // FR-004: reject notes exceeding 16 KB UTF-8.
     if trimmed.len() > MAX_NOTE_BYTES {
-        return Err(TargetOpError {
-            code: "note.content_too_large".to_owned(),
-            message: format!(
-                "Note body exceeds the 16 384-byte limit ({} bytes supplied).",
-                trimmed.len()
-            ),
-            details: None,
-        });
+        return Err(ContractError::new(
+            ErrorCode::NoteContentTooLarge,
+            format!("Note body exceeds the 16 384-byte limit ({} bytes supplied).", trimmed.len()),
+            ErrorSeverity::Blocking,
+            false,
+        ));
     }
     let stored: Option<&str> = if trimmed.is_empty() { None } else { Some(trimmed) };
     let updated =
         persistence_db::repositories::targets::set_target_notes(pool, &req.target_id, stored)
             .await
-            .map_err(|e| TargetOpError {
-                code: "internal.database".to_owned(),
-                message: format!("{e}"),
-                details: None,
-            })?;
+            .map_err(db_err)?;
     if !updated {
         // Should not happen (we verified existence above), but be defensive.
         return Err(not_found(&req.target_id));
@@ -541,7 +524,7 @@ mod tests {
         let db = setup().await;
         let req = TargetGetRequest { target_id: Uuid::new_v4().to_string() };
         let err = get(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     #[tokio::test]
@@ -549,7 +532,7 @@ mod tests {
         let db = setup().await;
         let req = TargetGetRequest { target_id: "not-a-uuid".to_owned() };
         let err = get(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.invalid_id");
+        assert_eq!(err.code, ErrorCode::TargetInvalidId);
     }
 
     // ── target.list ───────────────────────────────────────────────────────────
@@ -722,7 +705,7 @@ mod tests {
         let id = seed_m31(&db).await;
         let req = TargetAliasAddRequest { target_id: id.to_string(), alias: "   ".to_owned() };
         let err = alias_add(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "alias.blank");
+        assert_eq!(err.code, ErrorCode::AliasBlank);
     }
 
     #[tokio::test]
@@ -733,7 +716,7 @@ mod tests {
             alias: "Foo".to_owned(),
         };
         let err = alias_add(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     // ── target.alias.remove ───────────────────────────────────────────────────
@@ -765,7 +748,7 @@ mod tests {
             alias_id: designation.id.clone(),
         };
         let err = alias_remove(db.pool(), &rem_req).await.unwrap_err();
-        assert_eq!(err.code, "alias.not_removable");
+        assert_eq!(err.code, ErrorCode::AliasNotRemovable);
     }
 
     #[tokio::test]
@@ -777,7 +760,7 @@ mod tests {
             alias_id: Uuid::new_v4().to_string(),
         };
         let err = alias_remove(db.pool(), &rem_req).await.unwrap_err();
-        assert_eq!(err.code, "alias.not_found");
+        assert_eq!(err.code, ErrorCode::AliasNotFound);
     }
 
     // ── target.display_alias.set / clear ─────────────────────────────────────
@@ -821,7 +804,7 @@ mod tests {
             display_alias: "X".to_owned(),
         };
         let err = display_alias_set(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     #[tokio::test]
@@ -906,7 +889,7 @@ mod tests {
         let db = setup().await;
         let req = TargetSessionsListRequest { target_id: Uuid::new_v4().to_string() };
         let err = sessions_list(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     #[tokio::test]
@@ -914,7 +897,7 @@ mod tests {
         let db = setup().await;
         let req = TargetSessionsListRequest { target_id: "not-a-uuid".to_owned() };
         let err = sessions_list(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.invalid_id");
+        assert_eq!(err.code, ErrorCode::TargetInvalidId);
     }
 
     // ── target.projects.list (spec 023 US3) ──────────────────────────────────
@@ -945,7 +928,7 @@ mod tests {
         let db = setup().await;
         let req = TargetProjectsListRequest { target_id: Uuid::new_v4().to_string() };
         let err = projects_list(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     // ── target.note.get / target.note.update (spec 023 US4) ──────────────────
@@ -1012,7 +995,7 @@ mod tests {
         let db = setup().await;
         let req = TargetNoteGetRequest { target_id: Uuid::new_v4().to_string() };
         let err = note_get(db.pool(), &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     #[tokio::test]
@@ -1024,7 +1007,7 @@ mod tests {
             notes: "x".to_owned(),
         };
         let err = note_update(db.pool(), &bus, &req).await.unwrap_err();
-        assert_eq!(err.code, "target.not_found");
+        assert_eq!(err.code, ErrorCode::TargetNotFound);
     }
 
     // ── SC-003 / US4-AS3: note survives alias mutations ───────────────────────
@@ -1078,7 +1061,11 @@ mod tests {
         let oversized = "x".repeat(MAX_NOTE_BYTES + 1);
         let req = TargetNoteUpdateRequest { target_id: id.to_string(), notes: oversized };
         let err = note_update(db.pool(), &bus, &req).await.unwrap_err();
-        assert_eq!(err.code, "note.content_too_large", "FR-004: notes >16 KB must be rejected");
+        assert_eq!(
+            err.code,
+            ErrorCode::NoteContentTooLarge,
+            "FR-004: notes >16 KB must be rejected"
+        );
     }
 
     /// A note exactly at the 16 384-byte limit must be accepted.

--- a/crates/app/targets/src/target_resolve.rs
+++ b/crates/app/targets/src/target_resolve.rs
@@ -81,15 +81,7 @@ fn db_err(e: &cache::CacheError) -> ContractError {
 // ── Enum mapping (cache → contract DTO) ─────────────────────────────────────
 //
 // Shared mappers live in `crate::target_dto` (US11 T143).
-use crate::target_dto::{map_object_type, map_source};
-
-fn common_name(target: &CachedTarget) -> Option<String> {
-    target
-        .aliases
-        .iter()
-        .find(|a| matches!(a.kind, targeting_resolver::AliasKind::CommonName))
-        .map(|a| a.alias.clone())
-}
+use crate::target_dto::{common_name, map_object_type, map_source};
 
 fn cached_to_resolved(target: &CachedTarget) -> ResolvedTarget {
     ResolvedTarget {

--- a/crates/app/targets/src/target_search.rs
+++ b/crates/app/targets/src/target_search.rs
@@ -30,16 +30,7 @@ fn db_err(e: &targeting_resolver::cache::CacheError) -> ContractError {
 // ── Enum mapping (cache → contract DTO) ─────────────────────────────────────
 //
 // Shared mappers live in `crate::target_dto` (US11 T143).
-use crate::target_dto::{map_object_type, map_source};
-
-/// Find the common name (a `common_name` alias) for a cached target, if any.
-fn common_name(target: &CachedTarget) -> Option<String> {
-    target
-        .aliases
-        .iter()
-        .find(|a| matches!(a.kind, targeting_resolver::AliasKind::CommonName))
-        .map(|a| a.alias.clone())
-}
+use crate::target_dto::{common_name, map_object_type, map_source};
 
 // ── Catalogue derivation (T029) ─────────────────────────────────────────────
 //

--- a/crates/contracts/core/src/error_code.rs
+++ b/crates/contracts/core/src/error_code.rs
@@ -296,9 +296,9 @@ pub enum ErrorCode {
     #[serde(rename = "plan.required")]
     PlanRequired,
 
-    // ── Target / alias codes that flow through ContractError in some paths ────
-    /// Appears in `TargetOpError.code: String` (`target_management.rs`).
-    /// Included per task instruction ("include when unsure — superset is safe").
+    // ── Target / alias codes ───────────────────────────────────────────────────
+    /// Reserved: no current call site returns this — `target.alias.add`
+    /// resolves a duplicate idempotently rather than erroring.
     #[serde(rename = "alias.duplicate")]
     AliasDuplicate,
     #[serde(rename = "alias.blank")]

--- a/crates/contracts/core/src/targets.rs
+++ b/crates/contracts/core/src/targets.rs
@@ -111,17 +111,6 @@ pub struct TargetDetail {
 //
 // Contracts per `specs/036-retire-legacy-targets/contracts/target-management.md`.
 
-/// Generic error envelope for target operations (gen-3).
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
-#[serde(rename_all = "camelCase")]
-pub struct TargetOpError {
-    /// Error code string (e.g. `"target.not_found"`, `"alias.duplicate"`).
-    pub code: String,
-    pub message: String,
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub details: Option<crate::JsonAny>,
-}
-
 /// Kind of a target alias (gen-3).
 ///
 /// - `"designation"` — a SIMBAD catalog designation (read-only, not removable).


### PR DESCRIPTION
## Summary
- Target management and target favourites use cases returned a second, competing error shape instead of the canonical ContractError envelope; since the frontend's IPC layer validates every error against the strict ContractError schema, a call could fail that validation at runtime instead of surfacing the real error. Both now route through ContractError with the existing error-code variants.
- Regenerates the TypeScript bindings for the new error shape and updates the target detail view's error handling accordingly.
- Dedups a duplicated common_name helper and collapses two near-identical database-error mappers into one.

## Spec Context
Run: run-dab, node: n6_targeterror.