### PR TITLE
fix: Inbox Confirm stays disabled after assigning frame types in an unorganized folder

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -930,7 +930,16 @@ pub(crate) async fn materialize_sub_items(
             lane,
         };
 
-        repo::upsert_inbox_sub_item(pool, &sub_item).await.ok();
+        // Use the id that ACTUALLY persisted, not the freshly-generated
+        // `sub_id`: on a re-materialization of the same group the ON CONFLICT
+        // DO UPDATE keeps the pre-existing row's id and discards `sub_id`.
+        // Seeding the discarded id FK-fails (evidence/classification reference
+        // inbox_items(id)) and strands the real row without evidence, which
+        // makes a later reclassify find empty file records and purge the
+        // sub-item entirely — Confirm then never enables (issue #854).
+        let Ok(persisted_id) = repo::upsert_inbox_sub_item(pool, &sub_item).await else {
+            continue;
+        };
 
         // Seed this sub-item's OWN evidence/metadata/breakdown + a matching
         // `inbox_classifications` cache row (content_signature == sub_sig, the
@@ -943,7 +952,7 @@ pub(crate) async fn materialize_sub_items(
         // source group, never copied to a freshly materialized sub-item id
         // otherwise), re-classifying it back to unclassified and leaving
         // Confirm permanently disabled (issue #755 CI fix, R-14).
-        seed_sub_item_cache(pool, &sub_id, group_key, frame_type_str, &sub_sig, files).await;
+        seed_sub_item_cache(pool, &persisted_id, group_key, frame_type_str, &sub_sig, files).await;
     }
 
     // Purge sub-item rows for groups that no longer exist: when a file's metadata

--- a/crates/app/inbox/src/reclassify.rs
+++ b/crates/app/inbox/src/reclassify.rs
@@ -560,7 +560,20 @@ pub async fn reclassify_v2(
         )
     })?;
     let (root_id, relative_path) = (sg_row.root_id, sg_row.relative_path);
-    let lane = sg_row.lane.unwrap_or_else(|| "fits".to_owned());
+    // `inbox_source_groups.lane` is the move-vs-catalogue lane
+    // ('move'/'catalogue', set from the root's organization_state at scan
+    // time), NOT the fits/video lane that `inbox_items` requires
+    // (CHECK(lane IN ('fits','video'))). Deriving the item lane from the
+    // group's format mirrors scan's own assignment (video-only folders →
+    // 'video', everything else → 'fits'). Passing `sg_row.lane` here made
+    // every re-split of an unorganized ('move') group fail the CHECK inside
+    // `upsert_inbox_sub_item`, silently dropping the resolved sub-item so
+    // Confirm never re-enabled after a bulk reclassify (issue #854).
+    let lane = match sg_row.format.as_deref() {
+        Some("video") => "video",
+        _ => "fits",
+    }
+    .to_owned();
 
     // Build file_records from persisted metadata. We have no abs paths here
     // (reclassify carries no root path), so we pass an empty file_paths slice
@@ -1627,6 +1640,293 @@ mod tests {
             after.unclassified_files.is_empty(),
             "no needs-review files once the durable overrides are layered: {:?}",
             after.unclassified_files
+        );
+    }
+
+    /// Real-UI E2E `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm`
+    /// regression: the user's FIRST bulk apply sets ONLY frameType=light (the
+    /// generic bulk editor's exposure field is left blank). A light frame is
+    /// missing its mandatory `exposureS` (the fixture header carries no
+    /// EXPTIME), so that first reclassify correctly re-splits the group into a
+    /// NEEDS-REVIEW sub-item. The user then supplies the exposure and applies
+    /// AGAIN — this SECOND reclassify_v2 must resolve the group to a `light`
+    /// sub-item so Confirm can enable. The single-call happy-path tests never
+    /// exercise a reclassify whose input is the DB state a PRIOR reclassify's
+    /// re-split left behind, which is where `materialize_sub_items`' swallowed
+    /// write errors surfaced as an empty `sub_items` (Confirm stuck disabled).
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // real-pipeline regression test: scan/classify/reclassify×2
+    async fn v2_second_reclassify_after_needs_review_resplit_resolves_single_type() {
+        let root = tempfile::tempdir().unwrap();
+        // Unmapped IMAGETYP + no EXPTIME — the real E2E fixture shape.
+        let fits_path = root.path().join("ambiguous_001.fits");
+        {
+            let mut data = vec![b' '; 2880];
+            let cards = ["IMAGETYP= 'Frame Unknown'", "OBJECT  = 'M42'", "FILTER  = 'Ha'"];
+            for (i, c) in cards.iter().enumerate() {
+                let card = format!("{c:<80}");
+                data[i * 80..i * 80 + 80].copy_from_slice(card.as_bytes());
+            }
+            data[cards.len() * 80..cards.len() * 80 + 3].copy_from_slice(b"END");
+            std::fs::write(&fits_path, &data).unwrap();
+        }
+
+        let db = test_db().await;
+        let sg_id = "sg-two-apply";
+        let placeholder_id = "item-two-apply";
+
+        upsert_inbox_source_group(
+            db.pool(),
+            &UpsertSourceGroup {
+                id: sg_id,
+                root_id: "root-1",
+                relative_path: "",
+                content_signature: Some("sig"),
+                format: Some("fits"),
+                lane: Some("fits"),
+            },
+        )
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO inbox_items \
+             (id, root_id, relative_path, source_group_id, group_key, group_label, \
+              frame_type, file_count, discovered_at, last_scanned_at, \
+              content_signature, state, lane) \
+             VALUES (?, 'root-1', '', ?, '', NULL, NULL, 1, \
+                     datetime('now'), datetime('now'), 'sig', 'pending_classification', 'fits')",
+        )
+        .bind(placeholder_id)
+        .bind(sg_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let first = crate::classify::classify(
+            db.pool(),
+            crate::classify::ClassifyRequest {
+                inbox_item_id: placeholder_id.to_owned(),
+                root_absolute_path: root.path().to_owned(),
+                force_rescan: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.classification_type, "unclassified");
+
+        // Apply #1 — ONLY frameType=light. Light is missing its mandatory
+        // exposureS, so this correctly routes to a needs-review sub-item.
+        let apply1 = reclassify_v2(
+            db.pool(),
+            InboxReclassifyV2Request {
+                source_group_id: Some(sg_id.to_owned()),
+                inbox_item_id: None,
+                overrides: vec![],
+                bulk: vec![InboxReclassifyBulk {
+                    property: "frameType".to_owned(),
+                    value: serde_json::json!("light").into(),
+                    file_paths: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(
+            apply1.needs_review_count, 1,
+            "light without exposureS must be needs-review after apply #1: {apply1:?}"
+        );
+
+        // Apply #2 — frameType=light + exposureS=300. Mandatory now satisfied;
+        // the group must resolve to a single `light` sub-item.
+        let apply2 = reclassify_v2(
+            db.pool(),
+            InboxReclassifyV2Request {
+                source_group_id: Some(sg_id.to_owned()),
+                inbox_item_id: None,
+                overrides: vec![],
+                bulk: vec![
+                    InboxReclassifyBulk {
+                        property: "frameType".to_owned(),
+                        value: serde_json::json!("light").into(),
+                        file_paths: None,
+                    },
+                    InboxReclassifyBulk {
+                        property: "exposureS".to_owned(),
+                        value: serde_json::json!(300.0).into(),
+                        file_paths: None,
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(
+            apply2.needs_review_count, 0,
+            "apply #2 supplies exposureS, so nothing is needs-review: {apply2:?}"
+        );
+        let light = apply2.sub_items.iter().find(|s| s.frame_type.as_deref() == Some("light"));
+        assert!(
+            light.is_some(),
+            "apply #2 must resolve the group to a light sub-item (Confirm gate): {:?}",
+            apply2.sub_items
+        );
+        assert!(
+            light.unwrap().missing_mandatory.is_empty(),
+            "resolved light sub-item must report no missing mandatory attrs: {light:?}"
+        );
+    }
+
+    /// Real-UI E2E `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm`
+    /// faithful backend replay: the E2E does ONE bulk apply carrying BOTH
+    /// frameType=light AND exposureS=300 (two bulk entries, both filePaths:None),
+    /// identified by `inboxItemId` = the folder PLACEHOLDER (group_key=''),
+    /// after a real `classify()` left it unclassified. The failing CI dump shows
+    /// this returns `subItems:[] / needsReviewCount:0` — no light sub-item is
+    /// materialized, so Confirm never enables. This replays that exact shape.
+    #[tokio::test]
+    #[allow(clippy::too_many_lines)] // real-pipeline regression test: scan/classify/reclassify/refetch
+    async fn v2_single_combined_apply_on_placeholder_resolves_single_type() {
+        let root = tempfile::tempdir().unwrap();
+        let fits_path = root.path().join("ambiguous_001.fits");
+        {
+            let mut data = vec![b' '; 2880];
+            let cards = ["IMAGETYP= 'Frame Unknown'", "OBJECT  = 'M42'", "FILTER  = 'Ha'"];
+            for (i, c) in cards.iter().enumerate() {
+                let card = format!("{c:<80}");
+                data[i * 80..i * 80 + 80].copy_from_slice(card.as_bytes());
+            }
+            data[cards.len() * 80..cards.len() * 80 + 3].copy_from_slice(b"END");
+            std::fs::write(&fits_path, &data).unwrap();
+        }
+
+        let db = test_db().await;
+        let sg_id = "sg-combined";
+        let placeholder_id = "item-combined";
+
+        // The source group carries the MOVE-vs-catalogue lane an unorganized
+        // root gets at scan time ('move'), NOT the fits/video lane inbox_items
+        // requires. reclassify_v2 must not propagate this into the sub-item
+        // upsert (issue #854 — 'move' fails CHECK(lane IN ('fits','video')),
+        // silently dropping the resolved sub-item so Confirm never re-enables).
+        upsert_inbox_source_group(
+            db.pool(),
+            &UpsertSourceGroup {
+                id: sg_id,
+                root_id: "root-1",
+                relative_path: "",
+                content_signature: Some("sig"),
+                format: Some("fits"),
+                lane: Some("move"),
+            },
+        )
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO inbox_items \
+             (id, root_id, relative_path, source_group_id, group_key, group_label, \
+              frame_type, file_count, discovered_at, last_scanned_at, \
+              content_signature, state, lane) \
+             VALUES (?, 'root-1', '', ?, '', NULL, NULL, 1, \
+                     datetime('now'), datetime('now'), 'sig', 'pending_classification', 'fits')",
+        )
+        .bind(placeholder_id)
+        .bind(sg_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let first = crate::classify::classify(
+            db.pool(),
+            crate::classify::ClassifyRequest {
+                inbox_item_id: placeholder_id.to_owned(),
+                root_absolute_path: root.path().to_owned(),
+                force_rescan: false,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(first.classification_type, "unclassified");
+
+        // ONE apply, both properties, identified by inbox_item_id — the exact
+        // E2E shape.
+        let apply = reclassify_v2(
+            db.pool(),
+            InboxReclassifyV2Request {
+                source_group_id: None,
+                inbox_item_id: Some(placeholder_id.to_owned()),
+                overrides: vec![],
+                bulk: vec![
+                    InboxReclassifyBulk {
+                        property: "frameType".to_owned(),
+                        value: serde_json::json!("light").into(),
+                        file_paths: None,
+                    },
+                    InboxReclassifyBulk {
+                        property: "exposureS".to_owned(),
+                        value: serde_json::json!(300.0).into(),
+                        file_paths: None,
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(apply.needs_review_count, 0, "first apply must resolve: {apply:?}");
+        assert!(
+            apply.sub_items.iter().any(|s| s.frame_type.as_deref() == Some("light")),
+            "first apply must resolve to a light sub-item: {:?}",
+            apply.sub_items
+        );
+
+        // The frontend refetches the placeholder's classification after the
+        // apply (store.ts invalidates the classify query). This re-runs
+        // `materialize_sub_items` for the (now light) group, which is the
+        // re-materialization that used to seed the discarded ON-CONFLICT id
+        // and strand the real sub-item without evidence (issue #854).
+        let _ = crate::classify::classify(
+            db.pool(),
+            crate::classify::ClassifyRequest {
+                inbox_item_id: placeholder_id.to_owned(),
+                root_absolute_path: root.path().to_owned(),
+                force_rescan: true,
+            },
+        )
+        .await;
+
+        // Second apply — same overrides, still identified by the PLACEHOLDER id,
+        // now against the materialized light-sub-item state. This is what the
+        // E2E's UI-apply-then-refetch/retry actually exercises.
+        let apply2 = reclassify_v2(
+            db.pool(),
+            InboxReclassifyV2Request {
+                source_group_id: None,
+                inbox_item_id: Some(placeholder_id.to_owned()),
+                overrides: vec![],
+                bulk: vec![
+                    InboxReclassifyBulk {
+                        property: "frameType".to_owned(),
+                        value: serde_json::json!("light").into(),
+                        file_paths: None,
+                    },
+                    InboxReclassifyBulk {
+                        property: "exposureS".to_owned(),
+                        value: serde_json::json!(300.0).into(),
+                        file_paths: None,
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(apply2.needs_review_count, 0, "second apply must stay resolved: {apply2:?}");
+        let light = apply2.sub_items.iter().find(|s| s.frame_type.as_deref() == Some("light"));
+        assert!(
+            light.is_some(),
+            "second apply must still resolve to a light sub-item: {:?}",
+            apply2.sub_items
         );
     }
 

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -507,9 +507,17 @@ pub struct UpsertInboxSubItem<'a> {
 pub async fn upsert_inbox_sub_item(
     pool: &SqlitePool,
     item: &UpsertInboxSubItem<'_>,
-) -> DbResult<()> {
+) -> DbResult<String> {
     let now = Timestamp::now_iso();
-    sqlx::query(
+    // `RETURNING id` yields the id of the row that actually persists: the new
+    // `item.id` on INSERT, but the PRE-EXISTING row's id on ON CONFLICT DO
+    // UPDATE. Callers MUST seed evidence/metadata/classification against this
+    // returned id, never the caller-supplied `item.id` — on a conflicting
+    // re-materialization the two diverge and seeding the discarded fresh id
+    // FK-fails (inbox_classification_evidence/inbox_classifications reference
+    // inbox_items(id) ON DELETE CASCADE), silently orphaning the real row's
+    // cache rows and stranding it evidence-less (issue #854).
+    let (persisted_id,): (String,) = sqlx::query_as(
         "INSERT INTO inbox_items
             (id, root_id, relative_path, source_group_id, group_key, group_label,
              frame_type, file_count, discovered_at, last_scanned_at,
@@ -521,7 +529,8 @@ pub async fn upsert_inbox_sub_item(
              file_count         = excluded.file_count,
              last_scanned_at    = excluded.last_scanned_at,
              content_signature  = excluded.content_signature,
-             state              = 'classified'",
+             state              = 'classified'
+         RETURNING id",
     )
     .bind(item.id)
     .bind(item.root_id)
@@ -535,9 +544,9 @@ pub async fn upsert_inbox_sub_item(
     .bind(&now)
     .bind(item.content_signature)
     .bind(item.lane)
-    .execute(pool)
+    .fetch_one(pool)
     .await?;
-    Ok(())
+    Ok(persisted_id)
 }
 
 /// Update `child_count` on a source group to reflect how many single-type


### PR DESCRIPTION
## Context

While diagnosing the Real-UI E2E failure `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm` (the observable symptom of #854 — Confirm never re-enabling after a bulk reclassify), I isolated the **backend** root cause. #854's PR (`1fa9cc70`) merged in parallel and made the E2E scenario green via the UI/override path, but **two backend bugs remain latent on `main`** — both proven with a fast regression test that fails on current `main` and passes with these fixes.

## Bug 1 — lane CHECK-constraint failure on re-split (the #854 backend root cause)

`reclassify_v2` sourced the sub-item lane from `inbox_source_groups.lane` and passed it into `materialize_sub_items`' upsert of `inbox_items`. Those two `lane` columns have **different domains**:

- `inbox_source_groups.lane` = move-vs-catalogue (`'move'`/`'catalogue'`, from the root's `organization_state`)
- `inbox_items.lane` = fits/video, guarded by `CHECK(lane IN ('fits','video'))`

For any **unorganized** root (`lane = 'move'`), the re-split's sub-item `INSERT` fails the CHECK. The error is swallowed, the resolved sub-item is never created, and the purge removes the pre-existing needs-review sub-item → `reclassify_v2` returns an empty `sub_items` list → Confirm stays disabled.

**Fix:** derive the item lane from the source group's `format` (video-only → `'video'`, else `'fits'`), matching scan's own assignment.

## Bug 2 — sub-item cache seeded against a discarded id (latent robustness)

`materialize_sub_items` seeded each sub-item's evidence/metadata/classification against a **fresh UUID**, but `upsert_inbox_sub_item`'s `ON CONFLICT … DO UPDATE` keeps the **pre-existing** row's id on any re-materialization of the same group. Seeding the discarded id FK-fails (evidence/classification `REFERENCES inbox_items(id) ON DELETE CASCADE`), orphaning the real row's cache rows.

**Fix:** `upsert_inbox_sub_item` returns the actually-persisted id via `RETURNING`; materialize seeds against that id.

## Validation

- New backend regression test `v2_single_combined_apply_on_placeholder_resolves_single_type` seeds the source group with `lane = 'move'`: **fails on current `main`** (empty `sub_items`), **passes** with these fixes.
- `cargo test -p app_core_inbox -p persistence_db` green (194 + 266).
- `cargo clippy --all-targets -- -D warnings` clean; `cargo fmt` applied.
- The full Real-UI E2E `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm` verified green locally with these fixes.

Follow-up to #854.