### PR TITLE
perf: applying large plans is dramatically faster — group-commit DB writes and crash recovery

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -382,6 +382,26 @@ async fn boot(app: tauri::AppHandle, db_url: String, data_dir: std::path::PathBu
     }
     let pool = db.pool().clone();
 
+    // Startup sweep: any plan left in 'applying' with no live executor (e.g.
+    // after a hard crash) is unreachable by `resume_plan` (which requires
+    // `paused` state). Flip them to `paused` with pause_reason='crash' so the
+    // user can resume or cancel them. The active_runs registry is always empty
+    // at this point, so every applying plan qualifies.
+    {
+        let sweep_pool = pool.clone();
+        tokio::spawn(async move {
+            match app_core::plan_apply::sweep_crashed_applying_plans(&sweep_pool).await {
+                Ok(ids) if !ids.is_empty() => tracing::info!(
+                    count = ids.len(),
+                    "startup: flipped {} applying plan(s) to paused (crash recovery)",
+                    ids.len()
+                ),
+                Ok(_) => {}
+                Err(e) => tracing::warn!("startup sweep for crashed applying plans failed: {e}"),
+            }
+        });
+    }
+
     // Spec 052 P1 (D2): open (creating if missing) the shared redb resolve
     // cache. Opening is fast (no warm yet — the warm below is backgrounded so
     // a large seed never blocks startup).

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -159,14 +159,12 @@ export function usePlanApplyProgress() {
                 }
                 case 'progress': {
                   // Batch progress tick from the group-commit flush (kyo7.52).
-                  // Carries delta counters for the flush window — add to prev
-                  // rather than replacing so a stale or reordered tick cannot
-                  // regress the display.
+                  // Only itemsApplied is carried here — failures are counted
+                  // by individual item_failed emits to avoid double-counting
+                  // (itemsFailed is always 0 in the Progress envelope).
                   const p = event.payload as Record<string, unknown>;
                   if (typeof p.itemsApplied === 'number')
                     next.applied = prev.applied + p.itemsApplied;
-                  if (typeof p.itemsFailed === 'number')
-                    next.failed = prev.failed + p.itemsFailed;
                   break;
                 }
                 case 'item_applied':

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -157,6 +157,18 @@ export function usePlanApplyProgress() {
                   if (runId != null) next.runId = runId;
                   break;
                 }
+                case 'progress': {
+                  // Batch progress tick from the group-commit flush (kyo7.52).
+                  // Carries delta counters for the flush window — add to prev
+                  // rather than replacing so a stale or reordered tick cannot
+                  // regress the display.
+                  const p = event.payload as Record<string, unknown>;
+                  if (typeof p.itemsApplied === 'number')
+                    next.applied = prev.applied + p.itemsApplied;
+                  if (typeof p.itemsFailed === 'number')
+                    next.failed = prev.failed + p.itemsFailed;
+                  break;
+                }
                 case 'item_applied':
                   next.applied = prev.applied + 1;
                   break;

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -198,7 +198,7 @@ mod tests;
 pub use apply::{apply_plan, apply_plan_channel_free};
 pub use lifecycle::{
     cancel_plan, confirm_plan_destructive_items, get_apply_status, resume_plan, retry_plan_item,
-    skip_plan_item,
+    skip_plan_item, sweep_crashed_applying_plans,
 };
 pub(crate) use paths::resolve_root_path;
 

--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -304,16 +304,20 @@ pub(super) fn spawn_executor_run(params: SpawnExecutorParams) {
         // is the single removal site; there is no explicit `registry.remove`.
         let _run_guard = run_guard;
 
-        let callbacks = PlanApplyCallbacks {
-            pool: pool.clone(),
-            bus: bus.clone(),
-            plan_id: plan_id.clone(),
-            run_id: run_id.clone(),
-            op_emitter: op_emitter.clone(),
-        };
+        let callbacks = PlanApplyCallbacks::new(
+            pool.clone(),
+            bus.clone(),
+            plan_id.clone(),
+            run_id.clone(),
+            op_emitter.clone(),
+        );
 
         let outcome =
             execute_plan(executor_items, &callbacks, &cancel_token, &skip_set, &retry_queue).await;
+
+        // Mandatory flush: drain any items buffered in the last partial window
+        // before the outcome branches below read cumulative plan counters.
+        callbacks.flush().await;
 
         // Compute terminal state and persist.
         match outcome {

--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -239,9 +239,9 @@ pub(super) struct SpawnExecutorParams {
 
 /// Fetch the plan's up-to-date cumulative item counters.
 ///
-/// Each item transition (`item_succeeded`/`item_failed`/`item_skip`/
-/// `batch_cancel_pending_items`) increments `plans.items_applied` etc. in
-/// real time via `PlanApplyCallbacks`, so the plan row already reflects the
+/// Each flush (`batch_flush_item_states`) and `batch_cancel_pending_items`
+/// increments `plans.items_applied` etc. in real time via `PlanApplyCallbacks`,
+/// so the plan row already reflects the
 /// *whole* run's history — including a pre-pause phase from before a resume
 /// (issue #575). The `TerminalCounts` returned by a single `execute_plan`
 /// invocation only covers the items just processed in that segment, which

--- a/crates/app/core/src/plan_apply/callbacks.rs
+++ b/crates/app/core/src/plan_apply/callbacks.rs
@@ -240,13 +240,50 @@ impl PlanApplyCallbacks {
         // window instead of once per item.
         let _ = self.bus.broadcast_only(TOPIC_PLAN_ITEM_PROGRESS);
 
-        // Live long-op projection: per-item events after the tx (best-effort).
+        // Live long-op projection (spec 042 US16, kyo7.52): one batched
+        // Progress envelope per flush instead of one event per item.
+        // Individual failure emits are preserved — they carry detail the UI
+        // uses to show per-item error messages (rare, far below the item rate).
+        // Plan-level Started / Completed / Paused events are unchanged.
         if let Some(emitter) = self.op_emitter.as_ref() {
+            // Collect window failures for the batch Progress envelope.
+            let window_failures: Vec<serde_json::Value> = items
+                .iter()
+                .filter(|i| i.failure_code.is_some())
+                .map(|i| {
+                    json!({
+                        "itemId": i.item_id,
+                        "code": i.failure_code,
+                        "message": i.failure_message,
+                    })
+                })
+                .collect();
+
+            // Individual failure emits (kept for per-item detail in the UI).
             for item in &items {
                 if let Some(ref op) = item.op_event {
-                    emitter.emit(op.event_type, op.payload.clone());
+                    if op.event_type == OperationEventType::ItemFailed {
+                        emitter.emit(op.event_type, op.payload.clone());
+                    }
                 }
             }
+
+            // One Progress event for the whole flush window.
+            let last_item_id = items
+                .last()
+                .map_or(serde_json::Value::Null, |i| serde_json::Value::String(i.item_id.clone()));
+            emitter.emit(
+                OperationEventType::Progress,
+                json!({
+                    "planId": self.plan_id,
+                    "runId": self.run_id,
+                    "itemsApplied": delta_applied,
+                    "itemsFailed": delta_failed,
+                    "itemsSkipped": delta_skipped,
+                    "lastItemId": last_item_id,
+                    "windowFailures": window_failures,
+                }),
+            );
         }
     }
 }

--- a/crates/app/core/src/plan_apply/callbacks.rs
+++ b/crates/app/core/src/plan_apply/callbacks.rs
@@ -122,7 +122,7 @@ impl PlanApplyCallbacks {
         let mut delta_applied: i64 = 0;
         let mut delta_failed: i64 = 0;
         let mut delta_skipped: i64 = 0;
-        let mut owned_states: Vec<(String, String, Option<String>)> =
+        let mut owned_states: Vec<(String, String, Option<String>, bool)> =
             Vec::with_capacity(items.len());
         for item in &items {
             match item.new_state.as_str() {
@@ -134,14 +134,16 @@ impl PlanApplyCallbacks {
                 item.item_id.clone(),
                 item.new_state.clone(),
                 item.failure_reason.clone(),
+                item.new_state == "stale",
             ));
         }
         let batch_states: Vec<apply_repo::BatchItemState<'_>> = owned_states
             .iter()
-            .map(|(id, state, reason)| apply_repo::BatchItemState {
+            .map(|(id, state, reason, is_stale)| apply_repo::BatchItemState {
                 item_id: id.as_str(),
                 new_state: state.as_str(),
                 failure_reason: reason.as_deref(),
+                is_stale: *is_stale,
             })
             .collect();
 
@@ -268,7 +270,10 @@ impl PlanApplyCallbacks {
                 }
             }
 
-            // One Progress event for the whole flush window.
+            // One Progress event for the whole flush window. `itemsFailed` is
+            // intentionally 0: individual ItemFailed emits above already
+            // increment the UI counter, so including a non-zero delta here
+            // would double-count failures (kyo7.52 finding 2).
             let last_item_id = items
                 .last()
                 .map_or(serde_json::Value::Null, |i| serde_json::Value::String(i.item_id.clone()));
@@ -278,7 +283,7 @@ impl PlanApplyCallbacks {
                     "planId": self.plan_id,
                     "runId": self.run_id,
                     "itemsApplied": delta_applied,
-                    "itemsFailed": delta_failed,
+                    "itemsFailed": 0,
                     "itemsSkipped": delta_skipped,
                     "lastItemId": last_item_id,
                     "windowFailures": window_failures,

--- a/crates/app/core/src/plan_apply/callbacks.rs
+++ b/crates/app/core/src/plan_apply/callbacks.rs
@@ -1,10 +1,73 @@
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use fs_executor::failure::RollbackOutcome;
+use persistence_core::repositories::audit_writes;
+use persistence_lifecycle::repositories::events as events_repo;
+use persistence_plans::repositories::plan_apply as apply_repo;
+
 use super::{
-    apply_repo, deterministic_entity_id, json, new_id, AuditLogEntry, EntityType, EventBus,
-    ExecutorCallbacks, ItemProgressEvent, OpEventEmitter, OperationEventType, Outcome,
-    PlanItemProgress, Severity, Source, SqlitePool, TOPIC_PLAN_ITEM_PROGRESS,
+    deterministic_entity_id, json, new_id, AuditLogEntry, EntityType, EventBus, ExecutorCallbacks,
+    ItemProgressEvent, OpEventEmitter, OperationEventType, Outcome, PlanItemProgress, Severity,
+    Source, SqlitePool, TOPIC_PLAN_ITEM_PROGRESS,
 };
 
-// ── Executor callbacks implementation ────────────────────────────────────────
+// ── Flush constants ───────────────────────────────────────────────────────────
+
+/// Maximum number of items buffered before a flush is triggered at the next
+/// item boundary.
+const FLUSH_ITEM_COUNT: usize = 100;
+/// Maximum wall-clock time between flushes, checked at item boundaries (no
+/// background timer thread).
+const FLUSH_INTERVAL: Duration = Duration::from_millis(250);
+
+// ── Buffered item ─────────────────────────────────────────────────────────────
+
+/// One item's data captured at `on_item_progress` time, deferred until flush.
+struct BufferedItem {
+    item_id: String,
+    prior_state: String,
+    new_state: String,
+    at: String,
+    failure_reason: Option<String>,
+    failure_code: Option<String>,
+    failure_message: Option<String>,
+    failure_recoverable: Option<bool>,
+    rollback_attempted: bool,
+    rollback_outcome: RollbackOutcome,
+    rollback_message: Option<String>,
+    audit_entry: AuditLogEntry,
+    /// Pre-serialised `PlanItemProgress` payload for the events-table row.
+    bus_payload_json: String,
+    /// Data for the live long-op projection emit after the flush (best-effort,
+    /// not part of the durable tx — additive per constitution §II).
+    op_event: Option<OpEventPayload>,
+}
+
+struct OpEventPayload {
+    event_type: OperationEventType,
+    payload: serde_json::Value,
+}
+
+// ── Flush buffer ──────────────────────────────────────────────────────────────
+
+struct FlushBuffer {
+    items: Vec<BufferedItem>,
+    last_flush: Instant,
+}
+
+impl FlushBuffer {
+    fn new() -> Self {
+        Self { items: Vec::with_capacity(FLUSH_ITEM_COUNT + 1), last_flush: Instant::now() }
+    }
+
+    fn should_flush(&self) -> bool {
+        self.items.len() >= FLUSH_ITEM_COUNT
+            || (!self.items.is_empty() && self.last_flush.elapsed() >= FLUSH_INTERVAL)
+    }
+}
+
+// ── PlanApplyCallbacks ────────────────────────────────────────────────────────
 
 pub(super) struct PlanApplyCallbacks {
     pub(super) pool: SqlitePool,
@@ -14,113 +77,204 @@ pub(super) struct PlanApplyCallbacks {
     /// Optional live long-op projection (spec 042 US16). `None` when the caller
     /// (e.g. a unit test) does not subscribe; the DB audit trail is unaffected.
     pub(super) op_emitter: Option<OpEventEmitter>,
+    /// Buffered items awaiting the next flush transaction.
+    buffer: Mutex<FlushBuffer>,
+}
+
+impl PlanApplyCallbacks {
+    pub(super) fn new(
+        pool: SqlitePool,
+        bus: EventBus,
+        plan_id: String,
+        run_id: String,
+        op_emitter: Option<OpEventEmitter>,
+    ) -> Self {
+        Self { pool, bus, plan_id, run_id, op_emitter, buffer: Mutex::new(FlushBuffer::new()) }
+    }
+
+    /// Drain all buffered items into a single DB transaction.
+    ///
+    /// Called at mandatory flush points (before returning any `ApplyOutcome`,
+    /// before `pause_run` / `complete_run` / batch-cancel). Swallows DB errors
+    /// with a warning — the run still completes, matching the existing per-item
+    /// best-effort error handling for plan_apply_events / audit rows.
+    pub(super) async fn flush(&self) {
+        let items = {
+            let mut buf = self.buffer.lock().expect("flush buffer poisoned");
+            if buf.items.is_empty() {
+                return;
+            }
+            let drained =
+                std::mem::replace(&mut buf.items, Vec::with_capacity(FLUSH_ITEM_COUNT + 1));
+            buf.last_flush = Instant::now();
+            drained
+        };
+
+        self.flush_items(items).await;
+    }
+
+    async fn flush_items(&self, items: Vec<BufferedItem>) {
+        if items.is_empty() {
+            return;
+        }
+
+        // Compute deltas for the aggregated plans-counter UPDATE.
+        let mut delta_applied: i64 = 0;
+        let mut delta_failed: i64 = 0;
+        let mut delta_skipped: i64 = 0;
+        let mut owned_states: Vec<(String, String, Option<String>)> =
+            Vec::with_capacity(items.len());
+        for item in &items {
+            match item.new_state.as_str() {
+                "succeeded" => delta_applied += 1,
+                "skipped" => delta_skipped += 1,
+                _ => delta_failed += 1, // failed / stale / refused
+            }
+            owned_states.push((
+                item.item_id.clone(),
+                item.new_state.clone(),
+                item.failure_reason.clone(),
+            ));
+        }
+        let batch_states: Vec<apply_repo::BatchItemState<'_>> = owned_states
+            .iter()
+            .map(|(id, state, reason)| apply_repo::BatchItemState {
+                item_id: id.as_str(),
+                new_state: state.as_str(),
+                failure_reason: reason.as_deref(),
+            })
+            .collect();
+
+        // One transaction: plan_items + plans counter + plan_apply_events +
+        // audit_log_entry + events.
+        let plan_id = self.plan_id.as_str();
+        let run_id = self.run_id.as_str();
+        let mut tx = match self.pool.begin().await {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::error!(
+                    error = %e,
+                    item_count = items.len(),
+                    "group-commit flush: begin tx failed; items lost from audit trail"
+                );
+                return;
+            }
+        };
+
+        if let Err(e) = apply_repo::batch_flush_item_states(
+            &mut tx,
+            plan_id,
+            &batch_states,
+            delta_applied,
+            delta_failed,
+            delta_skipped,
+        )
+        .await
+        {
+            tracing::error!(error = %e, "group-commit flush: batch_flush_item_states failed");
+            return;
+        }
+
+        // plan_apply_events — one row per item.
+        for item in &items {
+            let failure_ref = item.failure_code.as_ref().map(|_| apply_repo::EventFailure {
+                code: item.failure_code.as_deref().unwrap_or(""),
+                message: item.failure_message.as_deref().unwrap_or(""),
+                recoverable: item.failure_recoverable.unwrap_or(false),
+            });
+            let rollback_ref = item.rollback_attempted.then(|| apply_repo::EventRollback {
+                attempted: item.rollback_attempted,
+                outcome: item.rollback_outcome.as_str(),
+                message: item.rollback_message.as_deref(),
+            });
+
+            if let Err(e) = apply_repo::append_event_conn(
+                &mut tx,
+                &new_id(),
+                run_id,
+                plan_id,
+                Some(item.item_id.as_str()),
+                item.prior_state.as_str(),
+                item.new_state.as_str(),
+                item.at.as_str(),
+                failure_ref.as_ref(),
+                rollback_ref.as_ref(),
+            )
+            .await
+            {
+                tracing::error!(item_id = %item.item_id, error = %e, "group-commit flush: append_event_conn failed");
+            }
+        }
+
+        // audit_log_entry — one row per item.
+        for item in &items {
+            if let Err(e) = audit_writes::insert_audit_entry_conn(&mut tx, &item.audit_entry).await
+            {
+                tracing::error!(item_id = %item.item_id, error = %e, "group-commit flush: insert_audit_entry_conn failed");
+            }
+        }
+
+        // events — one row per item (the log forwarder wakes once per flush
+        // broadcast, but each item still gets a durable events row).
+        let emitted_at = domain_core::ids::Timestamp::now_iso();
+        for item in &items {
+            if let Err(e) = events_repo::insert_event_conn(
+                &mut tx,
+                TOPIC_PLAN_ITEM_PROGRESS,
+                "system",
+                emitted_at.as_str(),
+                item.bus_payload_json.as_str(),
+            )
+            .await
+            {
+                tracing::error!(item_id = %item.item_id, error = %e, "group-commit flush: insert_event_conn failed");
+            }
+        }
+
+        if let Err(e) = tx.commit().await {
+            tracing::error!(error = %e, item_count = items.len(), "group-commit flush: commit failed");
+            return;
+        }
+
+        // One broadcast per flush — wakes the log forwarder once per flush
+        // window instead of once per item.
+        let _ = self.bus.broadcast_only(TOPIC_PLAN_ITEM_PROGRESS);
+
+        // Live long-op projection: per-item events after the tx (best-effort).
+        if let Some(emitter) = self.op_emitter.as_ref() {
+            for item in &items {
+                if let Some(ref op) = item.op_event {
+                    emitter.emit(op.event_type, op.payload.clone());
+                }
+            }
+        }
+    }
 }
 
 impl ExecutorCallbacks for PlanApplyCallbacks {
     fn on_item_start(
         &self,
-        item_id: &str,
+        _item_id: &str,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
-        let pool = self.pool.clone();
-        let plan_id = self.plan_id.clone();
-        let item_id = item_id.to_owned();
-        Box::pin(async move {
-            if let Err(e) = apply_repo::item_start_applying(&pool, &item_id, &plan_id).await {
-                tracing::error!(%item_id, error=%e, "failed to transition item to applying");
-            }
-        })
+        // The per-item 'applying' DB write (item_start_applying) is dropped in
+        // the group-commit design: items flush from pending → terminal in one
+        // batch tx. cancel_orphaned_applying_items is unaffected — it only
+        // targets items flipped to 'applying' by retry_plan_item, which writes
+        // directly via item_retry_applying (not buffered).
+        Box::pin(std::future::ready(()))
     }
 
     fn on_item_progress(
         &self,
         event: ItemProgressEvent,
     ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
-        let pool = self.pool.clone();
-        let bus = self.bus.clone();
-        let plan_id = self.plan_id.clone();
-        let run_id = self.run_id.clone();
-        let op_emitter = self.op_emitter.clone();
         Box::pin(async move {
             let item_id = event.item_id.clone();
             let at = event.at.clone();
 
-            // Persist item state. "refused" (destructive-unconfirmed / path-gate
-            // escape-symlink refusals, run.rs:381-401 and :408-426) has no
-            // distinct `plan_items.item_state` value — the CHECK constraint
-            // only allows pending/applying/succeeded/failed/skipped/cancelled
-            // (migration 0045) — so it persists as `failed` exactly like an
-            // ordinary execution failure, via the same `item_failed` write
-            // that increments `items_failed`. Without this arm a refused item
-            // stayed `pending` forever and its failure was never counted,
-            // letting an otherwise-clean run report `applied` (constitution
-            // §II non-silent-failure violation).
-            let persist_result = match event.new_state.as_str() {
-                "succeeded" => apply_repo::item_succeeded(&pool, &item_id, &plan_id).await,
-                "failed" | "stale" | "refused" => {
-                    let reason = event
-                        .failure
-                        .as_ref()
-                        .map(std::string::ToString::to_string)
-                        .unwrap_or_default();
-                    if event.new_state == "stale" {
-                        apply_repo::item_stale(&pool, &item_id, &plan_id).await
-                    } else {
-                        apply_repo::item_failed(&pool, &item_id, &plan_id, &reason).await
-                    }
-                }
-                "skipped" => apply_repo::item_skip(&pool, &item_id, &plan_id).await,
-                _ => Ok(()),
-            };
-
-            if let Err(e) = persist_result {
-                tracing::error!(%item_id, error=%e, "failed to persist item state transition");
-            }
-
-            // Append audit event.
-            let failure_ref = event.failure.as_ref();
-            let rollback_ref = if event.rollback_attempted {
-                Some(apply_repo::EventRollback {
-                    attempted: event.rollback_attempted,
-                    outcome: event.rollback_outcome.as_str(),
-                    message: event.rollback_message.as_deref(),
-                })
-            } else {
-                None
-            };
-
-            if let Err(e) = apply_repo::append_event(
-                &pool,
-                &new_id(),
-                &run_id,
-                &plan_id,
-                Some(&item_id),
-                &event.prior_state,
-                &event.new_state,
-                &at,
-                failure_ref
-                    .map(|f| apply_repo::EventFailure {
-                        code: f.code.as_str(),
-                        message: &f.message,
-                        recoverable: f.recoverable,
-                    })
-                    .as_ref(),
-                rollback_ref.as_ref(),
-            )
-            .await
-            {
-                tracing::error!(%item_id, error=%e, "failed to append apply event");
-            }
-
-            // Durable audit row + live bus event (#766). `append_event` above
-            // writes to the plan-apply run-history table, NOT `audit_log_entry` —
-            // this is the actual durable audit write the constitution (§II)
-            // and `audit::bus::EventBus::write_audit` cover; before this fix
-            // the item-progress path only ever called `bus.publish` (live-only,
-            // non-durable), so a succeeded plan apply left zero audit_log_entry
-            // rows despite every item transitioning to a terminal state.
             let bus_payload = PlanItemProgress {
-                plan_id: plan_id.clone(),
-                run_id: run_id.clone(),
+                plan_id: self.plan_id.clone(),
+                run_id: self.run_id.clone(),
                 item_id: item_id.clone(),
                 prior_state: event.prior_state.clone(),
                 new_state: event.new_state.clone(),
@@ -129,12 +283,12 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
                 failure_message: event.failure.as_ref().map(|f| f.message.clone()),
                 failure_recoverable: event.failure.as_ref().map(|f| f.recoverable),
             };
+            let bus_payload_json =
+                serde_json::to_string(&bus_payload).unwrap_or_else(|_| "{}".to_owned());
 
             let outcome = match event.new_state.as_str() {
                 "succeeded" => Outcome::Applied,
                 "failed" => Outcome::Failed,
-                // stale / refused / skipped: the item never completed a
-                // mutation attempt — declined, not a failed attempt.
                 _ => Outcome::Refused,
             };
             let reason_code = event
@@ -153,8 +307,8 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
             )
             .with_transition(event.prior_state.clone(), event.new_state.clone())
             .with_payload(json!({
-                "planId": plan_id,
-                "runId": run_id,
+                "planId": self.plan_id,
+                "runId": self.run_id,
                 "itemId": item_id,
                 "failureCode": event.failure.as_ref().map(|f| f.code.as_str()),
                 "failureMessage": event.failure.as_ref().map(|f| f.message.clone()),
@@ -163,26 +317,17 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
                 audit_entry = audit_entry.with_reason_code(reason);
             }
 
-            if let Err(e) = bus
-                .write_audit(audit_entry, TOPIC_PLAN_ITEM_PROGRESS, Source::System, bus_payload)
-                .await
-            {
-                tracing::error!(%item_id, error=%e, "durable audit write failed for item progress");
-            }
-
-            // Live long-op projection (spec 042 US16, T240). Additive to the
-            // durable audit record above — never a replacement (§II).
-            if let Some(emitter) = op_emitter.as_ref() {
+            let op_event = self.op_emitter.as_ref().map(|_| {
                 let event_type = match event.new_state.as_str() {
                     "succeeded" => OperationEventType::ItemApplied,
                     "failed" | "stale" => OperationEventType::ItemFailed,
                     _ => OperationEventType::Progress,
                 };
-                emitter.emit(
+                OpEventPayload {
                     event_type,
-                    json!({
-                        "planId": plan_id,
-                        "runId": run_id,
+                    payload: json!({
+                        "planId": self.plan_id,
+                        "runId": self.run_id,
                         "itemId": item_id,
                         "priorState": event.prior_state,
                         "newState": event.new_state,
@@ -190,17 +335,43 @@ impl ExecutorCallbacks for PlanApplyCallbacks {
                         "failureCode": event.failure.as_ref().map(|f| f.code.as_str()),
                         "failureMessage": event.failure.as_ref().map(|f| f.message.clone()),
                     }),
-                );
+                }
+            });
+
+            let buffered = BufferedItem {
+                item_id: item_id.clone(),
+                prior_state: event.prior_state.clone(),
+                new_state: event.new_state.clone(),
+                at: at.clone(),
+                failure_reason: event.failure.as_ref().map(std::string::ToString::to_string),
+                failure_code: event.failure.as_ref().map(|f| f.code.as_str().to_owned()),
+                failure_message: event.failure.as_ref().map(|f| f.message.clone()),
+                failure_recoverable: event.failure.as_ref().map(|f| f.recoverable),
+                rollback_attempted: event.rollback_attempted,
+                rollback_outcome: event.rollback_outcome,
+                rollback_message: event.rollback_message,
+                audit_entry,
+                bus_payload_json,
+                op_event,
+            };
+
+            let should_flush = {
+                let mut buf = self.buffer.lock().expect("flush buffer poisoned");
+                buf.items.push(buffered);
+                buf.should_flush()
+            };
+
+            if should_flush {
+                self.flush().await;
             }
         })
     }
 }
 
-/// Emit both the run-events row and a durable `audit_log_entry` row for one
-/// item forced into `cancelled` by a bulk-cancel path (#750: `list_pending_items`
-/// happy path, its retry, and the orphaned-`applying` sweep). The forward
-/// executor loop's own terminal transitions go through `on_item_progress`
-/// instead — this helper only covers the bulk-cancel paths that bypass it.
+/// Emit both a `plan_apply_events` row and a durable `audit_log_entry` row for
+/// one item forced into `cancelled` by a bulk-cancel path (#750). The forward
+/// executor loop's terminal transitions go through `on_item_progress`; this
+/// helper only covers the bulk-cancel paths that bypass it.
 pub(super) async fn audit_item_cancelled(
     pool: &SqlitePool,
     bus: &EventBus,

--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -7,6 +7,28 @@ use super::{
     SpawnExecutorParams, SqlitePool, Timestamp, Utf8Path, Utf8PathBuf, TOPIC_PLAN_APPLYING_RESUMED,
 };
 
+// ── startup sweep ────────────────────────────────────────────────────────────
+
+/// At boot, flip every plan left in state `applying` with no live executor to
+/// `paused` (with `pause_reason = 'crash'`), making `resume_plan` available.
+///
+/// Called once from the desktop app's `boot()` function, before any webview
+/// command can be invoked. The `active_runs` registry is always empty at
+/// startup, so every `applying` plan qualifies: no live executor will ever
+/// advance them.
+///
+/// Returns the plan ids that were transitioned.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure (non-fatal at boot —
+/// caller should log and continue).
+pub async fn sweep_crashed_applying_plans(
+    pool: &SqlitePool,
+) -> Result<Vec<String>, persistence_core::DbError> {
+    apply_repo::sweep_crashed_applying_plans(pool).await
+}
+
 // ── cancel_plan ───────────────────────────────────────────────────────────────
 
 /// Cancel an in-flight plan apply (US3, T032).

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -698,9 +698,24 @@ async fn retry_plan_item_transitions_failed_item_to_applying() {
     let (db, _bus) = setup().await;
     insert_approved_plan_with_items(&db, "p-retry", 1).await;
     plans_repo::update_plan_state(db.pool(), "p-retry", "applying").await.unwrap();
-    apply_repo::item_failed(db.pool(), "p-retry-item-0", "p-retry", "permission.denied")
+    {
+        let mut conn = db.pool().acquire().await.unwrap();
+        apply_repo::batch_flush_item_states(
+            &mut conn,
+            "p-retry",
+            &[apply_repo::BatchItemState {
+                item_id: "p-retry-item-0",
+                new_state: "failed",
+                failure_reason: Some("permission.denied"),
+                is_stale: false,
+            }],
+            0,
+            1,
+            0,
+        )
         .await
         .unwrap();
+    }
     register_fake_active_run("p-retry");
 
     let resp = retry_plan_item(db.pool(), "p-retry", "p-retry-item-0").await.unwrap();
@@ -720,14 +735,24 @@ async fn retry_plan_item_rejects_when_no_active_run() {
     let (db, _bus) = setup().await;
     insert_approved_plan_with_items(&db, "p-retry-no-run", 1).await;
     plans_repo::update_plan_state(db.pool(), "p-retry-no-run", "applying").await.unwrap();
-    apply_repo::item_failed(
-        db.pool(),
-        "p-retry-no-run-item-0",
-        "p-retry-no-run",
-        "permission.denied",
-    )
-    .await
-    .unwrap();
+    {
+        let mut conn = db.pool().acquire().await.unwrap();
+        apply_repo::batch_flush_item_states(
+            &mut conn,
+            "p-retry-no-run",
+            &[apply_repo::BatchItemState {
+                item_id: "p-retry-no-run-item-0",
+                new_state: "failed",
+                failure_reason: Some("permission.denied"),
+                is_stale: false,
+            }],
+            0,
+            1,
+            0,
+        )
+        .await
+        .unwrap();
+    }
     // Deliberately NOT registering an ActiveRun.
 
     let err =

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -107,14 +107,15 @@ async fn plan_apply_callbacks_persist_every_producible_failure_code() {
     .await
     .unwrap();
 
-    let callbacks = PlanApplyCallbacks {
-        pool: db.pool().clone(),
+    let callbacks = PlanApplyCallbacks::new(
+        db.pool().clone(),
         bus,
-        plan_id: plan_id.to_owned(),
-        run_id: run_id.to_owned(),
-        op_emitter: None,
-    };
+        plan_id.to_owned(),
+        run_id.to_owned(),
+        None,
+    );
 
+    // Buffer all events (group-commit design: rows aren't written until flush).
     for (index, code) in PRODUCIBLE_CODES.into_iter().enumerate() {
         let item_id = format!("{plan_id}-item-{index}");
         callbacks.on_item_start(&item_id).await;
@@ -131,7 +132,14 @@ async fn plan_apply_callbacks_persist_every_producible_failure_code() {
                 audit_reason: None,
             })
             .await;
+    }
 
+    // Mandatory flush: drains the buffer into the DB in one tx.
+    callbacks.flush().await;
+
+    // Verify every failure code was persisted.
+    for (index, code) in PRODUCIBLE_CODES.into_iter().enumerate() {
+        let item_id = format!("{plan_id}-item-{index}");
         let persisted: Option<String> = sqlx::query_scalar(
             "SELECT failure_code FROM plan_apply_events WHERE plan_id = ? AND item_id = ?",
         )
@@ -1548,4 +1556,101 @@ fn compute_plan_path_set_resolves_roots_and_archive() {
 
     let disjoint: PlanPathSet = [Utf8PathBuf::from("/elsewhere")].into_iter().collect();
     assert!(!set.overlaps(&disjoint));
+}
+
+/// Group-commit correctness: applying N items via the buffered
+/// `PlanApplyCallbacks` produces exactly N `plan_apply_events` rows + 1
+/// plan-level started row, and the `plans` counter ends at `items_applied = N`.
+///
+/// This also functions as a commit-reduction acceptance check: the design
+/// replaces ~5N individual autocommit writes with ceil(N/100) flush txs +
+/// plan-level bookends. For N=200 the former path issues ~1000 commits; the
+/// buffered path issues at most ceil(200/100)+2 = 4 commits.
+///
+/// Commit count is not directly measurable in a unit test (SQLite
+/// statement-count APIs are not exposed by sqlx), but row-count + counter
+/// correctness proves the flush logic is correct without relying on timing.
+#[tokio::test]
+async fn group_commit_produces_correct_row_count_and_counters() {
+    const N: usize = 200;
+
+    let (db, bus) = setup().await;
+    let plan_id = "gc-correctness";
+    let run_id = "gc-run-1";
+    insert_approved_plan_with_items(&db, plan_id, N).await;
+    let n = i64::try_from(N).unwrap();
+    apply_repo::cas_approved_to_applying(db.pool(), plan_id, run_id, "test-token", n, n)
+        .await
+        .unwrap();
+
+    let callbacks = PlanApplyCallbacks::new(
+        db.pool().clone(),
+        bus,
+        plan_id.to_owned(),
+        run_id.to_owned(),
+        None,
+    );
+
+    // Emit N succeeded events — mix in a few failures to test delta accounting.
+    let mut expected_applied = 0i64;
+    let mut expected_failed = 0i64;
+    for i in 0..N {
+        let item_id = format!("{plan_id}-item-{i}");
+        // Fail every 10th item so we exercise both counter paths.
+        let (new_state, failure) = if i % 10 == 9 {
+            expected_failed += 1;
+            ("failed", Some(PlanItemFailure::with_code(FailureCode::SourceMissing, "test")))
+        } else {
+            expected_applied += 1;
+            ("succeeded", None)
+        };
+
+        callbacks
+            .on_item_progress(ItemProgressEvent {
+                item_id,
+                prior_state: "pending".to_owned(),
+                new_state: new_state.to_owned(),
+                at: domain_core::ids::Timestamp::now_iso(),
+                failure,
+                rollback_attempted: false,
+                rollback_outcome: RollbackOutcome::NotApplicable,
+                rollback_message: None,
+                audit_reason: None,
+            })
+            .await;
+    }
+
+    // Final mandatory flush (mirrors what spawn_executor_run does before
+    // complete_run).
+    callbacks.flush().await;
+
+    // Verify plan_apply_events has exactly N item rows.
+    let event_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM plan_apply_events WHERE plan_id = ? AND item_id IS NOT NULL",
+    )
+    .bind(plan_id)
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(event_count, n, "must have one plan_apply_events row per item");
+
+    // Verify plans counters.
+    let plan =
+        persistence_plans::repositories::plans::get_plan(db.pool(), plan_id, false).await.unwrap();
+    assert_eq!(plan.items_applied, expected_applied, "items_applied counter");
+    assert_eq!(plan.items_failed, expected_failed, "items_failed counter");
+
+    // Verify audit_log_entry has N rows for this plan's items (one per item,
+    // written in the flush batch; entity_type = 'filesystem_plan').
+    let audit_count: i64 = sqlx::query_scalar(
+        "SELECT COUNT(*) FROM audit_log_entry WHERE entity_type = 'filesystem_plan'",
+    )
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert!(
+        audit_count >= expected_applied + expected_failed,
+        "must have at least one audit row per item; got {audit_count}, want >= {}",
+        expected_applied + expected_failed
+    );
 }

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1654,3 +1654,205 @@ async fn group_commit_produces_correct_row_count_and_counters() {
         expected_applied + expected_failed
     );
 }
+
+/// Flush-on-timeout: items accumulated for longer than 250 ms trigger a flush
+/// at the next item boundary even when the 100-item count threshold is not met.
+#[tokio::test]
+async fn group_commit_flush_on_timeout() {
+    let (db, bus) = setup().await;
+    let plan_id = "gc-timeout";
+    let run_id = "gc-timeout-run";
+    insert_approved_plan_with_items(&db, plan_id, 5).await;
+    apply_repo::cas_approved_to_applying(db.pool(), plan_id, run_id, "test-token", 5, 5)
+        .await
+        .unwrap();
+
+    let callbacks = PlanApplyCallbacks::new(
+        db.pool().clone(),
+        bus,
+        plan_id.to_owned(),
+        run_id.to_owned(),
+        None,
+    );
+
+    // Emit one item — well below the 100-item threshold.
+    callbacks
+        .on_item_progress(ItemProgressEvent {
+            item_id: format!("{plan_id}-item-0"),
+            prior_state: "pending".to_owned(),
+            new_state: "succeeded".to_owned(),
+            at: domain_core::ids::Timestamp::now_iso(),
+            failure: None,
+            rollback_attempted: false,
+            rollback_outcome: RollbackOutcome::NotApplicable,
+            rollback_message: None,
+            audit_reason: None,
+        })
+        .await;
+
+    // Before the 250 ms window expires the row must not be in the DB yet.
+    let count_before: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM plan_apply_events WHERE plan_id = ?")
+            .bind(plan_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(count_before, 0, "row must be buffered, not yet flushed");
+
+    // Advance past the 250 ms window.
+    tokio::time::sleep(tokio::time::Duration::from_millis(300)).await;
+
+    // A second item triggers the boundary check — the 250 ms elapsed flag
+    // causes the buffer to flush (the second item is then also flushed).
+    callbacks
+        .on_item_progress(ItemProgressEvent {
+            item_id: format!("{plan_id}-item-1"),
+            prior_state: "pending".to_owned(),
+            new_state: "succeeded".to_owned(),
+            at: domain_core::ids::Timestamp::now_iso(),
+            failure: None,
+            rollback_attempted: false,
+            rollback_outcome: RollbackOutcome::NotApplicable,
+            rollback_message: None,
+            audit_reason: None,
+        })
+        .await;
+
+    let count_after: i64 =
+        sqlx::query_scalar("SELECT COUNT(*) FROM plan_apply_events WHERE plan_id = ?")
+            .bind(plan_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+    assert_eq!(count_after, 2, "both items must be flushed after the 250 ms window expires");
+}
+
+/// Crash-window recovery: items from a lost flush window (simulated by
+/// executing the fs op but not flushing) re-execute on resume and land as
+/// `source.missing` terminal failures (CAS gate refuses them), never
+/// double-applying the mutation.
+///
+/// This validates the crash-safety claim in the batching design: fs ops for
+/// items in the lost window already ran; re-execution hits the
+/// `check_cas`/destination-exists gates and produces a reviewable failure
+/// rather than a silent duplicate mutation.
+#[tokio::test]
+async fn crash_window_recovery_produces_source_missing_not_double_apply() {
+    use std::fs;
+    use tempfile::TempDir;
+
+    let tmp = TempDir::new().unwrap();
+    let src = tmp.path().join("light.fits");
+    let dst = tmp.path().join("archive").join("light.fits");
+    fs::write(&src, "fits-data").unwrap();
+
+    let (db, bus) = setup().await;
+    // Register a root so item_row_to_executor_item resolves the path.
+    let root_id = uuid::Uuid::new_v4().to_string();
+    sqlx::query(
+        "INSERT INTO registered_sources \
+         (id, kind, path, scan_depth, created_at, created_via, organization_state) \
+         VALUES (?, 'light_frames', ?, 'recursive', '2026-01-01T00:00:00Z', 'first_run', 'organized')",
+    )
+    .bind(&root_id)
+    .bind(tmp.path().to_str().unwrap())
+    .execute(db.pool())
+    .await
+    .unwrap();
+
+    // Insert a plan item that moves src → archive/light.fits.
+    let plan_id = "crash-recovery";
+    let run_id = "crash-recovery-run";
+    repo::insert_plan(
+        db.pool(),
+        &repo::InsertPlan {
+            id: plan_id,
+            title: "Crash recovery test",
+            origin: "cleanup",
+            origin_path: None,
+            plan_type: "cleanup",
+            destructive_destination: "archive",
+            parent_plan_id: None,
+            total_bytes_required: 0,
+        },
+    )
+    .await
+    .unwrap();
+    repo::insert_plan_item(
+        db.pool(),
+        &repo::InsertPlanItem {
+            id: &format!("{plan_id}-item-0"),
+            plan_id,
+            item_index: 1,
+            name: "light.fits",
+            action: "move",
+            from_root_id: Some(&root_id),
+            from_relative_path: "light.fits",
+            to_root_id: Some(&root_id),
+            to_relative_path: "archive/light.fits",
+            reason: "test",
+            protection: "normal",
+            linked_entity: None,
+            provenance_json: None,
+            archive_path: None,
+            source_id: None,
+            category: None,
+        },
+    )
+    .await
+    .unwrap();
+    repo::update_plan_state(db.pool(), plan_id, "ready_for_review").await.unwrap();
+    repo::set_approved(db.pool(), plan_id, "2026-06-01T00:00:00Z", "test-token").await.unwrap();
+
+    // Simulate the crash-window scenario: the fs op ran (rename succeeded)
+    // but the flush tx never committed — move the file manually to represent
+    // a mutation that happened in a lost flush window.
+    fs::create_dir_all(dst.parent().unwrap()).unwrap();
+    fs::rename(&src, &dst).unwrap();
+    assert!(!src.exists(), "source must be gone after simulated move");
+    assert!(dst.exists(), "destination must exist after simulated move");
+
+    // Apply the plan — the executor runs the move on a missing source. The
+    // check_cas gate returns SourceMissing → terminal failed, no double-apply.
+    let resp = apply_plan(db.pool(), &bus, plan_id, "test-token", None).await.unwrap();
+    let _ = run_id; // not used after removing the manual CAS
+    assert_eq!(resp.new_state, "applying");
+
+    // Wait for the background executor to complete.
+    for _ in 0..50 {
+        tokio::time::sleep(tokio::time::Duration::from_millis(50)).await;
+        let state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+            .bind(plan_id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        if state != "applying" {
+            break;
+        }
+    }
+
+    // The plan must be terminal (failed or partially_applied, not applying).
+    let final_state: String = sqlx::query_scalar("SELECT state FROM plans WHERE id = ?")
+        .bind(plan_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert!(
+        matches!(final_state.as_str(), "failed" | "partially_applied"),
+        "plan must be terminal after re-apply of already-moved item; got {final_state}"
+    );
+
+    // The item must be in a failed state (not succeeded — it didn't move again).
+    let item_state: String = sqlx::query_scalar("SELECT item_state FROM plan_items WHERE id = ?")
+        .bind(format!("{plan_id}-item-0"))
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        item_state, "failed",
+        "re-applied item must be failed (source.missing), not succeeded"
+    );
+
+    // The destination must not have been touched a second time.
+    assert!(dst.exists(), "destination file must still exist — no double-apply");
+}

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -26,6 +26,34 @@ use persistence_plans::repositories::plan_apply as apply_repo;
 use persistence_plans::repositories::plans as plans_repo;
 use uuid::Uuid;
 
+/// Seed one item into `failed` state without going through the executor.
+/// Replaces the deleted `item_start_applying` + `item_failed` pair —
+/// `batch_flush_item_states` goes pending → terminal in one step,
+/// matching the group-commit path the real executor now uses.
+async fn seed_item_failed(
+    pool: &sqlx::SqlitePool,
+    item_id: &str,
+    plan_id: &str,
+    failure_reason: &str,
+) {
+    let mut conn = pool.acquire().await.expect("acquire connection");
+    apply_repo::batch_flush_item_states(
+        &mut conn,
+        plan_id,
+        &[apply_repo::BatchItemState {
+            item_id,
+            new_state: "failed",
+            failure_reason: Some(failure_reason),
+            is_stale: false,
+        }],
+        0,
+        1,
+        0,
+    )
+    .await
+    .expect("seed_item_failed");
+}
+
 /// Register a `registered_sources` root row pointing at a real directory, so
 /// `resolve_root_path`/the T023a root-map machinery has something real to
 /// resolve (required for the volume/disk probes, which target the plan
@@ -275,17 +303,13 @@ async fn resume_refused_while_volume_still_unavailable() {
     apply_repo::cas_approved_to_applying(db.pool(), &plan_id, &run_id, "tok-test-fixed", 2, 2)
         .await
         .expect("cas_approved_to_applying");
-    apply_repo::item_start_applying(db.pool(), &item0_id, &plan_id)
-        .await
-        .expect("item_start_applying");
-    apply_repo::item_failed(
+    seed_item_failed(
         db.pool(),
         &item0_id,
         &plan_id,
         "volume.unavailable: move failed: simulated disconnect",
     )
-    .await
-    .expect("item_failed");
+    .await;
     apply_repo::pause_run(db.pool(), &plan_id, &run_id, "volume.unavailable", 0, 1, 0, 0, 1)
         .await
         .expect("pause_run");
@@ -321,17 +345,13 @@ async fn resume_succeeds_after_volume_available_again() {
     apply_repo::cas_approved_to_applying(db.pool(), &plan_id, &run_id, "tok-test-fixed", 2, 2)
         .await
         .expect("cas_approved_to_applying");
-    apply_repo::item_start_applying(db.pool(), &item0_id, &plan_id)
-        .await
-        .expect("item_start_applying");
-    apply_repo::item_failed(
+    seed_item_failed(
         db.pool(),
         &item0_id,
         &plan_id,
         "volume.unavailable: move failed: simulated disconnect",
     )
-    .await
-    .expect("item_failed");
+    .await;
     apply_repo::pause_run(db.pool(), &plan_id, &run_id, "volume.unavailable", 0, 1, 0, 0, 1)
         .await
         .expect("pause_run");
@@ -380,17 +400,13 @@ async fn resume_refused_while_disk_still_full() {
     apply_repo::cas_approved_to_applying(db.pool(), &plan_id, &run_id, "tok-test-fixed", 2, 2)
         .await
         .expect("cas_approved_to_applying");
-    apply_repo::item_start_applying(db.pool(), &item0_id, &plan_id)
-        .await
-        .expect("item_start_applying");
-    apply_repo::item_failed(
+    seed_item_failed(
         db.pool(),
         &item0_id,
         &plan_id,
         "disk.full: move failed: simulated storage-full",
     )
-    .await
-    .expect("item_failed");
+    .await;
     apply_repo::pause_run(db.pool(), &plan_id, &run_id, "disk.full", 0, 1, 0, 0, 1)
         .await
         .expect("pause_run");
@@ -427,17 +443,13 @@ async fn resume_succeeds_after_disk_space_available_again() {
     apply_repo::cas_approved_to_applying(db.pool(), &plan_id, &run_id, "tok-test-fixed", 2, 2)
         .await
         .expect("cas_approved_to_applying");
-    apply_repo::item_start_applying(db.pool(), &item0_id, &plan_id)
-        .await
-        .expect("item_start_applying");
-    apply_repo::item_failed(
+    seed_item_failed(
         db.pool(),
         &item0_id,
         &plan_id,
         "disk.full: move failed: simulated storage-full",
     )
-    .await
-    .expect("item_failed");
+    .await;
     apply_repo::pause_run(db.pool(), &plan_id, &run_id, "disk.full", 0, 1, 0, 0, 1)
         .await
         .expect("pause_run");
@@ -499,17 +511,13 @@ async fn cancel_signals_the_executor_restarted_by_resume() {
     )
     .await
     .expect("cas_approved_to_applying");
-    apply_repo::item_start_applying(db.pool(), &item0_id, &plan_id)
-        .await
-        .expect("item_start_applying");
-    apply_repo::item_failed(
+    seed_item_failed(
         db.pool(),
         &item0_id,
         &plan_id,
         "volume.unavailable: move failed: simulated disconnect",
     )
-    .await
-    .expect("item_failed");
+    .await;
     apply_repo::pause_run(
         db.pool(),
         &plan_id,

--- a/crates/audit/src/bus.rs
+++ b/crates/audit/src/bus.rs
@@ -161,6 +161,19 @@ impl EventBus {
         Ok(entry.audit_id)
     }
 
+    /// Broadcast a signal to live subscribers **without** writing a durable
+    /// events-table row.
+    ///
+    /// Used by the group-commit flush path: durable rows are already committed
+    /// inside the flush transaction; this call wakes the log forwarder (which
+    /// re-queries the DB) without double-writing. Returns the number of active
+    /// receivers that received the signal; `0` is not an error.
+    #[must_use]
+    pub fn broadcast_only(&self, topic: &str) -> usize {
+        let envelope = EventEnvelope::new(topic, Source::System, serde_json::Value::Null);
+        self.sender.send(envelope).unwrap_or(0)
+    }
+
     /// Subscribe to all live events on the bus.
     ///
     /// Receiver is non-blocking (async). Missed events due to capacity overflow

--- a/crates/persistence/core/src/repositories/audit_writes.rs
+++ b/crates/persistence/core/src/repositories/audit_writes.rs
@@ -52,6 +52,47 @@ pub async fn insert_audit_entry(pool: &SqlitePool, entry: &AuditLogEntry) -> DbR
     Ok(())
 }
 
+/// Insert an `audit_log_entry` row on an existing connection (for use inside
+/// a transaction).
+///
+/// # Errors
+/// Returns [`crate::DbError`] if the insert fails.
+pub async fn insert_audit_entry_conn(
+    conn: &mut SqliteConnection,
+    entry: &AuditLogEntry,
+) -> DbResult<()> {
+    let at_str = entry
+        .at
+        .as_offset_date_time()
+        .format(&time::format_description::well_known::Rfc3339)
+        .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+    let payload_str = entry.payload.as_ref().map(std::string::ToString::to_string);
+
+    sqlx::query(
+        "INSERT INTO audit_log_entry \
+         (audit_id, entity_type, entity_id, from_state, to_state, trigger, actor, \
+          outcome, severity, request_id, at, payload, reason_code) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(entry.audit_id.as_uuid().to_string())
+    .bind(entry.entity_type.as_str())
+    .bind(entry.entity_id.to_string())
+    .bind(&entry.from_state)
+    .bind(&entry.to_state)
+    .bind(&entry.trigger)
+    .bind(&entry.actor)
+    .bind(entry.outcome.as_str())
+    .bind(entry.severity.as_str())
+    .bind(entry.request_id.to_string())
+    .bind(&at_str)
+    .bind(&payload_str)
+    .bind(&entry.reason_code)
+    .execute(conn)
+    .await?;
+
+    Ok(())
+}
+
 /// Insert a project auto-transition audit row, acquiring a connection from
 /// the pool.
 ///

--- a/crates/persistence/lifecycle/src/repositories/events.rs
+++ b/crates/persistence/lifecycle/src/repositories/events.rs
@@ -8,7 +8,7 @@
 //! `commands::log`) — hence the retention-gap and time-range read shapes
 //! below, not just the two `EventBus::replay` variants.
 
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use persistence_core::DbResult;
 
@@ -40,6 +40,29 @@ pub async fn insert_event(
             .bind(emitted_at)
             .bind(payload)
             .execute(pool)
+            .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Append a durable event row on an existing connection (for use inside a
+/// transaction). Returns the assigned `event_id`.
+///
+/// # Errors
+/// Returns [`DbError::Database`] on query failure.
+pub async fn insert_event_conn(
+    conn: &mut SqliteConnection,
+    topic: &str,
+    source: &str,
+    emitted_at: &str,
+    payload: &str,
+) -> DbResult<i64> {
+    let result =
+        sqlx::query("INSERT INTO events (topic, source, emitted_at, payload) VALUES (?, ?, ?, ?)")
+            .bind(topic)
+            .bind(source)
+            .bind(emitted_at)
+            .bind(payload)
+            .execute(conn)
             .await?;
     Ok(result.last_insert_rowid())
 }

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -13,7 +13,7 @@
 
 use domain_core::ids::Timestamp;
 use serde::{Deserialize, Serialize};
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use persistence_core::{DbError, DbResult};
 
@@ -705,6 +705,128 @@ pub async fn get_last_item_with_failure_prefix(
     .bind(pattern)
     .fetch_optional(pool)
     .await?)
+}
+
+// ── Batch item flush (group-commit writer) ────────────────────────────────────
+
+/// One item's terminal state to persist in a flush batch.
+#[derive(Clone, Debug)]
+pub struct BatchItemState<'a> {
+    pub item_id: &'a str,
+    /// Terminal state: `succeeded`, `failed`, `skipped`, or `refused`
+    /// (refused persists as `failed`).
+    pub new_state: &'a str,
+    /// Failure reason text, if any.
+    pub failure_reason: Option<&'a str>,
+}
+
+/// Persist a batch of item terminal-state transitions in one transaction
+/// connection.
+///
+/// Issues one UPDATE per item in `states`, then one aggregated plans-counter
+/// UPDATE. Callers open the transaction, call this, write audit and event rows
+/// on the same connection, and commit — achieving one fsync per flush window.
+///
+/// `delta_applied`, `delta_failed`, `delta_skipped` are the net counter
+/// changes for this batch.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn batch_flush_item_states(
+    conn: &mut SqliteConnection,
+    plan_id: &str,
+    states: &[BatchItemState<'_>],
+    delta_applied: i64,
+    delta_failed: i64,
+    delta_skipped: i64,
+) -> DbResult<()> {
+    if states.is_empty() {
+        return Ok(());
+    }
+
+    for item in states {
+        // Refused items have no distinct item_state — persist as 'failed'.
+        let db_state = if item.new_state == "refused" { "failed" } else { item.new_state };
+        sqlx::query("UPDATE plan_items SET item_state = ?, failure_reason = ? WHERE id = ?")
+            .bind(db_state)
+            .bind(item.failure_reason)
+            .bind(item.item_id)
+            .execute(&mut *conn)
+            .await?;
+    }
+
+    // One aggregated counter statement for the whole batch.
+    let delta_pending = delta_applied + delta_failed + delta_skipped;
+    sqlx::query(
+        "UPDATE plans SET \
+           items_applied = items_applied + ?, \
+           items_failed  = items_failed  + ?, \
+           items_skipped = items_skipped + ?, \
+           items_pending = MAX(0, items_pending - ?) \
+         WHERE id = ?",
+    )
+    .bind(delta_applied)
+    .bind(delta_failed)
+    .bind(delta_skipped)
+    .bind(delta_pending)
+    .bind(plan_id)
+    .execute(&mut *conn)
+    .await?;
+
+    Ok(())
+}
+
+/// Append a `plan_apply_events` row on an existing connection (for use inside
+/// a group-commit transaction).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+#[allow(clippy::too_many_arguments)]
+pub async fn append_event_conn(
+    conn: &mut SqliteConnection,
+    event_id: &str,
+    run_id: &str,
+    plan_id: &str,
+    item_id: Option<&str>,
+    prior_state: &str,
+    new_state: &str,
+    at: &str,
+    failure: Option<&EventFailure<'_>>,
+    rollback: Option<&EventRollback<'_>>,
+) -> DbResult<()> {
+    let (fc, fm, fr) = failure.map_or((None, None, None), |f| {
+        (Some(f.code), Some(f.message), Some(i64::from(f.recoverable)))
+    });
+
+    let (ra, ro, rm) = rollback
+        .map_or((None, None, None), |r| (Some(i64::from(r.attempted)), Some(r.outcome), r.message));
+
+    sqlx::query(
+        "INSERT INTO plan_apply_events \
+         (id, run_id, plan_id, item_id, prior_state, new_state, at, \
+          failure_code, failure_message, failure_recoverable, \
+          rollback_attempted, rollback_outcome, rollback_message) \
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(event_id)
+    .bind(run_id)
+    .bind(plan_id)
+    .bind(item_id)
+    .bind(prior_state)
+    .bind(new_state)
+    .bind(at)
+    .bind(fc)
+    .bind(fm)
+    .bind(fr)
+    .bind(ra)
+    .bind(ro)
+    .bind(rm)
+    .execute(conn)
+    .await?;
+
+    Ok(())
 }
 
 // ── Startup sweep ─────────────────────────────────────────────────────────────

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -718,6 +718,10 @@ pub struct BatchItemState<'a> {
     pub new_state: &'a str,
     /// Failure reason text, if any.
     pub failure_reason: Option<&'a str>,
+    /// Whether this is a CAS stale failure (sets `item_stale = 1`).
+    /// Required so `get_last_stale_item` (used by `revalidate_pause_condition`)
+    /// can find the triggering item after a flush-batched stale transition.
+    pub is_stale: bool,
 }
 
 /// Persist a batch of item terminal-state transitions in one transaction
@@ -746,14 +750,24 @@ pub async fn batch_flush_item_states(
     }
 
     for item in states {
-        // Refused items have no distinct item_state — persist as 'failed'.
-        let db_state = if item.new_state == "refused" { "failed" } else { item.new_state };
-        sqlx::query("UPDATE plan_items SET item_state = ?, failure_reason = ? WHERE id = ?")
-            .bind(db_state)
-            .bind(item.failure_reason)
-            .bind(item.item_id)
-            .execute(&mut *conn)
-            .await?;
+        // 'refused' and 'stale' have no distinct item_state CHECK values —
+        // both persist as 'failed'; item_stale=1 distinguishes stale items.
+        let db_state =
+            if matches!(item.new_state, "refused" | "stale") { "failed" } else { item.new_state };
+        // item_stale=1 is load-bearing: get_last_stale_item (used by
+        // revalidate_pause_condition for "item.stale" pauses) queries
+        // WHERE item_stale=1; omitting this flag makes stale-paused plans
+        // skip source re-validation on resume.
+        let stale_flag = i64::from(item.is_stale);
+        sqlx::query(
+            "UPDATE plan_items SET item_state = ?, failure_reason = ?, item_stale = ? WHERE id = ?",
+        )
+        .bind(db_state)
+        .bind(item.failure_reason)
+        .bind(stale_flag)
+        .bind(item.item_id)
+        .execute(&mut *conn)
+        .await?;
     }
 
     // One aggregated counter statement for the whole batch.
@@ -1097,5 +1111,59 @@ mod tests {
 
         let run = get_run(db.pool(), "run-6").await.unwrap();
         assert_eq!(run.terminal_state, Some("applied".to_owned()));
+    }
+
+    /// batch_flush_item_states must set item_stale=1 for stale items so
+    /// get_last_stale_item can find them (required by revalidate_pause_condition).
+    #[tokio::test]
+    async fn batch_flush_sets_item_stale_flag() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        setup_with_approved_plan(&db, "ps1", 2).await;
+        cas_approved_to_applying(db.pool(), "ps1", "run-ps1", "tok", 2, 2).await.unwrap();
+
+        let mut conn = db.pool().acquire().await.unwrap();
+        batch_flush_item_states(
+            &mut conn,
+            "ps1",
+            &[
+                BatchItemState {
+                    item_id: "ps1-item-0",
+                    new_state: "stale",
+                    failure_reason: Some("item.stale: source changed"),
+                    is_stale: true,
+                },
+                BatchItemState {
+                    item_id: "ps1-item-1",
+                    new_state: "failed",
+                    failure_reason: Some("other error"),
+                    is_stale: false,
+                },
+            ],
+            0,
+            2,
+            0,
+        )
+        .await
+        .unwrap();
+
+        let stale_flag: i64 =
+            sqlx::query_scalar("SELECT item_stale FROM plan_items WHERE id = 'ps1-item-0'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(stale_flag, 1, "stale item must have item_stale=1");
+
+        let non_stale_flag: i64 =
+            sqlx::query_scalar("SELECT item_stale FROM plan_items WHERE id = 'ps1-item-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(non_stale_flag, 0, "non-stale item must keep item_stale=0");
+
+        // Verify get_last_stale_item finds the stale item.
+        let found = get_last_stale_item(db.pool(), "ps1").await.unwrap();
+        assert!(found.is_some(), "get_last_stale_item must find the stale item");
+        assert_eq!(found.unwrap().id, "ps1-item-0");
     }
 }

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -286,145 +286,6 @@ pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbRes
 
 // ── Per-item state transitions ────────────────────────────────────────────────
 
-/// Transition an item from `pending` → `applying`; decrement items_pending.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn item_start_applying(pool: &SqlitePool, item_id: &str, plan_id: &str) -> DbResult<()> {
-    let mut tx = pool.begin().await?;
-
-    sqlx::query("UPDATE plan_items SET item_state = 'applying' WHERE id = ?")
-        .bind(item_id)
-        .execute(&mut *tx)
-        .await?;
-
-    sqlx::query(
-        "UPDATE plans SET items_pending = items_pending - 1 WHERE id = ? AND items_pending > 0",
-    )
-    .bind(plan_id)
-    .execute(&mut *tx)
-    .await?;
-
-    tx.commit().await?;
-    Ok(())
-}
-
-/// Transition an item from `applying` → `succeeded`; increment items_applied.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn item_succeeded(pool: &SqlitePool, item_id: &str, plan_id: &str) -> DbResult<()> {
-    let mut tx = pool.begin().await?;
-
-    sqlx::query(
-        "UPDATE plan_items SET item_state = 'succeeded', failure_reason = NULL WHERE id = ?",
-    )
-    .bind(item_id)
-    .execute(&mut *tx)
-    .await?;
-
-    sqlx::query("UPDATE plans SET items_applied = items_applied + 1 WHERE id = ?")
-        .bind(plan_id)
-        .execute(&mut *tx)
-        .await?;
-
-    tx.commit().await?;
-    Ok(())
-}
-
-/// Transition an item from `applying` → `failed`; increment items_failed.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn item_failed(
-    pool: &SqlitePool,
-    item_id: &str,
-    plan_id: &str,
-    failure_reason: &str,
-) -> DbResult<()> {
-    let mut tx = pool.begin().await?;
-
-    sqlx::query("UPDATE plan_items SET item_state = 'failed', failure_reason = ? WHERE id = ?")
-        .bind(failure_reason)
-        .bind(item_id)
-        .execute(&mut *tx)
-        .await?;
-
-    sqlx::query("UPDATE plans SET items_failed = items_failed + 1 WHERE id = ?")
-        .bind(plan_id)
-        .execute(&mut *tx)
-        .await?;
-
-    tx.commit().await?;
-    Ok(())
-}
-
-/// Transition an item to `stale` (R-FS-1); increments `items_failed` (the
-/// item is terminally `failed` from the plan's perspective, matching
-/// [`item_failed`]) and the run pauses.
-///
-/// Previously this left `plans.items_failed` unchanged, which `pause_run`
-/// never read either — but `resume_plan`'s cumulative-counter reporting
-/// (issue #575, spec 025 R-Pause-1) and `get_apply_status` both surface
-/// `plans.items_failed` directly, so an under-count here would silently
-/// misreport a stale-paused plan as fully applied once its remaining items
-/// finish on resume.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn item_stale(pool: &SqlitePool, item_id: &str, plan_id: &str) -> DbResult<()> {
-    let mut tx = pool.begin().await?;
-
-    sqlx::query(
-        "UPDATE plan_items SET item_state = 'failed', item_stale = 1, \
-         failure_reason = 'item.stale: source file changed since approval' WHERE id = ?",
-    )
-    .bind(item_id)
-    .execute(&mut *tx)
-    .await?;
-
-    sqlx::query("UPDATE plans SET items_failed = items_failed + 1 WHERE id = ?")
-        .bind(plan_id)
-        .execute(&mut *tx)
-        .await?;
-
-    tx.commit().await?;
-    Ok(())
-}
-
-/// Transition an item from `pending` → `skipped` (user action during apply).
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn item_skip(pool: &SqlitePool, item_id: &str, plan_id: &str) -> DbResult<()> {
-    let mut tx = pool.begin().await?;
-
-    sqlx::query(
-        "UPDATE plan_items SET item_state = 'skipped' WHERE id = ? AND item_state = 'pending'",
-    )
-    .bind(item_id)
-    .execute(&mut *tx)
-    .await?;
-
-    sqlx::query(
-        "UPDATE plans SET \
-         items_pending = items_pending - 1, \
-         items_skipped = items_skipped + 1 \
-         WHERE id = ? AND items_pending > 0",
-    )
-    .bind(plan_id)
-    .execute(&mut *tx)
-    .await?;
-
-    tx.commit().await?;
-    Ok(())
-}
-
 /// Transition a failed item back to `applying` (per-item retry within a run).
 /// Decrements items_failed.
 ///
@@ -995,11 +856,24 @@ mod tests {
         setup_with_approved_plan(&db, "p3", 1).await;
         cas_approved_to_applying(db.pool(), "p3", "run-3", "tok", 1, 1).await.unwrap();
 
-        item_start_applying(db.pool(), "p3-item-0", "p3").await.unwrap();
-        let items = plans_repo::list_plan_items(db.pool(), "p3").await.unwrap();
-        assert_eq!(items[0].item_state, "applying");
+        // Batch path: pending → succeeded in one flush (no applying intermediate).
+        let mut conn = db.pool().acquire().await.unwrap();
+        batch_flush_item_states(
+            &mut conn,
+            "p3",
+            &[BatchItemState {
+                item_id: "p3-item-0",
+                new_state: "succeeded",
+                failure_reason: None,
+                is_stale: false,
+            }],
+            1,
+            0,
+            0,
+        )
+        .await
+        .unwrap();
 
-        item_succeeded(db.pool(), "p3-item-0", "p3").await.unwrap();
         let items = plans_repo::list_plan_items(db.pool(), "p3").await.unwrap();
         assert_eq!(items[0].item_state, "succeeded");
 
@@ -1014,9 +888,23 @@ mod tests {
         setup_with_approved_plan(&db, "p4", 3).await;
         cas_approved_to_applying(db.pool(), "p4", "run-4", "tok", 3, 3).await.unwrap();
 
-        // Apply first item.
-        item_start_applying(db.pool(), "p4-item-0", "p4").await.unwrap();
-        item_succeeded(db.pool(), "p4-item-0", "p4").await.unwrap();
+        // Apply first item via batch path.
+        let mut conn = db.pool().acquire().await.unwrap();
+        batch_flush_item_states(
+            &mut conn,
+            "p4",
+            &[BatchItemState {
+                item_id: "p4-item-0",
+                new_state: "succeeded",
+                failure_reason: None,
+                is_stale: false,
+            }],
+            1,
+            0,
+            0,
+        )
+        .await
+        .unwrap();
 
         // Cancel remaining 2.
         let cancelled = batch_cancel_pending_items(db.pool(), "p4").await.unwrap();

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -707,6 +707,53 @@ pub async fn get_last_item_with_failure_prefix(
     .await?)
 }
 
+// ── Startup sweep ─────────────────────────────────────────────────────────────
+
+/// At startup, flip every plan in state `applying` to `paused` with
+/// `pause_reason = 'crash'`, and mark its open run row as paused.
+///
+/// A plan left in `applying` with no live executor (i.e. after a hard crash)
+/// can never progress: the `active_runs` registry is empty at boot, so
+/// `resume_plan` would immediately fail the live-run check. Flipping these
+/// plans to `paused` makes `resume_plan` available and sets a clear reason in
+/// the audit trail.
+///
+/// Returns the ids of the plans that were transitioned.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn sweep_crashed_applying_plans(pool: &SqlitePool) -> DbResult<Vec<String>> {
+    let mut tx = pool.begin().await?;
+
+    let ids: Vec<String> =
+        sqlx::query_scalar("SELECT id FROM plans WHERE state = 'applying' ORDER BY id ASC")
+            .fetch_all(&mut *tx)
+            .await?;
+
+    if !ids.is_empty() {
+        sqlx::query("UPDATE plans SET state = 'paused' WHERE state = 'applying'")
+            .execute(&mut *tx)
+            .await?;
+
+        // Mark each plan's open run (terminal_state IS NULL or 'paused' covers
+        // in-progress runs; a brand-new 'applying' run has terminal_state = NULL).
+        sqlx::query(
+            "UPDATE plan_apply_runs \
+             SET terminal_state = 'paused', pause_reason = 'crash' \
+             WHERE plan_id IN \
+               (SELECT value FROM json_each(?)) \
+             AND (terminal_state IS NULL OR terminal_state = 'applying')",
+        )
+        .bind(serde_json::to_string(&ids).unwrap_or_default())
+        .execute(&mut *tx)
+        .await?;
+    }
+
+    tx.commit().await?;
+    Ok(ids)
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -870,6 +917,47 @@ mod tests {
         assert_eq!(events.len(), 1);
         assert_eq!(events[0].prior_state, "pending");
         assert_eq!(events[0].new_state, "applying");
+    }
+
+    #[tokio::test]
+    async fn sweep_crashed_applying_plans_transitions_to_paused() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        setup_with_approved_plan(&db, "pc1", 2).await;
+
+        // Drive into 'applying' (crash simulation: no executor runs).
+        cas_approved_to_applying(db.pool(), "pc1", "run-c1", "tok", 2, 2).await.unwrap();
+        let plan = plans_repo::get_plan(db.pool(), "pc1", false).await.unwrap();
+        assert_eq!(plan.state, "applying");
+
+        let affected = sweep_crashed_applying_plans(db.pool()).await.unwrap();
+        assert_eq!(affected, vec!["pc1".to_owned()]);
+
+        let plan = plans_repo::get_plan(db.pool(), "pc1", false).await.unwrap();
+        assert_eq!(plan.state, "paused", "crash-applying plan must become paused");
+
+        let run = get_run(db.pool(), "run-c1").await.unwrap();
+        assert_eq!(run.terminal_state, Some("paused".to_owned()));
+        assert_eq!(run.pause_reason, Some("crash".to_owned()));
+    }
+
+    #[tokio::test]
+    async fn sweep_ignores_already_paused_and_terminal_plans() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        // A plan in 'paused' state should not be affected.
+        setup_with_approved_plan(&db, "pp1", 1).await;
+        cas_approved_to_applying(db.pool(), "pp1", "run-pp1", "tok", 1, 1).await.unwrap();
+        pause_run(db.pool(), "pp1", "run-pp1", "item.stale", 0, 1, 0, 0, 0).await.unwrap();
+
+        let affected = sweep_crashed_applying_plans(db.pool()).await.unwrap();
+        assert!(affected.is_empty(), "paused plan must not be swept again");
+
+        let plan = plans_repo::get_plan(db.pool(), "pp1", false).await.unwrap();
+        assert_eq!(plan.state, "paused");
+        // pause_reason stays 'item.stale', not overwritten to 'crash'.
+        let run = get_run(db.pool(), "run-pp1").await.unwrap();
+        assert_eq!(run.pause_reason, Some("item.stale".to_owned()));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

Applying a filesystem plan previously issued ~5 SQLite commits per item (each an fsync under WAL+synchronous=FULL). A 10 000-item plan spent 50-500 seconds on commit overhead alone. This PR reduces that to ~102 commits for the same plan by buffering item writes and flushing one transaction per 100 items. A separate fix recovers plans that were left mid-apply after a crash.

## What's new

- Plans that were applying when the app crashed are automatically set to paused at next startup, making them resumable or cancellable from the UI.
- Applying large plans is significantly faster: commit overhead drops ~490x for a 10 000-item plan (50 000 commits to 102).
- Live progress updates during apply are batched: one progress tick per 100 items instead of one channel message per item, eliminating UI-thread churn on large plans.

## Commit reduction table (design estimate, not benchmarked)

| Plan size | Before | After | Reduction |
|---|---|---|---|
| 100 items | ~500 commits | ~3 | ~167x |
| 1 000 items | ~5 000 | ~12 | ~417x |
| 10 000 items | ~50 000 | ~102 | ~490x |

Figures derived from the verified per-item commit chain (batching-result.json id:0): 5 autocommits per item before; ceil(N/100) flush txs + 2 plan-level bookends after. Not benchmarked on target hardware.

## Spec Context

kyo7.51 (group-commit writer), kyo7.52 (batched progress ticks), kyo7.53 (crash-recovery startup sweep).

Tracks-Bead: kyo7.51
Tracks-Bead: kyo7.52
Tracks-Bead: kyo7.53
Closes-Bead: kyo7.51
Closes-Bead: kyo7.52
Closes-Bead: kyo7.53
Merge-Bead: astro-plan-za6s
