### PR TITLE
fix(lint): exclude signatures/cla.json from end-of-file-fixer

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,9 +15,13 @@ repos:
       # Generated outputs (specta bindings, seed catalog) must keep their
       # generator-emitted bytes — CI's `just check-generated` drift gate
       # regenerates and `git diff --exit-code`s them, so whitespace "fixes"
-      # here would fail CI.
+      # here would fail CI. signatures/cla.json is written by the CLA
+      # Assistant GitHub Action, not by humans; it ships without a trailing
+      # newline, and the bot rewrites it without one on every signature, so
+      # a locally-added newline would never stick — excluded rather than
+      # "fixed" once.
       - id: end-of-file-fixer
-        exclude: '^(apps/desktop/src/bindings/|assets/seed/)'
+        exclude: '^(apps/desktop/src/bindings/|assets/seed/|signatures/cla\.json)'
       - id: trailing-whitespace
         exclude: '^(apps/desktop/src/bindings/|assets/seed/)'
 


### PR DESCRIPTION
`just lint` runs pre-commit, whose `end-of-file-fixer` hook rewrites `signatures/cla.json` because the file has no trailing newline. That makes the recipe fail on a clean checkout of any branch — three separate lanes hit it independently today.

Adding the newline by hand is not a durable fix: the file is written by the CLA Assistant GitHub Action, which will drop it again on the next signature. So `signatures/cla.json` is excluded from the `end-of-file-fixer` hook instead, alongside the existing `apps/desktop/src/bindings/` and `assets/seed/` exclusions.

`trailing-whitespace` already passed on that file, so no other hook needed changing. Verified: `pre-commit run --files signatures/cla.json` flagged only `end-of-file-fixer` before, `pre-commit run --all-files` is clean after, and `git diff signatures/cla.json` is empty — the file itself is untouched.

Scope note: this PR originally also carried a fix for the `StepSourceFolders` stale copy assertion. #1163 landed the same fix first, so that commit has been dropped and this PR is now the lint exclusion only.