### PR TITLE
feat: press Enter to search more catalogues when a target name isn't in SIMBAD

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -164,6 +164,7 @@
   "cmp_target_search_catalogue_label": "Catalogue",
   "cmp_target_search_filters_aria": "Search filters",
   "cmp_target_search_no_results": "No matching targets.",
+  "cmp_target_search_no_results_hint": "No matches in SIMBAD —",
   "cmp_target_search_search_harder": "Search more catalogues (NED/VizieR)",
   "cmp_target_search_search_harder_no_results": "Still no matching targets.",
   "cmp_target_search_search_harder_searching": "Searching more catalogues…",

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
@@ -613,6 +613,131 @@ describe('TargetSearch', () => {
     ).toBeNull();
   });
 
+  // ── "Search more catalogues" hybrid UX (spec 052 P2UX) ─────────────────────
+
+  it('frames the zero-result state as a next step, inline with the fallback button', async () => {
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [],
+    });
+    render(<TargetSearch onSelect={vi.fn()} />);
+    await typeAndFlush(screen.getByRole('combobox'), 'zzz-unknown');
+
+    expect(screen.getByText('No matches in SIMBAD —')).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', {
+        name: 'Search more catalogues (NED/VizieR)',
+      }),
+    ).toBeInTheDocument();
+    // The old bare "no matches" message is superseded by the inline framing.
+    expect(screen.queryByText('No matching targets.')).toBeNull();
+  });
+
+  it('shows the plain no-matches message below the resolve minimum length (no fallback offered yet)', async () => {
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [],
+    });
+    render(<TargetSearch onSelect={vi.fn()} />);
+    await typeAndFlush(screen.getByRole('combobox'), 'ic'); // 2 chars < 3
+
+    expect(screen.getByText('No matching targets.')).toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', {
+        name: 'Search more catalogues (NED/VizieR)',
+      }),
+    ).toBeNull();
+  });
+
+  it('shows "Searching more catalogues…" while the explicit fallback is in flight', async () => {
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [],
+    });
+    let releaseExplicit: (() => void) | null = null;
+    mockResolveExplicit.mockImplementation(
+      () =>
+        new Promise((res) => {
+          releaseExplicit = () => res(resolved(SIMBAD_LBN));
+        }),
+    );
+
+    render(<TargetSearch onSelect={vi.fn()} />);
+    await typeAndFlush(screen.getByRole('combobox'), 'lbn 552');
+
+    const btn = screen.getByRole('button', {
+      name: 'Search more catalogues (NED/VizieR)',
+    });
+    await act(async () => {
+      fireEvent.click(btn);
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Searching more catalogues…')).toBeInTheDocument();
+
+    await act(async () => {
+      releaseExplicit?.();
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    });
+    expect(
+      screen.queryByText('Searching more catalogues…'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('Enter fires the explicit fallback exactly once when it is the only actionable thing (0 results)', async () => {
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [],
+    });
+    mockResolveExplicit.mockResolvedValue(resolved(SIMBAD_LBN));
+
+    render(<TargetSearch onSelect={vi.fn()} />);
+    const input = screen.getByRole('combobox');
+    await typeAndFlush(input, 'lbn 552');
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+      for (let i = 0; i < 8; i++) await Promise.resolve();
+    });
+
+    expect(mockResolveExplicit).toHaveBeenCalledTimes(1);
+    expect(mockResolveExplicit).toHaveBeenCalledWith(
+      expect.objectContaining({ query: 'lbn 552', override: null }),
+    );
+
+    // A second Enter after resolving must not re-fire (harderState left idle).
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'Enter' });
+      await Promise.resolve();
+    });
+    expect(mockResolveExplicit).toHaveBeenCalledTimes(1);
+  });
+
+  it('Enter does NOT fire the explicit fallback when suggestions are present — it selects the highlighted option', async () => {
+    const onSelect = vi.fn();
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [M31, NGC7000],
+    });
+    render(<TargetSearch onSelect={onSelect} />);
+    const input = screen.getByRole('combobox');
+    await typeAndFlush(input, 'm');
+
+    await act(async () => {
+      fireEvent.keyDown(input, { key: 'ArrowDown' }); // highlight M31
+      fireEvent.keyDown(input, { key: 'Enter' });
+      await Promise.resolve();
+    });
+
+    expect(onSelect).toHaveBeenCalledWith(M31);
+    expect(mockResolveExplicit).not.toHaveBeenCalled();
+  });
+
   it('shows "still no matching targets" when the explicit fallback also misses', async () => {
     mockSearchTargets.mockResolvedValue({
       contractVersion: '1.0',

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
@@ -16,11 +16,15 @@
  *      appear. `unresolved` (incl. the offline / resolver-disabled case,
  *      FR-015) is treated as a normal, non-fatal outcome — no error is shown.
  *
- * "Search more catalogues" (spec 052 P2, FR-008/FR-009): when both phases
- * above still leave zero suggestions, a button calls `target.resolve_explicit`
- * (TAP-first, SIMBAD Sesame/NED/VizieR fallback on a miss) — the deliberate
- * resolve action the fallback is gated on. Never fired automatically or per
- * keystroke.
+ * "Search more catalogues" (spec 052 P2/P2UX, FR-008/FR-009): when both phases
+ * above still leave zero suggestions, the miss is framed as a next step, not
+ * an error — inline text + a button that calls `target.resolve_explicit`
+ * (TAP-first, SIMBAD Sesame/NED/VizieR fallback on a miss), plus a
+ * "Searching more catalogues…" status while it runs. Enter is a keyboard
+ * accelerator for that same button ONLY when it's the sole actionable thing
+ * on screen (zero typeahead suggestions); with any suggestion present, Enter
+ * still selects the highlighted one. Never fired automatically or per
+ * keystroke otherwise.
  *
  * Cancel-in-flight (US3 acceptance scenario #2): every query change bumps a
  * monotonic generation counter. Both phases check their captured generation
@@ -408,6 +412,17 @@ export function TargetSearch({
     [query, onOverride, onSelect],
   );
 
+  // "Search more catalogues" (spec 052 P2UX): true when the button is the only
+  // actionable next step — both prior phases came up empty and the fallback
+  // hasn't already been fired/exhausted for this query.
+  const harderOffered =
+    !loading &&
+    !error &&
+    !resolving &&
+    suggestions.length === 0 &&
+    harderState === 'idle' &&
+    query.trim().length >= MIN_RESOLVE_LEN;
+
   const showList = open && query.trim().length > 0;
 
   // Keep the highlighted option mounted + visible during keyboard navigation.
@@ -481,6 +496,17 @@ export function TargetSearch({
           autoFocus={autoFocus}
           onFocus={() => {
             if (query.trim().length > 0) setOpen(true);
+          }}
+          onKeyDown={(e) => {
+            // Enter-as-accelerator (spec 052 P2UX): fires the explicit
+            // "search more catalogues" fallback ONLY when it's the sole
+            // actionable thing on screen (zero typeahead suggestions). With
+            // any suggestion present, Enter falls through to Base UI's own
+            // select-the-highlighted-option handling — never both.
+            if (e.key === 'Enter' && harderOffered) {
+              e.preventDefault();
+              void handleSearchHarder();
+            }
           }}
         />
 
@@ -583,45 +609,50 @@ export function TargetSearch({
                     {m.cmp_target_search_searching()}
                   </Combobox.Status>
                 )}
-                {!loading &&
-                  !error &&
-                  suggestions.length === 0 &&
-                  !resolving && (
-                    <Combobox.Status className="alm-target-search__status">
-                      {m.cmp_target_search_no_results()}
-                    </Combobox.Status>
-                  )}
                 {/*
-                 * "Search more catalogues" (spec 052 P2, FR-008/FR-009): the
-                 * deliberate resolve action `target.resolve_explicit`'s Sesame
-                 * fallback is gated on. Only offered once both prior phases
-                 * (local cache + TAP long-tail) have already come up empty —
-                 * never fired automatically or per keystroke.
+                 * Below the minimum resolve length there's no fallback to
+                 * offer yet (Phase 2 hasn't even run) — plain "no matches".
                  */}
                 {!loading &&
                   !error &&
                   !resolving &&
                   suggestions.length === 0 &&
-                  harderState === 'idle' &&
-                  query.trim().length >= MIN_RESOLVE_LEN && (
-                    <div className="alm-target-search__status">
-                      <button
-                        type="button"
-                        className="alm-target-search__override"
-                        onPointerDown={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                        }}
-                        onClick={(e) => {
-                          e.preventDefault();
-                          e.stopPropagation();
-                          void handleSearchHarder();
-                        }}
-                      >
-                        {m.cmp_target_search_search_harder()}
-                      </button>
-                    </div>
+                  query.trim().length < MIN_RESOLVE_LEN && (
+                    <Combobox.Status className="alm-target-search__status">
+                      {m.cmp_target_search_no_results()}
+                    </Combobox.Status>
                   )}
+                {/*
+                 * "Search more catalogues" (spec 052 P2/P2UX, FR-008/FR-009):
+                 * once both prior phases (local cache + TAP long-tail) have
+                 * come up empty, frame it as a next step rather than a dead
+                 * end — the miss message and the fallback button read as one
+                 * inline sentence, not a separate error. Never fired
+                 * automatically or per keystroke; only this explicit button
+                 * click or the Enter accelerator below invokes it.
+                 */}
+                {harderOffered && (
+                  <div className="alm-target-search__status alm-target-search__no-match">
+                    <Combobox.Status>
+                      {m.cmp_target_search_no_results_hint()}
+                    </Combobox.Status>
+                    <button
+                      type="button"
+                      className="alm-target-search__override"
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        void handleSearchHarder();
+                      }}
+                    >
+                      {m.cmp_target_search_search_harder()}
+                    </button>
+                  </div>
+                )}
                 {harderState === 'searching' && (
                   <Combobox.Status className="alm-target-search__status alm-target-search__status--resolving">
                     {m.cmp_target_search_search_harder_searching()}

--- a/apps/desktop/src/styles/components/target-search.css
+++ b/apps/desktop/src/styles/components/target-search.css
@@ -73,6 +73,12 @@
   color: var(--alm-text-faint);
   border-top: 1px solid var(--alm-border-subtle);
 }
+/* Inline "no matches — search more catalogues" framing (spec 052 P2UX). */
+.alm-target-search__no-match {
+  display: flex;
+  align-items: center;
+  gap: var(--alm-sp-2);
+}
 .alm-target-search__option {
   display: flex;
   align-items: center;


### PR DESCRIPTION
## Summary
- When a target-name search returns nothing, the "Search more catalogues (NED/VizieR)" step is now framed inline as a next step ("No matches in SIMBAD —"), can be triggered by pressing **Enter** (not just clicking), and shows a "Searching more catalogues…" state while it runs. Ordinary type-ahead is unchanged and never triggers the broader search.

## Spec Context
Spec 052 P2 UX follow-up (hybrid affordance for the NED/VizieR fallback). Frontend-only (`TargetSearch.tsx`); Enter fires the broader search only at 0 typeahead results and otherwise falls through to normal select-highlighted-suggestion. Gates: vitest 1362/1362, typecheck/lint/build clean.