### PR TITLE
docs: record the load-state race sweep method and gate its silent failure mode

### DIFF
--- a/apps/desktop/eslint-rules/no-vacuous-waitfor.d.ts
+++ b/apps/desktop/eslint-rules/no-vacuous-waitfor.d.ts
@@ -1,0 +1,9 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+// Minimal ambient types for the local ESLint plugin so the rule's vitest test
+// (src/lib/no-vacuous-waitfor.rule.test.ts) type-checks. The rule itself is
+// plain ESLint JS; ESLint consumes it untyped at lint time.
+import type { ESLint } from 'eslint';
+declare const plugin: ESLint.Plugin;
+export default plugin;

--- a/apps/desktop/eslint-rules/no-vacuous-waitfor.js
+++ b/apps/desktop/eslint-rules/no-vacuous-waitfor.js
@@ -1,0 +1,149 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * ESLint rule: alm/no-vacuous-waitfor (issue #1136, from the #1083 sweep).
+ *
+ * Flags negated mock-call assertions inside a `waitFor` callback.
+ *
+ * Mock call counts are monotonically non-decreasing: once a mock has been
+ * called it never becomes un-called. So a NEGATED call assertion is either
+ * already true on `waitFor`'s first attempt — which returns immediately,
+ * asserting nothing — or already false and never able to recover. Either way
+ * the wrapper cannot do the job it looks like it is doing, and it silently
+ * converts a real regression test into a no-op.
+ *
+ * This is the shape a naive "fix the flake by wrapping it in waitFor" edit
+ * introduces. Two real examples the sweep deliberately left synchronous:
+ * `AuditLog.test.tsx` asserts a keystroke did NOT trigger an immediate IPC
+ * round-trip, and `SchemaViewer.callVersion.test.tsx` guards against an extra
+ * re-fetch. Wrapping either would have destroyed exactly the guarantee under
+ * test while still going green.
+ *
+ * NOT flagged, because they are legitimate and monotonic — the awaited
+ * condition becomes true as calls arrive:
+ *   await waitFor(() => expect(mock).toHaveBeenCalledTimes(1));
+ *   await waitFor(() => expect(mock).toHaveBeenCalledWith({ to: '/setup' }));
+ * The second is the actual fix applied in PR #1128 (`SetupWizard.test.tsx`),
+ * so a rule that banned call-count matchers outright would reject the fix.
+ *
+ * Negated DOM assertions such as `expect(el).not.toBeInTheDocument()` are also
+ * NOT flagged: the DOM is not monotonic, and waiting for removal is the
+ * documented Testing Library idiom.
+ */
+
+/**
+ * Mock/spy matchers whose subject only ever accumulates. Negating any of them
+ * yields a condition that `waitFor` cannot meaningfully poll for.
+ */
+const MONOTONIC_CALL_MATCHERS = new Set([
+  'toHaveBeenCalled',
+  'toHaveBeenCalledOnce',
+  'toHaveBeenCalledTimes',
+  'toHaveBeenCalledWith',
+  'toHaveBeenLastCalledWith',
+  'toHaveBeenNthCalledWith',
+  'toHaveReturned',
+  'toHaveReturnedTimes',
+  'toHaveReturnedWith',
+]);
+
+/** `waitFor(cb)` and `vi.waitFor(cb)` / `screen.waitFor(cb)` alike. */
+function isWaitForCall(node) {
+  if (node.type !== 'CallExpression') return false;
+  const { callee } = node;
+  if (callee.type === 'Identifier') return callee.name === 'waitFor';
+  return (
+    callee.type === 'MemberExpression' &&
+    callee.property.type === 'Identifier' &&
+    callee.property.name === 'waitFor'
+  );
+}
+
+/**
+ * True when `node` is a matcher chain rooted at `expect(...)` that passes
+ * through a `.not` modifier. Walking the chain (rather than checking the
+ * immediate parent) keeps `.resolves.not.` and `.not.resolves.` working.
+ */
+function isNegatedExpectChain(node) {
+  let current = node;
+  let negated = false;
+  while (current.type === 'MemberExpression') {
+    if (
+      current.property.type === 'Identifier' &&
+      current.property.name === 'not'
+    ) {
+      negated = true;
+    }
+    current = current.object;
+  }
+  return (
+    negated &&
+    current.type === 'CallExpression' &&
+    current.callee.type === 'Identifier' &&
+    current.callee.name === 'expect'
+  );
+}
+
+/**
+ * The real containment check. Returns the enclosing `waitFor` call only when
+ * `node` sits inside its CALLBACK argument, not merely near it in the source.
+ * Line-proximity matching is what produced 11 of 14 false positives in the
+ * original #1083 sweep (issue #1136).
+ */
+function enclosingWaitForCallback(ancestors, node) {
+  for (let i = 0; i < ancestors.length; i += 1) {
+    const ancestor = ancestors[i];
+    if (!isWaitForCall(ancestor)) continue;
+    const childOnPath = i + 1 < ancestors.length ? ancestors[i + 1] : node;
+    if (ancestor.arguments[0] === childOnPath) return ancestor;
+  }
+  return undefined;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow negated mock-call assertions inside a waitFor callback, which pass vacuously on the first attempt.',
+    },
+    schema: [],
+    messages: {
+      vacuous:
+        '`expect(...).not.{{matcher}}()` inside `waitFor` asserts nothing: call counts only increase, so this passes on the first attempt. Assert it synchronously instead, after awaiting whatever observable proves the work is done. See docs/development/testing.md.',
+    },
+  },
+
+  create(context) {
+    return {
+      CallExpression(node) {
+        const { callee } = node;
+        if (
+          callee.type !== 'MemberExpression' ||
+          callee.property.type !== 'Identifier' ||
+          !MONOTONIC_CALL_MATCHERS.has(callee.property.name)
+        ) {
+          return;
+        }
+        if (!isNegatedExpectChain(callee.object)) return;
+
+        const ancestors = context.sourceCode.getAncestors(node);
+        if (!enclosingWaitForCallback(ancestors, node)) return;
+
+        context.report({
+          node,
+          messageId: 'vacuous',
+          data: { matcher: callee.property.name },
+        });
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    'no-vacuous-waitfor': rule,
+  },
+};

--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -6,14 +6,16 @@ import tseslint from 'typescript-eslint';
 import reactHooks from 'eslint-plugin-react-hooks';
 import jsxA11y from 'eslint-plugin-jsx-a11y';
 import alm from './eslint-rules/no-user-string.js';
+import noVacuousWaitFor from './eslint-rules/no-vacuous-waitfor.js';
 
 // ESLint is the SECOND lint layer, after Biome (`pnpm lint` runs
 // `biome check` first). Biome owns the syntactic layer (core JS recommended +
 // non-type-aware TS rules — see biome.json); ESLint keeps ONLY the gates Biome
 // cannot replicate:
 //
-//   1. `alm/*` custom rules (the spec-046 i18n catalog gate) — Biome has no
-//      custom JS plugin rules.
+//   1. `alm/*` custom rules (the spec-046 i18n catalog gate and the
+//      no-vacuous-waitfor test-hygiene gate) — Biome has no custom JS plugin
+//      rules.
 //   2. Type-aware @typescript-eslint rules (recommendedTypeCheckedOnly) —
 //      Biome has no type-aware linting.
 //   3. eslint-plugin-react-hooks v7 — its React-compiler-derived rules
@@ -49,7 +51,9 @@ export default tseslint.config(
   // ENFORCED on migrated areas (I18N_MIGRATED), so it can be rolled out wave by
   // wave without turning the whole tree red at once.
   {
-    plugins: { alm },
+    plugins: {
+      alm: { rules: { ...alm.rules, ...noVacuousWaitFor.rules } },
+    },
   },
   {
     files: I18N_MIGRATED,
@@ -159,7 +163,14 @@ export default tseslint.config(
   // Off for tests; it stays on for app source.
   {
     files: ['**/*.test.{ts,tsx}', '**/*.spec.{ts,tsx}'],
-    rules: { '@typescript-eslint/no-unnecessary-type-assertion': 'off' },
+    rules: {
+      '@typescript-eslint/no-unnecessary-type-assertion': 'off',
+      // A negated mock-call assertion inside `waitFor` passes on the first
+      // attempt and asserts nothing — the silent no-op a naive "wrap the flake
+      // in waitFor" fix introduces. See the rule's header and
+      // docs/development/testing.md (issue #1136).
+      'alm/no-vacuous-waitfor': 'error',
+    },
   },
 
   // Scope: only lint app source (not generated bindings, not archived src)

--- a/apps/desktop/src/lib/no-vacuous-waitfor.rule.test.ts
+++ b/apps/desktop/src/lib/no-vacuous-waitfor.rule.test.ts
@@ -1,0 +1,106 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, expect } from 'vitest';
+import { Linter } from 'eslint';
+// The local ESLint rule guarding against vacuous waitFor wrappers (issue #1136).
+import plugin from '../../eslint-rules/no-vacuous-waitfor.js';
+
+function lint(code: string) {
+  const linter = new Linter();
+  return linter
+    .verify(code, {
+      plugins: { alm: plugin },
+      languageOptions: {
+        parserOptions: {
+          ecmaFeatures: { jsx: true },
+          ecmaVersion: 'latest',
+          sourceType: 'module',
+        },
+      },
+      rules: { 'alm/no-vacuous-waitfor': 'error' },
+    })
+    .filter((m) => m.ruleId === 'alm/no-vacuous-waitfor');
+}
+
+describe('alm/no-vacuous-waitfor', () => {
+  it('flags negated mock-call assertions inside a waitFor callback', () => {
+    expect(
+      lint('await waitFor(() => { expect(mockIpc).not.toHaveBeenCalled(); });'),
+    ).toHaveLength(1);
+    expect(
+      lint('await waitFor(() => expect(m).not.toHaveBeenCalledWith(1));'),
+    ).toHaveLength(1);
+    expect(
+      lint('await waitFor(() => expect(m).not.toHaveBeenCalledTimes(2));'),
+    ).toHaveLength(1);
+    // Buried among sibling assertions in a block body.
+    expect(
+      lint(
+        'await waitFor(() => { expect(a).toBeTruthy(); expect(m).not.toHaveBeenCalled(); });',
+      ),
+    ).toHaveLength(1);
+    // `vi.waitFor` is the same trap.
+    expect(
+      lint('await vi.waitFor(() => expect(m).not.toHaveBeenCalled());'),
+    ).toHaveLength(1);
+  });
+
+  it('leaves the correct fixes from PR #1128 alone', () => {
+    // Waiting for a call to ARRIVE is monotonic and legitimate. A rule that
+    // banned call-count matchers outright would reject the real fix.
+    expect(
+      lint(
+        'await waitFor(() => expect(mockFirstrunComplete).toHaveBeenCalledTimes(1));',
+      ),
+    ).toHaveLength(0);
+    expect(
+      lint(
+        "await waitFor(() => { expect(mockNavigate).toHaveBeenCalledWith({ to: '/setup' }); });",
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('leaves correctly-synchronous negative assertions alone', () => {
+    // The AuditLog/SchemaViewer shape: the guarantee is "no extra call ever
+    // arrives", asserted synchronously after an unrelated await. Outside the
+    // callback, so not vacuous.
+    expect(
+      lint(
+        'await waitFor(() => expect(x).toBeTruthy());\nexpect(mockIpc).not.toHaveBeenCalled();',
+      ),
+    ).toHaveLength(0);
+  });
+
+  it('does not flag negated DOM assertions, which are not monotonic', () => {
+    expect(
+      lint('await waitFor(() => { expect(el).not.toBeInTheDocument(); });'),
+    ).toHaveLength(0);
+  });
+
+  it('requires real containment, not line proximity', () => {
+    // The defect that produced 11 of 14 false positives in the original sweep:
+    // a matcher whose own `waitFor(` merely sits on a nearby line.
+    expect(
+      lint(
+        'await waitFor(() =>\n  expect(mockX).toHaveBeenCalledWith({ id: 1 }),\n);',
+      ),
+    ).toHaveLength(0);
+    // A negated assertion AFTER the waitFor block, not inside it.
+    expect(
+      lint(
+        'await waitFor(() => {\n  expect(a).toBeTruthy();\n});\nexpect(m).not.toHaveBeenCalled();',
+      ),
+    ).toHaveLength(0);
+    // A negated assertion inside a callback passed to something else entirely.
+    expect(
+      lint('act(() => { expect(m).not.toHaveBeenCalled(); });'),
+    ).toHaveLength(0);
+  });
+
+  it('ignores negated chains that are not rooted at expect()', () => {
+    expect(
+      lint('await waitFor(() => { assert(m).not.toHaveBeenCalled(); });'),
+    ).toHaveLength(0);
+  });
+});

--- a/docs/development/testing.md
+++ b/docs/development/testing.md
@@ -102,3 +102,100 @@ New features **ship with real-stack coverage**:
 
 Tests that touch the filesystem MUST use `tempfile::tempdir()` — never real user
 libraries. Tests covering destructive operations assert the audit record.
+
+## Diagnosing load-state races in component tests
+
+This section is the durable record of the #1083 sweep (#1095, #1109, #1118,
+#1128). Read it before hunting async flakes again — the sweep's main output was
+learning which methods do *not* work.
+
+### Do not classify by pattern
+
+The sweep's candidate list came from grepping for "a `waitFor(...)` block
+followed by a synchronous `expect(someMock).toHaveBeenCalled…`". **4 of 31
+candidates were real races.** Two independent reasons the textual pattern fails:
+
+- It cannot see containment. The original scanner matched on *line proximity*
+  and never checked whether the `expect` was inside the `waitFor` callback, so
+  it flagged 11 already-correct `await waitFor(() => expect(...))` calls whose
+  own opening `waitFor(` happened to sit one line up.
+- Even with containment fixed, the shape is not the signal. The remaining
+  candidates were still overwhelmingly false positives, because whether a test
+  races is a question about the *component*, not the assertion.
+
+No scanner is committed for this, deliberately. The discriminator below is
+semantic and not statically decidable, so a candidate-list generator mostly
+manufactures triage cost. (`ast-grep` would fix the containment defect but not
+the underlying imprecision, and it is not a dependency of this repo.)
+
+### The actual discriminator
+
+**Does a React effect or an `await` sit between the trigger and the
+observable?**
+
+- The component calls the mock straight from a click handler → it cannot race.
+  Classifiable by reading alone; skip it.
+- The assertion targets work scheduled *after* a render commit (`useEffect`, a
+  `.then()`, a state-triggered fetch) → genuine candidate.
+
+`LogPanel.crosslink` was 0 for 4 on exactly this point: `void navigate({...})`
+discards the returned promise, but the call itself is synchronous.
+
+### Confirm empirically, with a positive control
+
+Inject a ~120 ms delay into the relevant mock's *resolution* — keeping the call
+itself synchronous — or make it never resolve, then run the test:
+
+- fails under delay → genuine race; fix it
+- still passes → false positive; leave it completely alone
+
+**A suite that passes under hanging mocks is indistinguishable from a suite
+that never ran.** Validate the instrumentation before trusting a negative
+result: deliberately break one assertion (swap an expected route for a bogus
+value) and confirm it fails. Both null-result lanes in the sweep did this.
+
+Triage the assertion *block*, not the matched line. In 2 of the 3 real races,
+the flagged line was a synchronous handler call (safe) and the racing assertion
+was the next one.
+
+### `waitFor` is the wrong fix for "must never happen"
+
+`waitFor` retries until the callback stops throwing, so it only ever proves
+**"the call hasn't arrived *yet*"**. Mock call counts never decrease, so a
+*negated* call assertion inside a `waitFor` callback is satisfied on the first
+attempt and asserts nothing — silently converting a regression test into a
+no-op:
+
+```ts
+// WRONG — passes immediately, proves nothing
+await waitFor(() => expect(mockIpc).not.toHaveBeenCalled());
+
+// RIGHT — await the observable that proves the work is done, then assert
+await waitFor(() => expect(screen.getByRole('status')).toBeVisible());
+expect(mockIpc).not.toHaveBeenCalled();
+```
+
+`AuditLog.test.tsx` (a keystroke must not trigger an immediate IPC round-trip)
+and `SchemaViewer.callVersion.test.tsx` (no extra re-fetch) are both correctly
+synchronous for this reason. The `alm/no-vacuous-waitfor` ESLint rule
+(`apps/desktop/eslint-rules/no-vacuous-waitfor.js`) enforces this, since the
+failure mode is silent and green. Waiting for a call to *arrive*
+(`await waitFor(() => expect(m).toHaveBeenCalledTimes(1))`) is monotonic,
+legitimate, and not flagged.
+
+### Element-exists vs value-changed
+
+Where an element renders unconditionally and only its **value** arrives late,
+`findByLabelText` does *not* fix the race — it resolves immediately against the
+pre-hydration element. Use a value-aware query, e.g.
+`findByRole('checkbox', { name, checked: true })`. That was the #1109 lesson,
+and the #1128 `SourceProtectionOverride` fix is the same shape: it had to gate
+on the editor's select *disappearing*, because the two nearby queries both
+matched something present from first render.
+
+### Sweep residue
+
+The sweep covered `apps/desktop/src/{app,ui,dev,features/{settings,setup,targets,projects,inbox,archive,plans}}`.
+Every other directory is unswept. Given the 4-in-31 hit rate and the triage cost
+per real bug, a broad rescan is not worth running; investigate a specific
+observed flake instead.


### PR DESCRIPTION
Closes #1136.

## What I landed, and why not a scanner

The issue asks for two things: fix the defective race-triage scanner, and record the sweep method + residue. I landed the record, plus a lint rule for the one part of this that a machine can actually decide — and deliberately **did not** commit a fixed scanner.

**Why no scanner.** The containment defect is real (the original matched `expect` to `waitFor` by line proximity, which produced 11 of 14 false positives in one lane), but fixing it only removes part of the noise. It would still have been 4 real in ~20. Whether a test races depends on *whether an effect or an await sits between the trigger and the observable* — a property of the component, not a shape in the test file. That is not statically decidable, so a candidate-list generator for it mostly manufactures triage cost. Committing an unmaintained tool that still under- and over-matches is worse than committing none, especially against the issue's own conclusion that a broad rescan is not worth running.

Two supporting findings:
- The issue states `sg`/ast-grep "is already a repo tool". It is not — `/bin/sg` on this machine is util-linux `setgid`, and ast-grep appears nowhere in `package.json` or the `justfile`. So the suggested fix would also have meant a new dependency.
- ESLint with the typescript-eslint parser already runs over every test file in CI, and `apps/desktop/eslint-rules/` is an existing, maintained custom-rule extension point. No new dependency needed for the part that *is* decidable.

## The part that is decidable, and fails silently

Mock call counts never decrease. So a **negated** call assertion inside a `waitFor` callback is satisfied on the first attempt and asserts nothing:

```ts
// passes immediately, proves nothing
await waitFor(() => expect(mockIpc).not.toHaveBeenCalled());
```

This is exactly the shape a naive "fix the flake by wrapping it in `waitFor`" edit introduces, and it converts a real regression test into a no-op *while staying green* — documentation alone cannot catch it. The repo has 96 live `.not.toHaveBeenCalled` assertions, so the at-risk surface is real. `alm/no-vacuous-waitfor` rejects it, using the AST containment check the original scanner lacked.

Scoped tightly to the non-monotonic case:
- **Not** flagged: `await waitFor(() => expect(m).toHaveBeenCalledTimes(1))` — waiting for a call to *arrive* is legitimate, and this is the actual fix applied to `SetupWizard.test.tsx` in #1128. A rule banning call-count matchers outright would have rejected the fix.
- **Not** flagged: `expect(el).not.toBeInTheDocument()` — the DOM is not monotonic; waiting for removal is the documented idiom.

## Ground-truth verification

Applying the issue's own lesson — *validate the instrumentation or the negative result is worthless* — I ran a positive control rather than just reporting a clean scan.

Whole-corpus run (223 test files):
```
files scanned: 223
violations: 0
```

Controls (`PASS` = rule behaved as required):
```
PASS  hits=1  POSITIVE control — vacuous (must flag)
PASS  hits=1  POSITIVE — negated withArgs in block body (must flag)
PASS  hits=0  NEGATIVE — the actual PR #1128 SetupWizard fix (must NOT flag)
PASS  hits=0  NEGATIVE — the actual PR #1128 Advanced fix (must NOT flag)
PASS  hits=0  NEGATIVE — correctly-synchronous debounce guard, AuditLog shape (must NOT flag)
PASS  hits=0  NEGATIVE — waiting for DOM removal (must NOT flag)
PASS  hits=0  NEGATIVE — the FALSE-POSITIVE shape the old scanner matched (must NOT flag)
```

Against the three genuinely racy files **as they existed on main before #1128** (`git show 038781e2:<file>`):
```
pre-#1128 Advanced.test.tsx: 0 hit(s)
pre-#1128 SetupWizard.test.tsx: 0 hit(s)
pre-#1128 SourceProtectionOverride.test.tsx: 0 hit(s)
```

**This is the intended result, and I want to be explicit about it:** the rule does not detect races and is not a scanner replacement. It guards the inverse defect — the vacuous "fix". The race-detection knowledge is recorded as method in `docs/development/testing.md`, because that is the form it can actually survive in.

## Documentation

New section in `docs/development/testing.md` (the existing home for test strategy), covering: why pattern-classification fails, the real discriminator, the delay-injection method with its mandatory positive control, why `waitFor` is wrong for "must never happen", the element-exists vs value-changed lesson from #1109, and the unswept residue.

## Gates

- ESLint gate: `eslint: OK (474 files linted; 3 baselined alm/* violation(s) grandfathered)`.
- New rule test: 6/6 pass (`src/lib/no-vacuous-waitfor.rule.test.ts`).
- Biome: my files clean. `biome check .` fails on **main** too (14 pre-existing findings in 6 files); verified via stash/unstash two-direction control that this branch adds **zero**.
- `tsc --noEmit`: only a pre-existing `tsconfig.json` `baseUrl` deprecation, untouched here.