### PR TITLE
build: add periodic dependency and API-surface hygiene sweeps

### DIFF
--- a/justfile
+++ b/justfile
@@ -47,6 +47,48 @@ db-boundary:
 dead-callers:
     bash scripts/check-dead-callers.sh
 
+# Periodic hygiene sweeps. NOT CI gates and deliberately so: these surface debt
+# to triage, not per-PR correctness, and a noisy blocking gate gets suppressed.
+# Run them when you want a health read, not on every push.
+#
+# Tools install on demand:
+#   cargo install cargo-machete cargo-public-api
+#
+# Deliberately NOT included, so nobody re-adds them:
+#   cargo-udeps  - same job as machete, and needs a nightly toolchain
+#   cargo-shear  - same job as machete; one dependency checker is enough,
+#                  three reporting overlapping findings guarantees all three
+#                  get ignored
+#   warnalyzer   - dead. Last release 2021-05-20, ~3.5k downloads, and it
+#                  depends on rustc save-analysis which no longer exists.
+
+# Unused dependencies declared in Cargo.toml but never used.
+hygiene-deps:
+    @command -v cargo-machete >/dev/null 2>&1 || { echo "cargo-machete not installed: cargo install cargo-machete"; exit 1; }
+    cargo machete
+
+# `pub` items that are not actually reachable from outside their crate, i.e.
+# should be pub(crate). Narrowing them lets rustc's own dead_code lint fire on
+# the unused ones for free -- which is the compiler-native half of what
+# scripts/check-dead-callers.sh approximates textually. Measured 0 on
+# persistence_db on 2026-07-20; other crates are unmeasured.
+#
+# `pub` items that should be pub(crate), across the workspace.
+hygiene-pub:
+    cargo clippy --workspace --all-targets --message-format=short -- -A warnings -W unreachable_pub
+
+# Public API surface per crate. Not a pass/fail check -- a read of what each
+# crate exposes. Large surface that the workspace never consumes is the same
+# debt the dead-caller ratchet tracks, seen from the other side.
+#
+# Public API surface of one crate (read, not pass/fail).
+hygiene-api CRATE:
+    @command -v cargo-public-api >/dev/null 2>&1 || { echo "cargo-public-api not installed: cargo install cargo-public-api"; exit 1; }
+    cargo public-api -p {{CRATE}}
+
+# All non-interactive hygiene sweeps.
+hygiene: hygiene-deps hygiene-pub
+
 # Regenerate the sqlx offline query cache (.sqlx/) for compile-time verification.
 # Requires a DATABASE_URL pointing at a migrated SQLite db, or run after the
 # crate's migrations have been applied. Commit the resulting .sqlx/ dir so CI can

--- a/justfile
+++ b/justfile
@@ -59,8 +59,20 @@ dead-callers:
 #   cargo-shear  - same job as machete; one dependency checker is enough,
 #                  three reporting overlapping findings guarantees all three
 #                  get ignored
-#   warnalyzer   - dead. Last release 2021-05-20, ~3.5k downloads, and it
-#                  depends on rustc save-analysis which no longer exists.
+#   warnalyzer   - NOT dead (an earlier note here said so, wrongly: crates.io
+#                  shows a 2021 release, but the repo was pushed 2024-09 and
+#                  has a SCIP backend that works on stable). Not wired up only
+#                  because the SCIP route is covered below.
+#
+# WORTH EVALUATING, not yet wired: cargo-workspace-unused-pub does exactly what
+# scripts/check-dead-callers.sh approximates, but semantically -- it builds a
+# SCIP index via rust-analyzer instead of grepping, so re-exports, out-of-line
+# test modules and comments cannot fool it (all four bugs found in that script
+# on 2026-07-20 were grep artifacts). Caveats: 0.1.0, ~1.3k downloads, methods
+# only, no false-positive suppression yet, and index generation is slow enough
+# that it is a periodic sweep rather than a gate. warnalyzer and clippy issue
+# 5828 both confirm SCIP + rust-analyzer is the only workable approach --
+# rustc's dead_code is per-crate by construction and cannot see a workspace.
 
 # Unused dependencies declared in Cargo.toml but never used.
 hygiene-deps:


### PR DESCRIPTION
## Summary

- Adds `just hygiene-deps` (cargo-machete, unused dependencies), `just hygiene-pub` (workspace `unreachable_pub` sweep) and `just hygiene-api CRATE` (cargo-public-api, exported surface).
- **On-demand, not CI gates**, deliberately. These surface debt to triage rather than per-PR correctness, and a noisy blocking gate gets suppressed — CI is also already disk-constrained (#1250).
- Tools install on demand; recipes fail with the install command rather than a cryptic error.

## First run found real debt — 24 unused dependencies across 13 crates

```
desktop_shell        tauri-plugin-notification, tauri-plugin-prevent-default, thiserror
contracts_core       specta-typescript, strum, thiserror
app_core_inbox       app_core_cache, metadata_fits, metadata_xisf
fs_executor          serde_json, thiserror, uuid
audit                schemars, specta
targeting_resolver   time, tracing
workflow_artifacts   serde_json, uuid
seed-builder         serde, time
calibration_core     uuid
app_core_targets     app_core_errors
patterns             serde_json
metadata_fits        thiserror
metadata_xisf        thiserror
```

Not cleaned up here — that is a separate change, and some may be false positives worth an `[package.metadata.cargo-machete] ignored` entry instead. `app_core_inbox` depending on `metadata_fits`/`metadata_xisf` unused is the most interesting one given those are the extraction adapters.

## Three tools evaluated and excluded

Recorded in the justfile so they are not re-proposed:

| tool | why not |
|---|---|
| `cargo-udeps` | same job as machete, and needs a nightly toolchain |
| `cargo-shear` | same job as machete; three overlapping dependency checkers guarantees all three get ignored |
| `warnalyzer` | **dead** — last release 2021-05-20, ~3.5k downloads, depends on rustc `save-analysis` which no longer exists |

## Note on `unreachable_pub`

Measured **0 hits** on `persistence_db`. That is a real finding, not a broken check: the `pub` items there genuinely are reachable outside the crate, which is exactly why `dead_code` cannot fire on them and why `scripts/check-dead-callers.sh` exists. Other crates are unmeasured — hence the sweep.