### PR TITLE
test(e2e): give Windows WebView2 time to flush storage

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1878,7 +1878,16 @@ impl E2eApp {
         // Proof the window/process actually tore down: once it has, WebDriver
         // commands against the now-gone window/session fail — treat any
         // error the same as an explicit "bridge gone" (`Ok(false)`).
-        let deadline = Instant::now() + Duration::from_secs(10);
+        // WebView2 can take several seconds to finish tearing down its
+        // renderer/profile on a loaded Windows runner.  Killing the proxy
+        // after the shorter cross-platform deadline drops localStorage before
+        // the LevelDB writer has committed it.
+        let shutdown_timeout = if cfg!(target_os = "windows") {
+            Duration::from_secs(60)
+        } else {
+            Duration::from_secs(10)
+        };
+        let deadline = Instant::now() + shutdown_timeout;
         loop {
             match self.bridge_ready().await {
                 Ok(false) | Err(_) => break,
@@ -1902,24 +1911,48 @@ impl E2eApp {
         let dir = lookup(&instance_env().vars, "WEBVIEW2_USER_DATA_FOLDER")
             .map(PathBuf::from)
             .context("WEBVIEW2_USER_DATA_FOLDER was not configured")?;
-        let leveldb = dir.join("Default").join("Local Storage").join("leveldb");
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
-            let has_files = std::fs::read_dir(&leveldb)
-                .ok()
-                .map(|entries| entries.flatten().any(|entry| entry.path().is_file()))
-                .unwrap_or(false);
-            if has_files {
-                return Ok(());
+            if let Some(leveldb) = find_leveldb_dir(&dir) {
+                if std::fs::read_dir(&leveldb)
+                    .ok()
+                    .is_some_and(|entries| entries.flatten().any(|entry| entry.path().is_file()))
+                {
+                    return Ok(());
+                }
             }
             if Instant::now() >= deadline {
+                let expected = dir.join("Default").join("Local Storage").join("leveldb");
                 anyhow::bail!(
                     "WebView2 profile did not expose persisted LevelDB files at {}",
-                    leveldb.display()
+                    expected.display()
                 );
             }
             tokio::time::sleep(Duration::from_millis(100)).await;
         }
+    }
+
+    /// Locate WebView2's local-storage directory without assuming the profile
+    /// name chosen by the runtime. Chromium normally uses `Default`, but
+    /// updates and test runners can select another profile name.
+    #[cfg(target_os = "windows")]
+    fn find_leveldb_dir(root: &Path) -> Option<PathBuf> {
+        let mut pending = vec![root.to_path_buf()];
+        while let Some(dir) = pending.pop() {
+            let Ok(entries) = std::fs::read_dir(&dir) else {
+                continue;
+            };
+            for entry in entries.flatten() {
+                let path = entry.path();
+                if path.is_dir() {
+                    if path.file_name().is_some_and(|name| name == "leveldb") {
+                        return Some(path);
+                    }
+                    pending.push(path);
+                }
+            }
+        }
+        None
     }
 
     /// Quit the WebDriver session and kill the `tauri-webdriver` CLI process

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1913,7 +1913,7 @@ impl E2eApp {
             .context("WEBVIEW2_USER_DATA_FOLDER was not configured")?;
         let deadline = Instant::now() + Duration::from_secs(10);
         loop {
-            if let Some(leveldb) = find_leveldb_dir(&dir) {
+            if let Some(leveldb) = Self::find_leveldb_dir(&dir) {
                 if std::fs::read_dir(&leveldb)
                     .ok()
                     .is_some_and(|entries| entries.flatten().any(|entry| entry.path().is_file()))


### PR DESCRIPTION
## Fix

- allow up to 60s for the Windows native close to tear down WebView2 before the harness falls back to killing the proxy
- locate the committed LevelDB directory recursively instead of assuming the Default profile

## Evidence

- Failed runs 29824225393 and 29824144279 both show the dock preference missing after a forced shutdown; #1419 also showed the fixed profile path had no files.
- cargo check -p e2e_tests passes.
- git diff --check and pre-commit hooks pass.

This is a follow-up stacked on #1419; do not merge independently.