### PR TITLE
fix: confirm no longer builds a plan from a stale picture after a bulk reclassify

### DIFF
--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -5276,6 +5276,16 @@ export type InboxReclassifyV2Request_Deserialize = {
 	overrides?: InboxReclassifyFileOverride[],
 	/**  Bulk operations applied after per-file overrides. Processed in order. */
 	bulk?: InboxReclassifyBulk_Deserialize[],
+	/**
+	 *  Absolute path to the inbox root on disk. Not in the JSON Schema
+	 *  (transport detail), mirroring `InboxClassifyRequest`.
+	 * 
+	 *  Required, not optional: without it the re-split cannot hash the group's
+	 *  files, so every re-materialized sub-item inherits the signature of the
+	 *  empty set — a fixed constant that compares equal across unrelated items
+	 *  and silently disables the confirm staleness guard (spec 058 Q-5).
+	 */
+	rootAbsolutePath: string,
 };
 
 /**
@@ -5298,6 +5308,16 @@ export type InboxReclassifyV2Request_Serialize = {
 	overrides: InboxReclassifyFileOverride[],
 	/**  Bulk operations applied after per-file overrides. Processed in order. */
 	bulk?: InboxReclassifyBulk_Serialize[],
+	/**
+	 *  Absolute path to the inbox root on disk. Not in the JSON Schema
+	 *  (transport detail), mirroring `InboxClassifyRequest`.
+	 * 
+	 *  Required, not optional: without it the re-split cannot hash the group's
+	 *  files, so every re-materialized sub-item inherits the signature of the
+	 *  empty set — a fixed constant that compares equal across unrelated items
+	 *  and silently disables the confirm staleness guard (spec 058 Q-5).
+	 */
+	rootAbsolutePath: string,
 };
 
 /**  Response from `inbox.reclassify` v2 — field-agnostic + bulk (T068). */

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -98,6 +98,7 @@ interface ReclassifyV2Args {
  */
 function useInboxReclassifyV2(
   inboxItemId: string,
+  rootAbsolutePath: string,
   sourceGroupId?: string | null,
 ) {
   const queryClient = useQueryClient();
@@ -115,6 +116,10 @@ function useInboxReclassifyV2(
               ...(sourceGroupId ? { sourceGroupId } : { inboxItemId }),
               overrides: args.overrides ?? [],
               bulk: args.bulk ?? [],
+              // Lets the re-split hash the group's real files, so each
+              // re-materialized sub-item gets a per-group content signature
+              // the confirm staleness guard can actually compare.
+              rootAbsolutePath,
             }),
           ),
         );
@@ -134,7 +139,7 @@ function useInboxReclassifyV2(
         setLoading(false);
       }
     },
-    [inboxItemId, sourceGroupId, queryClient],
+    [inboxItemId, rootAbsolutePath, sourceGroupId, queryClient],
   );
 
   return { reclassifyV2, loading };
@@ -406,6 +411,7 @@ export function InboxDetail({
 }: InboxDetailProps) {
   const { reclassifyV2, loading: reclassifyLoading } = useInboxReclassifyV2(
     item.inboxItemId,
+    rootAbsolutePath,
     sourceGroupId,
   );
 

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
@@ -259,6 +259,10 @@ describe('InboxDetail', () => {
           { filePath: 'mystery.fits', properties: { frameType: 'dark' } },
         ],
         bulk: [],
+        // Required so reclassify hashes the real files instead of writing
+        // folder_signature([]) — the empty-set constant that made the confirm
+        // staleness guard compare equal unconditionally.
+        rootAbsolutePath: '/astro/inbox',
       });
     });
   });

--- a/crates/app/inbox/src/reclassify.rs
+++ b/crates/app/inbox/src/reclassify.rs
@@ -639,16 +639,17 @@ pub async fn reclassify_v2(
     }
     .to_owned();
 
-    // Build file_records from persisted metadata. We have no abs paths here
-    // (reclassify carries no root path), so we pass an empty file_paths slice
-    // and build minimal file_records from inbox_file_metadata.
+    // Build file_records from persisted metadata (inbox_file_metadata), then
+    // reconstruct the matching absolute paths from the request's root so
+    // materialize_sub_items can hash each group's real files.
     //
     // materialize_sub_items uses file_paths only for per-sub-group content
-    // signature computation (per-file sha2 hashes). Since we have no abs paths,
-    // the signatures will be zero-length (no hashes), yielding an empty
-    // sub-group sig. This is acceptable: the sub-item identity
-    // (root_id, relative_path, group_key) is stable regardless of the sig, and
-    // the sig is refreshed on the next full classify (when files are accessible).
+    // signature computation (per-file sha2 hashes), positionally aligned with
+    // file_records. Passing no paths does NOT yield an "empty" signature: it
+    // yields folder_signature(vec![]) — sha256 of empty input, the fixed
+    // constant e3b0c442…b855. Every re-split item in every library would then
+    // carry that same value, so confirm.rs's TOCTOU guard would compare equal
+    // unconditionally and never fire (spec 058 Q-5).
 
     // Load ALL generic overrides for the group once and index them by
     // (relative_file_path, property_key) → value. This covers every property
@@ -817,15 +818,23 @@ pub async fn reclassify_v2(
         }
     }
 
-    // Call materialize_sub_items with an empty file_paths (no abs paths available).
-    // Signatures will be empty (no file I/O); refreshed on next full classify.
+    // Absolute paths positionally aligned with `file_records`, so each group's
+    // content_signature hashes its real files. `relative_file_path` is stored
+    // root-relative (classify.rs strips the root prefix), so joining the root
+    // reconstructs the original absolute path. Files that have moved or been
+    // deleted since classify are skipped by `file_signature`, which changes the
+    // group signature — exactly the staleness confirm must refuse to plan from.
+    let root_abs = std::path::PathBuf::from(&req.root_absolute_path);
+    let file_paths: Vec<std::path::PathBuf> =
+        file_records.iter().map(|(rel, _, _)| root_abs.join(rel)).collect();
+
     super::classify::materialize_sub_items(
         pool,
         &source_group_id,
         &root_id,
         &relative_path,
         &lane,
-        &[], // no abs paths — sigs left empty until next classify
+        &file_paths,
         &file_records,
     )
     .await;
@@ -1362,6 +1371,7 @@ mod tests {
         let resp = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-arb".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![InboxReclassifyFileOverride {
@@ -1427,6 +1437,7 @@ mod tests {
         reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-identity".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![InboxReclassifyFileOverride {
@@ -1465,6 +1476,7 @@ mod tests {
         reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-bulk".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![],
@@ -1503,6 +1515,7 @@ mod tests {
         reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-ft".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![
@@ -1561,6 +1574,7 @@ mod tests {
         reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-fmo".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![InboxReclassifyFileOverride {
@@ -1606,6 +1620,7 @@ mod tests {
         let resp = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-split".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![
@@ -1733,6 +1748,7 @@ mod tests {
         let resp = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
                 source_group_id: Some(sg_id.to_owned()),
                 inbox_item_id: None,
                 overrides: vec![],
@@ -1857,6 +1873,7 @@ mod tests {
         let resp = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
                 source_group_id: Some(sg_id.to_owned()),
                 inbox_item_id: None,
                 overrides: vec![],
@@ -1993,6 +2010,7 @@ mod tests {
         let apply1 = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
                 source_group_id: Some(sg_id.to_owned()),
                 inbox_item_id: None,
                 overrides: vec![],
@@ -2015,6 +2033,7 @@ mod tests {
         let apply2 = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
                 source_group_id: Some(sg_id.to_owned()),
                 inbox_item_id: None,
                 overrides: vec![],
@@ -2127,6 +2146,7 @@ mod tests {
         let apply = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
                 source_group_id: None,
                 inbox_item_id: Some(placeholder_id.to_owned()),
                 overrides: vec![],
@@ -2175,6 +2195,7 @@ mod tests {
         let apply2 = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
                 source_group_id: None,
                 inbox_item_id: Some(placeholder_id.to_owned()),
                 overrides: vec![],
@@ -2218,6 +2239,7 @@ mod tests {
         let resp = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-offset-temp".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![
@@ -2285,6 +2307,7 @@ mod tests {
         let err = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-unk".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![InboxReclassifyFileOverride {
@@ -2318,6 +2341,7 @@ mod tests {
         let err = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-noo".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![InboxReclassifyFileOverride {
@@ -2347,6 +2371,7 @@ mod tests {
         let resp = reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: None,
                 inbox_item_id: Some("item-lkup".to_owned()),
                 overrides: vec![],
@@ -2369,6 +2394,7 @@ mod tests {
         reclassify_v2(
             db.pool(),
             InboxReclassifyV2Request {
+                root_absolute_path: "/nonexistent-root".to_owned(),
                 source_group_id: Some("sg-bexp".to_owned()),
                 inbox_item_id: None,
                 overrides: vec![],
@@ -2389,5 +2415,178 @@ mod tests {
         // Only frame_001.fits must have a gain override.
         assert_eq!(gain_overrides.len(), 1, "only the named file must have a gain override");
         assert_eq!(gain_overrides[0].relative_file_path, "inbox_folder/frame_001.fits");
+    }
+
+    // ── Confirm staleness guard: per-item signatures (spec 058 Q-5) ───────────
+
+    /// `folder_signature(vec![])` — sha256 of empty input. The value every
+    /// re-split sub-item carried while `reclassify_v2` passed no file paths.
+    const EMPTY_SET_SIGNATURE: &str =
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855";
+
+    /// Minimal FITS header with an unmapped IMAGETYP, so classify yields
+    /// `unclassified` and the bulk reclassify below drives the re-split.
+    /// `pad` varies the file's byte length to give it distinct content.
+    fn write_ambiguous_fits(path: &std::path::Path, object: &str, pad: usize) {
+        let mut data = vec![b' '; 2880 + pad];
+        let cards = [
+            "IMAGETYP= 'Frame Unknown'".to_owned(),
+            format!("OBJECT  = '{object}'"),
+            "FILTER  = 'Ha'".to_owned(),
+        ];
+        for (i, c) in cards.iter().enumerate() {
+            let card = format!("{c:<80}");
+            data[i * 80..i * 80 + 80].copy_from_slice(card.as_bytes());
+        }
+        data[cards.len() * 80..cards.len() * 80 + 3].copy_from_slice(b"END");
+        std::fs::write(path, &data).unwrap();
+    }
+
+    /// Seed a source group + placeholder item and run the real classify pass.
+    async fn seed_and_classify(
+        pool: &sqlx::SqlitePool,
+        root: &std::path::Path,
+        sg_id: &str,
+        item_id: &str,
+        root_id: &str,
+    ) {
+        upsert_inbox_source_group(
+            pool,
+            &UpsertSourceGroup {
+                id: sg_id,
+                root_id,
+                relative_path: "",
+                content_signature: Some("sig"),
+                format: Some("fits"),
+                lane: Some("fits"),
+            },
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO inbox_items \
+             (id, root_id, relative_path, source_group_id, group_key, group_label, \
+              frame_type, file_count, discovered_at, last_scanned_at, \
+              content_signature, state, lane) \
+             VALUES (?, ?, '', ?, '', NULL, NULL, 1, \
+                     datetime('now'), datetime('now'), 'sig', 'pending_classification', 'fits')",
+        )
+        .bind(item_id)
+        .bind(root_id)
+        .bind(sg_id)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        crate::classify::classify(
+            pool,
+            crate::classify::ClassifyRequest {
+                inbox_item_id: item_id.to_owned(),
+                root_absolute_path: root.to_owned(),
+                force_rescan: false,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    /// Run `reclassify_v2` over the whole group and return the re-materialized
+    /// sub-items' stored `content_signature`s — the exact values `confirm.rs`
+    /// compares the request's signature against.
+    async fn resplit_signatures(
+        pool: &sqlx::SqlitePool,
+        root: &std::path::Path,
+        sg_id: &str,
+    ) -> Vec<String> {
+        reclassify_v2(
+            pool,
+            InboxReclassifyV2Request {
+                root_absolute_path: root.to_string_lossy().into_owned(),
+                source_group_id: Some(sg_id.to_owned()),
+                inbox_item_id: None,
+                overrides: vec![],
+                bulk: vec![
+                    InboxReclassifyBulk {
+                        property: "frameType".to_owned(),
+                        value: serde_json::json!("light").into(),
+                        file_paths: None,
+                    },
+                    InboxReclassifyBulk {
+                        property: "exposureS".to_owned(),
+                        value: serde_json::json!(300.0).into(),
+                        file_paths: None,
+                    },
+                ],
+            },
+        )
+        .await
+        .unwrap();
+
+        let mut sigs: Vec<String> = inbox_repo::list_inbox_sub_items(pool, sg_id)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|r| r.content_signature)
+            .collect();
+        sigs.sort();
+        sigs
+    }
+
+    /// Two-direction control for the confirm staleness guard (spec 058 Q-5).
+    ///
+    /// `reclassify_v2` used to call `materialize_sub_items` with an empty
+    /// `file_paths` slice, so every re-split sub-item's `content_signature`
+    /// became `folder_signature(vec![])` — the fixed constant
+    /// [`EMPTY_SET_SIGNATURE`], identical in every folder and every library.
+    /// `confirm.rs`'s TOCTOU guard therefore compared equal unconditionally and
+    /// could never fire on the reclassify path; it would also have compared
+    /// equal between two entirely unrelated items.
+    ///
+    /// Asserts both properties the guard depends on: signatures distinguish
+    /// distinct items, and they track the files' actual bytes on disk.
+    #[tokio::test]
+    async fn v2_resplit_signatures_are_per_item_and_track_file_content() {
+        let db = test_db().await;
+
+        let root_a = tempfile::tempdir().unwrap();
+        let file_a = root_a.path().join("frame_a.fits");
+        write_ambiguous_fits(&file_a, "M42", 0);
+        seed_and_classify(db.pool(), root_a.path(), "sg-sig-a", "item-sig-a", "root-sig-a").await;
+        let sigs_a = resplit_signatures(db.pool(), root_a.path(), "sg-sig-a").await;
+
+        let root_b = tempfile::tempdir().unwrap();
+        write_ambiguous_fits(&root_b.path().join("frame_b.fits"), "M31", 1024);
+        seed_and_classify(db.pool(), root_b.path(), "sg-sig-b", "item-sig-b", "root-sig-b").await;
+        let sigs_b = resplit_signatures(db.pool(), root_b.path(), "sg-sig-b").await;
+
+        assert!(!sigs_a.is_empty(), "re-split must materialize at least one sub-item");
+
+        // Direction 1: the empty-set constant is gone — signatures hash real files.
+        for sig in sigs_a.iter().chain(&sigs_b) {
+            assert_ne!(
+                sig, EMPTY_SET_SIGNATURE,
+                "re-split sub-item still carries the signature of the empty set — \
+                 reclassify_v2 is not hashing its files"
+            );
+        }
+
+        // Direction 2: two unrelated items no longer collide.
+        assert_ne!(
+            sigs_a, sigs_b,
+            "two items that have both been through reclassify_v2 share an identical \
+             signature — the confirm staleness guard cannot distinguish them"
+        );
+
+        // Direction 3: a genuine file change is detected. Evidence is served
+        // from the DB cache, so only the on-disk bytes move here — precisely
+        // the TOCTOU the guard exists to catch.
+        write_ambiguous_fits(&file_a, "M42", 2880);
+        let sigs_a_after = resplit_signatures(db.pool(), root_a.path(), "sg-sig-a").await;
+        assert_ne!(
+            sigs_a, sigs_a_after,
+            "sub-item signature did not change after its file changed on disk — \
+             confirm would build a plan from a stale picture"
+        );
     }
 }

--- a/crates/contracts/core/src/inbox.rs
+++ b/crates/contracts/core/src/inbox.rs
@@ -859,6 +859,14 @@ pub struct InboxReclassifyV2Request {
     /// Bulk operations applied after per-file overrides. Processed in order.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub bulk: Vec<InboxReclassifyBulk>,
+    /// Absolute path to the inbox root on disk. Not in the JSON Schema
+    /// (transport detail), mirroring `InboxClassifyRequest`.
+    ///
+    /// Required, not optional: without it the re-split cannot hash the group's
+    /// files, so every re-materialized sub-item inherits the signature of the
+    /// empty set — a fixed constant that compares equal across unrelated items
+    /// and silently disables the confirm staleness guard (spec 058 Q-5).
+    pub root_absolute_path: String,
 }
 
 /// Summary of one re-materialized sub-item returned after reclassify (T068).

--- a/specs/058-inbox-drop-parent-items/research.md
+++ b/specs/058-inbox-drop-parent-items/research.md
@@ -171,26 +171,24 @@ request's. For a parent that is the folder signature written by scan/classify;
 for a sibling it is the per-group signature from `materialize_sub_items`
 (`classify.rs:935`, `:959`).
 
-Reclassify passes no file paths (`reclassify.rs:643-651`, `:820-831`), so the
-per-group signature it writes is **not empty** — it is `folder_signature([])`
-(`crates/app/inbox/src/signature.rs:69-76`), which hex-encodes the SHA-256 of
-empty input. That is a fixed 64-character constant, identical for every
-reclassified item in every folder in every library.
+**Corrected (was wrong in the original draft, and the same error was stated in
+two `reclassify.rs` comments).** Reclassify did not write an *empty* signature.
+Passing no file paths produced `folder_signature(vec![])` — the SHA-256 of empty
+input, the fixed 64-char constant `e3b0c442…b855`. Every item that had been
+through `reclassify_v2` carried that identical value, in every folder and every
+library, so the guard compared equal unconditionally and could never fire — it
+would also have compared equal between two entirely unrelated items. That was a
+live hole, not a latent one, and it did not depend on the parent row.
 
-The consequence is sharper than an empty value comparing equal to an empty
-request value: the guard passes trivially, and would pass across unrelated
-items. **The guard is therefore already vacuous on the reclassify path on
-`main` today**, independent of this feature. With the parent gone the per-group
-signature becomes the sole confirm anchor, promoting that vacuous path from a
-secondary case to the only case.
+Because the value was never empty, an "empty means stale" rule was never
+implementable as an emptiness check — which is why Q-5 was not resolved that
+way.
 
-An "empty means stale" rule cannot be implemented as an emptiness check,
-because the value is not empty. Resolved by Q-5.
-
-**Two in-tree comments state the same false premise** and must be corrected
-alongside the fix: `reclassify.rs:648-649` ("the signatures will be zero-length
-(no hashes), yielding an empty sub-group sig") and `reclassify.rs:821` ("Signatures
-will be empty (no file I/O)").
+Resolved ahead of this spec along Q-5's first option: `reclassify_v2` now takes
+`rootAbsolutePath` (matching `inbox.classify`) and computes real per-group
+signatures. With the parent gone the per-group signature becomes the sole
+confirm anchor, which is now a genuine anchor. Q-5 is answered for the guard
+itself; the D-005 re-scan invalidation signal it was coupled to remains open.
 
 ### 4.3 Source-group-to-item resolution
 


### PR DESCRIPTION
## Summary

- The confirm-time staleness guard could not fire on the reclassify path. It compared a constant against itself.
- Reclassify now computes real per-file signatures, so the guard discriminates again.
- Two-direction control included: the test fails without the fix, showing the same constant on both sides of the comparison.

## The defect

The guard at `confirm.rs:197-205` exists to prove a folder's files have not changed since the classification the user is looking at, so a filesystem plan is never built from a stale picture.

`reclassify_v2` passed an **empty slice** into `materialize_sub_items`, so the per-group signature became `folder_signature([])`. That function hashes the list and hex-encodes the digest, so an empty list yields the **SHA-256 of empty input** — the fixed constant `e3b0c442…b855` — **not** an empty string.

Every item that had been through `reclassify_v2` therefore carried that same value, in every folder and every library. The comparison passed trivially. It would also have passed between two entirely unrelated items under different roots.

This is a safety check on the operation that builds filesystem plans, and it silently did nothing. Code that reads as guarded but cannot fire is worse than code with no guard, because nobody thinks to check it.

## Why it survived so long

Three source statements asserted the signature would be "empty" — `reclassify.rs:642-651`, `reclassify.rs:820-821`, and spec 058's `research.md`. If you believe that, you reason "empty equals empty, degenerate but harmless" and move on. All three are corrected here; they are how the false premise reached the spec documents in the first place.

## The fix

Thread the root absolute path through the reclassify request so real per-file signatures are computed. This matches how `classify`, `confirm` and `scan_folder` already obtain it — there is no DB route, as no `roots.absolute_path` lookup exists anywhere.

The field is **required rather than optional**, so the hole cannot silently reopen. That cost 17 mechanical test-call-site updates.

`confirm.rs` is untouched: the comparison logic was always correct, its inputs were broken.

## Two-direction control

With the fix: `1 passed`. With the production line reverted to `&[]`, all three assertions fail:

```
assertion `left != right` failed: two items that have both been through reclassify_v2
share an identical signature — the confirm staleness guard cannot distinguish them
  left: ["e3b0c442…b855"]   right: ["e3b0c442…b855"]

assertion `left != right` failed: sub-item signature did not change after its file
changed on disk — confirm would build a plan from a stale picture
  left: ["e3b0c442…b855"]   right: ["e3b0c442…b855"]
```

The collision case uses two different roots and root_ids — genuinely unrelated items.

## Rejected alternative

Treating the empty-set constant as a stale sentinel and failing closed. It would force a mandatory re-classify round-trip after every bulk reclassify, which the SC-005 journey `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm` explicitly asserts works **without** one — trading a silent hole for a broken success criterion.

> [!NOTE]
> **A related nuance this does not fix**, flagged in `research.md` because spec 058 will hit it: `classify.rs:457` overwrites `content_signature` with the **folder** signature on every classify, so a per-group signature is transient for any item that is later re-classified. This change makes the stored value correct and discriminating wherever it survives, and closes the live hole. But 058's plan to make the per-group signature the *sole* confirm anchor must still reconcile that overwrite, or the anchor is whichever writer ran last.

## Gates

`cargo nextest --workspace` 2480 passed · `clippy -D warnings` clean · `fmt --check` clean · doc tests 7 passed · `typecheck` and `lint` clean · vitest 1765/1766 (the one failure is `LogPanel.followScroll.test.tsx`, passes in isolation, known load-induced flake in an untouched suite).

Real-UI E2E was not run locally. The fix does not fail closed, so nothing new rejects — signatures simply become real values instead of a constant. That is reasoning, not a run; CI covers it here.

This implements spec 058's Q-5 answer, pulled forward as a standalone fix because the hole is live on `main` today.

Refs #711