### PR TITLE
test: repair the Inbox journey selector broken by the design-system rename

### DIFF
--- a/crates/e2e-tests/tests/inbox_ui_journeys.rs
+++ b/crates/e2e-tests/tests/inbox_ui_journeys.rs
@@ -475,7 +475,7 @@ async fn inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm() -> anyhow
 
 /// Trimmed, lowercased text of every Type-column cell currently rendered in
 /// the Inbox list. That cell carries no `data-testid` of its own — it is the
-/// `span.alm-inbox-row__classification` inside each row (the `type:` cell in
+/// `span.pv-inbox-row__classification` inside each row (the `type:` cell in
 /// `apps/desktop/src/features/inbox/InboxList.tsx`), so it is located by class.
 ///
 /// Callers MUST compare with exact equality, never `contains`: "unclassified"
@@ -499,7 +499,7 @@ async fn classification_cell_labels(app: &E2eApp) -> anyhow::Result<Vec<String>>
             r#"
             return JSON.stringify(
                 Array.prototype.map.call(
-                    document.querySelectorAll('.alm-inbox-row__classification'),
+                    document.querySelectorAll('.pv-inbox-row__classification'),
                     function (el) { return el.textContent || ''; }
                 )
             );


### PR DESCRIPTION
## Summary

- The `#711` Real-UI journey queried `.alm-inbox-row__classification`. The
  `--alm-*`/`.alm-*` namespace was renamed to `--pv-*` in #1162, so the selector
  matched nothing, the settle loop never saw its signal, and the journey hung
  for 20s then failed after 144s reporting `Type cells were []`.
- The empty array was never an empty list. `select_only_item` had already
  succeeded and `inbox-unclassified-alert` had already rendered, so rows existed
  and classify had run — only the Type-column read was stale.
- With `.pv-` the journey passes in **3.4s**, and the **full Layer-2 suite is
  24/24 green** locally (152s).

## Why this was invisible

- `main` has no branch protection, so nothing is a required check.
- The journeys are `#[ignore]`d and run only under `--run-ignored all`.
- CI *was* reporting `failure` for `Real-UI E2E — ubuntu-latest` and
  `windows-latest`; it simply gated nothing.

## Two notes

This journey had **never been executed**. Its own doc comment says *"written but
NOT YET EXECUTED (authored alongside the fix without a Layer-2 run). Validate it
on its first real run."* This was that first run.

It was the only e2e selector reaching into a CSS class rather than a
`data-testid`, which is why #1162 broke this journey and no other. `grep`
confirms no `.alm-` selectors remain in `crates/e2e-tests`.

## Verification

Baseline before the fix (`main` @ `15edea17`), reproduced twice, deterministic:

    FAIL [143.966s] inbox_ui_unsplit_unclassified_folder_badge_is_not_classified
    Error: the post-classify Inbox list never settled within 20s
    (no materialized 'needs review' sub-item row appeared); Type cells were []

After:

    PASS [3.449s] inbox_ui_unsplit_unclassified_folder_badge_is_not_classified
    Summary [152.398s] 24 tests run: 24 passed, 0 skipped

Harness proven non-vacuous: with the preview server killed, a passing journey
hangs rather than passing, so these genuinely drive the app.

Fixes #1202.