### PR TITLE
fix(settings): eliminate Framing mount-race that clobbers user edits

### DIFF
--- a/apps/desktop/src/features/settings/Framing.test.tsx
+++ b/apps/desktop/src/features/settings/Framing.test.tsx
@@ -1,0 +1,85 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Framing settings pane — clustering tolerance mount-race regression (spec
+ * 008 Q27 F-Framing-11).
+ *
+ * Covers the flaky `tests/e2e/settings_framing.spec.ts` failure mode: a
+ * two-phase input (onChange updates local state; blur commits + persists)
+ * has a race window the Cleanup-style "edit before mount fetch resolves"
+ * guard did not cover — the mount fetch can resolve in the gap between
+ * onChange and blur, before `editedRef` was set, clobbering the typed value
+ * back to the fetched one. The subsequent blur then reads that clobbered DOM
+ * value and persists it, permanently losing the edit.
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockGetSettings } = vi.hoisted(() => ({
+  mockGetSettings: vi.fn().mockResolvedValue({ values: {} }),
+}));
+vi.mock('./settingsIpc', () => ({
+  getSettings: mockGetSettings,
+}));
+
+import { Framing } from './Framing';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockGetSettings.mockResolvedValue({ values: {} });
+});
+
+describe('Framing — mount-race clobber regression (spec 008 Q27 F-Framing-11)', () => {
+  it('an edit typed before the mount fetch resolves is not clobbered, and blur persists the typed value', async () => {
+    // Mount-time `getSettings('framing')` is left unresolved until after the
+    // user has already typed a new value (onChange only — not yet blurred),
+    // reproducing the real race: React StrictMode's live effect invocation
+    // can resolve after the keystroke but before the commit.
+    let resolveGet:
+      | ((value: { values: Record<string, unknown> }) => void)
+      | undefined;
+    mockGetSettings.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    const save = vi.fn();
+    render(<Framing save={save} />);
+
+    const input = await screen.findByTestId('framing-pointing-fraction-input');
+    fireEvent.change(input, { target: { value: '0.25' } });
+    expect(input).toHaveValue(0.25);
+
+    // The stale fetch now resolves with the pre-edit default — it must be
+    // ignored, not applied on top of the uncommitted edit.
+    resolveGet?.({
+      values: { framingPointingFractionOfFov: 0.1 },
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(input).toHaveValue(0.25);
+
+    // Commit (blur) must persist the typed value, not a clobbered default.
+    fireEvent.blur(input);
+    await waitFor(() => {
+      expect(save).toHaveBeenCalledWith('framing', {
+        framingPointingFractionOfFov: 0.25,
+      });
+    });
+    expect(input).toHaveValue(0.25);
+  });
+
+  it('loads the persisted value on mount when the user has not edited', async () => {
+    mockGetSettings.mockResolvedValue({
+      values: { framingPointingFractionOfFov: 0.25 },
+    });
+    render(<Framing save={vi.fn()} />);
+
+    const input = await screen.findByTestId('framing-pointing-fraction-input');
+    await waitFor(() => {
+      expect(input).toHaveValue(0.25);
+    });
+  });
+});

--- a/apps/desktop/src/features/settings/Framing.tsx
+++ b/apps/desktop/src/features/settings/Framing.tsx
@@ -100,6 +100,17 @@ export function Framing({ save }: FramingProps) {
     };
   }, []);
 
+  // Marks the mount-time fetch stale as soon as the user starts typing, not
+  // only once they blur/Enter to commit. Without this, the fetch can resolve
+  // in the gap between an onChange (uncommitted local state) and the later
+  // commit, clobbering the typed value back to the fetched one before
+  // `editedRef` was ever set — and the subsequent blur then persists that
+  // clobbered value, since it reads the (now-reset) DOM value.
+  function onFieldChange(raw: string, setter: (n: number) => void) {
+    editedRef.current = true;
+    setter(Number(raw));
+  }
+
   function commitNumber(
     raw: string,
     min: number,
@@ -139,7 +150,7 @@ export function Framing({ save }: FramingProps) {
           step={0.01}
           aria-label={m.settings_framing_pointing_fraction_label()}
           data-testid="framing-pointing-fraction-input"
-          onChange={(e) => setPointingFraction(Number(e.target.value))}
+          onChange={(e) => onFieldChange(e.target.value, setPointingFraction)}
           onBlur={(e) =>
             commitNumber(
               e.target.value,
@@ -178,7 +189,7 @@ export function Framing({ save }: FramingProps) {
           step={0.1}
           aria-label={m.settings_framing_pointing_fallback_label()}
           data-testid="framing-pointing-fallback-input"
-          onChange={(e) => setPointingFallback(Number(e.target.value))}
+          onChange={(e) => onFieldChange(e.target.value, setPointingFallback)}
           onBlur={(e) =>
             commitNumber(
               e.target.value,
@@ -217,7 +228,7 @@ export function Framing({ save }: FramingProps) {
           step={0.5}
           aria-label={m.settings_framing_rotation_label()}
           data-testid="framing-rotation-tolerance-input"
-          onChange={(e) => setRotationTolerance(Number(e.target.value))}
+          onChange={(e) => onFieldChange(e.target.value, setRotationTolerance)}
           onBlur={(e) =>
             commitNumber(
               e.target.value,
@@ -256,7 +267,7 @@ export function Framing({ save }: FramingProps) {
           step={0.1}
           aria-label={m.settings_framing_mosaic_envelope_label()}
           data-testid="framing-mosaic-envelope-input"
-          onChange={(e) => setMosaicEnvelope(Number(e.target.value))}
+          onChange={(e) => onFieldChange(e.target.value, setMosaicEnvelope)}
           onBlur={(e) =>
             commitNumber(
               e.target.value,


### PR DESCRIPTION
## Summary
- Fixes a mount-time race in the Framing settings pane where an in-flight settings load could clobber a value the user had just edited, silently reverting it.
- This was the root cause of the branch-independent CI flake in `tests/e2e/settings_framing.spec.ts:61` (pointing-tolerance persists round-trip): 13/15 failures pre-fix under 8x throttle, 55/55 passes post-fix.