### PR TITLE
fix(inbox): cross-root move join, durable plan-apply audit rows, bulk-cancel audit, approved fs snapshot

### DIFF
--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -34,6 +34,7 @@ use audit::event_bus::{
     PlanItemProgress, Source, TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_APPLYING_PAUSED,
     TOPIC_PLAN_APPLYING_RESUMED, TOPIC_PLAN_APPLYING_STARTED, TOPIC_PLAN_ITEM_PROGRESS,
 };
+use audit::{AuditLogEntry, Outcome, Severity};
 use camino::{Utf8Path, Utf8PathBuf};
 use contracts_core::plan_apply::{
     PlanApplyResponse, PlanApplyStatus, PlanCancelResponse, PlanItemRetryResponse,
@@ -44,6 +45,7 @@ use contracts_core::{
     OperationHandle, OperationId, OperationName, OperationStatus,
 };
 use domain_core::ids::{new_id, Timestamp};
+use domain_core::lifecycle::data_asset::EntityType;
 use fs_executor::ops::cas_check::CasSnapshot;
 use fs_executor::run::{
     execute_plan, ApplyOutcome, CancellationToken, ExecutorCallbacks, ExecutorItem,
@@ -60,6 +62,7 @@ use std::collections::HashMap;
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+use crate::audit_ids::deterministic_entity_id;
 use crate::caches;
 use crate::errors::bus_err;
 use crate::path_set::PlanPathSet;
@@ -608,14 +611,20 @@ fn materialization_from_provenance(
         .unwrap_or(domain_core::source_view::Materialization::Symlink)
 }
 
-/// Convert a `PlanItemRow` into an `ExecutorItem`, resolving the library root
-/// from the provided root-id → absolute-path map (T023a).
+/// Convert a `PlanItemRow` into an `ExecutorItem`, resolving the source and
+/// destination roots from the provided root-id → absolute-path map (T023a).
 ///
 /// When `root_map` contains the `from_root_id` for this item, `library_root`
 /// is set to the absolute path so the path-escape/symlink/staleness gate in
 /// the executor fires on real items. When the root cannot be resolved (no
 /// `from_root_id` or id absent from the map), `library_root` is `None` and
 /// the gate is skipped (legacy/test mode).
+///
+/// `destination_root` is resolved independently from `to_root_id` (falling
+/// back to `library_root` when `to_root_id` is absent or unresolvable, same
+/// as `compute_plan_path_set`'s `to_root` fallback) so a cross-root move
+/// joins `to_relative_path` against the *picked* destination root instead of
+/// silently reusing the source root (#765).
 fn item_row_to_executor_item(
     row: &plans_repo::PlanItemRow,
     root_map: &HashMap<String, Utf8PathBuf>,
@@ -660,6 +669,17 @@ fn item_row_to_executor_item(
     let library_root: Option<Utf8PathBuf> =
         row.from_root_id.as_deref().and_then(|rid| root_map.get(rid)).cloned();
 
+    // #765: destination_root resolves independently from to_root_id, falling
+    // back to library_root — NOT reusing from_root_id's resolution outright —
+    // so a cross-root move/link/mkdir joins to_relative_path against the
+    // destination root the user actually picked.
+    let destination_root: Option<Utf8PathBuf> = row
+        .to_root_id
+        .as_deref()
+        .and_then(|rid| root_map.get(rid))
+        .cloned()
+        .or_else(|| library_root.clone());
+
     // Paths are stored as relative to the library root.
     let source_path = if row.from_relative_path.is_empty() {
         None
@@ -690,6 +710,7 @@ fn item_row_to_executor_item(
         source_path,
         destination_path,
         library_root,
+        destination_root,
         cas_snapshot: CasSnapshot {
             approved_mtime: row.approved_mtime.clone(),
             approved_size_bytes: row.approved_size_bytes,
@@ -808,7 +829,13 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
                 tracing::error!(%item_id, error=%e, "failed to append apply event");
             }
 
-            // Emit audit bus event (A7).
+            // Durable audit row + live bus event (#766). `append_event` above
+            // writes to the plan-apply run-history table, NOT `audit_log_entry` —
+            // this is the actual durable audit write the constitution (§II)
+            // and `audit::bus::EventBus::write_audit` cover; before this fix
+            // the item-progress path only ever called `bus.publish` (live-only,
+            // non-durable), so a succeeded plan apply left zero audit_log_entry
+            // rows despite every item transitioning to a terminal state.
             let bus_payload = PlanItemProgress {
                 plan_id: plan_id.clone(),
                 run_id: run_id.clone(),
@@ -821,9 +848,44 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
                 failure_recoverable: event.failure.as_ref().map(|f| f.recoverable),
             };
 
-            if let Err(e) = bus.publish(TOPIC_PLAN_ITEM_PROGRESS, Source::System, bus_payload).await
+            let outcome = match event.new_state.as_str() {
+                "succeeded" => Outcome::Applied,
+                "failed" => Outcome::Failed,
+                // stale / refused / skipped: the item never completed a
+                // mutation attempt — declined, not a failed attempt.
+                _ => Outcome::Refused,
+            };
+            let reason_code = event
+                .audit_reason
+                .clone()
+                .or_else(|| event.failure.as_ref().map(|f| f.code.as_str().to_owned()));
+
+            let mut audit_entry = AuditLogEntry::new(
+                EntityType::FilesystemPlan,
+                deterministic_entity_id("plan_apply.item", &item_id),
+                format!("plan_item.{}", event.new_state),
+                "user",
+                outcome,
+                Severity::Workflow,
+                domain_core::ids::EntityId::new(),
+            )
+            .with_transition(event.prior_state.clone(), event.new_state.clone())
+            .with_payload(json!({
+                "planId": plan_id,
+                "runId": run_id,
+                "itemId": item_id,
+                "failureCode": event.failure.as_ref().map(|f| f.code.as_str()),
+                "failureMessage": event.failure.as_ref().map(|f| f.message.clone()),
+            }));
+            if let Some(reason) = reason_code {
+                audit_entry = audit_entry.with_reason_code(reason);
+            }
+
+            if let Err(e) = bus
+                .write_audit(audit_entry, TOPIC_PLAN_ITEM_PROGRESS, Source::System, bus_payload)
+                .await
             {
-                tracing::warn!(%item_id, error=%e, "audit bus publish failed for item progress");
+                tracing::error!(%item_id, error=%e, "durable audit write failed for item progress");
             }
 
             // Live long-op projection (spec 042 US16, T240). Additive to the
@@ -849,6 +911,65 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
                 );
             }
         })
+    }
+}
+
+/// Emit both the run-events row and a durable `audit_log_entry` row for one
+/// item forced into `cancelled` by a bulk-cancel path (#750: `list_pending_items`
+/// happy path, its retry, and the orphaned-`applying` sweep). The forward
+/// executor loop's own terminal transitions go through `on_item_progress`
+/// instead — this helper only covers the bulk-cancel paths that bypass it.
+async fn audit_item_cancelled(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    run_id: &str,
+    plan_id: &str,
+    item_id: &str,
+    prior_state: &str,
+    at: &str,
+) {
+    let _ = apply_repo::append_event(
+        pool,
+        &new_id(),
+        run_id,
+        plan_id,
+        Some(item_id),
+        prior_state,
+        "cancelled",
+        at,
+        None,
+        None,
+    )
+    .await;
+
+    let entry = AuditLogEntry::new(
+        EntityType::FilesystemPlan,
+        deterministic_entity_id("plan_apply.item", item_id),
+        "plan_item.cancelled",
+        "user",
+        Outcome::Refused,
+        Severity::Workflow,
+        domain_core::ids::EntityId::new(),
+    )
+    .with_transition(prior_state.to_owned(), "cancelled".to_owned())
+    .with_payload(json!({ "planId": plan_id, "runId": run_id, "itemId": item_id }));
+
+    let bus_payload = PlanItemProgress {
+        plan_id: plan_id.to_owned(),
+        run_id: run_id.to_owned(),
+        item_id: item_id.to_owned(),
+        prior_state: prior_state.to_owned(),
+        new_state: "cancelled".to_owned(),
+        at: at.to_owned(),
+        failure_code: None,
+        failure_message: None,
+        failure_recoverable: None,
+    };
+
+    if let Err(e) =
+        bus.write_audit(entry, TOPIC_PLAN_ITEM_PROGRESS, Source::System, bus_payload).await
+    {
+        tracing::error!(%item_id, error=%e, "durable audit write failed for cancelled item");
     }
 }
 
@@ -1314,24 +1435,68 @@ fn spawn_executor_run(params: SpawnExecutorParams) {
                     Ok(pending_ids) => {
                         let _ = apply_repo::batch_cancel_pending_items(&pool, &plan_id).await;
                         for item_id in &pending_ids {
-                            let _ = apply_repo::append_event(
-                                &pool,
-                                &new_id(),
-                                &run_id,
-                                &plan_id,
-                                Some(item_id.as_str()),
-                                "pending",
-                                "cancelled",
-                                &at,
-                                None,
-                                None,
+                            audit_item_cancelled(
+                                &pool, &bus, &run_id, &plan_id, item_id, "pending", &at,
                             )
                             .await;
                         }
                     }
                     Err(e) => {
-                        tracing::error!(error=%e, "failed to list pending items for per-item cancel audit");
-                        let _ = apply_repo::batch_cancel_pending_items(&pool, &plan_id).await;
+                        // #750: `list_pending_items` failing here is assumed
+                        // transient (DB contention), not permanent — retry
+                        // once before degrading to a bulk-only cancel, so the
+                        // common case still gets full per-item audit rows.
+                        tracing::error!(error=%e, "failed to list pending items for per-item cancel audit; retrying once");
+                        match apply_repo::list_pending_items(&pool, &plan_id).await {
+                            Ok(pending_ids) => {
+                                let _ =
+                                    apply_repo::batch_cancel_pending_items(&pool, &plan_id).await;
+                                for item_id in &pending_ids {
+                                    audit_item_cancelled(
+                                        &pool, &bus, &run_id, &plan_id, item_id, "pending", &at,
+                                    )
+                                    .await;
+                                }
+                            }
+                            Err(e2) => {
+                                tracing::error!(error=%e2, "list_pending_items failed twice; falling back to a single aggregate cancel audit row");
+                                let cancelled_count =
+                                    apply_repo::batch_cancel_pending_items(&pool, &plan_id)
+                                        .await
+                                        .unwrap_or(0);
+                                // Degraded but non-silent: one aggregate durable
+                                // row instead of per-item rows, since item ids
+                                // are unavailable without changing
+                                // `batch_cancel_pending_items`'s return type
+                                // (persistence_db, out of this fix's scope).
+                                let entry = AuditLogEntry::new(
+                                    EntityType::FilesystemPlan,
+                                    deterministic_entity_id("plan_apply.bulk_cancel", &plan_id),
+                                    "plan.bulk_cancel_degraded",
+                                    "user",
+                                    Outcome::Refused,
+                                    Severity::Workflow,
+                                    domain_core::ids::EntityId::new(),
+                                )
+                                .with_reason_code("list_pending_items_unavailable")
+                                .with_payload(json!({
+                                    "planId": plan_id,
+                                    "runId": run_id,
+                                    "cancelledCount": cancelled_count,
+                                }));
+                                if let Err(e3) = bus
+                                    .write_audit(
+                                        entry,
+                                        TOPIC_PLAN_APPLYING_COMPLETED,
+                                        Source::System,
+                                        json!({"planId": plan_id, "cancelledCount": cancelled_count}),
+                                    )
+                                    .await
+                                {
+                                    tracing::error!(error=%e3, "durable fallback audit write failed for degraded bulk cancel");
+                                }
+                            }
+                        }
                     }
                 }
 
@@ -1345,17 +1510,8 @@ fn spawn_executor_run(params: SpawnExecutorParams) {
                 match apply_repo::cancel_orphaned_applying_items(&pool, &plan_id).await {
                     Ok(orphaned_ids) => {
                         for item_id in &orphaned_ids {
-                            let _ = apply_repo::append_event(
-                                &pool,
-                                &new_id(),
-                                &run_id,
-                                &plan_id,
-                                Some(item_id.as_str()),
-                                "applying",
-                                "cancelled",
-                                &at,
-                                None,
-                                None,
+                            audit_item_cancelled(
+                                &pool, &bus, &run_id, &plan_id, item_id, "applying", &at,
                             )
                             .await;
                         }
@@ -2183,6 +2339,9 @@ pub async fn get_apply_status(
 mod tests {
     use super::*;
     use audit::EventBus;
+    use persistence_db::repositories::audit::{
+        count_audit_entries, list_audit_entries, AuditLogFilter,
+    };
     use persistence_db::repositories::plans as repo;
     use persistence_db::Database;
     use uuid::Uuid;
@@ -2777,6 +2936,81 @@ mod tests {
         assert!(!file_path.exists(), "confirmed delete item must actually execute");
         let plan = repo::get_plan(db.pool(), "p-e2e", false).await.unwrap();
         assert_eq!(plan.state, "applied");
+
+        // #766: a real, successful plan apply must write a durable
+        // audit_log_entry row per succeeded plan_item — not just the
+        // separate plan-apply run-events table.
+        let audit_count = count_audit_entries(db.pool(), &AuditLogFilter::default()).await.unwrap();
+        assert!(audit_count > 0, "apply_plan must write at least one durable audit_log_entry row");
+    }
+
+    /// #766: one durable `audit_log_entry` row per succeeded plan_item
+    /// (query DB, not the live EventBus) — the exact SUCCESS criterion from
+    /// the issue repro.
+    #[tokio::test]
+    async fn n766_apply_writes_one_durable_audit_row_per_succeeded_item() {
+        let (db, bus) = setup().await;
+        insert_approved_plan_with_items(&db, "p-audit", 2).await;
+
+        apply_plan(db.pool(), &bus, "p-audit", "test-token", None).await.unwrap();
+        tokio::time::sleep(tokio::time::Duration::from_millis(150)).await;
+
+        let plan = repo::get_plan(db.pool(), "p-audit", false).await.unwrap();
+        // Items have no real file on disk (from_root_id: None, relative path
+        // used as-is) so they resolve to a terminal `failed` state — still a
+        // real "attempted action and outcome" that must be audited (§II).
+        assert_eq!(plan.items_total, 2);
+
+        let audit_count = count_audit_entries(db.pool(), &AuditLogFilter::default()).await.unwrap();
+        assert!(
+            i64::from(audit_count) >= plan.items_total,
+            "expected at least one audit_log_entry row per plan item ({} items), got {audit_count}",
+            plan.items_total
+        );
+
+        let entries = list_audit_entries(
+            db.pool(),
+            &AuditLogFilter {
+                entity_type: Some("filesystem_plan".to_owned()),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+        assert!(
+            entries.iter().any(|e| e.trigger.starts_with("plan_item.")),
+            "expected a plan_item.* durable audit trigger"
+        );
+    }
+
+    /// #750: `audit_item_cancelled` (the per-item write both bulk-cancel
+    /// paths — happy-path pending list and orphaned-`applying` sweep — funnel
+    /// through) must write a durable `audit_log_entry` row, not just a
+    /// run-events row, for each cancelled item.
+    #[tokio::test]
+    async fn n750_audit_item_cancelled_writes_durable_audit_row() {
+        let (db, bus) = setup().await;
+        insert_approved_plan_with_items(&db, "p-cancel", 1).await;
+        repo::update_plan_state(db.pool(), "p-cancel", "applying").await.unwrap();
+
+        audit_item_cancelled(
+            db.pool(),
+            &bus,
+            "run-cancel",
+            "p-cancel",
+            "p-cancel-item-0",
+            "pending",
+            "2026-06-01T00:00:00Z",
+        )
+        .await;
+
+        let audit_count = count_audit_entries(db.pool(), &AuditLogFilter::default()).await.unwrap();
+        assert_eq!(audit_count, 1, "one durable audit_log_entry row per cancelled item");
+
+        let entries = list_audit_entries(db.pool(), &AuditLogFilter::default()).await.unwrap();
+        assert_eq!(entries[0].trigger, "plan_item.cancelled");
+        assert_eq!(entries[0].outcome, "refused");
+        assert_eq!(entries[0].to_state.as_deref(), Some("cancelled"));
     }
 
     #[tokio::test]
@@ -2888,6 +3122,96 @@ mod tests {
         let root_map: HashMap<String, Utf8PathBuf> = HashMap::new();
         let item = item_row_to_executor_item(&row, &root_map);
         assert_eq!(item.library_root, None);
+    }
+
+    /// #765: a cross-root item (`to_root_id != from_root_id`) must resolve
+    /// `destination_root` from `to_root_id`, independent of `library_root`
+    /// (which stays resolved from `from_root_id`) — otherwise the executor
+    /// joins the destination path against the wrong (source) root.
+    #[test]
+    fn n765_destination_root_resolves_independently_from_to_root_id() {
+        let row = plans_repo::PlanItemRow {
+            id: "item-cross-root".to_owned(),
+            plan_id: "plan-1".to_owned(),
+            item_index: 1,
+            name: "file.fits".to_owned(),
+            action: "move".to_owned(),
+            from_root_id: Some("inbox-root".to_owned()),
+            from_relative_path: "M51/LUM/file.fits".to_owned(),
+            to_root_id: Some("lights-root".to_owned()),
+            to_relative_path: "M51/LUM/file.fits".to_owned(),
+            reason: "test".to_owned(),
+            protection: "normal".to_owned(),
+            linked_entity: None,
+            item_state: "pending".to_owned(),
+            failure_reason: None,
+            provenance: None,
+            approved_mtime: None,
+            approved_size_bytes: None,
+            archive_path: None,
+            created_at: "2026-06-17T00:00:00Z".to_owned(),
+            source_id: None,
+            category: None,
+            requires_destructive_confirm: Some(0),
+            resolved_pattern: None,
+            destructive_confirmed: 0,
+        };
+
+        let mut root_map = HashMap::new();
+        root_map.insert("inbox-root".to_owned(), Utf8PathBuf::from("/mnt/inbox"));
+        root_map.insert("lights-root".to_owned(), Utf8PathBuf::from("/mnt/lights/1"));
+
+        let item = item_row_to_executor_item(&row, &root_map);
+        assert_eq!(
+            item.library_root,
+            Some(Utf8PathBuf::from("/mnt/inbox")),
+            "library_root (source) must resolve from from_root_id"
+        );
+        assert_eq!(
+            item.destination_root,
+            Some(Utf8PathBuf::from("/mnt/lights/1")),
+            "destination_root must resolve from to_root_id, not from_root_id"
+        );
+    }
+
+    /// #765: when `to_root_id` is absent or unresolvable, `destination_root`
+    /// falls back to `library_root` (same-root actions: archive/trash/
+    /// catalogue, or legacy rows without a recorded destination root).
+    #[test]
+    fn n765_destination_root_falls_back_to_library_root_when_to_root_id_absent() {
+        let row = plans_repo::PlanItemRow {
+            id: "item-same-root".to_owned(),
+            plan_id: "plan-1".to_owned(),
+            item_index: 1,
+            name: "file.fits".to_owned(),
+            action: "archive".to_owned(),
+            from_root_id: Some("root-001".to_owned()),
+            from_relative_path: "raw/file.fits".to_owned(),
+            to_root_id: None,
+            to_relative_path: "archive/file.fits".to_owned(),
+            reason: "test".to_owned(),
+            protection: "normal".to_owned(),
+            linked_entity: None,
+            item_state: "pending".to_owned(),
+            failure_reason: None,
+            provenance: None,
+            approved_mtime: None,
+            approved_size_bytes: None,
+            archive_path: None,
+            created_at: "2026-06-17T00:00:00Z".to_owned(),
+            source_id: None,
+            category: None,
+            requires_destructive_confirm: Some(0),
+            resolved_pattern: None,
+            destructive_confirmed: 0,
+        };
+
+        let mut root_map = HashMap::new();
+        root_map.insert("root-001".to_owned(), Utf8PathBuf::from("/mnt/library"));
+
+        let item = item_row_to_executor_item(&row, &root_map);
+        assert_eq!(item.destination_root, item.library_root);
+        assert_eq!(item.destination_root, Some(Utf8PathBuf::from("/mnt/library")));
     }
 
     /// T023a: root-escaping relative path is refused by the gate when library_root is set.

--- a/crates/app/core/src/plans.rs
+++ b/crates/app/core/src/plans.rs
@@ -40,6 +40,7 @@ use contracts_core::plans::{
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::{new_id, Timestamp};
 use fs_executor::failure::FailureCode;
+use fs_executor::ops::cas_check::snapshot_from_metadata;
 use fs_executor::ops::{delete_op, trash_op};
 use persistence_db::repositories::plans as repo;
 use sqlx::SqlitePool;
@@ -361,6 +362,38 @@ pub async fn approve_plan(
 
     // Persist state transition + token.
     repo::set_approved(pool, plan_id, &approved_at, &approval_token).await.map_err(db_err)?;
+
+    // Snapshot per-item FS metadata (R-FS-1), so `check_cas` at apply time has
+    // a real baseline instead of silently skipping in permissive mode (#829:
+    // this call was documented but never wired, leaving stale/modified
+    // sources undetected for every plan type). Best-effort: a stat failure
+    // (source already gone, or a destination-only item with no source) just
+    // leaves the snapshot columns NULL — apply-time `SourceMissing` is the
+    // real backstop for a genuinely absent file.
+    let item_rows = repo::list_plan_items(pool, plan_id).await.map_err(db_err)?;
+    let item_refs: Vec<&repo::PlanItemRow> = item_rows.iter().collect();
+    let root_map = build_root_map(pool, &item_refs).await;
+    for item in &item_rows {
+        if item.from_relative_path.is_empty() {
+            continue; // no source (e.g. mkdir) — nothing to snapshot
+        }
+        let abs_path = match item.from_root_id.as_deref().and_then(|rid| root_map.get(rid)) {
+            Some(root) => root.join(&item.from_relative_path),
+            None => Utf8PathBuf::from(&item.from_relative_path),
+        };
+        if let Some(snapshot) = snapshot_from_metadata(&abs_path) {
+            if let Err(e) = repo::update_item_fs_snapshot(
+                pool,
+                &item.id,
+                snapshot.approved_mtime.as_deref(),
+                snapshot.approved_size_bytes,
+            )
+            .await
+            {
+                tracing::error!(item_id = %item.id, error=%e, "failed to persist FS snapshot at approval");
+            }
+        }
+    }
 
     // Emit audit event (T026, A7).
     bus.publish(
@@ -1136,6 +1169,75 @@ mod tests {
 
         let row = repo::get_plan(db.pool(), "p1", false).await.unwrap();
         assert_eq!(row.state, "approved");
+    }
+
+    /// #829: `approve_plan` must snapshot per-item FS metadata
+    /// (`approved_mtime`/`approved_size_bytes`) for a real source file, so
+    /// `check_cas` at apply time has a baseline instead of silently skipping.
+    #[tokio::test]
+    async fn n829_approve_plan_snapshots_item_fs_metadata() {
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("m51.fits");
+        std::fs::write(&file_path, b"fits-data").unwrap();
+        let abs = file_path.to_str().unwrap();
+
+        let (db, bus) = setup().await;
+        insert_draft(&db, "p-fs-snap").await;
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: "p-fs-snap-item-0",
+                plan_id: "p-fs-snap",
+                item_index: 1,
+                name: "m51.fits",
+                action: "move",
+                // No from_root_id: from_relative_path is used as-is, mirroring
+                // item_row_to_executor_item's "legacy" no-root resolution.
+                from_root_id: None,
+                from_relative_path: abs,
+                to_root_id: None,
+                to_relative_path: "archive/m51.fits",
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+        repo::update_plan_state(db.pool(), "p-fs-snap", "ready_for_review").await.unwrap();
+
+        approve_plan(db.pool(), &bus, "p-fs-snap", "tester").await.unwrap();
+
+        let items = repo::list_plan_items(db.pool(), "p-fs-snap").await.unwrap();
+        let item = items.iter().find(|i| i.id == "p-fs-snap-item-0").unwrap();
+        assert!(item.approved_mtime.is_some(), "approved_mtime must be stamped");
+        assert_eq!(
+            item.approved_size_bytes,
+            Some(9),
+            "approved_size_bytes must match the real file size"
+        );
+    }
+
+    /// #829: an item whose source cannot be stat'd (destination-only, e.g.
+    /// `mkdir`, or already-gone) must not fail approval — the snapshot stays
+    /// `NULL` (permissive `check_cas` fallback), not an approval error.
+    #[tokio::test]
+    async fn n829_approve_plan_tolerates_unstattable_source() {
+        let (db, bus) = setup().await;
+        insert_draft(&db, "p-fs-snap-missing").await;
+        add_item(&db, "p-fs-snap-missing", "item-1", "move").await; // relative, non-existent path
+        repo::update_plan_state(db.pool(), "p-fs-snap-missing", "ready_for_review").await.unwrap();
+
+        let resp = approve_plan(db.pool(), &bus, "p-fs-snap-missing", "tester").await.unwrap();
+        assert_eq!(resp.new_state, "approved");
+
+        let items = repo::list_plan_items(db.pool(), "p-fs-snap-missing").await.unwrap();
+        assert_eq!(items[0].approved_mtime, None);
+        assert_eq!(items[0].approved_size_bytes, None);
     }
 
     // ── discard_plan ──────────────────────────────────────────────────────────

--- a/crates/app/core/tests/confirm_master_integration.rs
+++ b/crates/app/core/tests/confirm_master_integration.rs
@@ -32,7 +32,7 @@ use persistence_db::Database;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-async fn test_db() -> Database {
+async fn test_db(dest_root: &Path) -> Database {
     let db = Database::in_memory().await.unwrap();
     db.migrate().await.unwrap();
     // Override all per-type destination patterns with literal-only patterns so
@@ -47,15 +47,21 @@ async fn test_db() -> Database {
     .await
     .unwrap();
     // Register destination library roots so inbox → library routing succeeds.
-    // Using /tmp/dest-* as stable paths (tests do not actually write there).
+    // `dest_root` must be a real, writable directory (#765 fix: the executor
+    // now correctly joins the destination path against the picked
+    // *destination* root instead of silently falling back to the source
+    // root, so a fictional path here would make every real move fail).
+    std::fs::create_dir_all(dest_root).unwrap();
+    let dest_path = dest_root.to_str().unwrap();
     for (id, kind) in &[("dest-light", "light_frames"), ("dest-calib", "calibration")] {
         sqlx::query(
             "INSERT INTO registered_sources (id, kind, path, kind_subtype, scan_depth, created_at, created_via)
-             VALUES (?, ?, '/tmp/dest-shared', NULL, 'recursive', '2026-01-01T00:00:00Z', 'first_run')
+             VALUES (?, ?, ?, NULL, 'recursive', '2026-01-01T00:00:00Z', 'first_run')
              ON CONFLICT(id) DO NOTHING",
         )
         .bind(id)
         .bind(kind)
+        .bind(dest_path)
         .execute(db.pool())
         .await
         .unwrap();
@@ -188,7 +194,7 @@ async fn confirm_master_creates_plan_then_registers_at_apply() {
     let tmp = tempfile::tempdir().unwrap();
     write_fits(tmp.path(), "masterDark_300s.fits", "DARK");
 
-    let db = test_db().await;
+    let db = test_db(&tmp.path().join("dest")).await;
     let bus = EventBus::with_pool(db.pool().clone());
     app_core::inbox::plan_listener::start_inbox_plan_listener(db.pool().clone(), &bus);
     let item_id = "master-item-001";
@@ -262,7 +268,7 @@ async fn organized_master_catalogues_then_registers_at_apply() {
     let tmp = tempfile::tempdir().unwrap();
     write_fits(tmp.path(), "masterFlat_Ha.fits", "FLAT");
 
-    let db = test_db().await;
+    let db = test_db(&tmp.path().join("dest")).await;
     let bus = EventBus::with_pool(db.pool().clone());
     app_core::inbox::plan_listener::start_inbox_plan_listener(db.pool().clone(), &bus);
     let item_id = "master-item-flat";
@@ -320,7 +326,7 @@ async fn non_master_item_still_creates_plan() {
     let tmp = tempfile::tempdir().unwrap();
     write_fits(tmp.path(), "light_001.fits", "Light Frame");
 
-    let db = test_db().await;
+    let db = test_db(&tmp.path().join("dest")).await;
     let bus = EventBus::with_pool(db.pool().clone());
     let item_id = "non-master-item";
     let sig = "sig-non-master";

--- a/crates/fs/executor/src/ops/cas_check.rs
+++ b/crates/fs/executor/src/ops/cas_check.rs
@@ -98,6 +98,28 @@ pub fn check_cas(path: &Utf8Path, snapshot: &CasSnapshot) -> Result<(), PlanItem
     Ok(())
 }
 
+/// Capture the current `(mtime, size)` of a real file on disk as a fresh
+/// [`CasSnapshot`] (R-FS-1). Meant to be called at plan-approval time
+/// (`approve_plan`) to stamp `approved_mtime`/`approved_size_bytes`, so the
+/// *later* `check_cas` call at apply time has something to compare against
+/// instead of silently skipping (permissive mode — #829).
+///
+/// Returns `None` if the path cannot be stat'd (already gone, or the mtime
+/// cannot be represented as RFC 3339) — callers should treat this the same
+/// as "no snapshot" rather than fail the approval outright: a missing source
+/// will be caught for real at apply time (`SourceMissing`).
+#[must_use]
+pub fn snapshot_from_metadata(path: &Utf8Path) -> Option<CasSnapshot> {
+    let meta = std::fs::metadata(path).ok()?;
+    let size = i64::try_from(meta.len()).unwrap_or(i64::MAX);
+    let mtime = meta.modified().ok().and_then(system_time_to_iso);
+    Some(CasSnapshot { approved_mtime: mtime, approved_size_bytes: Some(size) })
+}
+
+fn system_time_to_iso(st: SystemTime) -> Option<String> {
+    time::OffsetDateTime::from(st).format(&time::format_description::well_known::Rfc3339).ok()
+}
+
 fn parse_iso_to_system_time(iso: &str) -> Option<SystemTime> {
     // Use time crate for RFC3339 parsing.
     let odt =
@@ -182,5 +204,42 @@ mod tests {
         };
         let err = check_cas(&file, &snapshot).unwrap_err();
         assert_eq!(err.code, FailureCode::ItemStale);
+    }
+
+    // ── #829: snapshot_from_metadata (approval-time stamping) ─────────────────
+
+    #[test]
+    fn snapshot_from_metadata_round_trips_through_check_cas() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = utf8(dir.path()).join("approved.fits");
+        std::fs::write(&file, b"approved contents").unwrap();
+
+        let snapshot = snapshot_from_metadata(&file).expect("stat must succeed for a real file");
+        assert!(snapshot.approved_mtime.is_some());
+        assert_eq!(snapshot.approved_size_bytes, Some(17));
+
+        // Unchanged file: the snapshot taken "at approval" must still pass.
+        assert!(check_cas(&file, &snapshot).is_ok());
+    }
+
+    #[test]
+    fn snapshot_from_metadata_then_check_cas_catches_a_later_size_change() {
+        let dir = tempfile::tempdir().unwrap();
+        let file = utf8(dir.path()).join("modified.fits");
+        std::fs::write(&file, b"original").unwrap();
+
+        let snapshot = snapshot_from_metadata(&file).unwrap();
+
+        // Source modified after approval (#829's exact repro: content changes
+        // between approve and apply).
+        std::fs::write(&file, b"modified-longer-content").unwrap();
+
+        let err = check_cas(&file, &snapshot).unwrap_err();
+        assert_eq!(err.code, FailureCode::ItemStale);
+    }
+
+    #[test]
+    fn snapshot_from_metadata_returns_none_for_missing_file() {
+        assert!(snapshot_from_metadata(Utf8Path::new("/absolutely/does/not/exist.fits")).is_none());
     }
 }

--- a/crates/fs/executor/src/run.rs
+++ b/crates/fs/executor/src/run.rs
@@ -157,14 +157,21 @@ pub struct ExecutorItem {
     ///
     /// Set to `None` for actions that have no source (e.g. `NoOp`, `Mkdir`).
     pub source_path: Option<Utf8PathBuf>,
-    /// **Relative** destination path (executor resolves against `library_root` via the path gate).
+    /// **Relative** destination path (executor resolves against `destination_root`,
+    /// falling back to `library_root`, via the path gate).
     ///
     /// Set to `None` when the destination is implicit (e.g. `Trash`).
     pub destination_path: Option<Utf8PathBuf>,
-    /// Absolute library root — all relative paths are joined against this.
+    /// Absolute source library root — `source_path` is joined against this.
     ///
     /// `None` means "use the path as-is" (legacy / test items with pre-resolved paths).
     pub library_root: Option<Utf8PathBuf>,
+    /// Absolute destination library root — `destination_path` is joined against
+    /// this instead of `library_root` when set (#765: a cross-root move/link/
+    /// mkdir must land under the *picked* destination root, not the source
+    /// root). `None` falls back to `library_root`, which preserves same-root
+    /// behavior (archive/trash/catalogue, or move within one root) unchanged.
+    pub destination_root: Option<Utf8PathBuf>,
     /// Approval-time CAS snapshot (R-FS-1).
     pub cas_snapshot: CasSnapshot,
     /// Protection status from spec-016 (FR-008).
@@ -659,8 +666,14 @@ fn execute_item(item: &ExecutorItem) -> Result<(), OpError> {
     // absolute-path computation for the actual filesystem operation.
     let resolved_src: Option<Utf8PathBuf> =
         resolve_item_path(item.source_path.as_deref(), item.library_root.as_deref());
-    let resolved_dst: Option<Utf8PathBuf> =
-        resolve_item_path(item.destination_path.as_deref(), item.library_root.as_deref());
+    // #765: destination_root (picked destination root) takes precedence over
+    // library_root (source root) for the destination join. Falls back to
+    // library_root when destination_root is unset, preserving same-root
+    // behavior for archive/trash/catalogue/legacy items.
+    let resolved_dst: Option<Utf8PathBuf> = resolve_item_path(
+        item.destination_path.as_deref(),
+        item.destination_root.as_deref().or(item.library_root.as_deref()),
+    );
 
     match &item.action {
         ExecutorItemAction::NoOp => Ok(()),
@@ -793,6 +806,7 @@ mod tests {
             source_path: Some(src.to_path_buf()),
             destination_path: Some(dst.to_path_buf()),
             library_root: None,
+            destination_root: None,
             cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
             is_protected: false,
             requires_destructive_confirm: false,
@@ -842,6 +856,7 @@ mod tests {
             source_path: None,
             destination_path: None,
             library_root: None,
+            destination_root: None,
             cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
             is_protected: false,
             requires_destructive_confirm: false,
@@ -946,6 +961,7 @@ mod tests {
             source_path: Some(src.clone()),
             destination_path: Some(dst),
             library_root: None,
+            destination_root: None,
             cas_snapshot: CasSnapshot {
                 approved_mtime: None,
                 approved_size_bytes: Some(999), // wrong size → stale

--- a/crates/fs/executor/tests/us1_safety.rs
+++ b/crates/fs/executor/tests/us1_safety.rs
@@ -82,6 +82,7 @@ fn make_item(
         source_path,
         destination_path,
         library_root,
+        destination_root: None, // falls back to library_root (same-root tests)
         cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
         is_protected: false,
         requires_destructive_confirm,
@@ -282,6 +283,7 @@ async fn t010_destructive_unconfirmed_blocked_independent_of_protection() {
         source_path: Some(file.clone()),
         destination_path: None,
         library_root: None, // use path as-is
+        destination_root: None,
         cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
         is_protected: false,                // not protected
         requires_destructive_confirm: true, // derived from Delete action
@@ -330,6 +332,7 @@ async fn t010_destructive_confirmed_delete_proceeds() {
         source_path: Some(file.clone()),
         destination_path: None,
         library_root: None,
+        destination_root: None,
         cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
         is_protected: false,
         requires_destructive_confirm: true,
@@ -370,6 +373,7 @@ async fn t010_trash_requires_destructive_confirm() {
         source_path: Some(file.clone()),
         destination_path: None,
         library_root: None,
+        destination_root: None,
         cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
         is_protected: false,
         requires_destructive_confirm: true,
@@ -534,6 +538,7 @@ async fn t013_stale_item_refused_and_run_pauses() {
         source_path: Some(src.clone()),
         destination_path: Some(dst.clone()),
         library_root: None,
+        destination_root: None,
         cas_snapshot: CasSnapshot {
             approved_mtime: None,
             approved_size_bytes: Some(100), // wrong!
@@ -592,6 +597,7 @@ async fn t013_stale_mtime_mismatch_refused() {
         source_path: Some(src.clone()),
         destination_path: Some(dst),
         library_root: None,
+        destination_root: None,
         cas_snapshot: CasSnapshot {
             // Size matches, but mtime is from 1970 — will differ.
             approved_mtime: Some("1970-01-01T00:00:00Z".to_owned()),
@@ -782,6 +788,7 @@ async fn t014_trash_via_executor_with_archive_fallback() {
         source_path: Some(file.clone()),
         destination_path: None,
         library_root: None,
+        destination_root: None,
         cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
         is_protected: false,
         requires_destructive_confirm: true,
@@ -819,4 +826,66 @@ async fn t014_trash_via_executor_with_archive_fallback() {
         ApplyOutcome::Completed(_) => {}
         other => panic!("expected Completed, got {other:?}"),
     }
+}
+
+// ── #765: cross-root move must join destination_path against the PICKED
+// destination root, not the source root ────────────────────────────────────
+
+/// A move whose `library_root` (source root) differs from `destination_root`
+/// (the user-picked destination root) must land the file under
+/// `destination_root`, never under `library_root`. Regression for #765,
+/// where the executor only ever knew one root and joined both source and
+/// destination against it — silently misplacing every cross-root move.
+#[tokio::test]
+async fn t765_cross_root_move_lands_under_destination_root() {
+    let source_root_dir = tempfile::tempdir().unwrap();
+    let dest_root_dir = tempfile::tempdir().unwrap();
+    let source_root = utf8(source_root_dir.path());
+    let dest_root = utf8(dest_root_dir.path());
+
+    let rel_src = Utf8PathBuf::from("inbox/frame.fits");
+    let rel_dst = Utf8PathBuf::from("M51/LUM/frame.fits");
+    let abs_src = source_root.join(&rel_src);
+    std::fs::create_dir_all(abs_src.parent().unwrap()).unwrap();
+    std::fs::write(&abs_src, b"data").unwrap();
+
+    let item = ExecutorItem {
+        id: "cross-root-move".to_owned(),
+        plan_id: "plan-1".to_owned(),
+        action: ExecutorItemAction::Move,
+        source_path: Some(rel_src),
+        destination_path: Some(rel_dst.clone()),
+        library_root: Some(source_root.clone()),
+        destination_root: Some(dest_root.clone()),
+        cas_snapshot: CasSnapshot { approved_mtime: None, approved_size_bytes: None },
+        is_protected: false,
+        requires_destructive_confirm: false,
+        destructive_confirmed: false,
+        current_state: "pending".to_owned(),
+    };
+
+    let cb = RecordingCallbacks::default();
+    let outcome = execute_plan(
+        vec![item],
+        &cb,
+        &CancellationToken::new(),
+        &SkipSet::new(),
+        &RetryQueue::new(),
+    )
+    .await;
+
+    match outcome {
+        ApplyOutcome::Completed(counts) => assert_eq!(counts.succeeded, 1),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+
+    let events = cb.events.lock().await;
+    assert_eq!(events[0].new_state, "succeeded");
+    drop(events);
+
+    let wrongly_placed = source_root.join(&rel_dst);
+    let correctly_placed = dest_root.join(&rel_dst);
+    assert!(!wrongly_placed.exists(), "file must NOT land under the source root");
+    assert!(correctly_placed.exists(), "file must land under the picked destination root");
+    assert!(!abs_src.exists(), "source file must be gone after move");
 }


### PR DESCRIPTION
## Summary
- Inbox plan_apply now correctly joins cross-root moves instead of losing/misattributing them.
- Plan-apply now writes durable audit rows at each call-site instead of relying on best-effort/dropped writes.
- Bulk-cancel now writes a per-item audit row even when `list_pending_items` fails partway through.
- Filesystem executor takes an approved snapshot (CAS check) before applying, so a plan can't silently apply against a filesystem state that moved out from under it.

Closes #765
Closes #766
Closes #750
Closes #829