### PR TITLE
ci: catch include!d sources that cargo fmt cannot reach

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -41,3 +41,17 @@ repos:
     hooks:
       - id: cocogitto-verify
         stages: [commit-msg]
+
+  # `cargo fmt --all` only walks `mod` declarations, so it structurally cannot
+  # reach bootstrap/specta.rs, which is `include!`d (see that file's header).
+  # A writer running bare `cargo fmt --all --check` therefore gets a green that
+  # CI contradicts, on identical bytes — this happened on spec 058 and cost a
+  # round trip. CI and `just lint` both add the standalone call; mirror it here
+  # so the gap closes at commit time rather than on a CI red.
+  - repo: local
+    hooks:
+      - id: rustfmt-included-sources
+        name: rustfmt (include!d sources cargo fmt cannot reach)
+        entry: rustfmt --edition 2021 --check
+        language: system
+        files: '^apps/desktop/src-tauri/src/bootstrap/specta\.rs$'


### PR DESCRIPTION
## Summary

- `cargo fmt --all` only walks `mod` declarations, so it structurally never visits `apps/desktop/src-tauri/src/bootstrap/specta.rs`, which is `include!`d rather than `mod`-declared. CI and `just lint` compensate with a standalone `rustfmt --edition 2021 --check`; a bare `cargo fmt --all --check` does not — so the common local command looks complete and isn't.
- Mirrors that standalone call as a `repo: local` pre-commit hook, scoped by `files:` to the one path, so the gap closes at commit time instead of on a CI red.
- No CI or `just lint` change — both were already correct.

## Why this is worth a hook

On spec 058 this cost a round trip. The writer got a clean local `cargo fmt --all --check` and a red CI **on identical bytes**, concluded CI's `toolchain: stable` disagreed with a repo pin of 1.95.0, hand-reflowed the file to match, and escalated it as an open question for the owner.

There is no toolchain split. `rust-toolchain.toml` pins `channel = "stable"` — the same thing CI resolves — and **no 1.95.0 pin exists anywhere in the repo**. The entire delta was the one file `cargo fmt` cannot see.

## Verification

Run in both directions, so the check isn't vacuous:

| state | result |
|---|---|
| file as committed | `Passed` |
| file reflowed with bad formatting | `Failed`, exit 1 |

Also confirmed `cargo fmt --all --check -- -l` never lists the file (0 matches), which is the underlying claim.