### PR TITLE
fix(targets): cross-target alias duplicate guard and session filter display

### DIFF
--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -3658,8 +3658,9 @@ export type ErrorCode = "validation.request_envelope_invalid" | "dev_mode.disabl
 /**  `plan.required` appears in `ContractError` in `transition_use_case.rs`. */
 "plan.required" | 
 /**
- *  Reserved: no current call site returns this — `target.alias.add`
- *  resolves a duplicate idempotently rather than erroring.
+ *  `target.alias.add` (#751, FR-008): the normalized alias already belongs
+ *  to a *different* canonical target. A same-target duplicate stays
+ *  idempotent (no error) — only a cross-target collision returns this.
  */
 "alias.duplicate" | "alias.blank" | "alias.not_found" | "alias.not_removable" | "target.not_found" | "target.invalid_id" | 
 /**
@@ -9455,23 +9456,28 @@ export type TargetSearchResponse_Serialize = {
  * 
  *  Only columns reliably present in `acquisition_session` are surfaced:
  *  - `id` — row UUID.
- *  - `session_key` — raw JSON string (matches the `session_key` column, which
- *    stores the composite key as a JSON object — caller can parse it if needed).
+ *  - `session_key` — the composite grouping key (pipe-delimited
+ *    `target|filter|binning|gain|night`, per `sessions::session_key`) —
+ *    caller can parse it further if needed.
  *  - `created_at` — RFC 3339 UTC timestamp the row was created.
  *  - `frame_count` — length of the `frame_ids` JSON array (computed via
  *    `json_array_length`; 0 for legacy rows with the default `'[]'`).
+ *  - `filter` — the filter segment of `session_key` (FR-003/US2-AC1, #739);
+ *    `""` when the session has no filter (e.g. an unfiltered OSC capture).
  * 
  *  Spec 041 FR-051 (T076): no `state` field — sessions are derived,
  *  already-confirmed inventory with no review lifecycle.
  */
 export type TargetSessionItem = {
 	id: string,
-	/**  Raw JSON object stored in `acquisition_session.session_key`. */
+	/**  The composite `session_key` grouping key (see struct docs for shape). */
 	sessionKey: string,
 	/**  RFC 3339 UTC creation timestamp. */
 	createdAt: string,
 	/**  Number of frames in `frame_ids` JSON array. */
 	frameCount: number,
+	/**  Filter segment of `session_key`; `""` when the session has no filter. */
+	filter: string,
 };
 
 /**  Request for `target.sessions.list` (spec 023 US2). */

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -578,6 +578,7 @@ describe('TargetDetailV2', () => {
           sessionKey: '{}',
           createdAt: '2026-03-15T22:00:00Z',
           frameCount: 42,
+          filter: '',
         },
       ]),
     );
@@ -589,6 +590,22 @@ describe('TargetDetailV2', () => {
     );
   });
 
+  it('21b. (#739) linked session row renders the filter alongside date and frame count', async () => {
+    mockListTargetSessions.mockResolvedValue(
+      ok([
+        {
+          id: 'sess-ha',
+          sessionKey: 'target|Ha|1x1|100|2026-03-15',
+          createdAt: '2026-03-15T22:00:00Z',
+          frameCount: 10,
+          filter: 'Ha',
+        },
+      ]),
+    );
+    render(<TargetDetailV2 targetId={TARGET_ID} />);
+    await waitFor(() => expect(screen.getByText('Ha')).toBeInTheDocument());
+  });
+
   it('22. (US2) clicking session row navigates to /sessions with selected=id', async () => {
     mockListTargetSessions.mockResolvedValue(
       ok([
@@ -597,6 +614,7 @@ describe('TargetDetailV2', () => {
           sessionKey: '{}',
           createdAt: '2026-03-15T22:00:00Z',
           frameCount: 5,
+          filter: '',
         },
       ]),
     );

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -1120,6 +1120,11 @@ export function TargetDetailV2({
                         <span className="alm-planner__link-date">
                           {dateStr}
                         </span>
+                        {s.filter !== '' && (
+                          <span className="alm-planner__link-meta">
+                            {s.filter}
+                          </span>
+                        )}
                         <span className="alm-planner__link-meta">
                           {m.targets_detail_session_frames({
                             count: s.frameCount,

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -183,13 +183,15 @@ pub async fn list(pool: &SqlitePool) -> Result<Vec<TargetListItem>, ContractErro
 
 /// `target.alias.add` — add a user alias to a target (gen-3).
 ///
-/// The alias is normalized before storage; a duplicate (same normalized form)
-/// is returned idempotently.
+/// The alias is normalized before storage; a same-target duplicate (same
+/// normalized form) is returned idempotently. A normalized form already owned
+/// by a *different* target is rejected (FR-008, #751) rather than silently
+/// creating an ambiguous cross-target alias.
 ///
 /// # Errors
 ///
 /// Returns [`ContractError`] with code `target.not_found`, `target.invalid_id`,
-/// `alias.blank`, or `internal.database`.
+/// `alias.blank`, `alias.duplicate`, or `internal.database`.
 pub async fn alias_add(
     pool: &SqlitePool,
     req: &TargetAliasAddRequest,
@@ -212,6 +214,31 @@ pub async fn alias_add(
             ErrorSeverity::Blocking,
             false,
         ));
+    }
+
+    // FR-008 (#751): guard against the same normalized alias already owned by
+    // a *different* canonical target. The DB constraint is per-target only
+    // (`UNIQUE(target_id, normalized)`), so a same-target duplicate stays the
+    // existing idempotent path below; only a cross-target collision errors.
+    let target_id_str = uuid.to_string();
+    let normalized = simbad_resolver::normalize::normalize(&req.alias);
+    if !normalized.is_empty() {
+        let owner = persistence_db::repositories::q_resolver::select_target_id_by_normalized_alias(
+            pool,
+            &normalized,
+        )
+        .await
+        .map_err(db_err)?;
+        if let Some(owner_id) = owner {
+            if owner_id != target_id_str {
+                return Err(ContractError::new(
+                    ErrorCode::AliasDuplicate,
+                    format!("Alias '{}' already belongs to another target.", req.alias),
+                    ErrorSeverity::Blocking,
+                    false,
+                ));
+            }
+        }
     }
 
     let result = cache::insert_user_alias(pool, uuid, &req.alias).await.map_err(db_err)?;
@@ -808,6 +835,39 @@ mod tests {
         };
         let err = alias_add(db.pool(), &req).await.unwrap_err();
         assert_eq!(err.code, ErrorCode::TargetNotFound);
+    }
+
+    /// FR-008 (#751): adding an alias to target B that's already an alias of
+    /// target A must return `alias.duplicate`, never silently succeed —
+    /// `UNIQUE(target_id, normalized)` alone does not stop cross-target reuse.
+    #[tokio::test]
+    async fn alias_add_cross_target_duplicate_returns_error() {
+        let db = setup().await;
+        let m31_id = seed_m31(&db).await;
+        let m42 = ResolvedIdentity {
+            simbad_oid: Some(1_575_545),
+            primary_designation: "M 42".to_owned(),
+            common_name: Some("Orion Nebula".to_owned()),
+            object_type: ObjectType::Other,
+            ra_deg: 83.822_08,
+            dec_deg: -5.391_11,
+            v_mag: None,
+            aliases: vec![ResolvedAlias::new("M 42", CacheKind::Designation)],
+            source: TargetSource::Resolved,
+        };
+        let (m42_id, _) = upsert_resolved(db.pool(), &m42).await.unwrap();
+
+        // "NGC 224" is already an M31 designation alias (seeded via m31()).
+        let req =
+            TargetAliasAddRequest { target_id: m42_id.to_string(), alias: "NGC 224".to_owned() };
+        let err = alias_add(db.pool(), &req).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::AliasDuplicate);
+
+        // Same-target re-add of an existing alias stays idempotent (FR-008
+        // first clause) — only the cross-target case above errors.
+        let same_target_req =
+            TargetAliasAddRequest { target_id: m31_id.to_string(), alias: "NGC 224".to_owned() };
+        assert!(alias_add(db.pool(), &same_target_req).await.is_ok());
     }
 
     // ── target.alias.remove ───────────────────────────────────────────────────

--- a/crates/app/targets/src/target_management.rs
+++ b/crates/app/targets/src/target_management.rs
@@ -383,13 +383,25 @@ pub async fn sessions_list(
             .map_err(db_err)?;
     Ok(rows
         .into_iter()
-        .map(|r| TargetSessionItem {
-            id: r.id,
-            session_key: r.session_key,
-            created_at: r.created_at,
-            frame_count: r.frame_count,
+        .map(|r| {
+            let filter = filter_from_session_key(&r.session_key);
+            TargetSessionItem {
+                id: r.id,
+                session_key: r.session_key,
+                created_at: r.created_at,
+                frame_count: r.frame_count,
+                filter,
+            }
         })
         .collect())
+}
+
+/// Extract the filter segment (2nd field) from a `session_key` of shape
+/// `target|filter|binning|gain|night` (`sessions::session_key`, #739
+/// FR-003/US2-AC1). Returns `""` for a malformed/legacy key rather than
+/// panicking — display-only derivation, never authoritative.
+fn filter_from_session_key(session_key: &str) -> String {
+    session_key.split('|').nth(1).unwrap_or("").to_owned()
 }
 
 /// `target.projects.list` — list projects linked to a target (spec 023 US3).
@@ -1024,6 +1036,41 @@ mod tests {
         assert_eq!(items.len(), 1);
         assert_eq!(items[0].id, "s-001");
         assert_eq!(items[0].frame_count, 3);
+    }
+
+    /// FR-003/US2-AC1 (#739): the filter segment of a real (pipe-delimited,
+    /// `sessions::session_key`-shaped) `session_key` must surface on the DTO.
+    #[tokio::test]
+    async fn sessions_list_extracts_filter_from_session_key() {
+        let db = setup().await;
+        let id = seed_m31(&db).await;
+        sqlx::query(
+            r"INSERT INTO acquisition_session
+               (id, session_key, frame_ids, created_at, canonical_target_id)
+               VALUES ('s-002', 'M 31|Ha|1x1|100|2026-01-01', '[1]',
+                       '2026-01-01T00:00:00Z', ?)",
+        )
+        .bind(id.to_string())
+        .execute(db.pool())
+        .await
+        .expect("insert session failed");
+
+        let req = TargetSessionsListRequest { target_id: id.to_string() };
+        let items = sessions_list(db.pool(), &req).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].filter, "Ha");
+    }
+
+    /// A malformed/legacy `session_key` (no pipes) yields `""`, never a panic.
+    #[tokio::test]
+    async fn sessions_list_filter_empty_for_malformed_session_key() {
+        let db = setup().await;
+        let id = seed_m31(&db).await;
+        insert_session_linked_to(&db, "s-003", id).await;
+        let req = TargetSessionsListRequest { target_id: id.to_string() };
+        let items = sessions_list(db.pool(), &req).await.unwrap();
+        assert_eq!(items.len(), 1);
+        assert_eq!(items[0].filter, "");
     }
 
     #[tokio::test]

--- a/crates/contracts/core/src/error_code.rs
+++ b/crates/contracts/core/src/error_code.rs
@@ -360,8 +360,9 @@ pub enum ErrorCode {
     PlanRequired,
 
     // ── Target / alias codes ───────────────────────────────────────────────────
-    /// Reserved: no current call site returns this — `target.alias.add`
-    /// resolves a duplicate idempotently rather than erroring.
+    /// `target.alias.add` (#751, FR-008): the normalized alias already belongs
+    /// to a *different* canonical target. A same-target duplicate stays
+    /// idempotent (no error) — only a cross-target collision returns this.
     #[serde(rename = "alias.duplicate")]
     AliasDuplicate,
     #[serde(rename = "alias.blank")]

--- a/crates/contracts/core/src/targets.rs
+++ b/crates/contracts/core/src/targets.rs
@@ -271,11 +271,14 @@ pub struct TargetDisplayAliasClearRequest {
 ///
 /// Only columns reliably present in `acquisition_session` are surfaced:
 /// - `id` — row UUID.
-/// - `session_key` — raw JSON string (matches the `session_key` column, which
-///   stores the composite key as a JSON object — caller can parse it if needed).
+/// - `session_key` — the composite grouping key (pipe-delimited
+///   `target|filter|binning|gain|night`, per `sessions::session_key`) —
+///   caller can parse it further if needed.
 /// - `created_at` — RFC 3339 UTC timestamp the row was created.
 /// - `frame_count` — length of the `frame_ids` JSON array (computed via
 ///   `json_array_length`; 0 for legacy rows with the default `'[]'`).
+/// - `filter` — the filter segment of `session_key` (FR-003/US2-AC1, #739);
+///   `""` when the session has no filter (e.g. an unfiltered OSC capture).
 ///
 /// Spec 041 FR-051 (T076): no `state` field — sessions are derived,
 /// already-confirmed inventory with no review lifecycle.
@@ -283,12 +286,14 @@ pub struct TargetDisplayAliasClearRequest {
 #[serde(rename_all = "camelCase")]
 pub struct TargetSessionItem {
     pub id: String,
-    /// Raw JSON object stored in `acquisition_session.session_key`.
+    /// The composite `session_key` grouping key (see struct docs for shape).
     pub session_key: String,
     /// RFC 3339 UTC creation timestamp.
     pub created_at: String,
     /// Number of frames in `frame_ids` JSON array.
     pub frame_count: i64,
+    /// Filter segment of `session_key`; `""` when the session has no filter.
+    pub filter: String,
 }
 
 /// A linked project returned by `target.projects.list` (spec 023 US3).


### PR DESCRIPTION
Closes #751
Refs #739 (filter field done; exposure not in schema; remainder → follow-up node)
Refs #634 (backend was never implemented — #1009's stub was inert; real command rides a dedicated node; do NOT close #634)