### PR TITLE
fix: detail panel content is no longer cut off and unreachable

### DIFF
--- a/apps/desktop/src/components/DetailPanel.test.tsx
+++ b/apps/desktop/src/components/DetailPanel.test.tsx
@@ -132,49 +132,56 @@ describe('DetailPanel — tasks #100/#99/#101', () => {
     ).not.toThrow();
   });
 
-  it('10. facts prop: renders facts content', () => {
-    render(
-      <DetailPanel
-        title="NGC 7000"
-        facts={<span data-testid="facts-content">Facts KV here</span>}
-      >
+  // ── The scroll-region contract (#1107) ────────────────────────────────────
+  //
+  // These replace the old facts/aux slot tests. Those slots were withdrawn
+  // (spec 054): no caller ever passed one, so the wrapper they gated — the
+  // panel's ONLY scroll region — was never rendered in production and content
+  // overflowing a docked panel became unreachable. The tests passed anyway,
+  // because they exercised a code path the app never took. Pin the real
+  // contract instead: the content region is ALWAYS present.
+
+  it('10. always renders the content region, with no slots passed', () => {
+    const { container } = render(
+      <DetailPanel title="NGC 7000">
         <span data-testid="content-body">Content here</span>
       </DetailPanel>,
     );
-    expect(screen.getByTestId('facts-content')).toBeDefined();
-    expect(screen.getByTestId('content-body')).toBeDefined();
+    const content = container.querySelector('.pv-detailpanel__content');
+    expect(content).not.toBeNull();
+    expect(
+      content?.contains(container.querySelector('[data-testid="content-body"]')),
+    ).toBe(true);
   });
 
-  it('11. facts prop: facts column and children column are in separate DOM regions', () => {
+  it('11. the content region wraps children — it is not bypassed (#1107)', () => {
+    // The regression this pins: children rendered as a bare sibling of the
+    // header, with nothing establishing overflow, so the ancestor
+    // .pv-listpage__detail-body (overflow:hidden) silently clipped them.
     const { container } = render(
-      <DetailPanel
-        title="NGC 7000"
-        facts={<span data-testid="facts-node">Facts</span>}
-      >
+      <DetailPanel title="NGC 7000">
         <span data-testid="content-node">Content</span>
       </DetailPanel>,
     );
-    const factsEl = container.querySelector('[data-testid="facts-node"]');
-    const contentEl = container.querySelector('[data-testid="content-node"]');
-    expect(factsEl).not.toBeNull();
-    expect(contentEl).not.toBeNull();
-    // The cols wrapper must be present.
-    const cols = container.querySelector('.pv-detailpanel__cols');
-    expect(cols).not.toBeNull();
-    // Facts must be inside the facts aside; content must NOT be inside it.
-    const factsAside = container.querySelector('.pv-detailpanel__facts');
-    expect(factsAside).not.toBeNull();
-    expect(factsAside?.contains(factsEl)).toBe(true);
-    expect(factsAside?.contains(contentEl)).toBe(false);
+    const node = container.querySelector('[data-testid="content-node"]');
+    const content = container.querySelector('.pv-detailpanel__content');
+    expect(node).not.toBeNull();
+    expect(content?.contains(node)).toBe(true);
+    // Exactly one content region — a second would mean nested scrollbars.
+    expect(container.querySelectorAll('.pv-detailpanel__content')).toHaveLength(
+      1,
+    );
   });
 
-  it('12. without facts or aux prop, no cols wrapper is rendered', () => {
+  it('12. the withdrawn facts/aux grid is gone (#1107)', () => {
     const { container } = render(
       <DetailPanel title="NGC 7000">
         <span>just children</span>
       </DetailPanel>,
     );
     expect(container.querySelector('.pv-detailpanel__cols')).toBeNull();
+    expect(container.querySelector('.pv-detailpanel__facts')).toBeNull();
+    expect(container.querySelector('.pv-detailpanel__aux')).toBeNull();
     expect(screen.getByText('just children')).toBeDefined();
   });
 
@@ -188,99 +195,26 @@ describe('DetailPanel — tasks #100/#99/#101', () => {
     ).not.toThrow();
   });
 
-  it('16. aux prop: renders aux content', () => {
-    render(
-      <DetailPanel
-        title="NGC 7000"
-        aux={<span data-testid="aux-content">Aux here</span>}
-      >
-        <span data-testid="content-body">Content here</span>
-      </DetailPanel>,
-    );
-    expect(screen.getByTestId('aux-content')).toBeDefined();
-    expect(screen.getByTestId('content-body')).toBeDefined();
-  });
-
-  it('17. aux prop: aux column is structurally separate from content', () => {
+  it('16. variant modifier lands on the content region', () => {
     const { container } = render(
-      <DetailPanel
-        title="NGC 7000"
-        aux={<span data-testid="aux-node">Aux</span>}
-      >
+      <DetailPanel title="NGC 7000" variant="inbox">
         <span data-testid="content-node">Content</span>
       </DetailPanel>,
     );
-    const auxEl = container.querySelector('[data-testid="aux-node"]');
-    const contentEl = container.querySelector('[data-testid="content-node"]');
-    expect(auxEl).not.toBeNull();
-    expect(contentEl).not.toBeNull();
-    // The cols wrapper and aux aside must be present.
-    const cols = container.querySelector('.pv-detailpanel__cols');
-    expect(cols).not.toBeNull();
-    const auxAside = container.querySelector('.pv-detailpanel__aux');
-    expect(auxAside).not.toBeNull();
-    expect(auxAside?.contains(auxEl)).toBe(true);
-    // Content must NOT be inside the aux aside.
-    expect(auxAside?.contains(contentEl)).toBe(false);
+    const content = container.querySelector('.pv-detailpanel__content');
+    expect(content?.classList.contains('pv-detailpanel--inbox')).toBe(true);
   });
 
-  it('18. aux only (no facts): renders cols wrapper with has-aux modifier', () => {
+  it('17. fill mode still renders exactly one content region', () => {
     const { container } = render(
-      <DetailPanel
-        title="NGC 7000"
-        aux={<span data-testid="aux-node">Aux</span>}
-      >
+      <DetailPanel fill title="NGC 7000">
         <span data-testid="content-node">Content</span>
       </DetailPanel>,
     );
-    const cols = container.querySelector('.pv-detailpanel__cols');
-    expect(cols).not.toBeNull();
-    expect(cols?.classList.contains('pv-detailpanel--has-aux')).toBe(true);
-    expect(cols?.classList.contains('pv-detailpanel--has-facts')).toBe(false);
-  });
-
-  it('19. 3-zone: facts + children + aux are all in separate DOM regions', () => {
-    const { container } = render(
-      <DetailPanel
-        title="NGC 7000"
-        facts={<span data-testid="facts-node">Facts</span>}
-        aux={<span data-testid="aux-node">Aux</span>}
-      >
-        <span data-testid="content-node">Content</span>
-      </DetailPanel>,
+    expect(container.querySelector('.pv-detail--fill')).not.toBeNull();
+    expect(container.querySelectorAll('.pv-detailpanel__content')).toHaveLength(
+      1,
     );
-    const factsEl = container.querySelector('[data-testid="facts-node"]');
-    const contentEl = container.querySelector('[data-testid="content-node"]');
-    const auxEl = container.querySelector('[data-testid="aux-node"]');
-    expect(factsEl).not.toBeNull();
-    expect(contentEl).not.toBeNull();
-    expect(auxEl).not.toBeNull();
-
-    const factsAside = container.querySelector('.pv-detailpanel__facts');
-    const contentDiv = container.querySelector('.pv-detailpanel__content');
-    const auxAside = container.querySelector('.pv-detailpanel__aux');
-
-    expect(factsAside).not.toBeNull();
-    expect(contentDiv).not.toBeNull();
-    expect(auxAside).not.toBeNull();
-
-    // Each node is in exactly its own region.
-    expect(factsAside?.contains(factsEl)).toBe(true);
-    expect(factsAside?.contains(contentEl)).toBe(false);
-    expect(factsAside?.contains(auxEl)).toBe(false);
-
-    expect(contentDiv?.contains(contentEl)).toBe(true);
-    expect(contentDiv?.contains(factsEl)).toBe(false);
-    expect(contentDiv?.contains(auxEl)).toBe(false);
-
-    expect(auxAside?.contains(auxEl)).toBe(true);
-    expect(auxAside?.contains(factsEl)).toBe(false);
-    expect(auxAside?.contains(contentEl)).toBe(false);
-
-    // Both modifiers present.
-    const cols = container.querySelector('.pv-detailpanel__cols');
-    expect(cols?.classList.contains('pv-detailpanel--has-facts')).toBe(true);
-    expect(cols?.classList.contains('pv-detailpanel--has-aux')).toBe(true);
   });
 });
 
@@ -307,46 +241,54 @@ describe('FactsKV', () => {
   // ── Scroll-containment contract — the #816 regression pin (T004, #1069) ───
   //
   // #816 was "Target detail panel: aliases/notes/coverage/links/back-button
-  // silently clipped by DetailPane fill-mode overflow:hidden". The fix (#1035)
-  // is a CSS rule in redesign-detail.css:
+  // silently clipped by DetailPane fill-mode overflow:hidden". Its original fix
+  // was a DIRECT-CHILD CSS rule in redesign-detail.css:
   //
   //     .pv-detail--fill > .pv-planner__scroll { flex:1; min-height:0; overflow-y:auto }
   //
-  // That is a DIRECT-CHILD selector, which makes it a structural contract on
-  // DetailPanel rather than a mere stylesheet detail: nest the scroll wrapper
-  // one level deeper and the selector silently stops matching — no test fails,
-  // no type breaks, the content just starts getting clipped again.
+  // #1107 moved that contract OUT one level. The root cause of #816 was that
+  // DetailPanel rendered `children` as a bare sibling of the header with no
+  // scroll region, so each feature had to supply its own — Targets via
+  // .pv-planner__scroll, Inbox via .pv-inbox-detail__scroll. DetailPanel now
+  // always renders .pv-detailpanel__content and that region owns the scrolling
+  // for every page, so the per-feature rules were retired (keeping them would
+  // nest a second scroller inside the shared one).
   //
-  // This became load-bearing in #1067, when TargetDetailV2 migrated onto
-  // DetailPanel and deliberately kept content-only mode instead of the facts
-  // slot, precisely because facts nests children one level too deep.
+  // So the invariant is no longer "planner scroll is a direct child of fill",
+  // it is "SOME single region between the panel root and the content owns the
+  // scrolling". Pin that, and pin that it is exactly one.
   //
-  // jsdom has no layout engine, so these assert the STRUCTURAL contract the
-  // CSS depends on, not actual pixel scrolling.
+  // jsdom has no layout engine, so these assert the STRUCTURAL contract the CSS
+  // depends on, not actual pixel scrolling. Live measurement at a 390px side
+  // dock is in the #1107 PR: Calibration 191px, Sessions 522px, Projects 1216px
+  // of previously unreachable content, all 0 after.
 
-  it('19. content-only children stay direct children of .pv-detail--fill (#816)', () => {
+  it('19. fill-mode content is wrapped by the shared scroll region (#816 → #1107)', () => {
     const { container } = render(
       <DetailPanel fill title="Selected target">
         <div className="pv-planner__scroll">tall unstructured content</div>
       </DetailPanel>,
     );
-    // The exact selector redesign-detail.css relies on.
-    expect(
-      container.querySelector('.pv-detail--fill > .pv-planner__scroll'),
-    ).not.toBeNull();
+    const content = container.querySelector(
+      '.pv-detail--fill > .pv-detailpanel__content',
+    );
+    // The shared region is a direct child of the fill pane, so it inherits the
+    // bounded flex height the old direct-child rule depended on.
+    expect(content).not.toBeNull();
+    // The feature's own wrapper still exists, but now INSIDE that region.
+    expect(content?.querySelector('.pv-planner__scroll')).not.toBeNull();
   });
 
-  it('20. the facts slot does NOT satisfy that selector — why TargetDetailV2 avoids it', () => {
+  it('20. exactly one scroll region — no nested scrollbars (#1107)', () => {
     const { container } = render(
-      <DetailPanel fill title="Selected target" facts={<dl>identity</dl>}>
+      <DetailPanel fill title="Selected target">
         <div className="pv-planner__scroll">tall unstructured content</div>
       </DetailPanel>,
     );
-    // Present in the tree, but nested under .pv-detailpanel__content — the
-    // direct-child rule no longer applies and #816's clipping would return.
-    expect(container.querySelector('.pv-planner__scroll')).not.toBeNull();
-    expect(
-      container.querySelector('.pv-detail--fill > .pv-planner__scroll'),
-    ).toBeNull();
+    // Regression guard: reinstating a per-feature scroll rule alongside the
+    // shared one is what would produce double scrollbars.
+    expect(container.querySelectorAll('.pv-detailpanel__content')).toHaveLength(
+      1,
+    );
   });
 });

--- a/apps/desktop/src/components/DetailPanel.test.tsx
+++ b/apps/desktop/src/components/DetailPanel.test.tsx
@@ -150,7 +150,9 @@ describe('DetailPanel — tasks #100/#99/#101', () => {
     const content = container.querySelector('.pv-detailpanel__content');
     expect(content).not.toBeNull();
     expect(
-      content?.contains(container.querySelector('[data-testid="content-body"]')),
+      content?.contains(
+        container.querySelector('[data-testid="content-body"]'),
+      ),
     ).toBe(true);
   });
 

--- a/apps/desktop/src/components/DetailPanel.tsx
+++ b/apps/desktop/src/components/DetailPanel.tsx
@@ -11,25 +11,26 @@
  *     left  — title (item identity) + optional titleExtra (pills) +
  *              optional subtitle (one prose context line)
  *     right — actions (per-item buttons)
- *   BODY — up to 3 balanced zones when slots are provided:
- *     FACTS (left rail, BOUNDED): col `minmax(220px, 0.26fr)`.
- *       Dense identity KV. Does NOT scroll on its own.
- *       Omit to collapse to 2-zone or content-only.
- *     CONTENT (center, always present): `minmax(0, 1fr)`.
- *       The page's PRIMARY table/list. This is THE ONLY scroll region.
- *     AUX (right rail, BOUNDED, only when `aux` provided): col `minmax(240px, 0.30fr)`.
- *       Secondary blocks (review state, linked projects, usage stats).
- *
- * Grid template per slot combination:
- *   facts + children + aux  → 3-zone: [0.26fr]  [1fr]  [0.30fr]
- *   facts + children        → 2-zone: [0.26fr]  [1fr]
- *   children + aux          → 2-zone: [1fr]  [0.30fr]
- *   children only           → 1-zone: [1fr]   (no wrapper)
+ *   BODY — a single CONTENT region (`.pv-detailpanel__content`), ALWAYS
+ *     rendered. It is THE ONLY scroll region in the panel: the header stays
+ *     pinned and everything below it scrolls as one.
  *
  * Auto-expand behavior: the dock (.pv-listpage__detail) is height:fit-content
  * capped at clamp(220px, 40vh, 52vh). The dock DOES NOT scroll — only the
- * CONTENT column scrolls (overflow-y:auto, scrollbar-gutter:stable). Remove
+ * CONTENT region scrolls (overflow-y:auto, scrollbar-gutter:stable). Remove
  * any overflow on the outer detail-body to avoid double scrollbars.
+ *
+ * #1107 — why CONTENT is unconditional. This component used to render the
+ * content wrapper only when a `facts` or `aux` rail slot was passed. NO caller
+ * ever passed one — they existed solely in this component's own tests — so in
+ * production the wrapper was NEVER rendered and the "only scroll region" did
+ * not exist. Details fell back to the ancestor `.pv-listpage__detail-body`,
+ * which is `overflow:hidden`, making overflowing content unreachable rather
+ * than merely unscrolled. Three features hit this and each patched it locally
+ * (#553 Inbox, #816 Targets, #1107 Calibration) while Sessions (522px) and
+ * Projects (1216px) stayed silently broken at a 390px side dock. The rails are
+ * withdrawn (spec 054); this single region replaces all three local fixes.
+ * Do NOT make the wrapper conditional again.
  *
  * The close ✕ lives in ListPageLayout (onCloseDetail), NOT here — as does
  * Escape-to-close (#771/#906): ListPageLayout owns a document-level Escape
@@ -98,22 +99,10 @@ export interface DetailPanelProps {
   /** Per-item contextual action buttons (act on THIS item, not the page). */
   actions?: ReactNode;
   /**
-   * Left rail — identity KV. When provided the body renders with a bounded
-   * left column (minmax(220px, 0.26fr)). When omitted, content spans from left.
-   * Typically a <dl> of <FactsKV> rows, or a RailCard wrapping them.
-   */
-  facts?: ReactNode;
-  /**
-   * Center column — the page's PRIMARY table/list. Always present when any
-   * slot is provided. This is THE ONLY scroll region inside the panel body.
+   * Panel body — the page's PRIMARY table/list. Rendered inside
+   * `.pv-detailpanel__content`, THE ONLY scroll region inside the panel.
    */
   children?: ReactNode;
-  /**
-   * Right rail — secondary blocks (review state, linked projects, usage stats,
-   * FileInspector). When provided the body gains a bounded right column
-   * (minmax(240px, 0.30fr)). When omitted, content spans to the right edge.
-   */
-  aux?: ReactNode;
   /**
    * Modifier applied to the outer element. Used to scope density overrides
    * per feature (e.g. 'sessions', 'calibration', 'inbox').
@@ -133,30 +122,13 @@ export function DetailPanel({
   titleExtra,
   subtitle,
   actions,
-  facts,
   children,
-  aux,
   variant,
   fill,
 }: DetailPanelProps) {
-  const hasFacts = facts != null;
-  const hasAux = aux != null;
-  // Only render the grid wrapper when at least one rail slot is provided.
-  // content-only → no wrapper (children render directly, as before).
-  const hasSlots = hasFacts || hasAux;
-
-  // Build modifier classes for CSS grid-template selection.
-  const modifiers = [
-    variant ? `pv-detailpanel--${variant}` : '',
-    hasFacts ? 'pv-detailpanel--has-facts' : '',
-    hasAux ? 'pv-detailpanel--has-aux' : '',
-  ]
-    .filter(Boolean)
-    .join(' ');
-
-  const colsClass = modifiers
-    ? `pv-detailpanel__cols ${modifiers}`
-    : 'pv-detailpanel__cols';
+  const contentClass = variant
+    ? `pv-detailpanel__content pv-detailpanel--${variant}`
+    : 'pv-detailpanel__content';
 
   return (
     <DetailPane fill={fill}>
@@ -166,15 +138,7 @@ export function DetailPanel({
         subtitle={subtitle}
         actions={actions}
       />
-      {hasSlots ? (
-        <div className={colsClass}>
-          {hasFacts && <aside className="pv-detailpanel__facts">{facts}</aside>}
-          <div className="pv-detailpanel__content">{children}</div>
-          {hasAux && <aside className="pv-detailpanel__aux">{aux}</aside>}
-        </div>
-      ) : (
-        children
-      )}
+      <div className={contentClass}>{children}</div>
     </DetailPane>
   );
 }

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -942,20 +942,16 @@ export function TargetDetailV2({
       {/* Suppress unused-state warning; newProjectOpen drives the navigate above */}
       {newProjectOpen && null}
 
-      {/* #816: DetailPane fill-mode contract (primitives.css .pv-detail--fill)
-          requires ONE descendant establishing overflow-y:auto. DetailPanel is
-          deliberately used in "content-only" mode here (no facts/aux slots) —
-          that mode renders `children` as a direct sibling of DetailHeader
-          inside `.pv-detail--fill` (see DetailPanel.tsx), identical to the
-          pre-migration structure this comment originally documented. facts/
-          aux were NOT used for the identity columns below: that would nest
-          this region under `.pv-detailpanel__cols` > `.pv-detailpanel__content`
-          instead of as a direct child of `.pv-detail--fill`, breaking the
-          `.pv-detail--fill > .pv-planner__scroll` CSS rule (redesign-detail.css)
-          this fix depends on — everything below (identity/tonight, coverage,
-          links, display label, aliases, projects, notes, back button) lives
-          in this single scrollable region so it isn't silently clipped by
-          the pane's own overflow:hidden. */}
+      {/* #816 → #1107: this div used to be the pane's own scroll region,
+          because DetailPanel rendered `children` as a bare sibling of the
+          header with nothing establishing overflow — so everything below
+          (identity/tonight, coverage, links, display label, aliases, projects,
+          notes, back button) was silently clipped by the pane's
+          overflow:hidden.
+          DetailPanel now always wraps children in `.pv-detailpanel__content`,
+          which owns the scrolling for every page, so this is a plain layout
+          div. Do NOT give it `overflow-y` again — that nests a second scroller
+          inside the shared one and produces double scrollbars. */}
       <div className="pv-planner__scroll">
         {/* ── Identity + Tonight — left-packed: [facts A][facts B][tonight] ── */}
         <div className="pv-planner__cols">

--- a/apps/desktop/src/styles/components/detail-panes.css
+++ b/apps/desktop/src/styles/components/detail-panes.css
@@ -548,28 +548,16 @@
 /* Metadata table horizontal scroll wrapper */
 .pv-inbox-detail__metadata-scroll { overflow-x: auto; }
 
-/* #553: InboxDetail renders in DetailPanel's "content-only" mode (no facts/
- * aux slots), which intentionally skips the `.pv-detailpanel__content`
- * scroll wrapper — that mode assumes children establish their own scroll
- * (e.g. a virtualized Table), which InboxDetail's multi-column body does not.
- * Without a scroll region the FILES/Needs-review content simply overflowed
- * the docked panel's max-height and was clipped by the ancestor
- * `.pv-listpage__detail-body`'s `overflow: hidden` (unreachable, not just
- * unscrolled — see tables-lists.css). Scoped to inbox only via `:has()` (the
- * same pattern already used in wizard-steps.css) so Sessions/Calibration/
- * Projects detail panes are unaffected. */
-.pv-listpage__detail-body:has(.pv-inbox-detail__scroll) .pv-detail {
-  display: flex;
-  flex-direction: column;
-  height: 100%;
-  min-height: 0;
-}
-.pv-listpage__detail-body:has(.pv-inbox-detail__scroll) .pv-detail__header {
-  flex-shrink: 0;
-}
+/* #553 → #1107: InboxDetail used to need a scroll region of its own, because
+ * DetailPanel's content-only mode skipped `.pv-detailpanel__content` and left
+ * the pane with no scroll region at all — FILES/Needs-review content was
+ * clipped by the ancestor `.pv-listpage__detail-body`'s `overflow: hidden`
+ * (unreachable, not merely unscrolled). DetailPanel now ALWAYS renders
+ * `.pv-detailpanel__content` as the single scroll region, and the docked flex
+ * chain lives in tables-lists.css for EVERY page instead of being scoped to
+ * inbox via `:has()`. This local override is retired: keeping its
+ * `overflow-y: auto` would nest a second scroller inside the shared one.
+ * The class stays as a plain layout hook (its e2e selectors still resolve). */
 .pv-inbox-detail__scroll {
-  flex: 1 1 auto;
   min-height: 0;
-  overflow-y: auto;
-  scrollbar-gutter: stable;
 }

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -670,78 +670,27 @@
   padding-top: var(--pv-sp-2);
 }
 
-/* === Canonical DetailPanel 3-zone body (spec 043 §4, redesign-ui-platevault) ===
+/* === Canonical DetailPanel body (spec 043 §4, redesign-ui-platevault) ========
  *
- * DetailPanel renders up to 3 balanced zones. Grid template is driven by
- * modifier classes set by the component:
- *
- *   facts + content + aux   (.pv-detailpanel--has-facts.pv-detailpanel--has-aux)
- *     → minmax(220px, 0.26fr)  minmax(0, 1fr)  minmax(240px, 0.30fr)
- *   facts + content         (.pv-detailpanel--has-facts)
- *     → minmax(220px, 0.26fr)  minmax(0, 1fr)
- *   content + aux           (.pv-detailpanel--has-aux)
- *     → minmax(0, 1fr)  minmax(240px, 0.30fr)
- *   content only            (no modifier)
- *     → no wrapper; children render directly
+ * DetailPanel renders ONE body region, `.pv-detailpanel__content`, always.
+ * The facts/aux rails the 3-zone grid was built for were never adopted by any
+ * caller and are withdrawn (spec 054, #1107) — see DetailPanel.tsx.
  *
  * Auto-expand: .pv-listpage__detail is height:fit-content with a max-height
- * cap. The .pv-listpage__detail-body must NOT also scroll — only the
- * .pv-detailpanel__content column scrolls (scrollbar-gutter:stable).
+ * cap. The .pv-listpage__detail-body must NOT also scroll — only
+ * .pv-detailpanel__content scrolls (scrollbar-gutter:stable).
  *
  * Token-only — no raw hex/rgb/ms.
  * ============================================================================*/
 
-/* Base cols wrapper — content-only default (single col, no wrapper needed,
- * but --has-facts / --has-aux modifiers override grid-template-columns). */
-.pv-detailpanel__cols {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr);
-  gap: var(--pv-sp-5);
-  align-items: start;
-  padding: var(--pv-sp-3) var(--pv-sp-4);
-  min-height: 0;
-}
-
-/* 2-zone: facts + content */
-.pv-detailpanel__cols.pv-detailpanel--has-facts {
-  grid-template-columns: minmax(220px, 0.26fr) minmax(0, 1fr);
-}
-
-/* 2-zone: content + aux */
-.pv-detailpanel__cols.pv-detailpanel--has-aux {
-  grid-template-columns: minmax(0, 1fr) minmax(240px, 0.30fr);
-}
-
-/* 3-zone: facts + content + aux */
-.pv-detailpanel__cols.pv-detailpanel--has-facts.pv-detailpanel--has-aux {
-  grid-template-columns: minmax(220px, 0.26fr) minmax(0, 1fr) minmax(240px, 0.30fr);
-}
-
-/* Facts rail (left): sizes to content, never scrolls on its own. */
-.pv-detailpanel__facts {
-  min-width: 0;
-}
-.pv-detailpanel__facts .pv-rail__panel {
-  /* Override fill-mode rail scroll so facts stay compact. */
-  max-height: none;
-  overflow: visible;
-}
-
-/* Content column (center): THE ONLY scroll region inside the body.
+/* Body region: THE ONLY scroll region inside the panel.
  * scrollbar-gutter:stable prevents dropdown-open layout shift. */
 .pv-detailpanel__content {
   min-width: 0;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow-y: auto;
   scrollbar-gutter: stable;
-}
-
-/* Aux rail (right): secondary blocks, sizes to content, no own scroll. */
-.pv-detailpanel__aux {
-  min-width: 0;
-}
-.pv-detailpanel__aux .pv-rail__panel {
-  max-height: none;
-  overflow: visible;
 }
 
 /* FactsKV helper: a compact label/value row for use inside the facts column. */

--- a/apps/desktop/src/styles/components/redesign-detail.css
+++ b/apps/desktop/src/styles/components/redesign-detail.css
@@ -424,15 +424,17 @@
 
 /* === TARGETS PLANNER DETAIL === */
 
-/* #816: TargetDetailV2 is a flat-sibling consumer of DetailPane fill mode
-   (primitives.css .pv-detail--fill), not the .pv-dash/.pv-dash__primary
-   grid pattern — this wrapper is its own single scrollable region so content
-   below the altitude graph isn't silently clipped by the pane's own
-   overflow:hidden. */
-.pv-detail--fill > .pv-planner__scroll {
-  flex: 1;
+/* #816 → #1107: this wrapper had to be its own scroll region because
+   DetailPanel's content-only mode rendered `children` as a direct sibling of
+   the header inside `.pv-detail--fill`, leaving no scroll region — so content
+   below the altitude graph was silently clipped by the pane's overflow:hidden.
+   DetailPanel now always wraps children in `.pv-detailpanel__content`, which
+   owns scrolling for every page.
+   The #816 CONTRACT IS NOT GONE — it MOVED one level out, from this
+   direct-child rule to the shared wrapper. Do NOT re-add `overflow-y: auto`
+   here: it would nest a second scroller inside the shared one. */
+.pv-planner__scroll {
   min-height: 0;
-  overflow-y: auto;
 }
 
 /* ── Planner header row: title + catalog pills + action buttons ── */

--- a/apps/desktop/src/styles/components/tables-lists.css
+++ b/apps/desktop/src/styles/components/tables-lists.css
@@ -312,9 +312,46 @@
 .pv-listpage__detail-body {
   flex: 1;
   min-height: 0;
-  /* Do NOT add overflow-y:auto here — the .pv-detailpanel__content column
-   * is the sole scroll region. Double overflow-y causes nested scrollbars. */
+  /* Do NOT add overflow-y:auto here — .pv-detailpanel__content is the sole
+   * scroll region. Double overflow-y causes nested scrollbars. */
   overflow: hidden;
+}
+
+/* #1107: give the panel a real flex chain inside the dock, so the header pins
+ * and .pv-detailpanel__content gets a BOUNDED height to scroll within. Without
+ * it the panel sizes to its content, overflows this `overflow:hidden` body, and
+ * the excess is unreachable (measured at a 390px side dock: Calibration 191px,
+ * Sessions 522px, Projects 1216px). Scoped to the dock — .pv-detail is also
+ * used outside a docked panel, where sizing to content is correct.
+ * .pv-detail--fill declares the same chain itself (primitives.css). */
+.pv-listpage__detail-body > .pv-detail {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 0;
+}
+.pv-listpage__detail-body .pv-detail__header {
+  flex-shrink: 0;
+}
+
+/* #1107: some pages dock a STACK rather than a single panel — Projects docks
+ * ProjectDetailContent (which owns the DetailPanel) above ProjectBottomDetail,
+ * so the panel's own scroll region covers only the first component and the
+ * sibling below it overflows unreachably (measured 1216px). Keyed on the
+ * composition SHAPE — "the dock's child is not a panel" — rather than on any
+ * one feature, so any future stacked detail is covered too. In that shape the
+ * body owns the scrolling, and the panel's inner region must stand down to
+ * avoid a second, nested scrollbar. */
+.pv-listpage__detail-body:not(:has(> .pv-detail)) {
+  overflow-y: auto;
+  scrollbar-gutter: stable;
+}
+.pv-listpage__detail-body:not(:has(> .pv-detail)) .pv-detail--fill {
+  height: auto;
+}
+.pv-listpage__detail-body:not(:has(> .pv-detail)) .pv-detailpanel__content {
+  flex: 0 0 auto;
+  overflow-y: visible;
 }
 /* The bottom panel has ample horizontal room, so its dashboard grid keeps its
  * natural multi-column rail layout (the old single-column collapse the narrow

--- a/specs/054-adaptive-detail-dock/plan.md
+++ b/specs/054-adaptive-detail-dock/plan.md
@@ -29,7 +29,11 @@ per-page opt-in code — the default `detailPlacement` prop value is
   scope, `adaptiveThreshold` prop to override the 1400px default per page (not
   currently used by any adopting page).
 - **`apps/desktop/src/components/DetailPanel.tsx`** is the shared detail
-  container (3-zone facts/content/aux grid, single scroll region). Adopted by
+  container: a single content region which owns the panel's scrolling.
+  The 3-zone facts/content/aux grid originally described here is
+  **WITHDRAWN (#1107)** — no page ever passed a rail slot, and because the
+  grid also gated the scroll region, the panel had *no* scroll region in
+  production. See the T004 note in `tasks.md`. Adopted by
   all six pages (Sessions via `SessionDetail`, Calibration via
   `MasterDetail`, Inbox via `InboxDetail`, Archive via `ArchiveDetail`,
   Targets via `TargetDetailV2`, Projects via `ProjectDetail`) — the last

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -51,14 +51,39 @@ pending verification).
   `localStorage`, untested by a dedicated unit-test file as of this
   reconciliation.
 - [x] T004 Component test: containment for a plain overflowing block, no
-  special internal scroll structure. **DELIVERED, PR #1076.** Landed as tests
-  19–20 in `DetailPanel.test.tsx:327-346` ("content-only children stay direct
-  children of `.alm-detail--fill`" / "the facts slot does NOT satisfy that
-  selector"), which pin the #816 fix mechanism (a direct-child CSS selector
-  in `redesign-detail.css`, from #1035). An earlier draft of this file
-  existed as an untracked, uncommitted stray in this worktree before #1076
-  merged it under the `DetailPanel.test.tsx` name instead of its own file —
-  that history is superseded by the committed version now on `main`.
+  special internal scroll structure. **DELIVERED, PR #1076; REVISED, #1107.**
+  Originally landed as tests 19–20 in `DetailPanel.test.tsx` ("content-only
+  children stay direct children of `.alm-detail--fill`" / "the facts slot does
+  NOT satisfy that selector"), pinning the #816 fix mechanism — a direct-child
+  CSS selector in `redesign-detail.css`, from #1035. An earlier draft of this
+  file existed as an untracked, uncommitted stray in this worktree before
+  #1076 merged it under the `DetailPanel.test.tsx` name instead of its own
+  file — that history is superseded by the committed version now on `main`.
+
+  **#1107 moved the contract these pin.** The reason #816 needed a per-feature
+  scroll wrapper at all is that `DetailPanel` rendered `children` as a bare
+  sibling of the header with no scroll region — the region was gated on the
+  facts/aux rails, which no page ever passed. Three features each worked
+  around it locally (#553 Inbox, #816 Targets, #1107 Calibration) while
+  Sessions and Projects stayed silently broken. The content region is now
+  unconditional and owns scrolling for every page, so the per-feature rules
+  were retired. Tests 19–20 now pin the relocated invariant: the shared region
+  wraps the content, and there is exactly one of them (a second would mean
+  nested scrollbars). The "facts slot does not satisfy the selector" pin goes
+  away with the slots.
+
+  Measured live in mock mode at a 390px side dock, 1280×860, before → after:
+  Projects 1216px → 0, Sessions 522px → 0, Calibration 191px → 0 of
+  unreachable content; Inbox and Targets unchanged at 0 (no regression).
+
+- [ ] T004a **WITHDRAWN (#1107)** — `DetailPanel` facts/aux rail slots and the
+  3-zone grid. Designed in spec 043 §4 and described in `plan.md`, but never
+  adopted: the props were passed only by `DetailPanel`'s own tests, which gave
+  false confidence in a code path the app never took. Withdrawn rather than
+  left latent because the grid *gated the panel's only scroll region*, so
+  keeping it dormant kept the clipping bug alive. Do not reintroduce a
+  conditional content wrapper; if per-page rails are wanted later, they must
+  not sit between the panel root and the scroll region.
 - [x] T005 Component test `ListPageLayout` placement mount. **DELIVERED
   (partial), #1003** — `ListPageLayout.test.tsx` covers the `'side-and-bottom'`
   variant; general adaptive-placement mounting is exercised indirectly by

--- a/tests/e2e/target_detail_unclip.spec.ts
+++ b/tests/e2e/target_detail_unclip.spec.ts
@@ -11,9 +11,18 @@
  * everything below the altitude graph — including the back button — sat
  * beyond the pane's clipped bottom edge with NO way for a mouse-wheel user to
  * ever scroll it into view (an `overflow:hidden` box is not wheel-scrollable,
- * unlike `overflow:auto`/`scroll`). Fixed by wrapping that content in
- * `.pv-planner__scroll` (`flex:1; min-height:0; overflow-y:auto`,
+ * unlike `overflow:auto`/`scroll`). Originally fixed by wrapping that content
+ * in `.pv-planner__scroll` (`flex:1; min-height:0; overflow-y:auto`,
  * redesign-detail.css).
+ *
+ * #1107 moved that scroll region out one level. The root cause was that
+ * `DetailPanel` only rendered its content wrapper when a facts/aux rail slot
+ * was passed, and no page ever passed one — so no scroll region existed and
+ * every feature had to grow its own. The wrapper is now unconditional and owns
+ * the scrolling for all six detail pages; `.pv-planner__scroll` is a plain
+ * layout div. This test therefore asserts on `.pv-detailpanel__content`, and
+ * aims the wheel at the visible pane rather than at a scroll region whose
+ * centroid can fall outside the viewport.
  *
  * IMPORTANT: this deliberately drives a real mouse-wheel event
  * (`page.mouse.wheel`) rather than `locator.scrollIntoViewIfNeeded()` /
@@ -62,7 +71,10 @@ test.describe('Regression · Target detail pane content unclipped (#816)', () =>
     await m31.click();
 
     const pane = page.locator('.pv-detail--fill');
-    const scrollRegion = page.locator('.pv-planner__scroll');
+    // The pane's content lives in DetailPanel's shared scroll region (#1107).
+    // Before that, each feature supplied its own — here `.pv-planner__scroll`,
+    // which is now a plain layout div inside the shared one.
+    const scrollRegion = page.locator('.pv-detailpanel__content');
     await expect(scrollRegion).toBeVisible();
 
     const backBtn = page.getByRole('button', { name: '← All targets' });
@@ -73,11 +85,19 @@ test.describe('Regression · Target detail pane content unclipped (#816)', () =>
     // post-fix, since it's the natural (unscrolled) layout position.
     expect(beforeBox.y).toBeGreaterThan(paneBox.y + paneBox.height);
 
-    // Real wheel scroll over the scroll region, as an actual user would do.
-    const scrollBox = await requireBox(scrollRegion);
+    // Real wheel scroll over the PANE, which is what a user actually points at.
+    //
+    // Deliberately not the scroll region's own centroid: whichever element owns
+    // the scrolling is unbounded in height (it is the full content), so at this
+    // short 620px viewport its midpoint lands *below the window* and the wheel
+    // hits nothing. That is what broke this test under #1107 — not the
+    // behaviour, which was re-verified by hand: the button travels from y=1204
+    // to y=536, above the pane bottom at 594, visible and enabled. Aiming at
+    // the visible pane keeps the assertion about user-facing behaviour rather
+    // than about which div happens to carry `overflow-y`.
     await page.mouse.move(
-      scrollBox.x + scrollBox.width / 2,
-      scrollBox.y + scrollBox.height / 2,
+      paneBox.x + paneBox.width / 2,
+      paneBox.y + paneBox.height / 2,
     );
     await page.mouse.wheel(0, 3000);
 


### PR DESCRIPTION
Closes #1107.
Closes #1239.
Closes #1240.
Closes #1241.
Closes #1242.

## What was actually wrong

`DetailPanel` rendered its content wrapper — documented in its own docstring as
*"THE ONLY scroll region"* — only when a `facts` or `aux` rail slot was passed.

**No caller ever passed one.** Both props appear exactly nowhere in `src/`
except `DetailPanel.test.tsx`. So `hasSlots` was always `false`, the wrapper was
never rendered in production, and no scroll region existed. Details taller than
their dock overflowed the ancestor `.pv-listpage__detail-body`
(`overflow: hidden`) — content became **unreachable**, not merely unscrolled.

That makes #1107 the third symptom of one root cause, not a Calibration quirk:

| | |
|---|---|
| #553 | Inbox — patched with a `:has()`-scoped local rule |
| #816 | Targets — patched with `.pv-detail--fill > .pv-planner__scroll` |
| #1107 | Calibration — this issue |

The tests passed throughout, because they exercised a code path the app never took.

## Measured, before → after

Mock mode, 1280×860, 390px side dock, measured in the live DOM:

| Page | Before | After | Unreachable controls |
|---|---|---|---|
| **Projects** | 1216px | **0** | Edit / Reveal / Generate |
| **Sessions** | 522px | **0** | Load frame inventory |
| **Calibration** | 191px | **0** | both Assign buttons |
| Archive | 0 | 0 | — (latent; content just happens to be short) |
| Inbox | 0 | 0 | — (no regression) |
| Targets | 0 | 0 | — (no regression) |

**Sessions and Projects were not in the issue.** They were found by sweeping every
detail page, and Projects was the worst of the three.

## The fix

Render the content region unconditionally and make it the single scroll region,
with the docked flex chain applied for every page rather than scoped to one
feature via `:has()`. The two local fixes are retired — keeping their
`overflow-y` would nest a second scroller inside the shared one.

**#816's contract is not gone, it moved one level out**, from a direct-child rule
to the shared wrapper. Called out in a comment at both sites and in the revised
test, since the direct-child selector was specifically flagged as a trap.

Projects needed separate handling: it docks a *stack*
(`ProjectDetailContent` + `ProjectBottomDetail`), so the panel's region can only
ever cover the first component. Rather than add another per-feature rule, this
keys on the composition shape — *"the dock's child is not a panel"* — so any
future stacked detail is covered too.

The facts/aux slots and their 3-zone grid are **withdrawn** (spec 054), following
that spec's existing WITHDRAWN convention rather than deleting the design:
recorded with rationale, plus a note on what a reintroduction must not do.
Withdrawn rather than left dormant because the grid *gated the scroll region* —
keeping it kept the bug alive.

## Verification

- Live-verified on all six detail pages in **both** side and bottom placement:
  0px unreachable, exactly one scroll region each, header pinned, and the
  previously-unreachable controls confirmed reachable after scrolling.
- `vitest run`: 199 files / 1811 tests pass. `tsc --noEmit`: clean. `biome`: clean.
- One caveat, stated plainly: the full parallel run emits an unhandled
  `window is not defined` from `LogPanel.followScroll.test.tsx` (react-virtual
  timer firing after teardown). It reproduces in **neither** the before nor the
  after state when that file is run in isolation, so it is a load-dependent
  teardown race rather than something this PR introduced — but I did not run the
  full suite on `main` to prove that end-to-end. Same class as #1083.

## Spec Context
- Spec: 054 (adaptive detail dock)
- Branch: fix/1107-detail-body-vertical-clip
