### PR TITLE
fix: correct flat calibration matching for rotator angles near 0/360°

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6219,8 +6219,9 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-match"
-version = "0.4.0"
-source = "git+https://github.com/nightwatch-astro/target-match#8dbc0758cd51fd08f0aab67871a87f585fcf1029"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c777eb96e32abd00fb956baf8d243b6f93006f0ea52faa8440b81114c2fc7f"
 dependencies = [
  "skymath 0.4.0",
  "thiserror 2.0.18",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5617,16 +5617,6 @@ dependencies = [
 
 [[package]]
 name = "skymath"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98d582775f713520fed98cc8fd1ecaac9ca87f11447b557c0ab3892bf9af9cbe"
-dependencies = [
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "skymath"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a10b1f9678d1f8e2aaa7f9f3af28e0c5d0bbb9c544ae563e08b5dc1d9fbc2bfb"
@@ -6229,11 +6219,10 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-match"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e2e3f70f5c67c7a6fc75a2b0afd4bf22c27228d0e08a76af481a25b8b2e2ec9"
+version = "0.4.0"
+source = "git+https://github.com/nightwatch-astro/target-match#8dbc0758cd51fd08f0aab67871a87f585fcf1029"
 dependencies = [
- "skymath 0.3.0",
+ "skymath 0.4.0",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "sessions",
  "sha2 0.10.9",
  "simbad-resolver",
- "skymath 0.3.0",
+ "skymath 0.4.0",
  "sqlx",
  "target-match",
  "targeting",
@@ -865,6 +865,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
+ "skymath 0.4.0",
  "time",
  "uuid",
 ]
@@ -1500,7 +1501,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1739,7 +1740,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2276,7 +2277,7 @@ dependencies = [
  "gobject-sys 0.21.5",
  "libc",
  "system-deps 7.0.8",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3327,7 +3328,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
- "skymath 0.3.0",
+ "skymath 0.4.0",
  "thiserror 2.0.18",
 ]
 
@@ -3513,7 +3514,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4560,7 +4561,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -4991,7 +4992,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5049,7 +5050,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5474,7 +5475,7 @@ name = "sessions"
 version = "0.1.0"
 dependencies = [
  "domain_core",
- "skymath 0.3.0",
+ "skymath 0.4.0",
  "thiserror 2.0.18",
  "time",
  "uuid",
@@ -5619,6 +5620,15 @@ name = "skymath"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98d582775f713520fed98cc8fd1ecaac9ca87f11447b557c0ab3892bf9af9cbe"
+dependencies = [
+ "thiserror 2.0.18",
+ "time",
+]
+
+[[package]]
+name = "skymath"
+version = "0.4.0"
+source = "git+https://github.com/nightwatch-astro/skymath#c8e1204d34deeb88c438390a0d658b29bb1b5c42"
 dependencies = [
  "thiserror 2.0.18",
  "time",
@@ -6231,7 +6241,7 @@ name = "targeting"
 version = "0.1.0"
 dependencies = [
  "simbad-resolver",
- "skymath 0.3.0",
+ "skymath 0.4.0",
  "target-match",
  "uuid",
 ]
@@ -6246,7 +6256,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.3.0",
+ "skymath 0.4.0",
  "sqlx",
  "targeting",
  "tempfile",
@@ -6779,7 +6789,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7883,7 +7893,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -8358,7 +8368,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d6f32a0ff4a9f6f01231eb2059cc85479330739333e0e58cadf03b6af2cca10"
 dependencies = [
  "cfg-if",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5628,7 +5628,8 @@ dependencies = [
 [[package]]
 name = "skymath"
 version = "0.4.0"
-source = "git+https://github.com/nightwatch-astro/skymath#c8e1204d34deeb88c438390a0d658b29bb1b5c42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10b1f9678d1f8e2aaa7f9f3af28e0c5d0bbb9c544ae563e08b5dc1d9fbc2bfb"
 dependencies = [
  "thiserror 2.0.18",
  "time",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,3 +135,9 @@ pedantic = { level = "warn", priority = -1 }
 #   cargo clippy -- -W clippy::disallowed_methods
 # See docs/development/persistence-layer-hardening.md.
 disallowed_methods = "allow"
+
+# TEMPORARY: skymath 0.4.0 (CircularMean/circular_distance, issue #921) is
+# merged upstream but the crates.io publish is still in flight. Remove this
+# patch once 0.4.0 is live and `cargo update -p skymath` picks it up.
+[patch.crates-io]
+skymath = { git = "https://github.com/nightwatch-astro/skymath" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,3 +135,11 @@ pedantic = { level = "warn", priority = -1 }
 #   cargo clippy -- -W clippy::disallowed_methods
 # See docs/development/persistence-layer-hardening.md.
 disallowed_methods = "allow"
+
+# TEMPORARY: target-match's v0.4.0 tag predates its own skymath 0.3->0.4 bump
+# (nightwatch-astro/target-match#19, merged after that release) and its
+# crates.io publish never ran anyway — release-please's own action step
+# failed on a "PR is locked" bug before reaching `cargo publish`. Track main
+# (has the skymath 0.4 bump) until a real release lands on crates.io.
+[patch.crates-io]
+target-match = { git = "https://github.com/nightwatch-astro/target-match" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,11 +135,3 @@ pedantic = { level = "warn", priority = -1 }
 #   cargo clippy -- -W clippy::disallowed_methods
 # See docs/development/persistence-layer-hardening.md.
 disallowed_methods = "allow"
-
-# TEMPORARY: target-match's v0.4.0 tag predates its own skymath 0.3->0.4 bump
-# (nightwatch-astro/target-match#19, merged after that release) and its
-# crates.io publish never ran anyway — release-please's own action step
-# failed on a "PR is locked" bug before reaching `cargo publish`. Track main
-# (has the skymath 0.4 bump) until a real release lands on crates.io.
-[patch.crates-io]
-target-match = { git = "https://github.com/nightwatch-astro/target-match" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,9 +135,3 @@ pedantic = { level = "warn", priority = -1 }
 #   cargo clippy -- -W clippy::disallowed_methods
 # See docs/development/persistence-layer-hardening.md.
 disallowed_methods = "allow"
-
-# TEMPORARY: skymath 0.4.0 (CircularMean/circular_distance, issue #921) is
-# merged upstream but the crates.io publish is still in flight. Remove this
-# patch once 0.4.0 is live and `cargo update -p skymath` picks it up.
-[patch.crates-io]
-skymath = { git = "https://github.com/nightwatch-astro/skymath" }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -32,7 +32,7 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
-skymath = "0.3"
+skymath = "0.4"
 sqlx.workspace = true
 target-match = "0.3"
 # spec 052 P3: the cone-search suggestion use case needs the upstream crate's

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -34,7 +34,7 @@ serde_json.workspace = true
 sha2.workspace = true
 skymath = "0.4"
 sqlx.workspace = true
-target-match = "0.3"
+target-match = "0.4"
 # spec 052 P3: the cone-search suggestion use case needs the upstream crate's
 # own `ResolvedIdentity` (otype_raw/common_name/aliases, OQ-1/OQ-2 ranking
 # inputs) and `PositionResolver` types directly — mirrors the existing

--- a/crates/calibration/core/Cargo.toml
+++ b/crates/calibration/core/Cargo.toml
@@ -11,6 +11,9 @@ path = "src/lib.rs"
 serde = { workspace = true }
 serde_json = { workspace = true }
 uuid = { workspace = true }
+# Issue #921: circular_distance replaces the hand-rolled `(a - b).abs()` flat
+# rotation delta, which max-penalized correct flats straddling the 0/360 seam.
+skymath = "0.4"
 # spec 042 (T201): ISO-8601 date parsing + Julian-day arithmetic for
 # observing-night proximity (replaces the hand-rolled YMD parse + JDN math).
 time = { workspace = true }

--- a/crates/calibration/core/src/rules/flat.rs
+++ b/crates/calibration/core/src/rules/flat.rs
@@ -69,7 +69,13 @@ pub fn evaluate(
     let rot_cfg = config.flat_rotation_config();
     match (session.rotation_deg, master.rotation_deg) {
         (Some(sr), Some(mr)) => {
-            let delta = (sr - mr).abs();
+            // Issue #921: rotator angles are circular — plain `.abs()` scored
+            // 359.9° vs 0.1° as 359.8° instead of the true 0.2° apart.
+            let delta = skymath::circular_distance(
+                skymath::Angle::from_degrees(sr),
+                skymath::Angle::from_degrees(mr),
+            )
+            .degrees();
             match rot_cfg.penalty(delta) {
                 Some(penalty) => {
                     matched.push(MatchedDim::soft(Dimension::Rotation, sr, mr, delta));
@@ -255,6 +261,25 @@ mod tests {
         );
         let r = r.unwrap();
         assert!(r.dimensions_mismatched.iter().any(|d| d.dimension == "rotation"));
+    }
+
+    #[test]
+    fn rotation_wraparound_across_0_360_seam_matched() {
+        // Issue #921: 359.9° vs 0.1° is truly 0.2° apart, not 359.8° — must
+        // match within the default ±0.5° tolerance, not be max-penalized.
+        let s = SessionInfo { rotation_deg: Some(359.9), ..session() };
+        let r = evaluate(
+            &s,
+            &master_flat("Ha", "1x1", "train-a", 100.0, 0.1, "2026-01-15"),
+            &MatchingRuleConfig::default(),
+        );
+        let r = r.unwrap();
+        assert!(
+            r.dimensions_matched.iter().any(|d| d.dimension == "rotation"),
+            "359.9 vs 0.1 should match within tolerance, got mismatched={:?}",
+            r.dimensions_mismatched
+        );
+        assert!(!r.dimensions_mismatched.iter().any(|d| d.dimension == "rotation"));
     }
 
     #[test]

--- a/crates/calibration/core/src/rules/flat.rs
+++ b/crates/calibration/core/src/rules/flat.rs
@@ -283,6 +283,66 @@ mod tests {
     }
 
     #[test]
+    fn rotation_far_apart_delta_is_shortest_arc_not_naive_diff() {
+        // 45° vs 295°: circularly 110° apart (the short way, through 0/360°
+        // seam via 350°); a naive |a-b| would wrongly give 250°.
+        let s = SessionInfo { rotation_deg: Some(45.0), ..session() };
+        let r = evaluate(
+            &s,
+            &master_flat("Ha", "1x1", "train-a", 100.0, 295.0, "2026-01-15"),
+            &MatchingRuleConfig::default(),
+        );
+        let r = r.unwrap();
+        let delta = r
+            .dimensions_mismatched
+            .iter()
+            .find(|d| d.dimension == "rotation")
+            .and_then(|d| d.delta)
+            .expect("rotation should be out of tolerance with a delta");
+        assert!((delta - 110.0).abs() < 1e-9, "expected 110.0, got {delta}");
+    }
+
+    #[test]
+    fn rotation_antipodal_boundary_delta_is_180() {
+        // 0° vs 180°: maximally distant on the circle either direction.
+        let r = evaluate(
+            &session(),
+            &master_flat("Ha", "1x1", "train-a", 100.0, 180.0, "2026-01-15"),
+            &MatchingRuleConfig::default(),
+        );
+        let r = r.unwrap();
+        let delta = r
+            .dimensions_mismatched
+            .iter()
+            .find(|d| d.dimension == "rotation")
+            .and_then(|d| d.delta)
+            .expect("rotation should be out of tolerance with a delta");
+        assert!((delta - 180.0).abs() < 1e-9, "expected 180.0, got {delta}");
+    }
+
+    #[test]
+    fn rotation_circular_distance_property_bounded_and_correct() {
+        // The exact function `evaluate` calls for the rotation delta: any
+        // pair of angles must be within [0, 180], and match the textbook
+        // shortest-arc formula — the naive `(a - b).abs()` this replaces
+        // (issue #921) can exceed 180 and blow past 360 near the seam.
+        let angles = [0.0, 0.1, 45.0, 90.0, 180.0, 270.0, 295.0, 359.0, 359.9];
+        for &a in &angles {
+            for &b in &angles {
+                let d = skymath::circular_distance(
+                    skymath::Angle::from_degrees(a),
+                    skymath::Angle::from_degrees(b),
+                )
+                .degrees();
+                assert!((0.0..=180.0).contains(&d), "distance {d} out of [0,180] for ({a}, {b})");
+                let raw = (a - b).abs().rem_euclid(360.0);
+                let expected = raw.min(360.0 - raw);
+                assert!((d - expected).abs() < 1e-9, "({a}, {b}): got {d}, expected {expected}");
+            }
+        }
+    }
+
+    #[test]
     fn different_night_fallback_reason() {
         let r = evaluate(
             &session(),

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-skymath = "0.3"
+skymath = "0.4"
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../domain/core" }
-skymath = "0.3"
+skymath = "0.4"
 thiserror = { workspace = true }
 time = { workspace = true }
 

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -459,7 +459,11 @@ fn best_matching_group(
             }
             let rotation_distance =
                 rotation_circular_distance_deg(rotation_deg, group.representative_rotation_deg());
-            if rotation_distance > f64::from(params.rotation_tolerance_deg) {
+            // Epsilon guards the inclusive boundary: skymath's circular
+            // distance round-trips through radians, so a degree input exactly
+            // at tolerance can come back ~1e-14° over (far below any real
+            // rotator precision) and spuriously fail this check.
+            if rotation_distance > f64::from(params.rotation_tolerance_deg) + 1e-9 {
                 return None;
             }
             Some((idx, pointing_distance))
@@ -489,8 +493,7 @@ struct GroupAccumulator {
     sum_sin_ra: f64,
     sum_cos_ra: f64,
     sum_dec: f64,
-    sum_sin_rot: f64,
-    sum_cos_rot: f64,
+    rotation_mean: skymath::CircularMean,
     count: u32,
     seed_used_fallback: bool,
     session_ids: Vec<EntityId>,
@@ -504,8 +507,7 @@ impl GroupAccumulator {
             sum_sin_ra: 0.0,
             sum_cos_ra: 0.0,
             sum_dec: 0.0,
-            sum_sin_rot: 0.0,
-            sum_cos_rot: 0.0,
+            rotation_mean: skymath::CircularMean::new(),
             count: 0,
             seed_used_fallback: false,
             session_ids: Vec::new(),
@@ -526,9 +528,7 @@ impl GroupAccumulator {
         self.sum_sin_ra += ra_rad.sin();
         self.sum_cos_ra += ra_rad.cos();
         self.sum_dec += pointing.dec_deg;
-        let rot_rad = f64::from(rotation_deg).to_radians();
-        self.sum_sin_rot += rot_rad.sin();
-        self.sum_cos_rot += rot_rad.cos();
+        self.rotation_mean.push(skymath::Angle::from_degrees(f64::from(rotation_deg)));
         self.count += 1;
         self.session_ids.push(session_id);
     }
@@ -545,11 +545,13 @@ impl GroupAccumulator {
         }
     }
 
-    // Angles live in [-180, 180] degrees; an f64->f32 rotation angle never
-    // approaches f32's magnitude limits, so this narrows precision, not range.
+    // `CircularMean::mean` normalizes to [0, 360); an f64->f32 rotation angle
+    // never approaches f32's magnitude limits, so this narrows precision, not
+    // range. `None` only when nothing was pushed — callers only call this
+    // once `count > 0` (see `representative_pointing`'s doc comment).
     #[allow(clippy::cast_possible_truncation)]
     fn representative_rotation_deg(&self) -> f32 {
-        self.sum_sin_rot.atan2(self.sum_cos_rot).to_degrees() as f32
+        self.rotation_mean.mean().map_or(0.0, |a| a.degrees() as f32)
     }
 }
 
@@ -596,8 +598,11 @@ fn to_equatorial(p: Pointing) -> skymath::Equatorial {
 /// modulo 360° (range `[0, 180]`). See module docs for why 360°, not 180°.
 #[must_use]
 pub fn rotation_circular_distance_deg(a: f32, b: f32) -> f64 {
-    let diff = (f64::from(a) - f64::from(b)).rem_euclid(360.0);
-    diff.min(360.0 - diff)
+    skymath::circular_distance(
+        skymath::Angle::from_degrees(f64::from(a)),
+        skymath::Angle::from_degrees(f64::from(b)),
+    )
+    .degrees()
 }
 
 /// Circular mean of a set of degree angles (mod 360°), for standalone testing

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -888,6 +888,30 @@ mod tests {
         assert!((rotation_circular_distance_deg(0.0, 180.0) - 180.0).abs() < 1e-9);
     }
 
+    #[test]
+    fn rotation_distance_shortest_arc_not_naive_diff() {
+        // 45 and 295 degrees are 110deg apart circularly (via the 350deg/0deg
+        // seam); a naive |a-b| would wrongly give 250.
+        assert!((rotation_circular_distance_deg(45.0, 295.0) - 110.0).abs() < 1e-9);
+    }
+
+    #[test]
+    fn rotation_distance_property_bounded_and_correct() {
+        // Same shortest-arc formula the flat calibration rule relies on
+        // (calibration_core issue #921) — any pair of angles must land in
+        // [0, 180], never the naive `(a - b).abs()` this delegates away from.
+        let angles: [f32; 9] = [0.0, 0.1, 45.0, 90.0, 180.0, 270.0, 295.0, 359.0, 359.9];
+        for &a in &angles {
+            for &b in &angles {
+                let d = rotation_circular_distance_deg(a, b);
+                assert!((0.0..=180.0).contains(&d), "distance {d} out of [0,180] for ({a}, {b})");
+                let raw = (f64::from(a) - f64::from(b)).abs().rem_euclid(360.0);
+                let expected = raw.min(360.0 - raw);
+                assert!((d - expected).abs() < 1e-9, "({a}, {b}): got {d}, expected {expected}");
+            }
+        }
+    }
+
     // ── FOV fallback path ────────────────────────────────────────────────────
 
     #[test]

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -28,7 +28,7 @@ path = "src/lib.rs"
 # trade.
 
 [dependencies]
-target-match = "0.3"
+target-match = "0.4"
 skymath = "0.4"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 simbad-resolver = "0.3.0"

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [dependencies]
 target-match = "0.3"
-skymath = "0.3"
+skymath = "0.4"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 simbad-resolver = "0.3.0"
 

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -53,7 +53,7 @@ persistence_db = { path = "../../persistence/db" }
 simbad-resolver = "0.3.0"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
-skymath = "0.3"
+skymath = "0.4"
 
 [dev-dependencies]
 # `#[tokio::test]` only — no production `tokio` usage in this crate (the


### PR DESCRIPTION
## Summary
- Flat-frame calibration matching compared rotator angles with a plain subtraction, so a correct flat at 359.9° vs a light session at 0.1° was scored as 359.8° apart instead of the true 0.2° — getting max-penalized or flagged as a rotation mismatch. Fixed by using proper circular-angle comparison.
- The same fix is applied to session framing-group clustering, which computed the identical quantity by hand in a second place.

Closes #921

## Test plan
- [x] `cargo test -p calibration_core -p sessions` — 116 passed, including a new regression test for the 359.9°/0.1° case
- [x] `cargo clippy -p calibration_core -p sessions --all-targets -- -D warnings` — clean
- [ ] Remove the temporary `[patch.crates-io]` git pin once `skymath` 0.4.0 is live on crates.io and re-verify (still publishing at push time)

## Spec Context
Adopts `skymath` 0.4 (`CircularMean` / `circular_distance`) workspace-wide, replacing hand-rolled circular-angle math in `crates/calibration/core/src/rules/flat.rs` and `crates/sessions/src/clustering.rs`.