### PR TITLE
fix: vitest suite fails on Node 25 due to incomplete localStorage global

### DIFF
--- a/apps/desktop/vitest.setup.ts
+++ b/apps/desktop/vitest.setup.ts
@@ -8,13 +8,15 @@
  */
 import "@testing-library/jest-dom/vitest";
 
-// Node 22+ exposes an experimental `localStorage` global that is `undefined`
-// unless --localstorage-file is passed.  This shadows the Storage
-// implementation that jsdom injects on `window`, causing
-// `window.localStorage` to resolve to `undefined` in vitest's jsdom
-// environment.  Fix: if the global is broken, replace it with a minimal
-// in-memory Storage so component code that reads/writes localStorage works.
-if (typeof window !== "undefined" && typeof window.localStorage === "undefined") {
+// Node 22+ may shadow jsdom's Storage with an incomplete experimental global.
+// Replace it unless it provides the interface the tests exercise.
+if (
+  typeof window !== "undefined" &&
+  (typeof window.localStorage?.getItem !== "function" ||
+    typeof window.localStorage?.setItem !== "function" ||
+    typeof window.localStorage?.removeItem !== "function" ||
+    typeof window.localStorage?.clear !== "function")
+) {
   const store = new Map<string, string>();
   const storage: Storage = {
     get length() {


### PR DESCRIPTION
## Summary

- Node 25 exposes a truthy but non-functional experimental `localStorage` global that shadowed jsdom's Storage, causing 155 test failures with `clear is not a function` / `removeItem is not a function`.
- Replaces the `=== 'undefined'` guard with a capability probe (checks all four Storage methods are functions), so the jsdom polyfill activates whenever the global lacks the required interface.

Merge-Bead: astro-plan-4fpq
Tracks-Bead: astro-plan-amf7.2
Closes-Bead: astro-plan-amf7.2
Tracks-Bead: astro-plan-ylmg
