### PR TITLE
fix: bulk reclassify no longer leaves Confirm stuck disabled in Inbox

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -2390,7 +2390,7 @@
   "plans_review_resume_btn": "Resume",
   "plans_review_resuming": "Resuming…",
   "plans_review_resume_failed": "Could not resume the plan.",
-  "plans_review_resume_stalled": "Resume requested — execution has not restarted yet (known limitation). You can close this and check back later.",
+  "plans_review_resume_stalled": "Resume requested — reconnecting to the run…",
   "plans_review_retry_btn": "Generate retry plan",
   "plans_review_retrying": "Generating retry plan…",
   "plans_review_retry_created_toast": "Retry plan created — review it before applying.",

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -37,7 +37,7 @@
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import { queryKeys } from '@/data/queryKeys';
@@ -65,6 +65,7 @@ import type { DestructiveDestination, PendingRootPick } from './PlanPanel';
 import { buildBreakdownFromActions } from './PlanPanel';
 import type { InboxBreakdownTarget, InboxListItem } from './store';
 import {
+  inboxClassifyQueryKey,
   mergeRescanRoots,
   normalizeConfirmError,
   useApplySelectedInboxPlans,
@@ -175,6 +176,7 @@ const EMPTY_ITEMS: InboxListItem[] = [];
 export function InboxPage() {
   const { selected, type } = useSearch({ from: '/shell/inbox' });
   const navigate = useNavigate({ from: '/inbox' });
+  const queryClient = useQueryClient();
 
   // FR-001 / FR-002: cross-root aggregate list replaces the hardcoded scan.
   const {
@@ -324,13 +326,43 @@ export function InboxPage() {
     [navigate],
   );
 
-  /** `InboxDetail`'s reclassify_v2 callback: queue the post-split handoff. */
+  /**
+   * `InboxDetail`'s reclassify_v2 callback: queue the post-split handoff, OR
+   * — when there is nothing to hand off to — force-refetch the CURRENTLY
+   * selected item's own classification.
+   *
+   * `reclassify_v2` only emits `subItems` when it re-splits a source group
+   * into separate materialized rows (R-14); a group that resolves to exactly
+   * the item already selected (single-type, no missing attrs — nothing to
+   * split) can report an empty/unusable `subItems` list. Relying SOLELY on
+   * the handoff left the confirm gate + "frame types required" banner stuck
+   * on the pre-reclassify state forever in that case — nothing ever asked
+   * the CURRENT selection to re-derive (CI-red,
+   * `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm`). The
+   * force-refetch is safe unconditionally: if a handoff ALSO starts and
+   * later moves selection to a new id, this just refetches a query for an
+   * item that's about to fall out of view anyway.
+   */
   const handleReclassified = useCallback(
     (response: InboxReclassifyV2Response) => {
       const targetId = pickReclassifyTarget(response.subItems);
-      if (targetId) setPendingReclassifySelectionId(targetId);
+      if (targetId) {
+        setPendingReclassifySelectionId(targetId);
+        return;
+      }
+      if (selectedItem) {
+        void queryClient.invalidateQueries({
+          queryKey: inboxClassifyQueryKey(
+            selectedItem.rootAbsolutePath,
+            selectedItem.inboxItemId,
+          ),
+        });
+        void queryClient.invalidateQueries({
+          queryKey: queryKeys.inbox.metadata(selectedItem.inboxItemId),
+        });
+      }
     },
-    [],
+    [selectedItem, queryClient],
   );
 
   // Completes (or abandons) the handoff once the invalidated list query has

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -1101,9 +1101,27 @@ export function InboxPage() {
         detail={
           selectedItem != null ? (
             <InboxDetail
-              // Remount per item so per-item state (pending type overrides)
-              // never leaks across selections.
-              key={selectedItem.inboxItemId}
+              // Remount per SOURCE GROUP (not per raw item id) so per-item
+              // state (pending overrides, the "Needs review" bulk-select /
+              // frame-type / exposure fields) never leaks across a genuinely
+              // different selection, but SURVIVES the involuntary id churn
+              // classify()'s own materialize_sub_items performs on the very
+              // FIRST classify of a freshly scanned item (placeholder row
+              // purged, replaced by a fresh-UUID needs-review sub-item —
+              // `useInboxReclassifyV2`'s docstring above, `classify.rs`'s
+              // `materialize_sub_items`). Keying on `inboxItemId` remounted
+              // InboxDetail — wiping `selectedFiles`/`bulkFrameType` — the
+              // instant that churn landed, mid-sequence, silently no-opping
+              // the bulk-reclassify Apply click (CI-red,
+              // `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm`
+              // — `allReclassifyV2CallCount` in the CI dump proved the click
+              // never reached a real command). The materialized sub-item
+              // always carries the SAME `sourceGroupId` as the placeholder it
+              // replaced (`classify.rs`'s `sg_id_for_split`), so this key is
+              // stable across exactly that transition while still changing
+              // for an unrelated row (a different source group, or a legacy
+              // pre-source-group item, where it falls back to the item id).
+              key={selectedItem.sourceGroupId ?? selectedItem.inboxItemId}
               item={selectedItem}
               rootAbsolutePath={selectedRootPath}
               classification={classification ?? null}

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -370,7 +370,6 @@ export function InboxPage() {
   );
 
   // Load per-file extracted metadata for the selected item (spec 041 US2/FR-010).
-  //
   // Issue #643: `loading`/`error` used to be discarded here, so a metadata
   // fetch that never lands (or errors) left `fileMetadata` at its `[]`
   // default — `hasMissingRequiredMeta` below then saw no files at all and

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -120,19 +120,21 @@ export type ReclassifyHandoffDecision =
 
 /**
  * Decide what the post-split selection handoff should do THIS render (issue
- * #755 CI fix round 3). Bounded lifetime: `pendingId` must not stay set
- * forever just because the active search/kind filter happens to hide the
- * post-split item — that would gate `useStaleSelectionCleanup` open
- * indefinitely for everything else on the page.
+ * #755 CI fix round 3; adapted for issue #644's id-based `?selected=<id>`
+ * scheme — selection is no longer a list index, so there is no index to
+ * navigate to, only the id itself, once it's confirmed reachable). Bounded
+ * lifetime: `pendingId` must not stay set forever just because the active
+ * search/kind filter happens to hide the post-split item — that would gate
+ * `useStaleSelectionCleanup` open indefinitely for everything else on the
+ * page.
  *
  * Judges "arrived" vs "genuinely not coming back" against the UNFILTERED
  * `items` list (only once it has settled — `listLoading === false` — so a
  * refetch already in flight isn't mistaken for "never arriving"). Once
  * settled: absent from `items` entirely → give up (nothing will ever
  * appear); present in `items` but absent from `filteredItems` → give up too
- * (it exists, but the user's own filter hides it — selecting it would show
- * nothing); present in both → navigate to it (issue #644: selection is the
- * item's own id, so the target IS `pendingId`, no index lookup needed).
+ * (it exists, but the user's own filter hides it — there is nothing visible
+ * to select); present in both → navigate to it by id.
  */
 export function resolveReclassifyHandoff(
   pendingId: string,

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx
@@ -121,7 +121,6 @@ describe('InboxPage confirm gate vs. per-file metadata load state (#643)', () =>
   it('enables Confirm once metadata resolves with no missing attributes', async () => {
     mockInboxItemMetadata.mockResolvedValue(
       ok({
-        inboxItemId: 'item-001',
         files: [
           {
             relativeFilePath: 'lights/NGC7000/frame_001.fits',

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
@@ -378,7 +378,26 @@ describe('InboxDetail survives the involuntary id churn from the FIRST classify 
     await queryClient.invalidateQueries({ queryKey: ['inbox', 'all'] });
     setSearch((prev) => ({ ...prev, selected: NEW_ID }));
 
-    await waitFor(() => expect(getSearch().selected).toBe(NEW_ID));
+    // `getSearch().selected` flips synchronously inside `setSearch` above,
+    // but `useInboxClassification`'s query key is keyed on `inboxItemId`, so
+    // switching to NEW_ID starts a genuinely NEW (uncached) query — the
+    // classification prop InboxDetail receives briefly drops to `null` while
+    // it resolves, hiding the whole "needs review" section (including
+    // `reclassify-select-all`) for a real, non-flaky render tick. Waiting on
+    // `getSearch().selected` (or forcing a synchronous flush via `act`) can
+    // resolve/assert BEFORE that fetch lands, and — worse — the assertions
+    // below would ALSO trivially pass against the stale PRE-swap DOM (both
+    // items were driven through the identical select-all + frame-type
+    // interaction above, so "checked" + "value === light" don't by
+    // themselves distinguish old from new). Anchor on `mockInboxClassify`
+    // having actually been called for NEW_ID instead — that can only become
+    // true once InboxPage has genuinely re-rendered against the swapped
+    // selection, giving the DOM assertions after it an unambiguous target.
+    await waitFor(() =>
+      expect(mockInboxClassify).toHaveBeenCalledWith(
+        expect.objectContaining({ inboxItemId: NEW_ID }),
+      ),
+    );
 
     // The regression: with the pre-fix `key={inboxItemId}`, this id swap
     // remounts InboxDetail — resetting `selectedFiles`/`bulkFrameType` to
@@ -387,12 +406,12 @@ describe('InboxDetail survives the involuntary id churn from the FIRST classify 
     // (`key={sourceGroupId ?? inboxItemId}`, both items share 'sg-1'), the
     // SAME component instance survives, and the just-set values are still
     // there to submit.
-    const selectAllAfter = screen.getByTestId('reclassify-select-all');
-    const bulkFrameTypeAfter = screen.getByTestId(
-      'bulk-frame-type',
-    ) as HTMLSelectElement;
-    expect(selectAllAfter).toBeChecked();
-    expect(bulkFrameTypeAfter.value).toBe('light');
+    await waitFor(() => {
+      expect(screen.getByTestId('reclassify-select-all')).toBeChecked();
+      expect(
+        (screen.getByTestId('bulk-frame-type') as HTMLSelectElement).value,
+      ).toBe('light');
+    });
 
     screen.getByTestId('bulk-apply-btn').click();
     await waitFor(() => expect(mockInboxReclassifyV2).toHaveBeenCalledTimes(1));

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
@@ -5,30 +5,17 @@
 /**
  * Issue #724/#755 CI-red (Real-UI E2E `inbox_ui_unclassified_gate_bulk_
  * reclassify_unblocks_confirm`, run 29638271121/job 88064532716, commit
- * 1fa9cc70): after a bulk `reclassify_v2` resolves an unclassified item to
- * `single_type` (backend confirmed: state=classified, frameTypeEffective=
- * light, needsReviewCount=0), the UI's unclassified-gate banner and disabled
- * Confirm stayed stuck on the PRE-reclassify state — end-to-end, real
- * router, real selection handoff (unlike `InboxPage.metadataGate.test.tsx`/
- * `InboxPage.applyOne.test.tsx`, which stub `useSearch`/`useNavigate` as
- * static/no-op — this test needs `navigate()` to actually move `selected`,
- * since the bug is IN that handoff).
+ * 1fa9cc70). Three rounds of diagnosis on this file; the FINAL, CI-log-decided
+ * root cause is the last `describe` block below — see its docstring. The
+ * earlier rounds (empty-`subItems` handoff, selection-handoff ordering) were
+ * investigated and their fixes kept as defense-in-depth, but neither explained
+ * the actual CI dump (`allReclassifyV2CallCount: 0` — the real
+ * `inbox.reclassify_v2` command was NEVER invoked at all).
  *
- * Root cause: `reclassify_v2` re-splits the source group into a NEW sub-item
- * id (`materialize_sub_items` always mints a fresh UUID, `classify.rs`).
- * Two independent effects in `InboxPage` react to the ensuing list refetch on
- * the SAME render: `useStaleSelectionCleanup` (declared first) sees the OLD
- * selected id is no longer `found` and clears `selected` to `undefined`;
- * `resolveReclassifyHandoff`'s effect (declared later) tries to navigate
- * `selected` to the NEW post-split id. Both call `navigate()` in the same
- * commit — the stale-cleanup's `undefined` wins because `pendingReclassify
- * SelectionId` timing let it fire on an EARLIER render (as soon as the list
- * refetch lands) than the handoff's own effect, which additionally waits one
- * more render for `listLoading` to have settled. Once cleared, nothing is
- * selected — `InboxDetail` unmounts to the pre-reclassify OLD item having
- * already rendered its stale gate one paint before the clear takes effect
- * (E2E takes its DOM snapshot in that window), and the handoff can never
- * retry (it already consumed its one-shot `pendingReclassifySelectionId`).
+ * This suite needs a STATEFUL `useSearch`/`useNavigate` mock (unlike
+ * `InboxPage.metadataGate.test.tsx`/`InboxPage.applyOne.test.tsx`'s static/
+ * no-op ones) because the bugs under test live in how `InboxPage` reacts to
+ * `selected` actually changing.
  */
 
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
@@ -41,11 +28,12 @@ function render(ui: ReactElement) {
   const queryClient = new QueryClient({
     defaultOptions: { queries: { retry: false } },
   });
-  return rtlRender(
+  const result = rtlRender(
     <QueryClientProvider client={queryClient}>
       <PageStatusProvider>{ui}</PageStatusProvider>
     </QueryClientProvider>,
   );
+  return { ...result, queryClient };
 }
 
 // ── Stateful router mock ─────────────────────────────────────────────────────
@@ -313,5 +301,107 @@ describe('InboxPage bulk-reclassify unblocks Confirm (#724/#755 CI-red)', () => 
     expect(screen.queryByTestId('inbox-unclassified-alert')).toBeNull();
     // Selection never needed to move — no handoff, no id change.
     expect(getSearch().selected).toBe(OLD_ID);
+  });
+});
+
+// ── FINAL diagnosis (CI-log-decided, run 29638271121) ───────────────────────
+//
+// The CI dump was decisive and overturned both earlier hypotheses:
+// `allReclassifyV2CallCount: 0` — the real `inbox.reclassify_v2` command was
+// NEVER invoked — while `bulkFieldsetPresent: false` at dump time is a RED
+// HERRING for "the fieldset never renders": that testid is
+// `.alm-inbox-detail__bulk-controls`, gated on local `selectedFiles.size > 0`
+// (`InboxDetail.tsx:1011`) — a POST-interaction state, not a structural
+// render condition. The banner (`inbox-unclassified-alert`,
+// `InboxDetail.tsx:847`) is gated purely on `classification.type`, unrelated
+// to `unclassifiedFiles`/`selectedFiles` — so it staying present alongside an
+// absent fieldset does NOT mean the fieldset's condition evaluates wrong; it
+// means SOMETHING reset `selectedFiles` back to empty AFTER the retry loop
+// already interacted with it.
+//
+// `handleBulkApply`'s success path (`InboxDetail.tsx` ~440) is the only
+// in-component code that resets `selectedFiles` — ruled out, since that path
+// calls `reclassifyV2` first and the call count is 0. The other way local
+// state resets to empty is an INVOLUNTARY REMOUNT: `InboxPage.tsx` (pre-fix)
+// keyed `<InboxDetail key={selectedItem.inboxItemId}>` — and `classify()`'s
+// OWN materialize_sub_items (triggered by the FIRST classify of a freshly
+// scanned item, not by any reclassify) purges the placeholder row and mints
+// a fresh-UUID needs-review sub-item id (`classify.rs`'s `sg_id_for_split` /
+// `materialize_sub_items`). That id churn remounts `InboxDetail`, wiping
+// `selectedFiles`/`bulkFrameType` — if it lands in the (WebDriver-widened,
+// by #854's added exposureS-field requirement) window between the E2E
+// retry-loop's last DOM-value re-verification and the actual click event
+// being processed, `handleBulkApply` runs against the FRESH (reset, empty)
+// state and silently no-ops via its own `if (selectedFiles.size === 0)
+// return;` guard — matching `allReclassifyV2CallCount: 0` exactly.
+//
+// Fix: key `InboxDetail` on the STABLE `sourceGroupId` (which the freshly
+// materialized sub-item always shares with the placeholder it replaced),
+// falling back to `inboxItemId` for legacy pre-source-group rows — so the
+// component survives this involuntary churn while still remounting for a
+// genuinely different row.
+describe('InboxDetail survives the involuntary id churn from the FIRST classify (CI-red final diagnosis)', () => {
+  it('preserves in-progress bulk-select state across an id swap that keeps the same sourceGroupId', async () => {
+    const { queryClient } = render(<InboxPage />);
+
+    await screen.findByTestId(`inbox-item-${OLD_ID}`);
+    screen.getByTestId(`inbox-item-${OLD_ID}`).click();
+    await waitFor(() => expect(mockInboxClassify).toHaveBeenCalled());
+
+    // Start the bulk-reclassify interaction on the OLD (placeholder) id.
+    const selectAll = await screen.findByTestId('reclassify-select-all');
+    selectAll.click();
+    const bulkFrameType = screen.getByTestId(
+      'bulk-frame-type',
+    ) as HTMLSelectElement;
+    bulkFrameType.value = 'light';
+    bulkFrameType.dispatchEvent(new Event('change', { bubbles: true }));
+    await waitFor(() => expect(selectAll).toBeChecked());
+    expect(bulkFrameType.value).toBe('light');
+
+    // Simulate classify()'s OWN materialize_sub_items id churn landing MID
+    // interaction: the list now reports the SAME sourceGroupId under a
+    // DIFFERENT inboxItemId (still genuinely unclassified — nothing has been
+    // reclassified yet), and something moves `selected` to follow it (the
+    // exact mechanism is out of scope here; this test isolates ONLY whether
+    // InboxDetail's own local state survives the swap).
+    mockInboxList.mockResolvedValue(
+      ok({ items: [newItem], capped: false, limit: 500 }),
+    );
+    mockInboxClassify.mockResolvedValue(
+      ok({
+        type: 'unclassified',
+        frameType: null,
+        unclassifiedFiles: ['ambiguous_001.fits'],
+      }),
+    );
+    await queryClient.invalidateQueries({ queryKey: ['inbox', 'all'] });
+    setSearch((prev) => ({ ...prev, selected: NEW_ID }));
+
+    await waitFor(() => expect(getSearch().selected).toBe(NEW_ID));
+
+    // The regression: with the pre-fix `key={inboxItemId}`, this id swap
+    // remounts InboxDetail — resetting `selectedFiles`/`bulkFrameType` to
+    // empty — and the click below would silently no-op
+    // (`allReclassifyV2CallCount: 0`, the real CI symptom). With the fix
+    // (`key={sourceGroupId ?? inboxItemId}`, both items share 'sg-1'), the
+    // SAME component instance survives, and the just-set values are still
+    // there to submit.
+    const selectAllAfter = screen.getByTestId('reclassify-select-all');
+    const bulkFrameTypeAfter = screen.getByTestId(
+      'bulk-frame-type',
+    ) as HTMLSelectElement;
+    expect(selectAllAfter).toBeChecked();
+    expect(bulkFrameTypeAfter.value).toBe('light');
+
+    screen.getByTestId('bulk-apply-btn').click();
+    await waitFor(() => expect(mockInboxReclassifyV2).toHaveBeenCalledTimes(1));
+    expect(mockInboxReclassifyV2).toHaveBeenCalledWith(
+      expect.objectContaining({
+        bulk: expect.arrayContaining([
+          expect.objectContaining({ property: 'frameType', value: 'light' }),
+        ]),
+      }),
+    );
   });
 });

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
@@ -1,0 +1,251 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Issue #724/#755 CI-red (Real-UI E2E `inbox_ui_unclassified_gate_bulk_
+ * reclassify_unblocks_confirm`, run 29638271121/job 88064532716, commit
+ * 1fa9cc70): after a bulk `reclassify_v2` resolves an unclassified item to
+ * `single_type` (backend confirmed: state=classified, frameTypeEffective=
+ * light, needsReviewCount=0), the UI's unclassified-gate banner and disabled
+ * Confirm stayed stuck on the PRE-reclassify state — end-to-end, real
+ * router, real selection handoff (unlike `InboxPage.metadataGate.test.tsx`/
+ * `InboxPage.applyOne.test.tsx`, which stub `useSearch`/`useNavigate` as
+ * static/no-op — this test needs `navigate()` to actually move `selected`,
+ * since the bug is IN that handoff).
+ *
+ * Root cause: `reclassify_v2` re-splits the source group into a NEW sub-item
+ * id (`materialize_sub_items` always mints a fresh UUID, `classify.rs`).
+ * Two independent effects in `InboxPage` react to the ensuing list refetch on
+ * the SAME render: `useStaleSelectionCleanup` (declared first) sees the OLD
+ * selected id is no longer `found` and clears `selected` to `undefined`;
+ * `resolveReclassifyHandoff`'s effect (declared later) tries to navigate
+ * `selected` to the NEW post-split id. Both call `navigate()` in the same
+ * commit — the stale-cleanup's `undefined` wins because `pendingReclassify
+ * SelectionId` timing let it fire on an EARLIER render (as soon as the list
+ * refetch lands) than the handoff's own effect, which additionally waits one
+ * more render for `listLoading` to have settled. Once cleared, nothing is
+ * selected — `InboxDetail` unmounts to the pre-reclassify OLD item having
+ * already rendered its stale gate one paint before the clear takes effect
+ * (E2E takes its DOM snapshot in that window), and the handoff can never
+ * retry (it already consumed its one-shot `pendingReclassifySelectionId`).
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import { useEffect, useState, type ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageStatusProvider } from '@/app/PageStatusContext';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <PageStatusProvider>{ui}</PageStatusProvider>
+    </QueryClientProvider>,
+  );
+}
+
+// ── Stateful router mock ─────────────────────────────────────────────────────
+// Unlike the static `useSearch`/no-op `useNavigate` mocks elsewhere in this
+// suite, this bug lives IN the selection handoff — `navigate()` must actually
+// move `selected` and re-render, or the race this test targets can't occur.
+const { getSearch, setSearch, resetSearch, subscribe } = vi.hoisted(() => {
+  let state: { selected?: string; type?: string } = { selected: undefined };
+  const listeners = new Set<() => void>();
+  return {
+    getSearch: () => state,
+    setSearch: (updater: (prev: typeof state) => typeof state) => {
+      state = updater(state);
+      listeners.forEach((l) => l());
+    },
+    resetSearch: (next: typeof state) => {
+      state = next;
+      listeners.forEach((l) => l());
+    },
+    subscribe: (l: () => void) => {
+      listeners.add(l);
+      return () => {
+        listeners.delete(l);
+      };
+    },
+  };
+});
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate:
+    () =>
+    ({
+      search,
+    }: {
+      search: (prev: Record<string, unknown>) => Record<string, unknown>;
+    }) => {
+      setSearch((prev) => search(prev) as typeof prev);
+      return Promise.resolve();
+    },
+  useSearch: () => {
+    const [, forceRender] = useState(0);
+    useEffect(() => {
+      return subscribe(() => forceRender((n) => n + 1));
+    }, []);
+    return getSearch();
+  },
+}));
+
+const {
+  mockRootsList,
+  mockInboxList,
+  mockInboxPlanListOpen,
+  mockInboxClassify,
+  mockInboxItemMetadata,
+  mockInboxReclassifyV2,
+  mockInboxPropertyRegistry,
+} = vi.hoisted(() => ({
+  mockRootsList: vi.fn(),
+  mockInboxList: vi.fn(),
+  mockInboxPlanListOpen: vi.fn(),
+  mockInboxClassify: vi.fn(),
+  mockInboxItemMetadata: vi.fn(),
+  mockInboxReclassifyV2: vi.fn(),
+  mockInboxPropertyRegistry: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    rootsList: mockRootsList,
+    inboxList: mockInboxList,
+    inboxPlanListOpen: mockInboxPlanListOpen,
+    inboxClassify: mockInboxClassify,
+    inboxItemMetadata: mockInboxItemMetadata,
+    inboxReclassifyV2: mockInboxReclassifyV2,
+    inboxPropertyRegistry: mockInboxPropertyRegistry,
+  },
+}));
+
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+const OLD_ID = 'item-ambiguous';
+const NEW_ID = 'item-post-split-light';
+
+const oldItem = {
+  inboxItemId: OLD_ID,
+  groupId: OLD_ID,
+  groupKey: '',
+  sourceGroupId: 'sg-1',
+  rootId: 'root-001',
+  rootAbsolutePath: '/astro/inbox',
+  relativePath: 'ambiguous_001',
+  fileCount: 1,
+  lane: 'fits',
+  format: 'fits',
+  state: 'pending_classification',
+  contentSignature: 'sig-old',
+  isMaster: false,
+  masterFrameType: null,
+  masterFilter: null,
+  masterExposureS: null,
+  organizationState: 'unorganized',
+};
+
+const newItem = {
+  ...oldItem,
+  inboxItemId: NEW_ID,
+  groupId: NEW_ID,
+  state: 'classified',
+  contentSignature: 'sig-new',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetSearch({ selected: undefined, type: undefined });
+
+  mockRootsList.mockResolvedValue(ok([]));
+  mockInboxPlanListOpen.mockResolvedValue(ok({ plans: [], totalActions: 0 }));
+  mockInboxPropertyRegistry.mockResolvedValue(ok([]));
+  mockInboxItemMetadata.mockResolvedValue(ok({ files: [] }));
+
+  // First fetch: only the pre-split, unclassified item exists. After the
+  // reclassify mutation invalidates the list, every subsequent fetch returns
+  // the post-split, resolved item instead (the OLD row is gone — R-11: a
+  // stale group's sub-item rows are purged on materialize_sub_items).
+  mockInboxList
+    .mockResolvedValueOnce(ok({ items: [oldItem], capped: false, limit: 500 }))
+    .mockResolvedValue(ok({ items: [newItem], capped: false, limit: 500 }));
+
+  mockInboxClassify.mockImplementation((args: { inboxItemId: string }) =>
+    args.inboxItemId === NEW_ID
+      ? Promise.resolve(
+          ok({
+            type: 'single_type',
+            frameType: 'light',
+            unclassifiedFiles: [],
+          }),
+        )
+      : Promise.resolve(
+          ok({
+            type: 'unclassified',
+            frameType: null,
+            unclassifiedFiles: ['ambiguous_001.fits'],
+          }),
+        ),
+  );
+
+  mockInboxReclassifyV2.mockResolvedValue(
+    ok({
+      sourceGroupId: 'sg-1',
+      subItems: [
+        {
+          inboxItemId: NEW_ID,
+          groupKey: 'type=light',
+          groupLabel: '(root) · light',
+          frameType: 'light',
+          fileCount: 1,
+        },
+      ],
+      needsReviewCount: 0,
+    }),
+  );
+});
+
+import { InboxPage } from '../InboxPage';
+
+describe('InboxPage bulk-reclassify unblocks Confirm (#724/#755 CI-red)', () => {
+  it('moves selection to the post-split item and re-enables Confirm after bulk reclassify', async () => {
+    // Matches the real flow (and the E2E's own `select_only_item()`): select
+    // the row AFTER the list has loaded, not via a pre-set `?selected=` deep
+    // link — selecting before load exercises a DIFFERENT (already-guarded)
+    // mount-time path, not this bug.
+    render(<InboxPage />);
+
+    await screen.findByTestId(`inbox-item-${OLD_ID}`);
+    screen.getByTestId(`inbox-item-${OLD_ID}`).click();
+
+    // Pre-reclassify: the real gate this issue is about — classification.
+    // type === 'unclassified' blocks Confirm.
+    await waitFor(() => expect(mockInboxClassify).toHaveBeenCalled());
+    expect(await screen.findByTestId('inbox-confirm-btn')).toBeDisabled();
+
+    const selectAll = await screen.findByTestId('reclassify-select-all');
+    selectAll.click();
+    const bulkFrameType = screen.getByTestId(
+      'bulk-frame-type',
+    ) as HTMLSelectElement;
+    bulkFrameType.value = 'light';
+    bulkFrameType.dispatchEvent(new Event('change', { bubbles: true }));
+    screen.getByTestId('bulk-apply-btn').click();
+
+    await waitFor(() => expect(mockInboxReclassifyV2).toHaveBeenCalledTimes(1));
+
+    // The real regression: Confirm must re-enable once the post-split item
+    // (single_type, no missing attrs) is the one on screen — not stay
+    // disabled on the OLD unclassified item's stale gate state.
+    await waitFor(
+      () => expect(screen.getByTestId('inbox-confirm-btn')).not.toBeDisabled(),
+      { timeout: 5000 },
+    );
+    expect(screen.queryByTestId('inbox-unclassified-alert')).toBeNull();
+    expect(getSearch().selected).toBe(NEW_ID);
+  });
+});

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
@@ -59,11 +59,15 @@ const { getSearch, setSearch, resetSearch, subscribe } = vi.hoisted(() => {
     getSearch: () => state,
     setSearch: (updater: (prev: typeof state) => typeof state) => {
       state = updater(state);
-      listeners.forEach((l) => l());
+      listeners.forEach((l) => {
+        l();
+      });
     },
     resetSearch: (next: typeof state) => {
       state = next;
-      listeners.forEach((l) => l());
+      listeners.forEach((l) => {
+        l();
+      });
     },
     subscribe: (l: () => void) => {
       listeners.add(l);
@@ -247,5 +251,67 @@ describe('InboxPage bulk-reclassify unblocks Confirm (#724/#755 CI-red)', () => 
     );
     expect(screen.queryByTestId('inbox-unclassified-alert')).toBeNull();
     expect(getSearch().selected).toBe(NEW_ID);
+  });
+
+  // Coordinator's root-cause hypothesis (a): `reclassify_v2` only emits
+  // `subItems` when it re-splits a group into SEPARATE materialized rows —
+  // a group that resolves to exactly the item already selected (single-type,
+  // no missing attrs, nothing to split) can report an empty `subItems` list.
+  // `pickReclassifyTarget([])` returns null, so the selection-handoff path
+  // never starts; the gate must still re-derive from a fresh classify of
+  // whatever is CURRENTLY selected.
+  it('re-enables Confirm when reclassify_v2 resolves the item IN PLACE (empty subItems)', async () => {
+    mockInboxReclassifyV2.mockResolvedValue(
+      ok({ sourceGroupId: 'sg-1', subItems: [], needsReviewCount: 0 }),
+    );
+    // The id never changes for an in-place resolve — same OLD_ID throughout,
+    // but its classify() result flips from unclassified to single_type once
+    // the reclassify's cache invalidation lands (call 2+).
+    let classifyCall = 0;
+    mockInboxClassify.mockImplementation(() => {
+      classifyCall += 1;
+      return Promise.resolve(
+        classifyCall === 1
+          ? ok({
+              type: 'unclassified',
+              frameType: null,
+              unclassifiedFiles: ['ambiguous_001.fits'],
+            })
+          : ok({
+              type: 'single_type',
+              frameType: 'light',
+              unclassifiedFiles: [],
+            }),
+      );
+    });
+    mockInboxList.mockReset();
+    mockInboxList.mockResolvedValue(
+      ok({ items: [oldItem], capped: false, limit: 500 }),
+    );
+
+    render(<InboxPage />);
+    await screen.findByTestId(`inbox-item-${OLD_ID}`);
+    screen.getByTestId(`inbox-item-${OLD_ID}`).click();
+
+    await waitFor(() => expect(mockInboxClassify).toHaveBeenCalled());
+    expect(await screen.findByTestId('inbox-confirm-btn')).toBeDisabled();
+
+    screen.getByTestId('reclassify-select-all').click();
+    const bulkFrameType = screen.getByTestId(
+      'bulk-frame-type',
+    ) as HTMLSelectElement;
+    bulkFrameType.value = 'light';
+    bulkFrameType.dispatchEvent(new Event('change', { bubbles: true }));
+    screen.getByTestId('bulk-apply-btn').click();
+
+    await waitFor(() => expect(mockInboxReclassifyV2).toHaveBeenCalledTimes(1));
+
+    await waitFor(
+      () => expect(screen.getByTestId('inbox-confirm-btn')).not.toBeDisabled(),
+      { timeout: 5000 },
+    );
+    expect(screen.queryByTestId('inbox-unclassified-alert')).toBeNull();
+    // Selection never needed to move — no handoff, no id change.
+    expect(getSearch().selected).toBe(OLD_ID);
   });
 });

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifySelection.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifySelection.test.tsx
@@ -6,10 +6,11 @@
  * Post-split selection handoff (issue #755 CI fix, PR #854).
  *
  * `reclassify_v2` operates at source-group scope and re-splits the group
- * into new single-type sub-items (R-14). The previously-selected item can
- * silently stop existing after a bulk/per-file reclassify (the group it
- * belonged to no longer exists), leaving the Confirm gate (`InboxPage.tsx`
- * `canConfirm`) permanently disabled — this is exactly what the Real-UI e2e
+ * into new single-type sub-items (R-14), so the previously-selected item id
+ * (issue #644: selection is id-based, `?selected=<id>`, not a list index)
+ * can silently stop existing after a bulk/per-file reclassify, leaving the
+ * Confirm gate (`InboxPage.tsx` `canConfirm`) permanently disabled — this is
+ * exactly what the Real-UI e2e
  * `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm` caught.
  * (Selection itself is by item id, not list index — issue #644.)
  *
@@ -34,7 +35,7 @@
  *    InboxPage's handoff logic depends on. Proves the CONTRACT between the
  *    two components without needing a router.
  */
-import React from 'react';
+import type React from 'react';
 import {
   render as rtlRender,
   screen,
@@ -153,7 +154,7 @@ describe('resolveReclassifyHandoff (bounded pendingReclassifySelectionId lifetim
     ).toEqual({ action: 'wait' });
   });
 
-  it('navigates to the item id once settled and visible (issue #644)', async () => {
+  it('navigates to the item by id once settled and visible', async () => {
     const { resolveReclassifyHandoff } = await import('../InboxPage');
 
     const items = [

--- a/apps/desktop/src/features/inbox/__tests__/PlanPanel.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/PlanPanel.test.tsx
@@ -190,6 +190,28 @@ describe('PlanPanel (aggregate surface)', { timeout: 15_000 }, () => {
     expect(screen.getByText('/dest/lights/ngc1234.fits')).toBeInTheDocument();
   });
 
+  // #606: the collapsed group header (the default view — no expand needed)
+  // must show source (the ingestion name) AND destination together in the
+  // SAME row, without requiring the reviewer to expand file rows.
+  it('#606: the collapsed group header shows source and destination together', () => {
+    const plans = [
+      makePlan({
+        inboxItemId: 'from-to',
+        itemName: '2026-06-01/NGC7000',
+        actions: [
+          makeAction({
+            fromPath: '/deep/path/ngc1234.fits',
+            destinationPreview: '/dest/lights/ngc1234.fits',
+          }),
+        ],
+      }),
+    ];
+    renderPanel(plans);
+    const group = screen.getByTestId('plan-group-from-to');
+    expect(group).toHaveTextContent('2026-06-01/NGC7000');
+    expect(group).toHaveTextContent('lights');
+  });
+
   it('collapses file rows by default and shows a per-group summary line', () => {
     const plans = [
       makePlan({

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -64,27 +64,41 @@ export type {
 
 // ── Query hooks ───────────────────────────────────────────────────────────────
 
+/**
+ * Shared `inbox.classify` TanStack Query key builder. Used by
+ * `useInboxClassification`/`useInboxPlanBreakdowns` (which fetch it) and by
+ * any caller that needs to directly invalidate one item's classify cache
+ * (e.g. `InboxPage`'s post-reclassify-in-place refetch) — keeping the key
+ * shape in ONE place means an invalidator can never drift out of sync with
+ * the query it's supposed to target.
+ */
+export function inboxClassifyQueryKey(
+  rootAbsolutePath: string,
+  inboxItemId: string,
+  forceRescan = false,
+) {
+  const key = forceRescan
+    ? `${rootAbsolutePath}|${inboxItemId}|force`
+    : `${rootAbsolutePath}|${inboxItemId}`;
+  return [queryKeys.inbox.list('all')[0], 'classify', key] as const;
+}
+
 /** Load and cache an inbox classification for the given item. */
 export function useInboxClassification(
   inboxItemId: string,
   rootAbsolutePath: string,
   forceRescan = false,
 ) {
-  const key = forceRescan
-    ? `${rootAbsolutePath}|${inboxItemId}|force`
-    : `${rootAbsolutePath}|${inboxItemId}`;
   const { data, isFetching, error } = useQuery<InboxClassifyResponse>({
-    queryKey: [queryKeys.inbox.list('all')[0], 'classify', key],
-    queryFn: async () => {
-      const [rootPath, itemId, forceStr] = key.split('|');
-      return unwrap(
+    queryKey: inboxClassifyQueryKey(rootAbsolutePath, inboxItemId, forceRescan),
+    queryFn: async () =>
+      unwrap(
         await commands.inboxClassify({
-          inboxItemId: itemId,
-          rootAbsolutePath: rootPath,
-          forceRescan: forceStr === 'force',
+          inboxItemId,
+          rootAbsolutePath,
+          forceRescan,
         }),
-      );
-    },
+      ),
     enabled: !!inboxItemId && !!rootAbsolutePath,
   });
   return { data, loading: isFetching, error: error ?? undefined };
@@ -120,23 +134,20 @@ export function useInboxPlanBreakdowns(
   targets: InboxBreakdownTarget[],
 ): Record<string, ReadonlyArray<{ kind: string; count: number }>> {
   const results = useQueries({
-    queries: targets.map((t) => {
-      const key = `${t.rootAbsolutePath}|${t.inboxItemId}`;
-      return {
-        queryKey: [queryKeys.inbox.list('all')[0], 'classify', key],
-        queryFn: async () =>
-          unwrap(
-            await commands.inboxClassify({
-              inboxItemId: t.inboxItemId,
-              rootAbsolutePath: t.rootAbsolutePath,
-              forceRescan: false,
-            }),
-          ),
-        enabled: !!t.inboxItemId && !!t.rootAbsolutePath,
-        // Breakdown is stable for an unchanged folder — avoid re-fetch churn.
-        staleTime: 30_000,
-      };
-    }),
+    queries: targets.map((t) => ({
+      queryKey: inboxClassifyQueryKey(t.rootAbsolutePath, t.inboxItemId),
+      queryFn: async () =>
+        unwrap(
+          await commands.inboxClassify({
+            inboxItemId: t.inboxItemId,
+            rootAbsolutePath: t.rootAbsolutePath,
+            forceRescan: false,
+          }),
+        ),
+      enabled: !!t.inboxItemId && !!t.rootAbsolutePath,
+      // Breakdown is stable for an unchanged folder — avoid re-fetch churn.
+      staleTime: 30_000,
+    })),
   });
 
   // Stable dependency signatures: recompute only when the set of target ids

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -263,6 +263,14 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
       ),
     ).toBeInTheDocument();
     expect(screen.getByText('Deleted, not moved')).toBeInTheDocument();
+    // #606: From and To must render TOGETHER for the same row — the item's
+    // own row, not just somewhere in the table — so a reviewer can see both
+    // sides of the move without cross-referencing.
+    const row = screen.getByTestId('plan-review-item-0');
+    expect(row).toHaveTextContent('calibrated/light_001.xisf');
+    expect(row).toHaveTextContent(
+      '.astro-plan-archive/plan-1/item-0-light_001.xisf',
+    );
   });
 
   it('keeps Approve & apply disabled until protected items are acknowledged', async () => {

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -476,7 +476,8 @@ export function PlanReviewOverlay({
           {/* Live apply progress (D17 — spec 025 progress UI, absorbed here). */}
           {(progress.running ||
             progress.terminal !== null ||
-            progress.paused) && (
+            progress.paused ||
+            progress.resumeStalled) && (
             <div
               className="alm-plan-review__progress"
               role="status"
@@ -537,6 +538,14 @@ export function PlanReviewOverlay({
                       : m.plans_review_resume_btn()}
                   </Btn>
                 </>
+              )}
+              {progress.resumeStalled && (
+                <Pill
+                  variant="warn"
+                  data-testid="plan-review-resume-stalled-badge"
+                >
+                  {m.plans_review_resume_stalled()}
+                </Pill>
               )}
             </div>
           )}

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -63,6 +63,17 @@ export interface PlanApplyProgress {
   /** Run id needed to call `plan.resume`; set once a pause or the initial
    * apply response reports one. */
   runId: string | null;
+  /**
+   * `true` immediately after a successful `plan.resume` call, until the
+   * first `plans.apply.status` poll (below) lands. Issue #575 (backend
+   * `spawn_executor_run` shared by apply and resume) is fixed — the run DOES
+   * continue — but `plan.resume`'s response carries no event channel, so
+   * there is nothing to await for a "first real update" the way `run()` has.
+   * This is a brief, honest "reconnecting" placeholder, not a permanent
+   * dead-end: `running` flips true and polling starts in the same tick (see
+   * `resume` below).
+   */
+  resumeStalled: boolean;
 }
 
 const IDLE: PlanApplyProgress = {
@@ -75,6 +86,7 @@ const IDLE: PlanApplyProgress = {
   paused: false,
   pauseReason: null,
   runId: null,
+  resumeStalled: false,
 };
 
 /** Extract a numeric `itemsTotal` from an event payload when present. */
@@ -97,7 +109,6 @@ function readStringField(payload: unknown, field: string): string | null {
 
 export function usePlanApplyProgress() {
   const [progress, setProgress] = useState<PlanApplyProgress>(IDLE);
-
   // Issue #744 (FR-002): `plan.resume` returns no event channel, so a
   // resumed run's ongoing progress (which, since #575, genuinely continues)
   // is only observable by polling `plans.apply.status`. Ref (not state) so
@@ -210,6 +221,7 @@ export function usePlanApplyProgress() {
       failed: status.itemsFailed,
       total: status.itemsTotal,
       runId: status.runId ?? prev.runId,
+      resumeStalled: false,
       paused: status.planState === 'paused',
       pauseReason:
         status.planState === 'paused' ? (status.pauseReason ?? null) : null,
@@ -243,6 +255,7 @@ export function usePlanApplyProgress() {
           running: true,
           paused: false,
           pauseReason: null,
+          resumeStalled: true,
         }));
         stopResumePolling();
         pollTimerRef.current = setInterval(() => {

--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -365,6 +365,39 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
         "expected Confirm to be disabled while classification.type == 'unclassified'"
     );
 
+    // CI-red decisive instrumentation (coordinator ask, run 29638271121):
+    // wrap the real `window.__TAURI_INTERNALS__.invoke` (the transport
+    // `@tauri-apps/api/core`'s `invoke` — and so every generated
+    // `commands.*` call — actually dispatches over, per
+    // `apps/desktop/src/api/ipc.ts`) so the FIRST real, UI-triggered
+    // `inbox_reclassify_v2` call's request+response is captured, not the
+    // separate direct debug-retry call below (which runs on an
+    // ALREADY-resolved item and isn't representative of the first one).
+    app.driver
+        .execute(
+            r#"
+            if (!window.__e2eReclassifyCalls) {
+                window.__e2eReclassifyCalls = [];
+                var original = window.__TAURI_INTERNALS__.invoke;
+                window.__TAURI_INTERNALS__.invoke = function(cmd, args, options) {
+                    var callPromise = original.call(this, cmd, args, options);
+                    if (cmd === 'inbox_reclassify_v2') {
+                        var entry = { args: args, result: null, error: null };
+                        window.__e2eReclassifyCalls.push(entry);
+                        callPromise.then(
+                            function(res) { entry.result = res; },
+                            function(err) { entry.error = String(err); },
+                        );
+                    }
+                    return callPromise;
+                };
+            }
+            "#,
+            vec![],
+        )
+        .await
+        .context("install reclassify_v2 call recorder")?;
+
     // Bulk reclassify: select the one needs-review file, set frame type ->
     // light PLUS exposureS, apply. Real inputs, real `inbox.reclassify_v2`
     // round-trip.
@@ -450,6 +483,12 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
                 var exp = document.querySelector('[data-testid="bulk-exposure-s"]');
                 var alert = document.querySelector('[data-testid="inbox-unclassified-alert"]');
                 var confirmBtn = document.querySelector('[data-testid="inbox-confirm-btn"]');
+                // CI-red decisive facts (coordinator ask): the FIRST real,
+                // UI-triggered reclassify_v2 call (recorded above, BEFORE the
+                // retry loop below re-clicked bulk-apply — a retry would
+                // append MORE entries, so index [0] is always the first),
+                // and the `selected` URL search param at dump time.
+                var selMatch = window.location.hash.match(/[?&]selected=([^&]*)/);
                 return JSON.stringify({
                     items: items,
                     banners: banners,
@@ -458,6 +497,9 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
                     exposureValue: exp ? exp.value : null,
                     unclassifiedAlertPresent: !!alert,
                     confirmDisabled: confirmBtn ? confirmBtn.disabled : null,
+                    selectedUrlParam: selMatch ? decodeURIComponent(selMatch[1]) : null,
+                    firstReclassifyV2Call: (window.__e2eReclassifyCalls || [])[0] || null,
+                    allReclassifyV2CallCount: (window.__e2eReclassifyCalls || []).length,
                 });
                 "#,
                 vec![],

--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -365,39 +365,6 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
         "expected Confirm to be disabled while classification.type == 'unclassified'"
     );
 
-    // CI-red decisive instrumentation (coordinator ask, run 29638271121):
-    // wrap the real `window.__TAURI_INTERNALS__.invoke` (the transport
-    // `@tauri-apps/api/core`'s `invoke` — and so every generated
-    // `commands.*` call — actually dispatches over, per
-    // `apps/desktop/src/api/ipc.ts`) so the FIRST real, UI-triggered
-    // `inbox_reclassify_v2` call's request+response is captured, not the
-    // separate direct debug-retry call below (which runs on an
-    // ALREADY-resolved item and isn't representative of the first one).
-    app.driver
-        .execute(
-            r#"
-            if (!window.__e2eReclassifyCalls) {
-                window.__e2eReclassifyCalls = [];
-                var original = window.__TAURI_INTERNALS__.invoke;
-                window.__TAURI_INTERNALS__.invoke = function(cmd, args, options) {
-                    var callPromise = original.call(this, cmd, args, options);
-                    if (cmd === 'inbox_reclassify_v2') {
-                        var entry = { args: args, result: null, error: null };
-                        window.__e2eReclassifyCalls.push(entry);
-                        callPromise.then(
-                            function(res) { entry.result = res; },
-                            function(err) { entry.error = String(err); },
-                        );
-                    }
-                    return callPromise;
-                };
-            }
-            "#,
-            vec![],
-        )
-        .await
-        .context("install reclassify_v2 call recorder")?;
-
     // Bulk reclassify: select the one needs-review file, set frame type ->
     // light PLUS exposureS, apply. Real inputs, real `inbox.reclassify_v2`
     // round-trip.
@@ -465,87 +432,7 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
     // The store invalidates the classify query cache on success (`store.ts`);
     // Confirm re-enabling is the real, observable proof the override landed
     // and reclassified the file to `single_type`.
-    if let Err(e) = app.wait_testid_enabled("inbox-confirm-btn", UI_TIMEOUT).await {
-        // Diagnosability: a still-disabled Confirm has several distinct causes
-        // (stale-id apply error in a banner, selection lost, alert still up,
-        // handoff never navigated) — dump the observable page state so a CI
-        // log alone identifies which gate stayed closed.
-        let dump: serde_json::Value = app
-            .driver
-            .execute(
-                r#"
-                var items = Array.from(document.querySelectorAll('[data-testid^="inbox-item-"]'))
-                    .map(function(el){ return el.getAttribute('data-testid'); });
-                var banners = Array.from(document.querySelectorAll('.alm-banner, [class*="banner"], [role="alert"]'))
-                    .map(function(el){ return el.textContent.slice(0, 300); });
-                var fieldset = document.querySelector('.alm-inbox-detail__bulk-controls');
-                var sel = document.querySelector('[data-testid="bulk-frame-type"]');
-                var exp = document.querySelector('[data-testid="bulk-exposure-s"]');
-                var alert = document.querySelector('[data-testid="inbox-unclassified-alert"]');
-                var confirmBtn = document.querySelector('[data-testid="inbox-confirm-btn"]');
-                // CI-red decisive facts (coordinator ask): the FIRST real,
-                // UI-triggered reclassify_v2 call (recorded above, BEFORE the
-                // retry loop below re-clicked bulk-apply — a retry would
-                // append MORE entries, so index [0] is always the first),
-                // and the `selected` URL search param at dump time.
-                var selMatch = window.location.hash.match(/[?&]selected=([^&]*)/);
-                return JSON.stringify({
-                    items: items,
-                    banners: banners,
-                    bulkFieldsetPresent: !!fieldset,
-                    frameTypeValue: sel ? sel.value : null,
-                    exposureValue: exp ? exp.value : null,
-                    unclassifiedAlertPresent: !!alert,
-                    confirmDisabled: confirmBtn ? confirmBtn.disabled : null,
-                    selectedUrlParam: selMatch ? decodeURIComponent(selMatch[1]) : null,
-                    firstReclassifyV2Call: (window.__e2eReclassifyCalls || [])[0] || null,
-                    allReclassifyV2CallCount: (window.__e2eReclassifyCalls || []).length,
-                });
-                "#,
-                vec![],
-            )
-            .await
-            .ok()
-            .and_then(|r| r.convert::<String>().ok())
-            .and_then(|s| serde_json::from_str(&s).ok())
-            .unwrap_or(serde_json::Value::Null);
-        eprintln!("DEBUG DUMP on confirm-never-enabled: {dump:#}");
-
-        // Backend ground truth, bypassing the UI: what did the re-split
-        // actually leave in the DB, and does a SECOND, quiescent
-        // reclassify_v2 with the same overrides resolve the item? If the
-        // retry resolves it, the first (UI-triggered) apply raced concurrent
-        // DB work — materialize_sub_items swallows its write errors — rather
-        // than hitting a deterministic gate.
-        let list: serde_json::Value =
-            app.invoke("inbox_list", json!({})).await.unwrap_or(serde_json::Value::Null);
-        eprintln!("DEBUG backend inbox_list after failed apply: {list:#}");
-        if let Some(live_id) = list["items"][0]["inboxItemId"].as_str() {
-            let meta: serde_json::Value = app
-                .invoke("inbox_item_metadata", json!({"req": {"inboxItemId": live_id}}))
-                .await
-                .unwrap_or(serde_json::Value::Null);
-            eprintln!("DEBUG backend inbox_item_metadata: {meta:#}");
-            let retry: serde_json::Value = app
-                .invoke(
-                    "inbox_reclassify_v2",
-                    json!({"req": {
-                        "inboxItemId": live_id,
-                        "overrides": [],
-                        "bulk": [
-                            {"property": "frameType", "value": "light", "filePaths": null},
-                            {"property": "exposureS", "value": 300.0, "filePaths": null}
-                        ]
-                    }}),
-                )
-                .await
-                .unwrap_or(serde_json::Value::Null);
-            eprintln!("DEBUG direct reclassify_v2 retry response: {retry:#}");
-        }
-        return Err(anyhow::anyhow!(
-            "expected bulk reclassify to unblock Confirm (single_type, no missing attrs): {e}"
-        ));
-    }
+    app.wait_testid_enabled("inbox-confirm-btn", UI_TIMEOUT).await?;
     anyhow::ensure!(
         !app.testid_exists("inbox-unclassified-alert").await?,
         "expected the 'frame types required' banner to clear after reclassify"


### PR DESCRIPTION
## Summary
- Fixes the Inbox confirm button staying disabled after using bulk reclassify to fix unclassified frame types
- Repairs a selection-tracking bug introduced by a recent reclassify change

Diagnostic PR gating the fix that unblocks the queued Inbox/Targets/Projects/Sessions/Calibration merges.