### PR TITLE
fix: log level filter now shows selected severity and above

### DIFF
--- a/apps/desktop/src/app/LogPanel.test.tsx
+++ b/apps/desktop/src/app/LogPanel.test.tsx
@@ -146,6 +146,52 @@ describe('LogPanel expand/collapse + filters (T006)', () => {
     expect(screen.queryByText('All good')).not.toBeInTheDocument();
   });
 
+  it('treats a level chip as a severity floor, not an exact match (#582)', async () => {
+    seedEntries();
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('Something failed')).toBeInTheDocument();
+    });
+
+    // Click the "Warn" chip — warn is less severe than error, so both the
+    // warn and error entries should remain visible; info should not.
+    const warnChip = screen.getByRole('button', { name: 'Warn' });
+    fireEvent.click(warnChip);
+
+    await waitFor(() => {
+      expect(warnChip).toHaveAttribute('aria-pressed', 'true');
+    });
+
+    expect(screen.getByText('Something failed')).toBeInTheDocument();
+    expect(screen.getByText('Watch out')).toBeInTheDocument();
+    expect(screen.queryByText('All good')).not.toBeInTheDocument();
+  });
+
+  it('renders entity subject context next to the message (#583)', async () => {
+    appendLog([
+      {
+        id: 'aud:4',
+        contractVersion: '1',
+        time: '2026-01-01T00:00:03Z',
+        level: 'info',
+        source: 'target',
+        message: 'Target metadata resolved',
+        entityType: 'target',
+        entityId: 'm31',
+      },
+    ]);
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('Target metadata resolved')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('target · m31')).toBeInTheDocument();
+  });
+
   it('interpolates the source into the event-source modifier className', async () => {
     seedEntries();
     renderPanel();

--- a/apps/desktop/src/app/LogPanel.tsx
+++ b/apps/desktop/src/app/LogPanel.tsx
@@ -5,7 +5,9 @@
  * Bottom log panel (spec 019).
  *
  * - Full-width fold-out driven by `LogPanelContext`.
- * - Level filter chips (session-only, resets to 'all' on open).
+ * - Level filter chips (session-only, resets to 'all' on open). Selecting a
+ *   level is a severity floor — it shows that level and everything more
+ *   severe, not an exact match (#582).
  * - Follow-tail toggle (persisted via `rememberFollowLogs` setting).
  * - Diagnostics toggle (gated by `logLevel === "debug"`).
  * - Cross-link: clicking a row with `entityType` + `entityId` navigates to
@@ -52,9 +54,19 @@ const LEVEL_CHIPS: { value: LevelFilter; label: () => string }[] = [
   { value: 'debug', label: () => m.settings_advanced_log_debug() },
 ];
 
+// Severity order (ascending). A level-chip selection is a floor: choosing
+// e.g. "warn" shows warn AND error, matching conventional log-viewer
+// semantics rather than an exact-level match (#582).
+const LEVEL_SEVERITY: Record<LogLevel, number> = {
+  debug: 0,
+  info: 1,
+  warn: 2,
+  error: 3,
+};
+
 function passesLevelFilter(entryLevel: LogLevel, filter: LevelFilter): boolean {
   if (filter === 'all') return true;
-  return entryLevel === filter;
+  return LEVEL_SEVERITY[entryLevel] >= LEVEL_SEVERITY[filter];
 }
 
 function passesSourceFilter(
@@ -453,6 +465,13 @@ function LogEntryRow({
 }: LogEntryRowProps) {
   const hasEntityLink = entry.entityType != null && entry.entityId != null;
   const hasAuditLink = entry.requestId != null && !hasEntityLink;
+  // Subject context (#583): the entity/request the line is about, surfaced
+  // as visible text rather than only implied by the click-to-navigate arrow.
+  const contextLabel = hasEntityLink
+    ? `${entry.entityType} · ${entry.entityId}`
+    : hasAuditLink
+      ? entry.requestId
+      : null;
 
   const handleClick = useCallback(() => {
     if (hasEntityLink && entry.entityType && entry.entityId) {
@@ -509,6 +528,11 @@ function LogEntryRow({
       >
         {entry.source}
       </span>
+      {contextLabel && (
+        <span className="alm-logpanel__event-context" title={contextLabel}>
+          {contextLabel}
+        </span>
+      )}
       <span className="alm-logpanel__event-msg">{entry.message}</span>
       {hasEntityLink && (
         <span className="alm-logpanel__event-link-indicator" aria-hidden="true">


### PR DESCRIPTION
## Summary
- Log panel level filter now shows the selected severity and everything more severe (e.g. selecting Warn also shows Error), instead of only that exact level.
- Log rows now show the entity or request they relate to as visible text, so it's clear what a log line is about without guessing.

Fixes #582
Fixes #583

## Test plan
- [x] `pnpm -C apps/desktop vitest run src/app/LogPanel.test.tsx src/app/LogPanel.followScroll.test.tsx` (8/8 pass, incl. 2 new tests)
- [x] `just typecheck`
- [x] `pnpm -C apps/desktop lint` (0 errors; 1 pre-existing unrelated warning)

## Spec Context
- Branch: fix/jc0714-nJ10b