### PR TITLE
chore: remove five unused frontend npm dependencies

### DIFF
--- a/apps/desktop/knip.json
+++ b/apps/desktop/knip.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://unpkg.com/knip@6/schema.json",
   "project": ["src/**/*.{ts,tsx}"],
-  "ignore": ["src/bindings/**"],
-  "ignoreDependencies": ["@tauri-apps/cli"]
+  "ignoreDependencies": [
+    "@tauri-apps/cli",
+    "@fontsource/space-grotesk",
+    "fontkit"
+  ]
 }

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -38,7 +38,6 @@
     "lockup:generate": "node scripts/generate-lockup.mjs"
   },
   "dependencies": {
-    "@astro-plan/contracts": "workspace:*",
     "@base-ui-components/react": "1.0.0-rc.0",
     "@hookform/resolvers": "5.4.0",
     "@inlang/paraglide-js": "^2.21.0",
@@ -47,12 +46,9 @@
     "@tanstack/react-virtual": "3.14.5",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
-    "@tauri-apps/plugin-log": "^2.8.0",
-    "@tauri-apps/plugin-notification": "^2.3.3",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",
-    "@tauri-apps/plugin-window-state": "^2.4.1",
     "@visx/group": "^4.0.0",
     "@visx/scale": "^4.0.0",
     "@visx/shape": "^4.0.0",
@@ -68,7 +64,6 @@
     "react-dom": "^19.2.7",
     "react-hook-form": "7.81.0",
     "react-joyride": "^3.2.0",
-    "react-resizable-panels": "4.12.1",
     "tinykeys": "4.0.0",
     "use-debounce": "10.1.1",
     "zod": "4.4.3"

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1071,7 +1071,7 @@ type MockRegistry = {
   ) => Promise<CommandPayload<(typeof commands)[K]>>;
 };
 
-export const mockHandlers = {
+const mockHandlers = {
   // ---------- Query Commands ----------
 
   sessions_list: async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,9 +17,6 @@ importers:
 
   apps/desktop:
     dependencies:
-      '@astro-plan/contracts':
-        specifier: workspace:*
-        version: link:../../packages/contracts
       '@base-ui-components/react':
         specifier: 1.0.0-rc.0
         version: 1.0.0-rc.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
@@ -44,12 +41,6 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
-      '@tauri-apps/plugin-log':
-        specifier: ^2.8.0
-        version: 2.8.0
-      '@tauri-apps/plugin-notification':
-        specifier: ^2.3.3
-        version: 2.3.3
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -59,9 +50,6 @@ importers:
       '@tauri-apps/plugin-updater':
         specifier: ^2.10.1
         version: 2.10.1
-      '@tauri-apps/plugin-window-state':
-        specifier: ^2.4.1
-        version: 2.4.1
       '@visx/group':
         specifier: ^4.0.0
         version: 4.0.0(@types/react@19.2.17)(react@19.2.7)
@@ -107,9 +95,6 @@ importers:
       react-joyride:
         specifier: ^3.2.0
         version: 3.2.0(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
-      react-resizable-panels:
-        specifier: 4.12.1
-        version: 4.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
       tinykeys:
         specifier: 4.0.0
         version: 4.0.0
@@ -2012,12 +1997,6 @@ packages:
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
 
-  '@tauri-apps/plugin-log@2.8.0':
-    resolution: {integrity: sha512-a+7rOq3MJwpTOLLKbL8d0qGZ85hgHw5pNOWusA9o3cf7cEgtYHiGY/+O8fj8MvywQIGqFv0da2bYQDlrqLE7rw==}
-
-  '@tauri-apps/plugin-notification@2.3.3':
-    resolution: {integrity: sha512-Zw+ZH18RJb41G4NrfHgIuofJiymusqN+q8fGUIIV7vyCH+5sSn5coqRv/MWB9qETsUs97vmU045q7OyseCV3Qg==}
-
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
 
@@ -2026,9 +2005,6 @@ packages:
 
   '@tauri-apps/plugin-updater@2.10.1':
     resolution: {integrity: sha512-NFYMg+tWOZPJdzE/PpFj2qfqwAWwNS3kXrb1tm1gnBJ9mYzZ4WDRrwy8udzWoAnfGCHLuePNLY1WVCNHnh3eRA==}
-
-  '@tauri-apps/plugin-window-state@2.4.1':
-    resolution: {integrity: sha512-OuvdrzyY8Q5Dbzpj+GcrnV1iCeoZbcFdzMjanZMMcAEUNy/6PH5pxZPXpaZLOR7whlzXiuzx0L9EKZbH7zpdRw==}
 
   '@testing-library/dom@10.4.1':
     resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
@@ -3850,12 +3826,6 @@ packages:
     peerDependenciesMeta:
       '@types/react':
         optional: true
-
-  react-resizable-panels@4.12.1:
-    resolution: {integrity: sha512-ElE/UpOvMLRWtAqbCgyizHXcbws8RPMyN3cBqmdY17Nxr5f01+DEwzOLqhgcy68GSnjtIUFgKWKl8aIgx5aypQ==}
-    peerDependencies:
-      react: ^18.0.0 || ^19.0.0
-      react-dom: ^18.0.0 || ^19.0.0
 
   react-style-singleton@2.2.3:
     resolution: {integrity: sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==}
@@ -5930,14 +5900,6 @@ snapshots:
     dependencies:
       '@tauri-apps/api': 2.11.1
 
-  '@tauri-apps/plugin-log@2.8.0':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
-  '@tauri-apps/plugin-notification@2.3.3':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
   '@tauri-apps/plugin-opener@2.5.4':
     dependencies:
       '@tauri-apps/api': 2.11.1
@@ -5947,10 +5909,6 @@ snapshots:
       '@tauri-apps/api': 2.11.1
 
   '@tauri-apps/plugin-updater@2.10.1':
-    dependencies:
-      '@tauri-apps/api': 2.11.1
-
-  '@tauri-apps/plugin-window-state@2.4.1':
     dependencies:
       '@tauri-apps/api': 2.11.1
 
@@ -8085,11 +8043,6 @@ snapshots:
       use-sidecar: 1.1.3(@types/react@19.2.17)(react@19.2.7)
     optionalDependencies:
       '@types/react': 19.2.17
-
-  react-resizable-panels@4.12.1(react-dom@19.2.7(react@19.2.7))(react@19.2.7):
-    dependencies:
-      react: 19.2.7
-      react-dom: 19.2.7(react@19.2.7)
 
   react-style-singleton@2.2.3(@types/react@19.2.17)(react@19.2.7):
     dependencies:

--- a/scripts/check-mock-baseline.mjs
+++ b/scripts/check-mock-baseline.mjs
@@ -56,10 +56,10 @@ function bindingCommands(src) {
  * elsewhere in the file cannot be mistaken for handlers.
  */
 function mockedCommands(src) {
-  const start = src.indexOf('export const mockHandlers = {');
+  const start = src.indexOf('const mockHandlers = {');
   if (start === -1) {
     throw new Error(
-      'mocks.ts: `export const mockHandlers = {` not found — the registry was renamed; update scripts/check-mock-baseline.mjs.',
+      'mocks.ts: `const mockHandlers = {` not found — the registry was renamed; update scripts/check-mock-baseline.mjs.',
     );
   }
   const end = src.indexOf('\n} satisfies MockRegistry;', start);


### PR DESCRIPTION
## Summary

- Removes five npm packages from `apps/desktop` that knip confirmed have no JS imports: `@astro-plan/contracts`, `@tauri-apps/plugin-log`, `@tauri-apps/plugin-notification`, `@tauri-apps/plugin-window-state`, `react-resizable-panels`
- Keeps `fontkit` and `@fontsource/space-grotesk` (used by `scripts/lib/wordmark.mjs` for splash/lockup/og-image generation) with `ignoreDependencies` entries in `knip.json`
- Removes the `export` keyword from `mockHandlers` in `src/api/mocks.ts` — only consumed internally by `mockInvoke` in the same file
- Removes `src/bindings/**` from knip `ignore` (bindings are imported from `src/`; knip's own hint flagged this)

**Note on Tauri plugins:** `plugin-log` and `plugin-window-state` remain as Rust dependencies in `src-tauri/Cargo.toml`; only the npm-side packages are removed. `plugin-notification` is also still in Cargo.toml but `tauri_plugin_notification::init()` is never called — Rust cleanup is a separate concern.

## Spec Context

Audit run: orc-audit-2026-07-23

## Beads

Tracks-Bead: astro-plan-kyo7.8
Closes-Bead: astro-plan-kyo7.8
Merge-Bead: astro-plan-b8bj
