### PR TITLE
fix: plan review shows both the source and destination of every move

### DIFF
--- a/apps/desktop/src/features/inbox/PlanPanel.tsx
+++ b/apps/desktop/src/features/inbox/PlanPanel.tsx
@@ -1047,7 +1047,22 @@ export function PlanPanel({
                             </span>
                           )}
                         </span>
+                        {/* #606 (Constitution II — a filesystem mutation must be
+                            reviewable): show BOTH sides of the move, not just the
+                            destination. The source was previously only reachable by
+                            hovering the file-name cell's tooltip, so a reviewer could
+                            not see what a move was actually moving. Mirrors
+                            PlanReviewOverlay's From/To columns. In-place catalogue
+                            actions have no second side — the single path is the
+                            item's current (and final) location. */}
                         <span className="pv-plan-panel__file-dest">
+                          <code
+                            className="pv-plan-panel__path"
+                            data-testid={`inbox-source-absolute-${rowIdx}`}
+                            title={`${m.plans_review_col_from()}: ${a.fromPath}`}
+                          >
+                            {a.fromPath}
+                          </code>
                           {inPlace ? (
                             <span className="pv-plan-panel__inplace">
                               {m.inbox_inplace_label()}
@@ -1058,20 +1073,19 @@ export function PlanPanel({
                                 className="pv-plan-panel__summary-arrow"
                                 aria-hidden="true"
                               >
+                                {' '}
                                 →{' '}
                               </span>
                               <code
-                                className="pv-plan-panel__dest"
+                                className="pv-plan-panel__path"
                                 data-testid={`inbox-dest-absolute-${rowIdx}`}
-                                title={destText}
+                                title={`${m.plans_review_col_to()}: ${destText}`}
                               >
                                 {destText}
                               </code>
                             </>
                           )}
                         </span>
-                        <span />
-                        <span />
                       </div>
                     );
                   })}

--- a/apps/desktop/src/features/inbox/__tests__/PlanApprovalOverlay.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/PlanApprovalOverlay.test.tsx
@@ -219,4 +219,40 @@ describe('PlanApprovalOverlay', () => {
     expect(screen.getByRole('dialog')).toBeInTheDocument();
     expect(screen.getByTestId('inbox-root-picker')).toBeInTheDocument();
   });
+
+  // #606 (Constitution II — every filesystem mutation must be reviewable):
+  // the Inbox overlay used to render the destination only; the source was
+  // reachable solely by hovering the file-name cell's `title` tooltip, so a
+  // reviewer could not see what a move was actually moving. Both sides must
+  // render as visible text on the SAME row, so neither can regress
+  // independently. Mirrors the equivalent assertion for the Projects/Archive
+  // consumer in PlanReviewOverlay.test.tsx.
+  it('#606: renders both the source and the destination path for a move item', () => {
+    renderOverlay({
+      plans: [
+        makePlan({
+          inboxItemId: 'item-1',
+          actions: [
+            makeAction({
+              action: 'move',
+              fromPath: '/root/lights/img001.fits',
+              toPath: '/dest/lights/img001.fits',
+              destinationPreview: '/dest/lights/img001.fits',
+            }),
+          ],
+        }),
+      ],
+    });
+    // Per-file rows are collapsed until the group is expanded.
+    fireEvent.click(screen.getByTestId('plan-group-toggle-item-1'));
+
+    const source = screen.getByTestId('inbox-source-absolute-0');
+    const dest = screen.getByTestId('inbox-dest-absolute-0');
+    expect(source).toHaveTextContent('/root/lights/img001.fits');
+    expect(dest).toHaveTextContent('/dest/lights/img001.fits');
+    // Both sides belong to one action's row, not merely somewhere in the panel.
+    const row = source.closest('.pv-plan-panel__file-row');
+    expect(row).not.toBeNull();
+    expect(row).toContainElement(dest);
+  });
 });

--- a/apps/desktop/src/styles/components/merges-1.css
+++ b/apps/desktop/src/styles/components/merges-1.css
@@ -756,7 +756,7 @@
   flex-wrap: wrap;
 }
 .pv-listpage__detail-body .pv-plan-panel__summary-dest,
-.pv-listpage__detail-body .pv-plan-panel__dest {
+.pv-listpage__detail-body .pv-plan-panel__path {
   word-break: break-all;
 }
 

--- a/apps/desktop/src/styles/components/plan-panel.css
+++ b/apps/desktop/src/styles/components/plan-panel.css
@@ -137,11 +137,15 @@
   gap: var(--pv-sp-1);
   color: var(--pv-text-muted);
 }
+/* #606: carries BOTH the source and destination path, so it claims the row's
+   otherwise-empty trailing columns (file count / discard are group-level only)
+   rather than squeezing two absolute paths into one 1.3fr column. */
 .pv-plan-panel__file-dest {
   display: inline-flex;
   align-items: baseline;
   gap: var(--pv-sp-0);
   min-width: 0;
+  grid-column: 4 / -1;
 }
 .pv-plan-panel__inplace {
   color: var(--pv-text-muted);
@@ -312,12 +316,15 @@
   white-space: nowrap;
 }
 
-.pv-plan-panel__dest {
+/* Shared path cell for BOTH sides of a plan action (#606). `direction: rtl`
+   keeps the meaningful tail visible when a long absolute path is ellipsised. */
+.pv-plan-panel__path {
   color: var(--pv-text-secondary);
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
   direction: rtl;
+  min-width: 0;
 }
 
 /* ── Destructive destination control ────────────────────────── */


### PR DESCRIPTION
## What

Makes the Inbox plan overlay show **both sides** of every move. Previously it rendered only each action's destination; the source was reachable solely by hovering the file-name cell's `title` tooltip, so a reviewer could not see what a move was actually moving.

This matters beyond cosmetics: Constitution II requires every filesystem mutation to be reviewable *before* it is applied. An overlay that hides half of each move undermines that guarantee.

## Issue #606 was substantially stale — verified against current main

Two of the three claims in #606 had already been fixed since it was filed (2026-07-11), and this PR does **not** re-fix them:

- **"`PlanReviewOverlay` shows the source but no destination"** — already fixed. PR #492 (`bbbd11ff`, "PlanReviewOverlay had no destination column at all (FR-003 gap)") added it. Current main renders `Item · Action · From · To · Protection` at `PlanReviewOverlay.tsx:369-379`, plus a same-row `#606` regression test added by PR #1025 at `PlanReviewOverlay.test.tsx:272-280`.
- **"duplicated header/close CSS (`merges-3.css:1117-1283`)"** — already consolidated. Both overlays now render through the shared `Modal` (`@/components`); those lines are a single shared `.pv-modal__*` block (`merges-3.css:1093`, "Modal — shared parameterised dialog/overlay").

The remaining real gap was the Inbox half, which this PR closes.

## Why not one unified overlay component

The issue recommends unifying both overlays into one. I did not, because they have genuinely divergent semantics — this is the escape hatch the task allows, and the divergence is concrete:

- **Cardinality** — `PlanReviewOverlay` reviews ONE plan by id via `plans.get`; `PlanApprovalOverlay` reviews N plans grouped by ingestion, with per-group selection, select-all, and apply-selected/all/one.
- **DTO** — `PlanItemDetail_Serialize` (`from`/`to`/`protection`/`state`/`reason`/`linked`/`provenance`) vs `InboxPlanAction` (`fromPath`/`toPath`/`destinationPreview`/`requiresDestructiveConfirm`). The Inbox DTO carries **no** protection, state, or reason field, so the proposed `Protection` column has no data source on that side.
- **Lifecycle** — approve-token → apply → retry/resume/cancel vs inbox confirm → apply + destination-root picker + archive/trash choice.
- **Layout** — the Inbox per-file rows are deliberately a CSS grid sharing the group-header column template so File aligns under "Plan" (`plan-panel.css:110-118`). Replacing them with the review overlay's `Table` would regress that alignment.

`PlanReviewOverlay.tsx:18-21` already documents this split as intentional. Merging them would produce two components in a trenchcoat, not one parameterised component.

## Approach

Instead of cloning a second path class, the existing truncating path cell is **reused for both sides** and renamed `__dest` → `__path`, since it now serves source and destination. `direction: rtl` keeps the meaningful path tail visible when ellipsised.

The path cell claims the row's trailing columns (`grid-column: 4 / -1`) — file count and discard are group-level and always empty per file — rather than squeezing two absolute paths into one `1.3fr` column.

## Gates

- `pnpm lint` — pass (exit 0)
- `pnpm typecheck` — pass (exit 0)
- `pnpm test` — the only failures are **5 pre-existing tests** in `devSurface.release.test.ts` and `GuidedOverlay.test.tsx`, proven pre-existing by running those two suites at `origin/main` without this change (identical 5 failures, same names). Unrelated to this PR.
- `css-dup-sniff` — 80 findings on both this branch and `origin/main`. **No reduction was available**: the duplication #606 cited was already removed by the shared-`Modal` extraction. This change adds no clone.

## Test coverage

`PlanApprovalOverlay.test.tsx` gains a `#606` test asserting source and destination both render as visible text **on the same row** (via `closest('.pv-plan-panel__file-row')`), so neither side can regress independently. Verified non-vacuous: it fails against the pre-fix component.

The Projects/Archive consumer already has the equivalent same-row assertion (`PlanReviewOverlay.test.tsx:272-280`), so both consumer contexts are covered.

## Needs real-UI visual validation

The two-path row is a layout change to a grid whose columns are shared with the group header. Unit tests confirm both paths render in the same row, but **not** that two long absolute paths read well at the app's real width. This needs a look on the real UI (Inbox → expand a plan group) before it is trusted — a separate lane owns the Tauri bridge, so I did not drive it.

Closes #606
