### PR TITLE
fix: offline library root hangs the sidebar until OS timeout

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1437,6 +1437,7 @@ dependencies = [
  "contracts_core",
  "domain_core",
  "fs_inventory",
+ "futures-util",
  "persistence_db",
  "serde",
  "serde_json",
@@ -2008,9 +2009,9 @@ dependencies = [
 
 [[package]]
 name = "futures-core"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+checksum = "2cd50c473c80f6d7c3670a752354b8e569b1a7cbfdc0419ec88e5edad85e0dc7"
 
 [[package]]
 name = "futures-executor"
@@ -2036,9 +2037,9 @@ dependencies = [
 
 [[package]]
 name = "futures-io"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+checksum = "4577ecaa3c4f96589d473f679a71b596316f6641bc350038b962a5daf0085d7a"
 
 [[package]]
 name = "futures-lite"
@@ -2055,9 +2056,9 @@ dependencies = [
 
 [[package]]
 name = "futures-macro"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
+checksum = "2d6d3cde68c518367be28956066ddfef33813991b77a55005a69dae04bf3b10b"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2066,15 +2067,15 @@ dependencies = [
 
 [[package]]
 name = "futures-sink"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c39754e157331b013978ec91992bde1ac089843443c49cbc7f46150b0fad0893"
+checksum = "e34418ac499d6305c2fb5ad0ed2f6ac998c5f8ca209b4510f7f94242c647e307"
 
 [[package]]
 name = "futures-task"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+checksum = "b231ed28831efb4a61a08580c4bc233ec56bc009f4cd8f52da2c3cb97df0c109"
 
 [[package]]
 name = "futures-timer"
@@ -2084,9 +2085,9 @@ checksum = "af43fadb8a98512d547e37b4e92e0ced13e205c061b87b4623eff01d918d6968"
 
 [[package]]
 name = "futures-util"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+checksum = "a77a90a256fce34da66415271e30f94ee91c57b04b8a2c042d9cf3220179deaa"
 dependencies = [
  "futures-core",
  "futures-io",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -108,6 +108,7 @@ byteorder = "1"
 camino = { version = "1", features = ["serde1"] }
 csv = "1"
 dashmap = "6"
+futures-util = "0.3"
 globset = "0.4"
 itertools = "0.14"
 moka = { version = "0.12", features = ["sync"] }

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -63,7 +63,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
-futures-util = "0.3.33"
+futures-util = { workspace = true }
 
 [dev-dependencies]
 # The `test` feature gates the `tauri::test` module (mock runtime, IPC

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -63,6 +63,7 @@ tracing-subscriber = { workspace = true }
 tracing-appender = { workspace = true }
 tokio = { workspace = true }
 uuid = { workspace = true }
+futures-util = "0.3.33"
 
 [dev-dependencies]
 # The `test` feature gates the `tauri::test` module (mock runtime, IPC

--- a/apps/desktop/src-tauri/src/commands/status.rs
+++ b/apps/desktop/src-tauri/src/commands/status.rs
@@ -57,7 +57,7 @@ pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary,
         let online = timeout(ROOT_PROBE_TIMEOUT, tokio::fs::try_exists(&path))
             .await
             .ok() // timeout => None => false
-            .and_then(std::result::Result::ok) // io::Error => false
+            .and_then(std::result::Result::ok) // permission-denied / IO error => offline, matching Path::exists() behaviour
             .unwrap_or(false);
         RootHealth { id: s.source_id, path, kind, online }
     });

--- a/apps/desktop/src-tauri/src/commands/status.rs
+++ b/apps/desktop/src-tauri/src/commands/status.rs
@@ -5,10 +5,12 @@
 //!
 //! Returns a `StatusSummary` DTO populated from the database.
 
-use std::path::Path;
+use std::time::Duration;
 
 use contracts_core::status::{LibraryStats, RootHealth, StatusSummary};
+use futures_util::future::join_all;
 use tauri::State;
+use tokio::time::timeout;
 
 use crate::commands::lifecycle::AppState;
 use contracts_core::ContractError;
@@ -18,10 +20,19 @@ use persistence_db::repositories::q_desktop::{
 };
 use persistence_db::repositories::target_favourites::count_favourites;
 
+/// Maximum time to wait for a single root-path existence probe.
+///
+/// An offline SMB/NAS mount can block an OS `stat` call for the full RPC
+/// timeout (up to 30 s on some hosts). Capping each probe keeps the sidebar
+/// responsive; timed-out roots report `online: false`.
+const ROOT_PROBE_TIMEOUT: Duration = Duration::from_secs(2);
+
 /// `status.summary` — returns current library status overview.
 ///
 /// Roots are fetched from `registered_sources`; each root's `online` flag is
 /// set by testing whether its path is currently accessible on the filesystem.
+/// Probes run concurrently with a per-root timeout so an offline NAS/SMB root
+/// cannot block a tokio worker for the full OS stat timeout.
 /// `inbox_count` reflects the real number of unacknowledged inbox items
 /// (`pending_classification` or `classified`) across all registered sources.
 ///
@@ -38,18 +49,19 @@ pub async fn status_summary(state: State<'_, AppState>) -> Result<StatusSummary,
         .await
         .map_err(|e| ContractError::internal(e.to_string()))?;
 
-    let roots: Vec<RootHealth> = sources
-        .into_iter()
-        .map(|s| {
-            let online = Path::new(&s.path).exists();
-            RootHealth {
-                id: s.source_id,
-                path: s.path,
-                kind: format!("{:?}", s.kind).to_lowercase(),
-                online,
-            }
-        })
-        .collect();
+    // Probe all roots concurrently; each probe is capped at ROOT_PROBE_TIMEOUT
+    // so total latency = slowest single probe capped at the timeout, not the sum.
+    let probe_futs = sources.into_iter().map(|s| async move {
+        let path = s.path.clone();
+        let kind = format!("{:?}", s.kind).to_lowercase();
+        let online = timeout(ROOT_PROBE_TIMEOUT, tokio::fs::try_exists(&path))
+            .await
+            .ok() // timeout => None => false
+            .and_then(std::result::Result::ok) // io::Error => false
+            .unwrap_or(false);
+        RootHealth { id: s.source_id, path, kind, online }
+    });
+    let roots: Vec<RootHealth> = join_all(probe_futs).await;
 
     // Count unacknowledged inbox items (states that need user attention).
     let inbox_count: u32 = count_unacknowledged_inbox_items(pool)

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1367,6 +1367,8 @@ export const commands = {
 	 * 
 	 *  Roots are fetched from `registered_sources`; each root's `online` flag is
 	 *  set by testing whether its path is currently accessible on the filesystem.
+	 *  Probes run concurrently with a per-root timeout so an offline NAS/SMB root
+	 *  cannot block a tokio worker for the full OS stat timeout.
 	 *  `inbox_count` reflects the real number of unacknowledged inbox items
 	 *  (`pending_classification` or `classified`) across all registered sources.
 	 * 

--- a/apps/desktop/src/data/queryClient.ts
+++ b/apps/desktop/src/data/queryClient.ts
@@ -16,6 +16,10 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 30_000,
+      // Desktop app: alt-tabbing back must not refetch multi-MB target/session
+      // queries. Queries that genuinely need fresh data on focus (e.g. status
+      // health checks) already use refetchInterval and do not need this too.
+      refetchOnWindowFocus: false,
     },
   },
 });


### PR DESCRIPTION
## Summary

- An offline SMB/NAS root now shows as offline within ~2 s instead of blocking the status poll for the full OS stat timeout (~30 s). Root probes now run concurrently with a per-root 2 s cap.
- Alt-tabbing back to the app no longer refetches all stale queries (including multi-MB target datasets). The query client disables focus-triggered refetch globally; status health queries already use a 30 s poll interval and are unaffected.

Tracks-Bead: astro-plan-kyo7.14
Merge-Bead: astro-plan-k096