### PR TITLE
docs(windows-validation): one canonical Windows driving-mechanics doc

### DIFF
--- a/.claude/skills/verify-on-windows/references/windows-mechanics.md
+++ b/.claude/skills/verify-on-windows/references/windows-mechanics.md
@@ -1,106 +1,41 @@
 # Windows verification mechanics (PlateVault / astro-plan)
 
-Canonical, tested steps for running and driving the real Tauri desktop app on
-Windows. Source: project memory (`windows-dev-loop`, `spec-033-windows-verify-loop`,
-`tauri-mcp-windows-verify-mechanics`, `vite-deps-reoptimize-blank-screen`) and
-`docs/development/testing.md`. When you generate a scenario, copy the *relevant*
-steps into it verbatim — the Windows agent has none of this context.
+The launch, reset, recompile-trap, MCP-bridge, native-picker, and blank-screen
+mechanics are **canonical in `docs/development/windows-native-rust-dev.md`
+§"Validation driving (MCP bridge, reset, recompile trap)"**. That doc is the
+single source of truth — do not re-derive the steps here. This file only covers
+how `verify-on-windows` consumes them.
 
-## Checkouts are separate
+## Using the canonical blocks in a generated scenario
 
-- WSL repo: `/home/sjors/dev/astro-plan` (where you edit/commit/push).
-- Windows app checkout: `C:\dev\astro-plan` (= `/mnt/c/dev/astro-plan` from WSL).
-- The app serves **from the Windows checkout**. Changes reach it only after
-  **commit → push → `git reset --hard origin/<branch>` on Windows**. Frontend HMR
-  and Rust both build from `C:\dev\astro-plan`.
+The Windows computer-use ("cowork") agent has **no access to this repo** — it
+sees only the scenario file and the running app. So you must **copy the relevant
+canonical blocks verbatim into the emitted scenario**, never link to them:
 
-## Launch (native Windows, never over /mnt/c)
+- **Preconditions → Deploy:** the "Recompile (mtime) trap" block (branch deploy +
+  touch changed `.rs` when Rust changed).
+- **Preconditions → Reset:** the "Reset to a clean first-run" block (delete
+  `wizard-test.db*`) when the flow needs a fresh first-run.
+- **Preconditions → Launch:** the throwaway-DB launch block. App process is
+  `desktop_shell.exe`, Vite on `http://127.0.0.1:5173`, real backend. (Any
+  `run-dev*.bat` you see is an optional local wrapper; the tracked launcher is
+  `scripts\win-native-dev.ps1`.)
+- **Troubleshooting:** the "Blank screen (empty `#root`)" block.
+- **If the scenario drives the MCP bridge** (vs. pure vision computer-use): the
+  "Connect the MCP bridge" + "Native pickers" + "Driving quirks" blocks —
+  connect with `driver_session host=localhost port=9223` (mirrored networking;
+  the old NAT gateway-IP lookup is obsolete).
 
-Launch **detached** with `powershell.exe` (not `cmd /mnt/c` — nested-quote escaping
-and a trailing-space-before-`&&` bug corrupt env vars). A `run-dev.bat` at repo
-root holds, each on its own line (no `&&`):
+Copy only the blocks the change needs. Every value the cowork agent needs (paths,
+command names, testids) must live inside the scenario.
 
-```
-cd /d C:\dev\astro-plan
-set ALM_DB_URL=sqlite://C:\dev\astro-plan\wizard-test.db?mode=rwc
-cargo tauri dev
-```
+## Separate checkouts (state the branch, not "the repo")
 
-Launch: `powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"`
-
-- App process = `desktop_shell.exe`; Vite on `localhost:5173`.
-- `.env` has `VITE_USE_MOCKS=false` (real backend).
-- Kill: `Get-Process desktop_shell,cargo | Stop-Process -Force`.
-
-## Reset to a clean first-run
-
-The **DB is the first-run source of truth** (clearing localStorage alone causes a
-`/`↔`/setup` redirect loop / navigation-throttle hang). Reset = fresh DB:
-
-```
-Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force
-```
-
-then relaunch. (`ALM_DB_URL` overrides the default `%APPDATA%\dev.astro-plan.astro-library-manager\alm.db`;
-WSL often can't enumerate Windows AppData — verify with PowerShell `Test-Path`.)
-
-## Deploy a branch + the RECOMPILE TRAP
-
-```
-cd C:\dev\astro-plan
-git fetch origin
-git reset --hard origin/<branch>     # run as its OWN command (a guard rejects it bundled with other git)
-```
-
-- **`git reset --hard` restores file content but leaves an OLD mtime**, so cargo
-  thinks the binary is newer and **skips recompiling** — the app stays stale
-  (symptom: a command that IS in the code returns "not found"). After reset,
-  **touch changed `.rs` files** to force a rebuild:
-  `Get-ChildItem <files>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }`,
-  then relaunch (`cargo tauri dev` recompiles). Verify binary mtime > source mtime.
-- **Frontend-only change**: a hard refresh (Ctrl+R) suffices — Vite serves from
-  disk on full reload. Rust changes REQUIRE the cargo-tauri-dev relaunch.
-- `pnpm install` alone does NOT recompile Rust; only `cargo tauri dev` does.
-
-## Blank screen (empty #root) recovery
-
-Two Vite/pnpm causes: (1) a mid-session `pnpm install` re-optimized deps → stale
-import graph → restart the dev server; (2) cold Vite start hits the
-`@rollup/rollup-win32-x64-msvc` optional-native bug → `pnpm install` in the
-Windows checkout with `$env:CI="true"`, then relaunch.
-
-## Driving the app programmatically (Tauri MCP bridge) — optional
-
-For an agent that can reach the bridge (vs. pure screen/vision computer-use):
-
-- Launch with the dev overlay so `withGlobalTauri` + the bridge are on:
-  `cargo tauri dev --config src-tauri\tauri.dev.conf.json` (bridge is
-  `#[cfg(debug_assertions)]`, WS on `0.0.0.0:9223`).
-- Connect over WSL↔Windows NAT: `driver_session host=<gateway> port=9223`, where
-  `gateway = ip route show default | awk '{print $3}'` (e.g. 172.23.112.1).
-  Firewall already allows 9223.
-- **Invoke a command directly** (bridge rejects many via `ipc_execute_command`):
-  `webview_execute_js` → `window.__TAURI__.core.invoke('<snake_command>', {args})`.
-- **Native folder pickers can't be driven**: launch with `VITE_E2E=1` to expose
-  `data-testid="e2e-path-input-<kind>"` / `e2e-add-path-btn-<kind>`
-  (kinds: light_frames, calibration, project, inbox). Set the React-controlled
-  input via the native value setter + dispatch `input`, then click the button in a
-  **separate** call so React state commits.
-- Throwaway DB read-only from WSL: python `sqlite3` `file:...?mode=ro&immutable=1`;
-  base64-encode output (grep/tool output otherwise mangles string literals).
-
-## Automated E2E (Layer 2) — the tool the scenario must stay in sync with
-
-- `just test-e2e` runs the built app through its real UI → real IPC → real backend
-  via `tauri-driver` (smoke journeys; required on Windows + Linux). Layer-1
-  (`just test-integration` = `cargo test --workspace`) is real backend + real
-  SQLite, no UI.
-- New features MUST ship real-stack coverage and update the mapping in
-  `specs/037-e2e-integration-testing/contracts/coverage-matrix.md`.
-- WSL has no webview, so the tauri-driver IPC run is validated on Windows / CI
-  Stage B — not in a WSL headless run. (WSL Playwright under `tests/e2e/` is for
-  mocks-backed render smoke only; the Playwright **MCP** browser can't reach
-  WSL-bound servers.)
+- WSL repo `/home/sjors/dev/astro-plan` is where you edit/commit/push.
+- The app serves from the **Windows checkout** `C:\dev\astro-plan`; a change
+  reaches it only after commit → push → `git reset --hard origin/<branch>` on
+  Windows. The cowork agent works only on the Windows side — give it the branch
+  name, not repo context.
 
 ## Pushing workflow files
 

--- a/docs/development/verify-on-windows-journeys.md
+++ b/docs/development/verify-on-windows-journeys.md
@@ -24,8 +24,11 @@ blocked on an open PR. Re-check `gh pr view <n>` if this doc ages.
   "reuses prior state"): `Remove-Item 'C:\dev\astro-plan\wizard-test.db*'
   -Force`, then relaunch. Clearing `localStorage` alone is NOT a reset (causes
   a `/`↔`/setup` redirect loop) — the DB is the first-run source of truth.
-- Full mechanics (bridge connect, `VITE_E2E` native-picker stand-ins, blank
-  screen recovery): `~/.claude/skills/verify-on-windows/references/windows-mechanics.md`.
+- Full mechanics (canonical: launch, reset, recompile trap, bridge connect,
+  `VITE_E2E` native-picker stand-ins, blank-screen recovery):
+  `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge,
+  reset, recompile trap)". The blocks above are the copy-once summary; that doc
+  is the source of truth.
 
 ## Automated coverage baseline (what you do NOT need to re-prove by hand)
 

--- a/docs/development/windows-journeys/journey-01-first-run-setup.md
+++ b/docs/development/windows-journeys/journey-01-first-run-setup.md
@@ -27,6 +27,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan` (separate from any WSL/Linux checkout
   — the app serves from THIS checkout only).
 - Deploy: `cd C:\dev\astro-plan`, `git fetch origin`, then

--- a/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
+++ b/docs/development/windows-journeys/journey-02-inbox-ingest-move.md
@@ -31,6 +31,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: after a reset, cargo may skip rebuilding because the

--- a/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
+++ b/docs/development/windows-journeys/journey-03-inbox-catalogue-in-place.md
@@ -24,6 +24,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: after a reset, touch changed `.rs` files

--- a/docs/development/windows-journeys/journey-04-sessions-review.md
+++ b/docs/development/windows-journeys/journey-04-sessions-review.md
@@ -30,6 +30,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-05-project-lifecycle.md
+++ b/docs/development/windows-journeys/journey-05-project-lifecycle.md
@@ -34,6 +34,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
+++ b/docs/development/windows-journeys/journey-06-cleanup-scan-apply.md
@@ -37,6 +37,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-07-archive-delete.md
+++ b/docs/development/windows-journeys/journey-07-archive-delete.md
@@ -35,6 +35,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
+++ b/docs/development/windows-journeys/journey-08-calibration-masters-matching.md
@@ -34,6 +34,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-09-targets-planning.md
+++ b/docs/development/windows-journeys/journey-09-targets-planning.md
@@ -43,6 +43,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
+++ b/docs/development/windows-journeys/journey-10-settings-appearance-i18n.md
@@ -31,6 +31,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` as its OWN command.
 - **Recompile trap**: touch changed `.rs` files after a reset if Rust

--- a/docs/development/windows-journeys/journey-11-framing-clustering-attribution.md
+++ b/docs/development/windows-journeys/journey-11-framing-clustering-attribution.md
@@ -75,6 +75,8 @@
 
 ## Windows environment mechanics (read once, applies to every Test below)
 
+> Canonical mechanics: `docs/development/windows-native-rust-dev.md` §"Validation driving (MCP bridge, reset, recompile trap)". The steps below are the self-contained per-journey copy; reconcile to that doc if they drift.
+
 - Windows checkout: `C:\dev\astro-plan`. Deploy: `git fetch origin`, then
   `git reset --hard origin/main` (or the named PR branch) as its OWN
   command.

--- a/docs/development/windows-native-rust-dev.md
+++ b/docs/development/windows-native-rust-dev.md
@@ -169,6 +169,86 @@ terminal:
   ```
   Then read `/mnt/c/dev/astro-plan/tauri-dev.log` for progress.
 
+### Validation driving (MCP bridge, reset, recompile trap)
+
+Canonical mechanics for driving the **real running app** during validation —
+manual computer-use ("cowork") scenarios and automated journeys alike. Each
+block below is self-contained: copy the relevant one verbatim into a scenario or
+run doc, since a zero-context agent must be able to execute it without following
+a link.
+
+**Launch with a throwaway database (bridge on).** For validation, point the app
+at a disposable DB inside the checkout so a reset never touches a real library,
+and launch with the dev overlay that enables the MCP bridge:
+
+```powershell
+cd C:\dev\astro-plan\apps\desktop
+$env:VITE_USE_MOCKS = 'false'                                        # real backend
+$env:ALM_DB_URL     = 'sqlite://C:\dev\astro-plan\wizard-test.db?mode=rwc'
+pnpm tauri dev --config src-tauri\tauri.dev.conf.json               # overlay = bridge on
+```
+
+`scripts\win-native-dev.ps1` launches the same overlay with the real backend;
+add the `ALM_DB_URL` line above when you need a disposable DB. Any `run-dev*.bat`
+referenced elsewhere is an optional local convenience wrapper — **not** tracked
+in the repo, so the tracked launcher above is the source of truth. App process is
+`desktop_shell.exe`; Vite on `http://127.0.0.1:5173`.
+
+**Reset to a clean first-run.** The DB is the first-run source of truth —
+clearing `localStorage` alone triggers a `/`↔`/setup` redirect loop, not a
+reset. Delete the throwaway DB and relaunch:
+
+```powershell
+Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force
+```
+
+**Recompile (mtime) trap.** Deploy a branch as its own command, then force a
+rebuild when any Rust changed — `git reset --hard` restores file content but
+keeps the old mtime, so cargo thinks the binary is current and runs a **stale**
+build (symptom: a command that IS in the code returns "not found"):
+
+```powershell
+cd C:\dev\astro-plan
+git fetch origin
+git reset --hard origin/<branch>        # its OWN command (a guard rejects it bundled)
+Get-ChildItem <changed>.rs | ForEach-Object { $_.LastWriteTime = Get-Date }
+```
+
+Then relaunch (`tauri dev` recompiles). A frontend-only change needs only a hard
+refresh (Ctrl+R). Confirm the binary mtime is newer than the source.
+
+**Connect the MCP bridge.** The bridge is `#[cfg(debug_assertions)]`, WebSocket
+on `0.0.0.0:9223`. This host runs WSL in mirrored networking, so `localhost`
+reaches Windows directly — connect with `driver_session host=localhost
+port=9223`. The old NAT gateway-IP lookup (`ip route show default`) is
+**obsolete**. Invoke a command directly with `webview_execute_js` →
+`window.__TAURI__.core.invoke('<snake_command>', {args})` (`ipc_execute_command`
+rejects many real commands but is fine for scripted backend probes).
+
+**Native pickers can't be driven.** Relaunch with `VITE_E2E=1` to expose
+`data-testid="e2e-path-input-<kind>"` / `e2e-add-path-btn-<kind>` stand-ins
+(kinds: `light_frames`, `calibration`, `project`, `inbox`). Set the
+React-controlled input via the native value setter + dispatch `input`, then click
+the button in a **separate** call so React state commits.
+
+**Driving quirks.** JS eval has a ~2 s timeout (avoid zombie loops); navigate in
+two steps (nav, then probe); **never** send modifier-key combos (renderer
+freeze). Recovery: kill `desktop_shell`, relaunch.
+
+**Blank screen (empty `#root`).** Two Vite causes: a mid-session `pnpm install`
+re-optimized deps → restart the dev server; or a cold start hit the
+`@rollup/rollup-win32-x64-msvc` optional-native bug → `pnpm install` with
+`$env:CI='true'`, then relaunch.
+
+**Fidelity honesty.** Backend-only IPC probes do not substitute for UI-level
+checks: anything visually or interactively observable must be validated in the
+real webview, not IPC-only. State which fidelity you actually drove.
+
+The test-layer and coverage story (Layer-1 integration, Layer-2 `tauri-driver`,
+the coverage matrix) lives in `docs/development/testing.md` and
+`specs/037-e2e-integration-testing/contracts/coverage-matrix.md` — it is not
+restated here.
+
 ## Stop / cleanup
 
 ```powershell

--- a/docs/journeys/README.md
+++ b/docs/journeys/README.md
@@ -44,44 +44,26 @@ validator can hold the Windows checkout/app process at a time. The
 Vite/mockIPC runtime fakes backend responses and MUST NOT be used to
 validate journeys (see `docs/development/testing.md`).
 
-Launch/reset mechanics (full detail in `docs/development/windows-journeys/`
-per-journey docs):
-- Deploy on the Windows checkout (`C:\dev\astro-plan`), not WSL:
-  `git fetch origin` then `git reset --hard origin/main` as its own command.
-- **Recompile trap:** `git reset --hard` restores content but keeps old
-  mtimes, so cargo skips rebuilding and the app silently runs a stale
-  binary — touch changed `.rs` files to force a recompile before relaunch.
-  Frontend-only changes just need a hard refresh.
-- **Reset to fresh first-run:** delete `wizard-test.db*` in the Windows
-  checkout root; clearing `localStorage` alone is not a reset (causes a
-  `/`↔`/setup` redirect loop) — the DB is first-run source of truth.
-- **Launch:** `run-dev.bat` in the Windows checkout (`run-dev-mcp.bat` when
-  driving through the bridge), detached via
-  `powershell.exe -NoProfile -Command "Start-Process ..."`; app process is
-  `desktop_shell.exe`, Vite on `localhost:5173`, real backend
-  (`VITE_USE_MOCKS=false`).
-- **Driving quirks:** 2s JS eval timeout (avoid zombie loops), navigate in
-  two steps (nav then probe), NEVER send modifier-key combos (renderer
-  freeze). Recovery: kill `desktop_shell`, relaunch `run-dev-mcp.bat`.
-- Native OS pickers (folder choosers, etc.) cannot be driven by the bridge;
-  relaunch with `VITE_E2E=1` to expose `data-testid` stand-in inputs/buttons
-  for those steps.
-- Prefer `webview_execute_js` invoking `window.__TAURI__.core.invoke(...)`
-  for direct backend calls; `ipc_execute_command` rejects many real commands
-  but is useful for scripted backend probes. Backend-only IPC probes are not
-  a substitute for UI-level Expects — anything visually/interactively
-  observable must be validated in the real webview, not IPC-only. Validators
-  announce when a check is backend-only IPC and classify findings
-  backend-vs-UI.
-- **State leakage prevention:** validation runs only against the Windows
-  checkout's dev database and `tempfile`-style scratch folders — never
-  against real user libraries; this repo checkout is never the app's working
-  directory, so no fixture can land in it.
+Launch, reset, recompile-trap, bridge-connect, native-picker, and blank-screen
+mechanics are **canonical in `docs/development/windows-native-rust-dev.md`
+§"Validation driving (MCP bridge, reset, recompile trap)"** — treat that doc as
+authoritative rather than re-deriving the steps here. Profile-specific rules
+that layer on top of it:
+- Backend-only IPC probes are not a substitute for UI-level Expects — anything
+  visually/interactively observable must be validated in the real webview, not
+  IPC-only. Validators announce when a check is backend-only IPC and classify
+  findings backend-vs-UI.
+- **State-leakage prevention:** validation runs only against the Windows
+  checkout's disposable dev database (`wizard-test.db` via `ALM_DB_URL`) and
+  `tempfile`-style scratch folders — never against real user libraries; this
+  repo checkout is never the app's working directory, so no fixture can land in
+  it.
 
-Pointers: `docs/development/windows-journeys/` (per-journey Windows
-validation docs with exact click sequences and troubleshooting) and
-`.claude/rules/50-tauri-mcp.md` (Tauri MCP driving surface, points into the
-`mcp-tauri` APM context doc).
+Pointers: `docs/development/windows-native-rust-dev.md` §"Validation driving"
+(canonical launch/reset/recompile/bridge mechanics),
+`docs/development/windows-journeys/` (per-journey Windows validation docs with
+exact click sequences and troubleshooting), and `.claude/rules/50-tauri-mcp.md`
+(Tauri MCP driving surface, points into the `mcp-tauri` APM context doc).
 
 ## Surface map
 


### PR DESCRIPTION
## Why
`verify-on-windows` (manual cowork scenarios) and `journey-verify` (automated journeys) both drive the real Windows Tauri app and shared the same launch/reset/recompile/bridge mechanics — duplicated across six places and already drifted (`windows-mechanics.md` still carried the obsolete NAT gateway lookup and the untracked `run-dev.bat` as if it were source of truth).

## What
- **Canonical source:** new *Validation driving (MCP bridge, reset, recompile trap)* section in `docs/development/windows-native-rust-dev.md` — standalone, copy-ready blocks (self-contained for zero-context cowork agents). Documents `scripts/win-native-dev.ps1` as the tracked launcher; marks the NAT gateway lookup obsolete (mirrored networking → `localhost`).
- **Consumers repointed:** `verify-on-windows/references/windows-mechanics.md` slimmed to a pointer + copy-verbatim framing; journeys `README.md` desktop-ui profile → pointer + profile-only rules (feeds `journey-validator` step 1 doc-pointers); `verify-on-windows-journeys.md` de-double-hopped; a canonical pointer added to each per-journey `windows-journeys/*.md`.
- Layer/coverage story stays in `testing.md` + spec-037 coverage-matrix (not restated).

## Contracts preserved
No skill `SKILL.md` frontmatter (`description`/trigger) touched; no APM-owned file touched in this repo. The paired `journey-validator` wording change ships separately in `srobroek/agentic-packages` (user-journeys) and lands here via `apm install`.

Docs-only; no product code.