### PR TITLE
docs(journeys): record 2026-07-20 behavior deltas

### DIFF
--- a/docs/journeys/J04-sessions-review-derived/journey.md
+++ b/docs/journeys/J04-sessions-review-derived/journey.md
@@ -1,7 +1,7 @@
 ---
 id: J04
 title: Review acquisition sessions as a derived, always-current inventory
-version: 5
+version: 6
 status: draft
 last_reviewed: 2026-07-14
 actors: [astrophotographer]
@@ -109,7 +109,9 @@ the view carries no leftover review-state controls.
   pin overrides the automatic width-based placement when set. A detail
   panel opens showing the session's attribute set —
   target, filter, frame count, exposure, total integration time (when
-  derivable), night, camera, gain, binning, sensor temperature, and
+  derivable, rendered as "1h 30m" — the same h/m grammar Projects and the
+  setup wizard use, not a decimal-hours or seconds variant), night, camera,
+  gain, binning, sensor temperature, and
   confirmed-by — each carrying a source badge (FITS/User/Inferred/Default)
   only when a real value is present; a field that is applicable but has no
   value renders a distinct "unresolved" chip (never a bare em dash and never
@@ -267,3 +269,10 @@ the view carries no leftover review-state controls.
   restarts), a bottom dock when narrow.
   Evidence: spec-054-adaptive-detail-dock (FR-001, FR-004, FR-005) · by:
   journey-scribe (intent-gated)
+
+- **Δ6** 2026-07-20 · S4 · behavior-change
+  Total integration time now renders as "1h 30m" (h/m grammar), matching
+  Projects and the setup wizard — previously Sessions, Projects, and the
+  wizard each used a different format (decimal hours, h/m, or h/m/s) for
+  the same quantity.
+  Evidence: PR #1288 (refs #631) · by: journey-scribe (intent-gated)

--- a/docs/journeys/J05-project-lifecycle/journey.md
+++ b/docs/journeys/J05-project-lifecycle/journey.md
@@ -1,7 +1,7 @@
 ---
 id: J05
 title: Run a project from creation through tool launch and output tracking
-version: 2
+version: 4
 status: draft
 last_reviewed: 2026-07-14
 actors: [astrophotographer]
@@ -62,7 +62,10 @@ safe-by-construction or was explicitly reviewed.
 ### S2 — Attach sources {#S2}
 - **Do:** From the project's edit view, add sources from a picker and, when
   needed, remove a previously attached source.
-- **Expect:** The picker offers only unlinked, already-confirmed sessions;
+- **Expect:** The edit view opens as a real dialog (`role=dialog`, an
+  accessible name, backdrop, Escape-to-close, and a focus trap) centred over
+  the page — not a full-window overlay covering the sidebar, list, and
+  action bars. The picker offers only unlinked, already-confirmed sessions;
   removing any source except the last one takes effect immediately.
 - **Expect (negative):** Not-yet-confirmed inbox data never appears as an
   attachable source. Removing the *last* remaining source is blocked behind
@@ -71,7 +74,9 @@ safe-by-construction or was explicitly reviewed.
 - **Expect (negative):** A project in a locked lifecycle state (e.g.
   archived) refuses source edits with an explicit message rather than
   silently no-op-ing.
-- **Trace:** e2e-agentic-test/008-.../edit-project-sources/scenario.md
+- **Trace:** e2e-agentic-test/008-.../edit-project-sources/scenario.md;
+  `apps/desktop/src/features/projects/edit/EditProjectPane.tsx` (rendered
+  through the shared `Modal`, PR #1290, closes #660).
 
 ### S3 — Review real per-channel numbers {#S3}
 - **Do:** Open the project detail view at the 1100×720 minimum window size,
@@ -83,7 +88,8 @@ safe-by-construction or was explicitly reviewed.
   (previously a bespoke side-and-bottom dual layout with no narrow
   fallback). The per-channel (per-filter) breakdown shows actual sub-frame
   counts and total integration time, computed from the currently attached
-  sessions and formatted as hours/minutes.
+  sessions and formatted as hours/minutes (e.g. "1h 30m" — the same grammar
+  Sessions and the setup wizard use for the identical quantity).
 - **Expect (negative):** No channel row shows a placeholder dash or a bare
   `0` where the real value is simply unknown — a missing value is
   distinguishable from a real zero. At the 1100×720 minimum, no part of the
@@ -162,3 +168,16 @@ safe-by-construction or was explicitly reviewed.
   1100×720 minimum window in bottom mode.
   Evidence: spec-054-adaptive-detail-dock (FR-004, FR-011) · by:
   journey-scribe (intent-gated)
+
+- **Δ3** 2026-07-20 · S2 · behavior-change
+  The project edit view now opens as a real dialog (role=dialog, Escape,
+  focus trap, backdrop) — previously a bare positioned div with no
+  containing block covered the entire 1280x800 window, including the
+  sidebar and action bars, with none of those affordances.
+  Evidence: PR #1290 (closes #660) · by: journey-scribe (intent-gated)
+
+- **Δ4** 2026-07-20 · S3 · behavior-change
+  Total integration time now renders as "1h 30m" (h/m grammar), matching
+  Sessions and the setup wizard — previously Projects showed a decimal-hours
+  variant ("1.5h") for the same quantity.
+  Evidence: PR #1288 (refs #631) · by: journey-scribe (intent-gated)

--- a/docs/journeys/J08-calibration-ingest-masters-matching/journey.md
+++ b/docs/journeys/J08-calibration-ingest-masters-matching/journey.md
@@ -1,7 +1,7 @@
 ---
 id: J08
 title: Ingest calibration masters and match them to sessions
-version: 4
+version: 6
 status: draft
 last_reviewed: 2026-07-15
 actors: [astrophotographer]
@@ -87,13 +87,25 @@ assigned through an explicit, confirmable action — never silently.
 
 ### S3 — Browse the Calibration page {#S3}
 - **Do:** Open the Calibration page.
-- **Expect:** One row per master file. Fingerprint columns are
+- **Expect:** One row per master file. When the master's camera is
+  registered under a friendly name in Settings → Equipment, the row (and
+  detail, S4) shows that name instead of the raw instrument string the
+  capture program wrote into the file header — matching is
+  case-insensitive and covers every alias, and renaming the camera in
+  Settings updates the list immediately. A master whose camera is not
+  registered still shows the raw header string; a master with no camera
+  recorded stays blank. This resolution is display-only — calibration
+  match scoring still compares the raw header values. Fingerprint columns are
   kind-conditional per an explicit applicability matrix — a dark's
   temperature/gain columns don't apply to a bias and render as an explicit
   not-applicable marker, never inferred from missing data. Sort headers,
   search, and group-by work; a kind filter appears once a second kind
-  exists; a search with no matches reads as a filter miss, not an empty
-  library. Composed identifying strings (meta lines, cells) omit absent
+  exists; a search and/or kind filter that matches nothing reads as a
+  filter miss — naming the active filter and offering a "Clear filters"
+  action — not an empty library, and only when showable masters actually
+  exist (a library holding only never-shown kinds still gets the
+  onboarding "run a scan" copy, not a misleading filter-miss state).
+  Composed identifying strings (meta lines, cells) omit absent
   tokens rather than showing a placeholder inside the joined string. Master
   *light* frames never appear here. Only dark/flat/bias kinds surface in
   this v1 — `dark_flat` and `bad_pixel_map` are out of scope by design.
@@ -213,3 +225,18 @@ assigned through an explicit, confirmable action — never silently.
   when narrow — same mechanism as Sessions/Projects/Archive/Targets.
   Evidence: spec-054-adaptive-detail-dock (FR-001, FR-004) · by:
   journey-scribe (intent-gated)
+
+- **Δ5** 2026-07-20 · S3 · behavior-change
+  A search and/or kind filter that matches nothing on the Calibration page
+  now names the active filter and offers a "Clear filters" action, and only
+  when showable masters actually exist — previously a search miss always
+  rendered the "No calibration masters — run a scan" onboarding copy even
+  when masters existed, indistinguishable from a truly empty library.
+  Evidence: PR #1291 (closes #669, #812) · by: journey-scribe (intent-gated)
+
+- **Δ6** 2026-07-20 · S3 · behavior-change
+  Masters now display the camera's registered friendly name (Settings →
+  Equipment) instead of the raw instrument header string, case-insensitive
+  across aliases; an unregistered camera still shows the raw string.
+  Display-only — match scoring is unaffected.
+  Evidence: PR #1341 · by: journey-scribe (intent-gated)

--- a/docs/journeys/J09-targets-planning/journey.md
+++ b/docs/journeys/J09-targets-planning/journey.md
@@ -1,7 +1,7 @@
 ---
 id: J09
 title: Find, add, and plan around an astrophotography target
-version: 6
+version: 7
 status: draft
 last_reviewed: 2026-07-14
 actors: [astrophotographer]
@@ -147,7 +147,10 @@ configured) real per-site astronomy for tonight.
   adaptive-dock default — Targets passes no page-specific threshold), and
   to the BOTTOM below that width; the chosen side-dock width persists across
   restarts, and a per-page pin (Auto/Side/Bottom) overrides the automatic
-  width-based choice when set. Every section — the altitude graph, alias
+  width-based choice when set. A linked project in the detail's Projects
+  list shows its lifecycle state (e.g. "Archived") with the same
+  StatusTag styling every other project surface uses, not raw unstyled
+  text. Every section — the altitude graph, alias
   list/add control, display-label editor, notes, Coverage/links sections,
   and the panel's own back button — is reachable by scrolling within the
   panel in either placement; nothing below the altitude graph is clipped or
@@ -200,8 +203,9 @@ configured) real per-site astronomy for tonight.
   transit-at-midnight date with unchanged sort.
 - **Expect (negative):** Without a configured observing site, these columns
   disclose that they need a site rather than rendering a plausible-looking
-  number. The Sessions column always renders as a dash — session-linkage is
-  not implemented yet (see G1).
+  number. The Sessions column shows the target's real, backend-populated
+  session count, sortable by that count; a target with zero or unresolved
+  sessions still shows the muted dash rather than a bare "0".
 - **Trace:** deltas/2026-07-14-jval-docdrift.md;
   `apps/desktop/src/features/targets/planner-derive.ts`,
   `AltitudeSparkline.tsx` — PR #896 fixes #579 (visibility rating no longer
@@ -294,6 +298,13 @@ configured) real per-site astronomy for tonight.
   change.
   Evidence: spec-054-adaptive-detail-dock (FR-001, FR-003, FR-005) · by:
   journey-scribe (intent-gated)
+
+- **Δ7** 2026-07-20 · S3, S4 · behavior-change
+  The Sessions column now shows the target's real, backend-populated
+  session count instead of a hardcoded dash with a no-op sort; a linked
+  project in the detail panel now shows its lifecycle state (e.g.
+  "Archived") with the shared StatusTag styling instead of raw text.
+  Evidence: PR #1293 (refs #622, #739) · by: journey-scribe (intent-gated)
 
 Note (not a Δ entry — provenance for why two deltas were not folded into the
 body above): `deltas/2026-07-14-q16-t132.md` and `2026-07-14-q16-t133.md`

--- a/docs/journeys/J13-audit-activity-investigation/journey.md
+++ b/docs/journeys/J13-audit-activity-investigation/journey.md
@@ -1,7 +1,7 @@
 ---
 id: J13
 title: Reconstruct what happened to my library
-version: 1
+version: 3
 status: draft
 last_reviewed: 2026-07-14
 actors: [astrophotographer]
@@ -49,7 +49,10 @@ happened" or "nothing was recorded".
 
 ### S1 — Open the Activity panel {#S1}
 - **Do:** Toggle the status-bar Log control.
-- **Expect:** The panel opens showing a live, newest-first stream of
+- **Expect:** The panel opens as a full-width bottom fold-out, expanding to
+  40% of the frame height (header always visible, only the event list
+  scrolls) — not a small, largely unstyled box capped at 200px. It shows a
+  live, newest-first stream of
   in-session events, each with a severity/level and a source indicator; rows
   that reference a specific entity are visually marked as navigable.
 - **Expect (negative):** Opening or closing the panel writes no Audit Log
@@ -145,18 +148,24 @@ happened" or "nothing was recorded".
   13 HEADLINE. Candidate Known Gap for this journey — needs explicit user
   confirmation before being recorded as one.
 
-### S8 — Find a settings, protection, equipment, or source change {#S8}
+### S8 — Find a settings, protection, equipment, source, or calibration change {#S8}
 - **Do:** After changing a setting, overriding or acknowledging a protection
-  rule, adding/editing equipment, or registering/enabling/disabling/remapping
-  a data source, filter the Audit Log by that entity type and date.
+  rule, adding/editing equipment, registering/enabling/disabling/remapping
+  a data source, or assigning/unassigning a calibration master to a session,
+  filter the Audit Log by that entity type and date.
 - **Expect:** The change is present as a durable row with outcome and actor.
   An equipment record created by auto-detection (not a direct user action)
   appears with actor=system at diagnostic severity, not attributed to the
-  user.
-- **Expect (negative):** A refused or failed attempt in any of these four
+  user. A calibration master assign/unassign is a durable row too — it is
+  not visible only in the transient Activity panel stream (S1).
+- **Expect (negative):** A refused or failed attempt in any of these five
   categories (P3's blocked override/duplicate-alias/blocked-delete case, or
   equivalent) still appears as a row, with outcome=refused or outcome=failed
   and a reason code — it is never silently dropped from the log.
+- **Trace:** `crates/app/calibration/src/matching/assign.rs` (assign/unassign
+  routed through `EventBus::write_audit`, PR #1287, refs #1120) — previously
+  these mutations were recorded only via the non-authoritative in-memory
+  `events` table, so they were absent from `audit_log_entry`.
 
 ### S9 — Confirm reads produce no audit noise {#S9}
 - **Do:** Navigate through several pages/panes performing only reads (no
@@ -226,3 +235,17 @@ happened" or "nothing was recorded".
 - G2: (dissolved 2026-07-15) — tracked as issue #647; activity-over-durable-audit, same audit-classes lane.
 
 ## Delta log
+
+- **Δ2** 2026-07-20 · S1 · behavior-change
+  The Activity panel now opens as the specified full-width bottom fold-out
+  (40% of the frame height, header always visible, list scrolls) —
+  previously most of its rows/chips/filters/buttons had no CSS at all and
+  the body was hard-capped at 200px, reading as a small unstyled debug box.
+  Evidence: PR #1303 (closes #734) · by: journey-scribe (intent-gated)
+
+- **Δ3** 2026-07-20 · S8 · behavior-change
+  Assigning or unassigning a calibration master to a session is now a
+  durable Audit Log row (outcome + actor) — previously recorded only in the
+  transient, non-authoritative in-memory events table, so it never appeared
+  in the durable Audit Log at all.
+  Evidence: PR #1287 (refs #1120) · by: journey-scribe (intent-gated)


### PR DESCRIPTION
## Summary
Records journey deltas for merged, user-visible behavior changes from today's PRs, in the journeys whose files were free of contention (J04, J05, J08, J09, J13). No product code touched.

- J04 (sessions): total integration time renders as "1h 30m" (h/m grammar), matching Projects/wizard — PR #1288
- J05 (project lifecycle): edit view opens as a real dialog (role=dialog, Escape, focus trap) instead of covering the window — PR #1290; same integration-time format fix as J04 — PR #1288
- J08 (calibration): filtered-empty search now distinguished from a truly-empty library, with a Clear filters action — PR #1291; masters show the camera's registered friendly name — PR #1341
- J09 (targets): Sessions column shows real backend-populated counts instead of a hardcoded dash — PR #1293; linked project lifecycle shown with shared StatusTag styling — PR #1293
- J13 (audit/activity): Activity panel renders as the specified full-width bottom fold-out instead of an unstyled 200px box — PR #1303; calibration master assign/unassign now lands in the durable Audit Log — PR #1287

Deferred (file-claim CLAIMED by other in-flight lanes/PRs at probe time — not edited):
- J01, J02, J03, J06, J07, J10, J12, J16, J18 — live uncommitted changes in worktree `fix/1230-1231-migration-perf` (J01/J06/J07/J10/J12/J16) and open PRs #1354 (J02/J03), #1319 (J01), #1320 (J10), onboarding-redesign worktree (J18).
- `INDEX.md` — claimed by worktree `spec/058-docs`; not regenerated.

Not mapped to any journey (no clear user-visible surface, or too narrow/timing-only to state as a falsifiable Expect): #1285 (gate-formula unification, no runtime-observable effect yet), #1349 (plan-approval metadata snapshot, no UI to compare it), #1254 (StrictMode-only race fix), #1308 (dev-mock alignment), #1311 (theoretical fallback color, never manifested), #1314 (release-build security hardening, not normal-use visible), #1298 (target-resolution latency, no journey states a timing bound), #1299 (splash/app-icon — actively being iterated in open PR #1381, and no journey currently describes app-launch chrome).

## Test plan
- [x] `python3 docs/journeys/journeys.py lint .` — 0 errors on the 5 edited files (1 pre-existing error on J12, from another lane's uncommitted work, untouched by this PR)
- [x] `git diff --name-only origin/main...HEAD` before starting — empty (clean worktree base)
- [ ] Confirm PR only touches docs/journeys/**