### PR TITLE
fix(ui): migrate MasterDetail and SessionListPopover onto TwoColDetailLayout

### DIFF
--- a/apps/desktop/src/components/TwoColDetailLayout.test.tsx
+++ b/apps/desktop/src/components/TwoColDetailLayout.test.tsx
@@ -1,0 +1,66 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * TwoColDetailLayout / DetailLinkedGroup (#813) — the shared two-col-
+ * properties + linked-entity detail recipe consumed by SessionDetail,
+ * MasterDetail, and (via `DetailLinkedGroup`) SessionListPopover.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { TwoColDetailLayout, DetailLinkedGroup } from './TwoColDetailLayout';
+
+describe('TwoColDetailLayout', () => {
+  it('renders colA/colB and omits the linked slot when absent', () => {
+    const { container } = render(
+      <TwoColDetailLayout colA={<span>A</span>} colB={<span>B</span>} />,
+    );
+    const wrapper = container.querySelector('.alm-session-detail2');
+    expect(
+      wrapper?.querySelectorAll(':scope > .alm-session-detail2__col'),
+    ).toHaveLength(2);
+    expect(wrapper?.querySelector('.alm-session-detail2__linked')).toBeNull();
+  });
+
+  it('renders the linked slot with an optional modifier class', () => {
+    const { container } = render(
+      <TwoColDetailLayout
+        colA={<span>A</span>}
+        colB={<span>B</span>}
+        linked={<span>linked</span>}
+        linkedClassName="alm-session-detail2__linked--stack"
+      />,
+    );
+    const linked = container.querySelector(
+      '.alm-session-detail2__linked.alm-session-detail2__linked--stack',
+    );
+    expect(linked).toBeInTheDocument();
+    expect(linked).toHaveTextContent('linked');
+  });
+});
+
+describe('DetailLinkedGroup', () => {
+  it('renders the head label plus children when not empty', () => {
+    render(
+      <DetailLinkedGroup label="Used by">
+        <span>content</span>
+      </DetailLinkedGroup>,
+    );
+    expect(screen.getByText('Used by')).toHaveClass(
+      'alm-session-detail2__head',
+    );
+    expect(screen.getByText('content')).toBeInTheDocument();
+  });
+
+  it('renders the muted emptyLabel instead of children when empty', () => {
+    render(
+      <DetailLinkedGroup label="Compatible" empty emptyLabel="None">
+        <span>content</span>
+      </DetailLinkedGroup>,
+    );
+    expect(screen.queryByText('content')).not.toBeInTheDocument();
+    expect(screen.getByText('None')).toHaveClass('alm-session-detail2__muted');
+  });
+});

--- a/apps/desktop/src/components/TwoColDetailLayout.tsx
+++ b/apps/desktop/src/components/TwoColDetailLayout.tsx
@@ -41,3 +41,38 @@ export function TwoColDetailLayout({
     </div>
   );
 }
+
+export interface DetailLinkedGroupProps {
+  /** Heading rendered above the content (`alm-session-detail2__head`). */
+  label: ReactNode;
+  /** Renders `emptyLabel` instead of `children` — e.g. a zero-count list. */
+  empty?: boolean;
+  /** Muted placeholder shown when `empty` (`alm-session-detail2__muted`). */
+  emptyLabel?: ReactNode;
+  children?: ReactNode;
+}
+
+/**
+ * A single labeled block inside a `linked` slot (#813): heading + either
+ * content or a muted empty placeholder. Same `__head`/`__muted` convention
+ * `SessionDetail`'s linked-projects block and `InboxDetail`'s Files column
+ * apply inline; extracted here so `SessionListPopover` doesn't hand-roll the
+ * two class names itself.
+ */
+export function DetailLinkedGroup({
+  label,
+  empty,
+  emptyLabel,
+  children,
+}: DetailLinkedGroupProps) {
+  return (
+    <div>
+      <div className="alm-session-detail2__head">{label}</div>
+      {empty ? (
+        <span className="alm-session-detail2__muted">{emptyLabel}</span>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}

--- a/apps/desktop/src/components/index.ts
+++ b/apps/desktop/src/components/index.ts
@@ -57,8 +57,11 @@ export type { DetailGridProps, RailProps, RailCardProps } from './DetailGrid';
 
 // #813: the shared two-col-properties + linked-entity detail recipe
 // (`.alm-session-detail2`), wrapped once instead of hand-copied per feature.
-export { TwoColDetailLayout } from './TwoColDetailLayout';
-export type { TwoColDetailLayoutProps } from './TwoColDetailLayout';
+export { TwoColDetailLayout, DetailLinkedGroup } from './TwoColDetailLayout';
+export type {
+  TwoColDetailLayoutProps,
+  DetailLinkedGroupProps,
+} from './TwoColDetailLayout';
 export { Lifecycle } from './Lifecycle';
 export type { LifecycleProps } from './Lifecycle';
 

--- a/apps/desktop/src/features/calibration/MasterDetail.layout.test.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.layout.test.tsx
@@ -1,0 +1,87 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * MasterDetail — two-col layout migration (#813).
+ *
+ * Proves the fingerprint columns + stacked session popovers still render
+ * through the shared `.alm-session-detail2` structure now that MasterDetail
+ * builds it via `TwoColDetailLayout` instead of hand-copied divs.
+ */
+
+import { render as rtlRender, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactElement } from 'react';
+import { MasterDetail } from './MasterDetail';
+import type { CalibrationMaster_Serialize as CalibrationMaster } from '@/bindings/index';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    calibrationMastersGet: vi.fn().mockResolvedValue({
+      status: 'ok',
+      data: { usedBySessionIds: [], compatibleSessions: [] },
+    }),
+    sessionsList: vi.fn().mockResolvedValue({ status: 'ok', data: [] }),
+  },
+}));
+
+function makeMaster(): CalibrationMaster {
+  return {
+    id: 'm-1',
+    kind: 'dark',
+    fingerprint: {
+      camera: 'ASI2600MM',
+      exposureS: 300,
+      tempC: -10,
+      gain: 100,
+      binning: '1x1',
+    },
+    sourceSessionId: 'cal-ses-001',
+    createdAt: '2026-01-01T00:00:00Z',
+    ageDays: 30,
+    sizeBytes: 128 * 1024 * 1024,
+    usedBySessionIds: [],
+    usedByProjectIds: [],
+  };
+}
+
+describe('MasterDetail — two-col layout (#813)', () => {
+  it('renders the shared two-col-properties + stacked-linked structure', () => {
+    const { container } = render(
+      <MasterDetail
+        master={makeMaster()}
+        prefillSuggestion={false}
+        agingThresholdDays={90}
+      />,
+    );
+
+    const wrapper = container.querySelector('.alm-session-detail2');
+    expect(wrapper).toBeInTheDocument();
+    expect(
+      wrapper?.querySelectorAll(':scope > .alm-session-detail2__col'),
+    ).toHaveLength(2);
+
+    const linked = wrapper?.querySelector(
+      ':scope > .alm-session-detail2__linked.alm-session-detail2__linked--stack',
+    );
+    expect(linked).toBeInTheDocument();
+
+    // The two SessionListPopover instances (Used by / Compatible) stack
+    // inside the single linked slot.
+    expect(screen.getByText('Used by')).toBeInTheDocument();
+    expect(screen.getByText('Compatible')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -53,6 +53,7 @@ import {
   type PropertyDef,
   PropertyTable,
   Modal,
+  TwoColDetailLayout,
 } from '@/components';
 import { Btn, EmptyState, Pill } from '@/ui';
 import type { CalibrationMatchMissingFlag } from '@/bindings/index';
@@ -511,27 +512,25 @@ export function MasterDetail({
         title={<strong>{masterTitle}</strong>}
         titleExtra={actionButtons}
       >
-        {/* Left-packed columns: [props A] [props B] [sessions: Used by + Compatible stacked]. */}
-        <div className="alm-session-detail2">
-          <div className="alm-session-detail2__col">
-            <PropertyTable mode="view" properties={colA} />
-          </div>
-          <div className="alm-session-detail2__col">
-            <PropertyTable mode="view" properties={colB} />
-          </div>
-
-          {/* Single column with both session popovers stacked vertically. */}
-          <div className="alm-session-detail2__linked alm-session-detail2__linked--stack">
-            <SessionListPopover
-              label={m.calibration_used_by_label()}
-              names={detail.loading ? [] : detail.confirmedNames}
-            />
-            <SessionListPopover
-              label={m.calibration_compatible_label()}
-              names={detail.loading ? [] : detail.compatibleNames}
-            />
-          </div>
-        </div>
+        {/* Left-packed columns: [props A] [props B] [sessions: Used by + Compatible
+            stacked] (#813: shared TwoColDetailLayout instead of hand-copied divs). */}
+        <TwoColDetailLayout
+          colA={<PropertyTable mode="view" properties={colA} />}
+          colB={<PropertyTable mode="view" properties={colB} />}
+          linkedClassName="alm-session-detail2__linked--stack"
+          linked={
+            <>
+              <SessionListPopover
+                label={m.calibration_used_by_label()}
+                names={detail.loading ? [] : detail.confirmedNames}
+              />
+              <SessionListPopover
+                label={m.calibration_compatible_label()}
+                names={detail.loading ? [] : detail.compatibleNames}
+              />
+            </>
+          }
+        />
 
         {/* Detail hero (spec 043 §4): ranked candidate-masters match table for
 			    the master's matching-context session, with assign/cancel. */}

--- a/apps/desktop/src/features/calibration/SessionListPopover.test.tsx
+++ b/apps/desktop/src/features/calibration/SessionListPopover.test.tsx
@@ -1,0 +1,38 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * SessionListPopover — migrated onto the shared `DetailLinkedGroup` leaf
+ * (#813) instead of hand-rolling the `alm-session-detail2__head`/`__muted`
+ * classes. Proves the head label and empty/non-empty rendering still hold.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { SessionListPopover } from './SessionListPopover';
+
+describe('SessionListPopover', () => {
+  it('renders the muted "None" placeholder when there are no names', () => {
+    render(<SessionListPopover label="Used by" names={[]} />);
+    expect(screen.getByText('Used by')).toHaveClass(
+      'alm-session-detail2__head',
+    );
+    expect(screen.getByText('None')).toHaveClass('alm-session-detail2__muted');
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+  });
+
+  it('renders a count trigger popover when names are present', () => {
+    render(
+      <SessionListPopover
+        label="Compatible"
+        names={['a · b · c', 'd · e · f']}
+      />,
+    );
+    expect(screen.getByText('Compatible')).toHaveClass(
+      'alm-session-detail2__head',
+    );
+    expect(screen.getByText('2 ▾')).toBeInTheDocument();
+    expect(screen.queryByText('None')).not.toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/calibration/SessionListPopover.tsx
+++ b/apps/desktop/src/features/calibration/SessionListPopover.tsx
@@ -11,6 +11,7 @@
 
 import { Popover } from '@base-ui-components/react/popover';
 import { useId, useRef, useState } from 'react';
+import { DetailLinkedGroup } from '@/components';
 import { m } from '@/lib/i18n';
 
 interface Props {
@@ -28,57 +29,58 @@ export function SessionListPopover({ label, names }: Props) {
     : names;
 
   return (
-    <div>
-      <div className="alm-session-detail2__head">{label}</div>
-      {names.length === 0 ? (
-        <span className="alm-session-detail2__muted">{m.common_none()}</span>
-      ) : (
-        <Popover.Root
-          onOpenChange={(open) => {
-            setQuery('');
-            if (open) {
-              // Focus the search input after the popup mounts.
-              setTimeout(() => inputRef.current?.focus(), 0);
-            }
-          }}
-        >
-          <Popover.Trigger className="alm-session-popover__trigger">
-            {names.length} ▾
-          </Popover.Trigger>
-          <Popover.Portal>
-            <Popover.Positioner side="bottom" align="start" sideOffset={4}>
-              <Popover.Popup className="alm-session-popover__popup">
-                {}
-                <label htmlFor={inputId} className="alm-visually-hidden">
-                  {m.calibration_session_popover_filter_label()}
-                </label>
-                <input
-                  ref={inputRef}
-                  id={inputId}
-                  className="alm-session-popover__search"
-                  placeholder={m.calibration_session_popover_filter_placeholder()}
-                  aria-label={m.calibration_session_popover_filter_label()}
-                  value={query}
-                  onChange={(e) => setQuery(e.target.value)}
-                />
-                <ul className="alm-session-popover__list">
-                  {filtered.length === 0 ? (
-                    <li className="alm-session-popover__empty">
-                      {m.calibration_session_popover_no_matches()}
+    // #813: shared DetailLinkedGroup (head + muted-or-content) instead of
+    // hand-rolling the `alm-session-detail2__head`/`__muted` classes here.
+    <DetailLinkedGroup
+      label={label}
+      empty={names.length === 0}
+      emptyLabel={m.common_none()}
+    >
+      <Popover.Root
+        onOpenChange={(open) => {
+          setQuery('');
+          if (open) {
+            // Focus the search input after the popup mounts.
+            setTimeout(() => inputRef.current?.focus(), 0);
+          }
+        }}
+      >
+        <Popover.Trigger className="alm-session-popover__trigger">
+          {names.length} ▾
+        </Popover.Trigger>
+        <Popover.Portal>
+          <Popover.Positioner side="bottom" align="start" sideOffset={4}>
+            <Popover.Popup className="alm-session-popover__popup">
+              {}
+              <label htmlFor={inputId} className="alm-visually-hidden">
+                {m.calibration_session_popover_filter_label()}
+              </label>
+              <input
+                ref={inputRef}
+                id={inputId}
+                className="alm-session-popover__search"
+                placeholder={m.calibration_session_popover_filter_placeholder()}
+                aria-label={m.calibration_session_popover_filter_label()}
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+              />
+              <ul className="alm-session-popover__list">
+                {filtered.length === 0 ? (
+                  <li className="alm-session-popover__empty">
+                    {m.calibration_session_popover_no_matches()}
+                  </li>
+                ) : (
+                  filtered.map((name) => (
+                    <li key={name} className="alm-session-popover__item">
+                      {name}
                     </li>
-                  ) : (
-                    filtered.map((name) => (
-                      <li key={name} className="alm-session-popover__item">
-                        {name}
-                      </li>
-                    ))
-                  )}
-                </ul>
-              </Popover.Popup>
-            </Popover.Positioner>
-          </Popover.Portal>
-        </Popover.Root>
-      )}
-    </div>
+                  ))
+                )}
+              </ul>
+            </Popover.Popup>
+          </Popover.Positioner>
+        </Popover.Portal>
+      </Popover.Root>
+    </DetailLinkedGroup>
   );
 }


### PR DESCRIPTION
Refs #813

## Scope
Migrates 2 of the 3 remaining hand-copied `.alm-session-detail2` call sites
onto the shared `TwoColDetailLayout` component (`SessionDetail.tsx` was
already migrated):

- `MasterDetail.tsx`: fingerprint columns + stacked session-popover slot now
  build through `TwoColDetailLayout` (colA/colB/linked/linkedClassName),
  matching `SessionDetail`'s idiom exactly. No prop additions were needed.
- `SessionListPopover.tsx`: its `alm-session-detail2__head` /
  `__muted` leaf markup moves onto a new `DetailLinkedGroup` export from the
  same `TwoColDetailLayout.tsx` module (head label + content-or-muted-empty),
  so it no longer hand-rolls those two class names.

`InboxDetail.tsx` (the third remaining site) is intentionally left alone: it
is fenced under the 057 owner and mid-split per #994, so #813 stays open for
that file specifically.

## Test plan
- [x] `pnpm typecheck` (apps/desktop) — clean
- [x] `pnpm lint` (apps/desktop) — clean (pre-existing warnings only, none in
      touched files)
- [x] `pnpm vitest run` for `MasterDetail`, `SessionListPopover`,
      `TwoColDetailLayout`, and `SessionDetail` test files — 26/26 pass,
      including 3 new test files covering the migrated DOM structure