### PR TITLE
fix(settings): apply density and font-size to the shared token layer

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -70,6 +70,7 @@
     "@tauri-apps/cli": "^2.11.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",
     "@types/react-dom": "^19.2.0",
     "@vitejs/plugin-react": "^5.1.0",

--- a/apps/desktop/src/data/preferences.ts
+++ b/apps/desktop/src/data/preferences.ts
@@ -88,6 +88,16 @@ export function resetPreferences(): void {
   notify();
 }
 
+/**
+ * Subscribes to preference changes outside React (components use the hooks
+ * below). Lets the appearance runtime (data/theme.ts) re-apply density when
+ * ANY caller writes it — Settings, the Setup wizard's usePreference — so the
+ * app-wide token rescale never depends on a per-call-site applyDensity (#587).
+ */
+export function subscribePreferences(listener: Listener): () => void {
+  return subscribe(listener);
+}
+
 // --- Hooks ---
 
 function subscribe(listener: Listener): () => void {

--- a/apps/desktop/src/data/theme.density-fontsize.test.ts
+++ b/apps/desktop/src/data/theme.density-fontsize.test.ts
@@ -193,3 +193,27 @@ describe('hydrateThemeFromSettings — reconciles font size alongside theme', ()
     expect(getFontSizeChoice()).toBe('large');
   });
 });
+
+describe('density preference writes — central rescale via initAppearance()', () => {
+  it('a bare setPreference("density") rescales tokens (the Setup wizard path, which never calls applyDensity)', async () => {
+    const { initAppearance } = await import('./theme');
+    const { setPreference } = await import('./preferences');
+    initAppearance();
+
+    // StepCatalogs' DensityControl only writes the preference via
+    // usePreference('density') → setPreference; no applyDensity call.
+    setPreference('density', 'compact');
+
+    const style = document.documentElement.style;
+    expect(style.getPropertyValue('--alm-sp-2')).toBe('6.00px'); // 8 * 0.75
+    expect(document.documentElement.classList.contains('density-compact')).toBe(
+      true,
+    );
+
+    setPreference('density', 'comfortable');
+    expect(style.getPropertyValue('--alm-sp-2')).toBe('');
+    expect(document.documentElement.classList.contains('density-compact')).toBe(
+      false,
+    );
+  });
+});

--- a/apps/desktop/src/data/theme.density-fontsize.test.ts
+++ b/apps/desktop/src/data/theme.density-fontsize.test.ts
@@ -19,9 +19,8 @@ type IpcOutcome =
 
 const isTauriMock = vi.fn<() => boolean>();
 const settingsGetMock = vi.fn<(scope: string) => Promise<IpcOutcome>>();
-const settingsUpdateMock = vi.fn<
-  (scope: string, values: unknown) => Promise<IpcOutcome>
->();
+const settingsUpdateMock =
+  vi.fn<(scope: string, values: unknown) => Promise<IpcOutcome>>();
 
 vi.mock('@tauri-apps/api/core', () => ({
   isTauri: () => isTauriMock(),
@@ -77,9 +76,9 @@ describe('applyDensity — spacing tokens (app-wide, not just row height)', () =
     expect(
       document.documentElement.classList.contains('density-spacious'),
     ).toBe(true);
-    expect(
-      document.documentElement.classList.contains('density-compact'),
-    ).toBe(false);
+    expect(document.documentElement.classList.contains('density-compact')).toBe(
+      false,
+    );
   });
 
   it('clears the override for comfortable (falls back to the tokens.css base)', async () => {

--- a/apps/desktop/src/data/theme.density-fontsize.test.ts
+++ b/apps/desktop/src/data/theme.density-fontsize.test.ts
@@ -1,0 +1,196 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * theme.density-fontsize.test.ts — #587 (density/font-size have no visible
+ * effect). Covers: `applyDensity`/`applyFontSize` scaling the shared
+ * `--alm-sp-*` / `--alm-text-*` tokens on <html> (the app-wide effect,
+ * verified without depending on any component stylesheet), font-size
+ * persistence (localStorage cache + settings-DB write-through, mirroring
+ * theme.persistence.test.ts), and `hydrateThemeFromSettings` reconciling
+ * both theme and font size from one settings scope.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+type IpcOutcome =
+  | { status: 'ok'; data: unknown }
+  | { status: 'error'; error: unknown };
+
+const isTauriMock = vi.fn<() => boolean>();
+const settingsGetMock = vi.fn<(scope: string) => Promise<IpcOutcome>>();
+const settingsUpdateMock = vi.fn<
+  (scope: string, values: unknown) => Promise<IpcOutcome>
+>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock(),
+}));
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({ setTheme: vi.fn().mockResolvedValue(undefined) }),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: (scope: string) => settingsGetMock(scope),
+    settingsUpdate: (scope: string, values: unknown) =>
+      settingsUpdateMock(scope, values),
+  },
+}));
+
+async function waitForCall(fn: ReturnType<typeof vi.fn>): Promise<void> {
+  for (let i = 0; i < 50; i++) {
+    if (fn.mock.calls.length > 0) return;
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+}
+
+beforeEach(() => {
+  vi.resetModules();
+  isTauriMock.mockReset();
+  settingsGetMock.mockReset();
+  settingsUpdateMock.mockReset();
+  settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+  localStorage.clear();
+  document.documentElement.removeAttribute('style');
+  document.documentElement.className = '';
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe('applyDensity — spacing tokens (app-wide, not just row height)', () => {
+  it('scales --alm-sp-* down for compact and up for spacious', async () => {
+    const { applyDensity } = await import('./theme');
+    const style = document.documentElement.style;
+
+    applyDensity('compact');
+    expect(style.getPropertyValue('--alm-sp-2')).toBe('6.00px'); // 8 * 0.75
+    expect(document.documentElement.classList.contains('density-compact')).toBe(
+      true,
+    );
+
+    applyDensity('spacious');
+    expect(style.getPropertyValue('--alm-sp-2')).toBe('10.00px'); // 8 * 1.25
+    expect(
+      document.documentElement.classList.contains('density-spacious'),
+    ).toBe(true);
+    expect(
+      document.documentElement.classList.contains('density-compact'),
+    ).toBe(false);
+  });
+
+  it('clears the override for comfortable (falls back to the tokens.css base)', async () => {
+    const { applyDensity } = await import('./theme');
+    const style = document.documentElement.style;
+
+    applyDensity('compact');
+    expect(style.getPropertyValue('--alm-sp-2')).not.toBe('');
+
+    applyDensity('comfortable');
+    expect(style.getPropertyValue('--alm-sp-2')).toBe('');
+  });
+});
+
+describe('applyFontSize — type-scale tokens (app-wide)', () => {
+  it('scales --alm-text-* down for small and up for large', async () => {
+    const { applyFontSize } = await import('./theme');
+    const style = document.documentElement.style;
+
+    applyFontSize('small');
+    expect(style.getPropertyValue('--alm-text-base')).toBe('11.70px'); // 13 * 0.9
+
+    applyFontSize('large');
+    expect(style.getPropertyValue('--alm-text-base')).toBe('14.95px'); // 13 * 1.15
+  });
+
+  it('clears the override for default', async () => {
+    const { applyFontSize } = await import('./theme');
+    const style = document.documentElement.style;
+
+    applyFontSize('large');
+    expect(style.getPropertyValue('--alm-text-base')).not.toBe('');
+
+    applyFontSize('default');
+    expect(style.getPropertyValue('--alm-text-base')).toBe('');
+  });
+});
+
+describe('font size choice — persistence (mirrors the theme choice pattern)', () => {
+  it('defaults to "default" with no stored value', async () => {
+    const { getFontSizeChoice } = await import('./theme');
+    expect(getFontSizeChoice()).toBe('default');
+  });
+
+  it('persists to localStorage synchronously and survives a reload (no reset-on-visit)', async () => {
+    isTauriMock.mockReturnValue(false);
+    const { setFontSizeChoice } = await import('./theme');
+
+    setFontSizeChoice('large');
+    expect(localStorage.getItem('alm.fontSize')).toBe('large');
+
+    // Simulate a fresh module load (e.g. a page revisit) reading the cache.
+    vi.resetModules();
+    const { getFontSizeChoice } = await import('./theme');
+    expect(getFontSizeChoice()).toBe('large');
+  });
+
+  it('writes through to the settings DB (general scope, fontSize key) when inside Tauri', async () => {
+    isTauriMock.mockReturnValue(true);
+    const { setFontSizeChoice } = await import('./theme');
+
+    setFontSizeChoice('small');
+
+    await waitForCall(settingsUpdateMock);
+    expect(settingsUpdateMock).toHaveBeenCalledWith('general', {
+      fontSize: 'small',
+    });
+  });
+
+  it('skips the settings-DB write outside Tauri (no-op)', async () => {
+    isTauriMock.mockReturnValue(false);
+    const { setFontSizeChoice } = await import('./theme');
+
+    setFontSizeChoice('small');
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('hydrateThemeFromSettings — reconciles font size alongside theme', () => {
+  it('applies a stored fontSize from the same settings.get payload', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'general', values: { fontSize: 'large' } },
+    });
+
+    const { hydrateThemeFromSettings, getFontSizeChoice } = await import(
+      './theme'
+    );
+    await hydrateThemeFromSettings();
+
+    expect(getFontSizeChoice()).toBe('large');
+    expect(
+      document.documentElement.style.getPropertyValue('--alm-text-base'),
+    ).toBe('14.95px');
+  });
+
+  it('ignores a malformed fontSize value and keeps the current choice', async () => {
+    isTauriMock.mockReturnValue(true);
+    localStorage.setItem('alm.fontSize', 'large');
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'general', values: { fontSize: 'huge' } },
+    });
+
+    const { hydrateThemeFromSettings, getFontSizeChoice } = await import(
+      './theme'
+    );
+    await hydrateThemeFromSettings();
+
+    expect(getFontSizeChoice()).toBe('large');
+  });
+});

--- a/apps/desktop/src/data/theme.tokens-drift.test.ts
+++ b/apps/desktop/src/data/theme.tokens-drift.test.ts
@@ -1,0 +1,55 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * theme.tokens-drift.test.ts — #587 follow-up.
+ *
+ * `theme.ts` hardcodes SPACING_BASE_PX / TEXT_SCALE_BASE_PX as duplicates of
+ * the `--alm-sp-*` / `--alm-text-*` base px values in tokens.css (jsdom can't
+ * reliably resolve stylesheet custom properties via getComputedStyle, so
+ * applyTokenScale reads these tables instead of the stylesheet). Nothing else
+ * enforces that the two stay in sync — this test parses tokens.css directly
+ * and fails if a value drifts, so a future tokens.css edit can't silently
+ * desync the runtime scaling.
+ */
+
+/// <reference types="node" />
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { SPACING_BASE_PX, TEXT_SCALE_BASE_PX } from './theme';
+
+// vitest's `css: false` test config replaces all `.css`-suffixed imports
+// (including `?raw`) with an empty string, so this reads the file directly
+// instead. vitest runs with cwd = apps/desktop (see package.json `test`).
+const tokensCssPath = join(process.cwd(), 'src/styles/tokens.css');
+
+/** Parses only the base `:root { ... }` block, before any `[data-theme]` override block. */
+function parseRootTokenPx(varPrefix: string): Record<string, number> {
+  const css = readFileSync(tokensCssPath, 'utf-8');
+  const rootBlockEnd = css.indexOf('\n}');
+  const rootBlock = css.slice(0, rootBlockEnd);
+  const pattern = new RegExp(
+    `(${varPrefix}[\\w-]+):\\s*(\\d+(?:\\.\\d+)?)px;`,
+    'g',
+  );
+  const result: Record<string, number> = {};
+  for (const match of rootBlock.matchAll(pattern)) {
+    result[match[1]] = Number(match[2]);
+  }
+  return result;
+}
+
+describe('theme.ts token-scale base tables match tokens.css :root', () => {
+  it('SPACING_BASE_PX matches --alm-sp-* base px values', () => {
+    const fromCss = parseRootTokenPx('--alm-sp-');
+    expect(Object.keys(fromCss).length).toBeGreaterThan(0);
+    expect(SPACING_BASE_PX).toEqual(fromCss);
+  });
+
+  it('TEXT_SCALE_BASE_PX matches --alm-text-* base px values', () => {
+    const fromCss = parseRootTokenPx('--alm-text-');
+    expect(Object.keys(fromCss).length).toBeGreaterThan(0);
+    expect(TEXT_SCALE_BASE_PX).toEqual(fromCss);
+  });
+});

--- a/apps/desktop/src/data/theme.tokens-drift.test.ts
+++ b/apps/desktop/src/data/theme.tokens-drift.test.ts
@@ -24,11 +24,16 @@ import { SPACING_BASE_PX, TEXT_SCALE_BASE_PX } from './theme';
 // instead. vitest runs with cwd = apps/desktop (see package.json `test`).
 const tokensCssPath = join(process.cwd(), 'src/styles/tokens.css');
 
-/** Parses only the base `:root { ... }` block, before any `[data-theme]` override block. */
+/**
+ * Parses the base `:root { ... }` block only. Anchored to the bare `:root`
+ * selector: theme blocks use `[data-theme=...]` and the shared default-palette
+ * block uses `:root, [data-theme=...]`, so neither matches `:root\s*{`. CSS
+ * blocks here never nest, so `[^}]*` spans exactly one block.
+ */
 function parseRootTokenPx(varPrefix: string): Record<string, number> {
   const css = readFileSync(tokensCssPath, 'utf-8');
-  const rootBlockEnd = css.indexOf('\n}');
-  const rootBlock = css.slice(0, rootBlockEnd);
+  const rootBlock = /:root\s*\{([^}]*)\}/.exec(css)?.[1];
+  if (rootBlock === undefined) throw new Error('no :root block in tokens.css');
   const pattern = new RegExp(
     `(${varPrefix}[\\w-]+):\\s*(\\d+(?:\\.\\d+)?)px;`,
     'g',

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -26,7 +26,7 @@
 // backed — it stays on the existing `AppPreferences.density` (localStorage)
 // path.
 import { useSyncExternalStore } from 'react';
-import { getPreferences } from '@/data/preferences';
+import { getPreferences, subscribePreferences } from '@/data/preferences';
 
 export type ThemeId =
   | 'warm-clay'
@@ -344,11 +344,24 @@ export function setFontSizeChoice(choice: FontSizeChoice): void {
   notify();
 }
 
-/** Call once at startup (before/at first render). Wires OS-theme changes. */
+/**
+ * Call once at startup (before/at first render). Wires OS-theme changes and
+ * re-applies density on any preference write, so every density writer
+ * (Settings, the Setup wizard's usePreference('density')) gets the token
+ * rescale without needing its own applyDensity call (#587).
+ */
 export function initAppearance(): void {
   applyTheme();
   applyDensity();
   applyFontSize();
+  let lastDensity = getPreferences().density;
+  subscribePreferences(() => {
+    const d = getPreferences().density;
+    if (d !== lastDensity) {
+      lastDensity = d;
+      applyDensity(d);
+    }
+  });
   if (typeof window !== 'undefined' && window.matchMedia) {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = (): void => {

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -1,22 +1,30 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-// Appearance runtime — theme + density (PlateVault redesign).
+// Appearance runtime — theme + density + font size (PlateVault redesign).
 //
 // Theme is applied as a `data-theme` attribute on <html>; tokens.css defines
 // one scope per theme. `system` follows the OS via prefers-color-scheme.
 // Density mirrors the existing AppPreferences.density and is applied as a
-// class on <html>.
+// class on <html>. Density and font size both scale the shared
+// spacing/type-scale CSS custom properties (tokens.css `--alm-sp-*` /
+// `--alm-text-*`) in place via inline overrides on <html> — those tokens are
+// consumed by hundreds of component stylesheets already, so this gives an
+// app-wide effect through the existing token layer rather than adding
+// per-component density/font-size branches (#587).
 //
 // Persistence (theme-settings-db): the settings DB (`general` scope, `theme`
-// key — spec 018) is the durable source of truth. localStorage (`alm.theme`)
-// is kept ONLY as a synchronous boot cache so `initAppearance()` can paint the
-// right theme before first render without waiting on an IPC round-trip. On
-// Windows, WebView2 only flushes its localStorage-backing LevelDB store on a
-// graceful shutdown, so a force-killed app can lose the cache entirely — the
-// DB survives that. `hydrateThemeFromSettings()` reconciles the cache from
-// the DB once IPC is available (call after `initAppearance()`); `setThemeChoice`
-// writes both on every change.
+// / `fontSize` keys — spec 018) is the durable source of truth. localStorage
+// (`alm.theme` / `alm.fontSize`) is kept ONLY as a synchronous boot cache so
+// `initAppearance()` can paint the right theme/font size before first render
+// without waiting on an IPC round-trip. On Windows, WebView2 only flushes its
+// localStorage-backing LevelDB store on a graceful shutdown, so a force-killed
+// app can lose the cache entirely — the DB survives that.
+// `hydrateThemeFromSettings()` reconciles both caches from the DB once IPC is
+// available (call after `initAppearance()`); `setThemeChoice` /
+// `setFontSizeChoice` write both on every change. Density is not settings-DB
+// backed — it stays on the existing `AppPreferences.density` (localStorage)
+// path.
 import { useSyncExternalStore } from 'react';
 import { getPreferences } from '@/data/preferences';
 
@@ -81,6 +89,45 @@ function isThemeChoice(v: unknown): v is ThemeChoice {
   );
 }
 
+/**
+ * Base pixel values for the shared spacing/type-scale tokens (tokens.css
+ * `:root`), duplicated here rather than read via `getComputedStyle` —
+ * jsdom (vitest) doesn't reliably resolve stylesheet-declared custom
+ * properties through computed style, which would make scaling non-
+ * deterministic under test. Keep these in sync with tokens.css if its base
+ * `--alm-sp-*` / `--alm-text-*` values ever change.
+ */
+const SPACING_BASE_PX: Record<string, number> = {
+  '--alm-sp-0': 2,
+  '--alm-sp-1': 4,
+  '--alm-sp-2': 8,
+  '--alm-sp-3': 12,
+  '--alm-sp-4': 16,
+  '--alm-sp-5': 24,
+  '--alm-sp-6': 32,
+  '--alm-sp-7': 48,
+};
+
+const TEXT_SCALE_BASE_PX: Record<string, number> = {
+  '--alm-text-2xs': 10,
+  '--alm-text-xs': 11,
+  '--alm-text-sm': 12,
+  '--alm-text-base': 13,
+  '--alm-text-md': 14,
+  '--alm-text-lg': 16,
+  '--alm-text-xl': 18,
+  '--alm-text-2xl': 22,
+};
+
+/** Rescales a base token table onto <html> inline styles; `scale === 1` clears the override (back to tokens.css defaults). */
+function applyTokenScale(base: Record<string, number>, scale: number): void {
+  const style = document.documentElement.style;
+  for (const [token, px] of Object.entries(base)) {
+    if (scale === 1) style.removeProperty(token);
+    else style.setProperty(token, `${(px * scale).toFixed(2)}px`);
+  }
+}
+
 const listeners = new Set<() => void>();
 function notify(): void {
   for (const l of listeners) l();
@@ -135,12 +182,14 @@ export function setThemeChoice(choice: ThemeChoice): void {
 }
 
 /**
- * Reconcile the synchronous localStorage boot cache against the settings DB
- * (spec 018) — the DB is the durable source of truth; localStorage only
- * exists to avoid a flash of the wrong theme before this async call
- * resolves. Call once after `initAppearance()` at boot. No-ops outside
- * Tauri or on any IPC failure (the localStorage cache stays authoritative
- * until the next successful reconcile).
+ * Reconcile the synchronous localStorage boot caches (theme + font size)
+ * against the settings DB (spec 018) — the DB is the durable source of
+ * truth; localStorage only exists to avoid a flash of the wrong value
+ * before this async call resolves. Both live in the same `general` scope,
+ * so one `settingsGet` round-trip reconciles both. Call once after
+ * `initAppearance()` at boot. No-ops outside Tauri or on any IPC failure
+ * (the localStorage caches stay authoritative until the next successful
+ * reconcile).
  */
 export async function hydrateThemeFromSettings(): Promise<void> {
   try {
@@ -152,12 +201,22 @@ export async function hydrateThemeFromSettings(): Promise<void> {
       import('@/api/ipc'),
     ]);
     const data = unwrap(await commands.settingsGet(SETTINGS_SCOPE));
-    const stored = (data.values as Record<string, unknown>)[SETTINGS_KEY];
-    if (isThemeChoice(stored) && stored !== getThemeChoice()) {
-      setThemeChoice(stored);
+    const values = data.values as Record<string, unknown>;
+
+    const storedTheme = values[SETTINGS_KEY];
+    if (isThemeChoice(storedTheme) && storedTheme !== getThemeChoice()) {
+      setThemeChoice(storedTheme);
+    }
+
+    const storedFontSize = values[FONT_SIZE_SETTINGS_KEY];
+    if (
+      isFontSizeChoice(storedFontSize) &&
+      storedFontSize !== getFontSizeChoice()
+    ) {
+      setFontSizeChoice(storedFontSize);
     }
   } catch {
-    // Best-effort — keep the current localStorage-cached choice.
+    // Best-effort — keep the current localStorage-cached choices.
   }
 }
 
@@ -204,6 +263,13 @@ export function applyTheme(): void {
   syncNativeWindowTheme(resolved);
 }
 
+/** Matches the existing row-height ratio (24/32/40px = -25%/base/+25%). */
+const DENSITY_SPACING_SCALE: Record<string, number> = {
+  compact: 0.75,
+  comfortable: 1,
+  spacious: 1.25,
+};
+
 export function applyDensity(density?: string): void {
   if (typeof document === 'undefined') return;
   const d = density ?? getPreferences().density;
@@ -211,12 +277,77 @@ export function applyDensity(density?: string): void {
   root.remove('density-compact', 'density-spacious');
   if (d === 'compact') root.add('density-compact');
   else if (d === 'spacious') root.add('density-spacious');
+  applyTokenScale(SPACING_BASE_PX, DENSITY_SPACING_SCALE[d] ?? 1);
+}
+
+export type FontSizeChoice = 'small' | 'default' | 'large';
+
+const FONT_SIZE_KEY = 'alm.fontSize';
+const FONT_SIZE_SETTINGS_KEY = 'fontSize';
+const FONT_SIZE_SCALE: Record<FontSizeChoice, number> = {
+  small: 0.9,
+  default: 1,
+  large: 1.15,
+};
+
+function isFontSizeChoice(v: unknown): v is FontSizeChoice {
+  return v === 'small' || v === 'default' || v === 'large';
+}
+
+export function getFontSizeChoice(): FontSizeChoice {
+  try {
+    const v = localStorage.getItem(FONT_SIZE_KEY);
+    return isFontSizeChoice(v) ? v : 'default';
+  } catch {
+    return 'default';
+  }
+}
+
+/** Best-effort write-through to the settings DB — mirrors `persistThemeToSettings`. */
+function persistFontSizeToSettings(choice: FontSizeChoice): void {
+  void (async () => {
+    try {
+      const { isTauri } = await import('@tauri-apps/api/core');
+      if (!isTauri()) return;
+
+      const [{ commands }, { unwrap }] = await Promise.all([
+        import('@/bindings/index'),
+        import('@/api/ipc'),
+      ]);
+      unwrap(
+        await commands.settingsUpdate(SETTINGS_SCOPE, {
+          [FONT_SIZE_SETTINGS_KEY]: choice,
+        }),
+      );
+    } catch {
+      // Best-effort — a DB write failure never blocks or reverts the UI change.
+    }
+  })();
+}
+
+export function applyFontSize(
+  choice: FontSizeChoice = getFontSizeChoice(),
+): void {
+  if (typeof document === 'undefined') return;
+  applyTokenScale(TEXT_SCALE_BASE_PX, FONT_SIZE_SCALE[choice]);
+}
+
+export function setFontSizeChoice(choice: FontSizeChoice): void {
+  try {
+    localStorage.setItem(FONT_SIZE_KEY, choice);
+  } catch {
+    /* localStorage may be unavailable */
+  }
+  persistFontSizeToSettings(choice);
+  applyFontSize(choice);
+  notify();
 }
 
 /** Call once at startup (before/at first render). Wires OS-theme changes. */
 export function initAppearance(): void {
   applyTheme();
   applyDensity();
+  applyFontSize();
   if (typeof window !== 'undefined' && window.matchMedia) {
     const mq = window.matchMedia('(prefers-color-scheme: dark)');
     const onChange = (): void => {
@@ -245,4 +376,13 @@ export function useThemeChoice(): [ThemeChoice, (c: ThemeChoice) => void] {
 /** Hook: the resolved (concrete) theme id, tracks OS changes under `system`. */
 export function useResolvedTheme(): ThemeId {
   return useSyncExternalStore(subscribe, () => resolveTheme());
+}
+
+/** Hook: [choice, setChoice] for the app-wide font size. */
+export function useFontSizeChoice(): [
+  FontSizeChoice,
+  (c: FontSizeChoice) => void,
+] {
+  const choice = useSyncExternalStore(subscribe, getFontSizeChoice);
+  return [choice, setFontSizeChoice];
 }

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -95,9 +95,10 @@ function isThemeChoice(v: unknown): v is ThemeChoice {
  * jsdom (vitest) doesn't reliably resolve stylesheet-declared custom
  * properties through computed style, which would make scaling non-
  * deterministic under test. Keep these in sync with tokens.css if its base
- * `--alm-sp-*` / `--alm-text-*` values ever change.
+ * `--alm-sp-*` / `--alm-text-*` values ever change — `theme.tokens-drift.test.ts`
+ * asserts these tables match the parsed tokens.css `:root` values.
  */
-const SPACING_BASE_PX: Record<string, number> = {
+export const SPACING_BASE_PX: Record<string, number> = {
   '--alm-sp-0': 2,
   '--alm-sp-1': 4,
   '--alm-sp-2': 8,
@@ -108,7 +109,7 @@ const SPACING_BASE_PX: Record<string, number> = {
   '--alm-sp-7': 48,
 };
 
-const TEXT_SCALE_BASE_PX: Record<string, number> = {
+export const TEXT_SCALE_BASE_PX: Record<string, number> = {
   '--alm-text-2xs': 10,
   '--alm-text-xs': 11,
   '--alm-text-sm': 12,

--- a/apps/desktop/src/features/settings/General.test.tsx
+++ b/apps/desktop/src/features/settings/General.test.tsx
@@ -34,12 +34,12 @@ describe('General — density', () => {
     const select = screen.getByDisplayValue('Comfortable (32px row)');
     fireEvent.change(select, { target: { value: 'compact' } });
 
-    expect(
-      document.documentElement.style.getPropertyValue('--alm-sp-2'),
-    ).toBe('6.00px');
-    expect(
-      document.documentElement.classList.contains('density-compact'),
-    ).toBe(true);
+    expect(document.documentElement.style.getPropertyValue('--alm-sp-2')).toBe(
+      '6.00px',
+    );
+    expect(document.documentElement.classList.contains('density-compact')).toBe(
+      true,
+    );
   });
 });
 

--- a/apps/desktop/src/features/settings/General.test.tsx
+++ b/apps/desktop/src/features/settings/General.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * General.test.tsx — #587 (Settings Appearance: density and font-size
+ * controls have no visible effect).
+ *
+ * Confirms both selects, when changed, apply through the shared token layer
+ * on <html> (data/theme.ts `applyDensity`/`applyFontSize`) rather than being
+ * inert local state — the density select already wired `applyDensity`
+ * on change (App), font size previously did nothing at all.
+ */
+
+import { render, screen, cleanup, fireEvent } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { General } from './General';
+
+beforeEach(() => {
+  localStorage.clear();
+  document.documentElement.removeAttribute('style');
+  document.documentElement.className = '';
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('General — density', () => {
+  it('scales the shared spacing tokens on <html> when changed', () => {
+    render(<General />);
+
+    const select = screen.getByDisplayValue('Comfortable (32px row)');
+    fireEvent.change(select, { target: { value: 'compact' } });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--alm-sp-2'),
+    ).toBe('6.00px');
+    expect(
+      document.documentElement.classList.contains('density-compact'),
+    ).toBe(true);
+  });
+});
+
+describe('General — font size', () => {
+  it('scales the shared type-scale tokens on <html> when changed', () => {
+    render(<General />);
+
+    const select = screen.getByDisplayValue('Default (14px)');
+    fireEvent.change(select, { target: { value: 'large' } });
+
+    expect(
+      document.documentElement.style.getPropertyValue('--alm-text-base'),
+    ).toBe('14.95px');
+  });
+
+  it('persists the choice so it does not reset on a revisit', () => {
+    const { unmount } = render(<General />);
+
+    const select = screen.getByDisplayValue('Default (14px)');
+    fireEvent.change(select, { target: { value: 'large' } });
+    unmount();
+
+    render(<General />);
+    expect(screen.getByDisplayValue('Large (16px)')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/settings/General.test.tsx
+++ b/apps/desktop/src/features/settings/General.test.tsx
@@ -7,20 +7,22 @@
  * controls have no visible effect).
  *
  * Confirms both selects, when changed, apply through the shared token layer
- * on <html> (data/theme.ts `applyDensity`/`applyFontSize`) rather than being
- * inert local state — the density select already wired `applyDensity`
- * on change (App), font size previously did nothing at all.
+ * on <html> (data/theme.ts) rather than being inert local state. Density
+ * applies via the preference subscription installed by `initAppearance()`
+ * (called at app boot in main.tsx), so the test boots it the same way.
  */
 
 import { render, screen, cleanup, fireEvent } from '@testing-library/react';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
+import { initAppearance } from '@/data/theme';
 import { General } from './General';
 
 beforeEach(() => {
   localStorage.clear();
   document.documentElement.removeAttribute('style');
   document.documentElement.className = '';
+  initAppearance();
 });
 
 afterEach(() => {

--- a/apps/desktop/src/features/settings/General.tsx
+++ b/apps/desktop/src/features/settings/General.tsx
@@ -12,7 +12,6 @@ import {
   useFontSizeChoice,
   resolveTheme,
   THEMES,
-  applyDensity,
 } from '@/data/theme';
 import type { FontSizeChoice } from '@/data/theme';
 import type { Density } from '@/bindings/types';
@@ -122,11 +121,7 @@ export function General() {
             <select
               className="alm-select"
               value={density}
-              onChange={(e) => {
-                const d = e.target.value as Density;
-                setDensity(d);
-                applyDensity(d);
-              }}
+              onChange={(e) => setDensity(e.target.value as Density)}
             >
               <option value="compact">
                 {m.settings_general_density_compact()}

--- a/apps/desktop/src/features/settings/General.tsx
+++ b/apps/desktop/src/features/settings/General.tsx
@@ -5,19 +5,18 @@
 // Theme is applied live via the appearance runtime (data/theme.ts): swatch
 // cards re-scope the token layer with `data-theme` so each preview shows its
 // own palette without any element-level color injection.
-import { useState } from 'react';
 import { clsx } from 'clsx';
 import { usePreference } from '@/data/preferences';
 import {
   useThemeChoice,
+  useFontSizeChoice,
   resolveTheme,
   THEMES,
   applyDensity,
 } from '@/data/theme';
+import type { FontSizeChoice } from '@/data/theme';
 import type { Density } from '@/bindings/types';
 import { m } from '@/lib/i18n';
-
-type FontSize = 'small' | 'default' | 'large';
 
 // `label` is a render-time thunk so it re-reads the active locale (spec 046 #8).
 // THEMES carry static brand names (not translatable) — wrap them as thunks so
@@ -33,7 +32,7 @@ const CHOICES = [
 
 export function General() {
   const [choice, setChoice] = useThemeChoice();
-  const [fontSize, setFontSize] = useState<FontSize>('default');
+  const [fontSize, setFontSize] = useFontSizeChoice();
   const [density, setDensity] = usePreference('density');
   const resolved = resolveTheme(choice);
 
@@ -95,7 +94,7 @@ export function General() {
             <select
               className="alm-select"
               value={fontSize}
-              onChange={(e) => setFontSize(e.target.value as FontSize)}
+              onChange={(e) => setFontSize(e.target.value as FontSizeChoice)}
             >
               <option value="small">
                 {m.settings_general_fontsize_small()}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,6 +138,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@types/node':
+        specifier: ^26.1.1
+        version: 26.1.1
       '@types/react':
         specifier: ^19.2.17
         version: 19.2.17
@@ -146,7 +149,7 @@ importers:
         version: 19.2.3(@types/react@19.2.17)
       '@vitejs/plugin-react':
         specifier: ^5.1.0
-        version: 5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 5.2.0(vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       eslint:
         specifier: ^10.7.0
         version: 10.7.0(jiti@2.7.0)
@@ -176,10 +179,10 @@ importers:
         version: 8.63.0(eslint@10.7.0(jiti@2.7.0))(typescript@5.9.3)
       vite:
         specifier: ^7.2.0
-        version: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+        version: 7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
       vitest:
         specifier: ^4.1.10
-        version: 4.1.10(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+        version: 4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
 
   packages/contracts:
     dependencies:
@@ -1835,8 +1838,8 @@ packages:
   '@types/lodash@4.17.24':
     resolution: {integrity: sha512-gIW7lQLZbue7lRSWEFql49QJJWThrTFFeIMJdp3eH4tKoxm1OvEPg02rm4wCCSHS0cL3/Fizimb35b7k8atwsQ==}
 
-  '@types/node@25.9.1':
-    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
+  '@types/node@26.1.1':
+    resolution: {integrity: sha512-nxAkRSVkN1Y0JC1W8ky/fTfkGsMmcrRsbx+3XoZE+rMOX71kLYTV7fLXpqud1GpbpP5TuffXFqfX7fH2GgZREw==}
 
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
@@ -3806,8 +3809,8 @@ packages:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
     engines: {node: '>= 0.4'}
 
-  undici-types@7.24.6:
-    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
+  undici-types@8.3.0:
+    resolution: {integrity: sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -5321,10 +5324,9 @@ snapshots:
 
   '@types/lodash@4.17.24': {}
 
-  '@types/node@25.9.1':
+  '@types/node@26.1.1':
     dependencies:
-      undici-types: 7.24.6
-    optional: true
+      undici-types: 8.3.0
 
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
@@ -5527,7 +5529,7 @@ snapshots:
       d3-time-format: 4.1.0
       internmap: 2.0.3
 
-  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitejs/plugin-react@5.2.0(vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@babel/core': 7.29.0
       '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
@@ -5535,7 +5537,7 @@ snapshots:
       '@rolldown/pluginutils': 1.0.0-rc.3
       '@types/babel__core': 7.20.5
       react-refresh: 0.18.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -5548,13 +5550,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@4.1.10(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.10(vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.10
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
 
   '@vitest/pretty-format@4.1.10':
     dependencies:
@@ -7643,8 +7645,7 @@ snapshots:
       has-symbols: 1.1.0
       which-boxed-primitive: 1.1.1
 
-  undici-types@7.24.6:
-    optional: true
+  undici-types@8.3.0: {}
 
   undici@7.25.0: {}
 
@@ -7694,7 +7695,7 @@ snapshots:
 
   uuid@14.0.1: {}
 
-  vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
+  vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0):
     dependencies:
       esbuild: 0.27.7
       fdir: 6.5.0(picomatch@4.0.4)
@@ -7703,17 +7704,17 @@ snapshots:
       rollup: 4.60.2
       tinyglobby: 0.2.16
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       fsevents: 2.3.3
       jiti: 2.7.0
       lightningcss: 1.32.0
       tsx: 4.22.3
       yaml: 2.9.0
 
-  vitest@4.1.10(@types/node@25.9.1)(jsdom@29.1.1)(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
+  vitest@4.1.10(@types/node@26.1.1)(jsdom@29.1.1)(vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)):
     dependencies:
       '@vitest/expect': 4.1.10
-      '@vitest/mocker': 4.1.10(vite@7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
+      '@vitest/mocker': 4.1.10(vite@7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0))
       '@vitest/pretty-format': 4.1.10
       '@vitest/runner': 4.1.10
       '@vitest/snapshot': 4.1.10
@@ -7730,10 +7731,10 @@ snapshots:
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
-      vite: 7.3.2(@types/node@25.9.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
+      vite: 7.3.2(@types/node@26.1.1)(jiti@2.7.0)(lightningcss@1.32.0)(tsx@4.22.3)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/node': 25.9.1
+      '@types/node': 26.1.1
       jsdom: 29.1.1
     transitivePeerDependencies:
       - msw


### PR DESCRIPTION
## Summary

- Fixes #587: Settings > Appearance Density and Font-size controls had no visible effect. Density persisted but was never applied to layout; font size was fully inert local state that reset on every remount.
- `apps/desktop/src/data/theme.ts`: added `applyTokenScale(base, scale)`, rescaling the shared `--alm-sp-*` / `--alm-text-*` design tokens as inline overrides on `<html>` (`scale === 1` clears back to `tokens.css` defaults). `applyDensity()` now scales spacing tokens (compact 0.75 / comfortable 1 / spacious 1.25, matching the existing 24/32/40px row-height ratio). A new `FontSizeChoice` API (`getFontSizeChoice`/`setFontSizeChoice`/`applyFontSize`, mirroring the existing theme-choice pattern) scales the text tokens, with `alm.fontSize` localStorage caching and settings-DB write-through (`general` scope, spec 018). `initAppearance()` calls `applyFontSize()` at boot, and `hydrateThemeFromSettings()` now reconciles both theme and font size from one settings round-trip.
- `apps/desktop/src/features/settings/General.tsx`: swapped the local, remount-resetting `useState<FontSize>` for the new `useFontSizeChoice()` hook.
- Applying through the shared token layer (rather than new per-component branches) means all 4 themes react automatically, since tokens.css is already consumed by every component stylesheet.
- Drift guard: `theme.ts` hardcodes base px tables for the two token sets because jsdom/vitest can't reliably resolve stylesheet custom properties via `getComputedStyle`. Nothing previously enforced that those tables stayed in sync with `tokens.css`. Added `apps/desktop/src/data/theme.tokens-drift.test.ts`, which parses `tokens.css`'s `:root` block directly and fails if a future edit desyncs the runtime scaling tables from the stylesheet defaults (verified it fails when a value is intentionally mismatched).

Journey impact: J10 (Settings).

## Test plan

- [x] `just typecheck` — green
- [x] `just lint` — green (cargo fmt/clippy, eslint 0 errors, token-policy checks; pre-commit clean on this branch's own diff)
- [x] Scoped vitest: `theme.test.ts`, `theme.persistence.test.ts`, `theme.density-fontsize.test.ts`, `theme.tokens-drift.test.ts`, `General.test.tsx` — 30/30 passing
- [x] Confirmed the new drift-guard test fails when `theme.ts`'s base px tables are intentionally mismatched against `tokens.css`
- [ ] Full desktop `pnpm test` run showed 3 pre-existing, unrelated failures/timeouts (`GuidedOverlay.test.tsx`, `inbox.affordances.test.tsx`) under CPU contention — not touched by this change

This work was recovered from an interrupted session (salvage artifact `nJ10d`); the implementation and scoped tests were already complete and verified, this PR adds the drift guard, fixes formatting, and completes verification/rebase/PR steps that didn't finish before the original session was interrupted.

Fixes #587