### PR TITLE
ci(e2e): per-OS builder/shard/gate chains for per-OS failure isolation

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -46,11 +46,11 @@
 # Layer-1 `cargo test --workspace` (ci.yml) stays required on macOS; only this
 # real-UI WebDriver leg is affected.
 #
-# Job DAG (build-once, test-sharded):
+# Job DAG (build-once, test-sharded, one independent chain per OS):
 #
-#   changes ─┬─ build-frontend (ubuntu, once) ──┐
-#            └─ build-app — per OS ─────────────┴─ e2e shard 1/2 ┐
-#                                                  e2e shard 2/2 ┴─ gate per OS
+#   changes ── build-frontend (ubuntu, once) ──┐          (per OS:)
+#          └── build-app-<os> ─────────────────┴─ shard 1/2 ┐
+#                                                 shard 2/2 ┴─ gate (<os>)
 #
 # - The frontend is built ONCE (VITE_E2E dist is OS-independent) and shared
 #   as an artifact; previously every matrix leg rebuilt it.
@@ -60,8 +60,15 @@
 #   the shards via artifacts (`ALM_E2E_APP_BIN` + `--archive-file`).
 # - Every journey still runs on every OS (no OS-splitting of tests); sharding
 #   is `--partition count:N/2` WITHIN each OS, halving serial wall time.
+# - Builder/shard/gate are written out PER OS instead of as one os-matrix:
+#   GitHub `needs` can only target a whole job (never a single matrix leg),
+#   so a matrixed builder would let one OS's build failure skip the other
+#   OS's shards too. Per-OS jobs restore the pre-DAG per-OS failure
+#   isolation. YAML anchors are unsupported by Actions, hence the
+#   duplication; keep the three chains textually in sync when editing.
 # - The per-OS gate jobs preserve the pre-DAG check names
-#   ("Real-UI E2E — <os>") so anything keyed on those names keeps working.
+#   ("Real-UI E2E — <os>") and each gate depends only on its own OS's
+#   shards, so the names behave exactly like the old per-OS jobs.
 
 name: Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)
 
@@ -104,7 +111,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.decide.outputs.run }}
-      os_matrix: ${{ steps.matrix.outputs.os_matrix }}
+      run_macos: ${{ steps.macos.outputs.run_macos }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v4
@@ -143,19 +150,14 @@ jobs:
           fi
           echo "run=$run" >> "$GITHUB_OUTPUT"
           echo "e2e changes: run=$run"
-      # macOS only joins the matrix on an explicit workflow_dispatch with
+      # The macOS chain only runs on an explicit workflow_dispatch with
       # run_macos=true (see header comment, issue #489) — never on
       # pull_request/push.
-      - id: matrix
+      - id: macos
         shell: bash
         env:
           RUN_MACOS: ${{ github.event_name == 'workflow_dispatch' && inputs.run_macos == true }}
-        run: |
-          if [ "$RUN_MACOS" = "true" ]; then
-            echo 'os_matrix=["ubuntu-latest","windows-latest","macos-latest"]' >> "$GITHUB_OUTPUT"
-          else
-            echo 'os_matrix=["ubuntu-latest","windows-latest"]' >> "$GITHUB_OUTPUT"
-          fi
+        run: echo "run_macos=$RUN_MACOS" >> "$GITHUB_OUTPUT"
 
   # Build the VITE_E2E frontend dist ONCE (it is OS-independent) and share it
   # with every test shard as an artifact. Content-keyed cache: a run whose
@@ -206,21 +208,23 @@ jobs:
           path: apps/desktop/dist
           retention-days: 1
 
-  # Build the e2e-feature app binary + the nextest test archive once per OS on
-  # a dedicated builder runner. Content-keyed cache on the Rust inputs: a
-  # frontend/docs-only change restores both outputs and skips the whole Rust
-  # toolchain + build. The `e2e` feature MUST be absent from release builds.
-  build-app:
-    name: Build app — ${{ matrix.os }}
+  # ---------------------------------------------------------------------------
+  # Per-OS builder: e2e-feature app binary + nextest test archive on a
+  # dedicated runner. Content-keyed cache on the Rust inputs: a frontend/
+  # docs-only change restores both outputs and skips the whole Rust toolchain
+  # + build. The `e2e` feature MUST be absent from release builds.
+  #
+  # build-app-windows / build-app-macos are line-for-line copies of this job
+  # with only os-name/APP_BIN/Linux-deps differences (see header: why per-OS
+  # jobs instead of a matrix).
+  # ---------------------------------------------------------------------------
+  build-app-ubuntu:
+    name: Build app — ubuntu-latest
     needs: changes
-    strategy:
-      fail-fast: false
-      matrix:
-        os: ${{ fromJson(needs.changes.outputs.os_matrix) }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
-      APP_BIN: target/debug/desktop_shell${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+      APP_BIN: target/debug/desktop_shell
     steps:
       - uses: actions/checkout@v4
 
@@ -232,12 +236,12 @@ jobs:
           path: |
             ${{ env.APP_BIN }}
             e2e-archive.tar.zst
-          key: e2e-app-${{ matrix.os }}-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
+          key: e2e-app-ubuntu-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
 
       # Tauri needs system webview/GTK libs to build on Linux.
       # No webkit2gtk-driver — the plugin replaces the external driver.
       - name: Install Tauri Linux system deps
-        if: runner.os == 'Linux' && needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -250,7 +254,7 @@ jobs:
       - uses: Swatinem/rust-cache@v2
         if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
         with:
-          shared-key: "rust-e2e-${{ matrix.os }}"
+          shared-key: "rust-e2e-ubuntu-latest"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
@@ -276,29 +280,146 @@ jobs:
       - uses: actions/upload-artifact@v4
         if: needs.changes.outputs.run == 'true'
         with:
-          name: e2e-build-${{ matrix.os }}
+          name: e2e-build-ubuntu-latest
           path: |
             ${{ env.APP_BIN }}
             e2e-archive.tar.zst
           retention-days: 1
 
-  real-ui-e2e:
-    name: Real-UI E2E shard — ${{ matrix.os }} ${{ matrix.shard }}/2
-    needs: [changes, build-frontend, build-app]
+  # Copy of build-app-ubuntu for Windows (no Linux system deps; .exe binary).
+  build-app-windows:
+    name: Build app — windows-latest
+    needs: changes
+    runs-on: windows-latest
+    timeout-minutes: 45
+    env:
+      APP_BIN: target/debug/desktop_shell.exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore app + test archive by content key
+        if: needs.changes.outputs.run == 'true'
+        id: app-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.APP_BIN }}
+            e2e-archive.tar.zst
+          key: e2e-app-windows-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+
+      - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        with:
+          shared-key: "rust-e2e-windows-latest"
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@nextest
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+
+      - name: Stub frontend dist for tauri-build
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
+
+      - name: Build desktop_shell with e2e feature
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        run: cargo build -p desktop_shell --features e2e
+
+      - name: Archive e2e test binaries
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
+
+      - uses: actions/upload-artifact@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          name: e2e-build-windows-latest
+          path: |
+            ${{ env.APP_BIN }}
+            e2e-archive.tar.zst
+          retention-days: 1
+
+  # Copy of build-app-ubuntu for the dispatch-only macOS chain (issue #489).
+  build-app-macos:
+    name: Build app — macos-latest
+    needs: changes
+    if: needs.changes.outputs.run_macos == 'true'
+    runs-on: macos-latest
+    timeout-minutes: 45
+    env:
+      APP_BIN: target/debug/desktop_shell
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Restore app + test archive by content key
+        if: needs.changes.outputs.run == 'true'
+        id: app-cache
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ env.APP_BIN }}
+            e2e-archive.tar.zst
+          key: e2e-app-macos-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
+
+      - uses: dtolnay/rust-toolchain@stable
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+
+      - uses: Swatinem/rust-cache@v2
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        with:
+          shared-key: "rust-e2e-macos-latest"
+          cache-on-failure: true
+
+      - uses: taiki-e/install-action@nextest
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+
+      - name: Stub frontend dist for tauri-build
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        shell: bash
+        run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
+
+      - name: Build desktop_shell with e2e feature
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        run: cargo build -p desktop_shell --features e2e
+
+      - name: Archive e2e test binaries
+        if: needs.changes.outputs.run == 'true' && steps.app-cache.outputs.cache-hit != 'true'
+        run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
+
+      - uses: actions/upload-artifact@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          name: e2e-build-macos-latest
+          path: |
+            ${{ env.APP_BIN }}
+            e2e-archive.tar.zst
+          retention-days: 1
+
+  # ---------------------------------------------------------------------------
+  # Per-OS test shards: download the prebuilt frontend + app/test-archive
+  # artifacts and run half the journeys each (`--partition count:N/2`) — no
+  # Rust compilation in these jobs. Depending only on their OWN OS's builder
+  # keeps a build failure on one OS from skipping the other OS's tests.
+  #
+  # real-ui-e2e-windows / -macos are copies of this job (see header).
+  # ---------------------------------------------------------------------------
+  real-ui-e2e-ubuntu:
+    name: Real-UI E2E shard — ubuntu-latest ${{ matrix.shard }}/2
+    needs: [changes, build-frontend, build-app-ubuntu]
     strategy:
       fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.changes.outputs.os_matrix) }}
         shard: [1, 2]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     # Backstop beyond nextest's own slow-timeout + the 120s app-launch
     # deadline. Pre-DAG full-job durations were ~13-20min on ubuntu/windows
     # including the build (CI runs 29031373925, 29033234950); a shard runs
-    # half the journeys with no build, so 30min is generous headroom. macOS
-    # keeps extra room for the 120s-per-attempt launch-failure loop (#489).
-    timeout-minutes: ${{ matrix.os == 'macos-latest' && 60 || 30 }}
+    # half the journeys with no build, so 30min is generous headroom.
+    timeout-minutes: 30
     env:
-      APP_BIN: target/debug/desktop_shell${{ matrix.os == 'windows-latest' && '.exe' || '' }}
+      APP_BIN: target/debug/desktop_shell
     steps:
       - uses: actions/checkout@v4
 
@@ -306,7 +427,7 @@ jobs:
       # dev metapackages are what the runner image resolves fastest and the
       # difference is seconds; keep the known-good set plus xvfb.
       - name: Install Tauri Linux system deps
-        if: runner.os == 'Linux' && needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -356,11 +477,11 @@ jobs:
       - uses: actions/download-artifact@v4
         if: needs.changes.outputs.run == 'true'
         with:
-          name: e2e-build-${{ matrix.os }}
+          name: e2e-build-ubuntu-latest
 
       # Artifact download drops the execute bit on POSIX.
       - name: Make app binary executable
-        if: runner.os != 'Windows' && needs.changes.outputs.run == 'true'
+        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: chmod +x "$APP_BIN"
 
@@ -372,52 +493,201 @@ jobs:
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
       # Run the Layer-2 harness (real journeys, serial per .config/nextest.toml)
-      # from the prebuilt archive — no Rust compilation in this job. Every
-      # journey runs on every OS; `--partition count:N/2` deterministically
-      # splits the serial list WITHIN this OS across the two shards.
-      # Linux wraps in xvfb-run for a headless display; Windows/macOS run
-      # natively.
+      # from the prebuilt archive, wrapped in xvfb-run for a headless display.
       #
       # WEBKIT_DISABLE_DMABUF_RENDERER / WEBKIT_DISABLE_COMPOSITING_MODE:
       # experiment (PR #928) — Ubuntu's WebKitGTK under Xvfb has no GPU, so
       # its default DMA-BUF/compositing render paths were suspected of adding
       # ~25-30s of per-test overhead vs Windows. Linux-only; harmless no-op if
       # the hypothesis is wrong.
-      - name: Run E2E (Linux — xvfb)
-        if: runner.os == 'Linux' && needs.changes.outputs.run == 'true'
+      - name: Run E2E (xvfb)
+        if: needs.changes.outputs.run == 'true'
         env:
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
         run: xvfb-run -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition count:${{ matrix.shard }}/2
 
-      # Also covers macOS when it joins the matrix via workflow_dispatch
-      # run_macos (header comment) — a dedicated step would be identical.
-      - name: Run E2E (Windows / macOS)
-        if: runner.os != 'Linux' && needs.changes.outputs.run == 'true'
+  # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
+  real-ui-e2e-windows:
+    name: Real-UI E2E shard — windows-latest ${{ matrix.shard }}/2
+    needs: [changes, build-frontend, build-app-windows]
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2]
+    runs-on: windows-latest
+    timeout-minutes: 30
+    env:
+      APP_BIN: target/debug/desktop_shell.exe
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@nextest
+        if: needs.changes.outputs.run == 'true'
+
+      - uses: taiki-e/install-action@cargo-binstall
+        if: needs.changes.outputs.run == 'true'
+
+      - name: Install tauri-webdriver CLI
+        if: needs.changes.outputs.run == 'true'
+        run: cargo binstall tauri-webdriver --locked --no-confirm
+
+      - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install JS deps
+        if: needs.changes.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          name: e2e-frontend-dist
+          path: apps/desktop/dist
+
+      - uses: actions/download-artifact@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          name: e2e-build-windows-latest
+
+      - name: Serve frontend dist on :5173
+        if: needs.changes.outputs.run == 'true'
+        shell: bash
+        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+
+      - name: Run E2E
+        if: needs.changes.outputs.run == 'true'
         shell: bash
         env:
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
         run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition count:${{ matrix.shard }}/2
 
-  # Aggregate gate per OS, preserving the pre-DAG check names
-  # ("Real-UI E2E — <os>"). GitHub `needs` results are per-job (not
-  # per-matrix-leg), so a shard failure on EITHER OS reds both gates — a
-  # deliberate coarseness: the board must be green anyway, and it keeps this
-  # job trivially simple.
-  e2e-gate:
-    name: Real-UI E2E — ${{ matrix.os }}
-    needs: [changes, real-ui-e2e]
-    if: always()
+  # Copy of real-ui-e2e-ubuntu for the dispatch-only macOS chain (issue #489):
+  # no xvfb (native display), longer timeout for the 120s-per-attempt
+  # launch-failure loop.
+  real-ui-e2e-macos:
+    name: Real-UI E2E shard — macos-latest ${{ matrix.shard }}/2
+    needs: [changes, build-frontend, build-app-macos]
     strategy:
+      fail-fast: false
       matrix:
-        os: ${{ fromJson(needs.changes.outputs.os_matrix) }}
+        shard: [1, 2]
+    runs-on: macos-latest
+    timeout-minutes: 60
+    env:
+      APP_BIN: target/debug/desktop_shell
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: taiki-e/install-action@nextest
+        if: needs.changes.outputs.run == 'true'
+
+      - uses: taiki-e/install-action@cargo-binstall
+        if: needs.changes.outputs.run == 'true'
+
+      - name: Install tauri-webdriver CLI
+        if: needs.changes.outputs.run == 'true'
+        run: cargo binstall tauri-webdriver --locked --no-confirm
+
+      - uses: pnpm/action-setup@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          version: 10.33.0
+
+      - uses: actions/setup-node@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - name: Install JS deps
+        if: needs.changes.outputs.run == 'true'
+        run: pnpm install --frozen-lockfile
+
+      - uses: actions/download-artifact@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          name: e2e-frontend-dist
+          path: apps/desktop/dist
+
+      - uses: actions/download-artifact@v4
+        if: needs.changes.outputs.run == 'true'
+        with:
+          name: e2e-build-macos-latest
+
+      - name: Make app binary executable
+        if: needs.changes.outputs.run == 'true'
+        shell: bash
+        run: chmod +x "$APP_BIN"
+
+      - name: Serve frontend dist on :5173
+        if: needs.changes.outputs.run == 'true'
+        shell: bash
+        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+
+      - name: Run E2E
+        if: needs.changes.outputs.run == 'true'
+        shell: bash
+        env:
+          ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
+        run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition count:${{ matrix.shard }}/2
+
+  # ---------------------------------------------------------------------------
+  # Per-OS gates preserving the pre-DAG check names ("Real-UI E2E — <os>").
+  # Each gate depends ONLY on its own OS's shards, so a failure on one OS
+  # reds only that OS's gate — identical semantics to the old per-OS jobs.
+  # `always()` keeps the gate reporting (red) instead of skipping when a
+  # shard or upstream builder fails; the run=false no-op path stays green
+  # because skipped-step shards still conclude success.
+  # ---------------------------------------------------------------------------
+  e2e-gate-ubuntu:
+    name: Real-UI E2E — ubuntu-latest
+    needs: [changes, real-ui-e2e-ubuntu]
+    if: always()
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check shard results
         env:
-          RESULT: ${{ needs.real-ui-e2e.result }}
+          RESULT: ${{ needs.real-ui-e2e-ubuntu.result }}
         run: |
-          echo "real-ui-e2e result: $RESULT"
+          echo "real-ui-e2e-ubuntu result: $RESULT"
+          [ "$RESULT" = "success" ] || exit 1
+
+  e2e-gate-windows:
+    name: Real-UI E2E — windows-latest
+    needs: [changes, real-ui-e2e-windows]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check shard results
+        env:
+          RESULT: ${{ needs.real-ui-e2e-windows.result }}
+        run: |
+          echo "real-ui-e2e-windows result: $RESULT"
+          [ "$RESULT" = "success" ] || exit 1
+
+  # Skipped entirely unless the dispatch-only macOS chain was requested.
+  e2e-gate-macos:
+    name: Real-UI E2E — macos-latest
+    needs: [changes, real-ui-e2e-macos]
+    if: always() && needs.changes.outputs.run_macos == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check shard results
+        env:
+          RESULT: ${{ needs.real-ui-e2e-macos.result }}
+        run: |
+          echo "real-ui-e2e-macos result: $RESULT"
           [ "$RESULT" = "success" ] || exit 1


### PR DESCRIPTION
Follow-up to #928 (merged mid-review at a1eba6ec before this fix could land on that branch — reviewer verdict seq 157, node nCI-build of run-jc0714).

## Changes
1. Split the matrixed `build-app` into per-OS jobs (`build-app-ubuntu` / `build-app-windows` / `build-app-macos`) and the shard/gate jobs likewise: GitHub `needs` can only target a whole job, so one OS's builder failure previously skipped BOTH OSes' shards. Each OS chain (builder -> shards -> gate) is now fully independent.
2. Each per-OS gate (`Real-UI E2E — <os>`) now depends only on its own OS's shards, so the preserved check names behave exactly like the pre-DAG per-OS jobs; the header/gate comments now state this accurately.

Cache keys and artifact names are unchanged per OS (`rust-e2e-<os>`, `e2e-app-<os>-...`, `e2e-build-<os>`). The macOS chain remains dispatch-only via the `run_macos` output (was `os_matrix`). Every journey still runs on every OS.

actionlint clean.