### PR TITLE
fix(tooling): fail-closed merge-queue watcher with main-snapshot guard

### DIFF
--- a/scripts/pv-merge-order.txt
+++ b/scripts/pv-merge-order.txt
@@ -1,0 +1,6 @@
+# PlateVault merge order, best-first. One PR number per line.
+# Re-rank whenever an unranked READY PR appears.
+# Releases and drafts are held, not ranked.
+#
+# No PR is ranked as of 2026-07-21. #1408 is merged. #1416 is intentionally
+# excluded pending a fresh owner ranking.

--- a/scripts/pv-watch-queue.sh
+++ b/scripts/pv-watch-queue.sh
@@ -105,7 +105,9 @@ printf '%s\n' \
   '   note: STUCK = a required context is absent or ambiguous.' \
   '   note: HELD = release or draft. Never rank or merge these.'
 
-mapfile -t ready_numbers < <(jq -r '.[] | select(.ready) | .number' "$classified_json" | sort -n)
+ready_numbers=()
+while IFS= read -r _num; do ready_numbers+=("$_num"); done \
+  < <(jq -r '.[] | select(.ready) | .number' "$classified_json" | sort -n)
 ranked_numbers=()
 if [[ -f "$ORDER_FILE" ]]; then
   while IFS= read -r line; do
@@ -212,7 +214,13 @@ jq -r '
 
 oldest_queued=$(jq -r '[.[] | select(.status == "queued")] | sort_by(.createdAt) | .[0].createdAt // empty' "$e2e_runs_json")
 if [[ -n "$oldest_queued" ]]; then
-  queued_epoch=$(date -u -d "$oldest_queued" +%s)
+  # GNU date uses -d; BSD/macOS date uses -j -f
+  if date --version >/dev/null 2>&1; then
+    queued_epoch=$(date -u -d "$oldest_queued" +%s)
+  else
+    queued_epoch=$(date -u -j -f "%Y-%m-%dT%H:%M:%SZ" "$oldest_queued" +%s 2>/dev/null \
+      || date -u -j -f "%Y-%m-%dT%H:%M:%S+00:00" "$oldest_queued" +%s)
+  fi
   printf '   oldest queued: %sm\n' "$((( $(date -u +%s) - queued_epoch ) / 60))"
 fi
 printf '%s\n' \

--- a/scripts/pv-watch-queue.sh
+++ b/scripts/pv-watch-queue.sh
@@ -29,6 +29,12 @@ ci_runs_json="$work_dir/ci-runs.json"
 e2e_runs_json="$work_dir/e2e-runs.json"
 merged_json="$work_dir/merged.json"
 
+main_sha=$(gh api "repos/$REPO/commits/main" --jq .sha)
+if [[ ! "$main_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  printf 'ERROR: GitHub returned an invalid main SHA: %s\n' "$main_sha" >&2
+  exit 1
+fi
+
 gh pr list -R "$REPO" --state open --base main --limit 100 \
   --json number,title,isDraft,headRefName,mergeStateStatus,statusCheckRollup >"$prs_json"
 
@@ -144,12 +150,6 @@ if ((${#unranked_ready[@]} > 0)); then
   printf '   !! UNRANKED AND READY:'
   printf ' #%s' "${unranked_ready[@]}"
   printf '\n   !! Re-rank the whole order before merging anything.\n'
-fi
-
-main_sha=$(gh api "repos/$REPO/commits/main" --jq .sha)
-if [[ ! "$main_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
-  printf 'ERROR: GitHub returned an invalid main SHA: %s\n' "$main_sha" >&2
-  exit 1
 fi
 
 gh run list -R "$REPO" --branch main --workflow CI --limit 100 \

--- a/scripts/pv-watch-queue.sh
+++ b/scripts/pv-watch-queue.sh
@@ -1,0 +1,224 @@
+#!/usr/bin/env bash
+# Read-only dashboard for the platevault/platevault merge queue.
+#
+# A PR is READY only when it is clean, is neither draft nor release automation,
+# and has exactly one accepted result for every required context. SUCCESS and
+# SKIPPED are accepted because branch protection treats both as satisfied. The
+# same classified record drives the dashboard and merge-order selection.
+set -Eeuo pipefail
+
+readonly REPO="${PV_REPO:-platevault/platevault}"
+readonly E2E_WORKFLOW="Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)"
+SCRIPT_DIR="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd -P)"
+readonly SCRIPT_DIR
+readonly ORDER_FILE="${PV_ORDER_FILE:-$SCRIPT_DIR/pv-merge-order.txt}"
+
+for command_name in gh jq date mktemp; do
+  if ! command -v "$command_name" >/dev/null 2>&1; then
+    printf 'ERROR: required command not found: %s\n' "$command_name" >&2
+    exit 127
+  fi
+done
+
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/pv-watch-queue.XXXXXX")
+trap 'rm -rf -- "$work_dir"' EXIT
+
+prs_json="$work_dir/prs.json"
+classified_json="$work_dir/classified.json"
+ci_runs_json="$work_dir/ci-runs.json"
+e2e_runs_json="$work_dir/e2e-runs.json"
+merged_json="$work_dir/merged.json"
+
+gh pr list -R "$REPO" --state open --base main --limit 100 \
+  --json number,title,isDraft,headRefName,mergeStateStatus,statusCheckRollup >"$prs_json"
+
+# A duplicate required context is ambiguous. It is not safe to guess which
+# result supersedes the other, so duplicates classify as STUCK.
+jq -e '
+  ["Detect changes (CI)",
+   "Unit + integration (L1+L2) — ubuntu-latest",
+   "Unit + integration (L1+L2) — windows-latest",
+   "UI mock-mode (Playwright)",
+   "Real-UI journeys (L3) — ubuntu-latest",
+   "Real-UI journeys (L3) — windows-latest"] as $required
+  | [ .[]
+      | . as $pr
+      | ($pr.statusCheckRollup // []) as $rollup
+      | (($pr.headRefName | test("^release-please"))
+          or ($pr.title | test("^chore(\\(.*\\))?: release"; "i"))) as $release
+      | [ $required[] as $name
+          | ($rollup | map(select(.name == $name))) as $matches
+          | if ($matches | length) == 0 then "ABSENT"
+            elif ($matches | length) > 1 then "AMBIGUOUS"
+            elif $matches[0].status != "COMPLETED" then "RUNNING"
+            elif ($matches[0].conclusion == "SUCCESS"
+                  or $matches[0].conclusion == "SKIPPED") then "OK"
+            else "FAIL"
+            end ] as $checks
+      | (($release | not)
+          and ($pr.isDraft | not)
+          and $pr.mergeStateStatus == "CLEAN"
+          and ($checks | length) == 6
+          and ($checks | all(. == "OK"))) as $ready
+      | {
+          number: $pr.number,
+          title: ($pr.title[0:52]),
+          draft: $pr.isDraft,
+          release: $release,
+          mergeState: $pr.mergeStateStatus,
+          checks: $checks,
+          done: ($checks | map(select(. == "OK")) | length),
+          ready: $ready,
+          bucket:
+            (if $release or $pr.isDraft then "HELD"
+             elif $ready then "READY"
+             elif $pr.mergeStateStatus == "DIRTY" then "CONFLICT"
+             elif ($checks | index("FAIL")) != null then "FAILING"
+             elif ($checks | index("RUNNING")) != null then "WAITING"
+             elif (($checks | index("ABSENT")) != null
+                   or ($checks | index("AMBIGUOUS")) != null) then "STUCK"
+             else "WAITING"
+             end)
+        }
+    ]
+' "$prs_json" >"$classified_json"
+
+printf '== %s ==\n' "$(date -u '+%H:%M:%SZ')"
+jq -r '
+  group_by(.bucket)
+  | sort_by(.[0].bucket as $bucket
+      | ["READY", "FAILING", "STUCK", "CONFLICT", "WAITING", "HELD"]
+      | index($bucket))
+  | .[]
+  | "-- \(.[0].bucket)  (\(length)) --",
+    (sort_by(.number) | reverse | .[]
+      | "   #\(.number)\(if .release then " [RELEASE - never merge]" elif .draft then " [draft - never merge]" else "" end)  \(.done)/6  \(.title)")
+' "$classified_json"
+
+printf '%s\n' \
+  '   note: STUCK = a required context is absent or ambiguous.' \
+  '   note: HELD = release or draft. Never rank or merge these.'
+
+mapfile -t ready_numbers < <(jq -r '.[] | select(.ready) | .number' "$classified_json" | sort -n)
+ranked_numbers=()
+if [[ -f "$ORDER_FILE" ]]; then
+  while IFS= read -r line; do
+    if [[ "$line" =~ ^[[:space:]]*([0-9]+) ]]; then
+      ranked_numbers+=("${BASH_REMATCH[1]}")
+    fi
+  done <"$ORDER_FILE"
+fi
+
+contains_number() {
+  local needle="$1"
+  shift
+  local number
+  for number in "$@"; do
+    [[ "$number" == "$needle" ]] && return 0
+  done
+  return 1
+}
+
+printf '%s\n' '-- MERGE ORDER --'
+if [[ ! -f "$ORDER_FILE" ]]; then
+  printf '   (no %s — every READY PR is unranked)\n' "$ORDER_FILE"
+fi
+
+first_ranked_ready=""
+for number in "${ranked_numbers[@]}"; do
+  if contains_number "$number" "${ready_numbers[@]}"; then
+    [[ -n "$first_ranked_ready" ]] || first_ranked_ready="$number"
+    printf '   ranked #%s  READY\n' "$number"
+  else
+    printf '   ranked #%s  (not ready or no longer open)\n' "$number"
+  fi
+done
+
+unranked_ready=()
+for number in "${ready_numbers[@]}"; do
+  if ! contains_number "$number" "${ranked_numbers[@]}"; then
+    unranked_ready+=("$number")
+  fi
+done
+if ((${#unranked_ready[@]} > 0)); then
+  printf '   !! UNRANKED AND READY:'
+  printf ' #%s' "${unranked_ready[@]}"
+  printf '\n   !! Re-rank the whole order before merging anything.\n'
+fi
+
+main_sha=$(gh api "repos/$REPO/commits/main" --jq .sha)
+if [[ ! "$main_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  printf 'ERROR: GitHub returned an invalid main SHA: %s\n' "$main_sha" >&2
+  exit 1
+fi
+
+gh run list -R "$REPO" --branch main --workflow CI --limit 100 \
+  --json headSha,status,conclusion,createdAt >"$ci_runs_json"
+gh run list -R "$REPO" --workflow "$E2E_WORKFLOW" --limit 100 \
+  --json headSha,status,conclusion,createdAt >"$e2e_runs_json"
+gh pr list -R "$REPO" --state merged --limit 100 --json mergedAt >"$merged_json"
+
+for json_file in "$ci_runs_json" "$e2e_runs_json" "$merged_json"; do
+  jq -e 'type == "array"' "$json_file" >/dev/null
+done
+
+workflow_state() {
+  local runs_file="$1"
+  jq -r --arg sha "$main_sha" '
+    [.[] | select(.headSha == $sha)] | first
+    | if . == null then "ABSENT"
+      elif .status != "completed" then "PENDING(\(.status))"
+      elif .conclusion == "success" then "SUCCESS"
+      else "FAILED(\(.conclusion // "unknown"))"
+      end
+  ' "$runs_file"
+}
+
+main_ci_state=$(workflow_state "$ci_runs_json")
+main_e2e_state=$(workflow_state "$e2e_runs_json")
+confirmed_main_sha=$(gh api "repos/$REPO/commits/main" --jq .sha)
+if [[ ! "$confirmed_main_sha" =~ ^[0-9a-fA-F]{40}$ ]]; then
+  printf 'ERROR: GitHub returned an invalid confirmation SHA: %s\n' "$confirmed_main_sha" >&2
+  exit 1
+fi
+
+printf '%s\n' '-- MERGE GATE --'
+if [[ "$confirmed_main_sha" != "$main_sha" ]]; then
+  printf '   HOLD — main moved during inspection (%s -> %s). No merge candidate.\n' \
+    "${main_sha:0:8}" "${confirmed_main_sha:0:8}"
+elif [[ "$main_ci_state" != "SUCCESS" || "$main_e2e_state" != "SUCCESS" ]]; then
+  printf '   HOLD — exact main %s is not green: CI=%s, real-UI=%s.\n' \
+    "${main_sha:0:8}" "$main_ci_state" "$main_e2e_state"
+  printf '%s\n' '          No merge candidate.'
+elif ((${#unranked_ready[@]} > 0)); then
+  printf '%s\n' '   HOLD — READY PRs are missing from the order. No merge candidate.'
+elif [[ -n "$first_ranked_ready" ]]; then
+  printf '   CLEAR — next merge is #%s\n' "$first_ranked_ready"
+  printf '%s\n' \
+    '          verify the required checks on its HEAD SHA immediately before merging.' \
+    '          Only one merge may be in flight at a time.'
+else
+  printf '%s\n' '   CLEAR — but nothing ranked is READY.'
+fi
+
+printf '%s\n' '-- E2E --'
+jq -r '
+  ([.[] | select(.status != "completed")] | length) as $pending
+  | ([.[] | select(.conclusion == "success")] | length) as $ok
+  | ([.[] | select(.conclusion == "failure")] | length) as $failed
+  | ([.[] | select(.conclusion == "cancelled")] | length) as $cancelled
+  | "   in-flight: \($pending)   recent: \($ok) ok / \($failed) fail / \($cancelled) cancelled (superseded)"
+' "$e2e_runs_json"
+
+oldest_queued=$(jq -r '[.[] | select(.status == "queued")] | sort_by(.createdAt) | .[0].createdAt // empty' "$e2e_runs_json")
+if [[ -n "$oldest_queued" ]]; then
+  queued_epoch=$(date -u -d "$oldest_queued" +%s)
+  printf '   oldest queued: %sm\n' "$((( $(date -u +%s) - queued_epoch ) / 60))"
+fi
+printf '%s\n' \
+  '   note: cancelled = superseded by an update-branch.' \
+  '         Never batch update-branch; each update cancels that branch run.'
+
+printf '%s\n' '-- main --'
+printf '   %s  CI=%s  real-UI=%s\n' "${confirmed_main_sha:0:8}" "$main_ci_state" "$main_e2e_state"
+printf '   merged today: %s\n' "$(jq --arg day "$(date -u +%Y-%m-%d)" '[.[] | select(.mergedAt[0:10] == $day)] | length' "$merged_json")"

--- a/scripts/tests/pv-watch-queue.bats
+++ b/scripts/tests/pv-watch-queue.bats
@@ -36,6 +36,9 @@ if [[ "$1" == "pr" && "$2" == "list" ]]; then
   done
   if [[ "$state" == "open" ]]; then
     [[ "${PV_TEST_FAIL_PR_LIST:-0}" != "1" ]] || exit 1
+    if [[ "${PV_TEST_MOVE_MAIN_ON_PR_LIST:-0}" == "1" ]]; then
+      : >"$TEST_ROOT/main-moved"
+    fi
     cat "$PV_TEST_PRS"
   else
     cat "$PV_TEST_MERGED"
@@ -44,7 +47,9 @@ if [[ "$1" == "pr" && "$2" == "list" ]]; then
 fi
 
 if [[ "$1" == "api" ]]; then
-  if [[ -n "${PV_TEST_MAIN_SHA_NEXT:-}" && -f "$TEST_ROOT/main-sha-read" ]]; then
+  if [[ -n "${PV_TEST_MAIN_SHA_NEXT:-}" && -f "$TEST_ROOT/main-moved" ]]; then
+    printf '%s\n' "$PV_TEST_MAIN_SHA_NEXT"
+  elif [[ -n "${PV_TEST_MAIN_SHA_NEXT:-}" && -f "$TEST_ROOT/main-sha-read" ]]; then
     printf '%s\n' "$PV_TEST_MAIN_SHA_NEXT"
   else
     : >"$TEST_ROOT/main-sha-read"
@@ -128,6 +133,10 @@ write_main_runs() {
     conclusion: (if $state == "success" then "success" elif $state == "failed" then "failure" else null end),
     createdAt: "2026-07-21T00:00:00Z"
   }]' >"$PV_TEST_E2E"
+}
+
+set_next_main_sha() {
+  export PV_TEST_MAIN_SHA_NEXT="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
 }
 
 @test "six successful required contexts produce the ranked candidate" {
@@ -215,7 +224,16 @@ write_main_runs() {
 }
 
 @test "main moving during inspection holds the gate" {
-  export PV_TEST_MAIN_SHA_NEXT="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  set_next_main_sha
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"HOLD — main moved during inspection (aaaaaaaa -> bbbbbbbb)."* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "main moving during PR listing is detected from the initial snapshot" {
+  set_next_main_sha
+  export PV_TEST_MOVE_MAIN_ON_PR_LIST=1
   run "$SCRIPT"
   [ "$status" -eq 0 ]
   [[ "$output" == *"HOLD — main moved during inspection (aaaaaaaa -> bbbbbbbb)."* ]]

--- a/scripts/tests/pv-watch-queue.bats
+++ b/scripts/tests/pv-watch-queue.bats
@@ -1,0 +1,239 @@
+#!/usr/bin/env bats
+
+setup() {
+  export TEST_ROOT
+  TEST_ROOT=$(mktemp -d)
+  export SCRIPT="$BATS_TEST_DIRNAME/../pv-watch-queue.sh"
+  export PV_ORDER_FILE="$TEST_ROOT/order.txt"
+  export PV_TEST_PRS="$TEST_ROOT/prs.json"
+  export PV_TEST_CI="$TEST_ROOT/ci.json"
+  export PV_TEST_E2E="$TEST_ROOT/e2e.json"
+  export PV_TEST_MERGED="$TEST_ROOT/merged.json"
+  export PV_TEST_MAIN_SHA="aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+  mkdir -p "$TEST_ROOT/bin"
+  export PATH="$TEST_ROOT/bin:$PATH"
+
+  printf '42\n' >"$PV_ORDER_FILE"
+  printf '[]\n' >"$PV_TEST_MERGED"
+  write_pr green false feature/test CLEAN
+  write_main_runs success success exact
+
+  write_gh_stub
+}
+
+write_gh_stub() {
+  cat >"$TEST_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "$1" == "pr" && "$2" == "list" ]]; then
+  state=""
+  for ((index = 1; index <= $#; index++)); do
+    if [[ "${!index}" == "--state" ]]; then
+      next=$((index + 1))
+      state="${!next}"
+    fi
+  done
+  if [[ "$state" == "open" ]]; then
+    [[ "${PV_TEST_FAIL_PR_LIST:-0}" != "1" ]] || exit 1
+    cat "$PV_TEST_PRS"
+  else
+    cat "$PV_TEST_MERGED"
+  fi
+  exit 0
+fi
+
+if [[ "$1" == "api" ]]; then
+  if [[ -n "${PV_TEST_MAIN_SHA_NEXT:-}" && -f "$TEST_ROOT/main-sha-read" ]]; then
+    printf '%s\n' "$PV_TEST_MAIN_SHA_NEXT"
+  else
+    : >"$TEST_ROOT/main-sha-read"
+    printf '%s\n' "$PV_TEST_MAIN_SHA"
+  fi
+  exit 0
+fi
+
+if [[ "$1" == "run" && "$2" == "list" ]]; then
+  workflow=""
+  for ((index = 1; index <= $#; index++)); do
+    if [[ "${!index}" == "--workflow" ]]; then
+      next=$((index + 1))
+      workflow="${!next}"
+    fi
+  done
+  if [[ "$workflow" == "CI" ]]; then
+    cat "$PV_TEST_CI"
+  else
+    cat "$PV_TEST_E2E"
+  fi
+  exit 0
+fi
+
+printf 'unexpected gh invocation:' >&2
+printf ' %q' "$@" >&2
+printf '\n' >&2
+exit 2
+STUB
+  chmod +x "$TEST_ROOT/bin/gh"
+}
+
+teardown() {
+  rm -rf -- "$TEST_ROOT"
+}
+
+write_pr() {
+  local mode="$1" draft="$2" branch="$3" merge_state="$4"
+  local checks
+  checks=$(jq -n '[
+    "Detect changes (CI)",
+    "Unit + integration (L1+L2) — ubuntu-latest",
+    "Unit + integration (L1+L2) — windows-latest",
+    "UI mock-mode (Playwright)",
+    "Real-UI journeys (L3) — ubuntu-latest",
+    "Real-UI journeys (L3) — windows-latest"
+  ] | map({name: ., status: "COMPLETED", conclusion: "SUCCESS"})')
+
+  case "$mode" in
+    green) ;;
+    missing) checks=$(jq '.[0:5]' <<<"$checks") ;;
+    pending) checks=$(jq '.[5].status = "IN_PROGRESS" | .[5].conclusion = null' <<<"$checks") ;;
+    failed) checks=$(jq '.[5].conclusion = "FAILURE"' <<<"$checks") ;;
+    duplicate) checks=$(jq '. + [.[0]]' <<<"$checks") ;;
+    *) return 2 ;;
+  esac
+
+  jq -n \
+    --argjson draft "$draft" \
+    --arg branch "$branch" \
+    --arg merge_state "$merge_state" \
+    --argjson checks "$checks" \
+    '[{number: 42, title: "test queue policy", isDraft: $draft,
+       headRefName: $branch, mergeStateStatus: $merge_state,
+       statusCheckRollup: $checks}]' >"$PV_TEST_PRS"
+}
+
+write_main_runs() {
+  local ci="$1" e2e="$2" sha_mode="$3"
+  local sha="$PV_TEST_MAIN_SHA"
+  [[ "$sha_mode" == exact ]] || sha="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  jq -n --arg sha "$sha" --arg state "$ci" '[{
+    headSha: $sha,
+    status: (if $state == "pending" then "in_progress" else "completed" end),
+    conclusion: (if $state == "success" then "success" elif $state == "failed" then "failure" else null end),
+    createdAt: "2026-07-21T00:00:00Z"
+  }]' >"$PV_TEST_CI"
+  jq -n --arg sha "$sha" --arg state "$e2e" '[{
+    headSha: $sha,
+    status: (if $state == "pending" then "queued" else "completed" end),
+    conclusion: (if $state == "success" then "success" elif $state == "failed" then "failure" else null end),
+    createdAt: "2026-07-21T00:00:00Z"
+  }]' >"$PV_TEST_E2E"
+}
+
+@test "six successful required contexts produce the ranked candidate" {
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- READY  (1) --"* ]]
+  [[ "$output" == *"CLEAR — next merge is #42"* ]]
+}
+
+@test "a missing required context is STUCK and never a candidate" {
+  write_pr missing false feature/test CLEAN
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- STUCK  (1) --"* ]]
+  [[ "$output" == *"CLEAR — but nothing ranked is READY."* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a pending required context is WAITING and never a candidate" {
+  write_pr pending false feature/test CLEAN
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- WAITING  (1) --"* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a failed required context is FAILING and never a candidate" {
+  write_pr failed false feature/test CLEAN
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- FAILING  (1) --"* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a draft with six successful contexts is held" {
+  write_pr green true feature/test CLEAN
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- HELD  (1) --"* ]]
+  [[ "$output" == *"[draft - never merge]"* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a release with six successful contexts is held" {
+  write_pr green false release-please--branches--main CLEAN
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- HELD  (1) --"* ]]
+  [[ "$output" == *"[RELEASE - never merge]"* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a duplicate required context fails closed as STUCK" {
+  write_pr duplicate false feature/test CLEAN
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- STUCK  (1) --"* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a dirty PR with successful checks is a conflict, not a candidate" {
+  write_pr green false feature/test DIRTY
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"-- CONFLICT  (1) --"* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a stale main workflow result holds the exact-SHA gate" {
+  write_main_runs success success stale
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"HOLD — exact main aaaaaaaa is not green: CI=ABSENT, real-UI=ABSENT."* ]]
+  [[ "$output" == *"No merge candidate."* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a pending exact-main real-UI run holds the gate" {
+  write_main_runs success pending exact
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"CI=SUCCESS, real-UI=PENDING(queued)"* ]]
+  [[ "$output" == *"No merge candidate."* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "main moving during inspection holds the gate" {
+  export PV_TEST_MAIN_SHA_NEXT="bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"HOLD — main moved during inspection (aaaaaaaa -> bbbbbbbb)."* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "an unranked READY PR holds the queue for re-ranking" {
+  printf '999\n' >"$PV_ORDER_FILE"
+  run "$SCRIPT"
+  [ "$status" -eq 0 ]
+  [[ "$output" == *"UNRANKED AND READY: #42"* ]]
+  [[ "$output" == *"HOLD — READY PRs are missing from the order."* ]]
+  [[ "$output" != *"next merge is #42"* ]]
+}
+
+@test "a GitHub API failure exits before recommending a candidate" {
+  export PV_TEST_FAIL_PR_LIST=1
+  run "$SCRIPT"
+  [ "$status" -ne 0 ]
+  [[ "$output" != *"next merge is #42"* ]]
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/pv-watch-queue.sh`: a read-only dashboard that classifies open PRs against six required CI contexts, gates on exact-main SHA, and outputs a single ranked merge candidate or a HOLD/CLEAR signal.
- Adds 14 bats scenarios covering every classification path and race-condition guard.
- Fixes `mapfile` (bash 4+) to a while/read loop and GNU `date -d` to a BSD-compat branch so the script runs on macOS bash 3.2 as well as Linux CI.

## Spec Context

A generalized version was ported to srobroek/agentic-packages PR #32 (pr-shepherd watch-queue). The local script remains operational until that package is adopted here, at which point it may be retired.

Merge-Bead: astro-plan-ldz3
Tracks-Bead: astro-plan-zfuy