### PR TITLE
fix: calibration master assignments are recorded in the audit log

### DIFF
--- a/crates/app/calibration/src/audit_ids.rs
+++ b/crates/app/calibration/src/audit_ids.rs
@@ -1,0 +1,53 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared derivation of audit `entity_id`s for this crate's write paths.
+//!
+//! Mirrors `app_core::audit_ids`, which this crate cannot reuse: `app_core`
+//! re-exports `app_calibration`, so the dependency edge only runs one way.
+
+use domain_core::ids::EntityId;
+
+/// Audit `entity_id` for `id` under `namespace` (a fixed per-call-site tag,
+/// e.g. `"equipment"`).
+///
+/// Parses `id` as a real UUID when possible — every persisted equipment item
+/// and calibration assignment id is one — and otherwise derives a stable
+/// UUIDv5, so audit rows for entities that have no id yet (a failed `create`,
+/// keyed on the attempted name) still correlate across repeated attempts.
+///
+/// The `astro-plan.audit.{namespace}` seed is load-bearing: changing it
+/// re-keys every already-written audit row's `entity_id`.
+pub(crate) fn audit_entity_id(namespace: &str, id: &str) -> EntityId {
+    uuid::Uuid::parse_str(id).map_or_else(
+        |_| {
+            let ns = uuid::Uuid::new_v5(
+                &uuid::Uuid::NAMESPACE_DNS,
+                format!("astro-plan.audit.{namespace}").as_bytes(),
+            );
+            EntityId::from_uuid(uuid::Uuid::new_v5(&ns, id.as_bytes()))
+        },
+        EntityId::from_uuid,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::audit_entity_id;
+
+    /// The pre-extraction `equipment_entity_id` hard-coded this namespace seed
+    /// as a byte literal; audit rows written under it must keep resolving to
+    /// the same `entity_id`.
+    #[test]
+    fn equipment_namespace_matches_the_pre_extraction_byte_seed() {
+        let ns = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_DNS, b"astro-plan.audit.equipment");
+        let expected = uuid::Uuid::new_v5(&ns, b"ASI2600MM");
+        assert_eq!(audit_entity_id("equipment", "ASI2600MM").as_uuid(), expected);
+    }
+
+    #[test]
+    fn a_uuid_id_is_used_verbatim() {
+        let id = uuid::Uuid::new_v4();
+        assert_eq!(audit_entity_id("calibration.assignment", &id.to_string()).as_uuid(), id);
+    }
+}

--- a/crates/app/calibration/src/equipment.rs
+++ b/crates/app/calibration/src/equipment.rs
@@ -22,6 +22,8 @@ use persistence_db::repositories::equipment as repo;
 use persistence_db::repositories::q_calibration;
 use sqlx::SqlitePool;
 
+use crate::audit_ids::audit_entity_id;
+
 // ── Error mapping ──────────────────────────────────────────────────────────
 
 fn db_to_contract(e: persistence_db::DbError) -> ContractError {
@@ -43,19 +45,8 @@ fn error_code_str(code: ErrorCode) -> String {
         .map_or_else(|_| "internal.error".to_owned(), |s| s.trim_matches('"').to_owned())
 }
 
-/// Deterministic `entity_id` for an equipment audit row: parses `id` as a
-/// real UUID when possible (every persisted camera/telescope/train/filter id
-/// is one), falling back to a stable UUIDv5 derivation for attempted-but-not-
-/// yet-created items (e.g. a failed `create` has no id) so repeated attempts
-/// with the same name still correlate under one `entity_id`.
 fn equipment_entity_id(id: &str) -> EntityId {
-    uuid::Uuid::parse_str(id).map_or_else(
-        |_| {
-            let ns = uuid::Uuid::new_v5(&uuid::Uuid::NAMESPACE_DNS, b"astro-plan.audit.equipment");
-            EntityId::from_uuid(uuid::Uuid::new_v5(&ns, id.as_bytes()))
-        },
-        EntityId::from_uuid,
-    )
+    audit_entity_id("equipment", id)
 }
 
 /// Write a durable audit row for an equipment CRUD attempt (T124,

--- a/crates/app/calibration/src/lib.rs
+++ b/crates/app/calibration/src/lib.rs
@@ -14,6 +14,8 @@
 /// snapshots (in-memory caching layer, F0 foundation). See each accessor's
 /// doc comment for its owning write-site invalidation calls.
 pub mod caches;
+
+mod audit_ids;
 pub mod equipment;
 mod matching;
 mod tolerances;

--- a/crates/app/calibration/src/matching/assign.rs
+++ b/crates/app/calibration/src/matching/assign.rs
@@ -6,6 +6,7 @@
 
 use audit::bus::EventBus;
 use audit::event_bus::Source;
+use audit::{AuditLogEntry, Outcome, Severity};
 use calibration_core::assign::{dimension_names, evaluate_assign, AssignError};
 use contracts_core::calibration_match::{
     contract_to_kind, kind_to_contract, AssignedDto, CalibrationMatchAssignRequest,
@@ -13,13 +14,50 @@ use contracts_core::calibration_match::{
     CalibrationMatchUnassignResponse, UnassignErrorDto, ASSIGN_CONTRACT_VERSION,
     UNASSIGN_CONTRACT_VERSION,
 };
-use domain_core::ids::Timestamp;
+use domain_core::ids::{EntityId, Timestamp};
+use domain_core::lifecycle::data_asset::EntityType;
 use persistence_db::repositories::calibration_assignment::{self as assign_repo, UpsertParams};
 use sqlx::SqlitePool;
 use uuid::Uuid;
 
 use super::loaders::{load_config, load_master_by_id, load_session};
 use super::responses::error_assign_response;
+use crate::audit_ids::audit_entity_id;
+
+/// Record an assignment mutation in the authoritative audit log, then emit it
+/// on the live bus.
+///
+/// #1120: `assign`/`unassign` previously recorded only a `bus.publish`, whose
+/// `events` row `crates/audit/src/bus.rs` documents as non-authoritative
+/// transient diagnostics — so assignment history was absent from the
+/// FR-131/T121 durable record. `topic` and `payload` stay byte-identical to
+/// that pre-#1120 publish, leaving live subscribers unaffected; `topic`
+/// doubles as the audit `trigger` (the `protection.source.set` precedent).
+///
+/// # Errors
+/// Returns `Err` if the durable `audit_log_entry` insert fails — constitution
+/// §II makes that row load-bearing, so the caller's command must fail with it.
+/// A bus-emit failure is swallowed inside `write_audit`.
+async fn write_assignment_audit(
+    bus: &EventBus,
+    topic: &str,
+    assignment_id: &str,
+    payload: serde_json::Value,
+) -> Result<(), String> {
+    let entry = AuditLogEntry::new(
+        EntityType::Calibration,
+        audit_entity_id("calibration.assignment", assignment_id),
+        topic,
+        "user",
+        Outcome::Applied,
+        Severity::Workflow,
+        EntityId::new(),
+    )
+    .with_payload(payload.clone());
+
+    bus.write_audit(entry, topic, Source::User, payload).await.map_err(|e| e.to_string())?;
+    Ok(())
+}
 
 /// `calibration.match.assign` — persist a calibration master assignment.
 ///
@@ -104,22 +142,22 @@ pub async fn assign(
             .await
             .map_err(|e| e.to_string())?;
 
-            // Emit audit event (T030).
-            let _ = bus
-                .publish(
-                    "calibration.assignment.created",
-                    Source::User,
-                    serde_json::json!({
-                        "assignmentId": assignment_id,
-                        "sessionId": req.session_id,
-                        "masterId": req.master_id,
-                        "calibrationType": master.kind.as_str(),
-                        "confidence": decision.confidence,
-                        "wasOverride": decision.was_override,
-                        "mismatchedDimensions": mismatch_names,
-                    }),
-                )
-                .await;
+            // Durable audit row + live event (T030, #1120).
+            write_assignment_audit(
+                bus,
+                "calibration.assignment.created",
+                &assignment_id,
+                serde_json::json!({
+                    "assignmentId": assignment_id,
+                    "sessionId": req.session_id,
+                    "masterId": req.master_id,
+                    "calibrationType": master.kind.as_str(),
+                    "confidence": decision.confidence,
+                    "wasOverride": decision.was_override,
+                    "mismatchedDimensions": mismatch_names,
+                }),
+            )
+            .await?;
 
             Ok(CalibrationMatchAssignResponse {
                 status: "success".to_owned(),
@@ -174,19 +212,19 @@ pub async fn unassign(
 
     assign_repo::delete(pool, &req.session_id, type_str).await.map_err(|e| e.to_string())?;
 
-    // Audit event mirrors "calibration.assignment.created" (T030).
-    let _ = bus
-        .publish(
-            "calibration.assignment.removed",
-            Source::User,
-            serde_json::json!({
-                "assignmentId": existing.id,
-                "sessionId": req.session_id,
-                "masterId": existing.master_id,
-                "calibrationType": type_str,
-            }),
-        )
-        .await;
+    // Mirrors "calibration.assignment.created" (T030, #1120).
+    write_assignment_audit(
+        bus,
+        "calibration.assignment.removed",
+        &existing.id,
+        serde_json::json!({
+            "assignmentId": existing.id,
+            "sessionId": req.session_id,
+            "masterId": existing.master_id,
+            "calibrationType": type_str,
+        }),
+    )
+    .await?;
 
     Ok(CalibrationMatchUnassignResponse {
         status: "success".to_owned(),

--- a/crates/app/core/tests/calibration_integration.rs
+++ b/crates/app/core/tests/calibration_integration.rs
@@ -471,6 +471,86 @@ async fn unassign_removes_persisted_assignment() {
     assert_eq!(again.error.expect("expected error details").code, "assignment.not_found");
 }
 
+/// #1120: assign/unassign history must land in `audit_log_entry`, the
+/// authoritative durable record — not only in the non-authoritative `events`
+/// table that `bus.publish` writes. Asserted on the durable table directly,
+/// because an `events` row satisfies the old (weak) check either way.
+#[tokio::test]
+async fn assign_and_unassign_write_durable_audit_log_entries() {
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+
+    let session_id = Uuid::new_v4().to_string();
+    let master_id = Uuid::new_v4().to_string();
+
+    insert_acq_session(pool, &session_id).await;
+    insert_acq_fingerprint(pool, &session_id, 200.0, 20.0, -15.0, "2x2").await;
+    insert_cal_session(pool, &master_id, "dark").await;
+    insert_cal_fingerprint(pool, &master_id, "dark", 200.0, 20.0, -15.0, "2x2").await;
+
+    let assign_resp = assign(
+        pool,
+        &bus,
+        CalibrationMatchAssignRequest {
+            contract_version: ASSIGN_CONTRACT_VERSION.to_owned(),
+            request_id: Uuid::new_v4().to_string(),
+            session_id: session_id.clone(),
+            master_id: master_id.clone(),
+            r#override: false,
+        },
+    )
+    .await
+    .expect("assign should not return Err");
+    assert_eq!(assign_resp.status, "success", "expected success, got: {:?}", assign_resp.error);
+    let assignment_id = assign_resp.assigned.expect("expected Some(assigned)").assignment_id;
+
+    let (created_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM audit_log_entry \
+         WHERE trigger = 'calibration.assignment.created' AND entity_type = 'calibration' \
+           AND outcome = 'applied' AND payload LIKE ?",
+    )
+    .bind(format!("%{assignment_id}%"))
+    .fetch_one(pool)
+    .await
+    .expect("audit_log_entry query failed");
+    assert_eq!(created_count, 1, "assign must write exactly 1 durable audit row");
+
+    let unassign_resp = unassign(
+        pool,
+        &bus,
+        CalibrationMatchUnassignRequest {
+            contract_version: UNASSIGN_CONTRACT_VERSION.to_owned(),
+            request_id: Uuid::new_v4().to_string(),
+            session_id: session_id.clone(),
+            calibration_type: CalibrationType::Dark,
+        },
+    )
+    .await
+    .expect("unassign should not return Err");
+    assert_eq!(unassign_resp.status, "success", "expected success, got: {:?}", unassign_resp.error);
+
+    let (removed_count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM audit_log_entry \
+         WHERE trigger = 'calibration.assignment.removed' AND entity_type = 'calibration' \
+           AND outcome = 'applied' AND payload LIKE ?",
+    )
+    .bind(format!("%{assignment_id}%"))
+    .fetch_one(pool)
+    .await
+    .expect("audit_log_entry query failed");
+    assert_eq!(removed_count, 1, "unassign must write exactly 1 durable audit row");
+
+    // Both mutations must resolve to the same audit entity, so an assignment's
+    // full history is reachable from one entity_id.
+    let (entity_ids,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(DISTINCT entity_id) FROM audit_log_entry WHERE entity_type = 'calibration'",
+    )
+    .fetch_one(pool)
+    .await
+    .expect("audit_log_entry query failed");
+    assert_eq!(entity_ids, 1, "create+remove must share one entity_id");
+}
+
 /// `batch_suggest` across two sessions: one with a matching master, one unknown.
 #[tokio::test]
 async fn batch_suggest_returns_results_and_errors_per_session() {

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -496,11 +496,13 @@ fn validate_edge(entity_type: EntityType, from: &str, to: &str) -> bool {
         // Spec 030 T120: Settings/Protection/Equipment are audit-only tags
         // with no lifecycle transition table; they are never dispatched
         // through `lifecycle.transition` (see `EntityType` doc comment).
-        // Framing (spec 008 Q27) joins the same audit-only precedent.
+        // Framing (spec 008 Q27) and Calibration (#1120) join the same
+        // audit-only precedent.
         EntityType::Settings
         | EntityType::Protection
         | EntityType::Equipment
-        | EntityType::Framing => {
+        | EntityType::Framing
+        | EntityType::Calibration => {
             unreachable!(
                 "{entity_type:?} has no lifecycle transition table; it never flows through lifecycle.transition"
             )

--- a/crates/domain/core/src/lifecycle/data_asset.rs
+++ b/crates/domain/core/src/lifecycle/data_asset.rs
@@ -61,6 +61,11 @@ pub enum EntityType {
     /// Settings/Protection/Equipment (no lifecycle table/transitions of its
     /// own; only used at the `insert_audit_entry` write path).
     Framing,
+    /// A calibration master assignment (#1120) — audit-only entity type, same
+    /// precedent as Framing. `calibration_assignment` rows are created and
+    /// deleted outright rather than transitioned, so an assignment's history
+    /// survives only in `audit_log_entry`.
+    Calibration,
 }
 
 impl EntityType {
@@ -80,6 +85,7 @@ impl EntityType {
             Self::Protection => "protection",
             Self::Equipment => "equipment",
             Self::Framing => "framing",
+            Self::Calibration => "calibration",
         }
     }
 }

--- a/crates/persistence/db/src/repositories/lifecycle.rs
+++ b/crates/persistence/db/src/repositories/lifecycle.rs
@@ -177,11 +177,13 @@ fn table_for(entity_type: EntityType) -> &'static str {
         // Spec 030 T120: Settings/Protection/Equipment are audit-only tags
         // (no lifecycle state table) written via `EventBus::write_audit`,
         // never through `record_transition`'s CAS state-column path. Framing
-        // (spec 008 Q27) joins the same audit-only precedent.
+        // (spec 008 Q27) and Calibration (#1120) join the same audit-only
+        // precedent.
         EntityType::Settings
         | EntityType::Protection
         | EntityType::Equipment
-        | EntityType::Framing => {
+        | EntityType::Framing
+        | EntityType::Calibration => {
             unreachable!(
                 "{entity_type:?} has no lifecycle state table; it never flows through record_transition"
             )


### PR DESCRIPTION
Closes #1120

## Summary

- Calibration master assign/un-assign now leave a record in the app's authoritative audit log, so a session's assignment history is recoverable. Previously these two actions were only announced to live listeners, and nothing durable was written.
- No user-facing behaviour changes otherwise: the same events fire with the same payloads.

## Problem

`assign()` and `unassign()` recorded their mutation only via `bus.publish(...)`,
which writes the `events` table — the store `crates/audit/src/bus.rs` documents
as *non-authoritative transient diagnostics*. Neither routed through
`EventBus::write_audit()` / `audit_log_entry`, the FR-131/T121-designated
durable record. #875's "audited" acceptance was met only in that weak sense.

## Change

Both call sites now go through a shared `write_assignment_audit` helper
(`crates/app/calibration/src/matching/assign.rs:41`) that writes the durable
`audit_log_entry` row and then emits the live bus event. Topic and payload are
byte-identical to the pre-fix publish, so existing live subscribers are
unaffected. Per constitution §II the durable insert is load-bearing: a failure
now fails the command, where previously the result was discarded with `let _ =`.

Supporting changes:

- `EntityType::Calibration` — a new audit-only entity type on the exact
  `Framing` precedent (`crates/domain/core/src/lifecycle/data_asset.rs:68`),
  plus its arm in the two exhaustive "no lifecycle table" matches. Calibration
  assignments are created and deleted outright rather than transitioned, so an
  assignment's history survives only in `audit_log_entry`.
- The audit `entity_id` derivation moved out of `equipment.rs` into
  `crates/app/calibration/src/audit_ids.rs` now that a second consumer exists.
  A unit test pins the `equipment` namespace to its pre-extraction byte seed so
  already-written equipment audit rows keep resolving to the same `entity_id`.

No SQL migration: `audit_log_entry.entity_type` is free `TEXT` with no CHECK
constraint, so nothing schema-level changes.

Rebased onto main after #1260's split of `matching.rs`; the fix is applied to
main's `matching/assign.rs` rather than reinstating the deleted flat module.

## Regression test

`assign_and_unassign_write_durable_audit_log_entries`
(`crates/app/core/tests/calibration_integration.rs:479`). It asserts on
`audit_log_entry` directly, because the pre-existing test only counted `events`
rows and passes either way.

```
cargo test -j 4 -p app_core --test calibration_integration \
  assign_and_unassign_write_durable_audit_log_entries
```

Against the unfixed code (`assign.rs` reverted to its pre-fix state), verified
both before and after the rebase:

```
assertion `left == right` failed: assign must write exactly 1 durable audit row
  left: 0
 right: 1
test result: FAILED. 0 passed; 1 failed
```

With the fix: `10 passed` (whole suite).

## Gates

Run post-rebase in the lane worktree:

- `cargo clippy -p app_core_calibration -p domain_core -p persistence_db -p app_core_lifecycle --all-targets -- -D warnings` — clean.
- `cargo test -p app_core_calibration -p domain_core` — 109 passed.
- `cargo test -p persistence_db -p app_core_lifecycle` — 347 passed.
- `cargo test -p app_core --test calibration_integration` — 10 passed.
- `just db-boundary` — sealed at zero.
- `just lint` — workspace `cargo fmt --all --check` and
  `clippy --workspace --all-targets -- -D warnings` pass; the `pnpm -r lint`
  stage (biome, eslint baseline, token checks, i18n catalogue) passes.

The full test suite was not run locally (nine concurrent lanes / memory); CI runs it.