### PR TITLE
build: install the beads package so its steering and hooks reach this repo

### DIFF
--- a/.claude/apm-hooks.json
+++ b/.claude/apm-hooks.json
@@ -60,6 +60,17 @@
         }
       ],
       "_apm_source": "agent-coder"
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "statusMessage": "Checking gh issue command against beads policy...",
+          "command": ".claude/hooks/beads/scripts/beads-gh-issue-guard.sh"
+        }
+      ],
+      "_apm_source": "beads"
     }
   ],
   "PostToolUse": [
@@ -143,6 +154,17 @@
         }
       ],
       "_apm_source": "code-intelligence"
+    },
+    {
+      "matcher": "*",
+      "hooks": [
+        {
+          "type": "command",
+          "statusMessage": "Injecting beads work contract...",
+          "command": ".claude/hooks/beads/scripts/beads-subagent-reminder.sh"
+        }
+      ],
+      "_apm_source": "beads"
     }
   ]
 }

--- a/.claude/hooks/beads/scripts/beads-gh-issue-guard.sh
+++ b/.claude/hooks/beads/scripts/beads-gh-issue-guard.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# beads-gh-issue-guard.sh — PreToolUse:Bash hook (Claude + Codex).
+#
+# In a repo with an active beads workspace, agent task tracking lives in bd,
+# not GitHub issues. DENY mutating `gh issue` subcommands with the bd
+# replacement in the reason (agent-facing self-correct per hook-guard policy).
+# Read-only subcommands (list, view, status) stay allowed — referencing
+# human-facing issues is fine; creating/closing them as task state is not.
+#
+# Self-gating: matcher is Bash with no `if` filter. Fail open (allow) whenever
+# state cannot be determined: no jq, no bd, no beads workspace, string payload.
+#
+# Portability floor: bash 3.2.57 + BSD grep. No PCRE, no \b.
+
+payload="$(cat 2>/dev/null || true)"
+[ -z "$payload" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Cheap pre-jq bail: only `gh issue` commands are of interest.
+case "$payload" in
+  *"gh"*issue*) ;;
+  *) exit 0 ;;
+esac
+
+# Single jq pass; tool_input may be an object {command:...} or a bare string.
+cwd=""
+cmd=""
+{
+  IFS= read -r cwd || true
+  cmd="$(cat)"
+} < <(
+  printf '%s' "$payload" | jq -j '
+    (.cwd // "") + "\n" +
+    (if (.tool_input|type)=="string" then .tool_input
+     else (.tool_input.command // "") end)
+  ' 2>/dev/null
+)
+[ -z "$cmd" ] || [ "$cmd" = "null" ] && exit 0
+[ -n "$cwd" ] && [ "$cwd" != "null" ] && [ -d "$cwd" ] || cwd="$PWD"
+
+# Only act when the repo the command runs in has a beads workspace.
+command -v bd >/dev/null 2>&1 || exit 0
+bd -C "$cwd" where >/dev/null 2>&1 || exit 0
+
+# Strip quoted values from a command string, leaving only bare tokens.
+# Copied from packages/hooks-precommit-gate/scripts/precommit-gate.sh (its
+# issues #4/#5 fix): quoted content is replaced by a single space so a
+# `gh issue edit` mentioned inside -m '...' cannot trip the guard.
+# Handles single-quoted (no escapes) and double-quoted (backslash escapes).
+strip_quoted() {
+  printf '%s' "$1" | awk '
+  { s=$0; n=length(s); out=""; i=1
+    while(i<=n){
+      c=substr(s,i,1)
+      if(c=="\x27"){i++;while(i<=n&&substr(s,i,1)!="\x27"){i++};i++;out=out " ";continue}
+      if(c=="\""){i++;while(i<=n){c=substr(s,i,1);if(c=="\""){i++;break}
+        if(c=="\\"){i++;if(i<=n)i++;continue};i++};out=out " ";continue}
+      out=out c;i++
+    }
+    print out
+  }'
+}
+
+# Match `gh issue <mutating-subcommand>` in the QUOTE-STRIPPED command. Anchor
+# is a non-word class (start, whitespace, ; & | subshell-( , backtick) rather
+# than strict command position: this catches command substitution `$(gh ...)`,
+# backticks, subshells, and wrapper prefixes (`time gh ...`, `env FOO=1 gh
+# ...`) for free, while quote-stripping removes the main false-positive source
+# (mentions inside quoted arguments). Residual FP: an UNQUOTED mention like
+# `echo gh issue close 5` -- accepted; deny is agent-facing self-correct.
+MUTATING='(create|close|edit|comment|reopen|delete|transfer|pin|unpin|lock|unlock|develop)'
+stripped="$(strip_quoted "$cmd")"
+printf '%s' "$stripped" | grep -Eq "(^|[[:space:];&|(\`])gh[[:space:]]+issue[[:space:]]+${MUTATING}([[:space:]]|$)" || exit 0
+
+reason="Task state lives in beads here (.beads/ present), not GitHub issues. Instead of gh issue: create work -> bd create \"title\" --spec-id <slug> (deps: bd dep add <later> <earlier>); pick up -> bd ready --unassigned --json + bd update <id> --claim; finish -> bd close <id> --reason \"...\"; discuss -> bd comments add <id> \"...\". If this is genuinely a human-facing GitHub issue (external users/reporting), the user must request it explicitly."
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'
+exit 0

--- a/.claude/hooks/beads/scripts/beads-subagent-reminder.sh
+++ b/.claude/hooks/beads/scripts/beads-subagent-reminder.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Hook: SubagentStart -- slim beads contract reminder for subagents.
+#
+# SessionStart (bd prime) does not fire for subagents, so without this a
+# spawned worker has only compiled steering. Inject the minimal contract:
+# where its work queues are, claim-before-work, and the close protocol.
+# Deliberately NOT bd prime (~1-2k tokens); this stays a few lines.
+#
+# Self-gating: silent unless bd is installed AND the spawn cwd has a beads
+# workspace. Never blocks a spawn; any failure exits 0 with no output.
+# Portability floor: bash 3.2.57 + BSD coreutils.
+set -eu
+
+INPUT=$(cat 2>/dev/null || true)
+[ -z "$INPUT" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v bd >/dev/null 2>&1 || exit 0
+
+AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null)
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -z "$AGENT_ID" ] && exit 0  # Not a subagent
+[ -n "$CWD" ] && [ -d "$CWD" ] || CWD="$PWD"
+
+# Only in repos with an active beads workspace.
+bd -C "$CWD" where >/dev/null 2>&1 || exit 0
+
+NL=$'\n'
+CTX="This repo tracks work in beads (bd)."
+CTX+=" If the parent gave you a bead id, claim it before working: bd update <id> --claim."
+CTX+=" Otherwise your queues are: bd ready --assignee <you> --json (pinned first), then bd ready --label agent:<kind> --unassigned --json."
+CTX+=" Never work an issue assigned to another actor.${NL}"
+CTX+="Before finishing: comment residual context on your bead (bd comments add <id> \"approach, tricky spots, what to check first on failure\"), close it (bd close <id> --reason \"...\"), and file discovered follow-ups (bd create --deps discovered-from:<id>). Do not wait for CI or merges -- gates and the pr-shepherd own that."
+
+jq -n --arg ctx "$CTX" '{
+  hookSpecificOutput: {
+    hookEventName: "SubagentStart",
+    additionalContext: $ctx
+  }
+}'
+exit 0

--- a/.claude/rules/40-beads.md
+++ b/.claude/rules/40-beads.md
@@ -1,0 +1,3 @@
+For task tracking, work claiming, bd labels/metadata conventions, JSON
+determinism, and multi-agent coordination, read
+[beads](../../apm_modules/srobroek/agentic-packages/packages/beads/.apm/context/beads.context.md).

--- a/.codex/apm-hooks.json
+++ b/.codex/apm-hooks.json
@@ -96,6 +96,18 @@
         }
       ],
       "_apm_source": "agent-coder"
+    },
+    {
+      "matcher": "Bash",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".codex/hooks/beads/scripts/beads-gh-issue-guard.sh",
+          "statusMessage": "Checking gh issue command against beads policy...",
+          "timeout": 10
+        }
+      ],
+      "_apm_source": "beads"
     }
   ],
   "PostToolUse": [
@@ -201,6 +213,18 @@
         }
       ],
       "_apm_source": "code-intelligence"
+    },
+    {
+      "matcher": "",
+      "hooks": [
+        {
+          "type": "command",
+          "command": ".codex/hooks/beads/scripts/beads-subagent-reminder.sh",
+          "statusMessage": "Injecting beads work contract...",
+          "timeout": 10
+        }
+      ],
+      "_apm_source": "beads"
     }
   ],
   "Stop": [

--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -89,6 +89,17 @@
             "timeout": 3
           }
         ]
+      },
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/beads/scripts/beads-gh-issue-guard.sh",
+            "statusMessage": "Checking gh issue command against beads policy...",
+            "timeout": 10
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -183,6 +194,17 @@
             "type": "command",
             "command": ".codex/hooks/code-intelligence/scripts/subagent-context-inject.sh",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".codex/hooks/beads/scripts/beads-subagent-reminder.sh",
+            "statusMessage": "Injecting beads work contract...",
+            "timeout": 10
           }
         ]
       }

--- a/.codex/hooks/beads/scripts/beads-gh-issue-guard.sh
+++ b/.codex/hooks/beads/scripts/beads-gh-issue-guard.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# beads-gh-issue-guard.sh — PreToolUse:Bash hook (Claude + Codex).
+#
+# In a repo with an active beads workspace, agent task tracking lives in bd,
+# not GitHub issues. DENY mutating `gh issue` subcommands with the bd
+# replacement in the reason (agent-facing self-correct per hook-guard policy).
+# Read-only subcommands (list, view, status) stay allowed — referencing
+# human-facing issues is fine; creating/closing them as task state is not.
+#
+# Self-gating: matcher is Bash with no `if` filter. Fail open (allow) whenever
+# state cannot be determined: no jq, no bd, no beads workspace, string payload.
+#
+# Portability floor: bash 3.2.57 + BSD grep. No PCRE, no \b.
+
+payload="$(cat 2>/dev/null || true)"
+[ -z "$payload" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+
+# Cheap pre-jq bail: only `gh issue` commands are of interest.
+case "$payload" in
+  *"gh"*issue*) ;;
+  *) exit 0 ;;
+esac
+
+# Single jq pass; tool_input may be an object {command:...} or a bare string.
+cwd=""
+cmd=""
+{
+  IFS= read -r cwd || true
+  cmd="$(cat)"
+} < <(
+  printf '%s' "$payload" | jq -j '
+    (.cwd // "") + "\n" +
+    (if (.tool_input|type)=="string" then .tool_input
+     else (.tool_input.command // "") end)
+  ' 2>/dev/null
+)
+[ -z "$cmd" ] || [ "$cmd" = "null" ] && exit 0
+[ -n "$cwd" ] && [ "$cwd" != "null" ] && [ -d "$cwd" ] || cwd="$PWD"
+
+# Only act when the repo the command runs in has a beads workspace.
+command -v bd >/dev/null 2>&1 || exit 0
+bd -C "$cwd" where >/dev/null 2>&1 || exit 0
+
+# Strip quoted values from a command string, leaving only bare tokens.
+# Copied from packages/hooks-precommit-gate/scripts/precommit-gate.sh (its
+# issues #4/#5 fix): quoted content is replaced by a single space so a
+# `gh issue edit` mentioned inside -m '...' cannot trip the guard.
+# Handles single-quoted (no escapes) and double-quoted (backslash escapes).
+strip_quoted() {
+  printf '%s' "$1" | awk '
+  { s=$0; n=length(s); out=""; i=1
+    while(i<=n){
+      c=substr(s,i,1)
+      if(c=="\x27"){i++;while(i<=n&&substr(s,i,1)!="\x27"){i++};i++;out=out " ";continue}
+      if(c=="\""){i++;while(i<=n){c=substr(s,i,1);if(c=="\""){i++;break}
+        if(c=="\\"){i++;if(i<=n)i++;continue};i++};out=out " ";continue}
+      out=out c;i++
+    }
+    print out
+  }'
+}
+
+# Match `gh issue <mutating-subcommand>` in the QUOTE-STRIPPED command. Anchor
+# is a non-word class (start, whitespace, ; & | subshell-( , backtick) rather
+# than strict command position: this catches command substitution `$(gh ...)`,
+# backticks, subshells, and wrapper prefixes (`time gh ...`, `env FOO=1 gh
+# ...`) for free, while quote-stripping removes the main false-positive source
+# (mentions inside quoted arguments). Residual FP: an UNQUOTED mention like
+# `echo gh issue close 5` -- accepted; deny is agent-facing self-correct.
+MUTATING='(create|close|edit|comment|reopen|delete|transfer|pin|unpin|lock|unlock|develop)'
+stripped="$(strip_quoted "$cmd")"
+printf '%s' "$stripped" | grep -Eq "(^|[[:space:];&|(\`])gh[[:space:]]+issue[[:space:]]+${MUTATING}([[:space:]]|$)" || exit 0
+
+reason="Task state lives in beads here (.beads/ present), not GitHub issues. Instead of gh issue: create work -> bd create \"title\" --spec-id <slug> (deps: bd dep add <later> <earlier>); pick up -> bd ready --unassigned --json + bd update <id> --claim; finish -> bd close <id> --reason \"...\"; discuss -> bd comments add <id> \"...\". If this is genuinely a human-facing GitHub issue (external users/reporting), the user must request it explicitly."
+
+jq -n --arg reason "$reason" '{
+  hookSpecificOutput: {
+    hookEventName: "PreToolUse",
+    permissionDecision: "deny",
+    permissionDecisionReason: $reason
+  }
+}'
+exit 0

--- a/.codex/hooks/beads/scripts/beads-subagent-reminder.sh
+++ b/.codex/hooks/beads/scripts/beads-subagent-reminder.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# Hook: SubagentStart -- slim beads contract reminder for subagents.
+#
+# SessionStart (bd prime) does not fire for subagents, so without this a
+# spawned worker has only compiled steering. Inject the minimal contract:
+# where its work queues are, claim-before-work, and the close protocol.
+# Deliberately NOT bd prime (~1-2k tokens); this stays a few lines.
+#
+# Self-gating: silent unless bd is installed AND the spawn cwd has a beads
+# workspace. Never blocks a spawn; any failure exits 0 with no output.
+# Portability floor: bash 3.2.57 + BSD coreutils.
+set -eu
+
+INPUT=$(cat 2>/dev/null || true)
+[ -z "$INPUT" ] && exit 0
+command -v jq >/dev/null 2>&1 || exit 0
+command -v bd >/dev/null 2>&1 || exit 0
+
+AGENT_ID=$(printf '%s' "$INPUT" | jq -r '.agent_id // empty' 2>/dev/null)
+CWD=$(printf '%s' "$INPUT" | jq -r '.cwd // empty' 2>/dev/null)
+[ -z "$AGENT_ID" ] && exit 0  # Not a subagent
+[ -n "$CWD" ] && [ -d "$CWD" ] || CWD="$PWD"
+
+# Only in repos with an active beads workspace.
+bd -C "$CWD" where >/dev/null 2>&1 || exit 0
+
+NL=$'\n'
+CTX="This repo tracks work in beads (bd)."
+CTX+=" If the parent gave you a bead id, claim it before working: bd update <id> --claim."
+CTX+=" Otherwise your queues are: bd ready --assignee <you> --json (pinned first), then bd ready --label agent:<kind> --unassigned --json."
+CTX+=" Never work an issue assigned to another actor.${NL}"
+CTX+="Before finishing: comment residual context on your bead (bd comments add <id> \"approach, tricky spots, what to check first on failure\"), close it (bd close <id> --reason \"...\"), and file discovered follow-ups (bd create --deps discovered-from:<id>). Do not wait for CI or merges -- gates and the pr-shepherd own that."
+
+jq -n --arg ctx "$CTX" '{
+  hookSpecificOutput: {
+    hookEventName: "SubagentStart",
+    additionalContext: $ctx
+  }
+}'
+exit 0

--- a/apm.lock.yaml
+++ b/apm.lock.yaml
@@ -618,6 +618,29 @@ dependencies:
     .codex/agents/journey-validator.toml: sha256:3ba8746661c250a471c08ebbad6a241af50eceda7d5fd04e80e5bdaee8d64706
   content_hash: sha256:50e13e8f558f9b7970283fb56e7a187968ba704f3355fa917247681dc4281e44
   declared_license: Apache-2.0
+- repo_url: srobroek/agentic-packages
+  name: beads
+  host: github.com
+  resolved_commit: df10eb45b8a8306bed96ef925d1d5ca7d5d6d2c6
+  resolved_ref: main
+  version: 0.4.0
+  virtual_path: packages/beads
+  is_virtual: true
+  package_type: marketplace_plugin
+  deployed_files:
+  - .claude/hooks/beads/scripts/beads-gh-issue-guard.sh
+  - .claude/hooks/beads/scripts/beads-subagent-reminder.sh
+  - .claude/rules/40-beads.md
+  - .codex/hooks/beads/scripts/beads-gh-issue-guard.sh
+  - .codex/hooks/beads/scripts/beads-subagent-reminder.sh
+  deployed_file_hashes:
+    .claude/hooks/beads/scripts/beads-gh-issue-guard.sh: sha256:9e8fc358f5d71f77899f0d6a102fa914758669430f5f403f198022a4f2304715
+    .claude/hooks/beads/scripts/beads-subagent-reminder.sh: sha256:8834883359e99cfa7fbd883c07030d1e84273f19da6adb36ad322ce3b994def4
+    .claude/rules/40-beads.md: sha256:c8bd01a2aab5346795681d9bc34169dcb3aa704df5b02cabf94266cecbaa454a
+    .codex/hooks/beads/scripts/beads-gh-issue-guard.sh: sha256:9e8fc358f5d71f77899f0d6a102fa914758669430f5f403f198022a4f2304715
+    .codex/hooks/beads/scripts/beads-subagent-reminder.sh: sha256:8834883359e99cfa7fbd883c07030d1e84273f19da6adb36ad322ce3b994def4
+  content_hash: sha256:27737a85735882d2d57d05bea3a71bb7d8a8682a2fd1c8f37833fec2e3b962b5
+  declared_license: Apache-2.0
 - repo_url: wshobson/agents
   name: database-design
   host: github.com
@@ -5861,6 +5884,24 @@ deployments:
   content_hash: sha256:664d02f8237f1bb78dcaa6ba4dca2a3e5a6ac43bdbef60a1efeb6c7dc68a43dd
 - kind: project-relative
   target: claude
+  value: .claude/hooks/beads/scripts/beads-gh-issue-guard.sh
+  runtime: null
+  scope: project
+  owners:
+  - srobroek/agentic-packages/packages/beads
+  active_owner: srobroek/agentic-packages/packages/beads
+  content_hash: sha256:9e8fc358f5d71f77899f0d6a102fa914758669430f5f403f198022a4f2304715
+- kind: project-relative
+  target: claude
+  value: .claude/hooks/beads/scripts/beads-subagent-reminder.sh
+  runtime: null
+  scope: project
+  owners:
+  - srobroek/agentic-packages/packages/beads
+  active_owner: srobroek/agentic-packages/packages/beads
+  content_hash: sha256:8834883359e99cfa7fbd883c07030d1e84273f19da6adb36ad322ce3b994def4
+- kind: project-relative
+  target: claude
   value: .claude/hooks/code-intelligence/scripts/subagent-context-inject.sh
   runtime: null
   scope: project
@@ -6048,6 +6089,15 @@ deployments:
   - srobroek/agentic-packages/packages/steering-frontend
   active_owner: srobroek/agentic-packages/packages/steering-frontend
   content_hash: sha256:658e4d9f2a801ad8a279326bcc117abaa62ac9a3b7779cce1c69b4817f464d0d
+- kind: project-relative
+  target: claude
+  value: .claude/rules/40-beads.md
+  runtime: null
+  scope: project
+  owners:
+  - srobroek/agentic-packages/packages/beads
+  active_owner: srobroek/agentic-packages/packages/beads
+  content_hash: sha256:c8bd01a2aab5346795681d9bc34169dcb3aa704df5b02cabf94266cecbaa454a
 - kind: project-relative
   target: claude
   value: .claude/rules/45-git-workflow.md
@@ -9441,6 +9491,24 @@ deployments:
   - srobroek/agentic-packages/packages/agent-coder
   active_owner: srobroek/agentic-packages/packages/agent-coder
   content_hash: sha256:664d02f8237f1bb78dcaa6ba4dca2a3e5a6ac43bdbef60a1efeb6c7dc68a43dd
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/beads/scripts/beads-gh-issue-guard.sh
+  runtime: null
+  scope: project
+  owners:
+  - srobroek/agentic-packages/packages/beads
+  active_owner: srobroek/agentic-packages/packages/beads
+  content_hash: sha256:9e8fc358f5d71f77899f0d6a102fa914758669430f5f403f198022a4f2304715
+- kind: project-relative
+  target: codex
+  value: .codex/hooks/beads/scripts/beads-subagent-reminder.sh
+  runtime: null
+  scope: project
+  owners:
+  - srobroek/agentic-packages/packages/beads
+  active_owner: srobroek/agentic-packages/packages/beads
+  content_hash: sha256:8834883359e99cfa7fbd883c07030d1e84273f19da6adb36ad322ce3b994def4
 - kind: project-relative
   target: codex
   value: .codex/hooks/code-intelligence/scripts/subagent-context-inject.sh

--- a/apm.yml
+++ b/apm.yml
@@ -5,6 +5,7 @@ author: Sjors Robroek
 dependencies:
   apm:
   - srobroek/agentic-packages/packages/core#main
+  - srobroek/agentic-packages/packages/beads#main
   - srobroek/agentic-packages/packages/steering-pragmatic#main
   - srobroek/agentic-packages/packages/orchestrate#main
   - srobroek/agentic-packages/packages/release-please#main


### PR DESCRIPTION
## Summary

- This repo uses `bd` for all task tracking, but the **beads APM package was never installed**. `.claude/rules/40-beads.md` did not exist, and the steering it points at was unreachable — agents fell back to the `SKILL.md` that `bd init` drops in, so the bd label/claim/JSON-determinism conventions never loaded.
- Installing it also brings two PreToolUse guards that were previously absent: the `gh issue` guard (task state belongs in bd) and the subagent work-contract reminder.
- `.claude/rules/40-beads.md` is **generated by APM**, not hand-written — which confirms the missing-pointer symptom was a missing install, not a broken rule.

## Why it was uninstallable

`apm.lock.yaml` pinned every `srobroek/agentic-packages` entry to `resolved_commit: 516509df5`, a commit that predates `packages/beads` existing upstream. A `#main` spec does not override a pinned lock commit, so `apm install` failed with "Subdirectory 'packages/beads' not found in repository" regardless of cache freshness.

## Scope

Scoped deliberately via `apm update <pkg> --yes`. An **unscoped** `apm install` reports *625 files would be removed* — 50 packages dragged forward from the old pin, with upstream restructuring deleting the difference. This PR touches only beads: **10 files, zero deletions**.

Bringing the other 50 packages current is a separate, larger decision and is deliberately not done here.