### PR TITLE
fix: settings toggles no longer revert, and lock reasons reach keyboard and screen-reader users

### DIFF
--- a/apps/desktop/src/components/PropertyTable.tsx
+++ b/apps/desktop/src/components/PropertyTable.tsx
@@ -205,6 +205,12 @@ export function PropertyTable({
               ) : prop.tooltip ? (
                 <Tooltip
                   content={prop.tooltip}
+                  // `tabIndex` makes the tooltip reachable without a pointer
+                  // (the shared Tooltip trigger is a bare <span>); `role` is
+                  // what actually exposes `aria-label` — naming is ignored on
+                  // a role-less <span>, so without it assistive tech hears the
+                  // value and never the tooltip. Same pairing as `ui/Lock`.
+                  role="note"
                   tabIndex={0}
                   data-testid={`proptable-tooltip-${prop.key}`}
                   aria-label={

--- a/apps/desktop/src/features/settings/CatalogueSettingsControl.test.tsx
+++ b/apps/desktop/src/features/settings/CatalogueSettingsControl.test.tsx
@@ -1,0 +1,109 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * CatalogueSettingsControl tests.
+ *
+ * Focus: the mount-read vs user-edit race. The control loads the persisted
+ * default catalogues asynchronously on mount; if the user toggles a catalogue
+ * before that read resolves, the in-flight response must not overwrite their
+ * choice. Same defect class as LogPanelContext (`followTouchedRef`), Settings >
+ * Cleanup (`editedRef`) and guidance-settings (`writeGen`).
+ */
+
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const { mockLoad, mockSave } = vi.hoisted(() => ({
+  mockLoad: vi.fn(),
+  mockSave: vi.fn(),
+}));
+
+vi.mock('@/features/targets/catalogue-settings', async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import('@/features/targets/catalogue-settings')
+    >();
+  return {
+    ...actual,
+    loadDefaultCatalogues: mockLoad,
+    saveDefaultCatalogues: mockSave,
+  };
+});
+
+import { CatalogueSettingsControl } from './CatalogueSettingsControl';
+import { PLANNER_CATALOGS } from '@/features/targets/planner-catalog';
+import { DEFAULT_ENABLED_CATALOGUES } from '@/features/targets/catalogue-settings';
+import { m } from '@/lib/i18n';
+
+beforeEach(() => {
+  mockLoad.mockReset();
+  mockSave.mockReset();
+  mockSave.mockResolvedValue(undefined);
+});
+
+/** First catalogue that is enabled by default — toggling it off is a change. */
+function firstDefaultOn() {
+  const c = PLANNER_CATALOGS.find((c) =>
+    DEFAULT_ENABLED_CATALOGUES.includes(c.id),
+  );
+  if (!c) throw new Error('no default-enabled catalogue to exercise');
+  return c;
+}
+
+/** `Toggle` renders an `<input type="checkbox">`, so the role is checkbox. */
+function toggleFor(c: { label: () => string }) {
+  return screen.getByRole('checkbox', {
+    name: m.settings_catalogue_enable_default_aria({ label: c.label() }),
+  });
+}
+
+describe('CatalogueSettingsControl mount-read vs user-toggle race', () => {
+  it('does not let the in-flight mount read clobber a toggle made while it was pending', async () => {
+    // Hold the mount load open so the user can toggle while it is in flight.
+    let resolveLoad!: (v: readonly string[]) => void;
+    mockLoad.mockReturnValue(
+      new Promise((resolve) => {
+        resolveLoad = resolve as (v: readonly string[]) => void;
+      }),
+    );
+
+    const target = firstDefaultOn();
+    render(<CatalogueSettingsControl />);
+
+    const toggle = toggleFor(target);
+    expect(toggle).toBeChecked();
+
+    // User turns it off before the read resolves. `persist` has already written
+    // this to the settings backend, so a clobber would leave the UI showing a
+    // value the backend no longer holds.
+    fireEvent.click(toggle);
+    expect(toggle).not.toBeChecked();
+    expect(mockSave).toHaveBeenCalled();
+
+    // The stale read lands, still carrying the pre-toggle defaults.
+    await act(async () => {
+      resolveLoad([...DEFAULT_ENABLED_CATALOGUES]);
+    });
+
+    // Assert directly, NOT via waitFor — waitFor can succeed on its first check
+    // before the clobber lands and so passes even with the fix removed.
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('still applies the persisted value when the user has not touched anything', async () => {
+    // The guard must not disable the load outright — only defer to real intent.
+    const target = firstDefaultOn();
+    const withoutTarget = DEFAULT_ENABLED_CATALOGUES.filter(
+      (id) => id !== target.id,
+    );
+    mockLoad.mockResolvedValue([...withoutTarget]);
+
+    render(<CatalogueSettingsControl />);
+
+    await act(async () => {});
+
+    expect(toggleFor(target)).not.toBeChecked();
+  });
+});

--- a/apps/desktop/src/features/settings/CatalogueSettingsControl.tsx
+++ b/apps/desktop/src/features/settings/CatalogueSettingsControl.tsx
@@ -8,7 +8,7 @@
 // `'catalogues'` scope (see features/targets/catalogue-settings.ts). The Planner
 // initializes its catalogue filter from this setting on load.
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { Toggle } from '@/ui';
 import {
   PLANNER_CATALOGS,
@@ -28,11 +28,21 @@ export function CatalogueSettingsControl() {
   );
   const [saveError, setSaveError] = useState<string | null>(null);
 
+  // Set once the user toggles a catalogue, so the mount read below can never
+  // overwrite a deliberate choice. `cancelled` only covers unmount, not the
+  // case where the component is still mounted and the user has already acted.
+  const toggledRef = useRef(false);
+
+  // Load the persisted defaults on mount. This resolves asynchronously, so on a
+  // slow backend it can land AFTER the user has toggled a catalogue — and by
+  // then `persist` has already written their choice to the settings DB, so
+  // applying the read would leave the UI showing a value the backend no longer
+  // holds. The toggle is the more recent intent and must win.
   useEffect(() => {
     let cancelled = false;
     loadDefaultCatalogues()
       .then((ids) => {
-        if (!cancelled) setEnabled(new Set(ids));
+        if (!cancelled && !toggledRef.current) setEnabled(new Set(ids));
       })
       .catch(() => {
         // Backend unavailable — keep in-code defaults.
@@ -55,6 +65,9 @@ export function CatalogueSettingsControl() {
   }, []);
 
   const toggle = (id: CatalogueId, on: boolean): void => {
+    // Claim the setting before the mount read can answer (see the effect
+    // above) — from here on the user owns it for this session.
+    toggledRef.current = true;
     const next = new Set(enabled);
     if (on) next.add(id);
     else next.delete(id);

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
@@ -11,7 +11,13 @@
  * (#504 — wired to the same `data/theme.ts` runtime as Settings > General).
  */
 
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitFor,
+  fireEvent,
+  act,
+} from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockGet, mockUpdate, mockSettingsGet, mockSettingsUpdate } = vi.hoisted(
@@ -133,5 +139,46 @@ describe('StepCatalogs (Configuration)', () => {
   it('shows no catalog-download affordance', () => {
     renderStep();
     expect(screen.queryByRole('button', { name: /download/i })).toBeNull();
+  });
+});
+
+describe('DefaultProtectionControl mount-read vs user-edit race', () => {
+  it('does not let the in-flight mount read clobber a choice made while it was pending', async () => {
+    // Hold the mount `settingsGet` open so the user can act while it is still
+    // in flight — the same defect fixed in LogPanelContext and Settings >
+    // Cleanup. The stale read must not overwrite the newer pick.
+    let resolveGet!: (v: unknown) => void;
+    mockSettingsGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    renderStep();
+
+    const select = screen.getByLabelText(
+      'Default source protection',
+    ) as HTMLSelectElement;
+    expect(select.value).toBe('protected');
+
+    // User picks 'unprotected' before the read resolves. This also persists,
+    // so a clobber would leave the UI disagreeing with the settings DB.
+    fireEvent.change(select, { target: { value: 'unprotected' } });
+    expect(select.value).toBe('unprotected');
+    expect(mockSettingsUpdate).toHaveBeenCalledWith('cleanup', {
+      defaultProtection: 'unprotected',
+    });
+
+    // The stale read now lands, carrying the pre-edit value.
+    await act(async () => {
+      resolveGet({
+        status: 'ok',
+        data: { values: { defaultProtection: 'protected' } },
+      });
+    });
+
+    // Assert directly, NOT via waitFor: waitFor would succeed on its first
+    // check before a clobber landed and would pass with the fix removed.
+    expect(select.value).toBe('unprotected');
   });
 });

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.tsx
@@ -10,7 +10,7 @@
 // screen: a few defaults the user can set up front (all changeable later in
 // Settings).
 
-import { useEffect, useState, type ReactNode } from 'react';
+import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { ResolverSettingsControl } from '@/features/settings/ResolverSettingsControl';
 import { usePreference } from '@/data/preferences';
 import { useThemeChoice, THEMES, type ThemeChoice } from '@/data/theme';
@@ -47,6 +47,16 @@ type DefaultProtection = 'protected' | 'unprotected';
 function DefaultProtectionControl() {
   const [value, setValue] = useState<DefaultProtection>('protected');
 
+  // Set once the user picks a value, so the mount read below can never
+  // overwrite a deliberate choice. `cancelled` only covers unmount, not the
+  // still-mounted case where the user has already chosen.
+  const chosenRef = useRef(false);
+
+  // Load the persisted value on mount. This resolves asynchronously, so on a
+  // slow backend it can land AFTER the user has already picked from the select
+  // — and `onChange` has by then persisted their pick, so applying the read
+  // would show a value the backend no longer holds. Same defect as the
+  // Settings → Cleanup pane guards with `editedRef`.
   useEffect(() => {
     let cancelled = false;
     commands
@@ -55,7 +65,7 @@ function DefaultProtectionControl() {
       .then((data) => {
         const vals = data?.values as Record<string, unknown> | undefined;
         const v = vals?.defaultProtection;
-        if (!cancelled && typeof v === 'string')
+        if (!cancelled && !chosenRef.current && typeof v === 'string')
           setValue(v as DefaultProtection);
       })
       .catch(() => {
@@ -67,6 +77,9 @@ function DefaultProtectionControl() {
   }, []);
 
   const onChange = (v: DefaultProtection) => {
+    // Claim the setting before the mount read can answer (see the effect
+    // above) — from here on the user owns it for this session.
+    chosenRef.current = true;
     setValue(v);
     void commands
       .settingsUpdate('cleanup', { defaultProtection: v })

--- a/apps/desktop/src/features/targets/observing-sites/site-store.race.test.ts
+++ b/apps/desktop/src/features/targets/observing-sites/site-store.race.test.ts
@@ -1,0 +1,146 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * site-store race tests.
+ *
+ * `Shell.tsx` kicks off `loadObservingState()` at boot. On a slow backend that
+ * read can still be in flight by the time the user reaches Targets and saves a
+ * site or moves the usable-altitude slider — a read that started before the
+ * write is stale by the time it resolves and must not clobber the newer value.
+ *
+ * This mirrors the `writeGen` guard added to the sibling `guidance-settings.ts`
+ * in #836; the same store shape here was left unguarded.
+ */
+
+import { beforeEach, describe, it, expect, vi } from 'vitest';
+
+const { settingsGet, settingsUpdate } = vi.hoisted(() => ({
+  settingsGet: vi.fn(),
+  settingsUpdate: vi.fn(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: { settingsGet, settingsUpdate },
+}));
+
+vi.mock('@/api/ipc', () => ({
+  unwrap: (r: unknown) => r,
+}));
+
+import {
+  __setObservingStateForTest,
+  getObservingState,
+  getUsableAltitude,
+  loadObservingState,
+  saveSites,
+  saveUsableAltitude,
+  OBSERVING_SCOPE,
+  SITES_KEY,
+  DEFAULT_SITE_ID_KEY,
+  ACTIVE_SITE_ID_KEY,
+} from './site-store';
+import type { ObserverSite } from './observer-site';
+
+const SITE: ObserverSite = {
+  id: 'site-1',
+  name: 'Backyard',
+  latitudeDeg: 52.1,
+  longitudeDeg: 5.1,
+  elevationM: 10,
+  timezone: 'Europe/Amsterdam',
+  twilight: 'astronomical',
+  minHorizonAltDeg: 0,
+};
+
+beforeEach(() => {
+  settingsGet.mockReset();
+  settingsUpdate.mockReset();
+  settingsUpdate.mockResolvedValue(null);
+  __setObservingStateForTest({});
+});
+
+describe('loadObservingState vs saveSites race', () => {
+  it('does not let a load started before a save clobber the just-saved sites', async () => {
+    let resolveGet!: (v: unknown) => void;
+    settingsGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    // Boot read starts...
+    const loadPromise = loadObservingState();
+
+    // ...then the user saves a site and it commits.
+    await saveSites([SITE], SITE.id, SITE.id);
+    expect(getObservingState().sites).toHaveLength(1);
+
+    // The stale boot read now resolves with the pre-save (empty) values.
+    resolveGet({
+      scope: OBSERVING_SCOPE,
+      values: {
+        [SITES_KEY]: [],
+        [DEFAULT_SITE_ID_KEY]: null,
+        [ACTIVE_SITE_ID_KEY]: null,
+      },
+    });
+    await loadPromise;
+
+    expect(getObservingState().sites).toHaveLength(1);
+    expect(getObservingState().activeSiteId).toBe(SITE.id);
+  });
+
+  it('does not let a failing load reset state saved while it was in flight', async () => {
+    // The catch path writes EMPTY_STATE unconditionally before the fix.
+    let rejectGet!: (e: unknown) => void;
+    settingsGet.mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectGet = reject;
+      }),
+    );
+
+    const loadPromise = loadObservingState();
+    await saveSites([SITE], SITE.id, SITE.id);
+
+    rejectGet(new Error('backend unavailable'));
+    await loadPromise;
+
+    expect(getObservingState().sites).toHaveLength(1);
+  });
+
+  it('does not let a load clobber a usable-altitude change made while it was in flight', async () => {
+    let resolveGet!: (v: unknown) => void;
+    settingsGet.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGet = resolve;
+      }),
+    );
+
+    const loadPromise = loadObservingState();
+    await saveUsableAltitude(42);
+    expect(getUsableAltitude()).toBe(42);
+
+    resolveGet({ scope: OBSERVING_SCOPE, values: {} });
+    await loadPromise;
+
+    expect(getUsableAltitude()).toBe(42);
+  });
+
+  it('still applies a load when no write raced it', async () => {
+    // The guard must not disable loading outright.
+    settingsGet.mockResolvedValue({
+      scope: OBSERVING_SCOPE,
+      values: {
+        [SITES_KEY]: [SITE],
+        [DEFAULT_SITE_ID_KEY]: SITE.id,
+        [ACTIVE_SITE_ID_KEY]: SITE.id,
+      },
+    });
+
+    await loadObservingState();
+
+    expect(getObservingState().sites).toHaveLength(1);
+    expect(getObservingState().activeSiteId).toBe(SITE.id);
+  });
+});

--- a/apps/desktop/src/features/targets/observing-sites/site-store.ts
+++ b/apps/desktop/src/features/targets/observing-sites/site-store.ts
@@ -89,6 +89,13 @@ export function resolveActiveSite(state: ObservingState): ObserverSite | null {
 let current: ObservingState = EMPTY_STATE;
 const listeners = new Set<() => void>();
 
+// Mirrors the `writeGen` guard in ../guidance-settings.ts (#836). `Shell.tsx`
+// kicks off `loadObservingState()` at boot; on a slow backend that read can
+// still be in flight once the user reaches Targets and saves a site, and a read
+// that started before the write is stale by the time it resolves. A load only
+// applies if no save has committed since the load started.
+let writeGen = 0;
+
 function emit(): void {
   for (const fn of listeners) fn();
 }
@@ -108,11 +115,16 @@ function snapshot(): ObservingState {
  * unavailable.
  */
 export async function loadObservingState(): Promise<ObservingState> {
+  const genAtStart = writeGen;
   try {
     const data = unwrap(await commands.settingsGet(OBSERVING_SCOPE));
-    current = coerceObservingState(data.values as Record<string, unknown>);
+    if (writeGen === genAtStart) {
+      current = coerceObservingState(data.values as Record<string, unknown>);
+    }
   } catch {
-    current = EMPTY_STATE;
+    if (writeGen === genAtStart) {
+      current = EMPTY_STATE;
+    }
   }
   emit();
   return current;
@@ -139,6 +151,7 @@ export async function saveSites(
         : null,
     usableAltitudeDeg: current.usableAltitudeDeg,
   };
+  writeGen += 1;
   unwrap(
     await commands.settingsUpdate(OBSERVING_SCOPE, {
       [SITES_KEY]: next.sites,
@@ -167,6 +180,7 @@ export async function saveActiveSiteId(
  */
 export async function saveUsableAltitude(degrees: number): Promise<void> {
   const clamped = clampThreshold(degrees);
+  writeGen += 1;
   current = { ...current, usableAltitudeDeg: clamped };
   emit();
   unwrap(

--- a/apps/desktop/src/ui/Lock.test.tsx
+++ b/apps/desktop/src/ui/Lock.test.tsx
@@ -1,0 +1,46 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Lock keyboard-reachability tests (WCAG 1.4.13 / 2.1.1).
+ *
+ * Same defect class as #1103: the shared `Tooltip` renders its trigger as a
+ * bare `<span>` and base-ui adds no `tabIndex`, so a caller that relies on the
+ * trigger alone for reveal is pointer-only. `Lock`'s reason is not redundant
+ * prose — it states a consequence shown nowhere else — so it must be reachable
+ * and exposed to assistive tech.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import { Lock } from './Lock';
+
+describe('Lock accessibility', () => {
+  it('exposes the reason to assistive tech via a role that supports naming', () => {
+    render(<Lock reason="Protected — needs acknowledgement" />);
+
+    // A role-less <span> does not reliably expose aria-label, so the role is
+    // what makes the name reachable at all.
+    const trigger = screen.getByRole('note', {
+      name: 'Protected — needs acknowledgement',
+    });
+    expect(trigger).toBeInTheDocument();
+  });
+
+  it('is keyboard focusable so the tooltip is not pointer-only', () => {
+    render(<Lock reason="Protected — needs acknowledgement" />);
+
+    const trigger = screen.getByRole('note');
+    expect(trigger).toHaveAttribute('tabindex', '0');
+
+    trigger.focus();
+    expect(trigger).toHaveFocus();
+  });
+
+  it('falls back to the generic protected label when no reason is given', () => {
+    render(<Lock />);
+    expect(screen.getByRole('note', { name: 'Protected' })).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/ui/Lock.tsx
+++ b/apps/desktop/src/ui/Lock.tsx
@@ -9,11 +9,34 @@ export interface LockProps extends HTMLAttributes<HTMLSpanElement> {
   reason?: string;
 }
 
+/**
+ * Padlock glyph whose tooltip explains why a row or category is protected.
+ *
+ * `role="note"` + `tabIndex={0}` mirror `InfoTip`, and both are load-bearing
+ * (WCAG 1.4.13 / 2.1.1, same defect class as #1103):
+ *
+ * - The shared `Tooltip` renders its trigger as a bare `<span>` and base-ui
+ *   adds no `tabIndex`, so without one the reason is reachable by pointer
+ *   hover only — and the reason is not redundant prose. The cleanup-row hint
+ *   ("requires explicit acknowledgement during plan review") states a
+ *   consequence that appears nowhere else on screen; the adjacent pill says
+ *   only "Protected".
+ * - `aria-label` on a role-less `<span>` is not reliably exposed — naming
+ *   applies to elements with a role that supports it — so the role is what
+ *   makes the label reach assistive tech at all.
+ */
 export function Lock({ reason, className, ...rest }: LockProps) {
   const label = reason ?? m.settings_cleanup_protection_protected();
   const cls = ['alm-lock', className].filter(Boolean).join(' ');
   return (
-    <Tooltip content={label} className={cls} aria-label={label} {...rest}>
+    <Tooltip
+      content={label}
+      className={cls}
+      role="note"
+      tabIndex={0}
+      aria-label={label}
+      {...rest}
+    >
       &#x1F512;
     </Tooltip>
   );


### PR DESCRIPTION
## Summary

- A settings toggle you flipped while the app was still loading that setting no longer snaps back to the old value a moment later.
- The explanation behind a locked/protected item is now reachable by keyboard and announced by screen readers, instead of being hover-only.

## Detail

### Late settings read clobbering a user choice

A mount-time `settingsGet` was assigned straight into state the user can also
change. If the read resolved *after* the user had already acted, it overwrote
their choice. The existing `cancelled` flag does not cover this — it only guards
*unmount*, not the still-mounted case where the user has already acted.

Swept every `settingsGet` call site. Three real hits:

- **`CatalogueSettingsControl`** — worst case: `persist` had already written the
  toggle to the settings DB, so the clobber left the UI disagreeing with the
  backend.
- **`StepCatalogs`** (`DefaultProtectionControl`) — same shape, same consequence.
- **`site-store`** — `Shell` starts `loadObservingState()` at boot. Mirrors the
  `writeGen` guard its sibling `guidance-settings.ts` already had (#836). The
  **catch path** needed guarding too (it wrote `EMPTY_STATE` unconditionally),
  and `saveUsableAltitude` updates optimistically *before* its await.

Already correct, left alone: `Cleanup.tsx` (`editedRef`), `guidance-settings.ts`.
Not affected: `CommandPalette` (devMode is not user-mutable there),
`useCalibration` (react-query cache is the source of truth), `catalogue-settings`
/ `theme` (pure loaders with no state of their own).

### Tooltip reasons unreachable without a pointer (WCAG 1.4.13)

Only three `<Tooltip` call sites exist. `InfoTip` was already correct
(`role="note"` + `tabIndex={0}`). Two were not:

- **`ui/Lock`** — had neither. Its reason is *not* redundant prose: the
  cleanup-row hint says "requires explicit acknowledgement during plan review",
  a consequence shown nowhere else (the adjacent pill says only "Protected").
- **`components/PropertyTable`** — had `tabIndex` but no role.

**Both halves are load-bearing.** `tabIndex` alone leaves `aria-label` unexposed
— naming is ignored on a role-less `<span>`, so a screen reader announces the
value and never the tooltip. Role alone leaves it pointer-only.

## Reviewer note — a deliberate tradeoff

This adds **one tab stop per `Lock` instance**. That is the cost `InfoTip`
already pays across Settings, and the alternative is keyboard-unreachable
content. Flagging it because it is a UX judgement call worth weighing in a
many-row cleanup table.

## Verification

- Race tests force the race with a deferred resolve and assert **directly**
  (never `waitFor`).
- Every guard verified in **both directions**: reverting a guard fails its race
  test while the no-race control keeps passing.
- `pnpm lint` exit 0, `pnpm typecheck` exit 0, 786/787 tests pass across
  `src/components`, `src/ui`, `src/features/*`.
- The one failure is **inherited from `main`**, not from this branch —
  `StepSourceFolders` asserts copy that #1130 reworded. Fixed separately in
  #1163; this branch will go fully green once that merges.

## Spec Context

Spec 056 follow-up sweep. Related a11y follow-up: #1103.
Deliberately does **not** touch `ui/Tooltip.tsx` or
`specs/056-onboarding-redesign/` — those belong to #1048.