### PR TITLE
feat(onboarding): persistence, contracts, and domain core

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -277,6 +277,8 @@
   "err_no_items_to_retry": "There are no items to retry.",
   "err_no_op": "Nothing to do.",
   "err_note_content_too_large": "This note is too long. Please shorten it.",
+  "err_onboarding_invalid_state": "That change to your getting-started progress isn't allowed.",
+  "err_onboarding_item_unknown": "That getting-started item is no longer available.",
   "err_operation_handler_duplicate": "This action is already registered.",
   "err_operation_not_found": "That action isn't available.",
   "err_os_command_failed": "The system command didn't complete.",

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -3652,6 +3652,18 @@ export type ErrorCode = "validation.request_envelope_invalid" | "dev_mode.disabl
  *  (`specs/010-guided-first-project-flow/contracts/guided.state.get.json`).
  */
 "state_corrupted" | 
+/**
+ *  `onboarding.item.set_state` referenced an `item_id` not in the
+ *  registry (contracts/onboarding-commands.md `unknown_item`).
+ */
+"onboarding.item.unknown" | 
+/**
+ *  A request violated an onboarding state-shape rule: `item.set_state`
+ *  with an auto state (`unchecked`/`auto_checked`), or `section.set` with
+ *  `hidden: false` — unhiding is exclusively `onboarding.restore`
+ *  (contracts/onboarding-commands.md `invalid_state`).
+ */
+"onboarding.invalid_state" | 
 /**  Used when a legacy `String` error is wrapped into `ContractError`. */
 "internal.error";
 

--- a/apps/desktop/src/lib/error-messages.ts
+++ b/apps/desktop/src/lib/error-messages.ts
@@ -160,6 +160,9 @@ export const ERROR_MESSAGES: Record<ErrorCode, () => string> = {
   // Inbox-confirm attribution (spec 008 Q27, F-Framing-5/10).
   'attribution.not_light_frame': m.err_attribution_not_light_frame,
   'attribution.geometry_unavailable': m.err_attribution_geometry_unavailable,
+  // Onboarding redesign (spec 056 contracts/onboarding-commands.md).
+  'onboarding.item.unknown': m.err_onboarding_item_unknown,
+  'onboarding.invalid_state': m.err_onboarding_invalid_state,
   // The generic wrap code maps to the shared generic fallback message (no
   // duplicated catalog values; spec 046 FR-013).
   'internal.error': m.err_generic_fallback,

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -85,6 +85,9 @@ pub mod inbox_plan;
 pub mod inventory;
 pub mod log_stream;
 pub mod native;
+/// Onboarding use cases and item registry (spec 056) — successor to
+/// [`guided_flow`], which stays until the spec 056 deletion lane removes it.
+pub mod onboarding;
 /// Path-set overlap comparison for the cross-plan concurrency guard
 /// (spec 025 FR-017 / R-Concur-1). Pure, camino-only helper consumed by
 /// [`plan_apply`]; relocated here after the vestigial `fs/planner` crate was

--- a/crates/app/core/src/onboarding.rs
+++ b/crates/app/core/src/onboarding.rs
@@ -1,0 +1,1101 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Onboarding use cases and item registry (spec 056).
+//!
+//! Successor to the spec-010 `guided_flow` state machine
+//! (`crates/app/core/src/guided_flow.rs`, scheduled for removal by the
+//! spec 056 deletion lane, T010 — left untouched here; that file and this
+//! one intentionally coexist until T010 lands). Three layers share this one
+//! backend:
+//! - L1 orientation walk: [`orientation_complete`] sets
+//!   `onboarding_flags.orientation_done_at`.
+//! - L2 checklists: [`get_state`]/[`set_item_state`]/[`section_set`] over
+//!   [`ITEM_REGISTRY`].
+//! - L3 find-it spotlight: reads `anchor` from the registry; no backend use
+//!   case (UI-only).
+//!
+//! ## Item registry
+//!
+//! [`ITEM_REGISTRY`] is the single source of truth for the five FR-006
+//! workflow pages (`inbox`, `sessions`, `calibration`, `targets`,
+//! `projects`), 2-4 items each. AUTOMATIC items (`completion_topic` +
+//! `seed_query` both set) are ticked by the live bus subscriber
+//! (`apps/desktop/src-tauri/src/commands/onboarding.rs`, T005) via
+//! [`tick_from_event`] and re-derived by seed/restore below; the rest are
+//! manual (FR-017). `completion_topic`/`seed_query` pairs are drawn from the
+//! research R4 verified auto-tick inventory only — no new backend events are
+//! minted (decision record #2). Labels/tooltips/reasons are Paraglide keys
+//! derived from `item_id` (research R9), not stored here.
+//!
+//! ## Seed/restore derivation (FR-014/PQ-001)
+//!
+//! [`target_state_for`] computes "what should this item's state be given
+//! real recorded data" for every item — the one derivation routine backing
+//! both:
+//! - the lazy first-activation seed ([`ensure_seeded`], called from
+//!   [`get_state`]): only inserts rows that don't exist yet, via
+//!   `persistence_db::repositories::onboarding::insert_if_missing` — never
+//!   re-touches an existing row, so a mere read can never silently
+//!   auto-tick an item (that would bypass the bus subscriber, breaking
+//!   FR-021's backend-authoritative-via-subscriber-only invariant);
+//! - the explicit [`restore`] command: re-derives every AUTOMATIC item's row
+//!   via `upsert_if_unsettled`, which is a no-op for settled
+//!   (`manually_checked`/`dismissed`) rows — user progress is never
+//!   discarded.
+//!
+//! ## FR-031 settle path
+//!
+//! [`settle_and_maybe_hide`] runs after every write that could be a
+//! *settling* transition — a live-event tick ([`tick_from_event`]) or a
+//! manual check-off/dismiss ([`set_item_state`]) — never seed/restore, which
+//! are derivations, not transitions. When it leaves zero `unchecked` rows
+//! across the whole registry, `onboarding_flags.section_hidden_at` is set.
+//! [`restore`] always clears that flag regardless of the resulting item
+//! states (FR-014) — a still-complete section stays visible until a NEW
+//! settling transition or an explicit `section_set { hidden: true }`.
+
+use std::collections::{HashMap, HashSet};
+
+use contracts_core::onboarding::{
+    OnboardingFlagsDto, OnboardingItemDto, OnboardingItemSetStateRequest,
+    OnboardingItemSetStateResponse, OnboardingItemState, OnboardingManualState,
+    OnboardingOrientationCompleteRequest, OnboardingOrientationCompleteResponse, OnboardingPage,
+    OnboardingPageProgressDto, OnboardingPrerequisiteDto, OnboardingProgressDto,
+    OnboardingRestoreResponse, OnboardingSectionSetRequest, OnboardingSectionSetResponse,
+    OnboardingStateDto, OnboardingStateGetResponse, OnboardingStateSource,
+};
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use domain_core::ids::Timestamp;
+use persistence_db::repositories::onboarding as repo;
+use persistence_db::repositories::onboarding::{OnboardingFlagsRow, UpsertOutcome};
+use sqlx::SqlitePool;
+
+// ── Item registry ─────────────────────────────────────────────────────────────
+
+/// How an AUTOMATIC item's seed/restore target state is derived from real
+/// recorded data (research R4's verified auto-tick inventory). Each variant
+/// dispatches to a dedicated read-only query in
+/// `persistence_db::repositories::onboarding` — raw SQL stays in that crate
+/// per the db-boundary rule.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SeedMilestone {
+    InboxConfirmed,
+    PlanApplied,
+    ProjectCreated,
+    ToolLaunchSpawned,
+    TargetResolved,
+}
+
+impl SeedMilestone {
+    async fn met(self, pool: &SqlitePool) -> Result<bool, OnboardingError> {
+        match self {
+            Self::InboxConfirmed => repo::has_confirmed_inbox_item(pool).await,
+            Self::PlanApplied => repo::has_applied_plan(pool).await,
+            Self::ProjectCreated => repo::has_project(pool).await,
+            Self::ToolLaunchSpawned => repo::has_spawned_tool_launch(pool).await,
+            Self::TargetResolved => repo::has_resolved_target(pool).await,
+        }
+        .map_err(db_err)
+    }
+}
+
+/// An item's prerequisite: an upstream registry item id plus the page to
+/// jump to when it's unmet (FR-010). Satisfaction is computed live from the
+/// upstream item's own `seed_query` — never cached (data-model.md
+/// "Derived (never stored)").
+pub struct PrerequisiteDef {
+    pub upstream_item_id: &'static str,
+    pub jump_page: OnboardingPage,
+}
+
+/// Static item definition. Labels/tooltips/reasons are Paraglide keys
+/// derived from `item_id`, not stored here (research R9).
+pub struct ItemDef {
+    pub item_id: &'static str,
+    pub page: OnboardingPage,
+    /// Bus topic that auto-ticks this item; `None` = manual item (FR-017).
+    pub completion_topic: Option<&'static str>,
+    /// Payload predicate gating the tick (e.g. `tool.launch` requires
+    /// `outcome == "spawned"`). Only meaningful when `completion_topic` is
+    /// set; evaluated by the T005 subscriber, not here.
+    pub payload_filter: Option<fn(&serde_json::Value) -> bool>,
+    /// How seed/restore derives "already met" for this item. `None` for
+    /// manual items — they always seed to `unchecked`.
+    pub seed_query: Option<SeedMilestone>,
+    pub prerequisite: Option<PrerequisiteDef>,
+    /// `data-guide-anchor` value for the L3 spotlight target.
+    pub anchor: &'static str,
+}
+
+impl ItemDef {
+    #[must_use]
+    pub fn is_automatic(&self) -> bool {
+        self.completion_topic.is_some()
+    }
+}
+
+/// The item registry (v1) — 11 items across the five FR-006 pages (2-4 each:
+/// inbox 2, sessions 2, calibration 2, targets 2, projects 3). Five are
+/// AUTOMATIC (tied to research R4's verified topics); the rest are manual.
+/// Missing-milestone follow-ups (calibration master registration, site save
+/// — research R4) stay manual per the v1 "no new backend events" constraint.
+pub const ITEM_REGISTRY: &[ItemDef] = &[
+    ItemDef {
+        item_id: "inbox.confirm_first",
+        page: OnboardingPage::Inbox,
+        completion_topic: Some("inventory.confirmed"),
+        payload_filter: None,
+        seed_query: Some(SeedMilestone::InboxConfirmed),
+        prerequisite: None,
+        anchor: "inbox.confirm-row",
+    },
+    ItemDef {
+        item_id: "inbox.apply_first_plan",
+        page: OnboardingPage::Inbox,
+        completion_topic: Some("plan.applying.completed"),
+        payload_filter: None,
+        seed_query: Some(SeedMilestone::PlanApplied),
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "inbox.confirm_first",
+            jump_page: OnboardingPage::Inbox,
+        }),
+        anchor: "inbox.apply-plan-cta",
+    },
+    ItemDef {
+        item_id: "sessions.review_first",
+        page: OnboardingPage::Sessions,
+        completion_topic: None,
+        payload_filter: None,
+        seed_query: None,
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "inbox.confirm_first",
+            jump_page: OnboardingPage::Inbox,
+        }),
+        anchor: "sessions.review-row",
+    },
+    ItemDef {
+        item_id: "sessions.add_note",
+        page: OnboardingPage::Sessions,
+        completion_topic: None,
+        payload_filter: None,
+        seed_query: None,
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "inbox.confirm_first",
+            jump_page: OnboardingPage::Inbox,
+        }),
+        anchor: "sessions.add-note-cta",
+    },
+    ItemDef {
+        item_id: "calibration.match_master",
+        page: OnboardingPage::Calibration,
+        completion_topic: None,
+        payload_filter: None,
+        seed_query: None,
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "inbox.confirm_first",
+            jump_page: OnboardingPage::Inbox,
+        }),
+        anchor: "calibration.match-cta",
+    },
+    ItemDef {
+        item_id: "calibration.review_masters",
+        page: OnboardingPage::Calibration,
+        completion_topic: None,
+        payload_filter: None,
+        seed_query: None,
+        prerequisite: None,
+        anchor: "calibration.review-row",
+    },
+    ItemDef {
+        item_id: "targets.resolve_first",
+        page: OnboardingPage::Targets,
+        completion_topic: Some("target.resolved"),
+        payload_filter: None,
+        seed_query: Some(SeedMilestone::TargetResolved),
+        prerequisite: None,
+        anchor: "targets.resolve-cta",
+    },
+    ItemDef {
+        item_id: "targets.add_favourite",
+        page: OnboardingPage::Targets,
+        completion_topic: None,
+        payload_filter: None,
+        seed_query: None,
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "targets.resolve_first",
+            jump_page: OnboardingPage::Targets,
+        }),
+        anchor: "targets.favourite-cta",
+    },
+    ItemDef {
+        item_id: "projects.create_first",
+        page: OnboardingPage::Projects,
+        completion_topic: Some("project.created"),
+        payload_filter: None,
+        seed_query: Some(SeedMilestone::ProjectCreated),
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "inbox.confirm_first",
+            jump_page: OnboardingPage::Inbox,
+        }),
+        anchor: "projects.create-cta",
+    },
+    ItemDef {
+        item_id: "projects.launch_tool",
+        page: OnboardingPage::Projects,
+        completion_topic: Some("tool.launch"),
+        payload_filter: Some(|payload| {
+            payload.get("outcome").and_then(|v| v.as_str()) == Some("spawned")
+        }),
+        seed_query: Some(SeedMilestone::ToolLaunchSpawned),
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "projects.create_first",
+            jump_page: OnboardingPage::Projects,
+        }),
+        anchor: "project.open-in-tool",
+    },
+    ItemDef {
+        item_id: "projects.review_artifacts",
+        page: OnboardingPage::Projects,
+        completion_topic: None,
+        payload_filter: None,
+        seed_query: None,
+        prerequisite: Some(PrerequisiteDef {
+            upstream_item_id: "projects.launch_tool",
+            jump_page: OnboardingPage::Projects,
+        }),
+        anchor: "projects.artifacts-row",
+    },
+];
+
+/// Look up a registry item by id.
+#[must_use]
+pub fn find_item(item_id: &str) -> Option<&'static ItemDef> {
+    ITEM_REGISTRY.iter().find(|i| i.item_id == item_id)
+}
+
+fn page_order(page: OnboardingPage) -> u8 {
+    match page {
+        OnboardingPage::Inbox => 0,
+        OnboardingPage::Sessions => 1,
+        OnboardingPage::Calibration => 2,
+        OnboardingPage::Targets => 3,
+        OnboardingPage::Projects => 4,
+    }
+}
+
+// ── Error type ────────────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone, PartialEq, thiserror::Error)]
+pub enum OnboardingError {
+    /// `item.set_state` referenced an `item_id` not in [`ITEM_REGISTRY`].
+    #[error("unknown onboarding item id: {0}")]
+    UnknownItem(String),
+    /// `section.set` was called with neither field set.
+    #[error("onboarding.section.set request must set hidden or sidebarCollapsed")]
+    SectionSetEmptyRequest,
+    /// `section.set { hidden: false }` — unhiding is exclusively
+    /// `onboarding.restore`.
+    #[error("onboarding.section.set hidden may only be true; unhide via onboarding.restore")]
+    SectionUnhideNotAllowed,
+    /// A persistence layer failure.
+    #[error("persistence unavailable: {0}")]
+    PersistenceUnavailable(String),
+}
+
+impl From<OnboardingError> for ContractError {
+    fn from(e: OnboardingError) -> Self {
+        match e {
+            OnboardingError::UnknownItem(id) => ContractError::new(
+                ErrorCode::OnboardingItemUnknown,
+                format!("unknown onboarding item id: {id}"),
+                ErrorSeverity::Blocking,
+                false,
+            ),
+            OnboardingError::SectionSetEmptyRequest | OnboardingError::SectionUnhideNotAllowed => {
+                ContractError::new(
+                    ErrorCode::OnboardingInvalidState,
+                    e.to_string(),
+                    ErrorSeverity::Blocking,
+                    false,
+                )
+            }
+            OnboardingError::PersistenceUnavailable(msg) => {
+                ContractError::new(ErrorCode::InternalDatabase, msg, ErrorSeverity::Fatal, true)
+            }
+        }
+    }
+}
+
+#[allow(clippy::needless_pass_by_value)]
+fn db_err(e: persistence_db::DbError) -> OnboardingError {
+    OnboardingError::PersistenceUnavailable(e.to_string())
+}
+
+// ── Seed/restore derivation (FR-014/PQ-001) ──────────────────────────────────
+
+/// The shared per-item derivation: `unchecked` for manual items, and for
+/// AUTOMATIC items whatever [`SeedMilestone::met`] reports right now.
+async fn target_state_for(
+    pool: &SqlitePool,
+    item: &ItemDef,
+) -> Result<&'static str, OnboardingError> {
+    match item.seed_query {
+        None => Ok("unchecked"),
+        Some(milestone) => {
+            Ok(if milestone.met(pool).await? { "auto_checked" } else { "unchecked" })
+        }
+    }
+}
+
+/// Lazy first-activation seed: insert a row for every registry item that
+/// doesn't have one yet, computed via [`target_state_for`]. Never touches an
+/// existing row (see module docs — that's what keeps a mere read from
+/// silently auto-ticking an item).
+async fn ensure_seeded(pool: &SqlitePool) -> Result<(), OnboardingError> {
+    let existing = repo::load_state(pool).await.map_err(db_err)?;
+    let existing_ids: HashSet<&str> = existing.iter().map(|r| r.item_id.as_str()).collect();
+
+    for item in ITEM_REGISTRY {
+        if existing_ids.contains(item.item_id) {
+            continue;
+        }
+        let state = target_state_for(pool, item).await?;
+        repo::insert_if_missing(pool, item.item_id, state, "seed").await.map_err(db_err)?;
+    }
+    Ok(())
+}
+
+/// Explicit restore: re-derive every AUTOMATIC item via
+/// [`repo::upsert_if_unsettled`] (a no-op against settled
+/// `manually_checked`/`dismissed` rows); defensively insert any missing
+/// manual-item row (never overwriting an existing one).
+async fn derive_all_automatic_items(pool: &SqlitePool) -> Result<(), OnboardingError> {
+    for item in ITEM_REGISTRY {
+        if !item.is_automatic() {
+            repo::insert_if_missing(pool, item.item_id, "unchecked", "seed")
+                .await
+                .map_err(db_err)?;
+            continue;
+        }
+        let state = target_state_for(pool, item).await?;
+        repo::upsert_if_unsettled(pool, item.item_id, state, "seed").await.map_err(db_err)?;
+    }
+    Ok(())
+}
+
+// ── FR-031 settle path ───────────────────────────────────────────────────────
+
+/// Run after a settling write (live-event tick or manual check-off/dismiss).
+/// Hides the section once every registry item is settled; a no-op while any
+/// item is still `unchecked`.
+async fn settle_and_maybe_hide(pool: &SqlitePool) -> Result<(), OnboardingError> {
+    if !repo::all_items_settled(pool).await.map_err(db_err)? {
+        return Ok(());
+    }
+    let mut flags = repo::load_flags(pool).await.map_err(db_err)?;
+    flags.section_hidden_at = Some(Timestamp::now_iso());
+    repo::upsert_flags(pool, &flags).await.map_err(db_err)?;
+    Ok(())
+}
+
+// ── DTO builders ──────────────────────────────────────────────────────────────
+
+fn parse_state(s: &str) -> OnboardingItemState {
+    match s {
+        "auto_checked" => OnboardingItemState::AutoChecked,
+        "manually_checked" => OnboardingItemState::ManuallyChecked,
+        "dismissed" => OnboardingItemState::Dismissed,
+        _ => OnboardingItemState::Unchecked,
+    }
+}
+
+fn parse_source(s: &str) -> OnboardingStateSource {
+    match s {
+        "event" => OnboardingStateSource::Event,
+        "user" => OnboardingStateSource::User,
+        _ => OnboardingStateSource::Seed,
+    }
+}
+
+fn flags_dto(row: &OnboardingFlagsRow) -> OnboardingFlagsDto {
+    OnboardingFlagsDto {
+        orientation_done: row.orientation_done_at.is_some(),
+        section_hidden: row.section_hidden_at.is_some(),
+        sidebar_collapsed: row.sidebar_collapsed,
+    }
+}
+
+async fn prerequisite_dto(
+    pool: &SqlitePool,
+    def: &PrerequisiteDef,
+) -> Result<OnboardingPrerequisiteDto, OnboardingError> {
+    let upstream = find_item(def.upstream_item_id)
+        .expect("registry prerequisite must reference a real item_id");
+    let met = match upstream.seed_query {
+        Some(milestone) => milestone.met(pool).await?,
+        None => false,
+    };
+    Ok(OnboardingPrerequisiteDto {
+        met,
+        reason_key: format!("onboarding.prerequisite.{}", def.upstream_item_id),
+        jump_page: def.jump_page,
+    })
+}
+
+async fn item_dto(
+    pool: &SqlitePool,
+    item: &ItemDef,
+    row: &repo::OnboardingStateRow,
+) -> Result<OnboardingItemDto, OnboardingError> {
+    let prerequisite = match &item.prerequisite {
+        Some(def) => Some(prerequisite_dto(pool, def).await?),
+        None => None,
+    };
+    Ok(OnboardingItemDto {
+        item_id: item.item_id.to_owned(),
+        page: item.page,
+        state: parse_state(&row.state),
+        at: row.at.clone(),
+        source: parse_source(&row.source),
+        prerequisite,
+        has_auto_tick: item.is_automatic(),
+    })
+}
+
+async fn build_state_dto(pool: &SqlitePool) -> Result<OnboardingStateDto, OnboardingError> {
+    let rows = repo::load_state(pool).await.map_err(db_err)?;
+    let by_id: HashMap<&str, &repo::OnboardingStateRow> =
+        rows.iter().map(|r| (r.item_id.as_str(), r)).collect();
+
+    let mut items = Vec::with_capacity(ITEM_REGISTRY.len());
+    let mut per_page: HashMap<OnboardingPage, (u32, u32)> = HashMap::new();
+
+    for item in ITEM_REGISTRY {
+        // Not seeded yet — callers always seed first (get_state/restore);
+        // skip defensively rather than fail the whole read.
+        let Some(row) = by_id.get(item.item_id) else { continue };
+
+        let settled = !matches!(parse_state(&row.state), OnboardingItemState::Unchecked);
+        let entry = per_page.entry(item.page).or_insert((0, 0));
+        entry.1 += 1;
+        if settled {
+            entry.0 += 1;
+        }
+
+        items.push(item_dto(pool, item, row).await?);
+    }
+
+    let done: u32 = per_page.values().map(|(done, _)| done).sum();
+    let total: u32 = per_page.values().map(|(_, total)| total).sum();
+    let mut per_page_dto: Vec<OnboardingPageProgressDto> = per_page
+        .into_iter()
+        .map(|(page, (done, total))| OnboardingPageProgressDto { page, done, total })
+        .collect();
+    per_page_dto.sort_by_key(|p| page_order(p.page));
+
+    let flags = repo::load_flags(pool).await.map_err(db_err)?;
+    Ok(OnboardingStateDto {
+        items,
+        flags: flags_dto(&flags),
+        progress: OnboardingProgressDto { done, total, per_page: per_page_dto },
+    })
+}
+
+// ── Use cases ─────────────────────────────────────────────────────────────────
+
+/// `onboarding.state.get` — read the full projection for UI hydration.
+/// Lazily seeds any registry item without a row yet (first-ever call, or a
+/// registry grown since the last seed/restore).
+///
+/// # Errors
+///
+/// - `PersistenceUnavailable`: database failure.
+pub async fn get_state(pool: &SqlitePool) -> Result<OnboardingStateGetResponse, OnboardingError> {
+    ensure_seeded(pool).await?;
+    Ok(OnboardingStateGetResponse { state: build_state_dto(pool).await? })
+}
+
+/// `onboarding.item.set_state` — manual check-off or dismiss (FR-017). Auto
+/// states are structurally unreachable via [`OnboardingManualState`]. A
+/// repeat call against an already-settled item is a no-op (manual states are
+/// permanent — PQ-002/FR-017); no per-item undo in v1.
+///
+/// # Errors
+///
+/// - `UnknownItem`: `item_id` is not in the registry.
+/// - `PersistenceUnavailable`: database failure.
+///
+/// # Panics
+///
+/// Never in practice: the just-written row is re-read immediately after a
+/// successful upsert, which always leaves a row present.
+pub async fn set_item_state(
+    pool: &SqlitePool,
+    req: &OnboardingItemSetStateRequest,
+) -> Result<OnboardingItemSetStateResponse, OnboardingError> {
+    let item =
+        find_item(&req.item_id).ok_or_else(|| OnboardingError::UnknownItem(req.item_id.clone()))?;
+    let target = match req.state {
+        OnboardingManualState::ManuallyChecked => "manually_checked",
+        OnboardingManualState::Dismissed => "dismissed",
+    };
+
+    let outcome =
+        repo::upsert_if_unsettled(pool, item.item_id, target, "user").await.map_err(db_err)?;
+    if outcome == UpsertOutcome::Written {
+        settle_and_maybe_hide(pool).await?;
+    }
+
+    let row = repo::load_item(pool, item.item_id)
+        .await
+        .map_err(db_err)?
+        .expect("row exists after upsert");
+    Ok(OnboardingItemSetStateResponse { item: item_dto(pool, item, &row).await? })
+}
+
+/// `onboarding.orientation.complete` — mark the walk finished or skipped;
+/// both set done-forever (FR-004). Idempotent — repeat calls return the
+/// original timestamp regardless of `outcome` (there is no separate
+/// finished-vs-skipped storage; both are terminal "done").
+///
+/// # Errors
+///
+/// - `PersistenceUnavailable`: database failure.
+///
+/// # Panics
+///
+/// Never in practice: `orientation_done_at` is always `Some` by this point,
+/// either just-set above or already set on entry.
+pub async fn orientation_complete(
+    pool: &SqlitePool,
+    _req: &OnboardingOrientationCompleteRequest,
+) -> Result<OnboardingOrientationCompleteResponse, OnboardingError> {
+    let mut flags = repo::load_flags(pool).await.map_err(db_err)?;
+    if flags.orientation_done_at.is_none() {
+        flags.orientation_done_at = Some(Timestamp::now_iso());
+        repo::upsert_flags(pool, &flags).await.map_err(db_err)?;
+    }
+    Ok(OnboardingOrientationCompleteResponse {
+        orientation_done_at: flags.orientation_done_at.expect("set above or already set"),
+    })
+}
+
+/// `onboarding.section.set` — explicit remove (FR-013) and collapse
+/// persistence (FR-012). `hidden` accepts only `true`; unhiding is
+/// exclusively [`restore`]. The FR-031 completion auto-hide is written only
+/// by [`settle_and_maybe_hide`], never through this command.
+///
+/// # Errors
+///
+/// - `SectionSetEmptyRequest`: neither field was set.
+/// - `SectionUnhideNotAllowed`: `hidden: false` was requested.
+/// - `PersistenceUnavailable`: database failure.
+pub async fn section_set(
+    pool: &SqlitePool,
+    req: &OnboardingSectionSetRequest,
+) -> Result<OnboardingSectionSetResponse, OnboardingError> {
+    if req.hidden.is_none() && req.sidebar_collapsed.is_none() {
+        return Err(OnboardingError::SectionSetEmptyRequest);
+    }
+    if req.hidden == Some(false) {
+        return Err(OnboardingError::SectionUnhideNotAllowed);
+    }
+
+    let mut flags = repo::load_flags(pool).await.map_err(db_err)?;
+    if req.hidden == Some(true) {
+        flags.section_hidden_at = Some(Timestamp::now_iso());
+    }
+    if let Some(collapsed) = req.sidebar_collapsed {
+        flags.sidebar_collapsed = collapsed;
+    }
+    repo::upsert_flags(pool, &flags).await.map_err(db_err)?;
+
+    Ok(OnboardingSectionSetResponse { flags: flags_dto(&flags) })
+}
+
+/// `onboarding.restore` — the single Settings → Advanced restore/reset
+/// (FR-014). Clears the hidden flag (explicit removal or completion
+/// auto-hide), then re-derives AUTOMATIC items only; `manually_checked` and
+/// `dismissed` rows keep their state. Idempotent.
+///
+/// # Errors
+///
+/// - `PersistenceUnavailable`: database failure.
+pub async fn restore(pool: &SqlitePool) -> Result<OnboardingRestoreResponse, OnboardingError> {
+    derive_all_automatic_items(pool).await?;
+
+    let mut flags = repo::load_flags(pool).await.map_err(db_err)?;
+    flags.section_hidden_at = None;
+    repo::upsert_flags(pool, &flags).await.map_err(db_err)?;
+
+    Ok(OnboardingRestoreResponse { state: build_state_dto(pool).await? })
+}
+
+/// Tick an item from a live bus event. Not itself a Tauri command — the T005
+/// subscriber calls this after its own topic/payload-filter/envelope-source
+/// checks pass (FR-016/FR-021: only the subscriber may produce
+/// `auto_checked`). Exposed here, not inlined in the subscriber, so the
+/// settle path stays centralized and both call sites share one code path.
+///
+/// # Errors
+///
+/// - `PersistenceUnavailable`: database failure.
+pub async fn tick_from_event(pool: &SqlitePool, item_id: &str) -> Result<(), OnboardingError> {
+    let outcome =
+        repo::upsert_if_unsettled(pool, item_id, "auto_checked", "event").await.map_err(db_err)?;
+    if outcome == UpsertOutcome::Written {
+        settle_and_maybe_hide(pool).await?;
+    }
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use contracts_core::onboarding::{OnboardingOrientationOutcome, OnboardingSectionSetRequest};
+
+    async fn setup_pool() -> SqlitePool {
+        let db = persistence_db::Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    // ── Registry shape ───────────────────────────────────────────────────────
+
+    #[test]
+    fn registry_has_two_to_four_items_per_page() {
+        let mut counts: HashMap<OnboardingPage, usize> = HashMap::new();
+        for item in ITEM_REGISTRY {
+            *counts.entry(item.page).or_default() += 1;
+        }
+        for page in [
+            OnboardingPage::Inbox,
+            OnboardingPage::Sessions,
+            OnboardingPage::Calibration,
+            OnboardingPage::Targets,
+            OnboardingPage::Projects,
+        ] {
+            let n = counts.get(&page).copied().unwrap_or(0);
+            assert!((2..=4).contains(&n), "{page:?} has {n} items, expected 2-4 (FR-006)");
+        }
+    }
+
+    /// research R4: only these five topics are verified auto-tick sources;
+    /// no invented events.
+    #[test]
+    fn only_verified_topics_appear_as_completion_topics() {
+        let verified = [
+            "inventory.confirmed",
+            "plan.applying.completed",
+            "project.created",
+            "tool.launch",
+            "target.resolved",
+        ];
+        for item in ITEM_REGISTRY {
+            if let Some(topic) = item.completion_topic {
+                assert!(verified.contains(&topic), "unverified completion_topic: {topic}");
+            }
+        }
+    }
+
+    #[test]
+    fn prerequisites_reference_real_registry_items() {
+        for item in ITEM_REGISTRY {
+            if let Some(def) = &item.prerequisite {
+                assert!(
+                    find_item(def.upstream_item_id).is_some(),
+                    "{}'s prerequisite references unknown item {}",
+                    item.item_id,
+                    def.upstream_item_id
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn tool_launch_payload_filter_requires_spawned_outcome() {
+        let item = find_item("projects.launch_tool").unwrap();
+        let filter = item.payload_filter.expect("projects.launch_tool must gate on outcome");
+        assert!(filter(&serde_json::json!({"outcome": "spawned"})));
+        assert!(!filter(&serde_json::json!({"outcome": "spawn_failed"})));
+        assert!(!filter(&serde_json::json!({})));
+    }
+
+    // ── get_state / seeding ──────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn get_state_seeds_every_registry_item_on_first_call() {
+        let pool = setup_pool().await;
+        let resp = get_state(&pool).await.unwrap();
+        assert_eq!(resp.state.items.len(), ITEM_REGISTRY.len());
+        assert!(resp.state.items.iter().all(|i| i.state == OnboardingItemState::Unchecked));
+        assert_eq!(resp.state.progress.total, u32::try_from(ITEM_REGISTRY.len()).unwrap());
+        assert_eq!(resp.state.progress.done, 0);
+    }
+
+    #[tokio::test]
+    async fn get_state_pre_ticks_automatic_items_already_met_on_upgrade() {
+        let pool = setup_pool().await;
+        // Simulate a pre-existing library: a project already exists before
+        // onboarding ever ran (PQ-001 — first activation uses the same
+        // recorded-state derivation as restore).
+        sqlx::query(
+            "INSERT INTO projects (id, name, tool, lifecycle, path, channel_drift, is_mosaic, created_at, updated_at) \
+             VALUES ('proj-1', 'Proj 1', 'PixInsight', 'setup_incomplete', 'proj-1', 0, 0, \
+                     '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = get_state(&pool).await.unwrap();
+        let create_first =
+            resp.state.items.iter().find(|i| i.item_id == "projects.create_first").unwrap();
+        assert_eq!(create_first.state, OnboardingItemState::AutoChecked);
+        assert_eq!(create_first.source, OnboardingStateSource::Seed);
+    }
+
+    #[tokio::test]
+    async fn get_state_never_re_derives_after_first_seed() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+
+        // A milestone becomes true AFTER the first seed, with no live event
+        // and no restore — a plain read must not silently auto-tick it
+        // (that would bypass the FR-021 subscriber-only invariant).
+        sqlx::query(
+            "INSERT INTO projects (id, name, tool, lifecycle, path, channel_drift, is_mosaic, created_at, updated_at) \
+             VALUES ('proj-1', 'Proj 1', 'PixInsight', 'setup_incomplete', 'proj-1', 0, 0, \
+                     '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = get_state(&pool).await.unwrap();
+        let create_first =
+            resp.state.items.iter().find(|i| i.item_id == "projects.create_first").unwrap();
+        assert_eq!(create_first.state, OnboardingItemState::Unchecked);
+    }
+
+    #[tokio::test]
+    async fn get_state_computes_prerequisite_met_live() {
+        let pool = setup_pool().await;
+        let resp = get_state(&pool).await.unwrap();
+        let create_first =
+            resp.state.items.iter().find(|i| i.item_id == "projects.create_first").unwrap();
+        let prereq = create_first.prerequisite.as_ref().expect("create_first has a prerequisite");
+        assert!(!prereq.met);
+        assert_eq!(prereq.jump_page, OnboardingPage::Inbox);
+
+        sqlx::query(
+            "INSERT INTO inbox_items (id, root_id, relative_path, file_count, discovered_at, last_scanned_at, state, lane) \
+             VALUES ('item-1', 'root-1', 'a.fits', 1, '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z', 'plan_open', 'fits')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = get_state(&pool).await.unwrap();
+        let create_first =
+            resp.state.items.iter().find(|i| i.item_id == "projects.create_first").unwrap();
+        assert!(
+            create_first.prerequisite.as_ref().unwrap().met,
+            "prerequisite must be computed live, not cached"
+        );
+    }
+
+    // ── set_item_state ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn set_item_state_manually_checks_item() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+
+        let resp = set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "sessions.review_first".to_owned(),
+                state: OnboardingManualState::ManuallyChecked,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(resp.item.state, OnboardingItemState::ManuallyChecked);
+        assert_eq!(resp.item.source, OnboardingStateSource::User);
+    }
+
+    #[tokio::test]
+    async fn set_item_state_unknown_item_errors() {
+        let pool = setup_pool().await;
+        let err = set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "nonexistent".to_owned(),
+                state: OnboardingManualState::Dismissed,
+            },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, OnboardingError::UnknownItem("nonexistent".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn set_item_state_is_permanent_no_undo() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+
+        set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "sessions.review_first".to_owned(),
+                state: OnboardingManualState::ManuallyChecked,
+            },
+        )
+        .await
+        .unwrap();
+
+        // A second manual call (e.g. trying to dismiss instead) is a no-op —
+        // PQ-002: no per-item undo in v1.
+        let resp = set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "sessions.review_first".to_owned(),
+                state: OnboardingManualState::Dismissed,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(resp.item.state, OnboardingItemState::ManuallyChecked);
+    }
+
+    // ── tick_from_event ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn tick_from_event_auto_checks_item() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+
+        tick_from_event(&pool, "inbox.confirm_first").await.unwrap();
+
+        let resp = get_state(&pool).await.unwrap();
+        let item = resp.state.items.iter().find(|i| i.item_id == "inbox.confirm_first").unwrap();
+        assert_eq!(item.state, OnboardingItemState::AutoChecked);
+        assert_eq!(item.source, OnboardingStateSource::Event);
+    }
+
+    #[tokio::test]
+    async fn tick_from_event_never_downgrades_manually_dismissed_item() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+        set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "calibration.review_masters".to_owned(),
+                state: OnboardingManualState::Dismissed,
+            },
+        )
+        .await
+        .unwrap();
+
+        tick_from_event(&pool, "calibration.review_masters").await.unwrap();
+
+        let resp = get_state(&pool).await.unwrap();
+        let item =
+            resp.state.items.iter().find(|i| i.item_id == "calibration.review_masters").unwrap();
+        assert_eq!(item.state, OnboardingItemState::Dismissed);
+    }
+
+    // ── orientation_complete ─────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn orientation_complete_is_idempotent() {
+        let pool = setup_pool().await;
+        let r1 = orientation_complete(
+            &pool,
+            &OnboardingOrientationCompleteRequest {
+                outcome: OnboardingOrientationOutcome::Finished,
+            },
+        )
+        .await
+        .unwrap();
+        let r2 = orientation_complete(
+            &pool,
+            &OnboardingOrientationCompleteRequest {
+                outcome: OnboardingOrientationOutcome::Skipped,
+            },
+        )
+        .await
+        .unwrap();
+        assert_eq!(r1.orientation_done_at, r2.orientation_done_at);
+    }
+
+    // ── section_set ───────────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn section_set_hides_permanently() {
+        let pool = setup_pool().await;
+        let resp = section_set(
+            &pool,
+            &OnboardingSectionSetRequest { hidden: Some(true), sidebar_collapsed: None },
+        )
+        .await
+        .unwrap();
+        assert!(resp.flags.section_hidden);
+    }
+
+    #[tokio::test]
+    async fn section_set_rejects_unhide() {
+        let pool = setup_pool().await;
+        let err = section_set(
+            &pool,
+            &OnboardingSectionSetRequest { hidden: Some(false), sidebar_collapsed: None },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, OnboardingError::SectionUnhideNotAllowed);
+    }
+
+    #[tokio::test]
+    async fn section_set_rejects_empty_request() {
+        let pool = setup_pool().await;
+        let err = section_set(
+            &pool,
+            &OnboardingSectionSetRequest { hidden: None, sidebar_collapsed: None },
+        )
+        .await
+        .unwrap_err();
+        assert_eq!(err, OnboardingError::SectionSetEmptyRequest);
+    }
+
+    #[tokio::test]
+    async fn section_set_persists_collapse() {
+        let pool = setup_pool().await;
+        let resp = section_set(
+            &pool,
+            &OnboardingSectionSetRequest { hidden: None, sidebar_collapsed: Some(true) },
+        )
+        .await
+        .unwrap();
+        assert!(resp.flags.sidebar_collapsed);
+        assert!(!resp.flags.section_hidden);
+    }
+
+    // ── FR-031 settle path ───────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn settling_last_item_hides_section() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+
+        // Dismiss every item; the last one settling must auto-hide the
+        // section (FR-031).
+        let ids: Vec<&str> = ITEM_REGISTRY.iter().map(|i| i.item_id).collect();
+        for (idx, id) in ids.iter().enumerate() {
+            let resp = set_item_state(
+                &pool,
+                &OnboardingItemSetStateRequest {
+                    item_id: (*id).to_owned(),
+                    state: OnboardingManualState::Dismissed,
+                },
+            )
+            .await
+            .unwrap();
+            let is_last = idx == ids.len() - 1;
+            assert_eq!(resp.item.state, OnboardingItemState::Dismissed);
+            let flags = repo::load_flags(&pool).await.unwrap();
+            assert_eq!(
+                flags.section_hidden_at.is_some(),
+                is_last,
+                "section must hide exactly on the settling transition of the last item"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn restore_clears_auto_hide_but_leaves_items_settled() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+        for item in ITEM_REGISTRY {
+            set_item_state(
+                &pool,
+                &OnboardingItemSetStateRequest {
+                    item_id: item.item_id.to_owned(),
+                    state: OnboardingManualState::Dismissed,
+                },
+            )
+            .await
+            .unwrap();
+        }
+        assert!(repo::load_flags(&pool).await.unwrap().section_hidden_at.is_some());
+
+        let resp = restore(&pool).await.unwrap();
+        assert!(!resp.state.flags.section_hidden, "restore must unhide the section (FR-014)");
+        // All-dismissed state survives restore untouched (manual states are
+        // never re-derived).
+        assert!(resp.state.items.iter().all(|i| i.state == OnboardingItemState::Dismissed));
+    }
+
+    // ── restore (FR-014) ──────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn restore_re_derives_automatic_items_only() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+
+        // Manually check one item, dismiss another — both must survive
+        // restore untouched.
+        set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "sessions.review_first".to_owned(),
+                state: OnboardingManualState::ManuallyChecked,
+            },
+        )
+        .await
+        .unwrap();
+        set_item_state(
+            &pool,
+            &OnboardingItemSetStateRequest {
+                item_id: "calibration.review_masters".to_owned(),
+                state: OnboardingManualState::Dismissed,
+            },
+        )
+        .await
+        .unwrap();
+
+        // A milestone becomes newly true; only restore should surface it
+        // (not a plain get_state read).
+        sqlx::query(
+            "INSERT INTO projects (id, name, tool, lifecycle, path, channel_drift, is_mosaic, created_at, updated_at) \
+             VALUES ('proj-1', 'Proj 1', 'PixInsight', 'setup_incomplete', 'proj-1', 0, 0, \
+                     '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        let resp = restore(&pool).await.unwrap();
+        let by_id: HashMap<&str, OnboardingItemState> =
+            resp.state.items.iter().map(|i| (i.item_id.as_str(), i.state)).collect();
+
+        assert_eq!(by_id["sessions.review_first"], OnboardingItemState::ManuallyChecked);
+        assert_eq!(by_id["calibration.review_masters"], OnboardingItemState::Dismissed);
+        assert_eq!(by_id["projects.create_first"], OnboardingItemState::AutoChecked);
+    }
+
+    #[tokio::test]
+    async fn restore_is_idempotent() {
+        let pool = setup_pool().await;
+        get_state(&pool).await.unwrap();
+        let r1 = restore(&pool).await.unwrap();
+        let r2 = restore(&pool).await.unwrap();
+        let ids1: Vec<_> = r1.state.items.iter().map(|i| (i.item_id.clone(), i.state)).collect();
+        let ids2: Vec<_> = r2.state.items.iter().map(|i| (i.item_id.clone(), i.state)).collect();
+        assert_eq!(ids1, ids2);
+    }
+}

--- a/crates/contracts/core/src/error_code.rs
+++ b/crates/contracts/core/src/error_code.rs
@@ -447,6 +447,18 @@ pub enum ErrorCode {
     #[serde(rename = "state_corrupted")]
     StateCorrupted,
 
+    // ── Onboarding (spec 056) ──────────────────────────────────────────────────
+    /// `onboarding.item.set_state` referenced an `item_id` not in the
+    /// registry (contracts/onboarding-commands.md `unknown_item`).
+    #[serde(rename = "onboarding.item.unknown")]
+    OnboardingItemUnknown,
+    /// A request violated an onboarding state-shape rule: `item.set_state`
+    /// with an auto state (`unchecked`/`auto_checked`), or `section.set` with
+    /// `hidden: false` — unhiding is exclusively `onboarding.restore`
+    /// (contracts/onboarding-commands.md `invalid_state`).
+    #[serde(rename = "onboarding.invalid_state")]
+    OnboardingInvalidState,
+
     // ── Generic fallback ─────────────────────────────────────────────────────
     /// Used when a legacy `String` error is wrapped into `ContractError`.
     #[serde(rename = "internal.error")]

--- a/crates/contracts/core/src/lib.rs
+++ b/crates/contracts/core/src/lib.rs
@@ -23,6 +23,7 @@ pub mod lifecycle;
 pub mod log;
 pub mod manifests;
 pub mod native;
+pub mod onboarding;
 pub mod patterns;
 pub mod plan_apply;
 pub mod plans;

--- a/crates/contracts/core/src/onboarding.rs
+++ b/crates/contracts/core/src/onboarding.rs
@@ -1,0 +1,295 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Rust-side contract DTOs for onboarding commands (spec 056).
+//!
+//! Replaces the removed `guided.*` operations and `tour.complete_step`
+//! (spec 010) — see `contracts/onboarding-commands.md`. Five commands:
+//! - `onboarding.state.get`          — read the full projection for UI hydration.
+//! - `onboarding.item.set_state`     — manual check-off or dismiss (FR-017).
+//! - `onboarding.orientation.complete` — mark the L1 walk finished/skipped.
+//! - `onboarding.section.set`        — explicit remove + collapse persistence.
+//! - `onboarding.restore`            — the single Settings → Advanced restore/reset.
+//!
+//! Plus the `onboarding:state-changed` notification payload (backend → frontend).
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+// ── Shared enums ──────────────────────────────────────────────────────────────
+
+/// Per-item lifecycle state (data-model.md "State transitions").
+///
+/// `AutoChecked`/`ManuallyChecked`/`Dismissed` are terminal: neither a live
+/// event nor a repeat manual action ever downgrades a settled item.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Type,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum OnboardingItemState {
+    Unchecked,
+    AutoChecked,
+    ManuallyChecked,
+    Dismissed,
+}
+
+/// What set the item's current state.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Type,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum OnboardingStateSource {
+    Seed,
+    Event,
+    User,
+}
+
+/// The five FR-006 workflow pages that carry a Getting Started checklist.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Type,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum OnboardingPage {
+    Inbox,
+    Sessions,
+    Calibration,
+    Targets,
+    Projects,
+}
+
+// ── Shared row/projection DTOs ───────────────────────────────────────────────
+
+/// Prerequisite presentation for an item whose upstream milestone is missing
+/// (FR-010).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingPrerequisiteDto {
+    /// Whether the upstream milestone is currently satisfied.
+    pub met: bool,
+    /// Paraglide message key for the human-readable reason.
+    pub reason_key: String,
+    /// Page to jump to in order to satisfy the prerequisite.
+    pub jump_page: OnboardingPage,
+}
+
+/// One onboarding item row for UI hydration.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingItemDto {
+    pub item_id: String,
+    pub page: OnboardingPage,
+    pub state: OnboardingItemState,
+    /// RFC-3339 UTC timestamp of the last state change.
+    pub at: String,
+    pub source: OnboardingStateSource,
+    /// `None` when the item has no prerequisite in the registry. Present
+    /// (with a live-computed `met`) whenever the item has one, regardless of
+    /// current satisfaction — the UI decides what to render for `met: true`.
+    pub prerequisite: Option<OnboardingPrerequisiteDto>,
+    /// True when this item has a `completion_topic` (auto-tick eligible) —
+    /// lets the UI distinguish "will tick itself" from "check me manually".
+    pub has_auto_tick: bool,
+}
+
+/// Section-level flags (`onboarding_flags` singleton).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingFlagsDto {
+    pub orientation_done: bool,
+    /// Covers both explicit removal (FR-013) and completion auto-hide
+    /// (FR-031).
+    pub section_hidden: bool,
+    pub sidebar_collapsed: bool,
+}
+
+/// Per-page item counts.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingPageProgressDto {
+    pub page: OnboardingPage,
+    pub done: u32,
+    pub total: u32,
+}
+
+/// Overall + per-page progress, derived from `onboarding_state` (never
+/// stored).
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingProgressDto {
+    pub done: u32,
+    pub total: u32,
+    pub per_page: Vec<OnboardingPageProgressDto>,
+}
+
+/// Full onboarding projection — the response shape shared by
+/// `onboarding.state.get` and `onboarding.restore`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingStateDto {
+    pub items: Vec<OnboardingItemDto>,
+    pub flags: OnboardingFlagsDto,
+    pub progress: OnboardingProgressDto,
+}
+
+// ── onboarding.state.get ─────────────────────────────────────────────────────
+
+/// Response from `onboarding.state.get`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingStateGetResponse {
+    pub state: OnboardingStateDto,
+}
+
+// ── onboarding.item.set_state ────────────────────────────────────────────────
+
+/// Manual state a caller may request via `onboarding.item.set_state`
+/// (FR-017). Auto states (`unchecked`/`auto_checked`) are rejected —
+/// `invalid_state`.
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Type,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum OnboardingManualState {
+    ManuallyChecked,
+    Dismissed,
+}
+
+/// Request for `onboarding.item.set_state`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingItemSetStateRequest {
+    pub item_id: String,
+    pub state: OnboardingManualState,
+}
+
+/// Response from `onboarding.item.set_state` — the updated item row.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingItemSetStateResponse {
+    pub item: OnboardingItemDto,
+}
+
+// ── onboarding.orientation.complete ──────────────────────────────────────────
+
+/// How the walk ended (both set done-forever, FR-004).
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    Serialize,
+    Deserialize,
+    JsonSchema,
+    Type,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum OnboardingOrientationOutcome {
+    Finished,
+    Skipped,
+}
+
+/// Request for `onboarding.orientation.complete`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingOrientationCompleteRequest {
+    pub outcome: OnboardingOrientationOutcome,
+}
+
+/// Response from `onboarding.orientation.complete`. Idempotent — repeat
+/// calls return the original timestamp.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingOrientationCompleteResponse {
+    pub orientation_done_at: String,
+}
+
+// ── onboarding.section.set ───────────────────────────────────────────────────
+
+/// Request for `onboarding.section.set`. At least one field MUST be set.
+/// `hidden` accepts only `true` (user remove) — unhiding happens exclusively
+/// via `onboarding.restore`; `hidden: false` is rejected as `invalid_state`.
+/// The completion auto-hide (FR-031) is written by the backend settle path,
+/// never through this command.
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingSectionSetRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub hidden: Option<bool>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sidebar_collapsed: Option<bool>,
+}
+
+/// Response from `onboarding.section.set` — the updated flags.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingSectionSetResponse {
+    pub flags: OnboardingFlagsDto,
+}
+
+// ── onboarding.restore ───────────────────────────────────────────────────────
+
+/// Response from `onboarding.restore` — same shape as `onboarding.state.get`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingRestoreResponse {
+    pub state: OnboardingStateDto,
+}
+
+// ── onboarding:state-changed notification ────────────────────────────────────
+
+/// Payload for the `onboarding:state-changed` Tauri notification. A hint
+/// only — the frontend re-reads via `onboarding.state.get`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct OnboardingStateChangedEvent {
+    pub item_id: Option<String>,
+}

--- a/crates/persistence/db/migrations/0069_onboarding.sql
+++ b/crates/persistence/db/migrations/0069_onboarding.sql
@@ -6,11 +6,17 @@
 -- registry itself (page/topic/prerequisite/seed_query/anchor) is code, not a
 -- table (data-model.md "Item registry (code, not DB)").
 --
--- `guided_flow_state` (0030_guided_flow.sql) is dropped: FR-027 greenfield
--- removal, no data migrated. Migration 0030 itself stays shipped and
--- untouched (append-only history).
-
-DROP TABLE IF EXISTS guided_flow_state;
+-- `guided_flow_state` (0030_guided_flow.sql) is NOT dropped here, despite
+-- tasks.md T001's literal wording and research R6/R7. Orchestrator sequencing
+-- decision (run-onb-0718, FIX to backend-foundation): dropping it in this
+-- migration would ship ahead of the spec 056 deletion lane (T010, separate
+-- node) that removes the code still reading/writing that table
+-- (`crates/persistence/db/src/repositories/guided_flow.rs`,
+-- `crates/app/core/src/guided_flow.rs`), leaving main's workspace tests red
+-- between the two merges. The `DROP TABLE IF EXISTS guided_flow_state`
+-- instead ships as migration 0070 inside T010, atomically with the code
+-- deletion (FR-027 greenfield removal, no data migrated). Migration 0030
+-- itself stays shipped and untouched either way (append-only history).
 
 -- ── onboarding_state — per-item rows ─────────────────────────────────────────
 --

--- a/crates/persistence/db/migrations/0069_onboarding.sql
+++ b/crates/persistence/db/migrations/0069_onboarding.sql
@@ -1,0 +1,56 @@
+-- Migration 0069: onboarding redesign persistence (spec 056, T001).
+--
+-- Replaces the legacy spec-010 guided-coach state machine (single-row
+-- current_step_id/completed_step_ids/dismissed) with a per-item projection:
+-- one row per registry item, plus a section-level flags singleton. The item
+-- registry itself (page/topic/prerequisite/seed_query/anchor) is code, not a
+-- table (data-model.md "Item registry (code, not DB)").
+--
+-- `guided_flow_state` (0030_guided_flow.sql) is dropped: FR-027 greenfield
+-- removal, no data migrated. Migration 0030 itself stays shipped and
+-- untouched (append-only history).
+
+DROP TABLE IF EXISTS guided_flow_state;
+
+-- ── onboarding_state — per-item rows ─────────────────────────────────────────
+--
+-- item_id: stable dot-notation id from the item registry (e.g.
+--          `inbox.confirm_first`). Rows exist for every registry item once
+--          onboarding is initialized (seeded on first activation and on
+--          restore via the same derivation, FR-014). Unknown item_ids (from a
+--          future registry shrink) are ignored on read.
+-- state:   unchecked | auto_checked | manually_checked | dismissed.
+--          auto_checked/manually_checked/dismissed are terminal for live
+--          events and for repeat manual actions — an event or a repeat
+--          manual call never downgrades or re-ticks a settled item
+--          (idempotent writes; data-model.md "State transitions").
+-- source:  seed | event | user — what set the current state.
+CREATE TABLE IF NOT EXISTS onboarding_state (
+    item_id TEXT NOT NULL PRIMARY KEY,
+    state   TEXT NOT NULL CHECK (state IN ('unchecked', 'auto_checked', 'manually_checked', 'dismissed')),
+    at      TEXT NOT NULL,
+    source  TEXT NOT NULL CHECK (source IN ('seed', 'event', 'user'))
+);
+
+-- ── onboarding_flags — singleton ─────────────────────────────────────────────
+--
+-- Same singleton pattern as the retired 0030_guided_flow.sql.
+--
+-- orientation_done_at: set on first finish OR skip of the walk (FR-004);
+--                       NULL = walk auto-runs on next launch after first-run
+--                       completion.
+-- section_hidden_at:   set by "Remove getting started" (FR-013) OR
+--                       automatically by the backend settle path when the
+--                       last open item settles and every group is
+--                       complete/dismissed (FR-031 auto-hide); cleared only
+--                       by restore (FR-014). Auto-hide is transition-
+--                       triggered — restore leaves a still-complete section
+--                       visible until a new settle or explicit removal.
+-- sidebar_collapsed:   persisted user collapse choice for the accordion
+--                       section (FR-012).
+CREATE TABLE IF NOT EXISTS onboarding_flags (
+    singleton_id       INTEGER NOT NULL PRIMARY KEY CHECK (singleton_id = 1),
+    orientation_done_at TEXT,
+    section_hidden_at   TEXT,
+    sidebar_collapsed   INTEGER NOT NULL DEFAULT 0
+);

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -12,8 +12,10 @@
 //! Migration 0061 added `target_favourite` (spec 051 US2).
 //! Migration 0064 added the `framing`/`framing_session` tables, `projects.is_mosaic`,
 //! and the durable `acquisition_session` clustering-key columns (spec 008 Q27).
-//! Migration 0069 replaced the spec-010 `guided_flow_state` table with
-//! `onboarding_state`/`onboarding_flags` (spec 056).
+//! Migration 0069 added `onboarding_state`/`onboarding_flags` (spec 056).
+//! The spec-010 `guided_flow_state` table it succeeds is dropped separately,
+//! by migration 0070 inside the spec 056 deletion lane (T010) — deferred
+//! from 0069 for CI-greenness (orchestrator sequencing decision, run-onb-0718).
 
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -12,6 +12,8 @@
 //! Migration 0061 added `target_favourite` (spec 051 US2).
 //! Migration 0064 added the `framing`/`framing_session` tables, `projects.is_mosaic`,
 //! and the durable `acquisition_session` clustering-key columns (spec 008 Q27).
+//! Migration 0069 replaced the spec-010 `guided_flow_state` table with
+//! `onboarding_state`/`onboarding_flags` (spec 056).
 
 use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
 
@@ -97,9 +99,10 @@ impl Database {
     /// database error if the reconciliation scan fails.
     // Touched for #773 (migration 0066), again for spec 008 Q27's migration
     // 0067 (renumbered from a 0066 collision with #773's own
-    // 0066_session_notes.sql), and again for its renumber to 0068 (a second
+    // 0066_session_notes.sql), again for its renumber to 0068 (a second
     // collision: 0067 vs #895's 0067_camera_sensor_type.sql, both merged to
-    // main independently) — to force `sqlx::migrate!` re-embed each time
+    // main independently), and again for spec 056's migration 0069
+    // (onboarding redesign) — to force `sqlx::migrate!` re-embed each time
     // (project memory: stale-embed guard).
     pub async fn migrate(&self) -> DbResult<()> {
         sqlx::migrate!("./migrations").run(&self.pool).await?;

--- a/crates/persistence/db/src/repositories/mod.rs
+++ b/crates/persistence/db/src/repositories/mod.rs
@@ -16,10 +16,13 @@
 //! Spec 051 US2 target favourites queries live in `target_favourites`.
 //!
 //! Spec 056 onboarding redesign lives in `onboarding` (per-item state +
-//! section flags, migration 0069). `guided_flow` (spec 010) stays until the
-//! spec 056 deletion lane removes it; its table was dropped by migration
-//! 0069, so its own tests fail at runtime until that lane lands (expected,
-//! atomic-landing risk documented in specs/056-onboarding-redesign/research.md R7).
+//! section flags, migration 0069). `guided_flow` (spec 010) stays fully
+//! functional — table included — until the spec 056 deletion lane (T010)
+//! removes it and drops `guided_flow_state` in migration 0070, atomically
+//! with the code deletion (orchestrator sequencing decision, run-onb-0718:
+//! migration 0069 deliberately does NOT drop the table, deviating from
+//! tasks.md T001's literal wording, so this crate's tests stay green between
+//! the two merges — see migration 0069's own header comment).
 
 pub mod artifacts;
 pub mod audit;

--- a/crates/persistence/db/src/repositories/mod.rs
+++ b/crates/persistence/db/src/repositories/mod.rs
@@ -14,6 +14,12 @@
 //! Spec 013/023 gen-2 target repository (`targets`) removed by spec 036.
 //! Spec 023 US2/US3/US4 target history + notes queries live in `targets`.
 //! Spec 051 US2 target favourites queries live in `target_favourites`.
+//!
+//! Spec 056 onboarding redesign lives in `onboarding` (per-item state +
+//! section flags, migration 0069). `guided_flow` (spec 010) stays until the
+//! spec 056 deletion lane removes it; its table was dropped by migration
+//! 0069, so its own tests fail at runtime until that lane lands (expected,
+//! atomic-landing risk documented in specs/056-onboarding-redesign/research.md R7).
 
 pub mod artifacts;
 pub mod audit;
@@ -28,6 +34,7 @@ pub mod inbox;
 pub mod inventory;
 pub mod lifecycle;
 pub mod manifests;
+pub mod onboarding;
 pub mod plan_apply;
 pub mod plans;
 pub mod prepared_source_views;

--- a/crates/persistence/db/src/repositories/onboarding.rs
+++ b/crates/persistence/db/src/repositories/onboarding.rs
@@ -1,0 +1,658 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repository methods for onboarding state (spec 056, T003).
+//!
+//! Operates on `onboarding_state` (per-item rows) and `onboarding_flags`
+//! (singleton) from migration 0069. The item registry (page/topic/
+//! prerequisite/seed_query) lives in `app_core::onboarding` — this module
+//! only persists and reads item_id-keyed rows and the section flags.
+//!
+//! ## The single guarded-upsert primitive
+//!
+//! [`upsert_if_unsettled`] is the ONLY write path for item state and serves
+//! seed, restore, live-event ticks, and manual check-off/dismiss alike: it
+//! inserts a missing row, or overwrites an existing row only while its
+//! current state is `unchecked`/`auto_checked` (data-model.md "State
+//! transitions" — settled states are terminal). This is what makes seed and
+//! restore share one derivation routine (FR-014/PQ-001: the caller computes
+//! a target state per item and calls this same primitive either way) and
+//! what makes live-event ticks and manual actions idempotent/non-downgrading
+//! without a read-then-write race.
+
+use domain_core::ids::Timestamp;
+use sqlx::SqlitePool;
+
+use crate::DbResult;
+
+// ── Row types ─────────────────────────────────────────────────────────────────
+
+/// Raw persisted row from `onboarding_state`.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct OnboardingStateRow {
+    pub item_id: String,
+    /// `unchecked` | `auto_checked` | `manually_checked` | `dismissed`.
+    pub state: String,
+    pub at: String,
+    /// `seed` | `event` | `user`.
+    pub source: String,
+}
+
+/// Raw persisted row from `onboarding_flags` (defaults when no row exists
+/// yet — the singleton is created lazily on first write).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct OnboardingFlagsRow {
+    pub orientation_done_at: Option<String>,
+    pub section_hidden_at: Option<String>,
+    pub sidebar_collapsed: bool,
+}
+
+/// Outcome of a guarded upsert — whether it actually changed the row (versus
+/// being a no-op against an already-settled item).
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum UpsertOutcome {
+    Written,
+    SkippedSettled,
+}
+
+// ── onboarding_state ─────────────────────────────────────────────────────────
+
+/// Load every persisted item row.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn load_state(pool: &SqlitePool) -> DbResult<Vec<OnboardingStateRow>> {
+    let rows: Vec<(String, String, String, String)> =
+        sqlx::query_as("SELECT item_id, state, at, source FROM onboarding_state")
+            .fetch_all(pool)
+            .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(|(item_id, state, at, source)| OnboardingStateRow { item_id, state, at, source })
+        .collect())
+}
+
+/// Load a single item row, or `None` if it has not been seeded yet.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn load_item(pool: &SqlitePool, item_id: &str) -> DbResult<Option<OnboardingStateRow>> {
+    let row: Option<(String, String, String, String)> =
+        sqlx::query_as("SELECT item_id, state, at, source FROM onboarding_state WHERE item_id = ?")
+            .bind(item_id)
+            .fetch_optional(pool)
+            .await?;
+
+    Ok(row.map(|(item_id, state, at, source)| OnboardingStateRow { item_id, state, at, source }))
+}
+
+/// Insert a missing item row, or overwrite an existing one only while its
+/// current state is `unchecked`/`auto_checked`. Settled rows
+/// (`manually_checked`/`dismissed`) are left untouched (data-model.md —
+/// settled states are terminal).
+///
+/// This single primitive is used for: explicit restore re-derivation
+/// (source=`seed`), live-event ticks (source=`event`), and manual
+/// check-off/dismiss (source=`user`) — it is deliberately NOT used for
+/// lazy first-activation seeding ([`insert_if_missing`]), which must never
+/// re-touch an existing `unchecked`/`auto_checked` row outside of an
+/// explicit restore (that would silently auto-tick an item on a read path,
+/// bypassing the bus subscriber — FR-021 backend-authoritative-via-
+/// subscriber-only). Callers distinguish "did this write actually change
+/// anything" via the returned [`UpsertOutcome`] (needed for the FR-031
+/// settle path, which only fires on a real settling transition, not a
+/// repeat/idempotent call).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn upsert_if_unsettled(
+    pool: &SqlitePool,
+    item_id: &str,
+    state: &str,
+    source: &str,
+) -> DbResult<UpsertOutcome> {
+    let now = Timestamp::now_iso();
+    let result = sqlx::query(
+        "INSERT INTO onboarding_state (item_id, state, at, source) VALUES (?, ?, ?, ?) \
+         ON CONFLICT(item_id) DO UPDATE SET \
+             state  = excluded.state, \
+             at     = excluded.at, \
+             source = excluded.source \
+         WHERE onboarding_state.state IN ('unchecked', 'auto_checked')",
+    )
+    .bind(item_id)
+    .bind(state)
+    .bind(&now)
+    .bind(source)
+    .execute(pool)
+    .await?;
+
+    Ok(if result.rows_affected() > 0 {
+        UpsertOutcome::Written
+    } else {
+        UpsertOutcome::SkippedSettled
+    })
+}
+
+/// Insert a row only if `item_id` has none yet; a no-op otherwise. Used
+/// exclusively by lazy first-activation seeding (`onboarding.state.get`'s
+/// first-ever call): every already-present row — regardless of its state —
+/// is left completely untouched, so this can run on every read without ever
+/// silently re-deriving or auto-ticking an existing item.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn insert_if_missing(
+    pool: &SqlitePool,
+    item_id: &str,
+    state: &str,
+    source: &str,
+) -> DbResult<()> {
+    let now = Timestamp::now_iso();
+    sqlx::query(
+        "INSERT INTO onboarding_state (item_id, state, at, source) VALUES (?, ?, ?, ?) \
+         ON CONFLICT(item_id) DO NOTHING",
+    )
+    .bind(item_id)
+    .bind(state)
+    .bind(&now)
+    .bind(source)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// True when no item row is `unchecked` (every registered item is
+/// `auto_checked`/`manually_checked`/`dismissed`, or unregistered rows don't
+/// exist yet). Used by the FR-031 settle path: the caller has already
+/// confirmed all registry items have a row before relying on this.
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn all_items_settled(pool: &SqlitePool) -> DbResult<bool> {
+    let unchecked_count: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM onboarding_state WHERE state = 'unchecked'")
+            .fetch_one(pool)
+            .await?;
+    Ok(unchecked_count == 0)
+}
+
+// ── Milestone queries (seed/restore derivation, FR-014) ──────────────────────
+//
+// Read-only checks against real domain tables. These back the item
+// registry's `seed_query` in `app_core::onboarding` (research R4's verified
+// auto-tick inventory) — kept here, not in app-core, per the db-boundary
+// rule (all raw SQL lives in this crate).
+
+/// At least one inbox item is currently confirmed (`inventory.confirmed`
+/// milestone; `inbox.confirm_first`).
+///
+/// Checks `inbox_items.state` rather than `inbox_plan_links` (whose rows are
+/// deleted once a plan resolves — apply/discard/fail/cancel — so it cannot
+/// answer "was anything ever confirmed"). `plan_open`/`resolved` are the
+/// post-confirm states; a discarded plan reverts its item to `classified`
+/// (`plan_listener.rs::handle_plan_discarded`), which correctly un-derives
+/// the milestone if it was the only confirm — restore reflects *current*
+/// recorded state, not historical audit trail (FR-014).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn has_confirmed_inbox_item(pool: &SqlitePool) -> DbResult<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM inbox_items WHERE state IN ('plan_open', 'resolved'))",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(exists)
+}
+
+/// At least one plan has finished applying, fully or partially
+/// (`plan.applying.completed` milestone; `inbox.apply_first_plan`).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn has_applied_plan(pool: &SqlitePool) -> DbResult<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM plans WHERE state IN ('applied', 'partially_applied'))",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(exists)
+}
+
+/// At least one project exists (`project.created` milestone;
+/// `projects.create_first`).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn has_project(pool: &SqlitePool) -> DbResult<bool> {
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM projects)").fetch_one(pool).await?;
+    Ok(exists)
+}
+
+/// At least one processing tool has been successfully spawned
+/// (`tool.launch` milestone, `outcome == "spawned"`; `projects.launch_tool`).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn has_spawned_tool_launch(pool: &SqlitePool) -> DbResult<bool> {
+    let exists: bool =
+        sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM tool_launches WHERE outcome = 'spawned')")
+            .fetch_one(pool)
+            .await?;
+    Ok(exists)
+}
+
+/// At least one FITS `OBJECT` value has resolved to a canonical target
+/// (`target.resolved` milestone; `targets.resolve_first`).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn has_resolved_target(pool: &SqlitePool) -> DbResult<bool> {
+    let exists: bool = sqlx::query_scalar(
+        "SELECT EXISTS(SELECT 1 FROM ingest_resolution WHERE state = 'resolved')",
+    )
+    .fetch_one(pool)
+    .await?;
+    Ok(exists)
+}
+
+// ── onboarding_flags ──────────────────────────────────────────────────────────
+
+/// Load the section flags, defaulting to an all-unset row when the singleton
+/// has not been written yet (no row = orientation not done, section not
+/// hidden, sidebar expanded).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn load_flags(pool: &SqlitePool) -> DbResult<OnboardingFlagsRow> {
+    let row: Option<(Option<String>, Option<String>, i64)> = sqlx::query_as(
+        "SELECT orientation_done_at, section_hidden_at, sidebar_collapsed \
+         FROM onboarding_flags WHERE singleton_id = 1",
+    )
+    .fetch_optional(pool)
+    .await?;
+
+    Ok(row.map_or_else(
+        OnboardingFlagsRow::default,
+        |(orientation_done_at, section_hidden_at, sidebar_collapsed)| OnboardingFlagsRow {
+            orientation_done_at,
+            section_hidden_at,
+            sidebar_collapsed: sidebar_collapsed != 0,
+        },
+    ))
+}
+
+/// Overwrite the full flags row (used after every flag transition — mirrors
+/// the guided-flow singleton upsert pattern).
+///
+/// # Errors
+///
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn upsert_flags(pool: &SqlitePool, row: &OnboardingFlagsRow) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO onboarding_flags (singleton_id, orientation_done_at, section_hidden_at, sidebar_collapsed) \
+         VALUES (1, ?, ?, ?) \
+         ON CONFLICT(singleton_id) DO UPDATE SET \
+             orientation_done_at = excluded.orientation_done_at, \
+             section_hidden_at   = excluded.section_hidden_at, \
+             sidebar_collapsed   = excluded.sidebar_collapsed",
+    )
+    .bind(&row.orientation_done_at)
+    .bind(&row.section_hidden_at)
+    .bind(i64::from(row.sidebar_collapsed))
+    .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> SqlitePool {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    // ── onboarding_state ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn load_state_empty_when_no_rows() {
+        let pool = setup().await;
+        assert!(load_state(&pool).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn upsert_inserts_missing_row() {
+        let pool = setup().await;
+        let outcome =
+            upsert_if_unsettled(&pool, "inbox.confirm_first", "unchecked", "seed").await.unwrap();
+        assert_eq!(outcome, UpsertOutcome::Written);
+
+        let row = load_item(&pool, "inbox.confirm_first").await.unwrap().unwrap();
+        assert_eq!(row.state, "unchecked");
+        assert_eq!(row.source, "seed");
+    }
+
+    #[tokio::test]
+    async fn insert_if_missing_creates_absent_row() {
+        let pool = setup().await;
+        insert_if_missing(&pool, "targets.resolve_first", "auto_checked", "seed").await.unwrap();
+        let row = load_item(&pool, "targets.resolve_first").await.unwrap().unwrap();
+        assert_eq!(row.state, "auto_checked");
+    }
+
+    #[tokio::test]
+    async fn insert_if_missing_never_touches_existing_row() {
+        let pool = setup().await;
+        upsert_if_unsettled(&pool, "targets.resolve_first", "unchecked", "seed").await.unwrap();
+        // A stale re-derivation attempt (e.g. a repeat lazy-seed call) must
+        // not flip this to auto_checked even though the milestone is met.
+        insert_if_missing(&pool, "targets.resolve_first", "auto_checked", "seed").await.unwrap();
+        assert_eq!(
+            load_item(&pool, "targets.resolve_first").await.unwrap().unwrap().state,
+            "unchecked"
+        );
+    }
+
+    #[tokio::test]
+    async fn upsert_overwrites_unchecked_row() {
+        let pool = setup().await;
+        upsert_if_unsettled(&pool, "inbox.confirm_first", "unchecked", "seed").await.unwrap();
+        let outcome = upsert_if_unsettled(&pool, "inbox.confirm_first", "auto_checked", "event")
+            .await
+            .unwrap();
+        assert_eq!(outcome, UpsertOutcome::Written);
+
+        let row = load_item(&pool, "inbox.confirm_first").await.unwrap().unwrap();
+        assert_eq!(row.state, "auto_checked");
+        assert_eq!(row.source, "event");
+    }
+
+    #[tokio::test]
+    async fn upsert_overwrites_auto_checked_row() {
+        let pool = setup().await;
+        upsert_if_unsettled(&pool, "targets.resolve_first", "auto_checked", "event").await.unwrap();
+        // Restore re-derives auto_checked items too (e.g. re-affirming with a
+        // fresh timestamp/source=seed).
+        let outcome = upsert_if_unsettled(&pool, "targets.resolve_first", "auto_checked", "seed")
+            .await
+            .unwrap();
+        assert_eq!(outcome, UpsertOutcome::Written);
+        assert_eq!(
+            load_item(&pool, "targets.resolve_first").await.unwrap().unwrap().source,
+            "seed"
+        );
+    }
+
+    #[tokio::test]
+    async fn upsert_never_downgrades_manually_checked_row() {
+        let pool = setup().await;
+        upsert_if_unsettled(&pool, "sessions.review_first", "manually_checked", "user")
+            .await
+            .unwrap();
+
+        // A live event trying to tick it, and a restore trying to re-derive
+        // it to unchecked, both must be no-ops.
+        let event_outcome =
+            upsert_if_unsettled(&pool, "sessions.review_first", "auto_checked", "event")
+                .await
+                .unwrap();
+        let restore_outcome =
+            upsert_if_unsettled(&pool, "sessions.review_first", "unchecked", "seed").await.unwrap();
+
+        assert_eq!(event_outcome, UpsertOutcome::SkippedSettled);
+        assert_eq!(restore_outcome, UpsertOutcome::SkippedSettled);
+
+        let row = load_item(&pool, "sessions.review_first").await.unwrap().unwrap();
+        assert_eq!(row.state, "manually_checked");
+        assert_eq!(row.source, "user");
+    }
+
+    #[tokio::test]
+    async fn upsert_never_downgrades_dismissed_row() {
+        let pool = setup().await;
+        upsert_if_unsettled(&pool, "calibration.review_masters", "dismissed", "user")
+            .await
+            .unwrap();
+        let outcome =
+            upsert_if_unsettled(&pool, "calibration.review_masters", "auto_checked", "event")
+                .await
+                .unwrap();
+        assert_eq!(outcome, UpsertOutcome::SkippedSettled);
+        assert_eq!(
+            load_item(&pool, "calibration.review_masters").await.unwrap().unwrap().state,
+            "dismissed"
+        );
+    }
+
+    #[tokio::test]
+    async fn all_items_settled_true_when_no_unchecked_rows() {
+        let pool = setup().await;
+        assert!(all_items_settled(&pool).await.unwrap(), "empty table has no unchecked rows");
+
+        upsert_if_unsettled(&pool, "inbox.confirm_first", "auto_checked", "event").await.unwrap();
+        assert!(all_items_settled(&pool).await.unwrap());
+
+        upsert_if_unsettled(&pool, "sessions.review_first", "unchecked", "seed").await.unwrap();
+        assert!(!all_items_settled(&pool).await.unwrap());
+    }
+
+    // ── Milestone queries ────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn has_confirmed_inbox_item_false_until_confirmed() {
+        let pool = setup().await;
+        assert!(!has_confirmed_inbox_item(&pool).await.unwrap());
+
+        sqlx::query(
+            "INSERT INTO inbox_items \
+                (id, root_id, relative_path, file_count, discovered_at, last_scanned_at, \
+                 state, lane) \
+             VALUES ('item-1', 'root-1', 'a.fits', 1, '2026-07-18T00:00:00Z', \
+                     '2026-07-18T00:00:00Z', 'plan_open', 'fits')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(has_confirmed_inbox_item(&pool).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn has_confirmed_inbox_item_false_after_discard_reverts_only_item() {
+        let pool = setup().await;
+        sqlx::query(
+            "INSERT INTO inbox_items \
+                (id, root_id, relative_path, file_count, discovered_at, last_scanned_at, \
+                 state, lane) \
+             VALUES ('item-1', 'root-1', 'a.fits', 1, '2026-07-18T00:00:00Z', \
+                     '2026-07-18T00:00:00Z', 'classified', 'fits')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(
+            !has_confirmed_inbox_item(&pool).await.unwrap(),
+            "classified-only is not confirmed"
+        );
+    }
+
+    #[tokio::test]
+    async fn has_applied_plan_true_only_for_applied_states() {
+        let pool = setup().await;
+        assert!(!has_applied_plan(&pool).await.unwrap());
+
+        sqlx::query(
+            "INSERT INTO plans \
+                (id, number, title, origin, state, plan_type, destructive_destination, \
+                 items_total, items_applied, items_failed, items_skipped, items_cancelled, \
+                 items_pending, total_bytes_required, created_at) \
+             VALUES ('plan-1', 1, 'Test', 'cleanup', 'applied', 'cleanup', 'archive', \
+                     0, 0, 0, 0, 0, 0, 0, '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(has_applied_plan(&pool).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn has_project_true_once_any_project_exists() {
+        let pool = setup().await;
+        assert!(!has_project(&pool).await.unwrap());
+
+        sqlx::query(
+            "INSERT INTO projects (id, name, tool, lifecycle, path, channel_drift, is_mosaic, created_at, updated_at) \
+             VALUES ('proj-1', 'Proj 1', 'PixInsight', 'setup_incomplete', 'proj-1', 0, 0, \
+                     '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        assert!(has_project(&pool).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn has_spawned_tool_launch_ignores_non_spawned_outcomes() {
+        let pool = setup().await;
+        sqlx::query(
+            "INSERT INTO tool_launches (id, project_id, tool_id, launched_at, outcome, audit_id) \
+             VALUES ('launch-1', 'proj-1', 'pixinsight', '2026-07-18T00:00:00Z', 'spawn_failed', 'audit-1')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert!(!has_spawned_tool_launch(&pool).await.unwrap());
+
+        sqlx::query(
+            "INSERT INTO tool_launches (id, project_id, tool_id, launched_at, outcome, audit_id) \
+             VALUES ('launch-2', 'proj-1', 'pixinsight', '2026-07-18T00:00:01Z', 'spawned', 'audit-2')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert!(has_spawned_tool_launch(&pool).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn has_resolved_target_true_only_when_state_resolved() {
+        let pool = setup().await;
+        sqlx::query(
+            "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
+             VALUES ('root-1', 'Root', '/lib', 'local', 'active', '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO file_record (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
+             VALUES ('file-1', 'root-1', 'a.fits', 100, '2026-07-18T00:00:00Z', 'observed', \
+                     '2026-07-18T00:00:00Z', '2026-07-18T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO ingest_resolution (id, image_id, object_raw, state, target_id, attempts) \
+             VALUES ('ir-1', 'file-1', 'M 31', 'pending', NULL, 0)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        assert!(!has_resolved_target(&pool).await.unwrap());
+
+        sqlx::query("UPDATE ingest_resolution SET state = 'resolved' WHERE id = 'ir-1'")
+            .execute(&pool)
+            .await
+            .unwrap();
+        assert!(has_resolved_target(&pool).await.unwrap());
+    }
+
+    // ── onboarding_flags ─────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn load_flags_defaults_when_no_row_exists() {
+        let pool = setup().await;
+        let flags = load_flags(&pool).await.unwrap();
+        assert!(flags.orientation_done_at.is_none());
+        assert!(flags.section_hidden_at.is_none());
+        assert!(!flags.sidebar_collapsed);
+    }
+
+    #[tokio::test]
+    async fn upsert_flags_roundtrip() {
+        let pool = setup().await;
+        let row = OnboardingFlagsRow {
+            orientation_done_at: Some("2026-07-18T00:00:00Z".to_owned()),
+            section_hidden_at: None,
+            sidebar_collapsed: true,
+        };
+        upsert_flags(&pool, &row).await.unwrap();
+
+        let loaded = load_flags(&pool).await.unwrap();
+        assert_eq!(loaded, row);
+    }
+
+    #[tokio::test]
+    async fn upsert_flags_overwrites_on_conflict() {
+        let pool = setup().await;
+        upsert_flags(
+            &pool,
+            &OnboardingFlagsRow {
+                orientation_done_at: Some("2026-07-18T00:00:00Z".to_owned()),
+                section_hidden_at: Some("2026-07-19T00:00:00Z".to_owned()),
+                sidebar_collapsed: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        // Restore clears section_hidden_at while leaving the rest alone.
+        upsert_flags(
+            &pool,
+            &OnboardingFlagsRow {
+                orientation_done_at: Some("2026-07-18T00:00:00Z".to_owned()),
+                section_hidden_at: None,
+                sidebar_collapsed: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let loaded = load_flags(&pool).await.unwrap();
+        assert!(loaded.section_hidden_at.is_none());
+        assert!(loaded.sidebar_collapsed);
+    }
+
+    // ── guided_flow_state drop (T001) ────────────────────────────────────────
+
+    #[tokio::test]
+    async fn guided_flow_state_table_no_longer_exists() {
+        let pool = setup().await;
+        let err = sqlx::query("SELECT 1 FROM guided_flow_state").fetch_optional(&pool).await;
+        assert!(err.is_err(), "guided_flow_state must be dropped by migration 0069");
+    }
+}

--- a/crates/persistence/db/src/repositories/onboarding.rs
+++ b/crates/persistence/db/src/repositories/onboarding.rs
@@ -647,12 +647,15 @@ mod tests {
         assert!(loaded.sidebar_collapsed);
     }
 
-    // ── guided_flow_state drop (T001) ────────────────────────────────────────
+    // ── guided_flow_state (deliberately NOT dropped by 0069) ────────────────
 
+    /// Orchestrator sequencing decision (run-onb-0718): the drop ships as
+    /// migration 0070 inside the T010 deletion lane, atomically with the
+    /// code that reads/writes this table — not here. See 0069's header.
     #[tokio::test]
-    async fn guided_flow_state_table_no_longer_exists() {
+    async fn guided_flow_state_table_still_exists() {
         let pool = setup().await;
-        let err = sqlx::query("SELECT 1 FROM guided_flow_state").fetch_optional(&pool).await;
-        assert!(err.is_err(), "guided_flow_state must be dropped by migration 0069");
+        let result = sqlx::query("SELECT 1 FROM guided_flow_state").fetch_optional(&pool).await;
+        assert!(result.is_ok(), "guided_flow_state must survive migration 0069");
     }
 }


### PR DESCRIPTION
## Summary
- Adds the data storage, contract types, and domain model foundation for the onboarding wizard (migration, DTOs, repository, domain core)

## Spec Context
- Implements T001-T004 of spec 056 (onboarding redesign)
- Review approved, 0 findings; branch green: 664 lib tests, clippy/fmt/db-boundary clean