### PR TITLE
fix: surface project lifecycle audit trail in project History

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -535,6 +535,8 @@
   "projects_stepper_aria": "Project lifecycle",
   "projects_stepper_blocked_chip": "blocked",
   "projects_stepper_created": "Created",
+  "projects_stepper_history_empty": "No lifecycle history recorded.",
+  "projects_stepper_history_load_error": "Could not load project history.",
   "projects_stepper_history_title": "History",
   "projects_stepper_updated": "Updated",
   "projects_table_blocked_aria": "Blocked: {reason}",

--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -13,6 +13,7 @@ export const queryKeys = {
     all: () => ['projects'] as const,
     detail: (id: string) => ['projects', id] as const,
     artifacts: (id: string) => ['projects', id, 'artifacts'] as const,
+    history: (id: string) => ['projects', id, 'history'] as const,
   },
   inventory: {
     // No filters → prefix-only key, so `invalidateQueries({ queryKey:

--- a/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
@@ -26,6 +26,19 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // ProjectLifecycleStepper's History section (#833) falls back to this
+    // route search param when its (optional) projectId prop isn't wired;
+    // unrelated to this file's assertions, so a static empty selection is
+    // enough.
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  };
+});
+
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {
@@ -35,6 +48,13 @@ vi.mock('./store', async (importOriginal) => {
     callTransitionLifecycle: vi.fn(),
     callReinferChannels: vi.fn(),
     callDismissChannelDrift: vi.fn(),
+    // Avoids requiring a QueryClientProvider for this file's real-useQuery
+    // History query (#833) — same reasoning as useProjectDetail above.
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
@@ -26,6 +26,19 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // ProjectLifecycleStepper's History section (#833) falls back to this
+    // route search param when its (optional) projectId prop isn't wired;
+    // unrelated to this file's assertions, so a static empty selection is
+    // enough.
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  };
+});
+
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {
@@ -35,6 +48,13 @@ vi.mock('./store', async (importOriginal) => {
     callTransitionLifecycle: vi.fn(),
     callReinferChannels: vi.fn(),
     callDismissChannelDrift: vi.fn(),
+    // Avoids requiring a QueryClientProvider for this file's real-useQuery
+    // History query (#833) — same reasoning as useProjectDetail above.
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
@@ -22,6 +22,19 @@ vi.mock('@tauri-apps/api/core', () => ({
   invoke: vi.fn(),
 }));
 
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // ProjectLifecycleStepper's History section (#833) falls back to this
+    // route search param when its (optional) projectId prop isn't wired;
+    // unrelated to this file's assertions, so a static empty selection is
+    // enough.
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  };
+});
+
 // Mock the project detail store
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
@@ -32,6 +45,13 @@ vi.mock('./store', async (importOriginal) => {
     callTransitionLifecycle: vi.fn(),
     callReinferChannels: vi.fn(),
     callDismissChannelDrift: vi.fn(),
+    // Avoids requiring a QueryClientProvider for this file's real-useQuery
+    // History query (#833) — same reasoning as useProjectDetail above.
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.sources-applicability.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.sources-applicability.test.tsx
@@ -12,6 +12,19 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // ProjectLifecycleStepper's History section (#833) falls back to this
+    // route search param when its (optional) projectId prop isn't wired;
+    // unrelated to this file's assertions, so a static empty selection is
+    // enough.
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  };
+});
+
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {
@@ -21,6 +34,13 @@ vi.mock('./store', async (importOriginal) => {
     useTransitionLifecycle: vi.fn(),
     useReinferChannels: vi.fn(),
     useDismissChannelDrift: vi.fn(),
+    // Avoids requiring a QueryClientProvider for this file's real-useQuery
+    // History query (#833) — same reasoning as useProjectDetail above.
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.sources-metric.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.sources-metric.test.tsx
@@ -17,6 +17,19 @@
 import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    // ProjectLifecycleStepper's History section (#833) falls back to this
+    // route search param when its (optional) projectId prop isn't wired;
+    // unrelated to this file's assertions, so a static empty selection is
+    // enough.
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  };
+});
+
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
   return {
@@ -26,6 +39,13 @@ vi.mock('./store', async (importOriginal) => {
     useTransitionLifecycle: vi.fn(),
     useReinferChannels: vi.fn(),
     useDismissChannelDrift: vi.fn(),
+    // Avoids requiring a QueryClientProvider for this file's real-useQuery
+    // History query (#833) — same reasoning as useProjectDetail above.
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
@@ -40,6 +40,10 @@ vi.mock('@tanstack/react-router', () => ({
       </a>
     );
   },
+  // ProjectLifecycleStepper's History section (#833) falls back to this route
+  // search param when its (optional) projectId prop isn't wired; unrelated to
+  // this file's assertions, so a static empty selection is enough.
+  useSearch: () => ({ selected: undefined, lifecycle: undefined }),
 }));
 
 vi.mock('./store', async (importOriginal) => {
@@ -51,6 +55,13 @@ vi.mock('./store', async (importOriginal) => {
     useTransitionLifecycle: vi.fn(),
     useReinferChannels: vi.fn(),
     useDismissChannelDrift: vi.fn(),
+    // Avoids requiring a QueryClientProvider for this file's real-useQuery
+    // History query (#833) — same reasoning as useProjectDetail above.
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectLifecycleStepper.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectLifecycleStepper.test.tsx
@@ -10,12 +10,20 @@
  * trailing danger chip, History is a collapsible (closed by default), and
  * (#833) the History section renders the project's audit trail — transitions
  * with from→to state/outcome/actor — with an empty state when there is none.
+ * Also covers the `/shell/projects` route `selected`-search-param fallback
+ * used when the (optional) `projectId` prop isn't passed — see the prop's
+ * doc comment on `ProjectLifecycleStepperProps` for why.
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
+
+const { mockUseSearch } = vi.hoisted(() => ({ mockUseSearch: vi.fn() }));
+vi.mock('@tanstack/react-router', () => ({
+  useSearch: mockUseSearch,
+}));
 
 vi.mock('./store', async (importOriginal) => {
   const original = await importOriginal<typeof import('./store')>();
@@ -63,11 +71,16 @@ function historyEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
 
 describe('ProjectLifecycleStepper', () => {
   beforeEach(() => {
-    // Default: empty, loaded history — individual tests override as needed.
+    // Default: empty, loaded history and no route selection — individual
+    // tests override as needed.
     mockUseProjectHistory.mockReturnValue({
       data: [],
       loading: false,
       error: undefined,
+    });
+    mockUseSearch.mockReturnValue({
+      selected: undefined,
+      lifecycle: undefined,
     });
   });
 
@@ -170,5 +183,24 @@ describe('ProjectLifecycleStepper', () => {
     expect(
       screen.getByText(/no lifecycle history recorded/i),
     ).toBeInTheDocument();
+  });
+
+  it('falls back to the /shell/projects route selected search param when projectId is not passed', () => {
+    mockUseSearch.mockReturnValue({
+      selected: 'proj-route-1',
+      lifecycle: undefined,
+    });
+    const { projectId: _unused, ...rest } = TS;
+    render(<ProjectLifecycleStepper state="ready" {...rest} />, { wrapper });
+    expect(mockUseProjectHistory).toHaveBeenCalledWith('proj-route-1');
+  });
+
+  it('prefers an explicit projectId prop over the route search param', () => {
+    mockUseSearch.mockReturnValue({
+      selected: 'proj-route-1',
+      lifecycle: undefined,
+    });
+    render(<ProjectLifecycleStepper state="ready" {...TS} />, { wrapper });
+    expect(mockUseProjectHistory).toHaveBeenCalledWith('proj-1');
   });
 });

--- a/apps/desktop/src/features/projects/ProjectLifecycleStepper.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectLifecycleStepper.test.tsx
@@ -3,26 +3,78 @@
 
 /// <reference types="@testing-library/jest-dom" />
 /**
- * ProjectLifecycleStepper tests — spec 043 task #74.
+ * ProjectLifecycleStepper tests — spec 043 task #74, #833.
  *
- * The compact horizontal stepper that replaced the vertical lifecycle rail.
  * Covers: all stages render, the current stage is marked active, prior stages
- * read as done, a next-action line is present, blocked projects get a trailing
- * danger chip, and History is a collapsible (closed by default).
+ * read as done, a next-action line is present, blocked projects get a
+ * trailing danger chip, History is a collapsible (closed by default), and
+ * (#833) the History section renders the project's audit trail — transitions
+ * with from→to state/outcome/actor — with an empty state when there is none.
  */
 
 import { render, screen, fireEvent } from '@testing-library/react';
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+
+vi.mock('./store', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./store')>();
+  return { ...original, useProjectHistory: vi.fn() };
+});
+
 import { ProjectLifecycleStepper } from './ProjectLifecycleStepper';
+import { useProjectHistory } from './store';
+import type { AuditEntry } from '@/bindings/index';
 
 const TS = {
+  projectId: 'proj-1',
   createdAt: '2026-06-01T00:00:00Z',
   updatedAt: '2026-06-10T00:00:00Z',
 };
 
+const mockUseProjectHistory = vi.mocked(useProjectHistory);
+
+function wrapper({ children }: { children: ReactNode }) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
+
+function historyEntry(overrides: Partial<AuditEntry> = {}): AuditEntry {
+  return {
+    id: 'audit-1',
+    timestamp: '2026-07-01T00:00:00Z',
+    eventType: 'project: ready -> processing',
+    entityType: 'project',
+    entityId: 'proj-1',
+    fromState: 'ready',
+    toState: 'processing',
+    actor: 'user',
+    outcome: 'applied',
+    detail: 'project: ready -> processing',
+    detailCode: null,
+    detailParams: null,
+    ...overrides,
+  };
+}
+
 describe('ProjectLifecycleStepper', () => {
+  beforeEach(() => {
+    // Default: empty, loaded history — individual tests override as needed.
+    mockUseProjectHistory.mockReturnValue({
+      data: [],
+      loading: false,
+      error: undefined,
+    });
+  });
+
   it('renders the stepper container and all lifecycle stages', () => {
-    render(<ProjectLifecycleStepper state="processing" {...TS} />);
+    render(<ProjectLifecycleStepper state="processing" {...TS} />, {
+      wrapper,
+    });
     expect(screen.getByTestId('project-lifecycle-stepper')).toBeInTheDocument();
     for (const stage of [
       'setup',
@@ -39,6 +91,7 @@ describe('ProjectLifecycleStepper', () => {
   it('marks the current stage active and prior stages done', () => {
     const { container } = render(
       <ProjectLifecycleStepper state="prepared" {...TS} />,
+      { wrapper },
     );
     const active = container.querySelector('.alm-stepper__chip--active');
     expect(active).toHaveTextContent('prepared');
@@ -49,13 +102,16 @@ describe('ProjectLifecycleStepper', () => {
   });
 
   it('renders a contextual next-action line', () => {
-    render(<ProjectLifecycleStepper state="processing" {...TS} />);
+    render(<ProjectLifecycleStepper state="processing" {...TS} />, {
+      wrapper,
+    });
     expect(screen.getByText(/record an accepted output/i)).toBeInTheDocument();
   });
 
   it('renders a trailing blocked chip for blocked projects', () => {
     const { container } = render(
       <ProjectLifecycleStepper state="blocked" {...TS} />,
+      { wrapper },
     );
     const blocked = container.querySelector('.alm-stepper__chip--blocked');
     expect(blocked).toHaveTextContent('blocked');
@@ -64,10 +120,55 @@ describe('ProjectLifecycleStepper', () => {
   });
 
   it('keeps History collapsed by default and expands on click', () => {
-    render(<ProjectLifecycleStepper state="ready" {...TS} />);
+    render(<ProjectLifecycleStepper state="ready" {...TS} />, { wrapper });
     expect(screen.queryByText(/created/i)).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('History'));
     expect(screen.getByText(/created/i)).toBeInTheDocument();
     expect(screen.getByText(/updated/i)).toBeInTheDocument();
+  });
+
+  it('renders transitions from the audit trail, newest-first as given by the query', () => {
+    mockUseProjectHistory.mockReturnValue({
+      data: [
+        historyEntry({
+          id: 'audit-2',
+          fromState: 'processing',
+          toState: 'completed',
+          outcome: 'applied',
+          actor: 'user',
+        }),
+        historyEntry({
+          id: 'audit-1',
+          fromState: 'ready',
+          toState: 'processing',
+          outcome: 'refused',
+          actor: 'system',
+        }),
+      ],
+      loading: false,
+      error: undefined,
+    });
+    render(<ProjectLifecycleStepper state="processing" {...TS} />, {
+      wrapper,
+    });
+    fireEvent.click(screen.getByText('History'));
+
+    const rows = screen.getAllByText(/→/);
+    expect(rows[0]).toHaveTextContent('processing → completed');
+    expect(rows[1]).toHaveTextContent('ready → processing');
+    expect(screen.getByText('system')).toBeInTheDocument();
+  });
+
+  it('renders an empty state when the project has no audit history', () => {
+    mockUseProjectHistory.mockReturnValue({
+      data: [],
+      loading: false,
+      error: undefined,
+    });
+    render(<ProjectLifecycleStepper state="ready" {...TS} />, { wrapper });
+    fireEvent.click(screen.getByText('History'));
+    expect(
+      screen.getByText(/no lifecycle history recorded/i),
+    ).toBeInTheDocument();
   });
 });

--- a/apps/desktop/src/features/projects/ProjectLifecycleStepper.tsx
+++ b/apps/desktop/src/features/projects/ProjectLifecycleStepper.tsx
@@ -18,11 +18,16 @@
  * collapsible. No inline styles.
  */
 
-import { Section } from '@/ui';
+import { Section, Table, EmptyState, Skeleton, Pill } from '@/ui';
 import { PROJECT_LIFECYCLE, projectStateIndex } from '@/lib/lifecycle';
 import { m } from '@/lib/i18n';
+import { formatDateTime } from '@/lib/datetime';
+import { auditOutcomeVariant, auditOutcomeLabel } from '@/lib/audit-outcome';
+import { useProjectHistory } from './store';
 
 export interface ProjectLifecycleStepperProps {
+  /** Project id — scopes the audit-log query for the History section (#833). */
+  projectId: string;
   /** Stored project state (e.g. "processing", "setup_incomplete", "blocked"). */
   state: string;
   /** ISO creation timestamp (for the History collapsible). */
@@ -50,6 +55,7 @@ function nextActionText(state: string): string {
 }
 
 export function ProjectLifecycleStepper({
+  projectId,
   state,
   createdAt,
   updatedAt,
@@ -57,6 +63,11 @@ export function ProjectLifecycleStepper({
   const currentIdx =
     projectStateIndex[state as keyof typeof projectStateIndex] ?? -1;
   const isBlocked = state === 'blocked';
+  const {
+    data: history,
+    loading: historyLoading,
+    error: historyError,
+  } = useProjectHistory(projectId);
 
   return (
     <div className="alm-stepper" data-testid="project-lifecycle-stepper">
@@ -104,6 +115,65 @@ export function ProjectLifecycleStepper({
             {new Date(updatedAt).toLocaleDateString()}
           </div>
         </div>
+
+        {/* #833: the project's own lifecycle audit trail — transitions with
+            from→to state, outcome, and actor, newest-first (backend-ordered,
+            `ORDER BY at DESC`). Reuses the same `audit.list` query the
+            archive feature runs for archived projects
+            (`features/archive/store.ts` `useArchiveAudit`), filtered to this
+            project's entity id, rather than a bespoke store. */}
+        {historyLoading ? (
+          <Skeleton count={3} label={m.common_loading()} />
+        ) : historyError ? (
+          <EmptyState title={m.projects_stepper_history_load_error()} />
+        ) : !history || history.length === 0 ? (
+          <EmptyState title={m.projects_stepper_history_empty()} />
+        ) : (
+          <Table
+            columns={[
+              {
+                key: 'ts',
+                label: m.archive_prop_date(),
+                style: { width: 150 },
+              },
+              {
+                key: 'stateChange',
+                label: m.settings_auditlog_col_state_change(),
+              },
+              {
+                key: 'outcome',
+                label: m.settings_auditlog_col_outcome(),
+                style: { width: 90 },
+              },
+              {
+                key: 'actor',
+                label: m.settings_auditlog_col_actor(),
+                style: { width: 72 },
+              },
+            ]}
+            rows={history.map((entry) => ({
+              ts: (
+                <span className="alm-mono">
+                  {formatDateTime(entry.timestamp)}
+                </span>
+              ),
+              stateChange:
+                entry.fromState || entry.toState ? (
+                  <span>
+                    {entry.fromState ?? '—'} → {entry.toState ?? '—'}
+                  </span>
+                ) : (
+                  entry.detail
+                ),
+              outcome: (
+                <Pill variant={auditOutcomeVariant(entry.outcome)}>
+                  {auditOutcomeLabel(entry.outcome)}
+                </Pill>
+              ),
+              actor: <span className="alm-mono">{entry.actor}</span>,
+            }))}
+          />
+        )}
       </Section>
     </div>
   );

--- a/apps/desktop/src/features/projects/ProjectLifecycleStepper.tsx
+++ b/apps/desktop/src/features/projects/ProjectLifecycleStepper.tsx
@@ -18,6 +18,7 @@
  * collapsible. No inline styles.
  */
 
+import { useSearch } from '@tanstack/react-router';
 import { Section, Table, EmptyState, Skeleton, Pill } from '@/ui';
 import { PROJECT_LIFECYCLE, projectStateIndex } from '@/lib/lifecycle';
 import { m } from '@/lib/i18n';
@@ -26,8 +27,16 @@ import { auditOutcomeVariant, auditOutcomeLabel } from '@/lib/audit-outcome';
 import { useProjectHistory } from './store';
 
 export interface ProjectLifecycleStepperProps {
-  /** Project id — scopes the audit-log query for the History section (#833). */
-  projectId: string;
+  /**
+   * Project id — scopes the audit-log query for the History section (#833).
+   * Optional: the component's only mount point (`ProjectDetail.tsx:638`) is
+   * off-limits while the #998 split is unmerged, so it isn't wired to pass
+   * this explicitly yet. Falls back to the `/shell/projects` route's
+   * `selected` search param — the same id source `ProjectDetail.tsx:176`
+   * reads via `useProjectDetail(projectId)`. Follow-up: once #998 lands,
+   * thread `projectId` through explicitly and drop the fallback.
+   */
+  projectId?: string;
   /** Stored project state (e.g. "processing", "setup_incomplete", "blocked"). */
   state: string;
   /** ISO creation timestamp (for the History collapsible). */
@@ -63,11 +72,13 @@ export function ProjectLifecycleStepper({
   const currentIdx =
     projectStateIndex[state as keyof typeof projectStateIndex] ?? -1;
   const isBlocked = state === 'blocked';
+  const { selected: routeProjectId } = useSearch({ from: '/shell/projects' });
+  const resolvedProjectId = projectId ?? routeProjectId;
   const {
     data: history,
     loading: historyLoading,
     error: historyError,
-  } = useProjectHistory(projectId);
+  } = useProjectHistory(resolvedProjectId);
 
   return (
     <div className="alm-stepper" data-testid="project-lifecycle-stepper">

--- a/apps/desktop/src/features/projects/store.ts
+++ b/apps/desktop/src/features/projects/store.ts
@@ -146,12 +146,19 @@ export function useProjectDetail(id: string): QueryState<ProjectDetailDto> {
   };
 }
 
-/** Subscribe to a project's lifecycle audit trail (#833). */
-export function useProjectHistory(id: string): QueryState<AuditEntry[]> {
+/**
+ * Subscribe to a project's lifecycle audit trail (#833). `id` is optional
+ * (matching `useArchiveAudit`'s `entityId: string | undefined` shape,
+ * `features/archive/store.ts`) — the query stays disabled until a caller
+ * resolves one.
+ */
+export function useProjectHistory(
+  id: string | undefined,
+): QueryState<AuditEntry[]> {
   const { data, isFetching, error } = useQuery({
-    queryKey: queryKeys.projects.history(id),
-    queryFn: () => listProjectAudit(id),
-    enabled: !!id,
+    queryKey: queryKeys.projects.history(id ?? ''),
+    queryFn: () => listProjectAudit(id as string),
+    enabled: Boolean(id),
   });
   return {
     data,

--- a/apps/desktop/src/features/projects/store.ts
+++ b/apps/desktop/src/features/projects/store.ts
@@ -22,7 +22,11 @@ import type {
   ProjectLifecycleState,
   LifecycleTransitionResponse,
 } from './lifecycleTransition';
-import type { ProjectSummaryDto, ProjectDetailDto } from '@/bindings/index';
+import type {
+  ProjectSummaryDto,
+  ProjectDetailDto,
+  AuditEntry,
+} from '@/bindings/index';
 import type {
   ProjectCreateRequest,
   ProjectCreateResult,
@@ -48,6 +52,21 @@ async function listProjects008(): Promise<ProjectSummaryDto[]> {
 
 async function getProject008(args: { id: string }): Promise<ProjectDetailDto> {
   return unwrap(await commands.projectsGet(args.id));
+}
+
+/**
+ * #833: reuses `audit.list` filtered to this project's entity id — the same
+ * query the archive feature's `useArchiveAudit` runs for archived projects
+ * (`features/archive/store.ts`) — rather than a bespoke project-history
+ * store. Newest-first ordering is a backend guarantee (`ORDER BY at DESC`,
+ * `persistence_db::repositories::audit::list_audit_entries`), not re-sorted
+ * here.
+ */
+async function listProjectAudit(id: string): Promise<AuditEntry[]> {
+  const res = unwrap(
+    await commands.auditList({ entityType: 'project', entityId: id }, null),
+  );
+  return res.entries;
 }
 
 async function createProject(
@@ -118,6 +137,20 @@ export function useProjectDetail(id: string): QueryState<ProjectDetailDto> {
   const { data, isFetching, error } = useQuery({
     queryKey: queryKeys.projects.detail(id),
     queryFn: () => getProject008({ id }),
+    enabled: !!id,
+  });
+  return {
+    data,
+    loading: isFetching,
+    error: error ?? undefined,
+  };
+}
+
+/** Subscribe to a project's lifecycle audit trail (#833). */
+export function useProjectHistory(id: string): QueryState<AuditEntry[]> {
+  const { data, isFetching, error } = useQuery({
+    queryKey: queryKeys.projects.history(id),
+    queryFn: () => listProjectAudit(id),
     enabled: !!id,
   });
   return {

--- a/apps/desktop/src/lib/audit-outcome.ts
+++ b/apps/desktop/src/lib/audit-outcome.ts
@@ -1,0 +1,47 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Shared `AuditOutcome` → pill variant/label mapping.
+ *
+ * Settings → Audit Log (`features/settings/AuditLog.tsx`) and the Archive
+ * detail panel (`features/archive/ArchiveDetail.tsx`) each keep their own
+ * copy of this five-case switch (documented there as intentional at the
+ * time — one extra caller wasn't worth a cross-feature extraction). Project
+ * history (#833) is a third caller, which crosses that threshold; new
+ * callers should use this module rather than adding a fourth copy.
+ */
+
+import type { AuditOutcome } from '@/bindings/index';
+import type { PillVariant } from '@/ui';
+import { m } from '@/lib/i18n';
+
+export function auditOutcomeVariant(outcome: AuditOutcome): PillVariant {
+  switch (outcome) {
+    case 'applied':
+    case 'ok':
+      return 'ok';
+    case 'refused':
+    case 'paused':
+      return 'warn';
+    case 'failed':
+      return 'danger';
+    default:
+      return 'neutral';
+  }
+}
+
+export function auditOutcomeLabel(outcome: AuditOutcome): string {
+  switch (outcome) {
+    case 'applied':
+      return m.settings_auditlog_outcome_applied();
+    case 'ok':
+      return m.settings_auditlog_outcome_ok();
+    case 'refused':
+      return m.settings_auditlog_outcome_refused();
+    case 'failed':
+      return m.settings_auditlog_outcome_failed();
+    case 'paused':
+      return m.settings_auditlog_outcome_paused();
+  }
+}


### PR DESCRIPTION
## What

Project detail's History section previously showed only static Created/Updated
dates. It now renders the project's own lifecycle audit trail — transitions
with from→to state, outcome, and actor — newest-first, in the same collapsible
section.

## Why

Closes #833. The audit data already existed (`audit_log_entry`, entity_type=
`project`) but nothing in the UI queried or rendered it — none of a project's
transitions, refusals, or actors were visible on its own detail page.

Related but distinct: #629 is about the *Archive* detail panel dropping
`outcome`/`actor` from the audit list it already renders for archived
projects. That panel (`ArchiveDetail.tsx`) already renders outcome/actor
today, so #629 may be partly stale — not investigated further here, out of
scope for this change.

## Implementation

- `features/projects/store.ts`: `useProjectHistory` hook, reusing the exact
  `audit.list` query (`entityType: 'project'`) the archive feature already
  runs for archived projects (`useArchiveAudit`). Backend orders newest-first
  (`ORDER BY at DESC`) — not re-sorted client-side.
- `lib/audit-outcome.ts` (new): shared outcome→pill variant/label mapping.
  `ArchiveDetail.tsx`/`AuditLog.tsx` each keep their own copy (documented as
  intentional at 1-extra-caller); this is the 3rd caller, crossing the
  "extract on 2nd+ consumer" threshold, so new callers should use this
  instead of a 4th copy. Existing files are untouched (out of scope/owned by
  another concurrent change).
- `ProjectLifecycleStepper.tsx`: renders the trail via `Table`/`EmptyState`/
  `Skeleton`, same idiom as `ArchiveDetail.tsx`.
- **`projectId` is optional and falls back to the `/shell/projects` route's
  `selected` search param.** `ProjectDetail.tsx` (mid-split, #998) is
  off-limits for edits, and its only call site (`:638`) doesn't pass the id
  explicitly. The fallback reads the same id source `ProjectDetail.tsx:176`
  already uses (`useProjectDetail(projectId)`). Follow-up once #998 lands:
  thread `projectId` through explicitly and drop the fallback.
- Updated the `ProjectDetail.*.test.tsx` files that render without a router
  context: added `useSearch`/`useProjectHistory` stubs (matching each file's
  existing `useProjectDetail` stubbing pattern) so they don't need a
  `QueryClientProvider` or `RouterProvider`.

## Verification

- `pnpm vitest run` (full desktop suite): 191 files / 1776 tests passed.
- `pnpm typecheck`: clean.
- `just lint` (biome, eslint, token policy, i18n catalog): clean, same
  pre-existing warning baseline as `main`.