### PR TITLE
fix: Targets page no longer freezes when opening the full catalog

### DIFF
--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -35,6 +35,7 @@ import {
   fireEvent,
   waitFor,
   within,
+  act,
 } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
@@ -499,5 +500,84 @@ describe('TargetsPage', () => {
       expect(screen.getByText('NGC 7000')).toBeInTheDocument();
       expect(screen.getByText('M 31')).toBeInTheDocument();
     });
+  });
+});
+
+// ── Progressive reveal of a large catalogue (#573) ───────────────────────────
+//
+// TargetsTable's per-row astronomy pass over the WHOLE catalogue synchronously
+// froze the app. TargetsPage now caps what it hands the table to REVEAL_CHUNK
+// (300) rows on first paint, then grows the revealed set toward the full total
+// on setTimeout macrotask boundaries so the browser can paint between chunks.
+// The table footer ("{count} targets") reflects exactly the revealed count, so
+// these tests drive the reveal timers with fake timers and assert on it.
+describe('TargetsPage — progressive reveal (#573)', () => {
+  // Valid Planner (NGC) rows so filterByCatalogues keeps them and the cap
+  // actually engages (a 2-row fixture never exceeds REVEAL_CHUNK).
+  function ngcItems(n: number) {
+    return Array.from({ length: n }, (_, i) => ({
+      id: `ngc-${i}`,
+      effectiveLabel: `NGC ${7000 + i}`,
+      primaryDesignation: `NGC ${7000 + i}`,
+      objectType: 'emission_nebula',
+    }));
+  }
+
+  // Flush the listTargets promise chain (microtasks only) WITHOUT firing the
+  // reveal setTimeout, so the first-paint cap is observable before any growth.
+  async function flushLoad() {
+    await act(async () => {
+      for (let i = 0; i < 6; i++) await Promise.resolve();
+    });
+  }
+
+  // Fire the delay-0 reveal timers (and their re-scheduled successors) while
+  // NOT advancing far enough to trip observing-night's hourly interval.
+  async function drainRevealTimers() {
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+  }
+
+  it('caps first paint to REVEAL_CHUNK rows, then grows to the full catalogue on timers', async () => {
+    vi.useFakeTimers();
+    try {
+      mockListTargets.mockResolvedValue(ok(ngcItems(350)));
+      render(<TargetsPage />);
+      await flushLoad();
+
+      // First paint is capped — never the full 350-row synchronous burst.
+      expect(screen.getByText('300 targets')).toBeInTheDocument();
+      expect(screen.queryByText('350 targets')).not.toBeInTheDocument();
+
+      // Draining the reveal timers grows the visible set to the full catalogue.
+      await drainRevealTimers();
+      expect(screen.getByText('350 targets')).toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not reset the revealed count on a sort interaction', async () => {
+    vi.useFakeTimers();
+    try {
+      mockListTargets.mockResolvedValue(ok(ngcItems(350)));
+      render(<TargetsPage />);
+      await flushLoad();
+      await drainRevealTimers();
+      expect(screen.getByText('350 targets')).toBeInTheDocument();
+
+      // A sort toggle re-renders but must NOT send the reveal back to the first
+      // chunk — only a fresh load() resets it.
+      fireEvent.click(
+        screen.getByRole('button', { name: 'Sort by Designation' }),
+      );
+      await flushLoad();
+
+      expect(screen.getByText('350 targets')).toBeInTheDocument();
+      expect(screen.queryByText('300 targets')).not.toBeInTheDocument();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -185,6 +185,15 @@ const RECOMMENDATION_FILTER_OPTIONS = (): FilterOption[] => [
   { value: 'unknown', label: recommendationLabel('unknown') },
 ];
 
+/**
+ * Progressive-reveal chunk size for the Planner catalogue load (#573). See
+ * the `revealCount` effects below for why: TargetsTable's per-row astronomy
+ * pass over the WHOLE catalogue synchronously on first render froze the app,
+ * so `TargetsPage` grows what it feeds TargetsTable in chunks of this size
+ * instead of handing over the full (possibly ~13k-row) set at once.
+ */
+const REVEAL_CHUNK = 300;
+
 export function TargetsPage() {
   const { selected } = useSearch({ from: '/shell/targets' });
   const navigate = useNavigate({ from: '/targets' });
@@ -295,6 +304,35 @@ export function TargetsPage() {
     load();
   }, [load]);
 
+  /**
+   * Progressive reveal of the Planner catalogue (#573): `commands.targetList()`
+   * IPC-loads every target at once (thousands of rows), and TargetsTable's
+   * per-row astronomy pass over the WHOLE set synchronously on first render is
+   * what froze the app on open. Capping what reaches TargetsTable to a small
+   * first chunk, then growing it in the background via `setTimeout` (a real
+   * macrotask boundary, so the browser gets to paint/handle input between
+   * chunks) keeps the page interactive immediately. TargetsTable's per-target-
+   * id row cache (see its module doc) means each growth step only pays for the
+   * newly-revealed delta, not the whole set again — so total work stays
+   * roughly linear in catalogue size instead of blocking once, all at once.
+   * Resets to the first chunk on every fresh `load()` (mount + "Add target").
+   */
+  const [revealCount, setRevealCount] = useState(REVEAL_CHUNK);
+
+  useEffect(() => {
+    if (listState.status === 'loading') setRevealCount(REVEAL_CHUNK);
+  }, [listState.status]);
+
+  useEffect(() => {
+    if (listState.status !== 'loaded') return;
+    const total = listState.items.length;
+    if (revealCount >= total) return;
+    const handle = setTimeout(() => {
+      setRevealCount((n) => Math.min(n + REVEAL_CHUNK, total));
+    }, 0);
+    return () => clearTimeout(handle);
+  }, [listState, revealCount]);
+
   const onSelect = (id: string) =>
     navigate({ search: (prev) => ({ ...prev, selected: id }) });
 
@@ -335,16 +373,33 @@ export function TargetsPage() {
   );
 
   /**
+   * #573: the "All targets" view is what the progressive reveal caps — a
+   * prefix slice of the full filtered catalogue, growing via `revealCount`.
+   * Order is the raw fetch order (not the user's chosen sort — TargetsTable
+   * sorts whatever it's given), so this only affects which rows exist during
+   * the brief initial-load window, not final correctness once fully loaded.
+   */
+  const revealedPlannerTargets = useMemo(
+    () => plannerTargets.slice(0, revealCount),
+    [plannerTargets, revealCount],
+  );
+
+  /**
    * task #18: when "My Targets" is active, filter the Planner catalog to only
    * the targets the user has starred (stored client-side via useFavourites).
    * STUB: favouriteIds comes from localStorage only until task #54 lands and
    * provides real backend "has linked sessions/projects" data.
+   *
+   * Uses the FULL `plannerTargets` (not the progressive-reveal slice, #573):
+   * favourites are a small set regardless of catalogue size, so there's no
+   * perf reason to cap it, and capping it would make a starred target
+   * transiently vanish from "My Targets" until reveal catches up to it.
    */
   const tabTargets = useMemo(() => {
-    if (myTargetsFilter !== MY_TARGETS_VALUE) return plannerTargets;
+    if (myTargetsFilter !== MY_TARGETS_VALUE) return revealedPlannerTargets;
     if (favouriteIds.size === 0) return MY_TARGETS_EMPTY;
     return plannerTargets.filter((t) => favouriteIds.has(t.id));
-  }, [myTargetsFilter, plannerTargets, favouriteIds]);
+  }, [myTargetsFilter, revealedPlannerTargets, plannerTargets, favouriteIds]);
 
   const visibleTargets = useMemo(() => {
     const q = search.trim();

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -41,7 +41,11 @@ vi.mock('@tanstack/react-router', () => ({
   ),
 }));
 
-import { TargetsTable, DEFAULT_TARGET_SORT, __testExports } from './TargetsTable';
+import {
+  TargetsTable,
+  DEFAULT_TARGET_SORT,
+  __testExports,
+} from './TargetsTable';
 import { __setObservingStateForTest } from './observing-sites/site-store';
 import type { ObserverSite } from './observing-sites/observer-site';
 import type { ObservingNight } from './astro/moon-state';
@@ -407,7 +411,13 @@ describe('TargetsTable row cache (#573)', () => {
 
   it('reuses the same object on a cache hit (same target id + genKey)', () => {
     const cache = new Map();
-    const genKey = rowCacheGenKey(30, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
+    const genKey = rowCacheGenKey(
+      30,
+      SITE_A,
+      1000,
+      null,
+      DEFAULT_MOON_AVOIDANCE,
+    );
     const first = getCachedRow(
       cache,
       TARGET,
@@ -433,8 +443,20 @@ describe('TargetsTable row cache (#573)', () => {
 
   it('recomputes (fresh object) when the generation key changes', () => {
     const cache = new Map();
-    const genKeyA = rowCacheGenKey(30, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
-    const genKeyB = rowCacheGenKey(45, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
+    const genKeyA = rowCacheGenKey(
+      30,
+      SITE_A,
+      1000,
+      null,
+      DEFAULT_MOON_AVOIDANCE,
+    );
+    const genKeyB = rowCacheGenKey(
+      45,
+      SITE_A,
+      1000,
+      null,
+      DEFAULT_MOON_AVOIDANCE,
+    );
     const first = getCachedRow(
       cache,
       TARGET,
@@ -462,17 +484,23 @@ describe('TargetsTable row cache (#573)', () => {
 
   it('rowCacheGenKey changes with each astronomy input', () => {
     const base = rowCacheGenKey(30, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
-    expect(rowCacheGenKey(31, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE)).not.toBe(
-      base,
-    );
-    expect(rowCacheGenKey(30, null, 1000, null, DEFAULT_MOON_AVOIDANCE)).not.toBe(
-      base,
-    );
-    expect(rowCacheGenKey(30, SITE_A, 2000, null, DEFAULT_MOON_AVOIDANCE)).not.toBe(
-      base,
-    );
     expect(
-      rowCacheGenKey(30, SITE_A, 1000, nightWithMoonAtVernalEquinox(), DEFAULT_MOON_AVOIDANCE),
+      rowCacheGenKey(31, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE),
+    ).not.toBe(base);
+    expect(
+      rowCacheGenKey(30, null, 1000, null, DEFAULT_MOON_AVOIDANCE),
+    ).not.toBe(base);
+    expect(
+      rowCacheGenKey(30, SITE_A, 2000, null, DEFAULT_MOON_AVOIDANCE),
+    ).not.toBe(base);
+    expect(
+      rowCacheGenKey(
+        30,
+        SITE_A,
+        1000,
+        nightWithMoonAtVernalEquinox(),
+        DEFAULT_MOON_AVOIDANCE,
+      ),
     ).not.toBe(base);
   });
 });

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -41,10 +41,11 @@ vi.mock('@tanstack/react-router', () => ({
   ),
 }));
 
-import { TargetsTable, DEFAULT_TARGET_SORT } from './TargetsTable';
+import { TargetsTable, DEFAULT_TARGET_SORT, __testExports } from './TargetsTable';
 import { __setObservingStateForTest } from './observing-sites/site-store';
 import type { ObserverSite } from './observing-sites/observer-site';
 import type { ObservingNight } from './astro/moon-state';
+import { DEFAULT_MOON_AVOIDANCE } from './astro/moon-avoidance';
 
 function item(
   primaryDesignation: string,
@@ -380,6 +381,99 @@ describe('TargetsTable — lunar distance (US2)', () => {
     );
     // No numeric lunar separations; both rows show the unknown dash.
     expect(screen.queryByText('90°')).not.toBeInTheDocument();
+  });
+});
+
+// ── Row cache contract (#573 perf) ──────────────────────────────────────────
+//
+// The full-catalogue sort/group pass reuses a per-target-id cache gated by a
+// generation key of all astronomy inputs (see TargetsTable.tsx's module doc)
+// so growing the revealed target set only pays for the delta. These tests
+// assert the cache CONTRACT directly (object-identity reuse on a hit, a
+// fresh compute on a miss) rather than timing, which would be flaky on CI.
+describe('TargetsTable row cache (#573)', () => {
+  const { getCachedRow, rowCacheGenKey } = __testExports;
+  const TARGET = coordItem('CACHE-TEST', 10, 20);
+  const SITE_A: ObserverSite = {
+    id: 'site-a',
+    name: 'A',
+    latitudeDeg: 52,
+    longitudeDeg: 5,
+    elevationM: 0,
+    timezone: 'Europe/Amsterdam',
+    twilight: 'astronomical',
+    minHorizonAltDeg: 0,
+  };
+
+  it('reuses the same object on a cache hit (same target id + genKey)', () => {
+    const cache = new Map();
+    const genKey = rowCacheGenKey(30, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
+    const first = getCachedRow(
+      cache,
+      TARGET,
+      genKey,
+      30,
+      SITE_A,
+      1000,
+      DEFAULT_MOON_AVOIDANCE,
+      null,
+    );
+    const second = getCachedRow(
+      cache,
+      TARGET,
+      genKey,
+      30,
+      SITE_A,
+      1000,
+      DEFAULT_MOON_AVOIDANCE,
+      null,
+    );
+    expect(second).toBe(first);
+  });
+
+  it('recomputes (fresh object) when the generation key changes', () => {
+    const cache = new Map();
+    const genKeyA = rowCacheGenKey(30, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
+    const genKeyB = rowCacheGenKey(45, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
+    const first = getCachedRow(
+      cache,
+      TARGET,
+      genKeyA,
+      30,
+      SITE_A,
+      1000,
+      DEFAULT_MOON_AVOIDANCE,
+      null,
+    );
+    const second = getCachedRow(
+      cache,
+      TARGET,
+      genKeyB,
+      45,
+      SITE_A,
+      1000,
+      DEFAULT_MOON_AVOIDANCE,
+      null,
+    );
+    expect(second).not.toBe(first);
+    // The new entry now occupies the cache slot for this id.
+    expect(cache.get(TARGET.id)).toBe(second);
+  });
+
+  it('rowCacheGenKey changes with each astronomy input', () => {
+    const base = rowCacheGenKey(30, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE);
+    expect(rowCacheGenKey(31, SITE_A, 1000, null, DEFAULT_MOON_AVOIDANCE)).not.toBe(
+      base,
+    );
+    expect(rowCacheGenKey(30, null, 1000, null, DEFAULT_MOON_AVOIDANCE)).not.toBe(
+      base,
+    );
+    expect(rowCacheGenKey(30, SITE_A, 2000, null, DEFAULT_MOON_AVOIDANCE)).not.toBe(
+      base,
+    );
+    expect(
+      rowCacheGenKey(30, SITE_A, 1000, nightWithMoonAtVernalEquinox(), DEFAULT_MOON_AVOIDANCE),
+    ).not.toBe(base);
   });
 });
 

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -250,6 +250,69 @@ interface TargetGroup {
   }>;
 }
 
+// ── Per-target row cache (#573) ─────────────────────────────────────────────
+//
+// The full-catalogue sort/group pass below (up to ~13k rows) is the
+// unbackgrounded synchronous work that froze the app on open (#573): each
+// row runs astronomy-engine altitude sampling (rowAltitudeFor) + Moon
+// planning (deriveRowMoonPlanning), which is not free at catalogue scale
+// (see rowAltitudeFor's doc — "a real perf cliff... a Layer-2 CI timeout
+// against the full ~13k-entry bundled seed catalogue"). Re-running that for
+// every target on every render (every sort/filter/group/reveal-chunk change)
+// is wasted work when the astronomy INPUTS (site/date/night/threshold/
+// guidance params) haven't changed for a given target. `rowCache` memoizes
+// per target id, gated by `genKey` (all astronomy inputs); TargetsPage's
+// incremental reveal (growing the `targets` array in chunks) then only pays
+// for the newly-revealed delta each step instead of recomputing the whole
+// set, since previously-seen ids hit the cache.
+interface RowCacheEntry {
+  genKey: string;
+  alt: RowAltitude;
+  moon: RowMoonPlanning;
+}
+
+/** Generation key gating `rowCache`: changes whenever any astronomy input does. */
+function rowCacheGenKey(
+  usableAltDeg: number,
+  site: ObserverSite | null,
+  dateMs: number,
+  night: ObservingNight | null,
+  guidanceParams: MoonAvoidanceParams,
+): string {
+  return `${usableAltDeg}|${site?.id ?? ''}|${dateMs}|${night?.nightKey ?? ''}|${JSON.stringify(guidanceParams)}`;
+}
+
+/**
+ * Look up (or compute + cache) a target's full-catalogue-pass altitude/moon
+ * values. `includeMoonGeometry` is always `false` here — same contract as
+ * the call sites this replaces.
+ */
+function getCachedRow(
+  cache: Map<string, RowCacheEntry>,
+  t: TargetListItem,
+  genKey: string,
+  usableAltDeg: number,
+  site: ObserverSite | null,
+  dateMs: number,
+  guidanceParams: MoonAvoidanceParams,
+  night: ObservingNight | null,
+): { alt: RowAltitude; moon: RowMoonPlanning } {
+  const cached = cache.get(t.id);
+  if (cached && cached.genKey === genKey) return cached;
+  const alt = rowAltitudeFor(
+    t,
+    usableAltDeg,
+    site,
+    dateMs,
+    guidanceParams,
+    false,
+  );
+  const moon = deriveRowMoonPlanning(t, night, guidanceParams);
+  const entry: RowCacheEntry = { genKey, alt, moon };
+  cache.set(t.id, entry);
+  return entry;
+}
+
 /**
  * Group targets by the selected key, compute altitude + moon planning for each,
  * sort within groups, then order groups by their first (sorted) row.
@@ -263,6 +326,8 @@ function groupTargets(
   night: ObservingNight | null,
   guidanceParams: MoonAvoidanceParams,
   dateMs: number,
+  cache: Map<string, RowCacheEntry>,
+  genKey: string,
 ): TargetGroup[] {
   const byKey = new Map<
     string,
@@ -270,18 +335,16 @@ function groupTargets(
   >();
   for (const t of targets) {
     const key = groupHeadlineOf(t, groupBy);
-    // includeMoonGeometry=false: this pass runs over the FULL (possibly
-    // ~13k-entry) catalogue for sort/group — the Moon time-series is only
-    // computed per visible row at render time (see the row-render loop).
-    const alt = rowAltitudeFor(
+    const { alt, moon } = getCachedRow(
+      cache,
       t,
+      genKey,
       usableAltDeg,
       site,
       dateMs,
       guidanceParams,
-      false,
+      night,
     );
-    const moon = deriveRowMoonPlanning(t, night, guidanceParams);
     const bucket = byKey.get(key);
     if (bucket) bucket.push({ target: t, alt, moon });
     else byKey.set(key, [{ target: t, alt, moon }]);
@@ -357,6 +420,9 @@ type FlatRow =
 function buildTargetAccessors(
   night: ObservingNight | null,
   guidanceParams: MoonAvoidanceParams,
+  // #573 perf: reuse the moon planning already computed by the cached
+  // full-catalogue pass (moonMap) instead of re-deriving it per target.
+  moonLookup?: (t: TargetListItem) => RowMoonPlanning,
 ): Readonly<Record<string, DimensionAccessor<TargetListItem>>> {
   return {
     constellation: (t) =>
@@ -369,11 +435,9 @@ function buildTargetAccessors(
     // Applicable filters: group by the target's REAL derived recommendation
     // category (broadband-ok / narrowband-only / avoid-tonight / unknown).
     filters: (t) => {
-      const { recommendation } = deriveRowMoonPlanning(
-        t,
-        night,
-        guidanceParams,
-      );
+      const { recommendation } = moonLookup
+        ? moonLookup(t)
+        : deriveRowMoonPlanning(t, night, guidanceParams);
       return recommendationLabel(recommendation);
     },
   };
@@ -585,6 +649,13 @@ export function TargetsTable({
   // a different date recomputes the whole table (SC-004).
   const dateMs = usePlannerDateMs();
 
+  // #573 perf: per-target-id cache for the full-catalogue astronomy pass
+  // below, persisted across renders for this component instance (a ref, not
+  // state — it never needs to trigger a re-render itself). See the
+  // `getCachedRow`/`rowCacheGenKey` doc above.
+  const rowCacheRef = useRef<Map<string, RowCacheEntry>>(new Map());
+  const genKey = rowCacheGenKey(usableAltDeg, site, dateMs, night, guidanceParams);
+
   // Grouping + sorting + per-row altitude are all derived here so a filter
   // or sort change does one O(n) pass off the render hot path, not per-row work
   // inside the virtualized render loop. usableAltDeg + site are included in the
@@ -599,20 +670,20 @@ export function TargetsTable({
   const flatRows = useMemo(() => {
     if (useMultiGroup) {
       // Pre-compute altitude + moon planning for all items (needed for sort +
-      // display). includeMoonGeometry=false: full-catalogue pass, see the
-      // legacy-path comment below for why.
-      const withAlt = targets.map((t) => ({
-        target: t,
-        alt: rowAltitudeFor(
+      // display), reusing the per-id cache (#573) — see getCachedRow's doc.
+      const withAlt = targets.map((t) => {
+        const { alt, moon } = getCachedRow(
+          rowCacheRef.current,
           t,
+          genKey,
           usableAltDeg,
           site,
           dateMs,
           guidanceParams,
-          false,
-        ),
-        moon: deriveRowMoonPlanning(t, night, guidanceParams),
-      }));
+          night,
+        );
+        return { target: t, alt, moon };
+      });
       // Sort the flat list first.
       const sortedWithAlt = [...withAlt].sort((a, b) =>
         compareTargetRows(
@@ -629,11 +700,16 @@ export function TargetsTable({
       const altMap = new Map(sortedWithAlt.map((r) => [r.target.id, r.alt]));
       const moonMap = new Map(sortedWithAlt.map((r) => [r.target.id, r.moon]));
 
-      // Build the group tree using shared engine.
+      // Build the group tree using shared engine. moonMap reuse (#573):
+      // avoids re-deriving moon planning already computed above.
       const tree = groupByDimensions(
         sorted,
         dims!,
-        buildTargetAccessors(night, guidanceParams),
+        buildTargetAccessors(
+          night,
+          guidanceParams,
+          (t) => moonMap.get(t.id) ?? UNKNOWN_ROW_PLANNING,
+        ),
       );
       // Flatten with collapse state, then map to our FlatRow shape.
       const visRows = flattenVisibleGroups(tree, collapsed);
@@ -681,19 +757,29 @@ export function TargetsTable({
         night,
         guidanceParams,
         dateMs,
+        rowCacheRef.current,
+        genKey,
       );
       return flattenGroups(groups);
     }
     // Default: no grouping selected → FLAT sorted list (no group headers).
-    // includeMoonGeometry=false: this is a full-catalogue pass (potentially
-    // ~13k rows pre-filter/pre-windowing) needed only for sort — the real
-    // Moon time-series is computed per visible row at render time instead
+    // Full-catalogue pass (potentially ~13k rows pre-filter/pre-windowing)
+    // needed only for sort, reusing the per-id cache (#573) — the real Moon
+    // time-series is still computed per visible row at render time instead
     // (a real Layer-2 CI perf regression otherwise: see rowAltitudeFor's doc).
-    const withAlt = targets.map((t) => ({
-      target: t,
-      alt: rowAltitudeFor(t, usableAltDeg, site, dateMs, guidanceParams, false),
-      moon: deriveRowMoonPlanning(t, night, guidanceParams),
-    }));
+    const withAlt = targets.map((t) => {
+      const { alt, moon } = getCachedRow(
+        rowCacheRef.current,
+        t,
+        genKey,
+        usableAltDeg,
+        site,
+        dateMs,
+        guidanceParams,
+        night,
+      );
+      return { target: t, alt, moon };
+    });
     const sortedWithAlt = [...withAlt].sort((a, b) =>
       compareTargetRows(a.target, a.alt, a.moon, b.target, b.alt, b.moon, sort),
     );
@@ -719,6 +805,7 @@ export function TargetsTable({
     useMultiGroup,
     dims,
     collapsed,
+    genKey,
   ]);
 
   const virtualizer = useVirtualizer({
@@ -1197,3 +1284,10 @@ export function TargetsTable({
     </div>
   );
 }
+
+// ── Test-only exports (#573) ────────────────────────────────────────────────
+//
+// Direct unit-testable access to the row cache contract (getCachedRow +
+// rowCacheGenKey), mirroring the `__setObservingStateForTest` convention in
+// site-store.ts. Not used by any non-test caller.
+export const __testExports = { getCachedRow, rowCacheGenKey };

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -654,7 +654,13 @@ export function TargetsTable({
   // state — it never needs to trigger a re-render itself). See the
   // `getCachedRow`/`rowCacheGenKey` doc above.
   const rowCacheRef = useRef<Map<string, RowCacheEntry>>(new Map());
-  const genKey = rowCacheGenKey(usableAltDeg, site, dateMs, night, guidanceParams);
+  const genKey = rowCacheGenKey(
+    usableAltDeg,
+    site,
+    dateMs,
+    night,
+    guidanceParams,
+  );
 
   // Grouping + sorting + per-row altitude are all derived here so a filter
   // or sort change does one O(n) pass off the render hot path, not per-row work


### PR DESCRIPTION
Fixes #573.

## Root cause

Opening the Targets page froze the app. `TargetsTable.tsx`'s `flatRows`
`useMemo` ran `rowAltitudeFor` (astronomy-engine altitude sampling) +
`deriveRowMoonPlanning` **synchronously over the entire `targets` prop**
(up to the full ~13,073-row bundled seed catalogue) on **every render**.
This is the exact "real perf cliff … a Layer-2 CI timeout against the full
~13k-entry bundled seed catalogue" already flagged in `planner-altitude.ts`'s
own doc — only the Moon-geometry portion had previously been mitigated, not the
altitude sampling. React's concurrent scheduler cannot interrupt a single
synchronous call inside one component's `useMemo`, so `startTransition` /
`useDeferredValue` could not help; and progressively growing the array alone
(without a per-row cache) still ends with one full-size synchronous burst equal
to today's freeze on the final increment.

## Approach

Per-item memoization + deferred first paint (capping/paginating the visible
catalogue was rejected as a product-behaviour change):

- **`TargetsTable.tsx`** — a per-target-id `rowCache` (`Map<string,
  RowCacheEntry>`, held in a `useRef`) gated by a `rowCacheGenKey` string that
  encodes every astronomy input (`usableAltDeg`, site id, `dateMs`, night key,
  guidance params). `getCachedRow` returns the cached `{alt, moon}` on a genKey
  hit, else recomputes and stores it. All three `flatRows` paths (multi-group,
  single-group, flat) route through `getCachedRow`; `buildTargetAccessors`
  gained an optional `moonLookup` to reuse the already-computed moon map for
  group-by filters. Test-only exports (`__testExports`) mirror the existing
  `__setObservingStateForTest` convention.
- **`TargetsPage.tsx`** — progressive reveal: `REVEAL_CHUNK = 300`, a
  `revealCount` that resets on each fresh `load()`, and a `setTimeout(…, 0)`
  effect that grows the revealed prefix toward the full total on real macrotask
  boundaries so the browser can paint/handle input between chunks. "My Targets"
  keeps using the full set (favourites are small; capping would make a starred
  target transiently vanish).

## Complexity / performance rationale

The freeze was `O(catalogue)` astronomy computation on **every** render
(each sort / filter / group / reveal step re-ran the full ~13k-row pass).
After this change:

- Astronomy is computed **once per target per generation** (a genKey change —
  i.e. an actual astronomy-input change — invalidates), not once per render.
  A sort/filter/group/reveal that leaves the astronomy inputs unchanged now
  does **zero** astronomy recompute; it reuses cached rows.
- First paint is bounded to `REVEAL_CHUNK = 300` rows instead of the full
  catalogue, and each subsequent macrotask growth step only pays for the newly
  revealed delta (cache hits on everything already seen). Total work stays
  roughly linear in catalogue size but is spread across macrotasks with paint
  gaps, rather than one blocking synchronous burst on open.

No standalone micro-benchmark is included — the repo has no existing
vitest-bench / perf-test harness, and timing assertions in unit tests are
CI-flaky (the cache and reveal contracts are asserted structurally instead,
see below). The `<~200 ms` first-paint acceptance target is a real-app
(Tauri/Windows) measurement that headless jsdom cannot represent faithfully;
it belongs to the downstream real-app verification pass.

## Tests

- `TargetsTable.test.tsx` — cache-contract block (`#573`): object-identity
  reuse on a genKey hit, fresh compute + cache replacement on a genKey miss,
  and `rowCacheGenKey` changing with each individual astronomy input.
- `TargetsPage.test.tsx` — new progressive-reveal coverage (`#573`, fake
  timers): first paint capped to `REVEAL_CHUNK`, grows to the full catalogue on
  timer drain, and a sort interaction does not reset the revealed count.

Local (frontend only; cargo skipped — WSL memory):

- `biome format` — clean on all 3 touched files.
- `eslint` — 0 errors (pre-existing warnings only, in unrelated lines).
- `tsc --noEmit` — clean.
- Full `apps/desktop` vitest suite — **1426 passed / 1426** (includes the new
  tests and the known-flaky GuidedOverlay / inbox.affordances / LogPanel
  cases, all green in the same run).

## Notes

- Recovered from an interrupted coder session: the fix and its cache-contract
  tests were committed but formatting/verification were incomplete and the
  reveal timer had no test coverage. This PR completes the formatting pass,
  runs and confirms the tests, adds the reveal coverage, and verifies.
- Node **nJ09c** (Visible-rating / Tonight-sparkline) is intentionally out of
  scope here and serialized behind this node.
