### PR TITLE
fix: prevent duplicate sessions during startup recovery

### DIFF
--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -32,9 +32,6 @@
 //! (Ref: R-PlanOpen) as the expected degraded-mode behaviour.
 #![allow(clippy::doc_markdown)]
 
-use std::collections::HashSet;
-use std::sync::{LazyLock, Mutex as StdMutex};
-
 use audit::bus::EventBus;
 use audit::event_bus::{
     PlanApplyingCompleted, PlanDiscarded, TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_DISCARDED,
@@ -48,15 +45,9 @@ use sqlx::SqlitePool;
 use targeting_resolver::simbad::ResolveCache;
 use tokio::sync::{broadcast, Mutex};
 
-/// Serializes the check-and-insert sequence shared by the event listener and
-/// repair sweep. Both run in this process and may observe the same plan link.
-static MASTER_REGISTRATION_LOCK: Mutex<()> = Mutex::const_new(());
-
-/// Prevents the event listener and immediate repair sweep from applying the
-/// same terminal plan concurrently. The database link is removed only after
-/// ingest completes, so both paths can otherwise observe the same work item.
-static COMPLETED_PLAN_IDS: LazyLock<StdMutex<HashSet<String>>> =
-    LazyLock::new(|| StdMutex::new(HashSet::new()));
+/// Serializes applied-plan side effects shared by the event listener and repair
+/// sweep. Both can observe the same plan link before either path removes it.
+static PLAN_COMPLETION_LOCK: Mutex<()> = Mutex::const_new(());
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -203,30 +194,8 @@ pub(crate) async fn complete_applied_plan(
     resolve_cache: &ResolveCache,
     plan_id: &str,
 ) -> Result<(), String> {
-    {
-        let mut completed =
-            COMPLETED_PLAN_IDS.lock().map_err(|_| "completed plan guard poisoned".to_owned())?;
-        if !completed.insert(plan_id.to_owned()) {
-            tracing::debug!(plan_id, "inbox plan_listener: duplicate completion ignored");
-            return Ok(());
-        }
-    }
+    let _completion_guard = PLAN_COMPLETION_LOCK.lock().await;
 
-    let result = complete_applied_plan_once(pool, bus, resolve_cache, plan_id).await;
-    if result.is_err() {
-        if let Ok(mut completed) = COMPLETED_PLAN_IDS.lock() {
-            completed.remove(plan_id);
-        }
-    }
-    result
-}
-
-async fn complete_applied_plan_once(
-    pool: &SqlitePool,
-    bus: &EventBus,
-    resolve_cache: &ResolveCache,
-    plan_id: &str,
-) -> Result<(), String> {
     // spec 041 US4/T032: master registration is relocated here from the old
     // confirm-time fast path. When the applied plan belongs to a detected
     // calibration master inbox item, register the master now — this applies
@@ -300,8 +269,6 @@ async fn ingest_light_frames_if_applicable(
 ///
 /// Non-master items and plans with no linked inbox item are a no-op.
 async fn register_master_if_applicable(pool: &SqlitePool, plan_id: &str) -> Result<(), String> {
-    let _registration_guard = MASTER_REGISTRATION_LOCK.lock().await;
-
     let link = inbox_repo::get_plan_link_by_plan_id(pool, plan_id)
         .await
         .map_err(|e| format!("get_plan_link_by_plan_id({plan_id}): {e}"))?;

--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -32,6 +32,9 @@
 //! (Ref: R-PlanOpen) as the expected degraded-mode behaviour.
 #![allow(clippy::doc_markdown)]
 
+use std::collections::HashSet;
+use std::sync::{LazyLock, Mutex as StdMutex};
+
 use audit::bus::EventBus;
 use audit::event_bus::{
     PlanApplyingCompleted, PlanDiscarded, TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_DISCARDED,
@@ -48,6 +51,12 @@ use tokio::sync::{broadcast, Mutex};
 /// Serializes the check-and-insert sequence shared by the event listener and
 /// repair sweep. Both run in this process and may observe the same plan link.
 static MASTER_REGISTRATION_LOCK: Mutex<()> = Mutex::const_new(());
+
+/// Prevents the event listener and immediate repair sweep from applying the
+/// same terminal plan concurrently. The database link is removed only after
+/// ingest completes, so both paths can otherwise observe the same work item.
+static COMPLETED_PLAN_IDS: LazyLock<StdMutex<HashSet<String>>> =
+    LazyLock::new(|| StdMutex::new(HashSet::new()));
 
 // ── Public entry point ────────────────────────────────────────────────────────
 
@@ -189,6 +198,30 @@ async fn handle_plan_completed(
 /// that guard: it logs and swallows its errors (spec 035 US4/T042, R12), so a
 /// per-frame metadata/IO problem never strands the inbox item.
 pub(crate) async fn complete_applied_plan(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    resolve_cache: &ResolveCache,
+    plan_id: &str,
+) -> Result<(), String> {
+    {
+        let mut completed =
+            COMPLETED_PLAN_IDS.lock().map_err(|_| "completed plan guard poisoned".to_owned())?;
+        if !completed.insert(plan_id.to_owned()) {
+            tracing::debug!(plan_id, "inbox plan_listener: duplicate completion ignored");
+            return Ok(());
+        }
+    }
+
+    let result = complete_applied_plan_once(pool, bus, resolve_cache, plan_id).await;
+    if result.is_err() {
+        if let Ok(mut completed) = COMPLETED_PLAN_IDS.lock() {
+            completed.remove(plan_id);
+        }
+    }
+    result
+}
+
+async fn complete_applied_plan_once(
     pool: &SqlitePool,
     bus: &EventBus,
     resolve_cache: &ResolveCache,


### PR DESCRIPTION
## Summary

- serialize applied-plan side effects shared by the event listener and immediate repair sweep
- use the existing async mutex as a scoped RAII guard so cancellation, panic, and errors cannot strand an in-process claim
- keep the fix independent of PR #1421, whose own diff only changes the Windows E2E harness

## Test Plan

- [x] exact attribution regression passed 10 consecutive runs
- [x] plan-listener unit tests passed (6)
- [x] repair unit tests passed (8), including concurrent listener/sweep coverage
- [x] cargo fmt and focused clippy passed

## Notes

- Root cause: both startup paths could observe one applied-plan link and concurrently perform a non-atomic SELECT-then-INSERT by non-unique session_key, producing two sessions.
- This fixes Windows CI run 29828199734/job 88626383489 without modifying #1421.

Tracks-Bead: astro-plan-jges