### PR TITLE
fix: update setup language prompt

### DIFF
--- a/apps/desktop/messages/en-GB.json
+++ b/apps/desktop/messages/en-GB.json
@@ -997,7 +997,7 @@
   "setup_kind_light_frames": "Light frames",
   "setup_kind_light_frames_help": "Raw light frames from your imaging sessions (FITS/XISF). PlateVault reads file headers to build your acquisition history — these files are never moved or copied without your approval.",
   "setup_kind_project_help": "Folders where your PixInsight/WBPP projects and processing outputs live. You'll create individual projects from these folders later, in a guided workflow — adding the folder now only registers where PlateVault should look.",
-  "setup_language_desc": "Pick the language you read. You can change it later in Settings.",
+  "setup_language_desc": "Pick your preferred language",
   "setup_language_heading": "Choose your language",
   "setup_language_label": "Language",
   "setup_scan_classify_failed": "Could not read types",

--- a/apps/desktop/messages/pt-BR.json
+++ b/apps/desktop/messages/pt-BR.json
@@ -997,7 +997,7 @@
   "setup_kind_light_frames": "Quadros de light",
   "setup_kind_light_frames_help": "Quadros de light brutos das suas sessões de imageamento (FITS/XISF). O PlateVault lê os cabeçalhos dos arquivos para montar seu histórico de aquisição — esses arquivos nunca são movidos ou copiados sem sua aprovação.",
   "setup_kind_project_help": "Pastas onde ficam seus projetos do PixInsight/WBPP e as saídas de processamento. Você criará projetos individuais a partir dessas pastas depois, em um fluxo guiado — adicionar a pasta agora apenas registra onde o PlateVault deve procurar.",
-  "setup_language_desc": "Escolha o idioma que você lê. Você pode alterá-lo depois em Configurações.",
+  "setup_language_desc": "Escolha seu idioma preferido",
   "setup_language_heading": "Escolha seu idioma",
   "setup_language_label": "Idioma",
   "setup_scan_classify_failed": "Não foi possível ler os tipos",

--- a/apps/desktop/src/features/onboarding/ChecklistSection.locale.test.tsx
+++ b/apps/desktop/src/features/onboarding/ChecklistSection.locale.test.tsx
@@ -1,0 +1,59 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+
+import { act, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => false,
+  invoke: vi.fn().mockRejectedValue(new Error('no tauri')),
+}));
+
+import {
+  LocaleProvider,
+  registerLocaleStrategy,
+  useLocale,
+} from '@/data/locale';
+import { m } from '@/lib/i18n';
+
+function WizardCopyProbe() {
+  const { locale, changeLocale } = useLocale();
+
+  return (
+    <>
+      <output data-testid="locale">{locale}</output>
+      <p>{m.setup_language_desc()}</p>
+      <button type="button" onClick={() => changeLocale('pt-BR')}>
+        Português (Brasil)
+      </button>
+    </>
+  );
+}
+
+beforeEach(() => {
+  registerLocaleStrategy();
+  localStorage.clear();
+});
+
+describe('wizard copy follows the active locale', () => {
+  it('switches to Portuguese-Brazil and renders the translated prompt', () => {
+    render(
+      <LocaleProvider>
+        <WizardCopyProbe />
+      </LocaleProvider>,
+    );
+
+    expect(screen.getByTestId('locale')).toHaveTextContent('en-GB');
+    expect(screen.getByText('Pick your preferred language')).toBeVisible();
+
+    act(() => {
+      screen.getByRole('button', { name: 'Português (Brasil)' }).click();
+    });
+
+    expect(screen.getByTestId('locale')).toHaveTextContent('pt-BR');
+    expect(screen.getByText('Escolha seu idioma preferido')).toBeVisible();
+    expect(localStorage.getItem('alm.locale')).toBe('pt-BR');
+  });
+});


### PR DESCRIPTION
## Summary

- Selecting `Português (Brasil)` now renders the Portuguese setup wizard prompt.
- The English prompt reads `Pick your preferred language`.
- The locale regression test verifies the rendered copy and persisted mirror.

## Test plan

- `pnpm i18n:compile`
- `pnpm exec vitest run src/features/onboarding/ChecklistSection.locale.test.tsx src/data/locale.test.ts src/data/locale.provider.test.tsx`
- `pnpm exec biome check src/features/onboarding/ChecklistSection.locale.test.tsx messages/en-GB.json messages/pt-BR.json`
