### PR TITLE
feat: remember detail panel placement in typed preferences

### DIFF
--- a/apps/desktop/src-tauri/src/commands/preferences.rs
+++ b/apps/desktop/src-tauri/src/commands/preferences.rs
@@ -30,6 +30,7 @@ pub async fn preferences_get() -> Result<AppPreferences, ContractError> {
         sessions_view: SessionsView::List,
         tour_completed: TourCompleted { step1: false, step2: false, step3: false },
         setup_completed: false,
+        detail_dock: HashMap::new(),
     })
 }
 

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -464,6 +464,7 @@ const mockPreferences: AppPreferences = {
   sessionsView: 'list',
   tourCompleted: { step1: false, step2: false, step3: false },
   setupCompleted: false,
+  detailDock: {},
 };
 
 // Review items are loaded from the wireframe-aligned fixture file (review.queue case below).

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -2082,6 +2082,8 @@ export type AppPreferences = {
 	sessionsView: SessionsView,
 	tourCompleted: TourCompleted,
 	setupCompleted: boolean,
+	/**  Keyed by `dockId` (the adopting list page, e.g. `"sessions"`). */
+	detailDock: { [key in string]: DetailDockPref },
 };
 
 /**
@@ -3517,6 +3519,17 @@ export type Density = "compact" | "comfortable" | "spacious";
 /**  Per-plan destination for destructive items (R-Trash-1). */
 export type DestructiveDestination = "archive" | "os_trash";
 
+/**
+ *  Per-page detail-dock state.
+ * 
+ *  `placement` is three-state: `Some(Side)` / `Some(Bottom)` pin the dock,
+ *  `None` means "auto" — follow the window-width rule (#1066).
+ */
+export type DetailDockPref = {
+	placement: DockPlacement | null,
+	width: number | null,
+};
+
 /**  Per-root detection trigger configuration (spec 048 FR-014/FR-015/FR-017). */
 export type DetectionConfig = {
 	live: boolean,
@@ -3694,6 +3707,9 @@ export type DirectoryPickResponse = {
 	/**  True when the user dismissed the dialog without selecting. */
 	cancelled: boolean,
 };
+
+/**  Detail-panel dock placement for a list page. */
+export type DockPlacement = "side" | "bottom";
 
 /**  Entity kind for audit-log correlation on reveal operations. */
 export type EntityKind = "inbox_item" | "inventory_row" | "project_manifest" | "master_calibration" | "registered_source" | "other";

--- a/apps/desktop/src/components/ListPageLayout.test.tsx
+++ b/apps/desktop/src/components/ListPageLayout.test.tsx
@@ -15,11 +15,19 @@
  * `bottomDetail`), each with their own aria label and close affordance.
  */
 
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import {
+  render,
+  screen,
+  fireEvent,
+  act,
+  renderHook,
+} from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { ListPageLayout } from './ListPageLayout';
 import { Modal } from './Modal';
 import { Combobox } from '@base-ui-components/react/combobox';
+import { resetPreferences } from '@/data/preferences';
+import { useAdaptiveDock } from '@/ui/useAdaptiveDock';
 
 /** Simulate a browser window resize for the adaptive-dock hook (jsdom
  * doesn't resize on its own — `window.innerWidth` must be forced). */
@@ -360,7 +368,9 @@ describe('ListPageLayout', () => {
     const originalInnerWidth = window.innerWidth;
 
     beforeEach(() => {
-      window.localStorage.clear();
+      // Clears the in-memory preference cache too — plain localStorage.clear()
+      // would leave the module cache holding the previous test's dock pins.
+      resetPreferences();
     });
 
     afterEach(() => {
@@ -415,7 +425,7 @@ describe('ListPageLayout', () => {
       );
     });
 
-    it('pinning to side persists across remount (dockId-scoped localStorage)', () => {
+    it('pinning to side persists across remount (dockId-scoped preference)', () => {
       resizeWindowTo(1024);
       const { container, unmount } = render(
         <ListPageLayout
@@ -542,6 +552,111 @@ describe('ListPageLayout', () => {
       expect(region).toBeInTheDocument();
       fireEvent.click(screen.getByRole('button', { name: 'Close details' }));
       expect(onClose).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  // ── useAdaptiveDock, directly (#1158) ────────────────────────────────────
+  //
+  // The hook drives all placement but was only ever covered indirectly, through
+  // this layout. That is how #1066 slipped through: `setOverride(null)` — the
+  // "return to Auto" path — had no call site at all, and no test caught it.
+  //
+  // Folded into this file rather than a new one on purpose: adding a
+  // React-rendering test file previously tipped the suite into load-induced
+  // timeouts in unrelated suites, so these live beside the layout tests that
+  // already exercise the same hook.
+
+  describe('useAdaptiveDock', () => {
+    const originalInnerWidth = window.innerWidth;
+
+    beforeEach(() => {
+      resetPreferences();
+    });
+
+    afterEach(() => {
+      resizeWindowTo(originalInnerWidth);
+    });
+
+    it('resolves placement from the threshold when unpinned', () => {
+      resizeWindowTo(1024);
+      const { result, rerender } = renderHook(() =>
+        useAdaptiveDock({ dockId: 'hook-threshold' }),
+      );
+      expect(result.current.placement).toBe('bottom');
+      expect(result.current.override).toBeNull();
+
+      act(() => resizeWindowTo(1600));
+      rerender();
+      expect(result.current.placement).toBe('side');
+    });
+
+    it('a pin overrides the threshold, and setOverride(null) restores it (#1066)', () => {
+      resizeWindowTo(1600);
+      const { result } = renderHook(() =>
+        useAdaptiveDock({ dockId: 'hook-override' }),
+      );
+      expect(result.current.placement).toBe('side');
+
+      act(() => result.current.setOverride('bottom'));
+      expect(result.current.placement).toBe('bottom');
+      expect(result.current.override).toBe('bottom');
+
+      // The regression: clearing the pin must resume the width rule, not
+      // persist a value that reads back as a pin.
+      act(() => result.current.setOverride(null));
+      expect(result.current.override).toBeNull();
+      expect(result.current.placement).toBe('side');
+    });
+
+    it('falls back to bottom when the window is too narrow for a side dock', () => {
+      // sideAvailable = innerWidth >= minWidth * 2. Below that an explicit
+      // 'side' pin must NOT win — the 1100x720 shell minimum stays workable.
+      resizeWindowTo(600);
+      const { result } = renderHook(() =>
+        useAdaptiveDock({ dockId: 'hook-narrow', minWidth: 320 }),
+      );
+      act(() => result.current.setOverride('side'));
+      expect(result.current.override).toBe('side');
+      expect(result.current.placement).toBe('bottom');
+    });
+
+    it('clamps width to [minWidth, window * maxWidthFraction]', () => {
+      resizeWindowTo(1600);
+      const { result } = renderHook(() =>
+        useAdaptiveDock({
+          dockId: 'hook-clamp',
+          minWidth: 320,
+          maxWidthFraction: 0.5,
+        }),
+      );
+      act(() => result.current.setWidth(50));
+      expect(result.current.width).toBe(320);
+
+      act(() => result.current.setWidth(5000));
+      expect(result.current.width).toBe(800); // 1600 * 0.5
+
+      act(() => result.current.setWidth(500));
+      expect(result.current.width).toBe(500);
+    });
+
+    it('persists across remount, scoped per dockId', () => {
+      resizeWindowTo(1600);
+      const first = renderHook(() => useAdaptiveDock({ dockId: 'page-a' }));
+      act(() => {
+        first.result.current.setOverride('bottom');
+        first.result.current.setWidth(500);
+      });
+      first.unmount();
+
+      // Same id: restored.
+      const restored = renderHook(() => useAdaptiveDock({ dockId: 'page-a' }));
+      expect(restored.result.current.override).toBe('bottom');
+      expect(restored.result.current.width).toBe(500);
+
+      // Different id: untouched by page-a's pin.
+      const other = renderHook(() => useAdaptiveDock({ dockId: 'page-b' }));
+      expect(other.result.current.override).toBeNull();
+      expect(other.result.current.placement).toBe('side');
     });
   });
 });

--- a/apps/desktop/src/data/preferences.ts
+++ b/apps/desktop/src/data/preferences.ts
@@ -20,6 +20,7 @@ const defaults: AppPreferences = {
   sessionsView: 'list',
   tourCompleted: { step1: false, step2: false, step3: false },
   setupCompleted: false,
+  detailDock: {},
 };
 
 function notify(): void {

--- a/apps/desktop/src/ui/useAdaptiveDock.ts
+++ b/apps/desktop/src/ui/useAdaptiveDock.ts
@@ -7,6 +7,8 @@ import {
   useEffect,
   useState,
 } from 'react';
+import type { DetailDockPref, DockPlacement } from '@/bindings';
+import { getPreferences, setPreference } from '@/data/preferences';
 
 /**
  * useAdaptiveDock — spec 054 (#936): decides whether a list page's detail
@@ -18,11 +20,12 @@ import {
  * of an override — bottom is the universal narrow-window fallback (decision
  * #8: the shell's enforced 1100x720 minimum must stay fully workable).
  *
- * `dockId` scopes localStorage persistence per adopting page (e.g.
- * "sessions", "targets") so each page remembers its own pin + width.
+ * `dockId` scopes persistence per adopting page (e.g. "sessions", "targets")
+ * so each page remembers its own pin + width, stored under the typed
+ * `detailDock` preference (#1158).
  */
 
-export type DockPlacement = 'side' | 'bottom';
+export type { DockPlacement };
 
 export interface UseAdaptiveDockOptions {
   /** Persistence key scope, e.g. "sessions", "calibration", "targets". */
@@ -55,19 +58,15 @@ export interface UseAdaptiveDockResult {
   resizing: boolean;
 }
 
-const STORAGE_PREFIX = 'pv-dock';
-
-function readStoredPlacement(dockId: string): DockPlacement | null {
-  const raw = window.localStorage.getItem(
-    `${STORAGE_PREFIX}-placement-${dockId}`,
-  );
-  return raw === 'side' || raw === 'bottom' ? raw : null;
+function readStored(dockId: string): DetailDockPref | undefined {
+  return getPreferences().detailDock?.[dockId];
 }
 
-function readStoredWidth(dockId: string): number | null {
-  const raw = window.localStorage.getItem(`${STORAGE_PREFIX}-width-${dockId}`);
-  const parsed = raw != null ? Number(raw) : NaN;
-  return Number.isFinite(parsed) ? parsed : null;
+/** Merges a partial dock update for one `dockId` into the typed preference. */
+function writeStored(dockId: string, patch: Partial<DetailDockPref>): void {
+  const all = getPreferences().detailDock ?? {};
+  const current = all[dockId] ?? { placement: null, width: null };
+  setPreference('detailDock', { ...all, [dockId]: { ...current, ...patch } });
 }
 
 export function useAdaptiveDock({
@@ -78,11 +77,11 @@ export function useAdaptiveDock({
   defaultWidth = 420,
 }: UseAdaptiveDockOptions): UseAdaptiveDockResult {
   const [windowWidth, setWindowWidth] = useState(() => window.innerWidth);
-  const [override, setOverrideState] = useState<DockPlacement | null>(() =>
-    readStoredPlacement(dockId),
+  const [override, setOverrideState] = useState<DockPlacement | null>(
+    () => readStored(dockId)?.placement ?? null,
   );
   const [width, setWidthState] = useState<number>(
-    () => readStoredWidth(dockId) ?? defaultWidth,
+    () => readStored(dockId)?.width ?? defaultWidth,
   );
   const [resizing, setResizing] = useState(false);
 
@@ -105,10 +104,7 @@ export function useAdaptiveDock({
     (value: number) => {
       const clamped = clampWidth(value);
       setWidthState(clamped);
-      window.localStorage.setItem(
-        `${STORAGE_PREFIX}-width-${dockId}`,
-        String(clamped),
-      );
+      writeStored(dockId, { width: clamped });
     },
     [clampWidth, dockId],
   );
@@ -116,9 +112,7 @@ export function useAdaptiveDock({
   const setOverride = useCallback(
     (value: DockPlacement | null) => {
       setOverrideState(value);
-      const key = `${STORAGE_PREFIX}-placement-${dockId}`;
-      if (value == null) window.localStorage.removeItem(key);
-      else window.localStorage.setItem(key, value);
+      writeStored(dockId, { placement: value });
     },
     [dockId],
   );

--- a/crates/contracts/core/src/preferences.rs
+++ b/crates/contracts/core/src/preferences.rs
@@ -45,6 +45,27 @@ pub enum SessionsView {
     Calendar,
 }
 
+/// Detail-panel dock placement for a list page.
+#[derive(
+    Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Type,
+)]
+#[serde(rename_all = "snake_case")]
+pub enum DockPlacement {
+    Side,
+    Bottom,
+}
+
+/// Per-page detail-dock state.
+///
+/// `placement` is three-state: `Some(Side)` / `Some(Bottom)` pin the dock,
+/// `None` means "auto" — follow the window-width rule (#1066).
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct DetailDockPref {
+    pub placement: Option<DockPlacement>,
+    pub width: Option<f64>,
+}
+
 /// Application-level user preferences.
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
@@ -57,4 +78,6 @@ pub struct AppPreferences {
     pub sessions_view: SessionsView,
     pub tour_completed: TourCompleted,
     pub setup_completed: bool,
+    /// Keyed by `dockId` (the adopting list page, e.g. `"sessions"`).
+    pub detail_dock: std::collections::HashMap<String, DetailDockPref>,
 }

--- a/tests/e2e/support/harness.ts
+++ b/tests/e2e/support/harness.ts
@@ -55,12 +55,33 @@ export async function installTauriChannelPolyfill(page: Page): Promise<void> {
   });
 }
 
-/** Seed first-run as complete so the app lands on real content, not the wizard. */
+/**
+ * Seed first-run as complete so the app lands on real content, not the wizard.
+ *
+ * MERGES into any existing `alm-preferences` rather than replacing it. This
+ * runs via `addInitScript`, so it re-executes on EVERY navigation *including
+ * reloads* — a wholesale `setItem` therefore silently wiped every other
+ * preference each time a spec reloaded the page.
+ *
+ * That went unnoticed while all cross-reload UI state lived in its own
+ * top-level localStorage keys. Once dock placement moved into the typed
+ * preferences blob (#1158), it made "persists across a reload" specs fail
+ * against a perfectly working app: the seed erased the pin mid-test. Any
+ * future preference would have hit the same trap, so merge here rather than
+ * special-casing one key.
+ */
 export function seedSetupComplete(page: Page): void {
   page.addInitScript(() => {
+    let existing: Record<string, unknown> = {};
+    try {
+      const raw = window.localStorage.getItem('alm-preferences');
+      if (raw) existing = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      // Corrupt or unreadable value — fall back to seeding a fresh object.
+    }
     window.localStorage.setItem(
       'alm-preferences',
-      JSON.stringify({ setupCompleted: true }),
+      JSON.stringify({ ...existing, setupCompleted: true }),
     );
   });
 }


### PR DESCRIPTION
Addresses items 2 and 3 of #1158.
Closes #1243.

## Summary

- Dock placement and width now persist through the typed `AppPreferences` layer
  instead of raw `pv-dock-*` localStorage keys written directly by the hook.
  This was spec 054's T007, designed but never built.
- The `useAdaptiveDock` hook now has direct test coverage. It drives all
  placement but was only covered indirectly — which is how #1066 got in.

## Contract change

`detail_dock: HashMap<String, DetailDockPref>` added to the Rust
`AppPreferences` (the generated source of truth), TS bindings regenerated.

`placement` is deliberately **three-state**: `Some(Side)` / `Some(Bottom)` pin
the dock, `None` means *auto — follow the window-width rule*. Collapsing that to
two states is exactly what #1066 was: the null-override path had no call site at
all, and no test caught it.

## No migration — deliberate

Per an explicit product decision, existing `pv-dock-*` keys are not migrated.
Users take a one-time placement reset, as they already did in #1106 when the keys
stopped being derived from a translated UI string.

## Tests are mutation-checked, not just green

The new assertions were verified to actually fail on the regressions they claim
to catch:

| Mutation | Result |
|---|---|
| `sideAvailable` forced `true` | narrow-window fallback test fails ✓ |
| `setOverride(null)` made a no-op (re-introducing #1066) | new hook test **and** existing layout test both fail ✓ |

Folded into `ListPageLayout.test.tsx` rather than a new `useAdaptiveDock.test.ts`
on purpose: adding a React-rendering test file previously tipped this suite into
load-induced timeouts in unrelated suites.

## Verification

- `just check-generated` — passes, no binding drift
- `cargo test -p contracts_core` — 71 passed; `cargo clippy` clean; `cargo fmt` no diff
- `tsc --noEmit` clean, `biome check` clean
- `vitest run` — 199 files / 1825 tests pass

Not verified: no real-UI run. This is unit/type-level evidence only. The
behaviour is covered by the mutation-checked tests above, but a live check that
placement still survives an app restart would be a reasonable follow-up.

## Spec Context
- Spec: 054 (adaptive detail dock), task T007
- Branch: fix/1158-typed-dock-prefs
