### PR TITLE
fix: tooltip popups render with a readable surface

### DIFF
--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -6,6 +6,20 @@
   max-width: 280px;
   white-space: normal;
   overflow-wrap: anywhere;
+
+  /* The popup renders in a PORTAL, so it inherits nothing from the surface it
+     floats over. Without its own background/border it drew as bare text on top
+     of whatever was underneath — unreadable over tables and panels. It carries
+     a full surface of its own, all token-driven so the four themes track it. */
+  background: var(--alm-surface-raised);
+  color: var(--alm-text);
+  border: 1px solid var(--alm-rule);
+  border-radius: var(--alm-radius-md);
+  padding: var(--alm-sp-2) var(--alm-sp-3);
+  font-size: var(--alm-text-xs);
+  line-height: 1.5;
+  box-shadow: var(--alm-shadow-sm);
+  z-index: 60;
 }
 
 /* === PILL === */


### PR DESCRIPTION
## What

`.alm-tooltip` carried only `max-width`, `white-space` and `overflow-wrap` — no background, border, padding, radius or shadow.

The popup renders in a **portal**, so it inherits nothing from the surface it floats over. It drew as bare text on top of whatever was underneath — unreadable over tables and panels. That is the "unstyled mouseover popup" a user reported.

## Fix

14 lines of CSS giving the popup a real surface, all token-driven so the four themes track it automatically.

Note: `--alm-text-primary` does **not** exist in `tokens.css` — the correct token is `--alm-text`. My first attempt used the former, which would have rendered transparent text. Every token used here was checked against `tokens.css`.

## Verification

Rendered in a real browser (vite dev + mocks, `#/setup`, which has four `InfoTip`s). Computed styles on the live popup element after hover:

| property | before | after |
|---|---|---|
| `background` | *(transparent)* | `rgb(255, 255, 255)` |
| `color` | *(inherited)* | `rgb(32, 33, 31)` |
| `border-width` | `0` | `0.909px` |
| `padding` | `0` | `8px 12px` |
| `border-radius` | `0` | `5px` |
| `box-shadow` | `none` | `rgba(0,0,0,0.08) 0 1px 2px` |

`tsc --noEmit` and `biome check` both clean.

Affects every `Tooltip` caller: `InfoTip`, `Lock`, `PropertyTable`.

## Not in scope

The same report also noted **clicking** an ⓘ does not open the popup. That is real but **not fixed here**: base-ui tooltips have no click trigger at all (hover/focus only), and the provider's default delay makes even hover feel unresponsive.

I attempted a controlled-`open` rewrite with `delay={0}`. Rendering it proved it **broke hover entirely** — popup absent from the DOM on both hover and click — so it is reverted and not part of this PR. Doing it properly likely means base-ui's `Popover` primitive (click-driven by design) or the `createHandle()` external-trigger API, which is more than a tweak and deserves its own change.

The branch name mentions "click" from that original intent; this PR is styling only.