### PR TITLE
fix(inbox): plan-approval overlay never stuck open on empty content

### DIFF
--- a/apps/desktop/src/features/inbox/PlanApprovalOverlay.tsx
+++ b/apps/desktop/src/features/inbox/PlanApprovalOverlay.tsx
@@ -10,6 +10,21 @@
  * single scroll inside the modal body (no plan-switcher rail) — each plan is a
  * collapsible group with a per-file action table. Applying the last plan
  * auto-closes the overlay.
+ *
+ * Issue #767: the Modal's `open` is DERIVED as `open && hasContent` rather
+ * than passed straight through. The previous version relied solely on an
+ * effect that watched `plans.length` and asked the CALLER to flip its own
+ * `open` state closed AFTER the render that first shows the emptied body — a
+ * two-render sequence (one render shows the dialog still open over an empty
+ * body, a later render finally closes it). Anything that stalls between those
+ * two renders (a deferred effect, a caller re-render that doesn't land in
+ * time) leaves the dialog stuck open with nothing left to dismiss it — Escape
+ * / ✕ / backdrop only re-invoke the very `onClose` that already fired.
+ * Deriving `visible` collapses both signals into the SAME render: the dialog
+ * can never be visually open while it has nothing to show. The effect below
+ * still calls `onClose` so the caller's own `open` flag resets — otherwise a
+ * later plan re-populating `plans` while the caller's stale `open` is still
+ * true would silently resurrect the overlay without a fresh trigger click.
  */
 
 import { useEffect } from 'react';
@@ -32,14 +47,21 @@ export function PlanApprovalOverlay({
   onClose,
   plans,
   totalActions,
+  pendingRootPick = null,
   ...rest
 }: PlanApprovalOverlayProps) {
-  // Auto-close when the last plan is applied/cancelled.
+  // A pending destination-root pick can leave `plans` empty (the plan hasn't
+  // been generated yet) while the overlay still has real content — the
+  // picker itself — to show, so it counts as content too.
+  const hasContent = plans.length > 0 || pendingRootPick != null;
+  const visible = open && hasContent;
+
+  // Reset the caller's `open` flag once content disappears (see file header).
   useEffect(() => {
-    if (open && plans.length === 0) {
+    if (open && !hasContent) {
       onClose();
     }
-  }, [open, plans.length, onClose]);
+  }, [open, hasContent, onClose]);
 
   const subtitle =
     plans.length > 0
@@ -48,7 +70,7 @@ export function PlanApprovalOverlay({
 
   return (
     <Modal
-      open={open}
+      open={visible}
       onClose={onClose}
       title={m.inbox_review_plans_title()}
       subtitle={subtitle}
@@ -56,7 +78,12 @@ export function PlanApprovalOverlay({
       ariaLabel={m.inbox_review_plans_title()}
       data-testid="plan-approval-overlay"
     >
-      <PlanPanel plans={plans} totalActions={totalActions} {...rest} />
+      <PlanPanel
+        plans={plans}
+        totalActions={totalActions}
+        pendingRootPick={pendingRootPick}
+        {...rest}
+      />
     </Modal>
   );
 }

--- a/apps/desktop/src/features/inbox/__tests__/PlanApprovalOverlay.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/PlanApprovalOverlay.test.tsx
@@ -182,5 +182,41 @@ describe('PlanApprovalOverlay', () => {
       );
     });
     expect(onClose).toHaveBeenCalled();
+    // Issue #767: the dialog itself must not remain visible over an empty
+    // body even in this same render, regardless of whether the CALLER has
+    // yet reacted to `onClose` by flipping its own `open` prop back to
+    // false — `open` is deliberately left `true` above to reproduce that
+    // exact stuck window.
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  // Issue #767: a caller passing a STATIC `open=true` with empty content
+  // (the precise "stuck open, empty body" report — Escape/✕/backdrop all
+  // re-invoke an `onClose` the caller never acts on in time) must never
+  // render a visible dialog. This is deliberately NOT a rerender: it checks
+  // the very first render, before any effect has a chance to run, so it
+  // cannot be masked by React/act() batching an effect-driven close into the
+  // same flush (which is what let a passing-but-vacuous mock-e2e test
+  // through previously).
+  it('issue #767: never shows a visible dialog when open=true but there is no content', () => {
+    renderOverlay({ plans: [], open: true, onClose });
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    expect(screen.queryByText('Review plans')).toBeNull();
+  });
+
+  // A pending destination-root pick is real content (the picker itself) even
+  // though `plans` is still empty — the dialog must stay visible for it.
+  it('issue #767: stays visible for a pending root pick even with empty plans', () => {
+    renderOverlay({
+      plans: [],
+      open: true,
+      onClose,
+      pendingRootPick: {
+        category: 'light_frames',
+        candidates: [{ rootId: 'root-1', path: '/lights', kind: 'library' }],
+      },
+    });
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByTestId('inbox-root-picker')).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -661,8 +661,13 @@ export function useOpenInboxPlans() {
         if (!cancelled) setState({ data: resp, loading: false, error: null });
       })
       .catch((e: unknown) => {
+        // Issue #767: keep the last-known plans on a transient refetch error
+        // instead of clobbering `data` to null. The 1s poll while the review
+        // overlay is open (InboxPage) treats a null/empty `data` exactly like
+        // "every plan applied" and auto-closes — a single dropped poll tick
+        // must not be mistaken for that.
         if (!cancelled)
-          setState({ data: null, loading: false, error: String(e) });
+          setState((s) => ({ data: s.data, loading: false, error: String(e) }));
       });
     return () => {
       cancelled = true;

--- a/tests/e2e/inbox_ingest_confirm.spec.ts
+++ b/tests/e2e/inbox_ingest_confirm.spec.ts
@@ -277,6 +277,31 @@ test.describe("inbox ingest · classify / reclassify / confirm (spec 041)", () =
 		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
 	});
 
+	test("issue #767: Apply all empties the plan list and the overlay auto-closes (not stuck open with an empty body)", async ({
+		page,
+	}) => {
+		seedSetupComplete(page);
+		await page.goto("/#/inbox");
+		await disableGuidedTourOverlay(page);
+		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+
+		const reviewBtn = page.getByTestId("inbox-review-plans-btn");
+		await expect(reviewBtn).toBeVisible({ timeout: 8_000 });
+		await reviewBtn.click();
+
+		const overlay = page.getByTestId("plan-approval-overlay");
+		await expect(overlay).toBeVisible({ timeout: 5_000 });
+
+		await overlay.getByTestId("plan-apply-all").click();
+
+		// The overlay auto-closes once every plan is applied — it must NOT be
+		// left open with an empty body (issue #767).
+		await expect(overlay).not.toBeVisible({ timeout: 5_000 });
+		await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+
+		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+	});
+
 	test("catalogue-in-place plan is distinguishable from a move plan in the review overlay (US4 FR-017/FR-018/SC-007)", async ({
 		page,
 	}) => {


### PR DESCRIPTION
## Summary
- `PlanApprovalOverlay` now derives the Modal's `open` as `open && hasContent` in the same render instead of relying solely on an effect to close it a render later once `plans` emptied — the two-render gap could leave the dialog stuck open over an empty body with Escape/close/backdrop only re-invoking an `onClose` that already fired.
- A pending destination-root pick counts as content too, so the root-picker itself isn't hidden while `plans` is still empty.
- `useOpenInboxPlans` (store.ts) no longer clobbers cached `data` to null on a single dropped poll tick while the review overlay is open — that false-empty signal fed the same premature auto-close.
- Adds unit test coverage (`PlanApprovalOverlay.test.tsx`) and an e2e regression (`tests/e2e/inbox_ingest_confirm.spec.ts`) for "Apply all empties the plan list" auto-closing cleanly.

Fixes #767

Salvaged out of abandoned PR #1025 (commit `51d48efb`), which bundled #767 together with unrelated #605/#606/#744 work. This PR ports **only** the #767 slice, rebased onto current `main` (`47e7d8c5`). The `pendingRootPick` plumbing #1025 also touched already exists on `main` (merged separately), so no `PlanPanel.tsx` changes were needed here.

## Test plan
- [x] `vitest run` on `PlanApprovalOverlay.test.tsx` / `PlanPanel.test.tsx` / `PlanReviewOverlay.test.tsx` — green
- [x] `tsc --noEmit` (desktop app) — clean
- [x] `biome check` on touched files — clean (0 errors)
- [x] `eslint` on touched files — 0 errors (2 pre-existing warnings in store.ts, unrelated lines)