### PR TITLE
feat(protection): two-level source protection model and settings simplification

### DIFF
--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -7825,8 +7825,14 @@ export type ProtectedPlanItem_Serialize = {
 	reason: string,
 };
 
-/**  Protection level enum (spec 016 data-model.md). */
-export type ProtectionLevel = "protected" | "normal" | "unprotected";
+/**
+ *  Protection level enum (spec 016 data-model.md; simplified to 2 levels per
+ *  issue #506 — the third "inherit-global via an explicit `normal` row" tier
+ *  added confusion without adding capability, since absence of an override
+ *  row already means inherit-global. Existing `normal` rows are remapped to
+ *  `unprotected` by migration 0070, non-destructively).
+ */
+export type ProtectionLevel = "protected" | "unprotected";
 
 /**  A provenance label/value pair for how an item was inferred. */
 export type ProvenanceEntry = {

--- a/apps/desktop/src/features/settings/Advanced.test.tsx
+++ b/apps/desktop/src/features/settings/Advanced.test.tsx
@@ -142,7 +142,6 @@ describe('Advanced — first-run setup restart control (spec 003 US3)', () => {
       {
         path: '/astro/lights',
         kind: 'light_frames',
-        scanDepth: 'recursive',
         organizationState: 'organized',
       },
     ]);

--- a/apps/desktop/src/features/settings/Advanced.tsx
+++ b/apps/desktop/src/features/settings/Advanced.tsx
@@ -140,13 +140,13 @@ export function Advanced({ save }: AdvancedProps) {
     try {
       const response = await restartFirstRun();
       // Prefill the wizard's working buffer with the currently registered
-      // sources (A7) — RegisterSourceResponse has no scanDepth, so default to
-      // 'recursive' per FR-017.
+      // sources (A7). `scanDepth` was retired from `SourceEntry` (#913) — this
+      // literal used to carry a dead `scanDepth: 'recursive'` field the type
+      // no longer declares.
       const prefilled: SourceEntry[] = response.prefilledSources.map(
         (source) => ({
           path: source.path,
           kind: source.kind,
-          scanDepth: 'recursive',
           organizationState: source.organizationState,
         }),
       );

--- a/apps/desktop/src/features/settings/Cleanup.tsx
+++ b/apps/desktop/src/features/settings/Cleanup.tsx
@@ -33,7 +33,8 @@ const CLEANUP_KEYS = [
 ];
 
 type CleanupAction = CleanupTypeFixture['action'];
-type DefaultProtection = 'protected' | 'normal' | 'unprotected';
+// 2-level model (issue #506): the third "normal" level is retired.
+type DefaultProtection = 'protected' | 'unprotected';
 
 /** Default per-type actions (from the CLEANUP_TYPES fixture). */
 function defaultActions(): Record<number, CleanupAction> {
@@ -182,9 +183,6 @@ export function Cleanup({ save }: CleanupProps) {
           >
             <option value="protected">
               {m.settings_cleanup_protection_protected()}
-            </option>
-            <option value="normal">
-              {m.settings_cleanup_protection_normal()}
             </option>
             <option value="unprotected">
               {m.settings_cleanup_protection_unprotected()}

--- a/apps/desktop/src/features/settings/DataSources.disable-delete.test.tsx
+++ b/apps/desktop/src/features/settings/DataSources.disable-delete.test.tsx
@@ -99,13 +99,13 @@ beforeEach(() => {
   mockSourceProtectionGet.mockResolvedValue(
     ok({
       sourceId: 'root-1',
-      level: 'normal',
+      level: 'unprotected',
       blockPermanentDelete: false,
       categories: [],
       inheritsDefault: true,
     }),
   );
-  mockOverridableKeys.mockResolvedValue(ok(['hashOnScan', 'followSymlinks']));
+  mockOverridableKeys.mockResolvedValue(ok(['defaultProtection']));
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/features/settings/DataSources.reconcile.test.tsx
+++ b/apps/desktop/src/features/settings/DataSources.reconcile.test.tsx
@@ -83,7 +83,7 @@ beforeEach(() => {
     status: 'ok',
     data: {
       sourceId: 'root-1',
-      level: 'normal',
+      level: 'unprotected',
       blockPermanentDelete: false,
       categories: [],
       inheritsDefault: true,
@@ -91,7 +91,7 @@ beforeEach(() => {
   });
   mockOverridableKeys.mockResolvedValue({
     status: 'ok',
-    data: ['hashOnScan', 'followSymlinks'],
+    data: ['defaultProtection'],
   });
 });
 

--- a/apps/desktop/src/features/settings/DataSources.rescan.test.tsx
+++ b/apps/desktop/src/features/settings/DataSources.rescan.test.tsx
@@ -81,7 +81,7 @@ beforeEach(() => {
     status: 'ok',
     data: {
       sourceId: 'root-1',
-      level: 'normal',
+      level: 'unprotected',
       blockPermanentDelete: false,
       categories: [],
       inheritsDefault: true,
@@ -89,7 +89,7 @@ beforeEach(() => {
   });
   mockOverridableKeys.mockResolvedValue({
     status: 'ok',
-    data: ['hashOnScan', 'followSymlinks'],
+    data: ['defaultProtection'],
   });
 });
 

--- a/apps/desktop/src/features/settings/DataSources.tsx
+++ b/apps/desktop/src/features/settings/DataSources.tsx
@@ -14,6 +14,15 @@
 // reads back — a real dual-source-of-truth. Removing it and routing
 // protection level exclusively through `SourceProtectionOverride`
 // (`source.protection.set`/`get`) removes that inconsistency at the root.
+//
+// Issue #623/#646: the remaining scan-behavior override widget
+// (`followSymlinks`/`hashOnScan`) duplicated the canonical `IngestionSettings`
+// document (Settings → Ingestion) and could never succeed for `hashOnScan`
+// (needs a string; the widget only ever offered a boolean). Both keys were
+// retired from the overridable set (`descriptors.rs`) — with `defaultProtection`
+// already excluded above, there is nothing left to render here, so the whole
+// contextual scan-override panel is removed rather than kept as always-empty
+// dead code.
 import { useState, useEffect, useRef, useCallback } from 'react';
 import { Btn, Pill } from '@/ui';
 import { DirPicker } from '@/ui/DirPicker';
@@ -25,8 +34,6 @@ import {
   reconcileRoot,
   setRootActive,
   deleteRoot,
-  settingsSourceOverrideSet,
-  settingsOverridableKeys,
 } from './settingsIpc';
 import type { LibraryRoot } from '@/bindings/types';
 import type { RootCategory } from '@/bindings/index';
@@ -44,14 +51,10 @@ import { revealInOs } from '@/shared/native/reveal';
 import { revealLabel } from '@/lib/reveal-label';
 import { addToast } from '@/shared/toast';
 
-const SOURCES_KEYS = [
-  'followSymlinks',
-  'hashOnScan',
-  'alwaysPreviewBeforePlan',
-];
-
-// Fallback list used before the backend responds or if the call fails.
-const OVERRIDABLE_KEYS_FALLBACK = ['hashOnScan', 'followSymlinks'] as const;
+// Issue #623: followSymlinks/hashOnScan removed — retired from the
+// overridable/scan-behavior duplicate (see the module doc comment above);
+// resetting them here reset invisible keys with no control on this pane.
+const SOURCES_KEYS = ['alwaysPreviewBeforePlan'];
 
 interface DataSourcesProps {
   save: (scope: string, values: Record<string, unknown>) => void;
@@ -113,19 +116,6 @@ export function DataSources({ save: _save }: DataSourcesProps) {
   const [deleteTarget, setDeleteTarget] = useState<LibraryRoot | null>(null);
   const [deletingId, setDeletingId] = useState<string | null>(null);
   const [deleteError, setDeleteError] = useState<string | null>(null);
-
-  // ── Overridable keys — fetched from backend (T025) ──────────────────────────
-  const [overridableKeys, setOverridableKeys] = useState<string[]>([
-    ...OVERRIDABLE_KEYS_FALLBACK,
-  ]);
-
-  useEffect(() => {
-    settingsOverridableKeys()
-      .then(setOverridableKeys)
-      .catch(() => {
-        // Keep fallback list on failure.
-      });
-  }, []);
 
   const loadRoots = useCallback(() => {
     setLoading(true);
@@ -387,7 +377,6 @@ export function DataSources({ save: _save }: DataSourcesProps) {
                 togglingActive={togglingActiveId === root.id}
                 onDelete={requestDelete}
                 deleting={deletingId === root.id}
-                overridableKeys={overridableKeys}
               />
             ))}
           </div>
@@ -465,8 +454,6 @@ interface RootCardProps {
   togglingActive: boolean;
   onDelete: (root: LibraryRoot) => void;
   deleting: boolean;
-  /** Overridable scan-setting keys (T025), shared across every card. */
-  overridableKeys: string[];
 }
 
 function RootCard({
@@ -480,7 +467,6 @@ function RootCard({
   togglingActive,
   onDelete,
   deleting,
-  overridableKeys,
 }: RootCardProps) {
   const isOffline = !root.online;
 
@@ -581,12 +567,6 @@ function RootCard({
           )}
         </div>
         {meta && <div className="alm-data-sources__root-meta">{meta}</div>}
-        {editProtectionOpen && (
-          <SourceOverridePanel
-            sourceId={root.id}
-            overridableKeys={overridableKeys}
-          />
-        )}
         {/* spec 048 US4: per-root detection config only applies to roots that
             carry `file_record` rows (raw/calibration). */}
         {RECONCILABLE_CATEGORIES.includes(root.category) && (
@@ -704,121 +684,6 @@ function RootCard({
             </button>
           </div>
         )}
-      </div>
-    </div>
-  );
-}
-
-interface SourceOverridePanelProps {
-  sourceId: string;
-  overridableKeys: string[];
-}
-
-/**
- * Contextual scan-setting override editor (issue #562) — folds the former
- * detached bottom "Per-source setting override" panel into the per-card
- * "Edit protection…" panel. No source picker needed (the source is already
- * known from context), and `defaultProtection` is excluded here: protection
- * level is set exclusively via `SourceProtectionOverride` (`source.protection.set`)
- * so there is exactly one write path for it (issue #563).
- */
-function SourceOverridePanel({
-  sourceId,
-  overridableKeys,
-}: SourceOverridePanelProps) {
-  const scanKeys = overridableKeys.filter((k) => k !== 'defaultProtection');
-  const [key, setKey] = useState<string>(scanKeys[0] ?? 'hashOnScan');
-  const [value, setValue] = useState('true');
-  const [applying, setApplying] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [saved, setSaved] = useState(false);
-
-  if (scanKeys.length === 0) return null;
-
-  const handleApply = async () => {
-    setApplying(true);
-    setError(null);
-    setSaved(false);
-    try {
-      const coerced: unknown =
-        value === 'true' ? true : value === 'false' ? false : value;
-      await settingsSourceOverrideSet({ sourceId, key, value: coerced });
-      setSaved(true);
-    } catch (err: unknown) {
-      setError(errMessage(err));
-    } finally {
-      setApplying(false);
-    }
-  };
-
-  return (
-    <div
-      className="alm-settings__group"
-      data-testid={`source-override-panel-${sourceId}`}
-    >
-      <div className="alm-settings__group-title">
-        {m.settings_datasources_source_override_title()}
-      </div>
-      <div className="alm-settings__row">
-        <div className="alm-settings__row-label">
-          {m.settings_datasources_source_override_key_aria()}
-        </div>
-        <div className="alm-settings__row-content">
-          <select
-            className="alm-select"
-            value={key}
-            onChange={(e) => {
-              setKey(e.target.value);
-              setSaved(false);
-            }}
-            aria-label={m.settings_datasources_source_override_key_aria()}
-          >
-            {scanKeys.map((k) => (
-              <option key={k} value={k}>
-                {k}
-              </option>
-            ))}
-          </select>
-        </div>
-      </div>
-      <div className="alm-settings__row">
-        <div className="alm-settings__row-label">
-          {m.settings_datasources_source_override_value_aria()}
-        </div>
-        <div className="alm-settings__row-content">
-          <select
-            className="alm-select"
-            value={value}
-            onChange={(e) => {
-              setValue(e.target.value);
-              setSaved(false);
-            }}
-            aria-label={m.settings_datasources_source_override_value_aria()}
-          >
-            <option value="true">{m.common_true()}</option>
-            <option value="false">{m.common_false()}</option>
-          </select>
-        </div>
-      </div>
-      {error && (
-        <div className="alm-data-sources__add-error">
-          {m.settings_datasources_source_override_error({ error })}
-        </div>
-      )}
-      <div className="alm-settings__row">
-        <div className="alm-settings__row-label" />
-        <div className="alm-settings__row-content">
-          <Btn size="sm" onClick={() => void handleApply()} disabled={applying}>
-            {applying
-              ? m.common_saving()
-              : m.settings_datasources_source_override_apply()}
-          </Btn>
-          {saved && (
-            <span className="alm-source-protect__status">
-              {m.common_saved()}
-            </span>
-          )}
-        </div>
       </div>
     </div>
   );

--- a/apps/desktop/src/features/settings/SourceProtectionOverride.test.tsx
+++ b/apps/desktop/src/features/settings/SourceProtectionOverride.test.tsx
@@ -119,7 +119,7 @@ describe('SourceProtectionOverride', () => {
   it('shows the override pill for a non-default level when not open', async () => {
     mockGet.mockResolvedValue({
       status: 'ok',
-      data: makeGetResponse({ inheritsDefault: false, level: 'normal' }),
+      data: makeGetResponse({ inheritsDefault: false, level: 'unprotected' }),
     });
     render(
       <SourceProtectionOverride
@@ -130,7 +130,7 @@ describe('SourceProtectionOverride', () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText('Normal')).toBeTruthy();
+      expect(screen.getByText('Unprotected')).toBeTruthy();
     });
   });
 
@@ -174,7 +174,7 @@ describe('SourceProtectionOverride', () => {
       data: {
         sourceId: 'src-1',
         priorLevel: 'protected',
-        newLevel: 'normal',
+        newLevel: 'unprotected',
         priorBlockPermanentDelete: null,
         newBlockPermanentDelete: null,
         priorCategories: null,
@@ -189,18 +189,18 @@ describe('SourceProtectionOverride', () => {
     const select = await screen.findByRole('combobox', {
       name: /Protection level override/i,
     });
-    fireEvent.change(select, { target: { value: 'normal' } });
+    fireEvent.change(select, { target: { value: 'unprotected' } });
 
     fireEvent.click(screen.getByRole('button', { name: /Save override/i }));
 
     await waitFor(() => {
-      expect(screen.getByText('Normal')).toBeTruthy();
+      expect(screen.getByText('Unprotected')).toBeTruthy();
     });
     expect(mockSet).toHaveBeenCalledWith({
       sourceId: 'src-1',
-      level: 'normal',
+      level: 'unprotected',
     });
-    expect(onSaved).toHaveBeenCalledWith('normal');
+    expect(onSaved).toHaveBeenCalledWith('unprotected');
     // Closed after save — editor no longer rendered.
     expect(screen.queryByRole('button', { name: /Save override/i })).toBeNull();
   });

--- a/apps/desktop/src/features/settings/SourceProtectionOverride.tsx
+++ b/apps/desktop/src/features/settings/SourceProtectionOverride.tsx
@@ -33,9 +33,11 @@ interface SourceProtectionOverrideProps {
 
 type LoadState = 'idle' | 'loading' | 'ready' | 'saving' | 'error';
 
+// 2-level model (issue #506): the third "normal" level is retired — absence
+// of a per-source override already means inherit-global, so a distinct
+// explicit "normal" state added confusion without capability.
 const LEVEL_LABEL: Record<ProtectionLevel, () => string> = {
   protected: m.settings_cleanup_protection_protected,
-  normal: m.settings_cleanup_protection_normal,
   unprotected: m.settings_cleanup_protection_unprotected,
 };
 
@@ -44,7 +46,6 @@ const LEVEL_VARIANT: Record<
   'ok' | 'info' | 'warn' | 'danger' | 'neutral'
 > = {
   protected: 'ok',
-  normal: 'info',
   unprotected: 'warn',
 };
 
@@ -54,8 +55,6 @@ function levelHint(level: ProtectionLevel, inherits: boolean): string {
   switch (level) {
     case 'protected':
       return m.settings_source_protect_hint_protected({ prefix });
-    case 'normal':
-      return m.settings_source_protect_hint_normal({ prefix });
     case 'unprotected':
       return m.settings_source_protect_hint_unprotected({ prefix });
   }
@@ -168,9 +167,6 @@ export function SourceProtectionOverride({
             >
               <option value="protected">
                 {m.settings_cleanup_protection_protected()}
-              </option>
-              <option value="normal">
-                {m.settings_cleanup_protection_normal()}
               </option>
               <option value="unprotected">
                 {m.settings_cleanup_protection_unprotected()}

--- a/apps/desktop/src/features/settings/settings.test.ts
+++ b/apps/desktop/src/features/settings/settings.test.ts
@@ -118,7 +118,7 @@ describe('useAutoSave', () => {
 
   it('passes scope and values to updateSettings with correct shape', async () => {
     const { result } = renderHook(() => useAutoSave());
-    const values = { blockPermanentDelete: false, defaultProtection: 'normal' };
+    const values = { blockPermanentDelete: false, defaultProtection: 'unprotected' };
 
     act(() => {
       result.current.save('cleanup', values);

--- a/apps/desktop/src/features/settings/settings.test.ts
+++ b/apps/desktop/src/features/settings/settings.test.ts
@@ -118,7 +118,10 @@ describe('useAutoSave', () => {
 
   it('passes scope and values to updateSettings with correct shape', async () => {
     const { result } = renderHook(() => useAutoSave());
-    const values = { blockPermanentDelete: false, defaultProtection: 'unprotected' };
+    const values = {
+      blockPermanentDelete: false,
+      defaultProtection: 'unprotected',
+    };
 
     act(() => {
       result.current.save('cleanup', values);

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -38,7 +38,9 @@ export interface StepCatalogsProps {
   onSettingsChange: (settings: CatalogSettings) => void;
 }
 
-type DefaultProtection = 'protected' | 'normal' | 'unprotected';
+// 2-level model (issue #506): the third "normal" level is retired — absence
+// of a per-source override already means inherit-global.
+type DefaultProtection = 'protected' | 'unprotected';
 
 // ── Default source protection (spec 018, persisted via the settings backend) ──
 
@@ -82,7 +84,6 @@ function DefaultProtectionControl() {
       <option value="protected">
         {m.settings_cleanup_protection_protected()}
       </option>
-      <option value="normal">{m.settings_cleanup_protection_normal()}</option>
       <option value="unprotected">
         {m.settings_cleanup_protection_unprotected()}
       </option>

--- a/crates/app/core/src/cleanup_generator.rs
+++ b/crates/app/core/src/cleanup_generator.rs
@@ -667,6 +667,16 @@ mod tests {
         let lock = crate::protection::PROTECTION_DEFAULTS_TEST_LOCK
             .lock()
             .unwrap_or_else(std::sync::PoisonError::into_inner);
+        // FIX: a prior test's `set_global_protection_default` call (e.g.
+        // `category_protection_elevates_real_frame_type_not_fixed_pseudo_category`
+        // below) can leave the process-global cache holding a non-"protected"
+        // snapshot from ITS OWN (now-dropped) in-memory DB. The lock alone only
+        // serializes execution order — it does not reset the cache, so this
+        // fresh DB's real `protection_defaults` row (seeded "protected" by
+        // migration 0035) was previously shadowed by the stale cached value,
+        // intermittently zeroing `protected_item_count` here. Mirrors
+        // `protection.rs`'s own `setup()`, which already does this.
+        app_core_cache::invalidate_protection_defaults();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());
@@ -1159,14 +1169,14 @@ mod tests {
             .unwrap();
         insert_acquisition_session(db.pool(), "sess-1", &[&light]).await;
 
-        // Global default level is "normal" (not protected); only category
+        // Global default level is "unprotected" (not protected); only category
         // membership should elevate a light frame.
         protection::set_global_protection_default(
             db.pool(),
             &bus,
             "global",
             "defaultProtection",
-            serde_json::json!("normal"),
+            serde_json::json!("unprotected"),
         )
         .await
         .unwrap();

--- a/crates/app/core/src/first_run.rs
+++ b/crates/app/core/src/first_run.rs
@@ -328,9 +328,23 @@ pub async fn register_source(
     // already be cached, but this keeps the write site authoritative if a
     // removed root's id is ever reused.
     caches::invalidate_library_root(&resp.source_id);
+    seed_new_source_protection(pool, &resp.source_id, req.kind).await;
     write_source_register_audit(bus, &resp.source_id, &req.path, req.kind, Outcome::Applied, None)
         .await?;
     Ok(resp)
+}
+
+/// Seed a freshly registered source's protection level (issue #730 — the real
+/// `register_source`/`register_source_batch` entry points never called
+/// `protection::seed_source_protection`, so new Inbox sources fell through to
+/// the flat global default (`protected`) instead of `data-model.md`'s
+/// Defaults Table). Best-effort: a seeding failure must not fail the
+/// registration itself, which already committed.
+async fn seed_new_source_protection(pool: &SqlitePool, source_id: &str, kind: SourceKind) {
+    let kind_str: &'static str = kind.into();
+    if let Err(e) = crate::protection::seed_source_protection(pool, source_id, kind_str).await {
+        tracing::warn!(%source_id, kind = kind_str, error = ?e, "failed to seed source protection");
+    }
 }
 
 /// Change a source's organization state after registration (spec 041, T030).
@@ -455,6 +469,7 @@ async fn partition_batch_sources<'a>(
 /// clippy's line budget; audits `Failure` items too (review round 1 #3 —
 /// these were previously dropped without a durable row).
 async fn audit_batch_results(
+    pool: &SqlitePool,
     bus: &EventBus,
     valid_sources: &[(usize, &RegisterSourceRequest)],
     repo_items: Vec<contracts_core::first_run::BatchItem>,
@@ -467,6 +482,7 @@ async fn audit_batch_results(
         match repo_item.status {
             ItemStatus::Success => {
                 if let Some(source_id) = &repo_item.source_id {
+                    seed_new_source_protection(pool, source_id, source.kind).await;
                     write_source_register_audit(
                         bus,
                         source_id,
@@ -547,7 +563,7 @@ pub async fn register_source_batch(
                 return Err(err);
             }
         };
-        items.extend(audit_batch_results(bus, &valid_sources, batch_resp.items).await?);
+        items.extend(audit_batch_results(pool, bus, &valid_sources, batch_resp.items).await?);
     }
 
     // Sort items by original index for deterministic output.

--- a/crates/app/core/src/protection.rs
+++ b/crates/app/core/src/protection.rs
@@ -214,7 +214,7 @@ pub async fn set_source_protection(
 
     let prior_level = prior_row
         .as_ref()
-        .map_or(ProtectionLevel::Normal, |r| ProtectionLevel::parse_level(&r.level));
+        .map_or(ProtectionLevel::Unprotected, |r| ProtectionLevel::parse_level(&r.level));
 
     let prior_bpd: Option<bool> =
         prior_row.as_ref().and_then(|r| r.block_permanent_delete.map(|v| v != 0));
@@ -289,7 +289,7 @@ pub async fn set_source_protection(
 
 /// Seed the initial per-source protection based on source kind.
 ///
-/// Inbox sources start at `normal`; all others start at `protected`.
+/// Inbox sources start at `unprotected`; all others start at `protected`.
 /// This is a best-effort operation — failures are logged but not propagated.
 ///
 /// # Errors
@@ -300,7 +300,7 @@ pub async fn seed_source_protection(
     source_id: &str,
     source_kind: &str,
 ) -> Result<(), ContractError> {
-    let level = if source_kind == "inbox" { "normal" } else { "protected" };
+    let level = if source_kind == "inbox" { "unprotected" } else { "protected" };
     prot_repo::upsert_source_protection(pool, source_id, level, None, None, "system")
         .await
         .map_err(db_err)?;
@@ -882,7 +882,7 @@ mod tests {
 
         let set_req = SourceProtectionSetRequest {
             source_id: source_id.to_owned(),
-            level: ProtectionLevel::Normal,
+            level: ProtectionLevel::Unprotected,
             block_permanent_delete: Some(false),
             categories: None,
         };
@@ -891,7 +891,7 @@ mod tests {
         let get_req = SourceProtectionGetRequest { source_id: Some(source_id.to_owned()) };
         let resp = get_source_protection(db.pool(), &get_req).await.unwrap();
 
-        assert_eq!(resp.level, ProtectionLevel::Normal);
+        assert_eq!(resp.level, ProtectionLevel::Unprotected);
         assert!(!resp.block_permanent_delete);
         assert!(!resp.inherits_default);
     }
@@ -968,7 +968,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn seed_source_protection_inbox_gets_normal() {
+    async fn seed_source_protection_inbox_gets_unprotected() {
         let (db, _bus, _lock) = setup().await;
         seed_source_protection(db.pool(), "src-inbox", "inbox").await.unwrap();
 
@@ -976,7 +976,7 @@ mod tests {
             .await
             .unwrap()
             .expect("row should exist");
-        assert_eq!(row.level, "normal");
+        assert_eq!(row.level, "unprotected");
     }
 
     #[tokio::test]
@@ -1239,17 +1239,17 @@ mod tests {
 
     // ── T042: a plan over a NON-protected source applies (gate is real, not always-on) ─
     //
-    // FR-016: the gate must not block plans whose items resolve to "normal" protection.
+    // FR-016: the gate must not block plans whose items resolve to non-gating protection.
 
     #[tokio::test]
     async fn t042_non_protected_source_plan_passes_gate() {
         let (db, bus, _lock) = setup().await;
 
-        // Set up a source explicitly marked as "normal" (e.g. an inbox source).
+        // Set up a source explicitly marked as "unprotected" (e.g. an inbox source).
         let source_id = "src-inbox-002";
         let set_req = SourceProtectionSetRequest {
             source_id: source_id.to_owned(),
-            level: ProtectionLevel::Normal,
+            level: ProtectionLevel::Unprotected,
             block_permanent_delete: Some(false),
             categories: None,
         };

--- a/crates/app/core/tests/first_run_integration.rs
+++ b/crates/app/core/tests/first_run_integration.rs
@@ -155,3 +155,95 @@ async fn seed_source_protection_sets_protected_for_non_inbox() {
         protection_resp.level.as_str(),
     );
 }
+
+/// Issue #730 regression: `register_source` — the real add-source entry
+/// point, not a direct `seed_source_protection` call — must seed protection
+/// itself. Without the fix, an Inbox source falls through to the flat global
+/// default (`protected`) instead of `unprotected` per the Defaults Table.
+#[tokio::test]
+async fn register_source_seeds_unprotected_for_inbox() {
+    let (db, _repo, bus) = support::setup().await;
+
+    let dir = tempdir().expect("tempdir");
+    let path = dir.path().to_str().expect("utf8 path").to_owned();
+
+    let req = RegisterSourceRequest {
+        kind: SourceKind::Inbox,
+        path,
+        kind_subtype: None,
+        scan_depth: ScanDepth::Recursive,
+        organization_state: OrganizationState::Unorganized,
+    };
+    let resp =
+        first_run::register_source(db.pool(), &bus, &req).await.expect("register should succeed");
+
+    // No explicit seed_source_protection call here — `register_source` itself
+    // must have seeded it.
+    let get_req = SourceProtectionGetRequest { source_id: Some(resp.source_id.clone()) };
+    let protection_resp = protection::get_source_protection(db.pool(), &get_req)
+        .await
+        .expect("get_source_protection should succeed");
+
+    assert_eq!(
+        protection_resp.level.as_str(),
+        "unprotected",
+        "register_source must auto-seed an inbox source to 'unprotected', got: {}",
+        protection_resp.level.as_str(),
+    );
+    assert!(
+        !protection_resp.inherits_default,
+        "an explicit seed row must exist, not fall through to the global default"
+    );
+}
+
+/// Issue #730 regression: `register_source_batch` must also seed protection
+/// per successfully registered item, not only the single-register path.
+#[tokio::test]
+async fn register_source_batch_seeds_protection_per_item() {
+    let (db, _repo, bus) = support::setup().await;
+
+    let inbox_dir = tempdir().expect("tempdir");
+    let raw_dir = tempdir().expect("tempdir");
+
+    let batch_req = contracts_core::first_run::RegisterSourceBatchRequest {
+        sources: vec![
+            RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: inbox_dir.path().to_str().expect("utf8 path").to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Unorganized,
+            },
+            RegisterSourceRequest {
+                kind: SourceKind::LightFrames,
+                path: raw_dir.path().to_str().expect("utf8 path").to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Organized,
+            },
+        ],
+    };
+
+    let resp = first_run::register_source_batch(db.pool(), &bus, &batch_req)
+        .await
+        .expect("batch register should succeed");
+
+    let inbox_id = resp.items[0].source_id.clone().expect("inbox item must have a source_id");
+    let raw_id = resp.items[1].source_id.clone().expect("raw item must have a source_id");
+
+    let inbox_level = protection::get_source_protection(
+        db.pool(),
+        &SourceProtectionGetRequest { source_id: Some(inbox_id) },
+    )
+    .await
+    .expect("get_source_protection should succeed");
+    assert_eq!(inbox_level.level.as_str(), "unprotected");
+
+    let raw_level = protection::get_source_protection(
+        db.pool(),
+        &SourceProtectionGetRequest { source_id: Some(raw_id) },
+    )
+    .await
+    .expect("get_source_protection should succeed");
+    assert_eq!(raw_level.level.as_str(), "protected");
+}

--- a/crates/app/core/tests/settings_logs_integration.rs
+++ b/crates/app/core/tests/settings_logs_integration.rs
@@ -260,7 +260,7 @@ async fn global_protection_default_update_persists_and_emits_protection_event() 
     let pool = db.pool();
 
     for (key, value) in [
-        ("defaultProtection", serde_json::json!("normal")),
+        ("defaultProtection", serde_json::json!("unprotected")),
         ("blockPermanentDelete", serde_json::json!(false)),
         ("protectedCategories", serde_json::json!(["lights", "masters", "finals", "raw"])),
     ] {

--- a/crates/app/settings/src/caches.rs
+++ b/crates/app/settings/src/caches.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, OnceLock};
 
 use app_core_cache::SnapshotCache;
 use domain_core::settings::SettingsState;
+use serde_json::Value;
 
 /// The full v1 settings bag, hydrated with in-code defaults for missing rows
 /// (mirrors `get_settings`'s output). 1 slot.
@@ -41,6 +42,40 @@ pub fn store_settings_bag(value: Arc<SettingsState>) {
 /// Clear the settings-bag snapshot so the next read reloads from the DB.
 pub fn invalidate_settings_bag() {
     settings_bag().invalidate();
+}
+
+/// The noisy-key values (as a JSON object) from the most recently PUBLISHED
+/// `settings.snapshot` event (issue #668). 1 slot.
+///
+/// `emit_snapshot` compares its freshly collected values against this before
+/// publishing, and skips the publish (a no-op) when nothing changed — mirrors
+/// `app_core_targets::ingest_resolution::resolve_pending`'s
+/// `target.resolve_batch.completed` suppression on `considered == 0`: a
+/// periodic heartbeat with nothing to report should not flood the activity
+/// log (#668 — ~470/500 rows in a real sweep were this + the target
+/// heartbeat). Not invalidated by `update_setting`/`restore_defaults`/
+/// `set_source_override`: those already emit their own real
+/// `settings.changed`/`protection.default.changed` events, so a later
+/// snapshot correctly finds "no further noisy-key change" and stays quiet
+/// until a *noisy* key changes.
+static LAST_SNAPSHOT_VALUES: OnceLock<SnapshotCache<Value>> = OnceLock::new();
+
+/// Return the process-global last-published-snapshot value cache.
+#[must_use]
+pub fn last_snapshot_values() -> &'static SnapshotCache<Value> {
+    LAST_SNAPSHOT_VALUES.get_or_init(SnapshotCache::new)
+}
+
+/// Store the noisy-key values just published in a `settings.snapshot` event.
+pub fn store_last_snapshot_values(value: Arc<Value>) {
+    last_snapshot_values().store(value);
+}
+
+/// Clear the last-published-snapshot cache (test isolation only — the real
+/// `emit_snapshot` caller never needs to invalidate this outside its own
+/// store-on-publish).
+pub fn invalidate_last_snapshot_values() {
+    last_snapshot_values().invalidate();
 }
 
 #[cfg(test)]

--- a/crates/app/settings/src/descriptors.rs
+++ b/crates/app/settings/src/descriptors.rs
@@ -130,9 +130,18 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         default: |s| Value::Bool(s.always_preview_before_plan),
     },
     Descriptor {
+        // Issue #623: no longer per-source overridable. This key duplicated
+        // the canonical `IngestionSettings.followSymlinks` (its own dedicated
+        // `ingestion.settings.*` document, rendered in the Ingestion pane) —
+        // this generic-settings copy was never read by any scan pipeline and
+        // its only UI surface was a per-source override widget that could
+        // never succeed for the sibling `hashOnScan` key (#646). The stable
+        // key itself is kept (some `SettingsState` consumer may still read
+        // the global value) but the confusing, non-functional per-source
+        // override path is removed at the root.
         key: "followSymlinks",
         noisy: false,
-        overridable: true,
+        overridable: false,
         validation: ValidationRule::Bool,
         apply: |v, s| {
             if let Some(b) = v.as_bool() {
@@ -142,9 +151,11 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         default: |s| Value::Bool(s.follow_symlinks),
     },
     Descriptor {
+        // Issue #623: see `followSymlinks` above — duplicates canonical
+        // `IngestionSettings.hashingMode`; per-source override removed.
         key: "hashOnScan",
         noisy: false,
-        overridable: true,
+        overridable: false,
         validation: ValidationRule::EnumStr {
             allowed: &["lazy", "eager", "off"],
             expected_msg: "must be \"lazy\", \"eager\", or \"off\"",
@@ -226,12 +237,15 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         default: |s| Value::Bool(s.remember_follow_logs),
     },
     Descriptor {
+        // 2-level model (issue #506): the third "normal" level is retired —
+        // absence of a per-source override already means inherit-global, so
+        // an explicit third state added confusion without capability.
         key: "defaultProtection",
         noisy: false,
         overridable: true,
         validation: ValidationRule::EnumStr {
-            allowed: &["protected", "normal", "unprotected"],
-            expected_msg: "must be \"protected\", \"normal\", or \"unprotected\"",
+            allowed: &["protected", "unprotected"],
+            expected_msg: "must be \"protected\" or \"unprotected\"",
         },
         apply: |v, s| {
             if let Some(x) = v.as_str() {

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -782,10 +782,13 @@ pub async fn restore_defaults(
 
 /// Set a per-source override for an overridable settings key (T023).
 ///
-/// Validates that `key` is one of `followSymlinks`, `hashOnScan`,
-/// `defaultProtection`. Validates the value type. The `source_id` existence
-/// check is best-effort: since the sources repository is in a different crate
-/// slice, callers may perform that check before calling this function.
+/// Validates that `key` is overridable per `descriptors::DESCRIPTORS`
+/// (currently just `defaultProtection` — issue #623 removed `followSymlinks`/
+/// `hashOnScan` from this list, since they duplicated the canonical
+/// `IngestionSettings` document and the per-source override never worked for
+/// either). Validates the value type. The `source_id` existence check is
+/// best-effort: since the sources repository is in a different crate slice,
+/// callers may perform that check before calling this function.
 ///
 /// # Errors
 ///
@@ -933,6 +936,13 @@ pub async fn resolve_setting(
 /// Called at session start and after the 5-minute inactivity debounce
 /// (the debounce timer is owned by the caller/command layer).
 ///
+/// Issue #668: a periodic snapshot whose noisy-key values are byte-identical
+/// to the last one PUBLISHED is a no-op heartbeat — it is skipped rather than
+/// published, mirroring `target.resolve_batch.completed`'s suppression on
+/// `considered == 0` (both stop a periodic internal event from flooding the
+/// activity log when there is nothing new to report). The first snapshot in a
+/// process (no prior published value) always publishes.
+///
 /// # Errors
 ///
 /// Returns `ContractError` on database or audit failure.
@@ -950,19 +960,23 @@ pub async fn emit_snapshot(
             .unwrap_or_else(|| default_value_for_key(key));
         noisy_values.insert(key.to_owned(), val);
     }
+    let noisy_keys = Value::Object(noisy_values);
+
+    // Skip the publish when nothing changed since the last one we actually
+    // published (#668).
+    if caches::last_snapshot_values().load().as_deref() == Some(&noisy_keys) {
+        return Ok(());
+    }
 
     let at = Timestamp::now_iso();
     bus.publish(
         TOPIC_SETTINGS_SNAPSHOT,
         Source::System,
-        SettingsSnapshot {
-            trigger: trigger.to_owned(),
-            noisy_keys: Value::Object(noisy_values),
-            at,
-        },
+        SettingsSnapshot { trigger: trigger.to_owned(), noisy_keys: noisy_keys.clone(), at },
     )
     .await
     .map_err(bus_err)?;
+    caches::store_last_snapshot_values(std::sync::Arc::new(noisy_keys));
 
     Ok(())
 }
@@ -1084,6 +1098,12 @@ mod tests {
         // silently serve another test's data. Mirrors the same caveat/fix in
         // `app_core_cache`'s `protection_defaults_*` test (crates/app/cache/src/lib.rs).
         caches::invalidate_settings_bag();
+        // Same hazard for the #668 last-published-snapshot cache: without
+        // this, a `emit_snapshot`-must-publish assertion here could
+        // false-negative if a sibling test already stored an
+        // identical-looking noisy-keys bag (fresh in-memory DBs share the
+        // same in-code defaults).
+        caches::invalidate_last_snapshot_values();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());
@@ -1306,12 +1326,12 @@ mod tests {
         let (db, bus) = setup().await;
         let req = SetSourceOverrideRequest {
             source_id: "src-abc".to_owned(),
-            key: "hashOnScan".to_owned(),
-            value: contracts_core::JsonAny::from(serde_json::json!("eager")),
+            key: "defaultProtection".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("unprotected")),
         };
         let resp = set_source_override(db.pool(), &bus, &req).await.unwrap();
         assert_eq!(resp.source_id, "src-abc");
-        assert_eq!(resp.key, "hashOnScan");
+        assert_eq!(resp.key, "defaultProtection");
     }
 
     /// Review round 1 #1: `set_source_override`'s durable audit id resolves
@@ -1321,8 +1341,8 @@ mod tests {
         let (db, bus) = setup().await;
         let req = SetSourceOverrideRequest {
             source_id: "src-abc".to_owned(),
-            key: "hashOnScan".to_owned(),
-            value: contracts_core::JsonAny::from(serde_json::json!("eager")),
+            key: "defaultProtection".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("unprotected")),
         };
         set_source_override(db.pool(), &bus, &req).await.unwrap();
 
@@ -1357,43 +1377,64 @@ mod tests {
         assert_eq!(row.1.as_deref(), Some("key.unoverridable"));
     }
 
+    /// Issue #623: `followSymlinks`/`hashOnScan` duplicated the canonical
+    /// `IngestionSettings` document and could never succeed as a per-source
+    /// override (`hashOnScan` needs a string, the UI only ever offered a
+    /// boolean — #646) — removed from the overridable set entirely.
+    #[rstest]
+    #[case("followSymlinks")]
+    #[case("hashOnScan")]
+    #[tokio::test]
+    async fn set_source_override_rejects_retired_scan_behavior_keys(#[case] key: &str) {
+        let (db, bus) = setup().await;
+        let req = SetSourceOverrideRequest {
+            source_id: "src-abc".to_owned(),
+            key: key.to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!(true)),
+        };
+        let err = set_source_override(db.pool(), &bus, &req).await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::KeyUnoverridable);
+    }
+
     // ── T022: resolution order ─────────────────────────────────────────
 
     #[tokio::test]
     async fn resolve_setting_prefers_source_override() {
         let (db, bus) = setup().await;
 
-        // Set global to "eager".
+        // Set global to "protected".
         let req = SettingsUpdateRequest {
-            key: "hashOnScan".to_owned(),
-            value: contracts_core::JsonAny::from(serde_json::json!("eager")),
+            key: "defaultProtection".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("protected")),
         };
         update_setting(db.pool(), &bus, &req).await.unwrap();
 
-        // Set source override to "off".
+        // Set source override to "unprotected".
         let ov_req = SetSourceOverrideRequest {
             source_id: "src-1".to_owned(),
-            key: "hashOnScan".to_owned(),
-            value: contracts_core::JsonAny::from(serde_json::json!("off")),
+            key: "defaultProtection".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("unprotected")),
         };
         set_source_override(db.pool(), &bus, &ov_req).await.unwrap();
 
-        let resolved = resolve_setting(db.pool(), "hashOnScan", Some("src-1")).await.unwrap();
-        assert_eq!(resolved, serde_json::json!("off"));
+        let resolved =
+            resolve_setting(db.pool(), "defaultProtection", Some("src-1")).await.unwrap();
+        assert_eq!(resolved, serde_json::json!("unprotected"));
     }
 
     #[tokio::test]
     async fn resolve_setting_falls_back_to_global() {
         let (db, bus) = setup().await;
         let req = SettingsUpdateRequest {
-            key: "hashOnScan".to_owned(),
-            value: contracts_core::JsonAny::from(serde_json::json!("eager")),
+            key: "defaultProtection".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!("unprotected")),
         };
         update_setting(db.pool(), &bus, &req).await.unwrap();
 
         // No override for "src-2".
-        let resolved = resolve_setting(db.pool(), "hashOnScan", Some("src-2")).await.unwrap();
-        assert_eq!(resolved, serde_json::json!("eager"));
+        let resolved =
+            resolve_setting(db.pool(), "defaultProtection", Some("src-2")).await.unwrap();
+        assert_eq!(resolved, serde_json::json!("unprotected"));
     }
 
     #[tokio::test]
@@ -1538,7 +1579,6 @@ mod tests {
     #[case("logLevel", serde_json::json!("warn"))]
     #[case("logLevel", serde_json::json!("info"))]
     #[case("defaultProtection", serde_json::json!("protected"))]
-    #[case("defaultProtection", serde_json::json!("normal"))]
     #[case("defaultProtection", serde_json::json!("unprotected"))]
     #[case("calibrationDarkTempTolerance", serde_json::json!(0.0))]
     #[case("calibrationDarkTempTolerance", serde_json::json!(5.5))]
@@ -1599,6 +1639,8 @@ mod tests {
     #[case("darkMatchTolerance", serde_json::json!("fuzzy"))]
     #[case("flatMatching", serde_json::json!("auto"))]
     #[case("defaultProtection", serde_json::json!("locked"))]
+    // Retired third level (issue #506's 2-level collapse) — no longer valid.
+    #[case("defaultProtection", serde_json::json!("normal"))]
     #[case("calibrationDarkTempTolerance", serde_json::json!(-1.0))] // must be >= 0
     #[case("calibrationDarkTempTolerance", serde_json::json!("x"))] // not a number
     #[case("calibrationAgingThresholdDays", serde_json::json!(0))] // below [1,3650]
@@ -1971,6 +2013,48 @@ mod tests {
         assert!(msg.is_ok(), "emit_snapshot must publish a settings.snapshot event on the bus");
     }
 
+    /// Issue #668: a periodic no-op snapshot (nothing changed since the last
+    /// PUBLISHED one) must not flood the activity log — mirrors
+    /// `resolve_pending`'s `considered == 0` suppression for the target
+    /// resolve-batch heartbeat.
+    #[tokio::test]
+    async fn emit_snapshot_suppresses_unchanged_repeat() {
+        let (db, bus) = setup().await;
+
+        emit_snapshot(db.pool(), &bus, "first").await.unwrap();
+        let mut rx = bus.subscribe();
+
+        // Second call, nothing changed — must be a no-op (no publish).
+        emit_snapshot(db.pool(), &bus, "second").await.unwrap();
+        assert!(
+            rx.try_recv().is_err(),
+            "an unchanged repeat snapshot must not publish a second settings.snapshot event"
+        );
+    }
+
+    /// Issue #668: once a noisy key actually changes, the next snapshot must
+    /// still publish (suppression is value-sensitive, not a blanket mute).
+    #[tokio::test]
+    async fn emit_snapshot_publishes_again_after_a_real_change() {
+        let (db, bus) = setup().await;
+
+        emit_snapshot(db.pool(), &bus, "first").await.unwrap();
+
+        // `pattern` is a noisy key (descriptors::DESCRIPTORS) — change it.
+        let req = SettingsUpdateRequest {
+            key: "pattern".to_owned(),
+            value: contracts_core::JsonAny::from(serde_json::json!(["*.fits"])),
+        };
+        update_setting(db.pool(), &bus, &req).await.unwrap();
+
+        let mut rx = bus.subscribe();
+        emit_snapshot(db.pool(), &bus, "second").await.unwrap();
+        assert!(
+            rx.try_recv().is_ok(),
+            "a snapshot after a real noisy-key change must still publish"
+        );
+    }
+
     /// Table-driven structural-equality cases. `expected_eq` is whether the two
     /// values are considered deep-equal (array order is significant).
     #[rstest]
@@ -2024,9 +2108,18 @@ mod tests {
     #[test]
     fn overridable_keys_includes_expected_keys() {
         let keys = overridable_keys();
-        assert!(keys.contains(&"hashOnScan".to_owned()), "hashOnScan must be overridable");
-        assert!(keys.contains(&"followSymlinks".to_owned()), "followSymlinks must be overridable");
-        // defaultProtection is also overridable per the descriptor table.
+        // Issue #623: followSymlinks/hashOnScan retired from the overridable
+        // set — they duplicated the canonical IngestionSettings document and
+        // the override could never succeed for either.
+        assert!(
+            !keys.contains(&"hashOnScan".to_owned()),
+            "hashOnScan must no longer be overridable"
+        );
+        assert!(
+            !keys.contains(&"followSymlinks".to_owned()),
+            "followSymlinks must no longer be overridable"
+        );
+        // defaultProtection is the sole overridable key per the descriptor table.
         assert!(
             keys.contains(&"defaultProtection".to_owned()),
             "defaultProtection must be overridable"

--- a/crates/contracts/core/src/protection.rs
+++ b/crates/contracts/core/src/protection.rs
@@ -14,12 +14,15 @@ use specta::Type;
 
 // ── Shared enum ───────────────────────────────────────────────────────────
 
-/// Protection level enum (spec 016 data-model.md).
+/// Protection level enum (spec 016 data-model.md; simplified to 2 levels per
+/// issue #506 — the third "inherit-global via an explicit `normal` row" tier
+/// added confusion without adding capability, since absence of an override
+/// row already means inherit-global. Existing `normal` rows are remapped to
+/// `unprotected` by migration 0070, non-destructively).
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
 #[serde(rename_all = "snake_case")]
 pub enum ProtectionLevel {
     Protected,
-    Normal,
     Unprotected,
 }
 
@@ -29,8 +32,7 @@ impl ProtectionLevel {
     pub fn parse_level(s: &str) -> Self {
         match s {
             "protected" => Self::Protected,
-            "unprotected" => Self::Unprotected,
-            _ => Self::Normal,
+            _ => Self::Unprotected,
         }
     }
 
@@ -39,7 +41,6 @@ impl ProtectionLevel {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::Protected => "protected",
-            Self::Normal => "normal",
             Self::Unprotected => "unprotected",
         }
     }
@@ -172,15 +173,22 @@ mod tests {
 
     #[test]
     fn protection_level_round_trips() {
-        for s in &["protected", "normal", "unprotected"] {
+        for s in &["protected", "unprotected"] {
             let level = ProtectionLevel::parse_level(s);
             assert_eq!(level.as_str(), *s);
         }
     }
 
     #[test]
-    fn protection_level_unknown_defaults_to_normal() {
-        assert_eq!(ProtectionLevel::parse_level("other"), ProtectionLevel::Normal);
+    fn protection_level_unknown_defaults_to_unprotected() {
+        assert_eq!(ProtectionLevel::parse_level("other"), ProtectionLevel::Unprotected);
+    }
+
+    #[test]
+    fn protection_level_legacy_normal_maps_to_unprotected() {
+        // Migration 0070 remaps stored 'normal' rows to 'unprotected'; the
+        // parser must agree for any value that slips through unmigrated.
+        assert_eq!(ProtectionLevel::parse_level("normal"), ProtectionLevel::Unprotected);
     }
 
     #[test]

--- a/crates/domain/core/src/settings.rs
+++ b/crates/domain/core/src/settings.rs
@@ -135,7 +135,7 @@ pub struct SettingsState {
     pub remember_follow_logs: bool,
 
     // ── Source Protection ────────────────────────────────────────────────
-    /// Default protection level: `"protected"` | `"normal"` | `"unprotected"`.
+    /// Default protection level: `"protected"` | `"unprotected"`.
     pub default_protection: String,
     /// Routes destructive operations to archive/trash workflows.
     pub block_permanent_delete: bool,

--- a/crates/e2e-tests/tests/archive_journeys.rs
+++ b/crates/e2e-tests/tests/archive_journeys.rs
@@ -112,13 +112,15 @@ async fn setup_archived_project(
     // safe-by-default level is "protected" (constitution II) — without
     // this, every archive item refuses apply with `protected.source`. A
     // real user sets this the same way before a first archive.
+    // 2-level model (issue #506): "normal" is retired — "unprotected" is the
+    // non-gating override this test needs.
     let _: serde_json::Value = app
         .invoke(
             "source_protection_set",
             json!({
                 "request": {
                     "sourceId": project_id,
-                    "level": "normal",
+                    "level": "unprotected",
                     "blockPermanentDelete": null,
                     "categories": null,
                 }

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -638,13 +638,15 @@ async fn cleanup_plan_review() -> anyhow::Result<()> {
     // step below refuses every item with `protected.source` — not a bug,
     // the documented constitution-II gate — so a real cleanup flow always
     // sets this (or the global default) before a first-time cleanup.
+    // 2-level model (issue #506): "normal" is retired — "unprotected" is the
+    // non-gating override this test needs.
     let _: serde_json::Value = app
         .invoke(
             "source_protection_set",
             json!({
                 "request": {
                     "sourceId": project_id,
-                    "level": "normal",
+                    "level": "unprotected",
                     "blockPermanentDelete": null,
                     "categories": null,
                 }

--- a/crates/persistence/db/migrations/0070_protection_two_level.sql
+++ b/crates/persistence/db/migrations/0070_protection_two_level.sql
@@ -1,0 +1,56 @@
+-- Migration 0070: collapse source protection to a 2-level model (issue #506).
+--
+-- Product decision (2026-07-17): the 3-level model (protected / normal /
+-- unprotected) is simplified to 2 levels (protected / unprotected). The
+-- "normal" level added a confusing third state that duplicated what an
+-- ABSENT override row already means (inherit the global default) without
+-- adding real capability. Per-source protection control lives only in
+-- Settings (not the first-run wizard).
+--
+-- Constitution §V (durable records): this migration is purely additive/
+-- remapping — every existing row survives with its value normalised to the
+-- new 2-value vocabulary. No row is deleted.
+--
+-- SQLite has no ALTER COLUMN / DROP CONSTRAINT, so the CHECK change on
+-- source_protection_state requires a table rebuild (mirrors migration 0053).
+
+PRAGMA foreign_keys = OFF;
+
+CREATE TABLE source_protection_state_0070 (
+    source_id             TEXT PRIMARY KEY NOT NULL,
+    level                 TEXT NOT NULL CHECK (level IN ('protected', 'unprotected')),
+    block_permanent_delete INTEGER,
+    categories            TEXT,
+    updated_at            TEXT NOT NULL,
+    updated_by            TEXT NOT NULL DEFAULT 'system'
+);
+
+INSERT INTO source_protection_state_0070
+SELECT
+    source_id,
+    CASE WHEN level = 'protected' THEN 'protected' ELSE 'unprotected' END,
+    block_permanent_delete,
+    categories,
+    updated_at,
+    updated_by
+FROM source_protection_state;
+
+DROP TABLE source_protection_state;
+ALTER TABLE source_protection_state_0070 RENAME TO source_protection_state;
+
+PRAGMA foreign_keys = ON;
+
+-- `protection_defaults` (migration 0035) and the legacy `settings`/
+-- `source_overrides` key-value tables (migration 0013) have no CHECK
+-- constraint — remap their stored 'normal' JSON values in place.
+UPDATE protection_defaults
+SET value = '"unprotected"'
+WHERE scope = 'global' AND key = 'defaultProtection' AND value = '"normal"';
+
+UPDATE settings
+SET value = '"unprotected"'
+WHERE key = 'defaultProtection' AND value = '"normal"';
+
+UPDATE source_overrides
+SET value = '"unprotected"'
+WHERE key = 'defaultProtection' AND value = '"normal"';

--- a/crates/persistence/db/src/repositories/source_protection.rs
+++ b/crates/persistence/db/src/repositories/source_protection.rs
@@ -325,7 +325,7 @@ mod tests {
         let db = setup().await;
         let source_id = "src-001";
 
-        upsert_source_protection(db.pool(), source_id, "normal", Some(false), None, "user")
+        upsert_source_protection(db.pool(), source_id, "unprotected", Some(false), None, "user")
             .await
             .unwrap();
 
@@ -334,7 +334,7 @@ mod tests {
             .unwrap()
             .expect("row should exist");
 
-        assert_eq!(row.level, "normal");
+        assert_eq!(row.level, "unprotected");
         assert_eq!(row.block_permanent_delete, Some(0));
         assert!(row.categories.is_none());
     }
@@ -365,7 +365,9 @@ mod tests {
         let db = setup().await;
         let source_id = "src-003";
 
-        upsert_source_protection(db.pool(), source_id, "normal", None, None, "user").await.unwrap();
+        upsert_source_protection(db.pool(), source_id, "unprotected", None, None, "user")
+            .await
+            .unwrap();
         delete_source_protection(db.pool(), source_id).await.unwrap();
 
         let row = get_source_protection_row(db.pool(), source_id).await.unwrap();
@@ -378,7 +380,7 @@ mod tests {
         let source_id = "src-004";
         let global_cats = vec!["lights".to_owned(), "masters".to_owned()];
 
-        upsert_source_protection(db.pool(), source_id, "normal", Some(false), None, "user")
+        upsert_source_protection(db.pool(), source_id, "unprotected", Some(false), None, "user")
             .await
             .unwrap();
 
@@ -393,8 +395,8 @@ mod tests {
         .await
         .unwrap();
 
-        // Override wins — level is "normal" even though "lights" is in protected categories.
-        assert_eq!(resolved.level, "normal");
+        // Override wins — level is "unprotected" even though "lights" is in protected categories.
+        assert_eq!(resolved.level, "unprotected");
         assert!(!resolved.block_permanent_delete);
         assert!(!resolved.inherits_default);
     }
@@ -406,10 +408,16 @@ mod tests {
         let global_cats = vec!["lights".to_owned(), "masters".to_owned()];
 
         // No override row.
-        let resolved =
-            resolve_protection(db.pool(), source_id, Some("lights"), "normal", true, &global_cats)
-                .await
-                .unwrap();
+        let resolved = resolve_protection(
+            db.pool(),
+            source_id,
+            Some("lights"),
+            "unprotected",
+            true,
+            &global_cats,
+        )
+        .await
+        .unwrap();
 
         assert_eq!(resolved.level, "protected");
         assert!(resolved.inherits_default);
@@ -422,11 +430,11 @@ mod tests {
         let global_cats: Vec<String> = vec![];
 
         let resolved =
-            resolve_protection(db.pool(), source_id, None, "normal", false, &global_cats)
+            resolve_protection(db.pool(), source_id, None, "unprotected", false, &global_cats)
                 .await
                 .unwrap();
 
-        assert_eq!(resolved.level, "normal");
+        assert_eq!(resolved.level, "unprotected");
         assert!(!resolved.block_permanent_delete);
         assert!(resolved.inherits_default);
     }
@@ -449,9 +457,10 @@ mod tests {
         .unwrap();
 
         let global_cats = vec!["lights".to_owned(), "masters".to_owned()];
-        let resolved = resolve_protection(db.pool(), source_id, None, "normal", true, &global_cats)
-            .await
-            .unwrap();
+        let resolved =
+            resolve_protection(db.pool(), source_id, None, "unprotected", true, &global_cats)
+                .await
+                .unwrap();
 
         assert_eq!(resolved.categories, vec!["finals".to_owned()]);
         assert!(!resolved.inherits_default);

--- a/crates/persistence/db/tests/migration_0070.rs
+++ b/crates/persistence/db/tests/migration_0070.rs
@@ -1,0 +1,236 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Migration 0070 integration test (source protection 2-level collapse, issue
+//! #506).
+//!
+//! `sqlx::migrate!` applies every migration in one shot, so by the time
+//! `Database::migrate()` returns, `source_protection_state.level` is already
+//! CHECK-constrained to `('protected', 'unprotected')` — a legacy `'normal'`
+//! row can no longer even be seeded to prove the remap. Instead, this test
+//! builds the minimal PRE-0070 schema directly (the exact `CREATE TABLE`
+//! statements from the migrations that own each table: 0013 `settings`/
+//! `source_overrides`, 0026 `source_protection_state`, 0035
+//! `protection_defaults`), seeds legacy `'normal'` rows across all four, then
+//! runs 0070's SQL and asserts every row survives with its value remapped
+//! (Constitution §V: non-destructive).
+
+use persistence_db::Database;
+
+const MIGRATION_0070: &str = include_str!("../migrations/0070_protection_two_level.sql");
+
+async fn setup_pre_0070_schema() -> Database {
+    let db = Database::in_memory().await.expect("in-memory db");
+    let pool = db.pool();
+
+    // Migration 0013.
+    sqlx::query(
+        "CREATE TABLE settings (
+            key        TEXT PRIMARY KEY NOT NULL,
+            value      TEXT NOT NULL,
+            updated_at TEXT NOT NULL
+        )",
+    )
+    .execute(pool)
+    .await
+    .expect("create settings");
+    sqlx::query(
+        "CREATE TABLE source_overrides (
+            source_id  TEXT NOT NULL,
+            key        TEXT NOT NULL,
+            value      TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (source_id, key)
+        )",
+    )
+    .execute(pool)
+    .await
+    .expect("create source_overrides");
+
+    // Migration 0026 (pre-0070 3-level CHECK).
+    sqlx::query(
+        "CREATE TABLE source_protection_state (
+            source_id             TEXT PRIMARY KEY NOT NULL,
+            level                 TEXT NOT NULL CHECK (level IN ('protected', 'normal', 'unprotected')),
+            block_permanent_delete INTEGER,
+            categories            TEXT,
+            updated_at            TEXT NOT NULL,
+            updated_by            TEXT NOT NULL DEFAULT 'system'
+        )",
+    )
+    .execute(pool)
+    .await
+    .expect("create source_protection_state");
+
+    // Migration 0035.
+    sqlx::query(
+        "CREATE TABLE protection_defaults (
+            scope      TEXT NOT NULL,
+            key        TEXT NOT NULL,
+            value      TEXT NOT NULL,
+            updated_at TEXT NOT NULL,
+            PRIMARY KEY (scope, key)
+        )",
+    )
+    .execute(pool)
+    .await
+    .expect("create protection_defaults");
+
+    db
+}
+
+#[tokio::test]
+async fn normal_rows_remap_to_unprotected_non_destructively() {
+    let db = setup_pre_0070_schema().await;
+    let pool = db.pool();
+
+    // Seed one row per level in source_protection_state, plus a legacy
+    // 'normal' defaultProtection value in every k/v store it can live in.
+    sqlx::query(
+        "INSERT INTO source_protection_state \
+         (source_id, level, block_permanent_delete, categories, updated_at, updated_by) \
+         VALUES \
+         ('src-normal', 'normal', 1, '[\"lights\"]', '2026-01-01T00:00:00Z', 'user'), \
+         ('src-protected', 'protected', NULL, NULL, '2026-01-01T00:00:00Z', 'user'), \
+         ('src-unprotected', 'unprotected', 0, NULL, '2026-01-01T00:00:00Z', 'user')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed source_protection_state");
+
+    sqlx::query(
+        "INSERT INTO protection_defaults (scope, key, value, updated_at) \
+         VALUES ('global', 'defaultProtection', '\"normal\"', '2026-01-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed protection_defaults");
+
+    sqlx::query(
+        "INSERT INTO settings (key, value, updated_at) \
+         VALUES ('defaultProtection', '\"normal\"', '2026-01-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed settings");
+
+    sqlx::query(
+        "INSERT INTO source_overrides (source_id, key, value, updated_at) \
+         VALUES ('src-normal', 'defaultProtection', '\"normal\"', '2026-01-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed source_overrides");
+
+    // Apply the migration under test (as a multi-statement script — sqlx's
+    // `query`/`execute` only runs the first statement, so use the raw
+    // sqlite connection's `execute_batch`-equivalent via `sqlx::raw_sql`).
+    sqlx::raw_sql(MIGRATION_0070).execute(pool).await.expect("0070 migration must apply");
+
+    // Every row survives (non-destructive) — count unchanged.
+    let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM source_protection_state")
+        .fetch_one(pool)
+        .await
+        .expect("count");
+    assert_eq!(count, 3, "no row may be dropped by the 2-level collapse");
+
+    let levels: Vec<(String, String)> =
+        sqlx::query_as("SELECT source_id, level FROM source_protection_state ORDER BY source_id")
+            .fetch_all(pool)
+            .await
+            .expect("levels");
+    assert_eq!(
+        levels,
+        vec![
+            ("src-normal".to_owned(), "unprotected".to_owned()),
+            ("src-protected".to_owned(), "protected".to_owned()),
+            ("src-unprotected".to_owned(), "unprotected".to_owned()),
+        ],
+        "'normal' must remap to 'unprotected'; 'protected'/'unprotected' rows are untouched"
+    );
+
+    // block_permanent_delete/categories/updated_at/updated_by survive untouched
+    // for the remapped row.
+    let (bpd, cats): (Option<i64>, Option<String>) = sqlx::query_as(
+        "SELECT block_permanent_delete, categories FROM source_protection_state WHERE source_id = 'src-normal'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("remapped row detail");
+    assert_eq!(bpd, Some(1));
+    assert_eq!(cats.as_deref(), Some("[\"lights\"]"));
+
+    // The new CHECK actually rejects 'normal' going forward.
+    let rejected = sqlx::query(
+        "INSERT INTO source_protection_state \
+         (source_id, level, updated_at, updated_by) \
+         VALUES ('src-new', 'normal', '2026-01-01T00:00:00Z', 'user')",
+    )
+    .execute(pool)
+    .await;
+    assert!(rejected.is_err(), "the rebuilt table's CHECK must reject 'normal' post-migration");
+
+    // protection_defaults / settings / source_overrides: no CHECK, but the
+    // stored 'normal' JSON value is remapped in place too.
+    let (pd_value,): (String,) = sqlx::query_as(
+        "SELECT value FROM protection_defaults WHERE scope = 'global' AND key = 'defaultProtection'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("protection_defaults value");
+    assert_eq!(pd_value, "\"unprotected\"");
+
+    let (settings_value,): (String,) =
+        sqlx::query_as("SELECT value FROM settings WHERE key = 'defaultProtection'")
+            .fetch_one(pool)
+            .await
+            .expect("settings value");
+    assert_eq!(settings_value, "\"unprotected\"");
+
+    let (override_value,): (String,) = sqlx::query_as(
+        "SELECT value FROM source_overrides WHERE source_id = 'src-normal' AND key = 'defaultProtection'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("source_overrides value");
+    assert_eq!(override_value, "\"unprotected\"");
+}
+
+#[tokio::test]
+async fn already_2_level_rows_are_left_alone() {
+    let db = setup_pre_0070_schema().await;
+    let pool = db.pool();
+
+    sqlx::query(
+        "INSERT INTO source_protection_state \
+         (source_id, level, updated_at, updated_by) \
+         VALUES ('src-1', 'protected', '2026-01-01T00:00:00Z', 'user')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed");
+    sqlx::query(
+        "INSERT INTO protection_defaults (scope, key, value, updated_at) \
+         VALUES ('global', 'defaultProtection', '\"protected\"', '2026-01-01T00:00:00Z')",
+    )
+    .execute(pool)
+    .await
+    .expect("seed");
+
+    sqlx::raw_sql(MIGRATION_0070).execute(pool).await.expect("0070 migration must apply");
+
+    let (level,): (String,) =
+        sqlx::query_as("SELECT level FROM source_protection_state WHERE source_id = 'src-1'")
+            .fetch_one(pool)
+            .await
+            .expect("level");
+    assert_eq!(level, "protected");
+
+    let (value,): (String,) = sqlx::query_as(
+        "SELECT value FROM protection_defaults WHERE scope = 'global' AND key = 'defaultProtection'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("value");
+    assert_eq!(value, "\"protected\"");
+}


### PR DESCRIPTION
Closes #506
Closes #730
Closes #623
Closes #646
Closes #657 (resolved by the ratified 2-level simplification — see .orchestration decisions.md refinement, user-confirmed 2026-07-17; no per-source clear command needed under the 2-level model)
Closes #668 (settings half here, completing the backend half already merged in #1061)