### PR TITLE
fix: inbox file details no longer double-count already-extracted calibration masters

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -222,6 +222,19 @@ pub async fn classify(
                 (None, EvidenceSource::None, None, true, false, None)
             };
 
+        // #549: a detected calibration master is extracted into its own
+        // `inbox_items` row at scan time (`persist_master_item`), but the
+        // file is never moved off disk, so a folder-PLACEHOLDER classify run
+        // still walks it here. Without this guard the master was tallied a
+        // second time into the placeholder's evidence/breakdown/file_count —
+        // the placeholder must represent only the un-extracted remainder.
+        // Only skip when classifying the placeholder itself: a master's own
+        // classify call (`item.is_master_item != 0`) has exactly this one
+        // file and must still record it.
+        if is_master && item.is_master_item == 0 {
+            continue;
+        }
+
         // Persist evidence
         let ev_id = Uuid::new_v4().to_string();
         let ev = InsertEvidence {
@@ -454,12 +467,16 @@ pub async fn classify(
     };
     repo::upsert_classification(pool, &classification).await.ok();
 
-    // 9. Update item state and signature
+    // 9. Update item state and signature.
+    // #549: `file_records.len()` (not `file_paths.len()`) — extracted-master
+    // files were filtered out of `file_records` above, so this is the
+    // un-extracted remainder the placeholder is meant to represent, matching
+    // the count `persist_folder_placeholder` (inbox.rs) writes at scan time.
     repo::update_inbox_item_scan(
         pool,
         &req.inbox_item_id,
         &content_signature,
-        i64::try_from(file_paths.len()).unwrap_or(i64::MAX),
+        i64::try_from(file_records.len()).unwrap_or(i64::MAX),
     )
     .await
     .ok();
@@ -1403,6 +1420,64 @@ mod tests {
         assert_eq!(resp.classification_type, "mixed");
         assert!(resp.frame_type.is_none());
         assert_eq!(resp.breakdown.len(), 2);
+    }
+
+    /// Regression (#549): a detected calibration master is extracted into its
+    /// own `inbox_items` row at scan time, but the file itself is never moved
+    /// off disk. Classifying the folder PLACEHOLDER (this item, is_master_item
+    /// = 0) must not re-tally that master into the breakdown or file_count —
+    /// the placeholder represents only the un-extracted remainder. Before the
+    /// fix `classify` walked every FITS/XISF file still in the folder, so a
+    /// folder of 2 un-extracted lights + 1 already-extracted master dark
+    /// reported "mixed"/3 files instead of "single_type light"/2 files.
+    #[tokio::test]
+    async fn classify_excludes_already_extracted_master_from_placeholder_tally() {
+        let tmp = tempfile::tempdir().unwrap();
+        write_fits_with_imagetyp(tmp.path(), "light_001.fits", "Light Frame");
+        write_fits_with_imagetyp(tmp.path(), "light_002.fits", "Light Frame");
+        write_fits_with_imagetyp(tmp.path(), "master_dark.fits", "Master Dark");
+
+        let db = test_db().await;
+        let item_id = "item-classify-placeholder-with-master";
+        repo::insert_inbox_item(
+            db.pool(),
+            &InsertInboxItem {
+                id: item_id,
+                root_id: "root-1",
+                relative_path: "",
+                file_count: 0,
+                content_signature: None,
+                lane: "fits",
+            },
+        )
+        .await
+        .unwrap();
+
+        let req = ClassifyRequest {
+            inbox_item_id: item_id.to_owned(),
+            root_absolute_path: tmp.path().to_owned(),
+            force_rescan: false,
+        };
+
+        let resp = classify(db.pool(), req).await.unwrap();
+
+        assert_eq!(
+            resp.classification_type, "single_type",
+            "the master must not turn this into a mixed folder: {:?}",
+            resp.breakdown
+        );
+        assert_eq!(resp.breakdown.len(), 1);
+        assert_eq!(resp.breakdown[0].kind, "light");
+        assert_eq!(
+            resp.breakdown[0].count, 2,
+            "breakdown must not double-count the already-extracted master (#549)"
+        );
+
+        let item = repo::get_inbox_item(db.pool(), item_id).await.unwrap();
+        assert_eq!(
+            item.file_count, 2,
+            "placeholder file_count must be the un-extracted remainder (#549), not the full folder"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- Opening a scanned inbox folder that had already had a calibration master pulled out of it (its own row) could show an inflated, wrong file count and a wrong mixed/single-type badge in the folder's details — the extracted master was silently counted a second time on top of the files still waiting to be classified.
- The status-bar "unacknowledged" badge over-counting a split folder (#1090) was already fixed on `main` prior to this PR; this PR references it only so the tracking issue gets closed.

## Details (for reviewers)

**#549 root cause**: `classify()` (`crates/app/inbox/src/classify.rs`) re-enumerates every FITS/XISF file still on disk when classifying a folder's placeholder item. A detected calibration master is extracted into its own `inbox_items` row at scan time but the file itself is never moved off disk, so the placeholder's classify run walked it too — re-tallying it into the breakdown and overwriting `file_count` with the inflated total. A folder of 2 un-extracted lights + 1 already-extracted master dark reported `"mixed"` with 3 files instead of `"single_type"` with 2 (at the scale reported in the issue: 20 instead of 5).

Same *class* of bug as #513 (scanned-folder count vs. detected-types mismatch), different mechanism: #513 was the setup-wizard scan preview silently dropping masters/unclassified from the type tally while the total stayed correct; here the Inbox `classify()` breakdown/`file_count` instead **includes** files already accounted for elsewhere.

Authoritative value: the scan-time placeholder `file_count` (`persist_folder_placeholder`, `apps/desktop/src-tauri/src/commands/inbox.rs:362-373`, un-extracted remainder = total − masters) was already correct. The detail pane's inflated count came from `classify()`'s breakdown recompute.

**Fix**: skip a file from `file_records` (feeds breakdown, `unclassified_files`, `materialize_sub_items`) when it's a detected master and the item being classified is the placeholder itself (`item.is_master_item == 0`); a master's own classify call is unaffected. `update_inbox_item_scan` now writes the filtered `file_records.len()` instead of the raw enumerated count. No UI change needed — `InboxDetail.tsx`'s "Files:" value is already derived from `breakdown` + `unclassifiedFiles` (its own `#653` comment), so it now reflects the corrected backend numbers automatically.

**#1090**: `count_unacknowledged_inbox_items` (`crates/persistence/db/src/repositories/q_desktop.rs:171-179`) already carries `exclude_split_placeholder!` on `main` (commit 77b42d17 / PR #1092), with its own regression test passing today. No code change added here.

**Regression test**: `classify_excludes_already_extracted_master_from_placeholder_tally`. Before (fix reverted, evidence captured, then restored): fails with `left: "mixed" right: "single_type"` and a breakdown showing `dark: 1, light: 2` — reproduces the reported shape. After: passes.

**Gates** (all run in a fresh worktree after `pnpm install` — not `CI=true`, which would have masked a real dependency gap):
- `just lint` — full pass: `cargo fmt --check` clean, `rustfmt --check` on `specta.rs` clean, `cargo clippy --workspace --all-targets -- -D warnings` clean, `pnpm -r lint` (biome: 72 pre-existing warnings/0 errors in files this PR does not touch, e.g. `grouping.test.ts`; eslint baseline OK; token policy OK; i18n catalog OK), pre-commit hooks all passed.
- `cargo clippy -p app_core_inbox --all-targets -- -D warnings` — clean.
- `cargo test -j 4 -p app_core_inbox` — 202 passed. (One transient flake seen once in an earlier run on an unrelated timing test, `plan_listener::tests::failed_plan_transitions_back_to_classified` — passes reliably in isolation and on a clean full-suite re-run; not touched by this change.)
- No persistence-crate files touched by this fix, so `just db-boundary` is not applicable here; not run.
- Full `just test` intentionally not run (nine concurrent lanes OOM the box per prior campaign notes) — CI runs the full suite.

## Overlap with PR #1194 (spec 058, `spec/058-inbox-drop-parent-items`)

Real structural overlap, flagged for the merge coordinator:

- #1194 removes the scan-time folder placeholder item entirely and migrates `file_count` onto `inbox_source_groups` (migration `0075_source_group_file_count.sql`). That is a different mechanism for a future state, not a duplicate of this fix's target.
- #1194's diff to `crates/app/inbox/src/classify.rs` is a substantial rewrite of the exact function this fix touches (extracts `classify_one_file()`/`build_file_records()`/`FileClassification`, adds a parallel `classify_source_group()` entry point). Their `FileClassification` carries an `is_master` field but it is not used anywhere in their diff to exclude already-extracted masters from `file_records`/breakdown — so #1194 does not independently fix #549, and whichever PR merges second will need real reconciliation, not a mechanical rebase. Recommend porting the same `is_master` exclusion into `build_file_records`/`classify_source_group` once #1194 lands, since a bare source group can also have already-extracted masters sitting next to it on disk.

Closes #1090
Closes #549