### PR TITLE
refactor: deduplicate repository test fixtures in persistence_db

### DIFF
--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -27,6 +27,10 @@ pub mod operation_state;
 /// `docs/development/persistence-layer-hardening.md`.
 #[cfg(test)]
 mod query_builder_example;
+/// Shared in-process test fixtures (setup, insert helpers) for repository unit
+/// tests. Compiled only under `cfg(test)`.
+#[cfg(test)]
+pub(crate) mod test_support;
 pub mod repositories;
 mod schema_cache;
 

--- a/crates/persistence/db/src/lib.rs
+++ b/crates/persistence/db/src/lib.rs
@@ -27,12 +27,12 @@ pub mod operation_state;
 /// `docs/development/persistence-layer-hardening.md`.
 #[cfg(test)]
 mod query_builder_example;
+pub mod repositories;
+mod schema_cache;
 /// Shared in-process test fixtures (setup, insert helpers) for repository unit
 /// tests. Compiled only under `cfg(test)`.
 #[cfg(test)]
 pub(crate) mod test_support;
-pub mod repositories;
-mod schema_cache;
 
 pub const CRATE_NAME: &str = "persistence_db";
 

--- a/crates/persistence/db/src/repositories/framing.rs
+++ b/crates/persistence/db/src/repositories/framing.rs
@@ -337,32 +337,7 @@ pub async fn set_session_geometry(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
-
-    async fn insert_project(pool: &SqlitePool, id: &str) {
-        sqlx::query(
-            "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
-             VALUES (?,?,?,?,?,?,?,?,?)",
-        )
-        .bind(id)
-        .bind(format!("Project {id}"))
-        .bind("PixInsight")
-        .bind("ready")
-        .bind(format!("projects/{id}"))
-        .bind::<Option<String>>(None)
-        .bind(false)
-        .bind("2026-01-01T00:00:00Z")
-        .bind("2026-01-01T00:00:00Z")
-        .execute(pool)
-        .await
-        .unwrap();
-    }
+    use crate::test_support::{insert_project, setup_db};
 
     async fn insert_acquisition_session(pool: &SqlitePool, id: &str) {
         sqlx::query(
@@ -395,7 +370,7 @@ mod tests {
 
     #[tokio::test]
     async fn project_is_mosaic_defaults_to_false() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-mosaic-default").await;
 
         let is_mosaic: bool = sqlx::query_scalar("SELECT is_mosaic FROM projects WHERE id = ?")
@@ -410,7 +385,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_and_get_framing_round_trips() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-1").await;
 
         insert_framing(db.pool(), &insert_data("framing-1", "proj-1")).await.unwrap();
@@ -426,14 +401,14 @@ mod tests {
 
     #[tokio::test]
     async fn get_framing_not_found_for_unknown_id() {
-        let db = setup().await;
+        let db = setup_db().await;
         let err = get_framing(db.pool(), "missing").await.unwrap_err();
         assert!(matches!(err, DbError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn list_framings_by_project_returns_only_that_projects_framings() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-a").await;
         insert_project(db.pool(), "proj-b").await;
 
@@ -448,7 +423,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_framings_by_optic_train_key_returns_only_matching_rows_across_projects() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-a").await;
         insert_project(db.pool(), "proj-b").await;
 
@@ -473,7 +448,7 @@ mod tests {
 
     #[tokio::test]
     async fn membership_add_list_remove_round_trips() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-m").await;
         insert_acquisition_session(db.pool(), "sess-1").await;
         insert_acquisition_session(db.pool(), "sess-2").await;
@@ -497,7 +472,7 @@ mod tests {
 
     #[tokio::test]
     async fn a_session_belongs_to_at_most_one_framing() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-u").await;
         insert_acquisition_session(db.pool(), "sess-u").await;
         insert_framing(db.pool(), &insert_data("framing-u1", "proj-u")).await.unwrap();
@@ -515,7 +490,7 @@ mod tests {
 
     #[tokio::test]
     async fn update_framing_clustering_flips_to_user_adjusted() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-c").await;
         insert_framing(db.pool(), &insert_data("framing-c", "proj-c")).await.unwrap();
 
@@ -527,7 +502,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_framing_cascades_memberships() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_project(db.pool(), "proj-d").await;
         insert_acquisition_session(db.pool(), "sess-d").await;
         insert_framing(db.pool(), &insert_data("framing-d", "proj-d")).await.unwrap();
@@ -544,7 +519,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_framing_missing_id_is_not_an_error() {
-        let db = setup().await;
+        let db = setup_db().await;
         delete_framing(db.pool(), "no-such-framing").await.unwrap();
     }
 
@@ -552,7 +527,7 @@ mod tests {
 
     #[tokio::test]
     async fn new_session_has_null_geometry_until_populated() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_acquisition_session(db.pool(), "sess-legacy").await;
 
         let geo = get_session_geometry(db.pool(), "sess-legacy").await.unwrap().unwrap();
@@ -570,7 +545,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_session_geometry_round_trips_and_preserves_none_fields() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_acquisition_session(db.pool(), "sess-confirmed").await;
 
         set_session_geometry(
@@ -593,7 +568,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_session_geometry_returns_none_for_unknown_session() {
-        let db = setup().await;
+        let db = setup_db().await;
         let geo = get_session_geometry(db.pool(), "missing").await.unwrap();
         assert!(geo.is_none());
     }

--- a/crates/persistence/db/src/repositories/inventory.rs
+++ b/crates/persistence/db/src/repositories/inventory.rs
@@ -563,24 +563,18 @@ pub async fn get_file_record_lookup(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     #[tokio::test]
     async fn list_roots_with_sessions_returns_empty_initially() {
-        let db = setup().await;
+        let db = setup_db().await;
         let roots = list_roots_with_sessions(db.pool()).await.unwrap();
         assert!(roots.is_empty(), "expected no roots with sessions on a fresh db");
     }
 
     #[tokio::test]
     async fn list_sessions_for_root_returns_empty_on_unknown_root() {
-        let db = setup().await;
+        let db = setup_db().await;
         let filters = InventoryFilters::default();
         let sessions =
             list_sessions_for_root(db.pool(), "00000000-0000-0000-0000-000000000000", &filters)
@@ -591,14 +585,14 @@ mod tests {
 
     #[tokio::test]
     async fn project_links_empty_for_empty_session_ids() {
-        let db = setup().await;
+        let db = setup_db().await;
         let links = list_project_links_for_sessions(db.pool(), &[]).await.unwrap();
         assert!(links.is_empty());
     }
 
     #[tokio::test]
     async fn project_links_for_sessions_returns_matching_rows_filtered_by_id_set() {
-        let db = setup().await;
+        let db = setup_db().await;
 
         sqlx::query(
             "INSERT INTO projects (id, name, tool, path, created_at, updated_at) VALUES \
@@ -640,7 +634,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_library_root_state_returns_none_for_unknown() {
-        let db = setup().await;
+        let db = setup_db().await;
         let result = get_library_root_state(db.pool(), "00000000-0000-0000-0000-000000000000")
             .await
             .unwrap();
@@ -651,14 +645,14 @@ mod tests {
 
     #[tokio::test]
     async fn session_context_empty_ids_returns_empty_without_querying() {
-        let db = setup().await;
+        let db = setup_db().await;
         let rows = get_session_context_by_ids(db.pool(), &[]).await.unwrap();
         assert!(rows.is_empty());
     }
 
     #[tokio::test]
     async fn session_context_batches_multiple_ids_in_one_call() {
-        let db = setup().await;
+        let db = setup_db().await;
 
         sqlx::query(
             "INSERT INTO canonical_target
@@ -716,7 +710,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_context_falls_back_to_primary_designation_without_display_alias() {
-        let db = setup().await;
+        let db = setup_db().await;
 
         sqlx::query(
             "INSERT INTO canonical_target
@@ -744,7 +738,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_session_notes_updates_acquisition_session() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
              VALUES ('acq-notes', 'k', '[]', '2026-01-01T00:00:00Z')",
@@ -767,7 +761,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_session_notes_updates_calibration_session() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO calibration_session (id, session_key, frame_ids, kind, created_at) \
              VALUES ('cal-notes', 'k', '[]', 'dark', '2026-01-01T00:00:00Z')",
@@ -790,7 +784,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_session_notes_clears_with_none() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at, notes) \
              VALUES ('acq-clear', 'k', '[]', '2026-01-01T00:00:00Z', 'old note')",
@@ -811,7 +805,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_session_notes_unknown_id_updates_nothing() {
-        let db = setup().await;
+        let db = setup_db().await;
         let updated = set_session_notes(db.pool(), "no-such-session", Some("x")).await.unwrap();
         assert!(!updated);
     }
@@ -820,14 +814,14 @@ mod tests {
 
     #[tokio::test]
     async fn calibration_matches_empty_for_empty_ids() {
-        let db = setup().await;
+        let db = setup_db().await;
         let rows = list_calibration_matches_for_sessions(db.pool(), &[]).await.unwrap();
         assert!(rows.is_empty());
     }
 
     #[tokio::test]
     async fn calibration_matches_batches_multiple_sessions() {
-        let db = setup().await;
+        let db = setup_db().await;
 
         sqlx::query(
             "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \

--- a/crates/persistence/db/src/repositories/manifests.rs
+++ b/crates/persistence/db/src/repositories/manifests.rs
@@ -155,31 +155,13 @@ pub async fn get_manifest(pool: &SqlitePool, manifest_id: &str) -> DbResult<Mani
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::insert_project;
     use sqlx::SqlitePool;
 
     async fn setup() -> SqlitePool {
         let pool = SqlitePool::connect("sqlite::memory:").await.unwrap();
         sqlx::migrate!("./migrations").run(&pool).await.unwrap();
         pool
-    }
-
-    async fn insert_project(pool: &SqlitePool, id: &str) {
-        sqlx::query(
-            "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
-             VALUES (?,?,?,?,?,?,?,?,?)",
-        )
-        .bind(id)
-        .bind("Test")
-        .bind("PixInsight")
-        .bind("ready")
-        .bind("projects/test")
-        .bind::<Option<String>>(None)
-        .bind(false)
-        .bind("2026-01-01T00:00:00Z")
-        .bind("2026-01-01T00:00:00Z")
-        .execute(pool)
-        .await
-        .unwrap();
     }
 
     #[tokio::test]

--- a/crates/persistence/db/src/repositories/plans.rs
+++ b/crates/persistence/db/src/repositories/plans.rs
@@ -512,13 +512,7 @@ pub async fn update_item_fs_snapshot(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     fn sample_plan(id: &str) -> InsertPlan<'_> {
         InsertPlan {
@@ -535,7 +529,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_and_get_plan_roundtrip() {
-        let db = setup().await;
+        let db = setup_db().await;
         let number = insert_plan(db.pool(), &sample_plan("plan-1")).await.unwrap();
         assert_eq!(number, 1);
 
@@ -549,7 +543,7 @@ mod tests {
 
     #[tokio::test]
     async fn chosen_framing_id_defaults_to_none_and_round_trips() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("plan-attr")).await.unwrap();
         assert_eq!(get_chosen_framing_id(db.pool(), "plan-attr").await.unwrap(), None);
 
@@ -579,7 +573,7 @@ mod tests {
 
     #[tokio::test]
     async fn display_numbers_increment() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("plan-a")).await.unwrap();
         insert_plan(db.pool(), &sample_plan("plan-b")).await.unwrap();
         let row_b = get_plan(db.pool(), "plan-b", false).await.unwrap();
@@ -588,14 +582,14 @@ mod tests {
 
     #[tokio::test]
     async fn get_plan_not_found_returns_error() {
-        let db = setup().await;
+        let db = setup_db().await;
         let err = get_plan(db.pool(), "nonexistent", false).await.unwrap_err();
         assert!(matches!(err, DbError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn soft_delete_sets_discarded_state() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("plan-x")).await.unwrap();
         soft_delete_plan(db.pool(), "plan-x", "2026-06-01T00:00:00Z").await.unwrap();
 
@@ -611,7 +605,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_plans_excludes_discarded_by_default() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("p1")).await.unwrap();
         insert_plan(db.pool(), &sample_plan("p2")).await.unwrap();
         soft_delete_plan(db.pool(), "p2", "2026-06-01T00:00:00Z").await.unwrap();
@@ -623,7 +617,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_plans_with_state_filter() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("p1")).await.unwrap();
         insert_plan(db.pool(), &sample_plan("p2")).await.unwrap();
         // Update p2 to ready_for_review.
@@ -636,7 +630,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_plan_item_updates_counters() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("p1")).await.unwrap();
 
         let item = InsertPlanItem {
@@ -666,7 +660,7 @@ mod tests {
 
     #[tokio::test]
     async fn confirm_plan_destructive_items_confirms_only_destructive_actions() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("p-confirm")).await.unwrap();
 
         let move_item = InsertPlanItem {
@@ -728,7 +722,7 @@ mod tests {
 
     #[tokio::test]
     async fn failed_first_ordering() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_plan(db.pool(), &sample_plan("p-draft")).await.unwrap();
         insert_plan(db.pool(), &sample_plan("p-failed")).await.unwrap();
         update_plan_state(db.pool(), "p-failed", "failed").await.unwrap();

--- a/crates/persistence/db/src/repositories/prepared_source_views.rs
+++ b/crates/persistence/db/src/repositories/prepared_source_views.rs
@@ -233,17 +233,11 @@ pub async fn update_item_observed_state(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     #[tokio::test]
     async fn insert_and_get_view_roundtrip() {
-        let db = setup().await;
+        let db = setup_db().await;
         // Need a project row first.
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at)
@@ -269,7 +263,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_removed_sets_state_and_timestamp() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at)
              VALUES ('proj-2', 'Test2', 'PixInsight', 'ready', 'projects/test2', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
@@ -294,7 +288,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_items_and_list() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at)
              VALUES ('proj-3', 'Test3', 'PixInsight', 'ready', 'projects/test3', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
@@ -343,14 +337,14 @@ mod tests {
 
     #[tokio::test]
     async fn get_view_not_found() {
-        let db = setup().await;
+        let db = setup_db().await;
         let err = get_view(db.pool(), "nonexistent").await.unwrap_err();
         assert!(matches!(err, DbError::NotFound(_)));
     }
 
     #[tokio::test]
     async fn list_views_for_project_returns_all() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at)
              VALUES ('proj-4', 'Test4', 'PixInsight', 'ready', 'projects/test4', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",
@@ -384,7 +378,7 @@ mod tests {
     /// dead-end `kind_diverged` state on every reopen.
     #[tokio::test]
     async fn migrate_does_not_flip_mixed_kind_views_to_kind_diverged() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at)
              VALUES ('proj-5', 'Test5', 'PixInsight', 'ready', 'projects/test5', '2026-01-01T00:00:00Z', '2026-01-01T00:00:00Z')",

--- a/crates/persistence/db/src/repositories/project_notes.rs
+++ b/crates/persistence/db/src/repositories/project_notes.rs
@@ -112,24 +112,7 @@ mod tests {
         pool
     }
 
-    async fn insert_project(pool: &SqlitePool, id: &str) {
-        sqlx::query(
-            "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
-             VALUES (?,?,?,?,?,?,?,?,?)",
-        )
-        .bind(id)
-        .bind("Test")
-        .bind("PixInsight")
-        .bind("ready")
-        .bind("projects/test")
-        .bind::<Option<String>>(None)
-        .bind(false)
-        .bind("2026-01-01T00:00:00Z")
-        .bind("2026-01-01T00:00:00Z")
-        .execute(pool)
-        .await
-        .unwrap();
-    }
+    use crate::test_support::insert_project;
 
     #[tokio::test]
     async fn upsert_note_creates_new_row() {

--- a/crates/persistence/db/src/repositories/q_core.rs
+++ b/crates/persistence/db/src/repositories/q_core.rs
@@ -682,17 +682,11 @@ pub async fn session_history(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     #[tokio::test]
     async fn frame_ids_absent_session_returns_none() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert!(get_acquisition_session_frame_ids(db.pool(), "no-such").await.unwrap().is_none());
         assert!(get_calibration_session_frame_ids_and_kind(db.pool(), "no-such")
             .await
@@ -702,14 +696,14 @@ mod tests {
 
     #[tokio::test]
     async fn file_records_by_ids_empty_short_circuits() {
-        let db = setup().await;
+        let db = setup_db().await;
         let rows = file_records_by_ids(db.pool(), &[]).await.unwrap();
         assert!(rows.is_empty());
     }
 
     #[tokio::test]
     async fn active_frame_summary_empty_ids_short_circuits() {
-        let db = setup().await;
+        let db = setup_db().await;
         let (count, total) = active_frame_summary(db.pool(), &[]).await.unwrap();
         assert_eq!((count, total), (0, 0));
     }
@@ -717,7 +711,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::float_cmp)] // 0.0 is exactly representable; no accumulated arithmetic
     async fn active_frame_exposure_seconds_empty_ids_short_circuits() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert_eq!(active_frame_exposure_seconds(db.pool(), &[]).await.unwrap(), 0.0);
     }
 
@@ -780,7 +774,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::float_cmp)] // seeded SUM of exact literal inputs; no rounding involved
     async fn active_frame_exposure_seconds_sums_real_per_frame_values() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_frame_with_exposure(db.pool(), "f-a", "root-x", "a.fits", "classified", 180.0).await;
         insert_frame_with_exposure(db.pool(), "f-b", "root-x", "b.fits", "classified", 180.0).await;
 
@@ -793,7 +787,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::float_cmp)] // seeded SUM of exact literal inputs; no rounding involved
     async fn active_frame_exposure_seconds_excludes_missing_frames() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_frame_with_exposure(db.pool(), "f-present", "root-y", "p.fits", "classified", 300.0)
             .await;
         insert_frame_with_exposure(db.pool(), "f-gone", "root-y", "g.fits", "missing", 9999.0)
@@ -811,7 +805,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::float_cmp)] // 0.0 is exactly representable; no accumulated arithmetic
     async fn active_frame_exposure_seconds_defaults_to_zero_without_metadata() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
              VALUES ('root-z', 'root-z', '/tmp', 'local', 'active', datetime('now'))",
@@ -844,7 +838,7 @@ mod tests {
     #[tokio::test]
     #[allow(clippy::float_cmp)] // exact literal input, no rounding involved
     async fn active_frame_exposure_seconds_collapses_duplicate_inbox_item_fan_out() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
              VALUES ('root-dup', 'root-dup', '/tmp', 'local', 'active', datetime('now'))",
@@ -893,7 +887,7 @@ mod tests {
 
     #[tokio::test]
     async fn mark_file_record_missing_updates_state() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO library_root (id, label, current_path, kind, state, created_at) \
              VALUES ('root-1', 'root-1', '/tmp', 'local', 'active', datetime('now'))",
@@ -919,7 +913,7 @@ mod tests {
 
     #[tokio::test]
     async fn search_and_recent_targets_roundtrip() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO canonical_target
                 (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at) \
@@ -940,7 +934,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_and_get_session_joined_roundtrip() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query(
             "INSERT INTO acquisition_session (id, session_key, frame_ids, created_at) \
              VALUES ('s-1', '{}', '[]', '2026-01-01T00:00:00Z')",
@@ -960,7 +954,7 @@ mod tests {
 
     #[tokio::test]
     async fn project_ids_for_session_empty_when_unlinked() {
-        let db = setup().await;
+        let db = setup_db().await;
         let ids = project_ids_for_session(db.pool(), "no-such").await.unwrap();
         assert!(ids.is_empty());
     }

--- a/crates/persistence/db/src/repositories/q_desktop.rs
+++ b/crates/persistence/db/src/repositories/q_desktop.rs
@@ -168,17 +168,11 @@ pub use super::q_targets_mgmt::get_resolver_settings_online as get_resolver_sett
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     #[tokio::test]
     async fn status_counts_are_zero_on_fresh_db() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert_eq!(count_unacknowledged_inbox_items(db.pool()).await.unwrap(), 0);
         assert_eq!(count_acquisition_sessions(db.pool()).await.unwrap(), 0);
         assert_eq!(count_calibration_masters(db.pool()).await.unwrap(), 0);
@@ -188,7 +182,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolver_settings_seeded_by_migration_0031() {
-        let db = setup().await;
+        let db = setup_db().await;
         let row = get_resolver_settings(db.pool()).await.unwrap().expect("seeded singleton row");
         assert_eq!(row.online_enabled, 1, "default online_enabled per migration 0031");
         assert_eq!(row.request_timeout_secs, 10, "default request_timeout_secs");
@@ -218,7 +212,7 @@ mod tests {
 
     #[tokio::test]
     async fn inbox_master_item_round_trips() {
-        let db = setup().await;
+        let db = setup_db().await;
         let root_id = register_test_root(db.pool()).await;
         insert_inbox_master_item(
             db.pool(),

--- a/crates/persistence/db/src/repositories/q_targets_mgmt.rs
+++ b/crates/persistence/db/src/repositories/q_targets_mgmt.rs
@@ -249,25 +249,7 @@ pub async fn insert_resolution_audit(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
-
-    async fn insert_target(pool: &SqlitePool, id: &str) {
-        sqlx::query(
-            "INSERT INTO canonical_target
-             (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
-             VALUES (?, NULL, 'Test Target', 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
-        )
-        .bind(id)
-        .execute(pool)
-        .await
-        .expect("insert_target failed");
-    }
+    use crate::test_support::{insert_target, setup_db};
 
     async fn insert_alias(pool: &SqlitePool, id: &str, target_id: &str, alias: &str, kind: &str) {
         sqlx::query(
@@ -287,7 +269,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolver_settings_seeded_row_is_readable() {
-        let db = setup().await;
+        let db = setup_db().await;
         let row = get_resolver_settings(db.pool()).await.unwrap();
         assert!(row.is_some(), "migration 0031 seeds the singleton row");
 
@@ -297,7 +279,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolver_settings_upsert_round_trips() {
-        let db = setup().await;
+        let db = setup_db().await;
         upsert_resolver_settings(db.pool(), 0, "https://example.test/tap", 500, 20).await.unwrap();
 
         let row = get_resolver_settings(db.pool()).await.unwrap().unwrap();
@@ -311,7 +293,7 @@ mod tests {
 
     #[tokio::test]
     async fn target_exists_true_and_false() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-001").await;
         assert!(target_exists(db.pool(), "t-001").await.unwrap());
         assert!(!target_exists(db.pool(), "t-missing").await.unwrap());
@@ -319,7 +301,7 @@ mod tests {
 
     #[tokio::test]
     async fn list_target_aliases_orders_by_alias_asc() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-001").await;
         insert_alias(db.pool(), "a-1", "t-001", "Zeta", "user").await;
         insert_alias(db.pool(), "a-2", "t-001", "Alpha", "user").await;
@@ -332,7 +314,7 @@ mod tests {
 
     #[tokio::test]
     async fn get_alias_kind_scopes_by_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-001").await;
         insert_target(db.pool(), "t-002").await;
         insert_alias(db.pool(), "a-1", "t-001", "Alpha", "user").await;
@@ -349,7 +331,7 @@ mod tests {
 
     #[tokio::test]
     async fn session_counts_by_target_prefers_legacy_and_falls_back_to_canonical() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "canon-1").await;
         sqlx::query(
             "INSERT INTO target (id, primary_designation, created_at)
@@ -401,7 +383,7 @@ mod tests {
     /// so the two read paths can never disagree about which target owns it.
     #[tokio::test]
     async fn session_counts_by_target_prefers_legacy_target_id_when_both_columns_set() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "canon-both").await;
         sqlx::query(
             "INSERT INTO target (id, primary_designation, created_at)
@@ -441,7 +423,7 @@ mod tests {
 
     #[tokio::test]
     async fn insert_resolution_audit_writes_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-001").await;
         insert_resolution_audit(
             db.pool(),

--- a/crates/persistence/db/src/repositories/settings.rs
+++ b/crates/persistence/db/src/repositories/settings.rs
@@ -415,24 +415,18 @@ pub async fn list_source_overrides(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     #[tokio::test]
     async fn get_raw_returns_none_for_missing_key() {
-        let db = setup().await;
+        let db = setup_db().await;
         let result = get_raw(db.pool(), "nonexistent_key").await.unwrap();
         assert!(result.is_none());
     }
 
     #[tokio::test]
     async fn set_and_get_raw_roundtrip() {
-        let db = setup().await;
+        let db = setup_db().await;
         let value = serde_json::json!("info");
         set_raw(db.pool(), "logLevel", &value).await.unwrap();
         let loaded = get_raw(db.pool(), "logLevel").await.unwrap();
@@ -443,7 +437,7 @@ mod tests {
     /// column codec (spec `n4_jsoncodec`) — not just a JSON scalar.
     #[tokio::test]
     async fn set_and_get_raw_roundtrip_nested_value() {
-        let db = setup().await;
+        let db = setup_db().await;
         let value = serde_json::json!({
             "patterns": ["a/{target}/", "b/{filter}/"],
             "nested": { "enabled": true, "count": 3 },
@@ -460,7 +454,7 @@ mod tests {
     /// `equipment.rs`/`artifacts.rs`).
     #[tokio::test]
     async fn get_raw_propagates_on_corrupt_cell() {
-        let db = setup().await;
+        let db = setup_db().await;
         sqlx::query("INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)")
             .bind("corrupt")
             .bind("not valid json")
@@ -475,7 +469,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_raw_upserts_on_conflict() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_raw(db.pool(), "logLevel", &serde_json::json!("info")).await.unwrap();
         set_raw(db.pool(), "logLevel", &serde_json::json!("debug")).await.unwrap();
         let loaded = get_raw(db.pool(), "logLevel").await.unwrap();
@@ -490,7 +484,7 @@ mod tests {
         // silently keeping the in-code default (found via the US3
         // regeneration integration test, which needs a non-default kind to
         // exercise the "hardlink unsupported" refusal path).
-        let db = setup().await;
+        let db = setup_db().await;
         set_raw(db.pool(), "sourceViewLinkKindIntraDrive", &serde_json::json!("symlink"))
             .await
             .unwrap();
@@ -505,7 +499,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_key_removes_stored_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_raw(db.pool(), "logLevel", &serde_json::json!("debug")).await.unwrap();
         delete_key(db.pool(), "logLevel").await.unwrap();
         let loaded = get_raw(db.pool(), "logLevel").await.unwrap();
@@ -514,7 +508,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_settings_returns_defaults_when_empty() {
-        let db = setup().await;
+        let db = setup_db().await;
         let state = load_settings(db.pool()).await.unwrap();
         let defaults = SettingsState::default();
         assert_eq!(state.log_level, defaults.log_level);
@@ -524,7 +518,7 @@ mod tests {
 
     #[tokio::test]
     async fn load_settings_applies_stored_values() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_raw(db.pool(), "logLevel", &serde_json::json!("debug")).await.unwrap();
         set_raw(db.pool(), "followSymlinks", &serde_json::json!(true)).await.unwrap();
         let state = load_settings(db.pool()).await.unwrap();
@@ -538,7 +532,7 @@ mod tests {
     /// `apply_key_to_state` catch-all.
     #[tokio::test]
     async fn load_settings_applies_stored_framing_tolerance_overrides() {
-        let db = setup().await;
+        let db = setup_db().await;
         let defaults = SettingsState::default();
         let state = load_settings(db.pool()).await.unwrap();
         assert!(
@@ -565,7 +559,7 @@ mod tests {
 
     #[tokio::test]
     async fn patterns_by_type_defaults_when_unset() {
-        let db = setup().await;
+        let db = setup_db().await;
         // No overrides stored → every class resolves to its built-in default,
         // reached via the raw (frame_type, is_master) inputs confirm.rs passes.
         for (raw_type, is_master, class) in raw_inputs_per_class() {
@@ -577,7 +571,7 @@ mod tests {
 
     #[tokio::test]
     async fn patterns_by_type_override_read_back() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_pattern_for(db.pool(), FrameTypeClass::Dark, "custom/{gain}/").await.unwrap();
         let got = effective_pattern_for(db.pool(), "dark", false).await.unwrap();
         assert_eq!(got.as_deref(), Some("custom/{gain}/"));
@@ -588,7 +582,7 @@ mod tests {
 
     #[tokio::test]
     async fn patterns_by_type_master_routing() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_pattern_for(db.pool(), FrameTypeClass::MasterDark, "m/{exposure}/").await.unwrap();
         // is_master = true selects the master class.
         let master = effective_pattern_for(db.pool(), "dark", true).await.unwrap();
@@ -600,7 +594,7 @@ mod tests {
 
     #[tokio::test]
     async fn set_pattern_rejects_invalid() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert!(set_pattern_for(db.pool(), FrameTypeClass::Bias, "{telescope}/").await.is_err());
         assert!(set_pattern_for(db.pool(), FrameTypeClass::Bias, "").await.is_err());
         // Nothing persisted on rejection → still the default.
@@ -612,7 +606,7 @@ mod tests {
     async fn stored_invalid_override_falls_back_on_read() {
         // Defensive read-side fallback: a malformed value written out-of-band
         // (e.g. hand-edited DB) must not surface a broken pattern.
-        let db = setup().await;
+        let db = setup_db().await;
         let mut map = BTreeMap::new();
         map.insert("bias".to_owned(), "{telescope}/".to_owned());
         set_raw(db.pool(), PATTERNS_BY_TYPE_KEY, &serde_json::to_value(&map).unwrap())
@@ -624,7 +618,7 @@ mod tests {
 
     #[tokio::test]
     async fn reset_pattern_restores_default() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_pattern_for(db.pool(), FrameTypeClass::Light, "{target}/x/").await.unwrap();
         reset_pattern_for(db.pool(), FrameTypeClass::Light).await.unwrap();
         let got = effective_pattern_for(db.pool(), "light", false).await.unwrap();
@@ -635,13 +629,13 @@ mod tests {
 
     #[tokio::test]
     async fn effective_pattern_for_unknown_type_is_none() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert!(effective_pattern_for(db.pool(), "unclassified", false).await.unwrap().is_none());
     }
 
     #[tokio::test]
     async fn load_settings_applies_patterns_by_type() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_pattern_for(db.pool(), FrameTypeClass::Flat, "f/{filter}/").await.unwrap();
         let state = load_settings(db.pool()).await.unwrap();
         assert_eq!(state.patterns_by_type.get("flat").map(String::as_str), Some("f/{filter}/"));
@@ -663,7 +657,7 @@ mod tests {
 
     #[tokio::test]
     async fn source_override_roundtrip() {
-        let db = setup().await;
+        let db = setup_db().await;
         let value = serde_json::json!("eager");
         set_source_override(db.pool(), "source-abc", "hashOnScan", &value).await.unwrap();
         let loaded = get_source_override_raw(db.pool(), "source-abc", "hashOnScan").await.unwrap();
@@ -672,7 +666,7 @@ mod tests {
 
     #[tokio::test]
     async fn source_override_upsert_updates_value() {
-        let db = setup().await;
+        let db = setup_db().await;
         set_source_override(db.pool(), "src-1", "followSymlinks", &serde_json::json!(false))
             .await
             .unwrap();

--- a/crates/persistence/db/src/repositories/source_protection.rs
+++ b/crates/persistence/db/src/repositories/source_protection.rs
@@ -312,17 +312,11 @@ pub async fn resolve_protection_with_fallback(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
+    use crate::test_support::setup_db;
 
     #[tokio::test]
     async fn upsert_and_read_round_trip() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-001";
 
         upsert_source_protection(db.pool(), source_id, "unprotected", Some(false), None, "user")
@@ -341,7 +335,7 @@ mod tests {
 
     #[tokio::test]
     async fn upsert_updates_existing_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-002";
 
         upsert_source_protection(db.pool(), source_id, "protected", None, None, "user")
@@ -362,7 +356,7 @@ mod tests {
 
     #[tokio::test]
     async fn delete_removes_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-003";
 
         upsert_source_protection(db.pool(), source_id, "unprotected", None, None, "user")
@@ -376,7 +370,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_returns_override_when_present() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-004";
         let global_cats = vec!["lights".to_owned(), "masters".to_owned()];
 
@@ -403,7 +397,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_elevates_level_for_protected_category() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-005";
         let global_cats = vec!["lights".to_owned(), "masters".to_owned()];
 
@@ -425,7 +419,7 @@ mod tests {
 
     #[tokio::test]
     async fn resolve_uses_global_defaults_when_no_override() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-006";
         let global_cats: Vec<String> = vec![];
 
@@ -441,7 +435,7 @@ mod tests {
 
     #[tokio::test]
     async fn categories_with_override_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         let source_id = "src-007";
         let per_source_cats = vec!["finals".to_owned()];
 

--- a/crates/persistence/db/src/repositories/target_favourites.rs
+++ b/crates/persistence/db/src/repositories/target_favourites.rs
@@ -107,30 +107,11 @@ pub async fn remove_favourite(pool: &SqlitePool, target_id: &str) -> DbResult<()
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
-
-    // Helper: insert a bare canonical_target row (no aliases, no notes).
-    async fn insert_target(pool: &SqlitePool, id: &str) {
-        sqlx::query(
-            "INSERT INTO canonical_target
-             (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
-             VALUES (?, NULL, 'Test Target', 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
-        )
-        .bind(id)
-        .execute(pool)
-        .await
-        .expect("insert_target failed");
-    }
+    use crate::test_support::{insert_target, setup_db};
 
     #[tokio::test]
     async fn add_then_list_returns_favourited_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-001").await;
 
         add_favourite(db.pool(), "t-001", "2026-07-05T00:00:00Z").await.unwrap();
@@ -141,7 +122,7 @@ mod tests {
 
     #[tokio::test]
     async fn add_twice_is_idempotent_single_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-002").await;
 
         add_favourite(db.pool(), "t-002", "2026-07-05T00:00:00Z").await.unwrap();
@@ -162,7 +143,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_deletes_the_row() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-003").await;
         add_favourite(db.pool(), "t-003", "2026-07-05T00:00:00Z").await.unwrap();
 
@@ -174,7 +155,7 @@ mod tests {
 
     #[tokio::test]
     async fn remove_of_never_favourited_id_is_a_noop() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-004").await;
 
         // Never favourited; removing must not error.
@@ -186,20 +167,20 @@ mod tests {
 
     #[tokio::test]
     async fn list_is_empty_when_nothing_favourited() {
-        let db = setup().await;
+        let db = setup_db().await;
         let ids = list_favourites(db.pool()).await.unwrap();
         assert!(ids.is_empty());
     }
 
     #[tokio::test]
     async fn count_favourites_is_zero_when_nothing_favourited() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert_eq!(count_favourites(db.pool()).await.unwrap(), 0);
     }
 
     #[tokio::test]
     async fn count_favourites_reflects_add_and_remove() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-009").await;
         insert_target(db.pool(), "t-010").await;
 
@@ -213,27 +194,27 @@ mod tests {
 
     #[tokio::test]
     async fn target_exists_true_for_known_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-006").await;
         assert!(target_exists(db.pool(), "t-006").await.unwrap());
     }
 
     #[tokio::test]
     async fn target_exists_false_for_unknown_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         assert!(!target_exists(db.pool(), "missing").await.unwrap());
     }
 
     #[tokio::test]
     async fn get_favourited_at_returns_none_when_not_favourited() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-007").await;
         assert!(get_favourited_at(db.pool(), "t-007").await.unwrap().is_none());
     }
 
     #[tokio::test]
     async fn get_favourited_at_returns_stored_timestamp() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-008").await;
         add_favourite(db.pool(), "t-008", "2026-07-05T00:00:00Z").await.unwrap();
         assert_eq!(
@@ -244,7 +225,7 @@ mod tests {
 
     #[tokio::test]
     async fn cascade_delete_of_canonical_target_drops_favourite() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-005").await;
         add_favourite(db.pool(), "t-005", "2026-07-05T00:00:00Z").await.unwrap();
 

--- a/crates/persistence/db/src/repositories/targets.rs
+++ b/crates/persistence/db/src/repositories/targets.rs
@@ -133,26 +133,7 @@ pub async fn set_target_notes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::Database;
-
-    async fn setup() -> Database {
-        let db = Database::in_memory().await.expect("in-memory DB");
-        db.migrate().await.expect("migrations");
-        db
-    }
-
-    // Helper: insert a bare canonical_target row (no aliases, no notes).
-    async fn insert_target(pool: &SqlitePool, id: &str) {
-        sqlx::query(
-            "INSERT INTO canonical_target
-             (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
-             VALUES (?, NULL, 'Test Target', 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
-        )
-        .bind(id)
-        .execute(pool)
-        .await
-        .expect("insert_target failed");
-    }
+    use crate::test_support::{insert_target, setup_db};
 
     // Helper: insert an acquisition_session linked to a canonical_target.
     async fn insert_linked_session(
@@ -202,7 +183,7 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_list_returns_linked_sessions_only() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-001").await;
         insert_target(db.pool(), "t-002").await;
 
@@ -219,7 +200,7 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_list_empty_when_no_sessions_linked() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-010").await;
         let rows = list_sessions_for_target(db.pool(), "t-010").await.unwrap();
         assert!(rows.is_empty());
@@ -227,7 +208,7 @@ mod tests {
 
     #[tokio::test]
     async fn sessions_list_empty_for_unknown_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         let rows = list_sessions_for_target(db.pool(), "00000000-0000-0000-0000-000000000000")
             .await
             .unwrap();
@@ -238,7 +219,7 @@ mod tests {
 
     #[tokio::test]
     async fn projects_list_returns_linked_projects_only() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-100").await;
         insert_target(db.pool(), "t-101").await;
 
@@ -255,7 +236,7 @@ mod tests {
 
     #[tokio::test]
     async fn projects_list_empty_when_no_projects_linked() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-110").await;
         let rows = list_projects_for_target(db.pool(), "t-110").await.unwrap();
         assert!(rows.is_empty());
@@ -265,7 +246,7 @@ mod tests {
 
     #[tokio::test]
     async fn notes_get_returns_none_when_not_set() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-200").await;
         let notes = get_target_notes(db.pool(), "t-200").await.unwrap();
         assert!(notes.is_none());
@@ -273,7 +254,7 @@ mod tests {
 
     #[tokio::test]
     async fn notes_get_returns_none_for_unknown_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         let notes =
             get_target_notes(db.pool(), "00000000-0000-0000-0000-000000000099").await.unwrap();
         assert!(notes.is_none());
@@ -281,7 +262,7 @@ mod tests {
 
     #[tokio::test]
     async fn notes_roundtrip_set_and_get() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-300").await;
 
         let updated =
@@ -294,7 +275,7 @@ mod tests {
 
     #[tokio::test]
     async fn notes_set_null_clears_note() {
-        let db = setup().await;
+        let db = setup_db().await;
         insert_target(db.pool(), "t-301").await;
 
         set_target_notes(db.pool(), "t-301", Some("Initial note.")).await.unwrap();
@@ -306,7 +287,7 @@ mod tests {
 
     #[tokio::test]
     async fn notes_set_returns_false_for_unknown_target() {
-        let db = setup().await;
+        let db = setup_db().await;
         let updated =
             set_target_notes(db.pool(), "00000000-0000-0000-0000-000000000099", Some("x"))
                 .await

--- a/crates/persistence/db/src/test_support.rs
+++ b/crates/persistence/db/src/test_support.rs
@@ -1,0 +1,57 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared in-process test fixtures for `persistence_db` repository unit tests.
+//!
+//! All helpers are `pub(crate)` and compiled only under `cfg(test)`.
+
+use sqlx::SqlitePool;
+
+use crate::Database;
+
+/// An in-memory [`Database`] with all migrations applied, ready for a single
+/// repository unit test.
+pub(crate) async fn setup_db() -> Database {
+    let db = Database::in_memory().await.expect("in-memory DB");
+    db.migrate().await.expect("migrations");
+    db
+}
+
+/// Insert a minimal `canonical_target` row sufficient to satisfy FK constraints.
+///
+/// No aliases, no notes. The id must be unique within the pool.
+pub(crate) async fn insert_target(pool: &SqlitePool, id: &str) {
+    sqlx::query(
+        "INSERT INTO canonical_target
+         (id, simbad_oid, primary_designation, object_type, ra_deg, dec_deg, source, resolved_at)
+         VALUES (?, NULL, 'Test Target', 'galaxy', 10.0, 20.0, 'seed', '2026-01-01T00:00:00Z')",
+    )
+    .bind(id)
+    .execute(pool)
+    .await
+    .expect("insert_target failed");
+}
+
+/// Insert a minimal `projects` row sufficient to satisfy FK constraints.
+///
+/// `name` and `path` are derived from `id` so multiple calls in the same pool
+/// never collide on the `UNIQUE(path)` constraint.
+pub(crate) async fn insert_project(pool: &SqlitePool, id: &str) {
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+         VALUES (?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(id)
+    .bind(format!("Project {id}"))
+    .bind("PixInsight")
+    .bind("ready")
+    .bind(format!("projects/{id}"))
+    .bind::<Option<String>>(None)
+    .bind(false)
+    .bind("2026-01-01T00:00:00Z")
+    .bind("2026-01-01T00:00:00Z")
+    .execute(pool)
+    .await
+    .expect("insert_project failed");
+}


### PR DESCRIPTION
## Summary

- Adds `crates/persistence/db/src/test_support.rs` (`#[cfg(test)]`, `pub(crate)`) with three shared helpers: `setup_db()`, `insert_target()`, `insert_project()`.
- Removes 11 verbatim copies of `setup() -> Database` (in-memory + migrate) from repository test modules.
- Removes 3 verbatim copies of `insert_target()` (canonical_target FK fixture).
- Removes 2 static-name copies of `insert_project()` in `manifests.rs` and `project_notes.rs`; unifies with the id-derived form already used in `framing.rs`.

Files not touched: `calibration_assignment`, `calibration_tolerances`, `onboarding` (setup returns `SqlitePool`, different contract), `events` (custom CREATE TABLE schema), inbox/onboarding boundary, and `tests/` integration helpers.

Tracks-Bead: astro-plan-kyo7.3
Merge-Bead: astro-plan-w47y