### PR TITLE
refactor: move the first-run Setup wizard's Scan and Tools steps onto TanStack Query

### DIFF
--- a/apps/desktop/src/features/setup/SetupWizard.test.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.test.tsx
@@ -25,6 +25,15 @@ import {
   act,
 } from '@testing-library/react';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { queryClient } from '@/data/queryClient';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
 
 // ---------------------------------------------------------------------------
 // Hoisted mock state — vi.hoisted runs BEFORE vi.mock factories, so
@@ -184,7 +193,7 @@ const WIZARD_STORAGE_KEY = 'alm-setup-wizard-state';
 
 /** Render the wizard and return the result. */
 function renderWizard() {
-  return render(<SetupWizard />);
+  return render(<SetupWizard />, { wrapper });
 }
 
 /**
@@ -199,7 +208,7 @@ function renderWizardAtSources() {
     WIZARD_STORAGE_KEY,
     JSON.stringify({ currentStep: 1 }),
   );
-  return render(<SetupWizard />);
+  return render(<SetupWizard />, { wrapper });
 }
 
 /**
@@ -261,6 +270,7 @@ beforeEach(() => {
   // Clear all wizard and preference state between tests.
   window.localStorage.clear();
   mockPickDirectory.mockReset();
+  queryClient.clear();
 });
 
 // ---------------------------------------------------------------------------

--- a/apps/desktop/src/features/setup/steps/StepScan.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.test.tsx
@@ -24,6 +24,15 @@ import {
   within,
 } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { queryClient } from '@/data/queryClient';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
 
 // ── Hoisted mocks ────────────────────────────────────────────────────────────
 
@@ -190,6 +199,7 @@ function renderStep(overrides: Partial<StepScanProps> = {}) {
       onAllDoneChange={onAllDoneChange}
       {...overrides}
     />,
+    { wrapper },
   );
 }
 
@@ -206,6 +216,10 @@ beforeEach(() => {
   mockInboxScanFolder.mockReset();
   mockInboxClassify.mockReset();
   mockRootsList.mockReset();
+  // Query cache is keyed per source path/rootId; several tests reuse the same
+  // fixture paths with different mock responses, so a stale cache entry from
+  // a prior test would otherwise leak in as fresh data.
+  queryClient.clear();
 });
 
 describe('StepScan', () => {

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -7,7 +7,8 @@
 // inbox_classify per source, showing per-source progress and a detection
 // summary.  Approval stays in the Inbox — no inbox_confirm called here.
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
+import { useQueries, useQuery } from '@tanstack/react-query';
 import { Pill } from '@/ui/Pill';
 import type { PillVariant } from '@/ui/Pill';
 import { Table } from '@/ui';
@@ -338,6 +339,75 @@ function SourceSummary({ state }: SourceSummaryProps) {
   );
 }
 
+// One scan+classify pass for a single source. Classify failures are captured
+// per-item (never thrown) so one bad folder doesn't fail the whole query —
+// only a `scanFolder` failure itself surfaces as the query's error.
+async function scanAndClassify(
+  rootId: string,
+  rootAbsolutePath: string,
+): Promise<{
+  items: InboxItemSummary[];
+  classifications: Map<string, InboxClassifyResponse>;
+  classifyFailures: Set<string>;
+}> {
+  const scanResponse = unwrap(
+    await commands.inboxScanFolder({ rootId, rootAbsolutePath }),
+  );
+  const items = scanResponse.items ?? [];
+
+  const classifications = new Map<string, InboxClassifyResponse>();
+  const classifyFailures = new Set<string>();
+  await Promise.allSettled(
+    items.map(async (item) => {
+      try {
+        const cls = unwrap(
+          await commands.inboxClassify({
+            inboxItemId: item.inboxItemId,
+            rootAbsolutePath,
+          }),
+        );
+        classifications.set(item.inboxItemId, cls);
+      } catch {
+        // Don't abort the whole scan for one item — but do record it.
+        // Swallowing it entirely made a crash look like a clean "nothing
+        // detected" result.
+        classifyFailures.add(item.inboxItemId);
+      }
+    }),
+  );
+  return { items, classifications, classifyFailures };
+}
+
+/** A source resolved to a real backend root, ready to scan+classify. */
+interface ScanRenderTarget {
+  source: SourceEntry;
+  rootId: string;
+  kind: 'scan';
+}
+/** A source whose already-scanned status couldn't be resolved (roots.list
+ * failed or returned no match) — surfaced as a static error, never scanned. */
+interface ResolutionErrorRenderTarget {
+  source: SourceEntry;
+  rootId: string;
+  kind: 'resolution-error';
+}
+type RenderTarget = ScanRenderTarget | ResolutionErrorRenderTarget;
+
+function isScanTarget(t: RenderTarget): t is ScanRenderTarget {
+  return t.kind === 'scan';
+}
+
+/** Map a `useQueries` result onto the same phase vocabulary the (still
+ * hand-rolled) `pending`/`scanning` display states used. */
+function queryPhase(q: {
+  status: 'pending' | 'error' | 'success';
+  fetchStatus: 'fetching' | 'paused' | 'idle';
+}): ScanPhase {
+  if (q.status === 'success') return 'done';
+  if (q.status === 'error') return 'error';
+  return q.fetchStatus === 'fetching' ? 'scanning' : 'pending';
+}
+
 // ── StepScan ─────────────────────────────────────────────────────────────────
 
 /**
@@ -350,221 +420,152 @@ function SourceSummary({ state }: SourceSummaryProps) {
  * Back and Finish buttons are rendered by the shared WizardShell footer in
  * SetupWizard.  StepScan notifies the parent of scan completion via
  * `onAllDoneChange` so the footer can enable/disable the Finish button.
+ *
+ * TanStack Query (#615/#630) replaces the former manual `cancelled`-flag
+ * orchestration. Query-cache identity (keyed per source) is what now protects
+ * against React StrictMode's mount→cleanup→remount double-invoke: the
+ * remounted observer subscribes to the SAME in-flight/cached query instead of
+ * starting a second scan, which is what a re-entry ref-guard was trying (and
+ * failing) to achieve by hand — see git history for that bug.
  */
 export function StepScan({
   sources,
   flushResult,
   onAllDoneChange,
 }: StepScanProps) {
-  const [sourceStates, setSourceStates] = useState<SourceScanState[]>([]);
-  // The alreadyRegistered resolution (roots.list) below is async, so
-  // sourceStates starts empty even when there is work to do — an empty array
-  // vacuously satisfies `.every()`, which would otherwise make `allDone`
-  // (below) briefly report true before scanning has even been set up. Gate
-  // on this instead of sourceStates.length so the transient empty state
-  // isn't mistaken for "nothing to scan".
-  const [resolved, setResolved] = useState(false);
-
-  useEffect(() => {
-    // No re-entry ref-guard here (there was one; removed — see git history):
-    // combined with the per-invocation `cancelled` flag below, it defeated
-    // React StrictMode's mount→cleanup→remount cycle. The guard let the
-    // first invocation's async scan keep running while marking it
-    // `cancelled` on the synthetic cleanup, then the remounted second
-    // invocation no-opped (guard already tripped) instead of starting a
-    // fresh, uncancelled scan — so no invocation ever delivered a result and
-    // every source stayed stuck on "scanning" forever. `[]` deps already
-    // guarantee this effect runs once per real mount; the `cancelled` flag
-    // below is the standard, StrictMode-safe way to discard a stale
-    // in-flight scan from a genuine unmount without needing a ref guard.
-
-    // The scan fans out into one independent async branch per source, each
-    // outliving the others. Any of them can still be awaiting IPC when the
-    // wizard unmounts, so every `setState` below is gated on this flag —
-    // otherwise a late update lands on a torn-down root (and, under vitest,
-    // after jsdom has removed `window`, failing the whole run).
-    let cancelled = false;
-
-    void (async () => {
-      // Issue #916: a wizard retry after a partial batch-registration
-      // failure resubmits *every* source, not just the ones that failed. A
-      // source that registered successfully on an earlier attempt in this
-      // same session therefore comes back from flushToDB as
-      // `alreadyRegistered` (duplicate) on the retry — the exact same shape
-      // a genuinely-already-scanned restart-flow source has (issue #704).
-      // flushResult alone can't tell the two apart: one has already been
-      // scanned and is safe to skip, the other has never been scanned and
-      // must not be dropped. Resolve the real root via roots.list and use
-      // its `lastScanned` (only set once inbox.scan_folder has actually run
-      // for that root — see roots.rs) as the ground truth.
-      const needsResolution = sources.filter((s) => {
+  // Issue #916: a wizard retry after a partial batch-registration failure
+  // resubmits *every* source, not just the ones that failed. A source that
+  // registered successfully on an earlier attempt in this same session
+  // therefore comes back from flushToDB as `alreadyRegistered` (duplicate) on
+  // the retry — the exact same shape a genuinely-already-scanned
+  // restart-flow source has (issue #704). flushResult alone can't tell the
+  // two apart: one has already been scanned and is safe to skip, the other
+  // has never been scanned and must not be dropped. Resolve the real root via
+  // roots.list and use its `lastScanned` (only set once inbox.scan_folder has
+  // actually run for that root — see roots.rs) as the ground truth.
+  const needsResolution = useMemo(
+    () =>
+      sources.filter((s) => {
         if (!s.path) return false;
         const row = flushResult.results.find((r) => r.path === s.path);
         return row?.alreadyRegistered ?? false;
+      }),
+    [sources, flushResult],
+  );
+
+  const rootsResolveQuery = useQuery({
+    queryKey: ['setup', 'rootsResolve'] as const,
+    queryFn: async () => unwrap(await commands.rootsList()),
+    enabled: needsResolution.length > 0,
+    retry: false,
+  });
+
+  const resolvedRoots = useMemo(() => {
+    const map = new Map<string, { id: string; lastScanned: string | null }>();
+    for (const root of rootsResolveQuery.data ?? []) {
+      map.set(root.path, {
+        id: root.id,
+        lastScanned: root.lastScanned ?? null,
       });
+    }
+    return map;
+  }, [rootsResolveQuery.data]);
 
-      const resolvedRoots = new Map<
-        string,
-        { id: string; lastScanned: string | null }
-      >();
-      if (needsResolution.length > 0) {
-        try {
-          const roots = unwrap(await commands.rootsList());
-          for (const root of roots) {
-            resolvedRoots.set(root.path, {
-              id: root.id,
-              lastScanned: root.lastScanned ?? null,
-            });
-          }
-        } catch {
-          // Best-effort: an unresolved lookup falls through to the
-          // conservative default below (skip — matches prior behaviour).
-        }
-      }
+  // Mirrors the former `resolved` flag: true once the alreadyRegistered
+  // resolution has settled (success or failure) or was never needed.
+  const resolutionReady =
+    needsResolution.length === 0 || rootsResolveQuery.isFetched;
 
-      // Issue #704 / #916: only scan folders this flush actually registered,
-      // or that a prior same-session attempt registered but never scanned. A
-      // root whose registration failed for a genuine reason (no rootId, not
-      // `alreadyRegistered`) is skipped — scanning it with the
-      // path-as-rootId fallback fails the registered_sources JOIN and would
-      // insert orphaned inbox_items.
-      const initialStates: SourceScanState[] = [];
-      for (const s of sources) {
-        if (!s.path) continue;
-        const row = flushResult.results.find((r) => r.path === s.path);
-        if (row?.success) {
-          initialStates.push({
-            source: s,
-            rootId: getRootId(flushResult, s.path),
-            phase: 'pending',
-            items: [],
-            classifications: new Map(),
-            classifyFailures: new Set(),
-          });
-          continue;
-        }
-        if (!row?.alreadyRegistered) continue;
-
-        const resolvedRoot = resolvedRoots.get(s.path);
-        if (resolvedRoot != null && resolvedRoot.lastScanned != null) {
-          // Genuinely already scanned in a prior session — safe to skip.
-          continue;
-        }
-        if (resolvedRoot != null) {
-          // Registered but never scanned (same-session retry) — rescan
-          // using the real resolved rootId.
-          initialStates.push({
-            source: s,
-            rootId: resolvedRoot.id,
-            phase: 'pending',
-            items: [],
-            classifications: new Map(),
-            classifyFailures: new Set(),
-          });
-          continue;
-        }
-        // Review round 2 #1: roots.list failed or returned no match for this
-        // path — we can't tell whether this source was already scanned.
-        // Silently excluding it here would resurrect the exact #916 bug via
-        // a resolution failure instead of a misclassification, so surface it
-        // as a visible error state instead of dropping it.
-        initialStates.push({
+  // Issue #704 / #916: only scan folders this flush actually registered, or
+  // that a prior same-session attempt registered but never scanned. A root
+  // whose registration failed for a genuine reason (no rootId, not
+  // `alreadyRegistered`) is skipped — scanning it with the path-as-rootId
+  // fallback fails the registered_sources JOIN and would insert orphaned
+  // inbox_items. A source genuinely already scanned in a prior session is
+  // skipped entirely (not rendered at all), matching the prior behaviour.
+  const renderTargets = useMemo((): RenderTarget[] | undefined => {
+    if (!resolutionReady) return undefined;
+    const out: RenderTarget[] = [];
+    for (const s of sources) {
+      if (!s.path) continue;
+      const row = flushResult.results.find((r) => r.path === s.path);
+      if (row?.success) {
+        out.push({
           source: s,
-          rootId: s.path,
+          rootId: getRootId(flushResult, s.path),
+          kind: 'scan',
+        });
+        continue;
+      }
+      if (!row?.alreadyRegistered) continue;
+
+      const resolvedRoot = resolvedRoots.get(s.path);
+      if (resolvedRoot != null && resolvedRoot.lastScanned != null) {
+        continue; // genuinely already scanned — safe to skip
+      }
+      if (resolvedRoot != null) {
+        out.push({ source: s, rootId: resolvedRoot.id, kind: 'scan' });
+        continue;
+      }
+      // Review round 2 #1: roots.list failed or returned no match for this
+      // path — we can't tell whether this source was already scanned.
+      // Silently excluding it here would resurrect the exact #916 bug via a
+      // resolution failure instead of a misclassification, so surface it as
+      // a visible error state instead of dropping it.
+      out.push({ source: s, rootId: s.path, kind: 'resolution-error' });
+    }
+    return out;
+  }, [sources, flushResult, resolvedRoots, resolutionReady]);
+
+  const scanTargets = useMemo(
+    () => (renderTargets ?? []).filter(isScanTarget),
+    [renderTargets],
+  );
+
+  // One query per source (StrictMode-safe dedup via the shared query cache —
+  // see the StepScan doc comment above). `retry`/`refetchOnWindowFocus` are
+  // disabled: a scan is a one-shot wizard action, not a resource to silently
+  // re-fetch or retry behind the user's back.
+  const scanQueries = useQueries({
+    queries: scanTargets.map((t) => ({
+      queryKey: ['setup', 'scan', t.rootId, t.source.path] as const,
+      queryFn: () => scanAndClassify(t.rootId, t.source.path),
+      retry: false,
+      refetchOnWindowFocus: false,
+    })),
+  });
+
+  const sourceStates: SourceScanState[] = useMemo(() => {
+    const scanResultByPath = new Map(
+      scanTargets.map((t, i) => [t.source.path, scanQueries[i]]),
+    );
+    return (renderTargets ?? []).map((t): SourceScanState => {
+      if (t.kind === 'resolution-error') {
+        return {
+          source: t.source,
+          rootId: t.rootId,
           phase: 'error',
           items: [],
           classifications: new Map(),
           classifyFailures: new Set(),
           error: m.setup_scan_resolution_failed(),
-        });
+        };
       }
-
-      if (cancelled) return;
-      setSourceStates(initialStates);
-      setResolved(true);
-
-      // Scan each source independently; one failure doesn't abort others.
-      for (let i = 0; i < initialStates.length; i++) {
-        const idx = i;
-        const entry = initialStates[idx];
-        // Already flagged (resolution failure above) — nothing to scan.
-        if (entry.phase === 'error') continue;
-
-        void (async () => {
-          if (cancelled) return;
-          // Mark as scanning
-          setSourceStates((prev) => {
-            const next = [...prev];
-            next[idx] = { ...next[idx], phase: 'scanning' };
-            return next;
-          });
-
-          try {
-            // 1. Scan the folder
-            const scanResponse = unwrap(
-              await commands.inboxScanFolder({
-                rootId: entry.rootId,
-                rootAbsolutePath: entry.source.path,
-              }),
-            );
-
-            const items = scanResponse.items ?? [];
-
-            // 2. Classify each discovered item
-            const classifications = new Map<string, InboxClassifyResponse>();
-            const classifyFailures = new Set<string>();
-            await Promise.allSettled(
-              items.map(async (item) => {
-                try {
-                  const cls = unwrap(
-                    await commands.inboxClassify({
-                      inboxItemId: item.inboxItemId,
-                      rootAbsolutePath: entry.source.path,
-                    }),
-                  );
-                  classifications.set(item.inboxItemId, cls);
-                } catch {
-                  // Don't abort the whole scan for one item — but do record it.
-                  // Swallowing it entirely made a crash look like a clean
-                  // "nothing detected" result.
-                  classifyFailures.add(item.inboxItemId);
-                }
-              }),
-            );
-
-            if (cancelled) return;
-            setSourceStates((prev) => {
-              const next = [...prev];
-              next[idx] = {
-                ...next[idx],
-                phase: 'done',
-                items,
-                classifications,
-                classifyFailures,
-              };
-              return next;
-            });
-          } catch (err: unknown) {
-            if (cancelled) return;
-            setSourceStates((prev) => {
-              const next = [...prev];
-              next[idx] = {
-                ...next[idx],
-                phase: 'error',
-                error: errMessage(err),
-              };
-              return next;
-            });
-          }
-        })();
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
+      const q = scanResultByPath.get(t.source.path);
+      return {
+        source: t.source,
+        rootId: t.rootId,
+        phase: q ? queryPhase(q) : 'pending',
+        items: q?.data?.items ?? [],
+        classifications: q?.data?.classifications ?? new Map(),
+        classifyFailures: q?.data?.classifyFailures ?? new Set(),
+        error: q?.error ? errMessage(q.error) : undefined,
+      };
+    });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []); // intentionally empty: run once on mount
+  }, [renderTargets, scanTargets, scanQueries]);
 
+  const resolved = resolutionReady;
   const allDone =
     resolved &&
     sourceStates.every((s) => s.phase === 'done' || s.phase === 'error');

--- a/apps/desktop/src/features/setup/steps/StepTools.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepTools.test.tsx
@@ -11,6 +11,15 @@
 
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { QueryClientProvider } from '@tanstack/react-query';
+import type { ReactNode } from 'react';
+import { queryClient } from '@/data/queryClient';
+
+function wrapper({ children }: { children: ReactNode }) {
+  return (
+    <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+  );
+}
 
 const { mockPick, mockToolsDiscover } = vi.hoisted(() => ({
   mockPick: vi.fn(),
@@ -44,12 +53,15 @@ beforeEach(() => {
   mockPick.mockReset();
   mockToolsDiscover.mockReset();
   mockToolsDiscover.mockResolvedValue({ status: 'ok', data: { entries: [] } });
+  queryClient.clear();
 });
 
 function renderStep(tools: ToolsState, onToolsChange = vi.fn()) {
   return {
     onToolsChange,
-    ...render(<StepTools tools={tools} onToolsChange={onToolsChange} />),
+    ...render(<StepTools tools={tools} onToolsChange={onToolsChange} />, {
+      wrapper,
+    }),
   };
 }
 

--- a/apps/desktop/src/features/setup/steps/StepTools.tsx
+++ b/apps/desktop/src/features/setup/steps/StepTools.tsx
@@ -2,12 +2,14 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import { useEffect, useState } from 'react';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { RotateCw } from 'lucide-react';
 import { Btn } from '@/ui/Btn';
 import { Pill } from '@/ui/Pill';
 import { Toggle } from '@/ui/Toggle';
 import { m } from '@/lib/i18n';
 import { useFilePicker } from '@/shared/native/picker';
+import { unwrap } from '@/api/ipc';
 
 export interface ToolConfig {
   enabled: boolean;
@@ -74,40 +76,40 @@ function looksExecutable(path: string): boolean {
  * then lets the user toggle/override the executable path.
  */
 export function StepTools({ tools, onToolsChange }: StepToolsProps) {
-  // Auto-detect installed tools once on mount and fill in any unset paths.
+  // Auto-detect installed tools once on mount (TanStack Query dedups a
+  // StrictMode double-invoke via the shared query cache) and fill in any
+  // unset paths. Detection is best-effort (spec 011): a failed/disabled
+  // discovery just leaves `tools` unchanged, never surfaced as an error.
+  const discoveryQuery = useQuery({
+    queryKey: ['setup', 'toolsDiscover'] as const,
+    queryFn: async () => {
+      const { commands } = await import('@/bindings/index');
+      return unwrap(await commands.toolsDiscover({ toolId: null }));
+    },
+    enabled: import.meta.env.VITE_USE_MOCKS !== 'true',
+    retry: false,
+  });
+
   useEffect(() => {
-    if (import.meta.env.VITE_USE_MOCKS === 'true') return undefined;
-    let cancelled = false;
-    void (async () => {
-      try {
-        const { commands } = await import('@/bindings/index');
-        const res = await commands.toolsDiscover({ toolId: null });
-        if (cancelled || res.status !== 'ok') return;
-        const found = new Map(
-          res.data.entries
-            .filter((e) => e.available)
-            .map((e) => [e.toolId, e.path]),
-        );
-        let changed = false;
-        const next: ToolsState = { ...tools };
-        for (const def of TOOL_DEFS) {
-          const path = found.get(def.key);
-          if (path && !next[def.key].path) {
-            next[def.key] = { enabled: true, path };
-            changed = true;
-          }
-        }
-        if (changed) onToolsChange(next);
-      } catch {
-        // detection is best-effort; the user can still set paths manually.
+    const found = discoveryQuery.data;
+    if (!found) return;
+    const foundPaths = new Map(
+      found.entries.filter((e) => e.available).map((e) => [e.toolId, e.path]),
+    );
+    let changed = false;
+    const next: ToolsState = { ...tools };
+    for (const def of TOOL_DEFS) {
+      const path = foundPaths.get(def.key);
+      if (path && !next[def.key].path) {
+        next[def.key] = { enabled: true, path };
+        changed = true;
       }
-    })();
-    return () => {
-      cancelled = true;
-    };
-    // Run once on mount; merging only fills empty paths so re-runs are safe.
+    }
+    if (changed) onToolsChange(next);
+    // Fires once when discovery data lands; merging only fills empty paths so
+    // a StrictMode double-invoke re-running this with the same data is safe.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [discoveryQuery.data]);
 
   const handleToggle = (key: keyof ToolsState, checked: boolean) => {
     // Only flip `enabled`; keep the (detected or manually-set) path so disabling →
@@ -125,16 +127,20 @@ export function StepTools({ tools, onToolsChange }: StepToolsProps) {
     });
   };
 
-  // Re-run auto-detection for a single tool (the "Redetect" button). Returns
-  // true if a binary was found (and the path was filled in), false otherwise.
+  // Re-run auto-detection for a single tool (the "Redetect" button).
+  const redetectMutation = useMutation({
+    mutationFn: async (key: keyof ToolsState) => {
+      const { commands } = await import('@/bindings/index');
+      return unwrap(await commands.toolsDiscover({ toolId: key }));
+    },
+  });
+
+  // Returns true if a binary was found (and the path was filled in), false
+  // otherwise — ToolCard uses the result to show its "not found" message.
   const handleRedetect = async (key: keyof ToolsState): Promise<boolean> => {
     try {
-      const { commands } = await import('@/bindings/index');
-      const res = await commands.toolsDiscover({ toolId: key });
-      if (res.status !== 'ok') return false;
-      const entry = res.data.entries.find(
-        (e) => e.toolId === key && e.available,
-      );
+      const data = await redetectMutation.mutateAsync(key);
+      const entry = data.entries.find((e) => e.toolId === key && e.available);
       if (entry?.path) {
         onToolsChange({ ...tools, [key]: { enabled: true, path: entry.path } });
         return true;


### PR DESCRIPTION
## Summary
- Migrates `StepScan` (per-source `inbox_scan_folder` + `inbox_classify` fan-out) and `StepTools` (`tools.discover` auto-detect + per-tool redetect) off hand-rolled `useState`/`useEffect`/`cancelled`-flag orchestration, onto `useQuery`/`useQueries`/`useMutation` (issues #615/#630).
- `StepScan` uses `useQueries` — one query per source — matching the existing `useInboxPlanBreakdowns` convention in `features/inbox/store.ts` for the same "N independent per-item async results" shape.
- `SetupWizard.tsx` itself is untouched: its `useEffect`s are `localStorage` persistence and one-shot submit handlers on Finish, not read-resource fetches, so they don't fit this migration's scope.

## Landed-today context this PR builds on
- Merged `origin/main` before starting, picking up the just-shipped fix that removed `StepScan`'s re-entry ref-guard (it defeated React StrictMode's mount→cleanup→remount, permanently stranding the wizard on "Scanning…"). No re-entry guard is reintroduced here — query-cache identity is the replacement: a remounted observer subscribes to the same in-flight/cached query instead of starting a second scan, which is what the guard was trying (and failing) to achieve by hand.
- The wizard's Language step (spec 061, #1319) shifted every later step index; `SetupWizard.tsx` already routes every step reference through named constants (`SOURCES_STEP`, `SCAN_STEP`, etc.), and this PR doesn't touch step wiring, so no further index changes were needed. `SetupWizard.test.tsx` and `StepScan.test.tsx`/`StepTools.test.tsx` needed a `QueryClientProvider` wrapper (new dependency from this migration) but no step-index changes.

## Behaviour preserved
- Every `StepScan` branch — genuinely-already-scanned (skip, no card at all), same-session-retry `alreadyRegistered` (rescan with the resolved root), resolution failure (static error card, never scanned), scan/classify failure (per-item classify failures never abort the whole source) — is unchanged; covered by the pre-existing `StepScan.test.tsx` suite (30 tests) with no assertions weakened, only a `QueryClientProvider` wrapper + `queryClient.clear()` in `beforeEach` added (query cache is keyed per source path/rootId, and several tests reuse the same fixture paths with different mock responses per test).
- `StepTools`'s "only fill empty paths" merge-on-detect semantics and the Redetect button's "not found" messaging are unchanged.
- Deliberate, faithful (not "fixed") preservation: `retry: false` + `refetchOnWindowFocus: false` on the per-source scan queries, since the original was a strict one-shot action, never silently retried or re-triggered on window focus.
- New query keys (`['setup', 'rootsResolve']`, `['setup', 'scan', rootId, path]`, `['setup', 'toolsDiscover']`) are inline, not added to the shared `queryKeys.ts` factory — that file is claimed by the still-open, near-landing #1048, and inline keys already have precedent in this codebase (`useInboxReclassifyState.ts`).

## Journey conclusion
`docs/journeys/J01-first-run-setup-data-sources` (S7 Scan, S8 Finish) describes exactly the branches above at the behavioural level, not implementation detail. All of them are covered unchanged by the existing test suite. **No journey update — this is a pure refactor with no behaviour change.**

## Test plan
- [x] `pnpm typecheck` (apps/desktop) — clean.
- [x] `pnpm exec vitest run` — 2014/2014 passed (full desktop suite).
- [x] `pnpm --filter @astro-plan/desktop test:e2e` — 104 passed, 1 skipped, 0 failed (includes `setup_wizard_language_step.spec.ts`, `setup_wizard_site_step.spec.ts`).
- [x] `pnpm --filter @astro-plan/desktop run lint` — exit 0.

## Note: pre-existing, unrelated lint break on main
A clean `origin/main` checkout currently fails `pnpm --filter @astro-plan/desktop run lint` with 2 biome errors in `src/features/inbox/inboxDetailHelpers.ts` (unused import) and one other file, introduced by `6eaa086e19` (#1194, merged just before this branch was cut) — confirmed via `git blame` and by stashing this PR's changes and re-running lint against bare `origin/main`. Not touched by this PR; flagging for a separate fix.