### PR TITLE
ci: detect merged PR paths missing from main

### DIFF
--- a/.github/workflows/merged-pr-path-gate.yml
+++ b/.github/workflows/merged-pr-path-gate.yml
@@ -1,0 +1,35 @@
+name: Merged PR path gate
+
+# A scheduled sweep is required because a child PR can merge into a feature
+# branch after that branch was forwarded to main. A per-PR check cannot see
+# whether the eventual main history retained the child PR's files.
+on:
+  schedule:
+    - cron: "23 3 * * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: merged-pr-path-gate
+  cancel-in-progress: false
+
+jobs:
+  path-presence:
+    name: Check merged PR paths on main
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out main history
+        uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Check recently merged PR paths
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          WINDOW_DAYS: "14"
+        run: scripts/check-merged-pr-paths.sh

--- a/scripts/check-merged-pr-paths.sh
+++ b/scripts/check-merged-pr-paths.sh
@@ -41,19 +41,46 @@ merged_in_window() {
   [ "$merged_epoch" -ge "$SINCE_EPOCH" ] && [ "$merged_epoch" -le "$NOW_EPOCH" ]
 }
 
-# Print PR numbers merged during the window. REST pagination is intentional:
-# the GraphQL files field is capped at 100 entries, while this sweep must see
-# every file in a large PR.
+# Load one validated pull-request snapshot. Keeping every stacked child in the
+# snapshot makes deferrals durable without repeated metadata API calls.
+load_pull_snapshot() {
+  local pages
+  pages=$(gh api --paginate --method GET \
+    "/repos/${REPO}/pulls" \
+    -f state=all \
+    -f sort=updated \
+    -f direction=desc \
+    -f per_page=100) || return 1
+  PULL_SNAPSHOT=$(jq -s -c '
+    if all(.[];
+      type == "array"
+      and all(.[];
+        (.number | type == "number" and floor == .)
+        and (.state | type == "string")
+        and (.base.ref | type == "string" and length > 0)
+        and (.head.ref | type == "string" and length > 0)
+        and (.merged_at == null or (.merged_at | type == "string" and length > 0))
+      )
+    ) then add else error("invalid pull-request snapshot") end
+  ' <<<"$pages") || return 1
+}
+
+# Print recently merged main PRs plus every merged stacked PR. Old stacked PRs
+# are cheap metadata-only candidates until their eligibility reaches the sweep
+# window; this prevents a deferred child from aging out before its root lands.
 merged_pr_numbers() {
-  gh api --paginate \
-    "/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
-    | jq -r --argjson since "$SINCE_EPOCH" --argjson until "$NOW_EPOCH" '
+  jq -r --argjson since "$SINCE_EPOCH" --argjson until "$NOW_EPOCH" '
       .[]
       | select(.merged_at != null)
-      | select((.merged_at | fromdateiso8601) >= $since)
-      | select((.merged_at | fromdateiso8601) <= $until)
+      | select(
+          .base.ref != "main"
+          or (
+            (.merged_at | fromdateiso8601) >= $since
+            and (.merged_at | fromdateiso8601) <= $until
+          )
+        )
       | .number
-    '
+    ' <<<"$PULL_SNAPSHOT"
 }
 
 # Print selected paths as a NUL-delimited stream. GitHub REST calls these
@@ -80,6 +107,16 @@ added_paths_for_pr() {
 # fields. An empty timestamp means the pull request has not merged.
 pull_metadata() {
   local pr="$1" response
+  if [ -n "${PULL_SNAPSHOT:-}" ]; then
+    jq -r --argjson pr "$pr" '
+      [.[] | select(.number == $pr)]
+      | if length == 1
+        then [.[0].base.ref, (.[0].merged_at // "")] | @tsv
+        else error("pull request absent or duplicated in snapshot")
+        end
+    ' <<<"$PULL_SNAPSHOT"
+    return
+  fi
   response=$(gh api "/repos/${REPO}/pulls/${pr}") || return 1
   jq -e '
     type == "object"
@@ -94,6 +131,21 @@ pull_metadata() {
 # deliberately treated as ambiguous instead of guessing at chronology.
 forwarding_pr_for_branch() {
   local branch="$1" owner response
+  if [ -n "${PULL_SNAPSHOT:-}" ]; then
+    jq -r --arg branch "$branch" '
+      [
+        .[]
+        | select(.head.ref == $branch)
+        | select(.state == "open" or .merged_at != null)
+        | .number
+      ]
+      | if length == 1 then .[0]
+        elif length == 0 then "none"
+        else "ambiguous"
+        end
+    ' <<<"$PULL_SNAPSHOT"
+    return
+  fi
   owner=${REPO%%/*}
   response=$(gh api --paginate --method GET \
     "/repos/${REPO}/pulls" \
@@ -125,7 +177,8 @@ forwarding_pr_for_branch() {
   ' <<<"$response"
 }
 
-# Print whether a merged PR is ready for path checks. A child that merged
+# Print whether a merged PR is ready for path checks and the timestamp when it
+# became eligible. A child that merged
 # before its base branch was forwarded follows that forwarding PR toward main;
 # it is deferred while any forwarding PR remains open. A child that merged
 # after its base was forwarded is checked immediately because that forwarding
@@ -150,7 +203,7 @@ stack_disposition() {
     return 1
   fi
   if [ "$base" = "main" ]; then
-    echo check
+    echo "check:${merged_at}"
     return 0
   fi
 
@@ -160,12 +213,12 @@ stack_disposition() {
   }
   case "$parent" in
     none)
-      echo "defer:no forwarding PR uniquely identifies base '${base}'"
+      echo "defer:no forwarding PR identifies base '${base}'"
       return 0
       ;;
     ambiguous)
-      echo "defer:multiple forwarding PRs match base '${base}'"
-      return 0
+      echo "ERROR PR #${pr}: multiple forwarding PRs match base '${base}'" >&2
+      return 1
       ;;
   esac
 
@@ -182,7 +235,7 @@ stack_disposition() {
   merged_epoch=$(iso_epoch "$merged_at") || return 1
   parent_epoch=$(iso_epoch "$parent_merged_at") || return 1
   if [ "$merged_epoch" -gt "$parent_epoch" ]; then
-    echo check
+    echo "check:${merged_at}"
     return 0
   fi
   stack_disposition "$parent" "$trail"
@@ -204,17 +257,30 @@ path_state() {
 }
 
 check_pr() {
-  local pr="$1" path state disposition missing=0 count=0 path_file
+  local pr="$1" path state disposition eligible_at eligible_epoch missing=0 count=0 path_file
   local -a paths=()
   if ! disposition=$(stack_disposition "$pr"); then
     echo "ERROR PR #${pr}: could not establish stacked-PR chronology" >&2
     return 1
   fi
   case "$disposition" in
-    check) ;;
+    check:*)
+      eligible_at=${disposition#check:}
+      eligible_epoch=$(iso_epoch "$eligible_at") || {
+        echo "ERROR PR #${pr}: invalid eligibility timestamp '${eligible_at}'" >&2
+        return 1
+      }
+      if [ "$eligible_epoch" -gt "$NOW_EPOCH" ]; then
+        echo "ERROR PR #${pr}: eligibility timestamp is after the sweep time" >&2
+        return 1
+      fi
+      if [ "$eligible_epoch" -lt "$SINCE_EPOCH" ]; then
+        return 3
+      fi
+      ;;
     defer:*)
       echo "DEFER PR #${pr}: ${disposition#defer:}"
-      return 0
+      return 2
       ;;
     *)
       echo "ERROR PR #${pr}: unknown stack disposition '${disposition}'" >&2
@@ -351,7 +417,11 @@ main() {
   echo "Checking merged PRs from $(date -u -d "@${SINCE_EPOCH}" +%Y-%m-%dT%H:%M:%SZ) through $(date -u -d "@${NOW_EPOCH}" +%Y-%m-%dT%H:%M:%SZ)"
 
   git fetch --no-tags origin main --quiet
-  local prs overall=0 pr
+  if ! load_pull_snapshot; then
+    echo "ERROR: could not read or validate pull-request metadata" >&2
+    return 1
+  fi
+  local prs overall=0 deferred=0 settled=0 pr status
   if ! prs=$(merged_pr_numbers); then
     echo "ERROR: could not list recently merged PRs" >&2
     return 1
@@ -362,12 +432,21 @@ main() {
   fi
   while IFS= read -r pr; do
     [ -n "$pr" ] || continue
-    check_pr "$pr" || overall=1
+    if check_pr "$pr"; then
+      continue
+    else
+      status=$?
+    fi
+    case "$status" in
+      2) deferred=$((deferred + 1)) ;;
+      3) settled=$((settled + 1)) ;;
+      *) overall=1 ;;
+    esac
   done <<<"$prs"
   if [ "$overall" -eq 0 ]; then
-    echo "PASS: every added path is present on main or has main history"
+    echo "PASS: every eligible added path is present on main or has main history; deferred=${deferred}; settled_outside_window=${settled}"
   else
-    echo "FAIL: one or more added paths were never present on main" >&2
+    echo "FAIL: one or more eligible paths or PR classifications failed" >&2
   fi
   return "$overall"
 }

--- a/scripts/check-merged-pr-paths.sh
+++ b/scripts/check-merged-pr-paths.sh
@@ -76,6 +76,118 @@ added_paths_for_pr() {
   ' <<<"$files"
 }
 
+# Print a pull request's base branch and merge timestamp as tab-separated
+# fields. An empty timestamp means the pull request has not merged.
+pull_metadata() {
+  local pr="$1" response
+  response=$(gh api "/repos/${REPO}/pulls/${pr}") || return 1
+  jq -e '
+    type == "object"
+    and (.base.ref | type == "string" and length > 0)
+    and (.merged_at == null or (.merged_at | type == "string" and length > 0))
+  ' >/dev/null <<<"$response" || return 1
+  jq -r '[.base.ref, (.merged_at // "")] | @tsv' <<<"$response"
+}
+
+# Identify the one active or merged PR that forwards a branch. Closed,
+# unmerged attempts cannot carry the branch toward main. Branch reuse is
+# deliberately treated as ambiguous instead of guessing at chronology.
+forwarding_pr_for_branch() {
+  local branch="$1" owner response
+  owner=${REPO%%/*}
+  response=$(gh api --paginate --method GET \
+    "/repos/${REPO}/pulls" \
+    -f state=all \
+    -f head="${owner}:${branch}" \
+    -f per_page=100) || return 1
+  jq -s -e '
+    all(.[];
+      type == "array"
+      and all(.[];
+        (.number | type == "number" and floor == .)
+        and (.state | type == "string")
+        and (.head.ref | type == "string" and length > 0)
+        and (.merged_at == null or (.merged_at | type == "string" and length > 0))
+      )
+    )
+  ' >/dev/null <<<"$response" || return 1
+  jq -s -r --arg branch "$branch" '
+    [
+      .[][]
+      | select(.head.ref == $branch)
+      | select(.state == "open" or .merged_at != null)
+      | .number
+    ]
+    | if length == 1 then .[0]
+      elif length == 0 then "none"
+      else "ambiguous"
+      end
+  ' <<<"$response"
+}
+
+# Print whether a merged PR is ready for path checks. A child that merged
+# before its base branch was forwarded follows that forwarding PR toward main;
+# it is deferred while any forwarding PR remains open. A child that merged
+# after its base was forwarded is checked immediately because that forwarding
+# could not have included the child (the lost-merge chronology from PR #1304).
+stack_disposition() {
+  local pr="$1" trail="${2:-:}" metadata base merged_at parent parent_metadata
+  local parent_base parent_merged_at merged_epoch parent_epoch
+
+  if [[ "$trail" == *":${pr}:"* ]]; then
+    echo "ERROR PR #${pr}: cycle in stacked-PR forwarding chain" >&2
+    return 1
+  fi
+  trail="${trail}${pr}:"
+
+  metadata=$(pull_metadata "$pr") || {
+    echo "ERROR PR #${pr}: could not read or validate pull-request metadata" >&2
+    return 1
+  }
+  IFS=$'\t' read -r base merged_at <<<"$metadata"
+  if [ -z "$merged_at" ]; then
+    echo "ERROR PR #${pr}: sweep selected a pull request without a merge timestamp" >&2
+    return 1
+  fi
+  if [ "$base" = "main" ]; then
+    echo check
+    return 0
+  fi
+
+  parent=$(forwarding_pr_for_branch "$base") || {
+    echo "ERROR PR #${pr}: could not resolve forwarding PR for base '${base}'" >&2
+    return 1
+  }
+  case "$parent" in
+    none)
+      echo "defer:no forwarding PR uniquely identifies base '${base}'"
+      return 0
+      ;;
+    ambiguous)
+      echo "defer:multiple forwarding PRs match base '${base}'"
+      return 0
+      ;;
+  esac
+
+  parent_metadata=$(pull_metadata "$parent") || {
+    echo "ERROR PR #${pr}: could not read forwarding PR #${parent}" >&2
+    return 1
+  }
+  IFS=$'\t' read -r parent_base parent_merged_at <<<"$parent_metadata"
+  if [ -z "$parent_merged_at" ]; then
+    echo "defer:base '${base}' is awaiting PR #${parent} into '${parent_base}'"
+    return 0
+  fi
+
+  merged_epoch=$(iso_epoch "$merged_at") || return 1
+  parent_epoch=$(iso_epoch "$parent_merged_at") || return 1
+  if [ "$merged_epoch" -gt "$parent_epoch" ]; then
+    echo check
+    return 0
+  fi
+  stack_disposition "$parent" "$trail"
+}
+
 # Classify one repo-relative path against main:
 #   present    — currently exists on main
 #   historical — absent now, but appeared in main's history
@@ -92,8 +204,23 @@ path_state() {
 }
 
 check_pr() {
-  local pr="$1" path state missing=0 count=0 path_file
+  local pr="$1" path state disposition missing=0 count=0 path_file
   local -a paths=()
+  if ! disposition=$(stack_disposition "$pr"); then
+    echo "ERROR PR #${pr}: could not establish stacked-PR chronology" >&2
+    return 1
+  fi
+  case "$disposition" in
+    check) ;;
+    defer:*)
+      echo "DEFER PR #${pr}: ${disposition#defer:}"
+      return 0
+      ;;
+    *)
+      echo "ERROR PR #${pr}: unknown stack disposition '${disposition}'" >&2
+      return 1
+      ;;
+  esac
   # Capture through a file because process substitution hides producer errors.
   path_file=$(mktemp)
   if ! added_paths_for_pr "$pr" >"$path_file"; then
@@ -175,21 +302,33 @@ self_test() {
   MAIN_REF=HEAD
   local got
   got=$(cd "$repo" && path_state present.txt)
-  [ "$got" = "present" ] \
-    && echo "ok: path_state detects a path currently present on main" \
-    || { echo "FAIL: path_state present got '$got'"; fail=1; }
+  if [ "$got" = "present" ]; then
+    echo "ok: path_state detects a path currently present on main"
+  else
+    echo "FAIL: path_state present got '$got'"
+    fail=1
+  fi
   got=$(git -C "$repo" rev-parse HEAD >/dev/null 2>&1; (cd "$repo" && path_state removed.txt))
-  [ "$got" = "historical" ] \
-    && echo "ok: path_state ignores a later deletion" \
-    || { echo "FAIL: path_state deletion got '$got'"; fail=1; }
+  if [ "$got" = "historical" ]; then
+    echo "ok: path_state ignores a later deletion"
+  else
+    echo "FAIL: path_state deletion got '$got'"
+    fail=1
+  fi
   got=$(cd "$repo" && path_state old.txt)
-  [ "$got" = "historical" ] \
-    && echo "ok: path_state ignores a later rename" \
-    || { echo "FAIL: path_state rename got '$got'"; fail=1; }
+  if [ "$got" = "historical" ]; then
+    echo "ok: path_state ignores a later rename"
+  else
+    echo "FAIL: path_state rename got '$got'"
+    fail=1
+  fi
   got=$(cd "$repo" && path_state never.txt)
-  [ "$got" = "never" ] \
-    && echo "ok: path_state distinguishes a never-on-main path" \
-    || { echo "FAIL: path_state never got '$got'"; fail=1; }
+  if [ "$got" = "never" ]; then
+    echo "ok: path_state distinguishes a never-on-main path"
+  else
+    echo "FAIL: path_state never got '$got'"
+    fail=1
+  fi
 
   if [ "$fail" -eq 0 ]; then
     echo "check-merged-pr-paths self-test: PASS"

--- a/scripts/check-merged-pr-paths.sh
+++ b/scripts/check-merged-pr-paths.sh
@@ -1,0 +1,238 @@
+#!/usr/bin/env bash
+# Check that files newly added by recently merged PRs still exist on main.
+#
+# A merged PR can be lost when a child PR lands on a feature branch after that
+# branch was already forwarded to main. The path is a real signal only when it
+# has never appeared in main's history: a missing path with history was
+# deliberately deleted or renamed later and is not a lost merge.
+#
+# Usage:
+#   scripts/check-merged-pr-paths.sh
+#   WINDOW_DAYS=14 scripts/check-merged-pr-paths.sh
+#   scripts/check-merged-pr-paths.sh --self-test
+#
+# Requires: gh (authenticated), jq, git, and a complete checkout containing
+# origin/main. The script reads GitHub state and local Git history only.
+set -euo pipefail
+
+REPO="${REPO:-${GITHUB_REPOSITORY:-platevault/platevault}}"
+MAIN_REF="${MAIN_REF:-origin/main}"
+WINDOW_DAYS="${WINDOW_DAYS:-14}"
+
+die() {
+  echo "ERROR: $*" >&2
+  return 1
+}
+
+validate_window() {
+  case "$WINDOW_DAYS" in
+    ''|*[!0-9]*) die "WINDOW_DAYS must be a non-negative integer" ;;
+  esac
+}
+
+iso_epoch() {
+  date -u -d "$1" +%s
+}
+
+# Return success when a timestamp is inside the inclusive sweep window.
+merged_in_window() {
+  local merged_at="$1" merged_epoch
+  merged_epoch=$(iso_epoch "$merged_at") || return 1
+  [ "$merged_epoch" -ge "$SINCE_EPOCH" ] && [ "$merged_epoch" -le "$NOW_EPOCH" ]
+}
+
+# Print PR numbers merged during the window. REST pagination is intentional:
+# the GraphQL files field is capped at 100 entries, while this sweep must see
+# every file in a large PR.
+merged_pr_numbers() {
+  gh api --paginate \
+    "/repos/${REPO}/pulls?state=closed&sort=updated&direction=desc&per_page=100" \
+    | jq -r --argjson since "$SINCE_EPOCH" --argjson until "$NOW_EPOCH" '
+      .[]
+      | select(.merged_at != null)
+      | select((.merged_at | fromdateiso8601) >= $since)
+      | select((.merged_at | fromdateiso8601) <= $until)
+      | .number
+    '
+}
+
+# Print selected paths as a NUL-delimited stream. GitHub REST calls these
+# entries "added"; additions > 0 excludes malformed/empty additions records.
+added_paths_for_pr() {
+  local pr="$1" files
+  files=$(gh api --paginate "/repos/${REPO}/pulls/${pr}/files?per_page=100") || return 1
+  jq -e '
+    type == "array"
+    and all(.[];
+      (.filename | type == "string" and length > 0)
+      and (.status | type == "string")
+      and (.additions | type == "number" and floor == .)
+    )
+  ' >/dev/null <<<"$files" || return 1
+  jq -j '
+    .[]
+    | select(.status == "added" and .additions > 0)
+    | .filename, "\u0000"
+  ' <<<"$files"
+}
+
+# Classify one repo-relative path against main:
+#   present    — currently exists on main
+#   historical — absent now, but appeared in main's history
+#   never      — absent from main and from its entire history
+path_state() {
+  local path="$1"
+  if git cat-file -e "${MAIN_REF}:${path}" 2>/dev/null; then
+    echo present
+  elif git log --format=%H -1 "$MAIN_REF" -- "$path" | grep -q .; then
+    echo historical
+  else
+    echo never
+  fi
+}
+
+check_pr() {
+  local pr="$1" path state missing=0 count=0 path_file
+  local -a paths=()
+  # Capture through a file because process substitution hides producer errors.
+  path_file=$(mktemp)
+  if ! added_paths_for_pr "$pr" >"$path_file"; then
+    rm -f "$path_file"
+    echo "ERROR PR #${pr}: could not read or validate its file list" >&2
+    return 1
+  fi
+  if ! mapfile -d '' -t paths <"$path_file"; then
+    rm -f "$path_file"
+    echo "ERROR PR #${pr}: could not read or validate its file list" >&2
+    return 1
+  fi
+  rm -f "$path_file"
+
+  for path in "${paths[@]}"; do
+    count=$((count + 1))
+    state=$(path_state "$path")
+    case "$state" in
+      present)
+        echo "OK   PR #${pr} ${path} (present on main)"
+        ;;
+      historical)
+        echo "OK   PR #${pr} ${path} (absent now, but present in main history; later deletion/rename)"
+        ;;
+      never)
+        echo "FAIL PR #${pr} ${path} (absent from main and main history: never landed)" >&2
+        missing=1
+        ;;
+      *)
+        echo "ERROR PR #${pr} ${path}: unknown path state '${state}'" >&2
+        return 1
+        ;;
+    esac
+  done
+
+  if [ "$count" -eq 0 ]; then
+    echo "OK   PR #${pr}: no added paths"
+  fi
+  return "$missing"
+}
+
+self_test() {
+  local fail=0
+  NOW_EPOCH=1000
+  SINCE_EPOCH=500
+
+  if merged_in_window "1970-01-01T00:15:00Z"; then
+    echo "ok: merged_in_window accepts timestamps inside the window"
+  else
+    echo "FAIL: merged_in_window rejected an in-window timestamp"
+    fail=1
+  fi
+  if ! merged_in_window "1970-01-01T00:08:19Z"; then
+    echo "ok: merged_in_window rejects timestamps before the window"
+  else
+    echo "FAIL: merged_in_window accepted an early timestamp"
+    fail=1
+  fi
+  if ! merged_in_window "1970-01-01T00:16:41Z"; then
+    echo "ok: merged_in_window rejects timestamps after the sweep time"
+  else
+    echo "FAIL: merged_in_window accepted a future timestamp"
+    fail=1
+  fi
+
+  local repo
+  repo=$(mktemp -d)
+  git -C "$repo" init -q
+  git -C "$repo" config user.name test
+  git -C "$repo" config user.email test@example.invalid
+  printf 'present\n' >"$repo/present.txt"
+  printf 'removed\n' >"$repo/removed.txt"
+  printf 'old\n' >"$repo/old.txt"
+  git -C "$repo" add .
+  git -C "$repo" commit -qm main-files
+  git -C "$repo" rm -q removed.txt
+  git -C "$repo" mv old.txt renamed.txt
+  git -C "$repo" commit -qm delete-and-rename
+  MAIN_REF=HEAD
+  local got
+  got=$(cd "$repo" && path_state present.txt)
+  [ "$got" = "present" ] \
+    && echo "ok: path_state detects a path currently present on main" \
+    || { echo "FAIL: path_state present got '$got'"; fail=1; }
+  got=$(git -C "$repo" rev-parse HEAD >/dev/null 2>&1; (cd "$repo" && path_state removed.txt))
+  [ "$got" = "historical" ] \
+    && echo "ok: path_state ignores a later deletion" \
+    || { echo "FAIL: path_state deletion got '$got'"; fail=1; }
+  got=$(cd "$repo" && path_state old.txt)
+  [ "$got" = "historical" ] \
+    && echo "ok: path_state ignores a later rename" \
+    || { echo "FAIL: path_state rename got '$got'"; fail=1; }
+  got=$(cd "$repo" && path_state never.txt)
+  [ "$got" = "never" ] \
+    && echo "ok: path_state distinguishes a never-on-main path" \
+    || { echo "FAIL: path_state never got '$got'"; fail=1; }
+
+  if [ "$fail" -eq 0 ]; then
+    echo "check-merged-pr-paths self-test: PASS"
+  else
+    echo "check-merged-pr-paths self-test: FAIL"
+    return 1
+  fi
+}
+
+main() {
+  if [ "${1:-}" = "--self-test" ]; then
+    self_test
+    return $?
+  fi
+  [ "$#" -eq 0 ] || die "usage: $0 [--self-test]"
+  validate_window
+
+  NOW_EPOCH="${NOW_EPOCH:-$(date -u +%s)}"
+  SINCE_EPOCH=$((NOW_EPOCH - WINDOW_DAYS * 86400))
+  echo "Checking merged PRs from $(date -u -d "@${SINCE_EPOCH}" +%Y-%m-%dT%H:%M:%SZ) through $(date -u -d "@${NOW_EPOCH}" +%Y-%m-%dT%H:%M:%SZ)"
+
+  git fetch --no-tags origin main --quiet
+  local prs overall=0 pr
+  if ! prs=$(merged_pr_numbers); then
+    echo "ERROR: could not list recently merged PRs" >&2
+    return 1
+  fi
+  if [ -z "$prs" ]; then
+    echo "PASS: no merged PRs in the sweep window"
+    return 0
+  fi
+  while IFS= read -r pr; do
+    [ -n "$pr" ] || continue
+    check_pr "$pr" || overall=1
+  done <<<"$prs"
+  if [ "$overall" -eq 0 ]; then
+    echo "PASS: every added path is present on main or has main history"
+  else
+    echo "FAIL: one or more added paths were never present on main" >&2
+  fi
+  return "$overall"
+}
+
+if [[ "${BASH_SOURCE[0]}" == "$0" ]]; then
+  main "$@"
+fi

--- a/scripts/tests/check-merged-pr-paths.sh
+++ b/scripts/tests/check-merged-pr-paths.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+script="$repo_root/scripts/check-merged-pr-paths.sh"
+
+if bash -n "$script"; then
+  echo "ok: script passes bash syntax check"
+else
+  echo "FAIL: script has invalid Bash syntax" >&2
+  exit 1
+fi
+
+bash "$script" --self-test
+
+source "$script"
+added_paths_for_pr() { return 1; }
+if output=$(check_pr 999 2>&1); then
+  echo "FAIL: check_pr ignored a file-list producer failure" >&2
+  exit 1
+elif [[ "$output" == *"could not read or validate its file list"* ]]; then
+  echo "ok: check_pr reports a file-list producer failure"
+else
+  echo "FAIL: check_pr returned an unexpected producer-failure message" >&2
+  exit 1
+fi
+
+echo "check-merged-pr-paths tests: PASS"

--- a/scripts/tests/check-merged-pr-paths.sh
+++ b/scripts/tests/check-merged-pr-paths.sh
@@ -13,7 +13,86 @@ fi
 
 bash "$script" --self-test
 
+# shellcheck source=scripts/check-merged-pr-paths.sh
 source "$script"
+
+declare -A fixture_base=()
+declare -A fixture_merged=()
+declare -A fixture_forward=()
+
+pull_metadata() {
+  local pr="$1"
+  [ -n "${fixture_base[$pr]-}" ] || return 1
+  printf '%s\t%s\n' "${fixture_base[$pr]}" "${fixture_merged[$pr]-}"
+}
+
+forwarding_pr_for_branch() {
+  printf '%s\n' "${fixture_forward[$1]-none}"
+}
+
+assert_disposition() {
+  local description="$1" pr="$2" expected="$3" actual
+  actual=$(stack_disposition "$pr")
+  if [ "$actual" = "$expected" ]; then
+    echo "ok: $description"
+  else
+    echo "FAIL: $description: expected '$expected', got '$actual'" >&2
+    exit 1
+  fi
+}
+
+# PR #1296 merged into feat/sd-token-pipeline before root PR #1279. It must
+# wait for the root, then become eligible for the ordinary path-history check.
+fixture_base[1296]=feat/sd-token-pipeline
+fixture_merged[1296]=2026-07-20T18:43:37Z
+fixture_forward[feat/sd-token-pipeline]=1279
+fixture_base[1279]=main
+assert_disposition "child-before-root defers while PR #1279 is open" 1296 \
+  "defer:base 'feat/sd-token-pipeline' is awaiting PR #1279 into 'main'"
+fixture_merged[1279]=2026-07-21T00:43:36Z
+assert_disposition "child-before-root checks after PR #1279 reaches main" 1296 check
+
+# PR #1310 and root PR #1379 exercise the same legitimate chronology with a
+# different stack, preventing the fixture from depending on one branch name.
+fixture_base[1310]=061-selectable-app-language
+fixture_merged[1310]=2026-07-20T18:43:28Z
+fixture_forward[061-selectable-app-language]=1379
+fixture_base[1379]=main
+assert_disposition "second child-before-root defers while PR #1379 is open" 1310 \
+  "defer:base '061-selectable-app-language' is awaiting PR #1379 into 'main'"
+fixture_merged[1379]=2026-07-21T01:17:01Z
+assert_disposition "second child-before-root checks after PR #1379 reaches main" 1310 check
+
+# PR #1304 merged after PR #1296 had already forwarded its direct base. The
+# open root is irrelevant: the child was absent from the forwarded snapshot.
+fixture_base[1304]=feat/sd-foundation-outputs
+fixture_merged[1304]=2026-07-20T20:37:16Z
+fixture_forward[feat/sd-foundation-outputs]=1296
+fixture_base[1296]=feat/sd-token-pipeline
+fixture_merged[1296]=2026-07-20T18:43:37Z
+fixture_merged[1279]=
+assert_disposition "child-after-forwarded-base checks before the root lands" 1304 check
+
+fixture_base[1400]=reused-base
+fixture_merged[1400]=2026-07-20T20:00:00Z
+fixture_forward[reused-base]=ambiguous
+assert_disposition "ambiguous branch reuse defers instead of guessing" 1400 \
+  "defer:multiple forwarding PRs match base 'reused-base'"
+
+stack_disposition() { echo "defer:base 'feature' is awaiting PR #998 into 'main'"; }
+added_paths_for_pr() {
+  echo "FAIL: deferred PR fetched its file list" >&2
+  return 1
+}
+if output=$(check_pr 999 2>&1) \
+  && [[ "$output" == *"DEFER PR #999"* ]]; then
+  echo "ok: check_pr defers before fetching paths"
+else
+  echo "FAIL: check_pr did not honor the stack deferral: $output" >&2
+  exit 1
+fi
+
+stack_disposition() { echo check; }
 added_paths_for_pr() { return 1; }
 if output=$(check_pr 999 2>&1); then
   echo "FAIL: check_pr ignored a file-list producer failure" >&2

--- a/scripts/tests/check-merged-pr-paths.sh
+++ b/scripts/tests/check-merged-pr-paths.sh
@@ -16,6 +16,9 @@ bash "$script" --self-test
 # shellcheck source=scripts/check-merged-pr-paths.sh
 source "$script"
 
+NOW_EPOCH=$(date -u -d "2026-07-22T12:00:00Z" +%s)
+SINCE_EPOCH=$((NOW_EPOCH - 14 * 86400))
+
 declare -A fixture_base=()
 declare -A fixture_merged=()
 declare -A fixture_forward=()
@@ -50,7 +53,8 @@ fixture_base[1279]=main
 assert_disposition "child-before-root defers while PR #1279 is open" 1296 \
   "defer:base 'feat/sd-token-pipeline' is awaiting PR #1279 into 'main'"
 fixture_merged[1279]=2026-07-21T00:43:36Z
-assert_disposition "child-before-root checks after PR #1279 reaches main" 1296 check
+assert_disposition "child-before-root checks after PR #1279 reaches main" 1296 \
+  "check:2026-07-21T00:43:36Z"
 
 # PR #1310 and root PR #1379 exercise the same legitimate chronology with a
 # different stack, preventing the fixture from depending on one branch name.
@@ -61,7 +65,8 @@ fixture_base[1379]=main
 assert_disposition "second child-before-root defers while PR #1379 is open" 1310 \
   "defer:base '061-selectable-app-language' is awaiting PR #1379 into 'main'"
 fixture_merged[1379]=2026-07-21T01:17:01Z
-assert_disposition "second child-before-root checks after PR #1379 reaches main" 1310 check
+assert_disposition "second child-before-root checks after PR #1379 reaches main" 1310 \
+  "check:2026-07-21T01:17:01Z"
 
 # PR #1304 merged after PR #1296 had already forwarded its direct base. The
 # open root is irrelevant: the child was absent from the forwarded snapshot.
@@ -71,28 +76,75 @@ fixture_forward[feat/sd-foundation-outputs]=1296
 fixture_base[1296]=feat/sd-token-pipeline
 fixture_merged[1296]=2026-07-20T18:43:37Z
 fixture_merged[1279]=
-assert_disposition "child-after-forwarded-base checks before the root lands" 1304 check
+assert_disposition "child-after-forwarded-base checks before the root lands" 1304 \
+  "check:2026-07-20T20:37:16Z"
 
 fixture_base[1400]=reused-base
-fixture_merged[1400]=2026-07-20T20:00:00Z
+fixture_merged[1400]=2026-06-01T20:00:00Z
 fixture_forward[reused-base]=ambiguous
-assert_disposition "ambiguous branch reuse defers instead of guessing" 1400 \
-  "defer:multiple forwarding PRs match base 'reused-base'"
+if output=$(stack_disposition 1400 2>&1); then
+  echo "FAIL: ambiguous branch reuse succeeded after the child expired" >&2
+  exit 1
+elif [[ "$output" == *"multiple forwarding PRs match base 'reused-base'"* ]]; then
+  echo "ok: ambiguous branch reuse remains a visible failure after child expiry"
+else
+  echo "FAIL: ambiguous branch reuse returned an unexpected error: $output" >&2
+  exit 1
+fi
+
+# This child merged outside the window, but its root lands inside it. The root
+# timestamp becomes the child's eligibility timestamp, so its paths are read.
+fixture_base[1500]=long-running-root
+fixture_merged[1500]=2026-06-01T12:00:00Z
+fixture_forward[long-running-root]=1501
+fixture_base[1501]=main
+fixture_merged[1501]=2026-07-20T12:00:00Z
+assert_disposition "old child becomes eligible when its root lands" 1500 \
+  "check:2026-07-20T12:00:00Z"
+
+added_paths_for_pr() { printf 'eventual path.txt\0'; }
+path_state() { echo present; }
+if output=$(check_pr 1500 2>&1) \
+  && [[ "$output" == *"eventual path.txt (present on main)"* ]]; then
+  echo "ok: deferred paths are checked when the root lands after WINDOW_DAYS"
+else
+  echo "FAIL: deferred paths were not checked after root landing: $output" >&2
+  exit 1
+fi
+
+PULL_SNAPSHOT='[
+  {"number":1500,"state":"closed","base":{"ref":"long-running-root"},"head":{"ref":"old-child"},"merged_at":"2026-06-01T12:00:00Z"},
+  {"number":1501,"state":"closed","base":{"ref":"main"},"head":{"ref":"long-running-root"},"merged_at":"2026-07-20T12:00:00Z"},
+  {"number":1502,"state":"closed","base":{"ref":"main"},"head":{"ref":"old-main"},"merged_at":"2026-06-01T12:00:00Z"}
+]'
+candidates=$(merged_pr_numbers)
+if [[ "$candidates" == *"1500"* ]] \
+  && [[ "$candidates" == *"1501"* ]] \
+  && [[ "$candidates" != *"1502"* ]]; then
+  echo "ok: candidate selection retains old stacked children until root landing"
+else
+  echo "FAIL: candidate selection did not preserve deferred eligibility: $candidates" >&2
+  exit 1
+fi
+unset PULL_SNAPSHOT
 
 stack_disposition() { echo "defer:base 'feature' is awaiting PR #998 into 'main'"; }
 added_paths_for_pr() {
   echo "FAIL: deferred PR fetched its file list" >&2
   return 1
 }
-if output=$(check_pr 999 2>&1) \
-  && [[ "$output" == *"DEFER PR #999"* ]]; then
+set +e
+output=$(check_pr 999 2>&1)
+status=$?
+set -e
+if [ "$status" -eq 2 ] && [[ "$output" == *"DEFER PR #999"* ]]; then
   echo "ok: check_pr defers before fetching paths"
 else
-  echo "FAIL: check_pr did not honor the stack deferral: $output" >&2
+  echo "FAIL: check_pr did not honor the stack deferral (status $status): $output" >&2
   exit 1
 fi
 
-stack_disposition() { echo check; }
+stack_disposition() { echo "check:2026-07-20T12:00:00Z"; }
 added_paths_for_pr() { return 1; }
 if output=$(check_pr 999 2>&1); then
   echo "FAIL: check_pr ignored a file-list producer failure" >&2
@@ -101,6 +153,21 @@ elif [[ "$output" == *"could not read or validate its file list"* ]]; then
   echo "ok: check_pr reports a file-list producer failure"
 else
   echo "FAIL: check_pr returned an unexpected producer-failure message" >&2
+  exit 1
+fi
+
+git() { return 0; }
+load_pull_snapshot() { PULL_SNAPSHOT='[]'; }
+merged_pr_numbers() { printf '999\n'; }
+check_pr() {
+  echo "DEFER PR #999: root is still open"
+  return 2
+}
+if output=$(main) \
+  && [[ "$output" == *"deferred=1"* ]]; then
+  echo "ok: successful sweep summary reports deferred PRs"
+else
+  echo "FAIL: successful sweep summary hid deferred PRs: $output" >&2
   exit 1
 fi
 


### PR DESCRIPTION
What changed

- Added a scheduled gate that reports added PR paths absent from main history.

Why

- Detects merged PR deliverables that were never forwarded to main.

Test plan

- Exercised the 2026-07-20/21 positive and negative controls.