### PR TITLE
fix(theme): default dark mode to Observatory Cool

### DIFF
--- a/apps/desktop/src/data/theme.test.ts
+++ b/apps/desktop/src/data/theme.test.ts
@@ -123,3 +123,29 @@ describe('applyTheme — native window theme sync (spec 051 US6)', () => {
     );
   });
 });
+
+describe('resolveTheme — system + OS dark preference (#1181)', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("resolves 'system' to the dark default (observatory-cool) when the OS prefers dark", async () => {
+    // Follows the matchMedia mock pattern in LogPanel.test.tsx (the only
+    // other matchMedia stub in the suite, there for prefers-reduced-motion).
+    vi.stubGlobal(
+      'matchMedia',
+      vi.fn().mockImplementation((query: string) => ({
+        matches: query.includes('prefers-color-scheme: dark'),
+        media: query,
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    );
+
+    const { resolveTheme } = await import('./theme');
+    expect(resolveTheme('system')).toBe('observatory-cool');
+  });
+});

--- a/apps/desktop/src/data/theme.ts
+++ b/apps/desktop/src/data/theme.ts
@@ -127,7 +127,7 @@ export const THEMES: ThemeMeta[] = [
 
 const THEME_KEY = 'alm.theme';
 const LIGHT_DEFAULT: ThemeId = 'warm-slate';
-const DARK_DEFAULT: ThemeId = 'observatory-dark';
+const DARK_DEFAULT: ThemeId = 'observatory-cool';
 
 /** Settings-DB scope/key for the durable theme choice (spec 018 `general` scope). */
 const SETTINGS_SCOPE = 'general';


### PR DESCRIPTION
## Summary

Product-identity change from the design-refresh campaign: **Observatory Cool** is the canonical theme pair, but the default dark theme (`DARK_DEFAULT` in `apps/desktop/src/data/theme.ts`) still pointed at the older warm-amber Observatory Dark. This flips the default to `observatory-cool`. Both dark themes (`observatory-dark`, `observatory-cool`) stay enabled — this only changes which one `system`/OS-dark-preference resolves to.

Closes #1181

## Scope

- Single-line change: `DARK_DEFAULT = 'observatory-cool'` (`apps/desktop/src/data/theme.ts:130`).
- Searched tests/fixtures that reference `observatory-dark` (`theme.test.ts`, `theme.persistence.test.ts`, `StepCatalogs.test.tsx`, `settings_appearance_i18n.spec.ts`, the settings-journeys Rust E2E test, `crates/app/settings` descriptors) — all of them exercise `observatory-dark` as an **explicit** theme choice, never asserted on the resolved system-dark default.
- Added `apps/desktop/src/data/theme.test.ts` coverage for the actual line this diff changes (`resolveTheme('system')` resolving via OS dark preference), which previously had zero coverage — no test in the suite mocked `prefers-color-scheme` (the only prior matchMedia mock was `LogPanel.test.tsx`, for `prefers-reduced-motion`). Verified in both directions: passes with `DARK_DEFAULT = 'observatory-cool'`, fails with it reverted to `'observatory-dark'`.
- Deliberately out of scope (per the tracked follow-up work): `apps/desktop/splash.html` (hardcodes Observatory Dark's amber hex — tracked separately as #1182) and `apps/desktop/src/styles/tokens.css` (owned by an in-flight, unrelated branch).

## Do not merge yet

This PR must **not** be merged until the orchestrator says so — an unrelated in-flight branch is mid-rebase against `tokens.css` and merging this early would move its rebase target.

## Test plan
- [x] `pnpm vitest run` (apps/desktop): 199 files / 1821 tests passed
- [x] `pnpm --filter @astro-plan/contracts test`: all conformance checks passed
- [x] `pnpm -r typecheck`: clean
- [x] `pnpm -r lint`: clean (pre-existing unrelated warnings only)
- [x] `node scripts/check-contrast.mjs` (apps/desktop): all 27 pairs meet AA across 6 themes
- [ ] `cargo test --workspace` not run — no Rust files touched