### PR TITLE
fix: calibration master detail surfaces the error message instead of a raw contract error

### DIFF
--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -65,6 +65,7 @@ import {
   formatGain,
   formatBinning,
 } from '@/lib/format';
+import { errMessage } from '@/lib/errors';
 import { addToast } from '@/shared/toast';
 import { useInventorySources } from '@/features/sessions/store';
 import { isSourceActionable } from '@/features/sessions/connectivity';
@@ -315,7 +316,7 @@ export function MasterDetail({
             return;
           }
           addToast({
-            message: err.message || m.archive_generate_failed(),
+            message: errMessage(err),
             variant: 'error',
           });
         },
@@ -330,7 +331,7 @@ export function MasterDetail({
         onSuccess: handleArchiveSuccess,
         onError: (err) => {
           addToast({
-            message: err.message || m.archive_generate_failed(),
+            message: errMessage(err),
             variant: 'error',
           });
         },


### PR DESCRIPTION
## Summary

- The two archive-plan `onError` handlers in `MasterDetail.tsx` (calibration master detail) fell back to `err.message`, which leaks the raw `ContractError` diagnostic string to the user instead of a translated, catalog-backed message.
- Routes both through `errMessage(err)` (from `@/lib/errors`), following the raw-error-leak sweep pattern from commit 26cc40b7 (#760).
- `m.archive_generate_failed()` remains referenced by `apps/desktop/src/features/projects/ProjectDetail.tsx:349`, so it is not orphaned by this change.

## Test plan

- [x] `pnpm --filter @astro-plan/desktop test` — full suite green (1792 passed)
- [x] `just typecheck` — clean