### PR TITLE
fix: explain over-long path failures instead of reporting them as unknown

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -1101,6 +1101,12 @@ async fn seed_sub_item_cache(
 }
 
 /// Enumerate FITS/XISF files directly inside a folder (non-recursive).
+///
+/// Skips symlinks and Windows junctions. `folder` is user-supplied, and
+/// `is_file()` resolves links, so without this gate a link planted in an
+/// inbox folder would pull an out-of-root file into classification — the
+/// do-not-follow-links rule the scanner already enforces (issue #1233,
+/// constitution product constraints).
 fn enumerate_fits_files(folder: &Path) -> Vec<PathBuf> {
     let mut files = Vec::new();
     let Ok(read_dir) = std::fs::read_dir(folder) else {
@@ -1108,6 +1114,9 @@ fn enumerate_fits_files(folder: &Path) -> Vec<PathBuf> {
     };
     for entry in read_dir.flatten() {
         let path = entry.path();
+        if fs_pathsafe::is_link_or_junction(&path) {
+            continue;
+        }
         if !path.is_file() {
             continue;
         }
@@ -3153,5 +3162,63 @@ mod tests {
             std::collections::HashSet::from(["light", "dark"]),
             "re-derived sub-items must cover both frame types present in the folder"
         );
+    }
+
+    /// Baseline for the two link tests below: a real FITS file in the folder
+    /// IS enumerated, so a later assertion of "not enumerated" is evidence of
+    /// the link gate rather than of a broken walker.
+    #[test]
+    fn real_fits_file_is_enumerated() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fits_with_imagetyp(tmp.path(), "real.fits", "LIGHT");
+
+        let found = enumerate_fits_files(tmp.path());
+        assert_eq!(found.len(), 1, "a real FITS file in the folder must be enumerated");
+    }
+
+    /// Issue #1233: a symlink to a FITS file outside the inbox folder must not
+    /// be pulled into classification. `is_file()` resolves the link, so the
+    /// explicit link gate is what refuses it.
+    #[cfg(unix)]
+    #[test]
+    fn symlinked_fits_file_is_not_enumerated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        write_fits_with_imagetyp(&outside, "elsewhere.fits", "LIGHT");
+
+        let folder = tmp.path().join("inbox_folder");
+        std::fs::create_dir_all(&folder).unwrap();
+        std::os::unix::fs::symlink(outside.join("elsewhere.fits"), folder.join("linked.fits"))
+            .unwrap();
+
+        let found = enumerate_fits_files(&folder);
+        assert!(found.is_empty(), "a symlinked FITS file must not be enumerated: {found:?}");
+    }
+
+    /// Windows counterpart: files reached through a junction must not be
+    /// enumerated either. Junctions are directory-only, so the link sits on
+    /// the folder the walker would descend into.
+    #[cfg(windows)]
+    #[test]
+    fn fits_file_behind_junction_is_not_enumerated() {
+        let tmp = tempfile::tempdir().unwrap();
+        let outside = tmp.path().join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+        write_fits_with_imagetyp(&outside, "elsewhere.fits", "LIGHT");
+
+        let folder = tmp.path().join("inbox_folder");
+        std::fs::create_dir_all(&folder).unwrap();
+        let junction = folder.join("junction_to_outside");
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J", junction.to_str().unwrap(), outside.to_str().unwrap()])
+            .status()
+            .expect("mklink invocation failed");
+        assert!(status.success(), "mklink /J failed to create the test junction");
+
+        // The walker is non-recursive, so the junction itself is the entry it
+        // must refuse; enumerating it as a directory would be a regression.
+        let found = enumerate_fits_files(&folder);
+        assert!(found.is_empty(), "nothing behind a junction may be enumerated: {found:?}");
     }
 }

--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -545,4 +545,57 @@ mod tests {
         let items = scan_root(&scan_root_dir, &options).unwrap();
         assert_eq!(items.len(), 1, "symlinked subdir is traversed when explicitly enabled");
     }
+
+    /// Create a directory junction, the reparse-point kind `is_symlink()` does
+    /// **not** report. Uses the `mklink /J` shell builtin (junctions need no
+    /// admin privilege, unlike symlinks) rather than adding a dependency for
+    /// two tests — the same approach as `fs_pathsafe`'s junction test.
+    #[cfg(windows)]
+    fn make_junction(link: &std::path::Path, target: &std::path::Path) {
+        let status = std::process::Command::new("cmd")
+            .args(["/C", "mklink", "/J", link.to_str().unwrap(), target.to_str().unwrap()])
+            .status()
+            .expect("mklink invocation failed");
+        assert!(status.success(), "mklink /J failed to create the test junction");
+    }
+
+    /// Windows-only counterpart to the two `cfg(unix)` symlink tests above.
+    ///
+    /// The Unix tests give no evidence about Windows: a followed junction can
+    /// walk the scan into a loop or onto an unrelated drive and produce inbox
+    /// items the user never pointed at (constitution product constraints).
+    #[cfg(windows)]
+    #[test]
+    fn junction_subdir_not_traversed_by_default() {
+        let tmp = tmpdir();
+        let real_target = tmp.path().join("real_target");
+        fs::create_dir_all(&real_target).unwrap();
+        write_file(&real_target, "hidden.fits", b"hidden");
+
+        let scan_root_dir = tmp.path().join("scan_root");
+        fs::create_dir_all(&scan_root_dir).unwrap();
+        make_junction(&scan_root_dir.join("junction_to_target"), &real_target);
+
+        let items = scan_root(&scan_root_dir, &ScanOptions::default()).unwrap();
+        assert!(items.is_empty(), "must not see files behind an un-enabled junction");
+    }
+
+    /// The opt-in direction, mirroring
+    /// `symlinked_subdir_traversed_when_follow_symlinks_enabled`.
+    #[cfg(windows)]
+    #[test]
+    fn junction_subdir_traversed_when_follow_symlinks_enabled() {
+        let tmp = tmpdir();
+        let real_target = tmp.path().join("real_target");
+        fs::create_dir_all(&real_target).unwrap();
+        write_file(&real_target, "visible.fits", b"visible");
+
+        let scan_root_dir = tmp.path().join("scan_root");
+        fs::create_dir_all(&scan_root_dir).unwrap();
+        make_junction(&scan_root_dir.join("junction_to_target"), &real_target);
+
+        let options = ScanOptions { follow_symlinks: true };
+        let items = scan_root(&scan_root_dir, &options).unwrap();
+        assert_eq!(items.len(), 1, "junction is traversed when explicitly enabled");
+    }
 }

--- a/crates/fs/executor/src/failure.rs
+++ b/crates/fs/executor/src/failure.rs
@@ -179,6 +179,12 @@ fn classify_io_error(err: &io::Error) -> (FailureCode, bool) {
         io::ErrorKind::NotFound => (FailureCode::SourceMissing, false),
         io::ErrorKind::WouldBlock => (FailureCode::SourceLocked, true),
         io::ErrorKind::StorageFull => (FailureCode::DiskFull, true),
+        // A path the OS refuses to name: ENAMETOOLONG on Unix, and on Windows
+        // both ERROR_INVALID_NAME and the filename-exceeds-range error raised
+        // past MAX_PATH. Retry cannot help — the path itself must change — so this
+        // is not recoverable, and it must not degrade to `Unknown`, which would
+        // tell the user nothing about their too-long path (constitution §II).
+        io::ErrorKind::InvalidFilename => (FailureCode::PathInvalid, false),
         _ => {
             // Inspect raw OS error for volume / cross-device clues.
             #[cfg(unix)]
@@ -189,6 +195,13 @@ fn classify_io_error(err: &io::Error) -> (FailureCode, bool) {
                     return (FailureCode::VolumeUnavailable, true);
                 }
             }
+            // Surface classification gaps in production instead of swallowing
+            // them: every `Unknown` a user sees is a kind we could have named.
+            tracing::warn!(
+                io_error_kind = ?err.kind(),
+                raw_os_error = ?err.raw_os_error(),
+                "fs_executor: unclassified io error mapped to FailureCode::Unknown"
+            );
             (FailureCode::Unknown, false)
         }
     }

--- a/crates/fs/executor/tests/real_os_failures.rs
+++ b/crates/fs/executor/tests/real_os_failures.rs
@@ -1,0 +1,146 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Real-OS failure classification (issue #1232).
+//!
+//! Every other test of [`fs_executor::failure`] drives `classify_io_error`
+//! with a **synthesised** `io::Error`, which proves only that the match arms
+//! are wired to each other — not that a real OS produces the kind we assume.
+//! These tests provoke genuine kernel errors against a real temp filesystem
+//! and assert the resulting `FailureCode`.
+//!
+//! Constitution §II: a refusal must explain itself. A misclassified error
+//! surfaces as `Unknown`, which tells the user nothing about their read-only
+//! drive or their too-long path.
+
+use camino::{Utf8Path, Utf8PathBuf};
+
+use fs_executor::failure::FailureCode;
+use fs_executor::ops::move_file;
+
+fn utf8(path: &std::path::Path) -> Utf8PathBuf {
+    Utf8PathBuf::from_path_buf(path.to_path_buf()).expect("temp dir path must be UTF-8")
+}
+
+fn write_source(dir: &Utf8Path, name: &str) -> Utf8PathBuf {
+    let path = dir.join(name);
+    std::fs::write(&path, b"payload").expect("failed to seed the test source file");
+    path
+}
+
+/// A genuinely unwritable destination directory must classify as
+/// `PermissionDenied`, not `Unknown`.
+///
+/// Skips (rather than passing vacuously) when the process can write into a
+/// mode-`0o555` directory anyway — root bypasses DAC, so under `sudo` or in a
+/// root CI container this test can prove nothing and must say so.
+#[cfg(unix)]
+#[test]
+fn permission_denied_on_unwritable_destination_is_classified() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8(tmp.path());
+
+    let source = write_source(&root, "source.fits");
+    let locked = root.join("locked");
+    std::fs::create_dir_all(&locked).unwrap();
+
+    let mut perms = std::fs::metadata(&locked).unwrap().permissions();
+    perms.set_mode(0o555);
+    std::fs::set_permissions(&locked, perms).unwrap();
+
+    // Probe the guarantee this test depends on before asserting on it.
+    if std::fs::write(locked.join("privilege_probe"), b"x").is_ok() {
+        eprintln!(
+            "SKIP permission_denied_on_unwritable_destination_is_classified: \
+             this process can write into a 0o555 directory (running as root), \
+             so a real EACCES cannot be provoked here"
+        );
+        return;
+    }
+
+    let (failure, _) = move_file(&source, &locked.join("dest.fits"))
+        .expect_err("moving into a mode-0o555 directory must fail");
+
+    assert_eq!(
+        failure.code,
+        FailureCode::PermissionDenied,
+        "real EACCES must classify as permission.denied, got {}: {}",
+        failure.code.as_str(),
+        failure.message
+    );
+    assert!(failure.recoverable, "the user can fix permissions and retry");
+}
+
+/// A path past the OS name limit must classify as `PathInvalid`.
+///
+/// The kernel reports `ENAMETOOLONG` on Unix, and on Windows either
+/// `ERROR_INVALID_NAME` or the filename-exceeds-range error raised past
+/// `MAX_PATH`; `std` folds all three into
+/// `io::ErrorKind::InvalidFilename`. Before issue #1232 that kind had no arm
+/// and degraded to `Unknown`.
+#[test]
+fn path_too_long_is_classified_as_path_invalid_not_unknown() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8(tmp.path());
+
+    let source = write_source(&root, "source.fits");
+    // 400 chars exceeds the 255-byte per-component limit on Linux/macOS and
+    // pushes the full path past MAX_PATH (260) on Windows.
+    let too_long = root.join("x".repeat(400));
+
+    let (failure, _) =
+        move_file(&source, &too_long).expect_err("a 400-character name must be refused by the OS");
+
+    assert_eq!(
+        failure.code,
+        FailureCode::PathInvalid,
+        "an over-long path must name itself, not degrade to unknown; got {}: {}",
+        failure.code.as_str(),
+        failure.message
+    );
+    assert!(source.exists(), "a refused move must leave the source intact");
+}
+
+/// Case-variant destination collision, asserted against the filesystem's
+/// actual case behaviour rather than against a `cfg!(windows)` guess —
+/// macOS ships case-insensitive APFS by default but can be formatted
+/// case-sensitive, and Linux can mount case-insensitive volumes.
+///
+/// Issue #1232 predicted `destination.exists()` returns false for a
+/// case-variant on a case-insensitive filesystem; it does not — `exists()`
+/// stats through the OS, which resolves case-insensitively. This test pins
+/// that behaviour so a future change to the guard cannot silently start
+/// clobbering files.
+#[test]
+fn case_variant_destination_collision_matches_filesystem_case_behaviour() {
+    let tmp = tempfile::tempdir().unwrap();
+    let root = utf8(tmp.path());
+
+    let occupied = root.join("dest.fits");
+    std::fs::write(&occupied, b"existing").unwrap();
+    let case_insensitive = root.join("DEST.FITS").exists();
+
+    let source = write_source(&root, "source.fits");
+    let result = move_file(&source, &root.join("DEST.FITS"));
+
+    if case_insensitive {
+        let (failure, _) = result.expect_err(
+            "on a case-insensitive filesystem a case-variant destination is the same file \
+             and must be refused rather than overwritten (constitution §II)",
+        );
+        assert_eq!(failure.code, FailureCode::ConflictDestinationExists);
+        assert_eq!(
+            std::fs::read(&occupied).unwrap(),
+            b"existing",
+            "the occupying file must not be clobbered"
+        );
+    } else {
+        result.expect(
+            "on a case-sensitive filesystem DEST.FITS is a distinct path and the move is legal",
+        );
+        assert_eq!(std::fs::read(&occupied).unwrap(), b"existing");
+        assert!(root.join("DEST.FITS").exists());
+    }
+}


### PR DESCRIPTION
## Summary

- A filesystem action refused because the destination path is too long for the OS now reports `path.invalid` and says so, instead of surfacing a bare "unknown" failure that explained nothing.
- Unrecognised OS errors are now logged with their kind, so future misclassifications show up instead of being silently absorbed.
- A symlink placed inside an inbox folder no longer pulls a file from outside your library into classification.
- Adds the missing real-filesystem and Windows-junction test coverage behind these paths.

Closes #1232
Closes #1233

## #1232 — real-OS failure classification

`classify_io_error` was driven only by synthesised `io::Error` values, so a kind we classify wrongly was indistinguishable from one we classify correctly.

**Behaviour changes**

- `crates/fs/executor/src/failure.rs:181` — new arm mapping `io::ErrorKind::InvalidFilename` to `FailureCode::PathInvalid`. This is the kind `std` produces for `ENAMETOOLONG` (Unix) and for both `ERROR_INVALID_NAME` and the filename-exceeds-range error past `MAX_PATH` (Windows). Previously all of these fell through to `Unknown`, which tells a user nothing about their too-long path (constitution §II).
- `crates/fs/executor/src/failure.rs:194` — the remaining `_` fallback now logs the unrecognised `ErrorKind` and raw OS error, so production surfaces classification gaps instead of swallowing them.

**New tests** — `crates/fs/executor/tests/real_os_failures.rs`, against a real temp filesystem:

- `permission_denied_on_unwritable_destination_is_classified` — mode-`0o555` destination directory. Probes whether it can write there anyway and **skips loudly** (prints a SKIP line and returns) rather than passing vacuously, because root bypasses DAC.
- `path_too_long_is_classified_as_path_invalid_not_unknown` — 400-character destination name.
- `case_variant_destination_collision_matches_filesystem_case_behaviour` — asserts against the filesystem's *probed* case behaviour rather than a `cfg!(windows)` guess, since macOS APFS can be formatted either way.

**Correction to the issue:** #1232 states `destination.exists()` at `move_op.rs:75` "returns false for a case-variant destination on a case-insensitive filesystem". It does not — `exists()` stats through the OS, which resolves case-insensitively, so the no-overwrite guard already holds there. The new test pins that behaviour in both directions so a future change to the guard cannot silently start clobbering files. No fix was needed.

Note the path in the issue is stale: the file is `crates/fs/executor/src/ops/move_op.rs`, not `crates/fs/executor/src/move_op.rs`.

## #1233 — Windows junction handling

**New tests** — `crates/app/inbox/src/scan.rs`: `junction_subdir_not_traversed_by_default` and `junction_subdir_traversed_when_follow_symlinks_enabled`, mirroring the `mklink /J` pattern at `crates/fs/pathsafe/src/lib.rs:272` (junctions need no admin privilege). These cover both directions of the rule that was previously tested only under `cfg(unix)`.

**Behaviour change** — `crates/app/inbox/src/classify.rs:1112`: `enumerate_fits_files` walked a user-supplied folder using `is_file()`, which resolves links. A symlink planted in an inbox folder pulled an out-of-root file into classification. It now skips links and junctions via `fs_pathsafe::is_link_or_junction`, the same gate `scan.rs` uses.

### Three-walker audit

- **`crates/app/inbox/src/classify.rs`** — real gap, gated (above). It is the only one of the three that crosses into a user-supplied directory.
- **`crates/workflow/profiles/src/discover.rs:165`** — **no change, deliberate.** It walks fixed OS application directories (`/usr/share/applications`, `~/.local/share/applications`, flatpak/snap export dirs), never a user-supplied path. Those export directories are *legitimately* symlinks; gating them would break tool discovery rather than protect anything.
- **`crates/workflow/artifacts/src/reconciler.rs`** — **no change, deliberate.** `reconcile` does not walk anything itself; `read_dir_fn` is injected by the caller. It also currently has **no production caller** — it is only re-exported at `crates/workflow/artifacts/src/lib.rs:36` and exercised by its own unit tests. The gate belongs in whichever real caller eventually supplies `read_dir_fn`; adding it now would be speculative.

## Verification

Run and passing on Linux/WSL:

- `cargo test -p fs_executor` — 88 passed (incl. 3 new).
- `cargo test -p app_core_inbox` — 202 passed.
- `cargo clippy -p fs_executor --all-targets -- -D warnings` — clean.
- `cargo clippy -p app_core_inbox --all-targets -- -D warnings` — clean.

`just lint` passes (exit 0).

The `cfg(windows)` tests **cannot run on Linux and were not run locally** — no claim is made about a local Windows run. They were, however, **executed and passed on the Windows CI runner** (`Unit + integration (L1+L2) — windows-latest`, job 88335614796):

- `app_core_inbox scan::tests::junction_subdir_not_traversed_by_default` — PASS
- `app_core_inbox scan::tests::junction_subdir_traversed_when_follow_symlinks_enabled` — PASS
- `app_core_inbox classify::tests::fits_file_behind_junction_is_not_enumerated` — PASS
- `fs_executor::real_os_failures path_too_long_is_classified_as_path_invalid_not_unknown` — PASS on Windows, exercising the `MAX_PATH` path rather than `ENAMETOOLONG`
- `fs_executor::real_os_failures case_variant_destination_collision_matches_filesystem_case_behaviour` — PASS on Windows, which takes the **case-insensitive** branch that Linux ext4 cannot reach

So both branches of the case-collision test and all junction coverage are now genuinely exercised across the CI matrix. L1+L2 is green on ubuntu, macOS and Windows.

`just test` was not run locally because nine lanes share this box; the full suite runs in CI.

No SQL migration in this change.

