### PR TITLE
fix: inbox classification no longer reports success when it fails to save

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -11,11 +11,29 @@
 //! This module is pure orchestration: DB reads/writes via
 //! `persistence_db::repositories::inbox`; metadata reads via
 //! `metadata_fits::FitsExtractor` / `metadata_xisf::XisfExtractor`.
+//!
+//! # Write-failure policy (issue #1101)
+//!
+//! Writes here split into two classes and are handled differently:
+//!
+//! - **Load-bearing** — the classification result itself (the stale-row wipe
+//!   that the fresh rows assume, the evidence rows, the classification cache
+//!   row, the item's scan columns and its `state = 'classified'`). A failure
+//!   propagates: returning `Ok` would report a classification the database
+//!   does not hold, and the `state` write in particular would leave a false
+//!   statement in the DB (#711 badge disagreement).
+//! - **Best-effort** — rows that are re-derivable from the next classify run
+//!   (per-file metadata seeded for materialized sub-items, override
+//!   restoration and staleness flags, breakdown cache rows, orphan sub-item
+//!   cleanup, denormalized child counts). These keep going, but every failure
+//!   is logged with the item id and path so a partial classify is diagnosable
+//!   after the fact instead of surfacing as a data bug months later.
 #![allow(clippy::doc_markdown)]
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+use app_core_errors::db_internal_ctx;
 use app_core_targets::metadata_cache::cached_extract;
 use calibration_master_detect::{detect_master, DetectInput};
 use camino::Utf8Path;
@@ -147,11 +165,17 @@ pub async fn classify(
         snapshot_overrides(pool, &req.inbox_item_id, &file_paths, &req.root_absolute_path).await;
 
     // Delete stale evidence
-    repo::delete_evidence_for_item(pool, &req.inbox_item_id).await.ok();
-    repo::delete_breakdown_for_item(pool, &req.inbox_item_id).await.ok();
+    repo::delete_evidence_for_item(pool, &req.inbox_item_id)
+        .await
+        .map_err(|e| db_internal_ctx(e, "classify: delete stale evidence"))?;
+    repo::delete_breakdown_for_item(pool, &req.inbox_item_id)
+        .await
+        .map_err(|e| db_internal_ctx(e, "classify: delete stale breakdown"))?;
     // spec 041 US2/T016: clear stale per-file metadata so removed files do not
     // leave orphaned rows behind after a re-scan.
-    repo::delete_file_metadata_for_item(pool, &req.inbox_item_id).await.ok();
+    repo::delete_file_metadata_for_item(pool, &req.inbox_item_id)
+        .await
+        .map_err(|e| db_internal_ctx(e, "classify: delete stale file metadata"))?;
 
     let mut frame_type_files: HashMap<String, Vec<String>> = HashMap::new();
     let mut unclassified_files: Vec<String> = Vec::new();
@@ -236,12 +260,16 @@ pub async fn classify(
             is_master,
             master_detector,
         };
-        repo::insert_evidence(pool, &ev).await.ok();
+        repo::insert_evidence(pool, &ev)
+            .await
+            .map_err(|e| db_internal_ctx(e, "classify: insert classification evidence"))?;
 
         // spec 041 US2/T016: persist per-file extracted header metadata. The
         // raw extractor returns string fields; we parse the numeric ones here
         // (gain stays a string — some cameras report scaled/non-integer gain).
-        persist_file_metadata(pool, &req.inbox_item_id, &rel, abs_path, raw_meta.as_ref()).await;
+        persist_file_metadata(pool, &req.inbox_item_id, &rel, abs_path, raw_meta.as_ref())
+            .await
+            .map_err(|e| db_internal_ctx(e, "classify: persist per-file metadata"))?;
 
         // T066: collect for sub-item grouping and the folder tallies — both
         // computed AFTER the loop, once user overrides are layered on top of
@@ -252,7 +280,7 @@ pub async fn classify(
     // spec 041 R-4 / T025: re-apply snapshotted overrides to freshly-inserted
     // evidence rows, then mark stale the subset whose file identity changed.
     for entry in &override_snapshot {
-        repo::set_overrides(
+        if let Err(e) = repo::set_overrides(
             pool,
             &req.inbox_item_id,
             &entry.relative_file_path,
@@ -262,11 +290,23 @@ pub async fn classify(
             entry.override_binning.as_deref(),
         )
         .await
-        .ok();
+        {
+            tracing::warn!(
+                item = %req.inbox_item_id,
+                file = %entry.relative_file_path,
+                "classify: restoring overrides failed, file reverts to its raw header state: {e}"
+            );
+        }
         if entry.stale {
             repo::mark_override_stale(pool, &req.inbox_item_id, &entry.relative_file_path)
                 .await
-                .ok();
+                .unwrap_or_else(|e| {
+                    tracing::warn!(
+                        item = %req.inbox_item_id,
+                        file = %entry.relative_file_path,
+                        "classify: marking override stale failed, file shows as fresh: {e}"
+                    );
+                });
         }
     }
 
@@ -367,7 +407,15 @@ pub async fn classify(
                     .ok()
                     .and_then(|t| time::OffsetDateTime::from(t).format(&Rfc3339).ok());
                 if cur_size != Some(stored_size) || cur_mtime.as_deref() != Some(stored_mtime) {
-                    repo::mark_file_override_stale(pool, sg_id, &ov.relative_file_path).await.ok();
+                    repo::mark_file_override_stale(pool, sg_id, &ov.relative_file_path)
+                        .await
+                        .unwrap_or_else(|e| {
+                            tracing::warn!(
+                                source_group = %sg_id,
+                                file = %ov.relative_file_path,
+                                "classify: marking file override stale failed, changed file shows as fresh: {e}"
+                            );
+                        });
                 }
             }
         }
@@ -452,7 +500,9 @@ pub async fn classify(
         content_signature: &content_signature,
         unclassified_file_count: unclassified_count,
     };
-    repo::upsert_classification(pool, &classification).await.ok();
+    repo::upsert_classification(pool, &classification)
+        .await
+        .map_err(|e| db_internal_ctx(e, "classify: upsert classification"))?;
 
     // 9. Update item state and signature
     repo::update_inbox_item_scan(
@@ -462,9 +512,11 @@ pub async fn classify(
         i64::try_from(file_paths.len()).unwrap_or(i64::MAX),
     )
     .await
-    .ok();
+    .map_err(|e| db_internal_ctx(e, "classify: update item scan columns"))?;
 
-    repo::update_inbox_item_state(pool, &req.inbox_item_id, "classified").await.ok();
+    repo::update_inbox_item_state(pool, &req.inbox_item_id, "classified")
+        .await
+        .map_err(|e| db_internal_ctx(e, "classify: mark item classified"))?;
 
     // 10. Build + persist breakdown with destination previews
     let breakdown =
@@ -506,7 +558,7 @@ async fn persist_file_metadata(
     rel: &str,
     abs_path: &Path,
     raw_meta: Option<&metadata_core::RawFileMetadata>,
-) {
+) -> persistence_db::DbResult<()> {
     // Parse a trimmed numeric string (e.g. "120.0", "2") to a target number.
     fn parse_f64(s: Option<&String>) -> Option<f64> {
         s.and_then(|v| v.trim().parse::<f64>().ok())
@@ -589,7 +641,7 @@ async fn persist_file_metadata(
         }
     };
 
-    repo::upsert_inbox_file_metadata(pool, &m).await.ok();
+    repo::upsert_inbox_file_metadata(pool, &m).await
 }
 
 /// Collect relative file paths that need to be marked as stale after the
@@ -1009,12 +1061,26 @@ pub(crate) async fn materialize_sub_items(
     if let Ok(existing) = repo::list_inbox_sub_items(pool, source_group_id).await {
         for row in existing {
             if !current_keys.contains(row.group_key.as_str()) {
-                repo::delete_sub_item_if_unlinked(pool, &row.id).await.ok();
+                repo::delete_sub_item_if_unlinked(pool, &row.id).await.unwrap_or_else(|e| {
+                    tracing::warn!(
+                        source_group = %source_group_id,
+                        sub_item = %row.id,
+                        "classify: deleting orphaned sub-item failed, stale group remains: {e}"
+                    );
+                });
             }
         }
     }
 
-    repo::update_source_group_child_count(pool, source_group_id, child_count).await.ok();
+    repo::update_source_group_child_count(pool, source_group_id, child_count).await.unwrap_or_else(
+        |e| {
+            tracing::warn!(
+                source_group = %source_group_id,
+                child_count,
+                "classify: updating source-group child count failed, badge count is stale: {e}"
+            );
+        },
+    );
 }
 
 /// Seed one materialized sub-item's evidence, per-file metadata, breakdown,
@@ -1034,9 +1100,25 @@ async fn seed_sub_item_cache(
 ) {
     let is_needs_review = group_key == SENTINEL_NEEDS_REVIEW;
 
-    repo::delete_evidence_for_item(pool, sub_id).await.ok();
-    repo::delete_breakdown_for_item(pool, sub_id).await.ok();
-    repo::delete_file_metadata_for_item(pool, sub_id).await.ok();
+    // Every write below seeds a cache the next classify re-derives, so a
+    // failure degrades rather than corrupts: log and continue (#1101).
+    let warn_seed = |op: &'static str, e: persistence_db::DbError| {
+        tracing::warn!(
+            sub_item = %sub_id,
+            group_key,
+            "classify: seeding sub-item cache failed at {op}, cache is partial: {e}"
+        );
+    };
+
+    repo::delete_evidence_for_item(pool, sub_id)
+        .await
+        .unwrap_or_else(|e| warn_seed("delete evidence", e));
+    repo::delete_breakdown_for_item(pool, sub_id)
+        .await
+        .unwrap_or_else(|e| warn_seed("delete breakdown", e));
+    repo::delete_file_metadata_for_item(pool, sub_id)
+        .await
+        .unwrap_or_else(|e| warn_seed("delete file metadata", e));
 
     let mut sample_files: Vec<String> = Vec::new();
     for (rel, abs_opt, raw_meta_opt) in files {
@@ -1053,7 +1135,7 @@ async fn seed_sub_item_cache(
             is_master: false,
             master_detector: None,
         };
-        repo::insert_evidence(pool, &ev).await.ok();
+        repo::insert_evidence(pool, &ev).await.unwrap_or_else(|e| warn_seed("insert evidence", e));
 
         // Real abs path when available (initial classify's own re-split) for
         // accurate file_size_bytes/file_mtime; falls back to an unreadable
@@ -1061,7 +1143,9 @@ async fn seed_sub_item_cache(
         // already treats a failed stat as None/None, same as its documented
         // "no abs path available" behaviour elsewhere in this module.
         let abs_for_stat = abs_opt.as_deref().unwrap_or_else(|| Path::new(""));
-        persist_file_metadata(pool, sub_id, rel, abs_for_stat, raw_meta_opt.as_ref()).await;
+        persist_file_metadata(pool, sub_id, rel, abs_for_stat, raw_meta_opt.as_ref())
+            .await
+            .unwrap_or_else(|e| warn_seed("persist file metadata", e));
 
         if sample_files.len() < 10 {
             sample_files.push(rel.clone());
@@ -1081,7 +1165,7 @@ async fn seed_sub_item_cache(
             &sample_json,
         )
         .await
-        .ok();
+        .unwrap_or_else(|e| warn_seed("upsert breakdown", e));
     }
 
     let (db_result, unclassified_count) = if is_needs_review {
@@ -1097,7 +1181,9 @@ async fn seed_sub_item_cache(
         content_signature,
         unclassified_file_count: unclassified_count,
     };
-    repo::upsert_classification(pool, &classification).await.ok();
+    repo::upsert_classification(pool, &classification)
+        .await
+        .unwrap_or_else(|e| warn_seed("upsert classification", e));
 }
 
 /// Enumerate FITS/XISF files directly inside a folder (non-recursive).
@@ -1166,7 +1252,15 @@ async fn build_breakdown(
             &sample_json,
         )
         .await
-        .ok();
+        .unwrap_or_else(|e| {
+            // The returned `entries` are built in memory regardless, so the
+            // response stays correct; only the persisted cache row is lost.
+            tracing::warn!(
+                item = %inbox_item_id,
+                kind,
+                "classify: persisting breakdown row failed, cached breakdown is partial: {e}"
+            );
+        });
 
         entries.push(BreakdownEntry {
             kind: kind.clone(),
@@ -1323,6 +1417,103 @@ mod tests {
         assert_eq!(resp.classification_type, "single_type");
         assert_eq!(resp.frame_type, Some("light".to_owned()));
         assert!(!resp.content_signature.is_empty());
+    }
+
+    /// Build the standard one-light-frame fixture used by the #1101 regression
+    /// tests: a temp dir holding one classifiable FITS file plus its inbox row.
+    async fn single_light_fixture(db: &Database, item_id: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fits_with_imagetyp(tmp.path(), "light_001.fits", "Light Frame");
+        repo::insert_inbox_item(
+            db.pool(),
+            &InsertInboxItem {
+                id: item_id,
+                root_id: "root-1",
+                relative_path: "",
+                file_count: 0,
+                content_signature: None,
+                lane: "fits",
+            },
+        )
+        .await
+        .unwrap();
+        tmp
+    }
+
+    /// Regression (#1101, headline site): when the `state = 'classified'` write
+    /// fails, classify MUST NOT return `Ok`. Previously the result was dropped
+    /// with `.await.ok()`, so the caller was told the item was classified while
+    /// the row still said otherwise — a false statement in the DB and the root
+    /// of the #711 badge disagreement.
+    ///
+    /// The failure is injected with a trigger scoped to exactly that write, so
+    /// every earlier write in the run still succeeds and only the state
+    /// transition breaks.
+    #[tokio::test]
+    async fn classify_surfaces_failed_item_state_write() {
+        let db = test_db().await;
+        let item_id = "item-1101-state";
+        let tmp = single_light_fixture(&db, item_id).await;
+
+        sqlx::query(
+            "CREATE TRIGGER block_classified BEFORE UPDATE ON inbox_items \
+             WHEN NEW.state = 'classified' \
+             BEGIN SELECT RAISE(ABORT, 'injected: state write failed'); END",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let err = classify(
+            db.pool(),
+            ClassifyRequest {
+                inbox_item_id: item_id.to_owned(),
+                root_absolute_path: tmp.path().to_owned(),
+                force_rescan: false,
+            },
+        )
+        .await
+        .expect_err("classify must not report success when the state write fails");
+
+        assert_eq!(err.code, ErrorCode::InternalDatabase);
+        assert!(
+            err.message.contains("mark item classified"),
+            "error must name the failed operation, got: {}",
+            err.message
+        );
+
+        // The DB must not claim the item is classified either.
+        let state: String = sqlx::query_scalar("SELECT state FROM inbox_items WHERE id = ?")
+            .bind(item_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_ne!(state, "classified");
+    }
+
+    /// Regression (#1101): evidence rows ARE the classification result, so a
+    /// failed evidence write must surface rather than yielding a response
+    /// describing rows that were never persisted.
+    #[tokio::test]
+    async fn classify_surfaces_failed_evidence_write() {
+        let db = test_db().await;
+        let item_id = "item-1101-evidence";
+        let tmp = single_light_fixture(&db, item_id).await;
+
+        sqlx::query("DROP TABLE inbox_classification_evidence").execute(db.pool()).await.unwrap();
+
+        let err = classify(
+            db.pool(),
+            ClassifyRequest {
+                inbox_item_id: item_id.to_owned(),
+                root_absolute_path: tmp.path().to_owned(),
+                force_rescan: false,
+            },
+        )
+        .await
+        .expect_err("classify must not report success when the evidence write fails");
+
+        assert_eq!(err.code, ErrorCode::InternalDatabase);
     }
 
     /// Regression (PR #457 Layer-2 Inbox journeys): a SECOND classify of an

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -606,7 +606,12 @@ pub async fn confirm(
         .await
         .map_err(|e| db_internal_ctx(e, "insert plan link"))?;
 
-    inbox_repo::update_inbox_item_state(pool, &req.inbox_item_id, "plan_open").await.ok();
+    // Load-bearing (#1101): the plan and its link were just committed above, so
+    // an item left off `plan_open` contradicts them — same class as the two
+    // propagating writes it follows.
+    inbox_repo::update_inbox_item_state(pool, &req.inbox_item_id, "plan_open")
+        .await
+        .map_err(|e| db_internal_ctx(e, "mark inbox item plan_open"))?;
 
     // 14. Attribution apply-path (spec 008 Q27, F-Framing-10/6, FR-022): the
     // plan now exists, so the pick can be persisted (`plans.chosen_framing_id`)


### PR DESCRIPTION
Closes #1101

`classify` discarded the result of 17 database writes with `.await.ok()` (plus 1 in `confirm.rs`). A failed write was indistinguishable from a successful one — no error, no log, no retry — and classify returned a response describing rows that were never persisted.

Per the issue, this was decided **per call site** rather than swept with a blanket `?`, which would have changed classify's failure semantics.

## Load-bearing → propagate

Now returned as `internal.database` via the existing `app_core_errors::db_internal_ctx`, naming the failed operation:

| Site | Why it is load-bearing |
|---|---|
| `delete_evidence_for_item` / `delete_breakdown_for_item` / `delete_file_metadata_for_item` (`classify.rs:167-176`) | The fresh rows assume the wipe happened; a failed wipe means fresh rows are appended to stale ones |
| `insert_evidence` (`classify.rs:263`) | The per-file classification result itself |
| `persist_file_metadata` (`classify.rs:269`) | Per-file header metadata the confirm flow reads |
| `upsert_classification` (`classify.rs:494`) | The classification cache row |
| `update_inbox_item_scan` (`classify.rs:499`) | Scan columns / content signature |
| `update_inbox_item_state(… "classified")` (`classify.rs:509`) | **The headline site.** It wrote a false statement into the DB — `state = 'classified'` while `group_key`/`frame_type` stayed untouched, the root of the #711 badge disagreement |
| `update_inbox_item_state(… "plan_open")` (`confirm.rs:609`) | Follows two writes that already propagate; an item left off `plan_open` contradicts the plan and link just committed |

## Best-effort → log with context

Kept going, but every failure now logs the item id and path. All of these are re-derived by the next classify run, so aborting mid-way would leave a worse state than continuing:

sub-item cache seeding (the issue names cache seeding as genuinely best-effort), override restoration and staleness flags, breakdown cache rows, orphan sub-item cleanup, and the denormalized source-group child count.

The module docstring now records this split so future call sites land on the right side of it.

## Regression tests

Both in `crates/app/inbox/src/classify.rs`, failing before and passing after:

- `classify_surfaces_failed_item_state_write` — injects a SQLite trigger scoped to exactly the `state = 'classified'` write, so every earlier write still succeeds and only the state transition breaks. Asserts classify returns `Err(InternalDatabase)` naming the operation, and that the row does not claim `classified`.
- `classify_surfaces_failed_evidence_write` — drops `inbox_classification_evidence`.

Against the unfixed code both fail with the exact bug — classify returning `Ok`:

```
classify must not report success when the state write fails: ClassifyResponse {
  classification_type: "single_type", frame_type: Some("light"), … }
```

## Gates

`cargo test -j 4 -p app_core_inbox` → 202 passed. `cargo clippy -p app_core_inbox --all-targets -- -D warnings` → clean. `cargo fmt --all` applied. The full suite runs in CI — it is not run locally here because several lanes build concurrently.

No migration and no persistence changes, so `just db-boundary` does not apply.

## Notes

- No `.tsx` touched. No UI follow-up identified: the propagated errors use the existing `internal.database` code, which the frontend already renders — classify failures simply stop being silent.
- Real-app verification is worth doing for the confirm path (`plan_open` now propagates), but the change only converts a silently-dropped failure into a surfaced one, so the happy path is unaffected.