### PR TITLE
refactor: setup wizard scan list uses the shared table component

### DIFF
--- a/apps/desktop/src/features/calibration/MastersTable.tsx
+++ b/apps/desktop/src/features/calibration/MastersTable.tsx
@@ -446,7 +446,7 @@ export function MastersTable({
       _selected: selected === master.id,
       _indent: indentPx || undefined,
       master: (
-        <span className="pv-calib-cell__master">
+        <span className="pv-table__cell-inline">
           <Pill variant={kindVariant(kindStr)}>{kindStr.toUpperCase()}</Pill>
           <span className="pv-calib-cell__master-label">
             {masterLabel(master)}

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -192,12 +192,12 @@ function SourceSummary({ state }: SourceSummaryProps) {
     return {
       _testid: `scan-item-${item.inboxItemId}`,
       folder: (
-        <>
+        <span className="pv-table__cell-inline">
           {item.isMaster && <Pill variant="info">{m.setup_scan_master()}</Pill>}
           {/* The root/top-level row of an expanded folder carries an empty
               relativePath; label it instead of leaving it blank (issue #513). */}
           {item.relativePath || m.setup_scan_root_label()}
-        </>
+        </span>
       ),
       files: item.fileCount,
       format: (item.format ?? item.lane).toUpperCase(),

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -10,6 +10,8 @@
 import { useEffect, useRef, useState } from 'react';
 import { Pill } from '@/ui/Pill';
 import type { PillVariant } from '@/ui/Pill';
+import { Table } from '@/ui';
+import type { TableColumn, TableRow } from '@/ui';
 import { m } from '@/lib/i18n';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
@@ -164,6 +166,48 @@ function SourceSummary({ state }: SourceSummaryProps) {
       a.relativePath.localeCompare(b.relativePath),
   );
 
+  // Built per render rather than hoisted to module scope: the `m.*` accessors
+  // resolve against the active locale at call time, so hoisting would freeze
+  // the header labels to whichever locale was active at import.
+  const columns: TableColumn[] = [
+    { key: 'folder', label: m.setup_scan_col_folder() },
+    { key: 'files', label: m.setup_scan_col_files() },
+    { key: 'format', label: m.setup_scan_col_format() },
+    { key: 'types', label: m.setup_scan_col_types() },
+  ];
+
+  const rows: TableRow[] = sortedItems.map((item) => {
+    const cls = classifications.get(item.inboxItemId);
+    const typeParts = (cls?.breakdown ?? []).map((b) => `${b.count} ${b.kind}`);
+    // Reconcile against fileCount (issue #513): files with no IMAGETYP (or an
+    // unmapped one) don't appear in the classify breakdown at all, so the type
+    // list previously undercounted the row's file total with no indication why.
+    const unclassifiedCount = cls?.unclassifiedFiles.length ?? 0;
+    if (unclassifiedCount > 0) {
+      typeParts.push(
+        m.setup_scan_unclassified_count({ count: unclassifiedCount }),
+      );
+    }
+    const types = typeParts.join(', ');
+    return {
+      _testid: `scan-item-${item.inboxItemId}`,
+      folder: (
+        <>
+          {item.isMaster && <Pill variant="info">{m.setup_scan_master()}</Pill>}
+          {/* The root/top-level row of an expanded folder carries an empty
+              relativePath; label it instead of leaving it blank (issue #513). */}
+          {item.relativePath || m.setup_scan_root_label()}
+        </>
+      ),
+      files: item.fileCount,
+      format: (item.format ?? item.lane).toUpperCase(),
+      // Individual calibration masters carry their frame type on the item
+      // itself (spec 040 FR-006); grouped sub-frame folders rely on the
+      // classify breakdown instead.
+      types: item.isMaster ? masterLabel(item) : types || '—',
+    };
+  });
+
   // The detail panel (chips + table) is expandable only when scan is done and
   // there are items to show.
   const isExpandable = phase === 'done' && totalItems > 0;
@@ -267,81 +311,16 @@ function SourceSummary({ state }: SourceSummaryProps) {
             </div>
           )}
 
-          {/* Scrollable metadata table of detected ingestion groups */}
-          <div className="pv-setup-scan__table-wrap">
-            <table className="pv-setup-scan__table">
-              <thead>
-                <tr className="pv-setup-scan__thead-row">
-                  <th className="pv-setup-scan__cell">
-                    {m.setup_scan_col_folder()}
-                  </th>
-                  <th className="pv-setup-scan__cell">
-                    {m.setup_scan_col_files()}
-                  </th>
-                  <th className="pv-setup-scan__cell">
-                    {m.setup_scan_col_format()}
-                  </th>
-                  <th className="pv-setup-scan__cell">
-                    {m.setup_scan_col_types()}
-                  </th>
-                </tr>
-              </thead>
-              <tbody>
-                {sortedItems.map((item) => {
-                  const cls = classifications.get(item.inboxItemId);
-                  const breakdown = cls?.breakdown ?? [];
-                  const typeParts = breakdown.map(
-                    (b) => `${b.count} ${b.kind}`,
-                  );
-                  // Reconcile against fileCount (issue #513): files with no
-                  // IMAGETYP (or an unmapped one) don't appear in the classify
-                  // breakdown at all, so the type list previously undercounted
-                  // the row's file total with no indication why.
-                  const unclassifiedCount = cls?.unclassifiedFiles.length ?? 0;
-                  if (unclassifiedCount > 0) {
-                    typeParts.push(
-                      m.setup_scan_unclassified_count({
-                        count: unclassifiedCount,
-                      }),
-                    );
-                  }
-                  const types = typeParts.join(', ');
-                  // Individual calibration masters carry their frame type on the
-                  // item itself (spec 040 FR-006); grouped sub-frame folders rely
-                  // on the classify breakdown instead.
-                  const detectedTypes = item.isMaster
-                    ? masterLabel(item)
-                    : types || '—';
-                  // The root/top-level row of an expanded folder carries an
-                  // empty relativePath; label it instead of leaving it blank
-                  // (issue #513).
-                  const rowLabel =
-                    item.relativePath || m.setup_scan_root_label();
-                  return (
-                    <tr
-                      key={item.inboxItemId}
-                      data-testid={`scan-item-${item.inboxItemId}`}
-                      className="pv-setup-scan__tbody-row"
-                    >
-                      <td className="pv-setup-scan__cell--path">
-                        <span className="pv-setup-scan__path-cell-inner">
-                          {item.isMaster && (
-                            <Pill variant="info">{m.setup_scan_master()}</Pill>
-                          )}
-                          {rowLabel}
-                        </span>
-                      </td>
-                      <td className="pv-setup-scan__cell">{item.fileCount}</td>
-                      <td className="pv-setup-scan__cell">
-                        {(item.format ?? item.lane).toUpperCase()}
-                      </td>
-                      <td className="pv-setup-scan__cell">{detectedTypes}</td>
-                    </tr>
-                  );
-                })}
-              </tbody>
-            </table>
-          </div>
+          {/* Scrollable metadata table of detected ingestion groups.
+              `virtualized` is used for its scroll container + sticky header
+              (primitives.css `.pv-table__scroll`), not for windowing — a
+              per-source detection list is small. */}
+          <Table
+            columns={columns}
+            rows={rows}
+            virtualized
+            scrollClassName="pv-setup-scan__table-wrap"
+          />
         </div>
       )}
     </div>

--- a/apps/desktop/src/styles/components/merges-1.css
+++ b/apps/desktop/src/styles/components/merges-1.css
@@ -318,13 +318,8 @@
   background: var(--pv-accent-bg);
 }
 
-/* Master cell: kind pill + readable label + optional aging pill. */
-.pv-calib-cell__master {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--pv-sp-2);
-  flex-wrap: wrap;
-}
+/* Master cell (kind pill + readable label + optional aging pill) lays out via
+   the shared `.pv-table__cell-inline` in primitives.css. */
 .pv-calib-cell__master-label {
   font-weight: var(--pv-weight-medium);
   color: var(--pv-text);

--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -322,6 +322,20 @@
   padding-left: var(--pv-row-indent, 0);
 }
 
+/* Cell content that is a Pill (or several) sitting next to its label: without a
+   flex gap the pill butts straight against the text, since adjacent JSX nodes
+   emit no whitespace. Wrap the cell's children in this to space them. Replaces
+   the per-feature clones of the same three declarations (calibration masters,
+   setup scan). `flex-wrap` matters where a row carries two pills plus a label.
+   Note `.pv-table td` clips with an ellipsis; an inline-flex box is atomic and
+   clips rather than ellipsizing, which is the long-standing behaviour here. */
+.pv-table__cell-inline {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--pv-sp-2);
+  flex-wrap: wrap;
+}
+
 /* Virtualized Table (opt-in `virtualized` prop): own scroll container + sticky
    header + zero-chrome sentinel spacer rows (padding-spacer windowing). */
 .pv-table__scroll {

--- a/apps/desktop/src/styles/components/wizard-steps.css
+++ b/apps/desktop/src/styles/components/wizard-steps.css
@@ -1040,48 +1040,14 @@
   color: var(--pv-text-secondary);
 }
 
-/* Scrollable table wrapper */
+/* Bounds the shared `Table`'s own scroll container (`.pv-table__scroll`), which
+   supplies the overflow and the sticky header. All table chrome — borders, cell
+   padding, header type — now comes from `.pv-table`; issue #752 deleted the
+   clone of it that used to live here. */
 .pv-setup-scan__table-wrap {
   max-height: 280px;
-  overflow-y: auto;
   border: 1px solid var(--pv-border-subtle);
   border-radius: var(--pv-radius-sm);
-}
-
-/* Detection table */
-.pv-setup-scan__table {
-  width: 100%;
-  border-collapse: collapse;
-  font-size: var(--pv-text-xs);
-  color: var(--pv-text-secondary);
-}
-
-.pv-setup-scan__thead-row {
-  position: sticky;
-  top: 0;
-  background: var(--pv-surface-raised);
-  color: var(--pv-text);
-}
-
-.pv-setup-scan__cell {
-  padding: var(--pv-sp-1) var(--pv-sp-2);
-  text-align: left;
-}
-
-.pv-setup-scan__cell--path {
-  padding: var(--pv-sp-1) var(--pv-sp-2);
-  text-align: left;
-  word-break: break-all;
-}
-
-.pv-setup-scan__tbody-row {
-  border-top: 1px solid var(--pv-border-subtle);
-}
-
-.pv-setup-scan__path-cell-inner {
-  display: inline-flex;
-  align-items: center;
-  gap: var(--pv-sp-2);
 }
 
 /* === SETUP STEP CONFIRM === */

--- a/specs/038-wizard-scan-step/spec.md
+++ b/specs/038-wizard-scan-step/spec.md
@@ -116,3 +116,64 @@ detection summary reusing Inbox components; clean handoff to the Inbox on Finish
   for the Inbox triage components.
 - Detections persist (DB) so they are visible in the Inbox after navigation.
 - Greenfield: replacing the static Confirm step's "scan after setup" copy is acceptable.
+
+## Accepted Deviation — FR-003 (recorded 2026-07-20, issue #752)
+
+FR-003 requires the summary to "reuse the existing Inbox triage components (no
+parallel UI)". The shipped implementation reuses the Inbox *data types*
+(`InboxItemSummary`, `InboxClassifyResponse`) and, since #752, the shared
+`Table` primitive — but **not** `InboxList`, `InboxDetail`, or
+`InboxStatsSummary`. That deviation is accepted and scoped as follows.
+
+### What now complies
+
+The step's detection list renders through the shared `Table` primitive
+(`apps/desktop/src/ui/Table.tsx`) — the same construct `InboxList` itself
+renders through. The seven bespoke `pv-setup-scan__*` table classes that
+re-implemented `.pv-table` were deleted; only `__table-wrap` remains, bounding
+the scroll height of `Table`'s own `.pv-table__scroll` container.
+
+### What deviates, and why
+
+**`InboxList` cannot render the wizard's data.** It is typed on
+`InboxListItem`, which extends `InboxItemSummary` with roughly fifteen
+enrichment fields the wizard's scan never returns. `InboxList` reads exactly
+those missing fields for its two headline columns: the primary detection column
+reads `rootAbsolutePath`, and the Type column reads `frameType` /
+`groupFrameType`. Feeding it wizard data would mean fabricating those fields and
+still rendering both headline columns blank.
+
+The mismatch is semantic, not cosmetic. `InboxList` models **single-type,
+post-materialization** items — one authoritative `frameType` per row. The wizard
+runs **before** materialization, over folders that are legitimately multi-type,
+and presents a per-kind count breakdown ("16 light, 2 dark") sourced from a
+separate `classifications` map rather than from item fields. `InboxList` has no
+column that can express a breakdown. It also mandates `selectedId`/`onSelect`;
+the wizard summary is read-only.
+
+**`InboxStatsSummary`** is a flat stats strip, not a per-source container, so it
+cannot host the wizard's grouped-by-source presentation. **`InboxDetail`** is
+the triage editor for a selected item — the wizard performs no triage (FR-004,
+FR-008), so it has no selected item to detail.
+
+**The per-source accordion stays bespoke.** A shared collapsible primitive does
+exist (`apps/desktop/src/ui/Section.tsx`, used by `InboxDetail` among others)
+and was evaluated rather than assumed absent. It renders `{open && children}`
+with no slot for always-visible body content. The wizard card must keep the
+spec-048 US4 `RootDetectionConfig` control and the phase messages
+(scanning/error/empty) visible *while collapsed*; adopting `Section` would
+either hide that control behind the collapse or reorder it below the detail
+table. Both are user-visible behaviour changes to a documented control, so they
+are out of scope for a reuse refactor and would need their own iterate cycle.
+
+Eleven `pv-setup-scan__*` classes therefore remain, all scoped to the accordion
+card and its chips (`__card`, `__header`, `__chevron`, `__path`, `__kind`,
+`__count`, `__msg*`, `__detail`, `__chips`, `__chip`).
+
+### Status
+
+Accepted. FR-003's intent — no cloned table markup or CSS — is met. The residual
+deviation is the component-level reuse of `InboxList`/`InboxDetail`/
+`InboxStatsSummary`, which is blocked by a genuine data-model difference rather
+than by convenience. If the wizard ever runs post-materialization scans, this
+decision should be revisited.

--- a/specs/038-wizard-scan-step/spec.md
+++ b/specs/038-wizard-scan-step/spec.md
@@ -166,9 +166,11 @@ either hide that control behind the collapse or reorder it below the detail
 table. Both are user-visible behaviour changes to a documented control, so they
 are out of scope for a reuse refactor and would need their own iterate cycle.
 
-Eleven `pv-setup-scan__*` classes therefore remain, all scoped to the accordion
-card and its chips (`__card`, `__header`, `__chevron`, `__path`, `__kind`,
-`__count`, `__msg*`, `__detail`, `__chips`, `__chip`).
+Eighteen `pv-setup-scan__*` classes therefore remain, down from twenty-four.
+Seventeen cover the accordion card, its phase messages, and its chips
+(`__card`, `__header`, `__header--expandable`, `__chevron`, `__path`, `__kind`,
+`__count`, `__msg` plus its three variants, `__detail`, `__chips`, `__chip`,
+`__summary`, `__scroll`, `__empty-msg`); the eighteenth is `__table-wrap`.
 
 ### Status
 


### PR DESCRIPTION
Closes #752

## What

Issue #752 found that the wizard scan step hand-rolled a parallel triage UI —
its own `<table>` markup backed by 24 bespoke `pv-setup-scan__*` classes —
against spec 038 FR-003's "MUST reuse the existing Inbox triage components (no
parallel UI)".

This takes both paths the issue offers, because investigation showed each one
covers a different half of the problem.

**Retrofit (done).** The detection list now renders through the shared `Table`
primitive — the same construct `InboxList` itself uses — in `virtualized` mode
for its scroll container and sticky header. Six clone classes are deleted
(`__table`, `__thead-row`, `__cell`, `__cell--path`, `__tbody-row`,
`__path-cell-inner`); `__table-wrap` survives only to bound the scroll height.

**Accepted-deviation note (done).** `InboxList`/`InboxDetail`/
`InboxStatsSummary` still are not reused, and that is now documented in
`specs/038-wizard-scan-step/spec.md` instead of shipping silently — which was
the issue's actual complaint.

## Why InboxList could not be reused

Not a styling difference — a data-model one.

`InboxList` is typed on `InboxListItem`, which extends `InboxItemSummary` with
~15 enrichment fields the wizard's scan never returns, and it reads exactly
those missing fields for its two headline columns: the detection column reads
`rootAbsolutePath` (`InboxList.tsx:192`), the Type column reads `frameType` /
`groupFrameType` (`InboxList.tsx:110-114`). Feeding it wizard data means
fabricating ~15 fields and still rendering both headline columns blank.

Semantically, `InboxList` models single-type post-materialization items
(`bindings/index.ts:5020-5025`). The wizard runs pre-materialization over
folders that are legitimately multi-type and shows a per-kind count breakdown
("16 light, 2 dark") from a separate `classifications` map. `InboxList` has no
column that can express a breakdown, and it mandates `selectedId`/`onSelect`
while the wizard summary is read-only.

The shared collapsible primitive `ui/Section.tsx` was also evaluated rather than
assumed absent. It renders `{open && children}` with no always-visible body
slot, but the card must keep the spec-048 `RootDetectionConfig` control and the
phase messages visible *while collapsed*. Adopting it would hide or reorder a
documented control — a behaviour change needing its own iterate cycle, not a
reuse refactor.

## Evidence

- `css-dup-sniff`: 1654 → 1648 rules; four-copy utility groups 68 → 67;
  `pv-setup-scan` findings 7 → 6. Classes 24 → 18.
- CSS definitions and TSX usage cross-checked: exact match, no dead rules.
- All 29 `StepScan.test.tsx` tests pass **with no test edits**.
- `pnpm lint` pass, `pnpm typecheck` pass.
- `pnpm test`: 1842/1845. The 3 failures (`GuidedOverlay.test.tsx`,
  `devSurface.release.test.ts`) reproduce identically on clean `origin/main`
  (3 failed | 12 passed both sides) — pre-existing, unrelated to these files.

## Needs real-UI visual validation

`pv-table`'s metrics differ from the deleted bespoke styling (`--pv-text-xs` /
`--pv-text-secondary`, tighter cell padding), so the step's table **will look
different**. Dropping `__path-cell-inner` also removes an explicit flex gap
between the Master pill and its label. Unit tests cannot catch either. Routing
to the real-UI lane per the issue's UI classification.