### PR TITLE
docs: end-user README, PlateVault title fix, runbook auth drift

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,91 @@
-# alm
+# PlateVault
 
 [![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
+A local-first desktop app for organizing large astrophotography libraries:
+map targets, sessions, and projects across a messy existing folder tree,
+prepare PixInsight/WBPP-friendly inputs, and plan cleanup and archiving
+safely. PlateVault never touches your files without a plan you review first,
+and it never calibrates, stacks, or otherwise processes your images —
+PixInsight/WBPP stays responsible for that.
+
+<!-- Docs site: link goes here once it ships separately. -->
+
+## Why
+
+Astrophotography libraries grow large and messy: raw subs, calibration
+frames, WBPP outputs, and years of capture-software exports scattered across
+drives. PlateVault sits alongside your existing folders — it does not force a
+migration — and gives you a reviewable, auditable record of what you have,
+how it maps to targets and projects, and what's safe to clean up.
+
+## Key features
+
+- **Inbox review and confirm** — classify newly-arrived frames (or catalogue
+  an already-organized folder in place) with a reviewable move/no-move plan
+  before anything touches disk.
+- **Sessions and calibration** — acquisition sessions and calibration masters
+  are derived, always-current inventory, with masters matched to sessions by
+  confidence level.
+- **Target and project mapping** — link targets to projects, track project
+  lifecycle from creation through tool launch to output tracking.
+- **PixInsight/WBPP preparation** — generate tool-friendly source views and
+  manifests without copying or duplicating your source files.
+- **Safe cleanup and archive planning** — every move, copy, archive, or
+  delete is a reviewable plan with an audit record; destructive operations
+  prefer archive/trash over permanent deletion.
+- **Full audit trail** — reconstruct what happened to your library at any
+  point, including refused or failed actions and why.
+- **Keyboard-first, localized, themeable** — drive the whole app without a
+  pointer; appearance and language are configurable per install.
+
+See `docs/journeys/` for the full set of supported user workflows.
+
+## Screenshots
+
+| Library overview | Inbox review and confirm | Cleanup plan |
+|---|---|---|
+| ![Library overview](assets/readme/screenshot-library-overview.svg) | ![Inbox review and confirm](assets/readme/screenshot-inbox-confirm.svg) | ![Cleanup plan](assets/readme/screenshot-cleanup-plan.svg) |
+
+(Placeholders — real screenshots are pending.)
+
+## Download
+
+Builds are published on [GitHub Releases](https://github.com/nightwatch-astro/alm/releases/latest).
+
+| Platform | Package |
+|---|---|
+| Windows x64 | NSIS installer or MSI |
+| Linux | AppImage, `.deb`, or `.rpm` |
+| macOS (Apple Silicon only) | `.dmg` |
+
+Intel macOS is not currently supported.
+
+Bundles are signed for the built-in auto-updater (minisign), but **not**
+signed with an OS-level code-signing certificate yet, so:
+
+- **Windows**: SmartScreen will show an "unrecognized publisher" warning
+  ("Windows protected your PC") — choose "More info" → "Run anyway".
+- **macOS**: Gatekeeper will refuse to open the app as "from an unidentified
+  developer" — right-click the app → "Open", or clear the quarantine
+  attribute (`xattr -d com.apple.quarantine PlateVault.app`).
+
+## Build from source
+
+Requires [pnpm](https://pnpm.io) and a [Rust](https://www.rust-lang.org)
+toolchain (Tauri v2 prerequisites for your OS).
+
+```bash
+pnpm install
+pnpm --dir apps/desktop tauri dev
+```
+
 ## License
 
-This project is licensed under the GNU Affero General Public License v3.0 — see [LICENSE](LICENSE) for details.
+PlateVault is licensed under the [GNU AGPL v3.0](LICENSE). If you modify this
+software and make it available over a network, you must make your modified
+source code available under the same license.
 
-If you modify this software and make it available over a network, you must make your modified source code available under the same license.
+Contributions require signing a CLA (enforced by the CLA Assistant GitHub
+Action on pull requests). See [CONTRIBUTING.md](CONTRIBUTING.md) for how to
+contribute.

--- a/apps/desktop/index.html
+++ b/apps/desktop/index.html
@@ -7,7 +7,7 @@
       rel="icon"
       href='data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32"><rect width="32" height="32" rx="5" fill="%232f4f43"/><text x="16" y="20" text-anchor="middle" font-family="Arial" font-size="10" font-weight="700" fill="%23dff4eb">ALM</text></svg>'
     />
-    <title>Astro Library Manager</title>
+    <title>PlateVault</title>
   </head>
   <body>
     <div id="root"></div>

--- a/assets/readme/screenshot-cleanup-plan.svg
+++ b/assets/readme/screenshot-cleanup-plan.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750">
+  <rect width="1200" height="750" fill="#dcdcdc"/>
+  <rect x="1" y="1" width="1198" height="748" fill="none" stroke="#9a9a9a" stroke-width="2"/>
+  <text x="600" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="34" fill="#5a5a5a">Screenshot TODO</text>
+  <text x="600" y="405" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#7a7a7a">Reviewable cleanup plan</text>
+</svg>

--- a/assets/readme/screenshot-inbox-confirm.svg
+++ b/assets/readme/screenshot-inbox-confirm.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750">
+  <rect width="1200" height="750" fill="#dcdcdc"/>
+  <rect x="1" y="1" width="1198" height="748" fill="none" stroke="#9a9a9a" stroke-width="2"/>
+  <text x="600" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="34" fill="#5a5a5a">Screenshot TODO</text>
+  <text x="600" y="405" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#7a7a7a">Inbox review and confirm</text>
+</svg>

--- a/assets/readme/screenshot-library-overview.svg
+++ b/assets/readme/screenshot-library-overview.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1200" height="750" viewBox="0 0 1200 750">
+  <rect width="1200" height="750" fill="#dcdcdc"/>
+  <rect x="1" y="1" width="1198" height="748" fill="none" stroke="#9a9a9a" stroke-width="2"/>
+  <text x="600" y="365" text-anchor="middle" font-family="Arial, sans-serif" font-size="34" fill="#5a5a5a">Screenshot TODO</text>
+  <text x="600" y="405" text-anchor="middle" font-family="Arial, sans-serif" font-size="18" fill="#7a7a7a">Library overview</text>
+</svg>

--- a/docs/development/release-and-signing-runbook.md
+++ b/docs/development/release-and-signing-runbook.md
@@ -23,16 +23,17 @@ the `release-please` skill.
 ## Authentication — the `nightwatch-astro-ci` GitHub App (not a PAT)
 
 release-please authenticates with a **GitHub App installation token**, minted in
-the workflow from the org secrets `NIGHTWATCH_APP_ID` /
-`NIGHTWATCH_APP_PRIVATE_KEY` (app slug `nightwatch-astro-ci`, permissions
-`contents: write` + `pull_requests: write`):
+the workflow from the org-wide (visibility=all) credentials
+`RELEASE_APP_CLIENT_ID` (Actions variable) / `RELEASE_APP_PRIVATE_KEY` (Actions
+secret) (app slug `nightwatch-astro-ci`, permissions `contents: write` +
+`pull_requests: write`):
 
 ```yaml
 - uses: actions/create-github-app-token@v1
   id: app-token
   with:
-    app-id: ${{ secrets.NIGHTWATCH_APP_ID }}
-    private-key: ${{ secrets.NIGHTWATCH_APP_PRIVATE_KEY }}
+    app-id: ${{ vars.RELEASE_APP_CLIENT_ID }}
+    private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 - uses: googleapis/release-please-action@v5
   with:
     token: ${{ steps.app-token.outputs.token }}
@@ -100,6 +101,19 @@ rsign verify -p /tmp/pub -x /tmp/m.minisig /tmp/m.txt   # "Signature ... verifie
 If they don't pair, CI ships `.sig` files the embedded pubkey can't verify — a
 silently-broken updater. Always verify before the first signed release after a
 key change.
+
+## OS code signing — not yet in place
+
+Today only the minisign updater signing above exists. There is **no Windows
+Authenticode signing and no macOS notarization** — released bundles trigger
+SmartScreen ("unrecognized publisher") on Windows and a Gatekeeper
+"unidentified developer" refusal on macOS. This is expected until an OS-level
+signing certificate is wired into the release workflow.
+
+Disabled SignPath-style infrastructure for Windows signing is being added on a
+separate branch, `ci/windows-oss-signing`; it is not wired into
+`release-please.yml` yet. Do not assume Windows builds are Authenticode-signed
+until that lands and this section is updated.
 
 ## Versioning — pre-1.0 (0.x) policy
 


### PR DESCRIPTION
## Summary
- Rewrite README.md as an end-user product page: PlateVault pitch, key features grounded in PRODUCT.md/docs/journeys, per-platform download/install (Windows NSIS/MSI, Linux AppImage/deb/rpm, macOS Apple Silicon dmg) with SmartScreen/Gatekeeper notes, placeholder screenshots (assets/readme/*.svg), build-from-source, license/CLA.
- Fix `apps/desktop/index.html` `<title>` from "Astro Library Manager" to "PlateVault".
- Correct `docs/development/release-and-signing-runbook.md` auth section: the live `.github/workflows/release-please.yml` uses `vars.RELEASE_APP_CLIENT_ID` / `secrets.RELEASE_APP_PRIVATE_KEY`, not `NIGHTWATCH_APP_ID`/`NIGHTWATCH_APP_PRIVATE_KEY`. Added an honest "OS code signing" subsection: only minisign updater signing exists today, no Authenticode/notarization yet, cross-referencing branch `ci/windows-oss-signing`.

## Test plan
- [x] Verified relative README links resolve to existing files (LICENSE, CONTRIBUTING.md, assets/readme/*.svg)
- [x] Confirmed auth env var names against `.github/workflows/release-please.yml` directly
- [x] Only the three intended files + new assets/readme/ dir touched (`git status --short`)