### PR TITLE
refactor: every list-page detail panel uses the shared container

### DIFF
--- a/apps/desktop/src/components/DetailPanel.shared-guard.test.ts
+++ b/apps/desktop/src/components/DetailPanel.shared-guard.test.ts
@@ -1,0 +1,48 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Shared-component guard — spec 054 T012a, issue #1067 (owner mandate: "the
+ * panels should be completely shared components that the individual pages can
+ * fill out with data").
+ *
+ * A static source check (in the `scripts/css-dup-sniff.mjs` spirit — cheaper
+ * and just as effective as mounting all six real detail components with their
+ * full data/IPC mocking, which would duplicate each feature's own test setup
+ * for no extra regression coverage): every list-page detail component must
+ * render through the shared `DetailPanel` (source contains a `<DetailPanel`
+ * JSX usage) and must NOT render `<DetailHeader` directly — that is
+ * `DetailPanel`'s own internal implementation detail, so a consumer using it
+ * means it has bypassed the shared container.
+ *
+ * Note this deliberately does NOT forbid `DetailPane` (no "l"): the bare
+ * primitive is still the correct choice for a loading/error early return,
+ * which has no title to give `DetailPanel`'s required `title` prop. Several
+ * of the files below use it for exactly that.
+ *
+ * Runtime confirmation that `DetailPanel`'s root actually carries its shared
+ * structure lives in `DetailPanel.test.tsx`, which renders real instances.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const MIGRATED_DETAIL_FILES = [
+  'src/features/sessions/SessionDetail.tsx',
+  'src/features/calibration/MasterDetail.tsx',
+  'src/features/inbox/InboxDetail.tsx',
+  'src/features/archive/ArchiveDetail.tsx',
+  'src/features/targets/TargetDetailV2.tsx',
+  'src/features/projects/ProjectDetail.tsx',
+];
+
+describe('shared DetailPanel guard (spec 054 T012a)', () => {
+  it.each(
+    MIGRATED_DETAIL_FILES,
+  )('%s renders through DetailPanel, not a raw DetailHeader', (relPath) => {
+    const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
+    expect(source).toMatch(/<DetailPanel\b/);
+    expect(source).not.toMatch(/<DetailHeader\b/);
+  });
+});

--- a/apps/desktop/src/features/archive/ArchiveDetail.tsx
+++ b/apps/desktop/src/features/archive/ArchiveDetail.tsx
@@ -1,7 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { DetailPane, DetailHeader } from '@/components';
+import { DetailPanel } from '@/components';
 import { m } from '@/lib/i18n';
 import { Pill, Section, Table, EmptyState, Skeleton } from '@/ui';
 import { useArchiveAudit } from './store';
@@ -60,22 +60,21 @@ export function ArchiveDetail({ item }: Props) {
   const { data: history = [], loading, error } = useArchiveAudit(item.id);
 
   return (
-    <DetailPane fill>
-      <DetailHeader
-        title={item.name}
-        titleExtra={
-          <>
-            <Pill variant="info">{item.entityType}</Pill>
-            <Pill variant="ghost">{m.archive_status_pill()}</Pill>
-          </>
-        }
-        subtitle={
-          item.originalPath !== '—'
-            ? item.originalPath
-            : m.archive_subtitle_no_path()
-        }
-      />
-
+    <DetailPanel
+      fill
+      title={item.name}
+      titleExtra={
+        <>
+          <Pill variant="info">{item.entityType}</Pill>
+          <Pill variant="ghost">{m.archive_status_pill()}</Pill>
+        </>
+      }
+      subtitle={
+        item.originalPath !== '—'
+          ? item.originalPath
+          : m.archive_subtitle_no_path()
+      }
+    >
       {/* Single column — no rail. The old rail (Status/Storage/Audit trail)
           duplicated the Details table and the Audit history table, so it was
           dropped along with the hero MetricLine. The "Details" table that
@@ -125,6 +124,6 @@ export function ArchiveDetail({ item }: Props) {
           />
         )}
       </Section>
-    </DetailPane>
+    </DetailPanel>
   );
 }

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -38,8 +38,8 @@ import { revealInOs } from '@/shared/native/reveal';
 import { queryKeys } from '@/data/queryKeys';
 import { queryClient as sharedQueryClient } from '@/data/queryClient';
 import {
-  DetailHeader,
   DetailPane,
+  DetailPanel,
   MetricLine,
   TopActionBar,
   renderValue,
@@ -474,30 +474,28 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
   });
 
   return (
-    <DetailPane fill>
-      {/* ── Identity header ────────────────────────────────────────────── */}
-      <DetailHeader
-        title={project.name}
-        titleExtra={
-          <ProjectStatusTag variant={projectStateVariant(lifecycle)}>
-            {projectStateLabel(lifecycle)}
-          </ProjectStatusTag>
-        }
-        subtitle={undefined}
-        actions={
-          lifecycle !== 'archived' && (
-            <Btn
-              size="sm"
-              variant="ghost"
-              onClick={() => setEditOpen(true)}
-              data-testid="edit-project-btn"
-            >
-              {m.projects_detail_edit_btn()}
-            </Btn>
-          )
-        }
-      />
-
+    <DetailPanel
+      fill
+      title={project.name}
+      titleExtra={
+        <ProjectStatusTag variant={projectStateVariant(lifecycle)}>
+          {projectStateLabel(lifecycle)}
+        </ProjectStatusTag>
+      }
+      subtitle={undefined}
+      actions={
+        lifecycle !== 'archived' && (
+          <Btn
+            size="sm"
+            variant="ghost"
+            onClick={() => setEditOpen(true)}
+            data-testid="edit-project-btn"
+          >
+            {m.projects_detail_edit_btn()}
+          </Btn>
+        )
+      }
+    >
       {/* ── Top action bar: tool · path · Reveal · Open in tool · CTA ───
           Wrapped in a project-detail scope so the breadcrumb (tool + path)
           and the action cluster lay out on their OWN rows and never overlap
@@ -828,6 +826,6 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
         onApplied={handleArchivePlanApplied}
         onRetryCreated={setArchiveReviewPlanId}
       />
-    </DetailPane>
+    </DetailPanel>
   );
 }

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -43,7 +43,12 @@ import {
   useUpdateTargetNotes,
 } from './store';
 import type { TargetDetailV3 } from './store';
-import { DetailPane, PropertyTable, type PropertyDef } from '@/components';
+import {
+  DetailPane,
+  DetailPanel,
+  PropertyTable,
+  type PropertyDef,
+} from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn, Skeleton } from '@/ui';
 import { m } from '@/lib/i18n';
 import {
@@ -881,63 +886,73 @@ export function TargetDetailV2({
       ]
     : [];
 
-  return (
-    <DetailPane fill>
-      {/* ── Planner header ──────────────────────────────────────────────── */}
-      <div className="alm-planner__header">
-        <div className="alm-planner__header-left">
-          {/* Title + actions inline-left (matches Sessions); pills below. */}
-          <div className="alm-planner__titlebar">
-            <h2 className="alm-planner__title">
-              {detail.effectiveLabel}
-              {commonName && commonName !== detail.effectiveLabel && (
-                <span className="alm-planner__subtitle"> — {commonName}</span>
-              )}
-            </h2>
-            <div className="alm-planner__actions">
-              {/* Primary/contextual action FIRST (Sessions convention: the
-                  highlight action leads the inline-left group). */}
-              <Btn
-                size="sm"
-                variant="primary"
-                onClick={() => {
-                  setNewProjectOpen(true);
-                  void navigate({
-                    to: '/projects/new',
-                    search: { targetId: detail.id },
-                  });
-                }}
-              >
-                {m.targets_detail_new_project()}
-              </Btn>
-            </div>
-          </div>
-          <div className="alm-planner__pill-row">
-            <Pill variant="neutral">
-              {detail.objectType.replace(/_/g, ' ')}
-            </Pill>
-            {catalogPills.map((a) => (
-              <Pill key={a.id} variant="ghost">
-                <span
-                  title={m.targets_detail_alias_kind_title({ kind: a.kind })}
-                >
-                  <span className="alm-target-detail__alias-kind">
-                    [{kindLabel(a.kind)}]
-                  </span>
-                  {a.alias}
-                </span>
-              </Pill>
-            ))}
-          </div>
-        </div>
-      </div>
+  // Title identity (h2, unchanged content/markup — just relocated into
+  // DetailPanel's `title` slot, spec 054 T011/#1067).
+  const titleContent = (
+    <h2 className="alm-planner__title">
+      {detail.effectiveLabel}
+      {commonName && commonName !== detail.effectiveLabel && (
+        <span className="alm-planner__subtitle"> — {commonName}</span>
+      )}
+    </h2>
+  );
 
+  // Pills + "New project" action, inline-left beside the title. Both go in
+  // `titleExtra` (not the `actions` slot): SessionDetail/MasterDetail already
+  // established this idiom — `actions` renders far-right in the header
+  // (`.alm-detail__actions`), which would break the "inline-left, matches
+  // Sessions" grouping this file's own header CSS documents.
+  const titleExtraContent = (
+    <>
+      <div className="alm-planner__actions">
+        {/* Primary/contextual action FIRST (Sessions convention: the
+            highlight action leads the inline-left group). */}
+        <Btn
+          size="sm"
+          variant="primary"
+          onClick={() => {
+            setNewProjectOpen(true);
+            void navigate({
+              to: '/projects/new',
+              search: { targetId: detail.id },
+            });
+          }}
+        >
+          {m.targets_detail_new_project()}
+        </Btn>
+      </div>
+      <div className="alm-planner__pill-row">
+        <Pill variant="neutral">{detail.objectType.replace(/_/g, ' ')}</Pill>
+        {catalogPills.map((a) => (
+          <Pill key={a.id} variant="ghost">
+            <span title={m.targets_detail_alias_kind_title({ kind: a.kind })}>
+              <span className="alm-target-detail__alias-kind">
+                [{kindLabel(a.kind)}]
+              </span>
+              {a.alias}
+            </span>
+          </Pill>
+        ))}
+      </div>
+    </>
+  );
+
+  return (
+    <DetailPanel fill title={titleContent} titleExtra={titleExtraContent}>
       {/* Suppress unused-state warning; newProjectOpen drives the navigate above */}
       {newProjectOpen && null}
 
       {/* #816: DetailPane fill-mode contract (primitives.css .alm-detail--fill)
-          requires ONE descendant establishing overflow-y:auto — the header
-          above stays pinned, everything else (identity/tonight, coverage,
+          requires ONE descendant establishing overflow-y:auto. DetailPanel is
+          deliberately used in "content-only" mode here (no facts/aux slots) —
+          that mode renders `children` as a direct sibling of DetailHeader
+          inside `.alm-detail--fill` (see DetailPanel.tsx), identical to the
+          pre-migration structure this comment originally documented. facts/
+          aux were NOT used for the identity columns below: that would nest
+          this region under `.alm-detailpanel__cols` > `.alm-detailpanel__content`
+          instead of as a direct child of `.alm-detail--fill`, breaking the
+          `.alm-detail--fill > .alm-planner__scroll` CSS rule (redesign-detail.css)
+          this fix depends on — everything below (identity/tonight, coverage,
           links, display label, aliases, projects, notes, back button) lives
           in this single scrollable region so it isn't silently clipped by
           the pane's own overflow:hidden. */}
@@ -1381,6 +1396,6 @@ export function TargetDetailV2({
           {m.targets_detail_back()}
         </button>
       </div>
-    </DetailPane>
+    </DetailPanel>
   );
 }


### PR DESCRIPTION
## Summary

- Every list-page detail panel now renders through the shared `DetailPanel` container. Archive, Projects, and Targets previously hand-rolled the `DetailPane` + `DetailHeader` pair themselves — the per-feature drift the shared-component mandate exists to prevent, and it kept them outside the container's scroll-containment contract.
- Adds a static guard test so this cannot silently regress: every detail component must contain a `<DetailPanel` usage and must not use `<DetailHeader` directly.

This is a structural refactor only. No content, ordering, or styling changes.

## Coverage before / after

| Surface | Before | After |
|---|---|---|
| `SessionDetail` | DetailPanel | DetailPanel |
| `MasterDetail` | DetailPanel | DetailPanel |
| `InboxDetail` | DetailPanel | DetailPanel |
| `ArchiveDetail` | raw markup | **DetailPanel** |
| `ProjectDetail` | raw markup | **DetailPanel** |
| `TargetDetailV2` | raw markup | **DetailPanel** |

## Notes on the two judgement calls

**Loading/error early returns keep the bare `DetailPane`.** `DetailPanel` requires a `title`, and these states have no item identity to give it. The guard test deliberately permits `DetailPane` (no "l") for exactly this reason — it only forbids bypassing the container via `DetailHeader`.

**`TargetDetailV2` stays in content-only mode** rather than moving its two identity `PropertyTable` columns into the `facts` slot. The #816 clipping fix is a CSS contract on `.alm-detail--fill > .alm-planner__scroll` (`redesign-detail.css`), and `facts` would nest that scroll region one level deeper under `.alm-detailpanel__cols`, severing the selector and reintroducing the clip. Content-only mode renders `children` as a direct sibling of the header, preserving the structure. No existing `DetailPanel` consumer uses `facts`/`aux`; `InboxDetail` carries the same rationale.

Buttons go in `titleExtra` rather than `actions`, matching both existing precedents (`SessionDetail`, `MasterDetail`) — `actions` renders far-right and would break the documented inline-left convention.

## Test plan

- `pnpm typecheck` — clean
- `pnpm vitest run` — 186 files, 1718 tests, all passing (includes the 8 ProjectDetail suites and `TargetDetailV2.test.tsx`)
- `pnpm lint` — 0 errors (208 pre-existing warnings unchanged)

The new guard test fails against `main` for `ArchiveDetail`, `ProjectDetail`, and `TargetDetailV2`, so it genuinely covers this change.

## Not covered here

Visual confirmation on the real app has not been done — the migrations are structurally faithful and the existing suites assert behaviour, but panel rendering is worth a look during Windows validation, particularly the Targets planner layout.

Closes #1067

## Spec Context

- Spec: 054 (adaptive detail dock), tasks T011, T012, T012a, T017
- Extracted from #1007, closed as superseded by #1003
