### PR TITLE
fix: close shared list-page detail panel on Escape

### DIFF
--- a/apps/desktop/src/components/DetailPanel.tsx
+++ b/apps/desktop/src/components/DetailPanel.tsx
@@ -31,7 +31,9 @@
  * CONTENT column scrolls (overflow-y:auto, scrollbar-gutter:stable). Remove
  * any overflow on the outer detail-body to avoid double scrollbars.
  *
- * The close ✕ lives in ListPageLayout (onCloseDetail), NOT here.
+ * The close ✕ lives in ListPageLayout (onCloseDetail), NOT here — as does
+ * Escape-to-close (#771): ListPageLayout owns a document-level Escape
+ * listener that calls onCloseDetail/onCloseBottomDetail.
  * Per-item contextual actions (Review / Assign / …) go in the `actions` slot.
  *
  * Row-data de-duplication contract (#100):

--- a/apps/desktop/src/components/DetailPanel.tsx
+++ b/apps/desktop/src/components/DetailPanel.tsx
@@ -32,8 +32,12 @@
  * any overflow on the outer detail-body to avoid double scrollbars.
  *
  * The close ✕ lives in ListPageLayout (onCloseDetail), NOT here — as does
- * Escape-to-close (#771): ListPageLayout owns a document-level Escape
- * listener that calls onCloseDetail/onCloseBottomDetail.
+ * Escape-to-close (#771/#906): ListPageLayout owns a document-level Escape
+ * listener that calls onCloseDetail/onCloseBottomDetail, and explicitly
+ * checks the DOM for an open Base UI overlay (Dialog/Select/Combobox/Menu)
+ * before firing — `stopPropagation()` on a same-target sibling `document`
+ * listener does NOT block this one, so Base UI's own Escape dismissal can't
+ * be relied on alone to keep this listener from also closing the panel.
  * Per-item contextual actions (Review / Assign / …) go in the `actions` slot.
  *
  * Row-data de-duplication contract (#100):

--- a/apps/desktop/src/components/ListPageLayout.test.tsx
+++ b/apps/desktop/src/components/ListPageLayout.test.tsx
@@ -18,6 +18,7 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ListPageLayout } from './ListPageLayout';
+import { Modal } from './Modal';
 
 describe('ListPageLayout', () => {
   it('defaults to the bottom dock (no side variant classes)', () => {
@@ -225,6 +226,36 @@ describe('ListPageLayout', () => {
     screen.getByText('focus me').focus();
     fireEvent.keyDown(document, { key: 'Escape' });
     expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not close the panel on Escape while a Base UI Modal is open above it (#906)', () => {
+    const onCloseDetail = vi.fn();
+    const onCloseModal = vi.fn();
+    render(
+      <>
+        <ListPageLayout
+          topBar={<div>bar</div>}
+          detail={<div>detail</div>}
+          onCloseDetail={onCloseDetail}
+        >
+          <div>main</div>
+        </ListPageLayout>
+        <Modal open onClose={onCloseModal} title="Overlay">
+          <div>modal body</div>
+        </Modal>
+      </>,
+    );
+    // Base UI stamps the open popup with `data-open` + role="dialog" — the
+    // same signal our overlay guard checks for.
+    expect(
+      document.querySelector('[data-open][role="dialog"]'),
+    ).toBeInTheDocument();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    // The panel must NOT also close — only the modal's own dismissal should
+    // react to this Escape (asserted separately from Base UI's own listener,
+    // which isn't under test here; the regression is that our listener used
+    // to co-fire regardless).
+    expect(onCloseDetail).not.toHaveBeenCalled();
   });
 
   it('does not call onCloseDetail on Escape when no detail is open', () => {

--- a/apps/desktop/src/components/ListPageLayout.test.tsx
+++ b/apps/desktop/src/components/ListPageLayout.test.tsx
@@ -191,4 +191,87 @@ describe('ListPageLayout', () => {
       container.querySelector('.alm-listpage__detail'),
     ).toBeInTheDocument();
   });
+
+  // ── Escape-to-close (#771) ────────────────────────────────────────────────
+
+  it('closes the bottom-dock detail on Escape, even with focus on <body>', () => {
+    const onClose = vi.fn();
+    render(
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={<div>detail</div>}
+        onCloseDetail={onClose}
+      >
+        <div>main</div>
+      </ListPageLayout>,
+    );
+    expect(document.activeElement).toBe(document.body);
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('closes the side-dock detail on Escape when focus is inside the panel', () => {
+    const onClose = vi.fn();
+    render(
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={<button type="button">focus me</button>}
+        detailPlacement="side"
+        onCloseDetail={onClose}
+      >
+        <div>main</div>
+      </ListPageLayout>,
+    );
+    screen.getByText('focus me').focus();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not call onCloseDetail on Escape when no detail is open', () => {
+    const onClose = vi.fn();
+    render(
+      <ListPageLayout topBar={<div>bar</div>} onCloseDetail={onClose}>
+        <div>main</div>
+      </ListPageLayout>,
+    );
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('does not close on Escape when an inner handler already consumed it', () => {
+    const onClose = vi.fn();
+    render(
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={
+          <input
+            aria-label="inner"
+            onKeyDown={(e) => {
+              if (e.key === 'Escape') e.preventDefault();
+            }}
+          />
+        }
+        onCloseDetail={onClose}
+      >
+        <div>main</div>
+      </ListPageLayout>,
+    );
+    fireEvent.keyDown(screen.getByLabelText('inner'), { key: 'Escape' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-Escape keys', () => {
+    const onClose = vi.fn();
+    render(
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={<div>detail</div>}
+        onCloseDetail={onClose}
+      >
+        <div>main</div>
+      </ListPageLayout>,
+    );
+    fireEvent.keyDown(document, { key: 'Enter' });
+    expect(onClose).not.toHaveBeenCalled();
+  });
 });

--- a/apps/desktop/src/components/ListPageLayout.test.tsx
+++ b/apps/desktop/src/components/ListPageLayout.test.tsx
@@ -19,6 +19,7 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 import { ListPageLayout } from './ListPageLayout';
 import { Modal } from './Modal';
+import { Combobox } from '@base-ui-components/react/combobox';
 
 describe('ListPageLayout', () => {
   it('defaults to the bottom dock (no side variant classes)', () => {
@@ -255,6 +256,46 @@ describe('ListPageLayout', () => {
     // react to this Escape (asserted separately from Base UI's own listener,
     // which isn't under test here; the regression is that our listener used
     // to co-fire regardless).
+    expect(onCloseDetail).not.toHaveBeenCalled();
+  });
+
+  it('does not close the panel on Escape while a Base UI Combobox is open above it (#906)', () => {
+    const onCloseDetail = vi.fn();
+    render(
+      <>
+        <ListPageLayout
+          topBar={<div>bar</div>}
+          detail={<div>detail</div>}
+          onCloseDetail={onCloseDetail}
+        >
+          <div>main</div>
+        </ListPageLayout>
+        <Combobox.Root items={['Alpha', 'Beta']} open>
+          <Combobox.Input aria-label="Search" />
+          <Combobox.Portal keepMounted>
+            <Combobox.Positioner>
+              <Combobox.Popup>
+                <Combobox.List>
+                  {(item: string) => (
+                    <Combobox.Item key={item} value={item}>
+                      {item}
+                    </Combobox.Item>
+                  )}
+                </Combobox.List>
+              </Combobox.Popup>
+            </Combobox.Positioner>
+          </Combobox.Portal>
+        </Combobox.Root>
+      </>,
+    );
+    // Combobox splits the signal across two nodes: `role="listbox"` sits on
+    // the List, `data-open` on its Positioner/Popup ancestor — neither node
+    // carries both, which is exactly what our overlay guard must handle.
+    const listbox = document.querySelector('[role="listbox"]');
+    expect(listbox).toBeInTheDocument();
+    expect(listbox).not.toHaveAttribute('data-open');
+    expect(listbox?.closest('[data-open]')).not.toBeNull();
+    fireEvent.keyDown(document, { key: 'Escape' });
     expect(onCloseDetail).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/components/ListPageLayout.tsx
+++ b/apps/desktop/src/components/ListPageLayout.tsx
@@ -52,7 +52,7 @@
  * it must be the page's outermost element (do not nest it inside PageShell).
  */
 
-import { type ReactNode } from 'react';
+import { type ReactNode, useEffect } from 'react';
 import { PageTopBar, type PageTopBarProps } from './PageTopBar';
 import { m } from '@/lib/i18n';
 
@@ -110,6 +110,33 @@ export function ListPageLayout({
 }: ListPageLayoutProps) {
   const hasDetail = detail != null;
   const hasBottom = bottomDetail != null;
+
+  // Escape closes the open detail panel(s), matching the ✕ affordance (#771).
+  // A bubble-phase `document` listener also catches the common case where
+  // nothing inside the panel has focus (e.g. focus stayed on the row that
+  // opened it, or on <body>). It does NOT steal Escape from a nested Modal or
+  // any other consumer that stops propagation on its own Escape handling —
+  // that in-tree `stopPropagation()` (Base UI dialogs do this by default)
+  // prevents the native event from ever reaching this document listener, so
+  // the innermost open dialog/input closes first, as intended.
+  useEffect(() => {
+    if (!hasDetail && !hasBottom) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape' || event.defaultPrevented) return;
+      if (hasDetail) onCloseDetail?.();
+      if (detailPlacement === 'side-and-bottom' && hasBottom) {
+        onCloseBottomDetail?.();
+      }
+    };
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [
+    hasDetail,
+    hasBottom,
+    detailPlacement,
+    onCloseDetail,
+    onCloseBottomDetail,
+  ]);
 
   // ── Dual side-and-bottom layout (task #104) ──────────────────────────────
   //

--- a/apps/desktop/src/components/ListPageLayout.tsx
+++ b/apps/desktop/src/components/ListPageLayout.tsx
@@ -96,6 +96,21 @@ export interface ListPageLayoutProps {
   bottomDetailLabel?: string;
 }
 
+/**
+ * True when a Base UI overlay (Dialog, Select, Combobox, Menu, …) is open
+ * anywhere in the document. Base UI stamps its open popup DOM node with
+ * `data-open` (its documented styling-state hook) alongside an ARIA overlay
+ * role; used to defer Escape-to-close to that overlay instead of also
+ * closing the detail panel underneath it (#906).
+ */
+function hasOpenOverlay(): boolean {
+  return (
+    document.querySelector(
+      '[data-open][role="dialog"], [data-open][role="alertdialog"], [data-open][role="listbox"], [data-open][role="menu"]',
+    ) != null
+  );
+}
+
 export function ListPageLayout({
   topBar,
   topBarProps,
@@ -112,17 +127,22 @@ export function ListPageLayout({
   const hasBottom = bottomDetail != null;
 
   // Escape closes the open detail panel(s), matching the ✕ affordance (#771).
-  // A bubble-phase `document` listener also catches the common case where
-  // nothing inside the panel has focus (e.g. focus stayed on the row that
-  // opened it, or on <body>). It does NOT steal Escape from a nested Modal or
-  // any other consumer that stops propagation on its own Escape handling —
-  // that in-tree `stopPropagation()` (Base UI dialogs do this by default)
-  // prevents the native event from ever reaching this document listener, so
-  // the innermost open dialog/input closes first, as intended.
+  // A `document`-level listener also catches the common case where nothing
+  // inside the panel has focus (e.g. focus stayed on the row that opened it,
+  // or on <body>). `stopPropagation()` does NOT stop a sibling listener
+  // registered on the SAME target — Base UI's own Escape dismissal
+  // (`useDismiss`) is also a `document`-level `keydown` listener, and by
+  // default (`escapeKeyBubbles: false`) it calls `stopPropagation()` but
+  // never `preventDefault()`, so neither mechanism reaches across to block
+  // this listener. We therefore check explicitly for an open Base UI overlay
+  // (Dialog/Select/Combobox/Menu — anything carrying Base UI's `data-open`
+  // styling-hook attribute plus an overlay ARIA role) and skip closing the
+  // panel while one is open, deferring to its own dismissal.
   useEffect(() => {
     if (!hasDetail && !hasBottom) return;
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key !== 'Escape' || event.defaultPrevented) return;
+      if (hasOpenOverlay()) return;
       if (hasDetail) onCloseDetail?.();
       if (detailPlacement === 'side-and-bottom' && hasBottom) {
         onCloseBottomDetail?.();

--- a/apps/desktop/src/components/ListPageLayout.tsx
+++ b/apps/desktop/src/components/ListPageLayout.tsx
@@ -98,17 +98,24 @@ export interface ListPageLayoutProps {
 
 /**
  * True when a Base UI overlay (Dialog, Select, Combobox, Menu, …) is open
- * anywhere in the document. Base UI stamps its open popup DOM node with
- * `data-open` (its documented styling-state hook) alongside an ARIA overlay
- * role; used to defer Escape-to-close to that overlay instead of also
- * closing the detail panel underneath it (#906).
+ * anywhere in the document. Base UI stamps the OPEN popup's outer node
+ * (Positioner/Popup) with `data-open` (its documented styling-state hook),
+ * but the ARIA overlay role doesn't always land on that same node: Dialog and
+ * Menu put `role` and `data-open` together on Popup, while Select/Combobox
+ * split them — `role="listbox"`/`"grid"` sits on an inner List that has no
+ * `data-open` of its own, only a `data-open` ANCESTOR (Positioner/Popup).
+ * Walking up from every overlay-role element to the nearest `data-open`
+ * ancestor (`closest`, which also matches the element itself) covers both
+ * shapes without hardcoding which library variant is in use (#906).
  */
 function hasOpenOverlay(): boolean {
-  return (
-    document.querySelector(
-      '[data-open][role="dialog"], [data-open][role="alertdialog"], [data-open][role="listbox"], [data-open][role="menu"]',
-    ) != null
+  const overlayRoles = document.querySelectorAll(
+    '[role="dialog"], [role="alertdialog"], [role="listbox"], [role="grid"], [role="menu"]',
   );
+  for (const el of overlayRoles) {
+    if (el.closest('[data-open]')) return true;
+  }
+  return false;
 }
 
 export function ListPageLayout({


### PR DESCRIPTION
## Summary
- Sessions/Calibration/Inbox/Projects share `ListPageLayout` + `DetailPanel` for the docked detail panel, but neither component registered any `keydown`/Escape handler — only the close ✕ button worked.
- `ListPageLayout` now closes the open detail (bottom, side, or the side-and-bottom dual strip) on a document-level Escape keydown. This also fixes the case where focus stays on `<body>` after selecting a row (the repro in the issue).
- The listener defers to nested dialogs/inputs: Base UI's `Dialog` stops propagation on its own Escape handling by default, so an open Modal (or any consumer that calls `stopPropagation`/`preventDefault` on Escape) closes first and our listener never fires.
- Updated `DetailPanel`'s doc comment (previously said the close ✕ "lives in ListPageLayout, NOT here" without mentioning Escape at all — flagged as misleading in the issue's root-cause note).

Fixes #771

## Test plan
- [x] `pnpm -C apps/desktop vitest run src/components/ListPageLayout.test.tsx src/components/DetailPanel.test.tsx` — 33 passed, including new Escape-to-close coverage (body-focus close, panel-focus close, no-detail no-op, inner-handler-consumed no-op, non-Escape keys ignored).
- [x] `just typecheck` — green.
- [ ] `just lint` — full workspace cargo fmt+clippy timed out at 300s in this sandbox on an unrelated, untouched Rust workspace; ran `pnpm -C apps/desktop lint` directly instead — 0 errors on the 4 changed files (one unrelated pre-existing fatal parse error in `eslint-rules/no-user-string.js`, not touched by this change). CI is the final gate.