### PR TITLE
chore: unify on skymath 0.3 and target-match 0.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1430,7 +1430,7 @@ dependencies = [
 
 [[package]]
 name = "desktop_shell"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "app_core",
  "audit",
@@ -5544,9 +5544,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skymath"
-version = "0.1.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6315a9ee05a1b250fb7562b5a057342352ae7db06dc924ebfe3d0c90506db0d3"
+checksum = "98d582775f713520fed98cc8fd1ecaac9ca87f11447b557c0ab3892bf9af9cbe"
 dependencies = [
  "thiserror 2.0.18",
  "time",
@@ -6146,9 +6146,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-match"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f751172247ddff306ab714fbfc3cca07fe919c753b6388a620577d8f7c258c"
+checksum = "5e2e3f70f5c67c7a6fc75a2b0afd4bf22c27228d0e08a76af481a25b8b2e2ec9"
 dependencies = [
  "skymath",
  "thiserror 2.0.18",

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -29,9 +29,9 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
-skymath = "0.1"
+skymath = "0.3"
 sqlx.workspace = true
-target-match = "0.2"
+target-match = "0.3"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-skymath = "0.1"
+skymath = "0.3"
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -14,8 +14,8 @@ path = "src/lib.rs"
 # `targeting_resolver` crate so pure consumers no longer pull that weight.
 
 [dependencies]
-target-match = "0.2"
-skymath = "0.1"
+target-match = "0.3"
+skymath = "0.3"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 unicode-normalization.workspace = true
 


### PR DESCRIPTION
## Summary

- Bumps `skymath` 0.1 → 0.3 (`crates/metadata/core`, `crates/targeting`, `crates/app/inbox`) and `target-match` 0.2 → 0.3 (`crates/targeting`, `crates/app/inbox`) so the workspace shares a single skymath type identity with target-match's re-exported coordinate types. Pre-1.0 caret semantics would otherwise split `Equatorial`/`Angle` into incompatible duplicates once anything here starts calling skymath's newer planning surface directly.
- No code changes. Upstream releases are additive over the API in use (skymath 0.2 = sun/moon ephemerides, 0.3 = constellation identification; target-match 0.3 = the same type unification on its side).
- Local gate green: fmt, clippy -D warnings, `cargo nextest run --workspace`, workspace doctests, contract generation + tauri-specta bindings test with zero generated-file drift.

## Notes

This also unblocks wiring skymath's twilight / lunar-separation / moon-avoidance / constellation APIs into planning features as a future spec — the types now line up across the dependency graph.