### PR TITLE
fix: show organization state in setup wizard Confirm summary

### DIFF
--- a/apps/desktop/src/features/setup/steps/StepConfirm.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepConfirm.test.tsx
@@ -1,0 +1,56 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * StepConfirm tests — first-run wizard Confirm summary (issue #515).
+ *
+ * Covers: each source row shows both organization state (organized/
+ * unorganized) and scan depth, not scan depth alone.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { StepConfirm } from './StepConfirm';
+import type { SourcesState } from '../sources-store';
+import type { CatalogSettings } from './StepCatalogs';
+import type { ToolsState } from './StepTools';
+
+const CATALOG_SETTINGS: CatalogSettings = { downloadAll: false };
+const TOOLS: ToolsState = {
+  pixinsight: { enabled: false, path: '' },
+  siril: { enabled: false, path: '' },
+};
+
+describe('StepConfirm', () => {
+  it('shows organization state alongside scan depth for each source row', () => {
+    const sources: SourcesState = [
+      {
+        path: '/astro/lights',
+        kind: 'light_frames',
+        scanDepth: 'recursive',
+        organizationState: 'organized',
+      },
+      {
+        path: '/astro/inbox',
+        kind: 'inbox',
+        scanDepth: 'recursive',
+        organizationState: 'unorganized',
+      },
+    ];
+
+    render(
+      <StepConfirm
+        sources={sources}
+        catalogSettings={CATALOG_SETTINGS}
+        tools={TOOLS}
+        isSubmitting={false}
+      />,
+    );
+
+    expect(screen.getByText('Already organized')).toBeInTheDocument();
+    expect(screen.getByText('Needs organizing')).toBeInTheDocument();
+    expect(screen.getAllByText('Recursive')).toHaveLength(2);
+  });
+});

--- a/apps/desktop/src/features/setup/steps/StepConfirm.tsx
+++ b/apps/desktop/src/features/setup/steps/StepConfirm.tsx
@@ -81,6 +81,11 @@ export function StepConfirm({
                       {entry.path}
                     </span>
                     <span className="alm-setup-confirm__scan-depth">
+                      {entry.organizationState === 'organized'
+                        ? m.setup_sources_org_organized()
+                        : m.setup_sources_org_unorganized()}
+                    </span>
+                    <span className="alm-setup-confirm__scan-depth">
                       {entry.scanDepth === 'recursive'
                         ? m.setup_scan_recursive()
                         : m.setup_scan_single_level()}


### PR DESCRIPTION
## Summary
- The Confirm step of first-run setup listed each folder's scan depth but not whether it was marked organized or unorganized, so users couldn't verify that setting before finishing setup.

Fixes #515

## Spec Context
- Branch: fix/jc0714-nJ01f