### PR TITLE
chore: adopt fits-header + xisf-header crates (quick-xml 0.39->0.41)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3346,8 +3346,8 @@ name = "metadata_xisf"
 version = "0.1.0"
 dependencies = [
  "metadata_core",
- "quick-xml",
  "thiserror 2.0.18",
+ "xisf-header",
 ]
 
 [[package]]
@@ -4271,7 +4271,7 @@ checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64 0.22.1",
  "indexmap 2.14.0",
- "quick-xml",
+ "quick-xml 0.39.2",
  "serde",
  "time",
 ]
@@ -4491,6 +4491,15 @@ name = "quick-xml"
 version = "0.39.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "958f21e8e7ceb5a1aa7fa87fab28e7c75976e0bfe7e23ff069e0a260f894067d"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
 dependencies = [
  "memchr",
 ]
@@ -8480,6 +8489,17 @@ checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
  "rustix",
+]
+
+[[package]]
+name = "xisf-header"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "674af42f41782a63546ad77dc4e0c80e2abf6b65b7ca10d85b707c0da1fc886e"
+dependencies = [
+ "quick-xml 0.41.0",
+ "thiserror 2.0.18",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1824,6 +1824,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
+name = "fits-header"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75b5915639594adba540c8c25b4e842d6a04401cb309f97edc87b2fbd5daa8c9"
+dependencies = [
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "flate2"
 version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3322,6 +3332,7 @@ dependencies = [
 name = "metadata_fits"
 version = "0.1.0"
 dependencies = [
+ "fits-header",
  "metadata_core",
  "thiserror 2.0.18",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ async-trait = "0.1"
 hex = "0.4"
 minisign = { version = "0.7", default-features = false }
 reqwest = { version = "0.13", default-features = false, features = ["json", "rustls"] }
-quick-xml = "0.39"
+quick-xml = "0.41"
 sha2 = "0.10"
 tempfile = "3"
 unicode-normalization = "0.1"

--- a/crates/metadata/fits/Cargo.toml
+++ b/crates/metadata/fits/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 metadata_core = { path = "../core" }
 thiserror = { workspace = true }
+fits-header = "0.2"
 
 [lints]
 workspace = true

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -1,4 +1,4 @@
-//! Minimal pure-Rust FITS header reader (spec 005 T005).
+//! Pure-Rust FITS header reader (spec 005 T005), built on the `fits-header` crate.
 //!
 //! # FITS Header Format
 //!
@@ -11,24 +11,24 @@
 //! `GAIN`, `XBINNING`, `YBINNING`, `NAXIS1`, `NAXIS2`, `INSTRUME`, `TELESCOP`,
 //! `DATE-OBS`.
 //!
-//! No cfitsio or heavy C dependencies — the implementation reads raw bytes.
-//! Missing or garbage headers are handled gracefully; the extractor never
-//! panics or returns hard errors for corrupt files, preferring `None` values.
+//! No cfitsio or heavy C dependencies — `fits-header` is pure Rust. Missing or
+//! garbage headers are handled gracefully; the extractor never panics or
+//! returns hard errors for corrupt files, preferring `None` values.
 #![allow(clippy::doc_markdown)]
 
 use std::io::{self, Read};
 use std::path::Path;
 
+use fits_header::{FitsError, FromCard, Header};
 use metadata_core::{
-    parse_f64, parse_i64, sexagesimal_dec_to_deg, sexagesimal_ra_to_deg, MetadataExtractError,
-    MetadataExtractor, RawFileMetadata,
+    sexagesimal_dec_to_deg, sexagesimal_ra_to_deg, MetadataExtractError, MetadataExtractor,
+    RawFileMetadata,
 };
 
 // ── Constants ─────────────────────────────────────────────────────────────────
 
 const BLOCK_SIZE: usize = 2880;
 const CARD_SIZE: usize = 80;
-const CARDS_PER_BLOCK: usize = BLOCK_SIZE / CARD_SIZE;
 
 /// Maximum number of blocks to read before giving up.
 /// A typical FITS primary header is 1-4 blocks; 32 is extremely generous.
@@ -58,12 +58,19 @@ impl MetadataExtractor for FitsExtractor {
             msg: e.to_string(),
         })?;
 
-        let cards = read_header_cards(file, path).map_err(|e| MetadataExtractError::Io {
+        let bytes = read_header_bytes(file).map_err(|e| MetadataExtractError::Io {
             path: path.display().to_string(),
             msg: e.to_string(),
         })?;
 
-        Ok(Some(parse_cards(&cards)))
+        // fits_header::parse never actually errs (parsing is lenient by design);
+        // propagate defensively rather than unwrap.
+        let header = fits_header::parse(&bytes).map_err(|e| MetadataExtractError::Parse {
+            path: path.display().to_string(),
+            msg: e.to_string(),
+        })?;
+
+        Ok(Some(parse_header(&header)))
     }
 
     fn supports_extension(&self, ext: &str) -> bool {
@@ -73,11 +80,14 @@ impl MetadataExtractor for FitsExtractor {
 
 // ── Header reading ────────────────────────────────────────────────────────────
 
-/// Read all header cards up to (but not including) the END card.
+/// Read header blocks from `reader`, stopping once the `END` card is seen or
+/// after `MAX_HEADER_BLOCKS` (whichever first).
 ///
-/// Returns only the 80-byte cards that precede the `END` marker.
-fn read_header_cards(mut reader: impl Read, _path: &Path) -> io::Result<Vec<[u8; CARD_SIZE]>> {
-    let mut cards = Vec::new();
+/// FITS files can carry gigabytes of pixel data after the header; bounding the
+/// read here keeps header extraction cheap regardless of file size instead of
+/// pulling the whole file into memory for `fits_header::parse`.
+fn read_header_bytes(mut reader: impl Read) -> io::Result<Vec<u8>> {
+    let mut bytes = Vec::with_capacity(BLOCK_SIZE);
     let mut block = [0u8; BLOCK_SIZE];
 
     for _ in 0..MAX_HEADER_BLOCKS {
@@ -87,206 +97,109 @@ fn read_header_cards(mut reader: impl Read, _path: &Path) -> io::Result<Vec<[u8;
             Err(e) => return Err(e),
         }
 
-        for i in 0..CARDS_PER_BLOCK {
-            let card_bytes = &block[i * CARD_SIZE..(i + 1) * CARD_SIZE];
-            let mut card = [0u8; CARD_SIZE];
-            card.copy_from_slice(card_bytes);
-
-            // Check for END marker
-            if card_bytes.starts_with(b"END     ") || card_bytes.starts_with(b"END\x00") {
-                return Ok(cards);
-            }
-
-            cards.push(card);
+        let has_end = block
+            .chunks_exact(CARD_SIZE)
+            .any(|c| c.starts_with(b"END     ") || c.starts_with(b"END\x00"));
+        bytes.extend_from_slice(&block);
+        if has_end {
+            break;
         }
     }
 
-    Ok(cards)
+    Ok(bytes)
 }
 
-// ── Card parsing ──────────────────────────────────────────────────────────────
+// ── Header field extraction ──────────────────────────────────────────────────
 
-/// Parse a list of 80-byte FITS cards into [`RawFileMetadata`].
+/// Typed keyword read that never hard-errors: a duplicated keyword
+/// (`FitsError::AmbiguousKeyword`) falls back to its first occurrence instead
+/// of surfacing an error, preserving this extractor's "always `None`, never
+/// `Err`" contract for corrupt/odd files.
+fn get<T: FromCard>(header: &Header, key: &str) -> Option<T> {
+    match header.get::<T>(key) {
+        Ok(v) => v,
+        Err(FitsError::AmbiguousKeyword { .. }) => header.get_all::<T>(key).into_iter().next(),
+        Err(_) => None,
+    }
+}
+
+/// Like [`get`] but for quoted string values (`Header::get_str`).
+fn get_str(header: &Header, key: &str) -> Option<String> {
+    match header.get_str(key) {
+        Ok(v) => v.map(str::to_owned),
+        Err(FitsError::AmbiguousKeyword { .. }) => header.get_all::<String>(key).into_iter().next(),
+        Err(_) => None,
+    }
+}
+
+/// Map header keywords into [`RawFileMetadata`].
 ///
-/// The observer-location fallback arms share bodies but are intentionally
-/// separate keyword patterns with per-field `is_none()` guards (fallback
-/// precedence); the keyword dispatch is necessarily long.
-#[allow(clippy::match_same_arms, clippy::too_many_lines)]
-fn parse_cards(cards: &[[u8; CARD_SIZE]]) -> RawFileMetadata {
+/// The observer-location fallback chains and RA/DEC decimal-over-sexagesimal
+/// precedence are shared value shapes but are intentionally kept as separate
+/// keyword lookups (fallback precedence); the field list is necessarily long.
+// A struct-literal initializer would be far less readable than these named
+// per-field assignments given the multi-keyword fallback chains.
+#[allow(clippy::field_reassign_with_default)]
+fn parse_header(header: &Header) -> RawFileMetadata {
     let mut meta = RawFileMetadata::default();
 
-    for card in cards {
-        // A value card has keyword in bytes 0..8 and '= ' at bytes 8..10.
-        // Some cards use HIERARCH extension but we ignore those for now.
-        let keyword_bytes = &card[0..8];
-        // Trim trailing spaces from the 8-byte keyword field.
-        let keyword = std::str::from_utf8(keyword_bytes).unwrap_or("").trim_end();
+    meta.image_typ = get_str(header, "IMAGETYP");
+    meta.filter = get_str(header, "FILTER");
+    meta.object = get_str(header, "OBJECT");
+    // EXPTIME takes priority; EXPOSURE is the fallback.
+    meta.exposure = get::<String>(header, "EXPTIME").or_else(|| get::<String>(header, "EXPOSURE"));
+    meta.gain = get(header, "GAIN");
+    meta.x_binning = get(header, "XBINNING");
+    meta.y_binning = get(header, "YBINNING");
+    meta.naxis1 = get(header, "NAXIS1");
+    meta.naxis2 = get(header, "NAXIS2");
+    meta.instrume = get_str(header, "INSTRUME");
+    meta.telescop = get_str(header, "TELESCOP");
+    meta.date_obs = get_str(header, "DATE-OBS");
 
-        match keyword {
-            "IMAGETYP" => meta.image_typ = extract_string_value(card),
-            "FILTER" => meta.filter = extract_string_value(card),
-            "OBJECT" => meta.object = extract_string_value(card),
-            "EXPTIME" | "EXPOSURE" if meta.exposure.is_none() => {
-                meta.exposure = extract_numeric_string(card);
-            }
-            "GAIN" => meta.gain = extract_numeric_string(card),
-            "XBINNING" => meta.x_binning = extract_numeric_string(card),
-            "YBINNING" => meta.y_binning = extract_numeric_string(card),
-            "NAXIS1" => meta.naxis1 = extract_numeric_string(card),
-            "NAXIS2" => meta.naxis2 = extract_numeric_string(card),
-            "INSTRUME" => meta.instrume = extract_string_value(card),
-            "TELESCOP" => meta.telescop = extract_string_value(card),
-            "DATE-OBS" => meta.date_obs = extract_string_value(card),
-            // Stack/integration count: STACKCNT (preferred) or NCOMBINE fallback.
-            "STACKCNT" => {
-                meta.stack_count =
-                    extract_numeric_string(card).and_then(|s| s.trim().parse::<u32>().ok());
-            }
-            "NCOMBINE" if meta.stack_count.is_none() => {
-                meta.stack_count =
-                    extract_numeric_string(card).and_then(|s| s.trim().parse::<u32>().ok());
-            }
+    // Stack/integration count: STACKCNT (preferred) or NCOMBINE fallback.
+    meta.stack_count = get::<u32>(header, "STACKCNT").or_else(|| get::<u32>(header, "NCOMBINE"));
 
-            // ── Extended extracted metadata (spec 041 T062, R-9/R-18) ───────
-            // Offset / pedestal: OFFSET preferred, BLKLEVEL fallback.
-            "OFFSET" => {
-                meta.offset = extract_numeric_string(card).and_then(|s| parse_i64(&s));
-            }
-            "BLKLEVEL" if meta.offset.is_none() => {
-                meta.offset = extract_numeric_string(card).and_then(|s| parse_i64(&s));
-            }
-            // Temperatures.
-            "SET-TEMP" => {
-                meta.set_temp_c = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "CCD-TEMP" => {
-                meta.ccd_temp_c = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "DET-TEMP" if meta.ccd_temp_c.is_none() => {
-                // DWARF III non-standard fallback for actual sensor temp.
-                meta.ccd_temp_c = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            // Pointing: decimal RA/DEC preferred over sexagesimal OBJCTRA/OBJCTDEC.
-            "RA" => {
-                meta.ra_deg = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "OBJCTRA" if meta.ra_deg.is_none() => {
-                meta.ra_deg = extract_string_value(card).and_then(|s| sexagesimal_ra_to_deg(&s));
-            }
-            "DEC" => {
-                meta.dec_deg = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "OBJCTDEC" if meta.dec_deg.is_none() => {
-                meta.dec_deg = extract_string_value(card).and_then(|s| sexagesimal_dec_to_deg(&s));
-            }
-            // Rotation: ROTATANG (= ROTATOR, mechanical) is the flat-match key;
-            // OBJCTROT is the informational sky position angle. Never swap them.
-            "ROTATANG" => {
-                meta.rotator_angle_deg = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "ROTATOR" if meta.rotator_angle_deg.is_none() => {
-                meta.rotator_angle_deg = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "ROTNAME" => meta.rotator_name = extract_string_value(card),
-            "OBJCTROT" => {
-                meta.sky_rotation_deg = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            // Readout mode (optional grouping dim).
-            "READOUTM" => meta.readout_mode = extract_string_value(card),
-            // Optic train inputs.
-            "FOCALLEN" => {
-                meta.focal_length_mm = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "XPIXSZ" => {
-                meta.pixel_size_um = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "PIXSIZE" if meta.pixel_size_um.is_none() => {
-                meta.pixel_size_um = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            // Observer location: SITE* preferred, OBSGEO-* then *-OBS fallbacks.
-            "SITELAT" => {
-                meta.observer_lat = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "OBSGEO-B" if meta.observer_lat.is_none() => {
-                meta.observer_lat = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "LAT-OBS" if meta.observer_lat.is_none() => {
-                meta.observer_lat = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "SITELONG" => {
-                meta.observer_long = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "OBSGEO-L" if meta.observer_long.is_none() => {
-                meta.observer_long = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "LONG-OBS" if meta.observer_long.is_none() => {
-                meta.observer_long = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "SITEELEV" => {
-                meta.observer_elev = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "OBSGEO-H" if meta.observer_elev.is_none() => {
-                meta.observer_elev = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "ALT-OBS" if meta.observer_elev.is_none() => {
-                meta.observer_elev = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            // Time keywords.
-            "DATE-LOC" => meta.date_loc = extract_string_value(card),
-            "DATE-END" => meta.date_end = extract_string_value(card),
-            "MJD-AVG" => {
-                meta.mjd_avg = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            "MJD-OBS" => {
-                meta.mjd_obs = extract_numeric_string(card).and_then(|s| parse_f64(&s));
-            }
-            _ => {}
-        }
-    }
+    // ── Extended extracted metadata (spec 041 T062, R-9/R-18) ───────────────
+    // Offset / pedestal: OFFSET preferred, BLKLEVEL fallback.
+    meta.offset = get::<i64>(header, "OFFSET").or_else(|| get::<i64>(header, "BLKLEVEL"));
+    // Temperatures.
+    meta.set_temp_c = get(header, "SET-TEMP");
+    // CCD-TEMP preferred; DET-TEMP is the DWARF III non-standard fallback.
+    meta.ccd_temp_c = get::<f64>(header, "CCD-TEMP").or_else(|| get::<f64>(header, "DET-TEMP"));
+    // Pointing: decimal RA/DEC preferred over sexagesimal OBJCTRA/OBJCTDEC.
+    meta.ra_deg = get::<f64>(header, "RA")
+        .or_else(|| get_str(header, "OBJCTRA").and_then(|s| sexagesimal_ra_to_deg(&s)));
+    meta.dec_deg = get::<f64>(header, "DEC")
+        .or_else(|| get_str(header, "OBJCTDEC").and_then(|s| sexagesimal_dec_to_deg(&s)));
+    // Rotation: ROTATANG (= ROTATOR, mechanical) is the flat-match key;
+    // OBJCTROT is the informational sky position angle. Never swap them.
+    meta.rotator_angle_deg =
+        get::<f64>(header, "ROTATANG").or_else(|| get::<f64>(header, "ROTATOR"));
+    meta.rotator_name = get_str(header, "ROTNAME");
+    meta.sky_rotation_deg = get(header, "OBJCTROT");
+    // Readout mode (optional grouping dim).
+    meta.readout_mode = get_str(header, "READOUTM");
+    // Optic train inputs.
+    meta.focal_length_mm = get(header, "FOCALLEN");
+    meta.pixel_size_um = get::<f64>(header, "XPIXSZ").or_else(|| get::<f64>(header, "PIXSIZE"));
+    // Observer location: SITE* preferred, OBSGEO-* then *-OBS fallbacks.
+    meta.observer_lat = get::<f64>(header, "SITELAT")
+        .or_else(|| get::<f64>(header, "OBSGEO-B"))
+        .or_else(|| get::<f64>(header, "LAT-OBS"));
+    meta.observer_long = get::<f64>(header, "SITELONG")
+        .or_else(|| get::<f64>(header, "OBSGEO-L"))
+        .or_else(|| get::<f64>(header, "LONG-OBS"));
+    meta.observer_elev = get::<f64>(header, "SITEELEV")
+        .or_else(|| get::<f64>(header, "OBSGEO-H"))
+        .or_else(|| get::<f64>(header, "ALT-OBS"));
+    // Time keywords.
+    meta.date_loc = get_str(header, "DATE-LOC");
+    meta.date_end = get_str(header, "DATE-END");
+    meta.mjd_avg = get(header, "MJD-AVG");
+    meta.mjd_obs = get(header, "MJD-OBS");
 
     meta
-}
-
-/// Extract a FITS string value (between single quotes) from a card.
-///
-/// FITS string values look like:  `IMAGETYP= 'Light Frame'         / comment`
-/// The value is between single quotes. Trailing spaces inside the quotes are
-/// significant per FITS standard but we trim them for practical use.
-fn extract_string_value(card: &[u8; CARD_SIZE]) -> Option<String> {
-    // Bytes 0..8 keyword, byte 8 should be '=', byte 9 is usually ' '.
-    let value_area = std::str::from_utf8(&card[8..]).ok()?;
-    let after_eq = value_area.trim_start_matches(['=', ' ']);
-
-    if let Some(inner) = after_eq.strip_prefix('\'') {
-        // Find closing quote (handle doubled single-quote escape '' → ')
-        let close = inner.find('\'')?;
-        let raw = &inner[..close];
-        let trimmed = raw.trim_end();
-        if trimmed.is_empty() {
-            None
-        } else {
-            Some(trimmed.replace("''", "'"))
-        }
-    } else {
-        None
-    }
-}
-
-/// Extract a FITS numeric value (no quotes) from a card as a string.
-///
-/// Example: `NAXIS1  =                 4144 / image width in pixels`
-fn extract_numeric_string(card: &[u8; CARD_SIZE]) -> Option<String> {
-    let value_area = std::str::from_utf8(&card[8..]).ok()?;
-    // Skip '=' and whitespace
-    let value_part = value_area.trim_start_matches(['=', ' ']);
-    // Take until '/' (comment marker) or end of field
-    let raw_value = value_part.split('/').next().unwrap_or("").trim().to_owned();
-
-    if raw_value.is_empty() {
-        None
-    } else {
-        Some(raw_value)
-    }
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -300,6 +213,7 @@ mod tests {
     /// Build a single FITS block (2880 bytes) from a list of 80-char card strings.
     /// Missing cards are filled with spaces. Appends an END card.
     fn build_fits_header(cards: &[&str]) -> Vec<u8> {
+        const CARDS_PER_BLOCK: usize = BLOCK_SIZE / CARD_SIZE;
         let mut block = vec![b' '; BLOCK_SIZE];
         let mut idx = 0usize;
 
@@ -327,107 +241,86 @@ mod tests {
         format!("{s:<80}")
     }
 
+    /// Parse a set of 80-char card strings into [`RawFileMetadata`] via the
+    /// real `fits_header::parse` + [`parse_header`] path.
+    fn parse(cards: &[String]) -> RawFileMetadata {
+        let refs: Vec<&str> = cards.iter().map(String::as_str).collect();
+        let block = build_fits_header(&refs);
+        let header = fits_header::parse(&block).unwrap();
+        parse_header(&header)
+    }
+
     // ── IMAGETYP extraction ───────────────────────────────────────────────────
 
     #[test]
     fn parses_imagetyp_light_frame() {
-        let card = pad80("IMAGETYP= 'Light Frame'");
-        let block = build_fits_header(&[&card]);
-        let cards_parsed = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards_parsed);
+        let meta = parse(&[pad80("IMAGETYP= 'Light Frame'")]);
         assert_eq!(meta.image_typ, Some("Light Frame".to_owned()));
     }
 
     #[test]
     fn parses_imagetyp_dark() {
-        let card = pad80("IMAGETYP= 'Dark Frame'           / frame type");
-        let block = build_fits_header(&[&card]);
-        let cards_parsed = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards_parsed);
+        let meta = parse(&[pad80("IMAGETYP= 'Dark Frame'           / frame type")]);
         assert_eq!(meta.image_typ, Some("Dark Frame".to_owned()));
     }
 
     #[test]
     fn parses_imagetyp_bias() {
-        let card = pad80("IMAGETYP= 'Bias Frame'");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[pad80("IMAGETYP= 'Bias Frame'")]);
         assert_eq!(meta.image_typ, Some("Bias Frame".to_owned()));
     }
 
     #[test]
     fn parses_filter() {
-        let card = pad80("FILTER  = 'Ha      '");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[pad80("FILTER  = 'Ha      '")]);
         assert_eq!(meta.filter, Some("Ha".to_owned()));
     }
 
     #[test]
     fn parses_object() {
-        let card = pad80("OBJECT  = 'NGC 7000'           / object name");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[pad80("OBJECT  = 'NGC 7000'           / object name")]);
         assert_eq!(meta.object, Some("NGC 7000".to_owned()));
     }
 
     #[test]
     fn parses_exptime() {
-        let card = pad80("EXPTIME =                 300.0 / exposure time in seconds");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[pad80("EXPTIME =                 300.0 / exposure time in seconds")]);
         assert_eq!(meta.exposure, Some("300.0".to_owned()));
     }
 
     #[test]
     fn parses_gain() {
-        let card = pad80("GAIN    =                   100 / camera gain");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[pad80("GAIN    =                   100 / camera gain")]);
         assert_eq!(meta.gain, Some("100".to_owned()));
     }
 
     #[test]
     fn parses_naxis() {
-        let cards =
-            [pad80("NAXIS1  =                  4144"), pad80("NAXIS2  =                  2822")];
-        let block = build_fits_header(&cards.iter().map(String::as_str).collect::<Vec<_>>());
-        let parsed = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&parsed);
+        let meta = parse(&[
+            pad80("NAXIS1  =                  4144"),
+            pad80("NAXIS2  =                  2822"),
+        ]);
         assert_eq!(meta.naxis1, Some("4144".to_owned()));
         assert_eq!(meta.naxis2, Some("2822".to_owned()));
     }
 
     #[test]
     fn parses_instrume_and_telescop() {
-        let cards = [pad80("INSTRUME= 'ZWO ASI2600MM Pro'"), pad80("TELESCOP= 'AT130-EDT'")];
-        let block = build_fits_header(&cards.iter().map(String::as_str).collect::<Vec<_>>());
-        let parsed = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&parsed);
+        let meta = parse(&[pad80("INSTRUME= 'ZWO ASI2600MM Pro'"), pad80("TELESCOP= 'AT130-EDT'")]);
         assert_eq!(meta.instrume, Some("ZWO ASI2600MM Pro".to_owned()));
         assert_eq!(meta.telescop, Some("AT130-EDT".to_owned()));
     }
 
     #[test]
     fn parses_date_obs() {
-        let card = pad80("DATE-OBS= '2025-10-10T22:15:00'");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[pad80("DATE-OBS= '2025-10-10T22:15:00'")]);
         assert_eq!(meta.date_obs, Some("2025-10-10T22:15:00".to_owned()));
     }
 
     #[test]
     fn missing_keywords_return_none() {
-        let card = pad80("SIMPLE  =                    T / file conforms to FITS standard");
-        let block = build_fits_header(&[&card]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta =
+            parse(&[pad80("SIMPLE  =                    T / file conforms to FITS standard")]);
         assert!(meta.image_typ.is_none());
         assert!(meta.filter.is_none());
         assert!(meta.object.is_none());
@@ -435,9 +328,7 @@ mod tests {
 
     #[test]
     fn empty_block_returns_empty_metadata() {
-        let block = build_fits_header(&[]);
-        let cards = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&cards);
+        let meta = parse(&[]);
         assert!(meta.image_typ.is_none());
     }
 
@@ -452,16 +343,13 @@ mod tests {
 
     #[test]
     fn multi_keyword_card_set() {
-        let cards = [
+        let meta = parse(&[
             pad80("IMAGETYP= 'Flat Frame'"),
             pad80("FILTER  = 'OIII    '"),
             pad80("EXPTIME =                   3.0"),
             pad80("XBINNING=                     1"),
             pad80("YBINNING=                     1"),
-        ];
-        let block = build_fits_header(&cards.iter().map(String::as_str).collect::<Vec<_>>());
-        let parsed = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&parsed);
+        ]);
         assert_eq!(meta.image_typ, Some("Flat Frame".to_owned()));
         assert_eq!(meta.filter, Some("OIII".to_owned()));
         assert_eq!(meta.exposure, Some("3.0".to_owned()));
@@ -472,21 +360,11 @@ mod tests {
     #[test]
     fn exposure_keyword_fallback_to_exposure() {
         // EXPTIME takes priority; if absent, EXPOSURE is used
-        let cards = [pad80("EXPOSURE=                 120.0 / exposure in seconds")];
-        let block = build_fits_header(&cards.iter().map(String::as_str).collect::<Vec<_>>());
-        let parsed = read_header_cards(block.as_slice(), Path::new("test.fits")).unwrap();
-        let meta = parse_cards(&parsed);
+        let meta = parse(&[pad80("EXPOSURE=                 120.0 / exposure in seconds")]);
         assert_eq!(meta.exposure, Some("120.0".to_owned()));
     }
 
     // ── Extended extracted metadata (spec 041 T062) ───────────────────────────
-
-    fn parse(cards: &[String]) -> RawFileMetadata {
-        let refs: Vec<&str> = cards.iter().map(String::as_str).collect();
-        let block = build_fits_header(&refs);
-        let parsed = read_header_cards(block.as_slice(), Path::new("t.fits")).unwrap();
-        parse_cards(&parsed)
-    }
 
     fn approx(a: Option<f64>, b: f64) {
         let v = a.expect("expected Some");

--- a/crates/metadata/xisf/Cargo.toml
+++ b/crates/metadata/xisf/Cargo.toml
@@ -9,8 +9,8 @@ path = "src/lib.rs"
 
 [dependencies]
 metadata_core = { path = "../core" }
-quick-xml.workspace = true
 thiserror.workspace = true
+xisf-header = "0.2"
 
 [lints]
 workspace = true

--- a/crates/metadata/xisf/src/lib.rs
+++ b/crates/metadata/xisf/src/lib.rs
@@ -1,4 +1,5 @@
-//! XISF metadata extraction adapter (spec 005 T006).
+//! XISF metadata extraction adapter (spec 005 T006), built on the
+//! `xisf-header` crate.
 //!
 //! # XISF Header Format
 //!
@@ -13,27 +14,16 @@
 //! This extractor reads only the XML header (no pixel data) and extracts the
 //! same keywords as the FITS extractor via the `<FITSKeyword>` elements.
 //!
-//! No heavy C dependencies — uses `quick-xml` for the XML parse.
+//! No heavy C dependencies — `xisf-header` is pure Rust.
 #![allow(clippy::doc_markdown)]
 
-use std::io::{self, Read};
 use std::path::Path;
 
 use metadata_core::{
-    parse_f64, parse_i64, sexagesimal_dec_to_deg, sexagesimal_ra_to_deg, MetadataExtractError,
-    MetadataExtractor, RawFileMetadata,
+    sexagesimal_dec_to_deg, sexagesimal_ra_to_deg, MetadataExtractError, MetadataExtractor,
+    RawFileMetadata,
 };
-use quick_xml::events::Event;
-use quick_xml::Reader;
-
-// ── Constants ─────────────────────────────────────────────────────────────────
-
-/// XISF file signature bytes (8-byte "XISF0100" marker).
-const XISF_SIGNATURE: &[u8; 8] = b"XISF0100";
-
-/// Maximum XML header size we're willing to read (8 MiB). A real XISF header
-/// with hundreds of FITSKeyword entries will be well under 1 MiB.
-const MAX_XML_BYTES: u32 = 8 * 1024 * 1024;
+use xisf_header::{Error as XisfError, FromField, Header};
 
 // ── XisfExtractor ─────────────────────────────────────────────────────────────
 
@@ -55,17 +45,11 @@ impl MetadataExtractor for XisfExtractor {
             return Ok(None);
         }
 
-        let mut file = std::fs::File::open(path).map_err(|e| MetadataExtractError::Io {
-            path: path.display().to_string(),
-            msg: e.to_string(),
-        })?;
+        // Reads only the 16-byte preamble + declared XML header (capped at
+        // 8 MiB internally); never touches pixel/attachment data.
+        let header = Header::read_from_file(path).map_err(|e| map_err(&e, path))?;
 
-        let xml = read_xml_header(&mut file, path).map_err(|e| MetadataExtractError::Io {
-            path: path.display().to_string(),
-            msg: e.to_string(),
-        })?;
-
-        parse_xml_header(&xml, path).map(Some)
+        Ok(Some(parse_header(&header)))
     }
 
     fn supports_extension(&self, ext: &str) -> bool {
@@ -73,257 +57,128 @@ impl MetadataExtractor for XisfExtractor {
     }
 }
 
-// ── Header reading ────────────────────────────────────────────────────────────
-
-/// Read the XML header bytes from an XISF file.
-///
-/// XISF header layout:
-/// - Bytes  0..8  : signature `XISF0100`
-/// - Bytes  8..12 : XML header length (u32 little-endian)
-/// - Bytes 12..16 : reserved (4 bytes, must be 0)
-/// - Bytes 16..16+length : UTF-8 XML
-fn read_xml_header(reader: &mut impl Read, path: &Path) -> io::Result<String> {
-    let mut preamble = [0u8; 16];
-    reader.read_exact(&mut preamble)?;
-
-    if &preamble[0..8] != XISF_SIGNATURE {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("{}: not an XISF file (bad signature)", path.display()),
-        ));
+/// Map an `xisf_header::Error` onto this crate's error contract: signature,
+/// size, encoding, and I/O failures are `Io`; XML/attribute syntax errors are
+/// `Parse`.
+fn map_err(e: &XisfError, path: &Path) -> MetadataExtractError {
+    let msg = e.to_string();
+    let path = path.display().to_string();
+    match e {
+        XisfError::Xml(_) | XisfError::Attr(_) => MetadataExtractError::Parse { path, msg },
+        _ => MetadataExtractError::Io { path, msg },
     }
+}
 
-    let xml_length = u32::from_le_bytes(preamble[8..12].try_into().unwrap());
+// ── Header field extraction ──────────────────────────────────────────────────
 
-    if xml_length > MAX_XML_BYTES {
-        return Err(io::Error::new(
-            io::ErrorKind::InvalidData,
-            format!("{}: XISF XML header too large ({xml_length} bytes)", path.display()),
-        ));
+/// Typed keyword read that never hard-errors: a duplicated keyword
+/// (`XisfError::Ambiguous`) falls back to its first occurrence instead of
+/// surfacing an error, preserving this extractor's "always `None`, never
+/// `Err`" field-level contract.
+fn get<T: FromField>(header: &Header, key: &str) -> Option<T> {
+    match header.get::<T>(key) {
+        Ok(v) => v,
+        Err(XisfError::Ambiguous { .. }) => header.get_all::<T>(key).into_iter().next(),
+        Err(_) => None,
     }
+}
 
-    let mut xml_bytes = vec![0u8; xml_length as usize];
-    reader.read_exact(&mut xml_bytes)?;
+/// Like [`get`] but for raw keyword text (`Header::get_str`).
+fn get_str(header: &Header, key: &str) -> Option<String> {
+    match header.get_str(key) {
+        Ok(v) => v.map(str::to_owned),
+        Err(XisfError::Ambiguous { .. }) => header.get_all::<String>(key).into_iter().next(),
+        Err(_) => None,
+    }
+}
 
-    String::from_utf8(xml_bytes).map_err(|_| {
-        io::Error::new(io::ErrorKind::InvalidData, "XISF XML header is not valid UTF-8")
+/// Trim and treat an empty value as absent. `xisf_header`'s `FromField<String>`
+/// never returns `None` for an empty-but-present keyword, unlike the numeric
+/// `FromField` impls (which already reject empty text); string-typed fields
+/// need this explicit check to match the FITS extractor's contract.
+fn non_empty(s: Option<String>) -> Option<String> {
+    s.and_then(|s| {
+        let t = s.trim();
+        (!t.is_empty()).then(|| t.to_owned())
     })
 }
 
-// ── XML parsing ───────────────────────────────────────────────────────────────
-
-/// Parse FITSKeyword elements from the XISF XML header and build
+/// Map header keywords (and, as a fallback, XISF `<Property>` elements) into
 /// [`RawFileMetadata`].
-fn parse_xml_header(xml: &str, path: &Path) -> Result<RawFileMetadata, MetadataExtractError> {
+///
+/// The observer-location fallback chains and RA/DEC decimal-over-sexagesimal
+/// precedence are shared value shapes but are intentionally kept as separate
+/// keyword lookups (fallback precedence); the field list is necessarily long.
+// A struct-literal initializer would be far less readable than these named
+// per-field assignments given the multi-keyword fallback chains.
+#[allow(clippy::field_reassign_with_default)]
+fn parse_header(header: &Header) -> RawFileMetadata {
     let mut meta = RawFileMetadata::default();
-    let mut reader = Reader::from_str(xml);
 
-    let path_str = path.display().to_string();
+    meta.image_typ = non_empty(get_str(header, "IMAGETYP"));
+    meta.filter = non_empty(get_str(header, "FILTER"));
+    meta.object = non_empty(get_str(header, "OBJECT"));
+    // EXPTIME takes priority; EXPOSURE is the fallback.
+    meta.exposure =
+        non_empty(get_str(header, "EXPTIME")).or_else(|| non_empty(get_str(header, "EXPOSURE")));
+    meta.gain = non_empty(get_str(header, "GAIN"));
+    meta.x_binning = non_empty(get_str(header, "XBINNING"));
+    meta.y_binning = non_empty(get_str(header, "YBINNING"));
+    meta.naxis1 = non_empty(get_str(header, "NAXIS1"));
+    meta.naxis2 = non_empty(get_str(header, "NAXIS2"));
+    meta.instrume = non_empty(get_str(header, "INSTRUME"));
+    meta.telescop = non_empty(get_str(header, "TELESCOP"));
+    meta.date_obs = non_empty(get_str(header, "DATE-OBS"));
 
-    loop {
-        match reader.read_event() {
-            Ok(Event::Empty(e) | Event::Start(e)) => {
-                match e.name().as_ref() {
-                    b"FITSKeyword" => {
-                        let mut name: Option<String> = None;
-                        let mut value: Option<String> = None;
+    // Stack/integration count: STACKCNT (preferred) or NCOMBINE fallback.
+    meta.stack_count = get::<u32>(header, "STACKCNT").or_else(|| get::<u32>(header, "NCOMBINE"));
 
-                        for attr_result in e.attributes() {
-                            let attr = attr_result.map_err(|e| MetadataExtractError::Parse {
-                                path: path_str.clone(),
-                                msg: format!("attribute error: {e}"),
-                            })?;
+    // ── Extended extracted metadata (spec 041 T062, R-9/R-18) ───────────────
+    // Offset / pedestal: OFFSET preferred, BLKLEVEL fallback.
+    meta.offset = get::<i64>(header, "OFFSET").or_else(|| get::<i64>(header, "BLKLEVEL"));
+    // Temperatures.
+    meta.set_temp_c = get(header, "SET-TEMP");
+    // CCD-TEMP preferred; DET-TEMP is the DWARF III non-standard fallback.
+    meta.ccd_temp_c = get::<f64>(header, "CCD-TEMP").or_else(|| get::<f64>(header, "DET-TEMP"));
+    // Pointing: decimal RA/DEC preferred over sexagesimal OBJCTRA/OBJCTDEC.
+    meta.ra_deg = get::<f64>(header, "RA")
+        .or_else(|| get_str(header, "OBJCTRA").and_then(|s| sexagesimal_ra_to_deg(&s)));
+    meta.dec_deg = get::<f64>(header, "DEC")
+        .or_else(|| get_str(header, "OBJCTDEC").and_then(|s| sexagesimal_dec_to_deg(&s)));
+    // Rotation: ROTATANG (= ROTATOR, mechanical) is the flat-match key;
+    // OBJCTROT is the informational sky position angle. Never swap them.
+    meta.rotator_angle_deg =
+        get::<f64>(header, "ROTATANG").or_else(|| get::<f64>(header, "ROTATOR"));
+    meta.rotator_name = non_empty(get_str(header, "ROTNAME"));
+    meta.sky_rotation_deg = get(header, "OBJCTROT");
+    // Readout mode (optional grouping dim).
+    meta.readout_mode = non_empty(get_str(header, "READOUTM"));
+    // Optic train inputs. FOCALLEN (FITSKeyword, mm) takes precedence over the
+    // XISF native Property (metres → mm). XPIXSZ/PIXSIZE (FITSKeyword, µm)
+    // take precedence over the Property (already µm).
+    meta.focal_length_mm = get(header, "FOCALLEN").or_else(|| {
+        header.property_get::<f64>("Instrument:Telescope:FocalLength").map(|m| m * 1000.0)
+    });
+    meta.pixel_size_um = get::<f64>(header, "XPIXSZ")
+        .or_else(|| get::<f64>(header, "PIXSIZE"))
+        .or_else(|| header.property_get::<f64>("Image:PixelSize"));
+    // Observer location: SITE* preferred, OBSGEO-* then *-OBS fallbacks.
+    meta.observer_lat = get::<f64>(header, "SITELAT")
+        .or_else(|| get::<f64>(header, "OBSGEO-B"))
+        .or_else(|| get::<f64>(header, "LAT-OBS"));
+    meta.observer_long = get::<f64>(header, "SITELONG")
+        .or_else(|| get::<f64>(header, "OBSGEO-L"))
+        .or_else(|| get::<f64>(header, "LONG-OBS"));
+    meta.observer_elev = get::<f64>(header, "SITEELEV")
+        .or_else(|| get::<f64>(header, "OBSGEO-H"))
+        .or_else(|| get::<f64>(header, "ALT-OBS"));
+    // Time keywords.
+    meta.date_loc = non_empty(get_str(header, "DATE-LOC"));
+    meta.date_end = non_empty(get_str(header, "DATE-END"));
+    meta.mjd_avg = get(header, "MJD-AVG");
+    meta.mjd_obs = get(header, "MJD-OBS");
 
-                            let key = std::str::from_utf8(attr.key.as_ref())
-                                .unwrap_or("")
-                                .to_ascii_lowercase();
-                            let val = attr
-                                .decode_and_unescape_value(reader.decoder())
-                                .map(std::borrow::Cow::into_owned)
-                                .unwrap_or_default();
-
-                            match key.as_str() {
-                                "name" => name = Some(val),
-                                "value" => value = Some(val),
-                                _ => {}
-                            }
-                        }
-
-                        if let (Some(kw), Some(val)) = (name, value) {
-                            apply_fits_keyword(&mut meta, &kw, &val);
-                        }
-                    }
-                    // XISF native <Property id="..." value="..."> elements carry
-                    // focal length & pixel size in SI units (metres). These are a
-                    // fallback for files that omit the equivalent FITSKeyword form.
-                    b"Property" => {
-                        let mut id: Option<String> = None;
-                        let mut value: Option<String> = None;
-
-                        for attr_result in e.attributes() {
-                            let attr = attr_result.map_err(|e| MetadataExtractError::Parse {
-                                path: path_str.clone(),
-                                msg: format!("attribute error: {e}"),
-                            })?;
-
-                            let key = std::str::from_utf8(attr.key.as_ref())
-                                .unwrap_or("")
-                                .to_ascii_lowercase();
-                            let val = attr
-                                .decode_and_unescape_value(reader.decoder())
-                                .map(std::borrow::Cow::into_owned)
-                                .unwrap_or_default();
-
-                            match key.as_str() {
-                                "id" => id = Some(val),
-                                "value" => value = Some(val),
-                                _ => {}
-                            }
-                        }
-
-                        if let (Some(prop_id), Some(val)) = (id, value) {
-                            apply_xisf_property(&mut meta, &prop_id, &val);
-                        }
-                    }
-                    _ => {}
-                }
-            }
-            Ok(Event::Eof) => break,
-            Err(e) => {
-                return Err(MetadataExtractError::Parse {
-                    path: path_str,
-                    msg: format!("XML parse error: {e}"),
-                });
-            }
-            _ => {}
-        }
-    }
-
-    Ok(meta)
-}
-
-/// Apply a FITS keyword/value pair to `meta`, following the same rules as the
-/// FITS extractor.
-///
-/// XISF stores string values with surrounding single quotes (like FITS cards);
-/// we strip them here.
-///
-/// The observer-location fallback arms share bodies but are intentionally
-/// separate keyword patterns with per-field `is_none()` guards (fallback
-/// precedence), so `match_same_arms` is allowed here.
-#[allow(clippy::match_same_arms)]
-fn apply_fits_keyword(meta: &mut RawFileMetadata, keyword: &str, raw_value: &str) {
-    // Strip FITS-style single-quote wrapping: 'Light Frame' → Light Frame
-    let value = strip_fits_string_quotes(raw_value);
-
-    match keyword.trim_end() {
-        "IMAGETYP" => meta.image_typ = non_empty(value),
-        "FILTER" => meta.filter = non_empty(value),
-        "OBJECT" => meta.object = non_empty(value),
-        "EXPTIME" | "EXPOSURE" if meta.exposure.is_none() => {
-            meta.exposure = non_empty(value);
-        }
-        "GAIN" => meta.gain = non_empty(value),
-        "XBINNING" => meta.x_binning = non_empty(value),
-        "YBINNING" => meta.y_binning = non_empty(value),
-        "NAXIS1" => meta.naxis1 = non_empty(value),
-        "NAXIS2" => meta.naxis2 = non_empty(value),
-        "INSTRUME" => meta.instrume = non_empty(value),
-        "TELESCOP" => meta.telescop = non_empty(value),
-        "DATE-OBS" => meta.date_obs = non_empty(value),
-        // Stack/integration count: STACKCNT (preferred) or NCOMBINE fallback.
-        "STACKCNT" => {
-            meta.stack_count = non_empty(value).and_then(|s| s.trim().parse::<u32>().ok());
-        }
-        "NCOMBINE" if meta.stack_count.is_none() => {
-            meta.stack_count = non_empty(value).and_then(|s| s.trim().parse::<u32>().ok());
-        }
-
-        // ── Extended extracted metadata (spec 041 T062, R-9/R-18) ───────────
-        "OFFSET" => meta.offset = parse_i64(value),
-        "BLKLEVEL" if meta.offset.is_none() => meta.offset = parse_i64(value),
-        "SET-TEMP" => meta.set_temp_c = parse_f64(value),
-        "CCD-TEMP" => meta.ccd_temp_c = parse_f64(value),
-        "DET-TEMP" if meta.ccd_temp_c.is_none() => meta.ccd_temp_c = parse_f64(value),
-        // Pointing: decimal RA/DEC preferred over sexagesimal OBJCTRA/OBJCTDEC.
-        "RA" => meta.ra_deg = parse_f64(value),
-        "OBJCTRA" if meta.ra_deg.is_none() => meta.ra_deg = sexagesimal_ra_to_deg(value),
-        "DEC" => meta.dec_deg = parse_f64(value),
-        "OBJCTDEC" if meta.dec_deg.is_none() => meta.dec_deg = sexagesimal_dec_to_deg(value),
-        // Rotation: ROTATANG (= ROTATOR, mechanical) flat-match key; OBJCTROT
-        // is the informational sky position angle. Never swap them.
-        "ROTATANG" => meta.rotator_angle_deg = parse_f64(value),
-        "ROTATOR" if meta.rotator_angle_deg.is_none() => {
-            meta.rotator_angle_deg = parse_f64(value);
-        }
-        "ROTNAME" => meta.rotator_name = non_empty(value),
-        "OBJCTROT" => meta.sky_rotation_deg = parse_f64(value),
-        "READOUTM" => meta.readout_mode = non_empty(value),
-        // FOCALLEN here is in mm (FITSKeyword form); the XISF Property form is
-        // handled separately in metres → mm.
-        "FOCALLEN" => meta.focal_length_mm = parse_f64(value),
-        "XPIXSZ" => meta.pixel_size_um = parse_f64(value),
-        "PIXSIZE" if meta.pixel_size_um.is_none() => meta.pixel_size_um = parse_f64(value),
-        // Observer location: SITE* preferred, OBSGEO-* then *-OBS fallbacks.
-        "SITELAT" => meta.observer_lat = parse_f64(value),
-        "OBSGEO-B" if meta.observer_lat.is_none() => meta.observer_lat = parse_f64(value),
-        "LAT-OBS" if meta.observer_lat.is_none() => meta.observer_lat = parse_f64(value),
-        "SITELONG" => meta.observer_long = parse_f64(value),
-        "OBSGEO-L" if meta.observer_long.is_none() => meta.observer_long = parse_f64(value),
-        "LONG-OBS" if meta.observer_long.is_none() => meta.observer_long = parse_f64(value),
-        "SITEELEV" => meta.observer_elev = parse_f64(value),
-        "OBSGEO-H" if meta.observer_elev.is_none() => meta.observer_elev = parse_f64(value),
-        "ALT-OBS" if meta.observer_elev.is_none() => meta.observer_elev = parse_f64(value),
-        "DATE-LOC" => meta.date_loc = non_empty(value),
-        "DATE-END" => meta.date_end = non_empty(value),
-        "MJD-AVG" => meta.mjd_avg = parse_f64(value),
-        "MJD-OBS" => meta.mjd_obs = parse_f64(value),
-        _ => {}
-    }
-}
-
-/// Apply an XISF native `<Property id=… value=…>` element to `meta`.
-///
-/// These carry instrument values in **SI units (metres)** and are used as a
-/// fallback for files that omit the equivalent FITSKeyword form. Per the
-/// data-model:
-/// - `Instrument:Telescope:FocalLength` (metres) → millimetres (×1000).
-/// - `Image:PixelSize` (micrometres) → pixel size in micrometres.
-///
-/// FITSKeyword values take precedence (already applied when this runs only if
-/// the corresponding field is still `None`).
-fn apply_xisf_property(meta: &mut RawFileMetadata, id: &str, value: &str) {
-    match id {
-        "Instrument:Telescope:FocalLength" if meta.focal_length_mm.is_none() => {
-            // metres → millimetres
-            meta.focal_length_mm = parse_f64(value).map(|m| m * 1000.0);
-        }
-        "Image:PixelSize" if meta.pixel_size_um.is_none() => {
-            // Already micrometres per data-model R-9 mapping.
-            meta.pixel_size_um = parse_f64(value);
-        }
-        _ => {}
-    }
-}
-
-/// Strip FITS-style single-quote wrapping: `'Light Frame'` → `Light Frame`.
-/// Also handles doubled single-quote escape: `''` → `'`.
-fn strip_fits_string_quotes(s: &str) -> &str {
-    let inner = s.trim();
-    if inner.starts_with('\'') && inner.ends_with('\'') && inner.len() >= 2 {
-        &inner[1..inner.len() - 1]
-    } else {
-        inner
-    }
-}
-
-fn non_empty(s: &str) -> Option<String> {
-    let t = s.trim();
-    if t.is_empty() {
-        None
-    } else {
-        Some(t.to_owned())
-    }
+    meta
 }
 
 // ── Test helpers ──────────────────────────────────────────────────────────────
@@ -331,6 +186,10 @@ fn non_empty(s: &str) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// XISF file signature bytes (8-byte `XISF0100` marker), for building test
+    /// containers only — `xisf_header::Header` validates this internally.
+    const XISF_SIGNATURE: &[u8; 8] = b"XISF0100";
 
     /// Build a minimal XISF byte stream with the given FITSKeyword entries.
     ///
@@ -367,111 +226,6 @@ mod tests {
         out
     }
 
-    #[test]
-    fn parses_imagetyp_light() {
-        let data = build_xisf(&[("IMAGETYP", "'Light Frame'", "frame type")]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.image_typ, Some("Light Frame".to_owned()));
-    }
-
-    #[test]
-    fn parses_imagetyp_dark() {
-        let data = build_xisf(&[("IMAGETYP", "'Dark Frame'", "")]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.image_typ, Some("Dark Frame".to_owned()));
-    }
-
-    #[test]
-    fn parses_filter_and_object() {
-        let data = build_xisf(&[
-            ("FILTER", "'Ha      '", "filter name"),
-            ("OBJECT", "'NGC 7000'", "target"),
-        ]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.filter, Some("Ha".to_owned()));
-        assert_eq!(meta.object, Some("NGC 7000".to_owned()));
-    }
-
-    #[test]
-    fn parses_exptime() {
-        let data = build_xisf(&[("EXPTIME", "300.0", "exposure in seconds")]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.exposure, Some("300.0".to_owned()));
-    }
-
-    #[test]
-    fn parses_gain_and_binning() {
-        let data = build_xisf(&[
-            ("GAIN", "100", "camera gain"),
-            ("XBINNING", "1", ""),
-            ("YBINNING", "1", ""),
-        ]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.gain, Some("100".to_owned()));
-        assert_eq!(meta.x_binning, Some("1".to_owned()));
-        assert_eq!(meta.y_binning, Some("1".to_owned()));
-    }
-
-    #[test]
-    fn parses_instrume_telescop() {
-        let data = build_xisf(&[
-            ("INSTRUME", "'ZWO ASI2600MM Pro'", "camera"),
-            ("TELESCOP", "'AT130-EDT'", "scope"),
-        ]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.instrume, Some("ZWO ASI2600MM Pro".to_owned()));
-        assert_eq!(meta.telescop, Some("AT130-EDT".to_owned()));
-    }
-
-    #[test]
-    fn parses_date_obs() {
-        let data = build_xisf(&[("DATE-OBS", "'2025-10-10T22:15:00'", "")]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert_eq!(meta.date_obs, Some("2025-10-10T22:15:00".to_owned()));
-    }
-
-    #[test]
-    fn missing_keywords_return_none() {
-        let data = build_xisf(&[]);
-        let xml = read_xml_header(&mut data.as_slice(), Path::new("test.xisf")).unwrap();
-        let meta = parse_xml_header(&xml, Path::new("test.xisf")).unwrap();
-        assert!(meta.image_typ.is_none());
-        assert!(meta.filter.is_none());
-        assert!(meta.object.is_none());
-    }
-
-    #[test]
-    fn bad_signature_returns_error() {
-        let mut data = build_xisf(&[]);
-        data[0..8].copy_from_slice(b"NOTXISF!");
-        let err = read_xml_header(&mut data.as_slice(), Path::new("bad.xisf"));
-        assert!(err.is_err());
-    }
-
-    #[test]
-    fn extractor_rejects_fits_extension() {
-        let extractor = XisfExtractor;
-        assert!(!extractor.supports_extension("fits"));
-        assert!(extractor.supports_extension("xisf"));
-    }
-
-    #[test]
-    fn strip_fits_string_quotes_works() {
-        assert_eq!(strip_fits_string_quotes("'Light Frame'"), "Light Frame");
-        assert_eq!(strip_fits_string_quotes("'Ha      '"), "Ha      ");
-        assert_eq!(strip_fits_string_quotes("300.0"), "300.0");
-        assert_eq!(strip_fits_string_quotes("''"), "");
-    }
-
-    // ── Extended extracted metadata (spec 041 T062) ───────────────────────────
-
     /// Build an XISF byte stream with explicit `<Property>` and `<FITSKeyword>`
     /// blocks. `properties` is `(id, type, value)`; `keywords` is
     /// `(name, value, comment)`.
@@ -507,11 +261,100 @@ mod tests {
         out
     }
 
+    /// Parse a built XISF byte stream via the real `Header::parse` +
+    /// [`parse_header`] path.
     fn parse(data: &[u8]) -> RawFileMetadata {
-        let mut slice = data;
-        let xml = read_xml_header(&mut slice, Path::new("t.xisf")).unwrap();
-        parse_xml_header(&xml, Path::new("t.xisf")).unwrap()
+        let header = Header::parse(data).unwrap();
+        parse_header(&header)
     }
+
+    #[test]
+    fn parses_imagetyp_light() {
+        let data = build_xisf(&[("IMAGETYP", "'Light Frame'", "frame type")]);
+        let meta = parse(&data);
+        assert_eq!(meta.image_typ, Some("Light Frame".to_owned()));
+    }
+
+    #[test]
+    fn parses_imagetyp_dark() {
+        let data = build_xisf(&[("IMAGETYP", "'Dark Frame'", "")]);
+        let meta = parse(&data);
+        assert_eq!(meta.image_typ, Some("Dark Frame".to_owned()));
+    }
+
+    #[test]
+    fn parses_filter_and_object() {
+        let data = build_xisf(&[
+            ("FILTER", "'Ha      '", "filter name"),
+            ("OBJECT", "'NGC 7000'", "target"),
+        ]);
+        let meta = parse(&data);
+        assert_eq!(meta.filter, Some("Ha".to_owned()));
+        assert_eq!(meta.object, Some("NGC 7000".to_owned()));
+    }
+
+    #[test]
+    fn parses_exptime() {
+        let data = build_xisf(&[("EXPTIME", "300.0", "exposure in seconds")]);
+        let meta = parse(&data);
+        assert_eq!(meta.exposure, Some("300.0".to_owned()));
+    }
+
+    #[test]
+    fn parses_gain_and_binning() {
+        let data = build_xisf(&[
+            ("GAIN", "100", "camera gain"),
+            ("XBINNING", "1", ""),
+            ("YBINNING", "1", ""),
+        ]);
+        let meta = parse(&data);
+        assert_eq!(meta.gain, Some("100".to_owned()));
+        assert_eq!(meta.x_binning, Some("1".to_owned()));
+        assert_eq!(meta.y_binning, Some("1".to_owned()));
+    }
+
+    #[test]
+    fn parses_instrume_telescop() {
+        let data = build_xisf(&[
+            ("INSTRUME", "'ZWO ASI2600MM Pro'", "camera"),
+            ("TELESCOP", "'AT130-EDT'", "scope"),
+        ]);
+        let meta = parse(&data);
+        assert_eq!(meta.instrume, Some("ZWO ASI2600MM Pro".to_owned()));
+        assert_eq!(meta.telescop, Some("AT130-EDT".to_owned()));
+    }
+
+    #[test]
+    fn parses_date_obs() {
+        let data = build_xisf(&[("DATE-OBS", "'2025-10-10T22:15:00'", "")]);
+        let meta = parse(&data);
+        assert_eq!(meta.date_obs, Some("2025-10-10T22:15:00".to_owned()));
+    }
+
+    #[test]
+    fn missing_keywords_return_none() {
+        let data = build_xisf(&[]);
+        let meta = parse(&data);
+        assert!(meta.image_typ.is_none());
+        assert!(meta.filter.is_none());
+        assert!(meta.object.is_none());
+    }
+
+    #[test]
+    fn bad_signature_returns_error() {
+        let mut data = build_xisf(&[]);
+        data[0..8].copy_from_slice(b"NOTXISF!");
+        assert!(Header::parse(&data).is_err());
+    }
+
+    #[test]
+    fn extractor_rejects_fits_extension() {
+        let extractor = XisfExtractor;
+        assert!(!extractor.supports_extension("fits"));
+        assert!(extractor.supports_extension("xisf"));
+    }
+
+    // ── Extended extracted metadata (spec 041 T062) ───────────────────────────
 
     fn approx(a: Option<f64>, b: f64) {
         let v = a.expect("expected Some");


### PR DESCRIPTION
## Summary
- Adopt fits-header + xisf-header under metadata adapters (node A of run-adopt-crates)
- Bump workspace.dependencies quick-xml 0.39 -> 0.41

## Test plan
- metadata_fits + metadata_xisf: 44 tests pass
- app_core_inbox: 140 tests pass
- clippy/fmt clean, full workspace build clean