### PR TITLE
chore: repair the design-system sync pipeline and the guidance it publishes

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -10,11 +10,13 @@ Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
   Section, Box, KV, EmptyState, Table, Banner, Toggle, SegControl, RadioGroup, CoverageBar,
   Lock, DirPicker, WizardShell, ToastContainer, InfoTip). Feature-level components live in
   `src/features/*` and are intentionally NOT synced (app screens, not reusable primitives).
-- **Theming**: tokens are `--alm-*` CSS custom properties in `src/styles/tokens.css`.
-  `:root` = default (light); 4 named themes as `[data-theme="warm-slate"|"warm-clay"|
-  "observatory-dark"|"espresso-dark"]` on `<html>`; density via `.density-compact`/
-  `.density-spacious` on `<html>`. `.alm-*` component classes are BEM
-  (`.alm-btn--primary`, `.alm-pill--ok`, …).
+- **Theming**: tokens are `--pv-*` CSS custom properties in `src/styles/tokens.css`, which
+  `@import`s the shared type/space/radius scale from `packages/tokens/foundation.css`.
+  `:root` = default (light); 6 named themes as `[data-theme="warm-slate"|"warm-clay"|
+  "observatory-cool-light"|"observatory-cool"|"observatory-dark"|"espresso-dark"]` on
+  `<html>` (`observatory-cool` is the canonical dark and the app's dark default); density
+  via `.density-compact`/`.density-spacious` on `<html>`. `.pv-*` component classes are BEM
+  (`.pv-btn--primary`, `.pv-pill--ok`, …).
 
 - **CSS must be pre-flattened (converter does NOT resolve `@import`).** `cfg.cssEntry`
   points at `apps/desktop/.ds-css/flattened.css` (gitignored, generated). Regenerate it
@@ -26,8 +28,14 @@ Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
     await e.build({entryPoints:['apps/desktop/.ds-css/_aggregate.css'],bundle:true, \
     outfile:'apps/desktop/.ds-css/flattened.css',loader:{'.css':'css'}})"
   ```
-  esbuild inlines the relative `@import`s (incl. `components.css` → `components/*.css`
-  partials, the `.alm-*` classes) and keeps the remote Google-Fonts `@import` external.
+  esbuild inlines the relative `@import`s — `components.css` → `components/*.css` partials
+  (the `.pv-*` classes) and `tokens.css` → `packages/tokens/foundation.css`, which sits
+  OUTSIDE `apps/desktop`, so the aggregate must be built from a root that can reach it.
+  **`external: ['*.woff2']` is required**: since spec 055 bundled the fonts, `tokens.css`
+  carries six `@font-face` rules, and esbuild hard-fails the entire flatten with *no loader
+  is configured for ".woff2"* without it. External is also the behaviour we want — the DS
+  project serves its own copies from `fonts/`, so those `url()`s are rewritten on upload
+  rather than inlined or hashed here.
   `cfg.tokensGlob` is a NO-OP here (`copyTokens` only reads a `node_modules` `tokensPkg`),
   so tokens ride inside the flattened `cssEntry` instead. Aggregate + esbuild command are
   also captured in `.design-sync/rebuild-css.sh`.
@@ -36,16 +44,22 @@ Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
   (`^[A-Z][A-Z0-9_]+$`) as constants → `KV` is filtered from the card list. It is STILL in
   the importable bundle (`window.PlateVault.KV`, 17 exports) — just no preview card. Not
   worth forking `lib/dts.mjs` for one trivial key-value component.
-- **Fonts are remote** — Inter + JetBrains Mono via a Google Fonts `@import url(...)` at the
-  top of `tokens.css` → validate reports `[FONT_REMOTE]` (informational). Nothing to ship;
-  cards render correctly online, fall back to system fonts offline.
+- **Fonts are bundled locally, not remote** (changed by spec 055). `tokens.css` declares
+  `@font-face` rules over the six Inter `.woff2` files in `apps/desktop/src/assets/fonts/`;
+  the Google Fonts CDN `@import` is gone. The DS project serves its own copies from
+  `fonts/`, so the bundle's `src:` URLs are rewritten on upload rather than inlined. Expect
+  `[FONT_REMOTE]` to no longer fire — if it does, something re-introduced a CDN import.
 - **Preview scope = floor cards** (first sync). User will author richer previews by driving
   the project in claude.ai/design. Every component still ships fully functional (importable
   bundle + `.d.ts` + `.prompt.md`).
 
 ## Known render warns (triaged clean — a warn NOT here is new)
-- `[FONT_REMOTE]` Inter / JetBrains Mono / Cascadia Code — remote Google-Fonts `@import`,
-  by design (see remote-fonts bullet).
+
+> **Stale — re-triage on the next run.** The list below records the FIRST sync's results.
+> Since then the `--alm-*` → `--pv-*` rename, the six-theme consolidation, the destructive
+> token, the local-font switch, and the `ConfirmOverlay` → `Modal` merge all landed without
+> a re-sync. Treat these as a starting hypothesis, not a clean baseline.
+
 - `[RENDER_BLANK]` on Banner, Box, Btn, CoverageBar, EmptyState, Pill, Section — these
   render the REAL component with empty default props (a childless button, an empty box),
   so the PNG is <5KB. Functional, just content-less until real props are supplied.
@@ -56,7 +70,7 @@ Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
 
 ## Re-sync risks (watch-list for the next run)
 - **CSS flatten step is mandatory and easy to forget** — if `flattened.css` is stale or
-  missing, `_ds_bundle.css` silently loses the `.alm-*` classes. Always re-run
+  missing, `_ds_bundle.css` silently loses the `.pv-*` classes. Always re-run
   `.design-sync/rebuild-css.sh` before `package-build.mjs`.
 - Tauri/app-context primitives (`DirPicker`, `ToastContainer`) call `@tauri-apps/*` /
   app context that is absent in headless Chromium — they may floor-card even with an
@@ -64,5 +78,7 @@ Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
   the place to look.
 - The bundle is built from `src/ui` source (not a versioned dist), so any refactor of the
   barrel or a primitive's props changes the synced contract — rebuild on any `src/ui` change.
-- Remote Google Fonts `@import` means the DS has no shipped `@font-face`; if the app ever
-  self-hosts fonts, add them via `cfg.extraFonts`.
+- **`componentSrcMap` rots silently.** It maps names to source paths; when a component is
+  deleted or merged away, the next build hits a missing source. `ConfirmOverlay` (merged
+  into `Modal`) and the `ProjectStatusTag` alias were both retired this way. Re-check the
+  map against `src/ui` + `src/components` whenever a component is removed or renamed.

--- a/.design-sync/config.json
+++ b/.design-sync/config.json
@@ -42,12 +42,8 @@
     "DetailPanel": "src/components/DetailPanel.tsx",
     "FactsKV": "src/components/DetailPanel.tsx",
     "MetricLine": "src/components/MetricLine.tsx",
-    "DetailGrid": "src/components/DetailGrid.tsx",
-    "Rail": "src/components/DetailGrid.tsx",
-    "RailCard": "src/components/DetailGrid.tsx",
     "Lifecycle": "src/components/Lifecycle.tsx",
     "Modal": "src/components/Modal.tsx",
-    "ConfirmOverlay": "src/components/ConfirmOverlay.tsx",
     "StatusTag": "src/components/StatusTag.tsx",
     "PropertyTable": "src/components/PropertyTable.tsx",
     "TargetSearch": null

--- a/.design-sync/conventions.md
+++ b/.design-sync/conventions.md
@@ -2,7 +2,7 @@
 
 PlateVault is a local-first desktop app for astrophotography library management. Its UI
 is a **token-driven, BEM-class** system: components are plain React styled entirely by CSS
-custom properties and `.alm-*` classes. There is **no styling provider to wrap** — the
+custom properties and `.pv-*` classes. There is **no styling provider to wrap** — the
 styles ship in `styles.css` (which `@import`s `_ds_bundle.css`); import that once and every
 component and class is styled.
 
@@ -11,34 +11,47 @@ component and class is styled.
 The default `:root` scope is the light theme. Switch themes by setting a `data-theme`
 attribute on the root element; switch density with a class:
 
-- `data-theme` — `warm-slate`, `warm-clay`, `observatory-dark`, `espresso-dark`
+- `data-theme` — light: `warm-slate`, `warm-clay`, `observatory-cool-light`;
+  dark: `observatory-cool`, `observatory-dark`, `espresso-dark`
 - density class — `density-compact` or `density-spacious`
 
-Each theme overrides only the raw palette tokens, so everything built with the tokens
-below re-themes automatically. Prefer the two dark themes for a low-light imaging mood.
+`observatory-cool` is the canonical dark theme and the app's dark default;
+`observatory-cool-light` is its light counterpart. Each theme overrides only the raw palette
+tokens, so everything built with the tokens below re-themes automatically.
 
-## Style with `--alm-*` tokens (this is the idiom — use these, don't invent values)
+## Style with `--pv-*` tokens (this is the idiom — use these, don't invent values)
 
-- **Text/ink**: `--alm-ink` (primary), `--alm-ink2`, `--alm-ink3`, `--alm-ink4` (faint)
-- **Surfaces**: `--alm-bg`, `--alm-bg3`, `--alm-chip`, `--alm-hover-bg`, `--alm-selected-bg`
-- **Lines**: `--alm-border`, `--alm-border-subtle`, `--alm-rule`, `--alm-rule2`
-- **Accent**: `--alm-accent`, `--alm-accent-hover`, `--alm-accent-bg`, `--alm-accent-text`,
-  `--alm-on-accent`
-- **Status**: `--alm-ok` / `--alm-danger` / `--alm-info` each with `-bg` and `-border`
-- **Type**: `--alm-font-sans`, `--alm-font-mono`; leading `--alm-leading-tight|normal|relaxed`
-- **Space**: `--alm-sp-0` … `--alm-sp-6` (spacing scale)
-- **Radius**: `--alm-radius-sm|md|lg|pill`
-- **Depth/focus**: `--alm-shadow-sm`, `--alm-focus-ring`
+- **Text/ink**: `--pv-text` (primary), `--pv-text-secondary`, `--pv-text-muted`,
+  `--pv-text-faint`; `--pv-ink` for maximum-contrast ink, `--pv-link` for links
+- **Surfaces**: `--pv-bg`, `--pv-chip`, `--pv-hover-bg`, `--pv-input-recessed-bg`
+- **Lines**: `--pv-border`, `--pv-border-subtle`, `--pv-rule`
+- **Accent**: `--pv-accent`, `--pv-accent-bg`, `--pv-on-accent`
+- **Status**: `--pv-ok` / `--pv-ok-bg`, `--pv-warn-bg`, `--pv-info-bg`, `--pv-danger-bg`
+- **Destructive**: `--pv-destructive` (+ `-bg`, `-bg-hover`) — reserved for actions that
+  actually delete, trash, or permanently discard. Reversible "danger" styling stays on the
+  `danger` family.
+- **Metrics**: `--pv-control-h` / `-sm`, `--pv-row-height`, `--pv-toolbar-height`,
+  `--pv-statusbar-height`, `--pv-sidebar-width` / `--pv-sidebar-collapsed`,
+  `--pv-action-sidebar-width`, `--pv-list-width`, `--pv-rail-width`
+- **Depth/focus**: `--pv-shadow-sm`, `--pv-focus-ring`
 
-## Component classes (BEM: `.alm-<block>` + `--modifier`)
+Type, spacing, and radius tokens come from `packages/tokens/foundation.css`, which
+`tokens.css` `@import`s — use those rather than hard-coded values:
+
+- **Type**: `--pv-font-sans`, `--pv-font-display`, `--pv-font-mono`;
+  leading `--pv-leading-tight|normal|relaxed`
+- **Space**: `--pv-sp-0` … `--pv-sp-7`
+- **Radius**: `--pv-radius-sm|md|lg`
+
+## Component classes (BEM: `.pv-<block>` + `--modifier`)
 
 Prefer the library components below; when writing your own layout glue, reuse these classes:
 
-- `.alm-btn` → `--primary` `--accent` `--danger` `--sm`
-- `.alm-pill` → `--accent` `--ok` `--warn` `--danger` `--info` `--neutral` `--ghost`
-- `.alm-banner` → `--info` `--warn` `--danger`
-- `.alm-toggle`, `.alm-seg`, `.alm-radio` (`.alm-radio-group`, `.alm-radio--active`)
-- `.alm-box`, `.alm-section`, `.alm-kv`, `.alm-empty`, `.alm-coverage`
+- `.pv-btn` → `--primary` `--danger` `--destructive` `--sm`
+- `.pv-pill` → `--accent` `--ok` `--warn` `--danger` `--info` `--neutral` `--ghost`
+- `.pv-banner` → `--info` `--warn` `--danger`
+- `.pv-toggle`, `.pv-seg`, `.pv-radio`
+- `.pv-box`, `.pv-section`, `.pv-kv`, `.pv-empty`, `.pv-coverage`
 
 ## Components — `window.PlateVault.*`
 
@@ -50,7 +63,7 @@ composing. Data-driven ones (Table, RadioGroup, SegControl, WizardShell) take ar
 
 ## Where the truth lives
 
-`styles.css` → `_ds_bundle.css` (all `--alm-*` tokens + `.alm-*` classes) is the styling
+`styles.css` → `_ds_bundle.css` (all `--pv-*` tokens + `.pv-*` classes) is the styling
 source; read it before adding custom CSS. Per-component contracts are the `.d.ts` files.
 
 ## Two tiers — primitives vs. layout scaffolds
@@ -62,27 +75,28 @@ The system is deliberately two-tier; **compose pages from Tier 2, not raw divs**
   InfoTip, ToastContainer, KV, Tooltip, Skeleton.
 - **Tier 2 — layout/composite scaffolds** (assemble a whole screen): `ListPageLayout`,
   `ListDetailLayout`, `PageShell`, `PageTopBar`, `TopActionBar`, `ListSidebar`, `FilterToolbar`,
-  `SortHeader`, `ListItem`, `DetailPanel`, `DetailPane`, `DetailHeader`, `DetailGrid`/`Rail`/
-  `RailCard`, `MetricLine`, `PropertyTable`, `Modal`, `ConfirmOverlay`, `StatusTag`, `Lifecycle`.
+  `SortHeader`, `ListItem`, `DetailPanel`, `DetailPane`, `DetailHeader`, `FactsKV`,
+  `MetricLine`, `PropertyTable`, `Modal`, `StatusTag`, `Lifecycle`.
 
-**Page shell contract:** a page is `.alm-page` with a pinned `.alm-page__bar` (action/filter
-bars — ALWAYS visible, never scroll) over a `.alm-page__scroll` (the ONLY scrolling region).
+**Page shell contract:** a page is `.pv-page` with a pinned `.pv-page__bar` (action/filter
+bars — ALWAYS visible, never scroll) over a `.pv-page__scroll` (the ONLY scrolling region).
 Prefer `ListPageLayout`/`PageTopBar`/`ListDetailLayout` to get this for free; a master-detail
-screen is a list (`Table` + `SortHeader`) beside a `DetailPanel`. Overlays use `Modal` (or
-`ConfirmOverlay` for confirms) — never hand-roll a dialog. Status is `StatusTag` (dot + label).
+screen is a list (`Table` + `SortHeader`) beside a `DetailPanel`. Overlays use `Modal` —
+including confirmations, which `Modal` absorbed — never hand-roll a dialog. Status is
+`StatusTag` (dot + label).
 
 ## One idiomatic snippet
 
 ```tsx
 import { Btn, Banner } from 'window.PlateVault'; // provided globally by the DS bundle
 
-<div style={{ display: 'grid', gap: 'var(--alm-sp-3)', padding: 'var(--alm-sp-4)',
-              background: 'var(--alm-bg)', color: 'var(--alm-ink)',
-              fontFamily: 'var(--alm-font-sans)' }}>
+<div style={{ display: 'grid', gap: 'var(--pv-sp-3)', padding: 'var(--pv-sp-4)',
+              background: 'var(--pv-bg)', color: 'var(--pv-text)',
+              fontFamily: 'var(--pv-font-sans)' }}>
   <Banner variant="info">Calibration frames matched for tonight's session.</Banner>
-  <div style={{ display: 'flex', gap: 'var(--alm-sp-2)' }}>
+  <div style={{ display: 'flex', gap: 'var(--pv-sp-2)' }}>
     <Btn variant="primary">Review plan</Btn>
-    <button className="alm-btn alm-btn--sm">Later</button>
+    <button className="pv-btn pv-btn--sm">Later</button>
   </div>
 </div>
 ```

--- a/.design-sync/rebuild-css.sh
+++ b/.design-sync/rebuild-css.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 # Regenerate the flattened design-system stylesheet that cfg.cssEntry points at.
 # The design-sync converter copies cssEntry VERBATIM (it does not resolve @import),
-# so we pre-flatten reset + tokens + components (the .alm-* classes) into one file.
+# so we pre-flatten reset + tokens + components (the .pv-* classes) into one file.
 # Run this from the repo root BEFORE every `package-build.mjs` run.
 set -euo pipefail
 cd "$(dirname "$0")/.."   # repo root
@@ -20,8 +20,21 @@ await esbuild.build({
   bundle: true,
   outfile: 'apps/desktop/.ds-css/flattened.css',
   loader: { '.css': 'css' },
+  // tokens.css @font-faces the bundled Inter .woff2 files (spec 055). esbuild has no
+  // loader for those and hard-fails the whole flatten unless they stay external. External
+  // is also what we want: the design project serves its own copies from fonts/, so the
+  // url()s are rewritten on upload rather than inlined or hashed here.
+  external: ['*.woff2'],
   logLevel: 'warning',
 });
 "
-echo "flattened: $(wc -c < apps/desktop/.ds-css/flattened.css) bytes, \
-$(grep -oc '\.alm-' apps/desktop/.ds-css/flattened.css) .alm- rules"
+rules=$(grep -o '\.pv-[a-z0-9-]*' apps/desktop/.ds-css/flattened.css | sort -u | wc -l)
+echo "flattened: $(wc -c < apps/desktop/.ds-css/flattened.css) bytes, ${rules} distinct .pv- classes"
+
+# The failure this guards against is silent: if the aggregate stops resolving
+# components.css, the build still succeeds and ships a bundle with tokens but no
+# component classes. Anything below a floor means the flatten did not work.
+if [ "$rules" -lt 20 ]; then
+  echo "ERROR: only ${rules} .pv- classes in flattened.css — the component partials did not inline." >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary

- ``.design-sync/rebuild-css.sh`` **could not run at all on `main`.** Bundling the fonts gave `tokens.css` six `@font-face` rules over `.woff2` files, and esbuild hard-fails the flatten with *no loader is configured for ".woff2"*. Since NOTES.md calls this step mandatory before every build, the sync pipeline was broken at its first step. Marked external — which is also the behaviour we want, as the design project serves its own font copies and rewrites those URLs on upload.
- Its sanity line counted `.alm-` rules, so after the rename it reported **zero** every run and nobody noticed. It now counts `.pv-` classes and fails below a floor. That is the silent failure worth catching: a bundle with tokens but no component classes still builds and still uploads.
- `config.json` mapped four components to files that no longer exist — `ConfirmOverlay` (merged into `Modal`) and `DetailGrid`/`Rail`/`RailCard` (gone entirely; only doc-comments still name them).
- `conventions.md` and `NOTES.md` documented the dead `--alm-*` namespace and four themes, and described fonts as remote Google Fonts.

The docs matter beyond tidiness: `conventions.md` is `cfg.readmeHeader`, injected into the design project as its authoring guidance. It was actively instructing collaborators to build with tokens that no longer exist.

## Verification

`bash .design-sync/rebuild-css.sh` → exit 0, 213975 bytes, 255 distinct `.pv-` classes. Output spot-checked: six `@font-face` rules with external relative URLs, all six `data-theme` blocks, `--pv-destructive` in all six, and `packages/tokens/foundation.css` inlined despite sitting outside `apps/desktop`.

The new floor check was verified in the other direction: a tokens-only aggregate yields 0 classes and exits 1.

Every remaining `componentSrcMap` path was checked to exist on disk.

## Notes

The `--alm-*` → `--pv-*` rename was **not** mechanical — `--alm-ink` became `--pv-text`, not `--pv-ink` — so `conventions.md` is rewritten against `tokens.css` rather than sed'd.

NOTES.md's "Known render warns" triage is empirical output from the first sync. Re-triaging it honestly requires an actual re-sync run, so it is **marked stale** rather than rewritten with guesses.

Two things deliberately left out of scope:
- `DetailPanel.tsx:113` and `DetailPane.tsx:11` still reference `DetailGrid` in doc-comments, though it no longer exists. App code, not sync config.
- The palette cards in the design project are still stale (no `observatory-cool` cards, no destructive swatch). That is the follow-up half of this work and needs the MCP surface, not a PR.

## Spec Context

Fallout from handoffs 01/03/06 of the design refresh (`run-dsr`) landing without `.design-sync/` being updated alongside.