### PR TITLE
test(e2e): say what the page looked like when a testid wait times out

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -698,11 +698,17 @@ impl E2eApp {
         ret.convert::<bool>().context("failed to deserialise bridge_ready result")
     }
 
-    /// Page state captured when a bridge wait times out (#1204).
+    /// Page state captured when a wait times out (#1204, #1272).
     ///
     /// Returns a human-readable one-liner and never fails: this runs on an
     /// already-failing path, so a diagnostic that could itself error would
     /// replace the real failure with its own.
+    ///
+    /// The name predates its second caller — [`Self::wait_testid`] and
+    /// [`Self::wait_testid_enabled`] use it too, since "the element never
+    /// appeared" needs exactly the same questions answered: what route are we
+    /// on, did the page finish loading, is an error boundary showing, and did
+    /// anything render at all.
     async fn bridge_failure_context(&self) -> String {
         let url = match self.driver.current_url().await {
             Ok(u) => u.to_string(),
@@ -710,14 +716,25 @@ impl E2eApp {
         };
 
         // One script, so a dying session yields one error rather than four.
+        //
+        // `presentTestids` is the decisive datum for a testid wait (#1272):
+        // "project-row-<id> never appeared" is ambiguous on its own, but the
+        // list of testids that ARE present separates "wrong route", "route
+        // rendered but list empty" and "nothing rendered at all" immediately.
+        // Capped at 40 and truncated so a large DOM cannot bury the failure.
         let probe = r#"
             var boundary = document.querySelector('[data-testid="app-error-boundary-fallback"]');
+            var ids = Array.prototype.slice
+                .call(document.querySelectorAll('[data-testid]'), 0, 40)
+                .map(function (el) { return el.getAttribute('data-testid'); });
             return JSON.stringify({
                 readyState: document.readyState,
                 hasBridge:  !!window.__ALM_E2E__,
                 bridgeKeys: window.__ALM_E2E__ ? Object.keys(window.__ALM_E2E__) : [],
                 errorBoundary: boundary ? (boundary.innerText || '').slice(0, 300) : null,
-                bodyChars: document.body ? document.body.innerHTML.length : 0
+                bodyChars: document.body ? document.body.innerHTML.length : 0,
+                testidCount: document.querySelectorAll('[data-testid]').length,
+                presentTestids: ids
             });
         "#;
         let page = match self.driver.execute(probe, vec![]).await {
@@ -1148,20 +1165,42 @@ impl E2eApp {
     }
 
     /// Poll for an element with the given `data-testid` to appear, returning it.
+    ///
+    /// On timeout, attaches the page context (#1272). "never appeared" alone
+    /// cannot distinguish a wrong route from an empty list from a page that
+    /// rendered nothing, and a real CI failure
+    /// (`project-row-… never appeared within 15s`,
+    /// `inventory_journeys::reconcile_drops_externally_deleted_frame…`) was
+    /// undiagnosable for exactly that reason.
     pub async fn wait_testid(&self, testid: &str, timeout: Duration) -> Result<WebElement> {
         let deadline = Instant::now() + timeout;
+        // Retain the last lookup error instead of discarding it. `NoSuchElement`
+        // is the expected, boring case while polling, but a dead session or a
+        // malformed selector surfaces here too and used to be swallowed --
+        // the same shape as the `.unwrap_or(false)` removed from
+        // `wait_bridge_ready` in #1211.
+        let mut last_err: Option<String>;
         loop {
-            if let Ok(el) = self.find_testid(testid).await {
-                return Ok(el);
+            match self.find_testid(testid).await {
+                Ok(el) => return Ok(el),
+                Err(e) => last_err = Some(format!("{e:#}")),
             }
             if Instant::now() >= deadline {
-                return Err(anyhow!("data-testid={testid:?} never appeared within {timeout:?}"));
+                let probed = self.bridge_failure_context().await;
+                let cause = last_err.map_or_else(String::new, |e| format!("; last error: {e}"));
+                return Err(anyhow!(
+                    "data-testid={testid:?} never appeared within {timeout:?}{cause}; {probed}"
+                ));
             }
             tokio::time::sleep(Duration::from_millis(150)).await;
         }
     }
 
     /// Poll until the element with the given `data-testid` becomes enabled.
+    ///
+    /// Attaches the same page context as [`Self::wait_testid`] on timeout
+    /// (#1272) -- "never became enabled" is ambiguous between an element that
+    /// stayed disabled and one that never rendered at all.
     pub async fn wait_testid_enabled(&self, testid: &str, timeout: Duration) -> Result<()> {
         let deadline = Instant::now() + timeout;
         loop {
@@ -1169,8 +1208,9 @@ impl E2eApp {
                 return Ok(());
             }
             if Instant::now() >= deadline {
+                let probed = self.bridge_failure_context().await;
                 return Err(anyhow!(
-                    "data-testid={testid:?} never became enabled within {timeout:?}"
+                    "data-testid={testid:?} never became enabled within {timeout:?}; {probed}"
                 ));
             }
             tokio::time::sleep(Duration::from_millis(150)).await;


### PR DESCRIPTION
Refs #1272. Diagnostics only — does not fix that flake.

## Why

A real CI failure read, in full:

```
Error: data-testid="project-row-4824ad2e-…" never appeared within 15s
```

That single line cannot distinguish:

- the app was on the **wrong route**,
- the route rendered but the **list was empty**,
- **nothing rendered at all** (blank page / error boundary).

Those have completely different causes, and #1272 (`inventory_journeys::reconcile_drops_externally_deleted_frame…`, 222s then a 7s pass on retry) is stuck at that fork.

## Change

- Attach the existing page context to `wait_testid` and `wait_testid_enabled` timeouts. That helper (`bridge_failure_context`) already reports URL, `readyState`, `hasBridge`, error-boundary text and body size — it was just wired to bridge waits only.
- Add **`presentTestids`** (capped at 40) and `testidCount` to the probe. This is the decisive datum: the testids that *are* present separate the three cases above at a glance.
- Stop discarding the lookup error. `if let Ok(el) = …` swallowed it every poll. `NoSuchElement` is the boring expected case while polling, but a dead session or a malformed selector surfaced there too and was thrown away.

## The recurring shape

That last point is the fourth instance of one pattern in this area:

| site | discarded by | status |
|---|---|---|
| `wait_bridge_ready` | `.unwrap_or(false)` | fixed in #1211 |
| driver/app log after launch | `ProcLog` dropped on the success path | #1262 |
| `registered_sources` fixture | `INSERT OR IGNORE` | #1266 |
| `wait_testid` | `if let Ok(el) = …` | here |

Each captured the evidence and then threw it away one layer up, and each cost real triage time before anyone noticed the evidence had ever existed.

## Verification

- `cargo fmt --check` and `cargo clippy --tests -p e2e_tests` clean. (Clippy caught an initial `None` that was never read; matched `wait_bridge_ready`s existing declare-without-initialiser form rather than silencing it.)
- **No passing-path change** — this only widens what an already-failing wait prints, so the existing journeys exercise it unchanged.
- Not unit-testable in a meaningful way: asserting the text of a diagnostic against a mocked page would only test my own construction. The proof is the next occurrence of #1272 in CI carrying the context.

## Conflicts

Touches `crates/e2e-tests/tests/common/mod.rs`, as do my #1255 (adds a timeout constant near the top) and #1262 (struct field + `wait_bridge_ready` body). This change is in a different region (`wait_testid`, ~line 1155) and only *calls* `bridge_failure_context` without renaming it, so all three should apply independently. Sequencing is up to whoever merges.