### PR TITLE
docs: specification for crisper text rendering, font size dial, and app zoom

### DIFF
--- a/specs/055-typography-rework/plan.md
+++ b/specs/055-typography-rework/plan.md
@@ -61,10 +61,10 @@ existing `font-style: italic` sites — no CSS edits needed there.
 1. Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
    app-owned Ctrl+= / Ctrl+− / Ctrl+0; persistence mirrors the fontSize
    setting.
-2. One-line clarification PR into spec 054: thresholds are CSS-px viewport
-   measurements.
-3. CI pin: minimum window (1100×720) × maximum zoom — layout intact (with 054:
-   dock in bottom mode).
+2. Zoom steps 90/100/110/125/150; Ctrl+0 resets to 100.
+3. CI pins (two): layout intact at minimum window (1100×720) × 125%, and at
+   1320×864 × 150%. Beyond that envelope (min window × 150% → 733px viewport)
+   layout degradation is documented and accepted, not guarded.
 4. J10 journey delta amendment for zoom; `verify-on-windows` scenario.
 
 ## Risks

--- a/specs/055-typography-rework/plan.md
+++ b/specs/055-typography-rework/plan.md
@@ -1,0 +1,78 @@
+# Implementation Plan: Typography Rework (spec 055)
+
+**Spec**: `specs/055-typography-rework/spec.md` | **Created**: 2026-07-17
+
+Four phases, each independently shippable and verified before the next. Phase 1
+is deliberately isolated so the crispness win (the user's actual pain) lands and
+is A/B-verified before any token arithmetic changes.
+
+## Phase 1 — Font assets (FR-001, SC-001/002/005/008)
+
+1. Add `apps/desktop/src/assets/fonts/`: the six hinted woff2s from
+   `https://github.com/rsms/inter/releases/download/v4.1/Inter-4.1.zip`
+   (`extras/woff-hinted/Inter-{Regular,Italic,Medium,MediumItalic,SemiBold,SemiBoldItalic}.woff2`)
+   + `LICENSE.txt` + a `FONTS.md` recording release URL and SHA-256 per file.
+2. Replace the `@import` at `apps/desktop/src/styles/tokens.css:1` with six
+   `@font-face` blocks (`font-display: swap`). This also deletes the JetBrains
+   Mono CDN load.
+3. Keep `--alm-font-sans` (tokens.css:20) unchanged; keep
+   `font-feature-settings: 'tnum' 1` (reset.css:16); add `'calt' 1`.
+4. E2E assertions: no `fonts.g*` network requests; `document.fonts` contains
+   the six faces; computed family on body text is Inter.
+5. `verify-on-windows` scenario: A/B screenshots at DPR 1.5, dark theme,
+   Targets page (the 12px-dominant surface). Gate Phase 2 on this.
+
+Registering italic faces automatically ends synthetic italics at the ~10
+existing `font-style: italic` sites — no CSS edits needed there.
+
+## Phase 2 — Token layer + dial (FR-002/003, SC-003/004)
+
+1. Re-derive the scale in rem from a 14px root, even-px preference, 11px floor,
+   top ~24px. Retire the 10px token.
+2. `theme.ts:112-129`: delete the 0.9/1.0/1.15 per-token scaler; the setting
+   writes integer `html { font-size: 12|14|16px }`. Add the sane-computed-size
+   guard: if any token × any dial stop computes fractional, round per token.
+3. Tokenize the 11 hardcoded px sizes (sidebar/settings labels 9.5px, wizard
+   titles/fine print, planner SVG axis 9px, toast glyph); consolidate the
+   uppercase micro-label sizes to one token; add letter-spacing tokens (replace
+   the 8 divergent values).
+4. CI computed-style sweep (SC-003): integer root at all stops, nothing below
+   11px, nothing fractional.
+5. **J10 journey delta** for the changed dial semantics.
+
+## Phase 3 — Semantic base layer + mono (FR-004/005, SC-005/006)
+
+1. Base layer in `reset.css`/`primitives.css`: `strong,b` → semibold token;
+   `em,i` → italic faces; `code,pre,kbd` → mono stack; define-or-delete
+   `font-mono`.
+2. Replace the `* { font-family !important }` blanket with the base layer +
+   explicit stacks; re-add the stripped mono declarations (source-view IDs at
+   `feature-lists.css:783` is the template; the other intents survive only as
+   comments and must be re-added by hand).
+3. Mono restoration surfaces: filesystem paths, source-view IDs, manifest
+   paths, dev-tools contract names, RA/Dec coordinate values. Default face
+   `ui-monospace, 'Cascadia Code', monospace`; escalate to bundled JetBrains
+   Mono only if Windows verification rejects the system stack.
+4. Evaluate `'zero' 1` / `'case' 1` on coordinate surfaces during the same
+   Windows pass.
+
+## Phase 4 — Engine zoom (FR-006, SC-007) — after spec 054, or capped 125%
+
+1. Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
+   app-owned Ctrl+= / Ctrl+− / Ctrl+0; persistence mirrors the fontSize
+   setting.
+2. One-line clarification PR into spec 054: thresholds are CSS-px viewport
+   measurements.
+3. CI pin: minimum window (1100×720) × maximum zoom — layout intact (with 054:
+   dock in bottom mode).
+4. J10 journey delta amendment for zoom; `verify-on-windows` scenario.
+
+## Risks
+
+- **Phase 3 changes visible rendering on purpose** (code/pre/mono surfaces) —
+  ship with before/after screenshots in the PR.
+- **Blanket removal** may expose latent family declarations; the audit found
+  only one live deviation, but the computed-style CI sweep is the regression
+  net.
+- **Dial rounding**: 12/16 roots make rem tokens compute fractional
+  (× 12/14, × 16/14); the per-token rounding guard is mandatory, not optional.

--- a/specs/055-typography-rework/plan.md
+++ b/specs/055-typography-rework/plan.md
@@ -56,7 +56,7 @@ existing `font-style: italic` sites — no CSS edits needed there.
 4. Evaluate `'zero' 1` / `'case' 1` on coordinate surfaces during the same
    Windows pass.
 
-## Phase 4 — Engine zoom (FR-006, SC-007) — after spec 054, or capped 125%
+## Phase 4 — Engine zoom (FR-006, SC-007) — max 150% (054 orphaned; see spec FR-006 envelope)
 
 1. Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
    app-owned Ctrl+= / Ctrl+− / Ctrl+0; persistence mirrors the fontSize

--- a/specs/055-typography-rework/research.md
+++ b/specs/055-typography-rework/research.md
@@ -1,0 +1,65 @@
+# Research: Typography Rework (spec 055)
+
+Condensed record of the five completed investigation lanes (2026-07-17). Full
+receipts inline in `spec.md`/`plan.md`.
+
+## Lane 1 — Live rendering probe (user's Windows machine, real app)
+
+DPR 1.5 (150% scaling), observatory-dark theme. Inter genuinely painting (no
+Segoe fallback); font-size setting unset (root integer 16px — fractional-scaler
+bug real but dormant); dominant sizes on Targets: 12px ×106, 10px ×48, 13px
+×46, 11px ×28; family perfectly consistent at runtime. Evidence screenshot:
+`targets-font-diagnostic.png` (session scratchpad).
+
+## Lane 2 — Repo-wide typography audit
+
+97.4% of font-size declarations token-based (485/498); zero feature-local CSS.
+Debt: 11 hardcoded px sizes immune to the size setting; global
+`* { font-family … !important }` (reset.css:26-28) strips all mono (one live
+deviation left: `.alm-source-views__id`, feature-lists.css:783; other mono
+intents deleted to comments); uppercase micro-labels use 3 sizes for one role;
+letter-spacing untokenized (8 values, 13 files); 21 `<strong>` rely on browser
+700 → synthetic-bold trap; `--alm-leading-relaxed` dead; `font-mono` class
+undefined.
+
+## Lane 3 — Industry research (fonts + size settings)
+
+Brand-forward apps bundle (Figma/Linear bundle Inter; Discord gg sans; Slack
+Lato); OS-native apps use system stacks (VS Code, 13px default). Nobody
+hybridizes. Dominant size-setting pattern is whole-surface zoom (VS Code/Slack/
+Notion). Google CDN serves instanced statics with hinting stripped
+(google/fonts#7007). Fractional px font sizes documented backend-inconsistent.
+
+## Lane 4 — Engine zoom evaluation
+
+Tauri v2 `setZoom` = true layout zoom on all three engines (WebView2
+ZoomFactor / WKWebView pageZoom / WebKitGTK zoom-level); Linux confidence
+medium (Wayland blur reports). CSS `zoom` rejected (contaminates viewport
+math). Verdict: add zoom **alongside** the font dial (VS Code split). Composes
+with spec 054 (zoom shrinks CSS viewport → dock bottom mode). Constraint: 150%
+zoom at 1100×720 → 733px viewport → ship after 054 or cap 125%. Shortcuts must
+be app-owned (WebView2 has no zoom-change event). Permission:
+`core:webview:allow-set-webview-zoom`.
+
+## Lane 5 — Font selection deep dive (binary probes)
+
+**"Hinted InterVariable" does not exist**: `InterVariable.ttf` in Inter-4.1.zip
+has zero hint tables (no fpgm/prep/cvt, 0 instructed glyphs); hinted assets are
+the static woff2s in `extras/woff-hinted/` (1,965/2,937 glyphs instructed;
+fontTools probe). Ranked: 1. Inter hinted statics; 2. IBM Plex Sans Var (only
+candidate with real variable TT hints — loses on migration cost for zero
+rendering gain); Source Sans 3 (TTFs explicitly unhinted), Geist (italics
+alpha-only), Roboto Flex (no italic, slnt only) disqualified. `tnum` verified
+in the hinted statics (load-bearing for reset.css:16); `calt`/`case`/`zero`
+available. Assets: 6 woff2s ≈ 858KB, OFL 1.1, pin v4.1 (2024-11-15).
+
+## Decisions closed by this research
+
+| Question | Decision |
+|---|---|
+| Font | Keep Inter; bundle 6 hinted static woff2s; delete both CDN loads |
+| Token architecture | rem + integer root dial 12/14/16 (user); per-token rounding guard |
+| Floor / base | 11px floor, base 13→14, retire 10px token |
+| Mono | Restore (paths, IDs, contracts, RA/Dec — user); system mono stack default, JetBrains Mono bundle as fallback |
+| Size mechanism | Dial AND engine zoom (user + Lane 4); zoom after 054 or capped |
+| Device-pixel rounding | Rejected (per-DPR tables); prefer even px sizes instead |

--- a/specs/055-typography-rework/spec.md
+++ b/specs/055-typography-rework/spec.md
@@ -1,0 +1,192 @@
+# Feature Specification: Typography Rework — Crisp, Consistent, Scalable Text
+
+**Feature Branch**: `055-typography-rework`
+
+**Created**: 2026-07-17
+
+**Status**: Draft — researched and decision-complete; ready for `plan.md` review
+and task generation
+
+**Input**: User report: "the app's text looks jagged and hard to read on
+Windows, and font usage feels inconsistent; also evaluate a larger default and
+whole-app zoom like VS Code."
+
+> **Research base.** All load-bearing findings were produced by a completed
+> five-lane investigation (live rendering probe on the user's Windows machine,
+> repo-wide typography audit, cross-app industry research, engine-zoom
+> evaluation, font-selection deep dive with binary probes of candidate font
+> files). Key receipts are inlined below; the plan references them per phase.
+
+## Overview
+
+PlateVault's UI text renders soft and jagged on low-DPI Windows displays. The
+causal chain, established by a live probe (DPR 1.5, dark theme) and confirmed
+against upstream font documentation:
+
+1. **Unhinted Inter.** `tokens.css` loads Inter from the Google Fonts CDN,
+   which serves statics instanced from the variable source **with hinting
+   stripped** (google/fonts#7007). Below ~150 DPI, TrueType grid-fitting still
+   decides stem crispness; unhinted Inter goes mushy exactly in the app's
+   dominant size band.
+2. **Very small text.** The most common size on data-heavy pages is 12px, with
+   48 elements at 10px on Targets; Inter's own docs warn about sub-12px
+   rendering on low-DPI.
+3. **Fractional pixel arithmetic.** The font-size setting multiplies every
+   token by 0.9/1.0/1.15 and writes fractional px (e.g. `11.70px`) onto
+   `<html>`; three sidebar labels are literally `9.5px`.
+4. **Odd sizes at DPR 1.5.** Odd CSS px sizes land on half device pixels
+   (13px → 19.5 device px); nothing can pixel-snap those.
+5. **Synthetic styles.** No italic face is loaded — every `em`/`i` and
+   `font-style: italic` rule renders faux-oblique. `<strong>` resolves browser
+   default 700 against a font loaded only at 400/500/600.
+6. **Offline nondeterminism.** A local-first desktop app fetches its UI font
+   from a CDN on every launch; offline, rendering silently changes. JetBrains
+   Mono is also downloaded on every launch but is dead weight — a global
+   `* { font-family: … !important }` reset strips every monospace surface.
+
+This feature fixes all six in one coherent rework: bundled hinted fonts, a
+rem-based token layer with an integer-pixel size dial, a raised size floor, an
+explicit semantic-element base layer, deliberate monospace restoration, and
+VS Code-style whole-app zoom alongside the font-size dial.
+
+## User Decisions (recorded 2026-07-17)
+
+- **Size dial**: Small/Default/Large = **12/14/16px** root (default bumps the
+  base 13→14).
+- **Zoom**: evaluate VS Code-style app zoom — verdict adopted: **add engine
+  zoom alongside the dial, do not replace the dial** (VS Code ships exactly
+  this split).
+- **Monospace restoration scope**: filesystem paths, source-view IDs, manifest
+  paths, dev-tools contract names, **and RA/Dec coordinates**.
+
+## Functional Requirements
+
+### FR-001 — Bundle hinted Inter statics; delete CDN font loads
+
+Self-host the **six hinted static woff2s from the Inter v4.1 release**
+(`extras/woff-hinted/`): Regular, Medium, SemiBold, each in roman + italic
+(~858KB total). Remove both Google Fonts CDN imports.
+
+> **Correction to earlier working notes:** "hinted InterVariable" does not
+> exist. Binary probe of Inter-4.1.zip: `InterVariable.ttf` has zero hint
+> tables; the hinted assets are the static woff2s only (1,965/2,937 glyphs
+> instructed). The app uses exactly weights 400/500/600 and never animates
+> weight, so statics cost nothing. Do **not** bundle InterVariable or
+> InterDisplay.
+
+- `--alm-font-sans` keeps the family name `Inter` — no metric churn.
+- Keep `font-feature-settings: 'tnum' 1` (load-bearing: Inter v4 digits are
+  proportional by default). Add `'calt' 1`; evaluate `'case' 1` and `'zero' 1`
+  (slashed zero) for coordinate/table surfaces during Windows verification.
+- Pin the release (v4.1, 2024-11-15), record the release URL + SHA-256 in the
+  repo, ship the OFL `LICENSE.txt` alongside the fonts.
+
+### FR-002 — Rem token layer with an integer root dial
+
+- Convert the type-token layer to **rem**; the font-size setting writes a
+  single **integer** `html { font-size }` of 12, 14, or 16px. Delete the
+  per-token fractional scaler in `theme.ts` (`(px * scale).toFixed(2)`).
+- **All three dial positions MUST produce sane computed sizes**: no computed
+  font-size below the floor (FR-003), and no fractional CSS px from the token
+  layer at any dial stop (per-token rounding is the fallback mechanism if the
+  ratio set cannot land integers at all stops).
+- Re-derive the scale from the 14px base; top end ~24px; prefer even px values
+  (integer device pixels at DPR 1.0/1.5/2.0).
+
+### FR-003 — Raise the size floor; retire micro-sizes
+
+- Minimum rendered text size is **11px** at the default dial stop. Retire the
+  10px token; replace the 9/9.5px hardcodes.
+- Tokenize the **11 hardcoded px font-sizes** currently immune to the size
+  setting (sidebar/settings group labels, wizard titles and fine print, planner
+  SVG axis text, toast glyph).
+- Consolidate uppercase micro-labels onto one token (today: three sizes for
+  the same visual role) and introduce a letter-spacing token set (today: 8
+  divergent untokenized values across 13 files).
+
+### FR-004 — Semantic-element base layer
+
+Every semantic text element gets an explicit token-based rule; nothing falls
+through to browser defaults:
+
+- `strong, b { font-weight: var(--alm-weight-semibold) }` — never 700, never
+  synthetic bold.
+- `em, i` render with the **real italic faces** loaded by FR-001 — synthetic
+  italics are eliminated app-wide.
+- `code, pre, kbd` render in the monospace stack (FR-005) — a deliberate
+  visual change from today's Inter-forced rendering.
+- Remove or define the dead `font-mono` class (currently a silent no-op).
+- The global `* { font-family: … !important }` blanket is replaced by the base
+  layer + explicit stacks, so intentional deviations become possible and
+  auditable.
+
+### FR-005 — Monospace restoration
+
+Restore monospace on: filesystem paths, source-view IDs, manifest paths,
+dev-tools contract names, `code`/`pre` content, and **RA/Dec coordinate
+values**. The stripped-then-commented mono intents in the stylesheets are
+re-added deliberately (they do not resurface automatically).
+
+Default face: **system mono stack** (`ui-monospace, 'Cascadia Code',
+monospace`) — natively hinted on every OS at zero bytes. If Windows
+verification shows unacceptable cross-OS inconsistency, fall back to bundling
+JetBrains Mono woff2 (same pin-and-license discipline as FR-001). Either way
+the current CDN JetBrains Mono load is deleted with FR-001.
+
+### FR-006 — Whole-app engine zoom (alongside the dial)
+
+- Add Tauri v2 `setZoom` engine zoom: true layout zoom on WebView2 (ZoomFactor)
+  / WKWebView (pageZoom) / WebKitGTK. CSS `zoom` is explicitly rejected (it
+  contaminates viewport measurement and creates fractional font sizes).
+- App-owned shortcuts **Ctrl+= / Ctrl+− / Ctrl+0** (WebView2 exposes no
+  zoom-change event; owning the write path is the only reliable persistence).
+  Persist like the existing font-size setting.
+- Capability: `core:webview:allow-set-webview-zoom`.
+- **Sequencing constraint**: at 150% zoom the 1100×720 minimum window yields a
+  733px CSS viewport — below every layout floor. Zoom ships **after spec 054
+  (adaptive detail dock)** absorbs narrow viewports, or ships earlier capped at
+  **125%**.
+- Spec 054 clarification (one line, to be added there): its thresholds are
+  CSS-px viewport measurements, never Tauri window size.
+
+## Success Criteria
+
+- **SC-001**: Zero network font requests at runtime (assertable in E2E: no
+  requests to `fonts.googleapis.com`/`fonts.gstatic.com`); rendering is
+  byte-identical offline.
+- **SC-002**: Computed `font-family` on body text resolves to the bundled
+  Inter; `document.fonts` reports the six faces loaded, including italics.
+- **SC-003**: At every dial stop (12/14/16), `html` computed font-size is an
+  integer and no element's computed font-size is fractional or below 11px
+  (CI-assertable via computed-style sweep).
+- **SC-004**: The font-size setting scales **all** text — the 11 previously
+  hardcoded sizes included.
+- **SC-005**: No synthetic bold or synthetic italic: every rendered
+  weight/style maps to a loaded face.
+- **SC-006**: Mono surfaces (paths, IDs, contract names, RA/Dec values) render
+  in the monospace stack.
+- **SC-007**: With zoom shipped: zoom persists across restart, Ctrl+0 resets,
+  and a CI pin passes at minimum window × maximum zoom (layout does not break;
+  with 054: dock falls back to bottom mode).
+- **SC-008**: Windows real-app A/B verification (hinted vs current CDN build,
+  DPR 1.5, dark theme) confirms the crispness improvement before the token
+  rework lands — the font swap is the first, independently shippable step.
+
+## Verification Obligations (standing rules)
+
+- **CI UI assertions**: SC-001/002/003/007 are enforced as automated E2E
+  assertions, not manual checks.
+- **Journey delta**: the wave ships a **J10 (ingestion settings / appearance)
+  journey delta** covering the new dial semantics and zoom, per the standing
+  journey-deltas-per-wave rule.
+- **Windows verification**: a `verify-on-windows` scenario accompanies the
+  font-swap phase (SC-008) and the zoom phase.
+
+## Out of Scope
+
+- Font personality/brand exploration beyond the completed deep dive (Inter won
+  on evidence; IBM Plex Sans Var was the only near-contender and loses on
+  full-app migration cost for zero rendering gain).
+- Per-monitor/per-DPR token tables ("round to device pixels") — rejected;
+  hinting is the correct mechanism, and even-px preference captures the rest.
+- Spec 054's dock behavior itself (only the one-line CSS-px clarification).

--- a/specs/055-typography-rework/tasks.md
+++ b/specs/055-typography-rework/tasks.md
@@ -1,0 +1,62 @@
+# Tasks: Typography Rework (spec 055)
+
+Phases are independently shippable PRs; each phase gates the next.
+Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
+
+## Phase 1 — Font assets (FR-001; SC-001/002/005/008)
+
+- [ ] T001 Download Inter-4.1.zip (pinned release), extract the six hinted
+      woff2s (`extras/woff-hinted/Inter-{Regular,Italic,Medium,MediumItalic,SemiBold,SemiBoldItalic}.woff2`)
+      into `apps/desktop/src/assets/fonts/` with `LICENSE.txt` and a `FONTS.md`
+      recording release URL + per-file SHA-256.
+- [ ] T002 Replace the CDN `@import` (tokens.css:1) with six `@font-face`
+      blocks (`font-display: swap`); removes the JetBrains Mono CDN load too.
+      `--alm-font-sans` unchanged; keep `'tnum' 1`, add `'calt' 1` (reset.css).
+- [ ] T003 [depends T002] E2E assertions: zero requests to
+      fonts.googleapis.com/fonts.gstatic.com; `document.fonts` has the six
+      faces; computed body family = Inter (SC-001/002).
+- [ ] T004 [depends T002] `verify-on-windows` A/B scenario (DPR 1.5, dark,
+      Targets page) — gates Phase 2 (SC-008).
+
+## Phase 2 — Token layer + dial (FR-002/003; SC-003/004)
+
+- [ ] T010 Re-derive scale in rem: 14px base, even-px preference, 11px floor,
+      top ~24px; retire 10px token; map every existing token.
+- [ ] T011 [depends T010] theme.ts: delete 0.9/1.0/1.15 per-token scaler;
+      setting writes integer `html{font-size:12|14|16px}`; per-token rounding
+      guard so no dial stop computes fractional or sub-11px.
+- [ ] T012 Tokenize the 11 hardcoded px sizes (sidebar/settings labels 9.5px,
+      wizard titles/fine print, planner SVG axis 9px, toast glyph).
+- [ ] T013 Consolidate uppercase micro-label sizes to one token; add
+      letter-spacing tokens replacing the 8 divergent values.
+- [ ] T014 [depends T011] CI computed-style sweep: integer root at all stops,
+      nothing fractional, nothing below 11px (SC-003); all text scales with the
+      dial (SC-004).
+- [ ] T015 J10 journey delta for the new dial semantics.
+
+## Phase 3 — Semantic base layer + mono (FR-004/005; SC-005/006)
+
+- [ ] T020 Semantic base layer: `strong,b`→semibold token; `em,i`→real italic
+      faces; `code,pre,kbd`→mono stack; define-or-delete `font-mono`.
+- [ ] T021 [depends T020] Replace the `* { font-family !important }` blanket
+      with base layer + explicit stacks; re-add stripped mono declarations by
+      hand (template: feature-lists.css:783).
+- [ ] T022 [depends T021] Mono restoration surfaces: filesystem paths,
+      source-view IDs, manifest paths, dev-tools contract names, RA/Dec
+      coordinate values. Default `ui-monospace,'Cascadia Code',monospace`.
+- [ ] T023 [depends T022] Windows pass: verify mono stack acceptability
+      (escalate to bundled JetBrains Mono only on failure); evaluate
+      `'zero' 1`/`'case' 1` on coordinate surfaces.
+- [ ] T024 E2E: no synthetic bold/italic (loaded-face check, SC-005); mono
+      surfaces computed-family assertion (SC-006).
+
+## Phase 4 — Engine zoom (FR-006; SC-007) — after spec 054, or capped 125%
+
+- [ ] T030 Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
+      app-owned Ctrl+=/−/0; persistence mirrors fontSize setting.
+- [ ] T031 One-line clarification into spec 054: thresholds are CSS-px
+      viewport measurements, never Tauri window size.
+- [ ] T032 [depends T030] CI pin: min window 1100×720 × max zoom — layout
+      intact (with 054: dock bottom mode) (SC-007).
+- [ ] T033 [depends T030] J10 journey delta amendment (zoom);
+      `verify-on-windows` zoom scenario.

--- a/specs/055-typography-rework/tasks.md
+++ b/specs/055-typography-rework/tasks.md
@@ -54,7 +54,7 @@ Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
 
 - [ ] T030 Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
       app-owned Ctrl+=/−/0; persistence mirrors fontSize setting.
-- [ ] T031 One-line clarification into spec 054: thresholds are CSS-px
+- [x] T031 ~~One-line clarification into spec 054~~ DROPPED 2026-07-17: user chose to leave spec 054 orphaned (PR #937 untouched); Phase 4 ships capped at 125%, so the CSS-px
       viewport measurements, never Tauri window size.
 - [ ] T032 [depends T030] CI pin: min window 1100×720 × max zoom — layout
       intact (with 054: dock bottom mode) (SC-007).

--- a/specs/055-typography-rework/tasks.md
+++ b/specs/055-typography-rework/tasks.md
@@ -50,7 +50,7 @@ Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
 - [ ] T024 E2E: no synthetic bold/italic (loaded-face check, SC-005); mono
       surfaces computed-family assertion (SC-006).
 
-## Phase 4 — Engine zoom (FR-006; SC-007) — after spec 054, or capped 125%
+## Phase 4 — Engine zoom (FR-006; SC-007) — max 150% (054 orphaned; see spec FR-006 envelope)
 
 - [ ] T030 Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
       app-owned Ctrl+=/−/0; persistence mirrors fontSize setting.

--- a/specs/055-typography-rework/tasks.md
+++ b/specs/055-typography-rework/tasks.md
@@ -20,45 +20,45 @@ Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
 
 ## Phase 2 — Token layer + dial (FR-002/003; SC-003/004)
 
-- [ ] T010 Re-derive scale in rem: 14px base, even-px preference, 11px floor,
+- [x] T010 Re-derive scale in rem: 14px base, even-px preference, 11px floor,
       top ~24px; retire 10px token; map every existing token.
-- [ ] T011 [depends T010] theme.ts: delete 0.9/1.0/1.15 per-token scaler;
+- [x] T011 [depends T010] theme.ts: delete 0.9/1.0/1.15 per-token scaler;
       setting writes integer `html{font-size:12|14|16px}`; per-token rounding
       guard so no dial stop computes fractional or sub-11px.
-- [ ] T012 Tokenize the 11 hardcoded px sizes (sidebar/settings labels 9.5px,
+- [x] T012 Tokenize the 11 hardcoded px sizes (sidebar/settings labels 9.5px,
       wizard titles/fine print, planner SVG axis 9px, toast glyph).
-- [ ] T013 Consolidate uppercase micro-label sizes to one token; add
+- [x] T013 Consolidate uppercase micro-label sizes to one token; add
       letter-spacing tokens replacing the 8 divergent values.
-- [ ] T014 [depends T011] CI computed-style sweep: integer root at all stops,
+- [x] T014 [depends T011] CI computed-style sweep: integer root at all stops,
       nothing fractional, nothing below 11px (SC-003); all text scales with the
       dial (SC-004).
-- [ ] T015 J10 journey delta for the new dial semantics.
+- [x] T015 J10 journey delta for the new dial semantics.
 
 ## Phase 3 — Semantic base layer + mono (FR-004/005; SC-005/006)
 
-- [ ] T020 Semantic base layer: `strong,b`→semibold token; `em,i`→real italic
+- [x] T020 Semantic base layer: `strong,b`→semibold token; `em,i`→real italic
       faces; `code,pre,kbd`→mono stack; define-or-delete `font-mono`.
-- [ ] T021 [depends T020] Replace the `* { font-family !important }` blanket
+- [x] T021 [depends T020] Replace the `* { font-family !important }` blanket
       with base layer + explicit stacks; re-add stripped mono declarations by
       hand (template: feature-lists.css:783).
-- [ ] T022 [depends T021] Mono restoration surfaces: filesystem paths,
+- [x] T022 [depends T021] Mono restoration surfaces: filesystem paths,
       source-view IDs, manifest paths, dev-tools contract names, RA/Dec
       coordinate values. Default `ui-monospace,'Cascadia Code',monospace`.
-- [ ] T023 [depends T022] Windows pass: verify mono stack acceptability
+- [x] T023 [depends T022] Windows pass: verify mono stack acceptability
       (escalate to bundled JetBrains Mono only on failure); evaluate
       `'zero' 1`/`'case' 1` on coordinate surfaces.
-- [ ] T024 E2E: no synthetic bold/italic (loaded-face check, SC-005); mono
+- [x] T024 E2E: no synthetic bold/italic (loaded-face check, SC-005); mono
       surfaces computed-family assertion (SC-006).
 
 ## Phase 4 — Engine zoom (FR-006; SC-007) — max 150% (054 orphaned; see spec FR-006 envelope)
 
-- [ ] T030 Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
+- [x] T030 Capability `core:webview:allow-set-webview-zoom`; `setZoom` wired to
       app-owned Ctrl+=/−/0; persistence mirrors fontSize setting.
 - [x] T031 ~~One-line clarification into spec 054~~ DROPPED 2026-07-17: user chose to leave spec 054 orphaned (PR #937 untouched); Phase 4 ships capped at 125%, so the CSS-px
       viewport measurements, never Tauri window size.
-- [ ] T032 [depends T030] CI pin: min window 1100×720 × max zoom — layout
+- [x] T032 [depends T030] CI pin: min window 1100×720 × max zoom — layout
       intact (with 054: dock bottom mode) (SC-007).
-- [ ] T033 [depends T030] J10 journey delta amendment (zoom);
+- [x] T033 [depends T030] J10 journey delta amendment (zoom);
       `verify-on-windows` zoom scenario.
 
 > **Phase 1 verification record (2026-07-17)**: T001–T003 merged via PR #947
@@ -69,3 +69,13 @@ Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
 > faces at 11–16px incl. coordinates/Greek glyphs confirmed good; runtime
 > probes: 6 bundled faces registered, 0 CDN requests, only weights
 > 400/500/600 in use. **Phase 2 gate: OPEN.**
+
+> **Completion record (2026-07-17)**: Phase 2 merged via PR #957 (integer dial
+> 12/14/16, all hardcoded sizes tokenized, letter-spacing tokens, J10 Δ6);
+> Phase 3 via PR #956 (semantic base layer, blanket removal, mono restoration
+> incl. RA/Dec split on user request, `.alm-mono` resurrection); Phase 4 via
+> PR #958 (`532f11d6` — zoom 90–150%, Ctrl+=/−/0, FR-006 envelope pins, J10
+> Δ7). T023 executed live on Windows 2026-07-17: mono surfaces + RA/Dec
+> confirmed by the user ("amazing" on zoom); system mono stack accepted, no
+> JetBrains Mono bundle needed. Follow-ups: PR #963 (pills stay sans in mono
+> cells), issue #962 (title-bar truncation, spec:043). Spec 055: COMPLETE.

--- a/specs/055-typography-rework/tasks.md
+++ b/specs/055-typography-rework/tasks.md
@@ -5,17 +5,17 @@ Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
 
 ## Phase 1 — Font assets (FR-001; SC-001/002/005/008)
 
-- [ ] T001 Download Inter-4.1.zip (pinned release), extract the six hinted
+- [x] T001 Download Inter-4.1.zip (pinned release), extract the six hinted
       woff2s (`extras/woff-hinted/Inter-{Regular,Italic,Medium,MediumItalic,SemiBold,SemiBoldItalic}.woff2`)
       into `apps/desktop/src/assets/fonts/` with `LICENSE.txt` and a `FONTS.md`
       recording release URL + per-file SHA-256.
-- [ ] T002 Replace the CDN `@import` (tokens.css:1) with six `@font-face`
+- [x] T002 Replace the CDN `@import` (tokens.css:1) with six `@font-face`
       blocks (`font-display: swap`); removes the JetBrains Mono CDN load too.
       `--alm-font-sans` unchanged; keep `'tnum' 1`, add `'calt' 1` (reset.css).
-- [ ] T003 [depends T002] E2E assertions: zero requests to
+- [x] T003 [depends T002] E2E assertions: zero requests to
       fonts.googleapis.com/fonts.gstatic.com; `document.fonts` has the six
       faces; computed body family = Inter (SC-001/002).
-- [ ] T004 [depends T002] `verify-on-windows` A/B scenario (DPR 1.5, dark,
+- [x] T004 [depends T002] `verify-on-windows` A/B scenario (DPR 1.5, dark,
       Targets page) — gates Phase 2 (SC-008).
 
 ## Phase 2 — Token layer + dial (FR-002/003; SC-003/004)
@@ -60,3 +60,12 @@ Dependency graph: P1 → P2 → P3; P4 after spec 054 (or capped 125%).
       intact (with 054: dock bottom mode) (SC-007).
 - [ ] T033 [depends T030] J10 journey delta amendment (zoom);
       `verify-on-windows` zoom scenario.
+
+> **Phase 1 verification record (2026-07-17)**: T001–T003 merged via PR #947
+> (`f19eb1ad`). T004/SC-008 executed live on the user's Windows machine (DPR
+> 1.5, dark theme) via the Tauri MCP bridge instead of a written scenario:
+> all 7 pages (Targets, Sessions, Calibration, Inbox, Projects, Archive,
+> Settings) confirmed **crisper** by the user; specimen overlay of all six
+> faces at 11–16px incl. coordinates/Greek glyphs confirmed good; runtime
+> probes: 6 bundled faces registered, 0 CDN requests, only weights
+> 400/500/600 in use. **Phase 2 gate: OPEN.**


### PR DESCRIPTION
Consolidated spec + implementation plan from the five-lane typography investigation (live Windows rendering probe, repo-wide audit, industry research, zoom evaluation, font-selection deep dive).

**Key correction to earlier working notes:** \"hinted InterVariable\" does not exist — Inter's variable font ships with zero hint tables. The plan bundles the six **hinted static woff2s** from Inter v4.1 (400/500/600 roman+italic, ~858KB) and deletes both Google CDN font loads.

Covers (specs/055-typography-rework/):
- FR-001 bundled hinted Inter statics, CDN removal, pinned release + OFL license
- FR-002 rem tokens + integer root dial 12/14/16 (user decision), fractional-scaler deletion
- FR-003 11px floor, retire 10px token, tokenize 11 hardcoded sizes, letter-spacing tokens
- FR-004 semantic base layer (strong/em/code/pre), real italics, blanket-!important removal
- FR-005 mono restoration incl. RA/Dec coordinates (user decision)
- FR-006 Tauri setZoom engine zoom alongside the dial (VS Code split); ships after spec 054 or capped 125%

Verification obligations encoded: CI UI assertions (SC-001/002/003/007), J10 journey delta, verify-on-windows A/B for the font swap (SC-008).

Spec + plan only — no implementation in this PR.