### PR TITLE
chore(lint): biome enforces explicit-any, template literals and folder ignores

### DIFF
--- a/apps/desktop/biome.json
+++ b/apps/desktop/biome.json
@@ -6,11 +6,11 @@
       "src/**/*.tsx",
       "src/**/*.js",
       "src/**/*.jsx",
-      "!src/bindings/**",
-      "!src/paraglide/**",
-      "!**/src-archived-2026-05-24/**",
-      "!node_modules/**",
-      "!dist/**"
+      "!src/bindings",
+      "!src/paraglide",
+      "!**/src-archived-2026-05-24",
+      "!node_modules",
+      "!dist"
     ]
   },
   "linter": {
@@ -28,12 +28,14 @@
       },
       "style": {
         "noNonNullAssertion": "warn",
+        "useTemplate": "error",
         "noCommonJs": "error"
       },
       "suspicious": {
         "noArrayIndexKey": "off",
-        "noExplicitAny": "warn",
-        "noTemplateCurlyInString": "off"
+        "noExplicitAny": "error",
+        "noTemplateCurlyInString": "off",
+        "useBiomeIgnoreFolder": "error"
       }
     }
   },

--- a/apps/desktop/src/dev/devSurface.release.test.ts
+++ b/apps/desktop/src/dev/devSurface.release.test.ts
@@ -27,14 +27,15 @@ describe('T072: release build dev surface gate', () => {
   let originalEnv: string;
 
   beforeEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const env = (import.meta as any).env as Record<string, string> | undefined;
+    const env = import.meta.env as unknown as
+      | Record<string, string>
+      | undefined;
     originalEnv = env?.VITE_DEV_TOOLS ?? 'false';
   });
 
   afterEach(() => {
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    (import.meta as any).env.VITE_DEV_TOOLS = originalEnv;
+    (import.meta.env as unknown as Record<string, string>).VITE_DEV_TOOLS =
+      originalEnv;
   });
 
   it('DEV_TOOLS_ENABLED is false when VITE_DEV_TOOLS is not "true"', () => {

--- a/apps/desktop/src/features/plans/PlanProtectionGate.tsx
+++ b/apps/desktop/src/features/plans/PlanProtectionGate.tsx
@@ -161,9 +161,9 @@ export function PlanProtectionGate({
         return (
           <div
             key={item.itemId}
-            className={
-              'pv-plan-gate__item' + (isDone ? ' pv-plan-gate__item--done' : '')
-            }
+            className={`pv-plan-gate__item${
+              isDone ? ' pv-plan-gate__item--done' : ''
+            }`}
           >
             <div className="pv-plan-gate__item-header">
               <Pill variant="ok">{item.level}</Pill>

--- a/apps/desktop/src/features/sessions/CalendarScroll.tsx
+++ b/apps/desktop/src/features/sessions/CalendarScroll.tsx
@@ -100,7 +100,10 @@ export function CalendarScroll({ nights, onNightSelect }: CalendarScrollProps) {
             );
           }
 
-          const night = row.night!;
+          const night = row.night;
+          if (!night) {
+            return null;
+          }
           return (
             <div
               key={virtualRow.key}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -77,7 +77,10 @@ if (import.meta.env.VITE_E2E) {
   });
 }
 
-const root = document.getElementById('root')!;
+const root = document.getElementById('root');
+if (!root) {
+  throw new Error('Root element #root is missing from index.html');
+}
 
 createRoot(root).render(
   <StrictMode>


### PR DESCRIPTION
Tightens the desktop biome config to the strictest setting each rule currently
supports without carrying a backlog, and clears the sites that only ever
surfaced as warnings.

## Why now

While checking a report that `biome check .` was failing on `main`, it turned
out not to be: every leg of root `pnpm lint` exits 0 (`cargo fmt`, `cargo
clippy --workspace --all-targets -D warnings`, the desktop lint chain, and
`lint:tests`). There is no local/CI divergence, and no issue was filed.

What the check did surface is that 81 findings were accumulating as warnings
nobody reads. This makes the ones we have actually cleared enforceable.

## Changes

| Rule | Before | After |
|---|---|---|
| `suspicious/noExplicitAny` | `warn` | **`error`** |
| `style/useTemplate` | default | **`error`** |
| `suspicious/useBiomeIgnoreFolder` | default | **`error`** |
| `style/noNonNullAssertion` | `warn` | `warn` (unchanged — see below) |

Sites cleared to make that possible:

- **`biome.json`** — folder ignores use the folder form (`!src/bindings`
  rather than `!src/bindings/**`).
- **`main.tsx`** — throws a named error when `#root` is absent rather than
  asserting it away. A missing root now fails with a readable message instead
  of a null deref.
- **`CalendarScroll.tsx`** — returns `null` for a night-less row instead of
  `row.night!`.
- **`PlanProtectionGate.tsx`** — template literal instead of string concat.
- **`devSurface.release.test.ts`** — reaches `import.meta.env` without an
  `any` cast, so two `eslint-disable` directives are no longer needed.

## Verification

A clean run proves nothing unless the new rules can fail, so a positive
control ran first: a probe file containing one `any` parameter and one string
concat.

```
probe exit=1
  src/__biome_probe.ts:1:29 lint/suspicious/noExplicitAny
  src/__biome_probe.ts:2:43 lint/style/useTemplate
  Found 2 errors.
```

With the probe removed:

- `biome check .` — exit 0, 72 warnings (was 81), all `noNonNullAssertion`
- **474 files checked before and after the ignore-glob rewrite** — the ignore
  scope is provably unchanged, which is the actual risk in that edit
- `tsc --noEmit` — exit 0, and exit 0 on stashed `main` too (two-direction
  control, so this is not masking a pre-existing failure)
- `vitest run src/dev src/features/sessions src/features/plans` — 24 files,
  192 tests, all passing

## Deliberately not in this PR

`noNonNullAssertion` stays a warning. 72 of its 74 hits are in test files
where `expect(x).toBeDefined(); expect(x!.y)` is the idiomatic shape, and
biome's fix is marked **unsafe** because it rewrites `x!` to `x?.` — which
converts assertions into ones that can pass on `undefined`. Mechanically
applying it across 72 sites would quietly degrade the suite.

The intended follow-up is to scope the rule to non-test files and promote it
to `error`, which surfaces its 2 remaining production hits instead of burying
them. Both are in `TargetsTable.tsx`, which #1160 is mid-rebase on, so that
change is deferred rather than merged into a conflict.