### PR TITLE
fix: keep the inbox target-missing check consistent everywhere it's shown

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -740,6 +740,26 @@ pub fn mandatory_set_for(ft: FrameType) -> Vec<&'static str> {
     out
 }
 
+/// Whether the `target` hard-mandatory key (R-14) counts as absent.
+///
+/// Single shared formula for the `target` arm of both mandatory-attribute
+/// gates — [`check_mandatory_missing`] here and
+/// [`crate::metadata::compute_missing_mandatory`] — so the two consumers
+/// agree on "target missing" **by construction**, not because every caller
+/// happens to pass the same `target_resolved` constant (issue #1132).
+///
+/// Satisfied by an explicit target resolution (`target_resolved`: coordinate
+/// auto-resolution or a user pick, R-17) **or** a non-empty (trimmed) `OBJECT`
+/// header/override. Every current call site pins `target_resolved` to
+/// `false` — R-17's coordinate resolver (`target_recommendations`,
+/// `cone_search`) is implemented and reachable from the UI, but nothing yet
+/// threads a resolved-target signal back into this gate; that wiring is the
+/// open product decision tracked in #1132.
+#[must_use]
+pub fn target_missing(object: Option<&str>, target_resolved: bool) -> bool {
+    !target_resolved && object.map_or("", str::trim).is_empty()
+}
+
 /// Check which mandatory attributes are absent for a classified file.
 ///
 /// `raw_meta` is `None` when FITS extraction failed entirely (→ all mandatory
@@ -759,11 +779,7 @@ pub fn check_mandatory_missing(
 
     for key in mandatory {
         let absent = match key {
-            "target" => {
-                // light-only: satisfied by coordinate resolution or user pick.
-                !target_resolved
-                    && raw_meta.and_then(|m| m.object.as_deref()).map_or("", str::trim).is_empty()
-            }
+            "target" => target_missing(raw_meta.and_then(|m| m.object.as_deref()), target_resolved),
             "filter" => raw_meta.and_then(|m| m.filter.as_deref()).map_or("", str::trim).is_empty(),
             "exposureS" => !raw_meta
                 .and_then(|m| m.exposure.as_deref())
@@ -2795,6 +2811,29 @@ mod tests {
         let set = mandatory_set_for(FrameType::Flat);
         assert!(set.contains(&"filter"), "flat must require filter");
         assert!(!set.contains(&"gain"), "flat must NOT require gain by default");
+    }
+
+    /// Issue #1132: `target_missing` is the single formula both mandatory
+    /// gates share for the `target` key (R-14/R-17). Pins the semantics:
+    /// resolution (coordinate or user pick) OR a non-empty, trimmed OBJECT
+    /// satisfies the requirement; neither does not.
+    #[test]
+    fn target_missing_r17_semantics() {
+        assert!(target_missing(None, false), "unresolved + no OBJECT is missing");
+        assert!(target_missing(Some(""), false), "unresolved + empty OBJECT is missing");
+        assert!(
+            target_missing(Some("   "), false),
+            "unresolved + whitespace-only OBJECT is missing"
+        );
+        assert!(
+            !target_missing(Some("M 42"), false),
+            "unresolved + non-empty OBJECT is not missing"
+        );
+        // R-17: coordinate/user resolution alone satisfies the requirement, even
+        // with no OBJECT header at all — the case #1131's equivalence test
+        // cannot exercise and #1132 flags as currently unreachable in production.
+        assert!(!target_missing(None, true), "resolved + no OBJECT is not missing");
+        assert!(!target_missing(Some(""), true), "resolved + empty OBJECT is not missing");
     }
 
     /// T070: check_mandatory_missing correctly flags absent attributes.

--- a/crates/app/inbox/src/metadata.rs
+++ b/crates/app/inbox/src/metadata.rs
@@ -151,7 +151,13 @@ pub async fn get_inbox_item_metadata(
         // T070 / FR-047: surface the mandatory-attribute gate per file so the UI
         // can prompt the user before the needs-review bucket blocks confirm.
         // Uses the same DTO values (override-applied) as missing_path_attributes.
-        entry.missing_mandatory = compute_missing_mandatory(&entry);
+        //
+        // `target_resolved` is pinned to `false` for the same reason as
+        // `classify::missing_mandatory_for_file`: nothing threads a resolved-target
+        // signal into this read path yet (#1132) — the parameter exists so the
+        // formula agrees with `check_mandatory_missing` by construction, not so a
+        // real value flows in today.
+        entry.missing_mandatory = compute_missing_mandatory(&entry, false);
 
         files.push(entry);
     }
@@ -169,7 +175,11 @@ pub async fn get_inbox_item_metadata(
 /// The mandatory set itself comes from [`crate::classify::mandatory_set_for`]
 /// (R-14) — the single definition this and the classify-time gate both read, so
 /// the list shown to the user cannot drift from the list promotion is gated on.
-fn compute_missing_mandatory(m: &InboxFileMetadata) -> Vec<String> {
+/// Likewise the `target` key's absence formula comes from
+/// [`crate::classify::target_missing`] (#1132) rather than a hand-copied
+/// duplicate, so this gate and [`crate::classify::check_mandatory_missing`]
+/// cannot silently diverge on what "target missing" means.
+fn compute_missing_mandatory(m: &InboxFileMetadata, target_resolved: bool) -> Vec<String> {
     let Some(ft_str) = m.frame_type_effective.as_deref() else {
         // Unclassified files are implicitly needs-review; frameType is the gate.
         return vec!["frameType".to_owned()];
@@ -181,10 +191,7 @@ fn compute_missing_mandatory(m: &InboxFileMetadata) -> Vec<String> {
     let mut missing = Vec::new();
     for key in crate::classify::mandatory_set_for(ft) {
         let absent = match key {
-            "target" => {
-                // light: satisfied by OBJECT header (proxy for coord resolution).
-                m.object.as_deref().map_or("", str::trim).is_empty()
-            }
+            "target" => crate::classify::target_missing(m.object.as_deref(), target_resolved),
             "filter" => m.filter.as_deref().map_or("", str::trim).is_empty(),
             "exposureS" => !m.exposure_s.is_some_and(|v| v > 0.0),
             "gain" => m.gain.as_deref().map_or("", str::trim).is_empty(),
@@ -308,15 +315,61 @@ mod tests {
             let gate = crate::classify::check_mandatory_missing(ft, None, false);
             assert_eq!(gate, expected, "classify gate for {ft} diverged from mandatory_set_for");
 
-            let shown = compute_missing_mandatory(&InboxFileMetadata {
-                frame_type_effective: Some(ft.as_str().to_owned()),
-                ..Default::default()
-            });
+            let shown = compute_missing_mandatory(
+                &InboxFileMetadata {
+                    frame_type_effective: Some(ft.as_str().to_owned()),
+                    ..Default::default()
+                },
+                false,
+            );
             assert_eq!(
                 shown, expected,
                 "metadata missing_mandatory for {ft} diverged from mandatory_set_for"
             );
         }
+    }
+
+    /// Issue #1132: the `target` arm specifically must agree between the two
+    /// gates for the coordinate-resolved-but-no-`OBJECT` case, not just the
+    /// all-attributes-absent case above (which both branches satisfy trivially
+    /// since `target_resolved` is fixed at `false` on both sides). This is
+    /// constructible today only because both gates now delegate to the shared
+    /// [`crate::classify::target_missing`] predicate and expose the same
+    /// `target_resolved` knob — no production caller supplies `true` yet
+    /// (that wiring is the open R-17 product decision), but the formula
+    /// itself is proven identical.
+    #[test]
+    fn target_missing_agrees_between_classify_and_metadata_for_resolved_no_object() {
+        use metadata_core::{FrameType, RawFileMetadata};
+
+        // Coordinate-resolved (or user-picked), but no OBJECT header at all.
+        let raw = RawFileMetadata { object: None, ..Default::default() };
+        let gate = crate::classify::check_mandatory_missing(FrameType::Light, Some(&raw), true);
+        assert!(!gate.contains(&"target".to_owned()), "classify gate: {gate:?}");
+
+        let shown = compute_missing_mandatory(
+            &InboxFileMetadata {
+                frame_type_effective: Some(FrameType::Light.as_str().to_owned()),
+                object: None,
+                ..Default::default()
+            },
+            true,
+        );
+        assert!(!shown.contains(&"target".to_owned()), "metadata gate: {shown:?}");
+
+        // Unresolved + no OBJECT: both still flag target missing.
+        let gate_unresolved =
+            crate::classify::check_mandatory_missing(FrameType::Light, Some(&raw), false);
+        assert!(gate_unresolved.contains(&"target".to_owned()));
+        let shown_unresolved = compute_missing_mandatory(
+            &InboxFileMetadata {
+                frame_type_effective: Some(FrameType::Light.as_str().to_owned()),
+                object: None,
+                ..Default::default()
+            },
+            false,
+        );
+        assert!(shown_unresolved.contains(&"target".to_owned()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- Two internal checks decide whether a light frame counts as missing its
  target: one gates when a plan can be created, the other is what the
  Inbox UI shows the user. They were hand-copied and only stayed in sync
  because every current code path happens to pass the same value into
  both. This change makes them share a single definition so they cannot
  silently drift apart as new target-resolution features (e.g.
  coordinate-based target search) are built out.
- No user-visible behavior changes today — this closes a latent gap
  before it can cause the Inbox to show "target missing" for a frame
  that would actually be allowed to proceed (or vice versa).

## Spec Context

Closes #1132.

Root-cause finding: R-17 (coordinate-based target resolution) is real,
implemented, and reachable from the UI (`inbox.target_recommendations`,
`target.cone_search.suggest`/`.confirm`) — not abandoned. It has a
remaining integration gap (a confirmed coordinate match isn't yet fed
back into either mandatory-attribute check); filed separately as #1294
so it doesn't evaporate when this PR merges. Wiring a real
`target_resolved` value is a product decision on how/whether to wire,
and is intentionally NOT made in this PR.

Regression test added: `target_missing_r17_semantics` and
`target_missing_agrees_between_classify_and_metadata_for_resolved_no_object`
in `crates/app/inbox/src/classify.rs` / `metadata.rs`. Verified fail
(compile error) before the shared-predicate fix, pass (203/203) after.

Gates, run for real in this worktree after `pnpm install` (not
`CI=true`, which only installs what's already in the lockfile):
- `cargo test -j 4 -p app_core_inbox`: 203 passed.
- `cargo clippy -p app_core_inbox --all-targets -- -D warnings`: clean.
- `just lint`: **passes in full**, including `cargo fmt --all --check`,
  `cargo clippy --workspace --all-targets -- -D warnings`, the
  `apps/desktop` biome/eslint-baseline/token/i18n-catalog checks, and
  `pre-commit run --all-files`. (An earlier run in this same worktree,
  before `node_modules` was installed, wrongly reported this as a
  pre-existing environment gap — it was not; re-run for real above.)

No SQL migration in this change.