### PR TITLE
fix: the project Edit form opens as a dialog instead of covering the whole window

### DIFF
--- a/apps/desktop/src/components/Modal.test.tsx
+++ b/apps/desktop/src/components/Modal.test.tsx
@@ -69,3 +69,58 @@ describe('Modal final focus (#844)', () => {
     });
   });
 });
+
+/**
+ * Journey 16 requires every overlay to close on Escape and trap focus. These
+ * assert the contract at the shared-component level, so every Modal consumer
+ * inherits it (#660 regressed because the edit pane bypassed Modal entirely).
+ */
+describe('Modal dismissal and focus containment (Journey 16)', () => {
+  it('closes on Escape', async () => {
+    const onClose = vi.fn();
+    render(
+      <Modal open onClose={onClose} title="Test">
+        <input aria-label="body field" />
+      </Modal>,
+    );
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close' })).toHaveFocus();
+    });
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(onClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('traps focus by removing the page behind it from the a11y tree', async () => {
+    function Harness() {
+      const [open, setOpen] = useState(true);
+      return (
+        <>
+          <button>Outside control</button>
+          <Modal open={open} onClose={() => setOpen(false)} title="Test">
+            <input aria-label="body field" />
+          </Modal>
+        </>
+      );
+    }
+    render(<Harness />);
+
+    expect(await screen.findByRole('dialog')).toBeInTheDocument();
+
+    // jsdom implements no real Tab traversal, so the trap is asserted via the
+    // mechanism that produces it: base-ui marks everything outside the open
+    // dialog inert/aria-hidden, which also drops it out of the a11y tree.
+    // The control is still in the DOM — it is just unreachable.
+    expect(
+      screen.queryByRole('button', { name: 'Outside control' }),
+    ).not.toBeInTheDocument();
+    expect(screen.getByText('Outside control')).toBeInTheDocument();
+
+    // ...and it becomes reachable again once the dialog closes.
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: 'Outside control' }),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/src/features/projects/ProjectDetail.edit-overlay.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.edit-overlay.test.tsx
@@ -1,0 +1,131 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * ProjectDetail — Edit pane dialog chrome (#660).
+ *
+ * The edit pane used to be a bare `position:absolute; inset:0` div with no
+ * positioned ancestor, so it sized against the viewport and hid the whole app
+ * shell, with no dialog role, no Escape and no focus trap. It now renders
+ * through the shared `Modal`, which supplies all four. These assert the
+ * user-visible contract (Journey 16), not the CSS.
+ */
+
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  };
+});
+
+vi.mock('./store', async (importOriginal) => {
+  const original = await importOriginal<typeof import('./store')>();
+  return {
+    ...original,
+    useProjectDetail: vi.fn(),
+    useSessionNames: vi.fn(() => new Map()),
+    useTransitionLifecycle: vi.fn(),
+    useReinferChannels: vi.fn(),
+    useDismissChannelDrift: vi.fn(),
+    useProjectHistory: vi.fn(() => ({
+      data: [],
+      loading: false,
+      error: undefined,
+    })),
+  };
+});
+
+vi.mock('@/shared/toast', () => ({
+  addToast: vi.fn(),
+  useToasts: () => ({ toasts: [], dismiss: vi.fn(), add: vi.fn() }),
+}));
+
+vi.mock('@/features/archive/store', () => ({
+  useGenerateArchivePlan: () => ({ mutateAsync: vi.fn(), isPending: false }),
+}));
+vi.mock('@/features/plans/PlanReviewOverlay', () => ({
+  PlanReviewOverlay: () => null,
+}));
+
+import { ProjectDetailContent } from './ProjectDetail';
+import * as store from './store';
+import type { ProjectDetailDto } from '@/bindings/index';
+
+const BASE_PROJECT: ProjectDetailDto = {
+  id: 'proj-m31',
+  name: 'M 31 LRGB',
+  tool: 'PixInsight',
+  lifecycle: 'ready',
+  path: 'projects/M31',
+  notes: null,
+  channelDrift: { hasNewSources: false, suggestedAction: 'dismiss' },
+  sources: [],
+  channels: [],
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+};
+
+function renderDetail() {
+  vi.mocked(store.useProjectDetail).mockReturnValue({
+    data: BASE_PROJECT,
+    loading: false,
+    error: undefined,
+  });
+  render(<ProjectDetailContent projectId="proj-m31" />);
+}
+
+async function openEditPane() {
+  fireEvent.click(screen.getByRole('button', { name: /edit/i }));
+  return await screen.findByRole('dialog');
+}
+
+describe('ProjectDetail — edit pane dialog chrome (#660)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('is closed until Edit is pressed', () => {
+    renderDetail();
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('opens the edit pane as a dialog with an accessible name', async () => {
+    renderDetail();
+    const dialog = await openEditPane();
+    expect(dialog).toHaveAccessibleName('Edit project');
+    // The pane's own form is inside the dialog, not loose in the page.
+    expect(dialog).toContainElement(screen.getByLabelText(/name/i));
+  });
+
+  it('closes on Escape', async () => {
+    renderDetail();
+    await openEditPane();
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+    });
+  });
+
+  it('traps focus: the detail pane behind it becomes unreachable, then reachable again on close', async () => {
+    renderDetail();
+    await openEditPane();
+
+    // The Edit button that opened the dialog is the page behind; while the
+    // dialog is open base-ui marks it inert, so it leaves the a11y tree.
+    // This is exactly what the old bare-div overlay failed to do.
+    expect(
+      screen.queryByRole('button', { name: /edit/i }),
+    ).not.toBeInTheDocument();
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /edit/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -38,6 +38,7 @@ import {
   DetailPane,
   DetailPanel,
   MetricLine,
+  Modal,
   StatusTag,
   TopActionBar,
 } from '@/components';
@@ -435,15 +436,21 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
         </div>
       )}
 
-      {/* ── Edit pane overlay ───────────────────────────────────────────── */}
-      {editOpen && (
-        <div className="pv-project-detail__edit-overlay">
-          <EditProjectPane
-            project={project}
-            onClose={() => setEditOpen(false)}
-          />
-        </div>
-      )}
+      {/* ── Edit pane overlay (#660) ────────────────────────────────────────
+          Uses the shared Modal rather than a bare positioned div: the old
+          `absolute; inset:0` overlay had no positioned ancestor, so it sized
+          against the viewport and hid the whole app shell. Modal also supplies
+          the dialog semantics Journey 16 requires (role=dialog, Escape,
+          focus trap). */}
+      <Modal
+        open={editOpen}
+        onClose={() => setEditOpen(false)}
+        title={m.projects_edit_pane_aria()}
+        size="lg"
+        data-testid="project-edit-modal"
+      >
+        <EditProjectPane project={project} onClose={() => setEditOpen(false)} />
+      </Modal>
 
       {/* ── Archive plan review overlay (spec 017 US2/WP-B) ──────────────────
           Opens automatically when the plan-gated Archive transition refuses

--- a/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
+++ b/apps/desktop/src/features/projects/edit/EditProjectPane.tsx
@@ -290,10 +290,12 @@ export function EditProjectPane({ project, onClose }: EditProjectPaneProps) {
   }, [addBusy, addSelection, linkedSessionIds, project.id]);
 
   return (
-    <div
-      className="pv-edit-project-pane"
-      aria-label={m.projects_edit_pane_aria()}
-    >
+    // No aria-label here: ProjectDetail always renders this pane inside a
+    // Modal, which already supplies role=dialog + aria-label from the same
+    // string (m.projects_edit_pane_aria()). A second aria-label on this root
+    // would duplicate the accessible name and break getByLabel() queries with
+    // a strict-mode violation (two matching elements).
+    <div className="pv-edit-project-pane">
       {/* Channel drift banner (US1c / US4) */}
       {project.channelDrift?.hasNewSources && (
         <Banner variant="warn" role="status" aria-live="polite">

--- a/apps/desktop/src/styles/components/detail-panes.css
+++ b/apps/desktop/src/styles/components/detail-panes.css
@@ -421,15 +421,6 @@
   justify-content: flex-end;
 }
 
-/* Edit-project pane full-pane overlay */
-.pv-project-detail__edit-overlay {
-  position: absolute;
-  inset: 0;
-  background: var(--pv-surface);
-  z-index: 10;
-  overflow: auto;
-}
-
 /* === INBOX DETAIL === */
 
 /* Muted dash spans produced by fmtOrDash / fmtBinning / fmtExposure / fmtTemp */


### PR DESCRIPTION
## #660 — Project Edit pane hijacks the entire window

**Verified still reproducing** against current `main` before fixing:
`.pv-project-detail__edit-overlay` (`apps/desktop/src/styles/components/detail-panes.css:425`) was `position:absolute; inset:0` with no positioned ancestor, mounted as a bare `div` at `apps/desktop/src/features/projects/ProjectDetail.tsx:441`. The containing block resolved to the viewport, so it covered the whole window — sidebar, list and action bars included — with no dialog role, no Escape and no focus trap.

The `role="dialog"` at `ProjectDetail.tsx:404` belongs to the **re-launch** confirm modal, a different overlay; the edit overlay had none of its own.

### Approach: reuse the shared `Modal`, don't add CSS

Per the one-shared-component mandate, the overlay now renders through `Modal`, which already wraps base-ui's `Dialog` and supplies the backdrop, centred chrome, `role="dialog"`, Escape and focus trap that Journey 16 requires. The dead `.pv-project-detail__edit-overlay` rule is **deleted** rather than repaired — no new CSS block was written, so the positioned-ancestor question disappears rather than being worked around.

This also satisfies the page-layout convention at 1100x720: a centred, width-capped modal with a scrolling body never covers the app's action bars, which was the actual user-visible complaint.

### Tests

- `Modal.test.tsx` — Escape closes; focus containment asserted via the mechanism that produces it (base-ui marks the page behind inert, so it drops out of the a11y tree and becomes reachable again on close). jsdom implements no real Tab traversal.
- `ProjectDetail.edit-overlay.test.tsx` (new) — dialog role, accessible name, Escape, focus trap.

**Non-vacuous:** the three behavioural ProjectDetail tests were confirmed to **fail** against the previous bare-div overlay (3/4 red), then pass after the fix.

## #640 — ConfirmOverlay unstyled confirm dialogs

**Already fixed on `main`; no change made.** Commit `0eb9ec09` ("refactor(components): merge ConfirmOverlay into Modal") deleted `ConfirmOverlay.tsx` and migrated its call sites to `Modal` directly — exactly the reuse-the-shared-component approach this issue called for.

Evidence on current `main`:
- `apps/desktop/src/components/ConfirmOverlay.tsx` no longer exists.
- `confirm-overlay` has **zero** matches repo-wide (the unstyled classes are gone).
- All named consumers now import the styled `Modal`: `DataSources.tsx:48`, `Equipment.tsx:29`, `ObservingSites.tsx:26`.

Closing as resolved rather than inventing a change.

## Gates

Run per-package from `apps/desktop`:

- `pnpm lint` — pass (exit 0)
- `pnpm typecheck` — pass (exit 0)
- `pnpm test` — 1849/1851; the failures are **pre-existing and unrelated** (`GuidedOverlay`, `devSurface.release`, a load-sensitive `row-planning` perf test). Confirmed by reverting these four files to the parent commit and re-running: the same suites fail there too (`GuidedOverlay` fails 4/4 in isolation on the untouched baseline).
- `node apps/desktop/scripts/css-dup-sniff.mjs` — no new duplication; this change only deletes a rule.

## Validation note

Worth a real-UI pass to confirm the edit form reads well inside the `size="lg"` modal body — the pane is tall (sources list + form) and its own Cancel/Save row now sits in the scrolling body rather than a pinned modal footer. Behaviour is unit-covered; it's the visual fit that merits eyes.

Closes #640
Closes #660