### PR TITLE
fix: stop database upgrades from deleting saved plan items

### DIFF
--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -124,8 +124,31 @@ impl Database {
     // produces), so the scan's only remaining effect was auto-corrupting
     // real cross-drive projects into the dead-end `kind_diverged` state on
     // every reopen. Removed along with `reconcile_kind_diverged_views`.
+    //
+    // #1307: 15 migrations rebuild a table that has children under `ON DELETE
+    // CASCADE` (e.g. `plans` -> `plan_items`) and open with `PRAGMA
+    // foreign_keys = OFF` to make their `DROP TABLE` safe. sqlx runs every
+    // migration inside its own transaction, and SQLite treats that pragma as
+    // a no-op once a transaction is open (sqlite.org/pragma.html#pragma_foreign_keys),
+    // so the in-file pragma never took effect and `DROP TABLE plans` cascaded
+    // through `plan_items.plan_id ON DELETE CASCADE`, silently deleting every
+    // plan item on each of those 15 migrations. The already-applied migration
+    // files can't be edited (their checksums are recorded in every deployed
+    // database and validated by sqlx), so the fix runs the whole chain over a
+    // single connection with FK enforcement disabled *before* any transaction
+    // opens on it — that setting isn't scoped to a transaction, so it survives
+    // every migration's own `BEGIN`/`COMMIT`, regardless of what that
+    // migration's own pragma lines attempt. This protects every rebuild in
+    // the chain, past and future, without touching the migration files.
     pub async fn migrate(&self) -> DbResult<()> {
-        sqlx::migrate!("./migrations").run(&self.pool).await?;
+        let mut conn = self.pool.acquire().await?;
+        sqlx::query("PRAGMA foreign_keys = OFF;").execute(&mut *conn).await?;
+        let migrate_result = sqlx::migrate!("./migrations").run(&mut *conn).await;
+        // Always restore enforcement before the connection returns to the pool:
+        // ordinary repository queries and legitimate runtime deletes rely on
+        // FK cascade behaviour being active outside of migrations.
+        sqlx::query("PRAGMA foreign_keys = ON;").execute(&mut *conn).await?;
+        migrate_result?;
         Ok(())
     }
 

--- a/crates/persistence/db/tests/migration_0071_plan_items_cascade.rs
+++ b/crates/persistence/db/tests/migration_0071_plan_items_cascade.rs
@@ -1,0 +1,111 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Regression test for #1307.
+//!
+//! `plans` has been rebuilt (drop + recreate + rename) 15 times to change its
+//! `CHECK` constraints; migration 0071 is used here as the sample. Every one
+//! of those rebuilds opens with `PRAGMA foreign_keys = OFF` to make its
+//! `DROP TABLE plans` safe. sqlx runs each migration inside its own
+//! transaction, and `SQLite` treats that pragma as a no-op once a transaction
+//! is open (see `sqlite.org/pragma.html#pragma_foreign_keys`) — so the in-file
+//! pragma never took effect, and the `DROP TABLE` cascaded through
+//! `plan_items.plan_id REFERENCES plans(id) ON DELETE CASCADE`, silently
+//! deleting every plan item.
+//!
+//! This test drives the *real* embedded migrator (same SQL as production, no
+//! duplicated copy) over a single connection, matching how
+//! `Database::migrate()` actually applies migrations, so it exercises the
+//! same transaction wrapping that triggers the defect.
+
+use persistence_db::Database;
+use sqlx::migrate::{Migration, Migrator};
+use sqlx::sqlite::SqliteConnection;
+
+/// The production migrator, filtered to every migration up to and including
+/// `through_version`. Reuses the real embedded SQL — nothing here can drift
+/// out of step with what `Database::migrate()` actually ships.
+fn migrator_through(through_version: i64) -> Migrator {
+    let full: Migrator = sqlx::migrate!("./migrations");
+    let filtered: Vec<Migration> =
+        full.migrations.iter().filter(|m| m.version <= through_version).cloned().collect();
+    Migrator { migrations: filtered.into(), ..Migrator::DEFAULT }
+}
+
+async fn seed_plan_with_item(conn: &mut SqliteConnection) {
+    sqlx::query(
+        "INSERT INTO plans \
+         (id, number, title, origin, origin_path, state, plan_type, \
+          destructive_destination, items_total, created_at) \
+         VALUES ('plan-1', 7, 'Archive M31', 'archive', '/astro/M31', 'applied', \
+                 'archive', 'trash', 3, '2026-06-01T00:00:00Z')",
+    )
+    .execute(&mut *conn)
+    .await
+    .expect("seed plan");
+
+    sqlx::query(
+        "INSERT INTO plan_items \
+         (id, plan_id, item_index, name, action, from_relative_path, \
+          to_relative_path, reason, created_at) \
+         VALUES ('item-1', 'plan-1', 0, 'frame_001.fits', 'archive', \
+                 'lights/frame_001.fits', 'archive/frame_001.fits', \
+                 'superseded', '2026-06-01T00:00:00Z')",
+    )
+    .execute(&mut *conn)
+    .await
+    .expect("seed plan_item");
+}
+
+/// Seeds a `plan`/`plan_item` at schema version 70, then runs the *real*
+/// `Database::migrate()` production entry point (not a hand-rolled
+/// reproduction of it) to carry the DB the rest of the way to head. This is
+/// deliberately the exact function real callers use, so a temporary revert of
+/// `Database::migrate()` to the pre-fix version reproduces the failure here
+/// and nowhere else needs to change.
+#[tokio::test]
+async fn migration_0071_preserves_plan_items() {
+    let db = Database::in_memory().await.expect("in-memory db");
+    {
+        let mut conn = db.pool().acquire().await.expect("acquire connection");
+        migrator_through(70).run(&mut *conn).await.expect("migrate through 0070");
+        seed_plan_with_item(&mut conn).await;
+
+        let (before,): (i64,) =
+            sqlx::query_as("SELECT COUNT(*) FROM plan_items WHERE plan_id = 'plan-1'")
+                .fetch_one(&mut *conn)
+                .await
+                .expect("count plan_items before 0071");
+        assert_eq!(before, 1, "seed must have inserted exactly one plan_item");
+        // `conn` drops here and returns to the pool before `db.migrate()`
+        // acquires its own connection — this is an in-memory DB, so a second
+        // *live* connection open at the same time would see an empty sibling
+        // database rather than this one.
+    }
+
+    // The call under test: on the unfixed `Database::migrate()`, this runs
+    // migration 0071 over the shared pool with default FK enforcement (ON,
+    // set at connect time) and no compensating pragma outside a transaction,
+    // so 0071's own `PRAGMA foreign_keys = OFF` (issued inside the
+    // migration's transaction) is a no-op and `DROP TABLE plans` cascades.
+    db.migrate().await.expect("migrate to head");
+
+    let (after,): (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM plan_items WHERE plan_id = 'plan-1'")
+            .fetch_one(db.pool())
+            .await
+            .expect("count plan_items after migrating to head");
+    assert_eq!(
+        after, 1,
+        "rebuilding plans (migration 0071) must not cascade-delete its plan_items"
+    );
+
+    // The plan row itself must also survive with every column intact.
+    let (title, origin): (String, String) =
+        sqlx::query_as("SELECT title, origin FROM plans WHERE id = 'plan-1'")
+            .fetch_one(db.pool())
+            .await
+            .expect("plan row must survive the rebuild");
+    assert_eq!(title, "Archive M31");
+    assert_eq!(origin, "archive");
+}


### PR DESCRIPTION
## Summary
- Some database upgrades on an existing library could silently delete every saved plan item (the file-by-file record of an archive, restore, cleanup, or source-view plan) while leaving the plan itself looking intact in the plans list. Fixed so upgrading never removes plan item history.

## What was wrong

The database schema is upgraded in versioned steps. 15 of those steps rebuild a table to change a validation rule (SQLite requires a table rebuild for this — copy rows into a new table, drop the old one, rename). Those steps disable a safety check before dropping the old table so the drop doesn't cascade into related rows, but that safety check turned out to still be active when the drop actually ran. So dropping the old `plans` table cascaded into every one of its `plan_items` rows and deleted them — the plan itself survived, but its item history did not.

The already-shipped upgrade steps that do this can't be edited: every installed copy has already recorded their exact contents and would reject a changed version.

## What changed

`crates/persistence/db/src/lib.rs`: the upgrade runner now disables that safety check on its own dedicated connection *before* any upgrade step starts, instead of relying on each step to disable it for itself. That makes the setting actually take effect for every step, past and future, without changing any of the already-shipped upgrade files. The safety check is restored immediately afterward, before normal database use resumes, so ordinary deletes still clean up correctly.

## Verified

- **Fail-before / pass-after**: temporarily reverted only the upgrade-runner change (via a backup file, not git), reran the regression test, confirmed it failed with plan items wiped, then restored the fix and confirmed it passed.
- `cargo test -p persistence_db` — 316 passed, 0 failed (full crate suite, not just the new test).
- `cargo clippy -p persistence_db --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `just lint` — exit 0 (workspace clippy, root fmt, biome/eslint, token-policy, i18n-catalog, pre-commit) — clean.

## New test

`crates/persistence/db/tests/migration_0071_plan_items_cascade.rs` seeds a plan and plan item at an older schema version, runs the real upgrade path to the latest version, and asserts both survive.

## Deliberately not done

- No new upgrade step was added — data already lost to this bug on databases that upgraded before this fix ships can't be recovered; this only prevents further loss.
- The 15 already-shipped upgrade files were not touched (see above — can't be edited without breaking every existing install).
- Did not add a dedicated regression test for each of the other 14 affected upgrade steps individually — the fix applies to the upgrade runner as a whole, not per-step, and one end-to-end case is exercised as the representative. Broader per-step coverage is tracked separately in #1231.
- Did not depend on or touch `crates/persistence/db/tests/common/` or the still-open, unmerged #1306, which independently found and documented this same defect. This PR's regression test is self-contained against `origin/main`. #1306's own ignored test for this issue will need to be reconciled with this fix when that PR lands.

## Spec Context

Fixes #1307. Related test-coverage tracking in #1231; sibling investigation in #1306 (unmerged).