### PR TITLE
feat: add framing data layer for mosaic/panel tracking

### DIFF
--- a/crates/domain/core/src/project/framing.rs
+++ b/crates/domain/core/src/project/framing.rs
@@ -1,0 +1,146 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `Framing` entity (spec 008 Q27, F-Framing-1) — data-model.md §Framing.
+//!
+//! A framing is the co-registerable integration unit within a project: the
+//! light sessions sharing target + optic-train + pointing + rotation within a
+//! tunable tolerance, spanning all filters and nights of one pointing.
+//! `project → framing → session → frames`.
+//!
+//! This module carries the entity shape and the invariants that are natural
+//! to encode as types/methods at this layer (FR-013/FR-016/FR-017). The
+//! clustering algorithm itself (F-Framing-2) and the merge/split/reassign use
+//! cases (F-Framing-3) live elsewhere; this is pure data + the small rules
+//! that follow directly from the shape.
+
+use crate::ids::EntityId;
+
+/// Representative FOV-relative pointing for a framing, or a session's durable
+/// clustering-key pointing. Degrees, ICRS.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Pointing {
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+}
+
+/// Snapshot of the tunable tolerance a clustering pass used (FR-014). Never an
+/// exact-match key — documents *why* sessions grouped, not a rule the app
+/// treats as authoritative.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct FramingTolerance {
+    /// Pointing tolerance as used by the clustering pass (FOV-relative
+    /// fraction, or the absolute-degree no-FOV fallback per research R11a —
+    /// the unit is a property of how the snapshot was produced, not of this
+    /// type).
+    pub pointing: f64,
+    /// Rotation tolerance in degrees.
+    pub rotation_deg: f32,
+}
+
+/// Clustering provenance (FR-015): the app's grouping is always a suggestion
+/// until a user merges, splits, or reassigns — it never becomes authoritative
+/// by itself.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum Clustering {
+    /// Produced by the tolerance-based clustering pass; still eligible for the
+    /// bulk re-derive pass (onboarding/rescan) to update it.
+    Suggested,
+    /// The user merged, split, or reassigned this framing. Re-derivation MUST
+    /// NEVER modify a `UserAdjusted` framing (FR-015) — it may only surface
+    /// new suggestions.
+    UserAdjusted,
+}
+
+impl Clustering {
+    /// Whether re-derivation must leave this framing's membership untouched
+    /// (FR-015). `Suggested` framings may be overwritten by a fresh suggestion;
+    /// `UserAdjusted` framings are protected.
+    #[must_use]
+    pub const fn protected_from_rederivation(self) -> bool {
+        matches!(self, Self::UserAdjusted)
+    }
+}
+
+/// The co-registerable integration unit within a project (Q27).
+///
+/// Mirrors data-model.md §Framing. `session_view_id`/`manifest` (Q20/Q10
+/// projections) are consumers of this model delivered by later iterations
+/// (F-Framing-7) and are not persisted by this node — omitted here rather
+/// than carried as always-`None` dead fields.
+#[derive(Clone, Debug, PartialEq)]
+pub struct Framing {
+    pub id: EntityId,
+    /// A framing belongs to exactly one project.
+    pub project_id: EntityId,
+    /// The framing's target; equals the project's declared target for mosaic
+    /// panels (FR-017) and for the single active framing of a non-mosaic
+    /// project (FR-016).
+    pub target_id: Option<EntityId>,
+    /// Optic-train identity (Q12/Q17 grouping key).
+    pub optic_train_key: String,
+    pub pointing: Pointing,
+    pub rotation_deg: f32,
+    pub tolerance: FramingTolerance,
+    pub session_ids: Vec<EntityId>,
+    pub clustering: Clustering,
+}
+
+impl Framing {
+    /// Whether this framing's `target_id` is consistent with the owning
+    /// project's declared target and mosaic mode.
+    ///
+    /// - Mosaic project (FR-017): every framing inherits the project's
+    ///   declared target; per-frame target resolution is suppressed, so any
+    ///   stored `target_id` (including `None`) is consistent.
+    /// - Non-mosaic project (FR-016, one-target-per-project rule): the
+    ///   framing's `target_id` MUST equal the project's declared target.
+    #[must_use]
+    pub fn target_is_consistent(&self, project_declared_target: EntityId, is_mosaic: bool) -> bool {
+        is_mosaic || self.target_id == Some(project_declared_target)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn id(byte: u8) -> EntityId {
+        EntityId::from_uuid(uuid::Uuid::from_bytes([byte; 16]))
+    }
+
+    #[test]
+    fn user_adjusted_is_protected_from_rederivation() {
+        assert!(Clustering::UserAdjusted.protected_from_rederivation());
+        assert!(!Clustering::Suggested.protected_from_rederivation());
+    }
+
+    fn framing_with_target(target_id: Option<EntityId>) -> Framing {
+        Framing {
+            id: id(2),
+            project_id: id(3),
+            target_id,
+            optic_train_key: "scope-a|cam-a".to_owned(),
+            pointing: Pointing { ra_deg: 10.0, dec_deg: 20.0 },
+            rotation_deg: 0.0,
+            tolerance: FramingTolerance { pointing: 0.1, rotation_deg: 3.0 },
+            session_ids: vec![],
+            clustering: Clustering::Suggested,
+        }
+    }
+
+    #[test]
+    fn non_mosaic_framing_must_match_the_project_declared_target() {
+        let declared = id(1);
+        assert!(framing_with_target(Some(declared)).target_is_consistent(declared, false));
+        assert!(!framing_with_target(Some(id(9))).target_is_consistent(declared, false));
+        assert!(!framing_with_target(None).target_is_consistent(declared, false));
+    }
+
+    #[test]
+    fn mosaic_framing_target_is_always_consistent() {
+        let declared = id(1);
+        assert!(framing_with_target(Some(id(9))).target_is_consistent(declared, true));
+        assert!(framing_with_target(None).target_is_consistent(declared, true));
+    }
+}

--- a/crates/domain/core/src/project/mod.rs
+++ b/crates/domain/core/src/project/mod.rs
@@ -9,4 +9,5 @@
 
 pub mod channel_map;
 pub mod channels;
+pub mod framing;
 pub mod validate;

--- a/crates/persistence/db/migrations/0064_framing.sql
+++ b/crates/persistence/db/migrations/0064_framing.sql
@@ -1,0 +1,77 @@
+PRAGMA foreign_keys = ON;
+
+-- Migration 0064: Framing layer (spec 008 Q27, F-Framing-1).
+--
+-- Adds the co-registerable integration unit that sits between a project and
+-- its light sessions: `project → framing → session → frames`. See
+-- specs/008-project-create-onboard-edit/data-model.md §Framing.
+--
+--   * `framing` — one row per suggested/user-adjusted grouping of light
+--     sessions sharing target + optic-train + pointing + rotation within a
+--     tolerance. All geometry columns are NOT NULL: a framing cannot exist
+--     without a representative pointing/rotation (F-Framing-2 computes it).
+--   * `framing_session` — membership join. `session_id` is UNIQUE: a light
+--     session belongs to at most one framing (data-model.md Invariants).
+--   * `projects.is_mosaic` — mosaic-mode flag (FR-017), default false,
+--     backward-compatible with existing rows.
+--   * Durable session-level clustering key: nullable `pointing_ra_deg`,
+--     `pointing_dec_deg`, `rotation_deg`, `optic_train_key` columns on
+--     `acquisition_session`. **Nullable is intentional** (Q16 null
+--     semantics) — legacy rows keep NULL geometry and are excluded from
+--     clustering until backfilled via rescan (Q28); NEVER default to 0.
+--     Populated at confirm time by a later node (F-Framing-2/5/10); this
+--     migration only adds the columns.
+--
+-- This node (F-Framing-1) adds schema + repository plumbing only. Clustering
+-- (F-Framing-2), the merge/split/reassign use cases (F-Framing-3), and the
+-- Q20/Q10 per-framing projections (F-Framing-7) are later nodes.
+
+CREATE TABLE IF NOT EXISTS framing (
+    id                      TEXT NOT NULL PRIMARY KEY,
+    project_id              TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    -- Nullable: FR-018 forbids OBJECT/panel-name attribution; a framing may
+    -- exist before target resolution completes.
+    target_id               TEXT REFERENCES canonical_target(id),
+    -- Optic-train identity (Q12/Q17 grouping key).
+    optic_train_key         TEXT NOT NULL,
+    -- Representative FOV-relative pointing (circular-mean of members, R11a).
+    pointing_ra_deg         REAL NOT NULL,
+    pointing_dec_deg        REAL NOT NULL,
+    rotation_deg            REAL NOT NULL,
+    -- Snapshot of the tunable tolerance the clustering pass used (FR-014).
+    -- `tolerance_pointing` is unit-agnostic (FOV-relative fraction, or the
+    -- absolute-degree no-FOV fallback per research R11a); never an exact key.
+    tolerance_pointing      REAL NOT NULL,
+    tolerance_rotation_deg  REAL NOT NULL,
+    -- 'suggested' | 'user_adjusted' (FR-015). Re-derivation MUST NEVER modify
+    -- a 'user_adjusted' framing.
+    clustering              TEXT NOT NULL DEFAULT 'suggested'
+                                 CHECK (clustering IN ('suggested', 'user_adjusted')),
+    created_at              TEXT NOT NULL,
+    updated_at              TEXT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_framing_project ON framing(project_id);
+CREATE INDEX IF NOT EXISTS idx_framing_target  ON framing(target_id)
+    WHERE target_id IS NOT NULL;
+
+CREATE TABLE IF NOT EXISTS framing_session (
+    framing_id  TEXT NOT NULL REFERENCES framing(id) ON DELETE CASCADE,
+    -- UNIQUE: a light session belongs to at most one framing.
+    session_id  TEXT NOT NULL UNIQUE REFERENCES acquisition_session(id) ON DELETE CASCADE,
+    added_at    TEXT NOT NULL,
+    PRIMARY KEY (framing_id, session_id)
+);
+
+-- ── project.is_mosaic (FR-017) ──────────────────────────────────────────────
+ALTER TABLE projects ADD COLUMN is_mosaic INTEGER NOT NULL DEFAULT 0;
+
+-- ── acquisition_session durable clustering key (session-level geometry) ────
+ALTER TABLE acquisition_session ADD COLUMN pointing_ra_deg  REAL;
+ALTER TABLE acquisition_session ADD COLUMN pointing_dec_deg REAL;
+ALTER TABLE acquisition_session ADD COLUMN rotation_deg     REAL;
+ALTER TABLE acquisition_session ADD COLUMN optic_train_key  TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_acq_session_optic_train_key
+    ON acquisition_session(optic_train_key)
+    WHERE optic_train_key IS NOT NULL;

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -10,6 +10,8 @@
 //! Migration 0053 added `projects.archived_via_plan_id` + re-added `'archive'`
 //! to the `plans.origin` CHECK (spec 017 C5).
 //! Migration 0061 added `target_favourite` (spec 051 US2).
+//! Migration 0064 added the `framing`/`framing_session` tables, `projects.is_mosaic`,
+//! and the durable `acquisition_session` clustering-key columns (spec 008 Q27).
 
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
@@ -93,7 +95,7 @@ impl Database {
     ///
     /// Returns [`DbError::Migration`] if any migration script fails, or a
     /// database error if the reconciliation scan fails.
-    // Touched for spec 030 (migration 0063) to force `sqlx::migrate!`
+    // Touched for spec 008 Q27 (migration 0064) to force `sqlx::migrate!`
     // re-embed (project memory: stale-embed guard).
     pub async fn migrate(&self) -> DbResult<()> {
         sqlx::migrate!("./migrations").run(&self.pool).await?;

--- a/crates/persistence/db/src/repositories/framing.rs
+++ b/crates/persistence/db/src/repositories/framing.rs
@@ -1,0 +1,481 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repository methods for the `framing` / `framing_session` tables (spec 008
+//! Q27, migration 0064), plus the durable session-level clustering-key
+//! accessors these tables depend on (`acquisition_session.pointing_ra_deg`
+//! etc).
+//!
+//! This is schema-adjacent CRUD/query plumbing only (F-Framing-1). Tolerance
+//! clustering (F-Framing-2), the merge/split/reassign use cases
+//! (F-Framing-3), and confirm-time geometry population (F-Framing-2/5/10)
+//! live in `crates/sessions` / `crates/app/core` and are not this module's
+//! concern.
+
+use domain_core::ids::Timestamp;
+use sqlx::SqlitePool;
+
+use crate::{DbError, DbResult};
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+/// Flat row from the `framing` table.
+#[derive(Clone, Debug, sqlx::FromRow)]
+pub struct FramingRow {
+    pub id: String,
+    pub project_id: String,
+    pub target_id: Option<String>,
+    pub optic_train_key: String,
+    pub pointing_ra_deg: f64,
+    pub pointing_dec_deg: f64,
+    pub rotation_deg: f64,
+    pub tolerance_pointing: f64,
+    pub tolerance_rotation_deg: f64,
+    /// `"suggested"` or `"user_adjusted"`.
+    pub clustering: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+/// Durable clustering-key geometry for an `acquisition_session` row.
+/// All fields nullable — Q16 null semantics: legacy/unresolved rows keep NULL,
+/// never a fabricated zero. `None` fields exclude the session from clustering
+/// (F-Framing-2) until backfilled via rescan (Q28).
+#[derive(Clone, Debug, PartialEq, sqlx::FromRow)]
+pub struct SessionGeometryRow {
+    pub pointing_ra_deg: Option<f64>,
+    pub pointing_dec_deg: Option<f64>,
+    pub rotation_deg: Option<f64>,
+    pub optic_train_key: Option<String>,
+}
+
+// ── Insert helpers ───────────────────────────────────────────────────────────
+
+/// Data required to insert a new `framing` row.
+#[derive(Clone, Debug)]
+pub struct InsertFraming<'a> {
+    pub id: &'a str,
+    pub project_id: &'a str,
+    pub target_id: Option<&'a str>,
+    pub optic_train_key: &'a str,
+    pub pointing_ra_deg: f64,
+    pub pointing_dec_deg: f64,
+    pub rotation_deg: f64,
+    pub tolerance_pointing: f64,
+    pub tolerance_rotation_deg: f64,
+    /// `"suggested"` or `"user_adjusted"`.
+    pub clustering: &'a str,
+}
+
+// ── framing CRUD ──────────────────────────────────────────────────────────────
+
+/// Insert a new framing row. Returns the `created_at`/`updated_at` timestamp.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on constraint violation (e.g. unknown
+/// `project_id`/`target_id`) or query failure.
+pub async fn insert_framing(pool: &SqlitePool, data: &InsertFraming<'_>) -> DbResult<String> {
+    let now = Timestamp::now_iso();
+    sqlx::query(
+        "INSERT INTO framing (
+            id, project_id, target_id, optic_train_key,
+            pointing_ra_deg, pointing_dec_deg, rotation_deg,
+            tolerance_pointing, tolerance_rotation_deg,
+            clustering, created_at, updated_at
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(data.id)
+    .bind(data.project_id)
+    .bind(data.target_id)
+    .bind(data.optic_train_key)
+    .bind(data.pointing_ra_deg)
+    .bind(data.pointing_dec_deg)
+    .bind(data.rotation_deg)
+    .bind(data.tolerance_pointing)
+    .bind(data.tolerance_rotation_deg)
+    .bind(data.clustering)
+    .bind(&now)
+    .bind(&now)
+    .execute(pool)
+    .await?;
+    Ok(now)
+}
+
+/// Fetch a single framing row by id.
+///
+/// # Errors
+/// Returns [`DbError::NotFound`] when no framing with the given id exists.
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_framing(pool: &SqlitePool, id: &str) -> DbResult<FramingRow> {
+    sqlx::query_as::<_, FramingRow>(
+        "SELECT id, project_id, target_id, optic_train_key,
+                pointing_ra_deg, pointing_dec_deg, rotation_deg,
+                tolerance_pointing, tolerance_rotation_deg,
+                clustering, created_at, updated_at
+         FROM framing WHERE id = ?",
+    )
+    .bind(id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("framing {id}")))
+}
+
+/// List all framings for a project (creation order).
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_framings_by_project(
+    pool: &SqlitePool,
+    project_id: &str,
+) -> DbResult<Vec<FramingRow>> {
+    let rows = sqlx::query_as::<_, FramingRow>(
+        "SELECT id, project_id, target_id, optic_train_key,
+                pointing_ra_deg, pointing_dec_deg, rotation_deg,
+                tolerance_pointing, tolerance_rotation_deg,
+                clustering, created_at, updated_at
+         FROM framing WHERE project_id = ? ORDER BY created_at ASC",
+    )
+    .bind(project_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
+// ── framing_session membership ───────────────────────────────────────────────
+
+/// Add a light session to a framing's membership.
+///
+/// A session belongs to at most one framing (`framing_session.session_id` is
+/// UNIQUE, migration 0064) — callers must [`remove_session_from_framing`] any
+/// prior membership before reassigning (F-Framing-3's `framing.reassign`).
+///
+/// # Errors
+/// Returns [`DbError::Database`] on constraint violation (unknown ids, or the
+/// session is already a member of a framing) or query failure.
+pub async fn add_session_to_framing(
+    pool: &SqlitePool,
+    framing_id: &str,
+    session_id: &str,
+) -> DbResult<()> {
+    let now = Timestamp::now_iso();
+    sqlx::query("INSERT INTO framing_session (framing_id, session_id, added_at) VALUES (?, ?, ?)")
+        .bind(framing_id)
+        .bind(session_id)
+        .bind(&now)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// Remove a light session from a framing's membership. No-op (not an error)
+/// when the pair does not exist.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn remove_session_from_framing(
+    pool: &SqlitePool,
+    framing_id: &str,
+    session_id: &str,
+) -> DbResult<()> {
+    sqlx::query("DELETE FROM framing_session WHERE framing_id = ? AND session_id = ?")
+        .bind(framing_id)
+        .bind(session_id)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+/// List the member session ids of a framing, in the order they were added.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn list_session_ids_for_framing(
+    pool: &SqlitePool,
+    framing_id: &str,
+) -> DbResult<Vec<String>> {
+    let rows: Vec<(String,)> = sqlx::query_as(
+        "SELECT session_id FROM framing_session WHERE framing_id = ? ORDER BY added_at ASC",
+    )
+    .bind(framing_id)
+    .fetch_all(pool)
+    .await?;
+    Ok(rows.into_iter().map(|(id,)| id).collect())
+}
+
+/// The framing id a session currently belongs to, if any (at most one, per the
+/// `framing_session.session_id` UNIQUE constraint).
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_framing_id_for_session(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<String>> {
+    let row: Option<(String,)> =
+        sqlx::query_as("SELECT framing_id FROM framing_session WHERE session_id = ?")
+            .bind(session_id)
+            .fetch_optional(pool)
+            .await?;
+    Ok(row.map(|(id,)| id))
+}
+
+// ── acquisition_session durable clustering-key geometry ─────────────────────
+
+/// Read the durable clustering-key geometry for an `acquisition_session` row.
+/// Returns `Ok(None)` when no session with the given id exists; returns
+/// `Ok(Some(row))` with individually-nullable fields otherwise (Q16 semantics —
+/// a session that exists but predates confirm-time geometry population has all
+/// four fields `None`).
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_session_geometry(
+    pool: &SqlitePool,
+    session_id: &str,
+) -> DbResult<Option<SessionGeometryRow>> {
+    let row = sqlx::query_as::<_, SessionGeometryRow>(
+        "SELECT pointing_ra_deg, pointing_dec_deg, rotation_deg, optic_train_key
+         FROM acquisition_session WHERE id = ?",
+    )
+    .bind(session_id)
+    .fetch_optional(pool)
+    .await?;
+    Ok(row)
+}
+
+/// Write the durable clustering-key geometry for an `acquisition_session` row
+/// (populated at confirm time by a later node — F-Framing-2/5/10). Passing
+/// `None` for a field writes NULL; callers MUST NOT synthesize a `0.0`/`""`
+/// sentinel for missing header data (Q16 FR-136 — "missing is missing").
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn set_session_geometry(
+    pool: &SqlitePool,
+    session_id: &str,
+    pointing_ra_deg: Option<f64>,
+    pointing_dec_deg: Option<f64>,
+    rotation_deg: Option<f64>,
+    optic_train_key: Option<&str>,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE acquisition_session
+         SET pointing_ra_deg = ?, pointing_dec_deg = ?, rotation_deg = ?, optic_train_key = ?
+         WHERE id = ?",
+    )
+    .bind(pointing_ra_deg)
+    .bind(pointing_dec_deg)
+    .bind(rotation_deg)
+    .bind(optic_train_key)
+    .bind(session_id)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> Database {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db
+    }
+
+    async fn insert_project(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+             VALUES (?,?,?,?,?,?,?,?,?)",
+        )
+        .bind(id)
+        .bind(format!("Project {id}"))
+        .bind("PixInsight")
+        .bind("ready")
+        .bind(format!("projects/{id}"))
+        .bind::<Option<String>>(None)
+        .bind(false)
+        .bind("2026-01-01T00:00:00Z")
+        .bind("2026-01-01T00:00:00Z")
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    async fn insert_acquisition_session(pool: &SqlitePool, id: &str) {
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
+             VALUES (?, ?, '[]', '2026-01-01T00:00:00Z')",
+        )
+        .bind(id)
+        .bind(format!("session-key-{id}"))
+        .execute(pool)
+        .await
+        .unwrap();
+    }
+
+    fn insert_data<'a>(id: &'a str, project_id: &'a str) -> InsertFraming<'a> {
+        InsertFraming {
+            id,
+            project_id,
+            target_id: None,
+            optic_train_key: "scope-a|cam-a",
+            pointing_ra_deg: 10.5,
+            pointing_dec_deg: -20.25,
+            rotation_deg: 3.0,
+            tolerance_pointing: 0.1,
+            tolerance_rotation_deg: 3.0,
+            clustering: "suggested",
+        }
+    }
+
+    // ── projects.is_mosaic default (F-Framing-1) ───────────────────────────────
+
+    #[tokio::test]
+    async fn project_is_mosaic_defaults_to_false() {
+        let db = setup().await;
+        insert_project(db.pool(), "proj-mosaic-default").await;
+
+        let is_mosaic: bool = sqlx::query_scalar("SELECT is_mosaic FROM projects WHERE id = ?")
+            .bind("proj-mosaic-default")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert!(!is_mosaic, "is_mosaic must default to false (backward-compatible)");
+    }
+
+    // ── framing insert / get / list-by-project ─────────────────────────────────
+
+    #[tokio::test]
+    async fn insert_and_get_framing_round_trips() {
+        let db = setup().await;
+        insert_project(db.pool(), "proj-1").await;
+
+        insert_framing(db.pool(), &insert_data("framing-1", "proj-1")).await.unwrap();
+
+        let row = get_framing(db.pool(), "framing-1").await.unwrap();
+        assert_eq!(row.project_id, "proj-1");
+        assert_eq!(row.target_id, None);
+        assert_eq!(row.optic_train_key, "scope-a|cam-a");
+        assert!((row.pointing_ra_deg - 10.5).abs() < f64::EPSILON);
+        assert!((row.pointing_dec_deg - (-20.25)).abs() < f64::EPSILON);
+        assert_eq!(row.clustering, "suggested");
+    }
+
+    #[tokio::test]
+    async fn get_framing_not_found_for_unknown_id() {
+        let db = setup().await;
+        let err = get_framing(db.pool(), "missing").await.unwrap_err();
+        assert!(matches!(err, DbError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn list_framings_by_project_returns_only_that_projects_framings() {
+        let db = setup().await;
+        insert_project(db.pool(), "proj-a").await;
+        insert_project(db.pool(), "proj-b").await;
+
+        insert_framing(db.pool(), &insert_data("framing-a1", "proj-a")).await.unwrap();
+        insert_framing(db.pool(), &insert_data("framing-a2", "proj-a")).await.unwrap();
+        insert_framing(db.pool(), &insert_data("framing-b1", "proj-b")).await.unwrap();
+
+        let rows = list_framings_by_project(db.pool(), "proj-a").await.unwrap();
+        let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+        assert_eq!(ids, vec!["framing-a1", "framing-a2"]);
+    }
+
+    // ── framing_session membership ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn membership_add_list_remove_round_trips() {
+        let db = setup().await;
+        insert_project(db.pool(), "proj-m").await;
+        insert_acquisition_session(db.pool(), "sess-1").await;
+        insert_acquisition_session(db.pool(), "sess-2").await;
+        insert_framing(db.pool(), &insert_data("framing-m", "proj-m")).await.unwrap();
+
+        add_session_to_framing(db.pool(), "framing-m", "sess-1").await.unwrap();
+        add_session_to_framing(db.pool(), "framing-m", "sess-2").await.unwrap();
+
+        let members = list_session_ids_for_framing(db.pool(), "framing-m").await.unwrap();
+        assert_eq!(members, vec!["sess-1", "sess-2"]);
+        assert_eq!(
+            get_framing_id_for_session(db.pool(), "sess-1").await.unwrap().as_deref(),
+            Some("framing-m")
+        );
+
+        remove_session_from_framing(db.pool(), "framing-m", "sess-1").await.unwrap();
+        let members = list_session_ids_for_framing(db.pool(), "framing-m").await.unwrap();
+        assert_eq!(members, vec!["sess-2"]);
+        assert_eq!(get_framing_id_for_session(db.pool(), "sess-1").await.unwrap(), None);
+    }
+
+    #[tokio::test]
+    async fn a_session_belongs_to_at_most_one_framing() {
+        let db = setup().await;
+        insert_project(db.pool(), "proj-u").await;
+        insert_acquisition_session(db.pool(), "sess-u").await;
+        insert_framing(db.pool(), &insert_data("framing-u1", "proj-u")).await.unwrap();
+        insert_framing(db.pool(), &insert_data("framing-u2", "proj-u")).await.unwrap();
+
+        add_session_to_framing(db.pool(), "framing-u1", "sess-u").await.unwrap();
+        let err = add_session_to_framing(db.pool(), "framing-u2", "sess-u").await.unwrap_err();
+        assert!(
+            matches!(err, DbError::Database(_)),
+            "UNIQUE(session_id) must reject a second framing"
+        );
+    }
+
+    // ── acquisition_session durable geometry (Q16 null semantics) ──────────────
+
+    #[tokio::test]
+    async fn new_session_has_null_geometry_until_populated() {
+        let db = setup().await;
+        insert_acquisition_session(db.pool(), "sess-legacy").await;
+
+        let geo = get_session_geometry(db.pool(), "sess-legacy").await.unwrap().unwrap();
+        assert_eq!(
+            geo,
+            SessionGeometryRow {
+                pointing_ra_deg: None,
+                pointing_dec_deg: None,
+                rotation_deg: None,
+                optic_train_key: None,
+            },
+            "legacy/unpopulated rows must stay NULL — never a fabricated 0.0 sentinel"
+        );
+    }
+
+    #[tokio::test]
+    async fn set_session_geometry_round_trips_and_preserves_none_fields() {
+        let db = setup().await;
+        insert_acquisition_session(db.pool(), "sess-confirmed").await;
+
+        set_session_geometry(
+            db.pool(),
+            "sess-confirmed",
+            Some(83.633_2),
+            Some(22.014_5),
+            Some(1.5),
+            Some("scope-a|cam-a"),
+        )
+        .await
+        .unwrap();
+
+        let geo = get_session_geometry(db.pool(), "sess-confirmed").await.unwrap().unwrap();
+        assert_eq!(geo.pointing_ra_deg, Some(83.633_2));
+        assert_eq!(geo.pointing_dec_deg, Some(22.014_5));
+        assert_eq!(geo.rotation_deg, Some(1.5));
+        assert_eq!(geo.optic_train_key.as_deref(), Some("scope-a|cam-a"));
+    }
+
+    #[tokio::test]
+    async fn get_session_geometry_returns_none_for_unknown_session() {
+        let db = setup().await;
+        let geo = get_session_geometry(db.pool(), "missing").await.unwrap();
+        assert!(geo.is_none());
+    }
+}

--- a/crates/persistence/db/src/repositories/mod.rs
+++ b/crates/persistence/db/src/repositories/mod.rs
@@ -8,6 +8,9 @@
 //! spec 016 source protection, spec 024 manifests/notes,
 //! spec 026 prepared source views, and spec 010 guided flow.
 //!
+//! Spec 008 Q27 framing layer (`framing`/`framing_session` +
+//! `acquisition_session` clustering-key geometry) lives in `framing`.
+//!
 //! Spec 013/023 gen-2 target repository (`targets`) removed by spec 036.
 //! Spec 023 US2/US3/US4 target history + notes queries live in `targets`.
 //! Spec 051 US2 target favourites queries live in `target_favourites`.
@@ -19,6 +22,7 @@ pub mod calibration_tolerances;
 pub mod equipment;
 pub mod events;
 pub mod first_run;
+pub mod framing;
 pub mod guided_flow;
 pub mod inbox;
 pub mod inventory;


### PR DESCRIPTION
## Summary
- New framing and framing_session tables, a project-level mosaic flag, session geometry columns, and a Framing domain entity — the persistence foundation for tracking multi-panel/mosaic acquisitions.

## Spec Context
Refs spec-008 F-Framing-1, FR-013/016/017, grilling decisions doc §Q27. Migration 0064 additive and non-colliding; NULL-geometry round-trips verified; db-boundary clean; workspace compiles; 362 tests pass.