### PR TITLE
fix: dev-tools Contracts page shows live calls, schemas, and replay

### DIFF
--- a/apps/desktop/src-tauri/src/commands/dev.rs
+++ b/apps/desktop/src-tauri/src/commands/dev.rs
@@ -10,8 +10,10 @@
 //! Commands:
 //! - `dev.contracts.list` — enumerate all registered contracts
 //! - `dev.calls.list`     — return the most recent N calls from the ring buffer
+//! - `dev.calls.push`     — record a call captured by the JS recording proxy
 //! - `dev.export`         — dump registry + calls to a JSON file
 
+use std::path::PathBuf;
 use std::sync::Mutex;
 
 use contracts_core::dev::{
@@ -76,6 +78,54 @@ impl CallBuffer {
     }
 }
 
+// ── Schema path resolution ────────────────────────────────────────────────────
+//
+// `app_core::dev_contracts::list_contracts` intentionally leaves `schema_path`
+// empty (its doc comment says the frontend computes it, but no such
+// computation exists client-side — the schema files live on disk and only
+// the Rust process knows where its own source checkout is). This table fills
+// in the subset of registry contracts whose JSON Schema file location is
+// currently known. Contracts without a discoverable schema file (most of the
+// non-dev registry — no schema was ever authored for them) legitimately keep
+// an empty path and render `schema.missing` (spec 021 follow-up #736).
+
+/// `(contract name, path relative to the repo root)` for every contract with
+/// a known schema file on disk.
+const KNOWN_SCHEMA_PATHS: &[(&str, &str)] = &[
+    (
+        "lifecycle.transition",
+        "specs/002-data-lifecycle-state-model/contracts/lifecycle.transition.json",
+    ),
+    ("provenance.read", "specs/002-data-lifecycle-state-model/contracts/provenance.read.json"),
+    ("settings.get", "specs/018-settings-configuration-model/contracts/settings.get.json"),
+    ("settings.update", "specs/018-settings-configuration-model/contracts/settings.update.json"),
+    ("dev.contracts.list", "packages/contracts/dev/dev.contracts.list.json"),
+    ("dev.calls.list", "packages/contracts/dev/dev.calls.list.json"),
+    ("dev.export", "packages/contracts/dev/dev.export.json"),
+];
+
+/// Repo root, resolved from this crate's manifest dir (`apps/desktop/src-tauri`)
+/// at compile time. Three levels up: `src-tauri` -> `desktop` -> `apps` -> root.
+fn repo_root() -> PathBuf {
+    let manifest_dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let joined = manifest_dir.join("../../..");
+    std::fs::canonicalize(&joined).unwrap_or(joined)
+}
+
+/// Fill in `schema_path` for contracts present in [`KNOWN_SCHEMA_PATHS`].
+fn attach_schema_paths(mut resp: DevContractsListResponse) -> DevContractsListResponse {
+    let root = repo_root();
+    for contract in &mut resp.contracts {
+        for (name, rel) in KNOWN_SCHEMA_PATHS {
+            if *name == contract.name {
+                contract.schema_path = root.join(rel).to_string_lossy().into_owned();
+                break;
+            }
+        }
+    }
+    resp
+}
+
 // ── Tauri commands ────────────────────────────────────────────────────────────
 
 /// `dev.contracts.list` — list all registered contracts (spec 021 US1).
@@ -93,10 +143,39 @@ pub async fn dev_contracts_list(
     let pool = state.repo.pool();
     let dev_mode = app_core::settings::resolve_setting(pool, "devMode", None)
         .await
-        .map(|v| v.as_bool().unwrap_or(false))
-        .unwrap_or(false);
+        .is_ok_and(|v| v.as_bool().unwrap_or(false));
 
-    app_core::dev_contracts::list_contracts(dev_mode, request)
+    app_core::dev_contracts::list_contracts(dev_mode, request).map(attach_schema_paths)
+}
+
+/// `dev.calls.push` — record a call captured by the JS-side recording proxy
+/// (spec 021 US2 / follow-up #736) into the shared ring buffer, so
+/// `dev.calls.list` and `dev.export` observe live calls too. The frontend
+/// recorder (`apps/desktop/src/dev/recorder.ts`) keeps its own buffer for
+/// instant, reactive rendering; this is a best-effort mirror for backend
+/// consumers (export). The call is already redacted client-side before this
+/// is invoked.
+///
+/// # Errors
+/// Returns `Err(String)` when `devMode` is disabled.
+#[tauri::command]
+#[specta::specta]
+pub async fn dev_calls_push(
+    state: State<'_, AppState>,
+    buffer: State<'_, CallBuffer>,
+    call: ContractCall,
+) -> Result<(), ContractError> {
+    let pool = state.repo.pool();
+    let dev_mode = app_core::settings::resolve_setting(pool, "devMode", None)
+        .await
+        .is_ok_and(|v| v.as_bool().unwrap_or(false));
+
+    if !dev_mode {
+        return Err(ContractError::internal("dev_mode.disabled: Developer mode is disabled."));
+    }
+
+    buffer.push(call);
+    Ok(())
 }
 
 /// `dev.calls.list` — return recent recorded calls (spec 021 US2).
@@ -115,11 +194,9 @@ pub async fn dev_calls_list(
     let pool = state.repo.pool();
     let dev_mode = app_core::settings::resolve_setting(pool, "devMode", None)
         .await
-        .map(|v| v.as_bool().unwrap_or(false))
-        .unwrap_or(false);
+        .is_ok_and(|v| v.as_bool().unwrap_or(false));
 
-    let limit =
-        request.limit.map(|n| (n as usize).clamp(1, CALL_BUFFER_CAP)).unwrap_or(CALL_BUFFER_CAP);
+    let limit = request.limit.map_or(CALL_BUFFER_CAP, |n| (n as usize).clamp(1, CALL_BUFFER_CAP));
 
     let calls = buffer.snapshot(limit);
 
@@ -143,8 +220,7 @@ pub async fn dev_export(
     let pool = state.repo.pool();
     let dev_mode = app_core::settings::resolve_setting(pool, "devMode", None)
         .await
-        .map(|v| v.as_bool().unwrap_or(false))
-        .unwrap_or(false);
+        .is_ok_and(|v| v.as_bool().unwrap_or(false));
 
     if !dev_mode {
         return Err(ContractError::internal("dev_mode.disabled: Developer mode is disabled."));
@@ -156,8 +232,8 @@ pub async fn dev_export(
 
     // Snapshot calls.
     let calls = buffer.snapshot(CALL_BUFFER_CAP);
-    let call_count = calls.len() as u32;
-    let contract_count = contracts_resp.contracts.len() as u32;
+    let call_count = u32::try_from(calls.len()).unwrap_or(u32::MAX);
+    let contract_count = u32::try_from(contracts_resp.contracts.len()).unwrap_or(u32::MAX);
 
     // Build export payload.
     let export = serde_json::json!({
@@ -204,8 +280,7 @@ pub async fn dev_schema_get(
     let pool = state.repo.pool();
     let dev_mode = app_core::settings::resolve_setting(pool, "devMode", None)
         .await
-        .map(|v| v.as_bool().unwrap_or(false))
-        .unwrap_or(false);
+        .is_ok_and(|v| v.as_bool().unwrap_or(false));
 
     if !dev_mode {
         return Err(ContractError::internal("dev_mode.disabled: Developer mode is disabled."));
@@ -291,5 +366,53 @@ mod tests {
         let buf = CallBuffer::new();
         assert_eq!(buf.snapshot(10).len(), 0);
         assert_eq!(buf.dropped(), 0);
+    }
+
+    // ── attach_schema_paths (#736) ────────────────────────────────────────────
+
+    use contracts_core::dev::{ContractMeta, DevContractsListResponse};
+
+    use super::attach_schema_paths;
+
+    fn make_meta(name: &str) -> ContractMeta {
+        ContractMeta {
+            name: name.to_owned(),
+            version: "1.0.0".to_owned(),
+            schema_path: String::new(),
+            direction: "ui-to-core".to_owned(),
+            replay_safe: true,
+            sensitive_fields: vec![],
+            ts_hash: None,
+            rust_hash: None,
+            mismatch: None,
+        }
+    }
+
+    #[test]
+    fn attach_schema_paths_fills_known_contracts_with_absolute_existing_path() {
+        let resp = DevContractsListResponse {
+            contracts: vec![make_meta("dev.contracts.list"), make_meta("settings.get")],
+        };
+        let resp = attach_schema_paths(resp);
+
+        for contract in &resp.contracts {
+            assert!(!contract.schema_path.is_empty(), "{} should get a path", contract.name);
+            let path = std::path::Path::new(&contract.schema_path);
+            assert!(path.is_absolute(), "{} path should be absolute", contract.name);
+            assert!(
+                path.exists(),
+                "{} schema file should exist at {}",
+                contract.name,
+                contract.schema_path
+            );
+        }
+    }
+
+    #[test]
+    fn attach_schema_paths_leaves_unknown_contracts_empty() {
+        let resp = DevContractsListResponse { contracts: vec![make_meta("sessions.list")] };
+        let resp = attach_schema_paths(resp);
+
+        assert_eq!(resp.contracts[0].schema_path, "");
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -37,7 +37,7 @@ use crate::commands::cleanup::{
 };
 #[cfg(feature = "dev-tools")]
 use crate::commands::dev::{
-    dev_calls_list, dev_contracts_list, dev_export, dev_schema_get, CallBuffer,
+    dev_calls_list, dev_calls_push, dev_contracts_list, dev_export, dev_schema_get, CallBuffer,
 };
 use crate::commands::equipment::{
     equipment_cameras_create, equipment_cameras_delete, equipment_cameras_list,
@@ -646,6 +646,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // developer diagnostics (spec 021) — dev-tools build only
         dev_contracts_list,
         dev_calls_list,
+        dev_calls_push,
         dev_export,
         dev_schema_get,
     ])

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1835,6 +1835,19 @@ export const commands = {
 	 */
 	devCallsList: (request: DevCallsListRequest_Deserialize) => typedError<DevCallsListResponse_Serialize, ContractError_Serialize>(__TAURI_INVOKE("dev_calls_list", { request })),
 	/**
+	 *  `dev.calls.push` — record a call captured by the JS-side recording proxy
+	 *  (spec 021 US2 / follow-up #736) into the shared ring buffer, so
+	 *  `dev.calls.list` and `dev.export` observe live calls too. The frontend
+	 *  recorder (`apps/desktop/src/dev/recorder.ts`) keeps its own buffer for
+	 *  instant, reactive rendering; this is a best-effort mirror for backend
+	 *  consumers (export). The call is already redacted client-side before this
+	 *  is invoked.
+	 * 
+	 *  # Errors
+	 *  Returns `Err(String)` when `devMode` is disabled.
+	 */
+	devCallsPush: (call: ContractCall_Deserialize) => typedError<null, ContractError_Serialize>(__TAURI_INVOKE("dev_calls_push", { call })),
+	/**
 	 *  `dev.export` — dump contract registry + calls to a JSON file (spec 021 US4).
 	 * 
 	 *  # Errors

--- a/apps/desktop/src/dev/CallList.tsx
+++ b/apps/desktop/src/dev/CallList.tsx
@@ -14,6 +14,7 @@ interface CallListProps {
   calls: ContractCall[];
   contracts: ContractMeta[];
   onViewSchema: (call: ContractCall) => void;
+  onReplay: (call: ContractCall) => void;
 }
 
 function formatDuration(ms: number | null): string {
@@ -31,7 +32,12 @@ function formatStarted(iso: string): string {
   }
 }
 
-export function CallList({ calls, contracts, onViewSchema }: CallListProps) {
+export function CallList({
+  calls,
+  contracts,
+  onViewSchema,
+  onReplay,
+}: CallListProps) {
   if (calls.length === 0) {
     return (
       <p className="alm-dev-calls__empty">
@@ -113,6 +119,7 @@ export function CallList({ calls, contracts, onViewSchema }: CallListProps) {
                       ? ' alm-dev-calls__replay-btn--safe'
                       : ' alm-dev-calls__replay-btn--unsafe')
                   }
+                  onClick={() => onReplay(call)}
                   disabled={!isReplaySafe}
                   title={
                     isReplaySafe

--- a/apps/desktop/src/dev/ContractsPage.tsx
+++ b/apps/desktop/src/dev/ContractsPage.tsx
@@ -14,13 +14,14 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import { commands } from '@/bindings/index';
-import { unwrap } from '@/api/ipc';
+import { unwrap, invoke } from '@/api/ipc';
 import type { ContractMeta, ContractCall } from '@/bindings/index';
 import { PageShell } from '@/components';
 import { ContractList } from './ContractList';
 import { CallList } from './CallList';
 import { SchemaViewer } from './SchemaViewer';
 import { pickDirectory } from '@/shared/native/picker';
+import { getCallSnapshot, subscribeRecorder } from './recorder';
 
 // ── Disabled stub ─────────────────────────────────────────────────────────────
 
@@ -46,7 +47,7 @@ function DevModeDisabledStub() {
 export function ContractsPage() {
   const [devMode, setDevMode] = useState<boolean | null>(null);
   const [contracts, setContracts] = useState<ContractMeta[]>([]);
-  const [calls, setCalls] = useState<ContractCall[]>([]);
+  const [calls, setCalls] = useState<ContractCall[]>(() => getCallSnapshot());
   const [selectedContract, setSelectedContract] = useState<ContractMeta | null>(
     null,
   );
@@ -85,20 +86,40 @@ export function ContractsPage() {
       .catch((e: unknown) => setError(String(e)));
   }, []);
 
-  const loadCalls = useCallback(() => {
-    commands
-      .devCallsList({ requestId: null, limit: null })
-      .then(unwrap)
-      .then((resp) => setCalls(resp.calls))
-      .catch((e: unknown) => setError(String(e)));
+  // Recent calls are read live from the JS-side recording proxy buffer
+  // (`recorder.ts`), which is populated in real time as the wrapped
+  // dispatcher records each call (spec 021 follow-up #736). This is the
+  // same buffer the recorder already exercises in its own tests; there is
+  // no backend round trip in the render path, so the list updates instantly
+  // (no manual refresh required).
+  const refreshCalls = useCallback(() => {
+    setCalls(getCallSnapshot());
   }, []);
 
   useEffect(() => {
-    if (devMode === true) {
-      loadContracts();
-      loadCalls();
+    if (devMode !== true) return;
+    loadContracts();
+    // `calls` is seeded from getCallSnapshot() at mount (useState initializer
+    // above); this only subscribes for subsequent live updates, so there is
+    // no synchronous setState call in the effect body itself.
+    return subscribeRecorder(refreshCalls);
+  }, [devMode, loadContracts, refreshCalls]);
+
+  const handleReplay = useCallback(async (call: ContractCall) => {
+    // Replay is only reachable from a `replaySafe` call row (CallList
+    // disables the button otherwise). Re-dispatches through the raw Tauri
+    // invoke name (dotted contract name -> snake_case fn name) with the
+    // exact (already-redacted) recorded request. The recording proxy is
+    // still installed, so this produces a brand-new `ContractCall` entry
+    // rather than mutating the original (spec 021 plan.md "Replay").
+    const cmd = call.contract.replace(/\./g, '_');
+    try {
+      await invoke(cmd, call.request as Record<string, unknown> | undefined);
+    } catch {
+      // The outcome (including errors) is captured as a new ContractCall by
+      // the recording proxy itself; nothing further to surface here.
     }
-  }, [devMode, loadContracts, loadCalls]);
+  }, []);
 
   const handleViewSchema = useCallback((contract: ContractMeta) => {
     setSelectedContract(contract);
@@ -181,7 +202,7 @@ export function ContractsPage() {
             <button
               type="button"
               className="alm-btn alm-btn--sm"
-              onClick={loadCalls}
+              onClick={refreshCalls}
               aria-label="Refresh calls"
             >
               Refresh calls
@@ -225,6 +246,7 @@ export function ContractsPage() {
             calls={calls}
             contracts={contracts}
             onViewSchema={handleViewSchemaForCall}
+            onReplay={handleReplay}
           />
         </section>
 

--- a/apps/desktop/src/dev/recorder.test.ts
+++ b/apps/desktop/src/dev/recorder.test.ts
@@ -85,6 +85,24 @@ describe('recorder ring buffer', () => {
     expect(snap[0].payloadTruncated).toBe(false);
   });
 
+  it('normalizes a generic snake_case cmd to the dotted contract name', async () => {
+    const dispatch = wrap(makeDispatch(), true);
+    await dispatch('dev_calls_list', {});
+
+    const snap = getCallSnapshot();
+    expect(snap[0].contract).toBe('dev.calls.list');
+  });
+
+  it('normalizes lifecycle_transition_apply/_preview to the single lifecycle.transition registry name', async () => {
+    const dispatch = wrap(makeDispatch(), true);
+    await dispatch('lifecycle_transition_apply', { id: 'x' });
+    await dispatch('lifecycle_transition_preview', { id: 'x' });
+
+    const snap = getCallSnapshot();
+    expect(snap[1].contract).toBe('lifecycle.transition');
+    expect(snap[0].contract).toBe('lifecycle.transition');
+  });
+
   it('records failed call with error, does not store response', async () => {
     const dispatch = wrap(makeFailingDispatch('not_found', 'Not found'), true);
     await expect(dispatch('targets.get', { id: 'x' })).rejects.toThrow(

--- a/apps/desktop/src/dev/recorder.ts
+++ b/apps/desktop/src/dev/recorder.ts
@@ -132,20 +132,34 @@ function pushCall(call: ContractCall): void {
 // ── Contract name normalization ─────────────────────────────────────────────
 
 /**
+ * Explicit aliases for commands whose Tauri fn name has MORE segments than
+ * the registry's dotted contract name — the blanket underscore-to-dot
+ * fallback below only recovers names where the two shapes are 1:1.
+ * `lifecycle.transition` is one logical (replay-unsafe) registry operation
+ * split into two backend command variants; both must resolve to the same
+ * `ContractMeta`. Add further entries here if another such split appears.
+ */
+const CONTRACT_NAME_ALIASES: Record<string, string> = {
+  lifecycle_transition_apply: 'lifecycle.transition',
+  lifecycle_transition_preview: 'lifecycle.transition',
+};
+
+/**
  * Normalize a Tauri invoke command name to the dotted contract-registry name.
  *
  * The real dispatcher receives the Rust `#[tauri::command]` fn name
  * (snake_case, e.g. `dev_calls_list`), not the dotted operation name used in
  * `ContractMeta.name` (e.g. `dev.calls.list`) — `tauri-specta` registers
  * commands under the Rust fn name (see `apps/desktop/src-tauri/tests/bindings.rs`
- * "IPC name alignment regression"). Every current registry entry follows a
- * `namespace_operation` -> `namespace.operation` shape, so a blanket
- * underscore-to-dot replacement recovers the dotted name. Commands outside
- * the dev registry simply fail to match a `ContractMeta` afterward, same as
- * before normalization (spec 021 follow-up #736).
+ * "IPC name alignment regression"). Every current registry entry EXCEPT
+ * `lifecycle.transition` (see `CONTRACT_NAME_ALIASES`) follows a 1:1
+ * `namespace_operation` -> `namespace.operation` shape, so aliases are
+ * checked first and a blanket underscore-to-dot replacement is the fallback.
+ * Commands outside the dev registry simply fail to match a `ContractMeta`
+ * afterward, same as before normalization (spec 021 follow-up #736).
  */
 function toContractName(cmd: string): string {
-  return cmd.replace(/_/g, '.');
+  return CONTRACT_NAME_ALIASES[cmd] ?? cmd.replace(/_/g, '.');
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/dev/recorder.ts
+++ b/apps/desktop/src/dev/recorder.ts
@@ -129,6 +129,25 @@ function pushCall(call: ContractCall): void {
   notify();
 }
 
+// ── Contract name normalization ─────────────────────────────────────────────
+
+/**
+ * Normalize a Tauri invoke command name to the dotted contract-registry name.
+ *
+ * The real dispatcher receives the Rust `#[tauri::command]` fn name
+ * (snake_case, e.g. `dev_calls_list`), not the dotted operation name used in
+ * `ContractMeta.name` (e.g. `dev.calls.list`) — `tauri-specta` registers
+ * commands under the Rust fn name (see `apps/desktop/src-tauri/tests/bindings.rs`
+ * "IPC name alignment regression"). Every current registry entry follows a
+ * `namespace_operation` -> `namespace.operation` shape, so a blanket
+ * underscore-to-dot replacement recovers the dotted name. Commands outside
+ * the dev registry simply fail to match a `ContractMeta` afterward, same as
+ * before normalization (spec 021 follow-up #736).
+ */
+function toContractName(cmd: string): string {
+  return cmd.replace(/_/g, '.');
+}
+
 // ── Public API ────────────────────────────────────────────────────────────────
 
 /** Subscribe to buffer changes. Returns an unsubscribe function. */
@@ -197,7 +216,8 @@ export function wrap(
     const startedAt = new Date().toISOString();
     const t0 = performance.now();
 
-    const sensitiveFields = sensitiveByContract.get(cmd) ?? [];
+    const contract = toContractName(cmd);
+    const sensitiveFields = sensitiveByContract.get(contract) ?? [];
     const rawRequest = args ?? {};
     const redactedRequest = redactPayload(rawRequest, sensitiveFields);
     const { value: storedRequest, truncated: reqTruncated } =
@@ -230,9 +250,9 @@ export function wrap(
 
     const durationMs = performance.now() - t0;
 
-    pushCall({
+    const record: ContractCall = {
       id,
-      contract: cmd,
+      contract,
       contractVersion: '1.0.0',
       request: storedRequest,
       response,
@@ -240,7 +260,18 @@ export function wrap(
       startedAt,
       durationMs,
       payloadTruncated: reqTruncated || resTruncated,
-    });
+    };
+    pushCall(record);
+
+    // Best-effort mirror into the backend ring buffer so `dev.export` also
+    // observes live calls (spec 021 follow-up #736). Uses the raw dispatcher
+    // captured above — NOT `recordingDispatch` itself — so this forwarding
+    // call is never recorded (would otherwise recurse). Failures (e.g. the
+    // command not yet available, or `devMode` racing off) are swallowed:
+    // the JS-side buffer above is the source of truth for the UI.
+    if (cmd !== 'dev_calls_push') {
+      void dispatch('dev_calls_push', { call: record }).catch(() => {});
+    }
 
     if (error)
       throw Object.assign(new Error(error.message), { code: error.code });


### PR DESCRIPTION
## Summary
- The developer Contracts page (dev-tools builds only) now works end-to-end: the Recent Calls list reads live from the IPC recorder buffer instead of a dead `dev.calls.list` round trip, and recorded calls are mirrored to the backend so `dev.export` includes them.
- `schema_path` is now populated for the 7 registry contracts that have schema files on disk; the remaining 7 correctly report `schema.missing` (pre-existing gap, tracked separately).
- The Replay button re-dispatches the recorded (redacted) request through the recording proxy, gated by per-contract replay-safety with a safe default of non-replayable.
- Fixed recorded command names: snake_case Tauri invoke names are normalized to dotted contract names (with an explicit alias for the multi-segment `lifecycle.transition` contract), so schema lookup and replay-safety classification match the registry.

Everything remains compile-time gated behind the workspace `dev-tools` feature and absent from release builds.

Closes #736.