### PR TITLE
fix: toggle revert and inline error when enabling a processing tool fails

### DIFF
--- a/apps/desktop/src/features/calibration/MatchCandidatesPanel.tsx
+++ b/apps/desktop/src/features/calibration/MatchCandidatesPanel.tsx
@@ -83,10 +83,6 @@ function reasonLabel(reason: MismatchReason): string {
   }
 }
 
-function _mismatchVariant(reason: MismatchReason): PillVariant {
-  return reason === 'hard_rule_violation' ? 'danger' : 'warn';
-}
-
 function confidencePct(confidence: number): string {
   return `${Math.round(confidence * 100)}%`;
 }
@@ -206,7 +202,7 @@ function AssignButton({
   sessionId: _sessionId,
   onAssign,
   assigning,
-  prefill,
+  prefill: _prefill,
 }: AssignButtonProps) {
   const [pending, setPending] = useState<
     'idle' | 'confirming' | 'override_confirm'
@@ -239,12 +235,9 @@ function AssignButton({
       return;
     }
 
-    // First click: pre-fill or prompt
-    if (prefill) {
-      setPending('confirming');
-    } else {
-      setPending('confirming');
-    }
+    // First click — always enter confirm state (prefill controls whether the
+    // panel pre-opens this button row; the confirm step is always required).
+    setPending('confirming');
   };
 
   const handleCancel = () => {

--- a/apps/desktop/src/features/settings/ProcessingTools.test.tsx
+++ b/apps/desktop/src/features/settings/ProcessingTools.test.tsx
@@ -3,7 +3,8 @@
 
 /// <reference types="@testing-library/jest-dom" />
 /**
- * ProcessingTools pane — path-edit side effects (#656, #825).
+ * ProcessingTools pane — path-edit side effects (#656, #825) and toggle
+ * rejection handling.
  *
  * Covers:
  *   1. Editing a disabled tool's path preserves `enabled: false` instead of
@@ -11,6 +12,9 @@
  *   2. A rejected path save (e.g. non-absolute path) surfaces inline instead
  *      of being lost as an unhandled promise rejection, and does not leave a
  *      stale Available/Missing pill implying the save succeeded.
+ *   3. A rejected toggle reverts `enabled` to its original value and renders
+ *      the inline error banner.
+ *   4. A successful retry after a failed toggle clears the stale error banner.
  */
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
@@ -82,5 +86,44 @@ describe('ProcessingTools — path-edit side effects', () => {
     // The stale "Available" pill from the last successful load must not be
     // left standing as if the rejected save had succeeded.
     expect(mockValidate).not.toHaveBeenCalled();
+  });
+
+  it('reverts enabled state and shows error banner when toggle update is rejected', async () => {
+    mockUpdate.mockRejectedValue(new Error('toggle failed'));
+    render(<ProcessingTools />);
+
+    const toggle = await screen.findByRole('checkbox', {
+      name: 'Enable Siril',
+    });
+    // SIRIL starts disabled (enabled: false); clicking should attempt to enable.
+    expect(toggle).not.toBeChecked();
+    fireEvent.click(toggle);
+
+    // Error banner must appear with the rejection message.
+    await waitFor(() =>
+      expect(screen.getByRole('alert')).toHaveTextContent('toggle failed'),
+    );
+    // Toggle must revert to its original unchecked state.
+    expect(toggle).not.toBeChecked();
+  });
+
+  it('clears a stale toggle error banner when the retry succeeds', async () => {
+    mockUpdate
+      .mockRejectedValueOnce(new Error('toggle failed'))
+      .mockResolvedValueOnce({ ...SIRIL, enabled: true });
+    render(<ProcessingTools />);
+
+    const toggle = await screen.findByRole('checkbox', {
+      name: 'Enable Siril',
+    });
+    // First click — rejected, banner appears.
+    fireEvent.click(toggle);
+    await waitFor(() => expect(screen.getByRole('alert')).toBeInTheDocument());
+    // Second click — succeeds; banner must clear.
+    fireEvent.click(toggle);
+    await waitFor(() =>
+      expect(screen.queryByRole('alert')).not.toBeInTheDocument(),
+    );
+    expect(toggle).toBeChecked();
   });
 });

--- a/apps/desktop/src/features/settings/ProcessingTools.tsx
+++ b/apps/desktop/src/features/settings/ProcessingTools.tsx
@@ -112,12 +112,29 @@ export function ProcessingTools() {
     async (toolId: string, enabled: boolean) => {
       const current = tools.find((t) => t.id === toolId);
       if (!current) return;
-      const updated = await toolUpdate({
-        id: toolId,
-        path: current.executablePath ?? null,
-        enabled,
-      });
-      setTools((prev) => prev.map((t) => (t.id === toolId ? updated : t)));
+      // Optimistic update so the toggle feels instant.
+      setTools((prev) =>
+        prev.map((t) => (t.id === toolId ? { ...t, enabled } : t)),
+      );
+      try {
+        const updated = await toolUpdate({
+          id: toolId,
+          path: current.executablePath ?? null,
+          enabled,
+        });
+        setTools((prev) => prev.map((t) => (t.id === toolId ? updated : t)));
+      } catch (err) {
+        // Revert the optimistic toggle and surface the error inline.
+        setTools((prev) =>
+          prev.map((t) =>
+            t.id === toolId ? { ...t, enabled: current.enabled } : t,
+          ),
+        );
+        setSaveError((e) => ({
+          ...e,
+          [toolId]: err instanceof Error ? err.message : String(err),
+        }));
+      }
     },
     [tools],
   );

--- a/apps/desktop/src/features/settings/ProcessingTools.tsx
+++ b/apps/desktop/src/features/settings/ProcessingTools.tsx
@@ -112,6 +112,13 @@ export function ProcessingTools() {
     async (toolId: string, enabled: boolean) => {
       const current = tools.find((t) => t.id === toolId);
       if (!current) return;
+      // Clear any stale error from a prior failed toggle before optimistic update.
+      setSaveError((e) => {
+        if (!(toolId in e)) return e;
+        const next = { ...e };
+        delete next[toolId];
+        return next;
+      });
       // Optimistic update so the toggle feels instant.
       setTools((prev) =>
         prev.map((t) => (t.id === toolId ? { ...t, enabled } : t)),


### PR DESCRIPTION
## Summary
- Enabling or disabling a processing tool now shows an inline error and reverts the toggle if the update fails, instead of silently leaving the UI in the wrong state.
- Dead code removed from the calibration assign flow (no behavior change).

## Spec context
- ProcessingTools: `handleToggle` — optimistic toggle + catch/revert using the same `saveError` row as path-save errors.
- MatchCandidatesPanel: collapsed identical `if (prefill) … else …` branches; removed unreferenced `_mismatchVariant` helper.

Tracks-Bead: astro-plan-kyo7.4
Merge-Bead: astro-plan-9w5e