### PR TITLE
fix: verify target column pinning after planner data loads

### DIFF
--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -780,6 +780,11 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
     // render, so the table keeps full width and barely overflows at all.
     app.goto_route(&format!("/targets?selected={target_id}")).await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    app.find_waiting(
+        By::Css(".pv-targets-table__scroll"),
+        "the loaded Targets table scroll container",
+    )
+    .await?;
 
     let before = measure_pinned_columns(&app).await?;
     let overflow = px(&before, "scrollWidth")? - px(&before, "clientWidth")?;


### PR DESCRIPTION
## Summary

- Wait for planner data to finish loading before checking pinned target columns in Windows desktop validation.
- Prevent slow Windows loads from failing validation before the Targets table renders.

## Test plan

- `cargo fmt --all --check`
- `cargo test -p e2e_tests --test targets_journeys --no-run`
- `pnpm --filter @astro-plan/desktop test src/features/targets/TargetsTable.test.tsx src/features/targets/TargetsPage.test.tsx` (64 tests)
- `pnpm --filter @astro-plan/desktop typecheck`
- `VITE_E2E=1 pnpm --filter @astro-plan/desktop build`
