### PR TITLE
fix: choosing the Observatory Cool theme now sticks after a restart

### DIFF
--- a/crates/app/settings/src/descriptors.rs
+++ b/crates/app/settings/src/descriptors.rs
@@ -565,8 +565,16 @@ pub(crate) const DESCRIPTORS: &[Descriptor] = &[
         noisy: false,
         overridable: false,
         validation: ValidationRule::EnumStr {
-            allowed: &["warm-clay", "warm-slate", "observatory-dark", "espresso-dark", "system"],
-            expected_msg: "must be \"warm-clay\", \"warm-slate\", \"observatory-dark\", \"espresso-dark\", or \"system\"",
+            allowed: &[
+                "warm-clay",
+                "warm-slate",
+                "observatory-dark",
+                "observatory-cool",
+                "observatory-cool-light",
+                "espresso-dark",
+                "system",
+            ],
+            expected_msg: "must be \"warm-clay\", \"warm-slate\", \"observatory-dark\", \"observatory-cool\", \"observatory-cool-light\", \"espresso-dark\", or \"system\"",
         },
         apply: |v, s| {
             if let Some(x) = v.as_str() {

--- a/crates/app/settings/src/tests.rs
+++ b/crates/app/settings/src/tests.rs
@@ -617,6 +617,8 @@ fn is_valid_key_cases(#[case] key: &str, #[case] expected: bool) {
 #[case("theme", serde_json::json!("warm-clay"))]
 #[case("theme", serde_json::json!("warm-slate"))]
 #[case("theme", serde_json::json!("observatory-dark"))]
+#[case("theme", serde_json::json!("observatory-cool"))]
+#[case("theme", serde_json::json!("observatory-cool-light"))]
 #[case("theme", serde_json::json!("espresso-dark"))]
 #[case("theme", serde_json::json!("system"))]
 #[case("framingPointingFractionOfFov", serde_json::json!(0.10))]


### PR DESCRIPTION
## Summary

- Selecting **Observatory Cool** or **Observatory Cool Light** appeared to work, then silently reverted to the previous theme on the next load. The choice is now saved.
- The backend validated the theme setting against an allowlist that still named only the four themes predating the Observatory Cool pair, so it rejected the write. The picker offered them anyway, because the frontend derives its list separately.

## Verification

`cargo test -p app_core_settings` — 211 passed; clippy clean.

Checked in both directions: with the allowlist change reverted but the new tests kept, both new cases fail with *expected theme="observatory-cool" to be accepted*. The tests pin the behaviour rather than restate the implementation.

## Spec Context

Fallout from spec 043 adding the Observatory Cool themes: the frontend allowlist is derived from `THEMES`, the backend one in `crates/app/settings/src/descriptors.rs` is hand-maintained, and only the frontend was updated. Closes #1193.