### PR TITLE
fix: reloading the app no longer loses the selected item

### DIFF
--- a/apps/desktop/src/features/archive/ArchivePage.test.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.test.tsx
@@ -356,3 +356,36 @@ describe('ArchivePage — spec 043 single-column layout', () => {
     ).not.toBeInTheDocument();
   });
 });
+
+// ── Cold-reload selection survival (#735 item 1) ──────────────────────────────
+
+/**
+ * Page-level wiring, not hook logic: `use-stale-selection.test.tsx` passes
+ * `found` as an explicit boolean and so structurally cannot catch a page that
+ * derives `found` from a still-empty query result. These two cases pin the
+ * gate from BOTH directions — held closed while loading, released once the
+ * list has settled — so the fix can't regress into a permanently-open gate.
+ */
+describe('ArchivePage stale-selection gating (#735)', () => {
+  it('keeps a valid ?selected= while the list query is still loading', () => {
+    archiveListState.loading = true;
+    archiveListState.data = [];
+    mockSelectedId.current = 'proj-1';
+
+    render(<ArchivePage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('still clears a genuinely absent id once the list has settled', () => {
+    archiveListState.loading = false;
+    archiveListState.data = [makeEntry({ id: 'proj-other' })];
+    mockSelectedId.current = 'proj-gone';
+
+    render(<ArchivePage />);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+  });
+});

--- a/apps/desktop/src/features/archive/ArchivePage.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.tsx
@@ -88,7 +88,9 @@ export function ArchivePage() {
   // the ✕ close button) with a bare `autoFocus`.
   const confirmInputRef = useRef<HTMLInputElement>(null);
 
-  useStaleSelectionCleanup(selected, item !== null, () => {
+  // #735: gated on `loading` so a cold reload's empty cache isn't mistaken for
+  // a stale id — see ProjectsPage for the full rationale.
+  useStaleSelectionCleanup(selected, loading || item !== null, () => {
     void navigate({
       search: (prev) => ({ ...prev, selected: undefined }),
       replace: true,

--- a/apps/desktop/src/features/calibration/CalibrationPage.staleSelection.test.tsx
+++ b/apps/desktop/src/features/calibration/CalibrationPage.staleSelection.test.tsx
@@ -1,0 +1,101 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * CalibrationPage stale-selection gating (#735 item 1).
+ *
+ * Page-level WIRING, deliberately not hook logic: `use-stale-selection.test.tsx`
+ * feeds the hook explicit booleans, so it structurally cannot catch a page that
+ * derives `found` from a query result that is still empty because the list IPC
+ * has not resolved yet. On a cold reload that misreads a perfectly valid
+ * `?selected=` as stale and rewrites the URL without it, breaking the spec 020
+ * SC-002 guarantee that a reload lands on the same selection.
+ *
+ * Both directions are asserted so the fix cannot regress into a gate that is
+ * simply held open forever.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { CalibrationMaster } from '@/bindings/index';
+
+const mastersState: {
+  masters: CalibrationMaster[];
+  loading: boolean;
+  error: Error | undefined;
+} = { masters: [], loading: false, error: undefined };
+
+function makeMaster(id: string): CalibrationMaster {
+  return {
+    id,
+    kind: 'dark',
+    fingerprint: {
+      camera: 'ASI2600MM',
+      exposureS: 300,
+      tempC: -10,
+      gain: 100,
+      binning: '1x1',
+    },
+    sourceSessionId: 'cal-ses-001',
+    createdAt: '2026-01-01T00:00:00Z',
+    ageDays: 30,
+    sizeBytes: 128 * 1024 * 1024,
+    usedBySessionIds: [],
+    usedByProjectIds: [],
+  } as CalibrationMaster;
+}
+
+vi.mock('./useCalibration', () => ({
+  useCalibrationMasters: () => mastersState,
+  useCalibrationSettings: () => ({
+    prefillSuggestion: false,
+    agingThresholdDays: 90,
+  }),
+}));
+
+// The detail pane pulls the whole calibration matching stack in; the gate under
+// test lives on the page, so a stub keeps this focused (and cheap).
+vi.mock('./MasterDetail', () => ({
+  MasterDetail: () => <div data-testid="master-detail-stub" />,
+}));
+
+const mockNavigate = vi.fn();
+const mockSelectedId = { current: undefined as string | undefined };
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({ selected: mockSelectedId.current }),
+}));
+
+import { CalibrationPage } from './CalibrationPage';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectedId.current = undefined;
+  mastersState.masters = [];
+  mastersState.loading = false;
+  mastersState.error = undefined;
+});
+
+describe('CalibrationPage stale-selection gating (#735)', () => {
+  it('keeps a valid ?selected= while the masters query is still loading', () => {
+    mastersState.loading = true;
+    mockSelectedId.current = 'master-1';
+
+    render(<CalibrationPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('still clears a genuinely absent id once the list has settled', () => {
+    mastersState.masters = [makeMaster('master-other')];
+    mockSelectedId.current = 'master-gone';
+
+    render(<CalibrationPage />);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+  });
+});

--- a/apps/desktop/src/features/calibration/CalibrationPage.tsx
+++ b/apps/desktop/src/features/calibration/CalibrationPage.tsx
@@ -86,7 +86,9 @@ export function CalibrationPage() {
       }),
     [navigate],
   );
-  useStaleSelectionCleanup(selected, master !== null, clearSelection);
+  // #735: gated on `loading` so a cold reload's empty cache isn't mistaken for
+  // a stale id — see ProjectsPage for the full rationale.
+  useStaleSelectionCleanup(selected, loading || master !== null, clearSelection);
 
   const onSelect = (id: string) =>
     navigate({ search: (prev) => ({ ...prev, selected: id }) });

--- a/apps/desktop/src/features/calibration/CalibrationPage.tsx
+++ b/apps/desktop/src/features/calibration/CalibrationPage.tsx
@@ -88,7 +88,11 @@ export function CalibrationPage() {
   );
   // #735: gated on `loading` so a cold reload's empty cache isn't mistaken for
   // a stale id — see ProjectsPage for the full rationale.
-  useStaleSelectionCleanup(selected, loading || master !== null, clearSelection);
+  useStaleSelectionCleanup(
+    selected,
+    loading || master !== null,
+    clearSelection,
+  );
 
   const onSelect = (id: string) =>
     navigate({ search: (prev) => ({ ...prev, selected: id }) });

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -312,9 +312,17 @@ export function InboxPage() {
   const [pendingReclassifySelectionId, setPendingReclassifySelectionId] =
     useState<string | null>(null);
 
+  // #735: `listLoading` joins the gate because on a cold reload the list cache
+  // is empty and an unguarded `selectedItem === undefined` wipes a valid
+  // `?selected=` before the list IPC resolves. This does NOT reopen the
+  // unbounded-gate hazard the reclassify handoff guards against: `listLoading`
+  // settles on its own, whereas `pendingReclassifySelectionId` needed
+  // `resolveReclassifyHandoff`'s explicit give-up path.
   useStaleSelectionCleanup(
     selected,
-    selectedItem !== undefined || pendingReclassifySelectionId !== null,
+    listLoading ||
+      selectedItem !== undefined ||
+      pendingReclassifySelectionId !== null,
     () =>
       navigate({
         search: (prev) => ({ ...prev, selected: undefined }),

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.staleSelection.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.staleSelection.test.tsx
@@ -1,0 +1,92 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * InboxPage stale-selection gating (#735 item 1).
+ *
+ * Page-level WIRING, deliberately not hook logic: `use-stale-selection.test.tsx`
+ * feeds the hook explicit booleans, so it structurally cannot catch a page that
+ * derives `found` from a query result that is still empty because the list IPC
+ * has not resolved yet. On a cold reload that misreads a perfectly valid
+ * `?selected=` as stale and rewrites the URL without it.
+ *
+ * The second case is the one that matters most here: InboxPage already carries
+ * a deliberately BOUNDED gate for the reclassify handoff (see
+ * `resolveReclassifyHandoff`), whose whole point is that the gate must not stay
+ * open forever. Adding `listLoading` must not weaken that — once the list has
+ * settled without the id, cleanup still fires.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { render as rtlRender, waitFor } from '@testing-library/react';
+import type { ReactElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+function render(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>,
+  );
+}
+
+const { mockRootsList, mockInboxList, mockInboxPlanListOpen } = vi.hoisted(
+  () => ({
+    mockRootsList: vi.fn(),
+    mockInboxList: vi.fn(),
+    mockInboxPlanListOpen: vi.fn(),
+  }),
+);
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    rootsList: mockRootsList,
+    inboxList: mockInboxList,
+    inboxPlanListOpen: mockInboxPlanListOpen,
+  },
+}));
+
+const mockNavigate = vi.fn();
+const mockSelectedId = { current: undefined as string | undefined };
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({ selected: mockSelectedId.current, type: undefined }),
+}));
+
+const ok = <T,>(data: T) => ({ status: 'ok' as const, data });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectedId.current = undefined;
+  mockRootsList.mockResolvedValue(ok([]));
+  mockInboxList.mockResolvedValue(ok({ items: [], capped: false, limit: 500 }));
+  mockInboxPlanListOpen.mockResolvedValue(ok({ plans: [], totalActions: 0 }));
+});
+
+import { InboxPage } from '../InboxPage';
+
+describe('InboxPage stale-selection gating (#735)', () => {
+  it('keeps a valid ?selected= while inbox.list is still in flight', () => {
+    mockInboxList.mockReturnValue(new Promise(() => {}));
+    mockSelectedId.current = 'item-1';
+
+    render(<InboxPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('still clears a genuinely absent id once the list has settled', async () => {
+    mockSelectedId.current = 'item-gone';
+
+    render(<InboxPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ replace: true }),
+      ),
+    );
+  });
+});

--- a/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.archive-plan.test.tsx
@@ -36,6 +36,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     // unrelated to this file's assertions, so a static empty selection is
     // enough.
     useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    // #735: the tool-launch toast's "Configure path" action now navigates
+    // through the router instead of assigning window.location.hash, and the
+    // tool-not-configured hint is a real `Link` — neither works against the
+    // spread-in real implementations without a router context.
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.blocked-reason.test.tsx
@@ -36,6 +36,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     // unrelated to this file's assertions, so a static empty selection is
     // enough.
     useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    // #735: the tool-launch toast's "Configure path" action now navigates
+    // through the router instead of assigning window.location.hash, and the
+    // tool-not-configured hint is a real `Link` — neither works against the
+    // spread-in real implementations without a router context.
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.lifecycle.test.tsx
@@ -32,6 +32,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     // unrelated to this file's assertions, so a static empty selection is
     // enough.
     useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    // #735: the tool-launch toast's "Configure path" action now navigates
+    // through the router instead of assigning window.location.hash, and the
+    // tool-not-configured hint is a real `Link` — neither works against the
+    // spread-in real implementations without a router context.
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.sources-applicability.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.sources-applicability.test.tsx
@@ -22,6 +22,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     // unrelated to this file's assertions, so a static empty selection is
     // enough.
     useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    // #735: the tool-launch toast's "Configure path" action now navigates
+    // through the router instead of assigning window.location.hash, and the
+    // tool-not-configured hint is a real `Link` — neither works against the
+    // spread-in real implementations without a router context.
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.sources-metric.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.sources-metric.test.tsx
@@ -27,6 +27,12 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     // unrelated to this file's assertions, so a static empty selection is
     // enough.
     useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    // #735: the tool-launch toast's "Configure path" action now navigates
+    // through the router instead of assigning window.location.hash, and the
+    // tool-not-configured hint is a real `Link` — neither works against the
+    // spread-in real implementations without a router context.
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
   };
 });
 

--- a/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.target.test.tsx
@@ -44,6 +44,9 @@ vi.mock('@tanstack/react-router', () => ({
   // search param when its (optional) projectId prop isn't wired; unrelated to
   // this file's assertions, so a static empty selection is enough.
   useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+  // #735: the tool-launch toast's "Configure path" action now navigates
+  // through the router instead of assigning window.location.hash.
+  useNavigate: () => vi.fn(),
 }));
 
 vi.mock('./store', async (importOriginal) => {

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -388,12 +388,13 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
         >
           <span className="pv-project-detail__tool-hint">
             {m.projects_tool_not_configured()}{' '}
-            <a
-              href="#/settings?pane=tools"
+            <Link
+              to="/settings/$pane"
+              params={{ pane: 'tools' }}
               className="pv-project-detail__tool-link"
             >
               {m.projects_tool_configure_link()}
-            </a>
+            </Link>
           </span>
         </div>
       )}

--- a/apps/desktop/src/features/projects/ProjectsPage.staleSelection.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectsPage.staleSelection.test.tsx
@@ -54,12 +54,17 @@ function makeProject(id: string): ProjectSummaryDto {
   return {
     id,
     name: 'NGC 7000 · HOO',
-    tool: 'pixinsight',
+    tool: 'PixInsight',
     lifecycle: 'processing',
     path: 'D:/Astro/Projects/NGC7000',
+    notes: null,
+    channelDrift: false,
+    sourceCount: 0,
     createdAt: '2026-01-01T00:00:00Z',
     updatedAt: '2026-01-01T00:00:00Z',
-  } as ProjectSummaryDto;
+    blockedReasonKind: null,
+    blockedReasonNote: null,
+  };
 }
 
 beforeEach(() => {

--- a/apps/desktop/src/features/projects/ProjectsPage.staleSelection.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectsPage.staleSelection.test.tsx
@@ -1,0 +1,93 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * ProjectsPage stale-selection gating (#735 item 1).
+ *
+ * Page-level WIRING, deliberately not hook logic: `use-stale-selection.test.tsx`
+ * feeds the hook explicit booleans, so it structurally cannot catch a page that
+ * derives `found` from a query result that is still empty because the list IPC
+ * has not resolved yet. This is the exact scenario spec 020 US1-AS1/SC-002
+ * guarantees ("app reloads → same project selected"): on a cold reload the
+ * cache is empty, and the unguarded page cleared the URL before the list
+ * arrived.
+ *
+ * Both directions are asserted so the fix cannot regress into a gate that is
+ * simply held open forever.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ProjectSummaryDto } from '@/bindings/index';
+
+const projectsState: {
+  data: ProjectSummaryDto[] | undefined;
+  loading: boolean;
+  error: Error | undefined;
+} = { data: [], loading: false, error: undefined };
+
+vi.mock('./store', () => ({
+  useProjects: () => projectsState,
+}));
+
+// The detail panes drag in the whole project stack; the gate under test lives
+// on the page, so stubs keep this focused (and cheap).
+vi.mock('./ProjectDetail', () => ({
+  ProjectDetailContent: () => <div data-testid="project-detail-stub" />,
+}));
+vi.mock('./ProjectBottomDetail', () => ({
+  ProjectBottomDetail: () => <div data-testid="project-bottom-detail-stub" />,
+}));
+
+const mockNavigate = vi.fn();
+const mockSelectedId = { current: undefined as string | undefined };
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({ selected: mockSelectedId.current, lifecycle: undefined }),
+}));
+
+import { ProjectsPage } from './ProjectsPage';
+
+function makeProject(id: string): ProjectSummaryDto {
+  return {
+    id,
+    name: 'NGC 7000 · HOO',
+    tool: 'pixinsight',
+    lifecycle: 'processing',
+    path: 'D:/Astro/Projects/NGC7000',
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+  } as ProjectSummaryDto;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectedId.current = undefined;
+  projectsState.data = [];
+  projectsState.loading = false;
+  projectsState.error = undefined;
+});
+
+describe('ProjectsPage stale-selection gating (#735)', () => {
+  it('keeps a valid ?selected= while the projects query is still loading', () => {
+    projectsState.loading = true;
+    mockSelectedId.current = 'proj-1';
+
+    render(<ProjectsPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('still clears a genuinely absent id once the list has settled', () => {
+    projectsState.data = [makeProject('proj-other')];
+    mockSelectedId.current = 'proj-gone';
+
+    render(<ProjectsPage />);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+  });
+});

--- a/apps/desktop/src/features/projects/ProjectsPage.tsx
+++ b/apps/desktop/src/features/projects/ProjectsPage.tsx
@@ -113,9 +113,14 @@ export function ProjectsPage() {
   // no longer exist. (Supersedes redesign's index-based selectedIdx.)
   const project: ProjectSummaryDto | undefined =
     selected != null ? projects.find((p) => p.id === selected) : undefined;
+  // #735: `loading` must gate the cleanup — on a cold reload the list cache is
+  // empty, so an unguarded `project === undefined` misreads a perfectly valid
+  // `?selected=` as stale and wipes it before the list IPC resolves (breaks
+  // spec 020 SC-002 "app reloads → same project selected"). Bounded: `loading`
+  // settles, at which point a genuinely absent id is still cleared.
   useStaleSelectionCleanup(
     selected,
-    project !== undefined || selected == null,
+    loading || project !== undefined || selected == null,
     () =>
       navigate({
         search: (prev) => ({ ...prev, selected: undefined }),

--- a/apps/desktop/src/features/projects/tool-launch.ts
+++ b/apps/desktop/src/features/projects/tool-launch.ts
@@ -14,6 +14,7 @@
  *   one-time-per-tool "cwd anchored" hint state (T021, US3 acceptance scenario 3).
  */
 import { useState, useCallback, useEffect } from 'react';
+import { useNavigate } from '@tanstack/react-router';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type {
@@ -189,6 +190,7 @@ export function useToolLaunch(
     working: false,
     priorInstanceAlive: false,
   });
+  const navigate = useNavigate();
 
   const launch = useCallback(
     async (force = false) => {
@@ -237,8 +239,14 @@ export function useToolLaunch(
             ? {
                 label: m.projects_tool_configure_path(),
                 onClick: () => {
-                  // Navigate to settings/tools pane — best-effort via location
-                  window.location.hash = '#/settings?pane=tools';
+                  // #735: was `window.location.hash = '#/settings?pane=tools'`,
+                  // which bypassed the router AND missed the pane entirely —
+                  // SettingsPage resolves its pane from the `/settings/$pane`
+                  // PATH param, so the `?pane=` search was simply ignored.
+                  void navigate({
+                    to: '/settings/$pane',
+                    params: { pane: 'tools' },
+                  });
                 },
               }
             : undefined,
@@ -255,7 +263,7 @@ export function useToolLaunch(
         setState((s) => ({ ...s, working: false }));
       }
     },
-    [projectId, toolId, toolName, supportsOpenFolder],
+    [projectId, toolId, toolName, supportsOpenFolder, navigate],
   );
 
   const dismissPriorWarning = useCallback(() => {

--- a/apps/desktop/src/features/sessions/SessionsPage.staleSelection.test.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.staleSelection.test.tsx
@@ -1,0 +1,108 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+/**
+ * SessionsPage stale-selection gating (#735 item 1).
+ *
+ * Page-level WIRING, deliberately not hook logic: `use-stale-selection.test.tsx`
+ * feeds the hook explicit booleans, so it structurally cannot catch a page that
+ * derives `found` from a query result that is still empty because the list IPC
+ * has not resolved yet. On a cold reload that misreads a perfectly valid
+ * `?selected=` as stale and rewrites the URL without it, breaking the spec 020
+ * SC-002 guarantee that a reload lands on the same selection.
+ *
+ * Both directions are asserted so the fix cannot regress into a gate that is
+ * simply held open forever.
+ */
+
+import { render } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { InventorySource, InventorySession } from '@/bindings/index';
+
+const sourcesState: {
+  data: { sources: InventorySource[] } | undefined;
+  loading: boolean;
+  error: Error | undefined;
+} = { data: { sources: [] }, loading: false, error: undefined };
+
+vi.mock('./store', () => ({
+  useInventorySources: () => sourcesState,
+}));
+
+// The detail pane drags in the whole session/calibration stack; the gate under
+// test lives on the page, so a stub keeps this focused (and cheap).
+vi.mock('./SessionDetail', () => ({
+  SessionDetail: () => <div data-testid="session-detail-stub" />,
+}));
+
+const mockNavigate = vi.fn();
+const mockSelectedId = { current: undefined as string | undefined };
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => mockNavigate,
+  useSearch: () => ({ selected: mockSelectedId.current }),
+}));
+
+import { SessionsPage } from './SessionsPage';
+
+function makeSource(sessionId: string): InventorySource {
+  const session = {
+    id: sessionId,
+    name: 'Session — 2026-07-11',
+    sourceId: 'src-1',
+    frames: 42,
+    type: 'light',
+    target: 'NGC 7000',
+    filter: 'Ha',
+    exposure: '300s',
+    camera: 'ASI2600MM',
+    gain: '100',
+    binning: '1x1',
+    setTemp: '-10',
+    capturedOn: '2026-07-11',
+    provenance: null,
+    linked: null,
+    relativePath: 'lights/2026-07-11',
+    notes: null,
+  } as unknown as InventorySession;
+
+  return {
+    id: 'src-1',
+    path: 'D:/Astro',
+    kind: 'library',
+    state: 'connected',
+    sessions: [session],
+  } as unknown as InventorySource;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockSelectedId.current = undefined;
+  sourcesState.data = { sources: [] };
+  sourcesState.loading = false;
+  sourcesState.error = undefined;
+});
+
+describe('SessionsPage stale-selection gating (#735)', () => {
+  it('keeps a valid ?selected= while the inventory query is still loading', () => {
+    sourcesState.loading = true;
+    sourcesState.data = undefined;
+    mockSelectedId.current = 'ses-1';
+
+    render(<SessionsPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('still clears a genuinely absent id once the list has settled', () => {
+    sourcesState.data = { sources: [makeSource('ses-other')] };
+    mockSelectedId.current = 'ses-gone';
+
+    render(<SessionsPage />);
+
+    expect(mockNavigate).toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+  });
+});

--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -195,9 +195,11 @@ export function SessionsPage() {
       }),
     [navigate],
   );
+  // #735: gated on `loading` so a cold reload's empty cache isn't mistaken for
+  // a stale id — see ProjectsPage for the full rationale.
   useStaleSelectionCleanup(
     selected,
-    selectedSession !== undefined,
+    loading || selectedSession !== undefined,
     clearSelection,
   );
 

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -550,18 +550,19 @@ describe('TargetsPage', () => {
 // on setTimeout macrotask boundaries so the browser can paint between chunks.
 // The table footer ("{count} targets") reflects exactly the revealed count, so
 // these tests drive the reveal timers with fake timers and assert on it.
-describe('TargetsPage — progressive reveal (#573)', () => {
-  // Valid Planner (NGC) rows so filterByCatalogues keeps them and the cap
-  // actually engages (a 2-row fixture never exceeds REVEAL_CHUNK).
-  function ngcItems(n: number) {
-    return Array.from({ length: n }, (_, i) => ({
-      id: `ngc-${i}`,
-      effectiveLabel: `NGC ${7000 + i}`,
-      primaryDesignation: `NGC ${7000 + i}`,
-      objectType: 'emission_nebula',
-    }));
-  }
+// Valid Planner (NGC) rows so filterByCatalogues keeps them and the cap
+// actually engages (a 2-row fixture never exceeds REVEAL_CHUNK). Module-scoped
+// so the stale-selection suite can reuse it.
+function ngcItems(n: number) {
+  return Array.from({ length: n }, (_, i) => ({
+    id: `ngc-${i}`,
+    effectiveLabel: `NGC ${7000 + i}`,
+    primaryDesignation: `NGC ${7000 + i}`,
+    objectType: 'emission_nebula',
+  }));
+}
 
+describe('TargetsPage — progressive reveal (#573)', () => {
   // Flush the listTargets promise chain (microtasks only) WITHOUT firing the
   // reveal setTimeout, so the first-paint cap is observable before any growth.
   async function flushLoad() {
@@ -644,5 +645,51 @@ describe('TargetsPage — progressive reveal (#573)', () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+});
+
+// ── Stale-selection cleanup (#735 item 2) ─────────────────────────────────────
+
+/**
+ * Targets was the one ledger page never wired for stale-id cleanup — tasks.md
+ * T030 claimed all six were. Both directions are pinned: a valid id must
+ * survive the in-flight list load (the #735 item 1 cold-reload race), and a
+ * genuinely absent id must still be cleared once the list settles.
+ */
+describe('TargetsPage stale-selection cleanup (#735)', () => {
+  it('keeps a valid ?selected= while targetList is still in flight', () => {
+    mockListTargets.mockReturnValue(new Promise(() => {}));
+    mockSelectedId.current = TARGET_ID;
+
+    render(<TargetsPage />);
+
+    expect(mockNavigate).not.toHaveBeenCalled();
+  });
+
+  it('leaves a selection that is present but not yet progressively revealed', async () => {
+    // The page caps what reaches TargetsTable and grows it on a timer; an
+    // unrevealed target is present, not stale, so the gate matches against the
+    // FULL query data rather than the revealed slice.
+    mockListTargets.mockResolvedValue(ok(ngcItems(350)));
+    mockSelectedId.current = 'ngc-349';
+
+    render(<TargetsPage />);
+
+    await waitFor(() => expect(mockListTargets).toHaveBeenCalled());
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+  });
+
+  it('clears a stale ?selected= once the list has settled without it', async () => {
+    mockSelectedId.current = '550e8400-e29b-41d4-a716-4466554409ff';
+
+    render(<TargetsPage />);
+
+    await waitFor(() =>
+      expect(mockNavigate).toHaveBeenCalledWith(
+        expect.objectContaining({ replace: true }),
+      ),
+    );
   });
 });

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -52,6 +52,7 @@ import type { FilterOption } from '@/components';
 import { m } from '@/lib/i18n';
 import { Btn, EmptyState } from '@/ui';
 import { useGrouping } from '@/lib/use-grouping';
+import { useStaleSelectionCleanup } from '@/lib/use-stale-selection';
 import { AddTargetDialog } from './AddTargetDialog';
 import { TargetDetailV2 } from './TargetDetailV2';
 import { useTargets } from './store';
@@ -343,6 +344,18 @@ export function TargetsPage() {
         replace: true,
       }),
     [navigate],
+  );
+
+  // #735: Targets was the one ledger page never wired for stale-id cleanup
+  // (tasks.md T030 claimed all six), so a `?selected=<uuid>` for a deleted
+  // target persisted forever. Matched against the FULL query data rather than
+  // the progressively-revealed slice — an unrevealed target is present, not
+  // stale. `status === 'loading'` gates the cold-reload race (#735 item 1).
+  useStaleSelectionCleanup(
+    selected,
+    listState.status !== 'loaded' ||
+      listState.items.some((t) => t.id === selected),
+    clearSelection,
   );
 
   const handleAdded = useCallback(

--- a/apps/desktop/src/test/router-link-stub.tsx
+++ b/apps/desktop/src/test/router-link-stub.tsx
@@ -1,0 +1,48 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Router `Link` stub for tests that render router-aware components WITHOUT a
+ * router context.
+ *
+ * The real `Link` reads router context and throws when it is absent, so any
+ * suite that mocks `@tanstack/react-router` by spreading `...actual` has to
+ * override `Link` explicitly. Extracted here once because every ProjectDetail
+ * suite needs the identical stub (#735 turned the tool-configure hint from a
+ * raw `<a href="#/settings?pane=tools">` into a real `<Link>`).
+ *
+ * Renders a plain anchor whose href mirrors what the router would build, so
+ * tests can still assert on link destinations:
+ *   `to="/targets"` + `search={{ selected: 'x' }}` → `/targets?selected=x`
+ *   `to="/settings/$pane"` + `params={{ pane: 'tools' }}` → `/settings/tools`
+ */
+
+import type { ReactNode } from 'react';
+
+export interface LinkStubProps {
+  children?: ReactNode;
+  to: string;
+  search?: Record<string, string>;
+  params?: Record<string, string>;
+}
+
+export function LinkStub({
+  children,
+  to,
+  search,
+  params,
+  ...rest
+}: LinkStubProps) {
+  const path = params
+    ? Object.entries(params).reduce(
+        (acc, [key, value]) => acc.replace(`$${key}`, value),
+        to,
+      )
+    : to;
+  const query = search ? `?${new URLSearchParams(search).toString()}` : '';
+  return (
+    <a href={`${path}${query}`} {...rest}>
+      {children}
+    </a>
+  );
+}


### PR DESCRIPTION
## Summary

- Reloading the app no longer loses what you had selected. Projects, Sessions,
  Calibration, Archive and Inbox all cleared the selection from the URL on a
  cold reload, because they judged the selected item "missing" while its list
  was still loading.
- Targets now forgets a selection whose target no longer exists, instead of
  keeping a dead selection in the URL forever.
- The two "Configure path" links into Settings now actually land on the Tools
  pane. They previously opened Settings on its default pane.

## Detail

### Selection survives a reload

The five wired ledger pages derived their found-flag from a possibly-still-empty
query result while ignoring the query's loading flag. On a cold reload the cache
is empty, so `useStaleSelectionCleanup` fired before the list IPC resolved and
rewrote the URL clearing the selection — a false-positive "stale" classification
of exactly the selection spec 020 US1-AS1/SC-002 guarantees survives a reload.

Each page now gates on its own loading flag. The gate stays **bounded**: loading
settles, and a genuinely absent id is still cleared.

`InboxPage` needed care — it already carries a deliberately bounded gate for the
reclassify handoff, whose whole point is that it must not stay open forever. The
new `listLoading` term does not weaken that (it settles on its own, unlike
`pendingReclassifySelectionId`, which needed `resolveReclassifyHandoff`'s
explicit give-up path).

### Targets is now wired

`TargetsPage` had no `useStaleSelectionCleanup` call at all (tasks.md T030
claimed all six pages were wired — five were). It matches against the **full**
query data rather than the progressively-revealed slice, since an unrevealed
target is present, not stale.

### Both hash-navigation escapes go through the router

`tool-launch.ts` and `ProjectDetail.tsx` now use `navigate` / `<Link>`.

Worth flagging: both were also **functionally wrong**, not just style
violations. `SettingsPage` resolves its pane from the `/settings/$pane` **path**
param (`SettingsPage.tsx:164,175`), so the `'#/settings?pane=tools'` search was
ignored — neither escape actually opened the Tools pane.

## Tests

The existing T053 test passes the hook explicit booleans and so structurally
cannot catch a page-level wiring bug. The new tests exercise the **page**
wiring, and each page gets a pair asserting the gate from **both** directions —
held closed while loading, released once the list settles — so the fix cannot
regress into a permanently-open gate.

Every new case was verified against the unfixed code: with the gate removed, all
six "keeps a valid `?selected=`" cases fail while the "still clears" cases keep
passing.

`ProjectDetail`'s new `<Link>` made the component need router context, which its
six suites did not provide. Their mocks now supply it; the `Link` stub is
extracted to `src/test/router-link-stub.tsx` rather than copied five times.

## Not included — #738 is only half closable

**Deliberately not closing #738.** Of its two missing entry points:

- **The project-source link is already built on main** —
  `ProjectDetail.tsx:344-363` is a real `<Link to="/targets" search={{selected}}>`
  with a test asserting `/targets?selected=ct-3`
  (`ProjectDetail.target.test.tsx:166`). The issue text is stale.
- **The Inventory/Inbox target chip is blocked on the backend.** The row DTOs
  carry no canonical target id: `InventorySession.target` and
  `InboxListItem.groupTarget` are both raw FITS `OBJECT` **strings**. Resolving
  them client-side is not a workaround — R-17 explicitly forbids using the raw
  `OBJECT` header for matching/search. The chip needs a real `targetId` on the
  DTO first, so it is reported rather than stubbed.

## Gates

`pnpm lint` ✅ · `pnpm test` ✅ (206 files / 1874 tests) · `pnpm typecheck` ✅ ·
`css-dup-sniff` ✅

No new CSS or components, so the one-shared-component mandate does not bind here
(the one product-side change is a tag swap on an existing element reusing its
existing class).

## Spec Context

Spec 020 FR-007 / FR-003 / SC-002 (router & URL state), spec 023 US1.

Closes #735
