### PR TITLE
test: log panel follow toggle waits for the persisted preference to load

### DIFF
--- a/apps/desktop/src/app/LogPanel.followScroll.test.tsx
+++ b/apps/desktop/src/app/LogPanel.followScroll.test.tsx
@@ -238,6 +238,24 @@ describe('LogPanel follow-tail scroll pause/resume (T011)', () => {
       expect(screen.getByText('Second entry')).toBeInTheDocument();
     });
 
+    // Gate on the HYDRATED follow state before toggling it (#1249).
+    //
+    // `followLogs` initialises to `false` (LogPanelContext.tsx:83) and is then
+    // hydrated asynchronously from `settings.get('advanced')` on mount
+    // (`:88`). Waiting for 'Second entry' above says nothing about that: it is
+    // an independent async path. On a loaded runner the click below could land
+    // while `followLogs` was still the pre-hydration `false`, toggling it to
+    // `true`, after which the late hydration confirmed `true` — leaving
+    // '↓ Follow' where this test expects '— Follow'. That is this file's
+    // long-standing flake, which #1118 reduced but did not remove.
+    //
+    // This is `waitFor` used correctly — "the state has not arrived yet" —
+    // rather than the vacuous "this must never happen" shape the
+    // alm/no-vacuous-waitfor rule rejects.
+    await waitFor(() => {
+      expect(getFollowButton().textContent).toBe('↓ Follow');
+    });
+
     // Turn follow off first (repro starts with Follow inactive).
     fireEvent.click(getFollowButton());
     await waitFor(() => {


### PR DESCRIPTION
## Summary

- The `#832` follow-tail test toggled Follow before the persisted preference had
  hydrated, so on a loaded runner it toggled the pre-hydration value and the late
  hydration landed on top.
- Verified by forcing the race, not by observing a green run.

Closes #1249.

## Root cause

`followLogs` initialises to `false` (`LogPanelContext.tsx:83`) and is then loaded
asynchronously from `settings.get('advanced')` on mount (`:88`).

The test's only gate before clicking was `waitFor('Second entry')` — an
**independent** async path that says nothing about whether hydration completed. So
the sequence under load was:

1. mount → `followLogs = false` → `— Follow`
2. test clicks → toggles to `true` → `↓ Follow`
3. hydration resolves → confirms `true` → still `↓ Follow`
4. assertion expects `— Follow` → **fails**

## Why this needed reopening

#1118 (`4c04b606`) targeted this exact assertion and reduced the window without
closing it. The same test failed **three times on 2026-07-20**, on PRs touching no
LogPanel code — #1169 (Rust `src-tauri` split), #1126 (inbox banner), and one
earlier. Each passed on rerun, which is what kept masking it.

Those Rust-only PRs ran the frontend suite at all because `force_full` pulls it in;
#1212 narrows that, but it does not fix this race — the test would keep failing on
genuinely frontend-touching PRs.

## Verification — the race was forced, both directions

With a 60 ms delay injected into the `settingsGet` mock:

| | Result |
|---|---|
| **Unfixed** + delay | **FAILS** — `AssertionError: expected '↓ Follow' to be '— Follow'` |
| **Fixed** + delay | passes (3/3) |
| Fixed, no delay | passes (3/3) |

The unfixed failure reproduces the CI error string **exactly**. Without the injected
delay it passes either way — which is precisely why a previous fix was accepted on
insufficient evidence, so the delay harness is the load-bearing part of this
verification.

## Note on the added `waitFor`

This is `waitFor` used correctly — *"the state has not arrived yet"*. It is not the
vacuous *"this must never happen"* shape that the `alm/no-vacuous-waitfor` rule
(added in #1180) rejects, where a negated call assertion passes on the first tick and
asserts nothing.