### PR TITLE
feat: strengthen audit trail durability and expand entity coverage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "thiserror 2.0.18",
  "time",
  "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/src/commands/audit.rs
+++ b/apps/desktop/src-tauri/src/commands/audit.rs
@@ -244,6 +244,9 @@ fn build_filter(
         entity_id: f.entity_id,
         outcome: f.outcome.map(outcome_to_db_str).map(str::to_owned),
         severity: f.severity.map(severity_to_db_str).map(str::to_owned),
+        // T120 (spec 030): reason_code filtering is not yet exposed on the
+        // `AuditFilterDto` contract — no UI consumer needs it in this task.
+        reason_code: None,
         from: f.from,
         to: f.to,
         search: f.search,

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -493,6 +493,12 @@ fn validate_edge(entity_type: EntityType, from: &str, to: &str) -> bool {
         EntityType::Projection | EntityType::ProcessingArtifact => parse_projection(from)
             .zip(parse_projection(to))
             .is_some_and(|(f, t)| projection::is_allowed(f, t)),
+        // Spec 030 T120: Settings/Protection/Equipment are audit-only tags
+        // with no lifecycle transition table; they are never dispatched
+        // through `lifecycle.transition` (see `EntityType` doc comment).
+        EntityType::Settings | EntityType::Protection | EntityType::Equipment => unreachable!(
+            "{entity_type:?} has no lifecycle transition table; it never flows through lifecycle.transition"
+        ),
     }
 }
 

--- a/crates/audit-types/src/event.rs
+++ b/crates/audit-types/src/event.rs
@@ -34,6 +34,18 @@ pub enum Outcome {
     Failed,
 }
 
+impl Outcome {
+    /// DB column value (matches the `audit_log_entry.outcome` CHECK constraint).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Applied => "applied",
+            Self::Refused => "refused",
+            Self::Failed => "failed",
+        }
+    }
+}
+
 /// Visibility tier for the audit event (FR-008).
 #[derive(
     Clone,
@@ -56,6 +68,15 @@ pub enum Severity {
 }
 
 impl Severity {
+    /// DB column value (matches the `audit_log_entry.severity` CHECK constraint).
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Workflow => "workflow",
+            Self::Diagnostic => "diagnostic",
+        }
+    }
+
     /// Default UI severity for newly minted audit entries (FR-008).
     ///
     /// Workflow is the visible tier; diagnostic stays log-only behind the
@@ -105,7 +126,16 @@ impl SeverityFilter {
     }
 }
 
-/// Durable, append-only record of a lifecycle transition attempt.
+/// Durable, append-only record of a mutation attempt.
+///
+/// Spec 030 FR-133 (T120, Q15/#647): generalized from a lifecycle-transition
+/// record to a generic mutation record — `entity_type` extends beyond the
+/// lifecycle `DataAsset` families (see `EntityType::Settings/Protection/
+/// Equipment`), `trigger` doubles as the generic `action`, and `reason_code`
+/// is the first-class machine-readable detail for `refused`/`failed`
+/// outcomes. `from_state`/`to_state` stay lifecycle-transition-specific;
+/// non-lifecycle mutations carry their before→after value pair in `payload`
+/// instead (data-model.md "Audit Entry — Generalized Mutation Record").
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct AuditLogEntry {
@@ -124,6 +154,10 @@ pub struct AuditLogEntry {
     pub at: Timestamp,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub payload: Option<Value>,
+    /// Machine-readable reason/code for `refused`/`failed` outcomes; `None`
+    /// for `applied` (T120 migration: nullable `reason_code` column).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason_code: Option<String>,
 }
 
 impl AuditLogEntry {
@@ -150,6 +184,7 @@ impl AuditLogEntry {
             request_id,
             at: Timestamp::now_utc(),
             payload: None,
+            reason_code: None,
         }
     }
 
@@ -163,6 +198,13 @@ impl AuditLogEntry {
     #[must_use]
     pub fn with_payload(mut self, payload: Value) -> Self {
         self.payload = Some(payload);
+        self
+    }
+
+    /// Attach the machine-readable reason/code for a `refused`/`failed` outcome.
+    #[must_use]
+    pub fn with_reason_code(mut self, reason_code: impl Into<String>) -> Self {
+        self.reason_code = Some(reason_code.into());
         self
     }
 }

--- a/crates/audit/Cargo.toml
+++ b/crates/audit/Cargo.toml
@@ -20,6 +20,7 @@ sqlx.workspace = true
 thiserror.workspace = true
 time.workspace = true
 tokio = { workspace = true, features = ["sync", "macros", "rt"] }
+tracing.workspace = true
 
 [lints]
 workspace = true

--- a/crates/audit/src/bus.rs
+++ b/crates/audit/src/bus.rs
@@ -11,7 +11,8 @@
 //! Durable reads/writes delegate to `persistence_db::repositories::events`
 //! (db-boundary-zero) rather than issuing raw SQL here.
 
-use audit_types::{EventPublisher, Source};
+use audit_types::{AuditLogEntry, EventPublisher, Source};
+use domain_core::ids::AuditId;
 use serde::Serialize;
 use sqlx::SqlitePool;
 use tokio::sync::broadcast;
@@ -100,6 +101,64 @@ impl EventBus {
         // 2. Broadcast to live subscribers.
         // `send` errors only when there are NO receivers at all (which is fine).
         Ok(self.sender.send(envelope).unwrap_or(0))
+    }
+
+    /// T121 (spec 030 FR-131, Q15/#647): single write-through path for
+    /// audit-worthy mutations. Writes the durable `audit_log_entry` row
+    /// first, then emits `event_payload` on `topic` for the live UI, and
+    /// returns the durable `entry.audit_id` — never a bus-only id (the
+    /// FR-131 violation this closes: settings/protection/equipment/source
+    /// mutations previously returned an id pointing at a bus event no audit
+    /// read could resolve).
+    ///
+    /// Build `entry` with `AuditLogEntry::new(..)` and, as needed,
+    /// `.with_reason_code(..)` (refused/failed outcomes) and
+    /// `.with_payload(json!({"before": .., "after": ..}))` for
+    /// non-lifecycle before→after pairs (data-model.md "Audit Entry —
+    /// Generalized Mutation Record"). Typical call site:
+    ///
+    /// ```ignore
+    /// let entry = AuditLogEntry::new(
+    ///     EntityType::Settings, entity_id, "settings.update", "user",
+    ///     Outcome::Applied, Severity::Workflow, request_id,
+    /// )
+    /// .with_payload(json!({"key": key, "before": prior_value, "after": new_value}));
+    /// let audit_id = bus.write_audit(entry, TOPIC_SETTINGS_CHANGED, Source::User, event_payload).await?;
+    /// ```
+    ///
+    /// # Failure semantics (constitution §II)
+    /// The durable `audit_log_entry` insert is load-bearing: an insert
+    /// failure returns `Err` and the caller's command MUST fail. The bus
+    /// emit (including its own durable `events`-table row) is best-effort:
+    /// a publish failure is logged and swallowed — the command still
+    /// succeeds, because `audit_log_entry` is the authoritative audit
+    /// record and `events` is non-authoritative transient diagnostics
+    /// (spec §8.3 "Store roles").
+    ///
+    /// # Errors
+    /// Returns `BusError::Database` only if the durable `audit_log_entry`
+    /// insert fails.
+    pub async fn write_audit<P: Serialize>(
+        &self,
+        entry: AuditLogEntry,
+        topic: &str,
+        source: Source,
+        event_payload: P,
+    ) -> Result<AuditId, BusError> {
+        persistence_db::repositories::audit::insert_audit_entry(&self.pool, &entry)
+            .await
+            .map_err(BusError::Database)?;
+
+        if let Err(err) = self.publish(topic, source, event_payload).await {
+            tracing::warn!(
+                audit_id = %entry.audit_id.as_uuid(),
+                topic,
+                error = %err,
+                "audit bus emit failed after durable write; audit_log_entry row is authoritative"
+            );
+        }
+
+        Ok(entry.audit_id)
     }
 
     /// Subscribe to all live events on the bus.
@@ -250,6 +309,119 @@ mod tests {
         for envelope in &replayed {
             assert_eq!(envelope.source, Source::Restore, "replay must use Restore source");
         }
+    }
+
+    /// Real migrated DB (not the hand-rolled `events`-only fixture above) —
+    /// `write_audit` needs the actual `audit_log_entry` table (migration
+    /// 0063 adds `reason_code`).
+    async fn make_migrated_bus() -> (persistence_db::Database, EventBus) {
+        let db = persistence_db::Database::in_memory().await.expect("in-memory db");
+        db.migrate().await.expect("migrate");
+        let bus = EventBus::with_pool(db.pool().clone());
+        (db, bus)
+    }
+
+    #[tokio::test]
+    async fn write_audit_writes_durable_row_and_returns_its_audit_id() {
+        use audit_types::{Outcome, Severity};
+        use domain_core::ids::EntityId;
+        use domain_core::lifecycle::data_asset::EntityType;
+
+        let (db, bus) = make_migrated_bus().await;
+        let entity_id = EntityId::new();
+        let entry = AuditLogEntry::new(
+            EntityType::Settings,
+            entity_id,
+            "settings.update",
+            "user",
+            Outcome::Refused,
+            Severity::Workflow,
+            EntityId::new(),
+        )
+        .with_reason_code("invalid_value")
+        .with_payload(serde_json::json!({"key": "pattern", "before": "a", "after": "b"}));
+        let expected_audit_id = entry.audit_id;
+
+        let audit_id = bus
+            .write_audit(entry, "settings.changed", Source::User, serde_json::json!({"ok": true}))
+            .await
+            .expect("write_audit");
+
+        assert_eq!(audit_id, expected_audit_id);
+
+        let row: (String, Option<String>, Option<String>) = sqlx::query_as(
+            "SELECT outcome, reason_code, payload FROM audit_log_entry WHERE audit_id = ?",
+        )
+        .bind(audit_id.as_uuid().to_string())
+        .fetch_one(db.pool())
+        .await
+        .expect("durable row must exist");
+        assert_eq!(row.0, "refused");
+        assert_eq!(row.1.as_deref(), Some("invalid_value"));
+        assert!(row.2.expect("payload present").contains("\"before\":\"a\""));
+    }
+
+    #[tokio::test]
+    async fn write_audit_propagates_error_when_durable_insert_fails() {
+        use audit_types::{Outcome, Severity};
+        use domain_core::ids::EntityId;
+        use domain_core::lifecycle::data_asset::EntityType;
+
+        let (db, bus) = make_migrated_bus().await;
+        // Simulate a durable-write failure: drop the load-bearing table.
+        sqlx::query("DROP TABLE audit_log_entry").execute(db.pool()).await.expect("drop table");
+
+        let entry = AuditLogEntry::new(
+            EntityType::Protection,
+            EntityId::new(),
+            "protection.source.set",
+            "user",
+            Outcome::Applied,
+            Severity::Workflow,
+            EntityId::new(),
+        );
+
+        let result = bus
+            .write_audit(entry, "protection.source.set", Source::User, serde_json::json!({}))
+            .await;
+        assert!(result.is_err(), "insert failure must propagate — the durable row is load-bearing");
+    }
+
+    #[tokio::test]
+    async fn write_audit_succeeds_when_bus_emit_fails_but_durable_row_is_written() {
+        use audit_types::{Outcome, Severity};
+        use domain_core::ids::EntityId;
+        use domain_core::lifecycle::data_asset::EntityType;
+
+        let (db, bus) = make_migrated_bus().await;
+        // Simulate a bus-emit failure (the events table's own durable write
+        // fails) while audit_log_entry stays intact.
+        sqlx::query("DROP TABLE events").execute(db.pool()).await.expect("drop events table");
+
+        let entry = AuditLogEntry::new(
+            EntityType::Equipment,
+            EntityId::new(),
+            "equipment.optical_train.create",
+            "user",
+            Outcome::Applied,
+            Severity::Workflow,
+            EntityId::new(),
+        );
+        let expected_audit_id = entry.audit_id;
+
+        let audit_id = bus
+            .write_audit(entry, "equipment.changed", Source::User, serde_json::json!({}))
+            .await
+            .expect("bus-emit failure must not fail the command");
+        assert_eq!(audit_id, expected_audit_id);
+
+        let count: (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM audit_log_entry WHERE audit_id = ?")
+                .bind(audit_id.as_uuid().to_string())
+                .fetch_one(db.pool())
+                .await
+                .expect("count");
+        assert_eq!(count.0, 1, "durable row must exist despite the bus-emit failure");
     }
 
     #[tokio::test]

--- a/crates/domain/core/src/lifecycle/data_asset.rs
+++ b/crates/domain/core/src/lifecycle/data_asset.rs
@@ -21,6 +21,14 @@ use crate::lifecycle::projection::{ProcessingArtifact, ProjectionState};
 /// `InventorySession` were removed. Sessions no longer carry a
 /// review-transitionable lifecycle state, so they are no longer Data Assets
 /// dispatched through the generic `lifecycle.transition` machinery.
+///
+/// Spec 030 FR-130–FR-134 (T120, Q15/#647): `Settings`, `Protection`, and
+/// `Equipment` extend the tag set to non-lifecycle audit-worthy mutations
+/// (durable `audit_log_entry` rows written via `EventBus::write_audit`, not
+/// through `lifecycle.transition`/`record_transition`'s CAS state-column
+/// path — they carry no lifecycle state and are never dispatched through
+/// `DataAsset`). Source/root mutations reuse the existing `DataSource` /
+/// `LibraryRoot` tags.
 #[derive(
     Clone,
     Copy,
@@ -46,6 +54,9 @@ pub enum EntityType {
     Projection,
     Plan,
     FilesystemPlan,
+    Settings,
+    Protection,
+    Equipment,
 }
 
 impl EntityType {
@@ -61,6 +72,9 @@ impl EntityType {
             Self::Projection => "projection",
             Self::Plan => "plan",
             Self::FilesystemPlan => "filesystem_plan",
+            Self::Settings => "settings",
+            Self::Protection => "protection",
+            Self::Equipment => "equipment",
         }
     }
 }

--- a/crates/persistence/db/migrations/0063_audit_log_reason_code.sql
+++ b/crates/persistence/db/migrations/0063_audit_log_reason_code.sql
@@ -1,0 +1,18 @@
+-- Migration 0063: audit_log_entry reason_code (spec 030 T120, Q15/#647).
+--
+-- Generalizes the durable audit_log_entry row from a lifecycle-transition
+-- record to a generic mutation record (FR-130-FR-134). `entity_type` and
+-- `trigger` already carry no CHECK constraint (0002_lifecycle.sql), so the
+-- EntityType tag-set generalization (settings/protection/equipment) needs no
+-- DDL — the real surface is the Rust EntityType enum and its generated TS
+-- union. before->after value pairs for non-lifecycle mutations are carried
+-- in the existing `payload` JSON column, not new columns.
+--
+-- The only schema change: a first-class, queryable reason/code column for
+-- refused/failed outcomes (data-model.md "Migration shape (T120)"). Resulting
+-- column set: audit_id, entity_type, entity_id, from_state, to_state,
+-- trigger, actor, outcome, severity, request_id, at, payload, reason_code.
+
+ALTER TABLE audit_log_entry ADD COLUMN reason_code TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_audit_outcome ON audit_log_entry(outcome, reason_code);

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -93,7 +93,7 @@ impl Database {
     ///
     /// Returns [`DbError::Migration`] if any migration script fails, or a
     /// database error if the reconciliation scan fails.
-    // Touched for spec 051 (migration 0061) to force `sqlx::migrate!`
+    // Touched for spec 030 (migration 0063) to force `sqlx::migrate!`
     // re-embed (project memory: stale-embed guard).
     pub async fn migrate(&self) -> DbResult<()> {
         sqlx::migrate!("./migrations").run(&self.pool).await?;

--- a/crates/persistence/db/src/repositories/audit.rs
+++ b/crates/persistence/db/src/repositories/audit.rs
@@ -21,6 +21,7 @@
 
 use std::fmt::Write as _;
 
+use audit_types::AuditLogEntry;
 use sqlx::SqlitePool;
 
 use crate::DbResult;
@@ -42,6 +43,9 @@ pub struct AuditLogRow {
     pub request_id: String,
     pub at: String,
     pub payload: Option<String>,
+    /// Machine-readable reason/code for `refused`/`failed` outcomes (T120
+    /// migration 0063); `NULL` for `applied`.
+    pub reason_code: Option<String>,
 }
 
 /// Filter for `audit_log_entry` queries. All fields are AND-combined.
@@ -58,6 +62,8 @@ pub struct AuditLogFilter {
     pub outcome: Option<String>,
     /// Exact match against the `severity` column (`workflow` | `diagnostic`).
     pub severity: Option<String>,
+    /// Exact match against the `reason_code` column (T120 migration 0063).
+    pub reason_code: Option<String>,
     /// RFC 3339 lower bound on `at` (inclusive).
     pub from: Option<String>,
     /// RFC 3339 upper bound on `at` (exclusive).
@@ -102,6 +108,10 @@ fn build_where(filter: &AuditLogFilter) -> (String, Vec<String>) {
         clauses.push("severity = ?".to_owned());
         binds.push(v.clone());
     }
+    if let Some(ref v) = filter.reason_code {
+        clauses.push("reason_code = ?".to_owned());
+        binds.push(v.clone());
+    }
     if let Some(ref v) = filter.from {
         clauses.push("at >= ?".to_owned());
         binds.push(v.clone());
@@ -141,7 +151,7 @@ pub async fn list_audit_entries(
 
     let mut sql = format!(
         "SELECT audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
-         outcome, severity, request_id, at, payload \
+         outcome, severity, request_id, at, payload, reason_code \
          FROM audit_log_entry{where_sql} ORDER BY at DESC, audit_id DESC"
     );
 
@@ -231,6 +241,53 @@ pub async fn insert_project_auto_transition(
     Ok(())
 }
 
+/// Insert a generalized `audit_log_entry` row from an `AuditLogEntry` (T120,
+/// spec 030 FR-131/FR-133).
+///
+/// The single durable-write half of `EventBus::write_audit` (`crates::audit`
+/// crate, T121) — the load-bearing half per constitution §II: callers MUST
+/// propagate an `Err` here as a command failure, unlike the bus emit, which
+/// is best-effort. Distinct from `record_transition`/`record_refused_transition`
+/// (`crate::repositories::lifecycle`): this is a plain append with no
+/// accompanying CAS state-column update, for audit-worthy mutations that
+/// have no lifecycle state (settings, protection, equipment) as well as any
+/// other mutation that does not need the CAS coupling.
+///
+/// # Errors
+/// Returns [`DbError`](crate::DbError) if the insert fails.
+pub async fn insert_audit_entry(pool: &SqlitePool, entry: &AuditLogEntry) -> DbResult<()> {
+    let at_str = entry
+        .at
+        .as_offset_date_time()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let payload_str = entry.payload.as_ref().map(std::string::ToString::to_string);
+
+    sqlx::query(
+        "INSERT INTO audit_log_entry \
+         (audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
+          outcome, severity, request_id, at, payload, reason_code) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(entry.audit_id.as_uuid().to_string())
+    .bind(entry.entity_type.as_str())
+    .bind(entry.entity_id.to_string())
+    .bind(&entry.from_state)
+    .bind(&entry.to_state)
+    .bind(&entry.trigger)
+    .bind(&entry.actor)
+    .bind(entry.outcome.as_str())
+    .bind(entry.severity.as_str())
+    .bind(entry.request_id.to_string())
+    .bind(&at_str)
+    .bind(&payload_str)
+    .bind(&entry.reason_code)
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::{count_audit_entries, list_audit_entries, AuditLogFilter};
@@ -251,7 +308,8 @@ mod tests {
              severity TEXT NOT NULL CHECK (severity IN ('workflow', 'diagnostic')),\
              request_id TEXT NOT NULL,\
              at TEXT NOT NULL,\
-             payload TEXT\
+             payload TEXT,\
+             reason_code TEXT\
              )",
         )
         .execute(&pool)

--- a/crates/persistence/db/src/repositories/lifecycle.rs
+++ b/crates/persistence/db/src/repositories/lifecycle.rs
@@ -174,6 +174,12 @@ fn table_for(entity_type: EntityType) -> &'static str {
         EntityType::ProcessingArtifact | EntityType::Projection => "processing_artifact",
         // DataSource and LibraryRoot both map to library_root table
         EntityType::DataSource | EntityType::LibraryRoot => "library_root",
+        // Spec 030 T120: Settings/Protection/Equipment are audit-only tags
+        // (no lifecycle state table) written via `EventBus::write_audit`,
+        // never through `record_transition`'s CAS state-column path.
+        EntityType::Settings | EntityType::Protection | EntityType::Equipment => unreachable!(
+            "{entity_type:?} has no lifecycle state table; it never flows through record_transition"
+        ),
     }
 }
 


### PR DESCRIPTION
## Summary
- Audit log entries are now guaranteed to be written even if in-app event notifications fail, and cover more entity types (settings, protection rules, equipment).

## Spec Context
Q15 audit unification foundation (spec-030 FR-130-134/SC-009). EntityType +Settings/Protection/Equipment (additive). Migration 0063: reason_code + idx_audit_outcome. EventBus::write_audit ensures the durable audit_log_entry write is load-bearing while bus publish remains best-effort; 3 failure-semantics tests added.