### PR TITLE
fix: restore the frontend test suite on macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,15 +402,23 @@ jobs:
           # Changed files under this package, rebased to package-relative paths
           # and filtered to ones that exist (a deleted file has no dependents to
           # resolve and makes `vitest related` error).
-          mapfile -t files < <(
+          #
+          # Read with `while read`, NOT `mapfile`: the macOS runner's /bin/bash
+          # is 3.2 (Apple ships no GPLv3 bash), where `mapfile` does not exist.
+          # It exits 127 and takes the whole step with it, so the frontend suite
+          # never runs on macOS at all. The existence filter is folded into the
+          # same loop rather than kept as a second pass over an intermediate
+          # array — one loop cannot disagree with itself about which files it
+          # collected.
+          existing=()
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            [ -f "$f" ] && existing+=("$f")
+          done < <(
             printf '%s' "$CHANGED_FILES" | tr ',' '\n' \
               | sed -n 's#^apps/desktop/##p' \
               | grep -E '^src/.*\.(ts|tsx)$' || true
           )
-          existing=()
-          for f in "${files[@]}"; do
-            [ -f "$f" ] && existing+=("$f")
-          done
 
           if [ ${#existing[@]} -eq 0 ]; then
             echo "No existing apps/desktop/src TS files changed -> full suite (conservative)."


### PR DESCRIPTION
## Summary

- The frontend unit-test step has been failing on every macOS CI run since
  #1212, before any test executes, so `Integration (Layer 1) — macos-latest`
  reds any PR that touches frontend files.
- Cause: #1212 used `mapfile`, a bash 4 builtin. The macOS runner's
  `/bin/bash` is 3.2 (Apple ships no GPLv3 bash), so it exits 127 and takes the
  step with it.
- Replaced with a portable `while IFS= read -r` loop.

## Why it reads as a test failure

The step is named "Frontend unit tests" and the log tail is
`grep: stdout: Broken pipe` from the orphaned process substitution — nothing
in it names bash or `mapfile` until you scroll to `exit code 127`. Anyone
triaging a red macOS job right now is likely to blame their own tests.

## Verification

Both branches exercised locally under `set -euo pipefail`:

- a mixed changed-file list (desktop TS, a Rust file, a deleted TS file)
  selects **exactly** the two existing `apps/desktop/src` TS files
- a list with no frontend files leaves the array empty and falls through to the
  full-suite branch without tripping `set -u` — the empty-array case that bites
  bash 3.2

Failure mode reproduced with `enable -n mapfile`, which prints the same
`mapfile: command not found` as the macOS runner log.

The existence filter is folded into the read loop rather than kept as a second
pass over an intermediate array, so there is no longer a way for the two to
disagree about which files were collected.

## Spec Context

Found while shepherding #1278, whose macOS job failed this way with no test of
its own at fault. Unrelated to that change; targets `main` because it blocks
every lane.

Refs #1212