### PR TITLE
fix: the Activity panel opens as a properly styled full-width bottom section

### DIFF
--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -420,7 +420,6 @@
   "logpanel_level_all_aria": "All levels",
   "logpanel_source_filter_aria": "Category filter",
   "logpanel_source_all_aria": "All sources",
-  "logpanel_preview_aria": "Latest log entry",
   "logpanel_title": "Activity",
   "nav_aria_label": "Main navigation",
   "nav_my_targets": "My Targets",

--- a/apps/desktop/messages/en.json
+++ b/apps/desktop/messages/en.json
@@ -412,6 +412,7 @@
   "logpanel_diagnostics": "Diagnostics",
   "logpanel_empty": "No log entries",
   "logpanel_empty_filtered": "No entries match the current filter.",
+  "logpanel_empty_filtered_named": "No entries match {filter}",
   "logpanel_export": "Export",
   "logpanel_export_aria": "Export log to JSON file",
   "logpanel_export_failed": "Could not export: {error}",

--- a/apps/desktop/src/app/LogPanel.test.tsx
+++ b/apps/desktop/src/app/LogPanel.test.tsx
@@ -329,12 +329,49 @@ describe('LogPanel expand/collapse + filters (T006)', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'target' }));
 
+    // #669: the miss must NAME the filter that excluded the rows, not just
+    // say "a filter is on" — an unnamed message still leaves the user unable
+    // to tell which control to undo.
     await waitFor(() => {
-      expect(
-        screen.getByText('No entries match the current filter.'),
-      ).toBeInTheDocument();
+      expect(screen.getByText('No entries match target')).toBeInTheDocument();
     });
     expect(screen.queryByText('No log entries')).not.toBeInTheDocument();
+  });
+
+  it('names an active severity filter in the empty state (#669)', async () => {
+    // The Sweep-C repro: entries exist, the Error severity chip is active,
+    // and nothing matches.
+    appendLog([
+      {
+        id: 'aud:10',
+        contractVersion: '1',
+        time: '2026-01-01T00:00:00Z',
+        level: 'info',
+        source: 'audit',
+        message: 'All good',
+      },
+    ]);
+    renderPanel();
+
+    fireEvent.click(getTrigger());
+    await waitFor(() => {
+      expect(screen.getByText('All good')).toBeInTheDocument();
+    });
+
+    const levelGroup = screen.getByRole('group', { name: 'Level filter' });
+    fireEvent.click(within(levelGroup).getByRole('button', { name: 'Error' }));
+
+    await waitFor(() => {
+      expect(screen.getByText('No entries match Error')).toBeInTheDocument();
+    });
+    expect(screen.queryByText('No log entries')).not.toBeInTheDocument();
+  });
+
+  it('still shows the plain empty message when nothing was recorded', () => {
+    renderPanel();
+    fireEvent.click(getTrigger());
+
+    expect(screen.getByText('No log entries')).toBeInTheDocument();
   });
 
   it('gives the level-filter and category-filter "All" chips distinct accessible names', async () => {

--- a/apps/desktop/src/app/LogPanel.tsx
+++ b/apps/desktop/src/app/LogPanel.tsx
@@ -42,6 +42,7 @@ import type { LevelFilter } from './LogPanelContext';
 import { errMessage } from '@/lib/errors';
 import { formatTimeOfDay } from '@/lib/datetime';
 import { useHotkeys } from '@/lib/useHotkeys';
+import { EmptyState } from '@/ui/EmptyState';
 
 // ── Level chip display helpers ────────────────────────────────────────────────
 
@@ -92,6 +93,28 @@ const ALL_LOG_SOURCES: LogEntrySource[] = [
   'target',
   'tool',
 ];
+
+/**
+ * Names the filters currently narrowing the list, or `null` when none of the
+ * user-selectable filters is active.
+ *
+ * #669 / Journey 13: a filtered-to-empty log must never render the same copy
+ * as a log that recorded nothing, so the empty state names what is excluding
+ * the rows. Returns `null` when only the non-user-selectable diagnostics gate
+ * is doing the excluding — there is no filter name to show the user then.
+ */
+function activeFilterLabel(
+  levelFilter: LevelFilter,
+  sourceFilter: LogEntrySource[],
+): string | null {
+  const parts: string[] = [];
+  if (levelFilter !== 'all') {
+    const chip = LEVEL_CHIPS.find((c) => c.value === levelFilter);
+    if (chip) parts.push(chip.label());
+  }
+  parts.push(...sourceFilter);
+  return parts.length > 0 ? parts.join(', ') : null;
+}
 
 // ── Entity navigation helpers ─────────────────────────────────────────────────
 
@@ -169,8 +192,7 @@ export function LogPanel() {
     return true;
   });
 
-  // Idle preview: show the most-recent visible entry message.
-  const previewEntry = visibleEntries[0];
+  const filterLabel = activeFilterLabel(levelFilter, sourceFilter);
 
   // Virtualize the (potentially long) log list. The `<ul>` is the scroll
   // element; entries are newest-first so index 0 (offset 0) is the newest.
@@ -309,16 +331,6 @@ export function LogPanel() {
       <div className="pv-logpanel__header">
         <span className="pv-logpanel__title">{m.logpanel_title()}</span>
 
-        {/* Idle preview line (collapsed state) */}
-        {!expanded && previewEntry && (
-          <span
-            className={`pv-logpanel__preview pv-logpanel__event-level--${previewEntry.level}`}
-            aria-label={m.logpanel_preview_aria()}
-          >
-            {formatTimeOfDay(previewEntry.time)} {previewEntry.message}
-          </span>
-        )}
-
         {/* Level filter chips (expanded state) */}
         {expanded && (
           <div
@@ -366,7 +378,7 @@ export function LogPanel() {
         {/* Category/source filter chips (#666) */}
         {expanded && (
           <div
-            className="pv-logpanel__filters"
+            className="pv-logpanel__filters pv-logpanel__filters--sources"
             role="group"
             aria-label={m.logpanel_source_filter_aria()}
           >
@@ -409,60 +421,64 @@ export function LogPanel() {
           </div>
         )}
 
-        {/* Follow toggle */}
-        {expanded && (
-          <button
-            type="button"
-            className={`pv-btn pv-btn--ghost pv-btn--xs${followLogs ? ' pv-logpanel__chip--active' : ''}`}
-            onClick={() => {
-              const next = !followLogs;
-              setFollowLogs(next);
-              // #832: re-enabling Follow must resume at the newest row even
-              // if a manual scroll-up left `scrollPaused` set — otherwise the
-              // follow-tail effect's guard (`!followLogs || scrollPaused`)
-              // silently no-ops and the toggle looks broken.
-              if (next) setScrollPaused(false);
-            }}
-            aria-pressed={followLogs}
+        {/* Actions — pinned to the header's trailing edge so they keep a
+            stable position as the filter chips wrap onto more rows. */}
+        <div className="pv-logpanel__actions">
+          {/* Follow toggle */}
+          {expanded && (
+            <button
+              type="button"
+              className={`pv-btn pv-btn--ghost pv-btn--xs${followLogs ? ' pv-logpanel__chip--active' : ''}`}
+              onClick={() => {
+                const next = !followLogs;
+                setFollowLogs(next);
+                // #832: re-enabling Follow must resume at the newest row even
+                // if a manual scroll-up left `scrollPaused` set — otherwise
+                // the follow-tail effect's guard (`!followLogs ||
+                // scrollPaused`) silently no-ops and the toggle looks broken.
+                if (next) setScrollPaused(false);
+              }}
+              aria-pressed={followLogs}
+              aria-label={
+                followLogs
+                  ? m.log_follow_tail_on_aria()
+                  : m.log_follow_tail_off_aria()
+              }
+              title={
+                scrollPaused && followLogs
+                  ? m.log_follow_tail_paused_title()
+                  : undefined
+              }
+            >
+              {followLogs
+                ? scrollPaused
+                  ? m.logpanel_follow_paused()
+                  : m.logpanel_follow_active()
+                : m.logpanel_follow_off()}
+            </button>
+          )}
+
+          {/* Export button */}
+          {expanded && (
+            <button
+              type="button"
+              className="pv-btn pv-btn--ghost pv-btn--xs"
+              onClick={() => void handleExport()}
+              aria-label={m.logpanel_export_aria()}
+            >
+              {m.logpanel_export()}
+            </button>
+          )}
+
+          <Collapsible.Trigger
+            className="pv-btn pv-btn--ghost pv-btn--sm"
             aria-label={
-              followLogs
-                ? m.log_follow_tail_on_aria()
-                : m.log_follow_tail_off_aria()
-            }
-            title={
-              scrollPaused && followLogs
-                ? m.log_follow_tail_paused_title()
-                : undefined
+              expanded ? m.log_collapse_panel_aria() : m.log_expand_panel_aria()
             }
           >
-            {followLogs
-              ? scrollPaused
-                ? m.logpanel_follow_paused()
-                : m.logpanel_follow_active()
-              : m.logpanel_follow_off()}
-          </button>
-        )}
-
-        {/* Export button */}
-        {expanded && (
-          <button
-            type="button"
-            className="pv-btn pv-btn--ghost pv-btn--xs"
-            onClick={() => void handleExport()}
-            aria-label={m.logpanel_export_aria()}
-          >
-            {m.logpanel_export()}
-          </button>
-        )}
-
-        <Collapsible.Trigger
-          className="pv-btn pv-btn--ghost pv-btn--sm"
-          aria-label={
-            expanded ? m.log_collapse_panel_aria() : m.log_expand_panel_aria()
-          }
-        >
-          {expanded ? '▾' : '▸'}
-        </Collapsible.Trigger>
+            {expanded ? '▾' : '▸'}
+          </Collapsible.Trigger>
+        </div>
       </div>
 
       {exportError && (
@@ -491,10 +507,16 @@ export function LogPanel() {
             <li className="pv-logpanel__empty">
               {/* #669: a filtered-to-empty view must not read as "nothing
                   was ever recorded" when entries exist but the active
-                  filter excludes all of them. */}
-              {entries.length === 0
-                ? m.logpanel_empty()
-                : m.logpanel_empty_filtered()}
+                  filter excludes all of them — so name the filter. */}
+              <EmptyState
+                title={
+                  entries.length === 0
+                    ? m.logpanel_empty()
+                    : filterLabel != null
+                      ? m.logpanel_empty_filtered_named({ filter: filterLabel })
+                      : m.logpanel_empty_filtered()
+                }
+              />
             </li>
           ) : (
             <div

--- a/apps/desktop/src/styles/components.css
+++ b/apps/desktop/src/styles/components.css
@@ -34,3 +34,4 @@
 @import './components/merges-2.css';
 @import './components/merges-3.css';
 @import './components/skeleton.css';
+@import './components/logpanel.css';

--- a/apps/desktop/src/styles/components/logpanel.css
+++ b/apps/desktop/src/styles/components/logpanel.css
@@ -1,0 +1,176 @@
+/* === LOG PANEL (spec 019, #734) ===
+ *
+ * Full-width bottom fold-out. Owns the whole bottom section of the frame:
+ * `.pv-frame` is a flex column, so a fixed flex-basis here reserves layout
+ * space and shrinks `.pv-frame__body` instead of overlaying it (FR-002).
+ *
+ * Layout contract (project page-layout rule): the header — title, filter
+ * chips, actions — is ALWAYS visible; only `.pv-logpanel__events` scrolls.
+ * Previously this block lived in wizard-base.css alongside progress-bar
+ * classes from a retired wizard widget and hard-capped the body at 200px,
+ * which contradicted FR-001's "expands across the full bottom section".
+ */
+.pv-logpanel {
+  display: flex;
+  flex-direction: column;
+  /* 40% of frame height: ~288px at the 720px reference viewport, leaving the
+     routed page the larger share. min-height keeps the list usable on short
+     windows, where 40% would collapse below a few rows. */
+  flex: 0 0 40%;
+  min-height: 180px;
+  border-top: 1px solid var(--pv-border);
+  background: var(--pv-surface);
+}
+
+/* Header — never scrolls. Wraps rather than overflowing: the source-filter
+   group alone is 12 chips, which cannot fit one row at the 1100px reference
+   width. */
+.pv-logpanel__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--pv-sp-2);
+  padding: var(--pv-sp-2) var(--pv-sp-3);
+  border-bottom: 1px solid var(--pv-border-subtle);
+  flex-shrink: 0;
+}
+.pv-logpanel__title {
+  font-size: var(--pv-text-xs);
+  font-weight: var(--pv-weight-semibold);
+  text-transform: uppercase;
+  letter-spacing: var(--pv-tracking-normal);
+  color: var(--pv-text-secondary);
+}
+.pv-logpanel__filters {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: var(--pv-sp-1);
+  min-width: 0;
+}
+/* Source chips always start their own row — 12 of them next to the level
+   chips would reflow the actions unpredictably as the window resizes. */
+.pv-logpanel__filters--sources { flex: 1 0 100%; }
+.pv-logpanel__actions {
+  display: flex;
+  align-items: center;
+  gap: var(--pv-sp-1);
+  margin-left: auto;
+}
+
+/* Filter chip = pressed state for the shared ghost/xs button. Only the
+   selected-ness is panel-specific; geometry and base color come from
+   `.pv-btn--ghost.pv-btn--xs` in primitives.css. */
+.pv-logpanel__chip--active {
+  background: var(--pv-accent-bg);
+  color: var(--pv-accent-text);
+  border-color: var(--pv-accent);
+}
+
+.pv-logpanel__export-error {
+  padding: var(--pv-sp-2) var(--pv-sp-3);
+  font-size: var(--pv-text-xs);
+  color: var(--pv-danger);
+  background: var(--pv-danger-bg);
+  border-bottom: 1px solid var(--pv-danger-border);
+  flex-shrink: 0;
+}
+
+/* Body owns the remaining height; the list inside it is the only scroller. */
+.pv-logpanel__body {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-height: 0;
+}
+.pv-logpanel__truncation-marker {
+  padding: var(--pv-sp-1) var(--pv-sp-3);
+  font-size: var(--pv-text-xs);
+  color: var(--pv-warn);
+  background: var(--pv-warn-bg);
+  border-bottom: 1px solid var(--pv-warn-border);
+  flex-shrink: 0;
+}
+.pv-logpanel__events {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  flex: 1;
+  min-height: 0;
+  overflow-y: auto;
+}
+/* Empty row hosts the shared `.pv-empty` (ui/EmptyState) — the panel supplies
+   only the row box, the visual language is the app-wide one. */
+.pv-logpanel__empty {
+  display: flex;
+  height: 100%;
+  min-height: 0;
+}
+
+.pv-logpanel__event {
+  display: flex;
+  align-items: center;
+  gap: var(--pv-sp-2);
+  padding: var(--pv-sp-1) var(--pv-sp-3);
+  font-size: var(--pv-text-xs);
+  border-bottom: 1px solid var(--pv-border-subtle);
+}
+.pv-logpanel__event:last-child { border-bottom: none; }
+.pv-logpanel__event--link { cursor: pointer; }
+.pv-logpanel__event--link:hover { background: var(--pv-hover-bg); }
+.pv-logpanel__event--link:focus-visible {
+  outline: none;
+  box-shadow: var(--pv-focus-ring);
+}
+.pv-logpanel__event-time {
+  color: var(--pv-text-muted);
+  min-width: 64px;
+  flex-shrink: 0;
+}
+.pv-logpanel__event-level {
+  font-size: var(--pv-text-xs);
+  font-weight: var(--pv-weight-medium);
+  text-transform: uppercase;
+  min-width: 40px;
+  flex-shrink: 0;
+}
+.pv-logpanel__event-level--info  { color: var(--pv-info); }
+.pv-logpanel__event-level--warn  { color: var(--pv-warn); }
+.pv-logpanel__event-level--error { color: var(--pv-danger); }
+.pv-logpanel__event-level--debug { color: var(--pv-text-muted); }
+/* Source is a category tag, not a severity: one muted treatment for all
+   sources. Per-source color variants would be a second, competing severity
+   language on the same row (the `--<source>` modifier stays in the markup as
+   a selector hook). */
+.pv-logpanel__event-source {
+  color: var(--pv-text-muted);
+  background: var(--pv-chip);
+  border-radius: var(--pv-radius-sm);
+  padding: 0 var(--pv-sp-1);
+  min-width: 64px;
+  flex-shrink: 0;
+  text-align: center;
+}
+.pv-logpanel__event-context {
+  color: var(--pv-text-faint);
+  max-width: 200px;
+  flex-shrink: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pv-logpanel__event-msg {
+  color: var(--pv-text);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pv-logpanel__event-link-indicator {
+  margin-left: auto;
+  color: var(--pv-text-faint);
+  flex-shrink: 0;
+}
+.pv-logpanel__event--link:hover .pv-logpanel__event-link-indicator {
+  color: var(--pv-accent);
+}

--- a/apps/desktop/src/styles/components/primitives.css
+++ b/apps/desktop/src/styles/components/primitives.css
@@ -126,6 +126,17 @@
   -webkit-mask-size: contain;
 }
 .pv-btn--sm { height: var(--pv-control-h-sm); padding: 0 var(--pv-sp-2); font-size: var(--pv-text-xs); }
+/* --xs / --ghost were used in markup (log panel chips, dev call list,
+   ProcessingTools) but had no rule anywhere, so those controls silently fell
+   back to full-size bordered buttons (#734). Defined once here rather than
+   per-feature. */
+.pv-btn--xs { height: var(--pv-control-h-xs); padding: 0 var(--pv-sp-2); font-size: var(--pv-text-xs); }
+.pv-btn--ghost {
+  background: transparent;
+  border-color: transparent;
+  color: var(--pv-text-muted);
+}
+.pv-btn--ghost:hover { background: var(--pv-hover-bg); border-color: transparent; color: var(--pv-text); }
 
 /* === SECTION === */
 .pv-section { margin-bottom: var(--pv-sp-4); }

--- a/apps/desktop/src/styles/components/wizard-base.css
+++ b/apps/desktop/src/styles/components/wizard-base.css
@@ -37,53 +37,6 @@
   flex-shrink: 0; background: var(--pv-surface);
 }
 
-/* === LOG PANEL === */
-.pv-logpanel { border-top: 1px solid var(--pv-border); background: var(--pv-surface); }
-.pv-logpanel__header {
-  display: flex; align-items: center; justify-content: space-between;
-  padding: var(--pv-sp-1) var(--pv-sp-3);
-  border-bottom: 1px solid var(--pv-border-subtle);
-}
-.pv-logpanel__title { font-size: var(--pv-text-xs); font-weight: var(--pv-weight-semibold); }
-.pv-logpanel__body { max-height: 200px; overflow-y: auto; }
-.pv-logpanel__op {
-  padding: var(--pv-sp-2) var(--pv-sp-3);
-  border-bottom: 1px solid var(--pv-border-subtle);
-}
-.pv-logpanel__op-label {
-  font-size: var(--pv-text-xs); color: var(--pv-text-muted);
-  margin-bottom: var(--pv-sp-1); display: block;
-}
-.pv-logpanel__progress-root { display: flex; flex-direction: column; gap: var(--pv-sp-1); }
-.pv-logpanel__progress {
-  height: 4px; background: var(--pv-rule2); border-radius: 2px; overflow: hidden;
-}
-.pv-logpanel__progress-fill {
-  height: 100%; background: var(--pv-accent); border-radius: 2px;
-  transition: width 0.3s ease;
-}
-.pv-logpanel__events { list-style: none; padding: 0; margin: 0; }
-.pv-logpanel__event {
-  display: flex; align-items: center; gap: var(--pv-sp-2);
-  padding: var(--pv-sp-1) var(--pv-sp-3);
-  font-size: var(--pv-text-xs);
-  border-bottom: 1px solid var(--pv-border-subtle);
-}
-.pv-logpanel__event:last-child { border-bottom: none; }
-.pv-logpanel__event-time {
-color: var(--pv-text-muted);
-  min-width: 64px; flex-shrink: 0;
-}
-.pv-logpanel__event-level {
-  font-size: var(--pv-text-xs); font-weight: var(--pv-weight-medium);
-  text-transform: uppercase; min-width: 40px; flex-shrink: 0;
-}
-.pv-logpanel__event-level--info  { color: var(--pv-info); }
-.pv-logpanel__event-level--warn  { color: var(--pv-warn); }
-.pv-logpanel__event-level--error { color: var(--pv-danger); }
-.pv-logpanel__event-level--debug { color: var(--pv-text-muted); }
-.pv-logpanel__event-msg { color: var(--pv-text); }
-
 /* === SELECT === */
 .pv-select {
   height: var(--pv-control-h); padding: 0 var(--pv-sp-2);

--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -98,6 +98,9 @@
      select 25px, button 24px, Settings select 28px, all in one chrome). */
   --pv-control-h: 26px;
   --pv-control-h-sm: 24px;
+  /* Dense filter chips (log panel, dev lists) — below this the 4px text
+     padding stops clearing the --pv-text-xs cap height. */
+  --pv-control-h-xs: 20px;
 
   /* Transitions and radius now live in foundation.css (handoff 04). */
 }

--- a/apps/desktop/src/styles/tokens.d.ts
+++ b/apps/desktop/src/styles/tokens.d.ts
@@ -16,6 +16,7 @@ export type PvTokenName =
   | 'pv-chip'
   | 'pv-control-h'
   | 'pv-control-h-sm'
+  | 'pv-control-h-xs'
   | 'pv-danger'
   | 'pv-danger-bg'
   | 'pv-danger-bg-hover'

--- a/specs/019-bottom-log-viewer/spec.md
+++ b/specs/019-bottom-log-viewer/spec.md
@@ -144,13 +144,18 @@ Promotion to a backend-canonical log stream is plan work, not spec work.
 
 > **Reconciliation note (2026-07-19, issue #764)**: both paths below moved —
 > `apps/desktop/src/app/LogPanel.tsx` (not `ui/`) and
-> `apps/desktop/src/data/logStore.ts` (not `store.ts`). The described
-> behavior, including the collapsed-state idle preview line, is intact at
-> the new paths.
+> `apps/desktop/src/data/logStore.ts` (not `store.ts`).
+>
+> **Reconciliation note (2026-07-20, issue #734)**: the collapsed-state idle
+> preview line is GONE, not merely moved. `Shell.tsx` mounts `LogPanel` only
+> while the panel is expanded, so the preview branch was unreachable in the
+> shipped app, and `StatusBar` already owns the collapsed-state affordance. No
+> FR required the preview — it was a mockup detail — so the dead branch was
+> deleted rather than rewired.
 
 - `apps/desktop/src/ui/LogPanel.tsx` - Bottom fold-out shell. Expand/collapse
-  state, level filter chips (`all`/`info`/`warn`/`error`/`debug`), per-entry
-  level coloring, and the closed-state idle preview line.
+  state, level filter chips (`all`/`info`/`warn`/`error`/`debug`), and
+  per-entry level coloring.
 - `apps/desktop/src/data/store.ts` - `useLog`, `appendLog`, `logPub`, and the
   seed log list. Maintains a 500-entry ring buffer via the publisher.
 - Log emission sites in `apps/desktop/src/data/store.ts` cover plan create,


### PR DESCRIPTION
## What

The Activity/Log panel's only CSS lived in `wizard-base.css`, inside a block left over from a retired wizard widget, and hard-capped the body at `max-height: 200px`. Half the classes the component actually renders had no rule at all, so the panel read as a small unstyled debug box rather than spec 019 FR-001's full-bottom fold-out.

## Changes

- **Own stylesheet.** Moved the block to `apps/desktop/src/styles/components/logpanel.css` and dropped the dead `__op` / `__op-label` / `__progress*` rules — no markup references them.
- **Real fold-out.** Replaced the 200px cap with a 40%-of-frame panel (min 180px). Header — title, filter chips, actions — is always visible; only `__events` scrolls, per the page-layout rule. The 12 source chips get their own row so the actions keep a stable position as chips wrap at 1100px.
- **Missing rules added:** `__chip--active`, `__filters`, `__truncation-marker`, `__export-error`, `__empty`, `__event--link` (+ hover/focus), `__event-source`, `__event-context`, `__event-link-indicator`.
- **`.pv-btn--ghost` / `.pv-btn--xs` defined once** in `primitives.css`. Both were used in markup (log panel, dev call/contract lists, ProcessingTools) with **no rule anywhere**, so those controls silently fell back to full-size bordered buttons. Added `--pv-control-h-xs` alongside the existing control-height tokens.
- **Dead code removed.** `Shell.tsx` mounts `LogPanel` only while expanded, so the collapsed idle-preview branch was unreachable. Deleted it (rather than rewiring Shell) because `StatusBar` already owns the collapsed-state affordance — an always-mounted collapsed header would duplicate it. Spec 019's Mockup Files note corrected accordingly, and the now-unused `logpanel_preview_aria` key dropped.

## #669 (log-panel half only)

The filtered-empty branch already existed but showed an unnamed "No entries match the current filter." — which still leaves the user unable to tell *which* control to undo. The empty state now names the active filter ("No entries match Error") via the shared `EmptyState` component, satisfying Journey 13's trust note. Uses one new message with a `{filter}` param; falls back to the unnamed string when only the non-user-selectable diagnostics gate is excluding rows.

**The Calibration half of #669 is owned by another lane and is untouched here** — hence no `Closes` for it.

## Mandates

- No per-feature CSS clones: `css-dup-sniff.mjs` puts no log-panel rule in the component-clone section (only shared one-line idioms like `cursor: pointer`). Source chips get **one** muted treatment rather than 11 per-source colors, which would be a second severity language on the row.
- All values token-driven; `check-tokens.sh` green.

## Verification

`pnpm lint` ✅ · `pnpm test` ✅ 1863/1863 · `pnpm typecheck` ✅ · `css-dup-sniff` ✅

**This change is visually validatable and has NOT been checked in the real app** — unit tests only, per lane scope. Layout reasoning was verified analytically at 1100x720, not observed. Recommend routing to the real-UI lane before closing #734.

Closes #734
Partially addresses #669