### PR TITLE
fix: warn before skipping the observing-site step in first-run setup

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1023,6 +1023,8 @@
   "setup_step_site_label": "Observing Site",
   "setup_step_site_heading": "Where do you observe from?",
   "setup_step_site_desc": "Add your observing location so the Targets Planner can show real tonight altitude, visibility, and imaging time.",
+  "setup_step_site_skip_warning": "Without an observing site the Targets planner can't work out what's visible from your location, so every target will read as not visible. You can add one now, or later in Settings → Target Planner.",
+  "setup_wizard_continue_without_site": "Continue without a site →",
   "setup_site_intro": "Optional — add one observing site now, or skip and add it later from Settings → Target Planner.",
   "setup_site_map_label": "Pick on map",
   "setup_site_map_unavailable": "Map unavailable right now — enter your coordinates in the fields below.",

--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -188,7 +188,9 @@ function _clickContinue() {
 /** Return the primary continue button. */
 function getContinueButton(): HTMLElement {
   const allButtons = screen.getAllByRole('button');
-  const match = allButtons.find((b) => b.textContent?.includes('Continue to'));
+  // Matches both "Continue to <step>" and the empty-site-step variant
+  // "Continue without a site".
+  const match = allButtons.find((b) => b.textContent?.includes('Continue'));
   if (!match) throw new Error('Continue button not found');
   return match;
 }
@@ -467,12 +469,66 @@ describe('SetupWizard 5-step flow', () => {
     ).toBeInTheDocument();
     expect(screen.getByText(/step 4 of 6/i)).toBeInTheDocument();
 
-    // Never required — Continue is enabled with every field blank.
+    // Never required — Continue stays enabled with every field blank (spec 044
+    // T016). Skipping is acknowledged, not blocked (#1050): the first click
+    // surfaces what is lost, the second proceeds.
     const continueBtn = getContinueButton();
     expect(continueBtn).not.toBeDisabled();
 
     fireEvent.click(continueBtn);
+
+    // Still on the site step, now with the consequence spelled out.
+    expect(screen.getByTestId('setup-site-skip-warning')).toBeInTheDocument();
+    expect(
+      screen.getByRole('heading', { name: /where do you observe from/i }),
+    ).toBeInTheDocument();
+
+    fireEvent.click(getContinueButton());
     expect(screen.getByText(/ready to go/i)).toBeInTheDocument();
+  });
+
+  it('re-arms the observing-site skip warning if the user edits then clears the step', () => {
+    const seeded = {
+      currentStep: 3,
+      sources: [
+        { path: '/astro/lights', kind: 'light_frames' },
+        { path: '/astro/projects', kind: 'project' },
+      ],
+      catalogSettings: { selectedCatalogIds: ['common', 'openngc'] },
+      tools: {
+        pixinsight: { enabled: false, path: null },
+        siril: { enabled: false, path: null },
+      },
+      site: {
+        name: '',
+        latitudeDegText: '',
+        longitudeDegText: '',
+        elevationMText: '',
+        timezone: 'UTC',
+      },
+    };
+    window.localStorage.setItem(WIZARD_STORAGE_KEY, JSON.stringify(seeded));
+
+    renderWizard();
+
+    // Acknowledge the skip once.
+    fireEvent.click(getContinueButton());
+    expect(screen.getByTestId('setup-site-skip-warning')).toBeInTheDocument();
+
+    // Touching the step withdraws that acknowledgement: typing a name hides the
+    // warning, and clearing it again must not inherit the earlier consent.
+    const nameField = screen.getByLabelText(/name/i);
+    fireEvent.change(nameField, { target: { value: 'Backyard' } });
+    expect(
+      screen.queryByTestId('setup-site-skip-warning'),
+    ).not.toBeInTheDocument();
+
+    fireEvent.change(nameField, { target: { value: '' } });
+    fireEvent.click(getContinueButton());
+
+    // Warned again rather than advancing straight to Confirm.
+    expect(screen.getByTestId('setup-site-skip-warning')).toBeInTheDocument();
+    expect(screen.queryByText(/ready to go/i)).not.toBeInTheDocument();
   });
 
   it('blocks Continue on the Observing Site step when latitude is out of range', () => {

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -497,11 +497,14 @@ export function SetupWizard() {
   // enabled by scanComplete — canProceed is not consulted for that step.
   const canProceed = isStepValid(step);
 
-  // True while the user is sitting on an empty Observing Site step and has not
-  // yet acknowledged skipping it. Drives both the warning banner and the
-  // Continue button's label/behaviour.
-  const siteSkipNeedsAck =
-    step === SITE_STEP && !siteStepHasSite(state.site) && !siteSkipAcked;
+  // Sitting on the Observing Site step with nothing filled in. The primary
+  // action is named for what it actually does for as long as this holds — it
+  // must NOT revert to "Continue to <next>" once the skip is acknowledged, or
+  // the button silently changes wording between the two clicks.
+  const siteStepEmpty = step === SITE_STEP && !siteStepHasSite(state.site);
+  // Only the first click on that empty step is an acknowledgement; the second
+  // proceeds.
+  const siteSkipNeedsAck = siteStepEmpty && !siteSkipAcked;
 
   const stepMeta = STEPS[step];
 
@@ -561,9 +564,9 @@ export function SetupWizard() {
             goTo(step + 1);
           }}
           disabled={!canProceed}
-          data-testid={siteSkipNeedsAck ? 'setup-site-skip-ack' : undefined}
+          data-testid={siteStepEmpty ? 'setup-site-skip-ack' : undefined}
         >
-          {siteSkipNeedsAck
+          {siteStepEmpty
             ? m.setup_wizard_continue_without_site()
             : m.setup_wizard_continue_to({
                 label: STEPS[step + 1].label().toLowerCase(),

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -103,6 +103,9 @@ const STEPS = [
 // Index of the Scan step (last step).
 const SCAN_STEP = STEPS.length - 1;
 
+// Index of the (optional) Observing Site step.
+const SITE_STEP = 3;
+
 function loadWizardState(): WizardState {
   try {
     const raw = localStorage.getItem(STORAGE_KEY);
@@ -202,7 +205,19 @@ export function SetupWizard() {
 
   const handleSiteChange = useCallback((site: SiteStepState) => {
     setState((prev) => ({ ...prev, site }));
+    // Editing the step withdraws a previous "skip anyway" acknowledgement, so
+    // clearing the fields again re-arms the warning rather than silently
+    // inheriting the earlier consent.
+    setSiteSkipAcked(false);
   }, []);
+
+  // Skipping the (optional) Observing Site step is acknowledged, not blocked:
+  // the first Continue on an empty step surfaces the consequence, the second
+  // proceeds. Spec 044 T016 keeps the step optional on purpose — a user may
+  // not have coordinates to hand — but silently skipping it leaves the Targets
+  // planner unable to compute visibility, which is invisible until they reach
+  // that page (#1050).
+  const [siteSkipAcked, setSiteSkipAcked] = useState(false);
 
   const isMockMode = import.meta.env.VITE_USE_MOCKS === 'true';
 
@@ -440,7 +455,7 @@ export function SetupWizard() {
       if (i === 0 || i === SCAN_STEP - 1) {
         return getMissingRequiredKinds(state.sources).length === 0;
       }
-      if (i === 3) {
+      if (i === SITE_STEP) {
         return siteStepError(state.site) === null;
       }
       return true;
@@ -481,6 +496,12 @@ export function SetupWizard() {
   // The Scan step (SCAN_STEP) uses the shared footer Finish button, which is
   // enabled by scanComplete — canProceed is not consulted for that step.
   const canProceed = isStepValid(step);
+
+  // True while the user is sitting on an empty Observing Site step and has not
+  // yet acknowledged skipping it. Drives both the warning banner and the
+  // Continue button's label/behaviour.
+  const siteSkipNeedsAck =
+    step === SITE_STEP && !siteStepHasSite(state.site) && !siteSkipAcked;
 
   const stepMeta = STEPS[step];
 
@@ -530,12 +551,23 @@ export function SetupWizard() {
         // Steps 0–2: "Continue to <next>"
         <Btn
           variant="primary"
-          onClick={() => goTo(step + 1)}
+          onClick={() => {
+            // First click on an empty site step only acknowledges the skip;
+            // the banner it reveals explains what is lost. Second click moves on.
+            if (siteSkipNeedsAck) {
+              setSiteSkipAcked(true);
+              return;
+            }
+            goTo(step + 1);
+          }}
           disabled={!canProceed}
+          data-testid={siteSkipNeedsAck ? 'setup-site-skip-ack' : undefined}
         >
-          {m.setup_wizard_continue_to({
-            label: STEPS[step + 1].label().toLowerCase(),
-          })}
+          {siteSkipNeedsAck
+            ? m.setup_wizard_continue_without_site()
+            : m.setup_wizard_continue_to({
+                label: STEPS[step + 1].label().toLowerCase(),
+              })}
         </Btn>
       ) : (
         // Step 3 (Confirm): register + enter Scan
@@ -605,8 +637,15 @@ export function SetupWizard() {
             onSettingsChange={handleCatalogSettingsChange}
           />
         )}
-        {step === 3 && (
-          <StepSite state={state.site} onChange={handleSiteChange} />
+        {step === SITE_STEP && (
+          <>
+            <StepSite state={state.site} onChange={handleSiteChange} />
+            {siteSkipAcked && !siteStepHasSite(state.site) && (
+              <Banner variant="warn" data-testid="setup-site-skip-warning">
+                {m.setup_step_site_skip_warning()}
+              </Banner>
+            )}
+          </>
         )}
         {step === 4 && (
           <StepConfirm

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -203,14 +203,6 @@ export function SetupWizard() {
     setState((prev) => ({ ...prev, tools }));
   }, []);
 
-  const handleSiteChange = useCallback((site: SiteStepState) => {
-    setState((prev) => ({ ...prev, site }));
-    // Editing the step withdraws a previous "skip anyway" acknowledgement, so
-    // clearing the fields again re-arms the warning rather than silently
-    // inheriting the earlier consent.
-    setSiteSkipAcked(false);
-  }, []);
-
   // Skipping the (optional) Observing Site step is acknowledged, not blocked:
   // the first Continue on an empty step surfaces the consequence, the second
   // proceeds. Spec 044 T016 keeps the step optional on purpose — a user may
@@ -218,6 +210,14 @@ export function SetupWizard() {
   // planner unable to compute visibility, which is invisible until they reach
   // that page (#1050).
   const [siteSkipAcked, setSiteSkipAcked] = useState(false);
+
+  const handleSiteChange = useCallback((site: SiteStepState) => {
+    setState((prev) => ({ ...prev, site }));
+    // Editing the step withdraws a previous "skip anyway" acknowledgement, so
+    // clearing the fields again re-arms the warning rather than silently
+    // inheriting the earlier consent.
+    setSiteSkipAcked(false);
+  }, []);
 
   const isMockMode = import.meta.env.VITE_USE_MOCKS === 'true';
 

--- a/tests/e2e/setup_wizard_site_step.spec.ts
+++ b/tests/e2e/setup_wizard_site_step.spec.ts
@@ -77,8 +77,23 @@ test.describe('setup wizard · Observing Site step (spec 044 US3/T016)', () => {
     await expect(page.locator('#setup-site-lat')).toHaveValue('');
     await expect(page.locator('#setup-site-lon')).toHaveValue('');
 
-    // FR-025: the step is entirely optional — leaving it blank must still advance.
-    await page.getByRole('button', { name: 'Continue to confirm →' }).click();
+    // FR-025: the step is entirely optional — leaving it blank must still
+    // advance. Skipping is acknowledged rather than blocked (#1050): on an
+    // empty step the primary action names the consequence, the first click
+    // reveals it, and the second proceeds.
+    const skipBtn = page.getByRole('button', {
+      name: 'Continue without a site →',
+    });
+    await expect(skipBtn).toBeEnabled();
+    await skipBtn.click();
+
+    // Still on the site step, now with the cost of skipping spelled out.
+    await expect(page.getByTestId('setup-site-skip-warning')).toBeVisible();
+    await expect(
+      page.getByRole('heading', { name: 'Where do you observe from?' }),
+    ).toBeVisible();
+
+    await skipBtn.click();
     await expect(
       page.getByRole('heading', { name: 'Ready to go' }),
     ).toBeVisible({ timeout: 5_000 });


### PR DESCRIPTION
## Summary

- The first-run wizard's Observing Site step is optional, and you can advance past it with every field blank — with nothing explaining what that costs.
- The Targets planner needs latitude/longitude to compute altitude and visibility. With no site saved, **every target reads as "not visible"**, and that only becomes apparent once you reach the planner.
- Skipping is now *acknowledged* rather than blocked: the first Continue on an empty step reveals a warning naming the consequence and offers "Continue without a site"; the second proceeds.

## Why not just make it required

Spec 044 T016 made the step optional on purpose — a user may simply not have their coordinates to hand on first launch. Blocking Continue would trap them. This keeps the step never-required (Continue is never disabled) while making the tradeoff visible at the moment it's made.

Editing the step withdraws a previous acknowledgement, so clearing the fields again re-arms the warning instead of inheriting earlier consent.

## Implementation notes

- Reuses the shared `Banner` component — no new component, no new CSS class.
- Replaces the magic step index `3` with a named `SITE_STEP` constant (it was already duplicated across `isStepValid` and the render branch).

## Verification

- The existing *"advances while completely empty"* test now asserts the two-step acknowledgement while still proving Continue is **never disabled** — so T016's invariant is still covered, not dropped.
- A new test covers the re-arm path. **Negative control:** removing the `setSiteSkipAcked(false)` reset fails that test *and only that test*.
- `pnpm vitest run src/features/setup/` — 102 passed across 10 files. `typecheck` and `biome check` clean.

## Context

Found while investigating #1050. That issue turns out to rest on a false premise — `settings.changed` is *already* granular (it carries `key`, `priorValue`, `newValue`), so no new bus topic is needed to auto-tick an observing-site checklist row; `ItemDef.payload_filter` already exists for exactly that. Evidence is posted on #1050, which is rescoped accordingly. The checklist row itself remains gated on #1048, since `onboarding.rs` only exists on that branch.

This PR is the wizard half, which stands alone on `main`.