### PR TITLE
fix: launch PixInsight without a broken folder path argument

### DIFF
--- a/crates/workflow/profiles/src/args.rs
+++ b/crates/workflow/profiles/src/args.rs
@@ -164,11 +164,13 @@ mod tests {
     }
 
     #[test]
-    fn render_pixinsight_folder() {
+    fn render_pixinsight_bare_no_args() {
+        // #778: PixInsight can't open a bare folder path — launch bare (no
+        // args) rather than pass a broken {folder} token.
         use crate::seed;
         let profile = seed::find("pixinsight").unwrap();
         let ctx = RenderContext { folder: Some("/mnt/lib/pi_project"), file: None };
         let argv = render(&profile.args_template, &ctx);
-        assert_eq!(argv, vec!["/mnt/lib/pi_project"]);
+        assert_eq!(argv, Vec::<String>::new());
     }
 }

--- a/crates/workflow/profiles/src/seed.rs
+++ b/crates/workflow/profiles/src/seed.rs
@@ -16,8 +16,15 @@ fn pixinsight_profile() -> ToolProfile {
         id: "pixinsight",
         name: "PixInsight",
         bundle_id: Some("com.pixinsight.PixInsight"),
-        args_template: vec![ArgsToken::Folder],
-        supports_open_folder: true,
+        // PixInsight cannot open a bare folder path (bug #778): the only
+        // robust path argument is a `.xosm` project file we never generate,
+        // and running WBPP's automationMode would violate the PixInsight
+        // processing boundary (Constitution III). Launch bare instead — the
+        // user opens their own files/project inside PixInsight. `cwd` is
+        // still anchored to the project folder (R-CwdContain), which is what
+        // drives the one-time "cwd anchored" hint (supports_open_folder=false).
+        args_template: vec![],
+        supports_open_folder: false,
         detach_strategy: DetachStrategy::OpenBundleId,
         // WBPP: session/night → filter → exposure grouping (spec 049 US2 T025).
         source_view_layout: Some(DEFAULT_SOURCE_VIEW_LAYOUT),
@@ -107,9 +114,13 @@ mod tests {
     }
 
     #[test]
-    fn pixinsight_supports_open_folder() {
+    fn pixinsight_launches_bare_with_no_folder_arg() {
+        // PixInsight cannot open a bare folder path (bug #778): launch with
+        // no args and rely on `cwd` anchoring instead of {folder} (spec 011
+        // R-CwdContain, supports_open_folder=false path).
         let p = find("pixinsight").expect("pixinsight must be seeded");
-        assert!(p.supports_open_folder);
+        assert!(!p.supports_open_folder);
+        assert!(p.args_template.is_empty());
         assert_eq!(p.bundle_id, Some("com.pixinsight.PixInsight"));
     }
 


### PR DESCRIPTION
## Summary
- PixInsight could not actually open the folder path PlateVault was passing to it on launch (it doesn't support opening a bare directory), so the "Open in PixInsight" button launched PixInsight into a broken state. PixInsight now launches cleanly with no arguments; the project folder is still set as its working directory.

## Spec Context

Fixes #778. PixInsight only accepts a `.xosm` project file as a path argument (which PlateVault does not generate), and using WBPP's automation mode to auto-open files would cross the app's PixInsight/processing boundary (Constitution III: this app prepares inputs and launches tools, it never drives PixInsight's processing). The safe default is a bare launch — the user opens their own files/project inside PixInsight.

Implementation: `crates/workflow/profiles/src/seed.rs` PixInsight's `args_template` is now empty and `supports_open_folder` is `false`, reusing the existing "cwd anchored" launch path already used for tools without folder-argument support (`crates/app/core/src/tool_launch.rs`). Siril's profile is unchanged.

Follow-up not addressed here: #778 also reports a `\\?\` verbatim-path normalization issue affecting the working directory on Windows — tracked separately on that issue.

Test plan:
- `cargo test -p workflow_profiles` — 33 passed
- `cargo test -p app_core tool_launch` — 14 passed
- `cargo build --workspace` — green