### PR TITLE
feat: preserve capture metadata in session identity

### DIFF
--- a/crates/sessions/src/identity.rs
+++ b/crates/sessions/src/identity.rs
@@ -1,0 +1,484 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Operation-scoped immutable session identity.
+//!
+//! Metadata extraction normalizes scalar values before constructing these
+//! types. Spatial thresholds and relation topology are separate from these
+//! exact discriminators.
+
+use std::num::NonZeroU32;
+
+use domain_core::EntityId;
+
+use crate::observing_night::ObservingNight;
+
+/// Exact normalized value or an explicit absence.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum IdentityValue<T> {
+    Known(T),
+    Absent,
+}
+
+impl<T> IdentityValue<T> {
+    #[must_use]
+    pub const fn is_absent(&self) -> bool {
+        matches!(self, Self::Absent)
+    }
+
+    #[must_use]
+    pub const fn as_ref(&self) -> IdentityValue<&T> {
+        match self {
+            Self::Known(value) => IdentityValue::Known(value),
+            Self::Absent => IdentityValue::Absent,
+        }
+    }
+}
+
+/// Exact positive raster dimensions.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub struct RasterDimensions {
+    width: NonZeroU32,
+    height: NonZeroU32,
+}
+
+impl RasterDimensions {
+    #[must_use]
+    pub const fn new(width: NonZeroU32, height: NonZeroU32) -> Self {
+        Self { width, height }
+    }
+
+    #[must_use]
+    pub const fn width(self) -> NonZeroU32 {
+        self.width
+    }
+
+    #[must_use]
+    pub const fn height(self) -> NonZeroU32 {
+        self.height
+    }
+}
+
+/// Exact camera-controlled capture fields shared by every supported frame kind.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CaptureDiscriminators {
+    /// Exact normalized gain text.
+    pub gain: String,
+    pub offset: IdentityValue<i64>,
+    pub binning_x: IdentityValue<NonZeroU32>,
+    pub binning_y: IdentityValue<NonZeroU32>,
+    pub readout_mode: IdentityValue<String>,
+    pub raster: RasterDimensions,
+}
+
+/// Parity remains independent from orientation.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum ImageParity {
+    Normal,
+    Mirrored,
+}
+
+/// Immutable representative geometry stored with a light session.
+///
+/// This is identity evidence only. Topology code owns tolerance comparison.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LightGeometryIdentity {
+    pub parity: ImageParity,
+    pub footprint_digest: String,
+    pub representative_orientation_udeg: i64,
+}
+
+/// Camera sensor geometry used by flat compatibility.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct CameraGeometryIdentity {
+    pub pixel_size_nm: IdentityValue<NonZeroU32>,
+    pub sensor_width_px: IdentityValue<NonZeroU32>,
+    pub sensor_height_px: IdentityValue<NonZeroU32>,
+}
+
+/// Verified physical orientation or its explicit degraded state.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum FlatOrientationIdentity {
+    VerifiedMicrodegrees(i64),
+    Absent,
+    Unverified,
+}
+
+/// Temperature mode stored with a dark session.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DarkTemperatureMode {
+    Regulated { cooling_setpoint_millic: i32 },
+    UnregulatedReviewed,
+    Unknown,
+}
+
+/// Exact light-session discriminators other than operation and observing night.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct LightSessionDiscriminators {
+    pub canonical_target_id: EntityId,
+    pub optical_profile_id: EntityId,
+    pub filter_label_id: IdentityValue<EntityId>,
+    pub exposure_us: u64,
+    pub capture: CaptureDiscriminators,
+    pub crop_evidence: IdentityValue<String>,
+    pub geometry: LightGeometryIdentity,
+}
+
+/// Exact dark-session recipe discriminators.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct DarkSessionDiscriminators {
+    pub camera_id: EntityId,
+    pub temperature_mode: DarkTemperatureMode,
+    pub exposure_us: u64,
+    pub capture: CaptureDiscriminators,
+}
+
+impl DarkSessionDiscriminators {
+    /// Compare a candidate directly with this immutable recipe representative.
+    #[must_use]
+    pub fn matches_recipe_candidate(&self, candidate: &Self) -> bool {
+        self.camera_id == candidate.camera_id
+            && self.temperature_mode == candidate.temperature_mode
+            && self.capture == candidate.capture
+            && self.exposure_us.abs_diff(candidate.exposure_us)
+                <= dark_exposure_tolerance_us(self.exposure_us)
+    }
+}
+
+/// Dark exposure tolerance for an immutable recipe representative.
+///
+/// The 0.05% tolerance is clamped to the inclusive 1–100 ms range.
+#[must_use]
+pub fn dark_exposure_tolerance_us(representative_exposure_us: u64) -> u64 {
+    (representative_exposure_us / 2_000).clamp(1_000, 100_000)
+}
+
+/// Exact bias-session recipe discriminators.
+///
+/// Exposure and temperature are intentionally absent from this type.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct BiasSessionDiscriminators {
+    pub camera_id: EntityId,
+    pub capture: CaptureDiscriminators,
+}
+
+/// Exact flat-session discriminators.
+///
+/// Exposure is intentionally absent from this type.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct FlatSessionDiscriminators {
+    pub optical_profile_id: EntityId,
+    pub filter_label_id: IdentityValue<EntityId>,
+    pub capture: CaptureDiscriminators,
+    pub camera_geometry: CameraGeometryIdentity,
+    pub physical_orientation: FlatOrientationIdentity,
+}
+
+/// Supported frame-kind-specific identity tuple.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum SessionDiscriminators {
+    Light(LightSessionDiscriminators),
+    Dark(DarkSessionDiscriminators),
+    Bias(BiasSessionDiscriminators),
+    Flat(FlatSessionDiscriminators),
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum SessionKind {
+    Light,
+    Dark,
+    Bias,
+    Flat,
+}
+
+impl SessionDiscriminators {
+    #[must_use]
+    pub const fn kind(&self) -> SessionKind {
+        match self {
+            Self::Light(_) => SessionKind::Light,
+            Self::Dark(_) => SessionKind::Dark,
+            Self::Bias(_) => SessionKind::Bias,
+            Self::Flat(_) => SessionKind::Flat,
+        }
+    }
+}
+
+/// Immutable identity within one approved materialization operation.
+///
+/// The operation ID distinguishes a replay from a later ingestion with the
+/// same metadata. A command replay returns the stored session rather than
+/// deriving another [`SessionIdentity`].
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct SessionIdentity {
+    materialization_operation_id: EntityId,
+    observing_night: ObservingNight,
+    discriminators: SessionDiscriminators,
+}
+
+impl SessionIdentity {
+    #[must_use]
+    pub const fn new(
+        materialization_operation_id: EntityId,
+        observing_night: ObservingNight,
+        discriminators: SessionDiscriminators,
+    ) -> Self {
+        Self { materialization_operation_id, observing_night, discriminators }
+    }
+
+    #[must_use]
+    pub const fn materialization_operation_id(&self) -> EntityId {
+        self.materialization_operation_id
+    }
+
+    #[must_use]
+    pub const fn observing_night(&self) -> &ObservingNight {
+        &self.observing_night
+    }
+
+    #[must_use]
+    pub const fn discriminators(&self) -> &SessionDiscriminators {
+        &self.discriminators
+    }
+
+    #[must_use]
+    pub const fn kind(&self) -> SessionKind {
+        self.discriminators.kind()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::{Date, Month, PrimitiveDateTime, Time};
+    use uuid::Uuid;
+
+    fn id(value: u128) -> EntityId {
+        EntityId::from_uuid(Uuid::from_u128(value))
+    }
+
+    fn positive(value: u32) -> NonZeroU32 {
+        NonZeroU32::new(value).unwrap()
+    }
+
+    fn night(day: u8) -> ObservingNight {
+        ObservingNight::from_reviewed_local_fallback(PrimitiveDateTime::new(
+            Date::from_calendar_date(2026, Month::March, day).unwrap(),
+            Time::from_hms(20, 0, 0).unwrap(),
+        ))
+        .unwrap()
+    }
+
+    fn capture() -> CaptureDiscriminators {
+        CaptureDiscriminators {
+            gain: "100".to_owned(),
+            offset: IdentityValue::Known(10),
+            binning_x: IdentityValue::Known(positive(1)),
+            binning_y: IdentityValue::Known(positive(2)),
+            readout_mode: IdentityValue::Known("low-noise".to_owned()),
+            raster: RasterDimensions::new(positive(6_000), positive(4_000)),
+        }
+    }
+
+    fn light() -> LightSessionDiscriminators {
+        LightSessionDiscriminators {
+            canonical_target_id: id(10),
+            optical_profile_id: id(20),
+            filter_label_id: IdentityValue::Known(id(30)),
+            exposure_us: 300_000_000,
+            capture: capture(),
+            crop_evidence: IdentityValue::Known("full-frame-reported".to_owned()),
+            geometry: LightGeometryIdentity {
+                parity: ImageParity::Normal,
+                footprint_digest: "footprint-a".to_owned(),
+                representative_orientation_udeg: 12_500_000,
+            },
+        }
+    }
+
+    #[test]
+    fn light_identity_is_scoped_to_the_operation_and_observing_night() {
+        let baseline =
+            SessionIdentity::new(id(1), night(15), SessionDiscriminators::Light(light()));
+
+        assert_ne!(
+            baseline,
+            SessionIdentity::new(id(2), night(15), SessionDiscriminators::Light(light()))
+        );
+        assert_ne!(
+            baseline,
+            SessionIdentity::new(id(1), night(16), SessionDiscriminators::Light(light()))
+        );
+        assert_eq!(baseline.kind(), SessionKind::Light);
+        assert_eq!(baseline.materialization_operation_id(), id(1));
+    }
+
+    #[test]
+    fn every_light_discriminator_participates_in_exact_identity() {
+        let baseline = light();
+        let mut variants = Vec::new();
+
+        let mut changed = baseline.clone();
+        changed.canonical_target_id = id(11);
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.optical_profile_id = id(21);
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.filter_label_id = IdentityValue::Absent;
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.exposure_us += 1;
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.capture.gain = "101".to_owned();
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.capture.offset = IdentityValue::Known(11);
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.capture.binning_x = IdentityValue::Known(positive(2));
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.capture.binning_y = IdentityValue::Known(positive(1));
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.capture.readout_mode = IdentityValue::Absent;
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.capture.raster = RasterDimensions::new(positive(5_999), positive(4_000));
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.crop_evidence = IdentityValue::Absent;
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.geometry.parity = ImageParity::Mirrored;
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.geometry.footprint_digest = "footprint-b".to_owned();
+        variants.push(changed);
+        let mut changed = baseline.clone();
+        changed.geometry.representative_orientation_udeg += 1;
+        variants.push(changed);
+
+        for variant in variants {
+            assert_ne!(baseline, variant);
+        }
+    }
+
+    #[test]
+    fn absent_capture_values_match_only_the_same_absence() {
+        let absent = CaptureDiscriminators {
+            gain: "100".to_owned(),
+            offset: IdentityValue::Absent,
+            binning_x: IdentityValue::Absent,
+            binning_y: IdentityValue::Absent,
+            readout_mode: IdentityValue::Absent,
+            raster: RasterDimensions::new(positive(6_000), positive(4_000)),
+        };
+
+        assert_eq!(absent, absent.clone());
+        assert!(absent.offset.is_absent());
+
+        let mut known_offset = absent.clone();
+        known_offset.offset = IdentityValue::Known(0);
+        assert_ne!(absent, known_offset);
+
+        let mut known_x = absent.clone();
+        known_x.binning_x = IdentityValue::Known(positive(1));
+        assert_ne!(absent, known_x);
+
+        let mut known_y = absent.clone();
+        known_y.binning_y = IdentityValue::Known(positive(1));
+        assert_ne!(absent, known_y);
+
+        let mut known_readout = absent.clone();
+        known_readout.readout_mode = IdentityValue::Known("default".to_owned());
+        assert_ne!(absent, known_readout);
+    }
+
+    #[test]
+    fn dark_identity_includes_recipe_fields_but_not_actual_temperature() {
+        let baseline = DarkSessionDiscriminators {
+            camera_id: id(40),
+            temperature_mode: DarkTemperatureMode::Regulated { cooling_setpoint_millic: -10_000 },
+            exposure_us: 300_000_000,
+            capture: capture(),
+        };
+
+        let mut changed_setpoint = baseline.clone();
+        changed_setpoint.temperature_mode =
+            DarkTemperatureMode::Regulated { cooling_setpoint_millic: -9_999 };
+        let mut changed_exposure = baseline.clone();
+        changed_exposure.exposure_us += 1;
+        let mut changed_camera = baseline.clone();
+        changed_camera.camera_id = id(41);
+
+        assert_ne!(baseline, changed_setpoint);
+        assert_ne!(baseline, changed_exposure);
+        assert_ne!(baseline, changed_camera);
+        assert_ne!(baseline.temperature_mode, DarkTemperatureMode::Unknown);
+    }
+
+    #[test]
+    fn dark_exposure_uses_the_immutable_representative_without_chaining() {
+        let representative = DarkSessionDiscriminators {
+            camera_id: id(40),
+            temperature_mode: DarkTemperatureMode::Regulated { cooling_setpoint_millic: -10_000 },
+            exposure_us: 2_000_000,
+            capture: capture(),
+        };
+        let mut at_boundary = representative.clone();
+        at_boundary.exposure_us += 1_000;
+        let mut chained_only = representative.clone();
+        chained_only.exposure_us += 2_000;
+
+        assert_eq!(dark_exposure_tolerance_us(representative.exposure_us), 1_000);
+        assert!(representative.matches_recipe_candidate(&at_boundary));
+        assert!(!representative.matches_recipe_candidate(&chained_only));
+        assert!(at_boundary.matches_recipe_candidate(&chained_only));
+    }
+
+    #[test]
+    fn dark_exposure_tolerance_is_bounded_to_one_and_one_hundred_ms() {
+        assert_eq!(dark_exposure_tolerance_us(1), 1_000);
+        assert_eq!(dark_exposure_tolerance_us(20_000_000), 10_000);
+        assert_eq!(dark_exposure_tolerance_us(u64::MAX), 100_000);
+    }
+
+    #[test]
+    fn bias_and_flat_exclude_their_non_discriminating_exposure_fields() {
+        let bias = BiasSessionDiscriminators { camera_id: id(40), capture: capture() };
+        let flat = FlatSessionDiscriminators {
+            optical_profile_id: id(20),
+            filter_label_id: IdentityValue::Known(id(30)),
+            capture: capture(),
+            camera_geometry: CameraGeometryIdentity {
+                pixel_size_nm: IdentityValue::Known(positive(3_760)),
+                sensor_width_px: IdentityValue::Known(positive(6_000)),
+                sensor_height_px: IdentityValue::Known(positive(4_000)),
+            },
+            physical_orientation: FlatOrientationIdentity::VerifiedMicrodegrees(90_000_000),
+        };
+
+        assert_eq!(SessionDiscriminators::Bias(bias.clone()).kind(), SessionKind::Bias);
+        assert_eq!(SessionDiscriminators::Flat(flat.clone()).kind(), SessionKind::Flat);
+
+        let mut other_bias = bias.clone();
+        other_bias.capture.offset = IdentityValue::Absent;
+        assert_ne!(bias, other_bias);
+
+        let mut other_flat = flat.clone();
+        other_flat.physical_orientation = FlatOrientationIdentity::Unverified;
+        assert_ne!(flat, other_flat);
+        let mut no_filter = flat.clone();
+        no_filter.filter_label_id = IdentityValue::Absent;
+        assert_ne!(flat, no_filter);
+    }
+
+    #[test]
+    fn dark_flat_is_not_a_supported_session_kind() {
+        let supported =
+            [SessionKind::Light, SessionKind::Dark, SessionKind::Bias, SessionKind::Flat];
+        assert_eq!(supported.len(), 4);
+    }
+}

--- a/crates/sessions/src/identity.rs
+++ b/crates/sessions/src/identity.rs
@@ -137,7 +137,9 @@ impl DarkSessionDiscriminators {
     /// Compare a candidate directly with this immutable recipe representative.
     #[must_use]
     pub fn matches_recipe_candidate(&self, candidate: &Self) -> bool {
-        self.camera_id == candidate.camera_id
+        !matches!(self.temperature_mode, DarkTemperatureMode::Unknown)
+            && !matches!(candidate.temperature_mode, DarkTemperatureMode::Unknown)
+            && self.camera_id == candidate.camera_id
             && self.temperature_mode == candidate.temperature_mode
             && self.capture == candidate.capture
             && self.exposure_us.abs_diff(candidate.exposure_us)
@@ -443,6 +445,22 @@ mod tests {
         assert_eq!(dark_exposure_tolerance_us(1), 1_000);
         assert_eq!(dark_exposure_tolerance_us(20_000_000), 10_000);
         assert_eq!(dark_exposure_tolerance_us(u64::MAX), 100_000);
+    }
+
+    #[test]
+    fn unknown_dark_temperature_never_matches_a_recipe_candidate() {
+        let known = DarkSessionDiscriminators {
+            camera_id: id(40),
+            temperature_mode: DarkTemperatureMode::Regulated { cooling_setpoint_millic: -10_000 },
+            exposure_us: 2_000_000,
+            capture: capture(),
+        };
+        let mut unknown = known.clone();
+        unknown.temperature_mode = DarkTemperatureMode::Unknown;
+
+        assert!(!unknown.matches_recipe_candidate(&unknown));
+        assert!(!unknown.matches_recipe_candidate(&known));
+        assert!(!known.matches_recipe_candidate(&unknown));
     }
 
     #[test]

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -4,7 +4,9 @@
 //! Acquisition and calibration session modeling boundaries.
 
 pub mod clustering;
+pub mod identity;
 pub mod key;
+pub mod observing_night;
 pub mod optic_train;
 
 pub use clustering::{
@@ -12,9 +14,17 @@ pub use clustering::{
     rotation_circular_distance_deg, Assignment, ClusteringResult, ExistingFraming, NewFramingGroup,
     SessionGeometry, ToleranceParams, UnassignedReason,
 };
+pub use identity::{
+    dark_exposure_tolerance_us, BiasSessionDiscriminators, CameraGeometryIdentity,
+    CaptureDiscriminators, DarkSessionDiscriminators, DarkTemperatureMode, FlatOrientationIdentity,
+    FlatSessionDiscriminators, IdentityValue, ImageParity, LightGeometryIdentity,
+    LightSessionDiscriminators, RasterDimensions, SessionDiscriminators, SessionIdentity,
+    SessionKind,
+};
 pub use key::{
     observing_night, parse_session_key, session_key, KeyError, ObserverContext, SessionKeyParts,
 };
+pub use observing_night::{ObservingNight, ObservingNightDerivation, ObservingNightError};
 pub use optic_train::optic_train_key;
 
 pub const CRATE_NAME: &str = "sessions";

--- a/crates/sessions/src/observing_night.rs
+++ b/crates/sessions/src/observing_night.rs
@@ -1,0 +1,220 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Canonical civil observing-night derivation.
+//!
+//! IANA timezone resolution belongs at the application boundary. This module
+//! receives the date-effective local timestamp after that resolution, or a
+//! local timestamp whose fallback use has already been reviewed.
+
+use thiserror::Error;
+use time::{Date, OffsetDateTime, PrimitiveDateTime};
+
+/// Evidence path used to derive an observing night.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub enum ObservingNightDerivation {
+    /// A canonical exposure instant resolved through the named acquisition
+    /// site's IANA timezone rules.
+    AcquisitionTimezone { timezone_name: String },
+    /// A local timestamp accepted through an explicit review when no usable
+    /// canonical instant and timezone were available.
+    ReviewedLocalFallback,
+}
+
+/// Immutable local calendar date and the evidence path that produced it.
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+pub struct ObservingNight {
+    date: Date,
+    derivation: ObservingNightDerivation,
+}
+
+impl ObservingNight {
+    /// Derive from a canonical instant already resolved into the acquisition
+    /// site's date-effective UTC offset.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservingNightError::MissingTimezoneName`] for an empty IANA
+    /// timezone snapshot, or [`ObservingNightError::DateUnderflow`] when a
+    /// pre-noon timestamp falls before [`Date::MIN`].
+    pub fn from_acquisition_timezone(
+        resolved_local_capture_at: OffsetDateTime,
+        timezone_name: impl Into<String>,
+    ) -> Result<Self, ObservingNightError> {
+        let timezone_name = timezone_name.into();
+        if timezone_name.trim().is_empty() {
+            return Err(ObservingNightError::MissingTimezoneName);
+        }
+
+        Ok(Self {
+            date: noon_bounded_date(
+                resolved_local_capture_at.date(),
+                resolved_local_capture_at.hour(),
+            )?,
+            derivation: ObservingNightDerivation::AcquisitionTimezone { timezone_name },
+        })
+    }
+
+    /// Derive from a reviewed local timestamp without inventing a timezone.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`ObservingNightError::DateUnderflow`] when a pre-noon
+    /// timestamp falls before [`Date::MIN`].
+    pub fn from_reviewed_local_fallback(
+        local_capture_at: PrimitiveDateTime,
+    ) -> Result<Self, ObservingNightError> {
+        Ok(Self {
+            date: noon_bounded_date(local_capture_at.date(), local_capture_at.hour())?,
+            derivation: ObservingNightDerivation::ReviewedLocalFallback,
+        })
+    }
+
+    #[must_use]
+    pub const fn date(&self) -> Date {
+        self.date
+    }
+
+    #[must_use]
+    pub const fn derivation(&self) -> &ObservingNightDerivation {
+        &self.derivation
+    }
+
+    #[must_use]
+    pub fn acquisition_timezone(&self) -> Option<&str> {
+        match &self.derivation {
+            ObservingNightDerivation::AcquisitionTimezone { timezone_name } => Some(timezone_name),
+            ObservingNightDerivation::ReviewedLocalFallback => None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Error, PartialEq)]
+pub enum ObservingNightError {
+    #[error("acquisition-timezone derivation requires an IANA timezone name")]
+    MissingTimezoneName,
+    #[error("pre-noon observing-night derivation falls before the supported date range")]
+    DateUnderflow,
+}
+
+fn noon_bounded_date(local_date: Date, local_hour: u8) -> Result<Date, ObservingNightError> {
+    if local_hour < 12 {
+        local_date.previous_day().ok_or(ObservingNightError::DateUnderflow)
+    } else {
+        Ok(local_date)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use time::{Duration, Month, Time, UtcOffset};
+
+    fn local(
+        year: i32,
+        month: Month,
+        day: u8,
+        hour: u8,
+        minute: u8,
+        offset_hours: i8,
+    ) -> OffsetDateTime {
+        PrimitiveDateTime::new(
+            Date::from_calendar_date(year, month, day).unwrap(),
+            Time::from_hms(hour, minute, 0).unwrap(),
+        )
+        .assume_offset(UtcOffset::from_hms(offset_hours, 0, 0).unwrap())
+    }
+
+    fn utc(year: i32, month: Month, day: u8, hour: u8, minute: u8) -> OffsetDateTime {
+        local(year, month, day, hour, minute, 0)
+    }
+
+    #[test]
+    fn exact_noon_starts_the_new_observing_night() {
+        let exact_noon = local(2026, Month::March, 16, 12, 0, 1);
+        let just_before = exact_noon - Duration::microseconds(1);
+
+        let at_boundary =
+            ObservingNight::from_acquisition_timezone(exact_noon, "Europe/Amsterdam").unwrap();
+        let before_boundary =
+            ObservingNight::from_acquisition_timezone(just_before, "Europe/Amsterdam").unwrap();
+
+        assert_eq!(at_boundary.date(), Date::from_calendar_date(2026, Month::March, 16).unwrap());
+        assert_eq!(
+            before_boundary.date(),
+            Date::from_calendar_date(2026, Month::March, 15).unwrap()
+        );
+    }
+
+    #[test]
+    fn spring_forward_uses_the_resolved_date_effective_offset() {
+        let before_jump =
+            utc(2026, Month::March, 8, 6, 59).to_offset(UtcOffset::from_hms(-5, 0, 0).unwrap());
+        let after_jump =
+            utc(2026, Month::March, 8, 7, 0).to_offset(UtcOffset::from_hms(-4, 0, 0).unwrap());
+
+        let before =
+            ObservingNight::from_acquisition_timezone(before_jump, "America/New_York").unwrap();
+        let after =
+            ObservingNight::from_acquisition_timezone(after_jump, "America/New_York").unwrap();
+
+        let expected = Date::from_calendar_date(2026, Month::March, 7).unwrap();
+        assert_eq!(before.date(), expected);
+        assert_eq!(after.date(), expected);
+    }
+
+    #[test]
+    fn fall_back_accepts_both_resolved_offsets_for_the_repeated_hour() {
+        let first =
+            utc(2026, Month::November, 1, 5, 30).to_offset(UtcOffset::from_hms(-4, 0, 0).unwrap());
+        let second =
+            utc(2026, Month::November, 1, 6, 30).to_offset(UtcOffset::from_hms(-5, 0, 0).unwrap());
+
+        let first_night =
+            ObservingNight::from_acquisition_timezone(first, "America/New_York").unwrap();
+        let second_night =
+            ObservingNight::from_acquisition_timezone(second, "America/New_York").unwrap();
+
+        let expected = Date::from_calendar_date(2026, Month::October, 31).unwrap();
+        assert_eq!(first_night.date(), expected);
+        assert_eq!(second_night.date(), expected);
+    }
+
+    #[test]
+    fn remote_site_timezone_wins_over_the_machine_timezone() {
+        let canonical = utc(2026, Month::March, 15, 10, 0);
+        let acquisition_site = canonical.to_offset(UtcOffset::from_hms(-7, 0, 0).unwrap());
+
+        let night =
+            ObservingNight::from_acquisition_timezone(acquisition_site, "America/Los_Angeles")
+                .unwrap();
+
+        assert_eq!(night.date(), Date::from_calendar_date(2026, Month::March, 14).unwrap());
+        assert_eq!(night.acquisition_timezone(), Some("America/Los_Angeles"));
+    }
+
+    #[test]
+    fn reviewed_fallback_keeps_timezone_absent() {
+        let timestamp = PrimitiveDateTime::new(
+            Date::from_calendar_date(2026, Month::March, 16).unwrap(),
+            Time::from_hms(11, 30, 0).unwrap(),
+        );
+
+        let night = ObservingNight::from_reviewed_local_fallback(timestamp).unwrap();
+
+        assert_eq!(night.date(), Date::from_calendar_date(2026, Month::March, 15).unwrap());
+        assert_eq!(night.derivation(), &ObservingNightDerivation::ReviewedLocalFallback);
+        assert_eq!(night.acquisition_timezone(), None);
+    }
+
+    #[test]
+    fn acquisition_timezone_requires_a_named_timezone_snapshot() {
+        assert_eq!(
+            ObservingNight::from_acquisition_timezone(
+                local(2026, Month::March, 16, 12, 0, 0),
+                "  ",
+            ),
+            Err(ObservingNightError::MissingTimezoneName)
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Preserves each materialization operation and observing night in session identity.
- Preserves target, filter, exposure, gain, offset, independent X/Y binning, readout, raster, crop, and geometry evidence in light-session identity.
- Uses the acquisition site's civil-noon boundary after date-effective timezone resolution, or a reviewed local timestamp fallback.
- Keeps absent offset, binning, readout, and filter values distinct from reported values.
- Compares dark exposure with the immutable recipe representative using the bounded 0.05% tolerance.
- Blocks dark recipe matching when either temperature mode is unknown.
- Excludes exposure and temperature from bias identity.
- Excludes exposure from flat identity.

## Spec Context

- `cargo nextest run -p sessions` (47 passed)
- `cargo clippy -p sessions --all-targets --all-features -- -D warnings`
- Bead: `astro-plan-ic9h.4`
