### PR TITLE
chore(apm): pin install targets to claude and codex

### DIFF
--- a/.agents/skills/orchestrate/SKILL.md
+++ b/.agents/skills/orchestrate/SKILL.md
@@ -1,14 +1,9 @@
 ---
 name: orchestrate
-description: >-
-  Orchestrate a fleet of subagents across a complex, parallel, or long-running
-  implementation while controlling cost by routing each role to the cheapest
-  capable model. Use when a task needs multiple coordinated agents, parallel
-  worktree implementation, independent code review, safe multi-branch merging, or
-  a durable/reproducible run record. Covers role-to-model routing, persistent vs
-  ephemeral subagents vs Claude agent-teams, worktree isolation, a deterministic
-  task DAG, a forensic ledger, and terse inter-agent messaging. Not for single
-  bounded edits (use `coder`) or one isolated branch (use `parallel-coder`).
+description: Orchestrate coordinated subagents for parallel or long-running implementation with isolated worktrees, independent review, safe merging, and a durable run ledger.
+x-lint:
+  allow: [W6]
+  reason: "the loaded skill must retain its core orchestration protocol while detailed mechanics remain in references"
 hooks:
   SubagentStart:
     - hooks:
@@ -60,9 +55,10 @@ Role: lead session / orchestrator.
    its `agentId`/name; drive fix rounds via SendMessage to that handle
    (auto-resumes with context + worktree). Never spawn a fresh coder for a
    node under review. Dismiss only on approval + merge.
-7. **SubagentStart hook auto-injects `comms-block.md` into every subagent.
-   Teammates are NOT subagents — the hook never reaches them: paste
-   `comms-block.md` verbatim into each teammate brief.**
+7. **Comms protocol is mandatory.** Claude's skill-scoped `SubagentStart` hook
+   auto-injects `comms-block.md` into subagents. Codex does not run skill
+   frontmatter hooks, so include `comms-block.md` verbatim in every Codex spawn
+   brief. Teammates are not subagents either; include it in their briefs.
 8. **Persistent infra, addressed on demand, never polled.** Gatekeeper +
    ledger-scribe live the whole run as background subagents, reached by
    SendMessage. State lives in the stores — recycle them to shed context

--- a/.agents/skills/write-agentic/references/template-steering.md
+++ b/.agents/skills/write-agentic/references/template-steering.md
@@ -8,7 +8,8 @@ session. The context loads on demand.
 ```markdown
 ---
 description: <≤15 words>
-applyTo: "<glob — scope as narrow as truthful; **/* only for genuinely global>"
+# Omit applyTo for unconditional instructions compiled into global context.
+applyTo: "<optional glob — include only for genuinely file-scoped rules>"
 ---
 
 For <topic list, ≤12 words>, read [<name>](../context/<name>.context.md).
@@ -41,4 +42,6 @@ MUST One home per fact: if another steering file owns it, delegate with one line
   ("see steering-x") — never restate.
 MUST No hedges: every rule uses MUST, DEFAULT, ASK, or NOT + an observable condition.
 DEFAULT Target ≤50 lines context, ≤6 lines pointer.
+DEFAULT Omit `applyTo` for unconditional instructions; scope file-specific rules
+  with the narrowest truthful glob.
 NOT Rationale paragraphs, aphorisms, scope disclaimers, command catalogs.

--- a/.agents/skills/write-agentic/scripts/lint.py
+++ b/.agents/skills/write-agentic/scripts/lint.py
@@ -194,10 +194,9 @@ def lint(path: Path) -> list[tuple[str, str, str]]:
     if kind in caps and n_lines > caps[kind]:
         warn("W6", f"{n_lines} non-empty lines > {caps[kind]} target for {kind}")
 
-    # E7 pointer shape
+    # E7 pointer shape. applyTo is optional: APM treats an omitted applyTo as
+    # unconditional and folds the instruction into compiled context files.
     if kind == "pointer":
-        if "applyTo" not in fm:
-            err("E7", "pointer missing applyTo glob")
         if not re.search(r"\]\(\.\./context/.*\.context\.md\)", body):
             err("E7", "pointer does not link a ../context/*.context.md file")
 

--- a/.agents/skills/write-agentic/scripts/test_lint.py
+++ b/.agents/skills/write-agentic/scripts/test_lint.py
@@ -220,6 +220,58 @@ MUST do something specific and verifiable.
 
 
 # ---------------------------------------------------------------------------
+# Pointer shape
+# ---------------------------------------------------------------------------
+
+class TestPointerShape:
+    def _pointer(self, tmp_path: Path, frontmatter: str) -> Path:
+        context_dir = tmp_path / "context"
+        context_dir.mkdir()
+        (context_dir / "rules.context.md").write_text("# Rules\n", encoding="utf-8")
+        instructions_dir = tmp_path / "instructions"
+        instructions_dir.mkdir()
+        return _write(
+            instructions_dir,
+            "rules.instructions.md",
+            f"""\
+---
+description: Route to the detailed rules.
+{frontmatter}---
+
+Read [rules](../context/rules.context.md).
+""",
+        )
+
+    def test_unconditional_pointer_may_omit_apply_to(self, tmp_path):
+        findings = lint_mod.lint(self._pointer(tmp_path, ""))
+        assert not [f for f in findings if f[0] == "ERROR"]
+
+    def test_scoped_pointer_may_include_apply_to(self, tmp_path):
+        findings = lint_mod.lint(
+            self._pointer(tmp_path, 'applyTo: "**/*.py"\n')
+        )
+        assert not [f for f in findings if f[0] == "ERROR"]
+
+    def test_pointer_still_requires_context_link(self, tmp_path):
+        path = _write(
+            tmp_path,
+            "rules.instructions.md",
+            """\
+---
+description: Route to the detailed rules.
+---
+
+Rules are documented elsewhere.
+""",
+        )
+        findings = lint_mod.lint(path)
+        assert any(
+            severity == "ERROR" and code == "E7"
+            for severity, code, _ in findings
+        )
+
+
+# ---------------------------------------------------------------------------
 # main() exit code with overrides
 # ---------------------------------------------------------------------------
 

--- a/.claude/apm-hooks.json
+++ b/.claude/apm-hooks.json
@@ -64,17 +64,6 @@
   ],
   "PostToolUse": [
     {
-      "matcher": "Bash",
-      "hooks": [
-        {
-          "type": "command",
-          "command": ".claude/hooks/mcp-repomix/scripts/repomix-refresh-snapshot.sh",
-          "timeout": 30
-        }
-      ],
-      "_apm_source": "mcp-repomix"
-    },
-    {
       "matcher": "apply_patch|Edit|Write|MultiEdit",
       "hooks": [
         {
@@ -84,6 +73,17 @@
         }
       ],
       "_apm_source": "hooks-quality"
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".claude/hooks/mcp-repomix/scripts/repomix-refresh-snapshot.sh",
+          "timeout": 30
+        }
+      ],
+      "_apm_source": "mcp-repomix"
     },
     {
       "matcher": "Bash",

--- a/apm.yml
+++ b/apm.yml
@@ -30,8 +30,11 @@ dependencies:
   - srobroek/agentic-packages/packages/mcp-serena#main
   - srobroek/agentic-packages/packages/user-journeys#main
 includes: auto
+targets:
+  - claude
+  - codex
 scripts:
-  install-agentic-tools: apm install --target claude,codex,agent-skills --update
+  install-agentic-tools: apm install --target claude,codex --update
   compile-agentic-tools: apm compile --target codex --no-constitution && apm compile
     --target claude --no-constitution
   setup-agentic-tools: apm run install-agentic-tools && apm run compile-agentic-tools


### PR DESCRIPTION
Declares `targets: [claude, codex]` in `apm.yml` and drops `agent-skills` from the install script.

Also carries local edits to APM-installed assets that were sitting uncommitted in the same tree: `orchestrate/SKILL.md`, `write-agentic` lint + a new 52-line `test_lint.py`, and a reordering of two PostToolUse entries in `apm-hooks.json`.

Note: those asset files are APM-generated from `srobroek/agentic-packages`, so the next `apm install` will overwrite them. The durable home for those edits is upstream; this PR lands them so the work is not lost on local disk during the org migration.