### PR TITLE
fix(master-detect): let Siril STACKCNT evidence beat filename heuristics

### DIFF
--- a/crates/calibration/master-detect/src/lib.rs
+++ b/crates/calibration/master-detect/src/lib.rs
@@ -10,8 +10,10 @@
 //! calibration master and what base frame type it carries.
 //!
 //! The public entry point is [`detect_master`]: it runs each registered
-//! detector in order and returns the first match (first-wins). Callers that
-//! only need the result do not need to know about individual detectors.
+//! detector in order. A detector whose determination rests on authoritative
+//! header evidence (`STACKCNT`/`NCOMBINE`) wins regardless of registry order;
+//! otherwise the first `Some` result wins. Callers that only need the result
+//! do not need to know about individual detectors.
 //!
 //! Adding support for a new capture/processing tool requires only:
 //! 1. Implementing `MasterDetector` in a new module.
@@ -59,6 +61,16 @@ pub struct MasterDetection {
     pub is_master: bool,
     /// Identifier of the detector that produced this result (provenance).
     pub detector: &'static str,
+    /// Whether `is_master` was determined from an authoritative header
+    /// integration count (`STACKCNT`/`NCOMBINE`) rather than from a file
+    /// name or path naming convention.
+    ///
+    /// Header counts are hard facts read from the FITS/XISF header; naming
+    /// conventions are inference and can be wrong (renamed files, generic
+    /// tool defaults). [`detect_master`] lets decisive header evidence from
+    /// any registered detector outrank a naming-only (or no-evidence) match
+    /// returned by an earlier detector in the registry (issue #753).
+    pub stack_count_evidence: bool,
 }
 
 /// Trait implemented by each per-tool detector.
@@ -76,25 +88,37 @@ pub trait MasterDetector: Send + Sync {
 
 /// Return the ordered list of registered detectors.
 ///
-/// Detectors are tried in order; the first `Some` result wins. Add new
-/// detectors at the end to keep the existing priority unchanged.
+/// Detectors are tried in order; absent decisive header evidence (see
+/// [`detect_master`]), the first `Some` result wins. Add new detectors at the
+/// end to keep the existing priority unchanged.
 #[must_use]
 pub fn detectors() -> Vec<Box<dyn MasterDetector>> {
     vec![Box::new(PixInsightDetector), Box::new(SirilDetector)]
 }
 
-/// Run all registered detectors in priority order and return the first match.
+/// Run all registered detectors and return the strongest match.
+///
+/// A result backed by decisive header evidence
+/// (`MasterDetection::stack_count_evidence`) wins immediately, even if a
+/// weaker (naming-convention or no-evidence) result was already produced by
+/// an earlier detector in the registry — header facts must not be shadowed by
+/// registry ordering (issue #753). When no detector reports header evidence,
+/// the first `Some` result wins, preserving prior behaviour.
 ///
 /// Returns `None` only when no detector could determine even the base frame
 /// type from the supplied input.
 #[must_use]
 pub fn detect_master(input: &DetectInput<'_>) -> Option<MasterDetection> {
+    let mut fallback = None;
     for detector in detectors() {
         if let Some(result) = detector.detect(input) {
-            return Some(result);
+            if result.stack_count_evidence {
+                return Some(result);
+            }
+            fallback.get_or_insert(result);
         }
     }
-    None
+    fallback
 }
 
 // ── Shared base-frame-type parser ─────────────────────────────────────────────
@@ -210,5 +234,75 @@ mod tests {
     fn path_looks_like_master_negative() {
         assert!(!path_looks_like_master("dark_001.fit", "calibration/darks/"));
         assert!(!path_looks_like_master("light_001.fits", "lights/"));
+    }
+
+    // ── Registry-level tests (detect_master) ─────────────────────────────────
+    //
+    // These exercise the full registry, not a single detector, and
+    // deliberately avoid "master"/"_stacked" in fixture names so the naming
+    // heuristic cannot mask a registry-ordering bug (issue #753).
+
+    /// Issue #753 counter-example (spec 040 SC-001 scenario 2): a Siril
+    /// master renamed away from any "master"/"_stacked" convention must
+    /// still be detected via STACKCNT, even though PixInsightDetector runs
+    /// first in the registry and would otherwise win with a false negative.
+    #[test]
+    fn detect_master_prefers_stackcnt_evidence_over_earlier_registry_entry() {
+        let input = DetectInput {
+            imagetyp: Some("DARK"),
+            stack_count: Some(30),
+            file_name: "dark_030.fits",
+            rel_path: "calibration/darks/",
+        };
+        let result = detect_master(&input).unwrap();
+        assert_eq!(result.frame_type, FrameType::Dark);
+        assert!(result.is_master, "STACKCNT=30 must win even without 'master' in the name/path");
+        assert_eq!(result.detector, "siril");
+    }
+
+    /// A decisive STACKCNT=1 (definitely not stacked) must also win over an
+    /// earlier detector's naming-based positive guess. The `IMAGETYP` text
+    /// itself says "Master Dark" (PixInsight's naming convention) but
+    /// neither the file name nor path carries a "master"/"_stacked" signal,
+    /// isolating the registry-ordering decision from Siril's own path
+    /// heuristic.
+    #[test]
+    fn detect_master_prefers_stackcnt_negative_over_earlier_naming_positive() {
+        let input = DetectInput {
+            imagetyp: Some("Master Dark"),
+            stack_count: Some(1),
+            file_name: "dark_001.fits",
+            rel_path: "calibration/darks/",
+        };
+        let result = detect_master(&input).unwrap();
+        assert!(!result.is_master, "decisive STACKCNT=1 must override a naming-only positive");
+        assert_eq!(result.detector, "siril");
+    }
+
+    /// With no header evidence from any detector, first-registered
+    /// (PixInsight) still wins — preserves prior behaviour.
+    #[test]
+    fn detect_master_falls_back_to_first_match_without_header_evidence() {
+        let input = DetectInput {
+            imagetyp: Some("Master Dark"),
+            stack_count: None,
+            file_name: "masterDark.xisf",
+            rel_path: "masterDarks/",
+        };
+        let result = detect_master(&input).unwrap();
+        assert!(result.is_master);
+        assert_eq!(result.detector, "pixinsight");
+    }
+
+    /// No detector can determine anything → None.
+    #[test]
+    fn detect_master_returns_none_when_no_detector_matches() {
+        let input = DetectInput {
+            imagetyp: None,
+            stack_count: None,
+            file_name: "readme.txt",
+            rel_path: "",
+        };
+        assert!(detect_master(&input).is_none());
     }
 }

--- a/crates/calibration/master-detect/src/pixinsight.rs
+++ b/crates/calibration/master-detect/src/pixinsight.rs
@@ -63,7 +63,14 @@ impl MasterDetector for PixInsightDetector {
             infer_frame_type_from_path(input.file_name, input.rel_path)?
         };
 
-        Some(MasterDetection { frame_type, is_master, detector: self.id() })
+        // PixInsight/WBPP never write STACKCNT/NCOMBINE-derived masters; this
+        // detector's is_master is always a naming-convention inference.
+        Some(MasterDetection {
+            frame_type,
+            is_master,
+            detector: self.id(),
+            stack_count_evidence: false,
+        })
     }
 }
 

--- a/crates/calibration/master-detect/src/siril.rs
+++ b/crates/calibration/master-detect/src/siril.rs
@@ -35,9 +35,14 @@ impl MasterDetector for SirilDetector {
         let imagetyp = input.imagetyp?;
         let frame_type = parse_frame_type(imagetyp)?;
 
-        // Master detection: STACKCNT > 1 OR path / name contains _stacked / master.
-        let is_master = input.stack_count.is_some_and(|n| n > 1)
-            || path_looks_like_master(input.file_name, input.rel_path);
+        // Master detection: a present STACKCNT/NCOMBINE is authoritative and
+        // decides is_master on its own (>1 = stacked, <=1 = not) — the naming
+        // heuristic must not override a decisive header count. Only fall
+        // back to the naming heuristic when no header count is available.
+        let is_master = match input.stack_count {
+            Some(n) => n > 1,
+            None => path_looks_like_master(input.file_name, input.rel_path),
+        };
 
         // A present STACKCNT/NCOMBINE value is decisive header evidence
         // regardless of its verdict (>1 confirms stacking, <=1 confirms it is
@@ -134,6 +139,17 @@ mod tests {
         let result = SirilDetector.detect(&inp).unwrap();
         assert!(!result.is_master);
         assert!(result.stack_count_evidence, "STACKCNT=1 is still a decisive header read");
+    }
+
+    /// STACKCNT=1 is authoritative even when the file name/path also carries
+    /// a "master"/"_stacked" naming convention — a decisive header count
+    /// must not be overridden by the naming heuristic (review fix for #753).
+    #[test]
+    fn siril_stackcnt_one_overrides_master_naming() {
+        let inp = input(Some("DARK"), Some(1), "dark_master_stacked.fit", "calibration/");
+        let result = SirilDetector.detect(&inp).unwrap();
+        assert!(!result.is_master, "STACKCNT=1 must win over a 'master'/'_stacked' file name");
+        assert!(result.stack_count_evidence);
     }
 
     /// Missing IMAGETYP → None.

--- a/crates/calibration/master-detect/src/siril.rs
+++ b/crates/calibration/master-detect/src/siril.rs
@@ -39,7 +39,13 @@ impl MasterDetector for SirilDetector {
         let is_master = input.stack_count.is_some_and(|n| n > 1)
             || path_looks_like_master(input.file_name, input.rel_path);
 
-        Some(MasterDetection { frame_type, is_master, detector: self.id() })
+        // A present STACKCNT/NCOMBINE value is decisive header evidence
+        // regardless of its verdict (>1 confirms stacking, <=1 confirms it is
+        // a plain sub) — it must not be shadowed by another detector's
+        // naming-only guess (issue #753).
+        let stack_count_evidence = input.stack_count.is_some();
+
+        Some(MasterDetection { frame_type, is_master, detector: self.id(), stack_count_evidence })
     }
 }
 
@@ -69,6 +75,7 @@ mod tests {
         assert_eq!(result.frame_type, FrameType::Dark);
         assert!(result.is_master);
         assert_eq!(result.detector, "siril");
+        assert!(result.stack_count_evidence, "a present STACKCNT must be decisive header evidence");
     }
 
     /// Siril FITS master: IMAGETYP="FLAT" + STACKCNT=20 → Flat + is_master=true
@@ -87,6 +94,7 @@ mod tests {
         let result = SirilDetector.detect(&inp).unwrap();
         assert_eq!(result.frame_type, FrameType::Dark);
         assert!(result.is_master);
+        assert!(!result.stack_count_evidence, "naming-only match must not claim header evidence");
     }
 
     /// Siril master via "master" in file name, no STACKCNT.
@@ -125,6 +133,7 @@ mod tests {
         let inp = input(Some("DARK"), Some(1), "dark_001.fit", "calibration/darks/");
         let result = SirilDetector.detect(&inp).unwrap();
         assert!(!result.is_master);
+        assert!(result.stack_count_evidence, "STACKCNT=1 is still a decisive header read");
     }
 
     /// Missing IMAGETYP → None.


### PR DESCRIPTION
Closes #753.

`detect_master()` returned the first `Some` from the detector registry, letting `PixInsightDetector` (registered first) win with a naming-only verdict over `SirilDetector`'s decisive `STACKCNT`/`NCOMBINE` header evidence.

- Add `MasterDetection::stack_count_evidence`; `detect_master` returns immediately on a detector result backed by decisive header evidence, otherwise falls back to first-match (prior behavior unchanged).
- Inside `SirilDetector`, `stack_count` is now authoritative for `is_master` (`Some(n) => n > 1`); the filename heuristic applies only when no count header is present, so `STACKCNT=1` can no longer be overridden by a `master`/`_stacked` filename.
- Registry-level tests reproduce the issue's counter-example (`IMAGETYP=DARK`, `STACKCNT=30`, `dark_030.fits`), a decisive-negative case, the no-header-evidence fallback, and the `STACKCNT=1` + master-named-file precedence case.

Verify: `calibration_master_detect` 28/28, `scan_masters_integration` 7/7, `app_core_inbox` 165/165, workspace nextest 2225/2225, fmt+clippy clean.