### PR TITLE
fix(persistence): enable WAL journal mode to kill poller/writer lock contention

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4186,6 +4186,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sqlx",
+ "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",

--- a/crates/persistence/db/Cargo.toml
+++ b/crates/persistence/db/Cargo.toml
@@ -27,6 +27,7 @@ uuid.workspace = true
 # `SqliteLifecycleRepository::new`.
 [dev-dependencies]
 audit = { path = "../../audit" }
+tempfile.workspace = true
 
 [lints]
 workspace = true

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -13,7 +13,9 @@
 //! Migration 0064 added the `framing`/`framing_session` tables, `projects.is_mosaic`,
 //! and the durable `acquisition_session` clustering-key columns (spec 008 Q27).
 
-use sqlx::sqlite::{SqlitePool, SqlitePoolOptions};
+use std::str::FromStr;
+
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions};
 
 pub mod operation_state;
 /// Reference pattern for the centralized typed persistence layer (sea-query +
@@ -67,11 +69,29 @@ impl Database {
     /// `connection_string` should be a `sqlite://`-prefixed path or the special
     /// value `sqlite::memory:` for an in-process ephemeral store.
     ///
+    /// Explicitly requests WAL journaling (#830): sqlx's default journal mode
+    /// is whatever the on-disk file already uses, which for a freshly created
+    /// file is SQLite's own default, rollback-journal (`DELETE`) mode. Under
+    /// rollback-journal, a writer holds an exclusive lock on the *whole file*
+    /// for the life of its transaction, so a background reader (e.g. the
+    /// desktop poller's `registered_sources`/`inbox_items` queries) sharing
+    /// this same pool blocks behind any concurrent writer (plan apply, audit,
+    /// `events` inserts) until `busy_timeout` elapses or the writer commits —
+    /// this is the slow-query pattern from #830, not a missing index or an
+    /// oversized transaction (`events` inserts are single-statement, see
+    /// `repositories::events::insert_event`). WAL lets readers proceed
+    /// concurrently with a single writer, removing that contention class.
+    /// `synchronous` is left at SQLite's default (`FULL`) — WAL commits are
+    /// already fsynced at that setting, so durability of the audit record
+    /// (constitution II/V) is unchanged; only the locking model differs.
+    ///
     /// # Errors
     ///
     /// Returns [`DbError::Database`] if the pool cannot connect to the given URL.
     pub async fn connect(connection_string: &str) -> DbResult<Self> {
-        let pool = SqlitePoolOptions::new().max_connections(8).connect(connection_string).await?;
+        let options =
+            SqliteConnectOptions::from_str(connection_string)?.journal_mode(SqliteJournalMode::Wal);
+        let pool = SqlitePoolOptions::new().max_connections(8).connect_with(options).await?;
         Ok(Self { pool })
     }
 

--- a/crates/persistence/db/tests/wal_journal_mode.rs
+++ b/crates/persistence/db/tests/wal_journal_mode.rs
@@ -1,0 +1,150 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+#![allow(clippy::doc_markdown)] // "SQLite" is a proper noun, not code -- matches src/lib.rs
+//! Regression coverage for #830 (background poll queries routinely exceeding
+//! the 1s slow-query threshold every 30-90s against ~10-row tables).
+//!
+//! Root cause: `Database::connect` opened the pool without an explicit
+//! journal mode, so file-backed databases stayed on SQLite's default
+//! rollback-journal (`DELETE`) mode. Under rollback-journal, a writer holding
+//! an exclusive lock (taken for the life of a `BEGIN EXCLUSIVE` transaction,
+//! or briefly at commit for any write) blocks *every* reader sharing the same
+//! file, including unrelated poller queries on other pooled connections. WAL
+//! mode gives readers a consistent snapshot independent of an in-flight
+//! writer, removing that contention class without weakening durability
+//! (`synchronous` is left at SQLite's default `FULL`).
+//!
+//! These tests reproduce the underlying SQLite locking behaviour directly
+//! (via `BEGIN EXCLUSIVE`) rather than racing a real poll loop, so they are
+//! deterministic: rollback-journal readers are provably blocked for the
+//! writer's held duration; WAL readers are provably not.
+
+use std::str::FromStr;
+use std::time::{Duration, Instant};
+
+use persistence_db::Database;
+use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode};
+use sqlx::{Connection, SqliteConnection};
+
+const HOLD: Duration = Duration::from_millis(600);
+/// Generous slack for CI/WSL scheduling jitter around the blocking case.
+const BLOCKED_FLOOR: Duration = Duration::from_millis(400);
+/// A reader that isn't blocked should return orders of magnitude faster than
+/// `HOLD`; this is well above normal in-process query latency but far below
+/// `HOLD`, so it can't pass by accident.
+const UNBLOCKED_CEILING: Duration = Duration::from_millis(300);
+
+/// Baseline: on rollback-journal (SQLite's un-configured default), a
+/// concurrent writer holding `BEGIN EXCLUSIVE` blocks a reader on a separate
+/// connection to the same file for the duration of the write.
+#[tokio::test]
+async fn rollback_journal_reader_blocks_behind_exclusive_writer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("rollback.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let writer_opts = SqliteConnectOptions::from_str(&url)
+        .expect("parse opts")
+        .journal_mode(SqliteJournalMode::Delete);
+    let mut writer = SqliteConnection::connect_with(&writer_opts).await.expect("writer connect");
+    sqlx::query("CREATE TABLE scratch (id INTEGER)").execute(&mut writer).await.expect("create");
+
+    // Reader connects *before* the writer's exclusive lock, mirroring a
+    // poller that already holds a live connection from the shared pool
+    // (rather than re-connecting per poll) when the writer starts.
+    let reader_opts = SqliteConnectOptions::from_str(&url)
+        .expect("parse opts")
+        .journal_mode(SqliteJournalMode::Delete)
+        .busy_timeout(Duration::from_secs(5));
+    let mut reader = SqliteConnection::connect_with(&reader_opts).await.expect("reader connect");
+
+    sqlx::query("BEGIN EXCLUSIVE").execute(&mut writer).await.expect("begin exclusive");
+
+    let writer_task = tokio::spawn(async move {
+        tokio::time::sleep(HOLD).await;
+        sqlx::query("COMMIT").execute(&mut writer).await.expect("commit");
+    });
+
+    // Give the writer a moment to actually acquire the exclusive lock before
+    // the reader queries, matching the poller-arrives-mid-write scenario.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let start = Instant::now();
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM scratch")
+        .fetch_one(&mut reader)
+        .await
+        .expect("blocked read eventually succeeds");
+    let elapsed = start.elapsed();
+
+    writer_task.await.expect("writer task");
+
+    assert_eq!(count, 0);
+    assert!(
+        elapsed >= BLOCKED_FLOOR,
+        "expected rollback-journal reader to block behind the exclusive writer for \
+         roughly {HOLD:?}, actually returned after {elapsed:?}"
+    );
+}
+
+/// Fix: `Database::connect` requests WAL, so the same "reader concurrent
+/// with an exclusive writer" scenario does not block.
+#[tokio::test]
+async fn database_connect_wal_reader_does_not_block_behind_exclusive_writer() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("wal.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = Database::connect(&url).await.expect("Database::connect");
+    let pool = db.pool();
+
+    sqlx::query("CREATE TABLE scratch (id INTEGER)")
+        .execute(pool)
+        .await
+        .expect("create scratch table");
+
+    let mut writer_conn = pool.acquire().await.expect("acquire writer connection");
+    sqlx::query("BEGIN EXCLUSIVE").execute(&mut *writer_conn).await.expect("begin exclusive");
+
+    let writer_task = tokio::spawn(async move {
+        tokio::time::sleep(HOLD).await;
+        sqlx::query("COMMIT").execute(&mut *writer_conn).await.expect("commit");
+    });
+
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let start = Instant::now();
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM scratch")
+        .fetch_one(pool)
+        .await
+        .expect("unblocked WAL read");
+    let elapsed = start.elapsed();
+
+    writer_task.await.expect("writer task");
+
+    assert_eq!(count, 0);
+    assert!(
+        elapsed < UNBLOCKED_CEILING,
+        "expected WAL reader to proceed concurrently with the exclusive writer \
+         (< {UNBLOCKED_CEILING:?}), actually took {elapsed:?} \
+         (regression: reader blocked like rollback-journal mode)"
+    );
+}
+
+/// `Database::connect` actually reports `journal_mode = wal` back from
+/// SQLite, not just requests it (WAL can silently fall back in some
+/// environments, e.g. network filesystems).
+#[tokio::test]
+async fn database_connect_reports_wal_journal_mode() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let path = dir.path().join("journal-mode-check.db");
+    let url = format!("sqlite://{}?mode=rwc", path.display());
+
+    let db = Database::connect(&url).await.expect("Database::connect");
+    let (mode,): (String,) = sqlx::query_as("PRAGMA journal_mode")
+        .fetch_one(db.pool())
+        .await
+        .expect("read journal_mode");
+
+    assert_eq!(mode.to_lowercase(), "wal");
+}


### PR DESCRIPTION
Refs #830 (NOT Closes — stays open pending real-app slow-query re-measurement, queued in the MCP validation lane)