### PR TITLE
fix: plan-apply progress no longer stalls after resuming a paused run

### DIFF
--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -32,6 +32,7 @@ const {
   mockPlansDiscard,
   mockPlansRetry,
   mockPlansResume,
+  mockPlansApplyStatus,
   mockPlansCancel,
   mockPlansConfirmDestructive,
   mockProtectionCheck,
@@ -43,6 +44,7 @@ const {
   mockPlansDiscard: vi.fn(),
   mockPlansRetry: vi.fn(),
   mockPlansResume: vi.fn(),
+  mockPlansApplyStatus: vi.fn(),
   mockPlansCancel: vi.fn(),
   mockPlansConfirmDestructive: vi.fn(),
   mockProtectionCheck: vi.fn(),
@@ -57,6 +59,7 @@ vi.mock('@/bindings/index', () => ({
     plansDiscard: mockPlansDiscard,
     plansRetry: mockPlansRetry,
     plansResume: mockPlansResume,
+    plansApplyStatus: mockPlansApplyStatus,
     plansCancel: mockPlansCancel,
     plansConfirmDestructive: mockPlansConfirmDestructive,
     planProtectionCheckCmd: mockProtectionCheck,
@@ -457,7 +460,42 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
         resumedAt: '2026-07-09T00:00:00Z',
       }),
     );
+    // Issue #575 fix + #744 FR-002: `plan.resume` re-spawns the executor but
+    // returns no event channel, so this hook polls `plans.apply.status`
+    // instead. First tick: still applying. Second: done.
+    let statusCall = 0;
+    mockPlansApplyStatus.mockImplementation(() => {
+      statusCall += 1;
+      return Promise.resolve(
+        ok(
+          statusCall === 1
+            ? {
+                planId: 'plan-1',
+                runId: 'run-1',
+                planState: 'applying',
+                itemsTotal: 2,
+                itemsApplied: 1,
+                itemsFailed: 0,
+                itemsSkipped: 0,
+                itemsCancelled: 0,
+                itemsPending: 1,
+              }
+            : {
+                planId: 'plan-1',
+                runId: 'run-1',
+                planState: 'applied',
+                itemsTotal: 2,
+                itemsApplied: 2,
+                itemsFailed: 0,
+                itemsSkipped: 0,
+                itemsCancelled: 0,
+                itemsPending: 0,
+              },
+        ),
+      );
+    });
 
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     renderOverlay();
     const approveBtn = await screen.findByTestId('plan-review-approve-apply');
     await waitFor(() => expect(approveBtn).not.toBeDisabled());
@@ -477,16 +515,27 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
       ).not.toBeInTheDocument(),
     );
 
-    // Regression: resume_plan doesn't re-spawn the executor (#575), so no
-    // further events ever arrive on this channel. The UI must not render as
-    // active progress (no "Applying X of Y…", no infinite-busy trap) and
-    // must keep an escape affordance available instead.
-    expect(
-      await screen.findByTestId('plan-review-resume-stalled-badge'),
-    ).toHaveTextContent(/not restarted yet/i);
-    expect(screen.queryByText(/Applying \d+ of \d+/)).not.toBeInTheDocument();
-    expect(screen.getByText('Discard plan')).not.toBeDisabled();
-    expect(screen.getByTestId('plan-review-approve-apply')).not.toBeDisabled();
+    // #744: the run genuinely continues (issue #575 is fixed) — the overlay
+    // now reflects that as real, busy progress instead of a permanent
+    // "stalled" dead end. Discard/Approve are disabled while it runs, same
+    // as any other in-flight apply; Cancel is the live escape hatch.
+    expect(screen.getByTestId('plan-review-cancel-run')).toBeInTheDocument();
+    expect(screen.getByText('Discard plan')).toBeDisabled();
+
+    await waitFor(() =>
+      expect(screen.getByText(/Applying 1 of 2/)).toBeInTheDocument(),
+    );
+
+    await vi.advanceTimersByTimeAsync(1000);
+    // Terminal: the footer syncs to the applied state (Close-only, matching
+    // the approve-and-apply path) instead of leaving a stale Discard/Approve
+    // pair around a plan that already finished applying.
+    await waitFor(() =>
+      expect(screen.getByText('2 items applied')).toBeInTheDocument(),
+    );
+    expect(screen.queryByTestId('plan-review-approve-apply')).toBeNull();
+    expect(screen.getByText('Close')).toBeInTheDocument();
+    vi.useRealTimers();
   });
 
   it('cannot approve a plan with zero items (FR-014)', async () => {

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -476,8 +476,7 @@ export function PlanReviewOverlay({
           {/* Live apply progress (D17 — spec 025 progress UI, absorbed here). */}
           {(progress.running ||
             progress.terminal !== null ||
-            progress.paused ||
-            progress.resumeStalled) && (
+            progress.paused) && (
             <div
               className="alm-plan-review__progress"
               role="status"
@@ -538,14 +537,6 @@ export function PlanReviewOverlay({
                       : m.plans_review_resume_btn()}
                   </Btn>
                 </>
-              )}
-              {progress.resumeStalled && (
-                <Pill
-                  variant="warn"
-                  data-testid="plan-review-resume-stalled-badge"
-                >
-                  {m.plans_review_resume_stalled()}
-                </Pill>
               )}
             </div>
           )}

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -21,7 +21,7 @@
  * inbox multi-plan PlanApprovalOverlay) predate it and remain separate.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { Modal } from '@/components';
 import { Btn, Pill, Banner, Table } from '@/ui';
@@ -155,11 +155,27 @@ export function PlanReviewOverlay({
     }
   }, [planId, queryClient]);
 
+  // #744 FR-002: `handleResume` (below) doesn't await the resumed run's
+  // completion — `usePlanApplyProgress.resume` returns once the poll has
+  // STARTED, not once it reaches a terminal state (unlike `runApply`, which
+  // does await completion). This ref tracks "a resume is in flight" so the
+  // effect below can sync `finalState`/refetch the plan exactly once the
+  // NEXT terminal outcome arrives, without also firing for (and clobbering
+  // the more precise `newState` set by) `handleApproveAndApply`'s own path.
+  const resumeAwaitingTerminal = useRef(false);
+  useEffect(() => {
+    if (!resumeAwaitingTerminal.current || progress.terminal === null) return;
+    resumeAwaitingTerminal.current = false;
+    invalidatePlan();
+    setFinalState(progress.terminal === 'completed' ? 'applied' : 'failed');
+  }, [progress.terminal, invalidatePlan]);
+
   // The overlay must not silently disappear mid-run (constitution II — the
   // apply outcome stays on screen); ignore close requests while busy.
   const handleClose = useCallback(() => {
     if (busy) return;
     resetApply();
+    resumeAwaitingTerminal.current = false;
     setApplyError(null);
     setGateReady(false);
     setFinalState(null);
@@ -249,7 +265,11 @@ export function PlanReviewOverlay({
     setApplyError(null);
     const ok = await resumeApply(planId);
     setResuming(false);
-    if (!ok) setApplyError(m.plans_review_resume_failed());
+    if (ok) {
+      resumeAwaitingTerminal.current = true;
+    } else {
+      setApplyError(m.plans_review_resume_failed());
+    }
   }, [planId, resuming, resumeApply]);
 
   /** Generate a retry plan from this plan's failed items (US5, T037) — the

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.test.tsx
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.test.tsx
@@ -8,7 +8,7 @@
  * hook reduces the streamed Started → per-item → terminal events into a live
  * progress state (item counter + terminal outcome).
  */
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { act, renderHook, waitFor } from '@testing-library/react';
 import type { Channel } from '@tauri-apps/api/core';
 import type { OperationEvent } from '@/bindings/types';
@@ -124,5 +124,109 @@ describe('usePlanApplyProgress', () => {
     expect(response).toBeNull();
     expect(result.current.progress.terminal).toBe('failed');
     expect(result.current.progress.running).toBe(false);
+  });
+
+  // Issue #744 FR-002: `plan.resume` returns no event channel (the run
+  // continues since #575, but nothing streams it), so this hook must POLL
+  // `plans.apply.status` to make a resumed run's progress visible instead of
+  // leaving it permanently invisible.
+  describe('resume (#744 FR-002 status polling)', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it('polls plans.apply.status after resume and reports live + terminal progress', async () => {
+      let statusCall = 0;
+      setInvokeOverride((cmd, args) => {
+        if (cmd === 'plans_apply_real') {
+          const channel = (args as { onEvent?: Channel<OperationEvent> })
+            .onEvent;
+          channel?.onmessage?.(
+            mk(0, 'item_started', { runId: 'run-9', itemsTotal: 5 }),
+          );
+          channel?.onmessage?.(
+            mk(1, 'warning', { runId: 'run-9', pauseReason: 'disk_full' }),
+          );
+          return Promise.resolve({
+            planId: 'plan-9',
+            runId: 'run-9',
+            newState: 'paused',
+          });
+        }
+        if (cmd === 'plans_resume') {
+          return Promise.resolve({ planId: 'plan-9', newState: 'applying' });
+        }
+        if (cmd === 'plans_apply_status') {
+          statusCall += 1;
+          // First tick: still applying, partial progress. Second tick: done.
+          if (statusCall === 1) {
+            return Promise.resolve({
+              planId: 'plan-9',
+              runId: 'run-9',
+              planState: 'applying',
+              itemsTotal: 5,
+              itemsApplied: 3,
+              itemsFailed: 0,
+              itemsSkipped: 0,
+              itemsCancelled: 0,
+              itemsPending: 2,
+            });
+          }
+          return Promise.resolve({
+            planId: 'plan-9',
+            runId: 'run-9',
+            planState: 'applied',
+            itemsTotal: 5,
+            itemsApplied: 5,
+            itemsFailed: 0,
+            itemsSkipped: 0,
+            itemsCancelled: 0,
+            itemsPending: 0,
+          });
+        }
+        return Promise.resolve(null);
+      });
+
+      const { result } = renderHook(() => usePlanApplyProgress());
+      await act(async () => {
+        await result.current.run({ id: 'plan-9', approvalToken: 'tok' });
+      });
+      expect(result.current.progress.paused).toBe(true);
+
+      let resumed = false;
+      await act(async () => {
+        resumed = await result.current.resume('plan-9');
+      });
+      expect(resumed).toBe(true);
+      // Resume itself carries no progress — running while the poll spins up.
+      expect(result.current.progress.running).toBe(true);
+      expect(result.current.progress.paused).toBe(false);
+
+      // First poll tick: partial progress, still running (not terminal).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(result.current.progress.applied).toBe(3);
+      expect(result.current.progress.running).toBe(true);
+      expect(result.current.progress.terminal).toBeNull();
+
+      // Second poll tick: plan reaches `applied` — terminal, polling stops.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      expect(result.current.progress.applied).toBe(5);
+      expect(result.current.progress.running).toBe(false);
+      expect(result.current.progress.terminal).toBe('completed');
+      expect(statusCall).toBe(2);
+
+      // Polling has genuinely stopped — no further status calls accrue.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(5000);
+      });
+      expect(statusCall).toBe(2);
+    });
   });
 });

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -63,17 +63,6 @@ export interface PlanApplyProgress {
   /** Run id needed to call `plan.resume`; set once a pause or the initial
    * apply response reports one. */
   runId: string | null;
-  /**
-   * `true` immediately after a successful `plan.resume` call, until the
-   * first `plans.apply.status` poll (below) lands. Issue #575 (backend
-   * `spawn_executor_run` shared by apply and resume) is fixed — the run DOES
-   * continue — but `plan.resume`'s response carries no event channel, so
-   * there is nothing to await for a "first real update" the way `run()` has.
-   * This is a brief, honest "reconnecting" placeholder, not a permanent
-   * dead-end: `running` flips true and polling starts in the same tick (see
-   * `resume` below).
-   */
-  resumeStalled: boolean;
 }
 
 const IDLE: PlanApplyProgress = {
@@ -86,7 +75,6 @@ const IDLE: PlanApplyProgress = {
   paused: false,
   pauseReason: null,
   runId: null,
-  resumeStalled: false,
 };
 
 /** Extract a numeric `itemsTotal` from an event payload when present. */
@@ -146,12 +134,9 @@ export function usePlanApplyProgress() {
           approvalToken: args.approvalToken,
           onEvent: (event: OperationEvent) => {
             setProgress((prev) => {
-              // Any event proves the run is alive, so a post-resume "stalled"
-              // read is stale the moment a new event arrives.
               const next: PlanApplyProgress = {
                 ...prev,
                 lastEventType: event.eventType,
-                resumeStalled: false,
               };
               switch (event.eventType) {
                 case 'item_started': {
@@ -225,7 +210,6 @@ export function usePlanApplyProgress() {
       failed: status.itemsFailed,
       total: status.itemsTotal,
       runId: status.runId ?? prev.runId,
-      resumeStalled: false,
       paused: status.planState === 'paused',
       pauseReason:
         status.planState === 'paused' ? (status.pauseReason ?? null) : null,
@@ -259,7 +243,6 @@ export function usePlanApplyProgress() {
           running: true,
           paused: false,
           pauseReason: null,
-          resumeStalled: true,
         }));
         stopResumePolling();
         pollTimerRef.current = setInterval(() => {

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -13,11 +13,29 @@
  * this hook surfaces a live item counter + terminal outcome to the UI.
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { applyPlan } from './planApply';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
-import type { OperationEvent, PlanApplyResponse } from '@/bindings/index';
+import type {
+  OperationEvent,
+  PlanApplyResponse,
+  PlanApplyStatus_Serialize as PlanApplyStatus,
+} from '@/bindings/index';
+
+/** `PlanApplyStatus.planState` values that mean the run is no longer active. */
+const TERMINAL_PLAN_STATES = new Set([
+  'applied',
+  'partially_applied',
+  'failed',
+  'cancelled',
+  'discarded',
+]);
+
+/** Poll interval for `plans.apply.status` while a resumed run has no live
+ * event channel (see `resume` below). Matches the Inbox review overlay's
+ * own open-plan poll cadence (InboxPage.tsx) for one consistent rhythm. */
+const RESUME_POLL_MS = 1000;
 
 export interface PlanApplyProgress {
   /** Whether an apply is currently streaming. */
@@ -46,14 +64,14 @@ export interface PlanApplyProgress {
    * apply response reports one. */
   runId: string | null;
   /**
-   * `true` immediately after a successful `plan.resume` call. The backend
-   * currently only flips the plan's DB state and does not re-spawn the
-   * executor (known limitation — see issue #575), so no further progress
-   * events will arrive on this run's channel. Rendered as a distinct,
-   * non-progressing state rather than as `running` so the UI never implies
-   * work is happening when it isn't. Cleared the instant a *real* event
-   * does arrive (any event proves the run is alive again), so a future fix
-   * to the backend continuation gap self-heals this without a UI change.
+   * `true` immediately after a successful `plan.resume` call, until the
+   * first `plans.apply.status` poll (below) lands. Issue #575 (backend
+   * `spawn_executor_run` shared by apply and resume) is fixed — the run DOES
+   * continue — but `plan.resume`'s response carries no event channel, so
+   * there is nothing to await for a "first real update" the way `run()` has.
+   * This is a brief, honest "reconnecting" placeholder, not a permanent
+   * dead-end: `running` flips true and polling starts in the same tick (see
+   * `resume` below).
    */
   resumeStalled: boolean;
 }
@@ -92,13 +110,35 @@ function readStringField(payload: unknown, field: string): string | null {
 export function usePlanApplyProgress() {
   const [progress, setProgress] = useState<PlanApplyProgress>(IDLE);
 
-  const reset = useCallback(() => setProgress(IDLE), []);
+  // Issue #744 (FR-002): `plan.resume` returns no event channel, so a
+  // resumed run's ongoing progress (which, since #575, genuinely continues)
+  // is only observable by polling `plans.apply.status`. Ref (not state) so
+  // `stopResumePolling` is stable across renders and effect cleanup always
+  // sees the current timer.
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const stopResumePolling = useCallback(() => {
+    if (pollTimerRef.current !== null) {
+      clearInterval(pollTimerRef.current);
+      pollTimerRef.current = null;
+    }
+  }, []);
+
+  // Stop polling if the component unmounts mid-resume (e.g. the overlay
+  // closes) — never let an interval outlive its hook instance.
+  useEffect(() => stopResumePolling, [stopResumePolling]);
+
+  const reset = useCallback(() => {
+    stopResumePolling();
+    setProgress(IDLE);
+  }, [stopResumePolling]);
 
   const run = useCallback(
     async (args: {
       id: string;
       approvalToken?: string;
     }): Promise<PlanApplyResponse | null> => {
+      stopResumePolling();
       setProgress({ ...IDLE, running: true });
       try {
         const response = await applyPlan({
@@ -169,22 +209,45 @@ export function usePlanApplyProgress() {
         return null;
       }
     },
-    [],
+    [stopResumePolling],
   );
 
   /**
+   * Reduce one `plans.apply.status` poll tick into `progress`. Returns
+   * whether the plan has reached a terminal state (poll should stop).
+   */
+  const applyStatusTick = useCallback((status: PlanApplyStatus) => {
+    const isTerminal = TERMINAL_PLAN_STATES.has(status.planState);
+    setProgress((prev) => ({
+      ...prev,
+      running: !isTerminal,
+      applied: status.itemsApplied,
+      failed: status.itemsFailed,
+      total: status.itemsTotal,
+      runId: status.runId ?? prev.runId,
+      resumeStalled: false,
+      paused: status.planState === 'paused',
+      pauseReason:
+        status.planState === 'paused' ? (status.pauseReason ?? null) : null,
+      terminal: isTerminal
+        ? status.planState === 'applied'
+          ? 'completed'
+          : 'failed'
+        : null,
+    }));
+    return isTerminal;
+  }, []);
+
+  /**
    * Resume a paused run (`plan.resume`, R-Pause-1). Calls the real backend
-   * command; the plan's DB state moves `paused -> applying` on success.
+   * command; the plan's DB state moves `paused -> applying` on success, and
+   * (since issue #575's `spawn_executor_run` fix) the executor genuinely
+   * continues applying the run's remaining items.
    *
-   * The backend does not yet re-spawn the executor to continue the run's
-   * remaining pending items (issue #575), so no `item_*`/`completed` events
-   * will follow. Landing on `running: true` here would render as an
-   * indefinite "Applying…" with every action disabled (`busy` gates the
-   * whole footer) — a real UI trap, since the run genuinely never
-   * progresses. Instead land on the distinct `resumeStalled` state:
-   * `running` stays `false` so the footer's Close/Discard remain usable,
-   * and the progress panel shows an honest "not yet restarted" message
-   * instead of implying live progress.
+   * `plan.resume`'s response carries no event channel (unlike the initial
+   * `run()`), so there is nothing to await for live `item_*` events. Instead
+   * poll `plans.apply.status` (issue #744 FR-002) — a DB-backed snapshot
+   * independent of any channel — until the plan reaches a terminal state.
    */
   const resume = useCallback(
     async (planId: string): Promise<boolean> => {
@@ -193,17 +256,30 @@ export function usePlanApplyProgress() {
         unwrap(await commands.plansResume(planId, progress.runId));
         setProgress((prev) => ({
           ...prev,
-          running: false,
+          running: true,
           paused: false,
           pauseReason: null,
           resumeStalled: true,
         }));
+        stopResumePolling();
+        pollTimerRef.current = setInterval(() => {
+          void commands
+            .plansApplyStatus(planId)
+            .then(unwrap)
+            .then((status) => {
+              if (applyStatusTick(status)) stopResumePolling();
+            })
+            .catch(() => {
+              // A transient status-poll failure is not a terminal outcome —
+              // keep polling rather than freezing the UI on a dropped tick.
+            });
+        }, RESUME_POLL_MS);
         return true;
       } catch {
         return false;
       }
     },
-    [progress.runId],
+    [progress.runId, applyStatusTick, stopResumePolling],
   );
 
   /**


### PR DESCRIPTION
## Summary
- Resuming a paused filesystem plan (Approve & apply → paused → Resume) now shows real, live progress through to completion instead of freezing on a permanent "not restarted yet" placeholder — the app polls the run's status every second until it finishes.

Salvaged from the abandoned PR #1025 (branch `coder-g-inbox-apply`), cherry-picked cleanly onto current `main` — only the resume-progress slice from commits `51d48efb` and `193634d1`; unrelated bundled changes from that branch (other issues, an id-vs-index merge repair) were left out.

Closes #575
Closes #744

## Test plan
- [x] `usePlanApplyProgress.test.tsx` and `PlanReviewOverlay.test.tsx` green (`pnpm vitest run src/features/plans`)
- [x] `tsc --noEmit` clean (workaround only for a pre-existing, unrelated `baseUrl` config warning; not part of this diff)
- [x] `biome check` clean on the touched files; `eslint` warnings on touched files are pre-existing on `main` (unrelated i18n message typing noise)

## Spec Context
- Spec: 744
- Branch: salvage/744-plan-apply-resume-polling