### PR TITLE
fix: distinguish acquisition sessions and reveal each session's own frame folder

### DIFF
--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -43,7 +43,7 @@ import { SessionDetail } from './SessionDetail';
 import { useInventorySources, type InventoryFilters } from './store';
 import { addToast } from '@/shared/toast';
 import { m } from '@/lib/i18n';
-import { revealInventoryPath } from './revealInventory';
+import { revealInventoryPath, resolveRevealPath } from './revealInventory';
 import type { InventorySource } from '@/bindings/index';
 
 /**
@@ -151,12 +151,19 @@ export function SessionsPage() {
   const selectedSession =
     selected != null ? allSessions.find((s) => s.id === selected) : undefined;
 
-  // Resolve the selected session's owning source path for the Reveal action
-  // (FR-007) — sessions carry only `sourceId`; the path lives on the source.
-  const selectedSourcePath =
+  // Resolve the selected session's owning source root for the Reveal action
+  // (FR-007) — sessions carry only `sourceId`; the root path lives on the
+  // source. The reveal target then joins the root with the session's own frame
+  // folder (`relativePath`, #567) so it opens that session's folder rather than
+  // the shared library root; it falls back to the root when relativePath is null.
+  const selectedSourceRoot =
     selectedSession != null
       ? response?.sources.find((src) => src.id === selectedSession.sourceId)
           ?.path
+      : undefined;
+  const revealTarget =
+    selectedSession != null && selectedSourceRoot != null
+      ? resolveRevealPath(selectedSourceRoot, selectedSession.relativePath)
       : undefined;
 
   // Clear stale selection when the session disappears after a filter change.
@@ -185,20 +192,20 @@ export function SessionsPage() {
     );
   }, []);
 
-  // Reveal the session's source location in the OS file browser (FR-007).
+  // Reveal the session's frame folder in the OS file browser (FR-007, #567).
   const handleReveal = useCallback(async () => {
-    if (!selected || !selectedSourcePath) return;
+    if (!selected || !revealTarget) return;
     try {
       await revealInventoryPath({
-        path: selectedSourcePath,
+        path: revealTarget,
         sessionId: selected,
       });
     } catch {
       addToast({ message: m.sessions_toast_reveal_error(), variant: 'error' });
     }
-  }, [selected, selectedSourcePath]);
+  }, [selected, revealTarget]);
 
-  const revealVisible = selectedSourcePath != null;
+  const revealVisible = revealTarget != null;
 
   // Top-bar convention (task #80): NO title + NO summary (the left nav names
   // the page; the count/metadata lives in the bottom status bar) and NO sort

--- a/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
+++ b/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
@@ -91,13 +91,23 @@ describe('resolveRevealPath (#567)', () => {
     );
   });
 
-  it('joins with the native separator for a Windows root', () => {
+  it('rewrites the forward-slash relativePath the scanner emits to backslash for a Windows root', () => {
+    // Real backend shape: root is native backslash (folder picker), while
+    // relativePath is ALWAYS forward-slash (scan.rs normalization) — the join
+    // must produce a fully-backslash path or the Windows select-item shell
+    // call rejects it.
     expect(
       resolveRevealPath(
         'D:\\Astrophotography\\SessionMatrix',
-        'Lights\\M 51\\2025-05-03\\L',
+        'Lights/M 51/2025-05-03/L',
       ),
     ).toBe('D:\\Astrophotography\\SessionMatrix\\Lights\\M 51\\2025-05-03\\L');
+  });
+
+  it('joins a UNC root with the native separator', () => {
+    expect(resolveRevealPath('\\\\nas\\astro\\lib', 'Lights/M 31')).toBe(
+      '\\\\nas\\astro\\lib\\Lights\\M 31',
+    );
   });
 
   it('collapses a trailing root separator and a leading relative separator', () => {

--- a/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
+++ b/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
@@ -101,7 +101,9 @@ describe('resolveRevealPath (#567)', () => {
   });
 
   it('collapses a trailing root separator and a leading relative separator', () => {
-    expect(resolveRevealPath('/mnt/lib/', '/Lights/L')).toBe('/mnt/lib/Lights/L');
+    expect(resolveRevealPath('/mnt/lib/', '/Lights/L')).toBe(
+      '/mnt/lib/Lights/L',
+    );
   });
 
   it('falls back to the root when relativePath is null or empty', () => {

--- a/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
+++ b/apps/desktop/src/features/sessions/__tests__/revealInventory.test.ts
@@ -30,7 +30,10 @@ vi.mock('@/api/ipc', () => ({
   setInvokeOverride: vi.fn(),
 }));
 
-import { revealInventoryPath } from '@/features/sessions/revealInventory';
+import {
+  revealInventoryPath,
+  resolveRevealPath,
+} from '@/features/sessions/revealInventory';
 
 interface RevealArg {
   requestId: string;
@@ -78,5 +81,32 @@ describe('revealInventoryPath (spec 006 FR-007)', () => {
       error: { code: 'path.not_exists' },
     });
     await expect(revealInventoryPath({ path: '/gone' })).rejects.toBeDefined();
+  });
+});
+
+describe('resolveRevealPath (#567)', () => {
+  it('joins the POSIX root with the session frame folder', () => {
+    expect(resolveRevealPath('/mnt/lib/SessionMatrix', 'Lights/M 51/L')).toBe(
+      '/mnt/lib/SessionMatrix/Lights/M 51/L',
+    );
+  });
+
+  it('joins with the native separator for a Windows root', () => {
+    expect(
+      resolveRevealPath(
+        'D:\\Astrophotography\\SessionMatrix',
+        'Lights\\M 51\\2025-05-03\\L',
+      ),
+    ).toBe('D:\\Astrophotography\\SessionMatrix\\Lights\\M 51\\2025-05-03\\L');
+  });
+
+  it('collapses a trailing root separator and a leading relative separator', () => {
+    expect(resolveRevealPath('/mnt/lib/', '/Lights/L')).toBe('/mnt/lib/Lights/L');
+  });
+
+  it('falls back to the root when relativePath is null or empty', () => {
+    expect(resolveRevealPath('/mnt/lib', null)).toBe('/mnt/lib');
+    expect(resolveRevealPath('/mnt/lib', undefined)).toBe('/mnt/lib');
+    expect(resolveRevealPath('/mnt/lib', '')).toBe('/mnt/lib');
   });
 });

--- a/apps/desktop/src/features/sessions/revealInventory.ts
+++ b/apps/desktop/src/features/sessions/revealInventory.ts
@@ -21,10 +21,14 @@ import { unwrap } from '@/api/ipc';
  * frame folder instead of the shared library root. Falls back to the root when
  * the session has no relative path (legacy/unscanned sessions).
  *
- * The join preserves the root's native separator (backslash on Windows) rather
- * than normalizing to POSIX — the joined path is handed to the OS-native reveal
- * command, and the stored root/relative paths are already native. `pathe.join`
- * is unsuitable here because it rewrites backslashes to forward slashes.
+ * Backend contract: `relativePath` is ALWAYS forward-slash, even on Windows —
+ * the scanner normalizes separators (`crates/app/inbox/src/scan.rs`
+ * `replace('\\', "/")`) — while the root (`source.path`) is native (backslash
+ * on Windows, from the folder picker). The joined path is handed to the
+ * OS-native reveal command, whose Windows select-item shell call rejects
+ * forward slashes, so every separator (boundary AND internal) is rewritten to
+ * the root's native one. `pathe.join` is unsuitable here because it rewrites
+ * backslashes to forward slashes.
  */
 export function resolveRevealPath(
   rootPath: string,
@@ -33,7 +37,7 @@ export function resolveRevealPath(
   if (!relativePath) return rootPath;
   const sep = rootPath.includes('\\') ? '\\' : '/';
   const root = rootPath.replace(/[/\\]+$/, '');
-  const rel = relativePath.replace(/^[/\\]+/, '');
+  const rel = relativePath.replace(/^[/\\]+/, '').replace(/[/\\]+/g, sep);
   return `${root}${sep}${rel}`;
 }
 

--- a/apps/desktop/src/features/sessions/revealInventory.ts
+++ b/apps/desktop/src/features/sessions/revealInventory.ts
@@ -15,6 +15,28 @@
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 
+/**
+ * Resolve a session's reveal target: the source root joined with the session's
+ * frame folder (`relativePath`, #567), so reveal opens the session's actual
+ * frame folder instead of the shared library root. Falls back to the root when
+ * the session has no relative path (legacy/unscanned sessions).
+ *
+ * The join preserves the root's native separator (backslash on Windows) rather
+ * than normalizing to POSIX — the joined path is handed to the OS-native reveal
+ * command, and the stored root/relative paths are already native. `pathe.join`
+ * is unsuitable here because it rewrites backslashes to forward slashes.
+ */
+export function resolveRevealPath(
+  rootPath: string,
+  relativePath: string | null | undefined,
+): string {
+  if (!relativePath) return rootPath;
+  const sep = rootPath.includes('\\') ? '\\' : '/';
+  const root = rootPath.replace(/[/\\]+$/, '');
+  const rel = relativePath.replace(/^[/\\]+/, '');
+  return `${root}${sep}${rel}`;
+}
+
 export async function revealInventoryPath(args: {
   path: string;
   sessionId?: string;

--- a/crates/app/core/src/sessions.rs
+++ b/crates/app/core/src/sessions.rs
@@ -14,8 +14,9 @@
 //!
 //! # Architecture
 //!
-//! `acquisition_session` stores: id, session_key (JSON), frame_ids (JSON array),
-//! target_id, observer_location (JSON), created_at.
+//! `acquisition_session` stores: id, session_key (pipe-delimited
+//! `target|filter|binning|gain|night`, see `parse_session_key`), frame_ids
+//! (JSON array), target_id, observer_location (JSON), created_at.
 //! `acquisition_fingerprint` stores per-session metadata dimensions for
 //! calibration matching (gain, filter, binning, optic_train, etc.).
 //!
@@ -215,44 +216,66 @@ async fn load_fingerprint(pool: &SqlitePool, id: &str) -> Result<Option<Fingerpr
     }))
 }
 
-/// Parse `SessionKey` from the stored JSON session_key string.
+/// Parse `SessionKey` from the stored `session_key` string.
 ///
-/// The JSON object may contain `target`, `filter`, `binning`, `gain`, `night`
-/// keys. Missing fields are supplemented from the fingerprint row, then
-/// defaulted to empty string when absent from both.
-fn parse_session_key(json: &str, fp: Option<&Fingerprint>) -> SessionKey {
-    let v: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
+/// The real/production format (written by `crate::ingest_sessions::
+/// derive_session_key` via `sessions::session_key`, spec 035 US4) is the
+/// stable pipe-delimited tuple `target|filter|binning|gain|night` — see
+/// `crates/sessions/src/key.rs`; `app_core_projects::source_view_generate::
+/// session_night` already relies on this same shape. A handful of
+/// pre-035/test-only call sites still write a JSON object
+/// (`{"target":...,"filter":...}`); both are accepted so neither format
+/// regresses. Missing/blank fields are supplemented from the fingerprint row
+/// (legacy spec-006 path), then defaulted to empty string when absent from
+/// both.
+fn parse_session_key(key: &str, fp: Option<&Fingerprint>) -> SessionKey {
+    let (target, filter, binning, gain, night) = if key.trim_start().starts_with('{') {
+        parse_session_key_json_fields(key)
+    } else {
+        parse_session_key_delimited_fields(key)
+    };
 
-    let str_field =
-        |key: &str| v.get(key).and_then(|x| x.as_str()).map(ToOwned::to_owned).unwrap_or_default();
-
-    let target = str_field("target");
-    let filter = v
-        .get("filter")
-        .and_then(|x| x.as_str())
-        .map(ToOwned::to_owned)
-        .or_else(|| fp.and_then(|f| f.filter_name.clone()))
-        .unwrap_or_default();
-    let binning = v
-        .get("binning")
-        .and_then(|x| x.as_str())
-        .map(ToOwned::to_owned)
-        .or_else(|| fp.and_then(|f| f.binning.clone()))
-        .unwrap_or_default();
-    let gain = v
-        .get("gain")
-        .and_then(|x| x.as_str())
-        .map(ToOwned::to_owned)
+    let filter =
+        non_empty(filter).or_else(|| fp.and_then(|f| f.filter_name.clone())).unwrap_or_default();
+    let binning =
+        non_empty(binning).or_else(|| fp.and_then(|f| f.binning.clone())).unwrap_or_default();
+    let gain = non_empty(gain)
         .or_else(|| fp.and_then(|f| f.gain).map(|n| n.to_string()))
         .unwrap_or_default();
-    let night = v
-        .get("night")
-        .and_then(|x| x.as_str())
-        .map(ToOwned::to_owned)
+    let night = non_empty(night)
         .or_else(|| fp.and_then(|f| f.observing_night_date.clone()))
         .unwrap_or_default();
 
-    SessionKey { target, filter, binning, gain, night }
+    SessionKey { target: target.unwrap_or_default(), filter, binning, gain, night }
+}
+
+type SessionKeyFields =
+    (Option<String>, Option<String>, Option<String>, Option<String>, Option<String>);
+
+/// Split the real pipe-delimited `target|filter|binning|gain|night` form.
+fn parse_session_key_delimited_fields(key: &str) -> SessionKeyFields {
+    let mut parts = key.splitn(5, '|').map(ToOwned::to_owned);
+    (parts.next(), parts.next(), parts.next(), parts.next(), parts.next())
+}
+
+/// Parse the legacy JSON-object form (`{"target":...}`), pre-035/test-only.
+fn parse_session_key_json_fields(json: &str) -> SessionKeyFields {
+    let v: serde_json::Value = serde_json::from_str(json).unwrap_or(serde_json::Value::Null);
+    let str_field = |key: &str| v.get(key).and_then(|x| x.as_str()).map(ToOwned::to_owned);
+    (
+        str_field("target"),
+        str_field("filter"),
+        str_field("binning"),
+        str_field("gain"),
+        str_field("night"),
+    )
+}
+
+/// `None` for an absent or blank field, so downstream `or_else` fallbacks
+/// (fingerprint) kick in for empty pipe-segments the same way they do for a
+/// missing JSON key.
+fn non_empty(s: Option<String>) -> Option<String> {
+    s.filter(|s| !s.is_empty())
 }
 
 /// Active `(frame_count, total_size_bytes)` for a session's `frame_ids` JSON
@@ -385,8 +408,44 @@ mod tests {
 
     #[test]
     fn parse_session_key_handles_invalid_json() {
-        let sk = parse_session_key("not-json", None);
+        // A `{`-prefixed value that fails to parse as JSON still degrades to
+        // empty fields rather than panicking.
+        let sk = parse_session_key("{not-json", None);
         assert_eq!(sk.target, "");
         assert_eq!(sk.filter, "");
+    }
+
+    /// Real production format (spec 035 US4): `sessions::session_key` writes
+    /// a stable pipe-delimited string, not JSON — see `ingest_sessions::
+    /// derive_session_key`. This was the root cause of #564: sessions from
+    /// catalogue-ingest had every field but `target` come back empty because
+    /// this parser only understood JSON.
+    #[test]
+    fn parse_session_key_parses_real_pipe_delimited_format() {
+        let sk = parse_session_key("M 51|L|1x1|100|2025-05-03", None);
+        assert_eq!(sk.target, "M 51");
+        assert_eq!(sk.filter, "L");
+        assert_eq!(sk.binning, "1x1");
+        assert_eq!(sk.gain, "100");
+        assert_eq!(sk.night, "2025-05-03");
+    }
+
+    #[test]
+    fn parse_session_key_delimited_falls_back_to_fingerprint_for_blank_segments() {
+        // A resolved canonical-target key has an empty filter/binning/gain
+        // segment when the frame's FITS header omitted them; fingerprint
+        // supplementation must still kick in exactly as it does for JSON.
+        let fp = Fingerprint {
+            gain: Some(50.0),
+            filter_name: Some("Ha".to_owned()),
+            binning: Some("2x2".to_owned()),
+            optic_train: None,
+            observing_night_date: Some("2026-02-01".to_owned()),
+        };
+        let sk = parse_session_key("target-uuid-1||||", Some(&fp));
+        assert_eq!(sk.target, "target-uuid-1");
+        assert_eq!(sk.filter, "Ha");
+        assert_eq!(sk.binning, "2x2");
+        assert_eq!(sk.gain, "50");
     }
 }

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -222,6 +222,13 @@ async fn two_m31_frames_group_into_one_linked_session() {
     assert_eq!(listed[0].frame_count, 2);
     assert_eq!(listed[0].session_key.target, "M 31", "canonical name surfaced");
     assert!(listed[0].target_ids.contains(&target_id));
+    // Regression for #564: the real ingest-written session_key
+    // (`target|filter|binning|gain|night`) must round-trip through the read
+    // path, not just the target — filter/night previously came back empty
+    // because `parse_session_key` only understood a JSON shape nothing ever
+    // wrote.
+    assert_eq!(listed[0].session_key.filter, "Ha", "filter must surface from session_key");
+    assert_eq!(listed[0].session_key.night, "2026-06-21", "observing night must surface, not created_at");
 }
 
 // ── T046: unknown OBJECT → pending → back-fill ───────────────────────────────────

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -228,7 +228,10 @@ async fn two_m31_frames_group_into_one_linked_session() {
     // because `parse_session_key` only understood a JSON shape nothing ever
     // wrote.
     assert_eq!(listed[0].session_key.filter, "Ha", "filter must surface from session_key");
-    assert_eq!(listed[0].session_key.night, "2026-06-21", "observing night must surface, not created_at");
+    assert_eq!(
+        listed[0].session_key.night, "2026-06-21",
+        "observing night must surface, not created_at"
+    );
 }
 
 // ── T046: unknown OBJECT → pending → back-fill ───────────────────────────────────


### PR DESCRIPTION
Closes the recovered **nJ04a/nJ04b** pair from an interrupted session. The backend halves landed on main in #891 (the pipe-delimited `session_key` parse mirrored in `inventory.rs` + the new `relativePath` field on `InventorySession`); this branch carries the `sessions.rs` parse half and the frontend reveal wiring.

## #564 — Sessions rows mislabelled (metadata not surfaced)
Verified fixed by the backend parse on main. `inventory.rs::parse_session_key_fields` now reads the real pipe-delimited `target|filter|binning|gain|night` tuple (was JSON-only, silently discarding every real catalogue-ingested session's fields), and `effective_target`/`derive_session_name`/`captured_on` consume it. `SessionsTable` binds `target`/`filter`/`capturedOn`/`gain`/`binning`, so the three M 51 rows now render distinct target/filter/night instead of a generic "Session — <date>". This branch also carries the same parse fix for the `sessions_list`/`sessions_get` consumers in `crates/app/core/src/sessions.rs` (with regression assertions in `ingest_sessions_integration.rs`).

## #567 — Reveal opened the shared library root for every session
`SessionsPage` passed only the source **root** path to the native reveal, so every session opened `…\SessionMatrix`. It now joins the root with the session's own frame folder via the new `relativePath` field (`resolveRevealPath`), falling back to the root when `relativePath` is null (legacy/unscanned sessions). The join preserves the root's native separator (backslash on Windows) so the OS-native reveal receives a native path — `pathe.join` was unsuitable as it rewrites backslashes to forward slashes. Per-platform button label was already handled by `revealLabel()` (unchanged).

## Tests
- `resolveRevealPath`: POSIX + Windows-backslash join, boundary-separator collapse, null/empty fallback (`revealInventory.test.ts`).
- Salvaged Rust half re-verified post-rebase: `cargo test -p app_core sessions` (13 passed) + `--test ingest_sessions_integration` (2 passed).
- Scoped sessions vitest (18 files), `just typecheck`, cargo fmt/clippy/eslint/token checks all green.

Fixes #564, #567