### PR TITLE
fix: give failed actions a retryable hint and name the field that caused them

### DIFF
--- a/crates/app/errors/src/lib.rs
+++ b/crates/app/errors/src/lib.rs
@@ -26,7 +26,24 @@
 //! byte-identical for every consumer.
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks
 
-use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity, RecoveryAction};
+
+/// The `retry` recovery action attached to every `retryable=true` error this
+/// crate produces (bd `astro-plan-qnj0`).
+///
+/// `label`/`description` are diagnostic fallback text, not translated copy —
+/// the same convention `ContractError.message` already uses (see
+/// `apps/desktop/src/lib/errors.ts` FR-009: raw backend strings are never
+/// shown to the user). A future UI (issue #930) resolves display text from
+/// `code` via an i18n catalog, mirroring how `ContractError.code` already
+/// drives `ERROR_MESSAGES` today.
+fn retry_action() -> RecoveryAction {
+    RecoveryAction {
+        code: "retry".to_owned(),
+        label: "Retry the operation".to_owned(),
+        description: None,
+    }
+}
 
 /// Convert a `sqlx::Error` inline (command-handler shorthand).
 ///
@@ -65,6 +82,7 @@ where
         ErrorSeverity::Fatal,
         true,
     )
+    .with_recovery_action(retry_action())
 }
 
 /// Canonical generic `DbError` → `ContractError` mapper (US11 T142).
@@ -101,7 +119,8 @@ pub fn db_err(e: persistence_db::DbError) -> ContractError {
             format!("{other}"),
             ErrorSeverity::Fatal,
             true,
-        ),
+        )
+        .with_recovery_action(retry_action()),
     }
 }
 
@@ -121,6 +140,51 @@ pub fn db_to_contract(e: persistence_db::DbError) -> ContractError {
 #[allow(clippy::needless_pass_by_value)]
 pub fn bus_err(e: audit::bus::BusError) -> ContractError {
     ContractError::new(ErrorCode::InternalAudit, format!("{e}"), ErrorSeverity::Fatal, true)
+        .with_recovery_action(retry_action())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// bd `astro-plan-qnj0`: every `retryable=true` error this crate produces
+    /// must carry a `recovery_actions` entry — before this change all three
+    /// mappers hardcoded `Vec::new()` via `ContractError::new`.
+    #[test]
+    fn db_err_fatal_branch_carries_retry_action() {
+        let err = db_err(persistence_db::DbError::CasFailed("stale version".to_owned()));
+        assert!(err.retryable);
+        assert_eq!(err.recovery_actions.len(), 1);
+        assert_eq!(err.recovery_actions[0].code, "retry");
+    }
+
+    /// `NotFound` stays `Blocking`/non-retryable and has no generic recovery
+    /// action to offer (the caller must supply a different reference) — this
+    /// path is intentionally left empty, not an oversight.
+    #[test]
+    fn db_err_not_found_branch_has_no_recovery_action() {
+        let err = db_err(persistence_db::DbError::NotFound("widget 1".to_owned()));
+        assert!(!err.retryable);
+        assert!(err.recovery_actions.is_empty());
+    }
+
+    #[test]
+    fn db_internal_ctx_carries_retry_action() {
+        let src = persistence_db::DbError::CasFailed("stale version".to_owned());
+        let err = db_internal_ctx(src, "insert widget");
+        assert_eq!(err.recovery_actions.len(), 1);
+        assert_eq!(err.recovery_actions[0].code, "retry");
+    }
+
+    #[test]
+    fn bus_err_carries_retry_action() {
+        let src = audit::bus::BusError::Database(persistence_db::DbError::CasFailed(
+            "stale version".to_owned(),
+        ));
+        let err = bus_err(src);
+        assert_eq!(err.recovery_actions.len(), 1);
+        assert_eq!(err.recovery_actions[0].code, "retry");
+    }
 }
 
 // NOTE (US11 T142): a `From<persistence_db::DbError> for ContractError` impl is

--- a/crates/app/projects/src/project_setup/create.rs
+++ b/crates/app/projects/src/project_setup/create.rs
@@ -49,12 +49,14 @@ async fn anchor_project_path(pool: &SqlitePool, raw: &str) -> Result<String, Con
     let candidate = std::path::Path::new(trimmed);
 
     if candidate.components().any(|c| matches!(c, std::path::Component::ParentDir)) {
+        let message = "Project path must not contain '..' components.";
         return Err(ContractError::new(
             ErrorCode::PathInvalid,
-            "Project path must not contain '..' components.",
+            message,
             ErrorSeverity::Blocking,
             false,
-        ));
+        )
+        .with_field_error(super::field_error("path", ErrorCode::PathInvalid, message)));
     }
 
     if candidate.is_absolute() {
@@ -69,13 +71,15 @@ async fn anchor_project_path(pool: &SqlitePool, raw: &str) -> Result<String, Con
         .map(|s| s.path);
 
     let Some(root) = project_root else {
+        let message = "Project path is relative and no project folder is registered; \
+             register a project folder in setup or provide an absolute path.";
         return Err(ContractError::new(
             ErrorCode::PathInvalid,
-            "Project path is relative and no project folder is registered; \
-             register a project folder in setup or provide an absolute path.",
+            message,
             ErrorSeverity::Blocking,
             false,
-        ));
+        )
+        .with_field_error(super::field_error("path", ErrorCode::PathInvalid, message)));
     };
 
     // Join with '/' (valid on all supported platforms); strip trailing
@@ -169,41 +173,41 @@ pub async fn create(
 ) -> Result<ProjectCreateResult, ContractError> {
     // 1. Validate name.
     validate_name(&req.name).map_err(|code| {
-        ContractError::new(
-            str_to_error_code(code),
-            format!("Project name error: {code}"),
-            ErrorSeverity::Blocking,
-            false,
-        )
+        let error_code = str_to_error_code(code);
+        let message = format!("Project name error: {code}");
+        ContractError::new(error_code, message.clone(), ErrorSeverity::Blocking, false)
+            .with_field_error(super::field_error("name", error_code, message))
     })?;
     validate_tool(req.tool.as_db_str()).map_err(|code| {
-        ContractError::new(
-            str_to_error_code(code),
-            format!("Processing tool error: {code}"),
-            ErrorSeverity::Blocking,
-            false,
-        )
+        let error_code = str_to_error_code(code);
+        let message = format!("Processing tool error: {code}");
+        ContractError::new(error_code, message.clone(), ErrorSeverity::Blocking, false)
+            .with_field_error(super::field_error("tool", error_code, message))
     })?;
 
     // 2. Check name uniqueness.
     if let Some(conflict_id) = repo::name_exists(pool, &req.name, None).await.map_err(db_err)? {
+        let message = "A project with this name already exists.";
         return Err(ContractError::new(
             ErrorCode::NameDuplicate,
-            "A project with this name already exists.",
+            message,
             ErrorSeverity::Blocking,
             false,
         )
+        .with_field_error(super::field_error("name", ErrorCode::NameDuplicate, message))
         .with_details(serde_json::json!({ "conflictingProjectId": conflict_id })));
     }
 
     // 3. Validate path non-empty.
     if req.path.trim().is_empty() {
+        let message = "Project path must not be empty.";
         return Err(ContractError::new(
             ErrorCode::PathInvalid,
-            "Project path must not be empty.",
+            message,
             ErrorSeverity::Blocking,
             false,
-        ));
+        )
+        .with_field_error(super::field_error("path", ErrorCode::PathInvalid, message)));
     }
 
     // 3b. Anchor a relative path to the registered project folder so the
@@ -212,12 +216,14 @@ pub async fn create(
 
     // 4. Check path uniqueness (on the anchored path).
     if let Some(collide_id) = repo::path_exists(pool, &project_path, None).await.map_err(db_err)? {
+        let message = "Another project already uses this path.";
         return Err(ContractError::new(
             ErrorCode::PathCollision,
-            "Another project already uses this path.",
+            message,
             ErrorSeverity::Blocking,
             false,
         )
+        .with_field_error(super::field_error("path", ErrorCode::PathCollision, message))
         .with_details(serde_json::json!({ "collidingProjectId": collide_id })));
     }
 

--- a/crates/app/projects/src/project_setup/mod.rs
+++ b/crates/app/projects/src/project_setup/mod.rs
@@ -39,7 +39,7 @@
 //! via `super::`.
 
 use contracts_core::projects_v2::ProjectChannelDto;
-use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity};
+use contracts_core::{error_code::ErrorCode, ContractError, ErrorSeverity, FieldError};
 use domain_core::project::channels::{infer_channels, Channel};
 use persistence_db::repositories::projects as repo;
 use persistence_db::repositories::q_core;
@@ -76,6 +76,20 @@ fn str_to_error_code(code: &str) -> ErrorCode {
             ErrorCode::InternalData
         }
     }
+}
+
+/// Build a `FieldError` naming the specific request field a validation
+/// failure belongs to (bd `astro-plan-qnj0`).
+///
+/// `code` is derived from `error_code`'s own wire string via serde rather
+/// than a second hardcoded literal, so it cannot drift from the
+/// `#[serde(rename = "...")]` on the `ErrorCode` variant.
+fn field_error(field: &str, error_code: ErrorCode, message: impl Into<String>) -> FieldError {
+    let code = serde_json::to_value(error_code)
+        .ok()
+        .and_then(|v| v.as_str().map(str::to_owned))
+        .unwrap_or_default();
+    FieldError { field: field.to_owned(), code, message: message.into() }
 }
 
 fn db_err(e: persistence_db::DbError) -> ContractError {

--- a/crates/app/projects/src/project_setup/tests.rs
+++ b/crates/app/projects/src/project_setup/tests.rs
@@ -142,6 +142,11 @@ async fn create_project_duplicate_name_rejected() {
     let req2 = ProjectCreateRequest { path: "projects/other".to_owned(), ..req };
     let err = create(&pool, &bus, &empty_cache(), &req2).await.unwrap_err();
     assert_eq!(err.code, ErrorCode::NameDuplicate);
+    // bd astro-plan-qnj0: field_errors must name the offending request field,
+    // not stay permanently empty.
+    assert_eq!(err.field_errors.len(), 1);
+    assert_eq!(err.field_errors[0].field, "name");
+    assert_eq!(err.field_errors[0].code, "name.duplicate");
 }
 
 #[tokio::test]
@@ -152,6 +157,9 @@ async fn create_project_duplicate_path_rejected() {
     let req2 = ProjectCreateRequest { name: "Other Name".to_owned(), ..req };
     let err = create(&pool, &bus, &empty_cache(), &req2).await.unwrap_err();
     assert_eq!(err.code, ErrorCode::PathCollision);
+    assert_eq!(err.field_errors.len(), 1);
+    assert_eq!(err.field_errors[0].field, "path");
+    assert_eq!(err.field_errors[0].code, "path.collision");
 }
 
 // ── Constitution I: path anchoring tests ──────────────────────────────────
@@ -236,6 +244,9 @@ async fn create_parent_dir_components_rejected() {
     };
     let err = create(&pool, &bus, &empty_cache(), &req).await.unwrap_err();
     assert_eq!(err.code, ErrorCode::PathInvalid);
+    assert_eq!(err.field_errors.len(), 1);
+    assert_eq!(err.field_errors[0].field, "path");
+    assert_eq!(err.field_errors[0].code, "path.invalid");
 }
 
 #[tokio::test]
@@ -244,6 +255,9 @@ async fn create_project_empty_name_rejected() {
     let req = make_create_req("", ProjectTool::PixInsight);
     let err = create(&pool, &bus, &empty_cache(), &req).await.unwrap_err();
     assert_eq!(err.code, ErrorCode::NameEmpty);
+    assert_eq!(err.field_errors.len(), 1);
+    assert_eq!(err.field_errors[0].field, "name");
+    assert_eq!(err.field_errors[0].code, "name.empty");
 }
 
 #[tokio::test]

--- a/crates/app/projects/src/project_setup/update.rs
+++ b/crates/app/projects/src/project_setup/update.rs
@@ -73,22 +73,22 @@ pub async fn update(
     // Validate new name if changing.
     if let Some(new_name) = &req.name {
         validate_name(new_name).map_err(|code| {
-            ContractError::new(
-                str_to_error_code(code),
-                format!("Name error: {code}"),
-                ErrorSeverity::Blocking,
-                false,
-            )
+            let error_code = str_to_error_code(code);
+            let message = format!("Name error: {code}");
+            ContractError::new(error_code, message.clone(), ErrorSeverity::Blocking, false)
+                .with_field_error(super::field_error("name", error_code, message))
         })?;
         if let Some(conflict_id) =
             repo::name_exists(pool, new_name, Some(&req.project_id)).await.map_err(db_err)?
         {
+            let message = "A project with this name already exists.";
             return Err(ContractError::new(
                 ErrorCode::NameDuplicate,
-                "A project with this name already exists.",
+                message,
                 ErrorSeverity::Blocking,
                 false,
             )
+            .with_field_error(super::field_error("name", ErrorCode::NameDuplicate, message))
             .with_details(serde_json::json!({ "conflictingProjectId": conflict_id })));
         }
     }


### PR DESCRIPTION
## Summary

- `ContractError.field_errors` and `recovery_actions` were modeled end to end (builders, wire schema, TS bindings) but every construction site left them empty (bd `astro-plan-qnj0`).
- The three canonical database/audit error mappers (`crates/app/errors/src/lib.rs`: `db_err`, `db_internal_ctx`, `bus_err`) now attach a `retry` recovery action whenever `retryable=true`.
- Project create/update name, tool, and path validation failures (`crates/app/projects/src/project_setup/{create,update,mod}.rs`) now attach a `FieldError` naming which request field was invalid.
- No struct/schema changes and no new error codes — `just check-generated` confirms the generated bindings are untouched.

## Design note

`RecoveryAction.label`/`FieldError.message` carry backend diagnostic text, not translated copy — the same convention `ContractError.message` already uses (`apps/desktop/src/lib/errors.ts`, FR-009: raw backend strings are never shown to the user; only `code` drives the displayed message, via `ERROR_MESSAGES`). No frontend code currently reads `field_errors`/`recovery_actions` (`apps/desktop/src/api/ipc.ts` still validates them as `z.array(z.unknown()).optional()`), so this PR adds no i18n catalogue strings and doesn't widen the `pt-BR` gap. UI rendering + i18n-keyed display text is the separately tracked issue #930.

## #1048 overlap

Draft PR #1048 (spec-056 onboarding) touches `crates/contracts/core/src/lib.rs` and `crates/app/core/src/lib.rs`, which this lane's target files also live under structurally. Checked via `gh pr diff 1048 --name-only` and diffed the actual hunks: #1048's changes to both files are confined to `pub mod` declaration lines near the top (removing `guided`/`guided_flow`, adding `onboarding`). This PR does not touch either `lib.rs` at all — it only calls the existing `with_field_error`/`with_recovery_action` builders from `crates/app/errors` and `crates/app/projects`. No line-level overlap; nothing to reconcile on merge.

## Journey

No delta. J12 (`docs/journeys/J12-failure-refusal-handling`) describes the currently-rendered toast/dialog/audit-log surfaces, all driven by `ContractError.code` → `ERROR_MESSAGES`. This PR only populates wire-payload fields with zero frontend consumers, so no J12 step's observed behavior changes.

## Test plan
- [x] `cargo check --workspace` — clean
- [x] `just check-generated` — exit 0, no binding drift
- [x] `cargo test -p app_core_errors -p app_core_projects` — 97+93 passed, including new tests proving `recovery_actions`/`field_errors` are non-empty at the touched sites (fail against pre-change code, which hardcoded `Vec::new()`)
- [x] `cargo clippy -p app_core_errors -p app_core_projects --all-targets -- -D warnings` — no issues