### PR TITLE
test: make domain, fs, patterns, and targeting tests exercise real behavior

### DIFF
--- a/crates/calibration/core/src/lib.rs
+++ b/crates/calibration/core/src/lib.rs
@@ -321,7 +321,9 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "calibration_core");
+        // Source of truth is Cargo.toml's package name, not a second hand-typed
+        // literal in this file — catches CRATE_NAME drifting from the manifest.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 
     #[test]

--- a/crates/calibration/core/src/rules/flat.rs
+++ b/crates/calibration/core/src/rules/flat.rs
@@ -322,22 +322,45 @@ mod tests {
 
     #[test]
     fn rotation_circular_distance_property_bounded_and_correct() {
-        // The exact function `evaluate` calls for the rotation delta: any
-        // pair of angles must be within [0, 180], and match the textbook
-        // shortest-arc formula — the naive `(a - b).abs()` this replaces
-        // (issue #921) can exceed 180 and blow past 360 near the seam.
+        // Drives evaluate() itself (not skymath::circular_distance in
+        // isolation) so a regression that swaps evaluate()'s rotation delta
+        // for a naive `(a - b).abs()` — the bug issue #921 fixed — is caught
+        // here across a grid of angle pairs, not just the handful of fixed
+        // examples in the other rotation_* tests.
         let angles = [0.0, 0.1, 45.0, 90.0, 180.0, 270.0, 295.0, 359.0, 359.9];
         for &a in &angles {
             for &b in &angles {
-                let d = skymath::circular_distance(
-                    skymath::Angle::from_degrees(a),
-                    skymath::Angle::from_degrees(b),
+                let s = SessionInfo { rotation_deg: Some(a), ..session() };
+                let r = evaluate(
+                    &s,
+                    &master_flat("Ha", "1x1", "train-a", 100.0, b, "2026-01-15"),
+                    &MatchingRuleConfig::default(),
                 )
-                .degrees();
-                assert!((0.0..=180.0).contains(&d), "distance {d} out of [0,180] for ({a}, {b})");
+                .expect("hard rules all satisfied");
+                let matched_delta = r
+                    .dimensions_matched
+                    .iter()
+                    .find(|d| d.dimension == "rotation")
+                    .and_then(|d| d.delta);
+                let mismatched_delta = r
+                    .dimensions_mismatched
+                    .iter()
+                    .find(|d| d.dimension == "rotation")
+                    .and_then(|d| d.delta);
+                let delta = matched_delta
+                    .or(mismatched_delta)
+                    .expect("rotation dimension always carries a delta when both angles are Some");
+
+                assert!(
+                    (0.0..=180.0).contains(&delta),
+                    "evaluate() rotation delta {delta} out of [0,180] for ({a}, {b})"
+                );
                 let raw = (a - b).abs().rem_euclid(360.0);
                 let expected = raw.min(360.0 - raw);
-                assert!((d - expected).abs() < 1e-9, "({a}, {b}): got {d}, expected {expected}");
+                assert!(
+                    (delta - expected).abs() < 1e-9,
+                    "({a}, {b}): evaluate() gave {delta}, expected {expected}"
+                );
             }
         }
     }

--- a/crates/domain/core/src/lib.rs
+++ b/crates/domain/core/src/lib.rs
@@ -170,7 +170,9 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "domain_core");
+        // Source of truth is Cargo.toml's package name, not a second hand-typed
+        // literal in this file — catches CRATE_NAME drifting from the manifest.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 
     #[test]

--- a/crates/domain/core/src/lifecycle/action_review_requirement.rs
+++ b/crates/domain/core/src/lifecycle/action_review_requirement.rs
@@ -71,12 +71,4 @@ mod tests {
         let fields = action_critical_fields(EntityType::Project, "ready", "processing");
         assert!(fields.is_empty());
     }
-
-    #[test]
-    fn table_is_empty_since_session_review_removal() {
-        // Spec 041 FR-051 (T076): the session confirmation cells were the
-        // only rows this table ever carried. If a future entity family adds
-        // action-bound review cells here, update this test to match.
-        assert!(TABLE.is_empty());
-    }
 }

--- a/crates/domain/core/src/lifecycle/project.rs
+++ b/crates/domain/core/src/lifecycle/project.rs
@@ -141,14 +141,53 @@ pub struct Project {
 mod tests {
     use super::*;
 
-    /// All 19 allowed edges from data-model.md §Transition Table.
+    /// All 19 allowed edges, independently transcribed from
+    /// specs/002-data-lifecycle-state-model/data-model.md §Lifecycle (the
+    /// spec's `PROJECT_TRANSITIONS` table), NOT read from `TRANSITIONS`
+    /// itself — so a drift between the table and the spec, or a broken
+    /// `is_allowed`, is caught rather than checking `TRANSITIONS` against
+    /// its own membership predicate.
     #[test]
     fn all_allowed_edges_are_accepted() {
-        let allowed = TRANSITIONS;
-        for &(from, to) in allowed {
+        use ProjectState::{
+            Archived, Blocked, Completed, Prepared, Processing, Ready, SetupIncomplete,
+        };
+        let spec_edges: &[(ProjectState, ProjectState)] = &[
+            (SetupIncomplete, Ready),
+            (SetupIncomplete, Blocked),
+            (Ready, Prepared),
+            (Ready, Processing),
+            (Ready, Blocked),
+            (Prepared, Ready),
+            (Prepared, Processing),
+            (Prepared, Blocked),
+            (Processing, Completed),
+            (Processing, Blocked),
+            (Completed, Archived),
+            (Completed, Processing),
+            (Archived, Processing),
+            (Archived, Ready),
+            (Blocked, SetupIncomplete),
+            (Blocked, Ready),
+            (Blocked, Prepared),
+            (Blocked, Processing),
+            (Blocked, Archived),
+        ];
+        assert_eq!(spec_edges.len(), 19, "expected exactly 19 allowed edges");
+        for &(from, to) in spec_edges {
             assert!(is_allowed(from, to), "expected ({from:?} → {to:?}) to be allowed");
         }
-        assert_eq!(allowed.len(), 19, "expected exactly 19 allowed edges");
+        assert_eq!(
+            TRANSITIONS.len(),
+            spec_edges.len(),
+            "TRANSITIONS has drifted from the spec's edge count"
+        );
+        for &(from, to) in TRANSITIONS {
+            assert!(
+                spec_edges.contains(&(from, to)),
+                "TRANSITIONS has an edge ({from:?} → {to:?}) not present in the spec table"
+            );
+        }
     }
 
     /// Forbidden edges: a representative set. Includes the explicitly

--- a/crates/fs/executor/tests/us1_safety.rs
+++ b/crates/fs/executor/tests/us1_safety.rs
@@ -458,14 +458,14 @@ async fn t011_existing_destination_refused_no_overwrite() {
 /// `list_pending_items` returns the right IDs before cancellation.
 #[tokio::test]
 async fn t012_batch_cancel_list_pending_items_returns_correct_ids() {
-    // This test validates the list_pending_items repository function that feeds
-    // the per-item audit loop in plan_apply.rs (T021).
-    //
-    // We use the persistence_db in-memory DB to exercise the full path.
-    // Note: this is an integration test in the executor crate that pulls in
-    // persistence_db via the app_core tests. Since executor has no DB dep,
-    // we verify the executor-level contract: on Cancelled outcome, the
-    // executor correctly returns which items were pending (via counts).
+    // `TerminalCounts` has no dedicated "pending" field — fs_executor has no
+    // DB dependency, so the actual `list_pending_items` repository query
+    // (persistence_db, exercised via plan_apply.rs T021) is out of scope
+    // here. What this executor-level test CAN and must verify: when both
+    // items are pre-cancelled before any execution starts, none of them are
+    // counted as succeeded/failed/skipped — i.e. both items are still
+    // implicitly pending (2 items - 0 accounted-for == 2 pending), which is
+    // the invariant the caller's `list_pending_items` sweep depends on.
 
     let dir = tempfile::tempdir().unwrap();
     let src1 = utf8(dir.path()).join("a.fits");
@@ -484,13 +484,13 @@ async fn t012_batch_cancel_list_pending_items_returns_correct_ids() {
     let outcome =
         execute_plan(vec![item1, item2], &cb, &cancel, &SkipSet::new(), &RetryQueue::new()).await;
 
-    // Both items cancelled — no events emitted by executor (callbacks are only
-    // emitted for items that started; the caller emits per-item audit rows).
     match outcome {
-        ApplyOutcome::Cancelled(_counts) => {
-            // Executor returned Cancelled — caller is responsible for per-item audit.
-            // The test documents the contract: caller must iterate the pending items
-            // and call append_event for each (see T021 in plan_apply.rs).
+        ApplyOutcome::Cancelled(counts) => {
+            assert_eq!(counts.succeeded, 0, "no item should have succeeded before cancellation");
+            assert_eq!(counts.failed, 0, "no item should have failed before cancellation");
+            assert_eq!(counts.skipped, 0, "no item should have been skipped before cancellation");
+            // Neither item was accounted for in the terminal counts, so both
+            // remain pending — this is what `list_pending_items` (T021) relies on.
         }
         other => panic!("expected Cancelled, got {other:?}"),
     }

--- a/crates/fs/inventory/src/lib.rs
+++ b/crates/fs/inventory/src/lib.rs
@@ -18,6 +18,8 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "fs_inventory");
+        // Source of truth is Cargo.toml's package name, not a second hand-typed
+        // literal in this file — catches CRATE_NAME drifting from the manifest.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 }

--- a/crates/fs/inventory/src/watcher.rs
+++ b/crates/fs/inventory/src/watcher.rs
@@ -223,10 +223,22 @@ mod tests {
     }
 
     #[test]
-    fn subscribe_returns_receiver() {
+    fn subscribe_receives_broadcast_events_without_active_watcher() {
+        // `tx` is private but visible from this child module — used here to
+        // drive the broadcast channel directly so the test can assert the
+        // receiver actually gets events (the "receiver is valid" property),
+        // not merely that `subscribe()` doesn't panic.
         let svc = WatcherService::new();
-        let _rx = svc.subscribe();
-        // Should not panic — receiver is valid even without active watcher.
+        let mut rx = svc.subscribe();
+        assert!(!svc.is_running(), "subscribing before start() should still work");
+
+        let evt = InboxFileEvent::Added { path: "/inbox/test.fits".to_owned() };
+        svc.tx.send(evt).expect("subscribed receiver keeps the channel open");
+
+        match rx.try_recv().expect("subscribed receiver should observe the broadcast event") {
+            InboxFileEvent::Added { path } => assert_eq!(path, "/inbox/test.fits"),
+            other => panic!("expected Added event, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/metadata/xisf/src/lib.rs
+++ b/crates/metadata/xisf/src/lib.rs
@@ -363,9 +363,24 @@ mod tests {
 
     #[test]
     fn bad_signature_returns_error() {
+        // Exercises the local extract() -> map_err() path (not
+        // Header::parse() in isolation) so a regression in this crate's
+        // error mapping — e.g. `map_err` dropped or misrouting the
+        // signature-failure variant — is actually caught.
         let mut data = build_xisf(&[]);
         data[0..8].copy_from_slice(b"NOTXISF!");
-        assert!(Header::parse(&data).is_err());
+
+        let path = std::env::temp_dir()
+            .join(format!("xisf_bad_signature_test_{}.xisf", std::process::id()));
+        std::fs::write(&path, &data).expect("write test fixture");
+
+        let result = XisfExtractor.extract(&path);
+        let _ = std::fs::remove_file(&path);
+
+        match result {
+            Err(MetadataExtractError::Io { .. }) => {}
+            other => panic!("expected Io error for bad signature, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/patterns/src/registry.rs
+++ b/crates/patterns/src/registry.rs
@@ -163,6 +163,8 @@ mod tests {
         assert_eq!(V1_REGISTRY.get("date").unwrap().fallback, "undated");
         assert_eq!(V1_REGISTRY.get("frame_type").unwrap().fallback, "unknown");
         assert_eq!(V1_REGISTRY.get("camera").unwrap().fallback, "unknown-camera");
+        assert_eq!(V1_REGISTRY.get("exposure").unwrap().fallback, "unknown-exposure");
+        assert_eq!(V1_REGISTRY.get("gain").unwrap().fallback, "unknown-gain");
         assert_eq!(V1_REGISTRY.get("binning").unwrap().fallback, "1x1");
         assert_eq!(V1_REGISTRY.get("set_temp").unwrap().fallback, "untempered");
     }

--- a/crates/patterns/src/resolver.rs
+++ b/crates/patterns/src/resolver.rs
@@ -743,10 +743,14 @@ mod tests {
 
     #[test]
     fn pattern_str_date_iso_transform_applied() {
-        // Token transforms (frame_type lowercasing here) apply just like resolve().
-        let bundle = meta(&[("frame_type", "Light")]);
-        let r = resolve_pattern_str("{frame_type}/", &bundle).unwrap();
-        assert_eq!(r.relative_path, "light");
+        // The DateIso transform, exercised through the resolve_pattern_str
+        // string-pattern entry point (not resolve_v1/resolve() directly, and
+        // not frame_type's Lower transform, which is already covered by
+        // frame_type_lowercased above and pattern_str_light_default_full_metadata).
+        let bundle = meta(&[("date", "2026-04-12")]);
+        let r = resolve_pattern_str("{date}/", &bundle).unwrap();
+        assert_eq!(r.relative_path, "2026-04-12");
+        assert!(r.missing_tokens.is_empty());
     }
 
     #[test]

--- a/crates/project/structure/src/lib.rs
+++ b/crates/project/structure/src/lib.rs
@@ -245,7 +245,9 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "project_structure");
+        // Source of truth is Cargo.toml's package name, not a second hand-typed
+        // literal in this file — catches CRATE_NAME drifting from the manifest.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 
     #[test]

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -23,6 +23,8 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "sessions");
+        // Source of truth is Cargo.toml's package name, not a second hand-typed
+        // literal in this file — catches CRATE_NAME drifting from the manifest.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 }

--- a/crates/targeting/src/identity.rs
+++ b/crates/targeting/src/identity.rs
@@ -99,12 +99,22 @@ mod tests {
 
     #[test]
     fn m31_messier_id_matches_expected_constant() {
-        // Pin a known value so accidental changes in derivation are caught.
-        // Computed once: UUIDv5(NAMESPACE, "messier:M31")
+        // Pin the literal value computed once via UUIDv5(NAMESPACE,
+        // "messier:M31") — NOT recomputed via the same derivation path,
+        // which would make this pass regardless of what the derivation
+        // actually does. If the namespace, format string, or hash algorithm
+        // ever changes, this hardcoded value must change too, which is the
+        // point: it is a real regression pin, not a self-check.
         let id = target_id("messier", "M31");
-        // Recompute the expected value to avoid hardcoding bytes.
-        let ns = target_namespace();
-        let expected = Uuid::new_v5(&ns, b"messier:M31");
+        let expected = Uuid::parse_str("0f6abf97-e34f-59cd-998a-940c021a617b").unwrap();
         assert_eq!(id, expected);
+    }
+
+    #[test]
+    fn namespace_uuid_matches_expected_constant() {
+        // Same rationale as m31_messier_id_matches_expected_constant: pin
+        // the literal NAMESPACE value rather than recomputing it.
+        let expected = Uuid::parse_str("b83f6123-043f-569d-bf50-ab3a74c86897").unwrap();
+        assert_eq!(target_namespace(), expected);
     }
 }

--- a/crates/targeting/src/lib.rs
+++ b/crates/targeting/src/lib.rs
@@ -47,6 +47,8 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "targeting");
+        // Source of truth is Cargo.toml's package name, not a second hand-typed
+        // literal in this file — catches CRATE_NAME drifting from the manifest.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 }


### PR DESCRIPTION
## Summary
- Test-validity audit follow-up across the domain/fs/metadata/patterns/project/sessions/targeting crates. **All 15 findings held up on re-verification (0 false positives in this cluster).**
- **Fixed (14):** rewired phantom/weak tests onto the real code path they claimed to cover — e.g. calibration `evaluate()` instead of calling `skymath` directly; xisf `extract()` instead of `Header::parse()` (so the local `map_err` is actually exercised); inventory watcher now sends a broadcast and asserts the receiver sees it; pattern resolver exercises the real `DateIso` transform; several `exposes_crate_name` tautologies now assert `env!("CARGO_PKG_NAME")`; missing assertions added where a test name promised coverage it didn't have.
- **Deleted (1):** a tautology over a hardcoded empty `TABLE` const already covered by a real-behavior test.
- No production code touched; no product bugs found.
- Verified: `cargo test -p <crate>` green for all 9 touched crates, plus clippy + fmt clean.