### PR TITLE
chore(desktop): rename Tauri productName to PlateVault

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
-  "productName": "Astro Library Manager",
+  "productName": "PlateVault",
   "version": "0.4.0",
   "identifier": "dev.astro-plan.astro-library-manager",
   "build": {


### PR DESCRIPTION
## What

Set the Tauri `productName` to **PlateVault** (was `Astro Library Manager`).

## Why

The app was renamed to PlateVault, but release bundles were still branded with the old name — e.g. `Astro.Library.Manager_0.4.0_x64_en-US.msi` in the v0.4.0 assets. This makes installer/updater filenames, Windows Start Menu entries, and the macOS `.app` bundle match the product name. The window title was already `PlateVault`.

## Scope / what is intentionally **not** changed

- **`identifier` stays `dev.astro-plan.astro-library-manager`.** It keys the app-data directory, the Windows MSI upgrade code, the updater identity, and the `APP_IDENTIFIER` constant in `crates/e2e-tests`. Renaming it would move user data and break in-place upgrades and E2E tests.
- Cosmetic references to "Astro Library Manager" in doc comments and `packages/contracts` schema `$id`/title are left as-is (not artifact-facing).

## Risk

Windows keys installs on `productName`, so existing v0.x installs will **not** upgrade in place to a PlateVault-named build (they'd get a second install). Acceptable for a days-old pre-1.0 app with no external users. The auto-update **endpoint** is unaffected — it's a fixed `latest.json` URL, independent of artifact filenames.

## Verification

- CI (Layer-1 integration on all 3 OS) must stay green — no test asserts the old product-name string (`grep` confirms only `identifier` is referenced, and that's unchanged).
- The rename takes visible effect on the **next release**, whose bundle assets will be `PlateVault_*` instead of `Astro.Library.Manager_*`.
