### PR TITLE
fix: drop redundant clones in app_core and persistence_db

### DIFF
--- a/crates/app/core/src/inventory.rs
+++ b/crates/app/core/src/inventory.rs
@@ -64,7 +64,7 @@ pub async fn list(
     // Registered equipment, loaded once for the whole ledger: every root's
     // rows resolve their raw header camera against the same set.
     let cameras =
-        app_core_calibration::equipment::list_cameras(pool).await.map_err(|e| e.message.clone())?;
+        app_core_calibration::equipment::list_cameras(pool).await.map_err(|e| e.message)?;
 
     let mut sources: Vec<InventorySource> = Vec::new();
 

--- a/crates/app/core/src/plan_apply/paths.rs
+++ b/crates/app/core/src/plan_apply/paths.rs
@@ -103,7 +103,7 @@ pub(super) fn check_overlap_and_register(
     }
 
     registry.insert(plan_id.to_owned(), run);
-    Ok(ActiveRunGuard { registry: registry.clone(), plan_id: plan_id.to_owned() })
+    Ok(ActiveRunGuard { registry, plan_id: plan_id.to_owned() })
 }
 
 // ── Approval token verification (A1) ─────────────────────────────────────────

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -288,7 +288,8 @@ pub async fn launch(
     let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref());
 
     // ── Step 4: canonicalize cwd + library-root containment check ────────────
-    let canonical_cwd = working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());
+    let canonical_cwd =
+        working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());
     let all_roots = inv_repo::list_all_roots(pool).await.map_err(|e| format!("{e}"))?;
     // Roots added through the setup wizard live in `registered_sources` (the
     // gen-3 source model) and are only mirrored into the legacy `library_root`

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -288,7 +288,7 @@ pub async fn launch(
     let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref());
 
     // ── Step 4: canonicalize cwd + library-root containment check ────────────
-    let canonical_cwd = working_dir_path.canonicalize().unwrap_or(working_dir_path.clone());
+    let canonical_cwd = working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());
     let all_roots = inv_repo::list_all_roots(pool).await.map_err(|e| format!("{e}"))?;
     // Roots added through the setup wizard live in `registered_sources` (the
     // gen-3 source model) and are only mirrored into the legacy `library_root`

--- a/crates/persistence/db/src/repositories/source_protection.rs
+++ b/crates/persistence/db/src/repositories/source_protection.rs
@@ -176,7 +176,7 @@ pub async fn resolve_protection(
             Some(v) => v != 0,
         };
         return Ok(ResolvedProtection {
-            level: row.level.clone(),
+            level: row.level,
             block_permanent_delete: bpd,
             categories: effective_cats,
             inherits_default: false,


### PR DESCRIPTION
## Summary

- `tool_launch.rs`: defer `PathBuf` clone to the `unwrap_or` fallback path only
- `inventory.rs`: remove `.clone()` on an owned `String` field in `map_err`
- `plan_apply/paths.rs`: move owned `Arc` registry into `ActiveRunGuard` instead of cloning
- `source_protection.rs`: move `row.level` (last use of owned row) instead of cloning

Tracks-Bead: astro-plan-kyo7.9
Merge-Bead: astro-plan-h648