### PR TITLE
ci: let unit, integration and mock-mode actually finish on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,22 @@ on:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Cancel superseded runs on branches, but never on `main` (#1203).
+  #
+  # Every main push shares one concurrency group, because `github.ref` is
+  # `refs/heads/main` for all of them. A blanket `true` therefore made each
+  # merge cancel the previous merge's run, and during a merge campaign no main
+  # run survived to report: `6e624adc` and `67f48ee9` landed five minutes apart
+  # and both concluded `cancelled,cancelled`.
+  #
+  # That silently emptied main's gate for unit, integration and mock-mode UI —
+  # the suites this workflow owns. It is worse than a plain outage because it is
+  # merge-rate dependent: when merges space out a run completes and main looks
+  # green, so the gap only opens during periods of highest change velocity,
+  # which is exactly when verification matters most.
+  #
+  # e2e.yml took the same fix in #1268; this is the other half.
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Incremental artifacts are not reusable across CI runs and only bloat the cache.
 env:


### PR DESCRIPTION
Closes the remaining half of #1203. #1268 fixed `e2e.yml`; `ci.yml` had the
identical bug and still has it on `main` as of this PR.

## The bug

```yaml
group: ci-${{ github.workflow }}-${{ github.ref }}
cancel-in-progress: true
```

`github.ref` is `refs/pull/N/merge` on a PR — one group per PR, so cancelling a
superseded run is correct and saves runner minutes.

On a push to main it is `refs/heads/main` for *every* merge. All main runs share
one group, so each merge cancelled the previous merge's run. Under campaign
merge rates nothing survived to report.

## Evidence on current main

```
6e624adc  15:29  fix(ci): frontend suite on macOS   -> cancelled,cancelled,...
67f48ee9  15:24  ci: rebalance E2E shards           -> cancelled,cancelled,...
```

`ci.yml` owns unit, integration and mock-mode UI, so main's gate for all three
was empty. It is worse than a visible outage because it is merge-rate
dependent: when merges space out a run completes and main looks green. The gap
opens only during the highest-velocity periods — when verification matters
most — which makes it easy to dismiss as flake.

## The fix

```yaml
cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
```

Same expression `e2e.yml` already carries. PRs keep cancelling superseded runs;
main runs always finish.

**Cost is bounded.** With `false`, GitHub keeps at most the in-flight run plus
one queued run per group and discards intermediate pending runs, so this is
~2 runs per group, not a serialised backlog — and the queued run always
coalesces to the newest commit.

## Scope

One line plus its rationale comment. No job, trigger or step changes. Verified
the workflow still parses and all three jobs are intact. Only #1292 also touches
`ci.yml`; it changes clippy wiring and does not go near the concurrency key.