### PR TITLE
fix: first-run audit event contract matches what the app actually emits

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1063,6 +1063,7 @@ dependencies = [
 name = "contract_tests"
 version = "0.1.0"
 dependencies = [
+ "audit_types",
  "contracts_core",
  "domain_core",
  "schemars 1.2.1",

--- a/packages/contracts/src/generated/audit.first_run.completed.d.ts
+++ b/packages/contracts/src/generated/audit.first_run.completed.d.ts
@@ -6,31 +6,53 @@
  */
 
 /**
- * Audit event emitted when the first-run wizard is successfully completed. Routed directly through crates/audit/ — this is NOT a spec 002 lifecycle transition event (R-E2). The event is append-only and must not be updated or deleted.
+ * Event emitted on the spec 002 event bus when the first-run wizard is successfully completed. Routed directly through crates/audit/ — this is NOT a spec 002 lifecycle transition event (R-E2). The durable `events` row is append-only and must not be updated or deleted; its `payload` column stores the `payload` object below, while `topic`, `source`, and `emittedAt` are carried as sibling columns. Projects `EventEnvelope<FirstRunCompleted>` (crates/audit-types/src/event_bus.rs); tests/contract/audit_first_run_completed_test.rs pins this document against those structs.
  */
 export interface AuditFirstRunCompleted {
-  event: "first_run.completed";
-  version: "1";
+  /**
+   * Contract version. Increment on breaking payload changes.
+   */
+  contractVersion: "1.0.0";
+  /**
+   * Event bus topic name.
+   */
+  topic: "first_run.completed";
+  /**
+   * Event source per spec 002 R-Source-1. Spec 003 always emits source='user' — wizard completion is an explicit operator action.
+   */
+  source: "user" | "restore" | "system";
+  /**
+   * Publish time, as [year, ordinalDay, hour, minute, second, nanosecond, offsetHours, offsetMinutes, offsetSeconds]. This is the `time` crate's default OffsetDateTime component encoding leaking through `Timestamp` (#[serde(transparent)], crates/domain/core/src/ids.rs) — NOT RFC 3339, and deliberately documented as-is rather than aspirationally: the durable `events.emitted_at` column holds the RFC 3339 form instead, because crates/audit/src/bus.rs formats it explicitly before the insert. See issue #1093 — normalising Timestamp's wire form is a cross-cutting change affecting every event and DTO that carries one, so it is out of scope here.
+   *
+   * @minItems 9
+   * @maxItems 9
+   */
+  emittedAt: [number, number, number, number, number, number, number, number, number];
   payload: {
     /**
      * RFC 3339 timestamp when the wizard was marked complete.
      */
-    completed_at: string;
+    completedAt: string;
     /**
-     * Count of RegisteredSource rows per kind at completion time.
+     * Count of RegisteredSource rows per kind at completion time. Every kind is always present — the producing struct has no optional fields.
      */
-    source_count_by_kind: {
+    sourceCountByKind: {
       /**
-       * Count of raw sources. Always >= 1 (required by firstrun.complete).
+       * Count of light-frame sources. Always >= 1 (required by firstrun.complete). Named `raw` before spec 030 unified the source-folder kinds.
        */
-      raw: number;
-      calibration?: number;
+      lightFrames: number;
+      /**
+       * Count of calibration sources. Per-image frame type is detected from image metadata, not from this source-folder kind.
+       */
+      calibration: number;
       /**
        * Count of project sources. Always >= 1 (required by firstrun.complete, R-Wiz-2).
        */
       project: number;
-      inbox?: number;
+      /**
+       * Count of inbox sources. Optional kind — spec 039 removed it from REQUIRED_KINDS.
+       */
+      inbox: number;
     };
   };
-  [k: string]: unknown;
 }

--- a/specs/003-first-run-source-setup/contracts/audit.first_run.completed.json
+++ b/specs/003-first-run-source-setup/contracts/audit.first_run.completed.json
@@ -2,40 +2,56 @@
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "$id": "https://astro-library-manager.local/contracts/audit.first_run.completed.json",
   "title": "audit.first_run.completed",
-  "description": "Audit event emitted when the first-run wizard is successfully completed. Routed directly through crates/audit/ — this is NOT a spec 002 lifecycle transition event (R-E2). The event is append-only and must not be updated or deleted.",
+  "description": "Event emitted on the spec 002 event bus when the first-run wizard is successfully completed. Routed directly through crates/audit/ — this is NOT a spec 002 lifecycle transition event (R-E2). The durable `events` row is append-only and must not be updated or deleted; its `payload` column stores the `payload` object below, while `topic`, `source`, and `emittedAt` are carried as sibling columns. Projects `EventEnvelope<FirstRunCompleted>` (crates/audit-types/src/event_bus.rs); tests/contract/audit_first_run_completed_test.rs pins this document against those structs.",
   "type": "object",
+  "required": ["contractVersion", "topic", "source", "emittedAt", "payload"],
+  "additionalProperties": false,
   "properties": {
-    "event": {
-      "const": "first_run.completed"
+    "contractVersion": {
+      "const": "1.0.0",
+      "description": "Contract version. Increment on breaking payload changes."
     },
-    "version": {
+    "topic": {
+      "const": "first_run.completed",
+      "description": "Event bus topic name."
+    },
+    "source": {
       "type": "string",
-      "const": "1"
+      "enum": ["user", "restore", "system"],
+      "description": "Event source per spec 002 R-Source-1. Spec 003 always emits source='user' — wizard completion is an explicit operator action."
+    },
+    "emittedAt": {
+      "type": "array",
+      "items": { "type": "integer" },
+      "minItems": 9,
+      "maxItems": 9,
+      "description": "Publish time, as [year, ordinalDay, hour, minute, second, nanosecond, offsetHours, offsetMinutes, offsetSeconds]. This is the `time` crate's default OffsetDateTime component encoding leaking through `Timestamp` (#[serde(transparent)], crates/domain/core/src/ids.rs) — NOT RFC 3339, and deliberately documented as-is rather than aspirationally: the durable `events.emitted_at` column holds the RFC 3339 form instead, because crates/audit/src/bus.rs formats it explicitly before the insert. See issue #1093 — normalising Timestamp's wire form is a cross-cutting change affecting every event and DTO that carries one, so it is out of scope here."
     },
     "payload": {
       "type": "object",
-      "required": ["completed_at", "source_count_by_kind"],
+      "required": ["completedAt", "sourceCountByKind"],
       "additionalProperties": false,
       "properties": {
-        "completed_at": {
+        "completedAt": {
           "type": "string",
           "format": "date-time",
           "description": "RFC 3339 timestamp when the wizard was marked complete."
         },
-        "source_count_by_kind": {
+        "sourceCountByKind": {
           "type": "object",
-          "required": ["raw", "project"],
+          "required": ["lightFrames", "calibration", "project", "inbox"],
           "additionalProperties": false,
-          "description": "Count of RegisteredSource rows per kind at completion time.",
+          "description": "Count of RegisteredSource rows per kind at completion time. Every kind is always present — the producing struct has no optional fields.",
           "properties": {
-            "raw": {
+            "lightFrames": {
               "type": "integer",
               "minimum": 1,
-              "description": "Count of raw sources. Always >= 1 (required by firstrun.complete)."
+              "description": "Count of light-frame sources. Always >= 1 (required by firstrun.complete). Named `raw` before spec 030 unified the source-folder kinds."
             },
             "calibration": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 0,
+              "description": "Count of calibration sources. Per-image frame type is detected from image metadata, not from this source-folder kind."
             },
             "project": {
               "type": "integer",
@@ -44,12 +60,12 @@
             },
             "inbox": {
               "type": "integer",
-              "minimum": 0
+              "minimum": 0,
+              "description": "Count of inbox sources. Optional kind — spec 039 removed it from REQUIRED_KINDS."
             }
           }
         }
       }
     }
-  },
-  "required": ["event", "version", "payload"]
+  }
 }

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -50,6 +50,7 @@ name = "project_tool_enum_parity"
 path = "project_tool_enum_parity.rs"
 
 [dev-dependencies]
+audit_types = { path = "../../crates/audit-types" }
 contracts_core = { path = "../../crates/contracts/core" }
 domain_core = { path = "../../crates/domain/core" }
 schemars.workspace = true

--- a/tests/contract/audit_first_run_completed_test.rs
+++ b/tests/contract/audit_first_run_completed_test.rs
@@ -3,36 +3,19 @@
 
 //! Contract checks for `specs/003-first-run-source-setup/contracts/audit.first_run.completed.json`.
 //!
-//! Scope limitation: `tests/contract` does not depend on `audit_types`,
-//! which owns the real `FirstRunCompleted` / `SourceCountByKind` structs and
-//! `TOPIC_FIRST_RUN_COMPLETED` (`crates/audit-types/src/event_bus.rs`). Without
-//! that dev-dependency this file cannot serialize the actual payload and
-//! diff it against the schema below — the previous version of this file
-//! worked around that gap by hand-authoring a fixture JSON blob and then
-//! asserting the fixture matched itself, which is tautological and was
-//! flagged by the C2-audit-firstrun test-validity audit. These tests
-//! instead assert directly on the schema document's own declared structure
-//! (types, required sets, minimums, `additionalProperties`) — the one real
-//! artifact reachable without adding a crate dependency.
-//!
-//! KNOWN DRIFT (flagged, intentionally not "fixed" here — reconciling it
-//! needs either a schema edit or a production change, both out of scope for
-//! a test-only fix): the schema below still requires
-//! `source_count_by_kind.raw`, but the real struct was renamed
-//! `raw` -> `light_frames` in spec 030 (2026-05-26/27, see git history of
-//! `crates/audit-types/src/event_bus.rs`) and the schema was never updated.
-//! The schema's top-level `{event, version, payload}` envelope also does
-//! not match anything production ever emits: the durable `events` row is
-//! `{topic, source, emitted_at, payload}` (`EventRow` in
-//! `crates/persistence/db/src/repositories/events.rs`) and the live broadcast
-//! envelope is `EventEnvelope { contract_version, topic, source,
-//! emitted_at, payload }` (`crates/audit/src/event_bus.rs`). Adding
-//! `audit_types` as a dev-dependency to `tests/contract/Cargo.toml` would let
-//! a future revision of this file assert on the real serialized output and
-//! catch that drift directly.
+//! The schema is pinned against the *real* producer — a serialized
+//! `EventEnvelope<FirstRunCompleted>` from `audit_types` — so a field rename,
+//! a `serde(rename_all)` change, or an envelope reshape fails here instead of
+//! silently drifting. Issue #1016: the schema had accumulated three drifts
+//! (`raw` -> `light_frames` from spec 030, `snake_case` vs the struct's
+//! `camelCase`, and a `{event, version, payload}` envelope that no code ever
+//! constructed) precisely because nothing compared it to the structs.
 
-use std::{fs, path::PathBuf};
+use std::{collections::BTreeSet, fs, path::PathBuf};
 
+use audit_types::event_bus::{
+    EventEnvelope, FirstRunCompleted, Source, SourceCountByKind, TOPIC_FIRST_RUN_COMPLETED,
+};
 use serde_json::Value;
 
 fn repo_root() -> PathBuf {
@@ -52,6 +35,128 @@ fn audit_schema() -> Value {
     serde_json::from_str(&contents).expect("audit schema should be valid JSON")
 }
 
+/// Serialize the event exactly as `EventBus::publish` does: the payload is
+/// converted to a `Value` and wrapped in an envelope, so the JSON below is
+/// byte-for-byte what subscribers receive and what lands in the durable
+/// `events` row's `payload` column.
+fn emitted_event() -> Value {
+    let envelope = EventEnvelope::new(
+        TOPIC_FIRST_RUN_COMPLETED,
+        Source::User,
+        FirstRunCompleted {
+            completed_at: "2026-05-26T14:30:00Z".to_owned(),
+            source_count_by_kind: SourceCountByKind {
+                light_frames: 2,
+                calibration: 1,
+                project: 1,
+                inbox: 0,
+            },
+        },
+    );
+    serde_json::to_value(&envelope).expect("event envelope should serialize")
+}
+
+fn key_set(value: &Value, what: &str) -> BTreeSet<String> {
+    value
+        .as_object()
+        .unwrap_or_else(|| panic!("{what} should be a JSON object, got: {value}"))
+        .keys()
+        .cloned()
+        .collect()
+}
+
+/// Assert that a schema object node and a serialized value declare exactly the
+/// same keys, then recurse into every nested object.
+///
+/// Exact equality (not subset) is the point: serde emits every non-`Option`
+/// field unconditionally, so any declared-but-unemitted or emitted-but-
+/// undeclared key is drift.
+fn assert_keys_agree(schema_node: &Value, value: &Value, path: &str) {
+    let declared = key_set(&schema_node["properties"], &format!("schema {path}.properties"));
+    let emitted = key_set(value, &format!("emitted {path}"));
+
+    assert_eq!(
+        declared,
+        emitted,
+        "CONTRACT DRIFT at `{path}`: the schema's declared properties and the keys the Rust \
+         structs actually serialize disagree.\n  schema declares: {declared:?}\n  code emits:      \
+         {emitted:?}\n  declared but never emitted: {:?}\n  emitted but undeclared:     {:?}\n\
+         Update specs/003-first-run-source-setup/contracts/audit.first_run.completed.json or the \
+         structs in crates/audit-types/src/event_bus.rs so the two agree.",
+        declared.difference(&emitted).collect::<Vec<_>>(),
+        emitted.difference(&declared).collect::<Vec<_>>(),
+    );
+
+    let required: BTreeSet<String> = schema_node["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("schema {path} should define a required list"))
+        .iter()
+        .map(|v| v.as_str().expect("required items should be strings").to_owned())
+        .collect();
+    assert_eq!(
+        required, emitted,
+        "schema `{path}` required set must list every key the code emits (no field is optional)"
+    );
+
+    assert_eq!(
+        schema_node["additionalProperties"], false,
+        "schema `{path}` must set additionalProperties:false — otherwise the key agreement above \
+         is documentation, not an enforced contract"
+    );
+
+    for (key, child_schema) in
+        schema_node["properties"].as_object().expect("checked by key_set above")
+    {
+        if child_schema.get("properties").is_some() {
+            assert_keys_agree(child_schema, &value[key], &format!("{path}.{key}"));
+        }
+    }
+}
+
+// ── schema ↔ struct agreement (the anti-drift guard, #1016) ────────────────
+
+#[test]
+fn schema_keys_agree_with_serialized_event_at_every_level() {
+    assert_keys_agree(&audit_schema(), &emitted_event(), "root");
+}
+
+#[test]
+fn schema_topic_const_matches_the_real_topic_constant() {
+    let schema = audit_schema();
+    assert_eq!(
+        schema["properties"]["topic"]["const"], TOPIC_FIRST_RUN_COMPLETED,
+        "schema topic const must match audit_types::event_bus::TOPIC_FIRST_RUN_COMPLETED"
+    );
+}
+
+#[test]
+fn schema_contract_version_const_matches_the_emitted_envelope() {
+    let schema = audit_schema();
+    assert_eq!(
+        schema["properties"]["contractVersion"]["const"],
+        emitted_event()["contractVersion"],
+        "schema contractVersion const must match what EventEnvelope::new stamps"
+    );
+}
+
+#[test]
+fn schema_source_enum_admits_the_emitted_source() {
+    let schema = audit_schema();
+    let admitted: BTreeSet<&str> = schema["properties"]["source"]["enum"]
+        .as_array()
+        .expect("source should declare an enum")
+        .iter()
+        .map(|v| v.as_str().expect("enum members should be strings"))
+        .collect();
+
+    let emitted = emitted_event();
+    let emitted_source = emitted["source"].as_str().expect("source should serialize as a string");
+    assert!(
+        admitted.contains(emitted_source),
+        "schema source enum {admitted:?} does not admit the emitted value {emitted_source:?}"
+    );
+}
+
 // ── schema structure checks ────────────────────────────────────────────────
 
 #[test]
@@ -64,104 +169,67 @@ fn audit_schema_is_valid_json_and_has_expected_title() {
 }
 
 #[test]
-fn audit_schema_requires_event_version_payload() {
-    let schema = audit_schema();
-    let required =
-        schema["required"].as_array().expect("schema should define required top-level keys");
-
-    let required_strs: Vec<&str> =
-        required.iter().map(|v| v.as_str().expect("required items should be strings")).collect();
-
-    assert!(required_strs.contains(&"event"), "schema must require 'event'");
-    assert!(required_strs.contains(&"version"), "schema must require 'version'");
-    assert!(required_strs.contains(&"payload"), "schema must require 'payload'");
-}
-
-#[test]
-fn audit_schema_event_and_version_are_const_literals() {
-    // `event`/`version` are declared as `const`, not free-form strings — a
-    // producer must emit exactly these literals, not merely a string.
-    let schema = audit_schema();
-    assert_eq!(schema["properties"]["event"]["const"], "first_run.completed");
-    assert_eq!(schema["properties"]["version"]["const"], "1");
-}
-
-#[test]
-fn audit_schema_payload_requires_completed_at_and_source_count_by_kind() {
-    let schema = audit_schema();
-    let required = schema["properties"]["payload"]["required"]
-        .as_array()
-        .expect("schema payload should define required keys");
-    let required_strs: Vec<&str> =
-        required.iter().map(|v| v.as_str().expect("required items should be strings")).collect();
-
-    assert!(required_strs.contains(&"completed_at"), "payload must require completed_at");
-    assert!(
-        required_strs.contains(&"source_count_by_kind"),
-        "payload must require source_count_by_kind"
-    );
-}
-
-#[test]
 fn audit_schema_completed_at_is_a_date_time_string() {
     let schema = audit_schema();
-    let field = &schema["properties"]["payload"]["properties"]["completed_at"];
+    let field = &schema["properties"]["payload"]["properties"]["completedAt"];
 
-    assert_eq!(field["type"], "string", "completed_at must be typed as a string");
-    assert_eq!(field["format"], "date-time", "completed_at must use date-time format");
+    assert_eq!(field["type"], "string", "completedAt must be typed as a string");
+    assert_eq!(field["format"], "date-time", "completedAt must use date-time format");
 }
 
 #[test]
-fn audit_schema_source_count_by_kind_requires_raw_and_project() {
+fn audit_schema_emitted_at_matches_the_timestamp_wire_form() {
+    // `Timestamp` is transparent over `time::OffsetDateTime`, whose default
+    // serde impl is a 9-int component array rather than RFC 3339 (issue
+    // #1093). The schema documents that as-is; this pins it so that fixing
+    // `Timestamp` fails here and forces the schema to be updated with it,
+    // rather than silently re-drifting.
     let schema = audit_schema();
-    let required = schema["properties"]["payload"]["properties"]["source_count_by_kind"]
-        ["required"]
-        .as_array()
-        .expect("source_count_by_kind should define required keys");
-    let required_strs: Vec<&str> =
-        required.iter().map(|v| v.as_str().expect("required items should be strings")).collect();
+    let declared = &schema["properties"]["emittedAt"];
+    let emitted = emitted_event();
+    let emitted_at = emitted["emittedAt"].as_array().unwrap_or_else(|| {
+        panic!(
+            "emittedAt is no longer an array ({}) — Timestamp's serde form changed; update \
+                 the schema's emittedAt property to match (issue #1093)",
+            emitted["emittedAt"]
+        )
+    });
 
-    assert!(required_strs.contains(&"raw"), "source_count_by_kind must require raw");
-    assert!(required_strs.contains(&"project"), "source_count_by_kind must require project");
+    assert_eq!(declared["type"], "array", "schema must declare emittedAt as an array");
+    assert_eq!(
+        declared["minItems"].as_u64(),
+        Some(emitted_at.len() as u64),
+        "schema emittedAt length must match the {} components actually emitted",
+        emitted_at.len()
+    );
+    assert_eq!(declared["minItems"], declared["maxItems"], "emittedAt is a fixed-length tuple");
+    assert!(
+        emitted_at.iter().all(serde_json::Value::is_i64),
+        "every emittedAt component should be an integer, got {emitted_at:?}"
+    );
 }
 
 #[test]
 fn audit_schema_source_count_by_kind_fields_are_typed_as_integers() {
     let schema = audit_schema();
-    let props = schema["properties"]["payload"]["properties"]["source_count_by_kind"]["properties"]
+    let props = schema["properties"]["payload"]["properties"]["sourceCountByKind"]["properties"]
         .as_object()
-        .expect("source_count_by_kind should define properties");
+        .expect("sourceCountByKind should define properties");
 
-    assert!(!props.is_empty(), "source_count_by_kind should declare at least one field");
+    assert!(!props.is_empty(), "sourceCountByKind should declare at least one field");
     for (kind, field) in props {
-        assert_eq!(field["type"], "integer", "source_count_by_kind.{kind} must be typed integer");
+        assert_eq!(field["type"], "integer", "sourceCountByKind.{kind} must be typed integer");
     }
 }
 
 #[test]
-fn audit_schema_raw_and_project_have_minimum_one() {
+fn audit_schema_light_frames_and_project_have_minimum_one() {
+    // `complete_first_run` refuses to complete without at least one
+    // light-frame and one project source (crates/persistence/db/src/
+    // repositories/first_run.rs), so these counts can never be zero.
     let schema = audit_schema();
-    let props =
-        &schema["properties"]["payload"]["properties"]["source_count_by_kind"]["properties"];
+    let props = &schema["properties"]["payload"]["properties"]["sourceCountByKind"]["properties"];
 
-    assert_eq!(props["raw"]["minimum"], 1, "raw count minimum must be 1 per contract");
+    assert_eq!(props["lightFrames"]["minimum"], 1, "lightFrames minimum must be 1 per contract");
     assert_eq!(props["project"]["minimum"], 1, "project count minimum must be 1 per contract");
-}
-
-#[test]
-fn audit_schema_payload_and_source_count_by_kind_reject_additional_properties() {
-    // `additionalProperties: false` is what turns "the payload has these
-    // keys" into an enforced contract rather than aspirational documentation.
-    let schema = audit_schema();
-
-    assert_eq!(
-        schema["properties"]["payload"]["additionalProperties"], false,
-        "payload must reject keys outside the declared contract"
-    );
-    assert_eq!(
-        schema["properties"]["payload"]["properties"]["source_count_by_kind"]
-            ["additionalProperties"],
-        false,
-        "source_count_by_kind must reject keys outside the declared contract"
-    );
 }


### PR DESCRIPTION
## Summary

- The committed contract for the first-run-completed audit event described a payload the app has never emitted. Anything generating clients or validating events from that schema was working from a fiction. This reconciles it with the real producer and adds a guard so it cannot drift again.
- Follow-up to #1012, which found the drift but deliberately left it unfixed (its scope was test-honesty, not the contract).

## The three drifts, and which side was wrong

In every case the **code was right and the contract was simply never maintained**:

1. **`raw` → `light_frames`** — a deliberate spec-030 domain rename. `SourceKind::LightFrames` is live throughout, including the completion precondition query. Contract updated.
2. **snake_case vs camelCase** — `camelCase` is the repo-wide event/IPC wire convention and `EventEnvelope` itself carries it. The schema was the lone outlier. Contract updated.
3. **The `{event, version, payload}` envelope** — **dead spec, not an unimplemented requirement.** No code, Rust or TS, ever constructs it; the generated `AuditFirstRunCompleted` type is not exported from `packages/contracts` and has zero importers; and the peer contract `workflow.run_completed.json` already documents the real `EventEnvelope` shape. Matched the established house pattern rather than inventing one.

## The guard

The schema is now pinned against a serialized `EventEnvelope<FirstRunCompleted>` from `audit_types`, compared recursively at every level. A field rename, a `serde(rename_all)` change, or an envelope reshape now fails the test instead of drifting silently. This required adding `audit_types` as a dev-dependency to `tests/contract`, which is exactly what #1012's own notes anticipated.

**Proven non-vacuous.** Reverting `lightFrames` → `raw` in the schema fails 2 tests with:

```
CONTRACT DRIFT at `root.payload.sourceCountByKind`: the schema's declared
properties and the keys the Rust structs actually serialize disagree.
```

## A fourth drift, deliberately not fixed here

`emittedAt` serializes as a **9-element integer array**, not RFC 3339: `Timestamp` is `#[serde(transparent)]` over `OffsetDateTime`, whose default serde impl is not RFC 3339 — while `crates/audit/src/bus.rs` hand-formats RFC 3339 for the durable column. One logical field, two wire forms. The schema documents the array **as it actually is** rather than aspirationally. Fixing it properly touches every DTO carrying a `Timestamp`, so it is filed separately as **#1093**.

## Verification

`cargo fmt --all --check`, `cargo clippy -p contract_tests -p audit_types --all-targets -D warnings`, `cargo test -p contract_tests` (71 tests), plus contracts package test + typecheck — all clean. The regenerated `packages/contracts/src/generated/audit.first_run.completed.d.ts` was stale too and is included.

Closes #1016