### PR TITLE
test: calibration matching test waits for hydration before toggling

### DIFF
--- a/apps/desktop/src/features/settings/CalibrationMatching.test.tsx
+++ b/apps/desktop/src/features/settings/CalibrationMatching.test.tsx
@@ -230,12 +230,20 @@ describe('CalibrationMatching — exposureToleranceS never sent as null (#639)',
     // making all updates in this pane silently no-op.
     mockGet.mockResolvedValue({
       status: 'ok',
-      data: makeTolerances({ exposureToleranceS: 3.5 }),
+      data: makeTolerances({
+        exposureToleranceS: 3.5,
+        // Hydration marker — see `cameraToggleInput`.
+        requireSameCamera: false,
+      }),
     });
     mockUpdate.mockResolvedValue({ status: 'ok', data: makeTolerances() });
 
     render(<CalibrationMatching save={vi.fn()} />);
-    await waitFor(() => expect(offsetToggleInput()).toBeChecked());
+    // Gate on the Camera toggle, not the Offset one: `requireSameOffset` is
+    // `true` in both the in-code default and the mocked payload, so waiting on
+    // it cannot prove the fetch landed. The click would then race hydration and
+    // send the default `2` instead of the fetched `3.5` (#1213).
+    await waitFor(() => expect(cameraToggleInput()).not.toBeChecked());
 
     fireEvent.click(offsetToggleInput());
 


### PR DESCRIPTION
## Summary

- Fixes #1213 — `CalibrationMatching.test.tsx` failed intermittently on loaded CI with `expected 2 to be 3.5`.
- The test gated hydration on the Offset toggle, but `requireSameOffset` is `true` in both the in-code default and the mocked payload, so that gate is satisfied *before* the fetch lands. The click then raced hydration and sent the default `exposureToleranceS: 2` instead of the fetched `3.5`.
- Switches the gate to the Camera toggle — the hydration marker this file already documents and that three sibling tests already use. Test-only; no product code touched, no assertion changed.

## Why this was already known

The `cameraToggleInput` helper's own doc comment spells out the hazard:

> Waiting on the Offset toggle alone is racy, because the in-code default (`requireSameOffset: true`) already satisfies "checked" before hydration lands.

The helper exists precisely for this. This test simply never adopted it.

## Verification

Reproduced deterministically rather than inferred, by delaying the mocked `calibrationTolerancesGet` by 250ms to simulate a contended runner:

| Variant | Result |
|---|---|
| Without the fix + forced delay | `1 failed` — `expected 3.5, received 2`, the exact CI error |
| With the fix + forced delay | `8 passed` |
| With the fix, no delay | `8 passed` |

Confirmed pre-existing and unrelated to any open PR: the identical assertion failed on `main` (job 88239609292) and on an unrelated PR's macOS leg (job 88274631206).

Frontend lint pipeline clean.

## Not fixed here

`restore-defaults sends the migration default (2.0), not null` has the same vacuous gate, but its expected value equals the in-code default so the race cannot change its outcome — left alone deliberately rather than churned.

## Spec Context
- Spec: 007