### PR TITLE
test(e2e): wait for Windows preference flush

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1893,6 +1893,35 @@ impl E2eApp {
         self.shutdown().await
     }
 
+    /// Wait until the isolated WebView2 profile has materialized persisted
+    /// storage after the native window has closed. WebView2 writes LevelDB
+    /// files asynchronously during teardown; observing the profile here
+    /// prevents a relaunch from racing that final flush on Windows.
+    #[cfg(target_os = "windows")]
+    pub async fn wait_for_webview_storage_flush() -> Result<()> {
+        let dir = lookup(&instance_env().vars, "WEBVIEW2_USER_DATA_FOLDER")
+            .map(PathBuf::from)
+            .context("WEBVIEW2_USER_DATA_FOLDER was not configured")?;
+        let leveldb = dir.join("Default").join("Local Storage").join("leveldb");
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            let has_files = std::fs::read_dir(&leveldb)
+                .ok()
+                .map(|entries| entries.flatten().any(|entry| entry.path().is_file()))
+                .unwrap_or(false);
+            if has_files {
+                return Ok(());
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!(
+                    "WebView2 profile did not expose persisted LevelDB files at {}",
+                    leveldb.display()
+                );
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+    }
+
     /// Quit the WebDriver session and kill the `tauri-webdriver` CLI process
     /// if present. Quitting the session (a `DELETE /session/{id}` through the
     /// CLI) makes the CLI terminate the app process it launched on our

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -875,6 +875,18 @@ async fn read_dock_pref(app: &E2eApp, dock_id: &str) -> anyhow::Result<(String, 
     Ok((placement.to_string(), width))
 }
 
+/// Return the raw preference bytes held by the live webview. Keeping this
+/// assertion separate from the resolved dock value proves the write happened
+/// before native shutdown rather than being reconstructed by the UI.
+async fn read_raw_preferences(app: &E2eApp) -> anyhow::Result<String> {
+    let raw: Value = app
+        .driver
+        .execute("return localStorage.getItem('alm-preferences');", vec![])
+        .await?
+        .convert()?;
+    raw.as_str().map(str::to_owned).context("alm-preferences was absent before shutdown")
+}
+
 /// The rendered width of the side dock, as the browser actually lays it out.
 async fn rendered_side_width(app: &E2eApp) -> anyhow::Result<i64> {
     let v: Value = app
@@ -1022,8 +1034,17 @@ async fn targets_ui_dock_pin_and_width_survive_a_real_restart() -> anyhow::Resul
          drag did not reach the handler, or clamping pinned it back to the default."
     );
 
+    let raw_before_shutdown = read_raw_preferences(&app).await?;
+    anyhow::ensure!(
+        raw_before_shutdown.contains("detailDock"),
+        "alm-preferences did not contain detailDock before shutdown: {raw_before_shutdown}"
+    );
+
     // Clean window close: WebView2 flushes localStorage here and not on a kill.
     app.graceful_shutdown().await?;
+
+    #[cfg(target_os = "windows")]
+    E2eApp::wait_for_webview_storage_flush().await?;
 
     // Cold start: new process, empty module cache, storage read from disk.
     let app = E2eApp::relaunch().await?;


### PR DESCRIPTION
Fixes astro-plan-xz3r.

Adds a raw alm-preferences assertion before graceful shutdown and waits for WebView2 Default/Local Storage/leveldb files after native process exit before relaunch. No product or migration changes.

Validation: cargo check -p e2e_tests (Linux). Windows journey/full shard must run in CI.