### PR TITLE
refactor: drop an unused type import in the inbox detail helpers

### DIFF
--- a/apps/desktop/src/features/inbox/inboxDetailHelpers.ts
+++ b/apps/desktop/src/features/inbox/inboxDetailHelpers.ts
@@ -9,7 +9,6 @@
  */
 
 import type { PillVariant } from '@/ui';
-import type { InboxClassifyResponse } from './store';
 
 /**
  * Resolve an inbox item's reveal target: the source root joined with the


### PR DESCRIPTION
## Summary

- `InboxClassifyResponse` is imported in `apps/desktop/src/features/inbox/inboxDetailHelpers.ts` but never referenced — left behind when the inbox detail pane was split into per-surface modules (#1260, #1194).

## Scope note

This is **noise reduction, not a broken-build fix**. Biome classifies it as a warning, and `pnpm --filter @astro-plan/desktop run lint` exits **0** on `main` with or without this change — I verified that directly in both directions rather than inferring it.

Verification: biome reports `! This import is unused` before the change and is clean after; `pnpm run lint` and `pnpm typecheck` both exit 0.