### PR TITLE
docs: correct stale comments about the Projects and Inbox detail layouts

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -2,37 +2,33 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * InboxPage — classify / confirm workflow on the Inbox's OWN 3-zone layout.
+ * InboxPage — classify / confirm workflow on the shared list-page layout.
  *
- * spec 043 (#83 inbox redesign): the Inbox is a special page that does NOT use
- * the shared `ListPageLayout` bottom-split. It shares only the pinned
- * `PageTopBar` convention (search + group/sort/frame-type filter + Confirm /
- * Rescan actions, no page title) and then composes its OWN body with three
- * zones:
+ * The Inbox once composed its own bespoke 3-zone body (list + fixed side panel
+ * + docked bottom plan panel) and deliberately avoided `ListPageLayout`. It no
+ * longer does. It renders through the shared `ListPageLayout` like every other
+ * list page, passing no `detailPlacement`, so it takes the `'adaptive'` default
+ * (spec 054 / #936): the detail docks to the SIDE on a wide window and to the
+ * BOTTOM on a narrow one, and the user can pin that per page via the
+ * Auto/Bottom/Right control. There is no Inbox-specific placement — the
+ * permanent narrow split once designed for it (spec 054 FR-014/FR-015) was
+ * never built and was withdrawn in #1068.
  *
- *   ┌──────────────── PageTopBar (pinned) ─────────────────┐
- *   ├───────────────────────────────┬──────────────────────┤
- *   │ detection LIST (primary,       │ file-details SIDE    │
- *   │ full height of the top region) │ panel (selected      │
- *   │                                │ detection: class +   │
- *   │                                │ breakdown + metadata)│
- *   ├═════════ planned-actions BOTTOM panel (docked) ═══════┤
- *   │ full width · own scroll · shown only when a plan/root │
- *   │ pick exists · never steals the list or side panel     │
- *   └───────────────────────────────────────────────────────┘
- *
+ *   - `detail` is the selected detection's `InboxDetail`: classification +
+ *     breakdown + per-file metadata. Its body is its own scroll region, so a
+ *     long FILES list is reachable rather than clipped (PR #939, fixes #553).
+ *   - `children` is the `InboxList` detection table.
+ *   - The aggregate `PlanPanel` is NOT a docked zone any more. It lives in the
+ *     plan-approval overlay below, opened from a top-bar trigger. #75:
+ *     per-group summaries collapse per-file rows and aggregate by ACTUAL frame
+ *     type from the item's breakdown.
  *   - #83: ONE search only (top-bar FilterToolbar). The list no longer wraps in
  *     ListSidebar (which carried a 2nd search box + a 3rd folder/master count).
  *     The triplicate counts collapse to a single compact per-frame-type
  *     breakdown in the top-bar summary; global totals live in the status bar.
- *   - The SIDE panel holds the selected detection's detail (`InboxDetail`):
- *     classification + breakdown + per-file metadata, at a sensible fixed width.
- *   - The BOTTOM panel holds the aggregate `PlanPanel` (every open plan), docked
- *     full-width with its own scroll. #75: per-group summaries collapse per-file
- *     rows and aggregate by ACTUAL frame type from the item's breakdown.
  *
- * spec 039: the left list is a cross-root aggregate of all unacknowledged
- * items (inbox.list), grouped/labelled by their registered root.
+ * spec 039: the list is a cross-root aggregate of all unacknowledged items
+ * (inbox.list), grouped/labelled by their registered root.
  */
 
 import { useNavigate, useSearch } from '@tanstack/react-router';

--- a/apps/desktop/src/features/projects/ProjectsPage.tsx
+++ b/apps/desktop/src/features/projects/ProjectsPage.tsx
@@ -21,13 +21,19 @@
  * project is selected — so they are, by construction, shown only on selection
  * and carry the canonical `transition-btn-*` / `lifecycle-actions` testids.
  *
- * Dual-panel layout (task #104): the Projects page uses `detailPlacement=
- * "side-and-bottom"`. The SIDE panel (ProjectDetailContent) shows the primary
- * project identity — header, actions, metrics, stepper, target, Sources table,
- * and Channels palette. The BOTTOM panel (ProjectBottomDetail) shows the
- * secondary/operational sections that benefit from full-width horizontal room:
- * Notes, Manifests, Calibration, Source views, Outputs, and Cleanup preview.
- * Both panels mount when a project is selected and close together.
+ * Single adaptive detail panel. This page once used the task #104 dual
+ * `detailPlacement="side-and-bottom"` layout, with project identity in a side
+ * panel and the operational sections in a separate bottom strip. It no longer
+ * does: `be2ecedf` dropped the right side panel, and the page now passes no
+ * `detailPlacement` at all, so it takes `ListPageLayout`'s `'adaptive'`
+ * default (spec 054 / #936) — the detail docks to the side on a wide window
+ * and to the bottom on a narrow one, and the user can pin that per page.
+ *
+ * Both content blocks still render, stacked inside that ONE panel:
+ * `ProjectDetailContent` (header, actions, metrics, stepper, target, Sources
+ * table, Channels palette) above `ProjectBottomDetail` (Notes, Manifests,
+ * Calibration, Source views, Outputs, Cleanup preview). They mount and close
+ * together with the selection.
  *
  * URL state:
  *   - `selected`: project UUID string (spec 023 caveat fix — was numeric index).
@@ -212,10 +218,11 @@ export function ProjectsPage() {
     <ListPageLayout
       topBar={topBar}
       dockId="projects"
-      // Standardised bottom-docked detail (Sessions/Calibration convention): the
-      // project identity (ProjectDetailContent) stacks above the operational
-      // sections (ProjectBottomDetail) in ONE full-width bottom panel — no right
-      // side panel. Keeps the projects table full-width and column layout stable.
+      // ONE detail panel, not the old side+bottom pair: project identity
+      // (ProjectDetailContent) stacks above the operational sections
+      // (ProjectBottomDetail). Placement itself is NOT fixed to the bottom —
+      // no `detailPlacement` is passed, so this takes the `'adaptive'` default
+      // and docks to the side on a wide window (spec 054 / #936).
       detail={
         project ? (
           <div className="alm-project-detail-stack">


### PR DESCRIPTION
## Summary

- Two list pages carried module docstrings describing detail layouts they stopped using. Comments only, no behaviour change.

Both were found while auditing detail panels for #1106, and both mislead in the same way: a reader following either comment forms the wrong model of how the page lays out.

## ProjectsPage — two comments, contradicting each other

**The module docstring** claimed `detailPlacement="side-and-bottom"` with a separate SIDE and BOTTOM panel. `be2ecedf` — *"Projects on standardised bottom detail (drop right side panel)"* (2026-06-23) — removed that layout but left the comment.

**The inline comment** was then stale in the opposite direction: it says the detail is *"bottom-docked … no right side panel"*. True when written, but the page passes no `detailPlacement`, so it takes the `'adaptive'` default and **does** dock to the side on a wide window.

This one has already caused a concrete error: an automated review of the journey docs read that stale comment as if it were the code, and wrongly concluded J05's delta was fabricated. Three findings had to be reversed.

## InboxPage — a whole ASCII diagram, obsolete three ways

The docstring described a bespoke 3-zone body (list + fixed side panel + docked bottom plan panel) and stated the Inbox *"does NOT use the shared `ListPageLayout` bottom-split"*.

1. It does use `ListPageLayout`.
2. It passes no `detailPlacement`, so it is adaptive like every other page — not a fixed split.
3. The aggregate `PlanPanel` is no longer a docked bottom zone at all; it lives in the plan-approval overlay opened from a top-bar trigger, further down the same file.

## What I checked before rewording

The ProjectsPage docstring describes `ProjectBottomDetail` as a separate panel, which raised the possibility it was passed but never rendered — `ListPageLayout` only renders `bottomDetail` when `detailPlacement === 'side-and-bottom'`, which would have made it dead code rather than a stale comment.

It isn't. `ProjectBottomDetail` renders inline inside the single `detail` panel, stacked under `ProjectDetailContent`. Confirmed in the running app: Manifests and Cleanup sections are present.

Both rewrites keep what is still true rather than dropping it — Inbox's #83 single-search rule, #75 per-group aggregation, spec 039's cross-root aggregate, and the detail body being its own scroll region (PR #939, fixes #553).

## Test plan

Comment-only diff on both files. `pnpm typecheck` clean, `pnpm lint` exit 0.
