### PR TITLE
refactor: the mandatory-attribute rule has one definition instead of two

### DIFF
--- a/crates/app/inbox/src/metadata.rs
+++ b/crates/app/inbox/src/metadata.rs
@@ -165,23 +165,21 @@ pub async fn get_inbox_item_metadata(
 /// Uses the same override-applied values as `missing_path_attributes` so that
 /// supplying a value via reclassify clears the gate on the next read.
 /// Returns an empty vec when all mandatory attributes are present.
+///
+/// The mandatory set itself comes from [`crate::classify::mandatory_set_for`]
+/// (R-14) — the single definition this and the classify-time gate both read, so
+/// the list shown to the user cannot drift from the list promotion is gated on.
 fn compute_missing_mandatory(m: &InboxFileMetadata) -> Vec<String> {
     let Some(ft_str) = m.frame_type_effective.as_deref() else {
         // Unclassified files are implicitly needs-review; frameType is the gate.
         return vec!["frameType".to_owned()];
     };
-
-    // Derive mandatory set from the same R-14 table as classify::mandatory_set_for.
-    let mandatory: &[&str] = match ft_str {
-        "light" => &["frameType", "target", "filter", "exposureS"],
-        "dark" | "dark_flat" => &["frameType", "exposureS", "gain"],
-        "bias" => &["frameType", "gain"],
-        "flat" => &["frameType", "filter"],
-        _ => return Vec::new(), // unknown type: no gate
+    let Some(ft) = metadata_core::FrameType::from_str_ci(ft_str) else {
+        return Vec::new(); // unknown type: no gate
     };
 
     let mut missing = Vec::new();
-    for &key in mandatory {
+    for key in crate::classify::mandatory_set_for(ft) {
         let absent = match key {
             "target" => {
                 // light: satisfied by OBJECT header (proxy for coord resolution).
@@ -280,6 +278,45 @@ mod tests {
         let db = Database::in_memory().await.unwrap();
         db.migrate().await.unwrap();
         db
+    }
+
+    /// R-14 drift guard (#1116): the mandatory set the user is *shown* must equal
+    /// the one promotion is *gated* on, for every frame type.
+    ///
+    /// A file with no attributes at all is missing exactly the mandatory set minus
+    /// `frameType` (which is satisfied by the type being known), so both consumers
+    /// must reproduce [`crate::classify::mandatory_set_for`] verbatim. Fails if a
+    /// key is added to the shared set but handled in only one consumer, or if
+    /// either consumer reintroduces its own copy of the table.
+    #[test]
+    fn r14_mandatory_gate_agrees_between_classify_and_metadata() {
+        use metadata_core::FrameType;
+
+        for ft in [
+            FrameType::Light,
+            FrameType::Dark,
+            FrameType::Bias,
+            FrameType::Flat,
+            FrameType::DarkFlat,
+        ] {
+            let expected: Vec<String> = crate::classify::mandatory_set_for(ft)
+                .into_iter()
+                .filter(|k| *k != "frameType")
+                .map(str::to_owned)
+                .collect();
+
+            let gate = crate::classify::check_mandatory_missing(ft, None, false);
+            assert_eq!(gate, expected, "classify gate for {ft} diverged from mandatory_set_for");
+
+            let shown = compute_missing_mandatory(&InboxFileMetadata {
+                frame_type_effective: Some(ft.as_str().to_owned()),
+                ..Default::default()
+            });
+            assert_eq!(
+                shown, expected,
+                "metadata missing_mandatory for {ft} diverged from mandatory_set_for"
+            );
+        }
     }
 
     #[tokio::test]

--- a/crates/contracts/core/src/inbox.rs
+++ b/crates/contracts/core/src/inbox.rs
@@ -437,7 +437,7 @@ pub struct InboxListResponse {
 /// `frame_type_effective` reflects override-if-present-else-extracted.
 /// `override_stale` is true when the file was changed (size/mtime) since the
 /// override was recorded (R-4); the override is surfaced but flagged.
-#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct InboxFileMetadata {
     pub relative_file_path: String,


### PR DESCRIPTION
Closes #1116.

## Summary

- The rule deciding which attributes each frame type requires was hand-written in **two** places that agreed only by luck.
- They feed different surfaces, so divergence means the app asks for one set and gates on another.
- Collapsed to one definition, with a test that fails if they ever drift apart again.

## Why it mattered

`classify::mandatory_set_for` decides whether an item passes the mandatory gate and can leave needs-review. A parallel table inside `metadata::compute_missing_mandatory` computes the per-file list shown to the user.

If those diverge, the user supplies exactly what the UI asks for and still cannot proceed, with nothing on screen explaining why. That is the same class of defect as #1114, reached by a different route.

Nothing enforced their agreement: no shared constant, no equivalence test, and the repo's drift guards cover **generated bindings**, not hand-written rule logic.

## The change

Both files are in the same crate and `mandatory_set_for` is already `pub`, so this needed no new construct. `metadata` now parses the frame type and iterates the shared function. **Net effect is a deletion.**

**Rejected:** adding a `mandatoryFor` field to the property registry. That is a contract plus generated-bindings change to serve a frontend consumer that does not exist — no TS file references the rule; the frontend consumes the backend-computed `missingMandatory` array. If a UI need appears, the registry is the right home then, and the shared function moves there in one step.

The equivalence test derives its expectation *from* the shared function rather than restating it, so it also fails if a key is added to the set but handled in only one consumer's `match` arms — closing the next drift route, not just this one.

## Two-direction control

With a divergent table temporarily reintroduced (bias gains an extra `exposureS`, flat loses `filter`):

```
FAIL r14_mandatory_gate_agrees_between_classify_and_metadata
assertion `left == right` failed: metadata missing_mandatory for bias
diverged from mandatory_set_for
  left: ["gain", "exposureS"]
 right: ["gain"]
```

Restored: `PASS`.

## Found while doing this, deliberately not fixed here

> [!IMPORTANT]
> The two copies matched on the **set** but differed in **per-key absence logic**, and the difference is inert only by accident.
>
> For `target`, `classify.rs:762` requires `!target_resolved && OBJECT.is_empty()`; `metadata.rs:187` tests `OBJECT.is_empty()` alone. A light whose target was resolved by coordinates (R-17) but carries no `OBJECT` header would **pass the promotion gate while the UI still lists `target` as missing** — the #1116 failure mode, one layer down.
>
> It is not live today because every production caller passes `target_resolved: false` (`classify.rs:898`, `reclassify.rs:903`). Which is its own smell: the R-17 coordinate-resolution rule documented at `classify.rs:718-720` is **not wired to anything** and the parameter is dead.
>
> Fixing it means changing absence semantics, which is a product decision outside this issue. Filed separately.

## Gates

`cargo nextest --workspace` 2495 passed · `clippy -D warnings` clean · `fmt --check` clean · doctests pass · `just check-generated` reports no binding drift.

The one addition beyond the collapse is `Default` on `InboxFileMetadata`, so the test can build an all-empty file with `..Default::default()` rather than a 30-field literal. It does not alter serde or specta output.