### PR TITLE
chore: include boundary checks in just check recipe

### DIFF
--- a/justfile
+++ b/justfile
@@ -133,8 +133,9 @@ check-generated:
     cargo test -q -p desktop_shell --features dev-tools --test bindings
     git diff --exit-code specs/*/contracts/*.generated.json apps/desktop/src/bindings/
 
-# Full pre-merge gate: lint + tests + typecheck + generated-artifact drift.
-check: lint test typecheck check-generated
+# Full pre-merge gate: lint + tests + typecheck + generated-artifact drift +
+# DB/dead-caller boundary ratchets.
+check: lint test typecheck check-generated db-boundary dead-callers
 
 # Placeholder fixture check hook.
 fixtures-check:


### PR DESCRIPTION
## Summary

Include `db-boundary` and `dead-callers` ratchets in the local `just check` recipe so developers validate boundary compliance and detect unreachable code before pushing.

Both checks are pure grep operations (seconds of runtime) and already exist as justfile recipes and CI gates. Adding them to pre-merge validation ensures local and CI verification stay synchronized.

## Test plan

- [x] `just db-boundary` exits 0 on current branch
- [x] `just dead-callers` exits 0 on current branch
- [x] CI step "DB boundary ratchet" remains gated in ci.yml

Tracks-Bead: astro-plan-o9xr
