### PR TITLE
perf: splash screen dismisses immediately on app ready instead of waiting 800ms

### DIFF
--- a/apps/desktop/splash.html
+++ b/apps/desktop/splash.html
@@ -48,12 +48,16 @@
           sans-serif;
         -webkit-font-smoothing: antialiased;
       }
+      /* .pv-fading is added by main.ts on boot-ready; the transition keeps the
+         wordmark visible through the fade so warm-start doesn't hard-cut. */
       .pv-card {
         width: 480px;
         height: 320px;
         border-radius: 16px;
         position: relative;
         overflow: hidden;
+        opacity: 1;
+        transition: opacity 150ms ease-out;
         background:
           radial-gradient(120% 90% at 85% -14%, rgba(217, 138, 61, 0.1), transparent 55%),
           radial-gradient(1px 1px at 6% 12%, rgba(240, 235, 226, 0.75), transparent),
@@ -84,6 +88,9 @@
         box-shadow:
           0 34px 70px -24px rgba(0, 0, 0, 0.72),
           inset 0 0 0 1px rgba(255, 255, 255, 0.05);
+      }
+      .pv-fading {
+        opacity: 0;
       }
       .pv-content {
         position: absolute;

--- a/apps/desktop/src/splash/main.test.ts
+++ b/apps/desktop/src/splash/main.test.ts
@@ -1,0 +1,150 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * splash/main.test.ts — event-driven splash dismissal (handoff 07).
+ *
+ * Verifies:
+ * - boot-ready triggers immediate dismissal (no minimum floor).
+ * - The fallback timer fires after READY_TIMEOUT_MS when boot-ready never
+ *   arrives (unchanged from the original design).
+ * - Timestamps are logged at splash-shown, boot-ready-received, and
+ *   window-shown.
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// --- Tauri API mocks ---
+
+const mockShow = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+const mockSetFocus = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+const mockClose = vi.fn<() => Promise<void>>().mockResolvedValue(undefined);
+
+let bootReadyCallback: (() => void) | null = null;
+
+vi.mock('@tauri-apps/api/window', () => ({
+  getAllWindows: vi.fn(() =>
+    Promise.resolve([
+      { label: 'main', show: mockShow, setFocus: mockSetFocus },
+    ]),
+  ),
+  getCurrentWindow: vi.fn(() => ({
+    close: mockClose,
+  })),
+}));
+
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn((_event: string, cb: () => void) => {
+    bootReadyCallback = cb;
+    return Promise.resolve(() => {});
+  }),
+}));
+
+// --- DOM stub ---
+
+// splash/main.ts reads #pv-version and .pv-card on module load / at
+// closeSplashAndShowMain call time. Provide minimal stubs.
+function setupDom() {
+  document.body.innerHTML = `
+    <div class="pv-card"></div>
+    <span id="pv-version"></span>
+  `;
+}
+
+// --- Helpers ---
+
+/** Fire the boot-ready event registered by the module. */
+function fireBootReady() {
+  if (!bootReadyCallback)
+    throw new Error('listen() never called — module not loaded');
+  bootReadyCallback();
+}
+
+describe('splash main — event-driven dismissal', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mockShow.mockClear();
+    mockSetFocus.mockClear();
+    mockClose.mockClear();
+    bootReadyCallback = null;
+    setupDom();
+  });
+
+  afterEach(async () => {
+    vi.useRealTimers();
+    vi.resetModules();
+  });
+
+  it('dismisses immediately on boot-ready without any floor wait', async () => {
+    // Load module — registers the listener.
+    await import('./main');
+
+    // Confirm listener was registered.
+    expect(bootReadyCallback).not.toBeNull();
+
+    // Fire boot-ready just after module load (simulates warm start where
+    // boot-ready arrives before any minimum floor would have elapsed).
+    fireBootReady();
+
+    // Advance only the FADE_MS (150 ms) — no 800 ms wait should exist.
+    await vi.advanceTimersByTimeAsync(150);
+
+    // main window must be shown and splash closed.
+    expect(mockShow).toHaveBeenCalledTimes(1);
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('does NOT show main or close before the fade completes', async () => {
+    await import('./main');
+    fireBootReady();
+
+    // Advance only half the fade.
+    await vi.advanceTimersByTimeAsync(74);
+
+    expect(mockShow).not.toHaveBeenCalled();
+    expect(mockClose).not.toHaveBeenCalled();
+  });
+
+  it('fallback timer fires after READY_TIMEOUT_MS when boot-ready never arrives', async () => {
+    const { READY_TIMEOUT_MS, FADE_MS } = await import('./main');
+
+    // Advance until main window is detected by the poll loop.
+    await vi.advanceTimersByTimeAsync(250);
+
+    // Advance past the fallback timeout + fade.
+    await vi.advanceTimersByTimeAsync(READY_TIMEOUT_MS + FADE_MS);
+
+    expect(mockShow).toHaveBeenCalledTimes(1);
+    expect(mockClose).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a second boot-ready after the first closes the splash', async () => {
+    await import('./main');
+
+    fireBootReady();
+    await vi.advanceTimersByTimeAsync(150);
+
+    // Reset call counts, then fire again.
+    mockShow.mockClear();
+    mockClose.mockClear();
+    fireBootReady();
+    await vi.advanceTimersByTimeAsync(150);
+
+    expect(mockClose).not.toHaveBeenCalled();
+  });
+
+  it('logs splash-shown, boot-ready-received, and window-shown timestamps', async () => {
+    const consoleSpy = vi.spyOn(console, 'debug').mockImplementation(() => {});
+
+    await import('./main');
+    fireBootReady();
+    await vi.advanceTimersByTimeAsync(150);
+
+    const labels = consoleSpy.mock.calls.map((c) => c[0] as string);
+    expect(labels.some((l) => l.includes('splash-shown'))).toBe(true);
+    expect(labels.some((l) => l.includes('boot-ready-received'))).toBe(true);
+    expect(labels.some((l) => l.includes('window-shown'))).toBe(true);
+
+    consoleSpy.mockRestore();
+  });
+});

--- a/apps/desktop/src/splash/main.ts
+++ b/apps/desktop/src/splash/main.ts
@@ -7,22 +7,24 @@
 //
 // The splash is the only window Tauri creates for itself; `main` is built by
 // the Rust side (`run_app` → `create_main_window`) only once migrations have
-// run, so this window is on screen for the whole of database startup. It holds
-// a minimum display time, waits for `main`'s "app:boot-ready" event (emitted
-// once from src/main.tsx after the first route renders), then shows `main` and
-// closes itself.
+// run, so this window is on screen for the whole of database startup. It waits
+// for `main`'s "app:boot-ready" event (emitted once from src/main.tsx after
+// the first route renders), plays a short CSS fade-out, then shows `main` and
+// closes itself. There is no minimum display floor — cold start is already
+// gated on migration completing before boot-ready fires.
 
 import { getAllWindows, getCurrentWindow } from '@tauri-apps/api/window';
 import { listen } from '@tauri-apps/api/event';
 
-const MIN_DISPLAY_MS = 800;
+// Duration must match the CSS transition on .pv-card in splash.html.
+export const FADE_MS = 150;
 // Fallback so a stuck/never-emitted boot-ready doesn't strand the user behind
 // the splash forever. Armed from the moment the `main` window EXISTS, not from
 // process start: migration now runs behind this splash and has no bounded
 // duration, so a timer started earlier would fire mid-migration and close the
 // splash while there is still no window to show — nothing on screen at all,
 // which is the failure this whole ordering exists to remove.
-const READY_TIMEOUT_MS = 15_000;
+export const READY_TIMEOUT_MS = 15_000;
 const MAIN_POLL_MS = 250;
 
 const versionEl = document.getElementById('pv-version');
@@ -31,8 +33,20 @@ if (versionEl) {
   versionEl.textContent = version ? `v${version}` : '';
 }
 
-const start = performance.now();
+// Exported so tests can mock performance.now without touching global state.
+export const splashStart = performance.now();
 let closing = false;
+
+// Timestamp log for warm-start diagnostics. Each call appends a labelled entry
+// to the console so the deltas between splash-shown, boot-ready, and
+// window-shown are visible in dev-tools / Tauri's log output.
+function logTimestamp(label: string): void {
+  const elapsed = (performance.now() - splashStart).toFixed(1);
+  // eslint-disable-next-line no-console
+  console.debug(`[splash] ${label} +${elapsed}ms`);
+}
+
+logTimestamp('splash-shown');
 
 async function findMainWindow() {
   const windows = await getAllWindows();
@@ -43,17 +57,22 @@ async function closeSplashAndShowMain(): Promise<void> {
   if (closing) return;
   closing = true;
 
-  const elapsed = performance.now() - start;
-  if (elapsed < MIN_DISPLAY_MS) {
-    await new Promise((resolve) =>
-      setTimeout(resolve, MIN_DISPLAY_MS - elapsed),
-    );
+  logTimestamp('boot-ready-received');
+
+  // Trigger the CSS fade-out before dismissing the window so warm-start
+  // dismissal doesn't hard-cut. The .pv-fading class sets opacity:0 with a
+  // 150ms transition (matching FADE_MS). We wait for it before proceeding.
+  const card = document.querySelector<HTMLElement>('.pv-card');
+  if (card) {
+    card.classList.add('pv-fading');
+    await new Promise((resolve) => setTimeout(resolve, FADE_MS));
   }
 
   const main = await findMainWindow();
   if (main) {
     await main.show();
     await main.setFocus();
+    logTimestamp('window-shown');
   }
   await getCurrentWindow().close();
 }


### PR DESCRIPTION
## Summary

- Removes the 800ms minimum display floor; the splash closes as soon as the app signals it is ready.
- Adds a 150ms opacity fade so warm-start dismissal does not hard-cut while the branding is still on screen.
- Adds dev-log timestamps (splash-shown, boot-ready-received, window-shown) so warm-start latency is measurable without a profiler.
- The stuck-boot fallback timer (15s) is unchanged.

## Beads
Tracks-Bead: astro-plan-kyo7.33
Closes-Bead: astro-plan-kyo7.33
Merge-Bead: astro-plan-2qm8
