### PR TITLE
perf: seed the target-lookup cache in one batched write instead of 13,000

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -1734,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3427,7 +3427,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3508,7 +3508,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4555,7 +4555,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4986,7 +4986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -5550,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "simbad-resolver"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6b26ebbfe68669dc579527adf7e53c39f799528209a99b31c852345048e00d7"
+checksum = "f412ea3c3d51dfcd6b24a9eba6acf154b07d91287ecc2518a7c4dce24124e299"
 dependencies = [
  "async-trait",
  "redb",
@@ -5639,7 +5639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6772,7 +6772,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7289,7 +7289,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7341,7 +7341,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -7876,7 +7876,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -8351,7 +8351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1734,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3508,7 +3508,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4555,7 +4555,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4986,7 +4986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5550,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "simbad-resolver"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff6f68107e874c3528e6ff97f9a5de628cadce88405dcc8fc797097b1bd78037"
+checksum = "d6b26ebbfe68669dc579527adf7e53c39f799528209a99b31c852345048e00d7"
 dependencies = [
  "async-trait",
  "redb",
@@ -6772,7 +6772,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7876,7 +7876,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8351,7 +8351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1734,7 +1734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2271,7 +2271,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3427,7 +3427,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3508,7 +3508,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4555,7 +4555,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4986,7 +4986,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5044,7 +5044,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5550,9 +5550,9 @@ dependencies = [
 
 [[package]]
 name = "simbad-resolver"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f412ea3c3d51dfcd6b24a9eba6acf154b07d91287ecc2518a7c4dce24124e299"
+checksum = "1aac89eca5180a1d9ec430e6d2e59a2909f00832a7bd0d996dbd0d49f80cb553"
 dependencies = [
  "async-trait",
  "redb",
@@ -5639,7 +5639,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6772,7 +6772,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7289,7 +7289,7 @@ dependencies = [
  "png 0.18.1",
  "serde",
  "thiserror 2.0.18",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7341,7 +7341,7 @@ checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
 dependencies = [
  "memoffset",
  "tempfile",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7876,7 +7876,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8351,7 +8351,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ audit = { path = "../../../crates/audit" }
 targeting_resolver = { path = "../../../crates/targeting/resolver" }
 # spec 052 P1: AppState owns the shared redb resolve-cache handle directly
 # (Cache trait for .cache()/search, identity::namespace for warming).
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 # target.astro_format.batch: sexagesimal RA/Dec formatting (adopt target-match).
 targeting = { path = "../../../crates/targeting" }
 contracts_core = { path = "../../../crates/contracts/core" }

--- a/apps/desktop/src-tauri/src/commands/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/commands/lifecycle.rs
@@ -43,9 +43,10 @@ pub struct AppState {
     pub resolve_cache_path: std::path::PathBuf,
     /// True while a bundled-seed/durable-row re-warm of `resolve_cache` is
     /// running in the background (the startup warm in `lib.rs`, or the one
-    /// `commands::resolve_cache::clear_and_rewarm` schedules). Set true
-    /// immediately before each warm is spawned and false when it finishes;
-    /// `target.search` surfaces the value so a caller whose query landed
+    /// `commands::resolve_cache::clear_and_rewarm` schedules). Set true and
+    /// cleared by a [`CacheWarmingGuard`] held for the warm task's whole
+    /// scope, never a bare sequential store, so a panic mid-warm still clears
+    /// it; `target.search` surfaces the value so a caller whose query landed
     /// mid-warm can tell a still-settling empty result apart from a genuine
     /// miss (issue #818). Two overlapping warms (startup racing an
     /// almost-immediate cache-clear) can make the flag go false slightly
@@ -70,6 +71,78 @@ impl AppState {
             resolve_cache_path,
             cache_warming,
         }
+    }
+}
+
+/// RAII guard that flips [`AppState::cache_warming`] back to `false` on
+/// **any** scope exit — normal return *or* unwind from a panic inside the
+/// warm task (issue #818 review). A bare sequential
+/// `flag.store(false, ...)` after both warm phases is skipped if either
+/// panics, since the unwind jumps past it; the flag then sticks `true` for
+/// the rest of the process, and every later `target.search` pays the full
+/// retry budget (`TargetSearch.tsx`) for a warm that will never finish.
+///
+/// [`CacheWarmingGuard::start`] sets the flag `true` and returns the guard in
+/// one call (mirroring `plan_apply::check_overlap_and_register` + its
+/// `ActiveRunGuard`) so the flag is visible to a concurrent `target.search`
+/// the instant the caller schedules the warm — the guard itself is then
+/// moved into the spawned task, so its `Drop` runs exactly once, whichever
+/// way that task ends. Shared by both warm sites (`lib.rs`'s startup warm and
+/// `resolve_cache.rs`'s `clear_and_rewarm`) instead of duplicating the
+/// set/clear pair at each.
+pub struct CacheWarmingGuard(std::sync::Arc<std::sync::atomic::AtomicBool>);
+
+impl CacheWarmingGuard {
+    /// Set `flag` true and return the guard that will clear it on drop.
+    #[must_use]
+    pub fn start(flag: std::sync::Arc<std::sync::atomic::AtomicBool>) -> Self {
+        flag.store(true, std::sync::atomic::Ordering::Relaxed);
+        Self(flag)
+    }
+}
+
+impl Drop for CacheWarmingGuard {
+    fn drop(&mut self) {
+        self.0.store(false, std::sync::atomic::Ordering::Relaxed);
+    }
+}
+
+#[cfg(test)]
+mod cache_warming_guard_tests {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+
+    use super::CacheWarmingGuard;
+
+    #[test]
+    fn start_sets_true_and_normal_drop_clears_it() {
+        let flag = Arc::new(AtomicBool::new(false));
+        {
+            let _guard = CacheWarmingGuard::start(flag.clone());
+            assert!(flag.load(Ordering::Relaxed), "flag must be true while the guard is held");
+        } // guard drops here
+        assert!(!flag.load(Ordering::Relaxed), "guard Drop must clear the flag on normal exit");
+    }
+
+    /// Regression for the #818 review finding: a panic inside the warm task
+    /// (after the guard is constructed) must still clear the flag, mirroring
+    /// `plan_apply::active_run_guard_removes_entry_when_scope_panics`.
+    #[test]
+    fn panic_after_start_still_clears_the_flag() {
+        let flag = Arc::new(AtomicBool::new(false));
+        let flag_for_scope = flag.clone();
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            // Guard is owned by this scope, mirroring
+            // `tokio::spawn(async move { let _guard = ...; warm().await })`.
+            let _guard = CacheWarmingGuard::start(flag_for_scope);
+            panic!("warm task panicked mid-warm");
+        }));
+
+        assert!(result.is_err(), "the scope must have panicked");
+        assert!(
+            !flag.load(Ordering::Relaxed),
+            "guard Drop must clear the flag even when the scope unwinds from a panic"
+        );
     }
 }
 

--- a/apps/desktop/src-tauri/src/commands/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/commands/lifecycle.rs
@@ -41,6 +41,17 @@ pub struct AppState {
     /// Filesystem path backing `resolve_cache`, needed by
     /// `target.cache.clear` to delete + reopen the redb file.
     pub resolve_cache_path: std::path::PathBuf,
+    /// True while a bundled-seed/durable-row re-warm of `resolve_cache` is
+    /// running in the background (the startup warm in `lib.rs`, or the one
+    /// `commands::resolve_cache::clear_and_rewarm` schedules). Set true
+    /// immediately before each warm is spawned and false when it finishes;
+    /// `target.search` surfaces the value so a caller whose query landed
+    /// mid-warm can tell a still-settling empty result apart from a genuine
+    /// miss (issue #818). Two overlapping warms (startup racing an
+    /// almost-immediate cache-clear) can make the flag go false slightly
+    /// early, when the first of the two finishes — an accepted, rare
+    /// edge case, not a full per-warm reference count.
+    pub cache_warming: std::sync::Arc<std::sync::atomic::AtomicBool>,
 }
 
 impl AppState {
@@ -50,12 +61,14 @@ impl AppState {
         bus: EventBus,
         resolve_cache: targeting_resolver::simbad::ResolveCache,
         resolve_cache_path: std::path::PathBuf,
+        cache_warming: std::sync::Arc<std::sync::atomic::AtomicBool>,
     ) -> Self {
         Self {
             repo,
             bus,
             resolve_cache: tokio::sync::RwLock::new(resolve_cache),
             resolve_cache_path,
+            cache_warming,
         }
     }
 }

--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -155,7 +155,11 @@ pub async fn target_search(
 ) -> Result<TargetSearchResponse, ContractError> {
     tracing::debug!("target.search query={:?} limit={}", req.query, req.limit);
     let cache = state.resolve_cache.read().await.clone();
-    app_core::target_search::search(&cache.cache(), &req).await
+    let mut resp = app_core::target_search::search(&cache.cache(), &req).await?;
+    // #818: the pure use case always answers `false`; only this wrapper has
+    // the live `AppState` flag a background re-warm sets/clears.
+    resp.cache_warming = state.cache_warming.load(std::sync::atomic::Ordering::Relaxed);
+    Ok(resp)
 }
 
 // ── target.adopt (spec 052 P1 FR-004) ───────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1111,6 +1111,12 @@ pub fn run_app(
     // (issue #818).
     let cache_warming = Arc::new(std::sync::atomic::AtomicBool::new(false));
     {
+        // Cloned (cheap — an `Arc` handle, see `ResolveCache`'s doc comment),
+        // not moved: `resolve_cache` itself is still needed below to build
+        // `AppState`. `warm_handle` keeps the CONCRETE type so `.flush()` is
+        // reachable after the warm; `warm_cache` (its `.cache()`) is the
+        // erased `Cache` trait object the warm functions themselves take.
+        let warm_handle = resolve_cache.clone();
         let warm_cache = resolve_cache.cache();
         let warm_pool = pool.clone();
         let warm_guard =
@@ -1138,6 +1144,15 @@ pub fn run_app(
                 }
                 Ok(_) => {}
                 Err(e) => tracing::warn!("failed to warm resolve cache from canonical_target: {e}"),
+            }
+            // #818 follow-up: both phases above write `Eventual` (fsync-free)
+            // chunks; this is the one fsync that persists all of them (redb
+            // commits are cumulative) — the bundled-seed phase's own warm-
+            // complete sentinel write is ALSO durable on its own (single-item
+            // upsert), but the canonical_target phase has no such capstone,
+            // so this explicit flush is what actually protects it.
+            if let Err(e) = warm_handle.flush().await {
+                tracing::warn!("failed to flush resolve cache after startup warm: {e}");
             }
         });
     }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1101,19 +1101,22 @@ pub fn run_app(
     // until the next launch, never blocks the UI.
     //
     // `cache_warming` (shared with the managed `AppState` below) is set true
-    // for the duration: batching a whole phase into one transaction means no
-    // row is visible to a reader until that phase commits, so a `target.search`
-    // query landing in this window can get a legitimate-looking empty result
-    // for a seed object that just hasn't committed yet — the flag lets
-    // `target.search` tell the frontend to retry instead of freezing on that
-    // stale answer (issue #818).
+    // for the duration via a `CacheWarmingGuard` (not a bare sequential
+    // store — a panic mid-warm must still clear it, see its doc comment):
+    // batching a whole phase into one transaction means no row is visible to
+    // a reader until that phase commits, so a `target.search` query landing
+    // in this window can get a legitimate-looking empty result for a seed
+    // object that just hasn't committed yet — the flag lets `target.search`
+    // tell the frontend to retry instead of freezing on that stale answer
+    // (issue #818).
     let cache_warming = Arc::new(std::sync::atomic::AtomicBool::new(false));
     {
         let warm_cache = resolve_cache.cache();
         let warm_pool = pool.clone();
-        let cache_warming = cache_warming.clone();
-        cache_warming.store(true, std::sync::atomic::Ordering::Relaxed);
+        let warm_guard =
+            crate::commands::lifecycle::CacheWarmingGuard::start(cache_warming.clone());
         tokio::spawn(async move {
+            let _warm_guard = warm_guard;
             let namespace = simbad_resolver::identity::namespace("astro-plan.targets");
             match targeting_resolver::seed::warm_bundled_on_first_run(&warm_cache, &namespace).await
             {
@@ -1136,7 +1139,6 @@ pub fn run_app(
                 Ok(_) => {}
                 Err(e) => tracing::warn!("failed to warm resolve cache from canonical_target: {e}"),
             }
-            cache_warming.store(false, std::sync::atomic::Ordering::Relaxed);
         });
     }
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1093,14 +1093,26 @@ pub fn run_app(
 
     // spec 052 P1 (D2/T012): warm the shared redb resolve cache from the
     // bundled seed + existing durable canonical_target rows, in the
-    // background — each cache entry is its own fsync'd write transaction, so
-    // warming the full ~14k-object popular seed synchronously would freeze
-    // startup for many seconds. First-run-guarded (`warm_bundled_on_first_run`
-    // no-ops once already warmed); failure degrades to seed+cache typeahead
-    // simply being emptier until the next launch, never blocks the UI.
+    // background — each phase is one `Cache::upsert_batch` write transaction
+    // (spec 052 P4/#695), so warming the full ~13k-object popular seed
+    // synchronously would still freeze startup for a noticeable moment.
+    // First-run-guarded (`warm_bundled_on_first_run` no-ops once already
+    // warmed); failure degrades to seed+cache typeahead simply being emptier
+    // until the next launch, never blocks the UI.
+    //
+    // `cache_warming` (shared with the managed `AppState` below) is set true
+    // for the duration: batching a whole phase into one transaction means no
+    // row is visible to a reader until that phase commits, so a `target.search`
+    // query landing in this window can get a legitimate-looking empty result
+    // for a seed object that just hasn't committed yet — the flag lets
+    // `target.search` tell the frontend to retry instead of freezing on that
+    // stale answer (issue #818).
+    let cache_warming = Arc::new(std::sync::atomic::AtomicBool::new(false));
     {
         let warm_cache = resolve_cache.cache();
         let warm_pool = pool.clone();
+        let cache_warming = cache_warming.clone();
+        cache_warming.store(true, std::sync::atomic::Ordering::Relaxed);
         tokio::spawn(async move {
             let namespace = simbad_resolver::identity::namespace("astro-plan.targets");
             match targeting_resolver::seed::warm_bundled_on_first_run(&warm_cache, &namespace).await
@@ -1124,6 +1136,7 @@ pub fn run_app(
                 Ok(_) => {}
                 Err(e) => tracing::warn!("failed to warm resolve cache from canonical_target: {e}"),
             }
+            cache_warming.store(false, std::sync::atomic::Ordering::Relaxed);
         });
     }
 
@@ -1148,7 +1161,7 @@ pub fn run_app(
     app.manage(pool.clone());
 
     let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
-    let state = AppState::new(repo, bus, resolve_cache, resolve_cache_path);
+    let state = AppState::new(repo, bus, resolve_cache, resolve_cache_path, cache_warming);
 
     app.manage(state);
 

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -213,6 +213,23 @@ mod tests {
         assert!(warmed, "background re-warm never populated the fresh cache");
     }
 
+    /// Bounded-poll deadline for [`poll_until`]/[`poll_until_non_empty`]
+    /// against a REAL, file-backed warm (`test_state` opens a real temp-dir
+    /// redb file, not an in-memory store) — the full bundled seed, chunked
+    /// into ~14 `Cache::upsert_batch` write transactions (#818 follow-up),
+    /// each a real fsync. A tighter (10s) deadline here was previously
+    /// observed to fail ONLY on Windows CI (macOS/Linux always passed):
+    /// Windows fsync is well documented as markedly slower than Linux/macOS,
+    /// especially on a virtualized CI runner, so a real (not stuck) warm can
+    /// legitimately still be running past 10s there. This is generous enough
+    /// to absorb that without masking an actual stuck task (a genuinely
+    /// hung/panicked warm still fails the assertion, just after a longer
+    /// wait) — reasoned through the `CacheWarmingGuard` Drop path (an
+    /// unconditional store, no early-return/`?` to skip — see its doc
+    /// comment) and tokio's task scheduling (both platform-independent), so
+    /// a real leak would misbehave identically on every OS, not Windows-only.
+    const WARM_SETTLE_DEADLINE: Duration = Duration::from_mins(1);
+
     /// Regression test for #818: `cache_warming` must be observably `true`
     /// while the background re-warm is running and `false` once it settles,
     /// so `target.search` can tell a still-warming empty result apart from a
@@ -245,7 +262,7 @@ mod tests {
     /// Polls (bounded) rather than sleeping a fixed duration — avoids both
     /// flakiness on a slow CI runner and a needlessly slow test on a fast one.
     async fn poll_until(mut done: impl FnMut() -> bool) -> bool {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let deadline = tokio::time::Instant::now() + WARM_SETTLE_DEADLINE;
         loop {
             if done() {
                 return true;
@@ -260,7 +277,7 @@ mod tests {
     /// Polls (bounded) rather than sleeping a fixed duration — avoids both
     /// flakiness on a slow CI runner and a needlessly slow test on a fast one.
     async fn poll_until_non_empty(cache: &targeting_resolver::simbad::ResolveCache) -> bool {
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let deadline = tokio::time::Instant::now() + WARM_SETTLE_DEADLINE;
         loop {
             if !cache.cache().list().await.expect("cache list failed").is_empty() {
                 return true;

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -211,6 +211,50 @@ mod tests {
         assert!(warmed, "background re-warm never populated the fresh cache");
     }
 
+    /// Regression test for #818: `cache_warming` must be observably `true`
+    /// while the background re-warm is running and `false` once it settles,
+    /// so `target.search` can tell a still-warming empty result apart from a
+    /// genuine miss (batching the warm into one write transaction per phase
+    /// removed the old per-entry incremental visibility that used to mask a
+    /// query racing this window).
+    #[tokio::test]
+    async fn cache_warming_flag_is_true_during_the_warm_and_false_after() {
+        use std::sync::atomic::Ordering;
+
+        let (state, _dir) = test_state().await;
+        assert!(
+            !state.cache_warming.load(Ordering::Relaxed),
+            "flag must start false — no warm has been scheduled yet"
+        );
+
+        clear_and_rewarm(&state).await.expect("clear_and_rewarm failed");
+        // `clear_and_rewarm` sets the flag before spawning and returns before
+        // the swap task even runs (regression-tested above), so it must
+        // already read true right after the call returns.
+        assert!(
+            state.cache_warming.load(Ordering::Relaxed),
+            "flag must be true immediately after clear_and_rewarm schedules the warm"
+        );
+
+        let settled = poll_until(|| !state.cache_warming.load(Ordering::Relaxed)).await;
+        assert!(settled, "flag never flipped back to false once the warm finished");
+    }
+
+    /// Polls (bounded) rather than sleeping a fixed duration — avoids both
+    /// flakiness on a slow CI runner and a needlessly slow test on a fast one.
+    async fn poll_until(mut done: impl FnMut() -> bool) -> bool {
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        loop {
+            if done() {
+                return true;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                return false;
+            }
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+    }
+
     /// Polls (bounded) rather than sleeping a fixed duration — avoids both
     /// flakiness on a slow CI runner and a needlessly slow test on a fast one.
     async fn poll_until_non_empty(cache: &targeting_resolver::simbad::ResolveCache) -> bool {

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -16,28 +16,35 @@
 //! Windows (sharing violation), surfaced as an error rather than silently
 //! leaving a stale cache in place.
 //!
-//! The re-warm (bundled seed + durable `canonical_target` rows, batched into
-//! one `Cache::upsert_batch` write transaction per phase since spec 052
-//! P4/#695) runs as a **background task** spawned right after the swap,
-//! mirroring the startup warm in `lib.rs` (issue #695: awaiting it inline
-//! froze the `target.cache.clear` IPC call — and, because the write lock
-//! used to stay held for the whole warm, every other resolve cache reader
-//! too — for minutes on a debug build). The background task never takes
+//! The re-warm (bundled seed + durable `canonical_target` rows, chunked into
+//! ~1000-entry `Cache::upsert_batch` write transactions per phase since spec
+//! 052 P4/#695 + #818 follow-up, `Eventual`-durability since #818's second
+//! follow-up — see [`targeting_resolver::simbad::ResolveCache::open`]) runs
+//! as a **background task** spawned right after the swap, mirroring the
+//! startup warm in `lib.rs` (issue #695: awaiting it inline froze the
+//! `target.cache.clear` IPC call — and, because the write lock used to stay
+//! held for the whole warm, every other resolve cache reader too — for
+//! minutes on a debug build). The background task never takes
 //! `AppState::resolve_cache`'s lock; it is handed the fresh cache's own
 //! handle (cloned out before the swap, so it keeps warming the same
 //! underlying store regardless of what `AppState::resolve_cache` is swapped
-//! to next).
+//! to next), plus a second clone of the whole [`ResolveCache`] (not just its
+//! erased `.cache()`) to call [`ResolveCache::flush`] on once both phases
+//! finish — the one fsync that persists every `Eventual` chunk.
 //!
-//! Batching each phase's warm into one transaction means nothing is visible
-//! to a reader until that whole phase commits (no more per-entry partial
-//! visibility) — a `target.search` query racing this window can get a
-//! legitimate-looking empty result for an object the seed does contain
-//! simply because it hasn't committed yet (issue #818). A
+//! Chunking each phase's warm means nothing in a given chunk is visible to a
+//! reader until THAT chunk's transaction commits (no more per-entry partial
+//! visibility, but no more one-giant-atomic-transaction either) — a
+//! `target.search` query racing this window can get a legitimate-looking
+//! empty result for an object the seed does contain simply because its
+//! chunk hasn't committed yet (issue #818). A
 //! [`crate::commands::lifecycle::CacheWarmingGuard`] set true before this
 //! spawn and moved into the task (so a panic mid-warm still clears it) makes
 //! `AppState::cache_warming` true for the spawn's whole duration, so
 //! `target.search` can surface that in-flight state and the frontend can
 //! retry instead of freezing on a stale empty result.
+//!
+//! [`ResolveCache`]: targeting_resolver::simbad::ResolveCache
 
 use contracts_core::ContractError;
 
@@ -112,6 +119,7 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
     // one; the stale task keeps writing into the now-unlinked file (wasted,
     // harmless) or — on Windows — the delete surfaces its own sharing-
     // violation error rather than corrupting anything.
+    let warm_handle = fresh.clone();
     let warm_cache = fresh.cache();
     let warm_pool = state.repo.pool().clone();
     *guard = fresh;
@@ -152,6 +160,12 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
             Err(e) => tracing::warn!(
                 "failed to re-warm resolve cache from canonical_target after cache clear: {e}"
             ),
+        }
+        // #818 follow-up: persists every `Eventual` chunk from both phases
+        // above in one fsync (redb commits are cumulative) — see the
+        // matching comment in `lib.rs`'s startup warm.
+        if let Err(e) = warm_handle.flush().await {
+            tracing::warn!("failed to flush resolve cache after cache-clear re-warm: {e}");
         }
     });
 

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -32,10 +32,12 @@
 //! to a reader until that whole phase commits (no more per-entry partial
 //! visibility) — a `target.search` query racing this window can get a
 //! legitimate-looking empty result for an object the seed does contain
-//! simply because it hasn't committed yet (issue #818). `AppState::
-//! cache_warming` is set true before this spawn and false once both phases
-//! finish so `target.search` can surface that in-flight state and the
-//! frontend can retry instead of freezing on a stale empty result.
+//! simply because it hasn't committed yet (issue #818). A
+//! [`crate::commands::lifecycle::CacheWarmingGuard`] set true before this
+//! spawn and moved into the task (so a panic mid-warm still clears it) makes
+//! `AppState::cache_warming` true for the spawn's whole duration, so
+//! `target.search` can surface that in-flight state and the frontend can
+//! retry instead of freezing on a stale empty result.
 
 use contracts_core::ContractError;
 
@@ -117,12 +119,13 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
 
     // #818: flip on before spawning so a `target.search` racing this warm
     // sees `cache_warming = true` and knows to retry rather than treat an
-    // empty result as settled. Flipped off unconditionally once the warm
-    // attempt (both phases, success or failure) is over.
-    let cache_warming = state.cache_warming.clone();
-    cache_warming.store(true, std::sync::atomic::Ordering::Relaxed);
+    // empty result as settled. `CacheWarmingGuard` (not a bare sequential
+    // store) so a panic mid-warm still clears it — see its doc comment.
+    let warm_guard =
+        crate::commands::lifecycle::CacheWarmingGuard::start(state.cache_warming.clone());
 
     tokio::spawn(async move {
+        let _warm_guard = warm_guard;
         let namespace = simbad_resolver::identity::namespace(NAMESPACE_SEED);
         match targeting_resolver::seed::warm_bundled_on_first_run(&warm_cache, &namespace).await {
             Ok(Some(count)) => {
@@ -150,7 +153,6 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
                 "failed to re-warm resolve cache from canonical_target after cache clear: {e}"
             ),
         }
-        cache_warming.store(false, std::sync::atomic::Ordering::Relaxed);
     });
 
     Ok(())

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -16,16 +16,26 @@
 //! Windows (sharing violation), surfaced as an error rather than silently
 //! leaving a stale cache in place.
 //!
-//! The re-warm (bundled seed + durable `canonical_target` rows — up to ~14k
-//! individually fsync'd redb writes) runs as a **background task** spawned
-//! right after the swap, mirroring the startup warm in `lib.rs` (issue #695:
-//! awaiting it inline froze the `target.cache.clear` IPC call — and, because
-//! the write lock used to stay held for the whole warm, every other resolve
-//! cache reader too — for minutes on a debug build). The background task
-//! never takes `AppState::resolve_cache`'s lock; it is handed the fresh
-//! cache's own handle (cloned out before the swap, so it keeps warming the
-//! same underlying store regardless of what `AppState::resolve_cache` is
-//! swapped to next).
+//! The re-warm (bundled seed + durable `canonical_target` rows, batched into
+//! one `Cache::upsert_batch` write transaction per phase since spec 052
+//! P4/#695) runs as a **background task** spawned right after the swap,
+//! mirroring the startup warm in `lib.rs` (issue #695: awaiting it inline
+//! froze the `target.cache.clear` IPC call — and, because the write lock
+//! used to stay held for the whole warm, every other resolve cache reader
+//! too — for minutes on a debug build). The background task never takes
+//! `AppState::resolve_cache`'s lock; it is handed the fresh cache's own
+//! handle (cloned out before the swap, so it keeps warming the same
+//! underlying store regardless of what `AppState::resolve_cache` is swapped
+//! to next).
+//!
+//! Batching each phase's warm into one transaction means nothing is visible
+//! to a reader until that whole phase commits (no more per-entry partial
+//! visibility) — a `target.search` query racing this window can get a
+//! legitimate-looking empty result for an object the seed does contain
+//! simply because it hasn't committed yet (issue #818). `AppState::
+//! cache_warming` is set true before this spawn and false once both phases
+//! finish so `target.search` can surface that in-flight state and the
+//! frontend can retry instead of freezing on a stale empty result.
 
 use contracts_core::ContractError;
 
@@ -105,6 +115,13 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
     *guard = fresh;
     drop(guard);
 
+    // #818: flip on before spawning so a `target.search` racing this warm
+    // sees `cache_warming = true` and knows to retry rather than treat an
+    // empty result as settled. Flipped off unconditionally once the warm
+    // attempt (both phases, success or failure) is over.
+    let cache_warming = state.cache_warming.clone();
+    cache_warming.store(true, std::sync::atomic::Ordering::Relaxed);
+
     tokio::spawn(async move {
         let namespace = simbad_resolver::identity::namespace(NAMESPACE_SEED);
         match targeting_resolver::seed::warm_bundled_on_first_run(&warm_cache, &namespace).await {
@@ -133,6 +150,7 @@ pub async fn clear_and_rewarm(state: &AppState) -> Result<(), ContractError> {
                 "failed to re-warm resolve cache from canonical_target after cache clear: {e}"
             ),
         }
+        cache_warming.store(false, std::sync::atomic::Ordering::Relaxed);
     });
 
     Ok(())
@@ -160,7 +178,8 @@ mod tests {
         let dir = tempfile::tempdir().expect("tempdir");
         let cache_path = dir.path().join("resolve-cache.redb");
         let cache = open_or_in_memory(&cache_path);
-        (AppState::new(repo, bus, cache, cache_path), dir)
+        let cache_warming = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        (AppState::new(repo, bus, cache, cache_path, cache_warming), dir)
     }
 
     /// Regression test for #695: `clear_and_rewarm` must return as soon as

--- a/apps/desktop/src-tauri/tests/commands.rs
+++ b/apps/desktop/src-tauri/tests/commands.rs
@@ -48,12 +48,18 @@ use desktop_shell::commands::tour::tour_complete_step;
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
-/// An ephemeral resolve cache + a throwaway path for `AppState::new` in
-/// tests — nothing here ever gets promoted, so an in-memory cache is fine.
-fn test_resolve_cache() -> (targeting_resolver::simbad::ResolveCache, std::path::PathBuf) {
+/// An ephemeral resolve cache, a throwaway path, and a fresh (never-warming)
+/// flag for `AppState::new` in tests — nothing here ever gets promoted, so an
+/// in-memory cache is fine.
+fn test_resolve_cache() -> (
+    targeting_resolver::simbad::ResolveCache,
+    std::path::PathBuf,
+    std::sync::Arc<std::sync::atomic::AtomicBool>,
+) {
     (
         targeting_resolver::simbad::ResolveCache::in_memory().expect("in-memory resolve cache"),
         std::path::PathBuf::from("test-resolve-cache.redb"),
+        std::sync::Arc::new(std::sync::atomic::AtomicBool::new(false)),
     )
 }
 
@@ -65,8 +71,8 @@ async fn mock_lifecycle_app() -> tauri::App<tauri::test::MockRuntime> {
     let pool = db.pool().clone();
     let bus = EventBus::with_pool(pool.clone());
     let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
-    let (resolve_cache, resolve_cache_path) = test_resolve_cache();
-    let state = AppState::new(repo, bus, resolve_cache, resolve_cache_path);
+    let (resolve_cache, resolve_cache_path, cache_warming) = test_resolve_cache();
+    let state = AppState::new(repo, bus, resolve_cache, resolve_cache_path, cache_warming);
 
     let app = tauri::test::mock_builder()
         .invoke_handler(tauri::generate_handler![
@@ -187,8 +193,8 @@ async fn make_projects_state() -> AppState {
     let pool = db.pool().clone();
     let bus = EventBus::with_pool(pool.clone());
     let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
-    let (resolve_cache, resolve_cache_path) = test_resolve_cache();
-    AppState::new(repo, bus, resolve_cache, resolve_cache_path)
+    let (resolve_cache, resolve_cache_path, cache_warming) = test_resolve_cache();
+    AppState::new(repo, bus, resolve_cache, resolve_cache_path, cache_warming)
 }
 
 #[tokio::test]
@@ -253,8 +259,8 @@ async fn make_plans_state() -> AppState {
     let pool = db.pool().clone();
     let bus = EventBus::with_pool(pool.clone());
     let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
-    let (resolve_cache, resolve_cache_path) = test_resolve_cache();
-    AppState::new(repo, bus, resolve_cache, resolve_cache_path)
+    let (resolve_cache, resolve_cache_path, cache_warming) = test_resolve_cache();
+    AppState::new(repo, bus, resolve_cache, resolve_cache_path, cache_warming)
 }
 
 #[tokio::test]
@@ -867,8 +873,8 @@ async fn lifecycle_transition_apply() {
     let pool = db.pool().clone();
     let bus = EventBus::with_pool(pool.clone());
     let repo = Arc::new(SqliteLifecycleRepository::new(pool, bus.clone()));
-    let (resolve_cache, resolve_cache_path) = test_resolve_cache();
-    let state = AppState::new(repo, bus, resolve_cache, resolve_cache_path);
+    let (resolve_cache, resolve_cache_path, cache_warming) = test_resolve_cache();
+    let state = AppState::new(repo, bus, resolve_cache, resolve_cache_path, cache_warming);
 
     let request = TransitionRequest::Project(ProjectTransitionRequest::new(
         uuid::Uuid::new_v4(),

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -881,6 +881,8 @@ export async function mockInvoke(
         contractVersion: '1.0',
         requestId: crypto.randomUUID(),
         suggestions,
+        // Mock mode never warms a real resolve cache — always settled.
+        cacheWarming: false,
       } satisfies TargetSearchResponse_Serialize;
     }
     case 'target_resolve': {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -8564,6 +8564,18 @@ export type TargetSearchResponse_Deserialize = {
 	contractVersion: string,
 	requestId: string,
 	suggestions: TargetSuggestion_Deserialize[],
+	/**
+	 *  Whether the shared resolve cache is still running its background
+	 *  seed/durable-row re-warm (startup, or after `target.cache.clear`) —
+	 *  issue #818: a query that lands mid-warm can get a legitimate-looking
+	 *  empty result for an object the seed does contain, simply because it
+	 *  hasn't committed yet. `true` tells the caller a retry may still find
+	 *  it; `false` means whatever `suggestions` holds is the settled answer.
+	 *  Always `false` from this pure use case directly (its own unit tests
+	 *  exercise no `AppState`) — the `target.search` Tauri command sets the
+	 *  real value from the live warm flag after calling `search`.
+	 */
+	cacheWarming?: boolean,
 };
 
 /**
@@ -8576,6 +8588,18 @@ export type TargetSearchResponse_Serialize = {
 	contractVersion: string,
 	requestId: string,
 	suggestions: TargetSuggestion_Serialize[],
+	/**
+	 *  Whether the shared resolve cache is still running its background
+	 *  seed/durable-row re-warm (startup, or after `target.cache.clear`) —
+	 *  issue #818: a query that lands mid-warm can get a legitimate-looking
+	 *  empty result for an object the seed does contain, simply because it
+	 *  hasn't committed yet. `true` tells the caller a retry may still find
+	 *  it; `false` means whatever `suggestions` holds is the settled answer.
+	 *  Always `false` from this pure use case directly (its own unit tests
+	 *  exercise no `AppState`) — the `target.search` Tauri command sets the
+	 *  real value from the live warm flag after calling `search`.
+	 */
+	cacheWarming: boolean,
 };
 
 /**

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
@@ -188,6 +188,107 @@ describe('TargetSearch', () => {
     );
   });
 
+  // ── #818: retry a Phase-1 miss while the backend reports a cache warm ──────
+
+  it('retries the local search while the backend reports the resolve cache still warming', async () => {
+    let call = 0;
+    mockSearchTargets.mockImplementation(() => {
+      call += 1;
+      // First answer lands mid-warm: legitimately empty, warm still running.
+      if (call === 1) {
+        return {
+          contractVersion: '1.0',
+          requestId: 'r',
+          suggestions: [],
+          cacheWarming: true,
+        };
+      }
+      // The warm has since committed: the object is there after all.
+      return {
+        contractVersion: '1.0',
+        requestId: 'r',
+        suggestions: [M31],
+        cacheWarming: false,
+      };
+    });
+
+    render(<TargetSearch onSelect={vi.fn()} />);
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'm31' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300); // debounce
+      await Promise.resolve();
+    });
+
+    expect(mockSearchTargets).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole('option')).toBeNull();
+
+    // The retry interval (250ms, mirroring WARM_RETRY_INTERVAL_MS).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(250);
+    });
+
+    expect(mockSearchTargets).toHaveBeenCalledTimes(2);
+    expect(screen.getByRole('option')).toHaveTextContent('M 31');
+  });
+
+  it('never retries an ordinary (non-warming) miss', async () => {
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [],
+      cacheWarming: false,
+    });
+
+    render(<TargetSearch onSelect={vi.fn()} />);
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'zzz' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    // Advancing well past one retry interval must not trigger a second call:
+    // a settled empty answer is final, not a warm to wait out.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+
+    expect(mockSearchTargets).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up retrying once the warm-retry budget elapses, keeping the empty result', async () => {
+    mockSearchTargets.mockResolvedValue({
+      contractVersion: '1.0',
+      requestId: 'r',
+      suggestions: [],
+      cacheWarming: true, // never settles within this test
+    });
+
+    render(<TargetSearch onSelect={vi.fn()} />);
+    fireEvent.change(screen.getByRole('combobox'), {
+      target: { value: 'm31' },
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+      await Promise.resolve();
+    });
+    // Advance past the retry budget (5000ms, mirroring WARM_RETRY_BUDGET_MS).
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(5200);
+    });
+
+    expect(screen.queryByRole('option')).toBeNull();
+    // Bounded: the retry loop must stop polling once the budget is spent,
+    // not keep firing target.search forever.
+    const callsAtBudget = mockSearchTargets.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1000);
+    });
+    expect(mockSearchTargets).toHaveBeenCalledTimes(callsAtBudget);
+  });
+
   it('renders designation, common name, and type/source badges', async () => {
     mockSearchTargets.mockResolvedValue({
       contractVersion: '1.0',

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.test.tsx
@@ -274,9 +274,9 @@ describe('TargetSearch', () => {
       vi.advanceTimersByTime(300);
       await Promise.resolve();
     });
-    // Advance past the retry budget (5000ms, mirroring WARM_RETRY_BUDGET_MS).
+    // Advance past the retry budget (30000ms, mirroring WARM_RETRY_BUDGET_MS).
     await act(async () => {
-      await vi.advanceTimersByTimeAsync(5200);
+      await vi.advanceTimersByTimeAsync(30_200);
     });
 
     expect(screen.queryByRole('option')).toBeNull();

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
@@ -107,16 +107,20 @@ const OPTION_ESTIMATE = 44;
 /**
  * Bounds for the empty-result-while-warming retry (#818): `target.search`
  * reports `cacheWarming = true` while the shared resolve cache's background
- * seed/durable-row re-warm is still running (batched into one write
- * transaction per phase since spec 052 P4 — nothing is visible to a reader
- * until that whole phase commits). A query that lands in this window and
- * comes back empty is retried on this interval until either a suggestion
- * appears, the backend reports the warm has settled (`cacheWarming` flips to
- * `false`), or this budget runs out — never on an ordinary (non-warming)
- * miss, so the common case pays no extra latency.
+ * seed/durable-row re-warm is still running (one write transaction per
+ * ~1000-entry chunk since the #818 follow-up — nothing in a given chunk is
+ * visible to a reader until THAT chunk's transaction commits, so a query for
+ * an object in a not-yet-committed chunk can still legitimately come back
+ * empty). A query that lands in this window and comes back empty is retried
+ * on this interval for as long as the backend keeps reporting
+ * `cacheWarming = true` — never on an ordinary (settled) miss, so the common
+ * case pays no extra latency. `WARM_RETRY_BUDGET_MS` is a safety cap, not
+ * the expected wait: it only bites if the backend's own flag never flips
+ * back to `false` (e.g. a stuck/crashed warm task), well past the seconds a
+ * real warm takes even on a slow disk.
  */
 const WARM_RETRY_INTERVAL_MS = 250;
-const WARM_RETRY_BUDGET_MS = 5000;
+const WARM_RETRY_BUDGET_MS = 30_000;
 
 function sleep(ms: number): Promise<void> {
   return new Promise((resolve) => setTimeout(resolve, ms));

--- a/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
+++ b/apps/desktop/src/components/TargetSearch/TargetSearch.tsx
@@ -35,6 +35,17 @@
  * the current query's results. (Tauri `invoke` exposes no AbortSignal, so this
  * generation guard is the cancel mechanism — no AbortController is involved.)
  *
+ * Empty-while-warming retry (spec 052 P4/#818): the shared resolve cache's
+ * background seed/durable-row re-warm (startup, or after a cache clear) is
+ * one write transaction per phase, so nothing in it is visible to a reader
+ * until that whole phase commits. A Phase-1 query landing in that window can
+ * come back with zero suggestions for an object the seed does contain,
+ * simply because it hasn't committed yet — `target.search`'s `cacheWarming`
+ * flag says so, and Phase 1 retries on a short interval (bounded budget)
+ * until either a suggestion appears or the backend reports the warm has
+ * settled. An ordinary (non-warming) miss never enters this loop, so it pays
+ * no extra latency.
+ *
  * Selecting a suggestion (mouse or keyboard) invokes `onSelect(suggestion)`,
  * exposing the canonical `targetId` so the caller can associate it.
  *
@@ -93,6 +104,23 @@ const DEFAULT_LIMIT = 20;
 const MIN_RESOLVE_LEN = 3;
 /** Estimated suggestion-row height (px) for the virtualizer. */
 const OPTION_ESTIMATE = 44;
+/**
+ * Bounds for the empty-result-while-warming retry (#818): `target.search`
+ * reports `cacheWarming = true` while the shared resolve cache's background
+ * seed/durable-row re-warm is still running (batched into one write
+ * transaction per phase since spec 052 P4 — nothing is visible to a reader
+ * until that whole phase commits). A query that lands in this window and
+ * comes back empty is retried on this interval until either a suggestion
+ * appears, the backend reports the warm has settled (`cacheWarming` flips to
+ * `false`), or this budget runs out — never on an ordinary (non-warming)
+ * miss, so the common case pays no extra latency.
+ */
+const WARM_RETRY_INTERVAL_MS = 250;
+const WARM_RETRY_BUDGET_MS = 5000;
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
 
 // ── Props ────────────────────────────────────────────────────────────────────
 
@@ -271,16 +299,34 @@ export function TargetSearch({
 
       // ── Phase 1: local seed + cache (instant) ──────────────────────────────
       try {
-        const res = unwrap(
-          await commands.targetSearch({
-            contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
-            requestId: crypto.randomUUID(),
-            query: trimmed,
-            catalogFilter: effectiveCatalogFilter,
-            typeFilter: effectiveTypeFilter,
-            limit,
-          }),
-        );
+        const doSearch = async () =>
+          unwrap(
+            await commands.targetSearch({
+              contractVersion: TARGET_SEARCH_CONTRACT_VERSION,
+              requestId: crypto.randomUUID(),
+              query: trimmed,
+              catalogFilter: effectiveCatalogFilter,
+              typeFilter: effectiveTypeFilter,
+              limit,
+            }),
+          );
+        let res = await doSearch();
+        // #818: an empty result while the backend is still warming the
+        // shared resolve cache isn't necessarily the settled answer — retry
+        // until a suggestion shows up, the backend reports the warm has
+        // finished, or the budget runs out. A no-warm miss (the overwhelming
+        // common case) never enters this loop.
+        const retryDeadline = Date.now() + WARM_RETRY_BUDGET_MS;
+        while (
+          isCurrent() &&
+          res.cacheWarming &&
+          res.suggestions.length === 0 &&
+          Date.now() < retryDeadline
+        ) {
+          await sleep(WARM_RETRY_INTERVAL_MS);
+          if (!isCurrent()) return;
+          res = await doSearch();
+        }
         if (!isCurrent()) return; // superseded — drop stale result
         setSuggestions(res.suggestions);
       } catch {

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -31,7 +31,7 @@ workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
 # spec 052 P1: project_create::create threads the shared redb resolve cache
 # through to app_core_projects::project_setup::create for in-use promotion.
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 # In-memory caching layer (F0 foundation).
 app_core_cache = { path = "../cache" }
 camino = { workspace = true }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -36,7 +36,7 @@ target-match = "0.3"
 # own `ResolvedIdentity` (otype_raw/common_name/aliases, OQ-1/OQ-2 ranking
 # inputs) and `PositionResolver` types directly — mirrors the existing
 # `app_core_targets` precedent (see that crate's Cargo.toml comment).
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -23,7 +23,7 @@ fs_inventory = { path = "../../fs/inventory" }
 patterns = { path = "../../patterns" }
 persistence_db = { path = "../../persistence/db" }
 project_structure = { path = "../../project/structure" }
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 workflow_profiles = { path = "../../workflow/profiles" }
 serde_json.workspace = true
 sqlx.workspace = true

--- a/crates/app/targets/Cargo.toml
+++ b/crates/app/targets/Cargo.toml
@@ -23,7 +23,7 @@ targeting_resolver = { path = "../../targeting/resolver" }
 # spec 052 P1: `target.search` reads the shared redb resolve cache directly
 # (`simbad_resolver::Cache`), and in-use promotion touches the crate's own
 # `ResolvedIdentity`/`Cache` types at the app-layer commit points.
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 serde_json.workspace = true
 sqlx.workspace = true
 time = { workspace = true }

--- a/crates/app/targets/src/target_search.rs
+++ b/crates/app/targets/src/target_search.rs
@@ -151,6 +151,10 @@ pub async fn search(
         contract_version: req.contract_version.clone(),
         request_id: req.request_id.clone(),
         suggestions,
+        // Always false here — this pure use case takes no `AppState`, so it
+        // cannot know about a live warm. The `target.search` Tauri command
+        // wrapper overwrites this from the real flag (#818).
+        cache_warming: false,
     })
 }
 

--- a/crates/app/targets/src/target_search.rs
+++ b/crates/app/targets/src/target_search.rs
@@ -245,6 +245,39 @@ mod tests {
         assert!(!s.target_id.is_empty());
     }
 
+    /// #818 follow-up: the warm-complete sentinel (`simbad_oid = -1`, the
+    /// crate has no metadata table separate from this same cache) must never
+    /// surface as a typeahead suggestion, even for a query that would
+    /// otherwise match it (a substring of its designation/alias).
+    #[tokio::test]
+    async fn search_excludes_the_warm_complete_sentinel() {
+        let store = Store::in_memory().unwrap();
+        let cache = store.cache();
+        let sentinel = CrateResolvedIdentity {
+            simbad_oid: Some(-1),
+            primary_designation: "ALM SEED WARM SENTINEL".to_owned(),
+            common_name: Some("2026-07-14T00:00:00Z".to_owned()),
+            object_type: CrateObjectType::Other,
+            otype_raw: String::new(),
+            ra_deg: 0.0,
+            dec_deg: 0.0,
+            v_mag: None,
+            aliases: vec![CrateResolvedAlias::new(
+                "ALM SEED WARM SENTINEL",
+                CrateAliasKind::Designation,
+            )],
+            source: CrateTargetSource::Seed,
+        };
+        cache.upsert(&sentinel, &ns()).await.unwrap();
+
+        let resp = search(&cache, &req("SENTINEL")).await.unwrap();
+        assert!(
+            resp.suggestions.is_empty(),
+            "the warm-complete sentinel must never surface as a typeahead suggestion, got {:?}",
+            resp.suggestions
+        );
+    }
+
     #[tokio::test]
     async fn search_prefix_returns_ranked_local_matches() {
         let cache = seeded_cache().await;

--- a/crates/app/targets/src/target_search.rs
+++ b/crates/app/targets/src/target_search.rs
@@ -141,6 +141,9 @@ pub async fn search(
     let suggestions: Vec<TargetSuggestion> = hits
         .into_iter()
         .map(targeting_resolver::simbad::from_crate_search_hit)
+        // The warm-complete sentinel (#818 follow-up) lives in this same
+        // cache — it must never surface as a typeahead suggestion.
+        .filter(|hit| !targeting_resolver::seed::is_warm_sentinel(hit.target.simbad_oid))
         .filter(|hit| matches_catalog_filter(&hit.target, catalog_filter))
         .map(hit_to_suggestion)
         .filter(|s| type_filter.is_empty() || type_filter.contains(&s.object_type))

--- a/crates/contracts/core/src/targets.rs
+++ b/crates/contracts/core/src/targets.rs
@@ -505,6 +505,17 @@ pub struct TargetSearchResponse {
     pub contract_version: String,
     pub request_id: String,
     pub suggestions: Vec<TargetSuggestion>,
+    /// Whether the shared resolve cache is still running its background
+    /// seed/durable-row re-warm (startup, or after `target.cache.clear`) —
+    /// issue #818: a query that lands mid-warm can get a legitimate-looking
+    /// empty result for an object the seed does contain, simply because it
+    /// hasn't committed yet. `true` tells the caller a retry may still find
+    /// it; `false` means whatever `suggestions` holds is the settled answer.
+    /// Always `false` from this pure use case directly (its own unit tests
+    /// exercise no `AppState`) — the `target.search` Tauri command sets the
+    /// real value from the live warm flag after calling `search`.
+    #[serde(default)]
+    pub cache_warming: bool,
 }
 
 // ── target.resolve ────────────────────────────────────────────────────────────

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -28,7 +28,7 @@ use std::time::Duration;
 use anyhow::Context;
 use common::E2eApp;
 use serde_json::json;
-use thirtyfour::By;
+use thirtyfour::{By, WebElement};
 
 const UI_TIMEOUT: Duration = Duration::from_secs(20);
 
@@ -355,7 +355,17 @@ async fn add_target_via_ui(app: &E2eApp, query: &str) -> anyhow::Result<String> 
     let popup =
         app.find_waiting(By::Css(".alm-add-target__popup"), "the Add-target dialog popup").await?;
     let input = popup.find(By::Css(".alm-target-search__input")).await?;
-    input.send_keys(query).await?;
+
+    // #841 (dialog focus race, product fix filed + out of this branch's
+    // scope): a keystroke can land on the modal's own close (X) button
+    // instead of the search input if the dialog's mount/focus sequencing
+    // hasn't settled by the moment we type. Wait for the REAL
+    // `document.activeElement` to actually BE this input, then verify the
+    // input's live `.value` DOM property (via JS — not `outerHTML`/the
+    // `value` ATTRIBUTE, which can lag a React-controlled input's live
+    // state) holds what we just typed; retry the whole focus-wait + type
+    // once if either check fails, rather than bailing on the first race.
+    type_into_search_input(app, &input, query).await?;
 
     // Poll for a real suggestion option to render (offline seed search).
     //
@@ -414,6 +424,64 @@ async fn add_target_via_ui(app: &E2eApp, query: &str) -> anyhow::Result<String> 
         .to_owned();
     anyhow::ensure!(!id.is_empty(), "extracted an empty target id from URL: {url}");
     Ok(id)
+}
+
+/// Wait for `input` to actually hold `document.activeElement` focus, type
+/// `query` into it, then verify the input's live `.value` DOM property
+/// equals `query` — retrying the whole focus-wait + type sequence once if
+/// either check fails (#841: a keystroke can otherwise land on the dialog's
+/// own close button during its mount/focus race, rather than the search
+/// input `add_target_via_ui` just found).
+async fn type_into_search_input(
+    app: &E2eApp,
+    input: &WebElement,
+    query: &str,
+) -> anyhow::Result<()> {
+    const FOCUS_TIMEOUT: Duration = Duration::from_secs(5);
+
+    for attempt in 0..2 {
+        let deadline = tokio::time::Instant::now() + FOCUS_TIMEOUT;
+        loop {
+            let is_focused: bool = app
+                .driver
+                .execute("return arguments[0] === document.activeElement;", vec![input.to_json()?])
+                .await
+                .context("document.activeElement check failed")?
+                .convert()
+                .context("failed to deserialize the document.activeElement check result")?;
+            if is_focused {
+                break;
+            }
+            if tokio::time::Instant::now() >= deadline {
+                anyhow::bail!(
+                    "search input never gained document.activeElement focus within \
+                     {FOCUS_TIMEOUT:?} (attempt {attempt})"
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+
+        input.send_keys(query).await?;
+
+        let live_value: String = app
+            .driver
+            .execute("return arguments[0].value;", vec![input.to_json()?])
+            .await
+            .context("reading the search input's live .value failed")?
+            .convert()
+            .context("failed to deserialize the search input's live .value")?;
+        if live_value == query {
+            return Ok(());
+        }
+        // Landed on the wrong element or got garbled — clear whatever's
+        // there (established pattern: `E2eApp::fill_testid`) and retry once.
+        input.clear().await.ok();
+    }
+
+    anyhow::bail!(
+        "search input's live .value never matched the typed query {query:?} after 2 attempts \
+         (#841 dialog focus race)"
+    );
 }
 
 /// Test 2 (journey-09): adding the same bundled-seed target twice via the

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 target-match = "0.3"
 skymath = "0.3"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 
 [lints]
 workspace = true

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -50,7 +50,7 @@ persistence_db = { path = "../../persistence/db" }
 # Published SIMBAD TAP client + Caldwell map + normalize/fuzzy helpers + the
 # cache-first facade (see crate doc above). Same author/org as this
 # workspace's own CI app.
-simbad-resolver = "0.2.0"
+simbad-resolver = "0.3.0"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
 skymath = "0.3"
@@ -65,7 +65,7 @@ tokio = { workspace = true }
 # drop-and-rebuild pointed at the same redb file — astro-plan's production
 # `simbad::SimbadResolver` wrapper only ever builds a real `TapResolver`, so
 # this test constructs the crate's facade directly.
-simbad-resolver = { version = "0.2.0", features = ["test-util"] }
+simbad-resolver = { version = "0.3.0", features = ["test-util"] }
 tempfile = { workspace = true }
 
 [features]

--- a/crates/targeting/resolver/src/seed.rs
+++ b/crates/targeting/resolver/src/seed.rs
@@ -216,14 +216,51 @@ pub async fn is_first_run(cache: &dyn Cache) -> Result<bool, SeedError> {
     Ok(cache.list().await?.is_empty())
 }
 
+/// Chunk size for [`chunked_upsert_batch`] (spec 052 P4/#818 follow-up): one
+/// write transaction for the WHOLE seed leaves nothing visible to a reader
+/// until it all commits, so a `target.search` query racing a multi-second
+/// warm can miss an object the seed does contain simply because its part of
+/// the batch hasn't committed yet. Chunking restores incremental
+/// visibility — each chunk's rows become searchable the moment ITS
+/// transaction commits — while keeping nearly all of batching's fsync
+/// savings (~13 write transactions for the full ~13k-object bundled seed,
+/// instead of 1 atomic transaction or ~13k per-entry ones pre-#695).
+const WARM_CHUNK_SIZE: usize = 1000;
+
+/// Upsert `identities` in [`WARM_CHUNK_SIZE`]-sized slices, one
+/// [`Cache::upsert_batch`] write transaction per chunk, summing the loaded
+/// count across chunks. Shared by [`warm_cache`] and
+/// [`warm_from_canonical_target`], which both build a full identity list up
+/// front and then need this exact chunk-and-count upsert.
+async fn chunked_upsert_batch(
+    cache: &dyn Cache,
+    identities: &[simbad_resolver::ResolvedIdentity],
+    namespace: &Uuid,
+) -> Result<usize, SeedError> {
+    let mut loaded = 0usize;
+    for chunk in identities.chunks(WARM_CHUNK_SIZE) {
+        let results = cache.upsert_batch(chunk, namespace).await?;
+        loaded += results
+            .iter()
+            .filter(|(_, outcome)| {
+                !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride)
+            })
+            .count();
+    }
+    Ok(loaded)
+}
+
 /// Warm the redb cache from a seed asset, writing rows with `source = seed`.
 ///
-/// Entries are upserted in one call to [`simbad_resolver::Cache::upsert_batch`]
-/// (a single backend write transaction for the whole batch, rather than one
-/// per entry — spec 052 P4/#695), so the warm is idempotent: re-running it
-/// dedups by `simbad_oid` (or the designation-derived id) and never overwrites
-/// a sticky `user-override` row. Returns the number of entries that resulted
-/// in a new or refreshed cache row.
+/// Entries are upserted via [`chunked_upsert_batch`] (one
+/// [`simbad_resolver::Cache::upsert_batch`] write transaction per
+/// [`WARM_CHUNK_SIZE`]-sized chunk, rather than one per entry — spec 052
+/// P4/#695 — or one atomic transaction for the whole seed, which left
+/// nothing visible until it all committed — #818 follow-up), so the warm is
+/// idempotent: re-running it dedups by `simbad_oid` (or the
+/// designation-derived id) and never overwrites a sticky `user-override`
+/// row. Returns the number of entries that resulted in a new or refreshed
+/// cache row.
 ///
 /// `namespace` MUST be the same id-namespace the production facade uses
 /// ([`crate::simbad`]'s `"astro-plan.targets"` seed) so warmed ids match the
@@ -242,14 +279,7 @@ pub async fn warm_cache(
 ) -> Result<usize, SeedError> {
     let identities: Vec<simbad_resolver::ResolvedIdentity> =
         seed.entries.iter().map(SeedEntry::to_crate_identity).collect();
-    let results = cache.upsert_batch(&identities, namespace).await?;
-    let loaded = results
-        .iter()
-        .filter(|(_, outcome)| {
-            !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride)
-        })
-        .count();
-    Ok(loaded)
+    chunked_upsert_batch(cache, &identities, namespace).await
 }
 
 /// Warm the redb cache from the bundled seed **only when the cache is empty**.
@@ -314,14 +344,7 @@ pub async fn warm_from_canonical_target(
             source: to_crate_source(durable.source),
         });
     }
-    let results = cache.upsert_batch(&identities, namespace).await?;
-    let warmed = results
-        .iter()
-        .filter(|(_, outcome)| {
-            !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride)
-        })
-        .count();
-    Ok(warmed)
+    chunked_upsert_batch(cache, &identities, namespace).await
 }
 
 #[cfg(test)]
@@ -517,17 +540,16 @@ mod tests {
 
     /// A real Messier-only slice of the committed bundled asset (~110 objects,
     /// including M 31/M 42) — fast enough for redb-touching tests. [`warm_cache`]
-    /// now goes through [`simbad_resolver::Cache::upsert_batch`] (one fsync'd
-    /// write transaction for the whole batch, since `simbad-resolver` 0.3.0 —
-    /// spec 052 P4/#695) instead of one transaction per entry, but the
-    /// per-entry dedup-by-`simbad_oid` lookup the crate's backend does inside
-    /// that transaction is still an O(n) scan per entry (O(n²) for the whole
-    /// batch), so warming the FULL ~14k-object popular seed is still far too
-    /// slow for `cargo test`/`nextest` (measured: low hundreds of ms at
-    /// n=500, growing to minutes by n=4000) — a Messier-only slice keeps this
-    /// suite fast regardless of the transaction-count change.
-    /// [`bundled_asset_loads_and_covers_messier_and_caldwell`] separately
-    /// proves the full committed asset's shape (pure JSON parse, no redb).
+    /// goes through [`chunked_upsert_batch`] (one [`simbad_resolver::Cache::
+    /// upsert_batch`] write transaction per [`WARM_CHUNK_SIZE`]-sized chunk —
+    /// spec 052 P4/#695, chunked by the #818 follow-up), which on a
+    /// file-backed store measures ~2.4s for the full ~13k-object bundled seed
+    /// (debug build) — fast in absolute terms, but still needless overhead to
+    /// pay on every `cargo test`/`nextest` invocation across every test that
+    /// only needs a handful of real, known objects. A Messier-only slice keeps
+    /// this suite fast regardless. [`bundled_asset_loads_and_covers_messier_and_caldwell`]
+    /// separately proves the full committed asset's shape (pure JSON parse,
+    /// no redb).
     fn messier_only_seed() -> SeedAsset {
         let full = bundled().expect("bundled seed asset must parse");
         let entries: Vec<SeedEntry> =
@@ -557,6 +579,58 @@ mod tests {
         assert!(!cache.list().await.unwrap().is_empty());
         let reloaded = warm_cache(&cache, &seed, &ns()).await.unwrap();
         assert!(reloaded >= 80, "re-warm dedups by oid/id, not by row count delta");
+    }
+
+    /// A synthetic seed of `n` distinct objects (unique `simbad_oid` +
+    /// designation each), for exercising chunk boundaries without depending
+    /// on the committed asset's real size.
+    fn synthetic_seed(n: usize) -> SeedAsset {
+        let entries = (0..n)
+            .map(|i| SeedEntry {
+                simbad_oid: Some(9_000_000 + i64::try_from(i).expect("test seed size fits i64")),
+                primary_designation: format!("SYN {i}"),
+                common_name: None,
+                object_type: ObjectType::Galaxy,
+                ra_deg: f64::from(u32::try_from(i % 360).expect("modulo 360 fits u32")),
+                dec_deg: 0.0,
+                v_mag: None,
+                aliases: vec![SeedAlias {
+                    alias: format!("SYN {i}"),
+                    kind: AliasKind::Designation,
+                }],
+            })
+            .collect();
+        SeedAsset { version: 1, generated_at: String::new(), source: String::new(), entries }
+    }
+
+    /// Regression guard for the #818 follow-up (chunked batching,
+    /// [`WARM_CHUNK_SIZE`]): a seed spanning multiple chunks must warm
+    /// EVERY entry exactly once — no drop, duplicate, or corruption at a
+    /// chunk boundary — proving `chunked_upsert_batch`'s per-chunk loop is
+    /// equivalent to the old single whole-seed `upsert_batch` call for the
+    /// final state, even though visibility now arrives incrementally.
+    #[tokio::test]
+    async fn warm_cache_across_multiple_chunks_loses_nothing() {
+        let store = Store::in_memory().unwrap();
+        let cache = store.cache();
+        let n = WARM_CHUNK_SIZE * 2 + 500; // spans 3 chunks
+        let seed = synthetic_seed(n);
+
+        let loaded = warm_cache(&cache, &seed, &ns()).await.unwrap();
+        assert_eq!(loaded, n, "every synthetic entry must be counted as loaded");
+
+        let rows = cache.list().await.unwrap();
+        assert_eq!(rows.len(), n, "every synthetic entry must be a distinct cache row");
+
+        // First entry (chunk 1), one crossing the chunk-1/chunk-2 boundary,
+        // and the last entry (final chunk) must all be independently queryable.
+        for i in [0, WARM_CHUNK_SIZE - 1, WARM_CHUNK_SIZE, n - 1] {
+            let norm = targeting::normalize::normalize(&format!("SYN {i}"));
+            assert!(
+                cache.get_by_normalized(&norm).await.unwrap().is_some(),
+                "SYN {i} must be resolvable after a multi-chunk warm"
+            );
+        }
     }
 
     /// SC-001: repeat search of a cached object issues zero network calls, and

--- a/crates/targeting/resolver/src/seed.rs
+++ b/crates/targeting/resolver/src/seed.rs
@@ -218,11 +218,12 @@ pub async fn is_first_run(cache: &dyn Cache) -> Result<bool, SeedError> {
 
 /// Warm the redb cache from a seed asset, writing rows with `source = seed`.
 ///
-/// Each entry is upserted through [`simbad_resolver::Cache::upsert`], so the
-/// warm is idempotent: re-running it dedups by `simbad_oid` (or the
-/// designation-derived id) and never overwrites a sticky `user-override` row.
-/// Returns the number of entries that resulted in a new or refreshed cache
-/// row.
+/// Entries are upserted in one call to [`simbad_resolver::Cache::upsert_batch`]
+/// (a single backend write transaction for the whole batch, rather than one
+/// per entry — spec 052 P4/#695), so the warm is idempotent: re-running it
+/// dedups by `simbad_oid` (or the designation-derived id) and never overwrites
+/// a sticky `user-override` row. Returns the number of entries that resulted
+/// in a new or refreshed cache row.
 ///
 /// `namespace` MUST be the same id-namespace the production facade uses
 /// ([`crate::simbad`]'s `"astro-plan.targets"` seed) so warmed ids match the
@@ -239,14 +240,15 @@ pub async fn warm_cache(
     seed: &SeedAsset,
     namespace: &Uuid,
 ) -> Result<usize, SeedError> {
-    let mut loaded = 0usize;
-    for entry in &seed.entries {
-        let identity = entry.to_crate_identity();
-        let (_, outcome) = cache.upsert(&identity, namespace).await?;
-        if !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride) {
-            loaded += 1;
-        }
-    }
+    let identities: Vec<simbad_resolver::ResolvedIdentity> =
+        seed.entries.iter().map(SeedEntry::to_crate_identity).collect();
+    let results = cache.upsert_batch(&identities, namespace).await?;
+    let loaded = results
+        .iter()
+        .filter(|(_, outcome)| {
+            !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride)
+        })
+        .count();
     Ok(loaded)
 }
 
@@ -288,10 +290,10 @@ pub async fn warm_from_canonical_target(
     namespace: &Uuid,
 ) -> Result<usize, SeedError> {
     let rows = crate::cache::list_all(pool).await?;
-    let mut warmed = 0usize;
+    let mut identities = Vec::with_capacity(rows.len());
     for row in rows {
         let Some(durable) = crate::cache::get_by_id(pool, row.id).await? else { continue };
-        let identity = simbad_resolver::ResolvedIdentity {
+        identities.push(simbad_resolver::ResolvedIdentity {
             simbad_oid: durable.simbad_oid,
             primary_designation: durable.primary_designation,
             common_name: durable
@@ -310,12 +312,15 @@ pub async fn warm_from_canonical_target(
                 .map(|a| simbad_resolver::ResolvedAlias::new(a.alias, to_crate_alias_kind(a.kind)))
                 .collect(),
             source: to_crate_source(durable.source),
-        };
-        let (_, outcome) = cache.upsert(&identity, namespace).await?;
-        if !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride) {
-            warmed += 1;
-        }
+        });
     }
+    let results = cache.upsert_batch(&identities, namespace).await?;
+    let warmed = results
+        .iter()
+        .filter(|(_, outcome)| {
+            !matches!(outcome, simbad_resolver::UpsertOutcome::SkippedUserOverride)
+        })
+        .count();
     Ok(warmed)
 }
 
@@ -511,16 +516,18 @@ mod tests {
     }
 
     /// A real Messier-only slice of the committed bundled asset (~110 objects,
-    /// including M 31/M 42) — fast enough for redb-touching tests. Each
-    /// [`simbad_resolver::Cache::upsert`] is its own fsync'd write transaction
-    /// (no batch-upsert primitive; a future `simbad-resolver` release may add
-    /// one), so warming the FULL ~14k-object popular seed one entry at a time
-    /// is a multi-second-to-tens-of-seconds operation — acceptable as a
-    /// one-time, backgrounded app-startup warm (never blocks the UI, see
-    /// `apps/desktop/src-tauri/src/lib.rs`), but too slow to run twice per
-    /// `cargo test`/`nextest` invocation. [`bundled_asset_loads_and_covers_messier_and_caldwell`]
-    /// separately proves the full committed asset's shape (pure JSON parse,
-    /// no redb).
+    /// including M 31/M 42) — fast enough for redb-touching tests. [`warm_cache`]
+    /// now goes through [`simbad_resolver::Cache::upsert_batch`] (one fsync'd
+    /// write transaction for the whole batch, since `simbad-resolver` 0.3.0 —
+    /// spec 052 P4/#695) instead of one transaction per entry, but the
+    /// per-entry dedup-by-`simbad_oid` lookup the crate's backend does inside
+    /// that transaction is still an O(n) scan per entry (O(n²) for the whole
+    /// batch), so warming the FULL ~14k-object popular seed is still far too
+    /// slow for `cargo test`/`nextest` (measured: low hundreds of ms at
+    /// n=500, growing to minutes by n=4000) — a Messier-only slice keeps this
+    /// suite fast regardless of the transaction-count change.
+    /// [`bundled_asset_loads_and_covers_messier_and_caldwell`] separately
+    /// proves the full committed asset's shape (pure JSON parse, no redb).
     fn messier_only_seed() -> SeedAsset {
         let full = bundled().expect("bundled seed asset must parse");
         let entries: Vec<SeedEntry> =

--- a/crates/targeting/resolver/src/seed.rs
+++ b/crates/targeting/resolver/src/seed.rs
@@ -209,11 +209,93 @@ pub fn bundled() -> Result<SeedAsset, SeedError> {
 /// idempotent (upsert dedups), so this is an optimization, not a correctness
 /// requirement.
 ///
+/// NOT used by [`warm_bundled_on_first_run`] (see the warm-complete sentinel
+/// below) — emptiness is unreliable there: a durable single-item write (a
+/// user search mid-warm, since [`Cache::upsert`] always stays durable even
+/// against an [`simbad_resolver::BatchDurability::Eventual`] store) can
+/// persist earlier `Eventual` seed chunks too (redb commits are cumulative),
+/// so a crash mid-warm can leave a non-empty but PARTIAL cache — this check
+/// would then see "not empty" and skip the re-warm forever (#818 follow-up).
+/// Still useful on its own (kept for `warm_cache`'s callers and the
+/// `canonical_target` backfill, which has no version concept to gate on).
+///
 /// # Errors
 ///
 /// Returns [`SeedError::Cache`] on a cache backend failure.
 pub async fn is_first_run(cache: &dyn Cache) -> Result<bool, SeedError> {
     Ok(cache.list().await?.is_empty())
+}
+
+/// Reserved, never-real `simbad_oid` for the warm-complete sentinel row
+/// below — real SIMBAD physical-object ids are always positive, so a
+/// negative value can never collide with an actual resolved/seeded object.
+const SENTINEL_SIMBAD_OID: i64 = -1;
+
+/// Whether `simbad_oid` identifies the warm-complete sentinel row (see
+/// [`sentinel_identity`]) rather than a real cached target. The bundled seed
+/// is stored in the SAME `Cache`-backed store any typeahead/cone-search
+/// query reads from (the crate exposes no separate metadata table), so any
+/// app-facing surface that reads broadly from the cache (`target.search`'s
+/// `cache.search`, in particular) MUST filter this out explicitly — a
+/// reserved designation string alone is not a structural guarantee against a
+/// fuzzy/substring match.
+#[must_use]
+pub fn is_warm_sentinel(simbad_oid: Option<i64>) -> bool {
+    simbad_oid == Some(SENTINEL_SIMBAD_OID)
+}
+
+/// Reserved designation for the warm-complete sentinel row. The crate has no
+/// metadata table separate from the target/alias store it already exposes
+/// via [`Cache`] (confirmed against `simbad-resolver` 0.3.2's public API), so
+/// the sentinel lives as an ordinary row in that same store instead — but
+/// always looked up and deduped by [`SENTINEL_SIMBAD_OID`] (`simbad_oid`
+/// takes precedence over a designation-derived id in the crate's own
+/// dedup — see `simbad-resolver`'s `upsert_within`), so this string's exact
+/// spelling is not a correctness requirement, only a debugging aid; the
+/// leading `∅` plus spaces make it visually obvious in a redb dump or log
+/// line that this is not a real catalogue designation.
+const SENTINEL_DESIGNATION: &str = "\u{2205} ALM SEED WARM SENTINEL";
+
+/// Build the warm-complete sentinel row for `seed`, carrying its
+/// `generated_at` in `common_name` as the version key (spec 052 P4/#818
+/// follow-up — "prefer a content hash or that timestamp"; the timestamp is
+/// simpler and the seed-builder tool already bumps it on every regen, so a
+/// hash would only guard against a same-timestamp-different-content mistake
+/// that tool doesn't make).
+fn sentinel_identity(seed: &SeedAsset) -> simbad_resolver::ResolvedIdentity {
+    simbad_resolver::ResolvedIdentity {
+        simbad_oid: Some(SENTINEL_SIMBAD_OID),
+        primary_designation: SENTINEL_DESIGNATION.to_owned(),
+        common_name: Some(seed.generated_at.clone()),
+        object_type: simbad_resolver::ObjectType::Other,
+        otype_raw: String::new(),
+        ra_deg: 0.0,
+        dec_deg: 0.0,
+        v_mag: None,
+        aliases: vec![simbad_resolver::ResolvedAlias::new(
+            SENTINEL_DESIGNATION,
+            simbad_resolver::AliasKind::Designation,
+        )],
+        source: simbad_resolver::TargetSource::Seed,
+    }
+}
+
+/// Whether the cache already holds a warm-complete sentinel matching `seed`'s
+/// `generated_at` — i.e. the bundled seed warm can be skipped. `false` for
+/// both "never warmed" (no sentinel) and "warmed a since-superseded seed
+/// version" (sentinel present, `generated_at` differs, e.g. after #696-style
+/// regenerated-asset ships in a new app build) — either way
+/// [`warm_bundled_on_first_run`] must (re-)run, which is safe: the warm is
+/// idempotent (upsert dedups).
+///
+/// # Errors
+///
+/// Returns [`SeedError::Cache`] on a cache backend failure.
+async fn sentinel_matches(cache: &dyn Cache, seed: &SeedAsset) -> Result<bool, SeedError> {
+    Ok(cache
+        .get_by_simbad_oid(SENTINEL_SIMBAD_OID)
+        .await?
+        .is_some_and(|row| row.common_name.as_deref() == Some(seed.generated_at.as_str())))
 }
 
 /// Chunk size for [`chunked_upsert_batch`] (spec 052 P4/#818 follow-up): one
@@ -282,11 +364,21 @@ pub async fn warm_cache(
     chunked_upsert_batch(cache, &identities, namespace).await
 }
 
-/// Warm the redb cache from the bundled seed **only when the cache is empty**.
+/// Warm the redb cache from the bundled seed **only when it isn't already
+/// warmed for this exact seed version**.
 ///
-/// Convenience wrapper combining [`is_first_run`] + [`bundled`] +
-/// [`warm_cache`]. Returns `Some(count)` of warmed entries when a first-run
-/// warm happened, or `None` when the cache was already populated (no-op).
+/// Gated on the warm-complete sentinel ([`sentinel_matches`]), not cache
+/// emptiness (spec 052 P4/#818 follow-up) — a crash partway through a
+/// chunked `Eventual` warm can leave a non-empty but partial cache (see
+/// [`is_first_run`]'s doc comment), which an emptiness check would mistake
+/// for "already done" forever. The sentinel also carries the seed's
+/// `generated_at`, so a newer app build shipping a regenerated asset
+/// (#696-style) re-warms existing installs instead of leaving them stuck on
+/// the version they first launched with.
+///
+/// Returns `Some(count)` of warmed entries when a warm happened (first run,
+/// a prior partial/crashed warm, or a seed version bump), or `None` when the
+/// cache already matches the current bundled seed (no-op).
 ///
 /// # Errors
 ///
@@ -295,11 +387,20 @@ pub async fn warm_bundled_on_first_run(
     cache: &dyn Cache,
     namespace: &Uuid,
 ) -> Result<Option<usize>, SeedError> {
-    if !is_first_run(cache).await? {
+    let seed = bundled()?;
+    if sentinel_matches(cache, &seed).await? {
         return Ok(None);
     }
-    let seed = bundled()?;
     let loaded = warm_cache(cache, &seed, namespace).await?;
+    // Sentinel written LAST, via a single-item `Cache::upsert` (always
+    // durable regardless of the store's bulk `BatchDurability` — see
+    // `simbad-resolver` 0.3.2's `BatchDurability` doc comment): this one
+    // commit persists itself AND every prior `Eventual` chunk from
+    // `warm_cache` above (redb commits are cumulative), so "sentinel
+    // present and matching" is only ever true once the whole seed warm it
+    // attests to is itself durably on disk.
+    let identity = sentinel_identity(&seed);
+    cache.upsert(&identity, namespace).await?;
     Ok(Some(loaded))
 }
 
@@ -542,14 +643,18 @@ mod tests {
     /// including M 31/M 42) — fast enough for redb-touching tests. [`warm_cache`]
     /// goes through [`chunked_upsert_batch`] (one [`simbad_resolver::Cache::
     /// upsert_batch`] write transaction per [`WARM_CHUNK_SIZE`]-sized chunk —
-    /// spec 052 P4/#695, chunked by the #818 follow-up), which on a
-    /// file-backed store measures ~2.4s for the full ~13k-object bundled seed
-    /// (debug build) — fast in absolute terms, but still needless overhead to
-    /// pay on every `cargo test`/`nextest` invocation across every test that
-    /// only needs a handful of real, known objects. A Messier-only slice keeps
-    /// this suite fast regardless. [`bundled_asset_loads_and_covers_messier_and_caldwell`]
-    /// separately proves the full committed asset's shape (pure JSON parse,
-    /// no redb).
+    /// spec 052 P4/#695, chunked by the first #818 follow-up), which on a
+    /// `simbad_resolver::BatchDurability::Eventual` file-backed store
+    /// (`crate::simbad::ResolveCache::open`'s production configuration since
+    /// the second #818 follow-up) measures ~3.2s total (warm + one flush)
+    /// for the full ~13k-object bundled seed, debug build — close to a
+    /// single atomic transaction's ~2.4s, and far better than the ~5.8s a
+    /// `Durable`-store chunked warm costs (13 fsyncs instead of 1) — but
+    /// still needless overhead to pay on every `cargo test`/`nextest`
+    /// invocation across every test that only needs a handful of real,
+    /// known objects. A Messier-only slice keeps this suite fast regardless.
+    /// [`bundled_asset_loads_and_covers_messier_and_caldwell`] separately
+    /// proves the full committed asset's shape (pure JSON parse, no redb).
     fn messier_only_seed() -> SeedAsset {
         let full = bundled().expect("bundled seed asset must parse");
         let entries: Vec<SeedEntry> =
@@ -579,6 +684,89 @@ mod tests {
         assert!(!cache.list().await.unwrap().is_empty());
         let reloaded = warm_cache(&cache, &seed, &ns()).await.unwrap();
         assert!(reloaded >= 80, "re-warm dedups by oid/id, not by row count delta");
+    }
+
+    /// Regression guard for the #818 follow-up (crash-recovery for partial
+    /// warms): a crashed process can leave the cache non-empty but PARTIAL
+    /// (an unrelated durable single-item write — e.g. a live resolve — can
+    /// persist earlier `Eventual` seed chunks too, since redb commits are
+    /// cumulative, without the warm ever reaching its sentinel step). The
+    /// NEXT `warm_bundled_on_first_run` call — modelling the next app
+    /// launch — must recognize this as incomplete (no sentinel yet) and
+    /// finish the job, not treat "non-empty" as "already done".
+    #[tokio::test]
+    async fn warm_bundled_on_first_run_recovers_from_a_partial_warm() {
+        let store = Store::in_memory().unwrap();
+        let cache = store.cache();
+        let namespace = ns();
+        let full = bundled().expect("bundled seed asset must parse");
+
+        // Simulate the crash: durably persist a slice of the real bundled
+        // seed directly via `warm_cache` (bypassing `warm_bundled_on_first_run`
+        // entirely, so no sentinel is ever written) — the cache ends up
+        // non-empty but with only part of the seed present.
+        let partial = SeedAsset {
+            version: full.version,
+            generated_at: full.generated_at.clone(),
+            source: full.source.clone(),
+            entries: full.entries.iter().take(50).cloned().collect(),
+        };
+        let partial_loaded = warm_cache(&cache, &partial, &namespace).await.unwrap();
+        assert_eq!(partial_loaded, 50, "the simulated partial warm must land exactly 50 rows");
+        assert!(
+            !sentinel_matches(&cache, &full).await.unwrap(),
+            "a partial (crashed) warm must not look complete — no sentinel was ever written"
+        );
+
+        // The next warm call: must NOT skip (an emptiness check would have —
+        // the cache is non-empty), and must warm the FULL seed, not just
+        // whatever was missing.
+        let loaded = warm_bundled_on_first_run(&cache, &namespace)
+            .await
+            .unwrap()
+            .expect("a partial/unsentineled cache must trigger a real warm, not a no-op");
+        assert!(
+            loaded >= full.entries.len(),
+            "expected the full seed to be (re-)warmed, got {loaded}"
+        );
+        assert!(
+            sentinel_matches(&cache, &full).await.unwrap(),
+            "warm_bundled_on_first_run must write a matching sentinel once it completes"
+        );
+
+        // Idempotent: a further call now correctly no-ops (sentinel matches).
+        let noop = warm_bundled_on_first_run(&cache, &namespace).await.unwrap();
+        assert!(noop.is_none(), "a matching sentinel must skip the warm on the next call");
+    }
+
+    /// Regression guard for the #818 follow-up: a newer seed build shipping
+    /// a regenerated asset (#696-style) must trigger a re-warm on existing
+    /// installs rather than being masked by an old, no-longer-matching
+    /// sentinel — proven directly against `sentinel_matches` (the exact
+    /// mechanism `warm_bundled_on_first_run` gates on), independent of the
+    /// committed asset's real size.
+    #[tokio::test]
+    async fn seed_version_change_invalidates_the_sentinel() {
+        let store = Store::in_memory().unwrap();
+        let cache = store.cache();
+        let namespace = ns();
+
+        let mut seed = messier_only_seed();
+        seed.generated_at = "2020-01-01T00:00:00Z".to_owned();
+        warm_cache(&cache, &seed, &namespace).await.unwrap();
+        let identity = sentinel_identity(&seed);
+        cache.upsert(&identity, &namespace).await.unwrap();
+        assert!(
+            sentinel_matches(&cache, &seed).await.unwrap(),
+            "a freshly-written sentinel must match the seed it was written for"
+        );
+
+        let mut newer_seed = seed.clone();
+        newer_seed.generated_at = "2026-07-14T00:00:00Z".to_owned();
+        assert!(
+            !sentinel_matches(&cache, &newer_seed).await.unwrap(),
+            "a version-mismatched sentinel must not be treated as complete"
+        );
     }
 
     /// A synthetic seed of `n` distinct objects (unique `simbad_oid` +

--- a/crates/targeting/resolver/src/simbad.rs
+++ b/crates/targeting/resolver/src/simbad.rs
@@ -75,18 +75,32 @@ pub struct ResolveCache(simbad_resolver::Store);
 
 impl ResolveCache {
     /// Open (creating if missing) the durable, file-backed resolve cache at
-    /// `path`.
+    /// `path`, with the store's bulk-batch writes configured `Eventual`
+    /// (`simbad-resolver` 0.3.2's [`simbad_resolver::BatchDurability`] —
+    /// skips the fsync per [`simbad_resolver::Cache::upsert_batch`]
+    /// transaction; [`Self::flush`] does one fsync at the end persisting
+    /// every chunk, since redb commits are cumulative). Single-item
+    /// [`simbad_resolver::Cache::upsert`] calls (e.g. an in-flight resolve
+    /// while a chunked seed warm is running) stay durable regardless — this
+    /// setting only relaxes the *bulk seed/backfill warm* path
+    /// (`crate::seed`), matching the app's own chunk size
+    /// (`crate::seed::WARM_CHUNK_SIZE`'s ~13-chunk bundled seed warm going
+    /// from ~13 fsyncs to 1).
     ///
     /// # Errors
     ///
     /// Returns [`ResolveError::Network`] if the redb file cannot be opened or
     /// its tables cannot be initialised.
     pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self, ResolveError> {
-        simbad_resolver::Store::open(path).map(Self).map_err(|e| from_cache_error(&e))
+        simbad_resolver::Store::open_with(path, simbad_resolver::BatchDurability::Eventual)
+            .map(Self)
+            .map_err(|e| from_cache_error(&e))
     }
 
     /// An ephemeral, in-memory resolve cache (nothing persisted) — for tests
-    /// and offline-only construction.
+    /// and offline-only construction. Always `Durable` (the crate has no
+    /// `Eventual` in-memory variant — there is no "reopen after a crash"
+    /// scenario for a store with nothing on disk to begin with).
     ///
     /// # Errors
     ///
@@ -101,6 +115,25 @@ impl ResolveCache {
     #[must_use]
     pub fn cache(&self) -> impl simbad_resolver::Cache + 'static {
         self.0.cache()
+    }
+
+    /// Force one fully durable commit, persisting every `Eventual` bulk-warm
+    /// chunk written since [`Self::open`] (redb commits are cumulative — see
+    /// [`simbad_resolver::RedbCache::flush`]). Call once after the LAST
+    /// warm/backfill phase of a startup or `target.cache.clear` re-warm —
+    /// don't rely on the cache closing naturally to persist those chunks, as
+    /// it stays open for the rest of the process's lifetime. A cheap,
+    /// safe-to-call no-op if nothing `Eventual` was written this session
+    /// (e.g. every phase short-circuited on its own gate).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ResolveError::Network`] if the (empty) commit fails.
+    pub async fn flush(&self) -> Result<(), ResolveError> {
+        // `Store::cache()` returns the CONCRETE `RedbCache` (unlike
+        // `Self::cache()` above, which erases it to `impl Cache` — `flush`
+        // is redb-specific, not part of the portable `Cache` trait).
+        self.0.cache().flush().await.map_err(|e| from_cache_error(&e))
     }
 }
 

--- a/crates/targeting/resolver/tests/seed_load_timing.rs
+++ b/crates/targeting/resolver/tests/seed_load_timing.rs
@@ -6,22 +6,22 @@
 //! single-transaction `SQLite` load to `simbad_resolver::Cache` upserts — see
 //! the module doc in `targeting_resolver::seed`).
 //!
-//! `targeting_resolver::seed::warm_cache` goes through
-//! [`simbad_resolver::Cache::upsert_batch`] (one redb write transaction for
-//! the whole batch, since `simbad-resolver` 0.3.0 — spec 052 P4/#695) rather
-//! than one transaction per entry. Measured on this Messier-only slice (87
-//! objects, debug build): ~147ms per-entry-transaction vs. ~96ms batched —
-//! a real but modest win, since at this scale the backend's per-entry
-//! dedup-by-`simbad_oid` lookup (an O(n) table scan, no index) still
-//! dominates over the saved fsyncs. That same O(n) lookup makes the FULL
-//! ~14k-object popular seed an O(n²) operation regardless of batching (this
-//! is why production warms it in a background task rather than blocking the
-//! UI — `apps/desktop/src-tauri/src/lib.rs` — and why this test only times a
-//! small real-data slice, not the full seed). This test times a real
-//! Messier-only slice (~110 objects, matching `targeting_resolver::seed`'s
-//! own test fixture) as a fast, still-real-data regression guard against a
-//! *worse* per-entry cost (e.g. an accidental read-then-write-then-read round
-//! trip per upsert).
+//! `targeting_resolver::seed::warm_cache` goes through the crate's private
+//! `chunked_upsert_batch` helper (one
+//! [`simbad_resolver::Cache::upsert_batch`] write transaction per
+//! ~1000-entry chunk — spec 052 P4/#695, chunked by the #818 follow-up so a
+//! `target.search` racing the warm sees each chunk's rows as soon as that
+//! chunk commits, rather than nothing until the whole seed does) rather than
+//! one transaction per entry. Measured on this Messier-only slice (87
+//! objects, well under one chunk, debug build): ~147ms per-entry-transaction
+//! vs. ~96ms batched — a real but modest win at this small scale, since
+//! `simbad-resolver` 0.3.1 fixed an O(n²) dedup-by-`simbad_oid` scan
+//! (nightwatch-astro/simbad-resolver#25) that used to dominate over the
+//! saved fsyncs. This test only times a small real-data slice, not the full
+//! ~13k-object seed (production warms that in a background task rather than
+//! blocking the UI — `apps/desktop/src-tauri/src/lib.rs`), as a fast,
+//! still-real-data regression guard against a *worse* per-entry cost (e.g.
+//! an accidental read-then-write-then-read round trip per upsert).
 
 use std::time::Instant;
 

--- a/crates/targeting/resolver/tests/seed_load_timing.rs
+++ b/crates/targeting/resolver/tests/seed_load_timing.rs
@@ -3,18 +3,25 @@
 
 //! Sanity timing: warming the redb resolve cache from the bundled seed must
 //! not regress to something absurd (spec 052 P1 D2/D4 retargeted this from a
-//! single-transaction `SQLite` load to per-identity `simbad_resolver::Cache`
-//! upserts — see the module doc in `targeting_resolver::seed`).
+//! single-transaction `SQLite` load to `simbad_resolver::Cache` upserts — see
+//! the module doc in `targeting_resolver::seed`).
 //!
-//! Each [`simbad_resolver::Cache::upsert`] call is its own fsync'd redb write
-//! transaction (the crate has no batch-upsert primitive today), so the FULL
-//! ~14k-object popular seed legitimately takes on the order of tens of
-//! seconds — that is why production warms it in a background task at app
-//! startup rather than blocking the UI (`apps/desktop/src-tauri/src/lib.rs`).
-//! This test times a real Messier-only slice (~110 objects, matching
-//! `targeting_resolver::seed`'s own test fixture) as a fast, still-real-data
-//! regression guard against a *worse* per-entry cost (e.g. an accidental
-//! read-then-write-then-read round trip per upsert).
+//! `targeting_resolver::seed::warm_cache` goes through
+//! [`simbad_resolver::Cache::upsert_batch`] (one redb write transaction for
+//! the whole batch, since `simbad-resolver` 0.3.0 — spec 052 P4/#695) rather
+//! than one transaction per entry. Measured on this Messier-only slice (87
+//! objects, debug build): ~147ms per-entry-transaction vs. ~96ms batched —
+//! a real but modest win, since at this scale the backend's per-entry
+//! dedup-by-`simbad_oid` lookup (an O(n) table scan, no index) still
+//! dominates over the saved fsyncs. That same O(n) lookup makes the FULL
+//! ~14k-object popular seed an O(n²) operation regardless of batching (this
+//! is why production warms it in a background task rather than blocking the
+//! UI — `apps/desktop/src-tauri/src/lib.rs` — and why this test only times a
+//! small real-data slice, not the full seed). This test times a real
+//! Messier-only slice (~110 objects, matching `targeting_resolver::seed`'s
+//! own test fixture) as a fast, still-real-data regression guard against a
+//! *worse* per-entry cost (e.g. an accidental read-then-write-then-read round
+//! trip per upsert).
 
 use std::time::Instant;
 

--- a/specs/035-simbad-target-resolution/contracts/target.search.json
+++ b/specs/035-simbad-target-resolution/contracts/target.search.json
@@ -44,12 +44,13 @@
     },
     "Response": {
       "type": "object",
-      "required": ["contractVersion", "requestId", "suggestions"],
+      "required": ["contractVersion", "requestId", "suggestions", "cacheWarming"],
       "additionalProperties": false,
       "properties": {
         "contractVersion": { "$ref": "#/$defs/ContractVersion" },
         "requestId": { "$ref": "#/$defs/Uuid" },
-        "suggestions": { "type": "array", "items": { "$ref": "#/$defs/Suggestion" }, "description": "Local matches only; ordered by match quality. Long-tail/SIMBAD results arrive via target.resolve." }
+        "suggestions": { "type": "array", "items": { "$ref": "#/$defs/Suggestion" }, "description": "Local matches only; ordered by match quality. Long-tail/SIMBAD results arrive via target.resolve." },
+        "cacheWarming": { "type": "boolean", "description": "True while the shared resolve cache is still running its background re-warm; a caller seeing zero suggestions while this is true should retry rather than treat the miss as settled (#818)." }
       }
     }
   }

--- a/tests/contract/target_resolution_parity_test.rs
+++ b/tests/contract/target_resolution_parity_test.rs
@@ -438,6 +438,7 @@ fn search_response_required_fields_present() {
         contract_version: "1.0".to_owned(),
         request_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890".to_owned(),
         suggestions: vec![],
+        cache_warming: false,
     };
     let value = serde_json::to_value(&resp).expect("search response should serialize");
     let keys = object_keys(&value);
@@ -459,6 +460,7 @@ fn search_response_no_extra_keys_beyond_contract() {
         contract_version: "1.0".to_owned(),
         request_id: "a1b2c3d4-e5f6-7890-abcd-ef1234567890".to_owned(),
         suggestions: vec![],
+        cache_warming: false,
     };
     let value = serde_json::to_value(&resp).expect("search response should serialize");
 


### PR DESCRIPTION
## Summary
- Bumped simbad-resolver to 0.3.2 and switched the cache warm path to its batch upsert/warm API, replacing 13,000 individual redb writes with a single transaction (dedup now O(n)).
- Warm runs chunked (1000/batch) with Eventual durability plus one final flush; a version sentinel row (written durably last) marks warm completion, so startup gates on sentinel+seed-version instead of table emptiness and interrupted warms self-heal.
- `resolve_cache` test module runtime dropped from 1066s to 3.24s.
- Target search retries while the cache is warming; `cache_warming` flag cleared via RAII guard; sentinel row excluded from search suggestions (regression-tested).
- E2E: add-target journey hardened to wait for real focus and verify typed value (mitigates #841 flake class).

Closes #695

## Spec Context
- Spec: 052
- Branch: chore/simbad-resolver-0.3-batch-warm