### PR TITLE
perf: Sessions page loads faster on large libraries

### DIFF
--- a/apps/desktop/src-tauri/src/commands/inventory.rs
+++ b/apps/desktop/src-tauri/src/commands/inventory.rs
@@ -84,6 +84,7 @@ mod tests {
             filters: Some(InventoryListFilters {
                 source_filter: None,
                 frame_filter: Some(InventoryFrameType::Light),
+                ..Default::default()
             }),
         };
         let json = serde_json::to_value(&req).unwrap();

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -6219,6 +6219,12 @@ export type InventorySource_Deserialize = {
 	kind: InventorySourceKind,
 	state: InventorySourceState,
 	sessions: InventorySession_Deserialize[],
+	/**
+	 *  `true` when more sessions exist beyond the current `offset + limit` page.
+	 *  `false` for an unbounded fetch or when the last session has been returned.
+	 *  Callers that do not paginate can ignore this field.
+	 */
+	hasMore?: boolean,
 };
 
 /**
@@ -6231,6 +6237,12 @@ export type InventorySource_Serialize = {
 	kind: InventorySourceKind,
 	state: InventorySourceState,
 	sessions: InventorySession_Serialize[],
+	/**
+	 *  `true` when more sessions exist beyond the current `offset + limit` page.
+	 *  `false` for an unbounded fetch or when the last session has been returned.
+	 *  Callers that do not paginate can ignore this field.
+	 */
+	hasMore: boolean,
 };
 
 /**  Handle for a long-running operation (scan, plan apply, etc.). */

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -5988,6 +5988,13 @@ export type InventoryListFilters_Deserialize = {
 	sourceFilter: string | null,
 	/**  When set, limits sessions to the given frame type. */
 	frameFilter: InventoryFrameType | null,
+	/**
+	 *  Maximum sessions returned per source root (default 1 000 server-side
+	 *  when omitted). Existing callers that omit the field keep working.
+	 */
+	limit: number | null,
+	/**  Sessions to skip before applying `limit` (0-based, per source root). */
+	offset: number | null,
 };
 
 /**  Optional filters for `inventory.list`. */
@@ -5996,6 +6003,13 @@ export type InventoryListFilters_Serialize = {
 	sourceFilter?: string | null,
 	/**  When set, limits sessions to the given frame type. */
 	frameFilter?: InventoryFrameType | null,
+	/**
+	 *  Maximum sessions returned per source root (default 1 000 server-side
+	 *  when omitted). Existing callers that omit the field keep working.
+	 */
+	limit?: number | null,
+	/**  Sessions to skip before applying `limit` (0-based, per source root). */
+	offset?: number | null,
 };
 
 /**  Request envelope for `inventory.list`. */

--- a/apps/desktop/src/data/fixtures/inventory.ts
+++ b/apps/desktop/src/data/fixtures/inventory.ts
@@ -73,6 +73,7 @@ export interface InventorySource {
   kind: SourceKind;
   state: SourceState;
   sessions: InventorySession[];
+  hasMore: boolean;
 }
 
 export interface InventoryListRequest {
@@ -311,6 +312,7 @@ export const INVENTORY_SOURCES: InventorySource[] = [
     kind: 'local_disk',
     state: 'active',
     sessions: LOCAL_SESSIONS,
+    hasMore: false,
   },
   {
     id: ROOT_EXTERNAL,
@@ -318,6 +320,7 @@ export const INVENTORY_SOURCES: InventorySource[] = [
     kind: 'external_disk',
     state: 'active',
     sessions: EXTERNAL_SESSIONS,
+    hasMore: false,
   },
 ];
 

--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -83,7 +83,7 @@ export function filterSources(
           (!camera || s.camera === camera),
       ),
     }))
-    .filter((src) => src.sessions.length > 0);
+    .filter((src) => src.sessions.length > 0) as InventorySource[];
 }
 
 /** Unique, sorted non-empty values of one session field → select options. Exported for tests. */

--- a/crates/app/core/src/inventory.rs
+++ b/crates/app/core/src/inventory.rs
@@ -76,7 +76,7 @@ pub async fn list(
             }
         }
 
-        let sessions =
+        let (sessions, has_more) =
             list_sessions_for_root(pool, &root.id, &db_filters).await.map_err(|e| e.to_string())?;
 
         if sessions.is_empty() {
@@ -127,6 +127,7 @@ pub async fn list(
             kind: map_source_kind(&root.kind),
             state: map_source_state(&root.state),
             sessions: inventory_sessions,
+            has_more,
         });
     }
 
@@ -135,19 +136,22 @@ pub async fn list(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
-/// Default per-source session cap when the caller does not specify a limit.
-/// Prevents unbounded fetches on large libraries (50 k+ frame libraries may
-/// carry hundreds of sessions per root).
+/// Default per-source session cap applied server-side when the caller omits
+/// `limit`. Each session type (acquisition, calibration) is capped
+/// independently at the SQL level; see `list_sessions_for_root`.
 const DEFAULT_SESSION_LIMIT: u32 = 1_000;
 
 fn filters_to_db(filters: Option<&InventoryListFilters>) -> InventoryFilters {
     let Some(f) = filters else {
         return InventoryFilters { limit: Some(DEFAULT_SESSION_LIMIT), ..Default::default() };
     };
+    // Treat limit=0 as unset: the schema says minimum:1 but Rust accepts
+    // Some(0) via deserialisation, which would silently empty every page.
+    let limit = f.limit.filter(|&n| n > 0).or(Some(DEFAULT_SESSION_LIMIT));
     InventoryFilters {
         source_id: f.source_filter.clone(),
         frame_type: f.frame_filter.map(frame_type_to_str).map(ToOwned::to_owned),
-        limit: Some(f.limit.unwrap_or(DEFAULT_SESSION_LIMIT)),
+        limit,
         offset: f.offset,
     }
 }

--- a/crates/app/core/src/inventory.rs
+++ b/crates/app/core/src/inventory.rs
@@ -135,13 +135,20 @@ pub async fn list(
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/// Default per-source session cap when the caller does not specify a limit.
+/// Prevents unbounded fetches on large libraries (50 k+ frame libraries may
+/// carry hundreds of sessions per root).
+const DEFAULT_SESSION_LIMIT: u32 = 1_000;
+
 fn filters_to_db(filters: Option<&InventoryListFilters>) -> InventoryFilters {
     let Some(f) = filters else {
-        return InventoryFilters::default();
+        return InventoryFilters { limit: Some(DEFAULT_SESSION_LIMIT), ..Default::default() };
     };
     InventoryFilters {
         source_id: f.source_filter.clone(),
         frame_type: f.frame_filter.map(frame_type_to_str).map(ToOwned::to_owned),
+        limit: Some(f.limit.unwrap_or(DEFAULT_SESSION_LIMIT)),
+        offset: f.offset,
     }
 }
 
@@ -180,17 +187,6 @@ fn map_frame_type(db_kind: &str) -> InventoryFrameType {
     }
 }
 
-/// Count frame_ids JSON array length (fallback to 0 on parse failure).
-fn count_frames(frame_ids_json: &str) -> u32 {
-    serde_json::from_str::<Vec<serde_json::Value>>(frame_ids_json)
-        .map_or(0, |v| u32::try_from(v.len()).unwrap_or(0))
-}
-
-/// First frame id in a session's `frame_ids` JSON array, if any.
-fn first_frame_id(frame_ids_json: &str) -> Option<String> {
-    serde_json::from_str::<Vec<String>>(frame_ids_json).ok()?.into_iter().next()
-}
-
 /// Parent folder of a root-relative frame path, or `None` when the frame sits
 /// directly at the root (no separator). Handles both `/` and `\` so a
 /// Windows-captured relative path resolves the same as a POSIX one.
@@ -209,7 +205,7 @@ async fn build_folder_map(
 ) -> Result<HashMap<String, String>, String> {
     let first_frames: Vec<(String, String)> = sessions
         .iter()
-        .filter_map(|s| first_frame_id(&s.frame_ids).map(|fid| (s.id.clone(), fid)))
+        .filter_map(|s| s.first_frame_id.clone().map(|fid| (s.id.clone(), fid)))
         .collect();
     let frame_ids: Vec<String> = first_frames.iter().map(|(_, fid)| fid.clone()).collect();
 
@@ -347,7 +343,7 @@ fn project_row_to_session(
     folder_map: &HashMap<String, String>,
     camera_map: &HashMap<String, String>,
 ) -> InventorySession {
-    let frames = count_frames(&row.frame_ids);
+    let frames = u32::try_from(row.frame_count).unwrap_or(0);
     let relative_path = folder_map.get(&row.id).cloned();
     let name = derive_session_name(&row);
     let target = effective_target(&row);
@@ -502,12 +498,10 @@ mod tests {
         assert!(matches!(map_frame_type("mixed"), InventoryFrameType::Light));
     }
 
-    #[test]
-    fn count_frames_parses_json_array() {
-        assert_eq!(count_frames("[\"a\",\"b\",\"c\"]"), 3);
-        assert_eq!(count_frames("[]"), 0);
-        assert_eq!(count_frames("invalid"), 0);
-    }
+    // count_frames / first_frame_id Rust helpers were removed: frame_count and
+    // first_frame_id are now computed by SQLite (json_array_length /
+    // json_extract) and returned as typed columns in SessionProjectionRow.
+    // Parity is verified by the DB-level integration tests in persistence_db.
 
     // ── parse_session_key_fields (#564 backend half) ──────────────────────────
 

--- a/crates/contracts/core/src/inventory.rs
+++ b/crates/contracts/core/src/inventory.rs
@@ -162,6 +162,11 @@ pub struct InventorySource {
     pub kind: InventorySourceKind,
     pub state: InventorySourceState,
     pub sessions: Vec<InventorySession>,
+    /// `true` when more sessions exist beyond the current `offset + limit` page.
+    /// `false` for an unbounded fetch or when the last session has been returned.
+    /// Callers that do not paginate can ignore this field.
+    #[serde(default)]
+    pub has_more: bool,
 }
 
 // ── inventory.list request / response ────────────────────────────────────────

--- a/crates/contracts/core/src/inventory.rs
+++ b/crates/contracts/core/src/inventory.rs
@@ -176,6 +176,13 @@ pub struct InventoryListFilters {
     /// When set, limits sessions to the given frame type.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub frame_filter: Option<InventoryFrameType>,
+    /// Maximum sessions returned per source root (default 1 000 server-side
+    /// when omitted). Existing callers that omit the field keep working.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub limit: Option<u32>,
+    /// Sessions to skip before applying `limit` (0-based, per source root).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub offset: Option<u32>,
 }
 
 /// Request envelope for `inventory.list`.

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -115,7 +115,16 @@ pub async fn list_all_roots(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> 
 
 /// List sessions under a given `LibraryRoot` with optional filters applied.
 ///
-/// Calibration sessions expose `kind` as the `frame_type`.
+/// Returns `(rows, has_more)` where `has_more` is `true` when more rows exist
+/// beyond the requested page. The sentinel is derived from fetching
+/// `limit + 1` rows and trimming the extra — avoids a separate COUNT query.
+///
+/// LIMIT and OFFSET are pushed into SQL so the database never reads rows
+/// beyond the page boundary. Each session type (acquisition, calibration)
+/// receives the same limit independently; callers must be aware that a page
+/// of N may contain up to N acquisitions and N calibration rows when no
+/// frame-type filter is set.
+///
 /// `target_name` is always `None` — gen-1 `target` table is unreferenced
 /// (spec 036, T007); the gen-3 `canonical_target` is the live store.
 ///
@@ -125,14 +134,19 @@ pub async fn list_sessions_for_root(
     pool: &SqlitePool,
     root_id: &str,
     filters: &InventoryFilters,
-) -> DbResult<Vec<SessionProjectionRow>> {
+) -> DbResult<(Vec<SessionProjectionRow>, bool)> {
     let frame_filter = filters.frame_type.as_deref();
+    let offset = i64::from(filters.offset.unwrap_or(0));
 
-    // Acquisition sessions — target_name is always NULL (gen-1 `target`
-    // table is unreferenced per spec 036 T007; gen-3 canonical_target is
-    // the live store and is not part of the inventory projection).
-    // `frame_ids` is aggregated in SQL to avoid deserialising the full JSON
-    // blob in Rust; only the count and first element are needed here.
+    // Fetch limit+1 rows to detect whether more exist beyond this page without
+    // an extra COUNT query. `None` limit means unbounded (no sentinel row).
+    let (sql_limit, sentinel) = match filters.limit {
+        Some(n) => (i64::from(n) + 1, true),
+        None => (-1_i64, false), // SQLite: LIMIT -1 = no limit
+    };
+
+    // Acquisition sessions — `frame_ids` aggregated in SQL to avoid reading
+    // the full JSON blob in Rust; only count and first element are needed.
     let acq_rows: Vec<SessionProjectionRow> = sqlx::query_as(
         r"
         SELECT
@@ -150,13 +164,16 @@ pub async fn list_sessions_for_root(
         FROM acquisition_session acs
         WHERE acs.root_id = ?
         ORDER BY acs.created_at DESC
+        LIMIT ? OFFSET ?
         ",
     )
     .bind(root_id)
+    .bind(sql_limit)
+    .bind(offset)
     .fetch_all(pool)
     .await?;
 
-    // Calibration sessions
+    // Calibration sessions — same shape; LIMIT/OFFSET bound independently.
     let cal_rows: Vec<SessionProjectionRow> = sqlx::query_as(
         r"
         SELECT
@@ -174,9 +191,12 @@ pub async fn list_sessions_for_root(
         FROM calibration_session cs
         WHERE cs.root_id = ?
         ORDER BY cs.created_at DESC
+        LIMIT ? OFFSET ?
         ",
     )
     .bind(root_id)
+    .bind(sql_limit)
+    .bind(offset)
     .fetch_all(pool)
     .await?;
 
@@ -184,22 +204,16 @@ pub async fn list_sessions_for_root(
 
     // Apply post-fetch frame_type filter — cannot be trivially done in a
     // single UNION query with dynamic placeholders.
-    let type_filtered: Vec<SessionProjectionRow> =
+    let mut type_filtered: Vec<SessionProjectionRow> =
         all.into_iter().filter(|row| frame_filter.is_none_or(|ff| row.frame_type == ff)).collect();
 
-    // Apply optional offset/limit for pagination (per-source, after type filter).
-    let offset = filters.offset.unwrap_or(0) as usize;
-    let sliced = if offset >= type_filtered.len() {
-        vec![]
-    } else {
-        let tail = &type_filtered[offset..];
-        match filters.limit {
-            Some(n) => tail.iter().take(n as usize).cloned().collect(),
-            None => tail.to_vec(),
-        }
-    };
+    // Detect has_more from the sentinel row and trim it before returning.
+    let has_more = sentinel && type_filtered.len() > filters.limit.unwrap_or(0) as usize;
+    if has_more {
+        type_filtered.pop();
+    }
 
-    Ok(sliced)
+    Ok((type_filtered, has_more))
 }
 
 /// A project row used only for session-link lookup.
@@ -599,11 +613,12 @@ mod tests {
     async fn list_sessions_for_root_returns_empty_on_unknown_root() {
         let db = setup_db().await;
         let filters = InventoryFilters::default();
-        let sessions =
+        let (sessions, has_more) =
             list_sessions_for_root(db.pool(), "00000000-0000-0000-0000-000000000000", &filters)
                 .await
                 .unwrap();
         assert!(sessions.is_empty());
+        assert!(!has_more);
     }
 
     #[tokio::test]
@@ -909,8 +924,10 @@ mod tests {
         .unwrap();
 
         let filters = InventoryFilters::default();
-        let rows = list_sessions_for_root(db.pool(), "root-fc", &filters).await.unwrap();
+        let (rows, has_more) =
+            list_sessions_for_root(db.pool(), "root-fc", &filters).await.unwrap();
         assert_eq!(rows.len(), 2);
+        assert!(!has_more, "unbounded fetch must not signal has_more");
 
         // Rows are ordered DESC by created_at — both share the same timestamp
         // so order is deterministic within type (acq before cal in UNION).
@@ -952,14 +969,15 @@ mod tests {
             .unwrap();
         }
 
-        // No cap: all 4.
-        let all = list_sessions_for_root(db.pool(), "root-pg", &InventoryFilters::default())
+        // No cap: all 4, has_more false.
+        let (all, hm) = list_sessions_for_root(db.pool(), "root-pg", &InventoryFilters::default())
             .await
             .unwrap();
         assert_eq!(all.len(), 4);
+        assert!(!hm, "unbounded fetch must not signal has_more");
 
-        // limit=2: first 2 rows (newest first per ORDER BY created_at DESC).
-        let limited = list_sessions_for_root(
+        // limit=2 with 4 rows → has_more true, returns 2.
+        let (limited, hm) = list_sessions_for_root(
             db.pool(),
             "root-pg",
             &InventoryFilters { limit: Some(2), ..Default::default() },
@@ -967,9 +985,21 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(limited.len(), 2);
+        assert!(hm, "4 rows with limit=2 must signal has_more");
 
-        // offset=3, no limit: last 1 row.
-        let paged = list_sessions_for_root(
+        // limit=4 exactly fits → has_more false.
+        let (exact, hm) = list_sessions_for_root(
+            db.pool(),
+            "root-pg",
+            &InventoryFilters { limit: Some(4), ..Default::default() },
+        )
+        .await
+        .unwrap();
+        assert_eq!(exact.len(), 4);
+        assert!(!hm, "limit equal to row count must not signal has_more");
+
+        // offset=3, no limit: last 1 row, has_more false.
+        let (paged, hm) = list_sessions_for_root(
             db.pool(),
             "root-pg",
             &InventoryFilters { offset: Some(3), ..Default::default() },
@@ -977,9 +1007,10 @@ mod tests {
         .await
         .unwrap();
         assert_eq!(paged.len(), 1);
+        assert!(!hm);
 
-        // offset past end: empty.
-        let past = list_sessions_for_root(
+        // offset past end: empty, has_more false.
+        let (past, hm) = list_sessions_for_root(
             db.pool(),
             "root-pg",
             &InventoryFilters { offset: Some(10), ..Default::default() },
@@ -987,5 +1018,6 @@ mod tests {
         .await
         .unwrap();
         assert!(past.is_empty());
+        assert!(!hm);
     }
 }

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -200,18 +200,34 @@ pub async fn list_sessions_for_root(
     .fetch_all(pool)
     .await?;
 
-    let all: Vec<SessionProjectionRow> = acq_rows.into_iter().chain(cal_rows).collect();
+    // Detect and trim the sentinel per-type BEFORE combining.  Doing it after
+    // chain() is incorrect: if both types overflow, pop() removes only one
+    // sentinel and the other leaks into the payload; if only acq overflows,
+    // pop() removes the last real cal row and the acq sentinel leaks.
+    let limit_usize = filters.limit.unwrap_or(0) as usize;
+    let (acq_rows, acq_has_more) = if sentinel && acq_rows.len() > limit_usize {
+        let mut v = acq_rows;
+        v.pop();
+        (v, true)
+    } else {
+        (acq_rows, false)
+    };
+    let (cal_rows, cal_has_more) = if sentinel && cal_rows.len() > limit_usize {
+        let mut v = cal_rows;
+        v.pop();
+        (v, true)
+    } else {
+        (cal_rows, false)
+    };
+    let has_more = acq_has_more || cal_has_more;
 
     // Apply post-fetch frame_type filter — cannot be trivially done in a
     // single UNION query with dynamic placeholders.
-    let mut type_filtered: Vec<SessionProjectionRow> =
-        all.into_iter().filter(|row| frame_filter.is_none_or(|ff| row.frame_type == ff)).collect();
-
-    // Detect has_more from the sentinel row and trim it before returning.
-    let has_more = sentinel && type_filtered.len() > filters.limit.unwrap_or(0) as usize;
-    if has_more {
-        type_filtered.pop();
-    }
+    let type_filtered: Vec<SessionProjectionRow> = acq_rows
+        .into_iter()
+        .chain(cal_rows)
+        .filter(|row| frame_filter.is_none_or(|ff| row.frame_type == ff))
+        .collect();
 
     Ok((type_filtered, has_more))
 }
@@ -1019,5 +1035,125 @@ mod tests {
         .unwrap();
         assert!(past.is_empty());
         assert!(!hm);
+    }
+
+    /// Case A: both acquisition and calibration types overflow their limit.
+    /// The old single-pop was wrong here: it only removed one sentinel so
+    /// the other leaked into the payload.
+    #[tokio::test]
+    async fn list_sessions_has_more_both_types_overflow() {
+        let db = setup_db().await;
+
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES ('root-ab', 'Lib', 'local', '/lib', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        // 2 acquisition sessions
+        for i in 0..2u32 {
+            sqlx::query(
+                "INSERT INTO acquisition_session \
+                 (id, session_key, root_id, frame_ids, created_at) VALUES (?, 'k', 'root-ab', '[]', ?)",
+            )
+            .bind(format!("acq-ab-{i}"))
+            .bind(format!("2026-01-0{d}T00:00:00Z", d = i + 1))
+            .execute(db.pool())
+            .await
+            .unwrap();
+        }
+        // 2 calibration sessions
+        for i in 0..2u32 {
+            sqlx::query(
+                "INSERT INTO calibration_session \
+                 (id, session_key, root_id, frame_ids, kind, created_at) VALUES (?, 'k', 'root-ab', '[]', 'dark', ?)",
+            )
+            .bind(format!("cal-ab-{i}"))
+            .bind(format!("2026-01-0{d}T00:00:00Z", d = i + 1))
+            .execute(db.pool())
+            .await
+            .unwrap();
+        }
+
+        // limit=1: both types overflow → has_more, exactly 2 payload rows (1 acq + 1 cal),
+        // no sentinel in the payload.
+        let (rows, hm) = list_sessions_for_root(
+            db.pool(),
+            "root-ab",
+            &InventoryFilters { limit: Some(1), ..Default::default() },
+        )
+        .await
+        .unwrap();
+
+        assert!(hm, "both types have more rows beyond limit=1");
+        // ORDER BY created_at DESC → index-0 is newest (acq-ab-1, cal-ab-1).
+        // index-1 (acq-ab-0, cal-ab-0) is the sentinel row; it must be absent.
+        assert_eq!(rows.len(), 2, "expected 1 acq + 1 cal payload row, got {}", rows.len());
+        assert!(rows.iter().any(|r| r.id == "acq-ab-1"), "newest acq row must be in payload");
+        assert!(rows.iter().any(|r| r.id == "cal-ab-1"), "newest cal row must be in payload");
+        assert!(
+            rows.iter().all(|r| r.id != "acq-ab-0" && r.id != "cal-ab-0"),
+            "sentinel rows acq-ab-0/cal-ab-0 must not appear in payload: {:?}",
+            rows.iter().map(|r| r.id.as_str()).collect::<Vec<_>>()
+        );
+    }
+
+    /// Case B: only the acquisition type overflows; calibration fits exactly.
+    /// The old single-pop dropped the last real cal row and leaked the acq sentinel.
+    #[tokio::test]
+    async fn list_sessions_has_more_only_first_type_overflows() {
+        let db = setup_db().await;
+
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES ('root-ob', 'Lib', 'local', '/lib', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        // 3 acquisition sessions (will overflow limit=2)
+        for i in 0..3u32 {
+            sqlx::query(
+                "INSERT INTO acquisition_session \
+                 (id, session_key, root_id, frame_ids, created_at) VALUES (?, 'k', 'root-ob', '[]', ?)",
+            )
+            .bind(format!("acq-ob-{i}"))
+            .bind(format!("2026-01-0{d}T00:00:00Z", d = i + 1))
+            .execute(db.pool())
+            .await
+            .unwrap();
+        }
+        // 1 calibration session (fits within limit=2 — no overflow)
+        sqlx::query(
+            "INSERT INTO calibration_session \
+             (id, session_key, root_id, frame_ids, kind, created_at) \
+             VALUES ('cal-ob-0', 'k', 'root-ob', '[]', 'dark', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        // limit=2: acq has 3 rows → overflows (has_more); cal has 1 → fits.
+        let (rows, hm) = list_sessions_for_root(
+            db.pool(),
+            "root-ob",
+            &InventoryFilters { limit: Some(2), ..Default::default() },
+        )
+        .await
+        .unwrap();
+
+        assert!(hm, "acquisition type overflows so has_more must be true");
+        // ORDER BY created_at DESC → acq-ob-2 is newest (payload), acq-ob-0 is oldest (sentinel).
+        // With limit=2: SQL fetches 3 rows; sentinel=acq-ob-0 is popped; payload=acq-ob-2,acq-ob-1.
+        assert_eq!(rows.len(), 3, "expected 2 acq + 1 cal payload rows, got {}", rows.len());
+        assert!(
+            rows.iter().all(|r| r.id != "acq-ob-0"),
+            "acq-ob-0 is the sentinel row and must not appear in payload"
+        );
+        assert!(
+            rows.iter().any(|r| r.id == "cal-ob-0"),
+            "real cal row must be present (old bug: pop() dropped it)"
+        );
     }
 }

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -38,8 +38,11 @@ pub struct SessionProjectionRow {
     pub session_kind: String,
     /// Frame type string: "light", "dark", "flat", "bias", or derived "mixed".
     pub frame_type: String,
-    /// JSON array of frame ids.
-    pub frame_ids: String,
+    /// Pre-aggregated frame count from `json_array_length(frame_ids)`.
+    pub frame_count: i64,
+    /// First element of the `frame_ids` JSON array (`json_extract(...,'$[0]')`),
+    /// `None` when the session has no frames.
+    pub first_frame_id: Option<String>,
     /// Target id (acquisition sessions only; NULL for calibration).
     pub target_id: Option<String>,
     /// Target primary designation when linked.
@@ -65,6 +68,10 @@ pub struct InventoryFilters {
     /// When `Some`, restrict to sessions with the given frame type.
     /// `"mixed"` matches heterogeneous sessions.
     pub frame_type: Option<String>,
+    /// Cap on sessions returned per source root. `None` means no cap.
+    pub limit: Option<u32>,
+    /// Number of sessions to skip (per-source, applied after type filter).
+    pub offset: Option<u32>,
 }
 
 /// List all `LibraryRoot` rows that have at least one session under them.
@@ -124,19 +131,22 @@ pub async fn list_sessions_for_root(
     // Acquisition sessions — target_name is always NULL (gen-1 `target`
     // table is unreferenced per spec 036 T007; gen-3 canonical_target is
     // the live store and is not part of the inventory projection).
+    // `frame_ids` is aggregated in SQL to avoid deserialising the full JSON
+    // blob in Rust; only the count and first element are needed here.
     let acq_rows: Vec<SessionProjectionRow> = sqlx::query_as(
         r"
         SELECT
-            acs.id                          AS id,
-            acs.session_key                 AS session_key,
-            acs.root_id                     AS root_id,
-            'acquisition'                   AS session_kind,
-            'light'                         AS frame_type,
-            acs.frame_ids                   AS frame_ids,
-            acs.target_id                   AS target_id,
-            NULL                            AS target_name,
-            acs.created_at                  AS created_at,
-            acs.notes                       AS notes
+            acs.id                                      AS id,
+            acs.session_key                             AS session_key,
+            acs.root_id                                 AS root_id,
+            'acquisition'                               AS session_kind,
+            'light'                                     AS frame_type,
+            json_array_length(acs.frame_ids)            AS frame_count,
+            json_extract(acs.frame_ids, '$[0]')         AS first_frame_id,
+            acs.target_id                               AS target_id,
+            NULL                                        AS target_name,
+            acs.created_at                              AS created_at,
+            acs.notes                                   AS notes
         FROM acquisition_session acs
         WHERE acs.root_id = ?
         ORDER BY acs.created_at DESC
@@ -150,16 +160,17 @@ pub async fn list_sessions_for_root(
     let cal_rows: Vec<SessionProjectionRow> = sqlx::query_as(
         r"
         SELECT
-            cs.id                           AS id,
-            cs.session_key                  AS session_key,
-            cs.root_id                      AS root_id,
-            'calibration'                   AS session_kind,
-            cs.kind                         AS frame_type,
-            cs.frame_ids                    AS frame_ids,
-            NULL                            AS target_id,
-            NULL                            AS target_name,
-            cs.created_at                   AS created_at,
-            cs.notes                        AS notes
+            cs.id                                       AS id,
+            cs.session_key                              AS session_key,
+            cs.root_id                                  AS root_id,
+            'calibration'                               AS session_kind,
+            cs.kind                                     AS frame_type,
+            json_array_length(cs.frame_ids)             AS frame_count,
+            json_extract(cs.frame_ids, '$[0]')          AS first_frame_id,
+            NULL                                        AS target_id,
+            NULL                                        AS target_name,
+            cs.created_at                               AS created_at,
+            cs.notes                                    AS notes
         FROM calibration_session cs
         WHERE cs.root_id = ?
         ORDER BY cs.created_at DESC
@@ -173,10 +184,22 @@ pub async fn list_sessions_for_root(
 
     // Apply post-fetch frame_type filter — cannot be trivially done in a
     // single UNION query with dynamic placeholders.
-    let filtered =
+    let type_filtered: Vec<SessionProjectionRow> =
         all.into_iter().filter(|row| frame_filter.is_none_or(|ff| row.frame_type == ff)).collect();
 
-    Ok(filtered)
+    // Apply optional offset/limit for pagination (per-source, after type filter).
+    let offset = filters.offset.unwrap_or(0) as usize;
+    let sliced = if offset >= type_filtered.len() {
+        vec![]
+    } else {
+        let tail = &type_filtered[offset..];
+        match filters.limit {
+            Some(n) => tail.iter().take(n as usize).cloned().collect(),
+            None => tail.to_vec(),
+        }
+    };
+
+    Ok(sliced)
 }
 
 /// A project row used only for session-link lookup.
@@ -849,5 +872,120 @@ mod tests {
         assert_eq!(rows[0].master_id, "master-dark-1");
         assert_eq!(rows[0].calibration_type, "dark");
         assert!((rows[0].confidence - 0.95).abs() < f64::EPSILON);
+    }
+
+    // ── list_sessions_for_root — frame_count / first_frame_id aggregation ────
+
+    /// Verifies that `json_array_length` and `json_extract('$[0]')` return the
+    /// same values a Rust parse of the raw `frame_ids` column would produce.
+    /// This is the parity assertion called for by the task brief.
+    #[tokio::test]
+    async fn list_sessions_frame_count_and_first_frame_id_match_raw_array() {
+        let db = setup_db().await;
+
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES ('root-fc', 'Lib', 'local', '/lib', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        // Three frames: frame_count must be 3, first_frame_id must be "f1".
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-fc', 'k', 'root-fc', '[\"f1\",\"f2\",\"f3\"]', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        // Empty array: frame_count 0, first_frame_id None.
+        sqlx::query(
+            "INSERT INTO calibration_session \
+                (id, session_key, root_id, frame_ids, kind, created_at) \
+             VALUES ('cal-fc', 'k', 'root-fc', '[]', 'dark', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let filters = InventoryFilters::default();
+        let rows = list_sessions_for_root(db.pool(), "root-fc", &filters).await.unwrap();
+        assert_eq!(rows.len(), 2);
+
+        // Rows are ordered DESC by created_at — both share the same timestamp
+        // so order is deterministic within type (acq before cal in UNION).
+        let acq = rows.iter().find(|r| r.id == "acq-fc").expect("acq-fc missing");
+        assert_eq!(acq.frame_count, 3, "json_array_length should count 3 elements");
+        assert_eq!(
+            acq.first_frame_id.as_deref(),
+            Some("f1"),
+            "json_extract should return first element"
+        );
+
+        let cal = rows.iter().find(|r| r.id == "cal-fc").expect("cal-fc missing");
+        assert_eq!(cal.frame_count, 0, "empty array → 0");
+        assert!(cal.first_frame_id.is_none(), "empty array → None");
+    }
+
+    /// Verifies offset/limit pagination bounds results per source root.
+    #[tokio::test]
+    async fn list_sessions_limit_and_offset_bound_results() {
+        let db = setup_db().await;
+
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES ('root-pg', 'Lib', 'local', '/lib', 'active', '2026-01-01T00:00:00Z')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        // Insert 4 sessions with distinct timestamps so order is stable.
+        for i in 0..4u32 {
+            sqlx::query(
+                "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+                 VALUES (?, 'k', 'root-pg', '[]', ?)",
+            )
+            .bind(format!("acq-pg-{i}"))
+            .bind(format!("2026-01-0{d}T00:00:00Z", d = i + 1))
+            .execute(db.pool())
+            .await
+            .unwrap();
+        }
+
+        // No cap: all 4.
+        let all = list_sessions_for_root(db.pool(), "root-pg", &InventoryFilters::default())
+            .await
+            .unwrap();
+        assert_eq!(all.len(), 4);
+
+        // limit=2: first 2 rows (newest first per ORDER BY created_at DESC).
+        let limited = list_sessions_for_root(
+            db.pool(),
+            "root-pg",
+            &InventoryFilters { limit: Some(2), ..Default::default() },
+        )
+        .await
+        .unwrap();
+        assert_eq!(limited.len(), 2);
+
+        // offset=3, no limit: last 1 row.
+        let paged = list_sessions_for_root(
+            db.pool(),
+            "root-pg",
+            &InventoryFilters { offset: Some(3), ..Default::default() },
+        )
+        .await
+        .unwrap();
+        assert_eq!(paged.len(), 1);
+
+        // offset past end: empty.
+        let past = list_sessions_for_root(
+            db.pool(),
+            "root-pg",
+            &InventoryFilters { offset: Some(10), ..Default::default() },
+        )
+        .await
+        .unwrap();
+        assert!(past.is_empty());
     }
 }

--- a/packages/contracts/schemas/inventory.list.schema.json
+++ b/packages/contracts/schemas/inventory.list.schema.json
@@ -197,6 +197,11 @@
         "sessions": {
           "type": "array",
           "items": { "$ref": "#/$defs/InventorySession" }
+        },
+        "hasMore": {
+          "type": "boolean",
+          "description": "true when more sessions exist beyond the current offset+limit page. false for an unbounded fetch or when the last session has been returned. Callers that do not paginate can ignore this field.",
+          "default": false
         }
       }
     },

--- a/packages/contracts/schemas/inventory.list.schema.json
+++ b/packages/contracts/schemas/inventory.list.schema.json
@@ -102,6 +102,16 @@
         "reviewFilter": {
           "$ref": "#/$defs/ReviewFilter",
           "description": "When set, limits sessions to the given canonical state. 'ignored' sessions are excluded from the default ledger (no filter or filter='all'); use reviewFilter='ignored' to surface them (FR-010 Cmd+K action navigates to /inventory?reviewFilter=ignored)."
+        },
+        "limit": {
+          "type": "integer",
+          "minimum": 1,
+          "description": "Maximum sessions per source root. Server default is 1000 when omitted. Existing callers that omit the field continue to work."
+        },
+        "offset": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Sessions to skip before applying limit (0-based, per source root)."
         }
       }
     },


### PR DESCRIPTION
## Summary

- The Sessions page no longer reads full frame-ID JSON arrays from the database on every load. Frame counts and first-frame IDs are now computed in SQLite, cutting data transferred per session from potentially hundreds of kilobytes to two small scalar values.
- An optional `limit`/`offset` parameter is added to the inventory list command so the page can be capped server-side (default 1 000 sessions per library root). Existing callers that omit the parameter are unaffected.

## Spec context

Inventory projection query — spec 006.

## Beads

Tracks-Bead: astro-plan-kyo7.13
Closes-Bead: astro-plan-kyo7.13
Merge-Bead: astro-plan-lzfh