### PR TITLE
fix(a11y): retune ink3/ink4 to AA on darkest surfaces; add contrast CI gate; keyboard Home/End on table rows

### DIFF
--- a/apps/desktop/scripts/check-contrast.mjs
+++ b/apps/desktop/scripts/check-contrast.mjs
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+// check-contrast.mjs — CI guard that text-on-surface token pairs meet WCAG AA
+// contrast (4.5:1) in every [data-theme] block.
+//
+// This is a regression gate for the a11y retune (handoff 02): ink3/ink4 scrape
+// past AA on the lightest surface (--pv-bg) but were failing on the darkest
+// surface they actually render on (--pv-bg3, chips/insets). Every pair below
+// is grounded in a real component-CSS usage site (see comments) so the check
+// reflects what ships, not a hypothetical worst case.
+//
+// Dependency-free (Node built-ins only). Run: node scripts/check-contrast.mjs
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const SRC = path.resolve(__dirname, '../src/styles/tokens.css');
+const AA_BODY = 4.5;
+
+// WCAG 2.x relative-luminance contrast ratio (sRGB linearization).
+function hexToRgb(hex) {
+  const h = hex.replace('#', '');
+  return [0, 2, 4].map((i) => Number.parseInt(h.slice(i, i + 2), 16));
+}
+function linearize(c) {
+  const s = c / 255;
+  return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
+}
+function relativeLuminance([r, g, b]) {
+  const [rl, gl, bl] = [r, g, b].map(linearize);
+  return 0.2126 * rl + 0.7152 * gl + 0.0722 * bl;
+}
+function contrastRatio(hexA, hexB) {
+  const [lA, lB] = [relativeLuminance(hexToRgb(hexA)), relativeLuminance(hexToRgb(hexB))];
+  const [lighter, darker] = lA > lB ? [lA, lB] : [lB, lA];
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+// Text tokens (--pv-ink..ink4) checked against every surface/status-bg token
+// they render on today. One line = one shipping usage site.
+const PAIRS = [
+  ['ink', 'bg', 'body text on the default app background'],
+  ['ink', 'surface', 'body text on panel/list surfaces'],
+  ['ink', 'bg3', 'body text on chip/inset surfaces'],
+  ['ink', 'surface-raised', 'body text on cards/modals'],
+  ['ink2', 'bg', 'secondary text on the default app background'],
+  ['ink2', 'surface', 'secondary text on panel/list surfaces'],
+  ['ink2', 'bg3', 'secondary text on chip surfaces (primitives.css .pv-pill--neutral)'],
+  ['ink2', 'surface-raised', 'secondary text on cards/modals'],
+  ['ink3', 'bg', 'muted text on the default app background'],
+  ['ink3', 'surface', 'muted text on panel/list surfaces'],
+  ['ink3', 'bg3', 'muted text on chip surfaces (target-search.css source badges) — the retune defect class'],
+  ['ink3', 'surface-raised', 'muted text on cards/modals'],
+  ['ink4', 'bg', 'faint text on the default app background'],
+  ['ink4', 'surface', 'faint text on panel/list surfaces'],
+  ['ink4', 'bg3', 'faint text on chip/inset surfaces — the darkest surface faint text sits on'],
+  ['ink4', 'surface-raised', 'faint text on cards/modals'],
+  ['ink2', 'accent-bg', 'secondary text on accent-tinted panels (settings.css highlight)'],
+  ['ink2', 'selected-bg', 'secondary text on selected nav/list rows'],
+  ['ink3', 'accent-bg', 'muted text on accent-tinted panels'],
+  ['ink3', 'selected-bg', 'muted text on selected nav/list rows'],
+  ['ok', 'ok-bg', 'success pill/banner/badge (primitives.css .pv-pill--ok, .pv-banner--ok)'],
+  ['warn', 'warn-bg', 'warning pill/banner/badge'],
+  ['danger', 'danger-bg', 'danger pill/banner/badge'],
+  ['danger', 'danger-bg-hover', 'danger button hover state (primitives.css .pv-btn--danger:hover)'],
+  ['info', 'info-bg', 'info pill/banner/badge'],
+  ['accent-text', 'accent-bg', 'accent pill/badge (primitives.css .pv-pill--accent)'],
+  ['accent-text', 'selected-bg', 'selected nav item text (app-shell.css)'],
+];
+
+const css = readFileSync(SRC, 'utf8');
+
+// Collect raw hex token values per theme, merging blocks that share a selector
+// (":root, [data-theme=\"warm-slate\"]") — same approach as
+// check-theme-completeness.mjs.
+const blockRe = /([^{}]*)\{([^{}]*)\}/g;
+const themeTokens = new Map(); // theme id -> Map<token name -> hex value>
+
+for (const [, selector, body] of css.matchAll(blockRe)) {
+  const themeNames = [...selector.matchAll(/\[data-theme="([a-z0-9-]+)"\]/g)].map((m) => m[1]);
+  if (themeNames.length === 0) continue;
+  const decls = [...body.matchAll(/(--pv-[a-z0-9-]+)\s*:\s*(#[0-9a-fA-F]{6})/g)];
+  for (const theme of themeNames) {
+    const map = themeTokens.get(theme) ?? new Map();
+    for (const [, name, value] of decls) map.set(name, value);
+    themeTokens.set(theme, map);
+  }
+}
+
+if (themeTokens.size === 0) {
+  console.error(`FAIL: no [data-theme] blocks found in ${SRC}`);
+  process.exit(1);
+}
+
+let ok = true;
+for (const [theme, tokens] of themeTokens) {
+  for (const [textName, surfaceName, note] of PAIRS) {
+    const fg = tokens.get(`--pv-${textName}`);
+    const bg = tokens.get(`--pv-${surfaceName}`);
+    if (!fg || !bg) {
+      ok = false;
+      console.error(
+        `FAIL: [data-theme="${theme}"] missing --pv-${textName} or --pv-${surfaceName} (pair: ${note})`,
+      );
+      continue;
+    }
+    const ratio = contrastRatio(fg, bg);
+    if (ratio < AA_BODY) {
+      ok = false;
+      console.error(
+        `FAIL: [data-theme="${theme}"] --pv-${textName} (${fg}) on --pv-${surfaceName} (${bg}) = ` +
+          `${ratio.toFixed(2)}:1, below AA ${AA_BODY}:1 (${note})`,
+      );
+    }
+  }
+}
+
+if (ok) {
+  console.log(
+    `OK: all ${PAIRS.length} text/surface pairs meet AA ${AA_BODY}:1 across ${themeTokens.size} theme(s).`,
+  );
+  process.exit(0);
+}
+process.exit(1);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -154,7 +154,7 @@
    :root default so the default light palette has a single source of truth. */
 :root,
 [data-theme="warm-slate"] {
-  --pv-ink: #20211f; --pv-ink2: #42433f; --pv-ink3: #6a6b66; --pv-ink4: #70706a;
+  --pv-ink: #20211f; --pv-ink2: #42433f; --pv-ink3: #5a5b54; --pv-ink4: #606159;
   --pv-rule: #d5d3cb; --pv-rule2: #e6e4dd;
   --pv-bg: #f5f4f1; --pv-surface: #ecebe6; --pv-bg3: #e2e0d9; --pv-surface-raised: #ffffff;
   --pv-on-accent: #ffffff;
@@ -172,7 +172,7 @@
 
 /* Warm Clay — warm light, terracotta accent */
 [data-theme="warm-clay"] {
-  --pv-ink: #221f1a; --pv-ink2: #433e35; --pv-ink3: #736b5e; --pv-ink4: #75705f;
+  --pv-ink: #221f1a; --pv-ink2: #433e35; --pv-ink3: #5b544a; --pv-ink4: #625b50;
   --pv-rule: #d8d1c4; --pv-rule2: #e8e2d6;
   --pv-bg: #f6f4ef; --pv-surface: #efeae1; --pv-bg3: #e6e0d4; --pv-surface-raised: #fffdf9;
   --pv-on-accent: #ffffff;
@@ -190,7 +190,7 @@
 
 /* Observatory Dark — warm charcoal, amber accent (default dark + OS-dark) */
 [data-theme="observatory-dark"] {
-  --pv-ink: #f0ebe2; --pv-ink2: #cfc7b8; --pv-ink3: #a59c8a; --pv-ink4: #8f8676;
+  --pv-ink: #f0ebe2; --pv-ink2: #cfc7b8; --pv-ink3: #a59c8a; --pv-ink4: #9a9180;
   --pv-rule: #3a352b; --pv-rule2: #2e2a22;
   --pv-bg: #1b1916; --pv-surface: #232019; --pv-bg3: #2c281f; --pv-surface-raised: #26221b;
   --pv-on-accent: #1b1916;
@@ -208,7 +208,7 @@
 
 /* Espresso Dark — deep near-black, caramel accent */
 [data-theme="espresso-dark"] {
-  --pv-ink: #ece7df; --pv-ink2: #cabfae; --pv-ink3: #9b9384; --pv-ink4: #8a8272;
+  --pv-ink: #ece7df; --pv-ink2: #cabfae; --pv-ink3: #9b9384; --pv-ink4: #9c947f;
   --pv-rule: #332e28; --pv-rule2: #272320;
   --pv-bg: #161412; --pv-surface: #1e1b18; --pv-bg3: #272320; --pv-surface-raised: #1e1b18;
   --pv-on-accent: #161412;

--- a/apps/desktop/src/ui/Table.test.tsx
+++ b/apps/desktop/src/ui/Table.test.tsx
@@ -1,0 +1,81 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Table row a11y tests (handoff 02): keyboard-operable clickable rows —
+ * roving Arrow Up/Down (pre-existing), Home/End jump-to-edge, and row/
+ * aria-selected semantics. Sessions/Projects/Masters/Archive/Targets tables
+ * all render through this component, so this is the single coverage point.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent } from '@testing-library/react';
+import { Table, type TableColumn, type TableRow } from './Table';
+
+const COLUMNS: TableColumn[] = [{ key: 'name', label: 'Name' }];
+
+function rows(onClick: (id: string) => void, selected?: string): TableRow[] {
+  return ['a', 'b', 'c'].map((id) => ({
+    name: id.toUpperCase(),
+    _onClick: () => onClick(id),
+    _selected: id === selected,
+    _testid: `row-${id}`,
+  }));
+}
+
+describe('Table clickable rows (handoff 02)', () => {
+  it('exposes native row semantics with aria-selected on the selected row', () => {
+    render(<Table columns={COLUMNS} rows={rows(vi.fn(), 'b')} />);
+    const rowEls = screen.getAllByRole('row').slice(1); // drop the header row
+    expect(rowEls).toHaveLength(3);
+    expect(rowEls[0]).toHaveAttribute('aria-selected', 'false');
+    expect(rowEls[1]).toHaveAttribute('aria-selected', 'true');
+    expect(rowEls[2]).toHaveAttribute('aria-selected', 'false');
+  });
+
+  it('is keyboard-focusable and activates on Enter/Space', () => {
+    const onClick = vi.fn();
+    render(<Table columns={COLUMNS} rows={rows(onClick)} />);
+    const rowA = screen.getByTestId('row-a');
+    expect(rowA).toHaveAttribute('tabIndex', '0');
+    fireEvent.keyDown(rowA, { key: 'Enter' });
+    expect(onClick).toHaveBeenCalledWith('a');
+    fireEvent.keyDown(rowA, { key: ' ' });
+    expect(onClick).toHaveBeenCalledWith('a');
+  });
+
+  it('ArrowDown/ArrowUp move focus between rows (pre-existing roving nav)', () => {
+    render(<Table columns={COLUMNS} rows={rows(vi.fn())} />);
+    const rowA = screen.getByTestId('row-a');
+    const rowB = screen.getByTestId('row-b');
+    rowA.focus();
+    fireEvent.keyDown(rowA, { key: 'ArrowDown' });
+    expect(rowB).toHaveFocus();
+    fireEvent.keyDown(rowB, { key: 'ArrowUp' });
+    expect(rowA).toHaveFocus();
+  });
+
+  it('End moves focus to the last row, Home back to the first', () => {
+    render(<Table columns={COLUMNS} rows={rows(vi.fn())} />);
+    const rowA = screen.getByTestId('row-a');
+    const rowC = screen.getByTestId('row-c');
+    rowA.focus();
+    fireEvent.keyDown(rowA, { key: 'End' });
+    expect(rowC).toHaveFocus();
+    fireEvent.keyDown(rowC, { key: 'Home' });
+    expect(rowA).toHaveFocus();
+  });
+
+  it('Home/End on a middle row jump straight to the edges', () => {
+    render(<Table columns={COLUMNS} rows={rows(vi.fn())} />);
+    const rowB = screen.getByTestId('row-b');
+    const rowA = screen.getByTestId('row-a');
+    const rowC = screen.getByTestId('row-c');
+    rowB.focus();
+    fireEvent.keyDown(rowB, { key: 'End' });
+    expect(rowC).toHaveFocus();
+    rowB.focus();
+    fireEvent.keyDown(rowB, { key: 'Home' });
+    expect(rowA).toHaveFocus();
+  });
+});

--- a/apps/desktop/src/ui/Table.tsx
+++ b/apps/desktop/src/ui/Table.tsx
@@ -40,6 +40,21 @@ function focusAdjacentRow(current: HTMLTableRowElement, dir: 1 | -1) {
   clickable[idx + dir]?.focus();
 }
 
+/**
+ * Move keyboard focus to the first or last focusable (selectable) row in the
+ * same scope as `current`. Wired to Home/End on clickable rows.
+ */
+function focusEdgeRow(current: HTMLTableRowElement, edge: 'first' | 'last') {
+  const scope = current.closest('tbody') ?? current.parentElement;
+  if (!scope) return;
+  const clickable = scope.querySelectorAll<HTMLTableRowElement>(
+    'tr[data-row-clickable="true"]',
+  );
+  const target =
+    edge === 'first' ? clickable[0] : clickable[clickable.length - 1];
+  target?.focus();
+}
+
 export interface TableColumn {
   key: string;
   /** Header content. Accepts a plain string or rich nodes (e.g. sortable header buttons). */
@@ -179,6 +194,12 @@ export const Table = forwardRef<HTMLTableElement, TableProps>(function Table(
                 } else if (e.key === 'ArrowUp') {
                   e.preventDefault();
                   focusAdjacentRow(e.currentTarget, -1);
+                } else if (e.key === 'Home') {
+                  e.preventDefault();
+                  focusEdgeRow(e.currentTarget, 'first');
+                } else if (e.key === 'End') {
+                  e.preventDefault();
+                  focusEdgeRow(e.currentTarget, 'last');
                 }
               }
             : undefined

--- a/scripts/check-tokens.sh
+++ b/scripts/check-tokens.sh
@@ -107,6 +107,16 @@ else
   PASS=false
 fi
 
+# ── Check 6: Text/surface token pairs meet WCAG AA contrast (handoff 02) ─────
+echo ""
+echo "6. Checking text/surface token contrast (WCAG AA)..."
+if node "$REPO_ROOT/apps/desktop/scripts/check-contrast.mjs"; then
+  echo "  OK: All contrast pairs meet AA."
+else
+  echo "FAIL: A text/surface pair is below AA contrast (see above)."
+  PASS=false
+fi
+
 # ── Result ────────────────────────────────────────────────────────────────────
 echo ""
 if [ "$PASS" = true ]; then


### PR DESCRIPTION
WCAG AA retune per approved design (handoff 02): six ink3/ink4 hex values retuned across the four warm themes, AA-verified against the darkest surface (bg3) they sit on (warm-slate/warm-clay both tiers; observatory-dark + espresso-dark ink4 only).

New CI gate `apps/desktop/scripts/check-contrast.mjs` (WCAG relative-luminance, ink-on-surface pairs incl. ink3/ink4-on-bg3) wired as check 6 in `scripts/check-tokens.sh` — proven fail-on-revert.

Table rows gain Home/End in the existing roving-keyboard idiom + tests.

Notes:
- `:root`/warm-slate dedupe verified already satisfied.
- Handoff's `LogPanel.tsx:418-437` pattern pointer was stale (chip toolbar) — `Table.tsx`'s existing idiom extended instead.

Closes #1138