### PR TITLE
test: make app-layer crate tests exercise real behavior and shared constants

### DIFF
--- a/crates/app/core/src/guided_flow.rs
+++ b/crates/app/core/src/guided_flow.rs
@@ -488,9 +488,14 @@ mod tests {
 
     #[test]
     fn step_registry_completion_topics() {
-        assert_eq!(STEP_REGISTRY[0].completion_topic, "inventory.confirmed");
+        // Bind against the published wire-format constants where one exists
+        // (audit_types::event_bus), so a rename of the real topic constant —
+        // not just a hand-typed literal — is what this test tracks.
+        // "project.created" has no shared TOPIC_ constant (project_setup.rs
+        // publishes it as a bare literal); no binding is possible there.
+        assert_eq!(STEP_REGISTRY[0].completion_topic, audit::event_bus::TOPIC_INVENTORY_CONFIRMED);
         assert_eq!(STEP_REGISTRY[1].completion_topic, "project.created");
-        assert_eq!(STEP_REGISTRY[2].completion_topic, "tool.launch");
+        assert_eq!(STEP_REGISTRY[2].completion_topic, audit::event_bus::TOPIC_TOOL_LAUNCH);
     }
 
     #[test]

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -291,7 +291,12 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "app_core");
+        // CRATE_NAME has no consumers today (nothing reads it outside this
+        // test): assert against the real source of truth (Cargo.toml's
+        // `name`, via CARGO_PKG_NAME) instead of mirroring the same literal
+        // the constant is defined with, so a Cargo.toml rename that forgets
+        // to update CRATE_NAME is caught.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 
     #[test]

--- a/crates/app/core/src/search.rs
+++ b/crates/app/core/src/search.rs
@@ -349,8 +349,11 @@ mod tests {
     #[tokio::test]
     async fn empty_query_returns_recent_suggestions() {
         let db = test_db().await;
-        // No data — should return empty without error.
+        // Fresh DB has no targets/sessions/projects, so the recent_* queries
+        // must return nothing — the old `|| score >= 0.0` fallback passed
+        // unconditionally (scores are always >= 0.0 by construction) and never
+        // actually distinguished "no data" from "data with a bug".
         let results = search_global(db.pool(), "").await.unwrap();
-        assert!(results.is_empty() || results.iter().all(|r| r.score >= 0.0));
+        assert!(results.is_empty(), "fresh DB must have no recent suggestions; got: {results:?}");
     }
 }

--- a/crates/app/core/tests/lifecycle_canonical.rs
+++ b/crates/app/core/tests/lifecycle_canonical.rs
@@ -216,20 +216,21 @@ async fn t046b_no_dual_write_to_legacy_project_table() {
     let row = repo::get_project(&pool, &project_id).await.unwrap();
     assert_eq!(row.lifecycle, "processing", "canonical table updated");
 
-    // The legacy `project` table should NOT have `processing` for this id
-    // (it was never written by the new path — confirming no dual-write).
-    // After migration 0036, the `project` table no longer has a `state` column,
-    // so this query verifies that the column is absent.
+    // The legacy `project` table must have NO row for this id: the project
+    // was created via the `projects` table (spec-008 path), and no write
+    // surface inserts into legacy `project` for that path. A real dual-write
+    // regression (an accidental INSERT into `project` alongside `projects`)
+    // would surface here as `Some(_)`.
     let legacy_state: Option<(String,)> = sqlx::query_as("SELECT name FROM project WHERE id = ?")
         .bind(&project_id)
         .fetch_optional(&pool)
         .await
         .unwrap_or(None);
-    // The project was created via `projects` (spec-008 path) — it may not even
-    // have a row in the legacy `project` table (different tables for different specs).
-    // If it does exist, there is no `state` column after migration 0036.
-    // The important assertion is that `projects.lifecycle` is the only state source.
-    let _ = legacy_state; // just confirm no crash — table_for now points to `projects`
+    assert!(
+        legacy_state.is_none(),
+        "no row should exist in the legacy `project` table for a projects-table-path project; \
+         found: {legacy_state:?}"
+    );
 }
 
 // ── T048: auto-transitions write audit rows and emit project.unarchived ───────

--- a/crates/app/core/tests/sessions_integration.rs
+++ b/crates/app/core/tests/sessions_integration.rs
@@ -39,29 +39,14 @@ async fn insert_acquisition_session(pool: &sqlx::SqlitePool, id: &str) {
 }
 
 // ── 1. sessions stub: merge and split return not-implemented errors ───────────
-
-#[tokio::test]
-async fn merge_and_split_stubs_return_not_implemented_errors() {
-    let (db, _repo, _bus) = support::setup().await;
-    let pool = db.pool();
-
-    // split_session stub
-    let split_result = app_core::sessions::split_session(pool, "ses-001", "filter").await;
-    assert!(split_result.is_err(), "split_session must return Err");
-    assert!(
-        split_result.unwrap_err().contains("not yet implemented"),
-        "error message must mention 'not yet implemented'"
-    );
-
-    // merge_sessions stub
-    let ids = vec!["ses-001".to_owned(), "ses-002".to_owned()];
-    let merge_result = app_core::sessions::merge_sessions(pool, &ids).await;
-    assert!(merge_result.is_err(), "merge_sessions must return Err");
-    assert!(
-        merge_result.unwrap_err().contains("not yet implemented"),
-        "error message must mention 'not yet implemented'"
-    );
-}
+//
+// `merge_and_split_stubs_return_not_implemented_errors` removed: it exactly
+// duplicated `split_session_returns_not_implemented` /
+// `merge_sessions_returns_not_implemented` in `src/sessions.rs`'s own unit
+// tests, with zero added value — both stubs take `_pool: &SqlitePool` and
+// ignore it entirely, so exercising them through a real DB pool here (vs. an
+// unconnected in-memory pool at the unit level) exercises no additional code
+// path.
 
 // ── 2. list_sessions: returns real rows, empty on fresh DB ───────────────────
 

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -2352,7 +2352,11 @@ mod tests {
 
         // A fully-resolved item (group_key defaults to '' in the helper, which is
         // not SENTINEL_NEEDS_REVIEW) must pass the sentinel gate.
-        let result = confirm(
+        // Same registered-source / classified-item shape as
+        // `non_inbox_source_moves_in_place`, which deterministically succeeds —
+        // a fully-resolved item must confirm cleanly, not merely "not fail on
+        // the sentinel gate".
+        let resp = confirm(
             db.pool(),
             &bus,
             ConfirmRequest {
@@ -2364,21 +2368,13 @@ mod tests {
                 chosen_attribution: None,
             },
         )
-        .await;
+        .await
+        .expect("fully-resolved item must confirm successfully and produce a plan");
 
-        // The item passes the sentinel gate (group_key != SENTINEL_NEEDS_REVIEW).
-        // It may still fail on other gates (destination root, pattern) — what we
-        // assert is that it does NOT fail with InboxMissingPathAttributes from the
-        // sentinel check: any error must NOT be the sentinel gate.
-        if let Err(ref e) = result {
-            assert_ne!(
-                e.code,
-                ErrorCode::InboxMissingPathAttributes,
-                "fully-resolved item must not be blocked by the needs-review sentinel gate: {}",
-                e.message
-            );
-        }
-        // If it succeeds, the plan was created — also valid.
+        assert!(!resp.plan_id.is_empty(), "confirm must produce a plan id");
+        assert_eq!(resp.items_total, 1, "one classified file must produce one plan item");
+        assert_eq!(resp.move_count, 1, "unorganized source must produce a move item");
+        assert_eq!(resp.catalogue_count, 0, "unorganized source must not catalogue in place");
     }
 
     // ── inventory.confirmed publish (review fix: swallow-on-failure) ─────────

--- a/crates/app/inbox/src/property_registry.rs
+++ b/crates/app/inbox/src/property_registry.rs
@@ -357,11 +357,10 @@ pub fn property_registry() -> Vec<PropertyRegistryEntry> {
 mod tests {
     use super::*;
 
-    #[test]
-    fn registry_is_non_empty() {
-        let reg = property_registry();
-        assert!(!reg.is_empty(), "registry must have at least one entry");
-    }
+    // `registry_is_non_empty` removed: `!reg.is_empty()` has no discriminating
+    // power (any non-empty registry passes regardless of content) and is
+    // fully subsumed by `required_r13_keys_present` below, which already
+    // implies non-emptiness while also verifying every mandated key exists.
 
     #[test]
     fn all_keys_are_unique() {

--- a/crates/app/lifecycle/src/lifecycle_use_case.rs
+++ b/crates/app/lifecycle/src/lifecycle_use_case.rs
@@ -143,6 +143,7 @@ mod tests {
     async fn noop_returns_none_without_persisting() {
         let repo = InMemoryLifecycleRepository;
         let bus = test_bus().await;
+        let mut rx = bus.subscribe();
 
         let result = transition_lifecycle(
             &repo,
@@ -161,6 +162,15 @@ mod tests {
         .unwrap();
 
         assert!(result.is_none());
+        // "Without persisting": the noop guard must short-circuit before the
+        // repository write AND before the event publish. InMemoryLifecycleRepository
+        // has no inspectable state (it would even return Err for from==to if
+        // record_transition were reached), so the bus is the only observable
+        // side channel proving the guard fired before any write.
+        assert!(
+            rx.try_recv().is_err(),
+            "noop transition must not publish lifecycle.transition.applied"
+        );
     }
 
     #[tokio::test]

--- a/crates/app/projects/src/project_setup.rs
+++ b/crates/app/projects/src/project_setup.rs
@@ -1711,6 +1711,29 @@ mod tests {
             .unwrap();
         let list = list(&pool).await.unwrap();
         assert_eq!(list.len(), 2);
+
+        // Verify summary content is real, not just row count — each summary
+        // must carry its own name/tool/path, not a copy or a default.
+        // `path` is resolved against the project root at create time (not a
+        // literal echo of the request path), so check the suffix rather than
+        // an exact match.
+        let a = list.iter().find(|p| p.name == "A").expect("project A must be in the list");
+        assert_eq!(a.tool, ProjectTool::PixInsight);
+        assert!(
+            a.path.ends_with("projects/A"),
+            "path must resolve under project A's name: {}",
+            a.path
+        );
+
+        let b = list.iter().find(|p| p.name == "B").expect("project B must be in the list");
+        assert_eq!(b.tool, ProjectTool::Siril);
+        assert!(
+            b.path.ends_with("projects/B"),
+            "path must resolve under project B's name: {}",
+            b.path
+        );
+
+        assert_ne!(a.id, b.id, "summaries must carry distinct project ids");
     }
 
     // ── Constitution II: folder plan tests ────────────────────────────────────

--- a/crates/app/settings/src/migrate.rs
+++ b/crates/app/settings/src/migrate.rs
@@ -183,10 +183,11 @@ mod tests {
         }
     }
 
-    /// Currently both lists are empty (identity migration).
-    #[test]
-    fn v1_to_v2_is_currently_identity() {
-        assert!(DROP_KEYS.is_empty(), "DROP_KEYS must be empty until a real v2 is defined");
-        assert!(RESET_KEYS.is_empty(), "RESET_KEYS must be empty until a real v2 is defined");
-    }
+    // `v1_to_v2_is_currently_identity` removed: it only mirrored the
+    // DROP_KEYS/RESET_KEYS const definitions against themselves, with zero
+    // discriminating power. The real, currently-identity migration behavior
+    // is already exercised end-to-end (real DB, real `migrate_v1_to_v2` call)
+    // by `migration_summary_counts_are_correct` and `dropped_key_is_removed_from_db`
+    // in `tests/settings_v1_to_v2.rs`, which assert `dropped == 0` / `reset == 0`
+    // via actual execution rather than reading the const back.
 }

--- a/crates/audit-types/src/lib.rs
+++ b/crates/audit-types/src/lib.rs
@@ -42,6 +42,10 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "audit_types");
+        // CRATE_NAME has no consumers today: assert against Cargo.toml's real
+        // `name` (CARGO_PKG_NAME) instead of mirroring the constant's own
+        // literal, so a package rename that forgets to update CRATE_NAME is
+        // caught.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 }

--- a/crates/audit/src/lib.rs
+++ b/crates/audit/src/lib.rs
@@ -161,7 +161,11 @@ mod tests {
 
     #[test]
     fn exposes_crate_name() {
-        assert_eq!(CRATE_NAME, "audit");
+        // CRATE_NAME has no consumers today: assert against Cargo.toml's real
+        // `name` (CARGO_PKG_NAME) instead of mirroring the constant's own
+        // literal, so a package rename that forgets to update CRATE_NAME is
+        // caught.
+        assert_eq!(CRATE_NAME, env!("CARGO_PKG_NAME"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Test-validity audit follow-up across the app-layer crates (`app/core`, `app/inbox`, `app/lifecycle`, `app/projects`, `app/settings`, `app/targets`, `audit`, `audit-types`).
- **Fixed:** bound assertions to real published constants/behaviour instead of self-mirrors — e.g. guided-flow completion topics now use the real `audit` event-bus constants; `exposes_crate_name` tautologies assert `env!("CARGO_PKG_NAME")`; a vacuous `is_empty() || score>=0` tightened; inbox confirm now asserts real plan fields; "without persisting" now actually checks the broadcast channel stayed empty; project-summary asserts real tool/path/id.
- **Deleted (4):** duplicates fully subsumed by real-DB tests, and a zero-discrimination `registry_is_non_empty`.
- **Left unchanged:** genuine golden-value/spec-invariant guards and real round-trip cache tests that the audit mis-flagged.
- No production code touched; no product bugs found.
- Verified: crate-scoped `cargo test` for all touched crates — 1061 passed combined, plus fmt.