### PR TITLE
refactor: consolidate debounce cache, drop unused strsim dep, split out safe-filename crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 name = "app_core"
 version = "0.1.0"
 dependencies = [
+ "app_core_cache",
  "app_core_calibration",
  "app_core_errors",
  "app_core_inbox",
@@ -213,13 +214,13 @@ dependencies = [
 name = "app_core_projects"
 version = "0.1.0"
 dependencies = [
+ "app_core_cache",
  "app_core_errors",
  "audit",
  "camino",
  "contracts_core",
  "domain_core",
  "fs_inventory",
- "moka",
  "patterns",
  "persistence_db",
  "project_structure",
@@ -4145,13 +4146,10 @@ checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 name = "patterns"
 version = "0.1.0"
 dependencies = [
- "proptest",
- "rstest",
+ "safe-filename",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
- "unicode-normalization",
- "unicode-security",
 ]
 
 [[package]]
@@ -5025,6 +5023,17 @@ name = "ryu"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+
+[[package]]
+name = "safe-filename"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "rstest",
+ "thiserror 2.0.18",
+ "unicode-normalization",
+ "unicode-security",
+]
 
 [[package]]
 name = "same-file"
@@ -6115,7 +6124,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
- "strsim",
  "targeting",
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = [
   "crates/patterns",
   "crates/persistence/db",
   "crates/project/structure",
+  "crates/safe-filename",
   "crates/sessions",
   "crates/targeting",
   "crates/targeting/resolver",

--- a/crates/app/cache/src/lib.rs
+++ b/crates/app/cache/src/lib.rs
@@ -23,19 +23,20 @@
 //!
 //! ## Migrating existing hand-rolled caches
 //!
-//! `crates/app/projects/src/project_health.rs`'s `DebounceTable` is a valid,
-//! working, hand-rolled equivalent of [`DebounceCache`] here. Spec 051 does
-//! **not** require migrating it — that is a pure refactor with no
-//! user-facing effect, tracked as a non-blocking follow-up (see
-//! `specs/051-tauri-shell-integration/research.md` §(d), "Consumers").
+//! `crates/app/projects/src/project_health.rs` previously hand-rolled its own
+//! `DebounceTable` (a `moka::sync::Cache` wrapper); it now uses
+//! [`DebounceCache`] here directly. Spec 051 did not require that migration —
+//! it was a pure refactor with no user-facing effect — but the duplication
+//! audit (`docs/development/duplication-and-abstraction-audit.md`, Phase 5)
+//! folded it in.
 //!
 //! ## What this crate provides
 //!
 //! - [`TtlCache`]: a generic, size- and TTL-bounded cache with a
 //!   single-flight get-or-insert (`get_or_insert_with`).
-//! - [`DebounceCache`]: a presence-only cache (mirrors
-//!   `project_health::DebounceTable`) for suppressing repeated signals within
-//!   a time window, generic over the debounce key.
+//! - [`DebounceCache`]: a presence-only cache (the generic form of
+//!   `project_health`'s former `DebounceTable`) for suppressing repeated
+//!   signals within a time window, generic over the debounce key.
 
 use std::hash::Hash;
 use std::time::Duration;
@@ -170,8 +171,8 @@ where
 }
 
 /// A presence-only cache for suppressing repeated signals within a time
-/// window — the generic form of
-/// `crates/app/projects/src/project_health.rs`'s `DebounceTable`.
+/// window — the generic form of the hand-rolled debounce table
+/// `crates/app/projects/src/project_health.rs` previously carried.
 ///
 /// Presence of a (non-expired) entry for a key means a signal for that key
 /// was already emitted within the debounce window and must be suppressed.
@@ -220,10 +221,10 @@ where
         false
     }
 
-    /// Force-expire the entry for `key` (test-only escape hatch for
-    /// simulating elapsed time without sleeping).
-    #[cfg(test)]
-    pub fn expire(&self, key: &K) {
+    /// Force-expire the entry for `key`, so the next `should_suppress` for it
+    /// starts a fresh window. Useful for resetting a debounce early, and for
+    /// tests that simulate elapsed time without sleeping.
+    pub fn invalidate(&self, key: &K) {
         self.last_emitted.invalidate(key);
     }
 }
@@ -330,7 +331,7 @@ mod tests {
         let debounce: DebounceCache<String> = DebounceCache::new(Duration::from_mins(1));
 
         assert!(!debounce.should_suppress(&"a".to_owned()));
-        debounce.expire(&"a".to_owned());
+        debounce.invalidate(&"a".to_owned());
         assert!(
             !debounce.should_suppress(&"a".to_owned()),
             "after expiry, signal is emitted again"

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -42,6 +42,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+app_core_cache = { path = "../cache" }
 tempfile = { workspace = true }
 rstest = { workspace = true }
 proptest = { workspace = true }

--- a/crates/app/core/tests/lifecycle_canonical.rs
+++ b/crates/app/core/tests/lifecycle_canonical.rs
@@ -7,14 +7,13 @@
 
 mod support;
 
-use std::sync::{Arc, Mutex};
-
 use app_core::project_health::{
     check_project_ready_invariant, emit_block_transition, emit_unarchive_transition,
-    BlockCondition, DebounceTable, DEBOUNCE_WINDOW,
+    BlockCondition, DEBOUNCE_WINDOW,
 };
 use app_core::transition_use_case::apply_transition;
 use app_core::{project_setup, project_setup::add_source};
+use app_core_cache::DebounceCache;
 use audit::bus::EventBus;
 use contracts_core::lifecycle::{
     ProjectState, ProjectTransitionRequest, TransitionActor, TransitionRequest, TransitionStatus,
@@ -138,7 +137,7 @@ async fn t046a_user_ipc_and_auto_read_same_canonical_lifecycle() {
     assert_eq!(result, None, "auto-ready invariant is a no-op when lifecycle != setup_incomplete");
 
     // Step 5: drive the block auto-transition via the health surface.
-    let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+    let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
     let condition = BlockCondition::SourceMissing { inventory_id: "inv-gone".to_owned() };
     let block_result =
         emit_block_transition(&pool, &bus, &debounce, &project_id, &condition).await.unwrap();
@@ -230,7 +229,7 @@ async fn t046b_no_dual_write_to_legacy_project_table() {
 async fn t048a_auto_block_writes_audit_row() {
     let (pool, bus) = setup().await;
     let project_id = create_project(&pool, &bus, "M42 Block Audit").await;
-    let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+    let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
 
     let condition = BlockCondition::ToolUnconfigured { tool: "PixInsight".to_owned() };
     let result =
@@ -357,7 +356,7 @@ async fn t048c_auto_unarchive_writes_audit_row_and_emits_event() {
 async fn t048d_typed_blocked_reason_persisted_and_readable() {
     let (pool, bus) = setup().await;
     let project_id = create_project(&pool, &bus, "M8 Blocked Reason").await;
-    let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+    let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
 
     let condition = BlockCondition::SourceMissing { inventory_id: "inv-missing-42".to_owned() };
     emit_block_transition(&pool, &bus, &debounce, &project_id, &condition).await.unwrap();
@@ -381,7 +380,12 @@ async fn t048d_typed_blocked_reason_persisted_and_readable() {
 async fn t048e_unblocking_clears_blocked_reason() {
     let (pool, bus) = setup().await;
     let project_id = create_project(&pool, &bus, "M101 Clear Reason").await;
+<<<<<<< HEAD
     let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+=======
+    let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
+    let edge_table = build_edge_table();
+>>>>>>> 3ecde1b5 (refactor: phase-5 crate sweep (dedup DebounceTable, drop strsim, extract safe-filename))
 
     // Block first.
     let condition = BlockCondition::User { note: "manual block".to_owned() };

--- a/crates/app/core/tests/lifecycle_canonical.rs
+++ b/crates/app/core/tests/lifecycle_canonical.rs
@@ -380,12 +380,7 @@ async fn t048d_typed_blocked_reason_persisted_and_readable() {
 async fn t048e_unblocking_clears_blocked_reason() {
     let (pool, bus) = setup().await;
     let project_id = create_project(&pool, &bus, "M101 Clear Reason").await;
-<<<<<<< HEAD
-    let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
-=======
     let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
-    let edge_table = build_edge_table();
->>>>>>> 3ecde1b5 (refactor: phase-5 crate sweep (dedup DebounceTable, drop strsim, extract safe-filename))
 
     // Block first.
     let condition = BlockCondition::User { note: "manual block".to_owned() };

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+app_core_cache = { path = "../cache" }
 app_core_errors = { path = "../errors" }
 audit = { path = "../../audit" }
 camino = { workspace = true }
@@ -18,7 +19,6 @@ patterns = { path = "../../patterns" }
 persistence_db = { path = "../../persistence/db" }
 project_structure = { path = "../../project/structure" }
 workflow_profiles = { path = "../../workflow/profiles" }
-moka = { workspace = true }
 serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true

--- a/crates/app/projects/src/project_health.rs
+++ b/crates/app/projects/src/project_health.rs
@@ -351,6 +351,9 @@ pub async fn emit_unarchive_transition(
 /// Write a durable audit row for a system-driven (actor=system) lifecycle
 /// transition. Used by `check_project_ready_invariant`, `emit_block_transition`,
 /// and `emit_unarchive_transition` to satisfy FR-021 (Constitution §V).
+///
+/// Delegates the raw insert to `persistence_db` (db-boundary rule: no `sqlx` in
+/// the app layer).
 async fn write_auto_transition_audit(
     pool: &SqlitePool,
     project_id: &str,
@@ -358,32 +361,10 @@ async fn write_auto_transition_audit(
     to_state: &str,
     trigger: &str,
 ) -> persistence_db::DbResult<()> {
-    use time::format_description::well_known::Rfc3339;
-    use uuid::Uuid;
-
-    let audit_id = Uuid::new_v4().to_string();
-    let request_id = Uuid::new_v4().to_string();
-    let at = time::OffsetDateTime::now_utc()
-        .format(&Rfc3339)
-        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
-
-    sqlx::query(
-        "INSERT INTO audit_log_entry \
-         (audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
-          outcome, severity, request_id, at, payload) \
-         VALUES (?, 'project', ?, ?, ?, ?, 'system', 'applied', 'workflow', ?, ?, NULL)",
+    persistence_db::repositories::audit::insert_project_auto_transition(
+        pool, project_id, from_state, to_state, trigger,
     )
-    .bind(&audit_id)
-    .bind(project_id)
-    .bind(from_state)
-    .bind(to_state)
-    .bind(trigger)
-    .bind(&request_id)
-    .bind(&at)
-    .execute(pool)
-    .await?;
-
-    Ok(())
+    .await
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/crates/app/projects/src/project_health.rs
+++ b/crates/app/projects/src/project_health.rs
@@ -28,12 +28,11 @@
 //! - `prepared_source_stale`: requires spec 012 / prepared_source_view table.
 //! - Both are deferred and documented in tasks.md.
 
-use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
+use app_core_cache::DebounceCache;
 use audit::bus::EventBus;
 use audit::event_bus::{LifecycleTransitionApplied, Source, TOPIC_LIFECYCLE_TRANSITION_APPLIED};
-use moka::sync::Cache;
 use persistence_db::repositories::projects as repo;
 use sqlx::SqlitePool;
 
@@ -77,48 +76,21 @@ impl BlockCondition {
 
 // ── Debounce table ────────────────────────────────────────────────────────────
 
-/// Key for the debounce table: entity + condition kind.
+/// Key for the block-transition debounce cache: entity + condition kind.
+///
+/// Presence of a (non-expired) entry in a [`DebounceCache<DebounceKey>`] means
+/// the signal was emitted within the debounce window and must be suppressed.
+/// The cache's `time_to_live` is the debounce window (see [`DEBOUNCE_WINDOW`]),
+/// so entries auto-expire without manual bookkeeping.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
-struct DebounceKey {
+pub struct DebounceKey {
     entity_id: String,
     condition_kind: &'static str,
 }
 
-/// In-process debounce table (P7, D5): a `moka` TTL cache keyed by
-/// `(entity_id, condition_kind)`. Presence of a (non-expired) entry means the
-/// signal was emitted within the debounce window and must be suppressed.
-///
-/// The cache's `time_to_live` is the debounce window, so entries auto-expire
-/// after the window elapses — reproducing the prior hand-rolled
-/// `Instant`-comparison semantics without manual bookkeeping.
-#[derive(Clone)]
-pub struct DebounceTable {
-    last_emitted: Cache<DebounceKey, ()>,
-}
-
-impl DebounceTable {
-    #[must_use]
-    pub fn new(window: Duration) -> Self {
-        Self { last_emitted: Cache::builder().time_to_live(window).build() }
-    }
-
-    /// Returns `true` if the signal should be suppressed (still within the debounce window).
-    pub fn should_suppress(&mut self, entity_id: &str, condition_kind: &'static str) -> bool {
-        let key = DebounceKey { entity_id: entity_id.to_owned(), condition_kind };
-        // If the key is still present (TTL not elapsed) the signal is debounced.
-        if self.last_emitted.get(&key).is_some() {
-            return true;
-        }
-        // Record the emission; the entry expires after the configured TTL.
-        self.last_emitted.insert(key, ());
-        false
-    }
-
-    /// Force-expire an entry (used by tests to simulate elapsed time without sleeping).
-    #[cfg(test)]
-    pub fn expire(&mut self, entity_id: &str, condition_kind: &'static str) {
-        let key = DebounceKey { entity_id: entity_id.to_owned(), condition_kind };
-        self.last_emitted.invalidate(&key);
+impl DebounceKey {
+    fn new(entity_id: &str, condition_kind: &'static str) -> Self {
+        Self { entity_id: entity_id.to_owned(), condition_kind }
     }
 }
 
@@ -225,27 +197,21 @@ pub struct BlockTransitionRecord {
 ///
 /// Returns `Some(record)` when applied, `None` when debounced or already blocked.
 ///
-/// # Panics
-/// Panics if the debounce table mutex is poisoned (only possible if another
-/// thread panicked while holding the lock — should not happen in practice).
-///
 /// # Errors
 /// Returns `HealthError` on database failure.
 pub async fn emit_block_transition(
     pool: &SqlitePool,
     bus: &EventBus,
-    debounce: &Arc<Mutex<DebounceTable>>,
+    debounce: &DebounceCache<DebounceKey>,
     project_id: &str,
     condition: &BlockCondition,
 ) -> Result<Option<BlockTransitionRecord>, HealthError> {
     let condition_kind = condition.kind_str();
 
-    // Debounce check (P7).
-    {
-        let mut table = debounce.lock().expect("debounce lock poisoned");
-        if table.should_suppress(project_id, condition_kind) {
-            return Ok(None);
-        }
+    // Debounce check (P7). `DebounceCache` is `Clone`/`&self` (moka handle is
+    // internally `Arc`-backed), so no external `Arc<Mutex<_>>` is needed.
+    if debounce.should_suppress(&DebounceKey::new(project_id, condition_kind)) {
+        return Ok(None);
     }
 
     let row = repo::get_project(pool, project_id)
@@ -424,8 +390,6 @@ async fn write_auto_transition_audit(
 
 #[cfg(test)]
 mod tests {
-    use std::sync::{Arc, Mutex};
-
     use audit::bus::EventBus;
     use contracts_core::projects_v2::{ProjectCreateRequest, ProjectSourceAddRequest};
     use persistence_db::Database;
@@ -530,7 +494,7 @@ mod tests {
     #[tokio::test]
     async fn debounce_suppresses_duplicate_block() {
         let (pool, bus) = setup().await;
-        let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+        let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
         let created =
             project_setup::create(&pool, &bus, &make_create_req("M31 Block Test")).await.unwrap();
         let condition = BlockCondition::SourceMissing { inventory_id: "inv-missing".to_owned() };
@@ -559,7 +523,7 @@ mod tests {
     #[tokio::test]
     async fn debounce_allows_after_window_expires() {
         let (pool, bus) = setup().await;
-        let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+        let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
         let created =
             project_setup::create(&pool, &bus, &make_create_req("M82 Expiry")).await.unwrap();
         let condition = BlockCondition::SourceMissing { inventory_id: "inv-gone".to_owned() };
@@ -569,10 +533,7 @@ mod tests {
             .unwrap();
 
         // Expire the debounce entry manually (avoids a 60s sleep).
-        {
-            let mut table = debounce.lock().unwrap();
-            table.expire(&created.project_id, "source_missing");
-        }
+        debounce.invalidate(&DebounceKey::new(&created.project_id, "source_missing"));
 
         // Reset lifecycle so the transition can succeed again.
         persistence_db::repositories::projects::update_project_lifecycle(
@@ -593,7 +554,7 @@ mod tests {
     #[tokio::test]
     async fn rapid_source_missing_produces_one_transition() {
         let (pool, bus) = setup().await;
-        let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
+        let debounce = DebounceCache::new(DEBOUNCE_WINDOW);
         let created =
             project_setup::create(&pool, &bus, &make_create_req("IC 1805 Rapid")).await.unwrap();
         let condition = BlockCondition::SourceMissing { inventory_id: "inv-rapid".to_owned() };

--- a/crates/patterns/Cargo.toml
+++ b/crates/patterns/Cargo.toml
@@ -8,16 +8,13 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+safe-filename = { path = "../safe-filename" }
 serde.workspace = true
 serde_json.workspace = true
 thiserror.workspace = true
-unicode-normalization.workspace = true
-unicode-security.workspace = true
 
 [dev-dependencies]
 serde_json.workspace = true
-rstest.workspace = true
-proptest.workspace = true
 
 [lints]
 workspace = true

--- a/crates/patterns/src/lib.rs
+++ b/crates/patterns/src/lib.rs
@@ -17,7 +17,6 @@
 pub mod per_type;
 pub mod registry;
 pub mod resolver;
-pub mod sanitize;
 pub mod validator;
 
 pub use per_type::{

--- a/crates/patterns/src/resolver.rs
+++ b/crates/patterns/src/resolver.rs
@@ -17,8 +17,9 @@
 
 use std::collections::HashMap;
 
+use safe_filename::{sanitize_token_value, SanitizeError};
+
 use crate::registry::{TokenRegistry, TokenTransform};
-use crate::sanitize::{sanitize_token_value, SanitizeError};
 use crate::validator::{validate, ValidationWarning};
 use crate::V1_REGISTRY;
 

--- a/crates/persistence/db/src/repositories/audit.rs
+++ b/crates/persistence/db/src/repositories/audit.rs
@@ -183,6 +183,51 @@ pub async fn count_audit_entries(pool: &SqlitePool, filter: &AuditLogFilter) -> 
     Ok(u32::try_from(count).unwrap_or(u32::MAX))
 }
 
+/// Insert a system-driven ("auto") project lifecycle-transition audit row.
+///
+/// Owns the raw `INSERT` for `app_core_projects::project_health` so no `sqlx`
+/// lives in the app layer (db-boundary rule). Fixed columns for this path:
+/// `entity_type = 'project'`, `actor = 'system'`, `outcome = 'applied'`,
+/// `severity = 'workflow'`, `payload = NULL`. Generates the `audit_id` /
+/// `request_id` UUIDs and the RFC3339 `at` timestamp.
+///
+/// # Errors
+/// Returns [`DbError`](crate::DbError) if the insert fails.
+pub async fn insert_project_auto_transition(
+    pool: &SqlitePool,
+    project_id: &str,
+    from_state: &str,
+    to_state: &str,
+    trigger: &str,
+) -> DbResult<()> {
+    use time::format_description::well_known::Rfc3339;
+    use uuid::Uuid;
+
+    let audit_id = Uuid::new_v4().to_string();
+    let request_id = Uuid::new_v4().to_string();
+    let at = time::OffsetDateTime::now_utc()
+        .format(&Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+
+    sqlx::query(
+        "INSERT INTO audit_log_entry \
+         (audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
+          outcome, severity, request_id, at, payload) \
+         VALUES (?, 'project', ?, ?, ?, ?, 'system', 'applied', 'workflow', ?, ?, NULL)",
+    )
+    .bind(&audit_id)
+    .bind(project_id)
+    .bind(from_state)
+    .bind(to_state)
+    .bind(trigger)
+    .bind(&request_id)
+    .bind(&at)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{count_audit_entries, list_audit_entries, AuditLogFilter};

--- a/crates/safe-filename/Cargo.toml
+++ b/crates/safe-filename/Cargo.toml
@@ -1,0 +1,23 @@
+[package]
+name = "safe-filename"
+version = "0.1.0"
+edition.workspace = true
+license.workspace = true
+description = "Security-conscious sanitization of a single path segment / filename component: NFC normalization, C0/C1/format/bidi-override stripping, Windows reserved-character and device-name rejection, path-traversal rejection, and Unicode-confusables (mixed-script) detection."
+keywords = ["filename", "sanitize", "path", "security", "unicode"]
+categories = ["filesystem", "text-processing"]
+
+[lib]
+path = "src/lib.rs"
+
+[dependencies]
+thiserror.workspace = true
+unicode-normalization.workspace = true
+unicode-security.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true
+rstest.workspace = true
+
+[lints]
+workspace = true

--- a/crates/safe-filename/src/lib.rs
+++ b/crates/safe-filename/src/lib.rs
@@ -1,15 +1,27 @@
-//! OS-path sanitization pipeline (spec 015 T3.3, data-model.md §Errors).
+//! Security-conscious sanitization of a single path segment / filename
+//! component.
+//!
+//! Turns an arbitrary string (e.g. a metadata value destined for a folder or
+//! file name) into one that is safe to place in a cross-platform path, or
+//! rejects it with a typed [`SanitizeError`]. The pipeline is stricter than a
+//! plain character filter on the trojan-source / homoglyph axis: it strips
+//! bidi overrides and Unicode format characters and rejects mixed-script
+//! confusables.
 //!
 //! Steps (applied in order):
-//! 1. NFC normalization + strip C0/C1 controls, format chars, bidi overrides.  (Ref: A1)
-//! 2. OS character substitution: Windows reserved chars → `_`, trim leading/trailing whitespace and dots.
-//! 3. Path-traversal rejection: `.` or `..` → `path.traversal`.  (Ref: A2)
-//! 4. Windows reserved device-name rejection (CON, PRN, AUX, NUL, COM1–9, LPT1–9),
-//!    case-insensitive, all platforms → `path.reserved_name`.  (Ref: A3)
-//! 5. Unicode confusables detection via `unicode-security` → `pattern.invalid.unicode`.  (Ref: A1)
+//! 1. NFC normalization + strip C0/C1 controls, format chars, bidi overrides.
+//! 2. OS character substitution: Windows reserved chars → `_`, trim
+//!    leading/trailing whitespace and dots.
+//! 3. Path-traversal rejection: `.` or `..`.
+//! 4. Windows reserved device-name rejection (CON, PRN, AUX, NUL, COM1–9,
+//!    LPT1–9), case-insensitive, on all platforms.
+//! 5. Unicode confusables detection via `unicode-security` (mixed-script).
 //!
-//! Each step is exposed individually so the resolver can call them in sequence
-//! and surface the first hard error.
+//! Each step is exposed individually so a caller can run them in sequence and
+//! surface the first hard error, or call [`sanitize_token_value`] for the full
+//! pipeline. `token_name` parameters are a free-text label used only for error
+//! context (this crate is domain-agnostic; it originated as the token-value
+//! sanitizer in a filesystem path-pattern resolver).
 
 use unicode_normalization::UnicodeNormalization;
 use unicode_security::MixedScript;

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -42,8 +42,6 @@ time.workspace = true
 percent-encoding.workspace = true
 # spec 042 (T204): RFC-4180 TSV tokenization of SIMBAD `basic` rows.
 csv.workspace = true
-# Fuzzy matching: token-set similarity + Damerau-Levenshtein (R2).
-strsim = "0.11"
 # db-boundary-zero: production dependency (not dev-only) so cache.rs's raw
 # sqlx sites can move into `persistence_db::repositories::q_resolver`.
 persistence_db = { path = "../../persistence/db" }


### PR DESCRIPTION
Phase 5 of the duplication-and-abstraction audit (`docs/development/duplication-and-abstraction-audit.md`), applied separately from the Phases 1–4 orchestrate run (`run-dab`, all 8 nodes merged). Three self-contained crate-hygiene changes; **item 4 (metadata_* packaging) intentionally left** as a packaging decision.

### 1. `DebounceTable` → `app_core_cache::DebounceCache` (fix)
`project_health` hand-rolled a `moka::sync::Cache` wrapper that duplicated the shared `DebounceCache` field-for-field. Switched to the shared primitive:
- `DebounceCache` is `Clone`/`&self` (moka handle is Arc-backed), so the external `Arc<Mutex<_>>` wrapper is **dropped** from `emit_block_transition` and its tests — no redundant lock.
- Added a public `DebounceCache::invalidate(&self, key)` (force-expire) so downstream tests can reset a window without relying on a `cfg(test)`-only method (which doesn't cross crate boundaries).
- Deleted ~45 LOC + the duplicate impl; dropped the `moka` direct dep from `app_core_projects`.

### 2. Drop `strsim` (fix)
`targeting/resolver` declared `strsim = "0.11"` for "fuzzy matching (R2)" but has **zero call sites** (resolver matching is exact-normalized, FR-008). Removed the direct dep; it remains only transitively via `tauri-build`.

### 3. Extract `patterns::sanitize` → `safe-filename` crate (apply)
Lifted the 373-LOC safe path-segment / filename sanitizer (NFC, C0/C1/format/bidi stripping, Windows reserved-char + device-name rejection, path-traversal rejection, Unicode-confusables detection) into a standalone, publish-ready `safe-filename` crate. `patterns::resolver` now consumes it; the two `unicode-*` deps move with it. `SanitizeError` was already internal (mapped to `ResolveError`), so `patterns`' public API is unchanged. History preserved via `git mv`.

### Verification (local, ubuntu/WSL)
- `cargo fmt --all --check` clean
- `cargo clippy --all-targets -D warnings` clean across all affected crates
- Tests: safe-filename **34**, patterns **62+4**, app_core_cache **10 + 2 doctests**, app_core_projects **85**, app_core **220 + integration** (incl. `lifecycle_canonical` **8**), targeting_resolver **55+1+2** — all green.

### Not included (deferred, per plan)
- **Item 4:** `metadata_{core,fits,xisf}` packaging — a packaging/publishing decision (already zero-coupling / publish-ready), not a code change.