### PR TITLE
ci: typecheck the end-to-end suite, which resolution silently excluded

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest",
     "test:e2e": "playwright test",
     "test:e2e:real": "bash scripts/run-e2e-real.sh",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsc --noEmit && tsc -p tsconfig.e2e.json --noEmit",
     "lint": "biome check . && node ../../scripts/check-eslint-baseline.mjs && bash ../../scripts/check-tokens.sh && node ../../scripts/check-i18n-catalog.mjs",
     "lint:biome": "biome check .",
     "lint:eslint": "node ../../scripts/check-eslint-baseline.mjs",

--- a/apps/desktop/tsconfig.e2e.json
+++ b/apps/desktop/tsconfig.e2e.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["@playwright/test"],
+    "paths": {
+      "@/*": ["./src/*"],
+      "@playwright/test": ["./node_modules/@playwright/test"]
+    }
+  },
+  "include": ["../../tests/e2e/**/*.ts"]
+}


### PR DESCRIPTION
Closes #1167 — the deferred half of the `tests/e2e` gate work started in #1166.

## The trap this avoids

The obvious fix is to add `tests/**` to the root `tsconfig.json` include. That would have been **theatre**: nothing runs the root config. CI runs `pnpm -r --if-present typecheck`, which iterates workspace packages (`apps/*`, `packages/*`) — the repo root is not one. Same failure mode as the `lint:tests` plan in #1166, which was caught for the same reason.

So the config lives in `apps/desktop`, whose `typecheck` script CI already runs, and which already owns `@playwright/test` and `playwright.config.ts` (whose `testDir` is `<repoRoot>/tests/e2e`). No new CI step needed.

## Why the `paths` mapping is load-bearing

A plain `include: ["../../tests/e2e/**"]` still fails. TypeScript resolves `node_modules` from the **importing file's** directory, so specs under `tests/e2e` cannot see `@playwright/test` installed in `apps/desktop/node_modules`. Every spec reported `TS2307`, which cascaded into ~50 spurious `TS7031`/`TS7006` implicit-`any` errors. Those were symptoms, not real findings — the `paths` entry pins the module to the installed copy and they all vanish.

## Result

With resolution fixed the suite typechecks **clean**. No spec changes are in this PR because none are needed — the gate simply could never run.

## Verification (non-vacuous, both directions)

- `tsc --listFiles` reports **25** spec files in the program — matching the 25 files biome checks, so nothing is silently skipped.
- Injecting `const __probe: number = "not a number"` into a spec fails the **exact CI command** `pnpm -r --if-present typecheck` with `TS2322` and exit 2.
- Removing it returns exit 0.

## Note for the reviewer

While verifying I hit a local `tsc` failure in `theme.tokens-drift.test.ts` (`node:path` / `process` unresolved) that looked like a red `main`. It was **not** — `@types/node` is declared in `apps/desktop/package.json` but was missing from my stale `node_modules`. `pnpm install` resolved it. `main` is fine; flagging only so the next person doesn't chase it.