### PR TITLE
feat(themes): add observatory-cool light+dark as canonical; group picker by family; disable clay/espresso variants

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1708,6 +1708,8 @@
   "settings_theme_mode_auto_light": "auto · light",
   "settings_theme_mode_dark": "dark",
   "settings_theme_mode_light": "light",
+  "settings_general_theme_group_warm": "Warm",
+  "settings_general_theme_group_cool": "Cool",
   "projects_lifecycle_prepare": "Prepare",
   "projects_lifecycle_mark_processing": "Mark as Processing",
   "projects_lifecycle_revert_ready": "Revert to Ready",

--- a/apps/desktop/src/data/theme.persistence.test.ts
+++ b/apps/desktop/src/data/theme.persistence.test.ts
@@ -181,3 +181,70 @@ describe('hydrateThemeFromSettings — reconcile the boot cache from the setting
     expect(localStorage.getItem('alm.theme')).toBe('warm-clay');
   });
 });
+
+describe('THEMES registry — canonical vs. variant (handoff 03)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    isTauriMock.mockReset();
+    settingsUpdateMock.mockReset();
+    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('marks exactly the four canonical themes enabled, keeping the two variants in the registry', async () => {
+    const { THEMES } = await import('./theme');
+
+    const enabled = THEMES.filter((t) => t.enabled)
+      .map((t) => t.id)
+      .sort();
+    const disabled = THEMES.filter((t) => !t.enabled)
+      .map((t) => t.id)
+      .sort();
+
+    expect(enabled).toEqual(
+      [
+        'observatory-cool',
+        'observatory-cool-light',
+        'observatory-dark',
+        'warm-slate',
+      ].sort(),
+    );
+    expect(disabled).toEqual(['espresso-dark', 'warm-clay'].sort());
+  });
+
+  it('groups the two new cool themes under the cool family, light before dark', async () => {
+    const { THEMES } = await import('./theme');
+    const cool = THEMES.filter((t) => t.family === 'cool');
+
+    expect(cool.map((t) => t.id)).toEqual(
+      expect.arrayContaining(['observatory-cool', 'observatory-cool-light']),
+    );
+    const light = cool.find((t) => t.id === 'observatory-cool-light');
+    const dark = cool.find((t) => t.id === 'observatory-cool');
+    expect(light?.mode).toBe('light');
+    expect(dark?.mode).toBe('dark');
+  });
+
+  it('a disabled (picker-hidden) variant already chosen still resolves, applies, and persists', async () => {
+    isTauriMock.mockReturnValue(true);
+    const { setThemeChoice, getThemeChoice, resolveTheme } = await import(
+      './theme'
+    );
+
+    setThemeChoice('espresso-dark');
+
+    expect(getThemeChoice()).toBe('espresso-dark');
+    expect(resolveTheme('espresso-dark')).toBe('espresso-dark');
+    expect(document.documentElement.getAttribute('data-theme')).toBe(
+      'espresso-dark',
+    );
+    await waitForCall(settingsUpdateMock);
+    expect(settingsUpdateMock).toHaveBeenCalledWith('general', {
+      theme: 'espresso-dark',
+    });
+  });
+});

--- a/apps/desktop/src/data/theme.test.ts
+++ b/apps/desktop/src/data/theme.test.ts
@@ -62,6 +62,11 @@ describe('applyTheme — native window theme sync (spec 051 US6)', () => {
     { id: 'warm-slate', mode: 'light' },
     { id: 'observatory-dark', mode: 'dark' },
     { id: 'espresso-dark', mode: 'dark' },
+    // Handoff 03 — the two new cool-family canonical themes; warm-clay and
+    // espresso-dark stay above as proof a disabled (picker-hidden) variant
+    // still resolves/applies exactly as before.
+    { id: 'observatory-cool-light', mode: 'light' },
+    { id: 'observatory-cool', mode: 'dark' },
   ];
 
   for (const { id, mode } of CASES) {

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -52,13 +52,24 @@ export type ThemeId =
   | 'warm-clay'
   | 'warm-slate'
   | 'observatory-dark'
-  | 'espresso-dark';
+  | 'espresso-dark'
+  | 'observatory-cool-light'
+  | 'observatory-cool';
 export type ThemeChoice = ThemeId | 'system';
 
 export interface ThemeMeta {
   id: ThemeId;
   label: string;
   mode: 'light' | 'dark';
+  /** Picker grouping (handoff 03) — Warm Slate/Observatory Dark form the warm
+   *  family, the two Observatory Cool themes form the cool family. */
+  family: 'warm' | 'cool';
+  /** Canonical (picker-visible) vs. variant (registry-only, handoff 03): a
+   *  disabled theme is still a fully valid ThemeChoice — it stays in
+   *  VALID_CHOICES below and keeps resolving/applying/persisting exactly as
+   *  before for anyone with it already selected. Only the picker filters on
+   *  this flag. */
+  enabled: boolean;
   /** [bg, surface, accent] for swatch previews */
   swatch: [string, string, string];
 }
@@ -68,25 +79,49 @@ export const THEMES: ThemeMeta[] = [
     id: 'warm-clay',
     label: 'Warm Clay',
     mode: 'light',
+    family: 'warm',
+    enabled: false,
     swatch: ['#f6f4ef', '#efeae1', '#b25a35'],
   },
   {
     id: 'warm-slate',
     label: 'Warm Slate',
     mode: 'light',
+    family: 'warm',
+    enabled: true,
     swatch: ['#f5f4f1', '#ecebe6', '#3f6b7a'],
   },
   {
     id: 'observatory-dark',
     label: 'Observatory',
     mode: 'dark',
+    family: 'warm',
+    enabled: true,
     swatch: ['#1b1916', '#232019', '#d98a3d'],
   },
   {
     id: 'espresso-dark',
     label: 'Espresso',
     mode: 'dark',
+    family: 'warm',
+    enabled: false,
     swatch: ['#161412', '#1e1b18', '#cf9d63'],
+  },
+  {
+    id: 'observatory-cool-light',
+    label: 'Observatory Cool · Light',
+    mode: 'light',
+    family: 'cool',
+    enabled: true,
+    swatch: ['#f2f4f8', '#e8ecf2', '#276f7c'],
+  },
+  {
+    id: 'observatory-cool',
+    label: 'Observatory Cool',
+    mode: 'dark',
+    family: 'cool',
+    enabled: true,
+    swatch: ['#12151b', '#191d25', '#3fb2c2'],
   },
 ];
 

--- a/apps/desktop/src/features/settings/General.test.tsx
+++ b/apps/desktop/src/features/settings/General.test.tsx
@@ -83,6 +83,35 @@ describe('General — font size', () => {
   });
 });
 
+describe('General — theme picker (handoff 03: canonical themes, grouped)', () => {
+  it('shows the four canonical themes grouped Warm/Cool, and hides the two disabled variants', () => {
+    render(<General />);
+
+    expect(screen.getByText('Warm')).toBeInTheDocument();
+    expect(screen.getByText('Cool')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('button', { name: /^Warm Slate/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^Observatorydark$/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^Observatory Cool · Light/i }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole('button', { name: /^Observatory Cooldark$/i }),
+    ).toBeInTheDocument();
+
+    expect(
+      screen.queryByRole('button', { name: /warm clay/i }),
+    ).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole('button', { name: /espresso/i }),
+    ).not.toBeInTheDocument();
+  });
+});
+
 describe('General — restore defaults (#802)', () => {
   it('renders a Restore defaults control for the Appearance pane', () => {
     render(<General />);
@@ -103,12 +132,19 @@ describe('General — restore defaults (#802)', () => {
       .closest('.pv-settings__row') as HTMLElement;
     const densitySelect = within(densityRow).getByRole('combobox');
 
-    fireEvent.click(screen.getByRole('button', { name: /espresso/i }));
+    // Espresso Dark is a disabled (registry-only) variant as of handoff 03 —
+    // it no longer renders in the picker, so this exercises a canonical
+    // theme instead. The exact-anchored name avoids matching the
+    // "Observatory Cool · Light" card, whose accessible name also starts
+    // with "Observatory Cool".
+    fireEvent.click(
+      screen.getByRole('button', { name: /^Observatory Cooldark$/i }),
+    );
     fireEvent.change(screen.getByDisplayValue('Default (14px)'), {
       target: { value: 'large' },
     });
     fireEvent.change(densitySelect, { target: { value: 'compact' } });
-    expect(getThemeChoice()).toBe('espresso-dark');
+    expect(getThemeChoice()).toBe('observatory-cool');
     expect(getFontSizeChoice()).toBe('large');
     expect(densitySelect).toHaveValue('compact');
 

--- a/apps/desktop/src/features/settings/General.tsx
+++ b/apps/desktop/src/features/settings/General.tsx
@@ -15,7 +15,7 @@ import {
   THEMES,
   ZOOM_STEPS,
 } from '@/data/theme';
-import type { FontSizeChoice, ZoomPercent } from '@/data/theme';
+import type { FontSizeChoice, ThemeId, ZoomPercent } from '@/data/theme';
 import type { Density } from '@/bindings/types';
 import { m } from '@/lib/i18n';
 import { SettingsSection, RestoreDefaultsBtn } from './SettingsKit';
@@ -26,17 +26,36 @@ import { SettingsSection, RestoreDefaultsBtn } from './SettingsKit';
  *  RestoreDefaultsBtn control). */
 const DEFAULT_DENSITY: Density = 'comfortable';
 
+interface ThemeSwatchChoice {
+  id: ThemeId | 'system';
+  label: () => string;
+  mode: 'light' | 'dark' | 'auto';
+}
+
 // `label` is a render-time thunk so it re-reads the active locale (spec 046 #8).
 // THEMES carry static brand names (not translatable) — wrap them as thunks so
-// every CHOICES entry exposes the same `() => string` label shape.
-const CHOICES = [
-  {
-    id: 'system' as const,
-    label: () => m.settings_general_theme_system(),
-    mode: 'auto' as const,
-  },
-  ...THEMES.map((t) => ({ ...t, label: () => t.label })),
-];
+// every choice exposes the same `() => string` label shape.
+const SYSTEM_CHOICE: ThemeSwatchChoice = {
+  id: 'system',
+  label: () => m.settings_general_theme_system(),
+  mode: 'auto',
+};
+
+// Picker (handoff 03): only canonical (`enabled`) themes are offered, grouped
+// by family (warm/cool) and, within a family, light before dark. Warm
+// Clay/Espresso Dark stay in THEMES (registry) so an already-persisted choice
+// keeps resolving/applying — they are simply omitted here.
+const MODE_ORDER: Record<'light' | 'dark', number> = { light: 0, dark: 1 };
+const WARM_CHOICES: ThemeSwatchChoice[] = THEMES.filter(
+  (t) => t.enabled && t.family === 'warm',
+)
+  .sort((a, b) => MODE_ORDER[a.mode] - MODE_ORDER[b.mode])
+  .map((t) => ({ id: t.id, label: () => t.label, mode: t.mode }));
+const COOL_CHOICES: ThemeSwatchChoice[] = THEMES.filter(
+  (t) => t.enabled && t.family === 'cool',
+)
+  .sort((a, b) => MODE_ORDER[a.mode] - MODE_ORDER[b.mode])
+  .map((t) => ({ id: t.id, label: () => t.label, mode: t.mode }));
 
 export function General() {
   const [choice, setChoice] = useThemeChoice();
@@ -52,49 +71,60 @@ export function General() {
     setDensity(DEFAULT_DENSITY);
   };
 
+  const renderSwatch = (t: ThemeSwatchChoice) => {
+    const isActive = choice === t.id;
+    // `system` card mirrors the resolved palette so it isn't a blank tile.
+    const previewTheme = t.id === 'system' ? resolved : t.id;
+    return (
+      <button
+        key={t.id}
+        type="button"
+        className={clsx(
+          'pv-theme-swatch',
+          isActive && 'pv-theme-swatch--active',
+        )}
+        onClick={() => setChoice(t.id)}
+        aria-pressed={isActive}
+      >
+        <span className="pv-theme-swatch__prev" data-theme={previewTheme}>
+          <i className="pv-theme-swatch__bg" />
+          <i className="pv-theme-swatch__surface" />
+          <i className="pv-theme-swatch__accent" />
+        </span>
+        <span className="pv-theme-swatch__name">{t.label()}</span>
+        <span className="pv-theme-swatch__mode">
+          {t.id === 'system'
+            ? resolved.includes('dark')
+              ? m.settings_theme_mode_auto_dark()
+              : m.settings_theme_mode_auto_light()
+            : t.mode === 'dark'
+              ? m.settings_theme_mode_dark()
+              : m.settings_theme_mode_light()}
+        </span>
+      </button>
+    );
+  };
+
   return (
     <>
       <SettingsSection
         title={m.settings_general_theme()}
         action={<RestoreDefaultsBtn onRestore={handleRestoreDefaults} />}
       >
+        <div className="pv-theme-swatches">{renderSwatch(SYSTEM_CHOICE)}</div>
+
+        <div className="pv-settings__group-title">
+          {m.settings_general_theme_group_warm()}
+        </div>
         <div className="pv-theme-swatches">
-          {CHOICES.map((t) => {
-            const isActive = choice === t.id;
-            // `system` card mirrors the resolved palette so it isn't a blank tile.
-            const previewTheme = t.id === 'system' ? resolved : t.id;
-            return (
-              <button
-                key={t.id}
-                type="button"
-                className={clsx(
-                  'pv-theme-swatch',
-                  isActive && 'pv-theme-swatch--active',
-                )}
-                onClick={() => setChoice(t.id)}
-                aria-pressed={isActive}
-              >
-                <span
-                  className="pv-theme-swatch__prev"
-                  data-theme={previewTheme}
-                >
-                  <i className="pv-theme-swatch__bg" />
-                  <i className="pv-theme-swatch__surface" />
-                  <i className="pv-theme-swatch__accent" />
-                </span>
-                <span className="pv-theme-swatch__name">{t.label()}</span>
-                <span className="pv-theme-swatch__mode">
-                  {t.id === 'system'
-                    ? resolved.includes('dark')
-                      ? m.settings_theme_mode_auto_dark()
-                      : m.settings_theme_mode_auto_light()
-                    : t.mode === 'dark'
-                      ? m.settings_theme_mode_dark()
-                      : m.settings_theme_mode_light()}
-                </span>
-              </button>
-            );
-          })}
+          {WARM_CHOICES.map(renderSwatch)}
+        </div>
+
+        <div className="pv-settings__group-title">
+          {m.settings_general_theme_group_cool()}
+        </div>
+        <div className="pv-theme-swatches">
+          {COOL_CHOICES.map(renderSwatch)}
         </div>
       </SettingsSection>
 

--- a/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepCatalogs.test.tsx
@@ -113,12 +113,18 @@ describe('StepCatalogs (Configuration)', () => {
     const theme = screen.getByLabelText('Theme') as HTMLSelectElement;
     expect(theme).not.toBeDisabled();
     const optionValues = Array.from(theme.options).map((o) => o.value);
+    // The wizard's ThemeControl deliberately maps over the full THEMES
+    // registry (unfiltered by `enabled`) — handoff 03's canonical/variant
+    // split only hides Warm Clay/Espresso from the Settings > Appearance
+    // picker, not this first-run control (#504's "all app themes" intent).
     expect(optionValues).toEqual([
       'system',
       'warm-clay',
       'warm-slate',
       'observatory-dark',
       'espresso-dark',
+      'observatory-cool-light',
+      'observatory-cool',
     ]);
   });
 

--- a/apps/desktop/src/styles/THEMES.md
+++ b/apps/desktop/src/styles/THEMES.md
@@ -1,0 +1,15 @@
+# Adding a theme
+
+A theme is **one `[data-theme="name"]` block that overrides only the ~30 raw
+palette tokens** (ink1–4, rule/rule2, bg/surface/bg3/surface-raised, accent
+set, status set, hover/selected, shadow-sm). Never redeclare semantic
+aliases, the type scale, spacing, radius, or layout — those are
+theme-invariant and resolve at use-site. Add the name to the theme registry
+with `enabled: true`, grouped by family (warm/cool) and mode (light/dark).
+CI enforces token completeness + AA contrast; a theme that fails either does
+not ship.
+
+See `apps/desktop/src/data/theme.ts` (`THEMES`, `ThemeMeta`) for the registry
+and `apps/desktop/scripts/check-theme-completeness.mjs` /
+`check-contrast.mjs` for the CI gates (run via `scripts/check-tokens.sh`,
+checks 5/6).

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -224,6 +224,45 @@
   --pv-shadow-sm: 0 1px 3px rgba(0,0,0,0.5);
 }
 
+/* Observatory Cool — cool DARK, blue-black neutrals + OIII teal accent. The app
+   counterpart to the docs "narrowband observatory" palette, rebuilt on the
+   --pv-* contract (flat, dense, no glow). Canonical (cool family). AA-clean. */
+[data-theme="observatory-cool"] {
+  --pv-ink: #eef2f7; --pv-ink2: #c5cdd8; --pv-ink3: #98a2b0; --pv-ink4: #8592a1;
+  --pv-rule: #303845; --pv-rule2: #252c37;
+  --pv-bg: #12151b; --pv-surface: #191d25; --pv-bg3: #212734; --pv-surface-raised: #1c212a;
+  --pv-on-accent: #0c1014;
+  --pv-input-recessed-bg: var(--pv-surface);
+  --pv-ok: #6fc191; --pv-warn: #d8b24e; --pv-danger: #e08a76; --pv-info: #86b3cc;
+  --pv-ok-bg: #16261d; --pv-ok-border: #2f4638;
+  --pv-warn-bg: #2a2415; --pv-warn-border: #4a3f24;
+  --pv-danger-bg: #2b1a16; --pv-danger-bg-hover: #38221c; --pv-danger-border: #4d2d25;
+  --pv-info-bg: #152331; --pv-info-border: #2f4658;
+  --pv-accent: #3fb2c2; --pv-accent-hover: #54c3d1; --pv-accent-deep: #2c8592;
+  --pv-accent-bg: #16303a; --pv-accent-text: #66cedb;
+  --pv-hover-bg: rgba(255,255,255,0.05); --pv-selected-bg: #1e2733;
+  --pv-shadow-sm: 0 1px 3px rgba(0,0,0,0.5);
+}
+
+/* Observatory Cool · Light — cool LIGHT counterpart, deep teal accent. Matches
+   the docs light palette. Canonical (cool family). AA-clean. */
+[data-theme="observatory-cool-light"] {
+  --pv-ink: #191d24; --pv-ink2: #3a414b; --pv-ink3: #565e6a; --pv-ink4: #525a66;
+  --pv-rule: #cbd2dd; --pv-rule2: #dce1ea;
+  --pv-bg: #f2f4f8; --pv-surface: #e8ecf2; --pv-bg3: #dde3eb; --pv-surface-raised: #ffffff;
+  --pv-on-accent: #ffffff;
+  --pv-input-recessed-bg: var(--pv-bg);
+  --pv-ok: #3a6b48; --pv-warn: #7a5a1a; --pv-danger: #8a2a1a; --pv-info: #35566a;
+  --pv-ok-bg: #e6efe8; --pv-ok-border: #bcd0bf;
+  --pv-warn-bg: #f4edd6; --pv-warn-border: #ddce9e;
+  --pv-danger-bg: #f2e0db; --pv-danger-bg-hover: #ebcfc6; --pv-danger-border: #dfbdb3;
+  --pv-info-bg: #e5eef2; --pv-info-border: #bcd2dc;
+  --pv-accent: #276f7c; --pv-accent-hover: #215d68; --pv-accent-deep: #1a4a53;
+  --pv-accent-bg: #dbebef; --pv-accent-text: #1c6470;
+  --pv-hover-bg: rgba(0,0,0,0.04); --pv-selected-bg: #e0eaef;
+  --pv-shadow-sm: 0 1px 2px rgba(0,0,0,0.08);
+}
+
 /* Density modifiers */
 .density-compact { --pv-row-height: 24px; }
 .density-spacious { --pv-row-height: 40px; }

--- a/crates/e2e-tests/tests/settings_journeys.rs
+++ b/crates/e2e-tests/tests/settings_journeys.rs
@@ -180,19 +180,23 @@ async fn settings_ui_theme_applies_live_and_persists_to_settings_db() -> anyhow:
     app.goto_route("/settings/general").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
 
-    // "Espresso" (`THEMES` id `espresso-dark`) — a real, non-default theme
-    // swatch, matched by its visible name (the swatch button's full text
-    // also includes its light/dark mode label, so an exact-match helper
-    // would be wrong here — use `contains`).
+    // "Observatory" (`THEMES` id `observatory-dark`) — a real, non-default,
+    // canonical theme swatch (handoff 03: Espresso Dark is now a disabled,
+    // picker-hidden variant — see apps/desktop/src/data/theme.ts `enabled`),
+    // matched by its visible name (the swatch button's full text also
+    // includes its light/dark mode label, so an exact-match helper would be
+    // wrong here — use `contains`). The predicate excludes "Cool" so this
+    // can't accidentally match the new "Observatory Cool" / "Observatory
+    // Cool · Light" swatches, which also contain the substring "Observatory".
     // Poll for the swatch to actually mount: it opens asynchronously
     // after the navigation, same route/render race `E2eApp::find_waiting`
     // documents.
-    let xpath = "//button[contains(., 'Espresso')]";
-    app.find_waiting(By::XPath(xpath), "the 'Espresso' theme swatch button")
+    let xpath = "//button[contains(., 'Observatory') and not(contains(., 'Cool'))]";
+    app.find_waiting(By::XPath(xpath), "the 'Observatory' theme swatch button")
         .await?
         .click()
         .await
-        .context("click the Espresso theme swatch failed")?;
+        .context("click the Observatory theme swatch failed")?;
 
     // Live apply: no reload needed.
     let theme: String = app
@@ -203,7 +207,7 @@ async fn settings_ui_theme_applies_live_and_persists_to_settings_db() -> anyhow:
         .convert()
         .context("failed to deserialise data-theme")?;
     anyhow::ensure!(
-        theme == "espresso-dark",
+        theme == "observatory-dark",
         "expected the theme to apply live with no reload, got data-theme={theme:?}"
     );
 
@@ -217,8 +221,8 @@ async fn settings_ui_theme_applies_live_and_persists_to_settings_db() -> anyhow:
         .convert()
         .context("failed to deserialise localStorage['alm.theme']")?;
     anyhow::ensure!(
-        stored == serde_json::json!("espresso-dark"),
-        "expected localStorage['alm.theme']=\"espresso-dark\" to be written on click, got {stored:?}"
+        stored == serde_json::json!("observatory-dark"),
+        "expected localStorage['alm.theme']=\"observatory-dark\" to be written on click, got {stored:?}"
     );
 
     // The settings DB write-through (theme-settings-db) is fire-and-forget,
@@ -228,14 +232,14 @@ async fn settings_ui_theme_applies_live_and_persists_to_settings_db() -> anyhow:
             "settings_get",
             json!({ "scope": "general" }),
             UI_TIMEOUT,
-            |v: &serde_json::Value| v["values"]["theme"] == json!("espresso-dark"),
+            |v: &serde_json::Value| v["values"]["theme"] == json!("observatory-dark"),
         )
         .await
         .map_err(|e| {
             anyhow::anyhow!("expected the theme choice to persist to the settings DB: {e}")
         })?;
     anyhow::ensure!(
-        settings["values"]["theme"] == json!("espresso-dark"),
+        settings["values"]["theme"] == json!("observatory-dark"),
         "unexpected persisted settings.theme: {settings}"
     );
 

--- a/tests/e2e/settings_appearance_i18n.spec.ts
+++ b/tests/e2e/settings_appearance_i18n.spec.ts
@@ -141,11 +141,24 @@ test.describe('Journey 10 · Settings configuration model (spec 018)', () => {
 
 // ── Scenario 2 — Appearance / 4 themes (spec 043) ───────────────────────────
 
-const THEME_CASES: { name: string; dataTheme: string }[] = [
-  { name: 'Warm Clay', dataTheme: 'warm-clay' },
-  { name: 'Warm Slate', dataTheme: 'warm-slate' },
-  { name: 'Observatory', dataTheme: 'observatory-dark' },
-  { name: 'Espresso', dataTheme: 'espresso-dark' },
+// Handoff 03 (design refresh): the picker now shows only the 4 canonical
+// themes (2 warm + 2 cool families) — Warm Clay/Espresso Dark are disabled
+// (registry-only) variants, hidden from the picker DOM entirely
+// (apps/desktop/src/features/settings/General.tsx WARM_CHOICES/COOL_CHOICES).
+// Swatch buttons' accessible name concatenates the theme-name span and the
+// mode span with no guaranteed literal space between them (differs slightly
+// between jsdom/testing-library and a real Chromium AX tree) — every case
+// below is a RegExp with an optional `\s*` at the join point so it matches
+// either rendering, anchored so e.g. "Observatory" (warm, dark) can't
+// accidentally match "Observatory Cool" (cool, dark/light).
+const THEME_CASES: { name: RegExp; dataTheme: string }[] = [
+  { name: /^Warm Slate\s*light$/i, dataTheme: 'warm-slate' },
+  { name: /^Observatory\s*dark$/i, dataTheme: 'observatory-dark' },
+  {
+    name: /^Observatory Cool · Light\s*light$/i,
+    dataTheme: 'observatory-cool-light',
+  },
+  { name: /^Observatory Cool\s*dark$/i, dataTheme: 'observatory-cool' },
 ];
 
 test.describe('Journey 10 · Appearance / 4 themes (spec 043)', () => {
@@ -156,13 +169,13 @@ test.describe('Journey 10 · Appearance / 4 themes (spec 043)', () => {
     await page.goto('/#/settings/general');
     await expect(page.getByText('Theme', { exact: true })).toBeVisible();
 
-    // System + 4 named themes = 5 swatch cards.
+    // System + the 4 canonical (warm × 2, cool × 2) themes = 5 swatch cards.
+    // Warm Clay/Espresso Dark stay in the registry (still resolve/persist if
+    // already chosen — see theme.persistence.test.ts) but no longer render.
     const swatches = page.locator('.pv-theme-swatch');
     await expect(swatches).toHaveCount(5);
 
     for (const theme of THEME_CASES) {
-      // Swatch buttons' accessible name is "<Theme name> <mode>" (e.g. "Warm
-      // Clay Light"); match by the brand-name substring (not exact).
       await page.getByRole('button', { name: theme.name }).click();
       // The appearance runtime writes data-theme on the document root.
       await expect(page.locator('html')).toHaveAttribute(
@@ -182,10 +195,15 @@ test.describe('Journey 10 · Appearance / 4 themes (spec 043)', () => {
   }) => {
     seedSetupComplete(page);
     await page.goto('/#/settings/general');
-    await page.getByRole('button', { name: 'Warm Clay' }).click();
+    // Warm Clay is a disabled (picker-hidden) variant as of handoff 03 —
+    // Observatory Cool (canonical, cool/dark) exercises the same non-default
+    // explicit-choice path.
+    await page
+      .getByRole('button', { name: /^Observatory Cool\s*dark$/i })
+      .click();
     await expect(page.locator('html')).toHaveAttribute(
       'data-theme',
-      'warm-clay',
+      'observatory-cool',
     );
 
     // #794 repro: switch theme, then navigate away — the choice must not
@@ -194,7 +212,7 @@ test.describe('Journey 10 · Appearance / 4 themes (spec 043)', () => {
     await expect(page.locator('.pv-sidebar')).toBeVisible();
     await expect(page.locator('html')).toHaveAttribute(
       'data-theme',
-      'warm-clay',
+      'observatory-cool',
     );
   });
 
@@ -203,17 +221,22 @@ test.describe('Journey 10 · Appearance / 4 themes (spec 043)', () => {
   }) => {
     seedSetupComplete(page);
     await page.goto('/#/settings/general');
-    await page.getByRole('button', { name: 'Espresso' }).click();
+    // Espresso Dark is a disabled (picker-hidden) variant as of handoff 03 —
+    // Observatory Cool · Light (canonical, cool/light) exercises the same
+    // reload-survival path.
+    await page
+      .getByRole('button', { name: 'Observatory Cool · Light' })
+      .click();
     await expect(page.locator('html')).toHaveAttribute(
       'data-theme',
-      'espresso-dark',
+      'observatory-cool-light',
     );
 
     await page.reload();
     // Boot-time initAppearance() re-applies the persisted theme before render.
     await expect(page.locator('html')).toHaveAttribute(
       'data-theme',
-      'espresso-dark',
+      'observatory-cool-light',
     );
   });
 });
@@ -463,10 +486,15 @@ test.describe('Journey 10 · Appearance Restore defaults (#802)', () => {
     await page.goto('/#/settings/general');
     await expect(page.getByText('Theme', { exact: true })).toBeVisible();
 
-    await page.getByRole('button', { name: 'Espresso' }).click();
+    // Espresso Dark is a disabled (picker-hidden) variant as of handoff 03 —
+    // Observatory Cool (canonical, cool/dark) exercises the same
+    // restore-to-System path.
+    await page
+      .getByRole('button', { name: /^Observatory Cool\s*dark$/i })
+      .click();
     await expect(page.locator('html')).toHaveAttribute(
       'data-theme',
-      'espresso-dark',
+      'observatory-cool',
     );
 
     await page


### PR DESCRIPTION
Ships the four canonical themes per approved design (handoff 03): two new cool-family [data-theme] blocks (observatory-cool, observatory-cool-light) copied verbatim from the design source (prefix-translated --alm- -> --pv- only, 33/33 raw tokens, AA-clean).

Theme registry gains enabled+family fields; Warm Clay + Espresso Dark are hidden from the Settings picker but fully retained (CSS, tests, persisted-choice resolution — a stored variant choice keeps working; re-enable is a one-line flag). Picker grouped Warm/Cool x light/dark reusing existing card styles; new i18n group labels. Defaults unchanged (warm-slate light / observatory-dark dark / system honored).

Completeness + contrast CI now cover all six theme blocks. THEMES.md documents how to add a theme.

Note: the setup wizard's ThemeControl deliberately lists the full registry (#504) and is unchanged — only its test's expected list grew.

Closes #1139