### PR TITLE
fix: integration time is displayed the same way on every screen

### DIFF
--- a/apps/desktop/src/features/projects/ProjectChannelsSection.tsx
+++ b/apps/desktop/src/features/projects/ProjectChannelsSection.tsx
@@ -16,7 +16,8 @@
 import { m } from '@/lib/i18n';
 import { CoverageBar, Pill, Section } from '@/ui';
 import type { DerivedChannel } from './projectDetailHelpers';
-import { fmtFrames, fmtIntegS, paletteName } from './projectDetailHelpers';
+import { fmtFrames, paletteName } from './projectDetailHelpers';
+import { formatIntegration } from '@/lib/format';
 
 export interface ProjectChannelsSectionProps {
   channels: DerivedChannel[];
@@ -64,7 +65,7 @@ export function ProjectChannelsSection({
               {fmtFrames(ch.totalFrames)}
             </span>
             <span className="pv-project-detail__ch-integ">
-              {ch.totalIntegS > 0 ? fmtIntegS(ch.totalIntegS) : '—'}
+              {formatIntegration(ch.totalIntegS)}
             </span>
             <div className="pv-project-detail__ch-status">
               <Pill variant={ch.inSync ? 'ghost' : 'warn'}>

--- a/apps/desktop/src/features/projects/ProjectDetail.sources-metric.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.sources-metric.test.tsx
@@ -92,7 +92,7 @@ describe('ProjectDetail — sources Integ cell (#622)', () => {
     vi.clearAllMocks();
   });
 
-  it('computes Integ from frames * parsed exposure seconds (54 * 120s = 1.8h)', () => {
+  it('computes Integ from frames * parsed exposure seconds (54 * 120s = 1h 48m)', () => {
     setupStore({
       sources: [
         {
@@ -108,7 +108,8 @@ describe('ProjectDetail — sources Integ cell (#622)', () => {
       ],
     });
     render(<ProjectDetailContent projectId="proj-m31" />);
-    expect(screen.getByText('1.8h')).toBeInTheDocument();
+    // #631: was '1.8h' — Projects now shares the Sessions h/m grammar.
+    expect(screen.getByText('1h 48m')).toBeInTheDocument();
   });
 
   it('degrades to 0 (—) for an unparseable exposure snapshot rather than throwing', () => {

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -43,7 +43,8 @@ import {
 } from '@/components';
 import { ProjectLifecycleStepper } from './ProjectLifecycleStepper';
 import { Btn, Banner } from '@/ui';
-import { deriveChannels, fmtIntegS } from './projectDetailHelpers';
+import { deriveChannels } from './projectDetailHelpers';
+import { formatIntegration } from '@/lib/format';
 import { ProjectChannelsSection } from './ProjectChannelsSection';
 import { ProjectSourcesSection } from './ProjectSourcesSection';
 import { projectStateLabel, projectStateVariant } from '@/lib/lifecycle';
@@ -307,12 +308,9 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
       <MetricLine
         metrics={[
           {
-            value:
-              derivedChannels.reduce((s, c) => s + c.totalIntegS, 0) > 0
-                ? fmtIntegS(
-                    derivedChannels.reduce((s, c) => s + c.totalIntegS, 0),
-                  )
-                : '—',
+            value: formatIntegration(
+              derivedChannels.reduce((s, c) => s + c.totalIntegS, 0),
+            ),
             label: m.projects_metric_integration(),
           },
           {

--- a/apps/desktop/src/features/projects/ProjectSourcesSection.tsx
+++ b/apps/desktop/src/features/projects/ProjectSourcesSection.tsx
@@ -13,10 +13,10 @@ import { Pill, Section, Table } from '@/ui';
 import type { ProjectSourceDto_Deserialize } from '@/bindings/index';
 import {
   fmtFrames,
-  fmtIntegS,
   parseExposureSeconds,
   sourceTypeVariant,
 } from './projectDetailHelpers';
+import { formatIntegration } from '@/lib/format';
 
 export interface ProjectSourcesSectionProps {
   sources: ProjectSourceDto_Deserialize[];
@@ -86,7 +86,7 @@ export function ProjectSourcesSection({
       ),
       integ: (
         <span className="pv-project-detail__integ-cell">
-          {fmtIntegS(integS)}
+          {formatIntegration(integS)}
         </span>
       ),
     };

--- a/apps/desktop/src/features/projects/projectDetailHelpers.ts
+++ b/apps/desktop/src/features/projects/projectDetailHelpers.ts
@@ -23,14 +23,6 @@ export function sourceTypeVariant(filter: string): PillVariant {
   return 'ghost';
 }
 
-/** Convert raw seconds → "X.Xh" / "Xm" display string, or "—" for null/zero. */
-export function fmtIntegS(s: number | null | undefined): string {
-  if (s == null || s === 0) return '—';
-  const h = s / 3600;
-  if (h >= 1) return `${h.toFixed(1)}h`;
-  return `${Math.round(s / 60)}m`;
-}
-
 /** Format a frame count; returns "—" for zero. */
 export function fmtFrames(n: number): string {
   return n > 0 ? String(n) : '—';

--- a/apps/desktop/src/features/sessions/SessionDetail.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.tsx
@@ -43,7 +43,8 @@ import { SessionFrameInventory } from './SessionFrameInventory';
 import { SessionNotesSection } from './SessionNotesSection';
 import { RawFrameCleanupSection } from './RawFrameCleanupSection';
 import { sessionDisplayName } from './displayName';
-import { integrationLabel } from './integration';
+import { integrationSeconds } from './integration';
+import { formatIntegration } from '@/lib/format';
 import { connectivityLabel, connectivityVariant } from './connectivity';
 
 /** `SessionCalibrationMatch.kind` is the wider `CalibrationKind` (adds
@@ -221,7 +222,9 @@ export function SessionDetail({
 
   const isLinked = (session.linked?.projects?.length ?? 0) > 0;
   const prov = session.provenance;
-  const integration = integrationLabel(session);
+  // Null (not zero) means no derivable total, which omits the row entirely
+  // rather than rendering a dash for it.
+  const integrationSec = integrationSeconds(session);
   const connLabel = sourceState ? connectivityLabel(sourceState) : null;
 
   // Session facts as a clean tabular PropertyTable, spread across two columns.
@@ -256,12 +259,12 @@ export function SessionDetail({
       value: session.exposure ?? null,
       source: 'fits',
     },
-    ...(integration != null
+    ...(integrationSec != null
       ? [
           {
             key: 'integration',
             label: m.sessions_col_total_integration(),
-            value: integration,
+            value: formatIntegration(integrationSec),
           } as PropertyDef,
         ]
       : []),

--- a/apps/desktop/src/features/sessions/SessionsTable.tsx
+++ b/apps/desktop/src/features/sessions/SessionsTable.tsx
@@ -323,7 +323,7 @@ export function SessionsTable({
           ),
           filter: s.filter ?? '—',
           frames: s.frames,
-          integration: integrationLabel(s) ?? '—',
+          integration: integrationLabel(s),
           night: s.capturedOn ?? '—',
           camera: s.camera ?? '—',
           projects:

--- a/apps/desktop/src/features/sessions/integration.ts
+++ b/apps/desktop/src/features/sessions/integration.ts
@@ -10,6 +10,7 @@
  */
 
 import type { InventorySession } from '@/bindings/index';
+import { formatIntegration } from '@/lib/format';
 
 /** Derive total integration seconds from frames × per-frame exposure. */
 export function integrationSeconds(
@@ -22,19 +23,12 @@ export function integrationSeconds(
   return secs * session.frames;
 }
 
-/** Format a total-seconds duration as `1h 30m` / `45m` / `1h`. */
-export function fmtSeconds(totalSec: number): string {
-  const h = Math.floor(totalSec / 3600);
-  const m = Math.floor((totalSec % 3600) / 60);
-  if (h === 0) return `${m}m`;
-  if (m === 0) return `${h}h`;
-  return `${h}h ${m}m`;
-}
-
-/** Total-integration display value for a session, or `null` when unknown. */
+/**
+ * Total-integration display value for a session (#631: formatting now comes
+ * from the shared `formatIntegration`; this only supplies the derivation).
+ */
 export function integrationLabel(
   session: Pick<InventorySession, 'exposure' | 'frames'>,
-): string | null {
-  const totalSec = integrationSeconds(session);
-  return totalSec != null ? fmtSeconds(totalSec) : null;
+): string {
+  return formatIntegration(integrationSeconds(session));
 }

--- a/apps/desktop/src/lib/format.test.ts
+++ b/apps/desktop/src/lib/format.test.ts
@@ -5,7 +5,6 @@ import { describe, it, expect } from 'vitest';
 import {
   formatBytes,
   formatIntegration,
-  formatIntegrationHours,
   formatExposureSeconds,
   formatTempC,
   formatGain,
@@ -19,17 +18,35 @@ describe('formatBytes', () => {
   });
 });
 
+// #631 — one formatter for integration time. Sessions rendered "1h 30m" while
+// Projects rendered "1.5h" for the same quantity; these lock the single
+// grammar both now share.
 describe('formatIntegration', () => {
-  it('formats seconds into h/m/s', () => {
-    expect(formatIntegration(3661)).toBe('1h 1m 1s');
-    expect(formatIntegration(0)).toBe('0s');
+  it('renders hours and minutes together', () => {
+    expect(formatIntegration(5400)).toBe('1h 30m');
+    expect(formatIntegration(3661)).toBe('1h 1m');
   });
-});
 
-describe('formatIntegrationHours', () => {
-  it('formats hours to one decimal', () => {
-    expect(formatIntegrationHours(2.5)).toBe('2.5h');
-    expect(formatIntegrationHours(0)).toBe('0h');
+  it('drops the empty unit rather than padding with a zero', () => {
+    expect(formatIntegration(7200)).toBe('2h');
+    expect(formatIntegration(3000)).toBe('50m');
+  });
+
+  it('keeps whole minutes exact where the old "1.5h" rounded them away', () => {
+    // 1.8h to one decimal — the divergent Projects formatter's output.
+    expect(formatIntegration(6480)).toBe('1h 48m');
+  });
+
+  it('floors a nonzero sub-minute total to "<1m", never a misleading "0m"', () => {
+    expect(formatIntegration(20)).toBe('<1m');
+    expect(formatIntegration(59)).toBe('<1m');
+  });
+
+  it('uses the dash convention for absent and zero totals', () => {
+    expect(formatIntegration(null)).toBe('—');
+    expect(formatIntegration(undefined)).toBe('—');
+    expect(formatIntegration(0)).toBe('—');
+    expect(formatIntegration(-1)).toBe('—');
   });
 });
 

--- a/apps/desktop/src/lib/format.ts
+++ b/apps/desktop/src/lib/format.ts
@@ -18,32 +18,32 @@ export function formatBytes(bytes: number): string {
   return `${value.toFixed(i === 0 ? 0 : 1)} ${units[i]}`;
 }
 
-/**
- * Format integration time in seconds to a human-readable string.
- * e.g. 3661 => "1h 1m 1s", 120 => "2m 0s"
- */
-export function formatIntegration(seconds: number): string {
-  if (seconds <= 0) return '0s';
-  const h = Math.floor(seconds / 3600);
-  const m = Math.floor((seconds % 3600) / 60);
-  const s = Math.round(seconds % 60);
-  if (h > 0) return `${h}h ${m}m ${s}s`;
-  if (m > 0) return `${m}m ${s}s`;
-  return `${s}s`;
-}
-
-/**
- * Format integration time in hours to a compact display string.
- * e.g. 2.5 => "2.5h", 0 => "0h"
- */
-export function formatIntegrationHours(hours: number): string {
-  if (hours === 0) return '0h';
-  if (hours < 0.1) return '<0.1h';
-  return `${hours.toFixed(1)}h`;
-}
-
 /** Blank marker for a missing/null value — matches RenderValue's convention. */
 const EMPTY = '—';
+
+/**
+ * Format an integration duration in seconds (#631).
+ *
+ * The single formatter for this quantity. It replaces four divergent versions
+ * that rendered the SAME total differently — Sessions' `1h 30m`, Projects'
+ * `1.5h`, the wizard's `1h 30m 0s`, and a dead hours-based variant — so a
+ * session and the project built from it no longer disagree on screen.
+ *
+ * `h`/`m` is exact where the old `1.5h` rounded a total away. Sub-minute
+ * totals collapse to `<1m` rather than the misleading `0m` the previous
+ * minute-rounding produced for any nonzero value under 30 seconds.
+ *
+ * e.g. 5400 => "1h 30m", 3000 => "50m", 7200 => "2h", 20 => "<1m".
+ */
+export function formatIntegration(seconds: number | null | undefined): string {
+  if (seconds == null || seconds <= 0) return EMPTY;
+  const h = Math.floor(seconds / 3600);
+  const m = Math.floor((seconds % 3600) / 60);
+  if (h === 0 && m === 0) return '<1m';
+  if (h === 0) return `${m}m`;
+  if (m === 0) return `${h}h`;
+  return `${h}h ${m}m`;
+}
 
 /** Round to 1 decimal place, dropping a trailing ".0" (e.g. 30 => "30", 6.92447668013071 => "6.9"). */
 function roundTrim1(n: number): string {

--- a/tests/e2e/project_lifecycle_surfaces.spec.ts
+++ b/tests/e2e/project_lifecycle_surfaces.spec.ts
@@ -31,7 +31,8 @@
  *
  * Mock wiring (apps/desktop/src/api/mocks.ts):
  *   projects_get           → mockProjectDetailFor(id) — proj-001 processing
- *                            (2 channels: Ha 1.8h, OIII 1.3h), proj-002 ready.
+ *                            (2 channels: Ha 1h 48m, OIII 1h 16m), proj-002
+ *                            ready.
  *   note_get / note_update → persisted note body + update echo.
  *   manifest_list          → 2 snapshot rows (created, lifecycle_transition).
  *   tools_list             → (unhandled) → useToolProfiles degrades to no
@@ -99,11 +100,11 @@ test.describe('project lifecycle · detail surfaces (Journey 5)', () => {
     await expect(outputs).toBeVisible();
     await expect(outputs.getByText('No accepted outputs yet')).toBeVisible();
 
-    // ── Per-channel integration time (Ha 1.8h, OIII 1.3h) ────────────────────
+    // ── Per-channel integration time (Ha 1h 48m, OIII 1h 16m) ────────────────
     const channels = page.locator('.pv-project-detail__channels-section');
     await expect(channels).toBeVisible();
-    await expect(channels.getByText('1.8h')).toBeVisible();
-    await expect(channels.getByText('1.3h')).toBeVisible();
+    await expect(channels.getByText('1h 48m')).toBeVisible();
+    await expect(channels.getByText('1h 16m')).toBeVisible();
 
     // ── Tool-launch affordance: rendered but disabled (no profile configured) ─
     const launchBtn = page.getByTestId('tool-launch-btn');


### PR DESCRIPTION
## Summary

- Sessions and Projects displayed the same integration time differently — a session reading `1h 30m` became `1.5h` on the project built from it, and the project wizard showed `1h 30m 0s`. All screens now use one format.
- The shared format is exact: totals that the old `1.5h` rounded away (e.g. `1h 48m`) now display in full, and a nonzero total under a minute reads `<1m` instead of a misleading `0m`.
- Missing and zero totals now show the app's standard dash rather than `0s`.

Polish pass over the #631 typography/consistency batch. Also scoped #1182, which turned out to be blocked.

## #631 group 3 — one integration-time formatter (done)

Four formatters rendered the same quantity four ways:

| formatter | 5400s | call sites |
|---|---|---|
| `formatIntegration` (`lib/format.ts`) | `1h 30m 0s` | Projects wizard |
| `formatIntegrationHours` (`lib/format.ts`) | `1.5h` | none — dead |
| `fmtSeconds`/`integrationLabel` (`features/sessions/integration.ts`) | `1h 30m` | Sessions table + detail |
| `fmtIntegS` (`features/projects/projectDetailHelpers.ts`) | `1.5h` | Project detail, sources, channels |

All four collapse into `formatIntegration` in the shared format lib. The h/m grammar survives: it is exact where `1.5h` rounded a total away, and a nonzero sub-minute total now reads `<1m` instead of the `0m` the old minute-rounding produced. Null/zero follow the app's dash convention, which let three call sites drop their own zero-guards.

`integrationSeconds` stays in the sessions module — that is derivation (frames x exposure), not formatting.

New vitest coverage in `src/lib/format.test.ts` pins the grammar, the exactness case, the `<1m` floor, and the dash cases.

## #631 groups 1, 2 — already fixed on main

Verified against current code rather than the issue's stale `alm-`-era line numbers:

- Sub-token-floor font sizes: zero non-token `font-size` declarations remain in any of the five named files. App-wide only three non-token uses survive, all legitimate: `styles/reset.css:15` (the `14px` root every rem token resolves against) and two relative `em` values (`detail-panes.css:349`, `dev.css:244`).
- Border-only input focus: fixed at `styles/components/target-search.css:33`, which applies `var(--pv-focus-ring)` and carries a `#631` comment.

## #631 group 4 — not done, deliberately

Stopped per the scope judgement in the brief. Both halves are larger than a relabel:

- **The group chain is a redesign, not a relabel.** `FilterToolbar` and `useGrouping` are already shared, so the architecture is not the problem. Collapsing the three always-visible slots into a "Sort & group" popover means a new popover component, a summary string, reworked a11y (three labelled selects become one control), and updates across six pages plus four grouping test suites. Estimate: 1-2 days including tests.
- **The vocabulary half is a product decision, not drift.** Sessions' "Filter" is `m.common_filter()` and means the *optical* filter (Ha/OIII) — the same key Inbox uses as a grouping dimension. It is domain vocabulary that happens to collide with the UI verb. Standardising it away would cost clarity, so it needs a product call on the target grammar first.

#631 stays open for group 4. Refs #631.

## #1182 — blocked, no change here

`apps/desktop/splash.html` does not exist on `main`; it is introduced by #1248 (`ds/07-assets`), still open. Nothing to fix on this branch without duplicating that file, so this PR does not touch it.

One finding worth carrying into #1248: the issue assumes the splash is "correct today" because `DARK_DEFAULT` is `observatory-dark`. It is not — `src/data/theme.ts:130` already reads `observatory-cool`. The amber splash is therefore **already** off-brand against the default theme, so #1182 is a live mismatch rather than a latent one.

Recommended fix once #1248 lands: resolve the persisted theme at splash time via a small inline script reading the `alm.theme` localStorage key and set the matching palette. A standalone Vite entry document cannot import `tokens.css` without pulling the app's whole style layer into the splash bundle and delaying first paint — which is the one thing a splash must not do. Tradeoff: the palette values get duplicated into the splash, so a token change needs a matching splash update; keeping the duplicated set to the four or five colors the splash actually paints keeps that cost small.

## Gates

`pnpm lint` (incl. `check-tokens.sh`), `pnpm typecheck`, `pnpm test` all pass. `css-dup-sniff.mjs` exits 0 with only pre-existing duplications; this PR adds no CSS.

Three tests fail both here and on a pristine `origin/main` worktree (`devSurface.release.test.ts`, `GuidedOverlay.test.tsx`) and are flaky — identical repeat runs on unmodified `main` produced 3, then 5 failures. Pre-existing, unrelated to this change, no import path to any file touched here.
