### PR TITLE
fix(setup): reconcile scan-preview file counts and label the root row

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -980,6 +980,8 @@
   "setup_scan_master_kind": "Master {kind}",
   "setup_scan_no_sources": "No sources registered. Go back and add at least one folder.",
   "setup_scan_nothing_detected": "Nothing detected in this folder.",
+  "setup_scan_root_label": "(root)",
+  "setup_scan_unclassified_count": "{count} unknown",
   "setup_scan_recursive": "Recursive",
   "setup_scan_single_level": "Single level",
   "setup_scan_phase_done": "Done",

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -121,6 +121,41 @@ const SCAN_RESPONSE_EMPTY = {
   items: [],
 };
 
+// A folder with an unclassified file alongside a light/flat mix (issue #513
+// evidence: headerless darks land in unclassifiedFiles, not the breakdown).
+const SCAN_RESPONSE_WITH_UNCLASSIFIED = {
+  rootId: 'root-004',
+  items: [
+    {
+      inboxItemId: 'item-002',
+      relativePath: '',
+      fileCount: 3,
+      lane: 'fits',
+      format: 'fits',
+      state: 'classified',
+      contentSignature: 'sig-def',
+      isMaster: false,
+      masterFrameType: null,
+      masterFilter: null,
+      masterExposureS: null,
+    },
+  ],
+};
+
+const CLASSIFY_RESPONSE_WITH_UNCLASSIFIED = {
+  inboxItemId: 'item-002',
+  type: 'mixed',
+  frameType: null,
+  contentSignature: 'sig-def',
+  breakdown: [
+    { kind: 'flat', count: 1, sampleFiles: [] },
+    { kind: 'light', count: 1, sampleFiles: [] },
+  ],
+  unclassifiedFiles: ['stack_9.fits'],
+  sampleFiles: [],
+  computedAt: '2025-10-10T22:00:00Z',
+};
+
 // A single detected calibration master file (spec 040 FR-005/FR-006): the item
 // carries its own frame type / exposure rather than relying on the breakdown.
 const SCAN_RESPONSE_WITH_MASTER = {
@@ -416,6 +451,100 @@ describe('StepScan', () => {
       expect(within(row).getByText('Master')).toBeInTheDocument();
       // Frame type + exposure in the Detected types cell (filter null → omitted)
       expect(within(row).getByText('Master Dark · 300s')).toBeInTheDocument();
+    });
+
+    it('reconciles the file count by surfacing unclassified files (issue #513)', async () => {
+      mockInboxScanFolder.mockResolvedValue({
+        status: 'ok',
+        data: SCAN_RESPONSE_WITH_UNCLASSIFIED,
+      });
+      mockInboxClassify.mockResolvedValue({
+        status: 'ok',
+        data: CLASSIFY_RESPONSE_WITH_UNCLASSIFIED,
+      });
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId('scan-source-/astro/lights')).getByText(
+            /1 folder/,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expandSource('/astro/lights');
+
+      const row = screen.getByTestId('scan-item-item-002');
+      // 1 flat + 1 light + 1 unknown = 3, matching fileCount.
+      expect(
+        within(row).getByText('1 flat, 1 light, 1 unknown'),
+      ).toBeInTheDocument();
+      expect(within(row).getByText('3')).toBeInTheDocument();
+    });
+
+    it('labels the root row instead of leaving the Folder/File cell blank (issue #513)', async () => {
+      mockInboxScanFolder.mockResolvedValue({
+        status: 'ok',
+        data: SCAN_RESPONSE_WITH_UNCLASSIFIED,
+      });
+      mockInboxClassify.mockResolvedValue({
+        status: 'ok',
+        data: CLASSIFY_RESPONSE_WITH_UNCLASSIFIED,
+      });
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId('scan-source-/astro/lights')).getByText(
+            /1 folder/,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expandSource('/astro/lights');
+
+      const row = screen.getByTestId('scan-item-item-002');
+      expect(within(row).getByText('(root)')).toBeInTheDocument();
+    });
+
+    it('surfaces masters and unclassified counts in the source header chips (issue #513)', async () => {
+      mockInboxScanFolder.mockResolvedValue({
+        status: 'ok',
+        data: {
+          rootId: 'root-005',
+          items: [
+            ...SCAN_RESPONSE_WITH_MASTER.items,
+            ...SCAN_RESPONSE_WITH_UNCLASSIFIED.items,
+          ],
+        },
+      });
+      mockInboxClassify.mockImplementation(({ inboxItemId }) =>
+        Promise.resolve({
+          status: 'ok',
+          data:
+            inboxItemId === 'item-002'
+              ? CLASSIFY_RESPONSE_WITH_UNCLASSIFIED
+              : CLASSIFY_RESPONSE,
+        }),
+      );
+
+      renderStep({ sources: [SOURCES[0]] });
+
+      await waitFor(() => {
+        expect(
+          within(screen.getByTestId('scan-source-/astro/lights')).getByText(
+            /2 folders/,
+          ),
+        ).toBeInTheDocument();
+      });
+
+      expandSource('/astro/lights');
+
+      const sourceEl = screen.getByTestId('scan-source-/astro/lights');
+      expect(within(sourceEl).getByText('1 master')).toBeInTheDocument();
+      expect(within(sourceEl).getByText('1 unclassified')).toBeInTheDocument();
     });
 
     it('shows the scan summary when all sources are done', async () => {

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -128,13 +128,31 @@ function SourceSummary({ state }: SourceSummaryProps) {
   const totalItems = items.length;
   const totalFiles = items.reduce((acc, it) => acc + it.fileCount, 0);
 
-  // Aggregate breakdown counts across all classified items
+  // Aggregate breakdown counts across all items, reconciled against the file
+  // count (issue #513): masters and unclassified files were previously
+  // dropped from this summary because they don't appear in a classify
+  // breakdown entry, so the chip counts silently undercounted totalFiles.
   const kindCounts = new Map<string, number>();
-  for (const [, cls] of classifications) {
-    for (const entry of cls.breakdown ?? []) {
+  for (const item of items) {
+    if (item.isMaster) {
+      kindCounts.set(
+        'master',
+        (kindCounts.get('master') ?? 0) + item.fileCount,
+      );
+      continue;
+    }
+    const cls = classifications.get(item.inboxItemId);
+    for (const entry of cls?.breakdown ?? []) {
       kindCounts.set(
         entry.kind,
         (kindCounts.get(entry.kind) ?? 0) + entry.count,
+      );
+    }
+    const unclassifiedCount = cls?.unclassifiedFiles.length ?? 0;
+    if (unclassifiedCount > 0) {
+      kindCounts.set(
+        'unclassified',
+        (kindCounts.get('unclassified') ?? 0) + unclassifiedCount,
       );
     }
   }
@@ -272,17 +290,35 @@ function SourceSummary({ state }: SourceSummaryProps) {
               </thead>
               <tbody>
                 {sortedItems.map((item) => {
-                  const breakdown =
-                    classifications.get(item.inboxItemId)?.breakdown ?? [];
-                  const types = breakdown
-                    .map((b) => `${b.count} ${b.kind}`)
-                    .join(', ');
+                  const cls = classifications.get(item.inboxItemId);
+                  const breakdown = cls?.breakdown ?? [];
+                  const typeParts = breakdown.map(
+                    (b) => `${b.count} ${b.kind}`,
+                  );
+                  // Reconcile against fileCount (issue #513): files with no
+                  // IMAGETYP (or an unmapped one) don't appear in the classify
+                  // breakdown at all, so the type list previously undercounted
+                  // the row's file total with no indication why.
+                  const unclassifiedCount = cls?.unclassifiedFiles.length ?? 0;
+                  if (unclassifiedCount > 0) {
+                    typeParts.push(
+                      m.setup_scan_unclassified_count({
+                        count: unclassifiedCount,
+                      }),
+                    );
+                  }
+                  const types = typeParts.join(', ');
                   // Individual calibration masters carry their frame type on the
                   // item itself (spec 040 FR-006); grouped sub-frame folders rely
                   // on the classify breakdown instead.
                   const detectedTypes = item.isMaster
                     ? masterLabel(item)
                     : types || '—';
+                  // The root/top-level row of an expanded folder carries an
+                  // empty relativePath; label it instead of leaving it blank
+                  // (issue #513).
+                  const rowLabel =
+                    item.relativePath || m.setup_scan_root_label();
                   return (
                     <tr
                       key={item.inboxItemId}
@@ -294,7 +330,7 @@ function SourceSummary({ state }: SourceSummaryProps) {
                           {item.isMaster && (
                             <Pill variant="info">{m.setup_scan_master()}</Pill>
                           )}
-                          {item.relativePath}
+                          {rowLabel}
                         </span>
                       </td>
                       <td className="alm-setup-scan__cell">{item.fileCount}</td>


### PR DESCRIPTION
## Summary
- Wizard Step 6 (Scan) "Detected types" column and per-source chip summary now
  account for unclassified files (no/unmapped IMAGETYP) and calibration
  masters, so a folder's shown breakdown reconciles with its file count.
- The root row of an expanded folder table now shows "(root)" instead of a
  blank Folder/File cell.

Fixes #513

## Test plan
- [x] `pnpm exec vitest run src/features/setup/steps/StepScan.test.tsx` — 23/23 passing (3 new)
- [x] `just typecheck`
- [x] `pnpm exec eslint` + `biome check` on changed files