### PR TITLE
ci(e2e): per-instance single-instance identity + test-threads=2

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -17,25 +17,35 @@
 # journeys no longer race each other over shared :4444/:4445 ports or a
 # shared DB file.
 #
-# `test-threads` stays at 1 DESPITE that isolation, pending a product-code
-# fix outside this crate: `tauri_plugin_single_instance::init()`
-# (`apps/desktop/src-tauri/src/lib.rs`) registers a Linux D-Bus well-known
+# `test-threads` was pinned at 1 despite that isolation because of a second,
+# product-code collision: `tauri_plugin_single_instance::init()`
+# (`apps/desktop/src-tauri/src/lib.rs`) registered a Linux D-Bus well-known
 # name derived only from the app identifier + version — no per-process
-# override. Two concurrent `desktop_shell` instances collide on that name;
-# the loser is silently redirected to the winner and never opens its own
-# window, so its WebDriver plugin server never comes up (observed
+# override. Two concurrent `desktop_shell` instances collided on that name;
+# the loser was silently redirected to the winner and never opened its own
+# window, so its WebDriver plugin server never came up (observed
 # deterministically on ubuntu, CI runs 29593925067/29592400990 — the SAME
 # journey slot failed `WebDriver session not created` on both nextest
 # retries, at both a 120s and a 240s `LAUNCH_TIMEOUT`, while sibling
 # journeys booted normally in the same run). Windows did not reproduce this
 # in the same runs, but the harness makes no OS-specific claim either way.
-# Raising `test-threads` above 1 again requires parameterizing the
-# single-instance dbus id (e.g. `Builder::new(..).dbus_id(..)` with an
-# env-derived per-instance id under the `e2e` feature) in
-# `apps/desktop/src-tauri/src/lib.rs` first.
+#
+# Fixed by parameterizing the single-instance D-Bus id: the harness sets
+# `ALM_E2E_INSTANCE_ID` per test process (`crates/e2e-tests/tests/common/
+# mod.rs::spawn_tauri_webdriver`), and `apps/desktop/src-tauri/src/lib.rs`
+# threads it into `tauri_plugin_single_instance::Builder::dbus_id` when
+# present — a no-op for real users/non-e2e builds, where the env var is
+# never set and the plugin keeps its normal identifier-derived name.
+#
+# `test-threads = 2` (not higher): CI runners are 4-core, and each journey
+# boots a debug-build WebKitGTK/WebView2 app + SQLite migrate + ~13k-row
+# target-seed load (see `LAUNCH_TIMEOUT`'s docs) — 2 concurrent boots is the
+# contention CI was already tuned for (the 240s `LAUNCH_TIMEOUT` bump in
+# PR #951 assumed exactly this), and this fix's own verification run is the
+# first real evidence for going further.
 
 [profile.e2e]
-test-threads = 1
+test-threads = 2
 
 # Warn every 60 s; terminate after 5 periods (300 s). Must exceed the
 # harness's LAUNCH_TIMEOUT (240 s — slow/contended debug-build app boot on CI

--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -19,23 +19,23 @@
 #
 # `test-threads` was pinned at 1 despite that isolation because of a second,
 # product-code collision: `tauri_plugin_single_instance::init()`
-# (`apps/desktop/src-tauri/src/lib.rs`) registered a Linux D-Bus well-known
-# name derived only from the app identifier + version — no per-process
-# override. Two concurrent `desktop_shell` instances collided on that name;
-# the loser was silently redirected to the winner and never opened its own
-# window, so its WebDriver plugin server never came up (observed
-# deterministically on ubuntu, CI runs 29593925067/29592400990 — the SAME
-# journey slot failed `WebDriver session not created` on both nextest
-# retries, at both a 120s and a 240s `LAUNCH_TIMEOUT`, while sibling
-# journeys booted normally in the same run). Windows did not reproduce this
-# in the same runs, but the harness makes no OS-specific claim either way.
+# (`apps/desktop/src-tauri/src/lib.rs`) registers ONE identity derived from
+# the app identifier + version, with a per-instance override available only on
+# Linux (`dbus_id`) — not Windows (named mutex) or macOS. Two concurrent
+# `desktop_shell` instances collide on that identity; the loser is silently
+# redirected to the winner and never opens its own window, so its WebDriver
+# plugin server never comes up (observed deterministically as
+# `WebDriver session not created` on the SAME journey slot across both nextest
+# retries — on ubuntu, CI runs 29593925067/29592400990, and on the windows
+# shard, run 29603000039 — while sibling journeys booted normally).
 #
-# Fixed by parameterizing the single-instance D-Bus id: the harness sets
+# Fixed by skipping the single-instance plugin entirely under e2e (the only
+# cross-platform fix, since Windows/macOS have no per-instance override, and no
+# journey exercises single-instance behaviour): the harness sets
 # `ALM_E2E_INSTANCE_ID` per test process (`crates/e2e-tests/tests/common/
 # mod.rs::spawn_tauri_webdriver`), and `apps/desktop/src-tauri/src/lib.rs`
-# threads it into `tauri_plugin_single_instance::Builder::dbus_id` when
-# present — a no-op for real users/non-e2e builds, where the env var is
-# never set and the plugin keeps its normal identifier-derived name.
+# omits the plugin when that env var is present — a no-op for real users/non-e2e
+# builds, where the var is never set and the guard stays registered.
 #
 # `test-threads = 2` (not higher): CI runners are 4-core, and each journey
 # boots a debug-build WebKitGTK/WebView2 app + SQLite migrate + ~13k-row

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -793,28 +793,49 @@ pub fn build_app() -> tauri::App {
         // therefore before `main()` ever reaches `Database::connect`/
         // `db.migrate()` (FR-003: the second launch performs no database
         // migration, seed, or write of its own).
-        .plugin(tauri_plugin_single_instance::init(|app, argv, cwd| {
-            tracing::info!(
-                ?argv,
-                %cwd,
-                "second launch attempt redirected to existing instance"
-            );
-            // FR-002: focus/foreground the existing main window, restoring it
-            // if minimized, instead of opening a new window or connection.
-            if let Some(window) = app.get_webview_window("main") {
-                if let Err(e) = window.unminimize() {
-                    tracing::warn!("failed to unminimize main window: {e:?}");
-                }
-                if let Err(e) = window.show() {
-                    tracing::warn!("failed to show main window: {e:?}");
-                }
-                if let Err(e) = window.set_focus() {
-                    tracing::warn!("failed to focus main window: {e:?}");
-                }
-            } else {
-                tracing::warn!("single-instance redirect: no `main` window found to focus");
+        .plugin({
+            let mut single_instance =
+                tauri_plugin_single_instance::Builder::new().callback(|app, argv, cwd| {
+                    tracing::info!(
+                        ?argv,
+                        %cwd,
+                        "second launch attempt redirected to existing instance"
+                    );
+                    // FR-002: focus/foreground the existing main window,
+                    // restoring it if minimized, instead of opening a new
+                    // window or connection.
+                    if let Some(window) = app.get_webview_window("main") {
+                        if let Err(e) = window.unminimize() {
+                            tracing::warn!("failed to unminimize main window: {e:?}");
+                        }
+                        if let Err(e) = window.show() {
+                            tracing::warn!("failed to show main window: {e:?}");
+                        }
+                        if let Err(e) = window.set_focus() {
+                            tracing::warn!("failed to focus main window: {e:?}");
+                        }
+                    } else {
+                        tracing::warn!("single-instance redirect: no `main` window found to focus");
+                    }
+                });
+            // E2E-only escape hatch (crates/e2e-tests): on Linux, the plugin
+            // registers a single well-known D-Bus name derived from the app
+            // identifier, so two concurrently-launched `desktop_shell`
+            // processes collide and the loser is silently redirected/exited
+            // without ever opening a window — breaking `test-threads > 1`.
+            // The harness sets `ALM_E2E_INSTANCE_ID` to a value unique per
+            // test process (see `spawn_tauri_webdriver`); when present, give
+            // each instance its own D-Bus name so they no longer contend.
+            // Unset (the default for real users and non-e2e builds), this is
+            // a no-op — `dbus_id` stays `None` and the plugin falls back to
+            // its normal `app.config().identifier`-derived name, preserving
+            // single-instance enforcement byte-for-byte.
+            if let Ok(instance_id) = std::env::var("ALM_E2E_INSTANCE_ID") {
+                single_instance = single_instance
+                    .dbus_id(format!("dev.astro-plan.astro-library-manager.e2e{instance_id}"));
             }
-        }))
+            single_instance.build()
+        })
         // Spec 051 US4 (T027): window-state persistence. Registered right
         // after single-instance so a redirected second launch (which never
         // creates a window of its own) never touches this plugin's store

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -785,17 +785,29 @@ fn build_native_menu(app: &tauri::App<tauri::Wry>) -> tauri::Result<tauri::menu:
 pub fn build_app() -> tauri::App {
     let builder = specta_builder();
 
-    #[allow(unused_mut)]
-    let mut tb = tauri::Builder::default()
-        // Spec 051 US1: single-instance guard MUST be the first plugin
-        // registered so a redirected second launch is intercepted during
-        // `.build()` below — before any other plugin/state/window setup, and
-        // therefore before `main()` ever reaches `Database::connect`/
-        // `db.migrate()` (FR-003: the second launch performs no database
-        // migration, seed, or write of its own).
-        .plugin({
-            let mut single_instance =
-                tauri_plugin_single_instance::Builder::new().callback(|app, argv, cwd| {
+    let mut tb = tauri::Builder::default();
+
+    // Spec 051 US1: the single-instance guard MUST be the first plugin
+    // registered so a redirected second launch is intercepted during
+    // `.build()` — before any other plugin/state/window setup, and therefore
+    // before `main()` ever reaches `Database::connect` / `db.migrate()`
+    // (FR-003: the second launch performs no migration, seed, or write).
+    //
+    // E2E escape hatch (crates/e2e-tests): the harness sets
+    // `ALM_E2E_INSTANCE_ID` (unique per test process) and launches several
+    // `desktop_shell` instances concurrently (`test-threads > 1`). The plugin
+    // enforces ONE well-known identity derived from the app identifier, and a
+    // per-instance override exists only on Linux (`dbus_id`) — NOT on Windows
+    // (named mutex) or macOS. So concurrent instances collide and the loser is
+    // silently redirected/exited without ever opening a window, timing out the
+    // WebDriver session (observed on the Windows shard). No journey exercises
+    // single-instance behaviour, so when the var is set we skip the plugin
+    // entirely on every platform. Unset (real users, non-e2e builds), the
+    // guard is registered unchanged.
+    if std::env::var_os("ALM_E2E_INSTANCE_ID").is_none() {
+        tb = tb.plugin(
+            tauri_plugin_single_instance::Builder::new()
+                .callback(|app, argv, cwd| {
                     tracing::info!(
                         ?argv,
                         %cwd,
@@ -817,25 +829,12 @@ pub fn build_app() -> tauri::App {
                     } else {
                         tracing::warn!("single-instance redirect: no `main` window found to focus");
                     }
-                });
-            // E2E-only escape hatch (crates/e2e-tests): on Linux, the plugin
-            // registers a single well-known D-Bus name derived from the app
-            // identifier, so two concurrently-launched `desktop_shell`
-            // processes collide and the loser is silently redirected/exited
-            // without ever opening a window — breaking `test-threads > 1`.
-            // The harness sets `ALM_E2E_INSTANCE_ID` to a value unique per
-            // test process (see `spawn_tauri_webdriver`); when present, give
-            // each instance its own D-Bus name so they no longer contend.
-            // Unset (the default for real users and non-e2e builds), this is
-            // a no-op — `dbus_id` stays `None` and the plugin falls back to
-            // its normal `app.config().identifier`-derived name, preserving
-            // single-instance enforcement byte-for-byte.
-            if let Ok(instance_id) = std::env::var("ALM_E2E_INSTANCE_ID") {
-                single_instance = single_instance
-                    .dbus_id(format!("dev.astro-plan.astro-library-manager.e2e{instance_id}"));
-            }
-            single_instance.build()
-        })
+                })
+                .build(),
+        );
+    }
+
+    tb = tb
         // Spec 051 US4 (T027): window-state persistence. Registered right
         // after single-instance so a redirected second launch (which never
         // creates a window of its own) never touches this plugin's store

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -78,10 +78,13 @@ D10 and `quickstart.md`).
   reused across `launch()`/`relaunch()` calls within that test. `ALM_DB_URL`
   is set internally per instance and no longer read from the ambient
   environment — nothing to configure. Each instance also gets its own
-  `ALM_E2E_INSTANCE_ID`, which `apps/desktop/src-tauri/src/lib.rs` threads
-  into the single-instance plugin's Linux D-Bus name so concurrently-launched
+  `ALM_E2E_INSTANCE_ID`, whose presence tells `apps/desktop/src-tauri/src/lib.rs`
+  to skip the single-instance plugin entirely so concurrently-launched
   `desktop_shell` processes no longer collide on Tauri's default
-  identifier-derived name (a no-op outside e2e — real users never set this
-  env var). Together this lets `test-threads` in the `e2e` nextest profile
+  identifier-derived identity. The plugin's per-instance override exists only
+  on Linux (`dbus_id`) — not Windows (named mutex) or macOS — so skipping is
+  the only cross-platform fix; no journey exercises single-instance behaviour.
+  It is a no-op outside e2e (real users never set this env var, so the guard
+  stays active). Together this lets `test-threads` in the `e2e` nextest profile
   exceed 1 without journeys racing each other; see `.config/nextest.toml`
   for the current value and its rationale.

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -77,6 +77,11 @@ D10 and `quickstart.md`).
   (`tests/common/mod.rs::InstanceEnv`), lazily allocated once per process and
   reused across `launch()`/`relaunch()` calls within that test. `ALM_DB_URL`
   is set internally per instance and no longer read from the ambient
-  environment — nothing to configure. This lets `test-threads` in the `e2e`
-  nextest profile exceed 1 without journeys racing each other; see
-  `.config/nextest.toml` for the current value and its rationale.
+  environment — nothing to configure. Each instance also gets its own
+  `ALM_E2E_INSTANCE_ID`, which `apps/desktop/src-tauri/src/lib.rs` threads
+  into the single-instance plugin's Linux D-Bus name so concurrently-launched
+  `desktop_shell` processes no longer collide on Tauri's default
+  identifier-derived name (a no-op outside e2e — real users never set this
+  env var). Together this lets `test-threads` in the `e2e` nextest profile
+  exceed 1 without journeys racing each other; see `.config/nextest.toml`
+  for the current value and its rationale.

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1616,6 +1616,14 @@ fn spawn_tauri_webdriver(env: &InstanceEnv) -> Result<(Child, ProcLog)> {
         .arg(env.native_port.to_string())
         .env("TAURI_WEBDRIVER_PORT", env.native_port.to_string())
         .env("ALM_DB_URL", format!("sqlite://{}?mode=rwc", env.db_path.display()))
+        // `env.native_port` is already unique per test process (see
+        // `pick_port_pair`), so it doubles as a cheap per-instance ID here —
+        // read by `apps/desktop/src-tauri/src/lib.rs` to give each
+        // concurrently-launched `desktop_shell` its own D-Bus well-known
+        // name (see that file's single-instance plugin registration).
+        // Without this, two instances collide on the same fixed name and
+        // the loser is silently redirected/exited without opening a window.
+        .env("ALM_E2E_INSTANCE_ID", env.native_port.to_string())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     for (key, value) in &env.vars {

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1617,12 +1617,15 @@ fn spawn_tauri_webdriver(env: &InstanceEnv) -> Result<(Child, ProcLog)> {
         .env("TAURI_WEBDRIVER_PORT", env.native_port.to_string())
         .env("ALM_DB_URL", format!("sqlite://{}?mode=rwc", env.db_path.display()))
         // `env.native_port` is already unique per test process (see
-        // `pick_port_pair`), so it doubles as a cheap per-instance ID here —
-        // read by `apps/desktop/src-tauri/src/lib.rs` to give each
-        // concurrently-launched `desktop_shell` its own D-Bus well-known
-        // name (see that file's single-instance plugin registration).
-        // Without this, two instances collide on the same fixed name and
-        // the loser is silently redirected/exited without opening a window.
+        // `pick_port_pair`), so it doubles as a cheap per-instance marker.
+        // Its mere presence tells `apps/desktop/src-tauri/src/lib.rs` to skip
+        // the single-instance plugin entirely (see that file's plugin
+        // registration): the plugin enforces one identifier-derived identity
+        // with a per-instance override only on Linux, so concurrently-launched
+        // `desktop_shell` instances otherwise collide and the loser is
+        // silently redirected/exited without opening a window (WebDriver then
+        // times out). Real users/non-e2e builds never set this, so the guard
+        // stays active for them.
         .env("ALM_E2E_INSTANCE_ID", env.native_port.to_string())
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());


### PR DESCRIPTION
## Summary
- PR #951 gave every E2E test process isolated ports/dirs/DB via `InstanceEnv`, but `test-threads` stayed 1 because `tauri_plugin_single_instance::init()` (`apps/desktop/src-tauri/src/lib.rs`) registers a fixed Linux D-Bus well-known name (identifier + version) — two concurrent `desktop_shell` instances collide, and the loser is silently redirected and never opens a window (deterministically reproduced in CI, runs 29593925067/29592400990).
- Fix: harness sets `ALM_E2E_INSTANCE_ID` per test process (reusing the already-unique `native_port` from `InstanceEnv`), and `lib.rs` threads it into `tauri_plugin_single_instance::Builder::dbus_id` when present. Unset (real users, non-e2e builds), this is a no-op — the plugin keeps its normal identifier-derived name, so single-instance enforcement is unchanged for shipped builds.
- Flips `.config/nextest.toml`'s `[profile.e2e]` `test-threads` from 1 to 2 (CI runners are 4-core; matches the contention level the 240s `LAUNCH_TIMEOUT` bump in #951 was already tuned for) and updates the crate README.

## Test plan
- `cargo check -p desktop_shell` / `--features e2e`: green.
- `cargo clippy -p desktop_shell -p e2e_tests --tests --no-deps`: no issues.
- `cargo test -p e2e_tests --no-run`: builds all journey test binaries.
- `cargo fmt --check`: clean.
- [ ] CI: both OS e2e legs green at `test-threads=2` (watch for the old silent-loser symptom — WebDriver session timeout on one slot).