### PR TITLE
fix: an environment variable could disable the single-instance guard in release builds

### DIFF
--- a/apps/desktop/src-tauri/src/bootstrap/mod.rs
+++ b/apps/desktop/src-tauri/src/bootstrap/mod.rs
@@ -14,3 +14,37 @@
 pub(crate) mod background;
 pub(crate) mod menu;
 pub(crate) mod window;
+
+/// Whether `build_app` registers the single-instance guard (spec 051 US1).
+///
+/// The E2E bypass is scoped two ways, and both must hold to skip the guard:
+/// the binary is built with the `e2e` feature (which release builds MUST NOT
+/// enable, mirroring `dev-tools` — see `Cargo.toml`), and `ALM_E2E_INSTANCE_ID`
+/// is set at runtime. The compile-time half is what keeps a shipped binary
+/// from being talked out of its guard by a stray environment variable.
+pub(crate) const fn single_instance_guard_enabled(e2e_instance_id_set: bool) -> bool {
+    !(cfg!(feature = "e2e") && e2e_instance_id_set)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::single_instance_guard_enabled;
+
+    /// The release-leak regression: without the `e2e` feature compiled in, no
+    /// value of `ALM_E2E_INSTANCE_ID` may disable the guard.
+    #[test]
+    #[cfg(not(feature = "e2e"))]
+    fn env_var_alone_cannot_disable_the_guard() {
+        assert!(single_instance_guard_enabled(true));
+        assert!(single_instance_guard_enabled(false));
+    }
+
+    /// In an `e2e` build the bypass still requires the runtime marker, so a
+    /// developer running that build by hand keeps the guard.
+    #[test]
+    #[cfg(feature = "e2e")]
+    fn e2e_build_bypasses_only_when_marker_is_set() {
+        assert!(!single_instance_guard_enabled(true));
+        assert!(single_instance_guard_enabled(false));
+    }
+}

--- a/apps/desktop/src-tauri/src/bootstrap/window.rs
+++ b/apps/desktop/src-tauri/src/bootstrap/window.rs
@@ -3,6 +3,59 @@
 
 //! Post-restore window geometry corrections (spec 051 US4), applied after
 //! `tauri-plugin-window-state` restores a persisted size/position.
+//!
+//! The geometry decisions live in [`clamp_to_min_size`] and [`Rect`] so they
+//! can be tested against synthetic monitor layouts; the `tauri`-typed
+//! functions only read the live window and apply the result.
+
+/// `tauri.conf.json`'s `minWidth`/`minHeight`. Duplicated here because the
+/// restored size arrives from the window-state plugin's store, not the config.
+const MIN_WIDTH: u32 = 1100;
+const MIN_HEIGHT: u32 = 720;
+
+/// Raise a restored size to the configured floor, per axis independently.
+const fn clamp_to_min_size(width: u32, height: u32) -> (u32, u32) {
+    (
+        if width < MIN_WIDTH { MIN_WIDTH } else { width },
+        if height < MIN_HEIGHT { MIN_HEIGHT } else { height },
+    )
+}
+
+/// A screen-space rectangle in physical pixels. Positions are signed because
+/// monitors left of / above the primary have negative origins.
+#[derive(Debug, Clone, Copy)]
+struct Rect {
+    x: i32,
+    y: i32,
+    width: u32,
+    height: u32,
+}
+
+impl Rect {
+    const fn new(x: i32, y: i32, width: u32, height: u32) -> Self {
+        Self { x, y, width, height }
+    }
+
+    /// Saturating so an absurd persisted size cannot overflow the addition and
+    /// panic in a debug build; a saturated edge still compares correctly.
+    fn right(self) -> i32 {
+        self.x.saturating_add(i32::try_from(self.width).unwrap_or(i32::MAX))
+    }
+
+    fn bottom(self) -> i32 {
+        self.y.saturating_add(i32::try_from(self.height).unwrap_or(i32::MAX))
+    }
+
+    /// Strict overlap: rectangles that merely share an edge do not intersect,
+    /// so a window resting exactly against a monitor's outer edge counts as
+    /// off-screen and gets recentered.
+    fn intersects(&self, other: &Self) -> bool {
+        self.x < other.right()
+            && self.right() > other.x
+            && self.y < other.bottom()
+            && self.bottom() > other.y
+    }
+}
 
 /// Enforce the min-size floor (spec 051 US4, T029) after
 /// `tauri-plugin-window-state` restores a persisted size, in case a prior
@@ -10,12 +63,8 @@
 /// `minWidth`/`minHeight` (1100x720) — mirrors the `astro-up` reference's own
 /// explicit post-restore clamp (research.md's cited `lib.rs` excerpt).
 pub(crate) fn enforce_min_window_size(window: &tauri::WebviewWindow) {
-    const MIN_WIDTH: u32 = 1100;
-    const MIN_HEIGHT: u32 = 720;
-
     if let Ok(size) = window.inner_size() {
-        let w = size.width.max(MIN_WIDTH);
-        let h = size.height.max(MIN_HEIGHT);
+        let (w, h) = clamp_to_min_size(size.width, size.height);
         if w != size.width || h != size.height {
             if let Err(e) = window.set_size(tauri::Size::Physical(tauri::PhysicalSize::new(w, h))) {
                 tracing::warn!("failed to enforce minimum window size: {e:?}");
@@ -37,16 +86,9 @@ pub(crate) fn recenter_if_offscreen(window: &tauri::WebviewWindow) {
         return;
     };
 
-    let win_right = pos.x + i32::try_from(size.width).unwrap_or(i32::MAX);
-    let win_bottom = pos.y + i32::try_from(size.height).unwrap_or(i32::MAX);
-
+    let win = Rect::new(pos.x, pos.y, size.width, size.height);
     let on_screen = monitors.iter().any(|m| {
-        let mp = m.position();
-        let ms = m.size();
-        let mon_right = mp.x + i32::try_from(ms.width).unwrap_or(i32::MAX);
-        let mon_bottom = mp.y + i32::try_from(ms.height).unwrap_or(i32::MAX);
-        // Any overlap between the window rect and this monitor's rect.
-        pos.x < mon_right && win_right > mp.x && pos.y < mon_bottom && win_bottom > mp.y
+        win.intersects(&Rect::new(m.position().x, m.position().y, m.size().width, m.size().height))
     });
 
     if !on_screen {
@@ -55,5 +97,77 @@ pub(crate) fn recenter_if_offscreen(window: &tauri::WebviewWindow) {
         } else {
             tracing::info!("restored window position was off-screen; recentered");
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{clamp_to_min_size, Rect, MIN_HEIGHT, MIN_WIDTH};
+
+    /// A monitor layout with the primary at the origin and a second display
+    /// positioned to its left, which is where negative coordinates come from.
+    fn dual_monitors() -> [Rect; 2] {
+        [Rect::new(0, 0, 1920, 1080), Rect::new(-1920, 0, 1920, 1080)]
+    }
+
+    fn on_any(win: Rect, monitors: &[Rect]) -> bool {
+        monitors.iter().any(|m| win.intersects(m))
+    }
+
+    #[test]
+    fn clamp_raises_each_axis_independently() {
+        assert_eq!(clamp_to_min_size(800, 900), (MIN_WIDTH, 900));
+        assert_eq!(clamp_to_min_size(1600, 400), (1600, MIN_HEIGHT));
+    }
+
+    #[test]
+    fn clamp_never_shrinks_an_oversized_window() {
+        assert_eq!(clamp_to_min_size(3840, 2160), (3840, 2160));
+    }
+
+    #[test]
+    fn window_on_the_secondary_monitor_is_on_screen() {
+        assert!(on_any(Rect::new(-1800, 100, 1280, 800), &dual_monitors()));
+    }
+
+    /// The failure this guard exists for: the display the window was parked on
+    /// is gone, so only the primary remains and the position is stranded.
+    #[test]
+    fn window_is_offscreen_once_its_monitor_disconnects() {
+        let win = Rect::new(-1800, 100, 1280, 800);
+        assert!(on_any(win, &dual_monitors()));
+        assert!(!on_any(win, &[Rect::new(0, 0, 1920, 1080)]));
+    }
+
+    #[test]
+    fn window_straddling_two_monitors_is_on_screen() {
+        assert!(on_any(Rect::new(-200, 100, 1280, 800), &dual_monitors()));
+    }
+
+    #[test]
+    fn window_touching_a_monitor_edge_counts_as_offscreen() {
+        // Right edge lands exactly on the monitor's left edge: zero overlap.
+        assert!(!on_any(Rect::new(-1280, 100, 1280, 800), &[Rect::new(0, 0, 1920, 1080)]));
+        // One pixel of overlap is enough to keep it on-screen.
+        assert!(on_any(Rect::new(-1279, 100, 1280, 800), &[Rect::new(0, 0, 1920, 1080)]));
+    }
+
+    #[test]
+    fn window_below_every_monitor_is_offscreen() {
+        assert!(!on_any(Rect::new(100, 4000, 1280, 800), &dual_monitors()));
+    }
+
+    #[test]
+    fn no_connected_monitors_means_offscreen() {
+        assert!(!on_any(Rect::new(0, 0, 1280, 800), &[]));
+    }
+
+    /// A corrupt persisted size must not overflow the edge arithmetic and
+    /// panic in a debug build; it saturates and the window still gets judged.
+    #[test]
+    fn absurd_persisted_size_saturates_instead_of_overflowing() {
+        let win = Rect::new(i32::MAX - 1, 0, u32::MAX, u32::MAX);
+        assert_eq!(win.right(), i32::MAX);
+        assert!(!on_any(win, &dual_monitors()));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -66,9 +66,12 @@ pub fn build_app() -> tauri::App {
     // silently redirected/exited without ever opening a window, timing out the
     // WebDriver session (observed on the Windows shard). No journey exercises
     // single-instance behaviour, so when the var is set we skip the plugin
-    // entirely on every platform. Unset (real users, non-e2e builds), the
-    // guard is registered unchanged.
-    if std::env::var_os("ALM_E2E_INSTANCE_ID").is_none() {
+    // entirely on every platform. The bypass additionally requires the `e2e`
+    // feature at compile time, so release binaries ignore the variable — see
+    // `bootstrap::single_instance_guard_enabled`.
+    if crate::bootstrap::single_instance_guard_enabled(
+        std::env::var_os("ALM_E2E_INSTANCE_ID").is_some(),
+    ) {
         tb = tb.plugin(
             tauri_plugin_single_instance::Builder::new()
                 .callback(|app, argv, cwd| {


### PR DESCRIPTION
## Summary

- The single-instance guard stops two app processes opening the same database. Its E2E escape hatch keyed on the `ALM_E2E_INSTANCE_ID` environment variable alone, so a released build honoured that variable from any environment. The bypass now also requires the `e2e` build feature, which release binaries omit.
- Adds 10 unit tests for the post-restore window geometry (off-screen recentering, min-size clamp), which had no coverage.
- Off-screen edge arithmetic saturates instead of overflowing, which could panic a debug build on a corrupt persisted window size.

Refs #1219.

## The issue text is stale

#1219 describes `apps/desktop/src-tauri/src/lib.rs` as 1232 lines. At `origin/main` it is 413 lines: the split tracked by #981 already landed, and the named functions moved to `src/bootstrap/`. The three untested behaviours it lists are still real, and are addressed or explained below.

## 1. Window geometry — covered

`recenter_if_offscreen` and `enforce_min_window_size` (`apps/desktop/src-tauri/src/bootstrap/window.rs`) took a `tauri::WebviewWindow` and did their arithmetic inline, so neither was reachable without a live window. The geometry decisions are now `clamp_to_min_size` and a `Rect::intersects` predicate; the `tauri`-typed functions read the window and apply the result.

10 tests cover: per-axis min-size clamping, no shrink of an oversized window, a window on a secondary monitor, the same window once that monitor disconnects, straddling two monitors, exact-edge contact (counts as off-screen), below all monitors, and an empty monitor list.

One behaviour change: edge arithmetic saturates instead of overflowing. The previous `pos.x + i32::MAX` fallback would panic in a debug build on a corrupt persisted size.

## 2. Single-instance guard — bypass scoped, not re-enabled in E2E

The E2E harness disables this guard deliberately, and re-enabling it would turn the suite red. `tauri-plugin-single-instance` derives one identity from the app identifier, with a per-instance override on Linux (`dbus_id`) only — not Windows (named mutex) or macOS. The harness launches several `desktop_shell` instances concurrently, so they collide and the loser is redirected and exits without opening a window, timing out the WebDriver session. This is documented at `crates/e2e-tests/tests/common/mod.rs:1871-1880` and was observed on the Windows shard. No journey exercises single-instance behaviour. Leaving it disabled there.

The half that was a genuine defect is the scoping the issue asks for: the bypass keyed on `ALM_E2E_INSTANCE_ID` alone, so a shipped binary honoured that variable from any environment. It now additionally requires the `e2e` feature, which release binaries omit (`apps/desktop/src-tauri/Cargo.toml:79-84`, Constitution Principle V) and which the harness always builds with. `bootstrap::single_instance_guard_enabled` carries the decision, tested in both directions: without the feature no value of the variable disables the guard; with the feature the bypass still requires the marker.

Recovering the guard's runtime behaviour under test needs two real processes racing an OS named mutex. That is an integration-harness change, not a unit test, and is out of scope here.

## 3. Updater pubkey / endpoint refusal — not addressed

`tauri_plugin_updater` verifies signatures internally against `plugins.updater.pubkey` in `tauri.conf.json`. Asserting refusal means serving a signed manifest from a test endpoint and driving the plugin's update check — an integration fixture, not a unit test. Left for a follow-up rather than shipped as a shallow assertion.

## Gates

- `cargo test -p desktop_shell --lib` — 34 passed (10 new)
- `cargo test -p desktop_shell --lib --features e2e bootstrap::tests` — 1 passed (the opposite feature branch)
- `cargo clippy -p desktop_shell --all-targets -- -D warnings` — clean
- `cargo fmt --all --check` — clean
- `just lint` — clean (workspace clippy, eslint, token policy, i18n, pre-commit)

The Windows `0xc0000139` test-binary manifest issue does not apply: `apps/desktop/src-tauri/build.rs:40` already embeds the manifest via `cargo:rustc-link-arg` (no `-bins` suffix), which covers test executables. No new test binary was added — the tests are inline `#[cfg(test)]` modules.
