### PR TITLE
ci: lint and format the end-to-end test suite, which no gate was reaching

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,6 +209,15 @@ jobs:
         if: needs.changes.outputs.frontend == 'true'
         run: pnpm --filter @astro-plan/desktop run lint
 
+      # `tests/` is outside the pnpm workspace globs (`apps/*`, `packages/*`),
+      # so `pnpm -r lint` never reaches it and `apps/desktop/biome.json` scopes
+      # itself to `src/**`. Without this step the E2E suite is unlinted and
+      # unformatted. Runs off the root biome.json, which is scoped to `tests/**`
+      # so it cannot shadow the nested desktop config.
+      - name: Test-suite lint (Biome over tests/)
+        if: needs.changes.outputs.frontend == 'true'
+        run: pnpm run lint:tests
+
       # Formatting is OS-agnostic; running it on all 3 legs is pure redundancy.
       - name: Rust format
         if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,49 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "files": {
+    "includes": ["tests/**/*.ts", "!**/node_modules/**"]
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true,
+      "a11y": "off",
+      "complexity": {
+        "useLiteralKeys": "off"
+      },
+      "correctness": {
+        "noUnusedVariables": "error",
+        "useExhaustiveDependencies": "off",
+        "useHookAtTopLevel": "off"
+      },
+      "style": {
+        "noNonNullAssertion": "warn",
+        "noCommonJs": "error"
+      },
+      "suspicious": {
+        "noArrayIndexKey": "off",
+        "noExplicitAny": "warn",
+        "noTemplateCurlyInString": "off"
+      }
+    }
+  },
+  "assist": {
+    "enabled": false
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 80,
+    "lineEnding": "lf"
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always",
+      "trailingCommas": "all",
+      "arrowParentheses": "always",
+      "jsxQuoteStyle": "double"
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -7,13 +7,15 @@
   "scripts": {
     "build": "cargo build --workspace && pnpm -r --if-present build",
     "test": "cargo test --workspace && pnpm -r --if-present test",
-    "lint": "cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && pnpm -r --if-present lint",
+    "lint": "cargo fmt --all --check && cargo clippy --workspace --all-targets -- -D warnings && pnpm -r --if-present lint && pnpm run lint:tests",
     "typecheck": "pnpm -r --if-present typecheck",
     "contracts:build": "pnpm --filter @astro-plan/contracts build",
     "desktop:dev": "pnpm --filter @astro-plan/desktop dev",
-    "fixtures:check": "echo \"Fixture checks pending fixture implementation\""
+    "fixtures:check": "echo \"Fixture checks pending fixture implementation\"",
+    "lint:tests": "biome check tests"
   },
   "devDependencies": {
+    "@biomejs/biome": "2.5.3",
     "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     devDependencies:
+      '@biomejs/biome':
+        specifier: 2.5.3
+        version: 2.5.3
       typescript:
         specifier: ^5.9.3
         version: 5.9.3

--- a/tests/e2e/adaptive_detail_dock.spec.ts
+++ b/tests/e2e/adaptive_detail_dock.spec.ts
@@ -20,73 +20,73 @@
  * adaptive threshold) and is unaffected by this change.
  */
 import {
-	test,
-	expect,
-	seedSetupComplete,
-	disableGuidedTourOverlay,
-} from "./support/harness";
+  test,
+  expect,
+  seedSetupComplete,
+  disableGuidedTourOverlay,
+} from './support/harness';
 
-test.describe("adaptive detail-panel dock (spec 054 / #936)", () => {
-	test("docks to the side at a wide viewport and falls back to the bottom at 1100x720", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.setViewportSize({ width: 1600, height: 900 });
-		await page.goto("/#/calibration");
-		await disableGuidedTourOverlay(page);
-		await expect(page.locator(".alm-calib-table")).toBeVisible({
-			timeout: 8_000,
-		});
+test.describe('adaptive detail-panel dock (spec 054 / #936)', () => {
+  test('docks to the side at a wide viewport and falls back to the bottom at 1100x720', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.setViewportSize({ width: 1600, height: 900 });
+    await page.goto('/#/calibration');
+    await disableGuidedTourOverlay(page);
+    await expect(page.locator('.alm-calib-table')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		const darkRow = page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Dark · 120s" });
-		await darkRow.click();
-		const detail = page.locator(".alm-listpage__detail");
-		await expect(detail).toBeVisible({ timeout: 5_000 });
-		await expect(detail).toHaveClass(/alm-listpage__detail--side/);
-		await expect(page.getByTestId("dock-resize-handle")).toBeVisible();
+    const darkRow = page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Dark · 120s' });
+    await darkRow.click();
+    const detail = page.locator('.alm-listpage__detail');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
+    await expect(detail).toHaveClass(/alm-listpage__detail--side/);
+    await expect(page.getByTestId('dock-resize-handle')).toBeVisible();
 
-		// Shrink to the shell's enforced minimum — bottom is the universal
-		// narrow fallback (decision #8); the resize handle disappears with it.
-		await page.setViewportSize({ width: 1100, height: 720 });
-		await expect(detail).not.toHaveClass(/alm-listpage__detail--side/);
-		await expect(page.getByTestId("dock-resize-handle")).not.toBeVisible();
-		// The panel itself, and its content, remain intact through the switch.
-		await expect(detail).toContainText("Poseidon-C PRO");
-	});
+    // Shrink to the shell's enforced minimum — bottom is the universal
+    // narrow fallback (decision #8); the resize handle disappears with it.
+    await page.setViewportSize({ width: 1100, height: 720 });
+    await expect(detail).not.toHaveClass(/alm-listpage__detail--side/);
+    await expect(page.getByTestId('dock-resize-handle')).not.toBeVisible();
+    // The panel itself, and its content, remain intact through the switch.
+    await expect(detail).toContainText('Poseidon-C PRO');
+  });
 
-	test("pinning to side persists the placement across a reload", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.setViewportSize({ width: 1024, height: 768 });
-		await page.goto("/#/calibration");
-		await disableGuidedTourOverlay(page);
-		await expect(page.locator(".alm-calib-table")).toBeVisible({
-			timeout: 8_000,
-		});
+  test('pinning to side persists the placement across a reload', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.setViewportSize({ width: 1024, height: 768 });
+    await page.goto('/#/calibration');
+    await disableGuidedTourOverlay(page);
+    await expect(page.locator('.alm-calib-table')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		await page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Dark · 120s" })
-			.click();
-		const detail = page.locator(".alm-listpage__detail");
-		await expect(detail).toBeVisible({ timeout: 5_000 });
-		await expect(detail).not.toHaveClass(/alm-listpage__detail--side/);
+    await page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Dark · 120s' })
+      .click();
+    const detail = page.locator('.alm-listpage__detail');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
+    await expect(detail).not.toHaveClass(/alm-listpage__detail--side/);
 
-		await page.getByRole("radio", { name: "Right" }).click();
-		await expect(detail).toHaveClass(/alm-listpage__detail--side/);
+    await page.getByRole('radio', { name: 'Right' }).click();
+    await expect(detail).toHaveClass(/alm-listpage__detail--side/);
 
-		await page.reload();
-		await disableGuidedTourOverlay(page);
-		await page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Dark · 120s" })
-			.click();
-		const detailAfterReload = page.locator(".alm-listpage__detail");
-		await expect(detailAfterReload).toBeVisible({ timeout: 5_000 });
-		// The pin survives the reload even though 1024 is below the auto threshold.
-		await expect(detailAfterReload).toHaveClass(/alm-listpage__detail--side/);
-	});
+    await page.reload();
+    await disableGuidedTourOverlay(page);
+    await page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Dark · 120s' })
+      .click();
+    const detailAfterReload = page.locator('.alm-listpage__detail');
+    await expect(detailAfterReload).toBeVisible({ timeout: 5_000 });
+    // The pin survives the reload even though 1024 is below the auto threshold.
+    await expect(detailAfterReload).toHaveClass(/alm-listpage__detail--side/);
+  });
 });

--- a/tests/e2e/add_target_focus.spec.ts
+++ b/tests/e2e/add_target_focus.spec.ts
@@ -13,19 +13,24 @@
  *
  * Verification layer: PE — Playwright mocks-UI (run in WSL).
  */
-import { test, expect, seedSetupComplete, disableGuidedTourOverlay } from "./support/harness";
+import {
+  test,
+  expect,
+  seedSetupComplete,
+  disableGuidedTourOverlay,
+} from './support/harness';
 
-test.describe("Regression · Add target dialog focus (#856)", () => {
-  test("opening Add target focuses the search input, not the close button", async ({
+test.describe('Regression · Add target dialog focus (#856)', () => {
+  test('opening Add target focuses the search input, not the close button', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await page.getByRole("button", { name: "Add target" }).click();
+    await page.getByRole('button', { name: 'Add target' }).click();
 
-    const search = page.getByLabel("Search for a target");
+    const search = page.getByLabel('Search for a target');
     await expect(search).toBeVisible();
     await expect(search).toBeFocused();
   });

--- a/tests/e2e/archive_lifecycle.spec.ts
+++ b/tests/e2e/archive_lifecycle.spec.ts
@@ -49,75 +49,85 @@
  * First-run seeding:
  *   Reads `alm-preferences.setupCompleted` from localStorage.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-function seedSetupComplete(page: import("@playwright/test").Page): void {
+function seedSetupComplete(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-preferences",
+      'alm-preferences',
       JSON.stringify({ setupCompleted: true }),
     );
   });
 }
 
-test.describe("archive lifecycle (spec 017 US6 / Journey 7)", () => {
-  test("archive page lists entries; selecting one opens detail with canonical archive|trash actions", async ({
+test.describe('archive lifecycle (spec 017 US6 / Journey 7)', () => {
+  test('archive page lists entries; selecting one opens detail with canonical archive|trash actions', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/archive");
+    await page.goto('/#/archive');
 
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // ── 1. Archive list renders both fixture entries ─────────────────────────
-    const list = page.getByTestId("archive-list");
+    const list = page.getByTestId('archive-list');
     await expect(list).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByTestId("archive-row-arch-proj-001")).toBeVisible();
-    await expect(page.getByTestId("archive-row-arch-proj-002")).toBeVisible();
-    await expect(list.getByText("NGC 7000 · HOO (v1)")).toBeVisible();
-    await expect(list.getByText("M31 · LRGB (2025)")).toBeVisible();
+    await expect(page.getByTestId('archive-row-arch-proj-001')).toBeVisible();
+    await expect(page.getByTestId('archive-row-arch-proj-002')).toBeVisible();
+    await expect(list.getByText('NGC 7000 · HOO (v1)')).toBeVisible();
+    await expect(list.getByText('M31 · LRGB (2025)')).toBeVisible();
 
     // ── 2. Select the first entry → single-column detail panel opens ────────
-    await page.getByTestId("archive-row-arch-proj-001").click();
+    await page.getByTestId('archive-row-arch-proj-001').click();
 
     // Detail-as-delta (spec-030 Q16 T133 / FR-139): the detail panel no
     // longer echoes list-row facts. The reason renders on the LIST row only;
     // the detail keeps header identity (name/type/status/path) and leads
     // with Audit history — the panel's one real information class.
     await expect(
-      page.getByTestId("archive-row-arch-proj-001").getByText("Superseded by reprocess"),
+      page
+        .getByTestId('archive-row-arch-proj-001')
+        .getByText('Superseded by reprocess'),
     ).toBeVisible();
-    const detail = page.locator(".alm-detail");
+    const detail = page.locator('.alm-detail');
     await expect(detail).toBeVisible({ timeout: 5_000 });
-    await expect(detail.getByText("Audit history")).toBeVisible();
+    await expect(detail.getByText('Audit history')).toBeVisible();
     // The original path renders as the header subtitle.
-    await expect(detail.getByText("Projects/NGC7000_HOO_v1").first()).toBeVisible();
+    await expect(
+      detail.getByText('Projects/NGC7000_HOO_v1').first(),
+    ).toBeVisible();
     // Status pill from the shared archive vocabulary (scoped + case-sensitive
     // regex — "Archived" also appears as a PropertyTable field label).
     await expect(
-      detail.locator(".alm-pill").filter({ hasText: /^archived$/ }),
+      detail.locator('.alm-pill').filter({ hasText: /^archived$/ }),
     ).toBeVisible();
 
     // ── 3. Management actions use the canonical archive|trash vocabulary,
     //       never the legacy "os_trash" term ────────────────────────────────
-    const sendToTrashBtn = page.getByRole("button", { name: "Send to trash" });
-    const deletePermBtn = page.getByRole("button", { name: "Delete permanently" });
+    const sendToTrashBtn = page.getByRole('button', { name: 'Send to trash' });
+    const deletePermBtn = page.getByRole('button', {
+      name: 'Delete permanently',
+    });
     await expect(sendToTrashBtn).toBeVisible();
     await expect(deletePermBtn).toBeVisible();
     await expect(page.getByText(/os_trash/i)).toHaveCount(0);
 
     // ── 4. Reveal is disabled — no fabricated archive-location data ─────────
-    const revealBtn = page.getByTestId("archive-reveal-btn");
+    const revealBtn = page.getByTestId('archive-reveal-btn');
     await expect(revealBtn).toBeVisible();
     await expect(revealBtn).toBeDisabled();
   });
 
-  test('"Send to trash" completes against the mock without error', async ({ page }) => {
+  test('"Send to trash" completes against the mock without error', async ({
+    page,
+  }) => {
     seedSetupComplete(page);
-    await page.goto("/#/archive");
+    await page.goto('/#/archive');
 
-    await page.getByTestId("archive-row-arch-proj-001").click();
-    const sendToTrashBtn = page.getByRole("button", { name: "Send to trash" });
+    await page.getByTestId('archive-row-arch-proj-001').click();
+    const sendToTrashBtn = page.getByRole('button', { name: 'Send to trash' });
     await expect(sendToTrashBtn).toBeEnabled({ timeout: 5_000 });
 
     await sendToTrashBtn.click();
@@ -125,32 +135,38 @@ test.describe("archive lifecycle (spec 017 US6 / Journey 7)", () => {
     // The mutation completes (button re-enables once settled) with no error
     // boundary or crash — mock archive_send_to_trash always succeeds.
     await expect(sendToTrashBtn).toBeEnabled({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 
   test('"Delete permanently" is gated behind the typed "DELETE" confirmation (FR-017)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/archive");
+    await page.goto('/#/archive');
 
-    await page.getByTestId("archive-row-arch-proj-001").click();
-    await page.getByRole("button", { name: "Delete permanently" }).click();
+    await page.getByTestId('archive-row-arch-proj-001').click();
+    await page.getByRole('button', { name: 'Delete permanently' }).click();
 
-    const modal = page.getByRole("dialog", { name: "Delete permanently" });
+    const modal = page.getByRole('dialog', { name: 'Delete permanently' });
     await expect(modal).toBeVisible({ timeout: 5_000 });
-    await expect(modal.getByText(/permanently deletes the archived/i)).toBeVisible();
+    await expect(
+      modal.getByText(/permanently deletes the archived/i),
+    ).toBeVisible();
 
-    const confirmBtn = modal.getByRole("button", { name: "Delete permanently" });
+    const confirmBtn = modal.getByRole('button', {
+      name: 'Delete permanently',
+    });
     // Disabled until the exact literal "DELETE" is typed (constitution II —
     // destructive operations require explicit confirmation).
     await expect(confirmBtn).toBeDisabled();
 
-    const confirmInput = modal.getByLabel("Type DELETE to confirm");
-    await confirmInput.fill("delete");
+    const confirmInput = modal.getByLabel('Type DELETE to confirm');
+    await confirmInput.fill('delete');
     await expect(confirmBtn).toBeDisabled();
 
-    await confirmInput.fill("DELETE");
+    await confirmInput.fill('DELETE');
     await expect(confirmBtn).toBeEnabled();
 
     await confirmBtn.click();
@@ -158,6 +174,8 @@ test.describe("archive lifecycle (spec 017 US6 / Journey 7)", () => {
     // On success the modal closes (archive.permanently_delete mock always
     // succeeds); no crash, no leftover error boundary.
     await expect(modal).not.toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 });

--- a/tests/e2e/calibration_masters_matching.spec.ts
+++ b/tests/e2e/calibration_masters_matching.spec.ts
@@ -65,216 +65,226 @@
  * top-candidate confidence 0.97 → "97%".
  */
 import {
-	test,
-	expect,
-	seedSetupComplete,
-	disableGuidedTourOverlay,
-} from "./support/harness";
+  test,
+  expect,
+  seedSetupComplete,
+  disableGuidedTourOverlay,
+} from './support/harness';
 
-test.describe("calibration · masters listing + matching (spec 040 / 007)", () => {
-	// ── Journey 8 · Calibration page lists detected masters individually with
-	//    kind-conditional fingerprint columns (spec 040 US2 FR-006 / US3 FR-007;
-	//    the "format/type-distinguished" master surface). ──────────────────────
-	test("Calibration page lists masters as individual items with kind-conditional Filter/Exposure columns (spec 040 US2/US3 FR-006/FR-007)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/calibration");
-		await disableGuidedTourOverlay(page);
+test.describe('calibration · masters listing + matching (spec 040 / 007)', () => {
+  // ── Journey 8 · Calibration page lists detected masters individually with
+  //    kind-conditional fingerprint columns (spec 040 US2 FR-006 / US3 FR-007;
+  //    the "format/type-distinguished" master surface). ──────────────────────
+  test('Calibration page lists masters as individual items with kind-conditional Filter/Exposure columns (spec 040 US2/US3 FR-006/FR-007)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/calibration');
+    await disableGuidedTourOverlay(page);
 
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
-		// The dense full-width masters table renders (not the loading/empty state).
-		const table = page.locator(".alm-calib-table");
-		await expect(table).toBeVisible({ timeout: 8_000 });
+    // The dense full-width masters table renders (not the loading/empty state).
+    const table = page.locator('.alm-calib-table');
+    await expect(table).toBeVisible({ timeout: 8_000 });
 
-		// Each master is its OWN row, labelled by type + its discriminator
-		// (exposure for darks, filter for flats) — FR-005/FR-006 "individual
-		// items distinguished by filter/exposure", not a folder lump.
-		const darkRow = page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Dark · 120s" });
-		const flatRow = page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Flat · Ha" });
-		const biasRow = page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Bias" })
-			.first();
-		await expect(darkRow).toBeVisible();
-		await expect(flatRow).toBeVisible();
-		await expect(biasRow).toBeVisible();
+    // Each master is its OWN row, labelled by type + its discriminator
+    // (exposure for darks, filter for flats) — FR-005/FR-006 "individual
+    // items distinguished by filter/exposure", not a folder lump.
+    const darkRow = page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Dark · 120s' });
+    const flatRow = page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Flat · Ha' });
+    const biasRow = page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Bias' })
+      .first();
+    await expect(darkRow).toBeVisible();
+    await expect(flatRow).toBeVisible();
+    await expect(biasRow).toBeVisible();
 
-		// Kind pills discriminate the base frame type (spec 040 FR-004 classify).
-		await expect(darkRow.getByText("DARK", { exact: true })).toBeVisible();
-		await expect(flatRow.getByText("FLAT", { exact: true })).toBeVisible();
-		await expect(biasRow.getByText("BIAS", { exact: true })).toBeVisible();
+    // Kind pills discriminate the base frame type (spec 040 FR-004 classify).
+    await expect(darkRow.getByText('DARK', { exact: true })).toBeVisible();
+    await expect(flatRow.getByText('FLAT', { exact: true })).toBeVisible();
+    await expect(biasRow.getByText('BIAS', { exact: true })).toBeVisible();
 
-		// Applicability-driven columns (MastersTable.filterCell / exposureCell,
-		// spec-030 Q16 field-applicability matrix): cell order → 2 = Filter,
-		// 4 = Exposure. "—" is the NOT-APPLICABLE marker (a missing-but-
-		// applicable value would render the "Unresolved" chip instead).
-		//   DARK: Exposure "120s"; Filter not applicable to darks → "—".
-		await expect(darkRow.locator("td").nth(4)).toHaveText("120s");
-		await expect(darkRow.locator("td").nth(2)).toHaveText("—");
-		//   FLAT: Filter "Ha"; Exposure applies to flats (matrix) and the
-		//   fixture carries a real 3.0s FlatWizard exposure → "3s", no longer
-		//   suppressed to a dash by the old kind-hardcoded cell.
-		await expect(flatRow.locator("td").nth(2)).toHaveText("Ha");
-		await expect(flatRow.locator("td").nth(4)).toHaveText("3s");
-		//   BIAS: neither Filter nor Exposure applies → both "—".
-		await expect(biasRow.locator("td").nth(2)).toHaveText("—");
-		await expect(biasRow.locator("td").nth(4)).toHaveText("—");
-	});
+    // Applicability-driven columns (MastersTable.filterCell / exposureCell,
+    // spec-030 Q16 field-applicability matrix): cell order → 2 = Filter,
+    // 4 = Exposure. "—" is the NOT-APPLICABLE marker (a missing-but-
+    // applicable value would render the "Unresolved" chip instead).
+    //   DARK: Exposure "120s"; Filter not applicable to darks → "—".
+    await expect(darkRow.locator('td').nth(4)).toHaveText('120s');
+    await expect(darkRow.locator('td').nth(2)).toHaveText('—');
+    //   FLAT: Filter "Ha"; Exposure applies to flats (matrix) and the
+    //   fixture carries a real 3.0s FlatWizard exposure → "3s", no longer
+    //   suppressed to a dash by the old kind-hardcoded cell.
+    await expect(flatRow.locator('td').nth(2)).toHaveText('Ha');
+    await expect(flatRow.locator('td').nth(4)).toHaveText('3s');
+    //   BIAS: neither Filter nor Exposure applies → both "—".
+    await expect(biasRow.locator('td').nth(2)).toHaveText('—');
+    await expect(biasRow.locator('td').nth(4)).toHaveText('—');
+  });
 
-	// ── Journey 8 · Aging masters are flagged (FR-023); selecting a master opens
-	//    its fingerprint detail with Used-by / Compatible session context and the
-	//    aging "Replace master" affordance (spec 040 metadata display). ─────────
-	test("aging masters carry an 'aging' pill and a fresh master does not; selecting one opens its fingerprint detail (spec 040 US3 / spec 007 FR-023)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/calibration");
-		await disableGuidedTourOverlay(page);
-		await expect(page.locator(".alm-calib-table")).toBeVisible({ timeout: 8_000 });
+  // ── Journey 8 · Aging masters are flagged (FR-023); selecting a master opens
+  //    its fingerprint detail with Used-by / Compatible session context and the
+  //    aging "Replace master" affordance (spec 040 metadata display). ─────────
+  test("aging masters carry an 'aging' pill and a fresh master does not; selecting one opens its fingerprint detail (spec 040 US3 / spec 007 FR-023)", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/calibration');
+    await disableGuidedTourOverlay(page);
+    await expect(page.locator('.alm-calib-table')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		// m-1 (ageDays 245 > 90-day threshold) is flagged as aging IN-ROW.
-		const agingRow = page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Dark · 120s" });
-		await expect(agingRow.getByText("aging 245d")).toBeVisible();
+    // m-1 (ageDays 245 > 90-day threshold) is flagged as aging IN-ROW.
+    const agingRow = page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Dark · 120s' });
+    await expect(agingRow.getByText('aging 245d')).toBeVisible();
 
-		// m-5 (ageDays 38 < threshold) is fresh — no aging pill on its row.
-		const freshRow = page
-			.locator(".alm-calib-table__row")
-			.filter({ hasText: "Master Dark · 300s" })
-			.first();
-		await expect(freshRow).toBeVisible();
-		await expect(freshRow.getByText(/aging \d+d/)).toHaveCount(0);
+    // m-5 (ageDays 38 < threshold) is fresh — no aging pill on its row.
+    const freshRow = page
+      .locator('.alm-calib-table__row')
+      .filter({ hasText: 'Master Dark · 300s' })
+      .first();
+    await expect(freshRow).toBeVisible();
+    await expect(freshRow.getByText(/aging \d+d/)).toHaveCount(0);
 
-		// Select the aging master → the right-side MasterDetail pane mounts.
-		await agingRow.click();
-		const detail = page.locator(".alm-listpage__detail");
-		await expect(detail).toBeVisible({ timeout: 5_000 });
+    // Select the aging master → the right-side MasterDetail pane mounts.
+    await agingRow.click();
+    const detail = page.locator('.alm-listpage__detail');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
 
-		// Fingerprint PropertyTable exposes the master's real metadata
-		// (Poseidon-C PRO · gain 125 · 120s) — the fields that later drive
-		// spec 007 dimension matching.
-		await expect(detail).toContainText("Poseidon-C PRO");
-		await expect(detail).toContainText("125");
-		await expect(detail).toContainText("120s");
+    // Fingerprint PropertyTable exposes the master's real metadata
+    // (Poseidon-C PRO · gain 125 · 120s) — the fields that later drive
+    // spec 007 dimension matching.
+    await expect(detail).toContainText('Poseidon-C PRO');
+    await expect(detail).toContainText('125');
+    await expect(detail).toContainText('120s');
 
-		// Session-context popovers render for both relationships (FR-006 usage).
-		await expect(detail.getByText("Used by", { exact: true })).toBeVisible();
-		await expect(detail.getByText("Compatible", { exact: true })).toBeVisible();
+    // Session-context popovers render for both relationships (FR-006 usage).
+    await expect(detail.getByText('Used by', { exact: true })).toBeVisible();
+    await expect(detail.getByText('Compatible', { exact: true })).toBeVisible();
 
-		// The aging master offers the destructive "Replace master" action
-		// alongside "Use in project" (a fresh master would omit Replace).
-		await expect(
-			detail.getByRole("button", { name: "Use in project" }),
-		).toBeVisible();
-		await expect(
-			detail.getByRole("button", { name: "Replace master" }),
-		).toBeVisible();
+    // The aging master offers the destructive "Replace master" action
+    // alongside "Use in project" (a fresh master would omit Replace).
+    await expect(
+      detail.getByRole('button', { name: 'Use in project' }),
+    ).toBeVisible();
+    await expect(
+      detail.getByRole('button', { name: 'Replace master' }),
+    ).toBeVisible();
 
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
-	});
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
+  });
 
-	// ── Journey 8 · Calibration matching/reuse: project readiness surfaces
-	//    ranked suggestions carrying an explicit per-candidate CONFIDENCE for
-	//    each linked light session (spec 007 US1/US6 FR-006 / SC-002). ──────────
-	test("project 'Calibration readiness' shows a confidence-carried match status per linked session (spec 007 FR-006/SC-002)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/projects");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  // ── Journey 8 · Calibration matching/reuse: project readiness surfaces
+  //    ranked suggestions carrying an explicit per-candidate CONFIDENCE for
+  //    each linked light session (spec 007 US1/US6 FR-006 / SC-002). ──────────
+  test("project 'Calibration readiness' shows a confidence-carried match status per linked session (spec 007 FR-006/SC-002)", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/projects');
+    await disableGuidedTourOverlay(page);
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
-		// Open proj-001's detail — this mounts ProjectBottomDetail, which renders
-		// the CalibrationMatchPanel for the project's linked source sessions
-		// (inv-001 / inv-002 from mockProjectDetail008).
-		const projectRow = page
-			.locator(".alm-projects-table__row")
-			.filter({ hasText: "NGC 7000 Narrowband" })
-			.first();
-		await expect(projectRow).toBeVisible({ timeout: 8_000 });
-		await projectRow.click();
+    // Open proj-001's detail — this mounts ProjectBottomDetail, which renders
+    // the CalibrationMatchPanel for the project's linked source sessions
+    // (inv-001 / inv-002 from mockProjectDetail008).
+    const projectRow = page
+      .locator('.alm-projects-table__row')
+      .filter({ hasText: 'NGC 7000 Narrowband' })
+      .first();
+    await expect(projectRow).toBeVisible({ timeout: 8_000 });
+    await projectRow.click();
 
-		// The read-only "Calibration readiness" section (batch-suggest driven).
-		const panel = page.getByTestId("cal-panel");
-		await expect(panel).toBeVisible({ timeout: 8_000 });
+    // The read-only "Calibration readiness" section (batch-suggest driven).
+    const panel = page.getByTestId('cal-panel');
+    await expect(panel).toBeVisible({ timeout: 8_000 });
 
-		// One row per linked source session — the panel is per-session (US6 batch).
-		await expect(panel.getByTestId("cal-session-inv-001")).toBeVisible();
-		await expect(panel.getByTestId("cal-session-inv-002")).toBeVisible();
+    // One row per linked source session — the panel is per-session (US6 batch).
+    await expect(panel.getByTestId('cal-session-inv-001')).toBeVisible();
+    await expect(panel.getByTestId('cal-session-inv-002')).toBeVisible();
 
-		// Each (session, type) result carries a status pill + an explicit
-		// confidence readout — the "recommendations carry per-candidate
-		// confidence" contract (FR-006). The mock's top dark candidate is 0.97.
-		const darkResult = panel.getByTestId("cal-type-dark-inv-001");
-		await expect(darkResult).toBeVisible();
-		await expect(darkResult.getByText("match", { exact: true })).toBeVisible();
-		await expect(panel.getByTestId("cal-confidence-dark-inv-001")).toHaveText(
-			"97%",
-		);
+    // Each (session, type) result carries a status pill + an explicit
+    // confidence readout — the "recommendations carry per-candidate
+    // confidence" contract (FR-006). The mock's top dark candidate is 0.97.
+    const darkResult = panel.getByTestId('cal-type-dark-inv-001');
+    await expect(darkResult).toBeVisible();
+    await expect(darkResult.getByText('match', { exact: true })).toBeVisible();
+    await expect(panel.getByTestId('cal-confidence-dark-inv-001')).toHaveText(
+      '97%',
+    );
 
-		// The panel is advisory (FR-007): it points at the Calibration page for
-		// the actual assign, rather than mutating from here.
-		await expect(panel).toContainText(/assign calibration masters/i);
-	});
+    // The panel is advisory (FR-007): it points at the Calibration page for
+    // the actual assign, rather than mutating from here.
+    await expect(panel).toContainText(/assign calibration masters/i);
+  });
 
-	// ── Journey 8 · Matching TOLERANCES are configurable and persist through the
-	//    update→get seam (spec 007 FR-002/FR-003 / SC-001). ─────────────────────
-	test("Calibration matching-criteria tolerances are configurable and the edit persists across a remount (spec 007 FR-002/FR-003/SC-001)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/settings/cal");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  // ── Journey 8 · Matching TOLERANCES are configurable and persist through the
+  //    update→get seam (spec 007 FR-002/FR-003 / SC-001). ─────────────────────
+  test('Calibration matching-criteria tolerances are configurable and the edit persists across a remount (spec 007 FR-002/FR-003/SC-001)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/settings/cal');
+    await disableGuidedTourOverlay(page);
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
-		// The "Matching criteria" pane loads the persisted tolerances singleton.
-		await expect(page.getByText("Matching criteria")).toBeVisible({
-			timeout: 8_000,
-		});
+    // The "Matching criteria" pane loads the persisted tolerances singleton.
+    await expect(page.getByText('Matching criteria')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		// Hard-required dimensions are exposed as toggles (spec 007 FR-012 hard
-		// rules): Camera / Binning / Gain / Offset, all defaulting on.
-		await expect(page.getByText("Camera", { exact: true })).toBeVisible();
-		await expect(page.getByText("Binning", { exact: true })).toBeVisible();
+    // Hard-required dimensions are exposed as toggles (spec 007 FR-012 hard
+    // rules): Camera / Binning / Gain / Offset, all defaulting on.
+    await expect(page.getByText('Camera', { exact: true })).toBeVisible();
+    await expect(page.getByText('Binning', { exact: true })).toBeVisible();
 
-		// Soft tolerances are numeric inputs seeded from the persisted singleton
-		// (temperatureToleranceC 5, agingLimitDays 365).
-		const tempInput = page.getByRole("spinbutton", {
-			name: /Sensor temperature tolerance/i,
-		});
-		const ageInput = page.getByRole("spinbutton", {
-			name: /Dark and bias age limit/i,
-		});
-		await expect(tempInput).toHaveValue("5");
-		await expect(ageInput).toHaveValue("365");
+    // Soft tolerances are numeric inputs seeded from the persisted singleton
+    // (temperatureToleranceC 5, agingLimitDays 365).
+    const tempInput = page.getByRole('spinbutton', {
+      name: /Sensor temperature tolerance/i,
+    });
+    const ageInput = page.getByRole('spinbutton', {
+      name: /Dark and bias age limit/i,
+    });
+    await expect(tempInput).toHaveValue('5');
+    await expect(ageInput).toHaveValue('365');
 
-		// Edit the sensor-temperature tolerance — this fires
-		// `calibration_tolerances_update`, which the stateful mock persists.
-		await tempInput.fill("8");
-		await expect(tempInput).toHaveValue("8");
+    // Edit the sensor-temperature tolerance — this fires
+    // `calibration_tolerances_update`, which the stateful mock persists.
+    await tempInput.fill('8');
+    await expect(tempInput).toHaveValue('8');
 
-		// Switch to another settings pane and back via the in-app nav (an SPA
-		// pane swap, NOT a document reload — so the persisted singleton survives).
-		// The pane switch unmounts CalibrationMatching and remounts it, forcing a
-		// fresh `calibration_tolerances_get`; the edited value must round-trip.
-		const nav = page.getByRole("navigation", { name: /settings/i });
-		await nav.getByRole("button", { name: "Appearance" }).click();
-		await expect(page.getByText("Matching criteria")).toHaveCount(0);
-		await nav.getByRole("button", { name: "Calibration Matching" }).click();
-		await expect(page.getByText("Matching criteria")).toBeVisible({
-			timeout: 8_000,
-		});
+    // Switch to another settings pane and back via the in-app nav (an SPA
+    // pane swap, NOT a document reload — so the persisted singleton survives).
+    // The pane switch unmounts CalibrationMatching and remounts it, forcing a
+    // fresh `calibration_tolerances_get`; the edited value must round-trip.
+    const nav = page.getByRole('navigation', { name: /settings/i });
+    await nav.getByRole('button', { name: 'Appearance' }).click();
+    await expect(page.getByText('Matching criteria')).toHaveCount(0);
+    await nav.getByRole('button', { name: 'Calibration Matching' }).click();
+    await expect(page.getByText('Matching criteria')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		const tempInputAfter = page.getByRole("spinbutton", {
-			name: /Sensor temperature tolerance/i,
-		});
-		await expect(tempInputAfter).toHaveValue("8");
-	});
+    const tempInputAfter = page.getByRole('spinbutton', {
+      name: /Sensor temperature tolerance/i,
+    });
+    await expect(tempInputAfter).toHaveValue('8');
+  });
 });

--- a/tests/e2e/cleanup_review.spec.ts
+++ b/tests/e2e/cleanup_review.spec.ts
@@ -55,109 +55,123 @@
 // The Tauri `Channel` polyfill this journey's approve-and-apply path needs is
 // installed globally by the shared harness `test` (see
 // `tests/e2e/support/harness.ts`) — no per-spec shim required.
-import { test, expect, seedSetupComplete } from "./support/harness";
+import { test, expect, seedSetupComplete } from './support/harness';
 
-test.describe("cleanup review (spec 017 WP-E / Journey 6)", () => {
-  test("scan → review candidates with confidence + protection → generate plan → protection gate → approve & apply", async ({
+test.describe('cleanup review (spec 017 WP-E / Journey 6)', () => {
+  test('scan → review candidates with confidence + protection → generate plan → protection gate → approve & apply', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
 
     // ── 1. Page renders without error boundary ────────────────────────────────
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // ── 2. Select the fixture project → bottom detail panel mounts ───────────
     const projectRow = page
-      .locator(".alm-projects-table__row")
-      .filter({ hasText: "NGC 7000 Narrowband" })
+      .locator('.alm-projects-table__row')
+      .filter({ hasText: 'NGC 7000 Narrowband' })
       .first();
     await expect(projectRow).toBeVisible({ timeout: 8_000 });
     await projectRow.click();
 
-    const cleanupSection = page.getByTestId("project-cleanup-preview");
+    const cleanupSection = page.getByTestId('project-cleanup-preview');
     await expect(cleanupSection).toBeVisible({ timeout: 8_000 });
 
     // ── 3. Protected categories are ALWAYS documented, even pre-scan
     //       (constitution II — protected categories/cleanup exclusions MUST
     //       be documented before any cleanup plan can be generated) ──────────
-    const protectedBlock = cleanupSection.getByTestId("cleanup-protected");
+    const protectedBlock = cleanupSection.getByTestId('cleanup-protected');
     await expect(protectedBlock).toBeVisible();
-    await expect(protectedBlock.getByText("Accepted outputs")).toBeVisible();
-    await expect(protectedBlock.getByText("Master calibration frames")).toBeVisible();
-    await expect(protectedBlock.getByText("Source acquisition frames")).toBeVisible();
+    await expect(protectedBlock.getByText('Accepted outputs')).toBeVisible();
+    await expect(
+      protectedBlock.getByText('Master calibration frames'),
+    ).toBeVisible();
+    await expect(
+      protectedBlock.getByText('Source acquisition frames'),
+    ).toBeVisible();
 
     // Before any scan, the section shows the scan prompt, not candidates.
     await expect(
-      cleanupSection.getByText("Scan this project to preview cleanup candidates."),
+      cleanupSection.getByText(
+        'Scan this project to preview cleanup candidates.',
+      ),
     ).toBeVisible();
 
     // ── 4. Scan (read-only preview, D11 step 1) ───────────────────────────────
-    const scanBtn = cleanupSection.getByTestId("cleanup-scan-btn");
+    const scanBtn = cleanupSection.getByTestId('cleanup-scan-btn');
     await expect(scanBtn).toBeVisible();
     await scanBtn.click();
 
     // Reclaimable total renders once the scan resolves (1_073_741_824 B = 1.0 GB).
-    await expect(cleanupSection.getByTestId("cleanup-reclaimable")).toHaveText(
-      "1.0 GB reclaimable",
+    await expect(cleanupSection.getByTestId('cleanup-reclaimable')).toHaveText(
+      '1.0 GB reclaimable',
       { timeout: 5_000 },
     );
 
     // ── 5. Candidates render grouped by classification with parsed confidence ─
-    const intermediateGroup = cleanupSection.getByTestId("cleanup-group-intermediate");
+    const intermediateGroup = cleanupSection.getByTestId(
+      'cleanup-group-intermediate',
+    );
     await expect(intermediateGroup).toBeVisible();
     // Two intermediate candidates, both 90% confidence, normal protection.
-    await expect(intermediateGroup.getByText("90%")).toHaveCount(2);
+    await expect(intermediateGroup.getByText('90%')).toHaveCount(2);
 
-    const masterGroup = cleanupSection.getByTestId("cleanup-group-master");
+    const masterGroup = cleanupSection.getByTestId('cleanup-group-master');
     await expect(masterGroup).toBeVisible();
-    await expect(masterGroup.getByText("95%")).toBeVisible();
+    await expect(masterGroup.getByText('95%')).toBeVisible();
 
     // The master candidate is protected: locked, NO affordance to include it,
     // clearly marked with the shared protected pill.
-    const protectedRow = masterGroup.getByTestId("cleanup-candidate-0");
+    const protectedRow = masterGroup.getByTestId('cleanup-candidate-0');
     await expect(protectedRow).toHaveClass(/alm-cleanup-scan__row--protected/);
-    await expect(protectedRow.getByText("Protected")).toBeVisible();
+    await expect(protectedRow.getByText('Protected')).toBeVisible();
 
     // ── 6. Destructive-destination picker uses canonical archive|trash vocab
     //       (spec 033 vocab split) — never the legacy "os_trash" wording ──────
     // exact:true — the destination hint text ("App-managed archive
     // folder — reversible…") also contains the substring "archive folder".
     await expect(
-      cleanupSection.getByText("Archive folder", { exact: true }),
+      cleanupSection.getByText('Archive folder', { exact: true }),
     ).toBeVisible();
     await expect(
-      cleanupSection.getByText("System trash", { exact: true }),
+      cleanupSection.getByText('System trash', { exact: true }),
     ).toBeVisible();
     await expect(cleanupSection.getByText(/os_trash/i)).toHaveCount(0);
 
     // ── 7. Generate the reviewable plan (D11 step 2) — no mutation yet ───────
-    const generateBtn = cleanupSection.getByTestId("cleanup-generate-btn");
+    const generateBtn = cleanupSection.getByTestId('cleanup-generate-btn');
     await generateBtn.click();
 
     await expect(
-      page.getByText("Cleanup plan created with 3 items — review before anything is applied."),
+      page.getByText(
+        'Cleanup plan created with 3 items — review before anything is applied.',
+      ),
     ).toBeVisible({ timeout: 5_000 });
 
     // ── 8. The shared PlanReviewOverlay opens automatically ──────────────────
-    const overlay = page.getByTestId("plan-review-overlay");
+    const overlay = page.getByTestId('plan-review-overlay');
     await expect(overlay).toBeVisible({ timeout: 5_000 });
-    await expect(overlay.getByText("Archive folder")).toBeVisible();
-    await expect(overlay.getByText(/Nothing has been changed on disk/)).toBeVisible();
+    await expect(overlay.getByText('Archive folder')).toBeVisible();
+    await expect(
+      overlay.getByText(/Nothing has been changed on disk/),
+    ).toBeVisible();
 
     // Every proposed item is listed before approval (FR-003/SC-001).
-    await expect(overlay.getByTestId("plan-review-items")).toBeVisible();
+    await expect(overlay.getByTestId('plan-review-items')).toBeVisible();
     // exact:true — the item's "from" path cell also contains this filename
     // as a substring (…/registered/Ha_300s_r_0001.xisf).
     await expect(
-      overlay.getByText("Ha_300s_r_0001.xisf", { exact: true }),
+      overlay.getByText('Ha_300s_r_0001.xisf', { exact: true }),
     ).toBeVisible();
 
     // ── 9. Spec-016 protection gate blocks approval until acknowledged ───────
-    const approveBtn = overlay.getByTestId("plan-review-approve-apply");
+    const approveBtn = overlay.getByTestId('plan-review-approve-apply');
     await expect(approveBtn).toBeDisabled();
 
-    await overlay.getByRole("button", { name: "Acknowledge" }).click();
+    await overlay.getByRole('button', { name: 'Acknowledge' }).click();
 
     // ── 9b. Destructive-confirm gate (FR-003, D9, issue #741): the shared
     //        plan fixture carries `delete` items, so approval also stays
@@ -165,17 +179,21 @@ test.describe("cleanup review (spec 017 WP-E / Journey 6)", () => {
     // `.click()` (not `.check()`) — the checkbox's `onChange` awaits a mock
     // IPC round-trip before flipping `checked`, and `.check()`'s single
     // post-click snapshot races that async update.
-    await overlay.getByTestId("plan-review-confirm-destructive").click();
+    await overlay.getByTestId('plan-review-confirm-destructive').click();
     await expect(
-      overlay.getByTestId("plan-review-confirm-destructive"),
+      overlay.getByTestId('plan-review-confirm-destructive'),
     ).toBeChecked({ timeout: 5_000 });
     await expect(approveBtn).toBeEnabled({ timeout: 5_000 });
 
     // ── 10. Approve & apply → plans.approve → plans.apply, live progress ────
     await approveBtn.click();
 
-    await expect(overlay.getByTestId("plan-review-progress")).toBeVisible({ timeout: 5_000 });
-    await expect(overlay.getByText("1 item applied")).toBeVisible();
-    await expect(page.getByText("Cleanup plan applied.")).toBeVisible({ timeout: 5_000 });
+    await expect(overlay.getByTestId('plan-review-progress')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(overlay.getByText('1 item applied')).toBeVisible();
+    await expect(page.getByText('Cleanup plan applied.')).toBeVisible({
+      timeout: 5_000,
+    });
   });
 });

--- a/tests/e2e/inbox_ingest_confirm.spec.ts
+++ b/tests/e2e/inbox_ingest_confirm.spec.ts
@@ -41,299 +41,345 @@
  * `test.skip`-documented scenarios are un-skipped at the foot of this file.
  */
 import {
-	test,
-	expect,
-	seedSetupComplete,
-	disableGuidedTourOverlay,
-} from "./support/harness";
+  test,
+  expect,
+  seedSetupComplete,
+  disableGuidedTourOverlay,
+} from './support/harness';
 
-test.describe("inbox ingest · classify / reclassify / confirm (spec 041)", () => {
-	test("cross-root aggregate list renders with reconciled per-type stats (spec 039 SC-001 / spec 041 US6 FR-021)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
+test.describe('inbox ingest · classify / reclassify / confirm (spec 041)', () => {
+  test('cross-root aggregate list renders with reconciled per-type stats (spec 039 SC-001 / spec 041 US6 FR-021)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
 
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
-		// ── Cross-root aggregate: items from both root-lights-001 (/astro/raw)
-		//    and root-inbox-001 (/astro/inbox) appear in a single list (spec 039).
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
-		await expect(page.getByTestId("inbox-item-item-001")).toBeVisible();
-		await expect(page.getByTestId("inbox-item-item-002")).toBeVisible();
-		await expect(page.getByTestId("inbox-item-item-master-dark")).toBeVisible();
-		await expect(page.getByTestId("inbox-item-item-003")).toBeVisible();
+    // ── Cross-root aggregate: items from both root-lights-001 (/astro/raw)
+    //    and root-inbox-001 (/astro/inbox) appear in a single list (spec 039).
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.getByTestId('inbox-item-item-001')).toBeVisible();
+    await expect(page.getByTestId('inbox-item-item-002')).toBeVisible();
+    await expect(page.getByTestId('inbox-item-item-master-dark')).toBeVisible();
+    await expect(page.getByTestId('inbox-item-item-003')).toBeVisible();
 
-		// ── No selection yet: the bottom detail dock is not mounted ───────────────
-		await expect(page.locator(".alm-listpage__detail")).toHaveCount(0);
+    // ── No selection yet: the bottom detail dock is not mounted ───────────────
+    await expect(page.locator('.alm-listpage__detail')).toHaveCount(0);
 
-		// ── Richer inbox queue statistics (US6): 3 non-master folders (item-001/
-		//    002/003) + 1 master (item-master-dark), broken down per frame type by
-		//    `deriveInboxStats` (dark: 1 master, unresolved: 3 folders — none of
-		//    the fixture items set `groupFrameType`, so all three fall into the
-		//    "unresolved" bucket (issue #791 renamed this from "mixed", which
-		//    collided with the unrelated per-item mixed-folder concept below);
-		//    the master alone carries `masterFrameType: "dark"`). ──
-		const statusSummary = page.getByTestId("statusbar-inbox-summary");
-		await expect(statusSummary).toContainText(/3 folders/i);
-		await expect(statusSummary).toContainText(/1 master/i);
+    // ── Richer inbox queue statistics (US6): 3 non-master folders (item-001/
+    //    002/003) + 1 master (item-master-dark), broken down per frame type by
+    //    `deriveInboxStats` (dark: 1 master, unresolved: 3 folders — none of
+    //    the fixture items set `groupFrameType`, so all three fall into the
+    //    "unresolved" bucket (issue #791 renamed this from "mixed", which
+    //    collided with the unrelated per-item mixed-folder concept below);
+    //    the master alone carries `masterFrameType: "dark"`). ──
+    const statusSummary = page.getByTestId('statusbar-inbox-summary');
+    await expect(statusSummary).toContainText(/3 folders/i);
+    await expect(statusSummary).toContainText(/1 master/i);
 
-		const statsSummary = page.getByTestId("inbox-stats-summary");
-		await expect(statsSummary.getByTestId("inbox-stats-type-dark")).toBeVisible();
-		await expect(statsSummary.getByTestId("inbox-stats-type-unresolved")).toBeVisible();
-		await expect(statsSummary.getByTestId("inbox-stats-type-unresolved")).toContainText("3");
-	});
+    const statsSummary = page.getByTestId('inbox-stats-summary');
+    await expect(
+      statsSummary.getByTestId('inbox-stats-type-dark'),
+    ).toBeVisible();
+    await expect(
+      statsSummary.getByTestId('inbox-stats-type-unresolved'),
+    ).toBeVisible();
+    await expect(
+      statsSummary.getByTestId('inbox-stats-type-unresolved'),
+    ).toContainText('3');
+  });
 
-	test("grouping the list by source then format nests items under their originating root (US2 FR-009 multi-level grouping)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test('grouping the list by source then format nests items under their originating root (US2 FR-009 multi-level grouping)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		// Slot 0: group by "Source" (basename of the item's root path — the
-		// closest observable analog, in the current mock/UI surface, to spec 041
-		// US13's source-group provenance: root-lights-001 → "raw",
-		// root-inbox-001 → "inbox").
-		await page
-			.getByRole("combobox", { name: "Group by", exact: true })
-			.selectOption("source");
-		// Slot 1: then by "Format" (fits / xisf / video) — a second, independent
-		// dimension so the nesting is genuinely two levels deep.
-		await page
-			.getByRole("combobox", { name: "Then group by (level 2)" })
-			.selectOption("format");
+    // Slot 0: group by "Source" (basename of the item's root path — the
+    // closest observable analog, in the current mock/UI surface, to spec 041
+    // US13's source-group provenance: root-lights-001 → "raw",
+    // root-inbox-001 → "inbox").
+    await page
+      .getByRole('combobox', { name: 'Group by', exact: true })
+      .selectOption('source');
+    // Slot 1: then by "Format" (fits / xisf / video) — a second, independent
+    // dimension so the nesting is genuinely two levels deep.
+    await page
+      .getByRole('combobox', { name: 'Then group by (level 2)' })
+      .selectOption('format');
 
-		// Top-level groups: "raw" (item-001, item-002, item-master-dark) and
-		// "inbox" (item-003).
-		const rawGroup = page.getByTestId("inbox-group-source-raw");
-		const inboxGroup = page.getByTestId("inbox-group-source-inbox");
-		await expect(rawGroup).toBeVisible();
-		await expect(inboxGroup).toBeVisible();
+    // Top-level groups: "raw" (item-001, item-002, item-master-dark) and
+    // "inbox" (item-003).
+    const rawGroup = page.getByTestId('inbox-group-source-raw');
+    const inboxGroup = page.getByTestId('inbox-group-source-inbox');
+    await expect(rawGroup).toBeVisible();
+    await expect(inboxGroup).toBeVisible();
 
-		// Nested format groups under "raw": fits (item-001, item-002) + xisf
-		// (item-master-dark). Under "inbox": video (item-003).
-		await expect(page.getByTestId("inbox-group-format-fits")).toBeVisible();
-		await expect(page.getByTestId("inbox-group-format-xisf")).toBeVisible();
-		await expect(page.getByTestId("inbox-group-format-video")).toBeVisible();
+    // Nested format groups under "raw": fits (item-001, item-002) + xisf
+    // (item-master-dark). Under "inbox": video (item-003).
+    await expect(page.getByTestId('inbox-group-format-fits')).toBeVisible();
+    await expect(page.getByTestId('inbox-group-format-xisf')).toBeVisible();
+    await expect(page.getByTestId('inbox-group-format-video')).toBeVisible();
 
-		// The persisted grouping is echoed as a hint at the foot of the list.
-		await expect(page.getByTestId("inbox-grouping-hint")).toContainText(
-			/Source.*Format/i,
-		);
-	});
+    // The persisted grouping is echoed as a hint at the foot of the list.
+    await expect(page.getByTestId('inbox-grouping-hint')).toContainText(
+      /Source.*Format/i,
+    );
+  });
 
-	test("a mixed detection shows its composition, blocks Confirm, and its needs-review file can be bulk-reclassified (US2 FR-011 / US3 FR-014 / US11 / US12 gate)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test('a mixed detection shows its composition, blocks Confirm, and its needs-review file can be bulk-reclassified (US2 FR-011 / US3 FR-014 / US11 / US12 gate)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		await page.getByTestId("inbox-item-item-001").click();
-		const detail = page.locator(".alm-listpage__detail");
-		await expect(detail).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId('inbox-item-item-001').click();
+    const detail = page.locator('.alm-listpage__detail');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
 
-		// FR-011: explicit multi-type composition, not a bare "mixed" label.
-		const mixedAlert = detail.getByTestId("inbox-mixed-alert");
-		await expect(mixedAlert).toBeVisible();
-		await expect(mixedAlert).toContainText("Mixed folder");
-		await expect(detail).toContainText("16 light");
-		await expect(detail).toContainText("2 dark");
+    // FR-011: explicit multi-type composition, not a bare "mixed" label.
+    const mixedAlert = detail.getByTestId('inbox-mixed-alert');
+    await expect(mixedAlert).toBeVisible();
+    await expect(mixedAlert).toContainText('Mixed folder');
+    await expect(detail).toContainText('16 light');
+    await expect(detail).toContainText('2 dark');
 
-		// Confirm is disabled for a mixed row (spec 041 FR-050 — the backend
-		// "split" action was removed; only single_type rows are confirmable).
-		await expect(detail.getByTestId("inbox-confirm-btn")).toBeDisabled();
+    // Confirm is disabled for a mixed row (spec 041 FR-050 — the backend
+    // "split" action was removed; only single_type rows are confirmable).
+    await expect(detail.getByTestId('inbox-confirm-btn')).toBeDisabled();
 
-		// US12 needs-review bucket: the item's one unclassified file is listed
-		// with a select-all + per-file override control.
-		await expect(detail.getByText("Needs review (1)")).toBeVisible();
-		const selectAll = detail.getByTestId("reclassify-select-all");
-		await expect(selectAll).toBeVisible();
+    // US12 needs-review bucket: the item's one unclassified file is listed
+    // with a select-all + per-file override control.
+    await expect(detail.getByText('Needs review (1)')).toBeVisible();
+    const selectAll = detail.getByTestId('reclassify-select-all');
+    await expect(selectAll).toBeVisible();
 
-		// US11/FR-014: multi-select bulk override — select the file, choose a
-		// bulk frame-type correction, and apply it to the whole selection.
-		await selectAll.check();
-		await detail.getByTestId("bulk-frame-type").selectOption("light");
-		const bulkApplyBtn = detail.getByTestId("bulk-apply-btn");
-		await expect(bulkApplyBtn).toContainText("Apply to selected (1)");
-		await bulkApplyBtn.click();
+    // US11/FR-014: multi-select bulk override — select the file, choose a
+    // bulk frame-type correction, and apply it to the whole selection.
+    await selectAll.check();
+    await detail.getByTestId('bulk-frame-type').selectOption('light');
+    const bulkApplyBtn = detail.getByTestId('bulk-apply-btn');
+    await expect(bulkApplyBtn).toContainText('Apply to selected (1)');
+    await bulkApplyBtn.click();
 
-		// FR-015: no leaked/failed-apply error banner, and the selection clears
-		// once the (mocked) reclassify succeeds — the bulk-apply affordance is
-		// ready to be used again rather than stuck mid-selection.
-		await expect(detail.locator(".alm-inbox-detail__banner-mt2")).toHaveCount(0);
-		await expect(selectAll).not.toBeChecked({ timeout: 5_000 });
-	});
+    // FR-015: no leaked/failed-apply error banner, and the selection clears
+    // once the (mocked) reclassify succeeds — the bulk-apply affordance is
+    // ready to be used again rather than stuck mid-selection.
+    await expect(detail.locator('.alm-inbox-detail__banner-mt2')).toHaveCount(
+      0,
+    );
+    await expect(selectAll).not.toBeChecked({ timeout: 5_000 });
+  });
 
-	test("confirming a single-type detection from an unorganized source produces a reviewable-plan toast (US1 FR-001/FR-002, US4 move path)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test('confirming a single-type detection from an unorganized source produces a reviewable-plan toast (US1 FR-001/FR-002, US4 move path)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		// item-002: state=pending_classification, classify() resolves to
-		// single_type "dark" — Confirm becomes available once classification
-		// lands (all fixture items are organizationState="unorganized", so this
-		// exercises the move-plan path per FR-017/FR-019).
-		await page.getByTestId("inbox-item-item-002").click();
-		const detail = page.locator(".alm-listpage__detail");
-		await expect(detail).toBeVisible({ timeout: 5_000 });
-		await expect(detail).toContainText("dark", { timeout: 5_000 });
+    // item-002: state=pending_classification, classify() resolves to
+    // single_type "dark" — Confirm becomes available once classification
+    // lands (all fixture items are organizationState="unorganized", so this
+    // exercises the move-plan path per FR-017/FR-019).
+    await page.getByTestId('inbox-item-item-002').click();
+    const detail = page.locator('.alm-listpage__detail');
+    await expect(detail).toBeVisible({ timeout: 5_000 });
+    await expect(detail).toContainText('dark', { timeout: 5_000 });
 
-		const confirmBtn = detail.getByTestId("inbox-confirm-btn");
-		await expect(confirmBtn).toBeEnabled({ timeout: 5_000 });
-		await confirmBtn.click();
+    const confirmBtn = detail.getByTestId('inbox-confirm-btn');
+    await expect(confirmBtn).toBeEnabled({ timeout: 5_000 });
+    await confirmBtn.click();
 
-		// The mock `inbox_confirm` always returns `{ itemsTotal: 18, planState:
-		// 'ready_for_review', ... }`, surfaced via a toast (FR-001: a reviewable
-		// plan is produced, not an immediate move).
-		await expect(
-			page.getByText(/Plan created \(18 items\)\. Review below before applying\./i),
-		).toBeVisible({ timeout: 5_000 });
+    // The mock `inbox_confirm` always returns `{ itemsTotal: 18, planState:
+    // 'ready_for_review', ... }`, surfaced via a toast (FR-001: a reviewable
+    // plan is produced, not an immediate move).
+    await expect(
+      page.getByText(
+        /Plan created \(18 items\)\. Review below before applying\./i,
+      ),
+    ).toBeVisible({ timeout: 5_000 });
 
-		// No error toast/boundary fired alongside the success toast.
-		await expect(page.getByText(/Confirm failed/i)).toHaveCount(0);
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    // No error toast/boundary fired alongside the success toast.
+    await expect(page.getByText(/Confirm failed/i)).toHaveCount(0);
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
-		// NOTE: this mock's `inbox_list` fixture is STATIC (does not transition
-		// the confirmed item's `state` to `plan_open`, mirroring the same
-		// documented limitation `lifecycle_transitions.spec.ts` already notes for
-		// `projects.list`), and the plan-approval overlay is unreachable in mock
-		// mode (see the file header) — so the post-confirm "item stays visible as
-		// planned" (SC-003) and "review the plan in-context" (SC-002) assertions
-		// are NOT made here; they need the real backend / additional mocks.
-	});
+    // NOTE: this mock's `inbox_list` fixture is STATIC (does not transition
+    // the confirmed item's `state` to `plan_open`, mirroring the same
+    // documented limitation `lifecycle_transitions.spec.ts` already notes for
+    // `projects.list`), and the plan-approval overlay is unreachable in mock
+    // mode (see the file header) — so the post-confirm "item stays visible as
+    // planned" (SC-003) and "review the plan in-context" (SC-002) assertions
+    // are NOT made here; they need the real backend / additional mocks.
+  });
 
-	test("bulk 'Confirm all classified' confirms every eligible detection in one action (US6 bulk affordance)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test("bulk 'Confirm all classified' confirms every eligible detection in one action (US6 bulk affordance)", async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		// Only item-001 carries state="classified" in the fixture, so the bulk
-		// button targets exactly one item.
-		const bulkBtn = page.getByTestId("inbox-bulk-confirm-btn");
-		await expect(bulkBtn).toBeVisible();
-		await expect(bulkBtn).toContainText("Confirm all (1)");
-		await bulkBtn.click();
+    // Only item-001 carries state="classified" in the fixture, so the bulk
+    // button targets exactly one item.
+    const bulkBtn = page.getByTestId('inbox-bulk-confirm-btn');
+    await expect(bulkBtn).toBeVisible();
+    await expect(bulkBtn).toContainText('Confirm all (1)');
+    await bulkBtn.click();
 
-		await expect(
-			page.getByText(/1 item confirmed — review plans below\./i),
-		).toBeVisible({ timeout: 5_000 });
-	});
+    await expect(
+      page.getByText(/1 item confirmed — review plans below\./i),
+    ).toBeVisible({ timeout: 5_000 });
+  });
 
-	// ── Previously-skipped mock-layer gaps — now enabled by the enriched harness ─
+  // ── Previously-skipped mock-layer gaps — now enabled by the enriched harness ─
 
-	test("plan-approval overlay: review → apply one plan (live progress) → cancel another (US1 FR-003/FR-003a/FR-006/FR-007)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test('plan-approval overlay: review → apply one plan (live progress) → cancel another (US1 FR-003/FR-003a/FR-006/FR-007)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		// The enriched `inbox_plan_list_open` mock seeds two open plans, so the
-		// top-bar "Review plans (2)" trigger now renders (was unreachable before).
-		const reviewBtn = page.getByTestId("inbox-review-plans-btn");
-		await expect(reviewBtn).toBeVisible({ timeout: 8_000 });
-		await expect(reviewBtn).toContainText("Review plans (2)");
-		await reviewBtn.click();
+    // The enriched `inbox_plan_list_open` mock seeds two open plans, so the
+    // top-bar "Review plans (2)" trigger now renders (was unreachable before).
+    const reviewBtn = page.getByTestId('inbox-review-plans-btn');
+    await expect(reviewBtn).toBeVisible({ timeout: 8_000 });
+    await expect(reviewBtn).toContainText('Review plans (2)');
+    await reviewBtn.click();
 
-		// The focused plan-approval overlay opens with both seeded plan groups.
-		const overlay = page.getByTestId("plan-approval-overlay");
-		await expect(overlay).toBeVisible({ timeout: 5_000 });
-		await expect(overlay.getByTestId("plan-group-item-002")).toBeVisible();
-		await expect(
-			overlay.getByTestId("plan-group-item-organized-inplace"),
-		).toBeVisible();
-		// Aggregate action count across both plans (2 + 2).
-		await expect(overlay.getByTestId("plan-total-count")).toContainText("4");
+    // The focused plan-approval overlay opens with both seeded plan groups.
+    const overlay = page.getByTestId('plan-approval-overlay');
+    await expect(overlay).toBeVisible({ timeout: 5_000 });
+    await expect(overlay.getByTestId('plan-group-item-002')).toBeVisible();
+    await expect(
+      overlay.getByTestId('plan-group-item-organized-inplace'),
+    ).toBeVisible();
+    // Aggregate action count across both plans (2 + 2).
+    await expect(overlay.getByTestId('plan-total-count')).toContainText('4');
 
-		// ── Apply ONE plan with live progress. This drives `plans_apply_real`
-		//    over a real `@tauri-apps/api/core` Channel — proving the first-party
-		//    Channel polyfill lets the streamed OperationEvents reach the UI
-		//    (without it, the Channel ctor throws before any event streams). ──
-		await overlay.getByTestId("plan-apply-one-item-002").click();
-		await expect(page.getByText(/^Plan applied\.$/)).toBeVisible({
-			timeout: 5_000,
-		});
+    // ── Apply ONE plan with live progress. This drives `plans_apply_real`
+    //    over a real `@tauri-apps/api/core` Channel — proving the first-party
+    //    Channel polyfill lets the streamed OperationEvents reach the UI
+    //    (without it, the Channel ctor throws before any event streams). ──
+    await overlay.getByTestId('plan-apply-one-item-002').click();
+    await expect(page.getByText(/^Plan applied\.$/)).toBeVisible({
+      timeout: 5_000,
+    });
 
-		// ── Cancel the OTHER plan (FR-006). The stateful mock removes it from the
-		//    aggregate surface, so after the refresh its group is gone. ──
-		await overlay.getByTestId("plan-cancel-item-organized-inplace").click();
-		await expect(
-			page.getByText(/Plan discarded\. Item is available for re-confirmation\./i),
-		).toBeVisible({ timeout: 5_000 });
-		await expect(
-			overlay.getByTestId("plan-group-item-organized-inplace"),
-		).toHaveCount(0, { timeout: 5_000 });
+    // ── Cancel the OTHER plan (FR-006). The stateful mock removes it from the
+    //    aggregate surface, so after the refresh its group is gone. ──
+    await overlay.getByTestId('plan-cancel-item-organized-inplace').click();
+    await expect(
+      page.getByText(
+        /Plan discarded\. Item is available for re-confirmation\./i,
+      ),
+    ).toBeVisible({ timeout: 5_000 });
+    await expect(
+      overlay.getByTestId('plan-group-item-organized-inplace'),
+    ).toHaveCount(0, { timeout: 5_000 });
 
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
-	});
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
+  });
 
-	test("issue #767: Apply all empties the plan list and the overlay auto-closes (not stuck open with an empty body)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test('issue #767: Apply all empties the plan list and the overlay auto-closes (not stuck open with an empty body)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		const reviewBtn = page.getByTestId("inbox-review-plans-btn");
-		await expect(reviewBtn).toBeVisible({ timeout: 8_000 });
-		await reviewBtn.click();
+    const reviewBtn = page.getByTestId('inbox-review-plans-btn');
+    await expect(reviewBtn).toBeVisible({ timeout: 8_000 });
+    await reviewBtn.click();
 
-		const overlay = page.getByTestId("plan-approval-overlay");
-		await expect(overlay).toBeVisible({ timeout: 5_000 });
+    const overlay = page.getByTestId('plan-approval-overlay');
+    await expect(overlay).toBeVisible({ timeout: 5_000 });
 
-		await overlay.getByTestId("plan-apply-all").click();
+    await overlay.getByTestId('plan-apply-all').click();
 
-		// The overlay auto-closes once every plan is applied — it must NOT be
-		// left open with an empty body (issue #767).
-		await expect(overlay).not.toBeVisible({ timeout: 5_000 });
-		await expect(page.locator('[role="dialog"]')).toHaveCount(0);
+    // The overlay auto-closes once every plan is applied — it must NOT be
+    // left open with an empty body (issue #767).
+    await expect(overlay).not.toBeVisible({ timeout: 5_000 });
+    await expect(page.locator('[role="dialog"]')).toHaveCount(0);
 
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
-	});
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
+  });
 
-	test("catalogue-in-place plan is distinguishable from a move plan in the review overlay (US4 FR-017/FR-018/SC-007)", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/inbox");
-		await disableGuidedTourOverlay(page);
-		await expect(page.getByTestId("inbox-list")).toBeVisible({ timeout: 8_000 });
+  test('catalogue-in-place plan is distinguishable from a move plan in the review overlay (US4 FR-017/FR-018/SC-007)', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/inbox');
+    await disableGuidedTourOverlay(page);
+    await expect(page.getByTestId('inbox-list')).toBeVisible({
+      timeout: 8_000,
+    });
 
-		await page.getByTestId("inbox-review-plans-btn").click();
-		const overlay = page.getByTestId("plan-approval-overlay");
-		await expect(overlay).toBeVisible({ timeout: 5_000 });
+    await page.getByTestId('inbox-review-plans-btn').click();
+    const overlay = page.getByTestId('plan-approval-overlay');
+    await expect(overlay).toBeVisible({ timeout: 5_000 });
 
-		// The MOVE plan (unorganized source, seeded all-`move` actions) renders a
-		// move arrow (`.alm-plan-panel__summary-arrow`) — files relocate (FR-017) —
-		// and carries NO "In place" marker.
-		const movePlan = overlay.getByTestId("plan-group-item-002");
-		await expect(movePlan).toBeVisible();
-		await expect(movePlan.locator(".alm-plan-panel__summary-arrow")).toBeVisible();
-		await expect(movePlan.locator(".alm-plan-panel__inplace")).toHaveCount(0);
+    // The MOVE plan (unorganized source, seeded all-`move` actions) renders a
+    // move arrow (`.alm-plan-panel__summary-arrow`) — files relocate (FR-017) —
+    // and carries NO "In place" marker.
+    const movePlan = overlay.getByTestId('plan-group-item-002');
+    await expect(movePlan).toBeVisible();
+    await expect(
+      movePlan.locator('.alm-plan-panel__summary-arrow'),
+    ).toBeVisible();
+    await expect(movePlan.locator('.alm-plan-panel__inplace')).toHaveCount(0);
 
-		// The CATALOGUE-IN-PLACE plan (organized source, seeded all-`catalogue`
-		// actions where destination == source) is explicitly marked "In place"
-		// (`.alm-plan-panel__inplace`) — zero file movements, a catalogue record
-		// only (FR-018 / SC-007) — with NO move arrow.
-		const inPlacePlan = overlay.getByTestId("plan-group-item-organized-inplace");
-		await expect(inPlacePlan).toBeVisible();
-		await expect(inPlacePlan.locator(".alm-plan-panel__inplace")).toBeVisible();
-		await expect(inPlacePlan.getByText("In place", { exact: true })).toBeVisible();
-		await expect(inPlacePlan.locator(".alm-plan-panel__summary-arrow")).toHaveCount(0);
+    // The CATALOGUE-IN-PLACE plan (organized source, seeded all-`catalogue`
+    // actions where destination == source) is explicitly marked "In place"
+    // (`.alm-plan-panel__inplace`) — zero file movements, a catalogue record
+    // only (FR-018 / SC-007) — with NO move arrow.
+    const inPlacePlan = overlay.getByTestId(
+      'plan-group-item-organized-inplace',
+    );
+    await expect(inPlacePlan).toBeVisible();
+    await expect(inPlacePlan.locator('.alm-plan-panel__inplace')).toBeVisible();
+    await expect(
+      inPlacePlan.getByText('In place', { exact: true }),
+    ).toBeVisible();
+    await expect(
+      inPlacePlan.locator('.alm-plan-panel__summary-arrow'),
+    ).toHaveCount(0);
 
-		await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
-	});
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
+  });
 });

--- a/tests/e2e/lifecycle_detail.spec.ts
+++ b/tests/e2e/lifecycle_detail.spec.ts
@@ -24,30 +24,32 @@
  *   The desktop shell reads `alm-preferences.setupCompleted` from localStorage.
  *   Seed it before navigating so the index redirect lands on /sessions, not /setup.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-function seedSetupComplete(page: import("@playwright/test").Page): void {
+function seedSetupComplete(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-preferences",
+      'alm-preferences',
       JSON.stringify({ setupCompleted: true }),
     );
   });
 }
 
-test.describe("lifecycle detail · sessions page + provenance UI (spec 006 / spec 043)", () => {
-  test("session rows render; clicking opens detail with source-tagged facts", async ({
+test.describe('lifecycle detail · sessions page + provenance UI (spec 006 / spec 043)', () => {
+  test('session rows render; clicking opens detail with source-tagged facts', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
     // ── 1. Page renders without error boundary ────────────────────────────────
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // ── 2. Flat table renders session rows (spec 043 §4: the list is FLAT by
     //       default — grouping is opt-in via the top-bar Group-by control) ─────
-    const rows = page.locator(".alm-sessions-table__row");
+    const rows = page.locator('.alm-sessions-table__row');
     await expect(rows.first()).toBeVisible({ timeout: 8_000 });
 
     // ── 3. Click a session row → detail pane opens ────────────────────────────
@@ -57,29 +59,31 @@ test.describe("lifecycle detail · sessions page + provenance UI (spec 006 / spe
     // ── 4. Detail shows a PropertyTable with a source-tagged fact ─────────────
     // The redesigned SessionDetail folds provenance into the fact PropertyTable;
     // each fact carries a Source badge (FITS / Inferred / User).
-    const propTable = page.locator(".alm-property-table").first();
+    const propTable = page.locator('.alm-property-table').first();
     await expect(propTable).toBeVisible({ timeout: 5_000 });
     await expect(
       propTable.getByText(/^(FITS|Inferred|User)$/).first(),
     ).toBeVisible();
   });
 
-  test("navigating to /#/sessions without a selection renders the table with no detail pane", async ({
+  test('navigating to /#/sessions without a selection renders the table with no detail pane', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // The flat sessions table renders its rows.
-    await expect(
-      page.locator(".alm-sessions-table__row").first(),
-    ).toBeVisible({ timeout: 8_000 });
+    await expect(page.locator('.alm-sessions-table__row').first()).toBeVisible({
+      timeout: 8_000,
+    });
 
     // The redesigned SessionsPage mounts the bottom SessionDetail pane ONLY when
     // a session is selected (`detail={selectedSession != null ? … : undefined}`),
     // so with no selection the detail's PropertyTable must be absent.
-    await expect(page.locator(".alm-property-table")).toHaveCount(0);
+    await expect(page.locator('.alm-property-table')).toHaveCount(0);
   });
 });

--- a/tests/e2e/lifecycle_transitions.spec.ts
+++ b/tests/e2e/lifecycle_transitions.spec.ts
@@ -35,39 +35,39 @@
  * First-run seeding:
  *   Reads `alm-preferences.setupCompleted` from localStorage.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-function seedSetupComplete(page: import("@playwright/test").Page): void {
+function seedSetupComplete(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-preferences",
+      'alm-preferences',
       JSON.stringify({ setupCompleted: true }),
     );
   });
 }
 
-test.describe("lifecycle transitions · write-side seam (spec 008 / design-v4)", () => {
-  test("Projects page renders rows; transition button triggers mock success toast", async ({
+test.describe('lifecycle transitions · write-side seam (spec 008 / design-v4)', () => {
+  test('Projects page renders rows; transition button triggers mock success toast', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
 
     // ── 1. Page renders without error boundary ────────────────────────────────
-    const errorBoundary = page.getByTestId("app-error-boundary-fallback");
+    const errorBoundary = page.getByTestId('app-error-boundary-fallback');
     await expect(errorBoundary).not.toBeVisible();
 
     // ── 2. Project row is visible with "Processing" lifecycle pill ────────────
     // ProjectsTable (spec 043 redesign) renders each project as a
     // `tr.alm-projects-table__row` containing the project name and a state tag.
     const projectRow = page
-      .locator(".alm-projects-table__row")
-      .filter({ hasText: "NGC 7000 Narrowband" })
+      .locator('.alm-projects-table__row')
+      .filter({ hasText: 'NGC 7000 Narrowband' })
       .first();
     await expect(projectRow).toBeVisible({ timeout: 8_000 });
 
     // The "Processing" state tag should be visible in the row.
-    await expect(projectRow.getByText("Processing")).toBeVisible();
+    await expect(projectRow.getByText('Processing')).toBeVisible();
 
     // ── 3. Select the row → detail pane opens ─────────────────────────────────
     // Unlike the old list (which auto-selected index 0), the redesigned
@@ -77,10 +77,10 @@ test.describe("lifecycle transitions · write-side seam (spec 008 / design-v4)",
     await projectRow.click();
 
     // For "processing" state: "Mark as Completed" → nextState "completed".
-    const footerActions = page.getByTestId("lifecycle-actions");
+    const footerActions = page.getByTestId('lifecycle-actions');
     await expect(footerActions).toBeVisible({ timeout: 5_000 });
 
-    const markCompletedBtn = page.getByTestId("transition-btn-completed");
+    const markCompletedBtn = page.getByTestId('transition-btn-completed');
     await expect(markCompletedBtn).toBeVisible();
     await expect(markCompletedBtn).toBeEnabled();
 
@@ -96,23 +96,29 @@ test.describe("lifecycle transitions · write-side seam (spec 008 / design-v4)",
     await expect(successToast).toBeVisible({ timeout: 5_000 });
   });
 
-  test("Projects page renders multiple projects in the list", async ({
+  test('Projects page renders multiple projects in the list', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
 
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // All three mock projects should appear.
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "NGC 7000 Narrowband" }),
+      page
+        .locator('.alm-projects-table__row')
+        .filter({ hasText: 'NGC 7000 Narrowband' }),
     ).toBeVisible({ timeout: 8_000 });
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "M31 LRGB" }),
+      page.locator('.alm-projects-table__row').filter({ hasText: 'M31 LRGB' }),
     ).toBeVisible();
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "IC 1396 SHO" }),
+      page
+        .locator('.alm-projects-table__row')
+        .filter({ hasText: 'IC 1396 SHO' }),
     ).toBeVisible();
   });
 
@@ -122,10 +128,7 @@ test.describe("lifecycle transitions · write-side seam (spec 008 / design-v4)",
   // stays "Processing" even after success. Full coverage needs the real backend.
   //
   // See: docs/development/test-strategy-033.md § J-4.4 (real-backend layer)
-  test.skip(
-    "lifecycle pill updates after successful transition — real-backend e2e required",
-    async () => {
-      // Intentionally skipped.
-    },
-  );
+  test.skip('lifecycle pill updates after successful transition — real-backend e2e required', async () => {
+    // Intentionally skipped.
+  });
 });

--- a/tests/e2e/project_lifecycle_create.spec.ts
+++ b/tests/e2e/project_lifecycle_create.spec.ts
@@ -33,46 +33,55 @@
  * per-step advance gates so the walk-through does not need real session/
  * calibration selections.
  */
-import { test, expect, seedSetupComplete, disableGuidedTourOverlay } from "./support/harness";
+import {
+  test,
+  expect,
+  seedSetupComplete,
+  disableGuidedTourOverlay,
+} from './support/harness';
 
 // The six wizard "Next" labels in order (StepName → … → Review). Clicking each
 // advances one step; the final step swaps in the Create button.
 const NEXT_LABELS = [
-  "Next: sources →",
-  "Next: calibration →",
-  "Next: source views →",
-  "Next: naming →",
-  "Next: review →",
+  'Next: sources →',
+  'Next: calibration →',
+  'Next: source views →',
+  'Next: naming →',
+  'Next: review →',
 ];
 
-async function openWizard(page: import("@playwright/test").Page): Promise<void> {
+async function openWizard(
+  page: import('@playwright/test').Page,
+): Promise<void> {
   seedSetupComplete(page);
-  await page.goto("/#/projects");
-  await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+  await page.goto('/#/projects');
+  await expect(
+    page.getByTestId('app-error-boundary-fallback'),
+  ).not.toBeVisible();
   await disableGuidedTourOverlay(page);
-  await page.getByRole("button", { name: "+ New project" }).click();
+  await page.getByRole('button', { name: '+ New project' }).click();
   // Wizard toolbar title confirms we landed on /#/projects/new.
   await expect(page.getByText(/New project —/)).toBeVisible({ timeout: 8_000 });
 }
 
-test.describe("project lifecycle · creation wizard (spec 008 US1 / Journey 5)", () => {
-  test("happy path: unique name walked through all steps creates the project", async ({
+test.describe('project lifecycle · creation wizard (spec 008 US1 / Journey 5)', () => {
+  test('happy path: unique name walked through all steps creates the project', async ({
     page,
   }) => {
     await openWizard(page);
 
     // ── Step 0: Name & profile ────────────────────────────────────────────────
-    const nameInput = page.locator("#project-name");
+    const nameInput = page.locator('#project-name');
     await expect(nameInput).toBeVisible();
-    await nameInput.fill("Pelican Nebula HOO");
+    await nameInput.fill('Pelican Nebula HOO');
 
     // ── Walk Name → Review (six steps, five Next clicks) ──────────────────────
     for (const label of NEXT_LABELS) {
-      await page.getByRole("button", { name: label }).click();
+      await page.getByRole('button', { name: label }).click();
     }
 
     // ── Review step: Create is enabled (name present) ─────────────────────────
-    const createBtn = page.getByTestId("wizard-create-btn");
+    const createBtn = page.getByTestId('wizard-create-btn');
     await expect(createBtn).toBeVisible({ timeout: 5_000 });
     await expect(createBtn).toBeEnabled();
 
@@ -83,24 +92,26 @@ test.describe("project lifecycle · creation wizard (spec 008 US1 / Journey 5)",
     await expect(
       page.getByText(/created — project folders created on disk/i),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 
-  test("validation: a duplicate name is blocked and the wizard bounces back to the Name step", async ({
+  test('validation: a duplicate name is blocked and the wizard bounces back to the Name step', async ({
     page,
   }) => {
     await openWizard(page);
 
     // Use a name that already exists in projects.list (mockProjectSummaries).
-    await page.locator("#project-name").fill("NGC 7000 Narrowband");
+    await page.locator('#project-name').fill('NGC 7000 Narrowband');
 
     for (const label of NEXT_LABELS) {
-      await page.getByRole("button", { name: label }).click();
+      await page.getByRole('button', { name: label }).click();
     }
 
     // Attempt to create — the live duplicate pre-check (findDuplicateProjectName)
     // must intercept before any projects.create call.
-    await page.getByTestId("wizard-create-btn").click();
+    await page.getByTestId('wizard-create-btn').click();
 
     // Observable outcome (constitution II — no silent mutation on bad input):
     // creation is BLOCKED and the wizard routes BACK to the Name step. (The
@@ -110,12 +121,18 @@ test.describe("project lifecycle · creation wizard (spec 008 US1 / Journey 5)",
     // report.) The proofs: we are on step 1 again, the Review step's Create
     // button is gone, and no "created" success toast fired.
     await expect(
-      page.getByRole("heading", { name: /Step 1 · Name & profile/ }),
+      page.getByRole('heading', { name: /Step 1 · Name & profile/ }),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator("#project-name")).toHaveValue("NGC 7000 Narrowband");
-    await expect(page.getByTestId("wizard-create-btn")).toHaveCount(0);
-    await expect(page.getByText(/created — project folders created on disk/i)).toHaveCount(0);
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(page.locator('#project-name')).toHaveValue(
+      'NGC 7000 Narrowband',
+    );
+    await expect(page.getByTestId('wizard-create-btn')).toHaveCount(0);
+    await expect(
+      page.getByText(/created — project folders created on disk/i),
+    ).toHaveCount(0);
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 
   test("empty-name gate: the Review step's Create button is disabled without a name", async ({
@@ -125,10 +142,10 @@ test.describe("project lifecycle · creation wizard (spec 008 US1 / Journey 5)",
 
     // Do NOT type a name; devSkip lets us advance through the gated steps.
     for (const label of NEXT_LABELS) {
-      await page.getByRole("button", { name: label }).click();
+      await page.getByRole('button', { name: label }).click();
     }
 
-    const createBtn = page.getByTestId("wizard-create-btn");
+    const createBtn = page.getByTestId('wizard-create-btn');
     await expect(createBtn).toBeVisible({ timeout: 5_000 });
     await expect(createBtn).toBeDisabled();
   });
@@ -138,19 +155,19 @@ test.describe("project lifecycle · creation wizard (spec 008 US1 / Journey 5)",
 // CreateProjectDialog retired, its target picker + validation folded into
 // the wizard, zero-source creation reachable, "From target context" no
 // longer fabricated, redundant "Save draft" button removed.
-test.describe("project creation wizard convergence (#887/#719/#586/#783/#795)", () => {
-  test("#719: zero-source creation is reachable — Create succeeds without selecting any session", async ({
+test.describe('project creation wizard convergence (#887/#719/#586/#783/#795)', () => {
+  test('#719: zero-source creation is reachable — Create succeeds without selecting any session', async ({
     page,
   }) => {
     await openWizard(page);
-    await page.locator("#project-name").fill("Zero Source Project");
+    await page.locator('#project-name').fill('Zero Source Project');
 
     // Advance past Sources (step 1) WITHOUT selecting any session.
     for (const label of NEXT_LABELS) {
-      await page.getByRole("button", { name: label }).click();
+      await page.getByRole('button', { name: label }).click();
     }
 
-    const createBtn = page.getByTestId("wizard-create-btn");
+    const createBtn = page.getByTestId('wizard-create-btn');
     await expect(createBtn).toBeEnabled();
     await createBtn.click();
 
@@ -163,9 +180,9 @@ test.describe("project creation wizard convergence (#887/#719/#586/#783/#795)", 
     page,
   }) => {
     await openWizard(page);
-    await expect(
-      page.getByRole("button", { name: "Save draft" }),
-    ).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Save draft' })).toHaveCount(
+      0,
+    );
   });
 
   test("#783/#887/#612: 'From target context' is absent until a real target is picked, then reflects it", async ({
@@ -174,16 +191,16 @@ test.describe("project creation wizard convergence (#887/#719/#586/#783/#795)", 
     await openWizard(page);
 
     // Typed name alone must never fabricate a "From target context" line.
-    await page.locator("#project-name").fill("Andromeda Wide Field");
+    await page.locator('#project-name').fill('Andromeda Wide Field');
     await expect(page.getByText(/From target context:/)).toHaveCount(0);
 
     // The folded-in target picker (from the retired CreateProjectDialog) —
     // pick a real target via the mock target.search fixture.
-    const targetCombobox = page.getByRole("combobox", {
-      name: "Target (optional)",
+    const targetCombobox = page.getByRole('combobox', {
+      name: 'Target (optional)',
     });
-    await targetCombobox.fill("Andromeda");
-    await page.getByRole("option", { name: /M 31/ }).click();
+    await targetCombobox.fill('Andromeda');
+    await page.getByRole('option', { name: /M 31/ }).click();
 
     // Now the sub-toolbar reflects the REAL picked target, not typed text.
     await expect(
@@ -196,15 +213,17 @@ test.describe("project creation wizard convergence (#887/#719/#586/#783/#795)", 
   // manual TargetSearch pick covered above. The wizard must resolve that id
   // via `target.get` and prefill the name step from it, not require the user
   // to re-pick the same target they started from.
-  test("#612: a real ?targetId= search param resolves and prefills the name step", async ({
+  test('#612: a real ?targetId= search param resolves and prefills the name step', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects/new?targetId=tgt-m31");
-    await expect(page.getByText(/New project —/)).toBeVisible({ timeout: 8_000 });
+    await page.goto('/#/projects/new?targetId=tgt-m31');
+    await expect(page.getByText(/New project —/)).toBeVisible({
+      timeout: 8_000,
+    });
 
     // Prefilled from the resolved target (mock target.get echoes 'M 31').
-    await expect(page.locator("#project-name")).toHaveValue("M 31", {
+    await expect(page.locator('#project-name')).toHaveValue('M 31', {
       timeout: 5_000,
     });
     await expect(page.getByText(/From target context:.*M 31/)).toBeVisible({

--- a/tests/e2e/project_lifecycle_surfaces.spec.ts
+++ b/tests/e2e/project_lifecycle_surfaces.spec.ts
@@ -39,139 +39,148 @@
  *   projects_source_remove → returns `lifecycle.last_confirmed_source` unless
  *                            confirmLastSource is set, exercising the guard.
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
+import { test, expect, seedSetupComplete } from './support/harness';
 
 async function selectProject(
-  page: import("@playwright/test").Page,
+  page: import('@playwright/test').Page,
   name: string,
 ): Promise<void> {
   const row = page
-    .locator(".alm-projects-table__row")
+    .locator('.alm-projects-table__row')
     .filter({ hasText: name })
     .first();
   await expect(row).toBeVisible({ timeout: 8_000 });
   await row.click();
-  await expect(page.getByTestId("lifecycle-actions")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId('lifecycle-actions')).toBeVisible({
+    timeout: 5_000,
+  });
 }
 
-test.describe("project lifecycle · detail surfaces (Journey 5)", () => {
-  test("notes surface: persisted body renders; editor shows a byte counter", async ({
+test.describe('project lifecycle · detail surfaces (Journey 5)', () => {
+  test('notes surface: persisted body renders; editor shows a byte counter', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "NGC 7000 Narrowband");
+    await page.goto('/#/projects');
+    await selectProject(page, 'NGC 7000 Narrowband');
 
     // Persisted note body (project.note.get) renders.
-    const notesRoot = page.locator(".alm-project-notes__root");
-    await expect(page.getByTestId("notes-body")).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByTestId("notes-body")).toContainText("SHO palette");
+    const notesRoot = page.locator('.alm-project-notes__root');
+    await expect(page.getByTestId('notes-body')).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.getByTestId('notes-body')).toContainText('SHO palette');
 
     // Open the inline editor → textarea + live byte counter against the cap.
-    await notesRoot.getByRole("button", { name: "Edit" }).click();
-    await expect(page.getByTestId("notes-textarea")).toBeVisible();
-    const counter = page.getByTestId("notes-byte-counter");
+    await notesRoot.getByRole('button', { name: 'Edit' }).click();
+    await expect(page.getByTestId('notes-textarea')).toBeVisible();
+    const counter = page.getByTestId('notes-byte-counter');
     await expect(counter).toBeVisible();
-    await expect(counter).toContainText("16,384");
-    await expect(counter).toContainText("bytes");
+    await expect(counter).toContainText('16,384');
+    await expect(counter).toContainText('bytes');
   });
 
-  test("manifests, outputs empty stub, channel integration time, and tool-launch affordance", async ({
+  test('manifests, outputs empty stub, channel integration time, and tool-launch affordance', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "NGC 7000 Narrowband");
+    await page.goto('/#/projects');
+    await selectProject(page, 'NGC 7000 Narrowband');
 
     // ── Manifests (project.manifest.list) render as rows ─────────────────────
-    await expect(page.getByTestId("manifests-list")).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByTestId("manifest-row-man-001")).toBeVisible();
-    await expect(page.getByTestId("manifest-row-man-002")).toBeVisible();
+    await expect(page.getByTestId('manifests-list')).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.getByTestId('manifest-row-man-001')).toBeVisible();
+    await expect(page.getByTestId('manifest-row-man-002')).toBeVisible();
 
     // ── Outputs: HONEST empty state, never fabricated rows ───────────────────
-    const outputs = page.getByTestId("project-outputs");
+    const outputs = page.getByTestId('project-outputs');
     await expect(outputs).toBeVisible();
-    await expect(outputs.getByText("No accepted outputs yet")).toBeVisible();
+    await expect(outputs.getByText('No accepted outputs yet')).toBeVisible();
 
     // ── Per-channel integration time (Ha 1.8h, OIII 1.3h) ────────────────────
-    const channels = page.locator(".alm-project-detail__channels-section");
+    const channels = page.locator('.alm-project-detail__channels-section');
     await expect(channels).toBeVisible();
-    await expect(channels.getByText("1.8h")).toBeVisible();
-    await expect(channels.getByText("1.3h")).toBeVisible();
+    await expect(channels.getByText('1.8h')).toBeVisible();
+    await expect(channels.getByText('1.3h')).toBeVisible();
 
     // ── Tool-launch affordance: rendered but disabled (no profile configured) ─
-    const launchBtn = page.getByTestId("tool-launch-btn");
+    const launchBtn = page.getByTestId('tool-launch-btn');
     await expect(launchBtn).toBeVisible();
-    await expect(launchBtn).toContainText("Open in PixInsight");
+    await expect(launchBtn).toContainText('Open in PixInsight');
     await expect(launchBtn).toBeDisabled();
     // Not-configured hint with a link to the tools settings pane.
-    await expect(page.getByTestId("tool-launch-footer")).toBeVisible();
+    await expect(page.getByTestId('tool-launch-footer')).toBeVisible();
   });
 
   test("attach sources: the Edit pane's Add-sources toggle reveals the session picker", async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "NGC 7000 Narrowband");
+    await page.goto('/#/projects');
+    await selectProject(page, 'NGC 7000 Narrowband');
 
     // Open the project Edit pane (header Edit — the first "Edit" in the detail).
-    await page.getByRole("button", { name: "Edit" }).first().click();
-    const editPane = page.getByLabel("Edit project");
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    const editPane = page.getByLabel('Edit project');
     await expect(editPane).toBeVisible({ timeout: 5_000 });
 
     // Current linked sources are listed.
-    await expect(editPane.getByText("NGC 7000 Ha 2024-11")).toBeVisible();
+    await expect(editPane.getByText('NGC 7000 Ha 2024-11')).toBeVisible();
 
     // The Add-sources toggle reveals the shared SessionSourcePicker (filtered to
     // sessions not already linked to this project).
-    await editPane.getByRole("button", { name: "Add sources" }).click();
-    await expect(editPane.locator(".alm-source-picker")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await editPane.getByRole('button', { name: 'Add sources' }).click();
+    await expect(editPane.locator('.alm-source-picker')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 
-  test("remove source: the last-confirmed-source guard requires an inline confirm (FR-011)", async ({
+  test('remove source: the last-confirmed-source guard requires an inline confirm (FR-011)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
     // proj-002 (ready) is not source-remove-locked, so the Remove affordance is
     // active — clicking it exercises the guard.
-    await selectProject(page, "M31 LRGB");
+    await selectProject(page, 'M31 LRGB');
 
-    await page.getByRole("button", { name: "Edit" }).first().click();
-    const editPane = page.getByLabel("Edit project");
+    await page.getByRole('button', { name: 'Edit' }).first().click();
+    const editPane = page.getByLabel('Edit project');
     await expect(editPane).toBeVisible({ timeout: 5_000 });
 
     // Click the first Remove → the mock returns lifecycle.last_confirmed_source,
     // which the pane surfaces as an inline confirm guard rather than removing.
-    await editPane.getByRole("button", { name: "Remove" }).first().click();
+    await editPane.getByRole('button', { name: 'Remove' }).first().click();
     await expect(
       editPane.getByText("You can't remove the last confirmed source."),
     ).toBeVisible({ timeout: 5_000 });
 
     // Confirming re-issues the removal with confirm_last_source=true (mock
     // succeeds); no crash.
-    await editPane.getByRole("button", { name: "Confirm" }).click();
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await editPane.getByRole('button', { name: 'Confirm' }).click();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 });
 
-test.describe("project detail · source click-through (#720 FR-006/SC-002/SC-001)", () => {
-  test("a source row deep-links to its Inventory/Sessions entry", async ({
+test.describe('project detail · source click-through (#720 FR-006/SC-002/SC-001)', () => {
+  test('a source row deep-links to its Inventory/Sessions entry', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "NGC 7000 Narrowband");
+    await page.goto('/#/projects');
+    await selectProject(page, 'NGC 7000 Narrowband');
 
     // The source name renders as a real anchor, not inert text.
-    const link = page.getByTestId("project-source-link-inv-001");
+    const link = page.getByTestId('project-source-link-inv-001');
     await expect(link).toBeVisible();
-    await expect(link).toHaveAttribute(
-      "href",
-      "#/sessions?selected=inv-001",
-    );
+    await expect(link).toHaveAttribute('href', '#/sessions?selected=inv-001');
 
     // Clicking navigates to Sessions with the source pre-selected (deep link).
     await link.click();
@@ -182,32 +191,34 @@ test.describe("project detail · source click-through (#720 FR-006/SC-002/SC-001
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
     const blockedRow = page
-      .locator(".alm-projects-table__row")
-      .filter({ hasText: "Cave Nebula attempt" });
+      .locator('.alm-projects-table__row')
+      .filter({ hasText: 'Cave Nebula attempt' });
     await expect(blockedRow).toBeVisible({ timeout: 8_000 });
     // Mock fixture: proj-007 is blocked with blockedReasonKind=calibration_unmatched.
     await expect(
-      blockedRow.getByRole("img", { name: /Blocked: .+/ }),
+      blockedRow.getByRole('img', { name: /Blocked: .+/ }),
     ).toBeVisible();
   });
 });
 
-test.describe("projects list · multiselect state filter (#721 009 SC-004 / 033 FR-022)", () => {
-  test("selecting multiple states filters the table; the URL round-trips as a CSV", async ({
+test.describe('projects list · multiselect state filter (#721 009 SC-004 / 033 FR-022)', () => {
+  test('selecting multiple states filters the table; the URL round-trips as a CSV', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "NGC 7000 Narrowband" }),
+      page
+        .locator('.alm-projects-table__row')
+        .filter({ hasText: 'NGC 7000 Narrowband' }),
     ).toBeVisible({ timeout: 8_000 });
 
     // Open the State multiselect popover and check two states.
-    await page.locator("#filterbar-state summary").click();
-    await page.locator("#filterbar-state-processing").check();
-    await page.locator("#filterbar-state-blocked").check();
+    await page.locator('#filterbar-state summary').click();
+    await page.locator('#filterbar-state-processing').check();
+    await page.locator('#filterbar-state-blocked').check();
 
     // URL reflects both selections (router search serializes the array as
     // URL-encoded JSON: lifecycle=["processing","blocked"]).
@@ -217,32 +228,38 @@ test.describe("projects list · multiselect state filter (#721 009 SC-004 / 033 
 
     // Table now shows only the processing + blocked projects.
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "NGC 7000 Narrowband" }),
+      page
+        .locator('.alm-projects-table__row')
+        .filter({ hasText: 'NGC 7000 Narrowband' }),
     ).toBeVisible();
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "Cave Nebula attempt" }),
+      page
+        .locator('.alm-projects-table__row')
+        .filter({ hasText: 'Cave Nebula attempt' }),
     ).toBeVisible();
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "M31 LRGB" }),
+      page.locator('.alm-projects-table__row').filter({ hasText: 'M31 LRGB' }),
     ).not.toBeVisible();
   });
 
-  test("a deep-linked CSV lifecycle param pre-checks the matching states and filters the table", async ({
+  test('a deep-linked CSV lifecycle param pre-checks the matching states and filters the table', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects?lifecycle=ready,prepared");
+    await page.goto('/#/projects?lifecycle=ready,prepared');
 
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "M31 LRGB" }),
+      page.locator('.alm-projects-table__row').filter({ hasText: 'M31 LRGB' }),
     ).toBeVisible({ timeout: 8_000 });
     await expect(
-      page.locator(".alm-projects-table__row").filter({ hasText: "NGC 7000 Narrowband" }),
+      page
+        .locator('.alm-projects-table__row')
+        .filter({ hasText: 'NGC 7000 Narrowband' }),
     ).not.toBeVisible();
 
     // The popover reflects the deep-linked selection (2 selected).
-    await expect(page.locator("#filterbar-state summary")).toContainText(
-      "2 selected",
+    await expect(page.locator('#filterbar-state summary')).toContainText(
+      '2 selected',
     );
   });
 });

--- a/tests/e2e/project_lifecycle_transitions_full.spec.ts
+++ b/tests/e2e/project_lifecycle_transitions_full.spec.ts
@@ -43,130 +43,150 @@
  * The Tauri `Channel` polyfill the approve-and-apply path needs is installed
  * globally by the shared harness `test` (tests/e2e/support/harness.ts).
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
+import { test, expect, seedSetupComplete } from './support/harness';
 
 async function selectProject(
-  page: import("@playwright/test").Page,
+  page: import('@playwright/test').Page,
   name: string,
 ): Promise<void> {
   const row = page
-    .locator(".alm-projects-table__row")
+    .locator('.alm-projects-table__row')
     .filter({ hasText: name })
     .first();
   await expect(row).toBeVisible({ timeout: 8_000 });
   await row.click();
-  await expect(page.getByTestId("lifecycle-actions")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId('lifecycle-actions')).toBeVisible({
+    timeout: 5_000,
+  });
 }
 
-test.describe("project lifecycle · full state machine (Journey 5)", () => {
-  test("each state surfaces its correct contextual footer transitions", async ({
+test.describe('project lifecycle · full state machine (Journey 5)', () => {
+  test('each state surfaces its correct contextual footer transitions', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await page.goto('/#/projects');
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // ready → { Prepare (plan-gated), Mark as Processing }
-    await selectProject(page, "M31 LRGB");
-    await expect(page.getByTestId("transition-btn-prepared")).toHaveText("Prepare");
-    await expect(page.getByTestId("transition-btn-processing")).toHaveText(
-      "Mark as Processing",
+    await selectProject(page, 'M31 LRGB');
+    await expect(page.getByTestId('transition-btn-prepared')).toHaveText(
+      'Prepare',
+    );
+    await expect(page.getByTestId('transition-btn-processing')).toHaveText(
+      'Mark as Processing',
     );
 
     // prepared → { Mark as Processing, Revert to Ready (plan-gated) }
-    await selectProject(page, "Heart Nebula SHO");
-    await expect(page.getByTestId("transition-btn-processing")).toHaveText(
-      "Mark as Processing",
+    await selectProject(page, 'Heart Nebula SHO');
+    await expect(page.getByTestId('transition-btn-processing')).toHaveText(
+      'Mark as Processing',
     );
-    await expect(page.getByTestId("transition-btn-ready")).toHaveText("Revert to Ready");
+    await expect(page.getByTestId('transition-btn-ready')).toHaveText(
+      'Revert to Ready',
+    );
 
     // processing → { Mark as Completed }
-    await selectProject(page, "NGC 7000 Narrowband");
-    await expect(page.getByTestId("transition-btn-completed")).toHaveText(
-      "Mark as Completed",
+    await selectProject(page, 'NGC 7000 Narrowband');
+    await expect(page.getByTestId('transition-btn-completed')).toHaveText(
+      'Mark as Completed',
     );
 
     // completed → { Archive (plan-gated), Re-open }
-    await selectProject(page, "Rosette Nebula HOO");
-    await expect(page.getByTestId("transition-btn-archived")).toHaveText("Archive");
-    await expect(page.getByTestId("transition-btn-processing")).toHaveText("Re-open");
+    await selectProject(page, 'Rosette Nebula HOO');
+    await expect(page.getByTestId('transition-btn-archived')).toHaveText(
+      'Archive',
+    );
+    await expect(page.getByTestId('transition-btn-processing')).toHaveText(
+      'Re-open',
+    );
 
     // archived → { Unarchive (plan-gated), Unarchive and Resume (plan-gated) }
-    await selectProject(page, "Veil Nebula (legacy)");
-    await expect(page.getByTestId("transition-btn-ready")).toHaveText("Unarchive");
-    await expect(page.getByTestId("transition-btn-processing")).toHaveText(
-      "Unarchive and Resume",
+    await selectProject(page, 'Veil Nebula (legacy)');
+    await expect(page.getByTestId('transition-btn-ready')).toHaveText(
+      'Unarchive',
+    );
+    await expect(page.getByTestId('transition-btn-processing')).toHaveText(
+      'Unarchive and Resume',
     );
 
     // blocked → BlockedBanner + { Archive (blocked escape) }
-    await selectProject(page, "Cave Nebula attempt");
-    await expect(page.getByTestId("transition-btn-archived")).toHaveText(
-      "Archive (blocked escape)",
+    await selectProject(page, 'Cave Nebula attempt');
+    await expect(page.getByTestId('transition-btn-archived')).toHaveText(
+      'Archive (blocked escape)',
     );
   });
 
-  test("non-plan edge (prepared → processing) applies immediately with a success toast", async ({
+  test('non-plan edge (prepared → processing) applies immediately with a success toast', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
 
-    await selectProject(page, "Heart Nebula SHO");
-    await page.getByTestId("transition-btn-processing").click();
+    await selectProject(page, 'Heart Nebula SHO');
+    await page.getByTestId('transition-btn-processing').click();
 
     // projects_toast_transitioned → "Project processing."
-    await expect(page.getByText(/Project processing\./i)).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(page.getByText(/Project processing\./i)).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 
-  test("plan-gated non-archive edge (ready → prepared) surfaces the plan-required info toast, no overlay", async ({
+  test('plan-gated non-archive edge (ready → prepared) surfaces the plan-required info toast, no overlay', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
 
-    await selectProject(page, "M31 LRGB");
-    await page.getByTestId("transition-btn-prepared").click();
+    await selectProject(page, 'M31 LRGB');
+    await page.getByTestId('transition-btn-prepared').click();
 
     await expect(
       page.getByText(/A filesystem plan is required before this transition/i),
     ).toBeVisible({ timeout: 5_000 });
     // ready → prepared has no archive generator, so no review overlay opens.
-    await expect(page.getByTestId("plan-review-overlay")).toHaveCount(0);
+    await expect(page.getByTestId('plan-review-overlay')).toHaveCount(0);
   });
 
-  test("completed → archived drives the full plan.required → review overlay → approve & apply path", async ({
+  test('completed → archived drives the full plan.required → review overlay → approve & apply path', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
+    await page.goto('/#/projects');
 
-    await selectProject(page, "Rosette Nebula HOO");
+    await selectProject(page, 'Rosette Nebula HOO');
 
     // ── Archive (plan-gated) → plan.required info toast + archive plan created ─
-    await page.getByTestId("transition-btn-archived").click();
+    await page.getByTestId('transition-btn-archived').click();
 
     await expect(
       page.getByText(/A filesystem plan is required before this transition/i),
     ).toBeVisible({ timeout: 5_000 });
     await expect(
-      page.getByText(/Archive plan created with 4 items — review before anything is moved/i),
+      page.getByText(
+        /Archive plan created with 4 items — review before anything is moved/i,
+      ),
     ).toBeVisible({ timeout: 5_000 });
 
     // ── The shared review overlay opens with the archive title ────────────────
-    const overlay = page.getByTestId("plan-review-overlay");
+    const overlay = page.getByTestId('plan-review-overlay');
     await expect(overlay).toBeVisible({ timeout: 5_000 });
-    await expect(overlay.getByText("Review archive plan")).toBeVisible();
+    await expect(overlay.getByText('Review archive plan')).toBeVisible();
     await expect(
       overlay.getByText(/Nothing has been changed on disk/),
     ).toBeVisible();
     // Every proposed item is reviewable before approval (FR-003/SC-001).
-    await expect(overlay.getByTestId("plan-review-items")).toBeVisible();
+    await expect(overlay.getByTestId('plan-review-items')).toBeVisible();
 
     // ── Spec-016 protection gate blocks approval until acknowledged ──────────
-    const approveBtn = overlay.getByTestId("plan-review-approve-apply");
+    const approveBtn = overlay.getByTestId('plan-review-approve-apply');
     await expect(approveBtn).toBeDisabled();
-    await overlay.getByRole("button", { name: "Acknowledge" }).click();
+    await overlay.getByRole('button', { name: 'Acknowledge' }).click();
 
     // ── Destructive-confirm gate (FR-003, D9, issue #741): the shared plan
     //    fixture carries `delete` items, so approval also stays locked
@@ -174,16 +194,22 @@ test.describe("project lifecycle · full state machine (Journey 5)", () => {
     // `.click()` (not `.check()`) — the checkbox's `onChange` awaits a mock
     // IPC round-trip before flipping `checked`, and `.check()`'s single
     // post-click snapshot races that async update.
-    await overlay.getByTestId("plan-review-confirm-destructive").click();
+    await overlay.getByTestId('plan-review-confirm-destructive').click();
     await expect(
-      overlay.getByTestId("plan-review-confirm-destructive"),
+      overlay.getByTestId('plan-review-confirm-destructive'),
     ).toBeChecked({ timeout: 5_000 });
     await expect(approveBtn).toBeEnabled({ timeout: 5_000 });
 
     // ── Approve & apply → plans.approve → plans.apply, live progress ─────────
     await approveBtn.click();
-    await expect(overlay.getByTestId("plan-review-progress")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByText("Cleanup plan applied.")).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(overlay.getByTestId('plan-review-progress')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(page.getByText('Cleanup plan applied.')).toBeVisible({
+      timeout: 5_000,
+    });
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 });

--- a/tests/e2e/regression_r1_index_redirect.spec.ts
+++ b/tests/e2e/regression_r1_index_redirect.spec.ts
@@ -24,27 +24,27 @@
  *   - docs/development/test-strategy-033.md § J-1.1
  *   - apps/desktop/src/app/router.tsx  indexRoute.beforeLoad
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
 // The app uses createHashHistory — routes are in the URL hash (#/sessions).
 // Seed preferences via the `alm-preferences` localStorage key so the
 // `checkFirstRunComplete()` call in indexRoute.beforeLoad reads the flag.
-function seedSetupComplete(page: import("@playwright/test").Page): void {
+function seedSetupComplete(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-preferences",
+      'alm-preferences',
       JSON.stringify({ setupCompleted: true }),
     );
   });
 }
 
-function seedSetupIncomplete(page: import("@playwright/test").Page): void {
+function seedSetupIncomplete(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
-    window.localStorage.removeItem("alm-preferences");
+    window.localStorage.removeItem('alm-preferences');
   });
 }
 
-test.describe("Regression R-1 · index route redirect", () => {
+test.describe('Regression R-1 · index route redirect', () => {
   /**
    * When `setupCompleted` is true (returning user), navigating to `/#/` must
    * redirect to `/#/sessions`, NOT render SessionsPage at the index match.
@@ -56,7 +56,7 @@ test.describe("Regression R-1 · index route redirect", () => {
    * The error boundary text "Something went wrong!" must NOT appear.
    * The final hash must contain `sessions`.
    */
-  test("R-1.1 · /#/ redirects to /#/sessions when setup is complete (not crash)", async ({
+  test('R-1.1 · /#/ redirects to /#/sessions when setup is complete (not crash)', async ({
     page,
   }) => {
     // Seed setup-complete flag before navigation so the router's beforeLoad
@@ -64,21 +64,21 @@ test.describe("Regression R-1 · index route redirect", () => {
     seedSetupComplete(page);
 
     // Navigate to the index hash route.
-    await page.goto("/#/");
+    await page.goto('/#/');
 
     // The router redirects via TanStack Router's hash history. The hash in
     // the URL changes from `#/` to `#/sessions`. Wait for the hash to settle.
     await page.waitForFunction(
-      () => window.location.hash.includes("sessions"),
+      () => window.location.hash.includes('sessions'),
       { timeout: 10_000 },
     );
 
     // Belt-and-braces: the error boundary fallback must NOT be visible.
-    const errorBoundary = page.getByTestId("app-error-boundary-fallback");
+    const errorBoundary = page.getByTestId('app-error-boundary-fallback');
     await expect(errorBoundary).not.toBeVisible();
 
     // The TanStack invariant error text must NOT appear.
-    const invariantError = page.getByText("Invariant failed");
+    const invariantError = page.getByText('Invariant failed');
     await expect(invariantError).not.toBeVisible();
   });
 
@@ -86,20 +86,19 @@ test.describe("Regression R-1 · index route redirect", () => {
    * When `setupCompleted` is false (new user), navigating to `/#/` must
    * redirect to `/#/setup`, NOT crash.
    */
-  test("R-1.2 · /#/ redirects to /#/setup when setup is incomplete", async ({
+  test('R-1.2 · /#/ redirects to /#/setup when setup is incomplete', async ({
     page,
   }) => {
     seedSetupIncomplete(page);
 
-    await page.goto("/#/");
+    await page.goto('/#/');
 
     // Should redirect to the setup wizard hash route.
-    await page.waitForFunction(
-      () => window.location.hash.includes("setup"),
-      { timeout: 10_000 },
-    );
+    await page.waitForFunction(() => window.location.hash.includes('setup'), {
+      timeout: 10_000,
+    });
 
-    const errorBoundary = page.getByTestId("app-error-boundary-fallback");
+    const errorBoundary = page.getByTestId('app-error-boundary-fallback');
     await expect(errorBoundary).not.toBeVisible();
   });
 
@@ -109,19 +108,19 @@ test.describe("Regression R-1 · index route redirect", () => {
    * include it as a baseline to distinguish the index-route crash from a
    * deeper render issue on /sessions itself.
    */
-  test("R-1.3 · /#/sessions renders without invariant error when navigated directly", async ({
+  test('R-1.3 · /#/sessions renders without invariant error when navigated directly', async ({
     page,
   }) => {
     seedSetupComplete(page);
 
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
     // No error boundary.
-    const errorBoundary = page.getByTestId("app-error-boundary-fallback");
+    const errorBoundary = page.getByTestId('app-error-boundary-fallback');
     await expect(errorBoundary).not.toBeVisible();
 
     // No invariant error text.
-    const invariantError = page.getByText("Invariant failed");
+    const invariantError = page.getByText('Invariant failed');
     await expect(invariantError).not.toBeVisible();
   });
 });

--- a/tests/e2e/regression_setup_legacy_catalog.spec.ts
+++ b/tests/e2e/regression_setup_legacy_catalog.spec.ts
@@ -17,23 +17,27 @@
  *
  * Verification layer: PE — Playwright mocks-UI (run in WSL).
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
 // App uses createHashHistory; setup wizard reads its persisted state on mount.
-function seedLegacyWizardState(page: import("@playwright/test").Page): void {
+function seedLegacyWizardState(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
     // Not setup-complete → SetupPage renders the wizard (mock mode skips the gate).
-    window.localStorage.removeItem("alm-preferences");
+    window.localStorage.removeItem('alm-preferences');
     window.localStorage.setItem(
-      "alm-setup-wizard-state",
+      'alm-setup-wizard-state',
       JSON.stringify({
         // Confirm step — reads catalogSettings.selectedCatalogIds.length.
         // (spec 044 US3 inserted a first-run Site step at index 3, shifting Confirm 3→4.)
         currentStep: 4,
         sources: [
-          { kind: "light_frames", path: "/astro/lights", scanDepth: "recursive" },
-          { kind: "project", path: "/astro/projects", scanDepth: "recursive" },
-          { kind: "inbox", path: "/astro/inbox", scanDepth: "recursive" },
+          {
+            kind: 'light_frames',
+            path: '/astro/lights',
+            scanDepth: 'recursive',
+          },
+          { kind: 'project', path: '/astro/projects', scanDepth: 'recursive' },
+          { kind: 'inbox', path: '/astro/inbox', scanDepth: 'recursive' },
         ],
         // OLD shape — no `selectedCatalogIds`.
         catalogSettings: { downloadAll: true },
@@ -46,37 +50,39 @@ function seedLegacyWizardState(page: import("@playwright/test").Page): void {
   });
 }
 
-test.describe("Regression · setup legacy catalogSettings", () => {
-  test("Confirm step renders with legacy {downloadAll} state (no crash)", async ({
+test.describe('Regression · setup legacy catalogSettings', () => {
+  test('Confirm step renders with legacy {downloadAll} state (no crash)', async ({
     page,
   }) => {
     const errors: string[] = [];
-    page.on("pageerror", (e) => errors.push(String(e)));
+    page.on('pageerror', (e) => errors.push(String(e)));
 
     seedLegacyWizardState(page);
-    await page.goto("/#/setup");
+    await page.goto('/#/setup');
 
     // The error boundary must NOT appear, and no 'length' of undefined error.
     await expect(page.getByText(/Something went wrong/i)).toHaveCount(0);
     // Confirm step heading (from SetupWizard STEPS[3]).
-    await expect(page.getByText(/Ready to go/i)).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/Ready to go/i)).toBeVisible({
+      timeout: 10_000,
+    });
 
     expect(
       errors.filter((e) => /Cannot read properties of undefined/i.test(e)),
-      `page errors: ${errors.join(" | ")}`,
+      `page errors: ${errors.join(' | ')}`,
     ).toHaveLength(0);
   });
 
-  test("Catalogs step renders with legacy {downloadAll} state (no crash)", async ({
+  test('Catalogs step renders with legacy {downloadAll} state (no crash)', async ({
     page,
   }) => {
     const errors: string[] = [];
-    page.on("pageerror", (e) => errors.push(String(e)));
+    page.on('pageerror', (e) => errors.push(String(e)));
 
     page.addInitScript(() => {
-      window.localStorage.removeItem("alm-preferences");
+      window.localStorage.removeItem('alm-preferences');
       window.localStorage.setItem(
-        "alm-setup-wizard-state",
+        'alm-setup-wizard-state',
         JSON.stringify({
           currentStep: 2, // Catalogs step
           sources: [],
@@ -88,15 +94,17 @@ test.describe("Regression · setup legacy catalogSettings", () => {
         }),
       );
     });
-    await page.goto("/#/setup");
+    await page.goto('/#/setup');
 
     await expect(page.getByText(/Something went wrong/i)).toHaveCount(0);
     // Step index 2 was rebranded "Catalogs" → "Configuration" (#259); the legacy
     // `{ downloadAll: true }` catalogSettings must still render the step (no crash).
-    await expect(page.getByText(/Configuration/i).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText(/Configuration/i).first()).toBeVisible({
+      timeout: 10_000,
+    });
     expect(
       errors.filter((e) => /Cannot read properties of undefined/i.test(e)),
-      `page errors: ${errors.join(" | ")}`,
+      `page errors: ${errors.join(' | ')}`,
     ).toHaveLength(0);
   });
 });

--- a/tests/e2e/sessions_list_regressions.spec.ts
+++ b/tests/e2e/sessions_list_regressions.spec.ts
@@ -17,55 +17,55 @@
  * Uses the static mock fixture (`VITE_USE_MOCKS=true`, see playwright.config.ts)
  * — no real backend.
  */
-import { test, expect } from "@playwright/test";
+import { test, expect } from '@playwright/test';
 
-function seedSetupComplete(page: import("@playwright/test").Page): void {
+function seedSetupComplete(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-preferences",
+      'alm-preferences',
       JSON.stringify({ setupCompleted: true }),
     );
   });
 }
 
-test.describe("Sessions list — Integration column shows total time (#798)", () => {
+test.describe('Sessions list — Integration column shows total time (#798)', () => {
   test("a session's Integration cell shows total time, not the raw per-frame exposure", async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
     // Fixture: M31 · L — 2026-03-28, 120 frames × 195s = 23400s = 6h 30m.
     // (There are several M31 sessions in the fixture — match the specific
     // filter cell so this doesn't accidentally hit a different M31 row.)
-    const row = page.locator(".alm-sessions-table__row", {
-      has: page.getByText("2026-03-28"),
-    }).first();
+    const row = page
+      .locator('.alm-sessions-table__row', {
+        has: page.getByText('2026-03-28'),
+      })
+      .first();
     await expect(row).toBeVisible({ timeout: 8_000 });
-    await expect(row).toContainText("6h 30m");
-    await expect(row).not.toContainText("195s");
+    await expect(row).toContainText('6h 30m');
+    await expect(row).not.toContainText('195s');
   });
 });
 
-test.describe("Sessions list — Type filter defaults to acquisition (#652)", () => {
-  test("the default view hides the calibration session; switching to All reveals it", async ({
+test.describe('Sessions list — Type filter defaults to acquisition (#652)', () => {
+  test('the default view hides the calibration session; switching to All reveals it', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
-    await expect(
-      page.locator(".alm-sessions-table__row").first(),
-    ).toBeVisible({ timeout: 8_000 });
+    await expect(page.locator('.alm-sessions-table__row').first()).toBeVisible({
+      timeout: 8_000,
+    });
 
     // Fixture calibration row: "dark calibration — 2026-04-01" — hidden by default.
-    await expect(
-      page.getByText(/dark calibration/i),
-    ).toHaveCount(0);
+    await expect(page.getByText(/dark calibration/i)).toHaveCount(0);
 
-    const typeSelect = page.getByRole("combobox", { name: "Type" });
-    await expect(typeSelect).toHaveValue("light");
-    await typeSelect.selectOption("");
+    const typeSelect = page.getByRole('combobox', { name: 'Type' });
+    await expect(typeSelect).toHaveValue('light');
+    await typeSelect.selectOption('');
 
     await expect(page.getByText(/dark calibration/i)).toBeVisible({
       timeout: 5_000,
@@ -73,20 +73,22 @@ test.describe("Sessions list — Type filter defaults to acquisition (#652)", ()
   });
 });
 
-test.describe("Sessions detail — project-chip navigation carries the id (#865)", () => {
-  test("clicking a linked-project chip lands on Projects with that project selected", async ({
+test.describe('Sessions detail — project-chip navigation carries the id (#865)', () => {
+  test('clicking a linked-project chip lands on Projects with that project selected', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
-    const row = page.locator(".alm-sessions-table__row", {
-      hasText: "NGC 7000",
-    }).first();
+    const row = page
+      .locator('.alm-sessions-table__row', {
+        hasText: 'NGC 7000',
+      })
+      .first();
     await expect(row).toBeVisible({ timeout: 8_000 });
     await row.click();
 
-    const chip = page.getByRole("button", { name: "NGC 7000 · HOO" });
+    const chip = page.getByRole('button', { name: 'NGC 7000 · HOO' });
     await expect(chip).toBeVisible({ timeout: 5_000 });
 
     // Navigating with the id in the URL is the observable symptom of #865

--- a/tests/e2e/settings_appearance_i18n.spec.ts
+++ b/tests/e2e/settings_appearance_i18n.spec.ts
@@ -37,63 +37,65 @@
  *   - Locale switching is not user-reachable (046 FR-004); no product switcher
  *     exists to drive.
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
-import type { Page } from "@playwright/test";
+import { test, expect, seedSetupComplete } from './support/harness';
+import type { Page } from '@playwright/test';
 
 // ── Scenario 1 — Settings config model persists (spec 018) ──────────────────
 
-test.describe("Journey 10 · Settings configuration model (spec 018)", () => {
-  test("Ingestion pane loads current values, edits, and PERSISTS via the settings mock round-trip", async ({
+test.describe('Journey 10 · Settings configuration model (spec 018)', () => {
+  test('Ingestion pane loads current values, edits, and PERSISTS via the settings mock round-trip', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/ingestion");
+    await page.goto('/#/settings/ingestion');
 
     // Pane loaded: section title + a representative one-setting-per-line row
     // (FR-002). Settings section titles are styled <div>s, not heading roles.
-    await expect(page.getByText("Scan defaults", { exact: true })).toBeVisible();
-    const hashing = page.getByLabel("Hashing mode");
+    await expect(
+      page.getByText('Scan defaults', { exact: true }),
+    ).toBeVisible();
+    const hashing = page.getByLabel('Hashing mode');
     // Current (seeded) value from mockIngestionSettings.
-    await expect(hashing).toHaveValue("lazy");
+    await expect(hashing).toHaveValue('lazy');
 
     // Edit → auto-save (FR-004: no global Save button). Selecting the option
     // fires `ingestion_settings_update`, which mutates the mock fixture.
-    await hashing.selectOption("eager");
-    await expect(hashing).toHaveValue("eager");
+    await hashing.selectOption('eager');
+    await expect(hashing).toHaveValue('eager');
 
     // Round-trip proof: leave the pane (Ingestion unmounts) and return
     // (it re-mounts and re-fetches via `ingestion_settings_get`). The value
     // must survive because the mock persisted it, not because component state
     // lingered.
-    await page.getByRole("button", { name: "Appearance", exact: true }).click();
-    await expect(page.getByText("Theme", { exact: true })).toBeVisible();
-    await page.getByRole("button", { name: "Ingestion", exact: true }).click();
+    await page.getByRole('button', { name: 'Appearance', exact: true }).click();
+    await expect(page.getByText('Theme', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Ingestion', exact: true }).click();
 
-    const hashingAfter = page.getByLabel("Hashing mode");
+    const hashingAfter = page.getByLabel('Hashing mode');
     await expect(hashingAfter).toBeVisible();
-    await expect(hashingAfter).toHaveValue("eager");
+    await expect(hashingAfter).toHaveValue('eager');
   });
 
-  test("Cleanup pane renders the per-type override table and persists an override via the settings mock round-trip", async ({
+  test('Cleanup pane renders the per-type override table and persists an override via the settings mock round-trip', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/cleanup");
+    await page.goto('/#/settings/cleanup');
 
     // Per-type action table present (spec 018 cleanup override surface).
     await expect(
-      page.getByText("Per-Type Default Actions", { exact: true }),
+      page.getByText('Per-Type Default Actions', { exact: true }),
     ).toBeVisible();
 
     // "Raw dark frames" defaults to "Archive"; flip it to "Keep" (a non-default
     // choice, so the override is observable). This now fires
     // `settings_update('cleanup', { cleanupTypeOverrides })` (spec 051 US3),
     // not a localStorage write.
-    const row = page.getByRole("row").filter({ hasText: "Raw dark frames" });
+    const row = page.getByRole('row').filter({ hasText: 'Raw dark frames' });
     await expect(row).toBeVisible();
     // SegControl renders WAI-ARIA radio-group semantics (#1010): options are
     // role="radio", not role="button".
-    await expect(row.getByRole("radio", { name: "Archive" })).toHaveClass(
+    await expect(row.getByRole('radio', { name: 'Archive' })).toHaveClass(
       /alm-seg__btn--active/,
     );
     // Cleanup's mount effect fires `settings_get('cleanup')` (mock IPC has a
@@ -103,8 +105,8 @@ test.describe("Journey 10 · Settings configuration model (spec 018)", () => {
     // back to "Archive"; Cleanup.tsx now tracks whether an edit happened and
     // ignores a mount fetch that resolves afterwards, so a single click+assert
     // is sufficient (no retry needed).
-    await row.getByRole("radio", { name: "Keep" }).click();
-    await expect(row.getByRole("radio", { name: "Keep" })).toHaveClass(
+    await row.getByRole('radio', { name: 'Keep' }).click();
+    await expect(row.getByRole('radio', { name: 'Keep' })).toHaveClass(
       /alm-seg__btn--active/,
       { timeout: 15_000 },
     );
@@ -119,16 +121,18 @@ test.describe("Journey 10 · Settings configuration model (spec 018)", () => {
     // re-mounts and re-fetches via `settings_get('cleanup')`). The value must
     // survive because the mock persisted it, not because component state
     // lingered — mirrors the Ingestion pane proof above.
-    await page.getByRole("button", { name: "Appearance", exact: true }).click();
-    await expect(page.getByText("Theme", { exact: true })).toBeVisible();
-    await page.getByRole("button", { name: "Cleanup", exact: true }).click();
+    await page.getByRole('button', { name: 'Appearance', exact: true }).click();
+    await expect(page.getByText('Theme', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Cleanup', exact: true }).click();
 
-    const rowAfter = page.getByRole("row").filter({ hasText: "Raw dark frames" });
+    const rowAfter = page
+      .getByRole('row')
+      .filter({ hasText: 'Raw dark frames' });
     await expect(rowAfter).toBeVisible();
     // No stomp risk here (single settings_get after remount, no competing
     // local click) — just the same mock IPC latency, so a longer read-only
     // wait is sufficient.
-    await expect(rowAfter.getByRole("radio", { name: "Keep" })).toHaveClass(
+    await expect(rowAfter.getByRole('radio', { name: 'Keep' })).toHaveClass(
       /alm-seg__btn--active/,
       { timeout: 15_000 },
     );
@@ -138,83 +142,85 @@ test.describe("Journey 10 · Settings configuration model (spec 018)", () => {
 // ── Scenario 2 — Appearance / 4 themes (spec 043) ───────────────────────────
 
 const THEME_CASES: { name: string; dataTheme: string }[] = [
-  { name: "Warm Clay", dataTheme: "warm-clay" },
-  { name: "Warm Slate", dataTheme: "warm-slate" },
-  { name: "Observatory", dataTheme: "observatory-dark" },
-  { name: "Espresso", dataTheme: "espresso-dark" },
+  { name: 'Warm Clay', dataTheme: 'warm-clay' },
+  { name: 'Warm Slate', dataTheme: 'warm-slate' },
+  { name: 'Observatory', dataTheme: 'observatory-dark' },
+  { name: 'Espresso', dataTheme: 'espresso-dark' },
 ];
 
-test.describe("Journey 10 · Appearance / 4 themes (spec 043)", () => {
-  test("switching among the 4 themes updates data-theme on <html> and persists", async ({
+test.describe('Journey 10 · Appearance / 4 themes (spec 043)', () => {
+  test('switching among the 4 themes updates data-theme on <html> and persists', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/general");
-    await expect(page.getByText("Theme", { exact: true })).toBeVisible();
+    await page.goto('/#/settings/general');
+    await expect(page.getByText('Theme', { exact: true })).toBeVisible();
 
     // System + 4 named themes = 5 swatch cards.
-    const swatches = page.locator(".alm-theme-swatch");
+    const swatches = page.locator('.alm-theme-swatch');
     await expect(swatches).toHaveCount(5);
 
     for (const theme of THEME_CASES) {
       // Swatch buttons' accessible name is "<Theme name> <mode>" (e.g. "Warm
       // Clay Light"); match by the brand-name substring (not exact).
-      await page.getByRole("button", { name: theme.name }).click();
+      await page.getByRole('button', { name: theme.name }).click();
       // The appearance runtime writes data-theme on the document root.
-      await expect(page.locator("html")).toHaveAttribute(
-        "data-theme",
+      await expect(page.locator('html')).toHaveAttribute(
+        'data-theme',
         theme.dataTheme,
       );
       // Choice is persisted in localStorage under `alm.theme`.
-      const stored = await page.evaluate(() => localStorage.getItem("alm.theme"));
+      const stored = await page.evaluate(() =>
+        localStorage.getItem('alm.theme'),
+      );
       expect(stored).toBe(theme.dataTheme);
     }
   });
 
-  test("theme choice survives navigating away from Settings (#794)", async ({
+  test('theme choice survives navigating away from Settings (#794)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/general");
-    await page.getByRole("button", { name: "Warm Clay" }).click();
-    await expect(page.locator("html")).toHaveAttribute(
-      "data-theme",
-      "warm-clay",
+    await page.goto('/#/settings/general');
+    await page.getByRole('button', { name: 'Warm Clay' }).click();
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-theme',
+      'warm-clay',
     );
 
     // #794 repro: switch theme, then navigate away — the choice must not
     // silently revert to the resolved-system dark default.
-    await page.goto("/#/targets");
-    await expect(page.locator(".alm-sidebar")).toBeVisible();
-    await expect(page.locator("html")).toHaveAttribute(
-      "data-theme",
-      "warm-clay",
+    await page.goto('/#/targets');
+    await expect(page.locator('.alm-sidebar')).toBeVisible();
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-theme',
+      'warm-clay',
     );
   });
 
-  test("theme choice survives a full reload (applied at boot via initAppearance)", async ({
+  test('theme choice survives a full reload (applied at boot via initAppearance)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/general");
-    await page.getByRole("button", { name: "Espresso" }).click();
-    await expect(page.locator("html")).toHaveAttribute(
-      "data-theme",
-      "espresso-dark",
+    await page.goto('/#/settings/general');
+    await page.getByRole('button', { name: 'Espresso' }).click();
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-theme',
+      'espresso-dark',
     );
 
     await page.reload();
     // Boot-time initAppearance() re-applies the persisted theme before render.
-    await expect(page.locator("html")).toHaveAttribute(
-      "data-theme",
-      "espresso-dark",
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-theme',
+      'espresso-dark',
     );
   });
 });
 
 // ── Scenario 3 — Layout convention (spec 043) ───────────────────────────────
 
-test.describe("Journey 10 · Page-layout convention (spec 043)", () => {
+test.describe('Journey 10 · Page-layout convention (spec 043)', () => {
   // The Settings Cleanup pane has a long per-type table, so its content region
   // (`.alm-two-pane__detail`, overflow-y:auto) actually overflows at 720px —
   // making it a faithful probe for "action bar always visible, only content
@@ -225,12 +231,12 @@ test.describe("Journey 10 · Page-layout convention (spec 043)", () => {
   ): Promise<void> {
     await page.setViewportSize({ width: 1100, height });
 
-    const bar = page.locator(".alm-page__bar").first();
+    const bar = page.locator('.alm-page__bar').first();
     await expect(bar).toBeVisible();
     const barBoxBefore = await bar.boundingBox();
     expect(barBoxBefore).not.toBeNull();
 
-    const scroller = page.locator(".alm-two-pane__detail").first();
+    const scroller = page.locator('.alm-two-pane__detail').first();
     // Content must genuinely overflow, else "only content scrolls" is untested.
     const overflow = await scroller.evaluate(
       (el) => el.scrollHeight - el.clientHeight,
@@ -251,17 +257,17 @@ test.describe("Journey 10 · Page-layout convention (spec 043)", () => {
     expect(Math.round(barBoxAfter!.y)).toBe(Math.round(barBoxBefore!.y));
   }
 
-  test("action bar stays pinned while only the content region scrolls (1100x720 and a shorter height)", async ({
+  test('action bar stays pinned while only the content region scrolls (1100x720 and a shorter height)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/cleanup");
+    await page.goto('/#/settings/cleanup');
     await expect(
-      page.getByText("Per-Type Default Actions", { exact: true }),
+      page.getByText('Per-Type Default Actions', { exact: true }),
     ).toBeVisible();
     // The top action bar carries the page title.
     await expect(
-      page.locator(".alm-page__bar").getByText("Settings", { exact: true }),
+      page.locator('.alm-page__bar').getByText('Settings', { exact: true }),
     ).toBeVisible();
 
     await assertBarPinnedWhileContentScrolls(page, 720);
@@ -271,22 +277,22 @@ test.describe("Journey 10 · Page-layout convention (spec 043)", () => {
 
 // ── Scenario 4 — i18n (spec 046) ────────────────────────────────────────────
 
-test.describe("Journey 10 · i18n catalog (spec 046)", () => {
-  test("Settings renders human strings — no raw message-key fallbacks leak", async ({
+test.describe('Journey 10 · i18n catalog (spec 046)', () => {
+  test('Settings renders human strings — no raw message-key fallbacks leak', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/sources");
+    await page.goto('/#/settings/sources');
 
     // Known keys must resolve to their English strings, not literal keys.
     await expect(
-      page.locator(".alm-page__bar").getByText("Settings", { exact: true }),
+      page.locator('.alm-page__bar').getByText('Settings', { exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Data Sources", exact: true }),
+      page.getByRole('button', { name: 'Data Sources', exact: true }),
     ).toBeVisible();
     await expect(
-      page.getByRole("button", { name: "Appearance", exact: true }),
+      page.getByRole('button', { name: 'Appearance', exact: true }),
     ).toBeVisible();
 
     // No `settings_*` / `logpanel_*` / `common_*` raw Paraglide key may appear
@@ -302,7 +308,7 @@ test.describe("Journey 10 · i18n catalog (spec 046)", () => {
 
     // Every settings-nav label must be a rendered string, never a raw key.
     const navLabels = await page
-      .locator(".alm-settings__nav-item")
+      .locator('.alm-settings__nav-item')
       .allInnerTexts();
     expect(navLabels.length).toBeGreaterThan(0);
     for (const label of navLabels) {
@@ -310,42 +316,42 @@ test.describe("Journey 10 · i18n catalog (spec 046)", () => {
     }
   });
 
-  test("plural-bearing message renders the correct plural form (Audit Log event count)", async ({
+  test('plural-bearing message renders the correct plural form (Audit Log event count)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/audit");
+    await page.goto('/#/settings/audit');
 
     // The mock audit fixture has 5 entries → `settings_auditlog_event_count`
     // must select the `pp=other` branch ("5 events"), proving Paraglide plural
     // resolution — not the singular "5 event" nor a raw-key render.
-    await expect(page.getByText("5 events")).toBeVisible();
+    await expect(page.getByText('5 events')).toBeVisible();
     await expect(page.getByText(/\b5 event\b(?! s)/)).toHaveCount(0);
   });
 });
 
 // ── Scenario 5 — Bottom log viewer (spec 019) ───────────────────────────────
 
-test.describe("Journey 10 · Bottom log viewer (spec 019)", () => {
-  test("opening the log panel renders entries; level filter + Escape-close behave", async ({
+test.describe('Journey 10 · Bottom log viewer (spec 019)', () => {
+  test('opening the log panel renders entries; level filter + Escape-close behave', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
+    await page.goto('/#/sessions');
 
     // Panel starts collapsed (Shell renders it only while expanded). Open it
     // via the status-bar toggle.
-    const logRegion = page.getByRole("log", { name: "Operation log" });
+    const logRegion = page.getByRole('log', { name: 'Operation log' });
     await expect(logRegion).toHaveCount(0);
-    await page.getByRole("button", { name: "Toggle log panel" }).click();
+    await page.getByRole('button', { name: 'Toggle log panel' }).click();
     await expect(logRegion).toBeVisible();
 
     // Seeded mock entries render (MOCK_LOG_ENTRIES).
     await expect(
-      logRegion.getByText("Scan completed: 1,247 files indexed"),
+      logRegion.getByText('Scan completed: 1,247 files indexed'),
     ).toBeVisible();
     const errorMsg =
-      "Failed to read: /raw/2026-04-17/frame_0043.fit — permission denied";
+      'Failed to read: /raw/2026-04-17/frame_0043.fit — permission denied';
     await expect(logRegion.getByText(errorMsg)).toBeVisible();
 
     // Controls present (FR-003 level chips + FR-007 JSON export, follow-tail).
@@ -353,39 +359,41 @@ test.describe("Journey 10 · Bottom log viewer (spec 019)", () => {
     // group, also with a visible "All" chip) — assert both by their
     // distinct accessible names rather than the shared visible text.
     await expect(
-      logRegion.getByRole("button", { name: "All levels", exact: true }),
+      logRegion.getByRole('button', { name: 'All levels', exact: true }),
     ).toBeVisible();
-    for (const chip of ["Error", "Warn", "Info", "Debug"]) {
+    for (const chip of ['Error', 'Warn', 'Info', 'Debug']) {
       await expect(
-        logRegion.getByRole("button", { name: chip, exact: true }),
+        logRegion.getByRole('button', { name: chip, exact: true }),
       ).toBeVisible();
     }
     await expect(
-      logRegion.getByRole("button", { name: "Export log to JSON file" }),
+      logRegion.getByRole('button', { name: 'Export log to JSON file' }),
     ).toBeVisible();
 
     // Category/source filter (#666) — same visible "All" text as the level
     // filter, disambiguated by aria-label; a real source chip is present.
     await expect(
-      logRegion.getByRole("button", { name: "All sources", exact: true }),
+      logRegion.getByRole('button', { name: 'All sources', exact: true }),
     ).toBeVisible();
     await expect(
-      logRegion.getByRole("button", { name: "target", exact: true }),
+      logRegion.getByRole('button', { name: 'target', exact: true }),
     ).toBeVisible();
 
     // Truncation marker is NOT reachable in mock mode (documented above):
     // assert its honest absence rather than fabricating a truncated buffer.
-    await expect(page.locator(".alm-logpanel__truncation-marker")).toHaveCount(0);
+    await expect(page.locator('.alm-logpanel__truncation-marker')).toHaveCount(
+      0,
+    );
 
     // Level filter behaves: selecting "Error" hides non-error entries.
-    await logRegion.getByRole("button", { name: "Error", exact: true }).click();
+    await logRegion.getByRole('button', { name: 'Error', exact: true }).click();
     await expect(logRegion.getByText(errorMsg)).toBeVisible();
     await expect(
-      logRegion.getByText("Scan completed: 1,247 files indexed"),
+      logRegion.getByText('Scan completed: 1,247 files indexed'),
     ).toHaveCount(0);
 
     // Escape closes the panel (Shell unmounts it).
-    await page.keyboard.press("Escape");
+    await page.keyboard.press('Escape');
     await expect(logRegion).toHaveCount(0);
   });
 });
@@ -405,13 +413,15 @@ test.describe("Journey 10 · Bottom log viewer (spec 019)", () => {
 // the enlarged-window x150% pin are deliberately chosen so they still land
 // inside the accepted envelope; min-window x150% (733px) is documented in
 // the spec as accepted degradation, not guarded here.
-test.describe("Journey 10 · Whole-app zoom envelope pins (spec 055 FR-006)", () => {
+test.describe('Journey 10 · Whole-app zoom envelope pins (spec 055 FR-006)', () => {
   const OVERFLOW_TOLERANCE_PX = 2;
 
-  async function assertShellIntactNoHorizontalOverflow(page: Page): Promise<void> {
-    await expect(page.locator(".alm-sidebar")).toBeVisible();
-    await expect(page.locator(".alm-page__bar").first()).toBeVisible();
-    await expect(page.locator(".alm-frame__main")).toBeVisible();
+  async function assertShellIntactNoHorizontalOverflow(
+    page: Page,
+  ): Promise<void> {
+    await expect(page.locator('.alm-sidebar')).toBeVisible();
+    await expect(page.locator('.alm-page__bar').first()).toBeVisible();
+    await expect(page.locator('.alm-frame__main')).toBeVisible();
 
     const overflow = await page.evaluate(() => {
       const doc = document.scrollingElement!;
@@ -420,24 +430,24 @@ test.describe("Journey 10 · Whole-app zoom envelope pins (spec 055 FR-006)", ()
     expect(overflow).toBeLessThanOrEqual(OVERFLOW_TOLERANCE_PX);
   }
 
-  test("1100x720 min window at 125% zoom equivalent (880x576) — shell intact, no horizontal overflow", async ({
+  test('1100x720 min window at 125% zoom equivalent (880x576) — shell intact, no horizontal overflow', async ({
     page,
   }) => {
     seedSetupComplete(page);
     await page.setViewportSize({ width: 880, height: 576 });
-    await page.goto("/#/settings/general");
-    await expect(page.getByText("Theme", { exact: true })).toBeVisible();
+    await page.goto('/#/settings/general');
+    await expect(page.getByText('Theme', { exact: true })).toBeVisible();
 
     await assertShellIntactNoHorizontalOverflow(page);
   });
 
-  test("1320x864 window at 150% zoom equivalent (880x576) — shell intact, no horizontal overflow", async ({
+  test('1320x864 window at 150% zoom equivalent (880x576) — shell intact, no horizontal overflow', async ({
     page,
   }) => {
     seedSetupComplete(page);
     await page.setViewportSize({ width: 880, height: 576 });
-    await page.goto("/#/targets");
-    await expect(page.locator(".alm-sidebar")).toBeVisible();
+    await page.goto('/#/targets');
+    await expect(page.locator('.alm-sidebar')).toBeVisible();
 
     await assertShellIntactNoHorizontalOverflow(page);
   });
@@ -445,49 +455,50 @@ test.describe("Journey 10 · Whole-app zoom envelope pins (spec 055 FR-006)", ()
 
 // ── Scenario 7 — Appearance "Restore defaults" adoption (#802) ──────────────
 
-test.describe("Journey 10 · Appearance Restore defaults (#802)", () => {
-  test("Restore defaults resets a changed theme back to System", async ({
+test.describe('Journey 10 · Appearance Restore defaults (#802)', () => {
+  test('Restore defaults resets a changed theme back to System', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/general");
-    await expect(page.getByText("Theme", { exact: true })).toBeVisible();
+    await page.goto('/#/settings/general');
+    await expect(page.getByText('Theme', { exact: true })).toBeVisible();
 
-    await page.getByRole("button", { name: "Espresso" }).click();
-    await expect(page.locator("html")).toHaveAttribute(
-      "data-theme",
-      "espresso-dark",
+    await page.getByRole('button', { name: 'Espresso' }).click();
+    await expect(page.locator('html')).toHaveAttribute(
+      'data-theme',
+      'espresso-dark',
     );
 
     await page
-      .getByRole("button", { name: "Restore defaults", exact: true })
+      .getByRole('button', { name: 'Restore defaults', exact: true })
       .click();
-    await expect(
-      page.getByRole("button", { name: "System" }),
-    ).toHaveAttribute("aria-pressed", "true");
+    await expect(page.getByRole('button', { name: 'System' })).toHaveAttribute(
+      'aria-pressed',
+      'true',
+    );
   });
 });
 
 // ── Scenario 8 — Advanced > Guided Tour restart confirm gate (#827) ─────────
 
-test.describe("Journey 10 · Advanced Guided Tour restart gate (#827)", () => {
+test.describe('Journey 10 · Advanced Guided Tour restart gate (#827)', () => {
   test("'Restart guided flow' requires confirmation and shows success feedback, matching 'Restart first-run setup'", async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/advanced");
+    await page.goto('/#/settings/advanced');
 
-    const restartBtn = page.getByTestId("guided-restart-btn");
+    const restartBtn = page.getByTestId('guided-restart-btn');
     await expect(restartBtn).toBeVisible();
 
     // Clicking must not fire the restart directly — a confirm step gates it,
     // symmetric with the "Restart first-run setup" control below it.
     await restartBtn.click();
-    const confirmBtn = page.getByTestId("guided-restart-confirm-btn");
+    const confirmBtn = page.getByTestId('guided-restart-confirm-btn');
     await expect(confirmBtn).toBeVisible();
-    await expect(page.getByTestId("guided-restart-done")).toHaveCount(0);
+    await expect(page.getByTestId('guided-restart-done')).toHaveCount(0);
 
     await confirmBtn.click();
-    await expect(page.getByTestId("guided-restart-done")).toBeVisible();
+    await expect(page.getByTestId('guided-restart-done')).toBeVisible();
   });
 });

--- a/tests/e2e/settings_framing.spec.ts
+++ b/tests/e2e/settings_framing.spec.ts
@@ -23,66 +23,66 @@
  * (`apps/desktop/src/api/mocks.ts`), seeded at the R11a shipped defaults —
  * mirrors the Ingestion/Cleanup panes' proven round-trip pattern.
  */
-import { expect, seedSetupComplete, test } from "./support/harness";
+import { expect, seedSetupComplete, test } from './support/harness';
 
-test.describe("Settings · Framing clustering tolerances (spec 008 Q27 F-Framing-11)", () => {
-	test("pane loads R11a defaults, edits the pointing tolerance, and PERSISTS via the settings mock round-trip", async ({
-		page,
-	}) => {
-		seedSetupComplete(page);
-		await page.goto("/#/settings/framing");
+test.describe('Settings · Framing clustering tolerances (spec 008 Q27 F-Framing-11)', () => {
+  test('pane loads R11a defaults, edits the pointing tolerance, and PERSISTS via the settings mock round-trip', async ({
+    page,
+  }) => {
+    seedSetupComplete(page);
+    await page.goto('/#/settings/framing');
 
-		// Pane loaded: section title + the four R11a-default values.
-		await expect(
-			page.getByText("Clustering Tolerances", { exact: true }),
-		).toBeVisible();
-		// `getByTestId`, not `getByLabel`: the row's InfoTip tooltip text
-		// contains "pointing tolerance" as a substring, so a substring-matching
-		// accessible-name locator resolves ambiguously to both the input and
-		// the tooltip note.
-		const pointingFraction = page.getByTestId(
-			"framing-pointing-fraction-input",
-		);
-		const pointingFallback = page.getByTestId(
-			"framing-pointing-fallback-input",
-		);
-		const rotation = page.getByTestId("framing-rotation-tolerance-input");
-		const mosaicEnvelope = page.getByTestId("framing-mosaic-envelope-input");
-		await expect(pointingFraction).toHaveValue("0.1");
-		await expect(pointingFallback).toHaveValue("0.2");
-		await expect(rotation).toHaveValue("3");
-		await expect(mosaicEnvelope).toHaveValue("1");
+    // Pane loaded: section title + the four R11a-default values.
+    await expect(
+      page.getByText('Clustering Tolerances', { exact: true }),
+    ).toBeVisible();
+    // `getByTestId`, not `getByLabel`: the row's InfoTip tooltip text
+    // contains "pointing tolerance" as a substring, so a substring-matching
+    // accessible-name locator resolves ambiguously to both the input and
+    // the tooltip note.
+    const pointingFraction = page.getByTestId(
+      'framing-pointing-fraction-input',
+    );
+    const pointingFallback = page.getByTestId(
+      'framing-pointing-fallback-input',
+    );
+    const rotation = page.getByTestId('framing-rotation-tolerance-input');
+    const mosaicEnvelope = page.getByTestId('framing-mosaic-envelope-input');
+    await expect(pointingFraction).toHaveValue('0.1');
+    await expect(pointingFallback).toHaveValue('0.2');
+    await expect(rotation).toHaveValue('3');
+    await expect(mosaicEnvelope).toHaveValue('1');
 
-		// Edit → auto-save on blur (no global Save button, matching every other
-		// settings pane's convention). Fires `settings_update('framing', …)`,
-		// which mutates the mock fixture.
-		await pointingFraction.fill("0.25");
-		await pointingFraction.blur();
-		await expect(pointingFraction).toHaveValue("0.25");
+    // Edit → auto-save on blur (no global Save button, matching every other
+    // settings pane's convention). Fires `settings_update('framing', …)`,
+    // which mutates the mock fixture.
+    await pointingFraction.fill('0.25');
+    await pointingFraction.blur();
+    await expect(pointingFraction).toHaveValue('0.25');
 
-		// `save()` debounces via useAutoSave (300ms) before it actually calls
-		// `settings_update`; wait it out so the mock has genuinely persisted the
-		// edit before navigating away (otherwise this proves nothing about
-		// backend persistence — just lingering component state; same convention
-		// as the Cleanup pane's round-trip proof).
-		await page.waitForTimeout(400);
+    // `save()` debounces via useAutoSave (300ms) before it actually calls
+    // `settings_update`; wait it out so the mock has genuinely persisted the
+    // edit before navigating away (otherwise this proves nothing about
+    // backend persistence — just lingering component state; same convention
+    // as the Cleanup pane's round-trip proof).
+    await page.waitForTimeout(400);
 
-		// Round-trip proof: leave the pane (Framing unmounts) and return (it
-		// re-mounts and re-fetches via `settings_get('framing')`). The value must
-		// survive because the mock persisted it, not because component state
-		// lingered — mirrors the Ingestion/Cleanup pane proofs.
-		await page.getByRole("button", { name: "Appearance", exact: true }).click();
-		await expect(page.getByText("Theme", { exact: true })).toBeVisible();
-		await page.getByRole("button", { name: "Framing", exact: true }).click();
+    // Round-trip proof: leave the pane (Framing unmounts) and return (it
+    // re-mounts and re-fetches via `settings_get('framing')`). The value must
+    // survive because the mock persisted it, not because component state
+    // lingered — mirrors the Ingestion/Cleanup pane proofs.
+    await page.getByRole('button', { name: 'Appearance', exact: true }).click();
+    await expect(page.getByText('Theme', { exact: true })).toBeVisible();
+    await page.getByRole('button', { name: 'Framing', exact: true }).click();
 
-		const pointingFractionAfter = page.getByTestId(
-			"framing-pointing-fraction-input",
-		);
-		await expect(pointingFractionAfter).toBeVisible();
-		await expect(pointingFractionAfter).toHaveValue("0.25");
-		// Untouched fields keep their R11a defaults across the round-trip too.
-		await expect(
-			page.getByTestId("framing-rotation-tolerance-input"),
-		).toHaveValue("3");
-	});
+    const pointingFractionAfter = page.getByTestId(
+      'framing-pointing-fraction-input',
+    );
+    await expect(pointingFractionAfter).toBeVisible();
+    await expect(pointingFractionAfter).toHaveValue('0.25');
+    // Untouched fields keep their R11a defaults across the round-trip too.
+    await expect(
+      page.getByTestId('framing-rotation-tolerance-input'),
+    ).toHaveValue('3');
+  });
 });

--- a/tests/e2e/setup_wizard_site_step.spec.ts
+++ b/tests/e2e/setup_wizard_site_step.spec.ts
@@ -28,18 +28,22 @@
  * `regression_setup_legacy_catalog.spec.ts` uses — avoids re-walking the
  * Sources/Tools/Config steps for every test.
  */
-import { test, expect } from "./support/harness";
+import { test, expect } from './support/harness';
 
-function seedWizardAtSiteStep(page: import("@playwright/test").Page): void {
+function seedWizardAtSiteStep(page: import('@playwright/test').Page): void {
   page.addInitScript(() => {
-    window.localStorage.removeItem("alm-preferences");
+    window.localStorage.removeItem('alm-preferences');
     window.localStorage.setItem(
-      "alm-setup-wizard-state",
+      'alm-setup-wizard-state',
       JSON.stringify({
         currentStep: 3, // Site step (STEPS[3], spec 044 US3 inserted before Confirm).
         sources: [
-          { kind: "light_frames", path: "/astro/lights", scanDepth: "recursive" },
-          { kind: "project", path: "/astro/projects", scanDepth: "recursive" },
+          {
+            kind: 'light_frames',
+            path: '/astro/lights',
+            scanDepth: 'recursive',
+          },
+          { kind: 'project', path: '/astro/projects', scanDepth: 'recursive' },
         ],
         catalogSettings: { selectedCatalogIds: [] },
         tools: {
@@ -51,15 +55,15 @@ function seedWizardAtSiteStep(page: import("@playwright/test").Page): void {
   });
 }
 
-test.describe("setup wizard · Observing Site step (spec 044 US3/T016)", () => {
-  test("renders the optional-site copy and advances to Confirm when left blank", async ({
+test.describe('setup wizard · Observing Site step (spec 044 US3/T016)', () => {
+  test('renders the optional-site copy and advances to Confirm when left blank', async ({
     page,
   }) => {
     seedWizardAtSiteStep(page);
-    await page.goto("/#/setup");
+    await page.goto('/#/setup');
 
     await expect(
-      page.getByRole("heading", { name: "Where do you observe from?" }),
+      page.getByRole('heading', { name: 'Where do you observe from?' }),
     ).toBeVisible({ timeout: 10_000 });
     await expect(
       page.getByText(/Optional — add one observing site now, or skip/i),
@@ -69,35 +73,37 @@ test.describe("setup wizard · Observing Site step (spec 044 US3/T016)", () => {
     ).toBeVisible();
 
     // Every field starts empty — never a pre-filled or fabricated value.
-    await expect(page.locator("#setup-site-name")).toHaveValue("");
-    await expect(page.locator("#setup-site-lat")).toHaveValue("");
-    await expect(page.locator("#setup-site-lon")).toHaveValue("");
+    await expect(page.locator('#setup-site-name')).toHaveValue('');
+    await expect(page.locator('#setup-site-lat')).toHaveValue('');
+    await expect(page.locator('#setup-site-lon')).toHaveValue('');
 
     // FR-025: the step is entirely optional — leaving it blank must still advance.
-    await page.getByRole("button", { name: "Continue to confirm →" }).click();
+    await page.getByRole('button', { name: 'Continue to confirm →' }).click();
     await expect(
-      page.getByRole("heading", { name: "Ready to go" }),
+      page.getByRole('heading', { name: 'Ready to go' }),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 
-  test("an out-of-range latitude surfaces the real, localized inline validation error", async ({
+  test('an out-of-range latitude surfaces the real, localized inline validation error', async ({
     page,
   }) => {
     seedWizardAtSiteStep(page);
-    await page.goto("/#/setup");
+    await page.goto('/#/setup');
     await expect(
-      page.getByRole("heading", { name: "Where do you observe from?" }),
+      page.getByRole('heading', { name: 'Where do you observe from?' }),
     ).toBeVisible({ timeout: 10_000 });
 
     // siteStepError only fires once the step is non-empty (siteStepHasSite) —
     // name + lat + lon must all be filled in first.
-    await page.locator("#setup-site-name").fill("Backyard");
-    await page.locator("#setup-site-lon").fill("10");
-    await page.locator("#setup-site-lat").fill("200");
+    await page.locator('#setup-site-name').fill('Backyard');
+    await page.locator('#setup-site-lon').fill('10');
+    await page.locator('#setup-site-lat').fill('200');
 
     await expect(
-      page.getByText("Latitude must be a number between -90 and 90."),
+      page.getByText('Latitude must be a number between -90 and 90.'),
     ).toBeVisible();
   });
 
@@ -105,27 +111,29 @@ test.describe("setup wizard · Observing Site step (spec 044 US3/T016)", () => {
     page,
   }) => {
     seedWizardAtSiteStep(page);
-    await page.goto("/#/setup");
+    await page.goto('/#/setup');
     await expect(
-      page.getByRole("heading", { name: "Where do you observe from?" }),
+      page.getByRole('heading', { name: 'Where do you observe from?' }),
     ).toBeVisible({ timeout: 10_000 });
 
-    await page.locator("#setup-site-name").fill("Backyard Observatory");
-    await page.locator("#setup-site-lat").fill("51.5");
-    await page.locator("#setup-site-lon").fill("-0.1");
+    await page.locator('#setup-site-name').fill('Backyard Observatory');
+    await page.locator('#setup-site-lat').fill('51.5');
+    await page.locator('#setup-site-lon').fill('-0.1');
     await expect(page.getByText(/must be a number between/)).toHaveCount(0);
 
-    await page.getByRole("button", { name: "Continue to confirm →" }).click();
+    await page.getByRole('button', { name: 'Continue to confirm →' }).click();
     await expect(
-      page.getByRole("heading", { name: "Ready to go" }),
+      page.getByRole('heading', { name: 'Ready to go' }),
     ).toBeVisible({ timeout: 5_000 });
 
-    await page.getByRole("button", { name: "← Back" }).click();
+    await page.getByRole('button', { name: '← Back' }).click();
     await expect(
-      page.getByRole("heading", { name: "Where do you observe from?" }),
+      page.getByRole('heading', { name: 'Where do you observe from?' }),
     ).toBeVisible({ timeout: 5_000 });
-    await expect(page.locator("#setup-site-name")).toHaveValue("Backyard Observatory");
-    await expect(page.locator("#setup-site-lat")).toHaveValue("51.5");
-    await expect(page.locator("#setup-site-lon")).toHaveValue("-0.1");
+    await expect(page.locator('#setup-site-name')).toHaveValue(
+      'Backyard Observatory',
+    );
+    await expect(page.locator('#setup-site-lat')).toHaveValue('51.5');
+    await expect(page.locator('#setup-site-lon')).toHaveValue('-0.1');
   });
 });

--- a/tests/e2e/source_view_stale_audit.spec.ts
+++ b/tests/e2e/source_view_stale_audit.spec.ts
@@ -18,75 +18,85 @@
  *                        a synthetic removal + regeneration plan scoped to
  *                        `mock-sv-view-stale` via `originPath`.
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
+import { test, expect, seedSetupComplete } from './support/harness';
 
 async function selectProject(
-  page: import("@playwright/test").Page,
+  page: import('@playwright/test').Page,
   name: string,
 ): Promise<void> {
   const row = page
-    .locator(".alm-projects-table__row")
+    .locator('.alm-projects-table__row')
     .filter({ hasText: name })
     .first();
   await expect(row).toBeVisible({ timeout: 8_000 });
   await row.click();
-  await expect(page.getByTestId("lifecycle-actions")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId('lifecycle-actions')).toBeVisible({
+    timeout: 5_000,
+  });
 }
 
-test.describe("source view stale-detection sweep + audit history (spec 026)", () => {
-  test("stale badge and broken-reference detail render without a Verify click", async ({
+test.describe('source view stale-detection sweep + audit history (spec 026)', () => {
+  test('stale badge and broken-reference detail render without a Verify click', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "M31 LRGB");
+    await page.goto('/#/projects');
+    await selectProject(page, 'M31 LRGB');
 
-    const row = page.getByTestId("source-view-row-mock-sv-view-stale");
+    const row = page.getByTestId('source-view-row-mock-sv-view-stale');
     await expect(row).toBeVisible({ timeout: 8_000 });
-    await expect(row).toContainText("Stale");
+    await expect(row).toContainText('Stale');
 
     // Persisted stale-item summary — visible on load, no interaction needed.
-    const summary = page.getByTestId("stale-summary-mock-sv-view-stale");
+    const summary = page.getByTestId('stale-summary-mock-sv-view-stale');
     await expect(summary).toBeVisible();
-    await expect(summary).toContainText("1 item(s) need attention");
+    await expect(summary).toContainText('1 item(s) need attention');
 
     // Per-item broken-reference detail rides the sweep's last_observed_state.
     await row.getByText(/inventory ref/).click();
-    await expect(page.getByTestId("source-view-item-observed-mock-sv-item-stale-broken")).toContainText(
-      "missing",
-    );
     await expect(
-      page.getByTestId("source-view-item-observed-mock-sv-item-stale-ok"),
+      page.getByTestId('source-view-item-observed-mock-sv-item-stale-broken'),
+    ).toContainText('missing');
+    await expect(
+      page.getByTestId('source-view-item-observed-mock-sv-item-stale-ok'),
     ).toHaveCount(0);
 
     // Regenerate is offered for a stale view (repair path).
-    await expect(page.getByTestId("regenerate-view-mock-sv-view-stale")).toBeVisible();
+    await expect(
+      page.getByTestId('regenerate-view-mock-sv-view-stale'),
+    ).toBeVisible();
   });
 
-  test("audit history lists the view's removal and regeneration plans", async ({ page }) => {
+  test("audit history lists the view's removal and regeneration plans", async ({
+    page,
+  }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "M31 LRGB");
+    await page.goto('/#/projects');
+    await selectProject(page, 'M31 LRGB');
 
-    const row = page.getByTestId("source-view-row-mock-sv-view-stale");
+    const row = page.getByTestId('source-view-row-mock-sv-view-stale');
     await expect(row).toBeVisible({ timeout: 8_000 });
 
-    await row.getByText("History").click();
+    await row.getByText('History').click();
 
-    const removalRow = page.getByTestId("view-history-row-mock-sv-plan-removal-1");
+    const removalRow = page.getByTestId(
+      'view-history-row-mock-sv-plan-removal-1',
+    );
     await expect(removalRow).toBeVisible({ timeout: 5_000 });
-    await expect(removalRow).toContainText("Removal");
-    await expect(removalRow).toContainText("applied");
-    await expect(removalRow).toContainText("1 applied, 0 failed");
+    await expect(removalRow).toContainText('Removal');
+    await expect(removalRow).toContainText('applied');
+    await expect(removalRow).toContainText('1 applied, 0 failed');
 
-    const regenRow = page.getByTestId("view-history-row-mock-sv-plan-regen-1");
+    const regenRow = page.getByTestId('view-history-row-mock-sv-plan-regen-1');
     await expect(regenRow).toBeVisible();
-    await expect(regenRow).toContainText("Regeneration");
-    await expect(regenRow).toContainText("partially_applied");
-    await expect(regenRow).toContainText("1 applied, 1 failed");
+    await expect(regenRow).toContainText('Regeneration');
+    await expect(regenRow).toContainText('partially_applied');
+    await expect(regenRow).toContainText('1 applied, 1 failed');
 
     // History is scoped to this view only — the clean view's plans (none in
     // this fixture) must not leak in.
-    await expect(page.getByTestId("view-history-row-mock-sv-plan-removal-1")).toHaveCount(1);
+    await expect(
+      page.getByTestId('view-history-row-mock-sv-plan-removal-1'),
+    ).toHaveCount(1);
   });
 });

--- a/tests/e2e/source_view_verify.spec.ts
+++ b/tests/e2e/source_view_verify.spec.ts
@@ -23,63 +23,71 @@
  *   sourceview_verify → `mock-sv-view-broken` reports one broken item
  *                        (state `moved`); every other view id reports clean.
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
+import { test, expect, seedSetupComplete } from './support/harness';
 
 async function selectProject(
-  page: import("@playwright/test").Page,
+  page: import('@playwright/test').Page,
   name: string,
 ): Promise<void> {
   const row = page
-    .locator(".alm-projects-table__row")
+    .locator('.alm-projects-table__row')
     .filter({ hasText: name })
     .first();
   await expect(row).toBeVisible({ timeout: 8_000 });
   await row.click();
-  await expect(page.getByTestId("lifecycle-actions")).toBeVisible({ timeout: 5_000 });
+  await expect(page.getByTestId('lifecycle-actions')).toBeVisible({
+    timeout: 5_000,
+  });
 }
 
-test.describe("source view verify (spec 049 US4)", () => {
-  test("clean view: verify reports safe-to-process with zero broken items", async ({
+test.describe('source view verify (spec 049 US4)', () => {
+  test('clean view: verify reports safe-to-process with zero broken items', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "M31 LRGB");
+    await page.goto('/#/projects');
+    await selectProject(page, 'M31 LRGB');
 
-    await expect(page.getByTestId("source-view-row-mock-sv-view-clean")).toBeVisible({
+    await expect(
+      page.getByTestId('source-view-row-mock-sv-view-clean'),
+    ).toBeVisible({
       timeout: 8_000,
     });
 
-    await page.getByTestId("verify-view-mock-sv-view-clean").click();
+    await page.getByTestId('verify-view-mock-sv-view-clean').click();
 
-    const result = page.getByTestId("verify-view-result-mock-sv-view-clean");
+    const result = page.getByTestId('verify-view-result-mock-sv-view-clean');
     await expect(result).toBeVisible({ timeout: 5_000 });
-    await expect(result).toContainText("Clean");
-    await expect(result).toContainText("Safe to process");
+    await expect(result).toContainText('Clean');
+    await expect(result).toContainText('Safe to process');
   });
 
-  test("broken view: verify reports the broken item, no mutation affordance", async ({
+  test('broken view: verify reports the broken item, no mutation affordance', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/projects");
-    await selectProject(page, "M31 LRGB");
+    await page.goto('/#/projects');
+    await selectProject(page, 'M31 LRGB');
 
-    await expect(page.getByTestId("source-view-row-mock-sv-view-broken")).toBeVisible({
+    await expect(
+      page.getByTestId('source-view-row-mock-sv-view-broken'),
+    ).toBeVisible({
       timeout: 8_000,
     });
 
-    await page.getByTestId("verify-view-mock-sv-view-broken").click();
+    await page.getByTestId('verify-view-mock-sv-view-broken').click();
 
-    const result = page.getByTestId("verify-view-result-mock-sv-view-broken");
+    const result = page.getByTestId('verify-view-result-mock-sv-view-broken');
     await expect(result).toBeVisible({ timeout: 5_000 });
-    await expect(result).toContainText("1 broken item");
-    await expect(result).toContainText("light_002.fits");
-    await expect(result).toContainText("source moved or removed");
+    await expect(result).toContainText('1 broken item');
+    await expect(result).toContainText('light_002.fits');
+    await expect(result).toContainText('source moved or removed');
 
     // No auto-repair affordance inside the verify report itself — repair is
     // only reachable via the row's own Regenerate button (FR-015).
-    await expect(result.getByRole("button")).toHaveCount(0);
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(result.getByRole('button')).toHaveCount(0);
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
   });
 });

--- a/tests/e2e/support/harness.ts
+++ b/tests/e2e/support/harness.ts
@@ -31,7 +31,7 @@
  * `VITE_USE_MOCKS`, independent of both.
  */
 
-import { test as base, expect, type Page } from "@playwright/test";
+import { test as base, expect, type Page } from '@playwright/test';
 
 /**
  * Install the minimal `window.__TAURI_INTERNALS__.transformCallback` the
@@ -42,11 +42,13 @@ export async function installTauriChannelPolyfill(page: Page): Promise<void> {
   await page.addInitScript(() => {
     // Preserve any pre-existing internals object; only supply the one method.
     const w = window as unknown as {
-      __TAURI_INTERNALS__?: { transformCallback?: (cb: unknown, once?: boolean) => number };
+      __TAURI_INTERNALS__?: {
+        transformCallback?: (cb: unknown, once?: boolean) => number;
+      };
     };
     let nextCallbackId = 1;
     const existing = w.__TAURI_INTERNALS__ ?? {};
-    if (typeof existing.transformCallback !== "function") {
+    if (typeof existing.transformCallback !== 'function') {
       existing.transformCallback = () => nextCallbackId++;
     }
     w.__TAURI_INTERNALS__ = existing;
@@ -57,7 +59,7 @@ export async function installTauriChannelPolyfill(page: Page): Promise<void> {
 export function seedSetupComplete(page: Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-preferences",
+      'alm-preferences',
       JSON.stringify({ setupCompleted: true }),
     );
   });
@@ -71,7 +73,7 @@ export function seedSetupComplete(page: Page): void {
  */
 export async function disableGuidedTourOverlay(page: Page): Promise<void> {
   await page.addStyleTag({
-    content: "#react-joyride-portal { display: none !important; }",
+    content: '#react-joyride-portal { display: none !important; }',
   });
 }
 

--- a/tests/e2e/target_detail_unclip.spec.ts
+++ b/tests/e2e/target_detail_unclip.spec.ts
@@ -26,69 +26,69 @@
  *
  * Verification layer: PE — Playwright mocks-UI (run in WSL).
  */
-import type { Locator } from "@playwright/test";
+import type { Locator } from '@playwright/test';
 import {
-	disableGuidedTourOverlay,
-	expect,
-	seedSetupComplete,
-	test,
-} from "./support/harness";
+  disableGuidedTourOverlay,
+  expect,
+  seedSetupComplete,
+  test,
+} from './support/harness';
 
 /** `locator.boundingBox()` types as nullable; every call site here expects the
  * element to be laid out (it's already asserted present), so fail loudly
  * instead of asserting away the null. */
 async function requireBox(locator: Locator) {
-	const box = await locator.boundingBox();
-	if (box === null) {
-		throw new Error("expected a bounding box, element is not laid out");
-	}
-	return box;
+  const box = await locator.boundingBox();
+  if (box === null) {
+    throw new Error('expected a bounding box, element is not laid out');
+  }
+  return box;
 }
 
-test.describe("Regression · Target detail pane content unclipped (#816)", () => {
-	test("mouse-wheel scrolling the detail pane reveals the back button below the altitude graph", async ({
-		page,
-	}) => {
-		// Short enough that the header + pill row + altitude graph alone fill the
-		// pane — pre-fix this pushed the back button out under overflow:hidden
-		// with no scrollable region to wheel it back into view.
-		await page.setViewportSize({ width: 1100, height: 620 });
-		seedSetupComplete(page);
-		await page.goto("/#/targets");
-		await disableGuidedTourOverlay(page);
+test.describe('Regression · Target detail pane content unclipped (#816)', () => {
+  test('mouse-wheel scrolling the detail pane reveals the back button below the altitude graph', async ({
+    page,
+  }) => {
+    // Short enough that the header + pill row + altitude graph alone fill the
+    // pane — pre-fix this pushed the back button out under overflow:hidden
+    // with no scrollable region to wheel it back into view.
+    await page.setViewportSize({ width: 1100, height: 620 });
+    seedSetupComplete(page);
+    await page.goto('/#/targets');
+    await disableGuidedTourOverlay(page);
 
-		const m31 = page.locator(".alm-targets-table__row", { hasText: "M 31" });
-		await expect(m31).toBeVisible({ timeout: 8_000 });
-		await m31.click();
+    const m31 = page.locator('.alm-targets-table__row', { hasText: 'M 31' });
+    await expect(m31).toBeVisible({ timeout: 8_000 });
+    await m31.click();
 
-		const pane = page.locator(".alm-detail--fill");
-		const scrollRegion = page.locator(".alm-planner__scroll");
-		await expect(scrollRegion).toBeVisible();
+    const pane = page.locator('.alm-detail--fill');
+    const scrollRegion = page.locator('.alm-planner__scroll');
+    await expect(scrollRegion).toBeVisible();
 
-		const backBtn = page.getByRole("button", { name: "← All targets" });
-		const beforeBox = await requireBox(backBtn);
-		const paneBox = await requireBox(pane);
-		// Before scrolling, the back button (last element in the region) sits
-		// below the pane's own clipped bottom edge — this holds both pre- and
-		// post-fix, since it's the natural (unscrolled) layout position.
-		expect(beforeBox.y).toBeGreaterThan(paneBox.y + paneBox.height);
+    const backBtn = page.getByRole('button', { name: '← All targets' });
+    const beforeBox = await requireBox(backBtn);
+    const paneBox = await requireBox(pane);
+    // Before scrolling, the back button (last element in the region) sits
+    // below the pane's own clipped bottom edge — this holds both pre- and
+    // post-fix, since it's the natural (unscrolled) layout position.
+    expect(beforeBox.y).toBeGreaterThan(paneBox.y + paneBox.height);
 
-		// Real wheel scroll over the scroll region, as an actual user would do.
-		const scrollBox = await requireBox(scrollRegion);
-		await page.mouse.move(
-			scrollBox.x + scrollBox.width / 2,
-			scrollBox.y + scrollBox.height / 2,
-		);
-		await page.mouse.wheel(0, 3000);
+    // Real wheel scroll over the scroll region, as an actual user would do.
+    const scrollBox = await requireBox(scrollRegion);
+    await page.mouse.move(
+      scrollBox.x + scrollBox.width / 2,
+      scrollBox.y + scrollBox.height / 2,
+    );
+    await page.mouse.wheel(0, 3000);
 
-		// Post-fix, the wheel scroll moves the button up into the pane's
-		// clipped viewport — it now overlaps the pane's own bounding box.
-		await expect(async () => {
-			const afterBox = await requireBox(backBtn);
-			expect(afterBox.y).toBeLessThan(paneBox.y + paneBox.height);
-			expect(afterBox.y + afterBox.height).toBeGreaterThan(paneBox.y);
-		}).toPass({ timeout: 2_000 });
-		await expect(backBtn).toBeVisible();
-		await expect(backBtn).toBeEnabled();
-	});
+    // Post-fix, the wheel scroll moves the button up into the pane's
+    // clipped viewport — it now overlaps the pane's own bounding box.
+    await expect(async () => {
+      const afterBox = await requireBox(backBtn);
+      expect(afterBox.y).toBeLessThan(paneBox.y + paneBox.height);
+      expect(afterBox.y + afterBox.height).toBeGreaterThan(paneBox.y);
+    }).toPass({ timeout: 2_000 });
+    await expect(backBtn).toBeVisible();
+    await expect(backBtn).toBeEnabled();
+  });
 });

--- a/tests/e2e/targets_planner.spec.ts
+++ b/tests/e2e/targets_planner.spec.ts
@@ -51,8 +51,8 @@ import {
   expect,
   seedSetupComplete,
   disableGuidedTourOverlay,
-} from "./support/harness";
-import type { Page } from "@playwright/test";
+} from './support/harness';
+import type { Page } from '@playwright/test';
 
 /**
  * Seed an active observing site into the mock `observing` settings scope so the
@@ -63,22 +63,22 @@ import type { Page } from "@playwright/test";
 function seedObservingSite(page: Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-e2e-observing",
+      'alm-e2e-observing',
       JSON.stringify({
         observingSites: [
           {
-            id: "site-e2e-1",
-            name: "Backyard (Amsterdam)",
+            id: 'site-e2e-1',
+            name: 'Backyard (Amsterdam)',
             latitudeDeg: 52.37,
             longitudeDeg: 4.9,
             elevationM: 5,
-            timezone: "Europe/Amsterdam",
-            twilight: "astronomical",
+            timezone: 'Europe/Amsterdam',
+            twilight: 'astronomical',
             minHorizonAltDeg: 0,
           },
         ],
-        observingActiveSiteId: "site-e2e-1",
-        observingDefaultSiteId: "site-e2e-1",
+        observingActiveSiteId: 'site-e2e-1',
+        observingDefaultSiteId: 'site-e2e-1',
         usableAltitudeDeg: 30,
       }),
     );
@@ -87,7 +87,7 @@ function seedObservingSite(page: Page): void {
 
 /** Locate a target row by its designation text (only 2 seed rows exist). */
 function targetRow(page: Page, designation: string) {
-  return page.locator(".alm-targets-table__row", { hasText: designation });
+  return page.locator('.alm-targets-table__row', { hasText: designation });
 }
 
 // Column order in TargetsTable (see COLUMNS; sparkline + visible columns
@@ -102,7 +102,7 @@ const COL = {
   sessions: 8,
 } as const;
 
-test.describe("PLANNER REGRESSION GUARD · site gate (spec 047 D7, #450)", () => {
+test.describe('PLANNER REGRESSION GUARD · site gate (spec 047 D7, #450)', () => {
   /**
    * NO observing site → the planner is honestly GATED, not silently dead:
    *   - the "set up your observing site" prompt renders in the top bar;
@@ -111,38 +111,42 @@ test.describe("PLANNER REGRESSION GUARD · site gate (spec 047 D7, #450)", () =>
    *   - every per-target astronomy value degrades to the honest placeholder
    *     ("—" for lunar/opposition, 0° max altitude) — never a fabricated number.
    */
-  test("9.1a · with NO observing site the planner shows the set-up prompt and no astronomy", async ({
+  test('9.1a · with NO observing site the planner shows the set-up prompt and no astronomy', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // The site-gate prompt is shown; the Moon summary is NOT.
-    const prompt = page.getByTestId("planner-site-prompt");
+    const prompt = page.getByTestId('planner-site-prompt');
     await expect(prompt).toBeVisible({ timeout: 8_000 });
-    await expect(prompt).toContainText("Set up your observing site");
+    await expect(prompt).toContainText('Set up your observing site');
     await expect(prompt).toContainText(
-      "Add a default observing location so the planner can compute",
+      'Add a default observing location so the planner can compute',
     );
-    await expect(page.getByTestId("moon-summary")).toHaveCount(0);
+    await expect(page.getByTestId('moon-summary')).toHaveCount(0);
 
     // The table-level "add a site" info banner is shown.
-    await expect(page.locator(".alm-targets-table__no-site-banner")).toBeVisible();
+    await expect(
+      page.locator('.alm-targets-table__no-site-banner'),
+    ).toBeVisible();
 
     // The seed catalog still lists targets (list is independent of the gate)…
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible();
 
     // …but every astronomy value is the honest placeholder, never fabricated:
     //   - lunar / opposition cells render "—" (no `.alm-targets-cell--lunardist`
     //     span is emitted when the value is unknown);
     //   - max altitude degrades to 0°.
-    await expect(page.locator(".alm-targets-cell--lunardist")).toHaveCount(0);
-    await expect(m31.locator("td").nth(COL.opposition)).toHaveText("—");
-    await expect(m31.locator("td").nth(COL.maxAlt)).toHaveText("0°");
+    await expect(page.locator('.alm-targets-cell--lunardist')).toHaveCount(0);
+    await expect(m31.locator('td').nth(COL.opposition)).toHaveText('—');
+    await expect(m31.locator('td').nth(COL.maxAlt)).toHaveText('0°');
   });
 
   /**
@@ -154,81 +158,93 @@ test.describe("PLANNER REGRESSION GUARD · site gate (spec 047 D7, #450)", () =>
    * This is the direct pin against the #450 dead-gate: once a site exists the
    * planner MUST come alive with real computed values.
    */
-  test("9.1b · seeding an active observing site brings the planner alive with real 044+047 values", async ({
+  test('9.1b · seeding an active observing site brings the planner alive with real 044+047 values', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await expect(page.getByTestId("app-error-boundary-fallback")).not.toBeVisible();
+    await expect(
+      page.getByTestId('app-error-boundary-fallback'),
+    ).not.toBeVisible();
 
     // ── 047 Track A: the Moon summary renders with real computed values ───────
-    const moon = page.getByTestId("moon-summary");
+    const moon = page.getByTestId('moon-summary');
     await expect(moon).toBeVisible({ timeout: 8_000 });
-    await expect(moon).toContainText("Moon tonight");
+    await expect(moon).toContainText('Moon tonight');
     // Real astronomy-engine output: an 8-phase name…
-    await expect(moon.locator(".alm-moon-summary__phase")).toHaveText(
+    await expect(moon.locator('.alm-moon-summary__phase')).toHaveText(
       /new moon|crescent|quarter|gibbous|full moon/i,
     );
     // …and an illumination % + waxing/waning direction (FR-002/FR-003).
-    await expect(moon.locator(".alm-moon-summary__meta")).toHaveText(
+    await expect(moon.locator('.alm-moon-summary__meta')).toHaveText(
       /\d{1,3}% illuminated · (waxing|waning)/,
     );
     // The full text equivalent is exposed via aria-label (accessibility).
     await expect(moon).toHaveAttribute(
-      "aria-label",
+      'aria-label',
       /^Moon tonight: .+, \d{1,3} percent illuminated, (waxing|waning)\.$/,
     );
 
     // The gated-off prompt + banner are gone now a site exists.
-    await expect(page.getByTestId("planner-site-prompt")).toHaveCount(0);
-    await expect(page.locator(".alm-targets-table__no-site-banner")).toHaveCount(0);
+    await expect(page.getByTestId('planner-site-prompt')).toHaveCount(0);
+    await expect(
+      page.locator('.alm-targets-table__no-site-banner'),
+    ).toHaveCount(0);
 
     // ── 044: real per-site altitude — M 31 (dec +41) culminates high from a
     //    +52° site, so max altitude tonight is a large non-zero value (was 0°
     //    with no site). Date-stable (culmination ≈ 90 − |lat − dec| ≈ 79°). ────
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible();
-    const maxAlt = m31.locator("td").nth(COL.maxAlt);
+    const maxAlt = m31.locator('td').nth(COL.maxAlt);
     await expect(maxAlt).toHaveText(/°$/);
-    await expect(maxAlt).not.toHaveText("0°");
+    await expect(maxAlt).not.toHaveText('0°');
 
     // ── 047 US2: real target↔Moon angular separation (geometry, always known
     //    for a coordinate-bearing target) renders as a degree value, not "—". ──
-    const lunar = m31.locator("td").nth(COL.lunarDist);
+    const lunar = m31.locator('td').nth(COL.lunarDist);
     await expect(lunar).toHaveText(/\d{1,3}°/);
-    await expect(lunar.locator(".alm-targets-cell--lunardist")).toBeVisible();
+    await expect(lunar.locator('.alm-targets-cell--lunardist')).toBeVisible();
 
     // ── 047 US4: real next-opposition date + relative "in N days/months". ─────
-    const opposition = m31.locator("td").nth(COL.opposition);
+    const opposition = m31.locator('td').nth(COL.opposition);
     await expect(opposition).toContainText(/in \d+ (day|days|month|months)/);
-    await expect(opposition).not.toHaveText("—");
+    await expect(opposition).not.toHaveText('—');
 
     // ── 047 US3: moon-driven filter guidance pills render in the Filters cell. ─
-    await expect(m31.locator(".alm-guidance-cell__trigger")).toBeVisible();
+    await expect(m31.locator('.alm-guidance-cell__trigger')).toBeVisible();
 
     // ── 044: imaging-time column present; renders an honest value ("2h10m"-
     //    style when the target clears the threshold tonight, else "—" with a
     //    reason glyph, FR-030/FR-032) — never fabricated or a bare 0. ─────────
-    await expect(page.getByRole("columnheader", { name: "Img time" })).toBeVisible();
-    await expect(m31.locator("td").nth(COL.imagingTime)).toHaveText(
+    await expect(
+      page.getByRole('columnheader', { name: 'Img time' }),
+    ).toBeVisible();
+    await expect(m31.locator('td').nth(COL.imagingTime)).toHaveText(
       /^(\d+h(\d+m)?( ☾)?|— [☀▲☾]|—)$/,
     );
 
     // ── Iteration 2026-07-15 (FR-007): the sparkline + visible columns are
     //    hard-removed; visibility is folded into the imaging-time glyph. ──────
-    await expect(page.getByRole("columnheader", { name: "Tonight" })).toHaveCount(0);
-    await expect(page.getByRole("columnheader", { name: "Visible" })).toHaveCount(0);
+    await expect(
+      page.getByRole('columnheader', { name: 'Tonight' }),
+    ).toHaveCount(0);
+    await expect(
+      page.getByRole('columnheader', { name: 'Visible' }),
+    ).toHaveCount(0);
 
     // ── Iteration 2026-07-15 (FR-033): the always-visible computation-context
     //    label disclosing site · latitude · twilight · threshold + "change". ──
-    const computedFor = page.getByTestId("planner-computed-for");
-    await expect(computedFor).toContainText("Computed for:");
-    await expect(computedFor).toContainText("52.4°N");
-    await expect(computedFor).toContainText("≥30°");
-    await expect(computedFor.getByRole("link", { name: "change" })).toBeVisible();
+    const computedFor = page.getByTestId('planner-computed-for');
+    await expect(computedFor).toContainText('Computed for:');
+    await expect(computedFor).toContainText('52.4°N');
+    await expect(computedFor).toContainText('≥30°');
+    await expect(
+      computedFor.getByRole('link', { name: 'change' }),
+    ).toBeVisible();
   });
 
   /**
@@ -238,30 +254,32 @@ test.describe("PLANNER REGRESSION GUARD · site gate (spec 047 D7, #450)", () =>
    * planner on — proving the round-trip the real Settings → Observing Sites save
    * performs, and that the gate is not wedged shut (the essence of #450).
    */
-  test("9.1c · a persisted observing site opens the planner after reload (dynamic gate)", async ({
+  test('9.1c · a persisted observing site opens the planner after reload (dynamic gate)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
     // Gate closed initially.
-    await expect(page.getByTestId("planner-site-prompt")).toBeVisible({ timeout: 8_000 });
+    await expect(page.getByTestId('planner-site-prompt')).toBeVisible({
+      timeout: 8_000,
+    });
 
     // Persist a site through the same IPC the Settings pane uses; the mock's
     // observing scope round-trips it (settings_update → settings_get).
     await page.evaluate(() => {
       const site = {
-        id: "site-persist-1",
-        name: "Persisted site",
+        id: 'site-persist-1',
+        name: 'Persisted site',
         latitudeDeg: 48.1,
         longitudeDeg: 11.6,
         elevationM: 520,
-        timezone: "Europe/Berlin",
-        twilight: "astronomical",
+        timezone: 'Europe/Berlin',
+        twilight: 'astronomical',
         minHorizonAltDeg: 0,
       };
       window.localStorage.setItem(
-        "alm-e2e-observing",
+        'alm-e2e-observing',
         JSON.stringify({
           observingSites: [site],
           observingActiveSiteId: site.id,
@@ -274,12 +292,14 @@ test.describe("PLANNER REGRESSION GUARD · site gate (spec 047 D7, #450)", () =>
     await disableGuidedTourOverlay(page);
 
     // Planner alive after reload.
-    await expect(page.getByTestId("moon-summary")).toBeVisible({ timeout: 8_000 });
-    await expect(page.getByTestId("planner-site-prompt")).toHaveCount(0);
+    await expect(page.getByTestId('moon-summary')).toBeVisible({
+      timeout: 8_000,
+    });
+    await expect(page.getByTestId('planner-site-prompt')).toHaveCount(0);
   });
 });
 
-test.describe("Planner date picker + per-band moon-free hours (spec 044 Track B US2/US5)", () => {
+test.describe('Planner date picker + per-band moon-free hours (spec 044 Track B US2/US5)', () => {
   /**
    * T024 (FR-008/SC-004): choosing a different planning date recomputes the
    * table's observability for that night. M 31's transit altitude is
@@ -291,69 +311,71 @@ test.describe("Planner date picker + per-band moon-free hours (spec 044 Track B 
    * vanishingly unlikely). Resetting via "Tonight" must restore the original
    * value exactly, proving the round-trip (not just "some value changed").
    */
-  test("9.4a · choosing a future date changes Img time, and Tonight restores it", async ({
+  test('9.4a · choosing a future date changes Img time, and Tonight restores it', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
-    const imgTimeCell = m31.locator("td").nth(COL.imagingTime);
+    const imgTimeCell = m31.locator('td').nth(COL.imagingTime);
     const beforeText = await imgTimeCell.textContent();
 
-    const dateInput = page.getByLabel("Plan for");
+    const dateInput = page.getByLabel('Plan for');
     await expect(dateInput).toBeVisible();
     const today = new Date();
     const future = new Date(today.getTime() + 182 * 86_400_000);
     const futureValue = future.toISOString().slice(0, 10);
     await dateInput.fill(futureValue);
 
-    const resetBtn = page.getByRole("button", { name: "Tonight" });
+    const resetBtn = page.getByRole('button', { name: 'Tonight' });
     await expect(resetBtn).toBeVisible();
-    await expect(imgTimeCell).not.toHaveText(beforeText ?? "");
+    await expect(imgTimeCell).not.toHaveText(beforeText ?? '');
 
     await resetBtn.click();
     await expect(resetBtn).toHaveCount(0);
-    await expect(imgTimeCell).toHaveText(beforeText ?? "");
+    await expect(imgTimeCell).toHaveText(beforeText ?? '');
   });
 
   /**
    * T029 (FR-007/FR-022): the Filters guidance popover shows each band's real
    * moon-free imaging hours alongside Track A's required-separation figure.
    */
-  test("9.4b · the Filters guidance popover shows per-band moon-free hours", async ({
+  test('9.4b · the Filters guidance popover shows per-band moon-free hours', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
-    await m31.locator(".alm-guidance-cell__trigger").click();
+    await m31.locator('.alm-guidance-cell__trigger').click();
 
-    const popup = page.getByTestId("guidance-explain-popup");
+    const popup = page.getByTestId('guidance-explain-popup');
     await expect(popup).toBeVisible();
     await expect(popup).toContainText(/h moon-free/);
   });
 });
 
-test.describe("Target catalog + SIMBAD resolve-on-demand (spec 035 / 023)", () => {
+test.describe('Target catalog + SIMBAD resolve-on-demand (spec 035 / 023)', () => {
   /**
    * The Targets page lists the seed catalog (spec 035 US1 local seed). Both
    * northern seed objects appear in the list from the `target_list` mock.
    */
-  test("9.2a · the target catalog list renders seed objects", async ({ page }) => {
+  test('9.2a · the target catalog list renders seed objects', async ({
+    page,
+  }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await expect(targetRow(page, "M 31")).toBeVisible({ timeout: 8_000 });
-    await expect(targetRow(page, "NGC 7000")).toBeVisible();
+    await expect(targetRow(page, 'M 31')).toBeVisible({ timeout: 8_000 });
+    await expect(targetRow(page, 'NGC 7000')).toBeVisible();
   });
 
   /**
@@ -361,23 +383,25 @@ test.describe("Target catalog + SIMBAD resolve-on-demand (spec 035 / 023)", () =
    * seed hit shows that hit with its identity/aliases (spec 023) — the primary
    * designation, the common-name secondary line, and the `seed` source badge.
    */
-  test("9.2b · a seed hit surfaces identity + aliases in the search typeahead", async ({
+  test('9.2b · a seed hit surfaces identity + aliases in the search typeahead', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await page.getByRole("button", { name: "Add target" }).click();
-    const search = page.getByLabel("Search for a target");
+    await page.getByRole('button', { name: 'Add target' }).click();
+    const search = page.getByLabel('Search for a target');
     await expect(search).toBeVisible();
-    await search.fill("M 31");
+    await search.fill('M 31');
 
-    const option = page.locator(".alm-target-search__option", { hasText: "M 31" });
+    const option = page.locator('.alm-target-search__option', {
+      hasText: 'M 31',
+    });
     await expect(option).toBeVisible({ timeout: 8_000 });
     // Identity + alias (spec 023): common name secondary + object-type + source.
-    await expect(option).toContainText("Andromeda Galaxy");
-    await expect(option).toContainText("seed");
+    await expect(option).toContainText('Andromeda Galaxy');
+    await expect(option).toContainText('seed');
   });
 
   /**
@@ -386,26 +410,28 @@ test.describe("Target catalog + SIMBAD resolve-on-demand (spec 035 / 023)", () =
    * source badge — the resolve-on-demand path that only a live resolver call
    * produces. The mock's `target_resolve` mirrors the real "resolved" envelope.
    */
-  test("9.2c · a long-tail query resolves on demand via SIMBAD (resolved source)", async ({
+  test('9.2c · a long-tail query resolves on demand via SIMBAD (resolved source)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await page.getByRole("button", { name: "Add target" }).click();
-    const search = page.getByLabel("Search for a target");
+    await page.getByRole('button', { name: 'Add target' }).click();
+    const search = page.getByLabel('Search for a target');
     await expect(search).toBeVisible();
     // "IC 1805" is not in the seed; only the long-tail resolver can supply it.
-    await search.fill("IC 1805");
+    await search.fill('IC 1805');
 
-    const option = page.locator(".alm-target-search__option", { hasText: "IC 1805" });
+    const option = page.locator('.alm-target-search__option', {
+      hasText: 'IC 1805',
+    });
     await expect(option).toBeVisible({ timeout: 8_000 });
-    await expect(option).toContainText("resolved");
+    await expect(option).toContainText('resolved');
   });
 });
 
-test.describe("Honest empty-state disclosure (no fabricated data)", () => {
+test.describe('Honest empty-state disclosure (no fabricated data)', () => {
   /**
    * Not-yet-built data must be disclosed honestly, never fabricated:
    *   - the Sessions column (backend linkage #57 not landed) is ALWAYS "—",
@@ -413,27 +439,29 @@ test.describe("Honest empty-state disclosure (no fabricated data)", () => {
    *   - the favourite star column shows every row un-starred (#54 client-side
    *     favourites, no fabricated favourites) with aria-pressed=false.
    */
-  test("9.3a · sessions count and favourites are honestly empty, not fabricated", async ({
+  test('9.3a · sessions count and favourites are honestly empty, not fabricated', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
 
     // Sessions column: always the honest "—" (linked-session count not on the
     // list payload yet — #57), never a fabricated number.
-    await expect(m31.locator("td").nth(COL.sessions)).toHaveText("—");
-    await expect(targetRow(page, "NGC 7000").locator("td").nth(COL.sessions)).toHaveText("—");
+    await expect(m31.locator('td').nth(COL.sessions)).toHaveText('—');
+    await expect(
+      targetRow(page, 'NGC 7000').locator('td').nth(COL.sessions),
+    ).toHaveText('—');
 
     // Favourites (#54): every star is un-filled and reports aria-pressed=false —
     // no fabricated "starred" state.
-    const star = m31.locator(".alm-targets-star");
-    await expect(star).toHaveAttribute("aria-pressed", "false");
-    await expect(star).toContainText("☆");
+    const star = m31.locator('.alm-targets-star');
+    await expect(star).toHaveAttribute('aria-pressed', 'false');
+    await expect(star).toContainText('☆');
   });
 
   /**
@@ -441,28 +469,28 @@ test.describe("Honest empty-state disclosure (no fabricated data)", () => {
    * backend linkage not landed). With no favourites it must show the honest
    * empty state, NOT fabricate a "my targets" list.
    */
-  test("9.3b · My Targets with no favourites shows the honest empty state", async ({
+  test('9.3b · My Targets with no favourites shows the honest empty state', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
     // Baseline: the catalog is populated.
-    await expect(targetRow(page, "M 31")).toBeVisible({ timeout: 8_000 });
+    await expect(targetRow(page, 'M 31')).toBeVisible({ timeout: 8_000 });
 
     // Switch the "Show" filter to "My Targets" (native <select>, aria-label "Show").
-    await page.getByLabel("Show").selectOption("my");
+    await page.getByLabel('Show').selectOption('my');
 
     // Honest empty state — not a fabricated list.
     await expect(
-      page.getByText("No favourites yet. Star a target (☆) to add it here."),
+      page.getByText('No favourites yet. Star a target (☆) to add it here.'),
     ).toBeVisible();
-    await expect(targetRow(page, "M 31")).toHaveCount(0);
+    await expect(targetRow(page, 'M 31')).toHaveCount(0);
   });
 });
 
-test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)", () => {
+test.describe('Planner observability iteration (spec 044 Phase 10, 2026-07-15)', () => {
   /**
    * #817 (FR-029/FR-030/FR-034, SC-015): a night with NO qualifying dark
    * window must state WHY imaging time is zero everywhere the number appears,
@@ -471,15 +499,15 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
    * solstice (minimum depression ≈ 14°), so planning for June 21 reproduces
    * the #817 condition date-stably every year.
    */
-  test("9.5a · #817: a no-dark-window night states its reason — table glyph, detail sentence, non-dark graph", async ({
+  test('9.5a · #817: a no-dark-window night states its reason — table glyph, detail sentence, non-dark graph', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
 
     // Plan for the NEXT June solstice (always in the future so the date
@@ -487,13 +515,13 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
     const now = new Date();
     const year =
       now.getMonth() >= 5 ? now.getFullYear() + 1 : now.getFullYear();
-    await page.getByLabel("Plan for").fill(`${year}-06-21`);
+    await page.getByLabel('Plan for').fill(`${year}-06-21`);
 
     // Table: zero imaging time carries the darkness reason glyph (FR-030) —
     // never a bare 0 or an unexplained "—" (SC-015).
-    const imgTime = m31.locator("td").nth(COL.imagingTime);
-    await expect(imgTime).toContainText("☀");
-    await expect(imgTime.locator(".alm-imgtime-glyph--warn")).toBeVisible();
+    const imgTime = m31.locator('td').nth(COL.imagingTime);
+    await expect(imgTime).toContainText('☀');
+    await expect(imgTime.locator('.alm-imgtime-glyph--warn')).toBeVisible();
 
     // Detail: the same zero is stated as a sentence (FR-029)…
     await m31.click();
@@ -504,7 +532,7 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
     // plot is shaded non-dark (exactly one full-width twilight rect —
     // pre-iteration the shading was omitted entirely and a green usable fill
     // contradicted the 0-hour stat, which was the #817 report).
-    await expect(page.locator(".alm-planner__graph-twilight")).toHaveCount(1);
+    await expect(page.locator('.alm-planner__graph-twilight')).toHaveCount(1);
   });
 
   /**
@@ -513,25 +541,25 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
    * opposition, "2h10m"+glyph imaging time) render unclipped in a 1100×720
    * window (the stub-width Opposition column used to clip).
    */
-  test("9.5b · #792: opposition and imaging-time cells render unclipped at 1100×720", async ({
+  test('9.5b · #792: opposition and imaging-time cells render unclipped at 1100×720', async ({
     page,
   }) => {
     await page.setViewportSize({ width: 1100, height: 720 });
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
 
-    const opposition = m31.locator("td").nth(COL.opposition);
+    const opposition = m31.locator('td').nth(COL.opposition);
     await expect(opposition).toContainText(/in \d+ (day|days|month|months)/);
     expect(
       await opposition.evaluate((el) => el.scrollWidth <= el.clientWidth),
     ).toBe(true);
 
-    const imgTime = m31.locator("td").nth(COL.imagingTime);
+    const imgTime = m31.locator('td').nth(COL.imagingTime);
     expect(
       await imgTime.evaluate((el) => el.scrollWidth <= el.clientWidth),
     ).toBe(true);
@@ -548,22 +576,22 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
    * tooltip names the list's opposition date; coincides / none-found →
    * detail date = list date.
    */
-  test("9.5c · FR-009 2026-07-17: detail Best date is Moon-aware and explains itself; list Opposition stays pure", async ({
+  test('9.5c · FR-009 2026-07-17: detail Best date is Moon-aware and explains itself; list Opposition stays pure', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
 
     // List surface unchanged: the pure "MMM D · in N ..." opposition cell.
-    const opposition = m31.locator("td").nth(COL.opposition);
+    const opposition = m31.locator('td').nth(COL.opposition);
     await expect(opposition).toContainText(/in \d+ (day|days|month|months)/);
     const listOppositionDate = (await opposition.innerText())
-      .split("·")[0]
+      .split('·')[0]
       .trim();
 
     await m31.click();
@@ -573,7 +601,7 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
     );
     await expect(bestDateTrigger).toBeVisible();
     // aria-label = "<detail date> · in N ... — <explanation>" (InfoTip mirror).
-    const label = (await bestDateTrigger.getAttribute("aria-label"))!;
+    const label = (await bestDateTrigger.getAttribute('aria-label'))!;
 
     if (/falls near full Moon/.test(label)) {
       // Diverged: list ≠ detail, and the skipped opposition the tooltip
@@ -587,7 +615,7 @@ test.describe("Planner observability iteration (spec 044 Phase 10, 2026-07-15)",
   });
 });
 
-test.describe("Design-review follow-ups (2026-07-11): #614 dead CTA, #618 header stack", () => {
+test.describe('Design-review follow-ups (2026-07-11): #614 dead CTA, #618 header stack', () => {
   /**
    * #614: the permanently-disabled "Add to plan" placeholder CTA (no backing
    * feature) is removed from the detail header entirely — never shipped as a
@@ -598,19 +626,19 @@ test.describe("Design-review follow-ups (2026-07-11): #614 dead CTA, #618 header
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
     await m31.click();
 
-    await expect(
-      page.getByRole("button", { name: "Add to plan" }),
-    ).toHaveCount(0);
+    await expect(page.getByRole('button', { name: 'Add to plan' })).toHaveCount(
+      0,
+    );
     // The real primary action (New project) is still present.
     await expect(
-      page.getByRole("button", { name: "New project" }),
+      page.getByRole('button', { name: 'New project' }),
     ).toBeVisible();
   });
 
@@ -620,26 +648,26 @@ test.describe("Design-review follow-ups (2026-07-11): #614 dead CTA, #618 header
    * bar itself no longer stacks a 3rd band, and "Add target" is the one
    * primary CTA at the bar's right edge.
    */
-  test("#618 · the pinned top bar holds only the filter row + primary Add target action", async ({
+  test('#618 · the pinned top bar holds only the filter row + primary Add target action', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    await expect(targetRow(page, "M 31")).toBeVisible({ timeout: 8_000 });
+    await expect(targetRow(page, 'M 31')).toBeVisible({ timeout: 8_000 });
 
     // The Moon summary / site-prompt no longer lives inside the pinned top
     // bar — it renders in the table's own header zone instead.
-    const topBar = page.locator(".alm-topbar");
-    await expect(topBar.getByTestId("moon-summary")).toHaveCount(0);
+    const topBar = page.locator('.alm-topbar');
+    await expect(topBar.getByTestId('moon-summary')).toHaveCount(0);
     await expect(
-      page.locator(".alm-targets-table__wrap").getByTestId("moon-summary"),
+      page.locator('.alm-targets-table__wrap').getByTestId('moon-summary'),
     ).toBeVisible();
 
     // "Add target" is the pinned bar's one primary CTA.
-    const addTarget = topBar.getByRole("button", { name: "Add target" });
+    const addTarget = topBar.getByRole('button', { name: 'Add target' });
     await expect(addTarget).toBeVisible();
     await expect(addTarget).toHaveClass(/alm-btn--primary/);
   });

--- a/tests/e2e/typography_bundled_fonts.spec.ts
+++ b/tests/e2e/typography_bundled_fonts.spec.ts
@@ -14,46 +14,51 @@
  * See apps/desktop/src/styles/tokens.css (@font-face blocks) and
  * apps/desktop/src/assets/fonts/FONTS.md (asset provenance).
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
+import { test, expect, seedSetupComplete } from './support/harness';
 
-test.describe("Spec 055 · bundled hinted fonts (Phase 1)", () => {
-  test("no network requests reach fonts.googleapis.com or fonts.gstatic.com during app load", async ({
+test.describe('Spec 055 · bundled hinted fonts (Phase 1)', () => {
+  test('no network requests reach fonts.googleapis.com or fonts.gstatic.com during app load', async ({
     page,
   }) => {
     const fontCdnRequests: string[] = [];
-    page.on("request", (request) => {
+    page.on('request', (request) => {
       const url = request.url();
-      if (url.includes("fonts.googleapis.com") || url.includes("fonts.gstatic.com")) {
+      if (
+        url.includes('fonts.googleapis.com') ||
+        url.includes('fonts.gstatic.com')
+      ) {
         fontCdnRequests.push(url);
       }
     });
 
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
     expect(fontCdnRequests).toEqual([]);
   });
 
-  test("document.fonts contains the six bundled Inter faces after load", async ({ page }) => {
+  test('document.fonts contains the six bundled Inter faces after load', async ({
+    page,
+  }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
     const faces = await page.evaluate(async () => {
       await document.fonts.ready;
       return Array.from(document.fonts)
-        .filter((face) => face.family === "Inter")
+        .filter((face) => face.family === 'Inter')
         .map((face) => ({ weight: face.weight, style: face.style }));
     });
 
     const expected = [
-      { weight: "400", style: "normal" },
-      { weight: "400", style: "italic" },
-      { weight: "500", style: "normal" },
-      { weight: "500", style: "italic" },
-      { weight: "600", style: "normal" },
-      { weight: "600", style: "italic" },
+      { weight: '400', style: 'normal' },
+      { weight: '400', style: 'italic' },
+      { weight: '500', style: 'normal' },
+      { weight: '500', style: 'italic' },
+      { weight: '600', style: 'normal' },
+      { weight: '600', style: 'italic' },
     ];
 
     for (const face of expected) {
@@ -64,14 +69,14 @@ test.describe("Spec 055 · bundled hinted fonts (Phase 1)", () => {
     }
   });
 
-  test("computed body font-family resolves to Inter", async ({ page }) => {
+  test('computed body font-family resolves to Inter', async ({ page }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
     const fontFamily = await page.evaluate(
       () => getComputedStyle(document.body).fontFamily,
     );
-    expect(fontFamily).toContain("Inter");
+    expect(fontFamily).toContain('Inter');
   });
 });

--- a/tests/e2e/typography_dial.spec.ts
+++ b/tests/e2e/typography_dial.spec.ts
@@ -23,38 +23,38 @@
  * hardcoded px before spec 055 T012 (e.g. the sidebar group label, formerly
  * a bare `9.5px`) — proof the dial reaches previously-inert surfaces.
  */
-import { test, expect, seedSetupComplete } from "./support/harness";
-import type { Page } from "@playwright/test";
+import { test, expect, seedSetupComplete } from './support/harness';
+import type { Page } from '@playwright/test';
 
 const STOPS = [
-  { choice: "small", rootPx: 12, floorPx: 9 },
-  { choice: "default", rootPx: 14, floorPx: 11 },
-  { choice: "large", rootPx: 16, floorPx: 13 },
+  { choice: 'small', rootPx: 12, floorPx: 9 },
+  { choice: 'default', rootPx: 14, floorPx: 11 },
+  { choice: 'large', rootPx: 16, floorPx: 13 },
 ] as const;
 
 async function selectFontSize(page: Page, choice: string): Promise<void> {
-  const select = page.locator("select", {
+  const select = page.locator('select', {
     has: page.locator(`option[value="${choice}"]`),
   });
   await select.selectOption(choice);
 }
 
-test.describe("Spec 055 Phase 2 · font-size dial (T014, SC-003/SC-004)", () => {
+test.describe('Spec 055 Phase 2 · font-size dial (T014, SC-003/SC-004)', () => {
   for (const stop of STOPS) {
     test(`${stop.choice} stop: integer root font-size, no fractional computed sizes, floor ${stop.floorPx}px`, async ({
       page,
     }) => {
       seedSetupComplete(page);
-      await page.goto("/#/settings/general");
+      await page.goto('/#/settings/general');
       await selectFontSize(page, stop.choice);
 
       // Navigate to a data-dense page so the sweep covers real rendered text,
       // not just the settings pane itself.
-      await page.goto("/#/sessions");
-      await page.waitForLoadState("networkidle");
+      await page.goto('/#/sessions');
+      await page.waitForLoadState('networkidle');
 
-      const rootFontSize = await page.evaluate(() =>
-        getComputedStyle(document.documentElement).fontSize,
+      const rootFontSize = await page.evaluate(
+        () => getComputedStyle(document.documentElement).fontSize,
       );
       expect(rootFontSize).toBe(`${stop.rootPx}px`);
       expect(Number.parseFloat(rootFontSize)).toBe(stop.rootPx); // exactly integer, not e.g. "12.0001px"
@@ -95,31 +95,31 @@ test.describe("Spec 055 Phase 2 · font-size dial (T014, SC-003/SC-004)", () => 
     });
   }
 
-  test("SC-004: the font-size setting scales a previously-hardcoded surface (sidebar group label)", async ({
+  test('SC-004: the font-size setting scales a previously-hardcoded surface (sidebar group label)', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
-    const groupLabel = page.locator(".alm-sidebar__group-label").first();
+    const groupLabel = page.locator('.alm-sidebar__group-label').first();
     await expect(groupLabel).toBeVisible();
 
     const defaultPx = await groupLabel.evaluate(
       (el) => getComputedStyle(el).fontSize,
     );
-    expect(defaultPx).toBe("11px"); // --alm-text-xs @ default (14px root)
+    expect(defaultPx).toBe('11px'); // --alm-text-xs @ default (14px root)
 
-    await page.goto("/#/settings/general");
-    await selectFontSize(page, "large");
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/settings/general');
+    await selectFontSize(page, 'large');
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
     const largePx = await page
-      .locator(".alm-sidebar__group-label")
+      .locator('.alm-sidebar__group-label')
       .first()
       .evaluate((el) => getComputedStyle(el).fontSize);
-    expect(largePx).toBe("13px"); // --alm-text-xs @ large (16px root)
+    expect(largePx).toBe('13px'); // --alm-text-xs @ large (16px root)
     expect(largePx).not.toBe(defaultPx);
   });
 });

--- a/tests/e2e/typography_semantic_mono.spec.ts
+++ b/tests/e2e/typography_semantic_mono.spec.ts
@@ -25,30 +25,30 @@ import {
   expect,
   seedSetupComplete,
   disableGuidedTourOverlay,
-} from "./support/harness";
-import type { Page } from "@playwright/test";
+} from './support/harness';
+import type { Page } from '@playwright/test';
 
 /** Seed an active observing site (mirrors targets_planner.spec.ts) so the M 31
  * seed target's detail view renders its resolved RA/Dec property row. */
 function seedObservingSite(page: Page): void {
   page.addInitScript(() => {
     window.localStorage.setItem(
-      "alm-e2e-observing",
+      'alm-e2e-observing',
       JSON.stringify({
         observingSites: [
           {
-            id: "site-e2e-1",
-            name: "Backyard (Amsterdam)",
+            id: 'site-e2e-1',
+            name: 'Backyard (Amsterdam)',
             latitudeDeg: 52.37,
             longitudeDeg: 4.9,
             elevationM: 5,
-            timezone: "Europe/Amsterdam",
-            twilight: "astronomical",
+            timezone: 'Europe/Amsterdam',
+            twilight: 'astronomical',
             minHorizonAltDeg: 0,
           },
         ],
-        observingActiveSiteId: "site-e2e-1",
-        observingDefaultSiteId: "site-e2e-1",
+        observingActiveSiteId: 'site-e2e-1',
+        observingDefaultSiteId: 'site-e2e-1',
         usableAltitudeDeg: 30,
       }),
     );
@@ -57,22 +57,22 @@ function seedObservingSite(page: Page): void {
 
 /** Locate a target row by its designation text (mirrors targets_planner.spec.ts). */
 function targetRow(page: Page, designation: string) {
-  return page.locator(".alm-targets-table__row", { hasText: designation });
+  return page.locator('.alm-targets-table__row', { hasText: designation });
 }
 
-test.describe("Spec 055 · semantic base layer + mono restoration (Phase 3)", () => {
-  test("no rendered element computes synthetic-bold font-weight 700", async ({
+test.describe('Spec 055 · semantic base layer + mono restoration (Phase 3)', () => {
+  test('no rendered element computes synthetic-bold font-weight 700', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
     const violations = await page.evaluate(() => {
       const bad: string[] = [];
-      document.querySelectorAll("body *").forEach((el) => {
+      document.querySelectorAll('body *').forEach((el) => {
         const cs = getComputedStyle(el);
-        if (cs.fontWeight === "700") {
+        if (cs.fontWeight === '700') {
           bad.push(`${el.tagName}.${(el as HTMLElement).className}`);
         }
       });
@@ -82,25 +82,25 @@ test.describe("Spec 055 · semantic base layer + mono restoration (Phase 3)", ()
     expect(violations).toEqual([]);
   });
 
-  test("italic-rendering elements resolve against a loaded Inter italic face", async ({
+  test('italic-rendering elements resolve against a loaded Inter italic face', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/sessions");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/sessions');
+    await page.waitForLoadState('networkidle');
 
     const result = await page.evaluate(async () => {
       await document.fonts.ready;
       const italics: { weight: string }[] = [];
-      document.querySelectorAll("body *").forEach((el) => {
+      document.querySelectorAll('body *').forEach((el) => {
         const cs = getComputedStyle(el);
-        if (cs.fontStyle === "italic" && cs.fontFamily.includes("Inter")) {
+        if (cs.fontStyle === 'italic' && cs.fontFamily.includes('Inter')) {
           italics.push({ weight: cs.fontWeight });
         }
       });
       const loadedItalicWeights = new Set(
         Array.from(document.fonts)
-          .filter((f) => f.family === "Inter" && f.style === "italic")
+          .filter((f) => f.family === 'Inter' && f.style === 'italic')
           .map((f) => f.weight),
       );
       const unmatched = italics.filter(
@@ -115,83 +115,83 @@ test.describe("Spec 055 · semantic base layer + mono restoration (Phase 3)", ()
     expect(result.unmatched).toEqual([]);
   });
 
-  test("code/pre content and a representative filesystem path render in the monospace stack", async ({
+  test('code/pre content and a representative filesystem path render in the monospace stack', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/sources");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/settings/sources');
+    await page.waitForLoadState('networkidle');
 
     // A registered data-source root's path (real, mock-fixture-backed data —
     // apps/desktop/src/api/mocks.ts `mockRoots`) — not the fabricated Advanced
     // pane db-path #601/#602 removed. Same `<code class="alm-mono">` mechanism.
-    const rootPath = page.locator(".alm-data-sources__root-path", {
-      hasText: "/astro/raw",
+    const rootPath = page.locator('.alm-data-sources__root-path', {
+      hasText: '/astro/raw',
     });
     await expect(rootPath).toBeVisible();
-    await expect(rootPath).toHaveText("/astro/raw");
+    await expect(rootPath).toHaveText('/astro/raw');
 
     const family = await rootPath.evaluate(
       (el) => getComputedStyle(el).fontFamily,
     );
-    expect(family).not.toContain("Inter");
-    expect(family.toLowerCase()).toContain("mono");
+    expect(family).not.toContain('Inter');
+    expect(family.toLowerCase()).toContain('mono');
 
     // `code, pre, kbd` base-layer rule (reset.css): the root-path element itself
     // is a <code>, which is the same mechanism as every other code/pre surface.
     const tag = await rootPath.evaluate((el) => el.tagName.toLowerCase());
-    expect(tag).toBe("code");
+    expect(tag).toBe('code');
   });
 
-  test("RA/Dec coordinate value renders in the monospace stack", async ({
+  test('RA/Dec coordinate value renders in the monospace stack', async ({
     page,
   }) => {
     seedSetupComplete(page);
     seedObservingSite(page);
-    await page.goto("/#/targets");
+    await page.goto('/#/targets');
     await disableGuidedTourOverlay(page);
 
-    const m31 = targetRow(page, "M 31");
+    const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
     await m31.click();
 
     const radecValue = page.locator(
-      ".alm-property-table__cell--value.alm-mono",
+      '.alm-property-table__cell--value.alm-mono',
     );
     await expect(radecValue.first()).toBeVisible({ timeout: 8_000 });
 
     const family = await radecValue
       .first()
       .evaluate((el) => getComputedStyle(el).fontFamily);
-    expect(family).not.toContain("Inter");
-    expect(family.toLowerCase()).toContain("mono");
+    expect(family).not.toContain('Inter');
+    expect(family.toLowerCase()).toContain('mono');
   });
 
-  test("regression net: every rendered element is Inter or an intentional mono surface", async ({
+  test('regression net: every rendered element is Inter or an intentional mono surface', async ({
     page,
   }) => {
     seedSetupComplete(page);
-    await page.goto("/#/settings/advanced");
-    await page.waitForLoadState("networkidle");
+    await page.goto('/#/settings/advanced');
+    await page.waitForLoadState('networkidle');
 
     const stragglers = await page.evaluate(() => {
       const bad: { tag: string; cls: string; family: string }[] = [];
-      document.querySelectorAll("body *").forEach((el) => {
+      document.querySelectorAll('body *').forEach((el) => {
         // SVG <text> declares font-family explicitly per-surface (spec 055
         // T021) rather than through inheritance — out of scope for this sweep.
-        if (el.closest("svg")) return;
+        if (el.closest('svg')) return;
         const cs = getComputedStyle(el);
         const family = cs.fontFamily;
         if (!family) return;
         const tag = el.tagName.toLowerCase();
         const isMonoIntent =
-          (el as HTMLElement).classList?.contains("alm-mono") ||
-          tag === "code" ||
-          tag === "pre" ||
-          tag === "kbd" ||
-          !!el.closest("code, pre, kbd, .alm-mono");
-        const isInter = family.includes("Inter");
-        const isMono = family.toLowerCase().includes("mono");
+          (el as HTMLElement).classList?.contains('alm-mono') ||
+          tag === 'code' ||
+          tag === 'pre' ||
+          tag === 'kbd' ||
+          !!el.closest('code, pre, kbd, .alm-mono');
+        const isInter = family.includes('Inter');
+        const isMono = family.toLowerCase().includes('mono');
         if (isMonoIntent ? !isMono : !isInter) {
           bad.push({ tag, cls: (el as HTMLElement).className, family });
         }


### PR DESCRIPTION
## Summary

- The `tests/` E2E suite was neither linted nor format-checked by anything. This wires it into CI and applies the resulting one-time reformat.
- No product code changes; no user-visible behaviour changes.

## The gap

`tests/` sits outside the pnpm workspace globs (`apps/*`, `packages/*`), so
`pnpm -r lint` never descended into it, and `apps/desktop/biome.json` scopes
`files.includes` to `src/**`. Nothing covered the E2E suite.

Blast radius was small, which is why this is a safe time to close it:
**25 formatting diffs** (those files were simply never formatted) and
**4 `noNonNullAssertion` warnings**.

## Two findings worth reviewer attention

**1. Wiring `lint:tests` into the root `lint` script would not have worked.**
CI runs `pnpm --filter @astro-plan/desktop run lint` — it never invokes the
root `lint` script. A root-script-only change would have looked correct and
silently never executed. Hence the explicit CI step, gated on the existing
`frontend` path filter (which matches `**/*.ts`, so it does cover
`tests/e2e/*.spec.ts`).

**2. The root config cannot shadow the nested one — verified, not assumed.**
`biome.json` is deliberately scoped to `tests/**` rather than being repo-wide.
Confirmed by running `biome check .` inside `apps/desktop` with the root config
present: still exits 0, still resolves the nested config.

## Commits

Split so the mechanical noise is separable from the decision:

- `f5676f00` **test:** the one-time reformat (25 files, formatting only).
- `a85b9d87` **ci:** the config, script, and CI step that turn the gate on.

Reformat-before-gate ordering keeps every commit green rather than landing a
commit whose own CI would fail.

## Verification

- `pnpm run lint:tests` → **exit 0**.
- `apps/desktop` `pnpm run lint` → **exit 0** (no shadowing).
- The reformat is provably cosmetic: normalizing whitespace, quote style,
  trailing commas, and semicolons out of all 25 files and diffing before/after
  yields **0 semantic differences**. No selector, assertion, or timeout moved.
- `@biomejs/biome` pinned to **2.5.3**, the version `apps/desktop` already
  depends on — no new third-party surface, 3-line lockfile delta.

## Known gap, deliberately not fixed here

`tests/e2e` is outside the root tsconfig `include` too, so it is **untypechecked**
as well as unlinted. That needs `@playwright/test` types wired up and is a larger
job than turning this gate on — filed separately as #1167.

## Spec Context

Spec 056 follow-up sweep, item 8.
