### PR TITLE
fix: status pills no longer switch to monospace inside data columns

### DIFF
--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -15,6 +15,10 @@
   font-size: var(--alm-text-xs); font-weight: var(--alm-weight-medium);
   line-height: 1.6; white-space: nowrap;
   border: 1px solid transparent;
+  /* Pills are labels/placeholders, never data values: stay sans even when
+     rendered inside a mono value cell (e.g. UnresolvedChip in PropertyTable
+     or calibration list columns). */
+  font-family: var(--alm-font-sans);
 }
 .alm-pill--neutral { background: var(--alm-chip); color: var(--alm-text-secondary); border-color: var(--alm-rule); }
 .alm-pill--ghost { background: transparent; color: var(--alm-text-muted); border-color: var(--alm-rule); }


### PR DESCRIPTION
## Summary
- "Unresolved" placeholder chips (and any other pill) rendered in monospace when placed inside a mono value cell (calibration columns, property tables) after the mono restoration. Pills are labels, not data — they now pin the sans stack at the pill base rule.

Found during the spec 055 live Windows verification; user verdict: chips should stay sans.

## Spec Context
055 typography rework — Phase 3 follow-up.