### PR TITLE
test(inbox): make the classify fixture actually seed its source row

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -1833,15 +1833,41 @@ mod tests {
     ) {
         let pool = db.pool();
         // Insert registered_sources row (FK required by inbox_source_groups).
+        //
+        // This INSERT must succeed: any query under test that JOINs
+        // `registered_sources` measures an empty table otherwise, and
+        // assertions of *absence* ("no rows", "item hidden") then pass
+        // vacuously — for the wrong reason, and they would keep passing if the
+        // production query broke (#1252).
+        //
+        // The old statement violated the 0006 schema four ways at once
+        // (missing NOT NULL `created_at` and `created_via`, `scan_depth` given
+        // `1` against `CHECK (IN ('recursive','single'))`, and a non-existent
+        // `organization_state` column), so it had never once inserted a row.
+        //
+        // What HID that was `INSERT OR IGNORE`, not the `.ok()` it was paired
+        // with: `OR IGNORE` makes SQLite swallow the constraint violation
+        // itself, so no error ever reaches sqlx and an `.expect()` here would
+        // have been equally silent. Verified both ways — `OR IGNORE` with
+        // `.expect()` still passes; the form below panics with
+        // `NOT NULL constraint failed: registered_sources.created_at`.
+        //
+        // So idempotency is expressed as a bare `ON CONFLICT DO NOTHING`,
+        // which suppresses only genuine uniqueness conflicts (the PK and
+        // `UNIQUE(kind, path)`, both expected when this helper runs more than
+        // once per test) while letting NOT NULL and CHECK violations surface.
+        // That, not the `.expect()`, is what keeps this from drifting again.
         sqlx::query(
-            "INSERT OR IGNORE INTO registered_sources \
-             (id, path, kind, scan_depth, organization_state) \
-             VALUES (?, '/test/root', 'inbox', 1, 'unorganized')",
+            "INSERT INTO registered_sources \
+             (id, path, kind, scan_depth, created_at, created_via) \
+             VALUES (?, '/test/root', 'inbox', 'recursive', \
+             '2026-01-01T00:00:00Z', 'first_run') \
+             ON CONFLICT DO NOTHING",
         )
         .bind(root_id)
         .execute(pool)
         .await
-        .ok();
+        .expect("test fixture: registered_sources INSERT must succeed");
 
         // Insert source group.
         sqlx::query(
@@ -1872,6 +1898,34 @@ mod tests {
         .execute(pool)
         .await
         .unwrap();
+    }
+
+    /// #1252: guard the fixture's own precondition.
+    ///
+    /// `insert_source_group_with_item` seeds `registered_sources` because
+    /// queries under test JOIN it. That INSERT silently inserted nothing for
+    /// its whole existence, so every such JOIN was measuring an empty table
+    /// and any assertion of absence passed vacuously.
+    ///
+    /// Asserting the row is present — rather than merely that the statement
+    /// did not error — is the part that survives future schema drift, since
+    /// a conflict-suppressing INSERT can succeed while writing nothing.
+    #[tokio::test]
+    async fn fixture_actually_seeds_registered_sources_1252() {
+        let db = test_db().await;
+        insert_source_group_with_item(&db, "sg-fixture", "item-fixture", "root-fixture", "a/b")
+            .await;
+
+        let (count, path): (i64, String) = sqlx::query_as(
+            "SELECT COUNT(*), COALESCE(MAX(path), '') FROM registered_sources WHERE id = ?",
+        )
+        .bind("root-fixture")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(count, 1, "the fixture must actually create its registered_sources row");
+        assert_eq!(path, "/test/root", "and it must be the row the helper claims to insert");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Fixes #1252.

## Summary

A shared test fixture claimed to seed `registered_sources` and never did. 17 classify tests were joining an empty table, so any assertion of *absence* passed vacuously — and would have kept passing if the production query broke.

## The correction to the diagnosis

#1252 names `.ok()` as the root cause and recommends `.expect()`. **That would not have worked**, and I only found out by trying it.

`INSERT OR IGNORE` makes **SQLite itself** swallow the constraint violation, so no error ever reaches sqlx. `.ok()` was redundant belt-and-braces on an error that was never produced.

Verified both directions:

| statement (broken columns) | `.expect()` result |
|---|---|
| `INSERT OR IGNORE` | **passes silently** |
| `INSERT ... ON CONFLICT DO NOTHING` | **panics** — `NOT NULL constraint failed: registered_sources.created_at` |

So the fix is to narrow the suppression, not to change the Rust error handling. A bare `ON CONFLICT DO NOTHING` still absorbs the genuine uniqueness conflicts the helper relies on (the PK, and `UNIQUE(kind, path)` — both expected when it runs repeatedly in one test) while letting NOT NULL and CHECK violations surface.

## Changes

- Correct the four schema violations: supply `created_at`/`created_via`, pass `scan_depth = 'recursive'`, drop the non-existent `organization_state` column.
- `INSERT OR IGNORE` -> `INSERT ... ON CONFLICT DO NOTHING`, keeping `.expect()` (now meaningful).
- Add `fixture_actually_seeds_registered_sources_1252`, asserting the row **is present** rather than that the statement did not error — a conflict-suppressing INSERT can succeed while writing nothing, which is precisely how this hid.

## Verification

- All **201** tests in `app_core_inbox` pass. **No existing assertion flipped**, so the vacuous-absence risk #1252 warns about did not materialise into a live false-negative — the tests were weaker than they looked, but not wrong.
- The new guard fails on the old statement with `left: 0, right: 1`, confirming empirically that `registered_sources` was always empty.
- `cargo fmt`, `cargo clippy -p app_core_inbox` clean.

## Coordination with #1194 / spec 058

#1252 flags that `classify.rs` is being rewritten by #1194, and asks that this be coordinated rather than landed underneath. Concretely:

- #1194 **does not** touch `insert_source_group_with_item`, so there is no competing fix.
- #1194 adds its own `seed_inbox_source` helper that goes through the real `register_source_batch` path and `.unwrap()`s — the right pattern, and unaffected by this.
- This change is confined to the `#[cfg(test)]` module of the same file, so it is a trivial-to-resolve textual conflict at worst. #1194 is currently `CONFLICTING` and will rebase regardless.

I did **not** convert the helper to route through `register_source_batch` like #1194's new tests do: that function generates its own UUID, so the helper would have to stop accepting a caller-chosen `root_id` and all 17 call sites would change — a large blast radius in a file mid-rewrite. Worth doing later, on top of #1194, not now.

**Sequencing: happy for this to land after #1194 if that lane prefers.**