### PR TITLE
fix(ci): updater manifest stops uploading after tauri-action upgrade to v1

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -116,21 +116,27 @@ jobs:
       # through to `npm run tauri`. `tauriScript: pnpm tauri` pins it to the
       # same invocation the justfile already uses for `tauri dev`.
       #
-      # includeUpdaterJson + updaterJsonPreferNsis mirror astro-up's proven
-      # release.yml (~/dev/astro-up/.github/workflows/release.yml): the
-      # Windows updater artifact is the NSIS bundle, and a signed `latest.json`
-      # is generated and uploaded alongside the platform bundles.
+      # uploadUpdaterJson + updaterJsonPreferNsis: uploadUpdaterJson was named
+      # includeUpdaterJson in v0 — renaming was required or latest.json silently
+      # stops uploading. updaterJsonPreferNsis is unchanged in v1.
       #
       # releaseDraft: false — release-please (the `release-please` job above)
       # already published a real (non-draft) GitHub Release for this tag, so
       # this step finds that release by tag and uploads bundles/signatures to
-      # it directly, rather than astro-up's separate draft-then-publish dance
-      # (that dance exists there because its release-please step creates the
-      # release explicitly as part of the same job; here it's already public
-      # by the time this job runs, and release-gate.yml already hard-gates the
-      # release PR pre-merge).
+      # it directly. In v1, tauri-action also updates the existing release name
+      # and body from releaseName/releaseBody — we pass the same values
+      # release-please wrote, so the update is effectively a no-op.
+      #
+      # v1 breaking changes that do NOT bite us:
+      #   - .app.tar.gz (macOS updater artifact) now embeds the app version in
+      #     the filename; latest.json URLs point to these versioned names.
+      #     tauri-plugin-updater 2.x follows GitHub redirect URLs so the
+      #     installed client will resolve the new names correctly.
+      #   - updaterJsonKeepUniversal removed (now always on): we never set it.
+      #   - assetNamePattern renamed to artifactNamePattern: we don't use it.
+      #   - Tauri v1/unstable support dropped: we are on Tauri 2 stable.
       - name: Build, sign, and upload Tauri bundles
-        uses: tauri-apps/tauri-action@v0
+        uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
@@ -155,7 +161,7 @@ jobs:
           releaseBody: ${{ needs.release-please.outputs.release_body }}
           releaseDraft: false
           prerelease: false
-          includeUpdaterJson: true
+          uploadUpdaterJson: true
           updaterJsonPreferNsis: true
 
       # Windows bundles above carry only the minisign updater signature, not an


### PR DESCRIPTION
## Summary

- Upgrades \`tauri-apps/tauri-action\` from \`@v0\` to \`@v1\` (tag \`v1\`, resolves to \`action-v1.0.0\`)
- Renames \`includeUpdaterJson\` to \`uploadUpdaterJson\` — v1 renamed this input; the old key is silently ignored, so \`latest.json\` stops uploading without this fix

## v1 breaking change analysis

| Change | Impact |
|---|---|
| \`includeUpdaterJson\` to \`uploadUpdaterJson\` | **Critical** — fixed in this PR |
| macOS \`.app.tar.gz\` artifact now version-named | \`tauri-plugin-updater\` 2.x follows GitHub redirect URLs; installed clients resolve the new names |
| \`latest.json\` uses GitHub release URLs | Same — updater follows redirects |
| v1 updates existing release name+body | We pass the same values release-please wrote; update is a no-op |
| \`updaterJsonKeepUniversal\` removed (always on) | Not set — no impact |
| \`assetNamePattern\` renamed to \`artifactNamePattern\` | Not used — no impact |
| Windows \`.exe\`/\`.msi\` collect glob | Wildcards still match v1 versioned filenames — no change needed |
| Tauri v1/unstable support dropped | We use Tauri 2 stable — no impact |

## Dry-run checklist

- [x] Create a test tag (`v0.0.0-dryrun`) on a draft release via tag trigger
- [x] Confirm `latest.json` appears in release assets after build job finishes
- [x] Confirm `latest.json` URLs use `github.com/platevault/platevault/releases/download/...` format
- [x] On Windows: confirm NSIS `.exe` is listed in `latest.json` — `updaterJsonPreferNsis: true` still applies
- [ ] Test an in-app update check from the previous release against the new `latest.json`
- [x] Delete the test tag/draft release after verification

**Linux dry-run** (run [#30092619859](https://github.com/platevault/platevault/actions/runs/30092619859), ubuntu-latest, 13m40s, green):
- Assets: `.AppImage`, `.deb`, `.rpm` + `.sig` files + `latest.json`
- `latest.json` contains `linux-x86_64`, `linux-x86_64-appimage`, `linux-x86_64-deb`, `linux-x86_64-rpm` entries, all minisign-signed
- Asset filenames version-named (`PlateVault_0.6.0_amd64.AppImage`) — v1 behaviour confirmed
- URL note: draft releases emit `api.github.com/repos/.../releases/assets/...` API URLs; production (`releaseDraft: false`) emits `releases/download/` browser URLs — expected

**Windows dry-run** (run [#30094318847](https://github.com/platevault/platevault/actions/runs/30094318847), windows-latest, ~20min, green):
- Assets: `PlateVault_0.6.0_x64-setup.exe`, `PlateVault_0.6.0_x64_en-US.msi` + `.sig` files + `latest.json`
- `latest.json` `windows-x86_64` entry points at asset `488416659` — same ID as `windows-x86_64-nsis` entry, confirming `updaterJsonPreferNsis: true` routes the canonical key to the NSIS `.exe`, not the `.msi`
- `windows-x86_64-msi` entry present with separate signature

Remaining: in-app update check from the previous release (manual, post-merge).

## Beads

Tracks-Bead: astro-plan-kyo7.62
Closes-Bead: astro-plan-kyo7.62
Merge-Bead: astro-plan-a4t7