### PR TITLE
refactor(inbox): migrate the last hand-copied two-col detail layout

### DIFF
--- a/apps/desktop/src/components/TwoColDetailLayout.test.tsx
+++ b/apps/desktop/src/components/TwoColDetailLayout.test.tsx
@@ -24,6 +24,51 @@ describe('TwoColDetailLayout', () => {
     expect(wrapper?.querySelector('.pv-session-detail2__linked')).toBeNull();
   });
 
+  it('omits the colB slot entirely when colB is null', () => {
+    // An empty `__col` still claims `min-width: 340px` in the flex row, so
+    // rendering one for absent content reads as a gap, not as nothing.
+    const { container } = render(
+      <TwoColDetailLayout colA={<span>A</span>} colB={null} />,
+    );
+    const wrapper = container.querySelector('.pv-session-detail2');
+    expect(
+      wrapper?.querySelectorAll(':scope > .pv-session-detail2__col'),
+    ).toHaveLength(1);
+  });
+
+  it('renders extraCols as full __col slots, skipping null entries', () => {
+    const { container } = render(
+      <TwoColDetailLayout
+        colA={<span>A</span>}
+        colB={<span>B</span>}
+        extraCols={[<span key="c">C</span>, null, <span key="d">D</span>]}
+      />,
+    );
+    const wrapper = container.querySelector('.pv-session-detail2');
+    // A, B, C, D — the null entry contributes nothing.
+    expect(
+      wrapper?.querySelectorAll(':scope > .pv-session-detail2__col'),
+    ).toHaveLength(4);
+    expect(screen.getByText('C')).toBeInTheDocument();
+    expect(screen.getByText('D')).toBeInTheDocument();
+  });
+
+  it('renders extraCols as __col, never as the narrow __linked slot', () => {
+    // Guards the regression this API exists to prevent: `__linked` is
+    // `flex: 0 0 auto; min-width: 160px` and squeezes table-shaped content.
+    const { container } = render(
+      <TwoColDetailLayout
+        colA={<span>A</span>}
+        colB={<span>B</span>}
+        extraCols={[<span key="t">table</span>]}
+      />,
+    );
+    expect(container.querySelector('.pv-session-detail2__linked')).toBeNull();
+    expect(screen.getByText('table').closest('div')).toHaveClass(
+      'pv-session-detail2__col',
+    );
+  });
+
   it('renders the linked slot with an optional modifier class', () => {
     const { container } = render(
       <TwoColDetailLayout

--- a/apps/desktop/src/components/TwoColDetailLayout.tsx
+++ b/apps/desktop/src/components/TwoColDetailLayout.tsx
@@ -6,11 +6,27 @@ import type { ReactNode } from 'react';
 export interface TwoColDetailLayoutProps {
   /** Left property column (typically a `PropertyTable` half). */
   colA: ReactNode;
-  /** Right property column (typically a `PropertyTable` half). */
-  colB: ReactNode;
   /**
-   * Third slot — a linked-entity list, a stacked pair of popovers, or any
-   * other right-aligned block. Omitted entirely when there is nothing to show.
+   * Right property column (typically a `PropertyTable` half). Pass `null` to
+   * omit the slot entirely — an empty `__col` is not free, it still claims
+   * `min-width: 340px` of the flex row and reads as a gap. For callers that
+   * spread a variable-length fact list across the two columns and may end up
+   * with nothing for the second.
+   */
+  colB?: ReactNode;
+  /**
+   * Further full-width property columns rendered after `colB`, each in its own
+   * `__col`. `null`/`undefined` entries are skipped, so a caller can pass
+   * conditional slots positionally. Use this — not `linked` — for anything
+   * table-shaped: `__col` is `flex: 0 1 400px; min-width: 340px` whereas
+   * `__linked` is `flex: 0 0 auto; min-width: 160px`, which squeezes real
+   * content.
+   */
+  extraCols?: ReactNode[];
+  /**
+   * Trailing slot — a linked-entity list, a stacked pair of popovers, or any
+   * other narrow right-aligned block. Omitted entirely when there is nothing
+   * to show.
    */
   linked?: ReactNode;
   /** Extra class appended to the linked slot (e.g. the `--stack` modifier
@@ -27,6 +43,7 @@ export interface TwoColDetailLayoutProps {
 export function TwoColDetailLayout({
   colA,
   colB,
+  extraCols,
   linked,
   linkedClassName,
 }: TwoColDetailLayoutProps) {
@@ -36,7 +53,16 @@ export function TwoColDetailLayout({
   return (
     <div className="pv-session-detail2">
       <div className="pv-session-detail2__col">{colA}</div>
-      <div className="pv-session-detail2__col">{colB}</div>
+      {colB != null && <div className="pv-session-detail2__col">{colB}</div>}
+      {(extraCols ?? []).map((col, i) =>
+        col == null ? null : (
+          // Positional slots: a caller passes a fixed-length array whose
+          // entries may be null, so the index IS the stable identity here.
+          <div className="pv-session-detail2__col" key={i}>
+            {col}
+          </div>
+        ),
+      )}
       {linked != null && <div className={linkedCls}>{linked}</div>}
     </div>
   );

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -25,7 +25,7 @@
  */
 
 import { Popover } from '@base-ui-components/react/popover';
-import { useCallback, useState } from 'react';
+import { Fragment, useCallback, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { commands } from '@/bindings/index';
 import type {
@@ -38,7 +38,12 @@ import { unwrap } from '@/api/ipc';
 import { ipcArgs } from '@/lib/ipc-args';
 import { queryKeys } from '@/data/queryKeys';
 import type { PropertyDef } from '@/components';
-import { DetailPanel, PropertyTable, renderValue } from '@/components';
+import {
+  DetailPanel,
+  PropertyTable,
+  TwoColDetailLayout,
+  renderValue,
+} from '@/components';
 import { errMessage } from '@/lib/errors';
 import { fieldApplicability } from '@/lib/field-applicability';
 import { m } from '@/lib/i18n';
@@ -1078,124 +1083,129 @@ export function InboxDetail({
           </div>
         )}
 
-        {/* Left-packed .pv-session-detail2 row */}
-        <div className="pv-session-detail2">
-          {/* Col A: detection facts (first half) */}
-          <div className="pv-session-detail2__col">
-            <PropertyTable mode="view" showSource properties={detColA} />
-          </div>
-
-          {/* Col B: detection facts (second half) — only when there are enough */}
-          {detColB.length > 0 && (
-            <div className="pv-session-detail2__col">
+        {/* Left-packed .pv-session-detail2 row, via the shared component
+            (#813) instead of a hand-copied div structure. Files and Needs-
+            review ride in `extraCols`, NOT `linked`: both are table-shaped
+            and need `__col` sizing (flex 0 1 400px / min-width 340px) —
+            `__linked` is flex 0 0 auto / min-width 160px and would squeeze
+            them. */}
+        <TwoColDetailLayout
+          colA={<PropertyTable mode="view" showSource properties={detColA} />}
+          colB={
+            // Only when the fact list was long enough to spread across two.
+            detColB.length > 0 ? (
               <PropertyTable mode="view" showSource properties={detColB} />
-            </div>
-          )}
+            ) : null
+          }
+          extraCols={[
+            /* Files — mixed-composition summary + the metadata popover */
+            <Fragment key="files">
+              <div className="pv-session-detail2__head">
+                {m.inbox_col_files()}
+              </div>
 
-          {/* Col C: Files — mixed-composition summary + the metadata popover */}
-          <div className="pv-session-detail2__col">
-            <div className="pv-session-detail2__head">
-              {m.inbox_col_files()}
-            </div>
-
-            {/* FR-011: compact mixed-composition summary */}
-            {mixedSummary && (
-              <section
-                aria-label={m.inbox_mixed_composition_summary_aria()}
-                className="pv-inbox-detail__mixed-summary"
-              >
-                {mixedSummary}
-              </section>
-            )}
-
-            {/* Files popover — trigger + portaled popup with metadata table + inspector */}
-            {hasMetadata ? (
-              <Popover.Root
-                onOpenChange={() => {
-                  // Reset inspector selection whenever the popover is closed.
-                  setInspectedIdx(null);
-                }}
-              >
-                <Popover.Trigger
-                  className="pv-inbox-detail__files-trigger"
-                  aria-label={m.inbox_file_metadata_count({
-                    count: metadataRows.length,
-                  })}
-                  data-testid="inbox-files-popover-trigger"
+              {/* FR-011: compact mixed-composition summary */}
+              {mixedSummary && (
+                <section
+                  aria-label={m.inbox_mixed_composition_summary_aria()}
+                  className="pv-inbox-detail__mixed-summary"
                 >
-                  {m.inbox_file_metadata_count({ count: metadataRows.length })}{' '}
-                  ▾
-                </Popover.Trigger>
-                <Popover.Portal>
-                  <Popover.Positioner
-                    side="bottom"
-                    align="start"
-                    sideOffset={4}
+                  {mixedSummary}
+                </section>
+              )}
+
+              {/* Files popover — trigger + portaled popup with metadata table + inspector */}
+              {hasMetadata ? (
+                <Popover.Root
+                  onOpenChange={() => {
+                    // Reset inspector selection whenever the popover is closed.
+                    setInspectedIdx(null);
+                  }}
+                >
+                  <Popover.Trigger
+                    className="pv-inbox-detail__files-trigger"
+                    aria-label={m.inbox_file_metadata_count({
+                      count: metadataRows.length,
+                    })}
+                    data-testid="inbox-files-popover-trigger"
                   >
-                    <Popover.Popup
-                      className="pv-inbox-detail__files-popup"
-                      data-testid="inbox-files-popup"
-                      aria-label={m.inbox_file_metadata_aria()}
+                    {m.inbox_file_metadata_count({
+                      count: metadataRows.length,
+                    })}{' '}
+                    ▾
+                  </Popover.Trigger>
+                  <Popover.Portal>
+                    <Popover.Positioner
+                      side="bottom"
+                      align="start"
+                      sideOffset={4}
                     >
-                      {/* Scrollable metadata table */}
-                      <div className="pv-inbox-detail__files-popup-table">
-                        <Table columns={metadataColumns} rows={metadataRows} />
-                      </div>
-                      {/* Inspector — updates on row click */}
-                      {inspectedIdx != null && (
-                        <div className="pv-inbox-detail__files-popup-inspector">
-                          <FileInspector
-                            file={fileMetadata?.[inspectedIdx] ?? null}
+                      <Popover.Popup
+                        className="pv-inbox-detail__files-popup"
+                        data-testid="inbox-files-popup"
+                        aria-label={m.inbox_file_metadata_aria()}
+                      >
+                        {/* Scrollable metadata table */}
+                        <div className="pv-inbox-detail__files-popup-table">
+                          <Table
+                            columns={metadataColumns}
+                            rows={metadataRows}
                           />
                         </div>
-                      )}
-                    </Popover.Popup>
-                  </Popover.Positioner>
-                </Popover.Portal>
-              </Popover.Root>
-            ) : (
-              !mixedSummary && (
-                <span className="pv-session-detail2__muted">
-                  {m.inbox_no_file_metadata()}
-                  {/* #551: no per-file metadata means the required-destination-
+                        {/* Inspector — updates on row click */}
+                        {inspectedIdx != null && (
+                          <div className="pv-inbox-detail__files-popup-inspector">
+                            <FileInspector
+                              file={fileMetadata?.[inspectedIdx] ?? null}
+                            />
+                          </div>
+                        )}
+                      </Popover.Popup>
+                    </Popover.Positioner>
+                  </Popover.Portal>
+                </Popover.Root>
+              ) : (
+                !mixedSummary && (
+                  <span className="pv-session-detail2__muted">
+                    {m.inbox_no_file_metadata()}
+                    {/* #551: no per-file metadata means the required-destination-
                     attribute gate has no data to evaluate here — say so
                     explicitly instead of silently reading as "nothing to
                     worry about" (confirm can still be rejected server-side
                     for these files; see inbox.missing_path_attributes). */}
-                  {' — '}
-                  {m.inbox_no_file_metadata_caveat()}
-                </span>
-              )
-            )}
+                    {' — '}
+                    {m.inbox_no_file_metadata_caveat()}
+                  </span>
+                )
+              )}
 
-            {/* FR-032 (US9) / #554: missing-required-attribute warning lives
+              {/* FR-032 (US9) / #554: missing-required-attribute warning lives
               INLINE in the Files column (the field it explains) rather than
               as its own full-width alert column competing with the property
               tables (#554 — "stands out horribly"). */}
-            {filesMissingAttrs.length > 0 && (
-              <Banner
-                variant="danger"
-                className="pv-inbox-detail__banner-mt2 pv-inbox-alert"
-                data-testid="inbox-missing-attr-banner"
-              >
-                <div className="pv-inbox-alert__msg">
-                  <span className="pv-inbox-alert__title">
-                    {m.inbox_required_metadata_missing_title()}
-                  </span>
-                  <span className="pv-inbox-alert__body">
-                    {m.inbox_required_metadata_body({
-                      count: filesMissingAttrs.length,
-                    })}
-                  </span>
-                </div>
-              </Banner>
-            )}
-          </div>
-
-          {/* Needs review — rendered when unclassified files exist */}
-          {unclassifiedRows.length > 0 && (
-            <div className="pv-session-detail2__col">
+              {filesMissingAttrs.length > 0 && (
+                <Banner
+                  variant="danger"
+                  className="pv-inbox-detail__banner-mt2 pv-inbox-alert"
+                  data-testid="inbox-missing-attr-banner"
+                >
+                  <div className="pv-inbox-alert__msg">
+                    <span className="pv-inbox-alert__title">
+                      {m.inbox_required_metadata_missing_title()}
+                    </span>
+                    <span className="pv-inbox-alert__body">
+                      {m.inbox_required_metadata_body({
+                        count: filesMissingAttrs.length,
+                      })}
+                    </span>
+                  </div>
+                </Banner>
+              )}
+            </Fragment>,
+            /* Needs review — rendered when unclassified files exist */
+            unclassifiedRows.length > 0 ? (
               <Section
+                key="needs-review"
                 title={m.inbox_needs_review_title({
                   count: unclassifiedRows.length,
                 })}
@@ -1448,9 +1458,9 @@ export function InboxDetail({
                   </Banner>
                 )}
               </Section>
-            </div>
-          )}
-        </div>
+            ) : null,
+          ]}
+        />
 
         {/* Cone-search target suggestion (spec 052 P3) — light framesets only. */}
         {itemFrameType === 'light' && (

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.layout.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.layout.test.tsx
@@ -1,0 +1,155 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * InboxDetail — two-col layout migration (#813, final call site).
+ *
+ * InboxDetail was the last of the four hand-copied `.pv-session-detail2`
+ * consumers. Unlike Sessions/Calibration it needs FOUR `__col` slots
+ * (detection facts A/B, Files, Needs-review), so the migration rides on
+ * `TwoColDetailLayout`'s `extraCols` rather than its `linked` slot.
+ *
+ * These assertions are the regression net for that: `__col` is
+ * `flex: 0 1 400px; min-width: 340px` while `__linked` is
+ * `flex: 0 0 auto; min-width: 160px`, so routing the table-shaped Files and
+ * Needs-review blocks through `linked` would silently squeeze them. Nothing
+ * else in the suite pins this structure.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, screen } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import type {
+  InboxItemSummary,
+  InboxFileMetadata_Serialize as InboxFileMetadata,
+} from '@/bindings/index';
+import type { InboxClassifyResponse } from '@/bindings/aliases';
+import { InboxDetail } from '../InboxDetail';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    inboxReclassify: vi.fn(),
+    inboxReclassifyV2: vi.fn(),
+    inboxPropertyRegistry: vi
+      .fn()
+      .mockResolvedValue({ status: 'ok', data: [] }),
+  },
+}));
+
+const item: InboxItemSummary & { organizationState?: string } = {
+  inboxItemId: 'item-1',
+  relativePath: 'M51/LUM/2025-05-03',
+  fileCount: 2,
+  lane: 'fits',
+  format: 'fits',
+  state: 'classified',
+  contentSignature: 'sig-1',
+  isMaster: false,
+  masterFrameType: null,
+  masterFilter: null,
+  masterExposureS: null,
+};
+
+function classification(
+  unclassifiedFiles: string[] = [],
+): InboxClassifyResponse {
+  return {
+    inboxItemId: 'item-1',
+    type: 'single_type',
+    frameType: 'light',
+    contentSignature: 'sig-1',
+    breakdown: [
+      {
+        kind: 'light',
+        count: 2,
+        destinationPreview: 'M51/LUM/2025-05-03/light/',
+        sampleFiles: ['frame_001.fits'],
+      },
+    ],
+    unclassifiedFiles,
+    sampleFiles: ['frame_001.fits'],
+    computedAt: '2025-05-03T00:00:00Z',
+  };
+}
+
+const fileMetadata = [
+  {
+    relativeFilePath: 'frame_001.fits',
+    frameTypeEffective: 'light',
+    filter: 'LUM',
+    exposureS: 300,
+    missingPathAttributes: [],
+  },
+] as unknown as InboxFileMetadata[];
+
+describe('InboxDetail — two-col layout (#813)', () => {
+  it('renders the shared .pv-session-detail2 structure', () => {
+    const { container } = render(
+      <InboxDetail
+        item={item}
+        rootAbsolutePath="/astro/inbox"
+        classification={classification()}
+        fileMetadata={fileMetadata}
+      />,
+    );
+    expect(container.querySelector('.pv-session-detail2')).toBeInTheDocument();
+  });
+
+  it('gives Files its own __col, never the narrow __linked slot', () => {
+    const { container } = render(
+      <InboxDetail
+        item={item}
+        rootAbsolutePath="/astro/inbox"
+        classification={classification()}
+        fileMetadata={fileMetadata}
+      />,
+    );
+    const wrapper = container.querySelector('.pv-session-detail2');
+
+    // detection A + detection B + Files. No needs-review column: nothing
+    // is unclassified here.
+    expect(
+      wrapper?.querySelectorAll(':scope > .pv-session-detail2__col'),
+    ).toHaveLength(3);
+    expect(
+      wrapper?.querySelector('.pv-session-detail2__linked'),
+    ).not.toBeInTheDocument();
+
+    // The Files trigger really is inside a __col, not floating elsewhere.
+    const trigger = screen.getByTestId('inbox-files-popover-trigger');
+    expect(trigger.closest('.pv-session-detail2__col')).toBeInTheDocument();
+  });
+
+  it('adds a fourth __col for Needs-review when files are unclassified', () => {
+    const { container } = render(
+      <InboxDetail
+        item={item}
+        rootAbsolutePath="/astro/inbox"
+        classification={classification(['frame_002.fits'])}
+        fileMetadata={fileMetadata}
+      />,
+    );
+    const wrapper = container.querySelector('.pv-session-detail2');
+    expect(
+      wrapper?.querySelectorAll(':scope > .pv-session-detail2__col'),
+    ).toHaveLength(4);
+    expect(
+      wrapper?.querySelector('.pv-session-detail2__linked'),
+    ).not.toBeInTheDocument();
+
+    // And it is the Needs-review block that occupies the extra column.
+    const selectAll = screen.getByTestId('reclassify-select-all');
+    expect(selectAll.closest('.pv-session-detail2__col')).toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
Closes #813.

InboxDetail was the fourth and final `.pv-session-detail2` consumer still hand-copying the div structure. Sessions, MasterDetail and SessionListPopover were migrated in #1125; this finishes the issue.

## Why it wasn't mechanical

The issue comment expected "same idiom as SessionDetail.tsx/MasterDetail.tsx". It isn't. InboxDetail needs **four** `__col` slots (detection facts A/B, Files, Needs-review), but `TwoColDetailLayout` offered only `colA`/`colB` plus a `linked` slot — and those classes are not interchangeable:

| class | sizing |
|---|---|
| `__col` | `flex: 0 1 400px; min-width: 340px` |
| `__linked` | `flex: 0 0 auto; min-width: 160px` |

Routing the table-shaped Files and Needs-review blocks through `linked` would have silently squeezed them into a 160px-min auto-width box — a real visual regression, not a no-op.

## Changes

- `TwoColDetailLayout` grows an `extraCols?: ReactNode[]` prop rendering further full `__col` slots, skipping `null` entries so callers can pass conditional slots positionally.
- `colB` becomes optional and is omitted entirely when `null` — an empty `__col` still claims 340px and reads as a gap.
- `InboxDetail` renders through the shared component instead of hand-copied divs.

Both existing callers pass a real `colB` and no `extraCols`, so their rendered output is byte-identical; their tests are untouched and still pass.

## Testing

- New `InboxDetail.layout.test.tsx` pins the structure (3 `__col`, 4 with Needs-review, never `__linked`) — nothing else in the suite covered it.
- **Verified non-vacuous**: temporarily rendering `extraCols` into `__linked` fails 2 of the 3 new tests.
- 437 pass across `inbox`, `components`, `sessions`, `calibration` (434 before + 3 new). Typecheck green; biome clean on all changed files.

## Note

`pnpm lint` exits 1 in a linked worktree due to a pre-existing eslint project-service parse error on `eslint-rules/no-user-string.js` — reproduced on pristine `origin/main`, unrelated to this change.

## Not included

The remaining `#994` InboxDetail split is parked on `refactor/994-split-inbox-detail` (leaf modules extracted, `InboxDetail.tsx` not yet rewired). It was deliberately held back because #1126 is in flight against the same regions of that file; landing a whole-file restructure first would force that fix to be re-applied by hand rather than merged.