### PR TITLE
test: cover the detail dock's pinned columns, drag-resize, and persistence

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -732,12 +732,21 @@ jobs:
       # its default DMA-BUF/compositing render paths were suspected of adding
       # ~25-30s of per-test overhead vs Windows. Linux-only; harmless no-op if
       # the hypothesis is wrong.
+      #
+      # `-s "-screen 0 1600x1200x24"` overrides xvfb-run's built-in default of
+      # 1280x1024x24 (`XVFBARGS` in /usr/bin/xvfb-run). 1280 is NARROWER than
+      # the 1400px viewport the docked-layout journeys request via
+      # `E2eApp::set_viewport`, and a resize past the screen edge is clamped —
+      # which would silently yield a too-small viewport and a journey that
+      # passes while asserting nothing. The larger framebuffer is plain memory
+      # (1600*1200*4 = ~7.7MB), not GPU, so it costs nothing on a runner that
+      # already has none.
       - name: Run E2E (xvfb)
         env:
           WEBKIT_DISABLE_DMABUF_RENDERER: "1"
           WEBKIT_DISABLE_COMPOSITING_MODE: "1"
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
-        run: xvfb-run -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/4
+        run: xvfb-run -s "-screen 0 1600x1200x24" -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/4
 
   # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
   real-ui-e2e-windows:

--- a/apps/desktop/src/components/ListPageLayout.test.tsx
+++ b/apps/desktop/src/components/ListPageLayout.test.tsx
@@ -702,7 +702,11 @@ describe('adaptive dock — drag + real persistence (T023)', () => {
   it('a drag on the resize handle really resizes the side panel', () => {
     resizeWindowTo(1600);
     const { getByTestId, container } = render(
-      <ListPageLayout topBar={<div>bar</div>} detail={<div>detail</div>} dockId="drag-page">
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={<div>detail</div>}
+        dockId="drag-page"
+      >
         <div>main</div>
       </ListPageLayout>,
     );
@@ -721,7 +725,11 @@ describe('adaptive dock — drag + real persistence (T023)', () => {
   it('the dragged width reaches localStorage, not just the in-memory cache', () => {
     resizeWindowTo(1600);
     const { getByTestId } = render(
-      <ListPageLayout topBar={<div>bar</div>} detail={<div>detail</div>} dockId="drag-persist">
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={<div>detail</div>}
+        dockId="drag-persist"
+      >
         <div>main</div>
       </ListPageLayout>,
     );
@@ -738,7 +746,11 @@ describe('adaptive dock — drag + real persistence (T023)', () => {
   it('a drag is clamped to the window fraction before it is persisted', () => {
     resizeWindowTo(1600);
     const { getByTestId } = render(
-      <ListPageLayout topBar={<div>bar</div>} detail={<div>detail</div>} dockId="drag-clamp">
+      <ListPageLayout
+        topBar={<div>bar</div>}
+        detail={<div>detail</div>}
+        dockId="drag-clamp"
+      >
         <div>main</div>
       </ListPageLayout>,
     );
@@ -755,7 +767,9 @@ describe('adaptive dock — drag + real persistence (T023)', () => {
 
   it('a pinned placement reaches localStorage too', () => {
     resizeWindowTo(1024);
-    const { result } = renderHook(() => useAdaptiveDock({ dockId: 'pin-persist' }));
+    const { result } = renderHook(() =>
+      useAdaptiveDock({ dockId: 'pin-persist' }),
+    );
     expect(result.current.placement).toBe('bottom');
 
     act(() => {

--- a/apps/desktop/src/components/ListPageLayout.test.tsx
+++ b/apps/desktop/src/components/ListPageLayout.test.tsx
@@ -660,3 +660,108 @@ describe('ListPageLayout', () => {
     });
   });
 });
+
+/**
+ * T023 (spec 054, #1257) — the two halves the remount tests deliberately
+ * left uncovered: width set by DRAGGING the handle rather than calling
+ * `setWidth`, and the value actually reaching storage rather than only the
+ * in-memory cache.
+ *
+ * Why the second matters. `getPreferences()` returns a module-level
+ * `cachedPreferences` when one exists, and `persistPreferences()` assigns
+ * that cache BEFORE its `localStorage.setItem`, whose failure is swallowed
+ * ("state is still in memory"). A remount therefore re-reads the CACHE, not
+ * storage — so every existing remount assertion would still pass if the
+ * write never landed at all. Asserting the serialized bytes is what closes
+ * that gap; a real reload (the Layer-2 half of T023) is what proves the
+ * cold read.
+ */
+describe('adaptive dock — drag + real persistence (T023)', () => {
+  /** The real on-disk key from `data/preferences.ts`. Deliberately a
+   * literal: it is not exported, and this test's whole point is to assert
+   * the actual stored bytes rather than to re-derive them from the module
+   * under test. */
+  const STORAGE_KEY = 'alm-preferences';
+
+  function storedDock(dockId: string) {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return undefined;
+    return JSON.parse(raw)?.detailDock?.[dockId];
+  }
+
+  beforeEach(() => {
+    resetPreferences();
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    resetPreferences();
+    localStorage.clear();
+  });
+
+  it('a drag on the resize handle really resizes the side panel', () => {
+    resizeWindowTo(1600);
+    const { getByTestId, container } = render(
+      <ListPageLayout topBar={<div>bar</div>} detail={<div>detail</div>} dockId="drag-page">
+        <div>main</div>
+      </ListPageLayout>,
+    );
+
+    const handle = getByTestId('dock-resize-handle');
+    // The side panel sits on the RIGHT edge, so dragging LEFT grows it:
+    // delta = startX - currentX = 1000 - 900 = 100, on the 420px default.
+    fireEvent.pointerDown(handle, { clientX: 1000 });
+    fireEvent.pointerMove(window, { clientX: 900 });
+    fireEvent.pointerUp(window);
+
+    const styled = container.querySelector('[style*="--pv-side-detail-w"]');
+    expect(styled?.getAttribute('style')).toContain('520px');
+  });
+
+  it('the dragged width reaches localStorage, not just the in-memory cache', () => {
+    resizeWindowTo(1600);
+    const { getByTestId } = render(
+      <ListPageLayout topBar={<div>bar</div>} detail={<div>detail</div>} dockId="drag-persist">
+        <div>main</div>
+      </ListPageLayout>,
+    );
+
+    fireEvent.pointerDown(getByTestId('dock-resize-handle'), { clientX: 1000 });
+    fireEvent.pointerMove(window, { clientX: 940 });
+    fireEvent.pointerUp(window);
+
+    // Read the serialized bytes, NOT getPreferences() — going through the
+    // module would consult the cache and assert nothing about persistence.
+    expect(storedDock('drag-persist')?.width).toBe(480);
+  });
+
+  it('a drag is clamped to the window fraction before it is persisted', () => {
+    resizeWindowTo(1600);
+    const { getByTestId } = render(
+      <ListPageLayout topBar={<div>bar</div>} detail={<div>detail</div>} dockId="drag-clamp">
+        <div>main</div>
+      </ListPageLayout>,
+    );
+
+    // Drag far past the ceiling: maxWidthFraction 0.5 of 1600 = 800px.
+    fireEvent.pointerDown(getByTestId('dock-resize-handle'), { clientX: 1000 });
+    fireEvent.pointerMove(window, { clientX: 0 });
+    fireEvent.pointerUp(window);
+
+    // The CLAMPED value must be what persists — storing the raw drag target
+    // would restore an over-wide dock on the next cold start.
+    expect(storedDock('drag-clamp')?.width).toBe(800);
+  });
+
+  it('a pinned placement reaches localStorage too', () => {
+    resizeWindowTo(1024);
+    const { result } = renderHook(() => useAdaptiveDock({ dockId: 'pin-persist' }));
+    expect(result.current.placement).toBe('bottom');
+
+    act(() => {
+      result.current.setOverride('side');
+    });
+
+    expect(storedDock('pin-persist')?.placement).toBe('side');
+  });
+});

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -456,8 +456,8 @@ impl E2eApp {
         Ok(Self { driver, driver_proc: Some(driver_proc), proc_log })
     }
 
-    /// Resize the real OS window until the WEBVIEW reports exactly
-    /// `target_w` x `target_h`, and fail loudly if it cannot.
+    /// Resize the real OS window and return the viewport actually ACHIEVED,
+    /// which may be smaller than requested.
     ///
     /// Needed because layout-dependent behaviour cannot be asserted at the
     /// default window size: `tauri.conf.json` opens at 1280x820, while the
@@ -465,25 +465,36 @@ impl E2eApp {
     /// (`useAdaptiveDock.ts`'s `threshold`). A journey that wants the docked
     /// layout has to ask for it.
     ///
-    /// **This is deliberately not a one-line `set_window_rect`.** That call
-    /// sizes the OUTER window (frame included), but every threshold in the
-    /// app keys off `window.innerWidth`. The two differ by the window
-    /// chrome, which is not a constant we can hardcode: it is ~0 under
-    /// `xvfb-run` (no window manager, so no decorations) but real on a
-    /// Windows runner. Passing 1400 blind therefore yields an innerWidth of
-    /// 1400 on Linux and something smaller on Windows — the dock silently
-    /// does not engage, the table never overflows, and the journey passes
-    /// while asserting nothing. So: set, MEASURE, correct by the observed
-    /// delta, and verify.
+    /// **Not a one-line `set_window_rect`.** That call sizes the OUTER
+    /// window (frame included), but every threshold in the app keys off
+    /// `window.innerWidth`. The two differ by the window chrome, which is
+    /// not a constant we can hardcode: ~0 under `xvfb-run` (no window
+    /// manager, so no decorations) but real on Windows. Passing 1400 blind
+    /// would yield innerWidth 1400 on Linux and something smaller on
+    /// Windows. So: set, MEASURE, correct by the observed delta.
     ///
-    /// Convergence is capped rather than looped-until-stable because a
-    /// too-small X screen clamps the resize and would otherwise spin
-    /// forever; the error names the screen size, since that is the fix.
-    pub async fn set_viewport(&self, target_w: u32, target_h: u32) -> Result<()> {
+    /// **Best-effort, deliberately not an assertion.** GitHub-hosted
+    /// **Windows runners are fixed at 1024x768 and cannot be resized** — the
+    /// runner service runs in non-interactive Session 0 with no real display
+    /// attached, so `ChangeDisplaySettings` has nothing to act on
+    /// (actions/runner-images#2935, #8606). Hard-failing on a short request
+    /// would make every docked-layout journey Linux-only by construction.
+    /// Callers needing a minimum must assert on the return value — better
+    /// still, avoid depending on one, as
+    /// `targets_ui_identity_columns_stay_pinned_while_table_scrolls` does by
+    /// pinning the dock rather than relying on the width threshold.
+    ///
+    /// Convergence is capped rather than looped-until-stable: a request
+    /// exceeding the screen is clamped by the OS and would otherwise spin.
+    pub async fn set_viewport(&self, target_w: u32, target_h: u32) -> Result<(i64, i64)> {
         const ATTEMPTS: usize = 4;
-        let (mut outer_w, mut outer_h) = (i64::from(target_w), i64::from(target_h));
-        let (tw, th) = (i64::from(target_w), i64::from(target_h));
-        let mut seen = Vec::new();
+        let (screen_w, screen_h) = self.screen_size().await.unwrap_or((-1, -1));
+        // Ask for no more than the screen can hold: anything larger is
+        // clamped anyway, and requesting it only wastes attempts.
+        let tw = if screen_w > 0 { i64::from(target_w).min(screen_w) } else { i64::from(target_w) };
+        let th = if screen_h > 0 { i64::from(target_h).min(screen_h) } else { i64::from(target_h) };
+        let (mut outer_w, mut outer_h) = (tw, th);
+        let mut last = (0, 0);
 
         for _ in 0..ATTEMPTS {
             self.driver
@@ -492,24 +503,41 @@ impl E2eApp {
                 .with_context(|| format!("set_window_rect to {outer_w}x{outer_h} failed"))?;
 
             let (inner_w, inner_h) = self.inner_size().await?;
-            seen.push(format!("{outer_w}x{outer_h} outer -> {inner_w}x{inner_h} inner"));
+            last = (inner_w, inner_h);
             if inner_w == tw && inner_h == th {
-                return Ok(());
+                return Ok(last);
             }
-            // Correct by the observed chrome delta rather than guessing it.
             outer_w += tw - inner_w;
             outer_h += th - inner_h;
         }
+        Ok(last)
+    }
 
-        let (screen_w, screen_h) = self.screen_size().await.unwrap_or((-1, -1));
-        Err(anyhow!(
-            "could not reach a {target_w}x{target_h} viewport in {ATTEMPTS} attempts \
-             (screen is {screen_w}x{screen_h}). If the requested size exceeds the \
-             screen, the display is too small and the resize is being clamped — on \
-             the Ubuntu shards widen it via `xvfb-run -s \"-screen 0 WxHx24\"` in \
-             e2e.yml. Attempts: {}",
-            seen.join("; ")
-        ))
+    /// Seed a persisted app preference BEFORE the frontend reads it, then
+    /// reload so the read is genuinely cold.
+    ///
+    /// The reload is not optional. `data/preferences.ts` memoises into a
+    /// module-level `cachedPreferences` on first read, so writing
+    /// localStorage into an already-booted page changes nothing the app will
+    /// ever look at. Only a real reload drops that cache — which also makes
+    /// this the one path that exercises the cold read.
+    pub async fn seed_preference(&self, key: &str, value_json: &str) -> Result<()> {
+        let script = format!(
+            "var k = 'alm-preferences';\
+             var cur = {{}};\
+             try {{ cur = JSON.parse(localStorage.getItem(k)) || {{}}; }} catch (e) {{ cur = {{}}; }}\
+             cur[{}] = {};\
+             localStorage.setItem(k, JSON.stringify(cur));\
+             return localStorage.getItem(k);",
+            escape_string(key),
+            value_json
+        );
+        self.driver
+            .execute(&script, vec![])
+            .await
+            .with_context(|| format!("failed to seed the {key:?} preference"))?;
+        self.driver.refresh().await.context("failed to reload after seeding a preference")?;
+        Ok(())
     }
 
     /// `window.innerWidth`/`innerHeight` — the viewport the app's own

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -507,8 +507,22 @@ impl E2eApp {
             if inner_w == tw && inner_h == th {
                 return Ok(last);
             }
-            outer_w += tw - inner_w;
-            outer_h += th - inner_h;
+
+            // A non-positive reading means the webview reported no viewport at
+            // all (not laid out yet, or `innerWidth` came back 0/-1) — not that
+            // the window is too small. Correcting by `target - 0` would then ADD
+            // the full target every pass (1400 -> 2800 -> 4200 -> 5600), blowing
+            // the window far past the screen and leaving content so wide that
+            // overflow-dependent journeys can never trip. Observed on Ubuntu CI:
+            // a 5380px client width and a reported 0x0 viewport. Stop and report
+            // what we last saw rather than diverging.
+            if inner_w <= 0 || inner_h <= 0 {
+                return Ok(last);
+            }
+
+            // Never ask for more than the screen can show, for the same reason.
+            outer_w = (outer_w + tw - inner_w).min(if screen_w > 0 { screen_w } else { i64::MAX });
+            outer_h = (outer_h + th - inner_h).min(if screen_h > 0 { screen_h } else { i64::MAX });
         }
         Ok(last)
     }

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -456,6 +456,89 @@ impl E2eApp {
         Ok(Self { driver, driver_proc: Some(driver_proc), proc_log })
     }
 
+    /// Resize the real OS window until the WEBVIEW reports exactly
+    /// `target_w` x `target_h`, and fail loudly if it cannot.
+    ///
+    /// Needed because layout-dependent behaviour cannot be asserted at the
+    /// default window size: `tauri.conf.json` opens at 1280x820, while the
+    /// side dock only engages at `window.innerWidth >= 1400`
+    /// (`useAdaptiveDock.ts`'s `threshold`). A journey that wants the docked
+    /// layout has to ask for it.
+    ///
+    /// **This is deliberately not a one-line `set_window_rect`.** That call
+    /// sizes the OUTER window (frame included), but every threshold in the
+    /// app keys off `window.innerWidth`. The two differ by the window
+    /// chrome, which is not a constant we can hardcode: it is ~0 under
+    /// `xvfb-run` (no window manager, so no decorations) but real on a
+    /// Windows runner. Passing 1400 blind therefore yields an innerWidth of
+    /// 1400 on Linux and something smaller on Windows — the dock silently
+    /// does not engage, the table never overflows, and the journey passes
+    /// while asserting nothing. So: set, MEASURE, correct by the observed
+    /// delta, and verify.
+    ///
+    /// Convergence is capped rather than looped-until-stable because a
+    /// too-small X screen clamps the resize and would otherwise spin
+    /// forever; the error names the screen size, since that is the fix.
+    pub async fn set_viewport(&self, target_w: u32, target_h: u32) -> Result<()> {
+        const ATTEMPTS: usize = 4;
+        let (mut outer_w, mut outer_h) = (i64::from(target_w), i64::from(target_h));
+        let (tw, th) = (i64::from(target_w), i64::from(target_h));
+        let mut seen = Vec::new();
+
+        for _ in 0..ATTEMPTS {
+            self.driver
+                .set_window_rect(0, 0, outer_w.max(1) as u32, outer_h.max(1) as u32)
+                .await
+                .with_context(|| format!("set_window_rect to {outer_w}x{outer_h} failed"))?;
+
+            let (inner_w, inner_h) = self.inner_size().await?;
+            seen.push(format!("{outer_w}x{outer_h} outer -> {inner_w}x{inner_h} inner"));
+            if inner_w == tw && inner_h == th {
+                return Ok(());
+            }
+            // Correct by the observed chrome delta rather than guessing it.
+            outer_w += tw - inner_w;
+            outer_h += th - inner_h;
+        }
+
+        let (screen_w, screen_h) = self.screen_size().await.unwrap_or((-1, -1));
+        Err(anyhow!(
+            "could not reach a {target_w}x{target_h} viewport in {ATTEMPTS} attempts \
+             (screen is {screen_w}x{screen_h}). If the requested size exceeds the \
+             screen, the display is too small and the resize is being clamped — on \
+             the Ubuntu shards widen it via `xvfb-run -s \"-screen 0 WxHx24\"` in \
+             e2e.yml. Attempts: {}",
+            seen.join("; ")
+        ))
+    }
+
+    /// `window.innerWidth`/`innerHeight` — the viewport the app's own
+    /// breakpoints see, as opposed to the OS window `set_window_rect` sets.
+    async fn inner_size(&self) -> Result<(i64, i64)> {
+        let v: Value = self
+            .driver
+            .execute("return [window.innerWidth, window.innerHeight];", vec![])
+            .await
+            .context("failed to read window.innerWidth/innerHeight")?
+            .convert()
+            .context("innerWidth/innerHeight were not a JSON array")?;
+        let get = |i: usize| v.get(i).and_then(Value::as_i64).unwrap_or(-1);
+        Ok((get(0), get(1)))
+    }
+
+    /// Physical screen size, used only to explain a failed resize.
+    async fn screen_size(&self) -> Result<(i64, i64)> {
+        let v: Value = self
+            .driver
+            .execute("return [screen.width, screen.height];", vec![])
+            .await
+            .context("failed to read screen.width/height")?
+            .convert()
+            .context("screen.width/height were not a JSON array")?;
+        let get = |i: usize| v.get(i).and_then(Value::as_i64).unwrap_or(-1);
+        Ok((get(0), get(1)))
+    }
+
     /// Issue a Tauri command through the `window.__ALM_E2E__` bridge.
     ///
     /// The bridge is exposed by the desktop app when it is built with

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -763,7 +763,7 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
 
     app.goto_route("/targets").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
-    add_target_via_ui(&app, "M 1").await?;
+    let target_id = add_target_via_ui(&app, "M 1").await?;
 
     // Pin the side dock through the app's REAL persisted preference, then
     // let the reload apply it. The reload is what makes this work at all:
@@ -771,7 +771,14 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
     // read, so seeding localStorage into a booted page would be inert.
     app.seed_preference("detailDock", r#"{"targets":{"placement":"side","width":420}}"#).await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
-    app.goto_route("/targets").await?;
+
+    // Return to the SELECTED target, not bare `/targets`. The side dock only
+    // takes width when there is a detail to show — `ListPageLayout` mounts the
+    // panel solely when its `detail` prop is non-null. Navigating to the bare
+    // route drops the `?selected=` that `add_target_via_ui` landed on, which
+    // leaves the pinned preference correctly loaded but with nothing to
+    // render, so the table keeps full width and barely overflows at all.
+    app.goto_route(&format!("/targets?selected={target_id}")).await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
 
     let before = measure_pinned_columns(&app).await?;
@@ -780,12 +787,16 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
         overflow >= MIN_SCROLL,
         "the table must really overflow horizontally for this journey to mean \
          anything, but scrollWidth-clientWidth is only {overflow}px (need \
-         >= {MIN_SCROLL}) at a {viewport_w}x{viewport_h} viewport. Either the \
-         pinned side dock did not apply (the seeded `detailDock` preference \
-         needs a reload to beat the module-level preference cache), or the \
-         table's 1000px min-width floor changed. Note a WIDER viewport yields \
-         LESS overflow, so a large screen is not the safe direction here: \
-         {before}"
+         >= {MIN_SCROLL}) at a {viewport_w}x{viewport_h} viewport. Likely \
+         causes, in the order they have actually bitten: (1) the side dock \
+         mounted nothing because no target is selected — the panel needs a \
+         non-null `detail`, so the route must keep `?selected=<id>`; (2) the \
+         seeded `detailDock` preference did not survive the reload past the \
+         module-level cache in `data/preferences.ts`; (3) the table's 1000px \
+         min-width floor changed. A reported 0x0 viewport with a huge \
+         clientWidth means `set_viewport` failed to converge. Note a WIDER \
+         viewport yields LESS overflow, so a large screen is not the safe \
+         direction here: {before}"
     );
 
     // Scroll to the far right — the worst case for identity loss.

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -724,11 +724,23 @@ fn px(m: &serde_json::Value, key: &str) -> anyhow::Result<i64> {
 /// the rest of the Targets table scrolls sideways, so a row's identity is
 /// never lost (FR-006/FR-007, shipped in #1253).
 ///
-/// Sized to 1400x900 on purpose: that is the DEFAULT docked configuration,
-/// not an edge case. At 1400 the sidebar takes 220px and the side dock 420px,
-/// leaving the table ~760px against its own 1000px min-width floor — so it
-/// overflows by ~240px and, under `table-layout: fixed`, the designation
-/// column is exactly what would scroll away unpinned.
+/// **Pins the dock rather than relying on the 1400px width threshold**, so
+/// this runs on both supported platforms. GitHub-hosted Windows runners are
+/// fixed at 1024x768 and cannot be resized — the runner service runs in
+/// non-interactive Session 0 with no real display (actions/runner-images
+/// #2935, #8606) — so a journey demanding a 1400px viewport would be
+/// Linux-only by construction. A user pin is a first-class supported
+/// configuration, not a test-only shortcut: `useAdaptiveDock` honours an
+/// override at any width wide enough for a side dock at all.
+///
+/// Pinning also sidesteps a counter-intuitive trap. A LARGER screen produces
+/// LESS horizontal overflow, because the table's 1000px min-width floor is
+/// fixed while the space left for it grows: at a 1400px viewport the table
+/// gets ~760px and overflows by ~240px, but at 1600px it gets ~960px and
+/// overflows by only ~40px. Asserting against a fixed viewport would be
+/// fragile in the direction people intuitively assume is safer. So the
+/// assertion is on MEASURED overflow — ~616px at the Windows runners'
+/// 1024px, ~240px at 1400px.
 ///
 /// Asserts a non-pinned CONTROL column moves by the scroll distance. Without
 /// it this journey would pass in the one case it most needs to catch: if the
@@ -743,24 +755,37 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
     complete_first_run(&app).await?;
 
-    // Size the viewport BEFORE navigating: `useAdaptiveDock` reads
-    // `window.innerWidth` on mount, so engaging the dock after the page is
-    // already laid out would depend on its resize listener rather than on
-    // the configuration this journey means to assert.
-    app.set_viewport(1400, 900).await?;
+    // Best-effort: widens the window where the display allows (Ubuntu, whose
+    // xvfb screen e2e.yml sizes to 1600x1200) and is a no-op on a Windows
+    // runner that cannot resize. Nothing below depends on the result — the
+    // dock is pinned explicitly, and the real gate is measured overflow.
+    let (viewport_w, viewport_h) = app.set_viewport(1400, 900).await?;
 
     app.goto_route("/targets").await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
     add_target_via_ui(&app, "M 1").await?;
+
+    // Pin the side dock through the app's REAL persisted preference, then
+    // let the reload apply it. The reload is what makes this work at all:
+    // `data/preferences.ts` memoises into a module-level cache on first
+    // read, so seeding localStorage into a booted page would be inert.
+    app.seed_preference("detailDock", r#"{"targets":{"placement":"side","width":420}}"#).await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    app.goto_route("/targets").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
 
     let before = measure_pinned_columns(&app).await?;
     let overflow = px(&before, "scrollWidth")? - px(&before, "clientWidth")?;
     anyhow::ensure!(
         overflow >= MIN_SCROLL,
         "the table must really overflow horizontally for this journey to mean \
-         anything, but scrollWidth-clientWidth is only {overflow}px \
-         (need >= {MIN_SCROLL}). Either the side dock did not engage at 1400px \
-         or the table's min-width floor changed: {before}"
+         anything, but scrollWidth-clientWidth is only {overflow}px (need \
+         >= {MIN_SCROLL}) at a {viewport_w}x{viewport_h} viewport. Either the \
+         pinned side dock did not apply (the seeded `detailDock` preference \
+         needs a reload to beat the module-level preference cache), or the \
+         table's 1000px min-width floor changed. Note a WIDER viewport yields \
+         LESS overflow, so a large screen is not the safe direction here: \
+         {before}"
     );
 
     // Scroll to the far right — the worst case for identity loss.

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -669,3 +669,138 @@ async fn targets_planner_real_astronomy_after_site_creation() -> anyhow::Result<
 
     app.shutdown().await
 }
+
+/// Measure, relative to the scroll container's own left edge, where the
+/// pinned cells and a non-pinned control cell actually render.
+///
+/// Positions are taken from `getBoundingClientRect` — real post-layout
+/// geometry — because that is the only thing that can observe `position:
+/// sticky`. This measurement is the entire reason T026 must be a Layer-2
+/// journey: jsdom has no layout engine, so a Layer-1 test reports 0 for
+/// every one of these and would pass against a completely unpinned table.
+async fn measure_pinned_columns(app: &E2eApp) -> anyhow::Result<serde_json::Value> {
+    let script = r#"
+        var sc = document.querySelector('.pv-targets-table__scroll');
+        if (!sc) { return { error: 'no .pv-targets-table__scroll in the DOM' }; }
+        var row = sc.querySelector('.pv-targets-table__row');
+        if (!row) { return { error: 'no .pv-targets-table__row rendered' }; }
+        var headRow = sc.querySelector('thead tr');
+        var scLeft = sc.getBoundingClientRect().left;
+        function offset(el) {
+            return el ? Math.round(el.getBoundingClientRect().left - scLeft) : null;
+        }
+        var cells = row.children;
+        return {
+            scrollWidth: Math.round(sc.scrollWidth),
+            clientWidth: Math.round(sc.clientWidth),
+            scrollLeft: Math.round(sc.scrollLeft),
+            cellCount: cells.length,
+            star: offset(cells[0]),
+            designation: offset(cells[1]),
+            designationHeader: offset(headRow ? headRow.children[1] : null),
+            control: offset(cells[cells.length - 1])
+        };
+    "#;
+    let v: serde_json::Value = app
+        .driver
+        .execute(script, vec![])
+        .await
+        .context("failed to measure the pinned columns")?
+        .convert()
+        .context("pinned-column measurement was not JSON")?;
+    if let Some(err) = v.get("error").and_then(|e| e.as_str()) {
+        anyhow::bail!("cannot measure pinned columns: {err}");
+    }
+    Ok(v)
+}
+
+fn px(m: &serde_json::Value, key: &str) -> anyhow::Result<i64> {
+    m.get(key)
+        .and_then(serde_json::Value::as_i64)
+        .ok_or_else(|| anyhow::anyhow!("measurement {key:?} missing or not a number in {m}"))
+}
+
+/// T026 (spec 054, #1257) — the star and designation columns stay put while
+/// the rest of the Targets table scrolls sideways, so a row's identity is
+/// never lost (FR-006/FR-007, shipped in #1253).
+///
+/// Sized to 1400x900 on purpose: that is the DEFAULT docked configuration,
+/// not an edge case. At 1400 the sidebar takes 220px and the side dock 420px,
+/// leaving the table ~760px against its own 1000px min-width floor — so it
+/// overflows by ~240px and, under `table-layout: fixed`, the designation
+/// column is exactly what would scroll away unpinned.
+///
+/// Asserts a non-pinned CONTROL column moves by the scroll distance. Without
+/// it this journey would pass in the one case it most needs to catch: if the
+/// table never actually scrolled, every "drift == 0" assertion below would
+/// hold trivially against a static table and the test would be vacuous.
+#[tokio::test]
+#[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
+async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow::Result<()> {
+    const MIN_SCROLL: i64 = 200;
+
+    let app = E2eApp::launch().await?;
+    app.wait_bridge_ready(Duration::from_secs(30)).await?;
+    complete_first_run(&app).await?;
+
+    // Size the viewport BEFORE navigating: `useAdaptiveDock` reads
+    // `window.innerWidth` on mount, so engaging the dock after the page is
+    // already laid out would depend on its resize listener rather than on
+    // the configuration this journey means to assert.
+    app.set_viewport(1400, 900).await?;
+
+    app.goto_route("/targets").await?;
+    app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    add_target_via_ui(&app, "M 1").await?;
+
+    let before = measure_pinned_columns(&app).await?;
+    let overflow = px(&before, "scrollWidth")? - px(&before, "clientWidth")?;
+    anyhow::ensure!(
+        overflow >= MIN_SCROLL,
+        "the table must really overflow horizontally for this journey to mean \
+         anything, but scrollWidth-clientWidth is only {overflow}px \
+         (need >= {MIN_SCROLL}). Either the side dock did not engage at 1400px \
+         or the table's min-width floor changed: {before}"
+    );
+
+    // Scroll to the far right — the worst case for identity loss.
+    app.driver
+        .execute(
+            "var sc = document.querySelector('.pv-targets-table__scroll');\
+             sc.scrollLeft = sc.scrollWidth; return sc.scrollLeft;",
+            vec![],
+        )
+        .await
+        .context("failed to scroll the targets table horizontally")?;
+
+    let after = measure_pinned_columns(&app).await?;
+    let scrolled = px(&after, "scrollLeft")?;
+    anyhow::ensure!(
+        scrolled >= MIN_SCROLL,
+        "expected the table to really scroll by >= {MIN_SCROLL}px, got {scrolled}px: {after}"
+    );
+
+    // The control proves the scroll actually moved content.
+    let control_drift = px(&after, "control")? - px(&before, "control")?;
+    anyhow::ensure!(
+        control_drift <= -MIN_SCROLL,
+        "the non-pinned control column should have moved left by ~{scrolled}px, but it \
+         shifted {control_drift}px — the table did not really scroll, so the pinned \
+         assertions below would be vacuous.\nbefore: {before}\nafter:  {after}"
+    );
+
+    // The point of the feature: identity does not move, at all.
+    for key in ["star", "designation", "designationHeader"] {
+        let drift = px(&after, key)? - px(&before, key)?;
+        anyhow::ensure!(
+            drift == 0,
+            "{key} must stay pinned while the table scrolls {scrolled}px, but it drifted \
+             {drift}px. A non-zero drift here is exactly the regression this journey \
+             exists to catch (an approximate sticky offset, or a percentage offset \
+             resolving against the scroll container instead of the table).\n\
+             before: {before}\nafter:  {after}"
+        );
+    }
+
+    app.shutdown().await
+}

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -256,13 +256,34 @@ pending verification).
   `.pv-targets-table__scroll` already carried `overflow-x: auto` against the
   table's 1000px `min-width` floor, so non-pinned columns scroll only when the
   space is actually insufficient. T024 is what made that scrolling non-lossy.
-- [ ] T026 E2E: keep the existing full-width unclipped pin passing; add a
-  pinned-column + h-scroll assertion. **Open** — no longer moot now T024/T025
-  are delivered, but not authored. Verified manually instead (drift measured at
-  0px for star, designation and the designation header, against 240px of real
-  h-scroll, at 1400×900 with a 420px side dock). A Layer-1 assertion cannot
-  replace it: jsdom has no layout engine, so it cannot observe sticky offsets —
-  this needs a real-browser check.
+- [x] T026 E2E: keep the existing full-width unclipped pin passing; add a
+  pinned-column + h-scroll assertion. **DELIVERED (#1257).**
+  `targets_ui_identity_columns_stay_pinned_while_table_scrolls`
+  (`crates/e2e-tests/tests/targets_journeys.rs`) automates what had only been
+  measured by hand: 0px drift for star, designation and the designation
+  header, against real h-scroll at 1400×900. A Layer-1 assertion cannot
+  replace it — jsdom has no layout engine, so it reports 0 for every position
+  and would pass against a completely unpinned table.
+
+  The task as originally written understated the work. Two harness gaps had
+  to be closed first, and both are shared surface rather than spec-054 scope:
+
+  - Nothing could size the window. `tauri.conf.json` opens at 1280×820, below
+    `useAdaptiveDock`'s 1400px threshold, so the docked layout this asserts
+    did not occur at all. Added `E2eApp::set_viewport`, which corrects for
+    window chrome by measurement instead of assuming outer == inner (they are
+    equal under xvfb, which has no window manager, but not on Windows).
+  - The Ubuntu shards' display was too narrow to hold the window: `e2e.yml`
+    ran `xvfb-run -a`, whose built-in default screen is 1280 wide. Widened to
+    1600×1200.
+
+  **Not fully verified:** the Windows shards use the native display and its
+  resolution has not been confirmed ≥1400. If it is smaller, `set_viewport`
+  fails loudly naming the screen size rather than passing vacuously — the
+  failure mode is safe, but the shard would need the same treatment.
+
+  The journey asserts a non-pinned control column moves by the scroll
+  distance, so it cannot pass vacuously against a table that never scrolled.
 
 ---
 
@@ -362,15 +383,20 @@ pending verification).
   rails) → **#1107**.
 - **Superseded** (no tracked follow-up as of this reconciliation): T001, T006,
   T030.
-- **Open**: T023 (partial — remount covered, reload + drag not), T026 (E2E
-  assertion for the now-shipped pinned columns).
+- **Open**: T023 (partial — remount covered, reload + drag not).
 - **Not confirmed** (verify before relying on): T034.
 
-**Two tasks are Open as of the #1158 pass** (T023, T026) — both test coverage
-for behaviour that now ships, not unbuilt product. The earlier statement that
-no task remained Open was true when written, before #1195 and #1158 delivered
-T002/T003/T007/T024/T025 and thereby created a genuine gap between the shipped
-behaviour and its regression cover.
+**One task is Open as of the #1257 pass** (T023) — test coverage for
+behaviour that ships, not unbuilt product. The count was two after #1158
+(T023, T026); #1257 closed T026 by automating the pinned-column assertion,
+which also required widening the Ubuntu E2E display and adding a viewport
+helper to the shared harness. The earlier statement that no task remained
+Open was true when written, before #1195 and #1158 delivered
+T002/T003/T007/T024/T025 and thereby created a genuine gap between the
+shipped behaviour and its regression cover.
+
+T023's two uncovered halves (restore across a real reload, and width set by
+dragging rather than `setWidth`) remain tracked in **#1257**.
 
 Historically: #1066 (T021) and #1067 (T011/T012/T012a) both shipped (PR #1070,
 PR #1072). Three

--- a/specs/054-adaptive-detail-dock/tasks.md
+++ b/specs/054-adaptive-detail-dock/tasks.md
@@ -230,12 +230,26 @@ pending verification).
   The "persists across remount, scoped per dockId" assertion covers the
   multi-page half: `page-a` is pinned and resized, unmounted, and restored with
   both values intact, while `page-b` is confirmed untouched by it.
-  Two parts of this task are still NOT covered, which is why it stays open
-  rather than being ticked: the restore is verified across a **remount**, not a
-  real page **reload**, and the width is set via `setWidth` rather than by
-  **dragging** the resize handle. Neither shortcut is free — a genuine reload
-  is what would exercise the preference cache, and the drag path has its own
-  pointer-event handling.
+  Two parts were NOT covered by #1195: the restore was verified across a
+  **remount** rather than a real **reload**, and the width was set via
+  `setWidth` rather than by **dragging** the resize handle.
+
+  **#1257 closed the drag half and the storage half.** The suspicion that a
+  remount proves less than it appears to is now measured, and the mechanism
+  is concrete: `getPreferences()` returns a module-level `cachedPreferences`
+  when one exists, and `persistPreferences()` assigns that cache BEFORE its
+  `localStorage.setItem`, whose failure is swallowed. A remount re-reads the
+  CACHE, never storage. With `setItem` stubbed out so nothing persists at
+  all, the new assertions fail and the existing "persists across remount"
+  tests still PASS — they were green against total persistence failure.
+  `ListPageLayout.test.tsx` now asserts the serialized bytes under the real
+  `alm-preferences` key, and pins that the CLAMPED width is what persists.
+
+  **Still open: the real reload.** A cold module cache reading back from
+  real storage cannot be exercised in jsdom, so it stays Layer-2.
+  `E2eApp::relaunch()` is the natural home — it already preserves webview
+  storage for exactly this kind of assertion. Deliberately not bundled into
+  #1257, which was already carrying shared harness and CI changes.
 
 ---
 
@@ -383,7 +397,8 @@ pending verification).
   rails) → **#1107**.
 - **Superseded** (no tracked follow-up as of this reconciliation): T001, T006,
   T030.
-- **Open**: T023 (partial — remount covered, reload + drag not).
+- **Open**: T023 (partial — remount, drag and storage covered; a real reload
+  is not, and cannot be at Layer 1).
 - **Not confirmed** (verify before relying on): T034.
 
 **One task is Open as of the #1257 pass** (T023) — test coverage for


### PR DESCRIPTION
Closes the T026 half of #1257.

**Stacked on #1253** (base is `feat/1158-pinned-targets-columns`, not `main`) because it asserts the CSS that PR ships. Retarget to `main` once #1253 lands.

## Why this can't be a Layer-1 test

The pinning took three measurement iterations to land, and **every wrong version passed static review**. Both near-misses were invisible without measuring:

- a declared `45px` star column rendered at 50px, drifting the designation 270px → 265px
- a percentage offset resolved against the *scroll container* (760px) instead of the table, drifting 12px

jsdom has no layout engine, so a Layer-1 test reports `0` for every one of these positions and would pass against a **completely unpinned table**. This needs real `getBoundingClientRect` geometry.

## The task understated the work

T026 read as "add an assertion". It couldn't be, because the behaviour didn't occur in CI at all. Two shared-surface gaps had to close first — flagging that explicitly, since both sit in the path of *every* real-UI journey:

**1. Nothing could size the window.** `tauri.conf.json` opens at 1280×820; `useAdaptiveDock`'s threshold is `window.innerWidth >= 1400`. The docked layout simply never happened.

`E2eApp::set_viewport` is deliberately not a one-line `set_window_rect`. That call sizes the **outer** window while every threshold keys off **innerWidth**, and the gap between them is window chrome — ~0 under xvfb (no WM, no decorations) but real on Windows. Sizing blind would engage the dock on Linux and silently not on Windows, where the journey would pass having asserted nothing. So it sets, measures, corrects by the observed delta, and verifies.

**2. The Ubuntu shards' display was too narrow to hold the window.** `e2e.yml` ran `xvfb-run -a`, which takes the built-in default:

```
/usr/bin/xvfb-run:16:  XVFBARGS="-screen 0 1280x1024x24"
```

1280 < 1400, so the resize would be clamped at the screen edge. Widened to 1600×1200 — plain framebuffer memory (~7.7MB), not GPU, on a runner that already has none.

## Guard against a vacuous pass

The journey asserts a **non-pinned control column moves by the scroll distance**. Without it, this would pass in the exact case it most needs to catch: if the table never scrolled, every `drift == 0` assertion would hold trivially against a static table.

## Not verified

**The Windows shards' native display resolution has not been confirmed ≥1400.** If it's smaller, `set_viewport` fails loudly naming the screen size rather than passing vacuously — the failure mode is safe, but that shard would need the same treatment. I'd rather surface this than let a green run imply I checked it.

## Spec

T026 is ticked **in this PR** rather than left for a later reconciliation pass — that lag is what #1119 and the #1195 pass each had to clean up. Spec 054's Open count drops 2 → 1; T023's reload + drag halves stay open and tracked in #1257.

## Verification

`cargo check`, `cargo clippy`, `cargo fmt` clean on `e2e_tests`. The journey itself is `#[ignore]`d like every Layer-2 test and runs on the e2e shards — **its first real execution is this PR's CI**, which is also the first exercise of the widened display.