### PR TITLE
test: log panel follow-scroll test no longer fails intermittently on loaded CI

### DIFF
--- a/apps/desktop/src/app/LogPanel.followScroll.test.tsx
+++ b/apps/desktop/src/app/LogPanel.followScroll.test.tsx
@@ -266,6 +266,14 @@ describe('LogPanel follow-tail scroll pause/resume (T011)', () => {
     expect(getFollowButton().title).toBeFalsy();
     // The follow-tail effect must actually run and scroll back to the
     // newest row, not silently no-op.
-    expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    //
+    // waitFor, not a sync expect: the waitFor above gates on the button
+    // LABEL, which flips in the same render commit as `followLogs`. The
+    // follow-tail effect that calls scrollTo runs *after* that commit, so a
+    // sync assertion races it — passing on a fast machine and failing on a
+    // contended runner (#1115). Polling preserves the assertion exactly.
+    await waitFor(() => {
+      expect(scrollToMock).toHaveBeenCalledWith({ top: 0, behavior: 'smooth' });
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `LogPanel.followScroll.test.tsx` → `re-enabling Follow resumes at the newest row even after a stale scroll-pause (#832)` failed once on a loaded windows-latest runner, on a PR (#1100) that changed **only Rust contract files** and touched zero frontend source. It cost a diagnosis cycle before being confirmed unrelated.

## Mechanism

Wait on one observable, synchronously assert another that lands later:

```ts
await waitFor(() => {
  expect(getFollowButton().textContent).toBe('↓ Follow');   // the LABEL
});
expect(scrollToMock).toHaveBeenCalledWith({ ... });          // the EFFECT
```

`followLogs` flipping re-renders the button label immediately, but the follow-tail effect that calls `scrollTo` runs *after* that render commit. The `waitFor` proves the label updated; it proves nothing about the effect having run. Same tick on a fast machine — not on a contended runner.

## Fix

The `scrollTo` assertion now polls inside `waitFor`. **The assertion is unchanged** — same matcher, same arguments. Nothing is weakened; it just stops sampling before the effect exists. The `title` assertion stays synchronous, since it is part of the same render commit as the label.

Verified: 3/3 clean runs, `biome check` clean, `tsc --noEmit` exit 0.

## On scope — deliberately narrow

A textual scan for this shape (`waitFor(...)` followed by a sync `expect(someMock).toHaveBeenCalled…`) finds **36 sites** across `apps/desktop/src`. I fixed **one**.

That is deliberate. The pattern is not the bug: most of those 36 assert on a mock invoked **synchronously by a click handler**, which cannot race. Only an assertion on an *effect* — work scheduled after a render commit — is genuinely racy. #1083 claimed 17 racy tests and delay-injection proved only **6**; the same over-count would happen here.

Classifying the remaining 35 needs the delay-injection method used in #1095 and #1109, not a regex. Worth doing as its own pass — noted in #1115 rather than smuggled in here.

Closes #1115