### PR TITLE
feat(inbox): scanned folders show up as rows you cannot confirm

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1949,6 +1949,10 @@
     }
   ],
   "inbox_list_root_label": "(root)",
+  "inbox_source_group_state": "not classified",
+  "inbox_source_group_detail_title": "Scanned folder",
+  "inbox_source_group_detail_body": "This folder has been scanned but not classified yet, so there is nothing to confirm. Classify it to see its frames.",
+  "inbox_source_group_scanned_at": "Discovered {when}",
   "inbox_dest_root_label": "Library:",
   "inbox_dest_root_aria": "Destination library",
   "inbox_no_file_metadata": "No file metadata",

--- a/apps/desktop/src/app/router.tsx
+++ b/apps/desktop/src/app/router.tsx
@@ -81,6 +81,11 @@ const inboxRoute = createRoute({
     // search/filters change the array shape (Sessions/Calibration already use
     // this id-based pattern).
     selected: parseString,
+    // Spec 058 T013: a scanned-but-unclassified folder is selected through its
+    // OWN param, never through `selected`. Keeping the two apart is what makes
+    // a source-group row structurally non-confirmable: confirm reads the
+    // selected item, and a source group can never become one.
+    selectedGroup: parseString,
     type: parseEnum(FRAME_TYPES),
     group: parseEnum(INBOX_GROUPS),
   }),

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -15,6 +15,10 @@
  * page / top-bar (FilterToolbar + useGrouping); this is a controlled
  * presentational list.
  *
+ * Rows are of two kinds: inbox items, and — spec 058 T013/FR-016 —
+ * scanned-but-unclassified source-group folders, which are visible and
+ * selectable but have no item id and therefore nothing to confirm.
+ *
  * Sort: column headers are <button> elements that call onSort (SessionsTable
  * convention). The page owns sort state and passes sortCol + sortDir.
  * Kind filter: the page passes a `kindFilter` string that filters by the item's
@@ -22,7 +26,7 @@
  */
 
 import { useState, useMemo, useCallback } from 'react';
-import type { InboxListItem } from '@/bindings/index';
+import type { InboxListItem, InboxSourceGroupListItem } from '@/bindings/index';
 import {
   Table,
   tableIndent,
@@ -189,10 +193,97 @@ function detectionLabel(item: InboxListItem): string {
   return base || m.inbox_list_root_label();
 }
 
+/**
+ * Short, uppercase format tag for a source-group row. Mirrors `formatTag` but
+ * reads the group's own `format`, because a source group has no `lane` in the
+ * `fits`/`video` sense — its `lane` column is the `move`/`catalogue` lane, a
+ * different axis that happens to share the name (see `InboxSourceGroupListItem`).
+ */
+function sourceGroupFormatTag(group: InboxSourceGroupListItem): string {
+  switch (group.format) {
+    case 'video':
+      return 'VIDEO';
+    case 'xisf':
+      return 'XISF';
+    case 'mixed':
+      return 'MIXED';
+    default:
+      return 'FITS';
+  }
+}
+
+/**
+ * The `fits`/`video` lane a source-group row answers to for the lane filter.
+ * Derived from `format` for the reason above: filtering source groups on their
+ * own `lane` column would silently match the `move`/`catalogue` values against
+ * `fits`/`video` and hide every group whatever the user picked.
+ */
+function sourceGroupLane(group: InboxSourceGroupListItem): string {
+  return group.format === 'video' ? 'video' : 'fits';
+}
+
+/** Path label for a source-group row — same root-basename fallback as items (#556). */
+function sourceGroupLabel(group: InboxSourceGroupListItem): string {
+  if (group.relativePath) return group.relativePath;
+  const base = pathBasename(group.rootAbsolutePath);
+  return base || m.inbox_list_root_label();
+}
+
 /** Dominant frame-type key for kind-filtering (matches the Kind filter options). */
 function itemKind(item: InboxListItem): string {
   if (item.isMaster) return item.masterFrameType ?? 'master';
   return item.frameType ?? item.groupFrameType ?? '';
+}
+
+/**
+ * The four sortable values, projected off either row kind so one comparator
+ * orders items and source-group rows in a single sequence. Sorting the two
+ * kinds separately would pin every source group above (or below) the items
+ * regardless of the chosen column, which reads as a broken sort.
+ */
+interface SortKey {
+  detection: string;
+  type: string;
+  count: number;
+  format: string;
+}
+
+function itemSortKey(item: InboxListItem): SortKey {
+  return {
+    detection: item.relativePath,
+    type: classificationLabel(item),
+    count: item.fileCount,
+    format: formatDisplayLabel(item),
+  };
+}
+
+function sourceGroupSortKey(group: InboxSourceGroupListItem): SortKey {
+  return {
+    detection: group.relativePath,
+    type: m.inbox_source_group_state(),
+    count: group.fileCount,
+    format: sourceGroupFormatTag(group),
+  };
+}
+
+/** Sort comparator over the projected keys of either row kind. */
+function compareSortKeys(a: SortKey, b: SortKey, sort: InboxSort): number {
+  let cmp = 0;
+  switch (sort.col) {
+    case 'detection':
+      cmp = a.detection.localeCompare(b.detection);
+      break;
+    case 'type':
+      cmp = a.type.localeCompare(b.type);
+      break;
+    case 'count':
+      cmp = a.count - b.count;
+      break;
+    case 'format':
+      cmp = a.format.localeCompare(b.format);
+      break;
+  }
+  return sort.dir === 'asc' ? cmp : -cmp;
 }
 
 /** Sort comparator for inbox items. */
@@ -201,28 +292,27 @@ function compareItems(
   b: InboxListItem,
   sort: InboxSort,
 ): number {
-  let cmp = 0;
-  switch (sort.col) {
-    case 'detection':
-      cmp = a.relativePath.localeCompare(b.relativePath);
-      break;
-    case 'type':
-      cmp = classificationLabel(a).localeCompare(classificationLabel(b));
-      break;
-    case 'count':
-      cmp = a.fileCount - b.fileCount;
-      break;
-    case 'format':
-      cmp = formatDisplayLabel(a).localeCompare(formatDisplayLabel(b));
-      break;
-  }
-  return sort.dir === 'asc' ? cmp : -cmp;
+  return compareSortKeys(itemSortKey(a), itemSortKey(b), sort);
 }
 
 // ── Component types ─────────────────────────────────────────────────────────────
 
 export interface InboxListProps {
   items: InboxListItem[];
+  /**
+   * Spec 058 T013/FR-016: folders the scan found but that carry no inbox item
+   * yet. These render as rows so the folder is visible and selectable, but they
+   * are **structurally** non-confirmable — a source group has no item id, and
+   * selection is reported through `onSelectSourceGroup`, a channel entirely
+   * separate from `onSelect`. Confirm reads the selected *item*, so there is no
+   * value it could be handed; nothing here refuses a confirm, there is simply
+   * nothing to refuse.
+   */
+  sourceGroups?: InboxSourceGroupListItem[];
+  /** Currently selected source group, if the selection is a source-group row. */
+  selectedSourceGroupId?: string | null;
+  /** Called when the user selects a source-group row. */
+  onSelectSourceGroup?: (sourceGroupId: string) => void;
   /** Issue #644: selection is by item identity, not list position — an index
    * silently points at whatever item now occupies that slot after search/lane/
    * kind filters change the array shape. */
@@ -270,7 +360,19 @@ export interface ItemVisualRow {
   indent: number;
 }
 
-export type VisualRow = HeaderVisualRow | ItemVisualRow;
+/**
+ * A scanned-but-unclassified folder row (spec 058 T013). Deliberately carries
+ * the group — never an `InboxListItem`-shaped stand-in — so no downstream
+ * consumer can read an `inboxItemId` off it.
+ */
+export interface SourceGroupVisualRow {
+  kind: 'sourceGroup';
+  group: InboxSourceGroupListItem;
+  /** Left indent (px), to match leaf alignment when grouping is active. */
+  indent: number;
+}
+
+export type VisualRow = HeaderVisualRow | ItemVisualRow | SourceGroupVisualRow;
 
 /**
  * Walk the grouped tree in render order and produce the flat list of VISIBLE
@@ -316,8 +418,11 @@ export function flattenVisibleTree(
 
 export function InboxList({
   items,
+  sourceGroups = [],
   selectedId,
+  selectedSourceGroupId = null,
   onSelect,
+  onSelectSourceGroup,
   filterType,
   dims = [],
   kindFilter,
@@ -341,6 +446,23 @@ export function InboxList({
     const sorted = [...result].sort((a, b) => compareItems(a, b, sort));
     return sorted;
   }, [items, filterType, kindFilter, sort]);
+
+  /**
+   * Source-group rows surviving the same two filters.
+   *
+   * The kind filter drops them whenever it is set to a specific frame type: an
+   * unclassified folder has no frame type, so it matches no kind. Showing it
+   * under "bias" would be the exact class of claim-what-you-are-not this
+   * feature removes.
+   */
+  const filteredGroups = useMemo(() => {
+    let result = sourceGroups;
+    if (filterType !== 'all') {
+      result = result.filter((g) => sourceGroupLane(g) === filterType);
+    }
+    if (kindFilter && kindFilter !== 'all') return [];
+    return result;
+  }, [sourceGroups, filterType, kindFilter]);
 
   const tree = useMemo(
     () => groupByDimensions(filtered, dims, ACCESSORS),
@@ -367,14 +489,50 @@ export function InboxList({
   const grouped = dims.length > 0;
 
   const visualRows = useMemo<VisualRow[]>(() => {
-    if (grouped) return flattenVisibleTree(tree, collapsed, originalIndexById);
-    return filtered.map((item) => ({
+    const groupRows: SourceGroupVisualRow[] = filteredGroups.map((group) => ({
+      kind: 'sourceGroup' as const,
+      group,
+      indent: 0,
+    }));
+
+    // Grouping dimensions read item fields (frame type, target, lane…) that an
+    // unclassified folder has none of, so source-group rows cannot be placed in
+    // the tree. They render as a flat block above it rather than being dropped
+    // — a folder disappearing because the user grouped the list would be the
+    // invisible-folder failure FR-016 exists to prevent.
+    if (grouped) {
+      return [
+        ...groupRows,
+        ...flattenVisibleTree(tree, collapsed, originalIndexById),
+      ];
+    }
+
+    const itemRows: ItemVisualRow[] = filtered.map((item) => ({
       kind: 'item' as const,
       item,
       originalIdx: originalIndexById.get(item.inboxItemId) ?? -1,
       indent: 0,
     }));
-  }, [grouped, tree, collapsed, originalIndexById, filtered]);
+
+    // Ungrouped, both kinds sort as one sequence off the shared key projection.
+    // Keys are computed once per row up front (rather than inside the
+    // comparator, which would re-derive every label on each of the O(n log n)
+    // comparisons) and carried alongside the row.
+    const keyed: { row: VisualRow; key: SortKey }[] = [
+      ...groupRows.map((row) => ({ row, key: sourceGroupSortKey(row.group) })),
+      ...itemRows.map((row) => ({ row, key: itemSortKey(row.item) })),
+    ];
+    keyed.sort((a, b) => compareSortKeys(a.key, b.key, sort));
+    return keyed.map((entry) => entry.row);
+  }, [
+    grouped,
+    tree,
+    collapsed,
+    originalIndexById,
+    filtered,
+    filteredGroups,
+    sort,
+  ]);
 
   // ── Sortable column headers (SessionsTable convention) ──────────────────────
   const makeSortHeader = (
@@ -471,6 +629,40 @@ export function InboxList({
             format: '',
           };
         }
+        if (row.kind === 'sourceGroup') {
+          const { group, indent } = row;
+          const selected = selectedSourceGroupId === group.sourceGroupId;
+          return {
+            _testid: `inbox-source-group-${group.sourceGroupId}`,
+            _rowClassName: [
+              'pv-inbox-table__row',
+              'pv-inbox-table__row--source-group',
+              selected ? 'pv-inbox-table__row--selected' : '',
+            ]
+              .filter(Boolean)
+              .join(' '),
+            _onClick: () => onSelectSourceGroup?.(group.sourceGroupId),
+            _selected: selected,
+            _indent: indent || undefined,
+            detection: (
+              <span className="pv-inbox-cell__path-wrap">
+                <span
+                  className="pv-inbox-cell__path"
+                  title={sourceGroupLabel(group)}
+                >
+                  {sourceGroupLabel(group)}
+                </span>
+              </span>
+            ),
+            type: (
+              <span className="pv-inbox-row__classification pv-inbox-row__classification--pending">
+                {m.inbox_source_group_state()}
+              </span>
+            ),
+            count: m.inbox_list_file_count({ count: group.fileCount }),
+            format: sourceGroupFormatTag(group),
+          };
+        }
         const { item, indent } = row;
         const selected = selectedId === item.inboxItemId;
         const mod = classificationMod(item);
@@ -522,7 +714,14 @@ export function InboxList({
           format: formatDisplayLabel(item),
         };
       }),
-    [visualRows, selectedId, onSelect, toggle],
+    [
+      visualRows,
+      selectedId,
+      selectedSourceGroupId,
+      onSelect,
+      onSelectSourceGroup,
+      toggle,
+    ],
   );
 
   const groupingHint = grouped

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -53,13 +53,18 @@ import { Btn } from '@/ui';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from './InboxControls';
 import { InboxDetail } from './InboxDetail';
 import { InboxList, DEFAULT_INBOX_SORT } from './InboxList';
+import { InboxSourceGroupDetail } from './InboxSourceGroupDetail';
 import type { InboxSortCol, InboxSort } from './InboxList';
 import { InboxStatsSummary } from './InboxStatsSummary';
 import { deriveInboxStats } from './inboxStatsFromItems';
 import { PlanApprovalOverlay } from './PlanApprovalOverlay';
 import type { DestructiveDestination, PendingRootPick } from './PlanPanel';
 import { buildBreakdownFromActions } from './PlanPanel';
-import type { InboxBreakdownTarget, InboxListItem } from './store';
+import type {
+  InboxBreakdownTarget,
+  InboxListItem,
+  InboxSourceGroupListItem,
+} from './store';
 import {
   inboxClassifyQueryKey,
   mergeRescanRoots,
@@ -168,9 +173,11 @@ function asRootRequiredDetails(
 // etc.) and recomputed their outputs every render too — feeding an unstable
 // value into `useSetPageStatus` and re-triggering its effect indefinitely.
 const EMPTY_ITEMS: InboxListItem[] = [];
+/** Same stable-identity reasoning as `EMPTY_ITEMS`, for the source-group list. */
+const EMPTY_SOURCE_GROUPS: InboxSourceGroupListItem[] = [];
 
 export function InboxPage() {
-  const { selected, type } = useSearch({ from: '/shell/inbox' });
+  const { selected, selectedGroup, type } = useSearch({ from: '/shell/inbox' });
   const navigate = useNavigate({ from: '/inbox' });
   const queryClient = useQueryClient();
 
@@ -181,6 +188,12 @@ export function InboxPage() {
     refresh: refreshList,
   } = useInboxList();
   const items = listData?.items ?? EMPTY_ITEMS;
+  // Spec 058 T013/FR-016: folders the scan found that carry no item row yet.
+  // Empty while the scan-time placeholder still exists (T012/T020), so this
+  // wiring is inert until that lands — but it is what makes the placeholder
+  // removable at all: without a rendered source-group row, deleting the
+  // placeholder would make every scanned folder invisible.
+  const sourceGroups = listData?.sourceGroups ?? EMPTY_SOURCE_GROUPS;
 
   // Search + grouping / sort / frame-type controls now live in the top bar
   // (spec 043 #73/#31). `useGrouping` owns the persisted ordered grouping
@@ -293,6 +306,19 @@ export function InboxPage() {
     return result;
   }, [items, search]);
 
+  // The same text search over source-group rows. A source group has no
+  // `groupTarget` (it is unclassified — that is the whole point), so only the
+  // path is searchable.
+  const filteredSourceGroups = useMemo(() => {
+    const q = search.trim().toLowerCase();
+    if (!q) return sourceGroups;
+    return sourceGroups.filter((g) => g.relativePath.toLowerCase().includes(q));
+  }, [sourceGroups, search]);
+
+  const selectedSourceGroup = selectedGroup
+    ? filteredSourceGroups.find((g) => g.sourceGroupId === selectedGroup)
+    : undefined;
+
   // URL-backed selection is by item id (issue #644), not list position — an
   // index silently points at whatever item now occupies that slot once
   // search/lane/kind filters reshape the array. Sessions and Calibration
@@ -322,13 +348,32 @@ export function InboxPage() {
       }),
   );
 
+  // The two selection channels are mutually exclusive — there is one detail
+  // pane — so each clears the other. They stay SEPARATE params rather than one
+  // tagged value so that no id-shaped string from a source-group row can ever
+  // be read back out as `selected` and reach the confirm path.
   const onSelect = (id: string) =>
-    navigate({ search: (prev) => ({ ...prev, selected: id }) });
+    navigate({
+      search: (prev) => ({ ...prev, selected: id, selectedGroup: undefined }),
+    });
+
+  const onSelectSourceGroup = (sourceGroupId: string) =>
+    navigate({
+      search: (prev) => ({
+        ...prev,
+        selected: undefined,
+        selectedGroup: sourceGroupId,
+      }),
+    });
 
   const clearSelection = useCallback(
     () =>
       navigate({
-        search: (prev) => ({ ...prev, selected: undefined }),
+        search: (prev) => ({
+          ...prev,
+          selected: undefined,
+          selectedGroup: undefined,
+        }),
         replace: true,
       }),
     [navigate],
@@ -875,7 +920,13 @@ export function InboxPage() {
   // summary sitting above a filtered list and disagreeing with it is the same
   // class of lie this feature exists to remove, so the counts now describe what
   // the user is actually looking at.
-  const derivedStats = useMemo(() => deriveInboxStats(filteredItems), [filteredItems]);
+  // spec 058 T013 / CHK010: source-group rows are counted here too — they are
+  // rows the list renders, and a summary that omits them under-reports what the
+  // user is looking at.
+  const derivedStats = useMemo(
+    () => deriveInboxStats(filteredItems, filteredSourceGroups),
+    [filteredItems, filteredSourceGroups],
+  );
 
   // #75: frame-type hint per ingestion, derived from the inbox item's
   // classification/breakdown (here: the dominant `groupFrameType`, or the
@@ -974,8 +1025,17 @@ export function InboxPage() {
   ]);
 
   // Summary count (no page title — top-bar convention): folders / masters.
-  const folderCount = items.filter((it) => !it.isMaster).length;
-  const masterCount = items.filter((it) => it.isMaster).length;
+  //
+  // spec 058 T013: counted off the FILTERED lists, matching `derivedStats`
+  // above. These two surfaces previously disagreed — the stats strip was moved
+  // onto `filteredItems` for SC-004 while the header stayed on the unfiltered
+  // `items`, so with any filter active the header and the strip sitting beside
+  // it reported different totals. Source-group rows are folders and count as
+  // such (CHK010).
+  const folderCount =
+    filteredItems.filter((it) => !it.isMaster).length +
+    filteredSourceGroups.length;
+  const masterCount = filteredItems.filter((it) => it.isMaster).length;
   const summary = useMemo(() => {
     if (listLoading) return m.common_loading();
     const parts: string[] = [];
@@ -1139,7 +1199,14 @@ export function InboxPage() {
         dockId="inbox"
         detailLabel={m.inbox_detection_details()}
         detail={
-          selectedItem != null ? (
+          selectedSourceGroup != null ? (
+            // Spec 058 T013: a source-group selection routes to its OWN panel,
+            // which has no confirm affordance at all. `selectedItem` is
+            // necessarily undefined here — the two search params are mutually
+            // exclusive — so `InboxDetail` (and with it the confirm path) is
+            // not merely disabled but unreachable for this row.
+            <InboxSourceGroupDetail group={selectedSourceGroup} />
+          ) : selectedItem != null ? (
             <InboxDetail
               // Remount per SOURCE GROUP (not per raw item id) so per-item
               // state (pending overrides, the "Needs review" bulk-select /
@@ -1184,12 +1251,19 @@ export function InboxPage() {
             />
           ) : undefined
         }
-        onCloseDetail={selectedItem != null ? clearSelection : undefined}
+        onCloseDetail={
+          selectedItem != null || selectedSourceGroup != null
+            ? clearSelection
+            : undefined
+        }
       >
         <InboxList
           items={filteredItems}
+          sourceGroups={filteredSourceGroups}
           selectedId={selected ?? null}
+          selectedSourceGroupId={selectedGroup ?? null}
           onSelect={onSelect}
+          onSelectSourceGroup={onSelectSourceGroup}
           filterType={type ?? 'all'}
           dims={dims}
           kindFilter={kindFilter}

--- a/apps/desktop/src/features/inbox/InboxSourceGroupDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxSourceGroupDetail.tsx
@@ -1,0 +1,45 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * InboxSourceGroupDetail — the detail pane for a scanned-but-unclassified
+ * folder (spec 058 T013 / FR-016).
+ *
+ * This is a deliberately inert panel: it states what the folder is and why
+ * there is nothing to act on yet. It renders **no** Confirm control — not a
+ * disabled one, and not one behind a guard. A source group has no inbox item
+ * id, so there is no value `inbox.confirm` could be handed; the absence is
+ * structural rather than enforced, which is exactly the FR-016 boundary. A
+ * disabled button here would re-introduce the "row claims an action it cannot
+ * perform" shape that #711 is about.
+ */
+
+import type { InboxSourceGroupListItem } from './store';
+import { m } from '@/lib/i18n';
+
+export interface InboxSourceGroupDetailProps {
+  group: InboxSourceGroupListItem;
+}
+
+export function InboxSourceGroupDetail({ group }: InboxSourceGroupDetailProps) {
+  const path = group.relativePath || group.rootAbsolutePath;
+  return (
+    <div
+      className="pv-inbox-detail pv-inbox-detail--source-group"
+      data-testid="inbox-source-group-detail"
+    >
+      <h2 className="pv-inbox-detail__title">
+        {m.inbox_source_group_detail_title()}
+      </h2>
+      <p className="pv-inbox-detail__path" title={path}>
+        {path}
+      </p>
+      <p className="pv-inbox-detail__body">
+        {m.inbox_source_group_detail_body()}
+      </p>
+      <p className="pv-inbox-detail__meta">
+        {m.inbox_list_file_count({ count: group.fileCount })}
+      </p>
+    </div>
+  );
+}

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.sourceGroups.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.sourceGroups.test.tsx
@@ -1,0 +1,235 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Spec 058 T013 / FR-016 — a scanned-but-unclassified folder renders as a
+ * source-group row that is **structurally** non-confirmable.
+ *
+ * "Structurally" is the load-bearing word and what these tests pin: the row
+ * carries no `inboxItemId`, and its selection is reported through a separate
+ * callback (`onSelectSourceGroup`), so there is no value the confirm path could
+ * receive. A test asserting only "Confirm is disabled" would pass equally
+ * against a guard, which FR-016 explicitly rejects — so the assertions here are
+ * about which callback fires and what the row does NOT carry.
+ *
+ * Two filter behaviours are pinned for reasons that are easy to get backwards:
+ *
+ * - The lane filter (`fits`/`video`) must read the group's `format`, NOT its
+ *   `lane` column. A source group's `lane` is the `move`/`catalogue` lane — a
+ *   different axis that shares the name (`InboxSourceGroupListItem`). Filtering
+ *   on it would match `"move"` against `"fits"` and hide every group.
+ * - The kind filter (a specific frame type) must drop source groups entirely.
+ *   An unclassified folder has no frame type, so surfacing it under "bias"
+ *   would be the claim-what-you-are-not shape #711 is about.
+ */
+
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { InboxList } from '../InboxList';
+import type { InboxListItem, InboxSourceGroupListItem } from '@/bindings/index';
+
+function makeGroup(
+  over: Partial<InboxSourceGroupListItem> & { sourceGroupId: string },
+): InboxSourceGroupListItem {
+  return {
+    rootId: 'root-1',
+    rootAbsolutePath: '/lib/root',
+    relativePath: over.sourceGroupId,
+    fileCount: 12,
+    format: 'fits',
+    lane: 'move',
+    contentSignature: `sig-${over.sourceGroupId}`,
+    discoveredAt: '2026-07-20T10:00:00Z',
+    ...over,
+  } as InboxSourceGroupListItem;
+}
+
+function makeItem(
+  over: Partial<InboxListItem> & { inboxItemId: string },
+): InboxListItem {
+  return {
+    relativePath: over.inboxItemId,
+    fileCount: 1,
+    lane: 'fits',
+    format: 'fits',
+    state: 'classified',
+    contentSignature: `sig-${over.inboxItemId}`,
+    isMaster: false,
+    masterFrameType: null,
+    masterFilter: null,
+    masterExposureS: null,
+    rootAbsolutePath: '/lib/root',
+    organizationState: 'unorganized',
+    groupTarget: null,
+    groupFrameType: null,
+    groupDate: null,
+    groupFilter: null,
+    groupExposure: null,
+    groupInstrument: null,
+    groupId: over.inboxItemId,
+    groupKey: 'type=dark',
+    needsReview: false,
+    ...over,
+  } as InboxListItem;
+}
+
+describe('InboxList — scanned-but-unclassified source-group rows (058 T013)', () => {
+  it('renders a source-group row with its path, file count and format', () => {
+    render(
+      <InboxList
+        items={[]}
+        sourceGroups={[makeGroup({ sourceGroupId: 'sg-1', fileCount: 41 })]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="all"
+      />,
+    );
+
+    const row = screen.getByTestId('inbox-source-group-sg-1');
+    expect(row).toBeInTheDocument();
+    expect(row).toHaveTextContent('sg-1');
+    expect(row).toHaveTextContent('41 files');
+    expect(row).toHaveTextContent('FITS');
+  });
+
+  it('selecting a source-group row reports it through onSelectSourceGroup, never onSelect', () => {
+    const onSelect = vi.fn();
+    const onSelectSourceGroup = vi.fn();
+    render(
+      <InboxList
+        items={[]}
+        sourceGroups={[makeGroup({ sourceGroupId: 'sg-1' })]}
+        selectedId={null}
+        onSelect={onSelect}
+        onSelectSourceGroup={onSelectSourceGroup}
+        filterType="all"
+      />,
+    );
+
+    fireEvent.click(screen.getByTestId('inbox-source-group-sg-1'));
+
+    expect(onSelectSourceGroup).toHaveBeenCalledWith('sg-1');
+    // The confirm path is driven by the selected ITEM. If a source-group click
+    // could reach `onSelect`, the row would become confirmable by accident —
+    // which is precisely the structural boundary FR-016 draws.
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not render an item testid for a source-group row (it has no item id)', () => {
+    render(
+      <InboxList
+        items={[]}
+        sourceGroups={[makeGroup({ sourceGroupId: 'sg-1' })]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="all"
+      />,
+    );
+
+    expect(screen.queryByTestId('inbox-item-sg-1')).not.toBeInTheDocument();
+  });
+
+  it('the lane filter reads the group format, not its move/catalogue lane column', () => {
+    const groups = [
+      makeGroup({ sourceGroupId: 'sg-fits', format: 'fits', lane: 'move' }),
+      makeGroup({
+        sourceGroupId: 'sg-video',
+        format: 'video',
+        lane: 'catalogue',
+      }),
+    ];
+
+    const { rerender } = render(
+      <InboxList
+        items={[]}
+        sourceGroups={groups}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="fits"
+      />,
+    );
+    expect(
+      screen.getByTestId('inbox-source-group-sg-fits'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('inbox-source-group-sg-video'),
+    ).not.toBeInTheDocument();
+
+    rerender(
+      <InboxList
+        items={[]}
+        sourceGroups={groups}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="video"
+      />,
+    );
+    expect(
+      screen.getByTestId('inbox-source-group-sg-video'),
+    ).toBeInTheDocument();
+    expect(
+      screen.queryByTestId('inbox-source-group-sg-fits'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('an active kind filter hides source groups — an unclassified folder has no frame type', () => {
+    render(
+      <InboxList
+        items={[]}
+        sourceGroups={[makeGroup({ sourceGroupId: 'sg-1' })]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="all"
+        kindFilter="bias"
+      />,
+    );
+
+    expect(
+      screen.queryByTestId('inbox-source-group-sg-1'),
+    ).not.toBeInTheDocument();
+  });
+
+  it('source-group rows and item rows sort as one sequence, not two blocks', () => {
+    render(
+      <InboxList
+        items={[
+          makeItem({ inboxItemId: 'a-item' }),
+          makeItem({ inboxItemId: 'z-item' }),
+        ]}
+        sourceGroups={[makeGroup({ sourceGroupId: 'm-group' })]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="all"
+        sort={{ col: 'detection', dir: 'asc' }}
+      />,
+    );
+
+    const testids = screen
+      .getAllByTestId(/^inbox-(item|source-group)-/)
+      .map((el) => el.getAttribute('data-testid'));
+    expect(testids).toEqual([
+      'inbox-item-a-item',
+      'inbox-source-group-m-group',
+      'inbox-item-z-item',
+    ]);
+  });
+
+  it('grouping keeps source-group rows visible rather than dropping them', () => {
+    render(
+      <InboxList
+        items={[makeItem({ inboxItemId: 'i-1', groupFrameType: 'light' })]}
+        sourceGroups={[makeGroup({ sourceGroupId: 'sg-1' })]}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="all"
+        dims={['frameType']}
+      />,
+    );
+
+    // Grouping dimensions read item fields an unclassified folder has none of,
+    // so the group row cannot sit in the tree — but it must not vanish, or the
+    // user loses the folder by changing a view control.
+    expect(screen.getByTestId('inbox-source-group-sg-1')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/inbox/inboxStatsFromItems.test.ts
+++ b/apps/desktop/src/features/inbox/inboxStatsFromItems.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { deriveInboxStats } from './inboxStatsFromItems';
-import type { InboxListItem } from '@/bindings/index';
+import type { InboxListItem, InboxSourceGroupListItem } from '@/bindings/index';
 
 function folder(
   id: string,
@@ -132,5 +132,58 @@ describe('deriveInboxStats', () => {
     const stats = deriveInboxStats([]);
     expect(stats.totals).toEqual({ folders: 0, masters: 0, images: 0 });
     expect(stats.perType).toEqual([]);
+  });
+
+  // Spec 058 T013 / CHK010: source-group rows ARE counted. They are folders the
+  // list renders, so omitting them would make the summary report fewer rows
+  // than the list shows — the SC-004 disagreement 058 exists to remove.
+  describe('source-group rows (058 T013 / CHK010)', () => {
+    function sourceGroup(id: string, files: number): InboxSourceGroupListItem {
+      return {
+        sourceGroupId: id,
+        rootId: 'r1',
+        rootAbsolutePath: '/lib',
+        relativePath: id,
+        fileCount: files,
+        format: 'fits',
+        lane: 'move',
+        contentSignature: 'sig',
+        discoveredAt: '2026-07-20T10:00:00Z',
+      } as InboxSourceGroupListItem;
+    }
+
+    it('counts a source group as a folder and its files as images', () => {
+      const stats = deriveInboxStats(
+        [folder('a', 'light', 10)],
+        [sourceGroup('sg-1', 7)],
+      );
+
+      expect(stats.totals.folders).toBe(2);
+      expect(stats.totals.images).toBe(17);
+      expect(stats.totals.masters).toBe(0);
+    });
+
+    it('buckets source groups as unresolved — an unclassified folder has no frame type', () => {
+      const stats = deriveInboxStats(
+        [folder('a', 'light', 10)],
+        [sourceGroup('sg-1', 7), sourceGroup('sg-2', 3)],
+      );
+
+      const unresolved = stats.perType.find(
+        (r) => r.frameType === 'unresolved',
+      );
+      expect(unresolved?.folderCount).toBe(2);
+      expect(unresolved?.imageCount).toBe(10);
+    });
+
+    it('keeps the per-type sum reconciled with the folder total', () => {
+      const stats = deriveInboxStats(
+        [folder('a', 'light', 10)],
+        [sourceGroup('sg-1', 7)],
+      );
+
+      const folderSum = stats.perType.reduce((n, r) => n + r.folderCount, 0);
+      expect(folderSum).toBe(stats.totals.folders);
+    });
   });
 });

--- a/apps/desktop/src/features/inbox/inboxStatsFromItems.ts
+++ b/apps/desktop/src/features/inbox/inboxStatsFromItems.ts
@@ -21,6 +21,7 @@
 
 import type {
   InboxListItem,
+  InboxSourceGroupListItem,
   InboxStatsResponse,
   InboxStatsPerType,
 } from '@/bindings/index';
@@ -65,6 +66,7 @@ function bucketKey(frameType: string | null | undefined): string {
  */
 export function deriveInboxStats(
   items: readonly InboxListItem[],
+  sourceGroups: readonly InboxSourceGroupListItem[] = [],
 ): InboxStatsResponse {
   const byType = new Map<string, InboxStatsPerType>();
   let folders = 0;
@@ -93,6 +95,19 @@ export function deriveInboxStats(
       row.folderCount += 1;
       row.imageCount += item.fileCount;
     }
+  }
+
+  // Spec 058 T013 / CHK010: source-group rows ARE counted. They are folders
+  // the user can see in the list, so leaving them out would make the summary
+  // report fewer rows than the list shows — the SC-004 disagreement this
+  // feature exists to remove. They always land in the "unresolved" bucket: an
+  // unclassified folder has no frame type by definition.
+  for (const group of sourceGroups) {
+    images += group.fileCount;
+    folders += 1;
+    const row = rowFor(UNRESOLVED_KEY);
+    row.folderCount += 1;
+    row.imageCount += group.fileCount;
   }
 
   // Stable display order: alphabetical by frame type, "unresolved" last.

--- a/apps/desktop/src/features/inbox/store.ts
+++ b/apps/desktop/src/features/inbox/store.ts
@@ -21,6 +21,7 @@ import { unwrap } from '@/api/ipc';
 import { ipcArgs } from '@/lib/ipc-args';
 import type {
   InboxListItem,
+  InboxSourceGroupListItem,
   InboxListResponse,
   InboxConfirmResponse,
   InboxScanFolderResponse,
@@ -47,6 +48,7 @@ export type {
   InboxClassifyResponse,
   InboxConfirmResponse,
   InboxListItem,
+  InboxSourceGroupListItem,
   InboxListResponse,
   InboxReclassifyResponse,
   InboxScanFolderResponse,


### PR DESCRIPTION
## Summary

A folder the scan has found but nothing has classified yet now appears in the
Inbox list as a row of its own. Previously such a folder had no way to reach the
list at all.

The row deliberately offers no Confirm action — there is nothing to confirm
about a folder whose contents are still unknown. Rather than showing a Confirm
button that refuses to work, the row simply has no confirm affordance, and its
detail panel explains what the folder is and why nothing can be done with it
yet.

## What's new

- Scanned-but-unclassified folders are visible in the Inbox list, showing their
  path, file count and format
- Selecting one opens a detail panel describing the folder, with no Confirm
  control
- These rows are counted in the Inbox summary and header, so the counts match
  the rows on screen
- The FITS/video filter includes them by their file format; a specific
  frame-type filter (bias, dark, flat, light) hides them, since an unclassified
  folder has no frame type
- Grouping the list keeps them visible instead of dropping them

## Note

These rows do not appear in the running app yet: every scanned folder still
gets a placeholder row, so the underlying list is always empty for now. This
change is the consumer that has to exist before that placeholder can be
removed. It is covered by unit tests rather than by on-screen behaviour.

## Spec Context

Spec 058 **T013's UI half**. `inbox.list` has returned `sourceGroups` since the
backend half landed, but nothing in the app read it (`grep`: only `mocks.ts`,
two fixtures and the generated bindings).

**Why this is the unblocking step.** T020 wants to delete the scan-time
placeholder row. It is blocked on two independent things, which the task notes
conflate:

1. **No group-scoped classification entry point** — `classify()` is keyed on
   `inbox_item_id`; `reclassify_v2` rebuilds from evidence only ever written
   against an item id. This design decision **still does not exist** and is
   T012's real blocker. *Not addressed here.*
2. **No UI consumer of `sourceGroups`** — with no source-group row rendered or
   selectable, deleting the placeholder makes every scanned folder invisible on
   top of unclassifiable.

This PR removes (2) only. T012/T019/T020/T024 stay blocked, and landing this
does not by itself make the placeholder deletable.

**Structurally non-confirmable, not guarded** (FR-016): the row carries no
`inboxItemId`, selection travels through `onSelectSourceGroup` and its own
`?selectedGroup` search param kept separate from `?selected`, and it opens
`InboxSourceGroupDetail`, which renders no confirm control — not a disabled
one. Confirm reads the selected *item*, so there is no value it could be
handed. A disabled button would have re-introduced the
row-claims-an-action-it-cannot-perform shape #711 is about.

**Two filter traps, both pinned by tests.** The lane filter reads `format`, not
`lane` — a source group's `lane` is the `move`/`catalogue` lane, a different
axis sharing the name, and filtering on it would match `"move"` against
`"fits"` and hide every group. An active kind filter drops source groups
entirely.

**Counts (T022 / CHK010).** Source-group rows are counted in `deriveInboxStats`
and the header. This also settles a disagreement already on the branch: the
stats strip had moved to `filteredItems` for SC-004 while the header still
counted the unfiltered `items`, so with any filter active the two numbers
beside each other disagreed.

**Verification.** `vitest` 1856 passed (204 files), including 7 new
source-group tests and 3 new stats tests; `tsc --noEmit`, `eslint` (i18n
baseline), token-policy and i18n catalogue checks all clean. Two-direction
control on both load-bearing assertions: routing a source-group click to
`onSelect` fails the non-confirmability test, and making the lane filter read
`group.lane` fails the filter test.

Refs #711