### PR TITLE
docs(readme): drop the Intel macOS caveat

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Builds are published on [GitHub Releases](https://github.com/nightwatch-astro/al
 | Linux | AppImage, `.deb`, or `.rpm` |
 | macOS (Apple Silicon only) | `.dmg` |
 
-Intel macOS is not currently supported.
-
 Bundles are signed for the built-in auto-updater (minisign), but **not**
 signed with an OS-level code-signing certificate yet, so:
 


### PR DESCRIPTION
## Summary
- Remove the standalone "Intel macOS is not currently supported" sentence from the README; the download table already says "macOS (Apple Silicon only)".