### PR TITLE
fix(inbox): show a "Plan pending review" chip on plan_open rows

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1552,6 +1552,7 @@
   "inbox_state_pending": "pending",
   "inbox_state_plan_open": "plan open",
   "inbox_state_resolved": "resolved",
+  "inbox_row_plan_pending": "Plan pending review",
   "inbox_sort_detection_aria": "Sort by Path",
   "inbox_sort_type_aria": "Sort by Type",
   "inbox_sort_files_aria": "Sort by Files",

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -27,6 +27,7 @@ import {
   Table,
   tableIndent,
   Skeleton,
+  Pill,
   type TableColumn,
   type TableRow,
 } from '@/ui';
@@ -453,8 +454,28 @@ export function InboxList({
           _selected: selected,
           _indent: indent || undefined,
           detection: (
-            <span className="alm-inbox-cell__path" title={detectionLabel(item)}>
-              {detectionLabel(item)}
+            <span className="alm-inbox-cell__path-wrap">
+              <span
+                className="alm-inbox-cell__path"
+                title={detectionLabel(item)}
+              >
+                {detectionLabel(item)}
+              </span>
+              {/* Issue #605: an in-context hint that Confirm already created a
+                  reviewable plan — the Type column keeps showing the item's
+                  dominant frame type (classificationLabel checks frameType
+                  before state), so without this the row looks unchanged and
+                  reads as "my confirm did nothing". Additive: no action
+                  needed here, "Review plans" in the top bar remains the one
+                  place to act on it. */}
+              {item.state === 'plan_open' && (
+                <Pill
+                  variant="info"
+                  data-testid={`inbox-item-plan-pending-${item.inboxItemId}`}
+                >
+                  {m.inbox_row_plan_pending()}
+                </Pill>
+              )}
             </span>
           ),
           type: (

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx
@@ -104,4 +104,53 @@ describe('InboxList — classification label + path column (#550/#556)', () => {
     expect(screen.getByText('DetectionMatrix')).toBeInTheDocument();
     expect(screen.queryByText('(root)')).not.toBeInTheDocument();
   });
+
+  // #605: Confirm creates a plan but the row previously gave no visible sign
+  // of it — the Type column keeps showing the item's dominant frame type
+  // (frameType is checked before `state` in classificationLabel), so a
+  // plan_open item looked byte-for-byte identical to one still awaiting
+  // confirm. A "Plan pending review" chip on the row is the additive fix.
+  it('(#605) a plan_open item shows a "Plan pending review" chip alongside its frame type', () => {
+    const items = [
+      makeItem({
+        inboxItemId: 'has-plan',
+        state: 'plan_open',
+        frameType: 'dark',
+      }),
+    ];
+    render(
+      <InboxList
+        items={items}
+        selectedIdx={null}
+        onSelect={vi.fn()}
+        filterType="all"
+      />,
+    );
+    // The Type column is unchanged (still "dark") — the chip is additive.
+    expect(screen.getByText('dark')).toBeInTheDocument();
+    expect(
+      screen.getByTestId('inbox-item-plan-pending-has-plan'),
+    ).toHaveTextContent('Plan pending review');
+  });
+
+  it('(#605) a classified item with no open plan shows no chip', () => {
+    const items = [
+      makeItem({
+        inboxItemId: 'no-plan',
+        state: 'classified',
+        frameType: 'dark',
+      }),
+    ];
+    render(
+      <InboxList
+        items={items}
+        selectedIdx={null}
+        onSelect={vi.fn()}
+        filterType="all"
+      />,
+    );
+    expect(
+      screen.queryByTestId('inbox-item-plan-pending-no-plan'),
+    ).not.toBeInTheDocument();
+  });
 });

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -95,6 +95,21 @@
   font-weight: 500;
   color: var(--alm-text);
 }
+/* Issue #605: path + the "Plan pending review" chip on one line — the path
+   shrinks/ellipses first, the chip (fixed content) never wraps or clips. */
+.alm-inbox-cell__path-wrap {
+  display: flex;
+  align-items: center;
+  gap: var(--alm-sp-2);
+  min-width: 0;
+}
+.alm-inbox-cell__path-wrap .alm-inbox-cell__path {
+  min-width: 0;
+  flex-shrink: 1;
+}
+.alm-inbox-cell__path-wrap .alm-pill {
+  flex-shrink: 0;
+}
 .alm-inbox-table__row {
   cursor: pointer;
 }


### PR DESCRIPTION
## Summary
- Fixes #605: Confirm silently creates a reviewable plan for a `plan_open`
  item, but the Type column keeps showing the item's dominant frame type
  (`frameType` is checked before `state` in `classificationLabel`), so the
  row looked unchanged with no in-context feedback.
- Adds an additive `Pill` (shared component, `variant="info"`) next to the
  path cell reading "Plan pending review"; "Review plans" in the top bar
  remains the one place to act on it.

Salvaged from the abandoned PR #1025, which bundled #605 together with
#767/#606/#744. Only the #605 slice (InboxList.tsx pill, en.json string,
merges-2.css layout, and the InboxList.classificationAndPath test) is
included here; the other issues are intentionally excluded and remain open
for separate salvage.

Note: the pill regression test was added to
`InboxList.classificationAndPath.test.tsx` (where the #1025 commit actually
put it), not `InboxList.grouping.test.tsx`.

## Test plan
- [x] `vitest run src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx` — 5/5 pass
- [x] `eslint` + `biome check` on touched `.ts`/`.tsx` — clean
- [x] `tsc --noEmit` — no new errors (pre-existing `baseUrl` deprecation warning unrelated to this change)
- [x] `scripts/check-tokens.sh` — passes (no raw CSS values/legacy tokens introduced)