### PR TITLE
fix: running a single test file no longer fails on a missing message catalogue

### DIFF
--- a/apps/desktop/vitest.config.ts
+++ b/apps/desktop/vitest.config.ts
@@ -23,6 +23,13 @@ export default defineConfig({
     environment: "jsdom",
     globals: true,
     setupFiles: ["./vitest.setup.ts"],
+    // Compiles the generated Paraglide catalogue before any suite loads.
+    // package.json's `pretest` hook only runs for `pnpm test`; invoking
+    // vitest directly (single file, watch mode, IDE runner) skipped it, and
+    // every suite then failed at import on `@/paraglide/messages`. A
+    // globalSetup runs once per vitest process whatever the entrypoint.
+    // See vitest.globalSetup.ts.
+    globalSetup: ["./vitest.globalSetup.ts"],
     css: false,
     // Vitest's 5s default is too tight for jsdom + React render + waitFor
     // chains once the runner is CPU-contended — and CI runners are contended

--- a/apps/desktop/vitest.globalSetup.ts
+++ b/apps/desktop/vitest.globalSetup.ts
@@ -1,0 +1,63 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { resolve } from "node:path";
+
+/**
+ * Compile the Paraglide message catalogue before any suite loads.
+ *
+ * `src/paraglide/` is generated and gitignored, and `src/lib/i18n.ts` imports
+ * from it, so on a tree that has never compiled it EVERY suite fails at import
+ * with `Failed to resolve import "@/paraglide/messages"`.
+ *
+ * package.json wires a `pretest` hook, which npm/pnpm run for `pnpm test` —
+ * but NOT for `pnpm vitest run <file>`, `vitest --watch`, or an IDE runner
+ * invoking vitest directly. Those are exactly the commands used to iterate on
+ * one spec, so the papercut landed on the narrow inner loop while the
+ * full-suite path stayed green.
+ *
+ * A globalSetup runs once per vitest process regardless of entrypoint, so it
+ * covers every one of those paths. `pretest` is left in place: it costs
+ * nothing, and it keeps `pnpm test` working if this file is ever removed.
+ */
+export default function setup(): void {
+  const dir = resolve(__dirname, "src/paraglide");
+
+  try {
+    execFileSync(
+      "pnpm",
+      [
+        "exec",
+        "paraglide-js",
+        "compile",
+        "--project",
+        "./project.inlang",
+        "--outdir",
+        "./src/paraglide",
+        "--strategy",
+        "baseLocale",
+        "--emit-ts-declarations",
+      ],
+      { cwd: __dirname, stdio: "pipe" },
+    );
+    return;
+  } catch (error) {
+    // Only fatal if the catalogue is genuinely absent. If a previous compile
+    // already produced it, a failure here (offline, transient CLI problem) is
+    // not worth blocking a test run that would otherwise pass.
+    if (existsSync(dir)) {
+      console.warn(
+        `[vitest] paraglide compile failed; reusing the existing ${dir}. ` +
+          `Message changes may not be reflected.\n${String(error)}`,
+      );
+      return;
+    }
+    throw new Error(
+      `Could not compile the Paraglide catalogue, and no previous output exists at ${dir}. ` +
+        `Every suite that imports '@/paraglide/messages' will fail to load. ` +
+        `Run \`pnpm i18n:compile\` in apps/desktop to diagnose.\n${String(error)}`,
+    );
+  }
+}


### PR DESCRIPTION
## Summary

- `src/paraglide/` is generated and gitignored, and `src/lib/i18n.ts` imports from it. On a tree that hasn't compiled it, **every** suite fails at import with `Failed to resolve import "@/paraglide/messages"`.
- `package.json`'s `pretest` hook covers `pnpm test`, but **not** `pnpm vitest run <file>`, watch mode, or an IDE runner invoking vitest directly — exactly the commands used to iterate on one spec. The papercut landed on the narrow inner loop while the full-suite path stayed green, which is why it survived.
- A `globalSetup` runs once per vitest process regardless of entrypoint, so it covers all of them.

## Why this is worth fixing

Not the inconvenience — the **shape of the failure**. A suite that cannot load reports as a failed file with *"no tests"*, which summarises into something that reads like success. I misread it exactly that way earlier today before checking the raw JSON, which is what prompted this.

## Verification

Both directions, on a tree with `src/paraglide/` deleted:

| | Result |
|---|---|
| globalSetup disabled | `1 failed / no tests` |
| globalSetup enabled | `27 passed` |

Full suite unaffected: **201 files / 1845 tests** green. `pnpm typecheck` clean.

## Design notes

- `pretest` is deliberately left in place: it costs nothing and keeps `pnpm test` working if this file is ever removed.
- A compile failure is only fatal when **no** previous output exists. Otherwise it warns and reuses the existing catalogue, so a transient CLI problem can't block an otherwise-passing run — while a genuinely absent catalogue still fails loudly with the command to diagnose it.

## Pre-existing, not from this PR

`pnpm lint` reports one fatal parse error in `eslint-rules/no-user-string.js` (*"was not found by the project service"*). Confirmed pre-existing by stashing these changes and re-running on clean `main` — identical `fatalErrorCount: 1`. Untouched here.

## Spec Context

Found while adding Layer-2 coverage for spec 054 (#1257 / #1265); unrelated to that spec, so it ships separately.