### PR TITLE
perf: window Calibration, Projects, and Archive tables to avoid rendering all rows

### DIFF
--- a/apps/desktop/src/features/archive/ArchiveTable.tsx
+++ b/apps/desktop/src/features/archive/ArchiveTable.tsx
@@ -154,7 +154,15 @@ export function ArchiveTable({
 
   return (
     <div className="pv-listtable" data-testid="archive-list">
-      <Table className="pv-densetable" columns={columns} rows={rows} />
+      <Table
+        className="pv-densetable"
+        columns={columns}
+        rows={rows}
+        virtualized
+        estimateRowHeight={36}
+        scrollClassName="pv-listtable__scroll"
+        scrollTestId="archive-virtual-sizer"
+      />
     </div>
   );
 }

--- a/apps/desktop/src/features/calibration/MastersTable.tsx
+++ b/apps/desktop/src/features/calibration/MastersTable.tsx
@@ -561,5 +561,17 @@ export function MastersTable({
     }
   }
 
-  return <Table className="pv-calib-table" columns={columns} rows={rows} />;
+  return (
+    <div className="pv-listtable" data-testid="masters-list">
+      <Table
+        className="pv-calib-table"
+        columns={columns}
+        rows={rows}
+        virtualized
+        estimateRowHeight={36}
+        scrollClassName="pv-listtable__scroll"
+        scrollTestId="masters-virtual-sizer"
+      />
+    </div>
+  );
 }

--- a/apps/desktop/src/features/inbox/InboxFilesColumn.tsx
+++ b/apps/desktop/src/features/inbox/InboxFilesColumn.tsx
@@ -47,6 +47,9 @@ export function InboxFilesColumn({ fileMetadata }: InboxFilesColumnProps) {
     (f) => (f.missingPathAttributes?.length ?? 0) > 0,
   );
 
+  // TODO(astro-plan-kyo7.37): virtualize or lazy-load — a large session folder
+  // renders one row per file; deferred to the memoization bead (popover rows
+  // built lazily on open).
   const metadataRows = (fileMetadata ?? []).map((f, rowIdx) => {
     const missingAttrs = f.missingPathAttributes ?? [];
     const fileName = basename(f.relativeFilePath);

--- a/apps/desktop/src/features/projects/ProjectsTable.tsx
+++ b/apps/desktop/src/features/projects/ProjectsTable.tsx
@@ -340,5 +340,17 @@ export function ProjectsTable({
 
   // The project count moved to the bottom status bar (top-bar convention,
   // task #80) — no in-table footer count line.
-  return <Table className="pv-projects-table" columns={columns} rows={rows} />;
+  return (
+    <div className="pv-listtable" data-testid="projects-list">
+      <Table
+        className="pv-projects-table"
+        columns={columns}
+        rows={rows}
+        virtualized
+        estimateRowHeight={36}
+        scrollClassName="pv-listtable__scroll"
+        scrollTestId="projects-virtual-sizer"
+      />
+    </div>
+  );
 }


### PR DESCRIPTION
## Summary

- Masters, Projects, and Archive list tables now use the same row-windowing the Inbox and Sessions tables already use — only visible rows are rendered, not the full list.

## Beads

Tracks-Bead: astro-plan-kyo7.40
Closes-Bead: astro-plan-kyo7.40
Merge-Bead: astro-plan-ow5y