### PR TITLE
test(e2e): session target waits outlast the 30s ingest-resolution drain

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -181,6 +181,35 @@ pub const LAUNCH_TIMEOUT: Duration = Duration::from_secs(240);
 /// cold CI runner without masking a genuinely-absent element for long.
 pub const DEFAULT_FIND_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Budget for waits that depend on the ingest-resolution drain
+/// (`apps/desktop/src-tauri/src/bootstrap/background.rs`,
+/// `spawn_ingest_resolution_drain`).
+///
+/// That task is the ONLY caller of `backfill_session_targets` in the app —
+/// there is no event-driven plan-applied listener for it — and its loop is
+/// `sleep(30s)` FIRST, then resolve, then back-fill. A session's `targetIds`
+/// therefore cannot populate until a drain tick lands, and ticks come every
+/// 30 s starting 30 s after launch.
+///
+/// Waiting on that with a 30 s budget is a coin flip: the poll window and the
+/// drain period are the SAME length, so whether a tick falls inside the window
+/// depends on where setup happens to finish relative to the drain's phase.
+/// That is what made `ingestion_sessions_search` flake (#1205) — it failed at
+/// 155 s and passed on retry at 38 s, on the same commit.
+///
+/// 90 s guarantees at least two ticks inside the window regardless of phase.
+///
+/// Use this ONLY for predicates that gate on `targetIds` being populated.
+/// Waits on `sessionKey`/`frameCount` observe session GROUPING, which is
+/// event-driven and genuinely prompt — those must keep the shorter budget so
+/// a real grouping regression still fails fast.
+///
+/// This is a test-side fix for a test-side race. It deliberately does NOT
+/// change the 30 s drain interval, because that interval also sets the real
+/// user-visible latency for target resolution after an ingest, and changing it
+/// is a product decision (see #1205).
+pub const DRAIN_BACKED_TIMEOUT: Duration = Duration::from_secs(90);
+
 /// Deadline for a single `execute_async` script, set explicitly on the session
 /// (#1205). Before this existed the suite silently inherited the driver's own
 /// default — the W3C default is 30 s, which a legitimate IPC invoke can exceed

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -37,7 +37,7 @@ mod common;
 
 use std::time::Duration;
 
-use common::{write_minimal_fits, E2eApp};
+use common::{write_minimal_fits, E2eApp, DRAIN_BACKED_TIMEOUT};
 use serde_json::json;
 
 const INVOKE_TIMEOUT: Duration = Duration::from_secs(30);
@@ -405,11 +405,18 @@ async fn ingestion_sessions_search() -> anyhow::Result<()> {
     let _: serde_json::Value =
         app.invoke("inbox_plan_apply", json!({ "inboxItemId": inbox_item_id })).await?;
 
-    // Session grouping is event-driven (the plan-listener reacts to the
-    // plan-applied event asynchronously) — poll `sessions.list` for the real,
-    // grouped-and-resolved session instead of a blind sleep.
+    // Poll `sessions.list` for the real, grouped-and-resolved session instead
+    // of a blind sleep.
+    //
+    // NOTE: the previous comment here claimed this is event-driven — "the
+    // plan-listener reacts to the plan-applied event asynchronously". That is
+    // true of session GROUPING, but NOT of the `targetIds` this predicate
+    // waits on. `backfill_session_targets` has exactly one caller in the app,
+    // the 30 s-interval ingest-resolution drain, so this wait is bounded by
+    // that drain's cadence and needs [`DRAIN_BACKED_TIMEOUT`], not the plain
+    // 30 s one. Waiting 30 s on a 30 s-period task is what flaked (#1205).
     let sessions: serde_json::Value = app
-        .invoke_until("sessions_list", json!({}), INVOKE_TIMEOUT, |v: &serde_json::Value| {
+        .invoke_until("sessions_list", json!({}), DRAIN_BACKED_TIMEOUT, |v: &serde_json::Value| {
             v.as_array().is_some_and(|arr| {
                 arr.iter().any(|s| s["targetIds"].as_array().is_some_and(|t| !t.is_empty()))
             })

--- a/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
+++ b/crates/e2e-tests/tests/lifecycle_ui_journeys.rs
@@ -24,7 +24,7 @@ mod common;
 use std::time::Duration;
 
 use anyhow::Context;
-use common::{write_minimal_fits, E2eApp};
+use common::{write_minimal_fits, E2eApp, DRAIN_BACKED_TIMEOUT};
 use serde_json::json;
 use thirtyfour::{By, WebElement};
 
@@ -144,7 +144,12 @@ async fn setup_project_library_and_one_session(app: &E2eApp) -> anyhow::Result<s
     // Session grouping is event-driven — poll the real backend read until it
     // resolves before the wizard needs it.
     let _: serde_json::Value = app
-        .invoke_until("sessions_list", json!({}), UI_TIMEOUT, |v: &serde_json::Value| {
+        // `targetIds` is populated only by the 30 s-interval ingest-resolution
+        // drain, so this needs DRAIN_BACKED_TIMEOUT rather than the 30 s
+        // UI_TIMEOUT — a 30 s wait on a 30 s-period task is a coin flip
+        // (#1205). Same latent race as `ingestion_sessions_search`; it had not
+        // been observed failing here yet, but the mechanism is identical.
+        .invoke_until("sessions_list", json!({}), DRAIN_BACKED_TIMEOUT, |v: &serde_json::Value| {
             v.as_array().is_some_and(|arr| {
                 arr.iter().any(|s| s["targetIds"].as_array().is_some_and(|t| !t.is_empty()))
             })


### PR DESCRIPTION
Fixes the #1205 flake, with an actual root cause rather than a timeout bump.

## Root cause

`ingestion_sessions_search` waits for a session with non-empty `targetIds`. `backfill_session_targets` — the only thing that populates that field — has **exactly one caller in the entire app**: `spawn_ingest_resolution_drain` (`apps/desktop/src-tauri/src/bootstrap/background.rs`). There is no event-driven plan-applied listener for it.

That loop is:

```rust
loop { sleep(30s); resolve_pending(...); backfill_session_targets(...); }
```

It **sleeps first**, so `targetIds` cannot populate until 30 s after launch, and then only every 30 s. The test waited on that with a 30 s budget — a poll window exactly as long as the drain period. Whether a tick lands inside the window depends on where setup happens to finish relative to the drain's phase.

That is a coin flip by construction, which is why the CI evidence looks the way it does: **failed at 155 s, passed on retry at 38 s, same commit**. Not a slow runner.

## A misleading comment, corrected

The test asserted this step was event-driven:

> Session grouping is event-driven (the plan-listener reacts to the plan-applied event asynchronously)

That is true of session **grouping**, but not of target back-fill. I corrected it in place, because that comment is precisely what made a 30 s budget look sufficient to every previous reader.

## The fix

A shared `DRAIN_BACKED_TIMEOUT` (90 s) in `common`, guaranteeing at least two drain ticks inside the window regardless of phase.

Applied to the **only two** waits that gate on `targetIds`:

| Site | Status |
|---|---|
| `journeys.rs` — `ingestion_sessions_search` | the observed flake (#1205) |
| `lifecycle_ui_journeys.rs` | identical latent race, **not yet observed failing** |

The other three `sessions_list` waits gate on `sessionKey`/`frameCount`, which observe event-driven grouping and are genuinely prompt. They keep the shorter budget **deliberately**, so a real grouping regression still fails fast. Blanket-raising `INVOKE_TIMEOUT` would have removed that protection.

The constant lives in `common` rather than being cloned into both files, per the one-definition rule.

## What I deliberately did NOT change

The 30 s drain interval. It is also the **real user-visible latency for target resolution after an ingest** — a session shows no target for up to 30 s after applying an ingest plan, and there is no faster path. Shortening it, or running the first pass immediately, is a product decision and a plausible UX improvement, but it is not a test fix and I am not smuggling it in here. Noted on #1205 for someone to judge on its merits.

## Verification

- `cargo check --tests -p e2e_tests` — clean
- `cargo clippy -p e2e_tests --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean

Test-infra only; no product code touched.

## Honest limits

I cannot prove this fixes the flake from one CI sample — the test passes on retry today, so a green run here is weak evidence either way. What is *proven* is the mechanism: a 30 s wait on a 30 s-period task with no prompt path. The fix removes that specific coupling.

`Refs #1205` rather than `Closes` — it should stay open until several clean runs accumulate.