### PR TITLE
fix(ci): required checks report on workflow-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,7 +84,8 @@ jobs:
   #   frontend  — run frontend steps (a TS/TSX/CSS / desktop-src / packages
   #               change, OR any force_full trigger).
   #   docs_only — informational: the change touched only docs and nothing that
-  #               drives Rust or frontend (fast-pass path).
+  #               drives Rust or frontend. No longer used as a gate; consumed
+  #               by the integration-idle step output for diagnostics.
   #   scripts   — a scripts/** change (drives the DB-boundary ratchet).
   #   all_files — CSV of every changed path, consumed by the changed-crate
   #               scoping step for `cargo test -p`.
@@ -574,32 +575,36 @@ jobs:
   #
   # This is invisible for almost every PR, because any Rust or frontend change
   # activates a lane. It bites exactly the changes that touch neither: a
-  # docs-only PR, or repo tooling such as `.design-sync/**` (which matches no
-  # filter at all, so it is not even `docs_only`). #1313 sat permanently
-  # unmergeable this way, and earlier tooling-only PRs were merged by admin
-  # override rather than by satisfying the gate.
+  # docs-only PR, a workflow-only PR (e.g. adding a new .github/workflows/*.yml
+  # file), or any other change that `decide` classifies as inert. #1313 sat
+  # permanently unmergeable this way, and earlier tooling-only PRs were merged
+  # by admin override rather than by satisfying the gate.
   #
   # Single-lane jobs need no shim: `ui-e2e` below is not a matrix, so when it
   # skips it still publishes `UI mock-mode (Playwright)` under its real name,
   # and GitHub accepts a skipped check as satisfying a required context. Only
   # the matrix name fails to materialise.
   #
-  # This job runs for docs-only changes, so the matrix DOES expand and the
-  # required contexts are reported — green, and explicit that nothing was tested
-  # rather than implying a suite passed. It runs every leg on ubuntu because it
+  # This job runs whenever NEITHER lane is active — the exact complement of
+  # `integration`'s job-level `if`. The matrix expands, the required contexts
+  # are reported green, and the step output makes clear nothing was tested
+  # rather than implying a suite passed. Every leg runs on ubuntu because it
   # executes no platform-specific work; the leg names exist to satisfy the
   # contexts, not to claim Windows coverage.
   #
-  # Gated on `docs_only` specifically, NOT on "both lanes idle". Those are no
-  # longer the same thing: `decide` now forces both lanes for any path no filter
-  # recognises, so an unclassified change is tested rather than waved through.
-  # Reporting green for "no filter matched" would be a check that degrades into
-  # "everything's fine" — the failure mode this whole gate exists to prevent.
-  # `docs_only` is the one case the repo positively asserts is inert.
+  # Gated on `rust != 'true' && frontend != 'true'`, NOT on `docs_only`. The
+  # two differ for workflow-only and config-only changes: `decide` recognises
+  # those paths (they match no force_full_* and no domain filter), so it does
+  # NOT activate either lane, but docs_only is false because no doc was touched.
+  # Reporting green only for docs_only would leave workflow-only PRs stuck with
+  # absent required contexts — the exact failure mode this shim exists to fix.
+  # The unclassified-path catch-all in `decide` forces both lanes for truly
+  # unknown paths, so rust==false && frontend==false can only occur for a change
+  # the repo positively asserts is inert.
   integration-idle:
     name: Unit + integration (L1+L2) — ${{ matrix.os }}
     needs: changes
-    if: needs.changes.outputs.docs_only == 'true'
+    if: needs.changes.outputs.rust != 'true' && needs.changes.outputs.frontend != 'true'
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
@@ -607,11 +612,13 @@ jobs:
     steps:
       - name: No Rust or frontend changes to test
         env:
+          RUST: ${{ needs.changes.outputs.rust }}
+          FRONTEND: ${{ needs.changes.outputs.frontend }}
           DOCS_ONLY: ${{ needs.changes.outputs.docs_only }}
           LEG: ${{ matrix.os }}
         run: |
           echo "Neither the Rust nor the frontend lane was triggered by this change."
-          echo "docs_only=$DOCS_ONLY"
+          echo "rust=$RUST frontend=$FRONTEND docs_only=$DOCS_ONLY"
           echo "Reporting the required context for $LEG so the PR is mergeable."
           echo "No tests ran, and none were applicable."
 


### PR DESCRIPTION
## Summary

- `integration-idle` was gated on `docs_only == 'true'`, but a workflow-only PR (rust=false, frontend=false, docs=false) leaves `docs_only=false`. Neither `integration` nor `integration-idle` ran, so the required matrix contexts were never published and the PR stalled with absent checks.
- Fix: change `integration-idle`'s `if:` to `rust != 'true' && frontend != 'true'` — the exact complement of `integration`'s gate. Covers docs-only, workflow-only, config-only, and any other inert change the decide step classifies as driving neither lane.
- Updated comment block and `docs_only` output description to reflect new semantics.

Unblocks #1496.

## Beads

Tracks-Bead: astro-plan-5m2w
Merge-Bead: astro-plan-63ai
Closes-Bead: astro-plan-5m2w