### PR TITLE
fix: install JavaScript dependencies for Rust CI contract tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -282,12 +282,12 @@ jobs:
           shared-key: "rust-${{ matrix.os }}-v2"
 
       - uses: pnpm/action-setup@v4
-        if: needs.changes.outputs.frontend == 'true'
+        if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
         with:
           version: 10.33.0
 
       - uses: actions/setup-node@v4
-        if: needs.changes.outputs.frontend == 'true'
+        if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
         with:
           node-version: 20
           cache: pnpm
@@ -300,7 +300,7 @@ jobs:
           tool: just,nextest
 
       - name: Install JS deps
-        if: needs.changes.outputs.frontend == 'true'
+        if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
         run: pnpm install --frozen-lockfile
 
       # Vite's dependency-optimizer output. Restored AFTER `pnpm install`


### PR DESCRIPTION
## Summary

- Install the JavaScript dependencies required by Rust contract tests on Rust-only changes, preventing clean-runner AJV module failures.
- Keep the existing frontend-only test gates unchanged.

## Spec Context

- Implements the Rust-only CI dependency setup fix for the session-heterogeneity delivery.