### PR TITLE
fix: target Visible rating reflects altitude on nights with no astronomical darkness; larger Tonight altitude graph

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1178,6 +1178,7 @@
   "targets_table_target_count": "{count} targets",
   "targets_table_visible_low": "low",
   "targets_table_visible_tonight": "tonight",
+  "targets_table_visible_twilight": "twilight",
   "ui_dir_picker_choose": "Choose folder…",
   "ui_dir_picker_error": "Couldn’t open the folder picker.",
   "ui_toast_dismiss_aria": "Dismiss notification",

--- a/apps/desktop/src/features/targets/AltitudeSparkline.tsx
+++ b/apps/desktop/src/features/targets/AltitudeSparkline.tsx
@@ -2,27 +2,28 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * AltitudeSparkline — tiny inline altitude sparkline for a Planner row (task
- * #85, spec 043; polished task #19; real ephemeris since spec 044 Track B).
+ * AltitudeSparkline — inline altitude sparkline for a Planner row (task #85,
+ * spec 043; polished task #19; real ephemeris since spec 044 Track B; enlarged
+ * + marked-up for #580).
  *
  * Plots the real per-row altitude curve from `planner-altitude.ts` (per-site
- * ephemeris, astronomy-engine) across the night. A faint guide line marks the
- * usable-altitude threshold; the stroke turns "usable" colour when the target
- * peaks above it tonight. Shares its x/y scale with `TargetDetailV2`'s
- * detail-pane graph via `altitude-scale.ts` (spec 044 Track B, T035).
+ * ephemeris, astronomy-engine) across the night. Shares its x/y scale with
+ * `TargetDetailV2`'s detail-pane graph via `altitude-scale.ts` (spec 044 Track
+ * B, T035) so the two never drift.
  *
- * task #19 additions:
- *   - Reduced height (viewBox uses VB_H = 20; CSS sets 22 px via wave2 block).
- *   - Bottom time-axis ticks at 18:00, 00:00, and 06:00 local.
- *   - A per-sample <title> tooltip so hovering anywhere on the curve shows
- *     the approximate time + altitude degree for that sample.  The tooltip
- *     uses a single full-SVG <title> with a compact multi-line summary rather
- *     than per-point hit targets, because the SVG is 72 px wide and individual
- *     sample regions would be sub-pixel.  Browser-native <title> shows on hover
- *     without JS; pointer-events are enabled via the wave2 CSS block.
+ * #580 (legibility): the sparkline was too small/cramped to read. It is now
+ * wider + taller, draws a distinct coloured line over a soft area fill, shades
+ * the twilight either side of the astronomical dark window (the same twilight
+ * marks the detail-pane graph uses, from `RowAltitude.darkWindowHours`), and
+ * marks the transit / max-altitude point with a dot. A faint guide line marks
+ * the usable-altitude threshold; the stroke turns "usable" colour when the
+ * target peaks above it tonight.
  *
- * Geometry (the polyline points, guide-line Y, and tick positions) is
- * data-driven — the allowed dynamic inline-attribute case.  All visual styling
+ * task #19 (kept): bottom time-axis ticks at 18:00, 00:00, 06:00 local, and a
+ * per-sample <title> tooltip so hovering shows approximate time + altitude.
+ *
+ * Geometry (polyline points, guide-line Y, tick + shading positions) is
+ * data-driven — the allowed dynamic inline-attribute case. All visual styling
  * is token-only CSS on the wrapping classes.
  */
 
@@ -31,11 +32,11 @@ import { altitudeScale, hourScale, HOUR_DOMAIN } from './altitude-scale';
 
 // ── Coordinate space ───────────────────────────────────────────────────────────
 //
-// task #19: VB_H increased from 18 → 20 (curve area) + TICK_H (axis ticks).
-// The CSS sets the rendered size to 72 × 22 px (via .cssblocks/targets-wave2.css).
+// #580: enlarged from 72×22 → 96×28 viewBox (curve area + axis ticks). The CSS
+// sets the rendered size to match (via .styles/components/merges-3.css).
 
-const VB_W = 72;
-const CURVE_H = 14; // height of the altitude-curve area (px in viewBox units)
+const VB_W = 96;
+const CURVE_H = 22; // height of the altitude-curve area (viewBox units)
 const TICK_H = 6; // height reserved below curve for time-axis tick + label
 const VB_H = CURVE_H + TICK_H;
 const PAD_Y = 1;
@@ -68,8 +69,8 @@ const TIME_TICKS: Array<{ tHour: number; label: string }> = [
 // ── Hover tooltip helper ───────────────────────────────────────────────────────
 //
 // Build a compact multi-line tooltip string summarising the night curve.
-// Format: "18:00 −3° | 21:00 42° | 00:00 68° | 03:00 52° | 06:00 8°"
-// We sample every 3 h (i.e. every 9th point at the 36-sample resolution).
+// Format: "18:00 −3° · 21:00 42° · 00:00 68° · 03:00 52° · 06:00 8°"
+// We sample every ~3 h (i.e. every 9th point at the 36-sample resolution).
 
 function buildTooltip(alt: RowAltitude): string {
   const step = Math.floor(alt.points.length / 4); // ~3h interval
@@ -91,22 +92,47 @@ interface Props {
 }
 
 export function AltitudeSparkline({ alt, label }: Props) {
-  const { points, visibleTonight } = alt;
+  const { points, visibleTonight, darkWindowHours } = alt;
   const n = points.length;
 
-  const polyline = points
-    .map((p, i) => {
-      const x = n > 1 ? tHourToX(p.tHour) : 0;
-      // Use i-based x when tHour spacing is uniform; tHour-based when not.
-      void i; // tHour is authoritative
-      return `${x.toFixed(1)},${altToY(p.altDeg).toFixed(1)}`;
-    })
+  const xy = points.map((p) => ({
+    x: n > 1 ? tHourToX(p.tHour) : 0,
+    y: altToY(p.altDeg),
+  }));
+  const polyline = xy
+    .map((c) => `${c.x.toFixed(1)},${c.y.toFixed(1)}`)
     .join(' ');
-
-  const guideY = altToY(USABLE_ALT_DEG).toFixed(1);
 
   // Axis baseline Y: top of tick area (just below the curve).
   const axisY = CURVE_H;
+
+  // #580 area fill: close the curve down to the axis baseline so the body of
+  // the night's altitude reads at a glance, not just a thin line.
+  const area =
+    xy.length > 1
+      ? `${xy[0].x.toFixed(1)},${axisY} ${polyline} ${xy[xy.length - 1].x.toFixed(1)},${axisY}`
+      : '';
+
+  const guideY = altToY(USABLE_ALT_DEG).toFixed(1);
+
+  // #580 transit/max-altitude marker: the highest sampled point.
+  const peak =
+    xy.length > 0
+      ? points.reduce(
+          (best, p, i) => (p.altDeg > best.alt ? { alt: p.altDeg, i } : best),
+          { alt: -Infinity, i: 0 },
+        )
+      : null;
+
+  // #580 twilight shading: the not-dark hours either side of the astronomical
+  // dark window (same source + semantics as the detail-pane graph). Clamped to
+  // the viewBox; omitted entirely when there is no dark window tonight.
+  const twilightStartW = darkWindowHours
+    ? Math.max(0, tHourToX(darkWindowHours.startHour))
+    : 0;
+  const twilightEndX = darkWindowHours
+    ? tHourToX(darkWindowHours.endHour)
+    : VB_W;
 
   const tooltip = buildTooltip(alt);
 
@@ -124,10 +150,33 @@ export function AltitudeSparkline({ alt, label }: Props) {
       aria-label={label}
     >
       {/* Hover tooltip: native <title> shown by browser on hover.
-          Pointer-events are enabled on the SVG via .cssblocks/targets-wave2.css. */}
+          Pointer-events are enabled on the SVG via the merges-3 CSS block. */}
       <title>
         {label} — {tooltip}
       </title>
+
+      {/* #580 twilight shading either side of the dark window. */}
+      {darkWindowHours && twilightStartW > 0 && (
+        <rect
+          className="alm-targets-spark__twilight"
+          x={0}
+          y={0}
+          width={twilightStartW}
+          height={axisY}
+        />
+      )}
+      {darkWindowHours && twilightEndX < VB_W && (
+        <rect
+          className="alm-targets-spark__twilight"
+          x={twilightEndX}
+          y={0}
+          width={VB_W - twilightEndX}
+          height={axisY}
+        />
+      )}
+
+      {/* #580 soft area fill under the curve. */}
+      {area && <polygon className="alm-targets-spark__area" points={area} />}
 
       {/* Usable-altitude guide line (≥30°). Geometry only; colour via CSS. */}
       <line
@@ -140,6 +189,16 @@ export function AltitudeSparkline({ alt, label }: Props) {
 
       {/* Altitude curve across the night. */}
       <polyline className="alm-targets-spark__curve" points={polyline} />
+
+      {/* #580 transit / max-altitude marker. */}
+      {peak && Number.isFinite(peak.alt) && (
+        <circle
+          className="alm-targets-spark__peak"
+          cx={xy[peak.i].x.toFixed(1)}
+          cy={xy[peak.i].y.toFixed(1)}
+          r={1.8}
+        />
+      )}
 
       {/* task #19: time-axis baseline (separates curve from tick labels). */}
       <line

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -548,7 +548,9 @@ describe('TargetsTable — needs-coordinates state (#757)', () => {
 // At lat 52 there is no astronomical darkness for months (summer). The Visible
 // column used to collapse EVERY target to a single not-visible state on such a
 // night. It must instead vary by altitude: a zenith/circumpolar target reads
-// visible, a never-riser reads low.
+// visible — with a persistent, distinct "twilight" state disclosing that there
+// is no astronomical darkness (a plain "tonight" dot would overpromise) —
+// while a never-riser reads low.
 describe('TargetsTable — Visible on a no-dark-window summer night (#579)', () => {
   beforeEach(() => {
     __setObservingStateForTest({
@@ -558,7 +560,7 @@ describe('TargetsTable — Visible on a no-dark-window summer night (#579)', () 
     });
   });
 
-  it('a zenith target reads visible while a never-riser reads low — not both the same', () => {
+  it('a zenith target reads twilight-visible while a never-riser reads low — not both the same', () => {
     vi.useFakeTimers();
     // Mid-July at 52°N: no astronomical dark window exists all night.
     vi.setSystemTime(new Date('2026-07-15T21:00:00Z'));
@@ -577,9 +579,31 @@ describe('TargetsTable — Visible on a no-dark-window summer night (#579)', () 
         .getByText('NEVER')
         .closest('tr') as HTMLTableRowElement;
       // Discrimination: the two extremes render DIFFERENT visibility states.
-      expect(zenithRow.querySelector('.alm-targets-vis--yes')).not.toBeNull();
+      // The visible one is the twilight state — an at-a-glance, persistent
+      // no-dark-window disclosure, never the plain "tonight" dot.
+      expect(
+        zenithRow.querySelector('.alm-targets-vis--twilight'),
+      ).not.toBeNull();
+      expect(zenithRow.querySelector('.alm-targets-vis--yes')).toBeNull();
+      expect(within(zenithRow).getByText('twilight')).toBeInTheDocument();
       expect(neverRow.querySelector('.alm-targets-vis--no')).not.toBeNull();
-      expect(neverRow.querySelector('.alm-targets-vis--yes')).toBeNull();
+      expect(neverRow.querySelector('.alm-targets-vis--twilight')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a normal dark night still renders the plain "tonight" state, not twilight', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-15T20:00:00Z'));
+    try {
+      renderTable({ targets: [coordItem('HIGH', 90, 52)] });
+      const table = screen.getByRole('table');
+      const row = within(table)
+        .getByText('HIGH')
+        .closest('tr') as HTMLTableRowElement;
+      expect(row.querySelector('.alm-targets-vis--yes')).not.toBeNull();
+      expect(row.querySelector('.alm-targets-vis--twilight')).toBeNull();
     } finally {
       vi.useRealTimers();
     }

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -542,3 +542,46 @@ describe('TargetsTable — needs-coordinates state (#757)', () => {
     }
   });
 });
+
+// ── #579: Visible discriminates by altitude even with no dark window ─────────
+//
+// At lat 52 there is no astronomical darkness for months (summer). The Visible
+// column used to collapse EVERY target to a single not-visible state on such a
+// night. It must instead vary by altitude: a zenith/circumpolar target reads
+// visible, a never-riser reads low.
+describe('TargetsTable — Visible on a no-dark-window summer night (#579)', () => {
+  beforeEach(() => {
+    __setObservingStateForTest({
+      sites: [SITE],
+      activeSiteId: SITE.id,
+      defaultSiteId: SITE.id,
+    });
+  });
+
+  it('a zenith target reads visible while a never-riser reads low — not both the same', () => {
+    vi.useFakeTimers();
+    // Mid-July at 52°N: no astronomical dark window exists all night.
+    vi.setSystemTime(new Date('2026-07-15T21:00:00Z'));
+    try {
+      renderTable({
+        targets: [
+          coordItem('ZENITH', 270, 52), // transits near the zenith
+          coordItem('NEVER', 0, -80), // never rises at 52°N
+        ],
+      });
+      const table = screen.getByRole('table');
+      const zenithRow = within(table)
+        .getByText('ZENITH')
+        .closest('tr') as HTMLTableRowElement;
+      const neverRow = within(table)
+        .getByText('NEVER')
+        .closest('tr') as HTMLTableRowElement;
+      // Discrimination: the two extremes render DIFFERENT visibility states.
+      expect(zenithRow.querySelector('.alm-targets-vis--yes')).not.toBeNull();
+      expect(neverRow.querySelector('.alm-targets-vis--no')).not.toBeNull();
+      expect(neverRow.querySelector('.alm-targets-vis--yes')).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -1132,10 +1132,12 @@ export function TargetsTable({
                       (does the target clear the usable altitude tonight),
                       which now discriminates even on a no-dark-window night
                       (high-lat summer) instead of collapsing every row to a
-                      single "no dark window" state. When there is no
-                      astronomical darkness the tooltip discloses it (FR-017 —
-                      imaging time is genuinely zero) without hiding the
-                      altitude distinction. */}
+                      single "no dark window" state. A visible target on a
+                      no-dark night renders a persistent, distinct "twilight"
+                      state (◐ + amber label) rather than the plain "tonight"
+                      dot, which would overpromise — the target only clears
+                      the threshold in twilight and imaging time is genuinely
+                      zero (FR-017). */}
                   <td className="alm-targets-cell--center">
                     {alt.needsCoordinates ? (
                       <span
@@ -1147,18 +1149,24 @@ export function TargetsTable({
                           {m.targets_table_needs_coordinates()}
                         </span>
                       </span>
+                    ) : alt.visibleTonight && alt.noDarkWindow ? (
+                      <span
+                        className="alm-targets-vis alm-targets-vis--twilight"
+                        title={m.targets_table_no_dark_window_title()}
+                      >
+                        ◐
+                        <span className="alm-targets-vis__label">
+                          {m.targets_table_visible_twilight()}
+                        </span>
+                      </span>
                     ) : alt.visibleTonight ? (
                       <span
                         className="alm-targets-vis alm-targets-vis--yes"
-                        title={
-                          alt.noDarkWindow
-                            ? m.targets_table_no_dark_window_title()
-                            : m.targets_table_visible_reaches_title({
-                                deg: Math.round(alt.maxAltDeg),
-                                hours: alt.hoursAboveUsable.toFixed(1),
-                                threshold: usableAltDeg,
-                              })
-                        }
+                        title={m.targets_table_visible_reaches_title({
+                          deg: Math.round(alt.maxAltDeg),
+                          hours: alt.hoursAboveUsable.toFixed(1),
+                          threshold: usableAltDeg,
+                        })}
                       >
                         ●
                         <span className="alm-targets-vis__label">

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -199,9 +199,12 @@ function compareTargetRows(
       break;
     case 'visible':
       // Primary: visible flag (true > false). Secondary: hours above threshold.
+      // Tertiary: peak altitude — the only key that still discriminates on a
+      // no-dark-window night (#579), where hoursAboveUsable is 0 for every row.
       cmp =
         Number(altA.visibleTonight) - Number(altB.visibleTonight) ||
-        altA.hoursAboveUsable - altB.hoursAboveUsable;
+        altA.hoursAboveUsable - altB.hoursAboveUsable ||
+        altA.maxAltDeg - altB.maxAltDeg;
       break;
     case 'opposition': {
       // Real next-opposition date (US4). Unknowns (no coordinates / no site)
@@ -1121,13 +1124,18 @@ export function TargetsTable({
                       />
                     )}
                   </td>
-                  {/* Visible-tonight indicator (peaks above usable alt).
+                  {/* Visible-tonight indicator, discriminating by ALTITUDE.
                       #757: no catalogued coordinates is a distinct
                       un-plannable state, checked first — it must never look
                       like a genuinely low/not-visible target (FR-024).
-                      US4/T033: a site/date with no qualifying dark window
-                      (FR-017) discloses that explicitly instead of implying
-                      the target is simply too low. */}
+                      #579: the visible/low split follows `visibleTonight`
+                      (does the target clear the usable altitude tonight),
+                      which now discriminates even on a no-dark-window night
+                      (high-lat summer) instead of collapsing every row to a
+                      single "no dark window" state. When there is no
+                      astronomical darkness the tooltip discloses it (FR-017 —
+                      imaging time is genuinely zero) without hiding the
+                      altitude distinction. */}
                   <td className="alm-targets-cell--center">
                     {alt.needsCoordinates ? (
                       <span
@@ -1139,24 +1147,18 @@ export function TargetsTable({
                           {m.targets_table_needs_coordinates()}
                         </span>
                       </span>
-                    ) : alt.noDarkWindow ? (
-                      <span
-                        className="alm-targets-vis alm-targets-vis--no"
-                        title={m.targets_table_no_dark_window_title()}
-                      >
-                        ○
-                        <span className="alm-targets-vis__label">
-                          {m.targets_table_no_dark_window()}
-                        </span>
-                      </span>
                     ) : alt.visibleTonight ? (
                       <span
                         className="alm-targets-vis alm-targets-vis--yes"
-                        title={m.targets_table_visible_reaches_title({
-                          deg: Math.round(alt.maxAltDeg),
-                          hours: alt.hoursAboveUsable.toFixed(1),
-                          threshold: usableAltDeg,
-                        })}
+                        title={
+                          alt.noDarkWindow
+                            ? m.targets_table_no_dark_window_title()
+                            : m.targets_table_visible_reaches_title({
+                                deg: Math.round(alt.maxAltDeg),
+                                hours: alt.hoursAboveUsable.toFixed(1),
+                                threshold: usableAltDeg,
+                              })
+                        }
                       >
                         ●
                         <span className="alm-targets-vis__label">
@@ -1166,10 +1168,14 @@ export function TargetsTable({
                     ) : (
                       <span
                         className="alm-targets-vis alm-targets-vis--no"
-                        title={m.targets_table_visible_peaks_title({
-                          deg: Math.round(alt.maxAltDeg),
-                          threshold: usableAltDeg,
-                        })}
+                        title={
+                          alt.noDarkWindow
+                            ? m.targets_table_no_dark_window_title()
+                            : m.targets_table_visible_peaks_title({
+                                deg: Math.round(alt.maxAltDeg),
+                                threshold: usableAltDeg,
+                              })
+                        }
                       >
                         ○
                         <span className="alm-targets-vis__label">

--- a/apps/desktop/src/features/targets/planner-derive.test.ts
+++ b/apps/desktop/src/features/targets/planner-derive.test.ts
@@ -154,6 +154,50 @@ describe('deriveObservability — never-visible edge case (T013)', () => {
   });
 });
 
+describe('deriveObservability — #579 no-dark-window still discriminates by altitude', () => {
+  // A high-latitude summer night: no astronomical dark window exists for
+  // months, but visibility MUST still vary by altitude (a zenith/circumpolar
+  // target is observable in twilight; a never-riser is not) instead of
+  // collapsing every target to not-visible.
+  const SUMMER_MS = Date.UTC(2026, 6, 15, 12, 0, 0);
+
+  it('has no dark window on a lat-52 summer night (precondition)', () => {
+    const night = getNightObservability('t', 270, 52, AMSTERDAM, SUMMER_MS);
+    expect(night.darkWindow).toBeNull();
+  });
+
+  it('a zenith-transiting target reads visible even with no dark window', () => {
+    const night = getNightObservability('t', 270, 52, AMSTERDAM, SUMMER_MS);
+    const derived = deriveObservability(night, 30);
+    expect(derived.maxAltDeg).toBeGreaterThan(80);
+    expect(derived.visibleTonight).toBe(true);
+    // Imaging time stays honestly zero — no astronomical darkness (FR-017).
+    expect(derived.totalImagingMinutes).toBe(0);
+  });
+
+  it('a never-rising target stays not-visible on the same no-dark night', () => {
+    const night = getNightObservability('never', 0, -80, AMSTERDAM, SUMMER_MS);
+    expect(night.darkWindow).toBeNull();
+    const derived = deriveObservability(night, 30);
+    expect(derived.maxAltDeg).toBeLessThan(0);
+    expect(derived.visibleTonight).toBe(false);
+  });
+
+  it('winter behaviour is unchanged: visibility follows the dark window', () => {
+    const night = getNightObservability(
+      't',
+      90,
+      52,
+      AMSTERDAM,
+      WINTER_NIGHT_MS,
+    );
+    expect(night.darkWindow).not.toBeNull();
+    const derived = deriveObservability(night, 30);
+    expect(derived.visibleTonight).toBe(true);
+    expect(derived.totalImagingMinutes).toBeGreaterThan(0);
+  });
+});
+
 describe('deriveObservability — US5 separation scalars (T028, SC-009)', () => {
   it('all three scalars are either a finite [0,180] degree figure or "moon-not-up"', () => {
     const night = getNightObservability(

--- a/apps/desktop/src/features/targets/planner-derive.ts
+++ b/apps/desktop/src/features/targets/planner-derive.ts
@@ -66,7 +66,12 @@ export interface BestImagingDate {
 export interface DerivedObservability {
   /** Peak altitude across the night (= transit altitude), degrees. */
   maxAltDeg: number;
-  /** True when any dark-window sample reaches the usable altitude (FR-005). */
+  /**
+   * True when the target reaches the usable altitude anywhere in the
+   * observable window — the astronomical dark window when one exists, else the
+   * whole night (#579: discriminate by altitude even when there is no
+   * astronomical darkness, rather than collapsing every target to not-visible).
+   */
   visibleTonight: boolean;
   /** Minutes of dark window with altitude ≥ usable (band-free — FR-005). */
   totalImagingMinutes: number;
@@ -214,15 +219,34 @@ export function deriveObservability(
   // Imaging time counts only samples inside the dark window that clear the
   // usable altitude. No dark window (high-lat summer) → zero imaging (FR-017).
   let usableSamples = 0;
-  let visibleTonight = false;
   const dark = night.darkWindow;
   if (dark) {
     for (const s of night.samples) {
       if (s.tMs < dark.startMs || s.tMs > dark.endMs) continue;
-      if (s.altDeg >= usableAltitudeDeg) {
-        usableSamples += 1;
-        visibleTonight = true;
-      }
+      if (s.altDeg >= usableAltitudeDeg) usableSamples += 1;
+    }
+  }
+
+  // Visibility (#579) discriminates by ALTITUDE over the observable window,
+  // which is the astronomical dark window when one exists, else the whole
+  // night. At high latitude there is no astronomical darkness for months
+  // (e.g. lat 52 in summer), but a high/circumpolar target is still observable
+  // in twilight and MUST NOT read identically to a target that never rises —
+  // gating visibility solely on the dark window collapsed the whole "Visible"
+  // column to a single non-discriminating value. Winter behaviour is
+  // unchanged: the dark window is present, so the observable window is the
+  // same span the prior dark-only loop used. Imaging time above stays
+  // dark-gated (FR-017); only the visibility flag falls back.
+  const observable = dark ?? {
+    startMs: night.nightStartMs,
+    endMs: night.nightEndMs,
+  };
+  let visibleTonight = false;
+  for (const s of night.samples) {
+    if (s.tMs < observable.startMs || s.tMs > observable.endMs) continue;
+    if (s.altDeg >= usableAltitudeDeg) {
+      visibleTonight = true;
+      break;
     }
   }
 

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -302,7 +302,7 @@
 
 /* Sparkline column: fixed-ish narrow column, vertically centered. */
 .alm-targets-cell--spark {
-  width: 76px;
+  width: 100px; /* #580: widened for the enlarged sparkline */
   padding-top: var(--alm-sp-1);
   padding-bottom: var(--alm-sp-1);
 }

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -329,7 +329,7 @@
 .alm-targets-col--maxalt { width: 7%; }
 
 /* Sparkline: fixed narrow column (SVG is 64px wide, cell adds padding). */
-.alm-targets-col--spark { width: 7%; }
+.alm-targets-col--spark { width: 9%; } /* #580: widened for the enlarged sparkline */
 
 /* Visible: "●tonight" / "○low" indicator. */
 .alm-targets-col--visible { width: 8.5%; }
@@ -743,14 +743,44 @@
 /* task 5: add readable spacing between filter badges (was alm-sp-1 = 4px). */
 .alm-filter-badges { gap: var(--alm-sp-2); }
 
-/* ── task 19: sparkline size + time-axis ───────────────────────────────────
- * Make the sparkline shorter vertically (from 18 px → 14 px) and a touch
- * wider (from 64 px → 72 px) so the bottom time-axis ticks have headroom.
- * The SVG viewBox is updated in AltitudeSparkline.tsx to match. */
+/* ── task 19 / #580: sparkline size + time-axis ────────────────────────────
+ * #580: the row sparkline was too small to read. Enlarged from 72×22 → 96×34
+ * (wider curve, taller body) with twilight shading, an area fill, and a
+ * transit/max-altitude marker. The SVG viewBox (96×28) is set in
+ * AltitudeSparkline.tsx; CSS renders it at a legible pixel size. */
 
 .alm-targets-spark {
-  width: 72px;
-  height: 22px; /* taller than before to fit axis ticks below the curve */
+  width: 96px;
+  height: 34px; /* taller so the enlarged curve + axis ticks are readable */
+}
+
+/* #580: soft area fill under the curve — usable/low tinted via the state
+ * modifier classes below. */
+.alm-targets-spark__area {
+  fill: var(--alm-text-muted);
+  opacity: 0.1;
+  stroke: none;
+}
+.alm-targets-spark--usable .alm-targets-spark__area {
+  fill: var(--alm-accent);
+  opacity: 0.14;
+}
+
+/* #580: twilight (not-dark) shading either side of the astronomical dark
+ * window — the same twilight the detail-pane graph marks. */
+.alm-targets-spark__twilight {
+  fill: var(--alm-text-faint);
+  opacity: 0.12;
+  stroke: none;
+}
+
+/* #580: transit / max-altitude dot marker. */
+.alm-targets-spark__peak {
+  fill: var(--alm-text-muted);
+  stroke: none;
+}
+.alm-targets-spark--usable .alm-targets-spark__peak {
+  fill: var(--alm-accent);
 }
 
 /* task 19: axis tick lines (bottom of sparkline viewBox). */

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -744,15 +744,38 @@
 .alm-filter-badges { gap: var(--alm-sp-2); }
 
 /* ── task 19 / #580: sparkline size + time-axis ────────────────────────────
- * #580: the row sparkline was too small to read. Enlarged from 72×22 → 96×34
- * (wider curve, taller body) with twilight shading, an area fill, and a
+ * #580: the row sparkline was too small to read. Enlarged from 72×22 → 96px
+ * wide with a density-capped height, twilight shading, an area fill, and a
  * transit/max-altitude marker. The SVG viewBox (96×28) is set in
- * AltitudeSparkline.tsx; CSS renders it at a legible pixel size. */
+ * AltitudeSparkline.tsx; preserveAspectRatio=none stretches it to this box.
+ *
+ * HEIGHT INVARIANT (virtualizer, TargetsTable.tsx ROW_ESTIMATE): the sparkline
+ * must NEVER be the row-height driver. Rows are border-box
+ * `height: var(--alm-row-height)` minimums (24/32/40 per density) and this
+ * cell carries 1px vertical padding + 1px border-bottom, so the height budget
+ * is `--alm-row-height - 3px`. `min()` grows the curve to 28px where the
+ * density allows (comfortable: 28+2+1 = 31 ≤ 32; spacious: 31 ≤ 40) and caps
+ * it to exactly fill compact (21+2+1 = 24). A fixed height taller than that
+ * budget would inflate EVERY row past the fixed-estimate windowing math and
+ * override the user's density choice. */
 
 .alm-targets-spark {
   width: 96px;
-  height: 34px; /* taller so the enlarged curve + axis ticks are readable */
+  height: min(28px, calc(var(--alm-row-height) - 3px));
 }
+
+/* #580: tighter vertical padding than the 4px table default so the enlarged
+ * curve fits the comfortable (32px) row budget — see the invariant above. */
+.alm-targets-table td.alm-targets-cell--spark {
+  padding-top: 1px;
+  padding-bottom: 1px;
+}
+
+/* #579 review nit: persistent "twilight" visibility state — the target clears
+ * the usable altitude tonight but there is NO astronomical dark window
+ * (high-lat summer), so a plain "tonight" dot would overpromise. Amber to
+ * read as a caveat, distinct from --yes (ok) and --no (muted). */
+.alm-targets-vis--twilight { color: var(--alm-warn); }
 
 /* #580: soft area fill under the curve — usable/low tinted via the state
  * modifier classes below. */


### PR DESCRIPTION
Fixes #579, fixes #580.

## Summary
- The Targets "Visible" rating no longer reads the same for every target on nights with no astronomical darkness (high-latitude summer). Previously, because visibility was tied entirely to the astronomical dark window, a target transiting the zenith read identically to one that never rises. It now reflects whether the target actually clears the usable altitude tonight, so the rating varies by altitude year-round. Imaging time stays zero without astronomical darkness, and normal (dark) nights are unchanged.
- The per-row "Tonight" altitude graph was too small to read. It is now larger and wider, with a coloured line, a soft fill under the curve, shading for the twilight either side of the dark window, and a marker at the transit/highest point.

## Spec Context
Journey J09 (node nJ09c). Builds on #890's per-target row cache + chunked catalogue reveal; the visibility change introduces no new astronomy input, so the row-cache generation key is unchanged. Added unit + component tests for the no-dark-window discrimination; full desktop test suite, typecheck, and lint all clean.