### PR TITLE
test: fix a false test failure that was blocking other pull requests

### DIFF
--- a/apps/desktop/src/features/projects/ProjectDetail.edit-overlay.test.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.edit-overlay.test.tsx
@@ -20,7 +20,17 @@ vi.mock('@tanstack/react-router', async (importOriginal) => {
     await importOriginal<typeof import('@tanstack/react-router')>();
   return {
     ...actual,
+    // ProjectLifecycleStepper's History section (#833) falls back to this
+    // route search param when its (optional) projectId prop isn't wired;
+    // unrelated to this file's assertions, so a static empty selection is
+    // enough.
     useSearch: () => ({ selected: undefined, lifecycle: undefined }),
+    // The tool-launch toast's "Configure path" action navigates through the
+    // router and the tool-not-configured hint is a real `Link` — neither
+    // works against the spread-in real implementations without a router
+    // context (same reasoning as the other ProjectDetail suites).
+    useNavigate: () => vi.fn(),
+    Link: (await import('@/test/router-link-stub')).LinkStub,
   };
 });
 


### PR DESCRIPTION
## Summary

The edit-pane dialog-chrome test (`ProjectDetail.edit-overlay.test.tsx`, spec #660) failed with `TypeError: Cannot read properties of null (reading 'isServer')` inside `useLinkProps`. `ProjectDetailContent` renders a real `Link` from `@tanstack/react-router`, but the file's router mock only overrode `useSearch`, leaving the real `Link`/`useLinkProps` in place with no router context to read.

This bug is pre-existing on `main` (reproduced on a clean worktree, unrelated to any change in flight) and became widely visible after CI path-filtering changes made the full frontend suite run on more PRs instead of `vitest related`, so it is now blocking multiple otherwise-unrelated PRs.

- Reused the router-context override already established by every other `ProjectDetail.*.test.tsx` suite: `useNavigate: () => vi.fn()` plus `Link: LinkStub` from `src/test/router-link-stub.tsx`.
- No production code changed; no test was skipped, deleted, or had its assertions weakened. All four dialog-chrome tests (open/close, accessible name, Escape-to-close, focus trap) still exercise the real behaviour.

## Test plan

- [x] `pnpm i18n:compile && pnpm exec vitest run src/features/projects/ProjectDetail.edit-overlay.test.tsx` in `apps/desktop` — 4 tests pass
- [x] `pnpm exec vitest run` in `apps/desktop` — 213 test files passed (213), 1926 tests passed (1926), no `Errors` line
- [x] `pnpm typecheck` in `apps/desktop` — clean