### PR TITLE
feat(cache): in-memory caching layer (SnapshotCache foundation + domain read-through/invalidate)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ name = "app_core_settings"
 version = "0.1.0"
 dependencies = [
  "app_core_cache",
+ "app_core_calibration",
  "app_core_errors",
  "audit",
  "contracts_core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -137,6 +137,7 @@ dependencies = [
 name = "app_core_calibration"
 version = "0.1.0"
 dependencies = [
+ "app_core_cache",
  "audit",
  "calibration_core",
  "contracts_core",
@@ -164,6 +165,7 @@ dependencies = [
 name = "app_core_inbox"
 version = "0.1.0"
 dependencies = [
+ "app_core_cache",
  "app_core_errors",
  "app_core_targets",
  "audit",
@@ -239,6 +241,7 @@ dependencies = [
 name = "app_core_settings"
 version = "0.1.0"
 dependencies = [
+ "app_core_cache",
  "app_core_errors",
  "audit",
  "contracts_core",
@@ -259,6 +262,7 @@ dependencies = [
 name = "app_core_targets"
 version = "0.1.0"
 dependencies = [
+ "app_core_cache",
  "app_core_errors",
  "audit",
  "contracts_core",
@@ -272,6 +276,7 @@ dependencies = [
  "sqlx",
  "targeting",
  "targeting_resolver",
+ "tempfile",
  "time",
  "tokio",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -166,6 +166,7 @@ name = "app_core_inbox"
 version = "0.1.0"
 dependencies = [
  "app_core_cache",
+ "app_core_calibration",
  "app_core_errors",
  "app_core_targets",
  "audit",

--- a/crates/app/cache/src/lib.rs
+++ b/crates/app/cache/src/lib.rs
@@ -43,7 +43,7 @@
 //!   construction (exactly one `Arc<T>` slot) — no capacity/TTL knobs needed.
 
 use std::hash::Hash;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, OnceLock, RwLock};
 use std::time::Duration;
 
 use moka::sync::Cache;
@@ -334,12 +334,58 @@ where
     }
 }
 
+// ── protection_defaults: global protection-default settings snapshot ───────
+//
+// Relocated here (not `app_core`) so both `app_core` (`protection.rs` reads
+// it) and `app_core_settings` (the generic settings-bag write path also
+// changes these three keys) can invalidate it without a dependency cycle —
+// `app_core` depends on `app_core_settings`, so the cache can't live in
+// `app_core` if `app_core_settings` needs to invalidate it too.
+
+/// Snapshot of the three global protection-default settings (`protection_defaults`
+/// table, scope `"global"`): default level, block-permanent-delete flag, and
+/// protected categories. Plain data so this leaf crate doesn't need to depend
+/// on `app_core`'s `GlobalProtection` (which stays where it is; callers convert
+/// at the boundary).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProtectionDefaultsSnapshot {
+    pub level: String,
+    pub block_permanent_delete: bool,
+    pub categories: Vec<String>,
+}
+
+static PROTECTION_DEFAULTS: OnceLock<SnapshotCache<ProtectionDefaultsSnapshot>> = OnceLock::new();
+
+/// Return the process-global protection-defaults snapshot cache.
+pub fn protection_defaults() -> &'static SnapshotCache<ProtectionDefaultsSnapshot> {
+    PROTECTION_DEFAULTS.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded [`ProtectionDefaultsSnapshot`].
+pub fn store_protection_defaults(value: Arc<ProtectionDefaultsSnapshot>) {
+    protection_defaults().store(value);
+}
+
+/// Clear the protection-defaults snapshot so the next read reloads from the DB.
+///
+/// Call after `protection::set_global_protection_default` commits (`app_core`)
+/// and after the generic settings-bag write path commits a change to
+/// `defaultProtection` / `blockPermanentDelete` / `protectedCategories`
+/// (`app_core_settings::update_setting` / `restore_defaults`).
+pub fn invalidate_protection_defaults() {
+    protection_defaults().invalidate();
+}
+
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
 
-    use super::{CacheConfig, DebounceCache, SnapshotCache, TtlCache};
+    use super::{
+        invalidate_protection_defaults, protection_defaults, store_protection_defaults,
+        CacheConfig, DebounceCache, ProtectionDefaultsSnapshot, SnapshotCache, TtlCache,
+    };
 
     #[test]
     fn ttl_cache_miss_then_hit() {
@@ -488,5 +534,25 @@ mod tests {
     fn snapshot_cache_default_is_empty() {
         let cache: SnapshotCache<u32> = SnapshotCache::default();
         assert_eq!(cache.load(), None);
+    }
+
+    #[test]
+    fn protection_defaults_store_load_invalidate_round_trips() {
+        // Reuses the process-global static, so scope this test to values it
+        // fully owns (invalidate at start and end) to stay independent of
+        // other tests' ordering.
+        invalidate_protection_defaults();
+        assert!(protection_defaults().load().is_none());
+
+        store_protection_defaults(Arc::new(ProtectionDefaultsSnapshot {
+            level: "protected".to_owned(),
+            block_permanent_delete: true,
+            categories: vec!["lights".to_owned()],
+        }));
+        let loaded = protection_defaults().load().expect("stored value must load");
+        assert_eq!(loaded.level, "protected");
+
+        invalidate_protection_defaults();
+        assert!(protection_defaults().load().is_none());
     }
 }

--- a/crates/app/cache/src/lib.rs
+++ b/crates/app/cache/src/lib.rs
@@ -34,11 +34,16 @@
 //!
 //! - [`TtlCache`]: a generic, size- and TTL-bounded cache with a
 //!   single-flight get-or-insert (`get_or_insert_with`).
-//! - [`DebounceCache`]: a presence-only cache (the generic form of
-//!   `project_health`'s former `DebounceTable`) for suppressing repeated
-//!   signals within a time window, generic over the debounce key.
+//! - [`DebounceCache`]: a presence-only cache (mirrors
+//!   `project_health::DebounceTable`) for suppressing repeated signals within
+//!   a time window, generic over the debounce key.
+//! - [`SnapshotCache`]: a single-slot whole-value cache (spec: in-memory
+//!   caching layer, F0) for values loaded via **async** SQL, where
+//!   `TtlCache::get_or_insert_with`'s sync-only closure doesn't fit. Bounded by
+//!   construction (exactly one `Arc<T>` slot) — no capacity/TTL knobs needed.
 
 use std::hash::Hash;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use moka::sync::Cache;
@@ -229,12 +234,96 @@ where
     }
 }
 
+/// A single-slot whole-value cache: `RwLock<Option<Arc<T>>>`.
+///
+/// For state loaded wholesale (e.g. a settings bag, a config row, a small
+/// list snapshot) rather than keyed per-entry. Bounded by construction — it
+/// only ever holds zero or one `Arc<T>` — so no capacity/TTL configuration is
+/// needed the way [`TtlCache`] requires it.
+///
+/// Explicit invalidation is the whole contract: [`invalidate`](Self::invalidate)
+/// clears the slot so the next [`load`](Self::load) observes a miss and the
+/// caller re-derives + [`store`](Self::store)s a fresh value. There is no
+/// TTL/TTI — owning modules call `invalidate` at their write sites (see the
+/// in-memory caching layer plan's invalidation-point map).
+///
+/// # Examples
+///
+/// ```
+/// use std::sync::Arc;
+///
+/// use app_core_cache::SnapshotCache;
+///
+/// let cache: SnapshotCache<u32> = SnapshotCache::new();
+/// assert_eq!(cache.load(), None, "empty cache is a miss");
+///
+/// cache.store(Arc::new(42));
+/// assert_eq!(cache.load(), Some(Arc::new(42)));
+///
+/// cache.invalidate();
+/// assert_eq!(cache.load(), None, "invalidated cache is a miss again");
+/// ```
+pub struct SnapshotCache<T>
+where
+    T: Send + Sync + 'static,
+{
+    slot: RwLock<Option<Arc<T>>>,
+}
+
+impl<T> SnapshotCache<T>
+where
+    T: Send + Sync + 'static,
+{
+    /// Build an empty cache (starts as a miss).
+    #[must_use]
+    pub const fn new() -> Self {
+        Self { slot: RwLock::new(None) }
+    }
+
+    /// Return the currently cached value, or `None` on a miss.
+    ///
+    /// A poisoned lock (a prior panic while holding the write lock) is treated
+    /// as recoverable: the cache is a best-effort in-memory optimization, not
+    /// a durable record, so a poisoned lock degrades to a miss rather than
+    /// propagating a panic to every subsequent reader.
+    #[must_use]
+    pub fn load(&self) -> Option<Arc<T>> {
+        self.slot.read().map_or(None, |guard| guard.clone())
+    }
+
+    /// Replace the cached value.
+    pub fn store(&self, value: Arc<T>) {
+        if let Ok(mut guard) = self.slot.write() {
+            *guard = Some(value);
+        }
+    }
+
+    /// Clear the slot so the next [`load`](Self::load) is a miss. Call this
+    /// at every write site that changes the underlying data (see the
+    /// invalidation-point map in the caching layer plan) — this cache has no
+    /// TTL, so a missed invalidation call means permanently stale data.
+    pub fn invalidate(&self) {
+        if let Ok(mut guard) = self.slot.write() {
+            *guard = None;
+        }
+    }
+}
+
+impl<T> Default for SnapshotCache<T>
+where
+    T: Send + Sync + 'static,
+{
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::thread;
     use std::time::Duration;
 
-    use super::{CacheConfig, DebounceCache, TtlCache};
+    use super::{CacheConfig, DebounceCache, SnapshotCache, TtlCache};
 
     #[test]
     fn ttl_cache_miss_then_hit() {
@@ -348,5 +437,40 @@ mod tests {
             !debounce.should_suppress(&"a".to_owned()),
             "after TTL elapses, signal is emitted again"
         );
+    }
+
+    #[test]
+    fn snapshot_cache_starts_empty() {
+        let cache: SnapshotCache<u32> = SnapshotCache::new();
+        assert_eq!(cache.load(), None, "fresh cache is a miss");
+    }
+
+    #[test]
+    fn snapshot_cache_store_then_load_hits() {
+        let cache: SnapshotCache<u32> = SnapshotCache::new();
+        cache.store(std::sync::Arc::new(42));
+        assert_eq!(cache.load(), Some(std::sync::Arc::new(42)));
+    }
+
+    #[test]
+    fn snapshot_cache_invalidate_clears_the_slot() {
+        let cache: SnapshotCache<u32> = SnapshotCache::new();
+        cache.store(std::sync::Arc::new(42));
+        cache.invalidate();
+        assert_eq!(cache.load(), None, "invalidated cache is a miss");
+    }
+
+    #[test]
+    fn snapshot_cache_store_overwrites_previous_value() {
+        let cache: SnapshotCache<u32> = SnapshotCache::new();
+        cache.store(std::sync::Arc::new(1));
+        cache.store(std::sync::Arc::new(2));
+        assert_eq!(cache.load(), Some(std::sync::Arc::new(2)), "store replaces the slot");
+    }
+
+    #[test]
+    fn snapshot_cache_default_is_empty() {
+        let cache: SnapshotCache<u32> = SnapshotCache::default();
+        assert_eq!(cache.load(), None);
     }
 }

--- a/crates/app/cache/src/lib.rs
+++ b/crates/app/cache/src/lib.rs
@@ -247,6 +247,17 @@ where
 /// TTL/TTI — owning modules call `invalidate` at their write sites (see the
 /// in-memory caching layer plan's invalidation-point map).
 ///
+/// **Usage contract for read-through call sites:** callers MUST call
+/// [`invalidate`](Self::invalidate) only *after* the underlying DB write has
+/// committed, never before or concurrently with it. A [`store`](Self::store)
+/// that races a concurrent [`invalidate`](Self::invalidate) — i.e. a reader
+/// re-derives from the pre-commit state and calls `store` after the writer's
+/// `invalidate` has already run — repopulates the slot with a stale value.
+/// Because there is no TTL, that staleness is permanent until the next
+/// explicit invalidation. Sequencing invalidation strictly after commit is
+/// what closes this window; do not replicate a store-then-invalidate (or
+/// invalidate-before-commit) ordering in downstream read-through workers.
+///
 /// # Examples
 ///
 /// ```
@@ -292,6 +303,11 @@ where
     }
 
     /// Replace the cached value.
+    ///
+    /// Not itself hazardous, but see the type-level doc for the lost-update
+    /// window this creates when a `store` races a concurrent
+    /// [`invalidate`](Self::invalidate): callers must invalidate strictly
+    /// after their DB write commits, never before/concurrently with it.
     pub fn store(&self, value: Arc<T>) {
         if let Ok(mut guard) = self.slot.write() {
             *guard = Some(value);

--- a/crates/app/calibration/Cargo.toml
+++ b/crates/app/calibration/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+app_core_cache = { path = "../cache" }
 audit = { path = "../../audit" }
 calibration_core = { path = "../../calibration/core" }
 contracts_core = { path = "../../contracts/core" }

--- a/crates/app/calibration/src/caches.rs
+++ b/crates/app/calibration/src/caches.rs
@@ -1,0 +1,99 @@
+//! `app_core_calibration`-owned cache statics (in-memory caching layer, F0 foundation).
+//!
+//! Module-local process-global `OnceLock`s, mirroring `app_core`'s
+//! `ACTIVE_RUNS`/`caches` pattern. This module defines the cache handles and
+//! their `pub invalidate_*`/reader functions only — wiring reads through the
+//! cache (`matching::suggest`/`batch_suggest`) and calling `invalidate_*` at
+//! write sites is downstream (W-CALCFG, W-MASTERS) work.
+//!
+//! Both caches cache the matcher's *inputs* (config + masters list), not the
+//! match output: DB round-trips dominate matching cost, and the match itself
+//! is bounded CPU (see the caching layer plan's confirmed design call).
+
+use std::sync::{Arc, OnceLock};
+
+use app_core_cache::SnapshotCache;
+use calibration_core::ranking::MatchingRuleConfig;
+use contracts_core::calibration::CalibrationMaster;
+
+// ── calibration config snapshot (`matching.rs`) ───────────────────────────────
+
+/// [`MatchingRuleConfig`] loaded from the `calibration*` settings keys. 1 slot.
+///
+/// Invalidate at the settings-bag fan-out (`app_core_settings::update_setting`
+/// / `restore_defaults` for the `calibrationDarkTempTolerance` /
+/// `calibrationDarkOverridePenalty` / `calibrationFlatOverridePenalty` /
+/// `calibrationBiasOverridePenalty` / `calibrationPrefillSuggestion` keys).
+static CALIBRATION_CONFIG: OnceLock<SnapshotCache<MatchingRuleConfig>> = OnceLock::new();
+
+/// Return the process-global calibration-config snapshot cache.
+#[must_use]
+pub fn calibration_config() -> &'static SnapshotCache<MatchingRuleConfig> {
+    CALIBRATION_CONFIG.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded calibration-config snapshot.
+pub fn store_calibration_config(value: Arc<MatchingRuleConfig>) {
+    calibration_config().store(value);
+}
+
+/// Clear the calibration-config snapshot so the next read reloads from settings.
+pub fn invalidate_calibration_config() {
+    calibration_config().invalidate();
+}
+
+// ── calibration masters snapshot (`matching.rs`) ──────────────────────────────
+
+/// All calibration masters (as seen in list views). 1 slot.
+///
+/// Invalidate site is **untested** — `assign:281` is a non-trigger (writes a
+/// link, not a master); the real trigger is the master-frame INSERT on the
+/// plan-apply/calibration-session path. The worker wiring this cache MUST
+/// confirm the actual write site before calling [`invalidate_calibration_masters`].
+static CALIBRATION_MASTERS: OnceLock<SnapshotCache<Vec<CalibrationMaster>>> = OnceLock::new();
+
+/// Return the process-global calibration-masters snapshot cache.
+#[must_use]
+pub fn calibration_masters() -> &'static SnapshotCache<Vec<CalibrationMaster>> {
+    CALIBRATION_MASTERS.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded calibration-masters snapshot.
+pub fn store_calibration_masters(value: Arc<Vec<CalibrationMaster>>) {
+    calibration_masters().store(value);
+}
+
+/// Clear the calibration-masters snapshot so the next read reloads from the DB.
+pub fn invalidate_calibration_masters() {
+    calibration_masters().invalidate();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn calibration_config_cache_store_load_invalidate_round_trips() {
+        invalidate_calibration_config();
+        assert!(calibration_config().load().is_none());
+
+        store_calibration_config(Arc::new(MatchingRuleConfig::default()));
+        assert!(calibration_config().load().is_some());
+
+        invalidate_calibration_config();
+        assert!(calibration_config().load().is_none());
+    }
+
+    #[test]
+    fn calibration_masters_cache_store_load_invalidate_round_trips() {
+        invalidate_calibration_masters();
+        assert!(calibration_masters().load().is_none());
+
+        store_calibration_masters(Arc::new(vec![]));
+        let loaded = calibration_masters().load().expect("stored snapshot must load");
+        assert!(loaded.is_empty());
+
+        invalidate_calibration_masters();
+        assert!(calibration_masters().load().is_none());
+    }
+}

--- a/crates/app/calibration/src/lib.rs
+++ b/crates/app/calibration/src/lib.rs
@@ -7,6 +7,10 @@
 //! surface stays byte-identical for `desktop_shell` and every other consumer.
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 
+/// Process-global in-memory cache statics for calibration config + masters
+/// snapshots (in-memory caching layer, F0 foundation). See each accessor's
+/// doc comment for its owning write-site invalidation calls.
+pub mod caches;
 pub mod equipment;
 mod matching;
 mod tolerances;

--- a/crates/app/calibration/src/matching.rs
+++ b/crates/app/calibration/src/matching.rs
@@ -30,6 +30,8 @@
     clippy::type_complexity, // DB tuple rows are intentionally typed inline
 )]
 
+use std::sync::Arc;
+
 use audit::bus::EventBus;
 use audit::event_bus::Source;
 use calibration_core::assign::{dimension_names, evaluate_assign, AssignError};
@@ -57,6 +59,8 @@ use time::OffsetDateTime;
 use uuid::Uuid;
 
 use calibration_core::ranking::suggest_status;
+
+use crate::caches;
 
 // ── Settings keys ─────────────────────────────────────────────────────────────
 
@@ -627,8 +631,23 @@ async fn load_master_by_id(
     }))
 }
 
-/// Load `MatchingRuleConfig` from persisted settings keys, falling back to defaults.
+/// Load `MatchingRuleConfig`, reading through the process-global
+/// `caches::calibration_config` snapshot (in-memory caching layer, F0).
+///
+/// A hit returns the cached snapshot without touching the DB; a miss falls
+/// through to [`load_config_from_db`] and stores the freshly loaded value
+/// before returning it.
 async fn load_config(pool: &SqlitePool) -> MatchingRuleConfig {
+    if let Some(cached) = caches::calibration_config().load() {
+        return (*cached).clone();
+    }
+    let config = load_config_from_db(pool).await;
+    caches::store_calibration_config(Arc::new(config.clone()));
+    config
+}
+
+/// Load `MatchingRuleConfig` from persisted settings keys, falling back to defaults.
+async fn load_config_from_db(pool: &SqlitePool) -> MatchingRuleConfig {
     let mut config = MatchingRuleConfig::default();
 
     // `require_same_offset` is persisted on the `calibration_tolerances`
@@ -677,14 +696,27 @@ async fn load_config(pool: &SqlitePool) -> MatchingRuleConfig {
 
 // ── Masters list / get (T037, FR-013) ─────────────────────────────────────────
 
-/// `calibration.masters.list` — return all calibration masters from real DB rows.
-///
-/// Backed by `calibration_master_view` (migration 0033) which joins
-/// `calibration_session` with `calibration_fingerprint`.
+/// `calibration.masters.list` — return all calibration masters, reading
+/// through the process-global `caches::calibration_masters` snapshot
+/// (in-memory caching layer, F0). A hit returns the cached list without a DB
+/// round trip; a miss loads from the DB, stores the snapshot, and returns it.
 ///
 /// # Errors
 /// Returns `Err(String)` on database failure.
 pub async fn masters_list(
+    pool: &SqlitePool,
+) -> Result<Vec<contracts_core::calibration::CalibrationMaster>, String> {
+    if let Some(cached) = caches::calibration_masters().load() {
+        return Ok((*cached).clone());
+    }
+    let masters = masters_list_from_db(pool).await?;
+    caches::store_calibration_masters(Arc::new(masters.clone()));
+    Ok(masters)
+}
+
+/// Load all calibration masters from `calibration_master_view` (migration
+/// 0033), which joins `calibration_session` with `calibration_fingerprint`.
+async fn masters_list_from_db(
     pool: &SqlitePool,
 ) -> Result<Vec<contracts_core::calibration::CalibrationMaster>, String> {
     let rows = q_calibration::list_calibration_masters(pool).await.map_err(|e| e.to_string())?;
@@ -799,9 +831,23 @@ mod masters_tests {
         db
     }
 
+    /// `masters_list`/`load_config` read through process-global snapshot
+    /// caches (`caches::calibration_masters`/`calibration_config`). Tests
+    /// that exercise them run concurrently by default under `cargo test`, so
+    /// without serialization one test's `invalidate`+prime can race another
+    /// test's assertions on the same static slot. Hold this lock for the
+    /// duration of any such test.
+    static CACHE_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    async fn lock_cache_tests() -> tokio::sync::MutexGuard<'static, ()> {
+        CACHE_TEST_LOCK.lock().await
+    }
+
     /// T032 / T037: masters_list returns real rows from calibration_master_view.
     #[tokio::test]
     async fn masters_list_returns_real_rows_not_fixtures() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_masters();
         let db = test_db().await;
 
         sqlx::query(
@@ -832,6 +878,8 @@ mod masters_tests {
     /// T032 / T037: masters_list returns empty on a fresh DB (no fixtures).
     #[tokio::test]
     async fn masters_list_returns_empty_on_fresh_db() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_masters();
         let db = test_db().await;
         let masters = masters_list(db.pool()).await.unwrap();
         assert!(masters.is_empty(), "fresh DB must have no masters — not fixtures");
@@ -876,6 +924,8 @@ mod masters_tests {
     /// T032 / T037: calibration suggest finds real masters from populated fingerprints.
     #[tokio::test]
     async fn suggest_uses_real_fingerprint_rows() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_masters();
         let db = test_db().await;
 
         // Insert acquisition session + fingerprint.
@@ -921,14 +971,85 @@ mod masters_tests {
         assert_eq!(masters[0].id, "cal-t3");
     }
 
+    /// In-memory caching layer (F0 follow-up): a `load_config` cache hit must
+    /// skip the DB entirely, so a `calibration_tolerances` update after the
+    /// first call is invisible until `invalidate_calibration_config` is
+    /// called.
+    #[tokio::test]
+    async fn load_config_cache_hit_skips_db_until_invalidated() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_config();
+        let db = test_db().await;
+
+        let first = load_config(db.pool()).await;
+        assert!(first.require_same_offset, "fresh DB primes the cache with the default (true)");
+
+        let row = persistence_db::repositories::calibration_tolerances::CalibrationTolerancesRow {
+            temperature_tolerance_c: 5.0,
+            exposure_tolerance_s: 2.0,
+            aging_limit_days: 365,
+            require_same_camera: true,
+            require_same_gain: true,
+            require_same_binning: true,
+            require_same_offset: false,
+        };
+        persistence_db::repositories::calibration_tolerances::update(db.pool(), &row)
+            .await
+            .unwrap();
+
+        let cached = load_config(db.pool()).await;
+        assert!(cached.require_same_offset, "cache hit must not see the post-priming update");
+
+        caches::invalidate_calibration_config();
+        let fresh = load_config(db.pool()).await;
+        assert!(!fresh.require_same_offset, "after invalidation, the update must be visible");
+    }
+
     /// Spec 043 P8: `load_config` defaults `require_same_offset` to true on a
     /// fresh DB, matching `MatchingRuleConfig::default()` (migration 0008/0051
     /// seed row).
     #[tokio::test]
     async fn load_config_defaults_require_same_offset_true() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_config();
         let db = test_db().await;
         let config = load_config(db.pool()).await;
         assert!(config.require_same_offset);
+    }
+
+    /// In-memory caching layer (F0 follow-up): a `masters_list` cache hit
+    /// must skip the DB entirely, so a row inserted after the first call is
+    /// invisible until `invalidate_calibration_masters` is called.
+    #[tokio::test]
+    async fn masters_list_cache_hit_skips_db_until_invalidated() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_masters();
+        let db = test_db().await;
+
+        let first = masters_list(db.pool()).await.unwrap();
+        assert!(first.is_empty(), "fresh DB primes the cache with an empty snapshot");
+
+        sqlx::query(
+            "INSERT INTO calibration_session (id, session_key, kind, created_at) \
+             VALUES ('cal-t4', 'dark-60s', 'dark', '2026-06-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO calibration_fingerprint (id, calibration_type, gain, exposure_s, binning) \
+             VALUES ('cal-t4', 'dark', 100.0, 60.0, '1x1')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let cached = masters_list(db.pool()).await.unwrap();
+        assert!(cached.is_empty(), "cache hit must not see the row inserted after priming");
+
+        caches::invalidate_calibration_masters();
+        let fresh = masters_list(db.pool()).await.unwrap();
+        assert_eq!(fresh.len(), 1, "after invalidation, the new row must be visible");
     }
 
     /// Spec 043 P8: the Settings > Calibration Matching "Offset match
@@ -938,6 +1059,8 @@ mod masters_tests {
     /// gap.
     #[tokio::test]
     async fn load_config_reads_require_same_offset_from_tolerances_table() {
+        let _guard = lock_cache_tests().await;
+        caches::invalidate_calibration_config();
         let db = test_db().await;
 
         let row = persistence_db::repositories::calibration_tolerances::CalibrationTolerancesRow {

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -29,6 +29,8 @@ persistence_db = { path = "../../persistence/db" }
 project_structure = { path = "../../project/structure" }
 workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
+# In-memory caching layer (F0 foundation).
+app_core_cache = { path = "../cache" }
 camino = { workspace = true }
 dashmap = { workspace = true }
 hex.workspace = true

--- a/crates/app/core/src/caches.rs
+++ b/crates/app/core/src/caches.rs
@@ -6,15 +6,16 @@
 //! rationale (would churn every command signature; background tasks have no
 //! `Tauri::State` handle anyway).
 //!
-//! This module defines the cache handles and their `pub invalidate_*` /
-//! reader functions only. Wiring reads through the cache and calling
-//! `invalidate_*` at write sites is downstream (W-ROOT, W-PROT) work.
+//! This module defines the `library_root` and `source_protection_state`
+//! cache handles and their `pub invalidate_*` / reader functions; read-through
+//! + invalidation wiring lives at their call sites in `first_run.rs` /
+//! `protection.rs` / `plan_apply.rs`. The `protection_defaults` cache is
+//! defined in `app_core_cache` instead (see the note below) because
+//! `app_core_settings` must also be able to invalidate it.
 
-use std::sync::{Arc, OnceLock};
+use std::sync::OnceLock;
 
-use app_core_cache::{CacheConfig, SnapshotCache, TtlCache};
-
-use crate::protection::GlobalProtection;
+use app_core_cache::{CacheConfig, TtlCache};
 
 // ── library_root: root_id → path (`first_run.rs`) ──────────────────────────
 
@@ -62,38 +63,12 @@ pub fn invalidate_source_protection_state(source_id: &str) {
     source_protection_state().invalidate(&source_id.to_owned());
 }
 
-// ── protection defaults: global default level/categories (`protection.rs`) ──
-
-/// Global protection defaults snapshot (`protection_defaults` table, scope
-/// `"global"`), 1 slot.
-///
-/// Invalidate at `protection::set_global_protection_default` and via the
-/// settings-bag fan-out (`app_core_settings::update_setting` /
-/// `restore_defaults` for the `defaultProtection`/`blockPermanentDelete`/
-/// `protectedCategories` keys) since defaults are also legacy-readable from
-/// the `settings` table.
-static PROTECTION_DEFAULTS: OnceLock<SnapshotCache<GlobalProtection>> = OnceLock::new();
-
-/// Return the process-global protection-defaults snapshot cache.
-///
-/// `pub(crate)` (not `pub`): [`GlobalProtection`] itself is `pub(crate)` to
-/// `app_core` (defined in `protection.rs`), so this accessor cannot be any
-/// more public than its return type without also widening that struct's
-/// visibility — every caller already lives inside this crate.
-pub(crate) fn protection_defaults() -> &'static SnapshotCache<GlobalProtection> {
-    PROTECTION_DEFAULTS.get_or_init(SnapshotCache::new)
-}
-
-/// Store a freshly loaded [`GlobalProtection`] snapshot.
-#[allow(dead_code)] // called by the read-through load path once W-PROT wires it in
-pub(crate) fn store_protection_defaults(value: Arc<GlobalProtection>) {
-    protection_defaults().store(value);
-}
-
-/// Clear the protection-defaults snapshot so the next read reloads from the DB.
-pub fn invalidate_protection_defaults() {
-    protection_defaults().invalidate();
-}
+// Note: the `protection_defaults` global-defaults snapshot cache lives in
+// `app_core_cache` (`app_core_cache::protection_defaults` /
+// `invalidate_protection_defaults`), not here — `app_core_settings` also
+// needs to invalidate it, and `app_core` depends on `app_core_settings`, so
+// keeping it in this crate would create a cycle. See `protection.rs` for the
+// read-through wiring.
 
 #[cfg(test)]
 mod tests {
@@ -126,25 +101,5 @@ mod tests {
 
         invalidate_source_protection_state("src-1");
         assert!(cache.get(&"src-1".to_owned()).is_none());
-    }
-
-    #[test]
-    fn protection_defaults_store_load_invalidate_round_trips() {
-        // Reuses the process-global static, so scope this test to values it
-        // fully owns (invalidate at start and end) to stay independent of
-        // other tests' ordering.
-        invalidate_protection_defaults();
-        assert!(protection_defaults().load().is_none());
-
-        store_protection_defaults(Arc::new(GlobalProtection {
-            level: "protected".to_owned(),
-            block_permanent_delete: true,
-            categories: vec!["lights".to_owned()],
-        }));
-        let loaded = protection_defaults().load().expect("stored value must load");
-        assert_eq!(loaded.level, "protected");
-
-        invalidate_protection_defaults();
-        assert!(protection_defaults().load().is_none());
     }
 }

--- a/crates/app/core/src/caches.rs
+++ b/crates/app/core/src/caches.rs
@@ -1,0 +1,150 @@
+//! `app_core`-owned cache statics (in-memory caching layer, F0 foundation).
+//!
+//! Each cache is a module-local process-global `OnceLock`, mirroring the
+//! `ACTIVE_RUNS` pattern in [`crate::plan_apply`]. No central `AppCaches`
+//! struct — see the caching layer plan's "Architecture" section for the
+//! rationale (would churn every command signature; background tasks have no
+//! `Tauri::State` handle anyway).
+//!
+//! This module defines the cache handles and their `pub invalidate_*` /
+//! reader functions only. Wiring reads through the cache and calling
+//! `invalidate_*` at write sites is downstream (W-ROOT, W-PROT) work.
+
+use std::sync::{Arc, OnceLock};
+
+use app_core_cache::{CacheConfig, SnapshotCache, TtlCache};
+
+use crate::protection::GlobalProtection;
+
+// ── library_root: root_id → path (`first_run.rs`) ──────────────────────────
+
+/// `root_id` → resolved filesystem path. Capacity 256 (registered library
+/// roots are few and long-lived), explicit-only invalidation (no TTL — a
+/// remapped root must never silently resurface its old path).
+///
+/// Invalidate at `first_run::register_source` / `register_source_batch` /
+/// `remap_root` for the affected `root_id`(s).
+static LIBRARY_ROOT: OnceLock<TtlCache<String, String>> = OnceLock::new();
+
+/// Return the process-global `library_root` cache (root_id → path).
+pub fn library_root() -> &'static TtlCache<String, String> {
+    LIBRARY_ROOT.get_or_init(|| TtlCache::new(CacheConfig::new(256)))
+}
+
+/// Remove the cached path for `root_id`. Call after any write that changes or
+/// removes a root's recorded path (register, remap, remove).
+pub fn invalidate_library_root(root_id: &str) {
+    library_root().invalidate(&root_id.to_owned());
+}
+
+// ── source_protection_state: source_id → resolved protection (`protection.rs`) ──
+
+/// `source_id` → resolved [`contracts_core::protection::SourceProtectionGetResponse`].
+/// Capacity 8,192, explicit-only invalidation.
+///
+/// Invalidate at `protection::set_source_protection` (the affected
+/// `source_id`) and `protection::seed_source_protection` (loop the affected
+/// `source_id`s — `TtlCache` exposes no bulk-clear, so a "seed touches every
+/// source" write invalidates each known id it just seeded).
+static SOURCE_PROTECTION_STATE: OnceLock<
+    TtlCache<String, contracts_core::protection::SourceProtectionGetResponse>,
+> = OnceLock::new();
+
+/// Return the process-global `source_protection_state` cache (source_id →
+/// resolved protection).
+pub fn source_protection_state(
+) -> &'static TtlCache<String, contracts_core::protection::SourceProtectionGetResponse> {
+    SOURCE_PROTECTION_STATE.get_or_init(|| TtlCache::new(CacheConfig::new(8_192)))
+}
+
+/// Remove the cached resolved protection for `source_id`.
+pub fn invalidate_source_protection_state(source_id: &str) {
+    source_protection_state().invalidate(&source_id.to_owned());
+}
+
+// ── protection defaults: global default level/categories (`protection.rs`) ──
+
+/// Global protection defaults snapshot (`protection_defaults` table, scope
+/// `"global"`), 1 slot.
+///
+/// Invalidate at `protection::set_global_protection_default` and via the
+/// settings-bag fan-out (`app_core_settings::update_setting` /
+/// `restore_defaults` for the `defaultProtection`/`blockPermanentDelete`/
+/// `protectedCategories` keys) since defaults are also legacy-readable from
+/// the `settings` table.
+static PROTECTION_DEFAULTS: OnceLock<SnapshotCache<GlobalProtection>> = OnceLock::new();
+
+/// Return the process-global protection-defaults snapshot cache.
+///
+/// `pub(crate)` (not `pub`): [`GlobalProtection`] itself is `pub(crate)` to
+/// `app_core` (defined in `protection.rs`), so this accessor cannot be any
+/// more public than its return type without also widening that struct's
+/// visibility — every caller already lives inside this crate.
+pub(crate) fn protection_defaults() -> &'static SnapshotCache<GlobalProtection> {
+    PROTECTION_DEFAULTS.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded [`GlobalProtection`] snapshot.
+#[allow(dead_code)] // called by the read-through load path once W-PROT wires it in
+pub(crate) fn store_protection_defaults(value: Arc<GlobalProtection>) {
+    protection_defaults().store(value);
+}
+
+/// Clear the protection-defaults snapshot so the next read reloads from the DB.
+pub fn invalidate_protection_defaults() {
+    protection_defaults().invalidate();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn library_root_cache_hit_then_invalidate_misses() {
+        let cache = library_root();
+        cache.insert("root-1".to_owned(), "/mnt/d/astro".to_owned());
+        assert_eq!(cache.get(&"root-1".to_owned()), Some("/mnt/d/astro".to_owned()));
+
+        invalidate_library_root("root-1");
+        assert_eq!(cache.get(&"root-1".to_owned()), None);
+    }
+
+    #[test]
+    fn source_protection_state_cache_hit_then_invalidate_misses() {
+        use contracts_core::protection::{ProtectionLevel, SourceProtectionGetResponse};
+
+        let cache = source_protection_state();
+        let value = SourceProtectionGetResponse {
+            source_id: Some("src-1".to_owned()),
+            level: ProtectionLevel::Protected,
+            block_permanent_delete: true,
+            categories: vec!["lights".to_owned()],
+            inherits_default: true,
+        };
+        cache.insert("src-1".to_owned(), value.clone());
+        assert_eq!(cache.get(&"src-1".to_owned()).map(|v| v.source_id), Some(value.source_id));
+
+        invalidate_source_protection_state("src-1");
+        assert!(cache.get(&"src-1".to_owned()).is_none());
+    }
+
+    #[test]
+    fn protection_defaults_store_load_invalidate_round_trips() {
+        // Reuses the process-global static, so scope this test to values it
+        // fully owns (invalidate at start and end) to stay independent of
+        // other tests' ordering.
+        invalidate_protection_defaults();
+        assert!(protection_defaults().load().is_none());
+
+        store_protection_defaults(Arc::new(GlobalProtection {
+            level: "protected".to_owned(),
+            block_permanent_delete: true,
+            categories: vec!["lights".to_owned()],
+        }));
+        let loaded = protection_defaults().load().expect("stored value must load");
+        assert_eq!(loaded.level, "protected");
+
+        invalidate_protection_defaults();
+        assert!(protection_defaults().load().is_none());
+    }
+}

--- a/crates/app/core/src/cleanup_generator.rs
+++ b/crates/app/core/src/cleanup_generator.rs
@@ -430,6 +430,11 @@ pub async fn generate(
 
 #[cfg(test)]
 mod tests {
+    // See the matching allow in `protection::tests`: `setup()`'s test-lock
+    // guard is deliberately held across every `.await` in each test body, and
+    // that's safe under `#[tokio::test]`'s current-thread runtime default.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use audit::bus::EventBus;
     use contracts_core::protection::{
@@ -440,11 +445,22 @@ mod tests {
     use persistence_db::repositories::projects::{insert_project, InsertProject};
     use persistence_db::Database;
 
-    async fn setup() -> (Database, EventBus) {
+    async fn setup() -> (Database, EventBus, std::sync::MutexGuard<'static, ()>) {
+        // `scan_with_policy` unconditionally calls `protection::load_global_protection`,
+        // which read-throughs the process-global `protection_defaults` cache
+        // (a single unkeyed slot shared by every in-memory DB in this test
+        // binary — see `protection::PROTECTION_DEFAULTS_TEST_LOCK`). Serialize
+        // against `protection.rs`'s tests (e.g. `t041_...`, which mutates the
+        // default to `"unprotected"`) so a value-sensitive assertion here
+        // (e.g. `generate_protected_final_gates_approval` expecting the
+        // default `"protected"`) can't race it.
+        let lock = crate::protection::PROTECTION_DEFAULTS_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());
-        (db, bus)
+        (db, bus, lock)
     }
 
     async fn seed_project(db: &Database, id: &str) {
@@ -521,7 +537,7 @@ mod tests {
 
     #[tokio::test]
     async fn policy_defaults_when_unset() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         let policy = get_policy(db.pool()).await.unwrap();
         assert_eq!(policy.entries.len(), 3);
         assert!(!policy.auto_on_completion);
@@ -530,7 +546,7 @@ mod tests {
 
     #[tokio::test]
     async fn policy_round_trip_persists() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         let updated = CleanupPolicy {
             entries: vec![
                 CleanupPolicyEntry {
@@ -558,7 +574,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_empty_project_has_no_candidates() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p-empty").await;
         let result = scan(db.pool(), "p-empty").await.unwrap();
         assert!(result.candidates.is_empty());
@@ -568,7 +584,7 @@ mod tests {
     #[tokio::test]
     async fn scan_default_policy_proposes_nothing() {
         // Default policy is all-Keep: even with artifacts present, no candidates.
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         seed_artifact(&db, "a1", "p1", "calibrated/light_001.xisf", "intermediate", 1000).await;
         let result = scan(db.pool(), "p1").await.unwrap();
@@ -577,7 +593,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_actioned_type_becomes_candidate_and_sums_bytes() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         seed_artifact(&db, "a1", "p1", "calibrated/light_001.xisf", "intermediate", 1000).await;
         seed_artifact(&db, "a2", "p1", "calibrated/light_002.xisf", "intermediate", 2000).await;
@@ -611,7 +627,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_excludes_unclassified() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         // A present artifact whose kind is not intermediate/master/final cannot
         // exist under the CHECK constraint; simulate the exclusion path by
@@ -639,7 +655,7 @@ mod tests {
 
     #[tokio::test]
     async fn scan_creates_no_plan() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         seed_artifact(&db, "a1", "p1", "calibrated/light_001.xisf", "intermediate", 1000).await;
         set_policy(
@@ -664,7 +680,7 @@ mod tests {
 
     #[tokio::test]
     async fn generate_creates_plan_with_items() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         seed_artifact(&db, "a1", "p1", "calibrated/light_001.xisf", "intermediate", 1000).await;
         seed_artifact(&db, "a2", "p1", "calibrated/light_002.xisf", "intermediate", 2000).await;
@@ -701,7 +717,7 @@ mod tests {
     async fn generate_delete_items_require_no_destination_bytes() {
         // Delete-action items are removed, not archived, so they contribute
         // zero to the plan's destination byte requirement (D17).
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         seed_artifact(&db, "a1", "p1", "calibrated/light_001.xisf", "intermediate", 1000).await;
         set_policy(
@@ -728,7 +744,7 @@ mod tests {
 
     #[tokio::test]
     async fn generate_protected_final_gates_approval() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         // A final output — default protected categories include "finals".
         seed_artifact(&db, "a1", "p1", "final/M31.xisf", "final", 9000).await;
@@ -768,7 +784,7 @@ mod tests {
         // intermediate item would gate approval. A per-source "unprotected"
         // override must flow through and downgrade it — proving the override
         // path is live, not inert.
-        let (db, bus) = setup().await;
+        let (db, bus, _lock) = setup().await;
         seed_project(&db, "p1").await;
         seed_artifact(&db, "a1", "p1", "calibrated/light_001.xisf", "intermediate", 1000).await;
         set_policy(

--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -27,6 +27,8 @@ use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity, JsonAn
 use persistence_db::repositories::first_run as repo;
 use sqlx::SqlitePool;
 
+use crate::caches;
+
 /// Maximum number of previously-recorded relative paths sampled by
 /// `remap_root` to preview whether they resolve under a candidate new path.
 const REMAP_SAMPLE_LIMIT: i64 = 5;
@@ -147,7 +149,12 @@ pub async fn register_source(
 ) -> Result<RegisterSourceResponse, ContractError> {
     validate_path(&req.path).map_err(|e| *e)?;
     check_duplicate(pool, &req.path, req.kind).await?;
-    repo::register_source(pool, req).await.map_err(db_to_contract)
+    let resp = repo::register_source(pool, req).await.map_err(db_to_contract)?;
+    // Invalidate after commit (F0 contract): a freshly registered id can't
+    // already be cached, but this keeps the write site authoritative if a
+    // removed root's id is ever reused.
+    caches::invalidate_library_root(&resp.source_id);
+    Ok(resp)
 }
 
 /// Change a source's organization state after registration (spec 041, T030).
@@ -277,6 +284,13 @@ pub async fn register_source_batch(
 
     // Sort items by original index for deterministic output.
     items.sort_by_key(|item| item.index);
+
+    // Invalidate after commit (F0 contract) for every newly registered root.
+    for item in items.iter().filter(|i| i.status == ItemStatus::Success) {
+        if let Some(source_id) = &item.source_id {
+            caches::invalidate_library_root(source_id);
+        }
+    }
 
     let success_count = items.iter().filter(|i| i.status == ItemStatus::Success).count();
     let failure_count = items.iter().filter(|i| i.status == ItemStatus::Failure).count();
@@ -478,6 +492,8 @@ pub async fn apply_root_remap(
     validate_path(new_path).map_err(|e| *e)?;
 
     repo::set_source_path(pool, root_id, new_path).await.map_err(db_to_contract)?;
+    // Invalidate after commit (F0 contract) so the next read reloads the new path.
+    caches::invalidate_library_root(root_id);
 
     // Publish audit event (best-effort; do not fail the operation if the bus drops).
     let _ = bus
@@ -569,6 +585,9 @@ pub async fn delete_source(
     }
 
     repo::remove_source(pool, root_id).await.map_err(db_to_contract)?;
+    // Invalidate after commit: the root row (and its path) no longer exists,
+    // so a still-cached path would otherwise resurface for a deleted root.
+    caches::invalidate_library_root(root_id);
 
     let kind_str: &'static str = kind.into();
     let _ = bus

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -57,6 +57,11 @@ pub use targets::{
 // and may reference the extracted domain crates as `crate::errors`,
 // `crate::lifecycle`, etc. via the re-exports above.
 pub mod archive_generator;
+/// Process-global in-memory cache statics for `app_core`-owned domain types
+/// (in-memory caching layer, F0 foundation): `library_root` path lookups and
+/// `source_protection_state`/defaults. See each accessor's doc comment for
+/// its owning write-site invalidation calls.
+pub mod caches;
 pub mod cleanup_generator;
 #[cfg(feature = "dev-tools")]
 pub mod dev_contracts;

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -57,6 +57,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use crate::caches;
 use crate::errors::bus_err;
 use crate::path_set::PlanPathSet;
 use dashmap::DashMap;
@@ -922,9 +923,27 @@ pub async fn apply_plan(
             // back to `registered_sources` when `library_root` has no row.
             // Without this, inbox `move` plans resolve to bare relative paths
             // and every apply fails with `source.missing`.
+            //
+            // Read-through `caches::library_root` (F0) wraps only the
+            // `registered_sources` fallback, not the legacy `library_root`
+            // table lookup: `invalidate_library_root` is only called from
+            // `first_run.rs`'s writers of `registered_sources` (register /
+            // remap / delete), so caching the legacy-table branch too would
+            // go stale on writes this module never sees.
             let resolved = match inventory_repo::get_library_root_path(pool, rid).await {
                 Ok(Some(path)) => Some(path),
-                _ => first_run_repo::get_source_path(pool, rid).await.ok().flatten(),
+                _ => {
+                    if let Some(cached) = caches::library_root().get(rid) {
+                        Some(cached)
+                    } else {
+                        let loaded =
+                            first_run_repo::get_source_path(pool, rid).await.ok().flatten();
+                        if let Some(path) = &loaded {
+                            caches::library_root().insert(rid.clone(), path.clone());
+                        }
+                        loaded
+                    }
+                }
             };
             if let Some(path) = resolved {
                 root_map.insert(rid.clone(), Utf8PathBuf::from(path));

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -840,6 +840,32 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
     }
 }
 
+/// Resolve a `root_id` to its absolute path: legacy `library_root` table
+/// first, then `registered_sources` (gen-3 source model).
+///
+/// Read-through `caches::library_root` (F0) wraps only the
+/// `registered_sources` fallback, not the legacy `library_root` table
+/// lookup: `invalidate_library_root` is only called from `first_run.rs`'s
+/// writers of `registered_sources` (register / remap / delete), so caching
+/// the legacy-table branch too would go stale on writes this module never
+/// sees.
+async fn resolve_root_path(pool: &SqlitePool, root_id: &str) -> Option<String> {
+    match inventory_repo::get_library_root_path(pool, root_id).await {
+        Ok(Some(path)) => Some(path),
+        _ => {
+            if let Some(cached) = caches::library_root().get(&root_id.to_owned()) {
+                Some(cached)
+            } else {
+                let loaded = first_run_repo::get_source_path(pool, root_id).await.ok().flatten();
+                if let Some(path) = &loaded {
+                    caches::library_root().insert(root_id.to_owned(), path.clone());
+                }
+                loaded
+            }
+        }
+    }
+}
+
 // ── apply_plan ────────────────────────────────────────────────────────────────
 
 /// Start applying an approved plan (US1, T018, T019, T020, T021, T055).
@@ -923,29 +949,7 @@ pub async fn apply_plan(
             // back to `registered_sources` when `library_root` has no row.
             // Without this, inbox `move` plans resolve to bare relative paths
             // and every apply fails with `source.missing`.
-            //
-            // Read-through `caches::library_root` (F0) wraps only the
-            // `registered_sources` fallback, not the legacy `library_root`
-            // table lookup: `invalidate_library_root` is only called from
-            // `first_run.rs`'s writers of `registered_sources` (register /
-            // remap / delete), so caching the legacy-table branch too would
-            // go stale on writes this module never sees.
-            let resolved = match inventory_repo::get_library_root_path(pool, rid).await {
-                Ok(Some(path)) => Some(path),
-                _ => {
-                    if let Some(cached) = caches::library_root().get(rid) {
-                        Some(cached)
-                    } else {
-                        let loaded =
-                            first_run_repo::get_source_path(pool, rid).await.ok().flatten();
-                        if let Some(path) = &loaded {
-                            caches::library_root().insert(rid.clone(), path.clone());
-                        }
-                        loaded
-                    }
-                }
-            };
-            if let Some(path) = resolved {
+            if let Some(path) = resolve_root_path(pool, rid).await {
                 root_map.insert(rid.clone(), Utf8PathBuf::from(path));
             } else {
                 tracing::warn!(root_id = %rid, "plan item references unknown root (not in library_root or registered_sources); path gate will be inactive for this item");
@@ -1773,6 +1777,53 @@ mod tests {
 
         repo::update_plan_state(db.pool(), plan_id, "ready_for_review").await.unwrap();
         repo::set_approved(db.pool(), plan_id, "2026-06-01T00:00:00Z", "test-token").await.unwrap();
+    }
+
+    /// Regression (FIX review, priority-check #2): `resolve_root_path`'s
+    /// `registered_sources` read-through must never resurface a
+    /// pre-remap path after `apply_root_remap` commits the new one.
+    #[tokio::test]
+    async fn resolve_root_path_reflects_remap_not_stale_cache() {
+        use contracts_core::first_run::{
+            OrganizationState, RegisterSourceRequest, ScanDepth, SourceKind,
+        };
+
+        // Needs two real, existing directories; "/tmp" and "/var/tmp" are Unix-only.
+        if !cfg!(unix) {
+            return;
+        }
+
+        let (db, bus) = setup().await;
+
+        let reg = crate::first_run::register_source(
+            db.pool(),
+            &RegisterSourceRequest {
+                kind: SourceKind::Project,
+                path: "/tmp".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Organized,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Populate the cache via the same registered_sources fallback branch
+        // apply_plan's root_map build resolves through.
+        let resolved = resolve_root_path(db.pool(), &reg.source_id).await;
+        assert_eq!(resolved.as_deref(), Some("/tmp"), "must resolve the registered path");
+
+        // Remap must invalidate the cache entry after its DB write commits.
+        crate::first_run::apply_root_remap(db.pool(), &bus, &reg.source_id, "/var/tmp", true)
+            .await
+            .unwrap();
+
+        let after_remap = resolve_root_path(db.pool(), &reg.source_id).await;
+        assert_eq!(
+            after_remap.as_deref(),
+            Some("/var/tmp"),
+            "resolve_root_path must return the remapped path, not a stale cached one"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -714,26 +714,46 @@ pub async fn generate_plan(
 
 // ── Tests ─────────────────────────────────────────────────────────────────
 
+/// Serializes every test — in this module and in `cleanup_generator.rs`
+/// (`pub(crate)` so that sibling module can reach it) — that reads or writes
+/// the process-global `protection_defaults` cache (directly, or via
+/// `load_global_protection` / `set_global_protection_default`). That cache is
+/// a single unkeyed slot shared by every in-memory DB in this test binary, so
+/// e.g. `t041_set_global_default_persists_and_emits_event` mutating it to
+/// `"unprotected"` could otherwise race a concurrently-running,
+/// value-sensitive read elsewhere that expects the default `"protected"`
+/// (`cleanup_generator::tests::generate_protected_final_gates_approval`).
+/// Acquired for the whole test body via `setup()`'s returned guard — an
+/// invalidate-at-setup reset alone only guards against a *completed* prior
+/// test's leftover value, not a genuinely concurrent mutation.
+#[cfg(test)]
+pub(crate) static PROTECTION_DEFAULTS_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
+    // `setup()`'s `PROTECTION_DEFAULTS_TEST_LOCK` guard is deliberately held
+    // across every `.await` for the rest of each test body — that's the whole
+    // point (serialize the full test, not just the lock acquisition). Safe
+    // here because `#[tokio::test]` defaults to a current-thread runtime: the
+    // guard is never held across a thread hand-off.
+    #![allow(clippy::await_holding_lock)]
+
     use super::*;
     use audit::bus::EventBus;
     use persistence_db::repositories::plans as plans_repo;
     use persistence_db::repositories::plans::InsertPlan;
     use persistence_db::Database;
 
-    async fn setup() -> (Database, EventBus) {
-        // `protection_defaults` is a process-global single-slot cache (F0):
-        // every test in this binary shares it regardless of which in-memory
-        // DB it's keyed to. Force a miss at the start of each test so a
-        // stale value left by a differently-configured DB from an earlier
-        // test can't leak in (same mitigation as the `library_root`
-        // cross-test collision fixed in plan_apply.rs).
+    async fn setup() -> (Database, EventBus, std::sync::MutexGuard<'static, ()>) {
+        // See `PROTECTION_DEFAULTS_TEST_LOCK` for why this lock (not just the
+        // `invalidate` reset below) is required.
+        let lock =
+            PROTECTION_DEFAULTS_TEST_LOCK.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         app_core_cache::invalidate_protection_defaults();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());
-        (db, bus)
+        (db, bus, lock)
     }
 
     async fn insert_plan_with_items(db: &Database, plan_id: &str, protection: &str) {
@@ -780,7 +800,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_global_protection_returns_defaults() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         let req = SourceProtectionGetRequest { source_id: None };
         let resp = get_source_protection(db.pool(), &req).await.unwrap();
         assert!(resp.inherits_default);
@@ -790,7 +810,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_source_protection_inherits_when_no_override() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         let req = SourceProtectionGetRequest { source_id: Some("src-abc".to_owned()) };
         let resp = get_source_protection(db.pool(), &req).await.unwrap();
         assert!(resp.inherits_default);
@@ -798,7 +818,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_and_get_source_protection_round_trip() {
-        let (db, bus) = setup().await;
+        let (db, bus, _lock) = setup().await;
         let source_id = "src-001";
 
         let set_req = SourceProtectionSetRequest {
@@ -819,7 +839,7 @@ mod tests {
 
     #[tokio::test]
     async fn plan_protection_check_not_found() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         let req = PlanProtectionCheckRequest { plan_id: "nonexistent".to_owned() };
         let err = plan_protection_check(db.pool(), &req).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::PlanNotFound);
@@ -827,7 +847,7 @@ mod tests {
 
     #[tokio::test]
     async fn plan_protection_check_returns_protected_items() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         insert_plan_with_items(&db, "plan-1", "protected").await;
 
         let req = PlanProtectionCheckRequest { plan_id: "plan-1".to_owned() };
@@ -842,7 +862,7 @@ mod tests {
 
     #[tokio::test]
     async fn plan_protection_check_normal_items_in_summary() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         insert_plan_with_items(&db, "plan-2", "normal").await;
 
         let req = PlanProtectionCheckRequest { plan_id: "plan-2".to_owned() };
@@ -855,7 +875,7 @@ mod tests {
 
     #[tokio::test]
     async fn seed_source_protection_inbox_gets_normal() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_source_protection(db.pool(), "src-inbox", "inbox").await.unwrap();
 
         let row = prot_repo::get_source_protection_row(db.pool(), "src-inbox")
@@ -867,7 +887,7 @@ mod tests {
 
     #[tokio::test]
     async fn seed_source_protection_inventory_gets_protected() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         seed_source_protection(db.pool(), "src-inv", "inventory").await.unwrap();
 
         let row = prot_repo::get_source_protection_row(db.pool(), "src-inv")
@@ -879,7 +899,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_protection_emits_audit_event() {
-        let (db, bus) = setup().await;
+        let (db, bus, _lock) = setup().await;
         let source_id = "src-002";
 
         let set_req = SourceProtectionSetRequest {
@@ -895,7 +915,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_action_on_protected_item_gets_rewritten_action() {
-        let (db, _bus) = setup().await;
+        let (db, _bus, _lock) = setup().await;
         // Insert a plan with a "delete" action item marked as protected.
         plans_repo::insert_plan(
             db.pool(),
@@ -955,7 +975,7 @@ mod tests {
 
     #[tokio::test]
     async fn t040_real_cleanup_plan_over_protected_source_is_blocked() {
-        let (db, bus) = setup().await;
+        let (db, bus, _lock) = setup().await;
 
         // Set up a protected source via source.protection.set.
         let source_id = "src-lights-001";
@@ -1033,7 +1053,7 @@ mod tests {
 
     #[tokio::test]
     async fn t041_set_global_default_persists_and_emits_event() {
-        let (db, bus) = setup().await;
+        let (db, bus, _lock) = setup().await;
 
         // Change the global default level to "unprotected".
         let new_value = serde_json::Value::String("unprotected".to_owned());
@@ -1077,7 +1097,7 @@ mod tests {
 
     #[tokio::test]
     async fn t042_non_protected_source_plan_passes_gate() {
-        let (db, bus) = setup().await;
+        let (db, bus, _lock) = setup().await;
 
         // Set up a source explicitly marked as "normal" (e.g. an inbox source).
         let source_id = "src-inbox-002";

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -25,6 +25,9 @@ use persistence_db::repositories::plans as plans_repo;
 use persistence_db::repositories::settings as settings_repo;
 use persistence_db::repositories::source_protection as prot_repo;
 use sqlx::SqlitePool;
+use std::sync::Arc;
+
+use crate::caches;
 
 // ── Error helpers ─────────────────────────────────────────────────────────
 //
@@ -45,6 +48,12 @@ pub(crate) async fn load_global_protection(
     pool: &SqlitePool,
 ) -> Result<GlobalProtection, ContractError> {
     use serde_json::Value;
+
+    // Read-through `caches::protection_defaults` (F0): on a hit, skip the
+    // three-row DB read below entirely.
+    if let Some(cached) = caches::protection_defaults().load() {
+        return Ok((*cached).clone());
+    }
 
     // Prefer protection_defaults table (migration 0035).
     let pd_level = prot_repo::get_protection_default(pool, "global", "defaultProtection")
@@ -83,9 +92,12 @@ pub(crate) async fn load_global_protection(
         _ => vec!["lights".to_owned(), "masters".to_owned(), "finals".to_owned()],
     };
 
-    Ok(GlobalProtection { level, block_permanent_delete, categories })
+    let global = GlobalProtection { level, block_permanent_delete, categories };
+    caches::store_protection_defaults(Arc::new(global.clone()));
+    Ok(global)
 }
 
+#[derive(Clone)]
 pub(crate) struct GlobalProtection {
     pub(crate) level: String,
     pub(crate) block_permanent_delete: bool,
@@ -120,6 +132,10 @@ pub async fn get_source_protection(
             })
         }
         Some(source_id) => {
+            if let Some(cached) = caches::source_protection_state().get(source_id) {
+                return Ok(cached);
+            }
+
             let resolved = prot_repo::resolve_protection(
                 pool,
                 source_id,
@@ -131,13 +147,15 @@ pub async fn get_source_protection(
             .await
             .map_err(db_err)?;
 
-            Ok(SourceProtectionGetResponse {
+            let response = SourceProtectionGetResponse {
                 source_id: Some(source_id.clone()),
                 level: ProtectionLevel::parse_level(&resolved.level),
                 block_permanent_delete: resolved.block_permanent_delete,
                 categories: resolved.categories,
                 inherits_default: resolved.inherits_default,
-            })
+            };
+            caches::source_protection_state().insert(source_id.clone(), response.clone());
+            Ok(response)
         }
     }
 }
@@ -187,6 +205,8 @@ pub async fn set_source_protection(
     )
     .await
     .map_err(db_err)?;
+    // Invalidate after commit (F0 contract) so the next get re-resolves.
+    caches::invalidate_source_protection_state(&req.source_id);
 
     // Emit audit event (T016).
     let at = Timestamp::now_iso();
@@ -236,7 +256,11 @@ pub async fn seed_source_protection(
     let level = if source_kind == "inbox" { "normal" } else { "protected" };
     prot_repo::upsert_source_protection(pool, source_id, level, None, None, "system")
         .await
-        .map_err(db_err)
+        .map_err(db_err)?;
+    // Invalidate after commit (F0 contract): a source is only ever seeded
+    // once, but this keeps re-seed (e.g. re-registration) safe.
+    caches::invalidate_source_protection_state(source_id);
+    Ok(())
 }
 
 // ── US3: plan.protection.check ────────────────────────────────────────────
@@ -423,6 +447,9 @@ pub async fn set_global_protection_default(
         value: contracts_core::JsonAny::from(value),
     };
     crate::settings::update_setting(pool, bus, &req).await?;
+    // Invalidate after commit (F0 contract): all three keys share the single
+    // protection_defaults snapshot, so any of them changing must drop it.
+    caches::invalidate_protection_defaults();
     Ok(())
 }
 

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -11,6 +11,7 @@
 //! `app_core::protection` so the public surface stays byte-identical.
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 
+use app_core_cache::ProtectionDefaultsSnapshot;
 use audit::bus::EventBus;
 use audit::event_bus::{ProtectionPlanAcknowledged, ProtectionSourceSet, Source};
 use audit::{TOPIC_PROTECTION_PLAN_ACKNOWLEDGED, TOPIC_PROTECTION_SOURCE_SET};
@@ -49,10 +50,16 @@ pub(crate) async fn load_global_protection(
 ) -> Result<GlobalProtection, ContractError> {
     use serde_json::Value;
 
-    // Read-through `caches::protection_defaults` (F0): on a hit, skip the
-    // three-row DB read below entirely.
-    if let Some(cached) = caches::protection_defaults().load() {
-        return Ok((*cached).clone());
+    // Read-through `app_core_cache::protection_defaults` (F0): on a hit, skip
+    // the three-row DB read below entirely. Cache lives in the `app_core_cache`
+    // leaf (not `crate::caches`) so `app_core_settings` can invalidate it too
+    // without a dependency cycle.
+    if let Some(cached) = app_core_cache::protection_defaults().load() {
+        return Ok(GlobalProtection {
+            level: cached.level.clone(),
+            block_permanent_delete: cached.block_permanent_delete,
+            categories: cached.categories.clone(),
+        });
     }
 
     // Prefer protection_defaults table (migration 0035).
@@ -93,7 +100,11 @@ pub(crate) async fn load_global_protection(
     };
 
     let global = GlobalProtection { level, block_permanent_delete, categories };
-    caches::store_protection_defaults(Arc::new(global.clone()));
+    app_core_cache::store_protection_defaults(Arc::new(ProtectionDefaultsSnapshot {
+        level: global.level.clone(),
+        block_permanent_delete: global.block_permanent_delete,
+        categories: global.categories.clone(),
+    }));
     Ok(global)
 }
 
@@ -449,7 +460,7 @@ pub async fn set_global_protection_default(
     crate::settings::update_setting(pool, bus, &req).await?;
     // Invalidate after commit (F0 contract): all three keys share the single
     // protection_defaults snapshot, so any of them changing must drop it.
-    caches::invalidate_protection_defaults();
+    app_core_cache::invalidate_protection_defaults();
     Ok(())
 }
 
@@ -712,6 +723,13 @@ mod tests {
     use persistence_db::Database;
 
     async fn setup() -> (Database, EventBus) {
+        // `protection_defaults` is a process-global single-slot cache (F0):
+        // every test in this binary shares it regardless of which in-memory
+        // DB it's keyed to. Force a miss at the start of each test so a
+        // stale value left by a differently-configured DB from an earlier
+        // test can't leak in (same mitigation as the `library_root`
+        // cross-test collision fixed in plan_apply.rs).
+        app_core_cache::invalidate_protection_defaults();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+app_core_cache = { path = "../cache" }
 app_core_errors = { path = "../errors" }
 app_core_targets = { path = "../targets" }
 audit = { path = "../../audit" }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 app_core_cache = { path = "../cache" }
+app_core_calibration = { path = "../calibration" }
 app_core_errors = { path = "../errors" }
 app_core_targets = { path = "../targets" }
 audit = { path = "../../audit" }

--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -2136,8 +2136,15 @@ mod tests {
         // runners — a real re-scan is never this fast, so explicitly advance
         // the mtime to model realistic elapsed time and make the assertion
         // deterministic across platforms rather than racing the clock.
+        // A read-only handle (`File::open`) is enough for `set_modified` on
+        // POSIX, but Windows requires FILE_WRITE_ATTRIBUTES access, which
+        // only a writable handle carries — `write(true)` opens for write
+        // without truncating (the file's freshly-written SII content is left
+        // intact) and gives a handle valid on all platforms.
         let flat_a_path = tmp.path().join("flat_a.fits");
-        std::fs::File::open(&flat_a_path)
+        std::fs::OpenOptions::new()
+            .write(true)
+            .open(&flat_a_path)
             .unwrap()
             .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(2))
             .unwrap();

--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -13,11 +13,10 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use app_core_targets::metadata_cache::cached_extract;
 use calibration_master_detect::{detect_master, DetectInput};
 use camino::Utf8Path;
-use metadata_core::{v1_normalization_table, EvidenceSource, FrameType, MetadataExtractor};
-use metadata_fits::FitsExtractor;
-use metadata_xisf::XisfExtractor;
+use metadata_core::{v1_normalization_table, EvidenceSource, FrameType};
 
 use super::grouping::{group_file, FrameMetadata, GroupingConfig};
 use super::signature::folder_signature;
@@ -135,8 +134,6 @@ pub async fn classify(
 
     // 6. Run metadata extraction + classification
     let norm_table = v1_normalization_table();
-    let fits_extractor = FitsExtractor;
-    let xisf_extractor = XisfExtractor;
 
     // spec 041 R-4 / T025: before wiping evidence, snapshot per-path override
     // values and detect which files have changed identity (size/mtime). After
@@ -176,14 +173,8 @@ pub async fn classify(
 
         let ext = abs_path.extension().and_then(|e| e.to_str()).unwrap_or("").to_ascii_lowercase();
 
-        // Extract raw metadata
-        let raw_meta = if xisf_extractor.supports_extension(&ext) {
-            xisf_extractor.extract(abs_path).ok().flatten()
-        } else if fits_extractor.supports_extension(&ext) {
-            fits_extractor.extract(abs_path).ok().flatten()
-        } else {
-            None
-        };
+        // Extract raw metadata (F0 cached-extract: memoized by path/mtime/size).
+        let raw_meta = cached_extract(abs_path).ok();
 
         let image_typ_raw = raw_meta.as_ref().and_then(|m| m.image_typ.as_deref());
         let stack_count = raw_meta.as_ref().and_then(|m| m.stack_count);
@@ -901,8 +892,6 @@ async fn build_breakdown(
     // Load the active pattern once; if it is unset/invalid every preview is None.
     let active_pattern = super::confirm::load_active_pattern(pool).await.ok();
     let norm_table = v1_normalization_table();
-    let fits_extractor = FitsExtractor;
-    let xisf_extractor = XisfExtractor;
 
     let mut entries = Vec::new();
 
@@ -915,13 +904,7 @@ async fn build_breakdown(
         let destination_preview = active_pattern.as_ref().and_then(|pattern| {
             let first_rel = files.first()?;
             let abs_path = root_absolute_path.join(first_rel);
-            let bundle = super::confirm::build_metadata_bundle(
-                &abs_path,
-                kind,
-                &norm_table,
-                &fits_extractor,
-                &xisf_extractor,
-            );
+            let bundle = super::confirm::build_metadata_bundle(&abs_path, kind, &norm_table);
             patterns::resolve_v1(pattern, &bundle).ok().map(|r| r.relative_path)
         });
 

--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -2127,6 +2127,20 @@ mod tests {
 
         // Change flat_a on disk: overwrite with SII filter header so it moves groups.
         write_fits_with_filter(tmp.path(), "flat_a.fits", "Flat Frame", "SII");
+        // app_core_targets::metadata_cache::cached_extract keys on (path, mtime,
+        // size); this rewrite keeps flat_a.fits at the same fixed 2880-byte
+        // length, so mtime is the only thing that can bust the cache. Its key
+        // truncates mtime to whole seconds (metadata_cache.rs's documented,
+        // accepted same-second/same-size collision risk), and a fast test can
+        // complete both writes within one wall-clock second on some CI
+        // runners — a real re-scan is never this fast, so explicitly advance
+        // the mtime to model realistic elapsed time and make the assertion
+        // deterministic across platforms rather than racing the clock.
+        let flat_a_path = tmp.path().join("flat_a.fits");
+        std::fs::File::open(&flat_a_path)
+            .unwrap()
+            .set_modified(std::time::SystemTime::now() + std::time::Duration::from_secs(2))
+            .unwrap();
 
         // Second classify: now Ha is gone, OIII remains, SII appears.
         classify(

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -26,11 +26,10 @@
 
 use std::path::PathBuf;
 
+use app_core_targets::metadata_cache::cached_extract;
 use contracts_core::first_run::{OrganizationState, SourceKind};
 use contracts_core::settings::PatternPart as ContractPatternPart;
-use metadata_core::{v1_normalization_table, MetadataExtractor};
-use metadata_fits::FitsExtractor;
-use metadata_xisf::XisfExtractor;
+use metadata_core::v1_normalization_table;
 use patterns::{classify_frame, resolve_pattern_str, FrameTypeClass, MetadataBundle, PatternPart};
 use persistence_db::repositories::first_run as first_run_repo;
 use persistence_db::repositories::inbox::{self as inbox_repo};
@@ -265,8 +264,6 @@ pub async fn confirm(
     // US9 gate (T056) is derived from it rather than a separate matrix. A hard
     // `Err(ResolveError)` signals a structural failure (traversal, length cap).
     let norm_table = v1_normalization_table();
-    let fits_extractor = FitsExtractor;
-    let xisf_extractor = XisfExtractor;
 
     let mut resolved_items: Vec<ResolvedRow> = Vec::with_capacity(plan_files.len());
     // Per-file missing path attributes for the US9 gate (FR-032/FR-033).
@@ -274,6 +271,11 @@ pub async fn confirm(
     // Cache the chosen destination root per category (keyed by the category's
     // stable string name) so a multi-category item resolves each category once.
     let mut chosen_root_cache: std::collections::HashMap<&'static str, DestinationRoot> =
+        std::collections::HashMap::new();
+    // Tier 2.5: cache the resolved per-type destination pattern by (frame_type,
+    // is_master) so a confirmable item (single-type per FR-050) fetches its
+    // pattern once instead of once per file in the loop below.
+    let mut pattern_cache: std::collections::HashMap<(String, bool), Option<String>> =
         std::collections::HashMap::new();
 
     for ev in &plan_files {
@@ -299,9 +301,13 @@ pub async fn confirm(
                 // Select the per-type pattern. `None` → frame type is not a known
                 // class (missing/garbage IMAGETYP) → needs-review (same flow as
                 // missing IMAGETYP: surfaced as a missing path attribute below).
-                let pattern = settings_repo::effective_pattern_for(pool, ft, is_master)
-                    .await
-                    .map_err(|e| {
+                let cache_key = (ft.to_owned(), is_master);
+                let pattern = if let Some(cached) = pattern_cache.get(&cache_key) {
+                    cached.clone()
+                } else {
+                    let fetched = settings_repo::effective_pattern_for(pool, ft, is_master)
+                        .await
+                        .map_err(|e| {
                         ContractError::new(
                             ErrorCode::InternalDatabase,
                             e.to_string(),
@@ -309,6 +315,9 @@ pub async fn confirm(
                             true,
                         )
                     })?;
+                    pattern_cache.insert(cache_key, fetched.clone());
+                    fetched
+                };
                 let Some(pattern) = pattern else {
                     // Unclassified frame: image type is the missing attribute.
                     missing_by_file
@@ -316,13 +325,7 @@ pub async fn confirm(
                     continue;
                 };
 
-                let bundle = build_metadata_bundle(
-                    &abs_path,
-                    ft,
-                    &norm_table,
-                    &fits_extractor,
-                    &xisf_extractor,
-                );
+                let bundle = build_metadata_bundle(&abs_path, ft, &norm_table);
 
                 let result = match resolve_pattern_str(&pattern, &bundle) {
                     Ok(r) => r,
@@ -700,25 +703,12 @@ pub(crate) fn build_metadata_bundle(
     abs_path: &std::path::Path,
     frame_type: &str,
     norm_table: &metadata_core::ImageTypNormalizationTable,
-    fits_ext: &FitsExtractor,
-    xisf_ext: &XisfExtractor,
 ) -> MetadataBundle {
     let mut bundle = MetadataBundle::new();
 
-    // Extract raw metadata from FITS or XISF file
-    let ext = abs_path
-        .extension()
-        .and_then(|e| e.to_str())
-        .map(str::to_ascii_lowercase)
-        .unwrap_or_default();
-
-    let raw_meta = if xisf_ext.supports_extension(&ext) {
-        xisf_ext.extract(abs_path).ok().flatten()
-    } else if fits_ext.supports_extension(&ext) {
-        fits_ext.extract(abs_path).ok().flatten()
-    } else {
-        None
-    };
+    // Extract raw metadata (F0 cached-extract: memoized by path/mtime/size;
+    // dispatches by extension internally).
+    let raw_meta = cached_extract(abs_path).ok();
 
     // frame_type (authoritative from classification)
     bundle.insert("frame_type".to_owned(), frame_type.to_owned());

--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -283,6 +283,13 @@ async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Resu
     .await
     .map_err(|e| format!("insert calibration_fingerprint: {e}"))?;
 
+    // F0 invalidate-after-commit contract (crates/app/cache/src/lib.rs): both
+    // inserts above have committed (sqlx pool auto-commits per statement; no
+    // explicit transaction wraps them), so the masters snapshot cache is safe
+    // to clear now — never before, to avoid a reader repopulating it with a
+    // stale pre-commit value.
+    app_core_calibration::caches::invalidate_calibration_masters();
+
     tracing::info!(
         inbox_item_id = %item.id,
         plan_id,

--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -17,12 +17,10 @@
 
 use std::path::{Path, PathBuf};
 
+use app_core_targets::metadata_cache::cached_extract;
 use calibration_master_detect::{detect_master, DetectInput, MasterDetection};
 use camino::Utf8Path;
-use metadata_core::MetadataExtractor;
-use metadata_fits::FitsExtractor;
 use metadata_video::is_video_extension;
-use metadata_xisf::XisfExtractor;
 
 use super::signature::compute_content_signature;
 
@@ -183,14 +181,9 @@ fn is_xisf_extension(ext: &str) -> bool {
 /// Returns `Some(ScannedMasterFile)` when the file is identified as a master.
 /// Returns `None` when not a master or metadata is unreadable.
 fn try_detect_master(abs_path: &Path, rel_path: &str, ext: &str) -> Option<ScannedMasterFile> {
-    // Extract metadata — same extractors used by classify.rs.
-    let bundle = if XisfExtractor.supports_extension(ext) {
-        XisfExtractor.extract(abs_path).ok().flatten()?
-    } else if FitsExtractor.supports_extension(ext) {
-        FitsExtractor.extract(abs_path).ok().flatten()?
-    } else {
-        return None;
-    };
+    // Cached extract (F0): memoized by (path, mtime, size); unsupported
+    // extensions and unparseable files both surface as `Err` here.
+    let bundle = cached_extract(abs_path).ok()?;
 
     let image_typ_raw = bundle.image_typ.as_deref();
     let stack_count = bundle.stack_count;

--- a/crates/app/settings/Cargo.toml
+++ b/crates/app/settings/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 app_core_cache = { path = "../cache" }
+app_core_calibration = { path = "../calibration" }
 app_core_errors = { path = "../errors" }
 audit = { path = "../../audit" }
 contracts_core = { path = "../../contracts/core" }

--- a/crates/app/settings/Cargo.toml
+++ b/crates/app/settings/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+app_core_cache = { path = "../cache" }
 app_core_errors = { path = "../errors" }
 audit = { path = "../../audit" }
 contracts_core = { path = "../../contracts/core" }

--- a/crates/app/settings/src/caches.rs
+++ b/crates/app/settings/src/caches.rs
@@ -1,0 +1,58 @@
+//! `app_core_settings`-owned cache statics (in-memory caching layer, F0 foundation).
+//!
+//! Module-local process-global `OnceLock`, mirroring `app_core`'s
+//! `ACTIVE_RUNS`/`caches` pattern. This module defines the cache handle and
+//! its `pub invalidate_settings_bag`/reader functions only — wiring
+//! `get_settings` to read through the cache and calling
+//! `invalidate_settings_bag` at write sites (`update_setting`,
+//! `restore_defaults`, `set_source_override`) is downstream (W-SETTINGS)
+//! work. Defined early (F0) so the parallel `W-PROT`/`W-CALCFG`/`W-RESOLV`
+//! workers can call `invalidate_settings_bag` from their own fan-out without
+//! waiting for W-SETTINGS to land.
+
+use std::sync::{Arc, OnceLock};
+
+use app_core_cache::SnapshotCache;
+use domain_core::settings::SettingsState;
+
+/// The full v1 settings bag, hydrated with in-code defaults for missing rows
+/// (mirrors `get_settings`'s output). 1 slot.
+///
+/// Invalidate at `update_setting`, `restore_defaults`, and
+/// `set_source_override` (per-source overrides also affect `resolve_setting`,
+/// which is not itself cached here but reads through the same underlying
+/// rows).
+static SETTINGS_BAG: OnceLock<SnapshotCache<SettingsState>> = OnceLock::new();
+
+/// Return the process-global settings-bag snapshot cache.
+#[must_use]
+pub fn settings_bag() -> &'static SnapshotCache<SettingsState> {
+    SETTINGS_BAG.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded settings-bag snapshot.
+pub fn store_settings_bag(value: Arc<SettingsState>) {
+    settings_bag().store(value);
+}
+
+/// Clear the settings-bag snapshot so the next read reloads from the DB.
+pub fn invalidate_settings_bag() {
+    settings_bag().invalidate();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn settings_bag_cache_store_load_invalidate_round_trips() {
+        invalidate_settings_bag();
+        assert!(settings_bag().load().is_none());
+
+        store_settings_bag(Arc::new(SettingsState::default()));
+        assert!(settings_bag().load().is_some());
+
+        invalidate_settings_bag();
+        assert!(settings_bag().load().is_none());
+    }
+}

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -83,6 +83,14 @@ pub mod migrate;
 // ── Per-root reconcile/detection configuration (spec 048 T005) ──────────────
 pub mod root_config;
 
+// ── In-memory settings-bag snapshot cache (F0 foundation) ────────────────────
+//
+// Defines the cache handle + `pub invalidate_settings_bag`/`store_settings_bag`
+// only. Wiring `get_settings` to read through the cache and calling
+// `invalidate_settings_bag` from `update_setting`/`restore_defaults`/
+// `set_source_override` is downstream (W-SETTINGS) work.
+pub mod caches;
+
 // ── Error mapping ──────────────────────────────────────────────────────────
 //
 // Canonical mappers live in `app_core_errors` (US11 T142). `db_err` now routes

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -456,12 +456,14 @@ pub async fn update_setting(
 
     // Cache invalidation fan-out (F0 in-memory caching layer): fires only
     // after the write above has committed, never before. `protection_defaults`
-    // (app_core::caches) is a documented consumer of this fan-out too, but
-    // app_core already depends on app_core_settings (crates/app/core/Cargo.toml),
-    // so wiring its invalidate call here would be a cyclic crate dependency
-    // (confirmed via `cargo check`) — raised as a design blocker, not wired.
+    // was relocated to the `app_core_cache` leaf (crates/app/cache/src/lib.rs:337-343)
+    // precisely so this crate can invalidate it without depending on `app_core`
+    // (which itself depends on `app_core_settings`).
     caches::invalidate_settings_bag();
     app_core_calibration::caches::invalidate_calibration_config();
+    if is_protection_default {
+        app_core_cache::invalidate_protection_defaults();
+    }
 
     // 6. Emit audit event. Global protection-default keys ALWAYS emit
     // `protection.default.changed` (T-004), overriding the noisy-key
@@ -555,6 +557,7 @@ pub async fn restore_defaults(
 
     let mut restored = Vec::new();
     let mut already_at_default = Vec::new();
+    let mut restored_protection_default = false;
 
     for key in &keys_to_restore {
         let default_val = default_value_for_key(key);
@@ -621,14 +624,19 @@ pub async fn restore_defaults(
         }
 
         restored.push(key.clone());
+        if is_protection_default {
+            restored_protection_default = true;
+        }
     }
 
     // Cache invalidation fan-out: one shot after the loop (not per-key) since
-    // both snapshots are single-slot whole-bag caches. See `update_setting`
-    // for the protection_defaults cyclic-dependency note.
+    // both snapshots are single-slot whole-bag caches.
     if !restored.is_empty() {
         caches::invalidate_settings_bag();
         app_core_calibration::caches::invalidate_calibration_config();
+        if restored_protection_default {
+            app_core_cache::invalidate_protection_defaults();
+        }
     }
 
     let status = if restored.is_empty() {
@@ -884,7 +892,7 @@ mod tests {
         // SETTINGS_BAG is a process-global single-slot cache (F0); each test
         // gets its own in-memory DB, so a stale cross-test snapshot would
         // silently serve another test's data. Mirrors the same caveat/fix in
-        // `app_core::caches`'s `protection_defaults_*` test.
+        // `app_core_cache`'s `protection_defaults_*` test (crates/app/cache/src/lib.rs).
         caches::invalidate_settings_bag();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -300,6 +300,11 @@ pub async fn get_settings(
     pool: &SqlitePool,
     bus: &EventBus,
 ) -> Result<SettingsGetResponse, ContractError> {
+    // Read-through: on hit, skip the DB entirely (F0 in-memory caching layer).
+    if let Some(cached) = caches::settings_bag().load() {
+        return Ok(SettingsGetResponse { settings: (*cached).clone() });
+    }
+
     let all_raw = repo::get_all_raw(pool).await.map_err(db_err)?;
     let mut settings = SettingsState::default();
 
@@ -332,6 +337,7 @@ pub async fn get_settings(
         apply_value_to_state(&key, value, &mut settings);
     }
 
+    caches::store_settings_bag(std::sync::Arc::new(settings.clone()));
     Ok(SettingsGetResponse { settings })
 }
 
@@ -447,6 +453,15 @@ pub async fn update_setting(
     } else {
         repo::set_raw(pool, key, new_value).await.map_err(db_err)?;
     }
+
+    // Cache invalidation fan-out (F0 in-memory caching layer): fires only
+    // after the write above has committed, never before. `protection_defaults`
+    // (app_core::caches) is a documented consumer of this fan-out too, but
+    // app_core already depends on app_core_settings (crates/app/core/Cargo.toml),
+    // so wiring its invalidate call here would be a cyclic crate dependency
+    // (confirmed via `cargo check`) — raised as a design blocker, not wired.
+    caches::invalidate_settings_bag();
+    app_core_calibration::caches::invalidate_calibration_config();
 
     // 6. Emit audit event. Global protection-default keys ALWAYS emit
     // `protection.default.changed` (T-004), overriding the noisy-key
@@ -608,6 +623,14 @@ pub async fn restore_defaults(
         restored.push(key.clone());
     }
 
+    // Cache invalidation fan-out: one shot after the loop (not per-key) since
+    // both snapshots are single-slot whole-bag caches. See `update_setting`
+    // for the protection_defaults cyclic-dependency note.
+    if !restored.is_empty() {
+        caches::invalidate_settings_bag();
+        app_core_calibration::caches::invalidate_calibration_config();
+    }
+
     let status = if restored.is_empty() {
         RestoreDefaultsStatus::Noop
     } else {
@@ -649,6 +672,13 @@ pub async fn set_source_override(
     validate_value(key, value)?;
 
     repo::set_source_override(pool, &req.source_id, key, value).await.map_err(db_err)?;
+
+    // `get_settings`'s bag is global-only (no source_id), so a per-source
+    // override never actually changes it; invalidating anyway is a cheap,
+    // safe no-op that keeps this write site consistent with the other two.
+    // Unlike `update_setting`/`restore_defaults`, no calibration/protection
+    // global key is ever written on this path, so no further fan-out applies.
+    caches::invalidate_settings_bag();
 
     Ok(SetSourceOverrideResponse { source_id: req.source_id.clone(), key: key.clone() })
 }
@@ -851,6 +881,11 @@ mod tests {
     }
 
     async fn setup() -> (Database, EventBus) {
+        // SETTINGS_BAG is a process-global single-slot cache (F0); each test
+        // gets its own in-memory DB, so a stale cross-test snapshot would
+        // silently serve another test's data. Mirrors the same caveat/fix in
+        // `app_core::caches`'s `protection_defaults_*` test.
+        caches::invalidate_settings_bag();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());

--- a/crates/app/targets/Cargo.toml
+++ b/crates/app/targets/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 path = "src/lib.rs"
 
 [dependencies]
+app_core_cache = { path = "../cache" }
 app_core_errors = { path = "../errors" }
 audit = { path = "../../audit" }
 contracts_core = { path = "../../contracts/core" }
@@ -26,6 +27,7 @@ tracing = { workspace = true }
 uuid = { workspace = true }
 
 [dev-dependencies]
+tempfile = { workspace = true }
 tokio.workspace = true
 # spec 035 (T020): the `FakeResolver` test double lives behind the resolver's
 # `test-fixture` feature; enable it for offline target.resolve use-case tests.

--- a/crates/app/targets/src/caches.rs
+++ b/crates/app/targets/src/caches.rs
@@ -1,0 +1,111 @@
+//! `app_core_targets`-owned cache statics (in-memory caching layer, F0 foundation).
+//!
+//! Module-local process-global `OnceLock`s, mirroring `app_core`'s
+//! `ACTIVE_RUNS`/`caches` pattern. This module defines the cache handles and
+//! their `pub invalidate_*`/reader functions only — wiring reads through the
+//! cache (`target_management::list`, typeahead) and calling `invalidate_*` at
+//! write sites is downstream (W-CATALOG, W-RESOLV) work.
+
+use std::sync::{Arc, OnceLock};
+
+use app_core_cache::SnapshotCache;
+use contracts_core::targets::{ResolverSettings, TargetListItem};
+
+// ── catalog snapshot: full target list (+ typeahead) (`target_management.rs`) ──
+
+/// Whole-catalog snapshot backing `target.list`, inbox target recommendations,
+/// and typeahead (filtered in memory instead of a per-keystroke SQLite
+/// `LIKE`) — one cache, one invalidation point. 1 slot.
+///
+/// Invalidate at `target_management::alias_add`/`alias_remove`/
+/// `display_alias_set`/`display_alias_clear`, constellation/magnitude UPDATE
+/// sites, `target_resolve::resolve` (new-row branch only), `search.rs` INSERT
+/// sites, and `project_setup.rs` alias INSERT. The resolver seed path stays
+/// uninvalidated (resolver decoupling; the lazy first read happens post-seed).
+static CATALOG: OnceLock<SnapshotCache<Vec<TargetListItem>>> = OnceLock::new();
+
+/// Return the process-global catalog snapshot cache.
+#[must_use]
+pub fn catalog() -> &'static SnapshotCache<Vec<TargetListItem>> {
+    CATALOG.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded catalog snapshot.
+pub fn store_catalog(value: Arc<Vec<TargetListItem>>) {
+    catalog().store(value);
+}
+
+/// Clear the catalog snapshot so the next read reloads from the DB.
+pub fn invalidate_catalog() {
+    catalog().invalidate();
+}
+
+// ── resolver_settings snapshot (`resolver_settings.rs`) ──────────────────────
+
+/// Singleton resolver settings row snapshot. 1 slot.
+///
+/// Invalidate at `resolver_settings::update`.
+static RESOLVER_SETTINGS: OnceLock<SnapshotCache<ResolverSettings>> = OnceLock::new();
+
+/// Return the process-global resolver-settings snapshot cache.
+#[must_use]
+pub fn resolver_settings() -> &'static SnapshotCache<ResolverSettings> {
+    RESOLVER_SETTINGS.get_or_init(SnapshotCache::new)
+}
+
+/// Store a freshly loaded resolver-settings snapshot.
+pub fn store_resolver_settings(value: Arc<ResolverSettings>) {
+    resolver_settings().store(value);
+}
+
+/// Clear the resolver-settings snapshot so the next read reloads from the DB.
+pub fn invalidate_resolver_settings() {
+    resolver_settings().invalidate();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_cache_store_load_invalidate_round_trips() {
+        invalidate_catalog();
+        assert!(catalog().load().is_none());
+
+        store_catalog(Arc::new(vec![TargetListItem {
+            id: "t-1".to_owned(),
+            effective_label: "M31".to_owned(),
+            primary_designation: "M31".to_owned(),
+            object_type: "galaxy".to_owned(),
+            ra_deg: 10.68,
+            dec_deg: 41.27,
+            constellation: None,
+            magnitude: None,
+            aliases: vec![],
+        }]));
+        let loaded = catalog().load().expect("stored snapshot must load");
+        assert_eq!(loaded.len(), 1);
+        assert_eq!(loaded[0].id, "t-1");
+
+        invalidate_catalog();
+        assert!(catalog().load().is_none());
+    }
+
+    #[test]
+    fn resolver_settings_cache_store_load_invalidate_round_trips() {
+        invalidate_resolver_settings();
+        assert!(resolver_settings().load().is_none());
+
+        store_resolver_settings(Arc::new(ResolverSettings {
+            online_enabled: true,
+            simbad_endpoint: "https://simbad.example/tap".to_owned(),
+            debounce_ms: 300,
+            request_timeout_secs: 10,
+        }));
+        let loaded = resolver_settings().load().expect("stored snapshot must load");
+        assert!(loaded.online_enabled);
+
+        invalidate_resolver_settings();
+        assert!(resolver_settings().load().is_none());
+    }
+}

--- a/crates/app/targets/src/caches.rs
+++ b/crates/app/targets/src/caches.rs
@@ -69,6 +69,11 @@ mod tests {
 
     #[test]
     fn catalog_cache_store_load_invalidate_round_trips() {
+        // Serialized against every other test in this crate that touches the
+        // shared catalog/resolver-settings statics (`target_management`,
+        // `target_resolve`, `target_search`, `resolver_settings`,
+        // `ingest_resolution`) — see `target_management::cache_test_lock`.
+        let _guard = crate::target_management::cache_test_lock::locked_reset();
         invalidate_catalog();
         assert!(catalog().load().is_none());
 
@@ -93,6 +98,10 @@ mod tests {
 
     #[test]
     fn resolver_settings_cache_store_load_invalidate_round_trips() {
+        // Serialized against every other test in this crate that touches the
+        // shared catalog/resolver-settings statics — see
+        // `target_management::cache_test_lock`.
+        let _guard = crate::target_management::cache_test_lock::locked_reset();
         invalidate_resolver_settings();
         assert!(resolver_settings().load().is_none());
 

--- a/crates/app/targets/src/ingest_resolution.rs
+++ b/crates/app/targets/src/ingest_resolution.rs
@@ -246,8 +246,15 @@ pub async fn resolve_pending<R: Resolver + ?Sized>(
 
         match resolver.resolve(row.object_raw.trim()).await {
             Ok(identity) => {
-                let (id, _outcome) =
+                let (id, outcome) =
                     cache::upsert_resolved(pool, &identity).await.map_err(db_err)?;
+                // Invalidate after the write commits (never before); a
+                // `SkippedUserOverride` outcome means no row was actually
+                // written (sticky user-override lock kept precedence), so the
+                // catalog snapshot is not stale (mirrors `target_resolve::resolve`).
+                if outcome != cache::UpsertOutcome::SkippedUserOverride {
+                    crate::caches::invalidate_catalog();
+                }
                 let target_id = id.to_string();
                 mark_resolved(pool, &row.id, &target_id).await?;
                 if let Some(bus) = bus {

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -61,9 +61,7 @@ use std::collections::BTreeSet;
 use std::path::Path;
 
 use audit::EventBus;
-use metadata_core::{MetadataExtractor, RawFileMetadata};
-use metadata_fits::FitsExtractor;
-use metadata_xisf::XisfExtractor;
+use metadata_core::RawFileMetadata;
 use persistence_db::repositories::projects as repo_projects;
 use persistence_db::repositories::q_targets_ingest as repo;
 use persistence_db::repositories::{first_run, inventory};
@@ -506,14 +504,12 @@ pub async fn backfill_session_targets(pool: &SqlitePool) -> Result<usize, Contra
 
 /// Read FITS/XISF header metadata for a file, or `None` when unreadable /
 /// unsupported (treated as "not an ingestable light", never an error).
+///
+/// Served through [`crate::metadata_cache::cached_extract`] (in-memory caching
+/// layer F0), memoized by `(path, mtime, size)` — a burst of reads for the
+/// same file during a scan does not re-parse the header once per caller.
 fn read_metadata(abs_path: &Path) -> Option<RawFileMetadata> {
-    if let Ok(Some(m)) = FitsExtractor.extract(abs_path) {
-        return Some(m);
-    }
-    if let Ok(Some(m)) = XisfExtractor.extract(abs_path) {
-        return Some(m);
-    }
-    None
+    crate::metadata_cache::cached_extract(abs_path).ok()
 }
 
 /// True when the frame's `IMAGETYP` normalizes to a light frame. Calibration

--- a/crates/app/targets/src/lib.rs
+++ b/crates/app/targets/src/lib.rs
@@ -11,9 +11,19 @@
 //! paths so the public surface is byte-identical.
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 
+/// Process-global in-memory cache statics for the target catalog snapshot and
+/// resolver settings (in-memory caching layer, F0 foundation). See each
+/// accessor's doc comment for its owning write-site invalidation calls.
+pub mod caches;
 pub mod frame_writer;
 pub mod ingest_resolution;
 pub mod ingest_sessions;
+/// Cached FITS/XISF header extraction (in-memory caching layer, F0/W-FITS).
+/// Lives here (not `app_core`) so both `app_core_inbox` and
+/// `app_core_targets::ingest_sessions` — the two current extractor call
+/// sites — can reach it without a cyclic crate dependency; see the module
+/// doc comment for the full reachability argument.
+pub mod metadata_cache;
 pub mod resolver_settings;
 pub mod target_dto;
 pub mod target_favourites;

--- a/crates/app/targets/src/metadata_cache.rs
+++ b/crates/app/targets/src/metadata_cache.rs
@@ -40,6 +40,10 @@ use metadata_xisf::XisfExtractor;
 /// preserves both mtime-second and byte length is the same accepted risk any
 /// mtime-based cache carries.
 type CacheKey = (PathBuf, u64, u64);
+/// Memoized alongside `Ok` results: an extraction failure for a given
+/// `(path, mtime, size)` is deterministic (same bytes in, same parse
+/// failure out), so caching `Err` under the TTI is safe and avoids
+/// re-parsing an unreadable/malformed file on every lookup.
 type CacheValue = Result<RawFileMetadata, MetadataExtractError>;
 
 static METADATA_CACHE: std::sync::OnceLock<TtlCache<CacheKey, CacheValue>> =

--- a/crates/app/targets/src/metadata_cache.rs
+++ b/crates/app/targets/src/metadata_cache.rs
@@ -1,0 +1,184 @@
+//! Cached FITS/XISF header extraction (in-memory caching layer, F0/W-FITS).
+//!
+//! Lives in `app_core_targets` (not `app_core`): the current
+//! `FitsExtractor`/`XisfExtractor` call sites are `app_core_inbox::scan` /
+//! `classify` / `confirm` and `app_core_targets::ingest_sessions` —
+//! `app_core_inbox` already depends on `app_core_targets`, but `app_core`
+//! depends on `app_core_inbox` (not the reverse), so a cache placed in
+//! `app_core` would be unreachable from those callers without a cyclic
+//! dependency. This module sits at the one crate genuinely upstream of both.
+//!
+//! Wraps [`metadata_fits::FitsExtractor`] / [`metadata_xisf::XisfExtractor`]
+//! behind a module-local [`app_core_cache::TtlCache`] keyed by
+//! `(path, mtime, size)`. The key is self-invalidating: any change to the
+//! file's mtime or size (edit, replace, re-download) produces a new key, so a
+//! changed file is a cache miss and a stale-metadata bug cannot occur without
+//! also requiring an unmodified file to report unmodified stats.
+//!
+//! Single-flight: concurrent callers requesting the same key coalesce onto one
+//! extraction (`TtlCache::get_or_insert_with` delegates to `moka`'s
+//! `get_with`), so a burst of reads for the same file during a scan does not
+//! re-parse the header once per caller.
+//!
+//! Callers needing a fresh read (e.g. after a known external file mutation)
+//! should re-`std::fs::metadata` the path — since mtime/size are part of the
+//! key, a genuinely changed file already misses; there is no separate
+//! `invalidate_*` entry point because there is nothing to explicitly track.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use app_core_cache::{CacheConfig, TtlCache};
+use metadata_core::{MetadataExtractError, MetadataExtractor, RawFileMetadata};
+use metadata_fits::FitsExtractor;
+use metadata_xisf::XisfExtractor;
+
+/// `(path, mtime_unix_secs, size_bytes)` — a file's identity for caching
+/// purposes. Second-resolution mtime is coarser than some filesystems'
+/// native precision, but is combined with `size` so a same-second rewrite
+/// that also changes length is still detected; a same-second rewrite that
+/// preserves both mtime-second and byte length is the same accepted risk any
+/// mtime-based cache carries.
+type CacheKey = (PathBuf, u64, u64);
+type CacheValue = Result<RawFileMetadata, MetadataExtractError>;
+
+static METADATA_CACHE: std::sync::OnceLock<TtlCache<CacheKey, CacheValue>> =
+    std::sync::OnceLock::new();
+
+fn cache() -> &'static TtlCache<CacheKey, CacheValue> {
+    METADATA_CACHE.get_or_init(|| {
+        TtlCache::new(CacheConfig::new(50_000).with_time_to_idle(Duration::from_mins(30)))
+    })
+}
+
+/// Extract FITS/XISF header metadata for `path`, memoized by `(path, mtime,
+/// size)`.
+///
+/// Dispatches by file extension to [`XisfExtractor`] / [`FitsExtractor`],
+/// mirroring the extension-check-then-extract pattern used in
+/// `app_core_inbox::scan`/`classify`/`confirm` and
+/// `app_core_targets::ingest_sessions`.
+///
+/// # Errors
+///
+/// Returns [`MetadataExtractError::Io`] if the file's metadata (mtime/size)
+/// or contents cannot be read, or the extension is not `.fits`/`.fit`/`.fts`/
+/// `.xisf`. Returns [`MetadataExtractError::Parse`] if the matched extractor
+/// cannot parse the header.
+pub fn cached_extract(path: &Path) -> Result<RawFileMetadata, MetadataExtractError> {
+    let key = cache_key(path)?;
+    cache().get_or_insert_with(key, || extract_uncached(path))
+}
+
+fn cache_key(path: &Path) -> Result<CacheKey, MetadataExtractError> {
+    let meta = std::fs::metadata(path).map_err(|e| MetadataExtractError::Io {
+        path: path.display().to_string(),
+        msg: e.to_string(),
+    })?;
+    let mtime = meta
+        .modified()
+        .ok()
+        .and_then(|t| t.duration_since(std::time::UNIX_EPOCH).ok())
+        .map_or(0, |d| d.as_secs());
+    Ok((path.to_path_buf(), mtime, meta.len()))
+}
+
+fn extract_uncached(path: &Path) -> Result<RawFileMetadata, MetadataExtractError> {
+    let ext =
+        path.extension().and_then(|e| e.to_str()).map(str::to_ascii_lowercase).unwrap_or_default();
+
+    let extracted = if XisfExtractor.supports_extension(&ext) {
+        XisfExtractor.extract(path)?
+    } else if FitsExtractor.supports_extension(&ext) {
+        FitsExtractor.extract(path)?
+    } else {
+        return Err(MetadataExtractError::Io {
+            path: path.display().to_string(),
+            msg: format!("unsupported metadata file extension: {ext:?}"),
+        });
+    };
+
+    extracted.ok_or_else(|| MetadataExtractError::Parse {
+        path: path.display().to_string(),
+        msg: "extractor matched extension but produced no metadata".to_owned(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Write;
+
+    use super::cached_extract;
+
+    /// Minimal valid FITS header: one 2880-byte block containing `END` and a
+    /// couple of keyword cards, enough for `FitsExtractor` to parse.
+    fn write_minimal_fits(path: &std::path::Path) {
+        let mut block = vec![b' '; 2880];
+        let cards: &[&[u8]] = &[
+            b"SIMPLE  =                    T",
+            b"IMAGETYP= 'Light   '",
+            b"OBJECT  = 'M31     '",
+            b"END",
+        ];
+        for (i, card) in cards.iter().enumerate() {
+            let start = i * 80;
+            block[start..start + card.len()].copy_from_slice(card);
+        }
+        let mut file = std::fs::File::create(path).expect("create fixture fits file");
+        file.write_all(&block).expect("write fixture fits header");
+    }
+
+    #[test]
+    fn cached_extract_hits_on_second_call_for_unchanged_file() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("frame.fits");
+        write_minimal_fits(&path);
+
+        let first = cached_extract(&path).expect("first extract succeeds");
+        let second = cached_extract(&path).expect("second extract succeeds (cache hit)");
+
+        assert_eq!(first.object, second.object);
+        assert_eq!(second.object.as_deref(), Some("M31"));
+    }
+
+    #[test]
+    fn cached_extract_misses_after_file_is_rewritten_with_different_size() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("frame.fits");
+        write_minimal_fits(&path);
+        let first = cached_extract(&path).expect("first extract succeeds");
+        assert_eq!(first.object.as_deref(), Some("M31"));
+
+        // Rewrite with a different OBJECT and a different file size, forcing
+        // a new (path, mtime, size) cache key.
+        let mut block = vec![b' '; 2880 * 2];
+        let cards: &[&[u8]] = &[
+            b"SIMPLE  =                    T",
+            b"IMAGETYP= 'Light   '",
+            b"OBJECT  = 'NGC7000 '",
+            b"END",
+        ];
+        for (i, card) in cards.iter().enumerate() {
+            let start = i * 80;
+            block[start..start + card.len()].copy_from_slice(card);
+        }
+        std::fs::write(&path, &block).expect("rewrite fixture fits file");
+
+        let second = cached_extract(&path).expect("second extract succeeds");
+        assert_eq!(
+            second.object.as_deref(),
+            Some("NGC7000"),
+            "changed file must not hit stale cache"
+        );
+    }
+
+    #[test]
+    fn cached_extract_rejects_unsupported_extension() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let path = dir.path().join("notes.txt");
+        std::fs::write(&path, b"not a fits file").expect("write fixture txt file");
+
+        let err = cached_extract(&path).expect_err("unsupported extension is an error");
+        assert!(matches!(err, metadata_core::MetadataExtractError::Io { .. }));
+    }
+}

--- a/crates/app/targets/src/resolver_settings.rs
+++ b/crates/app/targets/src/resolver_settings.rs
@@ -65,17 +65,27 @@ fn validate_endpoint(endpoint: &str) -> Result<(), ContractError> {
 }
 
 /// Read the singleton `resolver_settings` row.
+///
+/// Read-through against the settings snapshot ([`crate::caches::resolver_settings`],
+/// in-memory caching layer F0): a cache hit skips the DB round-trip; a miss
+/// loads from SQLite and populates the snapshot.
 async fn read_row(pool: &SqlitePool) -> Result<ResolverSettings, ContractError> {
+    if let Some(cached) = crate::caches::resolver_settings().load() {
+        return Ok((*cached).clone());
+    }
+
     let row = persistence_db::repositories::q_targets_mgmt::get_resolver_settings(pool)
         .await
         .map_err(db_err)?;
 
-    Ok(row.map_or_else(defaults, |r| ResolverSettings {
+    let settings = row.map_or_else(defaults, |r| ResolverSettings {
         online_enabled: r.online_enabled != 0,
         simbad_endpoint: r.simbad_endpoint,
         debounce_ms: u32::try_from(r.debounce_ms.max(0)).unwrap_or(300),
         request_timeout_secs: u32::try_from(r.request_timeout_secs.max(0)).unwrap_or(10),
-    }))
+    });
+    crate::caches::store_resolver_settings(std::sync::Arc::new(settings.clone()));
+    Ok(settings)
 }
 
 /// `target.resolution.settings` (get) — return the current resolver settings.
@@ -128,6 +138,10 @@ pub async fn update(
     .await
     .map_err(db_err)?;
 
+    // Invalidate after the write commits (never before) per the
+    // `SnapshotCache` usage contract.
+    crate::caches::invalidate_resolver_settings();
+
     // Read back so the response reflects exactly what was stored (clamps applied).
     let settings = read_row(pool).await?;
     Ok(ResolverSettingsResponse {
@@ -140,12 +154,13 @@ pub async fn update(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use persistence_db::Database;
 
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
+    // Serialized against `target_management`/`target_resolve`/
+    // `target_search` tests: `get`/`update` read/invalidate the shared
+    // resolver-settings `SnapshotCache` (F0), see
+    // `target_management::cache_test_lock` for the full rationale.
+    async fn setup() -> crate::target_management::cache_test_lock::LockedDb {
+        crate::target_management::cache_test_lock::locked_db().await
     }
 
     fn get_req() -> ResolverSettingsGetRequest {

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -499,6 +499,9 @@ pub async fn note_update(
 /// process-wide lock (released when the returned [`LockedDb`] is dropped at
 /// the end of the test), so `setup()` in each of those four files can use
 /// this in place of a bare `Database` with no other test-body changes.
+/// [`locked_reset`] is the sync counterpart for `crate::caches`'s own
+/// round-trip unit tests, which manipulate these same statics directly and
+/// are not `async`.
 #[cfg(test)]
 pub(crate) mod cache_test_lock {
     use persistence_db::Database;
@@ -530,6 +533,17 @@ pub(crate) mod cache_test_lock {
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         LockedDb { db, _guard: guard }
+    }
+
+    /// Acquire the shared lock and reset both snapshot caches, for non-async
+    /// `#[test]` functions. Blocks the current thread rather than `.await`ing
+    /// — safe here because these call sites have no Tokio runtime, unlike
+    /// [`locked_db`]'s async callers.
+    pub(crate) fn locked_reset() -> tokio::sync::MutexGuard<'static, ()> {
+        let guard = LOCK.blocking_lock();
+        crate::caches::invalidate_catalog();
+        crate::caches::invalidate_resolver_settings();
+        guard
     }
 }
 

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -160,12 +160,22 @@ pub async fn get(
 /// `target.list` — list all canonical targets (gen-3), ordered by
 /// `primary_designation`.
 ///
+/// Read-through against the whole-catalog snapshot ([`crate::caches::catalog`],
+/// in-memory caching layer F0): a cache hit skips the DB round-trip entirely; a
+/// miss loads from SQLite and populates the snapshot for subsequent readers
+/// (including `target_search::search`, which shares this same cache).
+///
 /// # Errors
 ///
 /// Returns [`ContractError`] with code `internal.database`.
 pub async fn list(pool: &SqlitePool) -> Result<Vec<TargetListItem>, ContractError> {
+    if let Some(cached) = crate::caches::catalog().load() {
+        return Ok((*cached).clone());
+    }
     let rows = cache::list_all(pool).await.map_err(db_err)?;
-    Ok(rows.into_iter().map(list_row_to_item).collect())
+    let items: Vec<TargetListItem> = rows.into_iter().map(list_row_to_item).collect();
+    crate::caches::store_catalog(std::sync::Arc::new(items.clone()));
+    Ok(items)
 }
 
 /// `target.alias.add` — add a user alias to a target (gen-3).
@@ -210,13 +220,18 @@ pub async fn alias_add(
             ErrorSeverity::Blocking,
             false,
         )),
-        Some((alias_id, alias_display)) => Ok(TargetAliasAddResult {
-            alias: TargetAliasDto {
-                id: alias_id,
-                alias: alias_display,
-                kind: ContractAliasKind::User,
-            },
-        }),
+        Some((alias_id, alias_display)) => {
+            // Invalidate after the write commits (never before) per the
+            // `SnapshotCache` usage contract (`app_core_cache::SnapshotCache`).
+            crate::caches::invalidate_catalog();
+            Ok(TargetAliasAddResult {
+                alias: TargetAliasDto {
+                    id: alias_id,
+                    alias: alias_display,
+                    kind: ContractAliasKind::User,
+                },
+            })
+        }
     }
 }
 
@@ -253,6 +268,11 @@ pub async fn alias_remove(
         Some(kind) if kind != "user" => Err(alias_not_removable()),
         Some(_) => {
             let deleted = cache::delete_user_alias(pool, &req.alias_id).await.map_err(db_err)?;
+            if deleted {
+                // Invalidate after the write commits (never before) per the
+                // `SnapshotCache` usage contract.
+                crate::caches::invalidate_catalog();
+            }
             Ok(TargetAliasRemoveResult { removed: deleted })
         }
     }
@@ -275,6 +295,9 @@ pub async fn display_alias_set(
     if !updated {
         return Err(not_found(&req.target_id));
     }
+    // Invalidate after the write commits (never before): `effective_label` in
+    // the catalog snapshot is derived from `display_alias`.
+    crate::caches::invalidate_catalog();
     // Re-fetch and return the updated detail.
     get(pool, &TargetGetRequest { target_id: req.target_id.clone() }).await
 }
@@ -294,6 +317,9 @@ pub async fn display_alias_clear(
     if !updated {
         return Err(not_found(&req.target_id));
     }
+    // Invalidate after the write commits (never before): `effective_label` in
+    // the catalog snapshot is derived from `display_alias`.
+    crate::caches::invalidate_catalog();
     get(pool, &TargetGetRequest { target_id: req.target_id.clone() }).await
 }
 
@@ -459,6 +485,54 @@ pub async fn note_update(
     Ok(TargetNoteUpdateResult { notes: stored.map(str::to_owned) })
 }
 
+/// Test-only serialization for the process-global `SnapshotCache` statics
+/// (in-memory caching layer F0 foundation).
+///
+/// `crate::caches::catalog`/`resolver_settings` are singleton `OnceLock`s
+/// shared by every test in this crate's test binary. Without serialization,
+/// parallel `#[tokio::test]` runs across `target_management`, `target_resolve`,
+/// `target_search`, and `resolver_settings` tests race on the same slot — a
+/// `store` from one test can land after another concurrently-running test's
+/// `invalidate`, reproducing the lost-update window the `SnapshotCache` type
+/// doc warns about, and leaking one test's DB content into another's
+/// assertions. [`locked_db`] builds a fresh in-memory DB while holding a
+/// process-wide lock (released when the returned [`LockedDb`] is dropped at
+/// the end of the test), so `setup()` in each of those four files can use
+/// this in place of a bare `Database` with no other test-body changes.
+#[cfg(test)]
+pub(crate) mod cache_test_lock {
+    use persistence_db::Database;
+
+    static LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    /// A `Database` that also holds the shared cache-test lock for its
+    /// lifetime. Derefs to `Database` so existing call sites (`db.pool()`,
+    /// `&db` passed where `&Database` is expected) are unchanged.
+    pub(crate) struct LockedDb {
+        db: Database,
+        _guard: tokio::sync::MutexGuard<'static, ()>,
+    }
+
+    impl std::ops::Deref for LockedDb {
+        type Target = Database;
+
+        fn deref(&self) -> &Database {
+            &self.db
+        }
+    }
+
+    /// Acquire the shared lock, reset both snapshot caches to a clean (miss)
+    /// state, and build a fresh in-memory, migrated DB.
+    pub(crate) async fn locked_db() -> LockedDb {
+        let guard = LOCK.lock().await;
+        crate::caches::invalidate_catalog();
+        crate::caches::invalidate_resolver_settings();
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        LockedDb { db, _guard: guard }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -470,10 +544,8 @@ mod tests {
         AliasKind as CacheKind, ResolvedAlias, ResolvedIdentity, TargetSource,
     };
 
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
+    async fn setup() -> cache_test_lock::LockedDb {
+        cache_test_lock::locked_db().await
     }
 
     fn make_bus(db: &Database) -> EventBus {

--- a/crates/app/targets/src/target_resolve.rs
+++ b/crates/app/targets/src/target_resolve.rs
@@ -210,8 +210,15 @@ pub async fn resolve<R: Resolver + ?Sized>(
         Ok(identity) => {
             // 3) Persist (source = resolved), dedup by oid, then read back the
             // canonical row (which may carry a sticky user-override identity).
-            let (id, _outcome) =
+            let (id, outcome) =
                 cache::upsert_resolved(pool, &identity).await.map_err(|e| db_err(&e))?;
+            // Invalidate after the write commits (never before): a
+            // `SkippedUserOverride` outcome means no row was actually written
+            // (the sticky user-override lock kept precedence), so the catalog
+            // snapshot is not stale and does not need invalidating.
+            if outcome != cache::UpsertOutcome::SkippedUserOverride {
+                crate::caches::invalidate_catalog();
+            }
             if let Some(target) = cache::get_by_id(pool, id).await.map_err(|e| db_err(&e))? {
                 // T039: durable audit record for the resolved outcome.
                 write_audit(
@@ -292,8 +299,14 @@ async fn apply_override(
         source: CacheSource::UserOverride,
     };
 
-    let (written_id, _outcome) =
+    let (written_id, outcome) =
         cache::upsert_resolved(pool, &identity).await.map_err(|e| db_err(&e))?;
+    // Invalidate after the write commits (never before); this override write
+    // always carries the new source/alias, so any outcome other than a no-op
+    // skip changes the catalog snapshot.
+    if outcome != cache::UpsertOutcome::SkippedUserOverride {
+        crate::caches::invalidate_catalog();
+    }
     if let Some(target) = cache::get_by_id(pool, written_id).await.map_err(|e| db_err(&e))? {
         // T039: durable audit record for the manual user-override (actor = user).
         write_audit(
@@ -321,10 +334,12 @@ mod tests {
         AliasKind, FakeResolver, ObjectType, ResolvedAlias, ResolvedIdentity, TargetSource as Src,
     };
 
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
+    // Serialized against `target_management`/`target_search`/
+    // `resolver_settings` tests: `resolve`/`apply_override` invalidate the
+    // shared catalog `SnapshotCache` (F0), see
+    // `target_management::cache_test_lock` for the full rationale.
+    async fn setup() -> crate::target_management::cache_test_lock::LockedDb {
+        crate::target_management::cache_test_lock::locked_db().await
     }
 
     fn m31() -> ResolvedIdentity {

--- a/crates/app/targets/src/target_search.rs
+++ b/crates/app/targets/src/target_search.rs
@@ -1,10 +1,21 @@
 //! `target.search` use case for spec 035 (US1 — project-creation target search).
 //!
-//! As-you-type target search served PURELY from the local seed + cache index
-//! (`targeting_resolver::cache::search_by_normalized`). There is NO network in
-//! this path (FR-005): long-tail / SIMBAD enrichment is a separate
-//! `target.resolve` call. Results are ranked best-first (exact → prefix →
-//! substring) and de-duplicated to one canonical target per hit.
+//! As-you-type target search served PURELY from the local seed + cache index.
+//! There is NO network in this path (FR-005): long-tail / SIMBAD enrichment is
+//! a separate `target.resolve` call. Results are ranked best-first (exact →
+//! prefix → substring) and de-duplicated to one canonical target per hit.
+//!
+//! Candidate ranking runs in memory against the whole-catalog snapshot
+//! (`crate::target_management::list`, backed by `crate::caches::catalog` — the
+//! in-memory caching layer F0) instead of a per-keystroke SQLite `LIKE` scan
+//! (`targeting_resolver::cache::search_by_normalized`, still used by nothing
+//! in this module — kept as the source of truth for the ranking scheme this
+//! mirrors). The winning targets (bounded by `limit`) are still hydrated via
+//! [`targeting_resolver::cache::get_by_id`] — an indexed point lookup, the
+//! same cost `search_by_normalized` already paid per hit — because the
+//! catalog snapshot's `aliases: Vec<String>` carries no alias-kind tag, so
+//! `common_name`/`source`/catalogue-membership derivation still need the full
+//! `CachedTarget`.
 //!
 //! ## Constitution
 //!
@@ -12,13 +23,17 @@
 //! - §III Metadata/identity only — no image processing.
 //! - §V SQLite (seed + resolution cache) is the durable record queried here.
 
+use std::collections::HashMap;
+
 use sqlx::SqlitePool;
+use uuid::Uuid;
 
 use contracts_core::targets::{
-    TargetCatalogId, TargetSearchRequest, TargetSearchResponse, TargetSuggestion,
+    TargetCatalogId, TargetListItem, TargetSearchRequest, TargetSearchResponse, TargetSuggestion,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
-use targeting_resolver::cache::{search_by_normalized, CachedTarget, SearchHit};
+use targeting::normalize::normalize;
+use targeting_resolver::cache::{get_by_id, CachedTarget, SearchHit};
 use targeting_resolver::AliasKind;
 
 // ── Error mapping ───────────────────────────────────────────────────────────
@@ -101,6 +116,82 @@ fn hit_to_suggestion(hit: SearchHit) -> TargetSuggestion {
     }
 }
 
+// ── In-memory typeahead ranking (F0 W-TARGETS) ──────────────────────────────
+//
+// Mirrors `targeting_resolver::cache::search_by_normalized`'s ranking scheme
+// exactly (rank buckets, dedup-by-target, tie-break order) so switching the
+// candidate source from a SQLite `LIKE` scan to the in-memory catalog
+// snapshot does not change result ordering or content.
+
+/// Rank bucket: `0` = exact normalized match, `1` = prefix, `2` = substring.
+const RANK_EXACT: u8 = 0;
+const RANK_PREFIX: u8 = 1;
+const RANK_SUBSTRING: u8 = 2;
+
+/// The best matching alias seen so far for one target during in-memory dedup.
+struct Best {
+    alias: String,
+    normalized_len: usize,
+    rank: u8,
+}
+
+impl Best {
+    /// A lower rank wins; ties break on the shorter matched alias.
+    fn is_better_than(&self, other: &Self) -> bool {
+        (self.rank, self.normalized_len) < (other.rank, other.normalized_len)
+    }
+}
+
+/// Rank every alias of every catalog item against the normalized (non-empty)
+/// query `q`, keeping each target's single best-ranked alias, then return
+/// `(target_id, matched_alias, rank)` sorted best-first and truncated to
+/// `limit`.
+///
+/// The catalog snapshot's `aliases` list is sourced from the same
+/// `target_alias` rows `search_by_normalized`'s SQL scans (including the
+/// primary designation, which is always one of its own aliases), so matching
+/// over it reproduces the same candidate set.
+fn rank_catalog(items: &[TargetListItem], q: &str, limit: usize) -> Vec<(String, String, u8)> {
+    let mut best_by_target: HashMap<&str, Best> = HashMap::new();
+    for item in items {
+        for alias in &item.aliases {
+            let normalized = normalize(alias);
+            if !normalized.contains(q) {
+                continue;
+            }
+            let rank = if normalized == q {
+                RANK_EXACT
+            } else if normalized.starts_with(q) {
+                RANK_PREFIX
+            } else {
+                RANK_SUBSTRING
+            };
+            let candidate = Best { alias: alias.clone(), normalized_len: normalized.len(), rank };
+            match best_by_target.entry(item.id.as_str()) {
+                std::collections::hash_map::Entry::Occupied(mut e) => {
+                    if candidate.is_better_than(e.get()) {
+                        e.insert(candidate);
+                    }
+                }
+                std::collections::hash_map::Entry::Vacant(e) => {
+                    e.insert(candidate);
+                }
+            }
+        }
+    }
+
+    let mut ranked: Vec<(&str, Best)> = best_by_target.into_iter().collect();
+    ranked.sort_by(|(_, a), (_, b)| {
+        (a.rank, a.normalized_len, a.alias.as_str()).cmp(&(
+            b.rank,
+            b.normalized_len,
+            b.alias.as_str(),
+        ))
+    });
+    ranked.truncate(limit);
+    ranked.into_iter().map(|(id, best)| (id.to_owned(), best.alias, best.rank)).collect()
+}
+
 // ── search ──────────────────────────────────────────────────────────────────
 
 /// `target.search` — ranked typeahead suggestions from local seed + cache.
@@ -121,7 +212,24 @@ pub async fn search(
 ) -> Result<TargetSearchResponse, ContractError> {
     let limit = if req.limit == 0 { 20 } else { req.limit as usize };
 
-    let hits = search_by_normalized(pool, &req.query, limit).await.map_err(|e| db_err(&e))?;
+    let q = normalize(&req.query);
+    let ranked: Vec<(String, String, u8)> = if q.is_empty() {
+        Vec::new()
+    } else {
+        let catalog = crate::target_management::list(pool).await?;
+        rank_catalog(&catalog, &q, limit)
+    };
+
+    // Hydrate each winning target's full row (needed for `common_name`/
+    // `source` and catalogue derivation, neither of which survives in the
+    // flat `aliases: Vec<String>` snapshot) — an indexed point lookup per hit.
+    let mut hits = Vec::with_capacity(ranked.len());
+    for (target_id, matched_alias, rank) in ranked {
+        let Ok(uuid) = Uuid::parse_str(&target_id) else { continue };
+        if let Some(target) = get_by_id(pool, uuid).await.map_err(|e| db_err(&e))? {
+            hits.push(SearchHit { target, matched_alias, rank });
+        }
+    }
 
     // Both filters AND together (T029): catalogue membership is derived from the
     // target's alias designations; the type filter checks the object type.
@@ -151,10 +259,12 @@ mod tests {
         AliasKind, ObjectType, ResolvedAlias, ResolvedIdentity, TargetSource as CacheSource,
     };
 
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
+    // Serialized against `target_management`/`target_resolve`/
+    // `resolver_settings` tests: `search` reads through the shared catalog
+    // `SnapshotCache` (F0), see `target_management::cache_test_lock` for the
+    // full rationale.
+    async fn setup() -> crate::target_management::cache_test_lock::LockedDb {
+        crate::target_management::cache_test_lock::locked_db().await
     }
 
     fn m31() -> ResolvedIdentity {


### PR DESCRIPTION
## Summary

Adds an in-memory, in-process caching layer across the `app_core_*` crates,
built on a shared `SnapshotCache<T>` / `TtlCache` foundation in
`app_core_cache`, with per-domain read-through and invalidate-after-commit
wiring at each relevant write site.

- **F0 (foundation)**: `SnapshotCache<T>` single-slot whole-value cache +
  existing `TtlCache`/`DebounceCache` in `crates/app/cache`; `OnceLock` cache
  statics + `invalidate_*()`/reader fns in owning modules; shared
  cached-extract metadata helper in `app/core`; Cargo.toml dep adds + mod
  decls across `app_core_{core,targets,calibration,settings,inbox}`.
- **W-CORE**: `source_protection_state` + protection-defaults +
  `library_root` path caches (read-through + invalidate); catalog-invalidate
  on core/search INSERTs; relocates `protection_defaults`
  invalidation into the leaf `app_core_cache` crate.
- **W-TARGETS**: catalog snapshot read-through + typeahead-over-snapshot +
  invalidate on alias/resolve/display writes; `resolver_settings` snapshot;
  FITS cached-extract at `ingest_sessions`; catalog-invalidate at
  `projects/project_setup`.
- **W-INBOX**: FITS/XISF cached-extract at scan/classify/confirm call sites
  (via the F0 shared helper); Tier 2.5 pattern-compile hoisted above the
  confirm per-file loop; calibration-masters invalidate write-site added at
  `plan_listener.rs`.
- **W-CALIB**: `MatchingRuleConfig` snapshot + masters-list snapshot
  read-through in `matching.rs`; invalidate masters on master
  detect/confirm.
- **W-SETTINGS**: settings-bag snapshot read-through + invalidation fan-out
  (`update_setting`/`restore_defaults`/`set_source_override` → settings-bag +
  calibration-config + protection-defaults + resolver-settings invalidate),
  all via F0 symbols.

Notable fixes found and landed along the way:
- `target_search`: SQL-based ranking replaced with in-memory ranking over
  the catalog snapshot (read-through correctness).
- `ingest_resolution`: a real stale-catalog production bug fixed during
  W-TARGETS review.
- Calibration-masters invalidate correctly routed through
  `plan_listener.rs` (the real write site) rather than `matching.rs`.
- Cross-test cache serialization added where global `OnceLock` statics made
  parallel tests order-dependent.

## Commits (6 merged nodes, FCFS order)

1. F0 — `e93ff4c99a176c3c5284114b3559ea01dd0f1d00` (merge `d62c0a5161728b097951955a80e32063464a2904`)
2. W-CALIB — `7b53f7845f820fbc92c9a5dae88e8d56d436c880` (merge `c136f977ff8b1f5fced1f51f57fa73417272840d`)
3. W-INBOX — `20531bc4d13ce1f03f2d2e3b2101ddf2711601b0` (merge `a042efe7f0b78f0418e4451b83f439e3364f28f9`)
4. W-TARGETS — `9b2cdbb2075d38247a7a562adc5ac9c7e8087d73` (merge `cdbe35ac81c7afaace27b65dd627dde2427fac6d`)
5. W-CORE — `0535ac4b6ed52a55310bc2e9c2fa2670e3d87ec6` (merge `df9e5381c6bee0a3d11d5947ee2a0ac7ba5a5080`)
6. W-SETTINGS — `a750eebfe4181f0f9b3c3bc81395a8224ddabaed` (merge `f6b13af1cd4c369d53bf1e799247327c52b02596`)

Each node was reviewer-approved and merged onto `feat/in-memory-cache-layer`
FCFS with a clean `git merge-tree` conflict probe before each merge (one
mechanical rebase required for F0 against a concurrent `main` change, PR
#590).

## Test plan
- [ ] CI green on this PR
- [ ] `just lint` / `just test` / `just typecheck` on the merged branch