### PR TITLE
fix: real run-completion trigger, real artifact sizes, Tool Launches accordion

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -13,6 +13,7 @@
   "calibration_master_title": "Master {kind}",
   "inbox_grouping_hint": "Grouped by {dims}",
   "projects_tool_unknown": "Unknown tool",
+  "projects_toollaunches_title": "Tool Launches",
   "projects_toollaunch_label": "Launch {id}…",
   "projects_toollaunch_unattributed": "Unattributed",
   "projects_toollaunch_low_confidence": "{kind} (low confidence)",

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -12,17 +12,30 @@
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
+use std::time::{Duration, Instant};
 
 use camino::Utf8PathBuf;
 
 use audit::bus::EventBus;
-use fs_inventory::artifact_watcher::{start_artifact_watcher, ArtifactEventKind, WatcherGuard};
+use fs_inventory::artifact_watcher::{
+    start_artifact_watcher, ArtifactEventKind, ArtifactFileEvent, WatcherGuard,
+};
 use fs_inventory::watcher::{InboxFileEvent, SharedWatcherService};
 use sqlx::SqlitePool;
 use tauri::{AppHandle, Emitter};
 use time::{format_description::well_known::Rfc3339, OffsetDateTime};
 use tokio::sync::Mutex;
 use tokio::task::JoinHandle;
+use workflow_artifacts::{
+    check_stability, FileSnapshot, StabilityStatus, DEFAULT_STABILITY_DEBOUNCE,
+};
+
+/// How often the per-project watcher re-checks its open tool launches for
+/// completion (#727). The attribution window itself defaults to 6h
+/// (`workflow_artifacts::DEFAULT_ATTRIBUTION_WINDOW`); this only bounds how
+/// stale that check can be, so a coarse interval is deliberate — there is no
+/// user-facing latency requirement on top of the attribution window itself.
+const STALE_LAUNCH_SWEEP_INTERVAL: Duration = Duration::from_mins(5);
 
 /// Start watching the given inbox paths and forward events to the Tauri webview.
 ///
@@ -156,6 +169,98 @@ fn real_metadata(path: &Path) -> Option<(u64, std::time::SystemTime)> {
     }
     let modified = meta.modified().ok()?;
     Some((meta.len(), modified))
+}
+
+// ── Live-watch debounce (spec 012 T003/T004, #729) ─────────────────────────────
+
+/// Record or cancel debounce tracking for a raw watcher event.
+///
+/// `Removed` events cancel any in-flight debounce for that path — no
+/// `detect()` fires for a file that vanished before stabilizing; removals
+/// otherwise stay handled by the on-attach reconciliation pass, matching the
+/// existing T005 design. Non-watched extensions are ignored (pre-existing
+/// filter). `Created`/`Modified` events (re-)seed the path's [`FileSnapshot`]
+/// with the size observed *now*; [`sweep_pending_artifacts`] decides once the
+/// size has held steady for the debounce window.
+fn record_raw_event(
+    evt: &ArtifactFileEvent,
+    extensions: &[String],
+    pending: &mut HashMap<PathBuf, FileSnapshot>,
+) {
+    let path = evt.path.as_std_path().to_path_buf();
+    if evt.kind == ArtifactEventKind::Removed {
+        pending.remove(&path);
+        return;
+    }
+
+    let file_name = evt.path.file_name().unwrap_or_default();
+    let ext_refs: Vec<&str> = extensions.iter().map(String::as_str).collect();
+    if !workflow_artifacts::extension_allowed(file_name, &ext_refs) {
+        return;
+    }
+
+    // File already gone by the time we could stat it — nothing to track.
+    if let Some((size_bytes, _)) = real_metadata(&path) {
+        pending.insert(path, FileSnapshot { size_bytes, arrived_at: Instant::now() });
+    }
+}
+
+/// Re-check every pending path's stability: `detect()` any that stabilized
+/// with their real observed size (fixing the previously-hardcoded
+/// `size_bytes: 0`), drop any that disappeared, and re-arm the debounce
+/// window for any still being written.
+async fn sweep_pending_artifacts(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+    tool_id: &str,
+    pending: &mut HashMap<PathBuf, FileSnapshot>,
+) {
+    let now = Instant::now();
+    let probe = |p: &Path| real_metadata(p).map(|(size, _)| size);
+    let paths: Vec<PathBuf> = pending.keys().cloned().collect();
+
+    for path in paths {
+        let Some(snapshot) = pending.get(&path).cloned() else { continue };
+        match check_stability(&path, &snapshot, now, DEFAULT_STABILITY_DEBOUNCE, probe) {
+            StabilityStatus::Stable { size_bytes } => {
+                pending.remove(&path);
+                let path_str = path.to_string_lossy().into_owned();
+                let now_iso = OffsetDateTime::now_utc()
+                    .format(&Rfc3339)
+                    .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+                let size_i64 = i64::try_from(size_bytes).unwrap_or(i64::MAX);
+                if let Err(e) = app_core::artifact::detect(
+                    pool, bus, project_id, &path_str, tool_id, size_i64, &now_iso, &now_iso,
+                )
+                .await
+                {
+                    tracing::debug!("artifact watcher: detect failed for {path_str}: {e}");
+                } else {
+                    tracing::debug!(
+                        "artifact watcher: detected {path_str} (project {project_id}, {size_bytes} bytes)"
+                    );
+                }
+            }
+            StabilityStatus::Gone => {
+                pending.remove(&path);
+            }
+            StabilityStatus::Writing => {
+                // Re-arm only once the window actually elapsed against a
+                // changed size, so the debounce restarts from the latest
+                // write instead of comparing against the original snapshot
+                // forever (`check_stability` alone can't distinguish "too
+                // early to check" from "checked, still growing").
+                if now.duration_since(snapshot.arrived_at) >= DEFAULT_STABILITY_DEBOUNCE {
+                    if let Some(size_bytes) = probe(&path) {
+                        pending.insert(path, FileSnapshot { size_bytes, arrived_at: now });
+                    } else {
+                        pending.remove(&path);
+                    }
+                }
+            }
+        }
+    }
 }
 
 /// Run the on-attach reconciliation pass (T005): scan `project_root`,
@@ -301,48 +406,53 @@ pub async fn attach_project_watcher(
     let task_tool_id = tool_id.clone();
     let task_extensions = extensions.clone();
     let forward_task = tokio::spawn(async move {
-        while let Some(evt) = rx.recv().await {
-            // Only handle create/modify — removals are handled by the
-            // on-attach reconciliation pass, matching the existing T005 design.
-            if evt.kind == ArtifactEventKind::Removed {
-                continue;
-            }
+        // Per-path debounce state for the stable-size check (spec 012
+        // T003/T004, #729): the raw watcher fires on every write; a file is
+        // only `detect()`-ed once its size has been unchanged for
+        // `DEFAULT_STABILITY_DEBOUNCE`, so the recorded `size_bytes` is real
+        // instead of the previously-hardcoded 0.
+        let mut pending: HashMap<PathBuf, FileSnapshot> = HashMap::new();
+        let mut debounce_tick = tokio::time::interval(DEFAULT_STABILITY_DEBOUNCE / 2);
+        debounce_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        // #727: periodically complete tool launches whose attribution window
+        // has closed — the real production trigger for `complete_run` /
+        // `workflow.run_completed`, previously exercised only by tests.
+        let mut launch_sweep_tick = tokio::time::interval(STALE_LAUNCH_SWEEP_INTERVAL);
+        launch_sweep_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
-            let file_name = evt.path.file_name().unwrap_or_default();
-            let ext_refs: Vec<&str> = task_extensions.iter().map(String::as_str).collect();
-            if !workflow_artifacts::extension_allowed(file_name, &ext_refs) {
-                continue;
-            }
-
-            let path_str = evt.path.as_str().to_owned();
-            let now = OffsetDateTime::now_utc()
-                .format(&Rfc3339)
-                .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
-
-            match app_core::artifact::detect(
-                &task_pool,
-                &task_bus,
-                &task_project_id,
-                &path_str,
-                &task_tool_id,
-                0, // size unknown at watch time; the next reconciliation fills it
-                &now,
-                &now,
-            )
-            .await
-            {
-                Ok(_) => {
-                    tracing::debug!(
-                        "artifact watcher: detected {path_str} (project {task_project_id})"
-                    );
+        loop {
+            tokio::select! {
+                maybe_evt = rx.recv() => {
+                    let Some(evt) = maybe_evt else {
+                        tracing::debug!(
+                            "artifact watcher: channel closed for project {task_project_id}"
+                        );
+                        break;
+                    };
+                    record_raw_event(&evt, &task_extensions, &mut pending);
                 }
-                Err(e) => {
-                    tracing::debug!("artifact watcher: detect failed for {path_str}: {e}");
+                _ = debounce_tick.tick() => {
+                    sweep_pending_artifacts(
+                        &task_pool,
+                        &task_bus,
+                        &task_project_id,
+                        &task_tool_id,
+                        &mut pending,
+                    )
+                    .await;
+                }
+                _ = launch_sweep_tick.tick() => {
+                    if let Err(e) =
+                        app_core::artifact::sweep_stale_launches(&task_pool, &task_bus, &task_project_id)
+                            .await
+                    {
+                        tracing::debug!(
+                            "artifact watcher: stale-launch sweep failed for project {task_project_id}: {e}"
+                        );
+                    }
                 }
             }
         }
-
-        tracing::debug!("artifact watcher: channel closed for project {task_project_id}");
     });
 
     tracing::info!("artifact watcher: attached for project {project_id} ({})", project.path);
@@ -360,5 +470,68 @@ pub async fn detach_project_watcher(registry: &ArtifactWatcherRegistry, project_
         entry.forward_task.abort();
         // Dropping `_guard` here (end of scope) stops the OS watcher.
         tracing::info!("artifact watcher: detached for project {project_id}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn xisf_extensions() -> Vec<String> {
+        vec![".xisf".to_owned()]
+    }
+
+    fn evt(path: &Path, kind: ArtifactEventKind) -> ArtifactFileEvent {
+        ArtifactFileEvent { path: Utf8PathBuf::from_path_buf(path.to_path_buf()).unwrap(), kind }
+    }
+
+    #[test]
+    fn record_raw_event_ignores_unwatched_extension() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("notes.txt");
+        std::fs::write(&path, b"hello").unwrap();
+        let mut pending = HashMap::new();
+
+        record_raw_event(&evt(&path, ArtifactEventKind::Created), &xisf_extensions(), &mut pending);
+
+        assert!(pending.is_empty(), "unwatched extension must not be tracked");
+    }
+
+    #[test]
+    fn record_raw_event_seeds_pending_snapshot_with_real_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("MasterDark.xisf");
+        std::fs::write(&path, b"0123456789").unwrap(); // 10 bytes
+        let mut pending = HashMap::new();
+
+        record_raw_event(&evt(&path, ArtifactEventKind::Created), &xisf_extensions(), &mut pending);
+
+        let snapshot = pending.get(&path).expect("watched extension must be tracked");
+        assert_eq!(snapshot.size_bytes, 10, "must record the real observed size, not 0");
+    }
+
+    #[test]
+    fn record_raw_event_removed_cancels_pending_debounce() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("MasterDark.xisf");
+        std::fs::write(&path, b"0123456789").unwrap();
+        let mut pending = HashMap::new();
+        record_raw_event(&evt(&path, ArtifactEventKind::Created), &xisf_extensions(), &mut pending);
+        assert!(!pending.is_empty());
+
+        record_raw_event(&evt(&path, ArtifactEventKind::Removed), &xisf_extensions(), &mut pending);
+
+        assert!(pending.is_empty(), "a Removed event must cancel any in-flight debounce");
+    }
+
+    #[test]
+    fn record_raw_event_ignores_vanished_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("MasterDark.xisf"); // never created
+        let mut pending = HashMap::new();
+
+        record_raw_event(&evt(&path, ArtifactEventKind::Created), &xisf_extensions(), &mut pending);
+
+        assert!(pending.is_empty(), "a path that can't be stat'd must not be tracked");
     }
 }

--- a/apps/desktop/src/features/projects/ProjectBottomDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectBottomDetail.tsx
@@ -13,6 +13,7 @@
  *   Notes          — project notes (editable unless archived)
  *   Manifests      — manifest files accordion
  *   Calibration    — calibration match panel for project sources
+ *   Tool Launches  — observed processing artifacts grouped by launch (spec 012)
  *   Source views   — generated source view removal / regenerate (spec 026)
  *   Outputs        — accepted outputs verification (stub; spec 043 §4)
  *   Cleanup        — cleanup preview (stub; spec 043 §4)
@@ -32,6 +33,7 @@ import { useProjectDetail } from './store';
 import { ProjectNotesSection } from './ProjectNotesSection';
 import { ManifestsAccordion } from './ManifestsAccordion';
 import { CalibrationMatchPanel } from './CalibrationMatchPanel';
+import { ToolLaunchesAccordion } from './ToolLaunchesAccordion';
 import { SourceViewsSection } from './SourceViewsSection';
 import { OutputsSection, CleanupSection } from './OutputsCleanupSections';
 
@@ -89,6 +91,12 @@ export function ProjectBottomDetail({ projectId }: ProjectBottomDetailProps) {
         {/* ── Manifests accordion ───────────────────────────────────────── */}
         <div className="alm-project-bottom__cell">
           <ManifestsAccordion projectId={projectId} defaultOpen={true} />
+        </div>
+
+        {/* ── Tool Launches — observed processing artifacts (spec 012 FR-009,
+            #728: previously built and tested but never mounted) ──────────── */}
+        <div className="alm-project-bottom__cell">
+          <ToolLaunchesAccordion projectId={projectId} defaultOpen={true} />
         </div>
 
         {/* ── Generated source views (spec 026) ────────────────────────── */}

--- a/apps/desktop/src/features/projects/ProjectDetail.tool-launches.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tool-launches.test.tsx
@@ -1,0 +1,161 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * ProjectBottomDetail — Tool Launches accordion mounting (#728).
+ *
+ * `ToolLaunchesAccordion` was built and unit-tested but never mounted
+ * anywhere in the project drawer, so observed artifacts were invisible to
+ * users (spec 012 FR-009 / SC-001). Asserts it now renders inside
+ * `ProjectBottomDetail` alongside the other secondary sections.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+// ── Hoisted mocks ─────────────────────────────────────────────────────────────
+
+const { mockArtifactList, mockListManifests, mockGetProjectNote } = vi.hoisted(
+  () => ({
+    mockArtifactList: vi.fn(),
+    mockListManifests: vi.fn(),
+    mockGetProjectNote: vi.fn(),
+  }),
+);
+
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...original,
+    commands: {
+      ...original.commands,
+      artifactList: mockArtifactList,
+      manifestList: mockListManifests,
+      noteGet: mockGetProjectNote,
+    },
+  };
+});
+
+vi.mock('./store', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./store')>();
+  return {
+    ...original,
+    useProjectDetail: vi.fn(),
+    useTransitionLifecycle: vi.fn(),
+    useReinferChannels: vi.fn(),
+    useDismissChannelDrift: vi.fn(),
+  };
+});
+
+// ── Imports ───────────────────────────────────────────────────────────────────
+
+import { ProjectBottomDetail } from './ProjectBottomDetail';
+import * as store from './store';
+import type { ProjectDetailDto, ArtifactSummary } from '@/bindings/index';
+
+// ── Fixtures ──────────────────────────────────────────────────────────────────
+
+const BASE_PROJECT: ProjectDetailDto = {
+  id: 'proj-tl1',
+  name: 'NGC 7000 HOO',
+  tool: 'PixInsight',
+  lifecycle: 'ready',
+  path: 'projects/NGC7000',
+  notes: null,
+  channelDrift: { hasNewSources: false, suggestedAction: 'dismiss' },
+  sources: [],
+  channels: [],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+const ARTIFACT: ArtifactSummary = {
+  id: 'art-1',
+  projectId: 'proj-tl1',
+  toolLaunchId: 'tl-1',
+  path: 'output/MasterDark.xisf',
+  kind: 'master',
+  tool: 'pixinsight',
+  detectedAt: '2026-06-01T10:00:00Z',
+  lastSeenAt: '2026-06-01T10:00:00Z',
+  state: 'present',
+  classificationConfidence: 0.95,
+  classificationSource: 'rule',
+  sizeBytes: 2048,
+};
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function ok<T>(data: T) {
+  return { status: 'ok' as const, data };
+}
+
+function setupStore(project: Partial<ProjectDetailDto> = {}) {
+  vi.mocked(store.useProjectDetail).mockReturnValue({
+    data: { ...BASE_PROJECT, ...project },
+    loading: false,
+    error: undefined,
+  });
+}
+
+function renderDetail(projectId = 'proj-tl1') {
+  function wrapper({ children }: { children: ReactNode }) {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  return render(<ProjectBottomDetail projectId={projectId} />, { wrapper });
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('ProjectBottomDetail — Tool Launches accordion (#728)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetProjectNote.mockResolvedValue(
+      ok({ projectId: 'proj-tl1', content: null }),
+    );
+    mockListManifests.mockResolvedValue(
+      ok({ manifests: [], nextCursor: null }),
+    );
+    mockArtifactList.mockResolvedValue(ok({ artifacts: [] }));
+    setupStore();
+  });
+
+  it('mounts the Tool Launches accordion in the bottom panel', async () => {
+    renderDetail();
+    await waitFor(() => {
+      expect(mockArtifactList).toHaveBeenCalledWith(
+        expect.objectContaining({ projectId: 'proj-tl1' }),
+      );
+    });
+    expect(screen.getByText('Tool Launches')).toBeInTheDocument();
+  });
+
+  it('renders an observed artifact grouped under its launch', async () => {
+    mockArtifactList.mockResolvedValue(ok({ artifacts: [ARTIFACT] }));
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByTestId('tool-launches-accordion')).toBeInTheDocument();
+    });
+    expect(screen.getByText('master')).toBeInTheDocument();
+    expect(screen.getByText('MasterDark.xisf')).toBeInTheDocument();
+  });
+
+  it('shows the empty state when no artifacts have been observed', async () => {
+    mockArtifactList.mockResolvedValue(ok({ artifacts: [] }));
+    renderDetail();
+    await waitFor(() => {
+      expect(screen.getByText('Tool Launches')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('No processing artifacts observed yet.'),
+    ).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
+++ b/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
@@ -15,6 +15,7 @@
 
 import { useCallback } from 'react';
 import { basename } from 'pathe';
+import { Section } from '@/ui';
 import { m } from '@/lib/i18n';
 import type { ArtifactSummary } from '@/bindings/index';
 import {
@@ -30,6 +31,8 @@ interface Props {
   projectId: string;
   /** Optional ordered list of launch ids (newest first) for bucket ordering. */
   launchOrder?: string[];
+  /** Whether the collapsible section starts open. Default true. */
+  defaultOpen?: boolean;
 }
 
 // ── ArtifactRow ───────────────────────────────────────────────────────────────
@@ -173,45 +176,62 @@ function ArtifactGroupSection({
 
 // ── ToolLaunchesAccordion ─────────────────────────────────────────────────────
 
-/** Renders the "Tool Launches" accordion section of the project drawer (T023). */
-export function ToolLaunchesAccordion({ projectId, launchOrder = [] }: Props) {
+/**
+ * Renders the "Tool Launches" accordion section of the project drawer
+ * (T023). Mounted in {@link ProjectBottomDetail} alongside the other
+ * secondary/operational sections (#728 — previously built and tested but
+ * never mounted anywhere, so observed artifacts were invisible to users).
+ */
+export function ToolLaunchesAccordion({
+  projectId,
+  launchOrder = [],
+  defaultOpen = true,
+}: Props) {
   const { artifacts, loading, error, reload } = useArtifacts(projectId);
   const groups = groupArtifactsByLaunch(artifacts, launchOrder);
 
   if (loading) {
     return (
-      <div className="tool-launches-loading alm-tool-launches__loading">
-        {m.projects_artifacts_loading()}
-      </div>
+      <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+        <div className="tool-launches-loading alm-tool-launches__loading">
+          {m.projects_artifacts_loading()}
+        </div>
+      </Section>
     );
   }
 
   if (error) {
     return (
-      <div className="tool-launches-error alm-tool-launches__error">
-        {m.projects_artifacts_load_error({ error })}
-      </div>
+      <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+        <div className="tool-launches-error alm-tool-launches__error">
+          {m.projects_artifacts_load_error({ error })}
+        </div>
+      </Section>
     );
   }
 
   if (groups.length === 0) {
     return (
-      <div className="tool-launches-empty alm-tool-launches__empty">
-        {m.projects_artifacts_empty()}
-      </div>
+      <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+        <div className="tool-launches-empty alm-tool-launches__empty">
+          {m.projects_artifacts_empty()}
+        </div>
+      </Section>
     );
   }
 
   return (
-    <div data-testid="tool-launches-accordion">
-      {groups.map((group, idx) => (
-        <ArtifactGroupSection
-          key={group.toolLaunchId ?? `unattributed-${idx}`}
-          group={group}
-          projectId={projectId}
-          onAction={reload}
-        />
-      ))}
-    </div>
+    <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+      <div data-testid="tool-launches-accordion">
+        {groups.map((group, idx) => (
+          <ArtifactGroupSection
+            key={group.toolLaunchId ?? `unattributed-${idx}`}
+            group={group}
+            projectId={projectId}
+            onAction={reload}
+          />
+        ))}
+      </div>
+    </Section>
   );
 }

--- a/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
+++ b/apps/desktop/src/features/projects/ToolLaunchesAccordion.tsx
@@ -192,7 +192,10 @@ export function ToolLaunchesAccordion({
 
   if (loading) {
     return (
-      <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+      <Section
+        title={m.projects_toollaunches_title()}
+        defaultOpen={defaultOpen}
+      >
         <div className="tool-launches-loading alm-tool-launches__loading">
           {m.projects_artifacts_loading()}
         </div>
@@ -202,7 +205,10 @@ export function ToolLaunchesAccordion({
 
   if (error) {
     return (
-      <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+      <Section
+        title={m.projects_toollaunches_title()}
+        defaultOpen={defaultOpen}
+      >
         <div className="tool-launches-error alm-tool-launches__error">
           {m.projects_artifacts_load_error({ error })}
         </div>
@@ -212,7 +218,10 @@ export function ToolLaunchesAccordion({
 
   if (groups.length === 0) {
     return (
-      <Section title={m.projects_toollaunches_title()} defaultOpen={defaultOpen}>
+      <Section
+        title={m.projects_toollaunches_title()}
+        defaultOpen={defaultOpen}
+      >
         <div className="tool-launches-empty alm-tool-launches__empty">
           {m.projects_artifacts_empty()}
         </div>

--- a/crates/app/lifecycle/src/artifact.rs
+++ b/crates/app/lifecycle/src/artifact.rs
@@ -713,6 +713,65 @@ pub async fn complete_run(
     Ok(updated)
 }
 
+// ── sweep_stale_launches ────────────────────────────────────────────────────────
+
+/// Complete any of a project's open tool launches whose attribution window
+/// has closed (#727 / FR-010's stated heuristic: a launch is terminal when
+/// the attribution window elapses after the last artifact attributed to it
+/// was last seen — or, when nothing was ever attributed, after the launch
+/// itself started).
+///
+/// This is the real production trigger for [`complete_run`]: it is polled
+/// periodically by the live per-project watcher
+/// (`apps/desktop/src-tauri/src/watcher.rs`) while a project's drawer is
+/// open. Previously `complete_run` had no production caller at all, so
+/// `workflow.run_completed` (and the spec 024 manifest subscriber that
+/// depends on it) never fired outside tests.
+///
+/// Returns the number of launches completed.
+///
+/// # Errors
+/// Returns `Err(String)` on DB failure.
+pub async fn sweep_stale_launches(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+) -> Result<usize, String> {
+    let launches = tl_repo::list_launches_for_project(pool, project_id)
+        .await
+        .map_err(|e| format!("DB launches failed: {e}"))?;
+    let open: Vec<_> = launches
+        .into_iter()
+        .filter(|l| l.outcome == "spawned" && l.completed_at.is_none())
+        .collect();
+    if open.is_empty() {
+        return Ok(0);
+    }
+
+    let artifacts = repo::list_artifacts_for_project(pool, project_id, &[])
+        .await
+        .map_err(|e| format!("DB artifacts failed: {e}"))?;
+
+    let now = OffsetDateTime::now_utc();
+    let mut completed = 0usize;
+    for launch in open {
+        let last_seen = artifacts
+            .iter()
+            .filter(|a| a.tool_launch_id.as_deref() == Some(launch.id.as_str()))
+            .filter_map(|a| parse_dt(&a.last_seen_at))
+            .max();
+        let Some(reference) = last_seen.or_else(|| parse_dt(&launch.launched_at)) else {
+            continue; // unparseable timestamp; leave for the next sweep
+        };
+        if now - reference >= DEFAULT_ATTRIBUTION_WINDOW
+            && complete_run(pool, bus, project_id, &launch.tool_id, &launch.id).await?
+        {
+            completed += 1;
+        }
+    }
+    Ok(completed)
+}
+
 // ── Internal helpers ──────────────────────────────────────────────────────────
 
 /// Load `LaunchRef` entries for a project + tool from the `tool_launches` table.
@@ -977,6 +1036,88 @@ mod tests {
         // Idempotent second call.
         let updated2 = complete_run(&pool, &bus, "proj-1", "pixinsight", "tl-1").await.unwrap();
         assert!(!updated2);
+    }
+
+    // ── sweep_stale_launches (#727) ─────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn sweep_completes_launch_with_no_recent_activity() {
+        let pool = make_pool().await;
+        let bus = make_bus(&pool);
+
+        // Launched long enough ago (> DEFAULT_ATTRIBUTION_WINDOW = 6h) with no
+        // artifacts ever attributed to it — the sweep must complete it.
+        sqlx::query(
+            "INSERT INTO tool_launches (id, project_id, tool_id, launched_at, outcome, audit_id)
+             VALUES ('tl-stale','proj-1','pixinsight','2020-01-01T00:00:00Z','spawned','aud-1')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let completed = sweep_stale_launches(&pool, &bus, "proj-1").await.unwrap();
+        assert_eq!(completed, 1);
+
+        let launches = tl_repo::list_launches_for_project(&pool, "proj-1").await.unwrap();
+        assert!(launches[0].completed_at.is_some());
+    }
+
+    #[tokio::test]
+    async fn sweep_leaves_recently_launched_run_open() {
+        let pool = make_pool().await;
+        let bus = make_bus(&pool);
+
+        let recent = Timestamp::now_iso();
+        sqlx::query(
+            "INSERT INTO tool_launches (id, project_id, tool_id, launched_at, outcome, audit_id)
+             VALUES ('tl-fresh','proj-1',?,?, 'spawned','aud-1')",
+        )
+        .bind("pixinsight")
+        .bind(&recent)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let completed = sweep_stale_launches(&pool, &bus, "proj-1").await.unwrap();
+        assert_eq!(completed, 0);
+
+        let launches = tl_repo::list_launches_for_project(&pool, "proj-1").await.unwrap();
+        assert!(launches[0].completed_at.is_none());
+    }
+
+    #[tokio::test]
+    async fn sweep_uses_last_artifact_activity_not_launch_time() {
+        let pool = make_pool().await;
+        let bus = make_bus(&pool);
+
+        // Launch started long ago, but an artifact under it was seen recently
+        // (e.g. re-touched by an on-attach reconciliation pass) — the run is
+        // still active and must NOT be completed.
+        sqlx::query(
+            "INSERT INTO tool_launches (id, project_id, tool_id, launched_at, outcome, audit_id)
+             VALUES ('tl-active','proj-1','pixinsight','2020-01-01T00:00:00Z','spawned','aud-1')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let art_id = detect(
+            &pool,
+            &bus,
+            "proj-1",
+            "output/img.xisf",
+            "pixinsight",
+            512,
+            "2020-01-01T00:05:00Z",
+            "2020-01-01T00:05:00Z",
+        )
+        .await
+        .unwrap();
+        repo::set_tool_launch_id(&pool, &art_id, "tl-active").await.unwrap();
+        repo::touch_artifact(&pool, &art_id).await.unwrap(); // bumps last_seen_at to now
+
+        let completed = sweep_stale_launches(&pool, &bus, "proj-1").await.unwrap();
+        assert_eq!(completed, 0);
     }
 
     // ── T028: artifact.detected AND artifact.classified both emitted (FR-009) ──

--- a/crates/fs/inventory/src/artifact_watcher.rs
+++ b/crates/fs/inventory/src/artifact_watcher.rs
@@ -4,9 +4,9 @@
 //! Artifact filesystem watcher service (spec 012, FR-009, spec 033 T028).
 //!
 //! Watches registered library-root paths for new or modified files.  Uses
-//! plain `notify 7` (already a workspace dep) with an in-loop time-based
-//! debounce via a `HashMap<PathBuf, Instant>` to coalesce Create/Modify
-//! bursts before forwarding them downstream.
+//! plain `notify 7` (already a workspace dep) and forwards every raw
+//! Create/Modify/Remove event downstream, undebounced, via a
+//! `tokio::sync::mpsc` channel.
 //!
 //! ## Debounce strategy (deviation from D10)
 //!
@@ -14,13 +14,12 @@
 //! `notify 8.x` while the rest of the workspace uses `notify 7`.  Adding
 //! `notify 8` as a second version would cause a duplicate-type conflict in
 //! `WatcherService` (which already uses `notify 7`).  The fallback described
-//! in D10 ("acceptable fallback — noted") is used here instead: a
-//! `HashMap<PathBuf, Instant>` tracks the last-seen timestamp for each path;
-//! events that arrive within 500 ms of the last flush for that path are
-//! deduplicated in the consumer loop.
-//!
-//! Events are delivered via a `tokio::sync::mpsc` channel so the caller can
-//! drive the `artifact::detect` use-case.
+//! in D10 ("acceptable fallback — noted") is used here instead: this crate
+//! does NOT debounce — it stays a thin raw-event source. The stable-size
+//! debounce (default 2s, spec 012 edge case) is pure logic in
+//! `workflow_artifacts::watcher::check_stability`/`FileSnapshot`, applied by
+//! the consumer (`apps/desktop/src-tauri/src/watcher.rs`'s per-project
+//! forward task) against a `HashMap<PathBuf, FileSnapshot>` it owns.
 
 use std::sync::Arc;
 

--- a/crates/workflow/artifacts/src/lib.rs
+++ b/crates/workflow/artifacts/src/lib.rs
@@ -37,5 +37,5 @@ pub use reconciler::{reconcile, NewDetection, ReconcileOutcome, ReconcileReport}
 pub use rules::{ArtifactKind, ArtifactRule, MatchKind};
 pub use watcher::{
     check_stability, extension_allowed, FileSnapshot, StabilityStatus, WatchEvent, WatchEventKind,
-    DEFAULT_WATCH_EXTENSIONS,
+    DEFAULT_STABILITY_DEBOUNCE, DEFAULT_WATCH_EXTENSIONS,
 };

--- a/crates/workflow/artifacts/src/watcher.rs
+++ b/crates/workflow/artifacts/src/watcher.rs
@@ -93,6 +93,11 @@ where
 pub const DEFAULT_WATCH_EXTENSIONS: &[&str] =
     &[".xisf", ".fits", ".fit", ".tif", ".tiff", ".png", ".jpg", ".jpeg", ".ser", ".avi"];
 
+/// Default stable-size debounce window (spec 012 edge case: "bounded debounce
+/// window (default 2s)"). Consumers call [`check_stability`] on a timer no
+/// coarser than this to detect the "no further events" quiet period.
+pub const DEFAULT_STABILITY_DEBOUNCE: Duration = Duration::from_secs(2);
+
 /// Returns `true` when the file name's extension is in the watch-extensions
 /// list (case-insensitive comparison).
 #[must_use]


### PR DESCRIPTION
## Summary
- Run completion is now triggered by the real tool-run lifecycle instead of a placeholder, and artifact sizes shown for completed runs are read from disk (#727, #729).
- The project drawer gains a Tool Launches accordion listing launches and their produced artifacts (#728).

Closes #727. Closes #728. Closes #729.