### PR TITLE
fix: stop settings toggle flashing its default state before load

### DIFF
--- a/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
@@ -78,6 +78,43 @@ describe('ResolverSettingsControl', () => {
     expect(checkbox).toBeChecked();
   });
 
+  // issue #584: don't paint the toggle as ON (in-code default) before the
+  // persisted (OFF) value has loaded — regression test for the render-
+  // before-lookup flash.
+  it('does not render the toggle checked before persisted settings load', async () => {
+    let resolveGet!: (v: unknown) => void;
+    mockGet.mockReset();
+    mockGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    render(<ResolverSettingsControl />);
+
+    expect(
+      screen.queryByLabelText('Enable online SIMBAD resolution'),
+    ).toBeNull();
+    expect(screen.getByTestId('skeleton')).toBeInTheDocument();
+
+    await act(async () => {
+      resolveGet({
+        status: 'ok',
+        data: {
+          contractVersion: '1.0',
+          requestId: 'r',
+          settings: { ...SETTINGS, onlineEnabled: false },
+        },
+      });
+      await Promise.resolve();
+    });
+
+    const checkbox = (await screen.findByLabelText(
+      'Enable online SIMBAD resolution',
+    )) as HTMLInputElement;
+    expect(checkbox).not.toBeChecked();
+  });
+
   it('persists the online toggle via updateResolverSettings', async () => {
     render(<ResolverSettingsControl />);
     await waitFor(() => expect(mockGet).toHaveBeenCalled());

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.tsx
@@ -16,7 +16,7 @@
 // with the endpoint / debounce / timeout fields deferred to full Settings.
 
 import { useCallback, useEffect, useId, useState } from 'react';
-import { Btn, Toggle } from '@/ui';
+import { Btn, Skeleton, Toggle } from '@/ui';
 import {
   clearResolveCache,
   getResolverSettings,
@@ -121,32 +121,55 @@ export function ResolverSettingsControl({
             <span className="alm-resolver-settings__compact-label">
               {m.settings_resolver_online_label()}
             </span>
-            <Toggle
-              checked={settings.onlineEnabled}
-              aria-label={m.settings_resolver_online_aria()}
-              onChange={(v) => void persist({ onlineEnabled: v })}
-            />
+            {loaded ? (
+              <Toggle
+                checked={settings.onlineEnabled}
+                aria-label={m.settings_resolver_online_aria()}
+                onChange={(v) => void persist({ onlineEnabled: v })}
+              />
+            ) : (
+              <Skeleton
+                variant="block"
+                width={36}
+                height={20}
+                radius="10px"
+                label={m.common_loading()}
+              />
+            )}
           </div>
           <div className="alm-settings__row-desc">
-            {settings.onlineEnabled
-              ? m.settings_resolver_online_desc()
-              : m.settings_resolver_offline_desc()}
+            {loaded &&
+              (settings.onlineEnabled
+                ? m.settings_resolver_online_desc()
+                : m.settings_resolver_offline_desc())}
           </div>
         </div>
       ) : (
         <SettingsRow
           label={m.settings_resolver_online_label()}
           info={
-            settings.onlineEnabled
-              ? m.settings_resolver_online_on_info()
-              : m.settings_resolver_online_off_info()
+            loaded
+              ? settings.onlineEnabled
+                ? m.settings_resolver_online_on_info()
+                : m.settings_resolver_online_off_info()
+              : undefined
           }
         >
-          <Toggle
-            checked={settings.onlineEnabled}
-            aria-label={m.settings_resolver_online_aria()}
-            onChange={(v) => void persist({ onlineEnabled: v })}
-          />
+          {loaded ? (
+            <Toggle
+              checked={settings.onlineEnabled}
+              aria-label={m.settings_resolver_online_aria()}
+              onChange={(v) => void persist({ onlineEnabled: v })}
+            />
+          ) : (
+            <Skeleton
+              variant="block"
+              width={36}
+              height={20}
+              radius="10px"
+              label={m.common_loading()}
+            />
+          )}
         </SettingsRow>
       )}
 


### PR DESCRIPTION
## Summary
- The SIMBAD-resolution online toggle painted its in-code default (ON) before the async settings fetch resolved, then snapped to the persisted value — a visible flash to the wrong state when the setting was actually OFF.
- Both toggle render sites (compact + full Settings pane) now gate on the existing `loaded` flag and show a `Skeleton` placeholder (matching the pattern already used elsewhere, e.g. `InboxList.tsx`) until the persisted value is known.
- Added a regression test that delays settings resolution and asserts no toggle (checked or unchecked) renders before load, then asserts it reflects the persisted value with no intermediate flash.

Fixes #584

## Test plan
- [x] `pnpm vitest run src/features/settings/ResolverSettingsControl.test.tsx` (7/7 pass)
- [x] `pnpm vitest run src/features/settings/` (124/124 pass)
- [x] `pnpm exec biome check` / `pnpm exec eslint` on changed files (no new warnings/errors)
- [x] `just typecheck` (workspace, green)
- [ ] CI