### PR TITLE
fix: tool profile fetch no longer updates state after its consumer unmounts

### DIFF
--- a/apps/desktop/src/features/projects/tool-launch.ts
+++ b/apps/desktop/src/features/projects/tool-launch.ts
@@ -128,13 +128,28 @@ export function useToolProfiles() {
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
+    // `cancelled` guard: this fetch outlives the component whenever a consumer
+    // unmounts while it is still in flight. Without it the late `setState`
+    // reaches a torn-down React root — harmless in the app, but under vitest it
+    // lands after jsdom has removed `window`, and React's own scheduler then
+    // throws `ReferenceError: window is not defined` into a promise nobody
+    // awaits. That surfaces as an unhandled rejection, which fails the entire
+    // unit-test job while every test still reports as passing (#1215).
+    let cancelled = false;
     setLoading(true);
     toolProfileList()
-      .then((resp) => setProfiles(resp.tools))
+      .then((resp) => {
+        if (!cancelled) setProfiles(resp.tools);
+      })
       .catch(() => {
         /* silently degrade — CTA will disable */
       })
-      .finally(() => setLoading(false));
+      .finally(() => {
+        if (!cancelled) setLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   return { profiles, loading };


### PR DESCRIPTION
## Summary

- Fixes #1215. `useToolProfiles`' mount fetch applied `setProfiles`/`setLoading` unconditionally, even when the consumer had already unmounted while the request was in flight.
- Adds the standard `cancelled` cleanup guard so no state update is dispatched after unmount.

## Why it matters

In the app this is benign — a no-op update against a torn-down root. Under vitest it is not: the late update lands after jsdom has removed `window`, and React's own scheduler throws `ReferenceError: window is not defined` into a promise nobody awaits.

That surfaces as an unhandled rejection, which fails the **entire** `Frontend unit tests` job while the summary still reads `Test Files 199 passed / Tests 1820 passed`. A red job whose own output says everything passed is a bad failure mode to leave in place.

## Evidence

From job 88276537750:

```
ReferenceError: window is not defined
 ❯ resolveUpdatePriority  react-dom-client.development.js:1308:7
 ❯ requestUpdateLane      react-dom-client.development.js:16345:11
 ❯ dispatchSetState       react-dom-client.development.js:9126:14
 ❯ src/features/projects/tool-launch.ts:137:22      ← .finally(() => setLoading(false))
This error originated in "src/features/projects/ProjectDetail.blocked-reason.test.tsx"
```

The chain: Testing Library's auto-cleanup unmounts in `afterEach` while the fetch is still in flight → the `.finally` fires → React reads `window` inside `resolveUpdatePriority` *before* it discovers the root is unmounted → jsdom has already torn `window` down. The guard stops the chain at step two.

## Verification — and its limits

Being explicit, because this one resisted a clean repro:

- The projects suite passes with the fix (30 files, 286 tests, no unhandled errors). Given the failure is intermittent, that is corroboration, not proof.
- I built a scratch test that unmounted the hook mid-flight and deleted `globalThis.window` to simulate teardown. **It passed against the unfixed code too**, so it did not discriminate and was discarded rather than shipped as a regression test that cannot fail.
- What the fix rests on is the stack trace above: the frames name the exact line, and the guard makes that line unreachable post-unmount. I could not reproduce the teardown timing deterministically in-process.

If a reviewer wants a hard gate, the honest option is watching the unit-test job across several runs rather than trusting a synthetic test.

## Spec Context
- Spec: 011