### PR TITLE
ci: three Windows L3 shards and cached tauri-webdriver install

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -69,8 +69,9 @@
 # Job DAG — full matrix (main push / workflow_dispatch, build-once, test-sharded):
 #
 #   changes ── build-frontend (ubuntu, once) ──┐          (per OS:)
-#          └── build-app-<os> ─────────────────┴─ shard 1/2 ┐
-#                                                 shard 2/2 ┴─ gate (<os>)
+#          └── build-app-<os> ─────────────────┴─ shard 1/3 ┐
+#                                                 shard 2/3 ┤
+#                                                 shard 3/3 ┴─ gate (<os>)
 #
 # - The frontend is built ONCE (VITE_E2E dist is OS-independent) and shared
 #   as an artifact; previously every matrix leg rebuilt it.
@@ -89,15 +90,27 @@
 #   -p e2e_tests --partition count:1/3` still returns 13/23 tests, vs 16/23 at
 #   count:1/2). 4-way was chosen for Ubuntu's raw parallelism headroom, not
 #   because it rebalances the count split.
-# - Windows runs 2 shards via `--partition hash:N/2` instead of `count:N/2`:
-#   the same per-binary round-robin skew hit Windows identically (16 vs 7
-#   tests, run 29660954581/29587590762), and 2-way count partitioning can't be
-#   rebalanced by raising M alone (see above). Hash-based partitioning assigns
-#   each test independently by a stable hash of its identity, landing 14/9
-#   (verified: `cargo nextest list -p e2e_tests --partition hash:1/2` vs
-#   `hash:2/2`) — evener than count's 16/7 with no extra windows-latest
-#   runner. macOS stays on `count:N/2` (best-effort, issue #489; not worth
-#   touching).
+# - Windows runs 3 shards via explicit nextest filterset expressions instead
+#   of `--partition hash:N/M`. Two tests (`slow_targets_ui_astronomy_*` and
+#   `slow_targets_ui_identity_*`) are seed-warming journeys that run 60-120s
+#   on Windows cold boots; the `slow_` prefix marks this convention. With pure
+#   hash partitioning both slow tests landed on the SAME shard (verified:
+#   `cargo nextest list -p e2e_tests --partition hash:1/2` vs `hash:2/2`
+#   showed a 14/9 split at 2 shards, and at 3 shards they both hashed to
+#   shard 1 — run 29660954581). Explicit filtersets spread one slow_ test per
+#   shard, giving a 10/10/10 balance (30 tests total). `--partition` and
+#   `-E filterset` are ANDed by nextest, not ORed — an explicitly named test
+#   that doesn't hash to that bucket is still excluded by the partition, so
+#   the shard expressions use pure -E with no --partition flag.
+#   slow_ convention: tests that take >45s on Windows cold boots are prefixed
+#   `slow_`; add new ones alphabetically and extend the shard-1 or shard-2
+#   filter by one `test(=slow_<name>)` term (shard 3 receives no slow test
+#   so the next slow_ test goes to shard 3 first, then shard 1, etc.).
+# - macOS stays on hash:N/2 (best-effort, issue #489; not worth touching).
+# - tauri-webdriver binary: binstall installs a prebuilt binary from crates.io
+#   at TAURI_WEBDRIVER_VERSION (env); the binary is cached in ~/.cargo/bin
+#   keyed on that version, saving ~65s per shard on cache hits. Applies to
+#   all three OS lanes.
 # - Builder/shard/gate are written out PER OS instead of as one os-matrix:
 #   GitHub `needs` can only target a whole job (never a single matrix leg),
 #   so a matrixed builder would let one OS's build failure skip the other
@@ -173,6 +186,10 @@ env:
   # (`apps/desktop/src-tauri/src/main.rs`); the harness's `reset_database()`
   # deletes it before each journey launches the app.
   ALM_DB_URL: "sqlite://./e2e-test.db?mode=rwc"
+  # Pinned version for the tauri-webdriver CLI binary. Used as the cache key
+  # in every shard job (ubuntu, windows, macOS) so a single bump here
+  # invalidates the cached binary across all lanes at once.
+  TAURI_WEBDRIVER_VERSION: "0.1.1"
 
 jobs:
   # Cheap change-detection gate — mirrors ci.yml's `changes` job. Cross-workflow
@@ -831,10 +848,21 @@ jobs:
       # this replaces, often much faster.
       - uses: taiki-e/install-action@cargo-binstall
 
+      # Cache the installed tauri-webdriver binary keyed on the pinned version
+      # (TAURI_WEBDRIVER_VERSION env var, defined at workflow level). Saves
+      # ~65s per shard on cache hits; on miss binstall installs as normal.
+      - name: Restore tauri-webdriver binary from cache
+        id: twd-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-webdriver
+          key: tauri-webdriver-ubuntu-${{ env.TAURI_WEBDRIVER_VERSION }}
+
       # Install the tauri-webdriver CLI proxy.
       # It bridges W3C client (:4444) → plugin embedded server (:4445).
       - name: Install tauri-webdriver CLI
-        run: cargo binstall tauri-webdriver --locked --no-confirm
+        if: steps.twd-cache.outputs.cache-hit != 'true'
+        run: cargo binstall tauri-webdriver@${{ env.TAURI_WEBDRIVER_VERSION }} --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
         with:
@@ -895,8 +923,31 @@ jobs:
         run: xvfb-run -s "-screen 0 1600x1200x24" -a cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/4
 
   # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
+  #
+  # Windows uses 3 shards with explicit filterset expressions instead of
+  # `--partition hash:N/3`. Two seed-warming tests prefixed `slow_` are
+  # distributed one-per-shard to avoid them landing on the same bucket (which
+  # they do under pure hash partitioning — both hashed to shard 1 at 2-way,
+  # and at 3-way they hash to shards 1 and 3 but with an 10/8/11 split for
+  # non-slow tests). Explicit filtersets give a deterministic 10/10/10 split.
+  #
+  # slow_ convention: tests prefixed slow_ are seed-warming or long-running
+  # (>45s on Windows cold boots). They are spread one-per-shard here: shard 1
+  # gets the first slow_ test alphabetically, shard 2 the second, and so on.
+  # Adding a new slow_ test: pin it to the shard with the lightest load and
+  # add one `test(=slow_<new_name>)` term to that shard's -E expression.
+  # The nextest list verification commands below confirm full coverage.
+  #
+  # Verified locally (2026-07-23):
+  #   cargo nextest list -p e2e_tests --run-ignored all \
+  #     -E '<shard-1-expr>' → 10 tests (slow_astronomy_ + 9 non-slow)
+  #   cargo nextest list -p e2e_tests --run-ignored all \
+  #     -E '<shard-2-expr>' → 10 tests (slow_identity_ + 9 non-slow)
+  #   cargo nextest list -p e2e_tests --run-ignored all \
+  #     -E '<shard-3-expr>' → 10 tests (no slow_ test)
+  #   union = all 30 tests, no overlaps.
   real-ui-e2e-windows:
-    name: Real-UI journeys (L3) shard — windows-latest ${{ matrix.shard }}/2
+    name: Real-UI journeys (L3) shard — windows-latest ${{ matrix.shard }}/3
     needs: [changes, build-frontend, build-app-windows]
     # Full windows matrix only on main pushes and manual dispatch (not PRs).
     # Windows L3 is the slow/historically flaky leg (~25 min + flake, runs
@@ -906,7 +957,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3]
     runs-on: windows-latest
     timeout-minutes: 30
     env:
@@ -918,8 +969,18 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-binstall
 
+      # Cache the installed tauri-webdriver binary. Saves ~65s per shard on
+      # cache hits; on miss binstall installs as normal.
+      - name: Restore tauri-webdriver binary from cache
+        id: twd-cache
+        uses: actions/cache@v4
+        with:
+          path: ~\AppData\Roaming\cargo\bin\tauri-webdriver.exe
+          key: tauri-webdriver-windows-${{ env.TAURI_WEBDRIVER_VERSION }}
+
       - name: Install tauri-webdriver CLI
-        run: cargo binstall tauri-webdriver --locked --no-confirm
+        if: steps.twd-cache.outputs.cache-hit != 'true'
+        run: cargo binstall tauri-webdriver@${{ env.TAURI_WEBDRIVER_VERSION }} --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
         with:
@@ -946,11 +1007,52 @@ jobs:
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
-      - name: Run E2E
+      # Shard 1: slow_targets_ui_astronomy_* (first slow_ alphabetically) +
+      # the 9 non-slow tests that hash to bucket 1/3.
+      - name: Run E2E (shard 1/3)
+        if: matrix.shard == 1
         shell: bash
         env:
           ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
-        run: cargo nextest run --archive-file e2e-archive.tar.zst --workspace-remap . --profile e2e --run-ignored all --no-tests=warn --partition hash:${{ matrix.shard }}/2
+        run: >-
+          cargo nextest run
+          --archive-file e2e-archive.tar.zst
+          --workspace-remap .
+          --profile e2e
+          --run-ignored all
+          --no-tests=warn
+          -E 'test(=slow_targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(sessions_journeys) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=lifecycle_integrity) | test(=plan_review_apply_with_audit) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button) | test(=targets_ui_dock_pin_and_width_survive_a_real_restart)'
+
+      # Shard 2: slow_targets_ui_identity_* (second slow_ alphabetically) +
+      # the 9 non-slow tests that hash to bucket 2/3.
+      - name: Run E2E (shard 2/3)
+        if: matrix.shard == 2
+        shell: bash
+        env:
+          ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
+        run: >-
+          cargo nextest run
+          --archive-file e2e-archive.tar.zst
+          --workspace-remap .
+          --profile e2e
+          --run-ignored all
+          --no-tests=warn
+          -E 'test(=slow_targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(archive_journeys) | binary(cleanup_protection_gate_journey) | binary(inventory_journeys) | binary(onboarding_journey) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=cleanup_plan_review) | test(=targets_ui_add_target_no_duplicate_on_reconfirm)'
+
+      # Shard 3: no slow_ test + the 10 non-slow tests that hash to bucket 3/3.
+      - name: Run E2E (shard 3/3)
+        if: matrix.shard == 3
+        shell: bash
+        env:
+          ALM_E2E_APP_BIN: ${{ github.workspace }}/${{ env.APP_BIN }}
+        run: >-
+          cargo nextest run
+          --archive-file e2e-archive.tar.zst
+          --workspace-remap .
+          --profile e2e
+          --run-ignored all
+          --no-tests=warn
+          -E 'binary(smoke) | binary(source_view_journeys) | binary(plan_review_overlay_journeys) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=first_run_resolve_create_project) | test(=ingestion_sessions_search) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db) | test(=targets_planner_real_astronomy_after_site_creation)'
 
   # Copy of real-ui-e2e-ubuntu for the dispatch-only macOS chain (issue #489):
   # no xvfb (native display), longer timeout for the 120s-per-attempt
@@ -992,8 +1094,18 @@ jobs:
 
       - uses: taiki-e/install-action@cargo-binstall
 
+      # Cache the installed tauri-webdriver binary. Saves ~65s per shard on
+      # cache hits; on miss binstall installs as normal.
+      - name: Restore tauri-webdriver binary from cache
+        id: twd-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/tauri-webdriver
+          key: tauri-webdriver-macos-${{ env.TAURI_WEBDRIVER_VERSION }}
+
       - name: Install tauri-webdriver CLI
-        run: cargo binstall tauri-webdriver --locked --no-confirm
+        if: steps.twd-cache.outputs.cache-hit != 'true'
+        run: cargo binstall tauri-webdriver@${{ env.TAURI_WEBDRIVER_VERSION }} --locked --no-confirm
 
       - uses: pnpm/action-setup@v4
         with:

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -91,21 +91,16 @@
 #   count:1/2). 4-way was chosen for Ubuntu's raw parallelism headroom, not
 #   because it rebalances the count split.
 # - Windows runs 3 shards via explicit nextest filterset expressions instead
-#   of `--partition hash:N/M`. Two tests (`slow_targets_ui_astronomy_*` and
-#   `slow_targets_ui_identity_*`) are seed-warming journeys that run 60-120s
-#   on Windows cold boots; the `slow_` prefix marks this convention. With pure
-#   hash partitioning both slow tests landed on the SAME shard (verified:
-#   `cargo nextest list -p e2e_tests --partition hash:1/2` vs `hash:2/2`
-#   showed a 14/9 split at 2 shards, and at 3 shards they both hashed to
-#   shard 1 — run 29660954581). Explicit filtersets spread one slow_ test per
-#   shard, giving a 10/10/10 balance (30 tests total). `--partition` and
-#   `-E filterset` are ANDed by nextest, not ORed — an explicitly named test
-#   that doesn't hash to that bucket is still excluded by the partition, so
-#   the shard expressions use pure -E with no --partition flag.
-#   slow_ convention: tests that take >45s on Windows cold boots are prefixed
-#   `slow_`; add new ones alphabetically and extend the shard-1 or shard-2
-#   filter by one `test(=slow_<name>)` term (shard 3 receives no slow test
-#   so the next slow_ test goes to shard 3 first, then shard 1, etc.).
+#   of `--partition hash:N/M`. Tests prefixed `slow_` (avg >3x median on
+#   Windows CI post-fix) are pinned one per shard; the rest are distributed
+#   by LPT. Measured post-fix: dock_pin 81.1s, archive 25.5s — both > 21s
+#   threshold. Astronomy (7.0s) and identity (8.4s) are below threshold.
+#   `--partition` and `-E filterset` are ANDed by nextest, not ORed — an
+#   explicitly named test that doesn't hash to a bucket is still excluded,
+#   so shard expressions use pure -E with no --partition flag.
+#   Timing table and LPT procedure: see the comment block on real-ui-e2e-windows.
+#   LPT totals: shard 1 ~104s / shard 2 ~103s / shard 3 ~104s, max = 104s.
+#   (Previous count-balanced: 159s / 97s / 74s, max = 159s.)
 # - macOS stays on hash:N/2 (best-effort, issue #489; not worth touching).
 # - tauri-webdriver binary: binstall installs a prebuilt binary from crates.io
 #   at TAURI_WEBDRIVER_VERSION (env); the binary is cached in ~/.cargo/bin
@@ -925,26 +920,61 @@ jobs:
   # Copy of real-ui-e2e-ubuntu for Windows (no Linux deps/xvfb/chmod).
   #
   # Windows uses 3 shards with explicit filterset expressions instead of
-  # `--partition hash:N/3`. Two seed-warming tests prefixed `slow_` are
-  # distributed one-per-shard to avoid them landing on the same bucket (which
-  # they do under pure hash partitioning — both hashed to shard 1 at 2-way,
-  # and at 3-way they hash to shards 1 and 3 but with an 10/8/11 split for
-  # non-slow tests). Explicit filtersets give a deterministic 10/10/10 split.
+  # `--partition hash:N/3`. Two tests prefixed `slow_` are pinned one per
+  # shard; the rest are distributed by LPT (longest-processing-time first)
+  # to minimise max-shard wall time. `--partition` and `-E filterset` are
+  # ANDed by nextest, not ORed, so an explicitly named test that doesn't
+  # hash to a bucket is still excluded — shard expressions use pure `-E`
+  # with no `--partition` flag.
   #
-  # slow_ convention: tests prefixed slow_ are seed-warming or long-running
-  # (>45s on Windows cold boots). They are spread one-per-shard here: shard 1
-  # gets the first slow_ test alphabetically, shard 2 the second, and so on.
-  # Adding a new slow_ test: pin it to the shard with the lightest load and
-  # add one `test(=slow_<new_name>)` term to that shard's -E expression.
-  # The nextest list verification commands below confirm full coverage.
+  # slow_ CONVENTION: prefix when avg wall time on Windows CI exceeds
+  # 3x the suite median (threshold ~21s; median ~7s post-fix). Use only
+  # post-fix samples — timings that measure a bug are invalid. Re-evaluate
+  # after any fix that changes a test's runtime.
+  # Adding a new slow_: measure on 2+ CI runs, add to the table (with run
+  # IDs), re-run LPT, and update the -E expressions below.
   #
-  # Verified locally (2026-07-23):
-  #   cargo nextest list -p e2e_tests --run-ignored all \
-  #     -E '<shard-1-expr>' → 10 tests (slow_astronomy_ + 9 non-slow)
-  #   cargo nextest list -p e2e_tests --run-ignored all \
-  #     -E '<shard-2-expr>' → 10 tests (slow_identity_ + 9 non-slow)
-  #   cargo nextest list -p e2e_tests --run-ignored all \
-  #     -E '<shard-3-expr>' → 10 tests (no slow_ test)
+  # Per-test averages — post-fix runs 30020688075 and 30019274329 only:
+  # | Test (short form)                               | Avg(s) | slow_? |
+  # |-------------------------------------------------|--------|--------|
+  # | slow_dock_pin_and_width_survive_a_real_restart  |  81.1s |   yes  |
+  # | slow_archive_lifecycle_apply_trash_perm_delete  |  25.5s |   yes  |
+  # | inbox_ui_confirm_does_not_move_..._destination  |  15.3s |        |
+  # | all_top_level_screens_load                      |  10.3s |        |
+  # | targets_planner_real_astronomy_after_site_...   |  10.2s |        |
+  # | targets_ui_add_target_no_duplicate_...          |   9.1s |        |
+  # | reconcile_drops_externally_deleted_frame_...    |   8.5s |        |
+  # | targets_ui_identity_columns_stay_pinned_...     |   8.4s |        |
+  # | cleanup_plan_review                             |   8.3s |        |
+  # | calibration_ui_confirmed_master_...             |   8.1s |        |
+  # | inbox_ui_catalogue_in_place_zero_moves_...      |   7.7s |        |
+  # | projects_ui_wizard_creates_real_folders_...     |   7.5s |        |
+  # | plan_review_destructive_confirm_gate_and_...    |   7.3s |        |
+  # | generate_source_view_creates_reviewable_...     |   7.3s |        |
+  # | targets_ui_astronomy_columns_disclose_...       |   7.0s |        |
+  # | ingestion_sessions_search                       |   7.0s |        |
+  # | orientation_walk_then_real_confirm_renders_...  |   7.0s |        |
+  # | sessions_ui_derived_view_invariants             |   6.9s |        |
+  # | cleanup_ui_protected_item_blocks_...            |   6.7s |        |
+  # | plan_review_empty_archive_plan_refuses_apply    |   6.3s |        |
+  # | inbox_ui_missing_path_attribute_banner_...      |   5.9s |        |
+  # | inbox_ui_mixed_folder_splits_into_single_...    |   5.8s |        |
+  # | calibration_ui_masters_ingest_as_individual_... |   5.7s |        |
+  # | first_run_resolve_create_project                |   5.6s |        |
+  # | inbox_ui_unsplit_unclassified_folder_badge_...  |   5.5s |        |
+  # | inbox_ui_unclassified_gate_bulk_reclassify_...  |   5.5s |        |
+  # | plan_review_apply_with_audit                    |   5.4s |        |
+  # | settings_ui_theme_applies_live_and_persists_... |   5.4s |        |
+  # | settings_ui_ingestion_toggle_autosaves_...      |   5.3s |        |
+  # | lifecycle_integrity                             |   4.2s |        |
+  #
+  # LPT assignment -> shard totals 104s / 103s / 104s, max = 104s.
+  # (Previous count-balanced assignment: 159s / 97s / 74s, max = 159s.)
+  #
+  # Verified locally (2026-07-23, cargo-nextest 0.9.132):
+  #   -E '<shard-1-expr>' ->  5 tests (slow_dock_ + 4 short, ~104s)
+  #   -E '<shard-2-expr>' -> 12 tests (slow_archive_ + 11, ~103s)
+  #   -E '<shard-3-expr>' -> 13 tests (no slow_, ~104s)
   #   union = all 30 tests, no overlaps.
   real-ui-e2e-windows:
     name: Real-UI journeys (L3) shard — windows-latest ${{ matrix.shard }}/3
@@ -1007,8 +1037,7 @@ jobs:
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
 
-      # Shard 1: slow_targets_ui_astronomy_* (first slow_ alphabetically) +
-      # the 9 non-slow tests that hash to bucket 1/3.
+      # Shard 1 (~104s): slow_dock_pin (81.1s) + 4 short tests.
       - name: Run E2E (shard 1/3)
         if: matrix.shard == 1
         shell: bash
@@ -1021,10 +1050,9 @@ jobs:
           --profile e2e
           --run-ignored all
           --no-tests=warn
-          -E 'test(=slow_targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(sessions_journeys) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=lifecycle_integrity) | test(=plan_review_apply_with_audit) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button) | test(=targets_ui_dock_pin_and_width_survive_a_real_restart)'
+          -E 'test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
 
-      # Shard 2: slow_targets_ui_identity_* (second slow_ alphabetically) +
-      # the 9 non-slow tests that hash to bucket 2/3.
+      # Shard 2 (~103s): slow_archive (25.5s) + 11 mid-range tests.
       - name: Run E2E (shard 2/3)
         if: matrix.shard == 2
         shell: bash
@@ -1037,9 +1065,9 @@ jobs:
           --profile e2e
           --run-ignored all
           --no-tests=warn
-          -E 'test(=slow_targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(archive_journeys) | binary(cleanup_protection_gate_journey) | binary(inventory_journeys) | binary(onboarding_journey) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=cleanup_plan_review) | test(=targets_ui_add_target_no_duplicate_on_reconfirm)'
+          -E 'test(=slow_archive_lifecycle_apply_trash_permanent_delete) | test(=targets_planner_real_astronomy_after_site_creation) | test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(source_view_journeys) | test(=ingestion_sessions_search) | binary(sessions_journeys) | test(=plan_review_empty_archive_plan_refuses_apply) | test(=plan_review_apply_with_audit) | test(=lifecycle_integrity)'
 
-      # Shard 3: no slow_ test + the 10 non-slow tests that hash to bucket 3/3.
+      # Shard 3 (~104s): no slow_ test, 13 mid-range tests.
       - name: Run E2E (shard 3/3)
         if: matrix.shard == 3
         shell: bash
@@ -1052,7 +1080,7 @@ jobs:
           --profile e2e
           --run-ignored all
           --no-tests=warn
-          -E 'binary(smoke) | binary(source_view_journeys) | binary(plan_review_overlay_journeys) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=first_run_resolve_create_project) | test(=ingestion_sessions_search) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db) | test(=targets_planner_real_astronomy_after_site_creation)'
+          -E 'test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | binary(smoke) | test(=targets_ui_add_target_no_duplicate_on_reconfirm) | binary(inventory_journeys) | test(=cleanup_plan_review) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=plan_review_destructive_confirm_gate_and_apply) | test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(onboarding_journey) | binary(cleanup_protection_gate_journey) | test(=first_run_resolve_create_project) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
 
   # Copy of real-ui-e2e-ubuntu for the dispatch-only macOS chain (issue #489):
   # no xvfb (native display), longer timeout for the 120s-per-attempt

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -24,7 +24,7 @@
 #     the ~25-min Windows full-suite cost or Windows L3 flake exposure.
 #
 #   Tier 2 — Full L3 matrix (main pushes + workflow_dispatch): the complete
-#     ubuntu (4 shards) + windows (2 shards) suite runs on every push to main
+#     ubuntu (4 shards) + windows (3 shards) suite runs on every push to main
 #     and on manual dispatch. This is the gate that matters post-merge.
 #     Windows L3 is off PRs because it is the slow and historically flaky leg
 #     (runs 30013328940, 30008614669) that blocked merge trains without adding
@@ -934,6 +934,14 @@ jobs:
   # Adding a new slow_: measure on 2+ CI runs, add to the table (with run
   # IDs), re-run LPT, and update the -E expressions below.
   #
+  # Adding a new NON-slow_ test: tests in files that have a binary() catch-all
+  # in one shard's -E expression are picked up automatically; tests in files
+  # that are only covered by individual test(=...) terms — currently
+  # archive_journeys, inbox_ui_journeys, journeys, plan_review_overlay_journeys,
+  # settings_journeys, and targets_journeys — must be pinned explicitly.
+  # The shard-coverage CI check (step "Verify shard coverage" in shard 1) will
+  # catch any new test that lands in zero shards and turn CI red.
+  #
   # Per-test averages — post-fix runs 30020688075 and 30019274329 only:
   # | Test (short form)                               | Avg(s) | slow_? |
   # |-------------------------------------------------|--------|--------|
@@ -1036,6 +1044,63 @@ jobs:
       - name: Serve frontend dist on :5173
         shell: bash
         run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+
+      # Shard-coverage integrity check (shard 1 only — runs once per push).
+      # Lists all ignored tests from the archive, then lists the union of all
+      # three shard -E expressions from the same archive, and fails if any test
+      # is uncovered. A new test added to a file with no binary() catch-all
+      # (archive_journeys, inbox_ui_journeys, journeys,
+      # plan_review_overlay_journeys, settings_journeys, targets_journeys) but
+      # not pinned in an -E expression would produce count_total > count_union,
+      # turning CI red before the test silently disappears from all shards.
+      - name: Verify shard coverage
+        if: matrix.shard == 1
+        shell: bash
+        run: |
+          SHARD1='\
+            test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | \
+            test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | \
+            test(=inbox_ui_mixed_folder_splits_into_single_type_items) | \
+            test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | \
+            test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
+          SHARD2='\
+            test(=slow_archive_lifecycle_apply_trash_permanent_delete) | \
+            test(=targets_planner_real_astronomy_after_site_creation) | \
+            test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | \
+            binary(calibration_ui_journeys) | \
+            binary(lifecycle_ui_journeys) | \
+            binary(source_view_journeys) | \
+            test(=ingestion_sessions_search) | \
+            binary(sessions_journeys) | \
+            test(=plan_review_empty_archive_plan_refuses_apply) | \
+            test(=plan_review_apply_with_audit) | \
+            test(=lifecycle_integrity)'
+          SHARD3='\
+            test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | \
+            binary(smoke) | \
+            test(=targets_ui_add_target_no_duplicate_on_reconfirm) | \
+            binary(inventory_journeys) | \
+            test(=cleanup_plan_review) | \
+            test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | \
+            test(=plan_review_destructive_confirm_gate_and_apply) | \
+            test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | \
+            binary(onboarding_journey) | \
+            binary(cleanup_protection_gate_journey) | \
+            test(=first_run_resolve_create_project) | \
+            test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | \
+            test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
+          TOTAL=$(cargo nextest list \
+            --archive-file e2e-archive.tar.zst --workspace-remap . \
+            --run-ignored all --message-format oneline 2>/dev/null | wc -l)
+          UNION=$(cargo nextest list \
+            --archive-file e2e-archive.tar.zst --workspace-remap . \
+            --run-ignored all --message-format oneline \
+            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" 2>/dev/null | wc -l)
+          echo "Total tests: ${TOTAL}, covered by shard union: ${UNION}"
+          if [ "${TOTAL}" != "${UNION}" ]; then
+            echo "::error::Shard coverage gap: ${TOTAL} tests in archive but only ${UNION} covered by the three shard filters. Add the missing test(s) to an -E expression."
+            exit 1
+          fi
 
       # Shard 1 (~104s): slow_dock_pin (81.1s) + 4 short tests.
       - name: Run E2E (shard 1/3)

--- a/crates/e2e-tests/tests/archive_journeys.rs
+++ b/crates/e2e-tests/tests/archive_journeys.rs
@@ -259,9 +259,15 @@ async fn setup_archived_project(
 /// `blockPermanentDelete` gate + real permanent delete. Running both
 /// commands sequentially against the SAME plan would have nothing left for
 /// the second call once the first really removes the files.
+///
+/// Prefixed `slow_`: two separate `setup_archived_project` fixture sequences
+/// (each involving a real app launch) plus real filesystem operations on
+/// disk. Measured 14-36s across 2 post-fix runs (avg 25.5s), above the
+/// >3× median (~21s) threshold. The `e2e.yml` shard filters pin each
+/// `slow_` test to a separate shard; see the timing table in that file.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn archive_lifecycle_apply_trash_permanent_delete() -> anyhow::Result<()> {
+async fn slow_archive_lifecycle_apply_trash_permanent_delete() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
 

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -9,6 +9,21 @@
 //! --workspace` job (ci.yml). The dedicated e2e.yml workflow runs them with
 //! `--run-ignored all` after standing that environment up.
 //!
+//! # `slow_` test naming convention
+//!
+//! Tests that take more than ~45s on Windows CI cold boots (seed-warming
+//! journeys, multiple app launches, or full reload cycles) are named with a
+//! `slow_` prefix. `e2e.yml`'s Windows shard filter expressions spread them
+//! one-per-shard so no shard accumulates two long-running tests. The shard
+//! expressions use `test(=slow_<name>)` terms pinned per shard — no
+//! `--partition` flag, which would AND with the explicit test name and exclude
+//! it if it doesn't hash to that bucket.
+//!
+//! Adding a new slow test: prefix the function with `slow_`, pick the shard
+//! with the lightest load (check `cargo nextest list -p e2e_tests
+//! --run-ignored all -E '<shardN-expr>'` counts), and add one
+//! `test(=slow_<name>)` term to that shard's `-E` expression in e2e.yml.
+//!
 //! Mechanism (mirrors `.github/workflows/e2e.yml`, research D10):
 //! - `desktop_shell` is built with `cargo build -p desktop_shell --features
 //!   e2e`, which compiles in `tauri-plugin-webdriver` (Choochmeque) — an

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -11,18 +11,22 @@
 //!
 //! # `slow_` test naming convention
 //!
-//! Tests that take more than ~45s on Windows CI cold boots (seed-warming
-//! journeys, multiple app launches, or full reload cycles) are named with a
-//! `slow_` prefix. `e2e.yml`'s Windows shard filter expressions spread them
-//! one-per-shard so no shard accumulates two long-running tests. The shard
-//! expressions use `test(=slow_<name>)` terms pinned per shard — no
-//! `--partition` flag, which would AND with the explicit test name and exclude
-//! it if it doesn't hash to that bucket.
+//! **Threshold**: prefix a test with `slow_` when its average wall time on
+//! Windows CI exceeds 3× the suite median, measured on post-fix runs only.
+//! With a current median of ~7s, the threshold is ~21s. Pre-fix timings are
+//! invalid — they measure a bug, not the test. Re-evaluate the prefix after
+//! any fix that materially changes a test's runtime.
 //!
-//! Adding a new slow test: prefix the function with `slow_`, pick the shard
-//! with the lightest load (check `cargo nextest list -p e2e_tests
-//! --run-ignored all -E '<shardN-expr>'` counts), and add one
-//! `test(=slow_<name>)` term to that shard's `-E` expression in e2e.yml.
+//! `e2e.yml`'s Windows shards use LPT (longest-processing-time first)
+//! assignment: each `slow_` test is pinned to a separate shard, non-slow
+//! tests fill the remaining slots by greedy LPT. The shard filter expressions
+//! use `test(=slow_<name>)` with no `--partition` flag — nextest ANDs
+//! `--partition` and `-E filterset`, which would exclude an explicitly named
+//! test that doesn't hash to that bucket.
+//!
+//! Adding a new slow test: rename the function with `slow_`, measure its
+//! average over 2+ post-fix CI runs, add a row to the timing table in
+//! e2e.yml, re-run LPT, and update the shard `-E` expressions there.
 //!
 //! Mechanism (mirrors `.github/workflows/e2e.yml`, research D10):
 //! - `desktop_shell` is built with `cargo build -p desktop_shell --features

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -592,14 +592,11 @@ async fn targets_ui_add_target_no_duplicate_on_reconfirm() -> anyhow::Result<()>
 /// number (`deriveRowMoonPlanning`'s real `!night` branch,
 /// `apps/desktop/src/features/targets/astro/row-planning.ts`).
 ///
-/// Prefixed `slow_`: seed-warming (adds a target via real UI before asserting)
-/// makes this take 45-90s, longer than the median journey. The `e2e.yml`
-/// shard filters spread `slow_` tests one-per-shard; see the comment block
-/// in that file for the convention.
+/// Post-fix measured time (runs 30020688075, 30019274329): 7.0s avg — below
+/// the `slow_` threshold (>3× median ≈ 21s post-fix). Not prefixed `slow_`.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn slow_targets_ui_astronomy_columns_disclose_placeholder_without_site() -> anyhow::Result<()>
-{
+async fn targets_ui_astronomy_columns_disclose_placeholder_without_site() -> anyhow::Result<()> {
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
     complete_first_run(&app).await?;
@@ -837,13 +834,12 @@ fn px(m: &serde_json::Value, key: &str) -> anyhow::Result<i64> {
 /// table never actually scrolled, every "drift == 0" assertion below would
 /// hold trivially against a static table and the test would be vacuous.
 ///
-/// Prefixed `slow_`: adds a target via real UI plus a full dock-pin + reload
-/// cycle, making this take 60-120s on Windows cold boots. The `e2e.yml`
-/// shard filters spread `slow_` tests one-per-shard; see the comment block
-/// in that file for the convention.
+/// Measured on Windows CI: 8-11s (warm), stable across runs. Not prefixed
+/// `slow_` — see `slow_targets_ui_dock_pin_and_width_survive_a_real_restart`
+/// for the convention and timing threshold.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn slow_targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow::Result<()> {
+async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow::Result<()> {
     const MIN_SCROLL: i64 = 200;
 
     let app = E2eApp::launch().await?;
@@ -1100,9 +1096,15 @@ const DRAG_PX: i64 = 140;
 /// restart is gone afterwards and a fresh one is added to give the dock
 /// something to render. That is fine here: the dock preference lives in
 /// `localStorage`, which is the thing under test.
+///
+/// Prefixed `slow_`: two full app launches plus a graceful-shutdown +
+/// WebView2 storage-flush cycle, consistently 75-88s on Windows CI
+/// (5 measured runs: 74.2, 75.0, 75.9, 78.2, 88.0s). The `e2e.yml`
+/// shard filters pin each `slow_` test to a separate shard; see the
+/// comment block in that file for the convention and rebalance procedure.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn targets_ui_dock_pin_and_width_survive_a_real_restart() -> anyhow::Result<()> {
+async fn slow_targets_ui_dock_pin_and_width_survive_a_real_restart() -> anyhow::Result<()> {
     const DEFAULT_WIDTH: i64 = 420;
 
     let app = E2eApp::launch().await?;

--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -591,9 +591,15 @@ async fn targets_ui_add_target_no_duplicate_on_reconfirm() -> anyhow::Result<()>
 /// disclosure ("—" with a real title) rather than a fabricated-looking
 /// number (`deriveRowMoonPlanning`'s real `!night` branch,
 /// `apps/desktop/src/features/targets/astro/row-planning.ts`).
+///
+/// Prefixed `slow_`: seed-warming (adds a target via real UI before asserting)
+/// makes this take 45-90s, longer than the median journey. The `e2e.yml`
+/// shard filters spread `slow_` tests one-per-shard; see the comment block
+/// in that file for the convention.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn targets_ui_astronomy_columns_disclose_placeholder_without_site() -> anyhow::Result<()> {
+async fn slow_targets_ui_astronomy_columns_disclose_placeholder_without_site() -> anyhow::Result<()>
+{
     let app = E2eApp::launch().await?;
     app.wait_bridge_ready(Duration::from_secs(30)).await?;
     complete_first_run(&app).await?;
@@ -830,9 +836,14 @@ fn px(m: &serde_json::Value, key: &str) -> anyhow::Result<i64> {
 /// it this journey would pass in the one case it most needs to catch: if the
 /// table never actually scrolled, every "drift == 0" assertion below would
 /// hold trivially against a static table and the test would be vacuous.
+///
+/// Prefixed `slow_`: adds a target via real UI plus a full dock-pin + reload
+/// cycle, making this take 60-120s on Windows cold boots. The `e2e.yml`
+/// shard filters spread `slow_` tests one-per-shard; see the comment block
+/// in that file for the convention.
 #[tokio::test]
 #[ignore = "Layer-2 real-UI journey: needs tauri-webdriver CLI + desktop_shell --features e2e + served frontend; run via e2e.yml (--run-ignored all)"]
-async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow::Result<()> {
+async fn slow_targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow::Result<()> {
     const MIN_SCROLL: i64 = 200;
 
     let app = E2eApp::launch().await?;


### PR DESCRIPTION
## Summary

- Three Windows L3 shards with LPT-balanced filterset expressions; 104s / 103s / 104s shard totals (previously 159s / 97s / 74s at 2-way hash).
- `slow_` prefix applied by measurement: tests averaging >3x suite median on post-fix CI runs. Two qualifying tests: `slow_targets_ui_dock_pin_and_width_survive_a_real_restart` (81.1s) and `slow_archive_lifecycle_apply_trash_permanent_delete` (25.5s).
- `tauri-webdriver` binary cached on all OS lanes keyed on `TAURI_WEBDRIVER_VERSION` (0.1.1); saves ~65s per shard on warm runs.

## Measured per-test durations (post-fix runs 30020688075 and 30019274329 only)

Pre-fix timings are discarded — they measured the cold-boot seed-load bug, not the test.

| Test (short form) | Avg (s) | slow_? |
|---|---|---|
| slow_dock_pin_and_width_survive_a_real_restart | 81.1 | yes |
| slow_archive_lifecycle_apply_trash_permanent_delete | 25.5 | yes |
| inbox_ui_confirm_does_not_move_..._destination | 15.3 | |
| all_top_level_screens_load | 10.3 | |
| targets_planner_real_astronomy_after_site_... | 10.2 | |
| targets_ui_add_target_no_duplicate_... | 9.1 | |
| reconcile_drops_externally_deleted_frame_... | 8.5 | |
| targets_ui_identity_columns_stay_pinned_... | 8.4 | |
| cleanup_plan_review | 8.3 | |
| calibration_ui_confirmed_master_... | 8.1 | |
| (remaining 20 tests) | 5.4–7.7 | |

Threshold: >3× median (~21s; median ~7s). astronomy_columns (7.0s) and identity_columns (8.4s) are below threshold — pre-fix cold-boot 145s times measured the bug, not these tests.

## LPT shard assignment (104s / 103s / 104s)

**Shard 1** (5 tests, ~104s): slow_dock_pin + 4 short tests
**Shard 2** (12 tests, ~103s): slow_archive + 11 mid-range tests
**Shard 3** (13 tests, ~104s): no slow_ test

Verified locally (2026-07-23, cargo-nextest 0.9.132): union = all 30 tests, no overlaps.

## Test plan

- [ ] Next main-push run: Windows shards labeled `1/3`, `2/3`, `3/3`; each completes in ~10-12 min
- [ ] Shard 1 has `slow_targets_ui_dock_pin_*`; shard 2 has `slow_archive_*`; shard 3 has no slow_ test
- [ ] Second main-push run: tauri-webdriver cache hits reduce install step from ~65s to <5s per shard
- [ ] `e2e-gate-windows` still reds when any shard fails

Merge-Bead: astro-plan-88uz
Tracks-Bead: astro-plan-behs