### PR TITLE
docs(058): correct three requirements that contradict their own decisions

### DIFF
--- a/specs/058-inbox-drop-parent-items/PENDING_REVIEW_QUESTIONS.md
+++ b/specs/058-inbox-drop-parent-items/PENDING_REVIEW_QUESTIONS.md
@@ -103,6 +103,14 @@ The row visible before classification is the *source group*, not an
 while a freshly-scanned folder is still visible to the user. Once classify runs,
 the source-group row is replaced by its N item rows.
 
+**Scope — read "no *parent* item", not "no item".** This answer constrains rows
+that stand for a folder as a whole. It does not touch self-describing file-level
+rows: a detected calibration master (spec 040) is created at scan time by
+`persist_master_item`, carrying real frame type, filter and exposure read from
+the file, so it asserts nothing classification has yet to determine. FR-015
+originally paraphrased this answer as "MUST NOT create any inbox item", which
+outlawed a shipped feature; it has been corrected to match this scope.
+
 **Rejected alternatives**:
 
 - **A — scan creates one provisional item that classify splits.** Rejected: a
@@ -175,7 +183,15 @@ not absent. Worth a journey delta.
 
 ---
 
-## Q-5 — What anchors the confirm staleness guard after reclassification? — RESOLVED: per-item
+## Q-5 — What anchors the confirm staleness guard after reclassification? — RESOLVED: per-item — **AND SHIPPED**
+
+> **Status (2026-07-19): the decision below is implemented on `main`.** PR #1105
+> (`038781e2`) added `root_absolute_path` to `InboxReclassifyV2Request` and
+> `reclassify.rs:827` joins it per file to compute real per-group signatures.
+> The two in-tree comments named at the end of this answer are corrected, and
+> `confirm.rs:1495` carries a `stale_signature_returns_error` test. **No work
+> remains under Q-5.** The present-tense defect language below is retained as
+> the historical record of why — read it as history, not as a task list.
 
 **Answer (product owner)**: Confirm-time staleness stays a **per-item**
 property. **FR-013 stands unchanged.** Reclassification is what must change:

--- a/specs/058-inbox-drop-parent-items/research.md
+++ b/specs/058-inbox-drop-parent-items/research.md
@@ -92,10 +92,15 @@ failing while every static check still passes.
 rather than corrected: with no aggregate row there is nothing to suppress
 (FR-026, SC-007).
 
-**Pre-existing inconsistency, fixed for free**: `count_unacknowledged_inbox_items`
-at `crates/persistence/db/src/repositories/q_desktop.rs:171-179` has **no**
-dedup clause at all, so the status-bar badge already counts the parent *and* its
-siblings. Removing the parent removes this divergence without a targeted fix.
+**~~Pre-existing inconsistency, fixed for free~~ — no longer true.** This
+paragraph described `count_unacknowledged_inbox_items` as having **no** dedup
+clause, so that removing the parent would resolve the status-bar divergence
+without a targeted fix. **#1092 changed that**: the function now calls
+`exclude_split_placeholder!` (`q_desktop.rs:184`, imported at `:13`) and is the
+**fourth** suppression call site listed in §2 — not a beneficiary of the other
+three being deleted. It must be deleted explicitly. Deleting three of four
+leaves the status-bar count inconsistent with the list and SC-004 failing,
+while every static check still passes.
 
 Tests that become vacuous and should be deleted with the predicates:
 
@@ -297,7 +302,7 @@ is the actual source of the extra row.
 
 ## 5. Summary of the change surface
 
-**Deleted**: the parent write path (§4.1), the three dedup predicates and
+**Deleted**: the parent write path (§4.1), the four dedup predicates and
 #1081's macro (§2), the `plan_open` re-split shim (§1), the `group_key != ''`
 filter (§4.3), and the parent-shaped tests (§2, §4.8).
 

--- a/specs/058-inbox-drop-parent-items/research.md
+++ b/specs/058-inbox-drop-parent-items/research.md
@@ -70,16 +70,25 @@ the wrong projection for the badge.
 
 The #1038 predicate — `group_key = '' AND source_group_id IS NOT NULL AND
 EXISTS (sibling with non-empty group_key)`, narrowed by #1081 to a genuine
-split — now lives in one macro with three call sites:
+split — now lives in one macro with four call sites:
 
 | Location | Query |
 |---|---|
 | `crates/persistence/db/src/repositories/inbox.rs:1494` | `exclude_split_placeholder!` definition (compile-time literal, because sqlx 0.9 rejects runtime-built SQL) |
-| `crates/persistence/db/src/repositories/inbox.rs:1782` | `list_unacknowledged_across_roots` (the Inbox list) |
-| `crates/persistence/db/src/repositories/inbox.rs:1559` | `inbox_stats` |
-| `crates/persistence/db/src/repositories/inbox.rs:1597` | `count_distinct_inbox_folders` |
+| `crates/persistence/db/src/repositories/inbox.rs:1788` | `list_unacknowledged_across_roots` (the Inbox list) |
+| `crates/persistence/db/src/repositories/inbox.rs:1565` | `inbox_stats` |
+| `crates/persistence/db/src/repositories/inbox.rs:1603` | `count_distinct_inbox_folders` |
+| `crates/persistence/db/src/repositories/q_desktop.rs:184` | `count_unacknowledged_inbox_items` — **the fourth site, in a different file**, reached via the import at `q_desktop.rs:13`. Added when #1092 merged, after this table was first written |
 
-Under this feature the macro and all three call sites are deleted outright
+**Note the file split.** Three sites live in `repositories/inbox.rs`; the fourth
+lives in `repositories/q_desktop.rs`. There is also an
+`apps/desktop/src-tauri/src/commands/inbox.rs` — a *different file with the same
+basename* that contains none of them. Grep the macro name tree-wide rather than
+searching "inbox.rs".
+
+Under this feature the macro and all four call sites are deleted outright
+(plus the `q_desktop.rs:13` import). Deleting three of the four leaves SC-004
+failing while every static check still passes.
 rather than corrected: with no aggregate row there is nothing to suppress
 (FR-026, SC-007).
 
@@ -225,7 +234,7 @@ worth revisiting under the new model rather than carrying forward (Q-7).
 | `crates/app/inbox/src/classify.rs:930-935`, `:959` | per-group signature from per-file hashes — the real per-row anchor |
 | `crates/persistence/db/src/repositories/inbox.rs:501-546` | `upsert_inbox_sub_item` conflicts on `(root_id, relative_path, group_key)`; re-scan stability rests on the group key, **not on any parent row** |
 | `crates/persistence/db/src/repositories/inbox.rs:610-619` | `delete_sub_item_if_unlinked` refuses to purge a plan-linked row; with no parent, a plan-linked stale group can no longer hide behind one (Q-2) |
-| `crates/app/inbox/src/reclassify.rs:820-831` | passes `&[]` for file paths, so the per-group signature is `folder_signature([])` — the empty-set hash constant, **not** an empty string. A live defect on `main` that makes the confirm guard vacuous; see §4.2 and Q-5 |
+| `crates/app/inbox/src/reclassify.rs:820-831` | **Fixed on `main` by #1105 (`038781e2`).** Formerly passed `&[]` for file paths, making the per-group signature `folder_signature([])` — the empty-set hash constant, **not** an empty string — which rendered the confirm guard vacuous. Now joins `req.root_absolute_path` per file (`:827`). Retained here because §4.2 and Q-5 describe the defect, not the fix |
 
 ### 4.6 Materialization
 

--- a/specs/058-inbox-drop-parent-items/spec.md
+++ b/specs/058-inbox-drop-parent-items/spec.md
@@ -122,8 +122,9 @@ for the current moment, not in principle.
 ### D-005 — A superseded sibling is invalidated, not preserved
 
 When a re-scan no longer produces a sibling that has an open plan, the system
-**invalidates** it: the plan is cancelled, the item is marked stale, and an
-explicit signal tells the user their confirmation was superseded.
+**invalidates** it: the item is marked superseded, its plan is blocked from
+application pending the user's decision, and an explicit signal tells the user
+their confirmation was superseded.
 
 The confirmation was made against a world that no longer exists, and a plan
 describes pending filesystem mutations, so silently honouring it is the
@@ -505,15 +506,24 @@ resulting sibling carries a frame type without any user input.
 - **FR-013**: Staleness detection at confirm time MUST be evaluated against the
   files belonging to the item being confirmed. *Confirmed unchanged by the Q-5
   decision: staleness is a per-item property. Reclassification MUST compute a
-  real per-group signature rather than the empty-set hash constant it writes
-  today, which requires threading a root absolute path into `reclassify_v2`.*
+  real per-group signature rather than the empty-set hash constant. **Delivered
+  by #1105** (`038781e2`): `root_absolute_path` is a field on
+  `InboxReclassifyV2Request` and `reclassify.rs:827` joins it per file. No work
+  remains under this requirement.*
 - **FR-014**: Re-classification MUST re-derive a folder's items from the files
   on disk without propagating state, plans, or confirmations between siblings.
 
 **Scan and classification boundary** *(D-006)*
 
 - **FR-015**: Scanning a folder MUST create its source group and MUST NOT
-  create any inbox item.
+  create an inbox item representing the folder as a whole. *Self-describing
+  file-level items are unaffected: a detected calibration master (spec 040)
+  carries its frame type, filter and exposure from the file itself, so its row
+  asserts nothing that classification has yet to determine. `persist_master_item`
+  already creates one row per master file, and a folder containing only masters
+  already produces no aggregate row at all
+  (`apps/desktop/src-tauri/src/commands/inbox.rs:356`) — that is this decision's
+  target shape, already shipped.*
 - **FR-016**: A scanned but unclassified folder MUST be visible in the Inbox
   list, represented by its source group.
 - **FR-017**: When classification completes, the folder's source-group row MUST
@@ -597,7 +607,8 @@ another there.
   aggregate row is deleted, and no replacement suppression logic is introduced.
 - **SC-008**: Re-scanning an unchanged folder produces no item identity churn.
 - **SC-009**: When re-derivation removes an item that had an open plan, that
-  plan is cancelled and the user receives an explicit superseded signal — zero
+  item is marked superseded, its plan is blocked from application pending the
+  user's decision, and the user receives an explicit superseded signal — zero
   cases of a silently discarded or silently retained plan (D-005).
 - **SC-010**: A user can group the Inbox by folder and see each folder's
   siblings together under one header (D-007).

--- a/specs/tiny/reclassify-split-per-item-and-rederivation.md
+++ b/specs/tiny/reclassify-split-per-item-and-rederivation.md
@@ -140,11 +140,13 @@ detect supersession. Do not start decision 3 before that lands.
 
 ## Open questions
 
-- **058 FR-020 needs amending.** As written (`spec.md:413-414`) it says the
-  system "MUST cancel that plan". Decision 4 says the system must *not* cancel
-  it without the user. D-005's prose (`spec.md:110-112`) has the same problem.
-  One of the two documents has to change; this spec assumes 058's text is
-  amended to "surface for user decision".
+- ~~**058 FR-020 needs amending.**~~ **RESOLVED (2026-07-19): 058 was amended;
+  decision 4 stands.** FR-020 had already been descoped out of 058 by Q-6, and
+  D-005 already carried the "*supersede and surface, never silently cancel*"
+  refinement — but D-005's opening paragraph and SC-009 still said the plan is
+  cancelled, contradicting the refinement below them. Both now read "marked
+  superseded, plan blocked from application pending the user's decision". No
+  document still asserts automatic cancellation.
 - **Who is the user-facing surface for a superseded item?** A queue row in a
   distinct state, a notification, or the plan surface — undecided. Requirement 5
   fixes the obligation, not the affordance.


### PR DESCRIPTION
An adversarial audit of spec 058's nine answers reported three defects needing
product decisions before implementation. On investigation none of them do:
each is a requirement disagreeing with the decision it was derived from. This
PR reconciles the text with the decisions already made.

## FR-015 outlawed calibration masters — Closes #1146

FR-015 said scanning "MUST NOT create any inbox item." D-006, which it
paraphrases, says no row *"representing a whole folder"* is ever created. Those
are not the same claim.

A detected calibration master (spec 040) is a **file-level** row. The detector
reads frame type, filter and exposure from the file at scan time, so the row
asserts nothing classification has yet to determine — which is the property
058 exists to enforce, not violate. Better still, `commands/inbox.rs:356`
already skips the aggregate row entirely when every file in a folder is a
master, so a masters-only folder already produces exactly the shape this
feature is driving toward.

Masters are not a counterexample to 058. They are an existing instance of it.
FR-015 is scoped to match D-006; Q-4 gains the same note, its own answer having
correctly said "no **parent** item ever exists" all along.

**Implementation hazard recorded, not fixed here:** `insert_inbox_master_item`
writes `group_key = ''`, the same sentinel the placeholder uses, and every
placeholder query is scoped `WHERE ... AND group_key = ''`. Once T020 stops
creating placeholders and FR-028 strips `group_key`'s discriminator role, those
queries begin matching master rows and need `AND is_master_item = 0`. PG-2's
harness assertion needs the same scoping — scanning a masters folder
legitimately yields confirmable items.

## D-005 contradicted itself on cancellation — Closes #1147

D-005 already carried the Q-6 refinement *"supersede and surface, never
silently cancel"* — but its opening paragraph and SC-009 still said the plan is
cancelled, two paragraphs above and below the refinement overriding them. The
follow-on micro-spec had flagged this in its open questions and pre-declared
that it assumed 058 would be amended; its implementer had already declined to
build automatic cancellation.

Auto-cancel is the safe direction for filesystem mutation but the destructive
direction for user intent: a drive unmounts, a re-scan comes back short, and
confirmations are silently destroyed with no undo. Blocking the plan from
application pending a decision preserves the safety property Q-2 wanted without
the irreversibility. Q-2's rejected-alternatives list never actually considered
this option — it rejected "keep and show" because a row would assert something
untrue, but a row explicitly marked superseded asserts something true.

Both sites now read "marked superseded, plan blocked from application pending
the user's decision." The micro-spec's open question is closed.

## Q-5 described a fixed defect as live

#1105 (`038781e2`) shipped it: `root_absolute_path` is a field on
`InboxReclassifyV2Request` and `reclassify.rs:827` joins it per file. The two
in-tree comments Q-5 named are corrected, and `confirm.rs:1495` carries a
`stale_signature_returns_error` test.

`spec.md` FR-013, `research.md` and the answer itself all still called for work
that is done. Now marked shipped, with the defect prose retained as historical
record rather than a task list — reading them previously sent you to fix
something already fixed.

## Bonus: the suppression count was wrong, and it has teeth

`research.md` said **three** call sites. There are **four**.
`q_desktop.rs:184` arrived with #1092 after that table was written, and it
lives in a different file from the other three. Deleting three of four leaves
SC-004 failing **while every static check still passes** — precisely the
failure mode this spec's verification standard warns about.

Line numbers corrected (+6 drift) and the same-basename trap called out
explicitly: `crates/persistence/db/src/repositories/inbox.rs` and
`apps/desktop/src-tauri/src/commands/inbox.rs` are different files, and only
the former holds the macro. Grep the macro name tree-wide, not "inbox.rs".

## Scope

Documentation only — four spec files, no code. Verified against `main` at
`718d3196`; every line reference above was re-read rather than carried over.

**Still needs a product decision, and not addressed here:** #1102 — with no
parent row, `resolve_item_id` picking an arbitrary sibling via `ids.next()` has
no defensible meaning. It is task T003 and blocks Phase 5.

---

Fixes #1146

Fixes #1147

Fixes #1148

## Spec Context
- Spec: 058
- Branch: docs/058-correct-fr015-and-d005
