### PR TITLE
refactor: drop dead lifecycle edge-table plumbing; guard archive closure against illegal edges

### DIFF
--- a/apps/desktop/src-tauri/src/commands/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/commands/lifecycle.rs
@@ -10,7 +10,6 @@
 use std::sync::Arc;
 
 use app_core::ledger_use_case::list_assets_ledger;
-use app_core::lifecycle_use_case::{build_edge_table, EdgeMeta};
 use app_core::provenance_use_case::read_provenance;
 use app_core::transition_use_case::{apply_transition, preview_transition};
 use audit::bus::EventBus;
@@ -28,13 +27,12 @@ use uuid::Uuid;
 pub struct AppState {
     pub repo: Arc<SqliteLifecycleRepository>,
     pub bus: EventBus,
-    pub edge_table: std::collections::HashMap<EntityType, Vec<([&'static str; 2], EdgeMeta)>>,
 }
 
 impl AppState {
     #[must_use]
     pub fn new(repo: Arc<SqliteLifecycleRepository>, bus: EventBus) -> Self {
-        Self { repo, bus, edge_table: build_edge_table() }
+        Self { repo, bus }
     }
 }
 
@@ -113,7 +111,7 @@ pub async fn lifecycle_transition_apply(
     state: State<'_, AppState>,
     request: TransitionRequest,
 ) -> Result<TransitionResponse, String> {
-    Ok(apply_transition(state.repo.as_ref(), &state.bus, request, &state.edge_table).await)
+    Ok(apply_transition(state.repo.as_ref(), &state.bus, request).await)
 }
 
 /// `lifecycle.transition.preview` — read-only dry-run for UI button enabling.

--- a/apps/desktop/src-tauri/tests/commands.rs
+++ b/apps/desktop/src-tauri/tests/commands.rs
@@ -860,13 +860,9 @@ async fn lifecycle_transition_apply() {
         TransitionActor::User,
     ));
 
-    let response = app_core::transition_use_case::apply_transition(
-        state.repo.as_ref(),
-        &state.bus,
-        request,
-        &state.edge_table,
-    )
-    .await;
+    let response =
+        app_core::transition_use_case::apply_transition(state.repo.as_ref(), &state.bus, request)
+            .await;
     // The entity doesn't exist so the transition will be refused, but the
     // command infrastructure should not panic.
     assert!(!response.contract_version.is_empty());

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -370,9 +370,7 @@ async fn finalize_archive_lifecycle(
     plan_id: &str,
     project_id: &str,
 ) {
-    use crate::lifecycle::lifecycle_use_case::{
-        build_edge_table, transition_lifecycle, TransitionCommand,
-    };
+    use crate::lifecycle::lifecycle_use_case::{transition_lifecycle, TransitionCommand};
     use domain_core::ids::EntityId;
     use domain_core::lifecycle::data_asset::EntityType;
     use persistence_db::repositories::lifecycle::SqliteLifecycleRepository;
@@ -405,8 +403,23 @@ async fn finalize_archive_lifecycle(
         return;
     }
 
+    // Edge-legality guard (Constitution §II). `transition_lifecycle` is un-gated
+    // and `record_transition` only CAS-checks `from_state`, so this closure would
+    // otherwise CAS `<any state> → archived`. Per the domain edge table
+    // (`domain_core::lifecycle::project::is_allowed`) the ONLY legal edges into
+    // `archived` are `completed → archived` and `blocked → archived`. Archive
+    // plans should only ever target completed/blocked projects; if we somehow
+    // reach here from another state, refuse to record an illegal edge and log
+    // for an external watchdog rather than corrupt lifecycle history.
+    if !matches!(current.as_str(), "completed" | "blocked") {
+        tracing::error!(
+            %project_id, %plan_id, from_state = %current,
+            "archive lifecycle closure: refusing illegal edge into 'archived' (legal sources: completed, blocked); leaving lifecycle unchanged"
+        );
+        return;
+    }
+
     let repo = SqliteLifecycleRepository::new(pool.clone(), bus.clone());
-    let table = build_edge_table();
     let cmd = TransitionCommand {
         entity_id: EntityId::from_uuid(uuid),
         entity_type: EntityType::Project,
@@ -417,7 +430,7 @@ async fn finalize_archive_lifecycle(
         request_id: EntityId::new(),
     };
 
-    match transition_lifecycle(&repo, bus, cmd, &table).await {
+    match transition_lifecycle(&repo, bus, cmd).await {
         Ok(_) => {
             if let Err(e) = projects_repo::set_archived_via_plan_id(pool, project_id, plan_id).await
             {
@@ -1935,6 +1948,45 @@ mod tests {
             .await
             .unwrap();
         assert!(archived.is_empty());
+    }
+
+    /// Edge-legality guard (Constitution §II): if an archive plan somehow targets
+    /// a project that is NOT in a legal `* → archived` source state
+    /// (`completed`/`blocked`), the closure must refuse — leaving the lifecycle
+    /// unchanged and recording no archive link — rather than CAS an illegal edge
+    /// into `archived`.
+    #[tokio::test]
+    async fn finalize_archive_lifecycle_refuses_illegal_source_state() {
+        use persistence_db::repositories::projects as projects_repo;
+
+        let (db, bus) = setup().await;
+        let project_id = Uuid::new_v4().to_string();
+        projects_repo::insert_project(
+            db.pool(),
+            &projects_repo::InsertProject {
+                id: &project_id,
+                name: "M31 Ready",
+                tool: "PixInsight",
+                lifecycle: "ready",
+                path: "projects/M31_Ready",
+                notes: None,
+                canonical_target_id: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        finalize_archive_lifecycle(db.pool(), &bus, "plan-arch-bad", &project_id).await;
+
+        // Lifecycle untouched — no illegal edge recorded.
+        let project = projects_repo::get_project(db.pool(), &project_id).await.unwrap();
+        assert_eq!(
+            project.lifecycle, "ready",
+            "illegal archive source must leave lifecycle unchanged"
+        );
+        // No archive link recorded.
+        let archived = projects_repo::list_archived_projects(db.pool()).await.unwrap();
+        assert!(archived.is_empty(), "no archive link may be recorded for a refused closure");
     }
 
     #[tokio::test]

--- a/crates/app/core/tests/lifecycle_canonical.rs
+++ b/crates/app/core/tests/lifecycle_canonical.rs
@@ -9,7 +9,6 @@ mod support;
 
 use std::sync::{Arc, Mutex};
 
-use app_core::lifecycle_use_case::build_edge_table;
 use app_core::project_health::{
     check_project_ready_invariant, emit_block_transition, emit_unarchive_transition,
     BlockCondition, DebounceTable, DEBOUNCE_WINDOW,
@@ -84,7 +83,6 @@ fn make_project_transition(
 #[tokio::test]
 async fn t046a_user_ipc_and_auto_read_same_canonical_lifecycle() {
     let (pool, bus) = setup().await;
-    let edge_table = build_edge_table();
     let project_id = create_project(&pool, &bus, "Canonical Test M31").await;
 
     // Step 1: add a source so the project can be ready.
@@ -118,7 +116,6 @@ async fn t046a_user_ipc_and_auto_read_same_canonical_lifecycle() {
             ProjectState::Processing,
             TransitionActor::User,
         ),
-        &edge_table,
     )
     .await;
 
@@ -164,7 +161,6 @@ async fn t046a_user_ipc_and_auto_read_same_canonical_lifecycle() {
             ProjectState::Ready,
             TransitionActor::User,
         ),
-        &edge_table,
     )
     .await;
 
@@ -184,7 +180,6 @@ async fn t046a_user_ipc_and_auto_read_same_canonical_lifecycle() {
 async fn t046b_no_dual_write_to_legacy_project_table() {
     let (pool, bus) = setup().await;
     let project_id = create_project(&pool, &bus, "No Divergence NGC 7000").await;
-    let edge_table = build_edge_table();
 
     // Force the lifecycle to `ready` by direct repo call.
     repo::update_project_lifecycle(&pool, &project_id, "ready").await.unwrap();
@@ -203,7 +198,6 @@ async fn t046b_no_dual_write_to_legacy_project_table() {
             ProjectState::Processing,
             TransitionActor::User,
         ),
-        &edge_table,
     )
     .await;
 
@@ -388,7 +382,6 @@ async fn t048e_unblocking_clears_blocked_reason() {
     let (pool, bus) = setup().await;
     let project_id = create_project(&pool, &bus, "M101 Clear Reason").await;
     let debounce = Arc::new(Mutex::new(DebounceTable::new(DEBOUNCE_WINDOW)));
-    let edge_table = build_edge_table();
 
     // Block first.
     let condition = BlockCondition::User { note: "manual block".to_owned() };
@@ -408,7 +401,6 @@ async fn t048e_unblocking_clears_blocked_reason() {
             ProjectState::Ready,
             TransitionActor::User,
         ),
-        &edge_table,
     )
     .await;
     assert!(resp.error.is_none());

--- a/crates/app/core/tests/transition_apply.rs
+++ b/crates/app/core/tests/transition_apply.rs
@@ -15,7 +15,6 @@
 //! `domain_core::lifecycle::action_review_requirement` for the (now empty)
 //! action-bound review table.
 
-use app_core::lifecycle_use_case::build_edge_table;
 use app_core::transition_use_case::apply_transition;
 use audit::bus::EventBus;
 use contracts_core::lifecycle::{
@@ -89,7 +88,6 @@ async fn success_path_commits_both_sides() {
     insert_project(db.pool(), &project, &target, "ready").await;
 
     let project_uuid = Uuid::parse_str(&project).unwrap();
-    let table = build_edge_table();
 
     let resp = apply_transition(
         &repo,
@@ -100,7 +98,6 @@ async fn success_path_commits_both_sides() {
             ProjectState::Processing,
             TransitionActor::User,
         ),
-        &table,
     )
     .await;
 
@@ -123,7 +120,6 @@ async fn refused_no_mutation_disallowed_edge() {
     insert_project(db.pool(), &project, &target, "processing").await;
 
     let project_uuid = Uuid::parse_str(&project).unwrap();
-    let table = build_edge_table();
 
     // processing → ready is explicitly disallowed (research.md §2.1).
     let resp = apply_transition(
@@ -135,7 +131,6 @@ async fn refused_no_mutation_disallowed_edge() {
             ProjectState::Ready,
             TransitionActor::User,
         ),
-        &table,
     )
     .await;
 
@@ -181,7 +176,6 @@ async fn same_state_returns_noop_no_writes() {
     insert_project(db.pool(), &project, &target, "ready").await;
 
     let project_uuid = Uuid::parse_str(&project).unwrap();
-    let table = build_edge_table();
 
     let resp = apply_transition(
         &repo,
@@ -192,7 +186,6 @@ async fn same_state_returns_noop_no_writes() {
             ProjectState::Ready,
             TransitionActor::User,
         ),
-        &table,
     )
     .await;
 
@@ -215,7 +208,6 @@ async fn plan_required_refusal() {
     insert_project(db.pool(), &project, &target, "ready").await;
 
     let project_uuid = Uuid::parse_str(&project).unwrap();
-    let table = build_edge_table();
 
     // ready → prepared requires a FilesystemPlan per T044.
     let resp = apply_transition(
@@ -227,7 +219,6 @@ async fn plan_required_refusal() {
             ProjectState::Prepared,
             TransitionActor::User,
         ),
-        &table,
     )
     .await;
 

--- a/crates/app/core/tests/us1_coverage_smoke.rs
+++ b/crates/app/core/tests/us1_coverage_smoke.rs
@@ -8,7 +8,6 @@
 
 mod support;
 
-use app_core::lifecycle_use_case::build_edge_table;
 use app_core::transition_use_case::apply_transition;
 use contracts_core::lifecycle::{
     ProjectState, ProjectTransitionRequest, TransitionActor, TransitionRequest, TransitionStatus,
@@ -71,8 +70,7 @@ async fn success_transition_writes_applied_audit_row() {
         TransitionActor::User,
     ));
 
-    let edge_table = build_edge_table();
-    let resp = apply_transition(&repo, &bus, request, &edge_table).await;
+    let resp = apply_transition(&repo, &bus, request).await;
 
     assert_eq!(
         resp.status,

--- a/crates/app/lifecycle/src/lifecycle_use_case.rs
+++ b/crates/app/lifecycle/src/lifecycle_use_case.rs
@@ -1,17 +1,21 @@
-//! `transition_lifecycle` use case — stub wiring for spec 002.
+//! `transition_lifecycle` — the shared lifecycle write-primitive.
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 //!
-//! Flow (full impl lands in T003/T044):
-//! 1. Load current state from repository.
-//! 2. Validate (entity_type, from, to) against the canonical edge table.
-//! 3. Perform atomic CAS via `repository.record_transition`.
-//! 4. Publish `lifecycle.transition.applied` on the event bus.
+//! This is intentionally a thin, **un-gated** primitive: it CAS-writes a
+//! lifecycle transition and publishes `lifecycle.transition.applied`. It does
+//! NOT enforce business rules.
 //!
-//! This file proves the wiring compiles. Business-rule enforcement (plan
-//! requirement checks, actor/blocked gate, provenance review gate) is
-//! deferred to T044/T045/T046.
-
-use std::collections::HashMap;
+//! Business-rule enforcement (edge legality, actor/blocked gate, provenance
+//! review gate, plan-requirement gate) lives one layer up in
+//! [`crate::transition_use_case::apply_transition`], which is what the
+//! `lifecycle.transition.apply` command calls. `apply_transition` runs every
+//! gate and only then reaches this primitive.
+//!
+//! The one caller that reaches this primitive directly, bypassing the gates,
+//! is the archive-closure path (`app_core::plan_apply::finalize_archive_lifecycle`):
+//! there the `completed → archived` plan was already reviewed, approved, and
+//! applied, so re-running the requires-plan gate would wrongly refuse it. That
+//! bypass is deliberate and documented at the call site.
 
 use audit::bus::EventBus;
 use audit::event_bus::{LifecycleTransitionApplied, Source, TOPIC_LIFECYCLE_TRANSITION_APPLIED};
@@ -20,39 +24,6 @@ use domain_core::lifecycle::data_asset::EntityType;
 use persistence_db::repositories::lifecycle::{
     LifecycleRepository, TransitionRecord, TransitionRequest,
 };
-
-/// Metadata carried on an allowed transition edge.
-#[derive(Clone, Debug)]
-pub struct EdgeMeta {
-    /// True when this edge requires a `FilesystemPlan` to be approved first.
-    pub requires_plan: bool,
-}
-
-/// Canonical transition edge table (spec 002 data-model.md §Plan-Requirement Edge Table).
-///
-/// Only edges that have special constraints are listed here.
-/// Unlisted edges default to `requires_plan = false` and are permitted.
-///
-/// TODO T044: wire the full table from data-model.md and enforce at runtime.
-#[must_use]
-pub fn build_edge_table() -> HashMap<EntityType, Vec<([&'static str; 2], EdgeMeta)>> {
-    let mut m: HashMap<EntityType, Vec<([&'static str; 2], EdgeMeta)>> = HashMap::new();
-
-    // project edges that require a plan
-    m.entry(EntityType::Project).or_default().extend([
-        (["ready", "prepared"], EdgeMeta { requires_plan: true }),
-        (["prepared", "ready"], EdgeMeta { requires_plan: true }),
-        (["completed", "archived"], EdgeMeta { requires_plan: true }),
-        (["blocked", "archived"], EdgeMeta { requires_plan: true }),
-    ]);
-
-    // prepared_source: all → retired requires plan
-    m.entry(EntityType::PreparedSource)
-        .or_default()
-        .push((["*", "retired"], EdgeMeta { requires_plan: true }));
-
-    m
-}
 
 /// Error type for the lifecycle use case.
 #[derive(Debug, thiserror::Error)]
@@ -79,30 +50,29 @@ pub struct TransitionCommand {
 
 /// Apply a lifecycle transition via the repository, then publish an event.
 ///
+/// Un-gated by design: this primitive assumes the caller already validated the
+/// transition (edge legality, actor, provenance, plan requirement). Callers
+/// reaching business rules must go through
+/// [`crate::transition_use_case::apply_transition`]; the archive-closure path
+/// is the one deliberate exception (see the module docs).
+///
 /// Returns `Ok(None)` when `from_state == to_state` (noop — no audit row, no event).
 ///
 /// # Errors
-/// - `LifecycleError::Refused` when the edge requires a plan that is not approved
-///   (full validation deferred to T044).
-/// - `LifecycleError::Persistence` on repository failure.
-pub async fn transition_lifecycle<R, S>(
+/// - `LifecycleError::Persistence` on repository failure (including the atomic
+///   CAS in `record_transition` rejecting a stale `from_state`).
+pub async fn transition_lifecycle<R>(
     repo: &R,
     bus: &EventBus,
     cmd: TransitionCommand,
-    _edge_table: &HashMap<EntityType, Vec<([&'static str; 2], EdgeMeta)>, S>,
 ) -> Result<Option<TransitionRecord>, LifecycleError>
 where
     R: LifecycleRepository + Sync,
-    S: std::hash::BuildHasher,
 {
     // Noop: caller-requested next_state equals current_state.
     if cmd.from_state == cmd.to_state {
         return Ok(None);
     }
-
-    // TODO T044: validate edge against _edge_table; check plan-requirement gate.
-    // TODO T045: enforce actor/blocked gate (actor == system only on blocked edges).
-    // TODO T046: provenance.unreviewed gate for action-critical fields.
 
     let record = repo
         .record_transition(TransitionRequest {
@@ -162,7 +132,6 @@ mod tests {
     async fn noop_returns_none_without_persisting() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = build_edge_table();
 
         let result = transition_lifecycle(
             &repo,
@@ -176,7 +145,6 @@ mod tests {
                 actor: "user".to_owned(),
                 request_id: EntityId::new(),
             },
-            &table,
         )
         .await
         .unwrap();
@@ -189,7 +157,6 @@ mod tests {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
         let mut rx = bus.subscribe();
-        let table = build_edge_table();
 
         let record = transition_lifecycle(
             &repo,
@@ -203,7 +170,6 @@ mod tests {
                 actor: "user".to_owned(),
                 request_id: EntityId::new(),
             },
-            &table,
         )
         .await
         .unwrap()
@@ -226,7 +192,6 @@ mod tests {
     async fn archive_closure_drives_completed_to_archived() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = build_edge_table();
 
         let record = transition_lifecycle(
             &repo,
@@ -240,7 +205,6 @@ mod tests {
                 actor: "user".to_owned(),
                 request_id: EntityId::new(),
             },
-            &table,
         )
         .await
         .expect("closure transition must not error")

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -16,8 +16,6 @@
 //! required field is not yet `reviewed`. Review state is derived from
 //! field-level provenance — it is NOT a per-entity column.
 
-use std::collections::HashMap;
-
 use audit::bus::EventBus;
 use contracts_core::lifecycle::{
     TransitionActor, TransitionError, TransitionErrorCode, TransitionRequest, TransitionResponse,
@@ -36,9 +34,7 @@ use serde::Serialize;
 use time::format_description::well_known::Rfc3339;
 use uuid::Uuid;
 
-use crate::lifecycle_use_case::{
-    transition_lifecycle, EdgeMeta, LifecycleError, TransitionCommand,
-};
+use crate::lifecycle_use_case::{transition_lifecycle, LifecycleError, TransitionCommand};
 
 /// Apply a lifecycle transition given a contract `TransitionRequest`.
 ///
@@ -51,15 +47,13 @@ use crate::lifecycle_use_case::{
 ///    provenance origin is not `reviewed` → `provenance.unreviewed`.
 /// 6. `requires_plan(...)` true → `plan.required` (plan creation deferred).
 /// 7. Hand off to [`transition_lifecycle`].
-pub async fn apply_transition<R, S>(
+pub async fn apply_transition<R>(
     repo: &R,
     bus: &EventBus,
     request: TransitionRequest,
-    edge_table: &HashMap<EntityType, Vec<([&'static str; 2], EdgeMeta)>, S>,
 ) -> TransitionResponse
 where
     R: LifecycleRepository + Sync,
-    S: std::hash::BuildHasher,
 {
     let parsed = match parse_request(request) {
         Ok(parsed) => parsed,
@@ -166,30 +160,28 @@ where
     }
 
     // 7. Hand off — record + publish.
-    dispatch_to_repository(repo, bus, command, edge_table, request_id, prior_state).await
+    dispatch_to_repository(repo, bus, command, request_id, prior_state).await
 }
 
 /// Final dispatch step of [`apply_transition`]. Extracted to keep
 /// `apply_transition` itself under clippy's `too_many_lines` limit and to
 /// keep the refusal-audit recovery (for CAS-loss and not-found errors) in
 /// a single locus.
-async fn dispatch_to_repository<R, S>(
+async fn dispatch_to_repository<R>(
     repo: &R,
     bus: &EventBus,
     command: TransitionCommand,
-    edge_table: &HashMap<EntityType, Vec<([&'static str; 2], EdgeMeta)>, S>,
     request_id: Uuid,
     prior_state: String,
 ) -> TransitionResponse
 where
     R: LifecycleRepository + Sync,
-    S: std::hash::BuildHasher,
 {
     // Clone for refusal-audit recovery in case `transition_lifecycle` itself
     // fails after our pre-checks (e.g. CAS lost a race, missing entity).
     // The clone is cheap (UUIDs + short strings).
     let command_for_refusal = command.clone();
-    match transition_lifecycle(repo, bus, command, edge_table).await {
+    match transition_lifecycle(repo, bus, command).await {
         Ok(None) => TransitionResponse::noop(request_id),
         Ok(Some(record)) => {
             let applied_at = record
@@ -696,14 +688,12 @@ mod tests {
     async fn rejects_disallowed_edge() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         // processing → ready is explicitly disallowed (research.md §2.1).
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Processing, ProjectState::Ready, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -717,13 +707,11 @@ mod tests {
     async fn rejects_system_on_non_blocked_edge() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Ready, ProjectState::Processing, TransitionActor::System),
-            &table,
         )
         .await;
 
@@ -737,14 +725,12 @@ mod tests {
     async fn allows_system_on_blocked_recovery() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         // blocked → ready does not require a plan; system actor is allowed.
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Blocked, ProjectState::Ready, TransitionActor::System),
-            &table,
         )
         .await;
 
@@ -761,13 +747,11 @@ mod tests {
     async fn flags_plan_required_for_ready_to_prepared() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Ready, ProjectState::Prepared, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -778,13 +762,11 @@ mod tests {
     async fn same_state_returns_noop() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Ready, ProjectState::Ready, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -796,7 +778,6 @@ mod tests {
     async fn allows_system_on_setup_incomplete_to_ready() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
@@ -806,7 +787,6 @@ mod tests {
                 ProjectState::Ready,
                 TransitionActor::System,
             ),
-            &table,
         )
         .await;
 
@@ -824,13 +804,11 @@ mod tests {
     async fn rejects_system_on_ready_to_processing() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Ready, ProjectState::Processing, TransitionActor::System),
-            &table,
         )
         .await;
 
@@ -845,13 +823,11 @@ mod tests {
     async fn flags_plan_required_for_completed_to_archived() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Completed, ProjectState::Archived, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -863,14 +839,12 @@ mod tests {
     async fn flags_plan_required_for_blocked_to_archived() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         // blocked → archived: system actor is permitted (touches blocked), but plan is required
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Blocked, ProjectState::Archived, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -882,13 +856,11 @@ mod tests {
     async fn flags_plan_required_for_archived_to_ready() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Archived, ProjectState::Ready, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -900,7 +872,6 @@ mod tests {
     async fn flags_plan_required_for_archived_to_processing() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
@@ -910,7 +881,6 @@ mod tests {
                 ProjectState::Processing,
                 TransitionActor::User,
             ),
-            &table,
         )
         .await;
 
@@ -922,13 +892,11 @@ mod tests {
     async fn rejects_processing_to_ready() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Processing, ProjectState::Ready, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -943,13 +911,11 @@ mod tests {
     async fn rejects_blocked_to_completed() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Blocked, ProjectState::Completed, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -964,13 +930,11 @@ mod tests {
     async fn rejects_archived_to_completed() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Archived, ProjectState::Completed, TransitionActor::User),
-            &table,
         )
         .await;
 
@@ -985,13 +949,11 @@ mod tests {
     async fn allows_ready_to_processing_user() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
-        let table = crate::lifecycle_use_case::build_edge_table();
 
         let resp = apply_transition(
             &repo,
             &bus,
             project_request(ProjectState::Ready, ProjectState::Processing, TransitionActor::User),
-            &table,
         )
         .await;
 


### PR DESCRIPTION
## Summary
- Resolves the "lifecycle stub on the archive path" finding from the duplication-and-abstraction audit. On investigation the finding turned out to be based on **stale, misleading comments**, not a missing gate: edge/actor/provenance/plan validation all run in `apply_transition`; `transition_lifecycle` is an intentional thin write-primitive; the archive-closure bypass is deliberate and documented. Three concrete cleanups plus one small hardening.

### 1. Fix misleading comments (comment-only)
Rewrote the `TODO T044-046` comments + "stub wiring" module doc in `lifecycle_use_case.rs` to state the real architecture (gates enforced in `apply_transition`; this primitive is deliberately un-gated; archive path bypasses by design). The old comments falsely advertised the primitive as unguarded — a trap that could lead someone to duplicate the gates or delete the archive bypass.

### 2. Delete dead `build_edge_table` / `EdgeMeta` plumbing
It was a *partial* duplicate of the authoritative `domain_core::lifecycle::plan_requirement::TABLE`, threaded through `AppState` → `apply_transition` → `dispatch_to_repository` → `transition_lifecycle` (as `_edge_table`, **never read**) and the archive path. Removed the param from every signature + ~30 call sites; deleted `build_edge_table` and `EdgeMeta`. Behavior-preserving.

### 3. Guard archive closure against illegal edges (latent §II fix)
`finalize_archive_lifecycle` is the one path that reaches the un-gated primitive directly, and `record_transition` only CAS-checks `from_state` — so it would drive `<any state> → archived`. Per the domain edge table, the only legal edges into `archived` are `completed → archived` and `blocked → archived`. The closure now **refuses** any other source state (logs + leaves lifecycle unchanged) instead of recording an illegal, unaudited edge (Constitution §II). Added a regression test.

## Verification
- `cargo fmt --all --check` clean; `clippy --all-targets -D warnings` clean (`app_core_lifecycle`, `app_core`, `desktop_shell`).
- Tests green: `app_core_lifecycle` 29, `app_core` lib 220 (incl. 4 `finalize_archive_lifecycle`, one new), `transition_apply` 4, `lifecycle_canonical` 8, `us1_coverage_smoke` 2, desktop `commands` 41.

## Not a product decision
The audit flagged this as a product call ("finish the partial edge table or document it as intentional"). The code answers it: the partial `build_edge_table` is **dead** (deleted); the complete `plan_requirement::TABLE` is already in use. No schema, contract, error-code, or frontend changes.