### PR TITLE
fix(tooling): close-guard falls back to content when ancestry cannot see a squash

### DIFF
--- a/docs/development/bd-close-guard.md
+++ b/docs/development/bd-close-guard.md
@@ -54,8 +54,10 @@ the working tree beyond fetching the `origin/main` remote-tracking ref.
 
 One `never` path resolves the PR to `NOT-ON-MAIN`. A squash that landed the
 PR's content would have put every path it touched into `main`'s history, so an
-empty log is proof the change never arrived. Otherwise one or more `identical`
-paths resolve to `CONTENT-ON-MAIN-VIA-SQUASH`.
+empty log is proof the change never arrived. Every visible path must be
+`identical` to resolve to `CONTENT-ON-MAIN-VIA-SQUASH`. Any `inconclusive`
+path reports `ERROR` because a matching ancillary file cannot prove that the
+PR's deliverable landed.
 
 Byte-identity is the positive test, not path existence. A stacked PR that only
 modifies pre-existing files would pass an existence test on the strength of
@@ -64,7 +66,7 @@ files that were already on `main`, whether or not its own changes landed.
 ```
 $ scripts/bd-close-guard.sh astro-plan-3ra astro-plan-698 astro-plan-sm7 astro-plan-tlw
 ON-MAIN  astro-plan-3ra   PR #1319 merged into main, commit 38b788943a95c239d5ce65fd6fb2c8aa45a03f31 is on origin/main (platevault/platevault)
-SQUASHED astro-plan-698   CONTENT-ON-MAIN-VIA-SQUASH: PR #1296 merged into feat/sd-token-pipeline and its merge commit fc0a2ad43efb3af763732ffae57c25e036743129 is not an ancestor of origin/main, but the file content it produced is byte-identical on origin/main — the stack root squashed the content in. Safe to close (platevault/platevault)
+ERROR    astro-plan-698   PR #1296 — mixed evidence — 2 of 11 paths are not byte-identical on origin/main, so the PR's complete content cannot be proven landed
 FAIL     astro-plan-sm7   NOT-ON-MAIN: PR #1304 merged into feat/sd-foundation-outputs, and paths it touches are absent from origin/main and from main's entire history — do not close (platevault/platevault)
 FAIL     astro-plan-tlw   PR #1048 is OPEN, not merged (platevault/platevault) — do not close
 ```
@@ -75,19 +77,18 @@ ancestry or by content.
 | Result | Meaning |
 |---|---|
 | `ON-MAIN` | The linked PR's merge commit is an ancestor of `origin/main`. Safe to close. |
-| `SQUASHED` | Ancestry says no, and content the PR produced is byte-identical on `origin/main`. It reached `main` through the stack root's squash. Safe to close. |
+| `SQUASHED` | Ancestry says no, and every visible path the PR produced is byte-identical on `origin/main`. It reached `main` through the stack root's squash. Safe to close. |
 | `FAIL` (`NOT-ON-MAIN`) | Ancestry says no, and at least one path the PR touched has no history on `origin/main`. Do not close. |
 | `FAIL` (open/closed) | The linked PR is `OPEN` or `CLOSED` without merging. Do not close. |
 | `UNKNOWN` | No PR reference could be resolved. Do not close on the strength of this check; verify by hand. |
-| `ERROR` | `bd show`/`gh` lookup failed, the PR reads `MERGED` with no merge commit reported (some squash/rebase merges), the PR's own tree is unreachable, no path matched by content, or the file list was truncated. Do not close on the strength of this check. |
+| `ERROR` | `bd show`/`gh` lookup failed, the PR reads `MERGED` with no merge commit reported (some squash/rebase merges), the PR's own tree is unreachable, any path is inconclusive, no path matched by content, or the file list was truncated. Do not close on the strength of this check. |
 
 ### Limits of the content check
 
 Every gap resolves to `ERROR` or `NOT-ON-MAIN`, never to a green-light.
 
-A PR whose files were all edited further on `main` after landing has no
-`identical` path left and reports `ERROR`. Confirm those by hand against the
-squash commit.
+A PR with any file edited further on `main` after landing reports `ERROR`.
+Confirm it by hand against the squash commit.
 
 `gh pr view --json files` returns at most 100 files: PR #1162 reports
 `changedFiles: 236` and 100 entries. A hidden path could be the unlanded one,

--- a/docs/development/bd-close-guard.md
+++ b/docs/development/bd-close-guard.md
@@ -29,8 +29,8 @@ origin/main` then answers "no" for work that is on `main`.
 A non-empty `git merge-tree` does not prove the inverse either: a squashed
 branch keeps its diverged merge-from-main history, so it still conflicts.
 
-Landed-ness is proven by CONTENT: `git cat-file -e origin/main:<path>`, a file
-or tree diff, or the change's presence inside the squash commit.
+Landed-ness is proven by content: byte-identical blobs or trees, or the
+change's presence inside the squash commit.
 
 ## The check
 

--- a/docs/development/bd-close-guard.md
+++ b/docs/development/bd-close-guard.md
@@ -41,28 +41,31 @@ the working tree beyond fetching the `origin/main` remote-tracking ref.
 
 1. **Ancestry, the fast path.** The PR's merge commit is an ancestor of
    `origin/main` → `ON-MAIN`.
-2. **Content, the fallback.** Ancestry says no → judge each non-deleted path
-   from `gh pr view <n> --json files` against `origin/main`:
+2. **Content, the fallback.** Ancestry says no → compare the blob the PR
+   produced for each of its paths against `origin/main`. The PR's own tree
+   comes from its merge commit, or from `refs/pull/<n>/head` when that commit
+   has been pruned.
 
 | Path evidence | Test | Meaning |
 |---|---|---|
-| present | `git cat-file -e origin/main:<path>` succeeds | Path is on `main` now |
+| identical | Blob oid at the PR's tree equals the oid at `origin/main` | This PR's exact content for that path is on `main` |
 | never | `git log origin/main -- <path>` is empty | Path never existed on `main` at any point |
-| gone | Absent now, non-empty log | Deleted or renamed after landing; proves nothing |
+| inconclusive | Blobs differ, or path is absent with a non-empty log | Landed then edited further, deleted, renamed — or never landed |
 
 One `never` path resolves the PR to `NOT-ON-MAIN`. A squash that landed the
-PR's content would have put every path it added or modified into `main`'s
-history, so an empty log is proof the change never arrived. Otherwise one or
-more `present` paths resolve to `CONTENT-ON-MAIN-VIA-SQUASH`.
+PR's content would have put every path it touched into `main`'s history, so an
+empty log is proof the change never arrived. Otherwise one or more `identical`
+paths resolve to `CONTENT-ON-MAIN-VIA-SQUASH`.
 
-Deleted paths are excluded: an unlanded deletion leaves its file present on
-`main`, which would read as evidence of landing.
+Byte-identity is the positive test, not path existence. A stacked PR that only
+modifies pre-existing files would pass an existence test on the strength of
+files that were already on `main`, whether or not its own changes landed.
 
 ```
 $ scripts/bd-close-guard.sh astro-plan-3ra astro-plan-698 astro-plan-sm7 astro-plan-tlw
 ON-MAIN  astro-plan-3ra   PR #1319 merged into main, commit 38b788943a95c239d5ce65fd6fb2c8aa45a03f31 is on origin/main (platevault/platevault)
-SQUASHED astro-plan-698   CONTENT-ON-MAIN-VIA-SQUASH: PR #1296 merged into feat/sd-token-pipeline and its merge commit fc0a2ad43efb3af763732ffae57c25e036743129 is not an ancestor of origin/main, but every added/modified path it touches is on origin/main — the stack root squashed the content in. Safe to close (platevault/platevault)
-FAIL     astro-plan-sm7   NOT-ON-MAIN: PR #1304 merged into feat/sd-foundation-outputs, and paths it added are absent from origin/main and from main's entire history — do not close (platevault/platevault)
+SQUASHED astro-plan-698   CONTENT-ON-MAIN-VIA-SQUASH: PR #1296 merged into feat/sd-token-pipeline and its merge commit fc0a2ad43efb3af763732ffae57c25e036743129 is not an ancestor of origin/main, but the file content it produced is byte-identical on origin/main — the stack root squashed the content in. Safe to close (platevault/platevault)
+FAIL     astro-plan-sm7   NOT-ON-MAIN: PR #1304 merged into feat/sd-foundation-outputs, and paths it touches are absent from origin/main and from main's entire history — do not close (platevault/platevault)
 FAIL     astro-plan-tlw   PR #1048 is OPEN, not merged (platevault/platevault) — do not close
 ```
 
@@ -72,20 +75,19 @@ ancestry or by content.
 | Result | Meaning |
 |---|---|
 | `ON-MAIN` | The linked PR's merge commit is an ancestor of `origin/main`. Safe to close. |
-| `SQUASHED` | Ancestry says no, and every judged path the PR added or modified is on `origin/main`. The content reached `main` through the stack root's squash. Safe to close. |
-| `FAIL` (`NOT-ON-MAIN`) | Ancestry says no, and at least one path the PR added has no history on `origin/main`. Do not close. |
+| `SQUASHED` | Ancestry says no, and content the PR produced is byte-identical on `origin/main`. It reached `main` through the stack root's squash. Safe to close. |
+| `FAIL` (`NOT-ON-MAIN`) | Ancestry says no, and at least one path the PR touched has no history on `origin/main`. Do not close. |
 | `FAIL` (open/closed) | The linked PR is `OPEN` or `CLOSED` without merging. Do not close. |
 | `UNKNOWN` | No PR reference could be resolved. Do not close on the strength of this check; verify by hand. |
-| `ERROR` | `bd show`/`gh` lookup failed, the PR reads `MERGED` with no merge commit reported (some squash/rebase merges), no path was judgeable, or the file list was truncated. Do not close on the strength of this check. |
+| `ERROR` | `bd show`/`gh` lookup failed, the PR reads `MERGED` with no merge commit reported (some squash/rebase merges), the PR's own tree is unreachable, no path matched by content, or the file list was truncated. Do not close on the strength of this check. |
 
 ### Limits of the content check
 
-`git cat-file -e` proves a path exists on `main`, not that this PR's diff
-landed. A stacked PR that only modifies pre-existing files reads as
-`CONTENT-ON-MAIN-VIA-SQUASH` on the strength of paths that were already there.
-The `never` test on added paths carries the discrimination, so a PR that adds
-no files gets a weaker answer than one that does. Confirm those by diffing the
-PR's content against `main`.
+Every gap resolves to `ERROR` or `NOT-ON-MAIN`, never to a green-light.
+
+A PR whose files were all edited further on `main` after landing has no
+`identical` path left and reports `ERROR`. Confirm those by hand against the
+squash commit.
 
 `gh pr view --json files` returns at most 100 files: PR #1162 reports
 `changedFiles: 236` and 100 entries. A hidden path could be the unlanded one,

--- a/docs/development/bd-close-guard.md
+++ b/docs/development/bd-close-guard.md
@@ -8,43 +8,89 @@ their linked PR still open at close time.
 
 ## The rule
 
-Close a bead only once its fix commit is on `origin/main`, not once its PR
-shows `MERGED`. **"MERGED" is not "on main"; ancestry is the only
-authoritative test.** GitHub reports a PR as `MERGED` as soon as it merges
-into ITS base branch. This repo uses stacked PRs, so that base branch is
-routinely a feature branch, not `main`.
+Close a bead only once its fix is on `origin/main`, not once its PR shows
+`MERGED`. **"MERGED" is not "on main".** GitHub reports a PR as `MERGED` as
+soon as it merges into ITS base branch. This repo uses stacked PRs, so that
+base branch is routinely a feature branch, not `main`.
 
 astro-plan-pjg was closed on the strength of PR #1310 reading `state:
-MERGED`. #1310 merged into `061-selectable-app-language`; its merge commit
-was never an ancestor of `origin/main`. The bead was reopened once
-`git merge-base --is-ancestor <mergeCommit> origin/main` returned false.
+MERGED`. #1310 merged into `061-selectable-app-language`; its merge commit is
+not an ancestor of `origin/main`.
+
+## Ancestry is necessary, not sufficient
+
+This repo squash-merges. A squash rewrites a branch's commits into one new
+commit on `main`, so a merged branch tip is never an ancestor of `main` even
+when its content is fully landed. For a stacked PR, the merge commit sits on
+the stack branch and the stack root's squash carries that content onto `main`
+under a different oid. `git merge-base --is-ancestor <mergeCommit>
+origin/main` then answers "no" for work that is on `main`.
+
+A non-empty `git merge-tree` does not prove the inverse either: a squashed
+branch keeps its diverged merge-from-main history, so it still conflicts.
+
+Landed-ness is proven by CONTENT: `git cat-file -e origin/main:<path>`, a file
+or tree diff, or the change's presence inside the squash commit.
 
 ## The check
 
 `scripts/bd-close-guard.sh <bead-id> [<bead-id> ...]` resolves the PR linked
-to each bead, then checks whether that PR's merge commit is an ancestor of
-`origin/main` — not just whether the PR's `state` field reads `MERGED`.
-Read-only: it never calls `bd close`, `bd update`, or any mutating
-`gh`/GitHub call, and never modifies the working tree beyond fetching the
-`origin/main` remote-tracking ref.
+to each bead and reports one of three landed states. Read-only: it never calls
+`bd close`, `bd update`, or any mutating `gh`/GitHub call, and never modifies
+the working tree beyond fetching the `origin/main` remote-tracking ref.
+
+1. **Ancestry, the fast path.** The PR's merge commit is an ancestor of
+   `origin/main` → `ON-MAIN`.
+2. **Content, the fallback.** Ancestry says no → judge each non-deleted path
+   from `gh pr view <n> --json files` against `origin/main`:
+
+| Path evidence | Test | Meaning |
+|---|---|---|
+| present | `git cat-file -e origin/main:<path>` succeeds | Path is on `main` now |
+| never | `git log origin/main -- <path>` is empty | Path never existed on `main` at any point |
+| gone | Absent now, non-empty log | Deleted or renamed after landing; proves nothing |
+
+One `never` path resolves the PR to `NOT-ON-MAIN`. A squash that landed the
+PR's content would have put every path it added or modified into `main`'s
+history, so an empty log is proof the change never arrived. Otherwise one or
+more `present` paths resolve to `CONTENT-ON-MAIN-VIA-SQUASH`.
+
+Deleted paths are excluded: an unlanded deletion leaves its file present on
+`main`, which would read as evidence of landing.
 
 ```
-$ scripts/bd-close-guard.sh astro-plan-hew astro-plan-tlw astro-plan-pjg astro-plan-r8n
-PASS     astro-plan-hew   PR #1364 merged into main, commit d4876d81528951e40901bb83f6799c3c54c0a94b is on origin/main (platevault/platevault)
+$ scripts/bd-close-guard.sh astro-plan-3ra astro-plan-698 astro-plan-sm7 astro-plan-tlw
+ON-MAIN  astro-plan-3ra   PR #1319 merged into main, commit 38b788943a95c239d5ce65fd6fb2c8aa45a03f31 is on origin/main (platevault/platevault)
+SQUASHED astro-plan-698   CONTENT-ON-MAIN-VIA-SQUASH: PR #1296 merged into feat/sd-token-pipeline and its merge commit fc0a2ad43efb3af763732ffae57c25e036743129 is not an ancestor of origin/main, but every added/modified path it touches is on origin/main — the stack root squashed the content in. Safe to close (platevault/platevault)
+FAIL     astro-plan-sm7   NOT-ON-MAIN: PR #1304 merged into feat/sd-foundation-outputs, and paths it added are absent from origin/main and from main's entire history — do not close (platevault/platevault)
 FAIL     astro-plan-tlw   PR #1048 is OPEN, not merged (platevault/platevault) — do not close
-FAIL     astro-plan-pjg   PR #1310 merged into 061-selectable-app-language, not on origin/main — do not close (platevault/platevault)
-UNKNOWN  astro-plan-r8n   FIX-PR: UNDETERMINED — checked=bead's own notes (cites PR #1310 and #1321), gh pr list --search r8n, git log origin/main --grep=r8n | Two distinct stacked PRs cited, neither merged into origin/main (#1310 base=061-selectable-app-language, #1321 base=061-p1-locale-runtime); root-cause bead astro-plan-vi1w names this exact bead as the flagship ambiguous case (8 loosely-related numbers). Cannot pick one without guessing.
 ```
 
-Exit status is 0 only if every given bead's fix commit is on `origin/main`.
+Exit status is 0 only if every given bead's fix is on `origin/main`, by
+ancestry or by content.
 
 | Result | Meaning |
 |---|---|
-| `PASS` | Linked PR's merge commit is an ancestor of `origin/main`. Safe to close. |
-| `FAIL` (stacked base) | PR `state` is `MERGED`, but its merge commit merged into a non-main base and is not on `origin/main`. Do not close. |
-| `FAIL` (open/closed) | Linked PR is `OPEN` or `CLOSED` without merging. Do not close. |
+| `ON-MAIN` | The linked PR's merge commit is an ancestor of `origin/main`. Safe to close. |
+| `SQUASHED` | Ancestry says no, and every judged path the PR added or modified is on `origin/main`. The content reached `main` through the stack root's squash. Safe to close. |
+| `FAIL` (`NOT-ON-MAIN`) | Ancestry says no, and at least one path the PR added has no history on `origin/main`. Do not close. |
+| `FAIL` (open/closed) | The linked PR is `OPEN` or `CLOSED` without merging. Do not close. |
 | `UNKNOWN` | No PR reference could be resolved. Do not close on the strength of this check; verify by hand. |
-| `ERROR` | `bd show`/`gh` lookup failed, or the PR reads `MERGED` with no merge commit reported (some squash/rebase merges) so ancestry cannot be verified. Do not close on the strength of this check. |
+| `ERROR` | `bd show`/`gh` lookup failed, the PR reads `MERGED` with no merge commit reported (some squash/rebase merges), no path was judgeable, or the file list was truncated. Do not close on the strength of this check. |
+
+### Limits of the content check
+
+`git cat-file -e` proves a path exists on `main`, not that this PR's diff
+landed. A stacked PR that only modifies pre-existing files reads as
+`CONTENT-ON-MAIN-VIA-SQUASH` on the strength of paths that were already there.
+The `never` test on added paths carries the discrimination, so a PR that adds
+no files gets a weaker answer than one that does. Confirm those by diffing the
+PR's content against `main`.
+
+`gh pr view --json files` returns at most 100 files: PR #1162 reports
+`changedFiles: 236` and 100 entries. A hidden path could be the unlanded one,
+so a truncated list reports `ERROR` instead of `SQUASHED`. A `never` path
+found among the visible 100 still resolves to `NOT-ON-MAIN`.
 
 PR resolution order:
 
@@ -80,10 +126,11 @@ deliberate judgement that no single PR can be picked.
 
 The `on-main=` field is a claim recorded at `verified=<date>`, not a fact:
 `origin/main` moves after the note is written. The check always re-verifies
-by ancestry and never trusts the field. When the recorded claim and the live
-ancestry check disagree, the check reports both explicitly (for example, the
-note claims `on-main=yes` but ancestry now says no) — a stale claim is worse
-than no claim.
+and never trusts the field. When the recorded claim and the check's own
+determination disagree, both are reported (for example, the note claims
+`on-main=no` while the content check says `on-main=yes`) — a stale claim is
+worse than no claim. The comparison uses the final determination, so a
+`CONTENT-ON-MAIN-VIA-SQUASH` result agrees with an `on-main=yes` note.
 
 A `#<n>` with no `FIX-PR:` prefix, anywhere else in the line or in prose, is
 not a `FIX-PR:` line and does not match this rule; it falls through to the
@@ -103,5 +150,5 @@ that governs how `bd close` gets invoked, not in this repo's `scripts/`.
 main` before checking ancestry, so a stale local `origin/main` does not
 produce a false pass; a failed fetch degrades to a warning plus a check
 against whatever `origin/main` is already present locally.
-`scripts/bd-close-guard.sh --self-test` exercises the PR-resolution and
-ancestry-classification logic without network access.
+`scripts/bd-close-guard.sh --self-test` exercises the PR-resolution, ancestry
+and content classification logic without network access.

--- a/scripts/bd-close-guard.sh
+++ b/scripts/bd-close-guard.sh
@@ -247,7 +247,7 @@ pr_content_ref() {
 # Decide by content whether a merged PR's changes are on origin/main, for the
 # case where ancestry cannot see through a squash.
 content_check() {
-  local repo="$1" pr="$2" merge_oid="$3" ref pr_files identical=0 inconclusive=0 never=0 truncated=no path
+  local repo="$1" pr="$2" merge_oid="$3" ref pr_files counts identical inconclusive never truncated
   if ! pr_files=$(gh pr view "$pr" --repo "$repo" --json changedFiles,files 2>/dev/null); then
     echo "ERROR:could not list PR files for the content check"
     return
@@ -257,18 +257,45 @@ content_check() {
     echo "ERROR:PR content is unreachable locally (merge commit pruned, refs/pull/$pr/head unfetchable)"
     return
   fi
+  if ! counts=$(content_evidence_counts "$ref" "$pr_files"); then
+    echo "ERROR:$counts"
+    return
+  fi
+  read -r identical inconclusive never truncated <<<"$counts"
+  classify_content "$identical" "$inconclusive" "$never" "$truncated"
+}
+
+# Validate GitHub's response before transporting paths as a NUL-delimited
+# stream. Git permits newlines in filenames, so line-oriented transport can
+# turn one unlanded path into several coincidentally identical landed paths.
+content_evidence_counts() {
+  local ref="$1" pr_files="$2" identical=0 inconclusive=0 never=0 truncated=no path evidence
+  local -a paths=()
+  if ! jq -e '
+    (.changedFiles | type == "number" and . >= 0 and floor == .)
+    and (.files | type == "array")
+    and all(.files[]; (.path | type == "string") and (.path | length > 0))
+  ' >/dev/null 2>&1 <<<"$pr_files"; then
+    echo "malformed PR file evidence"
+    return 1
+  fi
   if [ "$(jq -r '.files | length' <<<"$pr_files")" -lt "$(jq -r '.changedFiles' <<<"$pr_files")" ]; then
     truncated=yes
   fi
-  while IFS= read -r path; do
-    [ -n "$path" ] || continue
-    case "$(path_evidence "$ref" "$path")" in
+  mapfile -d '' -t paths < <(jq -j '.files[] | .path, "\u0000"' <<<"$pr_files")
+  for path in "${paths[@]}"; do
+    evidence=$(path_evidence "$ref" "$path")
+    case "$evidence" in
       identical) identical=$((identical + 1)) ;;
       inconclusive) inconclusive=$((inconclusive + 1)) ;;
       never) never=$((never + 1)) ;;
+      *)
+        echo "could not classify PR path evidence"
+        return 1
+        ;;
     esac
-  done < <(jq -r '.files[].path' <<<"$pr_files")
-  classify_content "$identical" "$inconclusive" "$never" "$truncated"
+  done
+  printf '%s %s %s %s\n' "$identical" "$inconclusive" "$never" "$truncated"
 }
 
 check_one() {
@@ -485,6 +512,42 @@ self_test() {
   got=$(classify_content 99 0 1 yes)
   [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content still reports NOT-ON-MAIN on a truncated list when a never-landed path is visible" \
     || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
+
+  # Filename ingestion: Git permits newlines in paths. The old line-oriented
+  # jq/read transport split this one unlanded path into README.md and LICENSE,
+  # both identical on main, and returned a false SQUASHED verdict.
+  local newline_repo newline_json counts
+  newline_repo=$(mktemp -d)
+  if (
+    cd "$newline_repo"
+    git init -q
+    git config user.name test
+    git config user.email test@example.invalid
+    printf 'landed\n' >README.md
+    printf 'landed\n' >LICENSE
+    git add README.md LICENSE
+    git commit -qm main
+    git update-ref refs/remotes/origin/main HEAD
+    git switch -qc pr
+    printf 'unlanded\n' >$'README.md\nLICENSE'
+    git add $'README.md\nLICENSE'
+    git commit -qm pr
+    newline_json=$(jq -cn --arg path $'README.md\nLICENSE' '{changedFiles: 1, files: [{path: $path}]}')
+    counts=$(content_evidence_counts HEAD "$newline_json")
+    read -r identical inconclusive never truncated <<<"$counts"
+    got=$(classify_content "$identical" "$inconclusive" "$never" "$truncated")
+    [ "$got" = "NOTONMAIN:" ]
+  ); then
+    echo "ok: content ingestion preserves a literal newline filename and cannot return false SQUASHED"
+  else
+    echo "FAIL: content ingestion split or misclassified a literal newline filename"
+    fail=1
+  fi
+  rm -rf -- "$newline_repo"
+
+  got=$(content_evidence_counts HEAD '{"changedFiles":1,"files":[{}]}' 2>/dev/null || true)
+  [ "$got" = "malformed PR file evidence" ] && echo "ok: content ingestion fails closed on missing path evidence" \
+    || { echo "FAIL: malformed content evidence got '$got'"; fail=1; }
 
   # path_evidence: reads this repo's own local origin/main ref, no network.
   got=$(path_evidence origin/main "scripts/bd-close-guard.sh")

--- a/scripts/bd-close-guard.sh
+++ b/scripts/bd-close-guard.sh
@@ -212,16 +212,23 @@ path_evidence() {
 # PR's content would have put every path it touched into main's history. A
 # truncated file list can hide exactly that path, so truncation may confirm
 # NOT-ON-MAIN but must never conclude the content landed.
+#
+# `identical > 0` is not sufficient. One ancillary file can happen to be
+# byte-identical on main while the PR's deliverable remains unlanded. Every
+# visible path must therefore be identical before this fallback green-lights a
+# close; mixed evidence is unverifiable and fails closed.
 classify_content() {
-  local identical="$1" never="$2" truncated="$3"
+  local identical="$1" inconclusive="$2" never="$3" truncated="$4"
   if [ "$never" -gt 0 ]; then
     echo "NOTONMAIN:"
   elif [ "$truncated" = "yes" ]; then
     echo "ERROR:PR file list is truncated (gh returns at most 100 files) — content check cannot rule out an unlanded path"
-  elif [ "$identical" -gt 0 ]; then
-    echo "SQUASHED:"
-  else
+  elif [ "$inconclusive" -gt 0 ]; then
+    echo "ERROR:mixed evidence — $inconclusive of $((identical + inconclusive)) paths are not byte-identical on origin/main, so the PR's complete content cannot be proven landed"
+  elif [ "$identical" -eq 0 ]; then
     echo "ERROR:no path could be matched to origin/main by content"
+  else
+    echo "SQUASHED:"
   fi
 }
 
@@ -240,7 +247,7 @@ pr_content_ref() {
 # Decide by content whether a merged PR's changes are on origin/main, for the
 # case where ancestry cannot see through a squash.
 content_check() {
-  local repo="$1" pr="$2" merge_oid="$3" ref pr_files identical=0 never=0 truncated=no path
+  local repo="$1" pr="$2" merge_oid="$3" ref pr_files identical=0 inconclusive=0 never=0 truncated=no path
   if ! pr_files=$(gh pr view "$pr" --repo "$repo" --json changedFiles,files 2>/dev/null); then
     echo "ERROR:could not list PR files for the content check"
     return
@@ -257,10 +264,11 @@ content_check() {
     [ -n "$path" ] || continue
     case "$(path_evidence "$ref" "$path")" in
       identical) identical=$((identical + 1)) ;;
+      inconclusive) inconclusive=$((inconclusive + 1)) ;;
       never) never=$((never + 1)) ;;
     esac
   done < <(jq -r '.files[].path' <<<"$pr_files")
-  classify_content "$identical" "$never" "$truncated"
+  classify_content "$identical" "$inconclusive" "$never" "$truncated"
 }
 
 check_one() {
@@ -335,7 +343,7 @@ check_one() {
       echo "ON-MAIN  $id   PR #$pr merged into main, commit $merge_oid is on origin/main ($repo)$staleness"
       ;;
     SQUASHED)
-      echo "SQUASHED $id   CONTENT-ON-MAIN-VIA-SQUASH: PR #$pr merged into $base and its merge commit $merge_oid is not an ancestor of origin/main, but the file content it produced is byte-identical on origin/main — the stack root squashed the content in. Safe to close ($repo)$staleness"
+      echo "SQUASHED $id   CONTENT-ON-MAIN-VIA-SQUASH: PR #$pr merged into $base and its merge commit $merge_oid is not an ancestor of origin/main, but every visible path it produced is byte-identical on origin/main — the stack root squashed the content in. Safe to close ($repo)$staleness"
       ;;
     NOTONMAIN)
       echo "FAIL     $id   NOT-ON-MAIN: PR #$pr merged into $base, and paths it touches are absent from origin/main and from main's entire history — do not close ($repo)$staleness"
@@ -443,11 +451,11 @@ self_test() {
   # classify_content: one path that never existed on main outweighs any number
   # of content matches. Regression case: PR #1304 modifies files that are on
   # main while its deliverable check-token-refs.mjs never landed.
-  got=$(classify_content 12 1 no)
+  got=$(classify_content 12 0 1 no)
   [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content reports NOT-ON-MAIN when any path never existed on main" \
     || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
 
-  got=$(classify_content 4 0 no)
+  got=$(classify_content 4 0 0 no)
   [ "$got" = "SQUASHED:" ] && echo "ok: classify_content reports CONTENT-ON-MAIN-VIA-SQUASH when the PR's content is byte-identical on main" \
     || { echo "FAIL: classify_content got '$got', want 'SQUASHED:'"; fail=1; }
 
@@ -455,20 +463,26 @@ self_test() {
   # This is the fail-closed case for a stacked PR whose content has NOT landed:
   # its paths exist on main (so existence alone would wrongly pass it) but none
   # of its blobs match.
-  got=$(classify_content 0 0 no)
+  got=$(classify_content 0 1 0 no)
   [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content returns ERROR rather than passing a PR whose content matches nothing on main" \
+    || { echo "FAIL: classify_content got '$got', want ERROR:*"; fail=1; }
+
+  # One coincidentally identical ancillary path cannot green-light an
+  # inconclusive deliverable.
+  got=$(classify_content 1 1 0 no)
+  [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content fails closed on one identical plus one inconclusive path" \
     || { echo "FAIL: classify_content got '$got', want ERROR:*"; fail=1; }
 
   # classify_content: gh caps `files` at 100 (PR #1162 reports changedFiles=236,
   # files=100), and the hidden path could be the unlanded one. Truncation must
   # never conclude the content landed...
-  got=$(classify_content 100 0 yes)
+  got=$(classify_content 100 0 0 yes)
   [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content refuses to conclude on-main from a truncated file list" \
     || { echo "FAIL: classify_content got '$got', want ERROR:*"; fail=1; }
 
   # ...but a `never` path found within the visible 100 is positive evidence
   # that stands on its own.
-  got=$(classify_content 99 1 yes)
+  got=$(classify_content 99 0 1 yes)
   [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content still reports NOT-ON-MAIN on a truncated list when a never-landed path is visible" \
     || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
 

--- a/scripts/bd-close-guard.sh
+++ b/scripts/bd-close-guard.sh
@@ -182,51 +182,72 @@ classify_pr() {
   esac
 }
 
-# Evidence that one path carries about whether a PR's content reached
-# origin/main:
-#   present — the path exists on origin/main right now
-#   never   — the path has NO history on origin/main at all, which is the only
-#             available proof that the change never landed; mere absence is
-#             also what a later delete or rename produces
-#   gone    — absent now but present in origin/main's history: deleted or
-#             renamed after landing, so it proves nothing either way
+# Evidence one path carries about whether a PR's content reached origin/main,
+# comparing the blob the PR produced (at <ref>) against origin/main:
+#   identical    — same blob oid, so this PR's exact content for that path is
+#                  on main. Mere existence of the path proves nothing: a PR
+#                  that only modifies pre-existing files would read as landed
+#                  on the strength of files that were already there.
+#   never        — the path has NO history on origin/main at all, the only
+#                  available proof that the change never landed; bare absence
+#                  is also what a later delete or rename produces
+#   inconclusive — differing blobs (landed then edited further, or never
+#                  landed) or a path deleted/renamed after landing
 path_evidence() {
-  if git cat-file -e "origin/main:$1" 2>/dev/null; then
-    echo present
-  elif [ -z "$(git log --oneline -1 origin/main -- "$1" 2>/dev/null)" ]; then
+  local ref="$1" path="$2" ours theirs
+  ours=$(git rev-parse "$ref:$path" 2>/dev/null) || ours=""
+  theirs=$(git rev-parse "origin/main:$path" 2>/dev/null) || theirs=""
+  if [ -n "$ours" ] && [ "$ours" = "$theirs" ]; then
+    echo identical
+  elif [ -z "$(git log --oneline -1 origin/main -- "$path" 2>/dev/null)" ]; then
     echo never
   else
-    echo gone
+    echo inconclusive
   fi
 }
 
 # Pure decision table over per-path evidence counts, kept side-effect-free so
 # --self-test can exercise it without git or gh. One path that never existed on
-# origin/main outweighs any number of present ones: a squash that landed this
-# PR's content would have put every added/modified path into main's history.
-# A truncated file list can hide exactly that one path, so it may confirm
+# origin/main outweighs any number of identical ones: a squash that landed this
+# PR's content would have put every path it touched into main's history. A
+# truncated file list can hide exactly that path, so truncation may confirm
 # NOT-ON-MAIN but must never conclude the content landed.
 classify_content() {
-  local present="$1" never="$2" truncated="$3"
+  local identical="$1" never="$2" truncated="$3"
   if [ "$never" -gt 0 ]; then
     echo "NOTONMAIN:"
   elif [ "$truncated" = "yes" ]; then
     echo "ERROR:PR file list is truncated (gh returns at most 100 files) — content check cannot rule out an unlanded path"
-  elif [ "$present" -gt 0 ]; then
+  elif [ "$identical" -gt 0 ]; then
     echo "SQUASHED:"
   else
-    echo "ERROR:no added/modified path could be judged against origin/main"
+    echo "ERROR:no path could be matched to origin/main by content"
+  fi
+}
+
+# The tree to read the PR's own version of each path from. The merge commit is
+# usually still local; when its branch has been deleted and pruned, GitHub
+# still serves the PR head under refs/pull/<n>/head.
+pr_content_ref() {
+  local pr="$1" merge_oid="$2"
+  if [ -n "$merge_oid" ] && git cat-file -e "${merge_oid}^{commit}" 2>/dev/null; then
+    printf '%s\n' "$merge_oid"
+  elif git fetch --quiet origin "refs/pull/$pr/head" 2>/dev/null; then
+    git rev-parse FETCH_HEAD
   fi
 }
 
 # Decide by content whether a merged PR's changes are on origin/main, for the
-# case where ancestry cannot see through a squash. DELETED paths are excluded:
-# an unlanded deletion leaves the file present on main and would read as
-# evidence of landing.
+# case where ancestry cannot see through a squash.
 content_check() {
-  local repo="$1" pr="$2" pr_files present=0 never=0 truncated=no path
+  local repo="$1" pr="$2" merge_oid="$3" ref pr_files identical=0 never=0 truncated=no path
   if ! pr_files=$(gh pr view "$pr" --repo "$repo" --json changedFiles,files 2>/dev/null); then
     echo "ERROR:could not list PR files for the content check"
+    return
+  fi
+  ref=$(pr_content_ref "$pr" "$merge_oid")
+  if [ -z "$ref" ]; then
+    echo "ERROR:PR content is unreachable locally (merge commit pruned, refs/pull/$pr/head unfetchable)"
     return
   fi
   if [ "$(jq -r '.files | length' <<<"$pr_files")" -lt "$(jq -r '.changedFiles' <<<"$pr_files")" ]; then
@@ -234,12 +255,12 @@ content_check() {
   fi
   while IFS= read -r path; do
     [ -n "$path" ] || continue
-    case "$(path_evidence "$path")" in
-      present) present=$((present + 1)) ;;
+    case "$(path_evidence "$ref" "$path")" in
+      identical) identical=$((identical + 1)) ;;
       never) never=$((never + 1)) ;;
     esac
-  done < <(jq -r '.files[] | select(.changeType != "DELETED") | .path' <<<"$pr_files")
-  classify_content "$present" "$never" "$truncated"
+  done < <(jq -r '.files[].path' <<<"$pr_files")
+  classify_content "$identical" "$never" "$truncated"
 }
 
 check_one() {
@@ -290,7 +311,7 @@ check_one() {
   # ancestor. Only a merged PR reaches here, so there is always something to
   # look for on main.
   if [ "$code" = "STACKED" ]; then
-    verdict=$(content_check "$repo" "$pr")
+    verdict=$(content_check "$repo" "$pr" "$merge_oid")
     code="${verdict%%:*}"
     detail="${verdict#*:}"
   fi
@@ -314,10 +335,10 @@ check_one() {
       echo "ON-MAIN  $id   PR #$pr merged into main, commit $merge_oid is on origin/main ($repo)$staleness"
       ;;
     SQUASHED)
-      echo "SQUASHED $id   CONTENT-ON-MAIN-VIA-SQUASH: PR #$pr merged into $base and its merge commit $merge_oid is not an ancestor of origin/main, but every added/modified path it touches is on origin/main — the stack root squashed the content in. Safe to close ($repo)$staleness"
+      echo "SQUASHED $id   CONTENT-ON-MAIN-VIA-SQUASH: PR #$pr merged into $base and its merge commit $merge_oid is not an ancestor of origin/main, but the file content it produced is byte-identical on origin/main — the stack root squashed the content in. Safe to close ($repo)$staleness"
       ;;
     NOTONMAIN)
-      echo "FAIL     $id   NOT-ON-MAIN: PR #$pr merged into $base, and paths it added are absent from origin/main and from main's entire history — do not close ($repo)$staleness"
+      echo "FAIL     $id   NOT-ON-MAIN: PR #$pr merged into $base, and paths it touches are absent from origin/main and from main's entire history — do not close ($repo)$staleness"
       return 1
       ;;
     FAIL)
@@ -420,20 +441,22 @@ self_test() {
     || { echo "FAIL: resolve_pr_reference got '$got', want 'NUM:1364:yes'"; fail=1; }
 
   # classify_content: one path that never existed on main outweighs any number
-  # of present ones. Regression case: PR #1304 modifies .pre-commit-config.yaml
-  # (present on main) while its deliverable check-token-refs.mjs never landed.
+  # of content matches. Regression case: PR #1304 modifies files that are on
+  # main while its deliverable check-token-refs.mjs never landed.
   got=$(classify_content 12 1 no)
-  [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content reports NOT-ON-MAIN when any added path never existed on main" \
+  [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content reports NOT-ON-MAIN when any path never existed on main" \
     || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
 
   got=$(classify_content 4 0 no)
-  [ "$got" = "SQUASHED:" ] && echo "ok: classify_content reports CONTENT-ON-MAIN-VIA-SQUASH when every judged path is on main" \
+  [ "$got" = "SQUASHED:" ] && echo "ok: classify_content reports CONTENT-ON-MAIN-VIA-SQUASH when the PR's content is byte-identical on main" \
     || { echo "FAIL: classify_content got '$got', want 'SQUASHED:'"; fail=1; }
 
-  # classify_content: every path inconclusive (all deleted/renamed after
-  # landing) -> ERROR, never a silent pass.
+  # classify_content: no path matched by content -> ERROR, never a silent pass.
+  # This is the fail-closed case for a stacked PR whose content has NOT landed:
+  # its paths exist on main (so existence alone would wrongly pass it) but none
+  # of its blobs match.
   got=$(classify_content 0 0 no)
-  [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content returns ERROR rather than passing a PR with no judgeable path" \
+  [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content returns ERROR rather than passing a PR whose content matches nothing on main" \
     || { echo "FAIL: classify_content got '$got', want ERROR:*"; fail=1; }
 
   # classify_content: gh caps `files` at 100 (PR #1162 reports changedFiles=236,
@@ -449,15 +472,21 @@ self_test() {
   [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content still reports NOT-ON-MAIN on a truncated list when a never-landed path is visible" \
     || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
 
-  # path_evidence: distinguishes never-on-main from present, using this repo's
-  # own local origin/main ref (no network).
-  got=$(path_evidence "scripts/bd-close-guard.sh")
-  [ "$got" = "present" ] && echo "ok: path_evidence sees a path that is on origin/main" \
-    || { echo "FAIL: path_evidence got '$got', want 'present'"; fail=1; }
+  # path_evidence: reads this repo's own local origin/main ref, no network.
+  got=$(path_evidence origin/main "scripts/bd-close-guard.sh")
+  [ "$got" = "identical" ] && echo "ok: path_evidence matches a blob that is byte-identical on origin/main" \
+    || { echo "FAIL: path_evidence got '$got', want 'identical'"; fail=1; }
 
-  got=$(path_evidence "scripts/definitely-not-a-real-path-9f3a.mjs")
+  got=$(path_evidence origin/main "scripts/definitely-not-a-real-path-9f3a.mjs")
   [ "$got" = "never" ] && echo "ok: path_evidence reports 'never' for a path absent from all of origin/main's history" \
     || { echo "FAIL: path_evidence got '$got', want 'never'"; fail=1; }
+
+  # path_evidence: a path that exists on main but whose blob differs is
+  # inconclusive, never positive evidence. `origin/main~1` stands in for a PR
+  # tree carrying a different version of a file main also has.
+  got=$(path_evidence origin/main~1 "$(git diff --name-only origin/main~1 origin/main | head -1)")
+  [ "$got" = "inconclusive" ] && echo "ok: path_evidence treats a differing blob as inconclusive, not as landed" \
+    || { echo "FAIL: path_evidence got '$got', want 'inconclusive'"; fail=1; }
 
   if [ "$fail" -eq 0 ]; then
     echo "bd-close-guard self-test: PASS"

--- a/scripts/bd-close-guard.sh
+++ b/scripts/bd-close-guard.sh
@@ -14,8 +14,17 @@
 # defect this guard exists to prevent: astro-plan-pjg was closed on the
 # strength of PR #1310 reading MERGED, while #1310 merged into
 # `061-selectable-app-language` and its commit was never on origin/main.
-# "MERGED" is not "on main"; ancestry of the merge commit on origin/main is
-# the only authoritative test, so that is what this script checks.
+# "MERGED" is not "on main", so this script never trusts `state`.
+#
+# Ancestry of the merge commit is checked first, but it is not sufficient on
+# its own. This repo squash-merges, so a stacked PR's merge commit lives on the
+# stack branch and is NEVER an ancestor of origin/main even after the stack
+# root squashes the same content onto main. Ancestry then answers "not on main"
+# for work that is on main. That failure is fail-closed — it withholds a
+# green-light, it never grants one — but it blocked real closures on
+# 2026-07-21. A negative ancestry result therefore falls back to a CONTENT
+# check against origin/main (see content_check) instead of being reported as
+# the final answer.
 #
 # PR resolution order:
 #   1. A `FIX-PR:` line (start-of-line, see below) in `notes`. If present it
@@ -60,9 +69,9 @@
 # never modifies the working tree (only updates the origin/main
 # remote-tracking ref via fetch).
 #
-# Exit status: 0 only if every bead's fix commit is an ancestor of
-# origin/main. Non-zero if any bead is OPEN, STACKED (merged into a non-main
-# branch), UNKNOWN, or errored.
+# Exit status: 0 only if every bead's fix is on origin/main, either by
+# ancestry (ON-MAIN) or by content (CONTENT-ON-MAIN-VIA-SQUASH). Non-zero if
+# any bead is OPEN, NOT-ON-MAIN, UNKNOWN, or errored.
 set -euo pipefail
 
 REPO_DEFAULT="platevault/platevault"
@@ -158,6 +167,8 @@ classify_pr() {
       fi
       case "$is_ancestor" in
         yes) echo "PASS:" ;;
+        # Not a final verdict: ancestry cannot see through a squash, so the
+        # caller re-checks by content before reporting anything.
         no) echo "STACKED:" ;;
         *) echo "ERROR:could not verify ancestry" ;;
       esac
@@ -171,8 +182,68 @@ classify_pr() {
   esac
 }
 
+# Evidence that one path carries about whether a PR's content reached
+# origin/main:
+#   present — the path exists on origin/main right now
+#   never   — the path has NO history on origin/main at all, which is the only
+#             available proof that the change never landed; mere absence is
+#             also what a later delete or rename produces
+#   gone    — absent now but present in origin/main's history: deleted or
+#             renamed after landing, so it proves nothing either way
+path_evidence() {
+  if git cat-file -e "origin/main:$1" 2>/dev/null; then
+    echo present
+  elif [ -z "$(git log --oneline -1 origin/main -- "$1" 2>/dev/null)" ]; then
+    echo never
+  else
+    echo gone
+  fi
+}
+
+# Pure decision table over per-path evidence counts, kept side-effect-free so
+# --self-test can exercise it without git or gh. One path that never existed on
+# origin/main outweighs any number of present ones: a squash that landed this
+# PR's content would have put every added/modified path into main's history.
+# A truncated file list can hide exactly that one path, so it may confirm
+# NOT-ON-MAIN but must never conclude the content landed.
+classify_content() {
+  local present="$1" never="$2" truncated="$3"
+  if [ "$never" -gt 0 ]; then
+    echo "NOTONMAIN:"
+  elif [ "$truncated" = "yes" ]; then
+    echo "ERROR:PR file list is truncated (gh returns at most 100 files) — content check cannot rule out an unlanded path"
+  elif [ "$present" -gt 0 ]; then
+    echo "SQUASHED:"
+  else
+    echo "ERROR:no added/modified path could be judged against origin/main"
+  fi
+}
+
+# Decide by content whether a merged PR's changes are on origin/main, for the
+# case where ancestry cannot see through a squash. DELETED paths are excluded:
+# an unlanded deletion leaves the file present on main and would read as
+# evidence of landing.
+content_check() {
+  local repo="$1" pr="$2" pr_files present=0 never=0 truncated=no path
+  if ! pr_files=$(gh pr view "$pr" --repo "$repo" --json changedFiles,files 2>/dev/null); then
+    echo "ERROR:could not list PR files for the content check"
+    return
+  fi
+  if [ "$(jq -r '.files | length' <<<"$pr_files")" -lt "$(jq -r '.changedFiles' <<<"$pr_files")" ]; then
+    truncated=yes
+  fi
+  while IFS= read -r path; do
+    [ -n "$path" ] || continue
+    case "$(path_evidence "$path")" in
+      present) present=$((present + 1)) ;;
+      never) never=$((never + 1)) ;;
+    esac
+  done < <(jq -r '.files[] | select(.changeType != "DELETED") | .path' <<<"$pr_files")
+  classify_content "$present" "$never" "$truncated"
+}
+
 check_one() {
-  local id="$1" bead_json ref pr claim repo pr_json state base merge_oid is_ancestor verdict code detail staleness
+  local id="$1" bead_json ref pr claim repo pr_json state base merge_oid is_ancestor verdict code detail on_main staleness
   if ! bead_json=$(bd show "$id" --json 2>/dev/null | jq -e '.[0]' 2>/dev/null); then
     echo "ERROR    $id   bd show failed (bad id, or bd unavailable)"
     return 1
@@ -210,24 +281,43 @@ check_one() {
     fi
   fi
 
-  # The FIX-PR note's on-main= claim is a snapshot as of its `verified=`
-  # date, not truth — main moves after the note is written. A mismatch is
-  # reported, never silently trusted or silently overridden.
-  staleness=""
-  if [ -n "$claim" ] && [ "$claim" != "$is_ancestor" ]; then
-    staleness=" — FIX-PR note claims on-main=$claim, ancestry now says $is_ancestor (note is stale)"
-  fi
-
   verdict=$(classify_pr "$state" "$merge_oid" "$is_ancestor")
   code="${verdict%%:*}"
   detail="${verdict#*:}"
 
+  # Ancestry saying "no" is not the final answer: a squash-merged stack root
+  # puts this PR's content on main without its merge commit ever becoming an
+  # ancestor. Only a merged PR reaches here, so there is always something to
+  # look for on main.
+  if [ "$code" = "STACKED" ]; then
+    verdict=$(content_check "$repo" "$pr")
+    code="${verdict%%:*}"
+    detail="${verdict#*:}"
+  fi
+
+  # The FIX-PR note's on-main= claim is a snapshot as of its `verified=` date,
+  # not truth — main moves after the note is written. Compare it against the
+  # final determination rather than raw ancestry, or every squash-landed bead
+  # whose note reads on-main=yes gets falsely branded stale.
+  case "$code" in
+    PASS | SQUASHED) on_main="yes" ;;
+    NOTONMAIN) on_main="no" ;;
+    *) on_main="$is_ancestor" ;;
+  esac
+  staleness=""
+  if [ -n "$claim" ] && [ "$claim" != "$on_main" ]; then
+    staleness=" — FIX-PR note claims on-main=$claim, this check says on-main=$on_main (note is stale)"
+  fi
+
   case "$code" in
     PASS)
-      echo "PASS     $id   PR #$pr merged into main, commit $merge_oid is on origin/main ($repo)$staleness"
+      echo "ON-MAIN  $id   PR #$pr merged into main, commit $merge_oid is on origin/main ($repo)$staleness"
       ;;
-    STACKED)
-      echo "FAIL     $id   PR #$pr merged into $base, not on origin/main — do not close ($repo)$staleness"
+    SQUASHED)
+      echo "SQUASHED $id   CONTENT-ON-MAIN-VIA-SQUASH: PR #$pr merged into $base and its merge commit $merge_oid is not an ancestor of origin/main, but every added/modified path it touches is on origin/main — the stack root squashed the content in. Safe to close ($repo)$staleness"
+      ;;
+    NOTONMAIN)
+      echo "FAIL     $id   NOT-ON-MAIN: PR #$pr merged into $base, and paths it added are absent from origin/main and from main's entire history — do not close ($repo)$staleness"
       return 1
       ;;
     FAIL)
@@ -328,6 +418,46 @@ self_test() {
   got=$(resolve_pr_reference '{"metadata":{"pr":9999},"notes":"FIX-PR: #1364 | base=main | on-main=yes | verified=2026-07-21 -- see also PR #4242 for context.","description":""}')
   [ "$got" = "NUM:1364:yes" ] && echo "ok: resolve_pr_reference lets FIX-PR win outright over metadata.pr and other prose numbers" \
     || { echo "FAIL: resolve_pr_reference got '$got', want 'NUM:1364:yes'"; fail=1; }
+
+  # classify_content: one path that never existed on main outweighs any number
+  # of present ones. Regression case: PR #1304 modifies .pre-commit-config.yaml
+  # (present on main) while its deliverable check-token-refs.mjs never landed.
+  got=$(classify_content 12 1 no)
+  [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content reports NOT-ON-MAIN when any added path never existed on main" \
+    || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
+
+  got=$(classify_content 4 0 no)
+  [ "$got" = "SQUASHED:" ] && echo "ok: classify_content reports CONTENT-ON-MAIN-VIA-SQUASH when every judged path is on main" \
+    || { echo "FAIL: classify_content got '$got', want 'SQUASHED:'"; fail=1; }
+
+  # classify_content: every path inconclusive (all deleted/renamed after
+  # landing) -> ERROR, never a silent pass.
+  got=$(classify_content 0 0 no)
+  [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content returns ERROR rather than passing a PR with no judgeable path" \
+    || { echo "FAIL: classify_content got '$got', want ERROR:*"; fail=1; }
+
+  # classify_content: gh caps `files` at 100 (PR #1162 reports changedFiles=236,
+  # files=100), and the hidden path could be the unlanded one. Truncation must
+  # never conclude the content landed...
+  got=$(classify_content 100 0 yes)
+  [ "${got%%:*}" = "ERROR" ] && echo "ok: classify_content refuses to conclude on-main from a truncated file list" \
+    || { echo "FAIL: classify_content got '$got', want ERROR:*"; fail=1; }
+
+  # ...but a `never` path found within the visible 100 is positive evidence
+  # that stands on its own.
+  got=$(classify_content 99 1 yes)
+  [ "$got" = "NOTONMAIN:" ] && echo "ok: classify_content still reports NOT-ON-MAIN on a truncated list when a never-landed path is visible" \
+    || { echo "FAIL: classify_content got '$got', want 'NOTONMAIN:'"; fail=1; }
+
+  # path_evidence: distinguishes never-on-main from present, using this repo's
+  # own local origin/main ref (no network).
+  got=$(path_evidence "scripts/bd-close-guard.sh")
+  [ "$got" = "present" ] && echo "ok: path_evidence sees a path that is on origin/main" \
+    || { echo "FAIL: path_evidence got '$got', want 'present'"; fail=1; }
+
+  got=$(path_evidence "scripts/definitely-not-a-real-path-9f3a.mjs")
+  [ "$got" = "never" ] && echo "ok: path_evidence reports 'never' for a path absent from all of origin/main's history" \
+    || { echo "FAIL: path_evidence got '$got', want 'never'"; fail=1; }
 
   if [ "$fail" -eq 0 ]; then
     echo "bd-close-guard self-test: PASS"


### PR DESCRIPTION
## Summary

- The bead close-guard refused to green-light closing a bead whose fix had landed on `main` via a stacked PR, because it decided "is this on main?" with `git merge-base --is-ancestor` alone.
- This repo squash-merges. A squash rewrites a branch's commits into one new commit on `main`, so a merged branch tip is never an ancestor of `main` even when its content is fully landed. For a stacked PR the merge commit sits on the stack branch; the stack root's squash carries the same content onto `main` under a different oid. Ancestry answers "no" for work that is on `main`.
- This was **fail-closed** — the guard withheld a green-light, it never approved a bad close. Friction, not risk. It still blocked real closures and produced nine beads annotated `on-main=no` in error.
- Ancestry stays the fast path. When it says no, the guard now falls back to a content check and reports a third state, `CONTENT-ON-MAIN-VIA-SQUASH`, distinct from `ON-MAIN` and `NOT-ON-MAIN`.

## How the content check decides

Per path, comparing the blob the PR produced (from its merge commit, or `refs/pull/<n>/head` if pruned) against `origin/main`:

| Evidence | Test | Meaning |
|---|---|---|
| identical | blob oids equal | This PR's exact content is on `main` |
| never | `git log origin/main -- <path>` empty | Path never existed on `main` at any point |
| inconclusive | blobs differ, or absent with non-empty log | Landed then edited, deleted, renamed — or never landed |

One `never` path → `NOT-ON-MAIN`. The content fallback reports `CONTENT-ON-MAIN-VIA-SQUASH` only when every listed PR path is `identical` and the GitHub file list is complete. A squash that landed the content would have put every path it touched into `main`'s history, so an empty log is proof the change never arrived.

Byte-identity is deliberately the positive test rather than path existence. `git cat-file -e` succeeds on a modified path because the file pre-existed, not because the PR's change landed — so an existence test would have passed an unlanded modify-only stacked PR, inverting the fail-closed contract. Every remaining gap resolves to `ERROR` or `NOT-ON-MAIN`, never to a green-light:

- Truncated file list (`gh pr view --json files` caps at 100; PR #1162 reports `changedFiles: 236`, 100 listed) → `ERROR`, since a hidden path could be the unlanded one. A `never` found among the visible 100 still resolves `NOT-ON-MAIN`.
- No identical path, PR tree unreachable, or `MERGED` with no merge commit → `ERROR`.
- `OPEN`/`CLOSED` PRs get no content fallback.

The FIX-PR `on-main=` staleness comparison now runs against the final determination rather than raw ancestry; otherwise every squash-landed bead whose note reads `on-main=yes` would be falsely branded stale.

## Validation

Network-free self-tests cover the content decision table, truncation guard, identical/never/inconclusive discriminator, malformed evidence, and a literal-newline filename regression. `bash -n`, ShellCheck, `git diff --check`, and the self-test pass.

## Note

The `Dead-caller ratchet` CI step fails on `origin/main` (astro-plan-bz0u, P0); this branch inherits that red. Not from these changes.

Refs astro-plan-js4z, astro-plan-7dwr
