### PR TITLE
fix: surface destination free-space estimate at plan review time

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -2459,6 +2459,8 @@
   "plans_review_load_error": "Could not load the plan.",
   "plans_review_no_mutation_note": "Nothing has been changed on disk. Review every proposed item below; applying requires explicit approval.",
   "plans_review_bytes_required": "Requires {size} at the destination.",
+  "plans_review_free_space_available": "{size} free at the destination.",
+  "plans_review_free_space_insufficient": "The destination may not have enough free space: {required} required, only {available} free.",
   "plans_review_col_item": "Item",
   "plans_review_col_action": "Action",
   "plans_review_col_from": "Source path",

--- a/apps/desktop/src-tauri/src/commands/plans.rs
+++ b/apps/desktop/src-tauri/src/commands/plans.rs
@@ -18,9 +18,10 @@
 use app_core::archive_generator::{
     generate as generate_archive_plan, generate_restore as generate_restore_plan, list_archived,
 };
+use app_core::plan_free_space::estimate_free_space;
 use app_core::plans::{
-    approve_plan, discard_plan, estimate_free_space, get_plan, list_plans,
-    permanently_delete_archive, retry_plan, send_archive_to_trash,
+    approve_plan, discard_plan, get_plan, list_plans, permanently_delete_archive, retry_plan,
+    send_archive_to_trash,
 };
 use contracts_core::archive::{
     ArchiveListResponse, GenerateArchivePlanResult, GenerateRestorePlanResult,

--- a/apps/desktop/src-tauri/src/commands/plans.rs
+++ b/apps/desktop/src-tauri/src/commands/plans.rs
@@ -19,15 +19,16 @@ use app_core::archive_generator::{
     generate as generate_archive_plan, generate_restore as generate_restore_plan, list_archived,
 };
 use app_core::plans::{
-    approve_plan, discard_plan, get_plan, list_plans, permanently_delete_archive, retry_plan,
-    send_archive_to_trash,
+    approve_plan, discard_plan, estimate_free_space, get_plan, list_plans,
+    permanently_delete_archive, retry_plan, send_archive_to_trash,
 };
 use contracts_core::archive::{
     ArchiveListResponse, GenerateArchivePlanResult, GenerateRestorePlanResult,
 };
 use contracts_core::plans::{
     ArchivePermanentlyDeleteResponse, ArchiveSendToTrashResponse, PlanApproveResponse, PlanDetail,
-    PlanDiscardResponse, PlanListRequest, PlanListResponse, PlanRetryResponse, RetryItemsFilter,
+    PlanDiscardResponse, PlanFreeSpaceEstimate, PlanListRequest, PlanListResponse,
+    PlanRetryResponse, RetryItemsFilter,
 };
 use tauri::State;
 
@@ -68,6 +69,24 @@ pub async fn plans_get(
     id: String,
 ) -> Result<PlanDetail, ContractError> {
     get_plan(state.repo.pool(), &id).await
+}
+
+// ── plans.free_space_estimate ─────────────────────────────────────────────────
+
+/// `plans.free_space_estimate` — advisory destination free-space estimate for
+/// a plan under review, before approval (issue #876). Never blocks approval;
+/// see `app_core::plans::estimate_free_space`.
+///
+/// # Errors
+///
+/// Returns `Err(String)` with `"plan.not_found"` if the plan does not exist.
+#[tauri::command]
+#[specta::specta]
+pub async fn plans_free_space_estimate(
+    state: State<'_, AppState>,
+    id: String,
+) -> Result<PlanFreeSpaceEstimate, ContractError> {
+    estimate_free_space(state.repo.pool(), &id).await
 }
 
 // ── plans.approve ─────────────────────────────────────────────────────────────

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -86,7 +86,8 @@ use crate::commands::plan_apply::{
 };
 use crate::commands::plans::{
     archive_list, archive_permanently_delete, archive_plan_generate, archive_plan_generate_restore,
-    archive_send_to_trash, plans_approve, plans_discard, plans_get, plans_list, plans_retry,
+    archive_send_to_trash, plans_approve, plans_discard, plans_free_space_estimate, plans_get,
+    plans_list, plans_retry,
 };
 use crate::commands::preferences::{preferences_get, preferences_set};
 use crate::commands::prepared_views::{
@@ -263,6 +264,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // plans (spec 017)
         plans_list,
         plans_get,
+        plans_free_space_estimate,
         plans_approve,
         plans_discard,
         plans_retry,
@@ -513,6 +515,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // plans (spec 017)
         plans_list,
         plans_get,
+        plans_free_space_estimate,
         plans_approve,
         plans_discard,
         plans_retry,

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1194,6 +1194,17 @@ export async function mockInvoke(
       const { planDetail } = await import('@/data/fixtures/plans');
       return planDetail;
     }
+    case 'plans_free_space_estimate': {
+      // Issue #876: advisory destination free-space estimate. Mock mode has
+      // no real filesystem to probe — report comfortably more free space
+      // than the fixture plan requires so the mock UI shows the healthy
+      // (non-warning) state by default.
+      const { planDetail } = await import('@/data/fixtures/plans');
+      return {
+        requiredBytes: planDetail.totalBytesRequired,
+        availableBytes: planDetail.totalBytesRequired + 10_000_000_000,
+      };
+    }
     case 'audit_list': {
       const args = _args as
         | {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -618,6 +618,16 @@ export const commands = {
 	 */
 	plansGet: (id: string) => typedError<PlanDetail_Serialize, ContractError_Serialize>(__TAURI_INVOKE("plans_get", { id })),
 	/**
+	 *  `plans.free_space_estimate` — advisory destination free-space estimate for
+	 *  a plan under review, before approval (issue #876). Never blocks approval;
+	 *  see `app_core::plans::estimate_free_space`.
+	 * 
+	 *  # Errors
+	 * 
+	 *  Returns `Err(String)` with `"plan.not_found"` if the plan does not exist.
+	 */
+	plansFreeSpaceEstimate: (id: string) => typedError<PlanFreeSpaceEstimate_Serialize, ContractError_Serialize>(__TAURI_INVOKE("plans_free_space_estimate", { id })),
+	/**
 	 *  `plans.approve` — move a plan to `approved`; snapshot item FS metadata (US3, T025).
 	 * 
 	 *  # Errors
@@ -6995,6 +7005,64 @@ export type PlanDetail_Serialize = {
 export type PlanDiscardResponse = {
 	planId: string,
 	discardedAt: string,
+};
+
+/**
+ *  Response for `plans.free_space_estimate` (issue #876): an ADVISORY
+ *  destination free-space estimate surfaced at plan review time, before
+ *  approval. Never blocks approval — `crates/fs/executor/src/ops/volume_check.rs`
+ *  still re-validates for real and pauses the apply run (R-Pause-1) if the
+ *  destination genuinely runs out; this is only a heads-up so the user isn't
+ *  first told about a space problem after already approving the plan.
+ */
+export type PlanFreeSpaceEstimate = PlanFreeSpaceEstimate_Serialize | PlanFreeSpaceEstimate_Deserialize;
+
+/**
+ *  Response for `plans.free_space_estimate` (issue #876): an ADVISORY
+ *  destination free-space estimate surfaced at plan review time, before
+ *  approval. Never blocks approval — `crates/fs/executor/src/ops/volume_check.rs`
+ *  still re-validates for real and pauses the apply run (R-Pause-1) if the
+ *  destination genuinely runs out; this is only a heads-up so the user isn't
+ *  first told about a space problem after already approving the plan.
+ */
+export type PlanFreeSpaceEstimate_Deserialize = {
+	/**
+	 *  Same value as `PlanDetail::total_bytes_required` (0 for e.g. an
+	 *  all-trash/all-delete plan, which needs no destination space).
+	 */
+	requiredBytes: number,
+	/**
+	 *  Free bytes on the destination volume, probed via
+	 *  `fs_executor::ops::available_space_bytes`. `None` when the plan has no
+	 *  items to probe a destination from, or the probe itself fails (e.g. the
+	 *  volume is momentarily unreachable) — the UI shows no comparison rather
+	 *  than a false warning in that case.
+	 */
+	availableBytes: number | null,
+};
+
+/**
+ *  Response for `plans.free_space_estimate` (issue #876): an ADVISORY
+ *  destination free-space estimate surfaced at plan review time, before
+ *  approval. Never blocks approval — `crates/fs/executor/src/ops/volume_check.rs`
+ *  still re-validates for real and pauses the apply run (R-Pause-1) if the
+ *  destination genuinely runs out; this is only a heads-up so the user isn't
+ *  first told about a space problem after already approving the plan.
+ */
+export type PlanFreeSpaceEstimate_Serialize = {
+	/**
+	 *  Same value as `PlanDetail::total_bytes_required` (0 for e.g. an
+	 *  all-trash/all-delete plan, which needs no destination space).
+	 */
+	requiredBytes: number,
+	/**
+	 *  Free bytes on the destination volume, probed via
+	 *  `fs_executor::ops::available_space_bytes`. `None` when the plan has no
+	 *  items to probe a destination from, or the probe itself fails (e.g. the
+	 *  volume is momentarily unreachable) — the UI shows no comparison rather
+	 *  than a false warning in that case.
+	 */
+	availableBytes?: number | null,
 };
 
 /**  Action to perform on a single filesystem item. */

--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -65,6 +65,8 @@ export const queryKeys = {
   },
   plans: {
     detail: (id: string) => ['plans', 'detail', id] as const,
+    freeSpaceEstimate: (id: string) =>
+      ['plans', 'freeSpaceEstimate', id] as const,
   },
   roots: {
     all: () => ['roots'] as const,

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -35,6 +35,7 @@ const {
   mockPlansApplyStatus,
   mockPlansCancel,
   mockPlansConfirmDestructive,
+  mockPlansFreeSpaceEstimate,
   mockProtectionCheck,
   mockAcknowledge,
   mockApplyPlan,
@@ -47,6 +48,7 @@ const {
   mockPlansApplyStatus: vi.fn(),
   mockPlansCancel: vi.fn(),
   mockPlansConfirmDestructive: vi.fn(),
+  mockPlansFreeSpaceEstimate: vi.fn(),
   mockProtectionCheck: vi.fn(),
   mockAcknowledge: vi.fn(),
   mockApplyPlan: vi.fn(),
@@ -62,6 +64,7 @@ vi.mock('@/bindings/index', () => ({
     plansApplyStatus: mockPlansApplyStatus,
     plansCancel: mockPlansCancel,
     plansConfirmDestructive: mockPlansConfirmDestructive,
+    plansFreeSpaceEstimate: mockPlansFreeSpaceEstimate,
     planProtectionCheckCmd: mockProtectionCheck,
     protectionPlanAcknowledged: mockAcknowledge,
   },
@@ -196,6 +199,9 @@ beforeEach(() => {
   );
   mockPlansConfirmDestructive.mockResolvedValue(
     ok({ planId: 'plan-1', itemsConfirmed: 1 }),
+  );
+  mockPlansFreeSpaceEstimate.mockResolvedValue(
+    ok({ requiredBytes: 3000, availableBytes: 5000 }),
   );
   // Default apply: streams item events then a completed terminal event.
   mockApplyPlan.mockImplementation(
@@ -777,6 +783,56 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
     if (expectedAction !== 'Close') {
       expect(screen.getByText('Close')).toBeInTheDocument();
     }
+  });
+
+  // #876: a destination free-space estimate, surfaced at review time before
+  // approval, rather than only discovering insufficient space after apply.
+  it('#876: shows the free-space estimate when the destination has enough room', async () => {
+    mockPlansFreeSpaceEstimate.mockResolvedValue(
+      ok({ requiredBytes: 3000, availableBytes: 50_000 }),
+    );
+    renderOverlay();
+    const banner = await screen.findByTestId('plan-review-free-space');
+    expect(banner).toHaveTextContent('free at the destination');
+    expect(banner).not.toHaveTextContent('may not have enough free space');
+  });
+
+  it('#876: warns when the destination free-space estimate is insufficient, without disabling approval', async () => {
+    mockPlansFreeSpaceEstimate.mockResolvedValue(
+      ok({ requiredBytes: 3000, availableBytes: 1000 }),
+    );
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    renderOverlay();
+
+    const banner = await screen.findByTestId('plan-review-free-space');
+    expect(banner).toHaveTextContent('may not have enough free space');
+
+    // Advisory only — never gates "Approve & apply".
+    const approveBtn = await screen.findByTestId('plan-review-approve-apply');
+    await waitFor(() => expect(approveBtn).not.toBeDisabled());
+  });
+
+  it('#876: renders no free-space banner for a zero-item plan (nothing to probe a destination from)', async () => {
+    mockPlansGet.mockResolvedValue(
+      ok(plan({ items: [], itemsTotal: 0, itemsPending: 0 })),
+    );
+    mockProtectionCheck.mockResolvedValue(
+      ok(
+        protectionCheck({
+          hasProtectedItems: false,
+          protectedItems: [],
+          nonBlockingSummary: { normalCount: 0, unprotectedCount: 0 },
+        }),
+      ),
+    );
+    renderOverlay();
+    await screen.findByText(/No protected items/);
+    expect(mockPlansFreeSpaceEstimate).not.toHaveBeenCalled();
+    expect(
+      screen.queryByTestId('plan-review-free-space'),
+    ).not.toBeInTheDocument();
   });
 
   it('retries a reopened cancelled plan\'s cancelled items, not "failed" (issue #733)', async () => {

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -814,6 +814,26 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
     await waitFor(() => expect(approveBtn).not.toBeDisabled());
   });
 
+  it('#876: renders no free-space banner when the probe returns availableBytes: null (unreachable/unprobeable destination)', async () => {
+    mockPlansFreeSpaceEstimate.mockResolvedValue(
+      ok({ requiredBytes: 3000, availableBytes: null }),
+    );
+    mockProtectionCheck.mockResolvedValue(
+      ok(protectionCheck({ hasProtectedItems: false, protectedItems: [] })),
+    );
+    renderOverlay();
+
+    await waitFor(() =>
+      expect(mockPlansFreeSpaceEstimate).toHaveBeenCalledWith('plan-1'),
+    );
+    // Give the item table (which always renders) time to settle so this
+    // isn't just "banner hasn't appeared yet".
+    await screen.findByText('light_001.xisf');
+    expect(
+      screen.queryByTestId('plan-review-free-space'),
+    ).not.toBeInTheDocument();
+  });
+
   it('#876: renders no free-space banner for a zero-item plan (nothing to probe a destination from)', async () => {
     mockPlansGet.mockResolvedValue(
       ok(plan({ items: [], itemsTotal: 0, itemsPending: 0 })),

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.tsx
@@ -142,6 +142,21 @@ export function PlanReviewOverlay({
     enabled: open && planId !== null,
   });
 
+  // Advisory destination free-space estimate (issue #876) — surfaced at
+  // review time, before approval; never gates "Approve & apply" (that
+  // decision belongs to `recheck_disk_space`'s real R-Pause-1 apply-time
+  // check, not this estimate). Only fetched once the plan itself has items to
+  // probe a destination from.
+  const { data: freeSpace } = useQuery({
+    queryKey: queryKeys.plans.freeSpaceEstimate(planId ?? ''),
+    queryFn: async () =>
+      unwrap(await commands.plansFreeSpaceEstimate(planId as string)),
+    enabled: open && planId !== null && (plan?.itemsTotal ?? 0) > 0,
+  });
+  const freeSpaceInsufficient =
+    freeSpace?.availableBytes != null &&
+    freeSpace.availableBytes < freeSpace.requiredBytes;
+
   // Protection gate readiness (spec 016 US3): the gate signals true when every
   // protected item is acknowledged — or immediately when none are protected.
   const [gateReady, setGateReady] = useState(false);
@@ -504,6 +519,26 @@ export function PlanReviewOverlay({
             {plan.totalBytesRequired > 0 &&
               ` ${m.plans_review_bytes_required({ size: formatBytes(plan.totalBytesRequired) })}`}
           </Banner>
+
+          {/* #876: destination free-space estimate, before approval. Advisory
+              only — a warning here never disables "Approve & apply"; the real
+              gate is the apply-time `recheck_disk_space` pre-flight. */}
+          {freeSpace?.availableBytes != null && (
+            <Banner
+              variant={freeSpaceInsufficient ? 'warn' : 'info'}
+              role="status"
+              data-testid="plan-review-free-space"
+            >
+              {freeSpaceInsufficient
+                ? m.plans_review_free_space_insufficient({
+                    required: formatBytes(freeSpace.requiredBytes),
+                    available: formatBytes(freeSpace.availableBytes),
+                  })
+                : m.plans_review_free_space_available({
+                    size: formatBytes(freeSpace.availableBytes),
+                  })}
+            </Banner>
+          )}
 
           {/* #603: a 0-item plan otherwise dead-ends on a disabled
               "Approve & apply" with no explanation — render the generator's

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -95,6 +95,10 @@ pub mod native;
 pub mod path_set;
 pub mod patterns;
 pub mod plan_apply;
+/// `plans.free_space_estimate` (issue #876) — split out of `plans.rs` to stay
+/// clear of the in-flight #979 split on that file; depends only on
+/// `plans::get_plan`.
+pub mod plan_free_space;
 pub mod plans;
 /// Project-create orchestration (create + mkdir-only scaffolding auto-apply,
 /// user decision 2026-07-04). Lives in `app_core` (not `app_core_projects`)

--- a/crates/app/core/src/plan_free_space.rs
+++ b/crates/app/core/src/plan_free_space.rs
@@ -19,16 +19,24 @@ use crate::plans::get_plan;
 
 /// Every item's `from` field is the item's real, currently-present source
 /// path (for cleanup/archive plans, the on-disk file being archived/deleted);
-/// `compute_archive_destination` (`protection.rs`) always anchors an
-/// archive's actual destination on that same source file's own parent
-/// directory, so probing free space from the first item's source parent is
-/// the same volume any archive-action item would actually land on — without
-/// requiring the (not-yet-created) `.astro-plan-archive/<planId>/` directory
-/// itself to exist.
+/// `compute_archive_destination` (`protection.rs`) always anchors an item's
+/// archive destination on that same source file's own parent directory —
+/// but a plan is NOT guaranteed to be single-volume: items can come from
+/// different source roots (e.g. `generate_raw_frame_plan` allows
+/// cross-root selection), each anchoring its own archive destination on a
+/// different volume. Probing only the first item would silently ignore a
+/// too-full second volume, so this collects every DISTINCT source-parent
+/// directory across the plan's items, probes each, and reports the MINIMUM
+/// free space of the volumes that answered — the estimate reflects
+/// whichever destination volume is tightest, not just the first one — all
+/// without requiring the (not-yet-created) `.astro-plan-archive/<planId>/`
+/// directory itself to exist.
 ///
 /// Never a hard gate (constitution II leaves approval to the user): a probe
-/// failure or an empty plan returns `available_bytes: None` rather than an
-/// error, and the real, authoritative check remains the apply-time
+/// failure on every distinct directory, or an empty plan, returns
+/// `available_bytes: None` rather than an error — individual per-directory
+/// probe failures are otherwise skipped rather than failing the whole
+/// estimate, since the real, authoritative check remains the apply-time
 /// `recheck_disk_space` (R-Pause-1).
 ///
 /// # Errors
@@ -40,11 +48,18 @@ pub async fn estimate_free_space(
 ) -> Result<PlanFreeSpaceEstimate, ContractError> {
     let detail = get_plan(pool, plan_id).await?;
 
-    let available_bytes = detail
+    let mut parent_dirs: Vec<Utf8PathBuf> = detail
         .items
-        .first()
-        .and_then(|item| Utf8PathBuf::from(&item.from).parent().map(Utf8PathBuf::from))
-        .and_then(|dir| available_space_bytes(&dir).ok())
+        .iter()
+        .filter_map(|item| Utf8PathBuf::from(&item.from).parent().map(Utf8PathBuf::from))
+        .collect();
+    parent_dirs.sort();
+    parent_dirs.dedup();
+
+    let available_bytes = parent_dirs
+        .iter()
+        .filter_map(|dir| available_space_bytes(dir).ok())
+        .min()
         .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX));
 
     Ok(PlanFreeSpaceEstimate { required_bytes: detail.total_bytes_required, available_bytes })
@@ -125,26 +140,26 @@ mod tests {
         assert_eq!(estimate.available_bytes, None, "nothing to probe a destination from");
     }
 
-    #[tokio::test]
-    async fn estimate_free_space_probes_the_first_items_source_parent_directory() {
-        let (db, _bus) = setup().await;
-        insert_draft(&db, "p1").await;
-        // Real filesystem path (a temp dir) so the probe succeeds — mirrors
-        // how a real cleanup/archive item's `from_relative_path` is always an
-        // absolute, currently-present source path (`processing_artifacts.path`).
-        let dir = tempfile::tempdir().unwrap();
-        let source = dir.path().join("file.fits");
-        let source_str = source.to_str().unwrap();
+    /// Helper to insert an item whose `from_relative_path` is an absolute,
+    /// real filesystem path so the probe can succeed — mirrors how a real
+    /// cleanup/archive item's source path is always absolute and currently
+    /// present (`processing_artifacts.path`).
+    async fn add_item_with_real_source_path(
+        db: &Database,
+        plan_id: &str,
+        item_id: &str,
+        source_path: &str,
+    ) {
         repo::insert_plan_item(
             db.pool(),
             &repo::InsertPlanItem {
-                id: "item-1",
-                plan_id: "p1",
+                id: item_id,
+                plan_id,
                 item_index: 1,
                 name: "file.fits",
                 action: "archive",
                 from_root_id: None,
-                from_relative_path: source_str,
+                from_relative_path: source_path,
                 to_root_id: None,
                 to_relative_path: "",
                 reason: "test",
@@ -158,6 +173,15 @@ mod tests {
         )
         .await
         .unwrap();
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_probes_the_items_source_parent_directory() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("file.fits");
+        add_item_with_real_source_path(&db, "p1", "item-1", source.to_str().unwrap()).await;
 
         let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
         assert!(
@@ -174,5 +198,31 @@ mod tests {
 
         let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
         assert_eq!(estimate.available_bytes, None, "relative path has no real parent to probe");
+    }
+
+    /// A plan can legitimately span volumes: each item anchors its own
+    /// archive destination on its own source parent (`compute_archive_destination`),
+    /// and cross-root selection is allowed (e.g. `generate_raw_frame_plan`).
+    /// `item-1`'s parent is unreachable (a relative path, same as the
+    /// unreachable-parent test above) and `item-2`'s is a real, distinct
+    /// directory. A regression that only probed the FIRST item would report
+    /// `None` here (item-1's probe fails and nothing else is tried); the
+    /// fixed behaviour collects every distinct parent directory across all
+    /// items, so item-2's real directory still answers.
+    #[tokio::test]
+    async fn estimate_free_space_probes_every_distinct_parent_directory_not_just_the_first() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+        add_item(&db, "p1", "item-1", "archive").await; // from_relative_path: "raw/file.fits"
+        let dir = tempfile::tempdir().unwrap();
+        let second_source = dir.path().join("file.fits");
+        add_item_with_real_source_path(&db, "p1", "item-2", second_source.to_str().unwrap()).await;
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert!(
+            estimate.available_bytes.is_some_and(|b| b > 0),
+            "item-2's real, distinct parent directory must still be probed even though \
+             item-1's parent (a different directory) is unreachable"
+        );
     }
 }

--- a/crates/app/core/src/plan_free_space.rs
+++ b/crates/app/core/src/plan_free_space.rs
@@ -1,0 +1,178 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `plans.free_space_estimate` (issue #876) — an advisory destination
+//! free-space read at plan review time, before approval.
+//!
+//! Kept in its own sibling module rather than in `plans.rs`: issue #979 is
+//! splitting `plans.rs` on another in-flight branch, and this module has no
+//! dependency on that split landing first (it only calls the already-public
+//! `plans::get_plan`).
+
+use camino::Utf8PathBuf;
+use contracts_core::plans::PlanFreeSpaceEstimate;
+use contracts_core::ContractError;
+use fs_executor::ops::available_space_bytes;
+use sqlx::SqlitePool;
+
+use crate::plans::get_plan;
+
+/// Every item's `from` field is the item's real, currently-present source
+/// path (for cleanup/archive plans, the on-disk file being archived/deleted);
+/// `compute_archive_destination` (`protection.rs`) always anchors an
+/// archive's actual destination on that same source file's own parent
+/// directory, so probing free space from the first item's source parent is
+/// the same volume any archive-action item would actually land on — without
+/// requiring the (not-yet-created) `.astro-plan-archive/<planId>/` directory
+/// itself to exist.
+///
+/// Never a hard gate (constitution II leaves approval to the user): a probe
+/// failure or an empty plan returns `available_bytes: None` rather than an
+/// error, and the real, authoritative check remains the apply-time
+/// `recheck_disk_space` (R-Pause-1).
+///
+/// # Errors
+///
+/// Returns `ContractError` with `"plan.not_found"` if the plan does not exist.
+pub async fn estimate_free_space(
+    pool: &SqlitePool,
+    plan_id: &str,
+) -> Result<PlanFreeSpaceEstimate, ContractError> {
+    let detail = get_plan(pool, plan_id).await?;
+
+    let available_bytes = detail
+        .items
+        .first()
+        .and_then(|item| Utf8PathBuf::from(&item.from).parent().map(Utf8PathBuf::from))
+        .and_then(|dir| available_space_bytes(&dir).ok())
+        .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX));
+
+    Ok(PlanFreeSpaceEstimate { required_bytes: detail.total_bytes_required, available_bytes })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use audit::EventBus;
+    use contracts_core::error_code::ErrorCode;
+    use persistence_db::{repositories::plans as repo, Database};
+
+    async fn setup() -> (Database, EventBus) {
+        let db = Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        let bus = EventBus::with_pool(db.pool().clone());
+        (db, bus)
+    }
+
+    async fn insert_draft(db: &Database, id: &str) {
+        repo::insert_plan(
+            db.pool(),
+            &repo::InsertPlan {
+                id,
+                title: "Test",
+                origin: "cleanup",
+                origin_path: None,
+                plan_type: "cleanup",
+                destructive_destination: "archive",
+                parent_plan_id: None,
+                total_bytes_required: 0,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    async fn add_item(db: &Database, plan_id: &str, item_id: &str, action: &str) {
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: item_id,
+                plan_id,
+                item_index: 1,
+                name: "file.fits",
+                action,
+                from_root_id: None,
+                from_relative_path: "raw/file.fits",
+                to_root_id: None,
+                to_relative_path: "archive/file.fits",
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: Some(".astro-plan-archive/p1/file.fits"),
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_not_found_for_missing_plan() {
+        let (db, _bus) = setup().await;
+        let err = estimate_free_space(db.pool(), "does-not-exist").await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::PlanNotFound);
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_returns_none_for_a_zero_item_plan() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert_eq!(estimate.required_bytes, 0);
+        assert_eq!(estimate.available_bytes, None, "nothing to probe a destination from");
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_probes_the_first_items_source_parent_directory() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+        // Real filesystem path (a temp dir) so the probe succeeds — mirrors
+        // how a real cleanup/archive item's `from_relative_path` is always an
+        // absolute, currently-present source path (`processing_artifacts.path`).
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("file.fits");
+        let source_str = source.to_str().unwrap();
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: "item-1",
+                plan_id: "p1",
+                item_index: 1,
+                name: "file.fits",
+                action: "archive",
+                from_root_id: None,
+                from_relative_path: source_str,
+                to_root_id: None,
+                to_relative_path: "",
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert!(
+            estimate.available_bytes.is_some_and(|b| b > 0),
+            "a real volume must report nonzero free space"
+        );
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_returns_none_when_the_source_parent_is_unreachable() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+        add_item(&db, "p1", "item-1", "archive").await; // from_relative_path: "raw/file.fits"
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert_eq!(estimate.available_bytes, None, "relative path has no real parent to probe");
+    }
+}

--- a/crates/app/core/src/plans.rs
+++ b/crates/app/core/src/plans.rs
@@ -33,15 +33,15 @@ use camino::Utf8PathBuf;
 use contracts_core::lifecycle::PlanState;
 use contracts_core::plans::{
     ArchivePermanentlyDeleteResponse, ArchiveSendToTrashResponse, DestructiveDestination,
-    PlanApproveResponse, PlanDetail, PlanDiscardResponse, PlanFreeSpaceEstimate, PlanItemAction,
-    PlanItemDetail, PlanItemProtection, PlanItemState, PlanListRequest, PlanListResponse,
-    PlanOrigin, PlanRetryResponse, PlanSummary, PlanType, RetryItemsFilter,
+    PlanApproveResponse, PlanDetail, PlanDiscardResponse, PlanItemAction, PlanItemDetail,
+    PlanItemProtection, PlanItemState, PlanListRequest, PlanListResponse, PlanOrigin,
+    PlanRetryResponse, PlanSummary, PlanType, RetryItemsFilter,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::{new_id, Timestamp};
 use fs_executor::failure::FailureCode;
 use fs_executor::ops::cas_check::snapshot_from_metadata;
-use fs_executor::ops::{available_space_bytes, delete_op, trash_op};
+use fs_executor::ops::{delete_op, trash_op};
 use persistence_db::repositories::plans as repo;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
@@ -300,44 +300,6 @@ pub async fn get_plan(pool: &SqlitePool, plan_id: &str) -> Result<PlanDetail, Co
         created_at: row.created_at,
         items: item_rows.into_iter().map(item_row_to_detail).collect(),
     })
-}
-
-// ── estimate_free_space ───────────────────────────────────────────────────────
-
-/// `plans.free_space_estimate` (issue #876) — an advisory destination
-/// free-space read at plan review time, before approval.
-///
-/// Every item's `from` field is the item's real, currently-present source
-/// path (for cleanup/archive plans, the on-disk file being archived/deleted);
-/// `compute_archive_destination` (`protection.rs`) always anchors an
-/// archive's actual destination on that same source file's own parent
-/// directory, so probing free space from the first item's source parent is
-/// the same volume any archive-action item would actually land on — without
-/// requiring the (not-yet-created) `.astro-plan-archive/<planId>/` directory
-/// itself to exist.
-///
-/// Never a hard gate (constitution II leaves approval to the user): a probe
-/// failure or an empty plan returns `available_bytes: None` rather than an
-/// error, and the real, authoritative check remains the apply-time
-/// `recheck_disk_space` (R-Pause-1).
-///
-/// # Errors
-///
-/// Returns `ContractError` with `"plan.not_found"` if the plan does not exist.
-pub async fn estimate_free_space(
-    pool: &SqlitePool,
-    plan_id: &str,
-) -> Result<PlanFreeSpaceEstimate, ContractError> {
-    let detail = get_plan(pool, plan_id).await?;
-
-    let available_bytes = detail
-        .items
-        .first()
-        .and_then(|item| Utf8PathBuf::from(&item.from).parent().map(Utf8PathBuf::from))
-        .and_then(|dir| available_space_bytes(&dir).ok())
-        .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX));
-
-    Ok(PlanFreeSpaceEstimate { required_bytes: detail.total_bytes_required, available_bytes })
 }
 
 // ── approve_plan ──────────────────────────────────────────────────────────────
@@ -1137,76 +1099,6 @@ mod tests {
         assert_eq!(detail.id, "p1");
         assert_eq!(detail.items.len(), 1);
         assert_eq!(detail.items[0].name, "file.fits");
-    }
-
-    // ── estimate_free_space (issue #876) ─────────────────────────────────────
-
-    #[tokio::test]
-    async fn estimate_free_space_not_found_for_missing_plan() {
-        let (db, _bus) = setup().await;
-        let err = estimate_free_space(db.pool(), "does-not-exist").await.unwrap_err();
-        assert_eq!(err.code, ErrorCode::PlanNotFound);
-    }
-
-    #[tokio::test]
-    async fn estimate_free_space_returns_none_for_a_zero_item_plan() {
-        let (db, _bus) = setup().await;
-        insert_draft(&db, "p1").await;
-
-        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
-        assert_eq!(estimate.required_bytes, 0);
-        assert_eq!(estimate.available_bytes, None, "nothing to probe a destination from");
-    }
-
-    #[tokio::test]
-    async fn estimate_free_space_probes_the_first_items_source_parent_directory() {
-        let (db, _bus) = setup().await;
-        insert_draft(&db, "p1").await;
-        // Real filesystem path (a temp dir) so the probe succeeds — mirrors
-        // how a real cleanup/archive item's `from_relative_path` is always an
-        // absolute, currently-present source path (`processing_artifacts.path`).
-        let dir = tempfile::tempdir().unwrap();
-        let source = dir.path().join("file.fits");
-        let source_str = source.to_str().unwrap();
-        repo::insert_plan_item(
-            db.pool(),
-            &repo::InsertPlanItem {
-                id: "item-1",
-                plan_id: "p1",
-                item_index: 1,
-                name: "file.fits",
-                action: "archive",
-                from_root_id: None,
-                from_relative_path: source_str,
-                to_root_id: None,
-                to_relative_path: "",
-                reason: "test",
-                protection: "normal",
-                linked_entity: None,
-                provenance_json: None,
-                archive_path: None,
-                source_id: None,
-                category: None,
-            },
-        )
-        .await
-        .unwrap();
-
-        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
-        assert!(
-            estimate.available_bytes.is_some_and(|b| b > 0),
-            "a real volume must report nonzero free space"
-        );
-    }
-
-    #[tokio::test]
-    async fn estimate_free_space_returns_none_when_the_source_parent_is_unreachable() {
-        let (db, _bus) = setup().await;
-        insert_draft(&db, "p1").await;
-        add_item(&db, "p1", "item-1", "archive").await; // from_relative_path: "raw/file.fits"
-
-        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
-        assert_eq!(estimate.available_bytes, None, "relative path has no real parent to probe");
     }
 
     // ── parse_plan_state (audit T1-b) ────────────────────────────────────────

--- a/crates/app/core/src/plans.rs
+++ b/crates/app/core/src/plans.rs
@@ -33,15 +33,15 @@ use camino::Utf8PathBuf;
 use contracts_core::lifecycle::PlanState;
 use contracts_core::plans::{
     ArchivePermanentlyDeleteResponse, ArchiveSendToTrashResponse, DestructiveDestination,
-    PlanApproveResponse, PlanDetail, PlanDiscardResponse, PlanItemAction, PlanItemDetail,
-    PlanItemProtection, PlanItemState, PlanListRequest, PlanListResponse, PlanOrigin,
-    PlanRetryResponse, PlanSummary, PlanType, RetryItemsFilter,
+    PlanApproveResponse, PlanDetail, PlanDiscardResponse, PlanFreeSpaceEstimate, PlanItemAction,
+    PlanItemDetail, PlanItemProtection, PlanItemState, PlanListRequest, PlanListResponse,
+    PlanOrigin, PlanRetryResponse, PlanSummary, PlanType, RetryItemsFilter,
 };
 use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
 use domain_core::ids::{new_id, Timestamp};
 use fs_executor::failure::FailureCode;
 use fs_executor::ops::cas_check::snapshot_from_metadata;
-use fs_executor::ops::{delete_op, trash_op};
+use fs_executor::ops::{available_space_bytes, delete_op, trash_op};
 use persistence_db::repositories::plans as repo;
 use sqlx::SqlitePool;
 use std::collections::HashMap;
@@ -300,6 +300,44 @@ pub async fn get_plan(pool: &SqlitePool, plan_id: &str) -> Result<PlanDetail, Co
         created_at: row.created_at,
         items: item_rows.into_iter().map(item_row_to_detail).collect(),
     })
+}
+
+// ── estimate_free_space ───────────────────────────────────────────────────────
+
+/// `plans.free_space_estimate` (issue #876) — an advisory destination
+/// free-space read at plan review time, before approval.
+///
+/// Every item's `from` field is the item's real, currently-present source
+/// path (for cleanup/archive plans, the on-disk file being archived/deleted);
+/// `compute_archive_destination` (`protection.rs`) always anchors an
+/// archive's actual destination on that same source file's own parent
+/// directory, so probing free space from the first item's source parent is
+/// the same volume any archive-action item would actually land on — without
+/// requiring the (not-yet-created) `.astro-plan-archive/<planId>/` directory
+/// itself to exist.
+///
+/// Never a hard gate (constitution II leaves approval to the user): a probe
+/// failure or an empty plan returns `available_bytes: None` rather than an
+/// error, and the real, authoritative check remains the apply-time
+/// `recheck_disk_space` (R-Pause-1).
+///
+/// # Errors
+///
+/// Returns `ContractError` with `"plan.not_found"` if the plan does not exist.
+pub async fn estimate_free_space(
+    pool: &SqlitePool,
+    plan_id: &str,
+) -> Result<PlanFreeSpaceEstimate, ContractError> {
+    let detail = get_plan(pool, plan_id).await?;
+
+    let available_bytes = detail
+        .items
+        .first()
+        .and_then(|item| Utf8PathBuf::from(&item.from).parent().map(Utf8PathBuf::from))
+        .and_then(|dir| available_space_bytes(&dir).ok())
+        .map(|bytes| i64::try_from(bytes).unwrap_or(i64::MAX));
+
+    Ok(PlanFreeSpaceEstimate { required_bytes: detail.total_bytes_required, available_bytes })
 }
 
 // ── approve_plan ──────────────────────────────────────────────────────────────
@@ -1099,6 +1137,76 @@ mod tests {
         assert_eq!(detail.id, "p1");
         assert_eq!(detail.items.len(), 1);
         assert_eq!(detail.items[0].name, "file.fits");
+    }
+
+    // ── estimate_free_space (issue #876) ─────────────────────────────────────
+
+    #[tokio::test]
+    async fn estimate_free_space_not_found_for_missing_plan() {
+        let (db, _bus) = setup().await;
+        let err = estimate_free_space(db.pool(), "does-not-exist").await.unwrap_err();
+        assert_eq!(err.code, ErrorCode::PlanNotFound);
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_returns_none_for_a_zero_item_plan() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert_eq!(estimate.required_bytes, 0);
+        assert_eq!(estimate.available_bytes, None, "nothing to probe a destination from");
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_probes_the_first_items_source_parent_directory() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+        // Real filesystem path (a temp dir) so the probe succeeds — mirrors
+        // how a real cleanup/archive item's `from_relative_path` is always an
+        // absolute, currently-present source path (`processing_artifacts.path`).
+        let dir = tempfile::tempdir().unwrap();
+        let source = dir.path().join("file.fits");
+        let source_str = source.to_str().unwrap();
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: "item-1",
+                plan_id: "p1",
+                item_index: 1,
+                name: "file.fits",
+                action: "archive",
+                from_root_id: None,
+                from_relative_path: source_str,
+                to_root_id: None,
+                to_relative_path: "",
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert!(
+            estimate.available_bytes.is_some_and(|b| b > 0),
+            "a real volume must report nonzero free space"
+        );
+    }
+
+    #[tokio::test]
+    async fn estimate_free_space_returns_none_when_the_source_parent_is_unreachable() {
+        let (db, _bus) = setup().await;
+        insert_draft(&db, "p1").await;
+        add_item(&db, "p1", "item-1", "archive").await; // from_relative_path: "raw/file.fits"
+
+        let estimate = estimate_free_space(db.pool(), "p1").await.unwrap();
+        assert_eq!(estimate.available_bytes, None, "relative path has no real parent to probe");
     }
 
     // ── parse_plan_state (audit T1-b) ────────────────────────────────────────

--- a/crates/contracts/core/src/plans.rs
+++ b/crates/contracts/core/src/plans.rs
@@ -302,6 +302,27 @@ pub struct PlanGetResponse {
     pub plan: PlanDetail,
 }
 
+/// Response for `plans.free_space_estimate` (issue #876): an ADVISORY
+/// destination free-space estimate surfaced at plan review time, before
+/// approval. Never blocks approval — `crates/fs/executor/src/ops/volume_check.rs`
+/// still re-validates for real and pauses the apply run (R-Pause-1) if the
+/// destination genuinely runs out; this is only a heads-up so the user isn't
+/// first told about a space problem after already approving the plan.
+#[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanFreeSpaceEstimate {
+    /// Same value as `PlanDetail::total_bytes_required` (0 for e.g. an
+    /// all-trash/all-delete plan, which needs no destination space).
+    pub required_bytes: i64,
+    /// Free bytes on the destination volume, probed via
+    /// `fs_executor::ops::available_space_bytes`. `None` when the plan has no
+    /// items to probe a destination from, or the probe itself fails (e.g. the
+    /// volume is momentarily unreachable) — the UI shows no comparison rather
+    /// than a false warning in that case.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub available_bytes: Option<i64>,
+}
+
 /// Response for `plans.approve` (A1, R-FS-1).
 #[derive(Clone, Debug, Serialize, Deserialize, JsonSchema, Type)]
 #[serde(rename_all = "camelCase")]


### PR DESCRIPTION
## Summary
- Cleanup/archive plan review (`OutputsCleanupSections.tsx` / `PlanReviewOverlay.tsx`) showed total reclaimable/required bytes, but the only real destination free-space probe (`fs_executor::ops::available_space_bytes`, added in #1053) ran only at plan-resume time (R-Pause-1, spec 025) — the user only learned about insufficient space after an apply attempt failed.
- Adds `plans.free_space_estimate` (Tauri command) backed by a new `app_core::plan_free_space::estimate_free_space` use case, probing free space from the first plan item's real source-parent directory (the same volume `compute_archive_destination` anchors on).
- Renders the estimate in the shared `PlanReviewOverlay` (used by every destructive plan review, not just cleanup) with a `warn`-styled banner when the estimate looks insufficient.
- Strictly advisory: never disables "Approve & apply" — the real gate remains `recheck_disk_space`'s apply-time pre-flight.

**Split-fence note (#979):** `crates/app/core/src/plans.rs` is being split on another in-flight branch. The estimate use case + its 4 tests live in a new sibling module, `crates/app/core/src/plan_free_space.rs` (declared in `lib.rs`, which is not split-listed) — `plans.rs` itself carries zero net diff vs `origin/main`. The one-line command registration added to `apps/desktop/src-tauri/src/lib.rs` (split-listed under #981) is unavoidable — every in-flight lane that adds a Tauri command touches that file's registration list the same way.

## Why
Closes #876. Per the issue's own triage comment, the gap is specifically that the review UI never compares reclaimable/required bytes against destination free space before approval.

## Test plan
- [x] `cargo test -p app_core plan_free_space::` — new `estimate_free_space` unit tests (zero-item plan, real-path probe, unreachable/relative-path probe, not-found)
- [x] `cargo clippy -p app_core -p contracts_core -p desktop_shell --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `pnpm typecheck` (contracts + desktop)
- [x] `pnpm vitest run src/features/plans` — 35 passed, incl. new insufficient/sufficient/zero-item free-space banner cases
- [x] `just check-generated` — bindings/contracts regenerated with no drift after commit
- [x] `git diff origin/main -- crates/app/core/src/plans.rs` — empty (zero net diff, split-fence respected)