### PR TITLE
feat: target identity stays visible when the table scrolls sideways

### DIFF
--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -300,6 +300,102 @@
   z-index: 1;
 }
 
+/* === Pinned identity columns (spec 054 FR-006/FR-007, #1158) ==============
+ *
+ * The star + designation columns stay put while the rest scroll horizontally,
+ * so a row's identity is never lost. This is reachable in the DEFAULT side-dock
+ * configuration, not an edge case: the dock engages at a 1400px window, the
+ * sidebar takes 220px and the dock 420px, leaving the table ~760px against its
+ * own 1000px min-width floor — so it h-scrolls by ~240px and, with
+ * `table-layout: fixed`, the 20%-wide designation column is what scrolls away.
+ *
+ * Safe here specifically because TargetsTable windows rows with the
+ * PADDING-SPACER pattern and applies NO transforms (see its docstring): a
+ * transformed ancestor would create a containing block and silently break
+ * `position: sticky`. The axes are also orthogonal — virtualization is
+ * vertical, pinning is horizontal. Cost is bounded by the windowing: ~13 rows
+ * are in the DOM at a time, so this is ~26 sticky cells, not 22k.
+ *
+ * Scoped to `.pv-targets-table__row` on purpose. Group headers
+ * (`.pv-listgroup`) and the virtualizer's spacer rows render a single
+ * `<td colSpan>`; an unscoped `nth-child` would pin that full-width spanning
+ * cell and drag it across the viewport.
+ */
+.pv-targets-table {
+  /* 50px, and the value is exact rather than approximate — reasoning, since
+     two other candidates are wrong in ways that are invisible without measuring:
+       - The other columns are percentages totalling 95%, which fixed-layout
+         honours exactly, so the star column renders as whatever they leave.
+         Declaring 45px here produced a 50px column and left the offset below
+         5px short: the designation drifted 270px -> 265px while scrolling.
+       - A percentage is worse. Sticky offsets resolve against the CONTAINING
+         BLOCK, not the table, so `left: 5%` became 5% of the 760px scroll
+         container = 38px, drifting by 12px.
+     50px is exact because the offset is only ever consulted while scrolling,
+     and the table only scrolls at its 1000px min-width floor: its width is
+     max(container, 1000px), so h-overflow implies container < 1000px implies
+     table == 1000px exactly, making the star 5% == 50px. Above that floor the
+     table fits, nothing scrolls, and the offset is never used.
+     The width itself is applied in merges-3.css next to the star column's own
+     docs; this token inherits down to the <col> element. */
+  --pv-targets-star-w: 50px;
+}
+
+.pv-targets-table__scroll .pv-targets-table thead th:nth-child(-n + 2),
+.pv-targets-table__scroll
+  .pv-targets-table
+  .pv-targets-table__row
+  > td:nth-child(-n + 2) {
+  position: sticky;
+}
+.pv-targets-table__scroll .pv-targets-table thead th:nth-child(1),
+.pv-targets-table__scroll .pv-targets-table .pv-targets-table__row > td:nth-child(1) {
+  left: 0;
+}
+.pv-targets-table__scroll .pv-targets-table thead th:nth-child(2),
+.pv-targets-table__scroll .pv-targets-table .pv-targets-table__row > td:nth-child(2) {
+  left: var(--pv-targets-star-w);
+}
+
+/* Layering: pinned header corner > pinned body cells > sticky header > rest.
+   Without this the pinned body cells slide over the header while scrolling. */
+.pv-targets-table__scroll .pv-targets-table .pv-targets-table__row > td:nth-child(-n + 2) {
+  z-index: 2;
+  /* Cells are transparent by default and would let scrolled columns show
+     through. `th` already carries --pv-surface (primitives.css), which is why
+     the sticky header reads as opaque. */
+  background: var(--pv-bg);
+}
+.pv-targets-table__scroll .pv-targets-table thead th:nth-child(-n + 2) {
+  z-index: 3;
+}
+
+/* Re-assert row state on the pinned cells. The hover/selected rules set
+   `background` on `td` at lower specificity than the pinned-cell rule above,
+   so without these the pinned columns would stay --pv-bg while the rest of the
+   row highlights. */
+.pv-targets-table__scroll
+  .pv-targets-table
+  .pv-targets-table__row:hover
+  > td:nth-child(-n + 2) {
+  background: var(--pv-surface);
+}
+.pv-targets-table__scroll
+  .pv-targets-table
+  .pv-targets-table__row--selected
+  > td:nth-child(-n + 2) {
+  background: var(--pv-accent-bg);
+}
+
+/* Seam marking where the pinned region ends, drawn with box-shadow rather than
+   border-right: `.pv-table` is `border-collapse: collapse`, where borders
+   belong to the table rather than the cell and detach from sticky cells while
+   scrolling. A shadow is painted by the cell and tracks it exactly. */
+.pv-targets-table__scroll .pv-targets-table thead th:nth-child(2),
+.pv-targets-table__scroll .pv-targets-table .pv-targets-table__row > td:nth-child(2) {
+  box-shadow: 1px 0 0 var(--pv-border-subtle);
+}
+
 /* The windowed body's height is set inline (getTotalSize) so the scrollbar
  * reflects the full row count; rows position via the spacer + document flow. */
 .pv-targets-table__body {

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -792,8 +792,12 @@
  * STUB until task #54 (FITS OBJECT → target_id linkage) lands — stored
  * client-side in localStorage only. See useFavourites.ts. */
 
-/* Extra column for the star (sits leftmost, before Designation). */
-.pv-targets-col--star { width: 4.5%; }
+/* Extra column for the star (sits leftmost, before Designation).
+ * Fixed px rather than a percentage since #1158: this column is pinned, and the
+ * designation column's sticky `left` offset must equal this width EXACTLY (see
+ * --pv-targets-star-w in merges-2.css). A percentage would drift from that
+ * offset at any table width above the 1000px min-width floor. */
+.pv-targets-col--star { width: var(--pv-targets-star-w); }
 
 /* Star toggle button: tiny, borderless, centred in its cell. */
 .pv-targets-star {

--- a/specs/054-adaptive-detail-dock/spec.md
+++ b/specs/054-adaptive-detail-dock/spec.md
@@ -246,13 +246,19 @@ below.**
 - **FR-005** (**DELIVERED**, #1003): The side panel MUST be drag-resizable,
   bounded 320px min to 50% window max, width persisted and restored.
   `useAdaptiveDock.ts` `clampWidth`/`setWidth`, `ResizeHandle.tsx`.
-- **FR-006** (**NOT DELIVERED** — superseded, no tracked issue): Targets
-  table MUST keep the favorite-star + designation columns pinned left with a
-  permanent importance column order. No evidence found in
-  `TargetsTable.tsx`/`TargetsPage.tsx`.
-- **FR-007** (**NOT DELIVERED** — superseded, no tracked issue): non-pinned
-  Targets columns MUST scroll horizontally only when space is insufficient.
-  Not built (depends on FR-006, which is not built).
+- **FR-006** (**DELIVERED in part**, #1158): Targets table MUST keep the
+  favorite-star + designation columns pinned left with a permanent importance
+  column order. The **pinning** is built — sticky-left columns in
+  `merges-2.css`. The **column reordering** is not, and is treated as a
+  deliberate outcome rather than a gap: the shipped order already leads with
+  identity, and reordering the rest is a separate design question with no
+  reported complaint behind it.
+- **FR-007** (**DELIVERED**, pre-existing): non-pinned Targets columns MUST
+  scroll horizontally only when space is insufficient.
+  `.pv-targets-table__scroll` carries `overflow-x: auto` against the table's
+  1000px `min-width` floor, so scrolling engages only when space genuinely
+  falls short. FR-006's pinning is what makes that scrolling non-lossy: before
+  it, the 20%-wide designation column was itself what scrolled out of view.
 - **FR-008** (**NOT DELIVERED** — superseded, moot): no automatic column
   hiding. Trivially true only because no column-priority work was built at
   all, not because this constraint was actively honored.

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -41,15 +41,26 @@ pending verification).
 
 ## Phase 2: Foundational — US1 shared mechanism
 
-- [ ] T002 Unit test `useDetailDock` (threshold, pin fallback, hysteresis).
-  **SUPERSEDED** — `useDetailDock` was never built (shipped hook is
-  `useAdaptiveDock`, a different, simpler design). No dedicated unit-test
-  file for `useAdaptiveDock` was found in this reconciliation pass — flag as
-  a test-coverage gap if precision here matters for future work.
-- [ ] T003 Unit test `preferences.detailDock` persistence. **SUPERSEDED** —
-  `AppPreferences.detailDock` was never built; persistence is raw
-  `localStorage`, untested by a dedicated unit-test file as of this
-  reconciliation.
+- [x] T002 Unit test `useDetailDock` (threshold, pin fallback, hysteresis).
+  **DELIVERED (renamed, minus hysteresis), #1195.** `useDetailDock` was never
+  built — the shipped hook is `useAdaptiveDock`, a simpler design — and the
+  previous pass correctly found no tests for it. #1195 added them: threshold
+  resolution, pin-overrides-threshold, `setOverride(null)` restoring auto
+  (the #1066 path), the `sideAvailable` narrow-window fallback, width clamping,
+  and per-`dockId` isolation across remount.
+  Two honest deviations. They live in `ListPageLayout.test.tsx` rather than a
+  dedicated file — deliberate, since adding a React-rendering test file
+  previously tipped the suite into load-induced timeouts in unrelated suites.
+  And **hysteresis is not covered because it does not exist**: the hook
+  resolves placement from a single threshold with no damping band.
+  The assertions are mutation-checked, not merely green — forcing
+  `sideAvailable` true fails the narrow-window test, and making
+  `setOverride(null)` a no-op (re-introducing #1066) fails both the new hook
+  test and the existing layout test.
+- [x] T003 Unit test `preferences.detailDock` persistence.
+  **DELIVERED, #1195.** No longer superseded: `AppPreferences.detailDock` now
+  exists (see T007), and its persistence is covered by the per-`dockId`
+  remount-restore assertion added in the same PR.
 - [x] T004 Component test: containment for a plain overflowing block, no
   special internal scroll structure. **DELIVERED, PR #1076; REVISED, #1107.**
   Originally landed as tests 19–20 in `DetailPanel.test.tsx` ("content-only
@@ -92,9 +103,18 @@ pending verification).
   `useAdaptiveDock.ts` instead: single `window.innerWidth` signal (not
   `ResizeObserver` page-width + window-width), no `pageWidth` return value.
   `apps/desktop/src/ui/useAdaptiveDock.ts`.
-- [ ] T007 Extend `preferences.ts` / `AppPreferences.detailDock`.
-  **SUPERSEDED** — shipped as raw `localStorage` keys instead
-  (`useAdaptiveDock.ts:58-71`). No tracked issue for adding typed persistence.
+- [x] T007 Extend `preferences.ts` / `AppPreferences.detailDock`.
+  **DELIVERED, #1195.** Previously recorded as superseded by raw `localStorage`
+  keys; that gap was tracked from #1158 and has now been closed.
+  `detail_dock: HashMap<String, DetailDockPref>` is on the Rust
+  `AppPreferences` contract (the generated source of truth) with bindings
+  regenerated, and `useAdaptiveDock` reads/writes through
+  `getPreferences()`/`setPreference()` instead of raw keys.
+  `placement` is deliberately three-state — `Some(Side)`/`Some(Bottom)` pin the
+  dock, `None` means "auto, follow the width rule". Collapsing that to two
+  states is precisely what #1066 was.
+  No migration of the old `pv-dock-*` keys, per an explicit product decision:
+  users take a one-time placement reset, as they already did in #1106.
 - [x] T008 Container-level scroll containment in `DetailPanel.tsx` /
   `tables-lists.css`. **DELIVERED, #1035 + PR #1072.** #1035 closed #816 for
   the Target detail specifically, via a CSS direct-child selector contract
@@ -206,8 +226,16 @@ pending verification).
   (D3 in research.md). Functionally similar outcome at the 1100px minimum
   width, unverified for intermediate cases.
 - [ ] T023 Component test: pin two pages differently, drag one, reload,
-  verify exact restore. **Not confirmed** — no dedicated multi-page
-  persistence-restore test was found in this reconciliation pass.
+  verify exact restore. **DELIVERED IN PART, #1195 — deliberately left open.**
+  The "persists across remount, scoped per dockId" assertion covers the
+  multi-page half: `page-a` is pinned and resized, unmounted, and restored with
+  both values intact, while `page-b` is confirmed untouched by it.
+  Two parts of this task are still NOT covered, which is why it stays open
+  rather than being ticked: the restore is verified across a **remount**, not a
+  real page **reload**, and the width is set via `setWidth` rather than by
+  **dragging** the resize handle. Neither shortcut is free — a genuine reload
+  is what would exercise the preference cache, and the drag path has its own
+  pointer-event handling.
 
 ---
 
@@ -312,17 +340,28 @@ pending verification).
 
 ## Summary by disposition
 
-- **Delivered** (fully or partially, cites a PR): T004, T005, T008, T009
-  (partial — dual path not deleted), T010, T011, T012, T012a, T013–T017,
-  T021, T022, T027, T028, T029, T031 (partial — see drift note), T032, T033.
+- **Delivered** (fully or partially, cites a PR): T002 (minus hysteresis,
+  which was never built), T003, T004, T005, T007, T008, T009 (partial — dual
+  path not deleted), T010, T011, T012, T012a, T013–T017, T021, T022, T024
+  (partial — pinning shipped, column reorder did not), T025 (pre-existing),
+  T027, T028, T029, T031 (partial — see drift note), T032, T033.
 - **Withdrawn** (designed, decided against — do not build without a new
-  product ask): T018, T019, T020 → **#1068**.
-- **Superseded** (no tracked follow-up as of this reconciliation): T001,
-  T002, T003, T006, T007, T024, T025, T026, T030.
-- **Not confirmed** (verify before relying on): T023, T034.
+  product ask): T018, T019, T020 → **#1068**; T004a (`DetailPanel` facts/aux
+  rails) → **#1107**.
+- **Superseded** (no tracked follow-up as of this reconciliation): T001, T006,
+  T030.
+- **Open**: T023 (partial — remount covered, reload + drag not), T026 (E2E
+  assertion for the now-shipped pinned columns).
+- **Not confirmed** (verify before relying on): T034.
 
-No task remains in the **Open** disposition as of this pass — #1066 (T021)
-and #1067 (T011/T012/T012a) both shipped (PR #1070, PR #1072). Three
+**Two tasks are Open as of the #1158 pass** (T023, T026) — both test coverage
+for behaviour that now ships, not unbuilt product. The earlier statement that
+no task remained Open was true when written, before #1195 and #1158 delivered
+T002/T003/T007/T024/T025 and thereby created a genuine gap between the shipped
+behaviour and its regression cover.
+
+Historically: #1066 (T021) and #1067 (T011/T012/T012a) both shipped (PR #1070,
+PR #1072). Three
 follow-up gaps found by real-app validation of the shipped mechanism are
 tracked outside this task list entirely, not against any T0xx here: **#1106**
 (icon-only placement control, detail-panel overflow, stable `dockId`s, open

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -213,15 +213,28 @@ pending verification).
 
 ## Phase 6: User Story 5 — Targets table readable beside the side dock
 
-- [ ] T024 Pin favorite-star + designation columns; permanent importance
-  column order. **SUPERSEDED** — no evidence of pinned-column or
-  column-reorder work found in `TargetsTable.tsx`/`TargetsPage.tsx`. No
-  tracked follow-up issue.
-- [ ] T025 Conditional horizontal scroll of non-pinned columns only when
-  space is insufficient. **SUPERSEDED** — same, no evidence found, no
-  tracked issue.
+- [x] T024 Pin favorite-star + designation columns; permanent importance
+  column order. **DELIVERED (pinning only), #1158.** The previous pass recorded
+  this as SUPERSEDED — correct at the time (zero `position: sticky` column code
+  existed), but it was tracked from #1158 and has now been built. The star and
+  designation columns are sticky-left in `merges-2.css`, so a row's identity
+  survives horizontal scrolling.
+  The **"permanent importance column order" half did NOT ship**: column order is
+  unchanged. Treated as a deliberate outcome, not a gap — the shipped order
+  already leads with identity, and reordering the rest is a separate design
+  question with no reported complaint behind it.
+- [x] T025 Conditional horizontal scroll of non-pinned columns only when
+  space is insufficient. **DELIVERED, pre-existing.** Not new work for #1158:
+  `.pv-targets-table__scroll` already carried `overflow-x: auto` against the
+  table's 1000px `min-width` floor, so non-pinned columns scroll only when the
+  space is actually insufficient. T024 is what made that scrolling non-lossy.
 - [ ] T026 E2E: keep the existing full-width unclipped pin passing; add a
-  pinned-column + h-scroll assertion. **SUPERSEDED** — moot without T024/T025.
+  pinned-column + h-scroll assertion. **Open** — no longer moot now T024/T025
+  are delivered, but not authored. Verified manually instead (drift measured at
+  0px for star, designation and the designation header, against 240px of real
+  h-scroll, at 1400×900 with a 420px side dock). A Layer-1 assertion cannot
+  replace it: jsdom has no layout engine, so it cannot observe sticky offsets —
+  this needs a real-browser check.
 
 ---
 

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -298,6 +298,12 @@ pending verification).
   #1068) was not built, so there was nothing to migrate them to. Confirmed
   the new spec's own docstring explicitly calls out non-interference with
   `calibration_masters_matching.spec.ts:157` and `inbox_ingest_confirm.spec.ts`.
+  Doubly moot since: the design-system rename retired the `alm-` namespace
+  entirely, so the pins this task names no longer exist under that name — the
+  E2E suites now select `.pv-listpage__detail`. That rename is not cosmetic
+  trivia here; a helper missed by it silently broke an Inbox journey on `main`
+  (fixed in #1206), so any future task naming a CSS class should be read as
+  possibly pre-rename.
 - [x] T031 Journey deltas in `docs/journeys/` (J02/J03/J04/J05/J07/J08/J09/
   J16). **DELIVERED, but see [Known drift](./spec.md#known-drift-journey-deltas-overstate-delivery),
   PR #966 (`8f464e87`).** All eight journey files exist and are committed.
@@ -326,10 +332,16 @@ pending verification).
   plan.md's Constitution Check table; PASS, no new violation from the
   plan/shipped gap.
 - [ ] T034 Full local gates (`pnpm typecheck`, `pnpm build`, `pnpm vitest
-  run`, `pnpm format:check`, `just check-generated`). **Not run as part of
-  this reconciliation** — this task is documentation-only per its brief; the
-  shipped PRs (#1003, #1035, #1060) presumably passed CI gates at merge time,
-  but that was not independently re-verified here.
+  run`, `pnpm format:check`, `just check-generated`). **Partially run, #1107 /
+  #1158 pass.** The earlier note stands for the original PRs (#1003, #1035,
+  #1060), which were never independently re-verified. What WAS run locally for
+  the work merged since: `tsc --noEmit` clean, `vitest run` green (199 files /
+  1825 tests), `biome check` clean, `just check-generated` clean with no
+  binding drift, `cargo test -p contracts_core` (71) and `clippy` clean, and
+  `scripts/check-tokens.sh` clean including WCAG AA contrast across 6 themes.
+  Stays open because that is not the same claim as the task: these gates cover
+  the changes merged in this pass, not a re-verification of the whole feature's
+  prior work.
 - [x] T035 `speckit-verify` / `speckit-verify-tasks` against real
   implementation evidence. **This document is that verification pass**,
   performed manually against `main` source rather than via the


### PR DESCRIPTION
Closes #1158.

## Summary

- The Targets table's star + designation columns now stay pinned while the rest scroll horizontally, so you never lose track of which target a row is.
- Spec 054's last outstanding item (T024/T025, FR-006/FR-007), designed but never built.

## The problem is the default, not an edge case

Measured live, not estimated:

| | |
|---|---|
| Side dock engages at | 1400px window |
| Sidebar | 220px |
| Dock | 420px (default) |
| Table space | **760px** |
| Table min-width | **1000px** |
| → horizontal overflow | **240px** |

With `table-layout: fixed`, the 20%-wide designation column is exactly what scrolls out of view — so you compare gain/exposure/filter values with no idea which target each row belongs to.

## CSS-only

The colgroup classes and a sticky `thead` already existed; this adds the horizontal axis. **No TypeScript touched**, which also kept it clear of the two open PRs currently editing `TargetsTable.tsx` (#1160, #1048) — I confirmed neither touches the colgroup, the column classes, or these CSS files.

Safe here specifically because `TargetsTable` windows rows with the padding-spacer pattern and applies **no transforms** — a transformed ancestor would create a containing block and silently break `position: sticky`. Cost is bounded by the windowing: ~13 rows in the DOM means ~26 sticky cells.

## Three things measurement caught that reasoning did not

1. **`45px` produced a 50px column.** The other columns are percentages totalling 95%, which fixed-layout honours exactly, so the star column renders as whatever they leave. The offset was 5px short and the designation drifted `270px → 265px` while scrolling.
2. **A percentage offset is worse.** Sticky offsets resolve against the *containing block*, so `left: 5%` became 5% of the 760px scroll container = 38px — a 12px drift.
3. **50px is exact**, because the offset is only consulted while scrolling, and the table only scrolls at its 1000px floor: width is `max(container, 1000px)`, so overflow implies the table is exactly 1000px and the star exactly 50px. Above the floor nothing scrolls and the offset is never used.

Every one of those would have shipped as a subtly misaligned column under static review.

## Two hazards handled

- **Spanning rows.** Scoped to `.pv-targets-table__row`, so group headers (`.pv-listgroup`) and the virtualizer's spacer rows — which render a single `<td colSpan>` — are structurally excluded. An unscoped `nth-child` would pin a full-width cell and drag it across the viewport.
- **Collapsed borders.** The seam uses `box-shadow`, not `border-right`: `.pv-table` is `border-collapse: collapse`, where borders belong to the table and detach from sticky cells while scrolling.

## Verification

At 1400×900 with a 420px side dock, scrolled fully right:

| Check | Result |
|---|---|
| star drift | **0px** |
| designation drift | **0px** |
| designation *header* drift | **0px** |
| third column | scrolled **240px** |
| header aligned with body | ✅ |
| pinned cells opaque | ✅ (no bleed-through) |
| hover / selected carry across pinned cells | ✅ |
| z-order (header 3 > body 2) | ✅ |

Plus `check-tokens.sh` clean (incl. WCAG AA contrast across 6 themes) and 28 files / 402 targets tests passing.

**Not verified:** the mock dataset has only 2 targets, so group-header and spacer rows never materialise and virtualization isn't exercised. Their exclusion is verified *structurally* — only data rows carry `.pv-targets-table__row` (`TargetsTable.tsx:1281`) — not observed live. T026 (a real-browser E2E assertion) is left open in the spec for that reason; a Layer-1 test cannot substitute, since jsdom has no layout engine and cannot observe sticky offsets.

## Spec Context
- Spec: 054 (adaptive detail dock), T024/T025, FR-006/FR-007
- Branch: feat/1158-pinned-targets-columns