### PR TITLE
fix: moving files across drives no longer resets their timestamps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1883,6 +1883,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "domain_core",
+ "filetime",
  "fs4",
  "fs_pathsafe",
  "path-clean",

--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -23,6 +23,8 @@ trash.workspace = true
 # gate (replaces the hand-rolled component walk; symlink-safety is unchanged).
 path-clean.workspace = true
 fs4 = { version = "1.1.0", default-features = false, features = ["sync"] }
+# Preserve source mtime after cross-volume copy (constitution §II archival fidelity).
+filetime = "0.2"
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fs/executor/src/ops/link_op.rs
+++ b/crates/fs/executor/src/ops/link_op.rs
@@ -23,6 +23,7 @@
 
 use camino::Utf8Path;
 use domain_core::source_view::Materialization;
+use filetime::FileTime;
 
 use crate::failure::{FailureCode, PlanItemFailure};
 
@@ -64,9 +65,32 @@ pub fn create_link(
         }
         Materialization::Hardlink => std::fs::hard_link(source, destination)
             .map_err(|e| PlanItemFailure::from_io(&e, "create hardlink")),
-        Materialization::Copy => std::fs::copy(source, destination)
-            .map(|_| ())
-            .map_err(|e| PlanItemFailure::from_io(&e, "copy file")),
+        Materialization::Copy => {
+            // Read source mtime before copying so it survives even if the source
+            // later becomes inaccessible.
+            let source_mtime =
+                std::fs::metadata(source).map(|m| FileTime::from_last_modification_time(&m)).ok();
+
+            std::fs::copy(source, destination)
+                .map_err(|e| PlanItemFailure::from_io(&e, "copy file"))?;
+
+            // Restore mtime: std::fs::copy resets it to "now".  mtime feeds the
+            // per-file signature in crates/app/inbox, so without this a Copy
+            // materialization would look like a new file to any watcher.
+            // Failure is non-fatal — bytes are correct; warn and continue.
+            if let Some(mtime) = source_mtime {
+                if let Err(e) = filetime::set_file_mtime(destination, mtime) {
+                    tracing::warn!(
+                        %destination,
+                        error = %e,
+                        "link Copy: could not restore mtime on destination; \
+                         file data is intact but timestamp reflects copy time"
+                    );
+                }
+            }
+
+            Ok(())
+        }
         Materialization::Junction => Err(PlanItemFailure::with_code(
             FailureCode::MaterializationUnsupported,
             "junction materialization is not yet implemented by this executor",
@@ -157,5 +181,48 @@ mod tests {
         let err = create_link(&source, &dest, Materialization::Junction).unwrap_err();
         assert_eq!(err.code, FailureCode::MaterializationUnsupported);
         assert!(!dest.exists());
+    }
+
+    #[test]
+    fn copy_materialization_preserves_source_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let source = utf8(dir.path().join("source.fits"));
+        let dest = utf8(dir.path().join("dest.fits"));
+        std::fs::write(&source, b"data").unwrap();
+
+        // Pin source mtime to a known value in the past.
+        let known_mtime = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+        filetime::set_file_mtime(&source, known_mtime).unwrap();
+
+        create_link(&source, &dest, Materialization::Copy).unwrap();
+
+        let dest_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&dest).unwrap());
+        assert_eq!(
+            dest_mtime.unix_seconds(),
+            known_mtime.unix_seconds(),
+            "Copy materialization must restore source mtime on destination"
+        );
+    }
+
+    #[test]
+    fn symlink_and_hardlink_do_not_use_mtime_restore_path() {
+        // Symlinks and hardlinks share the underlying inode or target mtime by
+        // OS contract; no filetime call is made by the executor for these kinds.
+        // This test confirms they succeed and the destination is accessible.
+        let dir = tempfile::tempdir().unwrap();
+        let source = utf8(dir.path().join("source.fits"));
+        std::fs::write(&source, b"data").unwrap();
+
+        let known_mtime = filetime::FileTime::from_unix_time(1_600_000_000, 0);
+        filetime::set_file_mtime(&source, known_mtime).unwrap();
+
+        let dest_sym = utf8(dir.path().join("sym.fits"));
+        create_link(&source, &dest_sym, Materialization::Symlink).unwrap();
+        assert_eq!(std::fs::read(&dest_sym).unwrap(), b"data");
+
+        let dest_hard = utf8(dir.path().join("hard.fits"));
+        create_link(&source, &dest_hard, Materialization::Hardlink).unwrap();
+        assert_eq!(std::fs::read(&dest_hard).unwrap(), b"data");
     }
 }

--- a/crates/fs/executor/src/ops/move_op.rs
+++ b/crates/fs/executor/src/ops/move_op.rs
@@ -14,6 +14,7 @@
 //! checked before any mutation.
 
 use camino::Utf8Path;
+use filetime::FileTime;
 
 use crate::failure::{FailureCode, PlanItemFailure, RollbackOutcome};
 
@@ -115,11 +116,34 @@ fn move_file_with_ops(
     }
 
     // Cross-volume: copy-then-delete.
+    //
+    // Read source mtime before the copy so it is available even if the source
+    // later becomes inaccessible.  Failure to read mtime is non-fatal: the data
+    // is already in `source` and will be preserved by the copy regardless.
+    let source_mtime =
+        std::fs::metadata(source).map(|m| FileTime::from_last_modification_time(&m)).ok();
+
     if let Err(copy_err) = std::fs::copy(source, destination) {
         return Err((
             PlanItemFailure::from_io(&copy_err, &format!("copy {source} to {destination}")),
             no_rollback,
         ));
+    }
+
+    // Restore mtime on the destination.  std::fs::copy resets it to "now", but
+    // mtime is user-meaningful (session-date sorting) and feeds the per-file
+    // signature in crates/app/inbox — without this a cross-volume move would
+    // look like a new file to any watcher on the destination root.
+    // Failure is non-fatal: the bytes are correct; we warn and continue.
+    if let Some(mtime) = source_mtime {
+        if let Err(e) = filetime::set_file_mtime(destination, mtime) {
+            tracing::warn!(
+                %destination,
+                error = %e,
+                "cross-volume move: could not restore mtime on destination; \
+                 file data is intact but timestamp reflects copy time"
+            );
+        }
     }
 
     // Copy succeeded. Attempt source delete.
@@ -339,5 +363,56 @@ mod tests {
         // leave behind on a genuine double-failure.
         assert!(src.exists(), "source must survive a delete failure");
         assert!(dst.exists(), "destination copy must survive a failed rollback");
+    }
+
+    // ── mtime preservation ────────────────────────────────────────────────────
+
+    #[test]
+    fn cross_volume_move_preserves_source_mtime() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8(dir.path());
+        let src = root.join("source.fits");
+        let dst = root.join("dest.fits");
+        std::fs::write(&src, b"data").unwrap();
+
+        // Pin source mtime to a known value in the past.
+        let known_mtime = filetime::FileTime::from_unix_time(1_700_000_000, 0);
+        filetime::set_file_mtime(&src, known_mtime).unwrap();
+
+        move_file_with_ops(&src, &dst, fake_exdev, |p| std::fs::remove_file(p)).unwrap();
+
+        let dst_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&dst).unwrap());
+        assert_eq!(
+            dst_mtime.unix_seconds(),
+            known_mtime.unix_seconds(),
+            "destination mtime must match source mtime after cross-volume move"
+        );
+    }
+
+    #[test]
+    fn same_volume_move_does_not_touch_mtime_logic() {
+        // rename() preserves mtime by OS contract; this test confirms the
+        // cross-volume branch (and its mtime logic) is NOT entered on same-volume.
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8(dir.path());
+        let src = root.join("source.fits");
+        let dst = root.join("dest.fits");
+        std::fs::write(&src, b"data").unwrap();
+
+        let known_mtime = filetime::FileTime::from_unix_time(1_600_000_000, 0);
+        filetime::set_file_mtime(&src, known_mtime).unwrap();
+
+        // Real rename — same-volume, no cross-device error.
+        move_file(&src, &dst).unwrap();
+
+        let dst_mtime =
+            filetime::FileTime::from_last_modification_time(&std::fs::metadata(&dst).unwrap());
+        // rename(2) preserves mtime on every supported OS.
+        assert_eq!(
+            dst_mtime.unix_seconds(),
+            known_mtime.unix_seconds(),
+            "rename preserves mtime; destination should match the known pinned mtime"
+        );
     }
 }


### PR DESCRIPTION
## Summary

- Cross-drive moves and source-view copy materializations were resetting file modification times to the current time, causing session-date sorting to break and the inbox to treat moved files as new arrivals.
- Fix reads the source mtime before copying and restores it on the destination; a failure to set mtime warns in the log but does not fail the plan item.

## Spec Context

crates/fs/executor — move_op.rs (cross-volume branch), link_op.rs (Copy materialization arm).

Tracks-Bead: astro-plan-kyo7.57
Closes-Bead: astro-plan-kyo7.57
Merge-Bead: astro-plan-jz3l