### PR TITLE
test(e2e): set an explicit script timeout and stop discarding bridge errors

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -181,6 +181,25 @@ pub const LAUNCH_TIMEOUT: Duration = Duration::from_secs(240);
 /// cold CI runner without masking a genuinely-absent element for long.
 pub const DEFAULT_FIND_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Deadline for a single `execute_async` script, set explicitly on the session
+/// (#1205). Before this existed the suite silently inherited the driver's own
+/// default — the W3C default is 30 s, which a legitimate IPC invoke can exceed
+/// on a saturated Windows runner, producing a bare "Script execution timed out"
+/// that names neither the command nor the budget it blew.
+///
+/// 90 s is chosen to sit *below* nextest's per-attempt hard kill (`period = 60s,
+/// terminate-after = 5` => 300 s in `.config/nextest.toml`) so a script timeout
+/// still fails as a readable test error rather than as a process kill, while
+/// leaving room for several sequential invokes in one journey. Raising this
+/// cannot mask a true hang: [`E2eApp::invoke`] names the in-flight command in
+/// its error context, so a script that never calls back still fails loudly.
+pub const SCRIPT_TIMEOUT: Duration = Duration::from_secs(90);
+
+/// Deadline for a document navigation. `goto_route` is followed by an explicit
+/// [`E2eApp::wait_bridge_ready`] poll, so this only needs to bound the raw
+/// navigation itself.
+pub const SCRIPT_TIMEOUT_PAGE_LOAD: Duration = Duration::from_secs(60);
+
 // ---------------------------------------------------------------------------
 // Private deserialization target for invoke() responses
 // ---------------------------------------------------------------------------
@@ -366,6 +385,38 @@ impl E2eApp {
             }
         };
 
+        // Set the script timeout EXPLICITLY (#1205). Until this call existed,
+        // every `execute_async` inherited whatever default the driver happened
+        // to use (W3C says 30s) — never a deliberate choice. A legitimate IPC
+        // invoke on a loaded Windows runner can exceed 30s, which surfaces as a
+        // bare "Script execution timed out" with no indication of which command
+        // was in flight.
+        //
+        // This does NOT hide a genuine hang: `invoke` names the command in its
+        // error context, so a script that never calls back still fails — it just
+        // fails at a budget we chose, naming the culprit, instead of at an
+        // undocumented default anonymously.
+        // Argument order is (script, page_load, implicit) — NOT the
+        // page-load-first order the name ordering might suggest. Passing these
+        // reversed silently swaps the two budgets and still compiles, so keep
+        // the labels below when editing.
+        let timeouts = TimeoutConfiguration::new(
+            /* script */ Some(SCRIPT_TIMEOUT),
+            /* page_load */ Some(SCRIPT_TIMEOUT_PAGE_LOAD),
+            // Implicit wait stays ZERO: every wait in this harness is an
+            // explicit poll loop, and thirtyfour's own default notes that
+            // ElementQuery requires zero. A non-zero implicit wait would
+            // silently stack on top of those and inflate every negative
+            // assertion.
+            /* implicit */
+            Some(Duration::from_secs(0)),
+        );
+        if let Err(e) = driver.update_timeouts(timeouts).await {
+            blocking_session_delete(env.proxy_port);
+            kill_driver_proc(&mut driver_proc);
+            return Err(e).context("failed to set explicit WebDriver timeouts");
+        }
+
         Ok(Self { driver, driver_proc: Some(driver_proc) })
     }
 
@@ -419,10 +470,22 @@ impl E2eApp {
             .driver
             .execute_async(script, vec![json!(command), args])
             .await
-            .context("execute_async failed")?;
+            // Name the command (#1205). This used to be a bare
+            // "execute_async failed", so a script timeout told us nothing about
+            // WHICH invoke never called back — the CI log was undiagnosable.
+            // With the command named, raising SCRIPT_TIMEOUT stays safe: a
+            // genuine hang still fails, and now says what hung.
+            .with_context(|| {
+                format!(
+                    "execute_async failed for command {command:?} \
+                     (script timeout is {SCRIPT_TIMEOUT:?}); a timeout here means the \
+                     bridge never invoked the WebDriver callback for that command"
+                )
+            })?;
 
-        let outcome: InvokeOutcome =
-            ret.convert().context("failed to deserialise InvokeOutcome from bridge response")?;
+        let outcome: InvokeOutcome = ret.convert().with_context(|| {
+            format!("failed to deserialise InvokeOutcome from bridge response for {command:?}")
+        })?;
 
         outcome.into_result::<T>()
     }
@@ -599,15 +662,63 @@ impl E2eApp {
         ret.convert::<bool>().context("failed to deserialise bridge_ready result")
     }
 
+    /// Page state captured when a bridge wait times out (#1204).
+    ///
+    /// Returns a human-readable one-liner and never fails: this runs on an
+    /// already-failing path, so a diagnostic that could itself error would
+    /// replace the real failure with its own.
+    async fn bridge_failure_context(&self) -> String {
+        let url = match self.driver.current_url().await {
+            Ok(u) => u.to_string(),
+            Err(e) => format!("<current_url failed: {e}>"),
+        };
+
+        // One script, so a dying session yields one error rather than four.
+        let probe = r#"
+            var boundary = document.querySelector('[data-testid="app-error-boundary-fallback"]');
+            return JSON.stringify({
+                readyState: document.readyState,
+                hasBridge:  !!window.__ALM_E2E__,
+                bridgeKeys: window.__ALM_E2E__ ? Object.keys(window.__ALM_E2E__) : [],
+                errorBoundary: boundary ? (boundary.innerText || '').slice(0, 300) : null,
+                bodyChars: document.body ? document.body.innerHTML.length : 0
+            });
+        "#;
+        let page = match self.driver.execute(probe, vec![]).await {
+            Ok(ret) => {
+                ret.convert::<String>().unwrap_or_else(|e| format!("<undeserialisable: {e}>"))
+            }
+            Err(e) => format!("<probe script failed: {e}>"),
+        };
+
+        format!("url={url}; page={page}")
+    }
+
     /// Wait for [`Self::bridge_ready`] to become `true`.
     pub async fn wait_bridge_ready(&self, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
+        // Retain the last probe error (#1204). This loop used to call
+        // `.unwrap_or(false)`, which DISCARDED the underlying WebDriver error on
+        // every iteration — so a dead session or a crashed page spun silently to
+        // the deadline and reported the generic "never became ready", throwing
+        // away the actual cause each time round.
+        let mut last_err: Option<String>;
         loop {
-            if self.bridge_ready().await.unwrap_or(false) {
-                return Ok(());
+            match self.bridge_ready().await {
+                Ok(true) => return Ok(()),
+                Ok(false) => last_err = None,
+                Err(e) => last_err = Some(format!("{e:#}")),
             }
             if Instant::now() >= deadline {
-                return Err(anyhow!("window.__ALM_E2E__ bridge never became ready"));
+                let probed = self.bridge_failure_context().await;
+                let cause = last_err.map_or_else(
+                    || "no probe error — the bridge simply never appeared".to_owned(),
+                    |e| format!("last probe error: {e}"),
+                );
+                return Err(anyhow!(
+                    "window.__ALM_E2E__ bridge never became ready within {timeout:?}; \
+                     {cause}; {probed}"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }


### PR DESCRIPTION
Makes two Windows Real-UI E2E failures diagnosable, and removes one real implicit-default dependency.

**These are not proven fixes for the flakes.** Both tests passed on nextest retry and I have one CI sample each; I cannot reproduce them on a hosted Windows runner. What this buys is that the next occurrence is readable instead of mute, and that one genuinely-undefined behaviour becomes defined. Framing it as "flake fixed" would be an unverified claim.

## #1205 — the suite never set a script timeout at all

The driver is built with `Capabilities::new()` carrying only `tauri:options`, and **nothing in `crates/e2e-tests/` ever called `update_timeouts`**. So every `execute_async` inherited whatever default the driver happened to use — W3C says 30s. That was never a deliberate budget.

The failing call is the generic IPC bridge helper: an async script that invokes a Tauri command and callbacks. A legitimate invoke on a saturated Windows runner exceeding an unconfigured 30s produces exactly the observed bare `Script execution timed out`.

- Script timeout now set explicitly to **90s** — deliberately below nextest's per-attempt hard kill (`period = 60s, terminate-after = 5` => 300s) so a timeout still fails as a readable test error rather than a process kill.
- `invoke` now **names the in-flight command**. It was `.context("execute_async failed")` — anonymous, which is precisely why the CI log could not tell us which command hung.

Those two go together: raising a budget without naming the culprit *would* risk masking a real hang. With the command named, a script that never calls back still fails loudly, just at a budget we chose.

## #1204 — the real error was being thrown away

`wait_bridge_ready` polled `bridge_ready()` through `.unwrap_or(false)`:

```rust
if self.bridge_ready().await.unwrap_or(false) {
```

That **discards the underlying WebDriver error on every iteration**. A dead session, a crashed page, or a failing execute therefore spun silently to the deadline and reported the generic "bridge never became ready" — the actual cause destroyed each time round. That is a defect in its own right, independent of the flake.

Now: the last probe error is retained and reported, plus a one-shot page probe capturing `current_url`, `document.readyState`, whether `window.__ALM_E2E__` exists and its keys, any `app-error-boundary` text, and body size. The probe runs on an already-failing path so it can never fail the test itself — every branch degrades to a placeholder string.

## Near-miss worth recording

`TimeoutConfiguration::new` takes `(script, page_load, implicit)`. I first wrote it page-load-first, which **compiles fine and silently swaps the two budgets**. Caught by reading the thirtyfour source. The call site now carries `/* script */` / `/* page_load */` labels and a comment so the next editor does not repeat it.

Implicit wait is pinned to zero — every wait here is an explicit poll loop, and thirtyfour's own default notes `ElementQuery` requires zero.

## Verification

- `cargo check --tests -p e2e_tests` — clean, no warnings
- `cargo clippy -p e2e_tests --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Test-infra only; no product code touched.

Refs #1204, #1205 (deliberately *not* `Closes` — these stay open until a real CI run shows whether the flakes actually stop.)