### PR TITLE
chore(ci): add missing EOF newline to cla-assistant.yml

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -34,4 +34,3 @@ jobs:
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
           branch: "cla-signatures"
           allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*,nightwatch-astro-ci*"
-


### PR DESCRIPTION
Pre-commit hook fails on every branch merging main because this file lacks a trailing newline.