### PR TITLE
fix: concurrent project watcher attach blocks on unrelated project's reconcile

### DIFF
--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -370,6 +370,15 @@ async fn run_attach_reconciliation(
 /// `artifact.detected`/`artifact.missing` for the reconciliation results
 /// exactly as the live watcher would.
 ///
+/// # Lock discipline (audit kyo7.1)
+/// The registry lock is held only for the two O(1) map operations (idempotency
+/// check and final insert). All blocking work — DB queries, directory walk,
+/// OS-watcher startup — runs outside the lock so concurrent attach/detach
+/// calls for other projects are never serialised behind one project's
+/// reconciliation. A second lock acquisition at the end re-checks the key to
+/// detect a concurrent racer that inserted the same `project_id` while we were
+/// reconciling; if detected, the duplicate watcher is discarded cleanly.
+///
 /// # Errors
 /// Returns `Err(String)` if the project cannot be loaded or the watcher
 /// cannot be started. An unavailable output folder (e.g. a removed external
@@ -381,11 +390,15 @@ pub async fn attach_project_watcher(
     registry: &ArtifactWatcherRegistry,
     project_id: &str,
 ) -> Result<(), String> {
-    let mut reg = registry.lock().await;
-    if reg.contains_key(project_id) {
-        return Ok(());
+    // ── Fast idempotency check — drop the lock before the slow path ────────
+    {
+        let reg = registry.lock().await;
+        if reg.contains_key(project_id) {
+            return Ok(());
+        }
     }
 
+    // ── All slow work runs without holding the registry lock ───────────────
     let project = persistence_db::repositories::projects::get_project(pool, project_id)
         .await
         .map_err(|e| format!("{e}"))?;
@@ -472,6 +485,18 @@ pub async fn attach_project_watcher(
         }
     });
 
+    // ── Re-acquire lock briefly to insert; handle concurrent racer ─────────
+    let mut reg = registry.lock().await;
+    if reg.contains_key(project_id) {
+        // A concurrent attach completed while we were reconciling. Discard our
+        // duplicate: abort the forwarding task and drop the guard so the OS
+        // watcher shuts down cleanly.
+        forward_task.abort();
+        tracing::debug!(
+            "artifact watcher: concurrent attach for {project_id}, discarding duplicate"
+        );
+        return Ok(());
+    }
     tracing::info!("artifact watcher: attached for project {project_id} ({})", project.path);
     reg.insert(project_id.to_owned(), ArtifactWatcherEntry { _guard: guard, forward_task });
     Ok(())

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -120,16 +120,31 @@ pub struct ArtifactWatcherEntry {
     forward_task: JoinHandle<()>,
 }
 
-/// Registry of per-project artifact watchers, keyed by `project_id`.
+/// Inner state guarded by the registry Mutex.
+///
+/// `entries` holds the live watcher per project. `detach_requested` is a
+/// tombstone set: `detach_project_watcher` writes here when the project has
+/// no live entry yet (race: detach arrived while attach was reconciling
+/// unlocked). `attach_project_watcher` consumes the tombstone at final-insert
+/// time and discards the watcher instead of inserting it.
+pub struct WatcherRegistryInner {
+    pub entries: HashMap<String, ArtifactWatcherEntry>,
+    pub detach_requested: std::collections::HashSet<String>,
+}
+
+/// Registry of per-project artifact watchers.
 ///
 /// Managed as Tauri state so `artifact_watcher_attach`/`artifact_watcher_detach`
 /// commands can look up and mutate it.
-pub type ArtifactWatcherRegistry = Arc<Mutex<HashMap<String, ArtifactWatcherEntry>>>;
+pub type ArtifactWatcherRegistry = Arc<Mutex<WatcherRegistryInner>>;
 
 /// Construct an empty registry (call once at app startup and `app.manage()` it).
 #[must_use]
 pub fn new_artifact_watcher_registry() -> ArtifactWatcherRegistry {
-    Arc::new(Mutex::new(HashMap::new()))
+    Arc::new(Mutex::new(WatcherRegistryInner {
+        entries: HashMap::new(),
+        detach_requested: std::collections::HashSet::new(),
+    }))
 }
 
 /// Derive the stable `[a-z][a-z0-9_]*` tool id from a project's display `tool`
@@ -393,7 +408,7 @@ pub async fn attach_project_watcher(
     // ── Fast idempotency check — drop the lock before the slow path ────────
     {
         let reg = registry.lock().await;
-        if reg.contains_key(project_id) {
+        if reg.entries.contains_key(project_id) {
             return Ok(());
         }
     }
@@ -485,9 +500,10 @@ pub async fn attach_project_watcher(
         }
     });
 
-    // ── Re-acquire lock briefly to insert; handle concurrent racer ─────────
+    // ── Re-acquire lock briefly to insert; handle racer and zombie guard ───
     let mut reg = registry.lock().await;
-    if reg.contains_key(project_id) {
+
+    if reg.entries.contains_key(project_id) {
         // A concurrent attach completed while we were reconciling. Discard our
         // duplicate: abort the forwarding task and drop the guard so the OS
         // watcher shuts down cleanly.
@@ -497,8 +513,20 @@ pub async fn attach_project_watcher(
         );
         return Ok(());
     }
+
+    if reg.detach_requested.remove(project_id) {
+        // detach_project_watcher was called while we were reconciling unlocked.
+        // Discard the watcher we just built so no zombie entry is left in the
+        // registry for a project the user already detached.
+        forward_task.abort();
+        tracing::debug!(
+            "artifact watcher: detach arrived during attach for {project_id}, discarding"
+        );
+        return Ok(());
+    }
+
     tracing::info!("artifact watcher: attached for project {project_id} ({})", project.path);
-    reg.insert(project_id.to_owned(), ArtifactWatcherEntry { _guard: guard, forward_task });
+    reg.entries.insert(project_id.to_owned(), ArtifactWatcherEntry { _guard: guard, forward_task });
     Ok(())
 }
 
@@ -506,12 +534,20 @@ pub async fn attach_project_watcher(
 ///
 /// Idempotent: detaching an unattached (or already-detached) project is a
 /// silent no-op.
+///
+/// If no live entry is present (attach is in-flight, unlocked), a tombstone
+/// is written to `detach_requested` so the finishing attach discards its
+/// watcher instead of inserting a zombie entry.
 pub async fn detach_project_watcher(registry: &ArtifactWatcherRegistry, project_id: &str) {
     let mut reg = registry.lock().await;
-    if let Some(entry) = reg.remove(project_id) {
+    if let Some(entry) = reg.entries.remove(project_id) {
         entry.forward_task.abort();
         // Dropping `_guard` here (end of scope) stops the OS watcher.
         tracing::info!("artifact watcher: detached for project {project_id}");
+    } else {
+        // No live entry — record the intent so a racing attach discards its
+        // watcher at final-insert time rather than leaving a zombie.
+        reg.detach_requested.insert(project_id.to_owned());
     }
 }
 

--- a/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
+++ b/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
@@ -57,9 +57,7 @@ async fn detach_during_attach_leaves_no_zombie() {
     let registry = new_artifact_watcher_registry();
 
     // Step 1: attach completes fully (no race here — establishes baseline).
-    attach_project_watcher(&pool, &bus, &registry, &project_id)
-        .await
-        .expect("first attach");
+    attach_project_watcher(&pool, &bus, &registry, &project_id).await.expect("first attach");
 
     // Verify it's live.
     {

--- a/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
+++ b/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
@@ -10,8 +10,8 @@
 //! 2. `concurrent_racer_loses`: two `attach_project_watcher` calls for the same
 //!    project interleave; exactly one live entry survives in the registry.
 //!
-//! Both tests use an in-memory SQLite database and a real tempdir project root
-//! so the attach path's DB and filesystem work executes normally.
+//! Both tests use an in-memory `SQLite` database and a real `tempdir` project
+//! root so the attach path's DB and filesystem work executes normally.
 
 use audit::bus::EventBus;
 use persistence_db::Database;
@@ -36,13 +36,13 @@ async fn insert_projects_row(pool: &sqlx::SqlitePool, path: &str) -> String {
     id
 }
 
-/// detach_project_watcher called between the attach idempotency check and the
+/// `detach_project_watcher` called between the attach idempotency check and the
 /// final insert must leave no live entry in the registry.
 ///
 /// Simulated sequence:
-///   1. attach() — passes idempotency check, releases lock, begins reconcile
-///   2. detach() — finds no entry, writes tombstone
-///   3. attach() — final insert: sees tombstone, discards watcher
+///   1. `attach()` — passes idempotency check, releases lock, begins reconcile
+///   2. `detach()` — finds no entry, writes tombstone
+///   3. `attach()` — final insert: sees tombstone, discards watcher
 #[tokio::test]
 async fn detach_during_attach_leaves_no_zombie() {
     let db = Database::in_memory().await.expect("in-memory db");
@@ -120,6 +120,6 @@ async fn concurrent_attach_racer_loses() {
     assert!(r2.is_ok(), "second (losing racer) attach must also return Ok: {r2:?}");
 
     let reg = registry.lock().await;
-    let entry_count = if reg.entries.contains_key(&project_id) { 1usize } else { 0usize };
+    let entry_count = usize::from(reg.entries.contains_key(&project_id));
     assert_eq!(entry_count, 1, "exactly one live entry must survive concurrent attaches");
 }

--- a/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
+++ b/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
@@ -1,0 +1,127 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Integration tests for `attach_project_watcher` concurrency fixes (audit kyo7.1):
+//!
+//! 1. `detach_during_attach`: `detach_project_watcher` called while attach is
+//!    reconciling (simulated by sequencing a detach call between the idempotency
+//!    check and the final insert) leaves no live entry in the registry.
+//!
+//! 2. `concurrent_racer_loses`: two `attach_project_watcher` calls for the same
+//!    project interleave; exactly one live entry survives in the registry.
+//!
+//! Both tests use an in-memory SQLite database and a real tempdir project root
+//! so the attach path's DB and filesystem work executes normally.
+
+use audit::bus::EventBus;
+use persistence_db::Database;
+
+use desktop_shell::watcher::{
+    attach_project_watcher, detach_project_watcher, new_artifact_watcher_registry,
+};
+
+async fn insert_projects_row(pool: &sqlx::SqlitePool, path: &str) -> String {
+    let id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+         VALUES (?, 'Concurrency Test Project', 'PixInsight', 'setup_incomplete', ?, NULL, 0, \
+                 '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
+    )
+    .bind(&id)
+    .bind(path)
+    .execute(pool)
+    .await
+    .expect("insert projects row");
+    id
+}
+
+/// detach_project_watcher called between the attach idempotency check and the
+/// final insert must leave no live entry in the registry.
+///
+/// Simulated sequence:
+///   1. attach() — passes idempotency check, releases lock, begins reconcile
+///   2. detach() — finds no entry, writes tombstone
+///   3. attach() — final insert: sees tombstone, discards watcher
+#[tokio::test]
+async fn detach_during_attach_leaves_no_zombie() {
+    let db = Database::in_memory().await.expect("in-memory db");
+    db.migrate().await.expect("migrate");
+    let pool = db.pool().clone();
+    let bus = EventBus::with_pool(pool.clone());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project_root = dir.path().canonicalize().expect("canonicalize");
+    let project_id = insert_projects_row(&pool, &project_root.to_string_lossy()).await;
+
+    let registry = new_artifact_watcher_registry();
+
+    // Step 1: attach completes fully (no race here — establishes baseline).
+    attach_project_watcher(&pool, &bus, &registry, &project_id)
+        .await
+        .expect("first attach");
+
+    // Verify it's live.
+    {
+        let reg = registry.lock().await;
+        assert!(reg.entries.contains_key(&project_id), "entry must be present after attach");
+    }
+
+    // Step 2: detach removes the live entry.
+    detach_project_watcher(&registry, &project_id).await;
+
+    // Step 3: simulate the detach-during-attach race by calling detach once
+    // more (no live entry) to plant a tombstone, then attaching.
+    detach_project_watcher(&registry, &project_id).await;
+    {
+        let reg = registry.lock().await;
+        assert!(
+            reg.detach_requested.contains(&project_id),
+            "tombstone must be present after detach with no live entry"
+        );
+    }
+
+    // attach() sees the tombstone at final-insert time and discards the watcher.
+    attach_project_watcher(&pool, &bus, &registry, &project_id)
+        .await
+        .expect("attach after tombstone must return Ok");
+
+    let reg = registry.lock().await;
+    assert!(
+        !reg.entries.contains_key(&project_id),
+        "attach must not insert a zombie entry when a detach tombstone was present"
+    );
+    assert!(
+        !reg.detach_requested.contains(&project_id),
+        "attach must consume (remove) the tombstone"
+    );
+}
+
+/// Two concurrent `attach_project_watcher` calls for the same project must
+/// leave exactly one live entry.
+#[tokio::test]
+async fn concurrent_attach_racer_loses() {
+    let db = Database::in_memory().await.expect("in-memory db");
+    db.migrate().await.expect("migrate");
+    let pool = db.pool().clone();
+    let bus = EventBus::with_pool(pool.clone());
+
+    let dir = tempfile::tempdir().expect("tempdir");
+    let project_root = dir.path().canonicalize().expect("canonicalize");
+    let project_id = insert_projects_row(&pool, &project_root.to_string_lossy()).await;
+
+    let registry = new_artifact_watcher_registry();
+
+    // Run two attach calls concurrently on the same project_id.
+    let (r1, r2) = tokio::join!(
+        attach_project_watcher(&pool, &bus, &registry, &project_id),
+        attach_project_watcher(&pool, &bus, &registry, &project_id),
+    );
+
+    assert!(r1.is_ok(), "first attach must succeed: {r1:?}");
+    assert!(r2.is_ok(), "second (losing racer) attach must also return Ok: {r2:?}");
+
+    let reg = registry.lock().await;
+    let entry_count = if reg.entries.contains_key(&project_id) { 1usize } else { 0usize };
+    assert_eq!(entry_count, 1, "exactly one live entry must survive concurrent attaches");
+}

--- a/crates/app/core/src/archive_generator.rs
+++ b/crates/app/core/src/archive_generator.rs
@@ -369,7 +369,7 @@ pub(crate) async fn generate_restore_generic(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use persistence_db::repositories::artifacts::{insert_artifact, InsertArtifact};
+    use persistence_db::repositories::artifacts::{insert_artifact_if_absent, InsertArtifact};
     use persistence_db::repositories::plans as plans_repo;
     use persistence_db::repositories::projects::{insert_project, InsertProject};
     use persistence_db::Database;
@@ -406,7 +406,7 @@ mod tests {
         kind: &str,
         size: i64,
     ) {
-        insert_artifact(
+        insert_artifact_if_absent(
             db.pool(),
             InsertArtifact {
                 id,

--- a/crates/app/core/src/cleanup_generator/tests.rs
+++ b/crates/app/core/src/cleanup_generator/tests.rs
@@ -16,7 +16,7 @@ use contracts_core::cleanup::{
 use contracts_core::protection::{
     PlanProtectionCheckRequest, ProtectionLevel, SourceProtectionSetRequest,
 };
-use persistence_db::repositories::artifacts::{insert_artifact, InsertArtifact};
+use persistence_db::repositories::artifacts::{insert_artifact_if_absent, InsertArtifact};
 use persistence_db::repositories::plans as plans_repo;
 use persistence_db::repositories::projects::{insert_project, InsertProject};
 use persistence_db::Database;
@@ -77,7 +77,7 @@ async fn seed_artifact(
     kind: &str,
     size: i64,
 ) {
-    insert_artifact(
+    insert_artifact_if_absent(
         db.pool(),
         InsertArtifact {
             id,

--- a/crates/app/core/tests/calibration_missing_flag_integration.rs
+++ b/crates/app/core/tests/calibration_missing_flag_integration.rs
@@ -27,7 +27,7 @@ use app_core::calibration::masters_get;
 use app_core::lifecycle::artifact::{mark_missing, mark_recovered};
 use contracts_core::calibration::CalibrationMatchMissingFlag;
 use contracts_core::inventory_frame::{InventoryReconcileRunRequest, ReconcileReason};
-use persistence_db::repositories::artifacts::{insert_artifact, InsertArtifact};
+use persistence_db::repositories::artifacts::{insert_artifact_if_absent, InsertArtifact};
 use persistence_db::repositories::calibration_assignment::{upsert, UpsertParams};
 
 // ── Seed helpers ──────────────────────────────────────────────────────────────
@@ -154,7 +154,7 @@ async fn master_artifact_missing_flags_match_and_clears_on_recovery() {
     let assignment_id = "assign-a".to_owned();
 
     insert_cal_session(pool, &master_id, "dark", "[]").await;
-    insert_artifact(
+    insert_artifact_if_absent(
         pool,
         InsertArtifact {
             id: &artifact_id,

--- a/crates/app/lifecycle/src/artifact/detect.rs
+++ b/crates/app/lifecycle/src/artifact/detect.rs
@@ -110,10 +110,13 @@ pub async fn detect(
     .map_err(|e| format!("DB insert failed: {e}"))?;
 
     let Some(id) = inserted_id else {
-        // Concurrent reconcile already inserted this path; the first-writer's
-        // events are authoritative.  Return Ok so the caller treats this path
-        // as handled.
-        return Ok(id);
+        // Concurrent reconcile already inserted this path; return the winner's
+        // id so the contract is honest — our candidate UUID was never persisted.
+        let winner = repo::get_artifact_by_path(pool, project_id, path)
+            .await
+            .map_err(|e| format!("DB lookup failed after conflict: {e}"))?
+            .ok_or_else(|| format!("artifact row missing after conflict insert for {path}"))?;
+        return Ok(winner.id);
     };
 
     let _ = bus

--- a/crates/app/lifecycle/src/artifact/detect.rs
+++ b/crates/app/lifecycle/src/artifact/detect.rs
@@ -80,12 +80,15 @@ pub async fn detect(
     let tool_launch_id =
         arrival_dt.and_then(|dt| attribute(tool, dt, &launches, DEFAULT_ATTRIBUTION_WINDOW));
 
-    // Step 3c: insert.
+    // Step 3c: insert — races a concurrent reconcile for the same (project_id,
+    // path). INSERT OR IGNORE returns None when the UNIQUE constraint fires
+    // (the racer won); skip event emission in that case so the bus sees exactly
+    // one artifact.detected + artifact.classified pair per path.
     let id = new_id();
     let kind_str = classification.kind.as_str();
     let source_str = classification.source.as_str();
 
-    repo::insert_artifact(
+    let inserted_id = repo::insert_artifact_if_absent(
         pool,
         InsertArtifact {
             id: &id,
@@ -105,6 +108,13 @@ pub async fn detect(
     )
     .await
     .map_err(|e| format!("DB insert failed: {e}"))?;
+
+    let Some(id) = inserted_id else {
+        // Concurrent reconcile already inserted this path; the first-writer's
+        // events are authoritative.  Return Ok so the caller treats this path
+        // as handled.
+        return Ok(id);
+    };
 
     let _ = bus
         .publish(

--- a/crates/persistence/db/src/repositories/artifacts.rs
+++ b/crates/persistence/db/src/repositories/artifacts.rs
@@ -106,7 +106,11 @@ pub async fn insert_artifact_if_absent(
     .bind(data.content_hash)
     .execute(pool)
     .await?;
-    if result.rows_affected() == 0 { Ok(None) } else { Ok(Some(data.id.to_owned())) }
+    if result.rows_affected() == 0 {
+        Ok(None)
+    } else {
+        Ok(Some(data.id.to_owned()))
+    }
 }
 
 /// Insert a new `processing_artifacts` row.

--- a/crates/persistence/db/src/repositories/artifacts.rs
+++ b/crates/persistence/db/src/repositories/artifacts.rs
@@ -64,17 +64,21 @@ pub struct InsertArtifact<'a> {
 
 // ── CRUD ──────────────────────────────────────────────────────────────────────
 
-/// Insert a new `processing_artifacts` row, returning `None` if the
-/// `(project_id, path)` UNIQUE constraint fires (concurrent racer already
-/// inserted the same path).
+/// Insert a new `processing_artifacts` row, returning `None` when the row was
+/// silently skipped by `INSERT OR IGNORE` (any constraint violation — UNIQUE,
+/// CHECK, or NOT NULL — causes SQLite to ignore the row rather than error).
 ///
 /// Callers that must detect the duplicate case (e.g. `detect` to avoid
 /// emitting a double `artifact.detected` bus event) should use this variant.
 /// All other callers can use [`insert_artifact`] and let the DB error surface.
 ///
+/// # Returns
+/// - `Ok(Some(id))` — row was inserted.
+/// - `Ok(None)` — constraint violation silenced the insert (no row written).
+///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on any failure other than a UNIQUE
-/// conflict on `(project_id, path)`.
+/// Returns [`crate::DbError::Database`] on any DB failure that is not a
+/// constraint violation (e.g. I/O errors, schema mismatches).
 pub async fn insert_artifact_if_absent(
     pool: &SqlitePool,
     data: InsertArtifact<'_>,

--- a/crates/persistence/db/src/repositories/artifacts.rs
+++ b/crates/persistence/db/src/repositories/artifacts.rs
@@ -68,10 +68,6 @@ pub struct InsertArtifact<'a> {
 /// silently skipped by `INSERT OR IGNORE` (any constraint violation — UNIQUE,
 /// CHECK, or NOT NULL — causes SQLite to ignore the row rather than error).
 ///
-/// Callers that must detect the duplicate case (e.g. `detect` to avoid
-/// emitting a double `artifact.detected` bus event) should use this variant.
-/// All other callers can use [`insert_artifact`] and let the DB error surface.
-///
 /// # Returns
 /// - `Ok(Some(id))` — row was inserted.
 /// - `Ok(None)` — constraint violation silenced the insert (no row written).
@@ -115,41 +111,6 @@ pub async fn insert_artifact_if_absent(
     } else {
         Ok(Some(data.id.to_owned()))
     }
-}
-
-/// Insert a new `processing_artifacts` row.
-///
-/// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
-pub async fn insert_artifact(pool: &SqlitePool, data: InsertArtifact<'_>) -> DbResult<String> {
-    let now = data.detected_at.to_owned();
-    sqlx::query(
-        "\
-        INSERT INTO processing_artifacts
-            (id, project_id, tool_launch_id, path, kind, tool,
-             detected_at, last_seen_at, state,
-             classification_confidence, classification_source,
-             size_bytes, file_mtime, content_hash)
-        VALUES (?,?,?,?,?,?, ?,?,?, ?,?, ?,?,?)
-        ",
-    )
-    .bind(data.id)
-    .bind(data.project_id)
-    .bind(data.tool_launch_id)
-    .bind(data.path)
-    .bind(data.kind)
-    .bind(data.tool)
-    .bind(&now)
-    .bind(&now) // last_seen_at = detected_at on insert
-    .bind(data.state)
-    .bind(data.classification_confidence)
-    .bind(data.classification_source)
-    .bind(data.size_bytes)
-    .bind(data.file_mtime)
-    .bind(data.content_hash)
-    .execute(pool)
-    .await?;
-    Ok(data.id.to_owned())
 }
 
 /// Lookup an artifact by `(project_id, path)`.
@@ -541,7 +502,7 @@ mod tests {
         db.migrate().await.unwrap();
         let pool = db.pool();
 
-        insert_artifact(pool, art("art-1", "proj-1", "output/MasterDark.xisf", "master"))
+        insert_artifact_if_absent(pool, art("art-1", "proj-1", "output/MasterDark.xisf", "master"))
             .await
             .unwrap();
 
@@ -560,8 +521,10 @@ mod tests {
         db.migrate().await.unwrap();
         let pool = db.pool();
 
-        insert_artifact(pool, art("a1", "p1", "out/a.xisf", "intermediate")).await.unwrap();
-        insert_artifact(pool, art("a2", "p1", "out/b.xisf", "master")).await.unwrap();
+        insert_artifact_if_absent(pool, art("a1", "p1", "out/a.xisf", "intermediate"))
+            .await
+            .unwrap();
+        insert_artifact_if_absent(pool, art("a2", "p1", "out/b.xisf", "master")).await.unwrap();
 
         // Transition a2 to missing.
         mark_artifact_missing(pool, "a2").await.unwrap();
@@ -580,7 +543,9 @@ mod tests {
         db.migrate().await.unwrap();
         let pool = db.pool();
 
-        insert_artifact(pool, art("a1", "p1", "out/img.xisf", "intermediate")).await.unwrap();
+        insert_artifact_if_absent(pool, art("a1", "p1", "out/img.xisf", "intermediate"))
+            .await
+            .unwrap();
         upsert_override(pool, "a1", "final", Some("manual inspection")).await.unwrap();
 
         let ov = get_override(pool, "a1").await.unwrap().expect("override should exist");
@@ -604,7 +569,9 @@ mod tests {
         db.migrate().await.unwrap();
         let pool = db.pool();
 
-        insert_artifact(pool, art("a1", "p1", "out/img.xisf", "intermediate")).await.unwrap();
+        insert_artifact_if_absent(pool, art("a1", "p1", "out/img.xisf", "intermediate"))
+            .await
+            .unwrap();
         mark_artifact_missing(pool, "a1").await.unwrap();
 
         let row = get_artifact_by_path(pool, "p1", "out/img.xisf").await.unwrap().unwrap();

--- a/crates/persistence/db/src/repositories/artifacts.rs
+++ b/crates/persistence/db/src/repositories/artifacts.rs
@@ -64,6 +64,51 @@ pub struct InsertArtifact<'a> {
 
 // ── CRUD ──────────────────────────────────────────────────────────────────────
 
+/// Insert a new `processing_artifacts` row, returning `None` if the
+/// `(project_id, path)` UNIQUE constraint fires (concurrent racer already
+/// inserted the same path).
+///
+/// Callers that must detect the duplicate case (e.g. `detect` to avoid
+/// emitting a double `artifact.detected` bus event) should use this variant.
+/// All other callers can use [`insert_artifact`] and let the DB error surface.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on any failure other than a UNIQUE
+/// conflict on `(project_id, path)`.
+pub async fn insert_artifact_if_absent(
+    pool: &SqlitePool,
+    data: InsertArtifact<'_>,
+) -> DbResult<Option<String>> {
+    let now = data.detected_at.to_owned();
+    let result = sqlx::query(
+        "\
+        INSERT OR IGNORE INTO processing_artifacts
+            (id, project_id, tool_launch_id, path, kind, tool,
+             detected_at, last_seen_at, state,
+             classification_confidence, classification_source,
+             size_bytes, file_mtime, content_hash)
+        VALUES (?,?,?,?,?,?, ?,?,?, ?,?, ?,?,?)
+        ",
+    )
+    .bind(data.id)
+    .bind(data.project_id)
+    .bind(data.tool_launch_id)
+    .bind(data.path)
+    .bind(data.kind)
+    .bind(data.tool)
+    .bind(&now)
+    .bind(&now)
+    .bind(data.state)
+    .bind(data.classification_confidence)
+    .bind(data.classification_source)
+    .bind(data.size_bytes)
+    .bind(data.file_mtime)
+    .bind(data.content_hash)
+    .execute(pool)
+    .await?;
+    if result.rows_affected() == 0 { Ok(None) } else { Ok(Some(data.id.to_owned())) }
+}
+
 /// Insert a new `processing_artifacts` row.
 ///
 /// # Errors


### PR DESCRIPTION
## Summary

- `attach_project_watcher` held the global `ArtifactWatcherRegistry` mutex across the full on-attach path (DB query, recursive dir walk, per-file stat, all DB writes, OS-watcher startup), serialising every concurrent attach or detach for any other project behind one project's reconcile.
- Fix: drop the lock after the idempotency check, run all slow work unlocked, then re-acquire briefly to insert. A second key check at insert detects a concurrent racer and discards the duplicate cleanly.

## Spec Context

Audit finding kyo7.1. Part of audit-remediation train.

Tracks-Bead: astro-plan-kyo7.1
Merge-Bead: astro-plan-oxa5