### PR TITLE
ci: gate CI jobs at job level so a skipped job never reports success

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,18 @@ name: CI
 # desktop_shell under the `e2e` feature flag — no external per-OS WebDriver
 # binary required. WebdriverIO has been retired.
 #
-# Path-aware gating (see the `changes` job): heavy Rust/frontend/E2E steps are
-# skipped for changes that cannot affect them (e.g. docs-only PRs), while every
-# job STILL RUNS and reports success. We deliberately gate *inside* the jobs
-# rather than skipping whole jobs, so each job name keeps reporting a green
-# status check on every PR (this repo's merge flow keys on all status checks
-# being green; a skipped job/workflow would leave a check pending/absent and
-# block the merge). Full-suite triggers (workflows, Cargo/lockfiles, package
-# manifests, justfile, scripts) force everything to run via `force_full`.
+# Path-aware gating (see the `changes` job): work that a change cannot affect is
+# skipped. Full-suite triggers (workflows, Cargo/lockfiles, package manifests,
+# justfile, scripts) force everything to run via `force_full`.
+#
+# A job that would have NOTHING meaningful left to do must be skipped at JOB
+# level, never step-by-step. A job whose every step is skipped still concludes
+# `success`, making "this passed" and "this never ran" indistinguishable in the
+# UI, the checks API and to automated pollers. A job skipped by a job-level
+# `if:` concludes `skipped` — a distinct conclusion that still lets a docs-only
+# PR merge. Step-level `if:` is legitimate only where the job as a whole still
+# runs real work (the `integration` matrix interleaves a Rust lane and a
+# frontend lane; its job-level gate fires only when BOTH lanes are idle).
 
 on:
   pull_request:
@@ -118,9 +122,17 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "changes: rust=$rust frontend=$frontend docs_only=$docs_only scripts=${{ steps.filter.outputs.scripts }}"
 
+  # Two lanes share this matrix (Rust and frontend), each with its own step-level
+  # gate, so it is NOT split into two jobs: whenever either lane is active every
+  # OS leg still runs real work — `Rust tests` + `Generated contract/binding
+  # drift` are OS-agnostic under the Rust lane, as are the frontend lint / unit
+  # test / typecheck steps under the frontend lane. The job-level gate below
+  # therefore fires only when BOTH lanes are idle, which is exactly the case
+  # where the job had nothing to do and must not report `success`.
   integration:
     name: Integration (Layer 1) — ${{ matrix.os }}
     needs: changes
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
     strategy:
       fail-fast: false # report each platform distinctly (FR-011)
       matrix:
@@ -291,29 +303,26 @@ jobs:
   # backend/Tauri build). The real UI->IPC->backend journeys run in the dedicated
   # WebdriverIO + tauri-driver workflow (e2e.yml). Not gated on `integration` so
   # UI regressions surface even when the Rust workspace gate is unrelatedly red.
-  # Heavy steps skip when the change cannot affect the frontend; the job still
-  # runs and reports success.
+  # Single-lane job: every step is frontend work, so the whole job is gated on
+  # the frontend lane and a change that cannot affect the frontend skips it
+  # outright rather than reporting a green check for an empty run.
   ui-e2e:
     name: UI E2E (mock-mode Playwright)
     needs: changes
+    if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.frontend == 'true'
         with:
           version: 10.33.0
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.frontend == 'true'
         with:
           node-version: 20
           cache: pnpm
       - name: Install JS deps
-        if: needs.changes.outputs.frontend == 'true'
         run: pnpm install --frozen-lockfile
       - name: Install Playwright chromium
-        if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop exec playwright install --with-deps chromium
       - name: Mock-mode UI tests
-        if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop test:e2e


### PR DESCRIPTION
Completes the work #1075 started. That PR fixed `e2e.yml`; the same hazard was still live in `ci.yml` in a different shape.

## Evidence: which jobs could report false green

Both non-trivial jobs in `ci.yml` applied the `changes` job's outputs as **per-step** `if:` conditions only. A job whose every step is skipped still concludes **`success`** — so "the suite passed" and "the suite never ran" were indistinguishable in the PR checks UI, the checks API, and to automated pollers.

| Job | Every step skipped when | Concluded |
|---|---|---|
| `Integration (Layer 1) — {ubuntu,windows,macos}` | `rust == false && frontend == false` (docs-only change) — all 18 gated steps were `rust`/`frontend`/`rust\|\|scripts` | `success` |
| `UI E2E (mock-mode Playwright)` | `frontend == false` (docs-only **or Rust-only** change) — all 5 steps were `frontend` | `success` |

`ui-e2e` was the wider hole: it reported green for every Rust-only PR, not just docs-only ones.

This is the failure mode that let the PR #1038 regression through and then kept `main` green for every subsequent config-only commit.

## What changed

- **`ui-e2e`** — single-lane job (every step is frontend work). Takes a plain job-level `if: frontend == 'true'`; its now-redundant per-step conditions are dropped, matching #1075.
- **`integration`** — deliberately **not** split into two jobs. Investigated the actual step conditions: the Rust and frontend lanes each contribute OS-agnostic steps (`Rust tests` + `Generated contract/binding drift`; frontend lint + unit tests + typecheck), so *every* OS leg runs real work whenever *either* lane is active. The lane gates stay at step level and the job takes an OR gate, which fires only when both lanes are idle — exactly the empty-run case. This avoids renaming three required checks for no behavioural gain.
- **Header comment** — the old rationale ("we deliberately gate *inside* the jobs … a skipped job would leave a check pending/absent and block the merge") is removed, not softened. It is the reasoning that caused this, and #1075 already established that `skipped` is accepted. Replaced with the rule: a job with nothing meaningful left to do is skipped at job level; step-level gating is legitimate only where the job as a whole still runs real work.

## Per-job condition dump

Parsed from the committed file (`yaml.safe_load`):

```
changes:     <always>
integration: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
ui-e2e:      needs.changes.outputs.frontend == 'true'
```

Resulting behaviour:

| Change type | `integration` | `ui-e2e` |
|---|---|---|
| docs-only | `skipped` | `skipped` |
| Rust-only | runs (frontend steps skip) | `skipped` |
| frontend-only | runs (Rust steps skip) | runs |
| `force_full` (workflows, Cargo/lockfiles, manifests, justfile, scripts) | runs | runs |

Docs-only PRs remain mergeable; no job was made to run unconditionally.

## Audit: nothing left silently unaddressed

- `changes` (`ci.yml`) — always runs real work (`dorny/paths-filter`). Not a hazard.
- `release-gate.yml` — already gated at job level (`release-gate.yml:49`). Clean.
- `release-please.yml` — gates are `release_created` / `runner.os` / signing-vars at job level. Clean.
- `cla-assistant.yml` — job-level `if:`. Clean.
- `e2e.yml` — fixed by #1075; re-verified, 7 job-level `run == 'true'` gates present.

No job with this hazard was left unfixed.

## Verification

- `actionlint .github/workflows/ci.yml .github/workflows/e2e.yml` — one finding, `SC2086` at the `cargo nextest` step. Confirmed **pre-existing and unchanged** (present identically on the base commit, only line-shifted); it is the intentional word-split of `$args`.
- YAML parses (`yaml.safe_load`), pre-commit `check yaml` passed.
- No untrusted input interpolated into any `run:` block; the existing `CHANGED_FILES` env indirection is untouched.
