### PR TITLE
feat: show your camera's name on calibration masters instead of the raw file header

### DIFF
--- a/crates/app/calibration/src/equipment.rs
+++ b/crates/app/calibration/src/equipment.rs
@@ -194,6 +194,32 @@ pub async fn list_cameras(pool: &SqlitePool) -> Result<Vec<Camera>, ContractErro
     repo::list_cameras(pool).await.map_err(db_to_contract)
 }
 
+/// Resolve a raw fingerprint equipment string (as captured from a FITS
+/// header) to the registered camera's user-facing name.
+///
+/// Matching is case- and surrounding-whitespace-insensitive against each
+/// camera's name and its aliases: capture programs write the same physical
+/// camera with differing case and spacing, and `find_or_create_camera_by_alias`
+/// stores whichever spelling was seen first.
+///
+/// Returns `None` when no registered camera claims the string, so callers fall
+/// back to the raw value instead of synthesizing an absent one (Q16 / FR-136).
+#[must_use]
+pub fn resolve_camera_display_name(cameras: &[Camera], raw: &str) -> Option<String> {
+    let needle = raw.trim();
+    if needle.is_empty() {
+        return None;
+    }
+    cameras
+        .iter()
+        .find(|c| {
+            std::iter::once(&c.name)
+                .chain(c.aliases.iter())
+                .any(|candidate| candidate.trim().eq_ignore_ascii_case(needle))
+        })
+        .map(|c| c.name.clone())
+}
+
 /// Create a new camera.
 ///
 /// # Errors
@@ -215,6 +241,9 @@ pub async fn create_camera(
                 serde_json::json!({"name": camera.name}),
             )
             .await?;
+            // The masters snapshot embeds resolved camera names, so a new
+            // camera can change how an already-cached fingerprint renders.
+            crate::caches::invalidate_calibration_masters();
             Ok(camera)
         }
         Err(e) => {
@@ -254,6 +283,9 @@ pub async fn update_camera(
                 serde_json::json!({"name": camera.name}),
             )
             .await?;
+            // A rename changes every master fingerprint that resolves to this
+            // camera; the cached snapshot would otherwise serve the old name.
+            crate::caches::invalidate_calibration_masters();
             Ok(camera)
         }
         Err(e) => {
@@ -282,7 +314,12 @@ pub async fn delete_camera(
     bus: &EventBus,
     id: &str,
 ) -> Result<(), ContractError> {
-    delete_equipment(bus, "equipment.camera.delete", id, repo::delete_camera(pool, id).await).await
+    delete_equipment(bus, "equipment.camera.delete", id, repo::delete_camera(pool, id).await)
+        .await?;
+    // Master fingerprints that resolved to this camera revert to their raw
+    // header string.
+    crate::caches::invalidate_calibration_masters();
+    Ok(())
 }
 
 /// Find a camera by alias, or create one if not found.
@@ -771,6 +808,57 @@ mod tests {
         db.migrate().await.expect("migrations");
         let bus = EventBus::with_pool(db.pool().clone());
         (db, bus)
+    }
+
+    fn camera(name: &str, aliases: &[&str]) -> Camera {
+        Camera {
+            id: "cam-1".to_owned(),
+            name: name.to_owned(),
+            aliases: aliases.iter().map(|a| (*a).to_owned()).collect(),
+            auto_detected: false,
+            sensor_type: None,
+            passband: None,
+        }
+    }
+
+    /// #879: an alias hit resolves to the camera's user-facing name.
+    #[test]
+    fn resolve_camera_display_name_maps_alias_to_registered_name() {
+        let cams = vec![camera("Main Imaging Rig", &["ASI2600MM"])];
+        assert_eq!(
+            resolve_camera_display_name(&cams, "ASI2600MM"),
+            Some("Main Imaging Rig".to_owned())
+        );
+    }
+
+    /// #879: the camera's own name resolves too, not only its aliases.
+    #[test]
+    fn resolve_camera_display_name_matches_the_name_itself() {
+        let cams = vec![camera("ZWO ASI2600MM", &[])];
+        assert_eq!(
+            resolve_camera_display_name(&cams, "ZWO ASI2600MM"),
+            Some("ZWO ASI2600MM".to_owned())
+        );
+    }
+
+    /// #879: capture programs differ in case and padding for one camera.
+    #[test]
+    fn resolve_camera_display_name_ignores_case_and_surrounding_whitespace() {
+        let cams = vec![camera("Main Imaging Rig", &["ASI2600MM"])];
+        assert_eq!(
+            resolve_camera_display_name(&cams, " asi2600mm  "),
+            Some("Main Imaging Rig".to_owned())
+        );
+    }
+
+    /// #879: unknown and blank strings stay unresolved so callers can fall
+    /// back to the raw header value rather than inventing a name.
+    #[test]
+    fn resolve_camera_display_name_returns_none_when_unclaimed_or_blank() {
+        let cams = vec![camera("Main Imaging Rig", &["ASI2600MM"])];
+        assert_eq!(resolve_camera_display_name(&cams, "Some Other Cam"), None);
+        assert_eq!(resolve_camera_display_name(&cams, "   "), None);
+        assert_eq!(resolve_camera_display_name(&[], "ASI2600MM"), None);
     }
 
     /// T124/SC-009: `create_camera` writes a durable `Outcome::Applied`

--- a/crates/app/calibration/src/matching/masters.rs
+++ b/crates/app/calibration/src/matching/masters.rs
@@ -6,15 +6,33 @@
 use std::sync::Arc;
 
 use calibration_core::{suggest as domain_suggest, SessionInfo};
+use contracts_core::equipment::Camera;
 use persistence_db::repositories::calibration_assignment as assign_repo;
+use persistence_db::repositories::equipment as equipment_repo;
 use persistence_db::repositories::q_calibration;
 use sqlx::SqlitePool;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 
 use crate::caches;
+use crate::equipment::resolve_camera_display_name;
 
 use super::loaders::{load_config, load_master_by_id};
+
+/// Render a master fingerprint's raw camera/optic-train header string as the
+/// registered camera name when one claims it (#879), falling back to the raw
+/// string so an unregistered camera still renders what the header said.
+fn display_camera(cameras: &[Camera], raw: Option<String>) -> Option<String> {
+    raw.map(|raw| resolve_camera_display_name(cameras, &raw).unwrap_or(raw))
+}
+
+/// The registered cameras used to resolve fingerprint display names.
+///
+/// Equipment being unreadable degrades to raw header strings rather than
+/// failing the masters read, mirroring the planner's FR-038 fallback.
+async fn display_cameras(pool: &SqlitePool) -> Vec<Camera> {
+    equipment_repo::list_cameras(pool).await.unwrap_or_default()
+}
 
 /// `calibration.masters.list` — return all calibration masters, reading
 /// through the process-global `caches::calibration_masters` snapshot
@@ -41,6 +59,7 @@ async fn masters_list_from_db(
 ) -> Result<Vec<contracts_core::calibration::CalibrationMaster>, String> {
     let rows = q_calibration::list_calibration_masters(pool).await.map_err(|e| e.to_string())?;
 
+    let cameras = display_cameras(pool).await;
     let now = OffsetDateTime::now_utc();
     let masters = rows
         .into_iter()
@@ -51,10 +70,10 @@ async fn masters_list_from_db(
                 id: r.id.clone(),
                 kind: cal_kind,
                 fingerprint: contracts_core::calibration::CalibrationFingerprint {
-                    // Q16 / FR-136: no absence-synthesizing fallbacks — pass
-                    // the row's Option straight through so unresolved
-                    // metadata renders as unresolved, not a sentinel.
-                    camera: r.fp_optic_train,
+                    // Q16 / FR-136: no absence-synthesizing fallbacks — an
+                    // absent row field stays absent; a present one renders as
+                    // the registered camera name when one claims it (#879).
+                    camera: display_camera(&cameras, r.fp_optic_train),
                     sensor_mode: None,
                     exposure_s: r.fp_exposure_s,
                     temp_c: r.fp_temp_c,
@@ -113,9 +132,10 @@ pub async fn masters_get(
         id: r.id.clone(),
         kind: cal_kind,
         fingerprint: contracts_core::calibration::CalibrationFingerprint {
-            // Q16 / FR-136: no absence-synthesizing fallbacks — pass the
-            // row's Option straight through.
-            camera: r.fp_optic_train,
+            // Q16 / FR-136: no absence-synthesizing fallbacks — an absent row
+            // field stays absent; a present one renders as the registered
+            // camera name when one claims it (#879).
+            camera: display_camera(&display_cameras(pool).await, r.fp_optic_train),
             sensor_mode: None,
             exposure_s: r.fp_exposure_s,
             temp_c: r.fp_temp_c,

--- a/crates/app/calibration/src/matching/tests.rs
+++ b/crates/app/calibration/src/matching/tests.rs
@@ -93,6 +93,183 @@ async fn masters_list_carries_absent_metadata_as_none_not_sentinels() {
     assert_eq!(m.size_bytes, None, "must never default to 0");
 }
 
+/// #879: a registered camera's user-facing name replaces the raw
+/// `optic_train` header string in the master fingerprint. Before this
+/// wiring, registered equipment was consumed nowhere outside Settings and
+/// the list rendered the FITS header spelling verbatim.
+#[tokio::test]
+async fn masters_list_renders_registered_camera_name_not_raw_header() {
+    let _guard = lock_cache_tests().await;
+    caches::invalidate_calibration_masters();
+    let db = test_db().await;
+    let bus = audit::bus::EventBus::with_pool(db.pool().clone());
+
+    crate::equipment::create_camera(
+        db.pool(),
+        &bus,
+        &contracts_core::equipment::CreateCamera {
+            name: "Main Imaging Rig".to_owned(),
+            aliases: vec!["ASI2600MM".to_owned()],
+            sensor_type: None,
+            passband: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    insert_master(&db, "cal-named", "ASI2600MM").await;
+
+    let masters = masters_list(db.pool()).await.unwrap();
+    assert_eq!(
+        masters[0].fingerprint.camera.as_deref(),
+        Some("Main Imaging Rig"),
+        "registered camera name must replace the raw optic_train header string"
+    );
+}
+
+/// #879: header spelling varies by capture program, so alias matching
+/// ignores case and surrounding whitespace.
+#[tokio::test]
+async fn masters_list_resolves_camera_name_ignoring_case_and_whitespace() {
+    let _guard = lock_cache_tests().await;
+    caches::invalidate_calibration_masters();
+    let db = test_db().await;
+    let bus = audit::bus::EventBus::with_pool(db.pool().clone());
+
+    crate::equipment::create_camera(
+        db.pool(),
+        &bus,
+        &contracts_core::equipment::CreateCamera {
+            name: "Main Imaging Rig".to_owned(),
+            aliases: vec!["ASI2600MM".to_owned()],
+            sensor_type: None,
+            passband: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    insert_master(&db, "cal-case", "  asi2600mm ").await;
+
+    let masters = masters_list(db.pool()).await.unwrap();
+    assert_eq!(masters[0].fingerprint.camera.as_deref(), Some("Main Imaging Rig"));
+}
+
+/// #879: an unregistered camera keeps rendering the raw header string —
+/// resolution adds names, it never blanks out unknown equipment.
+#[tokio::test]
+async fn masters_list_falls_back_to_raw_header_for_unregistered_camera() {
+    let _guard = lock_cache_tests().await;
+    caches::invalidate_calibration_masters();
+    let db = test_db().await;
+
+    insert_master(&db, "cal-unreg", "Unregistered Cam").await;
+
+    let masters = masters_list(db.pool()).await.unwrap();
+    assert_eq!(masters[0].fingerprint.camera.as_deref(), Some("Unregistered Cam"));
+}
+
+/// #879: `masters_get` resolves names on the same rule as `masters_list`,
+/// so the detail panel and the table never disagree.
+#[tokio::test]
+async fn masters_get_renders_registered_camera_name_not_raw_header() {
+    let _guard = lock_cache_tests().await;
+    caches::invalidate_calibration_masters();
+    let db = test_db().await;
+    let bus = audit::bus::EventBus::with_pool(db.pool().clone());
+
+    crate::equipment::create_camera(
+        db.pool(),
+        &bus,
+        &contracts_core::equipment::CreateCamera {
+            name: "Main Imaging Rig".to_owned(),
+            aliases: vec!["ASI2600MM".to_owned()],
+            sensor_type: None,
+            passband: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    insert_master(&db, "cal-detail", "ASI2600MM").await;
+
+    let detail = masters_get(db.pool(), "cal-detail").await.unwrap();
+    assert_eq!(detail.fingerprint.camera.as_deref(), Some("Main Imaging Rig"));
+}
+
+/// #879: renaming a camera must not serve the previous name out of the
+/// process-global masters snapshot.
+#[tokio::test]
+async fn renaming_a_camera_invalidates_the_cached_master_names() {
+    let _guard = lock_cache_tests().await;
+    caches::invalidate_calibration_masters();
+    let db = test_db().await;
+    let bus = audit::bus::EventBus::with_pool(db.pool().clone());
+
+    let camera = crate::equipment::create_camera(
+        db.pool(),
+        &bus,
+        &contracts_core::equipment::CreateCamera {
+            name: "Old Name".to_owned(),
+            aliases: vec!["ASI2600MM".to_owned()],
+            sensor_type: None,
+            passband: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    insert_master(&db, "cal-rename", "ASI2600MM").await;
+
+    // Prime the snapshot with the pre-rename name.
+    let before = masters_list(db.pool()).await.unwrap();
+    assert_eq!(before[0].fingerprint.camera.as_deref(), Some("Old Name"));
+
+    crate::equipment::update_camera(
+        db.pool(),
+        &bus,
+        &contracts_core::equipment::UpdateCamera {
+            id: camera.id,
+            name: "New Name".to_owned(),
+            aliases: vec!["ASI2600MM".to_owned()],
+            sensor_type: None,
+            passband: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    let after = masters_list(db.pool()).await.unwrap();
+    assert_eq!(
+        after[0].fingerprint.camera.as_deref(),
+        Some("New Name"),
+        "rename must invalidate the cached masters snapshot"
+    );
+}
+
+/// Insert a dark master whose fingerprint carries `optic_train`.
+async fn insert_master(db: &Database, id: &str, optic_train: &str) {
+    sqlx::query(
+        "INSERT INTO calibration_session (id, session_key, kind, created_at) \
+         VALUES (?, 'dark-300s', 'dark', '2026-06-01T00:00:00Z')",
+    )
+    .bind(id)
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    sqlx::query(
+        "INSERT INTO calibration_fingerprint \
+         (id, calibration_type, gain, exposure_s, temp_c, binning, optic_train) \
+         VALUES (?, 'dark', 100.0, 300.0, -10.0, '1x1', ?)",
+    )
+    .bind(id)
+    .bind(optic_train)
+    .execute(db.pool())
+    .await
+    .unwrap();
+}
+
 /// T032 / T037: masters_list returns empty on a fresh DB (no fixtures).
 #[tokio::test]
 async fn masters_list_returns_empty_on_fresh_db() {


### PR DESCRIPTION
## Summary

- Calibration masters displayed the instrument string exactly as the capture program wrote it into the file header, so a camera registered under a friendly name in Settings showed up as its raw model string.
- Masters now display the registered camera's name. Matching is case-insensitive and covers every alias, so one physical camera resolves whichever way a capture program spelled it.
- A camera that is not registered still shows the raw header string; a master with no camera recorded stays blank.
- Renaming a camera in Settings now updates the calibration masters list immediately. Previously the cached list kept serving the old name.

## Blast radius

Display-only. The domain matcher compares raw `optic_train` values through `SessionInfo` / `MasterInfo` (`crates/app/calibration/src/matching/loaders.rs:105`), a separate path from the contract DTO, so match scoring and candidate selection are untouched. In the UI `fingerprint.camera` feeds rendering, sorting, and filtering only (`MastersTable.tsx:160,209,247`, `MasterDetail.tsx:372`, `CalibrationPage.tsx:112`).

Confined to `app_core_calibration`. No SQL, migration, or contract-shape change; resolution reuses the existing `list_cameras` repo query.

## Fail-before / pass-after

Reverting only the two resolution call sites in `masters.rs` to `camera: r.fp_optic_train` (backup-file revert, not git) fails 4 of the new tests, each showing the raw header string where the registered name is expected:

```
masters_list_renders_registered_camera_name_not_raw_header
  left: Some("ASI2600MM")  right: Some("Main Imaging Rig")
masters_list_resolves_camera_name_ignoring_case_and_whitespace
  left: Some("  asi2600mm ")  right: Some("Main Imaging Rig")
renaming_a_camera_invalidates_the_cached_master_names
  left: Some("ASI2600MM")  right: Some("Old Name")
masters_get_renders_registered_camera_name_not_raw_header
```

Restoring gives 28 passed. `masters_list_falls_back_to_raw_header_for_unregistered_camera` passes in both directions by design — it guards the fallback, so it must not move.

## Gates

| Gate | Result |
|---|---|
| `cargo test -p app_core_calibration` | 28 passed |
| `cargo test -p app_core` (dependent re-exporter) | 476 passed |
| `cargo clippy -p app_core_calibration --all-targets -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `just lint` | pass |

## Spec Context

Wires consumer 2 of #879 (spec 030). #879 named four consumers and anticipated a per-consumer split; the other three are filed separately rather than bundled here:

- `astro-plan-nku` — sessions inventory `camera: None` (`crates/app/core/src/inventory.rs:370`). Needs a new column on the shared session projection plus a batch lookup; a shared-view edit is conflict-prone with many PRs in flight.
- `astro-plan-hew` — `find_or_create_*_by_alias` has no ingest-pipeline caller.
- `astro-plan-bh1` — planner telescope/optical-train. The original claim is partially stale: the planner already reads cameras via `planner-sensor.ts` (spec 044, FR-035).

#879 stays open until the split issues land.