### PR TITLE
chore: repoint org references to platevault after migration

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -33,5 +33,5 @@ jobs:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
           branch: "cla-signatures"
-          allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*,nightwatch-astro-ci*"
+          allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*"
           lock-pullrequest-aftermerge: "false"

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ name: Release Please
 # tauri-apps/tauri-action (minisign, via the TAURI_SIGNING_PRIVATE_KEY[_PASSWORD]
 # repo secrets), and uploads them — plus the generated `latest.json` updater
 # manifest — to the release that release-please just created. This is what
-# makes https://github.com/nightwatch-astro/alm/releases/latest/download/latest.json
+# makes https://github.com/platevault/platevault/releases/latest/download/latest.json
 # resolve for `tauri-plugin-updater`. The embedded public key that verifies
 # these signatures lives in apps/desktop/src-tauri/tauri.conf.json and is
 # owned by a separate US10 lane, not this workflow.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See `docs/journeys/` for the full set of supported user workflows.
 
 ## Download
 
-Builds are published on [GitHub Releases](https://github.com/nightwatch-astro/alm/releases/latest).
+Builds are published on [GitHub Releases](https://github.com/platevault/platevault/releases/latest).
 
 | Platform | Package |
 |---|---|

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMzMzJFRjQzNUMxNkVBNTgKUldSWTZoWmNRKzh5d3hnZGNJSUl5dkpiN2RuQTVPYUcycHp6SzN1d0tIWWtWNG1vSGZ6bXE2cnYK",
       "endpoints": [
-        "https://github.com/nightwatch-astro/alm/releases/latest/download/latest.json"
+        "https://github.com/platevault/platevault/releases/latest/download/latest.json"
       ]
     }
   }


### PR DESCRIPTION
Follow-up to the org migration (`nightwatch-astro/alm` → `platevault/platevault`).

Redirects cover git remotes and web links, but the **updater endpoint** is resolved by already-shipped clients rather than followed as a redirect, so it is pinned explicitly. Signing key is unchanged — the installed base keeps updating.

- `tauri.conf.json` updater endpoint → new canonical URL
- `README.md` releases link
- `release-please.yml` comment URL
- `cla-assistant.yml` — drop `nightwatch-astro-ci*` (superseded by `sjorsr-release-bot`, not installed on the new org)

CHANGELOG history links deliberately left alone; redirects cover them.