### PR TITLE
fix(inbox): fail-safe Confirm gate while per-file metadata loads or errors

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -366,9 +366,16 @@ export function InboxPage() {
   );
 
   // Load per-file extracted metadata for the selected item (spec 041 US2/FR-010).
-  const { data: fileMetadata } = useInboxItemMetadata(
-    selectedItem?.inboxItemId ?? null,
-  );
+  //
+  // Issue #643: `loading`/`error` used to be discarded here, so a metadata
+  // fetch that never lands (or errors) left `fileMetadata` at its `[]`
+  // default — `hasMissingRequiredMeta` below then saw no files at all and
+  // silently left Confirm ENABLED on an item the backend would still refuse.
+  const {
+    data: fileMetadata,
+    loading: fileMetadataLoading,
+    error: fileMetadataError,
+  } = useInboxItemMetadata(selectedItem?.inboxItemId ?? null);
 
   // Destination library roots (non-inbox) for the per-detection "Source" picker.
   // When more than one exists, the user can choose where files land instead of
@@ -746,10 +753,15 @@ export function InboxPage() {
   // rows (including the sub-items T066 already materialized alongside it)
   // are confirmable, so confirm is disabled for both "unclassified" and
   // "mixed" here.
+  // Issue #643: while per-file metadata is loading or failed to load, we
+  // cannot know whether mandatory attributes are missing — fail safe by
+  // keeping Confirm disabled instead of judging over an empty array.
   const canConfirm =
     !!selectedItem &&
     !!classification &&
     classification.type === 'single_type' &&
+    !fileMetadataLoading &&
+    !fileMetadataError &&
     !hasMissingRequiredMeta &&
     !hasOpenPlan;
 

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx
@@ -1,0 +1,142 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Issue #643 — Inbox per-file metadata intermittently never loads; the
+ * Confirm gate must fail SAFE (disabled) while metadata is loading or
+ * errored, not silently enable Confirm on an item the backend would refuse.
+ *
+ * Root cause: `InboxPage` only destructured `data` from `useInboxItemMetadata`
+ * and computed `hasMissingRequiredMeta` over the (empty) fallback array while
+ * the query was still pending/failed — `canConfirm` then judged an empty
+ * file list as "nothing missing" and enabled Confirm.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PageStatusProvider } from '@/app/PageStatusContext';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>
+      <PageStatusProvider>{ui}</PageStatusProvider>
+    </QueryClientProvider>,
+  );
+}
+
+const {
+  mockRootsList,
+  mockInboxList,
+  mockInboxPlanListOpen,
+  mockInboxClassify,
+  mockInboxItemMetadata,
+} = vi.hoisted(() => ({
+  mockRootsList: vi.fn(),
+  mockInboxList: vi.fn(),
+  mockInboxPlanListOpen: vi.fn(),
+  mockInboxClassify: vi.fn(),
+  mockInboxItemMetadata: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    rootsList: mockRootsList,
+    inboxList: mockInboxList,
+    inboxPlanListOpen: mockInboxPlanListOpen,
+    inboxClassify: mockInboxClassify,
+    inboxItemMetadata: mockInboxItemMetadata,
+  },
+}));
+
+// This repo's main selection is index-based (`?selected=<idx>` into the
+// filtered list), unlike the abandoned #644 id-based refactor — the fixture
+// list below has exactly one item, so index 0 always resolves to it.
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useSearch: () => ({ selected: 0, type: undefined }),
+}));
+
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+const item = {
+  inboxItemId: 'item-001',
+  groupId: 'item-001',
+  groupKey: '',
+  rootId: 'root-001',
+  rootAbsolutePath: '/astro/inbox',
+  relativePath: 'lights/NGC7000',
+  fileCount: 1,
+  lane: 'fits',
+  format: 'fits',
+  state: 'classified',
+  contentSignature: 'sig-a',
+  isMaster: false,
+  masterFrameType: null,
+  masterFilter: null,
+  masterExposureS: null,
+  organizationState: 'unorganized',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockRootsList.mockResolvedValue(ok([]));
+  mockInboxList.mockResolvedValue(
+    ok({ items: [item], capped: false, limit: 500 }),
+  );
+  mockInboxPlanListOpen.mockResolvedValue(ok({ plans: [], totalActions: 0 }));
+  mockInboxClassify.mockResolvedValue(
+    ok({ type: 'single_type', frameType: 'light', unclassifiedFiles: [] }),
+  );
+});
+
+import { InboxPage } from '../InboxPage';
+
+describe('InboxPage confirm gate vs. per-file metadata load state (#643)', () => {
+  it('keeps Confirm disabled while metadata is still loading (never resolves)', async () => {
+    // Simulate the stuck-fetch repro: the metadata promise never settles.
+    mockInboxItemMetadata.mockReturnValue(new Promise(() => {}));
+    render(<InboxPage />);
+
+    await waitFor(() => expect(mockInboxClassify).toHaveBeenCalled());
+
+    const confirmBtn = await screen.findByTestId('inbox-confirm-btn');
+    expect(confirmBtn).toBeDisabled();
+  });
+
+  it('keeps Confirm disabled when the metadata fetch errors', async () => {
+    mockInboxItemMetadata.mockRejectedValue(new Error('boom'));
+    render(<InboxPage />);
+
+    await waitFor(() => expect(mockInboxClassify).toHaveBeenCalled());
+
+    const confirmBtn = await screen.findByTestId('inbox-confirm-btn');
+    await waitFor(() => expect(confirmBtn).toBeDisabled());
+  });
+
+  it('enables Confirm once metadata resolves with no missing attributes', async () => {
+    mockInboxItemMetadata.mockResolvedValue(
+      ok({
+        inboxItemId: 'item-001',
+        files: [
+          {
+            relativeFilePath: 'lights/NGC7000/frame_001.fits',
+            missingPathAttributes: [],
+            missingMandatory: [],
+          },
+        ],
+      }),
+    );
+    render(<InboxPage />);
+
+    await waitFor(() => expect(mockInboxClassify).toHaveBeenCalled());
+
+    const confirmBtn = await screen.findByTestId('inbox-confirm-btn');
+    await waitFor(() => expect(confirmBtn).not.toBeDisabled());
+  });
+});


### PR DESCRIPTION
## Summary
- `canConfirm` previously judged only the resolved `data` from `useInboxItemMetadata`, discarding `loading`/`error`. A metadata fetch that never lands (or errors) left `fileMetadata` at its `[]` default, so `hasMissingRequiredMeta` saw no files at all and silently left Confirm ENABLED on an item the backend would still reject for missing mandatory attributes.
- `canConfirm` now also requires the per-file metadata query to have resolved without error, failing safe (Confirm disabled) while loading/errored.

Salvaged from abandoned PR #1025 (source commit `07640bd0`), scoped to #643 only — the other two changes bundled in that commit (#644 id-based selection, #769 approve-before-apply) are already/separately handled and are NOT part of this PR.

Fixes #643

## Test plan
- [x] `pnpm vitest run src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx` — 3 new tests green
- [x] `pnpm vitest run src/features/inbox/` — 174 tests green (no regressions)
- [x] `pnpm run typecheck` — clean
- [x] `biome check` / `eslint` on touched files — no new errors (pre-existing unrelated warnings only)