### PR TITLE
docs(ci): explain why `cancelled` still shows on main after the concurrency fix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,6 +44,17 @@ concurrency:
   # which is exactly when verification matters most.
   #
   # e2e.yml took the same fix in #1268; this is the other half.
+  #
+  # `cancelled` still appears on main, and that is expected — not a regression
+  # of #1203. With `false`, GitHub keeps the in-flight run plus ONE queued run
+  # per group and evicts intermediate pending runs. Measured on main minutes
+  # after this landed: `f3668b86` survived while `89025366`, `b37b072e` and
+  # `30e29bd1` were each evicted while queued.
+  #
+  # So the guarantee is "main always has a recent run that completes", NOT
+  # "every main commit is verified". Individual intermediate commits can still
+  # go unverified when merges land seconds apart. That is the bounded cost that
+  # keeps this from serialising the queue indefinitely.
   cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 # Incremental artifacts are not reusable across CI runs and only bloat the cache.


### PR DESCRIPTION
## Summary

- Comment-only follow-up to #1309. No behaviour change.
- #1309 stopped main runs from cancelling each other, but `cancelled` still
  appears on main and always will. Without a note saying so, the next person to
  see it has good reason to re-open #1203 as a regression.

## Why `cancelled` persists

With `cancel-in-progress: false`, GitHub keeps the in-flight run plus **one**
queued run per group and evicts intermediate pending runs. Measured on main
minutes after #1309 landed:

```
13:31:15  f3668b86  pending      <- survives
13:31:08  89025366  cancelled    <- evicted while queued
13:31:00  b37b072e  cancelled    <- evicted while queued
13:30:53  30e29bd1  cancelled    <- evicted while queued
```

All four landed *after* the fix.

## What the fix does and does not guarantee

- **Does:** main always has a recent run that completes. Before #1309, during a
  merge campaign, *none* did — each merge killed the previous mid-flight.
- **Does not:** verify every individual commit. Intermediate commits can still
  go unverified when merges land seconds apart.

That bounded eviction is what stops `false` from serialising the queue
indefinitely, so it is a deliberate trade rather than a leftover bug. #1309's
description overstated this as "main runs always finish"; corrected in a comment
there, and recorded here where the next reader will actually look.