### PR TITLE
fix: per-type cleanup actions and other saved settings no longer revert when you leave the pane

### DIFF
--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -18,7 +18,8 @@
 //!   the UI theme; the frontend still keeps a synchronous localStorage boot
 //!   cache to avoid a flash of the wrong theme, reconciled from this scope
 //!   at startup)
-//! - `"cleanup"`  → `blockPermanentDelete`, `defaultProtection`, `protectedCategories`
+//! - `"cleanup"`  → `blockPermanentDelete`, `defaultProtection`,
+//!   `protectedCategories`, `cleanupTypeOverrides`
 //! - `"naming"`   → `pattern`, `autoApplyPattern`, `patternsByType`
 //! - `"sources"`  → `followSymlinks`, `hashOnScan`
 //! - `"calibration"` → `darkMatchTolerance`, `flatMatching`, `suggestCalibration`,
@@ -31,7 +32,8 @@
 //!   `framingRotationToleranceDeg`, `framingMosaicEnvelopeFractionOfFov`
 //!   (spec 008 Q27 F-Framing-11, R11a clustering tolerance tunables)
 //! - `"catalogues"` → `enabled` (#645, default-enabled Planner catalogues)
-//! - `""` (empty) → reads the full settings bag (all known keys).
+//! - `""` (empty) → reads the full settings bag (every descriptor key, derived
+//!   from the descriptor table so it cannot drift, plus `enabled`).
 //!
 //! Unknown `values` keys from the frontend that are not valid settings keys are
 //! silently skipped (best-effort write) so fixture-driven panes can call
@@ -45,6 +47,7 @@
 //! - `settings.source-override.set`
 
 use std::collections::HashMap;
+use std::sync::LazyLock;
 
 use contracts_core::settings::{
     RestoreDefaultsRequest, RestoreDefaultsResponse, SetSourceOverrideRequest,
@@ -65,7 +68,12 @@ fn scope_keys(scope: &str) -> &'static [&'static str] {
     match scope {
         "advanced" => &["logLevel", "rememberFollowLogs", "devMode"],
         "general" => &["theme"],
-        "cleanup" => &["blockPermanentDelete", "defaultProtection", "protectedCategories"],
+        "cleanup" => &[
+            "blockPermanentDelete",
+            "defaultProtection",
+            "protectedCategories",
+            "cleanupTypeOverrides",
+        ],
         "naming" => &["pattern", "autoApplyPattern", "patternsByType"],
         "sources" => &["followSymlinks", "hashOnScan", "alwaysPreviewBeforePlan"],
         "calibration" => &[
@@ -98,45 +106,23 @@ fn scope_keys(scope: &str) -> &'static [&'static str] {
             "framingMosaicEnvelopeFractionOfFov",
         ],
         // Empty scope or "global" returns every stable key.
-        _ => &[
-            "logLevel",
-            "rememberFollowLogs",
-            "devMode",
-            "blockPermanentDelete",
-            "defaultProtection",
-            "protectedCategories",
-            "pattern",
-            "autoApplyPattern",
-            "patternsByType",
-            "followSymlinks",
-            "hashOnScan",
-            "alwaysPreviewBeforePlan",
-            "darkMatchTolerance",
-            "flatMatching",
-            "suggestCalibration",
-            "calibrationDarkTempTolerance",
-            "calibrationPrefillSuggestion",
-            "calibrationDarkOverridePenalty",
-            "calibrationFlatOverridePenalty",
-            "calibrationBiasOverridePenalty",
-            "calibrationAgingThresholdDays",
-            "currentLibraryId",
-            "sourceViewLinkKindIntraDrive",
-            "sourceViewLinkKindCrossDrive",
-            "observingSites",
-            "observingDefaultSiteId",
-            "observingActiveSiteId",
-            "usableAltitudeDeg",
-            "plannerMoonAvoidance",
-            "enabled",
-            "theme",
-            "framingPointingFractionOfFov",
-            "framingPointingFallbackDeg",
-            "framingRotationToleranceDeg",
-            "framingMosaicEnvelopeFractionOfFov",
-        ],
+        _ => &ALL_KEYS,
     }
 }
+
+/// Every key the catch-all scope resolves: the descriptor table plus the
+/// structured-path keys that have no descriptor.
+///
+/// Derived rather than hand-listed because the hand-maintained list drifted
+/// from the descriptor table and left four writable keys permanently
+/// unreadable (#641).
+static ALL_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
+    let mut keys = app_core::settings::stable_keys();
+    // `enabled` (#645) is validated via `is_catalogues_enabled_key`, not a
+    // descriptor, so it is not covered by `stable_keys()`.
+    keys.push("enabled");
+    keys
+});
 
 // ── Stable transport commands ────────────────────────────────────────────────
 
@@ -264,4 +250,54 @@ pub async fn settings_overridable_keys(
     _state: State<'_, AppState>,
 ) -> Result<Vec<String>, ContractError> {
     Ok(app_core::settings::overridable_keys())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A writable key that no scope resolves is silently unreadable: the write
+    /// succeeds, the pane re-reads defaults, and the user's choice vanishes
+    /// with no error (#641).
+    #[test]
+    fn every_descriptor_key_is_reachable_via_the_catch_all_scope() {
+        let reachable = scope_keys("");
+        let missing: Vec<_> = app_core::settings::stable_keys()
+            .into_iter()
+            .filter(|k| !reachable.contains(k))
+            .collect();
+        assert!(missing.is_empty(), "keys writable but unreadable via settings_get(''): {missing:?}");
+    }
+
+    #[test]
+    fn cleanup_scope_resolves_the_per_type_action_overrides() {
+        assert!(scope_keys("cleanup").contains(&"cleanupTypeOverrides"));
+    }
+
+    /// Guards the other direction: a typo or a key deleted from the descriptor
+    /// table leaves a scope entry that `settings_update` would reject.
+    #[test]
+    fn every_scope_key_is_a_valid_settings_key() {
+        for scope in [
+            "advanced",
+            "general",
+            "cleanup",
+            "naming",
+            "sources",
+            "calibration",
+            "sourceViews",
+            "observing",
+            "planner",
+            "catalogues",
+            "framing",
+            "",
+        ] {
+            for key in scope_keys(scope) {
+                assert!(
+                    app_core::settings::is_valid_key(key),
+                    "scope {scope:?} lists unknown key {key:?}"
+                );
+            }
+        }
+    }
 }

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -266,7 +266,10 @@ mod tests {
             .into_iter()
             .filter(|k| !reachable.contains(k))
             .collect();
-        assert!(missing.is_empty(), "keys writable but unreadable via settings_get(''): {missing:?}");
+        assert!(
+            missing.is_empty(),
+            "keys writable but unreadable via settings_get(''): {missing:?}"
+        );
     }
 
     #[test]

--- a/crates/app/settings/src/keys.rs
+++ b/crates/app/settings/src/keys.rs
@@ -93,6 +93,17 @@ pub(super) fn is_catalogues_enabled_key(key: &str) -> bool {
     key == "enabled"
 }
 
+/// Return the names of every stable v1 settings key, in declaration order.
+///
+/// Exposed so callers that must enumerate the whole settings surface (the
+/// `settings.get` catch-all scope) derive it from the descriptor table instead
+/// of maintaining a parallel list that silently drifts when a descriptor is
+/// added (#641).
+#[must_use]
+pub fn stable_keys() -> Vec<&'static str> {
+    descriptors::all_keys().collect()
+}
+
 /// Return the names of all stable settings keys that can be overridden per source root.
 ///
 /// Used by the `settings.overridable-keys` command (spec 018 T025) to provide the

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -87,7 +87,7 @@ mod writes;
 #[cfg(test)]
 mod tests;
 
-pub use keys::{is_global_protection_default_key, is_valid_key, overridable_keys};
+pub use keys::{is_global_protection_default_key, is_valid_key, overridable_keys, stable_keys};
 pub use read::get_settings;
 pub use validation::{settings_value_eq, validate_value};
 pub use writes::{


### PR DESCRIPTION
## Summary

- Setting a per-type cleanup action (e.g. "Raw light frames" to Archive) saved to the database but could never be read back, so the choice silently reverted every time you left and re-entered the Cleanup pane, and on every relaunch.
- The same defect silently affected three other saved settings: custom IMAGETYP mappings, tool watch extensions, and the tool attribution window.
- The read path is now derived from the settings registry, so a saved setting can no longer become unreadable.

Closes #641

## Problem

`cleanupTypeOverrides` is a valid, validated descriptor key (`crates/app/settings/src/descriptors.rs:548`) and `settings_update` persists it, but `scope_keys()` never returned it, so `settings_get("cleanup")` could not read it back. The Cleanup pane re-rendered fixture defaults on every re-entry and the users per-type action choice vanished with no error.

## Other keys were affected too

The catch-all scope list was hand-maintained alongside the descriptor table and had drifted in four places, not one. These keys were writable but permanently unreadable via `settings_get("")`:

- `cleanupTypeOverrides` (#641)
- `imagetypNormalizationUserMappings`
- `toolWatchExtensions`
- `toolAttributionWindowHours`

## Fix

Rather than adding a fifth hand-maintained entry, the catch-all is now derived from the descriptor table via a new `app_core::settings::stable_keys()` (`crates/app/settings/src/keys.rs`), so a new descriptor is reachable by construction and this class of drift cannot recur. `enabled` (#645) is appended explicitly because it is validated via `is_catalogues_enabled_key` and has no descriptor.

The named `"cleanup"` scope gains `cleanupTypeOverrides` — the named scopes stay hand-maintained on purpose, since scope membership is a product grouping, not derivable (e.g. `currentLibraryId` legitimately belongs to no pane).

## Regression test

`apps/desktop/src-tauri/src/commands/settings.rs` gains three tests. Verified failing before and passing after by temporarily reverting only the fix:

```
cargo test -j 4 -p desktop_shell --lib commands::settings
```

Before (fix reverted, tests kept):
```
test commands::settings::tests::cleanup_scope_resolves_the_per_type_action_overrides ... FAILED
test commands::settings::tests::every_descriptor_key_is_reachable_via_the_catch_all_scope ... FAILED
keys writable but unreadable via settings_get(1): ["imagetypNormalizationUserMappings", "toolWatchExtensions", "toolAttributionWindowHours", "cleanupTypeOverrides"]
test result: FAILED. 1 passed; 2 failed
```

After: `3 passed`.

## Gates

- `just lint` — green
- `cargo clippy -p app_core_settings -p desktop_shell --all-targets -- -D warnings` — clean
- `cargo test -p app_core_settings` — 209 passed
- `cargo test -p desktop_shell` — 73 passed

Full suite runs in CI (the local full `just test` was skipped deliberately; nine lanes run concurrently on this box).

No migration and no persistence change — this is a read-path omission only.

## Notes for the merger

- Overlaps PR #1048, which also edits `scope_keys()` (it removes the `"plans"` scope and a `plansListDefaultAgeCutoffDays` catch-all entry, from a stale base). Expect a textual conflict on the catch-all hunk. Resolution is straightforward: the derived list replaces theirs, and once their descriptor removal lands the key drops out of the derived list automatically.
- UI follow-up (owned by the frontend lane, NOT in this PR): `Cleanup.tsx` must actually consume `values.cleanupTypeOverrides` on mount instead of falling back to `defaultActions()`. This backend fix makes the value readable; it does not change the pane.
- Strong candidate for Windows real-app verification: set a protected category to Archive, switch panes, return, and confirm the row and the danger banner survive, then confirm they survive a relaunch.
