### PR TITLE
test: log panel follow-scroll test waits for settings before toggling Follow

### DIFF
--- a/apps/desktop/src/app/LogPanel.followScroll.test.tsx
+++ b/apps/desktop/src/app/LogPanel.followScroll.test.tsx
@@ -238,6 +238,19 @@ describe('LogPanel follow-tail scroll pause/resume (T011)', () => {
       expect(screen.getByText('Second entry')).toBeInTheDocument();
     });
 
+    // Gate on follow-tail having settled ON before toggling it, exactly as the
+    // two tests above do. The initial state arrives asynchronously from
+    // `settingsGet` (`rememberFollowLogs: true`), so a click fired before that
+    // promise resolves is undone by the resolution — leaving the button on
+    // '↓ Follow' where the assertion below expects '— Follow'. Passes on an
+    // idle machine, fails on a contended runner (#1209).
+    await waitFor(() => {
+      expect(getFollowButton()).toHaveAttribute(
+        'aria-label',
+        'Follow tail on (click to pause)',
+      );
+    });
+
     // Turn follow off first (repro starts with Follow inactive).
     fireEvent.click(getFollowButton());
     await waitFor(() => {


### PR DESCRIPTION
## Summary

- Fixes #1209 — `LogPanel.followScroll.test.tsx` failed intermittently on loaded CI with `expected '↓ Follow' to be '— Follow'`.
- The panel's initial follow-tail state arrives asynchronously from the mocked `settingsGet` (`rememberFollowLogs: true`). This test clicked the Follow button immediately after the first row rendered, so on a contended runner the click landed before that promise resolved and was then undone by the resolution.
- Adds the readiness gate the two sibling tests in the same file already use (`aria-label` = `Follow tail on (click to pause)`) before the first click. Test-only; no product code touched, no assertion weakened or removed.

## Why the earlier fix missed it

`4c04b606` (#1118) fixed the same class of race in this file, but at the `scrollTo` assertion near the end of the test. The missing gate before the *first click* is a separate point in the same test, so that fix left this path exposed.

## Verification

Reproduced deterministically rather than inferred, by injecting a 250ms delay into the `settingsGet` mock to simulate a contended runner, then running both directions:

| Variant | Result |
|---|---|
| Without the gate + forced race | `1 failed` — `AssertionError: expected '↓ Follow' to be '— Follow'`, the exact CI error |
| With the gate + forced race | `3 passed` |
| With the gate, no injected delay | `3 passed` |

Frontend lint pipeline clean (Biome, ESLint gates, token contrast, i18n catalog).

## Spec Context
- Spec: 019 (T011)