### PR TITLE
fix: Default Catalogues enabled setting now persists

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1431,6 +1431,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
+ "skymath 0.4.0",
  "specta",
  "specta-typescript",
  "sqlx",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -26,6 +26,10 @@ targeting_resolver = { path = "../../../crates/targeting/resolver" }
 simbad-resolver = "0.3.0"
 # target.astro_format.batch: sexagesimal RA/Dec formatting (adopt target-match).
 targeting = { path = "../../../crates/targeting" }
+# target.moon_opposition.batch (#634): geocentric Sun/Moon position
+# (sun_position/moon_position — not re-exported by `targeting`, which only
+# re-exports the coordinate primitives).
+skymath = "0.4"
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -30,6 +30,7 @@
 //! - `"framing"` → `framingPointingFractionOfFov`, `framingPointingFallbackDeg`,
 //!   `framingRotationToleranceDeg`, `framingMosaicEnvelopeFractionOfFov`
 //!   (spec 008 Q27 F-Framing-11, R11a clustering tolerance tunables)
+//! - `"catalogues"` → `enabled` (#645, default-enabled Planner catalogues)
 //! - `""` (empty) → reads the full settings bag (all known keys).
 //!
 //! Unknown `values` keys from the frontend that are not valid settings keys are
@@ -87,6 +88,10 @@ fn scope_keys(scope: &str) -> &'static [&'static str] {
             "usableAltitudeDeg",
         ],
         "planner" => &["plannerMoonAvoidance"],
+        // Default-enabled planner catalogues (#645); key name `enabled` is
+        // dictated by the frontend contract (`catalogue-settings.ts`), which
+        // reads `settingsGet('catalogues').values.enabled` directly.
+        "catalogues" => &["enabled"],
         "framing" => &[
             "framingPointingFractionOfFov",
             "framingPointingFallbackDeg",
@@ -125,6 +130,7 @@ fn scope_keys(scope: &str) -> &'static [&'static str] {
             "observingActiveSiteId",
             "usableAltitudeDeg",
             "plannerMoonAvoidance",
+            "enabled",
             "theme",
             "framingPointingFractionOfFov",
             "framingPointingFallbackDeg",

--- a/apps/desktop/src-tauri/src/commands/target_lookup.rs
+++ b/apps/desktop/src-tauri/src/commands/target_lookup.rs
@@ -23,6 +23,8 @@
 //!   background task (FR-002; issue #695).
 //! - `target.resolution.settings` / `target.resolution.settings.update` — resolver settings.
 //! - `target.astro_format.batch` — batched sexagesimal RA/Dec formatting (adopt target-match).
+//! - `target.moon_opposition.batch` — batched Moon-separation + next-opposition
+//!   for N targets in one call, replacing per-row TS ephemeris math (#634).
 //!
 //! Spec-013 commands `target.lookup` and `target.resolve.fits` have been
 //! removed by spec 036 (superseded by spec-035 `target.search`/`target.resolve`).
@@ -328,4 +330,222 @@ pub async fn target_cone_search_confirm(
     );
     let cache = state.resolve_cache.read().await.clone();
     app_core::inbox::cone_search::confirm(state.repo.pool(), &cache.cache(), &req).await
+}
+
+// ── target.moon_opposition.batch (#634) ──────────────────────────────────────
+//
+// Replaces the per-row TS ephemeris math (`astro/lunar-separation.ts`,
+// `astro/opposition.ts`) with a single batched Rust call, same geocentric
+// simplification and ±2°/±7-day tolerance those modules documented (no
+// observer coordinates; catalogued RA/Dec + a shared instant only —
+// Track A). `skymath::sun_position`/`moon_position` (Meeus low-accuracy
+// solar + truncated ELP-2000/82 lunar theory) replace the hand-rolled
+// `astronomy-engine` calls; `skymath::separation`/`circular_distance` replace
+// the hand-rolled vector/RA-diff helpers.
+
+/// One target's catalogued J2000 coordinates for a moon-separation/opposition
+/// batch request.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MoonOppositionTargetInput {
+    /// Caller-defined id, echoed back on the matching result (never re-derived).
+    pub id: String,
+    pub ra_deg: f64,
+    pub dec_deg: f64,
+}
+
+/// `target.moon_opposition.batch` request.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetMoonOppositionBatchRequest {
+    pub targets: Vec<MoonOppositionTargetInput>,
+    /// RFC3339 instant shared by every target in the batch: the Moon's
+    /// geocentric position, and the opposition search's start day, are the
+    /// same for every row on one observing night (same memoization rationale
+    /// as the TS `sunRaTable` this replaces) — pass the SAME instant for a
+    /// whole table render, not a per-row `now()`.
+    pub at: String,
+}
+
+/// Opposition search result for one target.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OppositionResult {
+    /// RFC3339 date (whole-day resolution) of the next opposition-like
+    /// midnight culmination.
+    pub date: String,
+    pub days_until: u32,
+}
+
+/// Moon-separation + opposition result for one target.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct MoonOppositionResult {
+    pub id: String,
+    /// Angular separation from the Moon in degrees (0..=180), or `None` for
+    /// out-of-domain RA/Dec (never a fabricated value).
+    pub moon_separation_deg: Option<f64>,
+    /// `None` for out-of-domain RA/Dec.
+    pub opposition: Option<OppositionResult>,
+}
+
+/// `target.moon_opposition.batch` response.
+#[derive(Clone, Debug, serde::Serialize, serde::Deserialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct TargetMoonOppositionBatchResponse {
+    pub results: Vec<MoonOppositionResult>,
+}
+
+/// Search window: matches the TS `nextOpposition` scan (a touch over one
+/// synodic year of solar RA drift).
+const OPPOSITION_SCAN_DAYS: u32 = 366;
+
+/// Build a J2000 `Equatorial` from decimal-degree RA/Dec, wrapping RA into
+/// `[0, 360)` and clamping Dec into `[-90, 90]` (same domain-safety treatment
+/// as `targeting::coords::to_equatorial`). Returns `None` for non-finite input.
+fn target_equatorial(ra_deg: f64, dec_deg: f64) -> Option<targeting::Equatorial> {
+    if !ra_deg.is_finite() || !dec_deg.is_finite() {
+        return None;
+    }
+    let ra = targeting::Angle::from_degrees(ra_deg).normalized_0_360();
+    let dec = targeting::Angle::from_degrees(dec_deg.clamp(-90.0, 90.0));
+    targeting::Equatorial::j2000(ra, dec).ok()
+}
+
+/// The Sun's geocentric RA (degrees) for each day offset `0..=OPPOSITION_SCAN_DAYS`
+/// from `at` — computed once per batch (see [`TargetMoonOppositionBatchRequest::at`]),
+/// never per target.
+fn sun_ra_table(at: time::OffsetDateTime) -> Vec<f64> {
+    (0..=OPPOSITION_SCAN_DAYS)
+        .map(|day| skymath::sun_position(at + time::Duration::days(i64::from(day))).ra().degrees())
+        .collect()
+}
+
+/// Next opposition-like (midnight-culmination) date for a target at `ra_deg`,
+/// searching forward from `at` using the memoized `table` (mirrors the TS
+/// `nextOpposition` coarse daily scan, FR-014/SC-003).
+fn next_opposition(ra_deg: f64, at: time::OffsetDateTime, table: &[f64]) -> OppositionResult {
+    let target_opposition_ra = targeting::Angle::from_degrees(ra_deg - 180.0).normalized_0_360();
+    let (best_day, _) = table
+        .iter()
+        .enumerate()
+        .map(|(day, &sun_ra)| {
+            let diff = skymath::circular_distance(
+                targeting::Angle::from_degrees(sun_ra),
+                target_opposition_ra,
+            )
+            .degrees()
+            .abs();
+            (u32::try_from(day).unwrap_or(u32::MAX), diff)
+        })
+        .min_by(|(_, a), (_, b)| a.total_cmp(b))
+        .unwrap_or((0, 0.0));
+
+    let date = at + time::Duration::days(i64::from(best_day));
+    OppositionResult {
+        date: date.format(&time::format_description::well_known::Rfc3339).unwrap_or_default(),
+        days_until: best_day,
+    }
+}
+
+/// `target.moon_opposition.batch` — batched Moon-separation + next-opposition
+/// computation for N targets in one call (never per-row round trips, #634).
+/// Pure geometry/ephemeris — no database access, so this never fails on a
+/// well-formed request; a malformed `at` is the only error case.
+///
+/// # Errors
+///
+/// Returns `Err(ContractError)` with code `"value.invalid"` when `at` is not
+/// a valid RFC3339 instant.
+#[tauri::command]
+#[specta::specta]
+pub async fn target_moon_opposition_batch(
+    req: TargetMoonOppositionBatchRequest,
+) -> Result<TargetMoonOppositionBatchResponse, ContractError> {
+    tracing::debug!("target.moon_opposition.batch count={}", req.targets.len());
+    let at = time::OffsetDateTime::parse(&req.at, &time::format_description::well_known::Rfc3339)
+        .map_err(|e| {
+        ContractError::new(
+            contracts_core::error_code::ErrorCode::ValueInvalid,
+            format!("at: invalid RFC3339 instant: {e}"),
+            contracts_core::ErrorSeverity::Warning,
+            false,
+        )
+    })?;
+
+    // Computed once per batch, not per target (moon position + the Sun's
+    // daily RA table are the same for every row on one observing night).
+    let moon = skymath::moon_position(at);
+    let table = sun_ra_table(at);
+
+    let results = req
+        .targets
+        .into_iter()
+        .map(|t| {
+            let eq = target_equatorial(t.ra_deg, t.dec_deg);
+            MoonOppositionResult {
+                id: t.id,
+                moon_separation_deg: eq.map(|e| skymath::separation(moon, e).degrees()),
+                opposition: eq.map(|_| next_opposition(t.ra_deg, at, &table)),
+            }
+        })
+        .collect();
+
+    Ok(TargetMoonOppositionBatchResponse { results })
+}
+
+#[cfg(test)]
+mod moon_opposition_tests {
+    use super::{
+        target_moon_opposition_batch, MoonOppositionTargetInput, TargetMoonOppositionBatchRequest,
+    };
+
+    /// #634 SUCCESS: one batched call returns both moon-separation and
+    /// opposition for N targets, keyed by the caller's `id`.
+    #[tokio::test]
+    async fn batched_moon_opposition_for_multiple_targets() {
+        let req = TargetMoonOppositionBatchRequest {
+            targets: vec![
+                MoonOppositionTargetInput { id: "m31".to_owned(), ra_deg: 10.68, dec_deg: 41.27 },
+                MoonOppositionTargetInput { id: "m42".to_owned(), ra_deg: 83.82, dec_deg: -5.39 },
+            ],
+            at: "2026-01-15T00:00:00Z".to_owned(),
+        };
+        let resp = target_moon_opposition_batch(req).await.unwrap();
+        assert_eq!(resp.results.len(), 2);
+        for r in &resp.results {
+            let sep = r.moon_separation_deg.expect("finite RA/Dec must produce a separation");
+            assert!((0.0..=180.0).contains(&sep), "separation out of range: {sep}");
+            let opp = r.opposition.as_ref().expect("finite RA/Dec must produce an opposition");
+            assert!(opp.days_until <= 366);
+            assert!(!opp.date.is_empty());
+        }
+        assert_eq!(resp.results[0].id, "m31");
+        assert_eq!(resp.results[1].id, "m42");
+    }
+
+    /// Non-finite RA/Dec returns `None` rather than a fabricated value.
+    #[tokio::test]
+    async fn non_finite_coordinates_return_none() {
+        let req = TargetMoonOppositionBatchRequest {
+            targets: vec![MoonOppositionTargetInput {
+                id: "bad".to_owned(),
+                ra_deg: f64::NAN,
+                dec_deg: 0.0,
+            }],
+            at: "2026-01-15T00:00:00Z".to_owned(),
+        };
+        let resp = target_moon_opposition_batch(req).await.unwrap();
+        assert_eq!(resp.results.len(), 1);
+        assert!(resp.results[0].moon_separation_deg.is_none());
+        assert!(resp.results[0].opposition.is_none());
+    }
+
+    /// A malformed `at` is rejected, not silently defaulted.
+    #[tokio::test]
+    async fn invalid_at_is_rejected() {
+        let req = TargetMoonOppositionBatchRequest { targets: vec![], at: "not-a-date".to_owned() };
+        let err = target_moon_opposition_batch(req).await.unwrap_err();
+        assert_eq!(err.code, contracts_core::error_code::ErrorCode::ValueInvalid);
+    }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -119,8 +119,8 @@ use crate::commands::target_favourites::{
 };
 use crate::commands::target_lookup::{
     target_adopt, target_astro_format_batch, target_cache_clear, target_cone_search_confirm,
-    target_cone_search_suggest, target_resolution_settings, target_resolution_settings_update,
-    target_resolve, target_resolve_explicit, target_search,
+    target_cone_search_suggest, target_moon_opposition_batch, target_resolution_settings,
+    target_resolution_settings_update, target_resolve, target_resolve_explicit, target_search,
 };
 use crate::commands::target_management as target_mgmt_cmds;
 use crate::commands::targets::{targets_get, targets_list};
@@ -237,6 +237,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         target_resolution_settings_update,
         // sexagesimal RA/Dec formatting (adopt target-match)
         target_astro_format_batch,
+        // moon separation + opposition batch (#634)
+        target_moon_opposition_batch,
         // projects (spec 008)
         projects_list,
         projects_get,
@@ -480,6 +482,8 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         target_resolution_settings_update,
         // sexagesimal RA/Dec formatting (adopt target-match)
         target_astro_format_batch,
+        // moon separation + opposition batch (#634)
+        target_moon_opposition_batch,
         // projects (spec 008)
         projects_list,
         projects_get,

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -425,6 +425,18 @@ export const commands = {
 	 */
 	targetAstroFormatBatch: (req: TargetAstroFormatBatchRequest) => typedError<TargetAstroFormatBatchResponse, ContractError_Serialize>(__TAURI_INVOKE("target_astro_format_batch", { req })),
 	/**
+	 *  `target.moon_opposition.batch` — batched Moon-separation + next-opposition
+	 *  computation for N targets in one call (never per-row round trips, #634).
+	 *  Pure geometry/ephemeris — no database access, so this never fails on a
+	 *  well-formed request; a malformed `at` is the only error case.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(ContractError)` with code `"value.invalid"` when `at` is not
+	 *  a valid RFC3339 instant.
+	 */
+	targetMoonOppositionBatch: (req: TargetMoonOppositionBatchRequest) => typedError<TargetMoonOppositionBatchResponse, ContractError_Serialize>(__TAURI_INVOKE("target_moon_opposition_batch", { req })),
+	/**
 	 *  `projects.list` — list all projects from the database.
 	 * 
 	 *  # Errors
@@ -6367,6 +6379,29 @@ export type MismatchedDimDto_Serialize = {
 	delta?: number | null,
 };
 
+/**  Moon-separation + opposition result for one target. */
+export type MoonOppositionResult = {
+	id: string,
+	/**
+	 *  Angular separation from the Moon in degrees (0..=180), or `None` for
+	 *  out-of-domain RA/Dec (never a fabricated value).
+	 */
+	moonSeparationDeg: number | null,
+	/**  `None` for out-of-domain RA/Dec. */
+	opposition: OppositionResult | null,
+};
+
+/**
+ *  One target's catalogued J2000 coordinates for a moon-separation/opposition
+ *  batch request.
+ */
+export type MoonOppositionTargetInput = {
+	/**  Caller-defined id, echoed back on the matching result (never re-derived). */
+	id: string,
+	raDeg: number | null,
+	decDeg: number | null,
+};
+
 /**  Summary of items that do NOT require acknowledgement (R-CheckScope, FR-008). */
 export type NonBlockingSummary = {
 	normalCount: number,
@@ -6384,6 +6419,16 @@ export type OperationEvent = {
 export type OperationEventType = "progress" | "discovered_item_batch" | "extracted_metadata_batch" | "failed_file_batch" | "candidate_batch" | "observed_artifact_batch" | "item_started" | "item_applied" | "item_failed" | "warning" | "completed" | "failed" | "custom";
 
 export type OperationId = string;
+
+/**  Opposition search result for one target. */
+export type OppositionResult = {
+	/**
+	 *  RFC3339 date (whole-day resolution) of the next opposition-like
+	 *  midnight culmination.
+	 */
+	date: string,
+	daysUntil: number,
+};
 
 export type OpticalTrain = {
 	id: string,
@@ -9080,6 +9125,24 @@ export type TargetListItem_Serialize = {
 	 *  that ignore unknown keys are unaffected.
 	 */
 	aliases: string[],
+};
+
+/**  `target.moon_opposition.batch` request. */
+export type TargetMoonOppositionBatchRequest = {
+	targets: MoonOppositionTargetInput[],
+	/**
+	 *  RFC3339 instant shared by every target in the batch: the Moon's
+	 *  geocentric position, and the opposition search's start day, are the
+	 *  same for every row on one observing night (same memoization rationale
+	 *  as the TS `sunRaTable` this replaces) — pass the SAME instant for a
+	 *  whole table render, not a per-row `now()`.
+	 */
+	at: string,
+};
+
+/**  `target.moon_opposition.batch` response. */
+export type TargetMoonOppositionBatchResponse = {
+	results: MoonOppositionResult[],
 };
 
 /**  Request for `target.note.get` (spec 023 US4). */

--- a/crates/app/settings/src/descriptors.rs
+++ b/crates/app/settings/src/descriptors.rs
@@ -67,6 +67,10 @@ pub(crate) enum ValidationRule {
     /// (stringified `1`-`20`, the frontend `CLEANUP_TYPES` fixture ids) to
     /// exactly one of `"Keep"`, `"Archive"`, or `"Delete"`.
     CleanupTypeOverrides,
+    /// Default-enabled planner catalogue ids (#645): JSON array of strings,
+    /// each a known `PLANNER_CATALOGS` id (`NGC`, `Sh2`, `LBN`, `LDN`, `IC`,
+    /// `M`, `C`, `B` — `apps/desktop/src/features/targets/planner-catalog.ts`).
+    CatalogueIds,
 }
 
 /// A stable settings key plus its audit/override flags, validation rule, and
@@ -792,6 +796,16 @@ pub(crate) fn check_rule(
             ));
         }
         ValidationRule::CleanupTypeOverrides => check_cleanup_type_overrides(value, invalid)?,
+        ValidationRule::CatalogueIds => {
+            const KNOWN_IDS: [&str; 8] = ["NGC", "Sh2", "LBN", "LDN", "IC", "M", "C", "B"];
+            let arr = value.as_array().ok_or_else(|| invalid("must be an array"))?;
+            for entry in arr {
+                let id = entry.as_str().ok_or_else(|| invalid("catalogue id must be a string"))?;
+                if !KNOWN_IDS.contains(&id) {
+                    return Err(invalid(&format!("unknown catalogue id: {id}")));
+                }
+            }
+        }
     }
     Ok(())
 }

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -154,6 +154,18 @@ pub fn is_valid_key(key: &str) -> bool {
         || is_tools_auto_detected_key(key)
         || is_workflow_profile_watch_extensions_key(key)
         || is_workflow_profile_attribution_window_key(key)
+        || is_catalogues_enabled_key(key)
+}
+
+/// `enabled` (#645, scope `"catalogues"`): default-enabled Planner catalogue
+/// ids. Not in the descriptor table on purpose — there is no dedicated
+/// `SettingsState` field for it (`SettingsState` lives in `domain_core`,
+/// outside this crate). Same treatment as the `tools.*`/`workflow_profile.*`
+/// structured-path keys: read/write through the DB row + `default_value_for_key`
+/// only, never through the in-memory `SettingsState` bag returned by
+/// `get_settings` (unused by the Planner/Settings pane for this key).
+fn is_catalogues_enabled_key(key: &str) -> bool {
+    key == "enabled"
 }
 
 /// Return the names of all stable settings keys that can be overridden per source root.
@@ -305,6 +317,9 @@ pub fn validate_value(key: &str, value: &Value) -> Result<(), ContractError> {
                 return Err(invalid("must be a number"));
             }
         }
+        _ if is_catalogues_enabled_key(key) => {
+            descriptors::check_rule(descriptors::ValidationRule::CatalogueIds, value, &invalid)?;
+        }
         _ => {
             // No additional validation for other keys.
         }
@@ -414,6 +429,9 @@ fn default_value_for_key(key: &str) -> Value {
             }
         }
         return Value::Null;
+    }
+    if is_catalogues_enabled_key(key) {
+        return serde_json::json!(["M", "NGC", "IC", "Sh2"]);
     }
     Value::Null
 }
@@ -1383,6 +1401,45 @@ mod tests {
         let (db, _bus) = setup().await;
         let resolved = resolve_setting(db.pool(), "hashOnScan", None).await.unwrap();
         assert_eq!(resolved, serde_json::json!("lazy")); // default
+    }
+
+    /// #645: the `catalogues` scope's `enabled` key is a known, persistable
+    /// key (previously silently skipped as unknown), and the persisted value
+    /// survives a fresh `resolve_setting` read (the reload path).
+    #[tokio::test]
+    async fn update_setting_enabled_catalogues_persists_across_reload() {
+        let (db, bus) = setup().await;
+
+        // Default (nothing stored yet) is the in-code default subset.
+        let default = resolve_setting(db.pool(), "enabled", None).await.unwrap();
+        assert_eq!(default, serde_json::json!(["M", "NGC", "IC", "Sh2"]));
+
+        let req = SettingsUpdateRequest {
+            key: "enabled".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!([
+                "M", "NGC", "IC", "Sh2", "LBN"
+            ])),
+        };
+        let resp = update_setting(db.pool(), &bus, &req).await.unwrap();
+        assert_eq!(resp.status, SettingsUpdateStatus::Success);
+
+        // Simulates "leave the pane and return": a fresh resolve reads the
+        // persisted row, not the in-code default.
+        let reloaded = resolve_setting(db.pool(), "enabled", None).await.unwrap();
+        assert_eq!(reloaded, serde_json::json!(["M", "NGC", "IC", "Sh2", "LBN"]));
+    }
+
+    /// #645: an unknown catalogue id is rejected as `value.invalid`, not
+    /// silently accepted.
+    #[tokio::test]
+    async fn update_setting_enabled_catalogues_rejects_unknown_id() {
+        let (db, bus) = setup().await;
+        let req = SettingsUpdateRequest {
+            key: "enabled".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!(["NotACatalogue"])),
+        };
+        let err = update_setting(db.pool(), &bus, &req).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::ValueInvalid);
     }
 
     // ── T026: restore_defaults contract tests ──────────────────────────


### PR DESCRIPTION
## Summary
- Fixes the Default Catalogues setting so the enabled/disabled choice actually persists (fixes #645)
- Adds backend support for batched moon-phase/opposition lookups (#634); UI wiring for this is a separate follow-up and #634 stays open

Fixes #645