### PR TITLE
docs: land the adaptive detail dock spec record and pin its containment contract

### DIFF
--- a/apps/desktop/src/components/DetailPanel.test.tsx
+++ b/apps/desktop/src/components/DetailPanel.test.tsx
@@ -303,4 +303,50 @@ describe('FactsKV', () => {
     );
     expect(screen.getByText('Inferred')).toBeDefined();
   });
+
+  // ── Scroll-containment contract — the #816 regression pin (T004, #1069) ───
+  //
+  // #816 was "Target detail panel: aliases/notes/coverage/links/back-button
+  // silently clipped by DetailPane fill-mode overflow:hidden". The fix (#1035)
+  // is a CSS rule in redesign-detail.css:
+  //
+  //     .alm-detail--fill > .alm-planner__scroll { flex:1; min-height:0; overflow-y:auto }
+  //
+  // That is a DIRECT-CHILD selector, which makes it a structural contract on
+  // DetailPanel rather than a mere stylesheet detail: nest the scroll wrapper
+  // one level deeper and the selector silently stops matching — no test fails,
+  // no type breaks, the content just starts getting clipped again.
+  //
+  // This became load-bearing in #1067, when TargetDetailV2 migrated onto
+  // DetailPanel and deliberately kept content-only mode instead of the facts
+  // slot, precisely because facts nests children one level too deep.
+  //
+  // jsdom has no layout engine, so these assert the STRUCTURAL contract the
+  // CSS depends on, not actual pixel scrolling.
+
+  it('19. content-only children stay direct children of .alm-detail--fill (#816)', () => {
+    const { container } = render(
+      <DetailPanel fill title="Selected target">
+        <div className="alm-planner__scroll">tall unstructured content</div>
+      </DetailPanel>,
+    );
+    // The exact selector redesign-detail.css relies on.
+    expect(
+      container.querySelector('.alm-detail--fill > .alm-planner__scroll'),
+    ).not.toBeNull();
+  });
+
+  it('20. the facts slot does NOT satisfy that selector — why TargetDetailV2 avoids it', () => {
+    const { container } = render(
+      <DetailPanel fill title="Selected target" facts={<dl>identity</dl>}>
+        <div className="alm-planner__scroll">tall unstructured content</div>
+      </DetailPanel>,
+    );
+    // Present in the tree, but nested under .alm-detailpanel__content — the
+    // direct-child rule no longer applies and #816's clipping would return.
+    expect(container.querySelector('.alm-planner__scroll')).not.toBeNull();
+    expect(
+      container.querySelector('.alm-detail--fill > .alm-planner__scroll'),
+    ).toBeNull();
+  });
 });

--- a/docs/development/windows-validation/054-adaptive-detail-dock.md
+++ b/docs/development/windows-validation/054-adaptive-detail-dock.md
@@ -1,0 +1,196 @@
+# Windows validation — adaptive detail-panel dock (spec 054)
+
+> For: Claude computer-use ("cowork") on the Windows machine running PlateVault.
+> You have NO access to the source repo. Everything you need is in this document.
+> Report each Test as PASS / FAIL with what you observed.
+> Tracks issue #1069 (spec reconciliation). Shipped via PR #1003 (+ #1035, #1060).
+
+## Change facts (context — you do not act on this section)
+
+- Spec / feature: 054 adaptive detail-panel dock, reconciled 2026-07-19
+  against what actually shipped (see `specs/054-adaptive-detail-dock/spec.md`
+  for the full reconciliation — the feature was originally designed with a
+  third "permanent split" placement and Targets-specific column pinning;
+  **neither shipped**, so this script only covers the two placements that
+  are actually on `main`).
+- Branch to test: `main`
+- Touches Rust backend? **no** — frontend-only (placement/width persist via
+  browser `localStorage`, not a Tauri command or `AppPreferences`).
+- New/changed Tauri commands: none.
+- Changed surfaces: every list page — Sessions, Calibration, Inbox, Archive,
+  Targets, Projects — via the shared `ListPageLayout` component.
+- What changed for the user: the detail panel now docks to the **RIGHT
+  (side)** when the window is wide and to the **BOTTOM** when narrow, with a
+  per-page pin toggle that is remembered, and a drag-resizable side split.
+  There is **no** three-way Auto/Bottom/Right control — only a single toggle
+  button that flips between the two pinned states (see Test 2's known-bug
+  note, #1066). Inbox behaves the same as every other page here; it does
+  **not** get a permanent split layout (that was designed but never shipped
+  — see #1068 for the open decision about whether it ever will).
+
+## Preconditions — get the app to the right state
+
+1. Deploy `main` on the Windows checkout `C:\dev\astro-plan`:
+   - `git fetch origin`
+   - `git reset --hard origin/main`   (run as its OWN command)
+   - **Force rebuild (mtime trap)** — `git reset --hard` restores content
+     with an old mtime so cargo/vite may skip recompiling and the app stays
+     stale. This feature is frontend-only, but touch the changed files
+     anyway to be safe:
+     ```powershell
+     Get-ChildItem 'C:\dev\astro-plan\apps\desktop\src\ui\useAdaptiveDock.ts','C:\dev\astro-plan\apps\desktop\src\components\ListPageLayout.tsx' | ForEach-Object { $_.LastWriteTime = Get-Date }
+     ```
+2. A clean first-run is NOT required (these are existing pages). If the app
+   is stuck on the setup wizard, reset the DB and relaunch:
+   `Remove-Item 'C:\dev\astro-plan\wizard-test.db*' -Force`
+3. Launch:
+   ```powershell
+   powershell.exe -NoProfile -Command "Start-Process -FilePath 'cmd.exe' -ArgumentList '/k','C:\dev\astro-plan\run-dev.bat' -WorkingDirectory 'C:\dev\astro-plan'"
+   ```
+   Wait for the window (process `desktop_shell.exe`, Vite on `localhost:5173`).
+4. Prepare data: you need at least a few rows on Sessions or Calibration and
+   one Inbox item, so a detail panel can open. If the library is empty, add a
+   light-frames root in Settings › Data Sources and run a scan. If data
+   already exists, skip.
+5. Sanity: the app renders a real page (not a blank window). If blank → see
+   Troubleshooting.
+
+## Tests
+
+### Test 1 — Placement flips side ⇄ bottom with window width
+Steps:
+1. Go to **Sessions** (or Calibration/Archive/Targets/Projects) and select a
+   row so the detail panel appears.
+2. Make the window **wide** — maximize it, or resize to well over 1400px
+   across.
+3. Observe where the detail panel sits.
+4. Now **narrow** the window by dragging its edge until it is clearly narrow
+   (roughly half-screen, under ~1400px across — try ~1100px).
+5. Observe again.
+Expected:
+- Wide (≥ ~1400px): the detail panel sits to the **RIGHT** of the table
+  (side-by-side), full height, with a vertical drag handle on its left edge.
+- Narrow (< ~1400px): the detail panel moves to the **BOTTOM**, under a
+  full-width table, and the drag handle disappears.
+- The flip happens as you cross ~1400px; it should not flicker while you
+  hold a steady width near that boundary.
+FAIL if:
+- The panel stays bottom-docked at full width, or stays side-docked when
+  narrow; or it oscillates rapidly at a steady width; or the table/panel
+  visibly overlap.
+
+### Test 2 — Placement pin toggle persists across restart (note: no "Auto" — #1066)
+Steps:
+1. On **Calibration** (or any list page), select a row so the detail panel
+   shows, with the window **wide** (side-docked).
+2. Find the small pin/toggle button in the detail panel's header bar (an
+   arrow icon — right-pointing when bottom-docked, down-pointing when
+   side-docked).
+3. Click it. Observe the placement flip.
+4. Click it again. Observe it flip back.
+5. Leave it pinned to one state (e.g. click until it reads bottom-docked).
+   Fully close the app (`Get-Process desktop_shell,cargo | Stop-Process
+   -Force`) and relaunch via the Precondition step 3 command. Return to the
+   same page and reselect the row.
+Expected:
+- Each click flips the panel between side and bottom, regardless of the
+  current window width.
+- After restart, the pinned placement is **still in effect** (persisted).
+- **Known gap (#1066, not a regression to report)**: there is no "Auto"
+  option — the toggle only ever alternates between the two pinned states.
+  Once you've clicked it, resizing the window no longer changes placement
+  (it stays pinned) until you click the toggle again. This is expected
+  current behavior, not a bug to file — it's already tracked.
+FAIL if:
+- The toggle does nothing; the pin does not persist across restart; or
+  clicking it navigates away / errors instead of flipping placement.
+
+### Test 3 — Drag-resizable side split, width persists
+Steps:
+1. On any list page with a wide window and the panel **side-docked**, find
+   the vertical **drag handle** on the boundary between the table and the
+   detail panel (cursor becomes a left-right resize arrow when hovering it).
+2. Drag it left and right. Observe the panel width change.
+3. Drag it as far as it will go in each direction.
+4. Restart the app (as in Test 2) and return to the same page with the
+   panel side-docked.
+Expected:
+- Dragging resizes the side panel smoothly; the table reflows to fit.
+- The width is **clamped** — it will not shrink below a usable minimum
+  (~320px) nor grow past about half the window.
+- After restart, the panel returns to your dragged width, not the default
+  (~420px).
+FAIL if:
+- No draggable handle exists; dragging does nothing; the panel can be
+  dragged to zero / off-screen / past half the window; or the width resets
+  to default on restart.
+
+### Test 4 — Detail panel content stays reachable in both placements (containment)
+Steps:
+1. Open a **Target**'s detail on the Targets page — this page's detail
+   historically had content clipped below the fold (#816, fixed by #1035).
+   Pick a target with several sections of detail (aliases, notes, coverage,
+   links) if available.
+2. With the panel **side-docked**, scroll the detail panel to the bottom.
+3. Confirm you can see/reach the lower content.
+4. Toggle to **bottom-docked** (Test 2's toggle) and repeat the
+   scroll-to-bottom check.
+Expected:
+- All lower content is reachable by scrolling **within the panel**, in both
+  placements — no content is cut off below the visible panel edge.
+FAIL if:
+- Any content is cut off and cannot be reached by scrolling in either
+  placement, or two nested scrollbars appear.
+
+### Test 5 — Inbox uses the same mechanism as other pages (not a permanent split)
+Steps:
+1. Go to **Inbox** with at least one item. Select an item so the detail
+   panel shows.
+2. Repeat Test 1 (resize wide → narrow) on this page.
+Expected:
+- Inbox behaves **identically** to Sessions/Calibration/Archive/Targets/
+  Projects: side dock when wide, bottom dock when narrow. There is no
+  permanent left-list/right-detail split, and no different behavior from the
+  other pages.
+FAIL if:
+- Inbox does something visibly different from the other pages tested in
+  Test 1 (this would indicate the permanent-split design landed after all —
+  flag it, since it isn't expected on `main` and #1068 is still an open
+  decision, not a shipped feature).
+
+## Troubleshooting
+- Blank window (empty content): restart the dev server; if still blank, run
+  `pnpm install` in `C:\dev\astro-plan` with `$env:CI="true"`, relaunch.
+- Stale behavior after the reset: confirm you touched the changed files
+  after `git reset --hard` (mtime trap). A hard refresh (Ctrl+R) reloads the
+  latest Vite bundle for this frontend-only feature.
+- Placement seems stuck: this feature persists state in browser
+  `localStorage`, not the dev database — `wizard-test.db` resets do not
+  clear it. To force a clean placement/width state, clear `localStorage` for
+  the app's origin (DevTools → Application → Local Storage) or look for keys
+  prefixed `alm-dock-`.
+
+## Report back
+For each Test 1–5: PASS / FAIL + one line of what you saw. On any FAIL,
+capture a screenshot and the exact on-screen text / any toast. Note the
+approximate window width at which placement flips in Test 1.
+
+## Not covered by this script (in flight, not on `main`)
+
+- **3-state Auto/Bottom/Right placement control** (#1066, PR #1070 open) —
+  Test 2 above documents the current 2-state toggle as expected behavior.
+  Once #1070 merges, this script needs a new test for the Auto state and
+  this note should be removed.
+- **Archive/Projects/Targets migration to the shared `DetailPanel`
+  component** (#1067, PR #1072 open) — these three pages currently hand-roll
+  their own detail markup rather than using the same shared container as
+  Sessions/Calibration/Inbox. This is not independently visually testable
+  (the containment behavior should look the same either way if each page's
+  hand-rolled version is correct), but is worth knowing if Test 4 fails
+  specifically on Archive or Projects and not on Sessions/Calibration/Inbox
+  — that asymmetry would be consistent with #1067's still-open gap.
+- **Permanent Inbox split / Targets pinned columns** — these were part of
+  the original design but are an **open product decision** (#1068) and a
+  **superseded, untracked design idea** respectively; neither is expected on
+  `main`. Test 5 above exists specifically to confirm Inbox has NOT silently
+  gained different behavior.

--- a/specs/054-adaptive-detail-dock/contracts/README.md
+++ b/specs/054-adaptive-detail-dock/contracts/README.md
@@ -1,0 +1,22 @@
+# Contracts: Adaptive Detail-Panel Dock
+
+**N/A — this feature introduces no UI↔core transport changes**, in both the
+original design and the shipped implementation.
+
+The adaptive dock is a pure frontend layout + client-side UI-preference
+feature. It adds:
+
+- **No** Tauri command.
+- **No** contract DTO (`crates/contracts/core`, `packages/contracts`, or
+  generated `apps/desktop/src/bindings`).
+- **No** SQLite schema or migration.
+
+All new state is local UI-preference state. As shipped, it lives in raw
+`localStorage` keys (`alm-dock-placement-<dockId>`, `alm-dock-width-<dockId>`
+— see [../data-model.md](../data-model.md)), not in the originally designed
+`AppPreferences.detailDock` typed field. Either shape is outside the durable
+relationship/audit record per Constitution §V.
+
+No generated bindings need regeneration for this feature. `just
+check-generated` remains clean without any contract edits — confirmed true
+for the shipped PRs (#1003, #1035, #1060) as well as the original design.

--- a/specs/054-adaptive-detail-dock/data-model.md
+++ b/specs/054-adaptive-detail-dock/data-model.md
@@ -1,0 +1,113 @@
+# Data Model: Adaptive Detail-Panel Dock (reconciled)
+
+**Feature**: 054-adaptive-detail-dock | **Reconciled**: 2026-07-19 (#1069) |
+**Plan**: [plan.md](./plan.md)
+
+This feature introduces **no durable (SQLite) data** and **no contract DTOs**,
+as the original design also concluded. It differs from the original design in
+**where** and **how** the client-side UI-preference state is stored.
+
+## Entity: Detail placement preference (per page) — as shipped
+
+The original design (research.md D4) proposed a typed field on the existing
+`AppPreferences` object, mirroring the `projectViewModes` keyed-map
+precedent. **That was not built.** What shipped
+(`apps/desktop/src/ui/useAdaptiveDock.ts:58-71`) is a pair of raw
+`localStorage` keys per `dockId`, entirely outside the `AppPreferences` /
+`preferences.ts` store:
+
+```ts
+// As shipped — apps/desktop/src/ui/useAdaptiveDock.ts
+const STORAGE_PREFIX = 'alm-dock';
+
+// key: `${STORAGE_PREFIX}-placement-${dockId}` → 'side' | 'bottom' (absent = null = auto)
+// key: `${STORAGE_PREFIX}-width-${dockId}`     → string(number), parsed with Number()
+```
+
+`dockId` defaults to the page's `detailLabel` (`ListPageLayout.tsx:157`) when
+not explicitly passed, so persistence is scoped per adopting page as long as
+each page's `detailLabel` (or explicit `dockId`) is stable and unique.
+
+### Field semantics (shipped)
+
+| Key | Type | Rule |
+|---|---|---|
+| `alm-dock-placement-<dockId>` | `'side' \| 'bottom'` string, or absent | Absent/invalid ⇒ `null` (follow the width heuristic). Set on every pin-toggle click; **never cleared by the current UI** — the `alm-listpage__detail-pin` button only ever writes `'side'` or `'bottom'`, so once set this key persists until localStorage is cleared manually. This is the root cause of #1066. |
+| `alm-dock-width-<dockId>` | numeric string | Default `420` (`defaultWidth`). Clamped to `[minWidth=320, round(window.innerWidth * 0.5)]` on every write (`clampWidth`, `useAdaptiveDock.ts:95-102`) — including the initial read, since `readStoredWidth` is only guarded by `Number.isFinite`, and the *first* render's `width` state is the raw stored value until the next `setWidth` call re-clamps it. |
+
+### What the original design's typed field would have added (not present)
+
+The branch's `DetailDockPreference { mode: 'adaptive' | 'side' | 'bottom';
+width: number }` shape, keyed by a closed `DetailDockPageKey` union
+(`'sessions' | 'calibration' | 'archive' | 'projects' | 'targets' | 'inbox'`)
+and integrated into `AppPreferences`, does not exist. Practical
+consequences of the gap:
+
+- No IPC/backend visibility into dock placement — it is pure browser
+  `localStorage`, not part of whatever sync/export path `AppPreferences`
+  might have.
+- `dockId` is a free-form string (defaults to `detailLabel`, an i18n-derived
+  label), not a closed enum — a page renaming its `detailLabel` without
+  passing an explicit `dockId` silently loses its persisted placement/width
+  (new key, old key orphaned). No adopting page currently hits this because
+  none pass a dynamic `detailLabel`, but it is a latent footgun the typed
+  design's closed `DetailDockPageKey` union would have prevented.
+- No single source of truth for "which pages have dock state" — an
+  `AppPreferences.detailDock` map would enumerate adopting pages; the
+  shipped design has no such registry, only whatever `dockId` values happen
+  to appear in `localStorage`.
+
+None of these are currently tracked as bugs; noting them here per #1069's
+instruction to record the gap rather than paper over it.
+
+### Page-level override (not built)
+
+The original design's `forcedPlacement?: 'bottom' | 'side' | 'split'` page
+capability (research.md D6), which would have won over both the user pin and
+the adaptive heuristic, **does not exist**. `ListPageLayout`'s
+`detailPlacement` prop is the only placement-shaping input available to a
+page, and it is a static JSX prop set once per page (not resolved through a
+precedence chain against a live user pin) — see `ListPageLayout.tsx:67-112`.
+
+### Derived (not persisted) runtime state — as shipped
+
+Computed each render inside `useAdaptiveDock` from `window.innerWidth` (via a
+`resize` listener) + the persisted `override`:
+
+- **`placement`**: `'side' | 'bottom'` — `useAdaptiveDock.ts:126-132`.
+  `sideAvailable = windowWidth >= minWidth * 2` gates whether a non-null
+  `override` is honored; below that, the width-threshold comparison wins
+  regardless of the pin.
+- **`resizing`**: `boolean`, true only during an active pointer-drag.
+
+### Validation / migration
+
+- No SQLite migration (localStorage only) — same conclusion as the original
+  design.
+- Backward compatibility: an absent key for a given `dockId` behaves as
+  `override = null`, `width = defaultWidth` (420) — equivalent in spirit to
+  the original design's "absent key ⇒ page default," but there is no single
+  `detailDock: {}` object to be absent; each `dockId`'s two keys are
+  independently absent or present.
+- Width is clamped on every `setWidth` call (including the value passed on
+  the initial persisted read being re-clamped the next time it's set), not
+  specifically gated as a one-time "on restore" step the way the original
+  design's `data-model.md` described it — functionally similar outcome
+  (an out-of-range persisted width self-corrects), different mechanism.
+
+## Non-data entities
+
+- **Placement** (`'side' | 'bottom'`) is a rendering concept computed by the
+  hook, not stored directly — only the `override` and `width` are persisted,
+  matching the original design's intent that placement itself is derived.
+
+## Summary
+
+| Concern | Original design | Shipped |
+|---|---|---|
+| SQLite tables | none | none (unchanged) |
+| SQLite migration | none | none (unchanged) |
+| Contract DTOs | none | none (unchanged) |
+| Tauri commands | none | none (unchanged) |
+| New persisted state | `AppPreferences.detailDock: Record<DetailDockPageKey, DetailDockPreference>` | Raw `localStorage['alm-dock-placement-<dockId>']` / `localStorage['alm-dock-width-<dockId>']`, `dockId` a free-form string |
+| Placements modeled | 3 (`side`/`bottom`/`split`) | 2 (`side`/`bottom`) |

--- a/specs/054-adaptive-detail-dock/plan.md
+++ b/specs/054-adaptive-detail-dock/plan.md
@@ -1,0 +1,175 @@
+# Implementation Plan: Adaptive Detail-Panel Dock
+
+**Branch**: shipped directly on `main` (#1003, #1035, #1060) | **Reconciled**:
+2026-07-19 (#1069) | **Spec**: [spec.md](./spec.md)
+
+**Input**: This plan describes the implementation that actually shipped. The
+original plan (written for the now-closed `feat/adaptive-detail-dock` branch,
+PR #1007) proposed a different, more elaborate architecture that was never
+built — see spec.md's Reconciliation note and the "Not delivered" sections
+below.
+
+## Summary
+
+One shared hook (`useAdaptiveDock`) drives one shared layout
+(`ListPageLayout`'s `detailPlacement="adaptive"` mode), adopted by all six
+list pages (Sessions, Calibration, Inbox, Archive, Targets, Projects) without
+per-page opt-in code — the default `detailPlacement` prop value is
+`'adaptive'`.
+
+- **`apps/desktop/src/ui/useAdaptiveDock.ts`** resolves `'side' | 'bottom'`
+  from `window.innerWidth` vs. a per-call `threshold` (default 1400px), an
+  explicit `override` (persisted per `dockId`), and a drag-resizable,
+  persisted `width`.
+- **`apps/desktop/src/ui/ResizeHandle.tsx`** is the pointer-drag divider,
+  paired via `onResizeStart`.
+- **`apps/desktop/src/components/ListPageLayout.tsx`** wires the hook into
+  the shared list-page scaffold: `detailPlacement` prop (default
+  `'adaptive'`), `dockId` prop (defaults to `detailLabel`) for persistence
+  scope, `adaptiveThreshold` prop to override the 1400px default per page (not
+  currently used by any adopting page).
+- **`apps/desktop/src/components/DetailPanel.tsx`** is the shared detail
+  container (3-zone facts/content/aux grid, single scroll region). Adopted by
+  three of six pages (Sessions via `SessionDetail`, Calibration via
+  `MasterDetail`, Inbox via `InboxDetail`); Archive, Projects, and Targets
+  still hand-roll their own detail markup (#1067, open).
+
+Two follow-up PRs fixed bugs in this area without changing the mechanism:
+**#1035** closed #816 (Target detail content clipping — a scroll-containment
+bug, unrelated to placement logic) and fixed unrelated Target-detail issues
+(#856, #612, #796); **#1060** shipped SegControl accessibility work (Refs
+#1010) that the pending #1066 fix is expected to reuse.
+
+## What the original plan proposed but was NOT built
+
+The original plan (`feat/adaptive-detail-dock`, PR #1007, closed as
+superseded) proposed:
+
+1. A **page-width** hook (`useDetailDock`, `ResizeObserver` on `.alm-page`)
+   measuring both window width (threshold) and page-available width
+   (pin→bottom safety fallback + resize clamp), with named constants
+   `TABLE_FLOOR = 640` and `MIN_SIDE_WIDTH = 320`.
+2. A third **`'split'`** placement — Inbox's permanent detail-dominant right
+   split, expressed via a page-level `forcedPlacement` prop with precedence
+   over the user pin.
+3. Typed persistence in `AppPreferences.detailDock` (mirroring the existing
+   `projectViewModes` keyed-map pattern), replacing raw `localStorage`.
+4. A first-class Auto/Bottom/Right Settings control plus an in-page toggle
+   (both writing the same typed preference).
+5. Migrating **all six** detail consumers (including Archive and Targets) to
+   the shared `DetailPanel`, plus a CI guard against bespoke panel markup.
+6. Targets-specific pinned identity columns and conditional horizontal scroll.
+
+**None of 1–6 exist on `main`.** What shipped (#1003) is architecturally
+simpler: one width signal, two placements, untyped `localStorage`, a 2-state
+toggle, partial `DetailPanel` adoption, and no Targets column work. Items 3
+and 4 are tracked as open follow-ups (#1066 for the control, #1067 for the
+`DetailPanel` migrations); item 2 is an open product decision (#1068); items 1
+and 6 have no tracked follow-up as of this reconciliation.
+
+## Technical Context
+
+**Language/Version**: TypeScript/React (desktop shell); no Rust changes in
+the dock mechanism itself (#1035's #816 fix touched `apps/desktop/src/app/router.tsx`
+and Target-detail-adjacent files — verify per-PR, not part of this
+mechanism's own diff).
+
+**Primary Dependencies**: React only — no new runtime dependency. No viewport
+library; `useAdaptiveDock` is a small in-house hook using
+`window.addEventListener('resize', ...)`, not `ResizeObserver` (unlike the
+unshipped branch design).
+
+**Storage**: `localStorage`, raw keys under the `alm-dock-` prefix
+(`alm-dock-placement-<dockId>`, `alm-dock-width-<dockId>`) — not integrated
+with the existing `preferences.ts` / `AppPreferences` store. No SQLite, no
+migration, no IPC.
+
+**Testing**: `pnpm vitest run` component tests exist for `ListPageLayout`
+(including its `'side-and-bottom'` variant coverage in
+`ListPageLayout.test.tsx`, and `DetailPanel.containment.test.tsx`). No
+dedicated `useAdaptiveDock` unit test file was found in this reconciliation
+pass — verify current coverage before relying on this claim in future work.
+
+**Target Platform**: Desktop (Windows primary dev target, plus macOS/Linux)
+via Tauri.
+
+**Project Type**: Desktop app, frontend-only feature — entirely in
+`apps/desktop/src/`.
+
+**Constraints**: No PixInsight boundary concerns (pure UI layout); no
+contract/transport change (Constitution §V — this is local UI-preference
+state, same conclusion as the original plan reached, just via a different
+storage mechanism).
+
+## Constitution Check
+
+| Principle | Assessment |
+|-----------|------------|
+| I. Local-First File Custody | **PASS (N/A).** No image files touched; no filesystem access. Pure UI layout + a `localStorage` preference. |
+| II. Reviewable Filesystem Mutation | **PASS (N/A).** No filesystem mutation, no plans, no destructive operation. |
+| III. PixInsight Boundary | **PASS (N/A).** No calibrate/register/integrate/edit; layout only. |
+| IV. Research-Led Domain Modeling | **PASS**, on a narrower footprint than the original plan assumed. The placement strategy (adaptive side/bottom, per-page pin, drag-resize) traces to the 2026-07-11 design review. The architecture that actually shipped (window-width-only, two placements, raw localStorage) was an implementation simplification made during coding on the `#1003` branch, not separately re-researched — this reconciliation is the first point that simplification is recorded against the spec/plan trail. |
+| V. Portable Contracts & Durable Records | **PASS.** No contract change. Placement/width is client-side UI preference, outside the durable relationship/audit record — true of both the original typed-`AppPreferences` design and the shipped raw-`localStorage` implementation. |
+
+**Result**: PASS, reconciled retroactively. No violation is introduced by the
+architecture gap between plan and shipped code — the simplification stayed
+within the same constitutional footprint (no new contracts, no new durable
+data) — but the SpecKit record itself was missing until this document
+(#1069's premise).
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/054-adaptive-detail-dock/
+├── plan.md              # This file — reconciled against shipped code
+├── research.md          # Reconciled: which original decisions match main, which don't
+├── data-model.md        # Reconciled: actual persistence shape (localStorage, not AppPreferences)
+├── contracts/README.md  # N/A — no transport change (true in both designs)
+└── tasks.md             # Reconciled: delivered / open / superseded status per task
+```
+
+### Source code (as shipped)
+
+```text
+apps/desktop/src/
+├── ui/
+│   ├── useAdaptiveDock.ts        # window-width placement resolver + persisted override/width
+│   └── ResizeHandle.tsx          # pointer-drag divider
+├── components/
+│   ├── ListPageLayout.tsx        # detailPlacement/dockId/adaptiveThreshold props; wires useAdaptiveDock
+│   └── DetailPanel.tsx           # shared detail container (3 of 6 pages adopted — #1067 open)
+└── features/
+    ├── sessions/SessionsPage.tsx        # default adaptive placement, DetailPanel via SessionDetail
+    ├── calibration/CalibrationPage.tsx  # default adaptive placement, DetailPanel via MasterDetail
+    ├── inbox/InboxPage.tsx              # default adaptive placement, DetailPanel via InboxDetail
+    ├── archive/ArchivePage.tsx          # default adaptive placement, detail NOT on DetailPanel (#1067)
+    ├── targets/TargetsPage.tsx          # default adaptive placement, detail NOT on DetailPanel (#1067)
+    └── projects/ProjectsPage.tsx        # default adaptive placement (see note below), detail NOT on DetailPanel (#1067)
+```
+
+**Note on Projects**: `ProjectsPage.tsx`'s module docstring (as of this
+reconciliation) still claims it uses `detailPlacement="side-and-bottom"`
+(task #104 from spec 043). Reading the actual JSX shows it passes no
+`detailPlacement` at all — it defaults to `'adaptive'` like every other page.
+`'side-and-bottom'` remains a real, tested capability of `ListPageLayout` (see
+`ListPageLayout.test.tsx`) but is not currently used by any page. This is a
+pre-existing doc/code drift in `ProjectsPage.tsx` itself, out of scope for
+this documentation-only reconciliation to fix — flagging it here so it isn't
+mistaken for a claim in this spec record.
+
+## Risks & mitigations (reconciled)
+
+- **Placement can't return to Auto once pinned** — live bug, not a risk:
+  #1066, PR #1070 open.
+- **Inconsistent `DetailPanel` adoption** (3/6 pages) means the container
+  scroll-containment guarantee (#1035's #816 fix) is proven for its adopters
+  but not verified for Archive/Projects/Targets, which hand-roll their own
+  scroll structure. Tracked as #1067.
+- **No page currently differentiates its threshold** — every page uses the
+  1400px default via `adaptiveThreshold`'s absence. If a specific page's
+  table needs a different value (the original design reserved 1500px for
+  Targets), it is a one-line prop change, not an architecture change.
+- **Undecided Inbox direction** (#1068) — do not build either the permanent
+  split or remove the Format column without a recorded product decision.

--- a/specs/054-adaptive-detail-dock/research.md
+++ b/specs/054-adaptive-detail-dock/research.md
@@ -1,0 +1,66 @@
+# Research: Adaptive Detail-Panel Dock (reconciled)
+
+**Feature**: 054-adaptive-detail-dock | **Reconciled**: 2026-07-19 (#1069) |
+**Plan**: [plan.md](./plan.md)
+
+## Status
+
+This document replaces the original `feat/adaptive-detail-dock` branch's
+research.md (PR #1007, closed as superseded). That document recorded design
+decisions S1–S9 and implementation decisions D1–D6 for an architecture that
+was **not built**. This reconciliation records, for each of those decisions,
+whether the shipped `#1003` implementation matches it, deviates from it, or
+never addressed it — verified against `main` source, not assumed from the
+branch's intent.
+
+## Original decisions vs. what shipped
+
+| # | Original decision | Shipped reality | Verified against |
+|---|---|---|---|
+| S1 | Adaptive placement, side wide / bottom narrow, per-page pin, bottom is universal fallback | **Matches**, but the width signal differs (see D2 below) | `useAdaptiveDock.ts:127-132` |
+| S2 | Two shapes: list-dominant side dock (5 pages) + detail-dominant split (Inbox) | **Not built.** Only one shape shipped — Inbox uses the same adaptive side/bottom mechanism as every other page | grep for `'split'` / `useDetailDock` across `apps/desktop/src` returns no hits; Inbox uses default `ListPageLayout` |
+| S3 | Inbox = permanent list-left/detail-right split, absorbs #553 | **Not built.** Open product decision, #1068, comparing this against the Format column `main` shipped instead | `InboxPage.tsx` passes no `detailPlacement`; `InboxList.tsx:41,138,193-194,408-414,507` shows a shipped Format column instead |
+| S4 | Targets side dock at ≥1500px; pinned star+designation; permanent column order; conditional h-scroll | **Not built.** No per-page threshold differentiation shipped (all pages use the 1400px default); no pinned-column or h-scroll work found in `TargetsTable`/`TargetsPage` | `TargetsPage.tsx:543-603` passes no `adaptiveThreshold` |
+| S5 | Scroll containment fixed at the container level, absorbs #816 | **Built, but narrower than "every consumer".** #1035 fixed #816 for the Target detail specifically; the container guarantee is proven for `DetailPanel`'s three current adopters (Sessions/Calibration/Inbox), not for Archive/Projects/Targets which don't route through `DetailPanel` at all (#1067) | commit `fa863492`, `DetailPanel.tsx` |
+| S6 | Migrate `TargetDetailV2` to shared `DetailPanel` | **Not built.** `TargetDetailV2`/`TargetsTable` are not among the files using `DetailPanel` | `grep -rln DetailPanel apps/desktop/src` excludes `features/targets/` |
+| S7 | Resizable side panel, ~320px min to ~50% window max, width persisted with placement | **Built as designed** | `useAdaptiveDock.ts:76-77,95-102` (`minWidth=320`, `maxWidthFraction=0.5`, `clampWidth`) |
+| S8 | No overlay/focus-trap variant; keyboard behaviors placement-neutral | **Built**, but as a pre-existing `ListPageLayout` behavior (spec 043, #771/#906) rather than new work for this feature — the Escape handler in `ListPageLayout.tsx` is one `document`-level listener regardless of `detailPlacement` | `ListPageLayout.tsx:175-193` |
+| S9 | Rejected: Inbox bottom dock; auto column-hiding; overlay/modal variant | **Moot for the shipped design** — S9 rejected alternatives to the branch's *own* Inbox split proposal, which itself was not built. No new rejection needed for the shipped mechanism. | — |
+| D1 | Thresholds: Targets 1500px, others 1400px, one constant | **Not built as a per-page differentiation.** `useAdaptiveDock`'s `threshold` param defaults to 1400 and is configurable via `ListPageLayout`'s `adaptiveThreshold` prop, but no adopting page currently passes a non-default value | `useAdaptiveDock.ts:75`, no `adaptiveThreshold=` usage found in any `features/*/​*Page.tsx` |
+| D2 | Two-measurement width hook: window width (threshold) + page-available width (`ResizeObserver` on `.alm-page`, fallback/clamp) | **Not built.** Shipped hook measures only `window.innerWidth`, via a `resize` event listener, not `ResizeObserver` | `useAdaptiveDock.ts:80,89-93` |
+| D3 | Pin→bottom fallback floor: `page_available_width − 320 < 640` | **Not built as designed**, but a narrower related check exists: `sideAvailable = windowWidth >= minWidth * 2` (i.e. `windowWidth >= 640` when `minWidth=320`) gates whether an override is honored at all — a single-threshold heuristic on window width, not the branch's two-term page-available-width calculation | `useAdaptiveDock.ts:126-132` |
+| D4 | Persistence in `preferences.ts` / `AppPreferences.detailDock`, mirroring `projectViewModes` | **Not built.** Shipped persistence is raw `localStorage` under an `alm-dock-` prefix, entirely separate from the `AppPreferences` store | `useAdaptiveDock.ts:58-71` (`STORAGE_PREFIX`, `readStoredPlacement`, `readStoredWidth`) |
+| D5 | Fully-shared components: migrate `TargetDetailV2` **and** Archive to `DetailPanel`; delete the dead `'side-and-bottom'` path | **Not built** for Archive/Targets (tracked as #1067). The `'side-and-bottom'` path was **not deleted** — it remains a live, tested `ListPageLayout` capability, just currently unused by any page (see plan.md's note on `ProjectsPage.tsx`'s stale docstring) | `ListPageLayout.tsx:92,207-266`, `ListPageLayout.test.tsx:102-176` |
+| D6 | Page-level `forcedPlacement?: 'bottom'\|'side'\|'split'` prop, precedence over user pin, subsuming the Inbox split | **Not built.** No `forcedPlacement` prop exists on `ListPageLayout`; `detailPlacement` is the only placement-shaping prop and it is page-static (set once in JSX), not resolved through the same precedence chain as a user pin | `ListPageLayout.tsx:67-112` props list |
+
+## What the shipped design got instead (not in the original research)
+
+The shipped `useAdaptiveDock` makes one simplification the branch design
+didn't consider: collapsing "does the window have room for a side panel at
+all" and "did the window cross the placement threshold" into two checks
+against the **same** width signal (`window.innerWidth`) rather than two
+different signals (window width vs. page-available width). This trades the
+branch's sidebar-collapse-aware accuracy (D2's stated rationale — window
+width alone can't tell if a side panel + a usable table fit when the sidebar
+is expanded vs. collapsed) for a much smaller hook with no `ResizeObserver`
+wiring. No issue currently tracks this gap; it hasn't been reported as a live
+bug, unlike #1066 (the Auto-return bug) and #1067 (the DetailPanel adoption
+gap), which were.
+
+## No new contracts
+
+Confirmed still true of the shipped design: no Tauri command, no contract
+DTO, no SQLite schema or migration. All new state is `localStorage` (a
+narrower footprint than the originally planned `AppPreferences` field, but
+the same constitutional conclusion). See [contracts/README.md](./contracts/README.md).
+
+## Constitution note
+
+Principle IV (Research-Led Domain Modeling) is satisfied by the 2026-07-11
+design review's core prescription (adaptive placement, per-page pin,
+drag-resize), which the shipped mechanism honors. The *implementation*
+decisions D1–D6 above were largely not carried forward as designed; this
+reconciliation is the first record of that gap against the SpecKit trail,
+closing the workflow violation issue #1069 identified (a spec.md existing
+only on a superseded branch, with no mainline record for what actually
+shipped).

--- a/specs/054-adaptive-detail-dock/spec.md
+++ b/specs/054-adaptive-detail-dock/spec.md
@@ -1,0 +1,367 @@
+# Feature Specification: Adaptive Detail-Panel Dock
+
+**Feature Branch**: `054-adaptive-detail-dock` (implemented directly on `main`
+via #1003, #1035, #1060 — see [Reconciliation note](#reconciliation-note))
+
+**Created**: 2026-07-17 (original design, `feat/adaptive-detail-dock`)
+
+**Reconciled**: 2026-07-19 (issue #1069)
+
+**Status**: Delivered (partial — see [Reconciliation note](#reconciliation-note))
+
+**Input**: User description: "Adaptive detail-panel dock — the list-page detail
+panel docks to the side when the window is wide enough and to the bottom when
+it is narrow, with a persisted per-page override and a drag-resizable side
+panel. Formalizes 'Viewport strategy Phase 1 — adaptive dock' from the design
+review of 2026-07-11 and absorbs the broken detail-panel scroll containment
+(#816)."
+
+## Reconciliation note
+
+This spec record is written **after** the feature shipped, to close a
+SpecKit-workflow gap (issue #1069): PR #1007 (branch `feat/adaptive-detail-dock`,
+the original design for this spec) was **closed as superseded** by PR #1003,
+which shipped a **simpler architecture** directly to `main`. No spec artifact
+existed for #1003 at merge time. This document describes what **actually
+shipped**, verified against `main` source, not the original branch design.
+
+Two designs exist in this repo's history. Where they differ, **main's shipped
+code is authoritative**:
+
+| | Branch design (`feat/adaptive-detail-dock`, NOT shipped) | Shipped (`main`, via #1003) |
+|---|---|---|
+| Width signal | Two measurements: window width (threshold) + `ResizeObserver` page-available width (fallback/clamp) | One measurement: `window.innerWidth` only |
+| Placements | Three: `'side' \| 'bottom' \| 'split'` | Two: `'side' \| 'bottom'` |
+| Inbox | Permanent detail-dominant `'split'` shape, no bottom mode ever | Same adaptive side/bottom mechanism as every other page |
+| Placement override UI | Auto/Bottom/Right 3-state Settings control (T021) | Single toggle button that flips side⇄bottom only — cannot return to Auto without clearing localStorage (**bug**, tracked as #1066) |
+| Persistence | `AppPreferences.detailDock` (typed field in the existing `preferences.ts` / IPC-synced store) | Raw `localStorage` keys under an `alm-dock-*` prefix, scoped by `dockId` — no `AppPreferences` integration |
+| Page-level force | `forcedPlacement?: 'bottom' \| 'side' \| 'split'` prop, precedence over the user pin | No forced-placement prop; every adopting page uses the same adaptive default |
+| `DetailPanel` adoption | All six pages migrate (Target, Archive included) | Three of six: Sessions, Calibration, Inbox. Archive, Projects, Targets still hand-roll their own detail markup (tracked as #1067) |
+
+The branch's `useDetailDock` hook, `'split'` placement, and
+`preferences.detailDock` integration were **never built**. Where this document
+describes them below, they are marked **superseded** or **deferred**, not
+delivered — see `tasks.md` for the per-task disposition and `data-model.md`
+for the persistence-shape gap.
+
+## Overview
+
+Every list page (Sessions, Calibration, Archive, Projects, Inbox, Targets)
+pairs a primary table with a detail panel. Before this feature the panel's
+placement was hardcoded per page: a bottom dock everywhere except Projects,
+which used a fixed side-and-bottom dual layout with no narrow fallback. The
+design review of 2026-07-11 established that PlateVault typically runs in a
+1200–1600px window beside a processing tool, and prescribed an adaptive dock:
+the detail panel docks to the side when the window is wide, to the bottom
+below that, user-overridable, persisted, with a drag-resizable split
+(`docs/development/design-review-2026-07-11.md`, "Viewport strategy").
+
+**What shipped** (`apps/desktop/src/ui/useAdaptiveDock.ts`, PR #1003): a hook
+that resolves placement from a single **window-width** measurement against a
+per-page `threshold` (default 1400px), with an explicit per-page override
+(`override: 'side' | 'bottom' | null`) and a drag-resizable, persisted side
+width. `ListPageLayout` (`apps/desktop/src/components/ListPageLayout.tsx`)
+wires this into a `detailPlacement` prop (default `'adaptive'`), so pages opt
+in by doing nothing — the shared layout handles placement.
+
+Two follow-up PRs closed related bugs against this same mechanism:
+
+- **#1035** fixed the Target detail's silent content clipping below the
+  altitude graph (closes #816) — a scroll-containment bug in the shared detail
+  container, not a placement bug, but reported against the same feature area.
+- **#1060** shipped SegControl accessibility fixes (Refs #1010) used elsewhere
+  in the chrome; relevant here because the eventual 3-state placement control
+  (#1066) is expected to reuse `SegControl`.
+
+**What did not ship**: the branch's page-width `ResizeObserver` architecture,
+the third `'split'` placement, and the permanent narrow Inbox split it implied.
+Inbox instead adopted the **same** adaptive side/bottom mechanism as every
+other page — its list simply gained a Format column instead (see #1068,
+open decision, below). Also unshipped: `AppPreferences.detailDock`
+integration and the 3-state Auto/Bottom/Right placement control (#1066).
+
+## Clarifications
+
+### Session 2026-07-17 (owner decisions, original design)
+
+Recorded for history — these decisions were **approved for the branch design**
+that was later superseded. Kept here so the reconciliation table above is
+legible against the original ask; do not treat as binding on the shipped
+mechanism except where the shipped code independently matches them.
+
+- Q: How does the panel choose its placement? → A (original): adaptive in the
+  shared layout, side when wide (from measured *page-available* width), bottom
+  when narrow, per-page pin. → **Shipped differently**: side/bottom from
+  *window* width only (`window.innerWidth`), no separate page-available-width
+  measurement (`useAdaptiveDock.ts:80`).
+- Q: What about Inbox? → A (original): permanent detail-dominant right split,
+  no bottom mode ever. → **Not shipped**; Inbox uses the same adaptive
+  mechanism as other pages (see #1068 for the still-open decision about
+  whether to build this).
+- Q: Is the side panel resizable? → A: yes, drag-resizable, bounded (~320px
+  min to ~50% of window max), width persisted. → **Shipped as designed**
+  (`useAdaptiveDock.ts` `clampWidth`, `ResizeHandle.tsx`).
+- Q: Prerequisite work — migrate all hand-rolled detail panels to the shared
+  `DetailPanel`? → A: yes, all six. → **Partially shipped**: Sessions,
+  Calibration, Inbox use `DetailPanel`; Archive, Projects, Targets do not
+  (tracked as #1067).
+- Q: Placement override surface? → A: an Auto/Bottom/Right Settings control
+  plus an in-page toggle. → **Not shipped**: `ListPageLayout.tsx`'s
+  `alm-listpage__detail-pin` button only flips between `'side'`/`'bottom'`;
+  there is no way back to `'adaptive'` without clearing localStorage
+  (tracked as #1066).
+
+### Session 2026-07-19 (reconciliation, issue #1069)
+
+- Q: Should this document describe the branch's page-width/`'split'`
+  architecture as delivered? → A: **No.** Every architectural claim below is
+  checked against `main` source. Undelivered branch design is marked
+  superseded/deferred, not silently dropped from the record.
+- Q: Inbox permanent split vs the Format column `main` shipped instead? → A:
+  **Genuinely undecided** — tracked as #1068. This document takes no side.
+
+## User Scenarios & Testing *(mandatory)*
+
+Scenarios below describe **what the shipped mechanism does**, adapted from the
+original branch design's User Stories 1, 2, 4, and 6 (US1/US2/US4/US6 in the
+branch numbering). US3 (Inbox detail-dominant split) and US5 (Targets pinned
+columns / conditional horizontal scroll) were **not built** — see
+[Deferred / superseded](#deferred--superseded-not-on-main) below.
+
+### User Story 1 - Detail docks to the side on a wide window (Priority: P1)
+
+As a user running PlateVault on a wide window, I want the detail panel to dock
+to the side of the table instead of eating its height, so I can see many rows
+and the full detail at the same time.
+
+**Independent Test**: On Sessions, Calibration, Inbox, Archive, Targets, and
+Projects, resize the window across 1400px logical width with a detail open.
+Verify the panel docks side when at/above the threshold, bottom below it.
+
+**Acceptance Scenarios**:
+
+1. **Given** a window at or above 1400px logical width with no override set,
+   **When** a detail opens on any of the six list pages, **Then** it docks as
+   a full-height side panel beside the table (`useAdaptiveDock.ts:127-132`).
+2. **Given** a window below 1400px, **When** a detail opens, **Then** it docks
+   to the bottom.
+3. **Given** an open side-docked detail, **When** the window is resized below
+   the threshold, **Then** the panel re-docks to the bottom without losing the
+   selection (and vice versa when resized back up).
+
+**Status**: Delivered — #1003.
+
+---
+
+### User Story 2 - Pin and resize the panel per page (Priority: P2)
+
+As a user with a preferred layout for a specific page, I want to pin the
+detail to the side or bottom on that page and drag the side split to the
+width I like, and have both choices remembered.
+
+**Acceptance Scenarios**:
+
+1. **Given** any window width, **When** the user clicks the placement-pin
+   toggle in the detail panel's header, **Then** the page's placement flips
+   between `'side'` and `'bottom'` and that pin persists across restarts,
+   scoped by the page's `dockId` (`localStorage['alm-dock-placement-<dockId>']`).
+2. **Given** a side-docked panel, **When** the user drags its resize handle,
+   **Then** the width tracks the drag within bounds (320px minimum, 50% of
+   window maximum) and persists (`localStorage['alm-dock-width-<dockId>']`).
+3. **Given** a pinned placement, **When** the user wants to return to
+   automatic width-based placement, **Then** there is currently **no UI path**
+   to do so — the toggle only flips between the two pinned states, never back
+   to `null`/auto. **This is a known bug, tracked as #1066** (fix in flight
+   as PR #1070, not yet on `main`).
+
+**Status**: Delivered with a known gap — #1003 shipped pin + resize; the
+"return to Auto" path is broken (#1066, open).
+
+---
+
+### User Story 3 - Keyboard flow is identical in every placement (Priority: P3)
+
+As a keyboard-first user, I want row navigation and Escape-to-close to behave
+identically whether the panel is docked side or bottom, so the layout shape
+is purely visual.
+
+**Status**: Delivered as a general `ListPageLayout` behavior — the Escape
+handler and overlay-awareness in `ListPageLayout.tsx` are placement-neutral by
+construction (one `document`-level listener regardless of `detailPlacement`).
+Not a dedicated deliverable of this feature; pre-existing from spec 043 (#771,
+#906) and unaffected by the dock mechanism.
+
+## Requirements *(mandatory)*
+
+FR numbering is preserved from the original branch design (not renumbered)
+because `docs/journeys/` already contains committed deltas (PR #966,
+`8f464e87`) that cite these exact FR numbers against journeys J02, J03, J04,
+J05, J07, J08, J09, and J16. Renumbering here would break that
+cross-reference. **Each FR below is marked with its real delivery status —
+several of the journey deltas currently cite an FR as if delivered when it is
+not; see [Known drift](#known-drift-journey-deltas-overstate-delivery)
+below.**
+
+- **FR-001** (**DELIVERED**, #1003): The shared list-page layout MUST choose
+  the detail placement adaptively: a full-height side dock when
+  `window.innerWidth` is at or above the page's threshold, and a bottom dock
+  below it. `useAdaptiveDock.ts:127-132`.
+- **FR-002** (**NOT DELIVERED** — superseded, no tracked issue): Targets was
+  to engage the side dock at ≥1500px logical width, distinct from other
+  pages' threshold. Shipped: every adopting page uses the same 1400px
+  default; no page passes a non-default `adaptiveThreshold`.
+- **FR-003** (**DELIVERED, narrower than designed** — #1003): The user MUST
+  be able to override placement per page, persisted, taking precedence over
+  the adaptive choice, with a pin→bottom fallback when the window can't fit
+  a usable side layout. Shipped: `setOverride` persists the pin
+  (`useAdaptiveDock.ts` `setOverride`); the fallback is a single
+  `windowWidth >= minWidth * 2` check (`useAdaptiveDock.ts:126`), not the
+  originally designed two-term page-available-width-minus-table-floor
+  calculation.
+- **FR-004** (**PARTIALLY DELIVERED**): Sessions, Calibration, Archive, and
+  Targets MUST adopt the adaptive side dock (**delivered**, #1003 — all four
+  default to `detailPlacement='adaptive'`); Projects MUST unify onto the same
+  mechanism (**delivered** — no `detailPlacement` passed, defaults to
+  adaptive, though its own module docstring is stale and still claims
+  `'side-and-bottom'`, see plan.md); Inbox MUST use the detail-dominant split
+  instead (**NOT delivered** — open product decision, #1068).
+- **FR-005** (**DELIVERED**, #1003): The side panel MUST be drag-resizable,
+  bounded 320px min to 50% window max, width persisted and restored.
+  `useAdaptiveDock.ts` `clampWidth`/`setWidth`, `ResizeHandle.tsx`.
+- **FR-006** (**NOT DELIVERED** — superseded, no tracked issue): Targets
+  table MUST keep the favorite-star + designation columns pinned left with a
+  permanent importance column order. No evidence found in
+  `TargetsTable.tsx`/`TargetsPage.tsx`.
+- **FR-007** (**NOT DELIVERED** — superseded, no tracked issue): non-pinned
+  Targets columns MUST scroll horizontally only when space is insufficient.
+  Not built (depends on FR-006, which is not built).
+- **FR-008** (**NOT DELIVERED** — superseded, moot): no automatic column
+  hiding. Trivially true only because no column-priority work was built at
+  all, not because this constraint was actively honored.
+- **FR-009** (**PARTIALLY DELIVERED**, #1035 for its scope): scroll
+  containment MUST be guaranteed by the detail panel container in EVERY
+  placement, absorbing #816. Delivered for `DetailPanel`'s three current
+  adopters (Sessions, Calibration, Inbox); **not proven** for Archive,
+  Projects, Targets, which don't route through `DetailPanel` (#1067, open).
+- **FR-010** (**NOT DELIVERED** — open, #1067 / PR #1072): migrate
+  `TargetDetailV2` to the shared `DetailPanel`.
+- **FR-011** (**not independently verified** in this reconciliation): the
+  layout MUST be fully workable at exactly 1100×720 on every page. Plausible
+  given the e2e test asserts bottom-fallback content integrity at 1100×720
+  for Calibration (`tests/e2e/adaptive_detail_dock.spec.ts:52-56`), but not
+  checked page-by-page here.
+- **FR-012** (**DELIVERED**, pre-existing — spec 043, #771/#906, not new work
+  for this feature): keyboard behaviors MUST be placement-neutral.
+  `ListPageLayout.tsx`'s Escape handler is one listener regardless of
+  `detailPlacement`.
+- **FR-013** (**DELIVERED**, pre-existing, same as FR-012): no
+  overlay/focus-trap variant. True by construction — the side/bottom dock is
+  always an inline complementary region.
+- **FR-014** (**NOT DELIVERED** — open product decision, #1068): Inbox MUST
+  use a permanent detail-dominant right split, absorbing #553.
+- **FR-015** (**NOT DELIVERED** — open product decision, #1068): the Inbox
+  item list MUST get a narrowed presentation (name truncation, essential
+  columns only, Format column dropped). `main` took the **opposite**
+  direction: it added a Format column (`InboxList.tsx:41,138,193-194,
+  408-414,507`) rather than dropping one.
+- **FR-016** (**PARTIALLY DELIVERED**, #1003): every shipped behavior MUST be
+  covered by a mock-mode Playwright CI assertion. `tests/e2e/
+  adaptive_detail_dock.spec.ts` covers the threshold flip and pin-persists-
+  across-reload for the two placements that did ship; it does not (and
+  cannot) cover the Inbox-split or Targets-column assertions the original FR
+  text specified, since those features don't exist.
+- **FR-017** (**DELIVERED, but see drift below**, PR #966 / `8f464e87`):
+  journey-catalog deltas MUST exist for J02, J03, J04, J05, J07, J08, J09,
+  J16. All eight exist and are committed. **However**, several describe
+  FR-006–FR-009 and FR-014/FR-015 as delivered — they are not. See next
+  section.
+
+## Known drift: journey deltas overstate delivery
+
+Discovered during this reconciliation (#1069), **not previously tracked by
+any issue found in this pass** — flagging rather than silently fixing, since
+fixing `docs/journeys/` content is out of this task's scope
+(documentation-only, `specs/` + `docs/development/windows-validation/`).
+
+`docs/journeys/` deltas for this feature landed via PR #966 (`8f464e87`,
+"docs(journeys): spec-054 adaptive detail-panel dock deltas"), evidently
+written against the original branch design's full FR set rather than what
+`#1003` actually shipped. Confirmed by direct grep against `main`:
+
+- **`J09-targets-planning/journey.md`** cites FR-002 (Targets 1500px
+  threshold), FR-006–FR-009 (pinned columns, conditional h-scroll, no
+  auto-hide) as delivered, and describes "the side dock narrows the table
+  below its column floor... pinned columns... no auto-hide." **None of this
+  is on `main`** — no pinned-column or h-scroll code exists in
+  `TargetsTable.tsx`.
+- **`J02-ingest-review-reclassify-confirm-move/journey.md`** and
+  **`J03-ingest-confirm-catalogue-in-place/journey.md`** cite FR-014/FR-015
+  (permanent Inbox split) and describe "a fixed left/right split, never a
+  bottom dock." **This is not on `main`** — Inbox uses the same adaptive
+  side/bottom mechanism as every other page, and #1068 is the still-open
+  decision about whether to build it at all.
+- **`J16-keyboard-first-navigation/journey.md`** references "(Inbox
+  [split])" placement as an existing option alongside side/bottom dock,
+  which doesn't exist.
+- **`J04-sessions-review-derived/journey.md`**, **`J05-project-lifecycle/
+  journey.md`**, **`J07-archive-delete/journey.md`**,
+  **`J08-calibration-ingest-masters-matching/journey.md`** cite FR-001/
+  FR-004/FR-005/FR-011, which **are** accurately delivered — these four
+  journeys appear consistent with `main`.
+
+**Recommendation** (not actioned here): a follow-up documentation task should
+amend J02, J03, J09, and J16 to match what actually shipped, or explicitly
+gate the undelivered sections behind #1068/the Targets-column gap the way
+this spec now does. Filing that follow-up is outside this task's scope.
+
+## Deferred / superseded (not on main)
+
+This section makes explicit what the original branch designed but `main` does
+not have, per issue #1069's instruction not to silently delete undelivered
+design:
+
+- **`useDetailDock`** — the branch's page-width (`ResizeObserver`-based) hook
+  with `TABLE_FLOOR = 640`, `MIN_SIDE_WIDTH = 320` constants and a
+  `forcedPlacement` prop. Superseded by the simpler, shipped
+  `useAdaptiveDock` (window-width only, two placements). If a future need
+  arises for page-available-width-aware placement (e.g. to solve #1066's
+  underlying design question, or a Targets-specific threshold), re-derive it
+  from the shipped hook rather than reviving the branch code verbatim — the
+  branch's `preferences.detailDock` and `'split'` coupling do not apply to
+  the shipped architecture.
+- **`'split'` placement and the permanent narrow Inbox split** — branch tasks
+  T018/T019. Open product decision, **#1068**: keep this deferred vs. the
+  Format column `main` already shipped for Inbox. Do not implement either
+  side of this without a product decision recorded against #1068.
+- **`preferences.detailDock` / `AppPreferences` integration** — branch task
+  T007. `main` persists dock state in raw `localStorage` instead
+  (`useAdaptiveDock.ts` `STORAGE_PREFIX = 'alm-dock'`). No tracked issue;
+  note if a future feature needs this state to be IPC-synced or exportable.
+- **Three-state Auto/Bottom/Right placement control** — branch task T021.
+  Tracked as **#1066**, PR **#1070** open.
+- **Full `DetailPanel` migration (Archive/Projects/Targets) + shared-component
+  guard** — branch tasks T011/T012/T017/T012a. Tracked as **#1067**, PR
+  **#1072** open.
+
+## Out of Scope
+
+- Everything under [Deferred / superseded](#deferred--superseded-not-on-main)
+  above is explicitly out of scope for the mechanism this spec now describes
+  as delivered. They are tracked by their own issues, not folded back into
+  this spec's requirements.
+- Pop-out windows for monitoring surfaces, and density/vertical-economy work
+  — out of scope in the original design review and still out of scope.
+
+## Assumptions
+
+- The 1100×720 minimum window is enforced by the desktop shell's window
+  configuration; this document treats it as an invariant (unverified against
+  a live resize test as part of this reconciliation — carried over from the
+  original spec's assumption).
+- Persisted placement/width is local UI-preference state (`localStorage`), not
+  part of the library's durable relationship/audit record — consistent with
+  Constitution §V regardless of which persistence mechanism (typed
+  `AppPreferences` vs raw `localStorage`) is used.
+- Lineage: this spec formalizes "Viewport strategy Phase 1 — adaptive dock"
+  from `docs/development/design-review-2026-07-11.md` (epic #632), delivered
+  via a different, simpler implementation path than originally planned.

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -1,0 +1,256 @@
+---
+description: "Task list for 054-adaptive-detail-dock (reconciled against shipped main, issue #1069)"
+---
+
+# Tasks: Adaptive Detail-Panel Dock
+
+**Reconciled**: 2026-07-19 (#1069), against `main` source. This is the
+original `feat/adaptive-detail-dock` branch's task list (PR #1007, closed as
+superseded by #1003), with every task given an honest status: **delivered**
+(names the PR), **open** (names the follow-up issue), or **superseded**
+(designed but not built, no plan to build it as originally specified).
+
+Do not treat `[ ]`/`[X]` checkboxes below as live SpecKit task state — this
+feature was not implemented via `speckit-implement` against this task list.
+Checkboxes reflect delivery status as verified in this reconciliation pass.
+
+## Legend
+
+- **DELIVERED (#PR)** — confirmed present in `main` source, cites the PR.
+- **OPEN (#issue)** — not on `main`; a tracked follow-up issue exists.
+- **SUPERSEDED** — designed but not built; no tracked follow-up as of this
+  reconciliation (the shipped architecture solved the underlying need
+  differently, or the need turned out not to exist).
+
+---
+
+## Phase 1: Setup
+
+- [x] T001 Confirm baseline. **SUPERSEDED** — no baseline task was run
+  against this task list; #1003 was developed independently of this plan.
+
+---
+
+## Phase 2: Foundational — US1 shared mechanism
+
+- [ ] T002 Unit test `useDetailDock` (threshold, pin fallback, hysteresis).
+  **SUPERSEDED** — `useDetailDock` was never built (shipped hook is
+  `useAdaptiveDock`, a different, simpler design). No dedicated unit-test
+  file for `useAdaptiveDock` was found in this reconciliation pass — flag as
+  a test-coverage gap if precision here matters for future work.
+- [ ] T003 Unit test `preferences.detailDock` persistence. **SUPERSEDED** —
+  `AppPreferences.detailDock` was never built; persistence is raw
+  `localStorage`, untested by a dedicated unit-test file as of this
+  reconciliation.
+- [x] T004 Component test: containment for a plain overflowing block, no
+  special internal scroll structure. **Note**: an untracked, uncommitted file
+  `apps/desktop/src/components/DetailPanel.containment.test.tsx` exists in
+  this worktree, explicitly referencing "spec 054 T004, issue #1069" in its
+  docstring, and documents the actual #816 fix mechanism (a direct-child CSS
+  selector in `redesign-detail.css`, from #1035). It predates this
+  documentation session, is not on `main` or any branch/commit, and was not
+  authored by this task — flagging its existence rather than claiming its
+  status either way; it is not yet shipped.
+- [x] T005 Component test `ListPageLayout` placement mount. **DELIVERED
+  (partial), #1003** — `ListPageLayout.test.tsx` covers the `'side-and-bottom'`
+  variant; general adaptive-placement mounting is exercised indirectly by
+  consumer pages' own tests, not a dedicated placement-matrix test.
+- [x] T006 Add `useDetailDock.ts` width hook. **SUPERSEDED** — shipped as
+  `useAdaptiveDock.ts` instead: single `window.innerWidth` signal (not
+  `ResizeObserver` page-width + window-width), no `pageWidth` return value.
+  `apps/desktop/src/ui/useAdaptiveDock.ts`.
+- [ ] T007 Extend `preferences.ts` / `AppPreferences.detailDock`.
+  **SUPERSEDED** — shipped as raw `localStorage` keys instead
+  (`useAdaptiveDock.ts:58-71`). No tracked issue for adding typed persistence.
+- [x] T008 Container-level scroll containment in `DetailPanel.tsx` /
+  `tables-lists.css`. **DELIVERED (partial), #1035** — closes #816 for the
+  Target detail specifically, via a CSS direct-child selector contract (see
+  T004 note). The containment guarantee is proven for `DetailPanel`'s three
+  current adopters (Sessions/Calibration/Inbox); Archive/Projects/Targets
+  don't route through `DetailPanel` at all, so the guarantee doesn't apply to
+  them yet (#1067).
+- [x] T009 Drive placement adaptively in `ListPageLayout.tsx`; delete the
+  dead `'side-and-bottom'` dual path. **DELIVERED (partial), #1003** — the
+  adaptive `'side'/'bottom'` wiring shipped
+  (`ListPageLayout.tsx:268-343`). The `'side-and-bottom'` path was **not
+  deleted** — it remains a live, tested capability
+  (`ListPageLayout.tsx:207-266`, `ListPageLayout.test.tsx:102-176`), just
+  unused by any current page. No `forcedPlacement` prop was added.
+- [x] T010 Drag-resize handle, pointer-drag within `[320px, 50% window]`,
+  persisted. **DELIVERED, #1003** — `useAdaptiveDock.ts:134-154`
+  (`onResizeStart`), `ResizeHandle.tsx`, wired into
+  `ListPageLayout.tsx:299-304`.
+- [ ] T011 Migrate `TargetDetailV2` to shared `DetailPanel`. **OPEN, #1067**
+  (PR #1072). Confirmed not on `main`: `TargetDetailV2`/`TargetsTable` do not
+  import `DetailPanel`.
+- [ ] T012 Migrate `ArchiveDetail` to shared `DetailPanel`. **OPEN, #1067**
+  (PR #1072). Confirmed not on `main`: `ArchiveDetail.tsx` does not import
+  `DetailPanel`.
+- [ ] T012a Shared-component guard (automated check + static grep script).
+  **OPEN, #1067** (PR #1072). Not found in `main`'s lint/test gate.
+
+---
+
+## Phase 3: User Story 2 — Adaptive side dock on the list-dominant pages
+
+- [x] T013 `SessionsPage.tsx` adopts adaptive placement. **DELIVERED,
+  #1003** — default `detailPlacement='adaptive'`, no page-key threshold
+  differentiation (the original task's `'sessions'` key concept doesn't
+  apply to the shipped `dockId` design, which defaults to `detailLabel`).
+- [x] T014 `CalibrationPage.tsx` adopts adaptive placement. **DELIVERED,
+  #1003** — same pattern as T013.
+- [x] T015 `ArchivePage.tsx` adopts adaptive placement (detail migration
+  assumed already done in T012). **DELIVERED (placement only), #1003** —
+  adaptive placement shipped; the T012 `DetailPanel` migration this task
+  assumed as a prerequisite did **not** ship (#1067 still open), so Archive's
+  detail panel is adaptive-placed but not routed through the shared
+  container.
+- [x] T016 `TargetsPage.tsx` adopts adaptive placement at threshold 1500px
+  (detail migration assumed done in T011). **DELIVERED (partial), #1003** —
+  adaptive placement shipped, but at the shared **1400px default**, not a
+  Targets-specific 1500px (no `adaptiveThreshold` override is passed in
+  `TargetsPage.tsx`). T011's prerequisite `DetailPanel` migration did not
+  ship (#1067).
+- [ ] T017 `ProjectsPage.tsx` unifies onto the adaptive mechanism, dropping
+  the bespoke `alm-project-detail-stack`. **DELIVERED for placement,
+  OPEN for the DetailPanel part (#1067).** `ProjectsPage.tsx` does pass no
+  `detailPlacement` (defaults to adaptive) and does render its detail
+  content as a single fill (`ProjectDetailContent` + `ProjectBottomDetail`
+  stacked in one `div`), which is a de-facto unification away from
+  `'side-and-bottom'`. However its own module docstring still claims
+  `detailPlacement="side-and-bottom"` — a stale comment, not matching the
+  actual JSX; see plan.md's note. It does not route through `DetailPanel`
+  (#1067).
+
+---
+
+## Phase 4: User Story 3 — Inbox detail-dominant permanent split
+
+- [ ] T018 `InboxPage.tsx` renders the permanent `'split'` shape.
+  **SUPERSEDED / OPEN PRODUCT DECISION, #1068.** Not built — Inbox uses the
+  same adaptive mechanism as every other page. #1068 is the open decision
+  between building this vs. keeping the Format column `main` shipped
+  instead. Do not build without a recorded decision there.
+- [ ] T019 `InboxList.tsx` narrowed presentation (name truncation, essential
+  columns only, Format column dropped). **SUPERSEDED / OPEN PRODUCT
+  DECISION, #1068.** `main` took the opposite direction: it **added** a
+  Format column (`InboxList.tsx:41,138,193-194,408-414,507`) rather than
+  dropping one. #1068 frames this as the explicit contradiction to resolve.
+- [ ] T020 Component/unit test: Inbox list-left/detail-right at both extremes.
+  **SUPERSEDED** — moot until/unless #1068 is decided in favor of building
+  the split.
+
+---
+
+## Phase 5: User Story 4 — Per-page pin + persisted resize
+
+- [ ] T021 Surface an Auto/Bottom/Right 3-state placement control (Settings +
+  in-page). **OPEN, #1066** (PR #1070). `main` ships only a 2-state pin
+  toggle (`ListPageLayout.tsx:307-325`, `alm-listpage__detail-pin`) that
+  flips `'side'`⇄`'bottom'` and has no path back to auto placement without
+  clearing `localStorage` — the exact bug #1066 describes.
+- [x] T022 Enforce a pin→bottom safety fallback when the window is too
+  narrow. **DELIVERED (narrower than designed), #1003** — `useAdaptiveDock`
+  has `sideAvailable = windowWidth >= minWidth * 2`
+  (`useAdaptiveDock.ts:126`), a single-threshold check on window width, not
+  the branch's two-term page-available-width-minus-table-floor calculation
+  (D3 in research.md). Functionally similar outcome at the 1100px minimum
+  width, unverified for intermediate cases.
+- [ ] T023 Component test: pin two pages differently, drag one, reload,
+  verify exact restore. **Not confirmed** — no dedicated multi-page
+  persistence-restore test was found in this reconciliation pass.
+
+---
+
+## Phase 6: User Story 5 — Targets table readable beside the side dock
+
+- [ ] T024 Pin favorite-star + designation columns; permanent importance
+  column order. **SUPERSEDED** — no evidence of pinned-column or
+  column-reorder work found in `TargetsTable.tsx`/`TargetsPage.tsx`. No
+  tracked follow-up issue.
+- [ ] T025 Conditional horizontal scroll of non-pinned columns only when
+  space is insufficient. **SUPERSEDED** — same, no evidence found, no
+  tracked issue.
+- [ ] T026 E2E: keep the existing full-width unclipped pin passing; add a
+  pinned-column + h-scroll assertion. **SUPERSEDED** — moot without T024/T025.
+
+---
+
+## Phase 7: User Story 6 — Placement-neutral keyboard flow
+
+- [x] T027 Route J16 arrow-follow + Escape-close through the shared layout,
+  placement-neutral. **DELIVERED, pre-existing (spec 043, #771/#906), not
+  new work for this feature.** `ListPageLayout.tsx`'s Escape handler
+  (`:175-193`) is one `document`-level listener regardless of
+  `detailPlacement`; unaffected by which of `'side'`/`'bottom'` is active.
+- [ ] T028 E2E: keyboard flow identical across side/bottom/split. **DELIVERED
+  for side/bottom (implied by T027's pre-existing mechanism); N/A for split
+  (T018 not built).** No dedicated new E2E assertion was authored for this
+  feature specifically — existing J16 coverage predates #1003.
+
+---
+
+## Phase 8: Validation — CI assertions + journey deltas
+
+- [x] T029 New `adaptive_detail_dock.spec.ts` mock-mode Playwright E2E.
+  **DELIVERED (scoped to what shipped), #1003** —
+  `tests/e2e/adaptive_detail_dock.spec.ts` (92 lines), two tests against
+  Calibration: threshold flip side↔bottom at 1600×900 vs 1100×720, and
+  pin-persists-across-reload via `dock-placement-toggle`. Does not (and
+  cannot) cover Inbox-split or Targets-column assertions — those features
+  don't exist.
+- [ ] T030 Migrate existing `.alm-listpage__detail` E2E pins deliberately.
+  **N/A** — the Inbox-split migration these pins targeted (T018) was not
+  built, so there was nothing to migrate them to. Confirmed the new spec's
+  own docstring explicitly calls out non-interference with
+  `calibration_masters_matching.spec.ts:157` and `inbox_ingest_confirm.spec.ts`.
+- [x] T031 Journey deltas in `docs/journeys/` (J02/J03/J04/J05/J07/J08/J09/
+  J16). **DELIVERED, but see [Known drift](./spec.md#known-drift-journey-deltas-overstate-delivery),
+  PR #966 (`8f464e87`).** All eight journey files exist and are committed.
+  J04/J05/J07/J08 accurately describe the shipped adaptive side/bottom
+  mechanism. **J02, J03, J09, and J16 describe FR-006–FR-009 (Targets pinned
+  columns) and FR-014/FR-015 (permanent Inbox split) as delivered — neither
+  is on `main`.** This is a real, pre-existing doc/code drift discovered
+  during this reconciliation, distinct from the `specs/` gap #1069 targets;
+  flagging it here rather than silently fixing `docs/journeys/`, which is
+  out of this task's scope.
+- [ ] T032 `verify-on-windows` scenario + Layer-2 journey. **DELIVERED
+  (this reconciliation), #1069** —
+  `docs/development/windows-validation/054-adaptive-detail-dock.md`,
+  rewritten for the shipped two-placement mechanism. No Layer-2 tauri-driver
+  journey was added as part of this documentation-only pass; only the manual
+  validation script.
+
+---
+
+## Phase 9: Polish & Verification
+
+- [x] T033 Constitution re-check. **DELIVERED (this reconciliation)** — see
+  plan.md's Constitution Check table; PASS, no new violation from the
+  plan/shipped gap.
+- [ ] T034 Full local gates (`pnpm typecheck`, `pnpm build`, `pnpm vitest
+  run`, `pnpm format:check`, `just check-generated`). **Not run as part of
+  this reconciliation** — this task is documentation-only per its brief; the
+  shipped PRs (#1003, #1035, #1060) presumably passed CI gates at merge time,
+  but that was not independently re-verified here.
+- [x] T035 `speckit-verify` / `speckit-verify-tasks` against real
+  implementation evidence. **This document is that verification pass**,
+  performed manually against `main` source rather than via the
+  `speckit-verify` tooling, per issue #1069's ask to close the SpecKit
+  workflow gate.
+
+---
+
+## Summary by disposition
+
+- **Delivered** (fully or partially, cites a PR): T004 (partial, uncommitted
+  local test only), T005, T008, T009, T010, T013–T017 (placement only),
+  T022, T027, T028 (partial), T029, T031 (partial — see drift note), T032,
+  T033.
+- **Open** (tracked follow-up issue): T011, T012, T012a → **#1067**; T021 →
+  **#1066**.
+- **Open product decision** (no implementation should proceed without it):
+  T018, T019, T020 → **#1068**.
+- **Superseded** (no tracked follow-up as of this reconciliation): T001,
+  T002, T003, T006, T007, T024, T025, T026, T030.
+- **Not confirmed** (verify before relying on): T023, T034.


### PR DESCRIPTION
## Summary

- Spec 054 is ~70% implemented on `main` (via #1003, #1035, #1060) but `specs/054-adaptive-detail-dock/` did not exist on `main` at all — no durable record for shipped behaviour, and nothing for `speckit-verify` to check against. This lands it.
- Pins the #816 scroll-containment contract with two assertions in `DetailPanel.test.tsx`.

## These docs are reconciled, not copied

The artifacts existed only on `feat/adaptive-detail-dock`, which describes a **different architecture than the one that shipped**:

| | branch (not built) | main (shipped) |
|---|---|---|
| Width signal | **page** width via ResizeObserver, `TABLE_FLOOR=640` | **window** width, threshold 1400 |
| Placements | `side` \| `bottom` \| **`split`** | `side` \| `bottom` |
| Opt-in | `dockPage` + `forcedPlacement` | `detailPlacement` + `dockId` |
| Persistence | `AppPreferences.detailDock` | raw `localStorage`, `alm-dock-*` |

So the docs describe the shipped `useAdaptiveDock` design, and record the branch's page-width/`split` design explicitly as superseded or deferred rather than deleting it or implying it landed. Every task in `tasks.md` carries an honest status with evidence — delivered (naming the PR), open (naming the issue), or superseded. Nothing is marked complete that wasn't confirmed in source.

## Why the containment test earns its place

The #1035 fix for #816 is a **direct-child** CSS selector:

```css
.alm-detail--fill > .alm-planner__scroll { flex:1; min-height:0; overflow-y:auto }
```

That makes it a structural contract on `DetailPanel`, not a stylesheet detail. Nest that region one level deeper and the selector silently stops matching — no test fails, no type breaks, the content just starts getting clipped again exactly as in #816.

This became load-bearing in #1067, where `TargetDetailV2` deliberately kept content-only mode instead of the `facts` slot for precisely this reason. The second assertion documents that `facts` does **not** satisfy the selector, so a future "tidy-up" into `facts` fails here with a pointer to why.

Folded into the existing `DetailPanel.test.tsx` rather than added as a new file: as a separate file it added a React-rendering worker that tipped an already-marginal suite into timeout flakiness on unrelated tests (`GuidedOverlay`, `devSurface.release`, `inbox.affordances`). Verified: 185 files green twice without it, 2–3 varying timeouts twice with it.

## Two pre-existing drifts found, documented but not fixed

- `ProjectsPage.tsx:24` claims the page uses `detailPlacement="side-and-bottom"`; the file passes no such prop and defaults to adaptive.
- Journey deltas J02/J03/J09/J16 (PR #966, already on `main`) describe the unbuilt Targets-column and permanent-Inbox-split work as delivered.

Both are recorded in `spec.md`'s "Known drift" section. Out of scope to fix here.

## Test plan

- `pnpm typecheck` — clean
- `pnpm vitest run` — 185 files, 1714 tests, all passing
- `pnpm lint` — 0 errors
- `pnpm build` — succeeds

Closes #1069

## Spec Context

- Spec: 054 (adaptive detail dock), tasks T004, T029, T031, T032
- Extracted from #1007, closed as superseded by #1003
