### PR TITLE
feat: record durable audit entries for settings, protection, equipment, and source changes

### DIFF
--- a/apps/desktop/src-tauri/src/commands/equipment.rs
+++ b/apps/desktop/src-tauri/src/commands/equipment.rs
@@ -41,7 +41,7 @@ pub async fn equipment_cameras_create(
     request: CreateCamera,
 ) -> Result<Camera, ContractError> {
     tracing::debug!("equipment.cameras.create name={}", request.name);
-    app_core::equipment::create_camera(state.repo.pool(), &request).await
+    app_core::equipment::create_camera(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.cameras.update` — update an existing camera.
@@ -55,7 +55,7 @@ pub async fn equipment_cameras_update(
     request: UpdateCamera,
 ) -> Result<Camera, ContractError> {
     tracing::debug!("equipment.cameras.update id={}", request.id);
-    app_core::equipment::update_camera(state.repo.pool(), &request).await
+    app_core::equipment::update_camera(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.cameras.delete` — delete a camera by ID.
@@ -69,7 +69,7 @@ pub async fn equipment_cameras_delete(
     id: String,
 ) -> Result<(), ContractError> {
     tracing::debug!("equipment.cameras.delete id={id}");
-    app_core::equipment::delete_camera(state.repo.pool(), &id).await
+    app_core::equipment::delete_camera(state.repo.pool(), &state.bus, &id).await
 }
 
 // ── Telescope commands ──────────────────────────────────────────────────────
@@ -98,7 +98,7 @@ pub async fn equipment_telescopes_create(
     request: CreateTelescope,
 ) -> Result<Telescope, ContractError> {
     tracing::debug!("equipment.telescopes.create name={}", request.name);
-    app_core::equipment::create_telescope(state.repo.pool(), &request).await
+    app_core::equipment::create_telescope(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.telescopes.update` — update an existing telescope.
@@ -112,7 +112,7 @@ pub async fn equipment_telescopes_update(
     request: UpdateTelescope,
 ) -> Result<Telescope, ContractError> {
     tracing::debug!("equipment.telescopes.update id={}", request.id);
-    app_core::equipment::update_telescope(state.repo.pool(), &request).await
+    app_core::equipment::update_telescope(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.telescopes.delete` — delete a telescope by ID.
@@ -126,7 +126,7 @@ pub async fn equipment_telescopes_delete(
     id: String,
 ) -> Result<(), ContractError> {
     tracing::debug!("equipment.telescopes.delete id={id}");
-    app_core::equipment::delete_telescope(state.repo.pool(), &id).await
+    app_core::equipment::delete_telescope(state.repo.pool(), &state.bus, &id).await
 }
 
 // ── Optical Train commands ──────────────────────────────────────────────────
@@ -155,7 +155,7 @@ pub async fn equipment_trains_create(
     request: CreateOpticalTrain,
 ) -> Result<OpticalTrain, ContractError> {
     tracing::debug!("equipment.trains.create name={}", request.name);
-    app_core::equipment::create_optical_train(state.repo.pool(), &request).await
+    app_core::equipment::create_optical_train(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.trains.update` — update an existing optical train.
@@ -169,7 +169,7 @@ pub async fn equipment_trains_update(
     request: UpdateOpticalTrain,
 ) -> Result<OpticalTrain, ContractError> {
     tracing::debug!("equipment.trains.update id={}", request.id);
-    app_core::equipment::update_optical_train(state.repo.pool(), &request).await
+    app_core::equipment::update_optical_train(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.trains.delete` — delete an optical train by ID.
@@ -183,7 +183,7 @@ pub async fn equipment_trains_delete(
     id: String,
 ) -> Result<(), ContractError> {
     tracing::debug!("equipment.trains.delete id={id}");
-    app_core::equipment::delete_optical_train(state.repo.pool(), &id).await
+    app_core::equipment::delete_optical_train(state.repo.pool(), &state.bus, &id).await
 }
 
 // ── Filter commands ─────────────────────────────────────────────────────────
@@ -212,7 +212,7 @@ pub async fn equipment_filters_create(
     request: CreateFilter,
 ) -> Result<Filter, ContractError> {
     tracing::debug!("equipment.filters.create name={}", request.name);
-    app_core::equipment::create_filter(state.repo.pool(), &request).await
+    app_core::equipment::create_filter(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.filters.update` — update an existing filter.
@@ -226,7 +226,7 @@ pub async fn equipment_filters_update(
     request: UpdateFilter,
 ) -> Result<Filter, ContractError> {
     tracing::debug!("equipment.filters.update id={}", request.id);
-    app_core::equipment::update_filter(state.repo.pool(), &request).await
+    app_core::equipment::update_filter(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `equipment.filters.delete` — delete a filter by ID.
@@ -240,5 +240,5 @@ pub async fn equipment_filters_delete(
     id: String,
 ) -> Result<(), ContractError> {
     tracing::debug!("equipment.filters.delete id={id}");
-    app_core::equipment::delete_filter(state.repo.pool(), &id).await
+    app_core::equipment::delete_filter(state.repo.pool(), &state.bus, &id).await
 }

--- a/apps/desktop/src-tauri/src/commands/firstrun.rs
+++ b/apps/desktop/src-tauri/src/commands/firstrun.rs
@@ -90,5 +90,6 @@ pub async fn roots_register_batch(
         .collect();
     let enforced_request = RegisterSourceBatchRequest { sources: enforced_sources };
 
-    app_core::first_run::register_source_batch(state.repo.pool(), &enforced_request).await
+    app_core::first_run::register_source_batch(state.repo.pool(), &state.bus, &enforced_request)
+        .await
 }

--- a/apps/desktop/src-tauri/src/commands/roots.rs
+++ b/apps/desktop/src-tauri/src/commands/roots.rs
@@ -136,7 +136,7 @@ pub async fn roots_register(
     let req =
         RegisterSourceRequest { kind, path, kind_subtype: None, scan_depth, organization_state };
 
-    app_core::first_run::register_source(state.repo.pool(), &req).await
+    app_core::first_run::register_source(state.repo.pool(), &state.bus, &req).await
 }
 
 /// `sources.set_organization_state` — change a source's organization state

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -230,7 +230,7 @@ pub async fn settings_source_override_set(
         request.source_id,
         request.key
     );
-    app_core::settings::set_source_override(state.repo.pool(), &request).await
+    app_core::settings::set_source_override(state.repo.pool(), &state.bus, &request).await
 }
 
 /// `settings.overridable-keys` — return the list of stable settings keys that

--- a/apps/desktop/src-tauri/tests/commands.rs
+++ b/apps/desktop/src-tauri/tests/commands.rs
@@ -448,6 +448,7 @@ fn _roots_list_compiles_check() {
 async fn roots_register_via_use_case() {
     let db = Database::in_memory().await.expect("in-memory database");
     db.migrate().await.expect("run migrations");
+    let bus = EventBus::with_pool(db.pool().clone());
 
     // Path must be absolute on the host OS (validate_path rejects POSIX-style
     // paths on Windows).
@@ -464,7 +465,7 @@ async fn roots_register_via_use_case() {
         organization_state: contracts_core::first_run::OrganizationState::Organized,
     };
 
-    let resp = app_core::first_run::register_source(db.pool(), &req).await;
+    let resp = app_core::first_run::register_source(db.pool(), &bus, &req).await;
     assert!(resp.is_ok(), "register_source failed: {resp:?}");
     let resp = resp.unwrap();
     assert_eq!(resp.kind, contracts_core::first_run::SourceKind::LightFrames);
@@ -484,6 +485,7 @@ fn _roots_remap_compiles_check() {
 async fn roots_remap_via_use_case() {
     let db = Database::in_memory().await.expect("in-memory database");
     db.migrate().await.expect("run migrations");
+    let bus = EventBus::with_pool(db.pool().clone());
 
     // Paths must be absolute on the host OS (validate_path rejects POSIX-style
     // paths on Windows).
@@ -499,7 +501,7 @@ async fn roots_remap_via_use_case() {
         scan_depth: contracts_core::first_run::ScanDepth::Recursive,
         organization_state: contracts_core::first_run::OrganizationState::Organized,
     };
-    let resp = app_core::first_run::register_source(db.pool(), &req)
+    let resp = app_core::first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect("register_source failed");
 
@@ -529,7 +531,7 @@ async fn roots_remap_apply_via_use_case() {
         scan_depth: contracts_core::first_run::ScanDepth::Recursive,
         organization_state: contracts_core::first_run::OrganizationState::Organized,
     };
-    let resp = app_core::first_run::register_source(db.pool(), &req)
+    let resp = app_core::first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect("register_source failed");
 
@@ -576,7 +578,7 @@ async fn sources_set_active_via_use_case() {
         scan_depth: contracts_core::first_run::ScanDepth::Recursive,
         organization_state: contracts_core::first_run::OrganizationState::Organized,
     };
-    let resp = app_core::first_run::register_source(db.pool(), &req)
+    let resp = app_core::first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect("register_source failed");
 
@@ -610,7 +612,7 @@ async fn roots_delete_via_use_case_blocks_on_dependents() {
         scan_depth: contracts_core::first_run::ScanDepth::Recursive,
         organization_state: contracts_core::first_run::OrganizationState::Unorganized,
     };
-    let resp = app_core::first_run::register_source(db.pool(), &req)
+    let resp = app_core::first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect("register_source failed");
 
@@ -658,7 +660,7 @@ async fn roots_delete_via_use_case_succeeds_without_dependents() {
         scan_depth: contracts_core::first_run::ScanDepth::Recursive,
         organization_state: contracts_core::first_run::OrganizationState::Organized,
     };
-    let resp = app_core::first_run::register_source(db.pool(), &req)
+    let resp = app_core::first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect("register_source failed");
 

--- a/crates/app/calibration/Cargo.toml
+++ b/crates/app/calibration/Cargo.toml
@@ -17,7 +17,10 @@ persistence_db = { path = "../../persistence/db" }
 serde_json.workspace = true
 sqlx.workspace = true
 time = { workspace = true }
-uuid = { workspace = true }
+# "v5" beyond the workspace default ("v4"): deterministic audit `entity_id`
+# fallback for equipment ids that aren't real UUIDs (T124, spec 030 FR-133),
+# same pattern as `crates/targeting/Cargo.toml`.
+uuid = { version = "1", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
 tokio.workspace = true

--- a/crates/app/calibration/src/equipment.rs
+++ b/crates/app/calibration/src/equipment.rs
@@ -7,12 +7,17 @@
 //! Includes `find_or_create_by_alias` for auto-detection workflows where
 //! equipment seen in FITS headers is created on demand.
 
+use audit::bus::EventBus;
+use audit::event_bus::Source;
+use audit::{AuditLogEntry, Outcome, Severity};
 use contracts_core::equipment::{
     Camera, CreateCamera, CreateFilter, CreateOpticalTrain, CreateTelescope, Filter,
     FilterCategory, OpticalTrain, Telescope, UpdateCamera, UpdateFilter, UpdateOpticalTrain,
     UpdateTelescope,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use domain_core::ids::EntityId;
+use domain_core::lifecycle::data_asset::EntityType;
 use persistence_db::repositories::equipment as repo;
 use persistence_db::repositories::q_calibration;
 use sqlx::SqlitePool;
@@ -28,6 +33,98 @@ fn db_to_contract(e: persistence_db::DbError) -> ContractError {
         ContractError::new(ErrorCode::EquipmentDuplicate, msg, ErrorSeverity::Warning, false)
     } else {
         ContractError::new(ErrorCode::InternalDatabase, msg, ErrorSeverity::Fatal, true)
+    }
+}
+
+/// Render an `ErrorCode` as its dotted wire string, for use as an audit
+/// `reason_code`.
+fn error_code_str(code: ErrorCode) -> String {
+    serde_json::to_string(&code)
+        .map_or_else(|_| "internal.error".to_owned(), |s| s.trim_matches('"').to_owned())
+}
+
+/// Deterministic `entity_id` for an equipment audit row: parses `id` as a
+/// real UUID when possible (every persisted camera/telescope/train/filter id
+/// is one), falling back to a stable UUIDv5 derivation for attempted-but-not-
+/// yet-created items (e.g. a failed `create` has no id) so repeated attempts
+/// with the same name still correlate under one `entity_id`.
+fn equipment_entity_id(id: &str) -> EntityId {
+    uuid::Uuid::parse_str(id).map_or_else(
+        |_| {
+            let ns = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_DNS, b"astro-plan.audit.equipment");
+            EntityId::from_uuid(uuid::Uuid::new_v5(&ns, id.as_bytes()))
+        },
+        EntityId::from_uuid,
+    )
+}
+
+/// Write a durable audit row for an equipment CRUD attempt (T124,
+/// FR-130/FR-131). `id_seed` is the item's real id on success/update/delete,
+/// or its attempted `name` on a failed `create` (no id exists yet).
+async fn write_equipment_audit(
+    bus: &EventBus,
+    action: &str,
+    id_seed: &str,
+    outcome: Outcome,
+    reason_code: Option<&str>,
+    payload: serde_json::Value,
+) -> Result<(), ContractError> {
+    let mut entry = AuditLogEntry::new(
+        EntityType::Equipment,
+        equipment_entity_id(id_seed),
+        action,
+        "user",
+        outcome,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(payload);
+    if let Some(code) = reason_code {
+        entry = entry.with_reason_code(code.to_owned());
+    }
+    bus.write_audit(
+        entry,
+        "equipment.changed",
+        Source::User,
+        serde_json::json!({"action": action, "outcome": outcome.as_str()}),
+    )
+    .await
+    .map_err(|e| {
+        ContractError::new(ErrorCode::InternalDatabase, e.to_string(), ErrorSeverity::Fatal, true)
+    })?;
+    Ok(())
+}
+
+/// Shared `delete_*` tail: audits `result` (already run against the repo)
+/// as `Applied`/`Failed`, then returns it as a `ContractError` result. All
+/// four equipment kinds share the same `(pool, id) -> DbResult<()>` delete
+/// shape, so this is the one place that maps outcome → audit row for all of
+/// them (T124).
+async fn delete_equipment(
+    bus: &EventBus,
+    action: &str,
+    id: &str,
+    result: Result<(), persistence_db::DbError>,
+) -> Result<(), ContractError> {
+    match result {
+        Ok(()) => {
+            write_equipment_audit(bus, action, id, Outcome::Applied, None, serde_json::json!({}))
+                .await?;
+            Ok(())
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                action,
+                id,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({}),
+            )
+            .await?;
+            Err(err)
+        }
     }
 }
 
@@ -47,8 +144,38 @@ pub async fn list_cameras(pool: &SqlitePool) -> Result<Vec<Camera>, ContractErro
 /// # Errors
 ///
 /// Returns `ContractError` on duplicate or database failure.
-pub async fn create_camera(pool: &SqlitePool, req: &CreateCamera) -> Result<Camera, ContractError> {
-    repo::create_camera(pool, req).await.map_err(db_to_contract)
+pub async fn create_camera(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    req: &CreateCamera,
+) -> Result<Camera, ContractError> {
+    match repo::create_camera(pool, req).await {
+        Ok(camera) => {
+            write_equipment_audit(
+                bus,
+                "equipment.camera.create",
+                &camera.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": camera.name}),
+            )
+            .await?;
+            Ok(camera)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.camera.create",
+                &req.name,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Update an existing camera.
@@ -56,8 +183,38 @@ pub async fn create_camera(pool: &SqlitePool, req: &CreateCamera) -> Result<Came
 /// # Errors
 ///
 /// Returns `ContractError` if the camera is not found.
-pub async fn update_camera(pool: &SqlitePool, req: &UpdateCamera) -> Result<Camera, ContractError> {
-    repo::update_camera(pool, req).await.map_err(db_to_contract)
+pub async fn update_camera(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    req: &UpdateCamera,
+) -> Result<Camera, ContractError> {
+    match repo::update_camera(pool, req).await {
+        Ok(camera) => {
+            write_equipment_audit(
+                bus,
+                "equipment.camera.update",
+                &camera.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": camera.name}),
+            )
+            .await?;
+            Ok(camera)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.camera.update",
+                &req.id,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Delete a camera by ID.
@@ -65,8 +222,12 @@ pub async fn update_camera(pool: &SqlitePool, req: &UpdateCamera) -> Result<Came
 /// # Errors
 ///
 /// Returns `ContractError` if the camera is not found.
-pub async fn delete_camera(pool: &SqlitePool, id: &str) -> Result<(), ContractError> {
-    repo::delete_camera(pool, id).await.map_err(db_to_contract)
+pub async fn delete_camera(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    id: &str,
+) -> Result<(), ContractError> {
+    delete_equipment(bus, "equipment.camera.delete", id, repo::delete_camera(pool, id).await).await
 }
 
 /// Find a camera by alias, or create one if not found.
@@ -114,9 +275,36 @@ pub async fn list_telescopes(pool: &SqlitePool) -> Result<Vec<Telescope>, Contra
 /// Returns `ContractError` on duplicate or database failure.
 pub async fn create_telescope(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &CreateTelescope,
 ) -> Result<Telescope, ContractError> {
-    repo::create_telescope(pool, req).await.map_err(db_to_contract)
+    match repo::create_telescope(pool, req).await {
+        Ok(scope) => {
+            write_equipment_audit(
+                bus,
+                "equipment.telescope.create",
+                &scope.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": scope.name}),
+            )
+            .await?;
+            Ok(scope)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.telescope.create",
+                &req.name,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Update an existing telescope.
@@ -126,9 +314,36 @@ pub async fn create_telescope(
 /// Returns `ContractError` if the telescope is not found.
 pub async fn update_telescope(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &UpdateTelescope,
 ) -> Result<Telescope, ContractError> {
-    repo::update_telescope(pool, req).await.map_err(db_to_contract)
+    match repo::update_telescope(pool, req).await {
+        Ok(scope) => {
+            write_equipment_audit(
+                bus,
+                "equipment.telescope.update",
+                &scope.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": scope.name}),
+            )
+            .await?;
+            Ok(scope)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.telescope.update",
+                &req.id,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Delete a telescope by ID.
@@ -136,8 +351,13 @@ pub async fn update_telescope(
 /// # Errors
 ///
 /// Returns `ContractError` if the telescope is not found.
-pub async fn delete_telescope(pool: &SqlitePool, id: &str) -> Result<(), ContractError> {
-    repo::delete_telescope(pool, id).await.map_err(db_to_contract)
+pub async fn delete_telescope(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    id: &str,
+) -> Result<(), ContractError> {
+    delete_equipment(bus, "equipment.telescope.delete", id, repo::delete_telescope(pool, id).await)
+        .await
 }
 
 /// Find a telescope by alias, or create one if not found.
@@ -184,9 +404,36 @@ pub async fn list_optical_trains(pool: &SqlitePool) -> Result<Vec<OpticalTrain>,
 /// Returns `ContractError` on database failure.
 pub async fn create_optical_train(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &CreateOpticalTrain,
 ) -> Result<OpticalTrain, ContractError> {
-    repo::create_optical_train(pool, req).await.map_err(db_to_contract)
+    match repo::create_optical_train(pool, req).await {
+        Ok(train) => {
+            write_equipment_audit(
+                bus,
+                "equipment.train.create",
+                &train.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": train.name}),
+            )
+            .await?;
+            Ok(train)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.train.create",
+                &req.name,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Update an existing optical train.
@@ -196,9 +443,36 @@ pub async fn create_optical_train(
 /// Returns `ContractError` if the optical train is not found.
 pub async fn update_optical_train(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &UpdateOpticalTrain,
 ) -> Result<OpticalTrain, ContractError> {
-    repo::update_optical_train(pool, req).await.map_err(db_to_contract)
+    match repo::update_optical_train(pool, req).await {
+        Ok(train) => {
+            write_equipment_audit(
+                bus,
+                "equipment.train.update",
+                &train.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": train.name}),
+            )
+            .await?;
+            Ok(train)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.train.update",
+                &req.id,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Delete an optical train by ID.
@@ -206,8 +480,13 @@ pub async fn update_optical_train(
 /// # Errors
 ///
 /// Returns `ContractError` if the optical train is not found.
-pub async fn delete_optical_train(pool: &SqlitePool, id: &str) -> Result<(), ContractError> {
-    repo::delete_optical_train(pool, id).await.map_err(db_to_contract)
+pub async fn delete_optical_train(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    id: &str,
+) -> Result<(), ContractError> {
+    delete_equipment(bus, "equipment.train.delete", id, repo::delete_optical_train(pool, id).await)
+        .await
 }
 
 // ── Filter use cases ───────────────────────────────────────────────────────
@@ -226,8 +505,38 @@ pub async fn list_filters(pool: &SqlitePool) -> Result<Vec<Filter>, ContractErro
 /// # Errors
 ///
 /// Returns `ContractError` on duplicate name or database failure.
-pub async fn create_filter(pool: &SqlitePool, req: &CreateFilter) -> Result<Filter, ContractError> {
-    repo::create_filter(pool, req).await.map_err(db_to_contract)
+pub async fn create_filter(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    req: &CreateFilter,
+) -> Result<Filter, ContractError> {
+    match repo::create_filter(pool, req).await {
+        Ok(filter) => {
+            write_equipment_audit(
+                bus,
+                "equipment.filter.create",
+                &filter.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": filter.name}),
+            )
+            .await?;
+            Ok(filter)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.filter.create",
+                &req.name,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Update an existing filter.
@@ -235,8 +544,38 @@ pub async fn create_filter(pool: &SqlitePool, req: &CreateFilter) -> Result<Filt
 /// # Errors
 ///
 /// Returns `ContractError` if the filter is not found.
-pub async fn update_filter(pool: &SqlitePool, req: &UpdateFilter) -> Result<Filter, ContractError> {
-    repo::update_filter(pool, req).await.map_err(db_to_contract)
+pub async fn update_filter(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    req: &UpdateFilter,
+) -> Result<Filter, ContractError> {
+    match repo::update_filter(pool, req).await {
+        Ok(filter) => {
+            write_equipment_audit(
+                bus,
+                "equipment.filter.update",
+                &filter.id,
+                Outcome::Applied,
+                None,
+                serde_json::json!({"name": filter.name}),
+            )
+            .await?;
+            Ok(filter)
+        }
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_audit(
+                bus,
+                "equipment.filter.update",
+                &req.id,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": req.name}),
+            )
+            .await?;
+            Err(err)
+        }
+    }
 }
 
 /// Delete a filter by ID.
@@ -244,8 +583,12 @@ pub async fn update_filter(pool: &SqlitePool, req: &UpdateFilter) -> Result<Filt
 /// # Errors
 ///
 /// Returns `ContractError` if the filter is not found.
-pub async fn delete_filter(pool: &SqlitePool, id: &str) -> Result<(), ContractError> {
-    repo::delete_filter(pool, id).await.map_err(db_to_contract)
+pub async fn delete_filter(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    id: &str,
+) -> Result<(), ContractError> {
+    delete_equipment(bus, "equipment.filter.delete", id, repo::delete_filter(pool, id).await).await
 }
 
 /// Find a filter by exact name match, or create one as auto-detected custom.
@@ -271,4 +614,111 @@ pub async fn find_or_create_filter_by_name(
     q_calibration::mark_filter_auto_detected(pool, &filter.id).await.map_err(db_to_contract)?;
 
     Ok(filter)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use persistence_db::Database;
+
+    async fn setup() -> (Database, EventBus) {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        let bus = EventBus::with_pool(db.pool().clone());
+        (db, bus)
+    }
+
+    /// T124/SC-009: `create_camera` writes a durable `Outcome::Applied`
+    /// `audit_log_entry` row tagged `EntityType::Equipment` (previously no
+    /// audit emission at all).
+    #[tokio::test]
+    async fn create_camera_writes_durable_applied_audit_row() {
+        let (db, bus) = setup().await;
+        let req = CreateCamera { name: "ZWO ASI2600MM".to_owned(), aliases: vec![] };
+        let camera = create_camera(db.pool(), &bus, &req).await.unwrap();
+
+        let row: (String, String) = sqlx::query_as(
+            "SELECT entity_type, outcome FROM audit_log_entry WHERE trigger = 'equipment.camera.create'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("create_camera must write a durable audit row");
+        assert_eq!(row.0, "equipment");
+        assert_eq!(row.1, "applied");
+        assert!(!camera.id.is_empty());
+    }
+
+    /// T127 "equipment failed": deleting a nonexistent camera writes a
+    /// durable `Outcome::Failed` row with a reason_code (FR-130).
+    #[tokio::test]
+    async fn delete_camera_missing_writes_durable_failed_row() {
+        let (db, bus) = setup().await;
+        let err = delete_camera(db.pool(), &bus, "does-not-exist").await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::EquipmentNotFound);
+
+        let row: (String, String, Option<String>) = sqlx::query_as(
+            "SELECT entity_type, outcome, reason_code FROM audit_log_entry WHERE trigger = 'equipment.camera.delete'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("failed delete_camera must write a durable audit row");
+        assert_eq!(row.0, "equipment");
+        assert_eq!(row.1, "failed");
+        assert_eq!(row.2.as_deref(), Some("equipment.not_found"));
+    }
+
+    /// Update/delete round trip for optical trains and filters, spot-checking
+    /// that every equipment kind (not just cameras) writes durable rows.
+    #[tokio::test]
+    async fn optical_train_and_filter_crud_write_durable_rows() {
+        let (db, bus) = setup().await;
+
+        let train = create_optical_train(
+            db.pool(),
+            &bus,
+            &CreateOpticalTrain {
+                name: "Main rig".to_owned(),
+                telescope_id: None,
+                camera_id: None,
+                focal_length_mm: 800,
+            },
+        )
+        .await
+        .unwrap();
+        delete_optical_train(db.pool(), &bus, &train.id).await.unwrap();
+
+        // "Custom-Ha-7nm"/"Custom-Ha-3nm": migration 0007 seeds standard names
+        // ("Ha", "SII", "L", ...); avoid colliding with the seeded rows.
+        let filter = create_filter(
+            db.pool(),
+            &bus,
+            &CreateFilter {
+                name: "Custom-Ha-7nm".to_owned(),
+                category: FilterCategory::Narrowband,
+            },
+        )
+        .await
+        .unwrap();
+        update_filter(
+            db.pool(),
+            &bus,
+            &UpdateFilter {
+                id: filter.id.clone(),
+                name: "Custom-Ha-3nm".to_owned(),
+                category: FilterCategory::Narrowband,
+            },
+        )
+        .await
+        .unwrap();
+
+        let count: (i64,) = sqlx::query_as(
+            "SELECT COUNT(*) FROM audit_log_entry WHERE entity_type = 'equipment' AND outcome = 'applied'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(count.0, 4, "create+delete train and create+update filter = 4 applied rows");
+    }
 }

--- a/crates/app/calibration/src/equipment.rs
+++ b/crates/app/calibration/src/equipment.rs
@@ -60,9 +60,64 @@ fn equipment_entity_id(id: &str) -> EntityId {
 
 /// Write a durable audit row for an equipment CRUD attempt (T124,
 /// FR-130/FR-131). `id_seed` is the item's real id on success/update/delete,
-/// or its attempted `name` on a failed `create` (no id exists yet).
+/// or its attempted `name` on a failed `create` (no id exists yet). User-
+/// initiated CRUD is `actor="user"`/`Severity::Workflow` per the data-model
+/// severity table; see [`write_equipment_system_audit`] for the
+/// system-initiated auto-detect variant.
 async fn write_equipment_audit(
     bus: &EventBus,
+    action: &str,
+    id_seed: &str,
+    outcome: Outcome,
+    reason_code: Option<&str>,
+    payload: serde_json::Value,
+) -> Result<(), ContractError> {
+    write_equipment_audit_as(
+        bus,
+        "user",
+        Severity::Workflow,
+        Source::User,
+        action,
+        id_seed,
+        outcome,
+        reason_code,
+        payload,
+    )
+    .await
+}
+
+/// System-initiated variant of [`write_equipment_audit`] for auto-detect
+/// creates (`find_or_create_*_by_alias`/`_by_name`) — `actor="system"`,
+/// `Severity::Diagnostic` per data-model.md's severity-per-mutation-class
+/// table (review round 1 #4: "system/periodic = diagnostic").
+async fn write_equipment_system_audit(
+    bus: &EventBus,
+    action: &str,
+    id_seed: &str,
+    outcome: Outcome,
+    reason_code: Option<&str>,
+    payload: serde_json::Value,
+) -> Result<(), ContractError> {
+    write_equipment_audit_as(
+        bus,
+        "system",
+        Severity::Diagnostic,
+        Source::System,
+        action,
+        id_seed,
+        outcome,
+        reason_code,
+        payload,
+    )
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn write_equipment_audit_as(
+    bus: &EventBus,
+    actor: &str,
+    severity: Severity,
+    source: Source,
     action: &str,
     id_seed: &str,
     outcome: Outcome,
@@ -73,9 +128,9 @@ async fn write_equipment_audit(
         EntityType::Equipment,
         equipment_entity_id(id_seed),
         action,
-        "user",
+        actor,
         outcome,
-        Severity::Workflow,
+        severity,
         EntityId::new(),
     )
     .with_payload(payload);
@@ -85,7 +140,7 @@ async fn write_equipment_audit(
     bus.write_audit(
         entry,
         "equipment.changed",
-        Source::User,
+        source,
         serde_json::json!({"action": action, "outcome": outcome.as_str()}),
     )
     .await
@@ -240,6 +295,7 @@ pub async fn delete_camera(
 /// Returns `ContractError` on database failure.
 pub async fn find_or_create_camera_by_alias(
     pool: &SqlitePool,
+    bus: &EventBus,
     alias: &str,
 ) -> Result<Camera, ContractError> {
     if let Some(camera) = repo::find_camera_by_alias(pool, alias).await.map_err(db_to_contract)? {
@@ -248,11 +304,39 @@ pub async fn find_or_create_camera_by_alias(
 
     // Create as auto-detected — the alias becomes both the name and the sole alias.
     let req = CreateCamera { name: alias.to_owned(), aliases: vec![alias.to_owned()] };
-    let mut camera = repo::create_camera(pool, &req).await.map_err(db_to_contract)?;
+    let mut camera = match repo::create_camera(pool, &req).await {
+        Ok(camera) => camera,
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_system_audit(
+                bus,
+                "equipment.camera.create",
+                alias,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": alias, "autoDetected": true}),
+            )
+            .await?;
+            return Err(err);
+        }
+    };
     camera.auto_detected = true;
 
     // Mark auto_detected in the database.
     q_calibration::mark_camera_auto_detected(pool, &camera.id).await.map_err(db_to_contract)?;
+
+    // Review round 1 #4: auto-detect creates a durable equipment row via a
+    // system-initiated mutation — audited at Severity::Diagnostic (data-model
+    // severity table), not Severity::Workflow like explicit user CRUD.
+    write_equipment_system_audit(
+        bus,
+        "equipment.camera.create",
+        &camera.id,
+        Outcome::Applied,
+        None,
+        serde_json::json!({"name": camera.name, "autoDetected": true}),
+    )
+    .await?;
 
     Ok(camera)
 }
@@ -367,6 +451,7 @@ pub async fn delete_telescope(
 /// Returns `ContractError` on database failure.
 pub async fn find_or_create_telescope_by_alias(
     pool: &SqlitePool,
+    bus: &EventBus,
     alias: &str,
 ) -> Result<Telescope, ContractError> {
     if let Some(scope) = repo::find_telescope_by_alias(pool, alias).await.map_err(db_to_contract)? {
@@ -378,10 +463,35 @@ pub async fn find_or_create_telescope_by_alias(
         aliases: vec![alias.to_owned()],
         focal_length_mm: None,
     };
-    let mut scope = repo::create_telescope(pool, &req).await.map_err(db_to_contract)?;
+    let mut scope = match repo::create_telescope(pool, &req).await {
+        Ok(scope) => scope,
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_system_audit(
+                bus,
+                "equipment.telescope.create",
+                alias,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": alias, "autoDetected": true}),
+            )
+            .await?;
+            return Err(err);
+        }
+    };
     scope.auto_detected = true;
 
     q_calibration::mark_telescope_auto_detected(pool, &scope.id).await.map_err(db_to_contract)?;
+
+    write_equipment_system_audit(
+        bus,
+        "equipment.telescope.create",
+        &scope.id,
+        Outcome::Applied,
+        None,
+        serde_json::json!({"name": scope.name, "autoDetected": true}),
+    )
+    .await?;
 
     Ok(scope)
 }
@@ -598,6 +708,7 @@ pub async fn delete_filter(
 /// Returns `ContractError` on database failure.
 pub async fn find_or_create_filter_by_name(
     pool: &SqlitePool,
+    bus: &EventBus,
     name: &str,
 ) -> Result<Filter, ContractError> {
     // Try exact name match in the existing list.
@@ -608,10 +719,35 @@ pub async fn find_or_create_filter_by_name(
 
     // Create as auto-detected custom filter.
     let req = CreateFilter { name: name.to_owned(), category: FilterCategory::Custom };
-    let mut filter = repo::create_filter(pool, &req).await.map_err(db_to_contract)?;
+    let mut filter = match repo::create_filter(pool, &req).await {
+        Ok(filter) => filter,
+        Err(e) => {
+            let err = db_to_contract(e);
+            write_equipment_system_audit(
+                bus,
+                "equipment.filter.create",
+                name,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+                serde_json::json!({"name": name, "autoDetected": true}),
+            )
+            .await?;
+            return Err(err);
+        }
+    };
     filter.auto_detected = true;
 
     q_calibration::mark_filter_auto_detected(pool, &filter.id).await.map_err(db_to_contract)?;
+
+    write_equipment_system_audit(
+        bus,
+        "equipment.filter.create",
+        &filter.id,
+        Outcome::Applied,
+        None,
+        serde_json::json!({"name": filter.name, "autoDetected": true}),
+    )
+    .await?;
 
     Ok(filter)
 }
@@ -667,6 +803,28 @@ mod tests {
         assert_eq!(row.0, "equipment");
         assert_eq!(row.1, "failed");
         assert_eq!(row.2.as_deref(), Some("equipment.not_found"));
+    }
+
+    /// Review round 1 #4: `find_or_create_camera_by_alias` auto-detect create
+    /// writes a durable row at `Severity::Diagnostic` with `actor="system"`
+    /// (system-initiated), not `Severity::Workflow`/`"user"` like explicit
+    /// CRUD (data-model.md severity-per-mutation-class table).
+    #[tokio::test]
+    async fn find_or_create_camera_by_alias_writes_diagnostic_system_audit_row() {
+        let (db, bus) = setup().await;
+        let camera =
+            find_or_create_camera_by_alias(db.pool(), &bus, "ASI294MM Auto").await.unwrap();
+        assert!(camera.auto_detected);
+
+        let row: (String, String, String) = sqlx::query_as(
+            "SELECT actor, severity, outcome FROM audit_log_entry WHERE trigger = 'equipment.camera.create'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("find_or_create_camera_by_alias must write a durable audit row");
+        assert_eq!(row.0, "system");
+        assert_eq!(row.1, "diagnostic");
+        assert_eq!(row.2, "applied");
     }
 
     /// Update/delete round trip for optical trains and filters, spot-checking

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -44,7 +44,10 @@ thiserror.workspace = true
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }
-uuid = { workspace = true }
+# "v5" beyond the workspace default ("v4"): deterministic audit `entity_id`
+# derivation for protection/source/root mutations (T123/T125, spec 030
+# FR-133), same pattern as `crates/targeting/Cargo.toml`.
+uuid = { version = "1", features = ["serde", "v4", "v5"] }
 
 [dev-dependencies]
 app_core_cache = { path = "../cache" }

--- a/crates/app/core/src/audit_ids.rs
+++ b/crates/app/core/src/audit_ids.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Deterministic `entity_id` derivation for durable audit rows whose real
+//! identity is a plain string, not a UUID (spec 030 FR-133, T123/T125).
+//!
+//! Shared by `protection.rs` (source ids, plan/item ids) and `first_run.rs`
+//! (attempted registration paths that never got a source id). UUIDv5 keeps
+//! every audit row for the same real-world id correlated under one
+//! `entity_id`, without requiring that id to already be a UUID — the same
+//! technique `crates/targeting/src/identity.rs` uses for target ids.
+
+use domain_core::ids::EntityId;
+
+/// Derive a stable UUIDv5 `entity_id` from `namespace` (a fixed per-call-site
+/// tag, e.g. `"protection.source"`) and `seed` (the real-world string id,
+/// e.g. a source id or attempted path).
+pub(crate) fn deterministic_entity_id(namespace: &str, seed: &str) -> EntityId {
+    let ns = uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_DNS,
+        format!("astro-plan.audit.{namespace}").as_bytes(),
+    );
+    EntityId::from_uuid(uuid::Uuid::new_v5(&ns, seed.as_bytes()))
+}

--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -225,7 +225,25 @@ pub async fn register_source(
         .await?;
         return Err(e);
     }
-    let resp = repo::register_source(pool, req).await.map_err(db_to_contract)?;
+    let resp = match repo::register_source(pool, req).await {
+        Ok(resp) => resp,
+        Err(e) => {
+            // FIX (review round 1 #2): the DB write was attempted (validation
+            // + duplicate check already passed) and failed — audit as
+            // `Failed`, not silently propagated.
+            let err = db_to_contract(e);
+            write_source_register_audit(
+                bus,
+                &req.path,
+                &req.path,
+                req.kind,
+                Outcome::Failed,
+                Some(&error_code_str(err.code)),
+            )
+            .await?;
+            return Err(err);
+        }
+    };
     // Invalidate after commit (F0 contract): a freshly registered id can't
     // already be cached, but this keeps the write site authoritative if a
     // removed root's id is ever reused.
@@ -294,6 +312,106 @@ pub async fn get_source_organization_state(
     Ok(state)
 }
 
+/// Validate every batch item, splitting into immediate `Failure` `BatchItem`s
+/// (audited `Refused`) and the still-pending `(original_index, source)`
+/// pairs the repository batch call will attempt. Extracted from
+/// `register_source_batch` to keep it under clippy's line budget.
+async fn partition_batch_sources<'a>(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    sources: &'a [RegisterSourceRequest],
+) -> Result<
+    (Vec<contracts_core::first_run::BatchItem>, Vec<(usize, &'a RegisterSourceRequest)>),
+    ContractError,
+> {
+    use contracts_core::first_run::{BatchItem, ItemStatus};
+
+    let mut items: Vec<BatchItem> = Vec::with_capacity(sources.len());
+    let mut valid_sources: Vec<(usize, &RegisterSourceRequest)> = Vec::new();
+
+    for (index, source) in sources.iter().enumerate() {
+        // Short-circuit: only check for a duplicate once the path itself is valid.
+        let validation_err = match validate_path(&source.path) {
+            Err(e) => Some(*e),
+            Ok(()) => check_duplicate(pool, &source.path, source.kind).await.err(),
+        };
+        let Some(e) = validation_err else {
+            valid_sources.push((index, source));
+            continue;
+        };
+        let code_str = error_code_str(e.code);
+        write_source_register_audit(
+            bus,
+            &source.path,
+            &source.path,
+            source.kind,
+            Outcome::Refused,
+            Some(&code_str),
+        )
+        .await?;
+        items.push(BatchItem {
+            index,
+            status: ItemStatus::Failure,
+            source_id: None,
+            error: Some(code_str),
+            error_detail: Some(JsonAny::new(serde_json::json!({ "message": e.message }))),
+        });
+    }
+
+    Ok((items, valid_sources))
+}
+
+/// Audit + map the repository batch call's per-item results back to
+/// `BatchItem`s. Extracted from `register_source_batch` to keep it under
+/// clippy's line budget; audits `Failure` items too (review round 1 #3 —
+/// these were previously dropped without a durable row).
+async fn audit_batch_results(
+    bus: &EventBus,
+    valid_sources: &[(usize, &RegisterSourceRequest)],
+    repo_items: Vec<contracts_core::first_run::BatchItem>,
+) -> Result<Vec<contracts_core::first_run::BatchItem>, ContractError> {
+    use contracts_core::first_run::{BatchItem, ItemStatus};
+
+    let mut items = Vec::with_capacity(repo_items.len());
+    for (batch_idx, repo_item) in repo_items.into_iter().enumerate() {
+        let (original_index, source) = valid_sources[batch_idx];
+        match repo_item.status {
+            ItemStatus::Success => {
+                if let Some(source_id) = &repo_item.source_id {
+                    write_source_register_audit(
+                        bus,
+                        source_id,
+                        &source.path,
+                        source.kind,
+                        Outcome::Applied,
+                        None,
+                    )
+                    .await?;
+                }
+            }
+            ItemStatus::Failure => {
+                write_source_register_audit(
+                    bus,
+                    &source.path,
+                    &source.path,
+                    source.kind,
+                    Outcome::Failed,
+                    repo_item.error.as_deref(),
+                )
+                .await?;
+            }
+        }
+        items.push(BatchItem {
+            index: original_index,
+            status: repo_item.status,
+            source_id: repo_item.source_id,
+            error: repo_item.error,
+            error_detail: repo_item.error_detail,
+        });
+    }
+    Ok(items)
+}
+
 /// Register multiple sources with per-item path validation.
 ///
 /// Items that fail validation are marked as failures in the batch response
@@ -307,88 +425,40 @@ pub async fn register_source_batch(
     bus: &EventBus,
     req: &RegisterSourceBatchRequest,
 ) -> Result<RegisterSourceBatchResponse, ContractError> {
+    use contracts_core::first_run::{BatchStatus, ItemStatus};
+
     // Pre-validate all paths and build a filtered request for the repository.
     // Items that fail validation are recorded as failures immediately.
-    use contracts_core::first_run::{BatchItem, BatchStatus, ItemStatus};
-
-    let mut items: Vec<BatchItem> = Vec::with_capacity(req.sources.len());
-    let mut valid_sources: Vec<(usize, &RegisterSourceRequest)> = Vec::new();
-
-    for (index, source) in req.sources.iter().enumerate() {
-        if let Err(e) = validate_path(&source.path) {
-            let code_str = error_code_str(e.code);
-            write_source_register_audit(
-                bus,
-                &source.path,
-                &source.path,
-                source.kind,
-                Outcome::Refused,
-                Some(&code_str),
-            )
-            .await?;
-            items.push(BatchItem {
-                index,
-                status: ItemStatus::Failure,
-                source_id: None,
-                error: Some(code_str),
-                error_detail: Some(JsonAny::new(serde_json::json!({ "message": e.message }))),
-            });
-        } else if let Err(e) = check_duplicate(pool, &source.path, source.kind).await {
-            let code_str = error_code_str(e.code);
-            write_source_register_audit(
-                bus,
-                &source.path,
-                &source.path,
-                source.kind,
-                Outcome::Refused,
-                Some(&code_str),
-            )
-            .await?;
-            items.push(BatchItem {
-                index,
-                status: ItemStatus::Failure,
-                source_id: None,
-                error: Some(code_str),
-                error_detail: Some(JsonAny::new(serde_json::json!({ "message": e.message }))),
-            });
-        } else {
-            valid_sources.push((index, source));
-        }
-    }
+    let (mut items, valid_sources) = partition_batch_sources(pool, bus, &req.sources).await?;
 
     // Register validated sources via the repository batch.
     if !valid_sources.is_empty() {
         let batch_req = RegisterSourceBatchRequest {
             sources: valid_sources.iter().map(|(_, s)| (*s).clone()).collect(),
         };
-        let batch_resp =
-            repo::register_source_batch(pool, &batch_req).await.map_err(db_to_contract)?;
-
-        // Map repository batch items back to original indices.
-        for (batch_idx, repo_item) in batch_resp.items.into_iter().enumerate() {
-            let original_index = valid_sources[batch_idx].0;
-            if repo_item.status == ItemStatus::Success {
-                if let Some(source_id) = &repo_item.source_id {
-                    let (_, source) = valid_sources[batch_idx];
+        let batch_resp = match repo::register_source_batch(pool, &batch_req).await {
+            Ok(resp) => resp,
+            Err(e) => {
+                // FIX (review round 1 #2): a catastrophic whole-batch failure
+                // (connection loss) — every still-pending item was an
+                // attempted registration; audit each as `Failed`.
+                let err = db_to_contract(e);
+                let reason = error_code_str(err.code);
+                for (_, source) in &valid_sources {
                     write_source_register_audit(
                         bus,
-                        source_id,
+                        &source.path,
                         &source.path,
                         source.kind,
-                        Outcome::Applied,
-                        None,
+                        Outcome::Failed,
+                        Some(&reason),
                     )
                     .await?;
                 }
+                return Err(err);
             }
-            items.push(BatchItem {
-                index: original_index,
-                status: repo_item.status,
-                source_id: repo_item.source_id,
-                error: repo_item.error,
-                error_detail: repo_item.error_detail,
-            });
-        }
+        };
+        items.extend(audit_batch_results(bus, &valid_sources, batch_resp.items).await?);
     }
 
     // Sort items by original index for deterministic output.
@@ -623,7 +693,20 @@ pub async fn apply_root_remap(
         return Err(*e);
     }
 
-    repo::set_source_path(pool, root_id, new_path).await.map_err(db_to_contract)?;
+    if let Err(e) = repo::set_source_path(pool, root_id, new_path).await {
+        // FIX (review round 1 #2): the write was attempted (root exists,
+        // new_path validated) and failed — audit as `Failed`.
+        let err = db_to_contract(e);
+        write_root_op_refusal(
+            bus,
+            root_id,
+            "root.remap.apply",
+            Outcome::Failed,
+            &error_code_str(err.code),
+        )
+        .await?;
+        return Err(err);
+    }
     // Invalidate after commit (F0 contract) so the next read reloads the new path.
     caches::invalidate_library_root(root_id);
 
@@ -726,7 +809,20 @@ pub async fn set_source_active(
         }
     };
 
-    repo::set_source_active(pool, root_id, active).await.map_err(db_to_contract)?;
+    if let Err(e) = repo::set_source_active(pool, root_id, active).await {
+        // FIX (review round 1 #2): the write was attempted (root exists) and
+        // failed — audit as `Failed`.
+        let err = db_to_contract(e);
+        write_root_op_refusal(
+            bus,
+            root_id,
+            "root.active_changed",
+            Outcome::Failed,
+            &error_code_str(err.code),
+        )
+        .await?;
+        return Err(err);
+    }
 
     // Write durable audit row + live event (T125, FR-130/FR-131).
     let entry = AuditLogEntry::new(
@@ -790,7 +886,23 @@ pub async fn delete_source(
         }
     };
 
-    let counts = repo::count_root_dependents(pool, root_id).await.map_err(db_to_contract)?;
+    let counts = match repo::count_root_dependents(pool, root_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            // FIX (review round 1 #2): the dependents check was attempted
+            // (root exists) and failed — audit as `Failed`.
+            let err = db_to_contract(e);
+            write_root_op_refusal(
+                bus,
+                root_id,
+                "root.deleted",
+                Outcome::Failed,
+                &error_code_str(err.code),
+            )
+            .await?;
+            return Err(err);
+        }
+    };
     if !counts.is_empty() {
         write_root_op_refusal(
             bus,
@@ -810,7 +922,20 @@ pub async fn delete_source(
         .with_details(details));
     }
 
-    repo::remove_source(pool, root_id).await.map_err(db_to_contract)?;
+    if let Err(e) = repo::remove_source(pool, root_id).await {
+        // FIX (review round 1 #2): the delete was attempted (root exists, no
+        // dependents) and failed — audit as `Failed`.
+        let err = db_to_contract(e);
+        write_root_op_refusal(
+            bus,
+            root_id,
+            "root.deleted",
+            Outcome::Failed,
+            &error_code_str(err.code),
+        )
+        .await?;
+        return Err(err);
+    }
     // Invalidate after commit: the root row (and its path) no longer exists,
     // so a still-cached path would otherwise resurface for a deleted root.
     caches::invalidate_library_root(root_id);

--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -19,6 +19,7 @@ use audit::event_bus::{
     FirstRunCompleted, RootActiveChanged, RootDeleted, RootRemapped, Source, SourceCountByKind,
     TOPIC_FIRST_RUN_COMPLETED, TOPIC_ROOT_ACTIVE_CHANGED, TOPIC_ROOT_DELETED, TOPIC_ROOT_REMAPPED,
 };
+use audit::{AuditLogEntry, Outcome, Severity};
 use contracts_core::first_run::{
     FirstRunCompleteResponse, FirstRunRestartResponse, FirstRunStateResponse, OrganizationState,
     RegisterSourceBatchRequest, RegisterSourceBatchResponse, RegisterSourceRequest,
@@ -27,10 +28,14 @@ use contracts_core::first_run::{
 };
 use contracts_core::roots::{RemapSample, RemapVerification};
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity, JsonAny};
+use domain_core::ids::EntityId;
+use domain_core::lifecycle::data_asset::EntityType;
 use persistence_db::repositories::first_run as repo;
 use sqlx::SqlitePool;
 
+use crate::audit_ids::deterministic_entity_id;
 use crate::caches;
+use crate::errors::bus_err;
 
 /// Maximum number of previously-recorded relative paths sampled by
 /// `remap_root` to preview whether they resolve under a candidate new path.
@@ -138,6 +143,51 @@ fn db_to_contract(e: persistence_db::DbError) -> ContractError {
     }
 }
 
+/// Render an `ErrorCode` as its dotted wire string (e.g. `"path.not_exists"`),
+/// for use as an audit `reason_code`.
+fn error_code_str(code: ErrorCode) -> String {
+    serde_json::to_string(&code)
+        .map_or_else(|_| "internal.error".to_owned(), |s| s.trim_matches('"').to_owned())
+}
+
+/// Write a durable audit row for a `source.register` attempt (T125,
+/// FR-130/FR-131). `entity_seed` is the created `source_id` on success, or
+/// the attempted `path` on refusal (no source id exists yet, so repeated
+/// refused attempts against the same path still correlate under one
+/// `entity_id`).
+async fn write_source_register_audit(
+    bus: &EventBus,
+    entity_seed: &str,
+    path: &str,
+    kind: SourceKind,
+    outcome: Outcome,
+    reason_code: Option<&str>,
+) -> Result<(), ContractError> {
+    let kind_str: &'static str = kind.into();
+    let mut entry = AuditLogEntry::new(
+        EntityType::DataSource,
+        deterministic_entity_id("source", entity_seed),
+        "source.register",
+        "user",
+        outcome,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(serde_json::json!({"path": path, "kind": kind_str}));
+    if let Some(code) = reason_code {
+        entry = entry.with_reason_code(code.to_owned());
+    }
+    bus.write_audit(
+        entry,
+        "source.registered",
+        Source::User,
+        serde_json::json!({"path": path, "kind": kind_str, "outcome": outcome.as_str()}),
+    )
+    .await
+    .map_err(bus_err)?;
+    Ok(())
+}
+
 // ── Use cases ───────────────────────────────────────────────────────────────
 
 /// Register a single source directory with path validation.
@@ -148,15 +198,40 @@ fn db_to_contract(e: persistence_db::DbError) -> ContractError {
 /// duplicate detection, or database failures.
 pub async fn register_source(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &RegisterSourceRequest,
 ) -> Result<RegisterSourceResponse, ContractError> {
-    validate_path(&req.path).map_err(|e| *e)?;
-    check_duplicate(pool, &req.path, req.kind).await?;
+    if let Err(e) = validate_path(&req.path) {
+        write_source_register_audit(
+            bus,
+            &req.path,
+            &req.path,
+            req.kind,
+            Outcome::Refused,
+            Some(&error_code_str(e.code)),
+        )
+        .await?;
+        return Err(*e);
+    }
+    if let Err(e) = check_duplicate(pool, &req.path, req.kind).await {
+        write_source_register_audit(
+            bus,
+            &req.path,
+            &req.path,
+            req.kind,
+            Outcome::Refused,
+            Some(&error_code_str(e.code)),
+        )
+        .await?;
+        return Err(e);
+    }
     let resp = repo::register_source(pool, req).await.map_err(db_to_contract)?;
     // Invalidate after commit (F0 contract): a freshly registered id can't
     // already be cached, but this keeps the write site authoritative if a
     // removed root's id is ever reused.
     caches::invalidate_library_root(&resp.source_id);
+    write_source_register_audit(bus, &resp.source_id, &req.path, req.kind, Outcome::Applied, None)
+        .await?;
     Ok(resp)
 }
 
@@ -229,6 +304,7 @@ pub async fn get_source_organization_state(
 /// Returns `ContractError` only for catastrophic failures (connection loss).
 pub async fn register_source_batch(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &RegisterSourceBatchRequest,
 ) -> Result<RegisterSourceBatchResponse, ContractError> {
     // Pre-validate all paths and build a filtered request for the repository.
@@ -240,8 +316,16 @@ pub async fn register_source_batch(
 
     for (index, source) in req.sources.iter().enumerate() {
         if let Err(e) = validate_path(&source.path) {
-            let code_str = serde_json::to_string(&e.code)
-                .map_or_else(|_| "internal.error".to_owned(), |s| s.trim_matches('"').to_owned());
+            let code_str = error_code_str(e.code);
+            write_source_register_audit(
+                bus,
+                &source.path,
+                &source.path,
+                source.kind,
+                Outcome::Refused,
+                Some(&code_str),
+            )
+            .await?;
             items.push(BatchItem {
                 index,
                 status: ItemStatus::Failure,
@@ -250,8 +334,16 @@ pub async fn register_source_batch(
                 error_detail: Some(JsonAny::new(serde_json::json!({ "message": e.message }))),
             });
         } else if let Err(e) = check_duplicate(pool, &source.path, source.kind).await {
-            let code_str = serde_json::to_string(&e.code)
-                .map_or_else(|_| "internal.error".to_owned(), |s| s.trim_matches('"').to_owned());
+            let code_str = error_code_str(e.code);
+            write_source_register_audit(
+                bus,
+                &source.path,
+                &source.path,
+                source.kind,
+                Outcome::Refused,
+                Some(&code_str),
+            )
+            .await?;
             items.push(BatchItem {
                 index,
                 status: ItemStatus::Failure,
@@ -275,6 +367,20 @@ pub async fn register_source_batch(
         // Map repository batch items back to original indices.
         for (batch_idx, repo_item) in batch_resp.items.into_iter().enumerate() {
             let original_index = valid_sources[batch_idx].0;
+            if repo_item.status == ItemStatus::Success {
+                if let Some(source_id) = &repo_item.source_id {
+                    let (_, source) = valid_sources[batch_idx];
+                    write_source_register_audit(
+                        bus,
+                        source_id,
+                        &source.path,
+                        source.kind,
+                        Outcome::Applied,
+                        None,
+                    )
+                    .await?;
+                }
+            }
             items.push(BatchItem {
                 index: original_index,
                 status: repo_item.status,
@@ -490,28 +596,99 @@ pub async fn apply_root_remap(
     new_path: &str,
     verified: bool,
 ) -> Result<(), ContractError> {
-    let (_, original_path) = get_root_or_not_found(pool, root_id).await?;
+    let (_, original_path) = match get_root_or_not_found(pool, root_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            write_root_op_refusal(
+                bus,
+                root_id,
+                "root.remap.apply",
+                Outcome::Failed,
+                &error_code_str(e.code),
+            )
+            .await?;
+            return Err(e);
+        }
+    };
 
-    validate_path(new_path).map_err(|e| *e)?;
+    if let Err(e) = validate_path(new_path) {
+        write_root_op_refusal(
+            bus,
+            root_id,
+            "root.remap.apply",
+            Outcome::Refused,
+            &error_code_str(e.code),
+        )
+        .await?;
+        return Err(*e);
+    }
 
     repo::set_source_path(pool, root_id, new_path).await.map_err(db_to_contract)?;
     // Invalidate after commit (F0 contract) so the next read reloads the new path.
     caches::invalidate_library_root(root_id);
 
-    // Publish audit event (best-effort; do not fail the operation if the bus drops).
-    let _ = bus
-        .publish(
-            TOPIC_ROOT_REMAPPED,
-            Source::User,
-            RootRemapped {
-                root_id: root_id.to_owned(),
-                original_path,
-                new_path: new_path.to_owned(),
-                verified,
-            },
-        )
-        .await;
+    // Write durable audit row + live event (T125, FR-130/FR-131).
+    let entry = AuditLogEntry::new(
+        EntityType::LibraryRoot,
+        deterministic_entity_id("root", root_id),
+        "root.remap.apply",
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(
+        serde_json::json!({"before": original_path, "after": new_path, "verified": verified}),
+    );
+    bus.write_audit(
+        entry,
+        TOPIC_ROOT_REMAPPED,
+        Source::User,
+        RootRemapped {
+            root_id: root_id.to_owned(),
+            original_path,
+            new_path: new_path.to_owned(),
+            verified,
+        },
+    )
+    .await
+    .map_err(bus_err)?;
 
+    Ok(())
+}
+
+/// Write a durable `Outcome::Failed` audit row for a root operation attempted
+/// against a missing/invalid root (T125/T127, FR-130). `action` names the
+/// specific operation (`root.remap.apply`, `root.active_changed`,
+/// `root.deleted`) so refusals for different root ops stay distinguishable
+/// under the same `entity_id`. `outcome` is `Failed` for a not-found/DB-level
+/// failure or `Refused` for a business-rule block (e.g. `root.has_dependents`).
+async fn write_root_op_refusal(
+    bus: &EventBus,
+    root_id: &str,
+    action: &str,
+    outcome: Outcome,
+    reason_code: &str,
+) -> Result<(), ContractError> {
+    let entry = AuditLogEntry::new(
+        EntityType::LibraryRoot,
+        deterministic_entity_id("root", root_id),
+        action,
+        "user",
+        outcome,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_reason_code(reason_code.to_owned())
+    .with_payload(serde_json::json!({"rootId": root_id}));
+    bus.write_audit(
+        entry,
+        "root.op_failed",
+        Source::User,
+        serde_json::json!({"rootId": root_id, "action": action, "outcome": outcome.as_str(), "reasonCode": reason_code}),
+    )
+    .await
+    .map_err(bus_err)?;
     Ok(())
 }
 
@@ -534,17 +711,42 @@ pub async fn set_source_active(
     root_id: &str,
     active: bool,
 ) -> Result<(), ContractError> {
-    let (_, path) = get_root_or_not_found(pool, root_id).await?;
+    let (_, path) = match get_root_or_not_found(pool, root_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            write_root_op_refusal(
+                bus,
+                root_id,
+                "root.active_changed",
+                Outcome::Failed,
+                &error_code_str(e.code),
+            )
+            .await?;
+            return Err(e);
+        }
+    };
 
     repo::set_source_active(pool, root_id, active).await.map_err(db_to_contract)?;
 
-    let _ = bus
-        .publish(
-            TOPIC_ROOT_ACTIVE_CHANGED,
-            Source::User,
-            RootActiveChanged { root_id: root_id.to_owned(), path, active },
-        )
-        .await;
+    // Write durable audit row + live event (T125, FR-130/FR-131).
+    let entry = AuditLogEntry::new(
+        EntityType::LibraryRoot,
+        deterministic_entity_id("root", root_id),
+        "root.active_changed",
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(serde_json::json!({"path": path, "active": active}));
+    bus.write_audit(
+        entry,
+        TOPIC_ROOT_ACTIVE_CHANGED,
+        Source::User,
+        RootActiveChanged { root_id: root_id.to_owned(), path, active },
+    )
+    .await
+    .map_err(bus_err)?;
 
     Ok(())
 }
@@ -573,10 +775,31 @@ pub async fn delete_source(
     bus: &EventBus,
     root_id: &str,
 ) -> Result<(), ContractError> {
-    let (kind, path) = get_root_or_not_found(pool, root_id).await?;
+    let (kind, path) = match get_root_or_not_found(pool, root_id).await {
+        Ok(v) => v,
+        Err(e) => {
+            write_root_op_refusal(
+                bus,
+                root_id,
+                "root.deleted",
+                Outcome::Failed,
+                &error_code_str(e.code),
+            )
+            .await?;
+            return Err(e);
+        }
+    };
 
     let counts = repo::count_root_dependents(pool, root_id).await.map_err(db_to_contract)?;
     if !counts.is_empty() {
+        write_root_op_refusal(
+            bus,
+            root_id,
+            "root.deleted",
+            Outcome::Refused,
+            "root.has_dependents",
+        )
+        .await?;
         let details = serde_json::to_value(counts).unwrap_or_default();
         return Err(ContractError::new(
             ErrorCode::RootHasDependents,
@@ -592,14 +815,26 @@ pub async fn delete_source(
     // so a still-cached path would otherwise resurface for a deleted root.
     caches::invalidate_library_root(root_id);
 
+    // Write durable audit row + live event (T125, FR-130/FR-131).
     let kind_str: &'static str = kind.into();
-    let _ = bus
-        .publish(
-            TOPIC_ROOT_DELETED,
-            Source::User,
-            RootDeleted { root_id: root_id.to_owned(), path, kind: kind_str.to_owned() },
-        )
-        .await;
+    let entry = AuditLogEntry::new(
+        EntityType::LibraryRoot,
+        deterministic_entity_id("root", root_id),
+        "root.deleted",
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(serde_json::json!({"path": path, "kind": kind_str}));
+    bus.write_audit(
+        entry,
+        TOPIC_ROOT_DELETED,
+        Source::User,
+        RootDeleted { root_id: root_id.to_owned(), path, kind: kind_str.to_owned() },
+    )
+    .await
+    .map_err(bus_err)?;
 
     Ok(())
 }
@@ -692,6 +927,64 @@ mod tests {
         assert!(!err.retryable);
     }
 
+    /// T125/SC-009: a successful `register_source` writes a durable
+    /// `Outcome::Applied` `audit_log_entry` row tagged `EntityType::DataSource`.
+    #[tokio::test]
+    async fn register_source_writes_durable_applied_audit_row() {
+        let db = persistence_db::Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        let pool = db.pool().clone();
+        let bus = EventBus::with_pool(pool.clone());
+
+        let req = RegisterSourceRequest {
+            kind: SourceKind::LightFrames,
+            path: "/tmp".to_owned(),
+            kind_subtype: None,
+            scan_depth: contracts_core::first_run::ScanDepth::Recursive,
+            organization_state: OrganizationState::Organized,
+        };
+        register_source(&pool, &bus, &req).await.unwrap();
+
+        let row: (String, String) = sqlx::query_as(
+            "SELECT entity_type, outcome FROM audit_log_entry WHERE trigger = 'source.register'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("register_source must write a durable audit row");
+        assert_eq!(row.0, "data_source");
+        assert_eq!(row.1, "applied");
+    }
+
+    /// T127: a refused `register_source` (duplicate path) writes a durable
+    /// `Outcome::Refused` row with a reason_code, per FR-130.
+    #[tokio::test]
+    async fn register_source_refused_duplicate_writes_durable_row() {
+        let db = persistence_db::Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        let pool = db.pool().clone();
+        let bus = EventBus::with_pool(pool.clone());
+
+        let req = RegisterSourceRequest {
+            kind: SourceKind::LightFrames,
+            path: "/tmp".to_owned(),
+            kind_subtype: None,
+            scan_depth: contracts_core::first_run::ScanDepth::Recursive,
+            organization_state: OrganizationState::Organized,
+        };
+        register_source(&pool, &bus, &req).await.unwrap();
+        let err = register_source(&pool, &bus, &req).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::PathAlreadyRegistered);
+
+        let row: (String, Option<String>) = sqlx::query_as(
+            "SELECT outcome, reason_code FROM audit_log_entry WHERE trigger = 'source.register' AND outcome = 'refused'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("refused register_source must write a durable audit row");
+        assert_eq!(row.0, "refused");
+        assert_eq!(row.1.as_deref(), Some("path.already_registered"));
+    }
+
     #[tokio::test]
     async fn complete_first_run_rejects_without_sources() {
         let db = persistence_db::Database::in_memory().await.unwrap();
@@ -762,6 +1055,9 @@ mod tests {
         assert!(preview.all_verified);
     }
 
+    /// T127 "source op failed": an `apply_root_remap` attempted against a
+    /// missing root writes a durable `Outcome::Failed` row tagged
+    /// `EntityType::LibraryRoot`, with a reason_code (FR-130).
     #[tokio::test]
     async fn apply_root_remap_missing_root_returns_not_found() {
         let db = persistence_db::Database::in_memory().await.unwrap();
@@ -772,6 +1068,16 @@ mod tests {
         let err =
             apply_root_remap(&pool, &bus, "nonexistent-root", "/tmp", true).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::SourceNotFound);
+
+        let row: (String, String, Option<String>) = sqlx::query_as(
+            "SELECT entity_type, outcome, reason_code FROM audit_log_entry WHERE trigger = 'root.remap.apply'",
+        )
+        .fetch_one(&pool)
+        .await
+        .expect("failed apply_root_remap must write a durable audit row");
+        assert_eq!(row.0, "library_root");
+        assert_eq!(row.1, "failed");
+        assert_eq!(row.2.as_deref(), Some("source.not_found"));
     }
 
     #[tokio::test]

--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -1061,9 +1061,14 @@ mod tests {
         let pool = db.pool().clone();
         let bus = EventBus::with_pool(pool.clone());
 
+        // CI FIX: `tempfile::tempdir()` (not a hardcoded "/tmp") — mirrors
+        // `crates/app/core/tests/first_run_integration.rs`'s pattern for this
+        // same function; a Unix-only literal path fails `validate_path` on
+        // windows-latest.
+        let dir = tempfile::tempdir().expect("tempdir");
         let req = RegisterSourceRequest {
             kind: SourceKind::LightFrames,
-            path: "/tmp".to_owned(),
+            path: dir.path().to_str().expect("utf8 path").to_owned(),
             kind_subtype: None,
             scan_depth: contracts_core::first_run::ScanDepth::Recursive,
             organization_state: OrganizationState::Organized,
@@ -1089,9 +1094,12 @@ mod tests {
         let pool = db.pool().clone();
         let bus = EventBus::with_pool(pool.clone());
 
+        // CI FIX: see `register_source_writes_durable_applied_audit_row` —
+        // same "/tmp" → tempdir() Windows fix.
+        let dir = tempfile::tempdir().expect("tempdir");
         let req = RegisterSourceRequest {
             kind: SourceKind::LightFrames,
-            path: "/tmp".to_owned(),
+            path: dir.path().to_str().expect("utf8 path").to_owned(),
             kind_subtype: None,
             scan_depth: contracts_core::first_run::ScanDepth::Recursive,
             organization_state: OrganizationState::Organized,

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -60,6 +60,9 @@ pub use targets::{
 // and may reference the extracted domain crates as `crate::errors`,
 // `crate::lifecycle`, etc. via the re-exports above.
 pub mod archive_generator;
+/// Deterministic `entity_id` derivation for audit rows keyed by a plain
+/// string (source id, attempted path) rather than a real UUID (T123/T125).
+mod audit_ids;
 /// Process-global in-memory cache statics for `app_core`-owned domain types
 /// (in-memory caching layer, F0 foundation): `library_root` path lookups and
 /// `source_protection_state`/defaults. See each accessor's doc comment for

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -2146,6 +2146,7 @@ mod tests {
 
         let reg = crate::first_run::register_source(
             db.pool(),
+            &bus,
             &RegisterSourceRequest {
                 kind: SourceKind::Project,
                 path: "/tmp".to_owned(),

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -17,7 +17,10 @@
 use app_core_cache::ProtectionDefaultsSnapshot;
 use audit::bus::EventBus;
 use audit::event_bus::{ProtectionPlanAcknowledged, ProtectionSourceSet, Source};
-use audit::{TOPIC_PROTECTION_PLAN_ACKNOWLEDGED, TOPIC_PROTECTION_SOURCE_SET};
+use audit::{
+    AuditLogEntry, Outcome, Severity, TOPIC_PROTECTION_PLAN_ACKNOWLEDGED,
+    TOPIC_PROTECTION_SOURCE_SET,
+};
 use camino::Utf8Path;
 use contracts_core::protection::{
     NonBlockingSummary, PlanProtectionCheckRequest, PlanProtectionCheckResponse, ProtectedPlanItem,
@@ -25,12 +28,14 @@ use contracts_core::protection::{
     SourceProtectionSetRequest, SourceProtectionSetResponse,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use domain_core::lifecycle::data_asset::EntityType;
 use persistence_db::repositories::plans as plans_repo;
 use persistence_db::repositories::settings as settings_repo;
 use persistence_db::repositories::source_protection as prot_repo;
 use sqlx::SqlitePool;
 use std::sync::Arc;
 
+use crate::audit_ids::deterministic_entity_id;
 use crate::caches;
 
 // ── Error helpers ─────────────────────────────────────────────────────────
@@ -39,7 +44,7 @@ use crate::caches;
 // `DbError::NotFound` to the recoverable `Blocking`/`retryable=false`
 // classification instead of the previous blanket `Fatal` (L2 divergence fix).
 use crate::errors::{bus_err, db_err};
-use domain_core::ids::{new_id, Timestamp};
+use domain_core::ids::{EntityId, Timestamp};
 
 // ── Global settings helpers ───────────────────────────────────────────────
 
@@ -222,23 +227,40 @@ pub async fn set_source_protection(
     // Invalidate after commit (F0 contract) so the next get re-resolves.
     caches::invalidate_source_protection_state(&req.source_id);
 
-    // Emit audit event (T016).
+    // Write durable audit row + live event (T016, T123: FR-130/FR-131).
     let at = Timestamp::now_iso();
-    let audit_id = new_id();
-    bus.publish(
-        TOPIC_PROTECTION_SOURCE_SET,
-        Source::User,
-        ProtectionSourceSet {
-            source_id: req.source_id.clone(),
-            prior_level: prior_level.as_str().to_owned(),
-            new_level: level_str.to_owned(),
-            prior_categories: prior_cats.clone(),
-            new_categories: req.categories.clone(),
-            at,
-        },
+    let entry = AuditLogEntry::new(
+        EntityType::Protection,
+        deterministic_entity_id("protection.source", &req.source_id),
+        "protection.source.set",
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
     )
-    .await
-    .map_err(bus_err)?;
+    .with_payload(serde_json::json!({
+        "sourceId": req.source_id,
+        "before": {"level": prior_level.as_str(), "blockPermanentDelete": prior_bpd, "categories": prior_cats},
+        "after": {"level": level_str, "blockPermanentDelete": req.block_permanent_delete, "categories": req.categories},
+    }));
+    let audit_id = bus
+        .write_audit(
+            entry,
+            TOPIC_PROTECTION_SOURCE_SET,
+            Source::User,
+            ProtectionSourceSet {
+                source_id: req.source_id.clone(),
+                prior_level: prior_level.as_str().to_owned(),
+                new_level: level_str.to_owned(),
+                prior_categories: prior_cats.clone(),
+                new_categories: req.categories.clone(),
+                at,
+            },
+        )
+        .await
+        .map_err(bus_err)?
+        .as_uuid()
+        .to_string();
 
     Ok(SourceProtectionSetResponse {
         source_id: req.source_id.clone(),
@@ -401,21 +423,37 @@ pub async fn acknowledge_protected_item(
     reason: &str,
 ) -> Result<String, ContractError> {
     let at = Timestamp::now_iso();
-    let audit_id = new_id();
-    bus.publish(
-        TOPIC_PROTECTION_PLAN_ACKNOWLEDGED,
-        Source::User,
-        ProtectionPlanAcknowledged {
-            plan_id: plan_id.to_owned(),
-            item_id: item_id.to_owned(),
-            source_id: source_id.map(str::to_owned),
-            resolved_level: resolved_level.to_owned(),
-            reason: reason.to_owned(),
-            at,
-        },
+    let entry = AuditLogEntry::new(
+        EntityType::Protection,
+        deterministic_entity_id("protection.plan_item", &format!("{plan_id}:{item_id}")),
+        "protection.plan.acknowledged",
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
     )
-    .await
-    .map_err(bus_err)?;
+    .with_payload(serde_json::json!({
+        "planId": plan_id, "itemId": item_id, "sourceId": source_id,
+        "resolvedLevel": resolved_level, "reason": reason,
+    }));
+    let audit_id = bus
+        .write_audit(
+            entry,
+            TOPIC_PROTECTION_PLAN_ACKNOWLEDGED,
+            Source::User,
+            ProtectionPlanAcknowledged {
+                plan_id: plan_id.to_owned(),
+                item_id: item_id.to_owned(),
+                source_id: source_id.map(str::to_owned),
+                resolved_level: resolved_level.to_owned(),
+                reason: reason.to_owned(),
+                at,
+            },
+        )
+        .await
+        .map_err(bus_err)?
+        .as_uuid()
+        .to_string();
     Ok(audit_id)
 }
 
@@ -914,6 +952,58 @@ mod tests {
         let resp = set_source_protection(db.pool(), &bus, &set_req).await.unwrap();
         assert_eq!(resp.new_level, ProtectionLevel::Unprotected);
         assert!(!resp.audit_id.is_empty());
+    }
+
+    /// FR-131/SC-009 (T123): `set_source_protection`'s returned `audit_id`
+    /// must resolve to a real durable `audit_log_entry` row (previously
+    /// bus-only), tagged `EntityType::Protection`.
+    #[tokio::test]
+    async fn set_protection_audit_id_resolves_to_durable_row() {
+        let (db, bus, _lock) = setup().await;
+        let set_req = SourceProtectionSetRequest {
+            source_id: "src-003".to_owned(),
+            level: ProtectionLevel::Protected,
+            block_permanent_delete: Some(true),
+            categories: None,
+        };
+        let resp = set_source_protection(db.pool(), &bus, &set_req).await.unwrap();
+
+        let row: (String, String) =
+            sqlx::query_as("SELECT entity_type, outcome FROM audit_log_entry WHERE audit_id = ?")
+                .bind(&resp.audit_id)
+                .fetch_one(db.pool())
+                .await
+                .expect("audit_id must resolve to a durable audit_log_entry row");
+        assert_eq!(row.0, "protection");
+        assert_eq!(row.1, "applied");
+    }
+
+    /// T127: a refused protection-default mutation (`defaultProtection` set to
+    /// an unrecognised level) writes a durable `Outcome::Refused` row tagged
+    /// `EntityType::Protection` with a reason_code, per FR-130.
+    #[tokio::test]
+    async fn set_global_protection_default_refused_writes_durable_row() {
+        let (db, bus, _lock) = setup().await;
+
+        let err = super::set_global_protection_default(
+            db.pool(),
+            &bus,
+            "global",
+            "defaultProtection",
+            serde_json::json!("locked"), // not one of protected/normal/unprotected
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValueInvalid);
+
+        let row: (String, Option<String>) = sqlx::query_as(
+            "SELECT outcome, reason_code FROM audit_log_entry WHERE entity_type = 'protection' AND outcome = 'refused'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("refused protection-default write must write a durable audit row");
+        assert_eq!(row.0, "refused");
+        assert_eq!(row.1.as_deref(), Some("value.invalid"));
     }
 
     #[tokio::test]

--- a/crates/app/core/tests/first_run_integration.rs
+++ b/crates/app/core/tests/first_run_integration.rs
@@ -25,7 +25,7 @@ use tempfile::tempdir;
 
 #[tokio::test]
 async fn register_source_persists_and_reads_back() {
-    let (db, _repo, _bus) = support::setup().await;
+    let (db, _repo, bus) = support::setup().await;
 
     let dir = tempdir().expect("tempdir");
     let path = dir.path().to_str().expect("utf8 path").to_owned();
@@ -38,7 +38,7 @@ async fn register_source_persists_and_reads_back() {
         organization_state: OrganizationState::Organized,
     };
 
-    let resp = first_run::register_source(db.pool(), &req)
+    let resp = first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect("register_source should succeed for a valid temp dir");
 
@@ -59,7 +59,7 @@ async fn register_source_persists_and_reads_back() {
 
 #[tokio::test]
 async fn register_source_rejects_duplicate_same_kind() {
-    let (db, _repo, _bus) = support::setup().await;
+    let (db, _repo, bus) = support::setup().await;
 
     let dir = tempdir().expect("tempdir");
     let path = dir.path().to_str().expect("utf8 path").to_owned();
@@ -73,10 +73,10 @@ async fn register_source_rejects_duplicate_same_kind() {
     };
 
     // First registration must succeed.
-    first_run::register_source(db.pool(), &req).await.expect("first register should succeed");
+    first_run::register_source(db.pool(), &bus, &req).await.expect("first register should succeed");
 
     // Second registration of the same path + kind must fail.
-    let err = first_run::register_source(db.pool(), &req)
+    let err = first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect_err("duplicate registration must be rejected");
 
@@ -94,7 +94,7 @@ async fn register_source_rejects_duplicate_same_kind() {
 
 #[tokio::test]
 async fn register_source_rejects_nonexistent_path() {
-    let (db, _repo, _bus) = support::setup().await;
+    let (db, _repo, bus) = support::setup().await;
 
     let req = RegisterSourceRequest {
         kind: SourceKind::Calibration,
@@ -105,7 +105,7 @@ async fn register_source_rejects_nonexistent_path() {
         organization_state: OrganizationState::Organized,
     };
 
-    let err = first_run::register_source(db.pool(), &req)
+    let err = first_run::register_source(db.pool(), &bus, &req)
         .await
         .expect_err("register with non-existent path must fail");
 
@@ -120,7 +120,7 @@ async fn register_source_rejects_nonexistent_path() {
 
 #[tokio::test]
 async fn seed_source_protection_sets_protected_for_non_inbox() {
-    let (db, _repo, _bus) = support::setup().await;
+    let (db, _repo, bus) = support::setup().await;
 
     let dir = tempdir().expect("tempdir");
     let path = dir.path().to_str().expect("utf8 path").to_owned();
@@ -133,7 +133,8 @@ async fn seed_source_protection_sets_protected_for_non_inbox() {
         scan_depth: ScanDepth::Recursive,
         organization_state: OrganizationState::Organized,
     };
-    let resp = first_run::register_source(db.pool(), &req).await.expect("register should succeed");
+    let resp =
+        first_run::register_source(db.pool(), &bus, &req).await.expect("register should succeed");
 
     // Seed the default protection for this (non-inbox) source.
     protection::seed_source_protection(db.pool(), &resp.source_id, "light_frames")

--- a/crates/app/core/tests/support/mod.rs
+++ b/crates/app/core/tests/support/mod.rs
@@ -15,7 +15,18 @@ use persistence_db::Database;
 
 /// Provision an isolated in-memory SQLite DB with all migrations applied and a
 /// repository/event-bus wired to it. Real backend, no mocks.
+///
+/// Review round 1 #5: `app_core_settings::caches::settings_bag()` is a
+/// process-global single-slot cache shared by every in-memory DB in this test
+/// binary (same caveat as `app_core_settings::lib.rs`'s own `setup()` and
+/// `app_core::protection::PROTECTION_DEFAULTS_TEST_LOCK`). Without a reset
+/// here, a settings test that runs after another test populated the bag can
+/// read that other test's stale snapshot instead of its own DB — the flake
+/// behind `settings_logs_integration.rs`'s `setting_update_persists_and_reads_back`.
+/// Invalidating at setup is a minimal fix for the shared-cache symptom, not
+/// the underlying single-process-cache architecture (out of scope here).
 pub async fn setup() -> (Database, SqliteLifecycleRepository, EventBus) {
+    app_core_settings::caches::invalidate_settings_bag();
     let db = Database::in_memory().await.expect("in-memory db");
     db.migrate().await.expect("migrations");
     let bus = EventBus::with_pool(db.pool().clone());

--- a/crates/app/settings/Cargo.toml
+++ b/crates/app/settings/Cargo.toml
@@ -19,7 +19,10 @@ persistence_db = { path = "../../persistence/db" }
 serde_json.workspace = true
 sqlx.workspace = true
 thiserror.workspace = true
-uuid = { workspace = true }
+# "v5" beyond the workspace default ("v4"): deterministic audit `entity_id`
+# derivation for settings keys (T122, spec 030 FR-133), same pattern as
+# `crates/targeting/Cargo.toml`.
+uuid = { version = "1", features = ["serde", "v4", "v5"] }
 workflow_profiles = { path = "../../workflow/profiles" }
 
 [features]

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -775,11 +775,19 @@ pub async fn restore_defaults(
 /// keys. Returns `"value.invalid"` for type-invalid values.
 pub async fn set_source_override(
     pool: &SqlitePool,
+    bus: &EventBus,
     req: &SetSourceOverrideRequest,
 ) -> Result<SetSourceOverrideResponse, ContractError> {
     let key = &req.key;
+    // FR-130/T122 FIX (review round 1 #1): a per-source override is a durable
+    // settings mutation regardless of whether a live caller exists today —
+    // entity_id keys on (source_id, key) so a source's override history for
+    // one key correlates under a single audit entity, distinct from the
+    // global-key entity `update_setting` uses.
+    let entity_seed = format!("{}:{key}", req.source_id);
 
     if !descriptors::is_overridable(key.as_str()) {
+        write_settings_override_refusal(bus, &entity_seed, key, "key.unoverridable").await?;
         return Err(ContractError::new(
             ErrorCode::KeyUnoverridable,
             format!("key {key} cannot be overridden per source"),
@@ -789,7 +797,10 @@ pub async fn set_source_override(
     }
 
     let value = &req.value.0;
-    validate_value(key, value)?;
+    if let Err(e) = validate_value(key, value) {
+        write_settings_override_refusal(bus, &entity_seed, key, "value.invalid").await?;
+        return Err(e);
+    }
 
     repo::set_source_override(pool, &req.source_id, key, value).await.map_err(db_err)?;
 
@@ -800,7 +811,56 @@ pub async fn set_source_override(
     // global key is ever written on this path, so no further fan-out applies.
     caches::invalidate_settings_bag();
 
+    let entry = AuditLogEntry::new(
+        EntityType::Settings,
+        settings_entity_id(&entity_seed),
+        "settings.source_override.set",
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(serde_json::json!({"sourceId": req.source_id, "key": key, "after": value}));
+    bus.write_audit(
+        entry,
+        TOPIC_SETTINGS_CHANGED,
+        Source::User,
+        serde_json::json!({"sourceId": req.source_id, "key": key}),
+    )
+    .await
+    .map_err(bus_err)?;
+
     Ok(SetSourceOverrideResponse { source_id: req.source_id.clone(), key: key.clone() })
+}
+
+/// Write a durable `Outcome::Refused` row for a rejected `set_source_override`
+/// attempt (FR-130, review round 1 #1).
+async fn write_settings_override_refusal(
+    bus: &EventBus,
+    entity_seed: &str,
+    key: &str,
+    reason_code: &str,
+) -> Result<(), ContractError> {
+    let entry = AuditLogEntry::new(
+        EntityType::Settings,
+        settings_entity_id(entity_seed),
+        "settings.source_override.set",
+        "user",
+        Outcome::Refused,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_reason_code(reason_code.to_owned())
+    .with_payload(serde_json::json!({"key": key}));
+    bus.write_audit(
+        entry,
+        TOPIC_SETTINGS_CHANGED,
+        Source::User,
+        serde_json::json!({"key": key, "outcome": "refused", "reasonCode": reason_code}),
+    )
+    .await
+    .map_err(bus_err)?;
+    Ok(())
 }
 
 // ── resolve_setting ───────────────────────────────────────────────────────
@@ -1225,27 +1285,58 @@ mod tests {
 
     #[tokio::test]
     async fn set_source_override_happy_path() {
-        let (db, _bus) = setup().await;
+        let (db, bus) = setup().await;
         let req = SetSourceOverrideRequest {
             source_id: "src-abc".to_owned(),
             key: "hashOnScan".to_owned(),
             value: contracts_core::JsonAny::from(serde_json::json!("eager")),
         };
-        let resp = set_source_override(db.pool(), &req).await.unwrap();
+        let resp = set_source_override(db.pool(), &bus, &req).await.unwrap();
         assert_eq!(resp.source_id, "src-abc");
         assert_eq!(resp.key, "hashOnScan");
     }
 
+    /// Review round 1 #1: `set_source_override`'s durable audit id resolves
+    /// to a real `audit_log_entry` row (FR-130/FR-131).
+    #[tokio::test]
+    async fn set_source_override_writes_durable_applied_audit_row() {
+        let (db, bus) = setup().await;
+        let req = SetSourceOverrideRequest {
+            source_id: "src-abc".to_owned(),
+            key: "hashOnScan".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("eager")),
+        };
+        set_source_override(db.pool(), &bus, &req).await.unwrap();
+
+        let row: (String, String) = sqlx::query_as(
+            "SELECT entity_type, outcome FROM audit_log_entry WHERE trigger = 'settings.source_override.set'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("set_source_override must write a durable audit row");
+        assert_eq!(row.0, "settings");
+        assert_eq!(row.1, "applied");
+    }
+
     #[tokio::test]
     async fn set_source_override_rejects_unoverridable_key() {
-        let (db, _bus) = setup().await;
+        let (db, bus) = setup().await;
         let req = SetSourceOverrideRequest {
             source_id: "src-abc".to_owned(),
             key: "logLevel".to_owned(),
             value: contracts_core::JsonAny::from(serde_json::json!("debug")),
         };
-        let err = set_source_override(db.pool(), &req).await.unwrap_err();
+        let err = set_source_override(db.pool(), &bus, &req).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::KeyUnoverridable);
+
+        let row: (String, Option<String>) = sqlx::query_as(
+            "SELECT outcome, reason_code FROM audit_log_entry WHERE trigger = 'settings.source_override.set' AND outcome = 'refused'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("refused set_source_override must write a durable audit row");
+        assert_eq!(row.0, "refused");
+        assert_eq!(row.1.as_deref(), Some("key.unoverridable"));
     }
 
     // ── T022: resolution order ─────────────────────────────────────────
@@ -1267,7 +1358,7 @@ mod tests {
             key: "hashOnScan".to_owned(),
             value: contracts_core::JsonAny::from(serde_json::json!("off")),
         };
-        set_source_override(db.pool(), &ov_req).await.unwrap();
+        set_source_override(db.pool(), &bus, &ov_req).await.unwrap();
 
         let resolved = resolve_setting(db.pool(), "hashOnScan", Some("src-1")).await.unwrap();
         assert_eq!(resolved, serde_json::json!("off"));

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -24,12 +24,15 @@ use audit::event_bus::{
     TOPIC_PROTECTION_DEFAULT_CHANGED, TOPIC_SETTINGS_CHANGED, TOPIC_SETTINGS_REPAIR,
     TOPIC_SETTINGS_SNAPSHOT,
 };
+use audit::{AuditLogEntry, Outcome, Severity};
 use contracts_core::settings::{
     RestoreDefaultsRequest, RestoreDefaultsResponse, RestoreDefaultsStatus,
     SetSourceOverrideRequest, SetSourceOverrideResponse, SettingsGetResponse, SettingsState,
     SettingsUpdateRequest, SettingsUpdateResponse, SettingsUpdateStatus,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use domain_core::ids::EntityId;
+use domain_core::lifecycle::data_asset::EntityType;
 use persistence_db::repositories::settings as repo;
 use persistence_db::repositories::source_protection as protection_repo;
 use serde_json::Value;
@@ -62,6 +65,41 @@ const GLOBAL_PROTECTION_DEFAULT_KEYS: [&str; 3] =
 #[must_use]
 pub fn is_global_protection_default_key(key: &str) -> bool {
     GLOBAL_PROTECTION_DEFAULT_KEYS.contains(&key)
+}
+
+// ── Durable-data noisy keys (spec 030 FR-130, Q15/#647, T122) ───────────────
+//
+// `descriptors::DESCRIPTORS[].noisy` conflates two different concerns:
+// UI-state keys (`rememberFollowLogs`, `plansListDefaultAgeCutoffDays`) that
+// FR-134 exempts from durable audit entirely, and durable-data keys whose
+// writes are debounced/frequent (`pattern`) but still get a single durable
+// row at the committed value, before→after (FR-130). This is the same
+// named-exception-list shape as `GLOBAL_PROTECTION_DEFAULT_KEYS` above, kept
+// separate from the descriptor table rather than adding a 36th field to every
+// one of its 35 literals for a single-member set.
+const NOISY_AUDITED_KEYS: [&str; 1] = ["pattern"];
+
+/// Whether a `noisy` key still gets a durable audit row at its committed
+/// value (`pattern`), vs. being fully exempt as UI state (FR-134).
+#[must_use]
+fn is_noisy_audited_key(key: &str) -> bool {
+    NOISY_AUDITED_KEYS.contains(&key)
+}
+
+// ── Audit entity identity (spec 030 FR-133, T122) ───────────────────────────
+
+/// Deterministic UUIDv5 `entity_id` for a settings key.
+///
+/// Settings keys have no natural UUID identity; deriving one from the key
+/// name (stable across every write) lets `audit_log_entry` reads correlate
+/// the full history of one key under a single `entity_id`, the same way a
+/// real entity's rows are correlated by its persisted id.
+fn settings_entity_id(key: &str) -> EntityId {
+    static NAMESPACE: std::sync::OnceLock<uuid::Uuid> = std::sync::OnceLock::new();
+    let ns = NAMESPACE.get_or_init(|| {
+        uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_DNS, b"astro-plan.audit.settings")
+    });
+    EntityId::from_uuid(uuid::Uuid::new_v5(ns, key.as_bytes()))
 }
 
 // ── Settings descriptor table (US11 T144) ────────────────────────────────
@@ -404,9 +442,11 @@ pub async fn update_setting(
     req: &SettingsUpdateRequest,
 ) -> Result<SettingsUpdateResponse, ContractError> {
     let key = &req.key;
+    let is_protection_default = is_global_protection_default_key(key);
 
     // 1. Validate key.
     if !is_valid_key(key) {
+        write_settings_refusal(bus, is_protection_default, key, "key.unknown").await?;
         return Err(ContractError::new(
             ErrorCode::KeyUnknown,
             format!("unknown settings key: {key}"),
@@ -417,9 +457,10 @@ pub async fn update_setting(
 
     // 2. Validate value.
     let new_value = &req.value.0;
-    validate_value(key, new_value)?;
-
-    let is_protection_default = is_global_protection_default_key(key);
+    if let Err(e) = validate_value(key, new_value) {
+        write_settings_refusal(bus, is_protection_default, key, "value.invalid").await?;
+        return Err(e);
+    }
 
     // 3. Load current stored value (or default). Global protection-default
     // keys read/write the dedicated `protection_defaults` table (T-005).
@@ -468,48 +509,35 @@ pub async fn update_setting(
         app_core_cache::invalidate_protection_defaults();
     }
 
-    // 6. Emit audit event. Global protection-default keys ALWAYS emit
+    // 6. Emit durable audit row + live event (FR-130/FR-131, T122). Global
+    // protection-default keys ALWAYS audit under `EntityType::Protection` via
     // `protection.default.changed` (T-004), overriding the noisy-key
     // no-audit policy — `protectedCategories` is `noisy` for the generic
     // `settings.changed` topic but is a named exception here (spec 016
     // plan.md E-016-3: "MUST emit `protection.default.changed` whenever it is
-    // updated").
+    // updated"). Non-protection noisy keys audit only when in
+    // `NOISY_AUDITED_KEYS` (durable-data, e.g. `pattern`); the rest
+    // (`rememberFollowLogs`, `plansListDefaultAgeCutoffDays`) are UI state and
+    // stay fully exempt (FR-134).
     let is_noisy = descriptors::is_noisy(key.as_str());
-    let audit_id = if is_protection_default {
-        let at = Timestamp::now_iso();
-        let evt_id = uuid::Uuid::new_v4().to_string();
-        bus.publish(
-            TOPIC_PROTECTION_DEFAULT_CHANGED,
-            Source::User,
-            ProtectionDefaultChanged {
-                scope: GLOBAL_PROTECTION_DEFAULT_SCOPE.to_owned(),
-                key: key.clone(),
-                old: Some(prior_value.clone()),
-                new: new_value.clone(),
-                changed_at: at,
-            },
-        )
-        .await
-        .map_err(bus_err)?;
-        Some(evt_id)
-    } else if is_noisy {
+    let audit_id = if !is_protection_default && is_noisy && !is_noisy_audited_key(key.as_str()) {
         None
     } else {
-        let at = Timestamp::now_iso();
-        let evt_id = uuid::Uuid::new_v4().to_string();
-        bus.publish(
-            TOPIC_SETTINGS_CHANGED,
-            Source::User,
-            SettingsChanged {
-                key: key.clone(),
-                prior_value: prior_value.clone(),
-                new_value: new_value.clone(),
-                at,
-            },
+        let action = if is_protection_default {
+            "settings.protection_default.update"
+        } else {
+            "settings.update"
+        };
+        let id = write_settings_applied_audit(
+            bus,
+            is_protection_default,
+            action,
+            key,
+            &prior_value,
+            new_value,
         )
-        .await
-        .map_err(bus_err)?;
-        Some(evt_id)
+        .await?;
+        Some(id.as_uuid().to_string())
     };
 
     Ok(SettingsUpdateResponse {
@@ -519,6 +547,108 @@ pub async fn update_setting(
         new_value: contracts_core::JsonAny::from(new_value.clone()),
         audit_id,
     })
+}
+
+/// Write a durable `Outcome::Applied` audit row + live event for an accepted
+/// settings write (T122). Shared by `update_setting`'s success path and
+/// `restore_defaults`'s per-key loop — both pick `EntityType`/topic/payload
+/// the same way based on `is_protection_default` (protection-default keys
+/// audit under `EntityType::Protection` via `protection.default.changed`,
+/// spec 016 T-004; everything else audits under `EntityType::Settings` via
+/// `settings.changed`).
+async fn write_settings_applied_audit(
+    bus: &EventBus,
+    is_protection_default: bool,
+    action: &str,
+    key: &str,
+    prior_value: &Value,
+    new_value: &Value,
+) -> Result<domain_core::ids::AuditId, ContractError> {
+    let entity_type =
+        if is_protection_default { EntityType::Protection } else { EntityType::Settings };
+    let entry = AuditLogEntry::new(
+        entity_type,
+        settings_entity_id(key),
+        action,
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(serde_json::json!({"key": key, "before": prior_value, "after": new_value}));
+    let at = Timestamp::now_iso();
+
+    if is_protection_default {
+        bus.write_audit(
+            entry,
+            TOPIC_PROTECTION_DEFAULT_CHANGED,
+            Source::User,
+            ProtectionDefaultChanged {
+                scope: GLOBAL_PROTECTION_DEFAULT_SCOPE.to_owned(),
+                key: key.to_owned(),
+                old: Some(prior_value.clone()),
+                new: new_value.clone(),
+                changed_at: at,
+            },
+        )
+        .await
+        .map_err(bus_err)
+    } else {
+        bus.write_audit(
+            entry,
+            TOPIC_SETTINGS_CHANGED,
+            Source::User,
+            SettingsChanged {
+                key: key.to_owned(),
+                prior_value: prior_value.clone(),
+                new_value: new_value.clone(),
+                at,
+            },
+        )
+        .await
+        .map_err(bus_err)
+    }
+}
+
+/// Write a durable `Outcome::Refused` audit row for a rejected `settings.update`
+/// attempt (FR-130/FR-134, T127) before returning the validation error to the
+/// caller. No before/after pair — validation is rejected before any read.
+/// `is_protection_default` picks the same `EntityType` the applied path would
+/// have used, so a refused global-protection-default write (e.g. `T123`'s
+/// "protection refused" coverage) is tagged `EntityType::Protection`, not
+/// `EntityType::Settings`.
+async fn write_settings_refusal(
+    bus: &EventBus,
+    is_protection_default: bool,
+    key: &str,
+    reason_code: &str,
+) -> Result<(), ContractError> {
+    let entity_type =
+        if is_protection_default { EntityType::Protection } else { EntityType::Settings };
+    let entry = AuditLogEntry::new(
+        entity_type,
+        settings_entity_id(key),
+        "settings.update",
+        "user",
+        Outcome::Refused,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_reason_code(reason_code.to_owned())
+    .with_payload(serde_json::json!({"key": key}));
+    bus.write_audit(
+        entry,
+        TOPIC_SETTINGS_CHANGED,
+        Source::User,
+        serde_json::json!({
+            "key": key,
+            "outcome": "refused",
+            "reasonCode": reason_code,
+        }),
+    )
+    .await
+    .map_err(bus_err)?;
+    Ok(())
 }
 
 // ── restore_defaults ──────────────────────────────────────────────────────
@@ -593,38 +723,17 @@ pub async fn restore_defaults(
             repo::set_raw(pool, key, &default_val).await.map_err(db_err)?;
         }
 
-        // Emit audit event (even for noisy keys — restore is an explicit action).
-        // Global protection-default keys emit `protection.default.changed`
-        // (T-004) instead of the generic `settings.changed` topic.
-        let at = Timestamp::now_iso();
-        if is_protection_default {
-            bus.publish(
-                TOPIC_PROTECTION_DEFAULT_CHANGED,
-                Source::User,
-                ProtectionDefaultChanged {
-                    scope: GLOBAL_PROTECTION_DEFAULT_SCOPE.to_owned(),
-                    key: key.clone(),
-                    old: Some(current_val),
-                    new: default_val,
-                    changed_at: at,
-                },
-            )
-            .await
-            .map_err(bus_err)?;
-        } else {
-            bus.publish(
-                TOPIC_SETTINGS_CHANGED,
-                Source::User,
-                SettingsChanged {
-                    key: key.clone(),
-                    prior_value: current_val,
-                    new_value: default_val,
-                    at,
-                },
-            )
-            .await
-            .map_err(bus_err)?;
-        }
+        // Write durable audit row + live event (even for noisy keys — restore
+        // is an explicit action, FR-130).
+        write_settings_applied_audit(
+            bus,
+            is_protection_default,
+            "settings.restore_defaults",
+            key,
+            &current_val,
+            &default_val,
+        )
+        .await?;
 
         restored.push(key.clone());
         if is_protection_default {
@@ -931,6 +1040,67 @@ mod tests {
         assert_eq!(resp.key, "logLevel");
         // Non-noisy key should have an audit_id.
         assert!(resp.audit_id.is_some());
+    }
+
+    /// FR-131/SC-009 (T122): the returned `audit_id` must resolve to a real
+    /// durable `audit_log_entry` row, not just a bus-only event id.
+    #[tokio::test]
+    async fn update_setting_audit_id_resolves_to_durable_row() {
+        let (db, bus) = setup().await;
+        let req = SettingsUpdateRequest {
+            key: "logLevel".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("debug")),
+        };
+        let resp = update_setting(db.pool(), &bus, &req).await.unwrap();
+        let audit_id = resp.audit_id.expect("non-noisy key must return an audit_id");
+
+        let row: (String, String) =
+            sqlx::query_as("SELECT entity_type, outcome FROM audit_log_entry WHERE audit_id = ?")
+                .bind(&audit_id)
+                .fetch_one(db.pool())
+                .await
+                .expect("audit_id must resolve to a durable audit_log_entry row");
+        assert_eq!(row.0, "settings");
+        assert_eq!(row.1, "applied");
+    }
+
+    /// FR-130 (T122): `pattern` is `noisy` (debounced) but is a durable-data
+    /// key — it must still audit at its committed value, unlike a UI-state
+    /// noisy key (see `update_setting_noisy_key_no_audit_id`).
+    #[tokio::test]
+    async fn update_setting_noisy_audited_key_pattern_gets_audit_id() {
+        let (db, bus) = setup().await;
+        let req = SettingsUpdateRequest {
+            key: "pattern".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!([{
+                "type": "literal", "value": "changed"
+            }])),
+        };
+        let resp = update_setting(db.pool(), &bus, &req).await.unwrap();
+        assert_eq!(resp.status, SettingsUpdateStatus::Success);
+        assert!(resp.audit_id.is_some(), "durable-data noisy key `pattern` must still be audited");
+    }
+
+    /// T127: a refused `settings.update` (unknown key) writes a durable
+    /// `Outcome::Refused` row with a reason_code, per FR-130/FR-134.
+    #[tokio::test]
+    async fn update_setting_refused_unknown_key_writes_durable_row() {
+        let (db, bus) = setup().await;
+        let req = SettingsUpdateRequest {
+            key: "notARealKey".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("whatever")),
+        };
+        let err = update_setting(db.pool(), &bus, &req).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::KeyUnknown);
+
+        let row: (String, Option<String>) = sqlx::query_as(
+            "SELECT outcome, reason_code FROM audit_log_entry WHERE entity_type = 'settings' AND outcome = 'refused'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .expect("refused settings.update must write a durable audit row");
+        assert_eq!(row.0, "refused");
+        assert_eq!(row.1.as_deref(), Some("key.unknown"));
     }
 
     /// Theme durability round trip (theme-settings-db): `settings.update`

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -33,7 +33,7 @@ Layer-2 smoke journey; **—** = covered implicitly via screen-load smoke.
 | 19 | Settings / configuration model | ✅ | ✅ | persist + reload |
 | 20 | Bottom log viewer | ✅ | ✅ | log stream render |
 | 21 | Router & URL state | n/a | ✅ | **all top-level screens load** (FR-007) |
-| 22 | Audit event model (cross-cutting) | ✅ | via #18 | bus + stale propagation |
+| 22 | Audit event model (cross-cutting) | ✅ | via #18 | bus + stale propagation; **spec 030 Q15/#647 (T122–T125, 2026-07-14)**: settings/protection/equipment/source+root mutations now write durable `audit_log_entry` rows (previously bus-only for protection/source/root, no audit at all for equipment) — see the Q15 row below |
 
 **Required round-trip proof (FR-008)**: areas #1, #7, #12/#14 each round-trip a
 UI value through the real backend.
@@ -62,6 +62,7 @@ failed, **0 ignored** (no faked/skipped passes).
 | #17/#18/#22 | `crates/app/core/tests/plan_apply_audit_integration.rs` | ✓ (mutation+audit) |
 | #19/#20 | `crates/app/core/tests/settings_logs_integration.rs` | ✓ |
 | #21 | — (Layer-2 only, by design) | see US3 |
+| #22 Q15 durable-audit sweep (spec 030 T122–T127, 2026-07-14) | in-crate `#[cfg(test)]` mods: `crates/app/settings/src/lib.rs`, `crates/app/core/src/protection.rs`, `crates/app/core/src/first_run.rs`, `crates/app/calibration/src/equipment.rs` | applied+refused/failed rows resolve to real `audit_log_entry` (SC-009); ≥1 refused/failed test per consumer (settings, protection, equipment, source/root) |
 
 Shared harness: `crates/app/core/tests/support/mod.rs` (T005).
 **Implementation note**: research D2's `wiremock` boundary stub was superseded by


### PR DESCRIPTION
## Summary
- Settings, protection-rule, equipment, and data-source mutations now write durable audit log rows -- including refused and failed attempts, and system-initiated diagnostic events -- giving a complete change history for these areas.

## Spec Context
Refs spec-030 T122-T125/T127, FR-130-134/SC-009. Approved after 1 fix round (flake fixed and verified across 18+6 reruns); 2193 workspace tests green.