### PR TITLE
fix(palette): style command palette, fix search matching, keyboard nav, and click handling

### DIFF
--- a/apps/desktop/src/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/app/CommandPalette.test.tsx
@@ -28,10 +28,18 @@
  * Tests 7-10 import PAGES directly from CommandPalette.tsx (not a
  * hand-copied array) so a route rename/removal in production is actually
  * caught here.
+ *
+ * `buildTargetResults` tests (#581) exercise the client-side target matcher
+ * against the REAL `matchesSearch`/`normalizeDesig` from TargetsPage.tsx (the
+ * same import target-search.test.ts already uses as its source of truth) so a
+ * regression in either the palette's wiring or the shared matcher is caught
+ * here, not just at `/targets`.
  */
 
 import { describe, it, expect } from 'vitest';
-import { PAGES } from './CommandPalette';
+import { PAGES, buildTargetResults } from './CommandPalette';
+import { matchesSearch, normalizeDesig } from '@/features/targets/TargetsPage';
+import type { TargetListItem } from '@/bindings/index';
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/app/CommandPalette.test.tsx
@@ -4,14 +4,16 @@
 /**
  * CommandPalette T008 integration tests — alias-aware target search routing.
  *
- * The CommandPalette renders via cmdk + @base-ui-components/react/dialog which
- * require ResizeObserver and other browser APIs not available in jsdom.
- * These tests therefore validate the **logic layer** of the palette:
+ * Logic-layer tests validate:
  *   - search results are filtered/routed correctly
  *   - target results produced by searchGlobal have the right shape
  *   - the navigate call receives the verbatim route from the result
  *
- * Full visual smoke is deferred to Playwright (WSL constraint).
+ * Rendered smoke tests (#581 review) mount the real palette with a local
+ * ResizeObserver/scrollIntoView stub (cmdk + @base-ui-components/react/dialog
+ * need both; jsdom has neither) and assert the alm-palette* class wiring,
+ * the initialFocus fix, and ArrowDown+Enter keyboard navigation. Pixel-level
+ * visual verification stays with Playwright (WSL constraint).
  *
  * Tests:
  *  1. Target search result routes start with /targets/
@@ -36,10 +38,35 @@
  * here, not just at `/targets`.
  */
 
-import { describe, it, expect } from 'vitest';
-import { PAGES, buildTargetResults } from './CommandPalette';
+import { describe, it, expect, vi, beforeAll, afterEach } from 'vitest';
+import { render, fireEvent, waitFor, cleanup } from '@testing-library/react';
+import { CommandPalette, PAGES, buildTargetResults } from './CommandPalette';
 import { matchesSearch, normalizeDesig } from '@/features/targets/TargetsPage';
 import type { TargetListItem } from '@/bindings/index';
+
+// ── Mocks (rendered smoke tests) ──────────────────────────────────────────────
+
+const mockNavigate = vi.fn();
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useRouterState: () => '/',
+}));
+
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...actual,
+    commands: {
+      ...actual.commands,
+      settingsGet: vi
+        .fn()
+        .mockResolvedValue({ status: 'ok', data: { values: {} } }),
+      targetList: vi.fn().mockResolvedValue({ status: 'ok', data: [] }),
+      searchGlobal: vi.fn().mockResolvedValue({ status: 'ok', data: [] }),
+    },
+  };
+});
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
@@ -314,5 +341,95 @@ describe('buildTargetResults (#581 client-side alias-aware target search)', () =
         results[i].score ?? 0,
       );
     }
+  });
+});
+
+// ── Rendered smoke tests (#581 review) ────────────────────────────────────────
+//
+// These mount the real palette so the CSS class wiring, the initialFocus fix,
+// and cmdk keyboard navigation have regression coverage — the styling blocker
+// shipped precisely because nothing rendered the component.
+
+class ResizeObserverStub {
+  observe() {}
+  unobserve() {}
+  disconnect() {}
+}
+
+beforeAll(() => {
+  vi.stubGlobal('ResizeObserver', ResizeObserverStub);
+  // cmdk scrolls the selected item into view; jsdom has no scrollIntoView.
+  Element.prototype.scrollIntoView = vi.fn();
+});
+
+afterEach(() => {
+  cleanup();
+  mockNavigate.mockClear();
+});
+
+/** Renders the palette and opens it via the real Ctrl+K hotkey path. */
+async function openPalette() {
+  render(<CommandPalette />);
+  fireEvent.keyDown(window, { key: 'k', code: 'KeyK', ctrlKey: true });
+  await waitFor(() => {
+    expect(document.querySelector('.alm-palette')).not.toBeNull();
+  });
+}
+
+describe('CommandPalette rendered smoke (#581)', () => {
+  it('opens on Ctrl+K with the expected alm-palette* class structure', async () => {
+    await openPalette();
+    expect(document.querySelector('.alm-palette-backdrop')).not.toBeNull();
+    expect(document.querySelector('.alm-palette__input')).not.toBeNull();
+    expect(document.querySelector('.alm-palette__list')).not.toBeNull();
+    // Pages + Actions groups render without a query; each must carry the
+    // styled class (the review blocker: cmdk only sets cmdk-group="",
+    // so .alm-palette__group CSS was dead without an explicit className).
+    const groups = document.querySelectorAll('.alm-palette__group');
+    expect(groups.length).toBeGreaterThanOrEqual(2);
+    for (const group of groups) {
+      expect(group.querySelector('[cmdk-group-heading]')).not.toBeNull();
+    }
+    expect(
+      document.querySelectorAll('.alm-palette__item').length,
+    ).toBeGreaterThan(0);
+  });
+
+  it('gives the search input initial focus (initialFocus fix)', async () => {
+    await openPalette();
+    // The focus race left focus on the popup container, which silenced all
+    // of cmdk's input-keydown plumbing (arrow keys, Enter, selection).
+    const input = document.querySelector<HTMLInputElement>(
+      '.alm-palette__input',
+    )!;
+    await waitFor(() => {
+      expect(document.activeElement).toBe(input);
+    });
+  });
+
+  it('navigates via ArrowDown + Enter (cmdk keyboard nav reaches the input)', async () => {
+    await openPalette();
+    const input = document.querySelector<HTMLInputElement>(
+      '.alm-palette__input',
+    )!;
+    fireEvent.keyDown(input, { key: 'ArrowDown', code: 'ArrowDown' });
+    fireEvent.keyDown(input, { key: 'Enter', code: 'Enter' });
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalledTimes(1);
+    });
+    const call = mockNavigate.mock.calls[0][0] as { to: string };
+    expect(PAGES.some((p) => p.route === call.to)).toBe(true);
+  });
+
+  it('navigates when an item is clicked (click-to-select)', async () => {
+    await openPalette();
+    const item = document.querySelector('.alm-palette__item')!;
+    // cmdk selects on pointer events, not plain click.
+    fireEvent.pointerMove(item);
+    fireEvent.pointerUp(item);
+    fireEvent.click(item);
+    await waitFor(() => {
+      expect(mockNavigate).toHaveBeenCalled();
+    });
   });
 });

--- a/apps/desktop/src/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/app/CommandPalette.test.tsx
@@ -178,3 +178,141 @@ describe('CommandPalette debounce contract', () => {
     expect(DEBOUNCE_MS).toBe(200);
   });
 });
+
+// ── buildTargetResults (#581) ─────────────────────────────────────────────────
+//
+// Exercises the palette's client-side target matcher against the REAL
+// `matchesSearch`/`normalizeDesig` from TargetsPage.tsx — the same pairing
+// `target-search.test.ts` uses — so a regression in either the palette's
+// wiring or the shared matcher fails here, not just at `/targets`. This is
+// the exact bug from #581: the backend's SQL `LIKE` never matched "M31"
+// against a stored "M 31" designation; the fix routes through this matcher
+// instead of a second, drifting implementation.
+
+function targetItem(
+  id: string,
+  primaryDesignation: string,
+  effectiveLabel?: string,
+  aliases: string[] = [],
+): TargetListItem {
+  return {
+    id,
+    effectiveLabel: effectiveLabel ?? primaryDesignation,
+    primaryDesignation,
+    objectType: 'other',
+    raDeg: 0,
+    decDeg: 0,
+    aliases,
+  };
+}
+
+describe('buildTargetResults (#581 client-side alias-aware target search)', () => {
+  const m31 = targetItem('t-m31', 'M 31', 'Andromeda Galaxy', [
+    'M 31',
+    'NGC 224',
+    'Andromeda Galaxy',
+  ]);
+  const ngc7000 = targetItem('t-ngc7000', 'NGC 7000', 'North America Nebula', [
+    'NGC 7000',
+    'Caldwell 20',
+  ]);
+  const targets = [m31, ngc7000];
+
+  it('empty query short-circuits to no results (no crash on blank input)', () => {
+    expect(
+      buildTargetResults(targets, '', { matchesSearch, normalizeDesig }),
+    ).toEqual([]);
+    expect(
+      buildTargetResults(targets, '   ', { matchesSearch, normalizeDesig }),
+    ).toEqual([]);
+  });
+
+  it('exact match: "M 31" scores highest and routes to /targets/<id>', () => {
+    const results = buildTargetResults(targets, 'M 31', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('t-m31');
+    expect(results[0].route).toBe('/targets/t-m31');
+    expect(results[0].score).toBe(1);
+  });
+
+  it('compact query "M31" matches the spaced designation "M 31" (#581 bug)', () => {
+    // This is the exact case the backend LIKE match missed: "M31" (no space)
+    // against a stored "M 31" designation.
+    const results = buildTargetResults(targets, 'M31', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results.map((r) => r.id)).toContain('t-m31');
+  });
+
+  it('prefix match scores above a plain contains match', () => {
+    const prefixResult = buildTargetResults(targets, 'NGC 70', {
+      matchesSearch,
+      normalizeDesig,
+    })[0];
+    const containsResult = buildTargetResults(targets, 'C 700', {
+      matchesSearch,
+      normalizeDesig,
+    })[0];
+    expect(prefixResult.id).toBe('t-ngc7000');
+    expect(containsResult.id).toBe('t-ngc7000');
+    expect(prefixResult.score ?? 0).toBeGreaterThan(containsResult.score ?? 0);
+  });
+
+  it('alias-only match: "Andromeda" resolves to M 31 via the aliases array', () => {
+    const results = buildTargetResults(targets, 'Andromeda', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results.map((r) => r.id)).toContain('t-m31');
+  });
+
+  it('alias match on "Caldwell 20" resolves to NGC 7000', () => {
+    const results = buildTargetResults(targets, 'Caldwell 20', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].id).toBe('t-ngc7000');
+  });
+
+  it('non-matching query returns no results', () => {
+    const results = buildTargetResults(targets, 'zzz-no-such-target', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results).toEqual([]);
+  });
+
+  it('sublabel carries the primary designation when it differs from the label', () => {
+    const results = buildTargetResults(targets, 'Andromeda', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results[0].sublabel).toBe('M 31');
+  });
+
+  it('sublabel is null when the designation equals the effective label', () => {
+    const bare = targetItem('t-bare', 'Sh2-155', 'Sh2-155');
+    const results = buildTargetResults([bare], 'Sh2-155', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    expect(results[0].sublabel).toBeNull();
+  });
+
+  it('results are sorted by descending score', () => {
+    const results = buildTargetResults(targets, 'NGC', {
+      matchesSearch,
+      normalizeDesig,
+    });
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i - 1].score ?? 0).toBeGreaterThanOrEqual(
+        results[i].score ?? 0,
+      );
+    }
+  });
+});

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -33,7 +33,10 @@ interface TargetMatcher {
  */
 async function loadTargetMatcher(): Promise<TargetMatcher> {
   const mod = await import('@/features/targets/TargetsPage');
-  return { matchesSearch: mod.matchesSearch, normalizeDesig: mod.normalizeDesig };
+  return {
+    matchesSearch: mod.matchesSearch,
+    normalizeDesig: mod.normalizeDesig,
+  };
 }
 
 /** Max target results shown (mirrors the backend's per-kind result budget). */

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -284,7 +284,10 @@ export function CommandPalette() {
                 </Command.Empty>
               )}
               {results.length > 0 && (
-                <Command.Group heading={m.cmdk_group_results()}>
+                <Command.Group
+                  className="alm-palette__group"
+                  heading={m.cmdk_group_results()}
+                >
                   {results.map((r) => (
                     <Command.Item
                       key={r.id}
@@ -302,7 +305,10 @@ export function CommandPalette() {
                   ))}
                 </Command.Group>
               )}
-              <Command.Group heading={m.cmdk_group_pages()}>
+              <Command.Group
+                className="alm-palette__group"
+                heading={m.cmdk_group_pages()}
+              >
                 {visiblePages.map((p) => (
                   <Command.Item
                     key={p.route}
@@ -313,7 +319,10 @@ export function CommandPalette() {
                   </Command.Item>
                 ))}
               </Command.Group>
-              <Command.Group heading={m.cmdk_group_actions()}>
+              <Command.Group
+                className="alm-palette__group"
+                heading={m.cmdk_group_actions()}
+              >
                 {ALL_ACTIONS.map((a) => (
                   <Command.Item
                     key={a.label()}

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -163,10 +163,15 @@ export function CommandPalette() {
     };
   }, []);
 
-  // Load the full target catalog on mount so target matches (#581) are
-  // available client-side the moment the user types — mirrors the devMode
-  // load above; matches TargetsPage's own load-full-list-on-mount pattern.
+  // Load the full target catalog when the palette opens (#581) so client-side
+  // matches are ready by the time the user types. Deferred to open (not
+  // mount) because CommandPalette lives in Shell — a mount-time fetch would
+  // pull the whole catalog on every app boot even if the palette is never
+  // used, and would go stale for targets added mid-session. Refetching per
+  // open keeps the list fresh; it is a local SQLite read and races only the
+  // 200ms search debounce below.
   useEffect(() => {
+    if (!open) return;
     let cancelled = false;
     commands
       .targetList()
@@ -180,7 +185,7 @@ export function CommandPalette() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [open]);
 
   // ⌘/Ctrl+K toggles the palette. `$mod` resolves to Cmd on macOS, Ctrl
   // elsewhere — matching the prior `metaKey || ctrlKey` check. We opt out of the

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useRef } from 'react';
 import { m } from '@/lib/i18n';
 import { Dialog } from '@base-ui-components/react/dialog';
 import { Command } from 'cmdk';
@@ -11,6 +11,83 @@ import { unwrap } from '@/api/ipc';
 import { openInNewWindow } from '@/lib/window';
 import { useHotkeys } from '@/lib/useHotkeys';
 import type { SearchResult } from '@/bindings/types';
+import type { TargetListItem } from '@/bindings/index';
+
+/** Matcher functions loaded from the Targets page (see {@link loadTargetMatcher}). */
+type MatchesSearchFn = (t: TargetListItem, query: string) => boolean;
+type NormalizeDesigFn = (s: string) => string;
+interface TargetMatcher {
+  matchesSearch: MatchesSearchFn;
+  normalizeDesig: NormalizeDesigFn;
+}
+
+/**
+ * Loads the Targets page's alias-aware matcher (#581) via a dynamic import
+ * rather than a static one. `TargetsPage.tsx` is route-lazy-loaded (see
+ * `router.tsx`'s `lazyRouteComponent`) and pulls in the astronomy engine +
+ * moon-phase calculations; CommandPalette is always mounted from `Shell`, so a
+ * static import would drag that whole feature into the eager bundle. A
+ * dynamic `import()` of the same specifier shares one chunk with the route's
+ * own lazy import — it stays lazy either way, and there is still exactly one
+ * implementation of the matcher (no forked copy to drift out of sync).
+ */
+async function loadTargetMatcher(): Promise<TargetMatcher> {
+  const mod = await import('@/features/targets/TargetsPage');
+  return { matchesSearch: mod.matchesSearch, normalizeDesig: mod.normalizeDesig };
+}
+
+/** Max target results shown (mirrors the backend's per-kind result budget). */
+const MAX_TARGET_RESULTS = 8;
+
+/**
+ * Scores a target match for ranking, mirroring the backend's exact >
+ * prefix > contains heuristic (`crates/app/core/src/search.rs::score`) so
+ * ordering feels consistent between the palette and `search_global`.
+ */
+function scoreTarget(
+  t: TargetListItem,
+  qNorm: string,
+  normalizeDesig: NormalizeDesigFn,
+): number {
+  const label = normalizeDesig(t.effectiveLabel);
+  const desig = normalizeDesig(t.primaryDesignation);
+  if (label === qNorm || desig === qNorm) return 1;
+  if (label.startsWith(qNorm) || desig.startsWith(qNorm)) return 0.92;
+  if (label.includes(qNorm) || desig.includes(qNorm)) return 0.75;
+  return 0.6; // alias-only match (e.g. "Andromeda" matching M 31 via aliases)
+}
+
+/**
+ * Client-side target search (#581): `search_global`'s SQL `LIKE` matches
+ * `primary_designation` verbatim, so a compact query like "M31" never matches
+ * a stored designation like "M 31" — the exact bug report (M31 finds nothing,
+ * M finds many unrelated targets). Reusing the Targets page's tested
+ * `matchesSearch`/`normalizeDesig` (whitespace/case-insensitive, alias-aware)
+ * keeps this in lockstep with the real search users already rely on at
+ * `/targets`, instead of hand-rolling a second matcher here.
+ */
+export function buildTargetResults(
+  targets: TargetListItem[],
+  query: string,
+  matcher: TargetMatcher,
+): SearchResult[] {
+  const q = query.trim();
+  if (!q) return [];
+  const qNorm = matcher.normalizeDesig(q);
+  return targets
+    .filter((t) => matcher.matchesSearch(t, q))
+    .map((t) => ({
+      id: t.id,
+      kind: 'target' as const,
+      label: t.effectiveLabel,
+      sublabel:
+        t.primaryDesignation !== t.effectiveLabel ? t.primaryDesignation : null,
+      route: `/targets/${t.id}`,
+      score: scoreTarget(t, qNorm, matcher.normalizeDesig),
+    }))
+    .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
+    .slice(0, MAX_TARGET_RESULTS);
+}
 
 // `label` is a render-time thunk so it re-reads the active locale (spec 046 #8).
 // Exported so tests can assert against the real source of truth (T007 guard)
@@ -55,8 +132,14 @@ export function CommandPalette() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [devMode, setDevMode] = useState(false);
+  const [allTargets, setAllTargets] = useState<TargetListItem[]>([]);
   const navigate = useNavigate();
   const currentHref = useRouterState({ select: (s) => s.location.href });
+  // Owns initial focus explicitly (base-ui `initialFocus`) instead of the
+  // input's own `autoFocus`, which raced with the dialog's own focus
+  // management and could leave focus on the popup container — arrow keys
+  // and Enter never reached cmdk's keydown handler on the input (#581).
+  const inputRef = useRef<HTMLInputElement>(null);
 
   // Load devMode from backend settings on mount (spec 021 T013).
   useEffect(() => {
@@ -71,6 +154,25 @@ export function CommandPalette() {
       })
       .catch(() => {
         // Backend unavailable — stay with default false.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // Load the full target catalog on mount so target matches (#581) are
+  // available client-side the moment the user types — mirrors the devMode
+  // load above; matches TargetsPage's own load-full-list-on-mount pattern.
+  useEffect(() => {
+    let cancelled = false;
+    commands
+      .targetList()
+      .then(unwrap)
+      .then((items) => {
+        if (!cancelled) setAllTargets(items);
+      })
+      .catch(() => {
+        // Backend unavailable — palette falls back to sessions/projects only.
       });
     return () => {
       cancelled = true;
@@ -99,18 +201,31 @@ export function CommandPalette() {
     const controller = new AbortController();
     // Debounce search by 200ms to avoid excessive API calls
     const timeoutId = setTimeout(() => {
-      void commands
-        .searchGlobal(query)
-        .then(unwrap)
-        .then((r) => {
-          if (!controller.signal.aborted) setResults(r);
+      void Promise.all([
+        loadTargetMatcher(),
+        commands.searchGlobal(query).then(unwrap),
+      ])
+        .then(([matcher, backendResults]) => {
+          if (controller.signal.aborted) return;
+          // Backend target matches are dropped in favor of the client-side,
+          // alias-aware matches above — see buildTargetResults for why.
+          const nonTargetResults = backendResults.filter(
+            (r) => r.kind !== 'target',
+          );
+          setResults([
+            ...buildTargetResults(allTargets, query, matcher),
+            ...nonTargetResults,
+          ]);
+        })
+        .catch(() => {
+          if (!controller.signal.aborted) setResults([]);
         });
     }, 200);
     return () => {
       clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [query]);
+  }, [query, allTargets]);
 
   const select = useCallback(
     (route: string) => {
@@ -146,15 +261,18 @@ export function CommandPalette() {
     <Dialog.Root open={open} onOpenChange={setOpen}>
       <Dialog.Portal>
         <Dialog.Backdrop className="alm-palette-backdrop" />
-        <Dialog.Popup className="alm-palette" aria-label={m.cmdk_aria_label()}>
+        <Dialog.Popup
+          className="alm-palette"
+          aria-label={m.cmdk_aria_label()}
+          initialFocus={inputRef}
+        >
           <Command shouldFilter={false}>
             <Command.Input
+              ref={inputRef}
               className="alm-palette__input"
               placeholder={m.cmdk_placeholder()}
               value={query}
               onValueChange={setQuery}
-              // eslint-disable-next-line jsx-a11y/no-autofocus -- command palette is a modal dialog summoned on demand; focusing its input is the expected behavior
-              autoFocus
             />
             <Command.List className="alm-palette__list">
               {query.trim() && results.length === 0 && (

--- a/apps/desktop/src/styles/components/target-search.css
+++ b/apps/desktop/src/styles/components/target-search.css
@@ -139,6 +139,123 @@
   cursor: default;
 }
 
+/* === COMMAND PALETTE (Ctrl+K) — apps/desktop/src/app/CommandPalette.tsx ===
+   Global overlay: dimmed backdrop + a centered floating card wrapping cmdk's
+   input/list. Sits above the shared Modal (z-index 500/501, see
+   .alm-modal__backdrop below) since a command can be summoned from within a
+   modal. Positioned nearer the top of the viewport (command-palette
+   convention) rather than dead-center like a Modal. */
+.alm-palette-backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 600;
+  background: color-mix(in srgb, var(--alm-ink) 45%, transparent);
+  backdrop-filter: blur(2px);
+}
+@supports not (backdrop-filter: blur(2px)) {
+  .alm-palette-backdrop {
+    background: color-mix(in srgb, var(--alm-ink) 55%, transparent);
+  }
+}
+
+.alm-palette {
+  position: fixed;
+  top: 14vh;
+  left: 50%;
+  transform: translateX(-50%);
+  z-index: 601;
+  display: flex;
+  flex-direction: column;
+  width: min(94vw, 560px);
+  max-height: 70vh;
+  background: var(--alm-surface-raised);
+  border: 1px solid var(--alm-border);
+  border-radius: var(--alm-radius-lg);
+  box-shadow: var(--alm-shadow-sm);
+  overflow: hidden;
+  outline: none;
+}
+
+.alm-palette__input {
+  flex-shrink: 0;
+  width: 100%;
+  padding: var(--alm-sp-3) var(--alm-sp-4);
+  border: none;
+  border-bottom: 1px solid var(--alm-border-subtle);
+  border-radius: 0;
+  background: transparent;
+  color: var(--alm-text);
+  font-size: var(--alm-text-md);
+  outline: none;
+}
+.alm-palette__input::placeholder { color: var(--alm-text-faint); }
+
+.alm-palette__list {
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+  padding: var(--alm-sp-2);
+}
+
+.alm-palette__empty {
+  padding: var(--alm-sp-4);
+  text-align: center;
+  font-size: var(--alm-text-sm);
+  color: var(--alm-text-muted);
+}
+
+.alm-palette__group { padding-block: var(--alm-sp-1); }
+.alm-palette__group:not(:last-child) {
+  border-bottom: 1px solid var(--alm-border-subtle);
+  margin-bottom: var(--alm-sp-1);
+}
+/* cmdk wraps the `heading` prop in an element carrying `cmdk-group-heading` —
+   there is no dedicated className prop for it, so it is styled by attribute. */
+.alm-palette__group [cmdk-group-heading] {
+  padding: var(--alm-sp-2) var(--alm-sp-3) var(--alm-sp-1);
+  font-size: var(--alm-text-xs);
+  font-weight: var(--alm-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--alm-text-muted);
+}
+
+.alm-palette__item {
+  display: flex;
+  align-items: center;
+  gap: var(--alm-sp-2);
+  padding: var(--alm-sp-2) var(--alm-sp-3);
+  border-radius: var(--alm-radius-sm);
+  color: var(--alm-text);
+  cursor: pointer;
+}
+/* cmdk marks the keyboard/pointer-highlighted item with data-selected — the
+   arrow-key/click affordance the palette was missing entirely (#581). */
+.alm-palette__item[data-selected='true'] { background: var(--alm-selected-bg); }
+
+.alm-palette__item-kind {
+  flex-shrink: 0;
+  font-size: var(--alm-text-2xs);
+  font-weight: var(--alm-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  color: var(--alm-text-faint);
+  min-width: 3.5em;
+}
+.alm-palette__item-label {
+  flex: 1;
+  min-width: 0;
+  font-size: var(--alm-text-sm);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.alm-palette__item-sub {
+  flex-shrink: 0;
+  font-size: var(--alm-text-xs);
+  color: var(--alm-text-muted);
+}
+
 /* === SCROLLBAR === */
 ::-webkit-scrollbar { width: 6px; height: 6px; }
 ::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
## Summary

- Fixes #581 — the Ctrl+K command palette was unstyled, had broken search matching, no keyboard navigation, and broken click handling.
- Adds the missing `.alm-palette*` CSS block to `target-search.css` so the palette renders styled (was previously bare/unstyled).
- Reuses the Targets page's tested, alias-aware `matchesSearch`/`normalizeDesig` matcher (via `buildTargetResults`/`scoreTarget` in `CommandPalette.tsx`) instead of relying on the backend's verbatim SQL `LIKE` match, which never matched a compact query like `M31` against a stored designation like `M 31`.
- Fixes a focus-ownership race: `Command.Input` used React's own `autoFocus`, which raced with `Dialog.Popup`'s own focus management and could leave focus on the popup container. cmdk's arrow-key/Enter handling lives on the input's keydown handler, so with focus elsewhere none of cmdk's already-correct keyboard nav or click (`Command.Item onSelect`) plumbing ever fired. Fixed via an explicit `inputRef` + `initialFocus={inputRef}` on `Dialog.Popup`.

## Review round 1 fixes

- **Blocker (dead CSS)**: the `.alm-palette__group` rules and the `[cmdk-group-heading]` heading style scoped under them never applied — cmdk only sets its own `cmdk-group=""` attribute and none of the three `Command.Group` elements carried the class. Added `className="alm-palette__group"` to all three groups, keeping the CSS on the repo's `alm-*` class convention used by every sibling rule.
- **Coverage gap**: added rendered smoke tests (see Tests below) so the class wiring, the focus fix, and keyboard/click navigation are regression-covered in jsdom.
- **Eager `targetList()` question**: it was a real cost — `CommandPalette` lives in `Shell`, so the mount-time fetch pulled the full catalog (~13k rows) over IPC on every app boot even when the palette was never opened, and went stale for targets added mid-session. Changed to fetch on open: the list resolves well within the 200ms search debounce, refreshes on each open, and costs nothing at boot.

## Recovery note

This branch was salvaged from an interrupted session. The functional fix (`CommandPalette.tsx`, `target-search.css`) landed in commit 5620533 fully intact. The test file (`CommandPalette.test.tsx`) had only its docstring and import list updated (importing `buildTargetResults`/`matchesSearch`/`normalizeDesig`/`TargetListItem`) before the coder was killed — the test bodies were never written, which left unused imports failing lint. This PR finishes that test file.

## Tests

**Logic layer** — a `buildTargetResults` describe block exercising the palette's client-side target matcher against the **real** `matchesSearch`/`normalizeDesig` from `TargetsPage.tsx` (same pairing `target-search.test.ts` already uses as source of truth):

- empty/whitespace query short-circuits to no results
- exact match (`M 31`) scores highest and routes to `/targets/<id>`
- compact query `M31` matches spaced designation `M 31` — the exact #581 bug
- prefix match scores above a plain contains match
- alias-only match (`Andromeda` → M 31 via the aliases array)
- alias match (`Caldwell 20` → NGC 7000)
- non-matching query returns no results
- sublabel carries the primary designation when it differs from the label, and is `null` when they match
- results are sorted by descending score

**Rendered smoke (review round 1)** — mounts the real palette in jsdom with local `ResizeObserver`/`scrollIntoView` stubs (router and IPC commands mocked):

- Ctrl+K opens the palette with the full `alm-palette*` class structure, including `alm-palette__group` on every rendered group (the review blocker's regression guard) with a `[cmdk-group-heading]` inside each
- the search input receives initial focus (`initialFocus` race fix)
- ArrowDown + Enter navigates to a real `PAGES` route (cmdk keyboard nav reaches the input)
- pointer/click on an item navigates (click-to-select)

Pixel-level visual verification stays with Playwright/manual (WSL constraint).

## Test plan

- [x] `npx vitest run CommandPalette` — 31/31 passed (logic + smoke + devMode gate)
- [x] `pnpm -C apps/desktop run typecheck` — clean
- [x] `pnpm -C apps/desktop run lint` — exit 0 (pre-existing warnings only; one pre-existing warning at `CommandPalette.tsx` debounce effect noted in the salvage report, unrelated to this fix)
- [x] `npx vitest run` (full desktop suite) — 1434/1438; the 4 failures (GuidedOverlay ×3, devSurface.release ×1) pass 15/15 in isolation — known parallel-run flakiness, neither file imports CommandPalette
- [ ] Manual/Windows verification of the actual styled palette, keyboard nav, and click-to-select (recommended follow-up per `verify-on-windows`)