### PR TITLE
fix(inbox): file-override staleness tracking and quiet no-op resolve heartbeat

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -342,6 +342,37 @@ pub async fn classify(
         }
     }
 
+    // spec 041 FR-046 / R-4: detect `inbox_file_overrides` staleness — the
+    // generic-property counterpart to the `mark_override_stale` snapshot pass
+    // above (which only covers the fixed evidence columns). Each override row
+    // carries the file identity recorded when it was set; compare it against
+    // the file's current on-disk stat and flag drift. One stat per file
+    // (property rows share identity), so dedupe by path first.
+    if let Some(sg_id) = item.source_group_id.as_deref() {
+        let mut checked_paths: std::collections::HashSet<&str> = std::collections::HashSet::new();
+        for ov in &group_overrides {
+            let (Some(stored_size), Some(stored_mtime)) =
+                (ov.file_size_bytes, ov.file_mtime.as_deref())
+            else {
+                continue; // no recorded identity yet — nothing to compare against
+            };
+            if !checked_paths.insert(ov.relative_file_path.as_str()) {
+                continue;
+            }
+            let abs = req.root_absolute_path.join(&ov.relative_file_path);
+            if let Ok(md) = std::fs::metadata(&abs) {
+                let cur_size = i64::try_from(md.len()).ok();
+                let cur_mtime = md
+                    .modified()
+                    .ok()
+                    .and_then(|t| time::OffsetDateTime::from(t).format(&Rfc3339).ok());
+                if cur_size != Some(stored_size) || cur_mtime.as_deref() != Some(stored_mtime) {
+                    repo::mark_file_override_stale(pool, sg_id, &ov.relative_file_path).await.ok();
+                }
+            }
+        }
+    }
+
     // Folder tallies from the layered (effective) records.
     for (rel, ft_opt, _) in &file_records {
         match ft_opt {
@@ -1693,6 +1724,86 @@ mod tests {
         );
         // The override values must also survive the rescan.
         assert_eq!(row.override_filter.as_deref(), Some("Ha"));
+    }
+
+    /// spec 041 FR-046: a generic `inbox_file_overrides` entry (set via
+    /// `set_file_override`, the reclassify_v2/cone_search path — not the
+    /// legacy `set_overrides` evidence columns exercised above) must be
+    /// flagged `override_stale` once classify observes the file's on-disk
+    /// identity has drifted from what was recorded when the override was set.
+    #[tokio::test]
+    async fn classify_marks_generic_file_override_stale_on_changed_file() {
+        use persistence_db::repositories::inbox as inbox_repo;
+        use std::io::Write;
+
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("light_001.fits");
+        write_fits_with_imagetyp(tmp.path(), "light_001.fits", "Light Frame");
+
+        let db = test_db().await;
+        insert_source_group_with_item(&db, "sg-fovr-stale", "item-fovr-stale", "root-fovr", "")
+            .await;
+
+        // First classify records the file's identity in inbox_file_metadata.
+        classify(
+            db.pool(),
+            ClassifyRequest {
+                inbox_item_id: "item-fovr-stale".to_owned(),
+                root_absolute_path: tmp.path().to_owned(),
+                force_rescan: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        let identity =
+            inbox_repo::list_inbox_file_metadata(db.pool(), "item-fovr-stale").await.unwrap();
+        let (size, mtime) = identity
+            .iter()
+            .find(|m| m.relative_file_path == "light_001.fits")
+            .map(|m| (m.file_size_bytes, m.file_mtime.clone()))
+            .expect("identity recorded by first classify");
+
+        // Set a generic override carrying that identity (mirrors what
+        // reclassify_v2/cone_search now do).
+        inbox_repo::set_file_override(
+            db.pool(),
+            "sg-fovr-stale",
+            "light_001.fits",
+            "gain",
+            "100",
+            size,
+            mtime.as_deref(),
+        )
+        .await
+        .unwrap();
+
+        let before =
+            inbox_repo::list_file_overrides_for_group(db.pool(), "sg-fovr-stale").await.unwrap();
+        assert_eq!(before[0].override_stale, 0, "override freshly set, not yet stale");
+
+        // Mutate the file so its size changes.
+        {
+            let mut f = std::fs::OpenOptions::new().append(true).open(&file_path).unwrap();
+            f.write_all(b"extra bytes that change size").unwrap();
+        }
+
+        classify(
+            db.pool(),
+            ClassifyRequest {
+                inbox_item_id: "item-fovr-stale".to_owned(),
+                root_absolute_path: tmp.path().to_owned(),
+                force_rescan: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        let after =
+            inbox_repo::list_file_overrides_for_group(db.pool(), "sg-fovr-stale").await.unwrap();
+        let ov = after.iter().find(|o| o.relative_file_path == "light_001.fits").unwrap();
+        assert_eq!(ov.override_stale, 1, "override_stale must be 1 after file size changed");
+        assert_eq!(ov.value, "100", "override value must survive being marked stale");
     }
 
     // ── T066: sub-item materialization tests ─────────────────────────────────

--- a/crates/app/inbox/src/cone_search.rs
+++ b/crates/app/inbox/src/cone_search.rs
@@ -15,6 +15,8 @@
 //! in-use promotion — no duplicate write path, constitution §V).
 #![allow(clippy::doc_markdown)] // RA/Dec/FOV/WCS are domain terms
 
+use std::collections::HashMap;
+
 use sqlx::SqlitePool;
 
 use contracts_core::cone_search::{
@@ -509,16 +511,31 @@ pub async fn confirm(
     // downstream apply/session propagation. Never fails the confirm itself —
     // the durable canonical_target write above already succeeded.
     if let Some(source_group_id) = &item.source_group_id {
+        // File identity (size/mtime) recorded by the last classify (spec 041
+        // FR-046) — threaded through so the durable override has a baseline
+        // to compare against for staleness, same as `reclassify_v2`.
+        let file_identity: HashMap<String, (Option<i64>, Option<String>)> =
+            repo::list_inbox_file_metadata(pool, &req.frameset_id)
+                .await
+                .unwrap_or_default()
+                .into_iter()
+                .map(|m| (m.relative_file_path, (m.file_size_bytes, m.file_mtime)))
+                .collect();
+
         if let Ok(rows) = repo::list_inbox_pointing(pool, &req.frameset_id).await {
             for row in rows {
+                let (id_size, id_mtime) = file_identity
+                    .get(row.relative_file_path.as_str())
+                    .cloned()
+                    .unwrap_or((None, None));
                 let _ = repo::set_file_override(
                     pool,
                     source_group_id,
                     &row.relative_file_path,
                     "target",
                     &req.candidate.primary_designation,
-                    None,
-                    None,
+                    id_size,
+                    id_mtime.as_deref(),
                 )
                 .await;
             }

--- a/crates/app/inbox/src/reclassify.rs
+++ b/crates/app/inbox/src/reclassify.rs
@@ -449,12 +449,27 @@ pub async fn reclassify_v2(
 
     // Build a flat map: relative_file_path → inbox_item_id
     let mut path_to_item: HashMap<String, String> = HashMap::new();
+    // File identity (size/mtime) most recently recorded by classify's own
+    // `stat` (spec 041 FR-046) — reclassify has no root path to stat files
+    // itself, but `inbox_file_metadata` already carries the identity from the
+    // classify run that produced this evidence. Threading it through here is
+    // what lets `set_file_override` (step 7) persist a real identity instead
+    // of `None, None`, which is required for staleness detection to have
+    // anything to compare against at the next classify.
+    let mut file_identity: HashMap<String, (Option<i64>, Option<String>)> = HashMap::new();
     for item_id in &evidence_item_ids {
         let evidence = inbox_repo::list_evidence(pool, item_id)
             .await
             .map_err(|e| db_internal_ctx(e, "list evidence for sub-item"))?;
         for ev in evidence {
             path_to_item.insert(ev.relative_file_path, item_id.clone());
+        }
+
+        let metadata_rows = inbox_repo::list_inbox_file_metadata(pool, item_id)
+            .await
+            .map_err(|e| db_internal_ctx(e, "list file metadata for sub-item"))?;
+        for m in metadata_rows {
+            file_identity.insert(m.relative_file_path, (m.file_size_bytes, m.file_mtime));
         }
     }
     let all_paths: std::collections::HashSet<&str> =
@@ -546,6 +561,12 @@ pub async fn reclassify_v2(
             )
         })?;
 
+        // Identity recorded at the last classify for this file, if any (spec
+        // 041 FR-046) — `None` for files never classified yet, which leaves
+        // the override with no comparison baseline until the next classify.
+        let (id_size, id_mtime) =
+            file_identity.get(file_path.as_str()).cloned().unwrap_or((None, None));
+
         if property_key == "frameType" {
             // Frame-type correction: write manual_override on the evidence row.
             let frame_type_str = match json_val {
@@ -577,8 +598,8 @@ pub async fn reclassify_v2(
                 file_path,
                 "frameType",
                 frame_type_str,
-                None, // size: caller doesn't stat files
-                None, // mtime: same
+                id_size,
+                id_mtime.as_deref(),
             )
             .await
             .map_err(|e| db_internal_ctx(e, "write durable frameType override"))?;
@@ -594,8 +615,8 @@ pub async fn reclassify_v2(
                 file_path,
                 property_key,
                 &value_str,
-                None, // size: caller doesn't stat files; staleness detected at classify time
-                None, // mtime: same
+                id_size,
+                id_mtime.as_deref(),
             )
             .await
             .map_err(|e| db_internal_ctx(e, "write generic file override"))?;
@@ -1300,6 +1321,60 @@ mod tests {
         assert!(gain_ov.is_some(), "gain override must be persisted");
         // String JSON values: the implementation stores the inner string (unwrapped from quotes).
         assert_eq!(gain_ov.unwrap().value, "100");
+    }
+
+    /// spec 041 FR-046: when `inbox_file_metadata` already carries a file's
+    /// identity (recorded by a prior classify), `reclassify_v2` must thread it
+    /// through to `set_file_override` instead of writing `None, None` — the
+    /// baseline required for staleness detection to have anything to compare
+    /// against at the next classify.
+    #[tokio::test]
+    async fn v2_generic_override_persists_known_file_identity() {
+        let db = test_db().await;
+        setup_source_group(&db, "sg-identity", "item-identity").await;
+
+        inbox_repo::upsert_inbox_file_metadata(
+            db.pool(),
+            &persistence_db::repositories::inbox::UpsertFileMetadata {
+                inbox_item_id: "item-identity",
+                relative_file_path: "inbox_folder/frame_001.fits",
+                file_size_bytes: Some(4_194_304),
+                file_mtime: Some("2025-10-10T22:00:00Z"),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        reclassify_v2(
+            db.pool(),
+            InboxReclassifyV2Request {
+                source_group_id: Some("sg-identity".to_owned()),
+                inbox_item_id: None,
+                overrides: vec![InboxReclassifyFileOverride {
+                    file_path: "inbox_folder/frame_001.fits".to_owned(),
+                    properties: {
+                        let mut m = std::collections::HashMap::new();
+                        m.insert("gain".to_owned(), serde_json::json!("100").into());
+                        m
+                    },
+                }],
+                bulk: vec![],
+            },
+        )
+        .await
+        .unwrap();
+
+        let overrides =
+            inbox_repo::list_file_overrides_for_group(db.pool(), "sg-identity").await.unwrap();
+        let gain_ov = overrides
+            .iter()
+            .find(|o| {
+                o.property_key == "gain" && o.relative_file_path == "inbox_folder/frame_001.fits"
+            })
+            .unwrap();
+        assert_eq!(gain_ov.file_size_bytes, Some(4_194_304), "identity must be threaded through");
+        assert_eq!(gain_ov.file_mtime.as_deref(), Some("2025-10-10T22:00:00Z"));
     }
 
     /// T068: bulk set-all — apply one value across all files in the group when

--- a/crates/app/targets/src/ingest_resolution.rs
+++ b/crates/app/targets/src/ingest_resolution.rs
@@ -284,20 +284,27 @@ pub async fn resolve_pending<R: Resolver + ?Sized>(
         }
     }
 
+    // issue #668: the periodic drain (~30s cadence) runs continuously whether
+    // or not there's anything in the queue; publishing a completion event for
+    // an empty pass floods the activity log with a no-op heartbeat (~470/500
+    // rows in the reported sweep) that buries user-meaningful events. Only
+    // publish when the pass actually considered something.
     if let Some(bus) = bus {
-        let _ = bus
-            .publish(
-                audit::event_bus::TOPIC_TARGET_RESOLVE_BATCH_COMPLETED,
-                Source::System,
-                TargetResolveBatchCompleted {
-                    considered,
-                    resolved: num_resolved,
-                    unresolved: num_unresolved,
-                    pending: num_pending,
-                    at: Timestamp::now_iso(),
-                },
-            )
-            .await;
+        if considered > 0 {
+            let _ = bus
+                .publish(
+                    audit::event_bus::TOPIC_TARGET_RESOLVE_BATCH_COMPLETED,
+                    Source::System,
+                    TargetResolveBatchCompleted {
+                        considered,
+                        resolved: num_resolved,
+                        unresolved: num_unresolved,
+                        pending: num_pending,
+                        at: Timestamp::now_iso(),
+                    },
+                )
+                .await;
+        }
     }
 
     Ok(DrainSummary {
@@ -491,6 +498,52 @@ mod tests {
         // Associated, and cached for next time.
         assert!(target_id_of(&db, &img).await.is_some());
         assert!(cache::get_by_simbad_oid(db.pool(), 1_575_544).await.unwrap().is_some());
+    }
+
+    /// issue #668: an empty drain pass (nothing pending — the common case for
+    /// the periodic ~30s heartbeat) must NOT publish `target.resolve_batch
+    /// .completed` at all, so it can't flood the activity log with no-op
+    /// events.
+    #[tokio::test]
+    async fn drain_with_nothing_pending_does_not_publish_batch_completed() {
+        let db = setup().await;
+        let bus = audit::EventBus::with_pool(db.pool().clone());
+        let resolver = FakeResolver::new();
+
+        let summary = resolve_pending(db.pool(), &resolver, Some(&bus), true, 50).await.unwrap();
+        assert_eq!(summary.considered, 0);
+
+        let events = persistence_db::repositories::events::list_since_by_topic(
+            db.pool(),
+            0,
+            audit::event_bus::TOPIC_TARGET_RESOLVE_BATCH_COMPLETED,
+        )
+        .await
+        .unwrap();
+        assert!(events.is_empty(), "empty drain pass must not publish a completion event");
+    }
+
+    /// A pass that actually considers rows — even if none resolve — is real
+    /// activity and must still publish the completion event.
+    #[tokio::test]
+    async fn drain_with_pending_rows_publishes_batch_completed() {
+        let db = setup().await;
+        let bus = audit::EventBus::with_pool(db.pool().clone());
+        let img = make_image(&db, "m31.fits").await;
+        associate_or_enqueue(db.pool(), None, &img, "M 31").await.unwrap();
+
+        let resolver = FakeResolver::new().with_response("M 31", m31());
+        let summary = resolve_pending(db.pool(), &resolver, Some(&bus), true, 50).await.unwrap();
+        assert_eq!(summary.considered, 1);
+
+        let events = persistence_db::repositories::events::list_since_by_topic(
+            db.pool(),
+            0,
+            audit::event_bus::TOPIC_TARGET_RESOLVE_BATCH_COMPLETED,
+        )
+        .await
+        .unwrap();
+        assert_eq!(events.len(), 1, "non-empty pass must publish exactly one completion event");
     }
 
     #[tokio::test]

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -1029,13 +1029,21 @@ pub struct FileOverrideRow {
     pub property_key: String,
     pub value: String,
     pub override_stale: i64,
+    /// File identity recorded when the override was set (spec 041 FR-046,
+    /// R-4 staleness detection). `None` for overrides written before this
+    /// field was wired, or by a caller with no accessible file stat.
+    pub file_size_bytes: Option<i64>,
+    pub file_mtime: Option<String>,
 }
 
-/// Fetch all non-stale property overrides for every file in a source group.
+/// Fetch all property overrides for every file in a source group.
 ///
 /// Returns one row per `(relative_file_path, property_key)` — the full override
 /// map the re-split grouping engine needs to compute updated group keys after a
-/// reclassify call (T068 R-13 re-split).
+/// reclassify call (T068 R-13 re-split). Includes stale rows — `override_stale`
+/// is informational (surfaced to the user), not a filter: a stale override is
+/// still the user's most recent explicit decision and stays in effect until
+/// they act on the staleness signal.
 ///
 /// # Errors
 /// Returns [`DbError::Database`] on connection failure.
@@ -1044,7 +1052,8 @@ pub async fn list_file_overrides_for_group(
     source_group_id: &str,
 ) -> DbResult<Vec<FileOverrideRow>> {
     Ok(sqlx::query_as::<_, FileOverrideRow>(
-        "SELECT relative_file_path, property_key, value, override_stale
+        "SELECT relative_file_path, property_key, value, override_stale,
+                file_size_bytes, file_mtime
          FROM inbox_file_overrides
          WHERE source_group_id = ?
          ORDER BY relative_file_path, property_key",
@@ -1089,6 +1098,33 @@ pub async fn mark_override_stale(
          WHERE inbox_item_id = ? AND relative_file_path = ?",
     )
     .bind(inbox_item_id)
+    .bind(relative_file_path)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+/// Mark every generic property override for one file in a source group as
+/// stale (spec 041 FR-046, R-4 — the `inbox_file_overrides` counterpart to
+/// [`mark_override_stale`]'s evidence-table check).
+///
+/// All property rows for the path share one file identity, so this flags
+/// every `(source_group_id, relative_file_path, *)` row at once rather than
+/// taking a single `property_key`.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn mark_file_override_stale(
+    pool: &SqlitePool,
+    source_group_id: &str,
+    relative_file_path: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE inbox_file_overrides
+         SET override_stale = 1
+         WHERE source_group_id = ? AND relative_file_path = ?",
+    )
+    .bind(source_group_id)
     .bind(relative_file_path)
     .execute(pool)
     .await?;
@@ -2494,6 +2530,76 @@ mod tests {
 
         let rows_after = list_evidence(pool, "item-stale-1").await.unwrap();
         assert_eq!(rows_after[0].override_stale, 1, "override_stale must be 1 after mark");
+    }
+
+    /// spec 041 FR-046: `set_file_override` round-trips the file identity
+    /// (size/mtime) through `list_file_overrides_for_group`, and
+    /// `mark_file_override_stale` flips `override_stale` on every property row
+    /// for that path without touching other files' rows.
+    #[tokio::test]
+    async fn mark_file_override_stale_sets_flag_for_path_only() {
+        let db = test_db().await;
+        let pool = db.pool();
+
+        // inbox_file_overrides.source_group_id is FK-constrained to
+        // inbox_source_groups(id).
+        upsert_inbox_source_group(
+            pool,
+            &UpsertSourceGroup {
+                id: "sg-fovr-1",
+                root_id: "root-1",
+                relative_path: "folder",
+                content_signature: None,
+                format: Some("fits"),
+                lane: Some("move"),
+            },
+        )
+        .await
+        .unwrap();
+
+        set_file_override(
+            pool,
+            "sg-fovr-1",
+            "folder/a.fits",
+            "temperatureC",
+            "-10.0",
+            Some(4_194_304),
+            Some("2025-10-10T22:00:00Z"),
+        )
+        .await
+        .unwrap();
+        set_file_override(
+            pool,
+            "sg-fovr-1",
+            "folder/a.fits",
+            "gain",
+            "100",
+            Some(4_194_304),
+            Some("2025-10-10T22:00:00Z"),
+        )
+        .await
+        .unwrap();
+        set_file_override(pool, "sg-fovr-1", "folder/b.fits", "gain", "200", None, None)
+            .await
+            .unwrap();
+
+        let before = list_file_overrides_for_group(pool, "sg-fovr-1").await.unwrap();
+        let a_temp = before
+            .iter()
+            .find(|o| o.relative_file_path == "folder/a.fits" && o.property_key == "temperatureC")
+            .unwrap();
+        assert_eq!(a_temp.file_size_bytes, Some(4_194_304), "identity must round-trip");
+        assert_eq!(a_temp.file_mtime.as_deref(), Some("2025-10-10T22:00:00Z"));
+        assert_eq!(a_temp.override_stale, 0);
+
+        mark_file_override_stale(pool, "sg-fovr-1", "folder/a.fits").await.unwrap();
+
+        let after = list_file_overrides_for_group(pool, "sg-fovr-1").await.unwrap();
+        for o in after.iter().filter(|o| o.relative_file_path == "folder/a.fits") {
+            assert_eq!(o.override_stale, 1, "every property row for the stale path must flip");
+        }
+        let b = after.iter().find(|o| o.relative_file_path == "folder/b.fits").unwrap();
+        assert_eq!(b.override_stale, 0, "unrelated file must be untouched");
     }
 
     /// get_file_metadata returns None before any classify and Some after upsert.


### PR DESCRIPTION
Closes #755
Refs #668 (targets half here + settings half rides g-protection-settings)
Refs #711 (mechanism confirmed in src-tauri, rides g-metadata-tools phase 2)