### PR TITLE
ci: stop stale caches from failing unrelated pull requests

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -1,0 +1,113 @@
+name: Cache cleanup
+
+# Actions caches are restored by key with a ref-scoped fallback: a PR sees its
+# own `refs/pull/N/merge` entries, then its base branch, then the default
+# branch. So one bad entry on `main` is restored by every PR that has no entry
+# of its own — which is exactly how a poisoned macOS entry produced
+# `build-script-build: cannot execute binary file` (exit 126) on an unrelated
+# PR, presenting as a source defect.
+#
+# Two hygiene passes, both of which only ever DELETE caches (a deleted cache
+# costs one rebuild; a bad cache costs a wrong diagnosis):
+#
+#   1. PR closed        — drop that PR's entries. They can never be restored
+#                         again, so keeping them only consumes the repo quota
+#                         and pushes out entries that are still useful.
+#   2. Run cancelled    — drop entries scoped to that run's PR. A run killed
+#                         mid-save is the most likely way a partial entry is
+#                         committed, and `cancel-in-progress` makes that common
+#                         under push traffic.
+#
+# Deliberately NOT triggered on plain `failure`: a legitimately red PR would
+# lose its cache on every iteration, making an already-slow feedback loop
+# slower. Saving from failed runs is prevented at the source instead —
+# `cache-on-failure` is left at its default (false) everywhere.
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_run:
+    workflows: ["CI", "Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)"]
+    types: [completed]
+
+permissions:
+  actions: write # required to delete caches
+  contents: read
+
+concurrency:
+  # Serialize per target ref so two passes cannot race the same delete.
+  group: cache-cleanup-${{ github.event.pull_request.number || github.event.workflow_run.id }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Purge ref-scoped caches
+    runs-on: ubuntu-latest
+    # workflow_run fires for every completion; only act on cancellations.
+    if: >-
+      github.event_name == 'pull_request' ||
+      github.event.workflow_run.conclusion == 'cancelled'
+    steps:
+      - name: Resolve target PR refs
+        id: refs
+        env:
+          # Event data is never interpolated into the script body — it is read
+          # from the environment and validated before use.
+          EVENT_NAME: ${{ github.event_name }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          RUN_PRS: ${{ toJSON(github.event.workflow_run.pull_requests.*.number) }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT_NAME" = "pull_request" ]; then
+            printf '%s\n' "$PR_NUMBER" > /tmp/prs.txt
+          else
+            printf '%s' "$RUN_PRS" | jq -r '.[]' > /tmp/prs.txt
+          fi
+
+          # Reject anything that is not a bare integer before it reaches a URL.
+          if grep -qvE '^[0-9]+$' /tmp/prs.txt 2>/dev/null; then
+            echo "refusing: non-numeric PR identifier in event payload" >&2
+            grep -vE '^[0-9]+$' /tmp/prs.txt >&2 || true
+            exit 1
+          fi
+          echo "targets: $(tr '\n' ' ' < /tmp/prs.txt)"
+
+      - name: Delete caches for those refs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          [ -s /tmp/prs.txt ] || { echo "no PR refs to clean"; exit 0; }
+
+          total=0
+          failed=0
+          while read -r pr; do
+            [ -n "$pr" ] || continue
+            ref="refs/pull/${pr}/merge"
+
+            # Snapshot the key list once. Deliberately NOT a re-query loop: if a
+            # DELETE ever fails silently the list never drains and the job spins
+            # until the runner times out. One pass, then report what is left.
+            keys="$(gh api --paginate \
+              "/repos/${REPO}/actions/caches?ref=${ref}&per_page=100" \
+              --jq '.actions_caches[].key' 2>/dev/null || true)"
+            [ -n "$keys" ] || { echo "no caches for ${ref}"; continue; }
+
+            while read -r key; do
+              [ -n "$key" ] || continue
+              if gh api --method DELETE \
+                   "/repos/${REPO}/actions/caches?key=${key}&ref=${ref}" >/dev/null 2>&1; then
+                echo "deleted  ${ref}  ${key}"
+                total=$((total + 1))
+              else
+                echo "FAILED   ${ref}  ${key}" >&2
+                failed=$((failed + 1))
+              fi
+            done <<< "$keys"
+          done < /tmp/prs.txt
+
+          echo "removed ${total} cache entries, ${failed} failed"
+          # Surface partial failure without failing the job: cleanup is hygiene,
+          # and a red cleanup run on a merged PR is noise, not signal.
+          [ "$failed" -eq 0 ] || echo "::warning::${failed} cache deletion(s) failed"

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -295,11 +295,17 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         if: steps.verify-app-cache.outputs.usable != 'true'
 
+      # cache-on-failure deliberately left at its default (false). Saving from a
+      # failed run persists whatever broken/partial state the failure produced,
+      # and every later run then restores it. A macOS leg failed with
+      # `build-script-build: cannot execute binary file` (exit 126) after
+      # restoring a bad entry — which reads as a source defect rather than a
+      # cache defect and cost real diagnostic time. A failed run should cost a
+      # rebuild, never poison the next one.
       - uses: Swatinem/rust-cache@v2
         if: steps.verify-app-cache.outputs.usable != 'true'
         with:
           shared-key: "rust-e2e-ubuntu-latest"
-          cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
         if: steps.verify-app-cache.outputs.usable != 'true'


### PR DESCRIPTION
## Summary
- A macOS job failed with `build-script-build: cannot execute binary file` (exit 126) after restoring a bad cache entry. It surfaced as a "Generated contract/binding drift" failure on an unrelated PR, so it read as a source defect. Nothing had drifted.
- Root cause: the same cache key existed **three times at two sizes** (744MB on `main`, 744MB and 916MB on PR refs). A PR with no entry of its own falls back to `main`'s, so one bad entry there is restored by every such PR.

## Changes
- **`e2e.yml`** — drop `cache-on-failure: true`. Saving from a failed run persists whatever broken state the failure produced, and every later run restores it. A failure should cost a rebuild, not poison the next run.
- **`cache-cleanup.yml`** (new) — delete a PR's ref-scoped caches when it **closes** (they can never be restored again, so they only consume quota and evict useful entries) and when one of its runs is **cancelled** (a run killed mid-save is the likeliest way a partial entry gets committed, and `cancel-in-progress` makes that common under push traffic).

## Deliberately not done
- **Not triggered on plain `failure`** — a legitimately red PR would lose its cache on every iteration, making a slow feedback loop slower. Saving from failed runs is prevented at the source instead.
- **The `shared-key` was left alone.** `Swatinem/rust-cache` already appends the architecture (`Darwin-arm64`), so the label-only key is not the defect — an earlier cross-architecture theory of mine was wrong.

## Also done outside this PR
Purged the poisoned `v0-rust-rust-macos-latest-v2-Darwin-arm64-*` entries so open PRs stop restoring them — the same manual step `ci.yml:154` records from a previous poisoning on `windows-latest`. This PR is what stops that being a recurring manual chore.

Verified: `actionlint` clean on both files.