### PR TITLE
docs: record that the palette cards are generated, not hand-authored

### DIFF
--- a/.design-sync/NOTES.md
+++ b/.design-sync/NOTES.md
@@ -82,3 +82,10 @@ Repo-specific gotchas for future `/design-sync` runs. One bullet per quirk.
   deleted or merged away, the next build hits a missing source. `ConfirmOverlay` (merged
   into `Modal`) and the `ProjectStatusTag` alias were both retired this way. Re-check the
   map against `src/ui` + `src/components` whenever a component is removed or renamed.
+- **Palette cards are generated — never hand-edit them.** Run
+  `node .design-sync/generate-palette-cards.mjs` to rebuild the whole set from
+  `tokens.css` (per-theme values) and the `THEMES` registry (id/label/mode). The cards were
+  hand-authored once and drifted badly: no destructive family, a pre-correction Warm Clay
+  red, and only four of six themes. The generator exits 1 if the card count and theme count
+  disagree, so a theme added to the registry but not to `tokens.css` fails loudly instead of
+  producing a quietly short set.


### PR DESCRIPTION
## Summary

- The palette-card generator landed in #1263, but `NOTES.md` still described the cards only as artifacts that exist. Anyone reading the notes to prepare a re-sync would reasonably hand-edit them — which is exactly how the published set drifted (no destructive family, a pre-correction Warm Clay red, four of six themes).
- Adds a bullet naming the generator as the way to rebuild them, and its fail-loudly behaviour.

This was deliberately held out of #1261 to avoid conflicting with that PR's rewrite of the same file. Both have since merged, so it is now a clean one-bullet addition.

## Spec Context

Follow-through on the split handoff 05 of `run-dsr` (#1261 config/doc hygiene, #1263 generator).