### PR TITLE
fix(ui): collapse accent Btn variant and honest disabled states

### DIFF
--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -1279,7 +1279,7 @@ export function InboxDetail({
 
                     <button
                       type="button"
-                      className="alm-btn alm-btn--sm alm-btn--accent"
+                      className="alm-btn alm-btn--sm alm-btn--primary"
                       onClick={handleBulkApply}
                       disabled={reclassifyLoading || !heterogeneousAcked}
                       aria-label={m.inbox_bulk_override_apply_aria({
@@ -1353,7 +1353,7 @@ export function InboxDetail({
                   <div className="alm-inbox-detail__apply-row">
                     <button
                       type="button"
-                      className="alm-btn alm-btn--sm alm-btn--accent"
+                      className="alm-btn alm-btn--sm alm-btn--primary"
                       onClick={handleApplyOverrides}
                       disabled={
                         Object.keys(pendingOverrides).length === 0 ||

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -1076,7 +1076,7 @@ export function InboxPage() {
           {showPlans && (
             <Btn
               size="sm"
-              variant="accent"
+              variant="ghost"
               onClick={() => setPlanOverlayOpen(true)}
               aria-label={m.inbox_review_plans_with_count({ count: planCount })}
               data-testid="inbox-review-plans-btn"
@@ -1090,7 +1090,7 @@ export function InboxPage() {
           {bulkEligibleItems.length > 0 && (
             <Btn
               size="sm"
-              variant="accent"
+              variant="primary"
               disabled={!canBulkConfirm}
               onClick={() => void handleBulkConfirm()}
               aria-label={m.inbox_confirm_all_classified_aria({

--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -678,7 +678,7 @@ export function PlanPanel({
               : m.inbox_apply_selected_plans({ count: selectedArray.length })}
           </Btn>
           <Btn
-            variant="accent"
+            variant="ghost"
             onClick={onApplyAll}
             disabled={applyAllDisabled}
             data-testid="plan-apply-all"

--- a/apps/desktop/src/features/projects/lifecycle-actions.ts
+++ b/apps/desktop/src/features/projects/lifecycle-actions.ts
@@ -25,7 +25,7 @@ export interface LifecycleAction {
   /** True when the backend will return plan.required for this edge. */
   requiresPlan: boolean;
   /** Button variant for the primary action. */
-  variant: 'primary' | 'accent' | 'danger' | 'ghost';
+  variant: 'primary' | 'danger' | 'ghost';
   /** If true, this is the primary (most prominent) footer action. */
   primary: boolean;
 }

--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -42,17 +42,25 @@
   transition: all var(--alm-transition-fast);
 }
 .alm-btn:hover { border-color: var(--alm-ink3); color: var(--alm-text); }
-.alm-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+/* #628: disabled must read as unambiguously inert — lower opacity than
+   hover/active states use anywhere else, and strip the primary/danger fill so
+   a disabled CTA never still reads as "the" accent-colored action. */
+.alm-btn:disabled { opacity: 0.35; cursor: not-allowed; }
 .alm-btn:disabled:hover { border-color: var(--alm-border); color: var(--alm-text-secondary); }
 /* Primary = theme accent. Was var(--alm-ink), which inverts to a light button
    in dark themes (ink is the light text color there). Accent stays correct in
-   every theme and unifies the previously-divergent primary/accent variants. */
+   every theme; the former separate `accent` variant was byte-identical to
+   `primary` (#627) and was removed rather than kept as a same-looking alias. */
 .alm-btn--primary { background: var(--alm-accent); color: var(--alm-on-accent); border-color: var(--alm-accent); }
 .alm-btn--primary:hover { background: var(--alm-accent-hover); border-color: var(--alm-accent-hover); }
-.alm-btn--accent { background: var(--alm-accent); color: var(--alm-on-accent); border-color: var(--alm-accent); }
-.alm-btn--accent:hover { background: var(--alm-accent-hover); border-color: var(--alm-accent-hover); }
 .alm-btn--danger { background: var(--alm-danger-bg); color: var(--alm-danger); border-color: var(--alm-danger-border); }
 .alm-btn--danger:hover { background: var(--alm-danger-bg-hover); }
+.alm-btn--primary:disabled,
+.alm-btn--danger:disabled {
+  background: var(--alm-bg);
+  color: var(--alm-text-secondary);
+  border-color: var(--alm-border);
+}
 .alm-btn--sm { height: 24px; padding: 0 var(--alm-sp-2); font-size: var(--alm-text-xs); }
 
 /* === SECTION === */

--- a/apps/desktop/src/ui/Btn.tsx
+++ b/apps/desktop/src/ui/Btn.tsx
@@ -4,7 +4,7 @@
 import { forwardRef } from 'react';
 import type { ReactNode, ButtonHTMLAttributes } from 'react';
 
-export type BtnVariant = 'primary' | 'accent' | 'danger' | 'ghost';
+export type BtnVariant = 'primary' | 'danger' | 'ghost';
 export type BtnSize = 'sm' | 'md';
 export interface BtnProps extends ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: BtnVariant;


### PR DESCRIPTION
Closes #627
Closes #628

Refs #640 (verified already fixed)
Refs #601, #602, #604, #619, #631 (routed to design-system-b)