### PR TITLE
fix(inbox): approve plan before per-row Apply, thread token through

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -684,9 +684,31 @@ export function InboxPage() {
   // Apply a single ingestion plan with live per-item progress streamed over
   // the long-operation OperationEvent channel (spec 042 US16 / FR-021). This is
   // the end-to-end consumer of the channel contract on the inbox plan surface.
+  //
+  // Issue #769: a freshly-confirmed plan is `ready_for_review` with no
+  // `approval_token` — `plans.apply` unconditionally rejects any plan that
+  // isn't `approved`. Approve it first (same precondition "Apply all" already
+  // satisfies via its own backend command) and thread the returned token
+  // through, otherwise this always fails with `plan.invalid_state` before any
+  // item is touched.
   const handleApplyOne = async (planId: string) => {
     setProgressPlanId(planId);
-    const response = await runPlanApply({ id: planId });
+    let approvalToken: string | undefined;
+    try {
+      approvalToken = unwrap(await commands.plansApprove(planId)).approvalToken;
+    } catch {
+      // runPlanApply (the success path below) resets progress to IDLE on its
+      // own; skipping it here means a stale progressPlanId from a previously
+      // applied plan would otherwise keep pointing a progress display at this
+      // now-failed row.
+      setProgressPlanId(null);
+      addToast({
+        message: m.inbox_plan_apply_failed_toast(),
+        variant: 'error',
+      });
+      return;
+    }
+    const response = await runPlanApply({ id: planId, approvalToken });
     if (response) {
       addToast({ message: m.inbox_plan_applied_toast(), variant: 'info' });
       refreshAll();

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.applyOne.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.applyOne.test.tsx
@@ -1,0 +1,171 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Issues #769 / #609 — per-plan Apply (live progress) must approve the plan
+ * before applying it: a freshly-confirmed plan is `ready_for_review` with no
+ * `approval_token`, and `plans.apply` unconditionally rejects any plan that
+ * isn't `approved`.
+ *
+ * Covers `InboxPage.handleApplyOne`'s two paths:
+ * 1. Success — plans.approve is called BEFORE the apply IPC, and its
+ *    returned token is threaded into the apply call.
+ * 2. Failure — when plans.approve rejects, the apply IPC must NEVER be
+ *    invoked (the old bug always called apply with an empty token and let
+ *    the backend reject it after the fact) and an error toast shows.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageStatusProvider } from '@/app/PageStatusContext';
+import type { InboxOpenPlan } from '@/bindings/index';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <PageStatusProvider>{ui}</PageStatusProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const {
+  mockRootsList,
+  mockInboxList,
+  mockInboxPlanListOpen,
+  mockPlansApprove,
+  mockApplyPlan,
+  mockAddToast,
+} = vi.hoisted(() => ({
+  mockRootsList: vi.fn(),
+  mockInboxList: vi.fn(),
+  mockInboxPlanListOpen: vi.fn(),
+  mockPlansApprove: vi.fn(),
+  mockApplyPlan: vi.fn(),
+  mockAddToast: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    rootsList: mockRootsList,
+    inboxList: mockInboxList,
+    inboxPlanListOpen: mockInboxPlanListOpen,
+    plansApprove: mockPlansApprove,
+  },
+}));
+
+// usePlanApplyProgress drives `applyPlan` (features/plans/planApply.ts), which
+// bridges a Tauri `Channel`; mock the wrapper directly (same seam
+// PlanReviewOverlay.test.tsx uses) instead of dealing with the Channel ctor.
+vi.mock('@/features/plans/planApply', () => ({
+  applyPlan: mockApplyPlan,
+}));
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({ selected: undefined, type: undefined }),
+}));
+
+vi.mock('@/shared/toast', () => ({
+  addToast: mockAddToast,
+  useToasts: () => ({ toasts: [], dismiss: vi.fn() }),
+}));
+
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+const openPlan: InboxOpenPlan = {
+  inboxItemId: 'item-plan-001',
+  itemName: 'lights/NGC7000',
+  planId: 'plan-001',
+  state: 'ready_for_review',
+  stale: false,
+  actions: [
+    {
+      index: 1,
+      action: 'move',
+      fromPath: 'lights/NGC7000/frame_001.fits',
+      toPath: 'M31/light/frame_001.fits',
+      destinationPreview: 'M31/light/frame_001.fits',
+      requiresDestructiveConfirm: false,
+    },
+  ],
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRootsList.mockResolvedValue(ok([]));
+  mockInboxList.mockResolvedValue(ok({ items: [], capped: false, limit: 500 }));
+  mockInboxPlanListOpen.mockResolvedValue(
+    ok({ plans: [openPlan], totalActions: 1 }),
+  );
+});
+
+import { InboxPage } from '../InboxPage';
+
+async function openOverlayAndClickApply() {
+  render(<InboxPage />);
+  const reviewBtn = await screen.findByTestId('inbox-review-plans-btn');
+  fireEvent.click(reviewBtn);
+  const applyBtn = await screen.findByTestId(
+    `plan-apply-one-${openPlan.inboxItemId}`,
+  );
+  fireEvent.click(applyBtn);
+}
+
+describe('InboxPage.handleApplyOne — approve before apply (#769, #609)', () => {
+  it('approves the plan before applying it and threads the token through', async () => {
+    mockPlansApprove.mockResolvedValue(
+      ok({
+        planId: openPlan.planId,
+        newState: 'approved',
+        approvalToken: 'tok-abc',
+        approvedAt: '2026-07-17T00:00:00Z',
+      }),
+    );
+    mockApplyPlan.mockResolvedValue({
+      results: [{ inboxItemId: openPlan.inboxItemId, planId: openPlan.planId }],
+    });
+
+    await openOverlayAndClickApply();
+
+    await waitFor(() => expect(mockApplyPlan).toHaveBeenCalled());
+
+    // approve must run BEFORE apply, and the returned token must be threaded
+    // into the apply call.
+    const approveOrder = mockPlansApprove.mock.invocationCallOrder[0];
+    const applyOrder = mockApplyPlan.mock.invocationCallOrder[0];
+    expect(approveOrder).toBeLessThan(applyOrder);
+    expect(mockPlansApprove).toHaveBeenCalledWith(openPlan.planId);
+    expect(mockApplyPlan).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: openPlan.planId,
+        approvalToken: 'tok-abc',
+      }),
+    );
+  });
+
+  it('never calls apply and shows an error toast when approve fails', async () => {
+    mockPlansApprove.mockRejectedValue(new Error('plan.invalid_state'));
+
+    await openOverlayAndClickApply();
+
+    await waitFor(() => expect(mockPlansApprove).toHaveBeenCalled());
+    // Give any (incorrect) apply call a chance to fire before asserting absence.
+    await new Promise((r) => setTimeout(r, 0));
+
+    expect(mockApplyPlan).not.toHaveBeenCalled();
+    expect(mockAddToast).toHaveBeenCalledWith(
+      expect.objectContaining({ variant: 'error' }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Per-row plan Apply (live progress) never approved the plan before calling `plans.apply`, which unconditionally rejects any plan not in the `approved` state -- every per-row Apply failed with a generic "0 applied, 0 failed" while "Apply all" (a separate, self-approving command) succeeded on the same plan.
- `handleApplyOne` now calls `plans.approve` first, resets stale progress state (`progressPlanId`) if that fails, and threads the returned `approvalToken` through to `runPlanApply`.
- Adds vitest coverage for both paths: approve-then-apply token threading, and approve-failure short-circuiting before any apply call.

Salvaged from abandoned PR #1025 (branch `coder-g-inbox-apply`), which bundled this fix with unrelated #644/#643 refactors. This PR isolates only the approve-before-apply fix and ports it onto clean `main`, adapted to main's current (pre-#644/#643) `handleApplyOne`/`InboxPage` shape.

Fixes #769
Fixes #609

## Test plan
- [x] `pnpm test` -- new `InboxPage.applyOne.test.tsx` (2 tests) green; full desktop suite otherwise green (1 pre-existing unrelated flaky timing test in `GuidedOverlay.test.tsx`)
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (0 errors; pre-existing warnings only, none in touched files)

## Spec Context
- Spec: 769
- Branch: salvage/769-inbox-approve-before-apply