### PR TITLE
fix(e2e): Windows L3 cold-boot timeouts and localStorage flush race

### DIFF
--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -1903,20 +1903,43 @@ impl E2eApp {
         let dir = lookup(&instance_env().vars, "WEBVIEW2_USER_DATA_FOLDER")
             .map(PathBuf::from)
             .context("WEBVIEW2_USER_DATA_FOLDER was not configured")?;
-        let deadline = Instant::now() + Duration::from_secs(10);
+        let deadline = Instant::now() + Duration::from_secs(15);
         loop {
             if let Some(leveldb) = find_leveldb_dir(&dir) {
-                if std::fs::read_dir(&leveldb)
-                    .ok()
-                    .is_some_and(|entries| entries.flatten().any(|entry| entry.path().is_file()))
-                {
+                // Wait for a DATA file (.ldb) or a write-ahead log (.log with
+                // non-zero size). Structural files (LOCK, CURRENT, MANIFEST-*)
+                // appear before localStorage content is committed, so checking
+                // "any file exists" is insufficient — that's what caused the
+                // TRY-1-only "no persisted detailDock entry" on loaded runners
+                // (bead astro-plan-msdw).
+                if std::fs::read_dir(&leveldb).ok().is_some_and(|entries| {
+                    entries.flatten().any(|entry| {
+                        let path = entry.path();
+                        if !path.is_file() {
+                            return false;
+                        }
+                        let ext = path.extension().and_then(|e| e.to_str()).unwrap_or("");
+                        if ext == "ldb" {
+                            return true;
+                        }
+                        // LevelDB .log files are the WAL — a non-empty one
+                        // means data has been written (even if not yet
+                        // compacted into .ldb).
+                        if ext == "log" {
+                            return path.metadata().map_or(false, |m| m.len() > 0);
+                        }
+                        false
+                    })
+                }) {
                     return Ok(());
                 }
             }
             if Instant::now() >= deadline {
-                anyhow::bail!("WebView2 profile did not expose persisted LevelDB files");
+                anyhow::bail!(
+                    "WebView2 profile did not expose persisted LevelDB data files within 15s"
+                );
             }
-            tokio::time::sleep(Duration::from_millis(100)).await;
+            tokio::time::sleep(Duration::from_millis(200)).await;
         }
     }
 

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -308,21 +308,29 @@ async fn wait_for_title_count_at_least(
     }
 }
 
-/// Ensure the Targets list has at least one entry via the IPC back-channel,
-/// then invalidate the TanStack Query so the UI reflects the data immediately.
+/// Wait for the Targets list to be ready in the UI: confirms ≥1 target
+/// exists via IPC, then drives the TanStack Query to reflect that data in
+/// the DOM via a retry-invalidation loop.
 ///
-/// Why IPC-backed rather than DOM-polling:
-/// `TargetsTable` renders a loading skeleton (which includes `planner-site-
-/// prompt`) while `count === 0 && loading === true`. DOM-polling for
-/// `.pv-targets-table__row` therefore stalls until TanStack Query finishes
-/// the `target_list` IPC round-trip — and on Windows CI cold boots, that
-/// round-trip can take 30-60s because it serialises and transfers ~13k rows.
-/// Polling `target_list` via the E2E invoke bridge gives the same signal but
-/// decouples it from TanStack Query's lifecycle, so the wait scales with the
-/// actual IPC latency rather than with the UI's query-result-to-DOM path.
-/// After the IPC confirms data is present, `invalidate_query` forces the UI
-/// to refetch and render rows immediately, regardless of `staleTime`.
+/// Three-stage design:
+/// 1. `invoke_until target_list` (TARGETS_TABLE_TIMEOUT): proves the backend
+///    has at least one target. Decoupled from TanStack Query — measures real
+///    IPC latency, not the UI's internal query state. Resolves the cold-start
+///    timing gap on Windows runners (bead h182).
+/// 2. `invalidate_query(["targets"])`: forces TanStack Query to refetch;
+///    awaits the refetch completion. This should bring `count ≥ 1` into
+///    React state and trigger a render with rows.
+/// 3. Retry loop (up to TARGETS_TABLE_TIMEOUT): if rows still absent after
+///    the first invalidation, re-invalidates every 10s. Covers:
+///    - Race between `invalidateQueries` Promise resolution and React's
+///      async commit (rows exist in cache but haven't hit the DOM yet);
+///    - `useStaleSelectionCleanup` mid-invalidation navigation that can
+///      cause the component to re-enter loading state;
+///    - Any in-flight concurrent `load()` refetch that returns before the
+///      invalidation and sets `data=[]`, leaving `count=0` until
+///      re-invalidated.
 async fn wait_targets_in_ipc_then_invalidate(app: &E2eApp) -> anyhow::Result<()> {
+    // Stage 1: wait for backend to have data.
     app.invoke_until("target_list", json!({}), TARGETS_TABLE_TIMEOUT, |v: &Value| {
         v.as_array().is_some_and(|a| !a.is_empty())
     })
@@ -331,11 +339,42 @@ async fn wait_targets_in_ipc_then_invalidate(app: &E2eApp) -> anyhow::Result<()>
         "target_list IPC never returned ≥1 target within TARGETS_TABLE_TIMEOUT — \
          the add or the DB write may have silently failed",
     )?;
-    // Force the UI's TanStack Query to refetch so the DOM reflects the IPC
-    // result immediately — without this the query may still be in its stale-
-    // time window and serve a cached empty list.
-    app.invalidate_query(r#"["targets"]"#).await.context("failed to invalidate targets query")?;
-    Ok(())
+
+    // Stage 2+3: invalidate + retry until rows are in the DOM.
+    let outer_deadline = tokio::time::Instant::now() + TARGETS_TABLE_TIMEOUT;
+    loop {
+        // Invalidate TanStack Query and await the refetch (blocks until
+        // the query has fresh data or SCRIPT_TIMEOUT elapses).
+        app.invalidate_query(r#"["targets"]"#)
+            .await
+            .context("failed to invalidate targets query")?;
+
+        // Poll DOM for up to 10s after each invalidation.
+        let poll_deadline = tokio::time::Instant::now() + Duration::from_secs(10);
+        let mut found = false;
+        while tokio::time::Instant::now() < poll_deadline {
+            if app.driver.find(By::Css(".pv-targets-table__row")).await.is_ok() {
+                found = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(250)).await;
+        }
+        if found {
+            return Ok(());
+        }
+
+        if tokio::time::Instant::now() >= outer_deadline {
+            let url = app
+                .driver
+                .current_url()
+                .await
+                .map_or_else(|_| "<unknown>".to_owned(), |u| u.to_string());
+            anyhow::bail!(
+                "no .pv-targets-table__row appeared within TARGETS_TABLE_TIMEOUT \
+                 after repeated invalidate-and-poll cycles; current URL: {url}"
+            );
+        }
+    }
 }
 
 /// Diagnostics for a `wait_for_title_count_at_least` timeout: the first real

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -32,6 +32,14 @@ use thirtyfour::{By, WebElement};
 
 const UI_TIMEOUT: Duration = Duration::from_secs(20);
 
+/// Extended timeout for waits that depend on the Targets table rendering its
+/// first row. On Windows CI cold boots the 13k-row bundled seed load can take
+/// 30-60s after the app process starts, and the targets list TanStack Query
+/// won't resolve until the seed is loaded. TRY-1 failures at exactly 20s
+/// (standard `UI_TIMEOUT`) that pass on TRY-2 in <8s are the signature of a
+/// warm-disk-cache dependency, not a product bug.
+const TARGETS_TABLE_TIMEOUT: Duration = Duration::from_secs(60);
+
 /// Real, per-target disclosure titles (spec 047) — asserted verbatim against
 /// `apps/desktop/messages/en.json` so a copy change fails this test loudly
 /// instead of silently drifting.
@@ -300,6 +308,33 @@ async fn wait_for_title_count_at_least(
     }
 }
 
+/// Wait for the Targets table to render at least one row, proving the list
+/// query resolved and the table component mounted its data. Uses the extended
+/// `TARGETS_TABLE_TIMEOUT` because on Windows CI cold boots the bundled
+/// 13k-row seed load can take 30-60s after launch, and the table won't render
+/// until that completes.
+async fn wait_targets_table_row(app: &E2eApp) -> anyhow::Result<()> {
+    let deadline = tokio::time::Instant::now() + TARGETS_TABLE_TIMEOUT;
+    loop {
+        if app.driver.find(By::Css(".pv-targets-table__row")).await.is_ok() {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline {
+            let url = app
+                .driver
+                .current_url()
+                .await
+                .map_or_else(|_| "<unknown>".to_owned(), |u| u.to_string());
+            anyhow::bail!(
+                "no .pv-targets-table__row appeared within {TARGETS_TABLE_TIMEOUT:?} — \
+                 the targets list query likely never resolved (seed load still in progress \
+                 on a cold Windows boot?); current URL: {url}"
+            );
+        }
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+}
+
 /// Diagnostics for a `wait_for_title_count_at_least` timeout: the first real
 /// target row's outerHTML (does the row even exist? does it carry the
 /// expected muted/unknown cells?) plus a page-wide count for both disclosure
@@ -526,6 +561,13 @@ async fn targets_ui_astronomy_columns_disclose_placeholder_without_site() -> any
     // Guarantee at least one real target row exists regardless of whether the
     // bundled seed catalog is pre-listed on a fresh DB.
     add_target_via_ui(&app, "M 1").await?;
+
+    // Wait for the table to actually render a row before asserting on
+    // row-level cell content. On a Windows cold boot the seed load can take
+    // 30-60s, and without this gate the 20s title-element poll below fires
+    // against an empty table — producing the TRY-1-only failures tracked by
+    // bead astro-plan-h182.
+    wait_targets_table_row(&app).await?;
 
     app.wait_testid("planner-site-prompt", UI_TIMEOUT).await.map_err(|e| {
         anyhow::anyhow!("expected the real site-setup prompt with no observing site: {e}")
@@ -780,6 +822,10 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
     // render, so the table keeps full width and barely overflows at all.
     app.goto_route(&format!("/targets?selected={target_id}")).await?;
     app.wait_bridge_ready(Duration::from_secs(15)).await?;
+    // Wait for the table to populate before asserting on scroll geometry. On
+    // Windows cold boots the seed load can take 30-60s, and
+    // DEFAULT_FIND_TIMEOUT (20s) is insufficient (bead astro-plan-h182).
+    wait_targets_table_row(&app).await?;
     app.find_waiting(
         By::Css(".pv-targets-table__scroll"),
         "the loaded Targets table scroll container",
@@ -1031,7 +1077,15 @@ async fn targets_ui_dock_pin_and_width_survive_a_real_restart() -> anyhow::Resul
     app.graceful_shutdown().await?;
 
     #[cfg(target_os = "windows")]
-    E2eApp::wait_for_webview_storage_flush().await?;
+    {
+        E2eApp::wait_for_webview_storage_flush().await?;
+        // WebView2's LevelDB commit is asynchronous: the directory and
+        // structural files appear before the actual localStorage key/value
+        // data is committed. On a loaded Windows runner this lag is
+        // non-trivial — the TRY-1-only "no persisted detailDock entry"
+        // failure (bead astro-plan-msdw) is this race.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+    }
 
     // Cold start: new process, empty module cache, storage read from disk.
     let app = E2eApp::relaunch().await?;

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -308,31 +308,34 @@ async fn wait_for_title_count_at_least(
     }
 }
 
-/// Wait for the Targets table to render at least one row, proving the list
-/// query resolved and the table component mounted its data. Uses the extended
-/// `TARGETS_TABLE_TIMEOUT` because on Windows CI cold boots the bundled
-/// 13k-row seed load can take 30-60s after launch, and the table won't render
-/// until that completes.
-async fn wait_targets_table_row(app: &E2eApp) -> anyhow::Result<()> {
-    let deadline = tokio::time::Instant::now() + TARGETS_TABLE_TIMEOUT;
-    loop {
-        if app.driver.find(By::Css(".pv-targets-table__row")).await.is_ok() {
-            return Ok(());
-        }
-        if tokio::time::Instant::now() >= deadline {
-            let url = app
-                .driver
-                .current_url()
-                .await
-                .map_or_else(|_| "<unknown>".to_owned(), |u| u.to_string());
-            anyhow::bail!(
-                "no .pv-targets-table__row appeared within {TARGETS_TABLE_TIMEOUT:?} — \
-                 the targets list query likely never resolved (seed load still in progress \
-                 on a cold Windows boot?); current URL: {url}"
-            );
-        }
-        tokio::time::sleep(Duration::from_millis(250)).await;
-    }
+/// Ensure the Targets list has at least one entry via the IPC back-channel,
+/// then invalidate the TanStack Query so the UI reflects the data immediately.
+///
+/// Why IPC-backed rather than DOM-polling:
+/// `TargetsTable` renders a loading skeleton (which includes `planner-site-
+/// prompt`) while `count === 0 && loading === true`. DOM-polling for
+/// `.pv-targets-table__row` therefore stalls until TanStack Query finishes
+/// the `target_list` IPC round-trip — and on Windows CI cold boots, that
+/// round-trip can take 30-60s because it serialises and transfers ~13k rows.
+/// Polling `target_list` via the E2E invoke bridge gives the same signal but
+/// decouples it from TanStack Query's lifecycle, so the wait scales with the
+/// actual IPC latency rather than with the UI's query-result-to-DOM path.
+/// After the IPC confirms data is present, `invalidate_query` forces the UI
+/// to refetch and render rows immediately, regardless of `staleTime`.
+async fn wait_targets_in_ipc_then_invalidate(app: &E2eApp) -> anyhow::Result<()> {
+    app.invoke_until("target_list", json!({}), TARGETS_TABLE_TIMEOUT, |v: &Value| {
+        v.as_array().is_some_and(|a| !a.is_empty())
+    })
+    .await
+    .context(
+        "target_list IPC never returned ≥1 target within TARGETS_TABLE_TIMEOUT — \
+         the add or the DB write may have silently failed",
+    )?;
+    // Force the UI's TanStack Query to refetch so the DOM reflects the IPC
+    // result immediately — without this the query may still be in its stale-
+    // time window and serve a cached empty list.
+    app.invalidate_query(r#"["targets"]"#).await.context("failed to invalidate targets query")?;
+    Ok(())
 }
 
 /// Diagnostics for a `wait_for_title_count_at_least` timeout: the first real
@@ -567,7 +570,7 @@ async fn targets_ui_astronomy_columns_disclose_placeholder_without_site() -> any
     // 30-60s, and without this gate the 20s title-element poll below fires
     // against an empty table — producing the TRY-1-only failures tracked by
     // bead astro-plan-h182.
-    wait_targets_table_row(&app).await?;
+    wait_targets_in_ipc_then_invalidate(&app).await?;
 
     app.wait_testid("planner-site-prompt", UI_TIMEOUT).await.map_err(|e| {
         anyhow::anyhow!("expected the real site-setup prompt with no observing site: {e}")
@@ -825,7 +828,7 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
     // Wait for the table to populate before asserting on scroll geometry. On
     // Windows cold boots the seed load can take 30-60s, and
     // DEFAULT_FIND_TIMEOUT (20s) is insufficient (bead astro-plan-h182).
-    wait_targets_table_row(&app).await?;
+    wait_targets_in_ipc_then_invalidate(&app).await?;
     app.find_waiting(
         By::Css(".pv-targets-table__scroll"),
         "the loaded Targets table scroll container",


### PR DESCRIPTION
## Summary

- Wait for the Targets table to render at least one row (60s budget) before asserting on row-level content (title tooltips, scroll geometry) — on Windows cold boots the 13k-row seed load takes 30-60s, exhausting the previous 20s assertion timeout.
- Tighten `wait_for_webview_storage_flush()` to require actual LevelDB data files (`.ldb` or non-empty `.log` WAL) rather than structural files like LOCK/CURRENT that appear before localStorage content is committed. Raise deadline to 15s and add a 2s post-flush settle delay.

## Root cause

On Windows CI cold boots, TRY-1 consistently fails because:
1. The bundled 13k-row target seed load makes app init take 100-130s, leaving only seconds for assertion polls that had a 20s budget.
2. `wait_for_webview_storage_flush` returned success on structural LevelDB files before localStorage key/value data was committed, causing the dock restart journey to read back empty state.

TRY-2 passes in 7-24s because the disk cache is warm. The fix addresses the budget mismatch without masking real regressions.

Merge-Bead: astro-plan-2zem
Tracks-Bead: astro-plan-h182
Tracks-Bead: astro-plan-msdw