### PR TITLE
docs: record why classifying a scanned folder is an explicit action

### DIFF
--- a/specs/058-inbox-drop-parent-items/PENDING_REVIEW_QUESTIONS.md
+++ b/specs/058-inbox-drop-parent-items/PENDING_REVIEW_QUESTIONS.md
@@ -1,9 +1,10 @@
 # Pending Review Questions — 058 Inbox Drop Parent Items
 
-Questions raised during specification. **All nine are now answered**
-(2026-07-19) — Q-1, Q-2, Q-4, Q-8 and then Q-5, Q-6, Q-7, Q-9 by the product
-owner, Q-3 by events. Answers are recorded here and promoted to decisions D-005
-through D-007 in [spec.md](spec.md#recorded-decisions).
+Questions raised during specification. **All ten are now answered** — Q-1, Q-2,
+Q-4, Q-8 and then Q-5, Q-6, Q-7, Q-9 by the product owner (2026-07-19), Q-3 by
+events, and **Q-10 by the product owner (2026-07-20)**, during implementation
+rather than specification. Answers are recorded here and promoted to decisions
+D-005 through D-007 in [spec.md](spec.md#recorded-decisions).
 
 Two of the later answers change this feature's shape rather than merely filling
 a blank, and are worth reading before the plan gate:
@@ -131,6 +132,77 @@ types** — unclassified source groups and classified items — and selection mu
 survive the "one source-group row becomes N item rows" transition. This is a
 real design task for the plan gate, not a solved problem. It is the same union
 that Q-8's grouping construct needs, so the two should be designed together.
+
+---
+
+## Q-10 — What triggers classification for a source-group row? — RESOLVED: explicit user action — **AND SHIPPED**
+
+**Answer (product owner, 2026-07-20)**: **An explicit per-row action.** The
+source-group row carries a `Classify` control; classification runs only when the
+user asks for it.
+
+**Why this needed answering at all.** Unlike Q-1 to Q-9, this gap surfaced during
+implementation, not specification. Q-4 resolved *what scan creates* (the source
+group only) and FR-017 describes what happens *when classification completes* —
+but nothing named the **trigger**, and Q-4 itself flagged the surrounding area as
+"a real design task for the plan gate, not a solved problem". Meanwhile the row
+was built inert by construction to satisfy FR-016, so no user gesture existed to
+hang classification on. The consequence was concrete: `classify_source_group`
+shipped with a backend, a Tauri command, both specta registrations and a
+generated binding, and **zero UI callers**. The operation was reachable only from
+a test.
+
+**Two existing invariants dictated the shape** — it was not a free choice:
+
+1. **Selection cannot carry it.** Selection is the `?selected=<inboxItemId>` URL
+   param, resolved via `filteredItems.find(...)`. A `sourceGroupId` placed there
+   matches no item, so `useStaleSelectionCleanup` clears it on the same commit —
+   the row would appear to do nothing. Routing through `onSelect` would also
+   destroy FR-016's guarantee that a source-group row selects nothing, which its
+   tests assert directly.
+2. **It is a mutation, not a fetch.** `classify_source_group` walks the folder,
+   parses every file header and writes `inbox_items` rows via
+   `materialize_sub_items`, returning only
+   `{ sourceGroupId, materializedSubItemCount }`. There is no payload to cache,
+   so the `useInboxClassification` fire-on-selection-and-cache idiom does not
+   transfer.
+
+**Rejected alternatives**:
+
+- **Auto-classify on render.** Rejected on three counts. It makes *rendering a
+  list* write to the database for every folder the user never touched. It raises
+  one blocking `MetadataUnreadable` per FITS-less folder, unprompted, on load.
+  And it transforms rows underneath the user with no gesture — the selection-churn
+  coupling that caused the #1038 outage, which FR-023 exists to prevent and which
+  Q-4 already rejected its **Option A** over. It also collapses toward Q-4's
+  rejected **Option B**: if every group row classifies itself on sight, FR-016's
+  visible-unclassified state becomes a flicker rather than a real state.
+- **Classify during scan.** Rejected: contradicts Q-4/D-006 (scan creates the
+  group only) and would make FR-016's row nearly unreachable — reopening a
+  resolved decision rather than implementing one.
+
+**FR-016 is unchanged.** The row still carries no `_onClick`, no `_selected` and
+no item id, so nothing can hand one to `inbox.confirm`. The action carries the
+`sourceGroupId` directly and leaves `onSelect` untouched. All seven pre-existing
+FR-016 tests pass **unmodified**, which is the evidence the invariant survived
+rather than being quietly relaxed.
+
+**Shipped 2026-07-20** in `bce27a49`, both halves, with the resulting contract
+recorded in [contracts/operations.md](contracts/operations.md) — which marks
+`inbox.classify.sourceGroup` `[shipped]` and carries the caller obligations
+(invalidate `inbox.list`, key busy state by `sourceGroupId` rather than a bare
+boolean). This entry records *why the trigger is explicit*; that file records
+*what the contract now requires*.
+
+**Idempotency**: `upsert_inbox_sub_item` is
+`ON CONFLICT(root_id, relative_path, group_key) DO UPDATE` and orphaned siblings
+are pruned by `delete_sub_item_if_unlinked`, so a repeated action converges
+rather than duplicating rows.
+
+**Still open, deliberately**: preserving selection across the "one source-group
+row becomes N item rows" transition (FR-023) remains **T029**. The explicit
+trigger makes it tractable by giving the transition a user-gesture anchor; it
+does not implement it.
 
 ---
 


### PR DESCRIPTION
## Summary

- Documentation only, no behaviour change. Adds **Q-10** to `PENDING_REVIEW_QUESTIONS.md`, recording the decision behind the **Classify** control on a source-group row.
- The implementation shipped in `bce27a49`; `contracts/operations.md` already records *what the contract requires*. This records *why the trigger is explicit* — which is where a reader looks, since Q-1 through Q-9 all live in this file.

## Why it was a gap

Not an oversight in reading the spec. Q-4 settled what scan creates (the source group only) and FR-017 describes what happens *when classification completes* — but nothing named the **trigger**, and Q-4 itself flagged the surrounding area as "a real design task for the plan gate, not a solved problem".

Meanwhile the row was built inert by construction to satisfy FR-016, so no user gesture existed to attach classification to. The consequence was concrete: `classify_source_group` shipped with a backend, a Tauri command, both specta registrations and a generated binding, and **zero UI callers** — reachable only from a test.

## What the entry records

- The answer, and that it came from the product owner during implementation rather than specification.
- The **two existing invariants that dictated the shape** rather than leaving it a free choice: selection can't carry a `sourceGroupId` (it resolves to no item and `useStaleSelectionCleanup` clears it on the same commit), and the operation is a mutation with no cacheable payload.
- Why **auto-classify-on-render** was rejected — it would write rows for untouched folders, raise a blocking `MetadataUnreadable` per FITS-less folder on load, and revive the FR-023 selection churn that Q-4 already rejected its Option A over.
- Why **classify-during-scan** was rejected — contradicts Q-4/D-006 and would make FR-016's row nearly unreachable.
- What it does **not** settle: FR-023 selection preservation across the row transition is still T029.

## Accuracy checks

- "All seven pre-existing FR-016 tests pass unmodified" — verified: the file holds 7 `it(` blocks and was last touched by `de8e5492`, not by the shipping commit.
- `contracts/operations.md` marking the operation `[shipped]` — verified in `bce27a49`.

## Spec Context
- Spec: 058
- Branch: docs/058-q10-classify-trigger