### PR TITLE
refactor(stores): migrate targets, calibration, and projects stores to TanStack Query

### DIFF
--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -12,6 +12,7 @@ export const queryKeys = {
   projects: {
     all: () => ['projects'] as const,
     detail: (id: string) => ['projects', id] as const,
+    artifacts: (id: string) => ['projects', id, 'artifacts'] as const,
   },
   inventory: {
     // No filters → prefix-only key, so `invalidateQueries({ queryKey:

--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -38,6 +38,7 @@ export const queryKeys = {
     masters: () => ['calibration', 'masters'] as const,
     master: (id: string) => ['calibration', 'masters', id] as const,
     matches: (sid: string) => ['calibration', 'matches', sid] as const,
+    settings: () => ['calibration', 'settings'] as const,
   },
   targets: {
     list: () => ['targets'] as const,

--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -39,6 +39,15 @@ export const queryKeys = {
     master: (id: string) => ['calibration', 'masters', id] as const,
     matches: (sid: string) => ['calibration', 'matches', sid] as const,
   },
+  targets: {
+    list: () => ['targets'] as const,
+    detail: (id: string) => ['targets', id] as const,
+    sessions: (id: string) => ['targets', id, 'sessions'] as const,
+    projects: (id: string) => ['targets', id, 'projects'] as const,
+    notes: (id: string) => ['targets', id, 'notes'] as const,
+    astroFormat: (id: string) => ['targets', id, 'astroFormat'] as const,
+    favourites: () => ['targets', 'favourites'] as const,
+  },
   guided: {
     state: () => ['guided'] as const,
   },

--- a/apps/desktop/src/features/calibration/MasterDetail.actions.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.actions.test.tsx
@@ -10,10 +10,27 @@
  * disabled (with an explanatory title) rather than silently do nothing.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { MasterDetail } from './MasterDetail';
 import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
+
+// MasterDetail is now backed by TanStack Query (useCalibration.ts) — every
+// render needs a QueryClientProvider ancestor.
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+}
 
 vi.mock('@/bindings/index', () => ({
   commands: {

--- a/apps/desktop/src/features/calibration/MasterDetail.actions.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.actions.test.tsx
@@ -25,9 +25,7 @@ function render(ui: ReactElement) {
   });
   return rtlRender(ui, {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
   });
 }

--- a/apps/desktop/src/features/calibration/MasterDetail.applicability.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.applicability.test.tsx
@@ -27,9 +27,7 @@ function render(ui: ReactElement) {
   });
   return rtlRender(ui, {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
   });
 }

--- a/apps/desktop/src/features/calibration/MasterDetail.applicability.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.applicability.test.tsx
@@ -11,11 +11,28 @@
  * value absence.
  */
 
-import { render, screen, within } from '@testing-library/react';
+import { render as rtlRender, screen, within } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { MasterDetail } from './MasterDetail';
 import { commands } from '@/bindings/index';
 import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
+
+// MasterDetail is now backed by TanStack Query (useCalibration.ts) — every
+// render needs a QueryClientProvider ancestor.
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+}
 
 const MASTER_ID = 'aaaaaaaa-0000-0000-0000-000000000002';
 

--- a/apps/desktop/src/features/calibration/MasterDetail.matching.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.matching.test.tsx
@@ -15,11 +15,33 @@
  * the real `calibration.match.assign` IPC command.
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { MasterDetail } from './MasterDetail';
 import { commands } from '@/bindings/index';
 import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
+
+// MasterDetail is now backed by TanStack Query (useCalibration.ts) — every
+// render needs a QueryClientProvider ancestor.
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+}
 
 const MASTER_ID = 'aaaaaaaa-0000-0000-0000-000000000001';
 const SESSION_ID = 'ses-001';

--- a/apps/desktop/src/features/calibration/MasterDetail.matching.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.matching.test.tsx
@@ -36,9 +36,7 @@ function render(ui: ReactElement) {
   });
   return rtlRender(ui, {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
   });
 }

--- a/apps/desktop/src/features/calibration/MasterDetail.revealLabel.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.revealLabel.test.tsx
@@ -11,10 +11,27 @@
  * platform source is actually consulted.
  */
 
-import { render, screen } from '@testing-library/react';
+import { render as rtlRender, screen } from '@testing-library/react';
 import { describe, it, expect, vi, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
 import { MasterDetail } from './MasterDetail';
 import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
+
+// MasterDetail is now backed by TanStack Query (useCalibration.ts) — every
+// render needs a QueryClientProvider ancestor.
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+}
 
 // Detail data-loading is not under test — resolve both commands empty.
 vi.mock('@/bindings/index', () => ({

--- a/apps/desktop/src/features/calibration/MasterDetail.revealLabel.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.revealLabel.test.tsx
@@ -26,9 +26,7 @@ function render(ui: ReactElement) {
   });
   return rtlRender(ui, {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
   });
 }

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -36,7 +36,9 @@
  *   master gets its first assignment instead of faked from stub data.
  */
 
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { queryKeys } from '@/data/queryKeys';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
@@ -100,13 +102,6 @@ export function MasterDetail({
   prefillSuggestion,
   agingThresholdDays,
 }: Props) {
-  const [detail, setDetail] = useState<DetailState>({
-    confirmedNames: [],
-    compatibleNames: [],
-    loading: false,
-    missingFlag: null,
-  });
-
   // Matching context: the session `calibration.match.suggest` is anchored on.
   // See the file-header note — real `usedBySessionIds`, not the stub
   // `compatibleSessions` field.
@@ -145,63 +140,70 @@ export function MasterDetail({
     };
   };
 
-  useEffect(() => {
-    if (!master) {
-      setDetail({
-        confirmedNames: [],
-        compatibleNames: [],
-        loading: false,
-        missingFlag: null,
-      });
-      return;
-    }
-    const masterId = master.id;
-    let cancelled = false;
-    setDetail({
+  // Real `usedBySessionIds`/`compatibleSessions` (populated) come from a
+  // per-master detail fetch; `sessionsList()` cross-references both sets of
+  // ids to human-readable "{target} · {filter} · {night}" labels. Shares the
+  // `queryKeys.sessions.all()` cache entry with the rest of the app (e.g.
+  // `SessionSourcePicker`) rather than a private key.
+  const masterId = master?.id;
+  const masterDetailQuery = useQuery({
+    queryKey: queryKeys.calibration.master(masterId ?? '__none__'),
+    queryFn: async () =>
+      unwrap(await commands.calibrationMastersGet(masterId as string)),
+    enabled: !!masterId,
+  });
+  const sessionsQuery = useQuery({
+    queryKey: queryKeys.sessions.all(),
+    queryFn: async () => unwrap(await commands.sessionsList()),
+  });
+
+  const detail: DetailState = useMemo(() => {
+    const empty: DetailState = {
       confirmedNames: [],
       compatibleNames: [],
-      loading: true,
+      loading: false,
       missingFlag: null,
-    });
-
-    Promise.all([
-      commands.calibrationMastersGet(masterId).then(unwrap),
-      commands.sessionsList().then(unwrap),
-    ])
-      .then(([masterDetail, sessions]) => {
-        if (cancelled) return;
-        const idToName = new Map<string, string>();
-        for (const s of sessions) {
-          const k = s.sessionKey;
-          idToName.set(s.id, `${k.target} · ${k.filter} · ${k.night}`);
-        }
-        const confirmedNames = masterDetail.usedBySessionIds
-          .map((id) => idToName.get(id) ?? id)
-          .filter(Boolean);
-        const compatibleNames = masterDetail.compatibleSessions
-          .map((e) => idToName.get(e.sessionId) ?? e.sessionId)
-          .filter(Boolean);
-        setDetail({
-          confirmedNames,
-          compatibleNames,
-          loading: false,
-          missingFlag: masterDetail.missingFlag ?? null,
-        });
-      })
-      .catch(() => {
-        if (!cancelled)
-          setDetail({
-            confirmedNames: [],
-            compatibleNames: [],
-            loading: false,
-            missingFlag: null,
-          });
-      });
-
-    return () => {
-      cancelled = true;
     };
-  }, [master]);
+    if (!masterId) return empty;
+    if (masterDetailQuery.isFetching || sessionsQuery.isFetching) {
+      return { ...empty, loading: true };
+    }
+    // Mirrors the pre-migration catch-and-swallow: a failed detail or
+    // sessions fetch degrades to the empty state rather than an error banner.
+    if (masterDetailQuery.error || sessionsQuery.error || !masterDetailQuery.data) {
+      return empty;
+    }
+    const masterDetail = masterDetailQuery.data;
+    const idToName = new Map<string, string>();
+    // Defensive: guard against a non-array `sessionsList()` payload (the old
+    // effect's Promise.all().catch() silently swallowed this; a bare `for...of`
+    // here would otherwise throw synchronously during render).
+    const sessionsList = Array.isArray(sessionsQuery.data)
+      ? sessionsQuery.data
+      : [];
+    for (const s of sessionsList) {
+      const k = s.sessionKey;
+      idToName.set(s.id, `${k.target} · ${k.filter} · ${k.night}`);
+    }
+    return {
+      confirmedNames: masterDetail.usedBySessionIds
+        .map((id) => idToName.get(id) ?? id)
+        .filter(Boolean),
+      compatibleNames: masterDetail.compatibleSessions
+        .map((e) => idToName.get(e.sessionId) ?? e.sessionId)
+        .filter(Boolean),
+      loading: false,
+      missingFlag: masterDetail.missingFlag ?? null,
+    };
+  }, [
+    masterId,
+    masterDetailQuery.data,
+    masterDetailQuery.isFetching,
+    masterDetailQuery.error,
+    sessionsQuery.data,
+    sessionsQuery.isFetching,
+    sessionsQuery.error,
+  ]);
 
   if (!master) {
     return (

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -170,7 +170,11 @@ export function MasterDetail({
     }
     // Mirrors the pre-migration catch-and-swallow: a failed detail or
     // sessions fetch degrades to the empty state rather than an error banner.
-    if (masterDetailQuery.error || sessionsQuery.error || !masterDetailQuery.data) {
+    if (
+      masterDetailQuery.error ||
+      sessionsQuery.error ||
+      !masterDetailQuery.data
+    ) {
       return empty;
     }
     const masterDetail = masterDetailQuery.data;

--- a/apps/desktop/src/features/calibration/useCalibration.ts
+++ b/apps/desktop/src/features/calibration/useCalibration.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Calibration feature hooks — spec 007.
+ * Calibration feature hooks — spec 007, TanStack Query (#610).
  *
  * useCalibrationMasters   : loads CalibrationMaster[] from the real backend.
  * useCalibrationSuggest   : calls calibration.match.suggest for one session.
@@ -10,7 +10,8 @@
  * useCalibrationSettings  : reads prefill_suggestion from persisted settings.
  */
 
-import { useState, useEffect, useCallback } from 'react';
+import { useQuery, useMutation } from '@tanstack/react-query';
+import { queryKeys } from '@/data/queryKeys';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type {
@@ -30,30 +31,15 @@ export interface UseMastersState {
 }
 
 export function useCalibrationMasters(): UseMastersState {
-  const [state, setState] = useState<UseMastersState>({
-    masters: [],
-    loading: true,
-    error: undefined,
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.calibration.masters(),
+    queryFn: async () => unwrap(await commands.calibrationMastersList()),
   });
-
-  useEffect(() => {
-    let cancelled = false;
-    commands
-      .calibrationMastersList()
-      .then(unwrap)
-      .then((masters) => {
-        if (!cancelled) setState({ masters, loading: false, error: undefined });
-      })
-      .catch((err: unknown) => {
-        if (!cancelled)
-          setState({ masters: [], loading: false, error: errMessage(err) });
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
-  return state;
+  return {
+    masters: data ?? [],
+    loading: isFetching,
+    error: error ? errMessage(error) : undefined,
+  };
 }
 
 // ── Suggest for one session ───────────────────────────────────────────────────
@@ -70,51 +56,26 @@ export function useCalibrationSuggest(
   sessionId: string | undefined,
   calibrationTypes?: CalibrationType[],
 ): UseSuggestState {
-  const [response, setResponse] = useState<
-    CalibrationMatchSuggestResponse | undefined
-  >(undefined);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | undefined>(undefined);
-  const [rev, setRev] = useState(0);
-
-  const refresh = useCallback(() => setRev((r) => r + 1), []);
-
-  useEffect(() => {
-    if (!sessionId) {
-      setResponse(undefined);
-      setLoading(false);
-      return undefined;
-    }
-    let cancelled = false;
-    setLoading(true);
-    setError(undefined);
-    commands
-      .calibrationMatchSuggest({
-        contractVersion: '2.0.0',
-        requestId: `suggest-${sessionId}-${Date.now()}`,
-        sessionId,
-        calibrationTypes: calibrationTypes ?? null,
-      })
-      .then(unwrap)
-      .then((res) => {
-        if (!cancelled) {
-          setResponse(res);
-          setLoading(false);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(errMessage(err));
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [sessionId, rev]);
-
-  return { response, loading, error, refresh };
+  const queryKey = queryKeys.calibration.matches(sessionId ?? '__none__');
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey,
+    queryFn: async () =>
+      unwrap(
+        await commands.calibrationMatchSuggest({
+          contractVersion: '2.0.0',
+          requestId: `suggest-${sessionId}-${Date.now()}`,
+          sessionId: sessionId as string,
+          calibrationTypes: calibrationTypes ?? null,
+        }),
+      ),
+    enabled: !!sessionId,
+  });
+  return {
+    response: data,
+    loading: isFetching,
+    error: error ? errMessage(error) : undefined,
+    refresh: () => void refetch(),
+  };
 }
 
 // ── Assign ────────────────────────────────────────────────────────────────────
@@ -131,34 +92,38 @@ export interface UseAssignState {
 }
 
 export function useCalibrationAssign(): UseAssignState {
-  const [assigning, setAssigning] = useState(false);
-  const [result, setResult] = useState<
-    CalibrationMatchAssignResponse | undefined
-  >(undefined);
+  const mutation = useMutation({
+    mutationFn: async ({
+      sessionId,
+      masterId,
+      override,
+    }: {
+      sessionId: string;
+      masterId: string;
+      override: boolean;
+    }) =>
+      unwrap(
+        await commands.calibrationMatchAssign({
+          contractVersion: '2.0.0',
+          requestId: `assign-${sessionId}-${Date.now()}`,
+          sessionId,
+          masterId,
+          override,
+        }),
+      ),
+  });
 
-  const assign = useCallback(
-    async (sessionId: string, masterId: string, override = false) => {
-      setAssigning(true);
-      try {
-        const res = unwrap(
-          await commands.calibrationMatchAssign({
-            contractVersion: '2.0.0',
-            requestId: `assign-${sessionId}-${Date.now()}`,
-            sessionId,
-            masterId,
-            override,
-          }),
-        );
-        setResult(res);
-        return res;
-      } finally {
-        setAssigning(false);
-      }
-    },
-    [],
-  );
+  const assign = async (
+    sessionId: string,
+    masterId: string,
+    override = false,
+  ) => mutation.mutateAsync({ sessionId, masterId, override });
 
-  return { assigning, result, assign };
+  return {
+    assigning: mutation.isPending,
+    result: mutation.data,
+    assign,
+  };
 }
 
 // ── Settings: prefill_suggestion + aging threshold ───────────────────────────
@@ -170,28 +135,26 @@ export function useCalibrationSettings(): {
   prefillSuggestion: boolean;
   agingThresholdDays: number;
 } {
-  const [prefillSuggestion, setPrefillSuggestion] = useState(true);
-  const [agingThresholdDays, setAgingThresholdDays] = useState(
-    DEFAULT_AGING_THRESHOLD_DAYS,
-  );
+  const { data } = useQuery({
+    queryKey: queryKeys.calibration.settings(),
+    queryFn: async () => {
+      const res = unwrap(await commands.settingsGet('calibration'));
+      const v = res.values as Record<string, unknown>;
+      return {
+        prefillSuggestion:
+          typeof v['calibrationPrefillSuggestion'] === 'boolean'
+            ? v['calibrationPrefillSuggestion']
+            : true,
+        agingThresholdDays:
+          typeof v['calibrationAgingThresholdDays'] === 'number'
+            ? v['calibrationAgingThresholdDays']
+            : DEFAULT_AGING_THRESHOLD_DAYS,
+      };
+    },
+  });
 
-  useEffect(() => {
-    commands
-      .settingsGet('calibration')
-      .then(unwrap)
-      .then((data) => {
-        const v = data.values as Record<string, unknown>;
-        if (typeof v['calibrationPrefillSuggestion'] === 'boolean') {
-          setPrefillSuggestion(v['calibrationPrefillSuggestion']);
-        }
-        if (typeof v['calibrationAgingThresholdDays'] === 'number') {
-          setAgingThresholdDays(v['calibrationAgingThresholdDays']);
-        }
-      })
-      .catch(() => {
-        // Backend unavailable — keep defaults.
-      });
-  }, []);
-
-  return { prefillSuggestion, agingThresholdDays };
+  return {
+    prefillSuggestion: data?.prefillSuggestion ?? true,
+    agingThresholdDays: data?.agingThresholdDays ?? DEFAULT_AGING_THRESHOLD_DAYS,
+  };
 }

--- a/apps/desktop/src/features/calibration/useCalibration.ts
+++ b/apps/desktop/src/features/calibration/useCalibration.ts
@@ -155,6 +155,7 @@ export function useCalibrationSettings(): {
 
   return {
     prefillSuggestion: data?.prefillSuggestion ?? true,
-    agingThresholdDays: data?.agingThresholdDays ?? DEFAULT_AGING_THRESHOLD_DAYS,
+    agingThresholdDays:
+      data?.agingThresholdDays ?? DEFAULT_AGING_THRESHOLD_DAYS,
   };
 }

--- a/apps/desktop/src/features/projects/artifacts.ts
+++ b/apps/desktop/src/features/projects/artifacts.ts
@@ -14,7 +14,9 @@
  * - `groupArtifactsByLaunch()` — pure grouping helper for the accordion (T023).
  */
 
-import { useState, useCallback, useEffect } from 'react';
+import { useEffect } from 'react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/data/queryKeys';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type {
@@ -142,40 +144,25 @@ export interface ArtifactsState {
 /**
  * Reactive query hook for artifact list.
  *
- * Fetches `["present", "missing"]` states by default.
+ * Fetches `["present", "missing"]` states by default. `reload` replaces the
+ * old manual tick-based re-fetch with a plain `refetch()`.
  */
 export function useArtifacts(projectId: string): ArtifactsState {
-  const [artifacts, setArtifacts] = useState<ArtifactSummary[]>([]);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [tick, setTick] = useState(0);
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: queryKeys.projects.artifacts(projectId),
+    queryFn: async () => {
+      const resp = await artifactList({ projectId, includeStates: [] });
+      return resp.artifacts ?? [];
+    },
+    enabled: !!projectId,
+  });
 
-  const reload = useCallback(() => setTick((t) => t + 1), []);
-
-  useEffect(() => {
-    if (!projectId) return;
-    let cancelled = false;
-    setLoading(true);
-    setError(null);
-    artifactList({ projectId, includeStates: [] })
-      .then((resp: ArtifactListResponse) => {
-        if (!cancelled) {
-          setArtifacts(resp.artifacts ?? []);
-          setLoading(false);
-        }
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setError(errMessage(err));
-          setLoading(false);
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [projectId, tick]);
-
-  return { artifacts, loading, error, reload };
+  return {
+    artifacts: data ?? [],
+    loading: isFetching,
+    error: error ? errMessage(error) : null,
+    reload: () => void refetch(),
+  };
 }
 
 // ── useProjectArtifactWatcher ─────────────────────────────────────────────────
@@ -228,42 +215,48 @@ export interface UseArtifactClassifyResult {
 export function useArtifactClassify(
   onSuccess?: () => void,
 ): UseArtifactClassifyResult {
-  const [working, setWorking] = useState(false);
-
-  const classify = useCallback(
-    async (request: ArtifactClassifyRequest) => {
-      setWorking(true);
-      try {
-        await artifactClassify(request);
-        onSuccess?.();
-      } finally {
-        setWorking(false);
-      }
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: (request: ArtifactClassifyRequest) => artifactClassify(request),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projects.artifacts(variables.projectId),
+      });
+      onSuccess?.();
     },
-    [onSuccess],
-  );
+  });
 
-  return { state: { working }, classify };
+  const classify = async (request: ArtifactClassifyRequest) => {
+    await mutation.mutateAsync(request);
+  };
+
+  return { state: { working: mutation.isPending }, classify };
 }
 
 // ── useArtifactMarkResolved ────────────────────────────────────────────────────
 
 /** Mutation hook for marking a missing artifact as user-resolved. */
 export function useArtifactMarkResolved(onSuccess?: () => void) {
-  const [working, setWorking] = useState(false);
-
-  const markResolved = useCallback(
-    async (projectId: string, artifactId: string) => {
-      setWorking(true);
-      try {
-        await artifactMarkResolved({ projectId, artifactId });
-        onSuccess?.();
-      } finally {
-        setWorking(false);
-      }
+  const queryClient = useQueryClient();
+  const mutation = useMutation({
+    mutationFn: ({
+      projectId,
+      artifactId,
+    }: {
+      projectId: string;
+      artifactId: string;
+    }) => artifactMarkResolved({ projectId, artifactId }),
+    onSuccess: (_data, variables) => {
+      void queryClient.invalidateQueries({
+        queryKey: queryKeys.projects.artifacts(variables.projectId),
+      });
+      onSuccess?.();
     },
-    [onSuccess],
-  );
+  });
 
-  return { working, markResolved };
+  const markResolved = async (projectId: string, artifactId: string) => {
+    await mutation.mutateAsync({ projectId, artifactId });
+  };
+
+  return { working: mutation.isPending, markResolved };
 }

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -56,9 +56,7 @@ function render(ui: ReactElement) {
   });
   return rtlRender(ui, {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
   });
 }

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -492,6 +492,36 @@ describe('TargetDetailV2', () => {
     );
   });
 
+  it('16b. alias add/remove refetch ONLY the detail query, not sessions/projects/notes (invalidation-prefix regression)', async () => {
+    // `queryKeys.targets.detail(id)` (['targets', id]) is itself a PREFIX of
+    // sessions(id)/projects(id)/notes(id)/astroFormat(id) (['targets', id,
+    // ...]) — an unqualified invalidateQueries() on detail(id) would fuzzy-
+    // match and refetch all four. Asserts store.ts's invalidateTarget() uses
+    // `exact: true` so an alias mutation costs exactly one extra detail fetch.
+    render(<TargetDetailV2 targetId={TARGET_ID} />);
+    await waitFor(() => screen.getByRole('textbox', { name: /new alias/i }));
+    expect(mockListTargetSessions).toHaveBeenCalledTimes(1);
+    expect(mockListTargetProjects).toHaveBeenCalledTimes(1);
+    expect(mockGetTargetNote).toHaveBeenCalledTimes(1);
+
+    fireEvent.change(screen.getByRole('textbox', { name: /new alias/i }), {
+      target: { value: 'Regression Alias' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^add$/i }));
+    await waitFor(() => expect(mockGetTargetDetail).toHaveBeenCalledTimes(2));
+
+    expect(mockListTargetSessions).toHaveBeenCalledTimes(1);
+    expect(mockListTargetProjects).toHaveBeenCalledTimes(1);
+    expect(mockGetTargetNote).toHaveBeenCalledTimes(1);
+
+    fireEvent.click(screen.getByLabelText('Remove alias My Nebula'));
+    await waitFor(() => expect(mockGetTargetDetail).toHaveBeenCalledTimes(3));
+
+    expect(mockListTargetSessions).toHaveBeenCalledTimes(1);
+    expect(mockListTargetProjects).toHaveBeenCalledTimes(1);
+    expect(mockGetTargetNote).toHaveBeenCalledTimes(1);
+  });
+
   it('17. display-alias Set/Edit button is visible', async () => {
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -38,12 +38,30 @@
 
 import {
   configure,
-  render,
+  render as rtlRender,
   screen,
   fireEvent,
   waitFor,
 } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+
+// TargetDetailV2 is now backed by TanStack Query (store.ts) — every render
+// needs a QueryClientProvider ancestor. Shadowing `render` here (instead of
+// touching every one of this file's ~30 call sites) keeps the diff mechanical.
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+}
 
 // Windows-CI headroom (same flake class as PR #412's settings hydration races):
 // every test in this file waits on content that only renders after mocked async

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -28,16 +28,21 @@
 import { useState, useEffect, useCallback } from 'react';
 import { X } from 'lucide-react';
 import { useNavigate, Link } from '@tanstack/react-router';
-import { commands } from '@/bindings/index';
-import { unwrap } from '@/api/ipc';
-import type { TargetDetailV3 } from '@/bindings/aliases';
 import type { ContractError } from '@/lib/errors';
 import type { TargetListItem } from '@/bindings/index';
-import type {
-  TargetSessionItem,
-  TargetProjectItem,
-  TargetAstroFormat,
-} from '@/bindings';
+import {
+  useTargetDetail,
+  useTargetSessions,
+  useTargetProjects,
+  useTargetNotes,
+  useTargetAstroFormat,
+  useAddTargetAlias,
+  useRemoveTargetAlias,
+  useSetTargetDisplayAlias,
+  useClearTargetDisplayAlias,
+  useUpdateTargetNotes,
+} from './store';
+import type { TargetDetailV3 } from './store';
 import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn, Skeleton } from '@/ui';
 import { m } from '@/lib/i18n';
@@ -422,7 +427,6 @@ export function TargetDetailV2({
   onMutated,
 }: Props) {
   const guidanceParams = useGuidanceParams();
-  const [loadState, setLoadState] = useState<LoadState>({ status: 'loading' });
   const [aliasInput, setAliasInput] = useState('');
   const [aliasError, setAliasError] = useState<string | null>(null);
   const [actionError, setActionError] = useState<string | null>(null);
@@ -430,28 +434,13 @@ export function TargetDetailV2({
   const [displayAliasEditing, setDisplayAliasEditing] = useState(false);
   const [newProjectOpen, setNewProjectOpen] = useState(false);
 
-  // US2: linked sessions
-  const [sessions, setSessions] = useState<TargetSessionItem[]>([]);
-  const [sessionsLoading, setSessionsLoading] = useState(true);
-
-  // US3: linked projects
-  const [projects, setProjects] = useState<TargetProjectItem[]>([]);
-  const [projectsLoading, setProjectsLoading] = useState(true);
-
-  // US4: observing notes
-  const [notes, setNotes] = useState<string | null>(null);
+  // US4: observing notes (draft/editing/save-status stay local; the persisted
+  // value is TanStack-Query-backed via useTargetNotes/useUpdateTargetNotes).
   const [notesEditing, setNotesEditing] = useState(false);
   const [notesDraft, setNotesDraft] = useState('');
   const [notesSaving, setNotesSaving] = useState(false);
   const [notesSaved, setNotesSaved] = useState(false);
   const [notesError, setNotesError] = useState<string | null>(null);
-
-  // Sexagesimal RA/Dec (adopt target-match): backend-formatted, carry-safe
-  // rounding (replaces the hand-rolled fmtRa/fmtDec, which could round a
-  // seconds value up to an invalid ":60").
-  const [astroFormat, setAstroFormat] = useState<TargetAstroFormat | null>(
-    null,
-  );
 
   const navigate = useNavigate();
 
@@ -461,91 +450,69 @@ export function TargetDetailV2({
   // US2/T024: the Planner's chosen date (defaults to "tonight", FR-008).
   const dateMs = usePlannerDateMs();
 
-  const load = useCallback(() => {
-    setLoadState({ status: 'loading' });
-    commands
-      .targetGet({ targetId })
-      .then(unwrap)
-      .then((data) => {
-        setLoadState({ status: 'loaded', data: data as TargetDetailV3 });
-        setDisplayAliasInput(data.displayAlias ?? '');
-      })
-      .catch(() => {
-        setLoadState({
-          status: 'error',
-          message: m.targets_detail_load_error(),
-        });
-      });
-  }, [targetId]);
+  const detailQuery = useTargetDetail(targetId);
+  const { data: sessions = [], loading: sessionsLoading } =
+    useTargetSessions(targetId);
+  const { data: projects = [], loading: projectsLoading } =
+    useTargetProjects(targetId);
+  const { data: notes = null } = useTargetNotes(targetId);
+  // Sexagesimal RA/Dec (adopt target-match): backend-formatted, carry-safe
+  // rounding (replaces the hand-rolled fmtRa/fmtDec, which could round a
+  // seconds value up to an invalid ":60"). Only fires once the detail has
+  // loaded (mirrors the pre-migration effect's `loadState.status==='loaded'` gate).
+  const { data: astroFormat = null } = useTargetAstroFormat(
+    targetId,
+    detailQuery.data?.raDeg ?? null,
+    detailQuery.data?.decDeg ?? null,
+    !!detailQuery.data,
+  );
+
+  const loadState: LoadState = detailQuery.error
+    ? { status: 'error', message: m.targets_detail_load_error() }
+    : detailQuery.loading || !detailQuery.data
+      ? { status: 'loading' }
+      : { status: 'loaded', data: detailQuery.data };
+
+  // Sync the display-alias draft from the server value whenever a fresh
+  // detail lands (mount, post-mutation refetch, or a display-alias mutation's
+  // own cache write) — guarded on `!displayAliasEditing` so an in-progress
+  // edit is never clobbered by a background refetch (mirrors
+  // ProjectNotesSection's initialContent-sync convention).
+  useEffect(() => {
+    if (detailQuery.data && !displayAliasEditing) {
+      setDisplayAliasInput(detailQuery.data.displayAlias ?? '');
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [detailQuery.data]);
+
+  // Sync the notes draft from the server value whenever it changes, and reset
+  // editing/saved/error state when the target itself changes.
+  useEffect(() => {
+    if (!notesEditing) setNotesDraft(notes ?? '');
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [notes]);
 
   useEffect(() => {
-    load();
-  }, [load]);
-
-  // US2: load linked sessions when targetId changes.
-  useEffect(() => {
-    setSessionsLoading(true);
-    commands
-      .targetSessionsList({ targetId })
-      .then(unwrap)
-      .then((data) => setSessions(data))
-      .catch(() => setSessions([]))
-      .finally(() => setSessionsLoading(false));
-  }, [targetId]);
-
-  // US3: load linked projects when targetId changes.
-  useEffect(() => {
-    setProjectsLoading(true);
-    commands
-      .targetProjectsList({ targetId })
-      .then(unwrap)
-      .then((data) => setProjects(data))
-      .catch(() => setProjects([]))
-      .finally(() => setProjectsLoading(false));
-  }, [targetId]);
-
-  // US4: load observing notes when targetId changes.
-  useEffect(() => {
-    commands
-      .targetNoteGet({ targetId })
-      .then(unwrap)
-      .then(({ notes: n }) => {
-        setNotes(n ?? null);
-        setNotesDraft(n ?? '');
-      })
-      .catch(() => {
-        setNotes(null);
-        setNotesDraft('');
-      });
-    // Reset editing state when target changes.
     setNotesEditing(false);
     setNotesSaved(false);
     setNotesError(null);
   }, [targetId]);
 
-  // Sexagesimal RA/Dec: one batched call (N=1 here) once the detail loads.
-  // No reset-to-null branch needed for the non-'loaded' states: `astroFormat`
-  // is only read below after the loading/error early-returns, so a stale
-  // value from a prior target is never displayed before this effect refetches.
-  useEffect(() => {
-    if (loadState.status !== 'loaded') return;
-    const { id, raDeg, decDeg } = loadState.data;
-    commands
-      .targetAstroFormatBatch({ targets: [{ id, raDeg, decDeg }] })
-      .then(unwrap)
-      .then(({ formatted }) => setAstroFormat(formatted[0] ?? null))
-      .catch(() => setAstroFormat(null));
-  }, [loadState]);
+  const addAliasMutation = useAddTargetAlias();
+  const removeAliasMutation = useRemoveTargetAlias();
+  const setDisplayAliasMutation = useSetTargetDisplayAlias();
+  const clearDisplayAliasMutation = useClearTargetDisplayAlias();
+  const updateNotesMutation = useUpdateTargetNotes();
 
   // US4: save notes handler.
   const handleNotesSave = useCallback(async () => {
     setNotesSaving(true);
     setNotesError(null);
     try {
-      const { notes: saved } = unwrap(
-        await commands.targetNoteUpdate({ targetId, notes: notesDraft }),
-      );
-      setNotes(saved ?? null);
+      const { notes: saved } = await updateNotesMutation.mutateAsync({
+        targetId,
+        notes: notesDraft,
+      });
       setNotesDraft(saved ?? '');
       setNotesEditing(false);
       setNotesSaved(true);
@@ -554,7 +521,7 @@ export function TargetDetailV2({
     } finally {
       setNotesSaving(false);
     }
-  }, [targetId, notesDraft]);
+  }, [targetId, notesDraft, updateNotesMutation]);
 
   // Add user alias.
   const handleAliasAdd = useCallback(async () => {
@@ -565,43 +532,38 @@ export function TargetDetailV2({
     }
     setAliasError(null);
     try {
-      unwrap(await commands.targetAliasAdd({ targetId, alias }));
+      await addAliasMutation.mutateAsync({ targetId, alias });
       setAliasInput('');
-      load();
       onMutated?.();
     } catch (err) {
       const e = err as ContractError;
       setAliasError(errorMessage(e, m.targets_detail_add_alias_failed()));
     }
-  }, [targetId, aliasInput, load, onMutated]);
+  }, [targetId, aliasInput, addAliasMutation, onMutated]);
 
   // Remove user alias by id.
   const handleAliasRemove = useCallback(
     async (aliasId: string) => {
       setActionError(null);
       try {
-        unwrap(await commands.targetAliasRemove({ targetId, aliasId }));
-        load();
+        await removeAliasMutation.mutateAsync({ targetId, aliasId });
         onMutated?.();
       } catch (err) {
         const e = err as ContractError;
         setActionError(errorMessage(e, m.targets_detail_remove_alias_failed()));
       }
     },
-    [targetId, load, onMutated],
+    [targetId, removeAliasMutation, onMutated],
   );
 
   // Set display alias.
   const handleDisplayAliasSet = useCallback(async () => {
     setActionError(null);
     try {
-      const data = unwrap(
-        await commands.targetDisplayAliasSet({
-          targetId,
-          displayAlias: displayAliasInput.trim(),
-        }),
-      );
-      setLoadState({ status: 'loaded', data: data as TargetDetailV3 });
+      const data = await setDisplayAliasMutation.mutateAsync({
+        targetId,
+        displayAlias: displayAliasInput.trim(),
+      });
       setDisplayAliasInput(data.displayAlias ?? '');
       setDisplayAliasEditing(false);
       onMutated?.();
@@ -611,14 +573,13 @@ export function TargetDetailV2({
         errorMessage(e, m.targets_detail_set_display_alias_failed()),
       );
     }
-  }, [targetId, displayAliasInput, onMutated]);
+  }, [targetId, displayAliasInput, setDisplayAliasMutation, onMutated]);
 
   // Clear display alias.
   const handleDisplayAliasClear = useCallback(async () => {
     setActionError(null);
     try {
-      const data = unwrap(await commands.targetDisplayAliasClear({ targetId }));
-      setLoadState({ status: 'loaded', data: data as TargetDetailV3 });
+      await clearDisplayAliasMutation.mutateAsync({ targetId });
       setDisplayAliasInput('');
       setDisplayAliasEditing(false);
       onMutated?.();
@@ -628,7 +589,7 @@ export function TargetDetailV2({
         errorMessage(e, m.targets_detail_clear_display_alias_failed()),
       );
     }
-  }, [targetId, onMutated]);
+  }, [targetId, clearDisplayAliasMutation, onMutated]);
 
   // ── Render ──────────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -30,7 +30,7 @@
  */
 
 import {
-  render,
+  render as rtlRender,
   screen,
   fireEvent,
   waitFor,
@@ -38,6 +38,24 @@ import {
   act,
 } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+
+// TargetsPage (list load + the nested TargetDetailV2/useFavourites) is now
+// TanStack-Query-backed — every render needs a QueryClientProvider ancestor.
+// Shadowing `render` keeps every call site in this file unchanged.
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>
+        {children}
+      </QueryClientProvider>
+    ),
+  });
+}
 
 // ── Hoist mocks ───────────────────────────────────────────────────────────────
 

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -50,9 +50,7 @@ function render(ui: ReactElement) {
   });
   return rtlRender(ui, {
     wrapper: ({ children }) => (
-      <QueryClientProvider client={queryClient}>
-        {children}
-      </QueryClientProvider>
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
     ),
   });
 }

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -46,8 +46,6 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { commands } from '@/bindings/index';
-import { unwrap } from '@/api/ipc';
 import type { TargetListItem } from '@/bindings/index';
 import { PageTopBar, FilterToolbar, ListPageLayout } from '@/components';
 import type { FilterOption } from '@/components';
@@ -56,6 +54,7 @@ import { Btn, EmptyState } from '@/ui';
 import { useGrouping } from '@/lib/use-grouping';
 import { AddTargetDialog } from './AddTargetDialog';
 import { TargetDetailV2 } from './TargetDetailV2';
+import { useTargets } from './store';
 import {
   filterByCatalogues,
   PLANNER_CATALOGS,
@@ -198,7 +197,6 @@ const REVEAL_CHUNK = 300;
 export function TargetsPage() {
   const { selected } = useSearch({ from: '/shell/targets' });
   const navigate = useNavigate({ from: '/targets' });
-  const [listState, setListState] = useState<ListState>({ status: 'loading' });
   const [addOpen, setAddOpen] = useState(false);
   /** '' = show full Planner catalog; 'my' = My Targets stub (#91). */
   const [myTargetsFilter, setMyTargetsFilter] = useState('');
@@ -293,20 +291,18 @@ export function TargetsPage() {
     void loadGuidanceParams();
   }, []);
 
-  const load = useCallback(() => {
-    setListState({ status: 'loading' });
-    commands
-      .targetList()
-      .then(unwrap)
-      .then((items) => setListState({ status: 'loaded', items }))
-      .catch(() =>
-        setListState({ status: 'error', message: m.targets_page_error_load() }),
-      );
-  }, []);
-
-  useEffect(() => {
-    load();
-  }, [load]);
+  const targetsQuery = useTargets();
+  const load = targetsQuery.refetch;
+  // `listState` mirrors the pre-migration state machine so the rest of this
+  // component (progressive reveal, error/loading branches) stays unchanged.
+  // `loading` covers BOTH the initial fetch and any explicit `load()` refetch
+  // (`isFetching`, not just "no data yet") — matching the old `load()`, which
+  // always flipped back to 'loading' synchronously on every reload.
+  const listState: ListState = targetsQuery.error
+    ? { status: 'error', message: m.targets_page_error_load() }
+    : targetsQuery.loading || !targetsQuery.data
+      ? { status: 'loading' }
+      : { status: 'loaded', items: targetsQuery.data };
 
   /**
    * Progressive reveal of the Planner catalogue (#573): `commands.targetList()`

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -29,7 +29,21 @@ import {
   waitFor,
 } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 import type { TargetListItem } from '@/bindings/index';
+
+// TargetsTable's internal `useFavourites()` fallback (used whenever a caller
+// doesn't pass `favouriteIds`/`onToggleFavourite`, which is every test in this
+// file) is now TanStack-Query-backed and needs a QueryClientProvider ancestor.
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
 
 // The no-site banner (spec 044 US3) links to Settings via `Link`, which needs
 // a router context this test doesn't provide. Stub it as a plain anchor —
@@ -62,6 +76,15 @@ const { mockMoonOppositionBatch } = vi.hoisted(() => ({
 vi.mock('@/bindings/index', () => ({
   commands: {
     targetMoonOppositionBatch: mockMoonOppositionBatch,
+    // TargetsTable's internal useFavourites() fallback fetches this on every
+    // mount; a static empty list keeps every test in this file deterministic
+    // (favourites are not this file's concern).
+    targetFavouritesList: () =>
+      Promise.resolve({ status: 'ok', data: { targetIds: [] } }),
+    targetFavouritesAdd: () =>
+      Promise.resolve({ status: 'ok', data: { targetId: '', favouritedAt: '' } }),
+    targetFavouritesRemove: () =>
+      Promise.resolve({ status: 'ok', data: { targetId: '' } }),
   },
 }));
 
@@ -134,6 +157,7 @@ function renderTable(
       onSort={onSort}
       {...overrides}
     />,
+    { wrapper },
   );
   return { onSelect, onSort };
 }
@@ -208,6 +232,7 @@ describe('TargetsTable (#84/#85)', () => {
         onSort={vi.fn()}
         night={nightWithMoonAtVernalEquinox()}
       />,
+      { wrapper },
     );
     // Each row has 7 band pills (L/R/G/B/Ha/SII/OIII), each labelled viable or
     // not-viable — never a fabricated recommendation. #634: separation now
@@ -433,6 +458,7 @@ describe('TargetsTable — lunar distance (US2)', () => {
         onSort={vi.fn()}
         night={night}
       />,
+      { wrapper },
     );
   }
 
@@ -475,6 +501,7 @@ describe('TargetsTable — lunar distance (US2)', () => {
         sort={DEFAULT_TARGET_SORT}
         onSort={vi.fn()}
       />,
+      { wrapper },
     );
     // No numeric lunar separations; both rows show the unknown dash.
     expect(screen.queryByText('90°')).not.toBeInTheDocument();

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -82,7 +82,10 @@ vi.mock('@/bindings/index', () => ({
     targetFavouritesList: () =>
       Promise.resolve({ status: 'ok', data: { targetIds: [] } }),
     targetFavouritesAdd: () =>
-      Promise.resolve({ status: 'ok', data: { targetId: '', favouritedAt: '' } }),
+      Promise.resolve({
+        status: 'ok',
+        data: { targetId: '', favouritedAt: '' },
+      }),
     targetFavouritesRemove: () =>
       Promise.resolve({ status: 'ok', data: { targetId: '' } }),
   },

--- a/apps/desktop/src/features/targets/store.ts
+++ b/apps/desktop/src/features/targets/store.ts
@@ -176,6 +176,11 @@ export function useTargetAstroFormat(
 // direct `setQueryData(detail(id), ...)` write below would get silently
 // clobbered by the list invalidation's own background refetch of the SAME
 // prefix-matched detail query).
+//
+// `exact: true` is required here too: `detail(id)` (`['targets', id]`) is
+// ITSELF a prefix of `sessions(id)`/`projects(id)`/`notes(id)`/`astroFormat(id)`
+// (all `['targets', id, ...]`) — an unqualified invalidate would fuzzy-match
+// and refetch all four every alias/display-alias mutation, not just detail.
 
 function invalidateTarget(
   queryClient: ReturnType<typeof useQueryClient>,
@@ -183,6 +188,7 @@ function invalidateTarget(
 ) {
   void queryClient.invalidateQueries({
     queryKey: queryKeys.targets.detail(targetId),
+    exact: true,
   });
 }
 

--- a/apps/desktop/src/features/targets/store.ts
+++ b/apps/desktop/src/features/targets/store.ts
@@ -1,0 +1,240 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Targets store — TanStack Query hooks (spec `tiny/targets-tanstack-query-migration`).
+ *
+ * Mirrors `features/sessions/store.ts`: local `unwrap(await commands.X(req))`
+ * helpers + `useQuery`/`useMutation` hooks keyed via `queryKeys.targets`.
+ * Mutations invalidate the affected key(s) instead of the old manual `load()`
+ * refetch calls that `TargetDetailV2`/`TargetsPage` used to thread through
+ * props (`onMutated`).
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/data/queryKeys';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import type {
+  TargetListItem,
+  TargetSessionItem,
+  TargetProjectItem,
+  TargetAstroFormat,
+  TargetAliasAddRequest,
+  TargetAliasAddResult,
+  TargetAliasRemoveRequest,
+  TargetAliasRemoveResult,
+  TargetDisplayAliasSetRequest,
+  TargetDisplayAliasClearRequest,
+  TargetNoteUpdateRequest,
+  TargetNoteUpdateResult_Serialize as TargetNoteUpdateResult,
+} from '@/bindings/index';
+import type { TargetDetailV3 } from '@/bindings/aliases';
+
+export type { TargetDetailV3 };
+
+// Local IPC helpers — mirrors the rest of the store layer (unwrap turns the
+// generated Result into the throw-on-error contract useQuery/useMutation rely on).
+
+async function getTargetDetail(targetId: string): Promise<TargetDetailV3> {
+  return unwrap(await commands.targetGet({ targetId })) as TargetDetailV3;
+}
+
+async function listTargetSessions(
+  targetId: string,
+): Promise<TargetSessionItem[]> {
+  return unwrap(await commands.targetSessionsList({ targetId }));
+}
+
+async function listTargetProjects(
+  targetId: string,
+): Promise<TargetProjectItem[]> {
+  return unwrap(await commands.targetProjectsList({ targetId }));
+}
+
+async function getTargetNotes(targetId: string): Promise<string | null> {
+  const { notes } = unwrap(await commands.targetNoteGet({ targetId }));
+  return notes ?? null;
+}
+
+// Query state shape (matches the other stores' backward-compat surface).
+
+export interface QueryState<T> {
+  data: T | undefined;
+  loading: boolean;
+  error: Error | undefined;
+}
+
+/** `useTargets()`'s state plus a manual refetch (e.g. after "Add target"). */
+export interface TargetsListState extends QueryState<TargetListItem[]> {
+  refetch: () => void;
+}
+
+// ── Query hooks ───────────────────────────────────────────────────────────────
+
+/**
+ * Subscribe to the full targets (Planner catalogue) list.
+ *
+ * `refetch` replaces the old manual `load()` re-fetch — `TargetsPage` calls it
+ * after "Add target" and passes it as `TargetDetailV2`'s `onMutated` so an
+ * alias/display-alias edit refreshes the list's search/label data too.
+ */
+export function useTargets(): TargetsListState {
+  const { data, isFetching, error, refetch } = useQuery({
+    queryKey: queryKeys.targets.list(),
+    queryFn: async () => unwrap(await commands.targetList()),
+  });
+  return {
+    data,
+    loading: isFetching,
+    error: error ?? undefined,
+    refetch: () => void refetch(),
+  };
+}
+
+/** Subscribe to a single target's gen-3 detail. */
+export function useTargetDetail(targetId: string): QueryState<TargetDetailV3> {
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.targets.detail(targetId),
+    queryFn: () => getTargetDetail(targetId),
+    enabled: !!targetId,
+  });
+  return { data, loading: isFetching, error: error ?? undefined };
+}
+
+/** Subscribe to a target's linked sessions (US2). */
+export function useTargetSessions(
+  targetId: string,
+): QueryState<TargetSessionItem[]> {
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.targets.sessions(targetId),
+    queryFn: () => listTargetSessions(targetId),
+    enabled: !!targetId,
+  });
+  return { data, loading: isFetching, error: error ?? undefined };
+}
+
+/** Subscribe to a target's linked projects (US3). */
+export function useTargetProjects(
+  targetId: string,
+): QueryState<TargetProjectItem[]> {
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.targets.projects(targetId),
+    queryFn: () => listTargetProjects(targetId),
+    enabled: !!targetId,
+  });
+  return { data, loading: isFetching, error: error ?? undefined };
+}
+
+/** Subscribe to a target's observing notes (US4). */
+export function useTargetNotes(targetId: string): QueryState<string | null> {
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.targets.notes(targetId),
+    queryFn: () => getTargetNotes(targetId),
+    enabled: !!targetId,
+  });
+  return { data, loading: isFetching, error: error ?? undefined };
+}
+
+/**
+ * Sexagesimal RA/Dec formatting for one target (batched endpoint, N=1 here).
+ * Keyed on the target id — coordinates are immutable for the life of a
+ * catalog entry, so no re-derivation is needed across mounts. `enabled` lets
+ * the caller gate this on its own detail query having resolved (mirrors the
+ * pre-migration effect's `loadState.status === 'loaded'` guard).
+ */
+export function useTargetAstroFormat(
+  targetId: string,
+  raDeg: number | null,
+  decDeg: number | null,
+  enabled: boolean,
+): QueryState<TargetAstroFormat | null> {
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.targets.astroFormat(targetId),
+    queryFn: async () => {
+      const { formatted } = unwrap(
+        await commands.targetAstroFormatBatch({
+          targets: [{ id: targetId, raDeg, decDeg }],
+        }),
+      );
+      return formatted[0] ?? null;
+    },
+    enabled: enabled && !!targetId,
+  });
+  return { data, loading: isFetching, error: error ?? undefined };
+}
+
+// ── Mutation hooks ────────────────────────────────────────────────────────────
+//
+// Every mutation below invalidates its target's `detail` key so `TargetDetailV2`
+// refetches without a manual `load()` (spec `tiny/targets-tanstack-query-migration`).
+// The LIST payload also carries alias/display-label search terms, but is
+// refreshed via the `onMutated` callback prop (TargetsPage's `useTargets()`
+// `refetch`) rather than a second `invalidateQueries({queryKey: ['targets']})`
+// here — that broader key is a PREFIX of `detail(id)` (`['targets', id]`), so
+// invalidating both in the same mutation double-invalidates (and, worse, a
+// direct `setQueryData(detail(id), ...)` write below would get silently
+// clobbered by the list invalidation's own background refetch of the SAME
+// prefix-matched detail query).
+
+function invalidateTarget(
+  queryClient: ReturnType<typeof useQueryClient>,
+  targetId: string,
+) {
+  void queryClient.invalidateQueries({
+    queryKey: queryKeys.targets.detail(targetId),
+  });
+}
+
+export function useAddTargetAlias() {
+  const queryClient = useQueryClient();
+  return useMutation<TargetAliasAddResult, Error, TargetAliasAddRequest>({
+    mutationFn: async (req) => unwrap(await commands.targetAliasAdd(req)),
+    onSuccess: (_data, variables) =>
+      invalidateTarget(queryClient, variables.targetId),
+  });
+}
+
+export function useRemoveTargetAlias() {
+  const queryClient = useQueryClient();
+  return useMutation<TargetAliasRemoveResult, Error, TargetAliasRemoveRequest>({
+    mutationFn: async (req) => unwrap(await commands.targetAliasRemove(req)),
+    onSuccess: (_data, variables) =>
+      invalidateTarget(queryClient, variables.targetId),
+  });
+}
+
+export function useSetTargetDisplayAlias() {
+  const queryClient = useQueryClient();
+  return useMutation<TargetDetailV3, Error, TargetDisplayAliasSetRequest>({
+    mutationFn: async (req) =>
+      unwrap(await commands.targetDisplayAliasSet(req)) as TargetDetailV3,
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(queryKeys.targets.detail(variables.targetId), data);
+    },
+  });
+}
+
+export function useClearTargetDisplayAlias() {
+  const queryClient = useQueryClient();
+  return useMutation<TargetDetailV3, Error, TargetDisplayAliasClearRequest>({
+    mutationFn: async (req) =>
+      unwrap(await commands.targetDisplayAliasClear(req)) as TargetDetailV3,
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(queryKeys.targets.detail(variables.targetId), data);
+    },
+  });
+}
+
+export function useUpdateTargetNotes() {
+  const queryClient = useQueryClient();
+  return useMutation<TargetNoteUpdateResult, Error, TargetNoteUpdateRequest>({
+    mutationFn: async (req) => unwrap(await commands.targetNoteUpdate(req)),
+    onSuccess: (data, variables) => {
+      queryClient.setQueryData(
+        queryKeys.targets.notes(variables.targetId),
+        data.notes ?? null,
+      );
+    },
+  });
+}

--- a/apps/desktop/src/features/targets/store.ts
+++ b/apps/desktop/src/features/targets/store.ts
@@ -216,7 +216,10 @@ export function useSetTargetDisplayAlias() {
     mutationFn: async (req) =>
       unwrap(await commands.targetDisplayAliasSet(req)) as TargetDetailV3,
     onSuccess: (data, variables) => {
-      queryClient.setQueryData(queryKeys.targets.detail(variables.targetId), data);
+      queryClient.setQueryData(
+        queryKeys.targets.detail(variables.targetId),
+        data,
+      );
     },
   });
 }
@@ -227,7 +230,10 @@ export function useClearTargetDisplayAlias() {
     mutationFn: async (req) =>
       unwrap(await commands.targetDisplayAliasClear(req)) as TargetDetailV3,
     onSuccess: (data, variables) => {
-      queryClient.setQueryData(queryKeys.targets.detail(variables.targetId), data);
+      queryClient.setQueryData(
+        queryKeys.targets.detail(variables.targetId),
+        data,
+      );
     },
   });
 }

--- a/apps/desktop/src/features/targets/useFavourites.test.tsx
+++ b/apps/desktop/src/features/targets/useFavourites.test.tsx
@@ -12,6 +12,20 @@
 
 import { beforeEach, describe, it, expect, vi } from 'vitest';
 import { renderHook, act, waitFor } from '@testing-library/react';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { queryClient } from '@/data/queryClient';
+
+// Every `useFavourites()` mount reads/writes the app-wide `queryClient`
+// singleton (matching production, where `main.tsx` mounts the same instance)
+// — `getFavouriteIds()`/`__resetFavouritesCacheForTests()` read that same
+// singleton directly, so tests must wrap with it too (not an ad-hoc client)
+// or the hook and the non-hook reads would diverge.
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
 
 type MockIpc = (...args: unknown[]) => Promise<unknown>;
 
@@ -73,7 +87,7 @@ describe('useFavourites', () => {
   it('loads the favourite set from the backend on mount', async () => {
     mockTargetFavouritesList.mockReturnValue(okList(['id-a', 'id-b']));
 
-    const { result } = renderHook(() => useFavourites());
+    const { result } = renderHook(() => useFavourites(), { wrapper });
 
     await waitFor(() => expect(result.current.favouriteIds.size).toBe(2));
     expect(result.current.isFavourite('id-a')).toBe(true);
@@ -82,15 +96,17 @@ describe('useFavourites', () => {
   });
 
   it('toggle favourites an unfavourited target optimistically then confirms via the backend', async () => {
-    const { result } = renderHook(() => useFavourites());
+    const { result } = renderHook(() => useFavourites(), { wrapper });
     await waitFor(() => expect(mockTargetFavouritesList).toHaveBeenCalled());
 
     act(() => {
       result.current.toggle('id-x');
     });
 
-    // Optimistic update is synchronous.
-    expect(result.current.isFavourite('id-x')).toBe(true);
+    // Optimistic update: applied to the query cache synchronously, but
+    // TanStack Query's notifyManager batches the resulting re-render via a
+    // macrotask, so the hook's return value reflects it after a tick.
+    await waitFor(() => expect(result.current.isFavourite('id-x')).toBe(true));
 
     await waitFor(() =>
       expect(mockTargetFavouritesAdd).toHaveBeenCalledWith({
@@ -102,14 +118,14 @@ describe('useFavourites', () => {
 
   it('toggle unfavourites an already-favourited target', async () => {
     mockTargetFavouritesList.mockReturnValue(okList(['id-y']));
-    const { result } = renderHook(() => useFavourites());
+    const { result } = renderHook(() => useFavourites(), { wrapper });
     await waitFor(() => expect(result.current.isFavourite('id-y')).toBe(true));
 
     act(() => {
       result.current.toggle('id-y');
     });
 
-    expect(result.current.isFavourite('id-y')).toBe(false);
+    await waitFor(() => expect(result.current.isFavourite('id-y')).toBe(false));
     await waitFor(() =>
       expect(mockTargetFavouritesRemove).toHaveBeenCalledWith({
         targetId: 'id-y',
@@ -124,21 +140,26 @@ describe('useFavourites', () => {
         error: { code: 'internal.database', message: 'boom' },
       }),
     );
-    const { result } = renderHook(() => useFavourites());
+    const { result } = renderHook(() => useFavourites(), { wrapper });
     await waitFor(() => expect(mockTargetFavouritesList).toHaveBeenCalled());
 
+    // The mock backend call rejects on the SAME microtask turn as the
+    // optimistic cache write, and TanStack Query's notifyManager batches
+    // same-turn cache writes into one render — so the optimistic `true` and
+    // its revert can coalesce into a single visible update here (unlike a
+    // real IPC round-trip, which always takes longer than one tick). The end
+    // state — reverted to unfavourited — is what matters and is asserted below.
     act(() => {
       result.current.toggle('id-z');
     });
-    expect(result.current.isFavourite('id-z')).toBe(true);
 
     await waitFor(() => expect(result.current.isFavourite('id-z')).toBe(false));
   });
 
   it('shares the cache across multiple hook mounts', async () => {
     mockTargetFavouritesList.mockReturnValue(okList(['id-shared']));
-    const a = renderHook(() => useFavourites());
-    const b = renderHook(() => useFavourites());
+    const a = renderHook(() => useFavourites(), { wrapper });
+    const b = renderHook(() => useFavourites(), { wrapper });
 
     await waitFor(() =>
       expect(a.result.current.isFavourite('id-shared')).toBe(true),

--- a/apps/desktop/src/features/targets/useFavourites.ts
+++ b/apps/desktop/src/features/targets/useFavourites.ts
@@ -6,81 +6,35 @@
  *
  * Favourites are canonical, database-backed state (`target_favourite` table,
  * migration `0061`) — see `targets.favourites.list` / `.add` / `.remove` in
- * `apps/desktop/src-tauri/src/commands/target_favourites.rs`. This replaces
- * the previous `localStorage`-only stub (task #18, spec 043).
+ * `apps/desktop/src-tauri/src/commands/target_favourites.rs`. Backed by
+ * TanStack Query (spec `tiny/targets-tanstack-query-migration`): the
+ * `queryKeys.targets.favourites()` cache entry IS the shared store, so every
+ * `useFavourites()` mount reads/writes the same set without a bespoke
+ * `useSyncExternalStore` subscriber list.
  *
- * The old stub cited task #54 (FITS OBJECT → target_id linkage) as its own
- * blocker — that citation was specific to *storage location*, which this
- * feature resolves (favourites are keyed directly off canonical target ids,
- * independent of any FITS ingest linkage). Task #54 itself is broader than
- * favourites storage: it also covers the FITS-derived target list backing
- * `TargetsPage.tsx`'s stub filters and `ProjectsTable.tsx`'s target column
- * (both still marked STUB pending #54), which this feature does not close.
- *
-
- * API (unchanged shape from the stub):
+ * API (unchanged shape from the pre-migration hook):
  *   useFavourites() → { favouriteIds: Set<string>, toggle, isFavourite }
  *   getFavouriteIds()         — non-hook read (for tests / outside React;
- *                               returns the current in-memory cache, which is
- *                               empty until the first backend fetch resolves)
+ *                               returns the current cache, empty until the
+ *                               first backend fetch resolves)
  */
 
-import { useSyncExternalStore, useCallback, useEffect } from 'react';
+import { useCallback } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { queryKeys } from '@/data/queryKeys';
+import { queryClient as sharedQueryClient } from '@/data/queryClient';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 
-// ── Module-level cache + subscriber wiring ──────────────────────────────────
-//
-// A single shared cache backs every `useFavourites()` mount so all
-// subscribers (e.g. TargetsTable + a detail pane) stay in sync without each
-// mount re-fetching independently.
+const FAVOURITES_KEY = queryKeys.targets.favourites();
 
-let cachedIds: ReadonlySet<string> = new Set();
-let hasLoaded = false;
-let inFlightLoad: Promise<void> | null = null;
+// Stable empty-set reference (not a fresh `new Set()` per render) so
+// `isFavourite`'s useCallback dependency doesn't churn while data is loading.
+const EMPTY_SET: ReadonlySet<string> = new Set();
 
-type Listener = () => void;
-const listeners = new Set<Listener>();
-
-function notify(): void {
-  for (const fn of listeners) fn();
-}
-
-function subscribe(fn: Listener): () => void {
-  listeners.add(fn);
-  return () => {
-    listeners.delete(fn);
-  };
-}
-
-function getSnapshot(): ReadonlySet<string> {
-  return cachedIds;
-}
-
-function getServerSnapshot(): ReadonlySet<string> {
-  return new Set();
-}
-
-/** Fetch the current favourite set from the backend (de-duplicates concurrent calls). */
-function ensureLoaded(): Promise<void> {
-  if (hasLoaded) return Promise.resolve();
-  if (inFlightLoad) return inFlightLoad;
-  inFlightLoad = Promise.resolve()
-    .then(() => commands.targetFavouritesList())
-    .then(unwrap)
-    .then(({ targetIds }) => {
-      cachedIds = new Set(targetIds);
-      hasLoaded = true;
-      notify();
-    })
-    .catch(() => {
-      // Leave the cache empty on failure; a future call may retry via a
-      // fresh mount (hasLoaded stays false).
-    })
-    .finally(() => {
-      inFlightLoad = null;
-    });
-  return inFlightLoad;
+async function fetchFavouriteIds(): Promise<Set<string>> {
+  const { targetIds } = unwrap(await commands.targetFavouritesList());
+  return new Set(targetIds);
 }
 
 // ── Public API ─────────────────────────────────────────────────────────────────
@@ -99,51 +53,55 @@ export interface UseFavouritesResult {
  *
  * Provides `toggle` (stable across renders) to star/unstar a target, and
  * `isFavourite` for conditional rendering. Applies an optimistic update on
- * `toggle`, then reconciles with the backend call; a failed call reverts the
- * optimistic change.
+ * `toggle` directly against the shared query cache, then reconciles with the
+ * backend call; a failed call reverts the optimistic change.
  */
 export function useFavourites(): UseFavouritesResult {
-  const favouriteIds = useSyncExternalStore(
-    subscribe,
-    getSnapshot,
-    getServerSnapshot,
-  );
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: FAVOURITES_KEY,
+    queryFn: fetchFavouriteIds,
+  });
+  const favouriteIds = data ?? EMPTY_SET;
 
-  useEffect(() => {
-    void ensureLoaded();
-  }, []);
+  const toggle = useCallback(
+    (targetId: string) => {
+      const current =
+        queryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ??
+        new Set<string>();
+      const wasFavourited = current.has(targetId);
 
-  const toggle = useCallback((targetId: string) => {
-    const wasFavourited = cachedIds.has(targetId);
-
-    // Optimistic update.
-    const next = new Set(cachedIds);
-    if (wasFavourited) {
-      next.delete(targetId);
-    } else {
-      next.add(targetId);
-    }
-    cachedIds = next;
-    notify();
-
-    const call = Promise.resolve().then(() =>
-      wasFavourited
-        ? commands.targetFavouritesRemove({ targetId })
-        : commands.targetFavouritesAdd({ targetId }),
-    );
-
-    call.then(unwrap).catch(() => {
-      // Revert the optimistic change on failure.
-      const reverted = new Set(cachedIds);
+      // Optimistic update.
+      const next = new Set(current);
       if (wasFavourited) {
-        reverted.add(targetId);
+        next.delete(targetId);
       } else {
-        reverted.delete(targetId);
+        next.add(targetId);
       }
-      cachedIds = reverted;
-      notify();
-    });
-  }, []);
+      queryClient.setQueryData(FAVOURITES_KEY, next);
+
+      const call = wasFavourited
+        ? commands.targetFavouritesRemove({ targetId })
+        : commands.targetFavouritesAdd({ targetId });
+
+      Promise.resolve(call)
+        .then(unwrap)
+        .catch(() => {
+          // Revert the optimistic change on failure.
+          const reverted = new Set(
+            queryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ??
+              new Set<string>(),
+          );
+          if (wasFavourited) {
+            reverted.add(targetId);
+          } else {
+            reverted.delete(targetId);
+          }
+          queryClient.setQueryData(FAVOURITES_KEY, reverted);
+        });
+    },
+    [queryClient],
+  );
 
   const isFavourite = useCallback(
     (targetId: string) => favouriteIds.has(targetId),
@@ -156,20 +114,20 @@ export function useFavourites(): UseFavouritesResult {
 /**
  * Non-hook read for use outside React (tests, initial render).
  *
- * Returns the current in-memory cache — empty until the first backend fetch
- * (triggered by a `useFavourites()` mount) resolves.
+ * Returns the current query-cache entry — empty until the first backend
+ * fetch (triggered by a `useFavourites()` mount) resolves. Reads the shared
+ * app-wide `queryClient` singleton (also mounted at the app root), matching
+ * the pattern in `data/queryClient.ts`'s module doc.
  */
 export function getFavouriteIds(): ReadonlySet<string> {
-  return cachedIds;
+  return sharedQueryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ?? new Set();
 }
 
 /**
- * Test-only reset of the module-level cache. Not part of the public hook
- * surface; exported so `useFavourites.test.ts` can isolate cases without
- * process-per-test isolation.
+ * Test-only reset of the shared favourites cache entry. Not part of the
+ * public hook surface; exported so `useFavourites.test.ts` can isolate cases
+ * without process-per-test isolation.
  */
 export function __resetFavouritesCacheForTests(): void {
-  cachedIds = new Set();
-  hasLoaded = false;
-  inFlightLoad = null;
+  sharedQueryClient.removeQueries({ queryKey: FAVOURITES_KEY });
 }

--- a/apps/desktop/src/features/targets/useFavourites.ts
+++ b/apps/desktop/src/features/targets/useFavourites.ts
@@ -120,7 +120,9 @@ export function useFavourites(): UseFavouritesResult {
  * the pattern in `data/queryClient.ts`'s module doc.
  */
 export function getFavouriteIds(): ReadonlySet<string> {
-  return sharedQueryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ?? new Set();
+  return (
+    sharedQueryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ?? new Set()
+  );
 }
 
 /**


### PR DESCRIPTION
Closes #608
Closes #610
Closes #613
Refs #615 (files owned elsewhere)

Found + fixed two invalidation-cascade bugs en route: a list<->detail query-key prefix collision, and a detail<->children cache invalidation that needed exact:true to avoid over-invalidating siblings.