### PR TITLE
fix(test): assert real sessionCount in the planner honest-empty test

### DIFF
--- a/tests/e2e/targets_planner.spec.ts
+++ b/tests/e2e/targets_planner.spec.ts
@@ -433,13 +433,19 @@ test.describe('Target catalog + SIMBAD resolve-on-demand (spec 035 / 023)', () =
 
 test.describe('Honest empty-state disclosure (no fabricated data)', () => {
   /**
-   * Not-yet-built data must be disclosed honestly, never fabricated:
-   *   - the Sessions column (backend linkage #57 not landed) is ALWAYS "—",
-   *     never a made-up linked-session count — even with an active site;
+   * Not-yet-built or not-yet-loaded data must be disclosed honestly, never
+   * fabricated:
+   *   - the Sessions column reads the real backend `sessionCount` (#622,
+   *     #877, #1293) — the seed fixture gives M 31 and NGC 7000 non-zero
+   *     counts, mirroring what the real backend returns for those targets.
+   *     The honest-"—"-for-zero rendering itself (never a bare 0, and never
+   *     fabricated for a target the backend reports as unshot) is covered at
+   *     the unit level in `TargetsTable.test.tsx` ("TargetsTable Sessions
+   *     column (#622)"), which exercises sessionCount: 0 and an absent field;
    *   - the favourite star column shows every row un-starred (#54 client-side
    *     favourites, no fabricated favourites) with aria-pressed=false.
    */
-  test('9.3a · sessions count and favourites are honestly empty, not fabricated', async ({
+  test('9.3a · sessions count reflects the real backend value and favourites are honestly empty', async ({
     page,
   }) => {
     seedSetupComplete(page);
@@ -450,12 +456,12 @@ test.describe('Honest empty-state disclosure (no fabricated data)', () => {
     const m31 = targetRow(page, 'M 31');
     await expect(m31).toBeVisible({ timeout: 8_000 });
 
-    // Sessions column: always the honest "—" (linked-session count not on the
-    // list payload yet — #57), never a fabricated number.
-    await expect(m31.locator('td').nth(COL.sessions)).toHaveText('—');
+    // Sessions column: the real per-target count from the backend-aligned
+    // mock fixture (#1308), not a hardcoded placeholder.
+    await expect(m31.locator('td').nth(COL.sessions)).toHaveText('3');
     await expect(
       targetRow(page, 'NGC 7000').locator('td').nth(COL.sessions),
-    ).toHaveText('—');
+    ).toHaveText('5');
 
     // Favourites (#54): every star is un-filled and reports aria-pressed=false —
     // no fabricated "starred" state.


### PR DESCRIPTION
Closes astro-plan-mxhz.

## Summary

Test `9.3a` in `tests/e2e/targets_planner.spec.ts` asserted the Targets
planner Sessions column always renders `—`, citing "#57 not landed" as the
reason. #1308 (merged today, "align development mock data with the real
backend") gave M31 and NGC 7000 real `sessionCount` values in the
`target_list` mock fixture, which broke that stale assertion.

## Which fix, and why

Two fixes were possible: revert the fixture back to zero counts, or update
the test. The fixture is correct — verified against the codebase, not
assumed:

- `apps/desktop/src/features/targets/TargetsTable.tsx:612-621` reads
  `t.sessionCount` and renders the real value (falling back to `—` only for
  zero/absent), landed by #622/#877/#1293 — **already merged to `main`
  before this branch point**, i.e. before #1308.
- That PR's own commit message: "TargetListItem has carried a real,
  backend-populated sessionCount since #877 ... the column only needed
  reading, not a backend change."
- #1308's mock fixture change is therefore correct: it mirrors what the
  real backend now returns for those two seed targets.

The old e2e assertion was written before #622/#877/#1293 shipped and never
updated. Reverting the fixture to satisfy it would reintroduce the exact
mock/backend drift #1308 exists to eliminate.

## What changed

- `tests/e2e/targets_planner.spec.ts`: 9.3a now asserts the real
  `sessionCount` values (`3` for M31, `5` for NGC 7000) and the docstring
  explains why, instead of asserting a stale always-dash placeholder.
- Favourites assertions in the same test are untouched — that path is
  still genuinely honest-empty and unaffected by #1308.

## Honest-empty coverage after this change

Not deleted — it lives at the unit level, added by #1293 itself:
`apps/desktop/src/features/targets/TargetsTable.test.tsx`, describe block
`TargetsTable Sessions column (#622)`:
- `renders '—' for a target with no linked sessions (never a bare 0)`
  (sessionCount: 0)
- `treats an absent sessionCount (older client) as no sessions`

Both directly exercise the honest-empty rendering path in
`TargetsTable.tsx`, more precisely than the old e2e assertion did (the old
e2e mock never actually contained a zero-count fixture; it just asserted
the placeholder against whatever the mock happened to omit).

## Verification

- `9.3a` reproduced failing before the fix (`Received: "3"`, expected `"—"`).
- `9.3a` passes after the fix.
- Full suite: `pnpm --filter @astro-plan/desktop test:e2e` → **99 passed, 1
  skipped** (100 total).
- Unit coverage: `vitest run TargetsTable.test.tsx -t "Sessions column"` →
  5/5 passed.
- `pnpm lint` in `apps/desktop`: confirmed the fatal ESLint parse error on
  `eslint-rules/no-user-string.js` reproduces identically on a clean branch
  off `origin/main` — pre-existing, not touched by this change.