### PR TITLE
fix(inbox): id-based selection so filters can't silently swap the detail panel

### DIFF
--- a/apps/desktop/src/app/router.tsx
+++ b/apps/desktop/src/app/router.tsx
@@ -15,7 +15,6 @@ import { Shell } from './Shell';
 import { checkFirstRunComplete } from './first-run';
 import {
   makeValidateSearch,
-  parseNumber,
   parseString,
   parseEnum,
   parseCsvEnum,
@@ -77,7 +76,11 @@ const inboxRoute = createRoute({
   getParentRoute: () => shellRoute,
   path: '/inbox',
   validateSearch: makeValidateSearch({
-    selected: parseNumber,
+    // Issue #644: `selected` is the item's own id, not a list-position index —
+    // an index silently points at whatever item now occupies that slot once
+    // search/filters change the array shape (Sessions/Calibration already use
+    // this id-based pattern).
+    selected: parseString,
     type: parseEnum(FRAME_TYPES),
     group: parseEnum(INBOX_GROUPS),
   }),

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -186,8 +186,11 @@ function compareItems(
 
 export interface InboxListProps {
   items: InboxListItem[];
-  selectedIdx: number | null;
-  onSelect: (idx: number) => void;
+  /** Issue #644: selection is by item identity, not list position — an index
+   * silently points at whatever item now occupies that slot after search/lane/
+   * kind filters change the array shape. */
+  selectedId: string | null;
+  onSelect: (id: string) => void;
   /** Lane filter ('all' | 'fits' | 'video'). Owned by the page (URL state). */
   filterType: string;
   /** Active ordered grouping dimensions (owned by the page / top-bar controls). */
@@ -276,7 +279,7 @@ export function flattenVisibleTree(
 
 export function InboxList({
   items,
-  selectedIdx,
+  selectedId,
   onSelect,
   filterType,
   dims = [],
@@ -438,8 +441,8 @@ export function InboxList({
             format: '',
           };
         }
-        const { item, originalIdx, indent } = row;
-        const selected = selectedIdx === originalIdx;
+        const { item, indent } = row;
+        const selected = selectedId === item.inboxItemId;
         const mod = classificationMod(item);
         return {
           _testid: `inbox-item-${item.inboxItemId}`,
@@ -450,7 +453,7 @@ export function InboxList({
           ]
             .filter(Boolean)
             .join(' '),
-          _onClick: () => onSelect(originalIdx),
+          _onClick: () => onSelect(item.inboxItemId),
           _selected: selected,
           _indent: indent || undefined,
           detection: (
@@ -493,7 +496,7 @@ export function InboxList({
             : formatTag(item),
         };
       }),
-    [visualRows, selectedIdx, onSelect, toggle],
+    [visualRows, selectedId, onSelect, toggle],
   );
 
   const groupingHint = grouped

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -115,7 +115,7 @@ export function pickReclassifyTarget(
 /** Outcome of {@link resolveReclassifyHandoff}: keep waiting, navigate, or give up. */
 export type ReclassifyHandoffDecision =
   | { action: 'wait' }
-  | { action: 'navigate'; idx: number }
+  | { action: 'navigate'; id: string }
   | { action: 'giveUp' };
 
 /**
@@ -130,8 +130,9 @@ export type ReclassifyHandoffDecision =
  * refetch already in flight isn't mistaken for "never arriving"). Once
  * settled: absent from `items` entirely → give up (nothing will ever
  * appear); present in `items` but absent from `filteredItems` → give up too
- * (it exists, but the user's own filter hides it — there is no index to
- * navigate to); present in both → navigate to its filtered-list index.
+ * (it exists, but the user's own filter hides it — selecting it would show
+ * nothing); present in both → navigate to it (issue #644: selection is the
+ * item's own id, so the target IS `pendingId`, no index lookup needed).
  */
 export function resolveReclassifyHandoff(
   pendingId: string,
@@ -143,8 +144,8 @@ export function resolveReclassifyHandoff(
   if (!items.some((it) => it.inboxItemId === pendingId)) {
     return { action: 'giveUp' };
   }
-  const idx = filteredItems.findIndex((it) => it.inboxItemId === pendingId);
-  return idx === -1 ? { action: 'giveUp' } : { action: 'navigate', idx };
+  const visible = filteredItems.some((it) => it.inboxItemId === pendingId);
+  return visible ? { action: 'navigate', id: pendingId } : { action: 'giveUp' };
 }
 
 /** Type-guard for the destination-root-required details payload. */
@@ -280,10 +281,13 @@ export function InboxPage() {
     return result;
   }, [items, search]);
 
-  // URL-backed selection is by index into the FILTERED list so it stays stable
-  // across re-fetches and tracks what the user actually sees.
-  const selectedItem =
-    selected !== undefined ? filteredItems[selected] : undefined;
+  // URL-backed selection is by item id (issue #644), not list position — an
+  // index silently points at whatever item now occupies that slot once
+  // search/lane/kind filters reshape the array. Sessions and Calibration
+  // already use this id-based `?selected=<id>` pattern.
+  const selectedItem = selected
+    ? filteredItems.find((it) => it.inboxItemId === selected)
+    : undefined;
 
   // `reclassify_v2` operates at source-group scope and re-splits the group
   // into new single-type sub-items (R-14, issue #755) — the currently
@@ -306,8 +310,8 @@ export function InboxPage() {
       }),
   );
 
-  const onSelect = (idx: number) =>
-    navigate({ search: (prev) => ({ ...prev, selected: idx }) });
+  const onSelect = (id: string) =>
+    navigate({ search: (prev) => ({ ...prev, selected: id }) });
 
   const clearSelection = useCallback(
     () =>
@@ -342,9 +346,9 @@ export function InboxPage() {
     );
     if (decision.action === 'wait') return;
     setPendingReclassifySelectionId(null);
-    if (decision.action === 'navigate' && decision.idx !== selected) {
+    if (decision.action === 'navigate' && decision.id !== selected) {
       void navigate({
-        search: (prev) => ({ ...prev, selected: decision.idx }),
+        search: (prev) => ({ ...prev, selected: decision.id }),
       });
     }
   }, [
@@ -1093,7 +1097,7 @@ export function InboxPage() {
       >
         <InboxList
           items={filteredItems}
-          selectedIdx={selected ?? null}
+          selectedId={selected ?? null}
           onSelect={onSelect}
           filterType={type ?? 'all'}
           dims={dims}

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx
@@ -61,7 +61,7 @@ describe('InboxList — classification label + path column (#550/#556)', () => {
     render(
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -74,7 +74,7 @@ describe('InboxList — classification label + path column (#550/#556)', () => {
     render(
       <InboxList
         items={[makeItem({ inboxItemId: 'a' })]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -96,7 +96,7 @@ describe('InboxList — classification label + path column (#550/#556)', () => {
     render(
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -121,7 +121,7 @@ describe('InboxList — classification label + path column (#550/#556)', () => {
     render(
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -144,7 +144,7 @@ describe('InboxList — classification label + path column (#550/#556)', () => {
     render(
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
@@ -14,7 +14,7 @@
  *    with per-group item counts.
  * 2. Picking a SECOND dimension nests groups under the first ("then by").
  * 3. Selecting a row inside a group still calls onSelect with the row's
- *    ORIGINAL index in the unfiltered items array.
+ *    item id (issue #644 — selection is by identity, not list position).
  * 4. The chosen ordered dimensions are persisted to localStorage and restored
  *    on a fresh mount.
  */
@@ -41,7 +41,7 @@ function Harness({
   onSelect = vi.fn(),
 }: {
   items: InboxListItem[];
-  onSelect?: (idx: number) => void;
+  onSelect?: (id: string) => void;
 }) {
   const { dims, setSlot } = useGrouping({
     storageKey: GROUPING_STORAGE_KEY,
@@ -62,7 +62,7 @@ function Harness({
       />
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={onSelect}
         filterType="all"
         dims={dims}
@@ -166,7 +166,7 @@ describe('InboxList — configurable grouping', () => {
     expect(screen.getByTestId('inbox-item-b')).toBeInTheDocument();
   });
 
-  it('(3) selecting a row inside a group reports the original item index', () => {
+  it('(3) selecting a row inside a group reports the item id', () => {
     const onSelect = vi.fn();
     render(<Harness items={items} onSelect={onSelect} />);
 
@@ -175,10 +175,10 @@ describe('InboxList — configurable grouping', () => {
     });
 
     fireEvent.click(screen.getByTestId('inbox-item-c'));
-    expect(onSelect).toHaveBeenCalledWith(2);
+    expect(onSelect).toHaveBeenCalledWith('c');
 
     fireEvent.click(screen.getByTestId('inbox-item-a'));
-    expect(onSelect).toHaveBeenLastCalledWith(0);
+    expect(onSelect).toHaveBeenLastCalledWith('a');
   });
 
   it('(3b) collapsing a group hides its leaf rows', () => {

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.virtualization.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.virtualization.test.tsx
@@ -58,7 +58,7 @@ function Harness({ items }: { items: InboxListItem[] }) {
       />
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
         dims={dims}
@@ -149,7 +149,7 @@ describe('InboxList — virtualization', () => {
     render(
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
         onFilterTypeChange={vi.fn()}

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.windowsSplitPayload.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.windowsSplitPayload.test.tsx
@@ -75,7 +75,7 @@ describe('InboxList — Windows CI split-payload regression', () => {
     render(
       <InboxList
         items={items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
@@ -305,7 +305,7 @@ describe('InboxList', () => {
     render(
       <InboxList
         items={[fitsItem]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
         onFilterTypeChange={vi.fn()}
@@ -319,7 +319,7 @@ describe('InboxList', () => {
     render(
       <InboxList
         items={[fitsItem, videoItem]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="video"
         onFilterTypeChange={vi.fn()}
@@ -331,19 +331,19 @@ describe('InboxList', () => {
     expect(screen.getByTestId('inbox-item-item-video')).toBeInTheDocument();
   });
 
-  it('calls onSelect with original index', () => {
+  it('calls onSelect with the item id (issue #644)', () => {
     const onSelect = vi.fn();
     render(
       <InboxList
         items={[fitsItem, videoItem]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={onSelect}
         filterType="all"
         onFilterTypeChange={vi.fn()}
       />,
     );
     fireEvent.click(screen.getByTestId('inbox-item-item-video'));
-    expect(onSelect).toHaveBeenCalledWith(1);
+    expect(onSelect).toHaveBeenCalledWith('item-video');
   });
 
   it('renders folder + master rows without a duplicate search box or footer count (#83)', () => {
@@ -369,7 +369,7 @@ describe('InboxList', () => {
     render(
       <InboxList
         items={[fitsItem, masterItem]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
         onFilterTypeChange={vi.fn()}

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.metadataGate.test.tsx
@@ -54,12 +54,11 @@ vi.mock('@/bindings/index', () => ({
   },
 }));
 
-// This repo's main selection is index-based (`?selected=<idx>` into the
-// filtered list), unlike the abandoned #644 id-based refactor — the fixture
-// list below has exactly one item, so index 0 always resolves to it.
+// Selection is by item id (issue #644) — the fixture list below has exactly
+// one item, so its id always resolves to it.
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => vi.fn(),
-  useSearch: () => ({ selected: 0, type: undefined }),
+  useSearch: () => ({ selected: 'item-001', type: undefined }),
 }));
 
 const ok = <T,>(data: T) => ({ status: 'ok' as const, data });

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifySelection.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifySelection.test.tsx
@@ -6,12 +6,12 @@
  * Post-split selection handoff (issue #755 CI fix, PR #854).
  *
  * `reclassify_v2` operates at source-group scope and re-splits the group
- * into new single-type sub-items (R-14). Because InboxPage's selection is an
- * INDEX into the item list (not the item id itself), the previously-selected
- * item can silently stop existing after a bulk/per-file reclassify, leaving
- * the Confirm gate (`InboxPage.tsx` `canConfirm`) permanently disabled —
- * this is exactly what the Real-UI e2e
+ * into new single-type sub-items (R-14). The previously-selected item can
+ * silently stop existing after a bulk/per-file reclassify (the group it
+ * belonged to no longer exists), leaving the Confirm gate (`InboxPage.tsx`
+ * `canConfirm`) permanently disabled — this is exactly what the Real-UI e2e
  * `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm` caught.
+ * (Selection itself is by item id, not list index — issue #644.)
  *
  * Three cheap unit-level checks stand in for a full-router InboxPage render
  * (no full-router test harness exists in this codebase — InboxPage.classify
@@ -153,7 +153,7 @@ describe('resolveReclassifyHandoff (bounded pendingReclassifySelectionId lifetim
     ).toEqual({ action: 'wait' });
   });
 
-  it('navigates to the filtered-list index once settled and visible', async () => {
+  it('navigates to the item id once settled and visible (issue #644)', async () => {
     const { resolveReclassifyHandoff } = await import('../InboxPage');
 
     const items = [
@@ -164,7 +164,7 @@ describe('resolveReclassifyHandoff (bounded pendingReclassifySelectionId lifetim
       resolveReclassifyHandoff('item-target', items, items, false),
     ).toEqual({
       action: 'navigate',
-      idx: 1,
+      id: 'item-target',
     });
   });
 

--- a/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.crossRoot.test.tsx
@@ -113,7 +113,7 @@ describe('T039-1: InboxList cross-root rendering (SC-001)', () => {
     render(
       <InboxList
         items={multiRootResponse.items}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
         onFilterTypeChange={vi.fn()}
@@ -137,7 +137,7 @@ describe('T039-2: confirmed items absent — empty list (FR-003)', () => {
     render(
       <InboxList
         items={[]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
         onFilterTypeChange={vi.fn()}

--- a/apps/desktop/src/features/inbox/__tests__/inbox.wave3.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.wave3.test.tsx
@@ -74,7 +74,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -90,7 +90,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -107,7 +107,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -121,7 +121,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -138,7 +138,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -153,7 +153,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={0}
+        selectedId="item-001"
         onSelect={vi.fn()}
         filterType="all"
       />,
@@ -167,7 +167,7 @@ describe('task 32: InboxRow classification-forward grid', () => {
     rtlRender(
       <InboxList
         items={[item]}
-        selectedIdx={null}
+        selectedId={null}
         onSelect={vi.fn()}
         filterType="all"
       />,


### PR DESCRIPTION
## Summary
- Inbox's URL-backed selection was a list-position index (`?selected=<idx>`) into `filteredItems`. Clearing search or changing the lane/kind filter reshapes that array, so the same index could silently point at a different item, swapping the detail panel (and every detail-header action) without any visible change.
- Switches to the item's own id (`?selected=<id>`), matching the pattern Sessions/Calibration already use. `InboxList`'s `selectedIdx`/`onSelect(idx)` become `selectedId`/`onSelect(id)`; the post-split reclassify_v2 selection handoff now navigates directly to the resolved item id instead of looking up a filtered-list index.

Salvaged from abandoned PR #1025 (commit `07640bd0`), scoped to ONLY the #644 selection-mechanism refactor. Decoupled from #854 (reclassify_v2 migration, already merged) and from #643 / #769 (already merged separately from that same commit) — this PR does not re-port either.

Fixes #644

## Test plan
- [x] `pnpm exec tsc --noEmit` (desktop) — clean
- [x] `pnpm vitest run src/features/inbox src/features/plans src/app` — 253 passed
- [x] `pnpm exec eslint src/features/inbox src/app/router.tsx` — 0 errors (same 22 pre-existing warnings as main)
- [x] `pnpm exec biome check` on touched files — same 2 pre-existing warnings as main, no new issues