### PR TITLE
fix: optimistic store writes now roll back on backend failure

### DIFF
--- a/apps/desktop/src/features/targets/guidance-settings.test.ts
+++ b/apps/desktop/src/features/targets/guidance-settings.test.ts
@@ -105,6 +105,52 @@ describe('saveGuidanceParams (live propagation, SC-008)', () => {
     });
     expect(getGuidanceParams().L).toEqual({ distanceDeg: 100, widthDays: 12 });
   });
+
+  it('restores the pre-write value when the backend write rejects', async () => {
+    settingsUpdate.mockRejectedValue(new Error('backend unavailable'));
+    const original = getGuidanceParams();
+    const next = {
+      ...DEFAULT_MOON_AVOIDANCE,
+      L: { distanceDeg: 100, widthDays: 12 },
+    };
+
+    await expect(saveGuidanceParams(next)).rejects.toThrow(
+      'backend unavailable',
+    );
+
+    // The optimistic update must be rolled back.
+    expect(getGuidanceParams().L).toEqual(original.L);
+  });
+
+  it('does not roll back when a newer write has committed after the failing one', async () => {
+    let rejectFirst!: (e: unknown) => void;
+    settingsUpdate
+      .mockReturnValueOnce(
+        new Promise<null>((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+      )
+      .mockResolvedValueOnce(null);
+
+    const first = {
+      ...DEFAULT_MOON_AVOIDANCE,
+      L: { distanceDeg: 90, widthDays: 8 },
+    };
+    const second = {
+      ...DEFAULT_MOON_AVOIDANCE,
+      L: { distanceDeg: 120, widthDays: 14 },
+    };
+
+    const firstWrite = saveGuidanceParams(first);
+    // Second write commits before the first backend call resolves.
+    await saveGuidanceParams(second);
+    expect(getGuidanceParams().L).toEqual({ distanceDeg: 120, widthDays: 14 });
+
+    rejectFirst(new Error('stale failure'));
+    await expect(firstWrite).rejects.toThrow('stale failure');
+    // Second write's state must not be reverted.
+    expect(getGuidanceParams().L).toEqual({ distanceDeg: 120, widthDays: 14 });
+  });
 });
 
 describe('loadGuidanceParams vs saveGuidanceParams race (#836)', () => {

--- a/apps/desktop/src/features/targets/guidance-settings.ts
+++ b/apps/desktop/src/features/targets/guidance-settings.ts
@@ -125,19 +125,35 @@ export async function loadGuidanceParams(): Promise<MoonAvoidanceParams> {
 /**
  * Persist a new per-band params set and update the live cache so dependent
  * pills/recommendations recompute immediately (SC-008).
+ *
+ * The cache is updated optimistically before the backend round-trip so pill
+ * recalculation and recommendations reflect the change immediately (SC-008
+ * instant-derivation). On backend failure the pre-change snapshot is restored
+ * so the UI and DB stay consistent; a stale rollback is suppressed if a newer
+ * write has since committed (writeGen guard).
  */
 export async function saveGuidanceParams(
   params: MoonAvoidanceParams,
 ): Promise<void> {
   const clean = coerceParams(params);
+  const prev = current;
   writeGen += 1;
-  unwrap(
-    await commands.settingsUpdate(PLANNER_SCOPE, {
-      [MOON_AVOIDANCE_KEY]: clean,
-    }),
-  );
+  const gen = writeGen;
   current = clean;
   emit();
+  try {
+    unwrap(
+      await commands.settingsUpdate(PLANNER_SCOPE, {
+        [MOON_AVOIDANCE_KEY]: clean,
+      }),
+    );
+  } catch (err) {
+    if (writeGen === gen) {
+      current = prev;
+      emit();
+    }
+    throw err;
+  }
 }
 
 /**

--- a/apps/desktop/src/features/targets/observing-sites/site-store.race.test.ts
+++ b/apps/desktop/src/features/targets/observing-sites/site-store.race.test.ts
@@ -144,3 +144,39 @@ describe('loadObservingState vs saveSites race', () => {
     expect(getObservingState().activeSiteId).toBe(SITE.id);
   });
 });
+
+describe('saveUsableAltitude backend-failure rollback', () => {
+  it('restores the pre-write value when the backend write rejects', async () => {
+    __setObservingStateForTest({ usableAltitudeDeg: 20 });
+    settingsUpdate.mockRejectedValue(new Error('backend unavailable'));
+
+    await expect(saveUsableAltitude(55)).rejects.toThrow('backend unavailable');
+
+    // The optimistic update must be rolled back.
+    expect(getUsableAltitude()).toBe(20);
+  });
+
+  it('does not roll back when a newer write has committed after the failing one', async () => {
+    __setObservingStateForTest({ usableAltitudeDeg: 20 });
+
+    let rejectFirst!: (e: unknown) => void;
+    settingsUpdate
+      .mockReturnValueOnce(
+        new Promise<null>((_resolve, reject) => {
+          rejectFirst = reject;
+        }),
+      )
+      .mockResolvedValueOnce(null);
+
+    // First write (will fail) starts optimistically at 55...
+    const firstWrite = saveUsableAltitude(55);
+    // ...then a second write commits at 60.
+    await saveUsableAltitude(60);
+    expect(getUsableAltitude()).toBe(60);
+
+    // The first write's backend call now rejects — must not roll back 60.
+    rejectFirst(new Error('stale failure'));
+    await expect(firstWrite).rejects.toThrow('stale failure');
+    expect(getUsableAltitude()).toBe(60);
+  });
+});

--- a/apps/desktop/src/features/targets/observing-sites/site-store.ts
+++ b/apps/desktop/src/features/targets/observing-sites/site-store.ts
@@ -177,17 +177,31 @@ export async function saveActiveSiteId(
  * Settings-pane edits reflect instantly (SC-003) rather than waiting on IPC
  * latency; the backend write still happens (durability, SC-006), it just
  * isn't gating the UI update.
+ *
+ * On backend failure the snapshot is restored so the UI and DB stay
+ * consistent; a stale rollback is suppressed if a newer write has since
+ * committed (writeGen guard).
  */
 export async function saveUsableAltitude(degrees: number): Promise<void> {
   const clamped = clampThreshold(degrees);
+  const prev = current;
   writeGen += 1;
+  const gen = writeGen;
   current = { ...current, usableAltitudeDeg: clamped };
   emit();
-  unwrap(
-    await commands.settingsUpdate(OBSERVING_SCOPE, {
-      [USABLE_ALTITUDE_KEY]: clamped,
-    }),
-  );
+  try {
+    unwrap(
+      await commands.settingsUpdate(OBSERVING_SCOPE, {
+        [USABLE_ALTITUDE_KEY]: clamped,
+      }),
+    );
+  } catch (err) {
+    if (writeGen === gen) {
+      current = prev;
+      emit();
+    }
+    throw err;
+  }
 }
 
 /** Non-hook read of the current cached state (comparators, tests). */


### PR DESCRIPTION
## Summary

- `saveUsableAltitude` and `saveGuidanceParams` applied optimistic cache updates with no recovery on IPC error, leaving the UI and DB silently diverged.
- Both functions now snapshot the pre-change value before the optimistic emit, then restore it on backend failure; the `writeGen` guard prevents a stale rollback from overwriting a newer committed write.

## Spec Context

spec 044 / spec 047 — site-store and guidance-settings write paths.

Tracks-Bead: astro-plan-kyo7.5
Merge-Bead: astro-plan-rgvu