### PR TITLE
fix: Targets sidebar count reflects your own targets, not the full catalog

### DIFF
--- a/apps/desktop/src-tauri/src/commands/status.rs
+++ b/apps/desktop/src-tauri/src/commands/status.rs
@@ -13,9 +13,10 @@ use tauri::State;
 use crate::commands::lifecycle::AppState;
 use contracts_core::ContractError;
 use persistence_db::repositories::q_desktop::{
-    count_acquisition_sessions, count_calibration_masters, count_canonical_targets, count_projects,
+    count_acquisition_sessions, count_calibration_masters, count_projects,
     count_unacknowledged_inbox_items,
 };
+use persistence_db::repositories::target_favourites::count_favourites;
 
 /// `status.summary` — returns current library status overview.
 ///
@@ -67,7 +68,9 @@ pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary,
         .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
         .map_err(|e| ContractError::internal(e.to_string()))?;
 
-    let targets: u32 = count_canonical_targets(pool)
+    // "My targets" (issue #574): the count of favourited targets, matching
+    // the Targets page's "My Targets" filter — not the bundled seed catalog.
+    let targets: u32 = count_favourites(pool)
         .await
         .map(|n| u32::try_from(n.max(0)).unwrap_or(u32::MAX))
         .map_err(|e| ContractError::internal(e.to_string()))?;

--- a/crates/persistence/db/src/repositories/target_favourites.rs
+++ b/crates/persistence/db/src/repositories/target_favourites.rs
@@ -50,6 +50,20 @@ pub async fn list_favourites(pool: &SqlitePool) -> DbResult<Vec<String>> {
     Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
+/// Count every currently-favourited canonical target. Used by
+/// `status.summary` (issue #574): the sidebar's "my targets" badge must equal
+/// what the Targets page's "My Targets" filter shows, which is wired to this
+/// same table, so count and visible list can never diverge.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn count_favourites(pool: &SqlitePool) -> DbResult<i64> {
+    let count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM target_favourite").fetch_one(pool).await?;
+    Ok(count)
+}
+
 /// Favourite `target_id`. Upsert-safe: favouriting an already-favourited
 /// target is a no-op (the original `favourited_at` is preserved, not bumped).
 ///
@@ -175,6 +189,26 @@ mod tests {
         let db = setup().await;
         let ids = list_favourites(db.pool()).await.unwrap();
         assert!(ids.is_empty());
+    }
+
+    #[tokio::test]
+    async fn count_favourites_is_zero_when_nothing_favourited() {
+        let db = setup().await;
+        assert_eq!(count_favourites(db.pool()).await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn count_favourites_reflects_add_and_remove() {
+        let db = setup().await;
+        insert_target(db.pool(), "t-009").await;
+        insert_target(db.pool(), "t-010").await;
+
+        add_favourite(db.pool(), "t-009", "2026-07-05T00:00:00Z").await.unwrap();
+        add_favourite(db.pool(), "t-010", "2026-07-05T00:00:00Z").await.unwrap();
+        assert_eq!(count_favourites(db.pool()).await.unwrap(), 2);
+
+        remove_favourite(db.pool(), "t-009").await.unwrap();
+        assert_eq!(count_favourites(db.pool()).await.unwrap(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- The Targets sidebar badge showed the size of the entire bundled/resolved catalog (~13073), not anything the user owns.
- It now shows the count of favourited targets — the same set shown by the Targets page's "My Targets" filter — so the badge and the visible list always match.

Fixes #574

## Spec Context
- Spec: 071
- Branch: fix/jc0714-nJ09b