### PR TITLE
feat: record the metadata a filesystem plan was approved on

### DIFF
--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -27,6 +27,7 @@
 //! `pattern.unset`.
 #![allow(clippy::doc_markdown)]
 
+use std::collections::BTreeMap;
 use std::path::PathBuf;
 
 use app_core_targets::metadata_cache::cached_extract;
@@ -36,6 +37,7 @@ use contracts_core::first_run::{OrganizationState, SourceKind};
 use contracts_core::framing::{
     AttributionAppliedDto, ChosenAttributionDto, IngestionAttributionCandidateDto,
 };
+use contracts_core::plans::ProvenanceEntry;
 use contracts_core::settings::PatternPart as ContractPatternPart;
 use metadata_core::v1_normalization_table;
 use patterns::{classify_frame, resolve_pattern_str, FrameTypeClass, MetadataBundle, PatternPart};
@@ -371,6 +373,11 @@ pub async fn confirm(
         let basename = ev.relative_file_path.rsplit('/').next().unwrap_or(&ev.relative_file_path);
         let item_name = format!("[{}] {basename}", ft.to_uppercase());
 
+        // Built once per file for both branches so a catalogued item carries the
+        // same frozen context as a moved one; the unorganized branch below also
+        // resolves its destination pattern against this bundle.
+        let bundle = build_metadata_bundle(&abs_path, ft, &norm_table);
+
         match org_state {
             OrganizationState::Organized => {
                 // Catalogue-in-place: dest == source; stays under its own root.
@@ -380,6 +387,7 @@ pub async fn confirm(
                     item_name,
                     action: "catalogue",
                     to_root_id: item.root_id.clone(),
+                    provenance: freeze_confirm_provenance(&bundle, is_master, None),
                 });
             }
             OrganizationState::Unorganized => {
@@ -409,8 +417,6 @@ pub async fn confirm(
                         .push((ev.relative_file_path.clone(), vec!["image type".to_owned()]));
                     continue;
                 };
-
-                let bundle = build_metadata_bundle(&abs_path, ft, &norm_table);
 
                 let result = match resolve_pattern_str(&pattern, &bundle) {
                     Ok(r) => r,
@@ -466,6 +472,7 @@ pub async fn confirm(
                     item_name,
                     action: "move",
                     to_root_id: dest_root.root_id,
+                    provenance: freeze_confirm_provenance(&bundle, is_master, Some(&pattern)),
                 });
             }
         }
@@ -571,7 +578,7 @@ pub async fn confirm(
             reason: "inbox_confirm",
             protection: "normal",
             linked_entity: None,
-            provenance_json: None,
+            provenance_json: row.provenance.as_deref(),
             archive_path: None,
             source_id: None,
             category: None,
@@ -679,6 +686,8 @@ struct ResolvedRow {
     item_name: String,
     action: &'static str,
     to_root_id: String,
+    /// Frozen inferred context at approval time (`freeze_confirm_provenance`).
+    provenance: Option<String>,
 }
 
 /// A chosen destination library root (id + absolute path) for inbox moves.
@@ -825,6 +834,41 @@ pub(crate) async fn load_active_pattern(
         .into_iter()
         .map(|p| PatternPart { id: p.id, kind: p.kind, value: p.value })
         .collect())
+}
+
+/// Freeze the inferred context that produced this plan item's destination, as
+/// the free-form `[{label,value}]` JSON the `plan_items.provenance` column
+/// already carries (spec 002 FR-005, applied at the spec 041 Inbox confirm
+/// gate).
+///
+/// The snapshot is self-contained by construction: a later rescan re-extracts
+/// headers and overwrites the live metadata, so anything that referenced a
+/// metadata row instead of copying it would silently answer with today's values
+/// rather than the ones the approver saw.
+///
+/// `destination_pattern` is stored next to the metadata because the destination
+/// is a function of both. Without it, a path that no longer matches cannot be
+/// attributed to metadata drift as opposed to a changed pattern setting. It is
+/// `None` for catalogue-in-place items, which resolve no pattern.
+///
+/// `BTreeMap` fixes entry order so two snapshots of the same context compare
+/// equal byte-for-byte.
+fn freeze_confirm_provenance(
+    bundle: &MetadataBundle,
+    is_master: bool,
+    destination_pattern: Option<&str>,
+) -> Option<String> {
+    let mut frozen: BTreeMap<&str, String> =
+        bundle.iter().map(|(k, v)| (k.as_str(), v.clone())).collect();
+    frozen.insert("is_master", is_master.to_string());
+    if let Some(pattern) = destination_pattern {
+        frozen.insert("destination_pattern", pattern.to_owned());
+    }
+    let entries: Vec<ProvenanceEntry> = frozen
+        .into_iter()
+        .map(|(label, value)| ProvenanceEntry { label: label.to_owned(), value })
+        .collect();
+    serde_json::to_string(&entries).ok()
 }
 
 /// Build a `MetadataBundle` for pattern resolution from extracted FITS/XISF
@@ -2655,5 +2699,152 @@ mod tests {
             Some("framing-attr2"),
             "the apply-path must persist the pick on the plan confirm() itself created"
         );
+    }
+
+    /// Read the single plan item's frozen provenance for `plan_id`.
+    async fn read_item_provenance(db: &Database, plan_id: &str) -> Vec<ProvenanceEntry> {
+        let raw = sqlx::query_as::<_, (Option<String>,)>(
+            "SELECT provenance FROM plan_items WHERE plan_id = ?",
+        )
+        .bind(plan_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        let json = raw.0.expect("confirm must write plan_items.provenance");
+        serde_json::from_str(&json).unwrap()
+    }
+
+    fn prov(entries: &[ProvenanceEntry], label: &str) -> Option<String> {
+        entries.iter().find(|e| e.label == label).map(|e| e.value.clone())
+    }
+
+    async fn confirm_defaults(
+        db: &Database,
+        bus: &EventBus,
+        item_id: &str,
+        sig: &str,
+        root_absolute_path: &std::path::Path,
+    ) -> ConfirmResponse {
+        confirm(
+            db.pool(),
+            bus,
+            ConfirmRequest {
+                inbox_item_id: item_id.to_owned(),
+                content_signature: sig.to_owned(),
+                destructive_destination: None,
+                root_absolute_path: root_absolute_path.to_owned(),
+                root_id: None,
+                chosen_attribution: None,
+            },
+        )
+        .await
+        .unwrap()
+    }
+
+    /// Spec 002 FR-005 at the spec 041 Inbox confirm gate: the inferred context
+    /// behind an approved destination is frozen on the plan item, so a later
+    /// rescan that reads different headers cannot rewrite the record of what
+    /// was known at approval time — while still producing a new snapshot of
+    /// its own.
+    #[tokio::test]
+    async fn confirm_provenance_survives_later_metadata_change() {
+        let tmp = tempfile::tempdir().unwrap();
+        let file_path = tmp.path().join("light_001.fits");
+        write_fits(
+            tmp.path(),
+            "light_001.fits",
+            "Light Frame",
+            Some("M42"),
+            Some("Ha"),
+            Some("2025-10-10T22:00:00"),
+        );
+
+        let db = test_db().await;
+        let bus = make_bus(&db);
+        register_source_org_state(&db, "root-1", "light_frames", "unorganized").await;
+        setup_classified_item(
+            &db,
+            "item-prov",
+            "classified",
+            Some("light"),
+            "sig-prov",
+            &["light_001.fits"],
+        )
+        .await;
+
+        let first = confirm_defaults(&db, &bus, "item-prov", "sig-prov", tmp.path()).await;
+
+        let approved = read_item_provenance(&db, &first.plan_id).await;
+        assert_eq!(prov(&approved, "target").as_deref(), Some("M42"));
+        assert_eq!(prov(&approved, "filter").as_deref(), Some("Ha"));
+        assert_eq!(prov(&approved, "date").as_deref(), Some("2025-10-10"));
+        assert_eq!(prov(&approved, "frame_type").as_deref(), Some("light"));
+        assert_eq!(prov(&approved, "is_master").as_deref(), Some("false"));
+        assert!(
+            prov(&approved, "destination_pattern").is_some_and(|p| !p.is_empty()),
+            "a moved item records the pattern its destination was resolved from"
+        );
+
+        // Rescan simulation: the same file now reports different headers.
+        // The metadata cache is keyed by (path, mtime, size), so this rewrite
+        // also changes the byte length — a same-second rewrite of identical
+        // length would be a cache hit and would make the "the live value really
+        // did change" leg below vacuous rather than failing loudly.
+        write_fits(
+            tmp.path(),
+            "light_001.fits",
+            "Light Frame",
+            Some("NGC7000"),
+            Some("Oiii"),
+            Some("2025-12-31T21:00:00"),
+        );
+        std::fs::OpenOptions::new()
+            .append(true)
+            .open(&file_path)
+            .unwrap()
+            .write_all(&[b' '; 2880])
+            .unwrap();
+        assert_eq!(
+            cached_extract(&file_path).unwrap().object.as_deref(),
+            Some("NGC7000"),
+            "precondition: the live metadata must actually have changed"
+        );
+
+        let after_rescan = read_item_provenance(&db, &first.plan_id).await;
+        assert_eq!(
+            prov(&after_rescan, "target").as_deref(),
+            Some("M42"),
+            "the approved snapshot must still report what was known at approval time"
+        );
+        assert_eq!(prov(&after_rescan, "filter").as_deref(), Some("Ha"));
+        assert_eq!(prov(&after_rescan, "date").as_deref(), Some("2025-10-10"));
+
+        // FR-005 also requires later rescans to produce their own snapshots.
+        // A second root: `inbox_items` is unique on (root_id, relative_path,
+        // group_key), so the rescanned item cannot reuse root-1.
+        // `registered_sources` is unique on (kind, path), so root-2 needs its
+        // own path rather than `register_source_org_state`'s fixed one.
+        sqlx::query(
+            "INSERT INTO registered_sources
+                (id, kind, path, kind_subtype, scan_depth, created_at, created_via, organization_state)
+             VALUES ('root-2', 'light_frames', '/tmp/src-2', NULL, 'recursive',
+                     '2026-01-01T00:00:00Z', 'first_run', 'unorganized')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        setup_classified_item_rooted(
+            &db,
+            "item-prov-2",
+            "root-2",
+            Some("light"),
+            "sig-prov-2",
+            &["light_001.fits"],
+        )
+        .await;
+        let second = confirm_defaults(&db, &bus, "item-prov-2", "sig-prov-2", tmp.path()).await;
+        let rescanned = read_item_provenance(&db, &second.plan_id).await;
+        assert_eq!(prov(&rescanned, "target").as_deref(), Some("NGC7000"));
+        assert_eq!(prov(&rescanned, "filter").as_deref(), Some("Oiii"));
     }
 }


### PR DESCRIPTION
## Summary

Approving an Inbox item builds destination paths from metadata read out of each file's headers. Only the resulting decision was stored, so once a later rescan re-read those headers there was no way to see what the plan had been approved on.

Each plan item now stores the metadata that produced its destination, plus the destination pattern in force at the time. Rescanning a file leaves those stored values untouched and records a fresh snapshot for the new plan, so the two can be compared.

## What's new

- Confirmed plan items record the target, filter, date, camera, exposure, gain, binning, telescope and frame type behind their destination, plus whether the frame is a master.
- Items record the destination pattern they were resolved against, so a path that no longer matches can be attributed to changed metadata rather than a changed pattern setting.
- Catalogue-in-place items carry the same recorded context as moved ones.
- A rescan leaves existing records untouched and produces its own snapshot.

## Implementation

Values are copied, not referenced: a rescan overwrites live metadata, so a foreign key would report today's values instead of the approved ones. The stored shape is the `[{label,value}]` JSON the `plan_items.provenance` column already carries. No migration and no schema change — the column and the `PlanItemDetail.provenance` DTO field already existed.

`build_metadata_bundle` moved above the organization-state match so both branches record the same context. This costs organized-source confirms one memoized header read per file, which the unorganized branch already paid.

### Other `None` call sites

`plan_apply.rs:751` and `plans.rs:655/685/707` sit inside `#[cfg(test)]` modules (boundaries at `plan_apply.rs:713`, `plans.rs:513`) — test fixtures, not production writes. `None` is correct there and they are unchanged.

Two production sites already populate the column and are unchanged: `crates/app/projects/src/prepared_views.rs:393` and `source_view_generate/generate.rs:484` write `{"label":"materialization"}`, read back by `materialization_from_provenance` (`crates/app/core/src/plan_apply/paths.rs:146`) to pick the link kind. That reader matches on `label == "materialization"` and ignores other entries, and Inbox items are never `link` actions, so the two uses do not interact.

## Test

`confirm_provenance_survives_later_metadata_change` asserts the rescan-survival property directly rather than asserting a non-null column:

1. Confirm a LIGHT frame with `OBJECT=M42`, `FILTER=Ha`; assert each recorded value.
2. Rewrite the file with `OBJECT=NGC7000`, `FILTER=Oiii`, changing byte length so the `(path, mtime, size)` metadata cache misses; assert via `cached_extract` that the live value really changed, so the leg cannot pass vacuously.
3. Assert the first plan still reports `M42` / `Ha` / the original date.
4. Confirm again and assert the new plan records `NGC7000` / `Oiii`.

Fail-before/pass-after proven by reverting production code via backup files, not git:

| Revert | Result |
|---|---|
| `provenance_json` back to `None` | FAILED |
| snapshot written but empty of metadata values | FAILED — `left: None, right: Some("M42")` |

The second revert leaves a non-null column and still fails, so the test asserts content, not row existence (#1222).

## Gates

| Gate | Result |
|---|---|
| `cargo test -p app_core_inbox` | 204 passed |
| `cargo test -p persistence_db` | 317 passed |
| `cargo clippy -p app_core_inbox --all-targets -D warnings` | clean |
| `cargo fmt --all --check` | clean |
| `just lint` | pass |

## Spec Context

Successor to #712. Spec 002 FR-005 requires reviews to preserve immutable snapshots of their inferred context; spec 041 FR-051 moved the review gate upstream to Inbox confirm without moving that guarantee with it.

FR-005 still names "session and calibration candidate reviews" as the point of preservation. That lifecycle no longer exists and the gate is now Inbox confirm, so the requirement text needs amending to name it — flagged for the owner, not edited here.