### PR TITLE
feat: add map picker to first-run Observing Site step

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -953,6 +953,8 @@
   "setup_step_site_heading": "Where do you observe from?",
   "setup_step_site_desc": "Add your observing location so the Targets Planner can show real tonight altitude, visibility, and imaging time.",
   "setup_site_intro": "Optional — add one observing site now, or skip and add it later from Settings → Target Planner.",
+  "setup_site_map_label": "Pick on map",
+  "setup_site_map_unavailable": "Map unavailable right now — enter your coordinates in the fields below.",
   "setup_site_skip_note": "You can leave this blank and set it up later; the Planner will prompt you when it's needed.",
   "setup_step_scan_desc": "Scanning each source folder and detecting ingestion groups.",
   "setup_step_scan_heading": "Scanning your library",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -51,6 +51,7 @@
     "cmdk": "1.1.1",
     "date-fns": "4.4.0",
     "lucide-react": "1.24.0",
+    "maplibre-gl": "^5.24.0",
     "pathe": "2.0.3",
     "react": "^19.2.7",
     "react-dom": "^19.2.7",

--- a/apps/desktop/src/features/setup/steps/SiteLocationPicker.test.tsx
+++ b/apps/desktop/src/features/setup/steps/SiteLocationPicker.test.tsx
@@ -1,0 +1,157 @@
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * SiteLocationPicker tests (issue #491) — the Observing Site step's map
+ * picker. `maplibre-gl` requires a real WebGL context, which jsdom doesn't
+ * provide, so the module is mocked at the boundary with a fake Map/Marker
+ * that records calls the way the real classes would be driven.
+ */
+import { render, screen, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { MockMap, MockMarker, MockNavigationControl } = vi.hoisted(() => {
+  class MockMap {
+    static instances: MockMap[] = [];
+    // Simulates a webview with no WebGL support (real MapLibre throws
+    // synchronously from its constructor in that case).
+    static shouldThrowOnConstruct = false;
+    listeners: Record<string, Array<(...args: unknown[]) => void>> = {};
+    removed = false;
+    easeToCalls: Array<{ center: [number, number] }> = [];
+    options: unknown;
+    constructor(options: unknown) {
+      if (MockMap.shouldThrowOnConstruct) {
+        throw new Error('Failed to initialize WebGL');
+      }
+      this.options = options;
+      MockMap.instances.push(this);
+    }
+    on(event: string, cb: (...args: unknown[]) => void) {
+      (this.listeners[event] ??= []).push(cb);
+    }
+    addControl() {}
+    remove() {
+      this.removed = true;
+    }
+    easeTo(opts: { center: [number, number] }) {
+      this.easeToCalls.push(opts);
+    }
+    emit(event: string, ...args: unknown[]) {
+      for (const cb of this.listeners[event] ?? []) cb(...args);
+    }
+  }
+  class MockMarker {
+    lngLat: [number, number] | null = null;
+    setLngLat(ll: [number, number]) {
+      this.lngLat = ll;
+      return this;
+    }
+    addTo() {
+      return this;
+    }
+  }
+  class MockNavigationControl {}
+  return { MockMap, MockMarker, MockNavigationControl };
+});
+
+vi.mock('maplibre-gl', () => ({
+  Map: MockMap,
+  Marker: MockMarker,
+  NavigationControl: MockNavigationControl,
+}));
+vi.mock('maplibre-gl/dist/maplibre-gl.css', () => ({}));
+
+import { SiteLocationPicker } from './SiteLocationPicker';
+
+beforeEach(() => {
+  MockMap.instances.length = 0;
+  MockMap.shouldThrowOnConstruct = false;
+});
+
+describe('SiteLocationPicker', () => {
+  it('reports coordinates when the map is clicked', () => {
+    const onPick = vi.fn();
+    render(
+      <SiteLocationPicker
+        latitudeDeg={null}
+        longitudeDeg={null}
+        onPick={onPick}
+      />,
+    );
+
+    const map = MockMap.instances[0];
+    expect(map).toBeDefined();
+    act(() => {
+      map.emit('click', { lngLat: { lat: 51.5, lng: -0.12 } });
+    });
+
+    expect(onPick).toHaveBeenCalledWith(51.5, -0.12);
+  });
+
+  it('recenters the pin when lat/long props change (fields edited)', () => {
+    const { rerender } = render(
+      <SiteLocationPicker
+        latitudeDeg={null}
+        longitudeDeg={null}
+        onPick={vi.fn()}
+      />,
+    );
+    const map = MockMap.instances[0];
+
+    act(() => {
+      rerender(
+        <SiteLocationPicker
+          latitudeDeg={40.7}
+          longitudeDeg={-74}
+          onPick={vi.fn()}
+        />,
+      );
+    });
+
+    expect(map.easeToCalls).toContainEqual({ center: [-74, 40.7] });
+
+    act(() => {
+      rerender(
+        <SiteLocationPicker
+          latitudeDeg={41}
+          longitudeDeg={-75}
+          onPick={vi.fn()}
+        />,
+      );
+    });
+
+    expect(map.easeToCalls).toContainEqual({ center: [-75, 41] });
+  });
+
+  it('degrades gracefully when the map/tiles fail to load', () => {
+    render(
+      <SiteLocationPicker
+        latitudeDeg={null}
+        longitudeDeg={null}
+        onPick={vi.fn()}
+      />,
+    );
+    const map = MockMap.instances[0];
+
+    act(() => {
+      map.emit('error', { error: new Error('tile load failed') });
+    });
+
+    expect(screen.queryByTestId('site-location-map')).not.toBeInTheDocument();
+    expect(screen.getByText(/map unavailable/i)).toBeInTheDocument();
+  });
+
+  it('degrades gracefully when the map fails to construct (no WebGL)', () => {
+    MockMap.shouldThrowOnConstruct = true;
+
+    render(
+      <SiteLocationPicker
+        latitudeDeg={null}
+        longitudeDeg={null}
+        onPick={vi.fn()}
+      />,
+    );
+
+    expect(screen.queryByTestId('site-location-map')).not.toBeInTheDocument();
+    expect(screen.getByText(/map unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/setup/steps/SiteLocationPicker.test.tsx
+++ b/apps/desktop/src/features/setup/steps/SiteLocationPicker.test.tsx
@@ -33,15 +33,32 @@ const { MockMap, MockMarker, MockNavigationControl } = vi.hoisted(() => {
       this.removed = true;
     }
     easeTo(opts: { center: [number, number] }) {
+      assertValidLngLat(opts.center);
       this.easeToCalls.push(opts);
     }
     emit(event: string, ...args: unknown[]) {
       for (const cb of this.listeners[event] ?? []) cb(...args);
     }
   }
+  // Mirrors real MapLibre's `LngLat.convert` validation, which throws
+  // synchronously for out-of-range coordinates (e.g. latitude 200) — the bug
+  // this test suite regression-guards against.
+  function assertValidLngLat([lng, lat]: [number, number]): void {
+    if (lat < -90 || lat > 90) {
+      throw new Error(
+        'Invalid LngLat latitude value: must be between -90 and 90',
+      );
+    }
+    if (lng < -180 || lng > 180) {
+      throw new Error(
+        'Invalid LngLat longitude value: must be between -180 and 180',
+      );
+    }
+  }
   class MockMarker {
     lngLat: [number, number] | null = null;
     setLngLat(ll: [number, number]) {
+      assertValidLngLat(ll);
       this.lngLat = ll;
       return this;
     }
@@ -138,6 +155,36 @@ describe('SiteLocationPicker', () => {
 
     expect(screen.queryByTestId('site-location-map')).not.toBeInTheDocument();
     expect(screen.getByText(/map unavailable/i)).toBeInTheDocument();
+  });
+
+  it('ignores an out-of-range latitude instead of crashing (regression)', () => {
+    // The lat/long fields intentionally accept out-of-range values while the
+    // wizard's own validation (siteStepError) hasn't rejected them yet — the
+    // map must not pass those straight to MapLibre, which throws for them.
+    const { rerender } = render(
+      <SiteLocationPicker
+        latitudeDeg={null}
+        longitudeDeg={null}
+        onPick={vi.fn()}
+      />,
+    );
+    const map = MockMap.instances[0];
+
+    expect(() => {
+      act(() => {
+        rerender(
+          <SiteLocationPicker
+            latitudeDeg={200}
+            longitudeDeg={10}
+            onPick={vi.fn()}
+          />,
+        );
+      });
+    }).not.toThrow();
+
+    expect(map.easeToCalls).toHaveLength(0);
+    expect(screen.getByTestId('site-location-map')).toBeInTheDocument();
+    expect(screen.queryByText(/map unavailable/i)).not.toBeInTheDocument();
   });
 
   it('degrades gracefully when the map fails to construct (no WebGL)', () => {

--- a/apps/desktop/src/features/setup/steps/SiteLocationPicker.tsx
+++ b/apps/desktop/src/features/setup/steps/SiteLocationPicker.tsx
@@ -18,6 +18,15 @@ const DEFAULT_CENTER: [number, number] = [10, 20];
 const DEFAULT_ZOOM = 1;
 const PICKED_ZOOM = 6;
 
+// The lat/long text fields intentionally accept out-of-range values while the
+// user is typing (`siteStepError` catches those on blur/submit) — but
+// MapLibre's LngLat validation throws synchronously for e.g. latitude 200,
+// which would crash the whole step from inside an effect. Only geographically
+// valid coordinates are ever handed to the map.
+function isValidLngLat(lat: number, lon: number): boolean {
+  return lat >= -90 && lat <= 90 && lon >= -180 && lon <= 180;
+}
+
 export interface SiteLocationPickerProps {
   /** `null` when the field is blank or not a valid number — no pin is shown. */
   latitudeDeg: number | null;
@@ -46,16 +55,16 @@ export function SiteLocationPicker({
   // Freeze the initial center/zoom at mount time — later coordinate changes
   // are handled by the recenter effect below, not by re-running this one.
   const [initialView] = useState<{ center: [number, number]; zoom: number }>(
-    () => ({
-      center:
-        latitudeDeg != null && longitudeDeg != null
-          ? [longitudeDeg, latitudeDeg]
-          : DEFAULT_CENTER,
-      zoom:
-        latitudeDeg != null && longitudeDeg != null
-          ? PICKED_ZOOM
-          : DEFAULT_ZOOM,
-    }),
+    () => {
+      const hasValidCoords =
+        latitudeDeg != null &&
+        longitudeDeg != null &&
+        isValidLngLat(latitudeDeg, longitudeDeg);
+      return {
+        center: hasValidCoords ? [longitudeDeg, latitudeDeg] : DEFAULT_CENTER,
+        zoom: hasValidCoords ? PICKED_ZOOM : DEFAULT_ZOOM,
+      };
+    },
   );
 
   useEffect(() => {
@@ -90,18 +99,26 @@ export function SiteLocationPicker({
   }, [initialView]);
 
   // Recenter + move the pin when the numeric fields change externally.
+  // Fields are still mid-edit / out-of-range while the user types (e.g. a
+  // latitude of 200 before `siteStepError` catches it on blur) — the map
+  // just leaves the pin where it was rather than touching MapLibre with an
+  // invalid coordinate.
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
     if (latitudeDeg == null || longitudeDeg == null) return;
-    if (!Number.isFinite(latitudeDeg) || !Number.isFinite(longitudeDeg)) return;
+    if (!isValidLngLat(latitudeDeg, longitudeDeg)) return;
     const lngLat: [number, number] = [longitudeDeg, latitudeDeg];
-    if (markerRef.current) {
-      markerRef.current.setLngLat(lngLat);
-    } else {
-      markerRef.current = new Marker().setLngLat(lngLat).addTo(map);
+    try {
+      if (markerRef.current) {
+        markerRef.current.setLngLat(lngLat);
+      } else {
+        markerRef.current = new Marker().setLngLat(lngLat).addTo(map);
+      }
+      map.easeTo({ center: lngLat });
+    } catch {
+      // Belt-and-suspenders: never let a map call crash the wizard.
     }
-    map.easeTo({ center: lngLat });
   }, [latitudeDeg, longitudeDeg]);
 
   if (unavailable) {

--- a/apps/desktop/src/features/setup/steps/SiteLocationPicker.tsx
+++ b/apps/desktop/src/features/setup/steps/SiteLocationPicker.tsx
@@ -1,0 +1,124 @@
+// Observing Site step: interactive map picker (spec 044 journey-1, issue #491).
+//
+// The numeric lat/long fields on `StepSite` remain the source of truth —
+// this component only translates between them and a MapLibre map: a click
+// reports coordinates up via `onPick`, and a `latitudeDeg`/`longitudeDeg`
+// prop change (from editing the fields) recenters the pin. If the map
+// fails to construct or load (offline, tile-provider outage, no WebGL in
+// the host webview), it degrades to a small notice rather than a blank
+// canvas or a crash — the fields keep working either way.
+import { useEffect, useRef, useState } from 'react';
+import { Map as MapLibreMap, Marker, NavigationControl } from 'maplibre-gl';
+import 'maplibre-gl/dist/maplibre-gl.css';
+import { m } from '@/lib/i18n';
+import { mapTileProviderStyle } from '@/lib/map-tile-provider';
+
+// World view used before any coordinates are set.
+const DEFAULT_CENTER: [number, number] = [10, 20];
+const DEFAULT_ZOOM = 1;
+const PICKED_ZOOM = 6;
+
+export interface SiteLocationPickerProps {
+  /** `null` when the field is blank or not a valid number — no pin is shown. */
+  latitudeDeg: number | null;
+  longitudeDeg: number | null;
+  /** Fired when the user clicks the map; the caller updates the numeric fields. */
+  onPick: (latitudeDeg: number, longitudeDeg: number) => void;
+}
+
+export function SiteLocationPicker({
+  latitudeDeg,
+  longitudeDeg,
+  onPick,
+}: SiteLocationPickerProps) {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const mapRef = useRef<MapLibreMap | null>(null);
+  const markerRef = useRef<Marker | null>(null);
+  const onPickRef = useRef(onPick);
+  const [unavailable, setUnavailable] = useState(false);
+
+  // Keep the ref in sync outside of render (assigning ref.current during
+  // render is flagged by react-hooks/refs).
+  useEffect(() => {
+    onPickRef.current = onPick;
+  });
+
+  // Freeze the initial center/zoom at mount time — later coordinate changes
+  // are handled by the recenter effect below, not by re-running this one.
+  const [initialView] = useState<{ center: [number, number]; zoom: number }>(
+    () => ({
+      center:
+        latitudeDeg != null && longitudeDeg != null
+          ? [longitudeDeg, latitudeDeg]
+          : DEFAULT_CENTER,
+      zoom:
+        latitudeDeg != null && longitudeDeg != null
+          ? PICKED_ZOOM
+          : DEFAULT_ZOOM,
+    }),
+  );
+
+  useEffect(() => {
+    if (!containerRef.current) return;
+    let map: MapLibreMap;
+    try {
+      map = new MapLibreMap({
+        container: containerRef.current,
+        style: mapTileProviderStyle(),
+        center: initialView.center,
+        zoom: initialView.zoom,
+      });
+    } catch {
+      // No WebGL / construction failure — never blocks the wizard.
+      setUnavailable(true);
+      return;
+    }
+    mapRef.current = map;
+    map.addControl(new NavigationControl({ showCompass: false }), 'top-right');
+    // Style/tile load failures (offline, provider outage) surface as an
+    // async 'error' event rather than a thrown exception.
+    map.on('error', () => setUnavailable(true));
+    map.on('click', (e) => {
+      onPickRef.current(e.lngLat.lat, e.lngLat.lng);
+    });
+
+    return () => {
+      map.remove();
+      mapRef.current = null;
+      markerRef.current = null;
+    };
+  }, [initialView]);
+
+  // Recenter + move the pin when the numeric fields change externally.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    if (latitudeDeg == null || longitudeDeg == null) return;
+    if (!Number.isFinite(latitudeDeg) || !Number.isFinite(longitudeDeg)) return;
+    const lngLat: [number, number] = [longitudeDeg, latitudeDeg];
+    if (markerRef.current) {
+      markerRef.current.setLngLat(lngLat);
+    } else {
+      markerRef.current = new Marker().setLngLat(lngLat).addTo(map);
+    }
+    map.easeTo({ center: lngLat });
+  }, [latitudeDeg, longitudeDeg]);
+
+  if (unavailable) {
+    return (
+      <p className="alm-step-site__map-unavailable">
+        {m.setup_site_map_unavailable()}
+      </p>
+    );
+  }
+
+  return (
+    <div
+      ref={containerRef}
+      className="alm-step-site__map"
+      data-testid="site-location-map"
+      role="application"
+      aria-label={m.setup_site_map_label()}
+    />
+  );
+}

--- a/apps/desktop/src/features/setup/steps/StepSite.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSite.tsx
@@ -14,6 +14,7 @@ import {
   ianaTimezones,
 } from '@/features/targets/observing-sites/iana-timezones';
 import type { Twilight } from '@/features/targets/observing-sites/observer-site';
+import { SiteLocationPicker } from './SiteLocationPicker';
 
 export interface SiteStepState {
   name: string;
@@ -75,6 +76,14 @@ export function siteStepError(state: SiteStepState): string | null {
  * wizard owns its own step-state shape rather than the settings-backed
  * site-store (the site isn't persisted until Finish).
  */
+/** Parsed field value for the map, or `null` when blank/not-a-number (no pin shown). */
+function parsedCoord(text: string): number | null {
+  const trimmed = text.trim();
+  if (trimmed === '') return null;
+  const n = Number(trimmed);
+  return Number.isFinite(n) ? n : null;
+}
+
 export function StepSite({ state, onChange }: StepSiteProps) {
   const timezones = ianaTimezones();
   const error = siteStepError(state);
@@ -82,6 +91,21 @@ export function StepSite({ state, onChange }: StepSiteProps) {
   return (
     <div className="alm-step-site">
       <p className="alm-step-site__intro">{m.setup_site_intro()}</p>
+
+      <div className="alm-step-site__map-section">
+        <span className="alm-field-label">{m.setup_site_map_label()}</span>
+        <SiteLocationPicker
+          latitudeDeg={parsedCoord(state.latitudeDegText)}
+          longitudeDeg={parsedCoord(state.longitudeDegText)}
+          onPick={(lat, lon) =>
+            onChange({
+              ...state,
+              latitudeDegText: lat.toFixed(5),
+              longitudeDegText: lon.toFixed(5),
+            })
+          }
+        />
+      </div>
 
       <div className="alm-step-site__grid">
         <div className="alm-stack-1">

--- a/apps/desktop/src/lib/map-tile-provider.ts
+++ b/apps/desktop/src/lib/map-tile-provider.ts
@@ -1,0 +1,19 @@
+// Map tile-provider abstraction (spec 044 journey-1, issue #491).
+//
+// Callers ask for a MapLibre style via `mapTileProviderStyle()` instead of
+// hard-coding a tile URL, so swapping providers later is a one-line change
+// here, not a call-site change.
+//
+// Swap points:
+//   - Protomaps hosted API (keyed): return
+//     `https://api.protomaps.com/styles/v5/light/en.json?key=${apiKey}`.
+//   - Self-hosted Protomaps `.pmtiles` (e.g. on R2): return a local style
+//     object whose source `url` is `pmtiles://https://<bucket>/<file>.pmtiles`,
+//     and register the `pmtiles` protocol via `maplibregl.addProtocol` once at
+//     startup (see https://docs.protomaps.com/pmtiles/maplibre).
+import type { StyleSpecification } from 'maplibre-gl';
+
+/** Current provider: OpenFreeMap public tiles — no API key, no signup. */
+export function mapTileProviderStyle(): string | StyleSpecification {
+  return 'https://tiles.openfreemap.org/styles/liberty';
+}

--- a/apps/desktop/src/styles/components/wizard-steps.css
+++ b/apps/desktop/src/styles/components/wizard-steps.css
@@ -1401,6 +1401,31 @@
   gap: var(--alm-sp-3);
 }
 
+/* Map picker (issue #491) — click sets lat/long; fields stay the source of
+   truth and recenter the pin when edited directly. */
+.alm-step-site__map-section {
+  display: flex;
+  flex-direction: column;
+  gap: var(--alm-sp-2);
+}
+
+.alm-step-site__map {
+  width: 100%;
+  height: 240px;
+  border: 1px solid var(--alm-border);
+  border-radius: var(--alm-radius-md);
+  overflow: hidden;
+}
+
+.alm-step-site__map-unavailable {
+  margin: 0;
+  padding: var(--alm-sp-3);
+  border: 1px dashed var(--alm-border);
+  border-radius: var(--alm-radius-md);
+  font-size: var(--alm-text-sm);
+  color: var(--alm-text-secondary);
+}
+
 .alm-step-site__note {
   margin: 0;
   font-size: var(--alm-text-xs);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -86,6 +86,9 @@ importers:
       lucide-react:
         specifier: 1.24.0
         version: 1.24.0(react@19.2.7)
+      maplibre-gl:
+        specifier: ^5.24.0
+        version: 5.24.0
       pathe:
         specifier: 2.0.3
         version: 2.0.3
@@ -943,6 +946,42 @@ packages:
 
   '@lix-js/server-protocol-schema@0.1.1':
     resolution: {integrity: sha512-jBeALB6prAbtr5q4vTuxnRZZv1M2rKe8iNqRQhFJ4Tv7150unEa0vKyz0hs8Gl3fUGsWaNJBh3J8++fpbrpRBQ==}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3':
+    resolution: {integrity: sha512-0SElaV0uMxEnxzBhhX9WTuPyUeMsAN/SS0i16tjuba4/mio63MG9khjC1a0JAiPGXAwvwm4UfHJURCN7nyudQg==}
+    engines: {node: '>= 22'}
+
+  '@mapbox/point-geometry@1.1.0':
+    resolution: {integrity: sha512-YGcBz1cg4ATXDCM/71L9xveh4dynfGmcLDqufR+nQQy3fKwsAZsWd/x4621/6uJaeB9mwOHE6hPeDgXz9uViUQ==}
+
+  '@mapbox/tiny-sdf@2.2.0':
+    resolution: {integrity: sha512-LVL4wgI9YAum5V+LNVQO6QgFBPw7/MIIY4XJPNsPDMrjEwcE+JfKk1LuIl8GnF197ejVdC9QdPaxrx5gfgdGXg==}
+
+  '@mapbox/unitbezier@0.0.1':
+    resolution: {integrity: sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==}
+
+  '@mapbox/unitbezier@1.0.0':
+    resolution: {integrity: sha512-fqd515fjBmANKGGsQ286E2Wvj/XvDFpGzwJxq4CI6jMQue6Oy04uCKp+JWKF00xRTmk6cEu1jPJ9p3xqH8YWqQ==}
+
+  '@mapbox/vector-tile@2.0.5':
+    resolution: {integrity: sha512-pXj8m7KTsqZt+1jsE0xIpGvqTSbblfkuEJL/NJmNePMtEwxO8V3XMDo9WMSfDeqHvCtBI9Lmt4mGcGR10zecmw==}
+
+  '@mapbox/whoots-js@3.1.0':
+    resolution: {integrity: sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==}
+    engines: {node: '>=6.0.0'}
+
+  '@maplibre/geojson-vt@6.1.1':
+    resolution: {integrity: sha512-FVMOcmSP/yqol45t7StApEyTL5/vmqBCuFhH9n+fFuINenhaX+YgHHIt1yJ86S8kln3uJLcMvmEU2cfn6E2eCQ==}
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    resolution: {integrity: sha512-lichxSiagMEBBrqHF0trtMQH9RKh+9jUlIJl0qW0QHvt2H/tbvUWdE+ZzI2Jd0/pT7j/iavLonlPu7EQ/ixTOw==}
+    hasBin: true
+
+  '@maplibre/mlt@1.1.12':
+    resolution: {integrity: sha512-ZeK5w2TTeHOajcLaEQs1KZXw2V9wIKo1PmThlxlsHoXsQsYlBqLJzPOd6tJHRtGTChUY3DPPmjXRArYVvAbmZw==}
+
+  '@maplibre/vt-pbf@4.3.2':
+    resolution: {integrity: sha512-j6p0AdjvAR19Z3XaCysle7A4ZSo08tYOzxD0Y9NQylwPAkwJJeYub5b2eVucdeDh7erhv69DahoLOevDRERRUw==}
 
   '@napi-rs/wasm-runtime@1.1.6':
     resolution: {integrity: sha512-ZLv/JdUfkvOy9eCnnBaGfiO+XimbjebAeO+MRQqD/B+FR1tnRN0tpKSJHRbE8sFfS6aqsXZ67TQjfwfsxULVbg==}
@@ -2405,6 +2444,9 @@ packages:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
+  earcut@3.2.3:
+    resolution: {integrity: sha512-vnS4AVwp1KHAF13i1vp1/2D5evWy3k5u/iW/B81QVsUZtV8cv2tU0b2VNFlqvh4kYwrFMDdjPCfAmfyJW9y14Q==}
+
   electron-to-chromium@1.5.349:
     resolution: {integrity: sha512-QsWVGyRuY07Aqb234QytTfwd5d9AJlfNIQ5wIOl1L+PZDzI9d9+Fn0FRale/QYlFxt/bUnB0/nLd1jFPGxGK1A==}
 
@@ -2656,6 +2698,9 @@ packages:
 
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
+
+  gl-matrix@3.4.4:
+    resolution: {integrity: sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==}
 
   glob-parent@6.0.2:
     resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
@@ -2932,6 +2977,9 @@ packages:
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
 
+  json-stringify-pretty-compact@4.0.0:
+    resolution: {integrity: sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
@@ -2940,6 +2988,9 @@ packages:
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
+
+  kdbush@4.1.0:
+    resolution: {integrity: sha512-e9vurzrXJQrFX6ckpHP3bvj5l+9CnYzkxDNnNQ1h2QTqdWsUAJgXiKdGNcOa1EY85dU8KbQ+z/FdQdB7P+9yfQ==}
 
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -3082,6 +3133,10 @@ packages:
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
 
+  maplibre-gl@5.24.0:
+    resolution: {integrity: sha512-ALyFxgtd5R+65UqZ/++lOqwWcC0SNho9c27fYSyLmG7AfnAul2o46F05aDJGPbFU57wos9dgcIySHs0Xe6ia3A==}
+    engines: {node: '>=16.14.0', npm: '>=8.1.0'}
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3119,6 +3174,9 @@ packages:
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  murmurhash-js@1.0.0:
+    resolution: {integrity: sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==}
 
   nanoid@3.3.12:
     resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
@@ -3214,6 +3272,14 @@ packages:
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
 
+  pbf@4.0.2:
+    resolution: {integrity: sha512-J0ajxARhZfpUEebxYs1vhMGMuLSXtBe1e+fFPDrf2uA2hgo+UshKfNUWOz92HJNz6/NFEXseQPddnHkTreWRqg==}
+    hasBin: true
+
+  pbf@5.1.2:
+    resolution: {integrity: sha512-mnvGdvOrIvJOBGUEdGkrVXjN8E/VkIJCkf2eS1DH2yv82ORUlLttmDt0rWY38yYZmVwciZwBUvHM20qxBZf40w==}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -3257,6 +3323,9 @@ packages:
     resolution: {integrity: sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==}
     engines: {node: ^10 || ^12 || >=14}
 
+  potpack@2.1.0:
+    resolution: {integrity: sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==}
+
   precinct@12.3.2:
     resolution: {integrity: sha512-JbJevI1K80z8e/WIyDt/4vUN/4qcfBSKKqOjJA4mosPPPb7zODKRJQV7YN7apVWN3k58nZYm/vEsLgEGYmnxwg==}
     engines: {node: '>=18'}
@@ -3279,9 +3348,15 @@ packages:
     resolution: {integrity: sha512-973driJZvxiGOQ5ONsFhOF/DtzPMOMtgC11kCpUrPGMTgqp2q/1gwzCquocrN33is0VZ5GFHXZYMM9l6h67v2Q==}
     engines: {node: '>=10'}
 
+  protocol-buffers-schema@3.6.1:
+    resolution: {integrity: sha512-VG2K63Igkiv9p76tk1lilczEK1cT+kCjKtkdhw1dQZV3k3IXJbd3o6Ho8b9zJZaHSnT2hKe4I+ObmX9w6m5SmQ==}
+
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
+
+  quickselect@3.0.0:
+    resolution: {integrity: sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==}
 
   quote-unquote@1.0.0:
     resolution: {integrity: sha512-twwRO/ilhlG/FIgYeKGFqyHhoEhqgnKVkcmqMKi2r524gz3ZbDTcyFt38E9xjJI2vT+KbRNHVbnJ/e0I25Azwg==}
@@ -3398,6 +3473,9 @@ packages:
 
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
+
+  resolve-protobuf-schema@2.1.0:
+    resolution: {integrity: sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==}
 
   resolve@1.22.12:
     resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
@@ -3639,6 +3717,9 @@ packages:
   tinykeys@4.0.0:
     resolution: {integrity: sha512-z5bQRQHL1PSx3lGOZEAMM2oKp0EBtn5T5f7HJnaKPOzk6vEH0wUPvdHLeQ7F4tmkek8AgoTQISUFmn/5SNF2xA==}
     engines: {node: '>=22'}
+
+  tinyqueue@3.0.0:
+    resolution: {integrity: sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==}
 
   tinyrainbow@3.1.0:
     resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
@@ -4564,6 +4645,47 @@ snapshots:
       - babel-plugin-macros
 
   '@lix-js/server-protocol-schema@0.1.1': {}
+
+  '@mapbox/jsonlint-lines-primitives@2.0.3': {}
+
+  '@mapbox/point-geometry@1.1.0': {}
+
+  '@mapbox/tiny-sdf@2.2.0': {}
+
+  '@mapbox/unitbezier@0.0.1': {}
+
+  '@mapbox/unitbezier@1.0.0': {}
+
+  '@mapbox/vector-tile@2.0.5':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 4.0.2
+
+  '@mapbox/whoots-js@3.1.0': {}
+
+  '@maplibre/geojson-vt@6.1.1':
+    dependencies:
+      kdbush: 4.1.0
+
+  '@maplibre/maplibre-gl-style-spec@24.10.0':
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/unitbezier': 1.0.0
+      json-stringify-pretty-compact: 4.0.0
+      minimist: 1.2.8
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
+  '@maplibre/mlt@1.1.12':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+
+  '@maplibre/vt-pbf@4.3.2':
+    dependencies:
+      '@mapbox/point-geometry': 1.1.0
+      '@types/geojson': 7946.0.16
+      pbf: 5.1.2
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.0)(@emnapi/runtime@1.11.0)':
     dependencies:
@@ -5914,6 +6036,8 @@ snapshots:
       es-errors: 1.3.0
       gopd: 1.2.0
 
+  earcut@3.2.3: {}
+
   electron-to-chromium@1.5.349: {}
 
   emoji-regex@9.2.2: {}
@@ -6318,6 +6442,8 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  gl-matrix@3.4.4: {}
+
   glob-parent@6.0.2:
     dependencies:
       is-glob: 4.0.3
@@ -6581,6 +6707,8 @@ snapshots:
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
+  json-stringify-pretty-compact@4.0.0: {}
+
   json5@2.2.3: {}
 
   jsx-ast-utils@3.3.5:
@@ -6589,6 +6717,8 @@ snapshots:
       array.prototype.flat: 1.3.3
       object.assign: 4.1.7
       object.values: 1.2.1
+
+  kdbush@4.1.0: {}
 
   keyv@4.5.4:
     dependencies:
@@ -6721,6 +6851,28 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  maplibre-gl@5.24.0:
+    dependencies:
+      '@mapbox/jsonlint-lines-primitives': 2.0.3
+      '@mapbox/point-geometry': 1.1.0
+      '@mapbox/tiny-sdf': 2.2.0
+      '@mapbox/unitbezier': 0.0.1
+      '@mapbox/vector-tile': 2.0.5
+      '@mapbox/whoots-js': 3.1.0
+      '@maplibre/geojson-vt': 6.1.1
+      '@maplibre/maplibre-gl-style-spec': 24.10.0
+      '@maplibre/mlt': 1.1.12
+      '@maplibre/vt-pbf': 4.3.2
+      '@types/geojson': 7946.0.16
+      earcut: 3.2.3
+      gl-matrix: 3.4.4
+      kdbush: 4.1.0
+      murmurhash-js: 1.0.0
+      pbf: 4.0.2
+      potpack: 2.1.0
+      quickselect: 3.0.0
+      tinyqueue: 3.0.0
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.27.1: {}
@@ -6751,6 +6903,8 @@ snapshots:
       requirejs-config-file: 4.0.0
 
   ms@2.1.3: {}
+
+  murmurhash-js@1.0.0: {}
 
   nanoid@3.3.12: {}
 
@@ -6895,6 +7049,14 @@ snapshots:
 
   pathe@2.0.3: {}
 
+  pbf@4.0.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
+  pbf@5.1.2:
+    dependencies:
+      resolve-protobuf-schema: 2.1.0
+
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
@@ -6932,6 +7094,8 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  potpack@2.1.0: {}
+
   precinct@12.3.2:
     dependencies:
       '@dependents/detective-less': 5.0.3
@@ -6966,7 +7130,11 @@ snapshots:
     dependencies:
       parse-ms: 2.1.0
 
+  protocol-buffers-schema@3.6.1: {}
+
   punycode@2.3.1: {}
+
+  quickselect@3.0.0: {}
 
   quote-unquote@1.0.0: {}
 
@@ -7091,6 +7259,10 @@ snapshots:
   resolve-dependency-path@4.0.1: {}
 
   resolve-pkg-maps@1.0.0: {}
+
+  resolve-protobuf-schema@2.1.0:
+    dependencies:
+      protocol-buffers-schema: 3.6.1
 
   resolve@1.22.12:
     dependencies:
@@ -7365,6 +7537,8 @@ snapshots:
       picomatch: 4.0.5
 
   tinykeys@4.0.0: {}
+
+  tinyqueue@3.0.0: {}
 
   tinyrainbow@3.1.0: {}
 


### PR DESCRIPTION
## Summary
The first-run setup wizard's Observing Site step now includes an interactive map: pan/zoom and click to drop a pin instead of typing coordinates blind. The numeric latitude/longitude/elevation fields remain authoritative — clicking the map fills them in, and editing them moves the pin.

## What's new
- Interactive map (MapLibre GL, OpenFreeMap tiles) in the Observing Site wizard step; click anywhere to set the site's coordinates.
- Numeric fields and map stay in sync in both directions; fields still work standalone.
- If the map or tiles fail to load (offline, no WebGL, tile-provider outage), the step shows a small "map unavailable" note instead of a blank map or a crash — setup is never blocked.
- Tile provider is swappable via a single config point (`apps/desktop/src/lib/map-tile-provider.ts`), so moving to a keyed provider or self-hosted tiles later doesn't require touching the picker component.

Closes #491

## Spec Context
- Spec: 491
- Branch: feat/491-observing-site-map-picker