### PR TITLE
fix: settings tests no longer fail intermittently on macOS and Windows CI

### DIFF
--- a/apps/desktop/src/features/settings/AuditLog.test.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.test.tsx
@@ -333,7 +333,18 @@ describe('AuditLog', () => {
     render(<AuditLog />);
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
-    fireEvent.click(screen.getByText('Export'));
+    // The Export button is `disabled={exporting || loading}` (AuditLog.tsx),
+    // and `loading` only clears once auditList's promise RESOLVES — the
+    // waitFor above only proves the call was made. fireEvent.click on a
+    // disabled button is a silent no-op, so clicking synchronously here
+    // races the load on slow runners: auditExport is simply never invoked
+    // and the assertion below fails with "Number of calls: 0" (observed on
+    // macos-latest). Wait for the button to actually be enabled first.
+    const exportBtn = await screen.findByRole('button', {
+      name: 'Export audit events to a file',
+    });
+    await waitFor(() => expect(exportBtn).toBeEnabled());
+    fireEvent.click(exportBtn);
 
     await waitFor(() => expect(mockExport).toHaveBeenCalledWith(null));
     await waitFor(() => expect(clickSpy).toHaveBeenCalled());

--- a/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
+++ b/apps/desktop/src/features/settings/ResolverSettingsControl.test.tsx
@@ -119,7 +119,14 @@ describe('ResolverSettingsControl', () => {
     render(<ResolverSettingsControl />);
     await waitFor(() => expect(mockGet).toHaveBeenCalled());
 
-    const toggle = screen.getByLabelText('Enable online SIMBAD resolution');
+    // findBy, not getBy: the waitFor above only proves mockGet was CALLED,
+    // not that its promise resolved — `loaded` flips in a .finally() after
+    // that, so a sync getBy races the loading skeleton on slow runners and
+    // fails with "Unable to find a label" (observed on windows-latest). The
+    // sibling compact-mode test below already carries this same fix.
+    const toggle = await screen.findByLabelText(
+      'Enable online SIMBAD resolution',
+    );
     await act(async () => {
       fireEvent.click(toggle);
       await Promise.resolve();

--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -24,6 +24,21 @@ export default defineConfig({
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
     css: false,
+    // Vitest's 5s default is too tight for jsdom + React render + waitFor
+    // chains once the runner is CPU-contended — and CI runners are contended
+    // by definition (2-4 cores running all 186 suites in parallel).
+    //
+    // Reproduced locally: the full suite is green at load ~1, but saturating
+    // all 12 cores makes UNRELATED suites fail with a bare
+    // "Error: Test timed out in 5000ms". GuidedOverlay and devSurface.release
+    // are the reliable casualties — exactly the suites that went red on
+    // macos-latest / windows-latest without any relevant code change.
+    //
+    // A timeout ceiling only costs wall-clock when a test is ACTUALLY stuck,
+    // so raising it does not slow the passing path. It stops a slow machine
+    // from being misreported as a broken test.
+    testTimeout: 15_000,
+    hookTimeout: 15_000,
     // Exclude Playwright e2e specs and any node_modules.
     include: ["src/**/*.{test,spec}.{ts,tsx}"],
     exclude: ["node_modules/**", "dist/**", "../../tests/e2e/**"],


### PR DESCRIPTION
## Summary

- Fixes the two settings-test flakes that have been failing CI on macOS and Windows across unrelated PRs.
- Both had the same root cause: the test waited for an IPC mock to have been **called**, never for its promise to **resolve**, then acted synchronously against a component still in its loading state.

## The two races

**`AuditLog` → "exports via auditExport"** (fails on macos-latest)

The Export button is `disabled={exporting || loading}` (`AuditLog.tsx:369`), and `loading` only clears once `auditList` resolves. `fireEvent.click` on a **disabled** button is a silent no-op — so `auditExport` was never invoked and the assertion failed with `Number of calls: 0`. Now waits for the button to be enabled before clicking.

**`ResolverSettingsControl` → "persists the online toggle"** (fails on windows-latest)

`loaded` flips in a `.finally()` after `mockGet` resolves, so a synchronous `getByLabelText` raced the loading skeleton and failed with `Unable to find a label`. Now uses `findByLabelText` — **the same fix the sibling compact-mode test in this very file already carries**, which is what confirmed the diagnosis.

## Verified by reproducing the race, not by re-running

Re-running a flake until it passes proves nothing. Instead I forced the race by making each mock resolve on a 120ms delay, and checked both directions:

| | old code + 120ms delay | new code + 120ms delay |
|---|---|---|
| `AuditLog` | **FAIL** — `expected "vi.fn()" to be called with arguments: [ null ]` / `Number of calls: 0` | **PASS** |
| `ResolverSettingsControl` | **FAIL** — `Unable to find a label with the text of: Enable online SIMBAD resolution` | **PASS** |

Both failure messages match the CI errors exactly. The injected delays were removed afterwards; the diff is test-only and contains no timing hacks.

Full suite on this branch: 186 files, 1729 tests, all passing. `pnpm typecheck` clean, biome clean.

## Known remaining instances

There are further occurrences of this shape in both files — a sync `getBy` immediately after `waitFor(mock called)` — that are not currently failing. I left them alone to keep this scoped to the two observed failures, but they're latent flakes of the same class and worth a follow-up sweep.

---

## Second commit: the systemic cause

While verifying the above I traced the wider flake class. `vitest.config.ts` sets no `testTimeout` and no worker cap, so the suite runs at vitest's **5000ms default** — too tight for jsdom + React render + `waitFor` chains on a contended runner, and CI runners are contended by definition (2–4 cores, 186 suites in parallel).

Reproduced by saturating all 12 local cores. Same load, before and after:

| `testTimeout` | result |
|---|---|
| 5s (default) | **2 files FAIL** — `Error: Test timed out in 5000ms` (`GuidedOverlay`, `devSurface.release`) |
| 15s (this PR) | **186 files / 1729 tests pass** |

Those two suites are exactly the ones that went red on macos-latest / windows-latest with no relevant code change. This also explains a one-off local run that showed 9 files / 35 tests failing — the box was at load average 15 at the time. **It was never test pollution.**

A timeout ceiling only costs wall-clock when a test is genuinely stuck, so this doesn't slow the passing path. It stops a slow machine from being misreported as a broken test.
