### PR TITLE
fix: Confirm no longer stays disabled after reclassifying an inbox item to a valid frame type

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -930,7 +930,16 @@ pub(crate) async fn materialize_sub_items(
             lane,
         };
 
-        repo::upsert_inbox_sub_item(pool, &sub_item).await.ok();
+        // Seed against the id that ACTUALLY persisted, not the freshly-generated
+        // `sub_id`: on a re-materialization of an existing group the ON CONFLICT
+        // DO UPDATE keeps the pre-existing row's id and discards `sub_id`.
+        // Seeding the discarded id FK-fails (evidence/metadata/classification
+        // reference inbox_items(id)) and strands the real row without evidence,
+        // so a later reclassify finds empty file records and never resolves the
+        // group to a confirmable single-type item (issue #854).
+        let Ok(persisted_id) = repo::upsert_inbox_sub_item(pool, &sub_item).await else {
+            continue;
+        };
 
         // Seed this sub-item's OWN evidence/metadata/breakdown + a matching
         // `inbox_classifications` cache row (content_signature == sub_sig, the
@@ -943,7 +952,7 @@ pub(crate) async fn materialize_sub_items(
         // source group, never copied to a freshly materialized sub-item id
         // otherwise), re-classifying it back to unclassified and leaving
         // Confirm permanently disabled (issue #755 CI fix, R-14).
-        seed_sub_item_cache(pool, &sub_id, group_key, frame_type_str, &sub_sig, files).await;
+        seed_sub_item_cache(pool, &persisted_id, group_key, frame_type_str, &sub_sig, files).await;
     }
 
     // Purge sub-item rows for groups that no longer exist: when a file's metadata

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -504,12 +504,19 @@ pub struct UpsertInboxSubItem<'a> {
 ///
 /// # Errors
 /// Returns [`DbError::Database`] on constraint or connection failure.
+///
+/// Returns the id of the persisted row. On an `ON CONFLICT` update this is the
+/// PRE-EXISTING row's id, NOT `item.id`: SQLite keeps the conflicting row's
+/// primary key. Callers MUST seed dependent rows (evidence/metadata/
+/// classification, which FK-reference `inbox_items(id)`) against the returned
+/// id — seeding against a discarded `item.id` FK-fails and strands the real row
+/// without evidence, breaking a later reclassify (issue #854).
 pub async fn upsert_inbox_sub_item(
     pool: &SqlitePool,
     item: &UpsertInboxSubItem<'_>,
-) -> DbResult<()> {
+) -> DbResult<String> {
     let now = Timestamp::now_iso();
-    sqlx::query(
+    let (id,): (String,) = sqlx::query_as(
         "INSERT INTO inbox_items
             (id, root_id, relative_path, source_group_id, group_key, group_label,
              frame_type, file_count, discovered_at, last_scanned_at,
@@ -521,7 +528,8 @@ pub async fn upsert_inbox_sub_item(
              file_count         = excluded.file_count,
              last_scanned_at    = excluded.last_scanned_at,
              content_signature  = excluded.content_signature,
-             state              = 'classified'",
+             state              = 'classified'
+         RETURNING id",
     )
     .bind(item.id)
     .bind(item.root_id)
@@ -535,9 +543,9 @@ pub async fn upsert_inbox_sub_item(
     .bind(&now)
     .bind(item.content_signature)
     .bind(item.lane)
-    .execute(pool)
+    .fetch_one(pool)
     .await?;
-    Ok(())
+    Ok(id)
 }
 
 /// Update `child_count` on a source group to reflect how many single-type
@@ -1904,6 +1912,89 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0].relative_file_path, "2025-10-10/lights/frame_001.fits");
         assert_eq!(rows[0].frame_type, Some("light".to_owned()));
+    }
+
+    /// issue #854: on a re-materialization of an existing group, the ON CONFLICT
+    /// DO UPDATE keeps the PRE-EXISTING row's id and discards the caller's
+    /// freshly-generated id. The function must return the id that actually
+    /// persisted so `materialize_sub_items` can seed evidence/metadata against a
+    /// real `inbox_items` row — seeding the discarded id FK-fails and strands the
+    /// row without evidence, so a later reclassify never resolves the group.
+    #[tokio::test]
+    async fn upsert_sub_item_returns_persisted_id_on_conflict() {
+        let db = test_db().await;
+        upsert_inbox_source_group(
+            db.pool(),
+            &UpsertSourceGroup {
+                id: "sg-854",
+                root_id: "root-1",
+                relative_path: "",
+                content_signature: Some("s"),
+                format: Some("fits"),
+                lane: Some("fits"),
+            },
+        )
+        .await
+        .unwrap();
+
+        let mk = |id| UpsertInboxSubItem {
+            id,
+            root_id: "root-1",
+            relative_path: "",
+            source_group_id: "sg-854",
+            group_key: "type=light",
+            group_label: "Light",
+            frame_type: Some("light"),
+            content_signature: "s",
+            file_count: 1,
+            lane: "fits",
+        };
+
+        let first = upsert_inbox_sub_item(db.pool(), &mk("id-A")).await.unwrap();
+        assert_eq!(first, "id-A");
+
+        // Same (root_id, relative_path, group_key) → conflict; the discarded id
+        // must NOT be returned.
+        let second = upsert_inbox_sub_item(db.pool(), &mk("id-B-discarded")).await.unwrap();
+        assert_eq!(second, "id-A", "ON CONFLICT keeps the existing row id");
+
+        // Seeding under the returned id succeeds; seeding under the discarded id
+        // FK-fails (evidence FK-references inbox_items(id)) — the exact swallowed
+        // write that #854 stranded on.
+        insert_evidence(
+            db.pool(),
+            &InsertEvidence {
+                id: "ev-ok",
+                inbox_item_id: &second,
+                relative_file_path: "f.fits",
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: None,
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await
+        .unwrap();
+        let orphan = insert_evidence(
+            db.pool(),
+            &InsertEvidence {
+                id: "ev-fk",
+                inbox_item_id: "id-B-discarded",
+                relative_file_path: "f.fits",
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: None,
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await;
+        assert!(orphan.is_err(), "the discarded id is not a real row; seeding it FK-fails");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What & why

PR #854 turned `main`'s Real-UI E2E **red**: `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm` began failing deterministically — after bulk-reclassifying an unclassified item to `light` (filter + target + date all present, so no missing mandatory attrs), the item never re-resolved to a clean `single_type` and **Confirm never re-enabled**.

Pre-#854 main was green (E2E run `29610425589`); the first post-#854 run (`29638271121`) failed. This restores green.

## Root cause — two linked #854 defects

1. **Curative (produces the symptom).** `reclassify_v2` narrowed its evidence gather to the materialized sub-items alone (`reclassify.rs`, #854-added to avoid double-counting the superseded placeholder). When a sub-item is stranded **without evidence**, that narrowing *starves* the gather → `file_records` empty → `materialize_sub_items` creates nothing and purges the sub-item → `reclassify_v2` returns `subItems: []`, `needsReviewCount: 0` → the frontend Confirm gate (`classification.type === 'single_type'`) never enables. Confirmed against the real CI failure dump.
2. **Preventive (how a sub-item ends up evidence-less).** `materialize_sub_items` generated a fresh uuid per sub-item, but `upsert_inbox_sub_item`'s `ON CONFLICT(root_id, relative_path, group_key) DO UPDATE` keeps the **pre-existing** row id and discards the fresh one — while `seed_sub_item_cache` seeded evidence against the *discarded* id. Evidence FK-references `inbox_items(id)`, so the insert failed silently via `.ok()`.

## The fix

- **Curative:** build an authoritative `path → item` map deduped by relative path — placeholder first (full-coverage baseline), then materialized sub-items override only paths they actually carry evidence for, with a per-path dedup guard. An evidence-less sub-item can no longer hide a file the placeholder still holds; no file is double-counted.
- **Preventive:** `upsert_inbox_sub_item` now `RETURNING id` (the persisted id); `materialize_sub_items` seeds against it; a failed upsert `continue`s rather than seeding a bogus id.

## Verification

- **Deterministic reproduction** `v2_reclassify_recovers_from_evidenceless_stranded_sub_item` — mirrors the CI dump; fails pre-fix, passes post-fix.
- `upsert_sub_item_returns_persisted_id_on_conflict` — proves the returned-id contract.
- Full `app_core_inbox` suite (196) + `persistence_db` (267) green; `clippy -D warnings` + `fmt` clean; independently re-verified in a clean worktree.

The Windows `inbox_ui_missing_path_attribute_banner_blocks_confirm` failure is a **separate** scenario (the opposite direction of the same gate) and is not addressed here.

**Merge policy:** hold until the full Real-UI E2E goes green on this branch — the non-required E2E shard is exactly what got skipped when #854 merged.