### PR TITLE
fix(projects): localized calibration statuses and linked canonical target

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -2326,6 +2326,7 @@
   "projects_calib_status_no_match": "no match",
   "projects_calib_status_needs_location": "needs location",
   "projects_calib_status_mixed_session": "mixed session",
+  "projects_calib_status_unknown": "unknown status",
   "settings_cleanup_action_keep": "Keep",
   "settings_cleanup_action_archive": "Archive",
   "settings_cleanup_action_delete": "Delete",

--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
@@ -75,7 +75,7 @@ function makeSuccessResponse(
       {
         sessionId: SESSION_1,
         calibrationType: 'bias',
-        status: 'observer_location_missing',
+        status: 'match.observer_location_missing',
       },
       {
         sessionId: SESSION_2,

--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
@@ -211,4 +211,28 @@ describe('CalibrationMatchPanel (spec 007 T034)', () => {
       expect(screen.getByTestId('cal-panel-empty')).toBeInTheDocument();
     });
   });
+
+  it('8. unrecognized status code renders the localized fallback, never the raw code (#664)', async () => {
+    vi.mocked(calibrationMatchSuggestBatch).mockResolvedValue(
+      makeSuccessResponse({
+        results: [
+          {
+            sessionId: SESSION_1,
+            calibrationType: 'dark',
+            status: 'some.unhandled.code',
+            candidates: [],
+          },
+        ],
+      }),
+    );
+    render(<CalibrationMatchPanel sessionIds={[SESSION_1]} />, { wrapper });
+    await waitFor(() => {
+      expect(
+        screen.getByTestId(`cal-type-dark-${SESSION_1}`),
+      ).toBeInTheDocument();
+    });
+    const pill = screen.getByTestId(`cal-type-dark-${SESSION_1}`);
+    expect(pill).toHaveTextContent('unknown status');
+    expect(pill).not.toHaveTextContent('some.unhandled.code');
+  });
 });

--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.tsx
@@ -15,9 +15,10 @@
  * Respects `prefill_suggestion` setting for the Assign link, but defers the
  * actual assign action to the Calibration feature page — no assign call here.
  *
- * Note: until `acquisition_fingerprint` rows are populated by the metadata
- * extraction pipeline, all sessions will return `observer_location_missing`
- * status. The panel handles this gracefully.
+ * Note: sessions missing `acquisition_fingerprint` data return the
+ * `match.observer_location_missing` status. The panel handles this
+ * gracefully (issue #664 — status codes here are backend-prefixed, e.g.
+ * `match.*` / `session.*`, and must be matched as such, not bare).
  */
 
 import { useQuery } from '@tanstack/react-query';
@@ -40,7 +41,7 @@ function statusVariant(status: string): PillVariant {
       return 'warn';
     case 'no_match':
       return 'neutral';
-    case 'observer_location_missing':
+    case 'match.observer_location_missing':
       return 'neutral';
     case 'session.mixed_state':
       return 'warn';
@@ -57,12 +58,12 @@ function statusLabel(status: string): string {
       return m.projects_calib_status_ambiguous();
     case 'no_match':
       return m.projects_calib_status_no_match();
-    case 'observer_location_missing':
+    case 'match.observer_location_missing':
       return m.projects_calib_status_needs_location();
     case 'session.mixed_state':
       return m.projects_calib_status_mixed_session();
     default:
-      return status;
+      return m.projects_calib_status_unknown();
   }
 }
 

--- a/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
@@ -19,6 +19,24 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockAddToast } = vi.hoisted(() => ({ mockAddToast: vi.fn() }));
 
+// The canonical-target block links to /targets (#738), which needs a router
+// context this test doesn't provide — stub as a plain anchor, consistent with
+// TargetsTable.test.tsx's `@tanstack/react-router` mock.
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({
+    children,
+    to,
+    ...rest
+  }: {
+    children?: import('react').ReactNode;
+    to: string;
+  }) => (
+    <a href={to} {...rest}>
+      {children}
+    </a>
+  ),
+}));
+
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {
@@ -116,5 +134,19 @@ describe('ProjectDetail — canonical target rail (spec 035)', () => {
     expect(
       screen.queryByTestId('project-canonical-target'),
     ).not.toBeInTheDocument();
+  });
+
+  it('4. links through to the Targets page (#738 — was a non-interactive span)', () => {
+    setupStore({
+      canonicalTarget: {
+        id: 'ct-3',
+        primaryDesignation: 'M 42',
+        commonName: 'Orion Nebula',
+      },
+    });
+    render(<ProjectDetailContent projectId="proj-m31" />);
+    const card = screen.getByTestId('project-canonical-target');
+    expect(card.tagName).toBe('A');
+    expect(card.getAttribute('href')).toBe('/targets');
   });
 });

--- a/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
@@ -26,15 +26,20 @@ vi.mock('@tanstack/react-router', () => ({
   Link: ({
     children,
     to,
+    search,
     ...rest
   }: {
     children?: import('react').ReactNode;
     to: string;
-  }) => (
-    <a href={to} {...rest}>
-      {children}
-    </a>
-  ),
+    search?: Record<string, string>;
+  }) => {
+    const query = search ? `?${new URLSearchParams(search).toString()}` : '';
+    return (
+      <a href={`${to}${query}`} {...rest}>
+        {children}
+      </a>
+    );
+  },
 }));
 
 vi.mock('./store', async (importOriginal) => {
@@ -147,6 +152,6 @@ describe('ProjectDetail — canonical target rail (spec 035)', () => {
     render(<ProjectDetailContent projectId="proj-m31" />);
     const card = screen.getByTestId('project-canonical-target');
     expect(card.tagName).toBe('A');
-    expect(card.getAttribute('href')).toBe('/targets');
+    expect(card.getAttribute('href')).toBe('/targets?selected=ct-3');
   });
 });

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -31,6 +31,7 @@
  */
 
 import { useState } from 'react';
+import { Link } from '@tanstack/react-router';
 import { m } from '@/lib/i18n';
 import { revealLabel } from '@/lib/reveal-label';
 import { revealInOs } from '@/shared/native/reveal';
@@ -636,9 +637,13 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
       />
 
       {/* spec 035 US1 #2: associated canonical target (resolved on read path).
-          No longer a rail card — a compact inline block under the stepper. */}
+          No longer a rail card — a compact inline block under the stepper.
+          #738: links through to the Targets page with the target
+          pre-selected, matching the Cmd+K / TargetsTable entry point. */}
       {project.canonicalTarget && (
-        <div
+        <Link
+          to="/targets"
+          search={{ selected: project.canonicalTarget.id }}
           className="alm-project-detail__target-info"
           data-testid="project-canonical-target"
         >
@@ -653,7 +658,7 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
               {project.canonicalTarget.commonName}
             </span>
           )}
-        </div>
+        </Link>
       )}
 
       <div className="alm-project-detail__sections">

--- a/apps/desktop/src/styles/components/merges-1.css
+++ b/apps/desktop/src/styles/components/merges-1.css
@@ -515,6 +515,10 @@
  * the leading uppercase label is new. */
 .alm-project-detail__target-info {
   padding: 0 var(--alm-sp-3) var(--alm-sp-2);
+  cursor: pointer;
+}
+.alm-project-detail__target-info:hover .alm-project-detail__target-name {
+  text-decoration: underline;
 }
 .alm-project-detail__target-label {
   font-size: var(--alm-text-xs);


### PR DESCRIPTION
Closes #664
Refs #738 (projects half only — inbox half pending)
Refs #622 (still gated on missing ProjectSummaryDto target field — issue stays open)