### PR TITLE
fix: docs-only PRs deadlock branch protection when CI skips test jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,10 +579,11 @@ jobs:
   # unmergeable this way, and earlier tooling-only PRs were merged by admin
   # override rather than by satisfying the gate.
   #
-  # Single-lane jobs need no shim: `ui-e2e` below is not a matrix, so when it
-  # skips it still publishes `UI mock-mode (Playwright)` under its real name,
-  # and GitHub accepts a skipped check as satisfying a required context. Only
-  # the matrix name fails to materialise.
+  # The same problem applies to non-matrix single-lane jobs: `ui-e2e-gate`
+  # below (which publishes the required "UI mock-mode (Playwright)" context)
+  # uses `always()` so the context is always published with a definitive
+  # conclusion. A plain `if: frontend == 'true'` job that skips publishes
+  # `skipped`, which GitHub no longer accepts as satisfying a required check.
   #
   # This job runs for docs-only changes, so the matrix DOES expand and the
   # required contexts are reported — green, and explicit that nothing was tested
@@ -623,7 +624,7 @@ jobs:
   # the frontend lane and a change that cannot affect the frontend skips it
   # outright rather than reporting a green check for an empty run.
   ui-e2e:
-    name: UI mock-mode (Playwright)
+    name: UI mock-mode (Playwright) — run
     needs: changes
     if: needs.changes.outputs.frontend == 'true'
     runs-on: ubuntu-latest
@@ -642,3 +643,33 @@ jobs:
         run: pnpm --filter @astro-plan/desktop exec playwright install --with-deps chromium
       - name: Mock-mode UI tests
         run: pnpm --filter @astro-plan/desktop test:e2e
+
+  # Gate for the mock-mode Playwright job. Published as "UI mock-mode (Playwright)"
+  # — the context required by branch protection.
+  #
+  # `ui-e2e` above skips when the frontend lane is idle (docs-only PR). A
+  # `skipped` conclusion does NOT satisfy a required check on GitHub — only
+  # `success` does. Splitting the actual work (`ui-e2e`) from the required-context
+  # gate (`ui-e2e-gate`) lets the gate always report `success` on a legitimate
+  # skip while still reporting `failure` when `ui-e2e` fails or is unexpectedly
+  # absent. The run check lives in the step so the `if: always()` keeps this
+  # job reporting a definitive conclusion on every PR regardless of the lane.
+  ui-e2e-gate:
+    name: UI mock-mode (Playwright)
+    needs: [changes, ui-e2e]
+    if: always()
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Check Playwright result
+        env:
+          RESULT: ${{ needs.ui-e2e.result }}
+          FRONTEND: ${{ needs.changes.outputs.frontend }}
+        run: |
+          echo "ui-e2e result: $RESULT"
+          echo "frontend lane active: $FRONTEND"
+          if [ "$FRONTEND" != 'true' ]; then
+            echo "Frontend lane idle — Playwright appropriately skipped."
+            exit 0
+          fi
+          [ "$RESULT" = "success" ] || exit 1

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -763,21 +763,32 @@ jobs:
   # full-matrix "Real-UI journeys (L3) — ubuntu-latest" and "— windows-latest"
   # required contexts). Only runs on pull_request; skipped on main push/dispatch
   # because the full e2e-gate-ubuntu/-windows gates cover those events.
+  #
+  # `always()` alone (without `run == 'true'`) keeps this gate reporting a
+  # definitive conclusion even on docs-only PRs where run='false' and the whole
+  # smoke chain was legitimately skipped. With `run == 'true'` in the `if:`,
+  # the gate itself skips on docs-only PRs and the required context
+  # "Real-UI smoke (L3) — ubuntu-latest" is never published — which deadlocks
+  # the PR because GitHub no longer accepts skipped as satisfying a required
+  # check. The run check moves into the step so a legitimate skip exits 0.
   e2e-smoke-gate-ubuntu:
     name: Real-UI smoke (L3) — ubuntu-latest
     needs: [changes, smoke-ubuntu]
-    # `always()` keeps this gate reporting red instead of skipping when smoke-ubuntu
-    # or its upstream builders fail. The run=='true' guard prevents a false green
-    # on a docs-only PR where the whole chain (builders included) was skipped.
-    if: always() && needs.changes.outputs.run == 'true' && github.event_name == 'pull_request'
+    if: always() && github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
       - name: Check smoke result
         env:
           RESULT: ${{ needs.smoke-ubuntu.result }}
+          RUN: ${{ needs.changes.outputs.run }}
         run: |
           echo "smoke-ubuntu result: $RESULT"
+          echo "e2e changes run: $RUN"
+          if [ "$RUN" != 'true' ]; then
+            echo "No E2E-relevant changes — smoke appropriately skipped."
+            exit 0
+          fi
           [ "$RESULT" = "success" ] || exit 1
 
   # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Docs/spec-only PRs were unmergeable without `--admin` because two required status contexts reported `skipped` instead of `success`, and GitHub no longer accepts skipped as satisfying a required check.
- Adds gate jobs with `if: always()` that report `success` on a legitimate skip and `failure` on a real test failure — same pattern already used by `integration-idle` for the matrix case.

## Spec Context

Root cause: `ui-e2e` (ci.yml) and `e2e-smoke-gate-ubuntu` (e2e.yml) were the two broken contexts. `ui-e2e` published "UI mock-mode (Playwright)" as `skipped` on docs-only PRs; `e2e-smoke-gate-ubuntu` had `run == 'true'` in its `if:` so the gate itself skipped and "Real-UI smoke (L3) — ubuntu-latest" was never published.

Tracks-Bead: astro-plan-sgiz
Closes-Bead: astro-plan-sgiz
Merge-Bead: astro-plan-wikr
