### PR TITLE
ci: name test jobs after the tier they actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -130,7 +130,7 @@ jobs:
   # therefore fires only when BOTH lanes are idle, which is exactly the case
   # where the job had nothing to do and must not report `success`.
   integration:
-    name: Integration (Layer 1) — ${{ matrix.os }}
+    name: Unit + integration (L1+L2) — ${{ matrix.os }}
     needs: changes
     if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
     strategy:
@@ -244,7 +244,7 @@ jobs:
         if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: cargo clippy --workspace --all-targets -- -D warnings
 
-      # --- Layer 1: real-backend integration + unit tests ---
+      # --- L1 (isolated units) + L2 (real-backend integration) ---
       # No standalone `cargo build --workspace` step: clippy --all-targets
       # (above, Linux) and nextest (below, every OS) each already build every
       # target they need, so a dedicated build step only duplicated work.
@@ -263,7 +263,7 @@ jobs:
       # force_full trigger (Cargo.lock, workflows, …) or a rust-relevant file
       # outside every member yields the full-workspace fallback. Build/clippy
       # stay workspace-wide — conservative: when in doubt, run more.
-      - name: Rust tests (Layer 1 — real SQLite, real migrations)
+      - name: Rust tests (L1+L2 — real SQLite, real migrations)
         if: needs.changes.outputs.rust == 'true'
         shell: bash
         # CHANGED_FILES is passed via env (never interpolated into the script
@@ -316,7 +316,7 @@ jobs:
   # the frontend lane and a change that cannot affect the frontend skips it
   # outright rather than reporting a green check for an empty run.
   ui-e2e:
-    name: UI E2E (mock-mode Playwright)
+    name: UI mock-mode (Playwright)
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -478,7 +478,7 @@ jobs:
   # for the shard COUNT (2, not 4) and OS-specific steps.
   # ---------------------------------------------------------------------------
   real-ui-e2e-ubuntu:
-    name: Real-UI E2E shard — ubuntu-latest ${{ matrix.shard }}/4
+    name: Real-UI journeys (L3) shard — ubuntu-latest ${{ matrix.shard }}/4
     needs: [changes, build-frontend, build-app-ubuntu]
     if: needs.changes.outputs.run == 'true'
     strategy:
@@ -572,7 +572,7 @@ jobs:
 
   # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
   real-ui-e2e-windows:
-    name: Real-UI E2E shard — windows-latest ${{ matrix.shard }}/2
+    name: Real-UI journeys (L3) shard — windows-latest ${{ matrix.shard }}/2
     needs: [changes, build-frontend, build-app-windows]
     if: needs.changes.outputs.run == 'true'
     strategy:
@@ -628,7 +628,7 @@ jobs:
   # no xvfb (native display), longer timeout for the 120s-per-attempt
   # launch-failure loop.
   real-ui-e2e-macos:
-    name: Real-UI E2E shard — macos-latest ${{ matrix.shard }}/2
+    name: Real-UI journeys (L3) shard — macos-latest ${{ matrix.shard }}/2
     needs: [changes, build-frontend, build-app-macos]
     if: needs.changes.outputs.run == 'true'
     strategy:
@@ -696,7 +696,7 @@ jobs:
   # ever claiming the suite passed.
   # ---------------------------------------------------------------------------
   e2e-gate-ubuntu:
-    name: Real-UI E2E — ubuntu-latest
+    name: Real-UI journeys (L3) — ubuntu-latest
     needs: [changes, real-ui-e2e-ubuntu]
     if: always() && needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
@@ -710,7 +710,7 @@ jobs:
           [ "$RESULT" = "success" ] || exit 1
 
   e2e-gate-windows:
-    name: Real-UI E2E — windows-latest
+    name: Real-UI journeys (L3) — windows-latest
     needs: [changes, real-ui-e2e-windows]
     if: always() && needs.changes.outputs.run == 'true'
     runs-on: ubuntu-latest
@@ -725,7 +725,7 @@ jobs:
 
   # Skipped entirely unless the dispatch-only macOS chain was requested.
   e2e-gate-macos:
-    name: Real-UI E2E — macos-latest
+    name: Real-UI journeys (L3) — macos-latest
     needs: [changes, real-ui-e2e-macos]
     if: always() && needs.changes.outputs.run == 'true' && needs.changes.outputs.run_macos == 'true'
     runs-on: ubuntu-latest

--- a/scripts/branch-protection-main.json
+++ b/scripts/branch-protection-main.json
@@ -1,0 +1,16 @@
+{
+  "required_status_checks": {
+    "strict": true,
+    "contexts": [
+      "Detect changes",
+      "Unit + integration (L1+L2) — ubuntu-latest",
+      "Unit + integration (L1+L2) — windows-latest",
+      "UI mock-mode (Playwright)",
+      "Real-UI journeys (L3) — ubuntu-latest",
+      "Real-UI journeys (L3) — windows-latest"
+    ]
+  },
+  "enforce_admins": false,
+  "required_pull_request_reviews": null,
+  "restrictions": null
+}

--- a/scripts/branch-protection-main.sh
+++ b/scripts/branch-protection-main.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Apply / inspect / remove branch protection on `main`.
+#
+# NOT APPLIED AUTOMATICALLY. The config lives in
+# `scripts/branch-protection-main.json` so the required contexts are reviewable
+# in a PR rather than living only in GitHub's UI, and so re-applying after a
+# job rename is a one-liner instead of a click-path.
+#
+# Why each setting:
+#
+#   strict: true          Branches must be up to date with main before merging.
+#                         Costly while main churns, correct once it settles.
+#   enforce_admins: false Sole maintainer needs an override path when a runner
+#                         or an upstream dependency breaks.
+#   reviews: null         Solo repo; a required-review rule would just block.
+#
+# Required contexts are the PARENT jobs, never the individual shards: the
+# `Real-UI journeys (L3) — <os>` gates already depend on their shards, so
+# requiring shards as well would add nothing and would break whenever the shard
+# count changes.
+#
+# Excluded on purpose:
+#   Real-UI journeys (L3) — macos-latest   blocked upstream, see issue #489
+#                                          (tauri-plugin-webdriver)
+#   Unit + integration (L1+L2) — macos-latest
+#                                          Held out only while the frontend
+#                                          suite still runs on Rust-only PRs.
+#                                          NOTE: issue #489 is about the E2E
+#                                          macOS leg, NOT this one — the two
+#                                          were previously conflated. Recent
+#                                          history is 3 success / 3 cancelled /
+#                                          2 failure, and both failures were
+#                                          attributable (a frontend flake
+#                                          dragged in by force_full, and a
+#                                          paraglide bug). Reconsider including
+#                                          it once those have landed.
+#
+# A context whose job is SKIPPED counts as satisfied by branch protection, so
+# docs-only PRs do not hang. That is why `e2e.yml` gates whole JOBS with a
+# job-level `if:` rather than step-level conditions — see the comment near the
+# top of that workflow. Do not convert those to step-level.
+#
+# Usage:
+#   scripts/branch-protection-main.sh show     # current protection (or 404)
+#   scripts/branch-protection-main.sh apply    # PUT the config
+#   scripts/branch-protection-main.sh remove   # DELETE protection
+#   scripts/branch-protection-main.sh verify   # apply-time sanity checks only
+set -euo pipefail
+
+REPO="${REPO:-platevault/platevault}"
+BRANCH="${BRANCH:-main}"
+here=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+CONFIG="$here/branch-protection-main.json"
+
+# The context strings contain U+2014 EM DASH, not a hyphen. A hyphen produces a
+# required context that never reports, which leaves every PR pending forever.
+verify_contexts() {
+  # Only the SEPARATOR matters. Hyphens inside a word are fine
+  # ("UI mock-mode (Playwright)", "ubuntu-latest"); the failure mode is a
+  # spaced hyphen " - " where the job name uses " — ".
+  local bad=0
+  while IFS= read -r ctx; do
+    case "$ctx" in
+      *" - "*) echo "  WARN: '$ctx' uses ' - ' as a separator; job names use ' — ' (U+2014)" >&2; bad=1 ;;
+    esac
+  done < <(python3 -c '
+import json,sys
+print("\n".join(json.load(open(sys.argv[1]))["required_status_checks"]["contexts"]))' "$CONFIG")
+  return $bad
+}
+
+# Guard against protecting on names no workflow produces.
+verify_names_exist() {
+  local missing=0
+  local names
+  names=$(grep -hoE "^    name: .*" "$here/../.github/workflows/ci.yml" \
+                                    "$here/../.github/workflows/e2e.yml" \
+          | sed 's/^    name: //')
+  while IFS= read -r ctx; do
+    # matrix jobs appear in source as `... — ${{ matrix.os }}`
+    local stem="${ctx% — *}"
+    if ! printf '%s\n' "$names" | grep -qF "$stem"; then
+      echo "  WARN: no workflow job matches '$ctx' (stem '$stem')" >&2
+      missing=1
+    fi
+  done < <(python3 -c '
+import json,sys
+print("\n".join(json.load(open(sys.argv[1]))["required_status_checks"]["contexts"]))' "$CONFIG")
+  return $missing
+}
+
+case "${1:-show}" in
+  show)
+    gh api "repos/$REPO/branches/$BRANCH/protection" 2>&1 || true
+    ;;
+  verify)
+    echo "Checking $CONFIG"
+    verify_contexts && echo "  contexts: em dash OK"
+    verify_names_exist && echo "  contexts: all match a workflow job name"
+    ;;
+  apply)
+    verify_contexts || { echo "refusing to apply: hyphen/em-dash problem" >&2; exit 1; }
+    verify_names_exist || echo "  (continuing despite name warnings)"
+    gh api -X PUT "repos/$REPO/branches/$BRANCH/protection" --input "$CONFIG"
+    ;;
+  remove)
+    gh api -X DELETE "repos/$REPO/branches/$BRANCH/protection"
+    ;;
+  *)
+    echo "usage: $0 {show|verify|apply|remove}" >&2
+    exit 2
+    ;;
+esac

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -10,6 +10,14 @@ mapping required by FR-019 / SC-001. Final per-test names are filled in by
 Legend: **L1** = real-backend integration test required; **L2** = appears in a
 Layer-2 smoke journey; **—** = covered implicitly via screen-load smoke.
 
+> **Naming note.** This table's `L1`/`L2` columns predate the CI tier names and
+> do NOT line up with them. Here `L1` means "real-backend integration" and `L2`
+> means "smoke journey". The CI tiers are: **L1** = isolated unit (no real I/O),
+> **L2** = integration against real SQLite/filesystem, **L3** = real-UI journey.
+> So this table's `L1` column corresponds to the CI tiers' **L2**, and its `L2`
+> column to the CI tiers' **L3**. The column headers are left unchanged because
+> every row references them; use this note when reading across.
+
 | # | Feature area | L1 | L2 | Notes |
 |---|---|:--:|:--:|---|
 | 1 | First-run source setup | ✅ | ✅ | setup wizard → root persisted |


### PR DESCRIPTION
## Summary

Renames the CI test jobs so their names describe what they execute, and checks
in the `main` branch-protection config (**not applied by this PR**).

## Why the old names were wrong

`Integration (Layer 1)` was wrong twice over: it is not Layer 1 (it uses real
SQLite and real migrations), and it is not only integration (it also runs the
frontend vitest suite and typecheck).

Measured: that job runs **2503 Rust tests — 1409 genuinely isolated units and
1094 that touch a real DB or filesystem**, with the slow half consuming 97% of
the CPU.

`UI E2E (mock-mode Playwright)` was misleading in its own way — IPC is mocked,
so it is not end-to-end and cannot observe the backend at all.

## Renames

| Before | After |
|---|---|
| `Integration (Layer 1) — <os>` | `Unit + integration (L1+L2) — <os>` |
| `UI E2E (mock-mode Playwright)` | `UI mock-mode (Playwright)` |
| `Real-UI E2E — <os>` | `Real-UI journeys (L3) — <os>` |
| `Real-UI E2E shard — …` | `Real-UI journeys (L3) shard — …` |

Tiers: **L1** = isolated unit (no real I/O) · **L2** = integration against real
SQLite/filesystem · **L3** = real-UI journey.

## Coverage matrix

Its `L1`/`L2` **columns** predate these names and mean something different again
(there, `L1` = real-backend integration, `L2` = smoke journey). Renumbering
would mean auditing every row, so a note records the mapping instead.

## Branch protection — checked in, deliberately not enabled

`scripts/branch-protection-main.json` + `.sh`. The config lives in the repo so
the required contexts are reviewable in a PR rather than only in GitHub's UI,
and so re-applying after a rename like this one is one command instead of a
click-path.

Enable with `scripts/branch-protection-main.sh apply`. `strict: true`,
`enforce_admins: false`.

**Job names are check-context names**, so this rename and enabling protection
must be sequenced: apply *after* this merges, or protection waits forever on
contexts that no longer exist. Doing the rename first means registering the
names once rather than twice.

### Guardrails, both verified in the failing direction

- Refuses to apply a config whose separator is `" - "` rather than `" — "`
  (U+2014). A hyphen there produces a required context that never reports,
  leaving every PR pending forever.
- Warns when a context matches no workflow job name.

The first check initially false-positived on the legitimate hyphen in
`UI mock-mode`, so it was narrowed to the spaced-separator case.

### On the macOS exclusions

`Real-UI journeys (L3) — macos-latest` stays excluded — genuinely blocked
upstream (#489, tauri-plugin-webdriver).

`Unit + integration (L1+L2) — macos-latest` is held out only provisionally, and
the reason it was excluded before does not hold up: **#489 is about the E2E
macOS leg, not this one** — the two were conflated. Recent history is 3 success
/ 3 cancelled / 2 failure, and both failures were attributable (a frontend
flake pulled in by `force_full`, and a paraglide bug). Worth including once
those land; the script's comments record this so the next reader does not have
to re-derive it.