### PR TITLE
test(e2e): give Windows WebView2 time to flush storage

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1878,7 +1878,12 @@ impl E2eApp {
         // Proof the window/process actually tore down: once it has, WebDriver
         // commands against the now-gone window/session fail — treat any
         // error the same as an explicit "bridge gone" (`Ok(false)`).
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let shutdown_timeout = if cfg!(target_os = "windows") {
+            Duration::from_secs(60)
+        } else {
+            Duration::from_secs(10)
+        };
+        let deadline = Instant::now() + shutdown_timeout;
         loop {
             match self.bridge_ready().await {
                 Ok(false) | Err(_) => break,
@@ -1891,6 +1896,28 @@ impl E2eApp {
         tokio::time::sleep(Duration::from_millis(200)).await;
 
         self.shutdown().await
+    }
+
+    #[cfg(target_os = "windows")]
+    pub async fn wait_for_webview_storage_flush() -> Result<()> {
+        let dir = lookup(&instance_env().vars, "WEBVIEW2_USER_DATA_FOLDER")
+            .map(PathBuf::from)
+            .context("WEBVIEW2_USER_DATA_FOLDER was not configured")?;
+        let deadline = Instant::now() + Duration::from_secs(10);
+        loop {
+            if let Some(leveldb) = find_leveldb_dir(&dir) {
+                if std::fs::read_dir(&leveldb)
+                    .ok()
+                    .is_some_and(|entries| entries.flatten().any(|entry| entry.path().is_file()))
+                {
+                    return Ok(());
+                }
+            }
+            if Instant::now() >= deadline {
+                anyhow::bail!("WebView2 profile did not expose persisted LevelDB files");
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
     }
 
     /// Quit the WebDriver session and kill the `tauri-webdriver` CLI process
@@ -1907,6 +1934,24 @@ impl E2eApp {
         }
         Ok(())
     }
+}
+
+#[cfg(target_os = "windows")]
+fn find_leveldb_dir(root: &Path) -> Option<PathBuf> {
+    let mut pending = vec![root.to_path_buf()];
+    while let Some(dir) = pending.pop() {
+        let Ok(entries) = std::fs::read_dir(&dir) else { continue };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                if path.file_name().is_some_and(|name| name == "leveldb") {
+                    return Some(path);
+                }
+                pending.push(path);
+            }
+        }
+    }
+    None
 }
 
 impl Drop for E2eApp {

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -1025,6 +1025,9 @@ async fn targets_ui_dock_pin_and_width_survive_a_real_restart() -> anyhow::Resul
     // Clean window close: WebView2 flushes localStorage here and not on a kill.
     app.graceful_shutdown().await?;
 
+    #[cfg(target_os = "windows")]
+    E2eApp::wait_for_webview_storage_flush().await?;
+
     // Cold start: new process, empty module cache, storage read from disk.
     let app = E2eApp::relaunch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;


### PR DESCRIPTION
## Summary

- Allow the Windows harness to wait for WebView2 to finish closing before force-killing the proxy.
- Locate the committed LevelDB profile recursively so the flush check follows the actual profile.

## Delivery context

PR #1418 was squash-merged into main. This follow-up was rebased onto current main and now contains only the two-file WebView2 persistence fix.

## Test plan

- cargo fmt --check -- crates/e2e-tests/tests/common/mod.rs crates/e2e-tests/tests/targets_journeys.rs
- cargo test -p e2e_tests --test targets_journeys --no-run
- cargo clippy -p e2e_tests --test targets_journeys -- -D warnings
- Windows Real-UI E2E gate on this PR