### PR TITLE
fix(projects): block a project when its source frames go missing

### DIFF
--- a/crates/app/core/src/frame_inventory/mod.rs
+++ b/crates/app/core/src/frame_inventory/mod.rs
@@ -37,8 +37,43 @@ mod relink;
 mod tests;
 
 pub use list::list_frames;
-pub use reconcile::run_reconcile;
 pub use relink::relink_frame;
+
+use contracts_core::inventory_frame::{
+    InventoryReconcileRunRequest, InventoryReconcileRunResponse,
+};
+
+/// `inventory.reconcile.run` — the reconcile pass followed by the project
+/// `source_missing` block check (spec 009 US4, FR-020/FR-021).
+///
+/// The two are deliberately one exported symbol rather than two the caller
+/// must remember to chain: reconcile is the only production writer of
+/// `file_record.state='missing'`, so a project whose sources vanished can only
+/// be detected here. Composing at the command layer instead is what left the
+/// `source_missing` trigger with zero production callers, and is unreachable
+/// from a Layer-1 test.
+///
+/// # Errors
+///
+/// Returns `ContractError` per [`reconcile::run_reconcile`], or an internal
+/// database error if the block check fails.
+pub async fn run_reconcile(
+    pool: &SqlitePool,
+    bus: &audit::bus::EventBus,
+    req: &InventoryReconcileRunRequest,
+) -> Result<InventoryReconcileRunResponse, ContractError> {
+    let response = reconcile::run_reconcile(pool, bus, req).await?;
+
+    app_core_projects::project_health::check_project_source_missing_invariant(
+        pool,
+        bus,
+        crate::caches::project_block_debounce(),
+    )
+    .await
+    .map_err(internal)?;
+
+    Ok(response)
+}
 
 fn internal(msg: impl std::fmt::Display) -> ContractError {
     ContractError::new(ErrorCode::InternalDatabase, msg.to_string(), ErrorSeverity::Fatal, true)

--- a/crates/app/core/tests/project_source_missing_block.rs
+++ b/crates/app/core/tests/project_source_missing_block.rs
@@ -1,0 +1,152 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Layer-1 integration test for the `source_missing` project auto-block
+//! (spec 009 US4, FR-020/FR-021).
+//!
+//! Real tempdir root, real `file_record` rows, real `project.source.add`, real
+//! `app_core::frame_inventory::run_reconcile`. This file deliberately contains
+//! no reference to the `project_health` block emitter: every pre-existing test
+//! of the `source_missing` condition invoked that emitter directly, which is
+//! how the condition shipped with zero production callers. Driving the
+//! reconcile entry point is the only assertion that proves the trigger is
+//! wired.
+
+mod support;
+
+use contracts_core::inventory_frame::{InventoryReconcileRunRequest, ReconcileReason};
+use contracts_core::projects_v2::ProjectSourceAddRequest;
+
+// ── Seed helpers ──────────────────────────────────────────────────────────────
+
+async fn insert_root(pool: &sqlx::SqlitePool, id: &str, path: &str) {
+    sqlx::query(
+        "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
+         VALUES (?, ?, ?, 'local', 'active', datetime('now'))",
+    )
+    .bind(id)
+    .bind(id)
+    .bind(path)
+    .execute(pool)
+    .await
+    .unwrap_or_else(|e| panic!("insert library_root failed: {e}"));
+}
+
+async fn insert_frame_record(pool: &sqlx::SqlitePool, id: &str, root_id: &str, rel: &str) {
+    sqlx::query(
+        "INSERT INTO file_record \
+         (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
+         VALUES (?, ?, ?, 2048, 't0', 'classified', 't0', 't0')",
+    )
+    .bind(id)
+    .bind(root_id)
+    .bind(rel)
+    .execute(pool)
+    .await
+    .unwrap_or_else(|e| panic!("insert file_record failed: {e}"));
+}
+
+async fn insert_acquisition_session(pool: &sqlx::SqlitePool, id: &str, frame_ids: &[&str]) {
+    sqlx::query(
+        "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
+         VALUES (?, ?, ?, '2026-07-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(format!("M31|Ha|2026-07-01|{id}"))
+    .bind(serde_json::to_string(frame_ids).unwrap())
+    .execute(pool)
+    .await
+    .unwrap_or_else(|e| panic!("insert acquisition_session failed: {e}"));
+}
+
+async fn project_lifecycle(pool: &sqlx::SqlitePool, id: &str) -> (String, Option<String>) {
+    sqlx::query_as("SELECT lifecycle, blocked_reason_kind FROM projects WHERE id = ?")
+        .bind(id)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
+/// Count of `actor='system'` audit rows recording a `* → blocked` transition
+/// for this project (FR-021).
+async fn auto_block_audit_count(pool: &sqlx::SqlitePool, project_id: &str) -> i64 {
+    let (count,): (i64,) = sqlx::query_as(
+        "SELECT COUNT(*) FROM audit_log_entry \
+         WHERE entity_type = 'project' AND entity_id = ? \
+           AND to_state = 'blocked' AND actor = 'system'",
+    )
+    .bind(project_id)
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    count
+}
+
+// ── Test ──────────────────────────────────────────────────────────────────────
+
+/// A `ready` project whose linked session references a frame that disappears
+/// from disk is transitioned to `blocked` with `blocked_reason_kind =
+/// 'source_missing'` by the reconcile pass, with an audit row recording it.
+/// A second reconcile writes no duplicate audit row.
+#[tokio::test]
+async fn missing_source_frame_blocks_project_via_reconcile() {
+    let dir = tempfile::tempdir().unwrap();
+    let kept = dir.path().join("light_001.fits");
+    let doomed = dir.path().join("light_002.fits");
+    std::fs::write(&kept, vec![0u8; 2048]).unwrap();
+    std::fs::write(&doomed, vec![0u8; 2048]).unwrap();
+
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+
+    let root_id = "root-sm";
+    let session_id = "sess-sm";
+    let project_id = "proj-sm";
+
+    insert_root(pool, root_id, dir.path().to_str().unwrap()).await;
+    insert_frame_record(pool, "frame-kept", root_id, "light_001.fits").await;
+    insert_frame_record(pool, "frame-doomed", root_id, "light_002.fits").await;
+    insert_acquisition_session(pool, session_id, &["frame-kept", "frame-doomed"]).await;
+    support::insert_project(pool, project_id, "target-sm", "setup_incomplete").await;
+
+    app_core::projects::project_setup::add_source(
+        pool,
+        &bus,
+        &ProjectSourceAddRequest {
+            request_id: "req-1".to_owned(),
+            project_id: project_id.to_owned(),
+            inventory_session_id: session_id.to_owned(),
+        },
+    )
+    .await
+    .expect("add_source");
+
+    let (lifecycle, _) = project_lifecycle(pool, project_id).await;
+    assert_eq!(lifecycle, "ready", "add_source must auto-ready the project first");
+
+    // Simulate an external delete, then run the production reconcile entry point.
+    std::fs::remove_file(&doomed).unwrap();
+    let req = InventoryReconcileRunRequest {
+        root_id: root_id.to_owned(),
+        reason: ReconcileReason::OnDemand,
+    };
+    let resp = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(resp.newly_missing, 1);
+
+    let (lifecycle, reason_kind) = project_lifecycle(pool, project_id).await;
+    assert_eq!(lifecycle, "blocked", "FR-020: a project with a missing source must auto-block");
+    assert_eq!(reason_kind.as_deref(), Some("source_missing"));
+    assert_eq!(
+        auto_block_audit_count(pool, project_id).await,
+        1,
+        "FR-021: the auto-block transition must be recorded in the audit trail"
+    );
+
+    // A repeat reconcile inside the debounce window writes no second audit row.
+    app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(
+        auto_block_audit_count(pool, project_id).await,
+        1,
+        "a repeat reconcile must not append a duplicate auto-transition audit row"
+    );
+}

--- a/crates/app/projects/src/project_health.rs
+++ b/crates/app/projects/src/project_health.rs
@@ -189,6 +189,41 @@ pub struct BlockTransitionRecord {
     pub condition: BlockCondition,
 }
 
+/// Check the `source_missing` block invariant (US4, FR-020) across every
+/// project whose linked acquisition sessions reference a `missing` frame
+/// record, and apply the `* → blocked` transition to each.
+///
+/// This is the detection half that `emit_block_transition` (the emission half)
+/// has no caller for on its own — a project whose files disappeared stays
+/// `ready` unless something runs this. `frame_inventory::run_reconcile` is the
+/// production trigger: it is the only writer of `file_record.state='missing'`.
+///
+/// `debounce` is passed in rather than read from a global here because the
+/// process-global table lives in `app_core::caches`, which depends on this
+/// crate.
+///
+/// # Errors
+/// Returns `HealthError` on database failure.
+pub async fn check_project_source_missing_invariant(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    debounce: &DebounceCache<DebounceKey>,
+) -> Result<Vec<BlockTransitionRecord>, HealthError> {
+    let pairs =
+        repo::find_blockable_missing_sources(pool).await.map_err(HealthError::Persistence)?;
+
+    let mut applied = Vec::new();
+    for (project_id, inventory_id) in pairs {
+        let condition = BlockCondition::SourceMissing { inventory_id };
+        if let Some(record) =
+            emit_block_transition(pool, bus, debounce, &project_id, &condition).await?
+        {
+            applied.push(record);
+        }
+    }
+    Ok(applied)
+}
+
 /// Emit a system-driven `* → blocked` transition for the given project.
 ///
 /// - Performs debounce (P7): if the same `(project_id, condition_kind)` was

--- a/crates/persistence/db/src/repositories/projects/mod.rs
+++ b/crates/persistence/db/src/repositories/projects/mod.rs
@@ -130,6 +130,7 @@ pub use crud::{
     ArchivedProjectRow, ProjectCanonicalTargetRow,
 };
 pub use sources::{
-    delete_project_source, get_project_source, has_archived_raw_frames_for_project,
-    insert_project_source, list_project_ids_for_session, list_project_sources,
+    delete_project_source, find_blockable_missing_sources, get_project_source,
+    has_archived_raw_frames_for_project, insert_project_source, list_project_ids_for_session,
+    list_project_sources,
 };

--- a/crates/persistence/db/src/repositories/projects/sources.rs
+++ b/crates/persistence/db/src/repositories/projects/sources.rs
@@ -31,6 +31,34 @@ pub async fn list_project_ids_for_session(
     Ok(rows.into_iter().map(|(id,)| id).collect())
 }
 
+/// Every `(project_id, inventory_session_id)` pair where a linked acquisition
+/// session currently lists a frame whose `file_record.state = 'missing'`, and
+/// the project is still in a lifecycle a system block may move it out of.
+///
+/// `archived` is excluded as well as `blocked`: `emit_block_transition` only
+/// guards `blocked`, so without this filter an archived project would be
+/// dragged back to `blocked` by a reconcile pass.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn find_blockable_missing_sources(pool: &SqlitePool) -> DbResult<Vec<(String, String)>> {
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT DISTINCT ps.project_id, ps.inventory_session_id
+         FROM project_sources ps
+         JOIN projects p ON p.id = ps.project_id
+         JOIN acquisition_session s ON s.id = ps.inventory_session_id
+         JOIN json_each(s.frame_ids) je
+         JOIN file_record fr ON fr.id = je.value
+         WHERE fr.state = 'missing'
+           AND p.lifecycle IN ('ready', 'setup_incomplete')
+         ORDER BY ps.project_id, ps.inventory_session_id",
+    )
+    .fetch_all(pool)
+    .await?;
+    Ok(rows)
+}
+
 /// Whether any of this project's linked sessions has had a raw-frame archived
 /// via an applied cleanup plan (spec 008 Q27 F-Framing-6, Q25 "raw-subs-archived"
 /// reopen warning).


### PR DESCRIPTION
## Summary

- A project whose source frames disappear from disk now moves to `blocked` with reason `source_missing`, and the transition is written to the audit trail. It previously stayed `ready` forever.

`BlockCondition::SourceMissing` had zero production callers. PR #1382 wired only the
`ToolUnconfigured` fallback trigger (`crates/app/core/src/tool_launch.rs:191`), so a project whose
source files went missing stayed `ready` indefinitely and no audit row recorded a transition
(FR-020, FR-021, Constitution Principle II).

## Production path wired

| Layer | Change |
| --- | --- |
| `crates/persistence/db/src/repositories/projects/sources.rs` | `find_blockable_missing_sources` returns every `(project_id, inventory_session_id)` pair whose linked `acquisition_session` lists a `file_record` in state `missing`. Restricted to `lifecycle IN ('ready','setup_incomplete')`. |
| `crates/app/projects/src/project_health.rs` | `check_project_source_missing_invariant` delegates each pair to the existing `emit_block_transition`, reusing its debounce, lifecycle write, and audit write. |
| `crates/app/core/src/frame_inventory/mod.rs` | `run_reconcile` composes the reconcile pass and the block check behind one exported symbol. |

`archived` is excluded from the query because `emit_block_transition` guards only `blocked`;
without the filter an archived project would be dragged back to `blocked`.

Composition lives in `app_core`, not in `apps/desktop/src-tauri/src/commands/inventory_frame.rs`.
The command layer is unreachable from a Layer-1 test, which is how the trigger shipped unwired.
`reconcile::run_reconcile` stays private to the module, so no caller can reach the pass without
the check.

## Test

`crates/app/core/tests/project_source_missing_block.rs`: real tempdir root, real `file_record`
rows, real `project.source.add`, real `run_reconcile`. Asserts `lifecycle == 'blocked'`,
`blocked_reason_kind == 'source_missing'`, and one `actor='system'` audit row. The file contains
zero references to the block emitter.

Non-vacuity: with the health-check call removed from `run_reconcile`, the test fails
(`left: "ready", right: "blocked"`); restored, it passes.

The second assertion checks that a repeat reconcile appends no duplicate audit row. It does not
isolate the debounce: the already-blocked guard and the query's lifecycle filter would each
suppress the second write on their own.

## Deviation

The task's fix shape suggested a session-to-project fan-out mirroring
`list_project_ids_for_session` / `propagate_target_to_projects`. This uses one global query
instead, which avoids threading newly-missing frame ids out of the reconcile pass.

Refs astro-plan-datq, astro-plan-akon
