### PR TITLE
ci: alert on main L3 E2E failure

### DIFF
--- a/.github/workflows/e2e-alert.yml
+++ b/.github/workflows/e2e-alert.yml
@@ -1,0 +1,150 @@
+# L3 E2E Failure Alert — CI Regression Issue
+#
+# Triggers on completion of the Real-UI E2E workflow (e2e.yml) and alerts via
+# GitHub issue when the full L3 suite fails on main. Since PR #1467, the full
+# L3 (including Windows) runs only on main pushes; a red main L3 currently
+# notifies nobody. This workflow provides immediate visibility.
+#
+# Gated to: github.event.workflow_run.conclusion == 'failure'
+#          && github.event.workflow_run.head_branch == 'main'
+#
+# Action: open (or update) a GitHub issue labeled `ci-regression` with
+#   - title: "main L3 E2E red @ <short-sha>"
+#   - body: run link + failed-job names
+#   - labels: ci-regression
+#
+# Deduplication: if an OPEN ci-regression issue for main L3 already exists,
+# comment on it instead of opening a new one. Label is created if missing.
+
+name: L3 E2E Failure Alert
+
+on:
+  workflow_run:
+    workflows: ["Real-UI E2E (thirtyfour + nextest + tauri-plugin-webdriver)"]
+    types: [completed]
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  alert:
+    name: Alert on L3 E2E failure
+    # Gate: only trigger on main push failure
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.head_branch == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Get workflow run metadata
+        id: workflow
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Fetch the workflow run to extract metadata
+          RUN_ID="${{ github.event.workflow_run.id }}"
+          RUN_URL="https://github.com/${{ github.repository }}/actions/runs/${RUN_ID}"
+          COMMIT_SHA="${{ github.event.workflow_run.head_commit }}"
+          SHORT_SHA="${COMMIT_SHA:0:7}"
+
+          {
+            echo "run_id=${RUN_ID}"
+            echo "run_url=${RUN_URL}"
+            echo "commit_sha=${COMMIT_SHA}"
+            echo "short_sha=${SHORT_SHA}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Extract failed job names
+        id: failed_jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          RUN_ID="${{ steps.workflow.outputs.run_id }}"
+
+          # Query the GitHub API for all jobs in the workflow run
+          JOBS=$(gh api \
+            --method GET \
+            "repos/${{ github.repository }}/actions/runs/${RUN_ID}/jobs" \
+            --jq '.jobs[] | select(.conclusion == "failure") | .name' \
+            2>/dev/null || echo "")
+
+          if [ -z "$JOBS" ]; then
+            FAILED_JOBS="(unable to retrieve specific job names)"
+          else
+            # Format as a bullet list using awk
+            FAILED_JOBS=$(echo "$JOBS" | awk '{print "- " $0}')
+          fi
+
+          # Escape newlines for multiline output
+          FAILED_JOBS_ESCAPED=$(echo "$FAILED_JOBS" | jq -Rs .)
+          echo "failed_jobs=${FAILED_JOBS_ESCAPED}" >> "$GITHUB_OUTPUT"
+
+      - name: Ensure ci-regression label exists
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Create the label if it doesn't exist (idempotent)
+          gh label create ci-regression \
+            --description "CI regression on main or release branch" \
+            --color "c41e3a" \
+            2>/dev/null || true
+
+      - name: Check for existing open ci-regression issue for main L3
+        id: existing_issue
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          # Search for open issues with ci-regression label and "main L3 E2E" in title
+          ISSUE_NUM=$(gh issue list \
+            --label ci-regression \
+            --state open \
+            --search "main L3 E2E in:title" \
+            --json number \
+            --jq '.[0].number' \
+            2>/dev/null || echo "")
+
+          if [ -n "$ISSUE_NUM" ] && [ "$ISSUE_NUM" != "null" ]; then
+            echo "issue_num=${ISSUE_NUM}" >> "$GITHUB_OUTPUT"
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Comment on existing issue
+        if: steps.existing_issue.outputs.found == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUM: ${{ steps.existing_issue.outputs.issue_num }}
+          RUN_URL: ${{ steps.workflow.outputs.run_url }}
+          SHORT_SHA: ${{ steps.workflow.outputs.short_sha }}
+          FAILED_JOBS: ${{ steps.failed_jobs.outputs.failed_jobs }}
+        run: |
+          # Build comment body using jq to safely handle multiline strings
+          COMMENT=$(jq -n \
+            --arg ru "$RUN_URL" \
+            --arg sha "$SHORT_SHA" \
+            --arg fj "$FAILED_JOBS" \
+            'Another L3 E2E failure detected on main.\n\n**Commit**: `\($sha)`\n**Run**: [\($ru)](\($ru))\n\n**Failed jobs**:\n\($fj)')
+
+          gh issue comment "$ISSUE_NUM" --body "$COMMENT"
+
+      - name: Create new issue if none exists
+        if: steps.existing_issue.outputs.found == 'false'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_URL: ${{ steps.workflow.outputs.run_url }}
+          SHORT_SHA: ${{ steps.workflow.outputs.short_sha }}
+          FAILED_JOBS: ${{ steps.failed_jobs.outputs.failed_jobs }}
+        run: |
+          TITLE="main L3 E2E red @ ${SHORT_SHA}"
+
+          # Build issue body using jq to safely handle multiline strings
+          BODY=$(jq -n \
+            --arg ru "$RUN_URL" \
+            --arg sha "$SHORT_SHA" \
+            --arg fj "$FAILED_JOBS" \
+            'The full L3 E2E suite failed on main.\n\n**Commit**: `\($sha)`\n**Run**: [\($ru)](\($ru))\n\n**Failed jobs**:\n\($fj)\n\nThis issue tracks main-branch E2E regressions. If fixed, close this issue.')
+
+          gh issue create \
+            --title "$TITLE" \
+            --body "$BODY" \
+            --label ci-regression


### PR DESCRIPTION
## What

Adds `.github/workflows/e2e-alert.yml`: triggers on completed "Real-UI E2E" runs, and when the conclusion is failure on a main push, opens a GitHub issue labeled `ci-regression` (or comments on the existing open one — deduped by label + title search).

## Why

Since #1467, the full L3 matrix (incl. Windows) runs only on main pushes. A red main L3 previously notified nobody; with PRs gated on the smoke tier only, main-health regressions need a loud signal.

## Test plan

- actionlint clean.
- Trigger/dedupe logic is minimal by design; full proof requires a real main L3 failure — the issue-query calls were validated read-only against the live repo.

## Beads

Tracks-Bead: astro-plan-ay3c
Closes-Bead: astro-plan-ay3c