### PR TITLE
refactor(test): consolidate duplicate DB test fixtures across persistence crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4181,12 +4181,14 @@ dependencies = [
 name = "persistence_lifecycle"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
  "audit",
  "audit_types",
  "domain_core",
  "patterns",
  "persistence_core",
  "persistence_inbox",
+ "persistence_lifecycle",
  "serde",
  "serde_json",
  "sha2 0.10.9",

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -69,6 +69,11 @@ targeting = { path = "../../targeting" }
 # `test-fixture` feature; enable it for offline target.resolve use-case tests.
 # (spec 042 / T250: moved from `targeting` to `targeting_resolver`.)
 targeting_resolver = { path = "../../targeting/resolver", features = ["test-fixture"] }
+# Enable shared DB test fixtures in tests/support/mod.rs. The test-fixture feature
+# gates the `test_support` modules in both persistence crates; must not be
+# enabled in production builds.
+persistence_core = { path = "../../persistence/core", features = ["test-fixture"] }
+persistence_lifecycle = { path = "../../persistence/lifecycle", features = ["test-fixture"] }
 
 [features]
 # Developer-mode surface (spec 021). Release binaries must NOT enable this.

--- a/crates/app/core/tests/support/mod.rs
+++ b/crates/app/core/tests/support/mod.rs
@@ -7,13 +7,20 @@
 //! Real SQLite + real migrations + a wired `SqliteLifecycleRepository` and
 //! `EventBus`, mirroring the established pattern in `transition_apply.rs`.
 //! Layer-1 tests use this instead of re-declaring `setup()` per file.
+//!
+//! DB provisioning and low-level row helpers delegate to
+//! `persistence_lifecycle::test_support`; app-layer concerns (settings-cache
+//! invalidation, project-root registration via the sanctioned first_run_repo
+//! API) remain here.
 #![allow(dead_code)]
 
 use std::future::Future;
 use std::time::Duration;
 
 use audit::bus::EventBus;
+use domain_core::first_run::{OrganizationState, RegisterSourceRequest, ScanDepth, SourceKind};
 use persistence_core::Database;
+use persistence_lifecycle::repositories::first_run as first_run_repo;
 use persistence_lifecycle::repositories::lifecycle::SqliteLifecycleRepository;
 
 /// Provision an isolated in-memory SQLite DB with all migrations applied and a
@@ -30,8 +37,7 @@ use persistence_lifecycle::repositories::lifecycle::SqliteLifecycleRepository;
 /// the underlying single-process-cache architecture (out of scope here).
 pub async fn setup() -> (Database, SqliteLifecycleRepository, EventBus) {
     app_core_settings::caches::invalidate_settings_bag();
-    let db = Database::in_memory().await.expect("in-memory db");
-    db.migrate().await.expect("migrations");
+    let db = persistence_core::test_support::setup_db().await;
     let bus = EventBus::with_pool(db.pool().clone());
     let repo = SqliteLifecycleRepository::new(db.pool().clone(), bus.clone());
     (db, repo, bus)
@@ -49,48 +55,38 @@ pub const TEST_PROJECT_ROOT: &str = "C:/library/projects-root";
 pub const TEST_PROJECT_ROOT: &str = "/library/projects-root";
 
 /// Register a project-kind source so relative project request paths have an
-/// anchor (mirrors the first-run wizard registering a project folder).
+/// anchor (mirrors the first-run wizard registering a project folder). Goes
+/// through the sanctioned `first_run` repository API rather than raw SQL so
+/// column additions to `registered_sources` are automatically handled.
 pub async fn register_project_root(pool: &sqlx::SqlitePool, path: &str) {
-    sqlx::query(
-        "INSERT INTO registered_sources \
-         (id, kind, path, scan_depth, created_at, created_via, organization_state) \
-         VALUES (?, 'project', ?, 'recursive', '2026-01-01T00:00:00Z', 'first_run', 'organized')",
+    first_run_repo::register_source(
+        pool,
+        &RegisterSourceRequest {
+            kind: SourceKind::Project,
+            path: path.to_owned(),
+            kind_subtype: None,
+            scan_depth: ScanDepth::Recursive,
+            organization_state: OrganizationState::Organized,
+        },
     )
-    .bind(uuid::Uuid::new_v4().to_string())
-    .bind(path)
-    .execute(pool)
     .await
-    .unwrap();
+    .expect("register_project_root failed");
 }
 
-/// Seed a minimal `target` row.
+/// Seed a minimal `target` row into the legacy `target` table.
+///
+/// Delegates to `persistence_lifecycle::test_support::insert_target`.
 pub async fn insert_target(pool: &sqlx::SqlitePool, id: &str) {
-    sqlx::query(
-        "INSERT INTO target (id, primary_designation, created_at) \
-         VALUES (?, ?, '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(format!("T-{id}"))
-    .execute(pool)
-    .await
-    .unwrap();
+    persistence_lifecycle::test_support::insert_target(pool, id).await;
 }
 
-/// Seed a minimal `project` row in a given lifecycle state.
+/// Seed a minimal `project` row in the given lifecycle state.
+///
+/// Delegates to `persistence_lifecycle::test_support::insert_project`.
+/// The `_target` parameter is accepted for call-site compatibility but unused
+/// (the `projects` table has no mandatory FK to `target`).
 pub async fn insert_project(pool: &sqlx::SqlitePool, id: &str, _target: &str, state: &str) {
-    // Since migration 0036, the canonical lifecycle is `projects.lifecycle`.
-    // The legacy `project.state` column no longer exists; seed into `projects`
-    // so that `transition_use_case` (which reads/writes `projects.lifecycle`)
-    // can find and transition this row.
-    sqlx::query(
-        "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at) \
-         VALUES (?, 'P', 'PixInsight', ?, '/tmp/p', '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(state)
-    .execute(pool)
-    .await
-    .unwrap();
+    persistence_lifecycle::test_support::insert_project(pool, id, state).await;
 }
 
 // ── Observable-condition poll helpers ─────────────────────────────────────────

--- a/crates/persistence/core/Cargo.toml
+++ b/crates/persistence/core/Cargo.toml
@@ -21,5 +21,10 @@ uuid.workspace = true
 sea-query.workspace = true
 tempfile.workspace = true
 
+[features]
+# Enables `test_support` helpers for crates that depend on persistence_core
+# in their dev-dependencies. Must NOT be enabled in production builds.
+test-fixture = []
+
 [lints]
 workspace = true

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -20,6 +20,7 @@ mod query_builder_example;
 pub mod repositories;
 mod schema_cache;
 
+#[cfg(any(test, feature = "test-fixture"))]
 pub mod test_support;
 
 pub const CRATE_NAME: &str = "persistence_core";

--- a/crates/persistence/lifecycle/Cargo.toml
+++ b/crates/persistence/lifecycle/Cargo.toml
@@ -19,15 +19,29 @@ sqlx.workspace = true
 thiserror.workspace = true
 time.workspace = true
 uuid.workspace = true
+# async-trait is required by test_support::NoopPublisher which implements
+# audit_types::EventPublisher (an #[async_trait] trait). Optional so it is
+# only compiled when the `test-fixture` feature is active.
+async-trait = { workspace = true, optional = true }
 
 [dev-dependencies]
 audit = { path = "../../audit" }
 domain_core = { path = "../../domain/core" }
-persistence_core = { path = "../core", features = [] }
+persistence_core = { path = "../core", features = ["test-fixture"] }
 persistence_inbox = { path = "../inbox" }
 tempfile.workspace = true
 tokio.workspace = true
 uuid.workspace = true
+# Self-reference activates the test-fixture feature when building integration
+# tests in the `tests/` directory (those are separate compilation units that
+# depend on this crate as a regular dep and therefore would not see
+# cfg(feature)-gated items without the feature being explicitly activated).
+persistence_lifecycle = { path = ".", features = ["test-fixture"] }
+
+[features]
+# Enables `test_support` helpers for crates that depend on persistence_lifecycle
+# in their dev-dependencies. Must NOT be enabled in production builds.
+test-fixture = ["persistence_core/test-fixture", "dep:async-trait"]
 
 [lints]
 workspace = true

--- a/crates/persistence/lifecycle/src/lib.rs
+++ b/crates/persistence/lifecycle/src/lib.rs
@@ -5,3 +5,6 @@
 #![allow(clippy::doc_markdown)]
 
 pub mod repositories;
+
+#[cfg(any(test, feature = "test-fixture"))]
+pub mod test_support;

--- a/crates/persistence/lifecycle/src/test_support.rs
+++ b/crates/persistence/lifecycle/src/test_support.rs
@@ -1,0 +1,168 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Shared in-process test fixtures for persistence_lifecycle integration tests.
+//!
+//! Available under `cfg(test)` within this crate and via the `test-fixture`
+//! feature for external consumers (e.g. `app_core` dev-dependencies).
+//!
+//! The returned `SqliteLifecycleRepository` owns an internal `EventBus`.
+//! Callers that need direct bus access (e.g. to subscribe a listener before the
+//! repo is exercised) should construct their own `EventBus` against the same
+//! pool and pass it to `SqliteLifecycleRepository::new` directly — see
+//! `app_core/tests/support/mod.rs` for that pattern.
+
+use audit_types::{EventPublisher, Source};
+use persistence_core::Database;
+use sqlx::SqlitePool;
+
+use crate::repositories::lifecycle::SqliteLifecycleRepository;
+
+/// No-op [`EventPublisher`] for test setups that do not need event delivery.
+///
+/// This avoids a dependency on the `audit` crate (which depends on
+/// `persistence_lifecycle`, creating a cycle) while still satisfying the
+/// `EventPublisher` bound on `SqliteLifecycleRepository::new`.
+struct NoopPublisher;
+
+#[async_trait::async_trait]
+impl EventPublisher for NoopPublisher {
+    async fn publish(&self, _topic: &str, _source: Source, _payload: serde_json::Value) {}
+}
+
+/// Provision an isolated in-memory `Database` with all migrations applied and
+/// wire a `SqliteLifecycleRepository` against it. Returns `(Database, repo)`.
+///
+/// The repository is wired with a no-op event publisher. If a test needs live
+/// event delivery (e.g. to subscribe a listener), construct an `audit::bus::EventBus`
+/// against the pool directly and pass it to `SqliteLifecycleRepository::new`.
+///
+/// # Panics
+///
+/// Panics if the in-memory pool, migrations, or repository construction fails.
+pub async fn setup() -> (Database, SqliteLifecycleRepository) {
+    let db = persistence_core::test_support::setup_db().await;
+    let repo = SqliteLifecycleRepository::new(db.pool().clone(), NoopPublisher);
+    (db, repo)
+}
+
+/// Insert a minimal `target` row sufficient to seed ledger-view entity data.
+///
+/// Inserts into the legacy `target` table (the simpler in-app catalog),
+/// NOT `canonical_target` (the resolver domain).
+///
+/// # Panics
+///
+/// Panics on SQL failure.
+pub async fn insert_target(pool: &SqlitePool, id: &str) {
+    sqlx::query(
+        "INSERT INTO target (id, primary_designation, created_at) \
+         VALUES (?, ?, '2026-05-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(format!("DES-{id}"))
+    .execute(pool)
+    .await
+    .expect("insert_target failed");
+}
+
+/// Insert a minimal `projects` row sufficient to satisfy lifecycle and ledger
+/// queries. `state` is the initial `lifecycle` column value.
+///
+/// Uses a per-`id` path to avoid the `UNIQUE(path)` constraint when multiple
+/// projects are seeded in the same test.
+///
+/// # Panics
+///
+/// Panics on SQL failure.
+pub async fn insert_project(pool: &SqlitePool, id: &str, state: &str) {
+    let path = format!("projects/{id}");
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, created_at, updated_at) \
+         VALUES (?, 'P', 'PixInsight', ?, ?, '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(state)
+    .bind(&path)
+    .execute(pool)
+    .await
+    .expect("insert_project failed");
+}
+
+/// Insert a `projects` row with an explicit `name` and `created_at` / `updated_at`
+/// timestamp — use this when ledger filter tests need stable titles or
+/// date-range queries. For simple FK-seed rows use [`insert_project`] instead.
+///
+/// # Panics
+///
+/// Panics on SQL failure.
+pub async fn insert_named_project(
+    pool: &SqlitePool,
+    id: &str,
+    name: &str,
+    state: &str,
+    created_at: &str,
+) {
+    let path = format!("projects/{id}");
+    sqlx::query(
+        "INSERT INTO projects \
+         (id, name, tool, lifecycle, path, created_at, updated_at) \
+         VALUES (?, ?, 'PixInsight', ?, ?, ?, ?)",
+    )
+    .bind(id)
+    .bind(name)
+    .bind(state)
+    .bind(&path)
+    .bind(created_at)
+    .bind(created_at)
+    .execute(pool)
+    .await
+    .expect("insert_named_project failed");
+}
+
+/// Insert a minimal `library_root` row for ledger-view entity seeding.
+///
+/// # Panics
+///
+/// Panics on SQL failure.
+pub async fn insert_library_root(pool: &SqlitePool, id: &str, label: &str) {
+    sqlx::query(
+        "INSERT INTO library_root \
+         (id, label, current_path, kind, state, last_seen_at, created_at) \
+         VALUES (?, ?, '/tmp/lr', 'local', 'active', '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
+    )
+    .bind(id)
+    .bind(label)
+    .execute(pool)
+    .await
+    .expect("insert_library_root failed");
+}
+
+/// Insert a minimal `file_record` row for ledger-view entity seeding.
+///
+/// # Panics
+///
+/// Panics on SQL failure.
+pub async fn insert_file_record(
+    pool: &SqlitePool,
+    id: &str,
+    root_id: &str,
+    rel_path: &str,
+    state: &str,
+    last_seen_at: &str,
+) {
+    sqlx::query(
+        "INSERT INTO file_record \
+         (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
+         VALUES (?, ?, ?, 0, '2026-05-01T00:00:00Z', ?, '2026-05-01T00:00:00Z', ?)",
+    )
+    .bind(id)
+    .bind(root_id)
+    .bind(rel_path)
+    .bind(state)
+    .bind(last_seen_at)
+    .execute(pool)
+    .await
+    .expect("insert_file_record failed");
+}

--- a/crates/persistence/lifecycle/tests/ledger_view.rs
+++ b/crates/persistence/lifecycle/tests/ledger_view.rs
@@ -7,103 +7,19 @@
 //! across multiple entity tables, then exercises the various filter
 //! combinations supported by `LedgerFilter`.
 
-use audit::bus::EventBus;
 use domain_core::ids::EntityId;
 use domain_core::lifecycle::data_asset::EntityType;
-use persistence_core::Database;
-use persistence_lifecycle::repositories::lifecycle::{
-    LedgerFilter, LifecycleRepository, SqliteLifecycleRepository,
-};
+use persistence_lifecycle::repositories::lifecycle::{LedgerFilter, LifecycleRepository};
+use persistence_lifecycle::test_support as support;
 use uuid::Uuid;
-
-async fn setup() -> (Database, SqliteLifecycleRepository) {
-    let db = Database::in_memory().await.expect("in-memory connect");
-    db.migrate().await.expect("migrations");
-    let repo =
-        SqliteLifecycleRepository::new(db.pool().clone(), EventBus::new(db.pool().clone(), 16));
-    (db, repo)
-}
 
 fn new_uuid() -> String {
     Uuid::new_v4().to_string()
 }
 
-async fn insert_library_root(pool: &sqlx::SqlitePool, id: &str, label: &str) {
-    sqlx::query(
-        "INSERT INTO library_root (id, label, current_path, kind, state, last_seen_at, created_at) \
-         VALUES (?, ?, '/tmp/lr', 'local', 'active', '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(label)
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-async fn insert_target(pool: &sqlx::SqlitePool, id: &str) {
-    sqlx::query(
-        "INSERT INTO target (id, primary_designation, created_at) \
-         VALUES (?, ?, '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(format!("DES-{id}"))
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-/// Insert a project into the canonical `projects` table used by the baseline ledger view.
-async fn insert_project(
-    pool: &sqlx::SqlitePool,
-    id: &str,
-    name: &str,
-    _target_id: &str,
-    state: &str,
-    created_at: &str,
-) {
-    // Use the id as part of the path to avoid UNIQUE(path) collisions.
-    let path = format!("projects/{id}");
-    sqlx::query(
-        "INSERT INTO projects (id, name, tool, lifecycle, path, created_at, updated_at) \
-         VALUES (?, ?, 'PixInsight', ?, ?, ?, ?)",
-    )
-    .bind(id)
-    .bind(name)
-    .bind(state)
-    .bind(&path)
-    .bind(created_at)
-    .bind(created_at)
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-async fn insert_file_record(
-    pool: &sqlx::SqlitePool,
-    id: &str,
-    root_id: &str,
-    rel_path: &str,
-    state: &str,
-    last_seen_at: &str,
-) {
-    sqlx::query(
-        "INSERT INTO file_record \
-         (id, root_id, relative_path, size_bytes, mtime, state, first_seen_at, last_seen_at) \
-         VALUES (?, ?, ?, 0, '2026-05-01T00:00:00Z', ?, '2026-05-01T00:00:00Z', ?)",
-    )
-    .bind(id)
-    .bind(root_id)
-    .bind(rel_path)
-    .bind(state)
-    .bind(last_seen_at)
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
 #[tokio::test]
 async fn ledger_view_unions_all_seeded_entities() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
@@ -111,10 +27,11 @@ async fn ledger_view_unions_all_seeded_entities() {
     let project = new_uuid();
     let file = new_uuid();
 
-    insert_library_root(pool, &root, "lr-1").await;
-    insert_target(pool, &target).await;
-    insert_project(pool, &project, "Test Project", &target, "ready", "2026-05-10T00:00:00Z").await;
-    insert_file_record(
+    support::insert_library_root(pool, &root, "lr-1").await;
+    support::insert_target(pool, &target).await;
+    support::insert_named_project(pool, &project, "Test Project", "ready", "2026-05-10T00:00:00Z")
+        .await;
+    support::insert_file_record(
         pool,
         &file,
         &root,
@@ -133,16 +50,16 @@ async fn ledger_view_unions_all_seeded_entities() {
 
 #[tokio::test]
 async fn entity_type_filter_restricts_results() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
     let target = new_uuid();
     let project = new_uuid();
 
-    insert_library_root(pool, &root, "lr").await;
-    insert_target(pool, &target).await;
-    insert_project(pool, &project, "P", &target, "ready", "2026-05-10T00:00:00Z").await;
+    support::insert_library_root(pool, &root, "lr").await;
+    support::insert_target(pool, &target).await;
+    support::insert_named_project(pool, &project, "P", "ready", "2026-05-10T00:00:00Z").await;
 
     let filter = LedgerFilter { entity_types: vec![EntityType::Project], ..Default::default() };
     let rows = repo.list_assets_ledger(filter).await.unwrap();
@@ -153,25 +70,30 @@ async fn entity_type_filter_restricts_results() {
 
 #[tokio::test]
 async fn state_filter_in_clause() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
     let target = new_uuid();
-    insert_library_root(pool, &root, "lr").await;
-    insert_target(pool, &target).await;
+    support::insert_library_root(pool, &root, "lr").await;
+    support::insert_target(pool, &target).await;
 
     let p_ready = new_uuid();
     let p_completed = new_uuid();
     let p_processing = new_uuid();
-    insert_project(pool, &p_ready, "ready", &target, "ready", "2026-05-10T00:00:00Z").await;
-    insert_project(pool, &p_completed, "completed", &target, "completed", "2026-05-11T00:00:00Z")
-        .await;
-    insert_project(
+    support::insert_named_project(pool, &p_ready, "ready", "ready", "2026-05-10T00:00:00Z").await;
+    support::insert_named_project(
+        pool,
+        &p_completed,
+        "completed",
+        "completed",
+        "2026-05-11T00:00:00Z",
+    )
+    .await;
+    support::insert_named_project(
         pool,
         &p_processing,
         "processing",
-        &target,
         "processing",
         "2026-05-12T00:00:00Z",
     )
@@ -190,17 +112,17 @@ async fn state_filter_in_clause() {
 
 #[tokio::test]
 async fn project_id_filter_restricts_to_owning_project() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
     let target = new_uuid();
     let p1 = new_uuid();
     let p2 = new_uuid();
-    insert_library_root(pool, &root, "lr").await;
-    insert_target(pool, &target).await;
-    insert_project(pool, &p1, "P1", &target, "ready", "2026-05-10T00:00:00Z").await;
-    insert_project(pool, &p2, "P2", &target, "ready", "2026-05-11T00:00:00Z").await;
+    support::insert_library_root(pool, &root, "lr").await;
+    support::insert_target(pool, &target).await;
+    support::insert_named_project(pool, &p1, "P1", "ready", "2026-05-10T00:00:00Z").await;
+    support::insert_named_project(pool, &p2, "P2", "ready", "2026-05-11T00:00:00Z").await;
 
     // project_id on a project row equals its own id.
     let filter = LedgerFilter {
@@ -214,20 +136,20 @@ async fn project_id_filter_restricts_to_owning_project() {
 
 #[tokio::test]
 async fn updated_range_filter() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
     let target = new_uuid();
-    insert_library_root(pool, &root, "lr").await;
-    insert_target(pool, &target).await;
+    support::insert_library_root(pool, &root, "lr").await;
+    support::insert_target(pool, &target).await;
 
     let p_early = new_uuid();
     let p_mid = new_uuid();
     let p_late = new_uuid();
-    insert_project(pool, &p_early, "E", &target, "ready", "2026-04-01T00:00:00Z").await;
-    insert_project(pool, &p_mid, "M", &target, "ready", "2026-05-15T00:00:00Z").await;
-    insert_project(pool, &p_late, "L", &target, "ready", "2026-06-01T00:00:00Z").await;
+    support::insert_named_project(pool, &p_early, "E", "ready", "2026-04-01T00:00:00Z").await;
+    support::insert_named_project(pool, &p_mid, "M", "ready", "2026-05-15T00:00:00Z").await;
+    support::insert_named_project(pool, &p_late, "L", "ready", "2026-06-01T00:00:00Z").await;
 
     let filter = LedgerFilter {
         entity_types: vec![EntityType::Project],
@@ -242,21 +164,20 @@ async fn updated_range_filter() {
 
 #[tokio::test]
 async fn limit_and_offset_paginate() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
     let target = new_uuid();
-    insert_library_root(pool, &root, "lr").await;
-    insert_target(pool, &target).await;
+    support::insert_library_root(pool, &root, "lr").await;
+    support::insert_target(pool, &target).await;
 
     for i in 0..5 {
         let id = new_uuid();
-        insert_project(
+        support::insert_named_project(
             pool,
             &id,
             &format!("P{i}"),
-            &target,
             "ready",
             &format!("2026-05-{:02}T00:00:00Z", 10 + i),
         )
@@ -295,13 +216,13 @@ async fn limit_and_offset_paginate() {
 
 #[tokio::test]
 async fn file_record_carries_path_not_title() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let root = new_uuid();
     let file = new_uuid();
-    insert_library_root(pool, &root, "lr").await;
-    insert_file_record(
+    support::insert_library_root(pool, &root, "lr").await;
+    support::insert_file_record(
         pool,
         &file,
         &root,

--- a/crates/persistence/lifecycle/tests/provenance_hydration.rs
+++ b/crates/persistence/lifecycle/tests/provenance_hydration.rs
@@ -8,49 +8,13 @@
 //!   * History pagination: inline retention bounded at 10 newest entries; the
 //!     `history_truncated` flag is set when more entries exist in the archive.
 
-use audit::bus::EventBus;
 use domain_core::ids::EntityId;
 use domain_core::lifecycle::data_asset::EntityType;
 use domain_core::lifecycle::provenance::ProvenanceTag;
-use persistence_core::Database;
-use persistence_lifecycle::repositories::lifecycle::{
-    LifecycleRepository, SqliteLifecycleRepository,
-};
+use persistence_lifecycle::repositories::lifecycle::LifecycleRepository;
 use persistence_lifecycle::repositories::provenance::{load_provenance, INLINE_HISTORY_LIMIT};
+use persistence_lifecycle::test_support as support;
 use uuid::Uuid;
-
-async fn setup() -> (Database, SqliteLifecycleRepository) {
-    let db = Database::in_memory().await.expect("in-memory connect");
-    db.migrate().await.expect("migrations");
-    let repo =
-        SqliteLifecycleRepository::new(db.pool().clone(), EventBus::new(db.pool().clone(), 16));
-    (db, repo)
-}
-
-async fn insert_target(pool: &sqlx::SqlitePool, id: &str) {
-    sqlx::query(
-        "INSERT INTO target (id, primary_designation, created_at) \
-         VALUES (?, ?, '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(format!("DES-{id}"))
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-/// Insert a project into the canonical `projects` table used by provenance hydration.
-async fn insert_project(pool: &sqlx::SqlitePool, id: &str, _target_id: &str) {
-    sqlx::query(
-        "INSERT INTO projects \
-         (id, name, tool, lifecycle, path, created_at, updated_at) \
-         VALUES (?, 'P', 'PixInsight', 'ready', 'projects/P', '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .execute(pool)
-    .await
-    .unwrap();
-}
 
 #[allow(clippy::too_many_arguments)]
 async fn insert_prov_row(
@@ -84,7 +48,7 @@ async fn insert_prov_row(
 
 #[tokio::test]
 async fn priority_resolution_reviewed_wins_over_inferred_and_observed() {
-    let (db, _repo) = setup().await;
+    let (db, _repo) = support::setup().await;
     let pool = db.pool();
 
     let asset_id = Uuid::new_v4().to_string();
@@ -140,7 +104,7 @@ async fn priority_resolution_reviewed_wins_over_inferred_and_observed() {
 
 #[tokio::test]
 async fn priority_resolution_skips_superseded_entries() {
-    let (db, _repo) = setup().await;
+    let (db, _repo) = support::setup().await;
     let pool = db.pool();
 
     let asset_id = Uuid::new_v4().to_string();
@@ -179,7 +143,7 @@ async fn priority_resolution_skips_superseded_entries() {
 
 #[tokio::test]
 async fn history_pagination_caps_inline_at_ten_and_sets_truncated_flag() {
-    let (db, _repo) = setup().await;
+    let (db, _repo) = support::setup().await;
     let pool = db.pool();
 
     let asset_id = Uuid::new_v4().to_string();
@@ -213,7 +177,7 @@ async fn history_pagination_caps_inline_at_ten_and_sets_truncated_flag() {
 
 #[tokio::test]
 async fn load_provenance_for_unknown_asset_returns_empty_map() {
-    let (db, _repo) = setup().await;
+    let (db, _repo) = support::setup().await;
     let pool = db.pool();
     let entity_id = EntityId::from_uuid(Uuid::new_v4());
     let (map, truncated) = load_provenance(pool, entity_id, "project").await.unwrap();
@@ -223,13 +187,13 @@ async fn load_provenance_for_unknown_asset_returns_empty_map() {
 
 #[tokio::test]
 async fn load_asset_detail_includes_hydrated_provenance() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let target = Uuid::new_v4().to_string();
     let proj = Uuid::new_v4().to_string();
-    insert_target(pool, &target).await;
-    insert_project(pool, &proj, &target).await;
+    support::insert_target(pool, &target).await;
+    support::insert_project(pool, &proj, "ready").await;
     insert_prov_row(
         pool,
         "project",
@@ -253,13 +217,13 @@ async fn load_asset_detail_includes_hydrated_provenance() {
 
 #[tokio::test]
 async fn field_origins_returns_winning_tag_per_field() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let pool = db.pool();
 
     let target = Uuid::new_v4().to_string();
     let proj = Uuid::new_v4().to_string();
-    insert_target(pool, &target).await;
-    insert_project(pool, &proj, &target).await;
+    support::insert_target(pool, &target).await;
+    support::insert_project(pool, &proj, "ready").await;
 
     // `name` has only an observed entry; `target.coords` has observed +
     // reviewed (reviewed must win per priority).
@@ -305,7 +269,7 @@ async fn field_origins_returns_winning_tag_per_field() {
 
 #[tokio::test]
 async fn field_origins_empty_for_unknown_asset() {
-    let (_db, repo) = setup().await;
+    let (_db, repo) = support::setup().await;
     let entity_id = EntityId::from_uuid(Uuid::new_v4());
     let origins = repo.field_origins(entity_id, EntityType::Project).await.unwrap();
     assert!(origins.is_empty());

--- a/crates/persistence/lifecycle/tests/transactional.rs
+++ b/crates/persistence/lifecycle/tests/transactional.rs
@@ -12,48 +12,12 @@
 
 #![allow(clippy::doc_markdown)]
 
-use audit::bus::EventBus;
 use domain_core::ids::EntityId;
 use domain_core::lifecycle::data_asset::EntityType;
-use persistence_core::{Database, DbError};
-use persistence_lifecycle::repositories::lifecycle::{
-    LifecycleRepository, SqliteLifecycleRepository, TransitionRequest,
-};
+use persistence_core::DbError;
+use persistence_lifecycle::repositories::lifecycle::{LifecycleRepository, TransitionRequest};
+use persistence_lifecycle::test_support as support;
 use uuid::Uuid;
-
-async fn setup() -> (Database, SqliteLifecycleRepository) {
-    let db = Database::in_memory().await.expect("in-memory connect");
-    db.migrate().await.expect("migrations");
-    let repo =
-        SqliteLifecycleRepository::new(db.pool().clone(), EventBus::new(db.pool().clone(), 16));
-    (db, repo)
-}
-
-async fn insert_target(pool: &sqlx::SqlitePool, id: &str) {
-    sqlx::query(
-        "INSERT INTO target (id, primary_designation, created_at) \
-         VALUES (?, ?, '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(format!("DES-{id}"))
-    .execute(pool)
-    .await
-    .unwrap();
-}
-
-/// Insert a project into the canonical `projects` table used by lifecycle transitions.
-async fn insert_project(pool: &sqlx::SqlitePool, id: &str, _target: &str, state: &str) {
-    sqlx::query(
-        "INSERT INTO projects \
-         (id, name, tool, lifecycle, path, created_at, updated_at) \
-         VALUES (?, 'P', 'PixInsight', ?, 'projects/P', '2026-05-01T00:00:00Z', '2026-05-01T00:00:00Z')",
-    )
-    .bind(id)
-    .bind(state)
-    .execute(pool)
-    .await
-    .unwrap();
-}
 
 async fn audit_row_count(pool: &sqlx::SqlitePool, entity_id: &str) -> i64 {
     let (n,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM audit_log_entry WHERE entity_id = ?")
@@ -76,11 +40,11 @@ async fn project_state(pool: &sqlx::SqlitePool, id: &str) -> String {
 
 #[tokio::test]
 async fn successful_transition_writes_audit_and_entity_together() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let target_id = Uuid::new_v4().to_string();
     let project_id = Uuid::new_v4().to_string();
-    insert_target(db.pool(), &target_id).await;
-    insert_project(db.pool(), &project_id, &target_id, "ready").await;
+    support::insert_target(db.pool(), &target_id).await;
+    support::insert_project(db.pool(), &project_id, "ready").await;
 
     let entity_id = EntityId::from_uuid(Uuid::parse_str(&project_id).unwrap());
     let record = repo
@@ -104,12 +68,12 @@ async fn successful_transition_writes_audit_and_entity_together() {
 
 #[tokio::test]
 async fn refused_transition_rolls_back_both_sides() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let target_id = Uuid::new_v4().to_string();
     let project_id = Uuid::new_v4().to_string();
-    insert_target(db.pool(), &target_id).await;
+    support::insert_target(db.pool(), &target_id).await;
     // Stored state is `ready`; caller claims `prepared` — CAS must fail.
-    insert_project(db.pool(), &project_id, &target_id, "ready").await;
+    support::insert_project(db.pool(), &project_id, "ready").await;
 
     let entity_id = EntityId::from_uuid(Uuid::parse_str(&project_id).unwrap());
     let result = repo
@@ -133,11 +97,11 @@ async fn refused_transition_rolls_back_both_sides() {
 
 #[tokio::test]
 async fn noop_transition_writes_nothing() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let target_id = Uuid::new_v4().to_string();
     let project_id = Uuid::new_v4().to_string();
-    insert_target(db.pool(), &target_id).await;
-    insert_project(db.pool(), &project_id, &target_id, "ready").await;
+    support::insert_target(db.pool(), &target_id).await;
+    support::insert_project(db.pool(), &project_id, "ready").await;
 
     let entity_id = EntityId::from_uuid(Uuid::parse_str(&project_id).unwrap());
     // Noop: from == to.
@@ -163,11 +127,11 @@ async fn noop_transition_writes_nothing() {
 
 #[tokio::test]
 async fn audit_carries_full_envelope_columns() {
-    let (db, repo) = setup().await;
+    let (db, repo) = support::setup().await;
     let target_id = Uuid::new_v4().to_string();
     let project_id = Uuid::new_v4().to_string();
-    insert_target(db.pool(), &target_id).await;
-    insert_project(db.pool(), &project_id, &target_id, "ready").await;
+    support::insert_target(db.pool(), &target_id).await;
+    support::insert_project(db.pool(), &project_id, "ready").await;
 
     let entity_id = EntityId::from_uuid(Uuid::parse_str(&project_id).unwrap());
     let request_id = EntityId::new();


### PR DESCRIPTION
## Summary
- Eliminates 9 duplicate helper functions (setup, insert_target, insert_project) that were copy-pasted across three persistence_lifecycle integration test files and had begun to diverge from persistence_core::test_support after the #1488 split.
- Replaces raw SQL in app_core's register_project_root test helper with the sanctioned first_run_repo API so column additions to registered_sources no longer silently break tests.

## What changed
- New persistence_lifecycle::test_support module (behind test-fixture feature): shared setup, insert_target (target table), insert_project, insert_named_project, insert_library_root, insert_file_record.
- persistence_core::test_support gated behind new test-fixture feature (was always-public, no behavior change).
- persistence_lifecycle/tests/transactional.rs, ledger_view.rs, provenance_hydration.rs: local helpers removed; use test_support as support.
- app_core/tests/support/mod.rs: setup and insert helpers delegate to the shared module; register_project_root uses first_run_repo API.
- app_core/tests/transition_apply.rs local setup/insert helpers deliberately left (predates the support module; separate cleanup).

## Beads

Tracks-Bead: astro-plan-ujo1
Merge-Bead: astro-plan-v0v9