### PR TITLE
fix: inline is_dir validation for manual source-path entry

### DIFF
--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1697,10 +1697,15 @@ export async function mockInvoke(
       // valid (mirrors the native-picker flow, which only ever adds paths
       // that already exist).
       const path = (_args?.path as string) ?? '';
+      const valid = path.trim().length > 0;
       return {
         path,
-        valid: path.trim().length > 0,
-        reason: path.trim().length > 0 ? null : 'Path does not exist',
+        valid,
+        reason: valid ? null : 'Path does not exist',
+        // Mock mode has no real filesystem; treat every valid mock path as a
+        // directory (mirrors the native-picker flow, which only ever adds
+        // existing directories).
+        isDir: valid ? true : null,
       } satisfies ToolPathValidation;
     }
     case 'firstrun_complete': {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -9841,6 +9841,13 @@ export type ToolPathValidation = {
 	path: string,
 	valid: boolean,
 	reason: string | null,
+	/**
+	 *  `Some(true)` when the path exists and is a directory, `Some(false)`
+	 *  when it exists and is a file (or other non-directory entry). `None`
+	 *  when the path does not exist, so callers cannot distinguish file vs.
+	 *  directory (issue #1056).
+	 */
+	isDir: boolean | null,
 };
 
 /**  Response DTO for `tool.profile.list`. */

--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
@@ -230,7 +230,7 @@ describe('StepSourceFolders — manual path entry existence validation', () => {
   it('adds a manually typed path that exists, clearing the input', async () => {
     mockToolsValidatePath.mockResolvedValueOnce({
       status: 'ok',
-      data: { path: '/astro/lights', valid: true, reason: null },
+      data: { path: '/astro/lights', valid: true, reason: null, isDir: true },
     });
     const onAdd = vi.fn();
     renderStep([], onAdd);
@@ -243,5 +243,31 @@ describe('StepSourceFolders — manual path entry existence validation', () => {
       expect(onAdd).toHaveBeenCalledWith('/astro/lights', 'light_frames'),
     );
     expect(input).toHaveValue('');
+  });
+
+  // Issue #1056: a path that exists but points at a file (not a directory)
+  // must be rejected inline instead of deferring to Confirm-step flush.
+  it('rejects a manually typed path that points at a file, not a directory', async () => {
+    mockToolsValidatePath.mockResolvedValueOnce({
+      status: 'ok',
+      data: {
+        path: '/astro/lights/frame.fits',
+        valid: true,
+        reason: null,
+        isDir: false,
+      },
+    });
+    const onAdd = vi.fn();
+    renderStep([], onAdd);
+
+    const input = screen.getByLabelText(/Light frames folder path/i);
+    fireEvent.change(input, { target: { value: '/astro/lights/frame.fits' } });
+    fireEvent.click(screen.getByTestId('manual-add-path-btn-light_frames'));
+
+    expect(await screen.findByRole('alert')).toHaveTextContent(
+      /not a directory/i,
+    );
+    expect(onAdd).not.toHaveBeenCalled();
+    expect(input).toHaveValue('/astro/lights/frame.fits');
   });
 });

--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.tsx
@@ -97,22 +97,24 @@ function findAddTimeConflict(
 }
 
 /**
- * Best-effort existence check for a manually typed/pasted path (#662) — the
- * native OS picker already guarantees a real, existing directory, so this
- * only matters for the manual-entry affordance, but runs for both so there is
- * one add-time validation path. Reuses `tools.validate_path` (an existing,
- * side-effect-free `exists() && is_absolute()` check meant for tool
- * executables) instead of inventing a new backend command; it does not
- * discriminate file vs. directory — that stricter check still runs, and
- * blocks registration, at Confirm-step flush via the real
- * `roots.register.batch` path validation (`crates/app/core/src/first_run.rs`).
- * An IPC failure here is treated as inconclusive (not blocking) for the same
- * reason: the authoritative check runs at flush regardless.
+ * Best-effort existence + file-vs-directory check for a manually typed/pasted
+ * path (#662, #1056) — the native OS picker already guarantees a real,
+ * existing directory, so this only matters for the manual-entry affordance,
+ * but runs for both so there is one add-time validation path. Reuses
+ * `tools.validate_path` (an existing, side-effect-free `exists() &&
+ * is_absolute()` check meant for tool executables, extended with an `isDir`
+ * signal) instead of inventing a new backend command. The stricter
+ * `roots.register.batch` path validation (`crates/app/core/src/first_run.rs`)
+ * still runs, and blocks registration, at Confirm-step flush regardless — this
+ * is only meant to surface the error earlier. An IPC failure here is treated
+ * as inconclusive (not blocking) for the same reason.
  */
 async function checkPathExists(path: string): Promise<string | null> {
   try {
     const result = unwrap(await commands.toolsValidatePath(path));
-    return result.valid ? null : m.err_path_not_exists();
+    if (!result.valid) return m.err_path_not_exists();
+    if (result.isDir === false) return m.err_path_not_directory();
+    return null;
   } catch {
     return null;
   }

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -554,6 +554,10 @@ pub fn validate_path(path: &str) -> ToolPathValidation {
     let p = std::path::Path::new(path);
     let exists = p.exists();
     let valid = exists && p.is_absolute();
+    // Only meaningful once the path exists; `is_dir()` is false for a
+    // nonexistent path, which would be indistinguishable from "exists and is
+    // a file" without gating on `exists` first (issue #1056).
+    let is_dir = exists.then(|| p.is_dir());
     ToolPathValidation {
         path: path.to_owned(),
         valid,
@@ -564,6 +568,7 @@ pub fn validate_path(path: &str) -> ToolPathValidation {
         } else {
             Some("Path does not exist".to_owned())
         },
+        is_dir,
     }
 }
 
@@ -931,6 +936,36 @@ mod tests {
         let v = validate_path(missing);
         assert!(!v.valid);
         assert!(v.reason.unwrap().contains("exist"));
+    }
+
+    #[tokio::test]
+    async fn validate_path_is_dir_true_for_directory() {
+        let dir = tempfile::tempdir().unwrap();
+        let v = validate_path(dir.path().to_str().unwrap());
+        assert!(v.valid);
+        assert_eq!(v.is_dir, Some(true));
+    }
+
+    #[tokio::test]
+    async fn validate_path_is_dir_false_for_file() {
+        // Issue #1056: a file path (not a directory) must be distinguishable
+        // so the manual source-path entry UI can reject it inline.
+        let dir = tempfile::tempdir().unwrap();
+        let file_path = dir.path().join("not-a-dir.txt");
+        std::fs::write(&file_path, b"x").unwrap();
+        let v = validate_path(file_path.to_str().unwrap());
+        assert!(v.valid);
+        assert_eq!(v.is_dir, Some(false));
+    }
+
+    #[tokio::test]
+    async fn validate_path_is_dir_none_for_nonexistent() {
+        #[cfg(windows)]
+        let missing = "C:\\no\\such\\binary";
+        #[cfg(not(windows))]
+        let missing = "/no/such/binary";
+        let v = validate_path(missing);
+        assert_eq!(v.is_dir, None);
     }
 
     #[test]

--- a/crates/contracts/core/src/tools.rs
+++ b/crates/contracts/core/src/tools.rs
@@ -45,6 +45,11 @@ pub struct ToolPathValidation {
     pub path: String,
     pub valid: bool,
     pub reason: Option<String>,
+    /// `Some(true)` when the path exists and is a directory, `Some(false)`
+    /// when it exists and is a file (or other non-directory entry). `None`
+    /// when the path does not exist, so callers cannot distinguish file vs.
+    /// directory (issue #1056).
+    pub is_dir: Option<bool>,
 }
 
 // ── Spec 011 new DTOs ─────────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1056

## What
- `ToolPathValidation` (backing `tools.validate_path`) gains `is_dir: Option<bool>` — `Some(true)`/`Some(false)` when the path exists, `None` when it doesn't.
- `StepSourceFolders`'s manual-entry `checkPathExists` now rejects `isDir === false` inline using the existing `err_path_not_directory` catalog string (no new i18n string needed).
- Regenerated `apps/desktop/src/bindings/index.ts` via `cargo test -p desktop_shell --features dev-tools --test bindings`.

## Why
The manual source-path entry flow only caught a file-not-directory mistake at Confirm-step flush (via `first_run.rs`'s `roots.register.batch`), not at add-time, per #1056.

## Verification
- `cargo test -p app_core -p contracts_core` — new tests `validate_path_is_dir_{true_for_directory,false_for_file,none_for_nonexistent}` pass.
- `cargo clippy -p app_core -p contracts_core -p desktop_shell --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `pnpm vitest run src/features/setup/steps/StepSourceFolders.test.tsx` — 12/12 pass, including new "rejects a manually typed path that points at a file, not a directory".
- `pnpm typecheck` (apps/desktop) — clean.
- `pnpm eslint` on touched files — 0 errors (1 pre-existing warning, unrelated line).