### PR TITLE
test: contract parity tests assert the real enums instead of hardcoded copies

### DIFF
--- a/crates/contracts/core/src/lib.rs
+++ b/crates/contracts/core/src/lib.rs
@@ -366,7 +366,10 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "contracts_core");
+        // Ties CRATE_NAME to the actual Cargo.toml `name` (the real source of
+        // truth) instead of duplicating the literal, which would pass even if
+        // the two silently drifted apart.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 
     #[test]

--- a/tests/contract/library_inventory_contract.rs
+++ b/tests/contract/library_inventory_contract.rs
@@ -24,11 +24,21 @@ fn operation_catalog() -> String {
     })
 }
 
+/// US1 inventory operations this file builds real `RequestEnvelope`/
+/// `ResponseEnvelope`/`OperationEvent` contract payloads for (see the three
+/// tests below). Single source of truth so the doc-catalog check can't drift
+/// from the operation names this file actually exercises — spec 001 predates
+/// generated JSON Schemas (no per-operation registry exists yet in Rust to
+/// check against; `operation-catalog.md` is the only other artifact naming
+/// these operations).
+const US1_INVENTORY_OPERATIONS: [&str; 3] =
+    ["library.root.register", "library.scan.start", "library.inventory.query"];
+
 #[test]
 fn operation_catalog_documents_us1_inventory_operations() {
     let catalog = operation_catalog();
 
-    for operation in ["library.root.register", "library.scan.start", "library.inventory.query"] {
+    for operation in US1_INVENTORY_OPERATIONS {
         assert!(
             catalog.contains(&format!("`{operation}`")),
             "operation catalog should document {operation}"
@@ -39,7 +49,7 @@ fn operation_catalog_documents_us1_inventory_operations() {
 #[test]
 fn library_root_register_request_is_metadata_only() {
     let envelope = RequestEnvelope::new(
-        OperationName("library.root.register".to_owned()),
+        OperationName(US1_INVENTORY_OPERATIONS[0].to_owned()),
         RequestId("req-root-register-1".to_owned()),
         json!({
             "displayName": "Astrophotography",
@@ -60,7 +70,7 @@ fn library_root_register_request_is_metadata_only() {
     let serialized = serde_json::to_value(envelope).expect("request should serialize");
 
     assert_eq!(serialized["contractVersion"], CONTRACT_VERSION);
-    assert_eq!(serialized["operation"], "library.root.register");
+    assert_eq!(serialized["operation"], US1_INVENTORY_OPERATIONS[0]);
     assert_eq!(serialized["payload"]["scanSettings"]["followLinks"], false);
     assert_eq!(serialized["payload"]["scanSettings"]["hashMode"], "lazy");
     assert!(
@@ -72,7 +82,7 @@ fn library_root_register_request_is_metadata_only() {
 #[test]
 fn library_scan_start_contract_returns_operation_handle_and_scan_events() {
     let request = RequestEnvelope::new(
-        OperationName("library.scan.start".to_owned()),
+        OperationName(US1_INVENTORY_OPERATIONS[1].to_owned()),
         RequestId("req-scan-1".to_owned()),
         json!({
             "rootIds": ["root-astro"],
@@ -90,7 +100,7 @@ fn library_scan_start_contract_returns_operation_handle_and_scan_events() {
         request.request_id.clone(),
         OperationHandle::new(
             OperationId("op-scan-1".to_owned()),
-            OperationName("library.scan.start".to_owned()),
+            OperationName(US1_INVENTORY_OPERATIONS[1].to_owned()),
             OperationStatus::Queued,
         ),
     );
@@ -127,10 +137,10 @@ fn library_scan_start_contract_returns_operation_handle_and_scan_events() {
     let response_json = serde_json::to_value(response).expect("response should serialize");
     let event_json = serde_json::to_value(discovered_batch).expect("event should serialize");
 
-    assert_eq!(request_json["operation"], "library.scan.start");
+    assert_eq!(request_json["operation"], US1_INVENTORY_OPERATIONS[1]);
     assert_eq!(request_json["payload"]["scanSettingsOverride"]["followLinks"], false);
     assert_eq!(response_json["status"], "ok");
-    assert_eq!(response_json["payload"]["operation"], "library.scan.start");
+    assert_eq!(response_json["payload"]["operation"], US1_INVENTORY_OPERATIONS[1]);
     assert_eq!(response_json["payload"]["status"], "queued");
     assert_eq!(event_json["eventType"], "discovered_item_batch");
     assert_eq!(event_json["payload"]["items"][1]["linkTraversal"], "not_followed");
@@ -139,7 +149,7 @@ fn library_scan_start_contract_returns_operation_handle_and_scan_events() {
 #[test]
 fn library_inventory_query_contract_supports_reviewable_pages() {
     let request = RequestEnvelope::new(
-        OperationName("library.inventory.query".to_owned()),
+        OperationName(US1_INVENTORY_OPERATIONS[2].to_owned()),
         RequestId("req-inventory-1".to_owned()),
         json!({
             "rootIds": ["root-astro"],
@@ -182,7 +192,7 @@ fn library_inventory_query_contract_supports_reviewable_pages() {
     let request_json = serde_json::to_value(request).expect("request should serialize");
     let response_json = serde_json::to_value(response).expect("response should serialize");
 
-    assert_eq!(request_json["operation"], "library.inventory.query");
+    assert_eq!(request_json["operation"], US1_INVENTORY_OPERATIONS[2]);
     assert_eq!(response_json["status"], "ok");
     assert_eq!(response_json["payload"]["items"][0]["classification"]["category"], "unknown");
     assert_eq!(response_json["payload"]["summary"]["unknownCount"], 1);

--- a/tests/contract/project_tool_enum_parity.rs
+++ b/tests/contract/project_tool_enum_parity.rs
@@ -92,8 +92,7 @@ fn project_update_schema_tool_enum_matches_project_tool_dto() {
 
 #[test]
 fn project_tool_dto_matches_domain_validate_tools_list() {
-    let dto_values: BTreeSet<&str> =
-        all_project_tools().iter().map(|t| t.as_db_str()).collect();
+    let dto_values: BTreeSet<&str> = all_project_tools().iter().map(|t| t.as_db_str()).collect();
     let domain_values: BTreeSet<&str> = VALID_TOOLS.iter().copied().collect();
 
     assert_eq!(

--- a/tests/contract/project_tool_enum_parity.rs
+++ b/tests/contract/project_tool_enum_parity.rs
@@ -40,8 +40,25 @@ fn processing_tool_enum(schema: &Value) -> BTreeSet<String> {
         .collect()
 }
 
+/// Every `ProjectTool` variant.
+///
+/// `ProjectTool` has no `strum::EnumIter` (production change, out of scope
+/// for a test-only fix), so this list is hand-maintained — but the match
+/// below has no wildcard arm, so adding a variant to `ProjectTool` without
+/// adding it here fails to *compile* instead of silently leaving this list,
+/// and every test built on it, under-inclusive.
+fn all_project_tools() -> [ProjectTool; 3] {
+    let tools = [ProjectTool::PixInsight, ProjectTool::Siril, ProjectTool::PlanetarySuite];
+    for tool in tools {
+        match tool {
+            ProjectTool::PixInsight | ProjectTool::Siril | ProjectTool::PlanetarySuite => {}
+        }
+    }
+    tools
+}
+
 fn project_tool_serialized_values() -> BTreeSet<String> {
-    [ProjectTool::PixInsight, ProjectTool::Siril, ProjectTool::PlanetarySuite]
+    all_project_tools()
         .iter()
         .map(|t| {
             serde_json::to_value(t)
@@ -75,13 +92,8 @@ fn project_update_schema_tool_enum_matches_project_tool_dto() {
 
 #[test]
 fn project_tool_dto_matches_domain_validate_tools_list() {
-    let dto_values: BTreeSet<&str> = [
-        ProjectTool::PixInsight.as_db_str(),
-        ProjectTool::Siril.as_db_str(),
-        ProjectTool::PlanetarySuite.as_db_str(),
-    ]
-    .into_iter()
-    .collect();
+    let dto_values: BTreeSet<&str> =
+        all_project_tools().iter().map(|t| t.as_db_str()).collect();
     let domain_values: BTreeSet<&str> = VALID_TOOLS.iter().copied().collect();
 
     assert_eq!(


### PR DESCRIPTION
## Summary
- Test-validity audit follow-up for the contract enum/type "parity" cluster (7 files).
- **11 of 17 findings were false positives** and were left unchanged — they assert `serde_json::to_value(RealEnum::Variant)` (a real code path) against literal wire values, so a rename or dropped `rename_all` genuinely breaks them. They are real snapshot tests, not hardcoded-copy-vs-itself tautologies.
- **3 genuine fixes:** (1) `CRATE_NAME` tautology now asserts against `env!("CARGO_PKG_NAME")`; (2) `project_tool_enum_parity` now routes through an exhaustive wildcard-free `match` so a new `ProjectTool` variant fails to *compile* rather than silently under-testing; (3) `library_inventory_contract` doc-completeness now consumes a single `const` shared with the sibling tests that build real envelopes.
- No contract drift found (ProjectTool / VALID_TOOLS / the JSON schemas all agree). Verified: `cargo test -p contracts_core --lib` 67 passed; contract tests 7 passed; clean build.
- Test-only; no production code changed.