### PR TITLE
feat: match targets by field of view and camera rotation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1423,7 +1423,7 @@ dependencies = [
 
 [[package]]
 name = "desktop_shell"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "app_core",
  "audit",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1436,6 +1436,7 @@ dependencies = [
  "specta",
  "specta-typescript",
  "sqlx",
+ "targeting",
  "targeting_resolver",
  "tauri",
  "tauri-build",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -181,6 +181,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
+ "skymath",
  "sqlx",
  "target-match",
  "targeting",
@@ -3327,7 +3328,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
- "target-match",
+ "skymath",
  "thiserror 2.0.18",
 ]
 
@@ -5535,6 +5536,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
+name = "skymath"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6315a9ee05a1b250fb7562b5a057342352ae7db06dc924ebfe3d0c90506db0d3"
+dependencies = [
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6128,10 +6139,11 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-match"
-version = "0.1.0"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05219dd320ebd25f9a1e09aa481a44946239b1491fe81486747e388f5d097398"
+checksum = "69f751172247ddff306ab714fbfc3cca07fe919c753b6388a620577d8f7c258c"
 dependencies = [
+ "skymath",
  "thiserror 2.0.18",
 ]
 
@@ -6139,6 +6151,7 @@ dependencies = [
 name = "targeting"
 version = "0.1.0"
 dependencies = [
+ "skymath",
  "target-match",
  "unicode-normalization",
  "uuid",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3325,6 +3325,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
+ "target-match",
  "thiserror 2.0.18",
 ]
 
@@ -6124,9 +6125,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
+name = "target-match"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05219dd320ebd25f9a1e09aa481a44946239b1491fe81486747e388f5d097398"
+dependencies = [
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "targeting"
 version = "0.1.0"
 dependencies = [
+ "target-match",
  "unicode-normalization",
  "uuid",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -182,6 +182,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "sqlx",
+ "target-match",
  "targeting",
  "targeting_resolver",
  "tempfile",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,6 +21,8 @@ audit = { path = "../../../crates/audit" }
 # spec 042 (T250): the SIMBAD resolver/seed surface this shell consumes moved
 # from `targeting` into the `targeting_resolver` crate.
 targeting_resolver = { path = "../../../crates/targeting/resolver" }
+# target.astro_format.batch: sexagesimal RA/Dec formatting (adopt target-match).
+targeting = { path = "../../../crates/targeting" }
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }

--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -6,12 +6,14 @@
 //! - `target.resolve` — cache-first SIMBAD resolution (spec 035).
 //! - `target.search` — local typeahead search (spec 035).
 //! - `target.resolution.settings` / `target.resolution.settings.update` — resolver settings.
+//! - `target.astro_format.batch` — batched sexagesimal RA/Dec formatting (adopt target-match).
 //!
 //! Spec-013 commands `target.lookup` and `target.resolve.fits` have been
 //! removed by spec 036 (superseded by spec-035 `target.search`/`target.resolve`).
 
 use contracts_core::targets::{
     ResolverSettingsGetRequest, ResolverSettingsResponse, ResolverSettingsUpdateRequest,
+    TargetAstroFormat, TargetAstroFormatBatchRequest, TargetAstroFormatBatchResponse,
     TargetResolveSimbadRequest, TargetResolveSimbadResponse, TargetSearchRequest,
     TargetSearchResponse,
 };
@@ -129,4 +131,36 @@ pub async fn target_resolution_settings_update(
         req.settings.online_enabled
     );
     app_core::resolver_settings::update(state.repo.pool(), &req).await
+}
+
+// ── target.astro_format.batch (adopt target-match) ───────────────────────────
+
+/// `target.astro_format.batch` — sexagesimal RA/Dec formatting for N targets
+/// in one call (never per-row round trips). Pure geometry (`targeting::astro_format`,
+/// backed by `target_match::Equatorial`'s carry-safe sexagesimal formatting) —
+/// no database access, so this never fails on a well-formed request.
+///
+/// Targets whose RA/Dec is non-finite are omitted from `formatted` (never a
+/// fabricated string); callers key results by `id`.
+///
+/// # Errors
+///
+/// This command does not fail; the `Result` shape matches the rest of the
+/// command surface for a consistent IPC error contract.
+#[tauri::command]
+#[specta::specta]
+pub async fn target_astro_format_batch(
+    req: TargetAstroFormatBatchRequest,
+) -> Result<TargetAstroFormatBatchResponse, ContractError> {
+    tracing::debug!("target.astro_format.batch count={}", req.targets.len());
+    let formatted =
+        req.targets
+            .into_iter()
+            .filter_map(|t| {
+                targeting::astro_format::sexagesimal(t.ra_deg, t.dec_deg).map(|s| {
+                    TargetAstroFormat { id: t.id, ra_sexagesimal: s.ra, dec_sexagesimal: s.dec }
+                })
+            })
+            .collect();
+    Ok(TargetAstroFormatBatchResponse { formatted })
 }

--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -137,7 +137,7 @@ pub async fn target_resolution_settings_update(
 
 /// `target.astro_format.batch` — sexagesimal RA/Dec formatting for N targets
 /// in one call (never per-row round trips). Pure geometry (`targeting::astro_format`,
-/// backed by `target_match::Equatorial`'s carry-safe sexagesimal formatting) —
+/// backed by `skymath::Equatorial`'s carry-safe sexagesimal formatting) —
 /// no database access, so this never fails on a well-formed request.
 ///
 /// Targets whose RA/Dec is non-finite are omitted from `formatted` (never a

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -112,7 +112,8 @@ use crate::commands::target_favourites::{
     target_favourites_add, target_favourites_list, target_favourites_remove,
 };
 use crate::commands::target_lookup::{
-    target_resolution_settings, target_resolution_settings_update, target_resolve, target_search,
+    target_astro_format_batch, target_resolution_settings, target_resolution_settings_update,
+    target_resolve, target_search,
 };
 use crate::commands::target_management as target_mgmt_cmds;
 use crate::commands::targets::{targets_get, targets_list};
@@ -219,6 +220,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // resolver settings (spec 035, US5)
         target_resolution_settings,
         target_resolution_settings_update,
+        // sexagesimal RA/Dec formatting (adopt target-match)
+        target_astro_format_batch,
         // projects (spec 008)
         projects_list,
         projects_get,
@@ -444,6 +447,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // resolver settings (spec 035, US5)
         target_resolution_settings,
         target_resolution_settings_update,
+        // sexagesimal RA/Dec formatting (adopt target-match)
+        target_astro_format_batch,
         // projects (spec 008)
         projects_list,
         projects_get,

--- a/apps/desktop/src-tauri/tests/bindings.rs
+++ b/apps/desktop/src-tauri/tests/bindings.rs
@@ -143,6 +143,7 @@ fn exports_typescript_bindings() {
         "target_resolve",
         "target_resolution_settings",
         "target_resolution_settings_update",
+        "target_astro_format_batch",
         // projects
         "projects_list",
         "projects_get",

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -332,7 +332,7 @@ export const commands = {
 	/**
 	 *  `target.astro_format.batch` — sexagesimal RA/Dec formatting for N targets
 	 *  in one call (never per-row round trips). Pure geometry (`targeting::astro_format`,
-	 *  backed by `target_match::Equatorial`'s carry-safe sexagesimal formatting) —
+	 *  backed by `skymath::Equatorial`'s carry-safe sexagesimal formatting) —
 	 *  no database access, so this never fails on a well-formed request.
 	 * 
 	 *  Targets whose RA/Dec is non-finite are omitted from `formatted` (never a

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -330,6 +330,21 @@ export const commands = {
 	 */
 	targetResolutionSettingsUpdate: (req: ResolverSettingsUpdateRequest) => typedError<ResolverSettingsResponse, ContractError_Serialize>(__TAURI_INVOKE("target_resolution_settings_update", { req })),
 	/**
+	 *  `target.astro_format.batch` — sexagesimal RA/Dec formatting for N targets
+	 *  in one call (never per-row round trips). Pure geometry (`targeting::astro_format`,
+	 *  backed by `target_match::Equatorial`'s carry-safe sexagesimal formatting) —
+	 *  no database access, so this never fails on a well-formed request.
+	 * 
+	 *  Targets whose RA/Dec is non-finite are omitted from `formatted` (never a
+	 *  fabricated string); callers key results by `id`.
+	 * 
+	 *  # Errors
+	 * 
+	 *  This command does not fail; the `Result` shape matches the rest of the
+	 *  command surface for a consistent IPC error contract.
+	 */
+	targetAstroFormatBatch: (req: TargetAstroFormatBatchRequest) => typedError<TargetAstroFormatBatchResponse, ContractError_Serialize>(__TAURI_INVOKE("target_astro_format_batch", { req })),
+	/**
 	 *  `projects.list` — list all projects from the database.
 	 * 
 	 *  # Errors
@@ -7541,6 +7556,45 @@ export type TargetAliasRemoveRequest = {
 /**  Response for `target.alias.remove` (gen-3). */
 export type TargetAliasRemoveResult = {
 	removed: boolean,
+};
+
+/**
+ *  One target's sexagesimal-formatted RA/Dec.
+ * 
+ *  Absent from the response when its input RA/Dec was non-finite — never a
+ *  fabricated string (callers key on `id` to look up a result and fall back
+ *  to an explicit "unknown" display for ids with no match).
+ */
+export type TargetAstroFormat = {
+	id: string,
+	/**  `HH:MM:SS` (0 fractional-second digits, carry-safe rounding). */
+	raSexagesimal: string,
+	/**  `±DD:MM:SS` (0 fractional-second digits, carry-safe rounding). */
+	decSexagesimal: string,
+};
+
+/**
+ *  Request for `target.astro_format.batch`: sexagesimal RA/Dec formatting for
+ *  N targets in a single call, never per-row round trips.
+ */
+export type TargetAstroFormatBatchRequest = {
+	targets: TargetAstroFormatItem[],
+};
+
+/**  Response for `target.astro_format.batch`. */
+export type TargetAstroFormatBatchResponse = {
+	formatted: TargetAstroFormat[],
+};
+
+/**  One target's RA/Dec to format, for `target.astro_format.batch`. */
+export type TargetAstroFormatItem = {
+	/**
+	 *  Caller-supplied id echoed back on the matching [`TargetAstroFormat`]
+	 *  (opaque to this command — a `canonical_target.id` in practice).
+	 */
+	id: string,
+	raDeg: number | null,
+	decDeg: number | null,
 };
 
 /**  Closed catalogue identifier slug (spec 035 `CatalogId`). */

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -60,6 +60,7 @@ const {
   mockListTargetProjects,
   mockGetTargetNote,
   mockUpdateTargetNote,
+  mockAstroFormatBatch,
 } = vi.hoisted(() => ({
   mockGetTargetDetail: vi.fn(),
   mockAddTargetAlias: vi.fn(),
@@ -70,6 +71,7 @@ const {
   mockListTargetProjects: vi.fn(),
   mockGetTargetNote: vi.fn(),
   mockUpdateTargetNote: vi.fn(),
+  mockAstroFormatBatch: vi.fn(),
 }));
 
 /** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
@@ -86,6 +88,7 @@ vi.mock('@/bindings/index', () => ({
     targetProjectsList: mockListTargetProjects,
     targetNoteGet: mockGetTargetNote,
     targetNoteUpdate: mockUpdateTargetNote,
+    targetAstroFormatBatch: mockAstroFormatBatch,
   },
 }));
 
@@ -152,6 +155,9 @@ beforeEach(() => {
   mockListTargetProjects.mockResolvedValue(ok([]));
   mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
   mockUpdateTargetNote.mockResolvedValue(ok({ notes: null }));
+  mockAstroFormatBatch.mockResolvedValue(
+    ok({ formatted: [{ id: TARGET_ID, raSexagesimal: '20:59:00', decSexagesimal: '+44:22:12' }] }),
+  );
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -30,7 +30,7 @@ import { unwrap } from '@/api/ipc';
 import type { TargetDetailV3 } from '@/bindings/aliases';
 import type { ContractError } from '@/lib/errors';
 import type { TargetListItem } from '@/bindings/index';
-import type { TargetSessionItem, TargetProjectItem } from '@/bindings';
+import type { TargetSessionItem, TargetProjectItem, TargetAstroFormat } from '@/bindings';
 import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn } from '@/ui';
 import { m } from '@/lib/i18n';
@@ -83,27 +83,6 @@ function kindLabel(kind: string): string {
     default:
       return kind;
   }
-}
-
-/** Format decimal RA degrees (0–360) to sexagesimal h m s string. */
-function fmtRa(deg: number): string {
-  if (!Number.isFinite(deg)) return '—';
-  const h = deg / 15;
-  const hh = Math.floor(h);
-  const mm = Math.floor((h - hh) * 60);
-  const ss = ((h - hh) * 60 - mm) * 60;
-  return `${String(hh).padStart(2, '0')}h${String(mm).padStart(2, '0')}m${ss.toFixed(0).padStart(2, '0')}s`;
-}
-
-/** Format decimal Dec degrees to ±DD°MM′SS″ string. */
-function fmtDec(deg: number): string {
-  if (!Number.isFinite(deg)) return '—';
-  const sign = deg < 0 ? '−' : '+';
-  const abs = Math.abs(deg);
-  const dd = Math.floor(abs);
-  const mm = Math.floor((abs - dd) * 60);
-  const ss = ((abs - dd) * 60 - mm) * 60;
-  return `${sign}${String(dd).padStart(2, '0')}°${String(mm).padStart(2, '0')}′${ss.toFixed(0).padStart(2, '0')}″`;
 }
 
 // ── Altitude curve helper ─────────────────────────────────────────────────────
@@ -315,6 +294,11 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
   const [notesSaved, setNotesSaved] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
 
+  // Sexagesimal RA/Dec (adopt target-match): backend-formatted, carry-safe
+  // rounding (replaces the hand-rolled fmtRa/fmtDec, which could round a
+  // seconds value up to an invalid ":60").
+  const [astroFormat, setAstroFormat] = useState<TargetAstroFormat | null>(null);
+
   const navigate = useNavigate();
 
   // US6/T015: real astronomy needs an active observing site; the graph/stats
@@ -381,6 +365,20 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
     setNotesSaved(false);
     setNotesError(null);
   }, [targetId]);
+
+  // Sexagesimal RA/Dec: one batched call (N=1 here) once the detail loads.
+  useEffect(() => {
+    if (loadState.status !== 'loaded') {
+      setAstroFormat(null);
+      return;
+    }
+    const { id, raDeg, decDeg } = loadState.data;
+    commands
+      .targetAstroFormatBatch({ targets: [{ id, raDeg, decDeg }] })
+      .then(unwrap)
+      .then(({ formatted }) => setAstroFormat(formatted[0] ?? null))
+      .catch(() => setAstroFormat(null));
+  }, [loadState]);
 
   // US4: save notes handler.
   const handleNotesSave = useCallback(async () => {
@@ -512,10 +510,9 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
     guidanceParams,
   );
 
-  const raDecStr =
-    detail.raDeg != null && detail.decDeg != null
-      ? `${fmtRa(detail.raDeg)} / ${fmtDec(detail.decDeg)}`
-      : null;
+  const raDecStr = astroFormat
+    ? `${astroFormat.raSexagesimal} / ${astroFormat.decSexagesimal}`
+    : null;
 
   // Identity facts split across two tabular columns (left-packed).
   const identityA: PropertyDef[] = [

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -367,11 +367,11 @@ export function TargetDetailV2({ targetId, item = null, usableAltDeg = USABLE_AL
   }, [targetId]);
 
   // Sexagesimal RA/Dec: one batched call (N=1 here) once the detail loads.
+  // No reset-to-null branch needed for the non-'loaded' states: `astroFormat`
+  // is only read below after the loading/error early-returns, so a stale
+  // value from a prior target is never displayed before this effect refetches.
   useEffect(() => {
-    if (loadState.status !== 'loaded') {
-      setAstroFormat(null);
-      return;
-    }
+    if (loadState.status !== 'loaded') return;
     const { id, raDeg, decDeg } = loadState.data;
     commands
       .targetAstroFormatBatch({ targets: [{ id, raDeg, decDeg }] })

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -44,6 +44,7 @@ const {
   mockListTargetProjects,
   mockGetTargetNote,
   mockUpdateTargetNote,
+  mockAstroFormatBatch,
 } = vi.hoisted(() => ({
   mockListTargets: vi.fn(),
   mockGetTargetDetail: vi.fn(),
@@ -57,6 +58,7 @@ const {
   mockListTargetProjects: vi.fn(),
   mockGetTargetNote: vi.fn(),
   mockUpdateTargetNote: vi.fn(),
+  mockAstroFormatBatch: vi.fn(),
 }));
 
 /** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
@@ -76,6 +78,7 @@ vi.mock('@/bindings/index', () => ({
     targetProjectsList: mockListTargetProjects,
     targetNoteGet: mockGetTargetNote,
     targetNoteUpdate: mockUpdateTargetNote,
+    targetAstroFormatBatch: mockAstroFormatBatch,
   },
 }));
 
@@ -87,6 +90,7 @@ mockListTargetSessions.mockResolvedValue(ok([]));
 mockListTargetProjects.mockResolvedValue(ok([]));
 mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
 mockUpdateTargetNote.mockResolvedValue(ok({ notes: null }));
+mockAstroFormatBatch.mockResolvedValue(ok({ formatted: [] }));
 
 const mockNavigate = vi.fn();
 const mockSelectedId = { current: undefined as string | undefined };

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -28,6 +28,7 @@ serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
 sqlx.workspace = true
+target-match = "0.1"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -27,8 +27,9 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
+skymath = "0.1"
 sqlx.workspace = true
-target-match = "0.1"
+target-match = "0.2"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/app/inbox/src/target_recommendations.rs
+++ b/crates/app/inbox/src/target_recommendations.rs
@@ -6,15 +6,31 @@
 //!
 //! 1. loads the sub-group's per-file pointing + optics from `inbox_file_metadata`
 //!    (the T062 extended columns) and derives a single sub-group pointing,
-//! 2. computes a **FOV-aware radius** from `FOCALLEN` + pixel size + sensor dims,
-//!    falling back to a **configurable fixed radius** when pixel size is absent
-//!    (R-17 C5),
+//! 2. builds a **rectangular frame membership** from the sub-group's optics
+//!    (focal length + pixel size + sensor dims, via `target_match::Field`),
+//!    falling back to a **configurable fixed circular radius** when optics are
+//!    absent (R-17 C5),
 //! 3. ranks every catalog entry (`canonical_target`, via the resolver cache) by
-//!    great-circle (haversine) angular separation, ascending, within the radius.
+//!    great-circle separation, ascending, keeping only those on the frame (or,
+//!    in the fixed-radius fallback, within the radius).
 //!
 //! The `OBJECT` header is returned only as `object_hint` for display — it is
-//! never used for matching or search. The pure ranking lives in
-//! [`targeting::coords`]; this module is orchestration only (DB load + map).
+//! never used for matching or search. Coordinate/geometry primitives come from
+//! [`targeting::coords`] and `target_match`'s `Constraint`/`rank`; this module
+//! is orchestration only (DB load + map).
+//!
+//! # Frame membership is rectangular, not yet rotation-aware
+//!
+//! Membership uses `target_match::Constraint::frame` — an axis-aligned
+//! rectangle sized from the sub-group's optics — instead of the wider
+//! circumscribed-circle radius used previously, so a target near the frame's
+//! corner but off-sensor is correctly excluded (a real precision gain over
+//! plain circular-radius matching). True camera-rotation-aware membership
+//! (`Constraint::frame_rotated`) needs `ROTATANG`
+//! (`inbox_file_metadata.rotator_angle_deg`, already persisted by migration
+//! 0049) added to `persistence_db::repositories::inbox::list_inbox_pointing`'s
+//! projection; that repository change is outside this module's crate — frame
+//! membership is computed un-rotated (position angle 0°) until it lands.
 //!
 //! This operation is **read-only**: it recommends, it does not write the chosen
 //! target (that is reclassify, T068). Propagation to a linked project (T075)
@@ -33,7 +49,9 @@ use contracts_core::inbox::{
     InboxPointing, InboxTargetCandidate, InboxTargetRecommendationsResponse,
 };
 use contracts_core::{ContractError, ErrorSeverity};
-use targeting::coords::{self, Pointing, TargetCoord};
+use target_match::{rank, Constraint, SkyObject};
+use targeting::coords::{self, Pointing};
+use targeting::{Angle, Equatorial};
 use targeting_resolver::cache;
 
 /// Default fixed search radius (degrees) used when a FOV-aware radius cannot be
@@ -102,36 +120,42 @@ pub async fn target_recommendations(
     // Safe: has_pointing guarantees both are Some + finite.
     let ra = pointing_row.ra_deg.unwrap_or_default();
     let dec = pointing_row.dec_deg.unwrap_or_default();
-    let pointing = Pointing::new(ra, dec);
+    let pointing = coords::to_equatorial(Pointing::new(ra, dec));
 
-    // 4. Radius: FOV-aware from optics, else the configurable fixed fallback.
-    let radius_deg = coords::fov_radius_deg(
+    // 4. Frame membership: an axis-aligned rectangle sized from the sub-group's
+    //    optics, else the configurable fixed circular fallback (R-17 C5).
+    let constraint = coords::field_from_optics(
         pointing_row.focal_length_mm,
         pointing_row.pixel_size_um,
         pointing_row.naxis1,
         pointing_row.naxis2,
     )
-    .unwrap_or(fixed_radius_deg);
+    .map_or_else(
+        || Constraint::circular(Angle::from_degrees(fixed_radius_deg)),
+        |field| Constraint::frame(&field),
+    );
 
-    // 5. Load the catalog and rank by angular separation (coordinate-only).
+    // 5. Load the catalog and rank by frame membership (coordinate-only).
     let catalog = cache::list_all(pool).await.map_err(|e| cache_err(&e))?;
-    let coords_list: Vec<TargetCoord> = catalog
+    let objects: Vec<CatalogObject> = catalog
         .into_iter()
-        .map(|t| TargetCoord {
+        // A non-finite catalog coordinate can't build an Equatorial; exclude it
+        // (mirrors the previous NaN-never-compares-within-radius behaviour).
+        .filter(|t| t.ra_deg.is_finite() && t.dec_deg.is_finite())
+        .map(|t| CatalogObject {
             target_id: t.id.to_string(),
             // Effective label: user display_alias wins, else primary designation.
             name: t.display_alias.unwrap_or(t.primary_designation),
-            ra_deg: t.ra_deg,
-            dec_deg: t.dec_deg,
+            position: coords::to_equatorial(Pointing::new(t.ra_deg, t.dec_deg)),
         })
         .collect();
 
-    let candidates = coords::rank_candidates(pointing, &coords_list, radius_deg)
+    let candidates = rank(pointing, &objects, constraint)
         .into_iter()
-        .map(|c| InboxTargetCandidate {
-            target_id: c.target_id,
-            name: c.name,
-            separation_deg: c.separation_deg,
+        .map(|m| InboxTargetCandidate {
+            target_id: m.object.target_id.clone(),
+            name: m.object.name.clone(),
+            separation_deg: m.separation.degrees(),
         })
         .collect();
 
@@ -140,6 +164,21 @@ pub async fn target_recommendations(
         pointing: Some(InboxPointing { ra_deg: ra, dec_deg: dec }),
         object_hint,
     })
+}
+
+/// A catalog entry adapted to `target_match::SkyObject` for frame ranking.
+/// Matching is coordinate-only (R-17): `name` rides along for display and is
+/// never read by [`rank`]/[`Constraint`] membership.
+struct CatalogObject {
+    target_id: String,
+    name: String,
+    position: Equatorial,
+}
+
+impl SkyObject for CatalogObject {
+    fn position(&self) -> Equatorial {
+        self.position
+    }
 }
 
 /// A pointing row is usable when both RA and Dec are present and finite.

--- a/crates/app/inbox/src/target_recommendations.rs
+++ b/crates/app/inbox/src/target_recommendations.rs
@@ -8,8 +8,9 @@
 //!    (the T062 extended columns) and derives a single sub-group pointing,
 //! 2. builds a **rectangular frame membership** from the sub-group's optics
 //!    (focal length + pixel size + sensor dims, via `target_match::Field`),
-//!    falling back to a **configurable fixed circular radius** when optics are
-//!    absent (R-17 C5),
+//!    rotated by `ROTATANG`/`ROTATOR` (`rotator_angle_deg`) when present,
+//!    falling back to an axis-aligned rectangle and then to a **configurable
+//!    fixed circular radius** when optics are absent (R-17 C5),
 //! 3. ranks every catalog entry (`canonical_target`, via the resolver cache) by
 //!    great-circle separation, ascending, keeping only those on the frame (or,
 //!    in the fixed-radius fallback, within the radius).
@@ -19,18 +20,16 @@
 //! [`targeting::coords`] and `target_match`'s `Constraint`/`rank`; this module
 //! is orchestration only (DB load + map).
 //!
-//! # Frame membership is rectangular, not yet rotation-aware
+//! # Frame membership: rotated rectangle when a rotator angle is known
 //!
-//! Membership uses `target_match::Constraint::frame` — an axis-aligned
-//! rectangle sized from the sub-group's optics — instead of the wider
-//! circumscribed-circle radius used previously, so a target near the frame's
-//! corner but off-sensor is correctly excluded (a real precision gain over
-//! plain circular-radius matching). True camera-rotation-aware membership
-//! (`Constraint::frame_rotated`) needs `ROTATANG`
-//! (`inbox_file_metadata.rotator_angle_deg`, already persisted by migration
-//! 0049) added to `persistence_db::repositories::inbox::list_inbox_pointing`'s
-//! projection; that repository change is outside this module's crate — frame
-//! membership is computed un-rotated (position angle 0°) until it lands.
+//! Membership uses `target_match::Constraint::frame_rotated` — a rectangle
+//! sized from the sub-group's optics and rotated by the mechanical rotator
+//! angle — instead of the wider circumscribed-circle radius used previously,
+//! so a target near the frame's corner but off-sensor (or off-sensor only
+//! because of camera rotation) is correctly excluded. Falls back to an
+//! axis-aligned `Constraint::frame` when `rotator_angle_deg` is absent/
+//! non-finite, and to the fixed circular radius when optics are absent
+//! entirely.
 //!
 //! This operation is **read-only**: it recommends, it does not write the chosen
 //! target (that is reclassify, T068). Propagation to a linked project (T075)
@@ -122,8 +121,9 @@ pub async fn target_recommendations(
     let dec = pointing_row.dec_deg.unwrap_or_default();
     let pointing = coords::to_equatorial(Pointing::new(ra, dec));
 
-    // 4. Frame membership: an axis-aligned rectangle sized from the sub-group's
-    //    optics, else the configurable fixed circular fallback (R-17 C5).
+    // 4. Frame membership: a rectangle sized from the sub-group's optics —
+    //    rotated by the rotator angle when known, else axis-aligned — else the
+    //    configurable fixed circular fallback (R-17 C5).
     let constraint = coords::field_from_optics(
         pointing_row.focal_length_mm,
         pointing_row.pixel_size_um,
@@ -132,7 +132,12 @@ pub async fn target_recommendations(
     )
     .map_or_else(
         || Constraint::circular(Angle::from_degrees(fixed_radius_deg)),
-        |field| Constraint::frame(&field),
+        |field| {
+            pointing_row.rotator_angle_deg.filter(|v| v.is_finite()).map_or_else(
+                || Constraint::frame(&field),
+                |pa_deg| Constraint::frame_rotated(&field, Angle::from_degrees(pa_deg)),
+            )
+        },
     );
 
     // 5. Load the catalog and rank by frame membership (coordinate-only).
@@ -249,6 +254,8 @@ mod tests {
     }
 
     /// Create a light item with one file carrying pointing + optics + OBJECT.
+    /// `naxis` sets both `naxis1`/`naxis2` (square sensor) and no rotator angle
+    /// is set; see [`seed_light_item_full`] for asymmetric/rotated frames.
     #[allow(clippy::too_many_arguments)]
     async fn seed_light_item(
         db: &Database,
@@ -260,12 +267,35 @@ mod tests {
         naxis: Option<i64>,
         object: Option<&str>,
     ) {
+        seed_light_item_full(db, item_id, ra, dec, focal, pixel, naxis, naxis, None, object).await;
+    }
+
+    /// [`seed_light_item`], generalized to independent `naxis1`/`naxis2` (an
+    /// elongated, non-square frame) and an optional rotator angle.
+    #[allow(clippy::too_many_arguments)]
+    async fn seed_light_item_full(
+        db: &Database,
+        item_id: &str,
+        ra: Option<f64>,
+        dec: Option<f64>,
+        focal: Option<f64>,
+        pixel: Option<f64>,
+        naxis1: Option<i64>,
+        naxis2: Option<i64>,
+        rotator_angle_deg: Option<f64>,
+        object: Option<&str>,
+    ) {
+        // Distinct per item_id: `inbox_items` is UNIQUE(root_id, relative_path),
+        // and a caller may seed several items in one db (e.g. an un-rotated vs
+        // rotated pair to compare frame membership).
+        let relative_path = format!("lights-{item_id}");
+        let relative_file_path = format!("{relative_path}/light_001.fits");
         repo::insert_inbox_item(
             db.pool(),
             &InsertInboxItem {
                 id: item_id,
                 root_id: "root-1",
-                relative_path: "lights",
+                relative_path: &relative_path,
                 file_count: 1,
                 content_signature: Some("sig"),
                 lane: "fits",
@@ -277,7 +307,7 @@ mod tests {
             db.pool(),
             &UpsertFileMetadata {
                 inbox_item_id: item_id,
-                relative_file_path: "lights/light_001.fits",
+                relative_file_path: &relative_file_path,
                 object,
                 ..Default::default()
             },
@@ -289,17 +319,18 @@ mod tests {
         sqlx::query(
             "UPDATE inbox_file_metadata
              SET ra_deg = ?, dec_deg = ?, focal_length_mm = ?, pixel_size_um = ?,
-                 naxis1 = ?, naxis2 = ?
+                 naxis1 = ?, naxis2 = ?, rotator_angle_deg = ?
              WHERE inbox_item_id = ? AND relative_file_path = ?",
         )
         .bind(ra)
         .bind(dec)
         .bind(focal)
         .bind(pixel)
-        .bind(naxis)
-        .bind(naxis)
+        .bind(naxis1)
+        .bind(naxis2)
+        .bind(rotator_angle_deg)
         .bind(item_id)
-        .bind("lights/light_001.fits")
+        .bind(&relative_file_path)
         .execute(db.pool())
         .await
         .unwrap();
@@ -347,6 +378,77 @@ mod tests {
         let p = resp.pointing.unwrap();
         assert!((p.ra_deg - 10.684_708).abs() < 1e-9);
         assert_eq!(resp.object_hint.as_deref(), Some("Andromeda"));
+    }
+
+    /// A target due East of the pointing sits inside an elongated (landscape)
+    /// un-rotated frame but falls off a 90°-rotated frame (rotation swaps which
+    /// axis is "wide") — proves `rotator_angle_deg` actually drives membership,
+    /// not just an axis-aligned rectangle regardless of camera rotation.
+    #[tokio::test]
+    async fn rotator_angle_changes_frame_membership() {
+        let db = test_db().await;
+        let (ra0, dec0): (f64, f64) = (10.684_708, 41.268_75); // M31 pointing
+                                                               // ~0.5° due East (same Dec), accounting for RA compression at this Dec.
+        let east_ra = ra0 + 0.5 / dec0.to_radians().cos();
+        seed_target(&db, "East Target", 1, east_ra, dec0).await;
+
+        // Elongated landscape frame: naxis1=6248 (width ~1.68°), naxis2=1200
+        // (height ~0.32°) at 800mm/3.76µm — half-width 0.84°, half-height 0.16°.
+        // The 0.5° East target is inside the un-rotated rectangle (0.5 < 0.84,
+        // ~0 North offset < 0.16) but outside once rotated 90° (axes swap: the
+        // East offset now falls along the narrow 0.16°-half axis).
+        seed_light_item_full(
+            &db,
+            "item-unrotated",
+            Some(ra0),
+            Some(dec0),
+            Some(800.0),
+            Some(3.76),
+            Some(6248),
+            Some(1200),
+            None,
+            None,
+        )
+        .await;
+        let unrotated = target_recommendations(
+            db.pool(),
+            &RecommendationTarget::InboxItem("item-unrotated".to_owned()),
+            DEFAULT_FIXED_RADIUS_DEG,
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            unrotated.candidates.len(),
+            1,
+            "East target is inside the un-rotated landscape frame: {:?}",
+            unrotated.candidates
+        );
+
+        seed_light_item_full(
+            &db,
+            "item-rotated",
+            Some(ra0),
+            Some(dec0),
+            Some(800.0),
+            Some(3.76),
+            Some(6248),
+            Some(1200),
+            Some(90.0),
+            None,
+        )
+        .await;
+        let rotated = target_recommendations(
+            db.pool(),
+            &RecommendationTarget::InboxItem("item-rotated".to_owned()),
+            DEFAULT_FIXED_RADIUS_DEG,
+        )
+        .await
+        .unwrap();
+        assert!(
+            rotated.candidates.is_empty(),
+            "the same East target falls outside the 90°-rotated frame: {:?}",
+            rotated.candidates
+        );
     }
 
     #[tokio::test]

--- a/crates/app/inbox/src/target_recommendations.rs
+++ b/crates/app/inbox/src/target_recommendations.rs
@@ -8,9 +8,9 @@
 //!    (the T062 extended columns) and derives a single sub-group pointing,
 //! 2. builds a **rectangular frame membership** from the sub-group's optics
 //!    (focal length + pixel size + sensor dims, via `target_match::Field`),
-//!    rotated by `ROTATANG`/`ROTATOR` (`rotator_angle_deg`) when present,
-//!    falling back to an axis-aligned rectangle and then to a **configurable
-//!    fixed circular radius** when optics are absent (R-17 C5),
+//!    rotated by the sky position angle when known, falling back to an
+//!    axis-aligned rectangle and then to a **configurable fixed circular
+//!    radius** when optics are absent (R-17 C5),
 //! 3. ranks every catalog entry (`canonical_target`, via the resolver cache) by
 //!    great-circle separation, ascending, keeping only those on the frame (or,
 //!    in the fixed-radius fallback, within the radius).
@@ -20,16 +20,19 @@
 //! [`targeting::coords`] and `target_match`'s `Constraint`/`rank`; this module
 //! is orchestration only (DB load + map).
 //!
-//! # Frame membership: rotated rectangle when a rotator angle is known
+//! # Frame rotation angle: sky PA (`OBJCTROT`), never the mechanical rotator
 //!
-//! Membership uses `target_match::Constraint::frame_rotated` — a rectangle
-//! sized from the sub-group's optics and rotated by the mechanical rotator
-//! angle — instead of the wider circumscribed-circle radius used previously,
-//! so a target near the frame's corner but off-sensor (or off-sensor only
-//! because of camera rotation) is correctly excluded. Falls back to an
-//! axis-aligned `Constraint::frame` when `rotator_angle_deg` is absent/
-//! non-finite, and to the fixed circular radius when optics are absent
-//! entirely.
+//! `target_match::Constraint::frame_rotated` expects a **sky** position angle
+//! (East of North) — the frame's orientation on the sky, not the camera's
+//! mechanical orientation. `sky_rotation_deg` (`OBJCTROT`) is that sky PA;
+//! `rotator_angle_deg` (`ROTATANG`/`ROTATOR`) is the mechanical rotator
+//! angle — the flat↔light match key elsewhere in this codebase (R-18,
+//! `grouping`), NOT a sky-frame angle, and NOT usable here. Precedence:
+//! `sky_rotation_deg` → `rotator_angle_deg` → axis-aligned `Constraint::frame`
+//! → fixed circular radius. The `rotator_angle_deg` middle rung is a
+//! best-effort fallback (mechanical ≈ sky PA only when the optical train has
+//! no field-derotation offset baked in) — better than the un-rotated
+//! rectangle, but not as correct as the true sky PA.
 //!
 //! This operation is **read-only**: it recommends, it does not write the chosen
 //! target (that is reclassify, T068). Propagation to a linked project (T075)
@@ -121,9 +124,15 @@ pub async fn target_recommendations(
     let dec = pointing_row.dec_deg.unwrap_or_default();
     let pointing = coords::to_equatorial(Pointing::new(ra, dec));
 
-    // 4. Frame membership: a rectangle sized from the sub-group's optics —
-    //    rotated by the rotator angle when known, else axis-aligned — else the
-    //    configurable fixed circular fallback (R-17 C5).
+    // 4. Frame membership: a rectangle sized from the sub-group's optics,
+    //    rotated by the best available sky PA — sky_rotation_deg (OBJCTROT,
+    //    the true sky PA) preferred over rotator_angle_deg (ROTATANG, a
+    //    mechanical-angle approximation) — else axis-aligned, else the
+    //    configurable fixed circular fallback (R-17 C5). See the module docs.
+    let sky_pa_deg = pointing_row
+        .sky_rotation_deg
+        .filter(|v| v.is_finite())
+        .or_else(|| pointing_row.rotator_angle_deg.filter(|v| v.is_finite()));
     let constraint = coords::field_from_optics(
         pointing_row.focal_length_mm,
         pointing_row.pixel_size_um,
@@ -133,7 +142,7 @@ pub async fn target_recommendations(
     .map_or_else(
         || Constraint::circular(Angle::from_degrees(fixed_radius_deg)),
         |field| {
-            pointing_row.rotator_angle_deg.filter(|v| v.is_finite()).map_or_else(
+            sky_pa_deg.map_or_else(
                 || Constraint::frame(&field),
                 |pa_deg| Constraint::frame_rotated(&field, Angle::from_degrees(pa_deg)),
             )
@@ -254,8 +263,8 @@ mod tests {
     }
 
     /// Create a light item with one file carrying pointing + optics + OBJECT.
-    /// `naxis` sets both `naxis1`/`naxis2` (square sensor) and no rotator angle
-    /// is set; see [`seed_light_item_full`] for asymmetric/rotated frames.
+    /// `naxis` sets both `naxis1`/`naxis2` (square sensor) and no rotation
+    /// angle is set; see [`seed_light_item_full`] for asymmetric/rotated frames.
     #[allow(clippy::too_many_arguments)]
     async fn seed_light_item(
         db: &Database,
@@ -267,11 +276,14 @@ mod tests {
         naxis: Option<i64>,
         object: Option<&str>,
     ) {
-        seed_light_item_full(db, item_id, ra, dec, focal, pixel, naxis, naxis, None, object).await;
+        seed_light_item_full(db, item_id, ra, dec, focal, pixel, naxis, naxis, None, None, object)
+            .await;
     }
 
     /// [`seed_light_item`], generalized to independent `naxis1`/`naxis2` (an
-    /// elongated, non-square frame) and an optional rotator angle.
+    /// elongated, non-square frame) and the two rotation fields
+    /// (`rotator_angle_deg` = mechanical `ROTATANG`, `sky_rotation_deg` = the
+    /// true sky PA `OBJCTROT` — see the module docs on why they differ).
     #[allow(clippy::too_many_arguments)]
     async fn seed_light_item_full(
         db: &Database,
@@ -283,6 +295,7 @@ mod tests {
         naxis1: Option<i64>,
         naxis2: Option<i64>,
         rotator_angle_deg: Option<f64>,
+        sky_rotation_deg: Option<f64>,
         object: Option<&str>,
     ) {
         // Distinct per item_id: `inbox_items` is UNIQUE(root_id, relative_path),
@@ -319,7 +332,7 @@ mod tests {
         sqlx::query(
             "UPDATE inbox_file_metadata
              SET ra_deg = ?, dec_deg = ?, focal_length_mm = ?, pixel_size_um = ?,
-                 naxis1 = ?, naxis2 = ?, rotator_angle_deg = ?
+                 naxis1 = ?, naxis2 = ?, rotator_angle_deg = ?, sky_rotation_deg = ?
              WHERE inbox_item_id = ? AND relative_file_path = ?",
         )
         .bind(ra)
@@ -329,6 +342,7 @@ mod tests {
         .bind(naxis1)
         .bind(naxis2)
         .bind(rotator_angle_deg)
+        .bind(sky_rotation_deg)
         .bind(item_id)
         .bind(&relative_file_path)
         .execute(db.pool())
@@ -380,23 +394,25 @@ mod tests {
         assert_eq!(resp.object_hint.as_deref(), Some("Andromeda"));
     }
 
-    /// A target due East of the pointing sits inside an elongated (landscape)
-    /// un-rotated frame but falls off a 90°-rotated frame (rotation swaps which
-    /// axis is "wide") — proves `rotator_angle_deg` actually drives membership,
-    /// not just an axis-aligned rectangle regardless of camera rotation.
-    #[tokio::test]
-    async fn rotator_angle_changes_frame_membership() {
-        let db = test_db().await;
-        let (ra0, dec0): (f64, f64) = (10.684_708, 41.268_75); // M31 pointing
-                                                               // ~0.5° due East (same Dec), accounting for RA compression at this Dec.
+    /// M31 pointing + a target ~0.5° due East (same Dec, RA-compression
+    /// corrected) + an elongated landscape frame (naxis1=6248 ~1.68° wide,
+    /// naxis2=1200 ~0.32° tall at 800mm/3.76µm — half-width 0.84°, half-height
+    /// 0.16°). The East target sits inside the un-rotated rectangle (0.5 <
+    /// 0.84 width, ~0 < 0.16 height) but outside once the frame is rotated
+    /// 90° (axes swap: the East offset now falls along the narrow axis).
+    fn east_target_and_landscape_field() -> (f64, f64, f64) {
+        let (ra0, dec0): (f64, f64) = (10.684_708, 41.268_75);
         let east_ra = ra0 + 0.5 / dec0.to_radians().cos();
+        (ra0, dec0, east_ra)
+    }
+
+    /// `sky_rotation_deg` (`OBJCTROT`) alone drives rotated frame membership.
+    #[tokio::test]
+    async fn sky_rotation_deg_changes_frame_membership() {
+        let db = test_db().await;
+        let (ra0, dec0, east_ra) = east_target_and_landscape_field();
         seed_target(&db, "East Target", 1, east_ra, dec0).await;
 
-        // Elongated landscape frame: naxis1=6248 (width ~1.68°), naxis2=1200
-        // (height ~0.32°) at 800mm/3.76µm — half-width 0.84°, half-height 0.16°.
-        // The 0.5° East target is inside the un-rotated rectangle (0.5 < 0.84,
-        // ~0 North offset < 0.16) but outside once rotated 90° (axes swap: the
-        // East offset now falls along the narrow 0.16°-half axis).
         seed_light_item_full(
             &db,
             "item-unrotated",
@@ -406,6 +422,7 @@ mod tests {
             Some(3.76),
             Some(6248),
             Some(1200),
+            None,
             None,
             None,
         )
@@ -426,28 +443,103 @@ mod tests {
 
         seed_light_item_full(
             &db,
-            "item-rotated",
+            "item-sky-rotated",
             Some(ra0),
             Some(dec0),
             Some(800.0),
             Some(3.76),
             Some(6248),
             Some(1200),
-            Some(90.0),
+            None,       // no mechanical rotator angle
+            Some(90.0), // sky_rotation_deg (OBJCTROT) alone
             None,
         )
         .await;
         let rotated = target_recommendations(
             db.pool(),
-            &RecommendationTarget::InboxItem("item-rotated".to_owned()),
+            &RecommendationTarget::InboxItem("item-sky-rotated".to_owned()),
             DEFAULT_FIXED_RADIUS_DEG,
         )
         .await
         .unwrap();
         assert!(
             rotated.candidates.is_empty(),
-            "the same East target falls outside the 90°-rotated frame: {:?}",
+            "the same East target falls outside the sky_rotation_deg=90° frame: {:?}",
             rotated.candidates
+        );
+    }
+
+    /// When both rotation fields are present, `sky_rotation_deg` (the true sky
+    /// PA) wins over `rotator_angle_deg` (mechanical) — a deliberately
+    /// misleading `rotator_angle_deg=0` (which would keep the frame
+    /// un-rotated if it were used) must NOT override the real 90° sky PA.
+    #[tokio::test]
+    async fn sky_rotation_deg_takes_precedence_over_rotator_angle_deg() {
+        let db = test_db().await;
+        let (ra0, dec0, east_ra) = east_target_and_landscape_field();
+        seed_target(&db, "East Target", 1, east_ra, dec0).await;
+
+        seed_light_item_full(
+            &db,
+            "item-conflict",
+            Some(ra0),
+            Some(dec0),
+            Some(800.0),
+            Some(3.76),
+            Some(6248),
+            Some(1200),
+            Some(0.0),  // misleading mechanical angle — must be ignored
+            Some(90.0), // true sky PA — must govern
+            None,
+        )
+        .await;
+        let resp = target_recommendations(
+            db.pool(),
+            &RecommendationTarget::InboxItem("item-conflict".to_owned()),
+            DEFAULT_FIXED_RADIUS_DEG,
+        )
+        .await
+        .unwrap();
+        assert!(
+            resp.candidates.is_empty(),
+            "sky_rotation_deg=90 must govern over the misleading rotator_angle_deg=0: {:?}",
+            resp.candidates
+        );
+    }
+
+    /// `rotator_angle_deg` is used as a fallback when `sky_rotation_deg` is
+    /// absent — better than an un-rotated rectangle, per the module docs.
+    #[tokio::test]
+    async fn rotator_angle_deg_used_as_fallback_when_sky_rotation_absent() {
+        let db = test_db().await;
+        let (ra0, dec0, east_ra) = east_target_and_landscape_field();
+        seed_target(&db, "East Target", 1, east_ra, dec0).await;
+
+        seed_light_item_full(
+            &db,
+            "item-fallback",
+            Some(ra0),
+            Some(dec0),
+            Some(800.0),
+            Some(3.76),
+            Some(6248),
+            Some(1200),
+            Some(90.0), // mechanical angle, no sky PA available
+            None,
+            None,
+        )
+        .await;
+        let resp = target_recommendations(
+            db.pool(),
+            &RecommendationTarget::InboxItem("item-fallback".to_owned()),
+            DEFAULT_FIXED_RADIUS_DEG,
+        )
+        .await
+        .unwrap();
+        assert!(
+            resp.candidates.is_empty(),
+            "rotator_angle_deg=90 fallback still excludes the East target: {:?}",
+            resp.candidates
         );
     }
 

--- a/crates/contracts/core/src/targets.rs
+++ b/crates/contracts/core/src/targets.rs
@@ -15,6 +15,12 @@
 //!
 //! Search/resolve/settings DTOs for `target.search`, `target.resolve`,
 //! `target.resolution.settings`.
+//!
+//! ## `target.astro_format.batch` (adopt target-match)
+//!
+//! [`TargetAstroFormatItem`], [`TargetAstroFormatBatchRequest`],
+//! [`TargetAstroFormat`], [`TargetAstroFormatBatchResponse`] — batched
+//! sexagesimal RA/Dec formatting for N targets in one IPC call.
 
 use crate::lifecycle::ProjectState;
 use crate::sessions::AcquisitionSession;
@@ -641,4 +647,47 @@ pub struct ResolverSettingsResponse {
     pub contract_version: String,
     pub request_id: String,
     pub settings: ResolverSettings,
+}
+
+// ── target.astro_format.batch (adopt target-match) ───────────────────────────
+
+/// One target's RA/Dec to format, for `target.astro_format.batch`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetAstroFormatItem {
+    /// Caller-supplied id echoed back on the matching [`TargetAstroFormat`]
+    /// (opaque to this command — a `canonical_target.id` in practice).
+    pub id: String,
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+}
+
+/// Request for `target.astro_format.batch`: sexagesimal RA/Dec formatting for
+/// N targets in a single call, never per-row round trips.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetAstroFormatBatchRequest {
+    pub targets: Vec<TargetAstroFormatItem>,
+}
+
+/// One target's sexagesimal-formatted RA/Dec.
+///
+/// Absent from the response when its input RA/Dec was non-finite — never a
+/// fabricated string (callers key on `id` to look up a result and fall back
+/// to an explicit "unknown" display for ids with no match).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetAstroFormat {
+    pub id: String,
+    /// `HH:MM:SS` (0 fractional-second digits, carry-safe rounding).
+    pub ra_sexagesimal: String,
+    /// `±DD:MM:SS` (0 fractional-second digits, carry-safe rounding).
+    pub dec_sexagesimal: String,
+}
+
+/// Response for `target.astro_format.batch`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetAstroFormatBatchResponse {
+    pub formatted: Vec<TargetAstroFormat>,
 }

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-target-match = "0.1"
+skymath = "0.1"
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,6 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
+target-match = "0.1"
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/metadata/core/src/lib.rs
+++ b/crates/metadata/core/src/lib.rs
@@ -309,55 +309,44 @@ pub struct RawFileMetadata {
 /// `"18 10 38"` or `"5 34 57.984"`) into decimal **degrees**.
 ///
 /// RA is expressed in hours; the result is multiplied by 15 (360° / 24h).
-/// Separators may be spaces or colons. Returns `None` for unparseable input.
+/// Separators may be spaces or colons. Returns `None` for unparseable input,
+/// or when the parsed value is outside the RA domain (`[0, 360)`).
+///
+/// Delegates the sexagesimal→decimal conversion to
+/// `target_match::Equatorial::parse` (a paired call with a `"0"` Dec
+/// sentinel, since that constructor validates RA and Dec together). FITS/XISF
+/// header values are frequently single-quoted; that quoting is stripped here
+/// before parsing, since `target_match` treats quote characters as part of
+/// the token (a FITS-specific tolerance, not a general coordinate concern).
 #[must_use]
 pub fn sexagesimal_ra_to_deg(raw: &str) -> Option<f64> {
-    let hours = sexagesimal_to_units(raw)?;
-    Some(hours * 15.0)
+    let cleaned = strip_fits_quotes(raw)?;
+    target_match::Equatorial::parse(cleaned, "0", target_match::Epoch::J2000)
+        .ok()
+        .map(|e| e.ra().degrees())
 }
 
 /// Parse a sexagesimal declination string in `±D M S` form (e.g.
 /// `"-15 01 11"` or `"+0 00 00.00"`) into decimal **degrees**.
 ///
 /// A leading `-` on the degrees field applies to the whole value.
-/// Separators may be spaces or colons. Returns `None` for unparseable input.
+/// Separators may be spaces or colons. Returns `None` for unparseable input,
+/// or when the parsed value is outside the Dec domain (`[-90, 90]`).
+///
+/// See [`sexagesimal_ra_to_deg`] for the shared parsing/quoting approach.
 #[must_use]
 pub fn sexagesimal_dec_to_deg(raw: &str) -> Option<f64> {
-    sexagesimal_to_units(raw)
+    let cleaned = strip_fits_quotes(raw)?;
+    target_match::Equatorial::parse("0", cleaned, target_match::Epoch::J2000)
+        .ok()
+        .map(|e| e.dec().degrees())
 }
 
-/// Shared sexagesimal parser: `D M S` (or `H M S`) → fractional units, sign
-/// taken from the first field. Minutes/seconds are optional.
-fn sexagesimal_to_units(raw: &str) -> Option<f64> {
+/// Strip surrounding whitespace and a single layer of FITS single-quoting
+/// (`'...'`) from a header value string. Returns `None` for empty input.
+fn strip_fits_quotes(raw: &str) -> Option<&str> {
     let trimmed = raw.trim().trim_matches('\'').trim();
-    if trimmed.is_empty() {
-        return None;
-    }
-
-    // Normalise colon separators to spaces, then split on whitespace.
-    let normalised = trimmed.replace(':', " ");
-    let mut parts = normalised.split_whitespace();
-
-    let deg_str = parts.next()?;
-    let negative = deg_str.starts_with('-');
-    let deg: f64 = deg_str.parse().ok()?;
-    let deg_abs = deg.abs();
-
-    let min: f64 = match parts.next() {
-        Some(s) => s.parse().ok()?,
-        None => 0.0,
-    };
-    let sec: f64 = match parts.next() {
-        Some(s) => s.parse().ok()?,
-        None => 0.0,
-    };
-
-    if min < 0.0 || sec < 0.0 {
-        return None;
-    }
-
-    let magnitude = deg_abs + min / 60.0 + sec / 3600.0;
-    Some(if negative { -magnitude } else { magnitude })
+    (!trimmed.is_empty()).then_some(trimmed)
 }
 
 /// Parse a decimal value from a FITS/XISF value string, tolerating a trailing

--- a/crates/metadata/core/src/lib.rs
+++ b/crates/metadata/core/src/lib.rs
@@ -313,17 +313,24 @@ pub struct RawFileMetadata {
 /// or when the parsed value is outside the RA domain (`[0, 360)`).
 ///
 /// Delegates the sexagesimal→decimal conversion to
-/// `target_match::Equatorial::parse` (a paired call with a `"0"` Dec
-/// sentinel, since that constructor validates RA and Dec together). FITS/XISF
-/// header values are frequently single-quoted; that quoting is stripped here
-/// before parsing, since `target_match` treats quote characters as part of
-/// the token (a FITS-specific tolerance, not a general coordinate concern).
+/// `skymath::Equatorial::parse_at_epoch` in [`skymath::ParseMode::Lenient`]
+/// (a paired call with a `"0"` Dec sentinel, since that constructor validates
+/// RA and Dec together; Lenient tolerates the missing-minutes/seconds and
+/// bare-decimal forms this parser has always accepted). FITS/XISF header
+/// values are frequently single-quoted; that quoting is stripped here before
+/// parsing, since `skymath` treats quote characters as part of the token (a
+/// FITS-specific tolerance, not a general coordinate concern).
 #[must_use]
 pub fn sexagesimal_ra_to_deg(raw: &str) -> Option<f64> {
     let cleaned = strip_fits_quotes(raw)?;
-    target_match::Equatorial::parse(cleaned, "0", target_match::Epoch::J2000)
-        .ok()
-        .map(|e| e.ra().degrees())
+    skymath::Equatorial::parse_at_epoch(
+        cleaned,
+        "0",
+        skymath::Epoch::J2000,
+        skymath::ParseMode::Lenient,
+    )
+    .ok()
+    .map(|e| e.ra().degrees())
 }
 
 /// Parse a sexagesimal declination string in `±D M S` form (e.g.
@@ -337,9 +344,14 @@ pub fn sexagesimal_ra_to_deg(raw: &str) -> Option<f64> {
 #[must_use]
 pub fn sexagesimal_dec_to_deg(raw: &str) -> Option<f64> {
     let cleaned = strip_fits_quotes(raw)?;
-    target_match::Equatorial::parse("0", cleaned, target_match::Epoch::J2000)
-        .ok()
-        .map(|e| e.dec().degrees())
+    skymath::Equatorial::parse_at_epoch(
+        "0",
+        cleaned,
+        skymath::Epoch::J2000,
+        skymath::ParseMode::Lenient,
+    )
+    .ok()
+    .map(|e| e.dec().degrees())
 }
 
 /// Strip surrounding whitespace and a single layer of FITS single-quoting

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -1226,9 +1226,12 @@ pub async fn list_inbox_file_metadata(
 /// Per-file pointing + optics, read for coordinate-based target resolution.
 ///
 /// Sourced from `inbox_file_metadata` (the T062 extended columns added in
-/// migration 0048). All fields are nullable — best-effort extraction. The
-/// caller derives a sub-group pointing (e.g. the first file carrying RA/Dec)
-/// and a FOV-aware radius from `focal_length_mm`/`pixel_size_um`/`naxis1/2`.
+/// migration 0048; `rotator_angle_deg` added in migration 0049). All fields
+/// are nullable — best-effort extraction. The caller derives a sub-group
+/// pointing (e.g. the first file carrying RA/Dec) and a FOV-aware radius from
+/// `focal_length_mm`/`pixel_size_um`/`naxis1/2`, optionally rotated by
+/// `rotator_angle_deg` (`ROTATANG`/`ROTATOR`, the flat↔light match key — NOT
+/// `sky_rotation_deg`/`OBJCTROT`, which is informational only).
 #[derive(Clone, Debug, Default, sqlx::FromRow)]
 pub struct InboxPointingRow {
     pub relative_file_path: String,
@@ -1238,6 +1241,7 @@ pub struct InboxPointingRow {
     pub pixel_size_um: Option<f64>,
     pub naxis1: Option<i64>,
     pub naxis2: Option<i64>,
+    pub rotator_angle_deg: Option<f64>,
     /// Raw `OBJECT` header value — display hint only, NEVER a matching key (R-17).
     pub object: Option<String>,
 }
@@ -1256,7 +1260,7 @@ pub async fn list_inbox_pointing(
 ) -> DbResult<Vec<InboxPointingRow>> {
     Ok(sqlx::query_as::<_, InboxPointingRow>(
         "SELECT relative_file_path, ra_deg, dec_deg, focal_length_mm,
-                pixel_size_um, naxis1, naxis2, object
+                pixel_size_um, naxis1, naxis2, rotator_angle_deg, object
          FROM inbox_file_metadata
          WHERE inbox_item_id = ?
          ORDER BY relative_file_path",

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -1226,12 +1226,17 @@ pub async fn list_inbox_file_metadata(
 /// Per-file pointing + optics, read for coordinate-based target resolution.
 ///
 /// Sourced from `inbox_file_metadata` (the T062 extended columns added in
-/// migration 0048; `rotator_angle_deg` added in migration 0049). All fields
-/// are nullable — best-effort extraction. The caller derives a sub-group
-/// pointing (e.g. the first file carrying RA/Dec) and a FOV-aware radius from
-/// `focal_length_mm`/`pixel_size_um`/`naxis1/2`, optionally rotated by
-/// `rotator_angle_deg` (`ROTATANG`/`ROTATOR`, the flat↔light match key — NOT
-/// `sky_rotation_deg`/`OBJCTROT`, which is informational only).
+/// migration 0048; `rotator_angle_deg`/`sky_rotation_deg` added in migration
+/// 0049). All fields are nullable — best-effort extraction. The caller
+/// derives a sub-group pointing (e.g. the first file carrying RA/Dec) and a
+/// FOV-aware radius from `focal_length_mm`/`pixel_size_um`/`naxis1/2`.
+///
+/// Two rotation fields, two different consumers — never conflate them:
+/// `rotator_angle_deg` (`ROTATANG`/`ROTATOR`) is the mechanical rotator
+/// angle, the flat↔light match key (R-18, used by `grouping`); it is NOT a
+/// sky-frame angle. `sky_rotation_deg` (`OBJCTROT`) is the true sky position
+/// angle (East of North) — the one FOV frame-rotation matching
+/// (`target_recommendations`) needs for `Constraint::frame_rotated`.
 #[derive(Clone, Debug, Default, sqlx::FromRow)]
 pub struct InboxPointingRow {
     pub relative_file_path: String,
@@ -1242,6 +1247,7 @@ pub struct InboxPointingRow {
     pub naxis1: Option<i64>,
     pub naxis2: Option<i64>,
     pub rotator_angle_deg: Option<f64>,
+    pub sky_rotation_deg: Option<f64>,
     /// Raw `OBJECT` header value — display hint only, NEVER a matching key (R-17).
     pub object: Option<String>,
 }
@@ -1260,7 +1266,7 @@ pub async fn list_inbox_pointing(
 ) -> DbResult<Vec<InboxPointingRow>> {
     Ok(sqlx::query_as::<_, InboxPointingRow>(
         "SELECT relative_file_path, ra_deg, dec_deg, focal_length_mm,
-                pixel_size_um, naxis1, naxis2, rotator_angle_deg, object
+                pixel_size_um, naxis1, naxis2, rotator_angle_deg, sky_rotation_deg, object
          FROM inbox_file_metadata
          WHERE inbox_item_id = ?
          ORDER BY relative_file_path",

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -14,6 +14,7 @@ path = "src/lib.rs"
 # `targeting_resolver` crate so pure consumers no longer pull that weight.
 
 [dependencies]
+target-match = "0.1"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 unicode-normalization.workspace = true
 

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -14,7 +14,8 @@ path = "src/lib.rs"
 # `targeting_resolver` crate so pure consumers no longer pull that weight.
 
 [dependencies]
-target-match = "0.1"
+target-match = "0.2"
+skymath = "0.1"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 unicode-normalization.workspace = true
 

--- a/crates/targeting/src/astro_format.rs
+++ b/crates/targeting/src/astro_format.rs
@@ -1,0 +1,63 @@
+//! Sexagesimal RA/Dec display formatting.
+//!
+//! Thin wrapper over `target_match::Equatorial::ra_to_sexagesimal` /
+//! `dec_to_sexagesimal`, which round at the requested precision *before*
+//! decomposing into degrees/minutes/seconds — carry-safe, so a value like
+//! `59.6"` never rolls over to an invalid `"...:60"` field the way a naive
+//! `seconds.toFixed(0)` on the raw remainder can.
+
+use crate::coords::{self, Pointing};
+
+/// A target's RA/Dec formatted as sexagesimal strings: `HH:MM:SS` for RA,
+/// `±DD:MM:SS` for Dec (0 fractional-second digits).
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SexagesimalCoords {
+    pub ra: String,
+    pub dec: String,
+}
+
+/// Format decimal-degree RA/Dec as sexagesimal strings.
+///
+/// Returns `None` when either coordinate is non-finite (NaN/±inf) — never a
+/// fabricated string. Out-of-domain-but-finite input is wrapped/clamped into
+/// domain first (see [`coords::to_equatorial`]).
+#[must_use]
+pub fn sexagesimal(ra_deg: f64, dec_deg: f64) -> Option<SexagesimalCoords> {
+    if !ra_deg.is_finite() || !dec_deg.is_finite() {
+        return None;
+    }
+    let eq = coords::to_equatorial(Pointing::new(ra_deg, dec_deg));
+    Some(SexagesimalCoords { ra: eq.ra_to_sexagesimal(0), dec: eq.dec_to_sexagesimal(0) })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn formats_m31() {
+        // M31: RA 10.6847deg = 00:42:44, Dec 41.2688deg = +41:16:08(ish).
+        let s = sexagesimal(10.6847, 41.2688).unwrap();
+        assert!(s.ra.starts_with("00:42:44"), "ra={}", s.ra);
+        assert!(s.dec.starts_with("+41:16:"), "dec={}", s.dec);
+    }
+
+    #[test]
+    fn seconds_never_roll_over_to_60() {
+        // A value engineered to be within rounding distance of a 60s carry.
+        let s = sexagesimal(0.0, 44.999_999_999).unwrap();
+        assert!(!s.dec.contains(":60"), "dec={}", s.dec);
+    }
+
+    #[test]
+    fn non_finite_is_none() {
+        assert!(sexagesimal(f64::NAN, 0.0).is_none());
+        assert!(sexagesimal(0.0, f64::INFINITY).is_none());
+    }
+
+    #[test]
+    fn negative_dec_keeps_sign() {
+        let s = sexagesimal(10.0, -5.5).unwrap();
+        assert!(s.dec.starts_with('-'), "dec={}", s.dec);
+    }
+}

--- a/crates/targeting/src/astro_format.rs
+++ b/crates/targeting/src/astro_format.rs
@@ -1,12 +1,17 @@
 //! Sexagesimal RA/Dec display formatting.
 //!
-//! Thin wrapper over `target_match::Equatorial::ra_to_sexagesimal` /
-//! `dec_to_sexagesimal`, which round at the requested precision *before*
-//! decomposing into degrees/minutes/seconds — carry-safe, so a value like
-//! `59.6"` never rolls over to an invalid `"...:60"` field the way a naive
-//! `seconds.toFixed(0)` on the raw remainder can.
+//! Thin wrapper over `skymath::Equatorial::ra_sexagesimal`/`dec_sexagesimal`,
+//! which round at the requested precision *before* decomposing into
+//! degrees/minutes/seconds — carry-safe, so a value like `59.6"` never rolls
+//! over to an invalid `"...:60"` field the way a naive `seconds.toFixed(0)`
+//! on the raw remainder can.
+
+use skymath::{Separator, SexaStyle};
 
 use crate::coords::{self, Pointing};
+
+/// Colon-separated, 0 fractional-second-digit style (`HH:MM:SS` / `±DD:MM:SS`).
+const DISPLAY_STYLE: SexaStyle = SexaStyle { separator: Separator::Colons, seconds_places: 0 };
 
 /// A target's RA/Dec formatted as sexagesimal strings: `HH:MM:SS` for RA,
 /// `±DD:MM:SS` for Dec (0 fractional-second digits).
@@ -27,7 +32,10 @@ pub fn sexagesimal(ra_deg: f64, dec_deg: f64) -> Option<SexagesimalCoords> {
         return None;
     }
     let eq = coords::to_equatorial(Pointing::new(ra_deg, dec_deg));
-    Some(SexagesimalCoords { ra: eq.ra_to_sexagesimal(0), dec: eq.dec_to_sexagesimal(0) })
+    Some(SexagesimalCoords {
+        ra: eq.ra_sexagesimal(DISPLAY_STYLE),
+        dec: eq.dec_sexagesimal(DISPLAY_STYLE),
+    })
 }
 
 #[cfg(test)]

--- a/crates/targeting/src/astro_format.rs
+++ b/crates/targeting/src/astro_format.rs
@@ -5,23 +5,30 @@
 //! degrees/minutes/seconds — carry-safe, so a value like `59.6"` never rolls
 //! over to an invalid `"...:60"` field the way a naive `seconds.toFixed(0)`
 //! on the raw remainder can.
+//!
+//! skymath exposes no h/m/s (or d/m/s) component accessors — only the fully
+//! formatted colon/space-separated string — so the astronomy-notation display
+//! (`HHhMMmSSs` / `±DD°MM′SS″`, matching the deleted TS `fmtRa`/`fmtDec`) is
+//! produced by splitting skymath's colon-separated, carry-already-applied
+//! string on `:` and re-joining with the display glyphs; the carry itself
+//! still happens inside skymath, this only changes field separators.
 
 use skymath::{Separator, SexaStyle};
 
 use crate::coords::{self, Pointing};
 
 /// Colon-separated, 0 fractional-second-digit style (`HH:MM:SS` / `±DD:MM:SS`).
-const DISPLAY_STYLE: SexaStyle = SexaStyle { separator: Separator::Colons, seconds_places: 0 };
+const COLON_STYLE: SexaStyle = SexaStyle { separator: Separator::Colons, seconds_places: 0 };
 
-/// A target's RA/Dec formatted as sexagesimal strings: `HH:MM:SS` for RA,
-/// `±DD:MM:SS` for Dec (0 fractional-second digits).
+/// A target's RA/Dec formatted in astronomy notation: `HHhMMmSSs` for RA,
+/// `±DD°MM′SS″` for Dec (negative sign is U+2212, not the ASCII hyphen).
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SexagesimalCoords {
     pub ra: String,
     pub dec: String,
 }
 
-/// Format decimal-degree RA/Dec as sexagesimal strings.
+/// Format decimal-degree RA/Dec as astronomy-notation sexagesimal strings.
 ///
 /// Returns `None` when either coordinate is non-finite (NaN/±inf) — never a
 /// fabricated string. Out-of-domain-but-finite input is wrapped/clamped into
@@ -33,9 +40,29 @@ pub fn sexagesimal(ra_deg: f64, dec_deg: f64) -> Option<SexagesimalCoords> {
     }
     let eq = coords::to_equatorial(Pointing::new(ra_deg, dec_deg));
     Some(SexagesimalCoords {
-        ra: eq.ra_sexagesimal(DISPLAY_STYLE),
-        dec: eq.dec_sexagesimal(DISPLAY_STYLE),
+        ra: ra_glyphs(&eq.ra_sexagesimal(COLON_STYLE)),
+        dec: dec_glyphs(&eq.dec_sexagesimal(COLON_STYLE)),
     })
+}
+
+/// `"HH:MM:SS"` → `"HHhMMmSSs"`.
+fn ra_glyphs(colon: &str) -> String {
+    let mut f = colon.splitn(3, ':');
+    let (h, m, s) = (f.next().unwrap_or(""), f.next().unwrap_or(""), f.next().unwrap_or(""));
+    format!("{h}h{m}m{s}s")
+}
+
+/// `"+DD:MM:SS"` / `"-DD:MM:SS"` → `"±DD°MM′SS″"`, with U+2212 (minus sign)
+/// for negative — never the ASCII hyphen `format_dec` emits.
+fn dec_glyphs(colon: &str) -> String {
+    let (sign, rest) = colon
+        .strip_prefix('-')
+        .map(|r| ("\u{2212}", r))
+        .or_else(|| colon.strip_prefix('+').map(|r| ("+", r)))
+        .unwrap_or(("+", colon));
+    let mut f = rest.splitn(3, ':');
+    let (d, m, s) = (f.next().unwrap_or(""), f.next().unwrap_or(""), f.next().unwrap_or(""));
+    format!("{sign}{d}\u{b0}{m}\u{2032}{s}\u{2033}")
 }
 
 #[cfg(test)]
@@ -43,29 +70,32 @@ mod tests {
     use super::*;
 
     #[test]
-    fn formats_m31() {
-        // M31: RA 10.6847deg = 00:42:44, Dec 41.2688deg = +41:16:08(ish).
+    fn formats_m31_exact_glyphs() {
+        // M31: RA 10.6847deg -> 00h42m44s, Dec 41.2688deg -> +41°16′08″.
         let s = sexagesimal(10.6847, 41.2688).unwrap();
-        assert!(s.ra.starts_with("00:42:44"), "ra={}", s.ra);
-        assert!(s.dec.starts_with("+41:16:"), "dec={}", s.dec);
+        assert_eq!(s.ra, "00h42m44s");
+        assert_eq!(s.dec, "+41\u{b0}16\u{2032}08\u{2033}");
     }
 
     #[test]
-    fn seconds_never_roll_over_to_60() {
-        // A value engineered to be within rounding distance of a 60s carry.
+    fn negative_dec_uses_u2212_not_ascii_hyphen() {
+        let s = sexagesimal(10.0, -5.5).unwrap();
+        assert_eq!(s.dec, "\u{2212}05\u{b0}30\u{2032}00\u{2033}");
+        assert!(!s.dec.starts_with('-'), "must be U+2212, not ASCII hyphen: {}", s.dec);
+    }
+
+    #[test]
+    fn seconds_carry_never_shows_60_and_keeps_glyphs() {
+        // 44.999_999_999° Dec rounds its seconds field up into the next minute;
+        // must land on a valid glyph string, never "...′60″".
         let s = sexagesimal(0.0, 44.999_999_999).unwrap();
-        assert!(!s.dec.contains(":60"), "dec={}", s.dec);
+        assert_eq!(s.dec, "+45\u{b0}00\u{2032}00\u{2033}");
+        assert!(!s.dec.contains("60\u{2033}"), "dec={}", s.dec);
     }
 
     #[test]
     fn non_finite_is_none() {
         assert!(sexagesimal(f64::NAN, 0.0).is_none());
         assert!(sexagesimal(0.0, f64::INFINITY).is_none());
-    }
-
-    #[test]
-    fn negative_dec_keeps_sign() {
-        let s = sexagesimal(10.0, -5.5).unwrap();
-        assert!(s.dec.starts_with('-'), "dec={}", s.dec);
     }
 }

--- a/crates/targeting/src/coords.rs
+++ b/crates/targeting/src/coords.rs
@@ -22,12 +22,16 @@
 
 #![allow(clippy::doc_markdown)] // domain terminology (RA/Dec, FOV) is not backtick-suited
 
+use target_match::{Angle, Equatorial, Field, Optics, RadiusPolicy};
+
 /// A sky pointing in ICRS J2000 decimal degrees.
 ///
 /// `ra_deg` is right ascension in `[0, 360)`; `dec_deg` is declination in
 /// `[-90, 90]`. Inputs are not re-validated here (the caller extracts them from
 /// already-validated metadata); out-of-domain values still produce a finite
-/// separation via the haversine form.
+/// separation via the haversine form (RA is wrapped into `[0, 360)` and Dec is
+/// clamped into `[-90, 90]` before the underlying `target_match::Equatorial` is
+/// built, since that type rejects out-of-domain input outright).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Pointing {
     /// Right ascension, decimal degrees.
@@ -76,43 +80,50 @@ pub struct Candidate {
 
 /// Great-circle angular separation between two pointings, in decimal degrees.
 ///
-/// Uses the numerically-stable haversine form (robust for the small separations
-/// that dominate target matching, where the law-of-cosines form loses
-/// precision). The result is in `[0, 180]`.
+/// Delegates to `target_match::separation` (numerically-stable haversine form,
+/// robust for the small separations that dominate target matching, where the
+/// law-of-cosines form loses precision). The result is in `[0, 180]`.
+///
+/// A non-finite input on either pointing yields `NaN` (matching the previous
+/// permissive behaviour), rather than the domain-validation error
+/// `target_match::Equatorial::new` would otherwise raise.
 #[must_use]
 pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
-    let ra1 = a.ra_deg.to_radians();
-    let dec1 = a.dec_deg.to_radians();
-    let ra2 = b.ra_deg.to_radians();
-    let dec2 = b.dec_deg.to_radians();
+    if !a.ra_deg.is_finite()
+        || !a.dec_deg.is_finite()
+        || !b.ra_deg.is_finite()
+        || !b.dec_deg.is_finite()
+    {
+        return f64::NAN;
+    }
+    target_match::separation(to_equatorial(a), to_equatorial(b)).degrees()
+}
 
-    let dra = ra2 - ra1;
-    let ddec = dec2 - dec1;
-
-    let sin_ddec = (ddec / 2.0).sin();
-    let sin_dra = (dra / 2.0).sin();
-
-    // haversine: hav(θ) = sin²(Δδ/2) + cos δ1 · cos δ2 · sin²(Δα/2)
-    let h = sin_ddec.mul_add(sin_ddec, dec1.cos() * dec2.cos() * sin_dra * sin_dra);
-    // Clamp guards against tiny FP excursions above 1.0 before asin.
-    let central = 2.0 * h.sqrt().clamp(0.0, 1.0).asin();
-    central.to_degrees()
+/// Build a `target_match::Equatorial` from a (already-finite) [`Pointing`],
+/// wrapping RA into `[0, 360)` and clamping Dec into `[-90, 90]` so
+/// out-of-domain-but-finite inputs still produce a position rather than an
+/// error (see the [`Pointing`] docs).
+fn to_equatorial(p: Pointing) -> Equatorial {
+    let ra = Angle::from_degrees(p.ra_deg).normalized_0_360();
+    let dec = Angle::from_degrees(p.dec_deg.clamp(-90.0, 90.0));
+    Equatorial::j2000(ra, dec).expect("ra normalized to [0, 360), dec clamped to [-90, 90]")
 }
 
 /// Compute a FOV-aware search radius (decimal degrees) from optics + sensor.
 ///
-/// The radius is **half the sensor diagonal field of view**, so any catalog
-/// target whose true position lies anywhere on the frame is inside the radius
-/// regardless of where in the frame it sits.
-///
-/// Geometry (small-angle pixel scale, exact frame angle):
-/// - pixel scale (arcsec/px) = `206.265 × pixel_size_um / focal_length_mm`
-/// - frame width/height (deg) = pixel-scale × `naxis` / 3600
-/// - radius (deg) = ½ · hypot(width, height)
+/// The radius is **half the sensor diagonal field of view** (`target_match`'s
+/// [`RadiusPolicy::Circumscribed`]), so any catalog target whose true position
+/// lies anywhere on the frame is inside the radius regardless of where in the
+/// frame it sits. Delegates the pixel-scale/field-of-view geometry to
+/// `target_match::Field::from_optics`, which uses the exact arcsec-per-radian
+/// constant (`206_264.806…`) rather than the rounded `206.265` this function
+/// used previously. Binning is fixed at `(1, 1)`: no binning factor is tracked
+/// by the caller's per-file metadata.
 ///
 /// Returns `None` when any input is missing or non-positive (so the caller can
-/// fall back to the configurable fixed radius, R-17 C5). `focal_length_mm` and
-/// `pixel_size_um` must be `> 0`; `naxis1`/`naxis2` must be `> 0`.
+/// fall back to the configurable fixed radius, R-17 C5), or when `naxis1`/
+/// `naxis2` overflow `u32`. `focal_length_mm` and `pixel_size_um` must be
+/// `> 0`; `naxis1`/`naxis2` must be `> 0`.
 #[must_use]
 pub fn fov_radius_deg(
     focal_length_mm: Option<f64>,
@@ -122,18 +133,17 @@ pub fn fov_radius_deg(
 ) -> Option<f64> {
     let focal = focal_length_mm.filter(|v| v.is_finite() && *v > 0.0)?;
     let pixel = pixel_size_um.filter(|v| v.is_finite() && *v > 0.0)?;
-    let nx = naxis1.filter(|v| *v > 0)?;
-    let ny = naxis2.filter(|v| *v > 0)?;
+    let nx = naxis1.filter(|v| *v > 0).and_then(|v| u32::try_from(v).ok())?;
+    let ny = naxis2.filter(|v| *v > 0).and_then(|v| u32::try_from(v).ok())?;
 
-    // arcsec per pixel = 206.265 * pixel_size_um / focal_length_mm
-    let pixel_scale_arcsec = 206.265 * pixel / focal;
-    // frame extents in degrees
-    #[allow(clippy::cast_precision_loss)] // sensor dims are small enough to be exact in f64
-    let width_deg = pixel_scale_arcsec * (nx as f64) / 3600.0;
-    #[allow(clippy::cast_precision_loss)]
-    let height_deg = pixel_scale_arcsec * (ny as f64) / 3600.0;
-
-    Some(width_deg.hypot(height_deg) / 2.0)
+    let field = Field::from_optics(Optics {
+        focal_mm: focal,
+        pixel_um: (pixel, pixel),
+        binning: (1, 1),
+        pixels: (nx, ny),
+    })
+    .ok()?;
+    Some(field.radius(RadiusPolicy::Circumscribed).degrees())
 }
 
 /// Rank catalog targets by angular separation from `pointing`, keeping only

--- a/crates/targeting/src/coords.rs
+++ b/crates/targeting/src/coords.rs
@@ -99,14 +99,54 @@ pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
     target_match::separation(to_equatorial(a), to_equatorial(b)).degrees()
 }
 
-/// Build a `target_match::Equatorial` from a (already-finite) [`Pointing`],
-/// wrapping RA into `[0, 360)` and clamping Dec into `[-90, 90]` so
-/// out-of-domain-but-finite inputs still produce a position rather than an
-/// error (see the [`Pointing`] docs).
-fn to_equatorial(p: Pointing) -> Equatorial {
+/// Build a `target_match::Equatorial` from a [`Pointing`], wrapping RA into
+/// `[0, 360)` and clamping Dec into `[-90, 90]` so out-of-domain-but-finite
+/// inputs still produce a position rather than an error (see the [`Pointing`]
+/// docs).
+///
+/// # Panics
+/// Panics if `p.ra_deg` or `p.dec_deg` is non-finite (NaN/±inf) — callers with
+/// possibly-non-finite input (e.g. an unvalidated catalog row) MUST filter
+/// first; [`angular_separation_deg`] does this internally.
+#[must_use]
+pub fn to_equatorial(p: Pointing) -> Equatorial {
     let ra = Angle::from_degrees(p.ra_deg).normalized_0_360();
     let dec = Angle::from_degrees(p.dec_deg.clamp(-90.0, 90.0));
     Equatorial::j2000(ra, dec).expect("ra normalized to [0, 360), dec clamped to [-90, 90]")
+}
+
+/// Build a `target_match::Field` from optics + sensor pixel counts
+/// (best-effort), for exact rectangular (optionally rotated) frame membership
+/// via `target_match::Constraint::frame`/`frame_rotated`.
+///
+/// Pixels are assumed square (`pixel_size_um` applies to both axes) and
+/// binning is fixed at `(1, 1)`: neither per-axis pixel size nor a binning
+/// factor is tracked by the caller's per-file metadata. Delegates to
+/// `target_match::Field::from_optics`, which uses the exact arcsec-per-radian
+/// constant (`206_264.806…`) rather than a rounded approximation.
+///
+/// Returns `None` when any input is missing or non-positive, or when
+/// `naxis1`/`naxis2` overflow `u32`. `focal_length_mm` and `pixel_size_um`
+/// must be `> 0`; `naxis1`/`naxis2` must be `> 0`.
+#[must_use]
+pub fn field_from_optics(
+    focal_length_mm: Option<f64>,
+    pixel_size_um: Option<f64>,
+    naxis1: Option<i64>,
+    naxis2: Option<i64>,
+) -> Option<Field> {
+    let focal = focal_length_mm.filter(|v| v.is_finite() && *v > 0.0)?;
+    let pixel = pixel_size_um.filter(|v| v.is_finite() && *v > 0.0)?;
+    let nx = naxis1.filter(|v| *v > 0).and_then(|v| u32::try_from(v).ok())?;
+    let ny = naxis2.filter(|v| *v > 0).and_then(|v| u32::try_from(v).ok())?;
+
+    Field::from_optics(Optics {
+        focal_mm: focal,
+        pixel_um: (pixel, pixel),
+        binning: (1, 1),
+        pixels: (nx, ny),
+    })
+    .ok()
 }
 
 /// Compute a FOV-aware search radius (decimal degrees) from optics + sensor.
@@ -114,16 +154,11 @@ fn to_equatorial(p: Pointing) -> Equatorial {
 /// The radius is **half the sensor diagonal field of view** (`target_match`'s
 /// [`RadiusPolicy::Circumscribed`]), so any catalog target whose true position
 /// lies anywhere on the frame is inside the radius regardless of where in the
-/// frame it sits. Delegates the pixel-scale/field-of-view geometry to
-/// `target_match::Field::from_optics`, which uses the exact arcsec-per-radian
-/// constant (`206_264.806…`) rather than the rounded `206.265` this function
-/// used previously. Binning is fixed at `(1, 1)`: no binning factor is tracked
-/// by the caller's per-file metadata.
+/// frame it sits. See [`field_from_optics`] for the underlying geometry.
 ///
-/// Returns `None` when any input is missing or non-positive (so the caller can
-/// fall back to the configurable fixed radius, R-17 C5), or when `naxis1`/
-/// `naxis2` overflow `u32`. `focal_length_mm` and `pixel_size_um` must be
-/// `> 0`; `naxis1`/`naxis2` must be `> 0`.
+/// Returns `None` when [`field_from_optics`] does (missing/non-positive input,
+/// or `naxis1`/`naxis2` overflowing `u32`), so the caller can fall back to the
+/// configurable fixed radius (R-17 C5).
 #[must_use]
 pub fn fov_radius_deg(
     focal_length_mm: Option<f64>,
@@ -131,19 +166,8 @@ pub fn fov_radius_deg(
     naxis1: Option<i64>,
     naxis2: Option<i64>,
 ) -> Option<f64> {
-    let focal = focal_length_mm.filter(|v| v.is_finite() && *v > 0.0)?;
-    let pixel = pixel_size_um.filter(|v| v.is_finite() && *v > 0.0)?;
-    let nx = naxis1.filter(|v| *v > 0).and_then(|v| u32::try_from(v).ok())?;
-    let ny = naxis2.filter(|v| *v > 0).and_then(|v| u32::try_from(v).ok())?;
-
-    let field = Field::from_optics(Optics {
-        focal_mm: focal,
-        pixel_um: (pixel, pixel),
-        binning: (1, 1),
-        pixels: (nx, ny),
-    })
-    .ok()?;
-    Some(field.radius(RadiusPolicy::Circumscribed).degrees())
+    field_from_optics(focal_length_mm, pixel_size_um, naxis1, naxis2)
+        .map(|f| f.radius(RadiusPolicy::Circumscribed).degrees())
 }
 
 /// Rank catalog targets by angular separation from `pointing`, keeping only

--- a/crates/targeting/src/coords.rs
+++ b/crates/targeting/src/coords.rs
@@ -22,7 +22,8 @@
 
 #![allow(clippy::doc_markdown)] // domain terminology (RA/Dec, FOV) is not backtick-suited
 
-use target_match::{Angle, Equatorial, Field, Optics, RadiusPolicy};
+use skymath::{Angle, Equatorial};
+use target_match::{Field, Optics, RadiusPolicy};
 
 /// A sky pointing in ICRS J2000 decimal degrees.
 ///
@@ -30,7 +31,7 @@ use target_match::{Angle, Equatorial, Field, Optics, RadiusPolicy};
 /// `[-90, 90]`. Inputs are not re-validated here (the caller extracts them from
 /// already-validated metadata); out-of-domain values still produce a finite
 /// separation via the haversine form (RA is wrapped into `[0, 360)` and Dec is
-/// clamped into `[-90, 90]` before the underlying `target_match::Equatorial` is
+/// clamped into `[-90, 90]` before the underlying `skymath::Equatorial` is
 /// built, since that type rejects out-of-domain input outright).
 #[derive(Clone, Copy, Debug, PartialEq)]
 pub struct Pointing {
@@ -80,13 +81,13 @@ pub struct Candidate {
 
 /// Great-circle angular separation between two pointings, in decimal degrees.
 ///
-/// Delegates to `target_match::separation` (numerically-stable haversine form,
+/// Delegates to `skymath::separation` (numerically-stable haversine form,
 /// robust for the small separations that dominate target matching, where the
 /// law-of-cosines form loses precision). The result is in `[0, 180]`.
 ///
 /// A non-finite input on either pointing yields `NaN` (matching the previous
 /// permissive behaviour), rather than the domain-validation error
-/// `target_match::Equatorial::new` would otherwise raise.
+/// `skymath::Equatorial::at_epoch` would otherwise raise.
 #[must_use]
 pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
     if !a.ra_deg.is_finite()
@@ -96,10 +97,10 @@ pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
     {
         return f64::NAN;
     }
-    target_match::separation(to_equatorial(a), to_equatorial(b)).degrees()
+    skymath::separation(to_equatorial(a), to_equatorial(b)).degrees()
 }
 
-/// Build a `target_match::Equatorial` from a [`Pointing`], wrapping RA into
+/// Build a `skymath::Equatorial` from a [`Pointing`], wrapping RA into
 /// `[0, 360)` and clamping Dec into `[-90, 90]` so out-of-domain-but-finite
 /// inputs still produce a position rather than an error (see the [`Pointing`]
 /// docs).

--- a/crates/targeting/src/lib.rs
+++ b/crates/targeting/src/lib.rs
@@ -7,6 +7,8 @@
 //! - [`coords`]: coordinate-based nearest-neighbour target resolution
 //!   (haversine separation + FOV-aware radius + ranking; spec 041 R-17/R-18),
 //!   now built on the `target-match` crate's coordinate primitives.
+//! - [`astro_format`]: sexagesimal RA/Dec display formatting (carry-safe
+//!   rounding via `target_match::Equatorial`).
 //!
 //! `Angle`, `Equatorial`, `Epoch`, and `separation` are re-exported from
 //! `target_match` so downstream crates get one coordinate-primitive dependency
@@ -23,6 +25,7 @@
 
 #![allow(clippy::doc_markdown)] // spec/domain terminology is not suited for backticks
 
+pub mod astro_format;
 pub mod coords;
 pub mod identity;
 pub mod normalize;

--- a/crates/targeting/src/lib.rs
+++ b/crates/targeting/src/lib.rs
@@ -6,14 +6,17 @@
 //! - [`identity`]: deterministic UUIDv5 generation for `canonical_target.id`.
 //! - [`coords`]: coordinate-based nearest-neighbour target resolution
 //!   (haversine separation + FOV-aware radius + ranking; spec 041 R-17/R-18),
-//!   now built on the `target-match` crate's coordinate primitives.
+//!   now built on the `skymath` crate's coordinate primitives (`target-match`
+//!   0.2 dropped its own copies in favour of `skymath`).
 //! - [`astro_format`]: sexagesimal RA/Dec display formatting (carry-safe
-//!   rounding via `target_match::Equatorial`).
+//!   rounding via `skymath::Equatorial`).
 //!
 //! `Angle`, `Equatorial`, `Epoch`, and `separation` are re-exported from
-//! `target_match` so downstream crates get one coordinate-primitive dependency
-//! (via `targeting`) rather than each pulling `target-match` directly for basic
-//! RA/Dec/angle types.
+//! `skymath` (NOT `target_match`, which no longer has its own copies) so
+//! downstream crates get one coordinate-primitive dependency (via `targeting`)
+//! rather than each pulling `skymath` directly for basic RA/Dec/angle types.
+//! `Field` stays a `target_match`-owned type (FOV/optics geometry has no
+//! `skymath` equivalent).
 //!
 //! The on-demand SIMBAD resolver, the SQLite resolution cache, and the
 //! bundled-seed loader (spec 035) live in the sibling `targeting_resolver`
@@ -30,7 +33,8 @@ pub mod coords;
 pub mod identity;
 pub mod normalize;
 
-pub use target_match::{separation, Angle, Epoch, Equatorial, Field};
+pub use skymath::{separation, Angle, Epoch, Equatorial};
+pub use target_match::Field;
 
 pub const CRATE_NAME: &str = "targeting";
 

--- a/crates/targeting/src/lib.rs
+++ b/crates/targeting/src/lib.rs
@@ -27,7 +27,7 @@ pub mod coords;
 pub mod identity;
 pub mod normalize;
 
-pub use target_match::{separation, Angle, Epoch, Equatorial};
+pub use target_match::{separation, Angle, Epoch, Equatorial, Field};
 
 pub const CRATE_NAME: &str = "targeting";
 

--- a/crates/targeting/src/lib.rs
+++ b/crates/targeting/src/lib.rs
@@ -5,7 +5,13 @@
 //! - [`normalize`]: query normalization pipeline (casefold, NFKC, prefix expansion).
 //! - [`identity`]: deterministic UUIDv5 generation for `canonical_target.id`.
 //! - [`coords`]: coordinate-based nearest-neighbour target resolution
-//!   (haversine separation + FOV-aware radius + ranking; spec 041 R-17/R-18).
+//!   (haversine separation + FOV-aware radius + ranking; spec 041 R-17/R-18),
+//!   now built on the `target-match` crate's coordinate primitives.
+//!
+//! `Angle`, `Equatorial`, `Epoch`, and `separation` are re-exported from
+//! `target_match` so downstream crates get one coordinate-primitive dependency
+//! (via `targeting`) rather than each pulling `target-match` directly for basic
+//! RA/Dec/angle types.
 //!
 //! The on-demand SIMBAD resolver, the SQLite resolution cache, and the
 //! bundled-seed loader (spec 035) live in the sibling `targeting_resolver`
@@ -20,6 +26,8 @@
 pub mod coords;
 pub mod identity;
 pub mod normalize;
+
+pub use target_match::{separation, Angle, Epoch, Equatorial};
 
 pub const CRATE_NAME: &str = "targeting";
 


### PR DESCRIPTION
## Summary
Target matching now accounts for field of view and camera rotation, not just
coordinates, and unifies RA/Dec sexagesimal parsing/formatting that previously
existed as separate half-implementations on each side of the IPC boundary.

## What's new
- Target matching considers FOV and rotation when identifying frames
- RA/Dec sexagesimal parsing and formatting is now a single shared
  implementation (frontend and backend agree)

## Test plan
- full workspace cargo test: 2070 passed
- clippy/fmt/tsc clean
- vitest: 1322 passed
- bindings diff: empty

closes #594, closes #595