### PR TITLE
fix: cone-search confirm no longer leaves target reported as missing

### DIFF
--- a/crates/app/inbox/src/cone_search.rs
+++ b/crates/app/inbox/src/cone_search.rs
@@ -972,6 +972,101 @@ mod tests {
         assert_eq!(count2, 1);
     }
 
+    /// #1294: confirming a cone-search match must clear the `target`
+    /// mandatory-attribute gate the Inbox UI reads via
+    /// `metadata::get_inbox_item_metadata` — not just write the durable
+    /// `canonical_target` link. Before the fix, `get_inbox_item_metadata`
+    /// read `inbox_file_metadata.object` directly and never saw the `target`
+    /// override `confirm` writes at cone_search.rs:509-540, so the frameset
+    /// kept reporting its target as missing until an unrelated reclassify
+    /// happened to re-run the override rebuild.
+    #[tokio::test]
+    async fn confirm_clears_the_target_mandatory_gate_for_the_confirmed_frameset() {
+        let db = test_db().await;
+        let item_id = "item-1294";
+        seed_item(&db, item_id, None, None, None, None, None, None, None).await;
+
+        // Wire the item into a source group (as classify normally does) so
+        // confirm's best-effort override write (cone_search.rs:509-540) has
+        // somewhere to land, and classify the sole file as a light frame with
+        // the other mandatory attributes present so `target` is isolated as
+        // the only variable.
+        sqlx::query(
+            "INSERT INTO inbox_source_groups \
+             (id, root_id, relative_path, discovered_at, last_scanned_at, child_count) \
+             VALUES ('sg-1294', 'root-1', 'lights-item-1294', \
+                     '2025-10-10T20:00:00Z', '2025-10-10T20:00:00Z', 1)",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query("UPDATE inbox_items SET source_group_id = 'sg-1294' WHERE id = ?")
+            .bind(item_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let relative_file_path = format!("lights-{item_id}/light_001.fits");
+        repo::insert_evidence(
+            db.pool(),
+            &repo::InsertEvidence {
+                id: "ev-1294",
+                inbox_item_id: item_id,
+                relative_file_path: &relative_file_path,
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: Some("Light Frame"),
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await
+        .unwrap();
+        repo::upsert_inbox_file_metadata(
+            db.pool(),
+            &UpsertFileMetadata {
+                inbox_item_id: item_id,
+                relative_file_path: &relative_file_path,
+                filter: Some("Ha"),
+                exposure_s: Some(300.0),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let files_before =
+            crate::metadata::get_inbox_item_metadata(db.pool(), item_id).await.unwrap();
+        assert!(
+            files_before[0].missing_mandatory.iter().any(|k| k == "target"),
+            "sanity: target starts out missing"
+        );
+
+        let cache = seeded_cache_with_m31().await;
+        let req = ConeSearchConfirmRequest {
+            frameset_id: item_id.to_owned(),
+            candidate: contracts_core::cone_search::ConeSearchConfirmCandidate {
+                canonical_target_id: None,
+                primary_designation: "M 31".to_owned(),
+                simbad_oid: Some(1_575_544),
+            },
+        };
+        confirm(db.pool(), &cache, &req).await.unwrap();
+
+        let files_after =
+            crate::metadata::get_inbox_item_metadata(db.pool(), item_id).await.unwrap();
+        assert!(
+            !files_after[0].missing_mandatory.iter().any(|k| k == "target"),
+            "confirming the cone-search match must clear the target mandatory gate"
+        );
+        assert_eq!(
+            files_after[0].object.as_deref(),
+            Some("M 31"),
+            "the confirmed designation must become the effective OBJECT"
+        );
+    }
+
     #[tokio::test]
     async fn confirm_unresolvable_candidate_is_candidate_invalid() {
         let db = test_db().await;

--- a/crates/app/inbox/src/metadata.rs
+++ b/crates/app/inbox/src/metadata.rs
@@ -85,10 +85,17 @@ pub async fn get_inbox_item_metadata(
         // is_master: a single-file master item OR a per-file detected master.
         let is_master = item_is_master || ev.is_some_and(|e| e.is_master != 0);
 
-        // Non-type overrides: override_filter/exposure/binning take
+        // Non-type overrides: override_filter/exposure/binning/target take
         // precedence over the extracted header values when set.
         let filter = ev.and_then(|e| e.override_filter.clone()).or_else(|| m.filter.clone());
         let exposure_s = ev.and_then(|e| e.override_exposure_s).or(m.exposure_s);
+        // #1294: the `target` override written by `cone_search::confirm`
+        // (a coordinate-resolved match) becomes the effective OBJECT here,
+        // same precedence as the other non-type overrides above — otherwise
+        // confirm's write is never read back and the mandatory-attribute
+        // gate (compute_missing_mandatory's "target" check, below) keeps
+        // reporting the file as missing its target forever.
+        let object = ev.and_then(|e| e.override_target.clone()).or_else(|| m.object.clone());
         // Parse "NxN" binning string (e.g. "2x2") → (binning_x, binning_y).
         let (binning_x, binning_y) =
             ev.and_then(|e| e.override_binning.as_deref()).and_then(parse_binning).map_or_else(
@@ -114,7 +121,7 @@ pub async fn get_inbox_item_metadata(
             binning_x,
             binning_y,
             temperature_c: m.temperature_c,
-            object: m.object.clone(),
+            object,
             date_obs: m.date_obs.clone(),
             instrume: m.instrume.clone(),
             telescop: m.telescop.clone(),
@@ -541,6 +548,114 @@ mod tests {
         assert_eq!(f.binning_y, Some(2), "parsed binning y from '2x2'");
         // A freshly-set override is not stale.
         assert!(!f.override_stale, "freshly-set override must not be stale");
+    }
+
+    /// #1294: the `target` override written by `cone_search::confirm` must
+    /// win over the extracted (missing) `object` header value in the
+    /// assembled metadata DTO, and clear the `target` mandatory-gate entry —
+    /// same override precedence as filter/exposure/binning above. Without the
+    /// `override_target` join in `list_evidence`, this override is a write
+    /// nobody reads and the file reports `target` missing forever.
+    #[tokio::test]
+    async fn target_override_surfaces_as_effective_object_and_clears_missing_mandatory() {
+        let db = test_db().await;
+        let item_id = "item-meta-target-1";
+
+        repo::insert_inbox_item(
+            db.pool(),
+            &InsertInboxItem {
+                id: item_id,
+                root_id: "root-1",
+                relative_path: "lights",
+                file_count: 1,
+                content_signature: Some("sig-target-1"),
+                lane: "fits",
+            },
+        )
+        .await
+        .unwrap();
+
+        // Wire the item to a source group (as classify normally does) so a
+        // target override has somewhere to attach — inbox_file_overrides is
+        // FK-constrained to inbox_source_groups.
+        repo::upsert_inbox_source_group(
+            db.pool(),
+            &repo::UpsertSourceGroup {
+                id: "sg-meta-target-1",
+                root_id: "root-1",
+                relative_path: "lights",
+                content_signature: None,
+                format: Some("fits"),
+                lane: Some("move"),
+            },
+        )
+        .await
+        .unwrap();
+        sqlx::query("UPDATE inbox_items SET source_group_id = ? WHERE id = ?")
+            .bind("sg-meta-target-1")
+            .bind(item_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        repo::insert_evidence(
+            db.pool(),
+            &InsertEvidence {
+                id: "ev-meta-target-1",
+                inbox_item_id: item_id,
+                relative_file_path: "lights/light_001.fits",
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: Some("Light Frame"),
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        // No OBJECT header, filter/exposure present so `target` is isolated
+        // as the only variable in the mandatory gate.
+        repo::upsert_inbox_file_metadata(
+            db.pool(),
+            &UpsertFileMetadata {
+                inbox_item_id: item_id,
+                relative_file_path: "lights/light_001.fits",
+                filter: Some("Ha"),
+                exposure_s: Some(300.0),
+                ..Default::default()
+            },
+        )
+        .await
+        .unwrap();
+
+        let before = get_inbox_item_metadata(db.pool(), item_id).await.unwrap();
+        assert_eq!(before[0].object, None, "no OBJECT header extracted yet");
+        assert!(
+            before[0].missing_mandatory.iter().any(|k| k == "target"),
+            "sanity: target starts out missing"
+        );
+
+        repo::set_file_override(
+            db.pool(),
+            "sg-meta-target-1",
+            "lights/light_001.fits",
+            "target",
+            "M 31",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let after = get_inbox_item_metadata(db.pool(), item_id).await.unwrap();
+        assert_eq!(after[0].object.as_deref(), Some("M 31"), "target override must win");
+        assert!(
+            !after[0].missing_mandatory.iter().any(|k| k == "target"),
+            "target override must clear the mandatory gate"
+        );
     }
 
     /// When mark_override_stale has been called (simulating R-4 detection),

--- a/crates/persistence/db/src/repositories/inbox.rs
+++ b/crates/persistence/db/src/repositories/inbox.rs
@@ -110,6 +110,12 @@ pub struct InboxEvidenceRow {
     /// race), this survives every evidence rebuild. Effective frame type
     /// resolves `manual_override` → `override_frame_type` → `frame_type`.
     pub override_frame_type: Option<String>,
+    /// Durable target override (property_key = 'target') from the same JOIN —
+    /// written by `cone_search::confirm`'s best-effort per-file link (#1294)
+    /// so the confirmed designation becomes the effective OBJECT for the
+    /// mandatory-attribute gate, not just the durable canonical_target row.
+    /// NULL when no override has been set.
+    pub override_target: Option<String>,
     /// 1 when any override recorded for this file is stale (file size/mtime
     /// changed since it was set — spec 041 R-4).
     pub override_stale: i64,
@@ -743,12 +749,12 @@ pub async fn list_evidence(
     pool: &SqlitePool,
     inbox_item_id: &str,
 ) -> DbResult<Vec<InboxEvidenceRow>> {
-    // Join inbox_file_overrides to recover the three non-type override values
-    // (filter/exposureS/binning) that were migrated out of the evidence table
-    // in migration 0048. The source_group_id is looked up from inbox_items.
-    // Three separate LEFT JOINs are used (one per property_key) so that each
-    // value is available as a distinct column in the result row, which
-    // sqlx::FromRow maps to the named struct fields.
+    // Join inbox_file_overrides to recover the non-type override values
+    // (filter/exposureS/binning/target) that live outside the evidence table
+    // (migration 0048, plus `target` for #1294). The source_group_id is
+    // looked up from inbox_items. Separate LEFT JOINs are used (one per
+    // property_key) so that each value is available as a distinct column in
+    // the result row, which sqlx::FromRow maps to the named struct fields.
     Ok(sqlx::query_as::<_, InboxEvidenceRow>(
         "SELECT
              ice.id,
@@ -764,6 +770,7 @@ pub async fn list_evidence(
              CAST(ov_exp.value AS REAL) AS override_exposure_s,
              ov_bin.value      AS override_binning,
              ov_ft.value       AS override_frame_type,
+             ov_target.value   AS override_target,
              ice.override_stale
          FROM inbox_classification_evidence ice
          LEFT JOIN inbox_items ii
@@ -784,6 +791,10 @@ pub async fn list_evidence(
              ON ov_ft.source_group_id = ii.source_group_id
             AND ov_ft.relative_file_path = ice.relative_file_path
             AND ov_ft.property_key = 'frameType'
+         LEFT JOIN inbox_file_overrides ov_target
+             ON ov_target.source_group_id = ii.source_group_id
+            AND ov_target.relative_file_path = ice.relative_file_path
+            AND ov_target.property_key = 'target'
          WHERE ice.inbox_item_id = ?
          ORDER BY ice.relative_file_path",
     )
@@ -3189,6 +3200,71 @@ mod tests {
         }
         let b = after.iter().find(|o| o.relative_file_path == "folder/b.fits").unwrap();
         assert_eq!(b.override_stale, 0, "unrelated file must be untouched");
+    }
+
+    /// #1294: `list_evidence` must join the `target` override the same way it
+    /// already joins filter/exposureS/binning/frameType — otherwise a target
+    /// override (written by `cone_search::confirm`) is a write nobody reads
+    /// back, and the mandatory-attribute gate in `app_core_inbox::metadata`
+    /// (which reads `list_evidence` rows) never sees it.
+    #[tokio::test]
+    async fn list_evidence_joins_target_override() {
+        let db = test_db().await;
+        let pool = db.pool();
+
+        // inbox_file_overrides.source_group_id is FK-constrained to
+        // inbox_source_groups(id); the evidence row's item must link to it.
+        upsert_inbox_source_group(
+            pool,
+            &UpsertSourceGroup {
+                id: "sg-target-1",
+                root_id: "root-1",
+                relative_path: "folder",
+                content_signature: None,
+                format: Some("fits"),
+                lane: Some("move"),
+            },
+        )
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO inbox_items \
+             (id, root_id, relative_path, source_group_id, group_key, \
+              discovered_at, last_scanned_at, state, lane) \
+             VALUES ('item-target-1', 'root-1', 'folder', 'sg-target-1', '', \
+                     '2025-10-10T20:00:00Z', '2025-10-10T20:00:00Z', \
+                     'pending_classification', 'fits')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        insert_evidence(
+            pool,
+            &InsertEvidence {
+                id: "ev-target-1",
+                inbox_item_id: "item-target-1",
+                relative_file_path: "folder/light.fits",
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: Some("Light Frame"),
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await
+        .unwrap();
+
+        let before = list_evidence(pool, "item-target-1").await.unwrap();
+        assert_eq!(before[0].override_target, None, "no override set yet");
+
+        set_file_override(pool, "sg-target-1", "folder/light.fits", "target", "M 31", None, None)
+            .await
+            .unwrap();
+
+        let after = list_evidence(pool, "item-target-1").await.unwrap();
+        assert_eq!(after[0].override_target.as_deref(), Some("M 31"));
     }
 
     /// get_file_metadata returns None before any classify and Some after upsert.


### PR DESCRIPTION
## Summary
- `cone_search::confirm` writes a durable canonical-target link and, best-effort, a `target` property override for every file in the frameset (cone_search.rs:509-540), but nothing read that override back for the Inbox mandatory-attribute gate: `list_evidence` (inbox.rs) only joined `filter`/`exposureS`/`binning`/`frameType` from `inbox_file_overrides`, so `metadata::get_inbox_item_metadata` — which drives what the Inbox UI shows — kept reading the raw, still-empty `object` column and reporting `target` missing until an unrelated `reclassify_v2` call happened to rebuild the override.
- Add a `target` LEFT JOIN to `list_evidence` (mirroring the existing filter/exposureS/binning/frameType joins) and merge `override_target` into the assembled `object` field in `metadata::get_inbox_item_metadata`, same precedence as the other non-type overrides.

Closes #1294.

## Citations verified
All four citations from #1294 held up as filed against `origin/main`:
- `cone_search.rs:509-540` writes the `target` override — confirmed.
- `inbox.rs` `list_evidence` (~771-783) only joined filter/exposureS/binning/frameType — confirmed, now extended with `target`.
- `metadata.rs:117` (`entry.object = m.object.clone()`) read the raw column — confirmed, now merges the override.
- `reclassify.rs:779-781` was the only place reading the override back — confirmed; still true for the durable rewrite path, unaffected by this change.

## Interaction with #1285
PR #1285 (open, green) extracts a shared `target_missing()` predicate used by `check_mandatory_missing` (classify.rs) and `compute_missing_mandatory` (metadata.rs), but does not touch `list_evidence`/`cone_search.rs`, and its `metadata.rs` hunk is `compute_missing_mandatory`'s match-arm body, not the entry-construction block this PR edits (`metadata.rs` lines ~88-124). This PR's `object` merge happens upstream of that predicate, so `compute_missing_mandatory`/`target_missing()` sees an already-correct `entry.object` regardless of merge order.

## Regression tests
- `crates/persistence/db/src/repositories/inbox.rs::list_evidence_joins_target_override` — persistence-level join proof.
- `crates/app/inbox/src/metadata.rs::target_override_surfaces_as_effective_object_and_clears_missing_mandatory` — DTO/gate-level proof.
- `crates/app/inbox/src/cone_search.rs::confirm_clears_the_target_mandatory_gate_for_the_confirmed_frameset` — end-to-end: calls real `confirm()`, then `metadata::get_inbox_item_metadata`, asserting `target` is missing before and cleared after.

Fail-before/pass-after verified by reverting the three prod hunks (not via git — via backup-file swap) while keeping the new tests: reverted state fails to compile (`E0609: no field override_target`, both new tests reference it), matching the pattern PR #1285 used. Restored state: all tests pass.

## Gates
- `cargo test -p app_core_inbox -p persistence_db`: 519 passed.
- `cargo clippy -p app_core_inbox -p persistence_db --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.
- `just lint`: exit 0 (includes `cargo fmt --all --check`, `cargo clippy --workspace --all-targets -- -D warnings`, biome/eslint, token/i18n checks, pre-commit).

No SQL migration — this reads an existing `inbox_file_overrides` row shape, it does not add a new property key.