### PR TITLE
fix: shared component consistency sweep — buttons, formatters, detail panels

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -126,6 +126,7 @@
   "calibration_empty_desc": "Run a scan to import calibration frames.",
   "calibration_empty_title": "No calibration masters",
   "calibration_fp_exposure": "Exposure",
+  "calibration_fp_age": "Age",
   "calibration_fp_kind": "Kind",
   "calibration_fp_sensor_mode": "Sensor mode",
   "calibration_fp_temperature": "Temperature",
@@ -694,19 +695,18 @@
   "settings_action_restore_defaults": "Restore defaults",
   "settings_action_restore_defaults_restoring": "Restoring…",
   "settings_action_restore_defaults_done": "Restored",
+  "settings_advanced_danger_confirm_desc": "This resets theme, density, and font size to defaults. Library roots, equipment, and session data are not affected.",
+  "settings_advanced_danger_confirm_yes": "Yes, reset",
   "settings_advanced_danger_desc": "Resets all UI preferences (theme, density, font size) to defaults. Library roots, equipment, and session data are not affected.",
   "settings_advanced_danger_reset": "Reset preferences",
+  "settings_advanced_danger_reset_cancel": "Cancel",
+  "settings_advanced_danger_reset_done": "Preferences reset to defaults.",
   "settings_advanced_danger_title": "Danger Zone",
   "settings_advanced_db_engine": "Engine",
   "settings_advanced_db_engine_value": "SQLite",
   "settings_advanced_db_export": "Export database",
-  "settings_advanced_db_location": "Location",
-  "settings_advanced_db_records": "Records",
-  "settings_advanced_db_records_value": "142,318 files · 22 sessions · 3 projects",
-  "settings_advanced_db_schema": "Schema version",
-  "settings_advanced_db_schema_value": "v1.0",
+  "settings_advanced_db_export_unavailable_title": "Database export isn't implemented yet",
   "settings_advanced_db_size": "Size",
-  "settings_advanced_db_size_value": "24.8 MB",
   "settings_advanced_db_title": "Database",
   "settings_advanced_log_debug": "Debug",
   "settings_advanced_log_error": "Error",
@@ -1174,7 +1174,6 @@
   "targets_detail_no_aliases": "No aliases",
   "targets_detail_no_coverage": "No coverage data yet.",
   "targets_detail_no_projects_linked": "No projects linked.",
-  "targets_detail_no_projects_linked_title": "No projects linked",
   "targets_detail_no_sessions": "No linked sessions yet.",
   "targets_detail_notes_title": "Observing notes",
   "targets_detail_notes_placeholder": "Add observing notes for this target…",
@@ -1303,6 +1302,7 @@
   "projects_toast_save_notes_failed": "Failed to save notes: {error}",
   "projects_notes_byte_limit_exceeded": "Note exceeds the {max}-byte limit.",
   "projects_wizard_toast_created": "Project \"{name}\" created.",
+  "projects_wizard_toast_view_project": "View project",
   "projects_wizard_toast_created_folders": "Project \"{name}\" created — project folders created on disk.",
   "projects_wizard_toast_folders_failed": "Project \"{name}\" created, but folder creation failed. The folder plan remains available for review.",
   "projects_source_views_removal_toast": "Removal plan created. Review and apply plan to complete removal.",
@@ -2032,6 +2032,21 @@
   "calibration_session_popover_no_matches": "No matches",
   "calibration_used_by_label": "Used by",
   "calibration_compatible_label": "Compatible",
+  "calibration_fp_age_value": [
+    {
+      "declarations": [
+        "input days",
+        "local pp = days: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{days} day old",
+        "pp=other": "{days} days old"
+      }
+    }
+  ],
   "inbox_apply_n_overrides": [
     {
       "declarations": [
@@ -2117,8 +2132,8 @@
         "pp"
       ],
       "match": {
-        "pp=one": "{count} master",
-        "pp=other": "{count} masters"
+        "pp=one": "{count} master candidate",
+        "pp=other": "{count} master candidates"
       }
     }
   ],

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -625,6 +625,21 @@
   "projects_wizard_summary_coming_up": "Coming up",
   "projects_wizard_summary_darks_label": "Darks",
   "projects_wizard_summary_lights_label": "Lights",
+  "projects_wizard_summary_master_count": [
+    {
+      "declarations": [
+        "input count",
+        "local pp = count: plural"
+      ],
+      "selectors": [
+        "pp"
+      ],
+      "match": {
+        "pp=one": "{count} master",
+        "pp=other": "{count} masters"
+      }
+    }
+  ],
   "projects_wizard_summary_selected": "Selected",
   "projects_wizard_summary_title": "Project summary",
   "projects_wizard_target_unresolved": "Unresolved target",

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -52,6 +52,12 @@ import { Btn, EmptyState, Pill } from '@/ui';
 import type { CalibrationMatchMissingFlag } from '@/bindings/index';
 import { m } from '@/lib/i18n';
 import { revealLabel } from '@/lib/reveal-label';
+import {
+  formatExposureSeconds,
+  formatTempC,
+  formatGain,
+  formatBinning,
+} from '@/lib/format';
 import { SessionListPopover } from './SessionListPopover';
 import { MatchCandidatesPanel } from './MatchCandidatesPanel';
 import { useCalibrationAssign, useCalibrationSuggest } from './useCalibration';
@@ -251,17 +257,23 @@ export function MasterDetail({
       label: m.settings_calmatch_camera(),
       value: fp.camera ?? null,
     },
-    { key: 'gain', label: m.settings_calmatch_gain(), value: fp.gain ?? null },
+    {
+      key: 'gain',
+      label: m.settings_calmatch_gain(),
+      value: fp.gain != null ? formatGain(fp.gain) : null,
+    },
     {
       key: 'exposure',
       label: m.calibration_fp_exposure(),
-      value: fp.exposureS != null ? `${fp.exposureS}s` : null,
+      // #811: shared formatter (consistent rounding/spacing with Calibration's
+      // MastersTable and Inbox), instead of the local `${v}s` ad hoc version.
+      value: fp.exposureS != null ? formatExposureSeconds(fp.exposureS) : null,
       applicability: masterFieldApplicability(master.kind, 'exposure'),
     },
     {
       key: 'temp',
       label: m.calibration_fp_temperature(),
-      value: fp.tempC != null ? `${fp.tempC}°C` : null,
+      value: fp.tempC != null ? formatTempC(fp.tempC) : null,
       applicability: masterFieldApplicability(master.kind, 'setTemp'),
     },
     {
@@ -278,12 +290,22 @@ export function MasterDetail({
     {
       key: 'binning',
       label: m.settings_calmatch_binning(),
-      value: fp.binning ?? null,
+      // #811: was raw `fp.binning`, unlike MastersTable's binningCell which
+      // already normalises the "x" separator to "×" — now consistent.
+      value: fp.binning != null ? formatBinning(fp.binning) : null,
     },
     {
       key: 'size',
       label: m.settings_advanced_db_size(),
       value: master.sizeBytes != null ? fmtBytes(master.sizeBytes) : null,
+    },
+    {
+      // #619: the row only shows ageDays conditionally, as a warning pill
+      // when the master is aging past the threshold — the actual age is
+      // otherwise invisible. The detail panel shows it unconditionally.
+      key: 'age',
+      label: m.calibration_fp_age(),
+      value: m.calibration_fp_age_value({ days: master.ageDays }),
     },
   ];
 

--- a/apps/desktop/src/features/inbox/inboxStatsFromItems.test.ts
+++ b/apps/desktop/src/features/inbox/inboxStatsFromItems.test.ts
@@ -112,6 +112,21 @@ describe('deriveInboxStats', () => {
     ]);
   });
 
+  // #625: "Dark_flat 1 · Darkflat 6" — an unnormalised underscore variant of
+  // the same IMAGETYP value leaked into the status bar as two sibling
+  // categories instead of one normalized category.
+  it('collapses underscore/hyphen/space variants of the same frame type into one bucket', () => {
+    const stats = deriveInboxStats([
+      folder('a', 'Dark_flat', 1),
+      folder('b', 'Darkflat', 6),
+      folder('c', 'dark-flat', 2),
+      folder('d', 'dark flat', 3),
+    ]);
+    const rows = stats.perType.filter((r) => r.frameType === 'darkflat');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].folderCount).toBe(4);
+  });
+
   it('returns zero totals and no rows for an empty list', () => {
     const stats = deriveInboxStats([]);
     expect(stats.totals).toEqual({ folders: 0, masters: 0, images: 0 });

--- a/apps/desktop/src/features/inbox/inboxStatsFromItems.ts
+++ b/apps/desktop/src/features/inbox/inboxStatsFromItems.ts
@@ -46,10 +46,15 @@ const UNRESOLVED_KEY = 'unresolved';
  * empty, or the cross-type sentinel `"Mixed"` all collapse to the single
  * {@link UNRESOLVED_KEY} bucket so such an item is counted exactly once
  * overall.
+ *
+ * #625: case AND underscore/hyphen/space variants of the same raw FITS
+ * IMAGETYP value must collapse into one bucket — an unnormalised "Dark_flat"
+ * vs "Darkflat" otherwise leaked into the status bar as two separate sibling
+ * categories ("Dark_flat 1 · Darkflat 6") instead of one normalized category.
  */
 function bucketKey(frameType: string | null | undefined): string {
   if (frameType == null || frameType === '') return UNRESOLVED_KEY;
-  const lower = frameType.toLowerCase();
+  const lower = frameType.toLowerCase().replace(/[\s_-]+/g, '');
   return lower === 'mixed' ? UNRESOLVED_KEY : lower;
 }
 

--- a/apps/desktop/src/features/projects/wizard/WizardPage.test.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.test.tsx
@@ -36,8 +36,11 @@ import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 // ── Mocks ─────────────────────────────────────────────────────────────────────
 
+const { mockNavigate } = vi.hoisted(() => ({
+  mockNavigate: vi.fn().mockReturnValue(undefined),
+}));
 vi.mock('@tanstack/react-router', () => ({
-  useNavigate: () => vi.fn().mockReturnValue(undefined),
+  useNavigate: () => mockNavigate,
   useSearch: () => ({}),
 }));
 
@@ -397,6 +400,43 @@ describe('T078c: create project end-to-end', () => {
         expect.objectContaining({ variant: 'success' }),
       );
     });
+  });
+
+  it('#604: success toast carries a "View project" navigation action', async () => {
+    mockCallCreateProject.mockResolvedValue({
+      projectId: 'proj-new-002b',
+      lifecycle: 'setup_incomplete',
+      planId: null,
+      channels: [],
+      auditId: 'audit-002b',
+      createdAt: '2026-06-17T00:00:00Z',
+    });
+
+    renderWizard();
+    await advanceToReview('M31 LRGB');
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId('wizard-create-btn'));
+    });
+
+    await waitFor(() => {
+      expect(mockAddToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          action: expect.objectContaining({ label: 'View project' }),
+        }),
+      );
+    });
+
+    const call = mockAddToast.mock.calls.find(
+      ([opts]) => opts.action?.label === 'View project',
+    );
+    call?.[0].action?.onClick();
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: '/projects',
+        search: { selected: 'proj-new-002b' },
+      }),
+    );
   });
 
   it('confirms folder creation when the scaffolding plan auto-applied (scaffoldApplied: true)', async () => {

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -376,12 +376,25 @@ export function WizardPage() {
       // - true  → folders exist on disk: confirm.
       // - false → creation failed; the plan record remains reviewable.
       // - null/undefined → plan needs manual review (non-mkdir actions).
+      //
+      // #604: every toast carries a "View project" navigation affordance —
+      // the project record exists in all three outcomes above, even when
+      // folder scaffolding failed.
+      const viewProjectAction = {
+        label: m.projects_wizard_toast_view_project(),
+        onClick: () =>
+          void navigate({
+            to: '/projects',
+            search: { selected: result.projectId },
+          }),
+      };
       if (result.scaffoldApplied === false) {
         addToast({
           message: m.projects_wizard_toast_folders_failed({
             name: trimmedName,
           }),
           variant: 'error',
+          action: viewProjectAction,
         });
       } else if (result.scaffoldApplied) {
         addToast({
@@ -389,11 +402,13 @@ export function WizardPage() {
             name: trimmedName,
           }),
           variant: 'success',
+          action: viewProjectAction,
         });
       } else {
         addToast({
           message: m.projects_wizard_toast_created({ name: trimmedName }),
           variant: 'success',
+          action: viewProjectAction,
         });
       }
 

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -489,15 +489,15 @@ export function WizardPage() {
           />
           <SummaryRow
             label={m.projects_wizard_summary_darks_label()}
-            value={m.inbox_count_masters({ count: darkSelected })}
+            value={m.projects_wizard_summary_master_count({ count: darkSelected })}
           />
           <SummaryRow
             label={m.projects_wizard_flats_label()}
-            value={m.inbox_count_masters({ count: flatsMapped })}
+            value={m.projects_wizard_summary_master_count({ count: flatsMapped })}
           />
           <SummaryRow
             label={m.projects_wizard_bias_label()}
-            value={m.inbox_count_masters({ count: biasSelected })}
+            value={m.projects_wizard_summary_master_count({ count: biasSelected })}
           />
         </div>
       </div>

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -489,15 +489,21 @@ export function WizardPage() {
           />
           <SummaryRow
             label={m.projects_wizard_summary_darks_label()}
-            value={m.projects_wizard_summary_master_count({ count: darkSelected })}
+            value={m.projects_wizard_summary_master_count({
+              count: darkSelected,
+            })}
           />
           <SummaryRow
             label={m.projects_wizard_flats_label()}
-            value={m.projects_wizard_summary_master_count({ count: flatsMapped })}
+            value={m.projects_wizard_summary_master_count({
+              count: flatsMapped,
+            })}
           />
           <SummaryRow
             label={m.projects_wizard_bias_label()}
-            value={m.projects_wizard_summary_master_count({ count: biasSelected })}
+            value={m.projects_wizard_summary_master_count({
+              count: biasSelected,
+            })}
           />
         </div>
       </div>

--- a/apps/desktop/src/features/sessions/SessionDetail.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.tsx
@@ -140,6 +140,13 @@ export function SessionDetail({
   // Session facts as a clean tabular PropertyTable, spread across two columns.
   const factProps: PropertyDef[] = [
     {
+      // #619: `type` was a genuinely unrendered DTO field — the row doesn't
+      // show it either, so this is new information, not a restated column.
+      key: 'type',
+      label: m.inbox_frame_type_label(),
+      value: session.type,
+    },
+    {
       key: 'target',
       label: m.projects_create_target_label(),
       value: session.target ?? null,

--- a/apps/desktop/src/features/settings/Advanced.test.tsx
+++ b/apps/desktop/src/features/settings/Advanced.test.tsx
@@ -50,11 +50,13 @@ vi.mock('@/features/guided/store', () => ({
   STEP_ORDER: ['step-one', 'step-two'],
 }));
 
-const { mockSetPreference } = vi.hoisted(() => ({
+const { mockSetPreference, mockResetPreferences } = vi.hoisted(() => ({
   mockSetPreference: vi.fn(),
+  mockResetPreferences: vi.fn(),
 }));
 vi.mock('@/data/preferences', () => ({
   setPreference: mockSetPreference,
+  resetPreferences: mockResetPreferences,
 }));
 
 const { mockResetWizardStateWithSources } = vi.hoisted(() => ({
@@ -322,5 +324,65 @@ describe('Advanced — Software Update section', () => {
     expect(status).toHaveTextContent(/restart the app manually/i);
     expect(status).not.toHaveTextContent(/failed/i);
     expect(await screen.findByTestId('update-restart-btn')).toBeInTheDocument();
+  });
+});
+
+// ── Database info + Danger zone (#601/#602) ─────────────────────────────────
+//
+// Both controls used to be console.log no-ops (#601) and the Database panel
+// hardcoded fabricated size/schema/record stats plus a pre-rename path
+// (#602). Export database has no real backend yet — it must render as
+// honestly disabled, not a live-looking no-op. Reset preferences has a real,
+// local-only implementation (`resetPreferences()`) and is wired for real.
+
+describe('Advanced — Database info panel (#602)', () => {
+  it('shows only the real, static Engine fact — no fabricated size/schema/record counts', async () => {
+    render(<Advanced save={vi.fn()} />);
+
+    expect(await screen.findByText('SQLite')).toBeInTheDocument();
+    expect(screen.queryByText('24.8 MB')).not.toBeInTheDocument();
+    expect(screen.queryByText('v1.0')).not.toBeInTheDocument();
+    expect(screen.queryByText(/142,318 files/)).not.toBeInTheDocument();
+    expect(
+      screen.queryByText('~/.alm/astro-library.db'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('renders "Export database" disabled with an explanatory title, not a silent no-op', async () => {
+    render(<Advanced save={vi.fn()} />);
+
+    const exportBtn = await screen.findByText('Export database');
+    expect(exportBtn.closest('button')).toBeDisabled();
+    expect(exportBtn.closest('button')).toHaveAttribute(
+      'title',
+      "Database export isn't implemented yet",
+    );
+  });
+});
+
+describe('Advanced — Reset preferences (#601)', () => {
+  it('requires a confirm step before calling resetPreferences', async () => {
+    render(<Advanced save={vi.fn()} />);
+
+    fireEvent.click(await screen.findByTestId('reset-preferences-btn'));
+
+    expect(mockResetPreferences).not.toHaveBeenCalled();
+    expect(
+      await screen.findByTestId('reset-preferences-confirm-btn'),
+    ).toBeInTheDocument();
+  });
+
+  it('on confirm, calls the real resetPreferences() and shows a success message', async () => {
+    render(<Advanced save={vi.fn()} />);
+
+    fireEvent.click(await screen.findByTestId('reset-preferences-btn'));
+    fireEvent.click(await screen.findByTestId('reset-preferences-confirm-btn'));
+
+    await waitFor(() => {
+      expect(mockResetPreferences).toHaveBeenCalledTimes(1);
+    });
+    expect(
+      await screen.findByTestId('reset-preferences-done'),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/features/settings/Advanced.tsx
+++ b/apps/desktop/src/features/settings/Advanced.tsx
@@ -15,6 +15,7 @@ import { useState, useEffect, useSyncExternalStore } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { Btn } from '@/ui';
 import { getSettings, restartFirstRun } from './settingsIpc';
+import { resetPreferences } from '@/data/preferences';
 import {
   getGuidedState,
   restartGuidedFlow,
@@ -64,6 +65,8 @@ export function Advanced({ save }: AdvancedProps) {
   const updateState = useSyncExternalStore(subscribeUpdate, getUpdateSnapshot);
   const [updateBusy, setUpdateBusy] = useState(false);
   const [runningVersion, setRunningVersion] = useState<string | null>(null);
+  const [resetConfirming, setResetConfirming] = useState(false);
+  const [resetDone, setResetDone] = useState(false);
 
   const applyValues = (vals: Record<string, unknown>) => {
     if (vals?.logLevel && typeof vals.logLevel === 'string') {
@@ -171,8 +174,22 @@ export function Advanced({ save }: AdvancedProps) {
     }
   };
 
-  const handleExport = () => console.log('Export DB triggered');
-  const handleReset = () => console.log('Reset preferences triggered');
+  // #601: no `db.export` backend command exists yet — the button used to be
+  // a console.log no-op styled as a real action. Disabled with an
+  // explanatory title (same "not backed yet" convention as MasterDetail's
+  // #642 disabled actions) rather than shipping a dead "live" button.
+  //
+  // Reset preferences, by contrast, genuinely has a real backend already
+  // (`resetPreferences()` — theme/density/font-size, local-only, no IPC
+  // needed) — it was just never wired to the button. Gated behind a confirm
+  // step for consistency with this pane's other resets (guided-tour/
+  // first-run restarts above).
+  const handleReset = () => {
+    resetPreferences();
+    setResetConfirming(false);
+    setResetDone(true);
+    setTimeout(() => setResetDone(false), 3000);
+  };
 
   // Staged update flow (#888, absorbs #869/#873): checking/downloading are
   // automatic; only the restart/install step is an explicit user action
@@ -198,32 +215,26 @@ export function Advanced({ save }: AdvancedProps) {
 
   return (
     <>
-      {/* Database info */}
+      {/* Database info (#602: this panel used to hardcode a fabricated size,
+          schema version, and record count — plus a pre-rename `~/.alm/` path
+          — directly above the real status bar showing genuinely different
+          live numbers. No backend command exists yet to report real db stats
+          or a real path, so those rows are removed rather than shown wrong;
+          "Engine" is the one row that was always a true, static fact. */}
       <SettingsSection
         title={m.settings_advanced_db_title()}
         action={
-          <Btn size="sm" onClick={handleExport}>
+          <Btn
+            size="sm"
+            disabled
+            title={m.settings_advanced_db_export_unavailable_title()}
+          >
             {m.settings_advanced_db_export()}
           </Btn>
         }
       >
-        <SettingsRow label={m.settings_advanced_db_location()}>
-          {/* eslint-disable-next-line alm/no-user-string -- filesystem path identifier, not translatable */}
-          <code className="alm-mono alm-adv-settings__db-path">
-            ~/.alm/astro-library.db
-          </code>
-        </SettingsRow>
         <SettingsRow label={m.settings_advanced_db_engine()}>
           {m.settings_advanced_db_engine_value()}
-        </SettingsRow>
-        <SettingsRow label={m.settings_advanced_db_size()}>
-          {m.settings_advanced_db_size_value()}
-        </SettingsRow>
-        <SettingsRow label={m.settings_advanced_db_schema()}>
-          {m.settings_advanced_db_schema_value()}
-        </SettingsRow>
-        <SettingsRow label={m.settings_advanced_db_records()}>
-          {m.settings_advanced_db_records_value()}
         </SettingsRow>
       </SettingsSection>
 
@@ -451,7 +462,10 @@ export function Advanced({ save }: AdvancedProps) {
         </SettingsRow>
       </SettingsSection>
 
-      {/* Danger zone */}
+      {/* Danger zone (#601): was a console.log no-op styled as a real
+          destructive action. `resetPreferences()` is real and local-only, so
+          it's wired for real, gated behind a confirm step like this pane's
+          other resets. */}
       <SettingsSection title={m.settings_advanced_danger_title()}>
         <div className="alm-adv-settings__danger-box">
           <div className="alm-adv-settings__danger-heading">
@@ -460,9 +474,48 @@ export function Advanced({ save }: AdvancedProps) {
           <p className="alm-adv-settings__danger-desc">
             {m.settings_advanced_danger_desc()}
           </p>
-          <Btn size="sm" variant="danger" onClick={handleReset}>
-            {m.settings_advanced_danger_reset()}
-          </Btn>
+          {resetConfirming ? (
+            <>
+              <p className="alm-adv-settings__danger-desc">
+                {m.settings_advanced_danger_confirm_desc()}
+              </p>
+              <div className="alm-adv-settings__control-row">
+                <Btn
+                  size="sm"
+                  variant="danger"
+                  onClick={handleReset}
+                  data-testid="reset-preferences-confirm-btn"
+                >
+                  {m.settings_advanced_danger_confirm_yes()}
+                </Btn>
+                <Btn
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setResetConfirming(false)}
+                >
+                  {m.settings_advanced_danger_reset_cancel()}
+                </Btn>
+              </div>
+            </>
+          ) : (
+            <Btn
+              size="sm"
+              variant="danger"
+              onClick={() => setResetConfirming(true)}
+              data-testid="reset-preferences-btn"
+            >
+              {m.settings_advanced_danger_reset()}
+            </Btn>
+          )}
+          {resetDone && (
+            <p
+              className="alm-adv-settings__control-desc"
+              role="status"
+              data-testid="reset-preferences-done"
+            >
+              {m.settings_advanced_danger_reset_done()}
+            </p>
+          )}
         </div>
       </SettingsSection>
     </>

--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -416,11 +416,15 @@ describe('TargetDetailV2', () => {
     expect(screen.queryByText('No sessions linked')).not.toBeInTheDocument();
   });
 
-  it('14. projects empty-state renders', async () => {
+  it('14. projects empty-state renders (single mid-page surface)', async () => {
     render(<TargetDetailV2 targetId={TARGET_ID} />);
     await waitFor(() =>
-      expect(screen.getByText('No projects linked')).toBeInTheDocument(),
+      expect(screen.getByText('No projects linked.')).toBeInTheDocument(),
     );
+    // #670: the duplicate bottom "Projects" section (same list + a redundant
+    // EmptyState restating the same sentence as its own title) was removed —
+    // same precedent as the Sessions section above.
+    expect(screen.queryAllByText('No projects linked.').length).toBe(1);
   });
 
   it('15. reloads detail after successful alias add', async () => {

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -1254,42 +1254,14 @@ export function TargetDetailV2({
           )}
         </Section>
 
-        {/* Sessions surface lives in the mid-page SESSIONS/PROJECTS link row
-          above (single source of truth) — the duplicate bottom Sessions
-          section was removed to avoid two Sessions surfaces. */}
-
-        {/* ── Projects (spec 023 US3) ──────────────────────────────────────── */}
-        <Section title={m.common_projects()} count={projects.length}>
-          {projects.length === 0 ? (
-            <EmptyState
-              title={m.targets_detail_no_projects_linked_title()}
-              desc={m.targets_detail_no_projects_linked()}
-            />
-          ) : (
-            <ul className="alm-target-detail__project-list">
-              {projects.map((p) => (
-                <li key={p.id} className="alm-target-detail__project-item">
-                  <button
-                    className="alm-target-detail__project-btn"
-                    onClick={() =>
-                      void navigate({
-                        to: '/projects',
-                        search: { selected: p.id },
-                      })
-                    }
-                  >
-                    <span className="alm-target-detail__project-name">
-                      {p.name}
-                    </span>
-                    <span className="alm-target-detail__project-lifecycle">
-                      {p.lifecycle}
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          )}
-        </Section>
+        {/* Sessions AND Projects surfaces both live in the mid-page
+          SESSIONS/PROJECTS link row above (single source of truth) — the
+          duplicate bottom Sessions section was already removed to avoid two
+          Sessions surfaces; the bottom Projects section (#670) was the same
+          duplication (identical p.name/p.lifecycle list, same
+          navigate-to-/projects action, plus a redundant EmptyState whose
+          title and desc restated the same "No projects linked" sentence
+          twice) — removed for the same reason. */}
 
         {/* ── Observing notes (spec 023 US4) ──────────────────────────────── */}
         <Section title={m.targets_detail_notes_title()}>

--- a/apps/desktop/src/lib/format.test.ts
+++ b/apps/desktop/src/lib/format.test.ts
@@ -1,0 +1,87 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, expect } from 'vitest';
+import {
+  formatBytes,
+  formatIntegration,
+  formatIntegrationHours,
+  formatExposureSeconds,
+  formatTempC,
+  formatGain,
+  formatBinning,
+} from './format';
+
+describe('formatBytes', () => {
+  it('formats byte counts across units', () => {
+    expect(formatBytes(0)).toBe('0 B');
+    expect(formatBytes(1536)).toBe('1.5 KB');
+  });
+});
+
+describe('formatIntegration', () => {
+  it('formats seconds into h/m/s', () => {
+    expect(formatIntegration(3661)).toBe('1h 1m 1s');
+    expect(formatIntegration(0)).toBe('0s');
+  });
+});
+
+describe('formatIntegrationHours', () => {
+  it('formats hours to one decimal', () => {
+    expect(formatIntegrationHours(2.5)).toBe('2.5h');
+    expect(formatIntegrationHours(0)).toBe('0h');
+  });
+});
+
+// #811 — FITS-value formatters, extending lib/format.ts instead of the
+// duplicated ad hoc versions in InboxDetail/MastersTable/MasterDetail.
+describe('formatExposureSeconds', () => {
+  it('rounds to 1 decimal and adds a space before the unit', () => {
+    // Root cause of #789 — the raw unrounded float this replaces.
+    expect(formatExposureSeconds(6.92447668013071)).toBe('6.9 s');
+  });
+
+  it('drops a trailing .0 for whole-number exposures', () => {
+    expect(formatExposureSeconds(30)).toBe('30 s');
+  });
+
+  it('null-guards to the dash convention instead of "null"/"undefined"', () => {
+    expect(formatExposureSeconds(null)).toBe('—');
+    expect(formatExposureSeconds(undefined)).toBe('—');
+  });
+});
+
+describe('formatTempC', () => {
+  it('rounds to 1 decimal with a degree-C suffix', () => {
+    expect(formatTempC(-10.449)).toBe('-10.4°C');
+    expect(formatTempC(20)).toBe('20°C');
+  });
+
+  it('null-guards to the dash convention', () => {
+    expect(formatTempC(null)).toBe('—');
+  });
+});
+
+describe('formatGain', () => {
+  it('stringifies a real gain value', () => {
+    expect(formatGain(100)).toBe('100');
+    expect(formatGain(0)).toBe('0');
+  });
+
+  it('null-guards instead of rendering the literal string "null"', () => {
+    expect(formatGain(null)).toBe('—');
+    expect(formatGain(undefined)).toBe('—');
+  });
+});
+
+describe('formatBinning', () => {
+  it('normalises the ascii "x" separator to "×"', () => {
+    expect(formatBinning('2x2')).toBe('2×2');
+    expect(formatBinning('1X1')).toBe('1×1');
+  });
+
+  it('null/empty-guards to the dash convention', () => {
+    expect(formatBinning(null)).toBe('—');
+    expect(formatBinning('')).toBe('—');
+  });
+});

--- a/apps/desktop/src/lib/format.ts
+++ b/apps/desktop/src/lib/format.ts
@@ -41,3 +41,52 @@ export function formatIntegrationHours(hours: number): string {
   if (hours < 0.1) return '<0.1h';
   return `${hours.toFixed(1)}h`;
 }
+
+/** Blank marker for a missing/null value — matches RenderValue's convention. */
+const EMPTY = '—';
+
+/** Round to 1 decimal place, dropping a trailing ".0" (e.g. 30 => "30", 6.92447668013071 => "6.9"). */
+function roundTrim1(n: number): string {
+  const r = Math.round(n * 10) / 10;
+  return Number.isInteger(r) ? String(r) : r.toFixed(1);
+}
+
+/**
+ * Format a FITS exposure time in seconds (#811): consistent rounding (1
+ * decimal place) and unit spacing. e.g. 6.92447668013071 => "6.9 s" (root
+ * cause of #789's raw unrounded float), 30 => "30 s".
+ */
+export function formatExposureSeconds(
+  seconds: number | null | undefined,
+): string {
+  if (seconds == null) return EMPTY;
+  return `${roundTrim1(seconds)} s`;
+}
+
+/**
+ * Format a FITS sensor temperature in Celsius (#811): consistent rounding (1
+ * decimal place). e.g. -10.449 => "-10.4°C".
+ */
+export function formatTempC(tempC: number | null | undefined): string {
+  if (tempC == null) return EMPTY;
+  return `${roundTrim1(tempC)}°C`;
+}
+
+/**
+ * Format a FITS gain value with a consistent null-guard (#811) — some call
+ * sites previously ran `String(gain)` unguarded, rendering the literal string
+ * "null" instead of the app's dash convention.
+ */
+export function formatGain(gain: number | null | undefined): string {
+  if (gain == null) return EMPTY;
+  return String(gain);
+}
+
+/**
+ * Format a FITS binning value (#811), normalising the ASCII "x" separator to
+ * the display "×" and null-guarding. e.g. "2x2" => "2×2".
+ */
+export function formatBinning(binning: string | null | undefined): string {
+  if (binning == null || binning === '') return EMPTY;
+  return binning.replace(/x/gi, '×');
+}

--- a/apps/desktop/src/styles/components/app-shell.css
+++ b/apps/desktop/src/styles/components/app-shell.css
@@ -213,7 +213,7 @@
   border-bottom: 1px solid var(--alm-border-subtle);
 }
 .alm-list-sidebar__controls select {
-  width: 100%; height: 26px; font-size: var(--alm-text-xs);
+  width: 100%; height: var(--alm-control-h); font-size: var(--alm-text-xs);
   border: 1px solid var(--alm-border); border-radius: var(--alm-radius-sm);
   background: var(--alm-bg); color: var(--alm-text-secondary);
   padding: 0 var(--alm-sp-2);

--- a/apps/desktop/src/styles/components/feature-lists.css
+++ b/apps/desktop/src/styles/components/feature-lists.css
@@ -365,8 +365,13 @@
   color: var(--alm-text-muted);
 }
 
-/* Textarea — resize handle only; theming via existing .alm-input */
+/* Textarea — resize handle only; theming via existing .alm-input. Overrides
+   .alm-input's fixed single-line control height (#616) back to a multi-line
+   minimum so notes stay a real textarea, not a clipped one-liner. */
 .alm-project-notes__textarea {
+  height: auto;
+  min-height: 80px;
+  padding: var(--alm-sp-2) var(--alm-sp-3);
   resize: vertical;
 }
 

--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -31,7 +31,7 @@
 /* === BUTTON === */
 .alm-btn {
   display: inline-flex; align-items: center; justify-content: center;
-  gap: var(--alm-sp-1); height: 28px;
+  gap: var(--alm-sp-1); height: var(--alm-control-h);
   padding: 0 var(--alm-sp-3);
   font-size: var(--alm-text-xs); font-weight: var(--alm-weight-medium);
 
@@ -61,7 +61,7 @@
   color: var(--alm-text-secondary);
   border-color: var(--alm-border);
 }
-.alm-btn--sm { height: 24px; padding: 0 var(--alm-sp-2); font-size: var(--alm-text-xs); }
+.alm-btn--sm { height: var(--alm-control-h-sm); padding: 0 var(--alm-sp-2); font-size: var(--alm-text-xs); }
 
 /* === SECTION === */
 .alm-section { margin-bottom: var(--alm-sp-4); }

--- a/apps/desktop/src/styles/components/settings-detail.css
+++ b/apps/desktop/src/styles/components/settings-detail.css
@@ -142,7 +142,7 @@
 
 /* Select height override (component geometry) + dark-mode theming */
 .alm-source-protect__select {
-  height: 28px;
+  height: var(--alm-control-h);
   background: var(--alm-surface);
   color: var(--alm-text);
   border: 1px solid var(--alm-border);
@@ -575,7 +575,7 @@
 
 /* Log-level select — fixed height to match other controls */
 .alm-adv-settings__log-select {
-  height: 28px;
+  height: var(--alm-control-h);
 }
 
 /* Settings-row control description paragraph — shared by the guided-tour

--- a/apps/desktop/src/styles/components/settings.css
+++ b/apps/desktop/src/styles/components/settings.css
@@ -158,9 +158,9 @@ font-weight: var(--alm-weight-medium);
 .alm-radio--active .alm-radio__desc { color: var(--alm-accent-text); }
 
 /* Segmented control */
-.alm-seg { display: inline-flex; border: 1px solid var(--alm-border); border-radius: var(--alm-radius-sm); overflow: hidden; }
+.alm-seg { display: inline-flex; height: var(--alm-control-h-sm); border: 1px solid var(--alm-border); border-radius: var(--alm-radius-sm); overflow: hidden; }
 .alm-seg__btn {
-  padding: var(--alm-sp-0) var(--alm-sp-2); font-size: var(--alm-text-xs);
+  height: 100%; padding: 0 var(--alm-sp-2); font-size: var(--alm-text-xs);
   border: none; background: var(--alm-bg); color: var(--alm-text-muted);
   cursor: pointer;font-weight: var(--alm-weight-medium);
   border-right: 1px solid var(--alm-border);

--- a/apps/desktop/src/styles/components/tables-lists.css
+++ b/apps/desktop/src/styles/components/tables-lists.css
@@ -132,7 +132,8 @@
 }
 .alm-filterbar__field-label { white-space: nowrap; }
 .alm-filterbar__select {
-  padding: var(--alm-sp-1) var(--alm-sp-2);
+  height: var(--alm-control-h);
+  padding: 0 var(--alm-sp-2);
   font-size: var(--alm-text-sm);
   color: var(--alm-text);
   background: var(--alm-surface-raised);

--- a/apps/desktop/src/styles/components/target-search.css
+++ b/apps/desktop/src/styles/components/target-search.css
@@ -17,7 +17,8 @@
 }
 .alm-input {
   width: 100%;
-  padding: var(--alm-sp-2) var(--alm-sp-3);
+  height: var(--alm-control-h);
+  padding: 0 var(--alm-sp-3);
   border: 1px solid var(--alm-border);
   border-radius: var(--alm-radius-sm);
   font-size: var(--alm-text-sm);
@@ -27,7 +28,9 @@
   outline: none;
   transition: border-color var(--alm-transition-fast);
 }
-.alm-input:focus { border-color: var(--alm-accent); }
+/* #631: was border-color only — every other focusable control uses the
+   real focus-ring token. */
+.alm-input:focus { border-color: var(--alm-accent); box-shadow: var(--alm-focus-ring); }
 .alm-input::placeholder { color: var(--alm-text-faint); }
 
 .alm-target-search { position: relative; }

--- a/apps/desktop/src/styles/components/wizard-base.css
+++ b/apps/desktop/src/styles/components/wizard-base.css
@@ -86,7 +86,7 @@ color: var(--alm-text-muted);
 
 /* === SELECT === */
 .alm-select {
-  height: 28px; padding: 0 var(--alm-sp-2);
+  height: var(--alm-control-h); padding: 0 var(--alm-sp-2);
   border: 1px solid var(--alm-border); border-radius: var(--alm-radius-sm);
   font-size: var(--alm-text-sm);
   background: var(--alm-bg); color: var(--alm-text);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -124,6 +124,13 @@
   /* Row density */
   --alm-row-height: 32px;
 
+  /* Control height (#616) — single source of truth for toolbar-adjacent
+     controls (buttons, text inputs, selects, SegControl) so they line up in
+     the same row instead of drifting per-component (measured: input 27px,
+     select 25px, button 24px, Settings select 28px, all in one chrome). */
+  --alm-control-h: 26px;
+  --alm-control-h-sm: 24px;
+
   /* Transitions */
   --alm-transition-fast: 100ms ease;
   --alm-transition-base: 150ms ease;

--- a/tests/e2e/typography_semantic_mono.spec.ts
+++ b/tests/e2e/typography_semantic_mono.spec.ts
@@ -119,22 +119,27 @@ test.describe("Spec 055 · semantic base layer + mono restoration (Phase 3)", ()
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/advanced");
+    await page.goto("/#/settings/sources");
     await page.waitForLoadState("networkidle");
 
-    const dbPath = page.locator(".alm-adv-settings__db-path");
-    await expect(dbPath).toBeVisible();
-    await expect(dbPath).toHaveText("~/.alm/astro-library.db");
+    // A registered data-source root's path (real, mock-fixture-backed data —
+    // apps/desktop/src/api/mocks.ts `mockRoots`) — not the fabricated Advanced
+    // pane db-path #601/#602 removed. Same `<code class="alm-mono">` mechanism.
+    const rootPath = page.locator(".alm-data-sources__root-path", {
+      hasText: "/astro/raw",
+    });
+    await expect(rootPath).toBeVisible();
+    await expect(rootPath).toHaveText("/astro/raw");
 
-    const family = await dbPath.evaluate(
+    const family = await rootPath.evaluate(
       (el) => getComputedStyle(el).fontFamily,
     );
     expect(family).not.toContain("Inter");
     expect(family.toLowerCase()).toContain("mono");
 
-    // `code, pre, kbd` base-layer rule (reset.css): the db-path element itself
+    // `code, pre, kbd` base-layer rule (reset.css): the root-path element itself
     // is a <code>, which is the same mechanism as every other code/pre surface.
-    const tag = await dbPath.evaluate((el) => el.tagName.toLowerCase());
+    const tag = await rootPath.evaluate((el) => el.tagName.toLowerCase());
     expect(tag).toBe("code");
   });
 


### PR DESCRIPTION
## Summary
- Unified control height and fixed input focus ring styling (#616, #631)
- Added shared FITS-value formatters (#811)
- Calibration/sessions detail panels show real derived info instead of
  echoing the selected row (#619)
- Removed a duplicated Projects section in target detail (#670)
- Advanced settings' Database info panel and Reset preferences no longer fake
  their actions/stats (#601, #602)

Closes #625
Closes #604
Closes #601
Closes #602
Closes #670
Closes #619
Closes #811
Closes #616