### PR TITLE
ci: let the Real-UI E2E suite actually finish on main

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -105,7 +105,24 @@ on:
 
 concurrency:
   group: e2e-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on branches, but never on `main` (#1208).
+  #
+  # `main` shares one concurrency group across every push, so with a blanket
+  # `true` each merge killed the previous main run. During a normal merge
+  # campaign, merges land seconds apart, and no main run ever survived to
+  # report: 0aced5f0's run was cancelled at 08:19:23, one second after
+  # 971e7b11's was created at 08:19:22, which was itself cancelled two seconds
+  # after the next push. Ten consecutive main runs went the same way.
+  #
+  # The E2E suite therefore never gated `main` at all, and main-side
+  # regressions were structurally invisible — the suite looked configured
+  # while reporting nothing.
+  #
+  # This does not serialise indefinitely: with `cancel-in-progress: false`
+  # GitHub keeps at most the in-flight run plus the newest queued one and
+  # discards intermediate pending runs, so the cost stays bounded at ~2 runs
+  # per group while guaranteeing that one actually completes.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 env:
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
Refs #1208. One line of behaviour; the rest is comment.

## The finding

`e2e.yml` shares a single concurrency group across every push to `main`, and `cancel-in-progress: true` applied there too. Merges during a campaign land seconds apart, so **each merge killed the previous main run and none ever survived to report.**

Measured directly from the run history, not inferred:

| run | head | created | ended | outcome |
|---|---|---|---|---|
| 29726962192 | `0aced5f0` | 08:10:18 | **08:19:23** | cancelled |
| 29727493804 | `971e7b11` | **08:19:22** | 08:21:14 | cancelled |

The first died one second after the second was created; the second died two seconds after the push that followed. **Ten consecutive main runs** went the same way — of the twelve most recent, only two were not cancelled.

## Why it matters

The Real-UI E2E suite has not been gating `main` at all. That is the structural half of #1203 and the reason #1208 was so hard to pin down: the suite *looked* configured while reporting nothing, and the absence of red reads as green.

It also explains the observed sequence on #1208 — main was believed green, then the first uncancelled main run in hours (`29717774194`) immediately failed on two shards.

## The change

```yaml
cancel-in-progress: ${{ github.ref != refs/heads/main }}
```

Superseded runs are still cancelled on branches, where it is correct and saves real runner time. On `main` they are allowed to finish.

**This does not serialise indefinitely.** With `cancel-in-progress: false`, GitHub keeps at most the in-flight run plus the newest queued run and discards intermediate pending ones — so the cost is bounded at ~2 runs per group, not one per merge, while guaranteeing that one completes.

## Scope I deliberately did not take

`ci.yml` and `release-gate.yml` carry the **identical** blanket setting, so main-side integration and unit regressions are just as invisible.

I did not touch them: #1216, #1212 and #1247 are all live in `ci.yml` right now, and a fourth lane editing it would be gratuitous. Reported on #1203 so it lands with whoever owns that file next. `release-gate.yml` may also be deliberate for release gating — worth a decision rather than a blanket sweep.

## Verification

- YAML parses; the expression renders as `${{ github.ref != refs/heads/main }}` (GitHub evaluates `cancel-in-progress` expressions — this is the documented idiom).
- The real proof is post-merge: main E2E runs should start reaching a conclusion instead of `cancelled`. Worth watching the first few, since this is a config change whose effect cannot be observed from a PR branch — on this branch the old behaviour still (correctly) applies.