### PR TITLE
test(e2e): stabilize archive trash journey on headless Windows CI

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1660,6 +1660,17 @@ fn spawn_tauri_webdriver(env: &InstanceEnv) -> Result<(Child, ProcLog)> {
         // times out). Real users/non-e2e builds never set this, so the guard
         // stays active for them.
         .env("ALM_E2E_INSTANCE_ID", env.native_port.to_string())
+        // OS-trash boundary double for headless CI. The Windows Shell trash
+        // (`trash::delete` -> `IFileOperation`) needs an interactive
+        // window-station/desktop and blocks indefinitely in the non-interactive
+        // CI runner context — verified: a real interactive Windows desktop
+        // trashes on every volume (incl. external + no-Recycle-Bin) in <300ms,
+        // only the headless session hangs. A real Recycle-Bin move is
+        // unperformable here, so the app does a deterministic filesystem
+        // removal instead (see `fs_executor::ops::trash_op`), matching the
+        // FakeSpawner/FakeResolver boundary pattern. Production/live never sets
+        // this and always uses real OS trash.
+        .env("ALM_E2E_OS_TRASH_FAKE", "1")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
     for (key, value) in &env.vars {

--- a/crates/fs/executor/src/ops/trash_op.rs
+++ b/crates/fs/executor/src/ops/trash_op.rs
@@ -53,6 +53,28 @@ pub fn trash_file(
     path: &Utf8Path,
     fallback_archive_dest: Option<&Utf8Path>,
 ) -> Result<TrashResult, (PlanItemFailure, TrashResult)> {
+    // E2E boundary double. The OS Shell trash needs an interactive
+    // window-station/desktop; on the headless CI runner `trash::delete`
+    // (`IFileOperation::PerformOperations` on Windows) blocks forever. A real
+    // Recycle-Bin move is unperformable there, so under the e2e harness env we
+    // remove the file deterministically — the observable side effect the
+    // real-UI journeys assert (the file leaves the archive subtree) is
+    // identical, and the real OS-trash primitive stays covered by the Layer-1
+    // unit tests below and by live use. Only the e2e harness sets this var
+    // (`crates/e2e-tests/tests/common/mod.rs`); production/release never does.
+    if std::env::var_os("ALM_E2E_OS_TRASH_FAKE").is_some() {
+        return match std::fs::remove_file(path) {
+            Ok(()) => Ok(TrashResult { destination_used: "trash", ..TrashResult::default() }),
+            Err(e) => Err((
+                PlanItemFailure::with_code(
+                    FailureCode::TrashUnavailable,
+                    format!("e2e fake-trash removal failed for '{path}': {e}"),
+                ),
+                TrashResult::default(),
+            )),
+        };
+    }
+
     match trash::delete(path) {
         Ok(()) => Ok(TrashResult { destination_used: "trash", ..TrashResult::default() }),
         Err(trash_err) => {


### PR DESCRIPTION
## Problem

The real-UI E2E `archive_lifecycle_apply_trash_permanent_delete` fails on **Windows only** — it hangs (`execute_async` script timeout, ~180s per retry) on shard `windows-latest 1/2`, while passing on ubuntu in ~34s. It regressed in #883 (`6b9ee91a`, 2026-07-15), which replaced the metadata-only trash stub (#732) with a real `trash::delete`.

## Root cause

`archive.send_to_trash` → `trash_op::trash_file` → `trash::delete`. On Windows that is the Shell COM path (`IFileOperation::PerformOperations`), which needs an **interactive window-station/desktop**. The non-interactive CI runner session lacks one, so the call blocks forever and the webview `execute_async` bridge times out. Linux uses the pure-filesystem XDG trash (no COM), which is why ubuntu passes.

## Verified: this is a headless-CI artifact, not a live bug

Reproduced the exact call pattern (`trash 5.2`, default STA, no-message-pump background thread) on a **real interactive Windows desktop**:

| Volume | Recycle Bin? | Result |
|---|---|---|
| `C:` | yes | Ok, ~100–280 ms |
| `D:` (external) | yes | Ok, 36 ms |
| `Z:` (subst, no bin) | no | Ok, 33 ms |

Trash succeeds on every volume including external + no-Recycle-Bin. So **production/live behavior is correct and stays on real OS trash** — only the headless CI session can't perform it.

## Fix

Gate `trash_op::trash_file` on `ALM_E2E_OS_TRASH_FAKE` (set only by the e2e harness in `crates/e2e-tests/tests/common/mod.rs`) to remove the file deterministically instead of invoking the Shell. This matches the repo's existing boundary-double pattern (FakeSpawner/FakeResolver) — the OS Shell is an external boundary that can't run headless. The observable side effect the journey asserts (the file leaves the archive subtree) is identical; the real `trash::delete` primitive stays covered by the Layer-1 unit tests in `trash_op.rs` and by live use. Production/release never sets the var.

## Verification

- `cargo test -p fs_executor` green locally (18/18; real-trash path unchanged).
- The Windows Real-UI E2E on this PR is the confirmation: green there proves `trash::delete` was the exact hang and the double resolves it.