### PR TITLE
fix: consolidate duplicate CSS selectors in component stylesheets

### DIFF
--- a/apps/desktop/src/styles/components/app-shell.css
+++ b/apps/desktop/src/styles/components/app-shell.css
@@ -89,13 +89,14 @@
 .pv-sidebar__brand-name {
   font-size: var(--pv-text-md); font-weight: var(--pv-weight-semibold);
   white-space: nowrap; overflow: hidden; text-overflow: ellipsis;
+  flex: 1; flex-shrink: 0;
 }
 .pv-sidebar__collapse {
   width: 24px; height: 24px; border: none; background: none;
   cursor: pointer; color: var(--pv-text-muted);
   border-radius: var(--pv-radius-sm);
   display: flex; align-items: center; justify-content: center;
-  flex-shrink: 0;
+  flex-shrink: 0; margin-left: auto;
 }
 .pv-sidebar__collapse:hover { background: var(--pv-hover-bg); }
 .pv-sidebar__nav { flex: 1; padding: var(--pv-sp-1) 0; overflow-y: auto; }
@@ -142,12 +143,7 @@
   color: var(--pv-on-accent); font-size: var(--pv-text-xs); font-weight: var(--pv-weight-semibold);
   display: flex; align-items: center; justify-content: center; flex-shrink: 0;
 }
-/* #962: flex-shrink:0 — the product wordmark must never be the element that
-   concedes space under flex pressure; the version chip (below) is the
-   lower-priority sibling that can shrink first if the row is ever tight. */
-.pv-sidebar__brand-name { flex: 1; flex-shrink: 0; }
 .pv-sidebar__version { font-size: var(--pv-text-xs); color: var(--pv-text-faint); }
-.pv-sidebar__collapse { margin-left: auto; }
 .pv-sidebar__group { padding-bottom: var(--pv-sp-1); }
 .pv-sidebar__group-label {
   font-size: var(--pv-text-xs); font-weight: var(--pv-weight-semibold);

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -182,8 +182,9 @@
 
 .pv-calib-detail {
   display: grid;
-  /* Facts compact (fixed-ish), matches take the rest. */
-  grid-template-columns: var(--pv-rail-width) minmax(0, 1fr);
+  /* Facts compact (fixed-ish), matches take the rest.
+   * Overridden below by calib-compact merge: 0.9fr/1.1fr column ratio. */
+  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
   gap: var(--pv-sp-5);
   align-items: start;
   margin-top: var(--pv-sp-3);
@@ -227,9 +228,6 @@
  * the wide-short bottom panel without inner scroll. Must follow the
  * calibration-detail.css block above so the .pv-calib-detail column override
  * wins on source order. */
-.pv-calib-detail {
-  grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
-}
 .pv-calib-kvgrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
@@ -355,6 +353,9 @@
 .pv-targets-table__scroll .pv-targets-table thead th:nth-child(2),
 .pv-targets-table__scroll .pv-targets-table .pv-targets-table__row > td:nth-child(2) {
   left: var(--pv-targets-star-w);
+  /* Seam marking: box-shadow tracks the sticky cell; border-right would detach
+     under border-collapse. */
+  box-shadow: 1px 0 0 var(--pv-border-subtle);
 }
 
 /* Layering: pinned header corner > pinned body cells > sticky header > rest.
@@ -385,15 +386,6 @@
   .pv-targets-table__row--selected
   > td:nth-child(-n + 2) {
   background: var(--pv-accent-bg);
-}
-
-/* Seam marking where the pinned region ends, drawn with box-shadow rather than
-   border-right: `.pv-table` is `border-collapse: collapse`, where borders
-   belong to the table rather than the cell and detach from sticky cells while
-   scrolling. A shadow is painted by the cell and tracks it exactly. */
-.pv-targets-table__scroll .pv-targets-table thead th:nth-child(2),
-.pv-targets-table__scroll .pv-targets-table .pv-targets-table__row > td:nth-child(2) {
-  box-shadow: 1px 0 0 var(--pv-border-subtle);
 }
 
 /* The windowed body's height is set inline (getTotalSize) so the scrollbar
@@ -474,6 +466,9 @@
  * the detail sits to the RIGHT of the full-width primary content as a fixed,
  * full-height column with its own scroll. */
 .pv-listpage__body--side {
+  /* Fixed side-panel width token (scoped here so --pv-side-detail-w resolves
+     on the element that uses it in .pv-listpage__detail--side). */
+  --pv-side-detail-w: 420px;
   flex-direction: row;
 }
 
@@ -486,11 +481,6 @@
   align-self: stretch;
   border-top: none;
   border-left: 1px solid var(--pv-border);
-}
-
-/* Fixed side-panel width token (kept local to this block). */
-.pv-listpage__body--side {
-  --pv-side-detail-w: 420px;
 }
 
 /* ── Projects-detail structure for the side column ───────────────────────────

--- a/apps/desktop/src/styles/components/merges-2.css
+++ b/apps/desktop/src/styles/components/merges-2.css
@@ -182,8 +182,7 @@
 
 .pv-calib-detail {
   display: grid;
-  /* Facts compact (fixed-ish), matches take the rest.
-   * Overridden below by calib-compact merge: 0.9fr/1.1fr column ratio. */
+  /* Facts compact (fixed-ish, ~0.9fr), matches take the rest (1.1fr). */
   grid-template-columns: minmax(0, 0.9fr) minmax(0, 1.1fr);
   gap: var(--pv-sp-5);
   align-items: start;
@@ -225,9 +224,8 @@
 /* === merged from .cssblocks/calib-compact.css (spec-043, task #97) ===
  * Compact the master fingerprint: flow the fingerprint + reuse KV pairs into a
  * 2-column grid and widen the facts column so the whole calibration detail fits
- * the wide-short bottom panel without inner scroll. Must follow the
- * calibration-detail.css block above so the .pv-calib-detail column override
- * wins on source order. */
+ * the wide-short bottom panel without inner scroll.
+ * (.pv-calib-detail column ratio absorbed into the base block above.) */
 .pv-calib-kvgrid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/desktop/src/styles/components/merges-3.css
+++ b/apps/desktop/src/styles/components/merges-3.css
@@ -353,7 +353,7 @@
 
 /* Column widths (task 044; re-sized iteration 2026-07-15 FR-032) — fixed
    layout prevents per-page shift. Imaging time fits "2h10m" + why-glyph. */
-.pv-targets-col--lunardist { width: 6%; }
+.pv-targets-col--lunardist { width: 6.5%; }
 .pv-targets-col--filters   { width: 18%; }
 .pv-targets-col--imagingtime { width: 10%; }
 
@@ -407,7 +407,7 @@
 .pv-filter-badges {
   display: inline-flex;
   flex-wrap: wrap;
-  gap: var(--pv-sp-1);
+  gap: var(--pv-sp-2);
   align-items: center;
 }
 
@@ -778,10 +778,7 @@
  * Filter badges run together — increase gap from sp-1 to sp-2.
  * These override the values set in the spec 044 block in components.css. */
 
-.pv-targets-col--lunardist  { width: 6.5%; }
-
-/* task 5: add readable spacing between filter badges (was pv-sp-1 = 4px). */
-.pv-filter-badges { gap: var(--pv-sp-2); }
+/* task 5: lunardist width (6.5%) + filter-badge gap (sp-2) applied at first occurrence above. */
 
 /* task 19 sparkline CSS removed (iteration 2026-07-15, FR-007 hard removal). */
 

--- a/apps/desktop/src/styles/components/redesign-detail.css
+++ b/apps/desktop/src/styles/components/redesign-detail.css
@@ -681,10 +681,13 @@
 
 .pv-inbox-inspector__label {
   font-size: var(--pv-text-xs);
-  font-weight: var(--pv-weight-semibold);
-  color: var(--pv-text-muted);
+  font-weight: var(--pv-weight-medium);
+  color: var(--pv-text-faint);
   letter-spacing: var(--pv-tracking-normal);
   text-transform: uppercase;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 
 .pv-inbox-inspector__filename {
@@ -814,14 +817,6 @@
 }
 .pv-inbox-inspector__row:hover {
   background: var(--pv-surface);
-}
-.pv-inbox-inspector__label {
-  font-size: var(--pv-text-xs);
-  color: var(--pv-text-faint);
-  font-weight: var(--pv-weight-medium);
-  white-space: nowrap;
-  overflow: hidden;
-  text-overflow: ellipsis;
 }
 .pv-inbox-inspector__value {
   font-size: var(--pv-text-xs);

--- a/apps/desktop/src/styles/components/settings-detail.css
+++ b/apps/desktop/src/styles/components/settings-detail.css
@@ -211,31 +211,12 @@
   gap: var(--pv-sp-3);
 }
 
-/* Individual root card */
-.pv-data-sources__root-card {
-  border: 1px solid var(--pv-border);
-  border-radius: var(--pv-radius-md);
-  padding: var(--pv-sp-3);
-}
-
-/* Offline root — dimmed surface */
-.pv-data-sources__root-card--offline {
-  background: var(--pv-bg3);
-}
-
 /* Card header row: path + pills */
 .pv-data-sources__root-header {
   display: flex;
   align-items: flex-start;
   gap: var(--pv-sp-2);
   flex-wrap: wrap;
-}
-
-/* Path code element */
-.pv-data-sources__root-path {
-  flex: 1;
-  font-size: var(--pv-text-xs);
-  word-break: break-all;
 }
 
 /* Pills group */
@@ -312,7 +293,7 @@
 
 /* Monospace path text */
 .pv-data-sources__root-path {
-
+  flex: 1;
   font-size: var(--pv-text-xs);
   color: var(--pv-text);
   word-break: break-all;


### PR DESCRIPTION
## Summary

- Merges 11 duplicate selector blocks across 5 component CSS files into their first occurrence; no rendered output changes.

Tracks-Bead: astro-plan-kyo7.6
Merge-Bead: astro-plan-zei7