### PR TITLE
chore(deps): update biome to 2.5.5

### DIFF
--- a/apps/desktop/biome.json
+++ b/apps/desktop/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": [
       "src/**/*.ts",

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -74,7 +74,7 @@
     "zod": "4.4.3"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.3",
+    "@biomejs/biome": "2.5.5",
     "@fontsource/space-grotesk": "^5.3.0",
     "@playwright/test": "^1.61.1",
     "@size-limit/file": "^12.1.0",

--- a/apps/desktop/src/components/DetailPanel.shared-guard.test.ts
+++ b/apps/desktop/src/components/DetailPanel.shared-guard.test.ts
@@ -38,11 +38,12 @@ const MIGRATED_DETAIL_FILES = [
 ];
 
 describe('shared DetailPanel guard (spec 054 T012a)', () => {
-  it.each(
-    MIGRATED_DETAIL_FILES,
-  )('%s renders through DetailPanel, not a raw DetailHeader', (relPath) => {
-    const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
-    expect(source).toMatch(/<DetailPanel\b/);
-    expect(source).not.toMatch(/<DetailHeader\b/);
-  });
+  it.each(MIGRATED_DETAIL_FILES)(
+    '%s renders through DetailPanel, not a raw DetailHeader',
+    (relPath) => {
+      const source = readFileSync(resolve(process.cwd(), relPath), 'utf8');
+      expect(source).toMatch(/<DetailPanel\b/);
+      expect(source).not.toMatch(/<DetailHeader\b/);
+    },
+  );
 });

--- a/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
+++ b/apps/desktop/src/features/plans/PlanReviewOverlay.test.tsx
@@ -811,19 +811,22 @@ describe('PlanReviewOverlay (spec 017 WP-E)', () => {
     ['failed', 'Generate retry plan'],
     ['partially_applied', 'Generate retry plan'],
     ['cancelled', 'Generate retry plan'],
-  ] as const)('renders the persisted %s plan.state footer on reopen, without a session apply (issue #733)', async (state, expectedAction) => {
-    mockPlansGet.mockResolvedValue(ok(plan({ state })));
-    renderOverlay();
+  ] as const)(
+    'renders the persisted %s plan.state footer on reopen, without a session apply (issue #733)',
+    async (state, expectedAction) => {
+      mockPlansGet.mockResolvedValue(ok(plan({ state })));
+      renderOverlay();
 
-    await screen.findByText('light_001.xisf');
-    expect(screen.getByText(expectedAction)).toBeInTheDocument();
-    expect(
-      screen.queryByTestId('plan-review-approve-apply'),
-    ).not.toBeInTheDocument();
-    if (expectedAction !== 'Close') {
-      expect(screen.getByText('Close')).toBeInTheDocument();
-    }
-  });
+      await screen.findByText('light_001.xisf');
+      expect(screen.getByText(expectedAction)).toBeInTheDocument();
+      expect(
+        screen.queryByTestId('plan-review-approve-apply'),
+      ).not.toBeInTheDocument();
+      if (expectedAction !== 'Close') {
+        expect(screen.getByText('Close')).toBeInTheDocument();
+      }
+    },
+  );
 
   // #876: a destination free-space estimate, surfaced at review time before
   // approval, rather than only discovering insufficient space after apply.

--- a/apps/desktop/src/features/settings/Ingestion.test.tsx
+++ b/apps/desktop/src/features/settings/Ingestion.test.tsx
@@ -107,20 +107,19 @@ describe('Ingestion', () => {
 
   // Issue #878: only followSymlinks has a pipeline consumer. The other three
   // controls must not present themselves as working settings.
-  it.each([
-    ['Scan on startup'],
-    ['Follow NTFS junctions'],
-    ['Hashing mode'],
-  ])('%s is disabled because no pipeline reads it', async (label) => {
-    render(<Ingestion save={vi.fn()} />);
+  it.each([['Scan on startup'], ['Follow NTFS junctions'], ['Hashing mode']])(
+    '%s is disabled because no pipeline reads it',
+    async (label) => {
+      render(<Ingestion save={vi.fn()} />);
 
-    await screen.findByRole('checkbox', {
-      name: 'Follow symbolic links',
-      checked: true,
-    });
+      await screen.findByRole('checkbox', {
+        name: 'Follow symbolic links',
+        checked: true,
+      });
 
-    expect(screen.getByLabelText(label)).toBeDisabled();
-  });
+      expect(screen.getByLabelText(label)).toBeDisabled();
+    },
+  );
 
   it('a slow initial fetch does not clobber an edit made before it resolves', async () => {
     // Reproduces a real race, not just CI flakiness: the mount-time

--- a/apps/desktop/src/lib/no-user-string.rule.test.ts
+++ b/apps/desktop/src/lib/no-user-string.rule.test.ts
@@ -677,15 +677,15 @@ describe('alm/no-user-string', () => {
     );
   });
 
-  it.each([
-    'confirm',
-    'prompt',
-  ])('flags a string passed to window.%s', (api) => {
-    const out = lint(`window.${api}('Delete these files permanently?');`);
-    const hits = out.filter((m) => m.ruleId === 'alm/no-user-string');
-    expect(hits).toHaveLength(1);
-    expect(hits[0].messageId).toBe('toast');
-  });
+  it.each(['confirm', 'prompt'])(
+    'flags a string passed to window.%s',
+    (api) => {
+      const out = lint(`window.${api}('Delete these files permanently?');`);
+      const hits = out.filter((m) => m.ruleId === 'alm/no-user-string');
+      expect(hits).toHaveLength(1);
+      expect(hits[0].messageId).toBe('toast');
+    },
+  );
 
   // Unlike every other sink, the dialog APIs do NOT apply the machine-string
   // gate: a confirm()/prompt() argument is shown verbatim to the user, so any

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.5.3/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.5.5/schema.json",
   "files": {
     "includes": ["tests/**/*.ts", "!**/node_modules/**"]
   },

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "lint:tests": "biome check tests"
   },
   "devDependencies": {
-    "@biomejs/biome": "2.5.3",
+    "@biomejs/biome": "2.5.5",
     "typescript": "^5.9.3"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.5.3
-        version: 2.5.3
+        specifier: 2.5.5
+        version: 2.5.5
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
@@ -121,8 +121,8 @@ importers:
         version: 4.4.3
     devDependencies:
       '@biomejs/biome':
-        specifier: 2.5.3
-        version: 2.5.3
+        specifier: 2.5.5
+        version: 2.5.5
       '@fontsource/space-grotesk':
         specifier: ^5.3.0
         version: 5.3.0
@@ -377,59 +377,59 @@ packages:
       '@types/react':
         optional: true
 
-  '@biomejs/biome@2.5.3':
-    resolution: {integrity: sha512-MrJswFdei9EfDwwUy2tQrPDpK0AO+RmMFvBoaaJ6ayBc3sUbHdCE+XG5N8vp+5So41ZupZJQm0roHFFhMGVD7A==}
+  '@biomejs/biome@2.5.5':
+    resolution: {integrity: sha512-r1S8nFsAG1MY+vJFZALzIvwXAJv6ejDQ0mxP21Tgr9YK3ZFtjrvbBwDdNhx1rUqvccEIeNg20cYCNzl6Cr69pQ==}
     engines: {node: '>=14.21.3'}
     hasBin: true
 
-  '@biomejs/cli-darwin-arm64@2.5.3':
-    resolution: {integrity: sha512-QhYP9muVQ0nUO5zztFuPbEwi4+94sJWVjaZds9aMi1l/KNZBiUjdiSUrGHsTaMGDXrYl+r4AS2sUKfgH3w+V3g==}
+  '@biomejs/cli-darwin-arm64@2.5.5':
+    resolution: {integrity: sha512-kUrAhXVWUrwmAUnV2iXSK7umxKFysTwvqK+Ty6ptUcLY/7T3SnCAjUowE4uvwaEej6nXZ7hu/dTtbokKdsPeag==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
 
-  '@biomejs/cli-darwin-x64@2.5.3':
-    resolution: {integrity: sha512-NC1Ss13UaW7QZX+y8j44bF7AP0jSJdBl6iRhe0MAkvaSqZy+mWg3GaXsrb+eSoHoGDBtaXWEbMVV0iVN2cZ7cQ==}
+  '@biomejs/cli-darwin-x64@2.5.5':
+    resolution: {integrity: sha512-DamiYc5bUYZ2uxlfc+RLEPtz1Abb6PO5eTbOkufLpSGwd/7AMQAdxhFYiXmwwkJL8IsT8S7GvdgwDHqaMFAvKw==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [darwin]
 
-  '@biomejs/cli-linux-arm64-musl@2.5.3':
-    resolution: {integrity: sha512-fccix0w6xp6csCXgxeC0dU/3ecgRQal0y+cv2SP9ajNlhe7Yrk2Ug7UDe2j9AT9ZDYitkXpvUKgZjjuoYeP4Vg==}
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
+    resolution: {integrity: sha512-U4WMl/sy/E/Q73vf15VspakLRRs2LDFcCeBxJnQfXzssb88zpV6PJPaQ3ezhQ7H6Ht2/8bvuZeHgJWzmoxllZg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-arm64@2.5.3':
-    resolution: {integrity: sha512-ksx1KWeyYW18ILL04msF/J4ZBtBDN33znYK8Z/aNv/vlBVxL9/g3mGP+omgHJKy4+KWbK87vcmmpmurfNjSgiA==}
+  '@biomejs/cli-linux-arm64@2.5.5':
+    resolution: {integrity: sha512-lRKF/pH/1RiYiBKExi3TCZVAtvzEm77aifrvcNiDFrR9WxeAnDUjDnseb6y2XV85mjitLs6SILGm2XG77cHtSQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-linux-x64-musl@2.5.3':
-    resolution: {integrity: sha512-O/yU9YKRUiHhmcjF2f38PSjseVk3G4VLWYc0G2HWpzdBVREV6G8IGWIVEFf7MFPfWIzNUIvPsEjeAZQIOgnLcQ==}
+  '@biomejs/cli-linux-x64-musl@2.5.5':
+    resolution: {integrity: sha512-m7wC7tjX5Lrmo69dc4md8FeKpPU1NTCY1v7xUoQQ2vadWwNnBS0KZOG8471otFPHrTHihQJAjQPgMObpLvDe6A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@biomejs/cli-linux-x64@2.5.3':
-    resolution: {integrity: sha512-yMkJtilsgvILDcVkh187aVLTb64xYsrxYajx5kym+r1ULkO5HUOfu9AYKLGQbOVLwJtT2utNw7hhFNg+17mUYA==}
+  '@biomejs/cli-linux-x64@2.5.5':
+    resolution: {integrity: sha512-H/O39nJEw/2Zm/fm7hrmxxoF8kK/aU1uCoPp70ruXVbomaAdLpJJnCmL11Q2JotT8QVHH06So04Oq53lCSwSwQ==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@biomejs/cli-win32-arm64@2.5.3':
-    resolution: {integrity: sha512-cX5z+GYwRcqEok0AH3KSfQGgqYd0Nomfp6Fbe1uiTtELE38hdH2k842wQ9wLNaF/JJ7r4rjJQ4VR+ce+fRmQbw==}
+  '@biomejs/cli-win32-arm64@2.5.5':
+    resolution: {integrity: sha512-7BryINPuYypLUAH3o/o5ZdgomJ4zn3EDR0ChZJst7n32S6ZhKbgHXuYydLu+YAnx59ehGFR0z/MG6qnzQi3Yyw==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
-  '@biomejs/cli-win32-x64@2.5.3':
-    resolution: {integrity: sha512-ExSaJWi4/u6+GXCszlSKpWSjKNbDseAYqqkCznsCsZ/4uidZ/BEqsCc5/3ctlq6dfIubdIIRSVLC/PG9xPl70Q==}
+  '@biomejs/cli-win32-x64@2.5.5':
+    resolution: {integrity: sha512-bIBFo+n6MIxdNcVFy5CrurbKiZQiUciK3bt8+O9I4wjFZNTfXLpi+giq47522eXqW5NBc9ulx7dR1SlZKi2J5g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -4719,39 +4719,39 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
 
-  '@biomejs/biome@2.5.3':
+  '@biomejs/biome@2.5.5':
     optionalDependencies:
-      '@biomejs/cli-darwin-arm64': 2.5.3
-      '@biomejs/cli-darwin-x64': 2.5.3
-      '@biomejs/cli-linux-arm64': 2.5.3
-      '@biomejs/cli-linux-arm64-musl': 2.5.3
-      '@biomejs/cli-linux-x64': 2.5.3
-      '@biomejs/cli-linux-x64-musl': 2.5.3
-      '@biomejs/cli-win32-arm64': 2.5.3
-      '@biomejs/cli-win32-x64': 2.5.3
+      '@biomejs/cli-darwin-arm64': 2.5.5
+      '@biomejs/cli-darwin-x64': 2.5.5
+      '@biomejs/cli-linux-arm64': 2.5.5
+      '@biomejs/cli-linux-arm64-musl': 2.5.5
+      '@biomejs/cli-linux-x64': 2.5.5
+      '@biomejs/cli-linux-x64-musl': 2.5.5
+      '@biomejs/cli-win32-arm64': 2.5.5
+      '@biomejs/cli-win32-x64': 2.5.5
 
-  '@biomejs/cli-darwin-arm64@2.5.3':
+  '@biomejs/cli-darwin-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-darwin-x64@2.5.3':
+  '@biomejs/cli-darwin-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64-musl@2.5.3':
+  '@biomejs/cli-linux-arm64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-arm64@2.5.3':
+  '@biomejs/cli-linux-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64-musl@2.5.3':
+  '@biomejs/cli-linux-x64-musl@2.5.5':
     optional: true
 
-  '@biomejs/cli-linux-x64@2.5.3':
+  '@biomejs/cli-linux-x64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-arm64@2.5.3':
+  '@biomejs/cli-win32-arm64@2.5.5':
     optional: true
 
-  '@biomejs/cli-win32-x64@2.5.3':
+  '@biomejs/cli-win32-x64@2.5.5':
     optional: true
 
   '@bramus/specificity@2.4.2':


### PR DESCRIPTION
## Summary

- Bumps `@biomejs/biome` 2.5.3 → 2.5.5 (root and `apps/desktop`).
- Updates both `biome.json` schema URLs to the 2.5.5 schema.
- Applies four deterministic formatter reformats: `it.each` call-style (no behavioural change) in `DetailPanel.shared-guard.test.ts`, `PlanReviewOverlay.test.tsx`, `Ingestion.test.tsx`, and `no-user-string.rule.test.ts`.

## Beads

Tracks-Bead: astro-plan-amf7.1
Tracks-Bead: astro-plan-ylmg
Merge-Bead: astro-plan-dxp3