### PR TITLE
fix: the needs-review panel names the attribute that is actually missing

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -383,6 +383,8 @@
   "inbox_frame_type_label": "Frame type",
   "inbox_frame_types_required_body": "No IMAGETYP headers could be read. Assign frame types below, then confirm.",
   "inbox_frame_types_required_title": "Frame types required",
+  "inbox_mandatory_attrs_required_body": "Frame type is set, but these files still need {attrs} before they can be confirmed. Assign the value(s) in “Needs review”, then confirm.",
+  "inbox_mandatory_attrs_required_title": "More detail needed: {attrs}",
   "inbox_mixed_folder_body": "Multiple frame types detected. This folder is automatically split into separate single-type items — find and confirm each one individually in the list.",
   "inbox_mixed_composition_summary_aria": "Mixed composition summary",
   "inbox_mixed_folder_title": "Mixed folder",

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -25,7 +25,7 @@
  */
 
 import { Popover } from '@base-ui-components/react/popover';
-import { Fragment, useCallback, useState } from 'react';
+import { Fragment, useCallback, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { commands } from '@/bindings/index';
 import type {
@@ -493,7 +493,25 @@ export function InboxDetail({
   };
 
   // T027 selection helpers.
-  const unclassifiedFiles = classification?.unclassifiedFiles ?? [];
+  //
+  // #1114: the needs-review set is every file that still blocks promotion, NOT
+  // just the ones with no frame type. `classification.unclassifiedFiles` drops
+  // a file the instant a frame-type override is written (classify.rs: the
+  // `unclassified != 0 && manual_override.is_none()` filter), which used to
+  // unmount this whole section — including the generic property editor — while
+  // the file was still blocked on a mandatory attribute like exposureS. The
+  // per-file `missingMandatory` set (metadata.rs `compute_missing_mandatory`,
+  // override-applied and re-fetched after every reclassify) is the truthful
+  // gate. Unioned rather than swapped because per-file metadata can be absent
+  // or still loading, and losing the frame-type affordance then would be the
+  // same class of bug in the other direction.
+  const filesNeedingReview = useMemo(() => {
+    const paths = new Set(classification?.unclassifiedFiles ?? []);
+    for (const f of fileMetadata ?? []) {
+      if ((f.missingMandatory?.length ?? 0) > 0) paths.add(f.relativeFilePath);
+    }
+    return Array.from(paths);
+  }, [classification?.unclassifiedFiles, fileMetadata]);
 
   const handleToggleFile = (filePath: string) => {
     setSelectedFiles((prev) => {
@@ -505,9 +523,9 @@ export function InboxDetail({
   };
 
   const handleSelectAll = () => {
-    if (selectedFiles.size === unclassifiedFiles.length)
+    if (selectedFiles.size === filesNeedingReview.length)
       setSelectedFiles(new Set());
-    else setSelectedFiles(new Set(unclassifiedFiles));
+    else setSelectedFiles(new Set(filesNeedingReview));
   };
 
   const handleBulkPropChange = (key: string, value: string) => {
@@ -619,6 +637,24 @@ export function InboxDetail({
   const title = item.relativePath || m.inbox_list_root_label();
   const classType = classification?.type ?? 'pending';
 
+  // #1114: the mandatory attributes still blocking promotion, frame type
+  // excluded. `frameType` is dropped because it has its own dedicated banner
+  // copy and its own dropdown affordance — once the user has supplied it, the
+  // remaining keys are what the banner must name. Empty (either nothing is
+  // missing, or only the frame type is) falls back to the frame-type banner.
+  const blockingAttrsExcludingFrameType = useMemo(() => {
+    const keys = new Set<string>();
+    for (const f of fileMetadata ?? []) {
+      for (const k of f.missingMandatory ?? []) {
+        if (k !== 'frameType') keys.add(k);
+      }
+    }
+    return Array.from(keys);
+  }, [fileMetadata]);
+  const blockingAttrsLabel = blockingAttrsExcludingFrameType
+    .map(humanizeKey)
+    .join(', ');
+
   // Reveal this item's location in the OS file browser (#715, spec 004
   // FR-005/SC-002). No connectivity gate like Sessions (#889): the Inbox
   // root is the currently-scanned root, always reachable while this pane is
@@ -718,8 +754,8 @@ export function InboxDetail({
   // ── Unclassified ("Needs review") table ───────────────────────────────────
 
   const allSelected =
-    unclassifiedFiles.length > 0 &&
-    selectedFiles.size === unclassifiedFiles.length;
+    filesNeedingReview.length > 0 &&
+    selectedFiles.size === filesNeedingReview.length;
   const someSelected = selectedFiles.size > 0 && !allSelected;
 
   const unclassifiedColumns = [
@@ -728,7 +764,7 @@ export function InboxDetail({
     { key: 'override', label: m.inbox_col_assign_frame_type() },
   ];
 
-  const unclassifiedRows = unclassifiedFiles.map((filePath, idx) => ({
+  const unclassifiedRows = filesNeedingReview.map((filePath, idx) => ({
     select: (
       <input
         type="checkbox"
@@ -1059,7 +1095,9 @@ export function InboxDetail({
           </Banner>
         )}
 
-        {/* Unclassified: blocking banner */}
+        {/* Unclassified: blocking banner. #1114 — when the frame type is
+            already supplied and only OTHER mandatory attributes are absent,
+            name those instead of asking again for the frame type. */}
         {classType === 'unclassified' && (
           <Banner
             variant="danger"
@@ -1068,10 +1106,18 @@ export function InboxDetail({
           >
             <div className="pv-inbox-alert__msg">
               <span className="pv-inbox-alert__title">
-                {m.inbox_frame_types_required_title()}
+                {blockingAttrsExcludingFrameType.length > 0
+                  ? m.inbox_mandatory_attrs_required_title({
+                      attrs: blockingAttrsLabel,
+                    })
+                  : m.inbox_frame_types_required_title()}
               </span>
               <span className="pv-inbox-alert__body">
-                {m.inbox_frame_types_required_body()}
+                {blockingAttrsExcludingFrameType.length > 0
+                  ? m.inbox_mandatory_attrs_required_body({
+                      attrs: blockingAttrsLabel,
+                    })
+                  : m.inbox_frame_types_required_body()}
               </span>
             </div>
           </Banner>

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.test.tsx
@@ -874,3 +874,118 @@ describe('InboxDetail — #789 exposure formatting', () => {
     );
   });
 });
+
+// ── #1114: partially-resolved needs-review item ──────────────────────────────
+//
+// A file whose frame type the user has just supplied but which is still
+// blocked on a mandatory attribute. The backend downgrades the classification
+// to "unclassified" (reclassify.rs, the #1086/#711-Instance-B gate), so the
+// detail pane sees classType === 'unclassified' in BOTH the "no frame type"
+// and the "frame type supplied, attribute missing" cases — the bug was that it
+// rendered identical copy for the two, and unmounted the editing affordance in
+// the second.
+
+describe('InboxDetail — #1114: partially-resolved needs-review', () => {
+  /** No frame type at all: the original, still-correct case. */
+  const noFrameType: InboxClassifyResponse = {
+    ...singleTypeClassification,
+    type: 'unclassified',
+    frameType: null,
+    unclassifiedFiles: ['mystery_001.fits'],
+  };
+
+  /**
+   * Frame type supplied (so the file has dropped out of `unclassifiedFiles`),
+   * but exposure + gain are still absent for a dark frame.
+   */
+  const frameTypeSuppliedOnly: InboxClassifyResponse = {
+    ...singleTypeClassification,
+    type: 'unclassified',
+    frameType: null,
+    unclassifiedFiles: [],
+  };
+
+  const partiallyResolvedMetadata: InboxFileMetadata[] = [
+    {
+      ...fileMetadataFixture[0],
+      relativeFilePath: 'mystery_001.fits',
+      frameTypeEffective: 'dark',
+      exposureS: null,
+      gain: null,
+      missingPathAttributes: [],
+      missingMandatory: ['exposureS', 'gain'],
+    },
+  ];
+
+  it('names the frame type when nothing has been supplied yet', () => {
+    render(
+      <InboxDetail
+        item={sampleItem}
+        rootAbsolutePath="/astro/inbox"
+        classification={noFrameType}
+        fileMetadata={[
+          {
+            ...fileMetadataFixture[0],
+            relativeFilePath: 'mystery_001.fits',
+            frameTypeEffective: null,
+            missingPathAttributes: [],
+            missingMandatory: ['frameType'],
+          },
+        ]}
+      />,
+    );
+    expect(screen.getByTestId('inbox-unclassified-alert')).toHaveTextContent(
+      m.inbox_frame_types_required_title(),
+    );
+  });
+
+  it('names the missing attribute, not the frame type, once the type is supplied', () => {
+    render(
+      <InboxDetail
+        item={sampleItem}
+        rootAbsolutePath="/astro/inbox"
+        classification={frameTypeSuppliedOnly}
+        fileMetadata={partiallyResolvedMetadata}
+      />,
+    );
+    const banner = screen.getByTestId('inbox-unclassified-alert');
+    expect(banner).toHaveTextContent('Exposure s');
+    expect(banner).toHaveTextContent('Gain');
+    expect(banner).not.toHaveTextContent(m.inbox_frame_types_required_title());
+  });
+
+  it('keeps the needs-review editor mounted while an attribute is still missing', () => {
+    render(
+      <InboxDetail
+        item={sampleItem}
+        rootAbsolutePath="/astro/inbox"
+        classification={frameTypeSuppliedOnly}
+        fileMetadata={partiallyResolvedMetadata}
+      />,
+    );
+    // The section survives the file leaving `unclassifiedFiles` — this is the
+    // affordance the user needs in order to supply the exposure.
+    expect(screen.getByTestId('reclassify-select-all')).toBeInTheDocument();
+    expect(screen.getByTitle('mystery_001.fits')).toBeInTheDocument();
+  });
+
+  it('unmounts the needs-review editor once nothing is missing', () => {
+    render(
+      <InboxDetail
+        item={sampleItem}
+        rootAbsolutePath="/astro/inbox"
+        classification={singleTypeClassification}
+        fileMetadata={[
+          {
+            ...fileMetadataFixture[0],
+            missingPathAttributes: [],
+            missingMandatory: [],
+          },
+        ]}
+      />,
+    );
+    expect(
+      screen.queryByTestId('reclassify-select-all'),
+    ).not.toBeInTheDocument();
+  });
+});

--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -779,6 +779,27 @@ pub fn check_mandatory_missing(
     missing
 }
 
+/// Mandatory attributes absent for one file record, as the needs-review bucket
+/// judges it (T070 / FR-047 / R-14).
+///
+/// An unresolved frame type reports `["frameType"]`: the frame type is itself
+/// the first mandatory attribute, and until it is known no per-type set can be
+/// derived. Empty means the file can leave the needs-review bucket.
+///
+/// `target_resolved` is pinned to `false` for the same reason as
+/// [`materialize_sub_items`]: coordinate resolution (FR-052) is not integrated
+/// at classify time, so the OBJECT header is the proxy.
+#[must_use]
+pub(crate) fn missing_mandatory_for_file(
+    frame_type: Option<FrameType>,
+    raw_meta: Option<&metadata_core::RawFileMetadata>,
+) -> Vec<String> {
+    match frame_type {
+        Some(ft) => check_mandatory_missing(ft, raw_meta, false),
+        None => vec!["frameType".to_owned()],
+    }
+}
+
 /// Build a [`FrameMetadata`] from a [`metadata_core::RawFileMetadata`] for use
 /// with the grouping engine (T066). All extended fields (set_temp, pointing,
 /// rotation, optic-train, observing-night) are sourced from the core
@@ -890,13 +911,11 @@ pub(crate) async fn materialize_sub_items(
     for (i, (rel, frame_type_opt, raw_meta_opt)) in file_records.iter().enumerate() {
         let abs_path = file_paths.get(i).cloned();
 
-        let (group_key, group_label) = if let Some(ft) = *frame_type_opt {
-            // T070 / FR-047: check mandatory attributes before grouping.
-            // target_resolved=false: coordinate resolution (FR-052) is not yet
-            // integrated at classify time; the user's OBJECT header value is
-            // used as the proxy. Lights with no OBJECT go to needs-review.
-            let missing = check_mandatory_missing(ft, raw_meta_opt.as_ref(), false);
-            if missing.is_empty() {
+        // T070 / FR-047: an unclassifiable file and one missing a mandatory
+        // attribute are the same outcome — the sentinel bucket (FR-048).
+        let missing = missing_mandatory_for_file(*frame_type_opt, raw_meta_opt.as_ref());
+        let (group_key, group_label) = match (*frame_type_opt, missing.is_empty()) {
+            (Some(ft), true) => {
                 // Build effective FrameMetadata for the grouping engine.
                 let meta = raw_meta_opt.as_ref().map_or_else(
                     || FrameMetadata { frame_type: ft, ..Default::default() },
@@ -906,13 +925,8 @@ pub(crate) async fn materialize_sub_items(
                 let config = GroupingConfig::default_for(ft);
                 let result = group_file(&meta, &config);
                 (result.key.0, result.label.0)
-            } else {
-                // Missing mandatory attributes — sentinel bucket (FR-048).
-                (SENTINEL_NEEDS_REVIEW.to_owned(), "(root) · needs review".to_owned())
             }
-        } else {
-            // Unclassifiable (no frame type) — sentinel bucket (FR-048).
-            (SENTINEL_NEEDS_REVIEW.to_owned(), "(root) · needs review".to_owned())
+            _ => (SENTINEL_NEEDS_REVIEW.to_owned(), "(root) · needs review".to_owned()),
         };
 
         // Files without a resolvable abs path (e.g. reclassify_v2's re-split,

--- a/crates/app/inbox/src/reclassify.rs
+++ b/crates/app/inbox/src/reclassify.rs
@@ -845,6 +845,20 @@ pub async fn reclassify_v2(
         .await
         .map_err(|e| db_internal_ctx(e, "list re-materialized sub-items"))?;
 
+    // Union of the mandatory attributes still absent across the files the
+    // re-split just routed to the sentinel bucket (#1114). Recomputed from the
+    // same `file_records` `materialize_sub_items` partitioned on, so the
+    // response names what is actually missing: a file whose frame type the user
+    // has now supplied but whose EXPTIME is still absent reports
+    // `["exposureS"]`, not the frame type it no longer lacks. BTreeSet for a
+    // deduplicated, deterministically ordered list.
+    let needs_review_missing: Vec<String> = file_records
+        .iter()
+        .flat_map(|(_, ft, raw)| super::classify::missing_mandatory_for_file(*ft, raw.as_ref()))
+        .collect::<std::collections::BTreeSet<_>>()
+        .into_iter()
+        .collect();
+
     let mut needs_review_count = 0u32;
     let mut sub_items: Vec<InboxSubItemSummary> = Vec::new();
 
@@ -860,9 +874,7 @@ pub async fn reclassify_v2(
             group_label: row.group_label.clone().unwrap_or_default(),
             frame_type: row.frame_type.clone(),
             file_count: u32::try_from(row.file_count).unwrap_or(u32::MAX),
-            // missing_mandatory population is T070's responsibility; here we
-            // surface an empty list (or "needs review" flag via the sentinel).
-            missing_mandatory: if is_needs_review { vec!["frameType".to_owned()] } else { vec![] },
+            missing_mandatory: if is_needs_review { needs_review_missing.clone() } else { vec![] },
         });
     }
 
@@ -2587,6 +2599,58 @@ mod tests {
             sigs_a, sigs_a_after,
             "sub-item signature did not change after its file changed on disk — \
              confirm would build a plan from a stale picture"
+        );
+    }
+
+    /// Issue #1114: once the user supplies the frame type, the needs-review
+    /// sub-item must stop reporting `frameType` as missing and must name the
+    /// mandatory attributes that are ACTUALLY still absent (dark requires
+    /// exposureS + gain; the fixture header carries neither).
+    ///
+    /// Before the fix `missing_mandatory` was hardcoded to `vec!["frameType"]`
+    /// for every sentinel row, so the response asked the user for the one thing
+    /// they had just supplied and never named the real blockers.
+    #[tokio::test]
+    async fn v2_partially_resolved_reports_real_missing_attrs_not_frame_type() {
+        let db = test_db().await;
+        let root = tempfile::tempdir().unwrap();
+        write_ambiguous_fits(&root.path().join("ambiguous_001.fits"), "M42", 0);
+        seed_and_classify(db.pool(), root.path(), "sg-1114", "item-1114-ph", "root-1114").await;
+
+        // The user supplies ONLY the frame type — exactly the partially
+        // resolved state #1114 describes.
+        let resp = reclassify_v2(
+            db.pool(),
+            InboxReclassifyV2Request {
+                root_absolute_path: root.path().to_string_lossy().into_owned(),
+                source_group_id: Some("sg-1114".to_owned()),
+                inbox_item_id: None,
+                overrides: vec![],
+                bulk: vec![InboxReclassifyBulk {
+                    property: "frameType".to_owned(),
+                    value: serde_json::json!("dark").into(),
+                    file_paths: None,
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let needs_review = resp
+            .sub_items
+            .iter()
+            .find(|s| s.group_key == super::super::classify::SENTINEL_NEEDS_REVIEW)
+            .unwrap_or_else(|| panic!("expected a needs-review sub-item: {:?}", resp.sub_items));
+
+        assert!(
+            !needs_review.missing_mandatory.iter().any(|k| k == "frameType"),
+            "must not ask again for the frame type the user just supplied: {:?}",
+            needs_review.missing_mandatory
+        );
+        assert_eq!(
+            needs_review.missing_mandatory,
+            vec!["exposureS".to_owned(), "gain".to_owned()],
+            "must name the mandatory attributes actually still absent for a dark frame"
         );
     }
 }


### PR DESCRIPTION
## Summary

- Supply a frame type for a file that is also missing `EXPTIME`, and the panel asked for the frame type again — the thing you just supplied.
- A file blocked for want of `gain` could render **no explanation at all**.
- And the editor that could have supplied the missing value **unmounted at the moment you used it**.

Closes #1114.

## The dead end

The needs-review section — checkbox list, frame-type select, and the generic registry-driven property editor — was gated on `classification.unclassifiedFiles`, which drops a file as soon as it carries a manual override.

So supplying the frame type unmounted the editor that supplies the exposure. **The user was not lacking a control; they were given one and it was taken away by the act of using it.**

`missing_mandatory` was also hardcoded to `vec!["frameType"]`, so the banner could name only one thing regardless of what was actually outstanding.

> [!NOTE]
> The issue's original root cause was wrong — it blamed `mandatory_set_for`. The banner is actually driven by a result enum too coarse to distinguish "no frame type" from "frame type present, attribute missing". Corrected on the issue before implementing.

## What changed

**Backend.** `missing_mandatory_for_file` wraps the existing `check_mandatory_missing` with the no-frame-type case, and *collapses* the two identical sentinel branches in `materialize_sub_items` — a net simplification, not an addition. `reclassify` builds a deduplicated, deterministically ordered union over the same `file_records` the split partitioned on, so the response is stable across runs.

**Frontend.** The needs-review set is keyed off files with outstanding mandatory attributes, **unioned** with the old set rather than swapped — per-file metadata can be absent or loading, and losing the frame-type affordance in that window would be the same bug mirrored. A second banner branch names the blocking attributes, excluding `frameType`, which has its own copy and its own control.

**Deliberately not done:** narrowing the generic field list to only the missing keys. That would hide a property whose value is *present but wrong*, so a user who mistyped an exposure could no longer correct it from the pane that is blocking them. The registry already narrows by `appliesTo`, which is the right axis.

**Not fixed here:** the mandatory rule is still duplicated across `classify.rs` and `metadata.rs` with nothing pinning the copies together. That is #1116, deliberately out of scope.

## Two-direction control

Backend, placeholder restored:
```
FAIL v2_partially_resolved_reports_real_missing_attrs_not_frame_type
panicked: must not ask again for the frame type the user just supplied: ["frameType"]
```
With the fix: `PASS`.

Frontend, both changes reverted — `PASS (35) FAIL (2)`, failing exactly the two load-bearing assertions:
```
1. partially-resolved needs-review names the missing attribute, not the frame type
2. partially-resolved needs-review keeps the needs-review editor mounted
```
With the fix: **37 passed.** Two further tests in the new suite pass in *both* directions by design — they guard against over-correcting and should not move.

`reclassify_type_agreement_without_mandatory_attrs_stays_needs_review` still passes. This changes what the response reports and what the pane renders, never the gate's verdict, so the #1086 fix is untouched.

## Gates

`cargo nextest --workspace` 2494 passed · `clippy -D warnings` clean · `fmt --check` clean · `just typecheck` clean · vitest 1775 passed · i18n catalog lint OK, no new baseline entries.

Two failures elsewhere are **pre-existing on `origin/main`, proven not assumed** — reproduced in a throwaway worktree at pristine main: `devSurface.release.test.ts` (dev-tools recorder gate, unrelated) and `end-of-file-fixer` rewriting `signatures/cla.json` (missing trailing newline on main; the hook's edit was reverted and is not in this diff).

## Still needs Real-UI verification

Not run — another PR held the E2E port. A journey draft exists with its insertion point noted; it needs landing once that surface frees up, plus a coverage-matrix row.

Unverified specifically: the full classify → `reclassify_v2` → re-classify → re-render loop across a real item-id remount. The vitest passes `fileMetadata` as a prop, so it cannot prove the query invalidation lands fresh `missingMandatory` before the user looks. The mid-interaction "editor still mounted" assertion is the one that matters.

Two judgement calls worth a second opinion, both flagged by the implementer:
- The banner branch is still gated on `classType === 'unclassified'`, which is where the backend downgrade lands today. A file blocked on attributes while reporting some *other* type would render nothing — judged unreachable, but not demonstrated so.
- The union in the needs-review set is conservative and could keep the section mounted for a file whose metadata row is stale. That direction fails safe — an extra affordance, not a missing one.