### PR TITLE
docs(journeys): journey-validation doc-drift deltas (2026-07-14 live run)

### DIFF
--- a/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J01-first-run-setup-data-sources/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,30 @@
+# jval-docdrift — J01-first-run-setup-data-sources: Wizard is 6 steps with a new Observing Site step; Project outputs is required
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline says the setup wizard is 5 steps. The shipped app actually ships a **6-step wizard**: a new **"Observing Site" step** (map picker + Name / Lat / Lon / Elevation / Timezone / Night-definition / Horizon; `apps/desktop/src/features/setup/steps/StepSite.tsx`) is inserted after Configuration, shipped via PR #686/#691.
+
+Baseline says Step 1's four folder categories are "Light frames (required), Calibration, Project outputs, and Inbox (all optional)." The shipped app actually treats **"Project outputs" as a REQUIRED category** alongside Light frames — `REQUIRED_KINDS = ['light_frames','project']` (`apps/desktop/src/features/setup/sources-store.ts:32`).
+
+## Stages hit
+
+- Stage 1 "the app opens the setup wizard ("Setup · Step 1 of 5")" — wizard is now 6 steps (new Observing Site step inserted after Configuration/Stage 3)
+- Stage 2 "Light frames (required), Calibration, Project outputs, and Inbox (all optional)" — Project outputs is now required, not optional
+
+## Reviewer verification
+
+1. Launch first-run setup on a fresh DB; count wizard steps in the stepper chrome — expect 6, with "Observing Site" appearing after Configuration and before Confirm.
+2. Confirm `apps/desktop/src/features/setup/steps/StepSite.tsx` exists and is wired into the step sequence (map picker + Name / Lat / Lon / Elevation / Timezone / Night-definition / Horizon fields).
+3. On Step 1 (Source Folders), try to reach Confirm/Finish without adding a Project-outputs folder — assert it is now blocked/flagged the same way Light frames is; cross-check `REQUIRED_KINDS` at `apps/desktop/src/features/setup/sources-store.ts:32`.
+4. Negative: Calibration and Inbox remain optional (no such gate on those categories).
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-01-*` (first-run setup) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #1

--- a/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J02-ingest-review-reclassify-confirm-move/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,27 @@
+# jval-docdrift — J02-ingest-review-reclassify-confirm-move: Destination-root picker surfaces inside the Review-plans overlay, not an inline Confirm modal
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline (Stage 4) reads as if the multi-root picker is an inline modal shown at Confirm time. The shipped app actually defers this: Confirm proceeds, the backend returns a typed `inbox.destination_root_required` signal, and the root picker surfaces inside the **"Review plans" overlay** (opened via a toast + the "Review plans (N)" button) — it is not an inline Confirm-time modal.
+
+## Stages hit
+
+- Stage 4 "If more than one destination library root is registered for that frame type, the user is forced to pick one via a root picker before a plan is generated"
+
+## Reviewer verification
+
+1. Register 2+ light-frame roots; confirm an inbox item without pre-selecting a destination root via the detail-header select.
+2. Assert Confirm does not open an inline modal; instead a toast appears and the root choice surfaces inside the "Review plans (N)" overlay.
+3. Assert the backend response carries `inbox.destination_root_required` before the picker renders.
+4. Negative: with exactly one valid root, no picker appears anywhere (auto-picked, per baseline).
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-02-*` (inbox confirm/move) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #3

--- a/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J03-ingest-confirm-catalogue-in-place/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,29 @@
+# jval-docdrift — J03-ingest-confirm-catalogue-in-place: Rescan-all-roots is inbox-only; catalogue plan's destructive-destination control observed absent
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline implies the Inbox's rescan mechanism surfaces new files from any registered root, including already-organized (catalogue-in-place) roots. The shipped app's Inbox page **"Rescan all roots" only rescans roots where `category==='inbox'`** (`InboxPage.tsx:161-167`) — surfacing a non-inbox (organized light-frames) root's new files instead requires **Settings → Data Sources → per-root Rescan**.
+
+Baseline (Stage 3) states the catalogue plan's review overlay shows "the same destructive-destination control present (Archive vs System Trash) even though these actions don't need it." The live app's catalogue plan review was observed with that control **absent** — spec-compliant per the journey's own Touch & validate bullet ("destructive-destination control is absent or visibly inert for pure catalogue plans"), but the Stage-3 narrative text implying "present" is stale/misleading as written.
+
+## Stages hit
+
+- Stage 1 "Files under an organized root are ingested and classified exactly like Journey 2" — the rescan trigger for organized-root files is Data Sources' per-root Rescan, not Inbox's "Rescan all roots"
+- Stage 3 "the same destructive-destination control present (Archive vs System Trash) even though these actions don't need it" — observed absent in the live app, not present
+
+## Reviewer verification
+
+1. Register an organized (non-inbox) light-frames root with new unscanned files; click Inbox's "Rescan all roots" — assert the new files do NOT surface.
+2. From Settings → Data Sources, run per-root Rescan on that same root — assert the files now surface for classify/confirm.
+3. Confirm a catalogue-in-place item; open the review overlay — assert the destructive-destination control is absent or inert, not an active present control.
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-03-*` (catalogue in place) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #3 (extend)

--- a/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J04-sessions-review-derived/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,30 @@
+# jval-docdrift — J04-sessions-review-derived: PR #415 interaction-parity gap is closed; frame-type filter intentionally removed
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline's Known-gaps note says Inbox-level interaction parity (filter/camera dropdowns, group + secondary sort, `aria-sort`, "Grouped by X" footer hint) "requires PR #415 (open)." **PR #415 is MERGED** — all of these are live and working on the shipped Sessions list.
+
+The shipped Sessions list **intentionally has no frame-type filter** (`SessionsPage.tsx:14`: sessions are light frames only; calibration lives on its own page/journey). This is a deliberate scope decision, not a missing control — reviewers should treat frame type as implicit here, not flag the absent filter as a gap.
+
+## Stages hit
+
+- Stage 1 "target/filter/camera filters, group + secondary sorts, every sortable header" (List chrome) — dropdowns/secondary-sort/`aria-sort`/footer hint are now live; frame-type filter is intentionally absent
+
+## Reviewer verification
+
+1. On Sessions, assert filter and camera dropdowns are present and functional.
+2. Assert a secondary sort is available in addition to the primary group/sort control.
+3. Inspect column headers for `aria-sort` on the active sortable column.
+4. Assert a "Grouped by X" footer hint renders when grouping is active.
+5. Negative: confirm there is no frame-type filter control, and that this is expected (cross-check `SessionsPage.tsx:14`), not a defect.
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-04-*` (sessions) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #6

--- a/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J05-project-lifecycle/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,26 @@
+# jval-docdrift — J05-project-lifecycle: Duplicate-name error fires at Create-time, not as-you-type
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline (Stage 1) reads as if the duplicate-name check validates while typing. The shipped app actually fires the case-insensitive duplicate-name check **at Create-time** (on submit) — the wizard bounces back to Step 1 with the inline field error at that point, not "immediately as you type."
+
+## Stages hit
+
+- Stage 1 "Typing a name that already exists (case-insensitively) surfaces an inline field error immediately, not a generic toast, and creation is blocked from that step"
+
+## Reviewer verification
+
+1. On Create (`/projects/new`), type an existing project name (any casing) and, without submitting, assert no inline error appears yet.
+2. Click Create/submit — assert the wizard bounces back to Step 1 with the inline field error only at that point.
+3. Confirm the check is case-insensitive (a mixed-case duplicate still blocks).
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-05-*` (project lifecycle) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #7

--- a/docs/product/journeys/J06-cleanup-scan-review-apply/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J06-cleanup-scan-review-apply/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,27 @@
+# jval-docdrift — J06-cleanup-scan-review-apply: PR #413 UI gap is stale; real blocker is the protection/audit backend
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline's Known-gaps note says the cleanup review UI "requires PR #413 (open) — pre-#413 the project detail's Cleanup section has no 'Scan for cleanup candidates' button at all." That note is **stale**: the scan/review/generate cleanup UI (Scan-for-candidates button, grouped-by-kind UI, destination picker, review overlay) is **fully implemented**. The real remaining blocker for this journey is the **protection/audit backend** — #780 (artifact-missing reconcile), #807 (cosmetic protected-ack), #766 (zero audit rows) — not missing UI.
+
+## Stages hit
+
+- Stage 1 "Scan for cleanup candidates runs a read-only preview … groups candidates by kind … totals the reclaimable size" — button and full scan UI are shipped, contradicting the Known-gaps "no button at all" note
+- Stage 3 "its protection must be explicitly acknowledged before Approve & apply becomes clickable" — acknowledgement UI works, but the backing audit/protection reconcile has open defects (#780/#807/#766)
+
+## Reviewer verification
+
+1. Open a project's Cleanup section — assert "Scan for cleanup candidates" is present and functional (not absent).
+2. Run a scan with protected items present — assert grouped-by-kind UI, destination picker, and review overlay all render.
+3. Acknowledge a protected item and apply — cross-check audit rows against #766 (zero audit rows) and #780 (artifact-missing reconcile) to confirm whether the backend gap still reproduces.
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-06-*` (cleanup) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #17

--- a/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J07-archive-delete/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,26 @@
+# jval-docdrift — J07-archive-delete: Archive button auto-generates the plan in one click; Known-gap #1 is false
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline's Known-gaps bullet #1 says "There is no shipped UI button that generates an archive plan yet … only reachable by invoking the backend command directly." This is **FALSE** in the shipped app: the project-detail **Archive button refuses server-side, then auto-generates the plan and opens the review overlay in one click** (`ProjectDetail.tsx:250-327`, `handleGenerateArchivePlan`) — no backend-only IPC call is needed. The back-half (apply/lifecycle-flip/DELETE-gate) remains untestable on current data because #780 zeroes the plan items — that is a separate, still-open gap.
+
+## Stages hit
+
+- Stage 1 "Clicking 'Archive' on a completed project is refused unless a filesystem plan for the archive already exists and has been applied" — the refusal now auto-triggers plan generation and opens the review overlay in the same click, not a dead-end refusal requiring backend-only IPC
+
+## Reviewer verification
+
+1. On a `completed` project with no existing archive plan, click "Archive."
+2. Assert the server-side refusal fires, then the plan is auto-generated and the review overlay opens in the same interaction — not two separate manual steps and not a backend-only path.
+3. Note (do not treat as a new finding): the back-half apply/DELETE-gate flow may show empty plan items due to #780 — cross-check before flagging as regression.
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-07-*` (archive) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #17

--- a/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J08-calibration-ingest-masters-matching/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,26 @@
+# jval-docdrift — J08-calibration-ingest-masters-matching: Master detection requires master-style filenames or IMAGETYP=master
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline (Stage 1) reads as if any calibration-root ingest of dark/flat/bias files yields individually tracked masters. The shipped spec-040 MasterDetector actually requires a **master-style filename** ("master" / "_stacked" in the filename) **or** `IMAGETYP` containing "master" — raw dark/flat fixtures without that naming/tag are **NOT** detected as masters; they ingest as ordinary calibration frames instead.
+
+## Stages hit
+
+- Stage 1 "Master calibration files ingest through the same Inbox pipeline as lights (Journey 2): a folder containing several master files … classifies as separate individual items"
+
+## Reviewer verification
+
+1. Ingest raw (non-stacked) dark/flat fixtures with ordinary filenames and no `IMAGETYP=master` — assert they do NOT appear as masters on the Calibration page.
+2. Ingest the same fixtures renamed with "master"/"_stacked" in the filename, or with `IMAGETYP` containing "master" — assert they now appear as individual master rows.
+3. Cross-check the detection rule against the spec-040 MasterDetector implementation.
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-08-*` (calibration) — re-walk with the live 2026-07-14 build
+- Coverage-matrix: #5

--- a/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-jval-docdrift.md
+++ b/docs/product/journeys/J09-targets-planning/deltas/2026-07-14-jval-docdrift.md
@@ -1,0 +1,42 @@
+# jval-docdrift — J09-targets-planning: 044/047 shipped — astronomy columns are real, not stubs (reconciles q16-t132/t133)
+
+Task: jval-docdrift · Status: observed-live-2026-07-14
+
+Journey-validation run 2026-07-14 (real Windows app, build 7e522c16) — observed doc-drift vs baseline.
+
+## Behavior delta (this journey)
+
+Baseline's entire "stubbed/pending" narrative (Stage 4 astronomy columns, Stage 5 favourites) is now **stale except Sessions**. Specs **044 Track B (astronomy-engine unification) and 047 Track A (Moon/filters) have SHIPPED**: Max altitude, Tonight's sparkline, Visible-tonight, Opposition, Lunar separation, recommended Filters, and Image time are now **REAL per-site astronomy-engine computations** against the configured observing site (via `settings_get`/`observingSites`) — not deterministic hash stubs. The **Sessions column is the only genuine remaining "—" stub** in this journey.
+
+Baseline (Stage 5) says Favourites/"My Targets" is a browser-local (`localStorage`) preference only. The shipped app's favourites are **DB-backed** (`target_favourite` table, a real row with a timestamp), not localStorage-only.
+
+Baseline's Known-gaps note says `aria-sort` on the Targets table "requires PR #415 (open)." **PR #415 is merged** — `aria-sort` works on the shipped table.
+
+Baseline (Stage 1) says the Targets table "lists the seeded catalog (thousands of rows, virtualized for smooth scrolling)." The shipped app's main Targets table is actually **the user's added-target library** (a handful of rows) — the ~13k seed catalog is only searched via the Add-target typeahead and is never materialized as browsable rows.
+
+**Planner math verified CORRECT**: the app's astronomy-engine computations agree with skyfield/DE421 and with Telescopius independently (e.g. M31 shows 0 imaging time on 2026-07-14 at 52.09°N because the Sun only reaches −16.4°, so there is no astronomical darkness that night). The one real defect found is a **graph-shading contradiction (#817)**: the altitude graph paints the usable-altitude fill under a high curve while omitting twilight shading when there's no dark window, making the target look imageable while imaging time is correctly computed as 0.
+
+**Reconciliation note for reviewers**: this supersedes the "disclosed stub" framing in the existing Wave-0 deltas `2026-07-14-q16-t132.md` and `2026-07-14-q16-t133.md` for the astronomy columns specifically — those deltas' "placeholder astronomy" language now applies **only to the Sessions column**; the astronomy columns themselves are real per-site computations and should be verified as such, with #817 tracked separately as a rendering defect, not a stub-honesty defect.
+
+## Stages hit
+
+- Stage 1 "Targets lists the seeded catalog (thousands of rows, virtualized for smooth scrolling)" — the main table is actually the user's added-target library; the seed catalog is typeahead-only
+- Stage 4 "The Targets table's astronomy-shaped columns … are not computed from real coordinates, date, or observer location yet. They are deterministic placeholders derived from a hash of the target's designation" — now real per-site astronomy-engine computations (044/047 shipped); Sessions is the only remaining stub
+- Stage 5 "'Favourites'/'My Targets' is currently a browser-local (localStorage) preference only" — now DB-backed (`target_favourite` table)
+
+## Reviewer verification
+
+1. With an observing site configured (Settings → Observing Site), open Targets and assert Max altitude / Tonight / Visible / Opposition / Lunar separation / Filters / Image time vary meaningfully by target and site — not a stable hash-derived value across reloads.
+2. Cross-check one target's computed values (e.g. M31 on 2026-07-14 at 52.09°N) against an independent ephemeris (skyfield/DE421) or Telescopius — expect agreement, including 0 imaging time when the Sun doesn't reach astronomical twilight.
+3. Reproduce #817: confirm the altitude graph shades a usable-altitude fill under a high curve even when imaging time is 0 and no twilight window exists — verify as a rendering defect, not a stub-honesty defect.
+4. Toggle a favourite, restart the app (or inspect the DB), and assert the `target_favourite` row persists with a timestamp — not merely `localStorage`.
+5. Tab to the Targets table's active sortable column header and assert `aria-sort` is present.
+6. Confirm the main Targets table row count matches the user's added targets, not the ~13k seed catalog; search "M31"/"Andromeda" in the Add-target typeahead to confirm the seed is reachable there instead.
+7. Cross-check `2026-07-14-q16-t132.md` and `2026-07-14-q16-t133.md` in this journey's deltas folder — their "disclosed stub" framing for astronomy columns should now be read as superseded by this note; only the Sessions column retains stub framing.
+
+## Rerun set (minimal)
+
+- Layer-1: to be written in the owning task
+- Layer-2: to be written in the owning task
+- Manual-Windows: `journey-09-*` (targets) — re-walk with the live 2026-07-14 build; see also #817 for the graph-shading repro
+- Coverage-matrix: #13


### PR DESCRIPTION
## Summary
- Adds 9 per-journey doc-drift deltas (`2026-07-14-jval-docdrift.md` in each `docs/product/journeys/J0N-*/deltas/`) from the 2026-07-14 real-Windows journey-validation run (build 7e522c16, via Tauri MCP bridge), matching the per-journey deltas structure introduced in #824.
- Each delta cites the baseline `journey.md`'s real stage numbers/quoted text, states the drift as "baseline says X; the shipped app actually does Y," and gives concrete reviewer verification steps + a rerun set (Manual-Windows `journey-NN-*`; Layer-1/Layer-2 left as "to be written in the owning task").
- **J09 is a reconciliation, not a new contradiction**: specs 044 (Track B, astronomy-engine unification) and 047 (Track A, Moon/filters) have SHIPPED, so the Targets astronomy columns (Max altitude, Tonight, Visible, Opposition, Lunar separation, Filters, Image time) are now real per-site computations, not hash stubs. The existing Wave-0 deltas `2026-07-14-q16-t132.md`/`2026-07-14-q16-t133.md` still frame these as "disclosed stubs" — this new delta explicitly supersedes that framing for the astronomy columns (Sessions remains the only genuine stub) and cross-references #817 (altitude-graph shading contradiction) plus the independently-verified-correct planner math (agrees with skyfield/DE421 and Telescopius).
- Index registration (`wave0-task-index.md`, `INDEX.md`) was intentionally left out: both files scope themselves explicitly to "Wave-0 grilling tasks" (Q15/Q16/Q27) in their own header text, and `jval-docdrift` is a different work stream (live validation, not grilling) — fitting it into that table felt like a format mismatch rather than a clean append. Left for the owner to decide how (or whether) to fold it in.
- J10–J17 doc-drift findings are deferred (per the live-run brief) and will append as additional dated delta files at campaign close-out.

## Test plan
- [ ] Reviewer spot-checks each delta's "Stages hit" quote against its journey's `journey.md` baseline
- [ ] J09 delta cross-checked against #817 and the existing q16-t132/t133 deltas for consistent framing
- [ ] No baseline `journey.md` or other agents' delta files were modified (delta-only diff)