### PR TITLE
docs: answer the four open questions blocking the inbox spec's plan gate

### DIFF
--- a/specs/058-inbox-drop-parent-items/PENDING_REVIEW_QUESTIONS.md
+++ b/specs/058-inbox-drop-parent-items/PENDING_REVIEW_QUESTIONS.md
@@ -1,14 +1,22 @@
 # Pending Review Questions — 058 Inbox Drop Parent Items
 
-Questions raised during specification. **Five are now answered** (2026-07-19) —
-Q-1, Q-2, Q-4 and Q-8 by the product owner, Q-3 by events. Answers are recorded
-here and promoted to decisions D-005 through D-007 in
-[spec.md](spec.md#recorded-decisions).
+Questions raised during specification. **All nine are now answered**
+(2026-07-19) — Q-1, Q-2, Q-4, Q-8 and then Q-5, Q-6, Q-7, Q-9 by the product
+owner, Q-3 by events. Answers are recorded here and promoted to decisions D-005
+through D-007 in [spec.md](spec.md#recorded-decisions).
 
-**Four remain genuinely open** and must be resolved at the plan gate: Q-5, Q-6,
-Q-7, Q-9.
+Two of the later answers change this feature's shape rather than merely filling
+a blank, and are worth reading before the plan gate:
 
-Line references verified against `22f94a9e`.
+- **Q-6 descopes plan invalidation** out of 058 (FR-020/021/022 move to a
+  follow-on micro-spec), and records the owner-approved target architecture so
+  the follow-on does not re-derive it.
+- **Q-9's premise was false.** The `mixed` branch does not become dead code. The
+  question dissolves; a different, unrecorded gap is raised in its place.
+
+Line references in the answers below were re-verified against `main` at
+`5059e164`. Several references in the original questions had drifted since
+`22f94a9e`; corrections are noted inline where they occur.
 
 ---
 
@@ -164,110 +172,229 @@ not absent. Worth a journey delta.
 
 ---
 
-# Open
+## Q-5 — What anchors the confirm staleness guard after reclassification? — RESOLVED: per-item
 
-## Q-5 — What anchors the confirm staleness guard after reclassification?
+**Answer (product owner)**: Confirm-time staleness stays a **per-item**
+property. **FR-013 stands unchanged.** Reclassification is what must change:
+`reclassify_v2` MUST compute real per-group signatures, which requires threading
+a root absolute path into it. That path is available at the Tauri command layer
+(`apps/desktop/src-tauri/src/commands/inbox.rs`) and is simply not carried into
+the reclassify request today.
 
-**Context**: The confirm TOCTOU guard (`crates/app/inbox/src/confirm.rs:198`)
-compares the item's content signature against the request's. Reclassify writes
-an **empty** signature to re-materialized items
-(`crates/app/inbox/src/reclassify.rs:665-674`) because it passes no file paths.
-Today the parent's folder signature is a second anchor; after this change the
-per-group signature is the only one.
+**Reasoning**: The signature answers a question about one row — *have the files
+under this item changed since the classification the user is looking at?* An
+anchor scoped more widely than the thing it describes cannot answer that
+question honestly.
 
-**Unresolved**: Either reclassify computes real per-group signatures, or confirm
-falls back to the source group's folder signature, or an empty signature is
-defined as explicitly-stale and forces a re-classify.
+**Rejected**: falling back to the source group's folder signature
+(`inbox_source_groups.content_signature`), which survives this feature and is
+written from real file hashes at scan time. It is materially cheaper, and it was
+rejected anyway: a folder-scoped anchor means a change to **any** file in the
+folder invalidates **every** sibling's confirmation. That is a lifecycle
+coupling — precisely the class D-003 declares extinguished — reintroduced
+through the back door, and it would have required amending FR-013.
 
-**Why it matters**: The guard exists to stop a user confirming a plan built from
-files that changed underneath them. An empty signature that compares equal to an
-empty request signature would silently disable it.
+### A factual correction to this specification's own account
 
-**Raised in priority by Q-2's answer**: D-005 requires an invalidation signal
-when a re-scan supersedes a confirmation, and this guard is the existing
-mechanism for that class of problem. Whether it is reused or a separate
-invalidation path is built is now part of this question.
+The premise stated in this question and in [research.md](research.md) §4.5 —
+that reclassify writes an **empty** signature — is **wrong**, and the error
+matters because it changes what fixes are possible.
 
-**Needs**: An engineering decision, with a regression test asserting the guard
-still fires after reclassification.
+`reclassify_v2` passes an empty file-path slice
+(`crates/app/inbox/src/reclassify.rs:820-831`), so the per-group signature is
+`folder_signature([])`. That function
+(`crates/app/inbox/src/signature.rs:69-76`) hashes the file signatures and
+hex-encodes the digest, so on empty input it returns **the SHA-256 of empty
+input** — a fixed 64-character constant, not an empty string.
 
----
+The consequence is sharper than the original framing. Every item that has ever
+been through `reclassify_v2` carries the *same universal constant* as every
+other such item, in every folder, in every library. The confirm guard
+(`crates/app/inbox/src/confirm.rs:197-205`) therefore passes trivially, and
+would also pass across unrelated items.
 
-## Q-6 — Should reclassify still block on any sibling having a plan?
+**This is a live defect on `main` today, independent of 058.** The guard is
+already vacuous on the reclassify path; this feature does not create the problem,
+it removes the parent row that was masking it and makes that path the only path.
+It could be fixed without this feature, and arguably should be.
 
-**Context**: `crates/app/inbox/src/reclassify.rs:372-380` refuses to reclassify
-when **any** item sharing the source group has a plan link.
+Note also that an "empty means stale" rule — one of the options originally
+considered — **cannot be implemented as an emptiness check**, because the value
+is not empty.
 
-**Unresolved**: This is a shared-lifecycle coupling, which D-003 says should not
-survive. But it is also a genuine safety interlock.
+**Two in-tree comments repeat the same false premise** and must be corrected in
+this feature's first code PR: `reclassify.rs:648-649` and `reclassify.rs:821`.
 
-**Changed by Q-2's answer**: D-005 now supplies a principled alternative that
-did not exist when this question was written — instead of *blocking*
-re-derivation because a plan exists, re-derivation proceeds and any plan whose
-basis vanished is *invalidated*. That is consistent with both D-003 and
-Constitution II, and suggests the interlock can be removed rather than
-preserved.
-
-**Still open because** removing a safety interlock deserves an explicit decision
-rather than inference, and the invalidation path (Q-5) must exist and be tested
-first. Sequencing matters: do not delete the interlock before invalidation
-works.
-
-**Needs**: A product decision, after Q-5.
-
----
-
-## Q-7 — Does the needs-review sentinel workaround survive?
-
-**Updated 2026-07-19 after `22f94a9e` (#1086).** That PR closed #711 Instance B
-by re-checking the mandatory-attribute gate before promoting a sentinel-carrying
-row, and by gating the classification-cache write with it
-(`crates/app/inbox/src/reclassify.rs:186-201`, sentinel cleared at `:221`).
-
-**What did not change**: `clear_needs_review_sentinel`
-(`crates/persistence/db/src/repositories/inbox.rs:584-599`) still rewrites the
-group key in place to a synthetic `type=<ft>·resolved=<item_id>` value, purely
-to dodge the `(root_id, relative_path, group_key)` UNIQUE against an existing
-sibling. The workaround survives #1086 intact.
-
-**The question sharpens rather than resolves.** #1086 made the sentinel *more*
-load-bearing, not less: `inbox_confirm` gates on
-`group_key == SENTINEL_NEEDS_REVIEW` directly
-(`crates/app/inbox/src/confirm.rs:174`), and the classification cache is now
-gated by the same check. So `group_key` currently carries three distinct
-meanings at once — a classification identity, a needs-review flag, and a
-uniqueness discriminator.
-
-**Unresolved**: Whether resolving a needs-review item should instead re-derive
-the folder's items, merging the resolved files into the correct sibling (which
-may already exist), retiring the synthetic key entirely.
-
-**Why it matters**: A group key that encodes an item id is not a classification
-identity, and FR-007 requires every item's identity to be consistent with its
-state. Overloading one column with three meanings is what let a row claim
-`classified` while carrying no frame type in the first place.
-
-**Needs**: A data-model decision. Any change must preserve #1086's Instance B
-fix, which has its own regression test at `reclassify.rs:1027`.
+**Needs**: a regression test asserting the guard still fires after
+reclassification — the existing tests cannot have been covering it.
 
 ---
 
-## Q-9 — Does the `mixed` classification branch become dead code?
+## Q-6 — Should reclassify still block on any sibling having a plan? — RESOLVED: descoped, with the target recorded
 
-**Context**: `canConfirm` requires `classification.type === 'single_type'`
-(`apps/desktop/src/features/inbox/InboxPage.tsx:832-841`). The parent is exactly
-the row that classifies as `mixed`.
+**Answer (product owner)**: **Descoped out of 058.** FR-020, FR-021 and FR-022
+move to a follow-on micro-spec. 058 keeps the existing interlock exactly as it
+is and ships the parent-removal it is actually about.
 
-**Unresolved**: Whether `mixed` remains reachable, and if not, whether
-`InboxDetail.tsx:1037-1048` (`inbox-mixed-alert`), `mixedSummary` (`:842-843`),
-the `handleConfirm` guard (`:607`), and the root-pick guard (`:691`) should be
-removed.
+**Reasoning**: The interlock cannot simply be deleted, because
+`delete_sub_item_if_unlinked`
+(`crates/persistence/db/src/repositories/inbox.rs:610-619`) refuses to purge a
+plan-linked row **silently** — a no-op, not an invalidation. Remove the block
+without an invalidation path and re-derivation leaves an orphaned row carrying
+an open plan and nothing on disk behind it: the "keep and show" outcome D-005
+rejects. So removing it is gated on building D-005's mechanism, which is the
+largest unscoped piece of work in the feature and which was itself gated on Q-5.
+Deciding a plan-lifecycle design under that much sequencing pressure, inside a
+spec about removing placeholder rows, is how the original defect got two
+read-side patches instead of one model fix.
 
-**Narrowed by Q-4's answer**: under D-006 no `inbox_items` row is ever created
-before classification, and classification produces only single-type items. So
-`mixed` looks unreachable for items. The remaining question is whether an
-unclassified **source-group** row needs its own equivalent of the mixed
-affordance — a scanned-but-unclassified folder is precisely a folder whose
-contents are not yet known to be uniform.
+**Consequence, recorded rather than hidden**: 058 ships with one lifecycle
+coupling that contradicts its own D-003. A folder with one confirmed sibling
+cannot have its other siblings reclassified until the follow-on lands. This is
+written up in [spec.md](spec.md#the-one-lifecycle-coupling-that-knowingly-survives),
+together with the **owner-approved target architecture** — per-item reclassify
+as the only user-facing classification action, folder re-derivation as a
+separate non-blocking identity-scoped operation triggered by disk change, the
+interlock retired by irrelevance rather than deleted defensively,
+supersede-and-surface rather than silent cancellation, and delivery by
+event-driven inversion following `crates/app/inbox/src/plan_listener.rs` rather
+than by adding a `crates/app/core` dependency edge to `crates/app/inbox`.
 
-**Needs**: An engineering decision, after the D-006 row-union design exists.
+The follow-on is being authored under `specs/tiny/`.
+
+See `specs/tiny/reclassify-split-per-item-and-rederivation.md` (PR #1097).
+
+**Line reference correction**: this question cited `reclassify.rs:372-380`; the
+interlock is at **`:347-360`** on current `main`.
+
+---
+
+## Q-7 — Does the needs-review sentinel workaround survive? — RESOLVED: give needs-review its own field
+
+**Answer (product owner)**: **No.** Needs-review gets its own column/field,
+distinct from the classification identity. Promoted to FR-028.
+
+**Reasoning**: `group_key` currently carries three meanings at once —
+classification identity, needs-review flag, and uniqueness discriminator — and
+overloading one column is what allowed a row to claim `classified` while
+carrying no frame type in the first place. D-004's greenfield decision (no
+installed base, confirmed by Q-1) means a schema change is **cheapest now** and
+will cost a real migration after release.
+
+**The collision this feature was assumed to relieve, it actually worsens.** The
+synthetic key exists to dodge the `(root_id, relative_path, group_key)` UNIQUE
+against an already-materialised sibling. 058 makes N siblings per folder the
+norm, so a needs-review item resolving to `dark` is **more** likely to find an
+existing `dark` sibling to collide with, not less. Deferring the cleanup would
+be deferring it into a harder problem.
+
+### Two constraints the implementation must respect
+
+**1. `clear_needs_review_sentinel` does three things, not one.**
+`crates/persistence/db/src/repositories/inbox.rs:584-600` writes `group_key`
+**and** `frame_type` **and** `state = 'classified'` in a single statement.
+[research.md](research.md) describes it as purely a UNIQUE-constraint dodge; in
+fact it is **the only path that makes a resolved needs-review item truthfully
+classified**. Any replacement MUST preserve all three writes as one atomic
+transition, or it recreates FR-007's exact violation — a `classified` state with
+no frame type — in a new location. Promoted to FR-029.
+
+**2. The #1086 regression test survives in intent, and is edited in mechanism.**
+`reclassify_type_agreement_without_mandatory_attrs_stays_needs_review`
+(`crates/app/inbox/src/reclassify.rs:1086`; this question originally cited
+`:1027`, and the spec cited `1076-1146`) must keep passing.
+
+Its invariant is **representation-independent**: frame-type agreement across an
+item's files is not sufficient evidence to report that item classified; the
+mandatory-attribute gate must pass; and all three surfaces — API response, item
+row, and classification cache — must agree on the answer. The third assertion is
+the anti-#711 clause, forbidding the cache from diverging from the row.
+
+Nothing in that invariant requires "needs review" to live in `group_key`. So the
+test's **setup and assertion will be edited** to read the new field. **This is
+recorded explicitly so that no later reader mistakes that edit for a weakening
+of the gate.** The invariant and SC-011 survive intact; only the representation
+the test pokes at changes. Promoted to FR-030.
+
+---
+
+## Q-9 — Does the `mixed` classification branch become dead code? — RESOLVED: no, and the premise was false
+
+**Answer**: **Keep `mixed` as is.** The question's premise does not hold, so it
+largely answers itself. Promoted to FR-031.
+
+**The finding**: `mixed` is **not** computed from group keys. It is computed
+from an item's evidence rows, in two places — `classify.rs:1219-1231` (the
+cache-hit path) and `reclassify.rs:166-171` — as a distinct set over
+`manual_override.or(frame_type)`, with `>= 2` meaning mixed.
+
+A freshly materialised needs-review sibling has `frame_type: None` on every
+evidence row, so its distinct set is empty and it reports `unclassified`, not
+mixed. **But the moment a user assigns two different frame types to files inside
+that sentinel item, `manual_override` makes the distinct set size 2 and the item
+reports `mixed`.** A needs-review item is something 058 explicitly keeps. So the
+branch remains reachable, and removing it would leave a reachable state with no
+rendered explanation of why Confirm is disabled.
+
+**A Layer-2 journey also depends on the affordance as a synchronisation
+signal.** `crates/e2e-tests/tests/inbox_ui_journeys.rs:237` waits on
+`inbox-mixed-alert` specifically because its appearance "proves the split was
+materialized server-side" (comment at `:232-236`). Removing the affordance would
+hang that journey — one of the three SC-005 journeys — rather than fail it
+cleanly.
+
+### Two follow-ups
+
+**1. A code comment becomes factually wrong.**
+`apps/desktop/src/features/inbox/InboxPage.tsx:599-606` states that
+`classification.type === "mixed"` is "only reachable when the SELECTED item is
+still the pre-materialization leaf-folder row". That premise is exactly what 058
+invalidates. The conclusion (keep the guard) is still right; the stated reason
+will not be. **Flagged for correction in 058's first code PR** — this comment is
+what misled this specification into asking Q-9 in the first place, and it will
+mislead the next reader the same way.
+
+**2. An open design gap, for the plan gate to size — not to decide here.**
+Resolving a heterogeneous needs-review bucket into two frame types is the
+*expected* outcome of the user doing what they were asked to do. This feature's
+own model says two types means two siblings. So that item arguably ought to
+**split**, rather than come to rest in `mixed` with Confirm disabled — a dead end
+the user can only escape by re-editing answers that were correct. Recorded as an
+edge case in [spec.md](spec.md#edge-cases). It inherits the item-identity /
+remount hazard already documented at `inbox_ui_journeys.rs:390-399`, because
+splitting moves the resolved files onto a different item id mid-interaction.
+
+---
+
+# Corrections to concerns raised against this specification
+
+Two concerns raised during review do not survive contact with the code, and are
+recorded here so they are not re-raised at the plan gate.
+
+**`write_minimal_fits` omitting `EXPTIME` is not a defect.** It is deliberate and
+documented (`crates/e2e-tests/tests/common/mod.rs:1857-1863`): the omission
+routes every frame type to the needs-review sentinel, which is what the
+needs-review journeys want. `write_minimal_fits_with_exposure` (`:1883`) exists
+for journeys that need a frame to actually classify, and the mixed-split journey
+already uses it. No action.
+
+**The real hidden E2E cost is different, and larger.** Two helpers assume a scan
+yields exactly one *selectable* inbox item per folder:
+
+- `rescan_and_wait_for_item` (`crates/e2e-tests/tests/inbox_ui_journeys.rs:135-138`)
+  waits for at least one `inbox-item-*` testid immediately after scan.
+- `select_only_item` (`:148-165`) takes the first `inbox-item-` suffix found,
+  clicks it, and waits for `inbox-confirm-btn` to mount.
+
+Under **D-006**, scan creates no inbox item at all — only a source group. Both
+helpers therefore break unless the source-group row is rendered with an
+`inbox-item-*` testid **and** mounts a Confirm button. But
+[spec.md](spec.md#edge-cases) requires that the source-group row must **not** be
+confirmable. **Those two requirements are in direct tension**, and the tension
+must be resolved before these journeys can be repaired.
+
+Call sites affected: `:224`/`:230`, `:368`/`:369`, `:493`/`:494`, `:554`/`:555`,
+`:630`/`:631` — **five journeys, including all three SC-005 journeys.**
+
+This is not itself an open question: it is a cost of the already-decided D-006
+surfacing through Q-9's territory. **The plan gate must budget for it.**

--- a/specs/058-inbox-drop-parent-items/research.md
+++ b/specs/058-inbox-drop-parent-items/research.md
@@ -39,7 +39,7 @@ shim has no reason to exist.
 
 ### The false statement
 
-- `crates/app/inbox/src/classify.rs:452` — `update_inbox_item_scan` writes the
+- `crates/app/inbox/src/classify.rs:458` — `update_inbox_item_scan` writes the
   recomputed **folder** signature onto the parent.
 - `crates/app/inbox/src/classify.rs:467` — `update_inbox_item_state(...,
   "classified")` sets the parent's state.
@@ -169,11 +169,28 @@ the change surface considerably.
 The signature guard at `confirm.rs:198` compares `item.content_signature` to the
 request's. For a parent that is the folder signature written by scan/classify;
 for a sibling it is the per-group signature from `materialize_sub_items`
-(`classify.rs:935`, `:959`). Reclassify writes an **empty** signature
-(`reclassify.rs:665-674`, `:844-845`) because it passes no file paths. With the
-parent gone, the per-group signature becomes the sole confirm anchor, so this
-empty-signature path is promoted from a secondary case to the only case. This
-must be resolved during planning — see Q-5.
+(`classify.rs:935`, `:959`).
+
+Reclassify passes no file paths (`reclassify.rs:643-651`, `:820-831`), so the
+per-group signature it writes is **not empty** — it is `folder_signature([])`
+(`crates/app/inbox/src/signature.rs:69-76`), which hex-encodes the SHA-256 of
+empty input. That is a fixed 64-character constant, identical for every
+reclassified item in every folder in every library.
+
+The consequence is sharper than an empty value comparing equal to an empty
+request value: the guard passes trivially, and would pass across unrelated
+items. **The guard is therefore already vacuous on the reclassify path on
+`main` today**, independent of this feature. With the parent gone the per-group
+signature becomes the sole confirm anchor, promoting that vacuous path from a
+secondary case to the only case.
+
+An "empty means stale" rule cannot be implemented as an emptiness check,
+because the value is not empty. Resolved by Q-5.
+
+**Two in-tree comments state the same false premise** and must be corrected
+alongside the fix: `reclassify.rs:648-649` ("the signatures will be zero-length
+(no hashes), yielding an empty sub-group sig") and `reclassify.rs:821` ("Signatures
+will be empty (no file I/O)").
 
 ### 4.3 Source-group-to-item resolution
 
@@ -182,7 +199,7 @@ must be resolved during planning — see Q-5.
 | `crates/app/inbox/src/target_recommendations.rs:227-231` | `resolve_item_id` takes `ids.into_iter().next()` — an arbitrary id-ordered row, today usually the parent. **Latent bug now, ambiguous by design after the change** |
 | `crates/persistence/db/src/repositories/inbox.rs:1451-1466` | `list_item_ids_for_source_group` returns all rows including the parent |
 | `crates/app/inbox/src/reclassify.rs:333-360` | resolves the source group from the request or from the item id |
-| `crates/app/inbox/src/reclassify.rs:372-380` | blocks reclassify if **any** sibling has a plan link — a shared-lifecycle coupling that D-003 contradicts (Q-6) |
+| `crates/app/inbox/src/reclassify.rs:347-360` | blocks reclassify if **any** sibling has a plan link — a shared-lifecycle coupling that D-003 contradicts (Q-6) |
 | `crates/app/inbox/src/reclassify.rs:389-400` | prefers `list_inbox_sub_items` over the full id set *only* to avoid double-counting the parent's duplicate evidence; falls back to the full set when nothing is materialized. This fallback exists solely for the parent and dies with it |
 | `crates/app/inbox/src/reclassify.rs:448-450`, `:697-699` | same double-count avoidance |
 | `crates/app/inbox/src/cone_search.rs:513-540` | per-file target overrides scoped to the source group — folder-scoped by intent, still correct, but re-check once parent evidence disappears |
@@ -210,6 +227,7 @@ worth revisiting under the new model rather than carrying forward (Q-7).
 | `crates/app/inbox/src/classify.rs:930-935`, `:959` | per-group signature from per-file hashes — the real per-row anchor |
 | `crates/persistence/db/src/repositories/inbox.rs:501-546` | `upsert_inbox_sub_item` conflicts on `(root_id, relative_path, group_key)`; re-scan stability rests on the group key, **not on any parent row** |
 | `crates/persistence/db/src/repositories/inbox.rs:610-619` | `delete_sub_item_if_unlinked` refuses to purge a plan-linked row; with no parent, a plan-linked stale group can no longer hide behind one (Q-2) |
+| `crates/app/inbox/src/reclassify.rs:820-831` | passes `&[]` for file paths, so the per-group signature is `folder_signature([])` — the empty-set hash constant, **not** an empty string. A live defect on `main` that makes the confirm guard vacuous; see §4.2 and Q-5 |
 
 ### 4.6 Materialization
 

--- a/specs/058-inbox-drop-parent-items/spec.md
+++ b/specs/058-inbox-drop-parent-items/spec.md
@@ -14,13 +14,27 @@ classification, the linkage is broken. Greenfield — no backwards
 compatibility."
 
 **Resolves**: [#711](https://github.com/platevault/platevault/issues/711)
-**Instance A** — a list row reporting `CLASSIFIED` for an item that is
-unclassified. Instance B (the false-`NEEDS REVIEW` direction) was closed
-separately by PR #1086 (`22f94a9e`); see
-[Relationship to #711 Instance B](#relationship-to-711-instance-b).
+**Instance A, unsplit remainder only** — a list row reporting `CLASSIFIED` for
+an item that is unclassified, in the case of a folder that does *not* split.
 
-**Supersedes the read-side workarounds in**: PR #1038 (`1eae04e9`) and PR #1081
-(`b4e72263`), both now merged.
+The scope claim is deliberately narrow, because ground is already held:
+
+- **The split case is fixed on `main`.** PR #1038 (`1eae04e9`) hid the aggregate
+  row whenever any sibling existed; PR #1081 (`b4e72263`) narrowed that to
+  genuine splits, which repaired #1038's regression. Between them, a folder that
+  splits no longer shows a lying aggregate row.
+- **Instance B is closed.** The false-`NEEDS REVIEW` direction was closed by
+  PR #1086 (`22f94a9e`); see
+  [Relationship to #711 Instance B](#relationship-to-711-instance-b).
+
+What remains — and what this feature is actually for — is the folder that
+produces exactly one item. #1081's narrowing knowingly returned Instance A for
+that case, because there is no sibling whose existence could suppress the
+placeholder. This feature removes the placeholder itself.
+
+**Supersedes the read-side workarounds in**: PR #1038 and PR #1081. Those
+workarounds are removed (FR-026, SC-007) rather than corrected — with no
+aggregate row there is nothing to suppress.
 
 ## Product Intent
 
@@ -118,8 +132,17 @@ that no longer exists), keep-and-hide (an invisible open plan — the worst
 failure mode), and block-re-scan-until-resolved (one stale plan freezes
 reconciliation for the whole folder, denying the user the obvious remedy).
 
-The mechanism is not yet chosen. The existing confirm staleness guard may
-already be the right hook — see Q-5, which remains open.
+**Refined by the Q-6 decision**: *supersede and surface, never silently cancel.*
+The orphaned sibling is marked superseded and the user decides what happens to
+its plan. Automatic cancellation was the original reading of "invalidate", but a
+plan is a record of pending filesystem mutations, and disposing of one without
+the user's involvement is the same class of act Constitution II exists to
+prevent. The decision's substance — a superseded sibling is not preserved as
+though nothing happened — is unchanged.
+
+**The mechanism is descoped from this feature** and delivered by the follow-on
+micro-spec, together with FR-020/021/022. The staleness guard Q-5 answers is
+per-item and stays per-item; it is not repurposed as the invalidation hook.
 
 ### D-006 — Scan creates the source group; classification creates the items
 
@@ -205,9 +228,62 @@ reconciles the existing rows against that answer. It does not propagate state,
 plans, or confirmations between siblings.
 
 The reconciliation rules this implies — in particular what happens to a sibling
-that a re-scan no longer produces but that already has a plan — are a genuine
-open question. See [PENDING_REVIEW_QUESTIONS.md](PENDING_REVIEW_QUESTIONS.md)
-Q-2.
+that a re-scan no longer produces but that already has a plan — are answered in
+principle by D-005 (invalidate, do not preserve). Their *mechanism* is
+deliberately not built here; see below.
+
+### The one lifecycle coupling that knowingly survives
+
+This feature declares shared lifecycle dead, and then ships one exception. It is
+recorded here rather than left to be discovered.
+
+`reclassify_v2` (`crates/app/inbox/src/reclassify.rs:347-360`) refuses to
+re-derive a folder when **any** sibling in that source group has an open plan.
+That is a folder-wide block, and it contradicts "no shared plan" above. It
+survives 058 untouched.
+
+It survives because it is load-bearing safety, not an oversight. Re-derivation
+ends by purging groups that no longer exist, via `delete_sub_item_if_unlinked`
+(`crates/persistence/db/src/repositories/inbox.rs:610-619`), which **refuses to
+delete a plan-linked row and does so silently**. Removing the interlock without
+first building an invalidation path would therefore not invalidate the orphaned
+sibling — it would leave it in the queue with an open plan and nothing on disk
+behind it. That is precisely the "keep and show" outcome D-005 rejects. The
+interlock is what prevents the system reaching that state today.
+
+Per-item `reclassify` (`:82`) blocks only on the item's own plan. That narrower
+check is already consistent with D-003 and is not in question.
+
+**Consequence for the reader**: until the follow-on lands, a folder with one
+confirmed sibling cannot have its other siblings reclassified. This is real,
+user-visible friction, accepted knowingly for one release rather than resolved
+by rushing a plan-lifecycle design.
+
+### Target architecture for retiring the coupling *(owner-approved)*
+
+Recorded so the follow-on does not re-derive it:
+
+- **Per-item reclassify becomes the only user-facing classification action**,
+  blocking on that item's own plan and nothing else.
+- **Folder re-derivation becomes a separate identity-scoped operation**,
+  triggered by disk change rather than by a user gesture, that never blocks.
+- **The interlock is retired by irrelevance, not deleted defensively.** Once no
+  user-facing action performs folder-wide re-derivation, the folder-wide block
+  has nothing left to guard and can be removed as dead code — not removed first
+  and compensated for afterwards.
+- **Supersede and surface, never silently cancel.** An orphaned plan-linked
+  sibling is marked superseded and shown to the user, who decides. The system
+  does not discard a plan on the user's behalf (Constitution II).
+- **Delivered by event-driven inversion**, following the existing
+  `crates/app/inbox/src/plan_listener.rs` pattern — **not** by adding a
+  `crates/app/core` dependency edge to `crates/app/inbox`. `cancel_plan` lives
+  at `crates/app/core/src/plan_apply.rs:1871` and `crates/app/core` is not a
+  dependency of `crates/app/inbox`; inverting the call preserves that boundary.
+  `plan_listener.rs:138-140` already returns an item to `classified` when a plan
+  reaches `partially_applied`, `failed`, or `cancelled`, so this is an extension
+  of an established pattern rather than new territory.
+
+See [PENDING_REVIEW_QUESTIONS.md](PENDING_REVIEW_QUESTIONS.md) Q-6.
 
 ## User Scenarios & Testing *(mandatory)*
 
@@ -339,8 +415,9 @@ resulting sibling carries a frame type without any user input.
 - **A re-scan that changes the split.** A folder previously split into three
   now yields two, or one, or four. Rows that still correspond to a group
   survive; a row that no longer corresponds to any group is invalidated, and if
-  it carried an open plan that plan is cancelled with an explicit superseded
-  signal (D-005).
+  it carried an open plan it is marked superseded and surfaced to the user, who
+  decides the plan's fate (D-005). *The mechanism ships in the follow-on
+  micro-spec, not here.*
 - **A re-scan that finds the folder unchanged.** Must not churn item ids, or
   the user's selection and any open plans are disturbed for no reason.
 - **Two folders at the same relative path under different roots.** Identity must
@@ -352,6 +429,18 @@ resulting sibling carries a frame type without any user input.
 - **A folder whose files all move into one group after reclassification.** A
   previously split folder becoming homogeneous must converge on a single item
   without leaving orphans.
+- **A needs-review item whose files receive two *different* user-supplied frame
+  types.** This state remains reachable after 058 and reports `mixed`. The
+  `mixed` affordance is therefore retained — see Q-9. **Open design gap for the
+  plan gate**: resolving a heterogeneous needs-review bucket into two frame types
+  is the *expected* outcome of the user doing exactly what they were asked to do,
+  and this feature's own model says two types means two siblings. So the item
+  arguably ought to **split**, rather than come to rest in `mixed` with Confirm
+  disabled — which is a dead end the user can only escape by re-editing answers
+  that were correct. This is recorded as a gap to size, not a decision taken; it
+  inherits the item-identity/remount hazard already documented at
+  `crates/e2e-tests/tests/inbox_ui_journeys.rs:390-399`, because splitting moves
+  the resolved files onto a different item id mid-interaction.
 
 ## Requirements *(mandatory)*
 
@@ -382,6 +471,21 @@ resulting sibling carries a frame type without any user input.
   classification result, for every item.
 - **FR-009**: Inbox summary counts MUST count each visible item consistently
   with the list, with no folder counted twice and none omitted.
+- **FR-028** *(Q-7)*: Needs-review MUST be represented as its own field, distinct
+  from the item's classification identity. One field MUST NOT simultaneously
+  carry classification identity, needs-review status, and a uniqueness
+  discriminator.
+- **FR-029** *(Q-7)*: Resolving a needs-review item MUST record its frame type,
+  its classification identity, and its `classified` state together, as one
+  atomic transition. No intermediate state may be observable in which the item
+  reports `classified` without a frame type.
+- **FR-030** *(Q-7)*: Frame-type agreement across an item's files MUST NOT by
+  itself cause that item to be reported classified; the mandatory-attribute gate
+  MUST pass, and the API response, the item row, and the classification cache
+  MUST agree on the result.
+- **FR-031** *(Q-9)*: The `mixed` classification result and its user-facing
+  affordance MUST be retained. It remains reachable on a needs-review item whose
+  files carry conflicting user-supplied frame types.
 
 **Lifecycle**
 
@@ -391,7 +495,10 @@ resulting sibling carries a frame type without any user input.
 - **FR-012**: Each sibling MUST be independently confirmable while its siblings
   remain unconfirmed.
 - **FR-013**: Staleness detection at confirm time MUST be evaluated against the
-  files belonging to the item being confirmed.
+  files belonging to the item being confirmed. *Confirmed unchanged by the Q-5
+  decision: staleness is a per-item property. Reclassification MUST compute a
+  real per-group signature rather than the empty-set hash constant it writes
+  today, which requires threading a root absolute path into `reclassify_v2`.*
 - **FR-014**: Re-classification MUST re-derive a folder's items from the files
   on disk without propagating state, plans, or confirmations between siblings.
 
@@ -410,12 +517,21 @@ resulting sibling carries a frame type without any user input.
   its existing items.
 - **FR-019**: The system MUST anchor folder-level re-scan comparison to the
   source group rather than to any single item.
-- **FR-020**: When re-derivation no longer produces an item that has an open
-  plan, the system MUST cancel that plan and mark the item stale (D-005).
-- **FR-021**: The system MUST surface an explicit signal when a user's
-  confirmation has been superseded, and MUST NOT silently discard a plan.
-- **FR-022**: Re-derivation MUST NOT be blocked for a whole folder by the
-  existence of one open plan.
+
+*FR-020, FR-021 and FR-022 have been moved out of this feature.* They covered
+plan invalidation on supersession, the user-facing supersession signal, and the
+removal of the folder-wide reclassify block. They are delivered by a follow-on
+micro-spec — see
+[The one lifecycle coupling that knowingly survives](#the-one-lifecycle-coupling-that-knowingly-survives)
+for why, and for the owner-approved target architecture the follow-on
+implements. D-005 remains a recorded decision of this specification; only its
+mechanism is descoped.
+
+See `specs/tiny/reclassify-split-per-item-and-rederivation.md` (PR #1097).
+
+The numbers are retired rather than reused, so that a reader of PR history or of
+the follow-on is never left wondering whether FR-020 means one thing here and
+another there.
 
 **User-visible continuity**
 
@@ -572,19 +688,24 @@ sentinel-carrying row, and gates the classification-cache write with the same
 check, so the cached classification can no longer flip to `single_type` while
 the list row and confirm still correctly see the sentinel.
 
-This feature therefore claims **Instance A only**. Instance A is the direction
-caused by the parent row, and it is the one no read-side patch has been able to
-fix without breaking something else.
+This feature therefore claims **the unsplit remainder of Instance A only**.
+Instance A is the direction caused by the parent row; #1038 and #1081 between
+them closed the split case, and the folder that produces exactly one item is
+what is left. It is the case no read-side patch has been able to fix without
+breaking something else, because for a homogeneous folder the placeholder is the
+row the workflow depends on.
 
 Two consequences for planning:
 
 - Instance B's fix must be **preserved**, not regressed. SC-011 makes that
   explicit, and `22f94a9e` ships its own regression test
-  (`crates/app/inbox/src/reclassify.rs:1027`).
+  (`crates/app/inbox/src/reclassify.rs:1086-1142`).
 - #1086 made the `__needs_review__` sentinel *more* load-bearing rather than
-  less, which sharpens rather than settles the question of whether the
-  sentinel's synthetic-group-key workaround should survive this model change.
-  See Q-7.
+  less. **Resolved by Q-7**: the workaround does not survive — needs-review moves
+  to its own field (FR-028), and the atomic frame-type/identity/state transition
+  that `clear_needs_review_sentinel` performs today must be preserved in its
+  replacement (FR-029). The #1086 test's setup and assertions are edited to read
+  the new field; **its invariant and SC-011 are unchanged** (FR-030).
 
 ## Dependencies
 
@@ -592,6 +713,13 @@ Two consequences for planning:
   deletes their shared read-side predicate and the `exclude_split_placeholder!`
   macro (FR-026, SC-007); nothing needs to be sequenced around them.
 - PR #1086 (`22f94a9e`) is merged and must be preserved (SC-011).
+- A follow-on micro-spec under `specs/tiny/` owns plan invalidation and the
+  retirement of the folder-wide reclassify interlock (the former FR-020/021/022).
+  It depends on this feature rather than blocking it: 058 ships the interlock
+  untouched. See `specs/tiny/reclassify-split-per-item-and-rederivation.md` (PR #1097).
+- The confirm staleness guard is **already vacuous on the reclassify path on
+  `main`** (Q-5). That defect is independent of this feature and could be fixed
+  ahead of it.
 
 ## Next Gates
 
@@ -600,3 +728,19 @@ Per the constitution, this specification must pass review before planning.
 included here — they are owned by the plan gate. [research.md](research.md)
 records the current-code evidence gathered during specification so the planner
 does not have to re-derive it.
+
+All nine review questions are now answered
+([PENDING_REVIEW_QUESTIONS.md](PENDING_REVIEW_QUESTIONS.md)). Three items are
+handed to the plan gate as **work to size, not decisions to take**:
+
+1. **The D-006 E2E helper tension.** `rescan_and_wait_for_item` and
+   `select_only_item` both assume a scan yields exactly one *selectable* item per
+   folder, but under D-006 a scan yields only a source group — which this
+   specification also requires to be non-confirmable. Five journeys are affected,
+   including all three SC-005 journeys. Detailed in
+   [PENDING_REVIEW_QUESTIONS.md](PENDING_REVIEW_QUESTIONS.md).
+2. **The needs-review split gap** (Q-9): whether a heterogeneous needs-review
+   bucket resolved into two frame types should split rather than come to rest in
+   `mixed` with Confirm disabled.
+3. **The Q-5 signature work**: threading a root absolute path into
+   `reclassify_v2`, plus the regression test that proves the confirm guard fires.


### PR DESCRIPTION
Spec-only change under `specs/`. No product code touched.

Records product-owner answers to Q-5, Q-6, Q-7 and Q-9 in `specs/058-inbox-drop-parent-items`, and narrows the spec's scope claim to what it still actually owns. Q-1/Q-2/Q-4/Q-8 were answered previously and are untouched.

## The decisions

**Q-5 staleness anchor — per-item.** FR-013 stands. `reclassify_v2` must compute real per-group signatures, which requires threading a root absolute path in (available at the command layer, deliberately not carried today). The cheaper per-folder fallback to `inbox_source_groups.content_signature` is recorded as **rejected**: it would let a change to any file invalidate every sibling's confirmation, reintroducing the lifecycle coupling D-003 forbids.

**Q-6 plan interlock — descoped, target architecture recorded.** FR-020/021/022 move to `specs/tiny/reclassify-split-per-item-and-rederivation.md` (#1097); their numbers are retired, not reused. A new section names the one lifecycle coupling that knowingly survives this spec, the user-visible friction accepted for a release, and why removing the interlock without an invalidation path produces exactly the orphaned row D-005 rejects.

**Q-7 needs-review sentinel — gets its own field** (FR-028). D-004's greenfield window makes the schema change cheapest now, and this spec makes the `group_key` collision *more* likely, not less, since N siblings per folder becomes the norm. FR-029 preserves the three writes `clear_needs_review_sentinel` performs as a single transition — correcting the earlier characterisation of it as merely a uniqueness dodge, when it is in fact the only path that makes a resolved item truthfully classified. FR-030 states the #1086 invariant representation-independently, so the test edit cannot later be misread as weakening the gate.

**Q-9 mixed branch — kept** (FR-031). The question's premise was false: `mixed` is computed from evidence rows via `manual_override.or(frame_type)`, not from group keys, so a needs-review item whose files carry two different manual overrides still reports it. A Layer-2 journey also waits on `inbox-mixed-alert` as its proof-of-classify sync signal, so removing the affordance would hang an SC-005 journey.

## Corrections to the record

- **The reclassify signature is not "empty".** `folder_signature([])` returns the SHA-256 of empty input — a fixed 64-char constant shared by every reclassified item in every library. The confirm staleness guard (`confirm.rs:197-198`) therefore compares equal trivially and is **vacuous on `main` today**, independent of this spec. An "empty means stale" rule is unimplementable as an emptiness check. The same false premise sits in the source comments at `reclassify.rs:648-649` and `:821` — which is how it propagated into the spec — and is flagged for correction alongside the fix.
- **Two raised concerns are not defects.** `write_minimal_fits` omitting `EXPTIME` is deliberate and documented; no row-count assertion depends on counting the placeholder.
- **The real E2E cost is different and larger.** `rescan_and_wait_for_item` and `select_only_item` both assume scan yields exactly one selectable item per folder, which D-006 breaks — five journeys, including all three SC-005 ones. That is a cost of an already-decided item surfacing here; the plan gate must budget for it.
- Drifted line references corrected against `main` throughout.

## Gap recorded for the plan gate, not decided here

Resolving a heterogeneous needs-review bucket into two frame types is the *expected* workflow outcome, and this spec's own model says two types means two siblings. So that item arguably should **split** rather than sit in `mixed` with Confirm disabled — a dead end the user escapes only by re-editing correct answers. Recorded as an open design gap; it inherits the item-identity/remount hazard.

## Spec Context
- Spec: 058
- Branch: spec/058-owner-answers