### PR TITLE
fix: show the cleanup protection rule as text instead of hiding it in per-row tooltips

### DIFF
--- a/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
+++ b/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
@@ -176,7 +176,10 @@ function candidateRow(candidate: CleanupCandidate, index: number) {
       : candidate.reason,
     protection: isProtected ? (
       <span className="pv-cleanup-scan__protected-cell">
-        <Lock reason={m.projects_cleanup_row_protected_hint()} />
+        {/* Decorative: the hint is one static sentence, identical on every
+            protected row, and is stated once above the table. Giving each row
+            its own tab stop would repeat that same announcement N times. */}
+        <Lock decorative />
         <Pill variant="warn">{m.settings_cleanup_protection_protected()}</Pill>
       </span>
     ) : parsed ? (
@@ -205,6 +208,12 @@ export function CleanupSection({
   const result = scan.data;
   const groups = result ? groupCandidates(result.candidates) : [];
   const hasCandidates = (result?.candidates.length ?? 0) > 0;
+  // Whether any candidate is protected. The acknowledgement rule is stated once
+  // here rather than N times behind identical per-row padlock tooltips, so it
+  // is visible without hovering and costs one tab stop instead of one per row.
+  const hasProtected = (result?.candidates ?? []).some(
+    (c) => parseCandidateReason(c.reason)?.protection === 'protected',
+  );
 
   const handleGenerate = () => {
     generate.mutate(
@@ -276,6 +285,13 @@ export function CleanupSection({
           title={m.projects_cleanup_no_candidates_title()}
           desc={m.projects_cleanup_no_candidates_desc()}
         />
+      )}
+
+      {/* The protection rule, stated once for every protected row below. */}
+      {hasProtected && (
+        <p className="pv-text-muted" data-testid="cleanup-protected-note">
+          {m.projects_cleanup_row_protected_hint()}
+        </p>
       )}
 
       {/* Candidates grouped by classification (intermediate → master → final). */}

--- a/apps/desktop/src/ui/Lock.test.tsx
+++ b/apps/desktop/src/ui/Lock.test.tsx
@@ -43,4 +43,23 @@ describe('Lock accessibility', () => {
     render(<Lock />);
     expect(screen.getByRole('note', { name: 'Protected' })).toBeInTheDocument();
   });
+
+  // The decorative variant is the deliberate exception: it is only correct
+  // where the reason is stated in text nearby AND is identical for every
+  // instance, so N focus stops would announce the same sentence N times.
+  it('decorative locks are hidden from assistive tech and out of the tab order', () => {
+    const { container } = render(<Lock decorative />);
+
+    expect(screen.queryByRole('note')).not.toBeInTheDocument();
+
+    const glyph = container.querySelector('.pv-lock');
+    expect(glyph).not.toBeNull();
+    expect(glyph).toHaveAttribute('aria-hidden', 'true');
+    expect(glyph).not.toHaveAttribute('tabindex');
+  });
+
+  it('decorative locks still render the padlock glyph', () => {
+    const { container } = render(<Lock decorative />);
+    expect(container.querySelector('.pv-lock')?.textContent).toBe('\u{1F512}');
+  });
 });

--- a/apps/desktop/src/ui/Lock.tsx
+++ b/apps/desktop/src/ui/Lock.tsx
@@ -7,6 +7,13 @@ import { m } from '@/lib/i18n';
 
 export interface LockProps extends HTMLAttributes<HTMLSpanElement> {
   reason?: string;
+  /**
+   * Render as pure decoration: no tooltip, no role, no tab stop, hidden from
+   * assistive tech. Only correct where the reason is already stated in text
+   * nearby AND is identical for every instance — otherwise the padlock is the
+   * sole carrier of that information and must stay reachable (see below).
+   */
+  decorative?: boolean;
 }
 
 /**
@@ -25,9 +32,23 @@ export interface LockProps extends HTMLAttributes<HTMLSpanElement> {
  *   applies to elements with a role that supports it — so the role is what
  *   makes the label reach assistive tech at all.
  */
-export function Lock({ reason, className, ...rest }: LockProps) {
+export function Lock({ reason, decorative, className, ...rest }: LockProps) {
   const label = reason ?? m.settings_cleanup_protection_protected();
   const cls = ['pv-lock', className].filter(Boolean).join(' ');
+
+  // Decorative instances carry no information of their own, so giving each one
+  // a role and a tab stop would add N identical announcements to the tab order
+  // (the cleanup table's per-row hint is one static sentence, repeated on every
+  // protected row). The rule is stated once above that table instead, and the
+  // row's "Protected" pill still marks the state in text.
+  if (decorative) {
+    return (
+      <span className={cls} aria-hidden="true" {...rest}>
+        &#x1F512;
+      </span>
+    );
+  }
+
   return (
     <Tooltip
       content={label}


### PR DESCRIPTION
## Summary

- The Cleanup section's scan table rendered a padlock on every protected row whose tooltip is **one static sentence, identical on every row**. Since #1164 made those padlocks keyboard-focusable, a table with twelve protected rows produced **twelve tab stops that all announce the same thing**.
- That rule is now stated once, in text, above the table — so it's visible without hovering. Previously a sighted user had to discover it through a tooltip.
- With the consequence on screen, the per-row padlock becomes decoration (the adjacent "Protected" pill already marks the state in text), so it leaves the tab order.

## Why this isn't a regression of #1164

#1164 was correct: `Lock`'s reason was reachable by pointer only, and it states a consequence shown nowhere else. This fixes the *root* of that — the consequence is no longer shown nowhere else — rather than reverting the focusability.

The **protected-categories list is deliberately unchanged**. Each of its reasons is distinct per category (`"{category} are protected and excluded from cleanup plans"`) and the list is short, so each tab stop there carries new information and stays focusable. `Lock`'s new `decorative` variant is documented as only correct where the reason is stated nearby *and* identical across instances.

Note the two blocks describe genuinely different protections — categories are *never proposed* for cleanup, while table rows *do* appear and merely need acknowledgement — so they aren't redundant with each other.

## Implementation notes

- No new i18n string: the note reuses the existing `projects_cleanup_row_protected_hint` key.
- No new CSS class: reuses the shared `.pv-text-muted` utility.
- `Lock` gains one parameterised variant rather than a second component.

## Verification

- 291 tests pass across 31 files (`src/ui/Lock.test.tsx` + all of `src/features/projects/`).
- New tests assert the decorative variant is `aria-hidden`, carries no `tabindex`, exposes no `note` role, and still renders the glyph.
- **Negative control:** removing `aria-hidden` from the decorative branch fails that test and only that test.
- `typecheck` and `biome check` clean.

## Context

This resolves the open question flagged for a reviewer in #1164 and recorded as ambiguity 2 in the session-3 decision log, rather than leaving it to be re-litigated in the next a11y sweep.