### PR TITLE
spec(052): SIMBAD resolver caching, dual-lookup, cone-search

### DIFF
--- a/specs/052-simbad-caching-dual-lookup-cone-search/contracts/operations.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/contracts/operations.md
@@ -1,0 +1,108 @@
+# Contracts: SIMBAD Resolver Caching, Dual-Lookup, and Cone-Search
+
+**Feature**: 052-simbad-caching-dual-lookup-cone-search | **Date**: 2026-07-12
+
+Language-neutral operation contracts (Constitution V). Realized as Rust DTOs in `crates/contracts/core`, exposed via Tauri commands, and generated into `packages/contracts` TS bindings (tauri-specta). Command names below are canonical; the registered Tauri fn name MUST match the invoke target exactly (no specta rename on the invoke target — known pitfall). All requests/responses carry the standard result-wrapper + error-code envelope (spec-046 error-code registry).
+
+## Phase 1 / Phase 2 — no new contract
+
+P1 (persistent cache, in-use persistence, enrichment, normalization) and P2 (dual lookup) are internal to the resolver and app-targets crates and the seed-builder tool. They change **behaviour behind existing operations**, not the operation surface:
+
+- Existing target search / typeahead / resolve operations (spec-035) keep their request/response shapes; only their backing store (persistent redb cache) and persistence timing (in-use gate) change.
+- The `magnitude` and `constellation` fields already exist on the target read model (populated, previously usually null).
+- One **new local command** is added in P1 but takes no domain payload: `target.cache.clear` — clears the resolve cache (redb) and returns `{ cleared: bool }`; it never touches `canonical_target`. Documented here for completeness; not part of the P3 cone-search surface.
+
+## Phase 3 — cone-search suggestion (NEW)
+
+### `target.cone_search.suggest`
+
+Run a cone-search around a light-frameset's derived pointing and return ranked, confidence-carrying target suggestions. Advisory only — creates nothing.
+
+- **Request**:
+  ```json
+  {
+    "frameset_id": "string",
+    "reason": "ingest | on_demand"
+  }
+  ```
+  The backend derives the pointing from the frameset's frames (WCS `CRVAL1/2` → mount `OBJCTRA/OBJCTDEC` → none); the client does not supply coordinates. `reason` distinguishes the automatic ingest run from a user-triggered re-run (FR-017).
+
+- **Response**:
+  ```json
+  {
+    "pointing": {
+      "source": "wcs | mount | none",
+      "center_ra_deg": 10.6847,
+      "center_dec_deg": 41.269,
+      "radius_deg": 1.0,
+      "optics_known": true
+    },
+    "suggestions": [
+      {
+        "candidate": {
+          "canonical_target_id": "string | null",
+          "primary_designation": "M 31",
+          "object_type": "galaxy",
+          "ra_deg": 10.6847,
+          "dec_deg": 41.269,
+          "magnitude": 3.4,
+          "constellation": "And"
+        },
+        "separation_deg": 0.02,
+        "confidence": "high | medium | low",
+        "preselected": true,
+        "excluded": false
+      }
+    ]
+  }
+  ```
+  - `source = "none"` ⇒ `suggestions: []` (no pointing → no suggestion; FR-012).
+  - `canonical_target_id` is `null` when the candidate is resolved from cache/online but not yet adopted; it becomes non-null only after confirm (FR-004/FR-016).
+  - `confidence` combines separation, `pointing.source` quality (WCS > mount), and catalogue prominence (OQ-1). Exactly the high-confidence candidates carry `preselected: true`; the system never sets `preselected` without a qualifying confidence, and never applies a link itself (FR-014).
+  - `excluded: true` marks candidates in the default niche-otype exclusion set (OQ-2); still returned so the UI can show them for manual override (FR-015).
+  - `radius_deg` is the FOV-derived radius, or the ~1° default when `optics_known: false` (FR-013).
+
+- **Errors** (spec-046 registry):
+  - `resolve.offline` — online-resolve disabled or network unavailable ⇒ cone-search unavailable; ingest proceeds without a suggestion (FR-018). Non-blocking.
+  - `frameset.not_found` — unknown `frameset_id`.
+  - `pointing.unavailable` — no reliable pointing (equivalent to `source = none`; may be returned as a `200` with empty suggestions instead, at impl's discretion — documented so the client handles both).
+
+- **Notes**: Read-only. Produces no filesystem mutation and no `canonical_target` write.
+
+### `target.cone_search.confirm`
+
+Confirm a suggested candidate as the frameset's target. This is the single point at which a cone-search suggestion becomes durable.
+
+- **Request**:
+  ```json
+  {
+    "frameset_id": "string",
+    "candidate": {
+      "canonical_target_id": "string | null",
+      "primary_designation": "M 31",
+      "simbad_oid": 1575544
+    }
+  }
+  ```
+  When `canonical_target_id` is null, the backend adopts the candidate (dedup on `simbad_oid` → normalized designation, FR-007), writing the `canonical_target` row (in-use, FR-004) and enriching magnitude/constellation (FR-006), then links the frameset.
+
+- **Response**:
+  ```json
+  {
+    "canonical_target_id": "string",
+    "created": true,
+    "linked": true
+  }
+  ```
+  `created` is `true` when a new durable row was written, `false` when an existing dedup match was reused.
+
+- **Errors**: `candidate.invalid` — the candidate no longer resolves; `frameset.not_found`.
+
+- **Notes**: This is the ONLY operation in the feature that writes a `canonical_target` row from the cone-search path. No suggestion is ever auto-confirmed (FR-016, SC-006).
+
+## Contract invariants
+
+- No operation in this feature mutates the filesystem.
+- `target.cone_search.suggest` is read-only and never writes `canonical_target`; only `target.cone_search.confirm` (or the other in-use adoption paths from P1) does.
+- Every candidate carries an explicit `confidence`; `preselected` is set only for high confidence and never implies a link (FR-014, constitution II).
+- Errors use the spec-046 error-code registry; `resolve.offline` is a non-blocking degraded state, not a failure.

--- a/specs/052-simbad-caching-dual-lookup-cone-search/data-model.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/data-model.md
@@ -1,0 +1,89 @@
+# Data Model: SIMBAD Resolver Caching, Dual-Lookup, and Cone-Search
+
+**Feature**: 052-simbad-caching-dual-lookup-cone-search | **Date**: 2026-07-12
+
+Principle: reuse existing tables and columns. This feature adds **no** new SQLite table and **no** migration. Changes are (a) enforcing when `canonical_target` rows are written (in-use gate), (b) actually populating the already-present `magnitude`/`constellation` columns, (c) a persistent redb resolve-cache shape (outside SQLite), and (d) a transient cone-search suggestion/confidence model.
+
+## Entities
+
+### Canonical target — existing `canonical_target` (`0031` + `0047`)
+
+No schema change. Semantics this feature enforces:
+
+| Column | Type | This feature |
+|--------|------|--------------|
+| `id` | TEXT PK (UUIDv5) | unchanged; UUIDv5-from-normalized-designation is also the synthetic-identity fallback when no `simbad_oid` (FR-010) |
+| `simbad_oid` | INTEGER | dedup key (UNIQUE when non-null); recovered via TAP re-enrichment for Sesame hits that lack it (FR-010) |
+| `primary_designation` | TEXT | normalized via the single choke-point before write (FR-007) |
+| `object_type` | TEXT | unchanged closed enum |
+| `ra_deg` / `dec_deg` | REAL | unchanged (ICRS J2000, never fabricated) |
+| `source` | TEXT `seed`\|`resolved`\|`user-override` | unchanged |
+| `resolved_at` | TEXT | unchanged |
+| `magnitude` | REAL (nullable) | **now populated** from `ResolvedIdentity.v_mag` (online) or the seed (offline) at adoption/resolve — remains NULL when the source has none (FR-006) |
+| `constellation` | TEXT (nullable) | **now populated** via skymath 0.3 IAU-from-coordinates at adoption/resolve (FR-006) |
+| `display_alias` | TEXT | unchanged (presentation-only, never normalized/matched) |
+
+**Write gate (FR-004, supersedes spec-035 FR-006)**: a row is written **only** when the target becomes in use — added to a project, linked to an acquisition session, favourited, or confirmed in the Inbox. Pure typeahead/search never writes here. On adoption, the row is created (or the existing dedup match reused) and enriched with magnitude + constellation.
+
+### Resolve cache — persistent redb (NEW, outside SQLite)
+
+`CacheBackend::File(<app_data>/simbad-cache.redb)`, one global file (identities are universal), **no TTL**. Owned by the `simbad-resolver` facade; the repo treats it as an opaque projection with these properties:
+
+| Property | Value |
+|----------|-------|
+| Scope | global (app-data dir), not per-library |
+| Contents | resolved identities + normalized aliases, keyed for typeahead/search |
+| Authority | **non-authoritative projection** — `canonical_target` wins on conflict (§V) |
+| Expiry | none |
+| Warm | at first run from the bundled seed + existing durable `canonical_target` rows (FR-005) |
+| Clear | manual "clear resolve cache" action; never deletes any `canonical_target` row; re-warms from seed + durable rows |
+| Search | `facade.search()` is the single search path (replaces `cache.rs` `search_by_normalized`/`search_fuzzy`) |
+
+**Invariant**: every string entering the cache passes the normalization choke-point (FR-007); dedup keys on `simbad_oid` → normalized primary designation.
+
+### Pointing — derived (transient, P3)
+
+Not persisted. Derived per light-frameset at ingest:
+
+| Field | Meaning |
+|-------|---------|
+| `center` | ICRS sky centre (deg) |
+| `source` | `wcs` (plate-solved, high) \| `mount` (medium) \| `none` (no suggestion) |
+| `fov` | field of view from target-match `Optics` (focal length + sensor); default radius ~1° when optics unknown |
+| `rotation` | camera rotation, applied to the footprint |
+
+Precedence: WCS `CRVAL1/2` → `OBJCTRA/OBJCTDEC` → none. **Never** from the filename. A frameset whose subs disagree on pointing beyond tolerance resolves to `source = none`.
+
+### Cone-search suggestion + confidence — derived (transient, P3)
+
+Not persisted until the user confirms (then it flows through the existing target-link/adoption path). Per candidate:
+
+| Field | Meaning |
+|-------|---------|
+| `candidate_target` | canonical identity (from resolution over local + online catalogues) |
+| `separation_deg` | angular separation from the field centre |
+| `confidence` | explicit level combining `separation_deg` + source quality (WCS > mount) + catalogue-prominence weight (OQ-1) |
+| `preselected` | true for high confidence, false for low (never silent auto-apply) |
+| `excluded` | true if the candidate's object type is in the default exclusion set (OQ-2), unless user-overridden |
+
+**Primary object** (multi-object frame): nearest-to-centre (min `separation_deg`) among non-excluded candidates, tie-broken by catalogue prominence (OQ-1). If all in-field candidates are excluded, no primary is pre-selected; candidates may still be shown for manual choice.
+
+## Relationships
+
+```
+canonical_target 1───1 resolve-cache entry   (projection of the durable row; cache re-derivable)  [NEW cache; SQLite canonical]
+canonical_target *───1 project / session / favourite / inbox-confirm  (in-use gate → write)        [existing links; write timing changed]
+light-frameset   1───1 Pointing               (derived at ingest; WCS→mount→none)                  [transient, P3]
+Pointing         1───* Cone-search suggestion  (top-N candidates + confidence)                      [transient, P3]
+Cone-search sugg 1───1 canonical_target        (on confirm → in-use → durable write)                [existing target-link path]
+```
+
+## Invariants
+
+- **INV-1**: `canonical_target` is written only on adoption (in-use); pure search never creates a row (FR-004).
+- **INV-2**: The redb cache is a reproducible projection; clearing it never deletes a `canonical_target` row and it re-warms from seed + durable rows (FR-002, FR-003, §V).
+- **INV-3**: Every identity string is normalized by the single choke-point before caching/persisting/matching; dedup keys `simbad_oid` → normalized designation (FR-007).
+- **INV-4**: Coordinates are never fabricated; magnitude/constellation are optional and stay NULL when the source lacks them (FR-006).
+- **INV-5**: The name-resolver fallback fires only on explicit resolve, never per keystroke (FR-009).
+- **INV-6**: A cone-search suggestion never becomes a durable link without explicit user confirmation (FR-014, FR-016).
+- **INV-7**: Pointing is never derived from the filename (FR-012).

--- a/specs/052-simbad-caching-dual-lookup-cone-search/plan.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/plan.md
@@ -1,0 +1,115 @@
+# Implementation Plan: SIMBAD Resolver Caching, Dual-Lookup, and Cone-Search
+
+**Branch**: `052-simbad-caching-dual-lookup-cone-search` | **Date**: 2026-07-12 | **Spec**: [spec.md](./spec.md)
+
+**Input**: Feature specification from `specs/052-simbad-caching-dual-lookup-cone-search/spec.md`
+
+## Summary
+
+Three phased, independently-shippable deliverables over the existing SIMBAD resolution stack (spec-035):
+
+- **P1 (US1)** — Adopt the `simbad-resolver` **`SimbadResolver` facade** with a persistent redb **`CacheBackend::File`** (one global `<app_data>/simbad-cache.redb`, no TTL, manual clear); move durable persistence from persist-on-resolve to **persist-on-in-use** (supersedes spec-035 FR-006); warm the cache from the bundled seed + existing durable rows; replace the hand-rolled `cache.rs` search with `facade.search()`; enrich adopted targets with `magnitude` (from `ResolvedIdentity.v_mag`) and `constellation` (skymath 0.3); route every identity string through one **normalization choke-point**. Bump `simbad-resolver` 0.1.3 → 0.2.0 and fix the seed-builder V-magnitude gap.
+- **P2 (US2)** — **Dual lookup**: TAP-first, Sesame name-resolver fallback only on a TAP miss, only on explicit resolve; oid recovery (TAP re-enrich → UUIDv5-from-designation); gated by the online-resolve setting.
+- **P3 (US3)** — **Cone-search** at Inbox ingest, per light-frameset: derive pointing (WCS → mount → none, never filename), rotation-aware footprint + FOV via target-match 0.3, radius from optics (~1° default), top-N candidates, explicit confidence, nearest-to-centre primary with a niche-otype exclusion set. New contract + Tauri command + Inbox suggestion UI. **Suggested only** — confirm creates the durable link → in-use → persists `canonical_target`.
+
+The approach reuses existing rails — the resolver crate and its `SimbadResolver` wrapper, `canonical_target` (with the already-present `magnitude`/`constellation` columns), the online-resolve gate, the Inbox confirm pipeline, and the pinned-but-unused `skymath`/`target-match` — rather than adding new crates or SQLite tables. No schema migration is required.
+
+## Technical Context
+
+**Language/Version**: Rust (workspace edition per `Cargo.toml`), TypeScript/React for the desktop shell.
+
+**Primary Dependencies**: `simbad-resolver` **0.2.0** (facade + `CacheBackend::File` redb + `ResolvedIdentity.v_mag` + Sesame fallback), `skymath` 0.3 (IAU constellation-from-coords), `target-match` 0.3 (optics→FOV, rotation-aware footprint), `sqlx` (SQLite, canonical store), Tauri + tauri-specta (contract boundary).
+
+**Storage**: SQLite `canonical_target` remains canonical (no migration — `magnitude`/`constellation` exist since `0047`). Resolve cache is redb, one global file in the app-data dir (outside SQLite).
+
+**Testing**: per-crate `cargo test` (workspace baseline is known-red — validate per crate), integration tests under `tests/`, TS typecheck; real-app verification via `verify-on-windows` + a tauri-driver Layer-2 journey for the P3 Inbox suggestion.
+
+**Target Platform**: Desktop (Windows primary dev target, plus macOS/Linux) via Tauri.
+
+**Project Type**: Desktop app over granular Rust crates with a language-neutral contract boundary.
+
+**Performance Goals**: Repeat search of a cached object issues zero network calls (SC-001); typeahead served locally; cone-search bounded to top-N.
+
+**Constraints**: PixInsight boundary (no image processing); reviewable mutation (no silent target auto-apply — suggestions carry explicit confidence and require confirm); portable contracts + durable SQLite record; the redb cache is a reproducible projection, never canonical.
+
+**Scale/Scope**: Resolution of individual objects and per-frameset cone-search; the seed catalogue is bundled.
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Local-First File Custody | **PASS.** No image files touched; resolution and cone-search operate on metadata (coordinates, designations) only. The redb cache lives in the app-data dir and holds no raw/processed image data. |
+| II. Reviewable Filesystem Mutation | **PASS (identity-linking analogue).** No filesystem mutation. Cone-search never silently assigns a target: every suggestion carries an explicit confidence (per §II's confidence requirement for inference) and becomes a durable link only on explicit user confirm. |
+| III. PixInsight Boundary | **PASS.** No calibrate/debayer/register/integrate/edit; the feature resolves identities and suggests target links from existing plate-solve/mount metadata. Plate-solving itself is not performed — WCS is read, not computed. |
+| IV. Research-Led Domain Modeling | **PASS.** Facade vs direct-TAP, cache backend, §V reconciliation, dual-lookup ordering, and normalization are decided with alternatives in `research.md`. The two genuinely-open P3 questions (catalogue-prominence ranking, default otype exclusion set) are documented as OQ-1/OQ-2 with proposed defaults, to be confirmed in P3 design before P3 implementation. |
+| V. Portable Contracts & Durable Records | **PASS.** The new cone-search operation is a language-neutral contract (`crates/contracts/core` + `packages/contracts` + generated bindings). SQLite `canonical_target` is the durable record; the redb resolve cache is an explicitly reproducible projection (§V). |
+
+**Result**: PASS (initial). Re-checked after Phase 1 design — still PASS. One item to close before P3 *implementation* (not before design): resolve OQ-1/OQ-2 (Principle IV gate for the cone-search modeling). P1/P2 have no open modeling questions. See Complexity Tracking (empty).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/052-simbad-caching-dual-lookup-cone-search/
+├── plan.md              # This file
+├── research.md          # Phase 0 output (decisions + OQ-1/OQ-2)
+├── data-model.md        # Phase 1 output
+├── contracts/           # Phase 1 output (operations.md — P3 cone-search)
+└── tasks.md             # Phase 2 output
+```
+
+### Source Code (repository root)
+
+```text
+crates/
+├── targeting/resolver/
+│   ├── Cargo.toml            # simbad-resolver 0.1.3 → 0.2.0 (P1)
+│   ├── simbad.rs             # refactor: direct TapResolver → SimbadResolver facade + CacheBackend::File (P1); Sesame fallback wiring (P2)
+│   ├── cache.rs              # replace hand-rolled search_by_normalized/search_fuzzy with facade.search() (P1)
+│   ├── seed.rs               # warm redb cache from bundled seed (P1)
+│   └── lib.rs                # normalization choke-point routing; v_mag/constellation on ResolvedIdentity mapping (P1)
+├── targeting/                # target-match 0.3 (FOV/footprint), skymath 0.3 (constellation) — already pinned (P1 constellation, P3 cone)
+├── app/targets/
+│   ├── target_resolve.rs     # in-use-gated canonical_target write (P1, supersede 035 FR-006); enrichment on adopt (P1)
+│   └── (cone-search orchestration for P3: pointing derivation + candidate ranking)
+├── app/inbox/                # per-light-frameset cone-search hook at confirm; suggestion carried to UI (P3)
+├── contracts/core/           # cone-search + Inbox target-suggestion DTOs (P3 only)
+└── tools/seed-builder/src/main.rs  # parse_basic_row 5→6-tuple + f.V + LEFT OUTER JOIN allfluxes (P1)
+
+apps/desktop/
+├── src-tauri/src/lib.rs                 # build SimbadResolver facade w/ File backend at startup (P1); register cone-search command (P3)
+├── src-tauri/src/commands/target_lookup.rs  # facade construction; "clear resolve cache" command (P1)
+├── src-tauri/src/commands/               # new cone-search command (P3)
+└── src/features/inbox/                    # target-suggestion UI in the confirm gate (P3)
+packages/contracts/                        # generated TS surface for the P3 cone-search operation
+tests/                                     # cache-persist-across-restart, in-use-gate, dual-lookup, cone-search suggestion
+```
+
+**Structure Decision**: Extend existing crates; add **no** new crate and **no** SQLite table. P1/P2 are internal to the resolver + app-targets + seed-builder and add **no new contract**. P3 adds exactly one new contract/command/UI surface. This follows the crate-split-by-domain rule and keeps pure-domain crates free of new cross-crate deps.
+
+## Phase 0 — Research
+
+See [research.md](./research.md). Decisions: D1 facade vs direct-TAP; D2 `CacheBackend::File` (redb) vs InMemory vs moka (moka dropped); D3 §V reconciliation (redb projection, SQLite canonical); D4 in-use-gated persistence (supersedes 035 FR-006); D5 TAP-first/Sesame-fallback + oid recovery; D6 normalization choke-point; D7 0.2.0 bump + seed-builder V-mag fix; D8 constellation via skymath; D9 cone-search building blocks. Open: OQ-1 catalogue-prominence ranking, OQ-2 default otype exclusion set (proposed defaults given; confirm in P3 design).
+
+## Phase 1 — Design
+
+See [data-model.md](./data-model.md) and [contracts/operations.md](./contracts/operations.md). P1/P2 add no new contract (documented in contracts). P3 adds the cone-search command + Inbox target-suggestion DTO.
+
+## Phased delivery
+
+| Phase | User Story | Ships | New contract? |
+|-------|-----------|-------|---------------|
+| P1 | US1 | facade + persistent redb cache + in-use persistence + 0.2.0 bump + seed-builder fix + magnitude/constellation enrichment + normalization choke-point | No |
+| P2 | US2 | TAP-first / Sesame-fallback dual lookup + oid recovery | No |
+| P3 | US3 | cone-search suggestion at Inbox ingest (contract + command + UI) | Yes |
+
+## Complexity Tracking
+
+> No constitution violations. Table intentionally empty.
+
+| Violation | Why Needed | Simpler Alternative Rejected Because |
+|-----------|------------|-------------------------------------|
+| — | — | — |

--- a/specs/052-simbad-caching-dual-lookup-cone-search/research.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/research.md
@@ -1,0 +1,102 @@
+# Research: SIMBAD Resolver Caching, Dual-Lookup, and Cone-Search
+
+**Feature**: 052-simbad-caching-dual-lookup-cone-search | **Date**: 2026-07-12
+
+Ground-truth code references confirmed during exploration (base `origin/main` @ 8b6b5839).
+
+## Baseline (what already exists)
+
+- **Resolver crate** `crates/targeting/resolver/` (`cache.rs`, `seed.rs`, `simbad.rs`, `caldwell.rs`, `lib.rs`). The repo's `SimbadResolver` is a **thin wrapper over `simbad_resolver::TapResolver`** (`simbad.rs:36`, `TapResolver::new` at `simbad.rs:47`) — it calls the TAP path directly. This is the "B2 direct-TAP" referenced in the campaign decisions.
+- **Hand-rolled search** in `cache.rs`: `search_by_normalized` (`:245`) plus opt-in `search_fuzzy` (`:339`) over `target_alias.normalized`, using `simbad_resolver::normalize::token_set_similarity`. Two ranking code paths to converge onto one facade search.
+- **`canonical_target`** schema: `crates/persistence/db/migrations/0031_target_resolution.sql` (id UUIDv5, `simbad_oid` dedup key UNIQUE-when-non-null, `primary_designation`, `object_type`, ICRS `ra_deg`/`dec_deg`, `source ∈ {seed,resolved,user-override}`, `display_alias`). `constellation TEXT` + `magnitude REAL` added nullable by `0047_target_constellation_magnitude.sql` — **present but only sparsely populated today**.
+- **Dependency pins**: `simbad-resolver = "0.1.3"` (`crates/targeting/resolver/Cargo.toml:48`), `target-match = "0.3"` and `skymath = "0.3"` (`crates/targeting/Cargo.toml:17-18`; also in `crates/app/inbox`, `crates/metadata/core`).
+- **Seed builder**: `crates/tools/seed-builder/src/main.rs`. `parse_basic_row` yields a 5-tuple `(oid, main_id, ra, dec, otype)`; two TAP `SELECT`s (around `:260`, `:297`) omit the V-magnitude column.
+- **Online gating**: the live `SimbadResolver` is built only when the online-resolve setting is on (`apps/desktop/src-tauri/src/lib.rs:934-958`; `commands/target_lookup.rs:49-74`) — the spec-035 FR-015 gate this feature reuses.
+
+---
+
+## D1 — Facade vs direct `TapResolver`
+
+**Decision**: Adopt the `simbad-resolver` crate's own **`SimbadResolver` facade** (0.2.0), constructed as `SimbadResolver::new(TapResolver, CacheBackend::File(<app_data>/simbad-cache.redb), ResolverConfig)`. Refactor the repo's current direct-`TapResolver` usage (`crates/targeting/resolver/src/simbad.rs`) onto it. The facade owns caching, dual-lookup, and unified search behind one type.
+
+**Alternatives**:
+- *(A) Keep calling `TapResolver` directly and bolt persistence/dual-lookup/search on in-repo.* Rejected: duplicates logic the upstream facade already maintains (caching, TAP+Sesame ordering, normalized search), and keeps two divergent search paths. Fails code-economy (reuse maintained upstream over hand-roll).
+- *(B) Facade (chosen).* One integration seam; the crate is the maintained home for resolution semantics; the repo keeps only its domain mapping (Caldwell translation, `ObjectType`/`TargetSource` enums, `canonical_target` persistence).
+
+**Consequence**: `cache.rs`'s hand-rolled `search_by_normalized`/`search_fuzzy` are replaced by `facade.search()` over the unified store; the `token_set_similarity` fuzzy path is dropped unless the facade lacks an equivalent (verify at impl).
+
+## D2 — Cache backend: `File` (redb) vs `InMemory` vs moka
+
+**Decision**: `CacheBackend::File` — the facade's own persistent **redb** file, **one global file** in the app-data dir, **no TTL**, plus a manual "clear resolve cache" action.
+
+**Alternatives**:
+- *`InMemory`* — the effective status quo; re-queries SIMBAD after every restart (SC-001 fails). Rejected.
+- *`moka`* (in-process concurrent cache) — still volatile across restarts and adds a dependency for no durability gain. **Rejected** (explicitly dropped in the campaign decisions).
+- *Per-library cache file* — rejected: SIMBAD identities are universal, not library-scoped; one global file avoids re-resolving the same object per library.
+- *TTL expiry* — rejected: catalogue identities are stable; a TTL would force needless re-queries. A manual clear covers the rare "the seed/catalogue changed" case.
+
+## D3 — §V reconciliation: cache vs system-of-record
+
+**Decision**: The redb cache is a **reproducible projection**; SQLite `canonical_target` remains the **canonical, FK-anchored system-of-record** (constitution §V). On any conflict the durable row wins; clearing the cache never touches `canonical_target` and the cache re-warms from seed + durable rows (D6).
+
+**Rationale**: §V requires the database to be the durable relationship/audit record and marks manifests/projections reproducible unless explicitly canonical. The cache is exactly such a projection. This is what lets FR-004 move persistence to adoption without risking data loss — the cache can be rebuilt, the durable rows cannot.
+
+## D4 — In-use-gated persistence (supersedes spec-035 FR-006)
+
+**Decision**: Write `canonical_target` **only** when a target becomes "in use": added to a project, linked to an acquisition session, favourited, or confirmed in the Inbox. Pure typeahead/search hits the redb cache only.
+
+**Rationale**: spec-035 FR-006 made the cache the durable record and persisted on every resolution, so browsing SIMBAD populated the system-of-record with objects the user never adopted. Splitting a persistent-but-reproducible cache (D2) from an adoption-gated durable table keeps the system-of-record clean while still making repeat search free. Documented supersession in `spec.md` FR-004.
+
+**Alternative**: *persist-on-resolve (status quo).* Rejected for the clutter and semantics above.
+
+## D5 — TAP-first / Sesame-fallback
+
+**Decision**: Dual lookup = **TAP first, Sesame name-resolver fallback only on a TAP miss**, fired only on an **explicit** resolve (Enter / confirm / "search harder"), never per typeahead keystroke. oid recovery: a Sesame hit lacking `simbad_oid` is re-enriched via TAP by coordinates/main_id; if still none, a **UUIDv5-from-designation** synthetic identity preserves FR-007 dedup. Gated by the online-resolve setting.
+
+**Alternatives**:
+- *Sesame-first* — rejected: TAP returns the structured identifier/oid the dedup key needs; Sesame is a name→coords resolver with weaker structure. TAP-first keeps oids populated.
+- *Fallback on every keystroke* — rejected: impolite to CDS and needless latency; typeahead is served locally.
+
+## D6 — Normalization choke-point
+
+**Decision**: A **single** normalization function (`simbad_resolver::normalize`) is the sole path by which any identity string is prepared before caching, persisting, or matching — applied identically to TAP, Sesame, Caldwell, user query, and seed. Dedup keys on `simbad_oid` → normalized primary designation; every alias is normalized before storage.
+
+**Rationale**: FR-007 and FR-010 both depend on the same string being normalized the same way regardless of source; divergent normalization is how aliases split across catalogues. Centralizing it makes the dedup invariant enforceable and testable in one place. The repo already routes cache reads/writes through `targeting::normalize::normalize`; this decision makes that the *only* route.
+
+## D7 — Seed builder V-magnitude fix (paired with the 0.2.0 bump)
+
+**Decision**: Bump `simbad-resolver` 0.1.3 → 0.2.0 (facade + `ResolvedIdentity.v_mag`). Fix `seed-builder`: widen `parse_basic_row` from a 5-tuple to a 6-tuple `(oid, main_id, ra, dec, otype, v_mag)`, and add `f.V` + `LEFT OUTER JOIN allfluxes AS f ON f.oidref = b.oid` to its two TAP `SELECT`s so the bundled seed carries magnitude.
+
+**Rationale**: Enrichment (FR-006) sources magnitude from `ResolvedIdentity.v_mag` for online resolves and from the seed for offline ones; without the seed-builder fix, seed-sourced adoptions would have no magnitude. `LEFT OUTER JOIN` keeps rows whose flux is absent (magnitude stays optional).
+
+## D8 — Constellation enrichment
+
+**Decision**: Populate `canonical_target.constellation` via **skymath 0.3** IAU constellation-from-coordinates (currently pinned but unused). Compute at adoption/resolve time from the target's ICRS coordinates.
+
+**Rationale**: Coordinates are always present (never fabricated, spec-035 FR-009); constellation is a pure function of them, so it needs no extra network call and works offline. Reuses an already-pinned dependency (code economy).
+
+## D9 — Cone-search building blocks (Phase 3)
+
+**Decision**: Pointing source precedence WCS `CRVAL1/2` → `OBJCTRA/OBJCTDEC` → none (never filename). Field footprint and FOV from **target-match 0.3** (`Field`/`Optics` from focal length + sensor), **rotation-aware**; cone radius from FOV with a **~1°** default when optics are unknown; fetch top-N in radius. Confidence = separation-from-centre + source quality (WCS > mount) + catalogue-prominence weight, carried explicitly (constitution II). Primary object = nearest-to-centre, tie-broken by prominence, minus a default niche-otype exclusion set.
+
+**Rationale**: `target-match` already models optics→FOV and field matching; reusing it avoids re-deriving plate scale. Confidence is explicit per constitution II (inference must carry confidence). "Suggested only, never silent auto-apply" satisfies constitution II's reviewable-mutation posture at the identity-linking layer.
+
+## Open Phase-3 research questions (resolve during P3 design, per Principle IV)
+
+These are genuine domain-modeling questions the constitution requires be documented before implementation. Proposed defaults below are the starting point, to be confirmed in P3 design.
+
+### OQ-1 — Catalogue-prominence ranking
+
+*Question*: How should catalogues be ranked when weighting confidence and breaking primary-object ties?
+
+**Proposed default**: `Messier / common-name > NGC > IC > Caldwell > niche catalogues`. Rationale: mirrors how amateur astrophotographers name targets (a frame centred on M31 should out-rank an incidental catalogued knot). To confirm in P3: exact tier boundaries, treatment of Sharpless/Barnard/LBN/LDN, and whether a well-known common name (e.g. "Veil Nebula") outranks a bare NGC number.
+
+### OQ-2 — Default object-type exclusion set
+
+*Question*: Which SIMBAD object types should be excluded by default from primary-object selection?
+
+**Proposed default**: exclude double/multiple stars and very-niche types (e.g. individual stars that are not the framing target) so a wide-field nebula is not mislabelled by an incidental star at the centre. User-overridable per FR-015. To confirm in P3: the exact otype list against SIMBAD's `otype` vocabulary, and whether some star types (e.g. named variable stars that *are* imaging targets) should be retained.
+
+## Migration note (impl-time only)
+
+The spec/plan add **no** schema migration: `canonical_target.magnitude`/`constellation` already exist (`0047`), and the resolve cache is redb (outside SQLite). Cone-search suggestions are transient (not persisted) until the user confirms, at which point they reuse the existing target-link path. If P3 design later decides to persist suggestion audit records, take the next free migration number after checking base + open PRs at implementation time.

--- a/specs/052-simbad-caching-dual-lookup-cone-search/spec.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/spec.md
@@ -1,0 +1,165 @@
+# Feature Specification: SIMBAD Resolver Caching, Dual-Lookup, and Cone-Search
+
+**Feature Branch**: `052-simbad-caching-dual-lookup-cone-search`
+
+**Created**: 2026-07-12
+
+**Status**: Draft
+
+**Input**: User description: "SIMBAD resolver: persistent resolve cache, in-use-gated persistence, dual lookup (catalogue-first with a name-resolver fallback), and cone-search from plate-solved coordinates to suggest a target at Inbox ingest."
+
+## Overview
+
+PlateVault resolves a FITS `OBJECT` value or a typed query into a **canonical target** (stable identity, ICRS coordinates, object type, aliases) using a bundled seed catalogue plus SIMBAD (spec-035). Three gaps remain, each shippable on its own:
+
+1. **The resolve cache is not durable across restarts, and typing pollutes the system-of-record.** Spec-035 wrote a `canonical_target` row for every resolution, including transient typeahead. That both persists objects the user never adopts and, because the working cache is in-process, re-queries SIMBAD after every restart. This feature makes the resolve cache **persistent** and moves durable persistence to the moment a target is actually **in use** — added to a project, linked to an acquisition session, favourited, or confirmed in the Inbox — leaving pure search backed only by the cache. It also unifies typeahead/search over a single store and enriches adopted targets with magnitude and constellation.
+
+2. **A single-source lookup misses objects SIMBAD only knows by name.** The current path queries SIMBAD's tabular service (TAP) only; objects reachable through SIMBAD's name resolver but not the TAP identifier path resolve to nothing. This feature adds a **dual lookup**: TAP first, a name-resolver **fallback** only on a TAP miss, fired only on an explicit resolve (not per keystroke).
+
+3. **Plate-solved frames carry their sky pointing, but the app never uses it to suggest a target.** When a frame has been plate-solved (WCS) — or at least records mount pointing — the app knows where the telescope was aimed but still asks the user to name the target by hand. This feature adds a **cone-search**: at Inbox ingest, per light-frameset, it searches the neighbourhood of the frame's pointing and offers a **suggested** target link, carrying explicit confidence, that the user confirms.
+
+Consistent with PlateVault's principles, nothing here processes images, and no target link is ever created without an explicit user action. SQLite remains the durable system-of-record; the resolve cache is a reproducible projection.
+
+## Clarifications
+
+### Session 2026-07-12
+
+Decisions below were resolved with the user in a pre-spec grilling pass; recorded here so the spec is self-contained.
+
+- Q: One spec or three? → A: One feature spec, three phased shippable deliverables (P1/P2/P3), each an independently-testable slice. Greenfield — no data migration.
+- Q: Where does the resolve cache live and does it expire? → A: A single persistent cache file in the app-data dir (SIMBAD identities are universal, not per-library), **no TTL** (identities are stable), plus a manual "clear resolve cache" action.
+- Q: When is a `canonical_target` row written? → A: Only when a target becomes **in use** — added to a project, linked to an acquisition session, favourited, or confirmed in the Inbox. Pure typeahead/search populates the cache only. **This supersedes spec-035 FR-006.**
+- Q: How does online resolution find objects TAP misses? → A: TAP-first, name-resolver **fallback only** on a TAP miss, and only on an explicit resolve (Enter / confirm / "search harder") — never per typeahead keystroke.
+- Q: Where do cone-search coordinates come from? → A: Plate-solved WCS pointing (high confidence) → mount pointing (medium) → none (no suggestion). **Never from the filename.**
+- Q: How is a suggestion chosen and presented? → A: Confidence combines separation-from-centre, coordinate-source quality (WCS > mount), and catalogue prominence. High confidence → pre-selected; low → shown but not pre-selected. **Never silently auto-applied** — the user confirms.
+- Q: What happens in multi-object frames? → A: Primary object = nearest-to-centre, tie-broken by prominence, with a default exclusion set of niche object types (double/multiple stars, etc.) that the user can override.
+- Q: Online features offline? → A: Dual-lookup and cone-search require network and are gated by the existing online-resolve setting; offline degrades to seed + cache, and cone-search is unavailable.
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Fast offline-first search with durable identity only for adopted targets (Priority: P1)
+
+As a user searching for and selecting targets, I want search to be instant and to survive restarts without re-querying SIMBAD, and I want the app to record a durable target identity only for objects I actually use, so that my library is not cluttered with objects I merely typed and repeated searches are free.
+
+**Why this priority**: This is the foundation. Persistent caching and in-use-gated persistence change the storage semantics every other phase builds on, and deliver immediate value on their own: faster search, a clean system-of-record, and enriched detail (magnitude, constellation) for adopted targets.
+
+**Independent Test**: Search for a catalogued object, restart the app, and search again — the second search returns instantly with no network call. Confirm no `canonical_target` row exists for a searched-but-unadopted object, then add it to a project and confirm exactly one durable row now exists, carrying magnitude and constellation where the source provides them.
+
+**Acceptance Scenarios**:
+
+1. **Given** an object resolved once (from seed or online), **When** the app is restarted and the same object is searched again, **Then** it resolves instantly from the persistent cache with zero network calls.
+2. **Given** a user types a query and browses suggestions but adopts nothing, **When** the search session ends, **Then** no `canonical_target` row is created for the browsed objects (cache only).
+3. **Given** a searched object, **When** the user adds it to a project, links it to an acquisition session, favourites it, or confirms it in the Inbox, **Then** exactly one durable `canonical_target` row is created (or reused) for that physical object.
+4. **Given** a target that has just become in use, **When** it is viewed, **Then** it shows its visual magnitude and IAU constellation when the source provides them.
+5. **Given** the same physical object reached through two different alias variants or catalogues, **When** both are searched or adopted, **Then** they map to a single canonical identity (no split).
+6. **Given** a populated persistent cache, **When** the user invokes "clear resolve cache", **Then** the cache is emptied and can be re-warmed from the bundled seed and existing durable targets without losing any `canonical_target` row.
+
+---
+
+### User Story 2 - Resolve objects SIMBAD only knows by name (Priority: P2)
+
+As a user resolving an unusual designation or a name the tabular catalogue does not carry, I want the app to fall back to SIMBAD's name resolver when its primary lookup misses, so that objects I can find on SIMBAD's website also resolve in PlateVault.
+
+**Why this priority**: Extends resolution coverage for real objects that the TAP-only path silently drops. Depends on P1's cache and normalization so a fallback hit is cached and deduplicated like any other. Standalone value: fewer "unresolved" dead ends.
+
+**Independent Test**: Resolve a designation that the tabular service does not carry but the name resolver does; confirm it resolves on an explicit resolve action (not during typeahead), is written to the cache, and deduplicates to a single identity when its aliases are searched.
+
+**Acceptance Scenarios**:
+
+1. **Given** a designation absent from the tabular (TAP) path, **When** the user triggers an explicit resolve (Enter / confirm / "search harder"), **Then** the app falls back to the name resolver and returns the object.
+2. **Given** the same query during as-you-type suggestions, **When** the user is still typing, **Then** the name-resolver fallback does NOT fire (only the local cache/seed answers typeahead).
+3. **Given** a name-resolver hit that lacks a stable physical-object id, **When** it is resolved, **Then** the app recovers an id by re-enriching from the tabular path, and if none exists still produces a single stable identity so aliases of the same object do not split.
+4. **Given** the online-resolve setting is disabled, **When** a resolve is attempted, **Then** neither the tabular path nor the fallback is used and resolution degrades to seed + cache.
+
+---
+
+### User Story 3 - Suggested target from plate-solved coordinates at Inbox ingest (Priority: P3)
+
+As a user ingesting light frames that were plate-solved (or that record mount pointing), I want PlateVault to suggest the target the frames were aimed at, with a clear confidence, so that I can confirm it in one click instead of typing the object by hand — while never having a target silently assigned for me.
+
+**Why this priority**: The headline convenience, and the most complex slice. Depends on P1 (a resolvable, cached, enriched catalogue) and benefits from P2 (broader coverage). Independent once resolution exists: it adds a coordinate-driven suggestion to the existing Inbox confirm gate.
+
+**Independent Test**: Ingest a plate-solved light-frameset and confirm a high-confidence, pre-selected target suggestion appears; ingest a frameset with only mount pointing and confirm a lower-confidence, shown-but-not-pre-selected suggestion; ingest a frameset with neither and confirm no suggestion appears. In every case, confirm no target link exists until the user confirms one.
+
+**Acceptance Scenarios**:
+
+1. **Given** a plate-solved light-frameset (WCS pointing), **When** it reaches the Inbox confirm gate, **Then** the app runs a cone-search around the pointing and pre-selects a high-confidence target suggestion.
+2. **Given** a frameset with only mount pointing (no plate solve), **When** it is ingested, **Then** a suggestion is shown at reduced confidence and is NOT pre-selected.
+3. **Given** a frameset whose only clue is the filename, **When** it is ingested, **Then** no coordinate-based suggestion is produced (the filename is never used as a pointing source).
+4. **Given** a frame whose field contains several catalogued objects, **When** a primary object is chosen, **Then** it is the object nearest the field centre, tie-broken by catalogue prominence, excluding niche object types in the default exclusion set (which the user can override).
+5. **Given** any suggestion, **When** the user does nothing, **Then** no target link is created; **When** the user confirms it, **Then** the target link is created, the target becomes in use, and its `canonical_target` row is persisted (per P1).
+6. **Given** a frameset already ingested, **When** the user requests it, **Then** the cone-search can be re-run on demand.
+7. **Given** the online-resolve setting is disabled or the network is unavailable, **When** a frameset is ingested, **Then** cone-search is unavailable and ingest proceeds without a coordinate-based suggestion.
+
+---
+
+### Edge Cases
+
+- **Offline / online-resolve disabled**: search and ingest degrade to seed + cache; the name-resolver fallback and cone-search are unavailable; no error blocks the user.
+- **Unknown optics**: when focal length / sensor are unknown, the cone-search radius falls back to a documented default (~1°) rather than failing.
+- **Field rotation**: the frame footprint used for matching accounts for camera rotation; a rotated field must not drop objects that fall inside the true footprint.
+- **Name-resolver hit without a physical-object id**: identity is recovered by re-enrichment, else a stable synthetic identity preserves alias deduplication.
+- **Cache vs seed vs durable-target conflict**: a single normalized identity per physical object wins; the durable `canonical_target` (system-of-record) is authoritative over the cache projection.
+- **Ambiguous multi-object frame with all candidates excluded**: if every in-field object is in the exclusion set, no primary is pre-selected; candidates may still be shown for manual choice.
+- **Clearing the cache**: removes only the reproducible projection; it never deletes a `canonical_target` row, and the cache re-warms from seed + durable targets.
+- **Subs disagree on pointing**: a frameset whose subs disagree on pointing beyond a tolerance is treated as no reliable pointing rather than guessing a centre.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Persistent cache, in-use persistence, enrichment, normalization (US1)**
+
+- **FR-001**: Typeahead and search MUST be served from a single unified store (bundled seed + persistent resolve cache + adopted durable targets); the system MUST NOT maintain a separate hand-rolled search path alongside it.
+- **FR-002**: The resolve cache MUST be durable across application restarts, stored once globally in the app-data directory (SIMBAD identities are universal, not per-library), with **no expiry** (identities are stable) and a user-invokable "clear resolve cache" action.
+- **FR-003**: SQLite `canonical_target` MUST remain the durable, foreign-key-anchored system-of-record; the resolve cache MUST be treated as a reproducible projection over it plus the bundled seed and online responses.
+- **FR-004** *(SUPERSEDES spec-035 FR-006)*: A durable `canonical_target` row MUST be written only when a target becomes **in use** — added to a project, linked to an acquisition session, favourited, or confirmed in the Inbox. Pure typeahead/search MUST populate only the resolve cache and MUST NOT create `canonical_target` rows. (Reason: spec-035 FR-006 made the cache the durable record and persisted on every resolution, cluttering the system-of-record with un-adopted objects; persistence now follows adoption.)
+- **FR-005**: At first run, the system MUST warm the persistent cache from the bundled seed, and MUST lazily incorporate existing durable `canonical_target` rows, so search works offline immediately.
+- **FR-006**: When a target becomes in use (or is resolved online), the system MUST populate its visual magnitude and its IAU constellation when the source provides them; absence MUST be tolerated (both remain optional).
+- **FR-007**: All identity strings (designations, aliases, user query, seed, tabular, and name-resolver results) MUST pass through a single normalization choke-point before being cached, persisted, or matched, applied identically across every source. Deduplication MUST key on the physical-object id first and the normalized primary designation second, and each alias MUST be normalized.
+
+**Dual lookup (US2)**
+
+- **FR-008**: Online resolution MUST query the tabular (TAP) path first and MUST consult the name-resolver fallback only when the tabular path returns no match.
+- **FR-009**: The name-resolver fallback MUST fire only on an explicit resolve action (Enter, confirm, or "search harder"); it MUST NOT fire during as-you-type suggestions.
+- **FR-010**: A name-resolver hit lacking a stable physical-object id MUST be re-enriched via the tabular path (by coordinates or main identifier) to recover one; when none can be recovered, the system MUST assign a stable synthetic identity derived from the normalized designation so aliases of the same object are not split.
+- **FR-011**: Both online paths MUST be gated by the existing online-resolve setting; when disabled, resolution MUST use only seed + cache.
+
+**Cone-search suggestion at Inbox ingest (US3)**
+
+- **FR-012**: For a light-frameset at Inbox ingest, the system MUST derive a sky pointing from plate-solved WCS pointing (high confidence) when present, else from mount pointing (medium confidence), else produce no suggestion. The system MUST NOT derive pointing from the filename.
+- **FR-013**: The system MUST perform a cone-search around the derived pointing, sized from the frame field of view (from focal length and sensor) with a documented default radius (~1°) when optics are unknown, accounting for camera rotation in the field footprint, and MUST consider the top-N in-field candidates.
+- **FR-014**: Each suggestion MUST carry an explicit confidence combining separation from the field centre, coordinate-source quality (WCS > mount), and catalogue prominence. High-confidence suggestions MUST be pre-selected; low-confidence suggestions MUST be shown but not pre-selected. The system MUST NEVER silently auto-apply a target link.
+- **FR-015**: For a frame containing multiple catalogued objects, the primary object MUST be the object nearest the field centre, tie-broken by catalogue prominence, excluding object types in a default exclusion set that the user can override.
+- **FR-016**: A suggestion MUST be advisory only; the durable target link MUST be created only on explicit user confirmation, at which point the target becomes in use and its `canonical_target` row is persisted (FR-004).
+- **FR-017**: Cone-search MUST run per light-frameset at ingest and MUST be re-runnable on demand for an already-ingested frameset.
+
+**Cross-cutting**
+
+- **FR-018**: Dual-lookup (US2) and cone-search (US3) require network access and MUST be gated by the online-resolve setting; when offline, search and ingest MUST degrade to seed + cache and cone-search MUST be unavailable, without blocking the user.
+
+### Key Entities *(include if feature involves data)*
+
+- **Canonical target (durable)**: The existing system-of-record identity (stable id, physical-object id, primary designation, ICRS coordinates, object type, aliases), now also carrying visual magnitude and IAU constellation for in-use targets. Written only on adoption (FR-004).
+- **Resolve cache entry (projection)**: A persistent, non-authoritative record of a resolved identity and its normalized aliases, keyed for instant typeahead/search, re-derivable from seed + durable targets + online responses. No expiry.
+- **Pointing**: A derived sky centre for a light-frameset, with a source quality (plate-solved WCS > mount > none). Never derived from the filename.
+- **Cone-search suggestion**: An advisory target candidate for a frameset, carrying the candidate canonical identity, angular separation from the field centre, and an explicit confidence; may be pre-selected (high) or shown-only (low); becomes a durable link only on confirm.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After resolving an object once, restarting the app and searching the same object issues **zero** network calls and returns from the persistent cache.
+- **SC-002**: Browsing search results without adopting anything creates **zero** `canonical_target` rows; adopting a target (project / session / favourite / Inbox confirm) creates exactly one durable row for that physical object.
+- **SC-003**: An in-use target displays its visual magnitude and IAU constellation whenever the resolving source provides them (0% of adopted, source-populated targets show them blank).
+- **SC-004**: An object carried only by SIMBAD's name resolver (a tabular miss) resolves via the fallback on an explicit resolve, is cached, and deduplicates to a single identity across its alias variants.
+- **SC-005**: A plate-solved light-frameset yields a pre-selected high-confidence suggestion; a mount-only frameset yields a shown-but-not-pre-selected suggestion; a filename-only frameset yields no coordinate-based suggestion.
+- **SC-006**: No target link is ever created without explicit user confirmation (0% silent auto-apply across cone-search suggestions).
+
+## Assumptions
+
+- Inbox confirm remains the single ingest gate; cone-search adds a suggestion to that gate and does not create a competing ingest path.
+- The published SIMBAD resolver crate provides both a tabular path and a name-resolver fallback, a persistent-file cache backend, and magnitude in its resolved identity at the target version; constellation is derived from coordinates by the pinned sky-math library.
+- Frame field-of-view and footprint (with rotation) are computable from focal length and sensor via the pinned field-matching library; when optics are unknown the documented default radius applies.
+- Catalogue-prominence ranking and the default niche-object-type exclusion set are open research decisions (see research.md) with proposed defaults; they are refined during Phase-3 design, not left silent.
+- The online-resolve setting (spec-035 FR-015) is the single gate for all network resolution introduced here.

--- a/specs/052-simbad-caching-dual-lookup-cone-search/tasks.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/tasks.md
@@ -1,0 +1,139 @@
+---
+description: "Task list for 052-simbad-caching-dual-lookup-cone-search"
+---
+
+# Tasks: SIMBAD Resolver Caching, Dual-Lookup, and Cone-Search
+
+**Input**: Design documents from `specs/052-simbad-caching-dual-lookup-cone-search/`
+**Prerequisites**: plan.md, spec.md, research.md, data-model.md, contracts/operations.md
+
+**Tests**: Included. Persistence semantics and "never silent auto-apply" are correctness-critical, so targeted unit/integration/contract tests are part of each story.
+
+**Organization**: Grouped by user story (US1/US2/US3 = P1/P2/P3) for independent implementation and testing. Each phase is independently shippable.
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: can run in parallel (different files, no dependency).
+- Paths are repo-relative and reference real crates from plan.md.
+
+---
+
+## Phase 1: Setup
+
+- [ ] T001 Confirm baseline on branch `052-simbad-caching-dual-lookup-cone-search` (worktree off `origin/main`); run `just lint` and per-crate `cargo test -p targeting-resolver -p app-targets -p app-inbox` to record the green/red baseline (workspace-test baseline is known-red — validate per crate).
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites for P1)
+
+**⚠️ No user-story work begins until this phase is complete.**
+
+- [ ] T002 [P] Bump `simbad-resolver` `0.1.3 → 0.2.0` in `crates/targeting/resolver/Cargo.toml`; update `Cargo.lock`; skim the 0.2.0 changelog for the `SimbadResolver` facade, `CacheBackend`, `ResolverConfig`, `ResolvedIdentity.v_mag`, and Sesame-fallback API surface used below.
+- [ ] T003 [P] Fix `crates/tools/seed-builder/src/main.rs`: widen `parse_basic_row` 5-tuple → 6-tuple `(oid, main_id, ra, dec, otype, v_mag)`; add `f.V` + `LEFT OUTER JOIN allfluxes AS f ON f.oidref = b.oid` to both TAP `SELECT`s (~`:260`, `:297`); thread `v_mag` into `SeedEntry`/`insert_base`. Regenerate the bundled seed and assert magnitude is present where SIMBAD has it.
+- [ ] T004 Establish the single normalization choke-point: make `simbad_resolver::normalize` the sole entry for every identity string before caching/persisting/matching in `crates/targeting/resolver/` (audit `cache.rs`, `seed.rs`, `simbad.rs`, `caldwell.rs`, `lib.rs` for any bypass). Unit test: TAP, Sesame, Caldwell, user-query, and seed inputs for one object all normalize identically and dedup to one identity (FR-007).
+
+**Checkpoint**: 0.2.0 available, seed carries magnitude, normalization centralized.
+
+---
+
+## Phase 3: User Story 1 — Persistent cache + in-use persistence + enrichment (P1) 🎯 MVP
+
+**Goal**: Search survives restart with no re-query; durable rows written only on adoption; adopted targets enriched.
+**Independent Test**: spec US1 Independent Test.
+
+### Tests (US1)
+- [ ] T005 [P] [US1] Integration test: resolve an object, drop and rebuild the facade (simulate restart) pointing at the same redb file → second resolve issues zero network calls (SC-001). Use a spy/fake TAP that counts calls.
+- [ ] T006 [P] [US1] Integration test: browse search results without adopting → assert zero `canonical_target` rows; then add to a project → assert exactly one durable row (SC-002, FR-004).
+- [ ] T007 [P] [US1] Unit test: adopting a target populates `magnitude` (from `ResolvedIdentity.v_mag` / seed) and `constellation` (skymath) when the source has them; stays NULL when absent (FR-006, SC-003).
+- [ ] T008 [P] [US1] Unit test: two alias variants of one physical object map to a single canonical identity via the choke-point dedup (FR-007, US1 scenario 5).
+
+### Implementation (US1)
+- [ ] T009 [US1] Refactor `crates/targeting/resolver/src/simbad.rs`: replace the direct `TapResolver` wrapper with `SimbadResolver::new(TapResolver, CacheBackend::File(<app_data>/simbad-cache.redb), ResolverConfig)`; expose the facade as the crate's resolver. (D1, D2)
+- [ ] T010 [US1] Build the facade at startup with the File backend in `apps/desktop/src-tauri/src/lib.rs:~934-958` and `commands/target_lookup.rs:~49-74`, resolving the app-data path once (global, not per-library). (D2)
+- [ ] T011 [US1] Replace the hand-rolled search in `crates/targeting/resolver/src/cache.rs` (`search_by_normalized` `:245`, `search_fuzzy` `:339`) with `facade.search()` over the unified store; remove the now-dead `token_set_similarity` path if the facade covers it. (D1, FR-001)
+- [ ] T012 [US1] Warm the redb cache at first run from the bundled seed (`seed.rs`) and lazily from existing `canonical_target` rows (FR-005).
+- [ ] T013 [US1] Move `canonical_target` persistence to the in-use gate in `crates/app/targets/src/target_resolve.rs`: write only on add-to-project / link-to-session / favourite / Inbox-confirm; pure search/typeahead writes cache only (FR-004, supersede spec-035 FR-006). Audit all current persist-on-resolve call sites and remove them.
+- [ ] T014 [US1] Enrich on adoption: set `magnitude` from `ResolvedIdentity.v_mag` (online) or seed (offline) and `constellation` via skymath 0.3 IAU-from-coordinates, at the in-use write (FR-006). (D8)
+- [ ] T015 [US1] Add the `target.cache.clear` local command (clears redb, never touches `canonical_target`, re-warms from seed + durable rows) + a settings action to invoke it (FR-002).
+
+**Checkpoint**: SC-001, SC-002, SC-003 met; spec-035 FR-006 superseded in behaviour.
+
+---
+
+## Phase 4: User Story 2 — Dual lookup (P2)
+
+**Goal**: TAP-first, Sesame fallback on TAP miss, explicit-resolve only, oid recovery.
+**Independent Test**: spec US2 Independent Test. **Depends on US1 (facade + normalization + cache).**
+
+### Tests (US2)
+- [ ] T016 [P] [US2] Integration test: a designation the fake TAP misses but the fake Sesame carries resolves via fallback on explicit resolve; asserts it is cached and dedups across aliases (SC-004).
+- [ ] T017 [P] [US2] Unit test: during typeahead, the Sesame fallback is NOT invoked (call-count spy) — only on the explicit-resolve entrypoint (FR-009).
+- [ ] T018 [P] [US2] Unit test: a Sesame hit lacking `simbad_oid` is re-enriched via TAP to recover one; when unrecoverable, a UUIDv5-from-normalized-designation identity is assigned and dedups stably (FR-010).
+
+### Implementation (US2)
+- [ ] T019 [US2] Wire the facade's TAP-first / Sesame-fallback dual lookup in `crates/targeting/resolver/src/simbad.rs`; ensure the fallback runs only from the explicit-resolve path, never the typeahead path (FR-008, FR-009). (D5)
+- [ ] T020 [US2] Implement oid recovery: Sesame hit without `simbad_oid` → TAP re-enrich by coordinates/main_id → else UUIDv5-from-designation; route all designations through the choke-point (FR-010, FR-007).
+- [ ] T021 [US2] Confirm both online paths are gated by the online-resolve setting; offline degrades to seed + cache (FR-011, FR-018). Add/extend the offline-degradation test.
+
+**Checkpoint**: SC-004 met; fallback is explicit-resolve-only and gated.
+
+---
+
+## Phase 5: User Story 3 — Cone-search suggestion at Inbox ingest (P3)
+
+**Goal**: Per light-frameset, suggest a target from plate-solved/mount pointing with explicit confidence; confirm-only.
+**Independent Test**: spec US3 Independent Test. **Depends on US1 (resolution/cache/enrichment); benefits from US2.**
+
+> **Gate (Principle IV)**: Before P3 implementation, resolve research OQ-1 (catalogue-prominence ranking) and OQ-2 (default otype exclusion set) with the user; encode the confirmed values before T028/T029.
+
+### Design gate (US3)
+- [ ] T022 [US3] Resolve OQ-1 + OQ-2 with the user (proposed defaults in research.md); record the confirmed prominence ranking and exclusion set in research.md before implementing ranking.
+
+### Tests (US3)
+- [ ] T023 [P] [US3] Contract test: `target.cone_search.suggest` — plate-solved frameset → high-confidence `preselected: true`; mount-only → shown, `preselected: false`; filename-only / no pointing → `source: "none"`, empty suggestions (SC-005, FR-012, FR-014).
+- [ ] T024 [P] [US3] Unit test: multi-object frame → primary = nearest-to-centre among non-excluded, tie-broken by prominence; excluded otypes flagged not pre-selected (FR-015).
+- [ ] T025 [P] [US3] Integration test: `suggest` writes no `canonical_target` row; `confirm` writes exactly one (or reuses a dedup match) and links the frameset (SC-006, FR-016).
+- [ ] T026 [P] [US3] Unit test: rotation-aware footprint includes an object inside the true rotated field that an axis-aligned box would drop; unknown optics → ~1° default radius (FR-013).
+
+### Implementation (US3)
+- [ ] T027 [US3] Pointing derivation (per light-frameset) in `crates/app/inbox/` / `crates/app/targets/`: WCS `CRVAL1/2` → mount `OBJCTRA/OBJCTDEC` → none; never filename; sub-disagreement beyond tolerance → none (FR-012). (D9)
+- [ ] T028 [US3] Cone-search + ranking in `crates/targeting/`: FOV/footprint via target-match 0.3 (rotation-aware), radius from optics with ~1° default, top-N candidates; confidence = separation + source quality + prominence (OQ-1); exclusion set (OQ-2); nearest-to-centre primary (FR-013, FR-014, FR-015). (D9)
+- [ ] T029 [US3] Contract DTOs in `crates/contracts/core/` for `target.cone_search.suggest` + `target.cone_search.confirm` (per contracts/operations.md); register Tauri commands (fn name == invoke target, no specta rename); regenerate `packages/contracts` bindings.
+- [ ] T030 [US3] Wire cone-search at Inbox ingest per light-frameset (auto `reason: ingest`) and expose the on-demand re-run (`reason: on_demand`) (FR-017); gate on the online-resolve setting, degrade gracefully offline (`resolve.offline`, FR-018).
+- [ ] T031 [US3] Inbox confirm-gate suggestion UI in `apps/desktop/src/features/inbox/`: show ranked suggestions, pre-select only high confidence, require explicit confirm; confirm calls `target.cone_search.confirm` (never auto-apply) (FR-014, FR-016, SC-006).
+
+**Checkpoint**: SC-005, SC-006 met — coordinate-driven suggestions, confirm-only.
+
+---
+
+## Phase 6: Polish & Verification
+
+- [ ] T032 Constitution re-check (custody, reviewable/confidence-carrying suggestion, PixInsight boundary, §V cache-projection vs canonical) against the built feature.
+- [ ] T033 `just lint` / per-crate `cargo test` / `just typecheck` green; regenerate + commit bindings.
+- [ ] T034 `speckit-verify` against FR-001..FR-018 and SC-001..SC-006; `speckit-verify-tasks` to catch phantom completions.
+- [ ] T035 `verify-on-windows` scenario for US1 (persist-across-restart + in-use write) and US3 (Inbox suggestion) on the real Tauri app; add the matching tauri-driver Layer-2 journey + coverage-matrix update.
+
+---
+
+## Dependencies
+
+- **Phase 2 (T002–T004)** blocks all user-story work.
+- **US1 (T005–T015)** depends on T002/T003/T004. → MVP (P1).
+- **US2 (T016–T021)** depends on US1 (facade + normalization + cache).
+- **US3 (T022–T031)** depends on US1 (resolution/cache/enrichment); benefits from US2; T022 (OQ gate) blocks T028/T029.
+- **Phase 6 (T032–T035)** depends on the targeted stories.
+
+### Dependency graph
+
+```
+T001 ─▶ T002 ┐
+        T003 ┼─▶ US1(T005–T015) ─▶ US2(T016–T021)
+        T004 ┘         └─▶ T022(OQ gate) ─▶ US3(T023–T031)
+US1..US3 ─▶ Phase 6 (T032–T035)
+```
+
+## Parallelization notes
+
+- Foundational T002/T003 touch different files (resolver Cargo.toml vs seed-builder) → parallelizable; T004 is a focused refactor over the resolver crate.
+- Within each story, [P] tests are independent; implementation tasks touching the same file (e.g. T009/T011/T019 all in `simbad.rs`/`cache.rs`) are serialized.
+- P1 → P2 → P3 ship in order; each phase is an independently reviewable/mergeable slice.


### PR DESCRIPTION
## Summary

SpecKit feature spec **052** authoring only (no product code) — satisfies the constitution's implementation gate for the three-phase SIMBAD resolver work. Greenfield, no data migration; three independently-shippable slices.

## What's new
- `spec.md` — 3 user stories (P1/P2/P3), FR-001..FR-018, SC-001..SC-006, edge cases. FR-004 explicitly supersedes spec-035 FR-006 (persist-on-resolve → persist-on-in-use, with documented reason).
- `research.md` — decisions D1..D9 with alternatives (facade vs direct-TAP; `CacheBackend::File` redb vs InMemory vs moka(dropped); §V redb-projection/SQLite-canonical; TAP-first/Sesame-fallback; normalization choke-point; 0.2.0 bump + seed-builder V-mag fix) + two open Phase-3 research questions with proposed defaults (catalogue-prominence ranking, default otype exclusion set).
- `plan.md` — phased P1/P2/P3 with concrete crates/files touched, `simbad-resolver` 0.1.3→0.2.0 bump, seed-builder fix, P3 contract/command/UI; Constitution Check (pre-Phase-0 + post-Phase-1, both PASS).
- `data-model.md` — `canonical_target` magnitude/constellation usage, redb resolve-cache shape, cone-search suggestion/confidence model; no new SQLite table/migration.
- `contracts/operations.md` — P1/P2 add no new contract (noted); P3 adds `target.cone_search.suggest` + `target.cone_search.confirm` (language-neutral).
- `tasks.md` — dependency-ordered tasks grouped by phase/story with an exhaustive dependency graph.

## Notes
- Authored manually as an orchestration-run node (run-052 campaign brief), not via the `/speckit.*` skill flow — deliberate deviation from the repo's "invoke speckit via Skill" convention.

## Spec Context
- Spec: 052
- Branch: 052-simbad-caching-dual-lookup-cone-search