### PR TITLE
fix(setup): require site name once coordinates are entered in wizard

### DIFF
--- a/apps/desktop/src/features/setup/steps/StepSite.test.ts
+++ b/apps/desktop/src/features/setup/steps/StepSite.test.ts
@@ -1,0 +1,74 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * StepSite validation tests — first-run wizard "Observing Site" step.
+ *
+ * Covers `siteStepError`/`siteStepHasSite` field-combination behavior,
+ * including the empty-name-with-valid-coordinates case (#516): the step is
+ * optional when fully blank, but once coordinates are entered a name is
+ * required so the site isn't silently dropped at Finish.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  DEFAULT_SITE_STEP_STATE,
+  siteStepError,
+  siteStepHasSite,
+  type SiteStepState,
+} from './StepSite';
+import { m } from '@/lib/i18n';
+
+function state(overrides: Partial<SiteStepState>): SiteStepState {
+  return { ...DEFAULT_SITE_STEP_STATE, ...overrides };
+}
+
+describe('siteStepError', () => {
+  it('is valid (null) when the step is entirely blank', () => {
+    expect(siteStepError(state({}))).toBeNull();
+  });
+
+  it('requires a name once valid coordinates are entered (#516)', () => {
+    const s = state({ latitudeDegText: '51.5', longitudeDegText: '-0.13' });
+    expect(siteStepError(s)).toBe(m.settings_observing_sites_error_name());
+  });
+
+  it('is valid once a name is added alongside valid coordinates', () => {
+    const s = state({
+      name: 'Home Backyard',
+      latitudeDegText: '51.5',
+      longitudeDegText: '-0.13',
+    });
+    expect(siteStepError(s)).toBeNull();
+  });
+
+  it('does not require a name when coordinates are still incomplete', () => {
+    const s = state({ latitudeDegText: '51.5' });
+    expect(siteStepError(s)).toBeNull();
+  });
+
+  it('still range-validates latitude once a name is present', () => {
+    const s = state({
+      name: 'Home Backyard',
+      latitudeDegText: '200',
+      longitudeDegText: '-0.13',
+    });
+    expect(siteStepError(s)).toBe(m.settings_observing_sites_error_latitude());
+  });
+});
+
+describe('siteStepHasSite', () => {
+  it('is false when the name is missing even with valid coordinates', () => {
+    const s = state({ latitudeDegText: '51.5', longitudeDegText: '-0.13' });
+    expect(siteStepHasSite(s)).toBe(false);
+  });
+
+  it('is true once name, latitude, and longitude are all filled in', () => {
+    const s = state({
+      name: 'Home Backyard',
+      latitudeDegText: '51.5',
+      longitudeDegText: '-0.13',
+    });
+    expect(siteStepHasSite(s)).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/setup/steps/StepSite.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSite.tsx
@@ -55,7 +55,19 @@ export function siteStepHasSite(state: SiteStepState): boolean {
 
 /** Validate the (optional) site step; `null` when the step is empty (skipped) or valid. */
 export function siteStepError(state: SiteStepState): string | null {
-  if (!siteStepHasSite(state)) return null;
+  const nameFilled = state.name.trim() !== '';
+  const coordsFilled =
+    state.latitudeDegText.trim() !== '' && state.longitudeDegText.trim() !== '';
+  // A blank step (nothing filled in yet) is skipped, not invalid. But once
+  // the user has entered coordinates, the site needs a name too — matching
+  // the Settings -> Target Planner site editor, which requires it
+  // (`ObservingSites.tsx`) — otherwise Continue silently accepted an
+  // anonymous site that then got dropped entirely at Finish (#516).
+  if (!nameFilled && !coordsFilled) return null;
+  if (!nameFilled) {
+    return m.settings_observing_sites_error_name();
+  }
+  if (!coordsFilled) return null;
   const lat = Number(state.latitudeDegText.trim());
   if (!Number.isFinite(lat) || lat < -90 || lat > 90) {
     return m.settings_observing_sites_error_latitude();


### PR DESCRIPTION
## Summary
- The first-run setup wizard's Observing Site step let a user fill in valid latitude/longitude while leaving the site Name blank, with Continue staying enabled; the entered coordinates were then silently dropped and no site was created when Finish was clicked.
- Site Name is now required as soon as coordinates are entered, matching the equivalent Settings -> Target Planner site editor.

Fixes #516

## Spec Context
- Spec: 071
- Branch: fix/jc0714-nJ01e