### PR TITLE
feat: add NINA and Dwarf capture metadata profiles

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3338,6 +3338,7 @@ dependencies = [
  "serde",
  "skymath",
  "thiserror 2.0.18",
+ "toml 0.9.12+spec-1.1.0",
 ]
 
 [[package]]

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/lib.rs"
 serde = { workspace = true }
 skymath = "0.5"
 thiserror = { workspace = true }
+toml = "0.9.5"
 
 [lints]
 workspace = true

--- a/crates/metadata/core/data/capture_profiles.toml
+++ b/crates/metadata/core/data/capture_profiles.toml
@@ -1,0 +1,273 @@
+format_version = 1
+fallback_profile = "generic"
+
+[[profiles]]
+id = "nina"
+version = 1
+priority = 200
+match_any = [{ field = "SWCREATE", contains = "N.I.N.A." }]
+
+[profiles.fields.camera]
+confidence = "reported"
+sources = [
+  { field = "INSTRUME", parser = "text" },
+  { field = "CAMERA", parser = "text" },
+  { field = "Instrument:Camera:Name", parser = "text" },
+]
+
+[profiles.fields.telescope]
+confidence = "reported"
+sources = [
+  { field = "TELESCOP", parser = "text" },
+  { field = "Instrument:Telescope:Name", parser = "text" },
+]
+
+[profiles.fields.filter]
+confidence = "reported"
+sources = [
+  { field = "FILTER", parser = "text" },
+  { field = "Instrument:Filter:Name", parser = "text" },
+]
+
+[profiles.fields.gain]
+confidence = "reported"
+sources = [{ field = "GAIN", parser = "text" }]
+
+[profiles.fields.offset]
+confidence = "reported"
+sources = [
+  { field = "OFFSET", parser = "integer" },
+  { field = "BLKLEVEL", parser = "integer" },
+]
+
+[profiles.fields.binning_x]
+confidence = "reported"
+sources = [{ field = "XBINNING", parser = "positive_integer" }]
+
+[profiles.fields.binning_y]
+confidence = "reported"
+sources = [{ field = "YBINNING", parser = "positive_integer" }]
+
+[profiles.fields.readout_mode]
+confidence = "reported"
+sources = [
+  { field = "READOUTM", parser = "text" },
+  { field = "READOUT", parser = "text" },
+]
+
+[profiles.fields.raster_width]
+confidence = "confirmed"
+sources = [{ field = "NAXIS1", parser = "positive_integer" }]
+
+[profiles.fields.raster_height]
+confidence = "confirmed"
+sources = [{ field = "NAXIS2", parser = "positive_integer" }]
+
+[profiles.fields.crop]
+confidence = "reported"
+sources = [
+  { field = "SUBFRAME", parser = "text" },
+  { field = "ROI", parser = "text" },
+]
+
+[profiles.fields.focal_length_reported]
+confidence = "reported"
+sources = [
+  { field = "FOCALLEN", parser = "positive_decimal" },
+  { field = "Instrument:Telescope:FocalLength", parser = "positive_decimal", scale = 1000.0 },
+]
+
+[profiles.fields.pixel_size]
+confidence = "reported"
+sources = [
+  { field = "XPIXSZ", parser = "positive_decimal" },
+  { field = "PIXSIZE", parser = "positive_decimal" },
+  { field = "Image:PixelSize", parser = "positive_decimal" },
+]
+
+[profiles.fields.physical_rotator]
+confidence = "reported"
+sources = [
+  { field = "ROTATANG", parser = "decimal" },
+  { field = "ROTATOR", parser = "decimal" },
+]
+
+[profiles.fields.sky_orientation]
+confidence = "reported"
+sources = [{ field = "OBJCTROT", parser = "decimal" }]
+
+[[profiles]]
+id = "dwarf"
+version = 1
+priority = 200
+match_any = [{ field = "ORIGIN", equals = "DWARFLAB" }]
+
+[profiles.fields.camera]
+confidence = "reported"
+sources = [
+  { field = "INSTRUME", parser = "text" },
+  { field = "CAMERA", parser = "text" },
+]
+
+[profiles.fields.camera.aliases]
+"DWARF III" = "DWARF 3"
+"DWARF3" = "DWARF 3"
+
+[profiles.fields.telescope]
+confidence = "reported"
+sources = [{ field = "TELESCOP", parser = "text" }]
+
+[profiles.fields.filter]
+confidence = "reported"
+sources = [{ field = "FILTER", parser = "text" }]
+
+[profiles.fields.gain]
+confidence = "reported"
+sources = [{ field = "GAIN", parser = "text" }]
+
+[profiles.fields.offset]
+confidence = "reported"
+sources = [{ field = "OFFSET", parser = "integer" }]
+
+[profiles.fields.binning_x]
+confidence = "reported"
+sources = [{ field = "XBINNING", parser = "positive_integer" }]
+
+[profiles.fields.binning_y]
+confidence = "reported"
+sources = [{ field = "YBINNING", parser = "positive_integer" }]
+
+[profiles.fields.readout_mode]
+confidence = "reported"
+sources = [{ field = "READOUTM", parser = "text" }]
+
+[profiles.fields.raster_width]
+confidence = "confirmed"
+sources = [{ field = "NAXIS1", parser = "positive_integer" }]
+
+[profiles.fields.raster_height]
+confidence = "confirmed"
+sources = [{ field = "NAXIS2", parser = "positive_integer" }]
+
+[profiles.fields.crop]
+confidence = "reported"
+sources = [
+  { field = "SUBFRAME", parser = "text" },
+  { field = "ROI", parser = "text" },
+]
+
+[profiles.fields.focal_length_reported]
+confidence = "reported"
+sources = [{ field = "FOCALLEN", parser = "positive_decimal" }]
+
+[profiles.fields.pixel_size]
+confidence = "reported"
+sources = [
+  { field = "XPIXSZ", parser = "positive_decimal" },
+  { field = "PIXSIZE", parser = "positive_decimal" },
+]
+
+[profiles.fields.physical_rotator]
+confidence = "reported"
+sources = [
+  { field = "ROTATANG", parser = "decimal" },
+  { field = "ROTATOR", parser = "decimal" },
+]
+
+[profiles.fields.sky_orientation]
+confidence = "reported"
+sources = [{ field = "OBJCTROT", parser = "decimal" }]
+
+[[profiles]]
+id = "generic"
+version = 1
+priority = 0
+
+[profiles.fields.camera]
+confidence = "reported"
+sources = [
+  { field = "INSTRUME", parser = "text" },
+  { field = "CAMERA", parser = "text" },
+  { field = "Instrument:Camera:Name", parser = "text" },
+]
+
+[profiles.fields.telescope]
+confidence = "reported"
+sources = [
+  { field = "TELESCOP", parser = "text" },
+  { field = "Instrument:Telescope:Name", parser = "text" },
+]
+
+[profiles.fields.filter]
+confidence = "reported"
+sources = [
+  { field = "FILTER", parser = "text" },
+  { field = "Instrument:Filter:Name", parser = "text" },
+]
+
+[profiles.fields.gain]
+confidence = "reported"
+sources = [{ field = "GAIN", parser = "text" }]
+
+[profiles.fields.offset]
+confidence = "reported"
+sources = [
+  { field = "OFFSET", parser = "integer" },
+  { field = "BLKLEVEL", parser = "integer" },
+]
+
+[profiles.fields.binning_x]
+confidence = "reported"
+sources = [{ field = "XBINNING", parser = "positive_integer" }]
+
+[profiles.fields.binning_y]
+confidence = "reported"
+sources = [{ field = "YBINNING", parser = "positive_integer" }]
+
+[profiles.fields.readout_mode]
+confidence = "reported"
+sources = [
+  { field = "READOUTM", parser = "text" },
+  { field = "READOUT", parser = "text" },
+]
+
+[profiles.fields.raster_width]
+confidence = "confirmed"
+sources = [{ field = "NAXIS1", parser = "positive_integer" }]
+
+[profiles.fields.raster_height]
+confidence = "confirmed"
+sources = [{ field = "NAXIS2", parser = "positive_integer" }]
+
+[profiles.fields.crop]
+confidence = "reported"
+sources = [
+  { field = "SUBFRAME", parser = "text" },
+  { field = "ROI", parser = "text" },
+]
+
+[profiles.fields.focal_length_reported]
+confidence = "reported"
+sources = [
+  { field = "FOCALLEN", parser = "positive_decimal" },
+  { field = "Instrument:Telescope:FocalLength", parser = "positive_decimal", scale = 1000.0 },
+]
+
+[profiles.fields.pixel_size]
+confidence = "reported"
+sources = [
+  { field = "XPIXSZ", parser = "positive_decimal" },
+  { field = "PIXSIZE", parser = "positive_decimal" },
+  { field = "Image:PixelSize", parser = "positive_decimal" },
+]
+
+[profiles.fields.physical_rotator]
+confidence = "reported"
+sources = [
+  { field = "ROTATANG", parser = "decimal" },
+  { field = "ROTATOR", parser = "decimal" },
+]
+
+[profiles.fields.sky_orientation]
+confidence = "reported"
+sources = [{ field = "OBJCTROT", parser = "decimal" }]

--- a/crates/metadata/core/src/evidence.rs
+++ b/crates/metadata/core/src/evidence.rs
@@ -3,7 +3,15 @@
 
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+
+/// Maximum UTF-8 size of one raw or normalized evidence value.
+pub const MAX_EVIDENCE_VALUE_BYTES: usize = 16 * 1024;
+
+/// Maximum canonical UTF-8 value payload of one metadata-evidence revision.
+pub const MAX_EVIDENCE_PAYLOAD_BYTES: usize = 256 * 1024;
+
+const MAX_EVIDENCE_FIELDS: usize = 256;
 
 /// Canonical fields emitted by capture-software profiles.
 #[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
@@ -46,8 +54,33 @@ pub enum EvidenceConfidence {
     Calculated,
 }
 
+/// Evidence construction or input-bound failure.
+#[derive(Clone, Debug, PartialEq, Eq, thiserror::Error)]
+pub enum EvidenceError {
+    #[error("{context} is {actual} UTF-8 bytes; maximum is {maximum}")]
+    ValueTooLarge { context: &'static str, actual: usize, maximum: usize },
+    #[error("metadata evidence has {actual} fields; maximum is {maximum}")]
+    TooManyFields { actual: usize, maximum: usize },
+    #[error("metadata evidence payload is {actual} UTF-8 bytes; maximum is {maximum}")]
+    PayloadTooLarge { actual: usize, maximum: usize },
+    #[error("invalid field evidence tuple: {0}")]
+    InvalidFieldEvidence(&'static str),
+    #[error("metadata decimal must be finite")]
+    NonFiniteDecimal,
+    #[error("capture profile identity is invalid: {0}")]
+    InvalidProfile(&'static str),
+    #[error("raw metadata field must not be empty")]
+    EmptyRawField,
+    #[error("raw metadata contains a case-insensitive key collision for {0}")]
+    RawKeyCollision(String),
+    #[error("raw metadata key does not match its source field")]
+    RawKeyMismatch,
+    #[error("capture-profile registry has no fallback profile")]
+    MissingFallbackProfile,
+}
+
 /// Typed scalar value produced by a profile mapping.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "snake_case")]
 pub enum MetadataValue {
     Text(String),
@@ -56,18 +89,133 @@ pub enum MetadataValue {
     Decimal(f64),
 }
 
+#[derive(Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum MetadataValueWire {
+    Text(String),
+    Integer(i64),
+    Unsigned(u64),
+    Decimal(f64),
+}
+
+impl MetadataValue {
+    fn validate(&self) -> Result<(), EvidenceError> {
+        match self {
+            Self::Text(value) => validate_value_size("normalized evidence value", value),
+            Self::Decimal(value) if !value.is_finite() => Err(EvidenceError::NonFiniteDecimal),
+            Self::Integer(_) | Self::Unsigned(_) | Self::Decimal(_) => Ok(()),
+        }
+    }
+
+    fn canonical_payload_bytes(&self) -> usize {
+        match self {
+            Self::Text(value) => value.len(),
+            Self::Integer(value) => value.to_string().len(),
+            Self::Unsigned(value) => value.to_string().len(),
+            Self::Decimal(value) => value.to_string().len(),
+        }
+    }
+}
+
+impl TryFrom<MetadataValueWire> for MetadataValue {
+    type Error = EvidenceError;
+
+    fn try_from(value: MetadataValueWire) -> Result<Self, Self::Error> {
+        let value = match value {
+            MetadataValueWire::Text(value) => Self::Text(value),
+            MetadataValueWire::Integer(value) => Self::Integer(value),
+            MetadataValueWire::Unsigned(value) => Self::Unsigned(value),
+            MetadataValueWire::Decimal(value) => Self::Decimal(value),
+        };
+        value.validate()?;
+        Ok(value)
+    }
+}
+
+impl<'de> Deserialize<'de> for MetadataValue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        MetadataValueWire::deserialize(deserializer)?.try_into().map_err(D::Error::custom)
+    }
+}
+
 /// Field-level value, state, and raw provenance.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct FieldEvidence {
-    pub state: EvidenceState,
-    pub source_field: Option<String>,
-    pub raw_value: Option<String>,
-    pub normalized_value: Option<MetadataValue>,
-    pub confidence: EvidenceConfidence,
+    state: EvidenceState,
+    source_field: Option<String>,
+    raw_value: Option<String>,
+    normalized_value: Option<MetadataValue>,
+    confidence: EvidenceConfidence,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct FieldEvidenceWire {
+    state: EvidenceState,
+    source_field: Option<String>,
+    raw_value: Option<String>,
+    normalized_value: Option<MetadataValue>,
+    confidence: EvidenceConfidence,
 }
 
 impl FieldEvidence {
+    /// Builds a field-evidence value after validating its state/value tuple.
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] for inconsistent state/value combinations,
+    /// non-finite decimals, or values exceeding the evidence-size limit.
+    pub fn try_new(
+        state: EvidenceState,
+        source_field: Option<String>,
+        raw_value: Option<String>,
+        normalized_value: Option<MetadataValue>,
+        confidence: EvidenceConfidence,
+    ) -> Result<Self, EvidenceError> {
+        match state {
+            EvidenceState::Known
+                if source_field.is_none() || raw_value.is_none() || normalized_value.is_none() =>
+            {
+                return Err(EvidenceError::InvalidFieldEvidence(
+                    "known evidence requires source, raw, and normalized values",
+                ));
+            }
+            EvidenceState::Absent
+                if source_field.is_some() || raw_value.is_some() || normalized_value.is_some() =>
+            {
+                return Err(EvidenceError::InvalidFieldEvidence(
+                    "absent evidence cannot contain source, raw, or normalized values",
+                ));
+            }
+            EvidenceState::Invalid | EvidenceState::Contradictory
+                if source_field.is_none() || raw_value.is_none() || normalized_value.is_some() =>
+            {
+                return Err(EvidenceError::InvalidFieldEvidence(
+                    "invalid or contradictory evidence requires source and raw values only",
+                ));
+            }
+            _ => {}
+        }
+
+        if source_field.as_ref().is_some_and(|field| field.trim().is_empty()) {
+            return Err(EvidenceError::EmptyRawField);
+        }
+        if let Some(source_field) = &source_field {
+            validate_value_size("evidence source field", source_field)?;
+        }
+        if let Some(raw_value) = &raw_value {
+            validate_value_size("raw evidence value", raw_value)?;
+        }
+        if let Some(normalized_value) = &normalized_value {
+            normalized_value.validate()?;
+        }
+
+        Ok(Self { state, source_field, raw_value, normalized_value, confidence })
+    }
+
     pub(crate) fn absent(confidence: EvidenceConfidence) -> Self {
         Self {
             state: EvidenceState::Absent,
@@ -83,70 +231,331 @@ impl FieldEvidence {
         raw_value: String,
         normalized_value: Option<MetadataValue>,
         confidence: EvidenceConfidence,
-    ) -> Self {
-        Self {
-            state: if normalized_value.is_some() {
-                EvidenceState::Known
-            } else {
-                EvidenceState::Invalid
-            },
-            source_field: Some(source_field),
-            raw_value: Some(raw_value),
+    ) -> Result<Self, EvidenceError> {
+        Self::try_new(
+            if normalized_value.is_some() { EvidenceState::Known } else { EvidenceState::Invalid },
+            Some(source_field),
+            Some(raw_value),
             normalized_value,
             confidence,
-        }
+        )
+    }
+
+    /// Returns this field's evidence state.
+    #[must_use]
+    pub const fn state(&self) -> EvidenceState {
+        self.state
+    }
+
+    /// Returns the original source-field spelling, when present.
+    #[must_use]
+    pub fn source_field(&self) -> Option<&str> {
+        self.source_field.as_deref()
+    }
+
+    /// Returns the unmodified source value, when present.
+    #[must_use]
+    pub fn raw_value(&self) -> Option<&str> {
+        self.raw_value.as_deref()
+    }
+
+    /// Returns the normalized value, when present.
+    #[must_use]
+    pub const fn normalized_value(&self) -> Option<&MetadataValue> {
+        self.normalized_value.as_ref()
+    }
+
+    /// Returns the confidence assigned by the selected profile.
+    #[must_use]
+    pub const fn confidence(&self) -> EvidenceConfidence {
+        self.confidence
+    }
+
+    fn canonical_payload_bytes(&self) -> usize {
+        self.raw_value.as_ref().map_or(0, String::len)
+            + self.normalized_value.as_ref().map_or(0, MetadataValue::canonical_payload_bytes)
+    }
+}
+
+impl TryFrom<FieldEvidenceWire> for FieldEvidence {
+    type Error = EvidenceError;
+
+    fn try_from(value: FieldEvidenceWire) -> Result<Self, Self::Error> {
+        Self::try_new(
+            value.state,
+            value.source_field,
+            value.raw_value,
+            value.normalized_value,
+            value.confidence,
+        )
+    }
+}
+
+impl<'de> Deserialize<'de> for FieldEvidence {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        FieldEvidenceWire::deserialize(deserializer)?.try_into().map_err(D::Error::custom)
     }
 }
 
 /// Exact capture-profile version used for normalization.
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CaptureProfileVersion {
-    pub profile_id: String,
-    pub version: u32,
-    pub registry_format_version: u32,
+    profile_id: String,
+    version: u32,
+    registry_format_version: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CaptureProfileVersionWire {
+    profile_id: String,
+    version: u32,
+    registry_format_version: u32,
+}
+
+impl CaptureProfileVersion {
+    /// Builds a validated capture-profile identity.
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] when the profile ID is empty or too large, or
+    /// either version is zero.
+    pub fn try_new(
+        profile_id: String,
+        version: u32,
+        registry_format_version: u32,
+    ) -> Result<Self, EvidenceError> {
+        if profile_id.trim().is_empty() {
+            return Err(EvidenceError::InvalidProfile("profile ID must not be empty"));
+        }
+        validate_value_size("capture profile ID", &profile_id)?;
+        if version == 0 || registry_format_version == 0 {
+            return Err(EvidenceError::InvalidProfile("profile versions must be positive"));
+        }
+        Ok(Self { profile_id, version, registry_format_version })
+    }
+
+    /// Returns the stable capture-profile identifier.
+    #[must_use]
+    pub fn profile_id(&self) -> &str {
+        &self.profile_id
+    }
+
+    /// Returns the selected profile's version.
+    #[must_use]
+    pub const fn version(&self) -> u32 {
+        self.version
+    }
+
+    /// Returns the registry format version.
+    #[must_use]
+    pub const fn registry_format_version(&self) -> u32 {
+        self.registry_format_version
+    }
+}
+
+impl TryFrom<CaptureProfileVersionWire> for CaptureProfileVersion {
+    type Error = EvidenceError;
+
+    fn try_from(value: CaptureProfileVersionWire) -> Result<Self, Self::Error> {
+        Self::try_new(value.profile_id, value.version, value.registry_format_version)
+    }
+}
+
+impl<'de> Deserialize<'de> for CaptureProfileVersion {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        CaptureProfileVersionWire::deserialize(deserializer)?.try_into().map_err(D::Error::custom)
+    }
 }
 
 /// Normalized field evidence extracted from one raw metadata source.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct MetadataEvidence {
-    pub profile: CaptureProfileVersion,
-    pub fields: BTreeMap<CanonicalField, FieldEvidence>,
+    profile: CaptureProfileVersion,
+    fields: BTreeMap<CanonicalField, FieldEvidence>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct MetadataEvidenceWire {
+    profile: CaptureProfileVersion,
+    fields: BTreeMap<CanonicalField, FieldEvidence>,
 }
 
 impl MetadataEvidence {
+    /// Builds a bounded metadata-evidence revision.
+    ///
+    /// The aggregate payload is the canonical UTF-8 representation of each
+    /// raw and normalized value. Source-field and profile identifiers are
+    /// bounded individually and are not evidence values.
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] when the field count or aggregate evidence
+    /// value payload exceeds its contract bound.
+    pub fn try_new(
+        profile: CaptureProfileVersion,
+        fields: BTreeMap<CanonicalField, FieldEvidence>,
+    ) -> Result<Self, EvidenceError> {
+        if fields.len() > MAX_EVIDENCE_FIELDS {
+            return Err(EvidenceError::TooManyFields {
+                actual: fields.len(),
+                maximum: MAX_EVIDENCE_FIELDS,
+            });
+        }
+        let payload_bytes = fields.values().try_fold(0usize, |size, field| {
+            size.checked_add(field.canonical_payload_bytes()).ok_or(
+                EvidenceError::PayloadTooLarge {
+                    actual: usize::MAX,
+                    maximum: MAX_EVIDENCE_PAYLOAD_BYTES,
+                },
+            )
+        })?;
+        if payload_bytes > MAX_EVIDENCE_PAYLOAD_BYTES {
+            return Err(EvidenceError::PayloadTooLarge {
+                actual: payload_bytes,
+                maximum: MAX_EVIDENCE_PAYLOAD_BYTES,
+            });
+        }
+        Ok(Self { profile, fields })
+    }
+
+    /// Returns the exact selected capture-profile version.
+    #[must_use]
+    pub const fn profile(&self) -> &CaptureProfileVersion {
+        &self.profile
+    }
+
     /// Returns the evidence for a canonical field mapped by the selected profile.
     #[must_use]
     pub fn field(&self, field: CanonicalField) -> Option<&FieldEvidence> {
         self.fields.get(&field)
     }
+
+    /// Returns all canonical field evidence in stable field order.
+    #[must_use]
+    pub const fn fields(&self) -> &BTreeMap<CanonicalField, FieldEvidence> {
+        &self.fields
+    }
+}
+
+impl TryFrom<MetadataEvidenceWire> for MetadataEvidence {
+    type Error = EvidenceError;
+
+    fn try_from(value: MetadataEvidenceWire) -> Result<Self, Self::Error> {
+        Self::try_new(value.profile, value.fields)
+    }
+}
+
+impl<'de> Deserialize<'de> for MetadataEvidence {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        MetadataEvidenceWire::deserialize(deserializer)?.try_into().map_err(D::Error::custom)
+    }
 }
 
 /// Independently calculated focal length supplied by a geometry interpreter.
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[derive(Clone, Debug, PartialEq, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub struct CalculatedFocalLength {
-    pub millimetres: f64,
-    pub source: String,
+    millimetres: f64,
+    source: String,
 }
 
-#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct CalculatedFocalLengthWire {
+    millimetres: f64,
+    source: String,
+}
+
+impl CalculatedFocalLength {
+    /// Builds calculated focal-length evidence with bounded provenance.
+    ///
+    /// Non-finite or non-positive focal lengths remain representable so the
+    /// profile can preserve them as explicit invalid evidence.
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] when `source` is empty or exceeds the value
+    /// size limit.
+    pub fn try_new(millimetres: f64, source: String) -> Result<Self, EvidenceError> {
+        if source.trim().is_empty() {
+            return Err(EvidenceError::EmptyRawField);
+        }
+        validate_value_size("calculated focal-length source", &source)?;
+        Ok(Self { millimetres, source })
+    }
+
+    /// Returns the calculated focal length in millimetres.
+    #[must_use]
+    pub const fn millimetres(&self) -> f64 {
+        self.millimetres
+    }
+
+    /// Returns the calculation provenance identifier.
+    #[must_use]
+    pub fn source(&self) -> &str {
+        &self.source
+    }
+}
+
+impl TryFrom<CalculatedFocalLengthWire> for CalculatedFocalLength {
+    type Error = EvidenceError;
+
+    fn try_from(value: CalculatedFocalLengthWire) -> Result<Self, Self::Error> {
+        Self::try_new(value.millimetres, value.source)
+    }
+}
+
+impl<'de> Deserialize<'de> for CalculatedFocalLength {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        CalculatedFocalLengthWire::deserialize(deserializer)?.try_into().map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize)]
 struct RawMetadataEntry {
     source_field: String,
     raw_value: String,
 }
 
-/// Raw FITS keywords or XISF properties keyed without case sensitivity.
-#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawMetadataEntryWire {
+    source_field: String,
+    raw_value: String,
+}
+
+/// Raw FITS keywords or XISF properties keyed without ASCII case sensitivity.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize)]
 pub struct RawMetadata {
     values: BTreeMap<String, RawMetadataEntry>,
 }
 
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct RawMetadataWire {
+    values: BTreeMap<String, RawMetadataEntryWire>,
+}
+
 impl RawMetadata {
     /// Builds raw metadata from `(source field, raw value)` pairs.
-    #[must_use]
-    pub fn from_pairs<I, K, V>(pairs: I) -> Self
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] for empty or oversized fields/values and for
+    /// fields that collide after ASCII case folding.
+    pub fn from_pairs<I, K, V>(pairs: I) -> Result<Self, EvidenceError>
     where
         I: IntoIterator<Item = (K, V)>,
         K: Into<String>,
@@ -154,23 +563,84 @@ impl RawMetadata {
     {
         let mut metadata = Self::default();
         for (field, value) in pairs {
-            metadata.insert(field, value);
+            metadata.insert(field, value)?;
         }
-        metadata
+        Ok(metadata)
     }
 
-    /// Inserts or replaces one raw field using ASCII case-insensitive identity.
-    pub fn insert(&mut self, field: impl Into<String>, value: impl Into<String>) {
-        let source_field = field.into();
-        self.values.insert(
-            source_field.to_ascii_uppercase(),
-            RawMetadataEntry { source_field, raw_value: value.into() },
-        );
+    /// Inserts one raw field using ASCII case-insensitive identity.
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] for empty or oversized fields/values or when
+    /// the canonical key is already present.
+    pub fn insert(
+        &mut self,
+        field: impl Into<String>,
+        value: impl Into<String>,
+    ) -> Result<(), EvidenceError> {
+        self.insert_entry(field.into(), value.into())
     }
 
     pub(crate) fn get(&self, field: &str) -> Option<(&str, &str)> {
         self.values
-            .get(&field.to_ascii_uppercase())
+            .get(&canonical_raw_key(field))
             .map(|entry| (entry.source_field.as_str(), entry.raw_value.as_str()))
     }
+
+    fn insert_entry(
+        &mut self,
+        source_field: String,
+        raw_value: String,
+    ) -> Result<(), EvidenceError> {
+        if source_field.trim().is_empty() {
+            return Err(EvidenceError::EmptyRawField);
+        }
+        validate_value_size("raw metadata source field", &source_field)?;
+        validate_value_size("raw metadata value", &raw_value)?;
+        let canonical_key = canonical_raw_key(&source_field);
+        if self.values.contains_key(&canonical_key) {
+            return Err(EvidenceError::RawKeyCollision(canonical_key));
+        }
+        self.values.insert(canonical_key, RawMetadataEntry { source_field, raw_value });
+        Ok(())
+    }
+}
+
+impl TryFrom<RawMetadataWire> for RawMetadata {
+    type Error = EvidenceError;
+
+    fn try_from(value: RawMetadataWire) -> Result<Self, Self::Error> {
+        let mut metadata = Self::default();
+        for (key, entry) in value.values {
+            if canonical_raw_key(&key) != canonical_raw_key(&entry.source_field) {
+                return Err(EvidenceError::RawKeyMismatch);
+            }
+            metadata.insert_entry(entry.source_field, entry.raw_value)?;
+        }
+        Ok(metadata)
+    }
+}
+
+impl<'de> Deserialize<'de> for RawMetadata {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        RawMetadataWire::deserialize(deserializer)?.try_into().map_err(D::Error::custom)
+    }
+}
+
+fn canonical_raw_key(field: &str) -> String {
+    field.to_ascii_uppercase()
+}
+
+fn validate_value_size(context: &'static str, value: &str) -> Result<(), EvidenceError> {
+    if value.len() > MAX_EVIDENCE_VALUE_BYTES {
+        return Err(EvidenceError::ValueTooLarge {
+            context,
+            actual: value.len(),
+            maximum: MAX_EVIDENCE_VALUE_BYTES,
+        });
+    }
+    Ok(())
 }

--- a/crates/metadata/core/src/evidence.rs
+++ b/crates/metadata/core/src/evidence.rs
@@ -1,0 +1,176 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::collections::BTreeMap;
+
+use serde::{Deserialize, Serialize};
+
+/// Canonical fields emitted by capture-software profiles.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum CanonicalField {
+    Camera,
+    Telescope,
+    Filter,
+    Gain,
+    Offset,
+    BinningX,
+    BinningY,
+    ReadoutMode,
+    RasterWidth,
+    RasterHeight,
+    Crop,
+    FocalLengthReported,
+    FocalLengthCalculated,
+    PixelSize,
+    PhysicalRotator,
+    SkyOrientation,
+}
+
+/// State of one normalized metadata value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceState {
+    Known,
+    Absent,
+    Invalid,
+    Contradictory,
+}
+
+/// Quality of the evidence supporting a normalized value.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceConfidence {
+    Confirmed,
+    Reported,
+    Calculated,
+}
+
+/// Typed scalar value produced by a profile mapping.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataValue {
+    Text(String),
+    Integer(i64),
+    Unsigned(u64),
+    Decimal(f64),
+}
+
+/// Field-level value, state, and raw provenance.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldEvidence {
+    pub state: EvidenceState,
+    pub source_field: Option<String>,
+    pub raw_value: Option<String>,
+    pub normalized_value: Option<MetadataValue>,
+    pub confidence: EvidenceConfidence,
+}
+
+impl FieldEvidence {
+    pub(crate) fn absent(confidence: EvidenceConfidence) -> Self {
+        Self {
+            state: EvidenceState::Absent,
+            source_field: None,
+            raw_value: None,
+            normalized_value: None,
+            confidence,
+        }
+    }
+
+    pub(crate) fn from_raw(
+        source_field: String,
+        raw_value: String,
+        normalized_value: Option<MetadataValue>,
+        confidence: EvidenceConfidence,
+    ) -> Self {
+        Self {
+            state: if normalized_value.is_some() {
+                EvidenceState::Known
+            } else {
+                EvidenceState::Invalid
+            },
+            source_field: Some(source_field),
+            raw_value: Some(raw_value),
+            normalized_value,
+            confidence,
+        }
+    }
+}
+
+/// Exact capture-profile version used for normalization.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CaptureProfileVersion {
+    pub profile_id: String,
+    pub version: u32,
+    pub registry_format_version: u32,
+}
+
+/// Normalized field evidence extracted from one raw metadata source.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataEvidence {
+    pub profile: CaptureProfileVersion,
+    pub fields: BTreeMap<CanonicalField, FieldEvidence>,
+}
+
+impl MetadataEvidence {
+    /// Returns the evidence for a canonical field mapped by the selected profile.
+    #[must_use]
+    pub fn field(&self, field: CanonicalField) -> Option<&FieldEvidence> {
+        self.fields.get(&field)
+    }
+}
+
+/// Independently calculated focal length supplied by a geometry interpreter.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CalculatedFocalLength {
+    pub millimetres: f64,
+    pub source: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+struct RawMetadataEntry {
+    source_field: String,
+    raw_value: String,
+}
+
+/// Raw FITS keywords or XISF properties keyed without case sensitivity.
+#[derive(Clone, Debug, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RawMetadata {
+    values: BTreeMap<String, RawMetadataEntry>,
+}
+
+impl RawMetadata {
+    /// Builds raw metadata from `(source field, raw value)` pairs.
+    #[must_use]
+    pub fn from_pairs<I, K, V>(pairs: I) -> Self
+    where
+        I: IntoIterator<Item = (K, V)>,
+        K: Into<String>,
+        V: Into<String>,
+    {
+        let mut metadata = Self::default();
+        for (field, value) in pairs {
+            metadata.insert(field, value);
+        }
+        metadata
+    }
+
+    /// Inserts or replaces one raw field using ASCII case-insensitive identity.
+    pub fn insert(&mut self, field: impl Into<String>, value: impl Into<String>) {
+        let source_field = field.into();
+        self.values.insert(
+            source_field.to_ascii_uppercase(),
+            RawMetadataEntry { source_field, raw_value: value.into() },
+        );
+    }
+
+    pub(crate) fn get(&self, field: &str) -> Option<(&str, &str)> {
+        self.values
+            .get(&field.to_ascii_uppercase())
+            .map(|entry| (entry.source_field.as_str(), entry.raw_value.as_str()))
+    }
+}

--- a/crates/metadata/core/src/lib.rs
+++ b/crates/metadata/core/src/lib.rs
@@ -23,9 +23,10 @@ mod profile;
 
 pub use evidence::{
     CalculatedFocalLength, CanonicalField, CaptureProfileVersion, EvidenceConfidence,
-    EvidenceState, FieldEvidence, MetadataEvidence, MetadataValue, RawMetadata,
+    EvidenceError, EvidenceState, FieldEvidence, MetadataEvidence, MetadataValue, RawMetadata,
+    MAX_EVIDENCE_PAYLOAD_BYTES, MAX_EVIDENCE_VALUE_BYTES,
 };
-pub use profile::{CaptureProfileError, CaptureProfileRegistry};
+pub use profile::{CaptureProfileError, CaptureProfileRegistry, MAX_CAPTURE_PROFILE_TOML_BYTES};
 
 // ── FrameType ─────────────────────────────────────────────────────────────────
 

--- a/crates/metadata/core/src/lib.rs
+++ b/crates/metadata/core/src/lib.rs
@@ -11,11 +11,21 @@
 //!   [`FrameType`] via case-insensitive lookup.
 //! - [`MetadataExtractor`] — trait implemented by FITS/XISF adapters.
 //! - [`RawFileMetadata`] — minimal header values returned by extractors.
+//! - [`CaptureProfileRegistry`] — versioned normalization of raw FITS/XISF fields.
 #![allow(clippy::doc_markdown)]
 
 use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
+
+mod evidence;
+mod profile;
+
+pub use evidence::{
+    CalculatedFocalLength, CanonicalField, CaptureProfileVersion, EvidenceConfidence,
+    EvidenceState, FieldEvidence, MetadataEvidence, MetadataValue, RawMetadata,
+};
+pub use profile::{CaptureProfileError, CaptureProfileRegistry};
 
 // ── FrameType ─────────────────────────────────────────────────────────────────
 

--- a/crates/metadata/core/src/profile.rs
+++ b/crates/metadata/core/src/profile.rs
@@ -1,0 +1,303 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::collections::{BTreeMap, HashSet};
+
+use serde::Deserialize;
+
+use crate::{
+    CalculatedFocalLength, CanonicalField, CaptureProfileVersion, EvidenceConfidence,
+    FieldEvidence, MetadataEvidence, MetadataValue, RawMetadata,
+};
+
+const EMBEDDED_PROFILES: &str = include_str!("../data/capture_profiles.toml");
+
+/// Registry parse or validation failure.
+#[derive(Debug, thiserror::Error)]
+pub enum CaptureProfileError {
+    #[error("invalid capture-profile TOML: {0}")]
+    Toml(#[from] toml::de::Error),
+    #[error("invalid capture-profile registry: {0}")]
+    Registry(String),
+}
+
+/// Versioned capture-software profiles loaded from TOML.
+#[derive(Clone, Debug)]
+pub struct CaptureProfileRegistry {
+    format_version: u32,
+    fallback_profile: String,
+    profiles: Vec<ProfileConfig>,
+}
+
+impl CaptureProfileRegistry {
+    /// Loads the profiles shipped with this crate.
+    ///
+    /// # Errors
+    /// Returns [`CaptureProfileError`] when the embedded registry cannot be
+    /// parsed or violates a registry invariant.
+    pub fn embedded() -> Result<Self, CaptureProfileError> {
+        Self::from_toml(EMBEDDED_PROFILES)
+    }
+
+    /// Loads and validates a capture-profile registry.
+    ///
+    /// # Errors
+    /// Returns [`CaptureProfileError`] when `source` is not valid registry TOML
+    /// or violates a registry invariant.
+    pub fn from_toml(source: &str) -> Result<Self, CaptureProfileError> {
+        let config: RegistryConfig = toml::from_str(source)?;
+        validate(&config)?;
+        Ok(Self {
+            format_version: config.format_version,
+            fallback_profile: config.fallback_profile,
+            profiles: config.profiles,
+        })
+    }
+
+    /// Selects a profile and extracts typed field evidence.
+    #[must_use]
+    pub fn extract(
+        &self,
+        raw: &RawMetadata,
+        calculated_focal_length: Option<CalculatedFocalLength>,
+    ) -> MetadataEvidence {
+        let profile = self.select_profile(raw);
+        let mut fields = profile
+            .fields
+            .iter()
+            .map(|(field, mapping)| (*field, extract_field(raw, mapping)))
+            .collect::<BTreeMap<_, _>>();
+        fields.insert(
+            CanonicalField::FocalLengthCalculated,
+            calculated_focal_length_evidence(calculated_focal_length),
+        );
+
+        MetadataEvidence {
+            profile: CaptureProfileVersion {
+                profile_id: profile.id.clone(),
+                version: profile.version,
+                registry_format_version: self.format_version,
+            },
+            fields,
+        }
+    }
+
+    fn select_profile(&self, raw: &RawMetadata) -> &ProfileConfig {
+        self.profiles
+            .iter()
+            .filter(|profile| profile.id != self.fallback_profile && profile.matches(raw))
+            .min_by(|left, right| {
+                right.priority.cmp(&left.priority).then_with(|| left.id.cmp(&right.id))
+            })
+            .unwrap_or_else(|| {
+                self.profiles
+                    .iter()
+                    .find(|profile| profile.id == self.fallback_profile)
+                    .expect("validated fallback profile must exist")
+            })
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct RegistryConfig {
+    format_version: u32,
+    fallback_profile: String,
+    profiles: Vec<ProfileConfig>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ProfileConfig {
+    id: String,
+    version: u32,
+    #[serde(default)]
+    priority: i32,
+    #[serde(default)]
+    match_any: Vec<ProfileMatcher>,
+    #[serde(default)]
+    fields: BTreeMap<CanonicalField, FieldMapping>,
+}
+
+impl ProfileConfig {
+    fn matches(&self, raw: &RawMetadata) -> bool {
+        self.match_any.iter().any(|matcher| matcher.matches(raw))
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct ProfileMatcher {
+    field: String,
+    equals: Option<String>,
+    contains: Option<String>,
+}
+
+impl ProfileMatcher {
+    fn matches(&self, raw: &RawMetadata) -> bool {
+        let Some((_, raw_value)) = raw.get(&self.field) else {
+            return false;
+        };
+        if let Some(expected) = &self.equals {
+            raw_value.trim().eq_ignore_ascii_case(expected.trim())
+        } else if let Some(fragment) = &self.contains {
+            raw_value.to_ascii_lowercase().contains(&fragment.to_ascii_lowercase())
+        } else {
+            false
+        }
+    }
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct FieldMapping {
+    confidence: EvidenceConfidence,
+    sources: Vec<SourceMapping>,
+    #[serde(default)]
+    aliases: BTreeMap<String, String>,
+}
+
+#[derive(Clone, Debug, Deserialize)]
+struct SourceMapping {
+    field: String,
+    parser: ValueParser,
+    scale: Option<f64>,
+}
+
+#[derive(Clone, Copy, Debug, Deserialize)]
+#[serde(rename_all = "snake_case")]
+enum ValueParser {
+    Text,
+    Integer,
+    PositiveInteger,
+    Decimal,
+    PositiveDecimal,
+}
+
+fn validate(config: &RegistryConfig) -> Result<(), CaptureProfileError> {
+    if config.format_version != 1 {
+        return Err(CaptureProfileError::Registry(format!(
+            "unsupported format_version {}",
+            config.format_version
+        )));
+    }
+    if config.profiles.is_empty() {
+        return Err(CaptureProfileError::Registry("profiles must not be empty".to_owned()));
+    }
+
+    let mut profile_ids = HashSet::new();
+    let mut fallback_count = 0;
+    for profile in &config.profiles {
+        if profile.id.trim().is_empty() {
+            return Err(CaptureProfileError::Registry("profile id must not be empty".to_owned()));
+        }
+        if !profile_ids.insert(profile.id.as_str()) {
+            return Err(CaptureProfileError::Registry(format!(
+                "duplicate profile id {}",
+                profile.id
+            )));
+        }
+        if profile.id == config.fallback_profile {
+            fallback_count += 1;
+        }
+        for matcher in &profile.match_any {
+            if matcher.field.trim().is_empty()
+                || usize::from(matcher.equals.is_some()) + usize::from(matcher.contains.is_some())
+                    != 1
+            {
+                return Err(CaptureProfileError::Registry(format!(
+                    "profile {} has an invalid matcher",
+                    profile.id
+                )));
+            }
+        }
+        for (field, mapping) in &profile.fields {
+            if *field == CanonicalField::FocalLengthCalculated {
+                return Err(CaptureProfileError::Registry(format!(
+                    "profile {} maps calculated focal length from raw metadata",
+                    profile.id
+                )));
+            }
+            if mapping.sources.is_empty() {
+                return Err(CaptureProfileError::Registry(format!(
+                    "profile {} field {field:?} has no sources",
+                    profile.id
+                )));
+            }
+            for source in &mapping.sources {
+                if source.field.trim().is_empty()
+                    || source.scale.is_some_and(|scale| !scale.is_finite() || scale <= 0.0)
+                {
+                    return Err(CaptureProfileError::Registry(format!(
+                        "profile {} field {field:?} has an invalid source",
+                        profile.id
+                    )));
+                }
+            }
+        }
+    }
+
+    if fallback_count != 1 {
+        return Err(CaptureProfileError::Registry(format!(
+            "fallback profile {} must exist exactly once",
+            config.fallback_profile
+        )));
+    }
+    Ok(())
+}
+
+fn extract_field(raw: &RawMetadata, mapping: &FieldMapping) -> FieldEvidence {
+    for source in &mapping.sources {
+        let Some((source_field, raw_value)) = raw.get(&source.field) else {
+            continue;
+        };
+        let normalized = parse_value(raw_value, source, &mapping.aliases);
+        return FieldEvidence::from_raw(
+            source_field.to_owned(),
+            raw_value.to_owned(),
+            normalized,
+            mapping.confidence,
+        );
+    }
+    FieldEvidence::absent(mapping.confidence)
+}
+
+fn parse_value(
+    raw_value: &str,
+    source: &SourceMapping,
+    aliases: &BTreeMap<String, String>,
+) -> Option<MetadataValue> {
+    let value = crate::strip_fits_quotes(raw_value)?;
+    match source.parser {
+        ValueParser::Text => {
+            let normalized = aliases
+                .iter()
+                .find_map(|(alias, replacement)| {
+                    value.eq_ignore_ascii_case(alias).then_some(replacement.as_str())
+                })
+                .unwrap_or(value);
+            Some(MetadataValue::Text(normalized.to_owned()))
+        }
+        ValueParser::Integer => value.parse().ok().map(MetadataValue::Integer),
+        ValueParser::PositiveInteger => {
+            value.parse::<u64>().ok().filter(|parsed| *parsed > 0).map(MetadataValue::Unsigned)
+        }
+        ValueParser::Decimal => parse_decimal(value, source.scale, false),
+        ValueParser::PositiveDecimal => parse_decimal(value, source.scale, true),
+    }
+}
+
+fn parse_decimal(raw_value: &str, scale: Option<f64>, positive: bool) -> Option<MetadataValue> {
+    let value = raw_value.parse::<f64>().ok()? * scale.unwrap_or(1.0);
+    (value.is_finite() && (!positive || value > 0.0)).then_some(MetadataValue::Decimal(value))
+}
+
+fn calculated_focal_length_evidence(calculated: Option<CalculatedFocalLength>) -> FieldEvidence {
+    let Some(calculated) = calculated else {
+        return FieldEvidence::absent(EvidenceConfidence::Calculated);
+    };
+    let normalized = (calculated.millimetres.is_finite() && calculated.millimetres > 0.0)
+        .then_some(MetadataValue::Decimal(calculated.millimetres));
+    FieldEvidence::from_raw(
+        calculated.source,
+        calculated.millimetres.to_string(),
+        normalized,
+        EvidenceConfidence::Calculated,
+    )
+}

--- a/crates/metadata/core/src/profile.rs
+++ b/crates/metadata/core/src/profile.rs
@@ -7,14 +7,19 @@ use serde::Deserialize;
 
 use crate::{
     CalculatedFocalLength, CanonicalField, CaptureProfileVersion, EvidenceConfidence,
-    FieldEvidence, MetadataEvidence, MetadataValue, RawMetadata,
+    EvidenceError, FieldEvidence, MetadataEvidence, MetadataValue, RawMetadata,
 };
 
 const EMBEDDED_PROFILES: &str = include_str!("../data/capture_profiles.toml");
 
+/// Maximum UTF-8 size accepted for a capture-profile registry.
+pub const MAX_CAPTURE_PROFILE_TOML_BYTES: usize = 256 * 1024;
+
 /// Registry parse or validation failure.
 #[derive(Debug, thiserror::Error)]
 pub enum CaptureProfileError {
+    #[error("capture-profile TOML is {actual} UTF-8 bytes; maximum is {maximum}")]
+    SourceTooLarge { actual: usize, maximum: usize },
     #[error("invalid capture-profile TOML: {0}")]
     Toml(#[from] toml::de::Error),
     #[error("invalid capture-profile registry: {0}")]
@@ -45,6 +50,12 @@ impl CaptureProfileRegistry {
     /// Returns [`CaptureProfileError`] when `source` is not valid registry TOML
     /// or violates a registry invariant.
     pub fn from_toml(source: &str) -> Result<Self, CaptureProfileError> {
+        if source.len() > MAX_CAPTURE_PROFILE_TOML_BYTES {
+            return Err(CaptureProfileError::SourceTooLarge {
+                actual: source.len(),
+                maximum: MAX_CAPTURE_PROFILE_TOML_BYTES,
+            });
+        }
         let config: RegistryConfig = toml::from_str(source)?;
         validate(&config)?;
         Ok(Self {
@@ -54,51 +65,54 @@ impl CaptureProfileRegistry {
         })
     }
 
-    /// Selects a profile and extracts typed field evidence.
-    #[must_use]
+    /// Selects a profile and extracts bounded typed field evidence.
+    ///
+    /// # Errors
+    /// Returns [`EvidenceError`] when raw, normalized, or aggregate evidence
+    /// exceeds its contract bound or an internal registry invariant is absent.
     pub fn extract(
         &self,
         raw: &RawMetadata,
         calculated_focal_length: Option<CalculatedFocalLength>,
-    ) -> MetadataEvidence {
-        let profile = self.select_profile(raw);
+    ) -> Result<MetadataEvidence, EvidenceError> {
+        let profile = self.select_profile(raw)?;
         let mut fields = profile
             .fields
             .iter()
             .map(|(field, mapping)| (*field, extract_field(raw, mapping)))
-            .collect::<BTreeMap<_, _>>();
+            .map(|(field, evidence)| evidence.map(|evidence| (field, evidence)))
+            .collect::<Result<BTreeMap<_, _>, _>>()?;
         fields.insert(
             CanonicalField::FocalLengthCalculated,
-            calculated_focal_length_evidence(calculated_focal_length),
+            calculated_focal_length_evidence(calculated_focal_length)?,
         );
 
-        MetadataEvidence {
-            profile: CaptureProfileVersion {
-                profile_id: profile.id.clone(),
-                version: profile.version,
-                registry_format_version: self.format_version,
-            },
+        MetadataEvidence::try_new(
+            CaptureProfileVersion::try_new(
+                profile.id.clone(),
+                profile.version,
+                self.format_version,
+            )?,
             fields,
-        }
+        )
     }
 
-    fn select_profile(&self, raw: &RawMetadata) -> &ProfileConfig {
-        self.profiles
+    fn select_profile(&self, raw: &RawMetadata) -> Result<&ProfileConfig, EvidenceError> {
+        let selected = self
+            .profiles
             .iter()
             .filter(|profile| profile.id != self.fallback_profile && profile.matches(raw))
             .min_by(|left, right| {
                 right.priority.cmp(&left.priority).then_with(|| left.id.cmp(&right.id))
-            })
-            .unwrap_or_else(|| {
-                self.profiles
-                    .iter()
-                    .find(|profile| profile.id == self.fallback_profile)
-                    .expect("validated fallback profile must exist")
-            })
+            });
+        selected
+            .or_else(|| self.profiles.iter().find(|profile| profile.id == self.fallback_profile))
+            .ok_or(EvidenceError::MissingFallbackProfile)
     }
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct RegistryConfig {
     format_version: u32,
     fallback_profile: String,
@@ -106,6 +120,7 @@ struct RegistryConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ProfileConfig {
     id: String,
     version: u32,
@@ -124,6 +139,7 @@ impl ProfileConfig {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ProfileMatcher {
     field: String,
     equals: Option<String>,
@@ -146,6 +162,7 @@ impl ProfileMatcher {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct FieldMapping {
     confidence: EvidenceConfidence,
     sources: Vec<SourceMapping>,
@@ -154,6 +171,7 @@ struct FieldMapping {
 }
 
 #[derive(Clone, Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct SourceMapping {
     field: String,
     parser: ValueParser,
@@ -186,6 +204,12 @@ fn validate(config: &RegistryConfig) -> Result<(), CaptureProfileError> {
     for profile in &config.profiles {
         if profile.id.trim().is_empty() {
             return Err(CaptureProfileError::Registry("profile id must not be empty".to_owned()));
+        }
+        if profile.version == 0 {
+            return Err(CaptureProfileError::Registry(format!(
+                "profile {} has a zero version",
+                profile.id
+            )));
         }
         if !profile_ids.insert(profile.id.as_str()) {
             return Err(CaptureProfileError::Registry(format!(
@@ -242,7 +266,10 @@ fn validate(config: &RegistryConfig) -> Result<(), CaptureProfileError> {
     Ok(())
 }
 
-fn extract_field(raw: &RawMetadata, mapping: &FieldMapping) -> FieldEvidence {
+fn extract_field(
+    raw: &RawMetadata,
+    mapping: &FieldMapping,
+) -> Result<FieldEvidence, EvidenceError> {
     for source in &mapping.sources {
         let Some((source_field, raw_value)) = raw.get(&source.field) else {
             continue;
@@ -255,7 +282,7 @@ fn extract_field(raw: &RawMetadata, mapping: &FieldMapping) -> FieldEvidence {
             mapping.confidence,
         );
     }
-    FieldEvidence::absent(mapping.confidence)
+    Ok(FieldEvidence::absent(mapping.confidence))
 }
 
 fn parse_value(
@@ -288,15 +315,18 @@ fn parse_decimal(raw_value: &str, scale: Option<f64>, positive: bool) -> Option<
     (value.is_finite() && (!positive || value > 0.0)).then_some(MetadataValue::Decimal(value))
 }
 
-fn calculated_focal_length_evidence(calculated: Option<CalculatedFocalLength>) -> FieldEvidence {
+fn calculated_focal_length_evidence(
+    calculated: Option<CalculatedFocalLength>,
+) -> Result<FieldEvidence, EvidenceError> {
     let Some(calculated) = calculated else {
-        return FieldEvidence::absent(EvidenceConfidence::Calculated);
+        return Ok(FieldEvidence::absent(EvidenceConfidence::Calculated));
     };
-    let normalized = (calculated.millimetres.is_finite() && calculated.millimetres > 0.0)
-        .then_some(MetadataValue::Decimal(calculated.millimetres));
+    let millimetres = calculated.millimetres();
+    let normalized = (millimetres.is_finite() && millimetres > 0.0)
+        .then_some(MetadataValue::Decimal(millimetres));
     FieldEvidence::from_raw(
-        calculated.source,
-        calculated.millimetres.to_string(),
+        calculated.source().to_owned(),
+        millimetres.to_string(),
         normalized,
         EvidenceConfidence::Calculated,
     )

--- a/crates/metadata/core/tests/capture_profiles.rs
+++ b/crates/metadata/core/tests/capture_profiles.rs
@@ -1,19 +1,32 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use std::collections::BTreeMap;
+
 use metadata_core::{
-    CalculatedFocalLength, CanonicalField, CaptureProfileRegistry, EvidenceConfidence,
-    EvidenceState, MetadataValue, RawMetadata,
+    CalculatedFocalLength, CanonicalField, CaptureProfileRegistry, CaptureProfileVersion,
+    EvidenceConfidence, EvidenceError, EvidenceState, FieldEvidence, MetadataEvidence,
+    MetadataValue, RawMetadata, MAX_CAPTURE_PROFILE_TOML_BYTES, MAX_EVIDENCE_PAYLOAD_BYTES,
+    MAX_EVIDENCE_VALUE_BYTES,
 };
 
 fn text(value: &str) -> MetadataValue {
     MetadataValue::Text(value.to_owned())
 }
 
+fn raw<I, K, V>(pairs: I) -> RawMetadata
+where
+    I: IntoIterator<Item = (K, V)>,
+    K: Into<String>,
+    V: Into<String>,
+{
+    RawMetadata::from_pairs(pairs).unwrap()
+}
+
 #[test]
 fn nina_uses_configured_camera_and_telescope_representatives() {
     let registry = CaptureProfileRegistry::embedded().unwrap();
-    let raw = RawMetadata::from_pairs([
+    let raw = raw([
         ("SWCREATE", "N.I.N.A. 3.2.0.9001 (x64)"),
         ("CAMERA", "ZWO ASI2600MM Pro"),
         ("TELESCOP", "Celestron C925"),
@@ -23,46 +36,48 @@ fn nina_uses_configured_camera_and_telescope_representatives() {
         ("FOCALLEN", "1645"),
     ]);
 
-    let extracted = registry.extract(
-        &raw,
-        Some(CalculatedFocalLength { millimetres: 1_632.5, source: "wcs_cd_matrix".to_owned() }),
-    );
+    let extracted = registry
+        .extract(
+            &raw,
+            Some(CalculatedFocalLength::try_new(1_632.5, "wcs_cd_matrix".to_owned()).unwrap()),
+        )
+        .unwrap();
 
-    assert_eq!(extracted.profile.profile_id, "nina");
-    assert_eq!(extracted.profile.version, 1);
+    assert_eq!(extracted.profile().profile_id(), "nina");
+    assert_eq!(extracted.profile().version(), 1);
 
     let camera = extracted.field(CanonicalField::Camera).unwrap();
-    assert_eq!(camera.state, EvidenceState::Known);
-    assert_eq!(camera.source_field.as_deref(), Some("CAMERA"));
-    assert_eq!(camera.normalized_value, Some(text("ZWO ASI2600MM Pro")));
+    assert_eq!(camera.state(), EvidenceState::Known);
+    assert_eq!(camera.source_field(), Some("CAMERA"));
+    assert_eq!(camera.normalized_value(), Some(&text("ZWO ASI2600MM Pro")));
 
     let telescope = extracted.field(CanonicalField::Telescope).unwrap();
-    assert_eq!(telescope.source_field.as_deref(), Some("TELESCOP"));
-    assert_eq!(telescope.normalized_value, Some(text("Celestron C925")));
+    assert_eq!(telescope.source_field(), Some("TELESCOP"));
+    assert_eq!(telescope.normalized_value(), Some(&text("Celestron C925")));
 
     assert_eq!(
-        extracted.field(CanonicalField::BinningX).unwrap().normalized_value,
-        Some(MetadataValue::Unsigned(1))
+        extracted.field(CanonicalField::BinningX).unwrap().normalized_value(),
+        Some(&MetadataValue::Unsigned(1))
     );
     assert_eq!(
-        extracted.field(CanonicalField::BinningY).unwrap().normalized_value,
-        Some(MetadataValue::Unsigned(2))
+        extracted.field(CanonicalField::BinningY).unwrap().normalized_value(),
+        Some(&MetadataValue::Unsigned(2))
     );
 
     let reported = extracted.field(CanonicalField::FocalLengthReported).unwrap();
-    assert_eq!(reported.normalized_value, Some(MetadataValue::Decimal(1_645.0)));
-    assert_eq!(reported.confidence, EvidenceConfidence::Reported);
+    assert_eq!(reported.normalized_value(), Some(&MetadataValue::Decimal(1_645.0)));
+    assert_eq!(reported.confidence(), EvidenceConfidence::Reported);
 
     let calculated = extracted.field(CanonicalField::FocalLengthCalculated).unwrap();
-    assert_eq!(calculated.normalized_value, Some(MetadataValue::Decimal(1_632.5)));
-    assert_eq!(calculated.confidence, EvidenceConfidence::Calculated);
-    assert_eq!(calculated.source_field.as_deref(), Some("wcs_cd_matrix"));
+    assert_eq!(calculated.normalized_value(), Some(&MetadataValue::Decimal(1_632.5)));
+    assert_eq!(calculated.confidence(), EvidenceConfidence::Calculated);
+    assert_eq!(calculated.source_field(), Some("wcs_cd_matrix"));
 }
 
 #[test]
 fn dwarf_prefers_instrume_and_keeps_missing_values_explicit() {
     let registry = CaptureProfileRegistry::embedded().unwrap();
-    let raw = RawMetadata::from_pairs([
+    let raw = raw([
         ("ORIGIN", "DWARFLAB"),
         ("INSTRUME", "DWARF III"),
         ("CAMERA", "TELE"),
@@ -71,75 +86,74 @@ fn dwarf_prefers_instrume_and_keeps_missing_values_explicit() {
         ("YBINNING", "1"),
     ]);
 
-    let extracted = registry.extract(&raw, None);
+    let extracted = registry.extract(&raw, None).unwrap();
 
-    assert_eq!(extracted.profile.profile_id, "dwarf");
+    assert_eq!(extracted.profile().profile_id(), "dwarf");
     let camera = extracted.field(CanonicalField::Camera).unwrap();
-    assert_eq!(camera.source_field.as_deref(), Some("INSTRUME"));
-    assert_eq!(camera.raw_value.as_deref(), Some("DWARF III"));
-    assert_eq!(camera.normalized_value, Some(text("DWARF 3")));
+    assert_eq!(camera.source_field(), Some("INSTRUME"));
+    assert_eq!(camera.raw_value(), Some("DWARF III"));
+    assert_eq!(camera.normalized_value(), Some(&text("DWARF 3")));
 
     for field in [CanonicalField::Filter, CanonicalField::Offset, CanonicalField::ReadoutMode] {
         let evidence = extracted.field(field).unwrap();
-        assert_eq!(evidence.state, EvidenceState::Absent);
-        assert!(evidence.source_field.is_none());
-        assert!(evidence.raw_value.is_none());
-        assert!(evidence.normalized_value.is_none());
+        assert_eq!(evidence.state(), EvidenceState::Absent);
+        assert!(evidence.source_field().is_none());
+        assert!(evidence.raw_value().is_none());
+        assert!(evidence.normalized_value().is_none());
     }
 }
 
 #[test]
 fn binning_axes_are_not_inferred_from_each_other_or_raster() {
     let registry = CaptureProfileRegistry::embedded().unwrap();
-    let raw = RawMetadata::from_pairs([
+    let raw = raw([
         ("INSTRUME", "Unknown camera"),
         ("XBINNING", "2"),
         ("NAXIS1", "3000"),
         ("NAXIS2", "2000"),
     ]);
 
-    let extracted = registry.extract(&raw, None);
+    let extracted = registry.extract(&raw, None).unwrap();
 
-    assert_eq!(extracted.profile.profile_id, "generic");
+    assert_eq!(extracted.profile().profile_id(), "generic");
     assert_eq!(
-        extracted.field(CanonicalField::BinningX).unwrap().normalized_value,
-        Some(MetadataValue::Unsigned(2))
+        extracted.field(CanonicalField::BinningX).unwrap().normalized_value(),
+        Some(&MetadataValue::Unsigned(2))
     );
-    assert_eq!(extracted.field(CanonicalField::BinningY).unwrap().state, EvidenceState::Absent);
+    assert_eq!(extracted.field(CanonicalField::BinningY).unwrap().state(), EvidenceState::Absent);
 }
 
 #[test]
 fn xisf_native_focal_length_is_scaled_without_overwriting_calculated_evidence() {
     let registry = CaptureProfileRegistry::embedded().unwrap();
-    let raw = RawMetadata::from_pairs([
+    let raw = raw([
         ("Instrument:Camera:Name", "QHY268M"),
         ("Instrument:Telescope:Name", "APO 120"),
         ("Instrument:Telescope:FocalLength", "0.835784"),
     ]);
 
-    let extracted = registry.extract(
-        &raw,
-        Some(CalculatedFocalLength {
-            millimetres: 821.25,
-            source: "xisf_wcs_transform".to_owned(),
-        }),
-    );
+    let extracted = registry
+        .extract(
+            &raw,
+            Some(CalculatedFocalLength::try_new(821.25, "xisf_wcs_transform".to_owned()).unwrap()),
+        )
+        .unwrap();
 
     assert_eq!(
-        extracted.field(CanonicalField::Camera).unwrap().normalized_value,
-        Some(text("QHY268M"))
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value(),
+        Some(&text("QHY268M"))
     );
     assert_eq!(
-        extracted.field(CanonicalField::Telescope).unwrap().normalized_value,
-        Some(text("APO 120"))
+        extracted.field(CanonicalField::Telescope).unwrap().normalized_value(),
+        Some(&text("APO 120"))
     );
     assert_eq!(
-        extracted.field(CanonicalField::FocalLengthReported).unwrap().normalized_value,
-        Some(MetadataValue::Decimal(835.784))
+        extracted.field(CanonicalField::FocalLengthReported).unwrap().normalized_value(),
+        Some(&MetadataValue::Decimal(835.784))
     );
     assert_eq!(
-        extracted.field(CanonicalField::FocalLengthCalculated).unwrap().normalized_value,
-        Some(MetadataValue::Decimal(821.25))
+        extracted.field(CanonicalField::FocalLengthCalculated).unwrap().normalized_value(),
+        Some(&MetadataValue::Decimal(821.25))
     );
 }
 
@@ -177,34 +191,30 @@ priority = 0
 "#,
     )
     .unwrap();
-    let raw = RawMetadata::from_pairs([
-        ("MAKER", "shared"),
-        ("LOWER_CAMERA", "lower"),
-        ("HIGHER_CAMERA", "higher"),
-    ]);
+    let raw = raw([("MAKER", "shared"), ("LOWER_CAMERA", "lower"), ("HIGHER_CAMERA", "higher")]);
 
-    let extracted = registry.extract(&raw, None);
+    let extracted = registry.extract(&raw, None).unwrap();
 
-    assert_eq!(extracted.profile.profile_id, "higher");
-    assert_eq!(extracted.profile.version, 2);
+    assert_eq!(extracted.profile().profile_id(), "higher");
+    assert_eq!(extracted.profile().version(), 2);
     assert_eq!(
-        extracted.field(CanonicalField::Camera).unwrap().normalized_value,
-        Some(text("higher"))
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value(),
+        Some(&text("higher"))
     );
 }
 
 #[test]
 fn invalid_present_value_is_not_collapsed_into_absence() {
     let registry = CaptureProfileRegistry::embedded().unwrap();
-    let raw = RawMetadata::from_pairs([("OFFSET", "not-an-integer")]);
+    let raw = raw([("OFFSET", "not-an-integer")]);
 
-    let extracted = registry.extract(&raw, None);
+    let extracted = registry.extract(&raw, None).unwrap();
     let offset = extracted.field(CanonicalField::Offset).unwrap();
 
-    assert_eq!(offset.state, EvidenceState::Invalid);
-    assert_eq!(offset.source_field.as_deref(), Some("OFFSET"));
-    assert_eq!(offset.raw_value.as_deref(), Some("not-an-integer"));
-    assert!(offset.normalized_value.is_none());
+    assert_eq!(offset.state(), EvidenceState::Invalid);
+    assert_eq!(offset.source_field(), Some("OFFSET"));
+    assert_eq!(offset.raw_value(), Some("not-an-integer"));
+    assert!(offset.normalized_value().is_none());
 }
 
 #[test]
@@ -225,14 +235,253 @@ sources = [{ field = "VENDOR_CAMERA", parser = "text" }]
 "#,
     )
     .unwrap();
-    let raw = RawMetadata::from_pairs([("VENDOR_CAMERA", "Configured Camera")]);
+    let raw = raw([("VENDOR_CAMERA", "Configured Camera")]);
 
-    let extracted = registry.extract(&raw, None);
+    let extracted = registry.extract(&raw, None).unwrap();
 
-    assert_eq!(extracted.profile.profile_id, "vendor");
-    assert_eq!(extracted.profile.version, 7);
+    assert_eq!(extracted.profile().profile_id(), "vendor");
+    assert_eq!(extracted.profile().version(), 7);
     assert_eq!(
-        extracted.field(CanonicalField::Camera).unwrap().normalized_value,
-        Some(text("Configured Camera"))
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value(),
+        Some(&text("Configured Camera"))
     );
+}
+
+#[test]
+fn pixel_size_and_rotator_keep_distinct_numeric_boundary_semantics() {
+    let registry = CaptureProfileRegistry::embedded().unwrap();
+    let boundary_raw = raw([("XPIXSZ", "0"), ("ROTATANG", "-180")]);
+
+    let extracted = registry.extract(&boundary_raw, None).unwrap();
+
+    let pixel_size = extracted.field(CanonicalField::PixelSize).unwrap();
+    assert_eq!(pixel_size.state(), EvidenceState::Invalid);
+    assert_eq!(pixel_size.raw_value(), Some("0"));
+
+    let rotator = extracted.field(CanonicalField::PhysicalRotator).unwrap();
+    assert_eq!(rotator.state(), EvidenceState::Known);
+    assert_eq!(rotator.normalized_value(), Some(&MetadataValue::Decimal(-180.0)));
+
+    let non_finite = raw([("XPIXSZ", "0.000001"), ("ROTATANG", "NaN")]);
+    let extracted = registry.extract(&non_finite, None).unwrap();
+    assert_eq!(
+        extracted.field(CanonicalField::PixelSize).unwrap().normalized_value(),
+        Some(&MetadataValue::Decimal(0.000_001))
+    );
+    assert_eq!(
+        extracted.field(CanonicalField::PhysicalRotator).unwrap().state(),
+        EvidenceState::Invalid
+    );
+}
+
+#[test]
+fn field_evidence_rejects_invalid_state_value_tuples_during_deserialization() {
+    let error = toml::from_str::<FieldEvidence>(
+        r#"
+state = "known"
+sourceField = "CAMERA"
+rawValue = "ASI2600MM"
+confidence = "reported"
+"#,
+    )
+    .unwrap_err();
+
+    assert!(error.to_string().contains("known evidence requires"));
+
+    let oversized = "x".repeat(MAX_EVIDENCE_VALUE_BYTES + 1);
+    let source = format!(
+        r#"
+state = "invalid"
+sourceField = "CAMERA"
+rawValue = "{oversized}"
+confidence = "reported"
+"#
+    );
+    let error = toml::from_str::<FieldEvidence>(&source).unwrap_err();
+    assert!(error.to_string().contains("maximum is 16384"));
+}
+
+#[test]
+fn individual_evidence_values_enforce_max_minus_one_max_and_max_plus_one() {
+    for size in [MAX_EVIDENCE_VALUE_BYTES - 1, MAX_EVIDENCE_VALUE_BYTES] {
+        let value = "x".repeat(size);
+        FieldEvidence::try_new(
+            EvidenceState::Known,
+            Some("CAMERA".to_owned()),
+            Some(value.clone()),
+            Some(MetadataValue::Text(value)),
+            EvidenceConfidence::Reported,
+        )
+        .unwrap();
+    }
+
+    let oversized = "x".repeat(MAX_EVIDENCE_VALUE_BYTES + 1);
+    let error = FieldEvidence::try_new(
+        EvidenceState::Invalid,
+        Some("CAMERA".to_owned()),
+        Some(oversized),
+        None,
+        EvidenceConfidence::Reported,
+    )
+    .unwrap_err();
+    assert!(matches!(
+        error,
+        EvidenceError::ValueTooLarge {
+            actual,
+            maximum: MAX_EVIDENCE_VALUE_BYTES,
+            ..
+        } if actual == MAX_EVIDENCE_VALUE_BYTES + 1
+    ));
+}
+
+#[derive(serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct UncheckedMetadataEvidence<'a> {
+    profile: &'a CaptureProfileVersion,
+    fields: &'a BTreeMap<CanonicalField, FieldEvidence>,
+}
+
+fn text_evidence(size: usize) -> FieldEvidence {
+    let value = "x".repeat(size);
+    FieldEvidence::try_new(
+        EvidenceState::Known,
+        Some("SOURCE".to_owned()),
+        Some(value.clone()),
+        Some(MetadataValue::Text(value)),
+        EvidenceConfidence::Reported,
+    )
+    .unwrap()
+}
+
+#[test]
+fn aggregate_evidence_payload_enforces_max_minus_one_max_and_max_plus_one() {
+    let profile = CaptureProfileVersion::try_new("test".to_owned(), 1, 1).unwrap();
+    let fields = [
+        CanonicalField::Camera,
+        CanonicalField::Telescope,
+        CanonicalField::Filter,
+        CanonicalField::Gain,
+        CanonicalField::Offset,
+        CanonicalField::ReadoutMode,
+        CanonicalField::Crop,
+        CanonicalField::SkyOrientation,
+    ];
+
+    let max_fields = fields
+        .into_iter()
+        .map(|field| (field, text_evidence(MAX_EVIDENCE_VALUE_BYTES)))
+        .collect::<BTreeMap<_, _>>();
+    MetadataEvidence::try_new(profile.clone(), max_fields.clone()).unwrap();
+
+    let mut max_minus_one_fields = max_fields.clone();
+    max_minus_one_fields
+        .insert(CanonicalField::Camera, text_evidence(MAX_EVIDENCE_VALUE_BYTES - 1));
+    MetadataEvidence::try_new(profile.clone(), max_minus_one_fields).unwrap();
+
+    let mut max_plus_one_fields = max_fields;
+    max_plus_one_fields.insert(
+        CanonicalField::BinningX,
+        FieldEvidence::try_new(
+            EvidenceState::Invalid,
+            Some("XBINNING".to_owned()),
+            Some("x".to_owned()),
+            None,
+            EvidenceConfidence::Reported,
+        )
+        .unwrap(),
+    );
+    let error =
+        MetadataEvidence::try_new(profile.clone(), max_plus_one_fields.clone()).unwrap_err();
+    assert_eq!(
+        error,
+        EvidenceError::PayloadTooLarge {
+            actual: MAX_EVIDENCE_PAYLOAD_BYTES + 1,
+            maximum: MAX_EVIDENCE_PAYLOAD_BYTES,
+        }
+    );
+
+    let serialized = toml::to_string(&UncheckedMetadataEvidence {
+        profile: &profile,
+        fields: &max_plus_one_fields,
+    })
+    .unwrap();
+    let error = toml::from_str::<MetadataEvidence>(&serialized).unwrap_err();
+    assert!(error.to_string().contains("metadata evidence payload"));
+}
+
+#[test]
+fn raw_metadata_deserialization_canonicalizes_keys_and_rejects_collisions() {
+    let canonicalized = toml::from_str::<RawMetadata>(
+        r#"
+[values.camera]
+source_field = "camera"
+raw_value = "QHY268M"
+"#,
+    )
+    .unwrap();
+    let canonical_toml = toml::to_string(&canonicalized).unwrap();
+    assert!(canonical_toml.contains("[values.CAMERA]"));
+    let extracted =
+        CaptureProfileRegistry::embedded().unwrap().extract(&canonicalized, None).unwrap();
+    assert_eq!(
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value(),
+        Some(&text("QHY268M"))
+    );
+
+    let collision = toml::from_str::<RawMetadata>(
+        r#"
+[values.camera]
+source_field = "camera"
+raw_value = "first"
+
+[values.CAMERA]
+source_field = "CAMERA"
+raw_value = "second"
+"#,
+    )
+    .unwrap_err();
+    assert!(collision.to_string().contains("case-insensitive key collision"));
+}
+
+const MINIMAL_PROFILE: &str = r#"
+format_version = 1
+fallback_profile = "generic"
+
+[[profiles]]
+id = "generic"
+version = 1
+"#;
+
+fn padded_profile(size: usize) -> String {
+    assert!(size >= MINIMAL_PROFILE.len() + 2);
+    let mut source = MINIMAL_PROFILE.to_owned();
+    source.push_str("\n#");
+    source.push_str(&"x".repeat(size - source.len()));
+    assert_eq!(source.len(), size);
+    source
+}
+
+#[test]
+fn capture_profile_input_is_bounded_at_the_documented_utf8_limit() {
+    for size in [MAX_CAPTURE_PROFILE_TOML_BYTES - 1, MAX_CAPTURE_PROFILE_TOML_BYTES] {
+        CaptureProfileRegistry::from_toml(&padded_profile(size)).unwrap();
+    }
+
+    let oversized = padded_profile(MAX_CAPTURE_PROFILE_TOML_BYTES + 1);
+    let error = CaptureProfileRegistry::from_toml(&oversized).unwrap_err();
+    assert!(matches!(
+        error,
+        metadata_core::CaptureProfileError::SourceTooLarge {
+            actual,
+            maximum: MAX_CAPTURE_PROFILE_TOML_BYTES,
+        } if actual == MAX_CAPTURE_PROFILE_TOML_BYTES + 1
+    ));
+}
+
+#[test]
+fn capture_profile_toml_rejects_unknown_fields() {
+    let source = format!("{MINIMAL_PROFILE}\nunexpected = true\n");
+    let error = CaptureProfileRegistry::from_toml(&source).unwrap_err();
+
+    assert!(error.to_string().contains("unknown field"));
 }

--- a/crates/metadata/core/tests/capture_profiles.rs
+++ b/crates/metadata/core/tests/capture_profiles.rs
@@ -1,0 +1,238 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use metadata_core::{
+    CalculatedFocalLength, CanonicalField, CaptureProfileRegistry, EvidenceConfidence,
+    EvidenceState, MetadataValue, RawMetadata,
+};
+
+fn text(value: &str) -> MetadataValue {
+    MetadataValue::Text(value.to_owned())
+}
+
+#[test]
+fn nina_uses_configured_camera_and_telescope_representatives() {
+    let registry = CaptureProfileRegistry::embedded().unwrap();
+    let raw = RawMetadata::from_pairs([
+        ("SWCREATE", "N.I.N.A. 3.2.0.9001 (x64)"),
+        ("CAMERA", "ZWO ASI2600MM Pro"),
+        ("TELESCOP", "Celestron C925"),
+        ("FILTER", "OIII"),
+        ("XBINNING", "1"),
+        ("YBINNING", "2"),
+        ("FOCALLEN", "1645"),
+    ]);
+
+    let extracted = registry.extract(
+        &raw,
+        Some(CalculatedFocalLength { millimetres: 1_632.5, source: "wcs_cd_matrix".to_owned() }),
+    );
+
+    assert_eq!(extracted.profile.profile_id, "nina");
+    assert_eq!(extracted.profile.version, 1);
+
+    let camera = extracted.field(CanonicalField::Camera).unwrap();
+    assert_eq!(camera.state, EvidenceState::Known);
+    assert_eq!(camera.source_field.as_deref(), Some("CAMERA"));
+    assert_eq!(camera.normalized_value, Some(text("ZWO ASI2600MM Pro")));
+
+    let telescope = extracted.field(CanonicalField::Telescope).unwrap();
+    assert_eq!(telescope.source_field.as_deref(), Some("TELESCOP"));
+    assert_eq!(telescope.normalized_value, Some(text("Celestron C925")));
+
+    assert_eq!(
+        extracted.field(CanonicalField::BinningX).unwrap().normalized_value,
+        Some(MetadataValue::Unsigned(1))
+    );
+    assert_eq!(
+        extracted.field(CanonicalField::BinningY).unwrap().normalized_value,
+        Some(MetadataValue::Unsigned(2))
+    );
+
+    let reported = extracted.field(CanonicalField::FocalLengthReported).unwrap();
+    assert_eq!(reported.normalized_value, Some(MetadataValue::Decimal(1_645.0)));
+    assert_eq!(reported.confidence, EvidenceConfidence::Reported);
+
+    let calculated = extracted.field(CanonicalField::FocalLengthCalculated).unwrap();
+    assert_eq!(calculated.normalized_value, Some(MetadataValue::Decimal(1_632.5)));
+    assert_eq!(calculated.confidence, EvidenceConfidence::Calculated);
+    assert_eq!(calculated.source_field.as_deref(), Some("wcs_cd_matrix"));
+}
+
+#[test]
+fn dwarf_prefers_instrume_and_keeps_missing_values_explicit() {
+    let registry = CaptureProfileRegistry::embedded().unwrap();
+    let raw = RawMetadata::from_pairs([
+        ("ORIGIN", "DWARFLAB"),
+        ("INSTRUME", "DWARF III"),
+        ("CAMERA", "TELE"),
+        ("TELESCOP", "DWARF 3"),
+        ("XBINNING", "1"),
+        ("YBINNING", "1"),
+    ]);
+
+    let extracted = registry.extract(&raw, None);
+
+    assert_eq!(extracted.profile.profile_id, "dwarf");
+    let camera = extracted.field(CanonicalField::Camera).unwrap();
+    assert_eq!(camera.source_field.as_deref(), Some("INSTRUME"));
+    assert_eq!(camera.raw_value.as_deref(), Some("DWARF III"));
+    assert_eq!(camera.normalized_value, Some(text("DWARF 3")));
+
+    for field in [CanonicalField::Filter, CanonicalField::Offset, CanonicalField::ReadoutMode] {
+        let evidence = extracted.field(field).unwrap();
+        assert_eq!(evidence.state, EvidenceState::Absent);
+        assert!(evidence.source_field.is_none());
+        assert!(evidence.raw_value.is_none());
+        assert!(evidence.normalized_value.is_none());
+    }
+}
+
+#[test]
+fn binning_axes_are_not_inferred_from_each_other_or_raster() {
+    let registry = CaptureProfileRegistry::embedded().unwrap();
+    let raw = RawMetadata::from_pairs([
+        ("INSTRUME", "Unknown camera"),
+        ("XBINNING", "2"),
+        ("NAXIS1", "3000"),
+        ("NAXIS2", "2000"),
+    ]);
+
+    let extracted = registry.extract(&raw, None);
+
+    assert_eq!(extracted.profile.profile_id, "generic");
+    assert_eq!(
+        extracted.field(CanonicalField::BinningX).unwrap().normalized_value,
+        Some(MetadataValue::Unsigned(2))
+    );
+    assert_eq!(extracted.field(CanonicalField::BinningY).unwrap().state, EvidenceState::Absent);
+}
+
+#[test]
+fn xisf_native_focal_length_is_scaled_without_overwriting_calculated_evidence() {
+    let registry = CaptureProfileRegistry::embedded().unwrap();
+    let raw = RawMetadata::from_pairs([
+        ("Instrument:Camera:Name", "QHY268M"),
+        ("Instrument:Telescope:Name", "APO 120"),
+        ("Instrument:Telescope:FocalLength", "0.835784"),
+    ]);
+
+    let extracted = registry.extract(
+        &raw,
+        Some(CalculatedFocalLength {
+            millimetres: 821.25,
+            source: "xisf_wcs_transform".to_owned(),
+        }),
+    );
+
+    assert_eq!(
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value,
+        Some(text("QHY268M"))
+    );
+    assert_eq!(
+        extracted.field(CanonicalField::Telescope).unwrap().normalized_value,
+        Some(text("APO 120"))
+    );
+    assert_eq!(
+        extracted.field(CanonicalField::FocalLengthReported).unwrap().normalized_value,
+        Some(MetadataValue::Decimal(835.784))
+    );
+    assert_eq!(
+        extracted.field(CanonicalField::FocalLengthCalculated).unwrap().normalized_value,
+        Some(MetadataValue::Decimal(821.25))
+    );
+}
+
+#[test]
+fn explicit_priority_selects_one_matching_profile_deterministically() {
+    let registry = CaptureProfileRegistry::from_toml(
+        r#"
+format_version = 1
+fallback_profile = "generic"
+
+[[profiles]]
+id = "lower"
+version = 1
+priority = 10
+match_any = [{ field = "MAKER", equals = "shared" }]
+
+[profiles.fields.camera]
+confidence = "reported"
+sources = [{ field = "LOWER_CAMERA", parser = "text" }]
+
+[[profiles]]
+id = "higher"
+version = 2
+priority = 20
+match_any = [{ field = "MAKER", equals = "shared" }]
+
+[profiles.fields.camera]
+confidence = "reported"
+sources = [{ field = "HIGHER_CAMERA", parser = "text" }]
+
+[[profiles]]
+id = "generic"
+version = 1
+priority = 0
+"#,
+    )
+    .unwrap();
+    let raw = RawMetadata::from_pairs([
+        ("MAKER", "shared"),
+        ("LOWER_CAMERA", "lower"),
+        ("HIGHER_CAMERA", "higher"),
+    ]);
+
+    let extracted = registry.extract(&raw, None);
+
+    assert_eq!(extracted.profile.profile_id, "higher");
+    assert_eq!(extracted.profile.version, 2);
+    assert_eq!(
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value,
+        Some(text("higher"))
+    );
+}
+
+#[test]
+fn invalid_present_value_is_not_collapsed_into_absence() {
+    let registry = CaptureProfileRegistry::embedded().unwrap();
+    let raw = RawMetadata::from_pairs([("OFFSET", "not-an-integer")]);
+
+    let extracted = registry.extract(&raw, None);
+    let offset = extracted.field(CanonicalField::Offset).unwrap();
+
+    assert_eq!(offset.state, EvidenceState::Invalid);
+    assert_eq!(offset.source_field.as_deref(), Some("OFFSET"));
+    assert_eq!(offset.raw_value.as_deref(), Some("not-an-integer"));
+    assert!(offset.normalized_value.is_none());
+}
+
+#[test]
+fn source_vocabulary_is_supplied_by_toml_not_rust_branches() {
+    let registry = CaptureProfileRegistry::from_toml(
+        r#"
+format_version = 1
+fallback_profile = "vendor"
+
+[[profiles]]
+id = "vendor"
+version = 7
+priority = 1
+
+[profiles.fields.camera]
+confidence = "confirmed"
+sources = [{ field = "VENDOR_CAMERA", parser = "text" }]
+"#,
+    )
+    .unwrap();
+    let raw = RawMetadata::from_pairs([("VENDOR_CAMERA", "Configured Camera")]);
+
+    let extracted = registry.extract(&raw, None);
+
+    assert_eq!(extracted.profile.profile_id, "vendor");
+    assert_eq!(extracted.profile.version, 7);
+    assert_eq!(
+        extracted.field(CanonicalField::Camera).unwrap().normalized_value,
+        Some(text("Configured Camera"))
+    );
+}


### PR DESCRIPTION
## Summary

- Add NINA and Dwarf mappings for camera, telescope, filter, binning, and optical metadata.
- Preserve missing and invalid filter, offset, and readout values as evidence instead of inferred defaults.
- Keep horizontal and vertical binning independent.
- Keep reported and calculated focal lengths independent.

## Test plan

- `cargo fmt --package metadata_core -- --check`
- `cargo clippy -p metadata_core -p metadata_fits -p metadata_xisf --all-targets --all-features --offline -- -D warnings`
- `cargo nextest run -p metadata_core -p metadata_fits -p metadata_xisf --offline` (81 passed)
