### PR TITLE
fix(e2e): isolate Windows webview storage via WEBVIEW2_USER_DATA_FOLDER

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -99,10 +99,16 @@ failure-output = "immediate-final"
 # above, which was also Windows/macOS-only for the same reason: per-instance
 # isolation that exists on Linux and silently does not on Windows.
 #
-# Serialising is the honest fix available here, not the ideal one. Real
-# isolation needs the app to accept an explicit data-directory override (and
-# to pass it to the webview's `data_directory`), since no environment variable
-# can redirect a Known Folder. Tracked on #1204; revert this when that lands.
+# Update: real per-instance webview isolation landed (`WEBVIEW2_USER_DATA_FOLDER`,
+# `crates/e2e-tests/tests/common/mod.rs::InstanceEnv::new` +
+# `apps/desktop/src-tauri/src/data_dir.rs`) — the redb-lock and shared-webview
+# collisions above should no longer happen regardless of `threads-required`.
+# This override stays ON deliberately for now: it also gates a DIFFERENT,
+# still-open contamination symptom (three PRs failing this shard on opposite
+# assertions, consistent with shared localStorage surviving the reset — see
+# the bead tracking this) that concurrency, not identity, may have been
+# masking. Lower this only after a real Windows run demonstrates the fix
+# holds under `test-threads > 1`, not from reading this comment.
 [[profile.e2e.overrides]]
 platform = 'cfg(windows)'
 retries = 2

--- a/apps/desktop/src-tauri/src/data_dir.rs
+++ b/apps/desktop/src-tauri/src/data_dir.rs
@@ -3,7 +3,7 @@
 
 //! Explicit app-data-root override (`ALM_DATA_DIR`) — issue #1204.
 //!
-//! # Why an env var cannot do this on its own
+//! # Why the platform env vars are not enough
 //!
 //! The E2E harness gives every concurrent app instance an isolated app-data
 //! root by overriding the platform's location env vars
@@ -11,53 +11,49 @@
 //! Linux, `HOME` on macOS, `APPDATA`/`LOCALAPPDATA` on Windows.
 //!
 //! That works on Linux and macOS. **It does nothing on Windows.** Tauri
-//! resolves both `app_data_dir()` and the config-driven webview
-//! `data_directory` through the `dirs` crate, which on Windows calls
-//! `SHGetKnownFolderPath(FOLDERID_RoamingAppData)` /
-//! `FOLDERID_LocalAppData` (`dirs-sys-0.5.0/src/lib.rs:176`). The Known
-//! Folder API reads the user's shell profile — it ignores `APPDATA` and
-//! `LOCALAPPDATA` entirely. No env var can redirect it.
+//! resolves `app_data_dir()` through the `dirs` crate, which on Windows calls
+//! `SHGetKnownFolderPath(FOLDERID_RoamingAppData)`
+//! (`dirs-sys-0.5.0/src/lib.rs:176`). The Known Folder API reads the user's
+//! shell profile — it ignores `APPDATA` and `LOCALAPPDATA` entirely, so no
+//! amount of env-var setting redirects it.
 //!
-//! So on Windows, every concurrent instance silently shared one real
-//! app-data root, which collided in two places:
-//!
-//! 1. **The redb resolve cache** (`simbad-cache.redb`) — the second instance
-//!    logs `Database already open. Cannot acquire lock` and degrades to an
-//!    in-memory cache.
-//! 2. **The `WebView2` user-data folder** — `create_environment` passes
-//!    `data_directory` straight to `CreateCoreWebView2EnvironmentWithOptions`
-//!    (`wry-0.55.1/src/webview2/mod.rs:345`), and an empty value means "the
-//!    default folder next to the exe". Two instances of the same exe get the
-//!    same folder, the second fails with
-//!    `failed to create webview: WindowsError(0x80070057)`, and — having no
-//!    window — never brings up its `WebDriver` port. That surfaced four layers
-//!    downstream as `window.__ALM_E2E__ bridge never became ready`, the
-//!    symptom chased since #1019.
+//! Concurrent Windows instances therefore all shared one real app-data root
+//! and fought over `simbad-cache.redb`: the loser logs
+//! `Database already open. Cannot acquire lock` and silently degrades to an
+//! in-memory resolve cache.
 //!
 //! # The override
 //!
 //! [`resolve`] reads `ALM_DATA_DIR`. When set, it is used verbatim as the
 //! app-data root instead of `app.path().app_data_dir()`, on every platform —
-//! one mechanism rather than three platform-specific ones that are only
-//! honoured on two of them.
+//! one mechanism the app itself honours, rather than three platform-specific
+//! ones that only two platforms actually obey.
 //!
 //! When unset (real users, every non-E2E build) nothing changes: callers
 //! fall back to the platform resolver exactly as before.
 //!
-//! # The webview folder is a separate lever
+//! # The webview folder is NOT covered here
 //!
-//! The webview's user-data folder cannot live under `ALM_DATA_DIR`, because
-//! a config-declared window's `data_directory` **must be relative** —
-//! `WebviewBuilder::from_config` rejects absolute paths outright and joins
-//! relative ones onto `dirs::data_local_dir()/<label>`
-//! (`tauri-2.11.5/src/webview/mod.rs:392-425`), which is the very Known
-//! Folder we cannot redirect.
+//! The other half of #1204 — concurrent instances sharing one `WebView2`
+//! user-data folder, so the loser cannot create its webview at all
+//! (`WindowsError(0x80070057)`) and never brings up its `WebDriver` port —
+//! is deliberately *not* solved by this module.
 //!
-//! What we *can* do is make the leaf name unique per instance, so concurrent
-//! instances stop sharing one folder even though they all sit under the real
-//! `LocalAppData`. [`webview_subdir`] derives that name from the override
-//! path. Isolation of *identity* is what fixes the collision; isolation of
-//! *location* is not available to us here.
+//! `WebView2` has its own documented loader override, `WEBVIEW2_USER_DATA_FOLDER`,
+//! which **replaces** the `userDataFolder` argument the app passes to
+//! `CreateCoreWebView2EnvironmentWithOptions`. Microsoft documents it as the
+//! intended lever for exactly this (testing/deployment overrides), so the
+//! harness sets it per instance and the app needs no webview code at all.
+//!
+//! An earlier attempt did try to solve it here, by pointing each
+//! config-declared window at a per-instance `data_directory`. Recorded so it
+//! is not retried: that route cannot isolate by *location*. A config window's
+//! `data_directory` must be relative — `WebviewBuilder::from_config` rejects
+//! absolute paths and joins relative ones onto `dirs::data_local_dir()`
+//! (`tauri-2.11.5/src/webview/mod.rs:392-425`), the very Known Folder that
+//! started this. Only `WebviewWindowBuilder::data_directory` takes an absolute
+//! path, and config-declared windows are built by Tauri during `.build()`,
+//! where there is no builder to reach.
 
 use std::path::PathBuf;
 
@@ -85,36 +81,6 @@ fn resolve_from(raw: Option<&std::ffi::OsStr>) -> Option<PathBuf> {
     Some(PathBuf::from(raw))
 }
 
-/// A per-instance webview user-data folder name, or `None` when no override
-/// is set (in which case config windows keep Tauri's default behaviour).
-///
-/// The name is a deterministic function of the override path, so the same
-/// instance reuses the same folder across a launch → shutdown → relaunch
-/// sequence — which the E2E harness's webview-storage-preserving
-/// `relaunch()` depends on — while two instances with different roots never
-/// collide.
-#[must_use]
-pub fn webview_subdir() -> Option<PathBuf> {
-    resolve().as_deref().map(webview_subdir_for)
-}
-
-/// [`webview_subdir`]'s derivation, as a pure function of the root. See
-/// [`resolve_from`] on why the split exists.
-fn webview_subdir_for(root: &std::path::Path) -> PathBuf {
-    PathBuf::from(format!("pv-{:016x}", fnv1a(root.as_os_str().as_encoded_bytes())))
-}
-
-/// FNV-1a, 64-bit. Used only to turn a path into a short, stable, filesystem-
-/// safe folder name — not for anything security-sensitive. Spelled out here
-/// rather than using `DefaultHasher`, whose output std explicitly reserves
-/// the right to change between releases (which would silently orphan an
-/// instance's webview storage across a toolchain bump).
-fn fnv1a(bytes: &[u8]) -> u64 {
-    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-    const PRIME: u64 = 0x0000_0100_0000_01b3;
-    bytes.iter().fold(OFFSET, |hash, &b| (hash ^ u64::from(b)).wrapping_mul(PRIME))
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -140,53 +106,6 @@ mod tests {
         assert_eq!(
             resolve_from(Some(os("/tmp/pv-instance-a"))),
             Some(PathBuf::from("/tmp/pv-instance-a"))
-        );
-    }
-
-    /// The property the whole fix rests on: different roots must produce
-    /// different webview folders, or concurrent instances still collide.
-    #[test]
-    fn different_roots_get_different_webview_dirs() {
-        let a = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
-        let b = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-b"));
-        assert_ne!(a, b, "two instance roots must not share a webview data directory");
-    }
-
-    /// The complementary property: one root is stable across relaunches, so
-    /// `ResetScope::PreserveWebviewStorage` still preserves storage.
-    #[test]
-    fn same_root_is_stable_across_calls() {
-        let a = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
-        let b = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
-        assert_eq!(a, b);
-    }
-
-    /// The E2E harness has to delete this exact folder to honour a
-    /// storage-clearing `relaunch()`, and it cannot call this function — it
-    /// deliberately does not depend on the Tauri app crate
-    /// (`crates/e2e-tests/Cargo.toml`). So it reimplements the derivation,
-    /// and this pinned pair is the contract between the two copies: the same
-    /// literal is asserted by
-    /// `crates/e2e-tests/tests/common/mod.rs::webview_subdir_matches_the_app`.
-    /// If either side drifts, one of the two tests fails.
-    #[test]
-    fn webview_dir_derivation_is_pinned() {
-        let dir = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
-        assert_eq!(dir, PathBuf::from("pv-b51d4cf056f3eb58"));
-    }
-
-    /// `from_config` rejects an absolute `data_directory` outright and
-    /// `SafePathBuf` rejects traversal, so the derived name must be a plain
-    /// relative single component or the config is silently ignored.
-    #[test]
-    fn webview_dir_is_a_plain_relative_component() {
-        let dir = webview_subdir_for(std::path::Path::new("/tmp/pv-instance-a"));
-        assert!(dir.is_relative(), "must be relative: {dir:?}");
-        assert_eq!(dir.components().count(), 1, "must be a single component: {dir:?}");
-        let name = dir.to_str().expect("ascii");
-        assert!(
-            name.chars().all(|c| c.is_ascii_alphanumeric() || c == '-'),
-            "must be filesystem-safe on every platform: {name}"
         );
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -219,31 +219,20 @@ pub fn build_app() -> tauri::App {
         .expect("error while building tauri application")
 }
 
-/// The compiled-in Tauri context, with each config-declared window pointed at
-/// a per-instance webview user-data folder when `ALM_DATA_DIR` is set.
+/// Builds the compiled-in Tauri context and defers the main window's
+/// creation (see [`defer_main_window`]).
 ///
-/// Issue #1204: concurrent instances on Windows otherwise share one `WebView2`
-/// user-data folder, and the loser fails to create its webview at all
-/// (`WindowsError(0x80070057)`) — see [`crate::data_dir`] for the full chain
-/// and for why this has to go through the *config* (as a relative path)
-/// rather than [`tauri::webview::WebviewWindowBuilder::data_directory`]:
-/// windows declared in `tauri.conf.json` are built by Tauri itself, during
-/// `.build()`, so there is no builder for us to reach.
-///
-/// Unset (real users, non-E2E builds) leaves every window's `data_directory`
-/// as `None` — byte-for-byte the previous behaviour.
-///
-/// **Windows only, deliberately.** Linux and macOS already get real webview
-/// isolation from the harness's `XDG_*`/`HOME` overrides, which those
-/// platforms actually honour; there is no collision to fix. Setting
-/// `data_directory` there would instead *move* WebKitGTK/WKWebView storage
-/// out from under the isolated root it currently lives in — a regression
-/// bought for nothing.
-///
-/// That gate is a runtime `cfg!`, not a `#[cfg]` attribute, so this body is
-/// type-checked on every platform. A `#[cfg(target_os = "windows")]` block
-/// here would be invisible to the Linux and macOS CI legs and could only
-/// break on the one platform whose failures this is meant to stop.
+/// Per-instance webview isolation for the E2E harness (#1204) does **not**
+/// go through this context any more: it used to point each config-declared
+/// window at a per-instance `data_directory`, but that must be relative —
+/// `WebviewBuilder::from_config` joins it onto `dirs::data_local_dir()`, the
+/// very Known Folder that ignores `LOCALAPPDATA` overrides on Windows — so
+/// it could isolate by *name* but never by *location*, and CI evidence
+/// (`WindowsError(0x80070057)` surviving to TRY-1) showed it did not
+/// reliably work. The harness now sets `WEBVIEW2_USER_DATA_FOLDER` instead
+/// (`crates/e2e-tests/tests/common/mod.rs`) — `WebView2`'s own documented
+/// loader override, read inside the app process — so this function needs no
+/// Windows-specific branch at all.
 /// Clear `create` on the [`MAIN_WINDOW_LABEL`] entry so Tauri's own `setup()`
 /// — which runs on `RunEvent::Ready`, i.e. *inside* `app.run()`, not during
 /// `.build()` (`tauri-2.11.5/src/app.rs:1424` + `:2524`) — creates the splash
@@ -276,29 +265,17 @@ fn instance_context() -> tauri::Context {
          run_app has nothing to create after migration"
     );
 
-    let subdir = crate::data_dir::webview_subdir();
-
-    if let (true, Some(subdir)) = (cfg!(target_os = "windows"), subdir.as_ref()) {
-        for window in &mut context.config_mut().app.windows {
-            window.data_directory = Some(subdir.clone());
-        }
-    }
-
-    // `eprintln!`, deliberately, not `tracing`: `build_app()` runs BEFORE
-    // `main.rs` installs the tracing subscriber, so anything logged from here
-    // is dropped on the floor. A first attempt at this used `tracing::info!`
-    // and produced no line in CI — which said nothing about whether the code
-    // had run, and cost a full Windows round-trip to find out. stderr is
-    // captured by the E2E harness's `ProcLog`, so this always shows up.
-    if let Some(dir) = &subdir {
-        eprintln!(
-            "ALM_DATA_DIR is set; webview data_directory = {} (applied: {})",
-            dir.display(),
-            cfg!(target_os = "windows")
-        );
-    } else {
-        eprintln!("ALM_DATA_DIR is unset; webview data_directory left at Tauri's default");
-    }
+    // The webview's per-instance isolation (#1204) no longer goes through
+    // config: a config-declared window's `data_directory` must be relative,
+    // and Tauri joins it onto `dirs::data_local_dir()` — the very Known
+    // Folder that ignores `LOCALAPPDATA` overrides on Windows, so that route
+    // could isolate by *name* but never by *location*, and CI evidence (TRY-1
+    // `WindowsError(0x80070057)`) showed it did not reliably work at all. The
+    // E2E harness now sets `WEBVIEW2_USER_DATA_FOLDER` instead — WebView2's
+    // own documented loader override, read inside the app process and immune
+    // to the Known Folder lookup — so no product-side window config is
+    // needed here any more (`crates/e2e-tests/tests/common/mod.rs`, refs
+    // #1204).
 
     context
 }

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -107,6 +107,29 @@ impl InstanceEnv {
             vec![
                 ("APPDATA", root.path().join("appdata").display().to_string()),
                 ("LOCALAPPDATA", root.path().join("localappdata").display().to_string()),
+                // The other half of #1204, and the fatal half: concurrent
+                // instances shared ONE WebView2 user-data folder, so the loser
+                // could not create its webview at all
+                // (`WindowsError(0x80070057)`), never opened a window, and
+                // never brought up its WebDriver port — surfacing four layers
+                // downstream as `bridge never became ready`.
+                //
+                // `WEBVIEW2_USER_DATA_FOLDER` is WebView2's own documented
+                // loader override: when set, it REPLACES the `userDataFolder`
+                // argument the app passes to
+                // `CreateCoreWebView2EnvironmentWithOptions`. Microsoft
+                // documents it as the intended lever for testing/deployment
+                // overrides, which is exactly this.
+                //
+                // It is read by the WebView2 loader inside the app process, so
+                // unlike APPDATA/LOCALAPPDATA it cannot be quietly bypassed by
+                // a Known Folder lookup — and unlike a config-declared
+                // window's `data_directory` (which must be RELATIVE, and
+                // resolves under `dirs::data_local_dir()`), it takes an
+                // absolute path, so the folder genuinely lives under this
+                // instance's temp root instead of merely having a unique name
+                // in a shared one.
+                ("WEBVIEW2_USER_DATA_FOLDER", root.path().join("webview2").display().to_string()),
             ]
         } else if cfg!(target_os = "macos") {
             // app_config_dir resolves under $HOME on macOS (see
@@ -354,11 +377,20 @@ impl E2eApp {
     /// `settings_journeys.rs`'s theme persistence test) must call this
     /// instead of `launch()` for its second call: calling `launch()` again
     /// wipes the very localStorage state the journey is trying to prove
-    /// persisted, which is a harness bug, not a product one (windows-only
-    /// symptom: only WebView2's `EBWebView` wipe path in
-    /// `reset_webview_storage()` actually deletes real localStorage files —
-    /// the Linux `localstorage`/`storage` paths don't match WebKitGTK's real
-    /// storage location, so the same call was already a no-op there).
+    /// persisted, which is a harness bug, not a product one.
+    ///
+    /// That was a Windows-only symptom, and since #1204 it is Windows-only
+    /// for a different reason. The old note here said the `EBWebView` path
+    /// was the one that "actually deletes real localStorage files" — it was
+    /// not: it pointed under the isolated `LOCALAPPDATA`, which no Known
+    /// Folder lookup honours, so it deleted nothing either. Windows storage
+    /// is now genuinely wiped, via the absolute `WEBVIEW2_USER_DATA_FOLDER`
+    /// this harness sets.
+    ///
+    /// The Linux `localstorage`/`storage` paths still do not match
+    /// WebKitGTK's real storage location, so that branch remains a no-op —
+    /// pre-existing, and left alone here deliberately rather than fixed
+    /// blind alongside a Windows change.
     ///
     /// Still resets the database and window-state store (same as `launch()`)
     /// — those are unrelated to the webview storage this exists to preserve,
@@ -2197,27 +2229,18 @@ fn reset_database(db_path: &Path) -> Result<()> {
 fn reset_webview_storage(vars: &[(&'static str, String)]) {
     let mut candidates: Vec<PathBuf> = Vec::new();
     if cfg!(target_os = "windows") {
-        // Since #1204 the app points each window at a per-instance WebView2
-        // user-data folder (`desktop_shell::data_dir::webview_subdir`), and
-        // Tauri resolves that relative name to
-        // `dirs::data_local_dir()/<window label>/<name>`
-        // (`tauri-2.11.5/src/webview/mod.rs:411-413`).
-        //
-        // `dirs::data_local_dir()` is the real Known Folder — NOT the
-        // `LOCALAPPDATA` this instance sets, which is exactly the bug #1204
-        // was. This harness process has its own env unmodified, so its own
-        // `LOCALAPPDATA` is that same real folder, which is why we read it
-        // here rather than from `vars`.
+        // Since #1204 this instance's WebView2 user-data folder is wherever
+        // we told the loader to put it (`WEBVIEW2_USER_DATA_FOLDER`, set in
+        // `InstanceEnv::new`), so the reset targets a path this harness
+        // itself chose — nothing is derived, mirrored, or guessed.
         //
         // The previous target — `<isolated LOCALAPPDATA>/<identifier>/
-        // EBWebView` — never existed: the app had been writing to the real
-        // profile all along, so every "reset" silently deleted nothing and
-        // journeys shared one localStorage.
-        if let (Some(name), Ok(real_local)) = (webview_subdir(vars), std::env::var("LOCALAPPDATA"))
-        {
-            for label in ["main", "splash"] {
-                candidates.push(PathBuf::from(&real_local).join(label).join(&name));
-            }
+        // EBWebView` — never existed. `LOCALAPPDATA` does not move a Known
+        // Folder, so the app had been writing to the REAL profile all along:
+        // every "reset" silently deleted nothing, and Windows journeys shared
+        // one localStorage no matter how carefully each one reset.
+        if let Some(dir) = lookup(vars, "WEBVIEW2_USER_DATA_FOLDER") {
+            candidates.push(PathBuf::from(dir));
         }
     } else if cfg!(target_os = "macos") {
         // WKWebView website data (incl. localStorage) lives under
@@ -2308,36 +2331,6 @@ fn app_config_dir(vars: &[(&'static str, String)]) -> Option<PathBuf> {
 /// isolated root while the app read and wrote the real one.
 fn app_data_dir(vars: &[(&'static str, String)]) -> Option<PathBuf> {
     lookup(vars, "ALM_DATA_DIR").map(PathBuf::from)
-}
-
-/// This instance's WebView2 user-data folder *name* (Windows; see
-/// [`reset_webview_storage`] for where it is rooted).
-///
-/// Reimplements `desktop_shell::data_dir::webview_subdir`, because this crate
-/// deliberately does not depend on the Tauri app crate (see `Cargo.toml`'s
-/// header — the whole point is that the heavy Tauri/thirtyfour stacks stay
-/// out of the shipping build). [`webview_subdir_matches_the_app`] pins the
-/// two copies to the same literal so drift is a test failure, not a silent
-/// "reset deleted nothing" — the failure mode this replaced.
-fn webview_subdir(vars: &[(&'static str, String)]) -> Option<String> {
-    let root = lookup(vars, "ALM_DATA_DIR")?;
-    if root.is_empty() {
-        return None;
-    }
-    const OFFSET: u64 = 0xcbf2_9ce4_8422_2325;
-    const PRIME: u64 = 0x0000_0100_0000_01b3;
-    let hash = root.as_bytes().iter().fold(OFFSET, |h, &b| (h ^ u64::from(b)).wrapping_mul(PRIME));
-    Some(format!("pv-{hash:016x}"))
-}
-
-/// The other half of the pinned contract asserted by
-/// `apps/desktop/src-tauri/src/data_dir.rs::webview_dir_derivation_is_pinned`.
-/// Both must agree on this literal, or the harness resets a folder the app
-/// does not use.
-#[test]
-fn webview_subdir_matches_the_app() {
-    let vars = vec![("ALM_DATA_DIR", "/tmp/pv-instance-a".to_string())];
-    assert_eq!(webview_subdir(&vars).as_deref(), Some("pv-b51d4cf056f3eb58"));
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Windows real-UI E2E journeys never got real webview-storage isolation. The merged half of #1204 (PR #1315) pointed each config-declared window at a per-instance `data_directory`, but Tauri resolves a relative `data_directory` onto `dirs::data_local_dir()` — the same Known Folder that ignores the `LOCALAPPDATA` override — so every journey process reset a folder the app never wrote to, and every sequential Windows journey shared one real `localStorage`.
- That is consistent with #1352 (`targets_ui_dock_pin_and_width_survive_a_real_restart`, missing persisted state) and #1319 (`targets_ui_astronomy_columns_disclose_placeholder_without_site`, unexpected persisted state) failing the same shard in opposite directions — the signature of shared mutable state, not one broken test.
- `WebView2` has its own loader override, `WEBVIEW2_USER_DATA_FOLDER`, read inside the app process and immune to the Known Folder lookup. The harness now sets it per instance (absolute path, real per-process isolation) and resets exactly that path; the app needs no window-config workaround.
- This ports a fix that was already written and reasoned through on the unmerged `fix/1204-webview-data-dir` branch (commits `c1301efaa`..`ec6eb85d9`) — PR #1315 only merged that branch's first, since-abandoned attempt.
- `.config/nextest.toml`'s `threads-required = 2` Windows serialization override is left in place deliberately (bead `astro-plan-cws` already tracks removing it, gated on a clean Windows CI run — see `astro-plan-1oe`'s acceptance criteria, which this PR's mechanism is what that bead was written to prove).

## What I could not verify

I have no Windows environment. Everything here is argued from `tauri-2.11.5`/`wry-0.55.1` source paths cited in the existing code comments, from the author's own prior commit messages diagnosing why the previous approach failed, and from the CI failure signature — not from a Windows run. `crates/e2e-tests` compiles, clippy is clean, and `desktop_shell --features e2e` builds, but the actual WebView2 isolation behavior needs a real Windows E2E run (bead `astro-plan-1oe`) before `threads-required` can be lowered.

## Test plan

- [x] `cargo build -p desktop_shell --features e2e`
- [x] `cargo build --workspace --all-targets --features desktop_shell/e2e`
- [x] `cargo clippy -p desktop_shell -p e2e_tests --features e2e --all-targets` (0 warnings)
- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p desktop_shell --lib` (42 passed, incl. `data_dir` module tests)
- [ ] Windows E2E run on this PR — confirm zero `0x80070057`, zero "bridge never became ready", zero "Database already open", zero flaky retries on either Windows shard (per `astro-plan-1oe`'s acceptance criteria)