### PR TITLE
fix(setup): wire wizard theme selector to theme runtime, live density preview

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -923,7 +923,6 @@
   "setup_config_density_compact": "Compact",
   "setup_config_density_spacious": "Spacious",
   "setup_config_display_density_desc": "How compact the interface is — affects row heights and spacing across the app.",
-  "setup_config_theme_light": "Light",
   "setup_confirm_blocked": "Cannot complete setup: missing required folder types — {kinds}. Go back to Step 1 to add them.",
   "setup_confirm_next_roots": "Your selected folders are registered as library roots.",
   "setup_confirm_next_scan": "An initial scan runs after setup, reading file headers to build the index.",

--- a/apps/desktop/src/features/setup/SetupPage.test.tsx
+++ b/apps/desktop/src/features/setup/SetupPage.test.tsx
@@ -1,0 +1,60 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * SetupPage tests — #505: the setup wizard renders outside Shell.tsx, so it
+ * carries its own `density-*` class (mirroring `.alm-frame density-${density}`
+ * in app/Shell.tsx) for a live density preview during setup.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+}));
+
+vi.mock('@/app/first-run', () => ({
+  checkFirstRunComplete: vi.fn().mockResolvedValue(false),
+}));
+
+// SetupWizard pulls in the full wizard step tree (folder pickers, IPC, etc.)
+// — out of scope here, stub it so this test stays focused on SetupPage's own
+// container markup.
+vi.mock('./SetupWizard', () => ({
+  SetupWizard: () => <div data-testid="setup-wizard-stub" />,
+}));
+
+import { setPreference, resetPreferences } from '@/data/preferences';
+import { SetupPage } from './SetupPage';
+
+beforeEach(() => {
+  mockNavigate.mockReset();
+  resetPreferences();
+});
+
+describe('SetupPage — live density preview (#505)', () => {
+  it('carries the density class matching the current preference', async () => {
+    setPreference('density', 'spacious');
+    const { container } = render(<SetupPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('setup-wizard-stub')).toBeInTheDocument(),
+    );
+    expect(container.querySelector('.alm-page')).toHaveClass(
+      'density-spacious',
+    );
+  });
+
+  it('defaults to the comfortable density class', async () => {
+    const { container } = render(<SetupPage />);
+    await waitFor(() =>
+      expect(screen.getByTestId('setup-wizard-stub')).toBeInTheDocument(),
+    );
+    expect(container.querySelector('.alm-page')).toHaveClass(
+      'density-comfortable',
+    );
+  });
+});

--- a/apps/desktop/src/features/setup/SetupPage.tsx
+++ b/apps/desktop/src/features/setup/SetupPage.tsx
@@ -10,6 +10,7 @@ import { SetupWizard } from './SetupWizard';
 
 export function SetupPage() {
   const [setupCompleted] = usePreference('setupCompleted');
+  const [density] = usePreference('density');
   const navigate = useNavigate();
   const [checking, setChecking] = useState(!setupCompleted);
 
@@ -45,7 +46,10 @@ export function SetupPage() {
   }
 
   return (
-    <div className="alm-page">
+    // density-* mirrors Shell.tsx's `.alm-frame` class: the wizard renders
+    // outside the Shell, so it needs its own carrier for a live density
+    // preview during setup (#505).
+    <div className={`alm-page density-${density}`}>
       <SetupWizard />
     </div>
   );

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
@@ -7,10 +7,11 @@
  *
  * The step no longer downloads catalogs (spec-014 backend removed). It is now a
  * small Configuration screen: SIMBAD online-resolution toggle, display density,
- * default source protection, default scan depth, and a disabled theme control.
+ * default source protection, default scan depth, and a live theme control
+ * (#504 — wired to the same `data/theme.ts` runtime as Settings > General).
  */
 
-import { render, screen, waitFor } from '@testing-library/react';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockGet, mockUpdate, mockSettingsGet, mockSettingsUpdate } = vi.hoisted(
@@ -50,6 +51,10 @@ beforeEach(() => {
   mockUpdate.mockReset();
   mockSettingsGet.mockReset();
   mockSettingsUpdate.mockReset();
+  // useThemeChoice is backed by localStorage (data/theme.ts) — reset between
+  // tests so each case starts from the 'system' default.
+  localStorage.clear();
+  document.documentElement.removeAttribute('data-theme');
   mockGet.mockResolvedValue({
     contractVersion: '1.0',
     requestId: 'r',
@@ -94,10 +99,32 @@ describe('StepCatalogs (Configuration)', () => {
     expect(screen.getByLabelText('Display density')).toBeInTheDocument();
   });
 
-  it('shows a disabled theme control', () => {
+  it('shows a live theme control listing all app themes (#504)', () => {
     renderStep();
-    const theme = screen.getByLabelText('Theme');
-    expect(theme).toBeDisabled();
+    const theme = screen.getByLabelText('Theme') as HTMLSelectElement;
+    expect(theme).not.toBeDisabled();
+    const optionValues = Array.from(theme.options).map((o) => o.value);
+    expect(optionValues).toEqual([
+      'system',
+      'warm-clay',
+      'warm-slate',
+      'observatory-dark',
+      'espresso-dark',
+    ]);
+  });
+
+  it('defaults the theme control to the current choice and applies changes live (#504)', () => {
+    localStorage.setItem('alm.theme', 'observatory-dark');
+    renderStep();
+    const theme = screen.getByLabelText('Theme') as HTMLSelectElement;
+    expect(theme.value).toBe('observatory-dark');
+
+    fireEvent.change(theme, { target: { value: 'warm-clay' } });
+
+    expect(theme.value).toBe('warm-clay');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'warm-clay',
+    );
   });
 
   it('shows no catalog-download affordance', () => {

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -13,6 +13,7 @@
 import { useEffect, useState, type ReactNode } from 'react';
 import { ResolverSettingsControl } from '@/features/settings/ResolverSettingsControl';
 import { usePreference } from '@/data/preferences';
+import { useThemeChoice, THEMES, type ThemeChoice } from '@/data/theme';
 import { m } from '@/lib/i18n';
 import type { Density } from '@/bindings/types';
 import { commands } from '@/bindings/index';
@@ -109,6 +110,29 @@ function DensityControl() {
   );
 }
 
+// ── Appearance / theme (data/theme.ts runtime; applied globally via `data-theme`
+// on <html>, so it is already live outside the wizard — this control just wires
+// the setup step's select to the same source of truth as Settings > General) ──
+
+function ThemeControl() {
+  const [choice, setChoice] = useThemeChoice();
+  return (
+    <select
+      className="alm-select"
+      value={choice}
+      aria-label={m.settings_general_theme()}
+      onChange={(e) => setChoice(e.target.value as ThemeChoice)}
+    >
+      <option value="system">{m.settings_general_theme_system()}</option>
+      {THEMES.map((t) => (
+        <option key={t.id} value={t.id}>
+          {t.label}
+        </option>
+      ))}
+    </select>
+  );
+}
+
 // ── A labelled config row: title + control on one line, description below ──────
 
 function ConfigOption({
@@ -161,15 +185,7 @@ export function StepCatalogs(_props: StepCatalogsProps) {
       <ConfigOption
         title={m.setup_config_appearance_title()}
         description={m.setup_config_appearance_desc()}
-        control={
-          <select
-            className="alm-select"
-            disabled
-            aria-label={m.settings_general_theme()}
-          >
-            <option>{m.setup_config_theme_light()}</option>
-          </select>
-        }
+        control={<ThemeControl />}
       />
     </div>
   );


### PR DESCRIPTION
## Summary

- Fixes #504: the Step 3 "Appearance" theme control in the wizard was a hardcoded `<select disabled>` with a single "Light" option, disconnected from the app's actual theme runtime. It is now a live `ThemeControl` in `StepCatalogs.tsx` bound to `useThemeChoice()` / `THEMES` from `data/theme.ts` (the same runtime Settings > General already uses), listing `system` plus all configured themes.
- Fixes #505: display density had no live visual effect in the wizard because `SetupPage` renders outside `Shell` (which is what applies `density-*` via `.alm-frame`). `SetupPage.tsx` now reads the density preference and applies `density-${density}` on its own `.alm-page` wrapper, mirroring `Shell.tsx`'s pattern, so the density choice previews live during setup.
- Removed the now-dead `setup_config_theme_light` i18n key.

## Test plan

- [x] Scoped tests: `pnpm vitest run SetupPage.test.tsx StepCatalogs.test.tsx` — 7/7 passed
- [x] `just typecheck` — green
- [x] `just lint` — 0 errors (236 pre-existing warnings unrelated to touched files)
- [x] Full desktop suite (`pnpm -C apps/desktop test -- --run`) — 1419/1424 passed; 3 pre-existing unrelated failures (GuidedOverlay Joyride timing, inbox affordances timeout, LogPanel virtualizer teardown) confirmed unrelated to this diff (none touch the 5 files changed here) and reproduce as flaky under load, not caused by this change

Note: this work was recovered from an interrupted orchestration session (salvaged from a dead coder's worktree transcript, verified clean replay against current `main`) and re-verified end-to-end before opening this PR.