### PR TITLE
fix: inbox selection follows the split sibling after classify materialises sub-items

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -32,7 +32,7 @@
  */
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
@@ -371,22 +371,27 @@ export function InboxPage() {
     ? filteredItems.find((it) => it.inboxItemId === selected)
     : undefined;
 
-  // Tracks the last-known selected item's identity. Updated while
-  // `selectedItem` is defined so that when it disappears from the list
-  // (classify-split: placeholder purged, fresh-UUID sub-item appears with the
-  // same `sourceGroupId`) the classify-split handoff effect below can still
-  // read the `sourceGroupId` and find the successor — by the time the effect
-  // fires, `selectedItem` is already undefined. Plain ref mutation is safe
-  // here: the value is consumed only by the effect, not by render output.
-  const lastSelectedRef = useRef<{
+  // Tracks the sourceGroupId of the last item that was actively selected.
+  // Updated via React's derived-state-from-render pattern (setState during render
+  // is permitted for local state driven by current props/state — the React docs'
+  // alternative to getDerivedStateFromProps). Written only when `selectedItem`
+  // is defined, so it always holds the most-recently-selected item's identity.
+  // When `selectedItem` disappears (classify-split purged the placeholder), this
+  // state still carries the sourceGroupId needed to find the successor — without
+  // touching a ref during render, which the react-hooks lint rule forbids.
+  const [prevSelectedInfo, setPrevSelectedInfo] = useState<{
     inboxItemId: string;
     sourceGroupId: string | null;
   } | null>(null);
-  if (selectedItem !== undefined) {
-    lastSelectedRef.current = {
+  if (
+    selectedItem !== undefined &&
+    (prevSelectedInfo === null ||
+      prevSelectedInfo.inboxItemId !== selectedItem.inboxItemId)
+  ) {
+    setPrevSelectedInfo({
       inboxItemId: selectedItem.inboxItemId,
       sourceGroupId: selectedItem.sourceGroupId ?? null,
-    };
+    });
   }
 
   // `reclassify_v2` operates at source-group scope and re-splits the group
@@ -409,9 +414,9 @@ export function InboxPage() {
   // Rule (CHK011 N=1 case, mirroring `resolveClassifiedGroupSelection`): if
   // EXACTLY ONE item in the settled list shares the missing item's
   // `sourceGroupId`, that is the unambiguous successor — navigate to it.
-  // Computed synchronously during render so its non-null value can gate
-  // `useStaleSelectionCleanup` on the SAME render that would otherwise clear
-  // the selection. Placed before `useStaleSelectionCleanup` for that reason.
+  // Computed synchronously during render (pure state/props derivation) so its
+  // non-null value can gate `useStaleSelectionCleanup` on the SAME render that
+  // would otherwise clear the selection. Placed before the cleanup call.
   const classifySplitSibling = useMemo(() => {
     if (
       listLoading ||
@@ -421,12 +426,15 @@ export function InboxPage() {
     ) {
       return null;
     }
-    const last = lastSelectedRef.current;
-    if (!last || last.inboxItemId !== selected || !last.sourceGroupId) {
+    if (
+      !prevSelectedInfo ||
+      prevSelectedInfo.inboxItemId !== selected ||
+      !prevSelectedInfo.sourceGroupId
+    ) {
       return null;
     }
     const decision = resolveClassifiedGroupSelection(
-      last.sourceGroupId,
+      prevSelectedInfo.sourceGroupId,
       items,
       false,
     );
@@ -436,6 +444,7 @@ export function InboxPage() {
     pendingReclassifySelectionId,
     selected,
     selectedItem,
+    prevSelectedInfo,
     items,
   ]);
 

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -32,7 +32,7 @@
  */
 
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
@@ -371,6 +371,24 @@ export function InboxPage() {
     ? filteredItems.find((it) => it.inboxItemId === selected)
     : undefined;
 
+  // Tracks the last-known selected item's identity. Updated while
+  // `selectedItem` is defined so that when it disappears from the list
+  // (classify-split: placeholder purged, fresh-UUID sub-item appears with the
+  // same `sourceGroupId`) the classify-split handoff effect below can still
+  // read the `sourceGroupId` and find the successor — by the time the effect
+  // fires, `selectedItem` is already undefined. Plain ref mutation is safe
+  // here: the value is consumed only by the effect, not by render output.
+  const lastSelectedRef = useRef<{
+    inboxItemId: string;
+    sourceGroupId: string | null;
+  } | null>(null);
+  if (selectedItem !== undefined) {
+    lastSelectedRef.current = {
+      inboxItemId: selectedItem.inboxItemId,
+      sourceGroupId: selectedItem.sourceGroupId ?? null,
+    };
+  }
+
   // `reclassify_v2` operates at source-group scope and re-splits the group
   // into new single-type sub-items (R-14, issue #755) — the currently
   // selected item's id can stop existing mid-flight. Holds the post-split
@@ -382,6 +400,45 @@ export function InboxPage() {
   const [pendingReclassifySelectionId, setPendingReclassifySelectionId] =
     useState<string | null>(null);
 
+  // Classify-split handoff (issue #1038 / astro-plan-srz6): when
+  // `inbox.classify` materializes sub-items from a placeholder, the placeholder
+  // row disappears from the list without any `reclassify_v2` call.
+  // `pendingReclassifySelectionId` is never set, so `useStaleSelectionCleanup`
+  // would clear the selection instead of following the successor.
+  //
+  // Rule (CHK011 N=1 case, mirroring `resolveClassifiedGroupSelection`): if
+  // EXACTLY ONE item in the settled list shares the missing item's
+  // `sourceGroupId`, that is the unambiguous successor — navigate to it.
+  // Computed synchronously during render so its non-null value can gate
+  // `useStaleSelectionCleanup` on the SAME render that would otherwise clear
+  // the selection. Placed before `useStaleSelectionCleanup` for that reason.
+  const classifySplitSibling = useMemo(() => {
+    if (
+      listLoading ||
+      pendingReclassifySelectionId !== null ||
+      selected === undefined ||
+      selectedItem !== undefined
+    ) {
+      return null;
+    }
+    const last = lastSelectedRef.current;
+    if (!last || last.inboxItemId !== selected || !last.sourceGroupId) {
+      return null;
+    }
+    const decision = resolveClassifiedGroupSelection(
+      last.sourceGroupId,
+      items,
+      false,
+    );
+    return decision.action === 'select' ? decision.id : null;
+  }, [
+    listLoading,
+    pendingReclassifySelectionId,
+    selected,
+    selectedItem,
+    items,
+  ]);
+
   // #735: `listLoading` joins the gate because on a cold reload the list cache
   // is empty and an unguarded `selectedItem === undefined` wipes a valid
   // `?selected=` before the list IPC resolves. This does NOT reopen the
@@ -392,7 +449,8 @@ export function InboxPage() {
     selected,
     listLoading ||
       selectedItem !== undefined ||
-      pendingReclassifySelectionId !== null,
+      pendingReclassifySelectionId !== null ||
+      classifySplitSibling !== null,
     () =>
       navigate({
         search: (prev) => ({ ...prev, selected: undefined }),
@@ -491,6 +549,13 @@ export function InboxPage() {
     selected,
     navigate,
   ]);
+
+  useEffect(() => {
+    if (!classifySplitSibling) return;
+    void navigate({
+      search: (prev) => ({ ...prev, selected: classifySplitSibling }),
+    });
+  }, [classifySplitSibling, navigate]);
 
   // Each item carries its own root path — use it for classify / confirm calls.
   const selectedRootPath = selectedItem?.rootAbsolutePath ?? '';

--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.reclassifyGate.test.tsx
@@ -426,3 +426,59 @@ describe('InboxDetail survives the involuntary id churn from the FIRST classify 
     );
   });
 });
+
+// ── #1038 (follow-up to #711): the selection handoff the block above stubbed ──
+//
+// The describe above deliberately hand-moved `selected` via `setSearch`,
+// calling the mechanism "out of scope". This block owns that mechanism.
+//
+// Selecting an unclassified folder PLACEHOLDER is what triggers the FIRST
+// `inbox.classify`, and classify materializes single-type sub-items. #1038 then
+// (correctly) hides the superseded placeholder from `inbox.list`, so the
+// selected id stops existing WITHOUT any reclassify having run —
+// `pendingReclassifySelectionId` cannot cover it. Pre-fix the selection was
+// simply dropped: the detail pane emptied and Confirm no-oped on a row the user
+// could still see (Real-UI casualty
+// `inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm`).
+describe('selection follows the classify-split successor (#1038)', () => {
+  it('moves selection to the sub-item sharing the placeholder sourceGroupId', async () => {
+    const { queryClient } = render(<InboxPage />);
+
+    await screen.findByTestId(`inbox-item-${OLD_ID}`);
+    screen.getByTestId(`inbox-item-${OLD_ID}`).click();
+    await waitFor(() => expect(getSearch().selected).toBe(OLD_ID));
+
+    // classify's split lands: the placeholder is deduped away and only its
+    // sub-item (same sourceGroupId, new id) remains listed. NOTHING here moves
+    // `selected` — that is exactly what is under test.
+    mockInboxList.mockResolvedValue(
+      ok({ items: [newItem], capped: false, limit: 500 }),
+    );
+    await queryClient.invalidateQueries({ queryKey: ['inbox', 'all'] });
+
+    await waitFor(() => expect(getSearch().selected).toBe(NEW_ID), {
+      timeout: 5000,
+    });
+    expect(await screen.findByTestId('inbox-confirm-btn')).toBeInTheDocument();
+  });
+
+  it('clears the selection when no sibling shares the source group', async () => {
+    const { queryClient } = render(<InboxPage />);
+
+    await screen.findByTestId(`inbox-item-${OLD_ID}`);
+    screen.getByTestId(`inbox-item-${OLD_ID}`).click();
+    await waitFor(() => expect(getSearch().selected).toBe(OLD_ID));
+
+    // The row is gone for an unrelated reason (resolved elsewhere, filtered
+    // out): the handoff must give up so `useStaleSelectionCleanup` is not
+    // gated open forever.
+    mockInboxList.mockResolvedValue(
+      ok({ items: [], capped: false, limit: 500 }),
+    );
+    await queryClient.invalidateQueries({ queryKey: ['inbox', 'all'] });
+
+    await waitFor(() => expect(getSearch().selected).toBeUndefined(), {
+      timeout: 5000,
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- When classify splits a placeholder folder into sub-items, the superseded row disappears from the list without a reclassify call. The selection was cleared instead of following the single unambiguous successor.
- Fix: on a settled list where the selected row is gone, look for exactly one item sharing the same source-group id; if found, navigate to it. Zero or multiple matches keep the existing clear behaviour.

## Spec Context

CHK011 / spec 058 FR-023 (N=1 rule). Tracks-Bead: astro-plan-srz6