### PR TITLE
fix: show real session counts on the Targets list and mark archived projects

### DIFF
--- a/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.test.tsx
@@ -719,7 +719,26 @@ describe('TargetDetailV2', () => {
         screen.getAllByText('Horsehead 2026').length,
       ).toBeGreaterThanOrEqual(1),
     );
-    expect(screen.getAllByText('ready').length).toBeGreaterThanOrEqual(1);
+    // #739 US3-AC2: lifecycle renders via the shared StatusTag, so it shows
+    // the localized label ("Ready") rather than the raw stored state.
+    expect(screen.getAllByText('Ready').length).toBeGreaterThanOrEqual(1);
+    expect(screen.queryByText('ready')).toBeNull();
+  });
+
+  it('24b. (US3) archived projects carry the shared archived lifecycle tone', async () => {
+    mockListTargetProjects.mockResolvedValue(
+      ok([{ id: 'proj-1', name: 'Old Horsehead', lifecycle: 'archived' }]),
+    );
+    render(<TargetDetailV2 targetId={TARGET_ID} />);
+    await waitFor(() =>
+      expect(
+        screen.getAllByText('Old Horsehead').length,
+      ).toBeGreaterThanOrEqual(1),
+    );
+    const tag = screen.getAllByText('Archived')[0];
+    // Reuses the shared tone token rather than a per-feature style (#739).
+    expect(tag).toHaveClass('pv-status-tag');
+    expect(tag).toHaveClass('pv-status-tag--ok');
   });
 
   it('25. (US3) clicking project row navigates to /projects with selected=id (mid-page link row)', async () => {

--- a/apps/desktop/src/features/targets/TargetDetailV2.tsx
+++ b/apps/desktop/src/features/targets/TargetDetailV2.tsx
@@ -46,10 +46,12 @@ import {
   DetailPane,
   DetailPanel,
   PropertyTable,
+  StatusTag,
   type PropertyDef,
 } from '@/components';
 import { Pill, Section, EmptyState, Banner, Btn, Skeleton } from '@/ui';
 import { m } from '@/lib/i18n';
+import { projectStateLabel, projectStateVariant } from '@/lib/lifecycle';
 import {
   altitudeFor,
   moonExcludedSpanHours,
@@ -707,9 +709,12 @@ export function TargetDetailV2({
                       }
                     >
                       <span className="pv-planner__link-name">{p.name}</span>
-                      <span className="pv-planner__link-state">
-                        {p.lifecycle}
-                      </span>
+                      {/* #739 US3-AC2: lifecycle carries the shared tone (and
+                          localized label) every other project surface uses,
+                          so an archived project reads as archived here too. */}
+                      <StatusTag variant={projectStateVariant(p.lifecycle)}>
+                        {projectStateLabel(p.lifecycle)}
+                      </StatusTag>
                     </button>
                   </li>
                 ))}

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -781,3 +781,76 @@ describe('TargetsTable — no-dark-window summer night (#579, glyph model)', () 
     }
   });
 });
+
+// ── Sessions column (#622) ───────────────────────────────────────────────────
+
+/**
+ * The Sessions cell used to be a hardcoded em-dash even though the backend
+ * populates `TargetListItem.sessionCount` (#877). These assert the column reads
+ * the real field, still shows '—' for genuinely-unshot targets, and that its
+ * header sort is no longer a no-op.
+ */
+describe('TargetsTable Sessions column (#622)', () => {
+  function sessionCell(label: string): HTMLElement {
+    const row = within(screen.getByRole('table'))
+      .getByText(label)
+      .closest('tr') as HTMLTableRowElement;
+    const cells = row.querySelectorAll('td');
+    // Sessions is the last column (COLUMNS order).
+    return cells[cells.length - 1] as HTMLElement;
+  }
+
+  it('renders the real sessionCount instead of a placeholder dash', () => {
+    renderTable({
+      targets: [{ ...item('SHOT'), sessionCount: 12 }],
+    });
+    expect(sessionCell('SHOT')).toHaveTextContent('12');
+  });
+
+  it("renders '—' for a target with no linked sessions (never a bare 0)", () => {
+    renderTable({ targets: [{ ...item('UNSHOT'), sessionCount: 0 }] });
+    const cell = sessionCell('UNSHOT');
+    expect(cell).toHaveTextContent('—');
+    expect(cell).not.toHaveTextContent('0');
+  });
+
+  it('treats an absent sessionCount (older client) as no sessions', () => {
+    const noField = item('LEGACY');
+    delete (noField as { sessionCount?: number }).sessionCount;
+    renderTable({ targets: [noField] });
+    expect(sessionCell('LEGACY')).toHaveTextContent('—');
+  });
+
+  it('sorts by session count ascending, tie-breaking on designation', () => {
+    renderTable({
+      targets: [
+        { ...item('MANY'), sessionCount: 9 },
+        { ...item('ZED'), sessionCount: 1 },
+        { ...item('ABLE'), sessionCount: 1 },
+      ],
+      sort: { col: 'sessions', dir: 'asc' },
+    });
+    const labels = Array.from(
+      screen.getByRole('table').querySelectorAll('tbody tr'),
+    )
+      .map((tr) => tr.querySelector('td:nth-child(2)')?.textContent ?? '')
+      .filter((t) => t.length > 0);
+    expect(labels[0]).toContain('ABLE');
+    expect(labels[1]).toContain('ZED');
+    expect(labels[2]).toContain('MANY');
+  });
+
+  it('reverses order when sorted descending (sort is not a no-op)', () => {
+    renderTable({
+      targets: [
+        { ...item('MANY'), sessionCount: 9 },
+        { ...item('FEW'), sessionCount: 1 },
+      ],
+      sort: { col: 'sessions', dir: 'desc' },
+    });
+    const first = screen
+      .getByRole('table')
+      .querySelector('tbody tr td:nth-child(2)');
+    expect(first?.textContent).toContain('MANY');
+  });
+});

--- a/apps/desktop/src/features/targets/TargetsTable.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.tsx
@@ -609,9 +609,16 @@ export function TargetsTable({
                   <td className="pv-targets-cell--num">
                     <ImagingTimeCell alt={altMoon} threshold={usableAltDeg} />
                   </td>
-                  {/* MOCK (#57): linked-session count not on TargetListItem yet. */}
+                  {/* #622: real linked-session count (`sessionCount`, #877).
+                      Zero renders '—' rather than a bare 0 — a target nothing
+                      has been shot on has no coverage to report, matching the
+                      muted placeholder the row's other unknown cells use. */}
                   <td className="pv-targets-cell--num">
-                    <span className="pv-targets-cell--muted">—</span>
+                    {(t.sessionCount ?? 0) > 0 ? (
+                      t.sessionCount
+                    ) : (
+                      <span className="pv-targets-cell--muted">—</span>
+                    )}
                   </td>
                 </tr>
               );

--- a/apps/desktop/src/features/targets/TargetsTableColumns.tsx
+++ b/apps/desktop/src/features/targets/TargetsTableColumns.tsx
@@ -21,7 +21,8 @@ import { m } from '@/lib/i18n';
 //
 // Opposition: real next midnight-transit peak date (spec 047 US4,
 // astro/opposition.ts); unknown coordinates render '—'.
-// Sessions: linked-session count not on TargetListItem yet (#57). Renders '—'.
+// Sessions: real linked-session count from `TargetListItem.sessionCount`
+// (#877/#622); zero renders '—'.
 // All non-text columns are sortable on their mock value.
 
 // `label`/`title` are render-time thunks (spec 046 #8b) so headers re-read the active locale.

--- a/apps/desktop/src/features/targets/table-model.ts
+++ b/apps/desktop/src/features/targets/table-model.ts
@@ -37,7 +37,7 @@ import type { ObserverSite } from './observing-sites/observer-site';
  *   - lunarDist: sorts by real target↔Moon separation; unknowns sort last
  *     regardless of direction (spec 047 US2)
  *   - imagingTime: sorts by hoursAboveUsable (Track B placeholder)
- *   - sessions: stub — all values 0; sort is a no-op
+ *   - sessions: sorts by real linked-session count (#622), ties by designation
  */
 export type TargetSortCol =
   | 'designation'
@@ -140,8 +140,12 @@ export function compareTargetRows(
       cmp = altA.hoursAboveUsable - altB.hoursAboveUsable;
       break;
     case 'sessions':
-      // All values are 0 until backend #57 lands; preserve input order.
-      cmp = 0;
+      // #622: real `sessionCount` (#877). Absent on older clients → 0, which
+      // sorts alongside genuinely-unshot targets; designation breaks ties so
+      // the order stays deterministic across the many zero-count rows.
+      cmp =
+        (a.sessionCount ?? 0) - (b.sessionCount ?? 0) ||
+        compareStr(a.effectiveLabel, b.effectiveLabel);
       break;
   }
   return sort.dir === 'asc' ? cmp : -cmp;


### PR DESCRIPTION
Frontend-only pass over the dead-column reports in #622 and #739. Several
items turned out to be **already fixed on main** since the issues were filed;
this PR changes only the two that were genuinely still broken and reports the
rest rather than inventing changes.

## Fixed here

**Targets list — SESSIONS column (#622 item 4).**
`TargetListItem` has carried a real, backend-populated `sessionCount` since
\#877 (`crates/app/targets/src/target_management.rs:182-187`, sourced from
`session_counts_by_target`), but the cell still rendered a hardcoded em-dash
and the column's sort was `cmp = 0`. Both now read the real field.

Deviation from the issue's recommendation, stated deliberately: #622 proposed
*hiding* IMG TIME/SESSIONS outside "My targets", or folding them into a
"Coverage" column. Since the data now exists on the DTO, populating the column
is strictly better than hiding it — and still needs no backend change. Zero
renders `—` rather than a bare `0`, matching the row's other unknown cells.

**Target detail — archived-project lifecycle tone (#739 US3-AC2).**
Linked projects rendered `p.lifecycle` as raw unstyled text. Now routed through
the existing shared `projectStateVariant`/`projectStateLabel` + `StatusTag` —
the documented canonical "state at a glance" affordance every other project
surface already uses. No new CSS class and no per-feature tone style was added.

## Already fixed on main (verified, no change made)

- **#622 item 1** — Integ is computed from `frames × exposure`:
  `ProjectSourcesSection.tsx:56`.
- **#622 item 2** — SOURCE renders a human label, not a raw UUID:
  `ProjectSourcesSection.tsx:54-55` (#663, since closed).
- **#622 item 4, IMG TIME half** — renders real astronomy-computed hours;
  `—` only when coordinates or an observing site are genuinely absent
  (`TargetsTableColumns.tsx`, `ImagingTimeCell`).
- **#739 item 1, filter half** — `TargetSessionItem` gained `filter` and the UI
  renders date + filter + frame count, satisfying US2-AC1
  (`TargetDetailV2.tsx`, sessions list).

## Blocked on backend (not stubbed — deliberately left as-is)

Per the frontend-only boundary, these need Rust DTO changes and have no
standalone frontend half:

- **#622 item 3** — Projects list "Target" column. `ProjectSummaryDto`
  (`bindings/index.ts:7848`) has no target field; `ProjectDetailDto` already
  carries `canonicalTarget: ProjectCanonicalTarget | null`. Needs the
  equivalent on the summary DTO.
- **#739 item 1, exposure half** — `TargetSessionItem` has no `exposure` field.
- **#739 item 2** — target-note `updated_at`. `canonical_target` has no such
  column and `TargetNoteUpdateResult` returns only `{ notes }`.

## Tests

Five new cases across `TargetsTable.test.tsx` (real count renders; zero and an
absent field both degrade to the dash; ascending sort with designation
tie-break; descending reverses) and `TargetDetailV2.test.tsx` (archived carries
the shared tone class). Verified **non-vacuous** by reverting the
implementation and confirming the count and sort tests fail.

Existing test 24 now expects the localized "Ready" — the visible consequence of
routing lifecycle through the shared component.

## Gates

`pnpm lint` ✅ (exit 0, all token/contrast/i18n checks) · `pnpm typecheck` ✅ ·
`pnpm test` — my two suites pass 80/80. Five failures elsewhere
(`GuidedOverlay.test.tsx` joyride, and an inbox masters case) are
**pre-existing on main**: they reproduce in isolation and neither `guided/`,
`inbox/` nor `calibration/` is touched by this branch's 6-file diff.
`css-dup-sniff` reports no new duplication — this PR adds no CSS.

Refs #622, #739. Neither is fully resolved; the backend items above remain.