### PR TITLE
fix: prevent plan audit failure reasons from silently regressing

### DIFF
--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1,5 +1,7 @@
 use super::*;
 use audit::EventBus;
+use fs_executor::failure::{FailureCode, PlanItemFailure};
+use fs_executor::RollbackOutcome;
 use persistence_db::repositories::audit::{
     count_audit_entries, list_audit_entries, AuditLogFilter,
 };
@@ -63,6 +65,83 @@ async fn insert_approved_plan_with_items(db: &Database, plan_id: &str, item_coun
 
     repo::update_plan_state(db.pool(), plan_id, "ready_for_review").await.unwrap();
     repo::set_approved(db.pool(), plan_id, "2026-06-01T00:00:00Z", "test-token").await.unwrap();
+}
+
+#[tokio::test]
+async fn plan_apply_callbacks_persist_every_producible_failure_code() {
+    const PRODUCIBLE_CODES: [FailureCode; 19] = [
+        FailureCode::PermissionDenied,
+        FailureCode::ConflictDestinationExists,
+        FailureCode::SourceMissing,
+        FailureCode::SourceLocked,
+        FailureCode::VolumeUnavailable,
+        FailureCode::DiskFull,
+        FailureCode::PathInvalid,
+        FailureCode::RootEscape,
+        FailureCode::SymlinkComponent,
+        FailureCode::DestructiveUnconfirmed,
+        FailureCode::ProtectedSource,
+        FailureCode::TrashUnavailable,
+        FailureCode::CopySucceededDeleteFailed,
+        FailureCode::CopySucceededDeleteFailedRollbackFailed,
+        FailureCode::ItemStale,
+        FailureCode::OsTrashFull,
+        FailureCode::OsTrashPermissionDenied,
+        FailureCode::MaterializationUnsupported,
+        FailureCode::Unknown,
+    ];
+
+    let (db, bus) = setup().await;
+    let plan_id = "p-all-failure-codes";
+    let run_id = "run-all-failure-codes";
+    insert_approved_plan_with_items(&db, plan_id, PRODUCIBLE_CODES.len()).await;
+    let item_count = i64::try_from(PRODUCIBLE_CODES.len()).unwrap();
+    apply_repo::cas_approved_to_applying(
+        db.pool(),
+        plan_id,
+        run_id,
+        "test-token",
+        item_count,
+        item_count,
+    )
+    .await
+    .unwrap();
+
+    let callbacks = PlanApplyCallbacks {
+        pool: db.pool().clone(),
+        bus,
+        plan_id: plan_id.to_owned(),
+        run_id: run_id.to_owned(),
+        op_emitter: None,
+    };
+
+    for (index, code) in PRODUCIBLE_CODES.into_iter().enumerate() {
+        let item_id = format!("{plan_id}-item-{index}");
+        callbacks.on_item_start(&item_id).await;
+        callbacks
+            .on_item_progress(ItemProgressEvent {
+                item_id: item_id.clone(),
+                prior_state: "applying".to_owned(),
+                new_state: "failed".to_owned(),
+                at: Timestamp::now_iso(),
+                failure: Some(PlanItemFailure::with_code(code, "natural-seam failure")),
+                rollback_attempted: false,
+                rollback_outcome: RollbackOutcome::NotApplicable,
+                rollback_message: None,
+                audit_reason: None,
+            })
+            .await;
+
+        let persisted: Option<String> = sqlx::query_scalar(
+            "SELECT failure_code FROM plan_apply_events WHERE plan_id = ? AND item_id = ?",
+        )
+        .bind(plan_id)
+        .bind(&item_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(persisted.as_deref(), Some(code.as_str()), "failed for {code:?}");
+    }
 }
 
 /// Regression (FIX review, priority-check #2): `resolve_root_path`'s

--- a/crates/fs/executor/src/failure.rs
+++ b/crates/fs/executor/src/failure.rs
@@ -261,6 +261,33 @@ mod tests {
     }
 
     #[test]
+    fn remaining_io_kinds_map_to_producible_codes() {
+        let cases = [
+            (io::ErrorKind::WouldBlock, FailureCode::SourceLocked),
+            (io::ErrorKind::StorageFull, FailureCode::DiskFull),
+            (io::ErrorKind::InvalidFilename, FailureCode::PathInvalid),
+            (io::ErrorKind::Other, FailureCode::Unknown),
+        ];
+
+        for (kind, expected) in cases {
+            let failure = PlanItemFailure::from_io(&io::Error::from(kind), "test operation");
+            assert_eq!(failure.code, expected, "failed for {kind:?}");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn unavailable_volume_os_errors_map_correctly() {
+        for raw_os_error in [6, 19] {
+            let failure = PlanItemFailure::from_io(
+                &io::Error::from_raw_os_error(raw_os_error),
+                "test operation",
+            );
+            assert_eq!(failure.code, FailureCode::VolumeUnavailable);
+        }
+    }
+
+    #[test]
     fn item_stale_triggers_pause() {
         assert!(FailureCode::ItemStale.triggers_pause());
         assert!(FailureCode::VolumeUnavailable.triggers_pause());
@@ -276,6 +303,11 @@ mod tests {
             FailureCode::CopySucceededDeleteFailedRollbackFailed.as_str(),
             "copy.succeeded.delete.failed.rollback.failed"
         );
+    }
+
+    #[test]
+    fn os_trash_unavailable_compatibility_alias_retains_its_wire_value() {
+        assert_eq!(FailureCode::OsTrashUnavailable.as_str(), "os_trash.unavailable");
     }
 
     #[test]

--- a/crates/fs/executor/src/ops/trash_op.rs
+++ b/crates/fs/executor/src/ops/trash_op.rs
@@ -136,13 +136,18 @@ fn classify_trash_error(err: &trash::Error, path: &Utf8Path) -> (FailureCode, St
     let msg = format!("OS trash failed for '{path}': {err}");
     // `trash::Error` doesn't expose a rich enum in all versions; use Display
     // to detect common cases.
-    let err_str = err.to_string().to_lowercase();
+    let failure_code = classify_trash_error_message(&err.to_string());
+    (failure_code, msg)
+}
+
+fn classify_trash_error_message(message: &str) -> FailureCode {
+    let err_str = message.to_lowercase();
     if err_str.contains("permission") || err_str.contains("access denied") {
-        (FailureCode::OsTrashPermissionDenied, msg)
+        FailureCode::OsTrashPermissionDenied
     } else if err_str.contains("full") || err_str.contains("no space") {
-        (FailureCode::OsTrashFull, msg)
+        FailureCode::OsTrashFull
     } else {
-        (FailureCode::TrashUnavailable, msg)
+        FailureCode::TrashUnavailable
     }
 }
 
@@ -155,6 +160,21 @@ mod tests {
 
     fn utf8(p: &std::path::Path) -> Utf8PathBuf {
         Utf8PathBuf::from_path_buf(p.to_path_buf()).expect("temp dir path is UTF-8")
+    }
+
+    #[test]
+    fn trash_error_messages_map_to_producible_codes() {
+        let cases = [
+            ("permission denied", FailureCode::OsTrashPermissionDenied),
+            ("access denied", FailureCode::OsTrashPermissionDenied),
+            ("trash is full", FailureCode::OsTrashFull),
+            ("no space left", FailureCode::OsTrashFull),
+            ("trash service unavailable", FailureCode::TrashUnavailable),
+        ];
+
+        for (message, expected) in cases {
+            assert_eq!(classify_trash_error_message(message), expected, "failed for {message}");
+        }
     }
 
     /// T014: trash destination moves to OS bin; archive fallback recorded when


### PR DESCRIPTION
## Summary

- Prevent plan audit failure reasons from silently regressing by covering all 19 production-emitted failure-code values.
- Cover the remaining standard I/O and OS-trash classification seams.
- Assert the `OsTrashUnavailable` compatibility alias while excluding it from the production-emitted table.

## Why

Audit records must preserve the executor outcome, not only the failed state.

## Compositional test strategy

- Exercise the production persistence callback with each producible `FailureCode`.
- Exercise environment-dependent error classification at deterministic I/O and trash-message seams.
- Keep the five executor-to-persistence integration cases for end-to-end coverage.
- Avoid a production fault-injection API.

## Test plan

- [x] Callback persistence test: 1 passed
- [x] `app_core` plan-apply unit tests: 44 passed
- [x] `plan_apply_audit_integration`: 13 passed
- [x] `fs_executor` tests: 98 passed
- [x] `cargo fmt --check`
- [x] `cargo clippy -p app_core -p fs_executor --all-targets -- -D warnings`
- [x] `git diff --check`

Refs #1222
