### PR TITLE
fix: clearing the resolve cache no longer freezes Settings while it re-warms

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -864,7 +864,7 @@
   "settings_resolver_cache_clear_info": "The local SIMBAD lookup cache is separate from your saved targets — clearing it never deletes a target. It re-warms from the bundled seed automatically.",
   "settings_resolver_cache_clear_label": "Clear resolve cache",
   "settings_resolver_cache_clear_pending": "Clearing…",
-  "settings_resolver_cache_clear_success": "Resolve cache cleared and re-warmed with {count} entries.",
+  "settings_resolver_cache_clear_success": "Resolve cache cleared — re-warming in the background.",
   "settings_resolver_catalogues_title": "DEFAULT CATALOGUES",
   "settings_resolver_debounce_label": "Typeahead debounce (ms)",
   "settings_resolver_endpoint_label": "SIMBAD endpoint",

--- a/apps/desktop/src-tauri/src/commands/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/commands/lifecycle.rs
@@ -33,8 +33,10 @@ pub struct AppState {
     /// Spec 052 P1 (D2): the shared SIMBAD resolve cache — one global redb
     /// file, opened once at app startup. Readers clone the cheap `Arc`-backed
     /// handle out from under a short-lived read lock; `target.cache.clear`
-    /// (`commands::resolve_cache::clear_and_rewarm`) takes the write lock to
-    /// swap in a freshly reopened, re-warmed store.
+    /// (`commands::resolve_cache::clear_and_rewarm`) takes the write lock
+    /// only to swap in a freshly reopened, still-empty store — the re-warm
+    /// itself runs afterward as a background task that never takes this
+    /// lock (issue #695).
     pub resolve_cache: tokio::sync::RwLock<targeting_resolver::simbad::ResolveCache>,
     /// Filesystem path backing `resolve_cache`, needed by
     /// `target.cache.clear` to delete + reopen the redb file.

--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -19,7 +19,8 @@
 //!   cache (spec 035/052).
 //! - `target.adopt` — explicit in-use commit for UI flows with no other
 //!   natural commit point (spec 052 P1 FR-004).
-//! - `target.cache.clear` — wipe + re-warm the redb resolve cache (FR-002).
+//! - `target.cache.clear` — wipe the redb resolve cache; re-warm runs as a
+//!   background task (FR-002; issue #695).
 //! - `target.resolution.settings` / `target.resolution.settings.update` — resolver settings.
 //! - `target.astro_format.batch` — batched sexagesimal RA/Dec formatting (adopt target-match).
 //!
@@ -179,8 +180,9 @@ pub async fn target_adopt(
 
 // ── target.cache.clear (spec 052 P1 FR-002) ─────────────────────────────────────
 
-/// `target.cache.clear` — wipe the redb resolve cache and re-warm it from the
-/// bundled seed + existing durable `canonical_target` rows. Never touches
+/// `target.cache.clear` — wipe the redb resolve cache and schedule its
+/// re-warm (bundled seed + existing durable `canonical_target` rows) as a
+/// background task, returning as soon as the swap is done. Never touches
 /// `canonical_target` itself (§V — the redb cache is a reproducible
 /// projection, never canonical).
 ///
@@ -188,17 +190,24 @@ pub async fn target_adopt(
 /// old redb file (e.g. a concurrent read still has it open) is reported as an
 /// internal error rather than silently leaving a stale cache in place.
 ///
+/// Fix for #695: this used to await the full re-warm (bundled seed +
+/// durable rows — up to ~14k individually fsync'd redb writes) inline,
+/// freezing the caller for minutes on a debug build. `rewarmed_count` is
+/// therefore always `0` now — "re-warm scheduled in the background, count
+/// not known synchronously" rather than "0 entries re-warmed" — kept as a
+/// response-meaning change instead of widening the contract.
+///
 /// # Errors
 ///
-/// Returns `Err(String)` if the cache file cannot be reopened/re-warmed.
+/// Returns `Err(String)` if the cache file cannot be removed/reopened.
 #[tauri::command]
 #[specta::specta]
 pub async fn target_cache_clear(
     state: State<'_, AppState>,
 ) -> Result<TargetCacheClearResponse, ContractError> {
     tracing::info!("target.cache.clear");
-    let rewarmed = crate::resolve_cache::clear_and_rewarm(&state).await?;
-    Ok(TargetCacheClearResponse { rewarmed_count: u32::try_from(rewarmed).unwrap_or(u32::MAX) })
+    crate::resolve_cache::clear_and_rewarm(&state).await?;
+    Ok(TargetCacheClearResponse { rewarmed_count: 0 })
 }
 
 // ── target.resolution.settings (spec 035, US5 — FR-015) ─────────────────────────

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -8,13 +8,24 @@
 //!
 //! `simbad_resolver::Cache` exposes no delete-all primitive, so "clear" is
 //! file-level: drop every handle to the old redb `Database`, delete the file,
-//! reopen, re-warm. [`AppState::resolve_cache`]'s write lock ensures no new
-//! reader starts mid-swap; a reader that already cloned the handle just
-//! before the swap keeps working against the (now-orphaned) old file until it
-//! finishes, which is why the old handle is dropped before the file delete —
-//! a concurrent straggler can still transiently make the delete fail on
+//! reopen. [`AppState::resolve_cache`]'s write lock ensures no new reader
+//! starts mid-swap; a reader that already cloned the handle just before the
+//! swap keeps working against the (now-orphaned) old file until it finishes,
+//! which is why the old handle is dropped before the file delete — a
+//! concurrent straggler can still transiently make the delete fail on
 //! Windows (sharing violation), surfaced as an error rather than silently
 //! leaving a stale cache in place.
+//!
+//! The re-warm (bundled seed + durable `canonical_target` rows — up to ~14k
+//! individually fsync'd redb writes) runs as a **background task** spawned
+//! right after the swap, mirroring the startup warm in `lib.rs` (issue #695:
+//! awaiting it inline froze the `target.cache.clear` IPC call — and, because
+//! the write lock used to stay held for the whole warm, every other resolve
+//! cache reader too — for minutes on a debug build). The background task
+//! never takes `AppState::resolve_cache`'s lock; it is handed the fresh
+//! cache's own handle (cloned out before the swap, so it keeps warming the
+//! same underlying store regardless of what `AppState::resolve_cache` is
+//! swapped to next).
 
 use contracts_core::ContractError;
 
@@ -48,14 +59,19 @@ pub fn open_or_in_memory(path: &std::path::Path) -> targeting_resolver::simbad::
     })
 }
 
-/// Clear and re-warm the shared resolve cache. Returns the number of entries
-/// the fresh cache was re-warmed with (bundled seed + durable rows).
+/// Clear the shared resolve cache and schedule its re-warm (bundled seed +
+/// durable rows) as a background task. Returns as soon as the fresh, empty
+/// cache is swapped in — the caller (the `target.cache.clear` IPC command)
+/// no longer waits for the re-warm to finish (issue #695).
 ///
 /// # Errors
 ///
 /// Returns [`ContractError`] (`internal.database`) if the old file cannot be
-/// removed or the fresh cache cannot be opened/warmed.
-pub async fn clear_and_rewarm(state: &AppState) -> Result<usize, ContractError> {
+/// removed or the fresh cache cannot be opened. A failure in the background
+/// re-warm itself is only logged (`tracing::warn!`) — the cache is already
+/// swapped in and usable (just emptier until the warm catches up), which
+/// matches how startup already degrades on a warm failure.
+pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
     let mut guard = state.resolve_cache.write().await;
 
     // Drop every handle this process holds on the old file BEFORE touching
@@ -73,18 +89,121 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<usize, ContractError> 
 
     let fresh = targeting_resolver::simbad::ResolveCache::open(&state.resolve_cache_path)
         .map_err(|e| ContractError::internal(e.to_string()))?;
-    let namespace = simbad_resolver::identity::namespace(NAMESPACE_SEED);
-    let cache = fresh.cache();
 
-    let seed_count = targeting_resolver::seed::warm_bundled_on_first_run(&cache, &namespace)
-        .await
-        .map_err(|e| ContractError::internal(e.to_string()))?
-        .unwrap_or(0);
-    let durable_count =
-        targeting_resolver::seed::warm_from_canonical_target(&cache, state.repo.pool(), &namespace)
-            .await
-            .map_err(|e| ContractError::internal(e.to_string()))?;
-
+    // Clone the fresh cache's own handle (cheap — an `Arc` over the redb
+    // `Database`, see `ResolveCache::cache`) for the background warm BEFORE
+    // moving `fresh` into the guard, then release the write lock immediately
+    // — the warm never needs it, exactly like the startup warm in `lib.rs`
+    // never takes it at all. A `target.cache.clear` that lands mid-warm
+    // takes this same write lock (uncontended, since it's already released),
+    // deletes the file this task is still writing into, and reopens a new
+    // one; the stale task keeps writing into the now-unlinked file (wasted,
+    // harmless) or — on Windows — the delete surfaces its own sharing-
+    // violation error rather than corrupting anything.
+    let warm_cache = fresh.cache();
+    let warm_pool = state.repo.pool().clone();
     *guard = fresh;
-    Ok(seed_count + durable_count)
+    drop(guard);
+
+    tokio::spawn(async move {
+        let namespace = simbad_resolver::identity::namespace(NAMESPACE_SEED);
+        match targeting_resolver::seed::warm_bundled_on_first_run(&warm_cache, &namespace).await {
+            Ok(Some(count)) => {
+                tracing::info!("re-warmed {count} bundled target seed entries after cache clear");
+            }
+            Ok(None) => tracing::debug!(
+                "resolve cache clear: bundled seed already warmed (unexpected on a freshly cleared cache)"
+            ),
+            Err(e) => {
+                tracing::warn!("failed to re-warm bundled target seed after cache clear: {e}");
+            }
+        }
+        match targeting_resolver::seed::warm_from_canonical_target(
+            &warm_cache,
+            &warm_pool,
+            &namespace,
+        )
+        .await
+        {
+            Ok(count) if count > 0 => {
+                tracing::info!("re-warmed {count} durable canonical_target rows after cache clear");
+            }
+            Ok(_) => {}
+            Err(e) => tracing::warn!(
+                "failed to re-warm resolve cache from canonical_target after cache clear: {e}"
+            ),
+        }
+    });
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use audit::bus::EventBus;
+    use persistence_db::repositories::lifecycle::SqliteLifecycleRepository;
+    use persistence_db::Database;
+    use simbad_resolver::Cache as _;
+
+    use super::*;
+
+    async fn test_state() -> (AppState, tempfile::TempDir) {
+        let db = Database::in_memory().await.expect("in-memory database");
+        db.migrate().await.expect("run migrations");
+        let pool = db.pool().clone();
+        let bus = EventBus::with_pool(pool.clone());
+        let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
+
+        let dir = tempfile::tempdir().expect("tempdir");
+        let cache_path = dir.path().join("resolve-cache.redb");
+        let cache = open_or_in_memory(&cache_path);
+        (AppState::new(repo, bus, cache, cache_path), dir)
+    }
+
+    /// Regression test for #695: `clear_and_rewarm` must return as soon as
+    /// the swap is done, without awaiting the seed/durable re-warm inline.
+    /// A generous deadline (the real bundled warm is the ~12-minute-on-a-
+    /// debug-build bug; a correct implementation returns in well under a
+    /// second even against the full bundled seed).
+    #[tokio::test]
+    async fn clear_and_rewarm_returns_before_the_warm_completes() {
+        let (state, _dir) = test_state().await;
+
+        let outcome = tokio::time::timeout(Duration::from_secs(2), clear_and_rewarm(&state)).await;
+
+        assert!(outcome.is_ok(), "clear_and_rewarm did not return promptly");
+        outcome.unwrap().expect("clear_and_rewarm failed");
+    }
+
+    /// The background task scheduled by `clear_and_rewarm` must actually
+    /// warm the fresh cache (bundled seed) — "returns fast" must not mean
+    /// "never warms".
+    #[tokio::test]
+    async fn clear_and_rewarm_warms_the_fresh_cache_in_the_background() {
+        let (state, _dir) = test_state().await;
+
+        clear_and_rewarm(&state).await.expect("clear_and_rewarm failed");
+
+        let cache = state.resolve_cache.read().await.clone();
+        let warmed = poll_until_non_empty(&cache).await;
+        assert!(warmed, "background re-warm never populated the fresh cache");
+    }
+
+    /// Polls (bounded) rather than sleeping a fixed duration — avoids both
+    /// flakiness on a slow CI runner and a needlessly slow test on a fast one.
+    async fn poll_until_non_empty(cache: &targeting_resolver::simbad::ResolveCache) -> bool {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if !cache.cache().list().await.expect("cache list failed").is_empty() {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
 }

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -345,8 +345,9 @@ export const commands = {
 	 */
 	targetAdopt: (req: TargetAdoptRequest) => typedError<TargetAdoptResponse, ContractError_Serialize>(__TAURI_INVOKE("target_adopt", { req })),
 	/**
-	 *  `target.cache.clear` — wipe the redb resolve cache and re-warm it from the
-	 *  bundled seed + existing durable `canonical_target` rows. Never touches
+	 *  `target.cache.clear` — wipe the redb resolve cache and schedule its
+	 *  re-warm (bundled seed + existing durable `canonical_target` rows) as a
+	 *  background task, returning as soon as the swap is done. Never touches
 	 *  `canonical_target` itself (§V — the redb cache is a reproducible
 	 *  projection, never canonical).
 	 * 
@@ -354,9 +355,16 @@ export const commands = {
 	 *  old redb file (e.g. a concurrent read still has it open) is reported as an
 	 *  internal error rather than silently leaving a stale cache in place.
 	 * 
+	 *  Fix for #695: this used to await the full re-warm (bundled seed +
+	 *  durable rows — up to ~14k individually fsync'd redb writes) inline,
+	 *  freezing the caller for minutes on a debug build. `rewarmed_count` is
+	 *  therefore always `0` now — "re-warm scheduled in the background, count
+	 *  not known synchronously" rather than "0 entries re-warmed" — kept as a
+	 *  response-meaning change instead of widening the contract.
+	 * 
 	 *  # Errors
 	 * 
-	 *  Returns `Err(String)` if the cache file cannot be reopened/re-warmed.
+	 *  Returns `Err(String)` if the cache file cannot be removed/reopened.
 	 */
 	targetCacheClear: () => typedError<TargetCacheClearResponse, ContractError_Serialize>(__TAURI_INVOKE("target_cache_clear")),
 	/**

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
@@ -9,6 +9,8 @@
  *   1. Loads current settings and reflects the online toggle state.
  *   2. Toggling online resolution persists via target.resolution.settings.update.
  *   3. compact mode hides the endpoint / debounce / timeout fields.
+ *   4. "Clear resolve cache" reports the background re-warm (#695) rather
+ *      than a synchronous count.
  */
 
 import {
@@ -20,15 +22,17 @@ import {
 } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-const { mockGet, mockUpdate } = vi.hoisted(() => ({
+const { mockGet, mockUpdate, mockCacheClear } = vi.hoisted(() => ({
   mockGet: vi.fn(),
   mockUpdate: vi.fn(),
+  mockCacheClear: vi.fn(),
 }));
 
 vi.mock('@/bindings/index', () => ({
   commands: {
     targetResolutionSettings: mockGet,
     targetResolutionSettingsUpdate: mockUpdate,
+    targetCacheClear: mockCacheClear,
   },
 }));
 
@@ -44,6 +48,7 @@ const SETTINGS = {
 beforeEach(() => {
   mockGet.mockReset();
   mockUpdate.mockReset();
+  mockCacheClear.mockReset();
   mockGet.mockResolvedValue({
     status: 'ok',
     data: { contractVersion: '1.0', requestId: 'r', settings: SETTINGS },
@@ -54,6 +59,10 @@ beforeEach(() => {
       data: { contractVersion: '1.0', requestId: 'r', settings: req.settings },
     }),
   );
+  mockCacheClear.mockResolvedValue({
+    status: 'ok',
+    data: { rewarmedCount: 0 },
+  });
 });
 
 describe('ResolverSettingsControl', () => {
@@ -105,5 +114,39 @@ describe('ResolverSettingsControl', () => {
       screen.getByLabelText('Typeahead debounce (ms)'),
     ).toBeInTheDocument();
     expect(screen.getByLabelText('Request timeout (s)')).toBeInTheDocument();
+  });
+
+  // spec 052 fix #695: the backend now returns as soon as the cache is wiped
+  // and re-warms it in the background, so the success copy no longer claims
+  // a synchronous count.
+  it('reports the background re-warm (not a count) after clearing the cache', async () => {
+    render(<ResolverSettingsControl />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Clear resolve cache' }),
+    );
+
+    await waitFor(() => expect(mockCacheClear).toHaveBeenCalled());
+    expect(
+      await screen.findByText(
+        'Resolve cache cleared — re-warming in the background.',
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByText(/entries\.$/)).toBeNull();
+  });
+
+  it('reports the cache-clear error when the command fails', async () => {
+    mockCacheClear.mockRejectedValue(new Error('disk full'));
+    render(<ResolverSettingsControl />);
+    await waitFor(() => expect(mockGet).toHaveBeenCalled());
+
+    fireEvent.click(
+      screen.getByRole('button', { name: 'Clear resolve cache' }),
+    );
+
+    expect(
+      await screen.findByText('Could not clear the resolve cache: disk full'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
@@ -90,18 +90,16 @@ export function ResolverSettingsControl({
 
   // spec 052 P1 (FR-002): manual "clear resolve cache" action — wipes the
   // shared redb typeahead/search cache and re-warms it; never touches saved
-  // targets (canonical_target).
+  // targets (canonical_target). The re-warm itself runs in the background
+  // (issue #695 — it used to freeze this button for minutes), so the success
+  // copy can no longer report a synchronous count.
   const handleClearCache = useCallback(async () => {
     setClearingCache(true);
     setCacheClearMessage(null);
     setCacheClearError(null);
     try {
-      const resp = await clearResolveCache();
-      setCacheClearMessage(
-        m.settings_resolver_cache_clear_success({
-          count: resp.rewarmedCount,
-        }),
-      );
+      await clearResolveCache();
+      setCacheClearMessage(m.settings_resolver_cache_clear_success());
     } catch (e) {
       setCacheClearError(
         m.settings_resolver_cache_clear_error({


### PR DESCRIPTION
## Summary
- `target.cache.clear` now wipes instantly instead of blocking the UI for ~12 minutes on a 13k-entry cache.
- Seed re-warm now runs batched and in the background after the wipe; the copy in Settings was updated to reflect the async flow.

Fixes #695 (app side; crate-side batch API ships separately in simbad-resolver 0.3.0, tracked as a7a/a7b)

Known follow-up (not in scope here): `crates/contracts/core` `targets.rs` doc comment on `rewarmed_count` is now stale relative to the background re-warm behavior; will be updated alongside the contract crate separately, not touched in this PR.

## Spec Context
- Spec: 052
- Branch: fix/052-cache-clear-background