### PR TITLE
fix: inbox item metadata refreshes after classification settles

### DIFF
--- a/apps/desktop/src/features/inbox/__tests__/useInboxClassification.metadataInvalidation.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/useInboxClassification.metadataInvalidation.test.tsx
@@ -1,0 +1,112 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * useInboxClassification metadata-invalidation tests (issue #1019).
+ *
+ * `inbox.classify` persists per-file extracted metadata rows as a backend side
+ * effect. The `inbox.item.metadata` query only re-fetches when its itemId
+ * changes, so on first selection it can resolve BEFORE those rows exist and
+ * cache an empty file list — the FR-032 "required metadata missing" banner then
+ * fails to render. The hook fixes this by invalidating that item's metadata
+ * query once classify settles.
+ *
+ * Covers:
+ * - After classify resolves, `metadata(itemId)` is invalidated exactly once
+ *   (the once-per-settle bound doubles as the no-loop proof).
+ * - A failed classify (no persisted rows) does NOT invalidate metadata.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { queryKeys } from '@/data/queryKeys';
+
+const { mockInboxClassify } = vi.hoisted(() => ({
+  mockInboxClassify: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: { inboxClassify: mockInboxClassify },
+}));
+
+import { useInboxClassification } from '../store';
+
+function classifyOk(itemId: string) {
+  return {
+    status: 'ok',
+    data: {
+      inboxItemId: itemId,
+      type: 'single_type',
+      frameType: 'light',
+      contentSignature: `sig-${itemId}`,
+      breakdown: [],
+      unclassifiedFiles: [],
+      sampleFiles: [],
+      computedAt: '2026-07-18T00:00:00Z',
+    },
+  };
+}
+
+function renderClassify(itemId: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  const invalidateSpy = vi.spyOn(queryClient, 'invalidateQueries');
+  function wrapper({ children }: { children: ReactNode }) {
+    return (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+  }
+  const view = renderHook(() => useInboxClassification(itemId, '/lib/root'), {
+    wrapper,
+  });
+  return { ...view, invalidateSpy };
+}
+
+/** How many of the recorded `invalidateQueries` calls target `metadata(itemId)`. */
+function metadataInvalidationCount(calls: unknown[][], itemId: string): number {
+  const key = JSON.stringify(queryKeys.inbox.metadata(itemId));
+  return calls.filter(
+    (c) =>
+      JSON.stringify((c[0] as { queryKey?: unknown } | undefined)?.queryKey) ===
+      key,
+  ).length;
+}
+
+describe('useInboxClassification metadata invalidation (#1019)', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('invalidates the item metadata query exactly once after classify settles', async () => {
+    mockInboxClassify.mockResolvedValue(classifyOk('item-1'));
+
+    const { result, invalidateSpy } = renderClassify('item-1');
+
+    await waitFor(() => expect(result.current.data).toBeDefined());
+    await waitFor(() =>
+      expect(
+        metadataInvalidationCount(invalidateSpy.mock.calls, 'item-1'),
+      ).toBe(1),
+    );
+
+    // Bounded: no second invalidation fires on subsequent renders (no loop).
+    await new Promise((r) => setTimeout(r, 50));
+    expect(metadataInvalidationCount(invalidateSpy.mock.calls, 'item-1')).toBe(
+      1,
+    );
+  });
+
+  it('does not invalidate metadata when classify fails (no rows persisted)', async () => {
+    mockInboxClassify.mockRejectedValue(new Error('boom'));
+
+    const { result, invalidateSpy } = renderClassify('item-2');
+
+    await waitFor(() => expect(result.current.error).toBeDefined());
+    await new Promise((r) => setTimeout(r, 50));
+    expect(metadataInvalidationCount(invalidateSpy.mock.calls, 'item-2')).toBe(
+      0,
+    );
+  });
+});

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -89,18 +89,44 @@ export function useInboxClassification(
   rootAbsolutePath: string,
   forceRescan = false,
 ) {
-  const { data, isFetching, error } = useQuery<InboxClassifyResponse>({
-    queryKey: inboxClassifyQueryKey(rootAbsolutePath, inboxItemId, forceRescan),
-    queryFn: async () =>
-      unwrap(
-        await commands.inboxClassify({
-          inboxItemId,
-          rootAbsolutePath,
-          forceRescan,
-        }),
+  const queryClient = useQueryClient();
+  const { data, isFetching, error, dataUpdatedAt } =
+    useQuery<InboxClassifyResponse>({
+      queryKey: inboxClassifyQueryKey(
+        rootAbsolutePath,
+        inboxItemId,
+        forceRescan,
       ),
-    enabled: !!inboxItemId && !!rootAbsolutePath,
-  });
+      queryFn: async () =>
+        unwrap(
+          await commands.inboxClassify({
+            inboxItemId,
+            rootAbsolutePath,
+            forceRescan,
+          }),
+        ),
+      enabled: !!inboxItemId && !!rootAbsolutePath,
+    });
+
+  // `inbox.classify` persists per-file extracted metadata rows as a backend
+  // side effect (issue #1019). The `inbox.item.metadata` query only re-fetches
+  // when its itemId changes, so on FIRST selection it can resolve BEFORE
+  // classify has written those rows, cache an empty file list, and never
+  // recover — the FR-032 "required metadata missing" banner then fails to
+  // render until a manual re-open. Invalidate that item's metadata query once
+  // each time classify settles with fresh data, mirroring the reclassify
+  // mutation (which persists the same rows and invalidates the same key).
+  // Bounded: keyed on `dataUpdatedAt` (fires once per settle) and gated on a
+  // real itemId; invalidating metadata never re-triggers classify, so there is
+  // no loop. The error path leaves `dataUpdatedAt` at 0 — no persistence, no
+  // invalidation.
+  useEffect(() => {
+    if (!inboxItemId || dataUpdatedAt === 0) return;
+    void queryClient.invalidateQueries({
+      queryKey: queryKeys.inbox.metadata(inboxItemId),
+    });
+  }, [inboxItemId, dataUpdatedAt, queryClient]);
+
   return { data, loading: isFetching, error: error ?? undefined };
 }
 

--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -494,18 +494,13 @@ async fn inbox_ui_missing_path_attribute_banner_blocks_confirm() -> anyhow::Resu
     select_only_item(&app).await?;
 
     // The FR-032 banner is metadata-driven: the detail pane's
-    // `inbox.item.metadata` query races the per-file extraction that the
-    // SAME selection's `inbox.classify` call persists, and can cache an
-    // empty file list for the session (nothing invalidates it when classify
-    // lands). A real user recovers by re-opening the item; do the same once
-    // — after a reload the metadata rows persisted by the first selection's
-    // classify make the banner render deterministically.
-    if app.wait_testid("inbox-missing-attr-banner", UI_TIMEOUT).await.is_err() {
-        app.driver.refresh().await.context("refresh for banner retry failed")?;
-        app.wait_bridge_ready(Duration::from_secs(15)).await?;
-        select_only_item(&app).await?;
-        app.wait_testid("inbox-missing-attr-banner", UI_TIMEOUT).await?;
-    }
+    // `inbox.item.metadata` query and the SAME selection's `inbox.classify`
+    // call (which persists the per-file extracted rows the query reads) fire
+    // concurrently. `useInboxClassification` now invalidates that item's
+    // metadata query once classify settles (issue #1019), so the banner
+    // renders deterministically on FIRST selection — no reload/re-select
+    // workaround. If this wait times out, the invalidation regressed.
+    app.wait_testid("inbox-missing-attr-banner", UI_TIMEOUT).await?;
     let banner_text = app.text_testid("inbox-missing-attr-banner").await?;
     anyhow::ensure!(
         banner_text.to_lowercase().contains("required metadata missing"),


### PR DESCRIPTION
## Summary
- Inbox item metadata was read before classification finished settling, so on **first selection** the metadata query could resolve before `inbox.classify` had written its per-file rows, cache an empty file list, and never recover — the required-metadata-missing banner then failed to render until the user manually re-opened the item.
- `useInboxClassification` now invalidates that item's metadata query once classify settles with fresh data, mirroring the existing reclassify-mutation idiom.
- Removes the `driver.refresh()` retry workaround from the `inbox_ui_missing_path_attribute_banner_blocks_confirm` journey, which now asserts the banner renders on first selection.

Fixes #1019.

## Safety of the invalidation
Bounded and loop-free by construction: keyed on `dataUpdatedAt` so it fires once per settle, gated on a real `itemId`, and invalidating metadata never re-triggers classify. The error path leaves `dataUpdatedAt` at 0 — no persistence, no invalidation.

## Verification
- `pnpm typecheck` — clean (exit 0).
- New regression test passes (2 tests).
- **Confirmed the test genuinely fails without the fix**: swapping in `main`'s `store.ts` fails `invalidates the item metadata query exactly once after classify settles`; restoring the fix passes.

## Rebase note
Rebased onto current `main`. The conflict was with #1025, which extracted the shared `inboxClassifyQueryKey()` builder. Resolution keeps main's refactored key builder and direct-parameter `queryFn`, and layers this fix's invalidation on top — no part of #1025's refactor was reverted.

## Provenance
Found orphaned during a worktree audit: one commit, no PR, no owner, idle ~23h, while #1019 was still open. Recovered rather than authored.