### PR TITLE
chore(hooks): PR issue-refs hook reads the branch and repo being merged, not the shared checkout

### DIFF
--- a/.claude/hooks/speckit/scripts/speckit-pr-issue-refs.sh
+++ b/.claude/hooks/speckit/scripts/speckit-pr-issue-refs.sh
@@ -47,8 +47,25 @@ Spec context goes at the bottom under "## Spec Context" (not in the title).
 The release-please draft PR will be manually curated before publish -- raw material matters.
 GUIDANCE
 
-# Detect current branch
-BRANCH=$(git branch --show-current 2>/dev/null)
+# Detect current branch.
+#
+# Read the branch from the directory the COMMAND runs in, not the hook's own
+# $PWD. With git worktrees those differ: `gh pr create` runs in the worktree
+# while the hook inherits the main checkout, so using $PWD reports whatever the
+# shared checkout happens to be on. In practice that injected another lane's
+# spec context into five unrelated PRs. Both Claude and Codex put the directory
+# in `.cwd`; fall back to $PWD when absent or not a directory, matching
+# packages/hooks-git-safety/scripts/git-guard.sh.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -n "$CWD" ] && [ "$CWD" != "null" ] && [ -d "$CWD" ] || CWD="$PWD"
+
+# Order of trust: an explicit `--head` on the command names the branch outright,
+# so prefer it over any checkout state. `--head` may be `owner:branch` for a
+# fork; keep only the branch part.
+BRANCH=$(echo "$COMMAND" | grep -oE -- '--head[= ]+[^ ]+' | head -1 | sed -E 's/--head[= ]+//; s/^[^:]*://')
+if [ -z "$BRANCH" ]; then
+  BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null)
+fi
 if [ -z "$BRANCH" ]; then
   jq -n --arg ctx "$CONTEXT" '{
     hookSpecificOutput: {
@@ -59,8 +76,30 @@ if [ -z "$BRANCH" ]; then
   exit 0
 fi
 
-# Extract spec number from branch name (e.g., 023-lifecycle-testing -> 023)
-SPEC_ID=$(echo "$BRANCH" | grep -oE '[0-9]{3}' | head -1)
+# Extract the spec number from the branch name.
+#
+# Spec branches put the id at the start of a path segment, followed by a dash:
+# `023-lifecycle-testing`, `spec/058-inbox-drop-parent-items`.
+#
+# Anchoring matters. The previous `grep -oE '[0-9]{3}'` took the first three
+# digits ANYWHERE, so an ordinary issue branch was misread as a spec:
+# `fix/1050-wizard-site-skip-nag` -> "105" and `fix/1249-logpanel-follow-race`
+# -> "124". Neither repo has those specs; the ids came from issue numbers.
+# Requiring a segment boundary before and a dash after means a four-digit issue
+# number cannot match: in `/1050-`, `105` is not followed by `-` and `050` is
+# not preceded by a boundary.
+SPEC_ID=$(echo "$BRANCH" | grep -oE '(^|/)[0-9]{3}-' | head -1 | tr -dc '0-9')
+
+# Final guard: only treat this as a spec branch if that spec directory actually
+# exists. Cheap, and it fails closed on any naming pattern the regex above did
+# not anticipate.
+#
+# compgen, not `[ -d glob ]`: the latter passes every match as a separate
+# argument to `[`, so two matching spec dirs would make it error out and
+# silently discard a valid spec id.
+if [ -n "$SPEC_ID" ] && ! compgen -G "$CWD/specs/${SPEC_ID}-*" >/dev/null 2>&1; then
+  SPEC_ID=""
+fi
 
 if [ -z "$SPEC_ID" ]; then
   jq -n --arg ctx "$CONTEXT" '{
@@ -75,7 +114,10 @@ fi
 # Detect repo from git remote.
 # Handles both SSH (git@host:owner/repo.git) and HTTPS (https://host/owner/repo.git)
 # forms. BSD sed has no '+?'; use a portable greedy slug regex with a [/:] anchor.
-REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[/:]([^/]+/[^/]+)$#\1#; s#\.git$##')
+# `git -C "$CWD"` for the same reason as the branch lookup: when the command
+# runs in a worktree of a DIFFERENT repo than the hook's own checkout, reading
+# the remote from $PWD queries the wrong repository's issues entirely.
+REPO=$(git -C "$CWD" remote get-url origin 2>/dev/null | sed -E 's#.*[/:]([^/]+/[^/]+)$#\1#; s#\.git$##')
 if [ -z "$REPO" ]; then
   jq -n --arg ctx "$CONTEXT" '{
     hookSpecificOutput: {

--- a/.codex/hooks/speckit/scripts/speckit-pr-issue-refs.sh
+++ b/.codex/hooks/speckit/scripts/speckit-pr-issue-refs.sh
@@ -47,8 +47,25 @@ Spec context goes at the bottom under "## Spec Context" (not in the title).
 The release-please draft PR will be manually curated before publish -- raw material matters.
 GUIDANCE
 
-# Detect current branch
-BRANCH=$(git branch --show-current 2>/dev/null)
+# Detect current branch.
+#
+# Read the branch from the directory the COMMAND runs in, not the hook's own
+# $PWD. With git worktrees those differ: `gh pr create` runs in the worktree
+# while the hook inherits the main checkout, so using $PWD reports whatever the
+# shared checkout happens to be on. In practice that injected another lane's
+# spec context into five unrelated PRs. Both Claude and Codex put the directory
+# in `.cwd`; fall back to $PWD when absent or not a directory, matching
+# packages/hooks-git-safety/scripts/git-guard.sh.
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -n "$CWD" ] && [ "$CWD" != "null" ] && [ -d "$CWD" ] || CWD="$PWD"
+
+# Order of trust: an explicit `--head` on the command names the branch outright,
+# so prefer it over any checkout state. `--head` may be `owner:branch` for a
+# fork; keep only the branch part.
+BRANCH=$(echo "$COMMAND" | grep -oE -- '--head[= ]+[^ ]+' | head -1 | sed -E 's/--head[= ]+//; s/^[^:]*://')
+if [ -z "$BRANCH" ]; then
+  BRANCH=$(git -C "$CWD" branch --show-current 2>/dev/null)
+fi
 if [ -z "$BRANCH" ]; then
   jq -n --arg ctx "$CONTEXT" '{
     hookSpecificOutput: {
@@ -59,8 +76,30 @@ if [ -z "$BRANCH" ]; then
   exit 0
 fi
 
-# Extract spec number from branch name (e.g., 023-lifecycle-testing -> 023)
-SPEC_ID=$(echo "$BRANCH" | grep -oE '[0-9]{3}' | head -1)
+# Extract the spec number from the branch name.
+#
+# Spec branches put the id at the start of a path segment, followed by a dash:
+# `023-lifecycle-testing`, `spec/058-inbox-drop-parent-items`.
+#
+# Anchoring matters. The previous `grep -oE '[0-9]{3}'` took the first three
+# digits ANYWHERE, so an ordinary issue branch was misread as a spec:
+# `fix/1050-wizard-site-skip-nag` -> "105" and `fix/1249-logpanel-follow-race`
+# -> "124". Neither repo has those specs; the ids came from issue numbers.
+# Requiring a segment boundary before and a dash after means a four-digit issue
+# number cannot match: in `/1050-`, `105` is not followed by `-` and `050` is
+# not preceded by a boundary.
+SPEC_ID=$(echo "$BRANCH" | grep -oE '(^|/)[0-9]{3}-' | head -1 | tr -dc '0-9')
+
+# Final guard: only treat this as a spec branch if that spec directory actually
+# exists. Cheap, and it fails closed on any naming pattern the regex above did
+# not anticipate.
+#
+# compgen, not `[ -d glob ]`: the latter passes every match as a separate
+# argument to `[`, so two matching spec dirs would make it error out and
+# silently discard a valid spec id.
+if [ -n "$SPEC_ID" ] && ! compgen -G "$CWD/specs/${SPEC_ID}-*" >/dev/null 2>&1; then
+  SPEC_ID=""
+fi
 
 if [ -z "$SPEC_ID" ]; then
   jq -n --arg ctx "$CONTEXT" '{
@@ -75,7 +114,10 @@ fi
 # Detect repo from git remote.
 # Handles both SSH (git@host:owner/repo.git) and HTTPS (https://host/owner/repo.git)
 # forms. BSD sed has no '+?'; use a portable greedy slug regex with a [/:] anchor.
-REPO=$(git remote get-url origin 2>/dev/null | sed -E 's#.*[/:]([^/]+/[^/]+)$#\1#; s#\.git$##')
+# `git -C "$CWD"` for the same reason as the branch lookup: when the command
+# runs in a worktree of a DIFFERENT repo than the hook's own checkout, reading
+# the remote from $PWD queries the wrong repository's issues entirely.
+REPO=$(git -C "$CWD" remote get-url origin 2>/dev/null | sed -E 's#.*[/:]([^/]+/[^/]+)$#\1#; s#\.git$##')
 if [ -z "$REPO" ]; then
   jq -n --arg ctx "$CONTEXT" '{
     hookSpecificOutput: {


### PR DESCRIPTION
## Summary

- Syncs `speckit-pr-issue-refs.sh` (both the `.claude` and `.codex` copies) to the upstream version from srobroek/agentic-packages#548.
- Supersedes #1238, which fixed two of the three defects locally. This carries all three.

## Why not just `apm install`

That was the plan, and it does not work. I ran it:

- The hook is reported as **"local files exist, not managed by APM"** — one of 50 files skipped. Plain `apm install` will neither overwrite it nor deliver the fix.
- The cached module is pinned to `resolved_commit bb7a3781`, which predates #548, so even the vendored `apm_modules/` copy is stale.

So the correction to the #1238 review note: this file is **not** at risk of being silently reverted by `apm install` — but the upstream fix also will **not** arrive on its own. It has to be synced deliberately, which is what this PR does.

## What the three fixes are

1. **Branch resolution** — read from the command's `cwd`, not the hook's `$PWD`. With worktrees those differ, which previously injected one lane's spec context into unrelated PRs.
2. **`--head` trust order** — an explicit `--head` names the branch outright and wins over checkout state. Upstream also strips the `owner:` prefix, which #1238 did not.
3. **Repo resolution** — `git -C "$CWD" remote get-url origin`. Previously read from the hook's cwd, so a lane working across two repos queried the *other* repository's issues. #1238 missed this one.

Plus a fail-closed guard: spec context is only emitted when `specs/<id>-*` actually exists.

## Verification

`bash -n` clean, and the behaviour was checked in both directions rather than only the positive case:

| test | setup | result |
|---|---|---|
| T1 | `cwd` = a worktree on `spec/058-…`, hook `$PWD` on a non-spec branch | emits spec 058 + its 3 real open issues |
| T2 | `cwd` = a non-spec branch | no spec context (no false positive) |
| T3 | `--head platevault:spec/058-…` from a non-spec `cwd` | emits spec 058 — `--head` wins, `owner:` stripped |
| T4 | `--head platevault:spec/999-does-not-exist` | no spec context — fail-closed guard holds |

## Note

`apm install` also produced an unrelated `apm.lock.yaml` diff (codex MCP deployment bookkeeping). Left out deliberately to keep this focused and avoid colliding with other lanes.