### PR TITLE
chore: remove CI-trigger annotation comments from tlw train merges

### DIFF
--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1437: locale included in general settings reads.
 
 //! Settings Tauri commands (spec 018, T014/T015).
 //!

--- a/apps/desktop/src/data/locale.tsx
+++ b/apps/desktop/src/data/locale.tsx
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1437: locale is now returned in general settings reads.
 
 // Locale runtime — persisted application-language preference (spec 061).
 //

--- a/apps/desktop/src/data/theme.test.ts
+++ b/apps/desktop/src/data/theme.test.ts
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1434: first-run OS theme policy tests.
 
 /**
  * theme.test.ts — spec 051 US6 (T039): native window theme sync.

--- a/apps/desktop/src/features/setup/SetupWizard.tsx
+++ b/apps/desktop/src/features/setup/SetupWizard.tsx
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1432: apply selected language across onboarding wizard.
 
 import { useState, useEffect, useCallback } from 'react';
 import { useNavigate } from '@tanstack/react-router';

--- a/apps/desktop/src/features/setup/steps/StepScan.tsx
+++ b/apps/desktop/src/features/setup/steps/StepScan.tsx
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1443: announce statuses and localize scan result labels.
 
 // First-run wizard: "Scan" step (spec 038).
 //

--- a/apps/desktop/src/styles/components/wizard-steps.css
+++ b/apps/desktop/src/styles/components/wizard-steps.css
@@ -2006,5 +2006,3 @@ button.pv-wizard__steps-card:disabled {
   padding: var(--pv-sp-3);
   margin-bottom: var(--pv-sp-3);
 }
-
-/* end wizard-steps */

--- a/apps/desktop/src/styles/wizard-navigation.accessibility.test.ts
+++ b/apps/desktop/src/styles/wizard-navigation.accessibility.test.ts
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1440: keyboard/zoom accessibility for wizard step navigation.
 
 /// <reference types="node" />
 import { readFileSync } from 'node:fs';

--- a/apps/desktop/src/ui/Toggle.test.tsx
+++ b/apps/desktop/src/ui/Toggle.test.tsx
@@ -1,6 +1,5 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
-// PR #1438: keyboard focus visibility on toggle controls.
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';


### PR DESCRIPTION
## Summary

- Removes 9 one-line \`// PR #14xx:\` comments and one \`/* end wizard-steps */\` CSS comment added by the tlw merge train to defeat a branch-protection deadlock (fixed in #1484).
- 8 files, 9 deletions; no functional change.

## Beads
Tracks-Bead: astro-plan-d6ry
Closes-Bead: astro-plan-d6ry
Merge-Bead: astro-plan-rcpx