### PR TITLE
fix(dev-tools): fix rotting clippy lints and wire CI to catch them

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,6 +306,17 @@ jobs:
         if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # The default workspace clippy above never enables `dev-tools`, so the
+      # developer-mode surface (apps/desktop/src-tauri/src/commands/dev.rs)
+      # was linted by nobody and four lints rotted unseen (#1165). Release
+      # binaries still omit `dev-tools` (see .claude/rules/21-astro-monorepo.md)
+      # — this step only adds lint coverage for the daily developer build, it
+      # does not touch the release build path. Same OS-agnostic reasoning as
+      # the step above, so Linux-only here too.
+      - name: Clippy (desktop_shell, dev-tools feature, deny warnings)
+        if: runner.os == 'Linux' && needs.changes.outputs.rust == 'true'
+        run: cargo clippy -p desktop_shell --features dev-tools --all-targets -- -D warnings
+
       # --- L1 (isolated units) + L2 (real-backend integration) ---
       # No standalone `cargo build --workspace` step: clippy --all-targets
       # (above, Linux) and nextest (below, every OS) each already build every

--- a/apps/desktop/src-tauri/src/commands/dev.rs
+++ b/apps/desktop/src-tauri/src/commands/dev.rs
@@ -56,6 +56,11 @@ impl CallBuffer {
     }
 
     /// Append a new call record. Evicts the oldest entry when over capacity.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned (a prior panic while holding
+    /// the lock).
     pub fn push(&self, call: ContractCall) {
         let mut guard = self.inner.lock().unwrap();
         guard.calls.push(call);
@@ -66,6 +71,11 @@ impl CallBuffer {
     }
 
     /// Return up to `limit` entries in newest-first order.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned (a prior panic while holding
+    /// the lock).
     pub fn snapshot(&self, limit: usize) -> Vec<ContractCall> {
         let guard = self.inner.lock().unwrap();
         // Entries are oldest-first internally; reverse for newest-first output.
@@ -73,8 +83,19 @@ impl CallBuffer {
     }
 
     /// Total entries dropped due to capacity overflow since session start.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned (a prior panic while holding
+    /// the lock).
     pub fn dropped(&self) -> u64 {
         self.inner.lock().unwrap().dropped
+    }
+}
+
+impl Default for CallBuffer {
+    fn default() -> Self {
+        Self::new()
     }
 }
 

--- a/justfile
+++ b/justfile
@@ -16,6 +16,10 @@ lint:
     cargo fmt --all --check
     rustfmt --edition 2021 --check apps/desktop/src-tauri/src/bootstrap/specta.rs
     cargo clippy --workspace --all-targets -- -D warnings
+    # The workspace clippy above never enables `dev-tools`, leaving the
+    # developer-mode surface (commands/dev.rs) unlinted (#1165). Release
+    # binaries still omit the feature; this only lints the daily dev build.
+    cargo clippy -p desktop_shell --features dev-tools --all-targets -- -D warnings
     pnpm -r --if-present lint
     pre-commit run --all-files
 


### PR DESCRIPTION
## Summary

- Fixes the four clippy lints flagged in #1165 in `apps/desktop/src-tauri/src/commands/dev.rs`: `missing_panics_doc` on `CallBuffer::push`/`snapshot`/`dropped` (each calls `.lock().unwrap()`, documented as panicking on a poisoned mutex) and `new_without_default` on `CallBuffer::new()` (added `impl Default`).
- **Decision recorded**: CI now lints the `dev-tools` surface via a scoped clippy pass. The workspace clippy in `.github/workflows/ci.yml` never enables `dev-tools`, so `commands/dev.rs` was compiled by developers daily but linted by nobody. Release binaries still omit `dev-tools` (`.claude/rules/21-astro-monorepo.md`) and that build path is untouched — this only adds lint coverage for the daily developer build. Added a second, Linux-only clippy step (`cargo clippy -p desktop_shell --features dev-tools --all-targets -- -D warnings`) right after the existing workspace clippy step, following the same OS-agnostic-lint reasoning already documented there. Mirrored the same invocation into `justfile`'s `lint` recipe so local `just lint` catches it too.

Closes #1165

## Verification

- `cargo clippy -p desktop_shell --features dev-tools --all-targets -- -D warnings` — clean, no issues.
- `just lint` — pass (workspace clippy, dev-tools clippy, Biome/ESLint, token/i18n checks, pre-commit hooks all green).
- `just typecheck` — pass.
- `just test` — one pre-existing, unrelated failure: `app_core::plan_resume_integration cancel_signals_the_executor_restarted_by_resume`. Passes in isolation (`cargo nextest run -p app_core cancel_signals_the_executor_restarted_by_resume` → 1 passed) but fails under the full parallel `just test` run (both attempts, same assertion — executor left in `"applying"` instead of `"cancelled"`), consistent with a timing/contention race under load. This PR touches only `commands/dev.rs`, `ci.yml`, and `justfile` — nothing in the plan-resume/executor path.

## Test plan

- [x] `cargo clippy -p desktop_shell --features dev-tools --all-targets -- -D warnings` exits clean
- [x] `just lint` passes
- [x] `just typecheck` passes
- [x] `just test` — only the pre-existing unrelated flake noted above