### PR TITLE
fix: the macOS test job no longer dies before running a single test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,15 +402,20 @@ jobs:
           # Changed files under this package, rebased to package-relative paths
           # and filtered to ones that exist (a deleted file has no dependents to
           # resolve and makes `vitest related` error).
-          mapfile -t files < <(
+          #
+          # `while read`, not `mapfile`: mapfile is a bash 4 builtin and the
+          # macOS runner still ships bash 3.2, where this step died with
+          # `mapfile: command not found` (exit 127) before running a single
+          # test. Keep this loop portable to bash 3.2.
+          existing=()
+          while IFS= read -r f; do
+            [ -n "$f" ] || continue
+            [ -f "$f" ] && existing+=("$f")
+          done < <(
             printf '%s' "$CHANGED_FILES" | tr ',' '\n' \
               | sed -n 's#^apps/desktop/##p' \
               | grep -E '^src/.*\.(ts|tsx)$' || true
           )
-          existing=()
-          for f in "${files[@]}"; do
-            [ -f "$f" ] && existing+=("$f")
-          done
 
           if [ ${#existing[@]} -eq 0 ]; then
             echo "No existing apps/desktop/src TS files changed -> full suite (conservative)."


### PR DESCRIPTION
## Summary

- #1212 scoped the frontend suite to changed files using `mapfile`, a **bash 4 builtin**. The macOS runner still ships **bash 3.2**, so the `Frontend unit tests` step aborts there with `mapfile: command not found` and exit 127 — before a single test runs.
- Linux and Windows runners have bash 4+, so this only ever surfaces on the macOS leg, where it reads as an unrelated test failure rather than a shell error.
- Replaced with a `while IFS= read -r` loop, portable to bash 3.2, which also folds the existing-file filter into the same pass instead of building an intermediate array.

## Scope of the breakage

It is currently red on `main`. **#1278** is the confirmed case — its macOS `Integration (Layer 1)` fails on `Frontend unit tests` with exit 127.

I initially wrote that this also explained the macOS reds on #1271 and #1265; that was wrong and I checked it after the fact. #1271's macOS leg fails on `Generated contract/binding drift` — the same step as its ubuntu leg, unrelated to this — and #1265 currently has no macOS failure at all. Only the `Frontend unit tests` step is affected by this bug.

## Verification

Two-directional, by disabling the builtin (`enable -n mapfile`) to emulate bash 3.2:

| | old (`mapfile`) | new (`while read`) |
|---|---|---|
| bash 3.2 | `mapfile: command not found`, aborts | selects the changed files that exist |

Behaviour is otherwise unchanged — checked all three branches:

```
crates/foo/src/lib.rs          -> 0 files -> full-suite fallback
(empty)                        -> 0 files -> full-suite fallback
apps/desktop/src/app/…tsx      -> 1 file  -> scoped
```

So the conservative fallback that #1212 added specifically to avoid a vacuous pass still triggers in exactly the same cases.

## Note

`mapfile` was the only bash 4+ construct in `.github/workflows/` — I grepped for `readarray`, `declare -A`, and `${var^^}`/`${var,,}` case conversion as well, and there are no other occurrences.