### PR TITLE
ci: give the two Detect changes jobs distinct names and narrow the E2E workflow trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,7 +48,7 @@ jobs:
   #   all_files — CSV of every changed path, consumed by the changed-crate
   #               scoping step for `cargo test -p`.
   changes:
-    name: Detect changes
+    name: Detect changes (CI)
     runs-on: ubuntu-latest
     outputs:
       rust: ${{ steps.decide.outputs.rust }}

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -149,7 +149,7 @@ jobs:
   # and "the suite never ran" indistinguishable to humans and pollers alike
   # (see the PR that introduced this comment: job 88177101061).
   changes:
-    name: Detect changes
+    name: Detect changes (E2E)
     runs-on: ubuntu-latest
     outputs:
       run: ${{ steps.decide.outputs.run }}
@@ -160,8 +160,14 @@ jobs:
         id: filter
         with:
           filters: |
+            # Deliberately NOT '.github/workflows/**': editing ci.yml or
+            # release-please.yml cannot change how e2e.yml runs its shards.
+            # The broad glob made every ci.yml touch — including one-line
+            # fixes like #1282 — force a full E2E run, which is a large part
+            # of the Windows/macOS runner contention. Mirrors the same
+            # narrowing ci.yml already applies (#1169).
             force_full:
-              - '.github/workflows/**'
+              - '.github/workflows/e2e.yml'
               - '**/Cargo.toml'
               - 'Cargo.lock'
               - '**/package.json'


### PR DESCRIPTION
## Summary

Two related fixes to CI routing. Neither changes what is tested.

## 1. `Detect changes` was ambiguous across two workflows

`ci.yml` and `e2e.yml` both defined a job displayed as **`Detect changes`**. Branch protection matches required contexts **by name**, so requiring `Detect changes` required *both* to pass — cancelling a queued E2E run to relieve runner pressure turned the CI gate red on PRs whose CI lane was perfectly healthy (#1295 hit this). The duplicate also rendered twice in every PR check list with no way to tell which was which.

They are genuinely different jobs:

| | `ci.yml` | `e2e.yml` |
|---|---|---|
| Outputs | `rust`, `frontend`, `frontend_full`, `docs_only`, `scripts`, `all_files` | `run`, `run_macos` |
| Decides | which Rust/frontend lanes run, full-vs-`vitest related`, `cargo test -p` scoping | whether the E2E suite runs at all, and the dispatch-only macOS chain |

Now named `Detect changes (CI)` and `Detect changes (E2E)`.

## 2. `e2e.yml` forced a full run on *any* workflow edit

`force_full` matched `.github/workflows/**`, so editing `ci.yml`, `release-please.yml` — anything — pulled in the entire Windows/macOS shard matrix. A one-line `ci.yml` fix like #1282 was triggering a full E2E run.

Windows/macOS runner pools are the binding constraint on this repo's throughput, not the 20-job aggregate, so this is a material share of the contention.

`ci.yml` already narrowed its own equivalent to a single file for exactly this reason (#1169, "treating every workflow edit as a full-suite trigger is what made a Rust-only refactor run the entire frontend suite"). This mirrors it: `.github/workflows/e2e.yml`.

`justfile` and `scripts/**` stay in `force_full` — those genuinely drive both lanes.

## Branch protection must be updated with this

Renaming changes the required-context strings. `Detect changes` must be replaced with `Detect changes (CI)` in main's required checks, or main gates on a name nothing reports — the failure mode `scripts/branch-protection-main.sh verify` exists to catch.