### PR TITLE
fix(deps): move to skymath 0.5, simbad-resolver 0.3.5 and target-match 0.4.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -191,7 +191,7 @@ dependencies = [
  "sessions",
  "sha2 0.10.9",
  "simbad-resolver",
- "skymath 0.4.0",
+ "skymath",
  "sqlx",
  "target-match",
  "targeting",
@@ -868,7 +868,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "skymath 0.4.0",
+ "skymath",
  "time",
  "uuid",
 ]
@@ -1437,7 +1437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.4.0",
+ "skymath",
  "specta",
  "specta-typescript",
  "sqlx",
@@ -3336,7 +3336,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
- "skymath 0.4.0",
+ "skymath",
  "thiserror 2.0.18",
 ]
 
@@ -5486,7 +5486,7 @@ name = "sessions"
 version = "0.1.0"
 dependencies = [
  "domain_core",
- "skymath 0.4.0",
+ "skymath",
  "thiserror 2.0.18",
  "time",
  "uuid",
@@ -5569,16 +5569,16 @@ dependencies = [
 
 [[package]]
 name = "simbad-resolver"
-version = "0.3.2"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aac89eca5180a1d9ec430e6d2e59a2909f00832a7bd0d996dbd0d49f80cb553"
+checksum = "48e8db7c75f0c5f3d642af85aa9e075b628f79f3bc8cb29ae8df1403b3f00a69"
 dependencies = [
  "async-trait",
  "redb",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "skymath 0.1.0",
+ "skymath",
  "thiserror 2.0.18",
  "time",
  "tokio",
@@ -5618,19 +5618,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skymath"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6315a9ee05a1b250fb7562b5a057342352ae7db06dc924ebfe3d0c90506db0d3"
-dependencies = [
- "thiserror 2.0.18",
- "time",
-]
-
-[[package]]
-name = "skymath"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10b1f9678d1f8e2aaa7f9f3af28e0c5d0bbb9c544ae563e08b5dc1d9fbc2bfb"
+checksum = "5fe24e1f966830a353f4a741d815655463e41a064b01c161a6b0a4cca62b84b1"
 dependencies = [
  "thiserror 2.0.18",
  "time",
@@ -6230,11 +6220,11 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-match"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c777eb96e32abd00fb956baf8d243b6f93006f0ea52faa8440b81114c2fc7f"
+checksum = "8c153b3cc35bfd761c260644ed0b6075c12169c93fcad0fee28dbda7afbfb7a5"
 dependencies = [
- "skymath 0.4.0",
+ "skymath",
  "thiserror 2.0.18",
 ]
 
@@ -6243,7 +6233,7 @@ name = "targeting"
 version = "0.1.0"
 dependencies = [
  "simbad-resolver",
- "skymath 0.4.0",
+ "skymath",
  "target-match",
  "uuid",
 ]
@@ -6258,7 +6248,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.4.0",
+ "skymath",
  "sqlx",
  "targeting",
  "tempfile",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,13 +23,13 @@ audit = { path = "../../../crates/audit" }
 targeting_resolver = { path = "../../../crates/targeting/resolver" }
 # spec 052 P1: AppState owns the shared redb resolve-cache handle directly
 # (Cache trait for .cache()/search, identity::namespace for warming).
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 # target.astro_format.batch: sexagesimal RA/Dec formatting (adopt target-match).
 targeting = { path = "../../../crates/targeting" }
 # target.moon_opposition.batch (#634): geocentric Sun/Moon position
 # (sun_position/moon_position — not re-exported by `targeting`, which only
 # re-exports the coordinate primitives).
-skymath = "0.4"
+skymath = "0.5"
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -31,7 +31,7 @@ workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
 # spec 052 P1: project_create::create threads the shared redb resolve cache
 # through to app_core_projects::project_setup::create for in-use promotion.
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 # In-memory caching layer (F0 foundation).
 app_core_cache = { path = "../cache" }
 camino = { workspace = true }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -32,14 +32,14 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
-skymath = "0.4"
+skymath = "0.5"
 sqlx.workspace = true
 target-match = "0.4"
 # spec 052 P3: the cone-search suggestion use case needs the upstream crate's
 # own `ResolvedIdentity` (otype_raw/common_name/aliases, OQ-1/OQ-2 ranking
 # inputs) and `PositionResolver` types directly — mirrors the existing
 # `app_core_targets` precedent (see that crate's Cargo.toml comment).
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -26,7 +26,7 @@ project_structure = { path = "../../project/structure" }
 # #1218: source snapshots read the session key, whose format this crate owns.
 sessions = { path = "../../sessions" }
 sha2.workspace = true
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 workflow_profiles = { path = "../../workflow/profiles" }
 serde_json.workspace = true
 sqlx.workspace = true

--- a/crates/app/targets/Cargo.toml
+++ b/crates/app/targets/Cargo.toml
@@ -23,7 +23,7 @@ targeting_resolver = { path = "../../targeting/resolver" }
 # spec 052 P1: `target.search` reads the shared redb resolve cache directly
 # (`simbad_resolver::Cache`), and in-use promotion touches the crate's own
 # `ResolvedIdentity`/`Cache` types at the app-layer commit points.
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 serde_json.workspace = true
 sqlx.workspace = true
 time = { workspace = true }

--- a/crates/calibration/core/Cargo.toml
+++ b/crates/calibration/core/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 # Issue #921: circular_distance replaces the hand-rolled `(a - b).abs()` flat
 # rotation delta, which max-penalized correct flats straddling the 0/360 seam.
-skymath = "0.4"
+skymath = "0.5"
 # spec 042 (T201): ISO-8601 date parsing + Julian-day arithmetic for
 # observing-night proximity (replaces the hand-rolled YMD parse + JDN math).
 time = { workspace = true }

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-skymath = "0.4"
+skymath = "0.5"
 thiserror = { workspace = true }
 
 [lints]

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../domain/core" }
-skymath = "0.4"
+skymath = "0.5"
 thiserror = { workspace = true }
 time = { workspace = true }
 

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -29,9 +29,9 @@ path = "src/lib.rs"
 
 [dependencies]
 target-match = "0.4"
-skymath = "0.4"
+skymath = "0.5"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 
 [lints]
 workspace = true

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -50,10 +50,10 @@ persistence_db = { path = "../../persistence/db" }
 # Published SIMBAD TAP client + Caldwell map + normalize/fuzzy helpers + the
 # cache-first facade (see crate doc above). Same author/org as this
 # workspace's own CI app.
-simbad-resolver = "0.3.0"
+simbad-resolver = "0.3"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
-skymath = "0.4"
+skymath = "0.5"
 
 [dev-dependencies]
 # `#[tokio::test]` only — no production `tokio` usage in this crate (the
@@ -65,7 +65,7 @@ tokio = { workspace = true }
 # drop-and-rebuild pointed at the same redb file — astro-plan's production
 # `simbad::SimbadResolver` wrapper only ever builds a real `TapResolver`, so
 # this test constructs the crate's facade directly.
-simbad-resolver = { version = "0.3.0", features = ["test-util"] }
+simbad-resolver = { version = "0.3", features = ["test-util"] }
 tempfile = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary

- Moves the workspace to **skymath 0.5.0**, **simbad-resolver 0.3.5** and **target-match 0.4.2** — all three now resolve to a single, latest version.
- skymath 0.5 could not be adopted before: both simbad-resolver and target-match pinned `skymath ^0.4`, and target-match re-exports skymath as `target_match::skymath`. Two skymath versions in one graph made `Equatorial` fail to type-unify — attempting the bump directly produced **7 `E0308` errors**. Both upstream crates have since released with `skymath ^0.5` (nightwatch-astro/simbad-resolver#37 → 0.3.5, nightwatch-astro/target-match#22 → 0.4.2), so the workspace moves in one step.
- Also drops a duplicate **skymath 0.1.0** that simbad-resolver 0.3.2 dragged in, and expresses simbad-resolver as `"0.3"` rather than `"0.3.0"` across all 8 declarations, matching the existing skymath style. In Cargo these are equivalent (`^0.3.0`); it's a readability change so the requirement stops reading like an exact pin.
- skymath 0.5.0 is **purely additive** over 0.4.0 — `Equatorial::j2000_lenient`, `Angle::ra_hms`, `Angle::dec_dms` are new and no public item was removed. The 0.4→0.5 bump is breaking only by Cargo's 0.x convention.

## Verification

- `cargo check --workspace --all-targets` — clean, 0 errors
- `cargo test -p app_core_settings --lib` — 211 passed

One unrelated flake surfaced during a full-workspace parallel run: `app_core_settings::tests::get_settings_repairs_invalid_stored_value` (`assertion failed: raw.is_none()`). It passes both alone and in its full crate suite with these changes, and the assertion concerns settings repair, not coordinates — a pre-existing load-dependent race, not something this PR introduces.