### PR TITLE
fix: event timestamps are RFC 3339 strings, and envelope contracts match what is emitted

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1069,6 +1069,7 @@ dependencies = [
  "schemars 1.2.1",
  "serde",
  "serde_json",
+ "time",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,7 +95,7 @@ schemars = { version = "1", features = ["uuid1"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"
-time = { version = "0.3", features = ["formatting", "parsing", "serde"] }
+time = { version = "0.3", features = ["formatting", "parsing", "serde", "serde-well-known"] }
 trash = "5.2"
 tokio = { version = "1", features = ["sync", "rt-multi-thread", "macros", "fs"] }
 tracing = "0.1"

--- a/crates/domain/core/src/ids.rs
+++ b/crates/domain/core/src/ids.rs
@@ -124,10 +124,16 @@ impl ContentHash {
 }
 
 /// RFC 3339 UTC timestamp wrapper.
+///
+/// The explicit `time::serde::rfc3339` is load-bearing: `OffsetDateTime`'s
+/// default serde impl is a 9-element integer component array, which contradicts
+/// this type's `JsonSchema` (`string` / `date-time`), its `now_iso()` helper,
+/// and the RFC 3339 string written to the durable `events.emitted_at` column
+/// (issue #1093).
 #[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type)]
 #[serde(transparent)]
 #[specta(transparent)]
-pub struct Timestamp(OffsetDateTime);
+pub struct Timestamp(#[serde(with = "time::serde::rfc3339")] OffsetDateTime);
 
 impl Timestamp {
     #[must_use]
@@ -206,6 +212,22 @@ mod tests {
         // Must parse back without error (time Rfc3339 round-trip).
         time::OffsetDateTime::parse(&s, &time::format_description::well_known::Rfc3339)
             .unwrap_or_else(|e| panic!("now_iso() produced non-RFC3339 output {s:?}: {e}"));
+    }
+
+    /// Pins the wire form against `OffsetDateTime`'s default 9-int component
+    /// array (issue #1093) and against the type's own `JsonSchema`.
+    #[test]
+    fn timestamp_serializes_as_an_rfc3339_string_and_round_trips() {
+        let ts = Timestamp::from_offset_date_time(
+            time::OffsetDateTime::from_unix_timestamp(1_752_000_000)
+                .expect("fixed unix timestamp is in range"),
+        );
+
+        let json = serde_json::to_string(&ts).expect("Timestamp should serialize");
+        assert_eq!(json, r#""2025-07-08T18:40:00Z""#);
+
+        let back: Timestamp = serde_json::from_str(&json).expect("Timestamp should deserialize");
+        assert_eq!(back, ts, "serialize/deserialize must round-trip");
     }
 
     #[test]

--- a/packages/contracts/src/generated/audit.first_run.completed.d.ts
+++ b/packages/contracts/src/generated/audit.first_run.completed.d.ts
@@ -22,12 +22,9 @@ export interface AuditFirstRunCompleted {
    */
   source: "user" | "restore" | "system";
   /**
-   * Publish time, as [year, ordinalDay, hour, minute, second, nanosecond, offsetHours, offsetMinutes, offsetSeconds]. This is the `time` crate's default OffsetDateTime component encoding leaking through `Timestamp` (#[serde(transparent)], crates/domain/core/src/ids.rs) — NOT RFC 3339, and deliberately documented as-is rather than aspirationally: the durable `events.emitted_at` column holds the RFC 3339 form instead, because crates/audit/src/bus.rs formats it explicitly before the insert. See issue #1093 — normalising Timestamp's wire form is a cross-cutting change affecting every event and DTO that carries one, so it is out of scope here.
-   *
-   * @minItems 9
-   * @maxItems 9
+   * Publish time as an RFC 3339 UTC string, e.g. '2025-07-08T18:40:00Z'. `Timestamp` (crates/domain/core/src/ids.rs) serialises via `time::serde::rfc3339`, so the broadcast envelope and the durable `events.emitted_at` column carry the same wire form. Issue #1093 fixed the earlier 9-element integer component array, which was the `time` crate's default OffsetDateTime encoding leaking through the transparent newtype.
    */
-  emittedAt: [number, number, number, number, number, number, number, number, number];
+  emittedAt: string;
   payload: {
     /**
      * RFC 3339 timestamp when the wizard was marked complete.

--- a/packages/contracts/src/generated/workflow.run_completed.d.ts
+++ b/packages/contracts/src/generated/workflow.run_completed.d.ts
@@ -21,6 +21,10 @@ export interface WorkflowRunCompletedEvent {
    * Event source per spec 002 R-Source-1. Spec 012 always emits source='system' for this event.
    */
   source: "user" | "restore" | "system";
+  /**
+   * Publish time as an RFC 3339 UTC string, stamped by EventEnvelope::new. Distinct from payload.completedAt, which is when the tool run finished.
+   */
+  emittedAt: string;
   payload: {
     /**
      * Project whose workflow run completed.

--- a/specs/003-first-run-source-setup/contracts/audit.first_run.completed.json
+++ b/specs/003-first-run-source-setup/contracts/audit.first_run.completed.json
@@ -21,11 +21,9 @@
       "description": "Event source per spec 002 R-Source-1. Spec 003 always emits source='user' — wizard completion is an explicit operator action."
     },
     "emittedAt": {
-      "type": "array",
-      "items": { "type": "integer" },
-      "minItems": 9,
-      "maxItems": 9,
-      "description": "Publish time, as [year, ordinalDay, hour, minute, second, nanosecond, offsetHours, offsetMinutes, offsetSeconds]. This is the `time` crate's default OffsetDateTime component encoding leaking through `Timestamp` (#[serde(transparent)], crates/domain/core/src/ids.rs) — NOT RFC 3339, and deliberately documented as-is rather than aspirationally: the durable `events.emitted_at` column holds the RFC 3339 form instead, because crates/audit/src/bus.rs formats it explicitly before the insert. See issue #1093 — normalising Timestamp's wire form is a cross-cutting change affecting every event and DTO that carries one, so it is out of scope here."
+      "type": "string",
+      "format": "date-time",
+      "description": "Publish time as an RFC 3339 UTC string, e.g. '2025-07-08T18:40:00Z'. `Timestamp` (crates/domain/core/src/ids.rs) serialises via `time::serde::rfc3339`, so the broadcast envelope and the durable `events.emitted_at` column carry the same wire form. Issue #1093 fixed the earlier 9-element integer component array, which was the `time` crate's default OffsetDateTime encoding leaking through the transparent newtype."
     },
     "payload": {
       "type": "object",

--- a/specs/012-processing-artifact-observation/contracts/workflow.run_completed.json
+++ b/specs/012-processing-artifact-observation/contracts/workflow.run_completed.json
@@ -4,7 +4,7 @@
   "title": "workflow.run_completed event",
   "description": "Emitted on the spec 002 event bus when a tool workflow run completes. Spec 012 emits this when ToolLaunch.completed_at is set by the attribution pass. Spec 024 subscribes to write workflow_run manifests; spec 024 calls artifact.list?projectId=... for artifact details on receipt.",
   "type": "object",
-  "required": ["contractVersion", "topic", "source", "payload"],
+  "required": ["contractVersion", "topic", "source", "emittedAt", "payload"],
   "additionalProperties": false,
   "properties": {
     "contractVersion": {
@@ -19,6 +19,11 @@
       "type": "string",
       "enum": ["user", "restore", "system"],
       "description": "Event source per spec 002 R-Source-1. Spec 012 always emits source='system' for this event."
+    },
+    "emittedAt": {
+      "type": "string",
+      "format": "date-time",
+      "description": "Publish time as an RFC 3339 UTC string, stamped by EventEnvelope::new. Distinct from payload.completedAt, which is when the tool run finished."
     },
     "payload": {
       "type": "object",

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -34,6 +34,10 @@ name = "audit_first_run_completed_test"
 path = "audit_first_run_completed_test.rs"
 
 [[test]]
+name = "workflow_run_completed_test"
+path = "workflow_run_completed_test.rs"
+
+[[test]]
 name = "native_contracts_test"
 path = "native_contracts_test.rs"
 
@@ -56,6 +60,7 @@ domain_core = { path = "../../crates/domain/core" }
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+time.workspace = true
 
 [lints]
 workspace = true

--- a/tests/contract/audit_first_run_completed_test.rs
+++ b/tests/contract/audit_first_run_completed_test.rs
@@ -11,29 +11,17 @@
 //! `camelCase`, and a `{event, version, payload}` envelope that no code ever
 //! constructed) precisely because nothing compared it to the structs.
 
-use std::{collections::BTreeSet, fs, path::PathBuf};
+#[path = "support/envelope_schema_parity.rs"]
+mod envelope_schema_parity;
 
 use audit_types::event_bus::{
     EventEnvelope, FirstRunCompleted, Source, SourceCountByKind, TOPIC_FIRST_RUN_COMPLETED,
 };
+use envelope_schema_parity::{assert_envelope_contract, load_schema};
 use serde_json::Value;
 
-fn repo_root() -> PathBuf {
-    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .and_then(std::path::Path::parent)
-        .expect("contract test package should live under tests/contract")
-        .to_path_buf()
-}
-
-fn audit_schema() -> Value {
-    let path = repo_root()
-        .join("specs/003-first-run-source-setup/contracts/audit.first_run.completed.json");
-    let contents = fs::read_to_string(&path).unwrap_or_else(|error| {
-        panic!("failed to read audit schema at {}: {error}", path.display());
-    });
-    serde_json::from_str(&contents).expect("audit schema should be valid JSON")
-}
+const SCHEMA_PATH: &str =
+    "specs/003-first-run-source-setup/contracts/audit.first_run.completed.json";
 
 /// Serialize the event exactly as `EventBus::publish` does: the payload is
 /// converted to a `Value` and wrapped in an envelope, so the JSON below is
@@ -56,112 +44,18 @@ fn emitted_event() -> Value {
     serde_json::to_value(&envelope).expect("event envelope should serialize")
 }
 
-fn key_set(value: &Value, what: &str) -> BTreeSet<String> {
-    value
-        .as_object()
-        .unwrap_or_else(|| panic!("{what} should be a JSON object, got: {value}"))
-        .keys()
-        .cloned()
-        .collect()
-}
-
-/// Assert that a schema object node and a serialized value declare exactly the
-/// same keys, then recurse into every nested object.
-///
-/// Exact equality (not subset) is the point: serde emits every non-`Option`
-/// field unconditionally, so any declared-but-unemitted or emitted-but-
-/// undeclared key is drift.
-fn assert_keys_agree(schema_node: &Value, value: &Value, path: &str) {
-    let declared = key_set(&schema_node["properties"], &format!("schema {path}.properties"));
-    let emitted = key_set(value, &format!("emitted {path}"));
-
-    assert_eq!(
-        declared,
-        emitted,
-        "CONTRACT DRIFT at `{path}`: the schema's declared properties and the keys the Rust \
-         structs actually serialize disagree.\n  schema declares: {declared:?}\n  code emits:      \
-         {emitted:?}\n  declared but never emitted: {:?}\n  emitted but undeclared:     {:?}\n\
-         Update specs/003-first-run-source-setup/contracts/audit.first_run.completed.json or the \
-         structs in crates/audit-types/src/event_bus.rs so the two agree.",
-        declared.difference(&emitted).collect::<Vec<_>>(),
-        emitted.difference(&declared).collect::<Vec<_>>(),
-    );
-
-    let required: BTreeSet<String> = schema_node["required"]
-        .as_array()
-        .unwrap_or_else(|| panic!("schema {path} should define a required list"))
-        .iter()
-        .map(|v| v.as_str().expect("required items should be strings").to_owned())
-        .collect();
-    assert_eq!(
-        required, emitted,
-        "schema `{path}` required set must list every key the code emits (no field is optional)"
-    );
-
-    assert_eq!(
-        schema_node["additionalProperties"], false,
-        "schema `{path}` must set additionalProperties:false — otherwise the key agreement above \
-         is documentation, not an enforced contract"
-    );
-
-    for (key, child_schema) in
-        schema_node["properties"].as_object().expect("checked by key_set above")
-    {
-        if child_schema.get("properties").is_some() {
-            assert_keys_agree(child_schema, &value[key], &format!("{path}.{key}"));
-        }
-    }
-}
-
-// ── schema ↔ struct agreement (the anti-drift guard, #1016) ────────────────
+// ── schema ↔ struct agreement (the anti-drift guard, #1016 / #1093) ────────
 
 #[test]
-fn schema_keys_agree_with_serialized_event_at_every_level() {
-    assert_keys_agree(&audit_schema(), &emitted_event(), "root");
-}
-
-#[test]
-fn schema_topic_const_matches_the_real_topic_constant() {
-    let schema = audit_schema();
-    assert_eq!(
-        schema["properties"]["topic"]["const"], TOPIC_FIRST_RUN_COMPLETED,
-        "schema topic const must match audit_types::event_bus::TOPIC_FIRST_RUN_COMPLETED"
-    );
-}
-
-#[test]
-fn schema_contract_version_const_matches_the_emitted_envelope() {
-    let schema = audit_schema();
-    assert_eq!(
-        schema["properties"]["contractVersion"]["const"],
-        emitted_event()["contractVersion"],
-        "schema contractVersion const must match what EventEnvelope::new stamps"
-    );
-}
-
-#[test]
-fn schema_source_enum_admits_the_emitted_source() {
-    let schema = audit_schema();
-    let admitted: BTreeSet<&str> = schema["properties"]["source"]["enum"]
-        .as_array()
-        .expect("source should declare an enum")
-        .iter()
-        .map(|v| v.as_str().expect("enum members should be strings"))
-        .collect();
-
-    let emitted = emitted_event();
-    let emitted_source = emitted["source"].as_str().expect("source should serialize as a string");
-    assert!(
-        admitted.contains(emitted_source),
-        "schema source enum {admitted:?} does not admit the emitted value {emitted_source:?}"
-    );
+fn schema_agrees_with_the_serialized_envelope() {
+    assert_envelope_contract(SCHEMA_PATH, TOPIC_FIRST_RUN_COMPLETED, &emitted_event());
 }
 
 // ── schema structure checks ────────────────────────────────────────────────
 
 #[test]
 fn audit_schema_is_valid_json_and_has_expected_title() {
-    let schema = audit_schema();
+    let schema = load_schema(SCHEMA_PATH);
     assert_eq!(
         schema["title"], "audit.first_run.completed",
         "schema title should match event name"
@@ -170,7 +64,7 @@ fn audit_schema_is_valid_json_and_has_expected_title() {
 
 #[test]
 fn audit_schema_completed_at_is_a_date_time_string() {
-    let schema = audit_schema();
+    let schema = load_schema(SCHEMA_PATH);
     let field = &schema["properties"]["payload"]["properties"]["completedAt"];
 
     assert_eq!(field["type"], "string", "completedAt must be typed as a string");
@@ -178,40 +72,8 @@ fn audit_schema_completed_at_is_a_date_time_string() {
 }
 
 #[test]
-fn audit_schema_emitted_at_matches_the_timestamp_wire_form() {
-    // `Timestamp` is transparent over `time::OffsetDateTime`, whose default
-    // serde impl is a 9-int component array rather than RFC 3339 (issue
-    // #1093). The schema documents that as-is; this pins it so that fixing
-    // `Timestamp` fails here and forces the schema to be updated with it,
-    // rather than silently re-drifting.
-    let schema = audit_schema();
-    let declared = &schema["properties"]["emittedAt"];
-    let emitted = emitted_event();
-    let emitted_at = emitted["emittedAt"].as_array().unwrap_or_else(|| {
-        panic!(
-            "emittedAt is no longer an array ({}) — Timestamp's serde form changed; update \
-                 the schema's emittedAt property to match (issue #1093)",
-            emitted["emittedAt"]
-        )
-    });
-
-    assert_eq!(declared["type"], "array", "schema must declare emittedAt as an array");
-    assert_eq!(
-        declared["minItems"].as_u64(),
-        Some(emitted_at.len() as u64),
-        "schema emittedAt length must match the {} components actually emitted",
-        emitted_at.len()
-    );
-    assert_eq!(declared["minItems"], declared["maxItems"], "emittedAt is a fixed-length tuple");
-    assert!(
-        emitted_at.iter().all(serde_json::Value::is_i64),
-        "every emittedAt component should be an integer, got {emitted_at:?}"
-    );
-}
-
-#[test]
 fn audit_schema_source_count_by_kind_fields_are_typed_as_integers() {
-    let schema = audit_schema();
+    let schema = load_schema(SCHEMA_PATH);
     let props = schema["properties"]["payload"]["properties"]["sourceCountByKind"]["properties"]
         .as_object()
         .expect("sourceCountByKind should define properties");
@@ -227,7 +89,7 @@ fn audit_schema_light_frames_and_project_have_minimum_one() {
     // `complete_first_run` refuses to complete without at least one
     // light-frame and one project source (crates/persistence/db/src/
     // repositories/first_run.rs), so these counts can never be zero.
-    let schema = audit_schema();
+    let schema = load_schema(SCHEMA_PATH);
     let props = &schema["properties"]["payload"]["properties"]["sourceCountByKind"]["properties"];
 
     assert_eq!(props["lightFrames"]["minimum"], 1, "lightFrames minimum must be 1 per contract");

--- a/tests/contract/support/envelope_schema_parity.rs
+++ b/tests/contract/support/envelope_schema_parity.rs
@@ -1,0 +1,142 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared schema-vs-struct parity checks for `EventEnvelope`-shaped contracts.
+//!
+//! Included by `#[path]` from each per-contract test binary. Extracted from the
+//! first-run guard added in #1016 when #1112 needed the same checks for
+//! `workflow.run_completed`.
+
+use std::{collections::BTreeSet, fs, path::PathBuf};
+
+use serde_json::Value;
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("contract test package should live under tests/contract")
+        .to_path_buf()
+}
+
+/// Load a contract schema by its repo-relative path.
+pub fn load_schema(relative_path: &str) -> Value {
+    let path = repo_root().join(relative_path);
+    let contents = fs::read_to_string(&path).unwrap_or_else(|error| {
+        panic!("failed to read schema at {}: {error}", path.display());
+    });
+    serde_json::from_str(&contents).expect("contract schema should be valid JSON")
+}
+
+fn key_set(value: &Value, what: &str) -> BTreeSet<String> {
+    value
+        .as_object()
+        .unwrap_or_else(|| panic!("{what} should be a JSON object, got: {value}"))
+        .keys()
+        .cloned()
+        .collect()
+}
+
+/// Assert that a schema object node and a serialized value declare exactly the
+/// same keys, then recurse into every nested object.
+///
+/// Exact equality (not subset) is the point: serde emits every non-`Option`
+/// field unconditionally, so any declared-but-unemitted or emitted-but-
+/// undeclared key is drift.
+pub fn assert_keys_agree(schema_node: &Value, value: &Value, path: &str, schema_path: &str) {
+    let declared = key_set(&schema_node["properties"], &format!("schema {path}.properties"));
+    let emitted = key_set(value, &format!("emitted {path}"));
+
+    assert_eq!(
+        declared,
+        emitted,
+        "CONTRACT DRIFT at `{path}`: the schema's declared properties and the keys the Rust \
+         structs actually serialize disagree.\n  schema declares: {declared:?}\n  code emits:      \
+         {emitted:?}\n  declared but never emitted: {:?}\n  emitted but undeclared:     {:?}\n\
+         Update {schema_path} or the structs in crates/audit-types/src/event_bus.rs so the two \
+         agree.",
+        declared.difference(&emitted).collect::<Vec<_>>(),
+        emitted.difference(&declared).collect::<Vec<_>>(),
+    );
+
+    let required: BTreeSet<String> = schema_node["required"]
+        .as_array()
+        .unwrap_or_else(|| panic!("schema {path} should define a required list"))
+        .iter()
+        .map(|v| v.as_str().expect("required items should be strings").to_owned())
+        .collect();
+    assert_eq!(
+        required, emitted,
+        "schema `{path}` required set must list every key the code emits (no field is optional)"
+    );
+
+    assert_eq!(
+        schema_node["additionalProperties"], false,
+        "schema `{path}` must set additionalProperties:false — otherwise the key agreement above \
+         is documentation, not an enforced contract"
+    );
+
+    for (key, child_schema) in
+        schema_node["properties"].as_object().expect("checked by key_set above")
+    {
+        if child_schema.get("properties").is_some() {
+            assert_keys_agree(child_schema, &value[key], &format!("{path}.{key}"), schema_path);
+        }
+    }
+}
+
+/// Run every envelope-level check a `EventEnvelope`-shaped contract must pass:
+/// recursive key parity, the `topic` and `contractVersion` consts, the `source`
+/// enum, and the RFC 3339 wire form of `emittedAt`.
+pub fn assert_envelope_contract(schema_path: &str, topic_const: &str, emitted: &Value) {
+    let schema = load_schema(schema_path);
+
+    assert_keys_agree(&schema, emitted, "root", schema_path);
+
+    assert_eq!(
+        schema["properties"]["topic"]["const"], topic_const,
+        "schema topic const must match the topic constant in audit_types::event_bus"
+    );
+    assert_eq!(
+        schema["properties"]["contractVersion"]["const"], emitted["contractVersion"],
+        "schema contractVersion const must match what EventEnvelope::new stamps"
+    );
+
+    let admitted: BTreeSet<&str> = schema["properties"]["source"]["enum"]
+        .as_array()
+        .expect("source should declare an enum")
+        .iter()
+        .map(|v| v.as_str().expect("enum members should be strings"))
+        .collect();
+    let emitted_source = emitted["source"].as_str().expect("source should serialize as a string");
+    assert!(
+        admitted.contains(emitted_source),
+        "schema source enum {admitted:?} does not admit the emitted value {emitted_source:?}"
+    );
+
+    assert_emitted_at_is_rfc3339(&schema, emitted, schema_path);
+}
+
+/// Pin `emittedAt` to RFC 3339 on both sides.
+///
+/// `Timestamp` serialises via `time::serde::rfc3339` (#1093, fixing the earlier
+/// 9-int component array). This fails loudly if that ever regresses, on either
+/// the schema side or the struct side.
+fn assert_emitted_at_is_rfc3339(schema: &Value, emitted: &Value, schema_path: &str) {
+    let declared = &schema["properties"]["emittedAt"];
+    assert_eq!(declared["type"], "string", "{schema_path}: emittedAt must be declared a string");
+    assert_eq!(
+        declared["format"], "date-time",
+        "{schema_path}: emittedAt must declare format date-time"
+    );
+
+    let value = emitted["emittedAt"].as_str().unwrap_or_else(|| {
+        panic!(
+            "emittedAt is no longer a string ({}) — Timestamp's serde form regressed away from \
+             RFC 3339 (issue #1093)",
+            emitted["emittedAt"]
+        )
+    });
+    time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|error| panic!("emittedAt {value:?} does not parse as RFC 3339: {error}"));
+}

--- a/tests/contract/workflow_run_completed_test.rs
+++ b/tests/contract/workflow_run_completed_test.rs
@@ -1,0 +1,51 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Contract checks for
+//! `specs/012-processing-artifact-observation/contracts/workflow.run_completed.json`.
+//!
+//! Issue #1112: the schema set `additionalProperties: false` but omitted
+//! `emittedAt`, so a real `EventEnvelope<WorkflowRunCompleted>` validated as
+//! invalid against its own contract. Nothing validates events at runtime, so
+//! only a schema-vs-struct guard can catch that class of drift.
+
+#[path = "support/envelope_schema_parity.rs"]
+mod envelope_schema_parity;
+
+use audit_types::event_bus::{
+    EventEnvelope, Source, WorkflowRunCompleted, TOPIC_WORKFLOW_RUN_COMPLETED,
+};
+use envelope_schema_parity::{assert_envelope_contract, load_schema};
+use serde_json::Value;
+
+const SCHEMA_PATH: &str =
+    "specs/012-processing-artifact-observation/contracts/workflow.run_completed.json";
+
+fn emitted_event() -> Value {
+    let envelope = EventEnvelope::new(
+        TOPIC_WORKFLOW_RUN_COMPLETED,
+        Source::System,
+        WorkflowRunCompleted {
+            project_id: "6f1b2c3d-4e5f-4a6b-8c9d-0e1f2a3b4c5d".to_owned(),
+            tool_id: "pixinsight".to_owned(),
+            tool_launch_id: "7a2c3d4e-5f60-4b7c-9d0e-1f2a3b4c5d6e".to_owned(),
+            completed_at: "2026-05-26T14:30:00Z".to_owned(),
+            artifact_ids: vec!["8b3d4e5f-6071-4c8d-ae1f-2a3b4c5d6e7f".to_owned()],
+        },
+    );
+    serde_json::to_value(&envelope).expect("event envelope should serialize")
+}
+
+#[test]
+fn schema_agrees_with_the_serialized_envelope() {
+    assert_envelope_contract(SCHEMA_PATH, TOPIC_WORKFLOW_RUN_COMPLETED, &emitted_event());
+}
+
+#[test]
+fn schema_completed_at_is_a_date_time_string() {
+    let schema = load_schema(SCHEMA_PATH);
+    let field = &schema["properties"]["payload"]["properties"]["completedAt"];
+
+    assert_eq!(field["type"], "string", "payload.completedAt must be typed as a string");
+    assert_eq!(field["format"], "date-time", "payload.completedAt must use date-time format");
+}


### PR DESCRIPTION
## Summary

- `Timestamp` serialized as a **9-element integer array** — `[2025,189,18,40,0,0,0,0,0]` — instead of an RFC 3339 string. It now emits `"2025-07-08T18:40:00Z"`.
- Two event-envelope contracts were wrong as a result, one of them actively rejecting valid data. Both are repaired and pinned by tests.

## Why this is a fix, not a redesign

`#[serde(transparent)]` silently delegated to `OffsetDateTime`'s **default** serde impl. Every other declaration of this type already said RFC 3339:

- the doc comment — "RFC 3339 UTC timestamp wrapper"
- the hand-written `schemars::JsonSchema` impl — `{"type":"string","format":"date-time"}`
- `Timestamp::now_iso()` — returns an RFC 3339 `String`
- the durable write path (`crates/audit/src/bus.rs`) — explicitly `.format(Rfc3339)` before the SQL bind

The derived impl was the lone dissenter, and it dissented by accident. One field-level attribute (`#[serde(with = "time::serde::rfc3339")]`) resolves it, with no hand-rolled `Serialize`/`Deserialize` to maintain and `#[specta(transparent)]` still emitting `string`.

**Demonstrated, not asserted** — same fixed input, `serde_json::to_string`:

| | output |
|---|---|
| before | `[2025,189,18,40,0,0,0,0,0]` |
| after | `"2025-07-08T18:40:00Z"` |

The regenerated bindings flip independently: `emittedAt: [number, ×9]` → `emittedAt: string`.

## Two contracts repaired

**`workflow.run_completed.json` (#1112)** set `"additionalProperties": false` while omitting `emittedAt`, which `EventEnvelope` has — so a **real envelope validated as invalid** against its own contract. `emittedAt` is now declared and required.

**`audit.first_run.completed.json`** declared the 9-integer array, because #1100 documented the serde leak as if it were the spec. That was my error in #1100 — I treated the serialization as ground truth when the type had an explicit, contradicting statement of intent beside it. Corrected to `string` / `date-time`.

## Guard

The #1100 key-parity helper is extracted to `tests/contract/support/envelope_schema_parity.rs` and now covers **both** contracts: recursive key parity, `topic`/`contractVersion` consts, and the `source` enum. The old array-pinning assertion became `assert_emitted_at_is_rfc3339`, which pins both sides — the schema must declare `string`/`date-time`, and the emitted value must actually parse as RFC 3339. Bespoke first-run checks stay local; no coverage was dropped.

## Blast radius — verified, not assumed

`Timestamp` appears in **zero** generated TS bindings and nothing deserializes `EventEnvelope` from JSON, so no consumer observes the old form. `cargo test --workspace` green. This was the cheapest possible moment to make the change; it gets more expensive as DTOs carrying `Timestamp` multiply.

Generated artifacts were regenerated via `pnpm --filter @astro-plan/contracts build`, not hand-edited.

## Verification

`cargo fmt --all --check`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace`, contracts test + typecheck — all clean.

Closes #1093
Closes #1112