### PR TITLE
spec(030): Q15 gate fixes — bus store-roles stance, noisy-key rule, T121/T126 semantics

### DIFF
--- a/specs/030-ui-audit-revision/contracts/commands.md
+++ b/specs/030-ui-audit-revision/contracts/commands.md
@@ -142,7 +142,8 @@ ones tightens:
 
 - Any mutation command that returns an `auditId` MUST return one that
   resolves to a durable `audit_log_entry` row (previously some ids pointed
-  at bus-only in-memory events, e.g. protection set/acknowledge).
+  at bus-only events — a topic stream no audit read resolves — e.g.
+  protection set/acknowledge).
 - Audit read/list commands keep their shape; their coverage expands to all
   durable-state mutations (settings changes, protection overrides, equipment
   CRUD, source enable/disable/register/delete, rescans/root ops), each with

--- a/specs/030-ui-audit-revision/data-model.md
+++ b/specs/030-ui-audit-revision/data-model.md
@@ -243,13 +243,49 @@ Mapping onto the existing `audit_log_entry` table
 - `at` → timestamp; `actor` unchanged; `trigger` → action.
 - `from_state` / `to_state` are subsumed by the optional before→after pair
   (lifecycle transitions keep using them; non-lifecycle mutations carry
-  before→after in the structured detail).
-- reason/code becomes first-class queryable detail (not buried in free-form
-  payload).
+  before→after in the structured `payload` JSON).
+- reason/code becomes first-class queryable detail as a concrete column,
+  not a JSON1 query over `payload`.
 - `severity` (workflow | diagnostic) and `request_id` are retained.
 
-The ephemeral bus event stream is unchanged in shape; audit-worthy mutations
-write the durable row and emit the bus event (durable row is authoritative).
+### Migration shape (T120)
+
+Consistent with existing schema conventions (TEXT columns, named
+`idx_audit_*` indexes; `0002_lifecycle.sql`):
+
+- Add nullable column `reason_code TEXT` — the machine-readable
+  reason/code for `refused`/`failed` outcomes; NULL for `applied`.
+  Human-readable detail stays in `payload`.
+- Add index `idx_audit_outcome` on `(outcome, reason_code)` for
+  refusal/failure queries.
+- No other table changes: `entity_type` and `trigger` have no CHECK
+  constraints, so the enum generalization is DB-free; the real surface is
+  the Rust `EntityType` enum and its generated TS union.
+
+Resulting column set: `audit_id, entity_type, entity_id, from_state,
+to_state, trigger, actor, outcome, severity, request_id, at, payload,
+reason_code`.
+
+### Severity per mutation class
+
+`severity` drives FR-132's user-meaningful filter. Assignment rule:
+user-initiated mutations are `workflow`; system-initiated ones are
+`diagnostic`.
+
+| Mutation class | Severity |
+|----------------|----------|
+| Settings changes (durable-data keys) | workflow |
+| Protection overrides/acknowledgements | workflow |
+| Equipment CRUD | workflow |
+| Source register/delete/enable/disable | workflow |
+| User-initiated rescans / root ops (incl. remap) | workflow |
+| Automatic/periodic rescans, system maintenance | diagnostic |
+
+The live event bus stream is unchanged in shape. Audit-worthy mutations
+write the `audit_log_entry` row and emit the bus event; `audit_log_entry`
+is the authoritative audit record, while the bus's durable `events` table
+is non-authoritative transient diagnostics (prunable). The resulting dual
+durable rows are accepted in v1 (spec §8.3).
 
 ## Metadata Value States
 

--- a/specs/030-ui-audit-revision/iteration-2026-07-14-applied.md
+++ b/specs/030-ui-audit-revision/iteration-2026-07-14-applied.md
@@ -6,6 +6,10 @@ change_request: "Formalize grilling decision Q15 (docs/development/ui-campaign-g
 scope: "Feature-wide (new requirement block: durable audit coverage & store unification)"
 ---
 
+> **Superseded by the 2026-07-14 critique fix round** — see spec.md §8.3
+> (store roles), FR-130/131/134, tasks.md T125. Historical record; content
+> below reflects the pre-fix state.
+
 ## Change Summary
 
 Add durable-audit coverage and store-unification requirements (grilling Q15,

--- a/specs/030-ui-audit-revision/plan.md
+++ b/specs/030-ui-audit-revision/plan.md
@@ -277,7 +277,7 @@ Phase 1 artifacts (data-model.md, contracts/) will document:
 
 ### Implementation Phases
 
-The implementation is organized into 6 phases, ordered by dependency:
+The implementation is organized into 8 phases (A–H), ordered by dependency:
 
 | Phase | Scope | Key Deliverables |
 |-------|-------|-----------------|
@@ -287,7 +287,7 @@ The implementation is organized into 6 phases, ordered by dependency:
 | **D. Inbox & Sessions** | Core review workflow + sessions | Inbox rename/rewrite, session review, calendar scroll |
 | **E. Calibration, Targets, Projects** | Remaining detail screens | Fingerprint section, coverage by train, lifecycle sidebar |
 | **F. Settings & Archive** | Configuration + archive | 11 panes, archive screen, audit log move |
-| **G. Audit Unification** *(iteration 2026-07-14, Q15 / #647)* | Durable audit coverage & store unification | Generalized audit entry model, durable writes for all bus-only mutation emitters (settings, protection, equipment, sources/roots), Activity/log panel reads durable audit + ephemeral bus |
+| **G. Audit Unification** *(iteration 2026-07-14, Q15 / #647)* | Durable audit coverage & store unification | Generalized audit entry model, durable writes for all bus-only mutation emitters (settings, protection, equipment, sources/roots), Activity/log panel reads durable audit + live event bus |
 | **H. Missing-Value Semantics & Detail-as-Delta** *(iteration 2026-07-14, Q16 / #620, #619)* | Three-state value model + shared renderer + detail-panel content model | Contract/model optionality sweep (no sentinel zeros), shared `renderValue` renderer with unresolved chip and presence-coupled source pills, adoption across all metadata surfaces, detail panels reworked to lead with non-row information |
 
 Each phase is independently testable and deployable. Phase A must come first

--- a/specs/030-ui-audit-revision/spec.md
+++ b/specs/030-ui-audit-revision/spec.md
@@ -388,21 +388,27 @@ cleanup available, and storage health. Verify sidebar footer shows root health.
   write a durable audit row — including settings changes, protection
   overrides, equipment CRUD, source enable/disable/register/delete, and
   rescans/root operations — recording the outcome including refused/failed
-  with a reason/code.
+  with a reason/code. Value-unchanged no-op writes are not mutations and
+  emit no audit row; refused and failed attempts do. Debounced/noisy
+  durable-data settings keys (e.g. the `pattern` naming key) are audited
+  once at the committed value with before→after — never per keystroke
+  (T122).
 - **FR-131**: The durable `audit_log_entry` store MUST be the single source
   of truth for audit history. Audit-worthy actions MUST write the durable
   row AND emit a live event to the bus; emitting to the bus only is
   prohibited for mutations. Any `auditId` returned to the UI MUST resolve to
-  a durable row.
+  a durable `audit_log_entry` row.
 - **FR-132**: The Activity/log panel MUST read user-meaningful events from
-  the durable audit store, and transient/internal noise from the ephemeral
+  the durable audit store, and transient/internal noise from the live event
   bus.
 - **FR-133**: The audit entry shape MUST generalize from a
   lifecycle-transition record to a generic mutation record: timestamp,
   actor, action, entity (type + id), outcome + reason, plus an optional
   before→after value pair for settings/protection changes.
 - **FR-134**: Reads, navigation, UI state changes, and transient
-  internal/periodic events MUST NOT be durably audited.
+  internal/periodic events MUST NOT be durably audited. UI-state settings
+  keys (e.g. `rememberFollowLogs`, `plansListDefaultAgeCutoffDays`) fall
+  under this exemption.
 
 **Missing-Value Semantics & Detail Panels** *(iteration 2026-07-14, grilling Q16 / #620, #619)*
 
@@ -471,7 +477,7 @@ cleanup available, and storage health. Verify sidebar footer shows root health.
   navigating to any specific screen.
 - **SC-009**: 100% of mutation commands that return an `auditId` return one
   that resolves to a durable `audit_log_entry` row; zero mutation paths emit
-  to the bus without a durable write.
+  to the bus without a durable `audit_log_entry` write.
 - **SC-010**: An entity with missing numeric metadata never displays a
   defaulted 0 (e.g., "Gain 0", "Exposure 0s", "Size 0 KB"); 100% of
   metadata value renderings across Inbox, Sessions, Calibration, Targets,
@@ -501,7 +507,8 @@ cleanup available, and storage health. Verify sidebar footer shows root health.
 
 **Change**: Every attempted mutation of durable state writes a durable
 `audit_log_entry` row (outcome incl. refused/failed + reason/code); the
-durable table becomes the single source of truth over the ephemeral bus;
+durable table becomes the authoritative audit record over the live event
+bus;
 the entry shape generalizes from a lifecycle-transition record to a generic
 mutation record. Decisions locked by
 `docs/development/ui-campaign-grilling-decisions-2026-07-13.md` §Q15.
@@ -1380,12 +1387,22 @@ Selecting an event shows:
 `docs/development/ui-campaign-grilling-decisions-2026-07-13.md` §Q15.)*
 
 Issue #647 is architectural, not a coverage gap. Two disjoint audit stores
-exist: an ephemeral event bus (live UI feed — settings changes, protection
-sets, equipment CRUD, `sources.set_active`, and rescans emit here only) and
-the durable `audit_log_entry` table (written only by lifecycle transitions,
-plan-apply, and project-health). A protection-set therefore returns an
-`auditId` that points at an in-memory event, not a durable row — violating
-constitution §II ("audit record for each attempted action and outcome").
+exist: the live event bus (hybrid: in-process broadcast for live UI plus a
+durable `events` topic stream — a topic+payload log with no
+outcome/refused semantics, not an audit record; settings changes,
+protection sets, equipment CRUD, `sources.set_active`, and rescans emit
+here only) and the durable `audit_log_entry` table (written only by
+lifecycle transitions, plan-apply, and project-health). A protection-set
+therefore returns an `auditId` that points at a bus event no audit read
+can resolve, not an `audit_log_entry` row — violating constitution §II
+("audit record for each attempted action and outcome").
+
+**Store roles:** `audit_log_entry` is the authoritative audit record; the
+`events` table is non-authoritative transient diagnostics and may be
+pruned. Audit-worthy mutations therefore produce two durable rows (an
+`audit_log_entry` row plus an `events` row via the bus) — accepted in v1;
+any change to `events`-table persistence is deferred to the Q9 log-panel
+iteration.
 
 **Unification (FR-130–FR-134):**
 
@@ -1398,7 +1415,7 @@ constitution §II ("audit record for each attempted action and outcome").
    Audit-worthy actions write the durable row *and* emit to the bus for
    live UI; the emit-to-bus-only pattern for mutations is eliminated. The
    Activity/log panel (Q9) reads durable audit for user-meaningful events
-   plus the ephemeral bus for transient/internal noise — making "activity
+   plus the live event bus for transient/internal noise — making "activity
    is a view over the audit" literally true, and the Q10 manifest-history
    reframe viable.
 3. **Generalized entry shape** — from a lifecycle-transition record to a

--- a/specs/030-ui-audit-revision/tasks.md
+++ b/specs/030-ui-audit-revision/tasks.md
@@ -247,17 +247,17 @@ testable and deployable. Paths relative to `apps/desktop/src/`.
 ## Phase 10: Durable Audit Unification (Q15 / #647) — iteration 2026-07-14
 
 **Purpose**: Every attempted mutation of durable state writes a durable
-`audit_log_entry` row; the durable table is the single source of truth over
-the ephemeral bus; the entry shape generalizes to a generic mutation record
-(FR-130–FR-134, SC-009, spec §8.3).
+`audit_log_entry` row; the durable table is the authoritative audit record
+over the live event bus; the entry shape generalizes to a generic mutation
+record (FR-130–FR-134, SC-009, spec §8.3).
 
 - [ ] T120 Generalize the durable audit entry model in `crates/audit-types` from lifecycle-transition shape to generic mutation record (action, generic entity type beyond the lifecycle enum, first-class reason/code, optional before→after) with a compatible migration for `audit_log_entry`
-- [ ] T121 Shared write-through helper: one path that writes the durable `audit_log_entry` row and emits the bus event, returning the durable `audit_id`
+- [ ] T121 Shared write-through helper: one path that writes the durable `audit_log_entry` row and emits the bus event, returning the durable `audit_id`. Failure semantics: the durable row is load-bearing (constitution §II) — insert failure fails the command; the bus emit is best-effort — failure is logged and the command succeeds
 - [ ] T122 Settings mutations write durable audit rows with before→after (`crates/app/settings/src/lib.rs` bus-only publishes)
 - [ ] T123 Protection overrides/acknowledgements write durable audit rows; returned `auditId` references the durable row (`crates/app/core/src/protection.rs`)
 - [ ] T124 Equipment CRUD writes durable audit rows (`crates/app/calibration/src/equipment.rs` — currently no audit emission at all)
-- [ ] T125 Source enable/disable/register/delete and rescans/root ops write durable audit rows (`crates/app/core/src/first_run.rs` bus-only publishes; Q5 delete-cascade audit lands here)
-- [ ] T126 Activity/log panel reads durable audit for user-meaningful events + ephemeral bus for transient/internal noise (Q9 wiring point)
+- [ ] T125 Source enable/disable/register and rescans/root ops (incl. remap) write durable audit rows (`crates/app/core/src/first_run.rs` bus-only publishes). Scoped to mutations that exist in spec-030 today; the Q5 source-delete cascade joins here when the spec-003/006 iterate lands
+- [ ] T126 Activity/log panel reads durable audit for user-meaningful events + live event bus for transient/internal noise (Q9 wiring point; BLOCKED on the Q9 log-panel iteration — see Phase Dependencies)
 - [ ] T127 Refusal/failure coverage tests: refused and failed mutations produce durable rows with outcome + reason/code; reads/navigation/UI state produce none (FR-134)
 
 ---
@@ -293,7 +293,7 @@ list rows (FR-135–FR-140, SC-010–SC-011, spec §12).
 - **Phase 7 (US5 Settings)**: Depends on Phase 2 (uses backend settings commands)
 - **Phase 8 (US6 Status Bar)**: Depends on Phase 2 (uses status.summary command)
 - **Phase 9 (Polish)**: Depends on all previous phases
-- **Phase 10 (Audit Unification)**: Depends only on existing audit plumbing (audit-types model, `audit_log_entry` table, event bus); independent of Phases 3–9. T120–T121 first; T122–T125 parallel after T121; T126–T127 last
+- **Phase 10 (Audit Unification)**: Depends only on existing audit plumbing (audit-types model, `audit_log_entry` table, event bus); independent of Phases 3–9. T120 → T121 first (the helper builds on the generalized model); T122–T125 parallel after T121; T127 last. T126 is BLOCKED on the Q9 log-panel iteration — the Activity/log panel it wires is not yet specified in spec-030 (spec §8 defines the Settings Audit Log pane, not an activity panel)
 - **Phase 11 (Missing-Value Semantics & Detail-as-Delta)**: Depends on shipped metadata/contract plumbing and shared components (Phase 2) only; independent of Phases 3–10. T128–T129 first (model), then T130–T131 (renderer), then T132–T133 in parallel, T134 last
 
 ### User Story Independence


### PR DESCRIPTION
Applies the Q15 critique-gate findings: durable audit_log_entry authoritative vs non-authoritative bus/store-roles events diagnostics stance, dual rows v1, Q9 deferral; noisy-key committed-value rule; T126 blocked-on-Q9; migration shape pinned.

## Spec Context
Spec-only markdown artifacts (specs/030-ui-audit-revision/**, 6 files across two commits), no code changes. Approved after 1 fix round (all 11 gate items + stale-record annotation verified).