### PR TITLE
test: E2E journeys no longer report driver failures as product observations

### DIFF
--- a/crates/e2e-tests/tests/calibration_ui_journeys.rs
+++ b/crates/e2e-tests/tests/calibration_ui_journeys.rs
@@ -207,25 +207,22 @@ async fn calibration_ui_masters_ingest_as_individual_items() -> anyhow::Result<(
         );
     }
 
-    let rows = app.find_all_testid_prefix("inbox-item-").await?;
+    // One live-document snapshot, not `find_all` + per-handle `.text()`: a
+    // `stale element reference` defaulted to "" would UNDERCOUNT the master
+    // labels and report a driver failure as a missing product label (#1111).
+    let row_texts = app.testid_prefix_texts("inbox-item-").await?;
     anyhow::ensure!(
-        rows.len() >= 2,
+        row_texts.len() >= 2,
         "expected the master dark + master bias to appear as 2 individual real \
          Inbox items (not one folder aggregate), found {}",
-        rows.len()
+        row_texts.len()
     );
-    let mut saw_master_label = 0usize;
-    for row in &rows {
-        let text = row.text().await.unwrap_or_default().to_lowercase();
-        if text.contains("master") {
-            saw_master_label += 1;
-        }
-    }
+    let saw_master_label = row_texts.iter().filter(|t| t.contains("master")).count();
     anyhow::ensure!(
         saw_master_label >= 2,
         "expected each master item's row to carry a real 'N master' label \
          (`inbox_master_row_label`), got {saw_master_label} of {} rows",
-        rows.len()
+        row_texts.len()
     );
 
     app.shutdown().await

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -791,10 +791,21 @@ impl E2eApp {
     /// (`apps/desktop/src/features/settings/DataSources.tsx::handleReconcile`)
     /// — but this journey triggers `inventory.reconcile.run` directly over
     /// the invoke bridge (documented KNOWN GAP, no UI trigger for that path),
-    /// which #517's handler never runs. This call is now belt-and-braces
-    /// rather than the only fix for a known-missing product hook; keep it
-    /// until the bridge-triggered path has a few weeks of green CI, then
-    /// re-evaluate whether `driver.refresh()` alone is sufficient.
+    /// which #517's handler never runs. This is the freshness guarantee for
+    /// that read, not belt-and-braces.
+    ///
+    /// The question this doc comment used to leave open — "re-evaluate
+    /// whether `driver.refresh()` alone is sufficient" — is settled: it is
+    /// not (#1113). A reload remounts the app through the setup gate and
+    /// route restore, so the document a journey is asserting against can be
+    /// torn down under it; the observed failure was an Inbox page with no
+    /// `inbox-list` element at all for a full 20s budget while WebDriver went
+    /// on serving detached row handles from the pre-reload document. Prefer
+    /// this method for any settle-then-assert step, so the settle signal and
+    /// the assertion read one live document. Reserve `driver.refresh()` for
+    /// steps that are genuinely exercising reload or route-restore behaviour
+    /// (see `complete_first_run_gate`, which needs a reload because the
+    /// preferences module caches its localStorage read in module state).
     pub async fn invalidate_query(&self, key_json: &str) -> Result<()> {
         let script = format!(
             r#"
@@ -871,6 +882,46 @@ impl E2eApp {
             .find_all(By::Css(format!("[data-testid^='{prefix}']")))
             .await
             .with_context(|| format!("query for data-testid prefix {prefix:?} failed"))
+    }
+
+    /// Lowercased, trimmed `textContent` of every element whose `data-testid`
+    /// starts with `prefix`, read as ONE snapshot of the live document.
+    ///
+    /// Prefer this over [`Self::find_all_testid_prefix`] + per-element
+    /// `.text()` whenever the texts are asserted on. The two-step form is not
+    /// equivalent on a list that re-renders (the Inbox list swaps row nodes
+    /// constantly): a handle can be detached before `.text()` reads it, and
+    /// `.text()` on a detached handle raises `stale element reference`. A
+    /// caller that defaults that error to `""` turns a WebDriver failure into
+    /// something shaped like product data — the #1111 failure mode, which
+    /// reported two blank Type badges the product can never render. A single
+    /// snapshot cannot interleave with a re-render, and a driver failure
+    /// propagates as an error rather than as text.
+    pub async fn testid_prefix_texts(&self, prefix: &str) -> Result<Vec<String>> {
+        let script = format!(
+            r#"
+            return JSON.stringify(
+                Array.prototype.map.call(
+                    document.querySelectorAll('[data-testid^="{prefix}"]'),
+                    function (el) {{ return el.textContent || ''; }}
+                )
+            );
+            "#
+        );
+        let raw = self
+            .driver
+            .execute(&script, vec![])
+            .await
+            .with_context(|| format!("snapshotting text for data-testid prefix {prefix:?} failed"))?
+            .json()
+            .as_str()
+            .with_context(|| {
+                format!("the {prefix:?} text snapshot script did not return a string")
+            })?
+            .to_owned();
+        let texts: Vec<String> = serde_json::from_str(&raw)
+            .with_context(|| format!("the {prefix:?} text snapshot was not a JSON array"))?;
+        Ok(texts.into_iter().map(|t| t.trim().to_lowercase()).collect())
     }
 
     /// The dynamic suffix of the first `data-testid` starting with `prefix`
@@ -1222,6 +1273,10 @@ impl E2eApp {
             .await
             .context("failed to persist setupCompleted preference")?;
 
+        // KEEP the reload (#1113 reviewed): this is not a settle step. The
+        // preferences module caches its localStorage read in module state, so
+        // the write above is invisible without a fresh page load —
+        // `invalidate_query` cannot substitute for it.
         self.driver.refresh().await.context("page refresh after first-run completion failed")?;
         self.wait_document_ready(Duration::from_secs(10)).await?;
         self.wait_bridge_ready(Duration::from_secs(15)).await?;

--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -236,15 +236,23 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
     // earlier would abort the in-flight classify and restart it every cycle.
     app.wait_testid("inbox-mixed-alert", UI_TIMEOUT).await?;
 
-    // The list itself isn't invalidated by classify; re-read it the way a
-    // user would (reload) until the split rows land. The list refetches and
-    // re-renders several times after a reload, so a transiently-empty
-    // `find_all` is churn, not failure — only the deadline decides.
+    // The list itself isn't invalidated by classify; force the refetch until
+    // the split rows land. The list refetches and re-renders several times,
+    // so a transiently-EMPTY `find_all` is churn, not failure — only the
+    // deadline decides. A driver-level `find_all` FAILURE is not churn and is
+    // no longer flattened into an empty vec (#1111): that default is
+    // indistinguishable from "the list rendered no rows", i.e. it reports a
+    // failure to observe as an observation.
+    //
+    // Read the rows as one live-document text snapshot rather than holding
+    // `WebElement` handles across the settle: the handles that satisfy the
+    // count check can be detached by the very next re-render before the
+    // "mixed" assertion below reads them.
     let deadline = tokio::time::Instant::now() + UI_TIMEOUT;
-    let rows = loop {
-        let rows = app.find_all_testid_prefix("inbox-item-").await.unwrap_or_default();
-        if rows.len() >= 2 {
-            break rows;
+    let row_texts = loop {
+        let row_texts = app.testid_prefix_texts("inbox-item-").await?;
+        if row_texts.len() >= 2 {
+            break row_texts;
         }
         if tokio::time::Instant::now() >= deadline {
             // Round 6 (fix-inbox-splitrow-label): rounds 3-5 proved the
@@ -254,7 +262,7 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
             // tsx`) — the drop is real-webview-only. Live diagnostics off
             // failing Windows runs (28807257849, 28807308638) then showed the
             // SAME instant recording `rows.len() == 0` from this very
-            // `find_all_testid_prefix` check while a `dump_ui_diagnostics`
+            // row-count check while a `dump_ui_diagnostics`
             // JS eval gathered moments later (after an intervening
             // `inbox.list` invoke round-trip) reported `rowCount: 2` for the
             // identical live page — i.e. the two split rows land in the real
@@ -265,10 +273,10 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
             // check the pass path uses, before treating it as a real
             // failure. A genuine regression still times out below.
             let grace_deadline = tokio::time::Instant::now() + Duration::from_secs(5);
-            let mut late_rows = rows;
+            let mut late_rows = row_texts;
             while late_rows.len() < 2 && tokio::time::Instant::now() < grace_deadline {
                 tokio::time::sleep(Duration::from_millis(250)).await;
-                late_rows = app.find_all_testid_prefix("inbox-item-").await.unwrap_or_default();
+                late_rows = app.testid_prefix_texts("inbox-item-").await?;
             }
             if late_rows.len() >= 2 {
                 break late_rows;
@@ -288,7 +296,13 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
                 .invoke("inbox_list", serde_json::json!({}))
                 .await
                 .unwrap_or_else(|e| serde_json::json!({ "invoke_error": e.to_string() }));
-            let url = app.driver.current_url().await.map(|u| u.to_string()).unwrap_or_default();
+            // Diagnostic-only: a failed read is reported AS a failed read, so
+            // it can never be mistaken for the app sitting on an empty URL.
+            let url = app
+                .driver
+                .current_url()
+                .await
+                .map_or_else(|e| format!("<current_url read failed: {e}>"), |u| u.to_string());
             // Round 5: the backend-vs-UI split above already proved the
             // backend returns the right rows, and the entire frontend
             // transform pipeline renders that exact payload correctly in
@@ -310,12 +324,20 @@ async fn inbox_ui_mixed_folder_splits_into_single_type_items() -> anyhow::Result
                 late_rows.len()
             );
         }
-        tokio::time::sleep(Duration::from_secs(2)).await;
-        app.driver.refresh().await.context("refresh while waiting for split rows failed")?;
-        app.wait_bridge_ready(Duration::from_secs(15)).await?;
+        // Invalidate the query rather than `driver.refresh()` (#1113). A full
+        // page reload tears down the document these assertions read: after it
+        // the app remounts through the setup gate and route restore, and the
+        // observed result was an Inbox page with NO `inbox-list` element for
+        // the rest of the budget while WebDriver kept serving detached row
+        // handles from the pre-reload document. Invalidation refetches the
+        // same list in place, so the settle signal and the rows below are read
+        // from one live document.
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        app.invalidate_query(r#"["inbox","all"]"#)
+            .await
+            .context("invalidating the inbox list query while waiting for split rows failed")?;
     };
-    for row in &rows {
-        let text = row.text().await.unwrap_or_default().to_lowercase();
+    for text in &row_texts {
         anyhow::ensure!(
             !text.contains("mixed"),
             "expected split single-type rows, not an ambiguous 'mixed' row: {text:?}"

--- a/crates/e2e-tests/tests/inventory_journeys.rs
+++ b/crates/e2e-tests/tests/inventory_journeys.rs
@@ -326,23 +326,24 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
     .await
     .map_err(|e| anyhow::anyhow!("sessions.list never settled to frameCount=1 for the reconciled session before the UI reload: {e}"))?;
 
-    // ── 6. Real UI (AFTER): a fresh page load re-fetches sessions.list ──
+    // ── 6. Real UI (AFTER): force sessions.list to re-fetch ──
     //
     // `goto_route` only changes the URL fragment on the SAME document — per
     // the HTML fragment-navigation algorithm this never creates a new
     // Document, so the shared `QueryClient` (30s `staleTime`,
     // `apps/desktop/src/data/queryClient.ts`) survives across it and the
-    // `sessions.list` query stays cached from the BEFORE read above. A real
-    // `driver.refresh()` (used for the same reason by
-    // `complete_first_run_gate`) forces an actual reload, discarding the
-    // in-memory QueryClient so the SAME real DOM surface is guaranteed to
-    // re-fetch and reflect the real reconciliation result rather than
-    // serving stale cached data.
-    app.driver
-        .refresh()
-        .await
-        .map_err(|e| anyhow::anyhow!("page refresh before the AFTER read failed: {e}"))?;
-    app.wait_document_ready(Duration::from_secs(10)).await?;
+    // `sessions.list` query stays cached from the BEFORE read above. The
+    // freshness guarantee is the `invalidate_query` below, which refetches
+    // that exact query in place.
+    //
+    // This step used to ALSO do a `driver.refresh()` to discard the whole
+    // QueryClient. Removed per #1113: a reload remounts the app through the
+    // setup gate and route restore, so the document the assertions read can
+    // be torn down under them while WebDriver keeps serving detached handles
+    // from the pre-reload document — and it was never the actual guarantee
+    // here anyway (the comment on `invalidate_query` below already recorded
+    // that the reload "is not a guaranteed proof of that on every WebDriver
+    // backend"). Invalidation keeps one live document.
     app.goto_route("/projects").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
     app.wait_testid(&format!("project-row-{project_id}"), Duration::from_secs(15))
@@ -358,11 +359,9 @@ async fn reconcile_drops_externally_deleted_frame_from_real_ui_count() -> anyhow
     // Deterministic fix for the cross-PR flake (CI evidence: "last seen:
     // Some(\"2\")" surviving the full 15s wait — only possible from a
     // served-stale-cache render, since step 5b above already proved a fresh
-    // backend read returns 1). `driver.refresh()` above is meant to force a
-    // fresh QueryClient, but is not a guaranteed proof of that on every
-    // WebDriver backend; explicitly invalidating the exact query the picker
-    // reads removes the dependency on the reload actually having discarded
-    // the 30s-`staleTime` cache (`E2eApp::invalidate_query` doc comment).
+    // backend read returns 1). Invalidating the exact query the picker reads
+    // is the whole freshness guarantee for this read — see step 6 for why the
+    // page reload that used to precede it was removed.
     // Lane nD's frontend reconcile invalidation (PR #517, MERGED) wires this
     // same invalidation into the real "Reconcile" button's click handler, but
     // this journey calls `inventory_reconcile_run` directly over the invoke

--- a/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
+++ b/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
@@ -196,6 +196,11 @@ async fn find_project_name_input_with_reload_retry(app: &E2eApp) -> anyhow::Resu
     }
 
     // Not there after 10s of polling: attempt the one-shot reload recovery.
+    //
+    // KEEP the reload (#1113 reviewed): the reload IS the mechanism under
+    // test here — recovering a stalled WebView2 first paint. There is no
+    // query to invalidate; the document itself is what has to be rebuilt, and
+    // every element used afterwards is re-found post-reload.
     app.driver.refresh().await.context("page refresh after a #project-name stall failed")?;
     app.wait_document_ready(Duration::from_secs(10))
         .await

--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -89,6 +89,13 @@ async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
 /// polling deadline (CI: both ubuntu and windows hung on
 /// `wait_testid_prefix_present("sessions-row-", ..)`, ruling out a timing
 /// flake). An explicit `driver.refresh()` is unambiguous.
+///
+/// KEPT as a reload (#1113 reviewed) rather than converted to
+/// `invalidate_query`: this helper is route-generic — it re-enters whatever
+/// route the app is on and has no single query key to invalidate — and its
+/// callers re-find every element afterwards, so no handle survives the
+/// reload. A caller that needs to settle ONE query before asserting on the
+/// DOM should use `E2eApp::invalidate_query` instead of this.
 async fn reload_current_route(app: &E2eApp) -> anyhow::Result<()> {
     app.driver.refresh().await.context("page refresh failed")?;
     app.wait_document_ready(Duration::from_secs(10)).await?;

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -125,28 +125,25 @@ async fn dump_target_search_diagnostics(app: &E2eApp, query: &str) -> String {
     // (b) Explicit state check: is a real `role="alert"` field error visible
     // (Phase 1 threw, `TargetSearch.tsx`'s catch branch), or is the
     // `--resolving` status still showing (stuck on Phase 2 / SIMBAD)?
-    match app.driver.find(By::Css(".alm-field-error")).await {
-        Ok(el) => {
-            let text = el.text().await.unwrap_or_default();
-            report.push_str(&format!("--- error state: PRESENT, text={text:?} ---\n"));
+    // Diagnostic-only, but a failed `.text()` read is reported AS a failed
+    // read rather than defaulted to "" (#1111) — otherwise a stale handle
+    // renders as `text=""`, which is indistinguishable from a real element
+    // whose text is genuinely empty and would misdirect the next investigation.
+    for (label, css) in [
+        ("error state", ".alm-field-error"),
+        ("resolving (SIMBAD phase-2) state", ".alm-target-search__status--resolving"),
+        ("generic status line", ".alm-target-search__status"),
+    ] {
+        match app.driver.find(By::Css(css)).await {
+            Ok(el) => {
+                let text = el
+                    .text()
+                    .await
+                    .map_or_else(|e| format!("<text read failed: {e}>"), |t| format!("{t:?}"));
+                report.push_str(&format!("--- {label}: PRESENT, text={text} ---\n"));
+            }
+            Err(_) => report.push_str(&format!("--- {label}: absent ---\n")),
         }
-        Err(_) => report.push_str("--- error state: absent ---\n"),
-    }
-    match app.driver.find(By::Css(".alm-target-search__status--resolving")).await {
-        Ok(el) => {
-            let text = el.text().await.unwrap_or_default();
-            report.push_str(&format!(
-                "--- resolving (SIMBAD phase-2) state: PRESENT, text={text:?} ---\n"
-            ));
-        }
-        Err(_) => report.push_str("--- resolving (SIMBAD phase-2) state: absent ---\n"),
-    }
-    match app.driver.find(By::Css(".alm-target-search__status")).await {
-        Ok(el) => {
-            let text = el.text().await.unwrap_or_default();
-            report.push_str(&format!("--- generic status line: PRESENT, text={text:?} ---\n"));
-        }
-        Err(_) => report.push_str("--- generic status line: absent ---\n"),
     }
 
     // (c) Best-effort screenshot — written to a fixed, predictable path per
@@ -655,7 +652,13 @@ async fn targets_planner_real_astronomy_after_site_creation() -> anyhow::Result<
         app.wait_testid("proptable-tooltip-bestdate", UI_TIMEOUT).await.map_err(|e| {
             anyhow::anyhow!("expected the detail Best-date stat with its Moon explanation: {e}")
         })?;
-    let label = best_date.attr("aria-label").await?.unwrap_or_default();
+    // A MISSING aria-label and an EMPTY one are different regressions; don't
+    // let `unwrap_or_default()` collapse them into the same `got ""` message.
+    let label = best_date
+        .attr("aria-label")
+        .await
+        .context("reading the Best-date stat's aria-label failed")?
+        .context("the Best-date stat has no aria-label attribute at all")?;
     anyhow::ensure!(
         label.contains("Matches opposition")
             || label.contains("falls near full Moon")


### PR DESCRIPTION
Test-infrastructure only. No product code touched.

Closes #1111. Closes #1113. They are fixed together because they are one failure mode: an unsound settle idiom detached the DOM, and error-swallowing then presented the resulting driver failures as measurements.

## The finding that matters most: an assertion that could never fail

`inbox_ui_journeys.rs` asserted `!text.contains("mixed")` over `row.text().unwrap_or_default()`. A stale handle yields `""`, and `!"".contains("mixed")` is `true` — **so the assertion passed vacuously whenever the rows had been detached**, which the `driver.refresh()` directly above it made likely.

That check has been green for reasons unrelated to the product.

> [!IMPORTANT]
> If this assertion now fails in CI, **that is the assertion working for the first time**, not a regression introduced here. Please diagnose before reverting.

## #1111 — error-swallowing

`unwrap_or_default()` on a WebDriver read converts a protocol error into a value indistinguishable from a measurement. This was not a mechanical sweep — each site was classified.

**Assertion/measurement paths — now propagate with context:**

| Site | Why it mattered |
|---|---|
| `inbox_ui_journeys.rs:248,274` | `find_all_testid_prefix(...).unwrap_or_default()` flattened a driver failure into an empty vec, indistinguishable from "the list rendered no rows" |
| `inbox_ui_journeys.rs` ~`:337` | The vacuous-pass site above |
| `calibration_ui_journeys.rs:219` | A stale read would undercount master labels and report a driver failure as a missing product label |
| `targets_journeys.rs:655` | A *missing* `aria-label` and an *empty* one both rendered as `got ""` |

**Diagnostic-only paths — default kept, output made honest:** `inbox_ui_journeys.rs:296` printed `current_url=""` as if the app sat on an empty URL; `targets_journeys.rs:128-147` printed `text=""` as though observed. Both now emit `<… read failed: …>`.

**Deliberately left:** fallbacks that already name the failure in their emitted output (`dump_ui_diagnostics`/`dump_testid_diagnostics`, `source_view_journeys.rs`, and others), plus defaults over `Option`/JSON that are not WebDriver reads at all.

`unwrap_or_default()` is not wrong in general — only where the default masquerades as a measurement.

## #1113 — the settle idiom

`driver.refresh()` is unsound on WebKit: the app remounts through the setup gate and route restore, and WebDriver goes on serving detached handles from the pre-reload document.

**Converted (2):** the inbox mixed-folder reload loop and `inventory_journeys.rs:341` now invalidate the relevant query, keeping one live document. The inbox loop also breaks out with *texts* rather than element handles, since a handle satisfying the count check can be detached before the assertion reads it.

**Kept and marked `KEEP … (#1113 reviewed)` (3):** the first-run gate (preferences cache localStorage in module state, so only a real reload makes the write visible), the stalled-first-paint recovery journey (the reload *is* the mechanism under test), and the route-generic reload helper.

Also settles the stale `invalidate_query` doc comment that #1113 cited, which asked whether `refresh()` alone suffices. It does not.

Adds `E2eApp::testid_prefix_texts` — one `execute` snapshot of the live document returning `Result` — extracted rather than copied because two journeys need it.

## Verified by running, not by reasoning

```
before  PASS [10.179s] inbox_ui_mixed_folder_splits_into_single_type_items
        PASS [ 9.921s] reconcile_drops_externally_deleted_frame_from_real_ui_count
        PASS [ 3.747s] calibration_ui_masters_ingest_as_individual_items
        PASS [ 8.101s] targets_planner_real_astronomy_after_site_creation
after   PASS [ 5.833s] / [ 6.858s] / [ 3.337s] / [ 8.058s]
        PASS [ 5.411s] sessions_ui_derived_view_invariants
```

A pass alone would not prove the new invalidation branch ever executes rather than breaking on iteration 1, so the row threshold was forced to an unreachable `>= 3`:

```
FAIL [151.932s] inbox_ui_mixed_folder_splits_into_single_type_items
Error: expected the mixed folder to split into >=2 single-type rows ... found 2
  queryState: {"status":"success","fetchStatus":"idle",...,"error":null}
  rowCount: 2
```

It failed at the deadline and **not** with the `invalidating the inbox list query failed` context — proving the invalidation ran ~40 times without error and that `["inbox","all"]` is the correct key. A wrong key would be a silent no-op that still passed. Thresholds restored; re-ran `PASS [6.465s]`.

## Notes for review

- **Expect a conflict with #1099** in `inbox_ui_journeys.rs`. Different regions (~`:239-345` here vs ~`:460-600` there), so it should resolve cleanly; whoever lands second resolves.
- Local runs are 4–10s while CI reports 123–151s. The forced failure took 151.9s, so the gap is failure-path teardown — but it means local timings are a weak signal for CI under load, and **Windows/WebView2 is where #1113's symptom was originally observed** and could not be exercised here.
- `console_log` returns `404 :: unrecognised response` on this WebKit driver. Pre-existing and diagnostic-only, but one evidence channel in that bail message is dead on Linux.

`cargo fmt --check` clean · `cargo clippy -p e2e_tests --tests` clean.
