### PR TITLE
feat: validate panel and mosaic relationships

### DIFF
--- a/crates/targeting/src/lib.rs
+++ b/crates/targeting/src/lib.rs
@@ -34,7 +34,9 @@
 pub mod astro_format;
 pub mod coords;
 pub mod identity;
+pub mod matching;
 pub mod normalize;
+pub mod relations;
 
 pub use skymath::{separation, Angle, Epoch, Equatorial};
 pub use target_match::Field;

--- a/crates/targeting/src/matching.rs
+++ b/crates/targeting/src/matching.rs
@@ -116,7 +116,7 @@ impl MatchingSettings {
             "mosaic.overlap_max_percent",
             &mut issues,
         );
-        if self.mosaic.residual_sky_rotation_cap_deg != 10.0 {
+        if (self.mosaic.residual_sky_rotation_cap_deg - 10.0).abs() > f64::EPSILON {
             push_red(
                 &mut issues,
                 "settings.mosaic_rotation_cap_fixed",
@@ -257,11 +257,24 @@ pub enum AutomaticRelation {
 /// Non-geometric facts required before a relation can be automatic.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RelationContext {
-    pub same_materialization: bool,
-    pub immutable_discriminators_match: bool,
-    pub target_compatible: bool,
-    pub acquisition_geometry_compatible: bool,
-    pub equipment_compatible: bool,
+    pub materialization: MaterializationRelation,
+    pub target: Compatibility,
+    pub acquisition_geometry: Compatibility,
+    pub equipment: Compatibility,
+}
+
+/// Whether the pair may form one session inside the active materialization.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MaterializationRelation {
+    SameWithMatchingDiscriminators,
+    DifferentOrDiscriminatorMismatch,
+}
+
+/// Compatibility of one independently reviewed relation dimension.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Compatibility {
+    Compatible,
+    Incompatible,
 }
 
 /// Measured evidence and the one policy outcome it supports.
@@ -269,7 +282,24 @@ pub struct RelationContext {
 pub struct GeometryEvidence {
     pub comparison: FootprintComparison,
     pub allowed_mosaic_rotations: Vec<RotationInterval>,
+    pub threshold_snapshot: Vec<ThresholdMeasurement>,
     pub relation: Option<AutomaticRelation>,
+}
+
+/// One inclusive measurement retained with a relation proposal.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct ThresholdMeasurement {
+    pub key: &'static str,
+    pub measured_value: f64,
+    pub threshold_value: f64,
+    pub comparison: ThresholdComparison,
+    pub passed: bool,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ThresholdComparison {
+    GreaterThanOrEqual,
+    LessThanOrEqual,
 }
 
 /// Search resolution used for the fixed +/-10 degree mosaic cap.
@@ -282,6 +312,11 @@ pub const MOSAIC_ROTATION_TOLERANCE_DEG: f64 = 0.001;
 /// Sibling is therefore never returned for a pair already classified into the
 /// same session. Mosaic overlap is evaluated only when neither same-panel class
 /// applies.
+///
+/// # Errors
+///
+/// Returns the upstream typed geometry error when the footprints cannot share
+/// a valid comparison plane or the rotation-band calculation cannot complete.
 pub fn evaluate_relation(
     left: &SkyFootprint,
     right: &SkyFootprint,
@@ -306,19 +341,25 @@ pub fn evaluate_relation(
         )?,
     )?;
 
-    let relation = if context.same_materialization
-        && context.immutable_discriminators_match
+    let (relation, threshold_snapshot) = if context.materialization
+        == MaterializationRelation::SameWithMatchingDiscriminators
         && geometry_passes(&comparison, settings.same_session)
     {
-        Some(AutomaticRelation::SameSession)
-    } else if context.target_compatible
-        && context.acquisition_geometry_compatible
-        && context.equipment_compatible
+        (
+            Some(AutomaticRelation::SameSession),
+            geometry_threshold_snapshot(&comparison, settings.same_session),
+        )
+    } else if context.target == Compatibility::Compatible
+        && context.acquisition_geometry == Compatibility::Compatible
+        && context.equipment == Compatibility::Compatible
         && geometry_passes(&comparison, settings.sibling)
     {
-        Some(AutomaticRelation::Sibling)
-    } else if context.target_compatible
-        && context.acquisition_geometry_compatible
+        (
+            Some(AutomaticRelation::Sibling),
+            geometry_threshold_snapshot(&comparison, settings.sibling),
+        )
+    } else if context.target == Compatibility::Compatible
+        && context.acquisition_geometry == Compatibility::Compatible
         && comparison.parity_match
         && mosaic_band_contains(&comparison, settings.mosaic)
         && residual_in_intervals(
@@ -326,12 +367,79 @@ pub fn evaluate_relation(
             &allowed_mosaic_rotations,
         )
     {
-        Some(AutomaticRelation::Mosaic)
+        (Some(AutomaticRelation::Mosaic), mosaic_threshold_snapshot(&comparison, settings.mosaic))
     } else {
-        None
+        (None, Vec::new())
     };
 
-    Ok(GeometryEvidence { comparison, allowed_mosaic_rotations, relation })
+    Ok(GeometryEvidence { comparison, allowed_mosaic_rotations, threshold_snapshot, relation })
+}
+
+fn geometry_threshold_snapshot(
+    comparison: &FootprintComparison,
+    thresholds: GeometryThresholds,
+) -> Vec<ThresholdMeasurement> {
+    vec![
+        minimum_measurement(
+            "coverage_percent",
+            comparison.normalized_coverage * 100.0,
+            thresholds.coverage_min_percent,
+        ),
+        maximum_measurement(
+            "center_separation_percent",
+            comparison.normalized_centre_separation * 100.0,
+            thresholds.center_separation_max_percent,
+        ),
+        maximum_measurement(
+            "residual_sky_rotation_deg",
+            comparison.residual_sky_rotation.degrees().abs(),
+            thresholds.rotation_max_deg,
+        ),
+    ]
+}
+
+fn mosaic_threshold_snapshot(
+    comparison: &FootprintComparison,
+    thresholds: MosaicThresholds,
+) -> Vec<ThresholdMeasurement> {
+    let coverage = comparison.normalized_coverage * 100.0;
+    vec![
+        minimum_measurement("coverage_percent", coverage, thresholds.overlap_min_percent),
+        maximum_measurement("coverage_percent", coverage, thresholds.overlap_max_percent),
+        maximum_measurement(
+            "residual_sky_rotation_deg",
+            comparison.residual_sky_rotation.degrees().abs(),
+            thresholds.residual_sky_rotation_cap_deg,
+        ),
+    ]
+}
+
+fn minimum_measurement(
+    key: &'static str,
+    measured_value: f64,
+    threshold_value: f64,
+) -> ThresholdMeasurement {
+    ThresholdMeasurement {
+        key,
+        measured_value,
+        threshold_value,
+        comparison: ThresholdComparison::GreaterThanOrEqual,
+        passed: measured_value >= threshold_value,
+    }
+}
+
+fn maximum_measurement(
+    key: &'static str,
+    measured_value: f64,
+    threshold_value: f64,
+) -> ThresholdMeasurement {
+    ThresholdMeasurement {
+        key,
+        measured_value,
+        threshold_value,
+        comparison: ThresholdComparison::LessThanOrEqual,
+        passed: measured_value <= threshold_value,
+    }
 }
 
 fn geometry_passes(comparison: &FootprintComparison, thresholds: GeometryThresholds) -> bool {

--- a/crates/targeting/src/matching.rs
+++ b/crates/targeting/src/matching.rs
@@ -116,7 +116,9 @@ impl MatchingSettings {
             "mosaic.overlap_max_percent",
             &mut issues,
         );
-        if (self.mosaic.residual_sky_rotation_cap_deg - 10.0).abs() > f64::EPSILON {
+        if !self.mosaic.residual_sky_rotation_cap_deg.is_finite()
+            || (self.mosaic.residual_sky_rotation_cap_deg - 10.0).abs() > f64::EPSILON
+        {
             push_red(
                 &mut issues,
                 "settings.mosaic_rotation_cap_fixed",
@@ -306,18 +308,45 @@ pub enum ThresholdComparison {
 pub const MOSAIC_ROTATION_SAMPLE_DEG: f64 = 0.1;
 pub const MOSAIC_ROTATION_TOLERANCE_DEG: f64 = 0.001;
 
-/// Compare solved footprints and apply the configured relation policy.
-///
-/// Same-session is tested first and is restricted to the active materialization.
-/// Sibling is therefore never returned for a pair already classified into the
-/// same session. Mosaic overlap is evaluated only when neither same-panel class
-/// applies.
-///
-/// # Errors
-///
-/// Returns the upstream typed geometry error when the footprints cannot share
-/// a valid comparison plane or the rotation-band calculation cannot complete.
-pub fn evaluate_relation(
+/// Live entry point for relation matching policy.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct RelationMatcher;
+
+impl RelationMatcher {
+    /// Compare solved footprints and apply the configured relation policy.
+    ///
+    /// Same-session is tested first and is restricted to the active
+    /// materialization. Sibling is therefore never returned for a pair already
+    /// classified into the same session. Mosaic overlap is evaluated only when
+    /// neither same-panel class applies.
+    ///
+    /// # Errors
+    ///
+    /// Returns the upstream typed geometry error when the footprints cannot
+    /// share a valid comparison plane or rotation-band calculation fails.
+    pub fn evaluate(
+        self,
+        left: &SkyFootprint,
+        right: &SkyFootprint,
+        context: RelationContext,
+        settings: MatchingSettings,
+    ) -> target_match::Result<GeometryEvidence> {
+        evaluate_relation(left, right, context, settings)
+    }
+
+    /// Enforce complete linkage between a candidate and every accepted member.
+    #[must_use]
+    pub fn complete_linkage<T>(
+        self,
+        candidate: &T,
+        accepted_members: &[T],
+        matches: impl Fn(&T, &T) -> bool,
+    ) -> bool {
+        complete_linkage(candidate, accepted_members, matches)
+    }
+}
+
+fn evaluate_relation(
     left: &SkyFootprint,
     right: &SkyFootprint,
     context: RelationContext,
@@ -464,9 +493,7 @@ fn residual_in_intervals(residual: f64, intervals: &[RotationInterval]) -> bool 
         .any(|interval| residual >= interval.start.degrees() && residual <= interval.end.degrees())
 }
 
-/// Complete-linkage guard against an immutable representative.
-#[must_use]
-pub fn complete_linkage<T>(
+fn complete_linkage<T>(
     candidate: &T,
     accepted_members: &[T],
     matches: impl Fn(&T, &T) -> bool,
@@ -536,11 +563,80 @@ mod tests {
     }
 
     #[test]
+    fn every_non_finite_threshold_is_red() {
+        type Mutator = fn(&mut MatchingSettings, f64);
+        let mutators: [Mutator; 7] = [
+            |settings, value| settings.same_session.coverage_min_percent = value,
+            |settings, value| settings.same_session.center_separation_max_percent = value,
+            |settings, value| settings.same_session.rotation_max_deg = value,
+            |settings, value| settings.sibling.coverage_min_percent = value,
+            |settings, value| settings.sibling.center_separation_max_percent = value,
+            |settings, value| settings.sibling.rotation_max_deg = value,
+            |settings, value| settings.mosaic.residual_sky_rotation_cap_deg = value,
+        ];
+        for mutate in mutators {
+            for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                let mut settings = MatchingSettings::default();
+                mutate(&mut settings, value);
+                assert!(!settings.is_valid(), "accepted non-finite value {value}");
+            }
+        }
+
+        for mutate in [
+            |settings: &mut MatchingSettings, value| settings.mosaic.overlap_min_percent = value,
+            |settings: &mut MatchingSettings, value| settings.mosaic.overlap_max_percent = value,
+        ] {
+            for value in [f64::NAN, f64::INFINITY, f64::NEG_INFINITY] {
+                let mut settings = MatchingSettings::default();
+                mutate(&mut settings, value);
+                assert!(!settings.is_valid(), "accepted non-finite mosaic threshold {value}");
+            }
+        }
+    }
+
+    #[test]
+    fn fixed_mosaic_rotation_cap_rejects_adjacent_float_values() {
+        let exact = MatchingSettings::default();
+        assert!(exact.is_valid());
+        for cap in [f64::from_bits(10.0_f64.to_bits() - 1), f64::from_bits(10.0_f64.to_bits() + 1)]
+        {
+            let mut settings = exact;
+            settings.mosaic.residual_sky_rotation_cap_deg = cap;
+            assert!(!settings.is_valid());
+        }
+    }
+
+    #[test]
+    fn every_configured_hard_bound_rejects_adjacent_outside_values() {
+        type Case = (fn(&mut MatchingSettings, f64), f64, f64);
+        let cases: [Case; 8] = [
+            (|s, v| s.same_session.coverage_min_percent = v, 90.0, 99.5),
+            (|s, v| s.same_session.center_separation_max_percent = v, 0.5, 5.0),
+            (|s, v| s.same_session.rotation_max_deg = v, 0.25, 3.0),
+            (|s, v| s.sibling.coverage_min_percent = v, 80.0, 95.0),
+            (|s, v| s.sibling.center_separation_max_percent = v, 2.0, 15.0),
+            (|s, v| s.sibling.rotation_max_deg = v, 1.0, 15.0),
+            (|s, v| s.mosaic.overlap_min_percent = v, 1.0, 20.0),
+            (|s, v| s.mosaic.overlap_max_percent = v, 20.0, 60.0),
+        ];
+        for (mutate, minimum, maximum) in cases {
+            for value in
+                [f64::from_bits(minimum.to_bits() - 1), f64::from_bits(maximum.to_bits() + 1)]
+            {
+                let mut settings = MatchingSettings::default();
+                mutate(&mut settings, value);
+                assert!(!settings.is_valid(), "accepted {value} outside {minimum}..={maximum}");
+            }
+        }
+    }
+
+    #[test]
     fn complete_linkage_does_not_allow_transitive_expansion() {
         let members = [0_i32, 4];
-        assert!(!complete_linkage(&7, &members, |left, right| (left - right).abs() <= 4));
-        assert!(complete_linkage(&3, &members, |left, right| (left - right).abs() <= 4));
-        assert!(!complete_linkage(&3, &[], |_, _| true));
+        let matcher = RelationMatcher;
+        assert!(!matcher.complete_linkage(&7, &members, |left, right| (left - right).abs() <= 4));
+        assert!(matcher.complete_linkage(&3, &members, |left, right| (left - right).abs() <= 4));
+        assert!(!matcher.complete_linkage(&3, &[], |_, _| true));
     }
 
     #[test]
@@ -581,6 +677,50 @@ mod tests {
     }
 
     #[test]
+    fn modulo_180_and_parity_hold_across_multiple_turns() {
+        for angle in (-720..=720).step_by(15) {
+            let base = footprint(f64::from(angle), ImageParity::Direct);
+            let equivalent = footprint(f64::from(angle + 180), ImageParity::Direct);
+            let mirrored = footprint(f64::from(angle + 180), ImageParity::Mirrored);
+            let comparison = compare_footprints(&base, &equivalent).expect("comparison");
+            assert!(comparison.residual_sky_rotation.degrees().abs() < 1e-9);
+            assert!(comparison.parity_match);
+            assert!(!compare_footprints(&base, &mirrored).expect("comparison").parity_match);
+        }
+    }
+
+    #[test]
+    fn same_session_wins_exclusively_over_sibling() {
+        let left = footprint(0.0, ImageParity::Direct);
+        let right = footprint(180.0, ImageParity::Direct);
+        let common = RelationContext {
+            materialization: MaterializationRelation::SameWithMatchingDiscriminators,
+            target: Compatibility::Compatible,
+            acquisition_geometry: Compatibility::Compatible,
+            equipment: Compatibility::Compatible,
+        };
+        let evidence = RelationMatcher
+            .evaluate(&left, &right, common, MatchingSettings::default())
+            .expect("valid geometry");
+        assert_eq!(evidence.relation, Some(AutomaticRelation::SameSession));
+        assert_eq!(evidence.threshold_snapshot.len(), 3);
+        assert!(evidence.threshold_snapshot.iter().all(|measurement| measurement.passed));
+
+        let sibling = RelationMatcher
+            .evaluate(
+                &left,
+                &right,
+                RelationContext {
+                    materialization: MaterializationRelation::DifferentOrDiscriminatorMismatch,
+                    ..common
+                },
+                MatchingSettings::default(),
+            )
+            .expect("valid geometry");
+        assert_eq!(sibling.relation, Some(AutomaticRelation::Sibling));
+    }
+
+    #[test]
     fn sampled_in_range_geometry_settings_avoid_bound_errors() {
         for sample in 0..=100 {
             let fraction = f64::from(sample) / 100.0;
@@ -598,6 +738,19 @@ mod tests {
                 ..MatchingSettings::default()
             };
             assert!(!settings.validate().iter().any(|issue| issue.code.contains("out_of_bounds")));
+        }
+    }
+
+    #[test]
+    fn complete_linkage_is_order_invariant_and_rejects_long_chains() {
+        let matcher = RelationMatcher;
+        let candidates = [[0_i32, 4, 8], [8, 4, 0], [4, 0, 8]];
+        for members in candidates {
+            assert!(!matcher
+                .complete_linkage(&12, &members, |left, right| { (left - right).abs() <= 4 }));
+            assert!(
+                matcher.complete_linkage(&4, &members, |left, right| { (left - right).abs() <= 4 })
+            );
         }
     }
 }

--- a/crates/targeting/src/matching.rs
+++ b/crates/targeting/src/matching.rs
@@ -1,0 +1,495 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Geometry matching policy for immutable light sessions and panel mosaics.
+
+use target_match::{
+    compare_footprints, coverage_rotation_intervals, CoverageBand, FootprintComparison,
+    RotationInterval, RotationSearch, SkyFootprint,
+};
+
+/// Percentage-based geometry thresholds used by one relation class.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GeometryThresholds {
+    pub coverage_min_percent: f64,
+    pub center_separation_max_percent: f64,
+    pub rotation_max_deg: f64,
+}
+
+/// Inclusive overlap band for accepted mosaic adjacency.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MosaicThresholds {
+    pub overlap_min_percent: f64,
+    pub overlap_max_percent: f64,
+    pub residual_sky_rotation_cap_deg: f64,
+}
+
+/// Versioned settings used to construct future relation suggestions.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct MatchingSettings {
+    pub revision: u64,
+    pub same_session: GeometryThresholds,
+    pub sibling: GeometryThresholds,
+    pub mosaic: MosaicThresholds,
+}
+
+impl Default for MatchingSettings {
+    fn default() -> Self {
+        Self {
+            revision: 1,
+            same_session: GeometryThresholds {
+                coverage_min_percent: 95.0,
+                center_separation_max_percent: 2.0,
+                rotation_max_deg: 1.0,
+            },
+            sibling: GeometryThresholds {
+                coverage_min_percent: 90.0,
+                center_separation_max_percent: 5.0,
+                rotation_max_deg: 5.0,
+            },
+            mosaic: MosaicThresholds {
+                overlap_min_percent: 5.0,
+                overlap_max_percent: 40.0,
+                residual_sky_rotation_cap_deg: 10.0,
+            },
+        }
+    }
+}
+
+/// Severity of a settings validation finding.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum SettingsSeverity {
+    Yellow,
+    Red,
+}
+
+/// Stable validation finding suitable for contract mapping.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SettingsIssue {
+    pub code: &'static str,
+    pub field: &'static str,
+    pub severity: SettingsSeverity,
+}
+
+impl MatchingSettings {
+    /// Return every hard-bound, cross-field, and warning finding in field order.
+    #[must_use]
+    pub fn validate(self) -> Vec<SettingsIssue> {
+        let mut issues = Vec::new();
+        check_geometry(
+            self.same_session,
+            GeometryBounds {
+                coverage: (90.0, 99.5),
+                center: (0.5, 5.0),
+                rotation: (0.25, 3.0),
+                coverage_warning_below: 93.0,
+                center_warning_above: 3.0,
+                rotation_warning_above: 2.0,
+            },
+            "same_session",
+            &mut issues,
+        );
+        check_geometry(
+            self.sibling,
+            GeometryBounds {
+                coverage: (80.0, 95.0),
+                center: (2.0, 15.0),
+                rotation: (1.0, 15.0),
+                coverage_warning_below: 85.0,
+                center_warning_above: 10.0,
+                rotation_warning_above: 10.0,
+            },
+            "sibling",
+            &mut issues,
+        );
+        check_inclusive(
+            self.mosaic.overlap_min_percent,
+            (1.0, 20.0),
+            "settings.mosaic_overlap_min_out_of_bounds",
+            "mosaic.overlap_min_percent",
+            &mut issues,
+        );
+        check_inclusive(
+            self.mosaic.overlap_max_percent,
+            (20.0, 60.0),
+            "settings.mosaic_overlap_max_out_of_bounds",
+            "mosaic.overlap_max_percent",
+            &mut issues,
+        );
+        if self.mosaic.residual_sky_rotation_cap_deg != 10.0 {
+            push_red(
+                &mut issues,
+                "settings.mosaic_rotation_cap_fixed",
+                "mosaic.residual_sky_rotation_cap_deg",
+            );
+        }
+        if self.same_session.coverage_min_percent < self.sibling.coverage_min_percent {
+            push_red(
+                &mut issues,
+                "settings.sibling_coverage_stricter",
+                "sibling.coverage_min_percent",
+            );
+        }
+        if self.same_session.center_separation_max_percent
+            > self.sibling.center_separation_max_percent
+        {
+            push_red(
+                &mut issues,
+                "settings.sibling_center_stricter",
+                "sibling.center_separation_max_percent",
+            );
+        }
+        if self.same_session.rotation_max_deg > self.sibling.rotation_max_deg {
+            push_red(&mut issues, "settings.sibling_rotation_stricter", "sibling.rotation_max_deg");
+        }
+        if self.mosaic.overlap_min_percent >= self.mosaic.overlap_max_percent {
+            push_red(&mut issues, "settings.mosaic_overlap_order", "mosaic.overlap_min_percent");
+        }
+        if self.mosaic.overlap_max_percent > self.sibling.coverage_min_percent - 10.0 {
+            push_red(&mut issues, "settings.mosaic_sibling_gap", "mosaic.overlap_max_percent");
+        }
+        if self.mosaic.overlap_min_percent < 3.0 {
+            push_yellow(
+                &mut issues,
+                "settings.mosaic_overlap_min_risky",
+                "mosaic.overlap_min_percent",
+            );
+        }
+        if self.mosaic.overlap_max_percent > 50.0 {
+            push_yellow(
+                &mut issues,
+                "settings.mosaic_overlap_max_risky",
+                "mosaic.overlap_max_percent",
+            );
+        }
+        issues.sort_by_key(|issue| (issue.field, issue.code));
+        issues
+    }
+
+    #[must_use]
+    pub fn is_valid(self) -> bool {
+        !self.validate().iter().any(|issue| issue.severity == SettingsSeverity::Red)
+    }
+}
+
+#[derive(Clone, Copy)]
+struct GeometryBounds {
+    coverage: (f64, f64),
+    center: (f64, f64),
+    rotation: (f64, f64),
+    coverage_warning_below: f64,
+    center_warning_above: f64,
+    rotation_warning_above: f64,
+}
+
+fn check_geometry(
+    value: GeometryThresholds,
+    bounds: GeometryBounds,
+    prefix: &'static str,
+    issues: &mut Vec<SettingsIssue>,
+) {
+    let fields = match prefix {
+        "same_session" => (
+            "same_session.coverage_min_percent",
+            "same_session.center_separation_max_percent",
+            "same_session.rotation_max_deg",
+            "settings.same_session_coverage_out_of_bounds",
+            "settings.same_session_center_out_of_bounds",
+            "settings.same_session_rotation_out_of_bounds",
+            "settings.same_session_coverage_risky",
+            "settings.same_session_center_risky",
+            "settings.same_session_rotation_risky",
+        ),
+        _ => (
+            "sibling.coverage_min_percent",
+            "sibling.center_separation_max_percent",
+            "sibling.rotation_max_deg",
+            "settings.sibling_coverage_out_of_bounds",
+            "settings.sibling_center_out_of_bounds",
+            "settings.sibling_rotation_out_of_bounds",
+            "settings.sibling_coverage_risky",
+            "settings.sibling_center_risky",
+            "settings.sibling_rotation_risky",
+        ),
+    };
+    check_inclusive(value.coverage_min_percent, bounds.coverage, fields.3, fields.0, issues);
+    check_inclusive(value.center_separation_max_percent, bounds.center, fields.4, fields.1, issues);
+    check_inclusive(value.rotation_max_deg, bounds.rotation, fields.5, fields.2, issues);
+    if value.coverage_min_percent < bounds.coverage_warning_below {
+        push_yellow(issues, fields.6, fields.0);
+    }
+    if value.center_separation_max_percent > bounds.center_warning_above {
+        push_yellow(issues, fields.7, fields.1);
+    }
+    if value.rotation_max_deg > bounds.rotation_warning_above {
+        push_yellow(issues, fields.8, fields.2);
+    }
+}
+
+fn check_inclusive(
+    value: f64,
+    bounds: (f64, f64),
+    code: &'static str,
+    field: &'static str,
+    issues: &mut Vec<SettingsIssue>,
+) {
+    if !value.is_finite() || !(bounds.0..=bounds.1).contains(&value) {
+        push_red(issues, code, field);
+    }
+}
+
+fn push_red(issues: &mut Vec<SettingsIssue>, code: &'static str, field: &'static str) {
+    issues.push(SettingsIssue { code, field, severity: SettingsSeverity::Red });
+}
+
+fn push_yellow(issues: &mut Vec<SettingsIssue>, code: &'static str, field: &'static str) {
+    issues.push(SettingsIssue { code, field, severity: SettingsSeverity::Yellow });
+}
+
+/// Relation produced by the mutually-exclusive geometry policy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AutomaticRelation {
+    SameSession,
+    Sibling,
+    Mosaic,
+}
+
+/// Non-geometric facts required before a relation can be automatic.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct RelationContext {
+    pub same_materialization: bool,
+    pub immutable_discriminators_match: bool,
+    pub target_compatible: bool,
+    pub acquisition_geometry_compatible: bool,
+    pub equipment_compatible: bool,
+}
+
+/// Measured evidence and the one policy outcome it supports.
+#[derive(Debug, Clone, PartialEq)]
+pub struct GeometryEvidence {
+    pub comparison: FootprintComparison,
+    pub allowed_mosaic_rotations: Vec<RotationInterval>,
+    pub relation: Option<AutomaticRelation>,
+}
+
+/// Search resolution used for the fixed +/-10 degree mosaic cap.
+pub const MOSAIC_ROTATION_SAMPLE_DEG: f64 = 0.1;
+pub const MOSAIC_ROTATION_TOLERANCE_DEG: f64 = 0.001;
+
+/// Compare solved footprints and apply the configured relation policy.
+///
+/// Same-session is tested first and is restricted to the active materialization.
+/// Sibling is therefore never returned for a pair already classified into the
+/// same session. Mosaic overlap is evaluated only when neither same-panel class
+/// applies.
+pub fn evaluate_relation(
+    left: &SkyFootprint,
+    right: &SkyFootprint,
+    context: RelationContext,
+    settings: MatchingSettings,
+) -> target_match::Result<GeometryEvidence> {
+    let comparison = compare_footprints(left, right)?;
+    let mosaic_band = CoverageBand::new(
+        settings.mosaic.overlap_min_percent / 100.0,
+        settings.mosaic.overlap_max_percent / 100.0,
+    )?;
+    let cap = settings.mosaic.residual_sky_rotation_cap_deg;
+    let allowed_mosaic_rotations = coverage_rotation_intervals(
+        left,
+        right,
+        mosaic_band,
+        RotationSearch::new(
+            skymath::Angle::from_degrees(-cap),
+            skymath::Angle::from_degrees(cap),
+            skymath::Angle::from_degrees(MOSAIC_ROTATION_SAMPLE_DEG),
+            skymath::Angle::from_degrees(MOSAIC_ROTATION_TOLERANCE_DEG),
+        )?,
+    )?;
+
+    let relation = if context.same_materialization
+        && context.immutable_discriminators_match
+        && geometry_passes(&comparison, settings.same_session)
+    {
+        Some(AutomaticRelation::SameSession)
+    } else if context.target_compatible
+        && context.acquisition_geometry_compatible
+        && context.equipment_compatible
+        && geometry_passes(&comparison, settings.sibling)
+    {
+        Some(AutomaticRelation::Sibling)
+    } else if context.target_compatible
+        && context.acquisition_geometry_compatible
+        && comparison.parity_match
+        && mosaic_band_contains(&comparison, settings.mosaic)
+        && residual_in_intervals(
+            comparison.residual_sky_rotation.degrees(),
+            &allowed_mosaic_rotations,
+        )
+    {
+        Some(AutomaticRelation::Mosaic)
+    } else {
+        None
+    };
+
+    Ok(GeometryEvidence { comparison, allowed_mosaic_rotations, relation })
+}
+
+fn geometry_passes(comparison: &FootprintComparison, thresholds: GeometryThresholds) -> bool {
+    comparison.parity_match
+        && comparison.normalized_coverage * 100.0 >= thresholds.coverage_min_percent
+        && comparison.normalized_centre_separation * 100.0
+            <= thresholds.center_separation_max_percent
+        && comparison.residual_sky_rotation.degrees().abs() <= thresholds.rotation_max_deg
+}
+
+fn mosaic_band_contains(comparison: &FootprintComparison, thresholds: MosaicThresholds) -> bool {
+    let coverage = comparison.normalized_coverage * 100.0;
+    coverage >= thresholds.overlap_min_percent
+        && coverage <= thresholds.overlap_max_percent
+        && comparison.residual_sky_rotation.degrees().abs()
+            <= thresholds.residual_sky_rotation_cap_deg
+}
+
+fn residual_in_intervals(residual: f64, intervals: &[RotationInterval]) -> bool {
+    intervals
+        .iter()
+        .any(|interval| residual >= interval.start.degrees() && residual <= interval.end.degrees())
+}
+
+/// Complete-linkage guard against an immutable representative.
+#[must_use]
+pub fn complete_linkage<T>(
+    candidate: &T,
+    accepted_members: &[T],
+    matches: impl Fn(&T, &T) -> bool,
+) -> bool {
+    !accepted_members.is_empty() && accepted_members.iter().all(|member| matches(candidate, member))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use target_match::{FootprintProvenance, ImageParity};
+
+    fn coordinate(ra: f64, dec: f64) -> skymath::Equatorial {
+        skymath::Equatorial::j2000(
+            skymath::Angle::from_degrees(ra),
+            skymath::Angle::from_degrees(dec),
+        )
+        .expect("valid coordinate")
+    }
+
+    fn footprint(position_angle: f64, parity: ImageParity) -> SkyFootprint {
+        SkyFootprint::new(
+            coordinate(10.0, 0.0),
+            vec![
+                coordinate(9.0, -1.0),
+                coordinate(11.0, -1.0),
+                coordinate(11.0, 1.0),
+                coordinate(9.0, 1.0),
+            ],
+            skymath::Angle::from_degrees(position_angle),
+            parity,
+            FootprintProvenance::new(format!("{position_angle}-{parity:?}"))
+                .expect("valid provenance"),
+        )
+        .expect("valid footprint")
+    }
+
+    #[test]
+    fn defaults_are_valid() {
+        assert!(MatchingSettings::default().validate().is_empty());
+    }
+
+    #[test]
+    fn hard_bounds_are_inclusive() {
+        let mut settings = MatchingSettings::default();
+        settings.same_session.coverage_min_percent = 90.0;
+        settings.same_session.center_separation_max_percent = 0.5;
+        settings.same_session.rotation_max_deg = 0.25;
+        settings.sibling.coverage_min_percent = 80.0;
+        settings.sibling.center_separation_max_percent = 2.0;
+        settings.sibling.rotation_max_deg = 1.0;
+        settings.mosaic.overlap_min_percent = 1.0;
+        settings.mosaic.overlap_max_percent = 60.0;
+        let issues = settings.validate();
+        assert!(!issues.iter().any(|issue| issue.code.contains("out_of_bounds")));
+    }
+
+    #[test]
+    fn rejects_non_finite_and_cross_field_values() {
+        let mut settings = MatchingSettings::default();
+        settings.same_session.coverage_min_percent = f64::NAN;
+        settings.sibling.rotation_max_deg = 0.5;
+        settings.mosaic.overlap_max_percent = 85.0;
+        let issues = settings.validate();
+        assert!(issues.iter().any(|issue| issue.severity == SettingsSeverity::Red));
+        assert!(!settings.is_valid());
+    }
+
+    #[test]
+    fn complete_linkage_does_not_allow_transitive_expansion() {
+        let members = [0_i32, 4];
+        assert!(!complete_linkage(&7, &members, |left, right| (left - right).abs() <= 4));
+        assert!(complete_linkage(&3, &members, |left, right| (left - right).abs() <= 4));
+        assert!(!complete_linkage(&3, &[], |_, _| true));
+    }
+
+    #[test]
+    fn inclusive_threshold_helpers_accept_exact_boundaries() {
+        let comparison = FootprintComparison {
+            anchor: skymath::Equatorial::at_epoch(
+                skymath::Angle::from_degrees(0.0),
+                skymath::Angle::from_degrees(0.0),
+                skymath::Epoch::J2000,
+            )
+            .expect("valid coordinate"),
+            left_area: 1.0,
+            right_area: 1.0,
+            intersection_area: 0.9,
+            normalized_coverage: 0.9,
+            centre_separation: skymath::Angle::from_degrees(0.05),
+            smaller_diagonal: skymath::Angle::from_degrees(1.0),
+            normalized_centre_separation: 0.05,
+            residual_sky_rotation: skymath::Angle::from_degrees(-5.0),
+            parity_match: true,
+        };
+        assert!(geometry_passes(&comparison, MatchingSettings::default().sibling));
+    }
+
+    #[test]
+    fn upstream_rotation_is_modulo_180_and_parity_stays_separate() {
+        let direct = footprint(0.0, ImageParity::Direct);
+        let meridian_equivalent = footprint(179.0, ImageParity::Direct);
+        let mirrored = footprint(179.0, ImageParity::Mirrored);
+
+        let equivalent = compare_footprints(&direct, &meridian_equivalent).expect("comparison");
+        assert!((equivalent.residual_sky_rotation.degrees() + 1.0).abs() < 1e-9);
+        assert!(equivalent.parity_match);
+
+        let parity_change = compare_footprints(&direct, &mirrored).expect("comparison");
+        assert!((parity_change.residual_sky_rotation.degrees() + 1.0).abs() < 1e-9);
+        assert!(!parity_change.parity_match);
+    }
+
+    #[test]
+    fn sampled_in_range_geometry_settings_avoid_bound_errors() {
+        for sample in 0..=100 {
+            let fraction = f64::from(sample) / 100.0;
+            let settings = MatchingSettings {
+                same_session: GeometryThresholds {
+                    coverage_min_percent: 90.0 + 9.5 * fraction,
+                    center_separation_max_percent: 0.5 + 4.5 * fraction,
+                    rotation_max_deg: 0.25 + 2.75 * fraction,
+                },
+                sibling: GeometryThresholds {
+                    coverage_min_percent: 80.0 + 10.0 * fraction,
+                    center_separation_max_percent: 5.0 + 10.0 * fraction,
+                    rotation_max_deg: 3.0 + 12.0 * fraction,
+                },
+                ..MatchingSettings::default()
+            };
+            assert!(!settings.validate().iter().any(|issue| issue.code.contains("out_of_bounds")));
+        }
+    }
+}

--- a/crates/targeting/src/matching.rs
+++ b/crates/targeting/src/matching.rs
@@ -172,6 +172,26 @@ impl MatchingSettings {
     pub fn is_valid(self) -> bool {
         !self.validate().iter().any(|issue| issue.severity == SettingsSeverity::Red)
     }
+
+    /// Compare solved footprints using this exact settings revision.
+    ///
+    /// Same-session is tested first and is restricted to the active
+    /// materialization. Sibling is therefore never returned for a pair already
+    /// classified into the same session. Mosaic overlap is evaluated only when
+    /// neither same-panel class applies.
+    ///
+    /// # Errors
+    ///
+    /// Returns the upstream typed geometry error when the footprints cannot
+    /// share a valid comparison plane or rotation-band calculation fails.
+    pub fn evaluate(
+        self,
+        left: &SkyFootprint,
+        right: &SkyFootprint,
+        context: RelationContext,
+    ) -> target_match::Result<GeometryEvidence> {
+        evaluate_relation(left, right, context, self)
+    }
 }
 
 #[derive(Clone, Copy)]
@@ -307,44 +327,6 @@ pub enum ThresholdComparison {
 /// Search resolution used for the fixed +/-10 degree mosaic cap.
 pub const MOSAIC_ROTATION_SAMPLE_DEG: f64 = 0.1;
 pub const MOSAIC_ROTATION_TOLERANCE_DEG: f64 = 0.001;
-
-/// Live entry point for relation matching policy.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct RelationMatcher;
-
-impl RelationMatcher {
-    /// Compare solved footprints and apply the configured relation policy.
-    ///
-    /// Same-session is tested first and is restricted to the active
-    /// materialization. Sibling is therefore never returned for a pair already
-    /// classified into the same session. Mosaic overlap is evaluated only when
-    /// neither same-panel class applies.
-    ///
-    /// # Errors
-    ///
-    /// Returns the upstream typed geometry error when the footprints cannot
-    /// share a valid comparison plane or rotation-band calculation fails.
-    pub fn evaluate(
-        self,
-        left: &SkyFootprint,
-        right: &SkyFootprint,
-        context: RelationContext,
-        settings: MatchingSettings,
-    ) -> target_match::Result<GeometryEvidence> {
-        evaluate_relation(left, right, context, settings)
-    }
-
-    /// Enforce complete linkage between a candidate and every accepted member.
-    #[must_use]
-    pub fn complete_linkage<T>(
-        self,
-        candidate: &T,
-        accepted_members: &[T],
-        matches: impl Fn(&T, &T) -> bool,
-    ) -> bool {
-        complete_linkage(candidate, accepted_members, matches)
-    }
-}
 
 fn evaluate_relation(
     left: &SkyFootprint,
@@ -493,12 +475,24 @@ fn residual_in_intervals(residual: f64, intervals: &[RotationInterval]) -> bool 
         .any(|interval| residual >= interval.start.degrees() && residual <= interval.end.degrees())
 }
 
-fn complete_linkage<T>(
-    candidate: &T,
-    accepted_members: &[T],
-    matches: impl Fn(&T, &T) -> bool,
-) -> bool {
-    !accepted_members.is_empty() && accepted_members.iter().all(|member| matches(candidate, member))
+/// Immutable membership snapshot used for complete-linkage admission.
+#[derive(Debug, Clone, Copy)]
+pub struct CompleteLinkage<'a, T> {
+    accepted_members: &'a [T],
+}
+
+impl<'a, T> CompleteLinkage<'a, T> {
+    #[must_use]
+    pub fn new(accepted_members: &'a [T]) -> Self {
+        Self { accepted_members }
+    }
+
+    /// Require the candidate to match every member of the immutable snapshot.
+    #[must_use]
+    pub fn accepts(&self, candidate: &T, matches: impl Fn(&T, &T) -> bool) -> bool {
+        !self.accepted_members.is_empty()
+            && self.accepted_members.iter().all(|member| matches(candidate, member))
+    }
 }
 
 #[cfg(test)]
@@ -633,10 +627,10 @@ mod tests {
     #[test]
     fn complete_linkage_does_not_allow_transitive_expansion() {
         let members = [0_i32, 4];
-        let matcher = RelationMatcher;
-        assert!(!matcher.complete_linkage(&7, &members, |left, right| (left - right).abs() <= 4));
-        assert!(matcher.complete_linkage(&3, &members, |left, right| (left - right).abs() <= 4));
-        assert!(!matcher.complete_linkage(&3, &[], |_, _| true));
+        let linkage = CompleteLinkage::new(&members);
+        assert!(!linkage.accepts(&7, |left, right| (left - right).abs() <= 4));
+        assert!(linkage.accepts(&3, |left, right| (left - right).abs() <= 4));
+        assert!(!CompleteLinkage::new(&[]).accepts(&3, |_, _| true));
     }
 
     #[test]
@@ -659,6 +653,36 @@ mod tests {
             parity_match: true,
         };
         assert!(geometry_passes(&comparison, MatchingSettings::default().sibling));
+    }
+
+    #[test]
+    fn mosaic_overlap_and_rotation_policy_is_inclusive_only_at_boundaries() {
+        let thresholds = MatchingSettings::default().mosaic;
+        let mut comparison = FootprintComparison {
+            anchor: coordinate(0.0, 0.0),
+            left_area: 1.0,
+            right_area: 1.0,
+            intersection_area: 0.05,
+            normalized_coverage: 0.05,
+            centre_separation: skymath::Angle::from_degrees(1.0),
+            smaller_diagonal: skymath::Angle::from_degrees(2.0),
+            normalized_centre_separation: 0.5,
+            residual_sky_rotation: skymath::Angle::from_degrees(10.0),
+            parity_match: true,
+        };
+        assert!(mosaic_band_contains(&comparison, thresholds));
+
+        comparison.normalized_coverage = 0.4;
+        comparison.intersection_area = 0.4;
+        assert!(mosaic_band_contains(&comparison, thresholds));
+
+        comparison.normalized_coverage = 0.05 - 1e-12;
+        assert!(!mosaic_band_contains(&comparison, thresholds));
+        comparison.normalized_coverage = 0.4 + 1e-12;
+        assert!(!mosaic_band_contains(&comparison, thresholds));
+        comparison.normalized_coverage = 0.2;
+        comparison.residual_sky_rotation = skymath::Angle::from_degrees(10.0 + 1e-12);
+        assert!(!mosaic_band_contains(&comparison, thresholds));
     }
 
     #[test]
@@ -699,14 +723,13 @@ mod tests {
             acquisition_geometry: Compatibility::Compatible,
             equipment: Compatibility::Compatible,
         };
-        let evidence = RelationMatcher
-            .evaluate(&left, &right, common, MatchingSettings::default())
-            .expect("valid geometry");
+        let evidence =
+            MatchingSettings::default().evaluate(&left, &right, common).expect("valid geometry");
         assert_eq!(evidence.relation, Some(AutomaticRelation::SameSession));
         assert_eq!(evidence.threshold_snapshot.len(), 3);
         assert!(evidence.threshold_snapshot.iter().all(|measurement| measurement.passed));
 
-        let sibling = RelationMatcher
+        let sibling = MatchingSettings::default()
             .evaluate(
                 &left,
                 &right,
@@ -714,7 +737,6 @@ mod tests {
                     materialization: MaterializationRelation::DifferentOrDiscriminatorMismatch,
                     ..common
                 },
-                MatchingSettings::default(),
             )
             .expect("valid geometry");
         assert_eq!(sibling.relation, Some(AutomaticRelation::Sibling));
@@ -743,14 +765,11 @@ mod tests {
 
     #[test]
     fn complete_linkage_is_order_invariant_and_rejects_long_chains() {
-        let matcher = RelationMatcher;
         let candidates = [[0_i32, 4, 8], [8, 4, 0], [4, 0, 8]];
         for members in candidates {
-            assert!(!matcher
-                .complete_linkage(&12, &members, |left, right| { (left - right).abs() <= 4 }));
-            assert!(
-                matcher.complete_linkage(&4, &members, |left, right| { (left - right).abs() <= 4 })
-            );
+            let linkage = CompleteLinkage::new(&members);
+            assert!(!linkage.accepts(&12, |left, right| { (left - right).abs() <= 4 }));
+            assert!(linkage.accepts(&4, |left, right| { (left - right).abs() <= 4 }));
         }
     }
 }

--- a/crates/targeting/src/relations.rs
+++ b/crates/targeting/src/relations.rs
@@ -3,9 +3,13 @@
 
 //! Pure panel, mosaic, lineage, proposal, and object-evidence invariants.
 
-use std::collections::{BTreeMap, BTreeSet, VecDeque};
+use std::{
+    collections::{BTreeMap, BTreeSet, VecDeque},
+    fmt::Write,
+};
 
 use target_match::{CoverageState, FootprintUnion, ObjectShape, SkyFootprint};
+use uuid::Uuid;
 
 /// Stable logical panel identity and one immutable accepted revision.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -53,6 +57,19 @@ impl PanelGroupRevision {
         }
         Ok(())
     }
+
+    /// Validate all current panel heads as one immutable snapshot.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invariant error for an invalid revision, duplicate current
+    /// membership, or predecessor/replacement coexistence.
+    pub fn validate_current(
+        revisions: &[Self],
+        supersessions: &[(String, String)],
+    ) -> Result<(), RelationInvariantError> {
+        validate_current_panel_membership(revisions, supersessions)
+    }
 }
 
 /// Validate current panel heads as one snapshot.
@@ -64,7 +81,7 @@ impl PanelGroupRevision {
 ///
 /// Returns an invariant error for an invalid revision, duplicate current
 /// membership, or predecessor/replacement coexistence.
-pub fn validate_current_panel_membership(
+fn validate_current_panel_membership(
     revisions: &[PanelGroupRevision],
     supersessions: &[(String, String)],
 ) -> Result<(), RelationInvariantError> {
@@ -91,6 +108,29 @@ pub struct MosaicEdge {
     pub left_panel_revision_id: String,
     pub right_panel_revision_id: String,
     pub evidence_id: String,
+}
+
+/// Live topology operations for exact mosaic revisions.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct MosaicTopology;
+
+impl MosaicTopology {
+    /// Whether an edge connects two components implied by accepted edges.
+    #[must_use]
+    pub fn edge_bridges(self, left: &str, right: &str, accepted_edges: &[MosaicEdge]) -> bool {
+        edge_bridges_components(left, right, accepted_edges)
+    }
+
+    /// Whether an edge connects two accepted mosaic membership snapshots.
+    #[must_use]
+    pub fn edge_bridges_accepted(
+        self,
+        left: &str,
+        right: &str,
+        accepted_components: &[BTreeSet<String>],
+    ) -> bool {
+        edge_bridges_accepted_mosaics(left, right, accepted_components)
+    }
 }
 
 impl MosaicEdge {
@@ -152,7 +192,7 @@ pub fn validate_mosaic_connectivity(
 
 /// Whether a proposed edge connects two already accepted components.
 #[must_use]
-pub fn edge_bridges_components(left: &str, right: &str, accepted_edges: &[MosaicEdge]) -> bool {
+fn edge_bridges_components(left: &str, right: &str, accepted_edges: &[MosaicEdge]) -> bool {
     if left == right {
         return false;
     }
@@ -167,7 +207,7 @@ pub fn edge_bridges_components(left: &str, right: &str, accepted_edges: &[Mosaic
 
 /// Detect a bridge when accepted component membership is already known.
 #[must_use]
-pub fn edge_bridges_accepted_mosaics(
+fn edge_bridges_accepted_mosaics(
     left: &str,
     right: &str,
     accepted_components: &[BTreeSet<String>],
@@ -314,6 +354,17 @@ impl ManualRelation {
                 if self.subject_ids.len() != 2 || self.edges.len() != 1 {
                     return Err(RelationInvariantError::KindShapeMismatch);
                 }
+                let edge = &self.edges[0];
+                if edge.left_panel_revision_id == edge.right_panel_revision_id {
+                    return Err(RelationInvariantError::InvalidMosaicEdge);
+                }
+                let reviewed_endpoints = BTreeSet::from([
+                    edge.left_panel_revision_id.clone(),
+                    edge.right_panel_revision_id.clone(),
+                ]);
+                if reviewed_endpoints != self.subject_ids {
+                    return Err(RelationInvariantError::MosaicEdgeOutsideReviewedSubjects);
+                }
             }
             RelationKind::MosaicSplit | RelationKind::MosaicMerge => {
                 if self.membership_ids.is_empty()
@@ -329,12 +380,196 @@ impl ManualRelation {
     }
 }
 
+/// Lifecycle state of one immutable relation-proposal revision.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ProposalState {
+    Pending,
+    Accepted,
+    Rejected,
+    Superseded,
+    Stale,
+}
+
+/// Canonical inputs that materially determine an automatic proposal.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProposalBasis {
+    pub kind: RelationKind,
+    pub target_scope: TargetScope,
+    pub source_revision_ids: BTreeSet<String>,
+    pub subject_ids: BTreeSet<String>,
+    pub membership_ids: BTreeSet<String>,
+    pub edges: Vec<MosaicEdge>,
+    pub lineage: Vec<(String, String)>,
+}
+
+impl ProposalBasis {
+    /// Produce a deterministic fingerprint independent of collection order.
+    #[must_use]
+    pub fn fingerprint(&self, evidence_revision: &str, matching_settings_revision: u64) -> String {
+        let mut canonical = String::new();
+        push_canonical_field(&mut canonical, "proposal_basis_v1");
+        push_canonical_field(&mut canonical, self.kind.canonical_name());
+        push_target_scope(&mut canonical, &self.target_scope);
+        push_canonical_field(&mut canonical, "source_revisions");
+        push_sorted_strings(&mut canonical, &self.source_revision_ids);
+        push_canonical_field(&mut canonical, "subjects");
+        push_sorted_strings(&mut canonical, &self.subject_ids);
+        push_canonical_field(&mut canonical, "memberships");
+        push_sorted_strings(&mut canonical, &self.membership_ids);
+
+        let mut edges = self.edges.clone();
+        edges.sort();
+        push_canonical_field(&mut canonical, "edges");
+        push_canonical_field(&mut canonical, &edges.len().to_string());
+        for edge in edges {
+            push_canonical_field(&mut canonical, &edge.left_panel_revision_id);
+            push_canonical_field(&mut canonical, &edge.right_panel_revision_id);
+            push_canonical_field(&mut canonical, &edge.evidence_id);
+        }
+
+        let mut lineage = self.lineage.clone();
+        lineage.sort();
+        push_canonical_field(&mut canonical, "lineage");
+        push_canonical_field(&mut canonical, &lineage.len().to_string());
+        for (predecessor, successor) in lineage {
+            push_canonical_field(&mut canonical, &predecessor);
+            push_canonical_field(&mut canonical, &successor);
+        }
+        push_canonical_field(&mut canonical, evidence_revision);
+        push_canonical_field(&mut canonical, &matching_settings_revision.to_string());
+        Uuid::new_v5(&Uuid::NAMESPACE_OID, canonical.as_bytes()).to_string()
+    }
+}
+
+impl RelationKind {
+    fn canonical_name(self) -> &'static str {
+        match self {
+            Self::PanelAdd => "panel_add",
+            Self::PanelReplace => "panel_replace",
+            Self::PanelSplit => "panel_split",
+            Self::PanelMerge => "panel_merge",
+            Self::MosaicCreate => "mosaic_create",
+            Self::MosaicEdge => "mosaic_edge",
+            Self::MosaicSplit => "mosaic_split",
+            Self::MosaicMerge => "mosaic_merge",
+        }
+    }
+}
+
+fn push_target_scope(canonical: &mut String, target_scope: &TargetScope) {
+    match target_scope {
+        TargetScope::SameTarget { canonical_target_id } => {
+            push_canonical_field(canonical, "same_target");
+            push_canonical_field(canonical, canonical_target_id);
+        }
+        TargetScope::ExistingCrossTarget { association_id } => {
+            push_canonical_field(canonical, "existing_cross_target");
+            push_canonical_field(canonical, association_id);
+        }
+        TargetScope::NewReviewedCrossTarget { canonical_target_ids } => {
+            push_canonical_field(canonical, "new_reviewed_cross_target");
+            push_sorted_strings(canonical, canonical_target_ids);
+        }
+    }
+}
+
+fn push_sorted_strings(canonical: &mut String, values: &BTreeSet<String>) {
+    let _ = write!(canonical, "{}[", values.len());
+    for value in values {
+        push_canonical_field(canonical, value);
+    }
+    canonical.push(']');
+}
+
+fn push_canonical_field(canonical: &mut String, value: &str) {
+    let _ = write!(canonical, "{}:{value};", value.len());
+}
+
+/// Immutable proposal head used for optimistic acceptance and stale marking.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RelationProposal {
+    pub revision: u64,
+    pub state: ProposalState,
+    pub basis_fingerprint: String,
+}
+
+impl RelationProposal {
+    #[must_use]
+    pub fn pending(revision: u64, basis_fingerprint: impl Into<String>) -> Self {
+        Self {
+            revision,
+            state: ProposalState::Pending,
+            basis_fingerprint: basis_fingerprint.into(),
+        }
+    }
+
+    /// Validate the optimistic revision and current material basis.
+    ///
+    /// # Errors
+    ///
+    /// Returns a state, revision, or basis-staleness error without changing
+    /// the proposal.
+    pub fn validate_pending(
+        &self,
+        expected_revision: u64,
+        current_basis_fingerprint: &str,
+    ) -> Result<(), RelationInvariantError> {
+        if self.state != ProposalState::Pending {
+            return Err(RelationInvariantError::ProposalNotPending);
+        }
+        if self.revision != expected_revision {
+            return Err(RelationInvariantError::StaleProposalRevision);
+        }
+        if self.basis_fingerprint != current_basis_fingerprint {
+            return Err(RelationInvariantError::StaleProposalBasis);
+        }
+        Ok(())
+    }
+
+    /// Mark this exact pending revision stale and advance its CAS token.
+    ///
+    /// # Errors
+    ///
+    /// Returns a state or revision error and leaves the proposal unchanged.
+    pub fn mark_stale(&mut self, expected_revision: u64) -> Result<(), RelationInvariantError> {
+        if self.state != ProposalState::Pending {
+            return Err(RelationInvariantError::ProposalNotPending);
+        }
+        if self.revision != expected_revision {
+            return Err(RelationInvariantError::StaleProposalRevision);
+        }
+        let successor_revision = self
+            .revision
+            .checked_add(1)
+            .ok_or(RelationInvariantError::ProposalRevisionExhausted)?;
+        self.state = ProposalState::Stale;
+        self.revision = successor_revision;
+        Ok(())
+    }
+}
+
 /// Complete fingerprint that suppresses only equivalent automatic proposals.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct RejectionFingerprint {
     pub basis_fingerprint: String,
     pub evidence_revision: String,
     pub matching_settings_revision: u64,
+}
+
+impl RejectionFingerprint {
+    #[must_use]
+    pub fn from_basis(
+        basis: &ProposalBasis,
+        evidence_revision: impl Into<String>,
+        matching_settings_revision: u64,
+    ) -> Self {
+        let evidence_revision = evidence_revision.into();
+        Self {
+            basis_fingerprint: basis.fingerprint(&evidence_revision, matching_settings_revision),
+            evidence_revision,
+            matching_settings_revision,
+        }
+    }
 }
 
 /// In-memory domain model of remembered rejection semantics.
@@ -366,13 +601,7 @@ pub enum MosaicObjectCoverage {
     Partial,
 }
 
-/// Measure one object and exclude zero-coverage results, including gap points.
-///
-/// # Errors
-///
-/// Returns the upstream typed geometry error when the object cannot be
-/// projected or measured against the union's persisted anchor.
-pub fn measure_mosaic_object(
+fn measure_mosaic_object(
     union: &FootprintUnion,
     object: ObjectShape<'_>,
 ) -> target_match::Result<Option<MosaicObjectEvidence>> {
@@ -401,14 +630,38 @@ pub fn measure_mosaic_object(
     }))
 }
 
-/// Build the captured union once for an exact mosaic revision.
-///
-/// # Errors
-///
-/// Returns the upstream typed geometry error for an empty set, duplicate
-/// provenance, incompatible epochs, projection failure, or invalid geometry.
-pub fn captured_union(footprints: &[SkyFootprint]) -> target_match::Result<FootprintUnion> {
-    FootprintUnion::new(footprints)
+/// Captured, hole-aware geometry for one exact mosaic revision.
+#[derive(Debug, Clone)]
+pub struct CapturedMosaic(FootprintUnion);
+
+impl CapturedMosaic {
+    /// Build captured geometry while preserving gaps and disconnected regions.
+    ///
+    /// # Errors
+    ///
+    /// Returns the upstream typed geometry error for an empty set, duplicate
+    /// provenance, incompatible epochs, projection failure, or invalid geometry.
+    pub fn new(footprints: &[SkyFootprint]) -> target_match::Result<Self> {
+        FootprintUnion::new(footprints).map(Self)
+    }
+
+    #[must_use]
+    pub fn component_count(&self) -> usize {
+        self.0.component_count()
+    }
+
+    /// Measure one object and exclude zero-coverage results, including gap points.
+    ///
+    /// # Errors
+    ///
+    /// Returns the upstream typed geometry error when the object cannot be
+    /// projected or measured against the union's persisted anchor.
+    pub fn measure(
+        &self,
+        object: ObjectShape<'_>,
+    ) -> target_match::Result<Option<MosaicObjectEvidence>> {
+        measure_mosaic_object(&self.0, object)
+    }
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -426,6 +679,11 @@ pub enum RelationInvariantError {
     KindShapeMismatch,
     DuplicateCurrentPanelMembership,
     PredecessorAndReplacementCoexist,
+    MosaicEdgeOutsideReviewedSubjects,
+    ProposalNotPending,
+    StaleProposalRevision,
+    StaleProposalBasis,
+    ProposalRevisionExhausted,
 }
 
 impl std::fmt::Display for RelationInvariantError {
@@ -440,7 +698,7 @@ impl std::error::Error for RelationInvariantError {}
 mod tests {
     use super::*;
     use skymath::{Angle, Equatorial};
-    use target_match::{FootprintProvenance, ImageParity};
+    use target_match::{FootprintProvenance, ImageParity, SkyEllipse};
 
     fn edge(left: &str, right: &str) -> MosaicEdge {
         MosaicEdge::new(left, right, format!("{left}-{right}"))
@@ -480,14 +738,14 @@ mod tests {
         let first = PanelGroupRevision::singleton("p1", "r1", "old", 1);
         let duplicate = PanelGroupRevision::singleton("p2", "r2", "old", 1);
         assert_eq!(
-            validate_current_panel_membership(&[first.clone(), duplicate], &[]),
+            PanelGroupRevision::validate_current(&[first.clone(), duplicate], &[]),
             Err(RelationInvariantError::DuplicateCurrentPanelMembership)
         );
 
         let mut coexist = first;
         coexist.session_ids.insert("new".into());
         assert_eq!(
-            validate_current_panel_membership(&[coexist], &[("old".into(), "new".into())]),
+            PanelGroupRevision::validate_current(&[coexist], &[("old".into(), "new".into())],),
             Err(RelationInvariantError::PredecessorAndReplacementCoexist)
         );
     }
@@ -508,11 +766,23 @@ mod tests {
     #[test]
     fn bridge_between_accepted_components_requires_merge_review() {
         let accepted = [edge("a", "b"), edge("c", "d")];
-        assert!(edge_bridges_components("b", "c", &accepted));
-        assert!(!edge_bridges_components("a", "b", &accepted));
+        let topology = MosaicTopology;
+        assert!(topology.edge_bridges("b", "c", &accepted));
+        assert!(!topology.edge_bridges("a", "b", &accepted));
         let components =
             [BTreeSet::from(["singleton".into()]), BTreeSet::from(["a".into(), "b".into()])];
-        assert!(edge_bridges_accepted_mosaics("singleton", "a", &components));
+        assert!(topology.edge_bridges_accepted("singleton", "a", &components));
+    }
+
+    #[test]
+    fn bridge_detection_handles_long_components_and_unknown_endpoints() {
+        let topology = MosaicTopology;
+        let left: BTreeSet<String> = (0..1_000).map(|index| format!("left-{index}")).collect();
+        let right: BTreeSet<String> = (0..1_000).map(|index| format!("right-{index}")).collect();
+        let components = [left, right];
+        assert!(topology.edge_bridges_accepted("left-999", "right-999", &components));
+        assert!(!topology.edge_bridges_accepted("left-0", "left-999", &components));
+        assert!(!topology.edge_bridges_accepted("left-0", "unknown", &components));
     }
 
     #[test]
@@ -523,12 +793,9 @@ mod tests {
 
     #[test]
     fn remembered_rejection_changes_with_material_evidence() {
-        let old = RejectionFingerprint {
-            basis_fingerprint: "basis".into(),
-            evidence_revision: "e1".into(),
-            matching_settings_revision: 1,
-        };
-        let changed = RejectionFingerprint { evidence_revision: "e2".into(), ..old.clone() };
+        let basis = proposal_basis();
+        let old = RejectionFingerprint::from_basis(&basis, "e1", 1);
+        let changed = RejectionFingerprint::from_basis(&basis, "e2", 1);
         let mut remembered = RememberedRejections::default();
         remembered.remember(old.clone());
         assert!(remembered.suppresses(&old));
@@ -551,21 +818,133 @@ mod tests {
         assert_eq!(relation.validate(), Err(RelationInvariantError::RelationFreeProposal));
     }
 
+    fn manual_mosaic_edge(subject_ids: BTreeSet<String>, edge: MosaicEdge) -> ManualRelation {
+        ManualRelation {
+            kind: RelationKind::MosaicEdge,
+            review_reason: "reviewed geometry".into(),
+            target_scope: TargetScope::SameTarget { canonical_target_id: "target".into() },
+            source_revision_ids: BTreeSet::from(["mosaic-r1".into()]),
+            subject_ids,
+            membership_ids: BTreeSet::new(),
+            edges: vec![edge],
+            lineage: Vec::new(),
+            missing_evidence_codes: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn manual_mosaic_edge_matches_exact_reviewed_subjects() {
+        let reviewed = BTreeSet::from(["a".into(), "b".into()]);
+        assert_eq!(manual_mosaic_edge(reviewed.clone(), edge("a", "b")).validate(), Ok(()));
+        assert_eq!(
+            manual_mosaic_edge(reviewed.clone(), edge("a", "a")).validate(),
+            Err(RelationInvariantError::InvalidMosaicEdge)
+        );
+        assert_eq!(
+            manual_mosaic_edge(reviewed, edge("a", "outside")).validate(),
+            Err(RelationInvariantError::MosaicEdgeOutsideReviewedSubjects)
+        );
+    }
+
+    fn proposal_basis() -> ProposalBasis {
+        ProposalBasis {
+            kind: RelationKind::MosaicMerge,
+            target_scope: TargetScope::SameTarget { canonical_target_id: "target".into() },
+            source_revision_ids: BTreeSet::from(["source-a".into(), "source-b".into()]),
+            subject_ids: BTreeSet::from(["a".into(), "b".into(), "c".into()]),
+            membership_ids: BTreeSet::from(["a".into(), "b".into(), "c".into()]),
+            edges: vec![edge("a", "b"), edge("b", "c")],
+            lineage: vec![("old-a".into(), "new".into()), ("old-b".into(), "new".into())],
+        }
+    }
+
+    #[test]
+    fn canonical_proposal_fingerprint_is_reorder_stable() {
+        let basis = proposal_basis();
+        let mut reordered = basis.clone();
+        reordered.edges.reverse();
+        reordered.lineage.reverse();
+        assert_eq!(basis.fingerprint("evidence-1", 7), reordered.fingerprint("evidence-1", 7));
+    }
+
+    #[test]
+    fn canonical_proposal_fingerprint_changes_with_relevant_inputs() {
+        let basis = proposal_basis();
+        let original = basis.fingerprint("evidence-1", 7);
+        assert_ne!(original, basis.fingerprint("evidence-2", 7));
+        assert_ne!(original, basis.fingerprint("evidence-1", 8));
+
+        let mut changed_membership = basis;
+        changed_membership.membership_ids.insert("d".into());
+        assert_ne!(original, changed_membership.fingerprint("evidence-1", 7));
+    }
+
+    #[test]
+    fn stale_proposal_revision_is_rejected_without_mutation() {
+        let fingerprint = proposal_basis().fingerprint("evidence-1", 7);
+        let mut proposal = RelationProposal::pending(3, fingerprint.clone());
+        assert_eq!(
+            proposal.validate_pending(2, &fingerprint),
+            Err(RelationInvariantError::StaleProposalRevision)
+        );
+        assert_eq!(
+            proposal.validate_pending(3, "changed"),
+            Err(RelationInvariantError::StaleProposalBasis)
+        );
+        assert_eq!(proposal.mark_stale(2), Err(RelationInvariantError::StaleProposalRevision));
+        assert_eq!(proposal.state, ProposalState::Pending);
+        assert_eq!(proposal.revision, 3);
+
+        assert_eq!(proposal.mark_stale(3), Ok(()));
+        assert_eq!(proposal.state, ProposalState::Stale);
+        assert_eq!(proposal.revision, 4);
+        assert_eq!(
+            proposal.validate_pending(4, &fingerprint),
+            Err(RelationInvariantError::ProposalNotPending)
+        );
+    }
+
+    #[test]
+    fn proposal_revision_overflow_fails_without_partial_state_change() {
+        let mut proposal = RelationProposal::pending(u64::MAX, "basis");
+        assert_eq!(
+            proposal.mark_stale(u64::MAX),
+            Err(RelationInvariantError::ProposalRevisionExhausted)
+        );
+        assert_eq!(proposal.state, ProposalState::Pending);
+        assert_eq!(proposal.revision, u64::MAX);
+    }
+
     #[test]
     fn point_in_uncaptured_gap_is_excluded() {
-        let union = captured_union(&[square(8.0, "left"), square(12.0, "right")])
+        let union = CapturedMosaic::new(&[square(8.0, "left"), square(12.0, "right")])
             .expect("valid disconnected union");
         assert_eq!(union.component_count(), 2);
         assert_eq!(
-            measure_mosaic_object(&union, ObjectShape::Point(coordinate(10.0, 0.0)))
-                .expect("coverage measurement"),
+            union.measure(ObjectShape::Point(coordinate(10.0, 0.0))).expect("coverage measurement"),
             None
         );
-        let captured = measure_mosaic_object(&union, ObjectShape::Point(coordinate(8.0, 0.0)))
+        let captured = union
+            .measure(ObjectShape::Point(coordinate(8.0, 0.0)))
             .expect("coverage measurement")
             .expect("captured point");
         assert_eq!(captured.state, MosaicObjectCoverage::Full);
         assert_eq!(captured.panel_evidence_ids, BTreeSet::from(["left".into()]));
+
+        let spanning = SkyEllipse::new(
+            coordinate(10.0, 0.0),
+            Angle::from_degrees(3.0),
+            Angle::from_degrees(0.25),
+            Angle::from_degrees(90.0),
+            128,
+        )
+        .expect("valid extended object");
+        let extended = union
+            .measure(ObjectShape::Ellipse(&spanning))
+            .expect("coverage measurement")
+            .expect("panels intersect extended object");
+        assert_eq!(extended.state, MosaicObjectCoverage::Partial);
+        assert_eq!(extended.panel_evidence_ids, BTreeSet::from(["left".into(), "right".into()]));
     }
 
     #[test]

--- a/crates/targeting/src/relations.rs
+++ b/crates/targeting/src/relations.rs
@@ -1,0 +1,486 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Pure panel, mosaic, lineage, proposal, and object-evidence invariants.
+
+use std::collections::{BTreeMap, BTreeSet, VecDeque};
+
+use target_match::{CoverageState, FootprintUnion, ObjectShape, SkyFootprint};
+
+/// Stable logical panel identity and one immutable accepted revision.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PanelGroupRevision {
+    pub panel_group_id: String,
+    pub revision_id: String,
+    pub parent_revision_id: Option<String>,
+    pub session_ids: BTreeSet<String>,
+    pub representative_session_id: String,
+    pub matching_settings_revision: u64,
+}
+
+impl PanelGroupRevision {
+    /// Create the stable singleton group required for every light session.
+    #[must_use]
+    pub fn singleton(
+        panel_group_id: impl Into<String>,
+        revision_id: impl Into<String>,
+        session_id: impl Into<String>,
+        matching_settings_revision: u64,
+    ) -> Self {
+        let session_id = session_id.into();
+        Self {
+            panel_group_id: panel_group_id.into(),
+            revision_id: revision_id.into(),
+            parent_revision_id: None,
+            session_ids: BTreeSet::from([session_id.clone()]),
+            representative_session_id: session_id,
+            matching_settings_revision,
+        }
+    }
+
+    /// Validate non-vacuous membership and representative stability.
+    pub fn validate(&self) -> Result<(), RelationInvariantError> {
+        if self.session_ids.is_empty() {
+            return Err(RelationInvariantError::EmptyPanelMembership);
+        }
+        if !self.session_ids.contains(&self.representative_session_id) {
+            return Err(RelationInvariantError::RepresentativeNotMember);
+        }
+        Ok(())
+    }
+}
+
+/// One exact accepted adjacency edge between panel revisions.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct MosaicEdge {
+    pub left_panel_revision_id: String,
+    pub right_panel_revision_id: String,
+    pub evidence_id: String,
+}
+
+impl MosaicEdge {
+    #[must_use]
+    pub fn new(
+        left: impl Into<String>,
+        right: impl Into<String>,
+        evidence_id: impl Into<String>,
+    ) -> Self {
+        Self {
+            left_panel_revision_id: left.into(),
+            right_panel_revision_id: right.into(),
+            evidence_id: evidence_id.into(),
+        }
+    }
+}
+
+/// Validate that exact mosaic members are connected by exact accepted edges.
+pub fn validate_mosaic_connectivity(
+    panels: &BTreeSet<String>,
+    edges: &[MosaicEdge],
+) -> Result<(), RelationInvariantError> {
+    if panels.len() < 2 {
+        return Err(RelationInvariantError::MosaicNeedsTwoPanels);
+    }
+    let mut adjacency: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    for edge in edges {
+        let left = edge.left_panel_revision_id.as_str();
+        let right = edge.right_panel_revision_id.as_str();
+        if left == right || !panels.contains(left) || !panels.contains(right) {
+            return Err(RelationInvariantError::InvalidMosaicEdge);
+        }
+        adjacency.entry(left).or_default().push(right);
+        adjacency.entry(right).or_default().push(left);
+    }
+    let seed = panels.first().expect("panel count checked").as_str();
+    let mut visited = BTreeSet::from([seed]);
+    let mut queue = VecDeque::from([seed]);
+    while let Some(node) = queue.pop_front() {
+        for next in adjacency.get(node).into_iter().flatten().copied() {
+            if visited.insert(next) {
+                queue.push_back(next);
+            }
+        }
+    }
+    if visited.len() != panels.len() {
+        return Err(RelationInvariantError::DisconnectedMosaic);
+    }
+    Ok(())
+}
+
+/// Whether a proposed edge connects two already accepted components.
+#[must_use]
+pub fn edge_bridges_components(left: &str, right: &str, accepted_edges: &[MosaicEdge]) -> bool {
+    if left == right {
+        return false;
+    }
+    !reachable(left, right, accepted_edges)
+        && accepted_edges
+            .iter()
+            .any(|edge| edge.left_panel_revision_id == left || edge.right_panel_revision_id == left)
+        && accepted_edges.iter().any(|edge| {
+            edge.left_panel_revision_id == right || edge.right_panel_revision_id == right
+        })
+}
+
+fn reachable(start: &str, destination: &str, edges: &[MosaicEdge]) -> bool {
+    let mut visited = BTreeSet::from([start]);
+    let mut queue = VecDeque::from([start]);
+    while let Some(node) = queue.pop_front() {
+        for edge in edges {
+            let next = if edge.left_panel_revision_id == node {
+                Some(edge.right_panel_revision_id.as_str())
+            } else if edge.right_panel_revision_id == node {
+                Some(edge.left_panel_revision_id.as_str())
+            } else {
+                None
+            };
+            if let Some(next) = next {
+                if next == destination {
+                    return true;
+                }
+                if visited.insert(next) {
+                    queue.push_back(next);
+                }
+            }
+        }
+    }
+    false
+}
+
+/// Validate a directed lineage snapshot, including proposed edges, is acyclic.
+pub fn validate_acyclic_lineage(edges: &[(String, String)]) -> Result<(), RelationInvariantError> {
+    let mut successors: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+    let mut indegree: BTreeMap<&str, usize> = BTreeMap::new();
+    for (predecessor, successor) in edges {
+        if predecessor == successor {
+            return Err(RelationInvariantError::LineageCycle);
+        }
+        successors.entry(predecessor).or_default().push(successor);
+        indegree.entry(predecessor).or_default();
+        *indegree.entry(successor).or_default() += 1;
+    }
+    let mut queue: VecDeque<&str> =
+        indegree.iter().filter_map(|(node, degree)| (*degree == 0).then_some(*node)).collect();
+    let mut visited = 0;
+    while let Some(node) = queue.pop_front() {
+        visited += 1;
+        for successor in successors.get(node).into_iter().flatten().copied() {
+            let degree = indegree.get_mut(successor).expect("successor was indexed");
+            *degree -= 1;
+            if *degree == 0 {
+                queue.push_back(successor);
+            }
+        }
+    }
+    if visited != indegree.len() {
+        return Err(RelationInvariantError::LineageCycle);
+    }
+    Ok(())
+}
+
+/// Kinds accepted by explicit manual relation review.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationKind {
+    PanelAdd,
+    PanelReplace,
+    PanelSplit,
+    PanelMerge,
+    MosaicCreate,
+    MosaicEdge,
+    MosaicSplit,
+    MosaicMerge,
+}
+
+/// Target scope reviewed with a manual relation.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TargetScope {
+    SameTarget { canonical_target_id: String },
+    ExistingCrossTarget { association_id: String },
+    NewReviewedCrossTarget { canonical_target_ids: BTreeSet<String> },
+}
+
+/// Pure shape of a manual relation proposal before persistence.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ManualRelation {
+    pub kind: RelationKind,
+    pub review_reason: String,
+    pub target_scope: TargetScope,
+    pub source_revision_ids: BTreeSet<String>,
+    pub subject_ids: BTreeSet<String>,
+    pub membership_ids: BTreeSet<String>,
+    pub edges: Vec<MosaicEdge>,
+    pub lineage: Vec<(String, String)>,
+    pub missing_evidence_codes: BTreeSet<String>,
+}
+
+impl ManualRelation {
+    /// Enforce the non-vacuous and kind-specific contract before persistence.
+    pub fn validate(&self) -> Result<(), RelationInvariantError> {
+        if self.review_reason.trim().is_empty() {
+            return Err(RelationInvariantError::MissingReviewReason);
+        }
+        if self.source_revision_ids.is_empty() || self.subject_ids.is_empty() {
+            return Err(RelationInvariantError::EmptyProposalInputs);
+        }
+        if self.membership_ids.is_empty() && self.edges.is_empty() && self.lineage.is_empty() {
+            return Err(RelationInvariantError::RelationFreeProposal);
+        }
+        if self.missing_evidence_codes.is_empty() {
+            return Err(RelationInvariantError::MissingEvidenceDisclosure);
+        }
+        if let TargetScope::NewReviewedCrossTarget { canonical_target_ids } = &self.target_scope {
+            if canonical_target_ids.len() < 2 {
+                return Err(RelationInvariantError::CrossTargetNeedsTwoTargets);
+            }
+        }
+        match self.kind {
+            RelationKind::PanelAdd | RelationKind::PanelReplace => {
+                if self.source_revision_ids.len() != 1 || self.membership_ids.is_empty() {
+                    return Err(RelationInvariantError::KindShapeMismatch);
+                }
+            }
+            RelationKind::PanelSplit | RelationKind::PanelMerge => {
+                if self.membership_ids.is_empty() || self.lineage.is_empty() {
+                    return Err(RelationInvariantError::KindShapeMismatch);
+                }
+            }
+            RelationKind::MosaicCreate => {
+                validate_mosaic_connectivity(&self.membership_ids, &self.edges)?;
+            }
+            RelationKind::MosaicEdge => {
+                if self.subject_ids.len() != 2 || self.edges.len() != 1 {
+                    return Err(RelationInvariantError::KindShapeMismatch);
+                }
+            }
+            RelationKind::MosaicSplit | RelationKind::MosaicMerge => {
+                if self.membership_ids.is_empty()
+                    || self.edges.is_empty()
+                    || self.lineage.is_empty()
+                {
+                    return Err(RelationInvariantError::KindShapeMismatch);
+                }
+                validate_mosaic_connectivity(&self.membership_ids, &self.edges)?;
+            }
+        }
+        validate_acyclic_lineage(&self.lineage)
+    }
+}
+
+/// Complete fingerprint that suppresses only equivalent automatic proposals.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
+pub struct RejectionFingerprint {
+    pub basis_fingerprint: String,
+    pub evidence_revision: String,
+    pub matching_settings_revision: u64,
+}
+
+/// In-memory domain model of remembered rejection semantics.
+#[derive(Debug, Default)]
+pub struct RememberedRejections(BTreeSet<RejectionFingerprint>);
+
+impl RememberedRejections {
+    pub fn remember(&mut self, fingerprint: RejectionFingerprint) {
+        self.0.insert(fingerprint);
+    }
+
+    #[must_use]
+    pub fn suppresses(&self, fingerprint: &RejectionFingerprint) -> bool {
+        self.0.contains(fingerprint)
+    }
+}
+
+/// Contract-facing object coverage retained for a captured mosaic union.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MosaicObjectEvidence {
+    pub state: MosaicObjectCoverage,
+    pub covered_fraction: Option<f64>,
+    pub panel_evidence_ids: BTreeSet<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MosaicObjectCoverage {
+    Full,
+    Partial,
+}
+
+/// Measure one object and exclude zero-coverage results, including gap points.
+pub fn measure_mosaic_object(
+    union: &FootprintUnion,
+    object: ObjectShape<'_>,
+) -> target_match::Result<Option<MosaicObjectEvidence>> {
+    let evidence = union.measure_object(object)?;
+    if evidence.state == CoverageState::None {
+        return Ok(None);
+    }
+    let panel_evidence_ids = if let Some(point) = evidence.point {
+        point
+            .panels
+            .into_iter()
+            .filter(|panel| panel.containment.is_covered())
+            .map(|panel| panel.provenance.as_str().to_owned())
+            .collect()
+    } else {
+        evidence.panels.into_iter().map(|panel| panel.provenance.as_str().to_owned()).collect()
+    };
+    Ok(Some(MosaicObjectEvidence {
+        state: match evidence.state {
+            CoverageState::Partial => MosaicObjectCoverage::Partial,
+            CoverageState::Full => MosaicObjectCoverage::Full,
+            CoverageState::None => unreachable!("zero coverage returned early"),
+        },
+        covered_fraction: evidence.covered_fraction,
+        panel_evidence_ids,
+    }))
+}
+
+/// Build the captured union once for an exact mosaic revision.
+pub fn captured_union(footprints: &[SkyFootprint]) -> target_match::Result<FootprintUnion> {
+    FootprintUnion::new(footprints)
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RelationInvariantError {
+    EmptyPanelMembership,
+    RepresentativeNotMember,
+    MosaicNeedsTwoPanels,
+    InvalidMosaicEdge,
+    DisconnectedMosaic,
+    LineageCycle,
+    MissingReviewReason,
+    EmptyProposalInputs,
+    RelationFreeProposal,
+    MissingEvidenceDisclosure,
+    CrossTargetNeedsTwoTargets,
+    KindShapeMismatch,
+}
+
+impl std::fmt::Display for RelationInvariantError {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(formatter, "{self:?}")
+    }
+}
+
+impl std::error::Error for RelationInvariantError {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use skymath::{Angle, Equatorial};
+    use target_match::{FootprintProvenance, ImageParity};
+
+    fn edge(left: &str, right: &str) -> MosaicEdge {
+        MosaicEdge::new(left, right, format!("{left}-{right}"))
+    }
+
+    fn coordinate(ra: f64, dec: f64) -> Equatorial {
+        Equatorial::j2000(Angle::from_degrees(ra), Angle::from_degrees(dec))
+            .expect("valid coordinate")
+    }
+
+    fn square(centre_ra: f64, provenance: &str) -> SkyFootprint {
+        SkyFootprint::new(
+            coordinate(centre_ra, 0.0),
+            vec![
+                coordinate(centre_ra - 0.5, -0.5),
+                coordinate(centre_ra + 0.5, -0.5),
+                coordinate(centre_ra + 0.5, 0.5),
+                coordinate(centre_ra - 0.5, 0.5),
+            ],
+            Angle::from_degrees(0.0),
+            ImageParity::Direct,
+            FootprintProvenance::new(provenance).expect("valid provenance"),
+        )
+        .expect("valid footprint")
+    }
+
+    #[test]
+    fn singleton_panel_is_valid_and_stable() {
+        let group = PanelGroupRevision::singleton("panel", "r1", "session", 7);
+        assert_eq!(group.representative_session_id, "session");
+        assert_eq!(group.matching_settings_revision, 7);
+        assert_eq!(group.validate(), Ok(()));
+    }
+
+    #[test]
+    fn mosaic_requires_connected_exact_members() {
+        let panels = BTreeSet::from(["a".into(), "b".into(), "c".into()]);
+        assert_eq!(
+            validate_mosaic_connectivity(&panels, &[edge("a", "b")]),
+            Err(RelationInvariantError::DisconnectedMosaic)
+        );
+        assert_eq!(
+            validate_mosaic_connectivity(&panels, &[edge("a", "b"), edge("b", "c")]),
+            Ok(())
+        );
+    }
+
+    #[test]
+    fn bridge_between_accepted_components_requires_merge_review() {
+        let accepted = [edge("a", "b"), edge("c", "d")];
+        assert!(edge_bridges_components("b", "c", &accepted));
+        assert!(!edge_bridges_components("a", "b", &accepted));
+    }
+
+    #[test]
+    fn lineage_cycle_is_rejected() {
+        let edges = vec![("a".into(), "b".into()), ("b".into(), "a".into())];
+        assert_eq!(validate_acyclic_lineage(&edges), Err(RelationInvariantError::LineageCycle));
+    }
+
+    #[test]
+    fn remembered_rejection_changes_with_material_evidence() {
+        let old = RejectionFingerprint {
+            basis_fingerprint: "basis".into(),
+            evidence_revision: "e1".into(),
+            matching_settings_revision: 1,
+        };
+        let changed = RejectionFingerprint { evidence_revision: "e2".into(), ..old.clone() };
+        let mut remembered = RememberedRejections::default();
+        remembered.remember(old.clone());
+        assert!(remembered.suppresses(&old));
+        assert!(!remembered.suppresses(&changed));
+    }
+
+    #[test]
+    fn manual_relation_cannot_be_vacuous() {
+        let relation = ManualRelation {
+            kind: RelationKind::PanelAdd,
+            review_reason: "geometry unavailable".into(),
+            target_scope: TargetScope::SameTarget { canonical_target_id: "target".into() },
+            source_revision_ids: BTreeSet::from(["r1".into()]),
+            subject_ids: BTreeSet::from(["s1".into()]),
+            membership_ids: BTreeSet::new(),
+            edges: Vec::new(),
+            lineage: Vec::new(),
+            missing_evidence_codes: BTreeSet::from(["footprint_missing".into()]),
+        };
+        assert_eq!(relation.validate(), Err(RelationInvariantError::RelationFreeProposal));
+    }
+
+    #[test]
+    fn point_in_uncaptured_gap_is_excluded() {
+        let union = captured_union(&[square(8.0, "left"), square(12.0, "right")])
+            .expect("valid disconnected union");
+        assert_eq!(union.component_count(), 2);
+        assert_eq!(
+            measure_mosaic_object(&union, ObjectShape::Point(coordinate(10.0, 0.0)))
+                .expect("coverage measurement"),
+            None
+        );
+        let captured = measure_mosaic_object(&union, ObjectShape::Point(coordinate(8.0, 0.0)))
+            .expect("coverage measurement")
+            .expect("captured point");
+        assert_eq!(captured.state, MosaicObjectCoverage::Full);
+        assert_eq!(captured.panel_evidence_ids, BTreeSet::from(["left".into()]));
+    }
+
+    #[test]
+    fn forward_only_lineage_is_acyclic_across_sampled_sizes() {
+        for node_count in 1_usize..128 {
+            let edges: Vec<(String, String)> = (0..node_count.saturating_sub(1))
+                .map(|index| (format!("n{index}"), format!("n{}", index + 1)))
+                .collect();
+            assert_eq!(validate_acyclic_lineage(&edges), Ok(()));
+        }
+    }
+}

--- a/crates/targeting/src/relations.rs
+++ b/crates/targeting/src/relations.rs
@@ -105,45 +105,78 @@ fn validate_current_panel_membership(
 /// One exact accepted adjacency edge between panel revisions.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct MosaicEdge {
-    pub left_panel_revision_id: String,
-    pub right_panel_revision_id: String,
-    pub evidence_id: String,
-}
-
-/// Live topology operations for exact mosaic revisions.
-#[derive(Debug, Default, Clone, Copy)]
-pub struct MosaicTopology;
-
-impl MosaicTopology {
-    /// Whether an edge connects two components implied by accepted edges.
-    #[must_use]
-    pub fn edge_bridges(self, left: &str, right: &str, accepted_edges: &[MosaicEdge]) -> bool {
-        edge_bridges_components(left, right, accepted_edges)
-    }
-
-    /// Whether an edge connects two accepted mosaic membership snapshots.
-    #[must_use]
-    pub fn edge_bridges_accepted(
-        self,
-        left: &str,
-        right: &str,
-        accepted_components: &[BTreeSet<String>],
-    ) -> bool {
-        edge_bridges_accepted_mosaics(left, right, accepted_components)
-    }
+    id: String,
+    left_revision: String,
+    right_revision: String,
+    evidence: String,
 }
 
 impl MosaicEdge {
-    #[must_use]
+    /// Construct a validated undirected panel-adjacency edge.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invariant error when the edge ID, evidence ID, or either
+    /// endpoint is blank or whitespace-only.
     pub fn new(
+        edge_id: impl Into<String>,
         left: impl Into<String>,
         right: impl Into<String>,
         evidence_id: impl Into<String>,
-    ) -> Self {
-        Self {
-            left_panel_revision_id: left.into(),
-            right_panel_revision_id: right.into(),
-            evidence_id: evidence_id.into(),
+    ) -> Result<Self, RelationInvariantError> {
+        let id = edge_id.into();
+        let left_revision = left.into();
+        let right_revision = right.into();
+        let evidence = evidence_id.into();
+        if id.trim().is_empty() {
+            return Err(RelationInvariantError::BlankMosaicEdgeId);
+        }
+        if evidence.trim().is_empty() {
+            return Err(RelationInvariantError::BlankEvidenceId);
+        }
+        if left_revision.trim().is_empty() || right_revision.trim().is_empty() {
+            return Err(RelationInvariantError::BlankPanelRevisionId);
+        }
+        Ok(Self { id, left_revision, right_revision, evidence })
+    }
+
+    #[must_use]
+    pub fn edge_id(&self) -> &str {
+        &self.id
+    }
+
+    #[must_use]
+    pub fn evidence_id(&self) -> &str {
+        &self.evidence
+    }
+
+    #[must_use]
+    pub fn endpoints(&self) -> (&str, &str) {
+        (&self.left_revision, &self.right_revision)
+    }
+
+    /// Whether this edge connects two components implied by accepted edges.
+    #[must_use]
+    pub fn bridges(&self, accepted_edges: &[Self]) -> bool {
+        edge_bridges_components(&self.left_revision, &self.right_revision, accepted_edges)
+    }
+
+    /// Whether this edge connects two accepted mosaic membership snapshots.
+    #[must_use]
+    pub fn bridges_accepted(&self, accepted_components: &[BTreeSet<String>]) -> bool {
+        edge_bridges_accepted_mosaics(
+            &self.left_revision,
+            &self.right_revision,
+            accepted_components,
+        )
+    }
+
+    fn canonical_undirected_record(&self) -> (&str, &str, &str, &str) {
+        let (left, right) = self.endpoints();
+        if left <= right {
+            (left, right, self.edge_id(), self.evidence_id())
+        } else {
+            (right, left, self.edge_id(), self.evidence_id())
         }
     }
 }
@@ -164,8 +197,7 @@ pub fn validate_mosaic_connectivity(
     }
     let mut adjacency: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
     for edge in edges {
-        let left = edge.left_panel_revision_id.as_str();
-        let right = edge.right_panel_revision_id.as_str();
+        let (left, right) = edge.endpoints();
         if left == right || !panels.contains(left) || !panels.contains(right) {
             return Err(RelationInvariantError::InvalidMosaicEdge);
         }
@@ -199,10 +231,10 @@ fn edge_bridges_components(left: &str, right: &str, accepted_edges: &[MosaicEdge
     !reachable(left, right, accepted_edges)
         && accepted_edges
             .iter()
-            .any(|edge| edge.left_panel_revision_id == left || edge.right_panel_revision_id == left)
-        && accepted_edges.iter().any(|edge| {
-            edge.left_panel_revision_id == right || edge.right_panel_revision_id == right
-        })
+            .any(|edge| edge.left_revision == left || edge.right_revision == left)
+        && accepted_edges
+            .iter()
+            .any(|edge| edge.left_revision == right || edge.right_revision == right)
 }
 
 /// Detect a bridge when accepted component membership is already known.
@@ -223,10 +255,10 @@ fn reachable(start: &str, destination: &str, edges: &[MosaicEdge]) -> bool {
     let mut queue = VecDeque::from([start]);
     while let Some(node) = queue.pop_front() {
         for edge in edges {
-            let next = if edge.left_panel_revision_id == node {
-                Some(edge.right_panel_revision_id.as_str())
-            } else if edge.right_panel_revision_id == node {
-                Some(edge.left_panel_revision_id.as_str())
+            let next = if edge.left_revision == node {
+                Some(edge.right_revision.as_str())
+            } else if edge.right_revision == node {
+                Some(edge.left_revision.as_str())
             } else {
                 None
             };
@@ -355,13 +387,11 @@ impl ManualRelation {
                     return Err(RelationInvariantError::KindShapeMismatch);
                 }
                 let edge = &self.edges[0];
-                if edge.left_panel_revision_id == edge.right_panel_revision_id {
+                if edge.left_revision == edge.right_revision {
                     return Err(RelationInvariantError::InvalidMosaicEdge);
                 }
-                let reviewed_endpoints = BTreeSet::from([
-                    edge.left_panel_revision_id.clone(),
-                    edge.right_panel_revision_id.clone(),
-                ]);
+                let reviewed_endpoints =
+                    BTreeSet::from([edge.left_revision.clone(), edge.right_revision.clone()]);
                 if reviewed_endpoints != self.subject_ids {
                     return Err(RelationInvariantError::MosaicEdgeOutsideReviewedSubjects);
                 }
@@ -417,14 +447,15 @@ impl ProposalBasis {
         push_canonical_field(&mut canonical, "memberships");
         push_sorted_strings(&mut canonical, &self.membership_ids);
 
-        let mut edges = self.edges.clone();
-        edges.sort();
+        let edges: BTreeSet<_> =
+            self.edges.iter().map(MosaicEdge::canonical_undirected_record).collect();
         push_canonical_field(&mut canonical, "edges");
         push_canonical_field(&mut canonical, &edges.len().to_string());
-        for edge in edges {
-            push_canonical_field(&mut canonical, &edge.left_panel_revision_id);
-            push_canonical_field(&mut canonical, &edge.right_panel_revision_id);
-            push_canonical_field(&mut canonical, &edge.evidence_id);
+        for (left, right, edge_id, evidence_id) in edges {
+            push_canonical_field(&mut canonical, left);
+            push_canonical_field(&mut canonical, right);
+            push_canonical_field(&mut canonical, edge_id);
+            push_canonical_field(&mut canonical, evidence_id);
         }
 
         let mut lineage = self.lineage.clone();
@@ -684,6 +715,9 @@ pub enum RelationInvariantError {
     StaleProposalRevision,
     StaleProposalBasis,
     ProposalRevisionExhausted,
+    BlankMosaicEdgeId,
+    BlankEvidenceId,
+    BlankPanelRevisionId,
 }
 
 impl std::fmt::Display for RelationInvariantError {
@@ -701,7 +735,17 @@ mod tests {
     use target_match::{FootprintProvenance, ImageParity, SkyEllipse};
 
     fn edge(left: &str, right: &str) -> MosaicEdge {
-        MosaicEdge::new(left, right, format!("{left}-{right}"))
+        MosaicEdge::new(
+            format!("edge-{left}-{right}"),
+            left,
+            right,
+            format!("evidence-{left}-{right}"),
+        )
+        .expect("valid edge")
+    }
+
+    fn identified_edge(edge_id: &str, left: &str, right: &str, evidence_id: &str) -> MosaicEdge {
+        MosaicEdge::new(edge_id, left, right, evidence_id).expect("valid edge")
     }
 
     fn coordinate(ra: f64, dec: f64) -> Equatorial {
@@ -764,25 +808,63 @@ mod tests {
     }
 
     #[test]
+    fn mosaic_connectivity_is_edge_order_invariant() {
+        let panels = BTreeSet::from(["a".into(), "b".into(), "c".into(), "d".into()]);
+        let permutations = [
+            vec![edge("a", "b"), edge("b", "c"), edge("c", "d")],
+            vec![edge("c", "d"), edge("a", "b"), edge("b", "c")],
+            vec![edge("b", "c"), edge("c", "d"), edge("a", "b")],
+        ];
+        for edges in permutations {
+            assert_eq!(validate_mosaic_connectivity(&panels, &edges), Ok(()));
+        }
+    }
+
+    #[test]
     fn bridge_between_accepted_components_requires_merge_review() {
         let accepted = [edge("a", "b"), edge("c", "d")];
-        let topology = MosaicTopology;
-        assert!(topology.edge_bridges("b", "c", &accepted));
-        assert!(!topology.edge_bridges("a", "b", &accepted));
+        assert!(edge("b", "c").bridges(&accepted));
+        assert!(!edge("a", "b").bridges(&accepted));
         let components =
             [BTreeSet::from(["singleton".into()]), BTreeSet::from(["a".into(), "b".into()])];
-        assert!(topology.edge_bridges_accepted("singleton", "a", &components));
+        assert!(edge("singleton", "a").bridges_accepted(&components));
     }
 
     #[test]
     fn bridge_detection_handles_long_components_and_unknown_endpoints() {
-        let topology = MosaicTopology;
         let left: BTreeSet<String> = (0..1_000).map(|index| format!("left-{index}")).collect();
         let right: BTreeSet<String> = (0..1_000).map(|index| format!("right-{index}")).collect();
         let components = [left, right];
-        assert!(topology.edge_bridges_accepted("left-999", "right-999", &components));
-        assert!(!topology.edge_bridges_accepted("left-0", "left-999", &components));
-        assert!(!topology.edge_bridges_accepted("left-0", "unknown", &components));
+        assert!(edge("left-999", "right-999").bridges_accepted(&components));
+        assert!(!edge("left-0", "left-999").bridges_accepted(&components));
+        assert!(!edge("left-0", "unknown").bridges_accepted(&components));
+    }
+
+    #[test]
+    fn mosaic_edge_rejects_blank_nested_identifiers() {
+        for blank in ["", " ", "\t\n"] {
+            assert_eq!(
+                MosaicEdge::new(blank, "left", "right", "evidence"),
+                Err(RelationInvariantError::BlankMosaicEdgeId)
+            );
+            assert_eq!(
+                MosaicEdge::new("edge", "left", "right", blank),
+                Err(RelationInvariantError::BlankEvidenceId)
+            );
+            assert_eq!(
+                MosaicEdge::new("edge", blank, "right", "evidence"),
+                Err(RelationInvariantError::BlankPanelRevisionId)
+            );
+        }
+
+        let nested: Result<Vec<_>, _> =
+            [("edge-a", "evidence-a"), ("edge-b", "   "), ("edge-c", "evidence-c")]
+                .into_iter()
+                .map(|(edge_id, evidence_id)| {
+                    MosaicEdge::new(edge_id, "left", "right", evidence_id)
+                })
+                .collect();
+        assert_eq!(nested, Err(RelationInvariantError::BlankEvidenceId));
     }
 
     #[test]
@@ -846,6 +928,55 @@ mod tests {
         );
     }
 
+    fn populated_manual_relation(kind: RelationKind) -> ManualRelation {
+        ManualRelation {
+            kind,
+            review_reason: "reviewed".into(),
+            target_scope: TargetScope::SameTarget { canonical_target_id: "target".into() },
+            source_revision_ids: BTreeSet::from(["source".into()]),
+            subject_ids: BTreeSet::from(["a".into(), "b".into()]),
+            membership_ids: BTreeSet::from(["a".into(), "b".into()]),
+            edges: vec![edge("a", "b")],
+            lineage: vec![("old".into(), "new".into())],
+            missing_evidence_codes: BTreeSet::new(),
+        }
+    }
+
+    #[test]
+    fn every_manual_kind_rejects_its_vacuous_shape() {
+        let mut cases = Vec::new();
+        for kind in [RelationKind::PanelAdd, RelationKind::PanelReplace] {
+            let mut relation = populated_manual_relation(kind);
+            relation.membership_ids.clear();
+            cases.push(relation);
+        }
+        for kind in [RelationKind::PanelSplit, RelationKind::PanelMerge] {
+            let mut relation = populated_manual_relation(kind);
+            relation.lineage.clear();
+            cases.push(relation);
+        }
+        let mut mosaic_create = populated_manual_relation(RelationKind::MosaicCreate);
+        mosaic_create.membership_ids = BTreeSet::from(["a".into()]);
+        cases.push(mosaic_create);
+
+        let mut mosaic_edge = populated_manual_relation(RelationKind::MosaicEdge);
+        mosaic_edge.subject_ids = BTreeSet::from(["a".into()]);
+        cases.push(mosaic_edge);
+
+        let mut mosaic_split = populated_manual_relation(RelationKind::MosaicSplit);
+        mosaic_split.edges.clear();
+        cases.push(mosaic_split);
+
+        let mut mosaic_merge = populated_manual_relation(RelationKind::MosaicMerge);
+        mosaic_merge.lineage.clear();
+        cases.push(mosaic_merge);
+
+        assert_eq!(cases.len(), 8);
+        for relation in cases {
+            assert!(relation.validate().is_err(), "accepted invalid {:?}", relation.kind);
+        }
+    }
+
     fn proposal_basis() -> ProposalBasis {
         ProposalBasis {
             kind: RelationKind::MosaicMerge,
@@ -865,6 +996,37 @@ mod tests {
         reordered.edges.reverse();
         reordered.lineage.reverse();
         assert_eq!(basis.fingerprint("evidence-1", 7), reordered.fingerprint("evidence-1", 7));
+    }
+
+    #[test]
+    fn canonical_proposal_fingerprint_normalizes_undirected_edges_and_duplicates() {
+        let mut forward = proposal_basis();
+        forward.edges = vec![identified_edge("edge", "a", "b", "evidence")];
+
+        let mut reversed = forward.clone();
+        reversed.edges = vec![
+            identified_edge("edge", "b", "a", "evidence"),
+            identified_edge("edge", "a", "b", "evidence"),
+        ];
+        assert_eq!(
+            forward.fingerprint("evidence-revision", 7),
+            reversed.fingerprint("evidence-revision", 7)
+        );
+    }
+
+    #[test]
+    fn canonical_proposal_fingerprint_keeps_lineage_directed() {
+        let forward = proposal_basis();
+        let mut reversed = forward.clone();
+        reversed.lineage = forward
+            .lineage
+            .iter()
+            .map(|(predecessor, successor)| (successor.clone(), predecessor.clone()))
+            .collect();
+        assert_ne!(
+            forward.fingerprint("evidence-revision", 7),
+            reversed.fingerprint("evidence-revision", 7)
+        );
     }
 
     #[test]

--- a/crates/targeting/src/relations.rs
+++ b/crates/targeting/src/relations.rs
@@ -39,6 +39,11 @@ impl PanelGroupRevision {
     }
 
     /// Validate non-vacuous membership and representative stability.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invariant error for empty membership or a representative
+    /// outside the immutable membership snapshot.
     pub fn validate(&self) -> Result<(), RelationInvariantError> {
         if self.session_ids.is_empty() {
             return Err(RelationInvariantError::EmptyPanelMembership);
@@ -48,6 +53,36 @@ impl PanelGroupRevision {
         }
         Ok(())
     }
+}
+
+/// Validate current panel heads as one snapshot.
+///
+/// A session belongs to at most one current group, and no current group may
+/// contain both sides of an accepted supersession relation.
+///
+/// # Errors
+///
+/// Returns an invariant error for an invalid revision, duplicate current
+/// membership, or predecessor/replacement coexistence.
+pub fn validate_current_panel_membership(
+    revisions: &[PanelGroupRevision],
+    supersessions: &[(String, String)],
+) -> Result<(), RelationInvariantError> {
+    let mut current_members = BTreeSet::new();
+    for revision in revisions {
+        revision.validate()?;
+        for session_id in &revision.session_ids {
+            if !current_members.insert(session_id) {
+                return Err(RelationInvariantError::DuplicateCurrentPanelMembership);
+            }
+        }
+        if supersessions.iter().any(|(predecessor, successor)| {
+            revision.session_ids.contains(predecessor) && revision.session_ids.contains(successor)
+        }) {
+            return Err(RelationInvariantError::PredecessorAndReplacementCoexist);
+        }
+    }
+    Ok(())
 }
 
 /// One exact accepted adjacency edge between panel revisions.
@@ -74,6 +109,12 @@ impl MosaicEdge {
 }
 
 /// Validate that exact mosaic members are connected by exact accepted edges.
+///
+/// # Errors
+///
+/// Returns an invariant error when fewer than two panels are supplied, an edge
+/// is self-referential or outside membership, or the accepted graph is not
+/// connected.
 pub fn validate_mosaic_connectivity(
     panels: &BTreeSet<String>,
     edges: &[MosaicEdge],
@@ -91,7 +132,9 @@ pub fn validate_mosaic_connectivity(
         adjacency.entry(left).or_default().push(right);
         adjacency.entry(right).or_default().push(left);
     }
-    let seed = panels.first().expect("panel count checked").as_str();
+    let Some(seed) = panels.first().map(String::as_str) else {
+        return Err(RelationInvariantError::MosaicNeedsTwoPanels);
+    };
     let mut visited = BTreeSet::from([seed]);
     let mut queue = VecDeque::from([seed]);
     while let Some(node) = queue.pop_front() {
@@ -122,6 +165,19 @@ pub fn edge_bridges_components(left: &str, right: &str, accepted_edges: &[Mosaic
         })
 }
 
+/// Detect a bridge when accepted component membership is already known.
+#[must_use]
+pub fn edge_bridges_accepted_mosaics(
+    left: &str,
+    right: &str,
+    accepted_components: &[BTreeSet<String>],
+) -> bool {
+    let left_component = accepted_components.iter().position(|component| component.contains(left));
+    let right_component =
+        accepted_components.iter().position(|component| component.contains(right));
+    matches!((left_component, right_component), (Some(left), Some(right)) if left != right)
+}
+
 fn reachable(start: &str, destination: &str, edges: &[MosaicEdge]) -> bool {
     let mut visited = BTreeSet::from([start]);
     let mut queue = VecDeque::from([start]);
@@ -148,6 +204,10 @@ fn reachable(start: &str, destination: &str, edges: &[MosaicEdge]) -> bool {
 }
 
 /// Validate a directed lineage snapshot, including proposed edges, is acyclic.
+///
+/// # Errors
+///
+/// Returns [`RelationInvariantError::LineageCycle`] for a self-edge or cycle.
 pub fn validate_acyclic_lineage(edges: &[(String, String)]) -> Result<(), RelationInvariantError> {
     let mut successors: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
     let mut indegree: BTreeMap<&str, usize> = BTreeMap::new();
@@ -165,10 +225,11 @@ pub fn validate_acyclic_lineage(edges: &[(String, String)]) -> Result<(), Relati
     while let Some(node) = queue.pop_front() {
         visited += 1;
         for successor in successors.get(node).into_iter().flatten().copied() {
-            let degree = indegree.get_mut(successor).expect("successor was indexed");
-            *degree -= 1;
-            if *degree == 0 {
-                queue.push_back(successor);
+            if let Some(degree) = indegree.get_mut(successor) {
+                *degree -= 1;
+                if *degree == 0 {
+                    queue.push_back(successor);
+                }
             }
         }
     }
@@ -215,6 +276,11 @@ pub struct ManualRelation {
 
 impl ManualRelation {
     /// Enforce the non-vacuous and kind-specific contract before persistence.
+    ///
+    /// # Errors
+    ///
+    /// Returns an invariant error when inputs or outputs are empty, target
+    /// scope is invalid, or the kind-specific membership/topology shape fails.
     pub fn validate(&self) -> Result<(), RelationInvariantError> {
         if self.review_reason.trim().is_empty() {
             return Err(RelationInvariantError::MissingReviewReason);
@@ -224,9 +290,6 @@ impl ManualRelation {
         }
         if self.membership_ids.is_empty() && self.edges.is_empty() && self.lineage.is_empty() {
             return Err(RelationInvariantError::RelationFreeProposal);
-        }
-        if self.missing_evidence_codes.is_empty() {
-            return Err(RelationInvariantError::MissingEvidenceDisclosure);
         }
         if let TargetScope::NewReviewedCrossTarget { canonical_target_ids } = &self.target_scope {
             if canonical_target_ids.len() < 2 {
@@ -304,6 +367,11 @@ pub enum MosaicObjectCoverage {
 }
 
 /// Measure one object and exclude zero-coverage results, including gap points.
+///
+/// # Errors
+///
+/// Returns the upstream typed geometry error when the object cannot be
+/// projected or measured against the union's persisted anchor.
 pub fn measure_mosaic_object(
     union: &FootprintUnion,
     object: ObjectShape<'_>,
@@ -334,6 +402,11 @@ pub fn measure_mosaic_object(
 }
 
 /// Build the captured union once for an exact mosaic revision.
+///
+/// # Errors
+///
+/// Returns the upstream typed geometry error for an empty set, duplicate
+/// provenance, incompatible epochs, projection failure, or invalid geometry.
 pub fn captured_union(footprints: &[SkyFootprint]) -> target_match::Result<FootprintUnion> {
     FootprintUnion::new(footprints)
 }
@@ -349,9 +422,10 @@ pub enum RelationInvariantError {
     MissingReviewReason,
     EmptyProposalInputs,
     RelationFreeProposal,
-    MissingEvidenceDisclosure,
     CrossTargetNeedsTwoTargets,
     KindShapeMismatch,
+    DuplicateCurrentPanelMembership,
+    PredecessorAndReplacementCoexist,
 }
 
 impl std::fmt::Display for RelationInvariantError {
@@ -402,6 +476,23 @@ mod tests {
     }
 
     #[test]
+    fn current_panel_membership_excludes_duplicates_and_replacements() {
+        let first = PanelGroupRevision::singleton("p1", "r1", "old", 1);
+        let duplicate = PanelGroupRevision::singleton("p2", "r2", "old", 1);
+        assert_eq!(
+            validate_current_panel_membership(&[first.clone(), duplicate], &[]),
+            Err(RelationInvariantError::DuplicateCurrentPanelMembership)
+        );
+
+        let mut coexist = first;
+        coexist.session_ids.insert("new".into());
+        assert_eq!(
+            validate_current_panel_membership(&[coexist], &[("old".into(), "new".into())]),
+            Err(RelationInvariantError::PredecessorAndReplacementCoexist)
+        );
+    }
+
+    #[test]
     fn mosaic_requires_connected_exact_members() {
         let panels = BTreeSet::from(["a".into(), "b".into(), "c".into()]);
         assert_eq!(
@@ -419,6 +510,9 @@ mod tests {
         let accepted = [edge("a", "b"), edge("c", "d")];
         assert!(edge_bridges_components("b", "c", &accepted));
         assert!(!edge_bridges_components("a", "b", &accepted));
+        let components =
+            [BTreeSet::from(["singleton".into()]), BTreeSet::from(["a".into(), "b".into()])];
+        assert!(edge_bridges_accepted_mosaics("singleton", "a", &components));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Validates same-session, sibling-panel, and mosaic relationship suggestions against inclusive geometry thresholds.
- Prevents disconnected mosaics, cyclic group history, duplicate panel membership, empty manual relationships, and repeated rejected suggestions.
- Excludes objects in uncaptured mosaic gaps while retaining partially covered extended objects.

## Test plan

- `cargo test -p targeting --locked`
- `cargo clippy -p targeting --all-targets --all-features --locked -- -D warnings`
- `RUSTDOCFLAGS='-D warnings' cargo doc -p targeting --no-deps --locked`

## Spec Context

Implements the pure targeting-domain portion of Spec 062. Persistence, application wiring, generated contracts, and UI remain separate changes.

Closes astro-plan-ic9h.11
