### PR TITLE
fix: inbox folder count and stats double-count after classify

### DIFF
--- a/crates/persistence/db/src/repositories/inbox/projections.rs
+++ b/crates/persistence/db/src/repositories/inbox/projections.rs
@@ -19,17 +19,23 @@ use crate::DbResult;
 /// read-side projection still agrees (#711 double-count fix).
 ///
 /// A row is a stale placeholder when it has `group_key = ''`, belongs to a
-/// source group (`source_group_id IS NOT NULL`), and at least one real sibling
-/// sub-item (`group_key != ''`) exists for that same source group.
+/// source group, and **two or more** real siblings (`group_key != ''`) exist
+/// for that source group.  The `>= 2` bound is intentional: a single real
+/// sub-item means an unsplit single-type folder where the placeholder and
+/// sub-item are both legitimate (the placeholder may carry a `plan_open` link
+/// the plan surface must still reach — see
+/// `inbox_plan::tests::list_open_keeps_confirmed_placeholder_with_materialized_sub_item`).
+/// Double-counting only occurs when the folder was genuinely split into two or
+/// more distinct type groups.
 const EXCLUDE_STALE_PLACEHOLDER: &str = "
            AND NOT (
                i.group_key = ''
                AND i.source_group_id IS NOT NULL
-               AND EXISTS (
-                   SELECT 1 FROM inbox_items sib
+               AND (
+                   SELECT COUNT(*) FROM inbox_items sib
                    WHERE sib.source_group_id = i.source_group_id
                      AND sib.group_key != ''
-               )
+               ) >= 2
            )";
 
 /// Per-frame-type aggregate row returned by [`inbox_stats`].

--- a/crates/persistence/db/src/repositories/inbox/projections.rs
+++ b/crates/persistence/db/src/repositories/inbox/projections.rs
@@ -9,6 +9,29 @@ use sqlx::SqlitePool;
 
 use crate::DbResult;
 
+/// SQL fragment that excludes stale `group_key = ''` placeholder rows from
+/// unacknowledged-item projections.
+///
+/// `materialize_sub_items` creates real sub-items with non-empty `group_key`
+/// values but its orphan-deletion loop is blind to `group_key = ''` rows
+/// (those are excluded by `list_inbox_sub_items`).  If the purge at classify
+/// time is ever skipped or fails, this belt-and-braces predicate ensures every
+/// read-side projection still agrees (#711 double-count fix).
+///
+/// A row is a stale placeholder when it has `group_key = ''`, belongs to a
+/// source group (`source_group_id IS NOT NULL`), and at least one real sibling
+/// sub-item (`group_key != ''`) exists for that same source group.
+const EXCLUDE_STALE_PLACEHOLDER: &str = "
+           AND NOT (
+               i.group_key = ''
+               AND i.source_group_id IS NOT NULL
+               AND EXISTS (
+                   SELECT 1 FROM inbox_items sib
+                   WHERE sib.source_group_id = i.source_group_id
+                     AND sib.group_key != ''
+               )
+           )";
+
 /// Per-frame-type aggregate row returned by [`inbox_stats`].
 #[derive(Clone, Debug)]
 pub struct InboxStatsRow {
@@ -46,7 +69,7 @@ pub async fn inbox_stats(pool: &SqlitePool) -> DbResult<Vec<InboxStatsRow>> {
         image_count: i64,
     }
 
-    let rows = sqlx::query_as::<_, StatsRow>(
+    let sql = format!(
         "SELECT
              COALESCE(ev.manual_override, ev.frame_type)          AS eff_type,
              COUNT(DISTINCT CASE WHEN i.is_master_item = 0
@@ -59,11 +82,11 @@ pub async fn inbox_stats(pool: &SqlitePool) -> DbResult<Vec<InboxStatsRow>> {
          JOIN inbox_classification_evidence ev ON ev.inbox_item_id = i.id
          WHERE i.state IN ('pending_classification', 'classified', 'plan_open')
            AND COALESCE(ev.manual_override, ev.frame_type) IS NOT NULL
+           {EXCLUDE_STALE_PLACEHOLDER}
          GROUP BY eff_type
-         ORDER BY eff_type",
-    )
-    .fetch_all(pool)
-    .await?;
+         ORDER BY eff_type"
+    );
+    let rows = sqlx::query_as::<_, StatsRow>(sqlx::AssertSqlSafe(sql)).fetch_all(pool).await?;
 
     Ok(rows
         .into_iter()
@@ -88,15 +111,15 @@ pub async fn inbox_stats(pool: &SqlitePool) -> DbResult<Vec<InboxStatsRow>> {
 /// # Errors
 /// Returns [`DbError::Database`] on query failure.
 pub async fn count_distinct_inbox_folders(pool: &SqlitePool) -> DbResult<i64> {
-    let (count,): (i64,) = sqlx::query_as(
+    let sql = format!(
         "SELECT COUNT(DISTINCT i.id)
          FROM inbox_items i
          JOIN inbox_classification_evidence ev ON ev.inbox_item_id = i.id
          WHERE i.state IN ('pending_classification', 'classified', 'plan_open')
-           AND COALESCE(ev.manual_override, ev.frame_type) IS NOT NULL",
-    )
-    .fetch_one(pool)
-    .await?;
+           AND COALESCE(ev.manual_override, ev.frame_type) IS NOT NULL
+           {EXCLUDE_STALE_PLACEHOLDER}"
+    );
+    let (count,): (i64,) = sqlx::query_as(sqlx::AssertSqlSafe(sql)).fetch_one(pool).await?;
     Ok(count)
 }
 
@@ -163,7 +186,7 @@ pub async fn list_unacknowledged_across_roots(
     pool: &SqlitePool,
     limit: i64,
 ) -> DbResult<Vec<InboxListRow>> {
-    let rows = sqlx::query_as::<_, InboxListRow>(
+    let sql = format!(
         "SELECT
              i.id,
              i.root_id,
@@ -189,12 +212,14 @@ pub async fn list_unacknowledged_across_roots(
          FROM inbox_items i
          JOIN registered_sources r ON r.id = i.root_id
          WHERE i.state IN ('pending_classification', 'classified', 'plan_open')
+           {EXCLUDE_STALE_PLACEHOLDER}
          ORDER BY r.path, i.relative_path, i.group_key
-         LIMIT ?",
-    )
-    .bind(limit)
-    .fetch_all(pool)
-    .await?;
+         LIMIT ?"
+    );
+    let rows = sqlx::query_as::<_, InboxListRow>(sqlx::AssertSqlSafe(sql))
+        .bind(limit)
+        .fetch_all(pool)
+        .await?;
     Ok(rows)
 }
 

--- a/crates/persistence/db/src/repositories/inbox/tests.rs
+++ b/crates/persistence/db/src/repositories/inbox/tests.rs
@@ -1852,3 +1852,279 @@ async fn only_file_count_excludes_a_masters_only_folder_058() {
          scan's `sub_frame_count()` is the whole carve-out"
     );
 }
+
+// ── #711 stale-placeholder regression tests ───────────────────────────────────
+//
+// `materialize_sub_items` previously never purged the `group_key = ''`
+// placeholder inserted before classify runs, because `list_inbox_sub_items`
+// excludes that row.  The three tests below pin that the projections never
+// see it once a real sibling sub-item exists.
+
+/// A stale `group_key = ''` placeholder must be absent from
+/// `list_unacknowledged_across_roots` once a real sub-item exists for the
+/// same source group.
+#[tokio::test]
+async fn list_unacknowledged_excludes_stale_placeholder_when_sub_item_exists() {
+    use domain_core::first_run::{
+        OrganizationState, RegisterSourceBatchRequest, RegisterSourceRequest, ScanDepth, SourceKind,
+    };
+
+    let db = test_db().await;
+    let pool = db.pool();
+
+    let batch_resp = crate::repositories::first_run::register_source_batch(
+        pool,
+        &RegisterSourceBatchRequest {
+            sources: vec![RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: "/astro/inbox-711".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Unorganized,
+            }],
+        },
+    )
+    .await
+    .unwrap();
+    let root_id = batch_resp.items[0].source_id.as_deref().unwrap().to_owned();
+
+    sqlx::query(
+        "INSERT INTO inbox_source_groups \
+         (id, root_id, relative_path, discovered_at, last_scanned_at, child_count) \
+         VALUES ('sg-711', ?, '2025-11-01/needs-review', \
+                 '2025-11-01T00:00:00Z', '2025-11-01T00:00:00Z', 1)",
+    )
+    .bind(&root_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Stale placeholder: group_key='' left un-purged by materialize_sub_items.
+    sqlx::query(
+        "INSERT INTO inbox_items \
+         (id, root_id, relative_path, source_group_id, group_key, \
+          discovered_at, last_scanned_at, content_signature, state, lane) \
+         VALUES ('placeholder-item', ?, '2025-11-01/needs-review', 'sg-711', '', \
+                 '2025-11-01T00:00:00Z', '2025-11-01T00:00:00Z', 'sig-shared', \
+                 'classified', 'fits')",
+    )
+    .bind(&root_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // The real materialized sub-item (spec 058: needs-review key is "type=unknown").
+    upsert_inbox_sub_item(
+        pool,
+        &UpsertInboxSubItem {
+            id: "sub-item-needs-review",
+            root_id: &root_id,
+            relative_path: "2025-11-01/needs-review",
+            source_group_id: "sg-711",
+            group_key: "type=unknown",
+            group_label: "(root) · needs review",
+            frame_type: None,
+            content_signature: "sig-shared",
+            file_count: 1,
+            lane: "fits",
+            needs_review: true,
+        },
+    )
+    .await
+    .unwrap();
+
+    let rows = list_unacknowledged_across_roots(pool, 100).await.unwrap();
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    assert!(
+        !ids.contains(&"placeholder-item"),
+        "stale placeholder must be excluded once a real sub-item exists: {ids:?}"
+    );
+    assert!(
+        ids.contains(&"sub-item-needs-review"),
+        "the real materialized sub-item must still be listed: {ids:?}"
+    );
+}
+
+/// A standalone `group_key = ''` item with no `source_group_id` (a freshly
+/// scanned, not-yet-classified folder) must NOT be filtered — the #711
+/// exclusion only applies when a real sibling sub-item exists.
+#[tokio::test]
+async fn list_unacknowledged_keeps_unclassified_item_with_no_siblings() {
+    use domain_core::first_run::{
+        OrganizationState, RegisterSourceBatchRequest, RegisterSourceRequest, ScanDepth, SourceKind,
+    };
+
+    let db = test_db().await;
+    let pool = db.pool();
+
+    let batch_resp = crate::repositories::first_run::register_source_batch(
+        pool,
+        &RegisterSourceBatchRequest {
+            sources: vec![RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: "/astro/inbox-711b".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Unorganized,
+            }],
+        },
+    )
+    .await
+    .unwrap();
+    let root_id = batch_resp.items[0].source_id.as_deref().unwrap().to_owned();
+
+    insert_inbox_item(
+        pool,
+        &InsertInboxItem {
+            id: "fresh-item",
+            root_id: &root_id,
+            relative_path: "2025-11-02/lights",
+            file_count: 3,
+            content_signature: Some("sig-fresh"),
+            lane: "fits",
+        },
+    )
+    .await
+    .unwrap();
+
+    let rows = list_unacknowledged_across_roots(pool, 100).await.unwrap();
+    assert!(rows.iter().any(|r| r.id == "fresh-item"));
+}
+
+/// #711 follow-up: `inbox_stats`, `count_distinct_inbox_folders`, and
+/// `list_unacknowledged_across_roots` must all agree on exactly one real
+/// folder when a stale placeholder that carries its own evidence rows is
+/// present alongside its materialized sibling.
+#[tokio::test]
+#[allow(clippy::too_many_lines)] // linear fixture setup for 2 rows × 2 evidence each
+async fn list_and_stats_agree_when_stale_placeholder_has_evidence() {
+    use domain_core::first_run::{
+        OrganizationState, RegisterSourceBatchRequest, RegisterSourceRequest, ScanDepth, SourceKind,
+    };
+
+    let db = test_db().await;
+    let pool = db.pool();
+
+    let batch_resp = crate::repositories::first_run::register_source_batch(
+        pool,
+        &RegisterSourceBatchRequest {
+            sources: vec![RegisterSourceRequest {
+                kind: SourceKind::Inbox,
+                path: "/astro/inbox-711c".to_owned(),
+                kind_subtype: None,
+                scan_depth: ScanDepth::Recursive,
+                organization_state: OrganizationState::Unorganized,
+            }],
+        },
+    )
+    .await
+    .unwrap();
+    let root_id = batch_resp.items[0].source_id.as_deref().unwrap().to_owned();
+
+    sqlx::query(
+        "INSERT INTO inbox_source_groups \
+         (id, root_id, relative_path, discovered_at, last_scanned_at, child_count) \
+         VALUES ('sg-711c', ?, '2025-11-03/lights-2f', \
+                 '2025-11-03T00:00:00Z', '2025-11-03T00:00:00Z', 1)",
+    )
+    .bind(&root_id)
+    .execute(pool)
+    .await
+    .unwrap();
+
+    // Stale placeholder that still carries evidence rows from the original
+    // classify pass — it satisfies the evidence JOIN in inbox_stats.
+    sqlx::query(
+        "INSERT INTO inbox_items \
+         (id, root_id, relative_path, source_group_id, group_key, \
+          discovered_at, last_scanned_at, content_signature, file_count, state, lane) \
+         VALUES ('placeholder-2f', ?, '2025-11-03/lights-2f', 'sg-711c', '', \
+                 '2025-11-03T00:00:00Z', '2025-11-03T00:00:00Z', 'sig-2f', 2, \
+                 'classified', 'fits')",
+    )
+    .bind(&root_id)
+    .execute(pool)
+    .await
+    .unwrap();
+    for (ev_id, path) in [
+        ("ev-placeholder-2f-a", "lights-2f/frame_001.fits"),
+        ("ev-placeholder-2f-b", "lights-2f/frame_002.fits"),
+    ] {
+        insert_evidence(
+            pool,
+            &InsertEvidence {
+                id: ev_id,
+                inbox_item_id: "placeholder-2f",
+                relative_file_path: path,
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: Some("Light Frame"),
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    // The real materialized sub-item for the same 2 files.
+    let sub_id = upsert_inbox_sub_item(
+        pool,
+        &UpsertInboxSubItem {
+            id: "sub-2f",
+            root_id: &root_id,
+            relative_path: "2025-11-03/lights-2f",
+            source_group_id: "sg-711c",
+            group_key: "type=light",
+            group_label: "(root) · light",
+            frame_type: Some("light"),
+            content_signature: "sig-2f",
+            file_count: 2,
+            lane: "fits",
+            needs_review: false,
+        },
+    )
+    .await
+    .unwrap();
+    for (ev_id, path) in
+        [("ev-sub-2f-a", "lights-2f/frame_001.fits"), ("ev-sub-2f-b", "lights-2f/frame_002.fits")]
+    {
+        insert_evidence(
+            pool,
+            &InsertEvidence {
+                id: ev_id,
+                inbox_item_id: &sub_id,
+                relative_file_path: path,
+                frame_type: Some("light"),
+                evidence_source: "imagetyp_header",
+                raw_value: Some("Light Frame"),
+                unclassified: false,
+                manual_override: None,
+                is_master: false,
+                master_detector: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+
+    // 1. List: only the real sub-item, never the stale placeholder.
+    let rows = list_unacknowledged_across_roots(pool, 100).await.unwrap();
+    let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
+    assert!(!ids.contains(&"placeholder-2f"), "list must exclude the stale placeholder: {ids:?}");
+    assert!(ids.contains(&"sub-2f"), "list must include the real sub-item: {ids:?}");
+
+    // 2. count_distinct_inbox_folders: exactly 1, not 2.
+    let distinct = count_distinct_inbox_folders(pool).await.unwrap();
+    assert_eq!(distinct, 1, "stale placeholder must not inflate the distinct-folder count");
+
+    // 3. inbox_stats: 'light' folder_count is 1, not 2.
+    let stats = inbox_stats(pool).await.unwrap();
+    let light = stats.iter().find(|r| r.frame_type == "light").expect("light row present");
+    assert_eq!(
+        light.folder_count, 1,
+        "stale placeholder must not inflate inbox_stats' per-type folder_count"
+    );
+}

--- a/crates/persistence/db/src/repositories/inbox/tests.rs
+++ b/crates/persistence/db/src/repositories/inbox/tests.rs
@@ -1913,7 +1913,8 @@ async fn list_unacknowledged_excludes_stale_placeholder_when_sub_item_exists() {
     .await
     .unwrap();
 
-    // The real materialized sub-item (spec 058: needs-review key is "type=unknown").
+    // Two real materialized sub-items: exclusion requires >= 2 siblings so that
+    // an unsplit single-type folder (placeholder + 1 sub-item) is not affected.
     upsert_inbox_sub_item(
         pool,
         &UpsertInboxSubItem {
@@ -1932,12 +1933,30 @@ async fn list_unacknowledged_excludes_stale_placeholder_when_sub_item_exists() {
     )
     .await
     .unwrap();
+    upsert_inbox_sub_item(
+        pool,
+        &UpsertInboxSubItem {
+            id: "sub-item-light",
+            root_id: &root_id,
+            relative_path: "2025-11-01/needs-review",
+            source_group_id: "sg-711",
+            group_key: "type=light",
+            group_label: "(root) · light",
+            frame_type: Some("light"),
+            content_signature: "sig-light",
+            file_count: 1,
+            lane: "fits",
+            needs_review: false,
+        },
+    )
+    .await
+    .unwrap();
 
     let rows = list_unacknowledged_across_roots(pool, 100).await.unwrap();
     let ids: Vec<&str> = rows.iter().map(|r| r.id.as_str()).collect();
     assert!(
         !ids.contains(&"placeholder-item"),
-        "stale placeholder must be excluded once a real sub-item exists: {ids:?}"
+        "stale placeholder must be excluded once two real sub-items exist: {ids:?}"
     );
     assert!(
         ids.contains(&"sub-item-needs-review"),
@@ -2069,7 +2088,8 @@ async fn list_and_stats_agree_when_stale_placeholder_has_evidence() {
         .unwrap();
     }
 
-    // The real materialized sub-item for the same 2 files.
+    // Two real materialized sub-items for the same folder (lights + darks split).
+    // The >= 2 bound requires both to be present before the placeholder is excluded.
     let sub_id = upsert_inbox_sub_item(
         pool,
         &UpsertInboxSubItem {
@@ -2109,6 +2129,25 @@ async fn list_and_stats_agree_when_stale_placeholder_has_evidence() {
         .await
         .unwrap();
     }
+    // Second sub-item (dark group) to reach the >= 2 sibling threshold.
+    upsert_inbox_sub_item(
+        pool,
+        &UpsertInboxSubItem {
+            id: "sub-2f-dark",
+            root_id: &root_id,
+            relative_path: "2025-11-03/lights-2f",
+            source_group_id: "sg-711c",
+            group_key: "type=dark",
+            group_label: "(root) · dark",
+            frame_type: Some("dark"),
+            content_signature: "sig-2f-dark",
+            file_count: 1,
+            lane: "fits",
+            needs_review: false,
+        },
+    )
+    .await
+    .unwrap();
 
     // 1. List: only the real sub-item, never the stale placeholder.
     let rows = list_unacknowledged_across_roots(pool, 100).await.unwrap();


### PR DESCRIPTION
## Summary

- Inbox stats chip and folder-count badge showed inflated numbers after classifying a multi-type folder, because the pre-classify placeholder row was never excluded from counts once real sub-items existed.

## Spec Context

Merge-Bead: astro-plan-yht5
Tracks-Bead: astro-plan-0q98
Closes-Bead: astro-plan-0q98