### PR TITLE
fix(ci): the DB boundary guard understands file-level test modules

### DIFF
--- a/scripts/check-db-boundary.sh
+++ b/scripts/check-db-boundary.sh
@@ -23,6 +23,8 @@
 #   - the example reference module (query_builder_example.rs)
 #   - query sites that appear at/after the first `#[cfg(test)]` line in a file
 #     (inline unit-test modules are not production code)
+#   - entire files the compiler excludes from production builds, i.e. file-level
+#     test modules (see is_test_only_file)
 #
 # Usage:
 #   scripts/check-db-boundary.sh            # enforce zero (CI mode)
@@ -39,10 +41,64 @@ BASELINE="$SCRIPT_DIR/db-boundary-baseline.txt"
 # Patterns that denote a raw sqlx query/exec site.
 PATTERN='sqlx::query|query_as|query_scalar|\.fetch_(one|all|optional)|\.execute\('
 
+# True when the compiler excludes this ENTIRE file from production builds.
+#
+# Two ways a whole file can be test-only, both checked against the compiler's
+# actual rule rather than the file's name — a production file called `tests.rs`
+# is still counted, which is why this is not a name-based exemption:
+#
+#   1. The file declares the inner attribute `#![cfg(test)]` in its header
+#      region (blank/comment/attribute lines only). Note this is NOT matched by
+#      the inline `#[cfg(test)]` cutoff regex below: the `!` makes it an inner
+#      attribute applying to the whole file, not a cutoff for what follows.
+#   2. The file is a module whose parent declares it `#[cfg(test)] mod <name>;`.
+#      Extracting an inline `#[cfg(test)] mod tests { .. }` into its own file
+#      leaves the attribute on the parent's declaration, so the file itself
+#      contains no cfg(test) marker at all.
+is_test_only_file() {
+  local file="$1"
+  local first_item modname dir parent inner
+
+  # (1) Inner attribute in the header region. Restricted to the leading run of
+  # blank/comment/attribute lines so an `#![cfg(test)]` nested inside an inline
+  # `mod foo { .. }` (legal, but scopes to that module only) does not count.
+  first_item="$(grep -nvE '^[[:space:]]*(//.*)?$|^[[:space:]]*#!?\[' "$file" | head -1 | cut -d: -f1 || true)"
+  inner="$(grep -nE '^[[:space:]]*#!\[cfg\(test\)\]' "$file" | head -1 | cut -d: -f1 || true)"
+  if [[ -n "$inner" ]] && { [[ -z "$first_item" ]] || [[ "$inner" -lt "$first_item" ]]; }; then
+    return 0
+  fi
+
+  # (2) Parent declares this module under #[cfg(test)].
+  modname="$(basename "$file" .rs)"
+  dir="$(dirname "$file")"
+  if [[ "$modname" == "mod" ]]; then
+    # `foo/mod.rs` is module `foo`, declared by foo's own parent directory.
+    modname="$(basename "$dir")"
+    dir="$(dirname "$dir")"
+  elif [[ "$modname" == "lib" || "$modname" == "main" ]]; then
+    return 1 # crate roots have no parent module
+  fi
+  for parent in "$dir/mod.rs" "$dir.rs" "$dir/lib.rs" "$dir/main.rs"; do
+    [[ -f "$parent" ]] || continue
+    # `#[cfg(test)]` on the line immediately preceding the `mod <name>;` decl.
+    if grep -A1 -E '^[[:space:]]*#\[cfg\(test\)\][[:space:]]*$' "$parent" \
+      | grep -qE "^[[:space:]]*(pub[[:space:]]*(\([^)]*\))?[[:space:]]+)?mod[[:space:]]+${modname}[[:space:]]*;"; then
+      return 0
+    fi
+  done
+  return 1
+}
+
 # Count production query sites in a single file (sites before first #[cfg(test)]).
 count_file() {
   local file="$1"
   local cutoff
+
+  if is_test_only_file "$file"; then
+    echo 0
+    return
+  fi
+
   # Line number of the first #[cfg(test)] (inline unit-test module marker).
   cutoff="$(grep -nE '#\[cfg\(test\)\]' "$file" | head -1 | cut -d: -f1 || true)"
   if [[ -n "$cutoff" ]]; then


### PR DESCRIPTION
## The false positive

`scripts/check-db-boundary.sh` excludes query sites at/after the first line matching `#[cfg(test)]` — the inline unit-test module marker.

Both open refactor PRs extract large inline `#[cfg(test)] mod tests { .. }` blocks into separate `tests.rs` files. In that pattern the attribute lives on the **parent's** `mod tests;` declaration, so the extracted file contains no `#[cfg(test)]` line of its own. The guard found no cutoff and counted every `sqlx::query`/`fetch_*`/`execute(` site in those test files as a production leak — 11 files, 146 sites, all test-only and all correctly excluded from production builds by the compiler.

## Why not exclude `tests.rs` by name

That punches a permanent hole in keystone enforcement: nothing stops production code living in a file with that name, and the boundary is sealed at zero precisely so no such hole exists. Rejected.

## The fix

Teach `count_file()` about whole-file exclusion, using the compiler's actual rule rather than the filename. `is_test_only_file()` returns true for either form:

1. An inner `#![cfg(test)]` in the file's header region (blank/comment/attribute lines only). Note the current cutoff regex `#\[cfg\(test\)\]` does **not** match this — the `!` makes it an inner attribute applying to the whole file. Scoping to the header region means an `#![cfg(test)]` nested inside an inline `mod foo { .. }` does not exempt the file.
2. The file is a module whose parent declares it `#[cfg(test)] mod <name>;` (resolving `dir/mod.rs`, `dir.rs`, `dir/lib.rs`, `dir/main.rs`).

Form 2 is what makes this script-only: the refactor branches already carry the gated parent declaration, so they need no edits. It also removes the blind spot for the whole class rather than annotating the 11 known instances and re-arming the same trap for the next extraction.

Existing inline `#[cfg(test)]` cutoff semantics are untouched — that grep is unchanged and the new check is separate.

## Both-directions proof

| Scenario | Expected | Result |
|---|---|---|
| Clean tree | pass | pass, `--list` empty |
| All 16 extracted `tests.rs` from both branches materialised | pass | pass, `--list` empty |
| Genuine `sqlx::query` added to production `plan_apply.rs` (before its cutoff) | **fail** | exit 1, violation reported |
| File named `tests.rs` whose parent decl is **not** cfg-gated | **fail** | exit 1, violation reported |
| File with inner `#![cfg(test)]` | pass | pass |
| Same file with the inner attribute removed | **fail** | exit 1, violation reported |

The name-hole and un-gated-parent cases are the ones that prove the exemption tracks compiler semantics, not filenames.

## Gates

- `cargo nextest run --workspace`: 2496 passed, 23 skipped, 0 failed
- `just typecheck`: green

## Blocks

#1160 (`coder-g-refactor-p2p3`) and #1171 (`coder-g-refactor-p1`) are both red on this guard and unblock once this merges. Neither branch needs any change.


## Spec Context
- Branch: worktree-worktree-419362
