### PR TITLE
fix(ci): use single-line filterset strings in Windows shard-coverage check

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1068,45 +1068,16 @@ jobs:
         if: matrix.shard == 1
         shell: bash
         run: |
-          SHARD1='\
-            test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | \
-            test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | \
-            test(=inbox_ui_mixed_folder_splits_into_single_type_items) | \
-            test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | \
-            test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
-          SHARD2='\
-            test(=slow_archive_lifecycle_apply_trash_permanent_delete) | \
-            test(=targets_planner_real_astronomy_after_site_creation) | \
-            test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | \
-            binary(calibration_ui_journeys) | \
-            binary(lifecycle_ui_journeys) | \
-            binary(source_view_journeys) | \
-            test(=ingestion_sessions_search) | \
-            binary(sessions_journeys) | \
-            test(=plan_review_empty_archive_plan_refuses_apply) | \
-            test(=plan_review_apply_with_audit) | \
-            test(=lifecycle_integrity)'
-          SHARD3='\
-            test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | \
-            binary(smoke) | \
-            test(=targets_ui_add_target_no_duplicate_on_reconfirm) | \
-            binary(inventory_journeys) | \
-            test(=cleanup_plan_review) | \
-            test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | \
-            test(=plan_review_destructive_confirm_gate_and_apply) | \
-            test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | \
-            binary(onboarding_journey) | \
-            binary(cleanup_protection_gate_journey) | \
-            test(=first_run_resolve_create_project) | \
-            test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | \
-            test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
+          SHARD1='test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
+          SHARD2='test(=slow_archive_lifecycle_apply_trash_permanent_delete) | test(=targets_planner_real_astronomy_after_site_creation) | test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(source_view_journeys) | test(=ingestion_sessions_search) | binary(sessions_journeys) | test(=plan_review_empty_archive_plan_refuses_apply) | test(=plan_review_apply_with_audit) | test(=lifecycle_integrity)'
+          SHARD3='test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | binary(smoke) | test(=targets_ui_add_target_no_duplicate_on_reconfirm) | binary(inventory_journeys) | test(=cleanup_plan_review) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=plan_review_destructive_confirm_gate_and_apply) | test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(onboarding_journey) | binary(cleanup_protection_gate_journey) | test(=first_run_resolve_create_project) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
           TOTAL=$(cargo nextest list \
             --archive-file e2e-archive.tar.zst --workspace-remap . \
-            --run-ignored all --message-format oneline 2>/dev/null | wc -l)
+            --run-ignored all --message-format oneline | wc -l)
           UNION=$(cargo nextest list \
             --archive-file e2e-archive.tar.zst --workspace-remap . \
             --run-ignored all --message-format oneline \
-            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" 2>/dev/null | wc -l)
+            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" | wc -l)
           echo "Total tests: ${TOTAL}, covered by shard union: ${UNION}"
           if [ "${TOTAL}" != "${UNION}" ]; then
             echo "::error::Shard coverage gap: ${TOTAL} tests in archive but only ${UNION} covered by the three shard filters. Add the missing test(s) to an -E expression."


### PR DESCRIPTION
Tracks-Bead: astro-plan-883h
Merge-Bead: astro-plan-eloy
Closes-Bead: astro-plan-883h

## Problem

The `Verify shard coverage` step on Windows shard 1 has been failing with exit code 94 since #1469 introduced it. The step ran before any tests, so Windows shards 2 and 3 still passed their actual tests.

Root cause: the `SHARD1`/`SHARD2`/`SHARD3` variables were built with backslash-newline continuation inside single quotes. Bash single-quoted strings are literal — `'...\` at end of line means the string contains a literal `\` followed by a newline. The resulting variable values had embedded `\n` and `\` characters that nextest's filterset parser rejected on Windows Git Bash, causing `cargo nextest list -E "${SHARD1} | ..."` to fail. The `2>/dev/null` suppressed the error, and `wc -l` returned 0, so `${TOTAL} != 0` always triggered exit 1.

## Fix

Replace the multi-line string literals with single-line strings, matching the format already used in the `Run E2E` steps. Remove `2>/dev/null` so future parser errors are visible in the CI log.

## Verification

- Strings contain no embedded backslashes or newlines (verified with bash)
- The new format is identical to the working `-E` strings in the actual run steps on lines 1129, 1144, 1159
