### PR TITLE
test: ingestion settings tests verify persisted values instead of passing vacuously

### DIFF
--- a/apps/desktop/src/features/settings/Ingestion.test.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.test.tsx
@@ -14,13 +14,7 @@
  *   4. "Restore defaults" persists the in-code defaults and re-hydrates.
  */
 
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  act,
-} from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockGet, mockUpdate } = vi.hoisted(() => ({
@@ -37,16 +31,22 @@ vi.mock('@/bindings/index', () => ({
 
 import { Ingestion } from './Ingestion';
 
+// Every field differs from Ingestion.tsx's in-code DEFAULTS. That is
+// load-bearing, not cosmetic: an identical fixture (the state before #1095's
+// follow-up) makes the assertions below indistinguishable from the component's
+// own defaults, so they pass whether or not the fetch ever resolves. Values are
+// plausible non-defaults — keep them differing from DEFAULTS when either side
+// changes.
 const SETTINGS = {
-  watcherEnabled: true,
-  scanOnStartup: true,
-  followSymlinks: false,
-  followJunctions: false,
-  hashingMode: 'lazy',
-  metadataExtraction: true,
-  exposureGroupingToleranceS: 2,
-  temperatureGroupingToleranceC: 5,
-  defaultFilter: null,
+  watcherEnabled: false,
+  scanOnStartup: false,
+  followSymlinks: true,
+  followJunctions: true,
+  hashingMode: 'eager',
+  metadataExtraction: false,
+  exposureGroupingToleranceS: 10,
+  temperatureGroupingToleranceC: 3,
+  defaultFilter: 'Ha',
 };
 
 beforeEach(() => {
@@ -61,19 +61,32 @@ beforeEach(() => {
 describe('Ingestion', () => {
   it('loads persisted settings and reflects them in the controls', async () => {
     render(<Ingestion save={vi.fn()} />);
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
 
-    expect(screen.getByLabelText('Scan on startup')).toBeChecked();
-    expect(screen.getByLabelText('Follow symbolic links')).not.toBeChecked();
-    expect(screen.getByLabelText('Follow NTFS junctions')).not.toBeChecked();
-    expect(screen.getByLabelText('Hashing mode')).toHaveValue('lazy');
+    // findBy on a hydrated *value*, not waitFor(mockGet called) + sync getBy —
+    // the call firing does not mean its promise resolved, and now that the
+    // fixture differs from DEFAULTS a sync assertion races hydration. The pane
+    // applies the whole document in one setSettings(loaded), so gating on this
+    // one control proves the other three have landed too.
+    await screen.findByRole('checkbox', {
+      name: 'Follow symbolic links',
+      checked: true,
+    });
+
+    expect(screen.getByLabelText('Scan on startup')).not.toBeChecked();
+    expect(screen.getByLabelText('Follow NTFS junctions')).toBeChecked();
+    expect(screen.getByLabelText('Hashing mode')).toHaveValue('eager');
   });
 
   it('persists a toggle change via ingestion.settings.update, preserving unrendered fields', async () => {
     render(<Ingestion save={vi.fn()} />);
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
 
-    const toggle = screen.getByLabelText('Follow symbolic links');
+    // Click only once the fetched state is in the control: clicking the
+    // pre-hydration default would toggle the wrong starting value and would
+    // persist DEFAULTS' unrendered fields, which the fixture no longer matches.
+    const toggle = await screen.findByRole('checkbox', {
+      name: 'Follow symbolic links',
+      checked: true,
+    });
     await act(async () => {
       fireEvent.click(toggle);
       await Promise.resolve();
@@ -81,7 +94,7 @@ describe('Ingestion', () => {
 
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({
-        followSymlinks: true,
+        followSymlinks: false,
         // Unrendered fields must round-trip untouched.
         watcherEnabled: SETTINGS.watcherEnabled,
         metadataExtraction: SETTINGS.metadataExtraction,
@@ -94,16 +107,27 @@ describe('Ingestion', () => {
 
   it('persists "off" for the hashing mode selector', async () => {
     render(<Ingestion save={vi.fn()} />);
-    await waitFor(() => expect(mockGet).toHaveBeenCalled());
 
+    // Same hydration gate as above — the persisted payload is built from
+    // loaded state, so editing pre-hydration would send DEFAULTS' companions.
+    await screen.findByRole('checkbox', {
+      name: 'Follow symbolic links',
+      checked: true,
+    });
     const select = screen.getByLabelText('Hashing mode');
+    expect(select).toHaveValue('eager');
     await act(async () => {
       fireEvent.change(select, { target: { value: 'off' } });
       await Promise.resolve();
     });
 
     expect(mockUpdate).toHaveBeenCalledWith(
-      expect.objectContaining({ hashingMode: 'off' }),
+      expect.objectContaining({
+        hashingMode: 'off',
+        // Proves the persisted document was built from the loaded settings,
+        // not from DEFAULTS.
+        defaultFilter: SETTINGS.defaultFilter,
+      }),
     );
   });
 
@@ -124,32 +148,30 @@ describe('Ingestion', () => {
     // Edit fires before the mount fetch has resolved.
     const select = screen.getByLabelText('Hashing mode');
     await act(async () => {
-      fireEvent.change(select, { target: { value: 'eager' } });
+      fireEvent.change(select, { target: { value: 'off' } });
       await Promise.resolve();
     });
-    expect(select).toHaveValue('eager');
+    expect(select).toHaveValue('off');
 
-    // Now let the slow initial fetch resolve with the stale "lazy" value.
+    // Now let the slow initial fetch resolve with the stale "eager" value —
+    // it must differ from the user's edit or this proves nothing.
     await act(async () => {
       resolveGet({ status: 'ok', data: SETTINGS });
       await Promise.resolve();
     });
 
     // The user's edit must survive — the late fetch must not stomp it.
-    expect(select).toHaveValue('eager');
+    expect(select).toHaveValue('off');
   });
 
   it('restore defaults persists in-code defaults and re-hydrates the controls', async () => {
-    mockGet.mockResolvedValueOnce({
-      status: 'ok',
-      data: { ...SETTINGS, followSymlinks: true, hashingMode: 'eager' },
-    });
     render(<Ingestion save={vi.fn()} />);
     // Wait for the fetched (non-default) value to be applied, not merely for
     // the get call to fire — asserting right after the call races hydration.
-    await waitFor(() =>
-      expect(screen.getByLabelText('Follow symbolic links')).toBeChecked(),
-    );
+    await screen.findByRole('checkbox', {
+      name: 'Follow symbolic links',
+      checked: true,
+    });
 
     const restoreBtn = screen.getByText('Restore defaults');
     await act(async () => {
@@ -157,9 +179,10 @@ describe('Ingestion', () => {
       await Promise.resolve();
     });
 
-    await waitFor(() =>
-      expect(screen.getByLabelText('Follow symbolic links')).not.toBeChecked(),
-    );
+    await screen.findByRole('checkbox', {
+      name: 'Follow symbolic links',
+      checked: false,
+    });
     expect(mockUpdate).toHaveBeenCalledWith(
       expect.objectContaining({ followSymlinks: false, hashingMode: 'lazy' }),
     );


### PR DESCRIPTION
## Summary

- Three tests in `Ingestion.test.tsx` could not fail for the reason they claimed. The `SETTINGS` fixture was **byte-identical to the component's in-code `DEFAULTS`** on all 9 fields, so `loads persisted settings and reflects them in the controls` passed whether or not the settings fetch ever resolved — it was asserting against the component's own hardcoded defaults.
- Found during the #1083 flake audit and deliberately deferred there, because giving these teeth changes what they assert.

## Proof, both directions

**Vacuous before.** With the fetch stubbed to never resolve, the file passed unchanged: **5 passed, 0 failed** — including all three target tests.

**Non-vacuous after.** Same sabotage against the fixed tests: **4 failed, 1 passed.** All three targets now fail. (The one pass supplies its own pending promise via `mockReturnValueOnce` and is unaffected by design.) Independently re-verified after rebase.

## The fix exposed a real race, as predicted

The pane renders `DEFAULTS` and then applies the fetched document, so once the fixture differs, every `waitFor(mockGet called)` + sync `getBy` site becomes a genuine load-state race — the same family as #1095.

One nuance worth recording: **a bare `findByLabelText` would not have fixed these.** Unlike the skeleton-gated controls in #1095, these elements exist unconditionally from first render — only their *values* change. The gate is `findByRole('checkbox', { name, checked: true })`, which waits on the hydrated value rather than mere existence. Because the pane hydrates via a single `setSettings(loaded)`, one gate proves every field landed.

## Two knock-on changes the differing fixture forced

- The slow-fetch test edited `hashingMode` to `'eager'`, which is now the fixture's own value — the late fetch would have been indistinguishable from the user's edit. Changed to `'off'`. Without this the test would have silently stopped discriminating.
- Dropped a now-redundant `mockResolvedValueOnce` override.

No assertion was weakened; two were strengthened (the hashing-mode test now also asserts `defaultFilter` in the persisted payload, proving the document was built from loaded state rather than `DEFAULTS`).

Test-only — `Ingestion.tsx` is untouched. 23 files / 158 tests pass in `src/features/settings`.