### PR TITLE
chore(apm): pull in issue-driven journey-campaign mode

### DIFF
--- a/.agents/skills/journey-campaign/SKILL.md
+++ b/.agents/skills/journey-campaign/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: journey-campaign
 description: >-
-  Multi-journey validation campaign: fan out validators, dedupe findings, dispatch coder agents for regressions, re-validate until green or a hard stop.
+  Validation campaign at fleet scale, journey-driven or issue-driven: fan out validators, dedupe findings, dispatch coder agents, re-validate until green or a hard stop.
 ---
 
 # journey-campaign
@@ -11,16 +11,35 @@ journeys directory are normative; the fix-loop policy comes from README
 frontmatter (`fix_loop`, `fix_loop_max_iterations`) unless the invocation
 overrides it.
 
+## Mode
+
+Two entry points, one engine. Take the mode from the invocation; when
+unstated, infer it from the scope: a journey, a journey subset, or a diff
+→ journey-driven; a tracker query or a list of issues → issue-driven.
+
+- **journey-driven** (default) — the unit of work is a journey. Validate to
+  discover defects. Findings are **outputs**. Done when the journeys are
+  green.
+- **issue-driven** — the unit of work is a tracker issue that already
+  describes a defect. Findings are **inputs**. Fix first, then verify only
+  the steps that cover the issue. Done when the issues are verified and
+  closed.
+
+Everything after selection is shared: exclusive-profile serialization,
+validator agents, dedupe, the fix loop, hard stops, the report.
+
 ## Plan
 
-1. Select journeys: all `active` by default, or the user's subset, or a
-   `journey-verify-changed` scoping pass when the campaign is diff-driven.
+1. Select the unit of work: journeys (all `active` by default, or the
+   user's subset, or a `journey-verify-changed` scoping pass when the
+   campaign is diff-driven), or issues (a reporter query).
 2. Group by interface profile. Profiles with `exclusive: true` form a
    serial lane (one validator at a time — typically a single desktop app
    instance); the rest run in parallel.
-3. Announce the plan: journeys, lanes, fix-loop mode, iteration budget.
+3. Announce the plan: mode, journeys or issues, lanes, fix-loop mode,
+   iteration budget.
 
-## Validate (iteration 1)
+## Journey-driven campaign
 
 Spawn one `journey-validator` agent per journey with: journey path,
 journeys-dir path, mode (full or the scoped step set), and the resolved
@@ -37,25 +56,73 @@ and the coordinator appends them to TRACKER.md in one pass (github-issues
 validators may file directly). The coordinator owns the single reindex and
 the single journeys-dir commit per wave.
 
+Then run the fix loop over the `suspected-regression` findings.
+
+## Issue-driven campaign
+
+1. **Select** the issues from the reporter. Subtract any issue already
+   owned by an in-flight branch or PR — never double-assign a lane someone
+   else holds.
+2. **Map issue → journey + steps**, in precedence order: an explicit
+   journey/step trace in the issue body; the `journey-<n>` label; else the
+   product surface via README's surface map. The resulting step set **is**
+   the verification scope. The mapping is the campaign's own artifact:
+   where a label is missing but the mapping is certain, add it.
+   - **Unmapped issues are not skipped.** They are fixed like any other,
+     and the fixed behavior still gets an in-app check at the profile's
+     fidelity, recorded as an ad-hoc verification on the issue. Each one
+     also raises a **coverage proposal**: the existing journey plus the new
+     step it belongs in, or a new journey when several orphans share one
+     user goal. Proposals go to the human in the report — never author or
+     amend a journey to fit an issue you just fixed. That is self-review,
+     and it invents intent the user never stated.
+   - Issues with no user-observable behavior (refactors, tech debt) are
+     marked `no-journey-surface`: they verify on the repo's own gates
+     alone. Say so in the report; do not invent a journey for them.
+3. **Lane** the issues and dispatch per `fix_loop`. One lane per issue,
+   except that issues touching the same files share a lane — the lane is
+   the conflict unit, not the issue.
+4. **Verify in waves, batched by journey.** Verification is the scarce
+   resource on an `exclusive: true` profile; never spend one app session
+   per issue. Once a wave's fixes have merged, group the merged issues by
+   journey and spawn ONE validator per journey with
+   `changed-only(<union of the steps covering that wave's issues>)`.
+   Serialize those validators. A journey with no merged fixes is not
+   re-run.
+5. **Resolve per issue** from the wave's run file:
+   - pass → comment the evidence (steps run, expected vs observed, run-file
+     reference, fix commit or PR) on the issue, then close it.
+   - fail → the issue stays open; route the finding back to its lane per
+     the fix loop. One retry per issue, then hard-stop it and report.
+
+   A step covering several issues can fail for one and pass for the rest —
+   attribute per issue, not per step.
+6. **Bank the by-product.** A wave often ends up running every step of a
+   journey; when it does and all pass, that is a full run — promote
+   `draft` → `active` per FORMAT if the journey's Known gaps are all
+   user-confirmed.
+
 ## Fix loop
 
 Per `fix_loop` mode:
 
-- **report-only** — stop after iteration 1; report.
-- **dispatch-coder** (default) — for each unique `suspected-regression`:
-  dispatch a fresh coder agent (isolated worktree when parallel) with the
-  finding (journey/step, expected vs observed, evidence, repro steps) and
-  the repo's own gates (tests/lint) as its acceptance bar. The validator
-  never fixes product code; the coder never edits journeys. When fixes
-  land, re-validate **only** the failed journeys, scoped to failed/blocked
-  steps plus what is needed to reach them. Iterate.
+- **report-only** — stop after the first validation pass; report.
+- **dispatch-coder** (default) — for each unique `suspected-regression`
+  (journey-driven) or selected issue (issue-driven): dispatch a fresh coder
+  agent (isolated worktree when parallel) with the defect (journey/step,
+  expected vs observed, evidence, repro steps) and the repo's own gates
+  (tests/lint) as its acceptance bar. The validator never fixes product
+  code; the coder never edits journeys. When fixes land, re-validate
+  **only** the failed journeys, scoped to failed/blocked steps plus what is
+  needed to reach them. Iterate.
 - **fix-direct** — the campaign context fixes small regressions itself,
   then re-validates. Note in each finding that fixer and validator shared
   context (weakest evidence integrity; solo use).
 
 **Hard stops** — end the loop and hand to the human when:
 - iteration count reaches the budget (default 3),
-- the same finding fails again after a fix attempt (one retry per finding),
+- the same finding or issue fails again after a fix attempt (one retry
+  each),
 - a finding is triaged `product-question` — never auto-resolved; park it
   and continue the rest,
 - the environment breaks (env findings spike) — fix the harness or stop;
@@ -71,6 +138,9 @@ Single campaign report at the end:
   amendments with evidence),
 - findings: fixed (with fix commits/PRs), still open, parked
   product-questions needing decisions,
+- issue-driven also: issues closed with their evidence, issues still open
+  and why, coverage proposals awaiting a decision, and the
+  `no-journey-surface` set,
 - iterations used; what was NOT covered and why,
 - proposals: consolidation candidates (green journeys with Δ entries),
   coverage gaps, surface-map additions.

--- a/.claude/apm-hooks.json
+++ b/.claude/apm-hooks.json
@@ -1,67 +1,4 @@
 {
-  "PreToolUse": [
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".claude/hooks/hooks-quality/scripts/quality-before-commit.sh",
-          "if": "Bash(git commit*)",
-          "timeout": 10
-        }
-      ],
-      "_apm_source": "hooks-quality"
-    },
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".claude/hooks/release-please/scripts/release-please-guard.sh"
-        }
-      ],
-      "_apm_source": "release-please"
-    },
-    {
-      "matcher": "Skill",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".claude/hooks/speckit/scripts/speckit-context7-reminder.sh"
-        }
-      ],
-      "_apm_source": "speckit"
-    },
-    {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".claude/hooks/speckit/scripts/speckit-issue-close-guard.sh"
-        },
-        {
-          "type": "command",
-          "command": ".claude/hooks/speckit/scripts/speckit-issue-label-guard.sh"
-        },
-        {
-          "type": "command",
-          "command": ".claude/hooks/speckit/scripts/speckit-pr-issue-refs.sh"
-        }
-      ],
-      "_apm_source": "speckit"
-    },
-    {
-      "matcher": "apply_patch|Edit|Write|MultiEdit",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".claude/hooks/agent-coder/scripts/coder-delegation-reminder.sh",
-          "timeout": 3
-        }
-      ],
-      "_apm_source": "agent-coder"
-    }
-  ],
   "PostToolUse": [
     {
       "matcher": "apply_patch|Edit|Write|MultiEdit",
@@ -190,15 +127,67 @@
       "_apm_source": "speckit"
     }
   ],
-  "UserPromptSubmit": [
+  "PreToolUse": [
     {
+      "matcher": "Bash",
       "hooks": [
         {
           "type": "command",
-          "command": ".claude/hooks/speckit/scripts/speckit-deferred-issues.sh"
+          "command": ".claude/hooks/hooks-quality/scripts/quality-before-commit.sh",
+          "if": "Bash(git commit*)",
+          "timeout": 10
+        }
+      ],
+      "_apm_source": "hooks-quality"
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/speckit/scripts/speckit-issue-close-guard.sh"
+        },
+        {
+          "type": "command",
+          "command": ".claude/hooks/speckit/scripts/speckit-issue-label-guard.sh"
+        },
+        {
+          "type": "command",
+          "command": ".claude/hooks/speckit/scripts/speckit-pr-issue-refs.sh"
         }
       ],
       "_apm_source": "speckit"
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/release-please/scripts/release-please-guard.sh"
+        }
+      ],
+      "_apm_source": "release-please"
+    },
+    {
+      "matcher": "Skill",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/speckit/scripts/speckit-context7-reminder.sh"
+        }
+      ],
+      "_apm_source": "speckit"
+    },
+    {
+      "matcher": "apply_patch|Edit|Write|MultiEdit",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/agent-coder/scripts/coder-delegation-reminder.sh",
+          "timeout": 3
+        }
+      ],
+      "_apm_source": "agent-coder"
     }
   ],
   "Stop": [
@@ -217,21 +206,32 @@
       "hooks": [
         {
           "type": "command",
-          "command": ".claude/hooks/steering-pragmatic/scripts/inject-working-style.sh",
-          "timeout": 5
-        }
-      ],
-      "_apm_source": "steering-pragmatic"
-    },
-    {
-      "hooks": [
-        {
-          "type": "command",
           "command": ".claude/hooks/code-intelligence/scripts/subagent-context-inject.sh",
           "timeout": 5
         }
       ],
       "_apm_source": "code-intelligence"
+    },
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/steering-pragmatic/scripts/inject-working-style.sh",
+          "timeout": 5
+        }
+      ],
+      "_apm_source": "steering-pragmatic"
+    }
+  ],
+  "UserPromptSubmit": [
+    {
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/speckit/scripts/speckit-deferred-issues.sh"
+        }
+      ],
+      "_apm_source": "speckit"
     }
   ]
 }

--- a/.claude/skills/journey-campaign/SKILL.md
+++ b/.claude/skills/journey-campaign/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: journey-campaign
 description: >-
-  Multi-journey validation campaign: fan out validators, dedupe findings, dispatch coder agents for regressions, re-validate until green or a hard stop.
+  Validation campaign at fleet scale, journey-driven or issue-driven: fan out validators, dedupe findings, dispatch coder agents, re-validate until green or a hard stop.
 ---
 
 # journey-campaign
@@ -11,16 +11,35 @@ journeys directory are normative; the fix-loop policy comes from README
 frontmatter (`fix_loop`, `fix_loop_max_iterations`) unless the invocation
 overrides it.
 
+## Mode
+
+Two entry points, one engine. Take the mode from the invocation; when
+unstated, infer it from the scope: a journey, a journey subset, or a diff
+→ journey-driven; a tracker query or a list of issues → issue-driven.
+
+- **journey-driven** (default) — the unit of work is a journey. Validate to
+  discover defects. Findings are **outputs**. Done when the journeys are
+  green.
+- **issue-driven** — the unit of work is a tracker issue that already
+  describes a defect. Findings are **inputs**. Fix first, then verify only
+  the steps that cover the issue. Done when the issues are verified and
+  closed.
+
+Everything after selection is shared: exclusive-profile serialization,
+validator agents, dedupe, the fix loop, hard stops, the report.
+
 ## Plan
 
-1. Select journeys: all `active` by default, or the user's subset, or a
-   `journey-verify-changed` scoping pass when the campaign is diff-driven.
+1. Select the unit of work: journeys (all `active` by default, or the
+   user's subset, or a `journey-verify-changed` scoping pass when the
+   campaign is diff-driven), or issues (a reporter query).
 2. Group by interface profile. Profiles with `exclusive: true` form a
    serial lane (one validator at a time — typically a single desktop app
    instance); the rest run in parallel.
-3. Announce the plan: journeys, lanes, fix-loop mode, iteration budget.
+3. Announce the plan: mode, journeys or issues, lanes, fix-loop mode,
+   iteration budget.
 
-## Validate (iteration 1)
+## Journey-driven campaign
 
 Spawn one `journey-validator` agent per journey with: journey path,
 journeys-dir path, mode (full or the scoped step set), and the resolved
@@ -37,25 +56,73 @@ and the coordinator appends them to TRACKER.md in one pass (github-issues
 validators may file directly). The coordinator owns the single reindex and
 the single journeys-dir commit per wave.
 
+Then run the fix loop over the `suspected-regression` findings.
+
+## Issue-driven campaign
+
+1. **Select** the issues from the reporter. Subtract any issue already
+   owned by an in-flight branch or PR — never double-assign a lane someone
+   else holds.
+2. **Map issue → journey + steps**, in precedence order: an explicit
+   journey/step trace in the issue body; the `journey-<n>` label; else the
+   product surface via README's surface map. The resulting step set **is**
+   the verification scope. The mapping is the campaign's own artifact:
+   where a label is missing but the mapping is certain, add it.
+   - **Unmapped issues are not skipped.** They are fixed like any other,
+     and the fixed behavior still gets an in-app check at the profile's
+     fidelity, recorded as an ad-hoc verification on the issue. Each one
+     also raises a **coverage proposal**: the existing journey plus the new
+     step it belongs in, or a new journey when several orphans share one
+     user goal. Proposals go to the human in the report — never author or
+     amend a journey to fit an issue you just fixed. That is self-review,
+     and it invents intent the user never stated.
+   - Issues with no user-observable behavior (refactors, tech debt) are
+     marked `no-journey-surface`: they verify on the repo's own gates
+     alone. Say so in the report; do not invent a journey for them.
+3. **Lane** the issues and dispatch per `fix_loop`. One lane per issue,
+   except that issues touching the same files share a lane — the lane is
+   the conflict unit, not the issue.
+4. **Verify in waves, batched by journey.** Verification is the scarce
+   resource on an `exclusive: true` profile; never spend one app session
+   per issue. Once a wave's fixes have merged, group the merged issues by
+   journey and spawn ONE validator per journey with
+   `changed-only(<union of the steps covering that wave's issues>)`.
+   Serialize those validators. A journey with no merged fixes is not
+   re-run.
+5. **Resolve per issue** from the wave's run file:
+   - pass → comment the evidence (steps run, expected vs observed, run-file
+     reference, fix commit or PR) on the issue, then close it.
+   - fail → the issue stays open; route the finding back to its lane per
+     the fix loop. One retry per issue, then hard-stop it and report.
+
+   A step covering several issues can fail for one and pass for the rest —
+   attribute per issue, not per step.
+6. **Bank the by-product.** A wave often ends up running every step of a
+   journey; when it does and all pass, that is a full run — promote
+   `draft` → `active` per FORMAT if the journey's Known gaps are all
+   user-confirmed.
+
 ## Fix loop
 
 Per `fix_loop` mode:
 
-- **report-only** — stop after iteration 1; report.
-- **dispatch-coder** (default) — for each unique `suspected-regression`:
-  dispatch a fresh coder agent (isolated worktree when parallel) with the
-  finding (journey/step, expected vs observed, evidence, repro steps) and
-  the repo's own gates (tests/lint) as its acceptance bar. The validator
-  never fixes product code; the coder never edits journeys. When fixes
-  land, re-validate **only** the failed journeys, scoped to failed/blocked
-  steps plus what is needed to reach them. Iterate.
+- **report-only** — stop after the first validation pass; report.
+- **dispatch-coder** (default) — for each unique `suspected-regression`
+  (journey-driven) or selected issue (issue-driven): dispatch a fresh coder
+  agent (isolated worktree when parallel) with the defect (journey/step,
+  expected vs observed, evidence, repro steps) and the repo's own gates
+  (tests/lint) as its acceptance bar. The validator never fixes product
+  code; the coder never edits journeys. When fixes land, re-validate
+  **only** the failed journeys, scoped to failed/blocked steps plus what is
+  needed to reach them. Iterate.
 - **fix-direct** — the campaign context fixes small regressions itself,
   then re-validates. Note in each finding that fixer and validator shared
   context (weakest evidence integrity; solo use).
 
 **Hard stops** — end the loop and hand to the human when:
 - iteration count reaches the budget (default 3),
-- the same finding fails again after a fix attempt (one retry per finding),
+- the same finding or issue fails again after a fix attempt (one retry
+  each),
 - a finding is triaged `product-question` — never auto-resolved; park it
   and continue the rest,
 - the environment breaks (env findings spike) — fix the harness or stop;
@@ -71,6 +138,9 @@ Single campaign report at the end:
   amendments with evidence),
 - findings: fixed (with fix commits/PRs), still open, parked
   product-questions needing decisions,
+- issue-driven also: issues closed with their evidence, issues still open
+  and why, coverage proposals awaiting a decision, and the
+  `no-journey-surface` set,
 - iterations used; what was NOT covered and why,
 - proposals: consolidation candidates (green journeys with Δ entries),
   coverage gaps, surface-map additions.

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -1,11 +1,11 @@
 lockfile_version: '1'
-generated_at: '2026-07-14T18:15:34.512554+00:00'
+generated_at: '2026-07-15T06:55:29.040397+00:00'
 apm_version: 0.24.0
 dependencies:
 - repo_url: srobroek/agentic-packages
   name: core
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 7.0.1
   virtual_path: packages/core
@@ -16,7 +16,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: docs-architecture
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 2.0.0
   virtual_path: packages/docs-architecture
@@ -27,7 +27,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: frontend
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 3.0.0
   virtual_path: packages/frontend
@@ -38,7 +38,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: hooks-quality
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.2.1
   virtual_path: packages/hooks-quality
@@ -59,7 +59,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: language-rust
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 3.0.0
   virtual_path: packages/language-rust
@@ -70,7 +70,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: language-shell
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 2.0.1
   virtual_path: packages/language-shell
@@ -81,7 +81,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: language-typescript
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 3.0.0
   virtual_path: packages/language-typescript
@@ -92,7 +92,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-codebase-memory
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.0
   virtual_path: packages/mcp-codebase-memory
@@ -103,7 +103,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-context7
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.0
   virtual_path: packages/mcp-context7
@@ -114,7 +114,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-package-version
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.0
   virtual_path: packages/mcp-package-version
@@ -125,7 +125,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-playwright
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.0
   virtual_path: packages/mcp-playwright
@@ -136,7 +136,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-repomix
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.1
   virtual_path: packages/mcp-repomix
@@ -153,7 +153,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-serena
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.0
   virtual_path: packages/mcp-serena
@@ -164,7 +164,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: mcp-tauri
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.1.0
   virtual_path: packages/mcp-tauri
@@ -179,7 +179,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: orchestrate
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.0.0
   virtual_path: packages/orchestrate
@@ -298,7 +298,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: release-please
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.0.0
   virtual_path: packages/release-please
@@ -353,7 +353,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: speckit
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 5.0.0
   virtual_path: packages/speckit
@@ -446,7 +446,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-data
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.0.0
   virtual_path: packages/steering-data
@@ -461,7 +461,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-docs-specs
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 3.0.0
   virtual_path: packages/steering-docs-specs
@@ -476,7 +476,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-infrastructure
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 2.0.0
   virtual_path: packages/steering-infrastructure
@@ -491,7 +491,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-pragmatic
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 4.2.0
   virtual_path: packages/steering-pragmatic
@@ -510,7 +510,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-speckit
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 3.0.0
   virtual_path: packages/steering-speckit
@@ -525,7 +525,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-tools-scripts
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
   version: 1.0.0
   virtual_path: packages/steering-tools-scripts
@@ -540,9 +540,9 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: user-journeys
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: main
-  version: 0.1.0
+  version: 0.2.0
   virtual_path: packages/user-journeys
   is_virtual: true
   package_type: marketplace_plugin
@@ -588,7 +588,7 @@ dependencies:
   - .codex/agents/journey-scribe.toml
   - .codex/agents/journey-validator.toml
   deployed_file_hashes:
-    .agents/skills/journey-campaign/SKILL.md: sha256:654508222dccaa5949ca804c07147f8b55c8a6c99d14292759a72ddebe65f90d
+    .agents/skills/journey-campaign/SKILL.md: sha256:4cc7f7bacf1a22adbf6c5d25def41ea56d10a87daae19f03a054bf8f7ffb1f76
     .agents/skills/journey-consolidate/SKILL.md: sha256:3bca6aa058cc39ccd7fe9d0082c422490914789c7568bcba5d98db26cce39494
     .agents/skills/journey-init/SKILL.md: sha256:f5714db899199edb33d2128a410abfaf21c9dbef37a8e6364568bf4aa14607f3
     .agents/skills/journey-init/scripts/journeys.py: sha256:9f07c6b0164ab2549821c94c1b7878ecad4be70133a7827e0bca73ceafdf0e03
@@ -602,7 +602,7 @@ dependencies:
     .agents/skills/journey-write/SKILL.md: sha256:a82aca760281612ae40cabee990d8b1869dd2a1f533c5de70c3c9801f008bc2f
     .claude/agents/journey-scribe.md: sha256:70da1cecee16bec516853a9f7c6d4cc7903b32cb4e9558ad39b6c2a02ca5f58e
     .claude/agents/journey-validator.md: sha256:eb2a9ac51a75a1e6d5b8426f7641d21cb37d7b136027e3d3f343e939e94be360
-    .claude/skills/journey-campaign/SKILL.md: sha256:654508222dccaa5949ca804c07147f8b55c8a6c99d14292759a72ddebe65f90d
+    .claude/skills/journey-campaign/SKILL.md: sha256:4cc7f7bacf1a22adbf6c5d25def41ea56d10a87daae19f03a054bf8f7ffb1f76
     .claude/skills/journey-consolidate/SKILL.md: sha256:3bca6aa058cc39ccd7fe9d0082c422490914789c7568bcba5d98db26cce39494
     .claude/skills/journey-init/SKILL.md: sha256:f5714db899199edb33d2128a410abfaf21c9dbef37a8e6364568bf4aa14607f3
     .claude/skills/journey-init/scripts/journeys.py: sha256:9f07c6b0164ab2549821c94c1b7878ecad4be70133a7827e0bca73ceafdf0e03
@@ -616,7 +616,7 @@ dependencies:
     .claude/skills/journey-write/SKILL.md: sha256:a82aca760281612ae40cabee990d8b1869dd2a1f533c5de70c3c9801f008bc2f
     .codex/agents/journey-scribe.toml: sha256:fdb8d720900d67aa91edd4d9cc076bc3a5b2a851c9fe4fbdea6d36d98db3ec52
     .codex/agents/journey-validator.toml: sha256:5809177196fa6417c971d2a6acb42c0f8df58aa80a24b59142c7641c9593090c
-  content_hash: sha256:030a67be587e58ed9af5e53c08efbec042a72f2c82b9fcc753380d4af959b521
+  content_hash: sha256:f396525a34fca4ab692254a823bcdb0ed7b47ffebcc06e8d5ddc4f8babd37a92
   declared_license: Apache-2.0
 - repo_url: wshobson/agents
   name: database-design
@@ -1228,7 +1228,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: agentic-maintenance
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=4.0.0 <5.0.0'
   version: 4.0.0
   virtual_path: packages/agentic-maintenance
@@ -1241,7 +1241,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: code-intelligence
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=6.0.0 <7.0.0'
   version: 6.0.0
   virtual_path: packages/code-intelligence
@@ -1260,7 +1260,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: language-steering-rust
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/language-steering-rust
@@ -1273,7 +1273,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: language-steering-typescript
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/language-steering-typescript
@@ -1286,7 +1286,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: lsp-rust
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=0.2.0 <1.0.0'
   version: 0.2.0
   virtual_path: packages/lsp-rust
@@ -1299,7 +1299,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: lsp-shell
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=0.2.0 <1.0.0'
   version: 0.2.0
   virtual_path: packages/lsp-shell
@@ -1312,7 +1312,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: lsp-typescript
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=0.2.0 <1.0.0'
   version: 0.2.0
   virtual_path: packages/lsp-typescript
@@ -1325,7 +1325,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: playwright
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=3.0.0 <4.0.0'
   version: 3.0.0
   virtual_path: packages/playwright
@@ -1346,7 +1346,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: project-lifecycle
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=3.1.0 <4.0.0'
   version: 3.1.0
   virtual_path: packages/project-lifecycle
@@ -1359,8 +1359,8 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: resume-session
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
-  resolved_ref: '>=2.0.0 <3.0.0'
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
+  resolved_ref: '>=2.0.1 <3.0.0'
   version: 2.0.1
   virtual_path: packages/resume-session
   is_virtual: true
@@ -1400,7 +1400,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: rust-quality
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/rust-quality
@@ -1433,7 +1433,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-delivery
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=1.0.0 <2.0.0'
   version: 1.0.0
   virtual_path: packages/steering-delivery
@@ -1450,7 +1450,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-frontend
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/steering-frontend
@@ -1469,7 +1469,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: typescript-quality
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/typescript-quality
@@ -2050,7 +2050,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: agent-coder
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=4.0.0 <5.0.0'
   version: 4.0.0
   virtual_path: packages/agent-coder
@@ -2079,7 +2079,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: agent-pr-reviewer
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/agent-pr-reviewer
@@ -2096,7 +2096,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: audit-steering
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/audit-steering
@@ -2133,7 +2133,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: catchup
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/catchup
@@ -2158,7 +2158,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: codebase-memory
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/codebase-memory
@@ -2195,7 +2195,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: handover
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/handover
@@ -2228,7 +2228,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-git-workflow
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.1.0 <3.0.0'
   version: 2.1.0
   virtual_path: packages/steering-git-workflow
@@ -2245,7 +2245,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: steering-project-structure
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=1.0.0 <2.0.0'
   version: 1.0.0
   virtual_path: packages/steering-project-structure
@@ -2262,7 +2262,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: verify
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/verify
@@ -2287,7 +2287,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: web-fetch
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=2.0.0 <3.0.0'
   version: 2.0.0
   virtual_path: packages/web-fetch
@@ -2312,7 +2312,7 @@ dependencies:
 - repo_url: srobroek/agentic-packages
   name: write-agentic
   host: github.com
-  resolved_commit: 57999765c239a322883d662545ab1b2739f19792
+  resolved_commit: 72b2a244049737acdfedf85ba1dcd623124bfb4f
   resolved_ref: '>=3.1.0 <4.0.0'
   version: 3.1.0
   virtual_path: packages/write-agentic


### PR DESCRIPTION
Propagates journey-campaign skill from agentic-packages PR #534, which introduces issue-driven campaign validation modes.

This is an APM-installed dependency update per `apm.yml` pinning of `srobroek/agentic-packages/packages/user-journeys#main`.