### PR TITLE
perf: faster database writes and automatic backup before schema updates

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -753,7 +753,7 @@ mod tests {
         assert!(!bak.exists(), "backup must not be created for a fresh (unmigrated) database");
     }
 
-    /// Existing DB with all migrations applied: no backup needed (has_pending=false).
+    /// Existing DB with all migrations applied: no backup needed (`has_pending=false`).
     #[tokio::test]
     async fn backup_skipped_when_up_to_date() {
         let dir = tempfile::tempdir().unwrap();

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -374,6 +374,16 @@ fn sqlite_file_path(db_url: &str) -> Option<std::path::PathBuf> {
 /// permission error) is non-fatal: the caller logs a warning and proceeds with
 /// migration rather than bricking startup.
 async fn run_pre_migration_backup(db: &Database, db_path: &std::path::Path, app_version: &str) {
+    // Skip fresh databases (no _sqlx_migrations table) and up-to-date ones.
+    match db.has_pending_migrations().await {
+        Ok(true) => {}
+        Ok(false) => return,
+        Err(e) => {
+            tracing::warn!("could not check for pending migrations before backup: {e}");
+            return;
+        }
+    }
+
     let bak_path = db_path.with_extension(format!("pre-{app_version}.bak"));
     // VACUUM INTO cannot accept bind parameters in SQLite — the destination
     // path must appear as a literal in the statement.  Single quotes in the
@@ -445,17 +455,11 @@ async fn boot(app: tauri::AppHandle, db_url: String, data_dir: std::path::PathBu
 
     // kyo7.28: back up the database before applying migrations to an existing,
     // behind-schema file.  Skip for fresh databases (no migration table yet)
-    // and for in-memory connections.
+    // and for in-memory connections.  run_pre_migration_backup owns the
+    // has_pending_migrations guard; boot just skips the whole call for
+    // in-memory URLs where VACUUM INTO is meaningless.
     if let Some(db_path) = sqlite_file_path(&db_url) {
-        match db.has_pending_migrations().await {
-            Ok(true) => {
-                run_pre_migration_backup(&db, &db_path, env!("CARGO_PKG_VERSION")).await;
-            }
-            Ok(false) => {}
-            Err(e) => {
-                tracing::warn!("could not check for pending migrations before backup: {e}");
-            }
-        }
+        run_pre_migration_backup(&db, &db_path, env!("CARGO_PKG_VERSION")).await;
     }
 
     if let Err(error) = db.migrate().await {

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -351,11 +351,113 @@ fn create_main_window(handle: &tauri::AppHandle) {
 // Sequential startup/subscriber-wiring assembly, not complex logic — same
 // shape as `bootstrap::specta::specta_builder`, which carries the same allow.
 #[allow(clippy::too_many_lines)]
+/// Extract the filesystem path from a `sqlite://…` URL, or `None` for
+/// in-memory / non-file URLs.
+///
+/// Only the path component before `?` is returned; any query parameters
+/// (e.g. `?mode=rwc`) are stripped.
+fn sqlite_file_path(db_url: &str) -> Option<std::path::PathBuf> {
+    let url = db_url.strip_prefix("sqlite://")?;
+    // Strip query string.
+    let path_part = url.split('?').next()?;
+    if path_part.is_empty() || path_part == ":memory:" {
+        return None;
+    }
+    Some(std::path::PathBuf::from(path_part))
+}
+
+/// Back up `db_path` via `VACUUM INTO '<db_path>.pre-<version>.bak'` before
+/// running migrations on an existing, behind-schema database.
+///
+/// Keeps only the two most-recent `.pre-*.bak` files alongside the database,
+/// deleting older ones after a successful backup.  A failure here (full disk,
+/// permission error) is non-fatal: the caller logs a warning and proceeds with
+/// migration rather than bricking startup.
+async fn run_pre_migration_backup(db: &Database, db_path: &std::path::Path, app_version: &str) {
+    let bak_path = db_path.with_extension(format!("pre-{app_version}.bak"));
+    // VACUUM INTO cannot accept bind parameters in SQLite — the destination
+    // path must appear as a literal in the statement.  Single quotes in the
+    // path are escaped to prevent injection; the statement is wrapped in
+    // `AssertSqlSafe` to satisfy sqlx's dynamic-SQL audit requirement.
+    let bak_str = bak_path.display().to_string().replace('\'', "''");
+    let stmt = sqlx::AssertSqlSafe(format!("VACUUM INTO '{bak_str}'"));
+    if let Err(e) = sqlx::query(stmt).execute(db.pool()).await {
+        tracing::warn!(
+            path = %bak_path.display(),
+            // Non-fatal: a full disk must not prevent the app from starting.
+            "pre-migration backup failed, proceeding without it: {e}"
+        );
+        return;
+    }
+    tracing::info!(path = %bak_path.display(), "pre-migration backup created");
+    prune_old_backups(db_path);
+}
+
+/// Delete all but the two newest `<stem>.pre-*.bak` files next to `db_path`.
+///
+/// Best-effort: any individual removal failure is logged and skipped.
+fn prune_old_backups(db_path: &std::path::Path) {
+    let Some(parent) = db_path.parent() else { return };
+    let Some(stem) = db_path.file_stem().and_then(|s| s.to_str()) else { return };
+    let prefix = format!("{stem}.pre-");
+    let suffix = ".bak";
+
+    let mut bak_files: Vec<std::path::PathBuf> = match std::fs::read_dir(parent) {
+        Ok(entries) => entries
+            .flatten()
+            .filter(|e| {
+                let name = e.file_name();
+                let n = name.to_string_lossy();
+                n.starts_with(&prefix) && n.ends_with(suffix)
+            })
+            .map(|e| e.path())
+            .collect(),
+        Err(e) => {
+            tracing::warn!("failed to read directory for backup pruning: {e}");
+            return;
+        }
+    };
+
+    if bak_files.len() <= 2 {
+        return;
+    }
+
+    // Sort oldest-first by modification time (fall back to path for stability).
+    bak_files.sort_by(|a, b| {
+        let mtime = |p: &std::path::Path| std::fs::metadata(p).and_then(|m| m.modified()).ok();
+        mtime(a).cmp(&mtime(b))
+    });
+
+    // Remove everything except the two newest.
+    for path in &bak_files[..bak_files.len() - 2] {
+        if let Err(e) = std::fs::remove_file(path) {
+            tracing::warn!(path = %path.display(), "failed to prune old backup: {e}");
+        }
+    }
+}
+
+#[allow(clippy::too_many_lines)]
 async fn boot(app: tauri::AppHandle, db_url: String, data_dir: std::path::PathBuf) {
     let db = match Database::connect(&db_url).await {
         Ok(db) => db,
         Err(e) => return fatal(&app, &format!("failed to connect to SQLite at {db_url}: {e}")),
     };
+
+    // kyo7.28: back up the database before applying migrations to an existing,
+    // behind-schema file.  Skip for fresh databases (no migration table yet)
+    // and for in-memory connections.
+    if let Some(db_path) = sqlite_file_path(&db_url) {
+        match db.has_pending_migrations().await {
+            Ok(true) => {
+                run_pre_migration_backup(&db, &db_path, env!("CARGO_PKG_VERSION")).await;
+            }
+            Ok(false) => {}
+            Err(e) => {
+                tracing::warn!("could not check for pending migrations before backup: {e}");
+            }
+        }
+    }
+
     if let Err(error) = db.migrate().await {
         // A raw `fatal()` here produced `Migration(VersionMismatch(71))` and
         // nothing else — technically true, actionable by nobody. Translate
@@ -621,6 +723,110 @@ mod tests {
 
     fn window(label: &str) -> WindowConfig {
         WindowConfig { label: label.to_owned(), ..WindowConfig::default() }
+    }
+
+    // ── sqlite_file_path ───────────────────────────────────────────────────
+
+    #[test]
+    fn sqlite_file_path_extracts_abs_path() {
+        let p = super::sqlite_file_path("sqlite:///home/user/alm.db?mode=rwc").unwrap();
+        assert_eq!(p, std::path::PathBuf::from("/home/user/alm.db"));
+    }
+
+    #[test]
+    fn sqlite_file_path_returns_none_for_memory() {
+        assert!(super::sqlite_file_path("sqlite::memory:").is_none());
+    }
+
+    // ── pre-migration backup ───────────────────────────────────────────────
+
+    /// Fresh DB (no migrations applied): backup must be skipped.
+    #[tokio::test]
+    async fn backup_skipped_for_fresh_db() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+        let db = Database::connect(&db_url).await.unwrap();
+        // Do NOT run migrate — fresh DB, no _sqlx_migrations table.
+        run_pre_migration_backup(&db, &db_path, "0.6.0").await;
+
+        let bak = db_path.with_extension("pre-0.6.0.bak");
+        assert!(!bak.exists(), "backup must not be created for a fresh (unmigrated) database");
+    }
+
+    /// Existing DB with all migrations applied: no backup needed (has_pending=false).
+    #[tokio::test]
+    async fn backup_skipped_when_up_to_date() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+        let db = Database::connect(&db_url).await.unwrap();
+        db.migrate().await.unwrap();
+
+        let pending = db.has_pending_migrations().await.unwrap();
+        assert!(!pending);
+
+        // has_pending_migrations = false → backup not triggered (tested via the
+        // flag; run_pre_migration_backup itself still works on any file-backed DB).
+    }
+
+    /// Existing DB that is behind (simulated by deleting one applied row):
+    /// backup must be created.
+    #[tokio::test]
+    async fn backup_created_when_migrations_pending() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("test.db");
+        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+
+        let db = Database::connect(&db_url).await.unwrap();
+        db.migrate().await.unwrap();
+
+        // Simulate a behind-schema DB.
+        sqlx::query(
+            "DELETE FROM _sqlx_migrations \
+             WHERE version = (SELECT MAX(version) FROM _sqlx_migrations)",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        assert!(db.has_pending_migrations().await.unwrap());
+        run_pre_migration_backup(&db, &db_path, "0.6.0").await;
+
+        let bak = db_path.with_extension("pre-0.6.0.bak");
+        assert!(bak.exists(), "backup must be created when migrations are pending");
+    }
+
+    /// After creating 3 backups, the oldest must be pruned (only 2 kept).
+    #[test]
+    fn prune_keeps_two_newest_backups() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("alm.db");
+
+        // Create three fake .bak files with distinct modification times.
+        let bak1 = dir.path().join("alm.pre-0.4.0.bak");
+        let bak2 = dir.path().join("alm.pre-0.5.0.bak");
+        let bak3 = dir.path().join("alm.pre-0.6.0.bak");
+        for p in [&bak1, &bak2, &bak3] {
+            std::fs::write(p, b"dummy").unwrap();
+        }
+        // Set mtimes so ordering is deterministic: bak1 oldest, bak3 newest.
+        let epoch = std::time::SystemTime::UNIX_EPOCH;
+        for (p, secs) in [(&bak1, 1000u64), (&bak2, 2000), (&bak3, 3000)] {
+            let ft = std::fs::FileTimes::new()
+                .set_accessed(epoch + std::time::Duration::from_secs(secs))
+                .set_modified(epoch + std::time::Duration::from_secs(secs));
+            let f = std::fs::OpenOptions::new().write(true).open(p).unwrap();
+            f.set_times(ft).unwrap();
+        }
+
+        super::prune_old_backups(&db_path);
+
+        assert!(!bak1.exists(), "oldest backup must be pruned");
+        assert!(bak2.exists(), "second backup must be kept");
+        assert!(bak3.exists(), "newest backup must be kept");
     }
 
     /// The ordering guarantee, at the only place it can be enforced: Tauri

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -385,13 +385,7 @@ async fn run_pre_migration_backup(db: &Database, db_path: &std::path::Path, app_
     }
 
     let bak_path = db_path.with_extension(format!("pre-{app_version}.bak"));
-    // VACUUM INTO cannot accept bind parameters in SQLite — the destination
-    // path must appear as a literal in the statement.  Single quotes in the
-    // path are escaped to prevent injection; the statement is wrapped in
-    // `AssertSqlSafe` to satisfy sqlx's dynamic-SQL audit requirement.
-    let bak_str = bak_path.display().to_string().replace('\'', "''");
-    let stmt = sqlx::AssertSqlSafe(format!("VACUUM INTO '{bak_str}'"));
-    if let Err(e) = sqlx::query(stmt).execute(db.pool()).await {
+    if let Err(e) = db.backup_to(&bak_path).await {
         tracing::warn!(
             path = %bak_path.display(),
             // Non-fatal: a full disk must not prevent the app from starting.

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -11,7 +11,9 @@
 
 use std::str::FromStr;
 
-use sqlx::sqlite::{SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions};
+use sqlx::sqlite::{
+    SqliteConnectOptions, SqliteJournalMode, SqlitePool, SqlitePoolOptions, SqliteSynchronous,
+};
 
 pub mod operation_state;
 /// Reference pattern for sea-query + sqlx 0.9 binding. Compiled only under `cfg(test)`.
@@ -76,8 +78,22 @@ pub struct Database {
 impl Database {
     /// Connect to a file-backed SQLite database.
     ///
-    /// Explicitly requests WAL journaling (#830) and pins `busy_timeout`
-    /// (#1231). See `persistence_db` module docs for the full rationale.
+    /// Durability tier policy (constitution v1.1.0 §V):
+    ///
+    /// - **WAL** (`journal_mode = WAL`, #830): concurrent readers during a write,
+    ///   no reader-writer blocking, and a crash-safe write path on all platforms.
+    /// - **`synchronous = NORMAL`** (tier-2): the OS journal is fsynced at each
+    ///   checkpoint, not every commit.  Under WAL, a crash between commits risks
+    ///   at most losing the last un-checkpointed transaction — the database is
+    ///   never corrupted.  This is materially faster than `FULL` on spinning or
+    ///   network-backed storage without sacrificing integrity guarantees the app
+    ///   depends on.  Tier-1 (`FULL`) escalation per-connection for high-value
+    ///   writes (audit events, filesystem plan commits) is tracked as a follow-up
+    ///   in kyo7.49.
+    /// - **`foreign_keys = ON`**: enforced explicitly so the constraint is not
+    ///   silently absent if a future sqlx version changes its default.
+    /// - **`busy_timeout`** (#1231): pins the wait interval so it is ours, not
+    ///   a transitively-inherited default.
     ///
     /// # Errors
     ///
@@ -85,6 +101,8 @@ impl Database {
     pub async fn connect(connection_string: &str) -> DbResult<Self> {
         let options = SqliteConnectOptions::from_str(connection_string)?
             .journal_mode(SqliteJournalMode::Wal)
+            .synchronous(SqliteSynchronous::Normal)
+            .foreign_keys(true)
             .busy_timeout(BUSY_TIMEOUT);
         let pool = SqlitePoolOptions::new().max_connections(8).connect_with(options).await?;
         Ok(Self { pool })
@@ -97,6 +115,44 @@ impl Database {
     /// Returns [`DbError::Database`] if the in-memory pool cannot be created.
     pub async fn in_memory() -> DbResult<Self> {
         Self::connect("sqlite::memory:").await
+    }
+
+    /// Return `true` when at least one migration in the embedded set has not yet
+    /// been applied to this database.
+    ///
+    /// Returns `false` for fresh databases (the `_sqlx_migrations` table does
+    /// not exist yet) because there is nothing to back up before a first-time
+    /// schema creation.  The backup logic in the desktop shell uses this to skip
+    /// the VACUUM INTO cost when startup would be a no-op anyway.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the number of compiled-in migrations exceeds `i64::MAX`, which
+    /// cannot occur in practice.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DbError::Database`] on an unexpected SQL error other than the
+    /// table-not-found case.
+    pub async fn has_pending_migrations(&self) -> DbResult<bool> {
+        let mut conn = self.pool.acquire().await?;
+        // If the migration tracking table has never been created this is a fresh
+        // database — no backup needed.
+        let table_exists: bool = sqlx::query_scalar(
+            "SELECT COUNT(*) > 0 FROM sqlite_master \
+             WHERE type = 'table' AND name = '_sqlx_migrations'",
+        )
+        .fetch_one(&mut *conn)
+        .await?;
+        if !table_exists {
+            return Ok(false);
+        }
+        let applied_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM _sqlx_migrations")
+            .fetch_one(&mut *conn)
+            .await?;
+        let total =
+            i64::try_from(schema_cache::MIGRATOR.iter().count()).expect("migration count fits i64");
+        Ok(applied_count < total)
     }
 
     /// Run all pending migrations from the frozen baseline and future append-only files.
@@ -205,5 +261,54 @@ mod tests {
         db.migrate().await.expect("migrations");
         let row: (i64,) = sqlx::query_as("SELECT 1").fetch_one(db.pool()).await.unwrap();
         assert_eq!(row.0, 1);
+    }
+
+    #[tokio::test]
+    async fn foreign_keys_enabled_on_fresh_connection() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        let fk_on: i64 =
+            sqlx::query_scalar("PRAGMA foreign_keys").fetch_one(db.pool()).await.unwrap();
+        assert_eq!(fk_on, 1, "PRAGMA foreign_keys must be 1 (ON) on every connection");
+    }
+
+    #[tokio::test]
+    async fn synchronous_normal_on_fresh_connection() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        // SQLite returns the numeric value: 0=OFF, 1=NORMAL, 2=FULL, 3=EXTRA.
+        let sync_level: i64 =
+            sqlx::query_scalar("PRAGMA synchronous").fetch_one(db.pool()).await.unwrap();
+        assert_eq!(sync_level, 1, "synchronous must be NORMAL (1) per tier-2 policy");
+    }
+
+    #[tokio::test]
+    async fn has_pending_migrations_is_false_for_fresh_db() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        // Fresh DB: _sqlx_migrations does not exist yet.
+        let pending = db.has_pending_migrations().await.expect("has_pending_migrations");
+        assert!(!pending, "a fresh database has no pending migrations to back up");
+    }
+
+    #[tokio::test]
+    async fn has_pending_migrations_is_false_after_migrate() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        db.migrate().await.expect("migrate");
+        let pending = db.has_pending_migrations().await.expect("has_pending_migrations");
+        assert!(!pending, "all migrations applied: no pending migrations");
+    }
+
+    #[tokio::test]
+    async fn has_pending_migrations_is_true_when_behind() {
+        let db = super::Database::in_memory().await.expect("in-memory connect");
+        db.migrate().await.expect("initial migrate");
+
+        // Simulate a DB that has had one migration rolled back by deleting the
+        // last applied row — so applied_count < total.
+        sqlx::query("DELETE FROM _sqlx_migrations WHERE version = (SELECT MAX(version) FROM _sqlx_migrations)")
+            .execute(db.pool())
+            .await
+            .expect("remove last applied migration");
+
+        let pending = db.has_pending_migrations().await.expect("has_pending_migrations");
+        assert!(pending, "one migration removed: must report pending");
     }
 }

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -155,6 +155,28 @@ impl Database {
         Ok(applied_count < total)
     }
 
+    /// Copy this database to `dest` using SQLite's `VACUUM INTO` statement.
+    ///
+    /// `VACUUM INTO` writes a consistent, compacted snapshot of the live
+    /// database to a new file without interrupting readers or writers.
+    ///
+    /// `VACUUM INTO` does not accept bind parameters — the destination path
+    /// must appear as a string literal in the statement.  Single quotes inside
+    /// the path are doubled (`'` → `''`) to form a valid SQLite string literal.
+    /// The resulting statement is wrapped in [`sqlx::AssertSqlSafe`] to satisfy
+    /// the sqlx dynamic-SQL audit requirement; the quoting is the audit.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`DbError::Database`] if the statement fails (e.g. destination
+    /// already exists, or disk full).
+    pub async fn backup_to(&self, dest: &std::path::Path) -> DbResult<()> {
+        let dest_str = dest.display().to_string().replace('\'', "''");
+        let stmt = sqlx::AssertSqlSafe(format!("VACUUM INTO '{dest_str}'"));
+        sqlx::query(stmt).execute(&self.pool).await?;
+        Ok(())
+    }
+
     /// Run all pending migrations from the frozen baseline and future append-only files.
     ///
     /// # Errors


### PR DESCRIPTION
## Summary

- Reduces unnecessary disk fsyncs on every write by switching to WAL-safe durability (synchronous=NORMAL). Under WAL journaling the database file is never corrupted by a crash; only the last un-checkpointed transaction can be lost, which is acceptable for local library metadata.
- Pins foreign key enforcement explicitly so referential integrity holds regardless of future library defaults.
- Creates a versioned backup of the database file before applying schema migrations, so a failed or interrupted update leaves the previous state recoverable. Backups rotate automatically (two kept).

## Verify

`cargo clippy -p persistence_core -p desktop_shell -- -D warnings`: green
`cargo fmt -- --check`: green
`cargo test -p persistence_core -p desktop_shell`: all 50 lib + integration tests pass

## Perf (N=500, local aarch64 macOS, NVMe)

| scenario | wall_ms | sqlx_stmts | post-kyo7.11 baseline |
|---|---|---|---|
| scan_root | 532 | 0 | — |
| classify_source_groups | 1721 | 2720 | 719 ms (kyo7.11 PR) |

`classify_source_groups` at 1721 ms reflects a larger total fixture (10 groups, N=500) than the kyo7.11 619-file baseline. The `synchronous=NORMAL` change has no meaningful effect on these scenarios because they do not issue the write-heavy migration path; the relevant gain is reduced fsync pressure on the write path (audit events, plan commits, session upserts), which is exercised during actual use rather than in the scan/classify bench.

## Spec Context

Constitution v1.1.0 §V durability tier-2.

Tracks-Bead: kyo7.47
Tracks-Bead: kyo7.29
Tracks-Bead: kyo7.28
Merge-Bead: astro-plan-lyay