### PR TITLE
docs: correct the E2E Channel claim, refresh the coverage matrix, record journey timing

### DIFF
--- a/apps/desktop/src-tauri/src/commands/plan_apply.rs
+++ b/apps/desktop/src-tauri/src/commands/plan_apply.rs
@@ -85,10 +85,11 @@ pub async fn plans_apply_real(
 /// Auto-approves the plan if it is still `ready_for_review`, then runs the
 /// same background executor and writes the same durable audit trail as
 /// `plans_apply_real` — it just takes no `tauri::ipc::Channel`, so it can be
-/// invoked directly by the Layer-2 `WebDriver` E2E bridge (which cannot
-/// construct a `Channel` from a test script) or by any UI surface that only
-/// needs a fire-and-poll apply (poll `plans.apply.status` for the durable
-/// terminal counts) rather than a live progress stream.
+/// invoked directly by the Layer-2 `WebDriver` E2E bridge (which could build
+/// a `Channel`, but should not have to reach into Tauri internals to do it)
+/// or by any UI surface that only needs a fire-and-poll apply (poll
+/// `plans.apply.status` for the durable terminal counts) rather than a live
+/// progress stream.
 ///
 /// Intended for archive/cleanup plans, which — unlike inbox plans — have no
 /// `inbox.plan.apply` channel-free equivalent to route through.

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -740,10 +740,11 @@ export const commands = {
 	 *  Auto-approves the plan if it is still `ready_for_review`, then runs the
 	 *  same background executor and writes the same durable audit trail as
 	 *  `plans_apply_real` — it just takes no `tauri::ipc::Channel`, so it can be
-	 *  invoked directly by the Layer-2 `WebDriver` E2E bridge (which cannot
-	 *  construct a `Channel` from a test script) or by any UI surface that only
-	 *  needs a fire-and-poll apply (poll `plans.apply.status` for the durable
-	 *  terminal counts) rather than a live progress stream.
+	 *  invoked directly by the Layer-2 `WebDriver` E2E bridge (which could build
+	 *  a `Channel`, but should not have to reach into Tauri internals to do it)
+	 *  or by any UI surface that only needs a fire-and-poll apply (poll
+	 *  `plans.apply.status` for the durable terminal counts) rather than a live
+	 *  progress stream.
 	 * 
 	 *  Intended for archive/cleanup plans, which — unlike inbox plans — have no
 	 *  `inbox.plan.apply` channel-free equivalent to route through.

--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -713,11 +713,15 @@ pub(super) fn spawn_executor_run(params: SpawnExecutorParams) {
 /// `apply_plan` requires a caller-supplied `approval_token` (spec 025 A1) and
 /// is normally reached through the webview's `tauri::ipc::Channel`-carrying
 /// `plans.apply` command so live per-item progress can stream back. Two kinds
-/// of caller have neither a token in hand nor a `Channel` to construct:
+/// of caller have no token in hand and no reason to build a `Channel`:
 ///
 /// - The spec 037 Layer-2 WebDriver test harness, which drives the real
-///   backend via `window.__ALM_E2E__.invoke(...)` and structurally cannot
-///   create a `tauri::ipc::Channel` from a test script.
+///   backend via `window.__ALM_E2E__.invoke(...)`. It *could* build a
+///   `Channel` — one is just `__CHANNEL__:${id}` from
+///   `__TAURI_INTERNALS__.transformCallback`, and the harness already runs
+///   arbitrary JS in the real webview — but doing so would mean reaching into
+///   Tauri-internal plumbing from a test, so the harness deliberately does
+///   not. This variant is the supported route instead.
 /// - Any archive/cleanup UI surface that only needs a fire-and-poll apply
 ///   (poll [`get_apply_status`] for the durable terminal counts) rather than
 ///   a live progress stream.

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -590,11 +590,13 @@ async fn lifecycle_integrity() -> anyhow::Result<()> {
 /// `plans.approve`, `plans.apply.direct`, `plans.apply.status`.
 ///
 /// FORMERLY a documented gap: applying the generated plan needed
-/// `plans.apply_real`, which takes a `tauri::ipc::Channel` progress
-/// argument this WebDriver harness cannot construct. `plans.apply.direct`
-/// (spec 037) is the channel-free equivalent — same executor, same durable
-/// audit trail, no `Channel` required — so this journey now drives the real
-/// filesystem mutation instead of stopping at `approved`.
+/// `plans.apply_real`, which takes a `tauri::ipc::Channel` progress argument
+/// this harness declines to construct — see the module docs: it is buildable
+/// from a WebDriver script, but only by reaching into Tauri internals.
+/// `plans.apply.direct` (spec 037) is the channel-free equivalent — same
+/// executor, same durable audit trail, no `Channel` required — so this
+/// journey now drives the real filesystem mutation instead of stopping at
+/// `approved`.
 ///
 /// `source.protection.set` marks this project `normal` before generating the
 /// plan: the app's safe-by-default protection level is `"protected"`

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -156,8 +156,10 @@ prose"):
 - **RESOLVED 2026-07-05: `cleanup_plan_review`'s apply gap.** The blocker was
   a missing channel-free apply command for archive/cleanup plans (unlike
   `inbox.plan.apply` for inbox plans) — `plans.apply_real` takes a
-  `tauri::ipc::Channel` progress argument this WebDriver harness cannot
-  construct. `plans.apply.direct` (a.k.a. `plans_apply_direct`,
+  `tauri::ipc::Channel` progress argument this WebDriver harness declines to
+  construct (buildable from a test script, but only by reaching into
+  Tauri internals — see #1234).
+  `plans.apply.direct` (a.k.a. `plans_apply_direct`,
   `app_core::plan_apply::apply_plan_channel_free`) now exists: same executor
   (`apply_plan`) and durable audit trail as `plans.apply_real`, no `Channel`
   required. `cleanup_plan_review` now drives a real apply past `plans.approve`

--- a/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
+++ b/specs/037-e2e-integration-testing/contracts/coverage-matrix.md
@@ -244,7 +244,7 @@ everything neither automated layer reaches.
 
 | Journey | Layer-1 | Layer-2 | Mock-Playwright | Manual-Windows doc |
 |---|:--:|:--:|:--:|---|
-| 1 First-run → data sources | ✅ | 🟡 wizard redirect + resolve + create only | 🟡 legacy-state + index-redirect regressions + **Observing Site step (`setup_wizard_site_step.spec.ts`, NEW 2026-07-09)**: optional-copy render, blank-skip advances to Confirm, out-of-range-latitude inline validation, field retention across Back/Continue. Full 6-step happy path and Data-Sources management (rescan/remap/disable/delete/reveal) still uncovered | `windows-journeys/journey-01-first-run-setup.md` |
+| 1 First-run → data sources | ✅ | 🟡 wizard redirect + resolve + create only | 🟡 legacy-state + index-redirect regressions + **Observing Site step (`setup_wizard_site_step.spec.ts`, NEW 2026-07-09)**: optional-copy render, blank-skip advances to Confirm, out-of-range-latitude inline validation, field retention across Back/Continue. Data Sources Rescan/Disable/Enable/Delete have vitest coverage (`DataSources.rescan.test.tsx`, `DataSources.disable-delete.test.tsx` — see correction below); full 6-step happy path and Remap/Reveal remain uncovered at every layer | `windows-journeys/journey-01-first-run-setup.md` |
 | 2 Ingest → reclassify → confirm (move) | ✅ | ✅ real-UI (`inbox_ui_journeys.rs`): mixed-folder split, unclassified-frame-type gate + bulk reclassify, missing-path-attribute gate, Confirm-doesn't-move + Apply-moves-to-shown-path, unsplit-folder Type-badge reads "unclassified" not "classified" (`inbox_ui_unsplit_unclassified_folder_badge_is_not_classified`, #711 Instance A, NEW 2026-07-19 — **written, not yet executed**). Root-picker prompt (2+ roots) and stale-plan refusal remain unautomated (follow-up) | ✅ `inbox_ingest_confirm.spec.ts` (batch 1, PR #448, 2026-07-05): mixed-folder split, needs-review gate + bulk reclassify, single-type confirm→plan toast, plan-approval overlay review→apply/cancel | `windows-journeys/journey-02-inbox-ingest-move.md` |
 | 3 Ingest → confirm (catalogue-in-place) | ✅ | ✅ real-UI (`inbox_ui_journeys.rs::inbox_ui_catalogue_in_place_zero_moves_byte_identical`): organized root → 0-move catalogue plan, no root picker, no destination-absolute cell, byte-identical apply | ✅ `inbox_ingest_confirm.spec.ts` (batch 1, PR #448): catalogue-in-place plan distinguishable from a move plan in the review overlay | `windows-journeys/journey-03-inbox-catalogue-in-place.md` |
 | 4 Sessions review (derived) | ✅ | 🟡 real-UI (`sessions_journeys.rs`): nothing before apply, real session row appears automatically, no review-lifecycle controls anywhere, no-op rescan never duplicates. Notes-edit invariant (Test 4) found untestable — see finding below | 🟡 rows/detail render only (`lifecycle_detail.spec.ts`, pre-existing) | `windows-journeys/journey-04-sessions-review.md` |
@@ -508,11 +508,64 @@ the existing batch work, not newly gapped: 046 i18n cross-cutting
 disclosure are both exercised by `settings_appearance_i18n.spec.ts` and
 `targets_planner.spec.ts` respectively (see the per-journey table).
 
-**Still open (not closed this pass, out of this task's named scope)**: the
-full 6-step wizard happy path (Sources→Tools→Config→Site→Confirm→Scan) end
-to end, and Data Sources management (rescan/remap/disable/delete/reveal) —
-both remain "UNCOVERED" per the original audit and are follow-up candidates,
-not regressions.
+**Correction (2026-07-20, issue #1235): the Data Sources line above was
+stale.** Rescan and Disable/Enable/Delete already had vitest component
+coverage *before* this note was originally written:
+`apps/desktop/src/features/settings/DataSources.rescan.test.tsx` (rescan,
+`7e19d7bb`, 2026-07-04) and `DataSources.disable-delete.test.tsx`
+(disable/enable/delete, `7219fb57`, 2026-07-04) — both predate this section's
+2026-07-09 date. Per this file's own convention (the `ObservingSites.test.tsx`
+precedent a few lines above), a vitest `.test.tsx` counts as real coverage,
+so "UNCOVERED" was never accurate for those two actions. **Remap and Reveal
+remain genuinely uncovered at every layer** — no test references `remap` or
+`reveal`/`RemapRootDialog`/`handleReveal` in any of the three DataSources
+`.test.tsx` files, and no Mock-Playwright spec exists for Data Sources at all
+(only `setup_wizard_site_step.spec.ts`, `settings_framing.spec.ts`,
+`settings_appearance_i18n.spec.ts`, and `source_view_*.spec.ts` exist under
+`tests/e2e/`). **Still open (not closed this pass, out of this task's named
+scope)**: the full 6-step wizard happy path (Sources→Tools→Config→Site→
+Confirm→Scan) end to end, and any Mock-Playwright or Layer-2 real-UI coverage
+of Data Sources management (rescan/remap/disable/delete/reveal) — these
+remain follow-up candidates, not regressions.
+
+## Spec 051 (tauri-shell-integration) — shipped-and-untested surface — 2026-07-20
+
+Per `specs/SPEC_STATUS.md:92` (🟡 Partial, 34/64 tasks ticked — undercounts,
+several merged tasks aren't checked off), US1/US2/US3/US4/US5/US6/US7/US10 are
+merged to `main` and this matrix has **zero reference to any of them** at any
+layer:
+
+- US1 single-instance guard (`64a94881`/#471)
+- US2 favourites-in-DB (`54378086`/#472)
+- US3 cleanup-overrides-in-DB (`c990f967`/#474)
+- US4 window-state persistence (`e9b1622b`/#476)
+- US5 native menu bar (`e9b1622b`/#476)
+- US6 native theme sync (`29617775`/#475)
+- US7 diagnostics log file (`e9b1622b`/#476)
+- US10 signed-update groundwork (`c1f3ede9`/#473, `a33dc427`, `60732f2f`/#469)
+
+None of these have a Layer-1 integration test, a Layer-2 real-UI journey, or a
+Mock-Playwright spec in this repo as of this writing — they are desktop-shell
+integrations (native OS behavior, window chrome, update signing) that are
+plausibly hard to assert in the existing harnesses, but that has not been
+verified either way; this row exists so the gap is tracked rather than
+silently absent. US8 (OS notifications) and US9 (release-build native
+behavior/reload-guard) are real open *product* scope per `SPEC_STATUS.md`, not
+a testing gap, and are excluded from this row.
+
+## Specs not yet implemented — no coverage expected — 2026-07-20
+
+Per `specs/SPEC_STATUS.md:92-95`, these specs in the 050-058 range have no
+shipped product code, so their absence from this matrix is not a test gap:
+
+- **050** publishable-crate-extractions — docs-only plan-of-record (#429)
+- **056** onboarding-redesign — 📄 Specified (2026-07-18), no implementation
+- **058** inbox-drop-parent-items — 📄 Specified (2026-07-19), no implementation
+
+Check `specs/SPEC_STATUS.md` before re-deriving shipped-vs-specified for any
+spec above 049; specs 052-055/057 (including 053, which has a `specs/`
+directory but no row in `SPEC_STATUS.md`'s table) aren't tracked there and
+are out of scope here too.
 
 ## Spec 008 Q27 iteration — framing clustering + Inbox-confirm attribution (F-Framing-8/9/11) — 2026-07-17
 
@@ -566,3 +619,28 @@ surface and an attribution-candidate picker at Inbox confirm), not on
 test-harness capability — the same class of gap as row 8's
 `MatchCandidatesPanel.tsx` "implemented but unreachable" finding, but here
 even earlier: no consuming component exists at all yet.
+
+## Recorded for whoever sequences the next journey-suite batch — 2026-07-20
+
+Net wall-clock impact of the proposed next batch of real-UI journey work, so
+sequencing doesn't have to re-derive it (issue #1228):
+
+- Four new real-UI journeys: cleanup/apply (~45s), archive/trash (~50s), root
+  remap (~35s), first-run wizard (~40s) — **+170s**.
+- Delete `plan_review_apply_with_audit`
+  (`crates/e2e-tests/tests/journeys.rs:155`, confirmed still present as of
+  this writing) as subsumed by the new cleanup/apply journey — **−30s**.
+- Move six IPC-only tests to `apps/desktop/src-tauri/tests/` — **−180s**.
+- **Net: ≈ −40s.**
+
+Caveats: `.config/nextest.toml`'s `e2e` profile runs with `test-threads > 1`,
+so real wall-clock is better than this raw sum suggests. The actual
+constraint is per-boot memory on a 4-vCPU CI runner, not seconds — sequence
+this batch to bound concurrent app boots, not to shave time. **This estimate
+assumes the Real-UI E2E suite actually runs to completion on `main`, which is
+not true today**: `main`'s `e2e.yml` concurrency group cancels in-flight runs
+on every subsequent merge, so the suite has been silently non-reporting
+(#1202, #1208; fix in #1268). Re-baseline these numbers once #1268 lands and
+a full run is observed to finish.
+
+Documentation only; no code change follows from this note in this task.


### PR DESCRIPTION
Fixes #1234. Comment/doc only — no behaviour change (Rust doc comments + coverage-matrix.md).

Closes #1234
Closes #1235
Closes #1228

## #1234 — false "cannot construct a Channel" claim

A Tauri Channel is an id from `__TAURI_INTERNALS__.transformCallback`, serialised as the plain string `__CHANNEL__:${id}` (`IPC_PAYLOAD_PREFIX`, tauri 2.11 `src/ipc/channel.rs:28`); the Rust side deserialises it from exactly that string via `JavaScriptChannelId`'s `FromStr`. The harness already runs arbitrary JS in the real webview, so nothing structurally prevents building one — it just means reaching into Tauri-internal plumbing from a test.

Corrected the four sites that overstated this as impossibility (`journeys.rs`, `plan_apply.rs`, `plan_apply/apply.rs`, coverage-matrix.md) to match the three sites that already framed it correctly as a deliberate choice. `archive_journeys.rs:11` was checked and left alone — it already said "no Channel required", never claimed impossibility. `plans.apply.direct` is unaffected; it remains independently justified for fire-and-poll callers.

Verification: `git grep -F "cannot construct"` → no hits remain anywhere in the repo.

## #1235 — coverage matrix refresh (specs 050-058)

The matrix referenced no spec above 049 and had one stale "uncovered" entry.

- **Stale entry corrected**: Data Sources Rescan and Disable/Enable/Delete have had vitest component coverage since 2026-07-04 (`DataSources.rescan.test.tsx` `7e19d7bb`, `DataSources.disable-delete.test.tsx` `7219fb57`) — predating the note that called them uncovered. Remap and Reveal remain genuinely untested at every layer (no test references them, no Mock-Playwright spec for Data Sources exists at all).
- **Spec 051 added** as the one shipped-and-untested surface in the 050-058 range: US1/US2/US3/US4/US5/US6/US7/US10 are merged to `main` per `SPEC_STATUS.md:93` with zero matrix reference at any layer.
- **"Not implemented" section added** for 050/056/058, pointing at `SPEC_STATUS.md` so a future audit doesn't re-derive shipped-vs-specified. (053 has a `specs/` directory but no `SPEC_STATUS.md` row, so it's called out as out-of-scope rather than lumped in as "not implemented".)

## #1228 — journey-suite timing record

Recorded the proposed next real-UI-journey batch's net timing impact (four new journeys +170s, minus a subsumed test −30s, minus moving six IPC-only tests to `apps/desktop/src-tauri/tests/` −180s ⇒ net ≈ −40s), with the caveat that `nextest`'s `e2e` profile parallelizes so real wall-clock beats the raw sum, and that the actual constraint is per-boot CI-runner memory, not seconds.

**Caveat added while addressing this**: main's Real-UI E2E suite has been silently non-reporting due to a concurrency-group cancellation bug (#1202, #1208; fixed by #1268) — the timing note flags that these estimates need re-baselining once a full run is observed to finish.

## Generated-bindings drift fix

The corrected `plans_apply_direct` doc comment (#1234 fix) changes the tauri-specta-generated TS doc comment too. Regenerated `apps/desktop/src/bindings/index.ts` (`just check-generated`) so CI's `Generated contract/binding drift` step stays green.

## Conflicts to expect

Touches two files other open PRs also touch (comment/doc-only conflicts, trivial to resolve):
- `crates/e2e-tests/tests/journeys.rs` — own #1255
- `specs/037-e2e-integration-testing/contracts/coverage-matrix.md` — #1194

## Test plan

- [x] `just lint` (clean, after `pnpm install` — this worktree's `node_modules` was missing)
- [x] `just check-generated` (clean, after regenerating bindings)
- Doc-comment-only Rust diff, no logic changed — `just test`/`just typecheck` skipped intentionally
