### PR TITLE
fix: write the project marker file when a project is created

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "desktop_shell"
-version = "0.5.0"
+version = "0.6.0"
 dependencies = [
  "app_core",
  "audit",
@@ -1937,6 +1937,7 @@ dependencies = [
  "fs4",
  "fs_pathsafe",
  "path-clean",
+ "project_structure",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/app/core/src/plan_apply/paths.rs
+++ b/crates/app/core/src/plan_apply/paths.rs
@@ -229,6 +229,14 @@ pub(super) fn item_row_to_executor_item(
         // to `symlink` (the constitution-preferred default) rather than
         // guessing a destructive kind.
         "link" => ExecutorItemAction::Link { kind: materialization_from_provenance(row) },
+        // astro-plan-l3y0: previously fell through to NoOp, so an applied
+        // project-create plan never wrote the app-owned project marker file
+        // to disk despite the plan reporting the item as applied. The
+        // project id rides `linked_entity` (set by `project_setup::create`
+        // for every item in the plan, including this one).
+        "write_manifest" => ExecutorItemAction::WriteManifest {
+            project_id: row.linked_entity.clone().unwrap_or_default(),
+        },
         _ => ExecutorItemAction::NoOp,
     };
 

--- a/crates/app/core/src/plans/tests.rs
+++ b/crates/app/core/src/plans/tests.rs
@@ -678,9 +678,14 @@ fn predicate_rejects_write_manifest_only_plan() {
 
 /// Insert a `ready_for_review` plan with the given item actions and
 /// per-item destination paths.
+///
+/// `write_manifest` items are linked to a fixed test project id, mirroring
+/// `project_setup::create` (astro-plan-l3y0: the executor refuses a
+/// `write_manifest` item with no linked project).
 async fn insert_review_plan(db: &Database, id: &str, actions: &[(&str, &str)]) {
     insert_draft(db, id).await;
     for (idx, (action, dest)) in actions.iter().enumerate() {
+        let linked_entity = (*action == "write_manifest").then_some("test-project");
         repo::insert_plan_item(
             db.pool(),
             &repo::InsertPlanItem {
@@ -695,7 +700,7 @@ async fn insert_review_plan(db: &Database, id: &str, actions: &[(&str, &str)]) {
                 to_relative_path: dest,
                 reason: "test",
                 protection: "normal",
-                linked_entity: None,
+                linked_entity,
                 provenance_json: None,
                 archive_path: None,
                 source_id: None,
@@ -748,6 +753,9 @@ async fn auto_apply_creates_directories_for_mkdir_only_plan() {
     assert_eq!(terminal, "applied");
     assert!(std::path::Path::new(&format!("{base}/proj/lights")).is_dir());
     assert!(std::path::Path::new(&format!("{base}/proj/darks")).is_dir());
+    // astro-plan-l3y0: the write_manifest item must actually write the
+    // marker file, not just report success.
+    assert!(std::path::Path::new(&format!("{base}/proj/.marker.json")).is_file());
 }
 
 /// A plan containing a user-file action is left untouched in

--- a/crates/app/core/src/project_create.rs
+++ b/crates/app/core/src/project_create.rs
@@ -165,6 +165,53 @@ mod tests {
         assert_eq!(plan.state, "applied");
     }
 
+    /// astro-plan-l3y0: the `write_manifest` plan item previously fell
+    /// through to `ExecutorItemAction::NoOp` (`plan_apply/paths.rs`), so
+    /// auto-apply reported the whole plan "applied" while the app-owned
+    /// project marker file was never written to disk. Proves the marker is a
+    /// real file with the correct project id — not just that the executor
+    /// was invoked — and that its own durable `audit_log_entry` row exists
+    /// (constitution §II: an audit record per attempted action and outcome).
+    #[tokio::test]
+    async fn create_auto_apply_writes_project_marker_to_disk_with_audit() {
+        let (db, bus) = setup().await;
+        let root = tempfile::tempdir().unwrap();
+        let project_path = format!("{}/ngc7000", root.path().to_str().unwrap());
+
+        let result = create(db.pool(), &bus, &empty_cache(), &make_req("NGC 7000", &project_path))
+            .await
+            .unwrap();
+
+        assert_eq!(result.scaffold_applied, Some(true), "mkdir + marker plan must auto-apply");
+
+        let marker_path = format!("{project_path}/.astro-plan-project.json");
+        let marker_content = std::fs::read_to_string(&marker_path).unwrap_or_else(|e| {
+            panic!("project marker file must exist on disk at {marker_path}: {e}")
+        });
+        let parsed = project_structure::parse_marker(&marker_content)
+            .expect("marker file must be valid, versioned marker JSON");
+        assert_eq!(parsed.project_id, result.project_id, "marker must record the project's own id");
+
+        // The per-item audit trail (constitution §II) must cover the marker
+        // write specifically, not just the sibling mkdir items.
+        let plan_id = result.plan_id.expect("plan_id present");
+        let items = plans_repo::list_plan_items(db.pool(), &plan_id).await.unwrap();
+        let marker_item = items
+            .iter()
+            .find(|i| i.action == "write_manifest")
+            .expect("plan must contain the write_manifest item");
+
+        let (payload,): (String,) = sqlx::query_as(
+            "SELECT payload FROM audit_log_entry \
+             WHERE payload LIKE '%' || ? || '%' AND to_state = 'succeeded' LIMIT 1",
+        )
+        .bind(&marker_item.id)
+        .fetch_one(db.pool())
+        .await
+        .expect("a durable audit_log_entry row must record the write_manifest item's outcome");
+        assert!(payload.contains(&marker_item.id));
+    }
+
     /// Failure path: a file blocking a scaffolding folder makes the apply
     /// fail; create still succeeds, `scaffold_applied` is `Some(false)`, and
     /// the plan lands in the reviewable `failed` state.

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -10,6 +10,9 @@ path = "src/lib.rs"
 [dependencies]
 domain_core = { path = "../../domain/core" }
 fs_pathsafe = { path = "../pathsafe" }
+# write_manifest renders the app-owned project marker via the domain-owned
+# `render_marker` (astro-plan-l3y0) instead of duplicating its JSON shape here.
+project_structure = { path = "../../project/structure" }
 camino = { workspace = true }
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/fs/executor/src/ops/mod.rs
+++ b/crates/fs/executor/src/ops/mod.rs
@@ -20,6 +20,7 @@ pub mod move_op;
 pub mod path_gate;
 pub mod trash_op;
 pub mod volume_check;
+pub mod write_manifest_op;
 
 pub use archive_op::archive_file;
 pub use cas_check::{check_cas, CasSnapshot};
@@ -31,3 +32,4 @@ pub use move_op::move_file;
 pub use path_gate::{lexical_normalize, resolve_and_validate};
 pub use trash_op::trash_file;
 pub use volume_check::{available_space_bytes, recheck_disk_space, recheck_volume_available};
+pub use write_manifest_op::write_marker;

--- a/crates/fs/executor/src/ops/write_manifest_op.rs
+++ b/crates/fs/executor/src/ops/write_manifest_op.rs
@@ -1,0 +1,134 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! App-owned project marker writer for `write_manifest` plan items
+//! (astro-plan-l3y0).
+//!
+//! Renders the marker via `project_structure::render_marker` and writes it to
+//! the plan item's destination path. Idempotent when a file with identical
+//! content already exists (safe re-apply/retry); any other pre-existing entry
+//! is a `conflict.destination_exists` failure — constitution §II: never
+//! overwrite silently.
+
+use camino::Utf8Path;
+
+use crate::failure::{FailureCode, PlanItemFailure};
+
+/// Write the project marker for `project_id` at `destination`.
+///
+/// # Errors
+///
+/// Returns a [`PlanItemFailure`] when `project_id` is empty (the plan item
+/// was not linked to a project), the destination is occupied by a
+/// non-identical file or non-file entry, or the write fails at the OS level.
+pub fn write_marker(destination: &Utf8Path, project_id: &str) -> Result<(), PlanItemFailure> {
+    if project_id.trim().is_empty() {
+        return Err(PlanItemFailure::with_code(
+            FailureCode::PathInvalid,
+            format!("write_manifest item for {destination} has no linked project id"),
+        ));
+    }
+
+    let content = project_structure::render_marker(project_id);
+
+    if destination.exists() {
+        if !destination.is_file() {
+            return Err(PlanItemFailure::with_code(
+                FailureCode::ConflictDestinationExists,
+                format!("destination exists and is not a file; cannot write marker: {destination}"),
+            ));
+        }
+        return match std::fs::read_to_string(destination) {
+            Ok(existing) if existing == content => Ok(()),
+            Ok(_) => Err(PlanItemFailure::with_code(
+                FailureCode::ConflictDestinationExists,
+                format!("marker file already exists with different content: {destination}"),
+            )),
+            Err(e) => {
+                Err(PlanItemFailure::from_io(&e, &format!("read existing marker {destination}")))
+            }
+        };
+    }
+
+    if let Some(parent) = destination.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| {
+            PlanItemFailure::from_io(
+                &e,
+                &format!("create parent directory for marker {destination}"),
+            )
+        })?;
+    }
+
+    std::fs::write(destination, content.as_bytes())
+        .map_err(|e| PlanItemFailure::from_io(&e, &format!("write marker {destination}")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+
+    fn utf8_tempdir() -> (tempfile::TempDir, Utf8PathBuf) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        (dir, path)
+    }
+
+    #[test]
+    fn writes_marker_file_to_disk() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        write_marker(&dest, "proj-123").expect("write must succeed");
+        assert!(dest.is_file());
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert!(content.contains("proj-123"));
+        assert!(content.contains("\"version\""));
+    }
+
+    #[test]
+    fn creates_missing_parent_directories() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join("proj/nested").join(".astro-plan-project.json");
+        write_marker(&dest, "proj-nested").expect("write must succeed");
+        assert!(dest.is_file());
+    }
+
+    #[test]
+    fn identical_content_is_idempotent() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        write_marker(&dest, "proj-123").unwrap();
+        write_marker(&dest, "proj-123").expect("re-apply with identical content must succeed");
+    }
+
+    #[test]
+    fn differing_content_is_a_conflict_and_does_not_overwrite() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        write_marker(&dest, "proj-123").unwrap();
+        let failure =
+            write_marker(&dest, "proj-456").expect_err("differing project id must be refused");
+        assert_eq!(failure.code, FailureCode::ConflictDestinationExists);
+        // Never overwrite silently — original content is untouched.
+        let content = std::fs::read_to_string(&dest).unwrap();
+        assert!(content.contains("proj-123"));
+    }
+
+    #[test]
+    fn directory_at_destination_is_a_conflict() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        std::fs::create_dir(&dest).unwrap();
+        let failure = write_marker(&dest, "proj-123").expect_err("directory must be refused");
+        assert_eq!(failure.code, FailureCode::ConflictDestinationExists);
+    }
+
+    #[test]
+    fn empty_project_id_is_rejected() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        let failure = write_marker(&dest, "").expect_err("empty project id must be refused");
+        assert_eq!(failure.code, FailureCode::PathInvalid);
+        assert!(!dest.exists());
+    }
+}

--- a/crates/fs/executor/src/run/dispatch.rs
+++ b/crates/fs/executor/src/run/dispatch.rs
@@ -15,6 +15,7 @@ use crate::ops::mkdir_op;
 use crate::ops::move_op;
 use crate::ops::path_gate;
 use crate::ops::trash_op;
+use crate::ops::write_manifest_op;
 
 use super::{ExecutorItem, ExecutorItemAction};
 
@@ -81,6 +82,12 @@ pub(super) fn execute_item(item: &ExecutorItem) -> Result<(), OpError> {
             let src = require_resolved_path(resolved_src.as_deref(), "source")?;
             let dst = require_resolved_path(resolved_dst.as_deref(), "destination")?;
             link_op::create_link(src, dst, *kind)
+                .map_err(|f| (f, false, RollbackOutcome::NotApplicable, None))
+        }
+
+        ExecutorItemAction::WriteManifest { project_id } => {
+            let dst = require_resolved_path(resolved_dst.as_deref(), "destination")?;
+            write_manifest_op::write_marker(dst, project_id)
                 .map_err(|f| (f, false, RollbackOutcome::NotApplicable, None))
         }
     }

--- a/crates/fs/executor/src/run/mod.rs
+++ b/crates/fs/executor/src/run/mod.rs
@@ -220,7 +220,16 @@ pub enum ExecutorItemAction {
     Link {
         kind: domain_core::source_view::Materialization,
     },
-    /// RecordOnly / WriteManifest — no FS mutation; mark succeeded.
+    /// Write the app-owned project marker file (spec 008 F-1, astro-plan-l3y0).
+    ///
+    /// Destination-only (no source). `project_id` is the plan item's
+    /// `linked_entity`; the executor refuses (rather than guesses) when it is
+    /// absent. Idempotent when the destination already holds identical
+    /// content — see `ops::write_manifest_op`.
+    WriteManifest {
+        project_id: String,
+    },
+    /// RecordOnly — no FS mutation; mark succeeded.
     NoOp,
 }
 


### PR DESCRIPTION
## Summary
- Fixed project creation silently skipping the folder marker file: new project folders weren't stamped with `.astro-plan-project.json`, so they couldn't be recognized as app-managed after a move or drive remap. The marker is now actually written to disk, with an audit record for the write.

## Test plan

- [x] `cargo check --workspace`
- [x] Added a test that fails without the fix and passes with it: `create_auto_apply_writes_project_marker_to_disk_with_audit` in `crates/app/core/src/project_create.rs` — asserts the marker file exists on disk with the correct project id, and that a durable audit record exists for the write. Verified red (stashed the fix, confirmed the exact "No such file" panic) then green.
- [x] Fixed a pre-existing test fixture gap surfaced by the stricter behavior: `auto_apply_creates_directories_for_mkdir_only_plan` fabricated a marker-write item with no linked project id; gave it one (mirroring production) and added an assertion that the marker file is actually written.
- [x] `cargo test -p fs_executor -p project_structure -p app_core_projects -p app_core` — 525 passed
- [x] `cargo clippy -p fs_executor -p project_structure -p app_core_projects -p app_core --all-targets -- -D warnings` — no issues
- [x] `cargo fmt --all -- --check` — clean

## Spec Context

Closes astro-plan-l3y0. Verified the bead's evidence directly against code before touching anything (`crates/app/core/src/plan_apply/paths.rs`, `crates/fs/executor/src/run/{mod,dispatch}.rs`, `crates/project/structure/src/lib.rs`) — it was accurate: `render_marker`/`parse_marker` had zero production callers, and the `write_manifest` action string fell through to `ExecutorItemAction::NoOp`.

No journey delta. Checked `docs/journeys/J05-project-lifecycle` and `docs/journeys/J14-target-first-project-start` (the two journeys covering project creation) — neither documents the marker file, and the happy-path user-visible outcome of creating a project (folders created, project appears in the app) is unchanged.