### PR TITLE
fix(workflow): manifests, source views, tool launch, reveal-in-OS, and watcher reconciliation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,6 +237,7 @@ dependencies = [
  "persistence_db",
  "project_structure",
  "serde_json",
+ "sha2 0.10.9",
  "simbad-resolver",
  "sqlx",
  "tempfile",

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1360,6 +1360,8 @@
   "calibration_master_singular": "master",
   "common_working": "Working…",
   "common_applying": "Applying…",
+  "common_copy_path": "Copy path",
+  "common_path_copied": "Path copied to clipboard.",
   "common_confirming": "Confirming…",
   "common_close": "Close",
   "common_rescan": "Rescan",

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1284,6 +1284,8 @@
   "inbox_toast_all_plans_applying": "All {count} plans are being applied.",
   "inbox_toast_apply_failed": "Apply failed — please try again.",
   "inbox_toast_plan_discarded": "Plan discarded. Item is available for re-confirmation.",
+  "inbox_toast_reveal_error": "Could not open the location.",
+  "inbox_reveal_title": "Open this item's location in the OS file browser",
   "logpanel_save_dialog_title": "Export Activity Log",
   "projects_toast_reinfer_failed": "Re-infer failed.",
   "projects_toast_dismiss_failed": "Dismiss failed.",

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -2406,6 +2406,7 @@
   "plans_review_col_protection": "Protection",
   "plans_review_col_reason": "Reason",
   "plans_review_col_linked": "Linked entity",
+  "plans_review_col_link_kind": "Link kind",
   "plans_review_col_result": "Result",
   "plans_review_result_pending": "pending",
   "plans_review_deletion_target": "Deleted, not moved",

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1329,6 +1329,7 @@
   "projects_source_views_verify_state_moved": "source moved or removed",
   "projects_source_views_verify_state_unresolved_link": "link does not resolve",
   "projects_source_views_verify_state_changed_kind": "materialization kind changed",
+  "projects_source_views_verify_state_hash_diverged": "content changed",
   "projects_source_views_observed_state_present": "present",
   "projects_source_views_observed_state_missing": "missing",
   "projects_source_views_observed_state_changed_kind": "kind changed",

--- a/apps/desktop/src-tauri/src/commands/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/commands/lifecycle.rs
@@ -212,6 +212,12 @@ pub async fn provenance_read(
 
 /// `lifecycle.transition.apply` Tauri command.
 ///
+/// #665: on a successful `Project` entity transition, fires the
+/// `LifecycleTransition` manifest trigger — this and the source add/remove
+/// trigger were the last of the 4 unwired manifest emitters (project create
+/// and source add/remove are wired in `app_core_projects`; `workflow_run` was
+/// the only one that ever existed).
+///
 /// # Errors
 /// Never returns `Err`; refusal / persistence errors fold into
 /// `TransitionResponse::error(...)` per the contract.
@@ -221,7 +227,26 @@ pub async fn lifecycle_transition_apply(
     state: State<'_, AppState>,
     request: TransitionRequest,
 ) -> Result<TransitionResponse, String> {
-    Ok(apply_transition(state.repo.as_ref(), &state.bus, request).await)
+    let project_id = match &request {
+        TransitionRequest::Project(req) => Some(req.entity_id.to_string()),
+        _ => None,
+    };
+
+    let response = apply_transition(state.repo.as_ref(), &state.bus, request).await;
+
+    if let Some(project_id) = project_id {
+        if response.status == contracts_core::lifecycle::TransitionStatus::Success {
+            app_core::project_manifests::write_lifecycle_manifest(
+                state.repo.pool(),
+                &state.bus,
+                &project_id,
+                contracts_core::manifests::ManifestReason::LifecycleTransition,
+            )
+            .await;
+        }
+    }
+
+    Ok(response)
 }
 
 /// `lifecycle.transition.preview` — read-only dry-run for UI button enabling.

--- a/apps/desktop/src-tauri/src/commands/manifests.rs
+++ b/apps/desktop/src-tauri/src/commands/manifests.rs
@@ -17,10 +17,11 @@ use contracts_core::manifests::{
     ManifestRevealRequest, ProjectNoteGetRequest, ProjectNoteGetResult, ProjectNoteUpdateRequest,
     ProjectNoteUpdateResult,
 };
+use contracts_core::native::{EntityKind, RevealRequest};
 use tauri::{AppHandle, State};
-use tauri_plugin_opener::OpenerExt;
 
 use crate::commands::lifecycle::AppState;
+use crate::commands::native::reveal_with_audit;
 
 // ── project.manifest.list ─────────────────────────────────────────────────────
 
@@ -116,41 +117,28 @@ pub async fn note_update(
 /// `project.manifest.reveal_in_os` — open the manifest file's folder in the
 /// OS file manager.
 ///
-/// Delegates to `tauri-plugin-opener::reveal_item_in_dir`. On Linux, if the
-/// opener plugin fails, falls back to `xdg-open` on the parent directory
-/// (matching the pattern from `native.reveal`).
+/// #716: routes through the shared spec-004 `native.reveal` core
+/// (`reveal_with_audit`) instead of reimplementing the opener/xdg-open
+/// fallback independently — path validation and `native.reveal.failed`
+/// audit-on-failure now apply here too, which the standalone reimplementation
+/// never had. The external `Result<(), String>` contract is unchanged.
 ///
 /// # Errors
 /// Returns `Err(String)` when the path does not exist or the OS open fails.
 #[tauri::command]
 #[specta::specta]
 pub async fn manifest_reveal_in_os(
-    _state: State<'_, AppState>,
+    state: State<'_, AppState>,
     app: AppHandle,
     request: ManifestRevealRequest,
 ) -> Result<(), String> {
     tracing::debug!("project.manifest.reveal_in_os path={}", request.path);
 
-    let path = std::path::Path::new(&request.path);
-    if !path.exists() {
-        return Err(format!("manifest file not found: {}", request.path));
-    }
-
-    match app.opener().reveal_item_in_dir(&request.path) {
-        Ok(()) => Ok(()),
-        Err(opener_err) => {
-            // Linux fallback: xdg-open on the parent directory.
-            #[cfg(target_os = "linux")]
-            if let Some(parent) = path.parent() {
-                let parent_str = parent.to_string_lossy();
-                match std::process::Command::new("xdg-open").arg(parent_str.as_ref()).spawn() {
-                    Ok(_) => return Ok(()),
-                    Err(e) => {
-                        tracing::warn!("manifest.reveal_in_os: xdg-open fallback failed: {e}");
-                    }
-                }
-            }
-            Err(format!("failed to reveal {} in file manager: {opener_err}", request.path))
-        }
-    }
+    let reveal_request = RevealRequest {
+        request_id: uuid::Uuid::new_v4().to_string(),
+        path: request.path,
+        entity_kind: Some(EntityKind::ProjectManifest),
+        entity_id: None,
+    };
+    reveal_with_audit(&app, &state, &reveal_request).await.map(|_| ()).map_err(|e| e.message)
 }

--- a/apps/desktop/src-tauri/src/commands/native.rs
+++ b/apps/desktop/src-tauri/src/commands/native.rs
@@ -113,16 +113,37 @@ pub async fn native_reveal(
     request: RevealRequest,
 ) -> Result<RevealResponse, ContractError> {
     tracing::debug!("native.reveal request_id={} path={}", request.request_id, request.path);
+    let selection = reveal_with_audit(&app, &state, &request).await?;
+    Ok(native::reveal_success(selection))
+}
 
+/// Shared reveal core: validates the path exists, attempts the OS reveal
+/// (+ Linux `xdg-open` fallback), and emits `native.reveal.failed` on any
+/// failure path (path-not-exists via `validate_reveal_path`, OS command
+/// failure here).
+///
+/// #716: `manifest_reveal_in_os` (spec 024) used to reimplement this
+/// independently — same opener/xdg-open logic, no audit on failure. Both
+/// commands now share this single reveal-with-audit path so they can never
+/// drift again.
+///
+/// # Errors
+/// Returns `ContractError` (`path.not_exists` or `os.command_failed`) on
+/// failure.
+pub(crate) async fn reveal_with_audit(
+    app: &tauri::AppHandle,
+    state: &AppState,
+    request: &RevealRequest,
+) -> Result<RevealSelection, ContractError> {
     // Check path existence and emit audit event on failure.
-    native::validate_reveal_path(&state.bus, &request).await?;
+    native::validate_reveal_path(&state.bus, request).await?;
 
     // Attempt the platform reveal.
     match app.opener().reveal_item_in_dir(&request.path) {
         Ok(()) => {
             // macOS and Windows select the item; Linux freedesktop ShowItems
             // also selects. Return `target`.
-            Ok(native::reveal_success(RevealSelection::Target))
+            Ok(RevealSelection::Target)
         }
         Err(opener_err) => {
             // On Linux, fall back to xdg-open on the parent directory.
@@ -133,10 +154,10 @@ pub async fn native_reveal(
 
                 match std::process::Command::new("xdg-open").arg(parent).spawn() {
                     Ok(_) => {
-                        return Ok(native::reveal_success(RevealSelection::DirectoryOnly));
+                        return Ok(RevealSelection::DirectoryOnly);
                     }
                     Err(xdg_err) => {
-                        tracing::warn!("native.reveal: xdg-open fallback also failed: {xdg_err}");
+                        tracing::warn!("reveal: xdg-open fallback also failed: {xdg_err}");
                     }
                 }
             }

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -140,24 +140,41 @@ fn tool_id_from_project_tool(project_tool: &str) -> String {
     project_tool.to_lowercase().split_whitespace().collect::<Vec<_>>().join("_")
 }
 
-/// Non-recursive directory listing of real files only.
+/// Recursive directory listing of real files only (#780).
 ///
-/// Constitution: never follows symlinks (no per-root opt-in exists for
-/// project output folders in v1), and never recurses (matches the
-/// single-level contract `workflow_artifacts::reconciler::reconcile` already
-/// exercises in its unit tests).
+/// Must agree with the live watcher's `RecursiveMode::Recursive`
+/// (`fs_inventory::artifact_watcher`, e.g. output/ subfolders) — a
+/// non-recursive on-attach reconcile only ever saw the project root's
+/// top-level files, so every reopen (a) marked every real artifact (which
+/// lives under a subfolder like `output/`) `Gone`→`missing`, and (b) never
+/// `detect`-ed files written to a subfolder while the project was closed.
+///
+/// Constitution: never follows symlinks/junctions (no per-root opt-in exists
+/// for project output folders in v1) — neither into a symlinked directory
+/// nor as a symlinked file.
 fn real_read_dir(dir: &Path) -> Result<Vec<PathBuf>, String> {
+    let mut out = Vec::new();
+    real_read_dir_into(dir, &mut out)?;
+    Ok(out)
+}
+
+/// Recursion helper for [`real_read_dir`]; `out` accumulates real file paths
+/// across the whole subtree.
+fn real_read_dir_into(dir: &Path, out: &mut Vec<PathBuf>) -> Result<(), String> {
     let entries =
         std::fs::read_dir(dir).map_err(|e| format!("read_dir({}) failed: {e}", dir.display()))?;
-    let mut out = Vec::new();
     for entry in entries.flatten() {
         let Ok(file_type) = entry.file_type() else { continue };
-        if file_type.is_symlink() || !file_type.is_file() {
+        if file_type.is_symlink() {
             continue;
         }
-        out.push(entry.path());
+        if file_type.is_dir() {
+            real_read_dir_into(&entry.path(), out)?;
+        } else if file_type.is_file() {
+            out.push(entry.path());
+        }
     }
-    Ok(out)
+    Ok(())
 }
 
 /// Real (size, mtime) probe. Uses `symlink_metadata` and rejects symlinks
@@ -533,5 +550,54 @@ mod tests {
         record_raw_event(&evt(&path, ArtifactEventKind::Created), &xisf_extensions(), &mut pending);
 
         assert!(pending.is_empty(), "a path that can't be stat'd must not be tracked");
+    }
+
+    // ── real_read_dir (#780) ──────────────────────────────────────────────────
+
+    #[test]
+    fn real_read_dir_finds_files_nested_under_subfolders() {
+        let dir = tempfile::tempdir().unwrap();
+        let output_dir = dir.path().join("output");
+        std::fs::create_dir_all(&output_dir).unwrap();
+        let top_file = dir.path().join("top.fits");
+        let nested_file = output_dir.join("nested.xisf");
+        std::fs::write(&top_file, b"x").unwrap();
+        std::fs::write(&nested_file, b"x").unwrap();
+
+        let found = real_read_dir(dir.path()).unwrap();
+
+        assert!(found.contains(&top_file), "top-level file must be found");
+        assert!(found.contains(&nested_file), "file nested under a subfolder must be found");
+    }
+
+    #[test]
+    fn real_read_dir_recurses_multiple_levels() {
+        let dir = tempfile::tempdir().unwrap();
+        let deep_dir = dir.path().join("output").join("2026-01-01");
+        std::fs::create_dir_all(&deep_dir).unwrap();
+        let deep_file = deep_dir.join("integration.xisf");
+        std::fs::write(&deep_file, b"x").unwrap();
+
+        let found = real_read_dir(dir.path()).unwrap();
+
+        assert!(found.contains(&deep_file), "file nested two levels deep must be found");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn real_read_dir_never_descends_into_a_symlinked_directory() {
+        // Constitution: never follow symlinks/junctions unless explicitly
+        // enabled per root — a symlinked subdirectory's contents must not
+        // leak into the reconcile pass's file list.
+        let dir = tempfile::tempdir().unwrap();
+        let real_target = tempfile::tempdir().unwrap();
+        let hidden_file = real_target.path().join("outside.fits");
+        std::fs::write(&hidden_file, b"x").unwrap();
+        let link_path = dir.path().join("linked_output");
+        std::os::unix::fs::symlink(real_target.path(), &link_path).unwrap();
+
+        let found = real_read_dir(dir.path()).unwrap();
+
+        assert!(found.is_empty(), "must not descend into a symlinked directory: found {found:?}");
     }
 }

--- a/apps/desktop/src-tauri/tests/artifact_watcher_subfolder_reconciliation.rs
+++ b/apps/desktop/src-tauri/tests/artifact_watcher_subfolder_reconciliation.rs
@@ -1,0 +1,127 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Real-backend integration test for #780 (release-blocker): the on-attach
+//! reconciliation pass (`run_attach_reconciliation`, private to `watcher.rs`)
+//! was non-recursive while the live `notify` watcher is recursive
+//! (`fs_inventory::artifact_watcher`, `RecursiveMode::Recursive`) — so a real
+//! project's `output/` subfolder was invisible on every reopen: existing
+//! subfolder artifacts got wrongly marked `missing`, and new files written to
+//! a subfolder while detached were never picked up.
+//!
+//! Companion to `artifact_watcher_missing_reconciliation.rs` (same public
+//! entry point, top-level-only repro). This test nests both files one level
+//! deep under `output/` to cover the exact spec-012 Touch & validate repro.
+
+use std::path::PathBuf;
+
+use audit::bus::EventBus;
+use audit::event_bus::{EventEnvelope, TOPIC_ARTIFACT_DETECTED, TOPIC_ARTIFACT_MISSING};
+use persistence_db::Database;
+
+use desktop_shell::watcher::{
+    attach_project_watcher, detach_project_watcher, new_artifact_watcher_registry,
+};
+
+async fn insert_projects_row(pool: &sqlx::SqlitePool, path: &str) -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+         VALUES (?, 'Watcher Subfolder-Reconciliation Project', 'PixInsight', 'setup_incomplete', ?, NULL, 0, \
+                 '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+    )
+    .bind(&id)
+    .bind(path)
+    .execute(pool)
+    .await
+    .expect("insert projects row");
+    id
+}
+
+/// Wait for a specific topic on the bus (draining others), up to `deadline`.
+async fn wait_for_topic(
+    rx: &mut tokio::sync::broadcast::Receiver<EventEnvelope<serde_json::Value>>,
+    topic: &str,
+    deadline: tokio::time::Instant,
+) -> Option<EventEnvelope<serde_json::Value>> {
+    loop {
+        match tokio::time::timeout_at(deadline, rx.recv()).await {
+            Ok(Ok(env)) if env.topic == topic => return Some(env),
+            Ok(Ok(_)) => {}
+            Ok(Err(_)) | Err(_) => return None,
+        }
+    }
+}
+
+#[tokio::test]
+async fn subfolder_artifact_survives_reopen_and_new_subfolder_file_is_detected() {
+    let db = Database::in_memory().await.expect("in-memory database");
+    db.migrate().await.expect("run migrations");
+    let pool = db.pool().clone();
+    let bus = EventBus::with_pool(pool.clone());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project_root: PathBuf = dir.path().canonicalize().expect("canonicalize tempdir");
+    let output_dir = project_root.join("output");
+    std::fs::create_dir_all(&output_dir).expect("create output subfolder");
+    let project_id = insert_projects_row(&pool, &project_root.to_string_lossy()).await;
+
+    // A subfolder file already on disk before the first attach — the
+    // on-attach reconciliation pass must find it despite it being nested
+    // under output/, not just the project root's top level.
+    let existing_file = output_dir.join("J5_integration_master.xisf");
+    std::fs::write(&existing_file, b"not-a-real-xisf-file").expect("write existing artifact");
+
+    let registry = new_artifact_watcher_registry();
+
+    let mut rx_first = bus.subscribe();
+    attach_project_watcher(&pool, &bus, &registry, &project_id)
+        .await
+        .expect("first attach_project_watcher");
+    let first_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let detected_env = wait_for_topic(&mut rx_first, TOPIC_ARTIFACT_DETECTED, first_deadline)
+        .await
+        .expect("artifact.detected must fire for the existing subfolder file");
+    let artifact_id =
+        detected_env.payload["artifactId"].as_str().expect("artifactId is a string").to_owned();
+
+    // Detach (project closed), drop a SECOND file into the same subfolder
+    // while detached, then re-attach (project reopened).
+    detach_project_watcher(&registry, &project_id).await;
+    let new_file = output_dir.join("J5_final_closed.fits");
+    std::fs::write(&new_file, b"not-a-real-fits-file").expect("write new artifact while detached");
+
+    let mut rx_second = bus.subscribe();
+    attach_project_watcher(&pool, &bus, &registry, &project_id)
+        .await
+        .expect("second attach_project_watcher (reopen)");
+
+    // The new subfolder file must be detected on reopen.
+    let second_deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(5);
+    let redetected_env = wait_for_topic(&mut rx_second, TOPIC_ARTIFACT_DETECTED, second_deadline)
+        .await
+        .expect("artifact.detected must fire for the new subfolder file on reopen");
+    assert_ne!(
+        redetected_env.payload["artifactId"].as_str(),
+        Some(artifact_id.as_str()),
+        "the newly-detected artifact must be the new file, not a re-detection of the first"
+    );
+
+    // The FIRST (still-present) subfolder artifact must NOT have been marked
+    // missing by the reconcile pass — assert no artifact.missing fired for it
+    // and its DB row is still `present`.
+    let missed_deadline = tokio::time::Instant::now() + std::time::Duration::from_millis(500);
+    let spurious_missing =
+        wait_for_topic(&mut rx_second, TOPIC_ARTIFACT_MISSING, missed_deadline).await;
+    assert!(
+        spurious_missing.is_none(),
+        "a still-present subfolder artifact must not be marked missing on reopen"
+    );
+    let row = sqlx::query_as::<_, (String,)>("SELECT state FROM processing_artifacts WHERE id = ?")
+        .bind(&artifact_id)
+        .fetch_one(&pool)
+        .await
+        .expect("query artifact state");
+    assert_eq!(row.0, "present", "existing subfolder artifact must stay 'present' across reopen");
+}

--- a/apps/desktop/src-tauri/tests/commands.rs
+++ b/apps/desktop/src-tauri/tests/commands.rs
@@ -895,6 +895,57 @@ async fn lifecycle_transition_apply() {
     assert!(!response.contract_version.is_empty());
 }
 
+/// #665: a successful Project transition through the real Tauri command
+/// (not just the bare use case above) must fire the `LifecycleTransition`
+/// manifest trigger — one of the 3 manifest emitters that never existed at
+/// all before this fix.
+#[tokio::test]
+async fn lifecycle_transition_apply_writes_lifecycle_transition_manifest() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let app = mock_lifecycle_app().await;
+    let state = app.state::<AppState>();
+
+    let project_id = uuid::Uuid::new_v4();
+    sqlx::query(
+        "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+         VALUES (?, 'M31 LRGB', 'PixInsight', 'ready', ?, NULL, 0, '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+    )
+    .bind(project_id.to_string())
+    .bind(dir.path().to_str().unwrap())
+    .execute(state.repo.pool())
+    .await
+    .expect("insert project row");
+
+    let request = TransitionRequest::Project(ProjectTransitionRequest::new(
+        uuid::Uuid::new_v4(),
+        project_id,
+        ProjectState::Ready,
+        ProjectState::Processing,
+        TransitionActor::User,
+    ));
+
+    let response =
+        desktop_shell::commands::lifecycle::lifecycle_transition_apply(state.clone(), request)
+            .await
+            .expect("command must not error");
+    assert_eq!(response.status, contracts_core::lifecycle::TransitionStatus::Success);
+
+    let (rows, _) = persistence_db::repositories::manifests::list_manifests_for_project(
+        state.repo.pool(),
+        &project_id.to_string(),
+        None,
+        10,
+    )
+    .await
+    .expect("list_manifests_for_project");
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].reason, "lifecycle_transition");
+    let manifest = app_core::project_manifests::get(state.repo.pool(), &rows[0].id)
+        .await
+        .expect("project_manifests::get");
+    assert_eq!(manifest.manifest.body.lifecycle_state, "processing");
+}
+
 #[tokio::test]
 async fn lifecycle_ledger_list() {
     let db = Database::in_memory().await.expect("in-memory database");

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -2524,7 +2524,13 @@ export type BrokenItemState =
  *  The on-disk materialization kind no longer matches the kind recorded
  *  for this item (spec 026 FR-008 mixed-kind concept, per-item).
  */
-"changed_kind";
+"changed_kind" | 
+/**
+ *  A copy-kind item's destination content no longer matches the
+ *  canonical source (a real file copy, unlike a symlink/hardlink, can
+ *  silently drift — spec 026 FR-009 / #746).
+ */
+"hash_diverged";
 
 /**  Calendar data for the sessions calendar view. */
 export type CalendarData = {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1795,9 +1795,11 @@ export const commands = {
 	 *  `project.manifest.reveal_in_os` — open the manifest file's folder in the
 	 *  OS file manager.
 	 * 
-	 *  Delegates to `tauri-plugin-opener::reveal_item_in_dir`. On Linux, if the
-	 *  opener plugin fails, falls back to `xdg-open` on the parent directory
-	 *  (matching the pattern from `native.reveal`).
+	 *  #716: routes through the shared spec-004 `native.reveal` core
+	 *  (`reveal_with_audit`) instead of reimplementing the opener/xdg-open
+	 *  fallback independently — path validation and `native.reveal.failed`
+	 *  audit-on-failure now apply here too, which the standalone reimplementation
+	 *  never had. The external `Result<(), String>` contract is unchanged.
 	 * 
 	 *  # Errors
 	 *  Returns `Err(String)` when the path does not exist or the OS open fails.

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -17,6 +17,12 @@ export const commands = {
 	/**
 	 *  `lifecycle.transition.apply` Tauri command.
 	 * 
+	 *  #665: on a successful `Project` entity transition, fires the
+	 *  `LifecycleTransition` manifest trigger — this and the source add/remove
+	 *  trigger were the last of the 4 unwired manifest emitters (project create
+	 *  and source add/remove are wired in `app_core_projects`; `workflow_run` was
+	 *  the only one that ever existed).
+	 * 
 	 *  # Errors
 	 *  Never returns `Err`; refusal / persistence errors fold into
 	 *  `TransitionResponse::error(...)` per the contract.

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -42,10 +42,32 @@ import { DetailPanel, PropertyTable, renderValue } from '@/components';
 import { errMessage } from '@/lib/errors';
 import { fieldApplicability } from '@/lib/field-applicability';
 import { m } from '@/lib/i18n';
+import { revealLabel } from '@/lib/reveal-label';
+import { revealInOs } from '@/shared/native/reveal';
 import type { PillVariant } from '@/ui';
 import { Banner, Btn, Pill, Section, Table } from '@/ui';
 import type { InboxClassifyResponse } from './store';
 import { ConeSearchSuggestions } from './ConeSearchSuggestions';
+
+/**
+ * Resolve an inbox item's reveal target: the source root joined with the
+ * item's `relativePath`. Mirrors `features/sessions/revealInventory.ts`'s
+ * `resolveRevealPath` (same tested contract: backend `relativePath` is always
+ * forward-slash-normalized — `crates/app/inbox/src/scan.rs` — while the root
+ * is native, so every separator is rewritten to the root's own). Duplicated
+ * rather than imported to keep this feature's scope self-contained; the two
+ * helpers must stay behaviorally identical if either changes.
+ */
+function resolveInboxRevealPath(
+  rootPath: string,
+  relativePath: string,
+): string {
+  if (!relativePath) return rootPath;
+  const sep = rootPath.includes('\\') ? '\\' : '/';
+  const root = rootPath.replace(/[/\\]+$/, '');
+  const rel = relativePath.replace(/^[/\\]+/, '').replace(/[/\\]+/g, sep);
+  return `${root}${sep}${rel}`;
+}
 
 // ── reclassify_v2 (spec 041 R-13/T068, issue #755) ────────────────────────────
 //
@@ -368,6 +390,7 @@ export interface InboxDetailProps {
 
 export function InboxDetail({
   item,
+  rootAbsolutePath,
   classification,
   fileMetadata,
   onConfirm,
@@ -583,6 +606,23 @@ export function InboxDetail({
 
   const title = item.relativePath || m.inbox_list_root_label();
   const classType = classification?.type ?? 'pending';
+
+  // Reveal this item's location in the OS file browser (#715, spec 004
+  // FR-005/SC-002). No connectivity gate like Sessions (#889): the Inbox
+  // root is the currently-scanned root, always reachable while this pane is
+  // shown.
+  const [revealError, setRevealError] = useState<string | null>(null);
+  const handleReveal = useCallback(async () => {
+    setRevealError(null);
+    try {
+      await revealInOs(
+        resolveInboxRevealPath(rootAbsolutePath, item.relativePath),
+        { entityKind: 'inbox_item', entityId: item.inboxItemId },
+      );
+    } catch {
+      setRevealError(m.inbox_toast_reveal_error());
+    }
+  }, [rootAbsolutePath, item.relativePath, item.inboxItemId]);
 
   // Library picker (point 1): narrow the destination roots to the category that
   // can receive this item's frame type. Only meaningful for a single-type item
@@ -946,6 +986,15 @@ export function InboxDetail({
           </select>
         </label>
       )}
+      {/* Reveal — platform-native label (shared revealLabel() helper, #715). */}
+      <Btn
+        size="sm"
+        onClick={() => void handleReveal()}
+        title={m.inbox_reveal_title()}
+        data-testid="inbox-reveal-btn"
+      >
+        {revealLabel()}
+      </Btn>
     </span>
   );
 
@@ -967,6 +1016,15 @@ export function InboxDetail({
           was clipped by `.alm-listpage__detail-body`'s `overflow: hidden`
           (unreachable, not just unscrolled). */}
       <div className="alm-inbox-detail__scroll">
+        {revealError && (
+          <Banner
+            variant="danger"
+            className="alm-inbox-detail__banner-mt3"
+            data-testid="inbox-reveal-error"
+          >
+            {revealError}
+          </Banner>
+        )}
         {/* Mixed: advisory banner */}
         {classType === 'mixed' && (
           <Banner

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -43,7 +43,8 @@ import { errMessage } from '@/lib/errors';
 import { fieldApplicability } from '@/lib/field-applicability';
 import { m } from '@/lib/i18n';
 import { revealLabel } from '@/lib/reveal-label';
-import { revealInOs } from '@/shared/native/reveal';
+import { copyToClipboard, revealInOs } from '@/shared/native/reveal';
+import { addToast } from '@/shared/toast';
 import type { PillVariant } from '@/ui';
 import { Banner, Btn, Pill, Section, Table } from '@/ui';
 import type { InboxClassifyResponse } from './store';
@@ -610,17 +611,33 @@ export function InboxDetail({
   // Reveal this item's location in the OS file browser (#715, spec 004
   // FR-005/SC-002). No connectivity gate like Sessions (#889): the Inbox
   // root is the currently-scanned root, always reachable while this pane is
-  // shown.
-  const [revealError, setRevealError] = useState<string | null>(null);
+  // shown. On failure, the toast carries a "Copy path" action (#717 FR-010:
+  // `copyToClipboard` was exported with zero call sites anywhere in the app).
   const handleReveal = useCallback(async () => {
-    setRevealError(null);
+    const revealPath = resolveInboxRevealPath(
+      rootAbsolutePath,
+      item.relativePath,
+    );
     try {
-      await revealInOs(
-        resolveInboxRevealPath(rootAbsolutePath, item.relativePath),
-        { entityKind: 'inbox_item', entityId: item.inboxItemId },
-      );
+      await revealInOs(revealPath, {
+        entityKind: 'inbox_item',
+        entityId: item.inboxItemId,
+      });
     } catch {
-      setRevealError(m.inbox_toast_reveal_error());
+      addToast({
+        message: m.inbox_toast_reveal_error(),
+        variant: 'error',
+        action: {
+          label: m.common_copy_path(),
+          onClick: () => {
+            void copyToClipboard(revealPath).then((ok) => {
+              if (ok) {
+                addToast({ message: m.common_path_copied(), variant: 'info' });
+              }
+            });
+          },
+        },
+      });
     }
   }, [rootAbsolutePath, item.relativePath, item.inboxItemId]);
 
@@ -1016,15 +1033,6 @@ export function InboxDetail({
           was clipped by `.alm-listpage__detail-body`'s `overflow: hidden`
           (unreachable, not just unscrolled). */}
       <div className="alm-inbox-detail__scroll">
-        {revealError && (
-          <Banner
-            variant="danger"
-            className="alm-inbox-detail__banner-mt3"
-            data-testid="inbox-reveal-error"
-          >
-            {revealError}
-          </Banner>
-        )}
         {/* Mixed: advisory banner */}
         {classType === 'mixed' && (
           <Banner

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.reveal.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.reveal.test.tsx
@@ -1,0 +1,147 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Issue #715 (spec 004 FR-005/SC-002): Inbox items had no Reveal-in-OS action
+ * anywhere on the surface. InboxDetail now wires the shared `revealInOs`
+ * helper (same one ProjectDetail/ArchivePage/SessionDetail use) behind the
+ * platform-native `revealLabel()` button.
+ *
+ * Tests:
+ * 1. The Reveal button renders with the shared platform-native label.
+ * 2. Clicking it calls `commands.nativeReveal` with the root+relativePath
+ *    joined into a single absolute path and `entityKind: 'inbox_item'`.
+ * 3. A reveal failure surfaces the inbox-scoped error banner (not a crash).
+ */
+import type React from 'react';
+import {
+  render as rtlRender,
+  screen,
+  fireEvent,
+  waitFor,
+} from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+function render(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+import type {
+  InboxItemSummary_Serialize as InboxItemSummary,
+  InboxClassifyResponse_Serialize as InboxClassifyResponse,
+} from '@/bindings';
+
+import { InboxDetail } from '../InboxDetail';
+
+const mockNativeReveal = vi.fn();
+
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const mod = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...mod,
+    commands: {
+      ...mod.commands,
+      nativeReveal: async (...args: unknown[]) => await mockNativeReveal(...args),
+    },
+  };
+});
+
+const sampleItem: InboxItemSummary = {
+  inboxItemId: 'item-001',
+  relativePath: '2025-11-01/NGC891',
+  fileCount: 4,
+  lane: 'fits',
+  format: 'fits',
+  state: 'classified',
+  contentSignature: 'sig-002',
+  isMaster: false,
+  masterFrameType: null,
+  masterFilter: null,
+  masterExposureS: null,
+};
+
+const sampleClassification: InboxClassifyResponse = {
+  inboxItemId: 'item-001',
+  type: 'single_type',
+  frameType: 'light',
+  contentSignature: 'sig-002',
+  breakdown: [
+    { kind: 'light', count: 4, destinationPreview: null, sampleFiles: [] },
+  ],
+  unclassifiedFiles: [],
+  sampleFiles: [],
+  computedAt: '2025-11-01T20:00:00Z',
+};
+
+type ItemProp = Parameters<typeof InboxDetail>[0]['item'];
+type ClassProp = Parameters<typeof InboxDetail>[0]['classification'];
+
+describe('InboxDetail — #715 Reveal-in-OS action', () => {
+  beforeEach(() => {
+    mockNativeReveal.mockReset();
+  });
+
+  it('renders the Reveal button with the shared platform-native label', () => {
+    render(
+      <InboxDetail
+        item={sampleItem as unknown as ItemProp}
+        rootAbsolutePath="/mnt/library/inbox"
+        classification={sampleClassification as unknown as ClassProp}
+      />,
+    );
+    // jsdom reports no platform → the Linux-generic label (matches the
+    // ProjectDetail/SessionDetail convention for the same helper).
+    expect(screen.getByTestId('inbox-reveal-btn')).toHaveTextContent(
+      'Show in file manager',
+    );
+  });
+
+  it('clicking Reveal calls native.reveal with the joined absolute path and inbox_item context', async () => {
+    mockNativeReveal.mockResolvedValue({
+      status: 'ok',
+      data: { revealed: true, selection: 'target' },
+    });
+    render(
+      <InboxDetail
+        item={sampleItem as unknown as ItemProp}
+        rootAbsolutePath="/mnt/library/inbox"
+        classification={sampleClassification as unknown as ClassProp}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('inbox-reveal-btn'));
+
+    await waitFor(() => expect(mockNativeReveal).toHaveBeenCalledTimes(1));
+    const [request] = mockNativeReveal.mock.calls[0] as [
+      { path: string; entityKind: string; entityId: string },
+    ];
+    expect(request.path).toBe('/mnt/library/inbox/2025-11-01/NGC891');
+    expect(request.entityKind).toBe('inbox_item');
+    expect(request.entityId).toBe('item-001');
+  });
+
+  it('surfaces a reveal failure as an inline error banner', async () => {
+    mockNativeReveal.mockResolvedValue({
+      status: 'error',
+      error: { code: 'os.command_failed', message: 'boom' },
+    });
+    render(
+      <InboxDetail
+        item={sampleItem as unknown as ItemProp}
+        rootAbsolutePath="/mnt/library/inbox"
+        classification={sampleClassification as unknown as ClassProp}
+      />,
+    );
+    fireEvent.click(screen.getByTestId('inbox-reveal-btn'));
+
+    expect(await screen.findByTestId('inbox-reveal-error')).toHaveTextContent(
+      'Could not open the location.',
+    );
+  });
+});

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.reveal.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.reveal.test.tsx
@@ -8,11 +8,19 @@
  * helper (same one ProjectDetail/ArchivePage/SessionDetail use) behind the
  * platform-native `revealLabel()` button.
  *
+ * `@/shared/native/reveal` is mocked directly (not the underlying
+ * `commands.nativeReveal` IPC binding) — that helper already owns the
+ * mock-stub-vs-real-Tauri branch (`isTauri()`) and is exercised by its own
+ * unit coverage; these tests assert InboxDetail's own responsibility: which
+ * path/context it passes in, and how it reacts to success/failure.
+ *
  * Tests:
  * 1. The Reveal button renders with the shared platform-native label.
- * 2. Clicking it calls `commands.nativeReveal` with the root+relativePath
- *    joined into a single absolute path and `entityKind: 'inbox_item'`.
- * 3. A reveal failure surfaces the inbox-scoped error banner (not a crash).
+ * 2. Clicking it calls `revealInOs` with the root+relativePath joined into a
+ *    single absolute path and `entityKind: 'inbox_item'`.
+ * 3. A reveal failure surfaces an error toast carrying a "Copy path" action
+ *    (#717 FR-010: `copyToClipboard` was exported with zero call sites).
+ * 4. Invoking that action copies the resolved path and confirms via toast.
  */
 import type React from 'react';
 import {
@@ -40,18 +48,18 @@ import type {
 
 import { InboxDetail } from '../InboxDetail';
 
-const mockNativeReveal = vi.fn();
+const mockRevealInOs = vi.fn();
+const mockCopyToClipboard = vi.fn();
+const mockAddToast = vi.fn();
 
-vi.mock('@/bindings/index', async (importOriginal) => {
-  const mod = await importOriginal<typeof import('@/bindings/index')>();
-  return {
-    ...mod,
-    commands: {
-      ...mod.commands,
-      nativeReveal: async (...args: unknown[]) => await mockNativeReveal(...args),
-    },
-  };
-});
+vi.mock('@/shared/native/reveal', () => ({
+  revealInOs: (...args: unknown[]) => mockRevealInOs(...args),
+  copyToClipboard: (...args: unknown[]) => mockCopyToClipboard(...args),
+}));
+
+vi.mock('@/shared/toast', () => ({
+  addToast: (...args: unknown[]) => mockAddToast(...args),
+}));
 
 const sampleItem: InboxItemSummary = {
   inboxItemId: 'item-001',
@@ -67,13 +75,16 @@ const sampleItem: InboxItemSummary = {
   masterExposureS: null,
 };
 
+// frameType deliberately non-"light": a light classification mounts
+// `ConeSearchSuggestions`, which makes its own unrelated IPC call — avoiding
+// it here keeps this file scoped to the Reveal action alone.
 const sampleClassification: InboxClassifyResponse = {
   inboxItemId: 'item-001',
   type: 'single_type',
-  frameType: 'light',
+  frameType: 'dark',
   contentSignature: 'sig-002',
   breakdown: [
-    { kind: 'light', count: 4, destinationPreview: null, sampleFiles: [] },
+    { kind: 'dark', count: 4, destinationPreview: null, sampleFiles: [] },
   ],
   unclassifiedFiles: [],
   sampleFiles: [],
@@ -85,7 +96,9 @@ type ClassProp = Parameters<typeof InboxDetail>[0]['classification'];
 
 describe('InboxDetail — #715 Reveal-in-OS action', () => {
   beforeEach(() => {
-    mockNativeReveal.mockReset();
+    mockRevealInOs.mockReset();
+    mockCopyToClipboard.mockReset();
+    mockAddToast.mockReset();
   });
 
   it('renders the Reveal button with the shared platform-native label', () => {
@@ -103,11 +116,8 @@ describe('InboxDetail — #715 Reveal-in-OS action', () => {
     );
   });
 
-  it('clicking Reveal calls native.reveal with the joined absolute path and inbox_item context', async () => {
-    mockNativeReveal.mockResolvedValue({
-      status: 'ok',
-      data: { revealed: true, selection: 'target' },
-    });
+  it('clicking Reveal calls revealInOs with the joined absolute path and inbox_item context', async () => {
+    mockRevealInOs.mockResolvedValue({ revealed: true, selection: 'target' });
     render(
       <InboxDetail
         item={sampleItem as unknown as ItemProp}
@@ -117,20 +127,18 @@ describe('InboxDetail — #715 Reveal-in-OS action', () => {
     );
     fireEvent.click(screen.getByTestId('inbox-reveal-btn'));
 
-    await waitFor(() => expect(mockNativeReveal).toHaveBeenCalledTimes(1));
-    const [request] = mockNativeReveal.mock.calls[0] as [
-      { path: string; entityKind: string; entityId: string },
+    await waitFor(() => expect(mockRevealInOs).toHaveBeenCalledTimes(1));
+    const [path, ctx] = mockRevealInOs.mock.calls[0] as [
+      string,
+      { entityKind: string; entityId: string },
     ];
-    expect(request.path).toBe('/mnt/library/inbox/2025-11-01/NGC891');
-    expect(request.entityKind).toBe('inbox_item');
-    expect(request.entityId).toBe('item-001');
+    expect(path).toBe('/mnt/library/inbox/2025-11-01/NGC891');
+    expect(ctx.entityKind).toBe('inbox_item');
+    expect(ctx.entityId).toBe('item-001');
   });
 
-  it('surfaces a reveal failure as an inline error banner', async () => {
-    mockNativeReveal.mockResolvedValue({
-      status: 'error',
-      error: { code: 'os.command_failed', message: 'boom' },
-    });
+  it('surfaces a reveal failure as an error toast with a Copy-path action', async () => {
+    mockRevealInOs.mockRejectedValue(new Error('boom'));
     render(
       <InboxDetail
         item={sampleItem as unknown as ItemProp}
@@ -140,8 +148,43 @@ describe('InboxDetail — #715 Reveal-in-OS action', () => {
     );
     fireEvent.click(screen.getByTestId('inbox-reveal-btn'));
 
-    expect(await screen.findByTestId('inbox-reveal-error')).toHaveTextContent(
-      'Could not open the location.',
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledTimes(1));
+    const [toastArg] = mockAddToast.mock.calls[0] as [
+      { message: string; variant: string; action?: { label: string } },
+    ];
+    expect(toastArg.message).toBe('Could not open the location.');
+    expect(toastArg.variant).toBe('error');
+    expect(toastArg.action?.label).toBe('Copy path');
+  });
+
+  it('the Copy-path action copies the resolved absolute path', async () => {
+    mockRevealInOs.mockRejectedValue(new Error('boom'));
+    mockCopyToClipboard.mockResolvedValue(true);
+
+    render(
+      <InboxDetail
+        item={sampleItem as unknown as ItemProp}
+        rootAbsolutePath="/mnt/library/inbox"
+        classification={sampleClassification as unknown as ClassProp}
+      />,
     );
+    fireEvent.click(screen.getByTestId('inbox-reveal-btn'));
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledTimes(1));
+
+    const [toastArg] = mockAddToast.mock.calls[0] as [
+      { action?: { onClick: () => void } },
+    ];
+    toastArg.action?.onClick();
+
+    await waitFor(() =>
+      expect(mockCopyToClipboard).toHaveBeenCalledWith(
+        '/mnt/library/inbox/2025-11-01/NGC891',
+      ),
+    );
+    await waitFor(() => expect(mockAddToast).toHaveBeenCalledTimes(2));
+    expect(mockAddToast.mock.calls[1][0]).toMatchObject({
+      message: 'Path copied to clipboard.',
+      variant: 'info',
+    });
   });
 });

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -698,6 +698,30 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
     expect(unlinkedRow).toHaveTextContent('None');
   });
 
+  // #761 (spec 049 FR-004): a generation/regeneration plan item's resolved
+  // link kind (materialization provenance) is on the contract already —
+  // the review UI never rendered it before approval.
+  it("renders each item's resolved link kind from provenance (#761)", async () => {
+    mockPlansGet.mockResolvedValue(
+      ok(
+        plan({
+          items: [
+            item({
+              provenance: [{ label: 'materialization', value: 'copy' }],
+            }),
+            // No provenance at all (e.g. an archive/cleanup plan item) —
+            // must render "None", not blank or crash.
+            item({ id: 'item-1', index: 1, name: 'raw_002.fits' }),
+          ],
+        }),
+      ),
+    );
+    renderOverlay();
+    expect(await screen.findByText('copy')).toBeInTheDocument();
+    const noProvenanceRow = screen.getByTestId('plan-review-item-1');
+    expect(noProvenanceRow).toHaveTextContent('None');
+  });
+
   // FR-011 (issue #733): a plan reopened from a prior session has no
   // session-local `finalState` — the footer must key off the persisted
   // `plan.state` instead of always rendering the pre-apply pair (which the

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -89,6 +89,20 @@ function resultPillVariant(state: PlanItemDetail_Serialize['state']) {
   }
 }
 
+/**
+ * #761 (spec 049 FR-004): the resolved per-item link kind (symlink/junction/
+ * copy/hardlink), when this item carries one. Generation/regeneration plans
+ * (`source_view_generate.rs`/`prepared_views.rs::regenerate_prepared_view`)
+ * attach it as a `materialization` provenance entry — the only way today to
+ * show the user, before apply, what capability was actually resolved for
+ * each item (the contract data already existed; the review UI never read it).
+ */
+function linkKind(item: PlanItemDetail_Serialize): string | null {
+  return (
+    item.provenance?.find((p) => p.label === 'materialization')?.value ?? null
+  );
+}
+
 function destinationLabel(plan: PlanDetail_Serialize): string {
   // DTO enum is `archive | os_trash` (the DB canonical vocabulary is
   // `archive | trash`; plans.get maps trash → os_trash).
@@ -335,6 +349,7 @@ export function PlanReviewOverlay({
     { key: 'from', label: m.plans_review_col_from() },
     { key: 'to', label: m.plans_review_col_to() },
     { key: 'protection', label: m.plans_review_col_protection() },
+    { key: 'linkKind', label: m.plans_review_col_link_kind() },
     { key: 'result', label: m.plans_review_col_result() },
     { key: 'reason', label: m.plans_review_col_reason() },
     { key: 'linked', label: m.plans_review_col_linked() },
@@ -367,6 +382,12 @@ export function PlanReviewOverlay({
       ) : (
         <Pill variant="ghost">{m.settings_cleanup_protection_normal()}</Pill>
       ),
+    // #761: per-item resolved link kind (generation/regeneration plans
+    // only); blank for every other plan type — matches the `linked` column's
+    // existing not-applicable convention.
+    linkKind: linkKind(item) ?? (
+      <span className="alm-cell--muted">{m.common_none()}</span>
+    ),
     // #607: per-item apply outcome, so a partial failure is diagnosable
     // without re-running the plan. `pending` (never attempted, e.g. the plan
     // hasn't been applied yet) shows a muted dash rather than a pill.

--- a/apps/desktop/src/features/projects/source-views.ts
+++ b/apps/desktop/src/features/projects/source-views.ts
@@ -123,7 +123,8 @@ export type BrokenItemState =
   | 'missing'
   | 'moved'
   | 'unresolved_link'
-  | 'changed_kind';
+  | 'changed_kind'
+  | 'hash_diverged';
 
 /** One broken/missing/stale item reported by `sourceview.verify`. */
 export interface BrokenItem {
@@ -322,6 +323,8 @@ export function brokenItemStateLabel(state: BrokenItemState): string {
       return m.projects_source_views_verify_state_unresolved_link();
     case 'changed_kind':
       return m.projects_source_views_verify_state_changed_kind();
+    case 'hash_diverged':
+      return m.projects_source_views_verify_state_hash_diverged();
     default:
       return state;
   }

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -188,6 +188,64 @@ fn db_err(e: DbError) -> ContractError {
 
 // ── Source view generation finalization (spec 049) ───────────────────────────
 
+/// Terminal step of a `project_create` plan apply: fire the `Created`
+/// manifest trigger (#665 — this and the source add/remove triggers had no
+/// emitters at all; only the unrelated `workflow.run_completed` trigger was
+/// wired). The project's folder structure (including `notes/`) only exists
+/// on disk once this plan applies, so this is the earliest point the write
+/// can succeed.
+///
+/// `origin_path` on a `project_create` plan is the project's filesystem
+/// path, not its id (unlike every other plan origin) — recovered via
+/// `projects::path_exists`.
+///
+/// Best-effort: the project already exists, so a manifest failure here must
+/// NOT fail the apply. Every failure is logged for an external watchdog (§II).
+async fn finalize_project_create_manifest(pool: &SqlitePool, bus: &EventBus, project_path: &str) {
+    use app_core_projects::project_manifests::{
+        build_source_calibration_snapshot, write, WriteManifestParams,
+    };
+    use contracts_core::manifests::ManifestReason as DtoManifestReason;
+    use persistence_db::repositories::projects as projects_repo;
+
+    let project_id = match projects_repo::path_exists(pool, project_path, None).await {
+        Ok(Some(id)) => id,
+        Ok(None) => {
+            tracing::warn!(%project_path, "project_create manifest: no project at this path");
+            return;
+        }
+        Err(e) => {
+            tracing::warn!(%project_path, error=%e, "project_create manifest: path lookup failed");
+            return;
+        }
+    };
+    let lifecycle = match projects_repo::get_project(pool, &project_id).await {
+        Ok(row) => row.lifecycle,
+        Err(e) => {
+            tracing::warn!(%project_id, error=%e, "project_create manifest: project lookup failed");
+            return;
+        }
+    };
+    let (source_map, calibration) = build_source_calibration_snapshot(pool, &project_id).await;
+    let result = write(
+        pool,
+        bus,
+        WriteManifestParams {
+            project_id: &project_id,
+            reason: DtoManifestReason::Created,
+            project_root: std::path::Path::new(project_path),
+            lifecycle_state: &lifecycle,
+            source_map,
+            calibration,
+            workflow_profile: None,
+        },
+    )
+    .await;
+    if let Err(e) = result {
+        tracing::warn!(%project_id, error=%e, "project_create manifest write failed");
+    }
+}
+
 /// Terminal step of a `prepared_view_generation` plan apply: write the
 /// first-materialization `PreparedSourceView` (state `current`) plus one
 /// `PreparedSourceViewItem` per successfully-applied `link` item.
@@ -1339,6 +1397,15 @@ fn spawn_executor_run(params: SpawnExecutorParams) {
                 if terminal == "applied" && plan_origin == "archive" {
                     if let Some(project_id) = plan_project_id.as_deref() {
                         finalize_archive_lifecycle(&pool, &bus, &plan_id, project_id).await;
+                    }
+                }
+
+                // #665: on a fully-applied project_create plan, fire the
+                // Created manifest trigger — see finalize_project_create_manifest
+                // for why origin_path is the project's PATH here, not its id.
+                if terminal == "applied" && plan_origin == "project" {
+                    if let Some(project_path) = plan_project_id.as_deref() {
+                        finalize_project_create_manifest(&pool, &bus, project_path).await;
                     }
                 }
 
@@ -2619,6 +2686,42 @@ mod tests {
         let archived = projects_repo::list_archived_projects(db.pool()).await.unwrap();
         assert_eq!(archived.len(), 1);
         assert_eq!(archived[0].archived_via_plan_id.as_deref(), Some("plan-arch-1"));
+    }
+
+    /// #665: a fully-applied `project_create` plan must fire the `Created`
+    /// manifest trigger — previously there was no emitter at all for it.
+    #[tokio::test]
+    async fn finalize_project_create_manifest_writes_created_manifest() {
+        use persistence_db::repositories::manifests::list_manifests_for_project;
+        use persistence_db::repositories::projects as projects_repo;
+
+        let (db, bus) = setup().await;
+        let dir = tempfile::tempdir().unwrap();
+        let project_id = Uuid::new_v4().to_string();
+        projects_repo::insert_project(
+            db.pool(),
+            &projects_repo::InsertProject {
+                id: &project_id,
+                name: "M31 LRGB",
+                tool: "PixInsight",
+                lifecycle: "setup_incomplete",
+                path: dir.path().to_str().unwrap(),
+                notes: None,
+                canonical_target_id: None,
+                is_mosaic: false,
+            },
+        )
+        .await
+        .unwrap();
+
+        finalize_project_create_manifest(db.pool(), &bus, dir.path().to_str().unwrap()).await;
+
+        let (rows, _) = list_manifests_for_project(db.pool(), &project_id, None, 10).await.unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].reason, "created");
+        let manifest =
+            app_core_projects::project_manifests::get(db.pool(), &rows[0].id).await.unwrap();
+        assert_eq!(manifest.manifest.body.lifecycle_state, "setup_incomplete");
     }
 
     /// An already-archived project is idempotent: the closure only (re)records

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -202,9 +202,6 @@ fn db_err(e: DbError) -> ContractError {
 /// Best-effort: the project already exists, so a manifest failure here must
 /// NOT fail the apply. Every failure is logged for an external watchdog (§II).
 async fn finalize_project_create_manifest(pool: &SqlitePool, bus: &EventBus, project_path: &str) {
-    use app_core_projects::project_manifests::{
-        build_source_calibration_snapshot, write, WriteManifestParams,
-    };
     use contracts_core::manifests::ManifestReason as DtoManifestReason;
     use persistence_db::repositories::projects as projects_repo;
 
@@ -219,31 +216,13 @@ async fn finalize_project_create_manifest(pool: &SqlitePool, bus: &EventBus, pro
             return;
         }
     };
-    let lifecycle = match projects_repo::get_project(pool, &project_id).await {
-        Ok(row) => row.lifecycle,
-        Err(e) => {
-            tracing::warn!(%project_id, error=%e, "project_create manifest: project lookup failed");
-            return;
-        }
-    };
-    let (source_map, calibration) = build_source_calibration_snapshot(pool, &project_id).await;
-    let result = write(
+    app_core_projects::project_manifests::write_lifecycle_manifest(
         pool,
         bus,
-        WriteManifestParams {
-            project_id: &project_id,
-            reason: DtoManifestReason::Created,
-            project_root: std::path::Path::new(project_path),
-            lifecycle_state: &lifecycle,
-            source_map,
-            calibration,
-            workflow_profile: None,
-        },
+        &project_id,
+        DtoManifestReason::Created,
     )
     .await;
-    if let Err(e) = result {
-        tracing::warn!(%project_id, error=%e, "project_create manifest write failed");
-    }
 }
 
 /// Terminal step of a `prepared_view_generation` plan apply: write the

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -39,8 +39,8 @@ use contracts_core::tools::{
 };
 use domain_core::ids::{new_id, Timestamp};
 use persistence_db::repositories::{
-    first_run as first_run_repo, inventory as inv_repo, projects as proj_repo,
-    settings as settings_repo, tool_launches as tl_repo,
+    first_run as first_run_repo, inventory as inv_repo, prepared_source_views as psv_repo,
+    projects as proj_repo, settings as settings_repo, tool_launches as tl_repo,
 };
 use project_structure::resolve_working_folder;
 use sqlx::SqlitePool;
@@ -129,6 +129,48 @@ fn compute_args_hash(executable_path: &str, argv: &[String]) -> String {
     hex::encode(hasher.finalize())
 }
 
+// ── Active source-view folder resolution (#726, spec 011 FR-009) ──────────────
+
+/// Resolve the project's currently active generated source-view folder, if
+/// one exists (spec 049 restored real generation via `prepared_source_views`;
+/// this was hardcoded to `None` — every launch silently fell back to the
+/// project root even when a real generated view existed).
+///
+/// `prepared_source_view_items.view_relative_path` is, despite its name, an
+/// ABSOLUTE path (`source_view_generate.rs`'s `dest_abs`, forward-slash
+/// portable) — there is no separate stored "destination root" column, so the
+/// folder is recovered as the longest common path-prefix across the view's
+/// items. With a single-item view this returns that file's immediate parent
+/// rather than a possibly-shallower destination root; an acceptable best
+/// effort given the schema has no dedicated root column.
+async fn resolve_active_source_view_folder(pool: &SqlitePool, project_id: &str) -> Option<String> {
+    let views = psv_repo::list_views_for_project(pool, project_id).await.ok()?;
+    let view = views.into_iter().find(|v| v.state == "current")?;
+    let items = psv_repo::list_view_items(pool, &view.id).await.ok()?;
+    common_ancestor_dir(items.iter().map(|i| i.view_relative_path.as_str()))
+}
+
+/// Longest common directory prefix (forward-slash-segmented) across `paths`.
+/// Returns `None` for zero paths.
+fn common_ancestor_dir<'a>(paths: impl Iterator<Item = &'a str>) -> Option<String> {
+    let mut common: Option<Vec<&str>> = None;
+    for p in paths {
+        let segments: Vec<&str> = p.split('/').collect();
+        // Drop the file name — only directory segments participate in the prefix.
+        let dir_segments = &segments[..segments.len().saturating_sub(1)];
+        common = Some(match common {
+            None => dir_segments.to_vec(),
+            Some(prev) => prev
+                .iter()
+                .zip(dir_segments.iter())
+                .take_while(|(a, b)| a == b)
+                .map(|(a, _)| *a)
+                .collect(),
+        });
+    }
+    common.filter(|c| !c.is_empty()).map(|c| c.join("/"))
+}
+
 // ── launch ────────────────────────────────────────────────────────────────────
 
 /// Launch the configured processing tool for the given project.
@@ -210,10 +252,12 @@ pub async fn launch(
     };
 
     // ── Step 3: resolve working directory ────────────────────────────────────
-    // `project.path` is the project root. Source-view folder is not stored on
-    // the project row in v1 (spec 026 owns that); pass `None` to fall back to root.
+    // `project.path` is the project root. Prefer the project's active
+    // generated source-view folder when one exists (spec 049 restored real
+    // generation, #726); fall back to the project root otherwise.
     let project_root = std::path::PathBuf::from(&project.path);
-    let working_dir_path = resolve_working_folder(&project_root, None);
+    let active_source_view = resolve_active_source_view_folder(pool, &req.project_id).await;
+    let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref());
 
     // ── Step 4: canonicalize cwd + library-root containment check ────────────
     let canonical_cwd = working_dir_path.canonicalize().unwrap_or(working_dir_path.clone());
@@ -667,6 +711,67 @@ mod tests {
         assert_eq!(calls[0].executable, "/usr/bin/pixinsight");
     }
 
+    /// #726 (spec 011 FR-009): launch must pass the project's active
+    /// generated source-view folder, not silently fall back to the project
+    /// root just because one exists.
+    #[tokio::test]
+    async fn launch_uses_active_source_view_folder_when_present() {
+        let db = setup_db().await;
+        let project_id = make_project(&db).await;
+        let bus = make_bus(db.pool().clone());
+        let spawner = FakeSpawner::ok();
+        insert_root(&db, "/mnt/library").await;
+        set_tool_path(&db, "siril", "/usr/bin/siril").await;
+
+        psv_repo::insert_view(
+            db.pool(),
+            &psv_repo::InsertPreparedSourceView {
+                id: "view-1",
+                project_id: &project_id,
+                kind: "symlink",
+            },
+        )
+        .await
+        .unwrap();
+        let view_dir = "/mnt/library/test_project/source-views/plan-1/2026-01-01/L";
+        for (idx, name) in ["light1.fits", "light2.fits"].iter().enumerate() {
+            psv_repo::insert_view_item(
+                db.pool(),
+                &psv_repo::InsertPreparedSourceViewItem {
+                    id: &format!("item-{idx}"),
+                    view_id: "view-1",
+                    inventory_item_id: &format!("inv-{idx}"),
+                    view_relative_path: &format!("{view_dir}/{name}"),
+                    materialization: "symlink",
+                },
+            )
+            .await
+            .unwrap();
+        }
+
+        let req = ToolLaunchRequest { project_id, tool_id: "siril".to_owned(), force: false };
+        let resp = launch(db.pool(), &bus, &spawner, req).await.unwrap();
+        assert_eq!(resp.status, ToolLaunchStatus::Success);
+        assert_eq!(resp.working_dir.as_deref(), Some(view_dir));
+    }
+
+    /// No generated view exists — must fall back to the project root exactly
+    /// as before (regression guard for the #726 fix).
+    #[tokio::test]
+    async fn launch_falls_back_to_project_root_without_a_view() {
+        let db = setup_db().await;
+        let project_id = make_project(&db).await;
+        let bus = make_bus(db.pool().clone());
+        let spawner = FakeSpawner::ok();
+        insert_root(&db, "/mnt/library").await;
+        set_tool_path(&db, "siril", "/usr/bin/siril").await;
+
+        let req = ToolLaunchRequest { project_id, tool_id: "siril".to_owned(), force: false };
+        let resp = launch(db.pool(), &bus, &spawner, req).await.unwrap();
+        assert_eq!(resp.status, ToolLaunchStatus::Success);
+        assert_eq!(resp.working_dir.as_deref(), Some("/mnt/library/test_project"));
+    }
+
     /// Wizard-registered roots live in `registered_sources` only (they are
     /// mirrored into `library_root` on ingest, which never happens for a
     /// project folder). Containment must accept them, or every launch from a
@@ -765,10 +870,12 @@ mod tests {
     async fn list_profiles_returns_all_seeds() {
         let db = setup_db().await;
         let resp = list_profiles(db.pool()).await.unwrap();
-        assert_eq!(resp.tools.len(), 2);
+        // #725: seed::all() now also includes Planetary Suite.
+        assert_eq!(resp.tools.len(), 3);
         let ids: Vec<&str> = resp.tools.iter().map(|t| t.id.as_str()).collect();
         assert!(ids.contains(&"pixinsight"));
         assert!(ids.contains(&"siril"));
+        assert!(ids.contains(&"planetary_suite"));
     }
 
     #[tokio::test]

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -23,6 +23,7 @@ fs_inventory = { path = "../../fs/inventory" }
 patterns = { path = "../../patterns" }
 persistence_db = { path = "../../persistence/db" }
 project_structure = { path = "../../project/structure" }
+sha2.workspace = true
 simbad-resolver = "0.3.0"
 workflow_profiles = { path = "../../workflow/profiles" }
 serde_json.workspace = true

--- a/crates/app/projects/src/prepared_views.rs
+++ b/crates/app/projects/src/prepared_views.rs
@@ -19,8 +19,11 @@
 //!   `destructiveDestination` field is accepted.
 //! - R-026-Strategies: only `symlink`, `junction`, `copy` are supported in v1.
 //!   `hardlink` is refused with `view.unsupported_kind`.
-//! - FR-008 / A2: `view.mixed_kind` is returned when `PreparedSourceView.kind`
-//!   disagrees with any item's `materialization`.
+//! - FR-008 (amended by spec 049 CL-2, 2026-07-04): a view whose items carry
+//!   more than one recorded kind is VALID — per-item kind is authoritative.
+//!   `view.mixed_kind` is reserved for the `kind_diverged` STATE only (a
+//!   distinct, explicit terminal state requiring manual resolution via the
+//!   UI), never for a plain per-item/view kind mismatch (#745).
 //! - A4: removed views are never hard-deleted; regeneration always available.
 //! - R-026-Pipeline: the plan enters the standard spec 017/025 review pipeline.
 //! - T004 invariant: plan actions are restricted to recorded view paths only.
@@ -172,7 +175,9 @@ pub async fn list_views(
 /// 1. Project lifecycle is in the allowed set (not `archived`).
 /// 2. View exists and is not in `kind_diverged` state.
 /// 3. All items use a v1-supported kind (not `hardlink`).
-/// 4. `view.kind` matches every item's `materialization` (A2 / FR-008).
+///
+/// A view whose items carry more than one recorded kind is NOT refused here
+/// (spec 049 CL-2 amended FR-008 — per-item kind is authoritative; #745).
 ///
 /// The produced plan has:
 /// - `origin = "prepared_view_removal"`
@@ -220,19 +225,9 @@ pub async fn remove_prepared_view(
         ));
     }
 
-    // 6. Refuse mixed-kind views (A2 / FR-008).
-    let kind_mismatch = items.iter().any(|i| i.materialization != view_row.kind);
-    if kind_mismatch {
-        return Err(ContractError::new(
-            ErrorCode::ViewMixedKind,
-            "The view contains items whose materialization kind does not match the \
-             view's recorded kind. Resolve the mismatch before removing.",
-            ErrorSeverity::Blocking,
-            false,
-        ));
-    }
-
-    // 7. Build the removal plan.
+    // 6. Build the removal plan. (A per-item/view kind mismatch is a VALID
+    //    state since spec 049 CL-2 amended FR-008 — it is intentionally NOT
+    //    refused here; see the module doc and #745.)
     let plan_id = new_id();
     let title = format!("Remove source view {view_id}");
 
@@ -252,7 +247,7 @@ pub async fn remove_prepared_view(
     .await
     .map_err(|e| db_internal_ctx(e, "insert prepared view plan"))?;
 
-    // 8. One archive action per item, targeting only the view's recorded paths
+    // 7. One archive action per item, targeting only the view's recorded paths
     //    (T004: actions restricted to view membership — no inventory paths).
     //    T005/T008: archive_path is pre-computed (see compute_archive_destination)
     //    — without it the executor's `to_relative_path` fallback is empty and
@@ -288,7 +283,7 @@ pub async fn remove_prepared_view(
         .map_err(|e| db_internal_ctx(e, "insert prepared view plan item"))?;
     }
 
-    // 9. Advance plan to ready_for_review so it appears in the review UI.
+    // 8. Advance plan to ready_for_review so it appears in the review UI.
     plans_repo::update_plan_state(pool, &plan_id, "ready_for_review")
         .await
         .map_err(|e| db_internal_ctx(e, "advance prepared view plan to ready_for_review"))?;
@@ -561,6 +556,43 @@ mod tests {
         assert_eq!(items[0].action, "archive");
         // linked_entity must point to the view, not to inventory.
         assert_eq!(items[0].linked_entity.as_deref(), Some("view-inv"));
+    }
+
+    /// #745 (spec 049 CL-2 amending FR-008): a per-item materialization that
+    /// differs from the view's own recorded `kind` is a VALID state — this
+    /// is exactly what `finalize_view_generation`'s drive-scope resolution
+    /// produces for a cross-drive project. Removal must NOT refuse it.
+    #[tokio::test]
+    async fn remove_allows_view_with_per_item_kind_mismatch() {
+        let db = setup().await;
+        insert_project(&db, "p-mixed", "ready").await;
+        views_repo::insert_view(
+            db.pool(),
+            &views_repo::InsertPreparedSourceView {
+                id: "view-mixed",
+                project_id: "p-mixed",
+                kind: "symlink",
+            },
+        )
+        .await
+        .unwrap();
+        // Item's own materialization ("copy") disagrees with the view's
+        // dominant recorded kind ("symlink") — the per-49 CL-2 valid case.
+        views_repo::insert_view_item(
+            db.pool(),
+            &views_repo::InsertPreparedSourceViewItem {
+                id: "view-mixed-item-1",
+                view_id: "view-mixed",
+                inventory_item_id: "inv-1",
+                view_relative_path: "Sources/cross_drive.fit",
+                materialization: "copy",
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = remove_prepared_view(db.pool(), "view-mixed").await.unwrap();
+        assert!(!resp.plan_id.is_empty());
     }
 
     #[tokio::test]

--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -275,6 +275,73 @@ pub async fn write(
     Ok(relative_path)
 }
 
+// ── Source-map / calibration snapshot (#740) ───────────────────────────────────
+
+/// Build the `source_map`/`calibration` snapshot for a manifest body from the
+/// project's currently-linked sources and their calibration assignments.
+///
+/// FR-001 requires manifests to "document project source mappings [and]
+/// calibration choices" — `spawn_workflow_run_subscriber` previously always
+/// passed `None` for both, the only trigger a real user ever exercises
+/// (#665 tracks the other 4 triggers being unwired).
+async fn build_source_calibration_snapshot(
+    pool: &SqlitePool,
+    project_id: &str,
+) -> (Option<serde_json::Value>, Option<serde_json::Value>) {
+    use persistence_db::repositories::{calibration_assignment, projects as projects_repo};
+
+    let sources = match projects_repo::list_project_sources(pool, project_id).await {
+        Ok(s) => s,
+        Err(e) => {
+            tracing::debug!("manifest snapshot: failed to list project sources: {e}");
+            return (None, None);
+        }
+    };
+    if sources.is_empty() {
+        return (None, None);
+    }
+
+    let source_map = serde_json::Value::Array(
+        sources
+            .iter()
+            .map(|s| {
+                serde_json::json!({
+                    "sourceId": s.id,
+                    "inventorySessionId": s.inventory_session_id,
+                    "name": s.name_snapshot,
+                })
+            })
+            .collect(),
+    );
+
+    let mut calibration_entries = Vec::new();
+    for s in &sources {
+        match calibration_assignment::list_for_session(pool, &s.inventory_session_id).await {
+            Ok(assignments) => {
+                calibration_entries.extend(assignments.into_iter().map(|a| {
+                    serde_json::json!({
+                        "sessionId": a.session_id,
+                        "calibrationType": a.calibration_type,
+                        "masterId": a.master_id,
+                        "confidence": a.confidence,
+                        "wasOverride": a.was_override,
+                    })
+                }));
+            }
+            Err(e) => {
+                tracing::debug!(
+                    "manifest snapshot: failed to list calibration for session {}: {e}",
+                    s.inventory_session_id
+                );
+            }
+        }
+    }
+    let calibration =
+        (!calibration_entries.is_empty()).then_some(serde_json::Value::Array(calibration_entries));
+
+    (Some(source_map), calibration)
+}
+
 // ── workflow_run_completed subscriber ─────────────────────────────────────────
 
 /// Spawn an event-bus subscriber that listens for `workflow.run_completed`
@@ -306,9 +373,12 @@ pub fn spawn_workflow_run_subscriber(
                         env.payload.get("toolId").and_then(|v| v.as_str()).map(str::to_owned);
 
                     if let Some(pid) = project_id {
-                        // Async DB lookup: resolve project root from projects.path.
-                        let project_root = match get_project(&pool, &pid).await {
-                            Ok(row) => Some(std::path::PathBuf::from(&row.path)),
+                        // Async DB lookup: resolve project root + real lifecycle
+                        // state from the project row (#740 — this used to be
+                        // hardcoded "unknown", the one manifest a real user can
+                        // ever get failing FR-001's lifecycle-state requirement).
+                        let project_row = match get_project(&pool, &pid).await {
+                            Ok(row) => Some(row),
                             Err(e) => {
                                 tracing::debug!(
                                     "workflow.run_completed: could not look up project {pid}: {e}; skipping manifest"
@@ -317,7 +387,10 @@ pub fn spawn_workflow_run_subscriber(
                             }
                         };
 
-                        if let Some(project_root) = project_root {
+                        if let Some(row) = project_row {
+                            let project_root = std::path::PathBuf::from(&row.path);
+                            let (source_map, calibration) =
+                                build_source_calibration_snapshot(&pool, &pid).await;
                             // Best-effort: log but do not crash the subscriber.
                             let result = write(
                                 &pool,
@@ -326,9 +399,9 @@ pub fn spawn_workflow_run_subscriber(
                                     project_id: &pid,
                                     reason: DtoManifestReason::WorkflowRun,
                                     project_root: &project_root,
-                                    lifecycle_state: "unknown",
-                                    source_map: None,
-                                    calibration: None,
+                                    lifecycle_state: &row.lifecycle,
+                                    source_map,
+                                    calibration,
                                     workflow_profile: tool_id,
                                 },
                             )
@@ -591,7 +664,98 @@ mod tests {
                 assert_eq!(rows[0].reason, "workflow_run");
                 let abs_path = dir.path().join(&rows[0].path);
                 assert!(abs_path.exists(), "manifest file should exist at {}", abs_path.display());
+                // #740: lifecycle_state must be the project's REAL lifecycle
+                // ("ready", from the inserted row), never the hardcoded "unknown".
+                let resp = get(&pool, &rows[0].id).await.unwrap();
+                assert_eq!(resp.manifest.body.lifecycle_state, "ready");
                 return; // success
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "manifest row not found within 2 s after workflow.run_completed event"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// #740: a project with a linked source (and a calibration assignment for
+    /// that source's session) must produce a manifest whose body actually
+    /// documents them, not `source_map: null, calibration: null` forever.
+    #[tokio::test]
+    async fn workflow_run_subscriber_documents_source_map_and_calibration() {
+        let pool = setup().await;
+        let dir = tempfile::tempdir().unwrap();
+        sqlx::query(
+            "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+             VALUES (?,?,?,?,?,?,?,?,?)",
+        )
+        .bind("proj-snap-1")
+        .bind("SnapTest")
+        .bind("PixInsight")
+        .bind("ready")
+        .bind(dir.path().to_str().unwrap())
+        .bind::<Option<String>>(None)
+        .bind(false)
+        .bind("2026-01-01T00:00:00Z")
+        .bind("2026-01-01T00:00:00Z")
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO project_sources (id, project_id, inventory_session_id, name_snapshot, frames_snapshot, filter_snapshot, exposure_snapshot, linked_at)
+             VALUES ('src-1', 'proj-snap-1', 'sess-1', 'M31 Lum', 42, 'L', '300', '2026-01-01T00:00:00Z')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        persistence_db::repositories::calibration_assignment::upsert(
+            &pool,
+            persistence_db::repositories::calibration_assignment::UpsertParams {
+                id: "calib-1",
+                session_id: "sess-1",
+                calibration_type: "dark",
+                master_id: "master-1",
+                confidence: 0.95,
+                was_override: false,
+                mismatched_dimensions: &[],
+                assigned_at: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let bus = make_bus(&pool);
+        let _handle = spawn_workflow_run_subscriber(pool.clone(), bus.clone());
+        let _ = bus
+            .publish(
+                "workflow.run_completed",
+                audit::event_bus::Source::System,
+                serde_json::json!({
+                    "projectId": "proj-snap-1",
+                    "toolId": "pixinsight",
+                    "toolLaunchId": "tl-snap-1",
+                    "completedAt": "2026-06-01T10:00:00Z",
+                    "artifactIds": [],
+                }),
+            )
+            .await;
+
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let (rows, _) =
+                list_manifests_for_project(&pool, "proj-snap-1", None, 10).await.unwrap();
+            if !rows.is_empty() {
+                let resp = get(&pool, &rows[0].id).await.unwrap();
+                let source_map =
+                    resp.manifest.body.source_map.expect("source_map must be populated").0;
+                assert_eq!(source_map[0]["name"], "M31 Lum");
+                let calibration =
+                    resp.manifest.body.calibration.expect("calibration must be populated").0;
+                assert_eq!(calibration[0]["calibrationType"], "dark");
+                assert_eq!(calibration[0]["masterId"], "master-1");
+                return;
             }
             assert!(
                 tokio::time::Instant::now() < deadline,

--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -346,6 +346,57 @@ pub async fn build_source_calibration_snapshot(
     (Some(source_map), calibration)
 }
 
+/// Load the project's current path + lifecycle, build its source/calibration
+/// snapshot, and write a manifest for `reason` (#665).
+///
+/// Best-effort: logs and swallows failure rather than propagating it — the
+/// triggering mutation (source add/remove, lifecycle transition, project
+/// create) has already succeeded by the time this runs; a manifest write
+/// failure must never roll it back or surface as the mutation's own error.
+///
+/// Shared by every #665 trigger site so they can't drift on what a manifest
+/// snapshot contains: `project_setup::add_source`/`remove_source`
+/// (`SourceChange`), `app_core::plan_apply`'s project-create-plan completion
+/// (`Created`), and the `lifecycle.transition.apply` Tauri command
+/// (`LifecycleTransition`, `apps/desktop/src-tauri/src/commands/lifecycle.rs`).
+///
+/// Reads the project row fresh rather than taking a lifecycle string from
+/// the caller: every call site here runs strictly after its own mutation
+/// has already committed the new lifecycle to the DB, so a fresh read is
+/// always the correct post-mutation value.
+pub async fn write_lifecycle_manifest(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+    reason: DtoManifestReason,
+) {
+    let row = match persistence_db::repositories::projects::get_project(pool, project_id).await {
+        Ok(row) => row,
+        Err(e) => {
+            tracing::debug!("manifest snapshot: could not load project {project_id}: {e}");
+            return;
+        }
+    };
+    let (source_map, calibration) = build_source_calibration_snapshot(pool, project_id).await;
+    if let Err(e) = write(
+        pool,
+        bus,
+        WriteManifestParams {
+            project_id,
+            reason,
+            project_root: std::path::Path::new(&row.path),
+            lifecycle_state: &row.lifecycle,
+            source_map,
+            calibration,
+            workflow_profile: None,
+        },
+    )
+    .await
+    {
+        tracing::warn!("manifest write failed for project {project_id}: {e}");
+    }
+}
+
 // ── workflow_run_completed subscriber ─────────────────────────────────────────
 
 /// Spawn an event-bus subscriber that listens for `workflow.run_completed`

--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -284,7 +284,11 @@ pub async fn write(
 /// calibration choices" — `spawn_workflow_run_subscriber` previously always
 /// passed `None` for both, the only trigger a real user ever exercises
 /// (#665 tracks the other 4 triggers being unwired).
-async fn build_source_calibration_snapshot(
+///
+/// `pub`: also called by `project_setup::add_source`/`remove_source` (this
+/// crate, the `SourceChange` trigger) and `app_core::plan_apply`'s
+/// `finalize_project_create_manifest` (the `Created` trigger, #665).
+pub async fn build_source_calibration_snapshot(
     pool: &SqlitePool,
     project_id: &str,
 ) -> (Option<serde_json::Value>, Option<serde_json::Value>) {

--- a/crates/app/projects/src/project_setup.rs
+++ b/crates/app/projects/src/project_setup.rs
@@ -244,6 +244,43 @@ async fn maybe_regress_to_incomplete(
     Ok(Some("setup_incomplete".to_owned()))
 }
 
+/// Fire the `SourceChange` manifest trigger after a source is linked/unlinked
+/// (#665 — project create, source add/remove, and lifecycle transitions had
+/// no emitters at all; this covers the source add/remove half).
+///
+/// Best-effort: a manifest write failure must never fail the source
+/// add/remove use case itself (Constitution V — the DB row for the mutation
+/// itself already succeeded; the manifest is a documentation side-effect).
+async fn write_source_change_manifest(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+    project_path: &str,
+    effective_lifecycle: &str,
+) {
+    use crate::project_manifests::{build_source_calibration_snapshot, write, WriteManifestParams};
+    use contracts_core::manifests::ManifestReason as DtoManifestReason;
+
+    let (source_map, calibration) = build_source_calibration_snapshot(pool, project_id).await;
+    if let Err(e) = write(
+        pool,
+        bus,
+        WriteManifestParams {
+            project_id,
+            reason: DtoManifestReason::SourceChange,
+            project_root: std::path::Path::new(project_path),
+            lifecycle_state: effective_lifecycle,
+            source_map,
+            calibration,
+            workflow_profile: None,
+        },
+    )
+    .await
+    {
+        tracing::warn!(%project_id, error=%e, "source-change manifest write failed");
+    }
+}
+
 // ── Path anchoring (Constitution I) ───────────────────────────────────────────
 
 /// Resolve the requested project path to an unambiguous absolute location.
@@ -867,6 +904,15 @@ pub async fn add_source(
     .await
     .map_err(bus_err)?;
 
+    write_source_change_manifest(
+        pool,
+        bus,
+        &req.project_id,
+        &row.path,
+        new_lifecycle.as_deref().unwrap_or(&row.lifecycle),
+    )
+    .await;
+
     let added_row = repo::ProjectSourceRow {
         id: src_id,
         project_id: req.project_id.clone(),
@@ -981,6 +1027,15 @@ pub async fn remove_source(
     )
     .await
     .map_err(bus_err)?;
+
+    write_source_change_manifest(
+        pool,
+        bus,
+        &req.project_id,
+        &row.path,
+        new_lifecycle.as_deref().unwrap_or(&row.lifecycle),
+    )
+    .await;
 
     Ok(ProjectSourceRemoveResult {
         project_id: req.project_id.clone(),
@@ -1460,6 +1515,48 @@ mod tests {
         assert_eq!(result.new_lifecycle, Some("ready".to_owned()));
     }
 
+    /// #665: `add_source` must fire the `SourceChange` manifest trigger with
+    /// the POST-mutation lifecycle (here, the auto `ready` transition), not
+    /// the stale pre-mutation value.
+    #[tokio::test]
+    async fn add_source_writes_source_change_manifest() {
+        let (pool, bus) = setup().await;
+        let create_req = make_create_req("M31 Andromeda", ProjectTool::PixInsight);
+        let created = create(&pool, &bus, &empty_cache(), &create_req).await.unwrap();
+
+        // `TEST_PROJECT_ROOT` is a synthetic, non-writable path (existing
+        // convention across this module's tests) — point the project at a
+        // real tempdir so the manifest file write can actually succeed.
+        let dir = tempfile::tempdir().unwrap();
+        sqlx::query("UPDATE projects SET path = ? WHERE id = ?")
+            .bind(dir.path().to_str().unwrap())
+            .bind(&created.project_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let add_req = ProjectSourceAddRequest {
+            request_id: new_id(),
+            project_id: created.project_id.clone(),
+            inventory_session_id: "inv-001".to_owned(),
+        };
+        add_source(&pool, &bus, &add_req).await.unwrap();
+
+        let (rows, _) = persistence_db::repositories::manifests::list_manifests_for_project(
+            &pool,
+            &created.project_id,
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0].reason, "source_change");
+        let manifest = crate::project_manifests::get(&pool, &rows[0].id).await.unwrap();
+        assert_eq!(manifest.manifest.body.lifecycle_state, "ready");
+        assert!(manifest.manifest.body.source_map.is_some());
+    }
+
     #[tokio::test]
     async fn add_source_duplicate_rejected() {
         let (pool, bus) = setup().await;
@@ -1524,6 +1621,51 @@ mod tests {
         };
         let result = remove_source(&pool, &bus, &rm_req).await.unwrap();
         assert_eq!(result.new_lifecycle, Some("setup_incomplete".to_owned()));
+    }
+
+    /// #665: `remove_source` must also fire the `SourceChange` manifest
+    /// trigger, with the POST-removal regressed lifecycle.
+    #[tokio::test]
+    async fn remove_source_writes_source_change_manifest() {
+        let (pool, bus) = setup().await;
+        let create_req = make_create_req("NGC 6960 Veil", ProjectTool::PixInsight);
+        let created = create(&pool, &bus, &empty_cache(), &create_req).await.unwrap();
+        let dir = tempfile::tempdir().unwrap();
+        sqlx::query("UPDATE projects SET path = ? WHERE id = ?")
+            .bind(dir.path().to_str().unwrap())
+            .bind(&created.project_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let add_req = ProjectSourceAddRequest {
+            request_id: new_id(),
+            project_id: created.project_id.clone(),
+            inventory_session_id: "inv-001".to_owned(),
+        };
+        add_source(&pool, &bus, &add_req).await.unwrap();
+
+        let rm_req = ProjectSourceRemoveRequest {
+            request_id: new_id(),
+            project_id: created.project_id.clone(),
+            project_source_id: "inv-001".to_owned(),
+            confirm_last_source: true,
+        };
+        remove_source(&pool, &bus, &rm_req).await.unwrap();
+
+        let (rows, _) = persistence_db::repositories::manifests::list_manifests_for_project(
+            &pool,
+            &created.project_id,
+            None,
+            10,
+        )
+        .await
+        .unwrap();
+        // One from add_source, one from remove_source.
+        assert_eq!(rows.len(), 2);
+        assert!(rows.iter().all(|r| r.reason == "source_change"));
+        let latest = crate::project_manifests::get(&pool, &rows[0].id).await.unwrap();
+        assert_eq!(latest.manifest.body.lifecycle_state, "setup_incomplete");
     }
 
     #[tokio::test]

--- a/crates/app/projects/src/project_setup.rs
+++ b/crates/app/projects/src/project_setup.rs
@@ -251,34 +251,19 @@ async fn maybe_regress_to_incomplete(
 /// Best-effort: a manifest write failure must never fail the source
 /// add/remove use case itself (Constitution V — the DB row for the mutation
 /// itself already succeeded; the manifest is a documentation side-effect).
-async fn write_source_change_manifest(
-    pool: &SqlitePool,
-    bus: &EventBus,
-    project_id: &str,
-    project_path: &str,
-    effective_lifecycle: &str,
-) {
-    use crate::project_manifests::{build_source_calibration_snapshot, write, WriteManifestParams};
+/// Delegates to the shared `project_manifests::write_lifecycle_manifest`
+/// (re-reads the project row, so the just-applied lifecycle change from
+/// `maybe_auto_ready`/`maybe_regress_to_incomplete` is already reflected).
+async fn write_source_change_manifest(pool: &SqlitePool, bus: &EventBus, project_id: &str) {
     use contracts_core::manifests::ManifestReason as DtoManifestReason;
 
-    let (source_map, calibration) = build_source_calibration_snapshot(pool, project_id).await;
-    if let Err(e) = write(
+    crate::project_manifests::write_lifecycle_manifest(
         pool,
         bus,
-        WriteManifestParams {
-            project_id,
-            reason: DtoManifestReason::SourceChange,
-            project_root: std::path::Path::new(project_path),
-            lifecycle_state: effective_lifecycle,
-            source_map,
-            calibration,
-            workflow_profile: None,
-        },
+        project_id,
+        DtoManifestReason::SourceChange,
     )
-    .await
-    {
-        tracing::warn!(%project_id, error=%e, "source-change manifest write failed");
-    }
+    .await;
 }
 
 // ── Path anchoring (Constitution I) ───────────────────────────────────────────
@@ -904,14 +889,7 @@ pub async fn add_source(
     .await
     .map_err(bus_err)?;
 
-    write_source_change_manifest(
-        pool,
-        bus,
-        &req.project_id,
-        &row.path,
-        new_lifecycle.as_deref().unwrap_or(&row.lifecycle),
-    )
-    .await;
+    write_source_change_manifest(pool, bus, &req.project_id).await;
 
     let added_row = repo::ProjectSourceRow {
         id: src_id,
@@ -1028,14 +1006,7 @@ pub async fn remove_source(
     .await
     .map_err(bus_err)?;
 
-    write_source_change_manifest(
-        pool,
-        bus,
-        &req.project_id,
-        &row.path,
-        new_lifecycle.as_deref().unwrap_or(&row.lifecycle),
-    )
-    .await;
+    write_source_change_manifest(pool, bus, &req.project_id).await;
 
     Ok(ProjectSourceRemoveResult {
         project_id: req.project_id.clone(),

--- a/crates/app/projects/src/source_view_verify.rs
+++ b/crates/app/projects/src/source_view_verify.rs
@@ -67,6 +67,28 @@ pub(crate) async fn resolve_source(pool: &SqlitePool, inventory_item_id: &str) -
     }
 }
 
+/// Bytes probed from the start of each file for the copy-kind content-drift
+/// check (#746). Partial, not a full-file hash: constitution ("Large-file
+/// hashing MUST be optional or lazy") plus astro frames can be huge; a
+/// changed size or a differing partial digest both prove drift, and this
+/// mirrors the existing partial-hash convention (`app_core_inbox::signature`).
+const HASH_PROBE_BYTES: usize = 65536;
+
+/// Cheap (size, partial-digest) content probe for the drift check. `None`
+/// when the file cannot be read (never treated as a divergence — avoids a
+/// false positive from a transient permission/race error).
+fn partial_content_probe(path: &Utf8Path) -> Option<(u64, [u8; 32])> {
+    use sha2::{Digest, Sha256};
+    use std::io::Read;
+
+    let file = std::fs::File::open(path).ok()?;
+    let size = file.metadata().ok()?.len();
+    let mut buf = vec![0u8; HASH_PROBE_BYTES.min(size as usize)];
+    let mut reader = file.take(buf.len() as u64);
+    reader.read_exact(&mut buf).ok()?;
+    Some((size, Sha256::digest(&buf).into()))
+}
+
 /// Classify one view item against the live filesystem + inventory state.
 /// `None` means the item is clean. Shared by `verify_source_view` (read-only
 /// report) and `sweep_view_staleness` (T014/T015: same resolution logic,
@@ -123,10 +145,23 @@ fn classify_item(
         // Recorded as a symlink but the destination is a regular file —
         // the on-disk kind diverged (spec 026 FR-008 mixed-kind concept).
         return Some(BrokenItemState::ChangedKind);
+    } else if item.materialization == "copy" {
+        // Copy-kind destinations are independent bytes on disk (unlike a
+        // hardlink, which shares the source's inode and can never drift) —
+        // #746: content can silently diverge from the canonical source.
+        if let Some(expected) = &source.abs_path {
+            let diverged = match (partial_content_probe(dest), partial_content_probe(expected)) {
+                (Some(a), Some(b)) => a != b,
+                // Can't probe one side (permission/race) — don't false-positive.
+                _ => false,
+            };
+            if diverged {
+                return Some(BrokenItemState::HashDiverged);
+            }
+        }
     }
-    // Non-symlink destinations (hardlink/copy) that lstat succeeded on
-    // and whose recorded kind wasn't symlink are clean: their bytes are
-    // independent of the source's current inventory path.
+    // Hardlink destinations that lstat succeeded on are clean: their bytes
+    // are identical to the source by construction (shared inode).
     None
 }
 
@@ -210,6 +245,7 @@ pub async fn sweep_view_staleness(pool: &SqlitePool, view_id: &str) -> Result<()
             None => ItemObservedState::Present,
             Some(BrokenItemState::Missing) => ItemObservedState::Missing,
             Some(BrokenItemState::ChangedKind) => ItemObservedState::ChangedKind,
+            Some(BrokenItemState::HashDiverged) => ItemObservedState::HashDiverged,
             Some(BrokenItemState::Moved | BrokenItemState::UnresolvedLink) => {
                 ItemObservedState::Diverged
             }
@@ -445,6 +481,147 @@ mod tests {
         let resp = verify_source_view(db.pool(), "view3").await.unwrap();
         assert!(!resp.clean);
         assert_eq!(resp.broken_items[0].state, BrokenItemState::Moved);
+    }
+
+    // ── #746: copy-kind content-drift detection ──────────────────────────────
+
+    #[tokio::test]
+    async fn copy_kind_identical_content_verifies_clean() {
+        let db = setup().await;
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join("source");
+        let dest_dir = dir.path().join("dest");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        let source_file = source_dir.join("light1.fits");
+        std::fs::write(&source_file, b"identical bytes").unwrap();
+        let dest_file = dest_dir.join("light1.fits");
+        std::fs::write(&dest_file, b"identical bytes").unwrap();
+
+        insert_project(&db, "p1", dir.path().join("proj").to_str().unwrap()).await;
+        insert_root(&db, "root1", source_dir.to_str().unwrap()).await;
+        insert_file_record(&db, "frame1", "root1", "light1.fits").await;
+
+        views_repo::insert_view(
+            db.pool(),
+            &views_repo::InsertPreparedSourceView {
+                id: "view-copy-1",
+                project_id: "p1",
+                kind: "copy",
+            },
+        )
+        .await
+        .unwrap();
+        views_repo::insert_view_item(
+            db.pool(),
+            &views_repo::InsertPreparedSourceViewItem {
+                id: "item-copy-1",
+                view_id: "view-copy-1",
+                inventory_item_id: "frame1",
+                view_relative_path: dest_file.to_str().unwrap(),
+                materialization: "copy",
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = verify_source_view(db.pool(), "view-copy-1").await.unwrap();
+        assert!(resp.clean, "expected clean, got broken_items: {:?}", resp.broken_items);
+    }
+
+    #[tokio::test]
+    async fn copy_kind_diverged_content_is_reported() {
+        let db = setup().await;
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join("source");
+        let dest_dir = dir.path().join("dest");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        let source_file = source_dir.join("light1.fits");
+        std::fs::write(&source_file, b"original bytes").unwrap();
+        let dest_file = dest_dir.join("light1.fits");
+        // Destination copy edited independently after generation — the drift
+        // FR-009 requires detecting (previously always reported clean).
+        std::fs::write(&dest_file, b"edited elsewhere").unwrap();
+
+        insert_project(&db, "p1", dir.path().join("proj").to_str().unwrap()).await;
+        insert_root(&db, "root1", source_dir.to_str().unwrap()).await;
+        insert_file_record(&db, "frame1", "root1", "light1.fits").await;
+
+        views_repo::insert_view(
+            db.pool(),
+            &views_repo::InsertPreparedSourceView {
+                id: "view-copy-2",
+                project_id: "p1",
+                kind: "copy",
+            },
+        )
+        .await
+        .unwrap();
+        views_repo::insert_view_item(
+            db.pool(),
+            &views_repo::InsertPreparedSourceViewItem {
+                id: "item-copy-2",
+                view_id: "view-copy-2",
+                inventory_item_id: "frame1",
+                view_relative_path: dest_file.to_str().unwrap(),
+                materialization: "copy",
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = verify_source_view(db.pool(), "view-copy-2").await.unwrap();
+        assert!(!resp.clean);
+        assert_eq!(resp.broken_items[0].state, BrokenItemState::HashDiverged);
+    }
+
+    #[tokio::test]
+    async fn hardlink_kind_never_probed_for_hash_divergence() {
+        // A hardlink shares the source's inode: its bytes are the source's
+        // bytes by construction, so no content probe should ever run (and
+        // none is needed — verifies the existing clean-hardlink contract is
+        // untouched by the new copy-kind probe).
+        let db = setup().await;
+        let dir = tempfile::tempdir().unwrap();
+        let source_dir = dir.path().join("source");
+        let dest_dir = dir.path().join("dest");
+        std::fs::create_dir_all(&source_dir).unwrap();
+        std::fs::create_dir_all(&dest_dir).unwrap();
+        let source_file = source_dir.join("light1.fits");
+        std::fs::write(&source_file, b"x").unwrap();
+        let dest_file = dest_dir.join("light1.fits");
+        std::fs::hard_link(&source_file, &dest_file).unwrap();
+
+        insert_project(&db, "p1", dir.path().join("proj").to_str().unwrap()).await;
+        insert_root(&db, "root1", source_dir.to_str().unwrap()).await;
+        insert_file_record(&db, "frame1", "root1", "light1.fits").await;
+
+        views_repo::insert_view(
+            db.pool(),
+            &views_repo::InsertPreparedSourceView {
+                id: "view-hl-1",
+                project_id: "p1",
+                kind: "hardlink",
+            },
+        )
+        .await
+        .unwrap();
+        views_repo::insert_view_item(
+            db.pool(),
+            &views_repo::InsertPreparedSourceViewItem {
+                id: "item-hl-1",
+                view_id: "view-hl-1",
+                inventory_item_id: "frame1",
+                view_relative_path: dest_file.to_str().unwrap(),
+                materialization: "hardlink",
+            },
+        )
+        .await
+        .unwrap();
+
+        let resp = verify_source_view(db.pool(), "view-hl-1").await.unwrap();
+        assert!(resp.clean, "expected clean, got broken_items: {:?}", resp.broken_items);
     }
 
     // ── sweep_view_staleness (T014/T015) ─────────────────────────────────────

--- a/crates/app/projects/src/source_view_verify.rs
+++ b/crates/app/projects/src/source_view_verify.rs
@@ -83,8 +83,9 @@ fn partial_content_probe(path: &Utf8Path) -> Option<(u64, [u8; 32])> {
 
     let file = std::fs::File::open(path).ok()?;
     let size = file.metadata().ok()?.len();
-    let mut buf = vec![0u8; HASH_PROBE_BYTES.min(size as usize)];
-    let mut reader = file.take(buf.len() as u64);
+    let probe_len = usize::try_from(size).unwrap_or(usize::MAX).min(HASH_PROBE_BYTES);
+    let mut buf = vec![0u8; probe_len];
+    let mut reader = file.take(probe_len as u64);
     reader.read_exact(&mut buf).ok()?;
     Some((size, Sha256::digest(&buf).into()))
 }

--- a/crates/audit-types/src/event_bus.rs
+++ b/crates/audit-types/src/event_bus.rs
@@ -155,40 +155,15 @@ pub const TOPIC_ROOT_DELETED: &str = "root.deleted";
 
 // ── Native filesystem control audit events (spec 004) ─────────────────────
 
-/// Kind of picker that failed.
-#[derive(
-    Clone,
-    Copy,
-    Debug,
-    Eq,
-    Hash,
-    Ord,
-    PartialEq,
-    PartialOrd,
-    Serialize,
-    Deserialize,
-    JsonSchema,
-    Type,
-)]
-#[serde(rename_all = "snake_case")]
-pub enum PickerKind {
-    Directory,
-    File,
-}
-
-/// Payload for the `native.picker.failed` topic (spec 004).
-///
-/// Audit event emitted when an OS picker dialog fails.
-/// Does NOT include path or path_hash fields (A2 decision: correlate via entity_id).
-#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
-#[serde(rename_all = "camelCase")]
-pub struct NativePickerFailed {
-    pub picker_kind: PickerKind,
-    pub error_code: String,
-    pub request_id: String,
-}
-
-pub const TOPIC_NATIVE_PICKER_FAILED: &str = "native.picker.failed";
+// #717 FR-006: `native.picker.failed` (`PickerKind`/`NativePickerFailed`/
+// `TOPIC_NATIVE_PICKER_FAILED`) was defined but never constructed anywhere —
+// tauri-plugin-dialog's blocking picker API (`blocking_pick_folder`/
+// `blocking_pick_file`, used by `commands::native::native_directory_pick`/
+// `native_file_pick`) returns `Option<FilePath>` with no error variant at
+// all, so there was never a real "picker failed" signal distinct from "user
+// cancelled" to emit it from. Removed per the issue's own fallback ("emit
+// from a real failure path or remove the dead type") rather than fabricate
+// a failure condition the underlying dialog API cannot report.
 
 /// Payload for the `native.reveal.failed` topic (spec 004).
 ///

--- a/crates/contracts/core/src/source_view_verify.rs
+++ b/crates/contracts/core/src/source_view_verify.rs
@@ -55,6 +55,10 @@ pub enum BrokenItemState {
     /// The on-disk materialization kind no longer matches the kind recorded
     /// for this item (spec 026 FR-008 mixed-kind concept, per-item).
     ChangedKind,
+    /// A copy-kind item's destination content no longer matches the
+    /// canonical source (a real file copy, unlike a symlink/hardlink, can
+    /// silently drift — spec 026 FR-009 / #746).
+    HashDiverged,
 }
 
 /// One broken/missing/stale item in a verified view.

--- a/crates/domain/core/src/lifecycle/prepared_source.rs
+++ b/crates/domain/core/src/lifecycle/prepared_source.rs
@@ -262,8 +262,17 @@ pub struct PreparedSourceView026 {
 }
 
 impl PreparedSourceView026 {
-    /// Returns true if the view's `kind` mismatches any item's `materialization`
-    /// (FR-008 / A2 mixed-kind check).
+    /// Returns true if the view's `kind` (its dominant/creation-time
+    /// materialization) mismatches any item's own `materialization`.
+    ///
+    /// This is a descriptive predicate only — NOT an error condition. Spec
+    /// 049 CL-2 (2026-07-04) amended FR-008: a cross-drive project's
+    /// drive-scope resolution can legitimately produce a view whose items
+    /// carry more than one kind (per-item kind is authoritative); such a
+    /// view must remain fully usable (removable/regeneratable), see #745.
+    /// The genuinely-error state is the distinct `ViewState::KindDiverged`
+    /// (a pre-existing record repaired to have a kind inconsistency that
+    /// needs manual resolution), not this predicate.
     #[must_use]
     pub fn has_mixed_kind(&self) -> bool {
         self.items.iter().any(|item| item.materialization != self.kind)

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -106,25 +106,26 @@ impl Database {
 
     /// Run all pending migrations from `./migrations/`.
     ///
-    /// Also runs the spec 026 T006a `kind_diverged` reconciliation scan
-    /// (idempotent, no-op on a fresh DB) — this is data reconciliation over
-    /// existing rows, not a schema change, so it belongs here rather than as
-    /// a versioned `.sql` migration.
-    ///
     /// # Errors
     ///
-    /// Returns [`DbError::Migration`] if any migration script fails, or a
-    /// database error if the reconciliation scan fails.
+    /// Returns [`DbError::Migration`] if any migration script fails.
     // Touched for #773 (migration 0066), again for spec 008 Q27's migration
     // 0067 (renumbered from a 0066 collision with #773's own
     // 0066_session_notes.sql), and again for its renumber to 0068 (a second
     // collision: 0067 vs #895's 0067_camera_sensor_type.sql, both merged to
     // main independently) — to force `sqlx::migrate!` re-embed each time
     // (project memory: stale-embed guard).
+    //
+    // #745 (spec 049 CL-2): this used to also run the spec 026 T006a
+    // `kind_diverged` reconciliation scan on every start, force-flipping any
+    // view whose items carried more than one recorded kind. CL-2 amended
+    // FR-008 to make that state VALID (per-item kind authoritative — exactly
+    // what a cross-drive project's drive-scope resolution legitimately
+    // produces), so the scan's only remaining effect was auto-corrupting
+    // real cross-drive projects into the dead-end `kind_diverged` state on
+    // every reopen. Removed along with `reconcile_kind_diverged_views`.
     pub async fn migrate(&self) -> DbResult<()> {
         sqlx::migrate!("./migrations").run(&self.pool).await?;
-        crate::repositories::prepared_source_views::reconcile_kind_diverged_views(&self.pool)
-            .await?;
         Ok(())
     }
 

--- a/crates/persistence/db/src/repositories/prepared_source_views.rs
+++ b/crates/persistence/db/src/repositories/prepared_source_views.rs
@@ -230,38 +230,6 @@ pub async fn update_item_observed_state(
     Ok(())
 }
 
-/// Spec 026 T006a: scan all non-terminal views for a pre-existing
-/// `kind`/item-`materialization` mismatch and flip them to `kind_diverged`.
-///
-/// Closes the gap for `PreparedSourceView` rows written before the
-/// mixed-kind check (D-026-H2) was enforced at write time — on a fresh
-/// install this is a no-op (no legacy rows exist); on an upgrade it
-/// reconciles any that do. `removed`/`kind_diverged` rows are excluded:
-/// removed views have no live on-disk representation to diverge, and
-/// already-diverged ones don't need re-flagging. Idempotent — safe to run
-/// on every `Database::migrate()` call.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on query failure.
-pub async fn reconcile_kind_diverged_views(pool: &SqlitePool) -> DbResult<u64> {
-    let mismatched: Vec<(String,)> = sqlx::query_as(
-        "SELECT DISTINCT v.id FROM prepared_source_views v
-         JOIN prepared_source_view_items i ON i.view_id = v.id
-         WHERE v.state NOT IN ('removed', 'kind_diverged')
-           AND i.materialization != v.kind",
-    )
-    .fetch_all(pool)
-    .await
-    .map_err(DbError::Database)?;
-
-    let count = u64::try_from(mismatched.len()).unwrap_or(u64::MAX);
-    for (id,) in mismatched {
-        update_view_state(pool, &id, "kind_diverged").await?;
-    }
-    Ok(count)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -408,8 +376,14 @@ mod tests {
         assert_eq!(views.len(), 2);
     }
 
+    /// #745 (spec 049 CL-2): re-running `Database::migrate()` must NOT
+    /// force-flip a view whose items carry more than one recorded kind —
+    /// that used to be `reconcile_kind_diverged_views`'s job on every app
+    /// start, auto-corrupting real cross-drive projects (whose drive-scope
+    /// resolution legitimately produces per-item kind diversity) into the
+    /// dead-end `kind_diverged` state on every reopen.
     #[tokio::test]
-    async fn reconcile_flags_mismatched_legacy_view_kind_diverged() {
+    async fn migrate_does_not_flip_mixed_kind_views_to_kind_diverged() {
         let db = setup().await;
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at)
@@ -419,63 +393,30 @@ mod tests {
         .await
         .unwrap();
 
-        // Legacy row: view.kind='symlink' but its item was recorded 'copy' —
-        // simulates a pre-mixed-kind-check record.
+        // A cross-drive project's view: kind='symlink' (dominant), one item
+        // resolved to 'copy' (drive-scope fallback) — VALID per CL-2.
         insert_view(
             db.pool(),
-            &InsertPreparedSourceView { id: "v-legacy", project_id: "proj-5", kind: "symlink" },
+            &InsertPreparedSourceView { id: "v-mixed", project_id: "proj-5", kind: "symlink" },
         )
         .await
         .unwrap();
         insert_view_item(
             db.pool(),
             &InsertPreparedSourceViewItem {
-                id: "item-legacy",
-                view_id: "v-legacy",
-                inventory_item_id: "inv-legacy",
-                view_relative_path: "Sources/legacy.fit",
+                id: "item-mixed",
+                view_id: "v-mixed",
+                inventory_item_id: "inv-mixed",
+                view_relative_path: "Sources/mixed.fit",
                 materialization: "copy",
             },
         )
         .await
         .unwrap();
 
-        // Clean row: should not be touched.
-        insert_view(
-            db.pool(),
-            &InsertPreparedSourceView { id: "v-clean", project_id: "proj-5", kind: "symlink" },
-        )
-        .await
-        .unwrap();
-        insert_view_item(
-            db.pool(),
-            &InsertPreparedSourceViewItem {
-                id: "item-clean",
-                view_id: "v-clean",
-                inventory_item_id: "inv-clean",
-                view_relative_path: "Sources/clean.fit",
-                materialization: "symlink",
-            },
-        )
-        .await
-        .unwrap();
+        // Re-running migrate() (as every app start does) must leave it alone.
+        db.migrate().await.unwrap();
 
-        let count = reconcile_kind_diverged_views(db.pool()).await.unwrap();
-        assert_eq!(count, 1);
-
-        assert_eq!(get_view(db.pool(), "v-legacy").await.unwrap().state, "kind_diverged");
-        assert_eq!(get_view(db.pool(), "v-clean").await.unwrap().state, "current");
-
-        // Idempotent: a second pass finds nothing new (already-diverged rows
-        // are excluded from the scan).
-        let count_again = reconcile_kind_diverged_views(db.pool()).await.unwrap();
-        assert_eq!(count_again, 0);
-    }
-
-    #[tokio::test]
-    async fn reconcile_is_noop_on_fresh_db_with_no_views() {
-        let db = setup().await;
-        let count = reconcile_kind_diverged_views(db.pool()).await.unwrap();
-        assert_eq!(count, 0);
+        assert_eq!(get_view(db.pool(), "v-mixed").await.unwrap().state, "current");
     }
 }

--- a/crates/workflow/profiles/src/seed.rs
+++ b/crates/workflow/profiles/src/seed.rs
@@ -191,7 +191,10 @@ mod tests {
         // explicit layout of their own (siril, planetary_suite) all fall back
         // to the WBPP/PixInsight default.
         assert_eq!(resolve_source_view_layout(None), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
-        assert_eq!(resolve_source_view_layout(Some("photoshop")), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
+        assert_eq!(
+            resolve_source_view_layout(Some("photoshop")),
+            crate::DEFAULT_SOURCE_VIEW_LAYOUT
+        );
         assert_eq!(resolve_source_view_layout(Some("siril")), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
         assert_eq!(
             resolve_source_view_layout(Some("Planetary Suite")),

--- a/crates/workflow/profiles/src/seed.rs
+++ b/crates/workflow/profiles/src/seed.rs
@@ -45,12 +45,30 @@ fn siril_profile() -> ToolProfile {
     }
 }
 
+fn planetary_suite_profile() -> ToolProfile {
+    ToolProfile {
+        id: "planetary_suite",
+        name: "Planetary Suite",
+        // No stable macOS bundle id is known for AutoStakkert! (research.md R2:
+        // "if present; else surface not found") — `open -b` dispatch stays
+        // unavailable until one is confirmed; Windows/Linux launch by path only.
+        bundle_id: None,
+        // AutoStakkert! opens its own dialog; cwd anchors it (spec 011 R3).
+        args_template: vec![],
+        supports_open_folder: false,
+        detach_strategy: DetachStrategy::Setsid,
+        // No Planetary-Suite-specific layout yet — falls back to
+        // DEFAULT_SOURCE_VIEW_LAYOUT like Siril.
+        source_view_layout: None,
+    }
+}
+
 /// Return all seeded processing-tool profiles as an owned `Vec`.
 ///
 /// Call `validate_seeds()` at app boot to assert integrity.
 #[must_use]
 pub fn all() -> Vec<ToolProfile> {
-    vec![pixinsight_profile(), siril_profile()]
+    vec![pixinsight_profile(), siril_profile(), planetary_suite_profile()]
 }
 
 /// Validate all seed profiles.
@@ -136,8 +154,16 @@ mod tests {
     }
 
     #[test]
-    fn two_seeds_are_registered() {
-        assert_eq!(all().len(), 2);
+    fn three_seeds_are_registered() {
+        assert_eq!(all().len(), 3);
+    }
+
+    #[test]
+    fn planetary_suite_is_seeded_and_launches_bare() {
+        let p = find("planetary_suite").expect("planetary_suite must be seeded");
+        assert_eq!(p.name, "Planetary Suite");
+        assert!(!p.supports_open_folder);
+        assert!(p.args_template.is_empty());
     }
 
     // ── Spec 049 US2 T023: WBPP layout groups by session/night → filter →
@@ -161,14 +187,16 @@ mod tests {
 
     #[test]
     fn resolve_source_view_layout_falls_back_to_default() {
-        // No profile, an unknown profile, and a seeded profile without an
-        // explicit layout (siril) all fall back to the WBPP/PixInsight default.
+        // No profile, an unmatched profile ref, and seeded profiles without an
+        // explicit layout of their own (siril, planetary_suite) all fall back
+        // to the WBPP/PixInsight default.
         assert_eq!(resolve_source_view_layout(None), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
+        assert_eq!(resolve_source_view_layout(Some("photoshop")), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
+        assert_eq!(resolve_source_view_layout(Some("siril")), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
         assert_eq!(
             resolve_source_view_layout(Some("Planetary Suite")),
             crate::DEFAULT_SOURCE_VIEW_LAYOUT
         );
-        assert_eq!(resolve_source_view_layout(Some("siril")), crate::DEFAULT_SOURCE_VIEW_LAYOUT);
     }
 
     // ── Spec 049 US2 T024: changing the layout pattern only changes the

--- a/packages/contracts/tests/conformance-harness.mjs
+++ b/packages/contracts/tests/conformance-harness.mjs
@@ -700,6 +700,18 @@ function responseSchema(fullSchema, testId) {
   };
 }
 
+// Request-side counterpart of responseSchema(), for schemas (like the
+// native.* contracts below) whose request shape also needs standalone
+// validation rather than just the response.
+function requestSchema(fullSchema, testId) {
+  return {
+    $schema: "https://json-schema.org/draft/2020-12/schema",
+    $id: `urn:test:${testId}`,
+    ...fullSchema.properties.request,
+    $defs: fullSchema.$defs,
+  };
+}
+
 // T009: plan.apply response shape (success + failure).
 const planApplySchema = loadSchema("specs/025-filesystem-plan-application/contracts/plan.apply.json");
 const planApplyResponseSchema = responseSchema(planApplySchema, "plan-apply-response");
@@ -870,6 +882,149 @@ validate(
     contractVersion: "2.0.0",
     requestId,
     errors: [{ code: "item.still.stale", message: "source file changed again while paused" }],
+  },
+  true
+);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// #717 SC-005 (spec 004): the 3 native.* contracts had zero Draft-2020-12
+// schema coverage in this harness — only syntax-level json-schema-to-typescript
+// generation exercised them. Covers request + both response variants for each.
+// ─────────────────────────────────────────────────────────────────────────────
+
+const nativeReveal = loadSchema("specs/004-native-filesystem-controls/contracts/native.reveal.json");
+const nativeRevealRequestSchema = requestSchema(nativeReveal, "native-reveal-request");
+const nativeRevealResponseSchema = responseSchema(nativeReveal, "native-reveal-response");
+
+validate(
+  "native.reveal request valid",
+  nativeRevealRequestSchema,
+  {
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    path: "/mnt/library/M31/notes/manifest.md",
+    entityKind: "project_manifest",
+    entityId: "proj-1",
+  },
+  true
+);
+
+validate(
+  "native.reveal DRIFT: missing 'path' must be rejected",
+  nativeRevealRequestSchema,
+  { contractVersion: "2.0.0", requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6" },
+  false
+);
+
+validate(
+  "native.reveal success response valid",
+  nativeRevealResponseSchema,
+  {
+    status: "success",
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    revealed: true,
+    selection: "target",
+  },
+  true
+);
+
+validate(
+  "native.reveal failure response valid (path.not_exists)",
+  nativeRevealResponseSchema,
+  {
+    status: "failure",
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    errors: [{ code: "path.not_exists", message: "Path does not exist" }],
+  },
+  true
+);
+
+const nativeDirPick = loadSchema(
+  "specs/004-native-filesystem-controls/contracts/native.directory.pick.json"
+);
+const nativeDirPickRequestSchema = requestSchema(nativeDirPick, "native-directory-pick-request");
+const nativeDirPickResponseSchema = responseSchema(nativeDirPick, "native-directory-pick-response");
+
+validate(
+  "native.directory.pick request valid (defaultPath omitted)",
+  nativeDirPickRequestSchema,
+  { contractVersion: "2.0.0", requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6" },
+  true
+);
+
+validate(
+  "native.directory.pick success response valid (cancelled)",
+  nativeDirPickResponseSchema,
+  {
+    status: "success",
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    path: null,
+    cancelled: true,
+  },
+  true
+);
+
+validate(
+  "native.directory.pick failure response valid (picker.unavailable)",
+  nativeDirPickResponseSchema,
+  {
+    status: "failure",
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    errors: [{ code: "picker.unavailable", message: "No display server available" }],
+  },
+  true
+);
+
+const nativeFilePick = loadSchema(
+  "specs/004-native-filesystem-controls/contracts/native.file.pick.json"
+);
+const nativeFilePickRequestSchema = requestSchema(nativeFilePick, "native-file-pick-request");
+const nativeFilePickResponseSchema = responseSchema(nativeFilePick, "native-file-pick-response");
+
+validate(
+  "native.file.pick request valid",
+  nativeFilePickRequestSchema,
+  {
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    filters: [{ name: "FITS", extensions: ["fits", "fit"] }],
+  },
+  true
+);
+
+validate(
+  "native.file.pick DRIFT: empty filters array must be rejected",
+  nativeFilePickRequestSchema,
+  { contractVersion: "2.0.0", requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6", filters: [] },
+  false
+);
+
+validate(
+  "native.file.pick success response valid",
+  nativeFilePickResponseSchema,
+  {
+    status: "success",
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    path: "/mnt/library/masters/flat_L.fits",
+    selectedFilter: "FITS",
+    cancelled: false,
+  },
+  true
+);
+
+validate(
+  "native.file.pick failure response valid (filters.invalid)",
+  nativeFilePickResponseSchema,
+  {
+    status: "failure",
+    contractVersion: "2.0.0",
+    requestId: "3fa85f64-5717-4562-b3fc-2c963f66afa6",
+    errors: [{ code: "filters.invalid", message: "'*' only valid in an 'All files' filter" }],
   },
   true
 );

--- a/specs/049-source-view-generation/contracts/sourceview.verify.json
+++ b/specs/049-source-view-generation/contracts/sourceview.verify.json
@@ -45,7 +45,7 @@
                   "viewRelativePath": { "type": "string" },
                   "state": {
                     "type": "string",
-                    "enum": ["missing", "moved", "unresolved_link", "changed_kind"],
+                    "enum": ["missing", "moved", "unresolved_link", "changed_kind", "hash_diverged"],
                     "description": "Why the item failed verification. Repair is via spec 026 regeneration, never auto-repair here."
                   }
                 }


### PR DESCRIPTION
Closes #725
Closes #715
Closes #717
Closes #726
Closes #746
Closes #745
Closes #761
Closes #740
Closes #665
Closes #716
Closes #780
Refs #711 (approach reverted — broke real-E2E confirm journeys; redo in dedicated node)

**Release-blocker (#780):** the artifact watcher now performs recursive reconciliation on attach — previously it only watched the top-level directory, silently missing files added to subfolders after the watcher started.

Real-app validations for #715/#717/#726/#780/#716 are queued for the MCP validation lane.