### PR TITLE
fix: remove two unused inbox database functions

### DIFF
--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -2514,10 +2514,8 @@ mod tests {
         assert_eq!(si.file_count, 2, "sub-item file_count must match files in the group");
 
         // Source group child_count updated.
-        let sg = inbox_repo::get_inbox_source_group_by_path(db.pool(), "root-sg1", "")
-            .await
-            .unwrap()
-            .unwrap();
+        let sg =
+            q_inbox::get_source_group_by_id(db.pool(), "sg-t066-single").await.unwrap().unwrap();
         assert_eq!(sg.child_count, 1, "source group child_count must be 1");
     }
 
@@ -2649,10 +2647,8 @@ mod tests {
         }
 
         // Source group child_count updated.
-        let sg = inbox_repo::get_inbox_source_group_by_path(db.pool(), "root-sg2", "")
-            .await
-            .unwrap()
-            .unwrap();
+        let sg =
+            q_inbox::get_source_group_by_id(db.pool(), "sg-t066-mixed").await.unwrap().unwrap();
         assert_eq!(sg.child_count, 2, "source group child_count must be 2");
     }
 

--- a/crates/persistence/db/src/repositories/inbox/items.rs
+++ b/crates/persistence/db/src/repositories/inbox/items.rs
@@ -54,32 +54,6 @@ pub struct InsertInboxItem<'a> {
     pub lane: &'a str,
 }
 
-/// Backfill the folder PLACEHOLDER item's (`group_key = ''`) link to its
-/// source group when the link is still NULL (rows inserted before scan wrote
-/// the link, or by older builds). Materialized single-type sub-items carry
-/// their own linkage and are deliberately not touched.
-///
-/// # Errors
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn link_placeholder_to_source_group(
-    pool: &SqlitePool,
-    root_id: &str,
-    relative_path: &str,
-    source_group_id: &str,
-) -> DbResult<()> {
-    sqlx::query(
-        "UPDATE inbox_items SET source_group_id = ?
-         WHERE root_id = ? AND relative_path = ? AND group_key = ''
-           AND source_group_id IS NULL",
-    )
-    .bind(source_group_id)
-    .bind(root_id)
-    .bind(relative_path)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
 /// Insert a new inbox item in `pending_classification` state.
 ///
 /// # Errors

--- a/crates/persistence/db/src/repositories/inbox/mod.rs
+++ b/crates/persistence/db/src/repositories/inbox/mod.rs
@@ -31,9 +31,9 @@ pub use classification::{
 };
 pub use items::{
     delete_sub_item_if_unlinked, get_inbox_item, get_source_group_id_for_item, insert_inbox_item,
-    link_placeholder_to_source_group, list_inbox_sub_items, list_item_ids_for_source_group,
-    reset_inbox_item_to_unconfirmed, update_inbox_item_scan, update_inbox_item_state,
-    upsert_inbox_sub_item, InboxItemRow, InsertInboxItem, UpsertInboxSubItem,
+    list_inbox_sub_items, list_item_ids_for_source_group, reset_inbox_item_to_unconfirmed,
+    update_inbox_item_scan, update_inbox_item_state, upsert_inbox_sub_item, InboxItemRow,
+    InsertInboxItem, UpsertInboxSubItem,
 };
 pub use metadata::{
     delete_breakdown_for_item, delete_file_metadata_for_item, get_file_metadata, list_breakdown,
@@ -50,7 +50,6 @@ pub use projections::{
     list_unacknowledged_across_roots, InboxItemGroupingKeys, InboxListRow, InboxStatsRow,
 };
 pub use source_groups::{
-    get_inbox_source_group_by_path, last_scanned_by_root, list_unclassified_source_groups,
-    update_source_group_child_count, upsert_inbox_source_group, InboxSourceGroupListRow,
-    InboxSourceGroupRow, UpsertSourceGroup,
+    last_scanned_by_root, list_unclassified_source_groups, update_source_group_child_count,
+    upsert_inbox_source_group, InboxSourceGroupListRow, InboxSourceGroupRow, UpsertSourceGroup,
 };

--- a/crates/persistence/db/src/repositories/inbox/source_groups.rs
+++ b/crates/persistence/db/src/repositories/inbox/source_groups.rs
@@ -84,30 +84,6 @@ pub async fn upsert_inbox_source_group(
     Ok(())
 }
 
-/// Fetch one `inbox_source_groups` row by `(root_id, relative_path)`.
-///
-/// Returns `None` when no matching row exists.
-///
-/// # Errors
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn get_inbox_source_group_by_path(
-    pool: &SqlitePool,
-    root_id: &str,
-    relative_path: &str,
-) -> DbResult<Option<InboxSourceGroupRow>> {
-    let row = sqlx::query_as::<_, InboxSourceGroupRow>(
-        "SELECT id, root_id, relative_path, discovered_at, last_scanned_at,
-                content_signature, format, lane, child_count
-         FROM inbox_source_groups
-         WHERE root_id = ? AND relative_path = ?",
-    )
-    .bind(root_id)
-    .bind(relative_path)
-    .fetch_optional(pool)
-    .await?;
-    Ok(row)
-}
-
 /// Most recent `inbox_source_groups.last_scanned_at` per `root_id` (P6a —
 /// `roots.list`'s `lastScanned` field).
 ///
@@ -183,14 +159,12 @@ pub struct InboxSourceGroupListRow {
 /// `file_count > 0` carries the FR-015 master carve-out. A folder of detected
 /// calibration masters has nothing left for classification to split, and its
 /// masters are `inbox_items` rows with a NULL `source_group_id`
-/// (`q_desktop.rs::insert_inbox_master_item`; a master row takes the same
-/// `group_key = ''` default as the folder placeholder, and stays unlinked only
-/// because its `relative_path` is the master FILE's path — `scan.rs` `rel_path`
-/// — which never equals the folder path [`link_placeholder_to_source_group`]
-/// matches on), so the `NOT EXISTS` clause alone
-/// would surface such a folder as an unclassified row *in addition to* the
-/// master rows already representing it. Scan writes `file_count` excluding
-/// masters, so that folder scores 0 here.
+/// (`q_desktop.rs::insert_inbox_master_item`), stored under the master FILE's
+/// own `relative_path` (`scan.rs` `rel_path`) rather than the folder's — so
+/// the `NOT EXISTS` clause alone would surface such a folder as an
+/// unclassified row *in addition to* the master rows already representing
+/// it. Scan writes `file_count` excluding masters, so that folder scores 0
+/// here.
 ///
 /// # Errors
 /// Returns [`DbError::Database`] on connection failure.

--- a/crates/persistence/db/src/repositories/inbox/tests.rs
+++ b/crates/persistence/db/src/repositories/inbox/tests.rs
@@ -1402,7 +1402,7 @@ async fn upsert_source_group_inserts_on_first_scan() {
     .await
     .unwrap();
 
-    let row = get_inbox_source_group_by_path(pool, "root-1", "2025-10-10/lights")
+    let row = crate::repositories::q_inbox::get_source_group_by_id(pool, "sg-t065-1")
         .await
         .unwrap()
         .expect("source group must exist after upsert");
@@ -1438,8 +1438,10 @@ async fn upsert_source_group_rescan_refreshes_without_duplicate() {
     .await
     .unwrap();
 
-    let first =
-        get_inbox_source_group_by_path(pool, "root-2", "2025-11-01/darks").await.unwrap().unwrap();
+    let first = crate::repositories::q_inbox::get_source_group_by_id(pool, "sg-t065-2")
+        .await
+        .unwrap()
+        .unwrap();
 
     // Record discovered_at so we can verify it is preserved on rescan.
     let discovered_at_first = first.discovered_at.clone();
@@ -1460,8 +1462,12 @@ async fn upsert_source_group_rescan_refreshes_without_duplicate() {
     .await
     .unwrap();
 
-    let second =
-        get_inbox_source_group_by_path(pool, "root-2", "2025-11-01/darks").await.unwrap().unwrap();
+    // Look up by the ORIGINAL id: the rescan's "sg-t065-2-ignored" id must
+    // never have been persisted (ON CONFLICT DO UPDATE does not touch id).
+    let second = crate::repositories::q_inbox::get_source_group_by_id(pool, "sg-t065-2")
+        .await
+        .unwrap()
+        .unwrap();
 
     // Row count is still 1 (not duplicated).
     let count: (i64,) = sqlx::query_as(
@@ -1535,7 +1541,7 @@ async fn upsert_source_group_video_lane_stored() {
     .await
     .unwrap();
 
-    let row = get_inbox_source_group_by_path(pool, "root-vid", "planetary/jupiter")
+    let row = crate::repositories::q_inbox::get_source_group_by_id(pool, "sg-t065-vid")
         .await
         .unwrap()
         .expect("video source group must be persisted");
@@ -1593,7 +1599,7 @@ async fn last_scanned_by_root_reports_max_across_leaf_folders() {
     .await
     .unwrap();
 
-    let later = get_inbox_source_group_by_path(pool, "root-scan", "2025-10-11/lights")
+    let later = crate::repositories::q_inbox::get_source_group_by_id(pool, "sg-scan-b")
         .await
         .unwrap()
         .expect("second group must exist");

--- a/crates/persistence/db/src/repositories/q_inbox.rs
+++ b/crates/persistence/db/src/repositories/q_inbox.rs
@@ -18,9 +18,9 @@ use crate::DbResult;
 
 /// Fetch one `inbox_source_groups` row by primary key `id`.
 ///
-/// Sibling of `repositories::inbox::get_inbox_source_group_by_path` (keyed on
-/// `(root_id, relative_path)` instead); `reclassify_v2` only has the group id
-/// on hand (from `source_group_id` request field or an item lookup).
+/// `reclassify_v2` and `classify_source_group` only have the group id on hand
+/// (from a `source_group_id` request field or an item lookup), not the
+/// `(root_id, relative_path)` natural key.
 ///
 /// # Errors
 /// Returns [`crate::DbError::Database`] on connection failure.


### PR DESCRIPTION
## Summary

- Removed two database functions in the Inbox module that had become unreachable after an earlier change stopped creating the data they operated on. No user-visible behavior changes; internal cleanup only.

## Test plan

- [x] Full workspace build
- [x] Persistence and Inbox test suites: 562 passed, 0 failed
- [x] Linting clean