### PR TITLE
ci: gate Real-UI E2E at job level so a skipped shard never reports success

### DIFF
--- a/.github/workflows/cla-assistant.yml
+++ b/.github/workflows/cla-assistant.yml
@@ -33,5 +33,5 @@ jobs:
           path-to-signatures: "signatures/cla.json"
           path-to-document: "https://github.com/${{ github.repository }}/blob/main/CLA.md"
           branch: "cla-signatures"
-          allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*,nightwatch-astro-ci*"
+          allowlist: "srobroek,bot*,dependabot*,renovate*,*[bot]*,sjorsr-release-bot*"
           lock-pullrequest-aftermerge: "false"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -119,11 +119,18 @@ env:
 jobs:
   # Cheap change-detection gate — mirrors ci.yml's `changes` job. Cross-workflow
   # `needs` is not supported, so each workflow detects changes itself. The E2E
-  # build (frontend + Rust app) is skipped when the change cannot affect either;
-  # the job still runs and reports success so its status check stays green.
-  # `run` is true when a frontend OR Rust change is present, or any full-suite
+  # build (frontend + Rust app) is skipped when the change cannot affect either.
+  # `run` is true when a frontend OR Rust change is present, any full-suite
   # trigger fires (workflows, Cargo/lockfiles, package manifests, justfile,
-  # scripts).
+  # scripts), or the run was dispatched by hand.
+  #
+  # `run` gates whole JOBS (`if:` at job level), never individual steps. A job
+  # skipped by `if:` concludes `skipped`, which branch protection accepts as
+  # satisfied but which is a DIFFERENT conclusion from `success` in the UI and
+  # in the checks API. Gating step-by-step instead produced a job full of
+  # skipped steps that still concluded `success`, making "the suite passed"
+  # and "the suite never ran" indistinguishable to humans and pollers alike
+  # (see the PR that introduced this comment: job 88177101061).
   changes:
     name: Detect changes
     runs-on: ubuntu-latest
@@ -159,9 +166,12 @@ jobs:
               - '**/*.css'
       - id: decide
         shell: bash
+        env:
+          DISPATCHED: ${{ github.event_name == 'workflow_dispatch' }}
         run: |
           run=false
-          if [ "${{ steps.filter.outputs.force_full }}" = "true" ] \
+          if [ "$DISPATCHED" = "true" ] \
+            || [ "${{ steps.filter.outputs.force_full }}" = "true" ] \
             || [ "${{ steps.filter.outputs.rust }}" = "true" ] \
             || [ "${{ steps.filter.outputs.frontend }}" = "true" ]; then
             run=true
@@ -183,13 +193,13 @@ jobs:
   build-frontend:
     name: Build frontend (once)
     needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
 
       - name: Restore dist by content key
-        if: needs.changes.outputs.run == 'true'
         id: dist-cache
         uses: actions/cache@v4
         with:
@@ -197,30 +207,29 @@ jobs:
           key: e2e-dist-${{ hashFiles('pnpm-lock.yaml', 'apps/desktop/package.json', 'apps/desktop/index.html', 'apps/desktop/vite.config.*', 'apps/desktop/tsconfig*.json', 'apps/desktop/src/**', 'apps/desktop/public/**', 'packages/**') }}
 
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.run == 'true' && steps.dist-cache.outputs.cache-hit != 'true'
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.run == 'true' && steps.dist-cache.outputs.cache-hit != 'true'
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         with:
           node-version: 20
           cache: pnpm
 
       - name: Install JS deps
-        if: needs.changes.outputs.run == 'true' && steps.dist-cache.outputs.cache-hit != 'true'
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         run: pnpm install --frozen-lockfile
 
       # VITE_E2E=1 enables CI-only typeable path inputs (the native folder
       # picker cannot be driven by WebDriver).
       - name: Build frontend (VITE_E2E)
-        if: needs.changes.outputs.run == 'true' && steps.dist-cache.outputs.cache-hit != 'true'
+        if: steps.dist-cache.outputs.cache-hit != 'true'
         env:
           VITE_E2E: "1"
         run: pnpm --filter @astro-plan/desktop build
 
       - uses: actions/upload-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-frontend-dist
           path: apps/desktop/dist
@@ -239,6 +248,7 @@ jobs:
   build-app-ubuntu:
     name: Build app — ubuntu-latest
     needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -247,7 +257,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore app + test archive by content key
-        if: needs.changes.outputs.run == 'true'
         id: app-cache
         uses: actions/cache@v4
         with:
@@ -264,7 +273,6 @@ jobs:
       # paths on disk before trusting it, so a bad cache entry self-heals into
       # a rebuild instead of a wall of red shards.
       - name: Verify cached binary is usable
-        if: needs.changes.outputs.run == 'true'
         id: verify-app-cache
         shell: bash
         run: |
@@ -277,7 +285,7 @@ jobs:
       # Tauri needs system webview/GTK libs to build on Linux.
       # No webkit2gtk-driver — the plugin replaces the external driver.
       - name: Install Tauri Linux system deps
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -285,36 +293,35 @@ jobs:
             libayatana-appindicator3-dev
 
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         with:
           shared-key: "rust-e2e-ubuntu-latest"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
 
       # Debug builds load the frontend from the Tauri devUrl at runtime, but
       # tauri-build still wants the configured frontendDist directory present.
       - name: Stub frontend dist for tauri-build
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         shell: bash
         run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
 
       - name: Build desktop_shell with e2e feature
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: cargo build -p desktop_shell --features e2e
 
       # Package the compiled e2e_tests binaries so shards run them without a
       # Rust rebuild (`cargo nextest run --archive-file`).
       - name: Archive e2e test binaries
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
 
       - uses: actions/upload-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-build-ubuntu-latest
           path: |
@@ -326,6 +333,7 @@ jobs:
   build-app-windows:
     name: Build app — windows-latest
     needs: changes
+    if: needs.changes.outputs.run == 'true'
     runs-on: windows-latest
     timeout-minutes: 45
     env:
@@ -334,7 +342,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore app + test archive by content key
-        if: needs.changes.outputs.run == 'true'
         id: app-cache
         uses: actions/cache@v4
         with:
@@ -346,7 +353,6 @@ jobs:
       # See the ubuntu chain's "Verify cached binary is usable" comment for
       # why a reported cache-hit alone is not trusted.
       - name: Verify cached binary is usable
-        if: needs.changes.outputs.run == 'true'
         id: verify-app-cache
         shell: bash
         run: |
@@ -357,32 +363,31 @@ jobs:
           fi
 
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         with:
           shared-key: "rust-e2e-windows-latest"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
 
       - name: Stub frontend dist for tauri-build
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         shell: bash
         run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
 
       - name: Build desktop_shell with e2e feature
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: cargo build -p desktop_shell --features e2e
 
       - name: Archive e2e test binaries
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
 
       - uses: actions/upload-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-build-windows-latest
           path: |
@@ -394,7 +399,7 @@ jobs:
   build-app-macos:
     name: Build app — macos-latest
     needs: changes
-    if: needs.changes.outputs.run_macos == 'true'
+    if: needs.changes.outputs.run == 'true' && needs.changes.outputs.run_macos == 'true'
     runs-on: macos-latest
     timeout-minutes: 45
     env:
@@ -403,7 +408,6 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Restore app + test archive by content key
-        if: needs.changes.outputs.run == 'true'
         id: app-cache
         uses: actions/cache@v4
         with:
@@ -415,7 +419,6 @@ jobs:
       # See the ubuntu chain's "Verify cached binary is usable" comment for
       # why a reported cache-hit alone is not trusted.
       - name: Verify cached binary is usable
-        if: needs.changes.outputs.run == 'true'
         id: verify-app-cache
         shell: bash
         run: |
@@ -426,32 +429,31 @@ jobs:
           fi
 
       - uses: dtolnay/rust-toolchain@stable
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         with:
           shared-key: "rust-e2e-macos-latest"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
 
       - name: Stub frontend dist for tauri-build
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         shell: bash
         run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
 
       - name: Build desktop_shell with e2e feature
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: cargo build -p desktop_shell --features e2e
 
       - name: Archive e2e test binaries
-        if: needs.changes.outputs.run == 'true' && steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.usable != 'true'
         run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
 
       - uses: actions/upload-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-build-macos-latest
           path: |
@@ -472,6 +474,7 @@ jobs:
   real-ui-e2e-ubuntu:
     name: Real-UI E2E shard — ubuntu-latest ${{ matrix.shard }}/4
     needs: [changes, build-frontend, build-app-ubuntu]
+    if: needs.changes.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -492,7 +495,6 @@ jobs:
       # dev metapackages are what the runner image resolves fastest and the
       # difference is seconds; keep the known-good set plus xvfb.
       - name: Install Tauri Linux system deps
-        if: needs.changes.outputs.run == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -501,28 +503,23 @@ jobs:
             xvfb
 
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.run == 'true'
 
       # cargo-binstall fetches a prebuilt tauri-webdriver binary when the
       # crate publishes one, falling back to `cargo install` (source build)
       # automatically otherwise — never slower than the plain `cargo install`
       # this replaces, often much faster.
       - uses: taiki-e/install-action@cargo-binstall
-        if: needs.changes.outputs.run == 'true'
 
       # Install the tauri-webdriver CLI proxy.
       # It bridges W3C client (:4444) → plugin embedded server (:4445).
       - name: Install tauri-webdriver CLI
-        if: needs.changes.outputs.run == 'true'
         run: cargo binstall tauri-webdriver --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           node-version: 20
           cache: pnpm
@@ -530,30 +527,25 @@ jobs:
       # Only needed for `vite preview` (SPA fallback for deep links); the
       # frontend itself arrives prebuilt from build-frontend.
       - name: Install JS deps
-        if: needs.changes.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       - uses: actions/download-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-frontend-dist
           path: apps/desktop/dist
 
       - uses: actions/download-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-build-ubuntu-latest
 
       # Artifact download drops the execute bit on POSIX.
       - name: Make app binary executable
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: chmod +x "$APP_BIN"
 
       # Serve built dist on :5173 in the background. The app binary reads the
       # Tauri devUrl (:5173) and loads its frontend from there — real IPC.
       - name: Serve frontend dist on :5173
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
@@ -566,7 +558,6 @@ jobs:
       # ~25-30s of per-test overhead vs Windows. Linux-only; harmless no-op if
       # the hypothesis is wrong.
       - name: Run E2E (xvfb)
-        if: needs.changes.outputs.run == 'true'
         env:
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
@@ -577,6 +568,7 @@ jobs:
   real-ui-e2e-windows:
     name: Real-UI E2E shard — windows-latest ${{ matrix.shard }}/2
     needs: [changes, build-frontend, build-app-windows]
+    if: needs.changes.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -589,48 +581,38 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.run == 'true'
 
       - uses: taiki-e/install-action@cargo-binstall
-        if: needs.changes.outputs.run == 'true'
 
       - name: Install tauri-webdriver CLI
-        if: needs.changes.outputs.run == 'true'
         run: cargo binstall tauri-webdriver --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           node-version: 20
           cache: pnpm
 
       - name: Install JS deps
-        if: needs.changes.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       - uses: actions/download-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-frontend-dist
           path: apps/desktop/dist
 
       - uses: actions/download-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-build-windows-latest
 
       - name: Serve frontend dist on :5173
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
       - name: Run E2E
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         env:
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
@@ -642,6 +624,7 @@ jobs:
   real-ui-e2e-macos:
     name: Real-UI E2E shard — macos-latest ${{ matrix.shard }}/2
     needs: [changes, build-frontend, build-app-macos]
+    if: needs.changes.outputs.run == 'true'
     strategy:
       fail-fast: false
       matrix:
@@ -654,53 +637,42 @@ jobs:
       - uses: actions/checkout@v4
 
       - uses: taiki-e/install-action@nextest
-        if: needs.changes.outputs.run == 'true'
 
       - uses: taiki-e/install-action@cargo-binstall
-        if: needs.changes.outputs.run == 'true'
 
       - name: Install tauri-webdriver CLI
-        if: needs.changes.outputs.run == 'true'
         run: cargo binstall tauri-webdriver --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           node-version: 20
           cache: pnpm
 
       - name: Install JS deps
-        if: needs.changes.outputs.run == 'true'
         run: pnpm install --frozen-lockfile
 
       - uses: actions/download-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-frontend-dist
           path: apps/desktop/dist
 
       - uses: actions/download-artifact@v4
-        if: needs.changes.outputs.run == 'true'
         with:
           name: e2e-build-macos-latest
 
       - name: Make app binary executable
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: chmod +x "$APP_BIN"
 
       - name: Serve frontend dist on :5173
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
       - name: Run E2E
-        if: needs.changes.outputs.run == 'true'
         shell: bash
         env:
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
@@ -710,14 +682,17 @@ jobs:
   # Per-OS gates preserving the pre-DAG check names ("Real-UI E2E — <os>").
   # Each gate depends ONLY on its own OS's shards, so a failure on one OS
   # reds only that OS's gate — identical semantics to the old per-OS jobs.
-  # `always()` keeps the gate reporting (red) instead of skipping when a
-  # shard or upstream builder fails; the run=false no-op path stays green
-  # because skipped-step shards still conclude success.
+  # `always()` keeps the gate reporting (red) instead of skipping when a shard
+  # or upstream builder fails. The gate is itself gated on run=='true', so a
+  # green gate means the shards genuinely executed and passed — it is never
+  # reachable via the no-op path. When run=='false' the whole chain, gate
+  # included, concludes `skipped`, which branch protection accepts without
+  # ever claiming the suite passed.
   # ---------------------------------------------------------------------------
   e2e-gate-ubuntu:
     name: Real-UI E2E — ubuntu-latest
     needs: [changes, real-ui-e2e-ubuntu]
-    if: always()
+    if: always() && needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -731,7 +706,7 @@ jobs:
   e2e-gate-windows:
     name: Real-UI E2E — windows-latest
     needs: [changes, real-ui-e2e-windows]
-    if: always()
+    if: always() && needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -746,7 +721,7 @@ jobs:
   e2e-gate-macos:
     name: Real-UI E2E — macos-latest
     needs: [changes, real-ui-e2e-macos]
-    if: always() && needs.changes.outputs.run_macos == 'true'
+    if: always() && needs.changes.outputs.run == 'true' && needs.changes.outputs.run_macos == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -17,7 +17,7 @@ name: Release Please
 # tauri-apps/tauri-action (minisign, via the TAURI_SIGNING_PRIVATE_KEY[_PASSWORD]
 # repo secrets), and uploads them — plus the generated `latest.json` updater
 # manifest — to the release that release-please just created. This is what
-# makes https://github.com/nightwatch-astro/alm/releases/latest/download/latest.json
+# makes https://github.com/platevault/platevault/releases/latest/download/latest.json
 # resolve for `tauri-plugin-updater`. The embedded public key that verifies
 # these signatures lives in apps/desktop/src-tauri/tauri.conf.json and is
 # owned by a separate US10 lane, not this workflow.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ See `docs/journeys/` for the full set of supported user workflows.
 
 ## Download
 
-Builds are published on [GitHub Releases](https://github.com/nightwatch-astro/alm/releases/latest).
+Builds are published on [GitHub Releases](https://github.com/platevault/platevault/releases/latest).
 
 | Platform | Package |
 |---|---|

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -40,7 +40,7 @@
     "updater": {
       "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEMzMzJFRjQzNUMxNkVBNTgKUldSWTZoWmNRKzh5d3hnZGNJSUl5dkpiN2RuQTVPYUcycHp6SzN1d0tIWWtWNG1vSGZ6bXE2cnYK",
       "endpoints": [
-        "https://github.com/nightwatch-astro/alm/releases/latest/download/latest.json"
+        "https://github.com/platevault/platevault/releases/latest/download/latest.json"
       ]
     }
   }


### PR DESCRIPTION
## The hazard

`.github/workflows/e2e.yml` applied the `Detect changes` job's `run` output as a
**per-step** `if:`. When a commit touched no app path, every meaningful step in a
shard job was skipped — but a job whose steps all skip still concludes
**`success`**. Branch protection, the PR checks UI and automated pollers all read
that as "the Real-UI E2E suite passed".

The workflow even documented the broken assumption out loud:

> `always()` keeps the gate reporting (red) instead of skipping when a shard or
> upstream builder fails; **the run=false no-op path stays green because
> skipped-step shards still conclude success.**

### Confirmed instance

Job **88177101061** (run 29680970533, commit `ad88f8a2` on `main`) reported shard
`success` with every one of these steps `skipped`:

- Install Tauri Linux system deps
- Run `taiki-e/install-action@nextest`
- Install `tauri-webdriver` CLI
- Install JS deps
- `actions/download-artifact` (frontend dist)
- `actions/download-artifact` (app + test archive)
- Make app binary executable

### What it cost

#1038 (`1eae04e9`) merged with a **real E2E failure on its own branch**. Every
subsequent commit on `main` was config-only, path-skipped the suite, and reported
green — so `main` looked healthy while carrying a live regression. It surfaced
only when an unrelated PR happened to touch an app path and un-skipped the suite.
This trap has burned this project before (docs-only pushes masking a red main).

## The fix

Move `run` gating from steps to **jobs**. One coherent mechanism, no new
machinery:

- `if: needs.changes.outputs.run == 'true'` on `build-frontend`, `build-app-*`
  and `real-ui-e2e-*`.
- The per-OS gates (`Real-UI E2E — <os>`, the required checks) carry the same
  condition, so a green gate is now **only reachable when the shards actually
  ran**.
- All the now-redundant per-step `if:` conditions are deleted; the cache-hit
  conditions that carried real meaning are preserved.

A job skipped by `if:` concludes `skipped`. Branch protection treats a skipped
required check as satisfied — so docs-only PRs still merge — but `skipped` is a
**different conclusion from `success`** in the checks API and renders distinctly
in the UI. A poller asking "did E2E pass?" can no longer be answered `success` by
a suite that never ran.

### Why this approach over the alternatives

- *Report neutral instead of success* would need a `gh api` call per shard to
  patch the check-run conclusion — new tokens, new failure modes, for an outcome
  GitHub already gives us free via job-level `if:`.
- *A separate "did it run" check* adds a job whose only purpose is to describe
  another job's state; the existing gates already occupy that slot.

Job-level gating is the smallest change that makes the distinction structural
rather than advisory, and it deletes more lines (79) than it adds (54).

### Also included

`run=true` is forced on `workflow_dispatch`. The dispatch-only macOS re-test
(issue #489) could otherwise path-skip itself into a silent no-op — the same bug
class, one line to close.

## Scope note

`ci.yml` has the same *hazard* but not the same *pattern*: its `integration` job
interleaves rust-gated and frontend-gated steps in a single job, so job-level
gating would require splitting it in two. That is a larger refactor and was not
the incident here — deliberately left out.

## Verification

- `actionlint .github/workflows/e2e.yml` — clean.
- YAML parses; all eleven jobs carry the expected conditions:

```
build-frontend       if: needs.changes.outputs.run == 'true'
build-app-ubuntu     if: needs.changes.outputs.run == 'true'
build-app-windows    if: needs.changes.outputs.run == 'true'
build-app-macos      if: run == 'true' && run_macos == 'true'
real-ui-e2e-ubuntu   if: needs.changes.outputs.run == 'true'
real-ui-e2e-windows  if: needs.changes.outputs.run == 'true'
real-ui-e2e-macos    if: needs.changes.outputs.run == 'true'
e2e-gate-ubuntu      if: always() && run == 'true'
e2e-gate-windows     if: always() && run == 'true'
e2e-gate-macos       if: always() && run == 'true' && run_macos == 'true'
```

This PR touches `.github/workflows/**`, which is a `force_full` trigger — so the
full suite runs on this PR and the green/red here is genuine.

## Spec Context
- Spec: 300
- Branch: worktree-worktree-3008119
