### PR TITLE
fix: detail panel buttons stay reachable when the panel is narrow

### DIFF
--- a/apps/desktop/src/components/DetailDockPlacementControl.tsx
+++ b/apps/desktop/src/components/DetailDockPlacementControl.tsx
@@ -16,8 +16,15 @@
  * `setOverride('bottom')`. Once a user touched it, Auto was unreachable
  * without clearing localStorage (#1066). Mapping the third state onto a real
  * control is the fix.
+ *
+ * Icon-only (#1068): three text buttons ran ~175px wide, dominating a
+ * ~390px narrow-dock detail bar. `SegControl`'s `icon` option renders each
+ * option as an icon with `label` moved to `aria-label`/`title`, so the
+ * accessible name (asserted by tests/e2e as "Auto"/"Bottom"/"Right") and a
+ * hover tooltip are unchanged — only the visible glyph differs.
  */
 
+import { Wand2, PanelBottom, PanelRight } from 'lucide-react';
 import { SegControl } from '@/ui';
 import type { DockPlacement } from '@/ui';
 import { m } from '@/lib/i18n';
@@ -44,13 +51,27 @@ export function DetailDockPlacementControl({
 }: DetailDockPlacementControlProps) {
   return (
     <SegControl
-      className={className}
+      className={['alm-dock-placement-control', className]
+        .filter(Boolean)
+        .join(' ')}
       data-testid="dock-placement-control"
       aria-label={m.detail_dock_placement_aria()}
       options={[
-        { value: 'adaptive', label: m.detail_dock_placement_auto() },
-        { value: 'bottom', label: m.detail_dock_placement_bottom() },
-        { value: 'side', label: m.detail_dock_placement_right() },
+        {
+          value: 'adaptive',
+          label: m.detail_dock_placement_auto(),
+          icon: <Wand2 size={14} aria-hidden="true" />,
+        },
+        {
+          value: 'bottom',
+          label: m.detail_dock_placement_bottom(),
+          icon: <PanelBottom size={14} aria-hidden="true" />,
+        },
+        {
+          value: 'side',
+          label: m.detail_dock_placement_right(),
+          icon: <PanelRight size={14} aria-hidden="true" />,
+        },
       ]}
       value={override ?? 'adaptive'}
       onChange={(value) =>

--- a/apps/desktop/src/features/archive/ArchivePage.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.tsx
@@ -257,6 +257,7 @@ export function ArchivePage() {
     <>
       <ListPageLayout
         topBar={topBar}
+        dockId="archive"
         detailLabel={m.common_details()}
         detail={item != null ? <ArchiveDetail item={item} /> : undefined}
         onCloseDetail={item != null ? () => void clearSelection() : undefined}

--- a/apps/desktop/src/features/calibration/CalibrationPage.tsx
+++ b/apps/desktop/src/features/calibration/CalibrationPage.tsx
@@ -161,6 +161,7 @@ export function CalibrationPage() {
   return (
     <ListPageLayout
       topBar={topBar}
+      dockId="calibration"
       detail={
         master != null ? (
           <MasterDetail

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -1132,6 +1132,7 @@ export function InboxPage() {
     <>
       <ListPageLayout
         topBar={topBar}
+        dockId="inbox"
         detailLabel={m.inbox_detection_details()}
         detail={
           selectedItem != null ? (

--- a/apps/desktop/src/features/projects/ProjectsPage.tsx
+++ b/apps/desktop/src/features/projects/ProjectsPage.tsx
@@ -211,6 +211,7 @@ export function ProjectsPage() {
   return (
     <ListPageLayout
       topBar={topBar}
+      dockId="projects"
       // Standardised bottom-docked detail (Sessions/Calibration convention): the
       // project identity (ProjectDetailContent) stacks above the operational
       // sections (ProjectBottomDetail) in ONE full-width bottom panel — no right

--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -293,6 +293,7 @@ export function SessionsPage() {
   return (
     <ListPageLayout
       topBar={topBar}
+      dockId="sessions"
       detail={
         selectedSession != null ? (
           <SessionDetail

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -560,6 +560,7 @@ export function TargetsPage() {
         }
         onCloseDetail={selected ? clearSelection : undefined}
         detailLabel="Target details"
+        dockId="targets"
       >
         {listState.status === 'error' ? (
           <EmptyState

--- a/apps/desktop/src/styles/components/app-shell.css
+++ b/apps/desktop/src/styles/components/app-shell.css
@@ -310,6 +310,10 @@
   font-size: var(--alm-text-lg); font-weight: var(--alm-weight-semibold);
   display: flex; align-items: center; gap: var(--alm-sp-2);
   line-height: var(--alm-leading-tight);
+  /* #1068: narrow side-dock widths (~390px) push the inline title-row
+     actions (e.g. Inbox's "Show in file manager") past the panel edge;
+     wrapping keeps every action reachable instead of clipped. */
+  flex-wrap: wrap;
 }
 /* Default subtitle content is a filesystem path (e.g. archive original path,
    spec 055 T022) — break-all + mono, see merges-1.css for the prose override. */

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -402,11 +402,51 @@
  * narrow side column we tighten section spacing, pin the close bar, and make
  * each region a compact, scannable block. */
 
-/* Tighter vertical rhythm between sections in the narrow column. */
+/* Tighter vertical rhythm between sections in the narrow column. #1068:
+   min-width:0 lets this column-flex item actually shrink to the fixed side
+   width instead of growing to its widest descendant's content size. */
 .alm-listpage__detail--side .alm-project-detail__sections {
   display: flex;
   flex-direction: column;
   gap: var(--alm-sp-2);
+  min-width: 0;
+}
+
+/* #1068: wide data tables (Projects sources ROLE/SOURCE/FILTER/SUBS/INTEG,
+   Calibration's compatible-sessions match table — both rendered via the
+   shared `Section` + `Table`) have no horizontal-scroll wrapper in the side
+   dock, so overflowing columns/buttons (e.g. Assign) are clipped and
+   unreachable. `overflow-x: auto` also zeroes this flex item's automatic
+   min-size (CSS Flexbox §4.5: non-visible overflow ⇒ no min-content floor),
+   which is what lets it shrink to the available width in the first place. */
+.alm-listpage__detail--side .alm-section {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+/* Calibration's match table sits one level up inside a row-flex row
+   (.alm-session-detail2), which — unlike the column above — needs its own
+   min-width:0 to stop the wide table forcing this flex item wider than the
+   panel before the wrap/scroll rules above ever get a chance to apply. */
+.alm-listpage__detail--side .alm-session-detail2__match {
+  min-width: 0;
+}
+
+/* #1068: ProjectBottomDetail's `.alm-project-bottom__grid` is shared between
+   the wide BOTTOM strip and this SIDE column (rendered via
+   .alm-project-detail-stack). Its `repeat(auto-fill, minmax(280px, 1fr))` plus
+   the notes cell's `grid-column: span 2` forces a second track that a ~390px
+   side panel can't actually give 280px to — Grid then crushes that column
+   (observed: 280px + 73px), stranding whatever section auto-placed into it
+   (e.g. "Scan for cleanup candidates") far narrower than its own content. The
+   component already collapses to 1 column via `@media (max-width: 700px)`,
+   but that's keyed to the WINDOW, not this panel, so it never fires here —
+   force the same collapse by panel width instead. */
+.alm-listpage__detail--side .alm-project-bottom__grid {
+  grid-template-columns: 1fr;
+}
+.alm-listpage__detail--side .alm-project-bottom__cell--notes {
+  grid-column: span 1;
 }
 
 /* Compact the lifecycle stepper so it doesn't dominate the top of the column. */

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -881,9 +881,12 @@
   gap: var(--alm-sp-2);
 }
 .alm-session-detail2__calib-note { color: var(--alm-text-faint); }
-/* Review actions inline with the title (left-grouped). */
+/* Review actions inline with the title (left-grouped). #1068: `nowrap` (the
+   inline-flex default) pushed "Show in file manager" etc. past a narrow
+   side-dock panel's clipped right edge — wrap keeps every action reachable. */
 .alm-session-detail2__actions {
   display: inline-flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--alm-sp-2);
   margin-left: var(--alm-sp-3);

--- a/apps/desktop/src/styles/components/redesign-detail.css
+++ b/apps/desktop/src/styles/components/redesign-detail.css
@@ -205,8 +205,11 @@
 }
 
 /* ── Cleanup scan results + generate controls (spec 017 WP-E) ─────────────── */
+/* #1068: nowrap (the flex default) pushed "Scan for cleanup candidates" past
+   a narrow side-dock panel's clipped right edge — wrap keeps it reachable. */
 .alm-cleanup-scan__controls {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--alm-sp-3);
   padding: var(--alm-sp-2) 0;

--- a/apps/desktop/src/styles/components/settings-detail.css
+++ b/apps/desktop/src/styles/components/settings-detail.css
@@ -830,16 +830,23 @@
   margin-bottom: var(--alm-sp-2);
 }
 
-/* Row header: label + reveal button side-by-side */
+/* Row header: label + reveal button side-by-side. #1068: nowrap (the flex
+   default) pushed "Reveal" past a narrow side-dock panel's clipped right
+   edge — wrap keeps it reachable. */
 .alm-manifests__row-header {
   display: flex;
+  flex-wrap: wrap;
   align-items: center;
   gap: var(--alm-sp-2);
 }
 
-/* Toggle button — resets browser button chrome, acts as a row trigger */
+/* Toggle button — resets browser button chrome, acts as a row trigger.
+   min-width:0 (#1068): a flex:1 item's default min-width:auto floors it at
+   its text's min-content width, which can itself force the row wider than
+   the panel before flex-wrap above gets a chance to move Reveal down. */
 .alm-manifests__toggle-btn {
   flex: 1;
+  min-width: 0;
   text-align: left;
   background: none;
   border: none;

--- a/apps/desktop/src/styles/components/tables-lists.css
+++ b/apps/desktop/src/styles/components/tables-lists.css
@@ -260,6 +260,20 @@
   padding: var(--alm-sp-1) var(--alm-sp-2);
   border-bottom: 1px solid var(--alm-border-subtle);
 }
+/* Icon-only Auto/Bottom/Right control (#1068): 3 text buttons ran ~175px,
+ * dominating a ~390px narrow-dock bar. 28px is the touch-target floor this
+ * app ships (WCAG 2.2's own minimum is 24x24 — we don't ship at that edge). */
+.alm-dock-placement-control .alm-seg__btn {
+  width: 28px;
+  height: 28px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+.alm-dock-placement-control.alm-seg {
+  height: 28px;
+}
 .alm-listpage__detail-close {
   background: none;
   border: none;

--- a/apps/desktop/src/ui/SegControl.tsx
+++ b/apps/desktop/src/ui/SegControl.tsx
@@ -2,12 +2,19 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { forwardRef, useCallback } from 'react';
-import type { HTMLAttributes, KeyboardEvent } from 'react';
+import type { HTMLAttributes, KeyboardEvent, ReactNode } from 'react';
 
 /** A segmented-control option: a stable `value` and a display `label`. */
 export interface SegControlOption {
   value: string;
   label: string;
+  /**
+   * When set, rendered instead of the `label` text (icon-only button).
+   * `label` still supplies the button's accessible name (`aria-label`) and
+   * hover tooltip so the option stays screen-reader- and hover-discoverable
+   * without visible text (#1068).
+   */
+  icon?: ReactNode;
 }
 
 export interface SegControlProps
@@ -69,8 +76,10 @@ export const SegControl = forwardRef<HTMLDivElement, SegControlProps>(
                 .join(' ')}
               onClick={() => onChange(o.value)}
               onKeyDown={handleKeyDown}
+              aria-label={o.icon ? o.label : undefined}
+              title={o.label}
             >
-              {o.label}
+              {o.icon ?? o.label}
             </button>
           );
         })}


### PR DESCRIPTION
## Summary

Three fixes to the adaptive detail dock, found by driving the real app at a narrow side-dock width:

- The **Auto/Bottom/Right control** is now icon-only — 175px → 86px, so it stops crowding the detail bar it sits in.
- **Detail panels no longer clip their content** when the side dock is narrow. Several buttons were not merely cut off but *unclickable*.
- **Dock placement no longer resets when the language changes** — the persistence key was a translated UI string.

## The clipping was an interaction bug, not a cosmetic one

The panel is `overflow-x: hidden`. Measured at a 390px panel, before this change:

| Page | Element | Overflow | Impact |
|---|---|---|---|
| Inbox | "Show in file manager" | 38px | partly unclickable |
| Calibration | match table | 486px | columns cut |
| Calibration | **"Assign"** inside that table | 474px | **entirely unreachable** |
| Projects | sources table | 89px | INTEG column cut |
| Projects | "Scan for cleanup candidates" | 83px | unclickable |
| Projects | "Reveal" | 63px | unclickable |

Sessions, Archive and Targets measured clean and are untouched.

Two root causes: action rows were `flex-wrap: nowrap` and could not reflow; wide data tables had no horizontal-scroll container inside the dock, so content was clipped away entirely. A third surfaced during verification — `.alm-project-bottom__grid` collapsed to one column only under a *viewport* media query, which never fires when just the panel is narrow.

Tables now **scroll rather than clip**, because the goal is reachability: "Assign" must stay operable at any panel width. Fixes are width-agnostic (wrap, `min-width: 0`, scroll containers) rather than keyed to breakpoints, since the panel is drag-resizable to arbitrary widths.

## Verification

Verified live in mock mode at a 390px side dock on all three affected pages, with a probe that distinguishes *truly clipped* from *reachable via a scroll container*:

| Page | truly clipped | unreachable buttons |
|---|---|---|
| Inbox | 0 | 0 |
| Calibration | 0 (44 elements sit inside a scroll container) | 0 |
| Projects | 0 (16 elements sit inside a scroll container) | 0 |

Raw bounding-box counts are misleading after a scroll-container fix — content legitimately extends past the edge and is reached by scrolling. The numbers above are after filtering for a scrollable ancestor.

Control contract re-checked live: `role=radiogroup`, accessible names still exactly `Auto` / `Bottom` / `Right` (so the existing unit test and `adaptive_detail_dock` e2e spec keep resolving them), `title` tooltips present, all three targets 28×28.

Gates: `pnpm typecheck` clean · `pnpm vitest run` 190 files / 1766 tests green · `pnpm lint` exit 0.

## Note for the changelog

The `dockId` change **resets saved dock placement once on upgrade**, because the storage key moves off the translated-label fallback. Deliberate: migrating values keyed by translated strings we cannot reliably enumerate isn't practical.

## Known, not fixed here

`.alm-listpage__detail-body` has `overflow-y: hidden` with content taller than the available height in Calibration's side dock — a pre-existing *vertical* clipping bug, out of scope for this horizontal pass. Worth its own issue.
