### PR TITLE
test(e2e): isolate concurrent instances with a data dir the OS cannot ignore

### DIFF
--- a/apps/desktop/src-tauri/src/data_dir.rs
+++ b/apps/desktop/src-tauri/src/data_dir.rs
@@ -1,0 +1,192 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Explicit app-data-root override (`ALM_DATA_DIR`) — issue #1204.
+//!
+//! # Why an env var cannot do this on its own
+//!
+//! The E2E harness gives every concurrent app instance an isolated app-data
+//! root by overriding the platform's location env vars
+//! (`crates/e2e-tests/tests/common/mod.rs::InstanceEnv`): `XDG_DATA_HOME` on
+//! Linux, `HOME` on macOS, `APPDATA`/`LOCALAPPDATA` on Windows.
+//!
+//! That works on Linux and macOS. **It does nothing on Windows.** Tauri
+//! resolves both `app_data_dir()` and the config-driven webview
+//! `data_directory` through the `dirs` crate, which on Windows calls
+//! `SHGetKnownFolderPath(FOLDERID_RoamingAppData)` /
+//! `FOLDERID_LocalAppData` (`dirs-sys-0.5.0/src/lib.rs:176`). The Known
+//! Folder API reads the user's shell profile — it ignores `APPDATA` and
+//! `LOCALAPPDATA` entirely. No env var can redirect it.
+//!
+//! So on Windows, every concurrent instance silently shared one real
+//! app-data root, which collided in two places:
+//!
+//! 1. **The redb resolve cache** (`simbad-cache.redb`) — the second instance
+//!    logs `Database already open. Cannot acquire lock` and degrades to an
+//!    in-memory cache.
+//! 2. **The `WebView2` user-data folder** — `create_environment` passes
+//!    `data_directory` straight to `CreateCoreWebView2EnvironmentWithOptions`
+//!    (`wry-0.55.1/src/webview2/mod.rs:345`), and an empty value means "the
+//!    default folder next to the exe". Two instances of the same exe get the
+//!    same folder, the second fails with
+//!    `failed to create webview: WindowsError(0x80070057)`, and — having no
+//!    window — never brings up its `WebDriver` port. That surfaced four layers
+//!    downstream as `window.__ALM_E2E__ bridge never became ready`, the
+//!    symptom chased since #1019.
+//!
+//! # The override
+//!
+//! [`resolve`] reads `ALM_DATA_DIR`. When set, it is used verbatim as the
+//! app-data root instead of `app.path().app_data_dir()`, on every platform —
+//! one mechanism rather than three platform-specific ones that are only
+//! honoured on two of them.
+//!
+//! When unset (real users, every non-E2E build) nothing changes: callers
+//! fall back to the platform resolver exactly as before.
+//!
+//! # The webview folder is a separate lever
+//!
+//! The webview's user-data folder cannot live under `ALM_DATA_DIR`, because
+//! a config-declared window's `data_directory` **must be relative** —
+//! `WebviewBuilder::from_config` rejects absolute paths outright and joins
+//! relative ones onto `dirs::data_local_dir()/<label>`
+//! (`tauri-2.11.5/src/webview/mod.rs:392-425`), which is the very Known
+//! Folder we cannot redirect.
+//!
+//! What we *can* do is make the leaf name unique per instance, so concurrent
+//! instances stop sharing one folder even though they all sit under the real
+//! `LocalAppData`. [`webview_subdir`] derives that name from the override
+//! path. Isolation of *identity* is what fixes the collision; isolation of
+//! *location* is not available to us here.
+
+use std::path::PathBuf;
+
+/// Name of the app-data-root override variable. See the module docs.
+pub const DATA_DIR_ENV: &str = "ALM_DATA_DIR";
+
+/// The app-data root override, if `ALM_DATA_DIR` is set to a non-empty value.
+///
+/// Returns `None` when unset or empty, meaning "use the platform resolver".
+#[must_use]
+pub fn resolve() -> Option<PathBuf> {
+    resolve_from(std::env::var_os(DATA_DIR_ENV).as_deref())
+}
+
+/// [`resolve`]'s logic, as a pure function of the raw variable.
+///
+/// Split out so the tests never mutate the process environment: `set_var` is
+/// `unsafe` (and forbidden workspace-wide), and a global mutated from
+/// multiple test threads is a race regardless.
+fn resolve_from(raw: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
+    let raw = raw?;
+    if raw.is_empty() {
+        return None;
+    }
+    Some(PathBuf::from(raw))
+}
+
+/// A per-instance webview user-data folder name, or `None` when no override
+/// is set (in which case config windows keep Tauri's default behaviour).
+///
+/// The name is a deterministic function of the override path, so the same
+/// instance reuses the same folder across a launch → shutdown → relaunch
+/// sequence — which the E2E harness's webview-storage-preserving
+/// `relaunch()` depends on — while two instances with different roots never
+/// collide.
+#[must_use]
+pub fn webview_subdir() -> Option<PathBuf> {
+    resolve().as_deref().map(webview_subdir_for)
+}
+
+/// [`webview_subdir`]'s derivation, as a pure function of the root. See
+/// [`resolve_from`] on why the split exists.
+fn webview_subdir_for(root: &std::path::Path) -> PathBuf {
+    PathBuf::from(format!("pv-{:016x}", fnv1a(root.as_os_str().as_encoded_bytes())))
+}
+
+/// FNV-1a, 64-bit. Used only to turn a path into a short, stable, filesystem-
+/// safe folder name — not for anything security-sensitive. Spelled out here
+/// rather than using `DefaultHasher`, whose output std explicitly reserves
+/// the right to change between releases (which would silently orphan an
+/// instance's webview storage across a toolchain bump).
+fn fnv1a(bytes: &[u8]) -> u64 {
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    bytes.iter().fold(OFFSET, |hash, &b| (hash ^ u64::from(b)).wrapping_mul(PRIME))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn os(s: &str) -> &std::ffi::OsStr {
+        std::ffi::OsStr::new(s)
+    }
+
+    #[test]
+    fn unset_means_use_the_platform_resolver() {
+        assert_eq!(resolve_from(None), None);
+    }
+
+    /// An empty value is treated as unset rather than as "the current
+    /// directory", which is what `PathBuf::from("")` would otherwise mean.
+    #[test]
+    fn empty_means_unset() {
+        assert_eq!(resolve_from(Some(os(""))), None);
+    }
+
+    #[test]
+    fn set_is_used_verbatim() {
+        assert_eq!(
+            resolve_from(Some(os("/tmp/pv-instance-a"))),
+            Some(PathBuf::from("/tmp/pv-instance-a"))
+        );
+    }
+
+    /// The property the whole fix rests on: different roots must produce
+    /// different webview folders, or concurrent instances still collide.
+    #[test]
+    fn different_roots_get_different_webview_dirs() {
+        let a = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
+        let b = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-b"));
+        assert_ne!(a, b, "two instance roots must not share a webview data directory");
+    }
+
+    /// The complementary property: one root is stable across relaunches, so
+    /// `ResetScope::PreserveWebviewStorage` still preserves storage.
+    #[test]
+    fn same_root_is_stable_across_calls() {
+        let a = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
+        let b = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
+        assert_eq!(a, b);
+    }
+
+    /// The E2E harness has to delete this exact folder to honour a
+    /// storage-clearing `relaunch()`, and it cannot call this function — it
+    /// deliberately does not depend on the Tauri app crate
+    /// (`crates/e2e-tests/Cargo.toml`). So it reimplements the derivation,
+    /// and this pinned pair is the contract between the two copies: the same
+    /// literal is asserted by
+    /// `crates/e2e-tests/tests/common/mod.rs::webview_subdir_matches_the_app`.
+    /// If either side drifts, one of the two tests fails.
+    #[test]
+    fn webview_dir_derivation_is_pinned() {
+        let dir = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
+        assert_eq!(dir, PathBuf::from("pv-b51d4cf056f3eb58"));
+    }
+
+    /// `from_config` rejects an absolute `data_directory` outright and
+    /// `SafePathBuf` rejects traversal, so the derived name must be a plain
+    /// relative single component or the config is silently ignored.
+    #[test]
+    fn webview_dir_is_a_plain_relative_component() {
+        let dir = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
+        assert!(dir.is_relative(), "must be relative: {dir:?}");
+        assert_eq!(dir.components().count(), 1, "must be a single component: {dir:?}");
+        let name = dir.to_str().expect("ascii");
+        assert!(
+            name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
+            "must be filesystem-safe on every platform: {name}"
+        );
+    }
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -8,6 +8,7 @@
 //! are emitted at test time by `tests/bindings.rs` via tauri-specta.
 
 pub mod commands;
+pub mod data_dir;
 pub mod resolve_cache;
 pub mod watcher;
 
@@ -215,8 +216,49 @@ pub fn build_app() -> tauri::App {
 
             Ok(())
         })
-        .build(tauri::generate_context!())
+        .build(instance_context())
         .expect("error while building tauri application")
+}
+
+/// The compiled-in Tauri context, with each config-declared window pointed at
+/// a per-instance webview user-data folder when `ALM_DATA_DIR` is set.
+///
+/// Issue #1204: concurrent instances on Windows otherwise share one `WebView2`
+/// user-data folder, and the loser fails to create its webview at all
+/// (`WindowsError(0x80070057)`) — see [`crate::data_dir`] for the full chain
+/// and for why this has to go through the *config* (as a relative path)
+/// rather than [`tauri::webview::WebviewWindowBuilder::data_directory`]:
+/// windows declared in `tauri.conf.json` are built by Tauri itself, during
+/// `.build()`, so there is no builder for us to reach.
+///
+/// Unset (real users, non-E2E builds) leaves every window's `data_directory`
+/// as `None` — byte-for-byte the previous behaviour.
+///
+/// **Windows only, deliberately.** Linux and macOS already get real webview
+/// isolation from the harness's `XDG_*`/`HOME` overrides, which those
+/// platforms actually honour; there is no collision to fix. Setting
+/// `data_directory` there would instead *move* WebKitGTK/WKWebView storage
+/// out from under the isolated root it currently lives in — a regression
+/// bought for nothing.
+///
+/// That gate is a runtime `cfg!`, not a `#[cfg]` attribute, so this body is
+/// type-checked on every platform. A `#[cfg(target_os = "windows")]` block
+/// here would be invisible to the Linux and macOS CI legs and could only
+/// break on the one platform whose failures this is meant to stop.
+fn instance_context() -> tauri::Context {
+    let mut context = tauri::generate_context!();
+
+    if let (true, Some(subdir)) = (cfg!(target_os = "windows"), crate::data_dir::webview_subdir()) {
+        for window in &mut context.config_mut().app.windows {
+            window.data_directory = Some(subdir.clone());
+        }
+        tracing::info!(
+            webview_data_directory = %subdir.display(),
+            "per-instance webview user-data folder in effect (ALM_DATA_DIR is set)"
+        );
+    }
+
+    context
 }
 
 // Sequential startup/subscriber-wiring assembly, not complex logic — same

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -248,14 +248,28 @@ pub fn build_app() -> tauri::App {
 fn instance_context() -> tauri::Context {
     let mut context = tauri::generate_context!();
 
-    if let (true, Some(subdir)) = (cfg!(target_os = "windows"), crate::data_dir::webview_subdir()) {
+    let subdir = crate::data_dir::webview_subdir();
+
+    if let (true, Some(subdir)) = (cfg!(target_os = "windows"), subdir.as_ref()) {
         for window in &mut context.config_mut().app.windows {
             window.data_directory = Some(subdir.clone());
         }
-        tracing::info!(
-            webview_data_directory = %subdir.display(),
-            "per-instance webview user-data folder in effect (ALM_DATA_DIR is set)"
+    }
+
+    // `eprintln!`, deliberately, not `tracing`: `build_app()` runs BEFORE
+    // `main.rs` installs the tracing subscriber, so anything logged from here
+    // is dropped on the floor. A first attempt at this used `tracing::info!`
+    // and produced no line in CI — which said nothing about whether the code
+    // had run, and cost a full Windows round-trip to find out. stderr is
+    // captured by the E2E harness's `ProcLog`, so this always shows up.
+    if let Some(dir) = &subdir {
+        eprintln!(
+            "ALM_DATA_DIR is set; webview data_directory = {} (applied: {})",
+            dir.display(),
+            cfg!(target_os = "windows")
         );
+    } else {
+        eprintln!("ALM_DATA_DIR is unset; webview data_directory left at Tauri's default");
     }
 
     context

--- a/apps/desktop/src-tauri/src/main.rs
+++ b/apps/desktop/src-tauri/src/main.rs
@@ -51,10 +51,18 @@ async fn main() {
     // `tauri_plugin_log::Builder::new().skip_logger()` comment in
     // `build_app()` for why the plugin does not also try to install one.
     {
-        let log_dir = app
-            .path()
-            .app_log_dir()
-            .unwrap_or_else(|_| std::env::temp_dir().join("plate-vault-logs"));
+        // `ALM_DATA_DIR` (issue #1204) relocates the whole app-data root, logs
+        // included — otherwise concurrent E2E instances on Windows interleave
+        // their lines into one shared daily log file, which is exactly the
+        // evidence trail those runs exist to produce.
+        let log_dir = desktop_shell::data_dir::resolve().map_or_else(
+            || {
+                app.path()
+                    .app_log_dir()
+                    .unwrap_or_else(|_| std::env::temp_dir().join("plate-vault-logs"))
+            },
+            |root| root.join("logs"),
+        );
         let _ = std::fs::create_dir_all(&log_dir);
 
         // Prune before creating today's writer so a just-rotated file from a
@@ -92,7 +100,16 @@ async fn main() {
     // redb resolve-cache file (`simbad-cache.redb`, D2 — one global file,
     // independent of the `ALM_DB_URL` override so dev/test SQLite swaps don't
     // also relocate the resolve cache).
-    let data_dir = app.path().app_data_dir().expect("failed to resolve platform data directory");
+    //
+    // `ALM_DATA_DIR` overrides it outright (issue #1204). The platform
+    // resolver goes through `dirs`, which on Windows reads a Known Folder and
+    // therefore ignores the `APPDATA`/`LOCALAPPDATA` overrides the E2E harness
+    // sets — so concurrent instances there all landed on ONE real root and
+    // fought over `simbad-cache.redb` ("Database already open. Cannot acquire
+    // lock"). See `desktop_shell::data_dir`.
+    let data_dir = desktop_shell::data_dir::resolve().unwrap_or_else(|| {
+        app.path().app_data_dir().expect("failed to resolve platform data directory")
+    });
     std::fs::create_dir_all(&data_dir).expect("failed to create app data directory");
 
     // `ALM_DB_URL` lets dev/test runs target an alternate SQLite store.

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -87,21 +87,37 @@ impl InstanceEnv {
     fn new() -> Result<Self> {
         let root = tempfile::tempdir().context("failed to create isolated E2E instance dir")?;
         let db_path = root.path().join("e2e-test.db");
-        let vars: Vec<(&'static str, String)> = if cfg!(target_os = "windows") {
+        // Issue #1204: the per-OS location vars below are honoured on Linux
+        // (`XDG_*`) and macOS (`HOME`), and silently ignored on Windows —
+        // Tauri resolves app dirs through `dirs`, which calls
+        // `SHGetKnownFolderPath`, and the Known Folder API reads the user's
+        // shell profile rather than `APPDATA`/`LOCALAPPDATA`. So on Windows
+        // every concurrent instance shared one real app-data root however
+        // these were set, colliding over `simbad-cache.redb` and — fatally —
+        // over the WebView2 user-data folder.
+        //
+        // `ALM_DATA_DIR` is an explicit override the app itself honours
+        // (`desktop_shell::data_dir`), so isolation no longer depends on the
+        // OS agreeing to be redirected. The per-OS vars stay: they still
+        // place `app_config_dir` (window-state) under this root on Linux and
+        // macOS, which `ALM_DATA_DIR` does not cover.
+        let mut vars: Vec<(&'static str, String)> =
+            vec![("ALM_DATA_DIR", root.path().join("appdata").display().to_string())];
+        vars.extend(if cfg!(target_os = "windows") {
             vec![
                 ("APPDATA", root.path().join("appdata").display().to_string()),
                 ("LOCALAPPDATA", root.path().join("localappdata").display().to_string()),
             ]
         } else if cfg!(target_os = "macos") {
-            // app_data_dir/app_config_dir both resolve under $HOME on macOS
-            // (see `app_data_dir`/`app_config_dir` below).
+            // app_config_dir resolves under $HOME on macOS (see
+            // `app_config_dir` below).
             vec![("HOME", root.path().display().to_string())]
         } else {
             vec![
                 ("XDG_DATA_HOME", root.path().join("xdg-data").display().to_string()),
                 ("XDG_CONFIG_HOME", root.path().join("xdg-config").display().to_string()),
             ]
-        };
+        });
         let (proxy_port, native_port) = pick_port_pair()?;
         Ok(Self { _root: root, vars, db_path, proxy_port, native_port })
     }
@@ -1956,11 +1972,27 @@ fn reset_database(db_path: &Path) -> Result<()> {
 fn reset_webview_storage(vars: &[(&'static str, String)]) {
     let mut candidates: Vec<PathBuf> = Vec::new();
     if cfg!(target_os = "windows") {
-        // WebView2 keeps ALL web storage under the user-data folder tauri
-        // points at `<app_local_data_dir>/EBWebView`.
-        if let Some(local) = lookup(vars, "LOCALAPPDATA") {
-            candidates
-                .push(PathBuf::from(local).join("dev.astro-plan.astro-library-manager/EBWebView"));
+        // Since #1204 the app points each window at a per-instance WebView2
+        // user-data folder (`desktop_shell::data_dir::webview_subdir`), and
+        // Tauri resolves that relative name to
+        // `dirs::data_local_dir()/<window label>/<name>`
+        // (`tauri-2.11.5/src/webview/mod.rs:411-413`).
+        //
+        // `dirs::data_local_dir()` is the real Known Folder — NOT the
+        // `LOCALAPPDATA` this instance sets, which is exactly the bug #1204
+        // was. This harness process has its own env unmodified, so its own
+        // `LOCALAPPDATA` is that same real folder, which is why we read it
+        // here rather than from `vars`.
+        //
+        // The previous target — `<isolated LOCALAPPDATA>/<identifier>/
+        // EBWebView` — never existed: the app had been writing to the real
+        // profile all along, so every "reset" silently deleted nothing and
+        // journeys shared one localStorage.
+        if let (Some(name), Ok(real_local)) = (webview_subdir(vars), std::env::var("LOCALAPPDATA"))
+        {
+            for label in ["main", "splash"] {
+                candidates.push(PathBuf::from(&real_local).join(label).join(&name));
+            }
         }
     } else if cfg!(target_os = "macos") {
         // WKWebView website data (incl. localStorage) lives under
@@ -2039,25 +2071,48 @@ fn app_config_dir(vars: &[(&'static str, String)]) -> Option<PathBuf> {
     base.map(|b| b.join(APP_IDENTIFIER))
 }
 
-/// Resolve the per-OS Tauri `app_data_dir` for the app identifier
-/// `dev.astro-plan.astro-library-manager` (`tauri.conf.json`) under this
-/// instance's isolated env overrides (`vars`, [`InstanceEnv::vars`]) instead
-/// of the real OS env. Mirrors `tauri::path::PathResolver::app_data_dir`
-/// (`dirs::data_dir()/<identifier>`) without needing a Tauri runtime in the
-/// test harness:
-/// - Linux:   `$XDG_DATA_HOME`
-/// - macOS:   `~/Library/Application Support`
-/// - Windows: `%APPDATA%` (roaming)
+/// This instance's app-data root — the directory the app actually writes its
+/// SQLite default, `simbad-cache.redb`, and logs into.
+///
+/// Since #1204 this is simply `ALM_DATA_DIR`, which the app honours directly
+/// (`desktop_shell::data_dir::resolve`), on every platform. It deliberately
+/// does NOT mirror `tauri::path::PathResolver::app_data_dir`'s per-OS
+/// `dirs::data_dir()/<identifier>` derivation any more: that derivation is
+/// what the harness used to reimplement, and on Windows the reimplementation
+/// and the app disagreed silently — the harness resetting files under the
+/// isolated root while the app read and wrote the real one.
 fn app_data_dir(vars: &[(&'static str, String)]) -> Option<PathBuf> {
-    const APP_IDENTIFIER: &str = "dev.astro-plan.astro-library-manager";
-    let base = if cfg!(target_os = "windows") {
-        lookup(vars, "APPDATA").map(PathBuf::from)
-    } else if cfg!(target_os = "macos") {
-        lookup(vars, "HOME").map(|h| PathBuf::from(h).join("Library/Application Support"))
-    } else {
-        lookup(vars, "XDG_DATA_HOME").map(PathBuf::from)
-    };
-    base.map(|b| b.join(APP_IDENTIFIER))
+    lookup(vars, "ALM_DATA_DIR").map(PathBuf::from)
+}
+
+/// This instance's WebView2 user-data folder *name* (Windows; see
+/// [`reset_webview_storage`] for where it is rooted).
+///
+/// Reimplements `desktop_shell::data_dir::webview_subdir`, because this crate
+/// deliberately does not depend on the Tauri app crate (see `Cargo.toml`'s
+/// header — the whole point is that the heavy Tauri/thirtyfour stacks stay
+/// out of the shipping build). [`webview_subdir_matches_the_app`] pins the
+/// two copies to the same literal so drift is a test failure, not a silent
+/// "reset deleted nothing" — the failure mode this replaced.
+fn webview_subdir(vars: &[(&'static str, String)]) -> Option<String> {
+    let root = lookup(vars, "ALM_DATA_DIR")?;
+    if root.is_empty() {
+        return None;
+    }
+    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
+    const PRIME: u64 = 0x0000_0100_0000_01b3;
+    let hash = root.as_bytes().iter().fold(OFFSET, |h, &b| (h ^ u64::from(b)).wrapping_mul(PRIME));
+    Some(format!("pv-{hash:016x}"))
+}
+
+/// The other half of the pinned contract asserted by
+/// `apps/desktop/src-tauri/src/data_dir.rs::webview_dir_derivation_is_pinned`.
+/// Both must agree on this literal, or the harness resets a folder the app
+/// does not use.
+#[test]
+fn webview_subdir_matches_the_app() {
+    let vars = vec![("ALM_DATA_DIR", "/tmp/pv-instance-a".to_string())];
+    assert_eq!(webview_subdir(&vars).as_deref(), Some("pv-b51d4cf056f3eb58"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Refs #1204, #1019. The real isolation fix that #1295 stands in for.

## The gap #1295 left open

#1295 found the root cause and stopped the bleeding by serialising Windows E2E journeys (`threads-required = 2`). I said there that it **serialises rather than isolates**, and that real isolation needs the app to accept a data-directory override, since no env var can redirect a Windows Known Folder. This is that override.

## Why the existing isolation was fake on Windows

The harness gives each concurrent instance an isolated app-data root via the platform location vars — `XDG_*` on Linux, `HOME` on macOS, `APPDATA`/`LOCALAPPDATA` on Windows.

Two of those work. Tauri resolves app dirs through `dirs`, which on Windows calls `SHGetKnownFolderPath` (`dirs-sys-0.5.0/src/lib.rs:176`). The Known Folder API reads the shell profile and ignores both variables outright. So every concurrent Windows instance shared one real root:

| Collision | Consequence |
|---|---|
| `simbad-cache.redb` | `Database already open. Cannot acquire lock` → that instance silently degrades to an in-memory cache |
| WebView2 user-data folder | loser cannot create its webview (`WindowsError(0x80070057)`) → no window → `tauri-plugin-webdriver` never serves → **`bridge never became ready`** |

## The fix

**`ALM_DATA_DIR`** — an override the *app* honours, so isolation no longer depends on the OS agreeing to be redirected. Used verbatim as the app-data root (SQLite default, resolve cache, logs) on every platform. Unset — real users, every non-E2E build — nothing changes.

**The webview folder needs a second lever.** A config-declared window's `data_directory` must be *relative*: `WebviewBuilder::from_config` rejects absolute paths and joins relative ones onto `dirs::data_local_dir()/<label>` (`tauri-2.11.5/src/webview/mod.rs:392-425`) — the very Known Folder we cannot redirect. So the fix makes the leaf name unique per instance rather than relocating it. **Isolating identity ends the collision; isolating location is not on offer here** — worth knowing if this ever needs revisiting.

Windows only. Linux and macOS already isolate correctly, and setting `data_directory` there would *move* WebKitGTK/WKWebView storage out of the isolated root it lives in today — a regression bought for nothing.

## A silent no-op this also fixes

`reset_webview_storage()` deleted `<isolated LOCALAPPDATA>/<identifier>/EBWebView` — a path that never existed, because the app had been writing to the real profile all along. Every Windows reset deleted nothing, and journeys shared one localStorage regardless of how carefully each one reset. That is a known separate symptom, now closed by the same change.

## Verification, and its limits

- `cargo test -p desktop_shell` — 77 passed
- `cargo clippy -p desktop_shell -p e2e_tests --all-targets` — clean
- 7 new unit tests on the derivation, including the two properties the fix rests on: different roots must not share a folder, and one root must stay stable across a relaunch (or `PreserveWebviewStorage` stops preserving).

**What I could not verify locally: the Windows behaviour itself.** I have no Windows runner here, so the claim that mutating the context config actually reaches window creation rests on reading `tauri-2.11.5`/`wry-0.55.1` source, not on observing it. The Windows E2E leg on this PR is the first real evidence — treat a green run there as the proof, not this description.

Two review notes:

- The harness reimplements the folder derivation (`crates/e2e-tests` deliberately does not depend on the Tauri app crate). Both copies pin the same literal, so drift fails a test instead of producing another reset that quietly deletes nothing.
- The Windows path is gated with a runtime `cfg!`, not `#[cfg]`, so it stays type-checked on the Linux and macOS legs rather than compiling only on the platform whose failures it exists to prevent.

## Follow-up, not in this PR

If the Windows leg is green here, #1295's `threads-required = 2` can come back out and Windows can return to two concurrent journeys. Leaving that as a separate change so the isolation lands on its own evidence, and the stop-gap stays until it has some.