### PR TITLE
fix: the settings error box can no longer fall back to a light-mode red in dark themes

### DIFF
--- a/apps/desktop/src/styles/components/settings.css
+++ b/apps/desktop/src/styles/components/settings.css
@@ -134,9 +134,9 @@ font-weight: var(--pv-weight-medium);
   color: var(--pv-danger);
   margin-top: var(--pv-sp-2);
   padding: var(--pv-sp-2) var(--pv-sp-3);
-  background: var(--pv-danger-bg, rgba(220,38,38,0.08));
+  background: var(--pv-danger-bg);
   border-radius: var(--pv-radius-sm);
-  border: 1px solid var(--pv-danger-border, rgba(220,38,38,0.2));
+  border: 1px solid var(--pv-danger-border);
 }
 
 /* Radio group */


### PR DESCRIPTION
`.pv-settings__error` read its background and border as `var(--pv-danger-bg, rgba(220,38,38,0.08))`. Both tokens are defined in **all six themes**, so the fallback never fired — and had it fired, it would have painted a light-mode red into the dark themes.

The fallback was also inconsistent with its own rule: the sibling `color: var(--pv-danger)` has no fallback, and the entire colour palette is theme-only (`:root` carries scales plus three border/link tokens, nothing else), so an un-themed document would already render the error text wrong.

## Verification

- Every one of the 6 theme blocks defines `--pv-danger-bg` and `--pv-danger-border` (checked by parsing `tokens.css`, not by eye).
- `scripts/check-tokens.sh`: all checks pass, including the 29 WCAG-AA contrast pairs across 6 themes.

## Context

These were the **last two** raw colour values in hand-written component CSS. One remains — an inset shadow in `primitives.css` — which #1303 currently owns, so it's left alone.

A stylelint rule to keep this at zero belongs with the stylelint config arriving in #1304; filed as a follow-up rather than bolted on here.