### PR TITLE
fix: plan apply confirms destructive actions, retries mid-run failures, and can be cancelled

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -389,6 +389,10 @@
   "inbox_system_trash": "System Trash",
   "inbox_unchanged_placeholder": "— unchanged —",
   "inbox_where_source_files_go": "Where should removed source files go?",
+  "inbox_confirm_destructive_label": "I confirm the destructive items below may be applied.",
+  "inbox_confirm_destructive_confirming": "Confirming…",
+  "inbox_confirm_destructive_failed": "Could not confirm the destructive items.",
+  "inbox_confirm_destructive_aria": "Confirm destructive plan items",
   "logpanel_aria_label": "Operation log",
   "logpanel_diagnostics": "Diagnostics",
   "logpanel_empty": "No log entries",
@@ -2272,6 +2276,12 @@
   "plans_review_retry_btn": "Generate retry plan",
   "plans_review_retrying": "Generating retry plan…",
   "plans_review_retry_created_toast": "Retry plan created — review it before applying.",
+  "plans_review_cancel_run_btn": "Cancel apply",
+  "plans_review_cancelling": "Cancelling…",
+  "plans_review_cancel_failed": "Could not cancel the run.",
+  "plans_review_confirm_destructive_label": "I confirm these items may be deleted.",
+  "plans_review_confirm_destructive_confirming": "Confirming…",
+  "plans_review_confirm_destructive_failed": "Could not confirm the destructive items.",
   "projects_cleanup_group_meta": [
     {
       "declarations": [

--- a/apps/desktop/src-tauri/src/commands/plan_apply.rs
+++ b/apps/desktop/src-tauri/src/commands/plan_apply.rs
@@ -4,13 +4,16 @@
 //! Plan apply Tauri commands (spec 025).
 //!
 //! Implements the five JSON-Schema contracts under
-//! `specs/025-filesystem-plan-application/contracts/`:
+//! `specs/025-filesystem-plan-application/contracts/`, plus one additional
+//! confirm command (issue #741, not part of the original spec 025 contract
+//! set — the DB column it writes predates this command by several specs):
 //! - `plans.apply`       — start applying an approved plan.
 //! - `plans.cancel`      — cancel an in-flight apply.
 //! - `plans.resume`      — resume a paused apply run.
 //! - `plans.item.skip`   — skip a pending item.
 //! - `plans.item.retry`  — retry a failed item.
 //! - `plans.apply.status`— fetch current apply status.
+//! - `plans.confirm.destructive` — confirm a plan's delete/trash items.
 //!
 //! All state-machine enforcement lives in `crates/app/core/src/plan_apply.rs`.
 //! These commands are thin adapters: validate inputs, delegate, return DTOs.
@@ -18,13 +21,15 @@
 use std::sync::Arc;
 
 use app_core::plan_apply::{
-    apply_plan, apply_plan_channel_free, cancel_plan, get_apply_status, resume_plan,
-    retry_plan_item, skip_plan_item, OperationEventSink,
+    apply_plan, apply_plan_channel_free, cancel_plan, confirm_plan_destructive_items,
+    get_apply_status, resume_plan, retry_plan_item, skip_plan_item, OperationEventSink,
 };
 use contracts_core::plan_apply::{
     PlanApplyResponse, PlanApplyStatus, PlanCancelResponse, PlanItemRetryResponse,
     PlanItemSkipResponse, PlanResumeResponse,
 };
+use serde::Serialize;
+use specta::Type;
 use tauri::ipc::Channel;
 use tauri::State;
 
@@ -190,6 +195,43 @@ pub async fn plans_item_retry(
     item_id: String,
 ) -> Result<PlanItemRetryResponse, ContractError> {
     retry_plan_item(state.repo.pool(), &plan_id, &item_id).await
+}
+
+// ── plans.confirm.destructive ─────────────────────────────────────────────────
+
+/// Response for `plans.confirm.destructive`.
+///
+/// Local to this command (rather than a `contracts_core::plan_apply` DTO):
+/// the shape is a plain confirmation receipt with no other consumer.
+#[derive(Clone, Debug, Serialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanDestructiveConfirmResponse {
+    pub plan_id: String,
+    /// Number of items whose `destructive_confirmed` flag flipped (0 when
+    /// every destructive item in the plan was already confirmed).
+    pub items_confirmed: i64,
+}
+
+/// `plans.confirm.destructive` — confirm every delete/trash item in a plan
+/// (FR-003, D9, issue #741).
+///
+/// Persists `destructive_confirmed = 1` on the plan's destructive items so a
+/// subsequent apply does not refuse them at the executor's
+/// destructive-confirm gate. Plan-level, not per-item — see
+/// `confirm_plan_destructive_items`'s doc comment for why.
+///
+/// # Errors
+///
+/// Returns `Err(ContractError)` with `"plan.not_found"` if the plan does not
+/// exist.
+#[tauri::command]
+#[specta::specta]
+pub async fn plans_confirm_destructive(
+    state: State<'_, AppState>,
+    plan_id: String,
+) -> Result<PlanDestructiveConfirmResponse, ContractError> {
+    let items_confirmed = confirm_plan_destructive_items(state.repo.pool(), &plan_id).await?;
+    Ok(PlanDestructiveConfirmResponse { plan_id, items_confirmed })
 }
 
 // ── plans.apply.status ────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -78,8 +78,8 @@ use crate::commands::patterns::{
     pattern_path_preview, pattern_preview, pattern_resolve, pattern_validate,
 };
 use crate::commands::plan_apply::{
-    plans_apply_direct, plans_apply_real, plans_apply_status, plans_cancel, plans_item_retry,
-    plans_item_skip, plans_resume,
+    plans_apply_direct, plans_apply_real, plans_apply_status, plans_cancel,
+    plans_confirm_destructive, plans_item_retry, plans_item_skip, plans_resume,
 };
 use crate::commands::plans::{
     archive_list, archive_permanently_delete, archive_plan_generate, archive_send_to_trash,
@@ -265,6 +265,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         plans_item_skip,
         plans_item_retry,
         plans_apply_status,
+        plans_confirm_destructive,
         // audit
         audit_list,
         audit_export,
@@ -502,6 +503,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         plans_item_skip,
         plans_item_retry,
         plans_apply_status,
+        plans_confirm_destructive,
         // audit
         audit_list,
         audit_export,

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1367,6 +1367,13 @@ export async function mockInvoke(
     case 'protection_plan_acknowledged': {
       return 'mock-audit-ack';
     }
+    case 'plans_confirm_destructive': {
+      // FR-003/D9/issue #741: persists `destructive_confirmed` so the
+      // review overlay's destructive-confirm gate unlocks Approve & apply.
+      const planId =
+        (_args as { planId?: string } | undefined)?.planId ?? 'mock-plan';
+      return { planId, itemsConfirmed: 1 };
+    }
     case 'cleanup_scan': {
       // D11 step 1: pure read-only preview. Reason strings follow the backend
       // generator format (see cleanup_generator.rs::scan_with_policy).

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -699,6 +699,21 @@ export const commands = {
 	 */
 	plansApplyStatus: (planId: string) => typedError<PlanApplyStatus_Serialize, ContractError_Serialize>(__TAURI_INVOKE("plans_apply_status", { planId })),
 	/**
+	 *  `plans.confirm.destructive` — confirm every delete/trash item in a plan
+	 *  (FR-003, D9, issue #741).
+	 * 
+	 *  Persists `destructive_confirmed = 1` on the plan's destructive items so a
+	 *  subsequent apply does not refuse them at the executor's
+	 *  destructive-confirm gate. Plan-level, not per-item — see
+	 *  `confirm_plan_destructive_items`'s doc comment for why.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(ContractError)` with `"plan.not_found"` if the plan does not
+	 *  exist.
+	 */
+	plansConfirmDestructive: (planId: string) => typedError<PlanDestructiveConfirmResponse, ContractError_Serialize>(__TAURI_INVOKE("plans_confirm_destructive", { planId })),
+	/**
 	 *  `audit.list` — returns paginated audit entries read from `audit_log_entry`.
 	 * 
 	 *  # Errors
@@ -5955,6 +5970,21 @@ export type PlanCancelResponse = {
 	itemsApplied: number,
 	/**  Items transitioned from pending to cancelled. */
 	itemsCancelled: number,
+};
+
+/**
+ *  Response for `plans.confirm.destructive`.
+ * 
+ *  Local to this command (rather than a `contracts_core::plan_apply` DTO):
+ *  the shape is a plain confirmation receipt with no other consumer.
+ */
+export type PlanDestructiveConfirmResponse = {
+	planId: string,
+	/**
+	 *  Number of items whose `destructive_confirmed` flag flipped (0 when
+	 *  every destructive item in the plan was already confirmed).
+	 */
+	itemsConfirmed: number,
 };
 
 /**  Full plan detail returned by `plans.get`. */

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -533,7 +533,9 @@ export function PlanPanel({
     setConfirmDestructiveError(null);
     try {
       await Promise.all(
-        pending.map(async (id) => unwrap(await commands.plansConfirmDestructive(id))),
+        pending.map(async (id) =>
+          unwrap(await commands.plansConfirmDestructive(id)),
+        ),
       );
       setConfirmedPlanIds((prev) => new Set([...prev, ...pending]));
     } catch (e) {
@@ -925,7 +927,9 @@ export function PlanPanel({
                       disabled={
                         busy ||
                         plan.stale ||
-                        (plan.actions.some((a) => a.requiresDestructiveConfirm) &&
+                        (plan.actions.some(
+                          (a) => a.requiresDestructiveConfirm,
+                        ) &&
                           !confirmedPlanIds.has(plan.planId))
                       }
                       data-testid={`plan-apply-one-${plan.inboxItemId}`}

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -18,6 +18,9 @@
 
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Banner, Btn } from '@/ui';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import { errMessage } from '@/lib/errors';
 import type { PlanApplyProgress } from '@/features/plans/usePlanApplyProgress';
 import type { InboxOpenPlan, InboxPlanAction } from './store';
 import { m } from '@/lib/i18n';
@@ -495,6 +498,51 @@ export function PlanPanel({
     [plans],
   );
 
+  // Destructive-confirm gate (FR-003, D9, issue #741): `destructive_confirmed`
+  // had no writer anywhere, so every plan with a trash/delete item was
+  // permanently refused at apply time. Plan-level (not per-item —
+  // `InboxPlanAction` carries no item id), matching the destructive-destination
+  // control above. Tracked by plan id rather than a single boolean so newly
+  // arrived destructive plans are not mistaken for already-confirmed ones.
+  const [confirmedPlanIds, setConfirmedPlanIds] = useState<Set<string>>(
+    new Set(),
+  );
+  const [confirmingDestructive, setConfirmingDestructive] = useState(false);
+  const [confirmDestructiveError, setConfirmDestructiveError] = useState<
+    string | null
+  >(null);
+
+  const destructivePlanIds = useMemo(
+    () =>
+      plans
+        .filter((p) => p.actions.some((a) => a.requiresDestructiveConfirm))
+        .map((p) => p.planId),
+    [plans],
+  );
+  const allDestructiveConfirmed = destructivePlanIds.every((id) =>
+    confirmedPlanIds.has(id),
+  );
+
+  const handleConfirmDestructive = useCallback(async () => {
+    if (confirmingDestructive) return;
+    const pending = destructivePlanIds.filter(
+      (id) => !confirmedPlanIds.has(id),
+    );
+    if (pending.length === 0) return;
+    setConfirmingDestructive(true);
+    setConfirmDestructiveError(null);
+    try {
+      await Promise.all(
+        pending.map(async (id) => unwrap(await commands.plansConfirmDestructive(id))),
+      );
+      setConfirmedPlanIds((prev) => new Set([...prev, ...pending]));
+    } catch (e) {
+      setConfirmDestructiveError(errMessage(e));
+    } finally {
+      setConfirmingDestructive(false);
+    }
+  }, [confirmingDestructive, destructivePlanIds, confirmedPlanIds]);
+
   const selectedArray = useMemo(() => [...selected], [selected]);
   const anySelectedStale = false; // selection set never contains stale plans by construction
   const allSelectableSelected =
@@ -578,8 +626,12 @@ export function PlanPanel({
   }
 
   const applySelectedDisabled =
-    busy || selectedArray.length === 0 || anySelectedStale;
-  const applyAllDisabled = busy || plans.length === 0;
+    busy ||
+    selectedArray.length === 0 ||
+    anySelectedStale ||
+    !allDestructiveConfirmed;
+  const applyAllDisabled =
+    busy || plans.length === 0 || !allDestructiveConfirmed;
 
   return (
     <div className="alm-plan-panel" data-testid="plan-panel">
@@ -870,7 +922,12 @@ export function PlanPanel({
                       variant="ghost"
                       size="sm"
                       onClick={() => onApplyOne(plan.planId)}
-                      disabled={busy || plan.stale}
+                      disabled={
+                        busy ||
+                        plan.stale ||
+                        (plan.actions.some((a) => a.requiresDestructiveConfirm) &&
+                          !confirmedPlanIds.has(plan.planId))
+                      }
                       data-testid={`plan-apply-one-${plan.inboxItemId}`}
                       aria-label={m.inbox_apply_plan_live_aria({
                         name: plan.itemName,
@@ -1063,6 +1120,29 @@ export function PlanPanel({
               <span>{m.inbox_system_trash()}</span>
             </label>
           </div>
+
+          {/* Destructive-confirm gate (FR-003, D9, issue #741): destructive
+              items (trash/delete) were previously refused permanently at
+              apply time — `destructive_confirmed` had no writer. Plan-level
+              (not per-item — `InboxPlanAction` carries no item id). */}
+          <label className="alm-plan-panel__dest-label">
+            <input
+              type="checkbox"
+              checked={allDestructiveConfirmed}
+              disabled={confirmingDestructive || allDestructiveConfirmed}
+              onChange={() => void handleConfirmDestructive()}
+              aria-label={m.inbox_confirm_destructive_aria()}
+              data-testid="plan-destructive-confirm"
+            />
+            <span>
+              {confirmingDestructive
+                ? m.inbox_confirm_destructive_confirming()
+                : m.inbox_confirm_destructive_label()}
+            </span>
+          </label>
+          {confirmDestructiveError !== null && (
+            <Banner variant="danger">{confirmDestructiveError}</Banner>
+          )}
         </div>
       )}
     </div>

--- a/apps/desktop/src/features/inbox/__tests__/PlanPanel.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/PlanPanel.test.tsx
@@ -17,7 +17,17 @@
  */
 
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const { mockPlansConfirmDestructive } = vi.hoisted(() => ({
+  mockPlansConfirmDestructive: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    plansConfirmDestructive: mockPlansConfirmDestructive,
+  },
+}));
 
 // Per-signature spy types. `vi.fn<Fn>()` yields a callable `Mock<Fn>` that the
 // project's strict types accept as a plain function prop — unlike the bare
@@ -117,6 +127,11 @@ describe('PlanPanel (aggregate surface)', { timeout: 15_000 }, () => {
     onApplyAll = vi.fn<() => void>();
     onCancel = vi.fn<(id: string) => void>();
     onDestructiveChange = vi.fn<(d: DestructiveDestination) => void>();
+    mockPlansConfirmDestructive.mockReset();
+    mockPlansConfirmDestructive.mockResolvedValue({
+      status: 'ok',
+      data: { planId: 'plan-1', itemsConfirmed: 1 },
+    });
   });
 
   // ── Aggregate rendering ────────────────────────────────────────────────────
@@ -512,6 +527,49 @@ describe('PlanPanel (aggregate surface)', { timeout: 15_000 }, () => {
     );
     fireEvent.click(screen.getByTestId('plan-destructive-trash'));
     expect(onDestructiveChange).toHaveBeenCalledWith('trash');
+  });
+
+  // ── Destructive-confirm gate (FR-003, D9, issue #741) ──────────────────────
+
+  it('blocks Apply all until the destructive-confirm checkbox is confirmed', () => {
+    renderPanel([
+      makePlan({
+        planId: 'plan-1',
+        actions: [makeAction({ requiresDestructiveConfirm: true })],
+      }),
+    ]);
+    expect(
+      (screen.getByTestId('plan-apply-all') as HTMLButtonElement).disabled,
+    ).toBe(true);
+    const confirmBox = screen.getByTestId(
+      'plan-destructive-confirm',
+    ) as HTMLInputElement;
+    expect(confirmBox.checked).toBe(false);
+  });
+
+  it('confirming destructive items calls plans.confirm.destructive and unblocks Apply all', async () => {
+    renderPanel([
+      makePlan({
+        planId: 'plan-1',
+        actions: [makeAction({ requiresDestructiveConfirm: true })],
+      }),
+    ]);
+    fireEvent.click(screen.getByTestId('plan-destructive-confirm'));
+    await waitFor(() =>
+      expect(mockPlansConfirmDestructive).toHaveBeenCalledWith('plan-1'),
+    );
+    await waitFor(() =>
+      expect(
+        (screen.getByTestId('plan-apply-all') as HTMLButtonElement).disabled,
+      ).toBe(false),
+    );
+  });
+
+  it('does not gate Apply all on destructive-confirm when no action requires it', () => {
+    renderPanel([makePlan({ actions: [makeAction()] })]);
+    expect(
+      (screen.getByTestId('plan-apply-all') as HTMLButtonElement).disabled,
+    ).toBe(false);
   });
 
   // ── Busy ───────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -569,8 +569,6 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
 
     const cancelBtn = await screen.findByTestId('plan-review-cancel-run');
     fireEvent.click(cancelBtn);
-    await waitFor(() =>
-      expect(mockPlansCancel).toHaveBeenCalledWith('plan-1'),
-    );
+    await waitFor(() => expect(mockPlansCancel).toHaveBeenCalledWith('plan-1'));
   });
 });

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -32,6 +32,8 @@ const {
   mockPlansDiscard,
   mockPlansRetry,
   mockPlansResume,
+  mockPlansCancel,
+  mockPlansConfirmDestructive,
   mockProtectionCheck,
   mockAcknowledge,
   mockApplyPlan,
@@ -41,6 +43,8 @@ const {
   mockPlansDiscard: vi.fn(),
   mockPlansRetry: vi.fn(),
   mockPlansResume: vi.fn(),
+  mockPlansCancel: vi.fn(),
+  mockPlansConfirmDestructive: vi.fn(),
   mockProtectionCheck: vi.fn(),
   mockAcknowledge: vi.fn(),
   mockApplyPlan: vi.fn(),
@@ -53,6 +57,8 @@ vi.mock('@/bindings/index', () => ({
     plansDiscard: mockPlansDiscard,
     plansRetry: mockPlansRetry,
     plansResume: mockPlansResume,
+    plansCancel: mockPlansCancel,
+    plansConfirmDestructive: mockPlansConfirmDestructive,
     planProtectionCheckCmd: mockProtectionCheck,
     protectionPlanAcknowledged: mockAcknowledge,
   },
@@ -176,6 +182,17 @@ beforeEach(() => {
   );
   mockPlansDiscard.mockResolvedValue(
     ok({ planId: 'plan-1', discardedAt: '2026-07-01T00:00:00Z' }),
+  );
+  mockPlansCancel.mockResolvedValue(
+    ok({
+      planId: 'plan-1',
+      cancelledAt: '2026-07-01T00:00:00Z',
+      itemsApplied: 0,
+      itemsCancelled: 1,
+    }),
+  );
+  mockPlansConfirmDestructive.mockResolvedValue(
+    ok({ planId: 'plan-1', itemsConfirmed: 1 }),
   );
   // Default apply: streams item events then a completed terminal event.
   mockApplyPlan.mockImplementation(
@@ -492,5 +509,68 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
       expect(screen.getByText(/No protected items/)).toBeInTheDocument(),
     );
     expect(approveBtn).toBeDisabled();
+  });
+
+  it('keeps Approve & apply disabled for a delete item until destructive-confirm succeeds (issue #741)', async () => {
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    mockPlansGet.mockResolvedValue(
+      ok(
+        plan({
+          items: [item({ action: 'delete', to: '' })],
+        }),
+      ),
+    );
+    renderOverlay();
+
+    const approveBtn = await screen.findByTestId('plan-review-approve-apply');
+    const confirmBox = await screen.findByTestId(
+      'plan-review-confirm-destructive',
+    );
+    // Protection gate is already satisfied (no protected items), but the
+    // destructive-confirm checkbox is unchecked — Approve & apply stays
+    // blocked until it is confirmed.
+    await waitFor(() => expect(approveBtn).toBeDisabled());
+    expect(confirmBox).not.toBeChecked();
+
+    fireEvent.click(confirmBox);
+    await waitFor(() =>
+      expect(mockPlansConfirmDestructive).toHaveBeenCalledWith('plan-1'),
+    );
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+  });
+
+  it('offers Cancel apply during a running apply and calls plan.cancel (US3/FR-009, issue #743)', async () => {
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    // Never emits a terminal event — the run stays "running" so Cancel stays
+    // available (mirrors the pause test's no-terminal-event pattern above).
+    mockApplyPlan.mockImplementation(
+      (args: { id: string; onEvent?: (e: OperationEvent) => void }) => {
+        args.onEvent?.({
+          contractVersion: '1.0.0',
+          operationId: 'op-1',
+          eventType: 'item_started',
+          sequence: 0,
+          payload: { itemsTotal: 2, runId: 'run-1' },
+        });
+        return new Promise(() => {
+          /* never resolves within the test — run stays live */
+        });
+      },
+    );
+
+    renderOverlay();
+    const approveBtn = await screen.findByTestId('plan-review-approve-apply');
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+    fireEvent.click(approveBtn);
+
+    const cancelBtn = await screen.findByTestId('plan-review-cancel-run');
+    fireEvent.click(cancelBtn);
+    await waitFor(() =>
+      expect(mockPlansCancel).toHaveBeenCalledWith('plan-1'),
+    );
   });
 });

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -111,12 +111,27 @@ export function PlanReviewOverlay({
   // real terminal plan state to decide whether to offer "Generate retry plan".
   const [finalState, setFinalState] = useState<string | null>(null);
   const [resuming, setResuming] = useState(false);
+  const [cancelling, setCancelling] = useState(false);
   const {
     progress,
     run: runApply,
     resume: resumeApply,
+    cancel: cancelApply,
     reset: resetApply,
   } = usePlanApplyProgress();
+
+  // Destructive-confirm gate (FR-003, D9, issue #741): `delete` items are
+  // permanently refused at apply time until `destructive_confirmed` is set.
+  // Plan-level (not per-item — `PlanItemDetail` carries no such flag; the
+  // gate mirrors the existing plan-wide protection gate above it).
+  const hasDestructiveItems = (plan?.items ?? []).some(
+    (item) => item.action === 'delete',
+  );
+  const [destructiveConfirmed, setDestructiveConfirmed] = useState(false);
+  const [confirmingDestructive, setConfirmingDestructive] = useState(false);
+  const [confirmDestructiveError, setConfirmDestructiveError] = useState<
+    string | null
+  >(null);
 
   const busy = approving || discarding || retrying || progress.running;
   const applied = finalState === 'applied';
@@ -139,8 +154,26 @@ export function PlanReviewOverlay({
     setApplyError(null);
     setGateReady(false);
     setFinalState(null);
+    setDestructiveConfirmed(false);
+    setConfirmDestructiveError(null);
     onClose();
   }, [busy, onClose, resetApply]);
+
+  /** Persist the destructive-confirm flag for this plan (`plans.confirm.destructive`,
+   * issue #741) before Approve & apply unlocks. */
+  const handleConfirmDestructive = useCallback(async () => {
+    if (planId === null || confirmingDestructive) return;
+    setConfirmingDestructive(true);
+    setConfirmDestructiveError(null);
+    try {
+      unwrap(await commands.plansConfirmDestructive(planId));
+      setDestructiveConfirmed(true);
+    } catch (e) {
+      setConfirmDestructiveError(errMessage(e));
+    } finally {
+      setConfirmingDestructive(false);
+    }
+  }, [planId, confirmingDestructive]);
 
   const handleApproveAndApply = useCallback(async () => {
     if (planId === null || busy) return;
@@ -169,6 +202,17 @@ export function PlanReviewOverlay({
       setApplyError(m.plans_review_apply_failed());
     }
   }, [planId, busy, runApply, invalidatePlan, onApplied]);
+
+  /** Cancel the currently-streaming apply run (`plan.cancel`, US3/FR-009,
+   * issue #743). The channel already delivers the resulting terminal event;
+   * this only signals the backend and surfaces a failure to send it. */
+  const handleCancelRun = useCallback(async () => {
+    if (planId === null || cancelling) return;
+    setCancelling(true);
+    const ok = await cancelApply(planId);
+    setCancelling(false);
+    if (!ok) setApplyError(m.plans_review_cancel_failed());
+  }, [planId, cancelling, cancelApply]);
 
   const handleDiscard = useCallback(async () => {
     if (planId === null || busy) return;
@@ -290,7 +334,13 @@ export function PlanReviewOverlay({
       <Btn
         variant="danger"
         onClick={() => void handleApproveAndApply()}
-        disabled={busy || !gateReady || plan == null || plan.itemsTotal === 0}
+        disabled={
+          busy ||
+          !gateReady ||
+          plan == null ||
+          plan.itemsTotal === 0 ||
+          (hasDestructiveItems && !destructiveConfirmed)
+        }
         data-testid="plan-review-approve-apply"
       >
         {approving
@@ -356,6 +406,32 @@ export function PlanReviewOverlay({
             onAcknowledgedChange={setGateReady}
           />
 
+          {/* Destructive-confirm gate (FR-003, D9, issue #741): delete items
+              are refused at apply time until confirmed. Plan-level — see
+              `handleConfirmDestructive`. */}
+          {hasDestructiveItems && (
+            <div className="alm-plan-review__destructive-gate">
+              <label className="alm-plan-review__destructive-label">
+                <input
+                  type="checkbox"
+                  checked={destructiveConfirmed}
+                  disabled={confirmingDestructive || destructiveConfirmed}
+                  onChange={() => void handleConfirmDestructive()}
+                  aria-label={m.plans_review_confirm_destructive_label()}
+                  data-testid="plan-review-confirm-destructive"
+                />
+                <span>
+                  {confirmingDestructive
+                    ? m.plans_review_confirm_destructive_confirming()
+                    : m.plans_review_confirm_destructive_label()}
+                </span>
+              </label>
+              {confirmDestructiveError !== null && (
+                <Banner variant="danger">{confirmDestructiveError}</Banner>
+              )}
+            </div>
+          )}
+
           {/* Live apply progress (D17 — spec 025 progress UI, absorbed here). */}
           {(progress.running ||
             progress.terminal !== null ||
@@ -372,6 +448,25 @@ export function PlanReviewOverlay({
                   applied: progress.applied,
                   total: progress.total ?? plan.itemsTotal,
                 })}
+              {/* Cancel-in-flight (US3/FR-009, issue #743): available for the
+                  whole active-run window (running or paused), matching what
+                  `plan.cancel` accepts server-side. */}
+              {progress.running && progress.terminal === null && (
+                <>
+                  {' '}
+                  <Btn
+                    size="sm"
+                    variant="ghost"
+                    onClick={() => void handleCancelRun()}
+                    disabled={cancelling}
+                    data-testid="plan-review-cancel-run"
+                  >
+                    {cancelling
+                      ? m.plans_review_cancelling()
+                      : m.plans_review_cancel_run_btn()}
+                  </Btn>
+                </>
+              )}
               {applied && (
                 <Pill variant="ok">
                   {m.plans_review_progress_done({ count: progress.applied })}

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -206,5 +206,23 @@ export function usePlanApplyProgress() {
     [progress.runId],
   );
 
-  return { progress, run, resume, reset };
+  /**
+   * Cancel an in-flight apply run (`plan.cancel`, US3/FR-009). Only needs the
+   * plan id — the backend signals the shared `CancellationToken` for the
+   * plan's currently-registered run, no `run_id` required. The channel
+   * already streaming this run's progress will still deliver the resulting
+   * terminal `completed` event (backend-emitted for a cancelled run too), so
+   * this function does not itself flip `progress` — the reducer above
+   * self-updates from that event.
+   */
+  const cancel = useCallback(async (planId: string): Promise<boolean> => {
+    try {
+      unwrap(await commands.plansCancel(planId));
+      return true;
+    } catch {
+      return false;
+    }
+  }, []);
+
+  return { progress, run, resume, cancel, reset };
 }

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -2030,6 +2030,55 @@ pub async fn retry_plan_item(
     Ok(PlanItemRetryResponse { item_id: item_id.to_owned(), new_state: "applying".to_owned() })
 }
 
+// ── confirm_plan_destructive_items ────────────────────────────────────────────
+
+/// Confirm every destructive (delete/trash) item in a plan, persisting
+/// `plan_items.destructive_confirmed = 1` (FR-003, D9, issue #741).
+///
+/// This is the write half of the executor's destructive-confirm gate
+/// (`fs_executor::run::execute_plan`'s `destructive_unconfirmed` refusal,
+/// `item_row_to_executor_item`'s `requires_destructive_confirm` derivation):
+/// before this function existed, `destructive_confirmed` had no writer
+/// anywhere in the codebase, so every delete/trash item was permanently
+/// refused at apply time regardless of what the plan's `destructiveDestination`
+/// UI showed.
+///
+/// Plan-level (not per-item): the caller confirms a whole plan's destructive
+/// items in one call, matching the existing panel-wide destructive-destination
+/// control rather than requiring a per-item id round-trip the frontend DTOs
+/// (`InboxPlanAction`, `PlanItemDetail`) don't carry.
+///
+/// Intentionally permissive on plan state: confirming while a run is
+/// `applying`/`paused` cannot retroactively affect an already-snapshotted
+/// forward pass, but a `paused` run's remaining `pending` items ARE re-read
+/// fresh from the DB on `resume_plan`, so confirming while paused is a
+/// legitimate way to unblock a stalled run before resuming.
+///
+/// Returns the number of items whose `destructive_confirmed` flag flipped
+/// (idempotent — already-confirmed items are not re-counted).
+///
+/// # Errors
+///
+/// - `plan.not_found` — plan not found.
+pub async fn confirm_plan_destructive_items(
+    pool: &SqlitePool,
+    plan_id: &str,
+) -> Result<i64, ContractError> {
+    // Existence check only — see docstring for why plan state is not gated.
+    plans_repo::get_plan(pool, plan_id, false).await.map_err(db_err)?;
+
+    let confirmed =
+        plans_repo::confirm_plan_destructive_items(pool, plan_id).await.map_err(db_err)?;
+    i64::try_from(confirmed).map_err(|e| {
+        ContractError::new(
+            ErrorCode::InternalDatabase,
+            format!("confirmed item count overflowed i64: {e}"),
+            ErrorSeverity::Fatal,
+            true,
+        )
+    })
+}
+
 // ── get_apply_status ──────────────────────────────────────────────────────────
 
 /// Fetch the current apply status for a plan.
@@ -2473,6 +2522,137 @@ mod tests {
         // Item is still `pending` (never failed) — retry must reject it.
         let err = retry_plan_item(db.pool(), "p-retry2", "p-retry2-item-0").await.unwrap_err();
         assert_eq!(err.code, ErrorCode::ItemNotFailed);
+    }
+
+    #[tokio::test]
+    async fn confirm_plan_destructive_items_rejects_unknown_plan() {
+        let (db, _bus) = setup().await;
+        let err = confirm_plan_destructive_items(db.pool(), "missing-plan").await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::PlanNotFound);
+    }
+
+    #[tokio::test]
+    async fn confirm_plan_destructive_items_persists_flag() {
+        let (db, _bus) = setup().await;
+        repo::insert_plan(
+            db.pool(),
+            &repo::InsertPlan {
+                id: "p-del",
+                title: "Test",
+                origin: "cleanup",
+                origin_path: None,
+                plan_type: "cleanup",
+                destructive_destination: "trash",
+                parent_plan_id: None,
+                total_bytes_required: 0,
+            },
+        )
+        .await
+        .unwrap();
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: "p-del-item-0",
+                plan_id: "p-del",
+                item_index: 1,
+                name: "junk.fits",
+                action: "delete",
+                from_root_id: None,
+                from_relative_path: "p-del/raw/junk.fits",
+                to_root_id: None,
+                to_relative_path: "",
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let before = repo::list_plan_items(db.pool(), "p-del").await.unwrap();
+        assert_eq!(before[0].destructive_confirmed, 0);
+
+        let confirmed = confirm_plan_destructive_items(db.pool(), "p-del").await.unwrap();
+        assert_eq!(confirmed, 1);
+
+        let after = repo::list_plan_items(db.pool(), "p-del").await.unwrap();
+        assert_eq!(after[0].destructive_confirmed, 1);
+
+        // Idempotent second call.
+        let confirmed_again = confirm_plan_destructive_items(db.pool(), "p-del").await.unwrap();
+        assert_eq!(confirmed_again, 0);
+    }
+
+    /// End-to-end regression for issue #741: before this fix, a delete item
+    /// was refused *permanently* at apply time (`destructive_confirmed` had
+    /// no writer anywhere). Confirming via the new write path must let a
+    /// subsequent apply actually delete the file on disk.
+    #[tokio::test]
+    async fn confirm_then_apply_executes_previously_refused_delete_item() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("junk.fits");
+        std::fs::write(&file_path, b"data").unwrap();
+        let abs = file_path.to_str().unwrap();
+
+        let (db, bus) = setup().await;
+        repo::insert_plan(
+            db.pool(),
+            &repo::InsertPlan {
+                id: "p-e2e",
+                title: "Test",
+                origin: "cleanup",
+                origin_path: None,
+                plan_type: "cleanup",
+                destructive_destination: "trash",
+                parent_plan_id: None,
+                total_bytes_required: 0,
+            },
+        )
+        .await
+        .unwrap();
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: "p-e2e-item-0",
+                plan_id: "p-e2e",
+                item_index: 1,
+                name: "junk.fits",
+                action: "delete",
+                // No from_root_id: item_row_to_executor_item leaves
+                // library_root None, so `from_relative_path` is used as-is —
+                // an absolute temp-file path works (mirrors the executor
+                // crate's own "legacy" no-root test items).
+                from_root_id: None,
+                from_relative_path: abs,
+                to_root_id: None,
+                to_relative_path: "",
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        confirm_plan_destructive_items(db.pool(), "p-e2e").await.unwrap();
+
+        repo::update_plan_state(db.pool(), "p-e2e", "ready_for_review").await.unwrap();
+        repo::set_approved(db.pool(), "p-e2e", "2026-06-01T00:00:00Z", "test-token").await.unwrap();
+
+        apply_plan(db.pool(), &bus, "p-e2e", "test-token", None).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+        assert!(!file_path.exists(), "confirmed delete item must actually execute");
+        let plan = repo::get_plan(db.pool(), "p-e2e", false).await.unwrap();
+        assert_eq!(plan.state, "applied");
     }
 
     #[tokio::test]

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -1330,6 +1330,36 @@ fn spawn_executor_run(params: SpawnExecutorParams) {
                     }
                 }
 
+                // Sweep items orphaned `applying` by a mid-run retry whose
+                // DB flip (`retry_plan_item`) landed but whose re-execution
+                // never got picked up by the executor's retry-drain before
+                // cancellation was observed (review fix, #742 follow-up).
+                // `batch_cancel_pending_items` above only targets `pending`
+                // and would otherwise leave these permanently stuck with no
+                // terminal audit record.
+                match apply_repo::cancel_orphaned_applying_items(&pool, &plan_id).await {
+                    Ok(orphaned_ids) => {
+                        for item_id in &orphaned_ids {
+                            let _ = apply_repo::append_event(
+                                &pool,
+                                &new_id(),
+                                &run_id,
+                                &plan_id,
+                                Some(item_id.as_str()),
+                                "applying",
+                                "cancelled",
+                                &at,
+                                None,
+                                None,
+                            )
+                            .await;
+                        }
+                    }
+                    Err(e) => {
+                        tracing::error!(error=%e, "failed to sweep orphaned applying items for cancel audit");
+                    }
+                }
+
                 // Fetch cumulative counters (see `cumulative_counts`) AFTER
                 // the batch-cancel above so the just-cancelled items are
                 // included.
@@ -1797,9 +1827,7 @@ pub async fn resume_plan(
     revalidate_pause_condition(pool, plan_id, active_run_row.pause_reason.as_deref()).await?;
 
     // Load the plan's remaining pending items and rebuild the executor's
-    // root map (mirrors apply_plan's item preparation, T023a). Previously
-    // failed/succeeded/skipped/cancelled items are excluded — the executor
-    // is only handed genuinely-pending work to continue.
+    // root map (mirrors apply_plan's item preparation, T023a).
     let item_rows = plans_repo::list_plan_items(pool, plan_id).await.map_err(db_err)?;
 
     let mut root_map: HashMap<String, Utf8PathBuf> = HashMap::new();
@@ -1814,9 +1842,20 @@ pub async fn resume_plan(
         }
     }
 
+    // `pending` items are the genuine remaining work; `failed` items are
+    // included too (not for re-execution — `execute_plan`'s forward loop
+    // treats "failed" as an already-terminal state and skips it as a no-op)
+    // so that `id -> ExecutorItem` lookup is complete for the resumed run.
+    // Without this, `retry_plan_item` can flip a pre-pause-failed item's DB
+    // row `failed -> applying` and queue it, but the executor's retry-drain
+    // (`item_by_id` in `fs_executor::run::execute_plan`) has no entry for
+    // it — the item is then permanently stuck `applying` with no terminal
+    // audit record (review fix, resume+retry item-set mismatch).
+    // succeeded/skipped/cancelled items are still excluded: they are truly
+    // terminal and never eligible for retry.
     let executor_items: Vec<ExecutorItem> = item_rows
         .iter()
-        .filter(|r| r.item_state == "pending")
+        .filter(|r| matches!(r.item_state.as_str(), "pending" | "failed"))
         .map(|r| item_row_to_executor_item(r, &root_map))
         .collect();
 
@@ -1975,6 +2014,13 @@ pub async fn skip_plan_item(
 /// - `plan.not_in_apply` — plan is not applying.
 /// - `item.not_found` — item not found.
 /// - `item.not_failed` — item is not in failed state.
+/// - `run.not_found` — the plan is `applying` in the DB but no `ActiveRun` is
+///   registered (the executor task already finished and dropped its
+///   registry entry — a narrow race between the run's completion and this
+///   call). Rejecting here, before any DB write, avoids flipping the item to
+///   `applying` with nothing left to ever re-execute or terminalize it
+///   (review fix: an item stuck `applying` forever with no terminal audit
+///   record).
 pub async fn retry_plan_item(
     pool: &SqlitePool,
     plan_id: &str,
@@ -2008,6 +2054,23 @@ pub async fn retry_plan_item(
                 "item {} is not failed; current state is '{}'. \
                  For plan-level retry use plan.retry on a terminal plan.",
                 item_id, item.item_state
+            ),
+            ErrorSeverity::Blocking,
+            false,
+        ));
+    }
+
+    // Require a live ActiveRun for this plan BEFORE mutating any DB state
+    // (see doc comment above). This does not fully eliminate the race (the
+    // run could still finish between this check and the DB write below),
+    // but it closes the common case: retrying against a plan whose run has
+    // already reached a terminal state.
+    if !active_runs().contains_key(plan_id) {
+        return Err(ContractError::new(
+            ErrorCode::RunNotFound,
+            format!(
+                "no active run found for plan {plan_id}; the run may have already finished. \
+                 For plan-level retry use plan.retry on a terminal plan."
             ),
             ErrorSeverity::Blocking,
             false,
@@ -2490,11 +2553,32 @@ mod tests {
         assert_eq!(err.code, ErrorCode::PlanNotInApply);
     }
 
+    /// Register a minimal `ActiveRun` directly in the process-global
+    /// registry, bypassing `apply_plan`/`resume_plan`'s executor spawn.
+    /// `retry_plan_item` requires a live entry before it will mutate any DB
+    /// state (review fix — see its doc comment); tests that exercise the
+    /// success path without driving a real executor need one of these.
+    /// Callers own removing it (or rely on process exit — the registry is a
+    /// `static`, so a leaked test entry cannot affect other plan ids).
+    fn register_fake_active_run(plan_id: &str) {
+        active_runs().insert(
+            plan_id.to_owned(),
+            ActiveRun {
+                cancel_token: CancellationToken::new(),
+                skip_set: SkipSet::new(),
+                retry_queue: RetryQueue::new(),
+                run_id: "fake-run".to_owned(),
+                path_set: crate::path_set::PlanPathSet::new(),
+            },
+        );
+    }
+
     /// T038 gap-fill: `retry_plan_item`'s success path had zero coverage at
     /// any level prior to this test (only the not-applying rejection was
     /// tested). Drives the item failed -> applying transition directly
-    /// (bypassing the executor, so no live `ActiveRun` is required) and
-    /// asserts both the response and the persisted item state.
+    /// (bypassing the real executor, but with a fake `ActiveRun` registered
+    /// so the review-fix "run must be active" gate passes) and asserts both
+    /// the response and the persisted item state.
     #[tokio::test]
     async fn retry_plan_item_transitions_failed_item_to_applying() {
         let (db, _bus) = setup().await;
@@ -2503,6 +2587,7 @@ mod tests {
         apply_repo::item_failed(db.pool(), "p-retry-item-0", "p-retry", "permission.denied")
             .await
             .unwrap();
+        register_fake_active_run("p-retry");
 
         let resp = retry_plan_item(db.pool(), "p-retry", "p-retry-item-0").await.unwrap();
         assert_eq!(resp.item_id, "p-retry-item-0");
@@ -2513,13 +2598,44 @@ mod tests {
         assert_eq!(item.item_state, "applying", "retried item must move failed -> applying in DB");
     }
 
+    /// Review fix: a retry attempted after the run has already finished
+    /// (no `ActiveRun` registered) must be rejected outright, not silently
+    /// flip the item to `applying` with nothing left to ever resolve it.
+    #[tokio::test]
+    async fn retry_plan_item_rejects_when_no_active_run() {
+        let (db, _bus) = setup().await;
+        insert_approved_plan_with_items(&db, "p-retry-no-run", 1).await;
+        plans_repo::update_plan_state(db.pool(), "p-retry-no-run", "applying").await.unwrap();
+        apply_repo::item_failed(
+            db.pool(),
+            "p-retry-no-run-item-0",
+            "p-retry-no-run",
+            "permission.denied",
+        )
+        .await
+        .unwrap();
+        // Deliberately NOT registering an ActiveRun.
+
+        let err = retry_plan_item(db.pool(), "p-retry-no-run", "p-retry-no-run-item-0")
+            .await
+            .unwrap_err();
+        assert_eq!(err.code, ErrorCode::RunNotFound);
+
+        // The DB write must never have happened — item stays failed, not
+        // stuck applying with nothing to resolve it.
+        let items = plans_repo::list_plan_items(db.pool(), "p-retry-no-run").await.unwrap();
+        let item = items.iter().find(|i| i.id == "p-retry-no-run-item-0").unwrap();
+        assert_eq!(item.item_state, "failed", "rejected retry must not mutate item state");
+    }
+
     #[tokio::test]
     async fn retry_plan_item_rejects_non_failed_item() {
         let (db, _bus) = setup().await;
         insert_approved_plan_with_items(&db, "p-retry2", 1).await;
         plans_repo::update_plan_state(db.pool(), "p-retry2", "applying").await.unwrap();
 
-        // Item is still `pending` (never failed) — retry must reject it.
+        // Item is still `pending` (never failed) — retry must reject it
+        // before reaching the active-run check (which runs after).
         let err = retry_plan_item(db.pool(), "p-retry2", "p-retry2-item-0").await.unwrap_err();
         assert_eq!(err.code, ErrorCode::ItemNotFailed);
     }

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -585,3 +585,112 @@ async fn resume_refused_when_plan_not_paused() {
         .expect_err("an approved (not paused) plan must refuse resume");
     assert_eq!(err.code, contracts_core::error_code::ErrorCode::RunNotPaused);
 }
+
+// ── resume + retry item-set agreement (review fix) ────────────────────────────
+
+/// Review fix regression: `resume_plan` previously filtered `executor_items`
+/// to `item_state == "pending"` only, excluding the item that caused the
+/// original pause (left `failed`, terminal, once resumed). A `retry_plan_item`
+/// call against that pre-pause-failed item — perfectly legal per its own
+/// state-machine guards (`plan` is `applying`, item is `failed`) — flipped
+/// its DB row `failed -> applying` and queued it, but the executor's
+/// `item_by_id` lookup (built only from the filtered, pending-only list) had
+/// no entry for it: the retry was silently dropped, leaving the item stuck
+/// `applying` forever with no terminal audit record and `items_total`
+/// permanently under-accounted.
+///
+/// Exercises the exact real sequence end to end (real SQLite + real tempdir
+/// files + the real spawned executor, no seeding shortcuts): pause on a
+/// stale item, resolve the staleness, resume, then retry the pre-pause-failed
+/// item while the resumed run is still draining its other pending items.
+/// Many pending items (as in `cancel_signals_the_executor_restarted_by_resume`
+/// above) widen the race window so the retry reliably lands while the
+/// executor task is still alive, rather than racing its completion.
+#[tokio::test]
+async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
+    const OTHER_PENDING_ITEMS: usize = 30;
+
+    let (db, _repo, bus) = support::setup().await;
+    let plan_id = Uuid::new_v4().to_string();
+    let dir = tempfile::tempdir().expect("tempdir");
+    let root_id = register_root(db.pool(), dir.path()).await;
+
+    let paths = seed_rooted_approved_plan(
+        db.pool(),
+        &plan_id,
+        &root_id,
+        dir.path(),
+        OTHER_PENDING_ITEMS + 1,
+    )
+    .await;
+    let (src0, dst0) = &paths[0];
+    let item0_id = format!("{plan_id}-item-0");
+
+    // Force item 0 stale, same as the other pause tests above.
+    let real_size = i64::try_from(std::fs::metadata(src0).expect("stat src0").len()).unwrap();
+    plans_repo::update_item_fs_snapshot(db.pool(), &item0_id, None, Some(real_size + 1))
+        .await
+        .expect("update_item_fs_snapshot");
+
+    app_core::plan_apply::apply_plan(db.pool(), &bus, &plan_id, "tok-test-fixed", None)
+        .await
+        .expect("apply_plan should start");
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+    let plan_row = plans_repo::get_plan(db.pool(), &plan_id, false).await.expect("get_plan");
+    assert_eq!(plan_row.state, "paused", "run must have paused on the stale item");
+    let run_row = apply_repo::get_active_run(db.pool(), &plan_id)
+        .await
+        .expect("get_active_run")
+        .expect("a paused run must still have its run row");
+
+    // Resolve the condition so resume succeeds.
+    plans_repo::update_item_fs_snapshot(db.pool(), &item0_id, None, Some(real_size))
+        .await
+        .expect("update_item_fs_snapshot to resolve staleness");
+
+    app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
+        .await
+        .expect("resume must succeed once the stale condition is resolved");
+
+    // Retry item 0 (still `failed` from the pre-pause attempt) immediately —
+    // no `.await` yield beyond `resume_plan`'s own, giving the restarted
+    // executor the least possible head start (same rationale as the cancel
+    // test above: the race is what this test exists to exercise).
+    app_core::plan_apply::retry_plan_item(db.pool(), &plan_id, &item0_id)
+        .await
+        .expect("retry must be accepted: plan is applying, item is failed, run is active");
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(500)).await;
+
+    // The retried item actually re-executed for real (not just a DB flip):
+    // its source file really moved.
+    assert!(!src0.exists(), "item 0's source should have been moved by the retried re-execution");
+    assert!(dst0.exists(), "item 0's destination should exist after the retry");
+
+    let items = plans_repo::list_plan_items(db.pool(), &plan_id).await.expect("list_plan_items");
+    let item0 = items.iter().find(|i| i.id == item0_id).expect("item 0 row");
+    assert_eq!(
+        item0.item_state, "succeeded",
+        "retried item must reach a real terminal state, not stay stuck 'applying'"
+    );
+
+    let plan_row = plans_repo::get_plan(db.pool(), &plan_id, false).await.expect("get_plan");
+    assert_eq!(plan_row.state, "applied", "every item (including the retried one) succeeded");
+    assert_eq!(
+        plan_row.items_applied,
+        i64::try_from(OTHER_PENDING_ITEMS + 1).unwrap(),
+        "items_total must not be under-accounted — the retried item counts too"
+    );
+    assert_eq!(plan_row.items_failed, 0, "the retry cleared item 0's failed count");
+
+    // A real terminal audit record landed for the retry (applying -> succeeded),
+    // not silence.
+    let events = apply_repo::list_events(db.pool(), &plan_id).await.expect("list_events");
+    assert!(
+        events.iter().any(|e| e.item_id.as_deref() == Some(item0_id.as_str())
+            && e.prior_state == "applying"
+            && e.new_state == "succeeded"),
+        "the retry must append a real terminal audit event for item 0, not leave it silent"
+    );
+}

--- a/crates/fs/executor/src/run.rs
+++ b/crates/fs/executor/src/run.rs
@@ -368,7 +368,7 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
     let item_by_id: HashMap<&str, &ExecutorItem> =
         items.iter().map(|i| (i.id.as_str(), i)).collect();
 
-    for item in &items {
+    'items: for item in &items {
         // Skip items that are already in a terminal state (re-apply idempotency).
         if matches!(item.current_state.as_str(), "succeeded" | "skipped" | "cancelled" | "failed") {
             tracing::debug!(item_id = %item.id, state = %item.current_state, "skipping already-terminal item");
@@ -410,6 +410,18 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
         // picks up a retry filed against ANY already-passed item, matching
         // this loop's "never mid-item" invariant.
         for retry_id in retry_queue.drain_all() {
+            // Check cancellation between retry items too (same "never
+            // mid-item" semantics as the forward loop above). Any retry ids
+            // already drained but not yet reached here are dropped from the
+            // queue without executing — their DB row is already `applying`
+            // (flipped eagerly by `retry_plan_item`), so the caller sweeps
+            // them via `cancel_orphaned_applying_items` after `Cancelled` is
+            // returned (fs_executor has no DB dependency to do so itself).
+            if cancel.is_cancelled() {
+                cancelled = true;
+                break 'items;
+            }
+
             let Some(retry_item) = item_by_id.get(retry_id.as_str()) else {
                 tracing::warn!(item_id = %retry_id, "retry queued for unknown item id; ignored");
                 continue;
@@ -1046,6 +1058,93 @@ mod tests {
         // The retry's prior_state reflects the DB row `retry_plan_item`
         // already transitioned to `applying` — not the original "pending".
         assert_eq!(item1_events[1].prior_state, "applying");
+    }
+
+    /// Callbacks that, on seeing `item-1` succeed, queue a retry for
+    /// `item-2` and signal cancellation in the same tick — mirroring a user
+    /// clicking Cancel right as a mid-run retry is filed (review fix for
+    /// #742's retry-drain loop).
+    #[derive(Clone)]
+    struct CancelDuringRetryDrainCallbacks {
+        events: Arc<Mutex<Vec<ItemProgressEvent>>>,
+        retry_queue: RetryQueue,
+        cancel: CancellationToken,
+    }
+
+    impl ExecutorCallbacks for CancelDuringRetryDrainCallbacks {
+        fn on_item_start(
+            &self,
+            _item_id: &str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            Box::pin(async {})
+        }
+
+        fn on_item_progress(
+            &self,
+            event: ItemProgressEvent,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            let events = self.events.clone();
+            let retry_queue = self.retry_queue.clone();
+            let cancel = self.cancel.clone();
+            Box::pin(async move {
+                if event.item_id == "item-1" && event.new_state == "succeeded" {
+                    retry_queue.push("item-2");
+                    cancel.cancel();
+                }
+                events.lock().await.push(event);
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn cancellation_is_observed_between_retry_items_not_just_forward_items() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8(dir.path());
+        let src1 = root.join("a.fits");
+        let dst1 = root.join("a_dst.fits");
+        let src2 = root.join("b.fits");
+        let dst2 = root.join("b_dst.fits");
+        std::fs::write(&src1, b"a").unwrap();
+        std::fs::write(&src2, b"b").unwrap();
+
+        let item1 = make_move_item("item-1", &src1, &dst1);
+        // item-2 carries `current_state: "failed"` — mirrors a pre-pause
+        // failed item a resumed run now carries forward purely for
+        // `item_by_id` lookup purposes (review fix for resume/retry item-set
+        // agreement); the forward loop skips it as already-terminal, so the
+        // ONLY path that could execute it is the retry-drain below.
+        let item2 = ExecutorItem {
+            current_state: "failed".to_owned(),
+            ..make_move_item("item-2", &src2, &dst2)
+        };
+
+        let cancel = CancellationToken::new();
+        let retry = RetryQueue::new();
+        let callbacks = CancelDuringRetryDrainCallbacks {
+            events: Arc::new(Mutex::new(Vec::new())),
+            retry_queue: retry.clone(),
+            cancel: cancel.clone(),
+        };
+        let skip = SkipSet::new();
+
+        let outcome = execute_plan(vec![item1, item2], &callbacks, &cancel, &skip, &retry).await;
+
+        match outcome {
+            ApplyOutcome::Cancelled(counts) => {
+                assert_eq!(counts.succeeded, 1, "only item-1's normal forward pass");
+            }
+            other => panic!("expected Cancelled, got {other:?}"),
+        }
+
+        // item-2's queued retry must NOT have executed: cancellation is
+        // checked between retry items too, same as forward items.
+        assert!(src2.exists(), "item-2's retry must not have run after cancel");
+        assert!(!dst2.exists());
+        let events = callbacks.events.lock().await;
+        assert!(
+            events.iter().all(|e| e.item_id != "item-2"),
+            "no progress event should have been emitted for the cancelled-out retry"
+        );
     }
 
     #[test]

--- a/crates/fs/executor/src/run.rs
+++ b/crates/fs/executor/src/run.rs
@@ -23,7 +23,7 @@
 //!
 //! Constitution §II: never overwrite silently; per-item audit via callbacks.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use camino::{Utf8Path, Utf8PathBuf};
@@ -323,6 +323,20 @@ impl RetryQueue {
     pub fn take(&self, item_id: &str) -> bool {
         self.inner.lock().expect("retry-queue mutex poisoned").remove(item_id)
     }
+
+    /// Remove and return every queued item id (order unspecified).
+    ///
+    /// Used between forward-loop items to pick up any retry requests filed
+    /// against already-passed items (issue #742) — a plain `take` only
+    /// checks a single id, so a retry filed for an EARLIER item was never
+    /// consumed by anything.
+    ///
+    /// # Panics
+    /// Panics if the internal mutex is poisoned.
+    #[must_use]
+    pub fn drain_all(&self) -> Vec<String> {
+        self.inner.lock().expect("retry-queue mutex poisoned").drain().collect()
+    }
 }
 
 // ── Executor entry point ──────────────────────────────────────────────────────
@@ -347,6 +361,12 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
 ) -> ApplyOutcome {
     let mut counts = TerminalCounts::default();
     let mut cancelled = false;
+
+    // Id-indexed lookup so a retry (which only carries an item id, filed by
+    // `retry_plan_item` against an item this loop has already passed) can be
+    // re-executed with its original action/paths/CAS-snapshot (issue #742).
+    let item_by_id: HashMap<&str, &ExecutorItem> =
+        items.iter().map(|i| (i.id.as_str(), i)).collect();
 
     for item in &items {
         // Skip items that are already in a terminal state (re-apply idempotency).
@@ -377,199 +397,243 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
             continue;
         }
 
-        // Destructive-confirm gate (FR-003, D9, T020).
-        // `requires_destructive_confirm` is derived from the action type (delete/trash),
-        // independent of protection status. Replaces the old `confirm_required = is_protected`
-        // inversion at plan_apply.rs:199.
-        if item.requires_destructive_confirm && !item.destructive_confirmed {
-            let failure = PlanItemFailure::with_code(
-                FailureCode::DestructiveUnconfirmed,
-                format!(
-                    "item {} requires destructive confirmation (action is destructive); \
-                     confirm before applying",
-                    item.id
-                ),
-            );
-            callbacks
-                .on_item_progress(ItemProgressEvent::terminal(
-                    item.id.clone(),
-                    "pending",
-                    "refused",
-                    Some(failure),
-                    Some("destructive_unconfirmed".to_owned()),
-                ))
-                .await;
-            counts.failed += 1;
-            continue;
+        match process_single_item(item, callbacks, &mut counts, "pending", true).await {
+            ItemOutcome::Pause(reason) => return ApplyOutcome::Paused { reason, counts },
+            ItemOutcome::Continue => {}
         }
 
-        // Notify start.
-        callbacks.on_item_start(&item.id).await;
-
-        // Path-resolution gate (FR-001/002, D8, T018): resolve + validate source path
-        // against the library root before any filesystem CAS or mutation.
-        if let (Some(ref src_rel), Some(ref root)) = (&item.source_path, &item.library_root) {
-            match path_gate::resolve_and_validate(root, src_rel) {
-                Err(gate_failure) => {
-                    let audit_reason = gate_failure.code.as_str().to_owned();
-                    let triggers_pause = gate_failure.code.triggers_pause();
-                    callbacks
-                        .on_item_progress(ItemProgressEvent::terminal(
-                            item.id.clone(),
-                            "applying",
-                            "refused",
-                            Some(gate_failure),
-                            Some(audit_reason),
-                        ))
-                        .await;
-                    counts.failed += 1;
-                    if triggers_pause {
-                        return ApplyOutcome::Paused { reason: "path.invalid".to_owned(), counts };
-                    }
-                    continue;
-                }
-                Ok(_resolved) => {
-                    // Path is safe; the resolved absolute path will be used by execute_item.
-                }
-            }
-        }
-
-        // Per-item FS CAS revalidation (R-FS-1).
-        // Use the library-root-resolved path if available; otherwise use the raw path (legacy).
-        let resolved_source_for_cas: Option<Utf8PathBuf> =
-            if let (Some(ref src_rel), Some(ref root)) = (&item.source_path, &item.library_root) {
-                // Already validated above; re-resolve (cheap lexical op).
-                path_gate::resolve_and_validate(root, src_rel).ok().map(|r| r.0)
-            } else {
-                item.source_path.clone()
-            };
-
-        if let Some(ref src) = resolved_source_for_cas {
-            if let Err(stale_failure) = check_cas(src, &item.cas_snapshot) {
-                let triggers_pause = stale_failure.code.triggers_pause();
-                let failure_clone = stale_failure.clone();
-
-                callbacks
-                    .on_item_progress(ItemProgressEvent::terminal(
-                        item.id.clone(),
-                        "applying",
-                        "stale",
-                        Some(failure_clone),
-                        Some("stale".to_owned()),
-                    ))
-                    .await;
-
-                counts.failed += 1;
-
-                if triggers_pause {
-                    return ApplyOutcome::Paused {
-                        reason: stale_failure.code.as_str().to_owned(),
-                        counts,
-                    };
-                }
+        // Drain and re-execute any items queued for retry (US4, issue #742).
+        // `retry_plan_item` only flips the item's DB row and pushes its id
+        // here; nothing previously consumed the queue for real (a single
+        // forward pass never revisits an earlier index). Checking between
+        // every item — the same boundary already used for cancel/skip —
+        // picks up a retry filed against ANY already-passed item, matching
+        // this loop's "never mid-item" invariant.
+        for retry_id in retry_queue.drain_all() {
+            let Some(retry_item) = item_by_id.get(retry_id.as_str()) else {
+                tracing::warn!(item_id = %retry_id, "retry queued for unknown item id; ignored");
                 continue;
+            };
+            // `retry_plan_item` already transitioned the DB row `failed ->
+            // applying` before queuing, so `on_item_start` (which would
+            // double-decrement `items_pending`) must NOT run again, and the
+            // gate/terminal events' prior_state is "applying", not "pending".
+            match process_single_item(retry_item, callbacks, &mut counts, "applying", false).await {
+                ItemOutcome::Pause(reason) => return ApplyOutcome::Paused { reason, counts },
+                ItemOutcome::Continue => {}
             }
         }
-
-        // Protection check (FR-008).
-        if item.is_protected
-            && !matches!(item.action, ExecutorItemAction::NoOp | ExecutorItemAction::Catalogue)
-        {
-            let failure = PlanItemFailure::with_code(
-                FailureCode::ProtectedSource,
-                format!("item {} is protected by source policy", item.id),
-            );
-            callbacks
-                .on_item_progress(ItemProgressEvent::terminal(
-                    item.id.clone(),
-                    "applying",
-                    "failed",
-                    Some(failure),
-                    Some("protected".to_owned()),
-                ))
-                .await;
-            counts.failed += 1;
-            continue;
-        }
-
-        // Execute the operation.
-        //
-        // T212: the filesystem primitives in `execute_item` are synchronous and
-        // blocking (`std::fs::rename`/`copy`/`remove_file`, trash). Running them
-        // directly on a tokio worker thread would stall the async runtime, so we
-        // hand the work to `spawn_blocking`, which dispatches it onto the
-        // dedicated blocking thread pool and yields the worker thread back to the
-        // runtime until the fs op completes.
-        let item_for_blocking = item.clone();
-        let op_result = tokio::task::spawn_blocking(move || execute_item(&item_for_blocking))
-            .await
-            .unwrap_or_else(|join_err| {
-                // The blocking task panicked. Surface it as an internal failure
-                // rather than propagating the panic through the executor loop.
-                Err((
-                    PlanItemFailure::with_code(
-                        FailureCode::Unknown,
-                        format!("filesystem worker task failed: {join_err}"),
-                    ),
-                    false,
-                    RollbackOutcome::NotApplicable,
-                    None,
-                ))
-            });
-
-        match op_result {
-            Ok(()) => {
-                callbacks
-                    .on_item_progress(ItemProgressEvent::terminal(
-                        item.id.clone(),
-                        "applying",
-                        "succeeded",
-                        None,
-                        None,
-                    ))
-                    .await;
-                counts.succeeded += 1;
-            }
-            Err((failure, rollback_attempted, rollback_outcome, rollback_message)) => {
-                let triggers_pause = failure.code.triggers_pause();
-                let failure_clone = failure.clone();
-
-                callbacks
-                    .on_item_progress(ItemProgressEvent {
-                        item_id: item.id.clone(),
-                        prior_state: "applying".to_owned(),
-                        new_state: "failed".to_owned(),
-                        at: Timestamp::now_iso(),
-                        failure: Some(failure_clone),
-                        rollback_attempted,
-                        rollback_outcome,
-                        rollback_message,
-                        audit_reason: None,
-                    })
-                    .await;
-                counts.failed += 1;
-
-                if triggers_pause {
-                    return ApplyOutcome::Paused {
-                        reason: failure.code.as_str().to_owned(),
-                        counts,
-                    };
-                }
-            }
-        }
-
-        // After resolving this item, check if a retry was queued.
-        // (Retry items are re-inserted at the front of the pending list by
-        // the use case; within this loop they would need re-ordering which
-        // is deferred to the use case. Here we just clear the queue entry
-        // to avoid phantom state.)
-        let _ = retry_queue.take(&item.id);
     }
 
     if cancelled {
         ApplyOutcome::Cancelled(counts)
     } else {
         ApplyOutcome::Completed(counts)
+    }
+}
+
+/// Outcome of processing a single item through the gate/execute pipeline.
+enum ItemOutcome {
+    /// Resolved (terminal or otherwise) — the caller should move on.
+    Continue,
+    /// A pause condition was hit; the caller should halt the whole run.
+    Pause(String),
+}
+
+/// Run one item through the destructive-confirm gate, path gate, CAS check,
+/// protection check, and (if all pass) the filesystem mutation itself,
+/// emitting progress events and updating `counts` throughout.
+///
+/// Shared by the main forward pass (`emit_start: true`, `gate_prior_state:
+/// "pending"`) and mid-run retry re-execution (`emit_start: false`,
+/// `gate_prior_state: "applying"` — the DB row is already `applying` via
+/// `retry_plan_item`, and calling `on_item_start` again would double-decrement
+/// `plans.items_pending`, which the retry path never re-incremented).
+#[allow(clippy::too_many_lines)]
+async fn process_single_item<C: ExecutorCallbacks>(
+    item: &ExecutorItem,
+    callbacks: &C,
+    counts: &mut TerminalCounts,
+    gate_prior_state: &str,
+    emit_start: bool,
+) -> ItemOutcome {
+    // Destructive-confirm gate (FR-003, D9, T020).
+    // `requires_destructive_confirm` is derived from the action type (delete/trash),
+    // independent of protection status. Replaces the old `confirm_required = is_protected`
+    // inversion at plan_apply.rs:199.
+    if item.requires_destructive_confirm && !item.destructive_confirmed {
+        let failure = PlanItemFailure::with_code(
+            FailureCode::DestructiveUnconfirmed,
+            format!(
+                "item {} requires destructive confirmation (action is destructive); \
+                 confirm before applying",
+                item.id
+            ),
+        );
+        callbacks
+            .on_item_progress(ItemProgressEvent::terminal(
+                item.id.clone(),
+                gate_prior_state,
+                "refused",
+                Some(failure),
+                Some("destructive_unconfirmed".to_owned()),
+            ))
+            .await;
+        counts.failed += 1;
+        return ItemOutcome::Continue;
+    }
+
+    // Notify start.
+    if emit_start {
+        callbacks.on_item_start(&item.id).await;
+    }
+
+    // Path-resolution gate (FR-001/002, D8, T018): resolve + validate source path
+    // against the library root before any filesystem CAS or mutation.
+    if let (Some(ref src_rel), Some(ref root)) = (&item.source_path, &item.library_root) {
+        match path_gate::resolve_and_validate(root, src_rel) {
+            Err(gate_failure) => {
+                let audit_reason = gate_failure.code.as_str().to_owned();
+                let triggers_pause = gate_failure.code.triggers_pause();
+                callbacks
+                    .on_item_progress(ItemProgressEvent::terminal(
+                        item.id.clone(),
+                        "applying",
+                        "refused",
+                        Some(gate_failure),
+                        Some(audit_reason),
+                    ))
+                    .await;
+                counts.failed += 1;
+                if triggers_pause {
+                    return ItemOutcome::Pause("path.invalid".to_owned());
+                }
+                return ItemOutcome::Continue;
+            }
+            Ok(_resolved) => {
+                // Path is safe; the resolved absolute path will be used by execute_item.
+            }
+        }
+    }
+
+    // Per-item FS CAS revalidation (R-FS-1).
+    // Use the library-root-resolved path if available; otherwise use the raw path (legacy).
+    let resolved_source_for_cas: Option<Utf8PathBuf> =
+        if let (Some(ref src_rel), Some(ref root)) = (&item.source_path, &item.library_root) {
+            // Already validated above; re-resolve (cheap lexical op).
+            path_gate::resolve_and_validate(root, src_rel).ok().map(|r| r.0)
+        } else {
+            item.source_path.clone()
+        };
+
+    if let Some(ref src) = resolved_source_for_cas {
+        if let Err(stale_failure) = check_cas(src, &item.cas_snapshot) {
+            let triggers_pause = stale_failure.code.triggers_pause();
+            let failure_clone = stale_failure.clone();
+
+            callbacks
+                .on_item_progress(ItemProgressEvent::terminal(
+                    item.id.clone(),
+                    "applying",
+                    "stale",
+                    Some(failure_clone),
+                    Some("stale".to_owned()),
+                ))
+                .await;
+
+            counts.failed += 1;
+
+            if triggers_pause {
+                return ItemOutcome::Pause(stale_failure.code.as_str().to_owned());
+            }
+            return ItemOutcome::Continue;
+        }
+    }
+
+    // Protection check (FR-008).
+    if item.is_protected
+        && !matches!(item.action, ExecutorItemAction::NoOp | ExecutorItemAction::Catalogue)
+    {
+        let failure = PlanItemFailure::with_code(
+            FailureCode::ProtectedSource,
+            format!("item {} is protected by source policy", item.id),
+        );
+        callbacks
+            .on_item_progress(ItemProgressEvent::terminal(
+                item.id.clone(),
+                "applying",
+                "failed",
+                Some(failure),
+                Some("protected".to_owned()),
+            ))
+            .await;
+        counts.failed += 1;
+        return ItemOutcome::Continue;
+    }
+
+    // Execute the operation.
+    //
+    // T212: the filesystem primitives in `execute_item` are synchronous and
+    // blocking (`std::fs::rename`/`copy`/`remove_file`, trash). Running them
+    // directly on a tokio worker thread would stall the async runtime, so we
+    // hand the work to `spawn_blocking`, which dispatches it onto the
+    // dedicated blocking thread pool and yields the worker thread back to the
+    // runtime until the fs op completes.
+    let item_for_blocking = item.clone();
+    let op_result = tokio::task::spawn_blocking(move || execute_item(&item_for_blocking))
+        .await
+        .unwrap_or_else(|join_err| {
+            // The blocking task panicked. Surface it as an internal failure
+            // rather than propagating the panic through the executor loop.
+            Err((
+                PlanItemFailure::with_code(
+                    FailureCode::Unknown,
+                    format!("filesystem worker task failed: {join_err}"),
+                ),
+                false,
+                RollbackOutcome::NotApplicable,
+                None,
+            ))
+        });
+
+    match op_result {
+        Ok(()) => {
+            callbacks
+                .on_item_progress(ItemProgressEvent::terminal(
+                    item.id.clone(),
+                    "applying",
+                    "succeeded",
+                    None,
+                    None,
+                ))
+                .await;
+            counts.succeeded += 1;
+            ItemOutcome::Continue
+        }
+        Err((failure, rollback_attempted, rollback_outcome, rollback_message)) => {
+            let triggers_pause = failure.code.triggers_pause();
+            let failure_clone = failure.clone();
+
+            callbacks
+                .on_item_progress(ItemProgressEvent {
+                    item_id: item.id.clone(),
+                    prior_state: "applying".to_owned(),
+                    new_state: "failed".to_owned(),
+                    at: Timestamp::now_iso(),
+                    failure: Some(failure_clone),
+                    rollback_attempted,
+                    rollback_outcome,
+                    rollback_message,
+                    audit_reason: None,
+                })
+                .await;
+            counts.failed += 1;
+
+            if triggers_pause {
+                return ItemOutcome::Pause(failure.code.as_str().to_owned());
+            }
+            ItemOutcome::Continue
+        }
     }
 }
 
@@ -892,6 +956,96 @@ mod tests {
             }
             other => panic!("expected Paused, got {other:?}"),
         }
+    }
+
+    /// Callbacks that, on seeing `item-1` fail, clear the conflicting
+    /// destination that caused the failure and files a retry — mirroring
+    /// what `retry_plan_item` + a user fix do in the real app (issue #742).
+    #[derive(Clone)]
+    struct RetryOnFailureCallbacks {
+        events: Arc<Mutex<Vec<ItemProgressEvent>>>,
+        retry_queue: RetryQueue,
+        conflicting_destination: Utf8PathBuf,
+    }
+
+    impl ExecutorCallbacks for RetryOnFailureCallbacks {
+        fn on_item_start(
+            &self,
+            _item_id: &str,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            Box::pin(async {})
+        }
+
+        fn on_item_progress(
+            &self,
+            event: ItemProgressEvent,
+        ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+            let events = self.events.clone();
+            let retry_queue = self.retry_queue.clone();
+            let conflicting_destination = self.conflicting_destination.clone();
+            Box::pin(async move {
+                if event.item_id == "item-1" && event.new_state == "failed" {
+                    let _ = std::fs::remove_file(&conflicting_destination);
+                    retry_queue.push("item-1");
+                }
+                events.lock().await.push(event);
+            })
+        }
+    }
+
+    #[tokio::test]
+    async fn mid_run_retry_reexecutes_already_passed_item() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8(dir.path());
+        let src1 = root.join("a.fits");
+        let dst1 = root.join("a_dst.fits");
+        let src2 = root.join("b.fits");
+        let dst2 = root.join("b_dst.fits");
+        std::fs::write(&src1, b"a").unwrap();
+        std::fs::write(&src2, b"b").unwrap();
+        // item-1's destination already exists, so its first attempt fails
+        // with a non-pausing conflict — exactly the class of failure a user
+        // fixes and retries mid-run.
+        std::fs::write(&dst1, b"stale").unwrap();
+
+        let item1 = make_move_item("item-1", &src1, &dst1);
+        let item2 = make_move_item("item-2", &src2, &dst2);
+
+        let retry = RetryQueue::new();
+        let callbacks = RetryOnFailureCallbacks {
+            events: Arc::new(Mutex::new(Vec::new())),
+            retry_queue: retry.clone(),
+            conflicting_destination: dst1.clone(),
+        };
+        let cancel = CancellationToken::new();
+        let skip = SkipSet::new();
+
+        let outcome = execute_plan(vec![item1, item2], &callbacks, &cancel, &skip, &retry).await;
+
+        match outcome {
+            ApplyOutcome::Completed(counts) => {
+                // item-1's original failure is still counted; its retry
+                // succeeds, and item-2 succeeds normally.
+                assert_eq!(counts.succeeded, 2);
+                assert_eq!(counts.failed, 1);
+            }
+            other => panic!("expected Completed, got {other:?}"),
+        }
+
+        // item-1 actually moved once the conflicting destination was cleared
+        // and the retry re-executed the real filesystem operation — not just
+        // a DB-state flip with no corresponding work (the original bug).
+        assert!(dst1.exists());
+        assert!(!src1.exists());
+
+        let events = callbacks.events.lock().await;
+        let item1_events: Vec<_> = events.iter().filter(|e| e.item_id == "item-1").collect();
+        assert_eq!(item1_events.len(), 2, "expected a failed then a succeeded event");
+        assert_eq!(item1_events[0].new_state, "failed");
+        assert_eq!(item1_events[1].new_state, "succeeded");
+        // The retry's prior_state reflects the DB row `retry_plan_item`
+        // already transitioned to `applying` — not the original "pending".
+        assert_eq!(item1_events[1].prior_state, "applying");
     }
 
     #[test]

--- a/crates/persistence/db/src/repositories/plan_apply.rs
+++ b/crates/persistence/db/src/repositories/plan_apply.rs
@@ -505,6 +505,58 @@ pub async fn batch_cancel_pending_items(pool: &SqlitePool, plan_id: &str) -> DbR
     Ok(cancelled_count)
 }
 
+/// Cancel any items left in `applying` when a run ends `Cancelled`.
+///
+/// Under normal forward-loop execution no item is ever `applying` when
+/// `fs_executor::run::execute_plan` returns `Cancelled` — cancellation is
+/// checked strictly *between* items, so an item picked up for real always
+/// runs to a terminal state first. The one exception is a mid-run retry
+/// (`retry_plan_item`): it flips the DB row `failed -> applying` and queues
+/// the id *eagerly*, independent of whether the executor's retry-drain loop
+/// ever actually re-executes it before observing cancellation. Such an item
+/// is invisible to [`batch_cancel_pending_items`] (which only targets
+/// `pending`) and would otherwise stay `applying` forever with no terminal
+/// audit record (review fix for issues #742/#575 follow-up). Returns the
+/// cancelled item ids so the caller can emit a per-item audit row for each.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn cancel_orphaned_applying_items(
+    pool: &SqlitePool,
+    plan_id: &str,
+) -> DbResult<Vec<String>> {
+    let mut tx = pool.begin().await?;
+
+    let ids: Vec<String> = sqlx::query_scalar(
+        "SELECT id FROM plan_items WHERE plan_id = ? AND item_state = 'applying' \
+         ORDER BY item_index ASC",
+    )
+    .bind(plan_id)
+    .fetch_all(&mut *tx)
+    .await?;
+
+    if !ids.is_empty() {
+        sqlx::query(
+            "UPDATE plan_items SET item_state = 'cancelled' \
+             WHERE plan_id = ? AND item_state = 'applying'",
+        )
+        .bind(plan_id)
+        .execute(&mut *tx)
+        .await?;
+
+        let cancelled_count = i64::try_from(ids.len()).unwrap_or(i64::MAX);
+        sqlx::query("UPDATE plans SET items_cancelled = items_cancelled + ? WHERE id = ?")
+            .bind(cancelled_count)
+            .bind(plan_id)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    tx.commit().await?;
+    Ok(ids)
+}
+
 // ── Audit event writes ────────────────────────────────────────────────────────
 
 /// Append an audit event row (append-only; no UPDATE/DELETE allowed).

--- a/crates/persistence/db/src/repositories/plans.rs
+++ b/crates/persistence/db/src/repositories/plans.rs
@@ -322,6 +322,32 @@ pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<P
         .await?)
 }
 
+/// Set `destructive_confirmed = 1` on every item in `plan_id` that requires
+/// destructive confirmation (`action IN ('delete','trash')`, or the explicit
+/// `requires_destructive_confirm` override column — mirrors the derivation in
+/// `app_core::plan_apply::item_row_to_executor_item`).
+///
+/// This is the write half of the FR-003/D9 confirm gate: the executor
+/// (`fs_executor::run::execute_plan`) refuses any destructive item where
+/// `destructive_confirmed` is still 0 (issue #741 — the column previously had
+/// no writer anywhere in the codebase). Idempotent: re-confirming an
+/// already-confirmed plan is a no-op.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) -> DbResult<u64> {
+    let result = sqlx::query(
+        "UPDATE plan_items SET destructive_confirmed = 1 \
+         WHERE plan_id = ? AND destructive_confirmed = 0 \
+         AND (action IN ('delete', 'trash') OR requires_destructive_confirm = 1)",
+    )
+    .bind(plan_id)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected())
+}
+
 /// Update the plan state.
 ///
 /// Only the review-side states are written by this function:
@@ -568,6 +594,68 @@ mod tests {
         let plan = get_plan(db.pool(), "p1", false).await.unwrap();
         assert_eq!(plan.items_total, 1);
         assert_eq!(plan.items_pending, 1);
+    }
+
+    #[tokio::test]
+    async fn confirm_plan_destructive_items_confirms_only_destructive_actions() {
+        let db = setup().await;
+        insert_plan(db.pool(), &sample_plan("p-confirm")).await.unwrap();
+
+        let move_item = InsertPlanItem {
+            id: "item-move",
+            plan_id: "p-confirm",
+            item_index: 1,
+            name: "keep.fits",
+            action: "move",
+            from_root_id: None,
+            from_relative_path: "raw/keep.fits",
+            to_root_id: None,
+            to_relative_path: "archive/keep.fits",
+            reason: "cleanup",
+            protection: "normal",
+            linked_entity: None,
+            provenance_json: None,
+            archive_path: None,
+            source_id: None,
+            category: None,
+        };
+        // `plan_items.action` CHECK never admits the literal 'trash' — the
+        // archive/trash *destination* choice lives on `plans.destructive_destination`;
+        // item-level destructive intent is always the 'delete' action (mirrors
+        // `cleanup_generator::action_label` and `item_row_to_executor_item`).
+        let delete_item = InsertPlanItem {
+            id: "item-delete",
+            plan_id: "p-confirm",
+            item_index: 2,
+            name: "junk.fits",
+            action: "delete",
+            from_root_id: None,
+            from_relative_path: "raw/junk.fits",
+            to_root_id: None,
+            to_relative_path: "",
+            reason: "cleanup",
+            protection: "normal",
+            linked_entity: None,
+            provenance_json: None,
+            archive_path: None,
+            source_id: None,
+            category: None,
+        };
+        insert_plan_item(db.pool(), &move_item).await.unwrap();
+        insert_plan_item(db.pool(), &delete_item).await.unwrap();
+
+        let confirmed = confirm_plan_destructive_items(db.pool(), "p-confirm").await.unwrap();
+        assert_eq!(confirmed, 1, "only the delete item requires confirmation");
+
+        let items = list_plan_items(db.pool(), "p-confirm").await.unwrap();
+        let move_row = items.iter().find(|i| i.id == "item-move").unwrap();
+        let delete_row = items.iter().find(|i| i.id == "item-delete").unwrap();
+        assert_eq!(move_row.destructive_confirmed, 0);
+        assert_eq!(delete_row.destructive_confirmed, 1);
+
+        // Idempotent: a second confirm on an already-confirmed plan touches nothing.
+        let confirmed_again = confirm_plan_destructive_items(db.pool(), "p-confirm").await.unwrap();
+        assert_eq!(confirmed_again, 0);
     }
 
     #[tokio::test]

--- a/tests/e2e/cleanup_review.spec.ts
+++ b/tests/e2e/cleanup_review.spec.ts
@@ -158,6 +158,17 @@ test.describe("cleanup review (spec 017 WP-E / Journey 6)", () => {
     await expect(approveBtn).toBeDisabled();
 
     await overlay.getByRole("button", { name: "Acknowledge" }).click();
+
+    // ── 9b. Destructive-confirm gate (FR-003, D9, issue #741): the shared
+    //        plan fixture carries `delete` items, so approval also stays
+    //        locked behind an explicit destructive-confirm checkbox ───────────
+    // `.click()` (not `.check()`) — the checkbox's `onChange` awaits a mock
+    // IPC round-trip before flipping `checked`, and `.check()`'s single
+    // post-click snapshot races that async update.
+    await overlay.getByTestId("plan-review-confirm-destructive").click();
+    await expect(
+      overlay.getByTestId("plan-review-confirm-destructive"),
+    ).toBeChecked({ timeout: 5_000 });
     await expect(approveBtn).toBeEnabled({ timeout: 5_000 });
 
     // ── 10. Approve & apply → plans.approve → plans.apply, live progress ────

--- a/tests/e2e/project_lifecycle_transitions_full.spec.ts
+++ b/tests/e2e/project_lifecycle_transitions_full.spec.ts
@@ -167,6 +167,17 @@ test.describe("project lifecycle · full state machine (Journey 5)", () => {
     const approveBtn = overlay.getByTestId("plan-review-approve-apply");
     await expect(approveBtn).toBeDisabled();
     await overlay.getByRole("button", { name: "Acknowledge" }).click();
+
+    // ── Destructive-confirm gate (FR-003, D9, issue #741): the shared plan
+    //    fixture carries `delete` items, so approval also stays locked
+    //    behind an explicit destructive-confirm checkbox ───────────────────
+    // `.click()` (not `.check()`) — the checkbox's `onChange` awaits a mock
+    // IPC round-trip before flipping `checked`, and `.check()`'s single
+    // post-click snapshot races that async update.
+    await overlay.getByTestId("plan-review-confirm-destructive").click();
+    await expect(
+      overlay.getByTestId("plan-review-confirm-destructive"),
+    ).toBeChecked({ timeout: 5_000 });
     await expect(approveBtn).toBeEnabled({ timeout: 5_000 });
 
     // ── Approve & apply → plans.approve → plans.apply, live progress ─────────


### PR DESCRIPTION
## Summary
- Destructive plan actions (delete/trash) now require an explicit confirmation before Approve/Apply is available, and the write path enforces it end-to-end — previously no confirmation path existed at all.
- Retry during an in-progress apply now actually re-executes the failed filesystem action; retries queued when you press Cancel no longer run afterwards.
- A running plan apply can be cancelled from the review overlay; items caught mid-flight are closed out with proper audit records instead of being stranded "applying" forever.
- Resume and retry now agree on the item set, fixing a state leak where a pre-pause failed item could be retried into a permanently stuck state that undercounted plan totals.

Closes #741. Closes #742. Closes #743.