### PR TITLE
feat: triage the inbox from the keyboard, with clearer master and protection labels

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -1959,6 +1959,8 @@
   "inbox_no_file_metadata_caveat": "Required-attribute status is checked when you confirm.",
   "inbox_col_detection": "Path",
   "inbox_no_detections": "No detections.",
+  "inbox_hotkey_hint": "J / K to move through detections, C to confirm the selected one.",
+  "inbox_row_selected_aria": "Selected: {label}",
   "inbox_review_plans_title": "Review plans",
   "inbox_plan_col_plan": "Plan",
   "inbox_plan_col_composition": "Composition",

--- a/apps/desktop/src/features/inbox/InboxDetail.tsx
+++ b/apps/desktop/src/features/inbox/InboxDetail.tsx
@@ -304,6 +304,9 @@ export function InboxDetail({
           onClick={onConfirm}
           disabled={confirmDisabled || confirmBusy}
           aria-label={confirmLabel}
+          // Issue #747: lets assistive tech announce the C binding on the
+          // control it activates, not only in the list's visual hint.
+          aria-keyshortcuts="C"
           data-testid="inbox-confirm-btn"
           data-guide-anchor="inbox.confirm-row"
         >

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -36,6 +36,7 @@ import { groupByDimensions, type GroupNode } from './grouping';
 import { ACCESSORS, dimLabel } from './InboxControls';
 import { m } from '@/lib/i18n';
 import { masterLabel } from '@/lib/master-label';
+import { useHotkeys } from '@/lib/useHotkeys';
 
 // ── Sort model ────────────────────────────────────────────────────────────────
 
@@ -378,6 +379,67 @@ export function InboxList({
     }));
   }, [grouped, tree, collapsed, originalIndexById, filtered]);
 
+  // ── J/K triage navigation (spec 027 FR-022, issue #747) ─────────────────────
+  // Bound here rather than on the page because this component owns the visual
+  // order: grouping, collapse state, sort and filters all reshape it, and J/K
+  // must step through what the user actually sees.
+  const navigableIds = useMemo(
+    () =>
+      visualRows
+        .filter((r): r is ItemVisualRow => r.kind === 'item')
+        .map((r) => r.item.inboxItemId),
+    [visualRows],
+  );
+
+  const step = useCallback(
+    (delta: number) => {
+      if (navigableIds.length === 0) return;
+      const cur = selectedId ? navigableIds.indexOf(selectedId) : -1;
+      // Clamped, not wrapped: triage is a top-to-bottom sweep, and silently
+      // jumping back to the top reads as "nothing happened" at the last row.
+      // With nothing selected, J enters at the top and K at the bottom.
+      const next =
+        cur === -1
+          ? delta > 0
+            ? 0
+            : navigableIds.length - 1
+          : Math.min(navigableIds.length - 1, Math.max(0, cur + delta));
+      const id = navigableIds[next];
+      if (id && id !== selectedId) onSelect(id);
+    },
+    [navigableIds, selectedId, onSelect],
+  );
+
+  // Single-key bindings, matching the scheme the retired Inbox ActionSidebar
+  // used. useHotkeys suppresses these while a text field has focus.
+  useHotkeys(
+    {
+      KeyJ: (e) => {
+        e.preventDefault();
+        step(1);
+      },
+      KeyK: (e) => {
+        e.preventDefault();
+        step(-1);
+      },
+    },
+    [step],
+  );
+
+  // Selection moves without moving DOM focus (the target row may not even be
+  // rendered under virtualization), so nothing would reach a screen reader
+  // without an explicit announcement.
+  const selectedItem = useMemo(
+    () =>
+      selectedId
+        ? visualRows.find(
+            (r): r is ItemVisualRow =>
+              r.kind === 'item' && r.item.inboxItemId === selectedId,
+          )?.item
+        : undefined,
+    [visualRows, selectedId],
+  );
+
   // ── Sortable column headers (SessionsTable convention) ──────────────────────
   const makeSortHeader = (
     col: InboxSortCol,
@@ -555,6 +617,21 @@ export function InboxList({
           {groupingHint}
         </div>
       )}
+      {/* Discoverability for the otherwise invisible J/K/C bindings (#747). */}
+      <div className="pv-listtable__foot" data-testid="inbox-hotkey-hint">
+        {m.inbox_hotkey_hint()}
+      </div>
+      {/* Keyboard selection moves no DOM focus, so announce it explicitly. */}
+      <div
+        className="pv-visually-hidden"
+        role="status"
+        aria-live="polite"
+        data-testid="inbox-selection-announcer"
+      >
+        {selectedItem
+          ? m.inbox_row_selected_aria({ label: detectionLabel(selectedItem) })
+          : ''}
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/features/inbox/InboxList.tsx
+++ b/apps/desktop/src/features/inbox/InboxList.tsx
@@ -35,6 +35,7 @@ import { SortHeader, ariaSortFor } from '@/components';
 import { groupByDimensions, type GroupNode } from './grouping';
 import { ACCESSORS, dimLabel } from './InboxControls';
 import { m } from '@/lib/i18n';
+import { masterLabel } from '@/lib/master-label';
 
 // ── Sort model ────────────────────────────────────────────────────────────────
 
@@ -156,17 +157,14 @@ function formatTag(item: InboxListItem): string {
 
 /**
  * The exact label rendered in the Format column cell (issue #649): a master
- * row displays `"{type} master"`, not its raw `formatTag`. The sort
- * comparator MUST compare this same displayed string — comparing the
- * internal format tag instead (as before) let master rows interleave
- * arbitrarily with FITS rows because "FITS" never equals "bias master" etc.
+ * row displays its spec 040 FR-006 "type · filter · exposure" label, not its
+ * raw `formatTag`. The sort comparator MUST compare this same displayed
+ * string — comparing the internal format tag instead (as before) let master
+ * rows interleave arbitrarily with FITS rows because "FITS" never equals
+ * "Master Bias" etc.
  */
 function formatDisplayLabel(item: InboxListItem): string {
-  return item.isMaster
-    ? m.inbox_master_row_label({
-        type: item.masterFrameType ?? m.inbox_state_master_fallback(),
-      })
-    : formatTag(item);
+  return item.isMaster ? masterLabel(item) : formatTag(item);
 }
 
 /**

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -48,6 +48,7 @@ import { m } from '@/lib/i18n';
 import type { FrameType } from '@/lib/route-contract';
 import { useGrouping } from '@/lib/use-grouping';
 import { useStaleSelectionCleanup } from '@/lib/use-stale-selection';
+import { useHotkeys } from '@/lib/useHotkeys';
 import { addToast } from '@/shared/toast';
 import { Btn } from '@/ui';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from './InboxControls';
@@ -832,6 +833,22 @@ export function InboxPage() {
     !fileMetadataError &&
     !hasMissingRequiredMeta &&
     !hasOpenPlan;
+
+  // Spec 027 FR-022 (issue #747): confirm the selected detection from the
+  // keyboard, so a triage sweep never leaves the home row. Gated on the same
+  // `canConfirm` as the button — the shortcut must not reach a state the
+  // visible affordance refuses. J/K navigation lives in InboxList, which owns
+  // the visual row order.
+  useHotkeys(
+    {
+      KeyC: (e) => {
+        if (!canConfirm || confirmLoading) return;
+        e.preventDefault();
+        void handleConfirm();
+      },
+    },
+    [canConfirm, confirmLoading, handleConfirm],
+  );
 
   const planBusy = applyAllLoading || applySelectedLoading || cancelLoading;
 

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.classificationAndPath.test.tsx
@@ -229,11 +229,11 @@ describe('InboxList — unsplit-folder badge agrees with inbox_classify (#711 In
 });
 
 describe('InboxList — Format column sort matches the displayed value (#649)', () => {
-  it('sorts master rows by their displayed "{type} master" label, not the internal format tag', () => {
-    // Displayed labels, ascending (locale compare): "bias master" <
-    // "dark master" < "FITS". Sorting by the internal `formatTag` (always
-    // "FITS" for masters, ignoring the displayed "{type} master" swap) left
-    // masters interleaved arbitrarily with plain FITS rows instead.
+  it('sorts master rows by their displayed spec 040 label, not the internal format tag', () => {
+    // Displayed labels, ascending (locale compare): "FITS" < "Master Bias" <
+    // "Master Dark". Sorting by the internal `formatTag` (always "FITS" for
+    // masters, ignoring the displayed master-label swap) left masters
+    // interleaved arbitrarily with plain FITS rows instead.
     const items = [
       makeItem({
         inboxItemId: 'dark-master',
@@ -259,9 +259,9 @@ describe('InboxList — Format column sort matches the displayed value (#649)', 
     const rows = screen.getAllByTestId(/^inbox-item-/);
     const order = rows.map((r) => r.getAttribute('data-testid'));
     expect(order).toEqual([
+      'inbox-item-plain-fits',
       'inbox-item-bias-master',
       'inbox-item-dark-master',
-      'inbox-item-plain-fits',
     ]);
   });
 });

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.hotkeys.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.hotkeys.test.tsx
@@ -1,0 +1,205 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Inbox J/K triage navigation (spec 027 FR-022/SC-003, issue #747).
+ *
+ * The Inbox shipped with zero keyboard bindings, so the "triage 10 sessions
+ * in under 60s" claim was false. These cover the binding contract the sweep
+ * asked for: J/K step the selection through VISIBLE rows, the shortcuts stay
+ * out of the way while typing, and the move is announced to a screen reader.
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { InboxList } from '../InboxList';
+import type { InboxListItem } from '@/bindings/index';
+
+function makeItem(
+  over: Partial<InboxListItem> & { inboxItemId: string },
+): InboxListItem {
+  return {
+    relativePath: over.inboxItemId,
+    fileCount: 1,
+    lane: 'fits',
+    format: 'fits',
+    state: 'classified',
+    contentSignature: `sig-${over.inboxItemId}`,
+    isMaster: false,
+    masterFrameType: null,
+    masterFilter: null,
+    masterExposureS: null,
+    rootAbsolutePath: '/lib/root',
+    organizationState: 'unorganized',
+    groupTarget: null,
+    groupFrameType: null,
+    groupDate: null,
+    groupFilter: null,
+    groupExposure: null,
+    groupInstrument: null,
+    groupId: over.inboxItemId,
+    groupKey: 'type=dark',
+    ...over,
+  } as InboxListItem;
+}
+
+const ITEMS = [
+  makeItem({ inboxItemId: 'a', frameType: 'dark' }),
+  makeItem({ inboxItemId: 'b', frameType: 'dark' }),
+  makeItem({ inboxItemId: 'c', frameType: 'dark' }),
+];
+
+function press(key: 'j' | 'k') {
+  fireEvent.keyDown(window, {
+    key,
+    code: key === 'j' ? 'KeyJ' : 'KeyK',
+  });
+}
+
+describe('InboxList — J/K triage navigation (#747)', () => {
+  it('J selects the first row when nothing is selected yet', () => {
+    const onSelect = vi.fn();
+    render(
+      <InboxList
+        items={ITEMS}
+        selectedId={null}
+        onSelect={onSelect}
+        filterType="all"
+      />,
+    );
+    press('j');
+    expect(onSelect).toHaveBeenCalledWith('a');
+  });
+
+  it('K enters at the LAST row when nothing is selected yet', () => {
+    const onSelect = vi.fn();
+    render(
+      <InboxList
+        items={ITEMS}
+        selectedId={null}
+        onSelect={onSelect}
+        filterType="all"
+      />,
+    );
+    press('k');
+    expect(onSelect).toHaveBeenCalledWith('c');
+  });
+
+  it('J advances to the next row and K returns to the previous one', () => {
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <InboxList
+        items={ITEMS}
+        selectedId="a"
+        onSelect={onSelect}
+        filterType="all"
+      />,
+    );
+    press('j');
+    expect(onSelect).toHaveBeenLastCalledWith('b');
+
+    rerender(
+      <InboxList
+        items={ITEMS}
+        selectedId="b"
+        onSelect={onSelect}
+        filterType="all"
+      />,
+    );
+    press('k');
+    expect(onSelect).toHaveBeenLastCalledWith('a');
+  });
+
+  it('clamps at both ends rather than wrapping around', () => {
+    const onSelect = vi.fn();
+    const { rerender } = render(
+      <InboxList
+        items={ITEMS}
+        selectedId="c"
+        onSelect={onSelect}
+        filterType="all"
+      />,
+    );
+    press('j');
+    expect(onSelect).not.toHaveBeenCalled();
+
+    rerender(
+      <InboxList
+        items={ITEMS}
+        selectedId="a"
+        onSelect={onSelect}
+        filterType="all"
+      />,
+    );
+    press('k');
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('does not fire while the user is typing in a text field', () => {
+    const onSelect = vi.fn();
+    render(
+      <>
+        <input aria-label={'filter'} data-testid="typing-here" />
+        <InboxList
+          items={ITEMS}
+          selectedId="a"
+          onSelect={onSelect}
+          filterType="all"
+        />
+      </>,
+    );
+    const input = screen.getByTestId('typing-here');
+    input.focus();
+    fireEvent.keyDown(input, { key: 'j', code: 'KeyJ' });
+    expect(onSelect).not.toHaveBeenCalled();
+  });
+
+  it('steps over rows hidden by a filter instead of selecting them', () => {
+    // The Type filter hides row "b"; J from "a" must land on "c".
+    const onSelect = vi.fn();
+    render(
+      <InboxList
+        items={[
+          makeItem({ inboxItemId: 'a', frameType: 'dark' }),
+          makeItem({ inboxItemId: 'b', frameType: 'flat' }),
+          makeItem({ inboxItemId: 'c', frameType: 'dark' }),
+        ]}
+        selectedId="a"
+        onSelect={onSelect}
+        filterType="all"
+        kindFilter="dark"
+      />,
+    );
+    press('j');
+    expect(onSelect).toHaveBeenCalledWith('c');
+  });
+
+  it('announces the selected row in a polite live region', () => {
+    render(
+      <InboxList
+        items={ITEMS}
+        selectedId="b"
+        onSelect={vi.fn()}
+        filterType="all"
+      />,
+    );
+    const announcer = screen.getByTestId('inbox-selection-announcer');
+    expect(announcer).toHaveAttribute('aria-live', 'polite');
+    expect(announcer).toHaveTextContent('Selected: b');
+  });
+
+  it('makes the bindings discoverable in the list footer', () => {
+    render(
+      <InboxList
+        items={ITEMS}
+        selectedId={null}
+        onSelect={vi.fn()}
+        filterType="all"
+      />,
+    );
+    expect(screen.getByTestId('inbox-hotkey-hint')).toHaveTextContent(
+      /J \/ K.*C to confirm/i,
+    );
+  });
+});

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.masterLabel.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.masterLabel.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * Inbox master row label (spec 040 FR-006/US2, issue #754).
+ *
+ * The Format cell used to render the master's frame type alone, so a dark and
+ * a flat master were indistinguishable from their exposure/filter. FR-006
+ * requires "type · filter · exposure" on the persistent list, not only in the
+ * first-run wizard's transient scan step.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { InboxList } from '../InboxList';
+import type { InboxListItem } from '@/bindings/index';
+
+function makeMaster(
+  over: Partial<InboxListItem> & { inboxItemId: string },
+): InboxListItem {
+  return {
+    relativePath: over.inboxItemId,
+    fileCount: 1,
+    lane: 'fits',
+    format: 'fits',
+    state: 'classified',
+    contentSignature: `sig-${over.inboxItemId}`,
+    isMaster: true,
+    masterFrameType: null,
+    masterFilter: null,
+    masterExposureS: null,
+    rootAbsolutePath: '/lib/root',
+    organizationState: 'unorganized',
+    groupTarget: null,
+    groupFrameType: null,
+    groupDate: null,
+    groupFilter: null,
+    groupExposure: null,
+    groupInstrument: null,
+    groupId: over.inboxItemId,
+    groupKey: 'type=dark',
+    ...over,
+  } as InboxListItem;
+}
+
+function renderList(items: InboxListItem[]) {
+  render(
+    <InboxList
+      items={items}
+      selectedId={null}
+      onSelect={vi.fn()}
+      filterType="all"
+    />,
+  );
+}
+
+describe('InboxList — master row label (#754)', () => {
+  it('shows type and exposure for a dark master', () => {
+    renderList([
+      makeMaster({
+        inboxItemId: 'd1',
+        masterFrameType: 'dark',
+        masterExposureS: 300,
+      }),
+    ]);
+    expect(screen.getByText('Master Dark · 300 s')).toBeInTheDocument();
+  });
+
+  it('shows type and filter for a flat master', () => {
+    renderList([
+      makeMaster({
+        inboxItemId: 'f1',
+        masterFrameType: 'flat',
+        masterFilter: 'Ha',
+      }),
+    ]);
+    expect(screen.getByText('Master Flat · Ha')).toBeInTheDocument();
+  });
+
+  it('no longer renders the bare frame type that #754 reported', () => {
+    renderList([
+      makeMaster({
+        inboxItemId: 'd2',
+        masterFrameType: 'dark',
+        masterExposureS: 300,
+        masterFilter: 'L',
+      }),
+    ]);
+    expect(screen.queryByText('dark master')).not.toBeInTheDocument();
+    expect(screen.getByText('Master Dark · L · 300 s')).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
+++ b/apps/desktop/src/features/projects/OutputsCleanupSections.tsx
@@ -34,6 +34,7 @@ import {
 import type { PillVariant } from '@/ui';
 import { m } from '@/lib/i18n';
 import { formatBytes } from '@/lib/format';
+import { isProtectedLevel, protectionLabel } from '@/lib/protection-label';
 import { addToast } from '@/shared/toast';
 import { PlanReviewOverlay } from '@/features/plans/PlanReviewOverlay';
 import { useCleanupScan, useGenerateCleanupPlan } from './cleanupStore';
@@ -159,7 +160,7 @@ function candidateColumns() {
  */
 function candidateRow(candidate: CleanupCandidate, index: number) {
   const parsed = parseCandidateReason(candidate.reason);
-  const isProtected = parsed?.protection === 'protected';
+  const isProtected = isProtectedLevel(parsed?.protection);
   return {
     _testid: `cleanup-candidate-${index}`,
     _rowClassName: isProtected ? 'pv-cleanup-scan__row--protected' : undefined,
@@ -180,10 +181,10 @@ function candidateRow(candidate: CleanupCandidate, index: number) {
             protected row, and is stated once above the table. Giving each row
             its own tab stop would repeat that same announcement N times. */}
         <Lock decorative />
-        <Pill variant="warn">{m.settings_cleanup_protection_protected()}</Pill>
+        <Pill variant="warn">{protectionLabel('protected')}</Pill>
       </span>
     ) : parsed ? (
-      <Pill variant="ghost">{parsed.protection}</Pill>
+      <Pill variant="ghost">{protectionLabel(parsed.protection)}</Pill>
     ) : null,
   };
 }

--- a/apps/desktop/src/features/sessions/RawFrameCleanupSection.tsx
+++ b/apps/desktop/src/features/sessions/RawFrameCleanupSection.tsx
@@ -27,6 +27,7 @@ import {
 import type { TableColumn } from '@/ui';
 import { m } from '@/lib/i18n';
 import { formatBytes } from '@/lib/format';
+import { isProtectedLevel, protectionLabel } from '@/lib/protection-label';
 import { errMessage } from '@/lib/errors';
 import { addToast } from '@/shared/toast';
 import { PlanReviewOverlay } from '@/features/plans/PlanReviewOverlay';
@@ -118,7 +119,7 @@ export function RawFrameCleanupSection({
   };
 
   const rows = candidates.map((c: RawFrameCleanupCandidate) => {
-    const isProtected = c.protection === 'protected';
+    const isProtected = isProtectedLevel(c.protection);
     return {
       _testid: `raw-cleanup-candidate-${c.frameId}`,
       select: isProtected ? null : (
@@ -139,10 +140,10 @@ export function RawFrameCleanupSection({
       ),
       type: c.frameType,
       size: formatBytes(c.sizeBytes),
-      protection: isProtected ? (
-        <Pill variant="warn">{m.settings_cleanup_protection_protected()}</Pill>
-      ) : (
-        <Pill variant="ghost">{c.protection}</Pill>
+      protection: (
+        <Pill variant={isProtected ? 'warn' : 'ghost'}>
+          {protectionLabel(c.protection)}
+        </Pill>
       ),
     };
   });

--- a/apps/desktop/src/features/settings/SourceProtectionOverride.tsx
+++ b/apps/desktop/src/features/settings/SourceProtectionOverride.tsx
@@ -18,6 +18,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { Pill, Btn } from '@/ui';
 import { sourceProtectionGet, sourceProtectionSet } from './settingsIpc';
 import type { ProtectionLevel } from './settingsIpc';
+import { protectionLabel } from '@/lib/protection-label';
 import { m } from '@/lib/i18n';
 
 interface SourceProtectionOverrideProps {
@@ -36,11 +37,6 @@ type LoadState = 'idle' | 'loading' | 'ready' | 'saving' | 'error';
 // 2-level model (issue #506): the third "normal" level is retired — absence
 // of a per-source override already means inherit-global, so a distinct
 // explicit "normal" state added confusion without capability.
-const LEVEL_LABEL: Record<ProtectionLevel, () => string> = {
-  protected: m.settings_cleanup_protection_protected,
-  unprotected: m.settings_cleanup_protection_unprotected,
-};
-
 const LEVEL_VARIANT: Record<
   ProtectionLevel,
   'ok' | 'info' | 'warn' | 'danger' | 'neutral'
@@ -143,7 +139,7 @@ export function SourceProtectionOverride({
         variant={LEVEL_VARIANT[level]}
         title={levelHint(level, inheritsDefault)}
       >
-        {LEVEL_LABEL[level]()}
+        {protectionLabel(level)}
       </Pill>
 
       {open && (

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -452,8 +452,9 @@ describe('StepScan', () => {
       const row = screen.getByTestId('scan-item-master-001');
       // "Master" pill in the Folder/File cell
       expect(within(row).getByText('Master')).toBeInTheDocument();
-      // Frame type + exposure in the Detected types cell (filter null → omitted)
-      expect(within(row).getByText('Master Dark · 300s')).toBeInTheDocument();
+      // Frame type + exposure in the Detected types cell (filter null → omitted).
+      // Exposure now goes through the shared formatExposureSeconds (#811).
+      expect(within(row).getByText('Master Dark · 300 s')).toBeInTheDocument();
     });
 
     it('reconciles the file count by surfacing unclassified files (issue #513)', async () => {

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -11,6 +11,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Pill } from '@/ui/Pill';
 import type { PillVariant } from '@/ui/Pill';
 import { m } from '@/lib/i18n';
+import { masterLabel } from '@/lib/master-label';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type { InboxItemSummary } from '@/bindings/index';
@@ -82,26 +83,6 @@ function getRootId(flushResult: FlushResult, path: string): string {
   const row = flushResult.results.find((r) => r.path === path);
   // Successful rows carry the assigned rootId; fall back to the path if absent.
   return row?.rootId ?? path;
-}
-
-/** Capitalize the first letter (e.g. "dark" → "Dark"). */
-function titleCase(s: string): string {
-  return s.length > 0 ? s[0].toUpperCase() + s.slice(1) : s;
-}
-
-/**
- * Human label for a detected calibration master item (spec 040 FR-006).
- * e.g. "Master Dark", "Master Flat · Ha · 120s".  Falls back to a generic
- * "Master" when the base frame type couldn't be inferred.
- */
-function masterLabel(item: InboxItemSummary): string {
-  const ft: string = item.masterFrameType
-    ? m.setup_scan_master_kind({ kind: titleCase(item.masterFrameType) })
-    : m.setup_scan_master();
-  const parts: string[] = [ft];
-  if (item.masterFilter) parts.push(item.masterFilter);
-  if (item.masterExposureS != null) parts.push(`${item.masterExposureS}s`);
-  return parts.join(' · ');
 }
 
 // ── Per-source detection summary ──────────────────────────────────────────────

--- a/apps/desktop/src/lib/master-label.test.ts
+++ b/apps/desktop/src/lib/master-label.test.ts
@@ -1,0 +1,57 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, expect } from 'vitest';
+import { masterLabel } from './master-label';
+
+describe('masterLabel (spec 040 FR-006, issue #754)', () => {
+  it('composes type · filter · exposure', () => {
+    expect(
+      masterLabel({
+        masterFrameType: 'flat',
+        masterFilter: 'Ha',
+        masterExposureS: 120,
+      }),
+    ).toBe('Master Flat · Ha · 120 s');
+  });
+
+  it('labels a dark by type and exposure (FR-006 example)', () => {
+    expect(
+      masterLabel({
+        masterFrameType: 'dark',
+        masterFilter: null,
+        masterExposureS: 300,
+      }),
+    ).toBe('Master Dark · 300 s');
+  });
+
+  it('labels a flat by type and filter (FR-006 example)', () => {
+    expect(
+      masterLabel({
+        masterFrameType: 'flat',
+        masterFilter: 'Ha',
+        masterExposureS: null,
+      }),
+    ).toBe('Master Flat · Ha');
+  });
+
+  it('omits qualifiers the extractor could not determine', () => {
+    expect(masterLabel({ masterFrameType: 'bias' })).toBe('Master Bias');
+  });
+
+  it('degrades to a bare Master rather than fabricating a type', () => {
+    expect(masterLabel({ masterFrameType: null })).toBe('Master');
+  });
+
+  it('keeps a zero-second exposure — 0 is a value, not a missing field', () => {
+    expect(masterLabel({ masterFrameType: 'bias', masterExposureS: 0 })).toBe(
+      'Master Bias · 0 s',
+    );
+  });
+
+  it('rounds a raw FITS exposure float instead of printing it (#811)', () => {
+    expect(
+      masterLabel({ masterFrameType: 'light', masterExposureS: 6.92447668 }),
+    ).toBe('Master Light · 6.9 s');
+  });
+});

--- a/apps/desktop/src/lib/master-label.ts
+++ b/apps/desktop/src/lib/master-label.ts
@@ -1,0 +1,53 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Label for a detected calibration master (spec 040 FR-006, issue #754).
+ *
+ * FR-006/US2 requires masters be identified by type + filter + exposure —
+ * "Master Dark · 300 s", "Master Flat · Ha". The first-run wizard's scan step
+ * built this label; the persistent Inbox list rendered the frame type alone,
+ * so the same master read differently on the two surfaces that show it.
+ * Both now call this.
+ */
+
+import { m } from '@/lib/i18n';
+import { formatExposureSeconds } from '@/lib/format';
+
+/**
+ * The master fields shared by `InboxItemSummary` and `InboxListItem`.
+ * Structural rather than a binding import: the two DTOs differ in optionality
+ * (`_Serialize` vs `_Deserialize`) but agree on these three.
+ */
+export interface MasterLabelFields {
+  masterFrameType?: string | null;
+  masterFilter?: string | null;
+  masterExposureS?: number | null;
+}
+
+/** Capitalize the first letter (e.g. "dark" → "Dark"). */
+function titleCase(s: string): string {
+  return s.length > 0 ? s[0].toUpperCase() + s.slice(1) : s;
+}
+
+/**
+ * Compose a master's display label, omitting qualifiers the extractor could
+ * not determine. Degrades to a bare "Master" when even the frame type is
+ * unknown — never fabricates a type.
+ *
+ * Exposure goes through `formatExposureSeconds` so masters round and space
+ * their unit like every other exposure in the app (#811); FR-006's "300s"
+ * examples predate that convention.
+ */
+export function masterLabel(item: MasterLabelFields): string {
+  const parts: string[] = [
+    item.masterFrameType
+      ? m.setup_scan_master_kind({ kind: titleCase(item.masterFrameType) })
+      : m.setup_scan_master(),
+  ];
+  if (item.masterFilter) parts.push(item.masterFilter);
+  if (item.masterExposureS != null) {
+    parts.push(formatExposureSeconds(item.masterExposureS));
+  }
+  return parts.join(' · ');
+}

--- a/apps/desktop/src/lib/protection-label.test.ts
+++ b/apps/desktop/src/lib/protection-label.test.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, expect } from 'vitest';
+import { isProtectedLevel, protectionLabel } from './protection-label';
+
+describe('protectionLabel (issue #801)', () => {
+  it('labels the protected level', () => {
+    expect(protectionLabel('protected')).toBe('Protected');
+  });
+
+  it('labels the unprotected level', () => {
+    expect(protectionLabel('unprotected')).toBe('Unprotected');
+  });
+
+  it('never echoes an unrecognized backend string back to the user', () => {
+    // The regression #801 filed: cleanup tables printed `c.protection` raw.
+    for (const raw of ['normal', 'NOT_PROTECTED', '', 'wat']) {
+      expect(protectionLabel(raw)).not.toBe(raw);
+    }
+  });
+
+  it('collapses unknown values to unprotected, mirroring parse_level', () => {
+    expect(protectionLabel('normal')).toBe('Unprotected');
+  });
+
+  it('isProtectedLevel matches only the exact protected value', () => {
+    expect(isProtectedLevel('protected')).toBe(true);
+    expect(isProtectedLevel('unprotected')).toBe(false);
+    expect(isProtectedLevel(null)).toBe(false);
+    expect(isProtectedLevel(undefined)).toBe(false);
+  });
+});

--- a/apps/desktop/src/lib/protection-label.ts
+++ b/apps/desktop/src/lib/protection-label.ts
@@ -1,0 +1,43 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Localized labels for spec-016 source protection levels (issue #801).
+ *
+ * Cleanup-candidate tables used to render the `protected` case through the
+ * catalog and print every other case as the raw backend string. This is the
+ * one place a protection value becomes user-facing prose.
+ *
+ * Callers own the `Pill` variant: the same level reads differently per
+ * surface (in Settings `protected` is reassuring — `ok`; in a cleanup
+ * candidate table it is a blocker — `warn`), so only the label is shared.
+ */
+
+import type { ProtectionLevel } from '@/bindings/index';
+import { m } from '@/lib/i18n';
+
+const LEVEL_LABEL: Record<ProtectionLevel, () => string> = {
+  protected: m.settings_cleanup_protection_protected,
+  unprotected: m.settings_cleanup_protection_unprotected,
+};
+
+/**
+ * Label an effective protection level.
+ *
+ * `protection` is typed `string` on the cleanup-candidate DTOs rather than as
+ * the closed `ProtectionLevel` union, so unknown values are possible on the
+ * wire. Anything that is not `protected` collapses to `unprotected`, mirroring
+ * `ProtectionLevel::parse_level` in crates/contracts/core/src/protection.rs —
+ * the UI must not report a frame as unprotected-looking when the backend would
+ * treat it as protected, and vice versa.
+ */
+export function protectionLabel(protection: string): string {
+  return protection === 'protected'
+    ? LEVEL_LABEL.protected()
+    : LEVEL_LABEL.unprotected();
+}
+
+/** True when `protection` resolves to the protected level. */
+export function isProtectedLevel(protection: string | null | undefined): boolean {
+  return protection === 'protected';
+}

--- a/apps/desktop/src/lib/protection-label.ts
+++ b/apps/desktop/src/lib/protection-label.ts
@@ -38,6 +38,8 @@ export function protectionLabel(protection: string): string {
 }
 
 /** True when `protection` resolves to the protected level. */
-export function isProtectedLevel(protection: string | null | undefined): boolean {
+export function isProtectedLevel(
+  protection: string | null | undefined,
+): boolean {
   return protection === 'protected';
 }


### PR DESCRIPTION
## Summary

- Triage the Inbox from the keyboard: `J`/`K` move through detections and `C` confirms the selected one. The Inbox previously bound no keys at all.
- Calibration masters in the Inbox list now read "Master Dark · 300 s" / "Master Flat · Ha" instead of just the frame type, matching how the first-run wizard already labelled them.
- Cleanup tables no longer show an untranslated internal value in the Protection column — every protection state is now a proper label.

---

Three Inbox/cleanup defects from the 2026-07-14 verification sweep. Each was re-verified against current `main` before being touched (the `alm-` → `pv-` rename had made the filed line numbers stale).

## #747 — Inbox had zero keyboard shortcuts

Spec 027 FR-022/SC-003 claims triage of 10 sessions in under 60s, but nothing in the Inbox bound a key: the `ActionSidebar` that once carried them was deleted and nothing replaced it.

Bindings go through the shared `useHotkeys` hook, which already suppresses shortcuts while a text field has focus:

- `J` / `K` — step the selection through the list. Bound in `InboxList` because it owns the visual row order (grouping, collapse state, sort and filters all reshape it), so navigation follows what the user actually sees rather than the page's unsorted array. Clamps rather than wraps: triage is a top-to-bottom sweep, and jumping back to the top reads as "nothing happened".
- `C` — confirm the selected detection. Bound on the page, gated on the same `canConfirm` as the button, so the shortcut can never reach a state the visible affordance refuses.

`Escape` was deliberately **not** bound: `ListPageLayout` already registers a document-level Escape handler for every list page including Inbox (J16/S4), and arrow-key row traversal already lives in the shared `Table`.

Accessibility:
- Selection moves without moving DOM focus (under virtualization the target row may not be rendered), so the list announces the selected row through a polite live region.
- The Confirm button carries `aria-keyshortcuts`.
- The list footer states the bindings — the app had no existing shortcut-help surface to hang them on.

## #754 — Inbox list showed only the master frame type

Spec 040 FR-006/US2 requires "type · filter · exposure". That label existed only in the first-run wizard's transient scan step, so the same master read differently on the two surfaces that show it. `masterFilter`/`masterExposureS` were already on the wire.

The wizard's `masterLabel()` is extracted into a shared helper used by both call sites rather than copied. Exposure now goes through the existing `formatExposureSeconds`, so masters round and space their unit like every other exposure in the app instead of printing a raw FITS float (#811) — FR-006's `300s` examples predate that convention.

The Format-column sort comparator already compared the displayed string, so it follows the new label automatically (#649).

## #801 — Cleanup tables leaked a raw backend protection string

The `protected` case rendered through the catalog; every other case printed `c.protection` verbatim. The same defect was present in `OutputsCleanupSections`, which the issue had pointed to as the reference implementation — both are fixed.

The label map that already existed in `SourceProtectionOverride` is extracted into a shared helper and used at all three call sites. Callers keep their own `Pill` variant, because the same level reads differently per surface: in Settings `protected` is reassuring (`ok`), in a cleanup candidate table it is a blocker (`warn`). Unknown values collapse to `unprotected`, mirroring `ProtectionLevel::parse_level`, so the UI never disagrees with the backend about what is protected.

## Tests

New: `master-label.test.ts` (7), `protection-label.test.ts` (5), `InboxList.hotkeys.test.tsx` (8 — entry, step, clamp, skip-hidden-rows, typing suppression, live region, footer hint), `InboxList.masterLabel.test.tsx` (3).

Updated for the intended label change: the #649 master sort ordering, and the StepScan FR-006 exposure assertion.

## Gates

`pnpm lint` ✅ · `pnpm typecheck` ✅ · `pnpm test` — all touched suites pass.

Two unrelated files (`devSurface.release.test.ts`, `GuidedOverlay.test.tsx`) fail under full-suite load with 15s **timeouts**. Verified pre-existing: they fail the same way on a clean `origin/main` worktree, and pass 15/15 isolated on this branch.

No CSS was added — the footer hint reuses `pv-listtable__foot` and the live region reuses `pv-visually-hidden`. `css-dup-sniff.mjs` reports no new duplication.

## Needs real-UI validation

The J/K/C bindings and the live-region announcement are unit-tested via synthetic `keydown`; real-app verification should confirm they do not collide with the command palette (`$mod+K`), the `ListPageLayout` Escape handler, or the guided tour overlay.

Closes #747
Closes #754
Closes #801
