### PR TITLE
fix: radio group options are keyboard-navigable and screen-reader accessible

### DIFF
--- a/apps/desktop/src/styles/components/settings.css
+++ b/apps/desktop/src/styles/components/settings.css
@@ -161,12 +161,14 @@ font-weight: var(--pv-weight-medium);
   background: var(--pv-bg); color: var(--pv-text-secondary);
 }
 .pv-radio:hover { border-color: var(--pv-ink3); }
-.pv-radio--active {
+.pv-radio--active,
+.pv-radio[data-checked] {
   border-color: var(--pv-accent); background: var(--pv-accent-bg);
   color: var(--pv-accent-text); font-weight: var(--pv-weight-medium);
 }
 .pv-radio__desc { font-size: var(--pv-text-xs); color: var(--pv-text-muted); margin-top: 1px; }
-.pv-radio--active .pv-radio__desc { color: var(--pv-accent-text); }
+.pv-radio--active .pv-radio__desc,
+.pv-radio[data-checked] .pv-radio__desc { color: var(--pv-accent-text); }
 
 /* Segmented control */
 .pv-seg { display: inline-flex; height: var(--pv-control-h-sm); border: 1px solid var(--pv-border); border-radius: var(--pv-radius-sm); overflow: hidden; }

--- a/apps/desktop/src/styles/components/settings.css
+++ b/apps/desktop/src/styles/components/settings.css
@@ -161,6 +161,7 @@ font-weight: var(--pv-weight-medium);
   background: var(--pv-bg); color: var(--pv-text-secondary);
 }
 .pv-radio:hover { border-color: var(--pv-ink3); }
+.pv-radio:focus-visible { outline: 2px solid transparent; box-shadow: var(--pv-focus-ring); }
 .pv-radio--active,
 .pv-radio[data-checked] {
   border-color: var(--pv-accent); background: var(--pv-accent-bg);

--- a/apps/desktop/src/ui/RadioGroup.test.tsx
+++ b/apps/desktop/src/ui/RadioGroup.test.tsx
@@ -1,0 +1,159 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * RadioGroup a11y tests (#1464-followup): radiogroup/radio semantics, aria-checked,
+ * and arrow-key roving-tabindex per the WAI-ARIA radio-group pattern.
+ * Rebuilding on @base-ui-components/react radio-group fixes the prior
+ * plain-<button> implementation that lacked role, aria-checked, and roving focus.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, act } from '@testing-library/react';
+import { useState } from 'react';
+import { RadioGroup, type RadioOption } from './RadioGroup';
+
+const OPTIONS: RadioOption[] = [
+  { value: 'archive', label: 'Archive' },
+  { value: 'trash', label: 'Trash' },
+  { value: 'delete', label: 'Delete' },
+];
+
+function Harness({ initial = 'archive' }: { initial?: string }) {
+  const [value, setValue] = useState(initial);
+  return (
+    <RadioGroup
+      options={OPTIONS}
+      value={value}
+      onChange={setValue}
+      aria-label="Destination"
+    />
+  );
+}
+
+describe('RadioGroup a11y', () => {
+  it('renders a labelled radiogroup with radio items', () => {
+    render(<Harness />);
+    const group = screen.getByRole('radiogroup', { name: 'Destination' });
+    expect(group).toBeInTheDocument();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+
+  it('marks only the selected item as aria-checked=true', () => {
+    render(<Harness initial="trash" />);
+    expect(screen.getByRole('radio', { name: 'Archive' })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+    expect(screen.getByRole('radio', { name: 'Trash' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+    expect(screen.getByRole('radio', { name: 'Delete' })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    );
+  });
+
+  it('uses roving tabindex: only the selected item is tabbable', () => {
+    render(<Harness initial="trash" />);
+    expect(screen.getByRole('radio', { name: 'Archive' })).toHaveAttribute(
+      'tabIndex',
+      '-1',
+    );
+    expect(screen.getByRole('radio', { name: 'Trash' })).toHaveAttribute(
+      'tabIndex',
+      '0',
+    );
+    expect(screen.getByRole('radio', { name: 'Delete' })).toHaveAttribute(
+      'tabIndex',
+      '-1',
+    );
+  });
+
+  it('calls onChange when a radio item is clicked', () => {
+    const onChange = vi.fn();
+    render(
+      <RadioGroup
+        options={OPTIONS}
+        value="archive"
+        onChange={onChange}
+        aria-label="Destination"
+      />,
+    );
+    fireEvent.click(screen.getByRole('radio', { name: 'Trash' }));
+    expect(onChange).toHaveBeenCalledWith('trash');
+  });
+
+  it('ArrowDown selects the next item, wrapping at the end', async () => {
+    render(<Harness initial="delete" />);
+    const item = screen.getByRole('radio', { name: 'Delete' });
+    await act(async () => {
+      item.focus();
+      fireEvent.keyDown(item, { key: 'ArrowDown' });
+    });
+    expect(screen.getByRole('radio', { name: 'Archive' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('ArrowUp selects the previous item, wrapping at the start', async () => {
+    render(<Harness initial="archive" />);
+    const item = screen.getByRole('radio', { name: 'Archive' });
+    await act(async () => {
+      item.focus();
+      fireEvent.keyDown(item, { key: 'ArrowUp' });
+    });
+    expect(screen.getByRole('radio', { name: 'Delete' })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    );
+  });
+
+  it('renders the desc text for RadioOption objects', () => {
+    render(
+      <RadioGroup
+        options={[{ value: 'x', label: 'X', desc: 'Hint text' }]}
+        value="x"
+        onChange={vi.fn()}
+        aria-label="Test"
+      />,
+    );
+    expect(screen.getByText('Hint text')).toBeInTheDocument();
+  });
+
+  it('passes testId to data-testid on the radio item', () => {
+    render(
+      <RadioGroup
+        options={[{ value: 'x', label: 'X', testId: 'my-option' }]}
+        value="x"
+        onChange={vi.fn()}
+        aria-label="Test"
+      />,
+    );
+    expect(screen.getByTestId('my-option')).toBeInTheDocument();
+  });
+
+  it('accepts plain string options', () => {
+    render(
+      <RadioGroup
+        options={['alpha', 'beta']}
+        value="alpha"
+        onChange={vi.fn()}
+        aria-label="Test"
+      />,
+    );
+    expect(screen.getByRole('radio', { name: 'alpha' })).toBeInTheDocument();
+    expect(screen.getByRole('radio', { name: 'beta' })).toBeInTheDocument();
+  });
+
+  it('does not carry a type=submit hazard (no native button rendered)', () => {
+    render(<Harness />);
+    // No <button> elements — base-ui Radio.Root renders a <span>
+    const buttons = document.querySelectorAll(
+      'button[type="submit"], button:not([type])',
+    );
+    expect(buttons.length).toBe(0);
+  });
+});

--- a/apps/desktop/src/ui/RadioGroup.test.tsx
+++ b/apps/desktop/src/ui/RadioGroup.test.tsx
@@ -8,10 +8,17 @@
  * plain-<button> implementation that lacked role, aria-checked, and roving focus.
  */
 
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
 import { render, screen, fireEvent, act } from '@testing-library/react';
 import { useState } from 'react';
 import { RadioGroup, type RadioOption } from './RadioGroup';
+
+const settingsCss = readFileSync(
+  resolve(process.cwd(), 'src/styles/components/settings.css'),
+  'utf8',
+);
 
 const OPTIONS: RadioOption[] = [
   { value: 'archive', label: 'Archive' },
@@ -155,5 +162,13 @@ describe('RadioGroup a11y', () => {
       'button[type="submit"], button:not([type])',
     );
     expect(buttons.length).toBe(0);
+  });
+
+  it('declares a focus-visible ring on .pv-radio matching the shared token', () => {
+    const focusRule = settingsCss.match(
+      /\.pv-radio:focus-visible\s*\{([^}]*)\}/,
+    )?.[1];
+    expect(focusRule).toContain('box-shadow: var(--pv-focus-ring)');
+    expect(focusRule).toContain('outline: 2px solid transparent');
   });
 });

--- a/apps/desktop/src/ui/RadioGroup.tsx
+++ b/apps/desktop/src/ui/RadioGroup.tsx
@@ -1,8 +1,9 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
+import { RadioGroup as BaseRadioGroup } from '@base-ui-components/react/radio-group';
+import { Radio } from '@base-ui-components/react/radio';
 
 export interface RadioOption {
   value: string;
@@ -18,30 +19,39 @@ export interface RadioGroupProps
   onChange: (value: string) => void;
 }
 
-export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
-  function RadioGroup({ options, value, onChange, className, ...rest }, ref) {
-    const cls = ['pv-radio-group', className].filter(Boolean).join(' ');
-    return (
-      <div ref={ref} className={cls} {...rest}>
-        {options.map((o) => {
-          const val = typeof o === 'string' ? o : o.value;
-          const label = typeof o === 'string' ? o : o.label;
-          const desc = typeof o === 'string' ? null : o.desc;
-          const testId = typeof o === 'string' ? undefined : o.testId;
-          return (
-            <button
-              key={val}
-              className={`pv-radio ${value === val ? 'pv-radio--active' : ''}`}
-              onClick={() => onChange(val)}
-              data-testid={testId}
-            >
-              <div>{label}</div>
-              {desc && <div className="pv-radio__desc">{desc}</div>}
-            </button>
-          );
-        })}
-      </div>
-    );
-  },
-);
+export function RadioGroup({
+  options,
+  value,
+  onChange,
+  className,
+  ...rest
+}: RadioGroupProps) {
+  const cls = ['pv-radio-group', className].filter(Boolean).join(' ');
+  return (
+    <BaseRadioGroup
+      className={cls}
+      value={value}
+      onValueChange={(v) => onChange(v as string)}
+      {...rest}
+    >
+      {options.map((o) => {
+        const val = typeof o === 'string' ? o : o.value;
+        const label = typeof o === 'string' ? o : o.label;
+        const desc = typeof o === 'string' ? null : o.desc;
+        const testId = typeof o === 'string' ? undefined : o.testId;
+        return (
+          <Radio.Root
+            key={val}
+            value={val}
+            className="pv-radio"
+            data-testid={testId}
+          >
+            <div>{label}</div>
+            {desc && <div className="pv-radio__desc">{desc}</div>}
+          </Radio.Root>
+        );
+      })}
+    </BaseRadioGroup>
+  );
+}
 RadioGroup.displayName = 'RadioGroup';

--- a/apps/desktop/src/ui/RadioGroup.tsx
+++ b/apps/desktop/src/ui/RadioGroup.tsx
@@ -1,6 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { forwardRef } from 'react';
 import type { HTMLAttributes } from 'react';
 import { RadioGroup as BaseRadioGroup } from '@base-ui-components/react/radio-group';
 import { Radio } from '@base-ui-components/react/radio';
@@ -19,39 +20,36 @@ export interface RadioGroupProps
   onChange: (value: string) => void;
 }
 
-export function RadioGroup({
-  options,
-  value,
-  onChange,
-  className,
-  ...rest
-}: RadioGroupProps) {
-  const cls = ['pv-radio-group', className].filter(Boolean).join(' ');
-  return (
-    <BaseRadioGroup
-      className={cls}
-      value={value}
-      onValueChange={(v) => onChange(v as string)}
-      {...rest}
-    >
-      {options.map((o) => {
-        const val = typeof o === 'string' ? o : o.value;
-        const label = typeof o === 'string' ? o : o.label;
-        const desc = typeof o === 'string' ? null : o.desc;
-        const testId = typeof o === 'string' ? undefined : o.testId;
-        return (
-          <Radio.Root
-            key={val}
-            value={val}
-            className="pv-radio"
-            data-testid={testId}
-          >
-            <div>{label}</div>
-            {desc && <div className="pv-radio__desc">{desc}</div>}
-          </Radio.Root>
-        );
-      })}
-    </BaseRadioGroup>
-  );
-}
+export const RadioGroup = forwardRef<HTMLDivElement, RadioGroupProps>(
+  function RadioGroup({ options, value, onChange, className, ...rest }, ref) {
+    const cls = ['pv-radio-group', className].filter(Boolean).join(' ');
+    return (
+      <BaseRadioGroup
+        ref={ref}
+        className={cls}
+        value={value}
+        onValueChange={(v) => onChange(v as string)}
+        {...rest}
+      >
+        {options.map((o) => {
+          const val = typeof o === 'string' ? o : o.value;
+          const label = typeof o === 'string' ? o : o.label;
+          const desc = typeof o === 'string' ? null : o.desc;
+          const testId = typeof o === 'string' ? undefined : o.testId;
+          return (
+            <Radio.Root
+              key={val}
+              value={val}
+              className="pv-radio"
+              data-testid={testId}
+            >
+              <div>{label}</div>
+              {desc && <div className="pv-radio__desc">{desc}</div>}
+            </Radio.Root>
+          );
+        })}
+      </BaseRadioGroup>
+    );
+  },
+);
 RadioGroup.displayName = 'RadioGroup';


### PR DESCRIPTION
## Summary

- Radio group options now carry `role=radio` / `role=radiogroup`, `aria-checked`, and roving tabindex — previously rendered as plain `<button>` elements with none of these attributes.
- Arrow key navigation (up/down, wrapping) works without custom key handlers; the `type=submit` hazard inside forms is eliminated.
- No change to the component props surface or any call site.

Tracks-Bead: astro-plan-kyo7.58
Closes-Bead: astro-plan-kyo7.58
Merge-Bead: astro-plan-9ux6