### PR TITLE
fix: extract shared entity-name resolver for calibration panel

### DIFF
--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.test.tsx
@@ -26,6 +26,21 @@ vi.mock('./calibrationMatch', async (importOriginal) => {
   return { ...original, calibrationMatchSuggestBatch: vi.fn() };
 });
 
+// The shared useEntityNames hook (#809) resolves session names via
+// useInventorySources — mock `inventoryList` so the panel's name lookup
+// doesn't hit a real Tauri bridge in jsdom. Empty by default; individual
+// tests override via mockResolvedValueOnce to prove name resolution.
+const { mockInventoryList } = vi.hoisted(() => ({
+  mockInventoryList: vi.fn(),
+}));
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...original,
+    commands: { ...original.commands, inventoryList: mockInventoryList },
+  };
+});
+
 import { CalibrationMatchPanel } from './CalibrationMatchPanel';
 import { calibrationMatchSuggestBatch } from './calibrationMatch';
 import type { CalibrationMatchBatchResponse } from '@/bindings/index';
@@ -113,6 +128,16 @@ function makeSuccessResponse(
 describe('CalibrationMatchPanel (spec 007 T034)', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockInventoryList.mockResolvedValue({
+      status: 'ok',
+      data: {
+        status: 'ok',
+        contractVersion: '1.0',
+        requestId: 'req-inventory',
+        generatedAt: '2026-01-01T00:00:00Z',
+        sources: [],
+      },
+    });
   });
 
   it('1. Renders nothing when sessionIds is empty', () => {
@@ -234,5 +259,50 @@ describe('CalibrationMatchPanel (spec 007 T034)', () => {
     const pill = screen.getByTestId(`cal-type-dark-${SESSION_1}`);
     expect(pill).toHaveTextContent('unknown status');
     expect(pill).not.toHaveTextContent('some.unhandled.code');
+  });
+
+  it('9. resolves a session id to its display name via the shared entity-name hook (#809)', async () => {
+    mockInventoryList.mockResolvedValue({
+      status: 'ok',
+      data: {
+        status: 'ok',
+        contractVersion: '1.0',
+        requestId: 'req-inventory',
+        generatedAt: '2026-01-01T00:00:00Z',
+        sources: [
+          {
+            id: 'src-1',
+            path: '/library/src-1',
+            kind: 'library',
+            state: 'active',
+            sessions: [
+              {
+                id: SESSION_1,
+                name: 'M31 – 2026-05-20',
+                sourceId: 'src-1',
+                frames: 40,
+                type: 'light',
+                target: 'M31',
+                filter: null,
+                exposure: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    vi.mocked(calibrationMatchSuggestBatch).mockResolvedValue(
+      makeSuccessResponse(),
+    );
+    render(<CalibrationMatchPanel sessionIds={[SESSION_1, SESSION_2]} />, {
+      wrapper,
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId('cal-panel')).toBeInTheDocument();
+    });
+    // SESSION_1 has a resolved name; SESSION_2 has no matching inventory
+    // source, so it keeps the truncated raw-id fallback.
+    expect(screen.getByText('M31 – 2026-05-20')).toBeInTheDocument();
+    expect(screen.getByText(`${SESSION_2.slice(0, 12)}…`)).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/features/projects/CalibrationMatchPanel.tsx
+++ b/apps/desktop/src/features/projects/CalibrationMatchPanel.tsx
@@ -21,6 +21,7 @@
  * `match.*` / `session.*`, and must be matched as such, not bare).
  */
 
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { queryKeys } from '@/data/queryKeys';
 import { Section, Pill, EmptyState } from '@/ui';
@@ -28,6 +29,7 @@ import type { PillVariant } from '@/ui';
 import { calibrationMatchSuggestBatch } from './calibrationMatch';
 import type { CalibrationMatchType } from './calibrationMatch';
 import type { BatchSessionResultDto } from '@/bindings/index';
+import { useEntityNames, entityNameKey } from '@/hooks/useEntityNames';
 import { errMessage } from '@/lib/errors';
 import { m } from '@/lib/i18n';
 
@@ -75,18 +77,11 @@ interface Props {
   sessionIds: string[];
   /** Whether the collapsible section starts open. Default true. */
   defaultOpen?: boolean;
-  /**
-   * Session id → human-readable name lookup (#663 — the panel previously
-   * always rendered a truncated raw UUID, unlike Sessions/the sources
-   * table which resolve real names).
-   */
-  sessionNames?: Map<string, string>;
 }
 
 export function CalibrationMatchPanel({
   sessionIds,
   defaultOpen = true,
-  sessionNames,
 }: Props) {
   // Batch key is the joined session-id list — matches the `matches(sid)` key
   // shape while distinguishing one panel's session set from another's.
@@ -104,6 +99,15 @@ export function CalibrationMatchPanel({
       }),
     enabled: sessionIds.length > 0,
   });
+
+  // Session id → human-readable name (#663, #809 — resolved via the shared
+  // entity-name hook instead of a prop-drilled ad hoc map, so this panel and
+  // Audit Log/Projects Sources use one resolver).
+  const sessionRefs = useMemo(
+    () => sessionIds.map((id) => ({ entityType: 'session', entityId: id })),
+    [sessionIds],
+  );
+  const sessionNames = useEntityNames(sessionRefs);
 
   const fetchError =
     data?.status === 'error'
@@ -188,7 +192,9 @@ export function CalibrationMatchPanel({
             data-testid={`cal-session-${sid}`}
           >
             <div className="alm-calib-match-panel__session-id">
-              {sessionNames?.get(sid) ?? `${sid.slice(0, 12)}…`}
+              {sessionNames.get(
+                entityNameKey({ entityType: 'session', entityId: sid }),
+              ) ?? `${sid.slice(0, 12)}…`}
             </div>
             <div className="alm-calib-match-panel__type-row">
               {typeResults.map((r) => {

--- a/apps/desktop/src/features/projects/ProjectBottomDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectBottomDetail.tsx
@@ -29,7 +29,7 @@
 
 import { Banner, Skeleton } from '@/ui';
 import { m } from '@/lib/i18n';
-import { useProjectDetail, useSessionNames } from './store';
+import { useProjectDetail } from './store';
 import { ProjectNotesSection } from './ProjectNotesSection';
 import { ManifestsAccordion } from './ManifestsAccordion';
 import { CalibrationMatchPanel } from './CalibrationMatchPanel';
@@ -47,7 +47,6 @@ export interface ProjectBottomDetailProps {
 
 export function ProjectBottomDetail({ projectId }: ProjectBottomDetailProps) {
   const { data: project, loading, error } = useProjectDetail(projectId);
-  const sessionNames = useSessionNames();
 
   if (loading && !project) {
     return (
@@ -85,11 +84,7 @@ export function ProjectBottomDetail({ projectId }: ProjectBottomDetailProps) {
         {/* ── Calibration match panel ───────────────────────────────────── */}
         {sourceIds.length > 0 && (
           <div className="alm-project-bottom__cell">
-            <CalibrationMatchPanel
-              sessionIds={sourceIds}
-              defaultOpen={true}
-              sessionNames={sessionNames}
-            />
+            <CalibrationMatchPanel sessionIds={sourceIds} defaultOpen={true} />
           </div>
         )}
 

--- a/apps/desktop/src/features/settings/AuditLog.test.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.test.tsx
@@ -23,6 +23,8 @@
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
 
 const { mockList, mockExport, mockNavigate } = vi.hoisted(() => ({
   mockList: vi.fn(),
@@ -30,12 +32,28 @@ const { mockList, mockExport, mockNavigate } = vi.hoisted(() => ({
   mockNavigate: vi.fn(),
 }));
 
+// The shared useEntityNames hook (#809) reads session names via
+// useInventorySources, a TanStack Query hook — AuditLog now needs a
+// QueryClientProvider ancestor, same pattern as CalibrationMatchPanel.test.tsx.
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
 vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
 // #803 entity-name resolution calls these per-row; default to a "not found"
 // error so unrelated tests keep seeing the raw `entityType · entityId` text.
+// #809: the shared useEntityNames hook (apps/desktop/src/hooks/useEntityNames.ts)
+// also reads session names off `inventoryList` (no per-id session lookup
+// exists) — an empty source list keeps existing raw-fallback assertions for
+// `entityType: 'session'` entries unchanged.
 vi.mock('@/bindings/index', () => ({
   commands: {
     auditList: mockList,
@@ -65,6 +83,16 @@ vi.mock('@/bindings/index', () => ({
         message: 'not found',
         severity: 'warning',
         retryable: false,
+      },
+    }),
+    inventoryList: vi.fn().mockResolvedValue({
+      status: 'ok',
+      data: {
+        status: 'ok',
+        contractVersion: '1.0',
+        requestId: 'req-inventory',
+        generatedAt: '2026-01-01T00:00:00Z',
+        sources: [],
       },
     }),
   },
@@ -115,7 +143,7 @@ beforeEach(() => {
 
 describe('AuditLog', () => {
   it('loads audit entries via auditList and renders them', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     // findBy, not getBy: rows render behind `{!loading && …}` (AuditLog.tsx)
@@ -129,7 +157,7 @@ describe('AuditLog', () => {
   });
 
   it('debounces the search box, then maps it to filters.search', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
     const callsBeforeTyping = mockList.mock.calls.length;
 
@@ -150,7 +178,7 @@ describe('AuditLog', () => {
   });
 
   it('maps the date-range inputs to filters.from / filters.to', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     fireEvent.change(screen.getByLabelText('From'), {
@@ -184,7 +212,7 @@ describe('AuditLog', () => {
       status: 'ok',
       data: { entries: ENTRIES, total: 20 },
     });
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     // Wait for the initial load to RESOLVE, not merely for auditList to have been
     // called: the Next button is disabled until `total` is set (totalPages > 1),
     // so clicking while the load promise is still pending is a no-op that leaves
@@ -212,7 +240,7 @@ describe('AuditLog', () => {
         retryable: true,
       },
     });
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
 
     await waitFor(() =>
       expect(
@@ -295,7 +323,7 @@ describe('AuditLog', () => {
       },
     });
 
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
 
     // waitFor on rendered content (not just "mockList was called") — the
     // list call resolves asynchronously, so asserting immediately after only
@@ -334,7 +362,7 @@ describe('AuditLog', () => {
       return el;
     });
 
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     // The Export button is `disabled={exporting || loading}` (AuditLog.tsx),
@@ -359,7 +387,7 @@ describe('AuditLog', () => {
   });
 
   it('renders the state-change column (#749)', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     // findBy: rows are gated on `loading` clearing, which the waitFor above
@@ -371,7 +399,7 @@ describe('AuditLog', () => {
   });
 
   it('maps the outcome and entity-type selects to structured filters (#749)', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     fireEvent.change(screen.getByLabelText('Outcome'), {
@@ -396,7 +424,7 @@ describe('AuditLog', () => {
   });
 
   it('navigates to the entity page when a linked row is clicked (#831)', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     // ENTRIES[0] is entityType 'session', which has a real /sessions/:id route.
@@ -408,7 +436,7 @@ describe('AuditLog', () => {
   });
 
   it('does not link entity types without a destination page (#626 reasoning, #831)', async () => {
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
     // ENTRIES[1] is entityType 'plan' — no /plans/:id route exists yet.
@@ -447,7 +475,7 @@ describe('AuditLog', () => {
       },
     });
 
-    render(<AuditLog />);
+    render(<AuditLog />, { wrapper });
 
     await waitFor(() => {
       expect(screen.getByText('J5 Lifecycle Test')).toBeInTheDocument();

--- a/apps/desktop/src/features/settings/AuditLog.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.tsx
@@ -1,24 +1,17 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import {
-  useState,
-  useMemo,
-  useId,
-  useCallback,
-  useEffect,
-  useRef,
-} from 'react';
+import { useState, useMemo, useId, useCallback, useEffect } from 'react';
 import { useDebouncedCallback } from 'use-debounce';
 import { useNavigate } from '@tanstack/react-router';
 import { Btn, Pill, Table } from '@/ui';
 import { auditList, auditExport } from './settingsIpc';
-import { commands } from '@/bindings/index';
 import type {
   AuditEntry,
   AuditFilterDto,
   AuditOutcome,
 } from '@/bindings/index';
+import { useEntityNames, entityNameKey } from '@/hooks/useEntityNames';
 import { errMessage } from '@/lib/errors';
 import { formatDateTime, toEpochMs } from '@/lib/datetime';
 import { m } from '@/lib/i18n';
@@ -79,62 +72,6 @@ function resolveAuditEntityPath(
     default:
       return null;
   }
-}
-
-/**
- * Resolve a human display name per row for the entity types that have one
- * (#803). Caches across renders (module scope) since ids repeat across pages
- * within a session. Falls back to the raw id for types with no lookup
- * command, or when the lookup fails/is still pending.
- */
-const entityNameCache = new Map<string, string | null>();
-
-function useEntityNames(entries: AuditEntry[]): Map<string, string> {
-  const [, forceRender] = useState(0);
-  const requested = useRef(new Set<string>());
-
-  useEffect(() => {
-    let cancelled = false;
-    for (const e of entries) {
-      const cacheKey = `${e.entityType}:${e.entityId}`;
-      if (entityNameCache.has(cacheKey) || requested.current.has(cacheKey)) {
-        continue;
-      }
-      const fetcher =
-        e.entityType === 'project'
-          ? commands
-              .projectsGet(e.entityId)
-              .then((r) => (r.status === 'ok' ? r.data.name : null))
-          : e.entityType === 'target'
-            ? commands
-                .targetsGet(e.entityId)
-                .then((r) => (r.status === 'ok' ? r.data.name : null))
-            : e.entityType === 'plan'
-              ? commands
-                  .plansGet(e.entityId)
-                  .then((r) => (r.status === 'ok' ? r.data.title : null))
-              : null;
-      if (!fetcher) continue;
-      requested.current.add(cacheKey);
-      void fetcher
-        .catch(() => null)
-        .then((name) => {
-          entityNameCache.set(cacheKey, name);
-          if (!cancelled) forceRender((n) => n + 1);
-        });
-    }
-    return () => {
-      cancelled = true;
-    };
-  }, [entries]);
-
-  const names = new Map<string, string>();
-  for (const e of entries) {
-    const cacheKey = `${e.entityType}:${e.entityId}`;
-    const cached = entityNameCache.get(cacheKey);
-    if (cached) names.set(cacheKey, cached);
-  }
-  return names;
 }
 
 const ITEMS_PER_PAGE = 8;
@@ -503,9 +440,7 @@ export function AuditLog() {
           ]}
           rows={entries.map((e) => {
             const path = resolveAuditEntityPath(e.entityType, e.entityId);
-            const resolvedName = entityNames.get(
-              `${e.entityType}:${e.entityId}`,
-            );
+            const resolvedName = entityNames.get(entityNameKey(e));
             return {
               _onClick: path
                 ? () => void navigate({ to: path as never })

--- a/apps/desktop/src/hooks/useEntityNames.test.tsx
+++ b/apps/desktop/src/hooks/useEntityNames.test.tsx
@@ -1,0 +1,152 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * useEntityNames tests (#809) — the resolver shared by Audit Log,
+ * Projects Sources, and the Calibration match panel.
+ */
+
+import { renderHook, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+const { mockProjectsGet, mockTargetsGet, mockPlansGet, mockInventoryList } =
+  vi.hoisted(() => ({
+    mockProjectsGet: vi.fn(),
+    mockTargetsGet: vi.fn(),
+    mockPlansGet: vi.fn(),
+    mockInventoryList: vi.fn(),
+  }));
+
+vi.mock('@/bindings/index', async (importOriginal) => {
+  const original = await importOriginal<typeof import('@/bindings/index')>();
+  return {
+    ...original,
+    commands: {
+      ...original.commands,
+      projectsGet: mockProjectsGet,
+      targetsGet: mockTargetsGet,
+      plansGet: mockPlansGet,
+      inventoryList: mockInventoryList,
+    },
+  };
+});
+
+import { useEntityNames, entityNameKey } from './useEntityNames';
+
+const NOT_FOUND = {
+  status: 'error' as const,
+  error: {
+    code: 'entity.not_found',
+    message: 'not found',
+    severity: 'warning',
+    retryable: false,
+  },
+};
+
+function emptyInventory() {
+  return {
+    status: 'ok' as const,
+    data: {
+      status: 'ok',
+      contractVersion: '1.0',
+      requestId: 'req-inventory',
+      generatedAt: '2026-01-01T00:00:00Z',
+      sources: [],
+    },
+  };
+}
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockProjectsGet.mockResolvedValue(NOT_FOUND);
+  mockTargetsGet.mockResolvedValue(NOT_FOUND);
+  mockPlansGet.mockResolvedValue(NOT_FOUND);
+  mockInventoryList.mockResolvedValue(emptyInventory());
+});
+
+describe('useEntityNames', () => {
+  it('resolves a known project id via commands.projectsGet', async () => {
+    mockProjectsGet.mockResolvedValue({
+      status: 'ok',
+      data: { id: 'proj-1', name: 'Andromeda Mosaic' },
+    });
+    const ref = { entityType: 'project', entityId: 'proj-1' };
+    const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.get(entityNameKey(ref))).toBe('Andromeda Mosaic');
+    });
+  });
+
+  it('resolves a known session id via the inventory-sources query, not a per-id lookup', async () => {
+    mockInventoryList.mockResolvedValue({
+      status: 'ok',
+      data: {
+        status: 'ok',
+        contractVersion: '1.0',
+        requestId: 'req-inventory',
+        generatedAt: '2026-01-01T00:00:00Z',
+        sources: [
+          {
+            id: 'src-1',
+            path: '/library/src-1',
+            kind: 'library',
+            state: 'active',
+            sessions: [
+              {
+                id: 'ses-1',
+                name: 'M31 – 2026-05-20',
+                sourceId: 'src-1',
+                frames: 40,
+                type: 'light',
+                target: 'M31',
+                filter: null,
+                exposure: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+    const ref = { entityType: 'session', entityId: 'ses-1' };
+    const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.get(entityNameKey(ref))).toBe('M31 – 2026-05-20');
+    });
+    expect(mockProjectsGet).not.toHaveBeenCalled();
+    expect(mockTargetsGet).not.toHaveBeenCalled();
+    expect(mockPlansGet).not.toHaveBeenCalled();
+  });
+
+  it('falls back (no entry in the map) for an id that genuinely fails to resolve', async () => {
+    const ref = { entityType: 'target', entityId: 'tgt-missing' };
+    const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
+
+    await waitFor(() =>
+      expect(mockTargetsGet).toHaveBeenCalledWith('tgt-missing'),
+    );
+    expect(result.current.get(entityNameKey(ref))).toBeUndefined();
+  });
+
+  it('falls back for an entity type with no known lookup (e.g. settings)', () => {
+    const ref = { entityType: 'settings', entityId: 'settings-1' };
+    const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
+
+    expect(result.current.get(entityNameKey(ref))).toBeUndefined();
+    expect(mockProjectsGet).not.toHaveBeenCalled();
+    expect(mockTargetsGet).not.toHaveBeenCalled();
+    expect(mockPlansGet).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/hooks/useEntityNames.ts
+++ b/apps/desktop/src/hooks/useEntityNames.ts
@@ -1,0 +1,102 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * useEntityNames -- resolves `(entityType, entityId)` refs to display names.
+ *
+ * Extracted from AuditLog's per-row resolver (#803) so Audit Log, Projects
+ * Sources, and the Calibration match panel share one implementation instead
+ * of three ad hoc treatments (#809).
+ *
+ * - `project` / `target` / `plan`: one IPC round-trip per unseen id, cached
+ *   module-wide since ids repeat across pages within a session.
+ * - `session`: sessions have no cheap per-id name lookup (`sessions.get`
+ *   returns session detail, not a display name), so names are read from the
+ *   already-fetched inventory-sources query instead of adding a new IPC
+ *   command -- the same batch data the Sessions page and Projects Sources
+ *   view already warm (#663).
+ *
+ * Callers decide the fallback text for a ref that never resolves (unknown id,
+ * lookup failed, or still pending) -- this hook only returns names it
+ * actually resolved.
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { commands } from '@/bindings/index';
+import { useInventorySources } from '@/features/sessions/store';
+
+export interface EntityNameRef {
+  entityType: string;
+  entityId: string;
+}
+
+/** Module-scope cache for the per-id IPC lookups (project/target/plan). */
+const entityNameCache = new Map<string, string | null>();
+
+export function entityNameKey(ref: EntityNameRef): string {
+  return `${ref.entityType}:${ref.entityId}`;
+}
+
+export function useEntityNames(
+  refs: readonly EntityNameRef[],
+): Map<string, string> {
+  const [, forceRender] = useState(0);
+  const requested = useRef(new Set<string>());
+  const { data: inventoryData } = useInventorySources();
+
+  useEffect(() => {
+    let cancelled = false;
+    for (const ref of refs) {
+      if (ref.entityType === 'session') continue;
+      const cacheKey = entityNameKey(ref);
+      if (entityNameCache.has(cacheKey) || requested.current.has(cacheKey)) {
+        continue;
+      }
+      const fetcher =
+        ref.entityType === 'project'
+          ? commands
+              .projectsGet(ref.entityId)
+              .then((r) => (r.status === 'ok' ? r.data.name : null))
+          : ref.entityType === 'target'
+            ? commands
+                .targetsGet(ref.entityId)
+                .then((r) => (r.status === 'ok' ? r.data.name : null))
+            : ref.entityType === 'plan'
+              ? commands
+                  .plansGet(ref.entityId)
+                  .then((r) => (r.status === 'ok' ? r.data.title : null))
+              : null;
+      if (!fetcher) continue;
+      requested.current.add(cacheKey);
+      void fetcher
+        .catch(() => null)
+        .then((name) => {
+          entityNameCache.set(cacheKey, name);
+          if (!cancelled) forceRender((n) => n + 1);
+        });
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, [refs]);
+
+  const sessionNames = new Map<string, string>();
+  for (const source of inventoryData?.sources ?? []) {
+    for (const session of source.sessions) {
+      sessionNames.set(session.id, session.name);
+    }
+  }
+
+  const names = new Map<string, string>();
+  for (const ref of refs) {
+    const cacheKey = entityNameKey(ref);
+    if (ref.entityType === 'session') {
+      const name = sessionNames.get(ref.entityId);
+      if (name) names.set(cacheKey, name);
+      continue;
+    }
+    const cached = entityNameCache.get(cacheKey);
+    if (cached) names.set(cacheKey, cached);
+  }
+  return names;
+}


### PR DESCRIPTION
Closes #809

## What
Extracts AuditLog's per-row entity-name resolver (added in #1059) into a
shared `useEntityNames` hook (`apps/desktop/src/hooks/useEntityNames.ts`),
then adopts it in `CalibrationMatchPanel` so it resolves session names
itself instead of depending on a caller-supplied `sessionNames` map.

## Why
#1059 fixed Audit Log's raw-id rendering but left `CalibrationMatchPanel`
falling back to a truncated raw session id, and the two resolvers were
separate ad hoc implementations — the maintainer's 2026-07-19 triage on
#809 narrowed the remaining scope to exactly this: extract the resolver
into one shared hook and use it from the Calibration panel too.

`project`/`target`/`plan` keep the existing per-id IPC + module-cache
lookup (behavior-preserving for Audit Log). `session` has no cheap per-id
name lookup (`sessions.get` returns session detail, not a display name),
so the hook reads session names off the already-fetched inventory-sources
query — the same batch data the Sessions page and the old
`useSessionNames`/Projects Sources view already warm.

`ProjectBottomDetail` no longer threads a `sessionNames` prop into
`CalibrationMatchPanel` — the panel resolves it internally now.

## Verification
- `pnpm vitest run` (full desktop suite): 1777 passed, 0 failed.
- `pnpm typecheck`: clean.
- `pnpm lint` (biome + eslint-baseline + tokens + i18n-catalog): clean.
- Added `apps/desktop/src/hooks/useEntityNames.test.tsx` (resolves
  project/session names, falls back for unknown ids and unhandled entity
  types) and a new CalibrationMatchPanel test proving session-name
  resolution + fallback.