### PR TITLE
fix: settings snapshot dedupe is scoped to its caller instead of the whole process

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1104,9 +1104,13 @@ pub fn run_app(
         let snap_pool = pool.clone();
         let snap_bus = bus.clone();
         tokio::spawn(async move {
+            // #668 suppression state, scoped to this loop — the only emitter
+            // of settings.snapshot.
+            let dedupe = app_core::settings::SnapshotDedupe::new();
             // Session-start snapshot.
             if let Err(e) =
-                app_core::settings::emit_snapshot(&snap_pool, &snap_bus, "session_start").await
+                app_core::settings::emit_snapshot(&snap_pool, &snap_bus, "session_start", &dedupe)
+                    .await
             {
                 tracing::warn!("settings.snapshot (session_start) failed: {e:?}");
             }
@@ -1114,8 +1118,13 @@ pub fn run_app(
             let interval = std::time::Duration::from_mins(5);
             loop {
                 tokio::time::sleep(interval).await;
-                if let Err(e) =
-                    app_core::settings::emit_snapshot(&snap_pool, &snap_bus, "debounce_5min").await
+                if let Err(e) = app_core::settings::emit_snapshot(
+                    &snap_pool,
+                    &snap_bus,
+                    "debounce_5min",
+                    &dedupe,
+                )
+                .await
                 {
                     tracing::warn!("settings.snapshot (debounce_5min) failed: {e:?}");
                 }

--- a/crates/app/core/tests/settings_logs_integration.rs
+++ b/crates/app/core/tests/settings_logs_integration.rs
@@ -227,7 +227,10 @@ async fn noisy_key_update_does_not_emit_changed_event_non_noisy_does() {
         .await
         .expect("snapshot count query");
 
-    settings::emit_snapshot(pool, &bus, "test").await.expect("emit_snapshot must not error");
+    let dedupe = settings::SnapshotDedupe::new();
+    settings::emit_snapshot(pool, &bus, "test", &dedupe)
+        .await
+        .expect("emit_snapshot must not error");
 
     let after_snap: (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events WHERE topic = ?")
         .bind(TOPIC_SETTINGS_SNAPSHOT)

--- a/crates/app/settings/src/caches.rs
+++ b/crates/app/settings/src/caches.rs
@@ -17,7 +17,6 @@ use std::sync::{Arc, OnceLock};
 
 use app_core_cache::SnapshotCache;
 use domain_core::settings::SettingsState;
-use serde_json::Value;
 
 /// The full v1 settings bag, hydrated with in-code defaults for missing rows
 /// (mirrors `get_settings`'s output). 1 slot.
@@ -42,40 +41,6 @@ pub fn store_settings_bag(value: Arc<SettingsState>) {
 /// Clear the settings-bag snapshot so the next read reloads from the DB.
 pub fn invalidate_settings_bag() {
     settings_bag().invalidate();
-}
-
-/// The noisy-key values (as a JSON object) from the most recently PUBLISHED
-/// `settings.snapshot` event (issue #668). 1 slot.
-///
-/// `emit_snapshot` compares its freshly collected values against this before
-/// publishing, and skips the publish (a no-op) when nothing changed — mirrors
-/// `app_core_targets::ingest_resolution::resolve_pending`'s
-/// `target.resolve_batch.completed` suppression on `considered == 0`: a
-/// periodic heartbeat with nothing to report should not flood the activity
-/// log (#668 — ~470/500 rows in a real sweep were this + the target
-/// heartbeat). Not invalidated by `update_setting`/`restore_defaults`/
-/// `set_source_override`: those already emit their own real
-/// `settings.changed`/`protection.default.changed` events, so a later
-/// snapshot correctly finds "no further noisy-key change" and stays quiet
-/// until a *noisy* key changes.
-static LAST_SNAPSHOT_VALUES: OnceLock<SnapshotCache<Value>> = OnceLock::new();
-
-/// Return the process-global last-published-snapshot value cache.
-#[must_use]
-pub fn last_snapshot_values() -> &'static SnapshotCache<Value> {
-    LAST_SNAPSHOT_VALUES.get_or_init(SnapshotCache::new)
-}
-
-/// Store the noisy-key values just published in a `settings.snapshot` event.
-pub fn store_last_snapshot_values(value: Arc<Value>) {
-    last_snapshot_values().store(value);
-}
-
-/// Clear the last-published-snapshot cache (test isolation only — the real
-/// `emit_snapshot` caller never needs to invalidate this outside its own
-/// store-on-publish).
-pub fn invalidate_last_snapshot_values() {
-    last_snapshot_values().invalidate();
 }
 
 #[cfg(test)]

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -931,17 +931,28 @@ pub async fn resolve_setting(
 
 // ── emit_snapshot ──────────────────────────────────────────────────────────
 
+/// Dedupe state for [`emit_snapshot`]: the noisy-key values (as a JSON object)
+/// from the most recently PUBLISHED `settings.snapshot` event (issue #668).
+///
+/// Owned by the snapshot loop that drives `emit_snapshot`, so suppression is
+/// scoped to that loop rather than to the whole process. Not invalidated by
+/// `update_setting`/`restore_defaults`/`set_source_override`: those already
+/// emit their own real `settings.changed`/`protection.default.changed`
+/// events, so a later snapshot correctly finds "no further noisy-key change"
+/// and stays quiet until a *noisy* key changes.
+pub type SnapshotDedupe = app_core_cache::SnapshotCache<Value>;
+
 /// Emit a `settings.snapshot` audit event (T020).
 ///
 /// Called at session start and after the 5-minute inactivity debounce
 /// (the debounce timer is owned by the caller/command layer).
 ///
 /// Issue #668: a periodic snapshot whose noisy-key values are byte-identical
-/// to the last one PUBLISHED is a no-op heartbeat — it is skipped rather than
-/// published, mirroring `target.resolve_batch.completed`'s suppression on
-/// `considered == 0` (both stop a periodic internal event from flooding the
-/// activity log when there is nothing new to report). The first snapshot in a
-/// process (no prior published value) always publishes.
+/// to the last one PUBLISHED via `dedupe` is a no-op heartbeat — it is skipped
+/// rather than published, mirroring `target.resolve_batch.completed`'s
+/// suppression on `considered == 0` (both stop a periodic internal event from
+/// flooding the activity log when there is nothing new to report). The first
+/// snapshot against a fresh `dedupe` always publishes.
 ///
 /// # Errors
 ///
@@ -950,6 +961,7 @@ pub async fn emit_snapshot(
     pool: &SqlitePool,
     bus: &EventBus,
     trigger: &str,
+    dedupe: &SnapshotDedupe,
 ) -> Result<(), ContractError> {
     // Collect current values of noisy keys.
     let mut noisy_values = serde_json::Map::new();
@@ -964,7 +976,7 @@ pub async fn emit_snapshot(
 
     // Skip the publish when nothing changed since the last one we actually
     // published (#668).
-    if caches::last_snapshot_values().load().as_deref() == Some(&noisy_keys) {
+    if dedupe.load().as_deref() == Some(&noisy_keys) {
         return Ok(());
     }
 
@@ -976,7 +988,7 @@ pub async fn emit_snapshot(
     )
     .await
     .map_err(bus_err)?;
-    caches::store_last_snapshot_values(std::sync::Arc::new(noisy_keys));
+    dedupe.store(std::sync::Arc::new(noisy_keys));
 
     Ok(())
 }
@@ -1098,12 +1110,6 @@ mod tests {
         // silently serve another test's data. Mirrors the same caveat/fix in
         // `app_core_cache`'s `protection_defaults_*` test (crates/app/cache/src/lib.rs).
         caches::invalidate_settings_bag();
-        // Same hazard for the #668 last-published-snapshot cache: without
-        // this, a `emit_snapshot`-must-publish assertion here could
-        // false-negative if a sibling test already stored an
-        // identical-looking noisy-keys bag (fresh in-memory DBs share the
-        // same in-code defaults).
-        caches::invalidate_last_snapshot_values();
         let db = Database::in_memory().await.expect("in-memory DB");
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());
@@ -2002,10 +2008,11 @@ mod tests {
     #[tokio::test]
     async fn emit_snapshot_fires_and_publishes_event() {
         let (db, bus) = setup().await;
+        let dedupe = SnapshotDedupe::new();
         let mut rx = bus.subscribe();
 
         // Call emit_snapshot — must not error.
-        emit_snapshot(db.pool(), &bus, "test_trigger").await.unwrap();
+        emit_snapshot(db.pool(), &bus, "test_trigger", &dedupe).await.unwrap();
 
         // There must be at least one event published on the bus.
         // Use try_recv to avoid blocking — the publish is synchronous inside the call.
@@ -2020,12 +2027,13 @@ mod tests {
     #[tokio::test]
     async fn emit_snapshot_suppresses_unchanged_repeat() {
         let (db, bus) = setup().await;
+        let dedupe = SnapshotDedupe::new();
 
-        emit_snapshot(db.pool(), &bus, "first").await.unwrap();
+        emit_snapshot(db.pool(), &bus, "first", &dedupe).await.unwrap();
         let mut rx = bus.subscribe();
 
         // Second call, nothing changed — must be a no-op (no publish).
-        emit_snapshot(db.pool(), &bus, "second").await.unwrap();
+        emit_snapshot(db.pool(), &bus, "second", &dedupe).await.unwrap();
         assert!(
             rx.try_recv().is_err(),
             "an unchanged repeat snapshot must not publish a second settings.snapshot event"
@@ -2037,8 +2045,9 @@ mod tests {
     #[tokio::test]
     async fn emit_snapshot_publishes_again_after_a_real_change() {
         let (db, bus) = setup().await;
+        let dedupe = SnapshotDedupe::new();
 
-        emit_snapshot(db.pool(), &bus, "first").await.unwrap();
+        emit_snapshot(db.pool(), &bus, "first", &dedupe).await.unwrap();
 
         // `pattern` is a noisy key (descriptors::DESCRIPTORS) — change it.
         let req = SettingsUpdateRequest {
@@ -2048,7 +2057,7 @@ mod tests {
         update_setting(db.pool(), &bus, &req).await.unwrap();
 
         let mut rx = bus.subscribe();
-        emit_snapshot(db.pool(), &bus, "second").await.unwrap();
+        emit_snapshot(db.pool(), &bus, "second", &dedupe).await.unwrap();
         assert!(
             rx.try_recv().is_ok(),
             "a snapshot after a real noisy-key change must still publish"


### PR DESCRIPTION
## Summary

- `emit_snapshot` deduped repeat emissions through a **process-global** cache, which three tests shared and raced on. The dedupe state now belongs to the caller that owns it.
- Net **deletion**: the `LAST_SNAPSHOT_VALUES` static and its three accessors are gone (+43/−57).

## Reproduction, before the fix

**17 of 40 runs failed** at `--test-threads=8` — considerably worse than the 2-in-8 originally reported, and it exposed a second failing test:

```
test tests::emit_snapshot_fires_and_publishes_event ... FAILED
  emit_snapshot must publish a settings.snapshot event on the bus
test tests::emit_snapshot_suppresses_unchanged_repeat ... FAILED
  an unchanged repeat snapshot must not publish a second settings.snapshot event
```

14 of those failures were the **sibling** test, only 3 the reported one. The coupling ran both ways: `setup()` called `invalidate_last_snapshot_values()`, so a sibling's setup landing between the suppression test's two emits broke suppression, while a sibling's publish landing first made the "must publish" test's bag look unchanged. Fixing only the reported test would have left the more frequent failure in place.

## Why injection rather than `#[serial]`

The global was not load-bearing, on three pieces of evidence:

1. **One production caller** — `apps/desktop/src-tauri/src/lib.rs:1106`, a single spawned loop with a moved pool and bus. It never dedupes across independent callers, so the correct scope is that task's lifetime, not the process.
2. **A test-only production function** — `invalidate_last_snapshot_values` said so in its own doc comment: *"test isolation only — the real `emit_snapshot` caller never needs to invalidate this."*
3. **No external reach** — the cache was read in exactly three places, all in one file.

So the fix removes API that only tests used. `#[serial]` would have hidden a coupling that had no reason to exist, and slowed the suite to do it.

## Proof

**0 failures / 60 iterations** at `--test-threads=8` — the same invocation that produced 17/40 before. Independently re-verified after rebase: **0 failures / 20 iterations**.

## Verification

`cargo fmt --all --check` (0) · `cargo clippy -p app_core_settings --all-targets -D warnings` ("No issues found") · `cargo test -p app_core_settings` (211 passed) · `cargo test -p app_core --test settings_logs_integration` (6 passed) · `cargo check -p desktop_shell --all-targets` (clean).

## Follow-up, not fixed here

`SETTINGS_BAG` (`crates/app/settings/src/caches.rs:29`) is still a process global that `setup()` invalidates per test, and `app_core_cache`'s `protection_defaults_*` tests carry the same documented caveat. Unlike the snapshot cache it **is** genuinely load-bearing — read by `get_settings` everywhere — so it cannot get this treatment. Same class of latent cross-test coupling; filed separately rather than forced into this change.

Closes #1129