### PR TITLE
feat: support mixed imaging sessions across review workflows

### DIFF
--- a/crates/contracts/core/src/sessions.rs
+++ b/crates/contracts/core/src/sessions.rs
@@ -22,6 +22,8 @@ pub use crate::provenance::ProvenanceOrigin;
 
 use crate::calibration::CalibrationKind;
 
+pub mod heterogeneity;
+
 /// Confidence level for inferred or reviewed metadata.
 #[derive(
     Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Deserialize, Type,

--- a/crates/contracts/core/src/sessions/heterogeneity/calibration.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/calibration.rs
@@ -539,13 +539,9 @@ pub enum CalibrationCommand {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(
-    tag = "event",
-    content = "payload",
-    rename_all = "snake_case",
-    rename_all_fields = "camelCase"
-)]
+#[serde(tag = "event", rename_all_fields = "camelCase")]
 pub enum CalibrationEvent {
+    #[serde(rename = "calibration.handoff_created")]
     HandoffCreated {
         project_id: CanonicalId,
         handoff_id: CanonicalId,
@@ -554,6 +550,7 @@ pub enum CalibrationEvent {
         unselected_requirement_ids: BoundedList<CanonicalId, 100>,
         warning_codes: BoundedList<SafeText, 100>,
     },
+    #[serde(rename = "calibration.handoff_reviewed_selection_added")]
     HandoffReviewedSelectionAdded {
         project_id: CanonicalId,
         handoff_id: CanonicalId,

--- a/crates/contracts/core/src/sessions/heterogeneity/calibration.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/calibration.rs
@@ -462,13 +462,19 @@ pub struct HandoffOperationQueryRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum CalibrationQuery {
+    #[serde(rename = "calibration.candidate.list")]
     CandidateList(Box<CandidateListRequest>),
+    #[serde(rename = "calibration.handoff.query")]
     Handoff(HandoffQueryRequest),
+    #[serde(rename = "calibration.handoff.requirement.list")]
     HandoffRequirementList(SnapshotPageRequest),
+    #[serde(rename = "calibration.handoff.selection.list")]
     HandoffSelectionList(SelectionListRequest),
+    #[serde(rename = "calibration.handoff.frame.list")]
     HandoffFrameList(HandoffFrameListRequest),
+    #[serde(rename = "calibration.handoff.operation.query")]
     HandoffOperation(HandoffOperationQueryRequest),
 }
 
@@ -520,11 +526,15 @@ pub struct OpenFrameResponse {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum CalibrationCommand {
+    #[serde(rename = "calibration.handoff.create")]
     HandoffCreate(HandoffCreateRequest),
+    #[serde(rename = "calibration.handoff.reviewed_add")]
     HandoffReviewedAdd(HandoffReviewedAddRequest),
+    #[serde(rename = "calibration.handoff.cancel")]
     HandoffCancel(HandoffCancelRequest),
+    #[serde(rename = "calibration.handoff.open_frame")]
     HandoffOpenFrame(OpenFrameRequest),
 }
 

--- a/crates/contracts/core/src/sessions/heterogeneity/calibration.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/calibration.rs
@@ -1,0 +1,558 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Calibration candidate and external-handoff contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::shared::{
+    BoundedList, CanonicalId, CanonicalRelativePath, Digest, FiniteDecimal, KeysetListOperation,
+    LocalDate, MutationContext, NonBlankSafeText, PageRequest, Rfc3339Timestamp, SafeText,
+    StableIdentity,
+};
+
+pub const MAX_HANDOFF_SOURCE_BYTES: u64 = 17_592_186_044_416;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationKind {
+    Dark,
+    Bias,
+    Flat,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "state", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum FilterIdentity {
+    Known { normalized_captured_label_id: CanonicalId },
+    Absent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationRequirement {
+    pub requirement_id: CanonicalId,
+    pub kind: CalibrationKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optical_profile_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub filter_identity: Option<FilterIdentity>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_light_session_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_observing_night: Option<LocalDate>,
+    pub recipe_id: CanonicalId,
+    pub recipe_revision_id: CanonicalId,
+    pub required_recipe_evidence_ref: SafeText,
+    pub required_recipe_evidence_complete: bool,
+    pub missing_required_fields: BoundedList<SafeText, 100>,
+}
+
+impl CalibrationRequirement {
+    #[must_use]
+    pub fn kind_fields_valid(&self) -> bool {
+        match self.kind {
+            CalibrationKind::Dark | CalibrationKind::Bias => {
+                self.camera_id.is_some()
+                    && self.optical_profile_id.is_none()
+                    && self.filter_identity.is_none()
+                    && self.target_light_session_id.is_none()
+                    && self.target_observing_night.is_none()
+            }
+            CalibrationKind::Flat => {
+                self.camera_id.is_none()
+                    && self.optical_profile_id.is_some()
+                    && self.filter_identity.is_some()
+                    && self.target_light_session_id.is_some()
+                    && self.target_observing_night.is_some()
+            }
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RecipeCompatibility {
+    Compatible,
+    Incompatible,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TemperatureMode {
+    Regulated,
+    Unregulated,
+    Unknown,
+    NotApplicable,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceState {
+    Fresh,
+    Yellow,
+    Red,
+    Unknown,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "basis", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum CalibrationAgeEvidence {
+    ElapsedDays {
+        state: EvidenceState,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        age_days: Option<u32>,
+        fresh_through_days: u32,
+        red_after_days: u32,
+        settings_revision: u64,
+    },
+    ObservingNightDistance {
+        state: EvidenceState,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        age_nights: Option<u32>,
+        fresh_through_nights: u32,
+        red_after_nights: u32,
+        settings_revision: u64,
+    },
+}
+
+impl CalibrationAgeEvidence {
+    #[must_use]
+    pub const fn state(&self) -> EvidenceState {
+        match self {
+            Self::ElapsedDays { state, .. } | Self::ObservingNightDistance { state, .. } => *state,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MeasurementState {
+    Normal,
+    Yellow,
+    Red,
+    Unknown,
+    NotApplicable,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ThermalEvidence {
+    pub state: MeasurementState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub valid_reading_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum_absolute_deviation_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub median_absolute_deviation_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub maximum_absolute_deviation_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub percentile95_absolute_deviation_deg: Option<FiniteDecimal>,
+    pub missing_reading_count: u32,
+    pub invalid_reading_count: u32,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OrientationEvidence {
+    pub state: MeasurementState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub minimum_circular_delta_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub normal_through_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub red_above_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub settings_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SourceAvailability {
+    pub indexed_frame_count: u32,
+    pub available_readable_indexed_frame_count: u32,
+    pub checked_at: Rfc3339Timestamp,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomaticEligibility {
+    Eligible,
+    ReviewRequired,
+    Blocked,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationCandidateEvidence {
+    pub evidence_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub requirement_id: CanonicalId,
+    pub recipe_compatibility: RecipeCompatibility,
+    pub recipe_evidence_ref: SafeText,
+    pub recipe_evidence_complete: bool,
+    pub missing_recipe_fields: BoundedList<SafeText, 100>,
+    pub temperature_mode: TemperatureMode,
+    pub age: CalibrationAgeEvidence,
+    pub thermal: ThermalEvidence,
+    pub orientation: OrientationEvidence,
+    pub source_availability: SourceAvailability,
+    pub sufficient: bool,
+    pub automatic_eligibility: AutomaticEligibility,
+    pub warning_codes: BoundedList<SafeText, 100>,
+    pub basis_fingerprint: Digest,
+}
+
+impl CalibrationCandidateEvidence {
+    #[must_use]
+    pub fn derives_blocked_state(&self) -> bool {
+        self.recipe_compatibility == RecipeCompatibility::Unknown
+            || !self.recipe_evidence_complete
+            || self.age.state() == EvidenceState::Unknown
+            || self.temperature_mode == TemperatureMode::Unknown
+            || !self.sufficient
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SelectionSource {
+    Automatic,
+    Reviewed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionReview {
+    pub review_id: CanonicalId,
+    pub reviewed_at: Rfc3339Timestamp,
+    pub decision_reason: NonBlankSafeText,
+    pub acknowledged_warning_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationSelection {
+    pub selection_id: CanonicalId,
+    pub requirement_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub evidence_id: CanonicalId,
+    pub source: SelectionSource,
+    pub selected_at: Rfc3339Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review: Option<SelectionReview>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExternalProcessor {
+    PixinsightWbpp,
+    Siril,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationHandoffSnapshot {
+    pub handoff_id: CanonicalId,
+    pub handoff_head_generation: u64,
+    pub snapshot_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predecessor_snapshot_id: Option<CanonicalId>,
+    pub project_id: CanonicalId,
+    pub external_processor: ExternalProcessor,
+    pub requirement_count: u32,
+    pub selection_count: u32,
+    pub frame_count: u64,
+    pub source_byte_count: u64,
+    pub maximum_source_bytes: u64,
+    pub matching_settings_revision: u64,
+    pub evaluation_at: Rfc3339Timestamp,
+    pub created_at: Rfc3339Timestamp,
+    pub created_by: CanonicalId,
+    pub basis_fingerprint: Digest,
+    pub warning_codes: BoundedList<SafeText, 100>,
+}
+
+impl CalibrationHandoffSnapshot {
+    #[must_use]
+    pub fn source_bytes_within_limit(&self) -> bool {
+        self.maximum_source_bytes == MAX_HANDOFF_SOURCE_BYTES
+            && self.source_byte_count <= MAX_HANDOFF_SOURCE_BYTES
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum HandoffOperationState {
+    Verifying,
+    Cancelling,
+    Cancelled,
+    Applied,
+    Failed,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+pub enum HandoffFailureCode {
+    #[serde(rename = "calibration.source_unavailable")]
+    SourceUnavailable,
+    #[serde(rename = "calibration.source_identity_changed")]
+    SourceIdentityChanged,
+    #[serde(rename = "calibration.source_fingerprint_changed")]
+    SourceFingerprintChanged,
+    #[serde(rename = "calibration.handoff_too_large")]
+    HandoffTooLarge,
+    #[serde(rename = "calibration.cancel_deadline_exceeded")]
+    CancelDeadlineExceeded,
+    #[serde(rename = "calibration.verification_failed")]
+    VerificationFailed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationHandoffOperation {
+    pub operation_id: CanonicalId,
+    pub handoff_id: CanonicalId,
+    pub state: HandoffOperationState,
+    pub verified_frame_count: u64,
+    pub total_frame_count: u64,
+    pub verified_source_bytes: u64,
+    pub total_source_bytes: u64,
+    pub cancel_safe: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub review_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<HandoffFailureCode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_detail: Option<SafeText>,
+    pub updated_at: Rfc3339Timestamp,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "visibility", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum CalibrationHandoffFrame {
+    Authorized {
+        selection_id: CanonicalId,
+        session_id: CanonicalId,
+        session_membership_ordinal: u32,
+        frame_id: CanonicalId,
+        source_state: IndexedReadableState,
+        file_record_id: CanonicalId,
+        source_root_id: CanonicalId,
+        source_relative_path: CanonicalRelativePath,
+        stable_file_identity: StableIdentity,
+        strong_content_fingerprint: Digest,
+        byte_size: u64,
+        no_follow: bool,
+        identity_verified_at: Rfc3339Timestamp,
+    },
+    Redacted {
+        selection_id: CanonicalId,
+        session_id: CanonicalId,
+        session_membership_ordinal: u32,
+        frame_id: CanonicalId,
+        source_state: IndexedReadableState,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IndexedReadableState {
+    IndexedReadable,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationListOperation {
+    Candidate,
+    HandoffRequirement,
+    HandoffSelection,
+    HandoffFrame,
+}
+
+impl CalibrationListOperation {
+    pub const ALL: [Self; 4] =
+        [Self::Candidate, Self::HandoffRequirement, Self::HandoffSelection, Self::HandoffFrame];
+}
+
+impl KeysetListOperation for CalibrationListOperation {
+    fn query_name(&self) -> &'static str {
+        match self {
+            Self::Candidate => "calibration.candidate.list",
+            Self::HandoffRequirement => "calibration.handoff.requirement.list",
+            Self::HandoffSelection => "calibration.handoff.selection.list",
+            Self::HandoffFrame => "calibration.handoff.frame.list",
+        }
+    }
+
+    fn unique_order(&self) -> &'static [&'static str] {
+        match self {
+            Self::Candidate => &[
+                "compatibilityRank ASC",
+                "sufficiencyRank ASC",
+                "observingNight DESC",
+                "createdAt DESC",
+                "sessionId ASC",
+            ],
+            Self::HandoffRequirement => &["requirementId ASC"],
+            Self::HandoffSelection => &["selectedAt ASC", "selectionId ASC"],
+            Self::HandoffFrame => {
+                &["selectionId ASC", "sessionMembershipOrdinal ASC", "frameId ASC"]
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CandidateListRequest {
+    pub requirement: CalibrationRequirement,
+    pub as_of: Rfc3339Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub automatic_eligibility: Option<AutomaticEligibility>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffQueryRequest {
+    pub handoff_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SnapshotPageRequest {
+    pub snapshot_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SelectionListRequest {
+    pub snapshot_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub requirement_id: Option<CanonicalId>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffFrameListRequest {
+    pub snapshot_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selection_id: Option<CanonicalId>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffOperationQueryRequest {
+    pub operation_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum CalibrationQuery {
+    CandidateList(Box<CandidateListRequest>),
+    Handoff(HandoffQueryRequest),
+    HandoffRequirementList(SnapshotPageRequest),
+    HandoffSelectionList(SelectionListRequest),
+    HandoffFrameList(HandoffFrameListRequest),
+    HandoffOperation(HandoffOperationQueryRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffCreateRequest {
+    pub project_id: CanonicalId,
+    pub external_processor: ExternalProcessor,
+    pub requirements: BoundedList<CalibrationRequirement, 100>,
+    pub expected_project_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffReviewedAddRequest {
+    pub handoff_id: CanonicalId,
+    pub snapshot_id: CanonicalId,
+    pub expected_handoff_head_generation: u64,
+    pub session_id: CanonicalId,
+    pub requirement_id: CanonicalId,
+    pub expected_snapshot_basis_fingerprint: Digest,
+    pub evidence_id: CanonicalId,
+    pub decision_reason: NonBlankSafeText,
+    pub acknowledged_warning_codes: BoundedList<SafeText, 100>,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct HandoffCancelRequest {
+    pub operation_id: CanonicalId,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenFrameRequest {
+    pub snapshot_id: CanonicalId,
+    pub frame_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OpenFrameResponse {
+    pub local_stream_handle: SafeText,
+    pub byte_size: u64,
+    pub strong_content_fingerprint: Digest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum CalibrationCommand {
+    HandoffCreate(HandoffCreateRequest),
+    HandoffReviewedAdd(HandoffReviewedAddRequest),
+    HandoffCancel(HandoffCancelRequest),
+    HandoffOpenFrame(OpenFrameRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "event",
+    content = "payload",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum CalibrationEvent {
+    HandoffCreated {
+        project_id: CanonicalId,
+        handoff_id: CanonicalId,
+        snapshot_id: CanonicalId,
+        automatic_selection_ids: BoundedList<CanonicalId, 100>,
+        unselected_requirement_ids: BoundedList<CanonicalId, 100>,
+        warning_codes: BoundedList<SafeText, 100>,
+    },
+    HandoffReviewedSelectionAdded {
+        project_id: CanonicalId,
+        handoff_id: CanonicalId,
+        predecessor_snapshot_id: CanonicalId,
+        snapshot_id: CanonicalId,
+        requirement_id: CanonicalId,
+        selection_id: CanonicalId,
+        session_id: CanonicalId,
+        review_id: CanonicalId,
+        warning_codes: BoundedList<SafeText, 100>,
+    },
+}

--- a/crates/contracts/core/src/sessions/heterogeneity/inbox.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/inbox.rs
@@ -446,13 +446,9 @@ pub enum InboxCommand {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(
-    tag = "event",
-    content = "payload",
-    rename_all = "snake_case",
-    rename_all_fields = "camelCase"
-)]
+#[serde(tag = "event", rename_all_fields = "camelCase")]
 pub enum InboxEvent {
+    #[serde(rename = "inbox.acquisition_site_resolved")]
     AcquisitionSiteResolved {
         plan_id: CanonicalId,
         resolution_id: CanonicalId,
@@ -464,11 +460,13 @@ pub enum InboxEvent {
         decision: SiteResolutionDecision,
         derived_observing_night: LocalDate,
     },
+    #[serde(rename = "inbox.materialization_approved")]
     MaterializationApproved {
         plan_id: CanonicalId,
         plan_revision: u64,
         approved_plan_digest: Digest,
     },
+    #[serde(rename = "session.materialization_progressed")]
     MaterializationProgressed {
         operation_id: CanonicalId,
         processed_session_count: u64,
@@ -476,10 +474,9 @@ pub enum InboxEvent {
         processed_frame_count: u64,
         total_frame_count: u64,
     },
-    MaterializationCancelled {
-        operation_id: CanonicalId,
-        source_plan_id: CanonicalId,
-    },
+    #[serde(rename = "session.materialization_cancelled")]
+    MaterializationCancelled { operation_id: CanonicalId, source_plan_id: CanonicalId },
+    #[serde(rename = "session.materialization_applied")]
     MaterializationApplied {
         operation_id: CanonicalId,
         kind: MaterializationKind,
@@ -491,13 +488,13 @@ pub enum InboxEvent {
         singleton_panel_group_count: u64,
         blocked_frame_count: u64,
     },
+    #[serde(rename = "session.materialization_failed")]
     MaterializationFailed {
         operation_id: CanonicalId,
         kind: MaterializationKind,
         source_plan_id: CanonicalId,
         failure_code: SafeText,
     },
-    MaterializationDiscarded {
-        plan_id: CanonicalId,
-    },
+    #[serde(rename = "inbox.materialization_discarded")]
+    MaterializationDiscarded { plan_id: CanonicalId },
 }

--- a/crates/contracts/core/src/sessions/heterogeneity/inbox.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/inbox.rs
@@ -323,18 +323,29 @@ pub struct OperationResultFrameListRequest {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum InboxQuery {
+    #[serde(rename = "inbox.materialization_plan.query")]
     MaterializationPlan(InboxPlanQueryRequest),
+    #[serde(rename = "inbox.acquisition_site_resolution.query")]
     AcquisitionSiteResolution(SiteResolutionQueryRequest),
+    #[serde(rename = "inbox.acquisition_site_candidate.list")]
     AcquisitionSiteCandidateList(SiteCandidateListRequest),
+    #[serde(rename = "inbox.materialization_plan.proposed_session.list")]
     ProposedSessionList(PlanSnapshotListRequest),
+    #[serde(rename = "inbox.materialization_plan.proposed_frame.list")]
     ProposedFrameList(ProposedFrameListRequest),
+    #[serde(rename = "inbox.materialization_plan.blocked_frame.list")]
     PlanBlockedFrameList(PlanSnapshotListRequest),
+    #[serde(rename = "session.materialization.query")]
     Materialization(OperationQueryRequest),
+    #[serde(rename = "session.materialization.result_session.list")]
     ResultSessionList(OperationSnapshotListRequest),
+    #[serde(rename = "session.materialization.result_frame.list")]
     ResultFrameList(OperationResultFrameListRequest),
+    #[serde(rename = "session.materialization.blocked_frame.list")]
     ResultBlockedFrameList(OperationSnapshotListRequest),
+    #[serde(rename = "session.materialization.progress.query")]
     Progress(OperationQueryRequest),
 }
 
@@ -420,12 +431,17 @@ pub struct MaterializationCancelRequest {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum InboxCommand {
+    #[serde(rename = "inbox.acquisition_site_resolution.decide")]
     AcquisitionSiteResolutionDecide(SiteResolutionDecideRequest),
+    #[serde(rename = "inbox.materialization.approve")]
     MaterializationApprove(InboxApproveRequest),
+    #[serde(rename = "inbox.materialization.apply")]
     MaterializationApply(InboxApplyRequest),
+    #[serde(rename = "inbox.materialization.discard")]
     MaterializationDiscard(InboxDiscardRequest),
+    #[serde(rename = "session.materialization.cancel")]
     MaterializationCancel(MaterializationCancelRequest),
 }
 

--- a/crates/contracts/core/src/sessions/heterogeneity/inbox.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/inbox.rs
@@ -1,0 +1,487 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Inbox planning and session-materialization contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::shared::{
+    BoundedList, CanonicalId, Digest, KeysetListOperation, LocalDate, MaterializationKind,
+    MutationContext, NonBlankSafeText, PageRequest, Rfc3339Timestamp, SafeText, SupportedFrameKind,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InboxPlanState {
+    Open,
+    Approved,
+    Applied,
+    Discarded,
+    Stale,
+    Refused,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxMaterializationPlan {
+    pub plan_id: CanonicalId,
+    pub plan_revision: u64,
+    pub state: InboxPlanState,
+    pub canonical_plan_digest: Digest,
+    pub input_evidence_revision: u64,
+    pub configuration_revision_id: CanonicalId,
+    pub acquisition_site_resolution_count: u64,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub candidate_frame_count: u64,
+    pub proposed_session_count: u64,
+    pub blocked_frame_count: u64,
+    pub warning_codes: BoundedList<SafeText, 100>,
+    pub created_at: Rfc3339Timestamp,
+    pub created_by: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approved_at: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approved_by: Option<CanonicalId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SiteResolutionState {
+    NeedsReview,
+    Resolved,
+    Conflict,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SiteResolutionDecision {
+    Unresolved,
+    AcceptedCandidate,
+    Corrected,
+    ReviewedLocalFallback,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TimestampDecision {
+    CanonicalInstantConfirmed,
+    ReviewedLocalFallback,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AcquisitionSiteResolution {
+    pub resolution_id: CanonicalId,
+    pub revision: u64,
+    pub state: SiteResolutionState,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_site_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_timezone: Option<SafeText>,
+    pub decision: SiteResolutionDecision,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timestamp_decision: Option<TimestampDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_exposure_instant: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_exposure_timestamp: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub derived_observing_night: Option<LocalDate>,
+    pub conflict_codes: BoundedList<SafeText, 100>,
+    pub evidence_refs: BoundedList<SafeText, 100>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decided_at: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decided_by: Option<CanonicalId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CandidateConfidence {
+    Exact,
+    Review,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AcquisitionSiteCandidate {
+    pub site_id: CanonicalId,
+    pub label: SafeText,
+    pub timezone: SafeText,
+    pub confidence: CandidateConfidence,
+    pub basis_codes: BoundedList<SafeText, 100>,
+    pub evidence_refs: BoundedList<SafeText, 100>,
+    pub derived_observing_night: LocalDate,
+    pub conflict_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MaterializationState {
+    Ready,
+    Applying,
+    Cancelling,
+    Cancelled,
+    Applied,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMaterializationOperation {
+    pub operation_id: CanonicalId,
+    pub kind: MaterializationKind,
+    pub state: MaterializationState,
+    pub source_plan_id: CanonicalId,
+    pub approved_plan_digest: Digest,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub result_snapshot_id: Option<CanonicalId>,
+    pub session_count: u64,
+    pub frame_membership_count: u64,
+    pub singleton_panel_group_count: u64,
+    pub blocked_frame_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub started_at: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub finished_at: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub failure_code: Option<SafeText>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterializationResultSession {
+    pub ordinal: u64,
+    pub session_id: CanonicalId,
+    pub frame_kind: SupportedFrameKind,
+    pub frame_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub singleton_panel_group_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub singleton_panel_revision_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxProposedSession {
+    pub ordinal: u64,
+    pub proposed_session_key: SafeText,
+    pub frame_kind: SupportedFrameKind,
+    pub proposed_identity_digest: Digest,
+    pub proposed_frame_count: u64,
+    pub acquisition_site_resolution_id: CanonicalId,
+    pub acquisition_site_resolution_revision: u64,
+    pub warning_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterializationFrameItem {
+    pub ordinal: u64,
+    pub frame_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct BlockedFrameItem {
+    pub ordinal: u64,
+    pub frame_id: CanonicalId,
+    pub reason_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionMaterializationProgress {
+    pub operation_id: CanonicalId,
+    pub state: MaterializationState,
+    pub processed_session_count: u64,
+    pub total_session_count: u64,
+    pub processed_frame_count: u64,
+    pub total_frame_count: u64,
+    pub cancel_safe: bool,
+    pub updated_at: Rfc3339Timestamp,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum InboxListOperation {
+    AcquisitionSiteCandidate,
+    ProposedSession,
+    ProposedFrame,
+    PlanBlockedFrame,
+    ResultSession,
+    ResultFrame,
+    ResultBlockedFrame,
+}
+
+impl InboxListOperation {
+    pub const ALL: [Self; 7] = [
+        Self::AcquisitionSiteCandidate,
+        Self::ProposedSession,
+        Self::ProposedFrame,
+        Self::PlanBlockedFrame,
+        Self::ResultSession,
+        Self::ResultFrame,
+        Self::ResultBlockedFrame,
+    ];
+}
+
+impl KeysetListOperation for InboxListOperation {
+    fn query_name(&self) -> &'static str {
+        match self {
+            Self::AcquisitionSiteCandidate => "inbox.acquisition_site_candidate.list",
+            Self::ProposedSession => "inbox.materialization_plan.proposed_session.list",
+            Self::ProposedFrame => "inbox.materialization_plan.proposed_frame.list",
+            Self::PlanBlockedFrame => "inbox.materialization_plan.blocked_frame.list",
+            Self::ResultSession => "session.materialization.result_session.list",
+            Self::ResultFrame => "session.materialization.result_frame.list",
+            Self::ResultBlockedFrame => "session.materialization.blocked_frame.list",
+        }
+    }
+
+    fn unique_order(&self) -> &'static [&'static str] {
+        match self {
+            Self::AcquisitionSiteCandidate => {
+                &["confidenceRank DESC", "normalizedLabel ASC", "siteId ASC"]
+            }
+            Self::ProposedSession => &["ordinal ASC", "proposedSessionKey ASC"],
+            Self::ProposedFrame
+            | Self::PlanBlockedFrame
+            | Self::ResultFrame
+            | Self::ResultBlockedFrame => &["ordinal ASC", "frameId ASC"],
+            Self::ResultSession => &["ordinal ASC", "sessionId ASC"],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxPlanQueryRequest {
+    pub plan_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub plan_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SiteResolutionQueryRequest {
+    pub plan_id: CanonicalId,
+    pub resolution_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SiteCandidateListRequest {
+    pub plan_id: CanonicalId,
+    pub resolution_id: CanonicalId,
+    pub resolution_revision: u64,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanSnapshotListRequest {
+    pub plan_id: CanonicalId,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposedFrameListRequest {
+    pub plan_id: CanonicalId,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub proposed_session_key: SafeText,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationQueryRequest {
+    pub operation_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationSnapshotListRequest {
+    pub operation_id: CanonicalId,
+    pub result_snapshot_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OperationResultFrameListRequest {
+    pub operation_id: CanonicalId,
+    pub result_snapshot_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum InboxQuery {
+    MaterializationPlan(InboxPlanQueryRequest),
+    AcquisitionSiteResolution(SiteResolutionQueryRequest),
+    AcquisitionSiteCandidateList(SiteCandidateListRequest),
+    ProposedSessionList(PlanSnapshotListRequest),
+    ProposedFrameList(ProposedFrameListRequest),
+    PlanBlockedFrameList(PlanSnapshotListRequest),
+    Materialization(OperationQueryRequest),
+    ResultSessionList(OperationSnapshotListRequest),
+    ResultFrameList(OperationResultFrameListRequest),
+    ResultBlockedFrameList(OperationSnapshotListRequest),
+    Progress(OperationQueryRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SiteResolutionDecisionInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_site_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub corrected_timezone: Option<SafeText>,
+    pub timestamp_decision: TimestampDecision,
+    pub evidence_refs: BoundedList<SafeText, 100>,
+    pub note: NonBlankSafeText,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SiteResolutionDecideRequest {
+    pub plan_id: CanonicalId,
+    pub resolution_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub expected_resolution_revision: u64,
+    pub decision: SiteResolutionDecisionInput,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SiteResolutionDecideResponse {
+    pub plan: InboxMaterializationPlan,
+    pub resolution: AcquisitionSiteResolution,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxApproveRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub expected_input_evidence_revision: u64,
+    pub expected_site_resolution_revisions_digest: Digest,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxApproveResponse {
+    pub plan_id: CanonicalId,
+    pub plan_revision: u64,
+    pub approved_plan_digest: Digest,
+    pub approved_at: Rfc3339Timestamp,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxApplyRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxApplyResponse {
+    pub operation: SessionMaterializationOperation,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct InboxDiscardRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MaterializationCancelRequest {
+    pub operation_id: CanonicalId,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum InboxCommand {
+    AcquisitionSiteResolutionDecide(SiteResolutionDecideRequest),
+    MaterializationApprove(InboxApproveRequest),
+    MaterializationApply(InboxApplyRequest),
+    MaterializationDiscard(InboxDiscardRequest),
+    MaterializationCancel(MaterializationCancelRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "event",
+    content = "payload",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum InboxEvent {
+    AcquisitionSiteResolved {
+        plan_id: CanonicalId,
+        resolution_id: CanonicalId,
+        revision: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        selected_site_id: Option<CanonicalId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        selected_timezone: Option<SafeText>,
+        decision: SiteResolutionDecision,
+        derived_observing_night: LocalDate,
+    },
+    MaterializationApproved {
+        plan_id: CanonicalId,
+        plan_revision: u64,
+        approved_plan_digest: Digest,
+    },
+    MaterializationProgressed {
+        operation_id: CanonicalId,
+        processed_session_count: u64,
+        total_session_count: u64,
+        processed_frame_count: u64,
+        total_frame_count: u64,
+    },
+    MaterializationCancelled {
+        operation_id: CanonicalId,
+        source_plan_id: CanonicalId,
+    },
+    MaterializationApplied {
+        operation_id: CanonicalId,
+        kind: MaterializationKind,
+        source_plan_id: CanonicalId,
+        approved_plan_digest: Digest,
+        result_snapshot_id: CanonicalId,
+        session_count: u64,
+        frame_membership_count: u64,
+        singleton_panel_group_count: u64,
+        blocked_frame_count: u64,
+    },
+    MaterializationFailed {
+        operation_id: CanonicalId,
+        kind: MaterializationKind,
+        source_plan_id: CanonicalId,
+        failure_code: SafeText,
+    },
+    MaterializationDiscarded {
+        plan_id: CanonicalId,
+    },
+}

--- a/crates/contracts/core/src/sessions/heterogeneity/metadata.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/metadata.rs
@@ -463,13 +463,15 @@ impl KeysetListOperation for MetadataListOperation {
             }
             Self::PanelConsequenceSession => &["ordinal ASC", "proposedSessionId ASC"],
             Self::PanelConsequenceRetirement => &["ordinal ASC", "predecessorPanelGroupId ASC"],
-            Self::PanelConsequenceLineage | Self::ApplyPanelLineage => {
-                &["ordinal ASC", "predecessorPanelGroupId ASC", "successorPanelGroupId ASC"]
-            }
+            Self::PanelConsequenceLineage | Self::ApplyPanelLineage => &[
+                "ordinal ASC",
+                "lineage.predecessorPanelGroupId ASC",
+                "lineage.successorPanelGroupId ASC",
+            ],
             Self::StaleMosaicEdge | Self::ApplyInvalidatedEdge => &["ordinal ASC", "edgeId ASC"],
             Self::ProjectConsequence => &["projectId ASC", "unchangedPinnedSessionId ASC"],
             Self::ApplyReplacementSession => &["ordinal ASC", "replacementSessionId ASC"],
-            Self::ApplyPanelRevision => &["ordinal ASC", "revisionId ASC"],
+            Self::ApplyPanelRevision => &["ordinal ASC", "revisionRef.revisionId ASC"],
             Self::ApplyProjectProposal => &["ordinal ASC", "projectReplacementProposalId ASC"],
         }
     }
@@ -477,10 +479,18 @@ impl KeysetListOperation for MetadataListOperation {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct SessionRevisionQueryRequest {
+pub struct MetadataEvidenceQueryRequest {
     pub session_id: CanonicalId,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub revision: Option<u64>,
+    pub evidence_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EquipmentResolutionQueryRequest {
+    pub session_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolution_revision: Option<u64>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
@@ -491,42 +501,95 @@ pub struct ReclassificationQueryRequest {
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct ReclassificationSnapshotListRequest {
+pub struct ReclassificationResultPageRequest {
     pub plan_id: CanonicalId,
-    pub snapshot_id: CanonicalId,
+    pub plan_result_snapshot_id: CanonicalId,
     pub page: PageRequest,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct ReclassificationChildListRequest {
+pub struct ReplacementFrameListRequest {
     pub plan_id: CanonicalId,
-    pub snapshot_id: CanonicalId,
-    pub owner_id: SafeText,
+    pub replacement_key: SafeText,
     pub page: PageRequest,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(rename_all = "camelCase")]
+pub struct PanelConsequenceSessionListRequest {
+    pub plan_id: CanonicalId,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub panel_group_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PanelConsequenceDestinationListRequest {
+    pub plan_id: CanonicalId,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub proposed_destination_panel_group_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectConsequenceReplacementListRequest {
+    pub plan_id: CanonicalId,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub project_id: CanonicalId,
+    pub unchanged_pinned_session_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationApplyResultPageRequest {
+    pub plan_id: CanonicalId,
+    pub apply_result_snapshot_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation")]
 pub enum MetadataQuery {
-    Evidence(SessionRevisionQueryRequest),
-    EquipmentResolution(SessionRevisionQueryRequest),
+    #[serde(rename = "metadata.evidence.query")]
+    Evidence(MetadataEvidenceQueryRequest),
+    #[serde(rename = "equipment.resolution.query")]
+    EquipmentResolution(EquipmentResolutionQueryRequest),
+    #[serde(rename = "metadata.reclassification.query")]
     Reclassification(ReclassificationQueryRequest),
-    ReplacementFrameList(ReclassificationChildListRequest),
-    ReplacementSessionList(ReclassificationSnapshotListRequest),
-    PanelConsequenceList(ReclassificationSnapshotListRequest),
-    PanelConsequenceSessionList(ReclassificationChildListRequest),
-    PanelConsequenceRetirementList(ReclassificationChildListRequest),
-    PanelConsequenceLineageList(ReclassificationChildListRequest),
-    StaleMosaicEdgeList(ReclassificationSnapshotListRequest),
-    ProjectConsequenceList(ReclassificationSnapshotListRequest),
-    ProjectConsequenceReplacementList(ReclassificationChildListRequest),
-    ApplyReplacementSessionList(ReclassificationSnapshotListRequest),
-    ApplyPanelRevisionList(ReclassificationSnapshotListRequest),
-    ApplyInvalidatedEdgeList(ReclassificationSnapshotListRequest),
-    ApplyRetiredPanelGroupList(ReclassificationSnapshotListRequest),
-    ApplyPanelLineageList(ReclassificationSnapshotListRequest),
-    ApplyProjectProposalList(ReclassificationSnapshotListRequest),
+    #[serde(rename = "metadata.reclassification.replacement_frame.list")]
+    ReplacementFrameList(ReplacementFrameListRequest),
+    #[serde(rename = "metadata.reclassification.replacement_session.list")]
+    ReplacementSessionList(ReclassificationResultPageRequest),
+    #[serde(rename = "metadata.reclassification.panel_consequence.list")]
+    PanelConsequenceList(ReclassificationResultPageRequest),
+    #[serde(rename = "metadata.reclassification.panel_consequence_session.list")]
+    PanelConsequenceSessionList(PanelConsequenceSessionListRequest),
+    #[serde(rename = "metadata.reclassification.panel_consequence_retirement.list")]
+    PanelConsequenceRetirementList(PanelConsequenceDestinationListRequest),
+    #[serde(rename = "metadata.reclassification.panel_consequence_lineage.list")]
+    PanelConsequenceLineageList(PanelConsequenceDestinationListRequest),
+    #[serde(rename = "metadata.reclassification.stale_mosaic_edge.list")]
+    StaleMosaicEdgeList(ReclassificationResultPageRequest),
+    #[serde(rename = "metadata.reclassification.project_consequence.list")]
+    ProjectConsequenceList(ReclassificationResultPageRequest),
+    #[serde(rename = "metadata.reclassification.project_consequence_replacement.list")]
+    ProjectConsequenceReplacementList(ProjectConsequenceReplacementListRequest),
+    #[serde(rename = "metadata.reclassification.apply_result.replacement_session.list")]
+    ApplyReplacementSessionList(ReclassificationApplyResultPageRequest),
+    #[serde(rename = "metadata.reclassification.apply_result.panel_revision.list")]
+    ApplyPanelRevisionList(ReclassificationApplyResultPageRequest),
+    #[serde(rename = "metadata.reclassification.apply_result.invalidated_edge.list")]
+    ApplyInvalidatedEdgeList(ReclassificationApplyResultPageRequest),
+    #[serde(rename = "metadata.reclassification.apply_result.retired_panel_group.list")]
+    ApplyRetiredPanelGroupList(ReclassificationApplyResultPageRequest),
+    #[serde(rename = "metadata.reclassification.apply_result.panel_lineage.list")]
+    ApplyPanelLineageList(ReclassificationApplyResultPageRequest),
+    #[serde(rename = "metadata.reclassification.apply_result.project_proposal.list")]
+    ApplyProjectProposalList(ReclassificationApplyResultPageRequest),
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
@@ -595,11 +658,15 @@ pub struct ReclassificationDiscardRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum MetadataCommand {
+    #[serde(rename = "equipment.resolution.decide")]
     EquipmentResolutionDecide(EquipmentResolutionDecideRequest),
+    #[serde(rename = "metadata.reclassification.plan")]
     ReclassificationPlan(ReclassificationPlanRequest),
+    #[serde(rename = "metadata.reclassification.apply")]
     ReclassificationApply(ReclassificationApplyRequest),
+    #[serde(rename = "metadata.reclassification.discard")]
     ReclassificationDiscard(ReclassificationDiscardRequest),
 }
 

--- a/crates/contracts/core/src/sessions/heterogeneity/metadata.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/metadata.rs
@@ -1,0 +1,655 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Metadata, equipment-resolution, and reclassification contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::shared::{
+    BoundedList, CanonicalId, FiniteDecimal, KeysetListOperation, LocalDate, MutationContext,
+    NonBlankSafeText, PageRequest, RevisionRef, Rfc3339Timestamp, SafeText, SupportedFrameKind,
+};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(untagged)]
+pub enum MetadataValue {
+    Boolean(bool),
+    Integer(i64),
+    Decimal(FiniteDecimal),
+    Text(SafeText),
+    Array(BoundedList<MetadataValue, 256>),
+    Object(BoundedList<MetadataProperty, 128>),
+    Null,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataProperty {
+    pub key: SafeText,
+    pub value: MetadataValue,
+}
+
+impl MetadataValue {
+    /// # Errors
+    ///
+    /// Returns an error when the metadata exceeds the contract's depth or object-key limits.
+    pub fn validate_depth_and_keys(&self) -> Result<(), &'static str> {
+        self.validate_at_depth(0)
+    }
+
+    fn validate_at_depth(&self, depth: usize) -> Result<(), &'static str> {
+        if depth > 8 {
+            return Err("metadata_depth_exceeded");
+        }
+        match self {
+            Self::Array(items) => {
+                for item in items {
+                    item.validate_at_depth(depth + 1)?;
+                }
+            }
+            Self::Object(properties) => {
+                let mut keys = std::collections::BTreeSet::new();
+                for property in properties {
+                    if property.key.chars().count() > 128 || !keys.insert(property.key.as_str()) {
+                        return Err("metadata_key_invalid");
+                    }
+                    property.value.validate_at_depth(depth + 1)?;
+                }
+            }
+            Self::Boolean(_) | Self::Integer(_) | Self::Decimal(_) | Self::Text(_) | Self::Null => {
+            }
+        }
+        Ok(())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataFieldState {
+    Known,
+    Absent,
+    Invalid,
+    Contradictory,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceConfidence {
+    Confirmed,
+    Reported,
+    Calculated,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataEvidenceField {
+    pub canonical_field: SafeText,
+    pub source_field: SafeText,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub raw_value: Option<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub normalized_value: Option<MetadataValue>,
+    pub state: MetadataFieldState,
+    pub confidence: EvidenceConfidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ObservingNightState {
+    Confirmed,
+    TimezoneMissing,
+    Contradictory,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataObservingNightEvidence {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub value: Option<LocalDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub timezone: Option<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_instant: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub local_timestamp: Option<Rfc3339Timestamp>,
+    pub state: ObservingNightState,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataEvidence {
+    pub evidence_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub capture_software: Option<SafeText>,
+    pub fields: BoundedList<MetadataEvidenceField, 256>,
+    pub observing_night: MetadataObservingNightEvidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolutionState {
+    Resolved,
+    NeedsReview,
+    Blocked,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ResolutionDecision {
+    Automatic,
+    Accepted,
+    Corrected,
+    Unresolved,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionChoice<T> {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_id: Option<CanonicalId>,
+    pub candidates: BoundedList<T, 100>,
+    pub basis: BoundedList<SafeText, 100>,
+    pub decision: ResolutionDecision,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CameraCandidate {
+    pub camera_id: CanonicalId,
+    pub display_name: SafeText,
+    pub matched_aliases: BoundedList<SafeText, 100>,
+    pub geometry_compatible: bool,
+    pub confidence: super::inbox::CandidateConfidence,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum OpticalProfileClassification {
+    Same,
+    Review,
+    Different,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OpticalProfileCandidate {
+    pub optical_profile_id: CanonicalId,
+    pub display_name: SafeText,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reported_focal_length_mm: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calculated_focal_length_mm: Option<FiniteDecimal>,
+    pub representative_focal_length_mm: FiniteDecimal,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub representative_difference_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reported_calculated_difference_percent: Option<FiniteDecimal>,
+    pub classification: OpticalProfileClassification,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum WarningSeverity {
+    Yellow,
+    Red,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ResolutionWarning {
+    pub code: SafeText,
+    pub severity: WarningSeverity,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<SafeText>,
+    pub evidence_refs: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EquipmentResolution {
+    pub resolution_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub revision: u64,
+    pub state: ResolutionState,
+    pub camera: ResolutionChoice<CameraCandidate>,
+    pub optical_profile: ResolutionChoice<OpticalProfileCandidate>,
+    pub warnings: BoundedList<ResolutionWarning, 100>,
+    pub evidence_revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decided_at: Option<Rfc3339Timestamp>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decided_by: Option<CanonicalId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum NightDerivationKind {
+    AcquisitionTimezone,
+    ReviewedLocalFallback,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionIdentity {
+    pub frame_kind: SupportedFrameKind,
+    pub observing_night: LocalDate,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acquisition_timezone: Option<SafeText>,
+    pub night_derivation: NightDerivationKind,
+    pub night_evidence_refs: BoundedList<SafeText, 100>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optical_profile_id: Option<CanonicalId>,
+    pub filter: MetadataValue,
+    pub exposure_ms: MetadataValue,
+    pub gain: MetadataValue,
+    pub offset: MetadataValue,
+    pub binning_x: MetadataValue,
+    pub binning_y: MetadataValue,
+    pub readout_mode: MetadataValue,
+    pub raster_width: u32,
+    pub raster_height: u32,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ReclassificationPlanState {
+    Open,
+    Applied,
+    Discarded,
+    Stale,
+    Refused,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MetadataCorrection {
+    pub canonical_field: SafeText,
+    pub corrected_value: Option<MetadataValue>,
+    pub evidence_refs: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationPlan {
+    pub plan_id: CanonicalId,
+    pub plan_revision: u64,
+    pub state: ReclassificationPlanState,
+    pub source_session_id: CanonicalId,
+    pub source_session_evidence_revision: u64,
+    pub requested_corrections: BoundedList<MetadataCorrection, 256>,
+    pub plan_result_snapshot_id: CanonicalId,
+    pub replacement_session_count: u64,
+    pub panel_consequence_count: u64,
+    pub predecessor_group_retirement_count: u64,
+    pub panel_lineage_count: u64,
+    pub stale_mosaic_edge_count: u64,
+    pub project_consequence_count: u64,
+    pub warnings: BoundedList<ResolutionWarning, 100>,
+    pub created_at: Rfc3339Timestamp,
+    pub created_by: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationProjectConsequence {
+    pub project_id: CanonicalId,
+    pub unchanged_pinned_session_id: CanonicalId,
+    pub replacement_session_count: u64,
+    pub proposal_required: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_replacement_proposal_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationReplacementSession {
+    pub replacement_key: SafeText,
+    pub frame_count: u64,
+    pub proposed_identity: SessionIdentity,
+    pub proposed_equipment_resolution: EquipmentResolution,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PanelConsequenceAction {
+    SuccessorRevision,
+    NewGroup,
+    ReviewRequired,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationPanelConsequence {
+    pub panel_group_id: CanonicalId,
+    pub source_revision_id: CanonicalId,
+    pub proposed_destination_panel_group_id: CanonicalId,
+    pub proposed_destination_revision_id: CanonicalId,
+    pub proposed_session_count: u64,
+    pub predecessor_group_retirement_count: u64,
+    pub lineage_edge_count: u64,
+    pub action: PanelConsequenceAction,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationPanelLineage {
+    pub predecessor_panel_group_id: CanonicalId,
+    pub successor_panel_group_id: CanonicalId,
+    pub kind: IdentityChangeKind,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum IdentityChangeKind {
+    IdentityChange,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationStaleMosaicEdge {
+    pub mosaic_id: CanonicalId,
+    pub mosaic_revision_id: CanonicalId,
+    pub edge_id: CanonicalId,
+    pub reason_code: SafeText,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationApplyResult {
+    pub apply_result_snapshot_id: CanonicalId,
+    pub replacement_session_count: u64,
+    pub accepted_panel_revision_count: u64,
+    pub retired_predecessor_group_count: u64,
+    pub panel_lineage_count: u64,
+    pub invalidated_mosaic_edge_count: u64,
+    pub project_replacement_proposal_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MetadataListOperation {
+    ReplacementFrame,
+    ReplacementSession,
+    PanelConsequence,
+    PanelConsequenceSession,
+    PanelConsequenceRetirement,
+    PanelConsequenceLineage,
+    StaleMosaicEdge,
+    ProjectConsequence,
+    ProjectConsequenceReplacement,
+    ApplyReplacementSession,
+    ApplyPanelRevision,
+    ApplyInvalidatedEdge,
+    ApplyRetiredPanelGroup,
+    ApplyPanelLineage,
+    ApplyProjectProposal,
+}
+
+impl MetadataListOperation {
+    pub const ALL: [Self; 15] = [
+        Self::ReplacementFrame,
+        Self::ReplacementSession,
+        Self::PanelConsequence,
+        Self::PanelConsequenceSession,
+        Self::PanelConsequenceRetirement,
+        Self::PanelConsequenceLineage,
+        Self::StaleMosaicEdge,
+        Self::ProjectConsequence,
+        Self::ProjectConsequenceReplacement,
+        Self::ApplyReplacementSession,
+        Self::ApplyPanelRevision,
+        Self::ApplyInvalidatedEdge,
+        Self::ApplyRetiredPanelGroup,
+        Self::ApplyPanelLineage,
+        Self::ApplyProjectProposal,
+    ];
+}
+
+impl KeysetListOperation for MetadataListOperation {
+    fn query_name(&self) -> &'static str {
+        match self {
+            Self::ReplacementFrame => "metadata.reclassification.replacement_frame.list",
+            Self::ReplacementSession => "metadata.reclassification.replacement_session.list",
+            Self::PanelConsequence => "metadata.reclassification.panel_consequence.list",
+            Self::PanelConsequenceSession => {
+                "metadata.reclassification.panel_consequence_session.list"
+            }
+            Self::PanelConsequenceRetirement => {
+                "metadata.reclassification.panel_consequence_retirement.list"
+            }
+            Self::PanelConsequenceLineage => {
+                "metadata.reclassification.panel_consequence_lineage.list"
+            }
+            Self::StaleMosaicEdge => "metadata.reclassification.stale_mosaic_edge.list",
+            Self::ProjectConsequence => "metadata.reclassification.project_consequence.list",
+            Self::ProjectConsequenceReplacement => {
+                "metadata.reclassification.project_consequence_replacement.list"
+            }
+            Self::ApplyReplacementSession => {
+                "metadata.reclassification.apply_result.replacement_session.list"
+            }
+            Self::ApplyPanelRevision => {
+                "metadata.reclassification.apply_result.panel_revision.list"
+            }
+            Self::ApplyInvalidatedEdge => {
+                "metadata.reclassification.apply_result.invalidated_edge.list"
+            }
+            Self::ApplyRetiredPanelGroup => {
+                "metadata.reclassification.apply_result.retired_panel_group.list"
+            }
+            Self::ApplyPanelLineage => "metadata.reclassification.apply_result.panel_lineage.list",
+            Self::ApplyProjectProposal => {
+                "metadata.reclassification.apply_result.project_proposal.list"
+            }
+        }
+    }
+
+    fn unique_order(&self) -> &'static [&'static str] {
+        match self {
+            Self::ReplacementFrame => &["ordinal ASC", "frameId ASC"],
+            Self::ReplacementSession | Self::ProjectConsequenceReplacement => {
+                &["ordinal ASC", "replacementKey ASC"]
+            }
+            Self::PanelConsequence | Self::ApplyRetiredPanelGroup => {
+                &["ordinal ASC", "panelGroupId ASC"]
+            }
+            Self::PanelConsequenceSession => &["ordinal ASC", "proposedSessionId ASC"],
+            Self::PanelConsequenceRetirement => &["ordinal ASC", "predecessorPanelGroupId ASC"],
+            Self::PanelConsequenceLineage | Self::ApplyPanelLineage => {
+                &["ordinal ASC", "predecessorPanelGroupId ASC", "successorPanelGroupId ASC"]
+            }
+            Self::StaleMosaicEdge | Self::ApplyInvalidatedEdge => &["ordinal ASC", "edgeId ASC"],
+            Self::ProjectConsequence => &["projectId ASC", "unchangedPinnedSessionId ASC"],
+            Self::ApplyReplacementSession => &["ordinal ASC", "replacementSessionId ASC"],
+            Self::ApplyPanelRevision => &["ordinal ASC", "revisionId ASC"],
+            Self::ApplyProjectProposal => &["ordinal ASC", "projectReplacementProposalId ASC"],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionRevisionQueryRequest {
+    pub session_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationQueryRequest {
+    pub plan_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationSnapshotListRequest {
+    pub plan_id: CanonicalId,
+    pub snapshot_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationChildListRequest {
+    pub plan_id: CanonicalId,
+    pub snapshot_id: CanonicalId,
+    pub owner_id: SafeText,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum MetadataQuery {
+    Evidence(SessionRevisionQueryRequest),
+    EquipmentResolution(SessionRevisionQueryRequest),
+    Reclassification(ReclassificationQueryRequest),
+    ReplacementFrameList(ReclassificationChildListRequest),
+    ReplacementSessionList(ReclassificationSnapshotListRequest),
+    PanelConsequenceList(ReclassificationSnapshotListRequest),
+    PanelConsequenceSessionList(ReclassificationChildListRequest),
+    PanelConsequenceRetirementList(ReclassificationChildListRequest),
+    PanelConsequenceLineageList(ReclassificationChildListRequest),
+    StaleMosaicEdgeList(ReclassificationSnapshotListRequest),
+    ProjectConsequenceList(ReclassificationSnapshotListRequest),
+    ProjectConsequenceReplacementList(ReclassificationChildListRequest),
+    ApplyReplacementSessionList(ReclassificationSnapshotListRequest),
+    ApplyPanelRevisionList(ReclassificationSnapshotListRequest),
+    ApplyInvalidatedEdgeList(ReclassificationSnapshotListRequest),
+    ApplyRetiredPanelGroupList(ReclassificationSnapshotListRequest),
+    ApplyPanelLineageList(ReclassificationSnapshotListRequest),
+    ApplyProjectProposalList(ReclassificationSnapshotListRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EquipmentDecisionInput {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optical_profile_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mark_camera_unregulated: Option<bool>,
+    pub note: NonBlankSafeText,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EquipmentResolutionDecideRequest {
+    pub session_id: CanonicalId,
+    pub expected_resolution_revision: u64,
+    pub decision: EquipmentDecisionInput,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EquipmentResolutionDecideResponse {
+    pub resolution: EquipmentResolution,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationPlanRequest {
+    pub session_id: CanonicalId,
+    pub expected_metadata_resolution_revision: u64,
+    pub corrections: BoundedList<MetadataCorrection, 256>,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationApplyRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub expected_source_session_evidence_revision: u64,
+    pub expected_group_head_revision_refs: BoundedList<RevisionRef, 500>,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationApplyResponse {
+    pub plan: ReclassificationPlan,
+    pub applied_reclassification_plan_revision_id: CanonicalId,
+    pub predecessor_session_id: CanonicalId,
+    pub result: ReclassificationApplyResult,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReclassificationDiscardRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum MetadataCommand {
+    EquipmentResolutionDecide(EquipmentResolutionDecideRequest),
+    ReclassificationPlan(ReclassificationPlanRequest),
+    ReclassificationApply(ReclassificationApplyRequest),
+    ReclassificationDiscard(ReclassificationDiscardRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "event",
+    content = "payload",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum MetadataEvent {
+    EquipmentResolutionDecided {
+        resolution_id: CanonicalId,
+        session_id: CanonicalId,
+        revision: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        camera_id: Option<CanonicalId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        optical_profile_id: Option<CanonicalId>,
+        decision: ResolutionDecision,
+    },
+    CameraMarkedUnregulated {
+        camera_id: CanonicalId,
+        effective_after: Rfc3339Timestamp,
+        resolution_id: CanonicalId,
+    },
+    ReclassificationPlanned {
+        plan_id: CanonicalId,
+        source_session_id: CanonicalId,
+        plan_result_snapshot_id: CanonicalId,
+        replacement_session_count: u64,
+        panel_consequence_count: u64,
+        predecessor_group_retirement_count: u64,
+        panel_lineage_count: u64,
+        stale_mosaic_edge_count: u64,
+        project_consequence_count: u64,
+    },
+    ReclassificationApplied {
+        plan_id: CanonicalId,
+        applied_reclassification_plan_revision_id: CanonicalId,
+        predecessor_session_id: CanonicalId,
+        apply_result_snapshot_id: CanonicalId,
+        replacement_session_count: u64,
+        accepted_panel_revision_count: u64,
+        retired_predecessor_group_count: u64,
+        panel_lineage_count: u64,
+        invalidated_mosaic_edge_count: u64,
+        project_replacement_proposal_count: u64,
+    },
+    ReclassificationDiscarded {
+        plan_id: CanonicalId,
+    },
+}

--- a/crates/contracts/core/src/sessions/heterogeneity/metadata.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/metadata.rs
@@ -671,13 +671,9 @@ pub enum MetadataCommand {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(
-    tag = "event",
-    content = "payload",
-    rename_all = "snake_case",
-    rename_all_fields = "camelCase"
-)]
+#[serde(tag = "event", rename_all_fields = "camelCase")]
 pub enum MetadataEvent {
+    #[serde(rename = "equipment.resolution.decided")]
     EquipmentResolutionDecided {
         resolution_id: CanonicalId,
         session_id: CanonicalId,
@@ -688,11 +684,13 @@ pub enum MetadataEvent {
         optical_profile_id: Option<CanonicalId>,
         decision: ResolutionDecision,
     },
+    #[serde(rename = "equipment.camera_marked_unregulated")]
     CameraMarkedUnregulated {
         camera_id: CanonicalId,
         effective_after: Rfc3339Timestamp,
         resolution_id: CanonicalId,
     },
+    #[serde(rename = "metadata.reclassification_planned")]
     ReclassificationPlanned {
         plan_id: CanonicalId,
         source_session_id: CanonicalId,
@@ -704,6 +702,7 @@ pub enum MetadataEvent {
         stale_mosaic_edge_count: u64,
         project_consequence_count: u64,
     },
+    #[serde(rename = "metadata.reclassification_applied")]
     ReclassificationApplied {
         plan_id: CanonicalId,
         applied_reclassification_plan_revision_id: CanonicalId,
@@ -716,7 +715,6 @@ pub enum MetadataEvent {
         invalidated_mosaic_edge_count: u64,
         project_replacement_proposal_count: u64,
     },
-    ReclassificationDiscarded {
-        plan_id: CanonicalId,
-    },
+    #[serde(rename = "metadata.reclassification_discarded")]
+    ReclassificationDiscarded { plan_id: CanonicalId },
 }

--- a/crates/contracts/core/src/sessions/heterogeneity/mod.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/mod.rs
@@ -1,0 +1,19 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Portable contracts for Spec 062 immutable session heterogeneity.
+
+pub mod calibration;
+pub mod inbox;
+pub mod metadata;
+pub mod projects;
+pub mod relations;
+pub mod settings;
+pub mod shared;
+
+pub use shared::{
+    AuditRecord, BoundedList, CanonicalId, CommandFence, ContractEvent, Cursor, CursorBinding,
+    Digest, ErrorCode, FiniteDecimal, KeysetListOperation, LocalDate, MutationContext,
+    NonBlankSafeText, Page, PageBasis, PageRequest, PortableContractError, ProtectedResourceState,
+    Rfc3339Timestamp, SafeErrorDetails, SafeText, ValidationError,
+};

--- a/crates/contracts/core/src/sessions/heterogeneity/projects.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/projects.rs
@@ -13,6 +13,10 @@ use super::shared::{
     StableIdentity,
 };
 
+const fn default_true() -> bool {
+    true
+}
+
 pub const MAX_UPDATE_VIEW_SESSIONS: u64 = 500;
 pub const MAX_UPDATE_VIEW_ITEMS: u64 = 100_000;
 pub const MAX_UPDATE_VIEW_SOURCE_FRAMES: u64 = 100_000;
@@ -426,13 +430,14 @@ impl KeysetListOperation for ProjectListOperation {
             Self::Pin | Self::MaterializedSession | Self::UnmaterializedSession => {
                 &["sessionId ASC"]
             }
-            Self::ManifestEntry => &["ordinal ASC", "entryId ASC"],
-            Self::ManifestCorrectionOverlay => &["ordinal ASC", "overlayId ASC"],
-            Self::CorrectionOverlayMapping | Self::PlanOverlayMapping => {
-                &["ordinal ASC", "predecessorEntryId ASC"]
-            }
-            Self::PlanPinnedSession | Self::PlanAddedSession => &["ordinal ASC", "sessionId ASC"],
-            Self::PlanItem | Self::PlanConflict => &["ordinal ASC", "itemId ASC"],
+            Self::ManifestEntry
+            | Self::ManifestCorrectionOverlay
+            | Self::CorrectionOverlayMapping
+            | Self::PlanPinnedSession
+            | Self::PlanAddedSession
+            | Self::PlanItem
+            | Self::PlanConflict
+            | Self::PlanOverlayMapping => &["ordinal ASC"],
         }
     }
 }
@@ -443,6 +448,8 @@ pub struct RelatedSessionListRequest {
     pub project_id: CanonicalId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relation_kinds: Option<BoundedList<RelatedSessionKind, 100>>,
+    #[serde(default = "default_true")]
+    #[schemars(default = "default_true")]
     pub include_pinned: bool,
     pub page: PageRequest,
 }
@@ -465,7 +472,7 @@ pub struct ProjectRevisionPageRequest {
 #[serde(rename_all = "camelCase")]
 pub struct ProjectSnapshotPageRequest {
     pub project_id: CanonicalId,
-    pub snapshot_id: CanonicalId,
+    pub materialized_snapshot_id: CanonicalId,
     pub page: PageRequest,
 }
 
@@ -523,23 +530,39 @@ pub struct UpdateViewOperationQueryRequest {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum ProjectQuery {
+    #[serde(rename = "project.related_session.list")]
     RelatedSessionList(RelatedSessionListRequest),
+    #[serde(rename = "project.view_state.query")]
     ViewState(ProjectQueryRequest),
+    #[serde(rename = "project.view_state.pin.list")]
     PinList(ProjectRevisionPageRequest),
+    #[serde(rename = "project.view_state.materialized_session.list")]
     MaterializedSessionList(ProjectSnapshotPageRequest),
+    #[serde(rename = "project.view_state.unmaterialized_session.list")]
     UnmaterializedSessionList(UnmaterializedSessionListRequest),
+    #[serde(rename = "project.manifest.query")]
     Manifest(ManifestQueryRequest),
+    #[serde(rename = "project.manifest.entry.list")]
     ManifestEntryList(ManifestPageRequest),
+    #[serde(rename = "project.manifest.correction_overlay.list")]
     ManifestCorrectionOverlayList(ManifestPageRequest),
+    #[serde(rename = "project.correction_overlay.mapping.list")]
     CorrectionOverlayMappingList(OverlayPageRequest),
+    #[serde(rename = "project.update_view.query")]
     UpdateView(PlanQueryRequest),
+    #[serde(rename = "project.update_view.pinned_session.list")]
     UpdateViewPinnedSessionList(PlanPageRequest),
+    #[serde(rename = "project.update_view.added_session.list")]
     UpdateViewAddedSessionList(PlanPageRequest),
+    #[serde(rename = "project.update_view.item.list")]
     UpdateViewItemList(PlanPageRequest),
+    #[serde(rename = "project.update_view.conflict.list")]
     UpdateViewConflictList(PlanPageRequest),
+    #[serde(rename = "project.update_view.overlay_mapping.list")]
     UpdateViewOverlayMappingList(PlanPageRequest),
+    #[serde(rename = "project.update_view.operation.query")]
     UpdateViewOperation(UpdateViewOperationQueryRequest),
 }
 
@@ -635,14 +658,21 @@ pub struct UpdateViewCancelRequest {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum ProjectCommand {
+    #[serde(rename = "project.session_pin.add")]
     SessionPinAdd(ProjectSessionPinAddRequest),
+    #[serde(rename = "project.session_pin.replace")]
     SessionPinReplace(ProjectSessionPinReplaceRequest),
+    #[serde(rename = "project.update_view.plan")]
     UpdateViewPlan(UpdateViewPlanRequest),
+    #[serde(rename = "project.update_view.approve")]
     UpdateViewApprove(UpdateViewApproveRequest),
+    #[serde(rename = "project.update_view.apply")]
     UpdateViewApply(UpdateViewApplyRequest),
+    #[serde(rename = "project.update_view.discard")]
     UpdateViewDiscard(UpdateViewDiscardRequest),
+    #[serde(rename = "project.update_view.cancel")]
     UpdateViewCancel(UpdateViewCancelRequest),
 }
 

--- a/crates/contracts/core/src/sessions/heterogeneity/projects.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/projects.rs
@@ -13,10 +13,6 @@ use super::shared::{
     StableIdentity,
 };
 
-const fn default_true() -> bool {
-    true
-}
-
 pub const MAX_UPDATE_VIEW_SESSIONS: u64 = 500;
 pub const MAX_UPDATE_VIEW_ITEMS: u64 = 100_000;
 pub const MAX_UPDATE_VIEW_SOURCE_FRAMES: u64 = 100_000;
@@ -430,14 +426,13 @@ impl KeysetListOperation for ProjectListOperation {
             Self::Pin | Self::MaterializedSession | Self::UnmaterializedSession => {
                 &["sessionId ASC"]
             }
-            Self::ManifestEntry
-            | Self::ManifestCorrectionOverlay
-            | Self::CorrectionOverlayMapping
-            | Self::PlanPinnedSession
-            | Self::PlanAddedSession
-            | Self::PlanItem
-            | Self::PlanConflict
-            | Self::PlanOverlayMapping => &["ordinal ASC"],
+            Self::ManifestEntry => &["ordinal ASC", "entryId ASC"],
+            Self::ManifestCorrectionOverlay => &["ordinal ASC", "overlayId ASC"],
+            Self::CorrectionOverlayMapping | Self::PlanOverlayMapping => {
+                &["ordinal ASC", "predecessorEntryId ASC"]
+            }
+            Self::PlanPinnedSession | Self::PlanAddedSession => &["ordinal ASC", "sessionId ASC"],
+            Self::PlanItem | Self::PlanConflict => &["ordinal ASC", "itemId ASC"],
         }
     }
 }
@@ -448,8 +443,8 @@ pub struct RelatedSessionListRequest {
     pub project_id: CanonicalId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub relation_kinds: Option<BoundedList<RelatedSessionKind, 100>>,
-    #[serde(default = "default_true")]
-    #[schemars(default = "default_true")]
+    #[serde(default)]
+    #[schemars(default)]
     pub include_pinned: bool,
     pub page: PageRequest,
 }
@@ -677,35 +672,32 @@ pub enum ProjectCommand {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(
-    tag = "event",
-    content = "payload",
-    rename_all = "snake_case",
-    rename_all_fields = "camelCase"
-)]
+#[serde(tag = "event", rename_all_fields = "camelCase")]
 pub enum ProjectEvent {
+    #[serde(rename = "project.related_session_available")]
     RelatedSessionAvailable {
         project_id: CanonicalId,
         session_id: CanonicalId,
         relation_kind: RelatedSessionKind,
         evidence_id: CanonicalId,
     },
+    #[serde(rename = "project.session_pinned")]
     SessionPinned {
         project_id: CanonicalId,
         session_id: CanonicalId,
         pin_revision: u64,
         source: PinSource,
     },
+    #[serde(rename = "project.session_pin_replaced")]
     SessionPinReplaced {
         project_id: CanonicalId,
         predecessor_session_id: CanonicalId,
         replacement_session_ids: BoundedList<CanonicalId, 500>,
         applied_reclassification_plan_revision_id: CanonicalId,
     },
-    ViewStale {
-        project_id: CanonicalId,
-        unmaterialized_session_count: u64,
-    },
+    #[serde(rename = "project.view_stale")]
+    ViewStale { project_id: CanonicalId, unmaterialized_session_count: u64 },
+    #[serde(rename = "project.update_view_planned")]
     UpdateViewPlanned {
         project_id: CanonicalId,
         plan_id: CanonicalId,
@@ -717,12 +709,14 @@ pub enum ProjectEvent {
         overlay_mapping_count: u64,
         remaining_session_count: u64,
     },
+    #[serde(rename = "project.update_view_approved")]
     UpdateViewApproved {
         project_id: CanonicalId,
         plan_id: CanonicalId,
         approval_id: CanonicalId,
         plan_revision: u64,
     },
+    #[serde(rename = "project.update_view_item_applied")]
     UpdateViewItemApplied {
         operation_id: CanonicalId,
         plan_id: CanonicalId,
@@ -730,6 +724,7 @@ pub enum ProjectEvent {
         session_id: CanonicalId,
         destination_relative_path: CanonicalRelativePath,
     },
+    #[serde(rename = "project.update_view_stopped")]
     UpdateViewStopped {
         operation_id: CanonicalId,
         plan_id: CanonicalId,
@@ -737,6 +732,7 @@ pub enum ProjectEvent {
         item_id: Option<CanonicalId>,
         error_code: SafeText,
     },
+    #[serde(rename = "project.update_view_failed")]
     UpdateViewFailed {
         operation_id: CanonicalId,
         plan_id: CanonicalId,
@@ -745,6 +741,7 @@ pub enum ProjectEvent {
         error_code: SafeText,
         resumable: bool,
     },
+    #[serde(rename = "project.update_view_applied")]
     UpdateViewApplied {
         operation_id: CanonicalId,
         plan_id: CanonicalId,

--- a/crates/contracts/core/src/sessions/heterogeneity/projects.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/projects.rs
@@ -1,0 +1,724 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Related-session, project-pin, and Update View contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::shared::{
+    BoundedList, CanonicalId, CanonicalRelativePath, DestinationCollisionKey, Digest,
+    FiniteDecimal, KeysetListOperation, MutationContext, PageRequest, Rfc3339Timestamp, SafeText,
+    StableIdentity,
+};
+
+pub const MAX_UPDATE_VIEW_SESSIONS: u64 = 500;
+pub const MAX_UPDATE_VIEW_ITEMS: u64 = 100_000;
+pub const MAX_UPDATE_VIEW_SOURCE_FRAMES: u64 = 100_000;
+pub const MAX_UPDATE_VIEW_SOURCE_BYTES: u64 = 17_592_186_044_416;
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RelatedSessionKind {
+    PanelSibling,
+    MosaicPanel,
+    SessionReplacement,
+    ReviewedCrossTarget,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedEvidenceSummary {
+    pub target_compatibility: SafeText,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footprint_coverage_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub center_separation_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub residual_sky_rotation_deg: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub equipment_compatibility: Option<SafeText>,
+    pub warning_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedSession {
+    pub project_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub relation_kind: RelatedSessionKind,
+    pub related_through_session_ids: BoundedList<CanonicalId, 100>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub panel_group_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mosaic_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement_for_session_id: Option<CanonicalId>,
+    pub evidence_id: CanonicalId,
+    pub evidence_summary: RelatedEvidenceSummary,
+    pub first_available_at: Rfc3339Timestamp,
+    pub already_pinned: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum PinSource {
+    ExplicitAdd,
+    ExplicitReplacement,
+    ProjectCreation,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSessionPin {
+    pub project_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub pin_revision: u64,
+    pub pinned_at: Rfc3339Timestamp,
+    pub pinned_by: CanonicalId,
+    pub source: PinSource,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_session_evidence_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replaces_session_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectLifecycle {
+    SetupIncomplete,
+    Ready,
+    Prepared,
+    Processing,
+    Blocked,
+    Completed,
+    Archived,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectViewState {
+    pub project_id: CanonicalId,
+    pub project_revision: u64,
+    pub lifecycle: ProjectLifecycle,
+    pub pinned_session_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub materialized_snapshot_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_manifest_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub current_manifest_version: Option<u64>,
+    pub materialized_session_count: u64,
+    pub unmaterialized_session_count: u64,
+    pub stale: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_view_revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectManifest {
+    pub manifest_id: CanonicalId,
+    pub version: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predecessor_manifest_id: Option<CanonicalId>,
+    pub materialized_snapshot_id: CanonicalId,
+    pub active_entry_count: u64,
+    pub active_correction_overlay_count: u64,
+    pub created_at: Rfc3339Timestamp,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrectionOverlay {
+    pub overlay_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub predecessor_overlay_id: Option<CanonicalId>,
+    pub applied_reclassification_plan_revision_id: CanonicalId,
+    pub mapping_count: u64,
+    pub created_at: Rfc3339Timestamp,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateViewPlanState {
+    Open,
+    Approved,
+    Applying,
+    Stopped,
+    Applied,
+    Failed,
+    Stale,
+    Discarded,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum DestinationPlatform {
+    Linux,
+    Macos,
+    Windows,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DestinationRootIdentity {
+    pub root_id: CanonicalId,
+    pub canonical_root_key: SafeText,
+    pub stable_file_identity: StableIdentity,
+    pub platform: DestinationPlatform,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewWorkLimits {
+    pub maximum_sessions: u64,
+    pub maximum_items: u64,
+    pub maximum_source_frames: u64,
+    pub maximum_source_bytes: u64,
+}
+
+impl Default for UpdateViewWorkLimits {
+    fn default() -> Self {
+        Self {
+            maximum_sessions: MAX_UPDATE_VIEW_SESSIONS,
+            maximum_items: MAX_UPDATE_VIEW_ITEMS,
+            maximum_source_frames: MAX_UPDATE_VIEW_SOURCE_FRAMES,
+            maximum_source_bytes: MAX_UPDATE_VIEW_SOURCE_BYTES,
+        }
+    }
+}
+
+impl UpdateViewWorkLimits {
+    #[must_use]
+    pub const fn is_contract_limit(&self) -> bool {
+        self.maximum_sessions == MAX_UPDATE_VIEW_SESSIONS
+            && self.maximum_items == MAX_UPDATE_VIEW_ITEMS
+            && self.maximum_source_frames == MAX_UPDATE_VIEW_SOURCE_FRAMES
+            && self.maximum_source_bytes == MAX_UPDATE_VIEW_SOURCE_BYTES
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewContinuation {
+    pub remaining_session_count: u64,
+    pub next_session_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CorrectionOverlayPreview {
+    pub predecessor_session_id: CanonicalId,
+    pub applied_reclassification_plan_revision_id: CanonicalId,
+    pub mapping_count: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewApproval {
+    pub approval_id: CanonicalId,
+    pub approved_at: Rfc3339Timestamp,
+    pub approved_by: CanonicalId,
+    pub plan_revision: u64,
+    pub approved_plan_digest: Digest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewPlan {
+    pub plan_id: CanonicalId,
+    pub plan_revision: u64,
+    pub project_id: CanonicalId,
+    pub state: UpdateViewPlanState,
+    pub project_revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_snapshot_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_view_revision: Option<u64>,
+    pub destination_root: DestinationRootIdentity,
+    pub plan_digest: Digest,
+    pub pinned_session_snapshot_count: u64,
+    pub added_session_count: u64,
+    pub item_count: u64,
+    pub source_frame_count: u64,
+    pub source_byte_count: u64,
+    pub conflict_count: u64,
+    pub work_limits: UpdateViewWorkLimits,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub continuation: Option<UpdateViewContinuation>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub correction_overlay_preview: Option<CorrectionOverlayPreview>,
+    pub created_at: Rfc3339Timestamp,
+    pub created_by: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval: Option<UpdateViewApproval>,
+}
+
+impl UpdateViewPlan {
+    #[must_use]
+    pub fn within_work_limits(&self) -> bool {
+        self.work_limits.is_contract_limit()
+            && self.added_session_count <= MAX_UPDATE_VIEW_SESSIONS
+            && self.item_count <= MAX_UPDATE_VIEW_ITEMS
+            && self.source_frame_count <= MAX_UPDATE_VIEW_SOURCE_FRAMES
+            && self.source_byte_count <= MAX_UPDATE_VIEW_SOURCE_BYTES
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PinnedSourceIdentity {
+    pub file_record_id: CanonicalId,
+    pub stable_file_identity: StableIdentity,
+    pub source_root_id: CanonicalId,
+    pub source_relative_path: CanonicalRelativePath,
+    pub no_follow: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateViewAction {
+    CreateDirectory,
+    CreateLink,
+    Copy,
+    WriteManifest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ExpectedDestinationState {
+    Absent,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewItem {
+    pub ordinal: u64,
+    pub item_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub action: UpdateViewAction,
+    pub destination_relative_path: CanonicalRelativePath,
+    pub destination_collision_key: DestinationCollisionKey,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source: Option<PinnedSourceIdentity>,
+    pub expected_destination_state: ExpectedDestinationState,
+    pub approved_content_fingerprint: Digest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateViewConflictCode {
+    PathExists,
+    IncompatibleDestination,
+    SourceUnavailable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewConflict {
+    pub ordinal: u64,
+    pub code: UpdateViewConflictCode,
+    pub item_id: CanonicalId,
+    pub destination_relative_path: CanonicalRelativePath,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub existing_entry_fingerprint: Option<Digest>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewOverlayMapping {
+    pub ordinal: u64,
+    pub predecessor_entry_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement_entry_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exclusion_reason_code: Option<SafeText>,
+}
+
+impl UpdateViewOverlayMapping {
+    #[must_use]
+    pub fn has_exactly_one_outcome(&self) -> bool {
+        self.replacement_entry_id.is_some() != self.exclusion_reason_code.is_some()
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum UpdateViewOperationState {
+    Applying,
+    Stopping,
+    Stopped,
+    Applied,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewOperationProgress {
+    pub operation_id: CanonicalId,
+    pub plan_id: CanonicalId,
+    pub state: UpdateViewOperationState,
+    pub completed_items: u64,
+    pub total_items: u64,
+    pub completed_source_bytes: u64,
+    pub total_source_bytes: u64,
+    pub cancel_safe: bool,
+    pub updated_at: Rfc3339Timestamp,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProjectListOperation {
+    RelatedSession,
+    Pin,
+    MaterializedSession,
+    UnmaterializedSession,
+    ManifestEntry,
+    ManifestCorrectionOverlay,
+    CorrectionOverlayMapping,
+    PlanPinnedSession,
+    PlanAddedSession,
+    PlanItem,
+    PlanConflict,
+    PlanOverlayMapping,
+}
+
+impl ProjectListOperation {
+    pub const ALL: [Self; 12] = [
+        Self::RelatedSession,
+        Self::Pin,
+        Self::MaterializedSession,
+        Self::UnmaterializedSession,
+        Self::ManifestEntry,
+        Self::ManifestCorrectionOverlay,
+        Self::CorrectionOverlayMapping,
+        Self::PlanPinnedSession,
+        Self::PlanAddedSession,
+        Self::PlanItem,
+        Self::PlanConflict,
+        Self::PlanOverlayMapping,
+    ];
+}
+
+impl KeysetListOperation for ProjectListOperation {
+    fn query_name(&self) -> &'static str {
+        match self {
+            Self::RelatedSession => "project.related_session.list",
+            Self::Pin => "project.view_state.pin.list",
+            Self::MaterializedSession => "project.view_state.materialized_session.list",
+            Self::UnmaterializedSession => "project.view_state.unmaterialized_session.list",
+            Self::ManifestEntry => "project.manifest.entry.list",
+            Self::ManifestCorrectionOverlay => "project.manifest.correction_overlay.list",
+            Self::CorrectionOverlayMapping => "project.correction_overlay.mapping.list",
+            Self::PlanPinnedSession => "project.update_view.pinned_session.list",
+            Self::PlanAddedSession => "project.update_view.added_session.list",
+            Self::PlanItem => "project.update_view.item.list",
+            Self::PlanConflict => "project.update_view.conflict.list",
+            Self::PlanOverlayMapping => "project.update_view.overlay_mapping.list",
+        }
+    }
+
+    fn unique_order(&self) -> &'static [&'static str] {
+        match self {
+            Self::RelatedSession => &["firstAvailableAt DESC", "sessionId ASC"],
+            Self::Pin | Self::MaterializedSession | Self::UnmaterializedSession => {
+                &["sessionId ASC"]
+            }
+            Self::ManifestEntry => &["ordinal ASC", "entryId ASC"],
+            Self::ManifestCorrectionOverlay => &["ordinal ASC", "overlayId ASC"],
+            Self::CorrectionOverlayMapping | Self::PlanOverlayMapping => {
+                &["ordinal ASC", "predecessorEntryId ASC"]
+            }
+            Self::PlanPinnedSession | Self::PlanAddedSession => &["ordinal ASC", "sessionId ASC"],
+            Self::PlanItem | Self::PlanConflict => &["ordinal ASC", "itemId ASC"],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelatedSessionListRequest {
+    pub project_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub relation_kinds: Option<BoundedList<RelatedSessionKind, 100>>,
+    pub include_pinned: bool,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectQueryRequest {
+    pub project_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectRevisionPageRequest {
+    pub project_id: CanonicalId,
+    pub project_revision: u64,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSnapshotPageRequest {
+    pub project_id: CanonicalId,
+    pub snapshot_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UnmaterializedSessionListRequest {
+    pub project_id: CanonicalId,
+    pub project_revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub materialized_snapshot_id: Option<CanonicalId>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestQueryRequest {
+    pub project_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manifest_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManifestPageRequest {
+    pub project_id: CanonicalId,
+    pub manifest_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct OverlayPageRequest {
+    pub project_id: CanonicalId,
+    pub overlay_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanQueryRequest {
+    pub plan_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PlanPageRequest {
+    pub plan_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewOperationQueryRequest {
+    pub operation_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum ProjectQuery {
+    RelatedSessionList(RelatedSessionListRequest),
+    ViewState(ProjectQueryRequest),
+    PinList(ProjectRevisionPageRequest),
+    MaterializedSessionList(ProjectSnapshotPageRequest),
+    UnmaterializedSessionList(UnmaterializedSessionListRequest),
+    Manifest(ManifestQueryRequest),
+    ManifestEntryList(ManifestPageRequest),
+    ManifestCorrectionOverlayList(ManifestPageRequest),
+    CorrectionOverlayMappingList(OverlayPageRequest),
+    UpdateView(PlanQueryRequest),
+    UpdateViewPinnedSessionList(PlanPageRequest),
+    UpdateViewAddedSessionList(PlanPageRequest),
+    UpdateViewItemList(PlanPageRequest),
+    UpdateViewConflictList(PlanPageRequest),
+    UpdateViewOverlayMappingList(PlanPageRequest),
+    UpdateViewOperation(UpdateViewOperationQueryRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSessionPinAddRequest {
+    pub project_id: CanonicalId,
+    pub session_id: CanonicalId,
+    pub expected_project_revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub related_session_evidence_id: Option<CanonicalId>,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSessionPinAddResponse {
+    pub pin: ProjectSessionPin,
+    pub view_state: ProjectViewState,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProjectSessionPinReplaceRequest {
+    pub project_id: CanonicalId,
+    pub predecessor_session_id: CanonicalId,
+    pub replacement_session_ids: BoundedList<CanonicalId, 500>,
+    pub applied_reclassification_plan_revision_id: CanonicalId,
+    pub expected_project_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ReplacementContext {
+    pub predecessor_session_id: CanonicalId,
+    pub applied_reclassification_plan_revision_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewPlanRequest {
+    pub project_id: CanonicalId,
+    pub expected_project_revision: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub expected_source_view_revision: Option<u64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_ids: Option<BoundedList<CanonicalId, 500>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub replacement_context: Option<ReplacementContext>,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewApproveRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewApplyRequest {
+    pub plan_id: CanonicalId,
+    pub approval_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewApplyResponse {
+    pub operation_id: CanonicalId,
+    pub plan_id: CanonicalId,
+    pub state: UpdateViewOperationState,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewDiscardRequest {
+    pub plan_id: CanonicalId,
+    pub expected_plan_revision: u64,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateViewCancelRequest {
+    pub operation_id: CanonicalId,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum ProjectCommand {
+    SessionPinAdd(ProjectSessionPinAddRequest),
+    SessionPinReplace(ProjectSessionPinReplaceRequest),
+    UpdateViewPlan(UpdateViewPlanRequest),
+    UpdateViewApprove(UpdateViewApproveRequest),
+    UpdateViewApply(UpdateViewApplyRequest),
+    UpdateViewDiscard(UpdateViewDiscardRequest),
+    UpdateViewCancel(UpdateViewCancelRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "event",
+    content = "payload",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum ProjectEvent {
+    RelatedSessionAvailable {
+        project_id: CanonicalId,
+        session_id: CanonicalId,
+        relation_kind: RelatedSessionKind,
+        evidence_id: CanonicalId,
+    },
+    SessionPinned {
+        project_id: CanonicalId,
+        session_id: CanonicalId,
+        pin_revision: u64,
+        source: PinSource,
+    },
+    SessionPinReplaced {
+        project_id: CanonicalId,
+        predecessor_session_id: CanonicalId,
+        replacement_session_ids: BoundedList<CanonicalId, 500>,
+        applied_reclassification_plan_revision_id: CanonicalId,
+    },
+    ViewStale {
+        project_id: CanonicalId,
+        unmaterialized_session_count: u64,
+    },
+    UpdateViewPlanned {
+        project_id: CanonicalId,
+        plan_id: CanonicalId,
+        added_session_count: u64,
+        item_count: u64,
+        source_frame_count: u64,
+        source_byte_count: u64,
+        conflict_count: u64,
+        overlay_mapping_count: u64,
+        remaining_session_count: u64,
+    },
+    UpdateViewApproved {
+        project_id: CanonicalId,
+        plan_id: CanonicalId,
+        approval_id: CanonicalId,
+        plan_revision: u64,
+    },
+    UpdateViewItemApplied {
+        operation_id: CanonicalId,
+        plan_id: CanonicalId,
+        item_id: CanonicalId,
+        session_id: CanonicalId,
+        destination_relative_path: CanonicalRelativePath,
+    },
+    UpdateViewStopped {
+        operation_id: CanonicalId,
+        plan_id: CanonicalId,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        item_id: Option<CanonicalId>,
+        error_code: SafeText,
+    },
+    UpdateViewFailed {
+        operation_id: CanonicalId,
+        plan_id: CanonicalId,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        item_id: Option<CanonicalId>,
+        error_code: SafeText,
+        resumable: bool,
+    },
+    UpdateViewApplied {
+        operation_id: CanonicalId,
+        plan_id: CanonicalId,
+        materialized_snapshot_id: CanonicalId,
+        applied_item_count: u64,
+    },
+}

--- a/crates/contracts/core/src/sessions/heterogeneity/relations.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/relations.rs
@@ -743,9 +743,9 @@ pub enum TraversalDirection {
 pub struct TraversalLimits {
     #[schemars(range(min = 1, max = 4096))]
     pub max_depth: u32,
-    #[schemars(range(min = 1, max = 100000))]
+    #[schemars(range(min = 1, max = 100_000))]
     pub max_nodes: u64,
-    #[schemars(range(min = 1, max = 2000000))]
+    #[schemars(range(min = 1, max = 2_000_000))]
     pub max_edges: u64,
 }
 
@@ -789,6 +789,7 @@ impl<'de> Deserialize<'de> for TraversalLimits {
         D: serde::Deserializer<'de>,
     {
         #[derive(Deserialize)]
+        #[allow(clippy::struct_field_names)]
         #[serde(rename_all = "camelCase")]
         struct Wire {
             #[serde(default = "default_max_depth")]

--- a/crates/contracts/core/src/sessions/heterogeneity/relations.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/relations.rs
@@ -1,0 +1,964 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Session, group, mosaic, and relation-proposal contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::shared::{
+    BoundedList, CanonicalId, ContractRange, Digest, EntityRef, FiniteDecimal, KeysetListOperation,
+    LocalDate, MaterializationKind, MutationContext, NonBlankSafeText, PageRequest,
+    PortableContractError, RevisionRef, Rfc3339Timestamp, SafeText, SupportedFrameKind,
+};
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "state",
+    content = "value",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum ValueState<T> {
+    Known(T),
+    Absent,
+    Unknown,
+    Contradictory { evidence_refs: BoundedList<SafeText, 100> },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum ObservingNightDerivation {
+    AcquisitionTimezone {
+        timezone: SafeText,
+        local_boundary_time: SafeText,
+    },
+    ReviewedLocalFallback {
+        local_boundary_time: SafeText,
+        review_evidence_id: CanonicalId,
+        reviewed_at: Rfc3339Timestamp,
+        reviewed_by: CanonicalId,
+        reason: SafeText,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ActivePanelMembership {
+    pub panel_group_id: CanonicalId,
+    pub panel_revision_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSummary {
+    pub session_id: CanonicalId,
+    pub materialization_operation_id: CanonicalId,
+    pub materialization_kind: MaterializationKind,
+    pub frame_kind: SupportedFrameKind,
+    pub observing_night: LocalDate,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acquisition_timezone: Option<SafeText>,
+    pub night_derivation: ObservingNightDerivation,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optical_profile_id: Option<CanonicalId>,
+    pub frame_count: u64,
+    pub created_at: Rfc3339Timestamp,
+    pub superseded_by_session_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_panel_membership: Option<ActivePanelMembership>,
+    pub warning_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ImmutableSessionIdentity {
+    pub filter: ValueState<SafeText>,
+    pub exposure_ms: ValueState<u64>,
+    pub gain: ValueState<FiniteDecimal>,
+    pub offset: ValueState<FiniteDecimal>,
+    pub binning_x: ValueState<u32>,
+    pub binning_y: ValueState<u32>,
+    pub readout_mode: ValueState<SafeText>,
+    pub raster_width: u32,
+    pub raster_height: u32,
+    pub crop_evidence: ValueState<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub geometry_evidence_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionProvenance {
+    pub source_group_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub acquisition_site_id: Option<CanonicalId>,
+    pub approved_at: Rfc3339Timestamp,
+    pub approved_by: CanonicalId,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ImmutableSessionDetail {
+    pub summary: SessionSummary,
+    pub identity: ImmutableSessionIdentity,
+    pub provenance: SessionProvenance,
+    pub predecessor_session_count: u64,
+    pub metadata_resolution_revision: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PanelGroupRevision {
+    pub panel_group_id: CanonicalId,
+    pub revision_id: CanonicalId,
+    pub revision_number: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_revision_id: Option<CanonicalId>,
+    pub accepted_head: bool,
+    pub retired: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub canonical_target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross_target_association_id: Option<CanonicalId>,
+    pub session_count: u32,
+    pub representative_session_id: CanonicalId,
+    pub representative_evidence_id: CanonicalId,
+    pub matching_settings_revision: u64,
+    pub accepted_at: Rfc3339Timestamp,
+    pub accepted_by: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_reason: Option<SafeText>,
+    pub predecessor_group_count: u64,
+    pub successor_group_count: u64,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicRevision {
+    pub mosaic_id: CanonicalId,
+    pub revision_id: CanonicalId,
+    pub revision_number: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub parent_revision_id: Option<CanonicalId>,
+    pub accepted_head: bool,
+    pub retired: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intended_target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross_target_association_id: Option<CanonicalId>,
+    pub panel_count: u32,
+    pub edge_count: u32,
+    pub captured_union_evidence_id: CanonicalId,
+    pub matching_settings_revision: u64,
+    pub accepted_at: Rfc3339Timestamp,
+    pub accepted_by: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_reason: Option<SafeText>,
+    pub predecessor_mosaic_count: u64,
+    pub successor_mosaic_count: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicEdge {
+    pub edge_id: CanonicalId,
+    pub left_panel_revision_id: CanonicalId,
+    pub right_panel_revision_id: CanonicalId,
+    pub overlap_percent: FiniteDecimal,
+    pub residual_sky_rotation_deg: FiniteDecimal,
+    pub allowed_residual_rotation_ranges_deg: BoundedList<ContractRange<FiniteDecimal>, 16>,
+    pub parity_match: bool,
+    pub acquisition_geometry_compatible: bool,
+    pub evidence_id: CanonicalId,
+    pub stale: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub invalidation_reason_code: Option<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub applied_reclassification_plan_revision_id: Option<CanonicalId>,
+}
+
+impl MosaicEdge {
+    #[must_use]
+    pub fn stale_fields_consistent(&self) -> bool {
+        self.stale
+            == (self.invalidation_reason_code.is_some()
+                && self.applied_reclassification_plan_revision_id.is_some())
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationProposalKind {
+    PanelAdd,
+    PanelReplace,
+    PanelSplit,
+    PanelMerge,
+    MosaicCreate,
+    MosaicEdge,
+    MosaicSplit,
+    MosaicMerge,
+    ManualRelation,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ManualRelationKind {
+    PanelAdd,
+    PanelReplace,
+    PanelSplit,
+    PanelMerge,
+    MosaicCreate,
+    MosaicEdge,
+    MosaicSplit,
+    MosaicMerge,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationProposalState {
+    Pending,
+    Accepted,
+    Rejected,
+    Superseded,
+    Stale,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TargetCompatibility {
+    SameTarget,
+    ReviewedCrossTarget,
+    Incompatible,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum EvidenceTernary {
+    Compatible,
+    Incompatible,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ParityEvidence {
+    Match,
+    Mismatch,
+    Unknown,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ThresholdComparison {
+    Lt,
+    Lte,
+    Eq,
+    Gte,
+    Gt,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ThresholdOutcome {
+    Pass,
+    Fail,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ThresholdMeasurement {
+    pub key: SafeText,
+    pub measured_value: FiniteDecimal,
+    pub unit: SafeText,
+    pub comparison: ThresholdComparison,
+    pub threshold_value: FiniteDecimal,
+    pub outcome: ThresholdOutcome,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelationEvidence {
+    pub evidence_id: CanonicalId,
+    pub target_compatibility: TargetCompatibility,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub footprint_coverage_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub center_separation_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub residual_sky_rotation_deg: Option<FiniteDecimal>,
+    pub allowed_residual_rotation_ranges_deg: BoundedList<ContractRange<FiniteDecimal>, 16>,
+    pub parity: ParityEvidence,
+    pub acquisition_geometry: EvidenceTernary,
+    pub equipment: EvidenceTernary,
+    pub missing_evidence_codes: BoundedList<SafeText, 100>,
+    pub threshold_snapshot: BoundedList<ThresholdMeasurement, 100>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CoverageState {
+    Full,
+    Partial,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicObjectEvidenceItem {
+    pub canonical_object_id: CanonicalId,
+    pub panel_containment_refs: BoundedList<EntityRef, 100>,
+    pub session_containment_refs: BoundedList<EntityRef, 100>,
+    pub coverage_state: CoverageState,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum ProposalDecisionKind {
+    Accepted,
+    Rejected,
+    Corrected,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalDecision {
+    pub decision: ProposalDecisionKind,
+    pub decided_at: Rfc3339Timestamp,
+    pub reason: SafeText,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum ManualTargetScope {
+    SameTarget {
+        canonical_target_id: CanonicalId,
+    },
+    ExistingCrossTarget {
+        cross_target_association_id: CanonicalId,
+    },
+    NewReviewedCrossTarget {
+        canonical_target_ids: BoundedList<CanonicalId, 500>,
+        purpose: NonBlankSafeText,
+    },
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManualRelationReview {
+    pub relation_kind: ManualRelationKind,
+    pub review_reason: NonBlankSafeText,
+    pub target_scope: ManualTargetScope,
+    pub missing_evidence_codes: BoundedList<SafeText, 100>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelationProposal {
+    pub proposal_id: CanonicalId,
+    pub proposal_revision: u64,
+    pub kind: RelationProposalKind,
+    pub state: RelationProposalState,
+    pub source_revision_count: u64,
+    pub subject_count: u64,
+    pub proposed_membership_count: u64,
+    pub proposed_edge_count: u64,
+    pub proposed_lineage_count: u64,
+    pub evidence: RelationEvidence,
+    pub matching_settings_revision: u64,
+    pub basis_fingerprint: Digest,
+    pub created_at: Rfc3339Timestamp,
+    pub created_by: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manual_relation: Option<ManualRelationReview>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision: Option<ProposalDecision>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded_by_proposal_id: Option<CanonicalId>,
+}
+
+impl RelationProposal {
+    #[must_use]
+    pub fn manual_relation_consistent(&self) -> bool {
+        (self.kind == RelationProposalKind::ManualRelation) == self.manual_relation.is_some()
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RelationDecisionCounts {
+    pub accepted_revision_count: u64,
+    pub retired_group_count: u64,
+    pub session_supersession_count: u64,
+    pub panel_lineage_count: u64,
+    pub mosaic_lineage_count: u64,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraversalState {
+    Queued,
+    Running,
+    Completed,
+    Cancelled,
+    CeilingExceeded,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TraversalPreviewProgress {
+    pub operation_id: CanonicalId,
+    pub read_watermark: u64,
+    pub state: TraversalState,
+    pub visited_node_count: u64,
+    pub visited_edge_count: u64,
+    pub frontier_count: u64,
+    pub deepest_level: u32,
+    pub updated_at: Rfc3339Timestamp,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub terminal_error: Option<PortableContractError>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum RelationListOperation {
+    Session,
+    SessionFrame,
+    SessionSupersessionSuccessor,
+    SessionSupersessionPredecessor,
+    PanelMembership,
+    PanelHistory,
+    PanelLineagePredecessor,
+    PanelLineageSuccessor,
+    Panel,
+    MosaicPanel,
+    MosaicEdge,
+    MosaicHistory,
+    MosaicLineagePredecessor,
+    MosaicLineageSuccessor,
+    MosaicObjectEvidence,
+    Proposal,
+    ProposalSourceRevision,
+    ProposalSubject,
+    ProposalMembership,
+    ProposalEdge,
+    ProposalLineage,
+    DecisionRevision,
+    DecisionRetiredGroup,
+    DecisionSessionSupersession,
+    DecisionGroupLineage,
+    TraversalNode,
+    TraversalEdge,
+}
+
+impl RelationListOperation {
+    pub const ALL: [Self; 27] = [
+        Self::Session,
+        Self::SessionFrame,
+        Self::SessionSupersessionSuccessor,
+        Self::SessionSupersessionPredecessor,
+        Self::PanelMembership,
+        Self::PanelHistory,
+        Self::PanelLineagePredecessor,
+        Self::PanelLineageSuccessor,
+        Self::Panel,
+        Self::MosaicPanel,
+        Self::MosaicEdge,
+        Self::MosaicHistory,
+        Self::MosaicLineagePredecessor,
+        Self::MosaicLineageSuccessor,
+        Self::MosaicObjectEvidence,
+        Self::Proposal,
+        Self::ProposalSourceRevision,
+        Self::ProposalSubject,
+        Self::ProposalMembership,
+        Self::ProposalEdge,
+        Self::ProposalLineage,
+        Self::DecisionRevision,
+        Self::DecisionRetiredGroup,
+        Self::DecisionSessionSupersession,
+        Self::DecisionGroupLineage,
+        Self::TraversalNode,
+        Self::TraversalEdge,
+    ];
+}
+
+impl KeysetListOperation for RelationListOperation {
+    fn query_name(&self) -> &'static str {
+        match self {
+            Self::Session => "session.list",
+            Self::SessionFrame => "session.frame.list",
+            Self::SessionSupersessionSuccessor => "session.supersession_successor.list",
+            Self::SessionSupersessionPredecessor => "session.supersession_predecessor.list",
+            Self::PanelMembership => "panel_group.membership.list",
+            Self::PanelHistory => "panel_group.history.list",
+            Self::PanelLineagePredecessor => "panel_group.lineage_predecessor.list",
+            Self::PanelLineageSuccessor => "panel_group.lineage_successor.list",
+            Self::Panel => "panel_group.list",
+            Self::MosaicPanel => "mosaic.panel.list",
+            Self::MosaicEdge => "mosaic.edge.list",
+            Self::MosaicHistory => "mosaic.history.list",
+            Self::MosaicLineagePredecessor => "mosaic.lineage_predecessor.list",
+            Self::MosaicLineageSuccessor => "mosaic.lineage_successor.list",
+            Self::MosaicObjectEvidence => "mosaic.object_evidence.list",
+            Self::Proposal => "relation_proposal.list",
+            Self::ProposalSourceRevision => "relation_proposal.source_revision.list",
+            Self::ProposalSubject => "relation_proposal.subject.list",
+            Self::ProposalMembership => "relation_proposal.membership.list",
+            Self::ProposalEdge => "relation_proposal.edge.list",
+            Self::ProposalLineage => "relation_proposal.lineage.list",
+            Self::DecisionRevision => "relation_proposal.decision_revision.list",
+            Self::DecisionRetiredGroup => "relation_proposal.decision_retired_group.list",
+            Self::DecisionSessionSupersession => {
+                "relation_proposal.decision_session_supersession.list"
+            }
+            Self::DecisionGroupLineage => "relation_proposal.decision_group_lineage.list",
+            Self::TraversalNode => "relation_traversal_preview.node.list",
+            Self::TraversalEdge => "relation_traversal_preview.edge.list",
+        }
+    }
+
+    fn unique_order(&self) -> &'static [&'static str] {
+        match self {
+            Self::Session => &["createdAt DESC", "sessionId ASC"],
+            Self::SessionFrame => &["ordinal ASC", "frameId ASC"],
+            Self::SessionSupersessionSuccessor => &["ordinal ASC", "successorSessionId ASC"],
+            Self::SessionSupersessionPredecessor => &["ordinal ASC", "predecessorSessionId ASC"],
+            Self::PanelMembership => &["ordinal ASC", "sessionId ASC"],
+            Self::PanelHistory | Self::MosaicHistory => &["revisionNumber DESC", "revisionId ASC"],
+            Self::PanelLineagePredecessor => &[
+                "acceptedAt DESC",
+                "acceptedProposalId ASC",
+                "ordinal ASC",
+                "predecessorGroupId ASC",
+            ],
+            Self::PanelLineageSuccessor => &[
+                "acceptedAt DESC",
+                "acceptedProposalId ASC",
+                "ordinal ASC",
+                "successorGroupId ASC",
+            ],
+            Self::Panel => &["acceptedAt DESC", "panelGroupId ASC"],
+            Self::MosaicPanel => &["ordinal ASC", "panelRevisionId ASC", "panelGroupId ASC"],
+            Self::MosaicEdge | Self::ProposalEdge => &["ordinal ASC", "edgeId ASC"],
+            Self::MosaicLineagePredecessor => &[
+                "acceptedAt DESC",
+                "acceptedProposalId ASC",
+                "ordinal ASC",
+                "predecessorMosaicId ASC",
+            ],
+            Self::MosaicLineageSuccessor => &[
+                "acceptedAt DESC",
+                "acceptedProposalId ASC",
+                "ordinal ASC",
+                "successorMosaicId ASC",
+            ],
+            Self::MosaicObjectEvidence => &["canonicalObjectId ASC"],
+            Self::Proposal => &["createdAt DESC", "proposalId ASC"],
+            Self::ProposalSourceRevision | Self::DecisionRevision => {
+                &["ordinal ASC", "entityType ASC", "entityId ASC", "revisionId ASC"]
+            }
+            Self::ProposalSubject | Self::ProposalMembership => {
+                &["ordinal ASC", "entityType ASC", "entityId ASC"]
+            }
+            Self::ProposalLineage
+            | Self::DecisionSessionSupersession
+            | Self::DecisionGroupLineage => {
+                &["ordinal ASC", "predecessorId ASC", "successorId ASC"]
+            }
+            Self::DecisionRetiredGroup => &["ordinal ASC", "groupId ASC"],
+            Self::TraversalNode => &["ordinal ASC", "nodeType ASC", "nodeId ASC"],
+            Self::TraversalEdge => &["ordinal ASC", "edgeType ASC", "edgeId ASC"],
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityQueryRequest {
+    pub entity_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RevisionQueryRequest {
+    pub entity_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityPageRequest {
+    pub entity_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RevisionPageRequest {
+    pub entity_id: CanonicalId,
+    pub revision_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frame_kind: Option<SupportedFrameKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observing_night_from: Option<LocalDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub observing_night_to: Option<LocalDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub camera_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub optical_profile_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub superseded: Option<SupersededFilter>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub panel_group_id: Option<CanonicalId>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SupersededFilter {
+    Exclude,
+    Include,
+    Only,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PanelListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub session_id: Option<CanonicalId>,
+    pub active_only: bool,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalListRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub state: Option<RelationProposalState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub kind: Option<RelationProposalKind>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub subject_ref: Option<EntityRef>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum GroupType {
+    Panel,
+    Mosaic,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DecisionPageRequest {
+    pub proposal_id: CanonicalId,
+    pub decision_snapshot_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub group_type: Option<GroupType>,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraversalGraph {
+    PanelLineage,
+    MosaicLineage,
+    AcceptedMosaicConnectivity,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum TraversalDirection {
+    Predecessors,
+    Successors,
+    Both,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TraversalLimits {
+    pub max_depth: u32,
+    pub max_nodes: u64,
+    pub max_edges: u64,
+}
+
+impl Default for TraversalLimits {
+    fn default() -> Self {
+        Self { max_depth: 64, max_nodes: 10_000, max_edges: 50_000 }
+    }
+}
+
+impl TraversalLimits {
+    #[must_use]
+    pub const fn within_contract_bounds(&self) -> bool {
+        self.max_depth >= 1
+            && self.max_depth <= 4_096
+            && self.max_nodes >= 1
+            && self.max_nodes <= 100_000
+            && self.max_edges >= 1
+            && self.max_edges <= 2_000_000
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TraversalStartRequest {
+    pub start_refs: BoundedList<EntityRef, 500>,
+    pub graph: TraversalGraph,
+    pub direction: TraversalDirection,
+    pub limits: TraversalLimits,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TraversalOperationRequest {
+    pub operation_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TraversalResultPageRequest {
+    pub operation_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum RelationQuery {
+    Session(EntityQueryRequest),
+    SessionList(SessionListRequest),
+    SessionFrameList(EntityPageRequest),
+    SessionSupersessionSuccessorList(EntityPageRequest),
+    SessionSupersessionPredecessorList(EntityPageRequest),
+    PanelGroup(RevisionQueryRequest),
+    PanelMembershipList(RevisionPageRequest),
+    PanelHistoryList(EntityPageRequest),
+    PanelLineagePredecessorList(EntityPageRequest),
+    PanelLineageSuccessorList(EntityPageRequest),
+    PanelList(PanelListRequest),
+    Mosaic(RevisionQueryRequest),
+    MosaicPanelList(RevisionPageRequest),
+    MosaicEdgeList(RevisionPageRequest),
+    MosaicHistoryList(EntityPageRequest),
+    MosaicLineagePredecessorList(EntityPageRequest),
+    MosaicLineageSuccessorList(EntityPageRequest),
+    MosaicObjectEvidenceList(RevisionPageRequest),
+    ProposalList(ProposalListRequest),
+    Proposal(EntityQueryRequest),
+    ProposalSourceRevisionList(EntityPageRequest),
+    ProposalSubjectList(EntityPageRequest),
+    ProposalMembershipList(EntityPageRequest),
+    ProposalEdgeList(EntityPageRequest),
+    ProposalLineageList(EntityPageRequest),
+    DecisionRevisionList(DecisionPageRequest),
+    DecisionRetiredGroupList(DecisionPageRequest),
+    DecisionSessionSupersessionList(DecisionPageRequest),
+    DecisionGroupLineageList(DecisionPageRequest),
+    TraversalProgress(TraversalOperationRequest),
+    TraversalResult(TraversalOperationRequest),
+    TraversalNodeList(TraversalResultPageRequest),
+    TraversalEdgeList(TraversalResultPageRequest),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposedLineage {
+    pub predecessor_group_id: CanonicalId,
+    pub successor_group_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManualRelationCreateRequest {
+    pub relation_kind: ManualRelationKind,
+    pub source_revision_refs: BoundedList<RevisionRef, 500>,
+    pub subject_refs: BoundedList<EntityRef, 500>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposed_membership_refs: Option<BoundedList<EntityRef, 500>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposed_edges: Option<BoundedList<MosaicEdge, 500>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub proposed_lineage: Option<BoundedList<ProposedLineage, 500>>,
+    pub target_scope: ManualTargetScope,
+    pub evidence: RelationEvidence,
+    pub review_reason: NonBlankSafeText,
+    pub mutation_context: MutationContext,
+}
+
+impl ManualRelationCreateRequest {
+    #[must_use]
+    pub fn has_required_collections(&self) -> bool {
+        !self.source_revision_refs.is_empty()
+            && !self.subject_refs.is_empty()
+            && [
+                self.proposed_membership_refs.as_ref().map_or(0, BoundedList::len),
+                self.proposed_edges.as_ref().map_or(0, BoundedList::len),
+                self.proposed_lineage.as_ref().map_or(0, BoundedList::len),
+            ]
+            .into_iter()
+            .sum::<usize>()
+                > 0
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ManualRelationCreateResponse {
+    pub proposal: RelationProposal,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalAcceptRequest {
+    pub proposal_id: CanonicalId,
+    pub expected_proposal_revision: u64,
+    pub expected_source_revision_set_digest: Digest,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalAcceptResponse {
+    pub proposal: RelationProposal,
+    pub decision_snapshot_id: CanonicalId,
+    pub result_counts: RelationDecisionCounts,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cross_target_association_id: Option<CanonicalId>,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalRejectRequest {
+    pub proposal_id: CanonicalId,
+    pub expected_proposal_revision: u64,
+    pub rejection_reason: NonBlankSafeText,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalCorrection {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub membership_refs: Option<BoundedList<EntityRef, 500>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub edge_overrides: Option<BoundedList<MosaicEdge, 500>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub intended_target_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub target_scope: Option<ManualTargetScope>,
+    pub note: NonBlankSafeText,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalCorrectRequest {
+    pub proposal_id: CanonicalId,
+    pub expected_proposal_revision: u64,
+    pub correction: ProposalCorrection,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TraversalCancelRequest {
+    pub operation_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum RelationCommand {
+    ManualCreate(ManualRelationCreateRequest),
+    ProposalAccept(ProposalAcceptRequest),
+    ProposalReject(ProposalRejectRequest),
+    ProposalCorrect(ProposalCorrectRequest),
+    TraversalStart(TraversalStartRequest),
+    TraversalCancel(TraversalCancelRequest),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "event",
+    content = "payload",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum RelationEvent {
+    SessionMaterialized {
+        session_id: CanonicalId,
+        materialization_operation_id: CanonicalId,
+        materialization_kind: MaterializationKind,
+        frame_kind: SupportedFrameKind,
+        frame_count: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        panel_group_id: Option<CanonicalId>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        panel_revision_id: Option<CanonicalId>,
+    },
+    SessionSuperseded {
+        predecessor_session_id: CanonicalId,
+        replacement_session_count: u64,
+        applied_reclassification_plan_revision_id: CanonicalId,
+    },
+    ProposalCreated {
+        proposal_id: CanonicalId,
+        kind: RelationProposalKind,
+        subject_count: u64,
+        basis_fingerprint: Digest,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        manual_relation_kind: Option<ManualRelationKind>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        missing_evidence_code_count: Option<u64>,
+    },
+    ProposalAccepted {
+        proposal_id: CanonicalId,
+        decision_snapshot_id: CanonicalId,
+        result_counts: RelationDecisionCounts,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        cross_target_association_id: Option<CanonicalId>,
+    },
+    CrossTargetAssociationCreated {
+        cross_target_association_id: CanonicalId,
+        accepted_proposal_id: CanonicalId,
+        canonical_target_count: u64,
+    },
+    ProposalRejected {
+        proposal_id: CanonicalId,
+        suppression_fingerprint: Digest,
+        rejection_reason: SafeText,
+    },
+    ProposalCorrected {
+        proposal_id: CanonicalId,
+        corrected_proposal_id: CanonicalId,
+        correction_note: SafeText,
+    },
+    GroupHeadChanged {
+        group_type: GroupType,
+        group_id: CanonicalId,
+        previous_revision_id: CanonicalId,
+        accepted_revision_id: CanonicalId,
+    },
+}

--- a/crates/contracts/core/src/sessions/heterogeneity/relations.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/relations.rs
@@ -531,7 +531,7 @@ impl KeysetListOperation for RelationListOperation {
             Self::SessionSupersessionSuccessor => &["ordinal ASC", "successorSessionId ASC"],
             Self::SessionSupersessionPredecessor => &["ordinal ASC", "predecessorSessionId ASC"],
             Self::PanelMembership => &["ordinal ASC", "sessionId ASC"],
-            Self::PanelHistory | Self::MosaicHistory => &["revisionNumber DESC"],
+            Self::PanelHistory | Self::MosaicHistory => &["revisionNumber DESC", "revisionId ASC"],
             Self::PanelLineagePredecessor => &[
                 "acceptedAt DESC",
                 "acceptedProposalId ASC",
@@ -546,7 +546,7 @@ impl KeysetListOperation for RelationListOperation {
             ],
             Self::Panel => &["acceptedAt DESC", "panelGroupId ASC"],
             Self::MosaicPanel => &["ordinal ASC", "panelRevisionId ASC", "panelGroupId ASC"],
-            Self::MosaicEdge => &["ordinal ASC", "edgeId ASC"],
+            Self::MosaicEdge | Self::ProposalEdge => &["ordinal ASC", "edgeId ASC"],
             Self::MosaicLineagePredecessor => &[
                 "acceptedAt DESC",
                 "acceptedProposalId ASC",
@@ -561,17 +561,25 @@ impl KeysetListOperation for RelationListOperation {
             ],
             Self::MosaicObjectEvidence => &["canonicalObjectId ASC"],
             Self::Proposal => &["createdAt DESC", "proposalId ASC"],
-            Self::ProposalSourceRevision
-            | Self::ProposalSubject
-            | Self::ProposalMembership
-            | Self::ProposalEdge
-            | Self::ProposalLineage
-            | Self::DecisionRevision
-            | Self::DecisionRetiredGroup
-            | Self::DecisionSessionSupersession
-            | Self::DecisionGroupLineage
-            | Self::TraversalNode
-            | Self::TraversalEdge => &["ordinal ASC"],
+            Self::ProposalSourceRevision | Self::DecisionRevision => {
+                &["ordinal ASC", "entityType ASC", "entityId ASC", "revisionId ASC"]
+            }
+            Self::ProposalSubject | Self::ProposalMembership => {
+                &["ordinal ASC", "entityType ASC", "entityId ASC"]
+            }
+            Self::ProposalLineage | Self::DecisionGroupLineage => {
+                &["ordinal ASC", "predecessorGroupId ASC", "successorGroupId ASC"]
+            }
+            Self::DecisionRetiredGroup => &["ordinal ASC", "groupId ASC"],
+            Self::DecisionSessionSupersession => {
+                &["ordinal ASC", "predecessorSessionId ASC", "successorSessionId ASC"]
+            }
+            Self::TraversalNode => {
+                &["ordinal ASC", "nodeRef.entityType ASC", "nodeRef.entityId ASC"]
+            }
+            Self::TraversalEdge => {
+                &["ordinal ASC", "edgeRef.entityType ASC", "edgeRef.entityId ASC"]
+            }
         }
     }
 }
@@ -1112,13 +1120,9 @@ pub enum RelationCommand {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(
-    tag = "event",
-    content = "payload",
-    rename_all = "snake_case",
-    rename_all_fields = "camelCase"
-)]
+#[serde(tag = "event", rename_all_fields = "camelCase")]
 pub enum RelationEvent {
+    #[serde(rename = "session.materialized")]
     SessionMaterialized {
         session_id: CanonicalId,
         materialization_operation_id: CanonicalId,
@@ -1130,11 +1134,13 @@ pub enum RelationEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         panel_revision_id: Option<CanonicalId>,
     },
+    #[serde(rename = "session.superseded")]
     SessionSuperseded {
         predecessor_session_id: CanonicalId,
         replacement_session_count: u64,
         applied_reclassification_plan_revision_id: CanonicalId,
     },
+    #[serde(rename = "relation_proposal.created")]
     ProposalCreated {
         proposal_id: CanonicalId,
         kind: RelationProposalKind,
@@ -1145,6 +1151,7 @@ pub enum RelationEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         missing_evidence_code_count: Option<u64>,
     },
+    #[serde(rename = "relation_proposal.accepted")]
     ProposalAccepted {
         proposal_id: CanonicalId,
         decision_snapshot_id: CanonicalId,
@@ -1152,21 +1159,25 @@ pub enum RelationEvent {
         #[serde(skip_serializing_if = "Option::is_none")]
         cross_target_association_id: Option<CanonicalId>,
     },
+    #[serde(rename = "cross_target_association.created")]
     CrossTargetAssociationCreated {
         cross_target_association_id: CanonicalId,
         accepted_proposal_id: CanonicalId,
         canonical_target_count: u64,
     },
+    #[serde(rename = "relation_proposal.rejected")]
     ProposalRejected {
         proposal_id: CanonicalId,
         suppression_fingerprint: Digest,
         rejection_reason: SafeText,
     },
+    #[serde(rename = "relation_proposal.corrected")]
     ProposalCorrected {
         proposal_id: CanonicalId,
         corrected_proposal_id: CanonicalId,
         correction_note: SafeText,
     },
+    #[serde(rename = "group.head_changed")]
     GroupHeadChanged {
         group_type: GroupType,
         group_id: CanonicalId,

--- a/crates/contracts/core/src/sessions/heterogeneity/relations.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/relations.rs
@@ -531,7 +531,7 @@ impl KeysetListOperation for RelationListOperation {
             Self::SessionSupersessionSuccessor => &["ordinal ASC", "successorSessionId ASC"],
             Self::SessionSupersessionPredecessor => &["ordinal ASC", "predecessorSessionId ASC"],
             Self::PanelMembership => &["ordinal ASC", "sessionId ASC"],
-            Self::PanelHistory | Self::MosaicHistory => &["revisionNumber DESC", "revisionId ASC"],
+            Self::PanelHistory | Self::MosaicHistory => &["revisionNumber DESC"],
             Self::PanelLineagePredecessor => &[
                 "acceptedAt DESC",
                 "acceptedProposalId ASC",
@@ -546,7 +546,7 @@ impl KeysetListOperation for RelationListOperation {
             ],
             Self::Panel => &["acceptedAt DESC", "panelGroupId ASC"],
             Self::MosaicPanel => &["ordinal ASC", "panelRevisionId ASC", "panelGroupId ASC"],
-            Self::MosaicEdge | Self::ProposalEdge => &["ordinal ASC", "edgeId ASC"],
+            Self::MosaicEdge => &["ordinal ASC", "edgeId ASC"],
             Self::MosaicLineagePredecessor => &[
                 "acceptedAt DESC",
                 "acceptedProposalId ASC",
@@ -561,50 +561,90 @@ impl KeysetListOperation for RelationListOperation {
             ],
             Self::MosaicObjectEvidence => &["canonicalObjectId ASC"],
             Self::Proposal => &["createdAt DESC", "proposalId ASC"],
-            Self::ProposalSourceRevision | Self::DecisionRevision => {
-                &["ordinal ASC", "entityType ASC", "entityId ASC", "revisionId ASC"]
-            }
-            Self::ProposalSubject | Self::ProposalMembership => {
-                &["ordinal ASC", "entityType ASC", "entityId ASC"]
-            }
-            Self::ProposalLineage
+            Self::ProposalSourceRevision
+            | Self::ProposalSubject
+            | Self::ProposalMembership
+            | Self::ProposalEdge
+            | Self::ProposalLineage
+            | Self::DecisionRevision
+            | Self::DecisionRetiredGroup
             | Self::DecisionSessionSupersession
-            | Self::DecisionGroupLineage => {
-                &["ordinal ASC", "predecessorId ASC", "successorId ASC"]
-            }
-            Self::DecisionRetiredGroup => &["ordinal ASC", "groupId ASC"],
-            Self::TraversalNode => &["ordinal ASC", "nodeType ASC", "nodeId ASC"],
-            Self::TraversalEdge => &["ordinal ASC", "edgeType ASC", "edgeId ASC"],
+            | Self::DecisionGroupLineage
+            | Self::TraversalNode
+            | Self::TraversalEdge => &["ordinal ASC"],
         }
     }
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct EntityQueryRequest {
-    pub entity_id: CanonicalId,
+pub struct SessionQueryRequest {
+    pub session_id: CanonicalId,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct RevisionQueryRequest {
-    pub entity_id: CanonicalId,
+pub struct SessionPageRequest {
+    pub session_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PanelGroupQueryRequest {
+    pub panel_group_id: CanonicalId,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub revision_id: Option<CanonicalId>,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct EntityPageRequest {
-    pub entity_id: CanonicalId,
+pub struct PanelGroupPageRequest {
+    pub panel_group_id: CanonicalId,
     pub page: PageRequest,
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
-pub struct RevisionPageRequest {
-    pub entity_id: CanonicalId,
+pub struct PanelGroupRevisionPageRequest {
+    pub panel_group_id: CanonicalId,
     pub revision_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicQueryRequest {
+    pub mosaic_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision_id: Option<CanonicalId>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicPageRequest {
+    pub mosaic_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicRevisionPageRequest {
+    pub mosaic_id: CanonicalId,
+    pub revision_id: CanonicalId,
+    pub page: PageRequest,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalQueryRequest {
+    pub proposal_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ProposalPageRequest {
+    pub proposal_id: CanonicalId,
     pub page: PageRequest,
 }
 
@@ -645,6 +685,8 @@ pub struct PanelListRequest {
     pub target_id: Option<CanonicalId>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<CanonicalId>,
+    #[serde(default = "default_true")]
+    #[schemars(default = "default_true")]
     pub active_only: bool,
     pub page: PageRequest,
 }
@@ -696,12 +738,31 @@ pub enum TraversalDirection {
     Both,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TraversalLimits {
+    #[schemars(range(min = 1, max = 4096))]
     pub max_depth: u32,
+    #[schemars(range(min = 1, max = 100000))]
     pub max_nodes: u64,
+    #[schemars(range(min = 1, max = 2000000))]
     pub max_edges: u64,
+}
+
+const fn default_true() -> bool {
+    true
+}
+
+const fn default_max_depth() -> u32 {
+    64
+}
+
+const fn default_max_nodes() -> u64 {
+    10_000
+}
+
+const fn default_max_edges() -> u64 {
+    50_000
 }
 
 impl Default for TraversalLimits {
@@ -722,12 +783,43 @@ impl TraversalLimits {
     }
 }
 
+impl<'de> Deserialize<'de> for TraversalLimits {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire {
+            #[serde(default = "default_max_depth")]
+            max_depth: u32,
+            #[serde(default = "default_max_nodes")]
+            max_nodes: u64,
+            #[serde(default = "default_max_edges")]
+            max_edges: u64,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let limits = Self {
+            max_depth: wire.max_depth,
+            max_nodes: wire.max_nodes,
+            max_edges: wire.max_edges,
+        };
+        if !limits.within_contract_bounds() {
+            return Err(serde::de::Error::custom("traversal limits are outside contract bounds"));
+        }
+        Ok(limits)
+    }
+}
+
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct TraversalStartRequest {
     pub start_refs: BoundedList<EntityRef, 500>,
     pub graph: TraversalGraph,
     pub direction: TraversalDirection,
+    #[serde(default)]
+    #[schemars(default)]
     pub limits: TraversalLimits,
 }
 
@@ -745,40 +837,73 @@ pub struct TraversalResultPageRequest {
 }
 
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum RelationQuery {
-    Session(EntityQueryRequest),
+    #[serde(rename = "session.query")]
+    Session(SessionQueryRequest),
+    #[serde(rename = "session.list")]
     SessionList(SessionListRequest),
-    SessionFrameList(EntityPageRequest),
-    SessionSupersessionSuccessorList(EntityPageRequest),
-    SessionSupersessionPredecessorList(EntityPageRequest),
-    PanelGroup(RevisionQueryRequest),
-    PanelMembershipList(RevisionPageRequest),
-    PanelHistoryList(EntityPageRequest),
-    PanelLineagePredecessorList(EntityPageRequest),
-    PanelLineageSuccessorList(EntityPageRequest),
+    #[serde(rename = "session.frame.list")]
+    SessionFrameList(SessionPageRequest),
+    #[serde(rename = "session.supersession_successor.list")]
+    SessionSupersessionSuccessorList(SessionPageRequest),
+    #[serde(rename = "session.supersession_predecessor.list")]
+    SessionSupersessionPredecessorList(SessionPageRequest),
+    #[serde(rename = "panel_group.query")]
+    PanelGroup(PanelGroupQueryRequest),
+    #[serde(rename = "panel_group.membership.list")]
+    PanelMembershipList(PanelGroupRevisionPageRequest),
+    #[serde(rename = "panel_group.history.list")]
+    PanelHistoryList(PanelGroupPageRequest),
+    #[serde(rename = "panel_group.lineage_predecessor.list")]
+    PanelLineagePredecessorList(PanelGroupPageRequest),
+    #[serde(rename = "panel_group.lineage_successor.list")]
+    PanelLineageSuccessorList(PanelGroupPageRequest),
+    #[serde(rename = "panel_group.list")]
     PanelList(PanelListRequest),
-    Mosaic(RevisionQueryRequest),
-    MosaicPanelList(RevisionPageRequest),
-    MosaicEdgeList(RevisionPageRequest),
-    MosaicHistoryList(EntityPageRequest),
-    MosaicLineagePredecessorList(EntityPageRequest),
-    MosaicLineageSuccessorList(EntityPageRequest),
-    MosaicObjectEvidenceList(RevisionPageRequest),
+    #[serde(rename = "mosaic.query")]
+    Mosaic(MosaicQueryRequest),
+    #[serde(rename = "mosaic.panel.list")]
+    MosaicPanelList(MosaicRevisionPageRequest),
+    #[serde(rename = "mosaic.edge.list")]
+    MosaicEdgeList(MosaicRevisionPageRequest),
+    #[serde(rename = "mosaic.history.list")]
+    MosaicHistoryList(MosaicPageRequest),
+    #[serde(rename = "mosaic.lineage_predecessor.list")]
+    MosaicLineagePredecessorList(MosaicPageRequest),
+    #[serde(rename = "mosaic.lineage_successor.list")]
+    MosaicLineageSuccessorList(MosaicPageRequest),
+    #[serde(rename = "mosaic.object_evidence.list")]
+    MosaicObjectEvidenceList(MosaicRevisionPageRequest),
+    #[serde(rename = "relation_proposal.list")]
     ProposalList(ProposalListRequest),
-    Proposal(EntityQueryRequest),
-    ProposalSourceRevisionList(EntityPageRequest),
-    ProposalSubjectList(EntityPageRequest),
-    ProposalMembershipList(EntityPageRequest),
-    ProposalEdgeList(EntityPageRequest),
-    ProposalLineageList(EntityPageRequest),
+    #[serde(rename = "relation_proposal.query")]
+    Proposal(ProposalQueryRequest),
+    #[serde(rename = "relation_proposal.source_revision.list")]
+    ProposalSourceRevisionList(ProposalPageRequest),
+    #[serde(rename = "relation_proposal.subject.list")]
+    ProposalSubjectList(ProposalPageRequest),
+    #[serde(rename = "relation_proposal.membership.list")]
+    ProposalMembershipList(ProposalPageRequest),
+    #[serde(rename = "relation_proposal.edge.list")]
+    ProposalEdgeList(ProposalPageRequest),
+    #[serde(rename = "relation_proposal.lineage.list")]
+    ProposalLineageList(ProposalPageRequest),
+    #[serde(rename = "relation_proposal.decision_revision.list")]
     DecisionRevisionList(DecisionPageRequest),
+    #[serde(rename = "relation_proposal.decision_retired_group.list")]
     DecisionRetiredGroupList(DecisionPageRequest),
+    #[serde(rename = "relation_proposal.decision_session_supersession.list")]
     DecisionSessionSupersessionList(DecisionPageRequest),
+    #[serde(rename = "relation_proposal.decision_group_lineage.list")]
     DecisionGroupLineageList(DecisionPageRequest),
+    #[serde(rename = "relation_traversal_preview.progress.query")]
     TraversalProgress(TraversalOperationRequest),
+    #[serde(rename = "relation_traversal_preview.result.query")]
     TraversalResult(TraversalOperationRequest),
+    #[serde(rename = "relation_traversal_preview.node.list")]
     TraversalNodeList(TraversalResultPageRequest),
+    #[serde(rename = "relation_traversal_preview.edge.list")]
     TraversalEdgeList(TraversalResultPageRequest),
 }
 
@@ -789,7 +914,7 @@ pub struct ProposedLineage {
     pub successor_group_id: CanonicalId,
 }
 
-#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[derive(Clone, Debug, PartialEq, Serialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct ManualRelationCreateRequest {
     pub relation_kind: ManualRelationKind,
@@ -820,6 +945,86 @@ impl ManualRelationCreateRequest {
             .into_iter()
             .sum::<usize>()
                 > 0
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error when the request cannot describe the selected relation kind.
+    pub fn validate(&self) -> Result<(), &'static str> {
+        if !self.has_required_collections() {
+            return Err("manual relation requires source, subject, and output collections");
+        }
+        if let ManualTargetScope::NewReviewedCrossTarget { canonical_target_ids, .. } =
+            &self.target_scope
+        {
+            let distinct = canonical_target_ids.iter().collect::<std::collections::HashSet<_>>();
+            if distinct.len() < 2 {
+                return Err("reviewed cross-target scope requires two distinct target IDs");
+            }
+        }
+
+        let membership_count = self.proposed_membership_refs.as_ref().map_or(0, BoundedList::len);
+        let edge_count = self.proposed_edges.as_ref().map_or(0, BoundedList::len);
+        let lineage_count = self.proposed_lineage.as_ref().map_or(0, BoundedList::len);
+        let valid = match self.relation_kind {
+            ManualRelationKind::PanelAdd | ManualRelationKind::PanelReplace => {
+                self.source_revision_refs.len() == 1 && membership_count > 0
+            }
+            ManualRelationKind::PanelSplit | ManualRelationKind::PanelMerge => {
+                membership_count > 0 && lineage_count > 0
+            }
+            ManualRelationKind::MosaicCreate => {
+                self.source_revision_refs.len() >= 2 && edge_count > 0
+            }
+            ManualRelationKind::MosaicEdge => {
+                self.source_revision_refs.len() == 2 && edge_count == 1
+            }
+            ManualRelationKind::MosaicSplit | ManualRelationKind::MosaicMerge => {
+                membership_count > 0 && edge_count > 0 && lineage_count > 0
+            }
+        };
+        if !valid {
+            return Err("manual relation collections do not match relation kind");
+        }
+        Ok(())
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ManualRelationCreateWire {
+    relation_kind: ManualRelationKind,
+    source_revision_refs: BoundedList<RevisionRef, 500>,
+    subject_refs: BoundedList<EntityRef, 500>,
+    proposed_membership_refs: Option<BoundedList<EntityRef, 500>>,
+    proposed_edges: Option<BoundedList<MosaicEdge, 500>>,
+    proposed_lineage: Option<BoundedList<ProposedLineage, 500>>,
+    target_scope: ManualTargetScope,
+    evidence: RelationEvidence,
+    review_reason: NonBlankSafeText,
+    mutation_context: MutationContext,
+}
+
+impl<'de> Deserialize<'de> for ManualRelationCreateRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let wire = ManualRelationCreateWire::deserialize(deserializer)?;
+        let request = Self {
+            relation_kind: wire.relation_kind,
+            source_revision_refs: wire.source_revision_refs,
+            subject_refs: wire.subject_refs,
+            proposed_membership_refs: wire.proposed_membership_refs,
+            proposed_edges: wire.proposed_edges,
+            proposed_lineage: wire.proposed_lineage,
+            target_scope: wire.target_scope,
+            evidence: wire.evidence,
+            review_reason: wire.review_reason,
+            mutation_context: wire.mutation_context,
+        };
+        request.validate().map_err(serde::de::Error::custom)?;
+        Ok(request)
     }
 }
 
@@ -889,13 +1094,19 @@ pub struct TraversalCancelRequest {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum RelationCommand {
+    #[serde(rename = "relation_proposal.manual.create")]
     ManualCreate(ManualRelationCreateRequest),
+    #[serde(rename = "relation_proposal.accept")]
     ProposalAccept(ProposalAcceptRequest),
+    #[serde(rename = "relation_proposal.reject")]
     ProposalReject(ProposalRejectRequest),
+    #[serde(rename = "relation_proposal.correct")]
     ProposalCorrect(ProposalCorrectRequest),
+    #[serde(rename = "relation_traversal_preview.start")]
     TraversalStart(TraversalStartRequest),
+    #[serde(rename = "relation_traversal_preview.cancel")]
     TraversalCancel(TraversalCancelRequest),
 }
 

--- a/crates/contracts/core/src/sessions/heterogeneity/settings.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/settings.rs
@@ -1,0 +1,500 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Matching-settings contracts.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use specta::Type;
+
+use super::shared::{
+    BoundedList, CanonicalId, FiniteDecimal, MutationContext, Rfc3339Timestamp, SafeText,
+};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SettingsSeverity {
+    Yellow,
+    Red,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CalibrationAgeKind {
+    Dark,
+    Bias,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GeometryThresholds {
+    pub coverage_min_percent: FiniteDecimal,
+    pub center_separation_max_percent: FiniteDecimal,
+    pub rotation_max_deg: FiniteDecimal,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MosaicThresholds {
+    pub overlap_min_percent: FiniteDecimal,
+    pub overlap_max_percent: FiniteDecimal,
+    pub residual_sky_rotation_cap_deg: FiniteDecimal,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct DarkThermalThresholds {
+    pub moderate_deg: FiniteDecimal,
+    pub severe_deg: FiniteDecimal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CalibrationAgePolicy {
+    pub camera_id: CanonicalId,
+    pub kind: CalibrationAgeKind,
+    pub fresh_through_days: u32,
+    pub red_after_days: u32,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FlatOrientationThresholds {
+    pub normal_through_deg: FiniteDecimal,
+    pub red_above_deg: FiniteDecimal,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FlatAgeThresholds {
+    pub red_after_nights: u32,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FixedMatchingRules {
+    pub optical_profile_same_max_percent: u32,
+    pub optical_profile_review_max_percent: u32,
+    pub optical_profile_evidence_conflict_percent: u32,
+    pub flat_same_night_fresh_max_nights: u32,
+    pub flat_yellow_starts_nights: u32,
+}
+
+impl Default for FixedMatchingRules {
+    fn default() -> Self {
+        Self {
+            optical_profile_same_max_percent: 5,
+            optical_profile_review_max_percent: 10,
+            optical_profile_evidence_conflict_percent: 10,
+            flat_same_night_fresh_max_nights: 1,
+            flat_yellow_starts_nights: 2,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettings {
+    pub revision: u64,
+    pub same_session: GeometryThresholds,
+    pub sibling: GeometryThresholds,
+    pub mosaic: MosaicThresholds,
+    pub dark_thermal: DarkThermalThresholds,
+    pub calibration_age: BoundedList<CalibrationAgePolicy, 500>,
+    pub flat_orientation: FlatOrientationThresholds,
+    pub flat_age: FlatAgeThresholds,
+    pub fixed_rules: FixedMatchingRules,
+    pub updated_at: Rfc3339Timestamp,
+    pub updated_by: CanonicalId,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsValue {
+    pub field_path: SafeText,
+    #[serde(flatten)]
+    pub value: SettingsScalar,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum SettingsScalar {
+    Decimal(FiniteDecimal),
+    Unsigned(u32),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsIssue {
+    pub code: SafeText,
+    pub severity: SettingsSeverity,
+    pub field_paths: BoundedList<SafeText, 50>,
+    pub values: BoundedList<SettingsValue, 50>,
+    pub message_key: SafeText,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct SettingsValidation {
+    pub valid: bool,
+    pub issues: BoundedList<SettingsIssue, 500>,
+    pub effective: MatchingSettings,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct GeometryThresholdPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub coverage_min_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub center_separation_max_percent: Option<FiniteDecimal>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub rotation_max_deg: Option<FiniteDecimal>,
+}
+
+#[derive(Clone, Debug, Default, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettingsPatch {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub same_session: Option<GeometryThresholdPatch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub sibling: Option<GeometryThresholdPatch>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mosaic: Option<MosaicThresholds>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub dark_thermal: Option<DarkThermalThresholds>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub calibration_age: Option<BoundedList<CalibrationAgePolicy, 500>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flat_orientation: Option<FlatOrientationThresholds>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub flat_age: Option<FlatAgeThresholds>,
+}
+
+impl MatchingSettings {
+    #[must_use]
+    pub fn apply_patch(&self, patch: &MatchingSettingsPatch) -> Self {
+        let mut effective = self.clone();
+        if let Some(value) = &patch.same_session {
+            apply_geometry_patch(&mut effective.same_session, value);
+        }
+        if let Some(value) = &patch.sibling {
+            apply_geometry_patch(&mut effective.sibling, value);
+        }
+        if let Some(value) = &patch.mosaic {
+            effective.mosaic = value.clone();
+        }
+        if let Some(value) = &patch.dark_thermal {
+            effective.dark_thermal = value.clone();
+        }
+        if let Some(value) = &patch.calibration_age {
+            effective.calibration_age = value.clone();
+        }
+        if let Some(value) = &patch.flat_orientation {
+            effective.flat_orientation = value.clone();
+        }
+        if let Some(value) = &patch.flat_age {
+            effective.flat_age = value.clone();
+        }
+        effective
+    }
+
+    #[must_use]
+    /// # Panics
+    ///
+    /// Panics only if the fixed set of validation rules produces more than 500 issues.
+    #[allow(clippy::too_many_lines)]
+    pub fn validate(&self) -> SettingsValidation {
+        let mut issues = Vec::new();
+        check_range(
+            &mut issues,
+            "sameSession.coverageMinPercent",
+            self.same_session.coverage_min_percent,
+            90.0,
+            99.5,
+            Some((93.0, false)),
+        );
+        check_range(
+            &mut issues,
+            "sameSession.centerSeparationMaxPercent",
+            self.same_session.center_separation_max_percent,
+            0.5,
+            5.0,
+            Some((3.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "sameSession.rotationMaxDeg",
+            self.same_session.rotation_max_deg,
+            0.25,
+            3.0,
+            Some((2.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "sibling.coverageMinPercent",
+            self.sibling.coverage_min_percent,
+            80.0,
+            95.0,
+            Some((85.0, false)),
+        );
+        check_range(
+            &mut issues,
+            "sibling.centerSeparationMaxPercent",
+            self.sibling.center_separation_max_percent,
+            2.0,
+            15.0,
+            Some((10.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "sibling.rotationMaxDeg",
+            self.sibling.rotation_max_deg,
+            1.0,
+            15.0,
+            Some((10.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "mosaic.overlapMinPercent",
+            self.mosaic.overlap_min_percent,
+            1.0,
+            20.0,
+            Some((3.0, false)),
+        );
+        check_range(
+            &mut issues,
+            "mosaic.overlapMaxPercent",
+            self.mosaic.overlap_max_percent,
+            20.0,
+            60.0,
+            Some((50.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "darkThermal.moderateDeg",
+            self.dark_thermal.moderate_deg,
+            0.1,
+            2.0,
+            Some((1.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "darkThermal.severeDeg",
+            self.dark_thermal.severe_deg,
+            0.5,
+            5.0,
+            Some((3.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "flatOrientation.normalThroughDeg",
+            self.flat_orientation.normal_through_deg,
+            0.5,
+            5.0,
+            Some((3.0, true)),
+        );
+        check_range(
+            &mut issues,
+            "flatOrientation.redAboveDeg",
+            self.flat_orientation.red_above_deg,
+            0.5,
+            15.0,
+            Some((8.0, true)),
+        );
+        if !(7..=365).contains(&self.flat_age.red_after_nights) {
+            issues.push(issue(
+                "settings.out_of_bounds",
+                SettingsSeverity::Red,
+                "flatAge.redAfterNights",
+            ));
+        } else if self.flat_age.red_after_nights > 90 {
+            issues.push(issue(
+                "settings.warning.flat_age",
+                SettingsSeverity::Yellow,
+                "flatAge.redAfterNights",
+            ));
+        }
+        for policy in &self.calibration_age {
+            if policy.fresh_through_days > 1_795 || !(30..=1_825).contains(&policy.red_after_days) {
+                issues.push(issue(
+                    "settings.out_of_bounds",
+                    SettingsSeverity::Red,
+                    "calibrationAge",
+                ));
+            }
+            if policy.red_after_days < policy.fresh_through_days.saturating_add(30) {
+                issues.push(issue(
+                    "settings.calibration_age_gap",
+                    SettingsSeverity::Red,
+                    "calibrationAge",
+                ));
+            } else if policy.red_after_days > 730 {
+                issues.push(issue(
+                    "settings.warning.calibration_age",
+                    SettingsSeverity::Yellow,
+                    "calibrationAge",
+                ));
+            }
+        }
+        cross_constraints(self, &mut issues);
+        let valid = !issues.iter().any(|item| item.severity == SettingsSeverity::Red);
+        SettingsValidation {
+            valid,
+            issues: BoundedList::try_new(issues).expect("settings checks are bounded"),
+            effective: self.clone(),
+        }
+    }
+}
+
+fn apply_geometry_patch(target: &mut GeometryThresholds, patch: &GeometryThresholdPatch) {
+    if let Some(value) = patch.coverage_min_percent {
+        target.coverage_min_percent = value;
+    }
+    if let Some(value) = patch.center_separation_max_percent {
+        target.center_separation_max_percent = value;
+    }
+    if let Some(value) = patch.rotation_max_deg {
+        target.rotation_max_deg = value;
+    }
+}
+
+fn safe(value: &str) -> SafeText {
+    SafeText::try_new(value).expect("static settings text is safe")
+}
+
+fn issue(code: &str, severity: SettingsSeverity, field_path: &str) -> SettingsIssue {
+    SettingsIssue {
+        code: safe(code),
+        severity,
+        field_paths: BoundedList::try_new(vec![safe(field_path)]).expect("one field path"),
+        values: BoundedList::default(),
+        message_key: safe(code),
+    }
+}
+
+fn check_range(
+    issues: &mut Vec<SettingsIssue>,
+    field: &str,
+    value: FiniteDecimal,
+    min: f64,
+    max: f64,
+    warning: Option<(f64, bool)>,
+) {
+    if !(min..=max).contains(&value.get()) {
+        issues.push(issue("settings.out_of_bounds", SettingsSeverity::Red, field));
+    } else if let Some((boundary, warn_above)) = warning {
+        if (warn_above && value.get() > boundary) || (!warn_above && value.get() < boundary) {
+            issues.push(issue("settings.warning.risky_value", SettingsSeverity::Yellow, field));
+        }
+    }
+}
+
+fn cross_constraints(settings: &MatchingSettings, issues: &mut Vec<SettingsIssue>) {
+    if settings.sibling.coverage_min_percent > settings.same_session.coverage_min_percent {
+        issues.push(issue(
+            "settings.sibling_coverage_stricter",
+            SettingsSeverity::Red,
+            "sibling.coverageMinPercent",
+        ));
+    }
+    if settings.sibling.center_separation_max_percent
+        < settings.same_session.center_separation_max_percent
+    {
+        issues.push(issue(
+            "settings.sibling_center_stricter",
+            SettingsSeverity::Red,
+            "sibling.centerSeparationMaxPercent",
+        ));
+    }
+    if settings.sibling.rotation_max_deg < settings.same_session.rotation_max_deg {
+        issues.push(issue(
+            "settings.sibling_rotation_stricter",
+            SettingsSeverity::Red,
+            "sibling.rotationMaxDeg",
+        ));
+    }
+    if settings.mosaic.overlap_min_percent >= settings.mosaic.overlap_max_percent {
+        issues.push(issue(
+            "settings.mosaic_overlap_order",
+            SettingsSeverity::Red,
+            "mosaic.overlapMinPercent",
+        ));
+    }
+    if settings.mosaic.overlap_max_percent.get()
+        > settings.sibling.coverage_min_percent.get() - 10.0
+    {
+        issues.push(issue(
+            "settings.mosaic_sibling_gap",
+            SettingsSeverity::Red,
+            "mosaic.overlapMaxPercent",
+        ));
+    }
+    if settings.dark_thermal.severe_deg.get() < settings.dark_thermal.moderate_deg.get() + 0.5 {
+        issues.push(issue(
+            "settings.dark_thermal_gap",
+            SettingsSeverity::Red,
+            "darkThermal.severeDeg",
+        ));
+    }
+    if settings.flat_orientation.red_above_deg <= settings.flat_orientation.normal_through_deg {
+        issues.push(issue(
+            "settings.flat_orientation_order",
+            SettingsSeverity::Red,
+            "flatOrientation.redAboveDeg",
+        ));
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettingsGetRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub revision: Option<u64>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettingsValidateRequest {
+    pub base_revision: u64,
+    pub patch: MatchingSettingsPatch,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettingsUpdateRequest {
+    pub expected_revision: u64,
+    pub patch: MatchingSettingsPatch,
+    pub acknowledged_warning_codes: BoundedList<SafeText, 500>,
+    pub mutation_context: MutationContext,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettingsUpdateResponse {
+    pub settings: MatchingSettings,
+    pub warnings: BoundedList<SettingsIssue, 500>,
+    pub audit_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MatchingSettingsUpdatedEvent {
+    pub previous_revision: u64,
+    pub revision: u64,
+    pub changed_field_paths: BoundedList<SafeText, 500>,
+    pub warning_codes: BoundedList<SafeText, 500>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum MatchingSettingsQuery {
+    Get(MatchingSettingsGetRequest),
+    Validate(MatchingSettingsValidateRequest),
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+pub enum MatchingSettingsCommand {
+    Update(MatchingSettingsUpdateRequest),
+}

--- a/crates/contracts/core/src/sessions/heterogeneity/settings.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/settings.rs
@@ -532,6 +532,13 @@ pub struct MatchingSettingsUpdatedEvent {
     pub warning_codes: BoundedList<SafeText, 500>,
 }
 
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "event")]
+pub enum MatchingSettingsEvent {
+    #[serde(rename = "matching_settings.updated")]
+    Updated(MatchingSettingsUpdatedEvent),
+}
+
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(tag = "operation")]
 pub enum MatchingSettingsQuery {

--- a/crates/contracts/core/src/sessions/heterogeneity/settings.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/settings.rs
@@ -306,7 +306,7 @@ impl MatchingSettings {
             60.0,
             Some((50.0, true)),
         );
-        if self.mosaic.residual_sky_rotation_cap_deg.get() != 90.0 {
+        if (self.mosaic.residual_sky_rotation_cap_deg.get() - 90.0).abs() > f64::EPSILON {
             issues.push(issue(
                 "settings.fixed_rule_changed",
                 SettingsSeverity::Red,

--- a/crates/contracts/core/src/sessions/heterogeneity/settings.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/settings.rs
@@ -70,13 +70,18 @@ pub struct FlatAgeThresholds {
     pub red_after_nights: u32,
 }
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct FixedMatchingRules {
+    #[schemars(range(min = 5, max = 5))]
     pub optical_profile_same_max_percent: u32,
+    #[schemars(range(min = 10, max = 10))]
     pub optical_profile_review_max_percent: u32,
+    #[schemars(range(min = 10, max = 10))]
     pub optical_profile_evidence_conflict_percent: u32,
+    #[schemars(range(min = 1, max = 1))]
     pub flat_same_night_fresh_max_nights: u32,
+    #[schemars(range(min = 2, max = 2))]
     pub flat_yellow_starts_nights: u32,
 }
 
@@ -89,6 +94,37 @@ impl Default for FixedMatchingRules {
             flat_same_night_fresh_max_nights: 1,
             flat_yellow_starts_nights: 2,
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for FixedMatchingRules {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire {
+            optical_profile_same_max_percent: u32,
+            optical_profile_review_max_percent: u32,
+            optical_profile_evidence_conflict_percent: u32,
+            flat_same_night_fresh_max_nights: u32,
+            flat_yellow_starts_nights: u32,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let rules = Self {
+            optical_profile_same_max_percent: wire.optical_profile_same_max_percent,
+            optical_profile_review_max_percent: wire.optical_profile_review_max_percent,
+            optical_profile_evidence_conflict_percent: wire
+                .optical_profile_evidence_conflict_percent,
+            flat_same_night_fresh_max_nights: wire.flat_same_night_fresh_max_nights,
+            flat_yellow_starts_nights: wire.flat_yellow_starts_nights,
+        };
+        if rules != Self::default() {
+            return Err(serde::de::Error::custom("fixed matching rules cannot be changed"));
+        }
+        Ok(rules)
     }
 }
 
@@ -270,6 +306,13 @@ impl MatchingSettings {
             60.0,
             Some((50.0, true)),
         );
+        if self.mosaic.residual_sky_rotation_cap_deg.get() != 90.0 {
+            issues.push(issue(
+                "settings.fixed_rule_changed",
+                SettingsSeverity::Red,
+                "mosaic.residualSkyRotationCapDeg",
+            ));
+        }
         check_range(
             &mut issues,
             "darkThermal.moderateDeg",
@@ -336,6 +379,9 @@ impl MatchingSettings {
                     "calibrationAge",
                 ));
             }
+        }
+        if self.fixed_rules != FixedMatchingRules::default() {
+            issues.push(issue("settings.fixed_rule_changed", SettingsSeverity::Red, "fixedRules"));
         }
         cross_constraints(self, &mut issues);
         let valid = !issues.iter().any(|item| item.severity == SettingsSeverity::Red);
@@ -487,14 +533,17 @@ pub struct MatchingSettingsUpdatedEvent {
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum MatchingSettingsQuery {
+    #[serde(rename = "matching_settings.get")]
     Get(MatchingSettingsGetRequest),
+    #[serde(rename = "matching_settings.validate")]
     Validate(MatchingSettingsValidateRequest),
 }
 
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
-#[serde(tag = "operation", content = "payload", rename_all = "snake_case")]
+#[serde(tag = "operation")]
 pub enum MatchingSettingsCommand {
+    #[serde(rename = "matching_settings.update")]
     Update(MatchingSettingsUpdateRequest),
 }

--- a/crates/contracts/core/src/sessions/heterogeneity/shared.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/shared.rs
@@ -1110,6 +1110,7 @@ fn domain_details_match(code: ErrorCode, details: &SafeErrorDetails) -> bool {
         .all(|value| allowed.contains(&value.name.as_str()) && seen.insert(value.name.as_str()))
 }
 
+#[allow(clippy::match_same_arms, clippy::too_many_lines)]
 fn domain_detail_fields(code: ErrorCode) -> &'static [&'static str] {
     match code {
         ErrorCode::SessionNotFound => &["sessionId"],

--- a/crates/contracts/core/src/sessions/heterogeneity/shared.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/shared.rs
@@ -400,7 +400,9 @@ string_schema!(
         "type": "string",
         "minLength": 1,
         "maxLength": 4096,
-        "pattern": r"^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\.\.?/)(?!.*\\).+$",
+        "pattern": r"^(?!/)(?![A-Za-z]:)(?!.*\\)(?!.*(?:^|/)\.\.?(/|$))(?:[^/\u0000]{1,255})(?:/[^/\u0000]{1,255}){0,63}$",
+        "x-maxUtf8Bytes": 4096,
+        "x-maxSegmentUtf8Bytes": 255,
     })
 );
 
@@ -786,16 +788,14 @@ pub enum SafeErrorDetails {
         actual_revision: u64,
     },
     StaleRevisions {
+        proposal_id: CanonicalId,
         revisions: BoundedList<RevisionRef, 500>,
         total_count: u64,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        decision_snapshot_id: Option<CanonicalId>,
+        truncated: bool,
     },
     Violations {
+        proposal_id: CanonicalId,
         violations: BoundedList<Violation, 100>,
-        total_count: u64,
-        #[serde(skip_serializing_if = "Option::is_none")]
-        decision_snapshot_id: Option<CanonicalId>,
     },
     Idempotency {
         command_id: CanonicalId,
@@ -805,6 +805,7 @@ pub enum SafeErrorDetails {
         operation_id: CanonicalId,
     },
     AuthorizedPath {
+        plan_id: CanonicalId,
         item_id: CanonicalId,
         #[serde(skip_serializing_if = "Option::is_none")]
         relative_path: Option<CanonicalRelativePath>,
@@ -1093,7 +1094,8 @@ impl PortableContractError {
 }
 
 fn domain_details_match(code: ErrorCode, details: &SafeErrorDetails) -> bool {
-    let SafeErrorDetails::Domain { code: detail_code, values, .. } = details else {
+    let SafeErrorDetails::Domain { code: detail_code, values, decision_snapshot_id } = details
+    else {
         return false;
     };
     let Ok(serialized_code) = serde_json::to_value(code) else {
@@ -1104,10 +1106,29 @@ fn domain_details_match(code: ErrorCode, details: &SafeErrorDetails) -> bool {
     }
 
     let allowed = domain_detail_fields(code);
+    let optional = domain_optional_detail_fields(code);
     let mut seen = std::collections::HashSet::with_capacity(values.len());
-    values
-        .iter()
-        .all(|value| allowed.contains(&value.name.as_str()) && seen.insert(value.name.as_str()))
+    let values_valid = values.iter().all(|value| {
+        value.name.as_str() != "decisionSnapshotId"
+            && allowed.contains(&value.name.as_str())
+            && seen.insert(value.name.as_str())
+    });
+    let required_present = allowed.iter().all(|field| {
+        optional.contains(field)
+            || (*field == "decisionSnapshotId" && decision_snapshot_id.is_some())
+            || seen.contains(field)
+    });
+    let snapshot_allowed =
+        decision_snapshot_id.is_none() || allowed.contains(&"decisionSnapshotId");
+    values_valid && required_present && snapshot_allowed
+}
+
+fn domain_optional_detail_fields(code: ErrorCode) -> &'static [&'static str] {
+    match code {
+        ErrorCode::CalibrationHandoffTooLarge => &["handoffId", "sessionId"],
+        ErrorCode::CalibrationHandoffNotFound => &["snapshotId"],
+        _ => &[],
+    }
 }
 
 #[allow(clippy::match_same_arms, clippy::too_many_lines)]
@@ -1137,11 +1158,10 @@ fn domain_detail_fields(code: ErrorCode) -> &'static [&'static str] {
         ErrorCode::TraversalEdgeCeilingExceeded => &["operationId", "maxEdges", "visitedEdgeCount"],
         ErrorCode::TraversalDepthCeilingExceeded => &["operationId", "maxDepth", "deepestLevel"],
         ErrorCode::TraversalCancellationDeadlineExceeded => &["operationId", "cancelRequestedAt"],
-        ErrorCode::InboxPlanNotFound
-        | ErrorCode::InboxPlanNotOpen
-        | ErrorCode::InboxPlanNotApproved
-        | ErrorCode::InboxPlanDigestMismatch
-        | ErrorCode::InboxPlanStale => &["planId", "planRevision", "decisionSnapshotId"],
+        ErrorCode::InboxPlanNotFound => &["planId", "planRevision"],
+        ErrorCode::InboxPlanNotOpen | ErrorCode::InboxPlanNotApproved => &["planId", "state"],
+        ErrorCode::InboxPlanDigestMismatch => &["planId", "expectedDigest", "actualDigest"],
+        ErrorCode::InboxPlanStale => &["planId", "staleRevisionCount", "decisionSnapshotId"],
         ErrorCode::InboxSiteResolutionNotFound => &["planId", "resolutionRevision"],
         ErrorCode::InboxPlanResultSnapshotNotFound => &["planId", "planResultSnapshotId"],
         ErrorCode::InboxProposedSessionNotFound => {
@@ -1152,77 +1172,90 @@ fn domain_detail_fields(code: ErrorCode) -> &'static [&'static str] {
         ErrorCode::InboxTimestampConflict => &["planId", "conflictCount", "decisionSnapshotId"],
         ErrorCode::MaterializationOperationNotFound => &["operationId"],
         ErrorCode::MaterializationResultSnapshotNotFound => &["operationId", "resultSnapshotId"],
-        ErrorCode::MetadataEvidenceNotFound => &["metadataEvidenceId"],
-        ErrorCode::MetadataIdentityBlocked => &["metadataEvidenceId", "reasonCodes"],
-        ErrorCode::MetadataObservingNightConflict => {
-            &["metadataEvidenceId", "conflictCount", "decisionSnapshotId"]
+        ErrorCode::MetadataEvidenceNotFound => &["sessionId", "evidenceRevision"],
+        ErrorCode::MetadataIdentityBlocked => &["sessionId", "fieldStates"],
+        ErrorCode::MetadataObservingNightConflict => &["sessionId", "evidenceRefs"],
+        ErrorCode::EquipmentResolutionNotFound => &["sessionId", "resolutionRevision"],
+        ErrorCode::EquipmentNotRegistered => &["equipmentType", "equipmentId"],
+        ErrorCode::EquipmentOpticalProfileReviewRequired => &["sessionId", "differences"],
+        ErrorCode::CalibrationCoolingSetPointRequired => &["sessionId", "cameraId"],
+        ErrorCode::CalibrationFlatGainRequired => &["sessionId", "evidenceRefs"],
+        ErrorCode::CalibrationDarkFlatUnsupported => &["sourceRecordId"],
+        ErrorCode::ReclassificationPlanNotFound => &["planId"],
+        ErrorCode::ReclassificationPlanNotOpen => &["planId", "state"],
+        ErrorCode::ReclassificationPlanStale => {
+            &["planId", "staleRevisionCount", "decisionSnapshotId"]
         }
-        ErrorCode::EquipmentResolutionNotFound => &["resolutionId"],
-        ErrorCode::EquipmentNotRegistered => &["equipmentId", "equipmentKind"],
-        ErrorCode::EquipmentOpticalProfileReviewRequired => {
-            &["resolutionId", "candidateCount", "decisionSnapshotId"]
-        }
-        ErrorCode::CalibrationCoolingSetPointRequired
-        | ErrorCode::CalibrationFlatGainRequired
-        | ErrorCode::CalibrationDarkFlatUnsupported => &["frameId", "sessionId"],
-        ErrorCode::ReclassificationPlanNotFound
-        | ErrorCode::ReclassificationPlanNotOpen
-        | ErrorCode::ReclassificationPlanStale => &["planId", "planRevision"],
         ErrorCode::ReclassificationInvalidPartition => {
             &["planId", "violationCount", "decisionSnapshotId"]
         }
-        ErrorCode::ReclassificationReplacementNotFound => &["planId", "replacementId"],
-        ErrorCode::ReclassificationPanelConsequenceNotFound => &["planId", "panelConsequenceId"],
-        ErrorCode::ReclassificationResultSnapshotNotFound
-        | ErrorCode::ReclassificationApplyResultSnapshotNotFound => &["planId", "resultSnapshotId"],
-        ErrorCode::MatchingSettingsRevisionNotFound => &["revision"],
-        ErrorCode::MatchingSettingsOutOfBounds
-        | ErrorCode::MatchingSettingsCrossConstraint
-        | ErrorCode::MatchingSettingsWarningUnacknowledged => {
-            &["revision", "issueCount", "decisionSnapshotId"]
+        ErrorCode::ReclassificationReplacementNotFound => &["planId", "replacementKey"],
+        ErrorCode::ReclassificationPanelConsequenceNotFound => {
+            &["planId", "planResultSnapshotId", "proposedDestinationPanelGroupId"]
         }
-        ErrorCode::CalibrationRequirementInvalid => &["requirementId", "reasonCodes"],
-        ErrorCode::CalibrationCandidateNotFound
-        | ErrorCode::CalibrationCandidateBlocked
-        | ErrorCode::CalibrationCandidateIncompatible => &["candidateId", "reasonCodes"],
+        ErrorCode::ReclassificationResultSnapshotNotFound => &["planId", "planResultSnapshotId"],
+        ErrorCode::ReclassificationApplyResultSnapshotNotFound => {
+            &["planId", "applyResultSnapshotId"]
+        }
+        ErrorCode::MatchingSettingsRevisionNotFound => &["revision"],
+        ErrorCode::MatchingSettingsOutOfBounds | ErrorCode::MatchingSettingsCrossConstraint => {
+            &["issues"]
+        }
+        ErrorCode::MatchingSettingsWarningUnacknowledged => &["warningCodes"],
+        ErrorCode::CalibrationRequirementInvalid => &["requirementId", "fields"],
+        ErrorCode::CalibrationCandidateNotFound => &["sessionId", "requirementId"],
+        ErrorCode::CalibrationCandidateBlocked => &["sessionId", "requirementId", "blockingCodes"],
+        ErrorCode::CalibrationCandidateIncompatible => {
+            &["sessionId", "requirementId", "evidenceId"]
+        }
         ErrorCode::CalibrationHandoffTooLarge => {
             &["handoffId", "sessionId", "sourceByteCount", "maximumSourceBytes"]
         }
         ErrorCode::CalibrationHandoffOperationNotCancellable => {
             &["operationId", "state", "cancelSafe"]
         }
-        ErrorCode::CalibrationWarningUnacknowledged => &["warningCodes"],
-        ErrorCode::CalibrationSelectionDuplicate => &["selectionId", "sessionId"],
-        ErrorCode::CalibrationHandoffNotFound | ErrorCode::CalibrationHandoffStaleBasis => {
-            &["handoffId", "revision"]
+        ErrorCode::CalibrationWarningUnacknowledged => &["sessionId", "warningCodes"],
+        ErrorCode::CalibrationSelectionDuplicate => &["snapshotId", "sessionId", "requirementId"],
+        ErrorCode::CalibrationHandoffNotFound => &["handoffId", "snapshotId"],
+        ErrorCode::CalibrationHandoffStaleBasis => {
+            &["snapshotId", "expectedBasisFingerprint", "actualBasisFingerprint"]
         }
-        ErrorCode::CalibrationSourceUnavailable | ErrorCode::CalibrationSourceIdentityChanged => {
-            &["selectionId", "frameId"]
-        }
-        ErrorCode::CalibrationPageInvalid | ErrorCode::CalibrationPageStale => {
-            &["handoffId", "cursor"]
+        ErrorCode::CalibrationSourceUnavailable => &["sessionId", "frameId", "evidenceId"],
+        ErrorCode::CalibrationSourceIdentityChanged => &["snapshotId", "frameId", "fileRecordId"],
+        ErrorCode::CalibrationPageInvalid => &["field"],
+        ErrorCode::CalibrationPageStale => {
+            &["expectedProjectionRevision", "actualProjectionRevision"]
         }
         ErrorCode::ProjectNotFound => &["projectId"],
-        ErrorCode::ProjectSessionNotFound
-        | ErrorCode::ProjectSessionAlreadyPinned
-        | ErrorCode::ProjectSessionNotPinned
-        | ErrorCode::ProjectLifecycleDisallowsSessionAdd
-        | ErrorCode::ProjectReclassificationRevisionInvalid => {
-            &["projectId", "sessionId", "revisionId", "lifecycleState"]
+        ErrorCode::ProjectSessionNotFound => &["sessionId"],
+        ErrorCode::ProjectSessionAlreadyPinned | ErrorCode::ProjectSessionNotPinned => {
+            &["projectId", "sessionId"]
         }
-        ErrorCode::ProjectUpdateViewNoAdditions => &["projectId"],
-        ErrorCode::ProjectUpdateViewPlanNotFound
-        | ErrorCode::ProjectUpdateViewPlanNotOpen
-        | ErrorCode::ProjectUpdateViewPlanNotApproved
-        | ErrorCode::ProjectUpdateViewPlanStale
-        | ErrorCode::ProjectUpdateViewPlanDigestMismatch => {
-            &["projectId", "planId", "planRevision"]
+        ErrorCode::ProjectLifecycleDisallowsSessionAdd => &["projectId", "lifecycle"],
+        ErrorCode::ProjectReclassificationRevisionInvalid => &[
+            "appliedReclassificationPlanRevisionId",
+            "predecessorSessionId",
+            "replacementSessionIds",
+        ],
+        ErrorCode::ProjectUpdateViewNoAdditions => &["projectId", "materializedSnapshotId"],
+        ErrorCode::ProjectUpdateViewPlanNotFound => &["planId"],
+        ErrorCode::ProjectUpdateViewPlanNotOpen | ErrorCode::ProjectUpdateViewPlanNotApproved => {
+            &["planId", "state"]
         }
-        ErrorCode::ProjectUpdateViewSourceUnavailable
-        | ErrorCode::ProjectUpdateViewRootChanged
-        | ErrorCode::ProjectUpdateViewSessionTooLarge => {
-            &["projectId", "planId", "sessionId", "sourceByteCount", "maximumSourceBytes"]
-        }
+        ErrorCode::ProjectUpdateViewPlanStale => &["planId", "staleRefs"],
+        ErrorCode::ProjectUpdateViewPlanDigestMismatch => &["planId", "approvalId"],
+        ErrorCode::ProjectUpdateViewSourceUnavailable => &["planId", "itemId", "fileRecordId"],
+        ErrorCode::ProjectUpdateViewRootChanged => &["planId", "rootId"],
+        ErrorCode::ProjectUpdateViewSessionTooLarge => &[
+            "projectId",
+            "sessionId",
+            "itemCount",
+            "sourceFrameCount",
+            "sourceByteCount",
+            "maximumItems",
+            "maximumSourceFrames",
+            "maximumSourceBytes",
+        ],
         ErrorCode::ProjectUpdateViewOperationNotCancellable => {
             &["operationId", "state", "cancelSafe"]
         }

--- a/crates/contracts/core/src/sessions/heterogeneity/shared.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/shared.rs
@@ -3,10 +3,11 @@
 
 //! Shared bounded scalars, envelopes, pagination, authorization, and command contracts.
 
+use std::borrow::Cow;
 use std::fmt;
 use std::ops::Deref;
 
-use schemars::JsonSchema;
+use schemars::{json_schema, JsonSchema, Schema, SchemaGenerator};
 use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
 use specta::Type;
 
@@ -39,10 +40,28 @@ impl fmt::Display for ValidationError {
 
 impl std::error::Error for ValidationError {}
 
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type, JsonSchema)]
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type)]
 #[serde(transparent)]
 #[specta(transparent)]
 pub struct BoundedList<T, const MAX: usize>(Vec<T>);
+
+impl<T: JsonSchema, const MAX: usize> JsonSchema for BoundedList<T, MAX> {
+    fn schema_name() -> Cow<'static, str> {
+        format!("BoundedList_{}_{}", T::schema_name(), MAX).into()
+    }
+
+    fn schema_id() -> Cow<'static, str> {
+        format!("{}::BoundedList<{},{}>", module_path!(), T::schema_id(), MAX).into()
+    }
+
+    fn json_schema(generator: &mut SchemaGenerator) -> Schema {
+        json_schema!({
+            "type": "array",
+            "items": generator.subschema_for::<T>(),
+            "maxItems": MAX,
+        })
+    }
+}
 
 impl<T, const MAX: usize> BoundedList<T, MAX> {
     /// # Errors
@@ -132,9 +151,7 @@ where
 
 macro_rules! validated_string {
     ($name:ident, $validator:ident) => {
-        #[derive(
-            Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Type, JsonSchema,
-        )]
+        #[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Type)]
         #[serde(transparent)]
         #[specta(transparent)]
         pub struct $name(String);
@@ -180,6 +197,24 @@ macro_rules! validated_string {
     };
 }
 
+macro_rules! string_schema {
+    ($name:ident, $schema:expr) => {
+        impl JsonSchema for $name {
+            fn schema_name() -> Cow<'static, str> {
+                stringify!($name).into()
+            }
+
+            fn schema_id() -> Cow<'static, str> {
+                concat!(module_path!(), "::", stringify!($name)).into()
+            }
+
+            fn json_schema(_: &mut SchemaGenerator) -> Schema {
+                $schema
+            }
+        }
+    };
+}
+
 fn validate_safe_text(value: &str) -> Result<(), ValidationError> {
     if value.len() > MAX_SAFE_TEXT_BYTES || value.chars().count() > MAX_SAFE_TEXT_SCALARS {
         return Err(ValidationError::new("text", "text_too_long"));
@@ -203,6 +238,18 @@ fn validate_canonical_id(value: &str) -> Result<(), ValidationError> {
         uuid::Uuid::parse_str(value).map_err(|_| ValidationError::new("id", "uuid_invalid"))?;
     if value.len() != 36 || parsed.hyphenated().to_string() != value {
         return Err(ValidationError::new("id", "uuid_not_canonical"));
+    }
+    if parsed.get_version_num() != 7 {
+        return Err(ValidationError::new("id", "uuid_version_invalid"));
+    }
+    Ok(())
+}
+
+fn validate_canonical_uuid(value: &str) -> Result<(), ValidationError> {
+    let parsed =
+        uuid::Uuid::parse_str(value).map_err(|_| ValidationError::new("uuid", "uuid_invalid"))?;
+    if value.len() != 36 || parsed.hyphenated().to_string() != value {
+        return Err(ValidationError::new("uuid", "uuid_not_canonical"));
     }
     Ok(())
 }
@@ -280,6 +327,7 @@ fn validate_relative_path(value: &str) -> Result<(), ValidationError> {
 validated_string!(SafeText, validate_safe_text);
 validated_string!(NonBlankSafeText, validate_non_blank_safe_text);
 validated_string!(CanonicalId, validate_canonical_id);
+validated_string!(CanonicalUuid, validate_canonical_uuid);
 validated_string!(Digest, validate_digest);
 validated_string!(Cursor, validate_cursor);
 validated_string!(Rfc3339Timestamp, validate_timestamp);
@@ -287,6 +335,74 @@ validated_string!(LocalDate, validate_local_date);
 validated_string!(StableIdentity, validate_stable_identity);
 validated_string!(DestinationCollisionKey, validate_collision_key);
 validated_string!(CanonicalRelativePath, validate_relative_path);
+
+string_schema!(
+    SafeText,
+    json_schema!({
+        "type": "string",
+        "maxLength": MAX_SAFE_TEXT_SCALARS,
+        "pattern": r"^[^\u0000-\u001f\u007f-\u009f]*$",
+    })
+);
+string_schema!(
+    NonBlankSafeText,
+    json_schema!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": MAX_SAFE_TEXT_SCALARS,
+        "pattern": r"^(?=.*\S)[^\u0000-\u001f\u007f-\u009f]*$",
+    })
+);
+string_schema!(
+    CanonicalId,
+    json_schema!({
+        "type": "string",
+        "format": "uuid",
+        "pattern": r"^[0-9a-f]{8}-[0-9a-f]{4}-7[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    })
+);
+string_schema!(
+    CanonicalUuid,
+    json_schema!({
+        "type": "string",
+        "format": "uuid",
+        "pattern": r"^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+    })
+);
+string_schema!(
+    Digest,
+    json_schema!({
+        "type": "string",
+        "pattern": r"^sha256:[0-9a-f]{64}$",
+    })
+);
+string_schema!(
+    Cursor,
+    json_schema!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": MAX_CURSOR_BYTES,
+    })
+);
+string_schema!(Rfc3339Timestamp, json_schema!({ "type": "string", "format": "date-time" }));
+string_schema!(LocalDate, json_schema!({ "type": "string", "format": "date" }));
+string_schema!(
+    StableIdentity,
+    json_schema!({ "type": "string", "minLength": 1, "maxLength": 1024 })
+);
+string_schema!(
+    DestinationCollisionKey,
+    json_schema!({ "type": "string", "minLength": 1, "maxLength": 4096 })
+);
+string_schema!(
+    CanonicalRelativePath,
+    json_schema!({
+        "type": "string",
+        "minLength": 1,
+        "maxLength": 4096,
+        "pattern": r"^(?!/)(?![A-Za-z]:)(?!.*(?:^|/)\.\.?/)(?!.*\\).+$",
+    })
+);
 
 #[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Type, JsonSchema)]
 #[serde(transparent)]
@@ -369,6 +485,7 @@ fn default_page_limit() -> u32 {
 pub struct PageRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub cursor: Option<Cursor>,
+    #[schemars(default = "default_page_limit", range(min = 1, max = 500))]
     pub limit: u32,
 }
 
@@ -569,7 +686,7 @@ impl ProtectedResourceState {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct MutationContext {
-    pub command_id: CanonicalId,
+    pub command_id: CanonicalUuid,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub reason: Option<SafeText>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -579,7 +696,7 @@ pub struct MutationContext {
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CommandFence {
-    pub command_id: CanonicalId,
+    pub command_id: CanonicalUuid,
     pub lease_generation: u64,
 }
 
@@ -938,6 +1055,7 @@ impl PortableContractError {
             ErrorCode::ValidationPayloadTooLarge => {
                 matches!(details, Some(SafeErrorDetails::PayloadLimit { .. }))
             }
+            ErrorCode::EntityNotFound => matches!(details, Some(SafeErrorDetails::Entity { .. })),
             ErrorCode::ConcurrencyStaleRevision => {
                 matches!(details, Some(SafeErrorDetails::StaleEntity { .. }))
             }
@@ -950,7 +1068,13 @@ impl PortableContractError {
             ErrorCode::ProjectUpdateViewPathConflict => {
                 matches!(details, Some(SafeErrorDetails::AuthorizedPath { .. }))
             }
-            _ => matches!(details, Some(SafeErrorDetails::Domain { .. })),
+            ErrorCode::RelationProposalStale => {
+                matches!(details, Some(SafeErrorDetails::StaleRevisions { .. }))
+            }
+            ErrorCode::RelationProposalInvalidMembership => {
+                matches!(details, Some(SafeErrorDetails::Violations { .. }))
+            }
+            _ => details.as_ref().is_some_and(|details| domain_details_match(code, details)),
         };
         if !valid {
             return Err(ValidationError::new("details", "error_details_not_allowlisted"));
@@ -965,6 +1089,154 @@ impl PortableContractError {
             message: SafeText("Resource unavailable.".to_owned()),
             details: None,
         }
+    }
+}
+
+fn domain_details_match(code: ErrorCode, details: &SafeErrorDetails) -> bool {
+    let SafeErrorDetails::Domain { code: detail_code, values, .. } = details else {
+        return false;
+    };
+    let Ok(serialized_code) = serde_json::to_value(code) else {
+        return false;
+    };
+    if serialized_code.as_str() != Some(detail_code.as_str()) {
+        return false;
+    }
+
+    let allowed = domain_detail_fields(code);
+    let mut seen = std::collections::HashSet::with_capacity(values.len());
+    values
+        .iter()
+        .all(|value| allowed.contains(&value.name.as_str()) && seen.insert(value.name.as_str()))
+}
+
+fn domain_detail_fields(code: ErrorCode) -> &'static [&'static str] {
+    match code {
+        ErrorCode::SessionNotFound => &["sessionId"],
+        ErrorCode::PanelGroupNotFound => &["panelGroupId"],
+        ErrorCode::PanelGroupRevisionNotFound => &["panelGroupId", "revisionId"],
+        ErrorCode::MosaicNotFound => &["mosaicId"],
+        ErrorCode::MosaicRevisionNotFound => &["mosaicId", "revisionId"],
+        ErrorCode::RelationProposalNotFound => &["proposalId"],
+        ErrorCode::RelationProposalNotPending => &["proposalId", "state"],
+        ErrorCode::RelationProposalLineageCycle => {
+            &["proposalId", "groupCount", "groupIds", "truncated"]
+        }
+        ErrorCode::RelationProposalMergeRequired => {
+            &["proposalId", "mosaicCount", "mosaicIds", "truncated"]
+        }
+        ErrorCode::RelationProposalCrossTargetReviewRequired => {
+            &["proposalId", "targetCount", "targetIds", "truncated"]
+        }
+        ErrorCode::RelationProposalEvidenceMissing => &["proposalId", "missingEvidenceCodes"],
+        ErrorCode::RelationProposalManualEvidenceDisclosureIncomplete => &["missingEvidenceCodes"],
+        ErrorCode::TraversalOperationNotFound => &["operationId"],
+        ErrorCode::TraversalResultNotReady => &["operationId", "state"],
+        ErrorCode::TraversalNodeCeilingExceeded => &["operationId", "maxNodes", "visitedNodeCount"],
+        ErrorCode::TraversalEdgeCeilingExceeded => &["operationId", "maxEdges", "visitedEdgeCount"],
+        ErrorCode::TraversalDepthCeilingExceeded => &["operationId", "maxDepth", "deepestLevel"],
+        ErrorCode::TraversalCancellationDeadlineExceeded => &["operationId", "cancelRequestedAt"],
+        ErrorCode::InboxPlanNotFound
+        | ErrorCode::InboxPlanNotOpen
+        | ErrorCode::InboxPlanNotApproved
+        | ErrorCode::InboxPlanDigestMismatch
+        | ErrorCode::InboxPlanStale => &["planId", "planRevision", "decisionSnapshotId"],
+        ErrorCode::InboxSiteResolutionNotFound => &["planId", "resolutionRevision"],
+        ErrorCode::InboxPlanResultSnapshotNotFound => &["planId", "planResultSnapshotId"],
+        ErrorCode::InboxProposedSessionNotFound => {
+            &["planId", "planResultSnapshotId", "proposedSessionKey"]
+        }
+        ErrorCode::InboxSiteSelectionRequired => &["planId", "resolutionId"],
+        ErrorCode::InboxSiteTimezoneInvalid => &["planId", "siteId"],
+        ErrorCode::InboxTimestampConflict => &["planId", "conflictCount", "decisionSnapshotId"],
+        ErrorCode::MaterializationOperationNotFound => &["operationId"],
+        ErrorCode::MaterializationResultSnapshotNotFound => &["operationId", "resultSnapshotId"],
+        ErrorCode::MetadataEvidenceNotFound => &["metadataEvidenceId"],
+        ErrorCode::MetadataIdentityBlocked => &["metadataEvidenceId", "reasonCodes"],
+        ErrorCode::MetadataObservingNightConflict => {
+            &["metadataEvidenceId", "conflictCount", "decisionSnapshotId"]
+        }
+        ErrorCode::EquipmentResolutionNotFound => &["resolutionId"],
+        ErrorCode::EquipmentNotRegistered => &["equipmentId", "equipmentKind"],
+        ErrorCode::EquipmentOpticalProfileReviewRequired => {
+            &["resolutionId", "candidateCount", "decisionSnapshotId"]
+        }
+        ErrorCode::CalibrationCoolingSetPointRequired
+        | ErrorCode::CalibrationFlatGainRequired
+        | ErrorCode::CalibrationDarkFlatUnsupported => &["frameId", "sessionId"],
+        ErrorCode::ReclassificationPlanNotFound
+        | ErrorCode::ReclassificationPlanNotOpen
+        | ErrorCode::ReclassificationPlanStale => &["planId", "planRevision"],
+        ErrorCode::ReclassificationInvalidPartition => {
+            &["planId", "violationCount", "decisionSnapshotId"]
+        }
+        ErrorCode::ReclassificationReplacementNotFound => &["planId", "replacementId"],
+        ErrorCode::ReclassificationPanelConsequenceNotFound => &["planId", "panelConsequenceId"],
+        ErrorCode::ReclassificationResultSnapshotNotFound
+        | ErrorCode::ReclassificationApplyResultSnapshotNotFound => &["planId", "resultSnapshotId"],
+        ErrorCode::MatchingSettingsRevisionNotFound => &["revision"],
+        ErrorCode::MatchingSettingsOutOfBounds
+        | ErrorCode::MatchingSettingsCrossConstraint
+        | ErrorCode::MatchingSettingsWarningUnacknowledged => {
+            &["revision", "issueCount", "decisionSnapshotId"]
+        }
+        ErrorCode::CalibrationRequirementInvalid => &["requirementId", "reasonCodes"],
+        ErrorCode::CalibrationCandidateNotFound
+        | ErrorCode::CalibrationCandidateBlocked
+        | ErrorCode::CalibrationCandidateIncompatible => &["candidateId", "reasonCodes"],
+        ErrorCode::CalibrationHandoffTooLarge => {
+            &["handoffId", "sessionId", "sourceByteCount", "maximumSourceBytes"]
+        }
+        ErrorCode::CalibrationHandoffOperationNotCancellable => {
+            &["operationId", "state", "cancelSafe"]
+        }
+        ErrorCode::CalibrationWarningUnacknowledged => &["warningCodes"],
+        ErrorCode::CalibrationSelectionDuplicate => &["selectionId", "sessionId"],
+        ErrorCode::CalibrationHandoffNotFound | ErrorCode::CalibrationHandoffStaleBasis => {
+            &["handoffId", "revision"]
+        }
+        ErrorCode::CalibrationSourceUnavailable | ErrorCode::CalibrationSourceIdentityChanged => {
+            &["selectionId", "frameId"]
+        }
+        ErrorCode::CalibrationPageInvalid | ErrorCode::CalibrationPageStale => {
+            &["handoffId", "cursor"]
+        }
+        ErrorCode::ProjectNotFound => &["projectId"],
+        ErrorCode::ProjectSessionNotFound
+        | ErrorCode::ProjectSessionAlreadyPinned
+        | ErrorCode::ProjectSessionNotPinned
+        | ErrorCode::ProjectLifecycleDisallowsSessionAdd
+        | ErrorCode::ProjectReclassificationRevisionInvalid => {
+            &["projectId", "sessionId", "revisionId", "lifecycleState"]
+        }
+        ErrorCode::ProjectUpdateViewNoAdditions => &["projectId"],
+        ErrorCode::ProjectUpdateViewPlanNotFound
+        | ErrorCode::ProjectUpdateViewPlanNotOpen
+        | ErrorCode::ProjectUpdateViewPlanNotApproved
+        | ErrorCode::ProjectUpdateViewPlanStale
+        | ErrorCode::ProjectUpdateViewPlanDigestMismatch => {
+            &["projectId", "planId", "planRevision"]
+        }
+        ErrorCode::ProjectUpdateViewSourceUnavailable
+        | ErrorCode::ProjectUpdateViewRootChanged
+        | ErrorCode::ProjectUpdateViewSessionTooLarge => {
+            &["projectId", "planId", "sessionId", "sourceByteCount", "maximumSourceBytes"]
+        }
+        ErrorCode::ProjectUpdateViewOperationNotCancellable => {
+            &["operationId", "state", "cancelSafe"]
+        }
+        ErrorCode::ValidationRequestInvalid
+        | ErrorCode::ValidationPayloadTooLarge
+        | ErrorCode::PaginationCursorInvalid
+        | ErrorCode::PaginationSnapshotUnavailable
+        | ErrorCode::EntityNotFound
+        | ErrorCode::ResourceUnavailable
+        | ErrorCode::ConcurrencyStaleRevision
+        | ErrorCode::IdempotencyPayloadMismatch
+        | ErrorCode::OperationInProgress
+        | ErrorCode::RelationProposalStale
+        | ErrorCode::RelationProposalInvalidMembership
+        | ErrorCode::ProjectUpdateViewPathConflict => &[],
     }
 }
 
@@ -983,7 +1255,7 @@ pub struct AuditRecord {
     pub audit_id: CanonicalId,
     pub occurred_at: Rfc3339Timestamp,
     pub actor_id: CanonicalId,
-    pub command_id: CanonicalId,
+    pub command_id: CanonicalUuid,
     pub operation: SafeText,
     pub outcome: AuditOutcome,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -1005,7 +1277,7 @@ pub struct ContractEvent<T> {
     pub event_id: CanonicalId,
     pub occurred_at: Rfc3339Timestamp,
     pub actor_id: CanonicalId,
-    pub command_id: CanonicalId,
+    pub command_id: CanonicalUuid,
     pub entity_refs: BoundedList<EntityRef, 500>,
     pub payload: T,
 }
@@ -1016,8 +1288,8 @@ mod tests {
 
     use super::*;
 
-    fn id(value: &str) -> CanonicalId {
-        CanonicalId::try_new(value).expect("fixture id")
+    fn uuid(value: &str) -> CanonicalUuid {
+        CanonicalUuid::try_new(value).expect("fixture UUID")
     }
 
     fn digest(byte: char) -> Digest {
@@ -1066,7 +1338,7 @@ mod tests {
     #[test]
     fn mutation_context_cannot_assert_actor_or_scope() {
         let context = MutationContext {
-            command_id: id("018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f"),
+            command_id: uuid("018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f"),
             reason: None,
             approval_digest: Some(digest('a')),
         };
@@ -1077,7 +1349,7 @@ mod tests {
 
     #[test]
     fn stale_fence_never_matches_current_generation() {
-        let command_id = id("018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f");
+        let command_id = uuid("018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f");
         let stale = CommandFence { command_id: command_id.clone(), lease_generation: 3 };
         let current = CommandFence { command_id, lease_generation: 4 };
         assert!(!stale.is_current(&current));

--- a/crates/contracts/core/src/sessions/heterogeneity/shared.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/shared.rs
@@ -1,0 +1,1085 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared bounded scalars, envelopes, pagination, authorization, and command contracts.
+
+use std::fmt;
+use std::ops::Deref;
+
+use schemars::JsonSchema;
+use serde::{de::Error as _, Deserialize, Deserializer, Serialize};
+use specta::Type;
+
+pub const MAX_REQUEST_BYTES: u64 = 1_048_576;
+pub const MAX_RESPONSE_BYTES: u64 = 4_194_304;
+pub const MAX_CURSOR_BYTES: usize = 4_096;
+pub const MAX_SAFE_TEXT_SCALARS: usize = 4_096;
+pub const MAX_SAFE_TEXT_BYTES: usize = 16_384;
+pub const MAX_PAGE_ITEMS: usize = 500;
+const MAX_PAGE_ITEMS_U32: u32 = 500;
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct ValidationError {
+    pub field: &'static str,
+    pub reason_code: &'static str,
+}
+
+impl ValidationError {
+    #[must_use]
+    pub const fn new(field: &'static str, reason_code: &'static str) -> Self {
+        Self { field, reason_code }
+    }
+}
+
+impl fmt::Display for ValidationError {
+    fn fmt(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(formatter, "{}: {}", self.field, self.reason_code)
+    }
+}
+
+impl std::error::Error for ValidationError {}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type, JsonSchema)]
+#[serde(transparent)]
+#[specta(transparent)]
+pub struct BoundedList<T, const MAX: usize>(Vec<T>);
+
+impl<T, const MAX: usize> BoundedList<T, MAX> {
+    /// # Errors
+    ///
+    /// Returns an error when `items` contains more than `MAX` entries.
+    pub fn try_new(items: Vec<T>) -> Result<Self, ValidationError> {
+        if items.len() > MAX {
+            return Err(ValidationError::new("items", "list_too_long"));
+        }
+        Ok(Self(items))
+    }
+
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        &self.0
+    }
+
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    #[must_use]
+    pub fn into_inner(self) -> Vec<T> {
+        self.0
+    }
+}
+
+impl<T, const MAX: usize> Default for BoundedList<T, MAX> {
+    fn default() -> Self {
+        Self(Vec::new())
+    }
+}
+
+impl<T, const MAX: usize> Deref for BoundedList<T, MAX> {
+    type Target = [T];
+
+    fn deref(&self) -> &Self::Target {
+        self.as_slice()
+    }
+}
+
+impl<T, const MAX: usize> IntoIterator for BoundedList<T, MAX> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.into_iter()
+    }
+}
+
+impl<'a, T, const MAX: usize> IntoIterator for &'a BoundedList<T, MAX> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter()
+    }
+}
+
+impl<'a, T, const MAX: usize> IntoIterator for &'a mut BoundedList<T, MAX> {
+    type Item = &'a mut T;
+    type IntoIter = std::slice::IterMut<'a, T>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.0.iter_mut()
+    }
+}
+
+impl<'de, T, const MAX: usize> Deserialize<'de> for BoundedList<T, MAX>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let items = Vec::<T>::deserialize(deserializer)?;
+        Self::try_new(items).map_err(D::Error::custom)
+    }
+}
+
+macro_rules! validated_string {
+    ($name:ident, $validator:ident) => {
+        #[derive(
+            Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd, Serialize, Type, JsonSchema,
+        )]
+        #[serde(transparent)]
+        #[specta(transparent)]
+        pub struct $name(String);
+
+        impl $name {
+            /// # Errors
+            ///
+            /// Returns an error when the value violates this scalar's portable contract.
+            pub fn try_new(value: impl Into<String>) -> Result<Self, ValidationError> {
+                let value = value.into();
+                $validator(&value)?;
+                Ok(Self(value))
+            }
+
+            #[must_use]
+            pub fn as_str(&self) -> &str {
+                &self.0
+            }
+
+            #[must_use]
+            pub fn into_inner(self) -> String {
+                self.0
+            }
+        }
+
+        impl Deref for $name {
+            type Target = str;
+
+            fn deref(&self) -> &Self::Target {
+                self.as_str()
+            }
+        }
+
+        impl<'de> Deserialize<'de> for $name {
+            fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+            where
+                D: Deserializer<'de>,
+            {
+                let value = String::deserialize(deserializer)?;
+                Self::try_new(value).map_err(D::Error::custom)
+            }
+        }
+    };
+}
+
+fn validate_safe_text(value: &str) -> Result<(), ValidationError> {
+    if value.len() > MAX_SAFE_TEXT_BYTES || value.chars().count() > MAX_SAFE_TEXT_SCALARS {
+        return Err(ValidationError::new("text", "text_too_long"));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(ValidationError::new("text", "control_character"));
+    }
+    Ok(())
+}
+
+fn validate_non_blank_safe_text(value: &str) -> Result<(), ValidationError> {
+    validate_safe_text(value)?;
+    if value.trim().is_empty() {
+        return Err(ValidationError::new("text", "blank"));
+    }
+    Ok(())
+}
+
+fn validate_canonical_id(value: &str) -> Result<(), ValidationError> {
+    let parsed =
+        uuid::Uuid::parse_str(value).map_err(|_| ValidationError::new("id", "uuid_invalid"))?;
+    if value.len() != 36 || parsed.hyphenated().to_string() != value {
+        return Err(ValidationError::new("id", "uuid_not_canonical"));
+    }
+    Ok(())
+}
+
+fn validate_digest(value: &str) -> Result<(), ValidationError> {
+    let hex = value
+        .strip_prefix("sha256:")
+        .ok_or_else(|| ValidationError::new("digest", "digest_algorithm_invalid"))?;
+    if hex.len() != 64
+        || !hex.bytes().all(|byte| byte.is_ascii_hexdigit() && !byte.is_ascii_uppercase())
+    {
+        return Err(ValidationError::new("digest", "digest_invalid"));
+    }
+    Ok(())
+}
+
+fn validate_cursor(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > MAX_CURSOR_BYTES {
+        return Err(ValidationError::new("cursor", "cursor_length_invalid"));
+    }
+    Ok(())
+}
+
+fn validate_timestamp(value: &str) -> Result<(), ValidationError> {
+    time::OffsetDateTime::parse(value, &time::format_description::well_known::Rfc3339)
+        .map_err(|_| ValidationError::new("timestamp", "timestamp_invalid"))?;
+    Ok(())
+}
+
+fn validate_local_date(value: &str) -> Result<(), ValidationError> {
+    let format = time::macros::format_description!("[year]-[month]-[day]");
+    time::Date::parse(value, &format).map_err(|_| ValidationError::new("date", "date_invalid"))?;
+    if value.len() != 10 {
+        return Err(ValidationError::new("date", "date_not_canonical"));
+    }
+    Ok(())
+}
+
+fn validate_stable_identity(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > 1_024 {
+        return Err(ValidationError::new("stableIdentity", "length_invalid"));
+    }
+    Ok(())
+}
+
+fn validate_collision_key(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > 4_096 {
+        return Err(ValidationError::new("destinationCollisionKey", "length_invalid"));
+    }
+    Ok(())
+}
+
+fn validate_relative_path(value: &str) -> Result<(), ValidationError> {
+    if value.is_empty() || value.len() > 4_096 || value.starts_with('/') || value.contains('\\') {
+        return Err(ValidationError::new("relativePath", "path_invalid"));
+    }
+    let segments: Vec<&str> = value.split('/').collect();
+    if !(1..=64).contains(&segments.len())
+        || segments.iter().any(|segment| {
+            segment.is_empty()
+                || segment.len() > 255
+                || *segment == "."
+                || *segment == ".."
+                || segment.contains('\0')
+        })
+    {
+        return Err(ValidationError::new("relativePath", "path_segment_invalid"));
+    }
+    if value.len() >= 2 && value.as_bytes()[1] == b':' {
+        return Err(ValidationError::new("relativePath", "path_drive_invalid"));
+    }
+    Ok(())
+}
+
+validated_string!(SafeText, validate_safe_text);
+validated_string!(NonBlankSafeText, validate_non_blank_safe_text);
+validated_string!(CanonicalId, validate_canonical_id);
+validated_string!(Digest, validate_digest);
+validated_string!(Cursor, validate_cursor);
+validated_string!(Rfc3339Timestamp, validate_timestamp);
+validated_string!(LocalDate, validate_local_date);
+validated_string!(StableIdentity, validate_stable_identity);
+validated_string!(DestinationCollisionKey, validate_collision_key);
+validated_string!(CanonicalRelativePath, validate_relative_path);
+
+#[derive(Clone, Copy, Debug, PartialEq, PartialOrd, Serialize, Type, JsonSchema)]
+#[serde(transparent)]
+#[specta(transparent)]
+pub struct FiniteDecimal(f64);
+
+impl FiniteDecimal {
+    /// # Errors
+    ///
+    /// Returns an error when `value` is NaN or infinite.
+    pub fn try_new(value: f64) -> Result<Self, ValidationError> {
+        if !value.is_finite() {
+            return Err(ValidationError::new("decimal", "decimal_not_finite"));
+        }
+        Ok(Self(value))
+    }
+
+    #[must_use]
+    pub const fn get(self) -> f64 {
+        self.0
+    }
+}
+
+impl<'de> Deserialize<'de> for FiniteDecimal {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        Self::try_new(f64::deserialize(deserializer)?).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityRef {
+    pub entity_type: SafeText,
+    pub entity_id: CanonicalId,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct RevisionRef {
+    pub entity_type: SafeText,
+    pub entity_id: CanonicalId,
+    pub revision_id: CanonicalId,
+    pub revision_number: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractRange<T> {
+    pub min: T,
+    pub max: T,
+    pub min_inclusive: bool,
+    pub max_inclusive: bool,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum SupportedFrameKind {
+    Light,
+    Dark,
+    Bias,
+    Flat,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum MaterializationKind {
+    InboxIngestion,
+    MetadataReclassification,
+}
+
+fn default_page_limit() -> u32 {
+    100
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PageRequest {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cursor: Option<Cursor>,
+    pub limit: u32,
+}
+
+impl Default for PageRequest {
+    fn default() -> Self {
+        Self { cursor: None, limit: default_page_limit() }
+    }
+}
+
+impl PageRequest {
+    /// # Errors
+    ///
+    /// Returns an error when `limit` is outside the inclusive range 1 through 500.
+    pub fn try_new(cursor: Option<Cursor>, limit: u32) -> Result<Self, ValidationError> {
+        if !(1..=MAX_PAGE_ITEMS_U32).contains(&limit) {
+            return Err(ValidationError::new("page.limit", "page_limit_out_of_range"));
+        }
+        Ok(Self { cursor, limit })
+    }
+}
+
+impl<'de> Deserialize<'de> for PageRequest {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire {
+            cursor: Option<Cursor>,
+            #[serde(default = "default_page_limit")]
+            limit: u32,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        Self::try_new(wire.cursor, wire.limit).map_err(D::Error::custom)
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum PageBasis {
+    Snapshot { snapshot_id: CanonicalId },
+    Watermark { watermark: SafeText },
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Page<T> {
+    pub items: BoundedList<T, MAX_PAGE_ITEMS>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub snapshot_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub watermark: Option<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub next_cursor: Option<Cursor>,
+}
+
+impl<'de, T> Deserialize<'de> for Page<T>
+where
+    T: Deserialize<'de>,
+{
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire<T> {
+            items: BoundedList<T, MAX_PAGE_ITEMS>,
+            snapshot_id: Option<CanonicalId>,
+            watermark: Option<SafeText>,
+            next_cursor: Option<Cursor>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        let page = Self {
+            items: wire.items,
+            snapshot_id: wire.snapshot_id,
+            watermark: wire.watermark,
+            next_cursor: wire.next_cursor,
+        };
+        page.validate().map_err(D::Error::custom)?;
+        Ok(page)
+    }
+}
+
+impl<T> Page<T> {
+    /// # Errors
+    ///
+    /// Returns an error if the page does not have exactly one snapshot basis.
+    pub fn try_new(
+        items: BoundedList<T, MAX_PAGE_ITEMS>,
+        basis: PageBasis,
+        next_cursor: Option<Cursor>,
+    ) -> Result<Self, ValidationError> {
+        let (snapshot_id, watermark) = match basis {
+            PageBasis::Snapshot { snapshot_id } => (Some(snapshot_id), None),
+            PageBasis::Watermark { watermark } => (None, Some(watermark)),
+        };
+        let page = Self { items, snapshot_id, watermark, next_cursor };
+        page.validate()?;
+        Ok(page)
+    }
+
+    /// # Errors
+    ///
+    /// Returns an error unless exactly one of `snapshot_id` or `watermark` is present.
+    pub fn validate(&self) -> Result<(), ValidationError> {
+        if self.snapshot_id.is_some() == self.watermark.is_some() {
+            return Err(ValidationError::new("page", "page_basis_invalid"));
+        }
+        Ok(())
+    }
+}
+
+pub trait KeysetListOperation {
+    fn query_name(&self) -> &'static str;
+    fn unique_order(&self) -> &'static [&'static str];
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CursorBinding {
+    pub principal_binding: Digest,
+    pub query_name: SafeText,
+    pub normalized_filters_digest: Digest,
+    pub sort_order_digest: Digest,
+    pub basis: PageBasis,
+    pub authorization_projection: SafeText,
+    pub last_unique_sort_key: BoundedList<SafeText, 100>,
+}
+
+impl CursorBinding {
+    #[must_use]
+    pub fn matches_context(&self, other: &Self) -> bool {
+        self.principal_binding == other.principal_binding
+            && self.query_name == other.query_name
+            && self.normalized_filters_digest == other.normalized_filters_digest
+            && self.sort_order_digest == other.sort_order_digest
+            && self.basis == other.basis
+            && self.authorization_projection == other.authorization_projection
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct TrustedAuthorization {
+    actor_id: CanonicalId,
+    principal_binding: Digest,
+    scope_binding: Digest,
+}
+
+impl TrustedAuthorization {
+    #[must_use]
+    pub const fn new(
+        actor_id: CanonicalId,
+        principal_binding: Digest,
+        scope_binding: Digest,
+    ) -> Self {
+        Self { actor_id, principal_binding, scope_binding }
+    }
+
+    #[must_use]
+    pub const fn actor_id(&self) -> &CanonicalId {
+        &self.actor_id
+    }
+
+    #[must_use]
+    pub const fn principal_binding(&self) -> &Digest {
+        &self.principal_binding
+    }
+
+    #[must_use]
+    pub const fn scope_binding(&self) -> &Digest {
+        &self.scope_binding
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum ProtectedResourceState {
+    Authorized,
+    Unauthorized,
+    Missing,
+}
+
+impl ProtectedResourceState {
+    #[must_use]
+    pub fn projected_error(self) -> Option<PortableContractError> {
+        match self {
+            Self::Authorized => None,
+            Self::Unauthorized | Self::Missing => {
+                Some(PortableContractError::resource_unavailable())
+            }
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct MutationContext {
+    pub command_id: CanonicalId,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub approval_digest: Option<Digest>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CommandFence {
+    pub command_id: CanonicalId,
+    pub lease_generation: u64,
+}
+
+impl CommandFence {
+    #[must_use]
+    pub fn is_current(&self, current: &Self) -> bool {
+        self == current
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum CommandExecutionState {
+    Received,
+    Executing,
+    Applied,
+    Refused,
+    Failed,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(
+    tag = "state",
+    content = "result",
+    rename_all = "snake_case",
+    rename_all_fields = "camelCase"
+)]
+pub enum IdempotencyOutcome<T> {
+    Recorded(T),
+    InProgress { operation_id: CanonicalId },
+    PayloadMismatch,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct FieldError {
+    pub field: SafeText,
+    pub reason_code: SafeText,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct Violation {
+    pub code: SafeText,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub field: Option<SafeText>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub entity_ref: Option<EntityRef>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_ref: Option<SafeText>,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "kind", content = "value", rename_all = "snake_case")]
+pub enum SafeScalar {
+    Text(SafeText),
+    Unsigned(u64),
+    Boolean(bool),
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct NamedSafeValue {
+    pub name: SafeText,
+    pub value: SafeScalar,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(tag = "kind", rename_all = "snake_case", rename_all_fields = "camelCase")]
+pub enum SafeErrorDetails {
+    FieldErrors {
+        fields: BoundedList<FieldError, 100>,
+    },
+    PayloadLimit {
+        field: SafeText,
+        limit_name: SafeText,
+        limit: u64,
+    },
+    Entity {
+        entity_type: SafeText,
+        entity_id: CanonicalId,
+    },
+    StaleEntity {
+        entity_type: SafeText,
+        entity_id: CanonicalId,
+        expected_revision: u64,
+        actual_revision: u64,
+    },
+    StaleRevisions {
+        revisions: BoundedList<RevisionRef, 500>,
+        total_count: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decision_snapshot_id: Option<CanonicalId>,
+    },
+    Violations {
+        violations: BoundedList<Violation, 100>,
+        total_count: u64,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decision_snapshot_id: Option<CanonicalId>,
+    },
+    Idempotency {
+        command_id: CanonicalId,
+    },
+    Operation {
+        command_id: CanonicalId,
+        operation_id: CanonicalId,
+    },
+    AuthorizedPath {
+        item_id: CanonicalId,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        relative_path: Option<CanonicalRelativePath>,
+    },
+    Domain {
+        code: SafeText,
+        values: BoundedList<NamedSafeValue, 100>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        decision_snapshot_id: Option<CanonicalId>,
+    },
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+pub enum ErrorCode {
+    #[serde(rename = "validation.request_invalid")]
+    ValidationRequestInvalid,
+    #[serde(rename = "validation.payload_too_large")]
+    ValidationPayloadTooLarge,
+    #[serde(rename = "pagination.cursor_invalid")]
+    PaginationCursorInvalid,
+    #[serde(rename = "pagination.snapshot_unavailable")]
+    PaginationSnapshotUnavailable,
+    #[serde(rename = "entity.not_found")]
+    EntityNotFound,
+    #[serde(rename = "resource.unavailable")]
+    ResourceUnavailable,
+    #[serde(rename = "concurrency.stale_revision")]
+    ConcurrencyStaleRevision,
+    #[serde(rename = "idempotency.payload_mismatch")]
+    IdempotencyPayloadMismatch,
+    #[serde(rename = "operation.in_progress")]
+    OperationInProgress,
+    #[serde(rename = "session.not_found")]
+    SessionNotFound,
+    #[serde(rename = "panel_group.not_found")]
+    PanelGroupNotFound,
+    #[serde(rename = "panel_group.revision_not_found")]
+    PanelGroupRevisionNotFound,
+    #[serde(rename = "mosaic.not_found")]
+    MosaicNotFound,
+    #[serde(rename = "mosaic.revision_not_found")]
+    MosaicRevisionNotFound,
+    #[serde(rename = "relation_proposal.not_found")]
+    RelationProposalNotFound,
+    #[serde(rename = "relation_proposal.not_pending")]
+    RelationProposalNotPending,
+    #[serde(rename = "relation_proposal.stale")]
+    RelationProposalStale,
+    #[serde(rename = "relation_proposal.invalid_membership")]
+    RelationProposalInvalidMembership,
+    #[serde(rename = "relation_proposal.lineage_cycle")]
+    RelationProposalLineageCycle,
+    #[serde(rename = "relation_proposal.merge_required")]
+    RelationProposalMergeRequired,
+    #[serde(rename = "relation_proposal.cross_target_review_required")]
+    RelationProposalCrossTargetReviewRequired,
+    #[serde(rename = "relation_proposal.evidence_missing")]
+    RelationProposalEvidenceMissing,
+    #[serde(rename = "relation_proposal.manual_evidence_disclosure_incomplete")]
+    RelationProposalManualEvidenceDisclosureIncomplete,
+    #[serde(rename = "traversal.operation_not_found")]
+    TraversalOperationNotFound,
+    #[serde(rename = "traversal.result_not_ready")]
+    TraversalResultNotReady,
+    #[serde(rename = "traversal.node_ceiling_exceeded")]
+    TraversalNodeCeilingExceeded,
+    #[serde(rename = "traversal.edge_ceiling_exceeded")]
+    TraversalEdgeCeilingExceeded,
+    #[serde(rename = "traversal.depth_ceiling_exceeded")]
+    TraversalDepthCeilingExceeded,
+    #[serde(rename = "traversal.cancellation_deadline_exceeded")]
+    TraversalCancellationDeadlineExceeded,
+    #[serde(rename = "inbox.plan_not_found")]
+    InboxPlanNotFound,
+    #[serde(rename = "inbox.plan_not_open")]
+    InboxPlanNotOpen,
+    #[serde(rename = "inbox.plan_not_approved")]
+    InboxPlanNotApproved,
+    #[serde(rename = "inbox.plan_digest_mismatch")]
+    InboxPlanDigestMismatch,
+    #[serde(rename = "inbox.plan_stale")]
+    InboxPlanStale,
+    #[serde(rename = "inbox.site_resolution_not_found")]
+    InboxSiteResolutionNotFound,
+    #[serde(rename = "inbox.plan_result_snapshot_not_found")]
+    InboxPlanResultSnapshotNotFound,
+    #[serde(rename = "inbox.proposed_session_not_found")]
+    InboxProposedSessionNotFound,
+    #[serde(rename = "inbox.site_selection_required")]
+    InboxSiteSelectionRequired,
+    #[serde(rename = "inbox.site_timezone_invalid")]
+    InboxSiteTimezoneInvalid,
+    #[serde(rename = "inbox.timestamp_conflict")]
+    InboxTimestampConflict,
+    #[serde(rename = "materialization.operation_not_found")]
+    MaterializationOperationNotFound,
+    #[serde(rename = "materialization.result_snapshot_not_found")]
+    MaterializationResultSnapshotNotFound,
+    #[serde(rename = "metadata.evidence_not_found")]
+    MetadataEvidenceNotFound,
+    #[serde(rename = "metadata.identity_blocked")]
+    MetadataIdentityBlocked,
+    #[serde(rename = "metadata.observing_night_conflict")]
+    MetadataObservingNightConflict,
+    #[serde(rename = "equipment.resolution_not_found")]
+    EquipmentResolutionNotFound,
+    #[serde(rename = "equipment.not_registered")]
+    EquipmentNotRegistered,
+    #[serde(rename = "equipment.optical_profile_review_required")]
+    EquipmentOpticalProfileReviewRequired,
+    #[serde(rename = "calibration.cooling_set_point_required")]
+    CalibrationCoolingSetPointRequired,
+    #[serde(rename = "calibration.flat_gain_required")]
+    CalibrationFlatGainRequired,
+    #[serde(rename = "calibration.dark_flat_unsupported")]
+    CalibrationDarkFlatUnsupported,
+    #[serde(rename = "reclassification.plan_not_found")]
+    ReclassificationPlanNotFound,
+    #[serde(rename = "reclassification.plan_not_open")]
+    ReclassificationPlanNotOpen,
+    #[serde(rename = "reclassification.plan_stale")]
+    ReclassificationPlanStale,
+    #[serde(rename = "reclassification.invalid_partition")]
+    ReclassificationInvalidPartition,
+    #[serde(rename = "reclassification.replacement_not_found")]
+    ReclassificationReplacementNotFound,
+    #[serde(rename = "reclassification.panel_consequence_not_found")]
+    ReclassificationPanelConsequenceNotFound,
+    #[serde(rename = "reclassification.result_snapshot_not_found")]
+    ReclassificationResultSnapshotNotFound,
+    #[serde(rename = "reclassification.apply_result_snapshot_not_found")]
+    ReclassificationApplyResultSnapshotNotFound,
+    #[serde(rename = "matching_settings.revision_not_found")]
+    MatchingSettingsRevisionNotFound,
+    #[serde(rename = "matching_settings.out_of_bounds")]
+    MatchingSettingsOutOfBounds,
+    #[serde(rename = "matching_settings.cross_constraint")]
+    MatchingSettingsCrossConstraint,
+    #[serde(rename = "matching_settings.warning_unacknowledged")]
+    MatchingSettingsWarningUnacknowledged,
+    #[serde(rename = "calibration.requirement_invalid")]
+    CalibrationRequirementInvalid,
+    #[serde(rename = "calibration.candidate_not_found")]
+    CalibrationCandidateNotFound,
+    #[serde(rename = "calibration.candidate_blocked")]
+    CalibrationCandidateBlocked,
+    #[serde(rename = "calibration.handoff_too_large")]
+    CalibrationHandoffTooLarge,
+    #[serde(rename = "calibration.handoff_operation_not_cancellable")]
+    CalibrationHandoffOperationNotCancellable,
+    #[serde(rename = "calibration.candidate_incompatible")]
+    CalibrationCandidateIncompatible,
+    #[serde(rename = "calibration.warning_unacknowledged")]
+    CalibrationWarningUnacknowledged,
+    #[serde(rename = "calibration.selection_duplicate")]
+    CalibrationSelectionDuplicate,
+    #[serde(rename = "calibration.handoff_not_found")]
+    CalibrationHandoffNotFound,
+    #[serde(rename = "calibration.handoff_stale_basis")]
+    CalibrationHandoffStaleBasis,
+    #[serde(rename = "calibration.source_unavailable")]
+    CalibrationSourceUnavailable,
+    #[serde(rename = "calibration.source_identity_changed")]
+    CalibrationSourceIdentityChanged,
+    #[serde(rename = "calibration.page_invalid")]
+    CalibrationPageInvalid,
+    #[serde(rename = "calibration.page_stale")]
+    CalibrationPageStale,
+    #[serde(rename = "project.not_found")]
+    ProjectNotFound,
+    #[serde(rename = "project.session_not_found")]
+    ProjectSessionNotFound,
+    #[serde(rename = "project.session_already_pinned")]
+    ProjectSessionAlreadyPinned,
+    #[serde(rename = "project.session_not_pinned")]
+    ProjectSessionNotPinned,
+    #[serde(rename = "project.lifecycle_disallows_session_add")]
+    ProjectLifecycleDisallowsSessionAdd,
+    #[serde(rename = "project.reclassification_revision_invalid")]
+    ProjectReclassificationRevisionInvalid,
+    #[serde(rename = "project.update_view_no_additions")]
+    ProjectUpdateViewNoAdditions,
+    #[serde(rename = "project.update_view_plan_not_found")]
+    ProjectUpdateViewPlanNotFound,
+    #[serde(rename = "project.update_view_plan_not_open")]
+    ProjectUpdateViewPlanNotOpen,
+    #[serde(rename = "project.update_view_plan_not_approved")]
+    ProjectUpdateViewPlanNotApproved,
+    #[serde(rename = "project.update_view_plan_stale")]
+    ProjectUpdateViewPlanStale,
+    #[serde(rename = "project.update_view_path_conflict")]
+    ProjectUpdateViewPathConflict,
+    #[serde(rename = "project.update_view_source_unavailable")]
+    ProjectUpdateViewSourceUnavailable,
+    #[serde(rename = "project.update_view_root_changed")]
+    ProjectUpdateViewRootChanged,
+    #[serde(rename = "project.update_view_plan_digest_mismatch")]
+    ProjectUpdateViewPlanDigestMismatch,
+    #[serde(rename = "project.update_view_session_too_large")]
+    ProjectUpdateViewSessionTooLarge,
+    #[serde(rename = "project.update_view_operation_not_cancellable")]
+    ProjectUpdateViewOperationNotCancellable,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PortableContractError {
+    pub code: ErrorCode,
+    pub message: SafeText,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub details: Option<SafeErrorDetails>,
+}
+
+impl<'de> Deserialize<'de> for PortableContractError {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Wire {
+            code: ErrorCode,
+            message: SafeText,
+            details: Option<SafeErrorDetails>,
+        }
+
+        let wire = Wire::deserialize(deserializer)?;
+        Self::try_new(wire.code, wire.message, wire.details).map_err(D::Error::custom)
+    }
+}
+
+impl PortableContractError {
+    /// # Errors
+    ///
+    /// Returns an error when `details` is not allowlisted for `code`.
+    pub fn try_new(
+        code: ErrorCode,
+        message: SafeText,
+        details: Option<SafeErrorDetails>,
+    ) -> Result<Self, ValidationError> {
+        let valid = match code {
+            ErrorCode::ResourceUnavailable
+            | ErrorCode::PaginationCursorInvalid
+            | ErrorCode::PaginationSnapshotUnavailable => details.is_none(),
+            ErrorCode::ValidationRequestInvalid => {
+                matches!(details, Some(SafeErrorDetails::FieldErrors { .. }))
+            }
+            ErrorCode::ValidationPayloadTooLarge => {
+                matches!(details, Some(SafeErrorDetails::PayloadLimit { .. }))
+            }
+            ErrorCode::ConcurrencyStaleRevision => {
+                matches!(details, Some(SafeErrorDetails::StaleEntity { .. }))
+            }
+            ErrorCode::IdempotencyPayloadMismatch => {
+                matches!(details, Some(SafeErrorDetails::Idempotency { .. }))
+            }
+            ErrorCode::OperationInProgress => {
+                matches!(details, Some(SafeErrorDetails::Operation { .. }))
+            }
+            ErrorCode::ProjectUpdateViewPathConflict => {
+                matches!(details, Some(SafeErrorDetails::AuthorizedPath { .. }))
+            }
+            _ => matches!(details, Some(SafeErrorDetails::Domain { .. })),
+        };
+        if !valid {
+            return Err(ValidationError::new("details", "error_details_not_allowlisted"));
+        }
+        Ok(Self { code, message, details })
+    }
+
+    #[must_use]
+    pub fn resource_unavailable() -> Self {
+        Self {
+            code: ErrorCode::ResourceUnavailable,
+            message: SafeText("Resource unavailable.".to_owned()),
+            details: None,
+        }
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "snake_case")]
+pub enum AuditOutcome {
+    Applied,
+    Rejected,
+    Refused,
+    Failed,
+}
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditRecord {
+    pub audit_id: CanonicalId,
+    pub occurred_at: Rfc3339Timestamp,
+    pub actor_id: CanonicalId,
+    pub command_id: CanonicalId,
+    pub operation: SafeText,
+    pub outcome: AuditOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub reason: Option<SafeText>,
+    pub entity_refs: BoundedList<EntityRef, 500>,
+    pub before_revision_count: u64,
+    pub after_revision_count: u64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub decision_snapshot_id: Option<CanonicalId>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error_code: Option<ErrorCode>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub evidence_ref: Option<SafeText>,
+}
+
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize, Type, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct ContractEvent<T> {
+    pub event_id: CanonicalId,
+    pub occurred_at: Rfc3339Timestamp,
+    pub actor_id: CanonicalId,
+    pub command_id: CanonicalId,
+    pub entity_refs: BoundedList<EntityRef, 500>,
+    pub payload: T,
+}
+
+#[cfg(test)]
+mod tests {
+    use serde_json::json;
+
+    use super::*;
+
+    fn id(value: &str) -> CanonicalId {
+        CanonicalId::try_new(value).expect("fixture id")
+    }
+
+    fn digest(byte: char) -> Digest {
+        Digest::try_new(format!("sha256:{}", byte.to_string().repeat(64))).expect("fixture digest")
+    }
+
+    #[test]
+    fn bounded_list_rejects_max_plus_one_during_deserialization() {
+        let value = serde_json::to_value(vec![0_u8; 101]).expect("fixture");
+        assert!(serde_json::from_value::<BoundedList<u8, 100>>(value).is_err());
+    }
+
+    #[test]
+    fn page_request_enforces_limit_and_cursor_bounds() {
+        assert!(serde_json::from_value::<PageRequest>(json!({ "limit": 0 })).is_err());
+        assert!(serde_json::from_value::<PageRequest>(json!({ "limit": 501 })).is_err());
+        assert_eq!(
+            serde_json::from_value::<PageRequest>(json!({})).expect("default page").limit,
+            100
+        );
+        assert!(Cursor::try_new("x".repeat(MAX_CURSOR_BYTES + 1)).is_err());
+    }
+
+    #[test]
+    fn page_requires_exactly_one_snapshot_basis() {
+        let page = Page::<u8> {
+            items: BoundedList::default(),
+            snapshot_id: None,
+            watermark: None,
+            next_cursor: None,
+        };
+        assert!(page.validate().is_err());
+    }
+
+    #[test]
+    fn protected_missing_and_unauthorized_resources_have_identical_errors() {
+        let missing = ProtectedResourceState::Missing.projected_error().expect("missing error");
+        let unauthorized =
+            ProtectedResourceState::Unauthorized.projected_error().expect("unauthorized error");
+        assert_eq!(
+            serde_json::to_value(missing).unwrap(),
+            serde_json::to_value(unauthorized).unwrap()
+        );
+    }
+
+    #[test]
+    fn mutation_context_cannot_assert_actor_or_scope() {
+        let context = MutationContext {
+            command_id: id("018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f"),
+            reason: None,
+            approval_digest: Some(digest('a')),
+        };
+        let value = serde_json::to_value(context).expect("serialize context");
+        assert!(value.get("actorId").is_none());
+        assert!(value.get("authorizationScope").is_none());
+    }
+
+    #[test]
+    fn stale_fence_never_matches_current_generation() {
+        let command_id = id("018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f");
+        let stale = CommandFence { command_id: command_id.clone(), lease_generation: 3 };
+        let current = CommandFence { command_id, lease_generation: 4 };
+        assert!(!stale.is_current(&current));
+    }
+}

--- a/packages/contracts/tests/conformance-harness.mjs
+++ b/packages/contracts/tests/conformance-harness.mjs
@@ -19,6 +19,8 @@ import { fileURLToPath } from "node:url";
 import { createRequire } from "node:module";
 import { dirname, resolve } from "node:path";
 
+import { registerUtf8ByteKeywords } from "./utf8-byte-keywords.test.mjs";
+
 const here = dirname(fileURLToPath(import.meta.url));
 const root = resolve(here, "../../..");
 
@@ -36,7 +38,7 @@ function loadSchema(relPath) {
 // ── AJV instance ─────────────────────────────────────────────────────────────
 
 // strict:false so unknown formats (date-time, uuid) produce warnings, not errors.
-const ajv = new Ajv2020({ strict: false, allErrors: true });
+const ajv = registerUtf8ByteKeywords(new Ajv2020({ strict: false, allErrors: true }));
 
 // ── Test runner ───────────────────────────────────────────────────────────────
 

--- a/packages/contracts/tests/utf8-byte-keywords.test.mjs
+++ b/packages/contracts/tests/utf8-byte-keywords.test.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+
+import { createRequire } from "node:module";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
+
+const require = createRequire(import.meta.url);
+const { Ajv2020 } = require("ajv/dist/2020");
+
+function utf8ByteLength(value) {
+  return Buffer.byteLength(value, "utf8");
+}
+
+export function registerUtf8ByteKeywords(ajv) {
+  ajv.addKeyword({
+    keyword: "x-maxUtf8Bytes",
+    schemaType: "number",
+    type: "string",
+    validate: (maximum, value) => utf8ByteLength(value) <= maximum,
+  });
+  ajv.addKeyword({
+    keyword: "x-maxSegmentUtf8Bytes",
+    schemaType: "number",
+    type: "string",
+    validate: (maximum, value) =>
+      value.split("/").every((segment) => utf8ByteLength(segment) <= maximum),
+  });
+  return ajv;
+}
+
+function validateCorpus({ schema, cases }) {
+  const ajv = registerUtf8ByteKeywords(new Ajv2020({ strict: false, allErrors: true }));
+  const validate = ajv.compile(schema);
+  return cases.map(({ value }) => Boolean(validate(value)));
+}
+
+function run() {
+  if (process.argv.includes("--stdin")) {
+    const corpus = JSON.parse(readFileSync(0, "utf8"));
+    process.stdout.write(`${JSON.stringify(validateCorpus(corpus))}\n`);
+    return;
+  }
+
+  const accepted = `${"é".repeat(127)}a`;
+  const rejected = "é".repeat(128);
+  const results = validateCorpus({
+    schema: {
+      $schema: "https://json-schema.org/draft/2020-12/schema",
+      type: "string",
+      "x-maxUtf8Bytes": 4096,
+      "x-maxSegmentUtf8Bytes": 255,
+    },
+    cases: [{ value: accepted }, { value: rejected }],
+  });
+  if (JSON.stringify(results) !== JSON.stringify([true, false])) {
+    throw new Error(`UTF-8 byte keyword boundary mismatch: ${JSON.stringify(results)}`);
+  }
+  console.log("OK — UTF-8 byte keywords enforce the 255/256-byte segment boundary");
+}
+
+const invokedPath = process.argv[1] ? resolve(process.argv[1]) : "";
+if (invokedPath === fileURLToPath(import.meta.url)) {
+  run();
+}

--- a/tests/contract/contract_schema_parity.rs
+++ b/tests/contract/contract_schema_parity.rs
@@ -1,6 +1,8 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
+mod spec062_portable_contracts;
+
 use std::{collections::BTreeSet, fs, path::PathBuf};
 
 use contracts_core::{

--- a/tests/contract/spec062_portable_contracts.rs
+++ b/tests/contract/spec062_portable_contracts.rs
@@ -5,26 +5,34 @@ use std::collections::HashSet;
 
 use contracts_core::sessions::heterogeneity::calibration::{
     AutomaticEligibility, CalibrationCandidateEvidence, CalibrationHandoffFrame, CalibrationKind,
-    CalibrationListOperation, IndexedReadableState,
+    CalibrationListOperation, CalibrationQuery, HandoffOperationQueryRequest, IndexedReadableState,
 };
-use contracts_core::sessions::heterogeneity::inbox::InboxListOperation;
-use contracts_core::sessions::heterogeneity::metadata::MetadataListOperation;
-use contracts_core::sessions::heterogeneity::projects::ProjectListOperation;
+use contracts_core::sessions::heterogeneity::inbox::{
+    InboxListOperation, InboxQuery, OperationQueryRequest,
+};
+use contracts_core::sessions::heterogeneity::metadata::{
+    MetadataEvidenceQueryRequest, MetadataListOperation, MetadataQuery,
+};
+use contracts_core::sessions::heterogeneity::projects::{
+    ProjectListOperation, ProjectQuery, ProjectQueryRequest, RelatedSessionListRequest,
+};
 use contracts_core::sessions::heterogeneity::relations::{
     EvidenceTernary, ManualRelationCreateRequest, ManualRelationKind, ManualTargetScope,
-    ParityEvidence, RelationEvidence, RelationListOperation, TargetCompatibility,
+    PanelListRequest, ParityEvidence, RelationEvidence, RelationListOperation, RelationQuery,
+    SessionQueryRequest, TargetCompatibility, TraversalStartRequest,
 };
 use contracts_core::sessions::heterogeneity::settings::{
     CalibrationAgePolicy, DarkThermalThresholds, FixedMatchingRules, FlatAgeThresholds,
-    FlatOrientationThresholds, GeometryThresholds, MatchingSettings, MosaicThresholds,
-    SettingsSeverity,
+    FlatOrientationThresholds, GeometryThresholds, MatchingSettings, MatchingSettingsGetRequest,
+    MatchingSettingsQuery, MosaicThresholds, SettingsSeverity,
 };
 use contracts_core::sessions::heterogeneity::shared::{
-    BoundedList, CanonicalId, CanonicalRelativePath, CommandFence, ContractRange, Cursor,
-    EntityRef, ErrorCode, FiniteDecimal, IdempotencyOutcome, KeysetListOperation, MutationContext,
-    NonBlankSafeText, Page, PageBasis, PageRequest, PortableContractError, ProtectedResourceState,
-    RevisionRef, Rfc3339Timestamp, SafeErrorDetails, SafeText, SupportedFrameKind,
-    MAX_CURSOR_BYTES, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES,
+    BoundedList, CanonicalId, CanonicalRelativePath, CanonicalUuid, CommandFence, ContractRange,
+    Cursor, EntityRef, ErrorCode, FiniteDecimal, IdempotencyOutcome, KeysetListOperation,
+    MutationContext, NamedSafeValue, NonBlankSafeText, Page, PageBasis, PageRequest,
+    PortableContractError, ProtectedResourceState, RevisionRef, Rfc3339Timestamp, SafeErrorDetails,
+    SafeScalar, SafeText, SupportedFrameKind, MAX_CURSOR_BYTES, MAX_REQUEST_BYTES,
+    MAX_RESPONSE_BYTES,
 };
 use schemars::schema_for;
 use serde_json::{json, Value};
@@ -35,6 +43,10 @@ const DIGEST: &str = "sha256:000000000000000000000000000000000000000000000000000
 
 fn id(value: &str) -> CanonicalId {
     CanonicalId::try_new(value).expect("fixture id is canonical")
+}
+
+fn uuid(value: &str) -> CanonicalUuid {
+    CanonicalUuid::try_new(value).expect("fixture UUID is canonical")
 }
 
 fn safe(value: &str) -> SafeText {
@@ -58,7 +70,7 @@ where
         let order = operation.unique_order();
         assert!(!order.is_empty(), "list operation must define a total order");
         assert!(
-            order.last().is_some_and(|field| field.ends_with(" ASC")),
+            order.last().is_some_and(|field| field.ends_with(" ASC") || field.ends_with(" DESC")),
             "the final keyset tie-breaker must be deterministic"
         );
     }
@@ -102,12 +114,32 @@ fn portable_bounds_are_enforced_during_construction_and_decode() {
     assert!(serde_json::from_value::<BoundedList<u8, 2>>(json!([1, 2, 3])).is_err());
     assert!(PageRequest::try_new(None, 0).is_err());
     assert!(PageRequest::try_new(None, 501).is_err());
+    assert_eq!(serde_json::from_value::<PageRequest>(json!({})).unwrap().limit, 100);
     assert!(serde_json::from_value::<PageRequest>(json!({ "limit": 501 })).is_err());
     assert!(Cursor::try_new("x".repeat(MAX_CURSOR_BYTES + 1)).is_err());
     assert!(SafeText::try_new("contains\ncontrol").is_err());
     assert!(CanonicalRelativePath::try_new("../outside.fit").is_err());
+    assert!(CanonicalId::try_new("550e8400-e29b-41d4-a716-446655440000").is_err());
+    assert!(CanonicalUuid::try_new("550e8400-e29b-41d4-a716-446655440000").is_ok());
     assert_eq!(MAX_REQUEST_BYTES, 1_048_576);
     assert_eq!(MAX_RESPONSE_BYTES, 4_194_304);
+}
+
+#[test]
+fn runtime_bounds_and_defaults_are_present_in_json_schema() {
+    let bounded = serde_json::to_value(schema_for!(BoundedList<u8, 2>)).unwrap();
+    assert_eq!(bounded["maxItems"], 2);
+
+    let page = serde_json::to_value(schema_for!(PageRequest)).unwrap();
+    assert_eq!(page["properties"]["limit"]["default"], 100);
+    assert_eq!(page["properties"]["limit"]["minimum"], 1);
+    assert_eq!(page["properties"]["limit"]["maximum"], 500);
+    assert!(!page["required"]
+        .as_array()
+        .is_some_and(|required| { required.iter().any(|field| field == "limit") }));
+
+    let entity_id = serde_json::to_value(schema_for!(CanonicalId)).unwrap();
+    assert!(entity_id["pattern"].as_str().unwrap().contains("-7"));
 }
 
 #[test]
@@ -119,6 +151,83 @@ fn every_reviewed_list_operation_has_a_unique_name_and_total_keyset_order() {
     assert_registry(RelationListOperation::ALL, &mut names);
     assert_registry(ProjectListOperation::ALL, &mut names);
     assert_eq!(names.len(), 65);
+}
+
+#[test]
+fn published_total_order_tuples_use_exact_documented_paths() {
+    assert_eq!(
+        MetadataListOperation::PanelConsequenceLineage.unique_order(),
+        &[
+            "ordinal ASC",
+            "lineage.predecessorPanelGroupId ASC",
+            "lineage.successorPanelGroupId ASC",
+        ]
+    );
+    assert_eq!(
+        MetadataListOperation::ApplyPanelRevision.unique_order(),
+        &["ordinal ASC", "revisionRef.revisionId ASC"]
+    );
+    for operation in [
+        RelationListOperation::ProposalSourceRevision,
+        RelationListOperation::ProposalSubject,
+        RelationListOperation::ProposalMembership,
+        RelationListOperation::ProposalEdge,
+        RelationListOperation::ProposalLineage,
+        RelationListOperation::DecisionRevision,
+        RelationListOperation::DecisionRetiredGroup,
+        RelationListOperation::DecisionSessionSupersession,
+        RelationListOperation::DecisionGroupLineage,
+        RelationListOperation::TraversalNode,
+        RelationListOperation::TraversalEdge,
+    ] {
+        assert_eq!(operation.unique_order(), &["ordinal ASC"], "{}", operation.query_name());
+    }
+    assert_eq!(RelationListOperation::PanelHistory.unique_order(), &["revisionNumber DESC"]);
+    assert_eq!(RelationListOperation::MosaicHistory.unique_order(), &["revisionNumber DESC"]);
+    assert_eq!(ProjectListOperation::PlanOverlayMapping.unique_order(), &["ordinal ASC"]);
+}
+
+#[test]
+fn six_surface_wire_operations_are_dotted_flat_and_operation_specific() {
+    let samples = [
+        serde_json::to_value(InboxQuery::Materialization(OperationQueryRequest {
+            operation_id: id(ID),
+        }))
+        .unwrap(),
+        serde_json::to_value(MetadataQuery::Evidence(MetadataEvidenceQueryRequest {
+            session_id: id(ID),
+            evidence_revision: Some(3),
+        }))
+        .unwrap(),
+        serde_json::to_value(RelationQuery::Session(SessionQueryRequest { session_id: id(ID) }))
+            .unwrap(),
+        serde_json::to_value(ProjectQuery::ViewState(ProjectQueryRequest { project_id: id(ID) }))
+            .unwrap(),
+        serde_json::to_value(CalibrationQuery::HandoffOperation(HandoffOperationQueryRequest {
+            operation_id: id(ID),
+        }))
+        .unwrap(),
+        serde_json::to_value(MatchingSettingsQuery::Get(MatchingSettingsGetRequest {
+            revision: Some(7),
+        }))
+        .unwrap(),
+    ];
+    let operations = [
+        "session.materialization.query",
+        "metadata.evidence.query",
+        "session.query",
+        "project.view_state.query",
+        "calibration.handoff.operation.query",
+        "matching_settings.get",
+    ];
+    for (sample, operation) in samples.iter().zip(operations) {
+        assert_eq!(sample["operation"], operation);
+        assert!(sample.get("payload").is_none());
+    }
+    assert_eq!(samples[1]["sessionId"], ID);
+    assert_eq!(samples[1]["evidenceRevision"], 3);
+    assert!(samples[1].get("entityId").is_none());
+    assert_eq!(samples[2]["sessionId"], ID);
 }
 
 #[test]
@@ -206,9 +315,9 @@ fn stale_errors_are_typed_and_detail_shapes_are_allowlisted_on_decode() {
     let stale = PortableContractError::try_new(
         ErrorCode::RelationProposalStale,
         safe("Proposal basis is stale."),
-        Some(SafeErrorDetails::Domain {
-            code: safe("relation_proposal.stale"),
-            values: BoundedList::default(),
+        Some(SafeErrorDetails::StaleRevisions {
+            revisions: BoundedList::default(),
+            total_count: 0,
             decision_snapshot_id: Some(id(ID)),
         }),
     )
@@ -227,6 +336,21 @@ fn stale_errors_are_typed_and_detail_shapes_are_allowlisted_on_decode() {
         }
     });
     assert!(serde_json::from_value::<PortableContractError>(invalid).is_err());
+
+    let wrong_field = PortableContractError::try_new(
+        ErrorCode::SessionNotFound,
+        safe("Session was not found."),
+        Some(SafeErrorDetails::Domain {
+            code: safe("session.not_found"),
+            values: BoundedList::try_new(vec![NamedSafeValue {
+                name: safe("secretPath"),
+                value: SafeScalar::Text(safe("redacted")),
+            }])
+            .unwrap(),
+            decision_snapshot_id: None,
+        }),
+    );
+    assert!(wrong_field.is_err());
 }
 
 #[test]
@@ -241,9 +365,9 @@ fn protected_missing_and_unauthorized_resources_are_indistinguishable() {
 
 #[test]
 fn idempotency_and_fencing_have_explicit_portable_states() {
-    let current = CommandFence { command_id: id(ID), lease_generation: 7 };
-    let stale = CommandFence { command_id: id(ID), lease_generation: 6 };
-    let other = CommandFence { command_id: id(OTHER_ID), lease_generation: 7 };
+    let current = CommandFence { command_id: uuid(ID), lease_generation: 7 };
+    let stale = CommandFence { command_id: uuid(ID), lease_generation: 6 };
+    let other = CommandFence { command_id: uuid(OTHER_ID), lease_generation: 7 };
     assert!(current.is_current(&current));
     assert!(!stale.is_current(&current));
     assert!(!other.is_current(&current));
@@ -285,16 +409,66 @@ fn manual_relation_request_discloses_missing_evidence_and_required_collections()
         },
         review_reason: non_blank("Reviewed by operator"),
         mutation_context: MutationContext {
-            command_id: id(OTHER_ID),
+            command_id: uuid(OTHER_ID),
             reason: Some(safe("manual relation")),
             approval_digest: None,
         },
     };
 
     assert!(request.has_required_collections());
-    let encoded = serde_json::to_value(request).unwrap();
+    let encoded = serde_json::to_value(&request).unwrap();
     assert_eq!(encoded["relationKind"], "panel_add");
     assert_eq!(encoded["evidence"]["missingEvidenceCodes"][0], "equipment.unknown");
+    assert_eq!(
+        serde_json::from_value::<ManualRelationCreateRequest>(encoded.clone()).unwrap(),
+        request
+    );
+
+    let mut wrong_kind = encoded.clone();
+    wrong_kind["relationKind"] = json!("mosaic_edge");
+    assert!(serde_json::from_value::<ManualRelationCreateRequest>(wrong_kind).is_err());
+
+    let mut duplicate_cross_target = encoded;
+    duplicate_cross_target["targetScope"] = json!({
+        "kind": "new_reviewed_cross_target",
+        "canonicalTargetIds": [ID, ID],
+        "purpose": "Reviewed association"
+    });
+    assert!(serde_json::from_value::<ManualRelationCreateRequest>(duplicate_cross_target).is_err());
+}
+
+#[test]
+fn optional_defaults_and_relation_bounds_are_enforced_on_decode() {
+    let panel: PanelListRequest = serde_json::from_value(json!({ "page": {} })).unwrap();
+    assert!(panel.active_only);
+
+    let related: RelatedSessionListRequest = serde_json::from_value(json!({
+        "projectId": ID,
+        "page": {}
+    }))
+    .unwrap();
+    assert!(related.include_pinned);
+
+    let traversal: TraversalStartRequest = serde_json::from_value(json!({
+        "startRefs": [{ "entityType": "panel_group", "entityId": ID }],
+        "graph": "panel_lineage",
+        "direction": "both"
+    }))
+    .unwrap();
+    assert_eq!(traversal.limits.max_depth, 64);
+    assert_eq!(traversal.limits.max_nodes, 10_000);
+    assert_eq!(traversal.limits.max_edges, 50_000);
+    assert!(serde_json::from_value::<TraversalStartRequest>(json!({
+        "startRefs": [{ "entityType": "panel_group", "entityId": ID }],
+        "graph": "panel_lineage",
+        "direction": "both",
+        "limits": { "maxDepth": 0, "maxNodes": 1, "maxEdges": 1 }
+    }))
+    .is_err());
+
+    let mut fixed = serde_json::to_value(FixedMatchingRules::default()).unwrap();
+    fixed["opticalProfileSameMaxPercent"] = json!(6);
+    assert!(serde_json::from_value::<FixedMatchingRules>(fixed).is_err());
 }
 
 #[test]

--- a/tests/contract/spec062_portable_contracts.rs
+++ b/tests/contract/spec062_portable_contracts.rs
@@ -1,30 +1,31 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-use std::collections::HashSet;
-
 use contracts_core::sessions::heterogeneity::calibration::{
-    AutomaticEligibility, CalibrationCandidateEvidence, CalibrationHandoffFrame, CalibrationKind,
-    CalibrationListOperation, CalibrationQuery, HandoffOperationQueryRequest, IndexedReadableState,
+    AutomaticEligibility, CalibrationCandidateEvidence, CalibrationEvent, CalibrationHandoffFrame,
+    CalibrationKind, CalibrationListOperation, CalibrationQuery, HandoffOperationQueryRequest,
+    IndexedReadableState,
 };
 use contracts_core::sessions::heterogeneity::inbox::{
-    InboxListOperation, InboxQuery, OperationQueryRequest,
+    InboxEvent, InboxListOperation, InboxQuery, OperationQueryRequest,
 };
 use contracts_core::sessions::heterogeneity::metadata::{
-    MetadataEvidenceQueryRequest, MetadataListOperation, MetadataQuery,
+    MetadataEvent, MetadataEvidenceQueryRequest, MetadataListOperation, MetadataQuery,
 };
 use contracts_core::sessions::heterogeneity::projects::{
-    ProjectListOperation, ProjectQuery, ProjectQueryRequest, RelatedSessionListRequest,
+    ProjectEvent, ProjectListOperation, ProjectQuery, ProjectQueryRequest,
+    RelatedSessionListRequest,
 };
 use contracts_core::sessions::heterogeneity::relations::{
     EvidenceTernary, ManualRelationCreateRequest, ManualRelationKind, ManualTargetScope,
-    PanelListRequest, ParityEvidence, RelationEvidence, RelationListOperation, RelationQuery,
-    SessionQueryRequest, TargetCompatibility, TraversalStartRequest,
+    PanelListRequest, ParityEvidence, RelationEvent, RelationEvidence, RelationListOperation,
+    RelationQuery, SessionQueryRequest, TargetCompatibility, TraversalStartRequest,
 };
 use contracts_core::sessions::heterogeneity::settings::{
     CalibrationAgePolicy, DarkThermalThresholds, FixedMatchingRules, FlatAgeThresholds,
-    FlatOrientationThresholds, GeometryThresholds, MatchingSettings, MatchingSettingsGetRequest,
-    MatchingSettingsQuery, MosaicThresholds, SettingsSeverity,
+    FlatOrientationThresholds, GeometryThresholds, MatchingSettings, MatchingSettingsEvent,
+    MatchingSettingsGetRequest, MatchingSettingsQuery, MatchingSettingsUpdatedEvent,
+    MosaicThresholds, SettingsSeverity,
 };
 use contracts_core::sessions::heterogeneity::shared::{
     BoundedList, CanonicalId, CanonicalRelativePath, CanonicalUuid, CommandFence, ContractRange,
@@ -61,18 +62,14 @@ fn decimal(value: f64) -> FiniteDecimal {
     FiniteDecimal::try_new(value).expect("fixture decimal is finite")
 }
 
-fn assert_registry<T, const N: usize>(operations: [T; N], names: &mut HashSet<&'static str>)
-where
+fn append_registry<T, const N: usize>(
+    operations: [T; N],
+    entries: &mut Vec<(&'static str, &'static [&'static str])>,
+) where
     T: Copy + KeysetListOperation,
 {
     for operation in operations {
-        assert!(names.insert(operation.query_name()), "duplicate query operation");
-        let order = operation.unique_order();
-        assert!(!order.is_empty(), "list operation must define a total order");
-        assert!(
-            order.last().is_some_and(|field| field.ends_with(" ASC") || field.ends_with(" DESC")),
-            "the final keyset tie-breaker must be deterministic"
-        );
+        entries.push((operation.query_name(), operation.unique_order()));
     }
 }
 
@@ -140,51 +137,219 @@ fn runtime_bounds_and_defaults_are_present_in_json_schema() {
 
     let entity_id = serde_json::to_value(schema_for!(CanonicalId)).unwrap();
     assert!(entity_id["pattern"].as_str().unwrap().contains("-7"));
-}
 
-#[test]
-fn every_reviewed_list_operation_has_a_unique_name_and_total_keyset_order() {
-    let mut names = HashSet::new();
-    assert_registry(InboxListOperation::ALL, &mut names);
-    assert_registry(MetadataListOperation::ALL, &mut names);
-    assert_registry(CalibrationListOperation::ALL, &mut names);
-    assert_registry(RelationListOperation::ALL, &mut names);
-    assert_registry(ProjectListOperation::ALL, &mut names);
-    assert_eq!(names.len(), 65);
-}
-
-#[test]
-fn published_total_order_tuples_use_exact_documented_paths() {
-    assert_eq!(
-        MetadataListOperation::PanelConsequenceLineage.unique_order(),
-        &[
-            "ordinal ASC",
-            "lineage.predecessorPanelGroupId ASC",
-            "lineage.successorPanelGroupId ASC",
-        ]
-    );
-    assert_eq!(
-        MetadataListOperation::ApplyPanelRevision.unique_order(),
-        &["ordinal ASC", "revisionRef.revisionId ASC"]
-    );
-    for operation in [
-        RelationListOperation::ProposalSourceRevision,
-        RelationListOperation::ProposalSubject,
-        RelationListOperation::ProposalMembership,
-        RelationListOperation::ProposalEdge,
-        RelationListOperation::ProposalLineage,
-        RelationListOperation::DecisionRevision,
-        RelationListOperation::DecisionRetiredGroup,
-        RelationListOperation::DecisionSessionSupersession,
-        RelationListOperation::DecisionGroupLineage,
-        RelationListOperation::TraversalNode,
-        RelationListOperation::TraversalEdge,
-    ] {
-        assert_eq!(operation.unique_order(), &["ordinal ASC"], "{}", operation.query_name());
+    let relative_path = serde_json::to_value(schema_for!(CanonicalRelativePath)).unwrap();
+    assert_eq!(relative_path["x-maxUtf8Bytes"], 4096);
+    assert_eq!(relative_path["x-maxSegmentUtf8Bytes"], 255);
+    let path_pattern = relative_path["pattern"].as_str().unwrap();
+    for structural_rule in ["(?!/)", "(?![A-Za-z]:)", "(?!.*\\\\)", "\\.\\.?", "{0,63}"] {
+        assert!(path_pattern.contains(structural_rule), "missing schema rule {structural_rule}");
     }
-    assert_eq!(RelationListOperation::PanelHistory.unique_order(), &["revisionNumber DESC"]);
-    assert_eq!(RelationListOperation::MosaicHistory.unique_order(), &["revisionNumber DESC"]);
-    assert_eq!(ProjectListOperation::PlanOverlayMapping.unique_order(), &["ordinal ASC"]);
+}
+
+#[test]
+fn relative_path_runtime_matches_every_published_schema_boundary() {
+    for accepted in ["frame.fit", "night-1/frame.fit", &"a".repeat(255)] {
+        assert!(CanonicalRelativePath::try_new(accepted).is_ok(), "accepted path: {accepted}");
+    }
+    let too_many_segments = std::iter::repeat_n("a", 65).collect::<Vec<_>>().join("/");
+    let too_many_bytes = std::iter::repeat_n("a".repeat(64), 64).collect::<Vec<_>>().join("/");
+    for rejected in [
+        "",
+        "/frame.fit",
+        "C:/frame.fit",
+        "night\\frame.fit",
+        "night//frame.fit",
+        "night/./frame.fit",
+        "night/../frame.fit",
+        "night/frame.fit/",
+        &"a".repeat(256),
+        &too_many_segments,
+        &too_many_bytes,
+    ] {
+        assert!(CanonicalRelativePath::try_new(rejected).is_err(), "rejected path: {rejected}");
+    }
+}
+
+#[test]
+#[allow(clippy::too_many_lines)]
+fn all_65_published_list_operations_match_the_documented_total_order_fixture() {
+    let mut actual = Vec::new();
+    append_registry(InboxListOperation::ALL, &mut actual);
+    append_registry(MetadataListOperation::ALL, &mut actual);
+    append_registry(RelationListOperation::ALL, &mut actual);
+    append_registry(ProjectListOperation::ALL, &mut actual);
+    append_registry(CalibrationListOperation::ALL, &mut actual);
+
+    let expected: &[(&str, &[&str])] = &[
+        (
+            "inbox.acquisition_site_candidate.list",
+            &["confidenceRank DESC", "normalizedLabel ASC", "siteId ASC"],
+        ),
+        (
+            "inbox.materialization_plan.proposed_session.list",
+            &["ordinal ASC", "proposedSessionKey ASC"],
+        ),
+        ("inbox.materialization_plan.proposed_frame.list", &["ordinal ASC", "frameId ASC"]),
+        ("inbox.materialization_plan.blocked_frame.list", &["ordinal ASC", "frameId ASC"]),
+        ("session.materialization.result_session.list", &["ordinal ASC", "sessionId ASC"]),
+        ("session.materialization.result_frame.list", &["ordinal ASC", "frameId ASC"]),
+        ("session.materialization.blocked_frame.list", &["ordinal ASC", "frameId ASC"]),
+        ("metadata.reclassification.replacement_frame.list", &["ordinal ASC", "frameId ASC"]),
+        (
+            "metadata.reclassification.replacement_session.list",
+            &["ordinal ASC", "replacementKey ASC"],
+        ),
+        ("metadata.reclassification.panel_consequence.list", &["ordinal ASC", "panelGroupId ASC"]),
+        (
+            "metadata.reclassification.panel_consequence_session.list",
+            &["ordinal ASC", "proposedSessionId ASC"],
+        ),
+        (
+            "metadata.reclassification.panel_consequence_retirement.list",
+            &["ordinal ASC", "predecessorPanelGroupId ASC"],
+        ),
+        (
+            "metadata.reclassification.panel_consequence_lineage.list",
+            &[
+                "ordinal ASC",
+                "lineage.predecessorPanelGroupId ASC",
+                "lineage.successorPanelGroupId ASC",
+            ],
+        ),
+        ("metadata.reclassification.stale_mosaic_edge.list", &["ordinal ASC", "edgeId ASC"]),
+        (
+            "metadata.reclassification.project_consequence.list",
+            &["projectId ASC", "unchangedPinnedSessionId ASC"],
+        ),
+        (
+            "metadata.reclassification.project_consequence_replacement.list",
+            &["ordinal ASC", "replacementKey ASC"],
+        ),
+        (
+            "metadata.reclassification.apply_result.replacement_session.list",
+            &["ordinal ASC", "replacementSessionId ASC"],
+        ),
+        (
+            "metadata.reclassification.apply_result.panel_revision.list",
+            &["ordinal ASC", "revisionRef.revisionId ASC"],
+        ),
+        (
+            "metadata.reclassification.apply_result.invalidated_edge.list",
+            &["ordinal ASC", "edgeId ASC"],
+        ),
+        (
+            "metadata.reclassification.apply_result.retired_panel_group.list",
+            &["ordinal ASC", "panelGroupId ASC"],
+        ),
+        (
+            "metadata.reclassification.apply_result.panel_lineage.list",
+            &[
+                "ordinal ASC",
+                "lineage.predecessorPanelGroupId ASC",
+                "lineage.successorPanelGroupId ASC",
+            ],
+        ),
+        (
+            "metadata.reclassification.apply_result.project_proposal.list",
+            &["ordinal ASC", "projectReplacementProposalId ASC"],
+        ),
+        ("session.list", &["createdAt DESC", "sessionId ASC"]),
+        ("session.frame.list", &["ordinal ASC", "frameId ASC"]),
+        ("session.supersession_successor.list", &["ordinal ASC", "successorSessionId ASC"]),
+        ("session.supersession_predecessor.list", &["ordinal ASC", "predecessorSessionId ASC"]),
+        ("panel_group.membership.list", &["ordinal ASC", "sessionId ASC"]),
+        ("panel_group.history.list", &["revisionNumber DESC", "revisionId ASC"]),
+        (
+            "panel_group.lineage_predecessor.list",
+            &["acceptedAt DESC", "acceptedProposalId ASC", "ordinal ASC", "predecessorGroupId ASC"],
+        ),
+        (
+            "panel_group.lineage_successor.list",
+            &["acceptedAt DESC", "acceptedProposalId ASC", "ordinal ASC", "successorGroupId ASC"],
+        ),
+        ("panel_group.list", &["acceptedAt DESC", "panelGroupId ASC"]),
+        ("mosaic.panel.list", &["ordinal ASC", "panelRevisionId ASC", "panelGroupId ASC"]),
+        ("mosaic.edge.list", &["ordinal ASC", "edgeId ASC"]),
+        ("mosaic.history.list", &["revisionNumber DESC", "revisionId ASC"]),
+        (
+            "mosaic.lineage_predecessor.list",
+            &[
+                "acceptedAt DESC",
+                "acceptedProposalId ASC",
+                "ordinal ASC",
+                "predecessorMosaicId ASC",
+            ],
+        ),
+        (
+            "mosaic.lineage_successor.list",
+            &["acceptedAt DESC", "acceptedProposalId ASC", "ordinal ASC", "successorMosaicId ASC"],
+        ),
+        ("mosaic.object_evidence.list", &["canonicalObjectId ASC"]),
+        ("relation_proposal.list", &["createdAt DESC", "proposalId ASC"]),
+        (
+            "relation_proposal.source_revision.list",
+            &["ordinal ASC", "entityType ASC", "entityId ASC", "revisionId ASC"],
+        ),
+        ("relation_proposal.subject.list", &["ordinal ASC", "entityType ASC", "entityId ASC"]),
+        ("relation_proposal.membership.list", &["ordinal ASC", "entityType ASC", "entityId ASC"]),
+        ("relation_proposal.edge.list", &["ordinal ASC", "edgeId ASC"]),
+        (
+            "relation_proposal.lineage.list",
+            &["ordinal ASC", "predecessorGroupId ASC", "successorGroupId ASC"],
+        ),
+        (
+            "relation_proposal.decision_revision.list",
+            &["ordinal ASC", "entityType ASC", "entityId ASC", "revisionId ASC"],
+        ),
+        ("relation_proposal.decision_retired_group.list", &["ordinal ASC", "groupId ASC"]),
+        (
+            "relation_proposal.decision_session_supersession.list",
+            &["ordinal ASC", "predecessorSessionId ASC", "successorSessionId ASC"],
+        ),
+        (
+            "relation_proposal.decision_group_lineage.list",
+            &["ordinal ASC", "predecessorGroupId ASC", "successorGroupId ASC"],
+        ),
+        (
+            "relation_traversal_preview.node.list",
+            &["ordinal ASC", "nodeRef.entityType ASC", "nodeRef.entityId ASC"],
+        ),
+        (
+            "relation_traversal_preview.edge.list",
+            &["ordinal ASC", "edgeRef.entityType ASC", "edgeRef.entityId ASC"],
+        ),
+        ("project.related_session.list", &["firstAvailableAt DESC", "sessionId ASC"]),
+        ("project.view_state.pin.list", &["sessionId ASC"]),
+        ("project.view_state.materialized_session.list", &["sessionId ASC"]),
+        ("project.view_state.unmaterialized_session.list", &["sessionId ASC"]),
+        ("project.manifest.entry.list", &["ordinal ASC", "entryId ASC"]),
+        ("project.manifest.correction_overlay.list", &["ordinal ASC", "overlayId ASC"]),
+        ("project.correction_overlay.mapping.list", &["ordinal ASC", "predecessorEntryId ASC"]),
+        ("project.update_view.pinned_session.list", &["ordinal ASC", "sessionId ASC"]),
+        ("project.update_view.added_session.list", &["ordinal ASC", "sessionId ASC"]),
+        ("project.update_view.item.list", &["ordinal ASC", "itemId ASC"]),
+        ("project.update_view.conflict.list", &["ordinal ASC", "itemId ASC"]),
+        ("project.update_view.overlay_mapping.list", &["ordinal ASC", "predecessorEntryId ASC"]),
+        (
+            "calibration.candidate.list",
+            &[
+                "compatibilityRank ASC",
+                "sufficiencyRank ASC",
+                "observingNight DESC",
+                "createdAt DESC",
+                "sessionId ASC",
+            ],
+        ),
+        ("calibration.handoff.requirement.list", &["requirementId ASC"]),
+        ("calibration.handoff.selection.list", &["selectedAt ASC", "selectionId ASC"]),
+        (
+            "calibration.handoff.frame.list",
+            &["selectionId ASC", "sessionMembershipOrdinal ASC", "frameId ASC"],
+        ),
+    ];
+    assert_eq!(expected.len(), 65);
+    assert_eq!(actual, expected);
 }
 
 #[test]
@@ -228,6 +393,88 @@ fn six_surface_wire_operations_are_dotted_flat_and_operation_specific() {
     assert_eq!(samples[1]["evidenceRevision"], 3);
     assert!(samples[1].get("entityId").is_none());
     assert_eq!(samples[2]["sessionId"], ID);
+}
+
+#[test]
+fn six_surface_events_use_published_dotted_discriminants_and_flat_fields() {
+    let samples = [
+        (
+            serde_json::to_value(InboxEvent::MaterializationDiscarded { plan_id: id(ID) }).unwrap(),
+            json!({ "event": "inbox.materialization_discarded", "planId": ID }),
+        ),
+        (
+            serde_json::to_value(MetadataEvent::ReclassificationDiscarded { plan_id: id(ID) })
+                .unwrap(),
+            json!({ "event": "metadata.reclassification_discarded", "planId": ID }),
+        ),
+        (
+            serde_json::to_value(RelationEvent::SessionSuperseded {
+                predecessor_session_id: id(ID),
+                replacement_session_count: 2,
+                applied_reclassification_plan_revision_id: id(OTHER_ID),
+            })
+            .unwrap(),
+            json!({
+                "event": "session.superseded",
+                "predecessorSessionId": ID,
+                "replacementSessionCount": 2,
+                "appliedReclassificationPlanRevisionId": OTHER_ID,
+            }),
+        ),
+        (
+            serde_json::to_value(ProjectEvent::ViewStale {
+                project_id: id(ID),
+                unmaterialized_session_count: 3,
+            })
+            .unwrap(),
+            json!({
+                "event": "project.view_stale",
+                "projectId": ID,
+                "unmaterializedSessionCount": 3,
+            }),
+        ),
+        (
+            serde_json::to_value(CalibrationEvent::HandoffCreated {
+                project_id: id(ID),
+                handoff_id: id(OTHER_ID),
+                snapshot_id: id(ID),
+                automatic_selection_ids: BoundedList::default(),
+                unselected_requirement_ids: BoundedList::default(),
+                warning_codes: BoundedList::default(),
+            })
+            .unwrap(),
+            json!({
+                "event": "calibration.handoff_created",
+                "projectId": ID,
+                "handoffId": OTHER_ID,
+                "snapshotId": ID,
+                "automaticSelectionIds": [],
+                "unselectedRequirementIds": [],
+                "warningCodes": [],
+            }),
+        ),
+        (
+            serde_json::to_value(MatchingSettingsEvent::Updated(MatchingSettingsUpdatedEvent {
+                previous_revision: 7,
+                revision: 8,
+                changed_field_paths: BoundedList::default(),
+                warning_codes: BoundedList::default(),
+            }))
+            .unwrap(),
+            json!({
+                "event": "matching_settings.updated",
+                "previousRevision": 7,
+                "revision": 8,
+                "changedFieldPaths": [],
+                "warningCodes": [],
+            }),
+        ),
+    ];
+
+    for (actual, expected) in samples {
+        assert_eq!(actual, expected);
+        assert!(actual.get("payload").is_none());
+    }
 }
 
 #[test]
@@ -316,9 +563,10 @@ fn stale_errors_are_typed_and_detail_shapes_are_allowlisted_on_decode() {
         ErrorCode::RelationProposalStale,
         safe("Proposal basis is stale."),
         Some(SafeErrorDetails::StaleRevisions {
+            proposal_id: id(ID),
             revisions: BoundedList::default(),
             total_count: 0,
-            decision_snapshot_id: Some(id(ID)),
+            truncated: false,
         }),
     )
     .unwrap();
@@ -351,6 +599,104 @@ fn stale_errors_are_typed_and_detail_shapes_are_allowlisted_on_decode() {
         }),
     );
     assert!(wrong_field.is_err());
+}
+
+#[test]
+fn domain_errors_require_the_exact_published_field_set() {
+    let detail = |code: &str, values: Vec<(&str, SafeScalar)>, decision_snapshot_id| {
+        SafeErrorDetails::Domain {
+            code: safe(code),
+            values: BoundedList::try_new(
+                values
+                    .into_iter()
+                    .map(|(name, value)| NamedSafeValue { name: safe(name), value })
+                    .collect(),
+            )
+            .unwrap(),
+            decision_snapshot_id,
+        }
+    };
+    let text = || SafeScalar::Text(safe(ID));
+
+    assert!(PortableContractError::try_new(
+        ErrorCode::SessionNotFound,
+        safe("Session was not found."),
+        Some(detail("session.not_found", vec![("sessionId", text())], None)),
+    )
+    .is_ok());
+    assert!(PortableContractError::try_new(
+        ErrorCode::SessionNotFound,
+        safe("Session was not found."),
+        Some(detail("session.not_found", vec![], None)),
+    )
+    .is_err());
+    assert!(PortableContractError::try_new(
+        ErrorCode::InboxPlanDigestMismatch,
+        safe("Digest mismatch."),
+        Some(detail(
+            "inbox.plan_digest_mismatch",
+            vec![("planId", text()), ("expectedDigest", text())],
+            None,
+        )),
+    )
+    .is_err());
+    assert!(PortableContractError::try_new(
+        ErrorCode::SessionNotFound,
+        safe("Session was not found."),
+        Some(detail(
+            "session.not_found",
+            vec![("sessionId", text()), ("unexpected", text())],
+            None,
+        )),
+    )
+    .is_err());
+    assert!(PortableContractError::try_new(
+        ErrorCode::SessionNotFound,
+        safe("Session was not found."),
+        Some(
+            detail("session.not_found", vec![("sessionId", text()), ("sessionId", text())], None,)
+        ),
+    )
+    .is_err());
+    assert!(PortableContractError::try_new(
+        ErrorCode::InboxPlanStale,
+        safe("Plan is stale."),
+        Some(detail(
+            "inbox.plan_stale",
+            vec![("planId", text()), ("staleRevisionCount", SafeScalar::Unsigned(1)),],
+            None,
+        )),
+    )
+    .is_err());
+    assert!(PortableContractError::try_new(
+        ErrorCode::InboxPlanStale,
+        safe("Plan is stale."),
+        Some(detail(
+            "inbox.plan_stale",
+            vec![("planId", text()), ("staleRevisionCount", SafeScalar::Unsigned(1)),],
+            Some(id(ID)),
+        )),
+    )
+    .is_ok());
+    assert!(PortableContractError::try_new(
+        ErrorCode::SessionNotFound,
+        safe("Session was not found."),
+        Some(detail("session.not_found", vec![("sessionId", text())], Some(id(ID)),)),
+    )
+    .is_err());
+    assert!(PortableContractError::try_new(
+        ErrorCode::CalibrationHandoffTooLarge,
+        safe("Handoff is too large."),
+        Some(detail(
+            "calibration.handoff_too_large",
+            vec![
+                ("sourceByteCount", SafeScalar::Unsigned(10)),
+                ("maximumSourceBytes", SafeScalar::Unsigned(8)),
+            ],
+            None,
+        )),
+    )
+    .is_ok());
 }
 
 #[test]
@@ -447,7 +793,7 @@ fn optional_defaults_and_relation_bounds_are_enforced_on_decode() {
         "page": {}
     }))
     .unwrap();
-    assert!(related.include_pinned);
+    assert!(!related.include_pinned);
 
     let traversal: TraversalStartRequest = serde_json::from_value(json!({
         "startRefs": [{ "entityType": "panel_group", "entityId": ID }],

--- a/tests/contract/spec062_portable_contracts.rs
+++ b/tests/contract/spec062_portable_contracts.rs
@@ -1,0 +1,333 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+use std::collections::HashSet;
+
+use contracts_core::sessions::heterogeneity::calibration::{
+    AutomaticEligibility, CalibrationCandidateEvidence, CalibrationHandoffFrame, CalibrationKind,
+    CalibrationListOperation, IndexedReadableState,
+};
+use contracts_core::sessions::heterogeneity::inbox::InboxListOperation;
+use contracts_core::sessions::heterogeneity::metadata::MetadataListOperation;
+use contracts_core::sessions::heterogeneity::projects::ProjectListOperation;
+use contracts_core::sessions::heterogeneity::relations::{
+    EvidenceTernary, ManualRelationCreateRequest, ManualRelationKind, ManualTargetScope,
+    ParityEvidence, RelationEvidence, RelationListOperation, TargetCompatibility,
+};
+use contracts_core::sessions::heterogeneity::settings::{
+    CalibrationAgePolicy, DarkThermalThresholds, FixedMatchingRules, FlatAgeThresholds,
+    FlatOrientationThresholds, GeometryThresholds, MatchingSettings, MosaicThresholds,
+    SettingsSeverity,
+};
+use contracts_core::sessions::heterogeneity::shared::{
+    BoundedList, CanonicalId, CanonicalRelativePath, CommandFence, ContractRange, Cursor,
+    EntityRef, ErrorCode, FiniteDecimal, IdempotencyOutcome, KeysetListOperation, MutationContext,
+    NonBlankSafeText, Page, PageBasis, PageRequest, PortableContractError, ProtectedResourceState,
+    RevisionRef, Rfc3339Timestamp, SafeErrorDetails, SafeText, SupportedFrameKind,
+    MAX_CURSOR_BYTES, MAX_REQUEST_BYTES, MAX_RESPONSE_BYTES,
+};
+use schemars::schema_for;
+use serde_json::{json, Value};
+
+const ID: &str = "018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7f";
+const OTHER_ID: &str = "018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f80";
+const DIGEST: &str = "sha256:0000000000000000000000000000000000000000000000000000000000000000";
+
+fn id(value: &str) -> CanonicalId {
+    CanonicalId::try_new(value).expect("fixture id is canonical")
+}
+
+fn safe(value: &str) -> SafeText {
+    SafeText::try_new(value).expect("fixture text is safe")
+}
+
+fn non_blank(value: &str) -> NonBlankSafeText {
+    NonBlankSafeText::try_new(value).expect("fixture text is non-blank")
+}
+
+fn decimal(value: f64) -> FiniteDecimal {
+    FiniteDecimal::try_new(value).expect("fixture decimal is finite")
+}
+
+fn assert_registry<T, const N: usize>(operations: [T; N], names: &mut HashSet<&'static str>)
+where
+    T: Copy + KeysetListOperation,
+{
+    for operation in operations {
+        assert!(names.insert(operation.query_name()), "duplicate query operation");
+        let order = operation.unique_order();
+        assert!(!order.is_empty(), "list operation must define a total order");
+        assert!(
+            order.last().is_some_and(|field| field.ends_with(" ASC")),
+            "the final keyset tie-breaker must be deterministic"
+        );
+    }
+}
+
+#[test]
+fn snapshot_and_watermark_pages_round_trip_but_ambiguous_pages_are_rejected() {
+    let page = Page::try_new(
+        BoundedList::try_new(vec![safe("accepted")]).unwrap(),
+        PageBasis::Snapshot { snapshot_id: id(ID) },
+        Some(Cursor::try_new("next-page").unwrap()),
+    )
+    .unwrap();
+
+    let encoded = serde_json::to_value(&page).unwrap();
+    assert_eq!(encoded["snapshotId"], ID);
+    assert!(encoded.get("watermark").is_none());
+    assert_eq!(serde_json::from_value::<Page<SafeText>>(encoded).unwrap(), page);
+
+    let ambiguous = json!({
+        "items": [],
+        "snapshotId": ID,
+        "watermark": "42"
+    });
+    assert!(serde_json::from_value::<Page<SafeText>>(ambiguous).is_err());
+    assert!(serde_json::from_value::<Page<SafeText>>(json!({ "items": [] })).is_err());
+
+    let watermark = Page::<SafeText>::try_new(
+        BoundedList::default(),
+        PageBasis::Watermark { watermark: safe("43") },
+        None,
+    )
+    .unwrap();
+    assert_eq!(serde_json::to_value(watermark).unwrap()["watermark"], "43");
+}
+
+#[test]
+fn portable_bounds_are_enforced_during_construction_and_decode() {
+    assert!(BoundedList::<u8, 2>::try_new(vec![1, 2]).is_ok());
+    assert!(BoundedList::<u8, 2>::try_new(vec![1, 2, 3]).is_err());
+    assert!(serde_json::from_value::<BoundedList<u8, 2>>(json!([1, 2, 3])).is_err());
+    assert!(PageRequest::try_new(None, 0).is_err());
+    assert!(PageRequest::try_new(None, 501).is_err());
+    assert!(serde_json::from_value::<PageRequest>(json!({ "limit": 501 })).is_err());
+    assert!(Cursor::try_new("x".repeat(MAX_CURSOR_BYTES + 1)).is_err());
+    assert!(SafeText::try_new("contains\ncontrol").is_err());
+    assert!(CanonicalRelativePath::try_new("../outside.fit").is_err());
+    assert_eq!(MAX_REQUEST_BYTES, 1_048_576);
+    assert_eq!(MAX_RESPONSE_BYTES, 4_194_304);
+}
+
+#[test]
+fn every_reviewed_list_operation_has_a_unique_name_and_total_keyset_order() {
+    let mut names = HashSet::new();
+    assert_registry(InboxListOperation::ALL, &mut names);
+    assert_registry(MetadataListOperation::ALL, &mut names);
+    assert_registry(CalibrationListOperation::ALL, &mut names);
+    assert_registry(RelationListOperation::ALL, &mut names);
+    assert_registry(ProjectListOperation::ALL, &mut names);
+    assert_eq!(names.len(), 65);
+}
+
+#[test]
+fn unknown_calibration_evidence_is_explicitly_blocked() {
+    let candidate: CalibrationCandidateEvidence = serde_json::from_value(json!({
+        "evidenceId": ID,
+        "sessionId": ID,
+        "requirementId": ID,
+        "recipeCompatibility": "unknown",
+        "recipeEvidenceRef": "recipe-evidence",
+        "recipeEvidenceComplete": true,
+        "missingRecipeFields": [],
+        "temperatureMode": "unknown",
+        "age": {
+            "basis": "elapsed_days",
+            "state": "unknown",
+            "freshThroughDays": 30,
+            "redAfterDays": 365,
+            "settingsRevision": 4
+        },
+        "thermal": {
+            "state": "unknown",
+            "missingReadingCount": 1,
+            "invalidReadingCount": 0
+        },
+        "orientation": { "state": "not_applicable" },
+        "sourceAvailability": {
+            "indexedFrameCount": 4,
+            "availableReadableIndexedFrameCount": 4,
+            "checkedAt": "2026-07-22T00:00:00Z"
+        },
+        "sufficient": true,
+        "automaticEligibility": "blocked",
+        "warningCodes": ["calibration.temperature_unknown"],
+        "basisFingerprint": DIGEST
+    }))
+    .unwrap();
+
+    assert_eq!(candidate.automatic_eligibility, AutomaticEligibility::Blocked);
+    assert!(candidate.derives_blocked_state());
+}
+
+#[test]
+fn risky_but_valid_settings_produce_yellow_warnings() {
+    let settings = MatchingSettings {
+        revision: 8,
+        same_session: GeometryThresholds {
+            coverage_min_percent: decimal(92.0),
+            center_separation_max_percent: decimal(2.0),
+            rotation_max_deg: decimal(1.0),
+        },
+        sibling: GeometryThresholds {
+            coverage_min_percent: decimal(84.0),
+            center_separation_max_percent: decimal(5.0),
+            rotation_max_deg: decimal(5.0),
+        },
+        mosaic: MosaicThresholds {
+            overlap_min_percent: decimal(2.0),
+            overlap_max_percent: decimal(30.0),
+            residual_sky_rotation_cap_deg: decimal(90.0),
+        },
+        dark_thermal: DarkThermalThresholds {
+            moderate_deg: decimal(0.5),
+            severe_deg: decimal(2.0),
+        },
+        calibration_age: BoundedList::<CalibrationAgePolicy, 500>::default(),
+        flat_orientation: FlatOrientationThresholds {
+            normal_through_deg: decimal(2.0),
+            red_above_deg: decimal(6.0),
+        },
+        flat_age: FlatAgeThresholds { red_after_nights: 100 },
+        fixed_rules: FixedMatchingRules::default(),
+        updated_at: Rfc3339Timestamp::try_new("2026-07-22T00:00:00Z").unwrap(),
+        updated_by: id(ID),
+    };
+
+    let validation = settings.validate();
+    assert!(validation.valid);
+    assert!(!validation.issues.is_empty());
+    assert!(validation.issues.iter().all(|issue| issue.severity == SettingsSeverity::Yellow));
+}
+
+#[test]
+fn stale_errors_are_typed_and_detail_shapes_are_allowlisted_on_decode() {
+    let stale = PortableContractError::try_new(
+        ErrorCode::RelationProposalStale,
+        safe("Proposal basis is stale."),
+        Some(SafeErrorDetails::Domain {
+            code: safe("relation_proposal.stale"),
+            values: BoundedList::default(),
+            decision_snapshot_id: Some(id(ID)),
+        }),
+    )
+    .unwrap();
+    let encoded = serde_json::to_value(&stale).unwrap();
+    assert_eq!(encoded["code"], "relation_proposal.stale");
+    assert_eq!(serde_json::from_value::<PortableContractError>(encoded).unwrap(), stale);
+
+    let invalid = json!({
+        "code": "resource.unavailable",
+        "message": "Resource unavailable.",
+        "details": {
+            "kind": "domain",
+            "code": "secret",
+            "values": []
+        }
+    });
+    assert!(serde_json::from_value::<PortableContractError>(invalid).is_err());
+}
+
+#[test]
+fn protected_missing_and_unauthorized_resources_are_indistinguishable() {
+    let missing = ProtectedResourceState::Missing.projected_error().unwrap();
+    let unauthorized = ProtectedResourceState::Unauthorized.projected_error().unwrap();
+    assert_eq!(missing, unauthorized);
+    let encoded = serde_json::to_string(&missing).unwrap();
+    assert_eq!(encoded, r#"{"code":"resource.unavailable","message":"Resource unavailable."}"#);
+    assert!(!encoded.contains(ID));
+}
+
+#[test]
+fn idempotency_and_fencing_have_explicit_portable_states() {
+    let current = CommandFence { command_id: id(ID), lease_generation: 7 };
+    let stale = CommandFence { command_id: id(ID), lease_generation: 6 };
+    let other = CommandFence { command_id: id(OTHER_ID), lease_generation: 7 };
+    assert!(current.is_current(&current));
+    assert!(!stale.is_current(&current));
+    assert!(!other.is_current(&current));
+
+    let mismatch = IdempotencyOutcome::<SafeText>::PayloadMismatch;
+    assert_eq!(serde_json::to_value(mismatch).unwrap()["state"], "payload_mismatch");
+}
+
+#[test]
+fn manual_relation_request_discloses_missing_evidence_and_required_collections() {
+    let entity = EntityRef { entity_type: safe("session"), entity_id: id(ID) };
+    let request = ManualRelationCreateRequest {
+        relation_kind: ManualRelationKind::PanelAdd,
+        source_revision_refs: BoundedList::try_new(vec![RevisionRef {
+            entity_type: safe("panel_group"),
+            entity_id: id(ID),
+            revision_id: id(OTHER_ID),
+            revision_number: 3,
+        }])
+        .unwrap(),
+        subject_refs: BoundedList::try_new(vec![entity.clone()]).unwrap(),
+        proposed_membership_refs: Some(BoundedList::try_new(vec![entity]).unwrap()),
+        proposed_edges: None,
+        proposed_lineage: None,
+        target_scope: ManualTargetScope::SameTarget { canonical_target_id: id(ID) },
+        evidence: RelationEvidence {
+            evidence_id: id(ID),
+            target_compatibility: TargetCompatibility::SameTarget,
+            footprint_coverage_percent: None,
+            center_separation_percent: None,
+            residual_sky_rotation_deg: None,
+            allowed_residual_rotation_ranges_deg:
+                BoundedList::<ContractRange<FiniteDecimal>, 16>::default(),
+            parity: ParityEvidence::Unknown,
+            acquisition_geometry: EvidenceTernary::Unknown,
+            equipment: EvidenceTernary::Unknown,
+            missing_evidence_codes: BoundedList::try_new(vec![safe("equipment.unknown")]).unwrap(),
+            threshold_snapshot: BoundedList::default(),
+        },
+        review_reason: non_blank("Reviewed by operator"),
+        mutation_context: MutationContext {
+            command_id: id(OTHER_ID),
+            reason: Some(safe("manual relation")),
+            approval_digest: None,
+        },
+    };
+
+    assert!(request.has_required_collections());
+    let encoded = serde_json::to_value(request).unwrap();
+    assert_eq!(encoded["relationKind"], "panel_add");
+    assert_eq!(encoded["evidence"]["missingEvidenceCodes"][0], "equipment.unknown");
+}
+
+#[test]
+fn dark_flat_is_not_a_supported_frame_or_calibration_kind() {
+    assert!(serde_json::from_str::<CalibrationKind>(r#""dark_flat""#).is_err());
+    assert!(serde_json::from_str::<SupportedFrameKind>(r#""dark_flat""#).is_err());
+
+    let calibration_schema = serde_json::to_string(&schema_for!(CalibrationKind)).unwrap();
+    let frame_schema = serde_json::to_string(&schema_for!(SupportedFrameKind)).unwrap();
+    assert!(!calibration_schema.contains("dark_flat"));
+    assert!(!frame_schema.contains("dark_flat"));
+}
+
+#[test]
+fn redacted_calibration_sources_omit_paths_and_fingerprints() {
+    let redacted = CalibrationHandoffFrame::Redacted {
+        selection_id: id(ID),
+        session_id: id(ID),
+        session_membership_ordinal: 1,
+        frame_id: id(OTHER_ID),
+        source_state: IndexedReadableState::IndexedReadable,
+    };
+    let encoded = serde_json::to_value(redacted).unwrap();
+    assert_eq!(encoded["visibility"], "redacted");
+    for forbidden in
+        ["sourceRootId", "sourceRelativePath", "stableFileIdentity", "strongContentFingerprint"]
+    {
+        assert!(encoded.get(forbidden).is_none());
+    }
+}
+
+#[test]
+fn portable_error_and_contract_schema_roots_are_serializable() {
+    let schema: Value = serde_json::to_value(schema_for!(PortableContractError)).unwrap();
+    assert!(schema.get("$schema").is_some());
+}

--- a/tests/contract/spec062_portable_contracts.rs
+++ b/tests/contract/spec062_portable_contracts.rs
@@ -1,6 +1,9 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
+use std::io::Write;
+use std::process::{Command, Stdio};
+
 use contracts_core::sessions::heterogeneity::calibration::{
     AutomaticEligibility, CalibrationCandidateEvidence, CalibrationEvent, CalibrationHandoffFrame,
     CalibrationKind, CalibrationListOperation, CalibrationQuery, HandoffOperationQueryRequest,
@@ -168,6 +171,54 @@ fn relative_path_runtime_matches_every_published_schema_boundary() {
         &too_many_bytes,
     ] {
         assert!(CanonicalRelativePath::try_new(rejected).is_err(), "rejected path: {rejected}");
+    }
+}
+
+#[test]
+fn relative_path_schema_and_serde_share_utf8_byte_boundaries() {
+    let segment_255 = format!("{}a", "é".repeat(127));
+    let segment_256 = "é".repeat(128);
+    let total_4096 = std::iter::repeat_n("é".repeat(120), 17).collect::<Vec<_>>().join("/");
+    let mut total_4097 = total_4096.clone();
+    total_4097.push('a');
+    let corpus =
+        [(segment_255, true), (segment_256, false), (total_4096, true), (total_4097, false)];
+    assert_eq!(corpus[0].0.len(), 255);
+    assert_eq!(corpus[1].0.len(), 256);
+    assert_eq!(corpus[2].0.len(), 4096);
+    assert_eq!(corpus[3].0.len(), 4097);
+
+    let manifest_dir = std::path::Path::new(env!("CARGO_MANIFEST_DIR"));
+    let repo_root = manifest_dir.parent().and_then(std::path::Path::parent).unwrap();
+    let validator = repo_root.join("packages/contracts/tests/utf8-byte-keywords.test.mjs");
+    let mut child = Command::new("node")
+        .arg(validator)
+        .arg("--stdin")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("project AJV validator should start");
+    let schema = serde_json::to_value(schema_for!(CanonicalRelativePath)).unwrap();
+    let request = json!({
+        "schema": schema,
+        "cases": corpus.iter().map(|(value, _)| json!({ "value": value })).collect::<Vec<_>>(),
+    });
+    serde_json::to_writer(child.stdin.as_mut().unwrap(), &request).unwrap();
+    child.stdin.take().unwrap().flush().unwrap();
+    let output = child.wait_with_output().unwrap();
+    assert!(
+        output.status.success(),
+        "AJV validator failed: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let schema_results: Vec<bool> = serde_json::from_slice(&output.stdout).unwrap();
+
+    for ((value, expected), schema_valid) in corpus.iter().zip(schema_results) {
+        let serde_valid = serde_json::from_value::<CanonicalRelativePath>(json!(value)).is_ok();
+        assert_eq!(schema_valid, *expected, "schema byte boundary for {} bytes", value.len());
+        assert_eq!(serde_valid, *expected, "Serde byte boundary for {} bytes", value.len());
+        assert_eq!(schema_valid, serde_valid, "schema/Serde parity for {} bytes", value.len());
     }
 }
 


### PR DESCRIPTION
## Summary

Adds the portable contract layer needed for PlateVault to handle mixed acquisition sessions safely across ingestion, metadata correction, calibration, relationship review, and project updates. The contract keeps long-running work deterministic and reviewable while preventing unsupported DarkFlat frames and sensitive source disclosure.

## What's new

- Bounded, stable review data for mixed-session ingestion, reclassification, calibration handoff, relationships, and project updates.
- Explicit blocked, warning, stale, and manual-review outcomes so callers cannot silently accept ambiguous evidence.
- Redacted calibration source views and indistinguishable missing-versus-unauthorized errors.
- Deterministic pagination, idempotent mutations, and command fencing for large or long-running workflows.

## Verification

- `cargo fmt --all -- --check`
- `cargo nextest run -p contracts_core -p contract_tests` (209 passed)
- `cargo clippy -p contracts_core -p contract_tests --all-targets --all-features -- -D warnings`
- `cargo run -p contracts_core --bin schema-agreement-test`
- `cargo doc -p contracts_core -p contract_tests --no-deps`

Strict rustdoc still reports the two existing broken links in `cone_search.rs` and `patterns.rs`; both files are unchanged by this branch.

## Spec Context

The new public module is `contracts_core::sessions::heterogeneity`. Root-level aggregation, generated schemas, TypeScript bindings, and generator allowlists remain intentionally unchanged for the integration work that consumes these contracts.
