### PR TITLE
test: assert the not-a-folder error against the catalog, not a copy regex

### DIFF
--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
@@ -10,6 +10,8 @@
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi } from 'vitest';
 
+import { m } from '@/lib/i18n';
+
 const mockPick = vi.fn();
 
 vi.mock('@/shared/native', () => ({
@@ -265,7 +267,7 @@ describe('StepSourceFolders — manual path entry existence validation', () => {
     fireEvent.click(screen.getByTestId('manual-add-path-btn-light_frames'));
 
     expect(await screen.findByRole('alert')).toHaveTextContent(
-      /not a directory/i,
+      m.err_path_not_directory(),
     );
     expect(onAdd).not.toHaveBeenCalled();
     expect(input).toHaveValue('/astro/lights/frame.fits');


### PR DESCRIPTION
## What

`StepSourceFolders` has one assertion that matched the error copy with a
hand-written regex:

```ts
expect(await screen.findByRole('alert')).toHaveTextContent(/not a directory/i);
```

The #1130 voice-consistency sweep (`7219fb57`) reworded
`err_path_not_directory` to **"This path is not a folder."** without updating
that regex, so **`main` has been red since #1130 merged**.

## Why this shape

Rather than swapping in today's wording, the assertion now goes through the
catalog:

```ts
expect(await screen.findByRole('alert')).toHaveTextContent(m.err_path_not_directory());
```

That keeps the test checking the thing worth checking — that the component
selects the correct message for `isDir === false` — instead of restating copy
that product is free to reword. The next voice sweep cannot break it.

Same rationale as #1014 (contract parity tests assert the real enums instead of
hardcoded copies).

## Verification

- `vitest run StepSourceFolders.test.tsx` → **12/12 pass** (was 11/12).
- Verified in **both directions**: with the component mutated to return
  `m.err_path_missing()`, the suite fails; restored, it passes. The assertion
  is load-bearing, not vacuous.
- Scope is one line of test code plus the `m` import. No product code changed.