### PR TITLE
refactor: fold Add Target dialog into the shared Modal; test the real target error mapping

### DIFF
--- a/apps/desktop/src/features/targets/AddTargetDialog.tsx
+++ b/apps/desktop/src/features/targets/AddTargetDialog.tsx
@@ -13,10 +13,9 @@
  */
 
 import { useState, useCallback } from 'react';
-import { Dialog } from '@base-ui-components/react/dialog';
 import { m } from '@/lib/i18n';
 import { Btn, Pill } from '@/ui';
-import { TargetSearch } from '@/components';
+import { Modal, TargetSearch } from '@/components';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type { TargetSuggestion } from '@/bindings/aliases';
@@ -85,73 +84,65 @@ export function AddTargetDialog({ open, onClose, onAdded }: AddTargetDialogProps
   }, [pending, handleOpenChange, onAdded]);
 
   return (
-    <Dialog.Root open={open} onOpenChange={handleOpenChange}>
-      <Dialog.Portal>
-        <Dialog.Backdrop className="alm-confirm-overlay__backdrop" />
-        <Dialog.Popup
-          className="alm-confirm-overlay alm-add-target__popup"
-          aria-label={m.targets_add_target()}
-        >
-          <div className="alm-confirm-overlay__header">
-            <Dialog.Title className="alm-confirm-overlay__title">{m.targets_add_target()}</Dialog.Title>
-            <Dialog.Description className="alm-confirm-overlay__description">
-              {m.targets_add_target_desc()}
-            </Dialog.Description>
-          </div>
-
-          <div
-            className="alm-confirm-overlay__body alm-add-target__body"
+    <Modal
+      open={open}
+      onClose={() => handleOpenChange(false)}
+      title={m.targets_add_target()}
+      subtitle={m.targets_add_target_desc()}
+      size="md"
+      className="alm-add-target__popup"
+      ariaLabel={m.targets_add_target()}
+      footer={
+        <>
+          <Btn
+            type="button"
+            variant="ghost"
+            onClick={() => handleOpenChange(false)}
+            disabled={resolving}
           >
-            {pending ? (
-              <div>
-                <span className="alm-field-label">{m.targets_add_target_selected()}</span>
-                <div className="alm-add-target__selected-row">
-                  <Pill variant="accent">{pending.primaryDesignation}</Pill>
-                  {pending.commonName && (
-                    <span className="alm-field-hint">{pending.commonName}</span>
-                  )}
-                  <Btn type="button" variant="ghost" onClick={reset}>
-                    {m.common_change()}
-                  </Btn>
-                </div>
-              </div>
-            ) : (
-              <TargetSearch
-                label={m.targets_add_target_search_label()}
-                placeholder={m.projects_create_target_search_placeholder()}
-                onSelect={handleSelect}
-                // eslint-disable-next-line jsx-a11y/no-autofocus -- focus management: moves focus to the search field when the Add Target dialog opens (expected modal behaviour)
-                autoFocus
-              />
-            )}
-
-            {error && (
-              <span role="alert" className="alm-field-error">
-                {error}
-              </span>
-            )}
+            {m.common_cancel()}
+          </Btn>
+          <Btn
+            type="button"
+            variant="primary"
+            disabled={!pending || resolving}
+            onClick={() => void handleConfirm()}
+          >
+            {resolving ? m.common_adding() : m.targets_add_target()}
+          </Btn>
+        </>
+      }
+    >
+      <div className="alm-add-target__body">
+        {pending ? (
+          <div>
+            <span className="alm-field-label">{m.targets_add_target_selected()}</span>
+            <div className="alm-add-target__selected-row">
+              <Pill variant="accent">{pending.primaryDesignation}</Pill>
+              {pending.commonName && (
+                <span className="alm-field-hint">{pending.commonName}</span>
+              )}
+              <Btn type="button" variant="ghost" onClick={reset}>
+                {m.common_change()}
+              </Btn>
+            </div>
           </div>
+        ) : (
+          <TargetSearch
+            label={m.targets_add_target_search_label()}
+            placeholder={m.projects_create_target_search_placeholder()}
+            onSelect={handleSelect}
+            // eslint-disable-next-line jsx-a11y/no-autofocus -- focus management: moves focus to the search field when the Add Target dialog opens (expected modal behaviour)
+            autoFocus
+          />
+        )}
 
-          <div className="alm-confirm-overlay__footer">
-            <Btn
-              type="button"
-              variant="ghost"
-              onClick={() => handleOpenChange(false)}
-              disabled={resolving}
-            >
-              {m.common_cancel()}
-            </Btn>
-            <Btn
-              type="button"
-              variant="primary"
-              disabled={!pending || resolving}
-              onClick={() => void handleConfirm()}
-            >
-              {resolving ? m.common_adding() : m.targets_add_target()}
-            </Btn>
-          </div>
-        </Dialog.Popup>
-      </Dialog.Portal>
-    </Dialog.Root>
+        {error && (
+          <span role="alert" className="alm-field-error">
+            {error}
+          </span>
+        )}
+      </div>
+    </Modal>
   );
 }

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -35,6 +35,7 @@ import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn } from '@/ui';
 import { m } from '@/lib/i18n';
 import { altitudeFor, rowAltitudeFor, USABLE_ALT_DEG } from './planner-altitude';
+import { errorMessage } from './target-error-message';
 import { useActiveSite } from './observing-sites/site-store';
 import { usePlannerDateMs } from './planner-date-store';
 import { GuidanceCell } from './GuidanceCell';
@@ -103,26 +104,6 @@ function fmtDec(deg: number): string {
   const mm = Math.floor((abs - dd) * 60);
   const ss = ((abs - dd) * 60 - mm) * 60;
   return `${sign}${String(dd).padStart(2, '0')}°${String(mm).padStart(2, '0')}′${ss.toFixed(0).padStart(2, '0')}″`;
-}
-
-/** Map ContractError.code to a user-readable message. */
-function errorMessage(err: ContractError, fallback: string): string {
-  switch (err.code) {
-    case 'alias.blank':
-      return m.targets_detail_alias_blank();
-    case 'alias.not_found':
-      return m.targets_detail_alias_not_found();
-    case 'alias.not_removable':
-      return m.targets_detail_alias_not_removable();
-    case 'target.not_found':
-      return m.targets_detail_target_not_found();
-    case 'target.invalid_id':
-      return m.targets_detail_invalid_target_id();
-    case 'note.content_too_large':
-      return m.err_note_content_too_large();
-    default:
-      return fallback;
-  }
 }
 
 // ── Altitude curve helper ─────────────────────────────────────────────────────

--- a/apps/desktop/src/features/targets/target-error-message.ts
+++ b/apps/desktop/src/features/targets/target-error-message.ts
@@ -1,0 +1,34 @@
+/**
+ * Maps a target-operation `ContractError.code` to a user-readable, localized
+ * message.
+ *
+ * Extracted from `TargetDetailV2.tsx` so the mapping can be unit-tested directly
+ * (see `target-identity.test.ts`) instead of via a hand-copied mirror that
+ * silently drifts from production.
+ */
+
+import { m } from '@/lib/i18n';
+import type { ContractError } from '@/lib/errors';
+
+/**
+ * Map a target `ContractError.code` to a user-readable, localized message.
+ * Returns `fallback` for any unrecognized code.
+ */
+export function errorMessage(err: ContractError, fallback: string): string {
+  switch (err.code) {
+    case 'alias.blank':
+      return m.targets_detail_alias_blank();
+    case 'alias.not_found':
+      return m.targets_detail_alias_not_found();
+    case 'alias.not_removable':
+      return m.targets_detail_alias_not_removable();
+    case 'target.not_found':
+      return m.targets_detail_target_not_found();
+    case 'target.invalid_id':
+      return m.targets_detail_invalid_target_id();
+    case 'note.content_too_large':
+      return m.err_note_content_too_large();
+    default:
+      return fallback;
+  }
+}

--- a/apps/desktop/src/features/targets/target-identity.test.ts
+++ b/apps/desktop/src/features/targets/target-identity.test.ts
@@ -2,7 +2,8 @@
  * Spec 023 target identity logic tests.
  *
  * Tests:
- * 1. Error code mapping — all 7 known TargetOpError codes produce human-readable strings.
+ * 1. Error code mapping — the real TargetDetailV2 `errorMessage` helper maps
+ *    every known `ContractError` code to its localized message.
  * 2. Date formatting helper.
  * 3. Targets NOT in primary nav (T007 / X-3 regression guard).
  * 4. Contract snapshot: ProjectLifecycle enum values match spec 009.
@@ -10,76 +11,34 @@
 
 import { describe, it, expect } from 'vitest';
 
-// ── Error code mapping (mirrors TargetDetailV2.tsx helper) ────────────────────
+import { m } from '@/lib/i18n';
+import type { ContractError } from '@/lib/errors';
+import { errorMessage } from './target-error-message';
 
-type TargetOpError = { code: string; message: string };
+// ── Error code mapping (exercises the REAL TargetDetailV2 helper) ─────────────
+//
+// This imports the production `errorMessage` (extracted to
+// `target-error-message.ts`) rather than a hand-copied mirror, so the test
+// cannot silently drift from the mapping the UI actually uses — as it did when
+// the target error envelope moved from the old `TargetOpError` (`alias.duplicate`,
+// `designation.*`, …) to `ContractError` (`alias.blank`, `alias.not_removable`, …).
 
-function errorMessage(err: TargetOpError, fallback: string): string {
-  switch (err.code) {
-    case 'alias.duplicate':
-      return 'This alias is already used by a different target.';
-    case 'alias.invalid':
-      return 'Alias must not be empty.';
-    case 'alias.is_primary':
-      return 'Cannot remove the primary name. Rename primary first.';
-    case 'alias.not_found':
-      return 'Alias not found on this target.';
-    case 'designation.not_in_aliases':
-      return 'New primary must already be an alias. Add it first.';
-    case 'designation.already_primary':
-      return 'This is already the primary name.';
-    case 'target.not_found':
-      return 'Target not found.';
-    default:
-      return fallback;
-  }
-}
+const ce = (code: string): ContractError => ({ code, message: '' }) as ContractError;
 
-describe('errorMessage', () => {
-  it('maps alias.duplicate', () => {
-    expect(errorMessage({ code: 'alias.duplicate', message: '' }, 'fallback')).toBe(
-      'This alias is already used by a different target.',
-    );
+describe('errorMessage (real TargetDetailV2 mapping)', () => {
+  it.each([
+    ['alias.blank', m.targets_detail_alias_blank()],
+    ['alias.not_found', m.targets_detail_alias_not_found()],
+    ['alias.not_removable', m.targets_detail_alias_not_removable()],
+    ['target.not_found', m.targets_detail_target_not_found()],
+    ['target.invalid_id', m.targets_detail_invalid_target_id()],
+    ['note.content_too_large', m.err_note_content_too_large()],
+  ])('maps %s to its localized message', (code, expected) => {
+    expect(errorMessage(ce(code), 'fallback')).toBe(expected);
   });
 
-  it('maps alias.invalid', () => {
-    expect(errorMessage({ code: 'alias.invalid', message: '' }, 'fallback')).toBe(
-      'Alias must not be empty.',
-    );
-  });
-
-  it('maps alias.is_primary', () => {
-    expect(errorMessage({ code: 'alias.is_primary', message: '' }, 'fallback')).toBe(
-      'Cannot remove the primary name. Rename primary first.',
-    );
-  });
-
-  it('maps alias.not_found', () => {
-    expect(errorMessage({ code: 'alias.not_found', message: '' }, 'fallback')).toBe(
-      'Alias not found on this target.',
-    );
-  });
-
-  it('maps designation.not_in_aliases', () => {
-    expect(
-      errorMessage({ code: 'designation.not_in_aliases', message: '' }, 'fallback'),
-    ).toBe('New primary must already be an alias. Add it first.');
-  });
-
-  it('maps designation.already_primary', () => {
-    expect(
-      errorMessage({ code: 'designation.already_primary', message: '' }, 'fallback'),
-    ).toBe('This is already the primary name.');
-  });
-
-  it('maps target.not_found', () => {
-    expect(errorMessage({ code: 'target.not_found', message: '' }, 'fallback')).toBe(
-      'Target not found.',
-    );
-  });
-
-  it('returns fallback for unknown code', () => {
-    expect(errorMessage({ code: 'some.unknown.code', message: '' }, 'fallback')).toBe('fallback');
+  it('returns the fallback for an unknown code', () => {
+    expect(errorMessage(ce('some.unknown.code'), 'fallback')).toBe('fallback');
   });
 });
 


### PR DESCRIPTION
## Summary
- Tidies the `features/targets` slice of the audit's Tier-4 frontend-consistency work — the part frontend node n8 left untouched because targets was a different node's lane.

### 1. Fold `AddTargetDialog` into the canonical `Modal`
Replaced the ad-hoc base-ui `Dialog.Root`/`Portal`/`Backdrop`/`Popup` chrome with the shared `Modal` (title/subtitle/footer slots), matching the fold n8 applied to `CreateProjectDialog`. Pure chrome swap — no behavior change; the dialog's search → select → confirm flow is unchanged and still covered by `AddTargetDialog.test.tsx`.

### 2. Fix the `target-identity.test.ts` drift
The test carried a **hand-copied `errorMessage` mirror** for the retired `TargetOpError` codes (`alias.duplicate`, `designation.*`, hard-coded English). After the `TargetOpError → ContractError` migration, production moved to different codes (`alias.blank`, `alias.not_removable`, `note.content_too_large`, …) and localized messages — so the test was asserting **dead logic** while passing (it tested its own copy, not the app).

Fixed properly: extracted the real `errorMessage(ContractError, fallback)` out of `TargetDetailV2` into `target-error-message.ts`, and rewrote the test to **import and exercise the actual helper** against the current codes/messages. It can't silently drift again.

## Verification (`apps/desktop`)
- `vitest run src/features/targets/` — **337 tests pass** (24 files), incl. `AddTargetDialog.test.tsx`, `TargetDetailV2.test.tsx`, and the rewritten `target-identity.test.ts`.
- `tsc --noEmit` clean; `eslint` 0 errors (no new warnings); design-token checks pass.

## Not included (deliberately)
The broader "migrate the targets feature's hand-rolled `useState`/`useEffect` IPC to TanStack-Query" item is **not** here: the targets feature has no query-store to migrate onto (it'd mean building one and rewriting a data-rich page — `TargetDetailV2` alone has ~9 fetch/mutation sites), which is a real refactor needing real-app validation, not "polish." Better as its own scoped effort.