### PR TITLE
ci: run Windows E2E journeys one at a time, since their isolation is fake

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -68,9 +68,45 @@ failure-output = "immediate-final"
 # green CI runs there show 1-3 retried flakes recovering by luck). One extra
 # retry buys more margin without masking a real regression, since a genuinely
 # broken journey still fails all 3 attempts.
+#
+# `threads-required = 2` makes each Windows journey occupy the whole
+# `test-threads = 2` budget, i.e. Windows runs one journey at a time while
+# ubuntu/macOS keep running two.
+#
+# Why (#1204): the note above claims concurrent journeys have "isolated
+# app-data/config dirs". That is true on Linux (`XDG_*`) and macOS (`HOME`),
+# and **false on Windows**. `InstanceEnv::new` sets `APPDATA`/`LOCALAPPDATA`,
+# but Tauri resolves those directories through `dirs`, which on Windows calls
+# `SHGetKnownFolderPath(FOLDERID_RoamingAppData)` (`dirs-sys-0.5.0/src/lib.rs`)
+# — the Known Folder API ignores both environment variables outright. So every
+# concurrent instance shares the real `C:\Users\runneradmin\AppData\…`.
+#
+# Observed end-to-end in main run 29734205501, `windows-latest 1/2`, in the
+# driver log that #1262 started surfacing:
+#
+#   WARN resolve_cache: Database already open. Cannot acquire lock.
+#         path=…\AppData\Roaming\…\simbad-cache.redb          <- 2nd instance
+#   ERROR tauri_runtime_wry: failed to create webview:
+#         WebView2 error: WindowsError(HRESULT(0x80070057))   <- shared UDF
+#   Error serving connection: … target machine actively refused it (10061)
+#   Error: window.__ALM_E2E__ bridge never became ready within 30s
+#
+# No webview means no window, so the plugin's WebDriver port never serves and
+# every proxy request is refused — which is the bare "bridge never became
+# ready" this file's readers have been chasing since #1019.
+#
+# This is the *same class* of bug as the single-instance collision documented
+# above, which was also Windows/macOS-only for the same reason: per-instance
+# isolation that exists on Linux and silently does not on Windows.
+#
+# Serialising is the honest fix available here, not the ideal one. Real
+# isolation needs the app to accept an explicit data-directory override (and
+# to pass it to the webview's `data_directory`), since no environment variable
+# can redirect a Known Folder. Tracked on #1204; revert this when that lands.
 [[profile.e2e.overrides]]
 platform = 'cfg(windows)'
 retries = 2
+threads-required = 2
 
 # ---------------------------------------------------------------------------
 # CI profile for the Layer-1 workspace test run (spec: build/adopt-nextest).


### PR DESCRIPTION
Refs #1204, #1019. One config line; the rest is the evidence.

## Root cause of "bridge never became ready"

Visible for the first time in the driver log #1262 started attaching — main run `29734205501`, `windows-latest 1/2`:

```
WARN  resolve_cache: Database already open. Cannot acquire lock.
      path=C:\Users\runneradmin\AppData\Roaming\…\simbad-cache.redb
ERROR tauri_runtime_wry: failed to create webview:
      WebView2 error: WindowsError(HRESULT(0x80070057), "The parameter is incorrect.")
Error serving connection: … target machine actively refused it (os error 10061)
Error: window.__ALM_E2E__ bridge never became ready within 30s
```

Read bottom-up, the chain is complete and every link is observed:

1. Two app instances are alive at once (the redb lock proves it).
2. The second fails to create its **WebView2** user-data folder → `HRESULT(0x80070057)`.
3. No webview means no window, so `tauri-plugin-webdriver` never binds its port.
4. Every proxy request is refused (`10061`).
5. The client reports the bare **"bridge never became ready"**.

The generic error this issue has chased since #1019 was **four layers downstream** of the real fault.

## Why two instances collide on Windows only

`.config/nextest.toml` justifies `test-threads = 2` on the premise that concurrent journeys have *"isolated app-data/config dirs"*.

That premise is **true on Linux** (`XDG_*`), **true on macOS** (`HOME`), and **false on Windows**.

`InstanceEnv::new` does set `APPDATA`/`LOCALAPPDATA` — but Tauri resolves those directories through `dirs`, which on Windows calls `SHGetKnownFolderPath(FOLDERID_RoamingAppData)` (`dirs-sys-0.5.0/src/lib.rs:176`). **The Known Folder API ignores both environment variables outright.** Verified in the vendored source, not assumed.

So on Windows every concurrent instance shares the real `C:\Users\runneradmin\AppData\…`: one redb file, one WebView2 user-data folder.

Note this is the **same class of bug** as the single-instance collision already documented in that file — also Windows/macOS-only, also because per-instance isolation exists on Linux and silently does not elsewhere. That one was found and patched; this one sat behind it.

It also explains the symptom pattern: Windows-only, hits an arbitrary journey (whichever loses the race), and passes on retry once the other instance has exited.

## The change

```toml
[[profile.e2e.overrides]]
platform = cfg(windows)
retries = 2
threads-required = 2   # <- added
```

Each Windows journey now occupies the whole `test-threads = 2` budget, so Windows runs one journey at a time. ubuntu/macOS are untouched and keep running two, because their isolation is genuine.

## Honest limits

- **This serialises rather than isolates.** Real isolation needs the app to accept an explicit data-directory override *and* pass it to the webviews `data_directory` — no environment variable can redirect a Known Folder. Recorded in the config comment and left open on #1204; revert this when that lands.
- **Throughput cost is real but likely smaller than it looks**: the Windows shard currently burns 44s per failed attempt plus up to 3 retries on collisions, and `archive_lifecycle_apply_trash_permanent_delete` spent 154s failing. Serial-but-passing may well beat concurrent-but-colliding. I have not measured that, and I am not claiming it.
- ~~`archive_lifecycle_apply_trash_permanent_delete` failed all three attempts — a hard failure, not this race.~~ **Corrected after checking the logs:** all three of its attempts failed with `bridge never became ready` (TRY 1/2 with the transport error, TRY 3 with the original bare `Unknown error`). It is the *same* collision, not a separate fault — so this PR should address it too, and the whole Windows-side redness in that run reduces to one cause. I had written it off as unrelated before reading its stderr.

## Verification

- `.config/nextest.toml` parses; `cargo nextest list -p e2e_tests --profile e2e --run-ignored all` accepts the profile with no warnings and lists all **24** journeys, including the one that failed.
- The real proof is the next Windows E2E run, which is now observable at all thanks to #1268.