### PR TITLE
fix: keep astronomy metadata processing and target matching compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -300,6 +300,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,10 +1842,11 @@ checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "fits-header"
-version = "0.2.0"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "75b5915639594adba540c8c25b4e842d6a04401cb309f97edc87b2fbd5daa8c9"
+checksum = "d9f03c8e9bb8afa98de1186e5237a70d2e907b239a9c1f0d523131402cc0b326"
 dependencies = [
+ "skymath",
  "thiserror 2.0.18",
  "time",
 ]
@@ -1851,6 +1861,12 @@ dependencies = [
  "miniz_oxide",
  "zlib-rs",
 ]
+
+[[package]]
+name = "float_next_after"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
 name = "flume"
@@ -2203,6 +2219,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "geo"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f811f663912a69249fa620dcd2a005db7254529da2d8a0b23942e81f47084501"
+dependencies = [
+ "float_next_after",
+ "geo-types",
+ "geographiclib-rs",
+ "log",
+ "num-traits",
+ "robust",
+ "rstar",
+]
+
+[[package]]
+name = "geo-types"
+version = "0.7.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ff16065e5720f376fbced200a5ae0f47ace85fd70b7e54269790281353b6d61"
+dependencies = [
+ "approx",
+ "num-traits",
+ "rstar",
+ "serde",
+]
+
+[[package]]
+name = "geographiclib-rs"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a7f08910fd98737a6eda7568e7c5e645093e073328eeef49758cfe8b0489c7"
+dependencies = [
+ "libm",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2473,6 +2525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "hash32"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47d60b12902ba28e2730cd37e95b8c9223af2808df9e902d4df49588d1470606"
+dependencies = [
+ "byteorder",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2520,6 +2581,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea0b22561a9c04a7cb1a302c013e0259cd3b4bb619f145b32f72b8b4bcbed230"
 dependencies = [
  "hashbrown 0.16.1",
+]
+
+[[package]]
+name = "heapless"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bfb9eb618601c89945a70e254898da93b13be0388091d42117462b265bb3fad"
+dependencies = [
+ "hash32",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -3211,6 +3282,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
 name = "libredox"
 version = "0.1.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3539,6 +3616,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -4934,6 +5012,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "robust"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e27ee8bb91ca0adcf0ecb116293afa12d393f9c2b9b9cd54d33e8078fe19839"
+
+[[package]]
+name = "rstar"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421400d13ccfd26dfa5858199c30a5d76f9c54e0dba7575273025b43c5175dbb"
+dependencies = [
+ "heapless",
+ "num-traits",
+ "smallvec",
+]
+
+[[package]]
 name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5570,9 +5665,9 @@ dependencies = [
 
 [[package]]
 name = "simbad-resolver"
-version = "0.3.5"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48e8db7c75f0c5f3d642af85aa9e075b628f79f3bc8cb29ae8df1403b3f00a69"
+checksum = "0d402bb4990100903c7b8d4695c80281ae0c1bff4d388869877db45c7efd098a"
 dependencies = [
  "async-trait",
  "redb",
@@ -5619,9 +5714,9 @@ checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "skymath"
-version = "0.5.0"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fe24e1f966830a353f4a741d815655463e41a064b01c161a6b0a4cca62b84b1"
+checksum = "c2a79e14882fa3b8890da09ab6c285953fc3ad0fa801bdb73bacf1492309091c"
 dependencies = [
  "thiserror 2.0.18",
  "time",
@@ -6221,10 +6316,12 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "target-match"
-version = "0.4.2"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c153b3cc35bfd761c260644ed0b6075c12169c93fcad0fee28dbda7afbfb7a5"
+checksum = "23a0b58f5c23ca0507df3dd8ceb2a382a388acbdec8b8dd323f68dc5490fa796"
 dependencies = [
+ "geo",
+ "geo-types",
  "skymath",
  "thiserror 2.0.18",
 ]
@@ -8569,11 +8666,12 @@ dependencies = [
 
 [[package]]
 name = "xisf-header"
-version = "0.2.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "674af42f41782a63546ad77dc4e0c80e2abf6b65b7ca10d85b707c0da1fc886e"
+checksum = "5946a5236693506e10bf909a69d249b62affc50d0fcc5e37fa08b12ee614e033"
 dependencies = [
  "quick-xml 0.41.0",
+ "skymath",
  "thiserror 2.0.18",
  "time",
 ]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,13 +23,13 @@ audit = { path = "../../../crates/audit" }
 targeting_resolver = { path = "../../../crates/targeting/resolver" }
 # spec 052 P1: AppState owns the shared redb resolve-cache handle directly
 # (Cache trait for .cache()/search, identity::namespace for warming).
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 # target.astro_format.batch: sexagesimal RA/Dec formatting (adopt target-match).
 targeting = { path = "../../../crates/targeting" }
 # target.moon_opposition.batch (#634): geocentric Sun/Moon position
 # (sun_position/moon_position — not re-exported by `targeting`, which only
 # re-exports the coordinate primitives).
-skymath = "0.5"
+skymath = "0.6.0"
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -31,7 +31,7 @@ workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
 # spec 052 P1: project_create::create threads the shared redb resolve cache
 # through to app_core_projects::project_setup::create for in-use promotion.
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 # In-memory caching layer (F0 foundation).
 app_core_cache = { path = "../cache" }
 camino = { workspace = true }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -32,14 +32,14 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
-skymath = "0.5"
+skymath = "0.6.0"
 sqlx.workspace = true
-target-match = "0.4"
+target-match = "0.5.1"
 # spec 052 P3: the cone-search suggestion use case needs the upstream crate's
 # own `ResolvedIdentity` (otype_raw/common_name/aliases, OQ-1/OQ-2 ranking
 # inputs) and `PositionResolver` types directly — mirrors the existing
 # `app_core_targets` precedent (see that crate's Cargo.toml comment).
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -26,7 +26,7 @@ project_structure = { path = "../../project/structure" }
 # #1218: source snapshots read the session key, whose format this crate owns.
 sessions = { path = "../../sessions" }
 sha2.workspace = true
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 workflow_profiles = { path = "../../workflow/profiles" }
 serde_json.workspace = true
 sqlx.workspace = true

--- a/crates/app/targets/Cargo.toml
+++ b/crates/app/targets/Cargo.toml
@@ -23,7 +23,7 @@ targeting_resolver = { path = "../../targeting/resolver" }
 # spec 052 P1: `target.search` reads the shared redb resolve cache directly
 # (`simbad_resolver::Cache`), and in-use promotion touches the crate's own
 # `ResolvedIdentity`/`Cache` types at the app-layer commit points.
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 serde_json.workspace = true
 sqlx.workspace = true
 time = { workspace = true }

--- a/crates/calibration/core/Cargo.toml
+++ b/crates/calibration/core/Cargo.toml
@@ -13,7 +13,7 @@ serde_json = { workspace = true }
 uuid = { workspace = true }
 # Issue #921: circular_distance replaces the hand-rolled `(a - b).abs()` flat
 # rotation delta, which max-penalized correct flats straddling the 0/360 seam.
-skymath = "0.5"
+skymath = "0.6.0"
 # spec 042 (T201): ISO-8601 date parsing + Julian-day arithmetic for
 # observing-night proximity (replaces the hand-rolled YMD parse + JDN math).
 time = { workspace = true }

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-skymath = "0.5"
+skymath = "0.6.0"
 thiserror = { workspace = true }
 toml = "0.9.5"
 

--- a/crates/metadata/fits/Cargo.toml
+++ b/crates/metadata/fits/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 metadata_core = { path = "../core" }
 thiserror = { workspace = true }
-fits-header = "0.2"
+fits-header = "0.4.2"
 
 [lints]
 workspace = true

--- a/crates/metadata/fits/src/lib.rs
+++ b/crates/metadata/fits/src/lib.rs
@@ -66,11 +66,10 @@ impl MetadataExtractor for FitsExtractor {
             msg: e.to_string(),
         })?;
 
-        // fits_header::parse never actually errs (parsing is lenient by design);
+        // Header::parse never actually errs (parsing is lenient by design);
         // propagate defensively rather than unwrap.
-        let header = fits_header::parse(&bytes).map_err(|e| MetadataExtractError::Parse {
-            path: path.display().to_string(),
-            msg: e.to_string(),
+        let header = fits_header::Header::parse(&bytes).map_err(|e| {
+            MetadataExtractError::Parse { path: path.display().to_string(), msg: e.to_string() }
         })?;
 
         Ok(Some(parse_header(&header)))
@@ -262,11 +261,11 @@ mod tests {
     }
 
     /// Parse a set of 80-char card strings into [`RawFileMetadata`] via the
-    /// real `fits_header::parse` + [`parse_header`] path.
+    /// real [`fits_header::Header::parse`] + [`parse_header`] path.
     fn parse(cards: &[String]) -> RawFileMetadata {
         let refs: Vec<&str> = cards.iter().map(String::as_str).collect();
         let block = build_fits_header(&refs);
-        let header = fits_header::parse(&block).unwrap();
+        let header = fits_header::Header::parse(&block).unwrap();
         parse_header(&header)
     }
 

--- a/crates/metadata/xisf/Cargo.toml
+++ b/crates/metadata/xisf/Cargo.toml
@@ -10,7 +10,7 @@ path = "src/lib.rs"
 [dependencies]
 metadata_core = { path = "../core" }
 thiserror.workspace = true
-xisf-header = "0.2"
+xisf-header = "0.4.3"
 
 [lints]
 workspace = true

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../domain/core" }
-skymath = "0.5"
+skymath = "0.6.0"
 thiserror = { workspace = true }
 time = { workspace = true }
 

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -28,10 +28,10 @@ path = "src/lib.rs"
 # trade.
 
 [dependencies]
-target-match = "0.4"
-skymath = "0.5"
+target-match = "0.5.1"
+skymath = "0.6.0"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 
 [lints]
 workspace = true

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -50,10 +50,10 @@ persistence_db = { path = "../../persistence/db" }
 # Published SIMBAD TAP client + Caldwell map + normalize/fuzzy helpers + the
 # cache-first facade (see crate doc above). Same author/org as this
 # workspace's own CI app.
-simbad-resolver = "0.3"
+simbad-resolver = "0.4.0"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
-skymath = "0.5"
+skymath = "0.6.0"
 
 [dev-dependencies]
 # `#[tokio::test]` only — no production `tokio` usage in this crate (the
@@ -65,7 +65,7 @@ tokio = { workspace = true }
 # drop-and-rebuild pointed at the same redb file — astro-plan's production
 # `simbad::SimbadResolver` wrapper only ever builds a real `TapResolver`, so
 # this test constructs the crate's facade directly.
-simbad-resolver = { version = "0.3", features = ["test-util"] }
+simbad-resolver = { version = "0.4.0", features = ["test-util"] }
 tempfile = { workspace = true }
 
 [features]


### PR DESCRIPTION
## Summary

- Keeps FITS and XISF metadata extraction compatible with the published astronomy libraries.
- Keeps astronomical target matching and SIMBAD resolution on one compatible crates.io dependency graph.
- Retains SQLx 0.9.0 and one `time` 0.3.53 package.

## Test plan

- [x] `cargo fmt --all --check`
- [x] `cargo metadata --locked --format-version 1 --no-deps`
- [x] `cargo check --workspace --all-targets`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo nextest run --workspace` (2,672 passed; 31 skipped)
- [x] `cargo test --workspace --doc` (7 passed; 1 ignored)
- [x] `cargo doc --workspace --no-deps`
- [ ] `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` reports existing broken intra-doc links outside this diff.
