### PR TITLE
fix(projects): preserve source-missing block retries

### DIFF
--- a/crates/app/cache/src/lib.rs
+++ b/crates/app/cache/src/lib.rs
@@ -223,11 +223,24 @@ where
     /// last call that returned `false` for this key). Otherwise records the
     /// emission (starting a fresh window) and returns `false`.
     pub fn should_suppress(&self, key: &K) -> bool {
-        if self.last_emitted.get(key).is_some() {
+        if self.is_suppressed(key) {
             return true;
         }
-        self.last_emitted.insert(key.clone(), ());
+        self.record(key);
         false
+    }
+
+    /// Return whether `key` is still inside its suppression window without
+    /// starting a new window.
+    #[must_use]
+    pub fn is_suppressed(&self, key: &K) -> bool {
+        self.last_emitted.get(key).is_some()
+    }
+
+    /// Start a suppression window after the caller successfully emits its
+    /// durable signal.
+    pub fn record(&self, key: &K) {
+        self.last_emitted.insert(key.clone(), ());
     }
 
     /// Force-expire the entry for `key`, so the next `should_suppress` for it

--- a/crates/app/core/src/frame_inventory/mod.rs
+++ b/crates/app/core/src/frame_inventory/mod.rs
@@ -55,22 +55,63 @@ use contracts_core::inventory_frame::{
 ///
 /// # Errors
 ///
-/// Returns `ContractError` per [`reconcile::run_reconcile`], or an internal
-/// database error if the block check fails.
+/// Returns `ContractError` per [`reconcile::run_reconcile`]. A failed
+/// project-health check is retried on the next reconcile for the same root,
+/// because the frame-state writes have already committed by then.
 pub async fn run_reconcile(
     pool: &SqlitePool,
     bus: &audit::bus::EventBus,
     req: &InventoryReconcileRunRequest,
 ) -> Result<InventoryReconcileRunResponse, ContractError> {
-    let response = reconcile::run_reconcile(pool, bus, req).await?;
-
-    app_core_projects::project_health::check_project_source_missing_invariant(
+    let retry_pending = persistence_db::repositories::projects::begin_source_missing_health_check(
         pool,
-        bus,
-        crate::caches::project_block_debounce(),
+        &req.root_id,
     )
     .await
-    .map_err(internal)?;
+    .map_err(db_err)?;
+
+    let response = match reconcile::run_reconcile(pool, bus, req).await {
+        Ok(response) => response,
+        Err(error) => {
+            if !retry_pending {
+                let _ = persistence_db::repositories::projects::clear_source_missing_health_check(
+                    pool,
+                    &req.root_id,
+                )
+                .await;
+            }
+            return Err(error);
+        }
+    };
+
+    let should_check = response.newly_missing > 0 || retry_pending;
+    if should_check {
+        match app_core_projects::project_health::check_project_source_missing_invariant(
+            pool,
+            bus,
+            crate::caches::project_block_debounce(),
+        )
+        .await
+        {
+            Ok(app_core_projects::project_health::SourceMissingCheckOutcome::RetryRequired) => {
+                return Ok(response);
+            }
+            Ok(app_core_projects::project_health::SourceMissingCheckOutcome::Complete) => {}
+            Err(error) => {
+                tracing::warn!(%error, "project source-missing health check failed after reconcile");
+                return Ok(response);
+            }
+        }
+    }
+
+    if let Err(error) = persistence_db::repositories::projects::clear_source_missing_health_check(
+        pool,
+        &req.root_id,
+    )
+    .await
+    {
+        tracing::warn!(%error, "failed to clear project source-missing health retry");
+    }
 
     Ok(response)
 }

--- a/crates/app/core/tests/project_source_missing_block.rs
+++ b/crates/app/core/tests/project_source_missing_block.rs
@@ -82,14 +82,18 @@ async fn auto_block_audit_count(pool: &sqlx::SqlitePool, project_id: &str) -> i6
     count
 }
 
-// ── Test ──────────────────────────────────────────────────────────────────────
+async fn source_missing_retry_count(pool: &sqlx::SqlitePool, root_id: &str) -> i64 {
+    sqlx::query_scalar(
+        "SELECT COUNT(*) FROM operation_states
+         WHERE id = ? AND status = 'pending'",
+    )
+    .bind(format!("project-source-missing-health:{root_id}"))
+    .fetch_one(pool)
+    .await
+    .unwrap()
+}
 
-/// A `ready` project whose linked session references a frame that disappears
-/// from disk is transitioned to `blocked` with `blocked_reason_kind =
-/// 'source_missing'` by the reconcile pass, with an audit row recording it.
-/// A second reconcile writes no duplicate audit row.
-#[tokio::test]
-async fn missing_source_frame_blocks_project_via_reconcile() {
+async fn run_lifecycle_case(initial_lifecycle: &str, should_block: bool) {
     let dir = tempfile::tempdir().unwrap();
     let kept = dir.path().join("light_001.fits");
     let doomed = dir.path().join("light_002.fits");
@@ -99,21 +103,105 @@ async fn missing_source_frame_blocks_project_via_reconcile() {
     let (db, _repo, bus) = support::setup().await;
     let pool = db.pool();
 
-    let root_id = "root-sm";
-    let session_id = "sess-sm";
-    let project_id = "proj-sm";
+    let root_id = format!("root-{initial_lifecycle}");
+    let session_id = format!("sess-{initial_lifecycle}");
+    let project_id = format!("proj-{initial_lifecycle}");
+    let kept_id = format!("frame-kept-{initial_lifecycle}");
+    let doomed_id = format!("frame-doomed-{initial_lifecycle}");
 
-    insert_root(pool, root_id, dir.path().to_str().unwrap()).await;
-    insert_frame_record(pool, "frame-kept", root_id, "light_001.fits").await;
-    insert_frame_record(pool, "frame-doomed", root_id, "light_002.fits").await;
-    insert_acquisition_session(pool, session_id, &["frame-kept", "frame-doomed"]).await;
-    support::insert_project(pool, project_id, "target-sm", "setup_incomplete").await;
+    insert_root(pool, &root_id, dir.path().to_str().unwrap()).await;
+    insert_frame_record(pool, &kept_id, &root_id, "light_001.fits").await;
+    insert_frame_record(pool, &doomed_id, &root_id, "light_002.fits").await;
+    insert_acquisition_session(pool, &session_id, &[&kept_id, &doomed_id]).await;
+    support::insert_project(pool, &project_id, "target-sm", "setup_incomplete").await;
 
     app_core::projects::project_setup::add_source(
         pool,
         &bus,
         &ProjectSourceAddRequest {
-            request_id: "req-1".to_owned(),
+            request_id: format!("req-{initial_lifecycle}"),
+            project_id: project_id.clone(),
+            inventory_session_id: session_id,
+        },
+    )
+    .await
+    .expect("add_source");
+
+    let (lifecycle, _) = project_lifecycle(pool, &project_id).await;
+    assert_eq!(lifecycle, "ready", "add_source must auto-ready the project first");
+
+    sqlx::query("UPDATE projects SET lifecycle = ? WHERE id = ?")
+        .bind(initial_lifecycle)
+        .bind(&project_id)
+        .execute(pool)
+        .await
+        .expect("set lifecycle under test");
+
+    std::fs::remove_file(&doomed).unwrap();
+    let req = InventoryReconcileRunRequest { root_id, reason: ReconcileReason::OnDemand };
+    let resp = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(resp.newly_missing, 1);
+
+    let (lifecycle, reason_kind) = project_lifecycle(pool, &project_id).await;
+    let expected_lifecycle = if should_block { "blocked" } else { initial_lifecycle };
+    assert_eq!(lifecycle, expected_lifecycle, "unexpected result from {initial_lifecycle}");
+    assert_eq!(
+        reason_kind.as_deref(),
+        should_block.then_some("source_missing"),
+        "unexpected block reason from {initial_lifecycle}"
+    );
+    assert_eq!(
+        auto_block_audit_count(pool, &project_id).await,
+        i64::from(should_block),
+        "unexpected audit count from {initial_lifecycle}"
+    );
+
+    app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(
+        auto_block_audit_count(pool, &project_id).await,
+        i64::from(should_block),
+        "repeat reconcile changed the audit count from {initial_lifecycle}"
+    );
+}
+
+/// The production reconcile path follows the canonical project lifecycle
+/// matrix: the four allowed states auto-block, while terminal or already
+/// blocked states remain unchanged.
+#[tokio::test]
+async fn missing_source_frame_uses_canonical_block_transition_matrix() {
+    for lifecycle in ["setup_incomplete", "ready", "prepared", "processing"] {
+        run_lifecycle_case(lifecycle, true).await;
+    }
+    for lifecycle in ["completed", "archived", "blocked"] {
+        run_lifecycle_case(lifecycle, false).await;
+    }
+}
+
+/// A post-commit health-check failure does not turn a successful reconcile
+/// into an error, and the same root retries the check even though the frame is
+/// no longer newly missing on its next pass.
+#[tokio::test]
+async fn failed_health_check_retries_after_committed_reconcile() {
+    let dir = tempfile::tempdir().unwrap();
+    let doomed = dir.path().join("light_001.fits");
+    std::fs::write(&doomed, vec![0u8; 2048]).unwrap();
+
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+    let root_id = "root-retry";
+    let session_id = "sess-retry";
+    let project_id = "proj-retry";
+    let frame_id = "frame-retry";
+
+    insert_root(pool, root_id, dir.path().to_str().unwrap()).await;
+    insert_frame_record(pool, frame_id, root_id, "light_001.fits").await;
+    insert_acquisition_session(pool, session_id, &[frame_id]).await;
+    support::insert_project(pool, project_id, "target-retry", "setup_incomplete").await;
+    app_core::projects::project_setup::add_source(
+        pool,
+        &bus,
+        &ProjectSourceAddRequest {
+            request_id: "req-retry".to_owned(),
             project_id: project_id.to_owned(),
             inventory_session_id: session_id.to_owned(),
         },
@@ -121,32 +209,249 @@ async fn missing_source_frame_blocks_project_via_reconcile() {
     .await
     .expect("add_source");
 
-    let (lifecycle, _) = project_lifecycle(pool, project_id).await;
-    assert_eq!(lifecycle, "ready", "add_source must auto-ready the project first");
+    sqlx::query("UPDATE acquisition_session SET frame_ids = '{' WHERE id = ?")
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .expect("make health query fail");
+    std::fs::remove_file(&doomed).unwrap();
 
-    // Simulate an external delete, then run the production reconcile entry point.
+    let req = InventoryReconcileRunRequest {
+        root_id: root_id.to_owned(),
+        reason: ReconcileReason::OnDemand,
+    };
+    let first = app_core::frame_inventory::run_reconcile(pool, &bus, &req)
+        .await
+        .expect("committed reconcile must remain successful");
+    assert_eq!(first.newly_missing, 1);
+    assert_eq!(project_lifecycle(pool, project_id).await.0, "ready");
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM operation_states
+         WHERE id = 'project-source-missing-health:root-retry' AND status = 'pending'",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(pending, 1, "failed health check must leave a durable retry marker");
+
+    sqlx::query("ALTER TABLE library_root RENAME TO library_root_reconcile_error")
+        .execute(pool)
+        .await
+        .expect("make intervening reconcile fail");
+    app_core::frame_inventory::run_reconcile(pool, &bus, &req)
+        .await
+        .expect_err("intervening reconcile must fail");
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM operation_states
+         WHERE id = 'project-source-missing-health:root-retry' AND status = 'pending'",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(pending, 1, "reconcile error must preserve a pre-existing retry marker");
+    sqlx::query("ALTER TABLE library_root_reconcile_error RENAME TO library_root")
+        .execute(pool)
+        .await
+        .expect("restore library root table");
+
+    sqlx::query("UPDATE acquisition_session SET frame_ids = ? WHERE id = ?")
+        .bind(serde_json::to_string(&[frame_id]).unwrap())
+        .bind(session_id)
+        .execute(pool)
+        .await
+        .expect("repair health query input");
+
+    let retry = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(retry.newly_missing, 0, "retry precondition must be non-new missing state");
+    let (lifecycle, reason_kind) = project_lifecycle(pool, project_id).await;
+    assert_eq!(lifecycle, "blocked");
+    assert_eq!(reason_kind.as_deref(), Some("source_missing"));
+    assert_eq!(auto_block_audit_count(pool, project_id).await, 1);
+    let pending: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM operation_states
+         WHERE id = 'project-source-missing-health:root-retry'",
+    )
+    .fetch_one(pool)
+    .await
+    .unwrap();
+    assert_eq!(pending, 0, "successful retry must clear its durable marker");
+}
+
+/// The project mutation and required audit row commit atomically. A failed
+/// audit insert rolls the lifecycle update back and does not start debounce,
+/// so the durable next-run retry can still apply the transition.
+#[tokio::test]
+async fn failed_block_audit_rolls_back_and_retry_applies() {
+    let dir = tempfile::tempdir().unwrap();
+    let doomed = dir.path().join("light_001.fits");
+    std::fs::write(&doomed, vec![0u8; 2048]).unwrap();
+
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+    let root_id = "root-audit-retry";
+    let session_id = "sess-audit-retry";
+    let project_id = "proj-audit-retry";
+    let frame_id = "frame-audit-retry";
+
+    insert_root(pool, root_id, dir.path().to_str().unwrap()).await;
+    insert_frame_record(pool, frame_id, root_id, "light_001.fits").await;
+    insert_acquisition_session(pool, session_id, &[frame_id]).await;
+    support::insert_project(pool, project_id, "target-audit-retry", "setup_incomplete").await;
+    app_core::projects::project_setup::add_source(
+        pool,
+        &bus,
+        &ProjectSourceAddRequest {
+            request_id: "req-audit-retry".to_owned(),
+            project_id: project_id.to_owned(),
+            inventory_session_id: session_id.to_owned(),
+        },
+    )
+    .await
+    .expect("add_source");
+    sqlx::query("UPDATE projects SET lifecycle = 'processing' WHERE id = ?")
+        .bind(project_id)
+        .execute(pool)
+        .await
+        .unwrap();
+    sqlx::query(
+        "CREATE TRIGGER fail_project_block_audit BEFORE INSERT ON audit_log_entry
+         WHEN NEW.entity_type = 'project' AND NEW.to_state = 'blocked'
+         BEGIN SELECT RAISE(ABORT, 'forced block audit failure'); END",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
     std::fs::remove_file(&doomed).unwrap();
     let req = InventoryReconcileRunRequest {
         root_id: root_id.to_owned(),
         reason: ReconcileReason::OnDemand,
     };
-    let resp = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
-    assert_eq!(resp.newly_missing, 1);
+    let first = app_core::frame_inventory::run_reconcile(pool, &bus, &req)
+        .await
+        .expect("post-commit health failure must not fail reconcile");
+    assert_eq!(first.newly_missing, 1);
+    assert_eq!(project_lifecycle(pool, project_id).await.0, "processing");
+    assert_eq!(auto_block_audit_count(pool, project_id).await, 0);
 
-    let (lifecycle, reason_kind) = project_lifecycle(pool, project_id).await;
-    assert_eq!(lifecycle, "blocked", "FR-020: a project with a missing source must auto-block");
-    assert_eq!(reason_kind.as_deref(), Some("source_missing"));
+    sqlx::query("DROP TRIGGER fail_project_block_audit").execute(pool).await.unwrap();
+    let retry = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(retry.newly_missing, 0);
+    assert_eq!(project_lifecycle(pool, project_id).await.0, "blocked");
+    assert_eq!(auto_block_audit_count(pool, project_id).await, 1);
+}
+
+/// The mutation boundary rejects both a stale processing selection and a
+/// direct forbidden completed-to-blocked request.
+#[tokio::test]
+async fn auto_block_mutation_rejects_completed_state() {
+    let (db, _repo, _bus) = support::setup().await;
+    let pool = db.pool();
+    let project_id = "proj-completed-cas";
+    support::insert_project(pool, project_id, "target-completed-cas", "completed").await;
+
+    let stale = persistence_db::repositories::projects::apply_project_auto_block(
+        pool,
+        project_id,
+        "processing",
+        "source_missing",
+        "Source missing: sess-completed-cas",
+        "auto block: source_missing",
+    )
+    .await
+    .unwrap();
     assert_eq!(
-        auto_block_audit_count(pool, project_id).await,
-        1,
-        "FR-021: the auto-block transition must be recorded in the audit trail"
+        stale,
+        persistence_db::repositories::projects::ProjectAutoBlockOutcome::CasLost {
+            current_lifecycle: Some("completed".to_owned()),
+            still_blockable: false,
+        },
+        "completed CAS winner must not request a retry"
     );
 
-    // A repeat reconcile inside the debounce window writes no second audit row.
-    app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    let direct = persistence_db::repositories::projects::apply_project_auto_block(
+        pool,
+        project_id,
+        "completed",
+        "source_missing",
+        "Source missing: sess-completed-cas",
+        "auto block: source_missing",
+    )
+    .await
+    .unwrap();
+    assert_eq!(direct, persistence_db::repositories::projects::ProjectAutoBlockOutcome::Rejected);
+
+    assert_eq!(project_lifecycle(pool, project_id).await.0, "completed");
+    assert_eq!(auto_block_audit_count(pool, project_id).await, 0);
+}
+
+async fn run_production_allowed_cas_loss_case() {
+    let dir = tempfile::tempdir().unwrap();
+    let doomed = dir.path().join("light_001.fits");
+    std::fs::write(&doomed, vec![0u8; 2048]).unwrap();
+
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+    let root_id = "root-cas-race";
+    let session_id = "sess-cas-race";
+    let project_id = "proj-cas-race";
+    let frame_id = "frame-cas-race";
+
+    insert_root(pool, root_id, dir.path().to_str().unwrap()).await;
+    insert_frame_record(pool, frame_id, root_id, "light_001.fits").await;
+    insert_acquisition_session(pool, session_id, &[frame_id]).await;
+    support::insert_project(pool, project_id, "target-cas", "setup_incomplete").await;
+    app_core::projects::project_setup::add_source(
+        pool,
+        &bus,
+        &ProjectSourceAddRequest {
+            request_id: "req-cas-race".to_owned(),
+            project_id: project_id.to_owned(),
+            inventory_session_id: session_id.to_owned(),
+        },
+    )
+    .await
+    .expect("add_source");
+
+    sqlx::query(
+        "CREATE TRIGGER force_auto_block_cas_loss
+         BEFORE UPDATE OF lifecycle ON projects
+         WHEN OLD.id = 'proj-cas-race' AND OLD.lifecycle = 'ready' AND NEW.lifecycle = 'blocked'
+         BEGIN
+           UPDATE projects SET lifecycle = 'prepared' WHERE id = OLD.id;
+           SELECT RAISE(IGNORE);
+         END",
+    )
+    .execute(pool)
+    .await
+    .unwrap();
+
+    std::fs::remove_file(&doomed).unwrap();
+    let req = InventoryReconcileRunRequest {
+        root_id: root_id.to_owned(),
+        reason: ReconcileReason::OnDemand,
+    };
+    let first = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(first.newly_missing, 1);
+    assert_eq!(project_lifecycle(pool, project_id).await.0, "prepared");
+    assert_eq!(auto_block_audit_count(pool, project_id).await, 0);
     assert_eq!(
-        auto_block_audit_count(pool, project_id).await,
+        source_missing_retry_count(pool, root_id).await,
         1,
-        "a repeat reconcile must not append a duplicate auto-transition audit row"
+        "blockable CAS winner must preserve the retry marker"
     );
+
+    sqlx::query("DROP TRIGGER force_auto_block_cas_loss").execute(pool).await.unwrap();
+    let second = app_core::frame_inventory::run_reconcile(pool, &bus, &req).await.unwrap();
+    assert_eq!(second.newly_missing, 0);
+    assert_eq!(project_lifecycle(pool, project_id).await.0, "blocked");
+    assert_eq!(auto_block_audit_count(pool, project_id).await, 1);
+    assert_eq!(source_missing_retry_count(pool, root_id).await, 0);
+}
+
+/// Losing `ready` to another blockable state preserves the durable retry, so
+/// the next zero-newly-missing reconcile can apply the automatic block.
+#[tokio::test]
+async fn allowed_to_allowed_cas_loss_retries_on_production_path() {
+    run_production_allowed_cas_loss_case().await;
 }

--- a/crates/app/projects/src/project_health.rs
+++ b/crates/app/projects/src/project_health.rs
@@ -189,6 +189,20 @@ pub struct BlockTransitionRecord {
     pub condition: BlockCondition,
 }
 
+enum BlockTransitionOutcome {
+    Applied(BlockTransitionRecord),
+    Noop,
+    RetryableCasLoss,
+}
+
+/// Whether a source-missing invariant pass completed or must be retried after
+/// losing a lifecycle compare-and-swap to another blockable state.
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum SourceMissingCheckOutcome {
+    Complete,
+    RetryRequired,
+}
+
 /// Check the `source_missing` block invariant (US4, FR-020) across every
 /// project whose linked acquisition sessions reference a `missing` frame
 /// record, and apply the `* → blocked` transition to each.
@@ -208,20 +222,25 @@ pub async fn check_project_source_missing_invariant(
     pool: &SqlitePool,
     bus: &EventBus,
     debounce: &DebounceCache<DebounceKey>,
-) -> Result<Vec<BlockTransitionRecord>, HealthError> {
+) -> Result<SourceMissingCheckOutcome, HealthError> {
     let pairs =
         repo::find_blockable_missing_sources(pool).await.map_err(HealthError::Persistence)?;
 
-    let mut applied = Vec::new();
+    let mut retry_required = false;
     for (project_id, inventory_id) in pairs {
         let condition = BlockCondition::SourceMissing { inventory_id };
-        if let Some(record) =
-            emit_block_transition(pool, bus, debounce, &project_id, &condition).await?
-        {
-            applied.push(record);
+        if matches!(
+            emit_block_transition_outcome(pool, bus, debounce, &project_id, &condition).await?,
+            BlockTransitionOutcome::RetryableCasLoss
+        ) {
+            retry_required = true;
         }
     }
-    Ok(applied)
+    Ok(if retry_required {
+        SourceMissingCheckOutcome::RetryRequired
+    } else {
+        SourceMissingCheckOutcome::Complete
+    })
 }
 
 /// Emit a system-driven `* → blocked` transition for the given project.
@@ -245,46 +264,55 @@ pub async fn emit_block_transition(
     project_id: &str,
     condition: &BlockCondition,
 ) -> Result<Option<BlockTransitionRecord>, HealthError> {
+    Ok(match emit_block_transition_outcome(pool, bus, debounce, project_id, condition).await? {
+        BlockTransitionOutcome::Applied(record) => Some(record),
+        BlockTransitionOutcome::Noop | BlockTransitionOutcome::RetryableCasLoss => None,
+    })
+}
+
+async fn emit_block_transition_outcome(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    debounce: &DebounceCache<DebounceKey>,
+    project_id: &str,
+    condition: &BlockCondition,
+) -> Result<BlockTransitionOutcome, HealthError> {
     let condition_kind = condition.kind_str();
 
-    // Debounce check (P7). `DebounceCache` is `Clone`/`&self` (moka handle is
-    // internally `Arc`-backed), so no external `Arc<Mutex<_>>` is needed.
-    if debounce.should_suppress(&DebounceKey::new(project_id, condition_kind)) {
-        return Ok(None);
+    let debounce_key = DebounceKey::new(project_id, condition_kind);
+    if debounce.is_suppressed(&debounce_key) {
+        return Ok(BlockTransitionOutcome::Noop);
     }
 
     let row = repo::get_project(pool, project_id)
         .await
         .map_err(|e| HealthError::NotFound(format!("project {project_id}: {e}")))?;
 
-    // Already blocked → nothing to do.
-    if row.lifecycle == "blocked" {
-        return Ok(None);
-    }
-
     let from_state = row.lifecycle.clone();
     let message = condition.message();
+    let trigger = format!("auto block: {condition_kind} — {message}");
 
-    // FR-020: persist typed blocked reason alongside the lifecycle transition.
-    repo::update_project_lifecycle_blocked(
-        pool,
-        project_id,
-        condition_kind,
-        Some(message.as_str()),
-    )
-    .await
-    .map_err(HealthError::Persistence)?;
-
-    // FR-021: write an audit row for this auto block transition.
-    write_auto_transition_audit(
+    let outcome = repo::apply_project_auto_block(
         pool,
         project_id,
         &from_state,
-        "blocked",
-        &format!("auto block: {condition_kind} — {message}"),
+        condition_kind,
+        &message,
+        &trigger,
     )
     .await
     .map_err(HealthError::Persistence)?;
+    match outcome {
+        repo::ProjectAutoBlockOutcome::Applied => {}
+        repo::ProjectAutoBlockOutcome::CasLost { still_blockable: true, .. } => {
+            return Ok(BlockTransitionOutcome::RetryableCasLoss);
+        }
+        repo::ProjectAutoBlockOutcome::Rejected
+        | repo::ProjectAutoBlockOutcome::CasLost { still_blockable: false, .. } => {
+            return Ok(BlockTransitionOutcome::Noop);
+        }
+    }
+    debounce.record(&debounce_key);
 
     let now = domain_core::ids::Timestamp::now_utc();
 
@@ -317,7 +345,7 @@ pub async fn emit_block_transition(
         )
         .await;
 
-    Ok(Some(BlockTransitionRecord {
+    Ok(BlockTransitionOutcome::Applied(BlockTransitionRecord {
         project_id: project_id.to_owned(),
         from_state,
         condition: condition.clone(),

--- a/crates/persistence/db/src/repositories/audit.rs
+++ b/crates/persistence/db/src/repositories/audit.rs
@@ -22,7 +22,7 @@
 use std::fmt::Write as _;
 
 use audit_types::AuditLogEntry;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::DbResult;
 
@@ -213,6 +213,17 @@ pub async fn insert_project_auto_transition(
     to_state: &str,
     trigger: &str,
 ) -> DbResult<()> {
+    let mut conn = pool.acquire().await?;
+    insert_project_auto_transition_conn(&mut conn, project_id, from_state, to_state, trigger).await
+}
+
+pub(crate) async fn insert_project_auto_transition_conn(
+    conn: &mut SqliteConnection,
+    project_id: &str,
+    from_state: &str,
+    to_state: &str,
+    trigger: &str,
+) -> DbResult<()> {
     use time::format_description::well_known::Rfc3339;
     use uuid::Uuid;
 
@@ -235,7 +246,7 @@ pub async fn insert_project_auto_transition(
     .bind(trigger)
     .bind(&request_id)
     .bind(&at)
-    .execute(pool)
+    .execute(conn)
     .await?;
 
     Ok(())

--- a/crates/persistence/db/src/repositories/projects/crud.rs
+++ b/crates/persistence/db/src/repositories/projects/crud.rs
@@ -4,6 +4,7 @@
 //! `projects` table CRUD.
 
 use domain_core::ids::Timestamp;
+use domain_core::lifecycle::project::{is_allowed, ProjectState};
 use sqlx::{SqliteConnection, SqlitePool};
 
 use crate::{DbError, DbResult};
@@ -416,33 +417,102 @@ pub async fn update_project_lifecycle(
     Ok(now)
 }
 
-/// Update a project's lifecycle to "blocked" and persist the typed blocked reason.
+fn project_state(value: &str) -> Option<ProjectState> {
+    match value {
+        "setup_incomplete" => Some(ProjectState::SetupIncomplete),
+        "ready" => Some(ProjectState::Ready),
+        "prepared" => Some(ProjectState::Prepared),
+        "processing" => Some(ProjectState::Processing),
+        "completed" => Some(ProjectState::Completed),
+        "archived" => Some(ProjectState::Archived),
+        "blocked" => Some(ProjectState::Blocked),
+        _ => None,
+    }
+}
+
+/// Result of a canonical automatic project-block mutation.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum ProjectAutoBlockOutcome {
+    /// The lifecycle change and audit row committed atomically.
+    Applied,
+    /// The requested edge is not canonical for the expected lifecycle.
+    Rejected,
+    /// The selected lifecycle changed before the compare-and-swap.
+    CasLost {
+        /// Lifecycle observed after losing the compare-and-swap, if the row
+        /// still exists.
+        current_lifecycle: Option<String>,
+        /// Whether the observed lifecycle still has a canonical edge to
+        /// `blocked` and therefore needs a durable retry.
+        still_blockable: bool,
+    },
+}
+
+/// Atomically apply a canonical project auto-block transition and its required
+/// audit row when the lifecycle still matches `expected_from_state`.
 ///
-/// FR-020 / T053: stores `blocked_reason_kind` and `blocked_reason_note` so the
-/// `BlockedBanner` DTO can surface the real reason instead of a hardcoded value.
+/// Returns [`ProjectAutoBlockOutcome::Rejected`] when the edge is forbidden,
+/// or [`ProjectAutoBlockOutcome::CasLost`] when the compare-and-swap loses a
+/// concurrent lifecycle change.
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
-pub async fn update_project_lifecycle_blocked(
+/// Returns [`DbError::Database`] on update, audit, or transaction failure.
+pub async fn apply_project_auto_block(
     pool: &SqlitePool,
     id: &str,
+    expected_from_state: &str,
     reason_kind: &str,
-    reason_note: Option<&str>,
-) -> DbResult<String> {
+    reason_note: &str,
+    trigger: &str,
+) -> DbResult<ProjectAutoBlockOutcome> {
+    let Some(from_state) = project_state(expected_from_state) else {
+        return Ok(ProjectAutoBlockOutcome::Rejected);
+    };
+    if !is_allowed(from_state, ProjectState::Blocked) {
+        return Ok(ProjectAutoBlockOutcome::Rejected);
+    }
+
     let now = Timestamp::now_iso();
-    sqlx::query(
-        "UPDATE projects SET lifecycle = 'blocked', \
-         blocked_reason_kind = ?, blocked_reason_note = ?, updated_at = ? \
-         WHERE id = ?",
+    let mut tx = pool.begin().await?;
+    let rows_affected = sqlx::query(
+        "UPDATE projects SET lifecycle = 'blocked', blocked_reason_kind = ?,
+         blocked_reason_note = ?, updated_at = ?
+         WHERE id = ? AND lifecycle = ?",
     )
     .bind(reason_kind)
     .bind(reason_note)
     .bind(&now)
     .bind(id)
-    .execute(pool)
+    .bind(expected_from_state)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    if rows_affected == 0 {
+        let current_lifecycle =
+            sqlx::query_scalar::<_, String>("SELECT lifecycle FROM projects WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&mut *tx)
+                .await?;
+        let still_blockable = current_lifecycle
+            .as_deref()
+            .and_then(project_state)
+            .is_some_and(|state| is_allowed(state, ProjectState::Blocked));
+        tx.commit().await?;
+        return Ok(ProjectAutoBlockOutcome::CasLost { current_lifecycle, still_blockable });
+    }
+
+    crate::repositories::audit::insert_project_auto_transition_conn(
+        &mut tx,
+        id,
+        expected_from_state,
+        "blocked",
+        trigger,
+    )
     .await?;
-    Ok(now)
+    tx.commit().await?;
+    Ok(ProjectAutoBlockOutcome::Applied)
 }
 
 /// Update a project's lifecycle state and clear the blocked reason columns.

--- a/crates/persistence/db/src/repositories/projects/mod.rs
+++ b/crates/persistence/db/src/repositories/projects/mod.rs
@@ -122,15 +122,15 @@ mod tests;
 pub use channels::{list_project_channels, replace_project_channels};
 pub use create_tx::{create_project_tx, CreateProjectInput};
 pub use crud::{
-    clear_archived_via_plan_id, get_project, get_project_canonical_target,
-    get_project_canonical_target_id, insert_project, list_archived_projects, list_projects,
-    list_projects_by_canonical_target_id, name_exists, path_exists, set_archived_via_plan_id,
-    set_channel_drift, set_project_canonical_target_id, update_project_fields,
-    update_project_lifecycle, update_project_lifecycle_blocked, update_project_lifecycle_unblock,
-    ArchivedProjectRow, ProjectCanonicalTargetRow,
+    apply_project_auto_block, clear_archived_via_plan_id, get_project,
+    get_project_canonical_target, get_project_canonical_target_id, insert_project,
+    list_archived_projects, list_projects, list_projects_by_canonical_target_id, name_exists,
+    path_exists, set_archived_via_plan_id, set_channel_drift, set_project_canonical_target_id,
+    update_project_fields, update_project_lifecycle, update_project_lifecycle_unblock,
+    ArchivedProjectRow, ProjectAutoBlockOutcome, ProjectCanonicalTargetRow,
 };
 pub use sources::{
-    delete_project_source, find_blockable_missing_sources, get_project_source,
-    has_archived_raw_frames_for_project, insert_project_source, list_project_ids_for_session,
-    list_project_sources,
+    begin_source_missing_health_check, clear_source_missing_health_check, delete_project_source,
+    find_blockable_missing_sources, get_project_source, has_archived_raw_frames_for_project,
+    insert_project_source, list_project_ids_for_session, list_project_sources,
 };

--- a/crates/persistence/db/src/repositories/projects/sources.rs
+++ b/crates/persistence/db/src/repositories/projects/sources.rs
@@ -9,6 +9,12 @@ use crate::{DbError, DbResult};
 
 use super::{InsertProjectSource, ProjectSourceRow};
 
+const SOURCE_MISSING_HEALTH_OPERATION: &str = "project-source-missing-health";
+
+fn source_missing_health_operation_id(root_id: &str) -> String {
+    format!("{SOURCE_MISSING_HEALTH_OPERATION}:{root_id}")
+}
+
 /// List the ids of every project linked (via `project_sources`) to a given
 /// `inventory_session_id` (an `acquisition_session.id`).
 ///
@@ -35,9 +41,8 @@ pub async fn list_project_ids_for_session(
 /// session currently lists a frame whose `file_record.state = 'missing'`, and
 /// the project is still in a lifecycle a system block may move it out of.
 ///
-/// `archived` is excluded as well as `blocked`: `emit_block_transition` only
-/// guards `blocked`, so without this filter an archived project would be
-/// dragged back to `blocked` by a reconcile pass.
+/// The explicit lifecycle list mirrors the canonical `ProjectState -> Blocked`
+/// edges. In particular, `completed` remains terminal for automatic blocking.
 ///
 /// # Errors
 ///
@@ -51,12 +56,48 @@ pub async fn find_blockable_missing_sources(pool: &SqlitePool) -> DbResult<Vec<(
          JOIN json_each(s.frame_ids) je
          JOIN file_record fr ON fr.id = je.value
          WHERE fr.state = 'missing'
-           AND p.lifecycle IN ('ready', 'setup_incomplete')
+           AND p.lifecycle IN ('setup_incomplete', 'ready', 'prepared', 'processing')
          ORDER BY ps.project_id, ps.inventory_session_id",
     )
     .fetch_all(pool)
     .await?;
     Ok(rows)
+}
+
+/// Mark a root's source-missing health check as pending before reconciliation.
+///
+/// Returns `true` when a marker already existed from an interrupted or failed
+/// prior run. The marker uses the existing resumable `operation_states` table.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn begin_source_missing_health_check(pool: &SqlitePool, root_id: &str) -> DbResult<bool> {
+    let result = sqlx::query(
+        "INSERT INTO operation_states (id, operation_type, status, updated_at)
+         VALUES (?, ?, 'pending', datetime('now'))
+         ON CONFLICT(id) DO NOTHING",
+    )
+    .bind(source_missing_health_operation_id(root_id))
+    .bind(SOURCE_MISSING_HEALTH_OPERATION)
+    .execute(pool)
+    .await?;
+    Ok(result.rows_affected() == 0)
+}
+
+/// Clear a root's pending source-missing health check after success or a
+/// reconcile that produced no newly missing frames.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn clear_source_missing_health_check(pool: &SqlitePool, root_id: &str) -> DbResult<()> {
+    sqlx::query("DELETE FROM operation_states WHERE id = ? AND operation_type = ?")
+        .bind(source_missing_health_operation_id(root_id))
+        .bind(SOURCE_MISSING_HEALTH_OPERATION)
+        .execute(pool)
+        .await?;
+    Ok(())
 }
 
 /// Whether any of this project's linked sessions has had a raw-frame archived


### PR DESCRIPTION
## What changed

- Source-missing reconciliation auto-blocks projects in `setup_incomplete`, `ready`, `prepared`, or `processing`.
- Projects in `completed`, `archived`, or `blocked` remain unchanged.
- The lifecycle compare-and-swap and required audit insert now commit in one transaction after canonical transition validation.
- A lost lifecycle compare-and-swap reports the winning state distinctly: another blockable state retains the durable retry, while terminal `completed` does not.
- The missing-source scan runs after a newly missing frame or a durable failed-scan marker for the same root.
- A pre-existing retry marker survives an intervening reconcile error.
- A post-commit health-check failure emits a warning and preserves the successful reconcile response.
- Failed transition persistence no longer starts the emitter debounce window, so the durable retry can apply the transition later.
- The obsolete non-transactional blocked-lifecycle writer was removed after the atomic mutation replaced its final production caller.
- Production-path regressions cover the lifecycle matrix, blockable-state CAS loss, stale/forbidden completed-state mutation attempts, atomic audit rollback, and zero-newly-missing retries.

## Why

PR #1415 connected `inventory.reconcile.run` to source-missing project health checks, but limited transitions to `ready` and `setup_incomplete`. The residual fix must include every canonical automatic block transition without allowing `completed` to move to `blocked`.

The health check runs after reconcile writes commit. Reporting its failure as a reconcile error misrepresents the committed frame state, while skipping every later check prevents retry.

The transition must also remain safe when project state changes after selection. Enforcing the canonical edge with a compare-and-swap prevents a concurrent `processing` to `completed` transition from being overwritten, while coupling the audit insert to the same transaction prevents partially recorded lifecycle changes.

## Test plan

- `cargo test -p app_core --test project_source_missing_block --target-dir /tmp/astro-plan-2dhk-target`
- `cargo test -p app_core_projects project_health --target-dir /tmp/astro-plan-2dhk-target`
- `cargo test -p app_core_cache --target-dir /tmp/astro-plan-2dhk-target`
- `cargo clippy -p app_core -p app_core_projects -p app_core_cache -p persistence_db --all-targets -- -D warnings`
- `scripts/check-dead-callers.sh`
- `cargo fmt --all -- --check`
- `git diff --check`
- `rg -n "emit_block_transition" crates/app/core/tests/project_source_missing_block.rs` returns no matches.

Refs astro-plan-2dhk
