### PR TITLE
fix: inbox end-to-end check looks for the current Type-column class

### DIFF
--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -475,7 +475,7 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
 
 /// Trimmed, lowercased text of every Type-column cell currently rendered in
 /// the Inbox list. That cell carries no `data-testid` of its own — it is the
-/// `span.alm-inbox-row__classification` inside each row (the `type:` cell in
+/// `span.pv-inbox-row__classification` inside each row (the `type:` cell in
 /// `apps/desktop/src/features/inbox/InboxList.tsx`), so it is located by class.
 ///
 /// Callers MUST compare with exact equality, never `contains`: "unclassified"
@@ -499,7 +499,7 @@ async fn classification_cell_labels(app: &E2eApp) -> anyhow::Result<Vec<String>>
             r#"
             return JSON.stringify(
                 Array.prototype.map.call(
-                    document.querySelectorAll('.alm-inbox-row__classification'),
+                    document.querySelectorAll('.pv-inbox-row__classification'),
                     function (el) { return el.textContent || ''; }
                 )
             );


### PR DESCRIPTION
## Summary

- The Inbox Type-column E2E helper still looked for the old `alm-` CSS class after the `--alm-*` → `--pv-*` rename, so it matched no elements and the journey guarding the unclassified-folder badge failed on Linux and Windows.

## Root cause

#1162 renamed the namespace and updated `InboxList.tsx`, whose Type cell now renders `pv-inbox-row__classification` (`InboxList.tsx:520`). It missed this Rust E2E helper, which kept querying `.alm-inbox-row__classification` (`inbox_ui_journeys.rs:502`). `querySelectorAll` matched nothing, so `classification_cell_labels` returned an empty list and `inbox_ui_unsplit_unclassified_folder_badge_is_not_classified` — the journey protecting the #1099 fix — failed on the ubuntu 2/4 and windows 2/2 shards.

## This is a defect on main, not on the PR that surfaced it

It first appeared on #1169, which changes only `apps/desktop/src-tauri/**`, `justfile` and `.github/**` — no frontend and no test files — so it cannot affect a DOM selector. #1169 was simply the first PR to complete a full Real-UI E2E run after #1162 landed. Merging this unblocks that gate.

Related: #1162 (the rename), #1099 (the fix the journey protects).
