### PR TITLE
feat(targets): wire batched moon/opposition backend into targets table

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -38,6 +38,8 @@ import type {
   TargetDetailV3_Serialize,
   TargetSearchResponse_Serialize,
   TargetResolveSimbadResponse_Serialize,
+  TargetMoonOppositionBatchRequest,
+  TargetMoonOppositionBatchResponse,
   ProjectCreateResult_Serialize,
   ProjectUpdateResult,
   ProjectSourceAddResult_Serialize,
@@ -864,6 +866,57 @@ export async function mockInvoke(
       const targetId = req?.targetId ?? '';
       mockFavourites.delete(targetId);
       return { targetId };
+    }
+    case 'target_moon_opposition_batch': {
+      // #634: mock mode reuses the SAME TS ephemeris (`astro/moon-state.ts` +
+      // `astro/lunar-separation.ts` + `astro/opposition.ts`) the detail panel
+      // (`TargetDetailV2`'s Best-date tooltip, still TS per ADR-0001's
+      // interactive-ephemeris boundary) computes independently — a
+      // hand-rolled placeholder here would diverge from the detail panel's
+      // value and break the "list Opposition == detail Best date" mock-mode
+      // regression guard (e2e 9.5c). This mirrors what the real Rust command
+      // approximates (both derive the same physical quantity); it is NOT the
+      // real backend, only its mock-mode stand-in.
+      const [{ moonStateAt }, { lunarSeparationDeg }, { nextOpposition }] =
+        await Promise.all([
+          import('@/features/targets/astro/moon-state'),
+          import('@/features/targets/astro/lunar-separation'),
+          import('@/features/targets/astro/opposition'),
+        ]);
+      const req = (
+        _args as { req?: TargetMoonOppositionBatchRequest } | undefined
+      )?.req;
+      const at = req?.at ? new Date(req.at) : new Date();
+      const targets = req?.targets ?? [];
+      const { moonVec } = moonStateAt(at);
+      return {
+        results: targets.map((t) => {
+          if (
+            t.raDeg == null ||
+            t.decDeg == null ||
+            !Number.isFinite(t.raDeg) ||
+            !Number.isFinite(t.decDeg)
+          ) {
+            return { id: t.id, moonSeparationDeg: null, opposition: null };
+          }
+          const moonSeparationDeg = lunarSeparationDeg(
+            t.raDeg,
+            t.decDeg,
+            moonVec,
+          );
+          const opposition = nextOpposition(t.raDeg, at);
+          return {
+            id: t.id,
+            moonSeparationDeg,
+            opposition: opposition
+              ? {
+                  date: opposition.date.toISOString(),
+                  daysUntil: opposition.daysUntil,
+                }
+              : null,
+          };
+        }),
+      } satisfies TargetMoonOppositionBatchResponse;
     }
     case 'target_search': {
       const req = (_args as { req?: { query?: string } } | undefined)?.req;

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -55,6 +55,7 @@ const {
   mockGetTargetNote,
   mockUpdateTargetNote,
   mockAstroFormatBatch,
+  mockMoonOppositionBatch,
 } = vi.hoisted(() => ({
   mockListTargets: vi.fn(),
   mockGetTargetDetail: vi.fn(),
@@ -69,6 +70,8 @@ const {
   mockGetTargetNote: vi.fn(),
   mockUpdateTargetNote: vi.fn(),
   mockAstroFormatBatch: vi.fn(),
+  // #634: TargetsTable's batched Moon-separation/opposition call.
+  mockMoonOppositionBatch: vi.fn(),
 }));
 
 /** Wrap a value in the generated `{ status: 'ok' }` Result envelope. */
@@ -89,6 +92,7 @@ vi.mock('@/bindings/index', () => ({
     targetNoteGet: mockGetTargetNote,
     targetNoteUpdate: mockUpdateTargetNote,
     targetAstroFormatBatch: mockAstroFormatBatch,
+    targetMoonOppositionBatch: mockMoonOppositionBatch,
   },
 }));
 
@@ -103,6 +107,20 @@ mockListTargetProjects.mockResolvedValue(ok([]));
 mockGetTargetNote.mockResolvedValue(ok({ notes: null }));
 mockUpdateTargetNote.mockResolvedValue(ok({ notes: null }));
 mockAstroFormatBatch.mockResolvedValue(ok({ formatted: [] }));
+// #634: default to "no result yet" for every requested id — rows render the
+// existing explicit-unknown "—" state, matching the pre-#634 behavior these
+// tests already assert on (no test here depends on a specific separation/
+// opposition value).
+mockMoonOppositionBatch.mockImplementation(
+  async (req: { targets: Array<{ id: string }> }) =>
+    ok({
+      results: req.targets.map((t) => ({
+        id: t.id,
+        moonSeparationDeg: null,
+        opposition: null,
+      })),
+    }),
+);
 
 const mockNavigate = vi.fn();
 const mockSelectedId = { current: undefined as string | undefined };

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -479,6 +479,20 @@ describe('TargetsTable — lunar distance (US2)', () => {
     // No numeric lunar separations; both rows show the unknown dash.
     expect(screen.queryByText('90°')).not.toBeInTheDocument();
   });
+
+  it('#634: fetches geometry for the whole revealed set in ONE batched call, never per-row', async () => {
+    renderWithNight('asc', [FAR, UNK, NEAR, MID]);
+    await waitFor(() => expect(screen.getByText('90°')).toBeInTheDocument());
+    // One call for the batch, not one per target row.
+    expect(mockMoonOppositionBatch).toHaveBeenCalledTimes(1);
+    // UNK (null coordinates) is filtered out client-side before the IPC call
+    // (mirrors the real command's own "never a fabricated value" contract) —
+    // only the 3 targets with real coordinates are sent.
+    const req = mockMoonOppositionBatch.mock.calls[0][0] as {
+      targets: unknown[];
+    };
+    expect(req.targets).toHaveLength(3);
+  });
 });
 
 // ── Row cache contract (#573 perf) ──────────────────────────────────────────

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -21,7 +21,13 @@
  *  - filter badges render broadband and/or narrowband bands.
  */
 
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  within,
+  waitFor,
+} from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { TargetListItem } from '@/bindings/index';
 
@@ -42,6 +48,46 @@ vi.mock('@tanstack/react-router', () => ({
     </a>
   ),
 }));
+
+// #634: real lunar separation + opposition now come from ONE batched
+// `target.moon_opposition.batch` IPC call instead of synchronous TS
+// `astronomy-engine` math — mock it (mirrors `TargetDetailV2.test.tsx`'s
+// `targetAstroFormatBatch` mock). `moonSeparationDeg: raDeg` reproduces the
+// exact degrees the old synchronous test fixtures assumed (a Dec-0 target's
+// separation from a Moon at RA0/Dec0 equals its RA), without hardcoding by id.
+const { mockMoonOppositionBatch } = vi.hoisted(() => ({
+  mockMoonOppositionBatch: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    targetMoonOppositionBatch: mockMoonOppositionBatch,
+  },
+}));
+
+interface MoonOppositionBatchTestRequest {
+  targets: Array<{ id: string; raDeg: number | null; decDeg: number | null }>;
+}
+
+beforeEach(() => {
+  mockMoonOppositionBatch.mockReset();
+  mockMoonOppositionBatch.mockImplementation(
+    async (req: MoonOppositionBatchTestRequest) => ({
+      status: 'ok' as const,
+      data: {
+        results: req.targets.map((t) => ({
+          id: t.id,
+          moonSeparationDeg:
+            t.raDeg != null && t.decDeg != null ? Math.abs(t.raDeg) : null,
+          opposition:
+            t.raDeg != null && t.decDeg != null
+              ? { date: '2026-08-01T00:00:00Z', daysUntil: 10 }
+              : null,
+        })),
+      },
+    }),
+  );
+});
 
 import {
   TargetsTable,
@@ -152,7 +198,7 @@ describe('TargetsTable (#84/#85)', () => {
     expect(screen.getAllByText('Unknown').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('renders real per-band viability pills with a night (spec 047 US3)', () => {
+  it('renders real per-band viability pills with a night (spec 047 US3)', async () => {
     render(
       <TargetsTable
         targets={TARGETS}
@@ -164,11 +210,14 @@ describe('TargetsTable (#84/#85)', () => {
       />,
     );
     // Each row has 7 band pills (L/R/G/B/Ha/SII/OIII), each labelled viable or
-    // not-viable — never a fabricated recommendation.
-    const haPills = screen.getAllByLabelText(
-      /^Ha: (viable|not viable) tonight$/,
-    );
-    expect(haPills.length).toBeGreaterThanOrEqual(1);
+    // not-viable — never a fabricated recommendation. #634: separation now
+    // resolves from the (mocked) batched IPC call, one render tick later.
+    await waitFor(() => {
+      const haPills = screen.getAllByLabelText(
+        /^Ha: (viable|not viable) tonight$/,
+      );
+      expect(haPills.length).toBeGreaterThanOrEqual(1);
+    });
   });
 
   it('fires onSelect when a target row is clicked', () => {
@@ -394,23 +443,27 @@ describe('TargetsTable — lunar distance (US2)', () => {
       .map((el) => el.textContent as string);
   }
 
-  it('renders whole-degree separations and "—" for unknown coordinates', () => {
+  it('renders whole-degree separations and "—" for unknown coordinates', async () => {
     renderWithNight('asc', [MID, UNK]);
-    // MID is 90° from the Moon.
-    expect(screen.getByText('90°')).toBeInTheDocument();
+    // MID is 90° from the Moon (#634: resolves from the mocked batched call).
+    await waitFor(() => expect(screen.getByText('90°')).toBeInTheDocument());
     // UNK shows an explicit dash, never a number.
     const table = screen.getByRole('table');
     expect(within(table).getAllByText('—').length).toBeGreaterThanOrEqual(1);
   });
 
-  it('sorts ascending by real separation with unknowns last', () => {
+  it('sorts ascending by real separation with unknowns last', async () => {
     renderWithNight('asc', [FAR, UNK, NEAR, MID]);
-    expect(rowOrder()).toEqual(['NEAR', 'MID', 'FAR', 'UNK']);
+    await waitFor(() =>
+      expect(rowOrder()).toEqual(['NEAR', 'MID', 'FAR', 'UNK']),
+    );
   });
 
-  it('sorts descending by real separation, unknowns STILL last', () => {
+  it('sorts descending by real separation, unknowns STILL last', async () => {
     renderWithNight('desc', [FAR, UNK, NEAR, MID]);
-    expect(rowOrder()).toEqual(['FAR', 'MID', 'NEAR', 'UNK']);
+    await waitFor(() =>
+      expect(rowOrder()).toEqual(['FAR', 'MID', 'NEAR', 'UNK']),
+    );
   });
 
   it('gates off (all "—") when no observing night is provided', () => {
@@ -435,9 +488,15 @@ describe('TargetsTable — lunar distance (US2)', () => {
 // so growing the revealed target set only pays for the delta. These tests
 // assert the cache CONTRACT directly (object-identity reuse on a hit, a
 // fresh compute on a miss) rather than timing, which would be flaky on CI.
+//
+// #634: only `alt` (real astronomy-engine altitude sampling) is cached by
+// `genKey` now — `moon` is derived fresh from the (O(1) map-lookup) batch
+// geometry on every call, so the identity assertions below target `.alt`
+// specifically rather than the whole `{alt, moon}` wrapper.
 describe('TargetsTable row cache (#573)', () => {
   const { getCachedRow, rowCacheGenKey } = __testExports;
   const TARGET = coordItem('CACHE-TEST', 10, 20);
+  const NO_GEOMETRY = new Map();
   const SITE_A: ObserverSite = {
     id: 'site-a',
     name: 'A',
@@ -449,7 +508,7 @@ describe('TargetsTable row cache (#573)', () => {
     minHorizonAltDeg: 0,
   };
 
-  it('reuses the same object on a cache hit (same target id + genKey)', () => {
+  it('reuses the same alt object on a cache hit (same target id + genKey)', () => {
     const cache = new Map();
     const genKey = rowCacheGenKey(
       30,
@@ -467,6 +526,7 @@ describe('TargetsTable row cache (#573)', () => {
       1000,
       DEFAULT_MOON_AVOIDANCE,
       null,
+      NO_GEOMETRY,
     );
     const second = getCachedRow(
       cache,
@@ -477,11 +537,12 @@ describe('TargetsTable row cache (#573)', () => {
       1000,
       DEFAULT_MOON_AVOIDANCE,
       null,
+      NO_GEOMETRY,
     );
-    expect(second).toBe(first);
+    expect(second.alt).toBe(first.alt);
   });
 
-  it('recomputes (fresh object) when the generation key changes', () => {
+  it('recomputes a fresh alt object when the generation key changes', () => {
     const cache = new Map();
     const genKeyA = rowCacheGenKey(
       30,
@@ -506,6 +567,7 @@ describe('TargetsTable row cache (#573)', () => {
       1000,
       DEFAULT_MOON_AVOIDANCE,
       null,
+      NO_GEOMETRY,
     );
     const second = getCachedRow(
       cache,
@@ -516,10 +578,11 @@ describe('TargetsTable row cache (#573)', () => {
       1000,
       DEFAULT_MOON_AVOIDANCE,
       null,
+      NO_GEOMETRY,
     );
-    expect(second).not.toBe(first);
+    expect(second.alt).not.toBe(first.alt);
     // The new entry now occupies the cache slot for this id.
-    expect(cache.get(TARGET.id)).toBe(second);
+    expect(cache.get(TARGET.id)?.alt).toBe(second.alt);
   });
 
   it('rowCacheGenKey changes with each astronomy input', () => {

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -73,9 +73,11 @@
  * is driven by the host page via `?selected`).
  */
 
-import { useMemo, useRef } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { Link } from '@tanstack/react-router';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import type { TargetListItem, TargetObjectType } from '@/bindings/index';
 import { Pill, Banner, Skeleton, tableIndent } from '@/ui';
 import { SortHeader, ariaSortFor } from '@/components';
@@ -91,6 +93,7 @@ import type { ObservingNight } from './astro/moon-state';
 import {
   deriveRowMoonPlanning,
   UNKNOWN_ROW_PLANNING,
+  type RowMoonGeometry,
   type RowMoonPlanning,
 } from './astro/row-planning';
 import {
@@ -266,7 +269,6 @@ interface TargetGroup {
 interface RowCacheEntry {
   genKey: string;
   alt: RowAltitude;
-  moon: RowMoonPlanning;
 }
 
 /**
@@ -293,9 +295,16 @@ function rowCacheGenKey(
 }
 
 /**
- * Look up (or compute + cache) a target's full-catalogue-pass altitude/moon
- * values. `includeMoonGeometry` is always `false` here — same contract as
+ * Look up (or compute + cache) a target's full-catalogue-pass altitude, and
+ * derive its Moon planning fresh from the pre-fetched batch geometry map
+ * (#634). `includeMoonGeometry` is always `false` here — same contract as
  * the call sites this replaces.
+ *
+ * Only `alt` (real astronomy-engine altitude sampling) is cached by `genKey`
+ * — `moon` is no longer astronomy-engine-derived here (real geometry now
+ * comes from `moonGeometry`, an O(1) map lookup), so recomputing it on every
+ * call is cheap and always reflects the latest fetched batch without needing
+ * its own cache-invalidation key.
  */
 function getCachedRow(
   cache: Map<string, RowCacheEntry>,
@@ -306,21 +315,23 @@ function getCachedRow(
   dateMs: number,
   guidanceParams: MoonAvoidanceParams,
   night: ObservingNight | null,
+  moonGeometry: ReadonlyMap<string, RowMoonGeometry>,
 ): { alt: RowAltitude; moon: RowMoonPlanning } {
   const cached = cache.get(t.id);
-  if (cached && cached.genKey === genKey) return cached;
-  const alt = rowAltitudeFor(
+  const alt =
+    cached && cached.genKey === genKey
+      ? cached.alt
+      : rowAltitudeFor(t, usableAltDeg, site, dateMs, guidanceParams, false);
+  if (!cached || cached.genKey !== genKey) {
+    cache.set(t.id, { genKey, alt });
+  }
+  const moon = deriveRowMoonPlanning(
     t,
-    usableAltDeg,
-    site,
-    dateMs,
+    night,
     guidanceParams,
-    false,
+    night ? (moonGeometry.get(t.id) ?? null) : null,
   );
-  const moon = deriveRowMoonPlanning(t, night, guidanceParams);
-  const entry: RowCacheEntry = { genKey, alt, moon };
-  cache.set(t.id, entry);
-  return entry;
+  return { alt, moon };
 }
 
 /**
@@ -338,6 +349,7 @@ function groupTargets(
   dateMs: number,
   cache: Map<string, RowCacheEntry>,
   genKey: string,
+  moonGeometry: ReadonlyMap<string, RowMoonGeometry>,
 ): TargetGroup[] {
   const byKey = new Map<
     string,
@@ -354,6 +366,7 @@ function groupTargets(
       dateMs,
       guidanceParams,
       night,
+      moonGeometry,
     );
     const bucket = byKey.get(key);
     if (bucket) bucket.push({ target: t, alt, moon });
@@ -810,6 +823,68 @@ export function TargetsTable({
     guidanceParams,
   );
 
+  // #634: real lunar-separation + opposition geometry now comes from ONE
+  // batched Rust call per newly-seen target id (never per-row round trips),
+  // replacing the TS `astronomy-engine` math this table used to run at
+  // catalogue scale. A ref cache (mirrors the #573 `rowCacheRef` pattern)
+  // means TargetsPage's incremental reveal only fetches the NEW tail of
+  // ids each chunk, not the whole revealed set again; the night's `nightKey`
+  // gates invalidation (the Moon's position is night-specific). A version
+  // counter (not the cache map itself) triggers the re-render that picks up
+  // newly-arrived entries — mutating a ref never does.
+  const moonGeometryCacheRef = useRef<Map<string, RowMoonGeometry>>(new Map());
+  const moonGeometryNightRef = useRef<string | null>(null);
+  const [moonGeometryVersion, setMoonGeometryVersion] = useState(0);
+
+  useEffect(() => {
+    if (!night) return;
+    if (moonGeometryNightRef.current !== night.nightKey) {
+      moonGeometryCacheRef.current = new Map();
+      moonGeometryNightRef.current = night.nightKey;
+    }
+    const cache = moonGeometryCacheRef.current;
+    const missing = targets.filter(
+      (t) =>
+        typeof t.raDeg === 'number' &&
+        typeof t.decDeg === 'number' &&
+        !cache.has(t.id),
+    );
+    if (missing.length === 0) return;
+
+    let cancelled = false;
+    commands
+      .targetMoonOppositionBatch({
+        targets: missing.map((t) => ({
+          id: t.id,
+          raDeg: t.raDeg as number,
+          decDeg: t.decDeg as number,
+        })),
+        at: night.midnight.toISOString(),
+      })
+      .then(unwrap)
+      .then(({ results }) => {
+        if (cancelled) return;
+        for (const r of results) {
+          cache.set(r.id, {
+            lunarSeparationDeg: r.moonSeparationDeg,
+            nextOppositionDate: r.opposition
+              ? r.opposition.date.slice(0, 10)
+              : null,
+            daysToOpposition: r.opposition ? r.opposition.daysUntil : null,
+          });
+        }
+        setMoonGeometryVersion((v) => v + 1);
+      })
+      .catch(() => {
+        // Leave the missing ids absent from the cache — those rows render
+        // the existing explicit-unknown "—" state (never a fabricated
+        // value); a later target-set/night change retries the fetch.
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [targets, night]);
+
   // Grouping + sorting + per-row altitude are all derived here so a filter
   // or sort change does one O(n) pass off the render hot path, not per-row work
   // inside the virtualized render loop. usableAltDeg + site are included in the
@@ -835,6 +910,7 @@ export function TargetsTable({
           dateMs,
           guidanceParams,
           night,
+          moonGeometryCacheRef.current,
         );
         return { target: t, alt, moon };
       });
@@ -913,6 +989,7 @@ export function TargetsTable({
         dateMs,
         rowCacheRef.current,
         genKey,
+        moonGeometryCacheRef.current,
       );
       return flattenGroups(groups);
     }
@@ -931,6 +1008,7 @@ export function TargetsTable({
         dateMs,
         guidanceParams,
         night,
+        moonGeometryCacheRef.current,
       );
       return { target: t, alt, moon };
     });
@@ -960,6 +1038,7 @@ export function TargetsTable({
     dims,
     collapsed,
     genKey,
+    moonGeometryVersion,
   ]);
 
   const virtualizer = useVirtualizer({

--- a/apps/desktop/src/features/targets/astro/row-planning.ts
+++ b/apps/desktop/src/features/targets/astro/row-planning.ts
@@ -11,6 +11,18 @@
  *
  * `night === null` means the site gate is closed (no observing site yet); every
  * derived value is then the explicit unknown state, never a fabricated number.
+ *
+ * `geometryOverride` (#634): `TargetsTable`'s full-catalogue pass no longer
+ * computes lunar separation / opposition via the TS `astronomy-engine` calls
+ * below — it fetches them once per batch from the real Rust
+ * `target.moon_opposition.batch` command (never per-row round trips) and
+ * passes the looked-up result in explicitly (`null` = fetch not resolved yet
+ * / unknown coordinates, same "never fabricate" contract as everything else
+ * here). Every OTHER caller (`TargetDetailV2`'s single-target planner,
+ * `TargetsPage`'s synchronous full-catalogue filter-count pass, and this
+ * file's own tests) omits the 4th argument and keeps the original synchronous
+ * TS-ephemeris path unchanged — this is a purely additive, backward-compatible
+ * parameter, not a signature break.
  */
 
 import type { ObservingNight } from './moon-state';
@@ -29,6 +41,18 @@ import { nextOpposition } from './opposition';
 export interface RowCoords {
   raDeg: number | null;
   decDeg: number | null;
+}
+
+/**
+ * Real Moon geometry for one target (#634): lunar separation + next
+ * opposition, sourced from the batched Rust command instead of computed
+ * locally. `lunarSeparationDeg: null` mirrors the existing "unknown
+ * coordinates" convention (never a fabricated number).
+ */
+export interface RowMoonGeometry {
+  lunarSeparationDeg: number | null;
+  nextOppositionDate: string | null;
+  daysToOpposition: number | null;
 }
 
 /** Per-target planner astronomy (data-model.md §RowMoonPlanning). */
@@ -52,31 +76,55 @@ export interface RowMoonPlanning {
  * @param night - The shared observing night, or `null` when no site exists.
  * @param params - Active per-band Moon-avoidance parameters (Settings →
  *   Target Planner); defaults to the shipped table.
+ * @param geometryOverride - #634: when provided (even `null`), lunar
+ *   separation + opposition come from this pre-fetched batch result instead
+ *   of the local TS ephemeris — `TargetsTable`'s only call site. Omitted
+ *   (`undefined`, every other caller) preserves the original synchronous,
+ *   no-fetch TS computation.
  */
 export function deriveRowMoonPlanning(
   coords: RowCoords,
   night: ObservingNight | null,
   params: MoonAvoidanceParams = DEFAULT_MOON_AVOIDANCE,
+  geometryOverride?: RowMoonGeometry | null,
 ): RowMoonPlanning {
   if (!night) return { ...UNKNOWN_ROW_PLANNING };
 
-  const separation = lunarSeparationDeg(
-    coords.raDeg,
-    coords.decDeg,
-    night.moonVec,
-  );
+  const geometry: RowMoonGeometry | null =
+    geometryOverride !== undefined
+      ? geometryOverride
+      : localGeometry(coords, night);
+  if (!geometry) return { ...UNKNOWN_ROW_PLANNING };
+
+  const separation = geometry.lunarSeparationDeg;
   const viability =
     separation === null
       ? null
       : bandViability(separation, night.moonAgeFromFullDays, params);
   const recommendation = deriveRecommendation(viability);
 
-  const opposition = nextOpposition(coords.raDeg, night.midnight);
-
   return {
     lunarSeparationDeg: separation,
     bandViability: viability,
     recommendation,
+    nextOppositionDate: geometry.nextOppositionDate,
+    daysToOpposition: geometry.daysToOpposition,
+  };
+}
+
+/** The original synchronous TS-ephemeris geometry (pre-#634 behavior). */
+function localGeometry(
+  coords: RowCoords,
+  night: ObservingNight,
+): RowMoonGeometry {
+  const separation = lunarSeparationDeg(
+    coords.raDeg,
+    coords.decDeg,
+    night.moonVec,
+  );
+  const opposition = nextOpposition(coords.raDeg, night.midnight);
+  return {
+    lunarSeparationDeg: separation,
     nextOppositionDate: opposition
       ? opposition.date.toISOString().slice(0, 10)
       : null,


### PR DESCRIPTION
Closes #634 (backend existed on main; this lands the frontend wiring + batch regression pin)
Refs #739 (bullets 2-3 → maintenance sweep)