### PR TITLE
test(e2e): fix stale bridge-ready race in complete_first_run_gate reload

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1607,6 +1607,28 @@ impl E2eApp {
             .await
             .context("failed to persist setupCompleted preference")?;
 
+        // Clear the bridge marker on the PRE-refresh document before asking
+        // for the reload (#1385-followup — CI run 29779614765 and local
+        // repro under `--partition hash:4/4`, `test-threads = 2`): under
+        // load, `driver.refresh()` can return before WebKitGTK's navigation
+        // has actually started, so the OLD document (bridge already set from
+        // before this call) is still what `execute()` runs against for a
+        // stretch afterward. `wait_bridge_ready` below then reads that STALE
+        // true, `complete_first_run_gate` returns "ready", and the real
+        // reload — delayed, not skipped — lands moments later and tears down
+        // `window.__ALM_E2E__` right as the caller's very next `invoke()`
+        // fires (observed as "invoke error: __ALM_E2E__ bridge missing"
+        // immediately after this function returns, only under concurrent
+        // nextest execution — never standalone, never on Windows, which
+        // serialises this profile for an unrelated reason, see
+        // `.config/nextest.toml`). Deleting the marker here means a
+        // subsequent `true` reading can only come from the NEW document's
+        // own `main.tsx` re-assigning it — a real condition, not a race.
+        self.driver
+            .execute("delete window.__ALM_E2E__;", vec![])
+            .await
+            .context("failed to clear the pre-refresh __ALM_E2E__ marker")?;
+
         // KEEP the reload (#1113 reviewed): this is not a settle step. The
         // preferences module caches its localStorage read in module state, so
         // the write above is invisible without a fresh page load —


### PR DESCRIPTION
## Summary

Fixes main's red Real-UI L3 (`plan_review_destructive_confirm_gate_and_apply` on 5c2bcacb, `plan_review_empty_archive_plan_refuses_apply` on 399308d8), which blocks the merge queue via the required `Real-UI journeys (L3) — ubuntu-latest` aggregate check.

## Root cause

`E2eApp::complete_first_run_gate()` (`crates/e2e-tests/tests/common/mod.rs`) does: write `setupCompleted` to `localStorage` → `driver.refresh()` → `wait_document_ready` → `wait_bridge_ready`. Under the Linux `e2e` nextest profile's `test-threads = 2` (`.config/nextest.toml`), a concurrently-running sibling test contends for CPU. Under that contention, `driver.refresh()` can return before WebKitGTK's navigation has actually started, so the subsequent readiness polls keep executing script against the *pre-refresh* document — which still has `window.__ALM_E2E__` set from before the reload. `wait_bridge_ready` reads that stale `true`, `complete_first_run_gate()` reports "ready", and the caller immediately issues its next `invoke()` — which is exactly the moment the real (delayed) navigation finally lands and tears the bridge down, producing `invoke error: __ALM_E2E__ bridge missing`.

Windows never hits this: its profile override sets `threads-required = 2` for this test class (documented in `.config/nextest.toml`, for an unrelated AppData-sharing reason), which serialises it and removes the concurrency this race depends on.

Only two of the ~40 real-UI journeys are exposed: `plan_review_destructive_confirm_gate_and_apply` and `plan_review_empty_archive_plan_refuses_apply`. Both call `complete_first_run()` → `complete_first_run_gate()` and then immediately call a raw `invoke()` (`create_unprotected_project`) as their very next step. Every other journey's first post-gate action is `goto_route(...)`, which already retries navigation until the target URL sticks (`goto_route`'s own doc comment: "several app-level redirects can move the page away... retry until the URL actually stays") — that retry loop happens to absorb the same stale-document window, hiding the bug elsewhere.

Confirmed not a build-config issue: if `VITE_E2E=1` were missing from the served dist, every real-UI test would fail identically and permanently. Instead the failure moves between shards across commits — 4/4 red with 1-3 green on 5c2bcacb, then 4/4 green and 2/4 red (with the *other* plan-review test) on 399308d8 — which is the signature of a race, not a missing build flag.

Test-vs-product verdict: neither is wrong. This is a test-harness synchronization bug in a shared helper, not a wrong test expectation and not a product safety defect — the destructive-confirm gate itself is untouched.

## Fix

Delete `window.__ALM_E2E__` on the current document immediately before calling `driver.refresh()`. A later `true` reading can then only come from the new document's own `main.tsx` re-assigning it during its real boot — a real condition, not a race window.

## Verification

Built `desktop_shell --features e2e` + frontend with `VITE_E2E=1`, served on `:5173`, ran via `xvfb-run` + `tauri-webdriver` in a local WSL sandbox (the crate's own README notes this isn't fully reliable there — confirmed: a standalone run of either test hits an unrelated local window-creation flake, not this bug).

Running the exact CI invocation (`cargo nextest run -p e2e_tests --profile e2e --run-ignored all --partition hash:N/4`, matching `.github/workflows/e2e.yml`) reproduced the verbatim CI error before this change:
- `--partition hash:4/4`: `plan_review_destructive_confirm_gate_and_apply` failed with `Error: invoke error: __ALM_E2E__ bridge missing (build with VITE_E2E=1)`.
- `--partition hash:2/4`: `plan_review_empty_archive_plan_refuses_apply` failed with the identical error text.

After the fix, both partitions were re-run against the exact same CI invocation and both tests passed, including one run instrumented with temporary `eprintln!` markers (removed before commit) confirming each ran its full real-backend flow — project create, real file write, real UI scan/generate/confirm/apply clicks, real on-disk delete — rather than short-circuiting.

`cargo check --workspace` and `cargo clippy -p e2e_tests --tests --all-features -- -D warnings` are clean.

## Test plan

- [x] Reproduced both failures locally under CI-matching partitioned execution
- [x] Verified the fix resolves both under the same partitioned execution
- [x] `cargo check --workspace`
- [x] `cargo clippy -p e2e_tests --tests --all-features -- -D warnings`
- [ ] CI: `Real-UI journeys (L3) — ubuntu-latest` green on this branch