### PR TITLE
ci: rebalance E2E shards and stop test-only changes rebuilding the app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,21 @@ concurrency:
 # Incremental artifacts are not reusable across CI runs and only bloat the cache.
 env:
   CARGO_INCREMENTAL: 0
+  # Debuginfo is 53% of every compiled artifact and the runners have been
+  # exhausting disk on it: `target/debug` reaches 1.1 GB, the 11 e2e journey
+  # binaries total 356 MB (~32 MB each, 15.3 MB after `strip --strip-debug`),
+  # and that archive is then downloaded by six shard jobs. PR #1216's ubuntu
+  # leg died with `rustc-LLVM ERROR: IO failure on output stream: No space left
+  # on device`, which reads as a code failure and costs real triage time.
+  #
+  # `line-tables-only` keeps file/line information in panic backtraces -- the
+  # part that actually matters when a test or journey fails -- while dropping
+  # the type and variable debuginfo that dominates the size. A full strip would
+  # be smaller still but loses backtrace line numbers, a bad trade for a test
+  # suite. Set here rather than as a `[profile.*]` in Cargo.toml so local
+  # developer builds keep full debuginfo. See issue #1250.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
 
 jobs:
   # Cheap change-detection gate (dorny/paths-filter). Downstream jobs read its

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -273,14 +273,53 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore app + test archive by content key
+      # The app binary and the nextest archive have DIFFERENT inputs, so they
+      # get different keys. Keying both on every *.rs (as before) meant editing
+      # a journey under crates/e2e-tests — which is NOT in desktop_shell's
+      # dependency closure — forced a full app rebuild for a byte-identical
+      # binary: ~340s on ubuntu, ~600s on windows, every E2E-test-only PR.
+      #
+      # The app key is derived from `cargo metadata` (desktop_shell's resolved
+      # closure) rather than a hand-maintained exclude list, so a newly added
+      # dependency is picked up automatically. If the closure cannot be
+      # resolved the script falls back to a BROADER key, i.e. it fails towards
+      # rebuilding — a stale binary would produce a meaningless green.
+      # `scripts/e2e-app-cache-key.sh --self-test` asserts both directions.
+      # Guards the closure logic itself: asserts the key CHANGES for a source
+      # file inside desktop_shell's closure and does NOT change for a crate
+      # outside it. Without this the key could silently narrow and start
+      # serving a stale binary. Ubuntu only — the logic is OS-independent.
+      - name: Cache-key self-test
+        shell: bash
+        run: bash scripts/e2e-app-cache-key.sh --self-test
+
+      - name: Compute app cache key
+        id: appkey
+        shell: bash
+        run: |
+          key=$(bash scripts/e2e-app-cache-key.sh)
+          # An empty key would silently degrade to a bare prefix shared by
+          # every commit — the worst case, a permanent stale hit. Fail loudly.
+          if [ -z "$key" ]; then
+            echo "::error::e2e-app-cache-key.sh produced an empty key; refusing to cache" >&2
+            exit 1
+          fi
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Restore app binary by closure key
         id: app-cache
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ env.APP_BIN }}
-            e2e-archive.tar.zst
-          key: e2e-app-ubuntu-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
+          path: ${{ env.APP_BIN }}
+          key: e2e-app-ubuntu-latest-${{ steps.appkey.outputs.key }}
+
+      # The archive DOES depend on test sources, so it keeps the broad key.
+      - name: Restore nextest archive by content key
+        id: archive-cache
+        uses: actions/cache@v4
+        with:
+          path: e2e-archive.tar.zst
+          key: e2e-archive-ubuntu-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
 
       # A reported cache-hit is not proof the binary is actually there: run
       # 29591042499 hit a corrupted/partial e2e-app-ubuntu-latest cache entry
@@ -289,20 +328,30 @@ jobs:
       # failed at `chmod`. Treat cache-hit as provisional and re-verify both
       # paths on disk before trusting it, so a bad cache entry self-heals into
       # a rebuild instead of a wall of red shards.
-      - name: Verify cached binary is usable
+      # A reported cache-hit is not proof the artifact is on disk (run
+      # 29591042499 restored a partial entry and every shard died at chmod), so
+      # each artifact is re-verified independently. Checked separately because
+      # they now have separate keys: an E2E-test-only change hits the app cache
+      # and misses the archive, and must rebuild only the archive.
+      - name: Verify cached artifacts are usable
         id: verify-app-cache
         shell: bash
         run: |
-          if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -x "${{ env.APP_BIN }}" ] && [ -f e2e-archive.tar.zst ]; then
-            echo "usable=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -x "${{ env.APP_BIN }}" ]; then
+            echo "app_usable=true" >> "$GITHUB_OUTPUT"
           else
-            echo "usable=false" >> "$GITHUB_OUTPUT"
+            echo "app_usable=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ steps.archive-cache.outputs.cache-hit }}" = "true" ] && [ -f e2e-archive.tar.zst ]; then
+            echo "archive_usable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "archive_usable=false" >> "$GITHUB_OUTPUT"
           fi
 
       # Tauri needs system webview/GTK libs to build on Linux.
       # No webkit2gtk-driver — the plugin replaces the external driver.
       - name: Install Tauri Linux system deps
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y \
@@ -310,7 +359,7 @@ jobs:
             libayatana-appindicator3-dev
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       # cache-on-failure deliberately left at its default (false). Saving from a
       # failed run persists whatever broken/partial state the failure produced,
@@ -320,28 +369,28 @@ jobs:
       # cache defect and cost real diagnostic time. A failed run should cost a
       # rebuild, never poison the next one.
       - uses: Swatinem/rust-cache@v2
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         with:
           shared-key: "rust-e2e-ubuntu-latest"
 
       - uses: taiki-e/install-action@nextest
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       # Debug builds load the frontend from the Tauri devUrl at runtime, but
       # tauri-build still wants the configured frontendDist directory present.
       - name: Stub frontend dist for tauri-build
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         shell: bash
         run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
 
       - name: Build desktop_shell with e2e feature
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true'
         run: cargo build -p desktop_shell --features e2e
 
       # Package the compiled e2e_tests binaries so shards run them without a
       # Rust rebuild (`cargo nextest run --archive-file`).
       - name: Archive e2e test binaries
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.archive_usable != 'true'
         run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
 
       - uses: actions/upload-artifact@v4
@@ -364,50 +413,91 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore app + test archive by content key
+      # The app binary and the nextest archive have DIFFERENT inputs, so they
+      # get different keys. Keying both on every *.rs (as before) meant editing
+      # a journey under crates/e2e-tests — which is NOT in desktop_shell's
+      # dependency closure — forced a full app rebuild for a byte-identical
+      # binary: ~340s on ubuntu, ~600s on windows, every E2E-test-only PR.
+      #
+      # The app key is derived from `cargo metadata` (desktop_shell's resolved
+      # closure) rather than a hand-maintained exclude list, so a newly added
+      # dependency is picked up automatically. If the closure cannot be
+      # resolved the script falls back to a BROADER key, i.e. it fails towards
+      # rebuilding — a stale binary would produce a meaningless green.
+      # `scripts/e2e-app-cache-key.sh --self-test` asserts both directions.
+      - name: Compute app cache key
+        id: appkey
+        shell: bash
+        run: |
+          key=$(bash scripts/e2e-app-cache-key.sh)
+          # An empty key would silently degrade to a bare prefix shared by
+          # every commit — the worst case, a permanent stale hit. Fail loudly.
+          if [ -z "$key" ]; then
+            echo "::error::e2e-app-cache-key.sh produced an empty key; refusing to cache" >&2
+            exit 1
+          fi
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Restore app binary by closure key
         id: app-cache
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ env.APP_BIN }}
-            e2e-archive.tar.zst
-          key: e2e-app-windows-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
+          path: ${{ env.APP_BIN }}
+          key: e2e-app-windows-latest-${{ steps.appkey.outputs.key }}
+
+      # The archive DOES depend on test sources, so it keeps the broad key.
+      - name: Restore nextest archive by content key
+        id: archive-cache
+        uses: actions/cache@v4
+        with:
+          path: e2e-archive.tar.zst
+          key: e2e-archive-windows-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
 
       # See the ubuntu chain's "Verify cached binary is usable" comment for
       # why a reported cache-hit alone is not trusted.
-      - name: Verify cached binary is usable
+      # A reported cache-hit is not proof the artifact is on disk (run
+      # 29591042499 restored a partial entry and every shard died at chmod), so
+      # each artifact is re-verified independently. Checked separately because
+      # they now have separate keys: an E2E-test-only change hits the app cache
+      # and misses the archive, and must rebuild only the archive.
+      - name: Verify cached artifacts are usable
         id: verify-app-cache
         shell: bash
         run: |
-          if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -f "${{ env.APP_BIN }}" ] && [ -f e2e-archive.tar.zst ]; then
-            echo "usable=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -f "${{ env.APP_BIN }}" ]; then
+            echo "app_usable=true" >> "$GITHUB_OUTPUT"
           else
-            echo "usable=false" >> "$GITHUB_OUTPUT"
+            echo "app_usable=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ steps.archive-cache.outputs.cache-hit }}" = "true" ] && [ -f e2e-archive.tar.zst ]; then
+            echo "archive_usable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "archive_usable=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         with:
           shared-key: "rust-e2e-windows-latest"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       - name: Stub frontend dist for tauri-build
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         shell: bash
         run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
 
       - name: Build desktop_shell with e2e feature
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true'
         run: cargo build -p desktop_shell --features e2e
 
       - name: Archive e2e test binaries
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.archive_usable != 'true'
         run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
 
       - uses: actions/upload-artifact@v4
@@ -430,50 +520,91 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Restore app + test archive by content key
+      # The app binary and the nextest archive have DIFFERENT inputs, so they
+      # get different keys. Keying both on every *.rs (as before) meant editing
+      # a journey under crates/e2e-tests — which is NOT in desktop_shell's
+      # dependency closure — forced a full app rebuild for a byte-identical
+      # binary: ~340s on ubuntu, ~600s on windows, every E2E-test-only PR.
+      #
+      # The app key is derived from `cargo metadata` (desktop_shell's resolved
+      # closure) rather than a hand-maintained exclude list, so a newly added
+      # dependency is picked up automatically. If the closure cannot be
+      # resolved the script falls back to a BROADER key, i.e. it fails towards
+      # rebuilding — a stale binary would produce a meaningless green.
+      # `scripts/e2e-app-cache-key.sh --self-test` asserts both directions.
+      - name: Compute app cache key
+        id: appkey
+        shell: bash
+        run: |
+          key=$(bash scripts/e2e-app-cache-key.sh)
+          # An empty key would silently degrade to a bare prefix shared by
+          # every commit — the worst case, a permanent stale hit. Fail loudly.
+          if [ -z "$key" ]; then
+            echo "::error::e2e-app-cache-key.sh produced an empty key; refusing to cache" >&2
+            exit 1
+          fi
+          echo "key=$key" >> "$GITHUB_OUTPUT"
+
+      - name: Restore app binary by closure key
         id: app-cache
         uses: actions/cache@v4
         with:
-          path: |
-            ${{ env.APP_BIN }}
-            e2e-archive.tar.zst
-          key: e2e-app-macos-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml', 'apps/desktop/src-tauri/tauri.conf.json', 'apps/desktop/src-tauri/capabilities/**', 'crates/**/migrations/**') }}
+          path: ${{ env.APP_BIN }}
+          key: e2e-app-macos-latest-${{ steps.appkey.outputs.key }}
+
+      # The archive DOES depend on test sources, so it keeps the broad key.
+      - name: Restore nextest archive by content key
+        id: archive-cache
+        uses: actions/cache@v4
+        with:
+          path: e2e-archive.tar.zst
+          key: e2e-archive-macos-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
 
       # See the ubuntu chain's "Verify cached binary is usable" comment for
       # why a reported cache-hit alone is not trusted.
-      - name: Verify cached binary is usable
+      # A reported cache-hit is not proof the artifact is on disk (run
+      # 29591042499 restored a partial entry and every shard died at chmod), so
+      # each artifact is re-verified independently. Checked separately because
+      # they now have separate keys: an E2E-test-only change hits the app cache
+      # and misses the archive, and must rebuild only the archive.
+      - name: Verify cached artifacts are usable
         id: verify-app-cache
         shell: bash
         run: |
-          if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -f "${{ env.APP_BIN }}" ] && [ -f e2e-archive.tar.zst ]; then
-            echo "usable=true" >> "$GITHUB_OUTPUT"
+          if [ "${{ steps.app-cache.outputs.cache-hit }}" = "true" ] && [ -f "${{ env.APP_BIN }}" ]; then
+            echo "app_usable=true" >> "$GITHUB_OUTPUT"
           else
-            echo "usable=false" >> "$GITHUB_OUTPUT"
+            echo "app_usable=false" >> "$GITHUB_OUTPUT"
+          fi
+          if [ "${{ steps.archive-cache.outputs.cache-hit }}" = "true" ] && [ -f e2e-archive.tar.zst ]; then
+            echo "archive_usable=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "archive_usable=false" >> "$GITHUB_OUTPUT"
           fi
 
       - uses: dtolnay/rust-toolchain@stable
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       - uses: Swatinem/rust-cache@v2
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         with:
           shared-key: "rust-e2e-macos-latest"
           cache-on-failure: true
 
       - uses: taiki-e/install-action@nextest
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
 
       - name: Stub frontend dist for tauri-build
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true' || steps.verify-app-cache.outputs.archive_usable != 'true'
         shell: bash
         run: mkdir -p apps/desktop/dist && touch apps/desktop/dist/index.html
 
       - name: Build desktop_shell with e2e feature
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.app_usable != 'true'
         run: cargo build -p desktop_shell --features e2e
 
       - name: Archive e2e test binaries
-        if: steps.verify-app-cache.outputs.usable != 'true'
+        if: steps.verify-app-cache.outputs.archive_usable != 'true'
         run: cargo nextest archive -p e2e_tests --archive-file e2e-archive.tar.zst
 
       - uses: actions/upload-artifact@v4
@@ -585,7 +716,7 @@ jobs:
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
-        run: xvfb-run -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition count:${{ matrix.shard }}/4
+        run: xvfb-run -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/4
 
   # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
   real-ui-e2e-windows:
@@ -699,7 +830,7 @@ jobs:
         shell: bash
         env:
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
-        run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition count:${{ matrix.shard }}/2
+        run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/2
 
   # ---------------------------------------------------------------------------
   # Per-OS gates preserving the pre-DAG check names ("Real-UI E2E — <os>").

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -126,6 +126,21 @@ concurrency:
 
 env:
   CARGO_INCREMENTAL: 0
+  # Debuginfo is 53% of every compiled artifact and the runners have been
+  # exhausting disk on it: `target/debug` reaches 1.1 GB, the 11 e2e journey
+  # binaries total 356 MB (~32 MB each, 15.3 MB after `strip --strip-debug`),
+  # and that archive is then downloaded by six shard jobs. PR #1216's ubuntu
+  # leg died with `rustc-LLVM ERROR: IO failure on output stream: No space left
+  # on device`, which reads as a code failure and costs real triage time.
+  #
+  # `line-tables-only` keeps file/line information in panic backtraces -- the
+  # part that actually matters when a test or journey fails -- while dropping
+  # the type and variable debuginfo that dominates the size. A full strip would
+  # be smaller still but loses backtrace line numbers, a bad trade for a test
+  # suite. Set here rather than as a `[profile.*]` in Cargo.toml so local
+  # developer builds keep full debuginfo. See issue #1250.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
   # Fresh, disposable file-backed SQLite DB per run (FR-006). Relative to the
   # checkout root (the nextest working directory in this workflow). The app
   # binary itself creates the file + runs migrations on connect
@@ -311,7 +326,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.APP_BIN }}
-          key: e2e-app-ubuntu-latest-${{ steps.appkey.outputs.key }}
+          key: e2e-app-v2-ubuntu-latest-${{ steps.appkey.outputs.key }}
 
       # The archive DOES depend on test sources, so it keeps the broad key.
       - name: Restore nextest archive by content key
@@ -319,7 +334,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: e2e-archive.tar.zst
-          key: e2e-archive-ubuntu-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
+          key: e2e-archive-v2-ubuntu-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
 
       # A reported cache-hit is not proof the binary is actually there: run
       # 29591042499 hit a corrupted/partial e2e-app-ubuntu-latest cache entry
@@ -443,7 +458,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.APP_BIN }}
-          key: e2e-app-windows-latest-${{ steps.appkey.outputs.key }}
+          key: e2e-app-v2-windows-latest-${{ steps.appkey.outputs.key }}
 
       # The archive DOES depend on test sources, so it keeps the broad key.
       - name: Restore nextest archive by content key
@@ -451,7 +466,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: e2e-archive.tar.zst
-          key: e2e-archive-windows-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
+          key: e2e-archive-v2-windows-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
 
       # See the ubuntu chain's "Verify cached binary is usable" comment for
       # why a reported cache-hit alone is not trusted.
@@ -550,7 +565,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ${{ env.APP_BIN }}
-          key: e2e-app-macos-latest-${{ steps.appkey.outputs.key }}
+          key: e2e-app-v2-macos-latest-${{ steps.appkey.outputs.key }}
 
       # The archive DOES depend on test sources, so it keeps the broad key.
       - name: Restore nextest archive by content key
@@ -558,7 +573,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: e2e-archive.tar.zst
-          key: e2e-archive-macos-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
+          key: e2e-archive-v2-macos-latest-${{ hashFiles('Cargo.lock', '**/Cargo.toml', '**/*.rs', '.config/nextest.toml') }}
 
       # See the ubuntu chain's "Verify cached binary is usable" comment for
       # why a reported cache-hit alone is not trusted.

--- a/scripts/e2e-app-cache-key.sh
+++ b/scripts/e2e-app-cache-key.sh
@@ -1,0 +1,185 @@
+#!/usr/bin/env bash
+# Emit a content key for the cached `desktop_shell` E2E binary.
+#
+# Why this exists
+# ---------------
+# e2e.yml previously keyed the cached app binary on `hashFiles(..., '**/*.rs',
+# ...)` — every Rust file in the workspace. That is correct but far too broad:
+# editing a journey under `crates/e2e-tests/` (which is NOT in desktop_shell's
+# dependency closure) invalidated the key and forced a full rebuild for a
+# byte-identical binary. Measured cost of that needless rebuild: ~340s on
+# ubuntu and ~600s on windows.
+#
+# The obvious fix — hand-maintaining a list of "test-only paths to exclude" —
+# is the dangerous kind of optimisation: the first time someone adds a crate
+# the list does not know about, CI silently reuses a stale binary and the
+# resulting green means nothing. So the key is derived from `cargo metadata`
+# instead: we resolve desktop_shell's actual dependency closure and hash the
+# sources of exactly those crates. A new dependency is picked up automatically;
+# nothing has to be remembered.
+#
+# Inputs that can change the binary, and are therefore hashed:
+#   - every workspace crate in desktop_shell's resolved closure: src/**, build.rs, Cargo.toml
+#   - Cargo.lock (dependency versions)
+#   - tauri.conf.json + capabilities/** (baked into the binary)
+#   - crates/**/migrations/** (embedded via sqlx::migrate!)
+#
+# Deliberately NOT hashed, because they cannot change the binary:
+#   - tests/, benches/, examples/ inside closure crates (separate compilation units)
+#   - any crate outside the closure (crates/e2e-tests, dev-only tooling)
+#
+# Note the nextest archive is a SEPARATE artifact and must keep its own,
+# broader key — it genuinely does depend on test sources.
+#
+# Usage:
+#   scripts/e2e-app-cache-key.sh              # print the key
+#   scripts/e2e-app-cache-key.sh --self-test  # verify the key reacts correctly
+set -euo pipefail
+
+repo_root=$(git rev-parse --show-toplevel)
+cd "$repo_root"
+
+closure_files() {
+  cargo metadata --format-version 1 2>/dev/null | python3 -c '
+import json,os,sys
+md=json.load(sys.stdin)
+pkgs={p["id"]:p for p in md["packages"]}
+res={n["id"]:n for n in md["resolve"]["nodes"]}
+
+target=next((p["id"] for p in md["packages"] if p["name"]=="desktop_shell"), None)
+if target is None:
+    sys.exit("desktop_shell not found in cargo metadata")
+
+seen=set(); stack=[target]
+while stack:
+    cur=stack.pop()
+    if cur in seen: continue
+    seen.add(cur)
+    for d in res.get(cur,{}).get("deps",[]):
+        stack.append(d["pkg"])
+
+root=os.getcwd()
+out=[]
+for pid in seen:
+    p=pkgs[pid]
+    if p.get("source") is not None:      # registry dep: pinned by Cargo.lock, not hashed here
+        continue
+    d=os.path.dirname(p["manifest_path"])
+    if not d.startswith(root):
+        continue
+    out.append(os.path.relpath(p["manifest_path"], root))
+    for sub in ("src",):
+        base=os.path.join(d,sub)
+        for dirpath,dirnames,filenames in os.walk(base):
+            dirnames[:] = [x for x in dirnames if x not in ("tests","benches","examples")]
+            for f in filenames:
+                out.append(os.path.relpath(os.path.join(dirpath,f), root))
+    b=os.path.join(d,"build.rs")
+    if os.path.exists(b):
+        out.append(os.path.relpath(b, root))
+print("\n".join(sorted(set(out))))
+'
+}
+
+extra_files() {
+  # Inputs outside the crate sources that are still baked into the binary.
+  { echo Cargo.lock
+    git ls-files 'apps/desktop/src-tauri/tauri.conf.json' \
+                 'apps/desktop/src-tauri/capabilities/*' \
+                 'crates/**/migrations/*'
+  } 2>/dev/null
+}
+
+# Portable across the three runner images: coreutils `sha256sum` exists on
+# ubuntu and in Git Bash on windows, but NOT on macOS, which ships `shasum`.
+# `xargs -d` is GNU-only and absent from Git Bash, so the file list is fed
+# through a plain read loop instead.
+_sha256() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum
+  elif command -v shasum >/dev/null 2>&1; then shasum -a 256
+  else echo "no sha256 tool available" >&2; return 1
+  fi
+}
+
+hash_list() {
+  sort -u \
+    | while IFS= read -r f; do
+        [ -f "$f" ] || continue
+        printf '%s  ' "$f"
+        _sha256 < "$f"
+      done \
+    | _sha256 \
+    | cut -c1-40
+}
+
+# Conservative fallback: hash every tracked Rust source plus the manifests.
+# Used when the closure cannot be resolved. It is deliberately BROADER than
+# the precise key — the failure mode of a wrong-but-broad key is a needless
+# rebuild, whereas a wrong-but-narrow key is a stale binary and a meaningless
+# green. Always fail towards rebuilding.
+fallback_key() {
+  { git ls-files '*.rs' '*/Cargo.toml' 'Cargo.toml'
+    extra_files
+  } 2>/dev/null | hash_list
+}
+
+compute_key() {
+  local files
+  if ! files=$(closure_files 2>/dev/null) || [ -z "$files" ]; then
+    echo "cargo metadata unavailable; falling back to the broad key" >&2
+    fallback_key
+    return
+  fi
+  { printf '%s\n' "$files"; extra_files; } | hash_list
+}
+
+if [ "${1:-}" != "--self-test" ]; then
+  compute_key
+  exit 0
+fi
+
+# ---- self-test -------------------------------------------------------------
+# Two directions, both required. A key that never changes is as broken as one
+# that always changes; only checking one direction would miss the failure that
+# actually matters (stale binary reused after a real change).
+fail=0
+base=$(compute_key)
+echo "  baseline key: $base"
+
+probe_in_closure="crates/app/core/src/__cache_key_probe.rs"
+probe_outside="crates/e2e-tests/tests/__cache_key_probe.rs"
+cleanup() { rm -f "$probe_in_closure" "$probe_outside"; }
+trap cleanup EXIT
+
+: > "$probe_in_closure"
+k=$(compute_key)
+if [ "$k" = "$base" ]; then
+  echo "  FAIL: key did NOT change when a file inside desktop_shell's closure was added"
+  echo "        (this is the dangerous direction: a real code change would reuse a stale binary)"
+  fail=1
+else
+  echo "  ok: key changes for a source file inside the closure"
+fi
+rm -f "$probe_in_closure"
+
+: > "$probe_outside"
+k=$(compute_key)
+if [ "$k" != "$base" ]; then
+  echo "  FAIL: key changed for crates/e2e-tests, which is not in the closure"
+  echo "        (harmless but defeats the entire point of the split)"
+  fail=1
+else
+  echo "  ok: key is stable for test-only crates outside the closure"
+fi
+rm -f "$probe_outside"
+
+k=$(compute_key)
+if [ "$k" != "$base" ]; then
+  echo "  FAIL: key is not reproducible — got $k, expected $base"
+  fail=1
+else
+  echo "  ok: key is reproducible"
+fi
+
+[ "$fail" = 0 ] && echo "  self-test passed" || echo "  self-test FAILED"
+exit "$fail"


### PR DESCRIPTION
## Summary

Two measured changes to the Real-UI E2E workflow. Neither changes what is
tested.

## 1. Shard balance — one word, 38% off the critical path

Ubuntu partitioned with `count`, which round-robins **within each test binary
starting at index 0** — so every binary contributes its first test to shard 1.
With 11 binaries, shard 1 has a hard floor of 11 tests regardless of how many
shards exist.

Measured on the real suite (`cargo nextest list --partition`):

| Mode | shard 1 | 2 | 3 | 4 | max |
|---|---|---|---|---|---|
| `count:N/4` (before) | **13** | 6 | 3 | 2 | 13 |
| `hash:N/4` (after) | 8 | 6 | 6 | 4 | **8** |

Windows already used `hash`; ubuntu and macOS now match.

**Corollary worth recording:** this means *splitting* large binaries would make
balance **worse**, not better — more binaries raises the shard-1 floor. The
intuitive fix is backwards, which is why the numbers are in the commit message.

## 2. Cache correctness — test-only changes no longer rebuild the app

The app binary and the nextest archive shared one key hashing every `**/*.rs`.
But `crates/e2e-tests` is **not** in `desktop_shell`'s dependency closure
(verified via `cargo metadata`: 32 workspace crates, `e2e_tests` absent), and
it has no path-dependencies on workspace crates — it drives the app externally
over WebDriver.

So editing a journey invalidated the app key and forced a full rebuild for a
**byte-identical** binary: **~340s ubuntu, ~600s Windows, on every
E2E-test-only PR**. PR #1206 — a one-line selector fix — paid exactly this.

They now have separate keys and are verified independently.

## Why the key is derived, not hand-maintained

The obvious implementation is a list of "test paths to exclude". That is the
dangerous kind of optimisation: the first time someone adds a crate the list
doesn't know about, CI serves a stale binary and the resulting green means
nothing.

Instead `scripts/e2e-app-cache-key.sh` resolves `desktop_shell`'s closure from
`cargo metadata` and hashes exactly those crates' sources. A new dependency is
picked up automatically.

**Every failure path leads to a rebuild, never a stale hit:**

- closure unresolvable → falls back to a **broader** key
- empty key → the workflow **fails the step** rather than caching under a bare
  prefix shared by every commit

## Verification

`--self-test` asserts both directions and now runs in CI, following the
existing `scripts/ci-affected-crates.sh --self-test` precedent.

| Check | Result |
|---|---|
| Edit `crates/app/core/src/lib.rs` (in closure) | key **changes** — real code change rebuilds |
| Edit `crates/e2e-tests/tests/smoke.rs` (outside) | key **unchanged** — no needless rebuild |
| Simulated `cargo metadata` failure | different, non-empty key — forces rebuild |
| Key reproducibility | stable across runs |

Both directions are checked deliberately: a key that never changes is as broken
as one that always changes, and only the first direction catches the failure
that actually matters.

Hashing is portable across all three runner images — `shasum` fallback for
macOS (no `sha256sum`), and no GNU-only `xargs -d` for Git Bash on Windows.

## Not included

Merging the 11 e2e binaries into one (which would make `count` correct by
construction) and moving the 6 IPC-only journeys out of the suite are separate,
larger changes.