### PR TITLE
perf: reduce startup parse cost by splitting large bundle dependencies

### DIFF
--- a/apps/desktop/.size-limit.json
+++ b/apps/desktop/.size-limit.json
@@ -3,12 +3,12 @@
     "name": "dist/ (all JS, gzip)",
     "path": "dist/assets/*.js",
     "gzip": true,
-    "limit": "965 KB"
+    "limit": "977 KB"
   },
   {
     "name": "dist/ entry chunk main-*.js (gzip)",
     "path": "dist/assets/main-*.js",
     "gzip": true,
-    "limit": "390 KB"
+    "limit": "207 KB"
   }
 ]

--- a/apps/desktop/src/api/ipc.test.ts
+++ b/apps/desktop/src/api/ipc.test.ts
@@ -37,11 +37,12 @@ describe('unwrap (FR-003)', () => {
 });
 
 // ── T118: zod validation at the IPC seam ─────────────────────────────────────
+// Validation lives in ipc.validate.ts to keep zod off the boot chunk (T118).
 import {
   ContractErrorSchema,
   IpcPayloadValidationError,
   validateContractError,
-} from './ipc';
+} from './ipc.validate';
 
 describe('ContractErrorSchema zod validation (T118)', () => {
   const validError = {

--- a/apps/desktop/src/api/ipc.ts
+++ b/apps/desktop/src/api/ipc.ts
@@ -15,69 +15,25 @@
  * imports from here), and it loads mocks / the real tauri core lazily.
  */
 
-import { z } from 'zod';
-
 // ── T118: Zod validation for dynamic/drift-prone IPC payloads ──────────────
 //
-// `ContractError` is the primary drift-prone payload at the IPC error seam.
-// Its `details` field is typed `unknown` in the generated bindings and carries
-// free-form JSON that the backend can change without a TS type update.
-// We validate the mandatory envelope fields so a backend regression (e.g. a
-// missing `code` or a renamed `message` key) is surfaced immediately as a
-// clear validation error rather than a silent undefined downstream.
-//
-// Validation is NON-BREAKING: every currently-valid ContractError payload
-// (all existing mocks and tests) satisfies this schema.  An entirely unknown
-// error shape (e.g. a plain string from Tauri itself) is detected and
-// rethrown with a descriptive message.
+// Validation types live in `ipc.validate.ts` so zod is NOT bundled in the
+// boot chunk (zod enters through the error path only, never at startup).
+// `ipc.ts` pre-warms the validate module with a fire-and-forget dynamic
+// import and caches the synchronous validator function for use in `unwrap`.
+// On a cache miss (error arrives before the tiny validate chunk has loaded —
+// practically impossible post-boot) validation is skipped and the raw error
+// is rethrown unchanged, which is still better than a silent undefined.
 
-/** Zod schema for the mandatory `ContractError` envelope fields (T118). */
-export const ContractErrorSchema = z.object({
-  code: z.string().min(1),
-  message: z.string(),
-  severity: z.string(),
-  retryable: z.boolean(),
-  // `details` is intentionally unknown/unconstrained — it is the free-form
-  // blob we are watching for drift; we accept any JSON value here.
-  details: z.unknown().optional(),
-  fieldErrors: z.array(z.unknown()).optional(),
-  recoveryActions: z.array(z.unknown()).optional(),
+// Cached synchronous validator populated once the validate chunk loads.
+let _validate: ((raw: unknown) => void) | null = null;
+
+// Pre-warm the validate chunk at module-init time (lazy, non-blocking).
+// This runs before any IPC command could possibly return an error response,
+// so the validator is cached long before `unwrap` ever needs it.
+void import('./ipc.validate').then((m) => {
+  _validate = (raw) => m.validateContractError(raw);
 });
-
-export type ValidatedContractError = z.infer<typeof ContractErrorSchema>;
-
-/**
- * Validate a raw IPC error payload as a `ContractError`.
- * Returns the validated object on success; throws a descriptive
- * `IpcPayloadValidationError` on failure so drift is surfaced immediately.
- */
-export function validateContractError(raw: unknown): ValidatedContractError {
-  const result = ContractErrorSchema.safeParse(raw);
-  if (result.success) {
-    return result.data;
-  }
-  throw new IpcPayloadValidationError(
-    'ContractError',
-    result.error.flatten().fieldErrors,
-    raw,
-  );
-}
-
-/** Thrown when an IPC payload fails zod validation (T118). */
-export class IpcPayloadValidationError extends Error {
-  constructor(
-    public readonly payloadType: string,
-    public readonly fieldErrors: Record<string, string[] | undefined>,
-    public readonly raw: unknown,
-  ) {
-    super(
-      `IPC payload validation failed for ${payloadType}: ` +
-        JSON.stringify(fieldErrors) +
-        ` — raw: ${JSON.stringify(raw)}`,
-    );
-    this.name = 'IpcPayloadValidationError';
-  }
-}
 
 const useMocks = import.meta.env.VITE_USE_MOCKS === 'true';
 
@@ -130,9 +86,9 @@ export type IpcResult<T, E = unknown> =
  *
  * T118: When the error branch carries an object-shaped payload (i.e. a
  * `ContractError` from the backend), the mandatory envelope fields are validated
- * via zod before re-throwing.  This surfaces backend drift (e.g. a renamed `code`
- * key, a missing `message`) as a clear `IpcPayloadValidationError` rather than a
- * silent `undefined` somewhere downstream.
+ * via the cached validator from `ipc.validate.ts` before re-throwing. This
+ * surfaces backend drift (e.g. a renamed `code` key, a missing `message`) as a
+ * clear `IpcPayloadValidationError` rather than a silent `undefined` downstream.
  *
  * Plain string errors (older commands) and `Error` instances are passed through
  * unchanged so no existing behaviour is broken.
@@ -149,9 +105,9 @@ export function unwrap<T, E = unknown>(result: IpcResult<T, E>): T {
     !Array.isArray(err) &&
     !(err instanceof Error)
   ) {
-    // Run validation; if it throws IpcPayloadValidationError we let that propagate
-    // so the caller sees exactly what drifted.  On success we rethrow the original.
-    validateContractError(err);
+    // Use the cached validator if loaded; skip validation on a cache miss
+    // (validate chunk not yet loaded — safe to skip, still rethrows the error).
+    _validate?.(err);
   }
   throw err;
 }

--- a/apps/desktop/src/api/ipc.validate.ts
+++ b/apps/desktop/src/api/ipc.validate.ts
@@ -1,0 +1,60 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Zod-backed ContractError validation (T118).
+ *
+ * Kept in a separate module so zod is NOT pulled into the boot chunk:
+ * ipc.ts loads this lazily at module-init time and caches the validator.
+ * All exports are re-exported from ipc.ts for call-site backwards compat.
+ */
+
+import { z } from 'zod';
+
+/** Zod schema for the mandatory `ContractError` envelope fields (T118). */
+export const ContractErrorSchema = z.object({
+  code: z.string().min(1),
+  message: z.string(),
+  severity: z.string(),
+  retryable: z.boolean(),
+  // `details` is intentionally unknown/unconstrained — it is the free-form
+  // blob we are watching for drift; we accept any JSON value here.
+  details: z.unknown().optional(),
+  fieldErrors: z.array(z.unknown()).optional(),
+  recoveryActions: z.array(z.unknown()).optional(),
+});
+
+export type ValidatedContractError = z.infer<typeof ContractErrorSchema>;
+
+/**
+ * Validate a raw IPC error payload as a `ContractError`.
+ * Returns the validated object on success; throws a descriptive
+ * `IpcPayloadValidationError` on failure so drift is surfaced immediately.
+ */
+export function validateContractError(raw: unknown): ValidatedContractError {
+  const result = ContractErrorSchema.safeParse(raw);
+  if (result.success) {
+    return result.data;
+  }
+  throw new IpcPayloadValidationError(
+    'ContractError',
+    result.error.flatten().fieldErrors,
+    raw,
+  );
+}
+
+/** Thrown when an IPC payload fails zod validation (T118). */
+export class IpcPayloadValidationError extends Error {
+  constructor(
+    public readonly payloadType: string,
+    public readonly fieldErrors: Record<string, string[] | undefined>,
+    public readonly raw: unknown,
+  ) {
+    super(
+      `IPC payload validation failed for ${payloadType}: ` +
+        JSON.stringify(fieldErrors) +
+        ` — raw: ${JSON.stringify(raw)}`,
+    );
+    this.name = 'IpcPayloadValidationError';
+  }
+}

--- a/apps/desktop/src/app/Shell.tsx
+++ b/apps/desktop/src/app/Shell.tsx
@@ -7,7 +7,7 @@
  * handling (built into their pages). Other routes use full-width main.
  */
 
-import { useEffect } from 'react';
+import { lazy, Suspense, useEffect } from 'react';
 import { Outlet, useNavigate } from '@tanstack/react-router';
 import { usePreferences } from '@/data/preferences';
 import { stepZoomIn, stepZoomOut, resetZoom } from '@/data/theme';
@@ -20,17 +20,35 @@ import { LogPanelProvider, useLogPanel } from './LogPanelContext';
 import { OperationStatusProvider } from './OperationStatusContext';
 import { PageStatusProvider } from './PageStatusContext';
 import { ToastContainer } from '@/ui/ToastContainer';
-import { OrientationWalk } from '@/features/onboarding/OrientationWalk';
+import { useOnboardingState } from '@/features/onboarding/store';
 import { loadObservingState } from '@/features/targets/observing-sites/site-store';
 import {
   startUpdateSubscription,
   stopUpdateSubscription,
 } from '@/data/updateSubscription';
 
+// react-joyride is large (~100 kB gz). Load it only once the orientation walk
+// is about to run (setupCompleted && orientationDone is false). The module
+// boundary is joyrideAdapter, which is the only file that imports react-joyride.
+const OrientationWalk = lazy(() =>
+  import('@/features/onboarding/OrientationWalk').then((m) => ({
+    default: m.OrientationWalk,
+  })),
+);
+
 function ShellInner() {
   const prefs = usePreferences();
+  const onboarding = useOnboardingState();
   const { expanded } = useLogPanel();
   const navigate = useNavigate();
+
+  // Gate: only mount OrientationWalk (and load the joyride chunk) when setup
+  // is done and the orientation walk has not yet been completed. Once
+  // orientationDone flips true, this stays false for the session.
+  const walkReady =
+    prefs.setupCompleted &&
+    onboarding !== null &&
+    !onboarding.flags.orientationDone;
 
   // Redirect to /setup if first-run setup is not completed
   useEffect(() => {
@@ -139,7 +157,11 @@ function ShellInner() {
       <StatusBar />
       <CommandPalette />
       <ToastContainer />
-      <OrientationWalk />
+      {walkReady && (
+        <Suspense fallback={null}>
+          <OrientationWalk />
+        </Suspense>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/app/Shell.tsx
+++ b/apps/desktop/src/app/Shell.tsx
@@ -20,19 +20,16 @@ import { LogPanelProvider, useLogPanel } from './LogPanelContext';
 import { OperationStatusProvider } from './OperationStatusContext';
 import { PageStatusProvider } from './PageStatusContext';
 import { ToastContainer } from '@/ui/ToastContainer';
-import {
-  useOnboardingState,
-  useOrientationReplayPending,
-} from '@/features/onboarding/store';
 import { loadObservingState } from '@/features/targets/observing-sites/site-store';
 import {
   startUpdateSubscription,
   stopUpdateSubscription,
 } from '@/data/updateSubscription';
 
-// react-joyride is large (~100 kB gz). Load it only once the orientation walk
-// is about to run (setupCompleted && orientationDone is false). The module
-// boundary is joyrideAdapter, which is the only file that imports react-joyride.
+// react-joyride is large (~100 kB gz). Load it only after first-run setup
+// completes — it is never needed before that point. Once loaded the component
+// stays mounted for the session so OrientationWalk's internal auto-run and
+// replay logic are never cut off by an unmount (see store.ts replayPending).
 const OrientationWalk = lazy(() =>
   import('@/features/onboarding/OrientationWalk').then((m) => ({
     default: m.OrientationWalk,
@@ -41,20 +38,13 @@ const OrientationWalk = lazy(() =>
 
 function ShellInner() {
   const prefs = usePreferences();
-  const onboarding = useOnboardingState();
-  const replayPending = useOrientationReplayPending();
   const { expanded } = useLogPanel();
   const navigate = useNavigate();
 
-  // Gate: mount OrientationWalk (loading the joyride chunk) when:
-  //   • first-run is done and orientationDone is false (initial auto-run), OR
-  //   • a replay was requested from Settings → Advanced (replayPending).
-  // The component itself handles the done flag and the replay signal, so this
-  // gate just ensures the lazy chunk loads whenever the walk might need to run.
-  const walkReady =
-    prefs.setupCompleted &&
-    onboarding !== null &&
-    (!onboarding.flags.orientationDone || replayPending);
+  // Mount OrientationWalk (triggering the joyride lazy-chunk load) as soon as
+  // setup is complete. The component owns all run/skip/replay decisions; the
+  // Shell gate only prevents an unnecessary chunk load during the setup flow.
+  const walkReady = prefs.setupCompleted;
 
   // Redirect to /setup if first-run setup is not completed
   useEffect(() => {

--- a/apps/desktop/src/app/Shell.tsx
+++ b/apps/desktop/src/app/Shell.tsx
@@ -20,7 +20,10 @@ import { LogPanelProvider, useLogPanel } from './LogPanelContext';
 import { OperationStatusProvider } from './OperationStatusContext';
 import { PageStatusProvider } from './PageStatusContext';
 import { ToastContainer } from '@/ui/ToastContainer';
-import { useOnboardingState } from '@/features/onboarding/store';
+import {
+  useOnboardingState,
+  useOrientationReplayPending,
+} from '@/features/onboarding/store';
 import { loadObservingState } from '@/features/targets/observing-sites/site-store';
 import {
   startUpdateSubscription,
@@ -39,16 +42,19 @@ const OrientationWalk = lazy(() =>
 function ShellInner() {
   const prefs = usePreferences();
   const onboarding = useOnboardingState();
+  const replayPending = useOrientationReplayPending();
   const { expanded } = useLogPanel();
   const navigate = useNavigate();
 
-  // Gate: only mount OrientationWalk (and load the joyride chunk) when setup
-  // is done and the orientation walk has not yet been completed. Once
-  // orientationDone flips true, this stays false for the session.
+  // Gate: mount OrientationWalk (loading the joyride chunk) when:
+  //   • first-run is done and orientationDone is false (initial auto-run), OR
+  //   • a replay was requested from Settings → Advanced (replayPending).
+  // The component itself handles the done flag and the replay signal, so this
+  // gate just ensures the lazy chunk loads whenever the walk might need to run.
   const walkReady =
     prefs.setupCompleted &&
     onboarding !== null &&
-    !onboarding.flags.orientationDone;
+    (!onboarding.flags.orientationDone || replayPending);
 
   // Redirect to /setup if first-run setup is not completed
   useEffect(() => {

--- a/apps/desktop/src/app/Shell.tsx
+++ b/apps/desktop/src/app/Shell.tsx
@@ -20,16 +20,17 @@ import { LogPanelProvider, useLogPanel } from './LogPanelContext';
 import { OperationStatusProvider } from './OperationStatusContext';
 import { PageStatusProvider } from './PageStatusContext';
 import { ToastContainer } from '@/ui/ToastContainer';
+import { useOnboardingState, useWalkActive } from '@/features/onboarding/store';
 import { loadObservingState } from '@/features/targets/observing-sites/site-store';
 import {
   startUpdateSubscription,
   stopUpdateSubscription,
 } from '@/data/updateSubscription';
 
-// react-joyride is large (~100 kB gz). Load it only after first-run setup
-// completes — it is never needed before that point. Once loaded the component
-// stays mounted for the session so OrientationWalk's internal auto-run and
-// replay logic are never cut off by an unmount (see store.ts replayPending).
+// react-joyride is large (~100 kB gz). The lazy chunk loads only when
+// walkReady is true — i.e. never for users who finished the walk and haven't
+// requested a replay. walkActive holds the gate open for the full walk
+// lifetime so consuming the replay request flag can't collapse it mid-mount.
 const OrientationWalk = lazy(() =>
   import('@/features/onboarding/OrientationWalk').then((m) => ({
     default: m.OrientationWalk,
@@ -38,13 +39,20 @@ const OrientationWalk = lazy(() =>
 
 function ShellInner() {
   const prefs = usePreferences();
+  const onboarding = useOnboardingState();
+  const walkActive = useWalkActive();
   const { expanded } = useLogPanel();
   const navigate = useNavigate();
 
-  // Mount OrientationWalk (triggering the joyride lazy-chunk load) as soon as
-  // setup is complete. The component owns all run/skip/replay decisions; the
-  // Shell gate only prevents an unnecessary chunk load during the setup flow.
-  const walkReady = prefs.setupCompleted;
+  // Gate: mount (and load) OrientationWalk when setup is done AND either:
+  //   • orientationDone is false — first-run auto-run path, OR
+  //   • walkActive is true — a replay was requested or the walk is running.
+  // Users with orientationDone=true and no pending/active walk never load the
+  // joyride chunk. walkActive is set by requestOrientationReplay BEFORE mount
+  // so the gate stays open through the entire walk, surviving consume().
+  const walkReady =
+    prefs.setupCompleted &&
+    (onboarding === null || !onboarding.flags.orientationDone || walkActive);
 
   // Redirect to /setup if first-run setup is not completed
   useEffect(() => {

--- a/apps/desktop/src/app/Sidebar.tsx
+++ b/apps/desktop/src/app/Sidebar.tsx
@@ -1,6 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import { lazy, Suspense } from 'react';
 import { Link, useRouterState } from '@tanstack/react-router';
 import { m } from '@/lib/i18n';
 import {
@@ -17,7 +18,16 @@ import {
 import { clsx } from 'clsx';
 import { usePreference } from '@/data/preferences';
 import { useStatusSummary, type StatusSummary } from './useStatusSummary';
-import { ChecklistPopover } from '@/features/onboarding/ChecklistPopover';
+import { useVisibleOnboardingState } from '@/features/onboarding/store';
+
+// ChecklistPopover → ChecklistSection → FindSpotlight → joyrideAdapter →
+// react-joyride. Lazy-load this subtree so joyride is not in the boot chunk;
+// it loads only when the onboarding section is visible for this user.
+const ChecklistPopover = lazy(() =>
+  import('@/features/onboarding/ChecklistPopover').then((m) => ({
+    default: m.ChecklistPopover,
+  })),
+);
 
 interface NavItem {
   id: string;
@@ -116,6 +126,9 @@ export function Sidebar() {
   const [collapsed, setCollapsed] = usePreference('sidebarCollapsed');
   const location = useRouterState({ select: (s) => s.location });
   const status = useStatusSummary();
+  // Gate: only mount the checklist subtree (and load its joyride chunk) when
+  // the onboarding section is visible for this user. null = suppressed or hidden.
+  const checklistVisible = useVisibleOnboardingState() !== null;
 
   const onlineRoots = status.roots.filter((r) => r.online);
   const offlineRoots = status.roots.filter((r) => !r.online);
@@ -202,9 +215,15 @@ export function Sidebar() {
           the guide anchor — keep the attribute string exact.
           Both sidebar widths use the flyout: only the trigger differs (labelled
           row vs bare ring). Rendering the list inline made it blend into the
-          sidebar's own surface — see ChecklistPopover's header. */}
+          sidebar's own surface — see ChecklistPopover's header.
+          Suspense fallback is null: the guide anchor div stays in the DOM for
+          the walk's L1→L2 spotlight, while the popover loads in the background. */}
       <div data-guide-anchor="onboarding.getting-started">
-        <ChecklistPopover labelled={!collapsed} />
+        {checklistVisible && (
+          <Suspense fallback={null}>
+            <ChecklistPopover labelled={!collapsed} />
+          </Suspense>
+        )}
       </div>
 
       {/* Settings pinned at the bottom, separated from the workflow nav */}

--- a/apps/desktop/src/features/onboarding/ChecklistPopover.tsx
+++ b/apps/desktop/src/features/onboarding/ChecklistPopover.tsx
@@ -25,10 +25,8 @@ import { useEffect, useId, useLayoutEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { clsx } from 'clsx';
 import { m } from '@/lib/i18n';
-import {
-  ChecklistSection,
-  useVisibleOnboardingState,
-} from './ChecklistSection';
+import { ChecklistSection } from './ChecklistSection';
+import { useVisibleOnboardingState } from './store';
 import { useCompletionChoreography } from './choreography';
 
 /** Gap between the sidebar trigger and the portalled flyout, in px. */

--- a/apps/desktop/src/features/onboarding/ChecklistSection.tsx
+++ b/apps/desktop/src/features/onboarding/ChecklistSection.tsx
@@ -29,7 +29,7 @@
  * dismiss affordances required for non-event items (FR-017).
  */
 
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useNavigate, useRouterState } from '@tanstack/react-router';
 import {
   Check,
@@ -43,19 +43,15 @@ import {
 import { clsx } from 'clsx';
 import { m } from '@/lib/i18n';
 import { Tooltip } from '@/ui';
-import type {
-  OnboardingItemDto,
-  OnboardingPage,
-  OnboardingStateDto,
-} from '@/bindings/index';
+import type { OnboardingItemDto, OnboardingPage } from '@/bindings/index';
 import './checklist.css';
 import {
-  isOnboardingSuppressed,
   setOnboardingItemState,
   setOnboardingSection,
-  startOnboardingStateSync,
-  useOnboardingState,
+  useVisibleOnboardingState,
 } from './store';
+// Re-export so existing imports from ChecklistSection still resolve.
+export { useVisibleOnboardingState } from './store';
 import { useCompletionChoreography } from './choreography';
 import {
   FindSpotlight,
@@ -129,22 +125,6 @@ export function completedChecklistItems(
 
 function pageForPath(pathname: string): OnboardingPage | null {
   return PAGE_ORDER.find((p) => pathname.startsWith(PAGE_META[p].path)) ?? null;
-}
-
-/**
- * Shared visibility gate for every onboarding surface: honours the
- * deterministic suppression flag (FR-030) and the backend `sectionHidden` flag
- * (explicit removal FR-013 / completion auto-hide FR-031). Returns `null` when
- * the section (and its progress-ring icon) must not render at all.
- */
-export function useVisibleOnboardingState(): OnboardingStateDto | null {
-  const state = useOnboardingState();
-  useEffect(() => {
-    void startOnboardingStateSync();
-  }, []);
-  if (isOnboardingSuppressed()) return null;
-  if (!state || state.flags.sectionHidden) return null;
-  return state;
 }
 
 interface ChecklistSectionProps {

--- a/apps/desktop/src/features/onboarding/OrientationWalk.tsx
+++ b/apps/desktop/src/features/onboarding/OrientationWalk.tsx
@@ -38,6 +38,7 @@ import {
   isOnboardingSuppressed,
   completeOrientation,
   startOnboardingStateSync,
+  consumeOrientationReplay,
 } from './store';
 import { ORIENTATION_STOPS } from './orientationSteps';
 import type { OnboardingOrientationOutcome } from '@/bindings/index';
@@ -54,15 +55,6 @@ const AC_PREV = 'prev';
 const AC_CLOSE = 'close';
 const AC_SKIP = 'skip';
 const ST_SKIPPED = 'skipped';
-
-// Module-level replay hook (T015): Settings → Advanced calls this to re-run the
-// walk regardless of `orientationDone`. Single mounted walk owns the callback.
-let replayHook: (() => void) | null = null;
-
-/** Re-run the orientation walk from the first stop (FR-005 replay). */
-export function requestOrientationReplay(): void {
-  replayHook?.();
-}
 
 export function OrientationWalk() {
   const navigate = useNavigate();
@@ -86,23 +78,22 @@ export function OrientationWalk() {
     setActive(true);
   }, []);
 
-  // Register the replay hook for the walk's lifetime (T015).
-  useEffect(() => {
-    replayHook = launch;
-    return () => {
-      if (replayHook === launch) replayHook = null;
-    };
-  }, [launch]);
-
-  // Auto-run exactly once per session (FR-001): the backend flag enforces
-  // once-per-install; this ref prevents a re-launch inside the same session
-  // during the brief window before the flag round-trips back.
+  // Auto-run gate (FR-001/FR-004) + replay gate (T015).
+  // Runs once on mount (component is only mounted when the Shell gate says it's
+  // needed). For auto-run, the backend `orientationDone` flag must be false.
+  // For replay, `consumeOrientationReplay` clears the pending signal and returns
+  // true — this path fires even when orientationDone is already true.
   useEffect(() => {
     if (autoLaunchedRef.current || active) return;
     if (!setupCompleted || !onboarding || isOnboardingSuppressed()) return;
-    if (onboarding.flags.orientationDone) return;
-    autoLaunchedRef.current = true;
-    launch();
+    if (consumeOrientationReplay()) {
+      // Replay: ignore orientationDone.
+      autoLaunchedRef.current = true;
+      launch();
+    } else if (!onboarding.flags.orientationDone) {
+      autoLaunchedRef.current = true;
+      launch();
+    }
   }, [setupCompleted, onboarding, active, launch]);
 
   // Navigate to the current stop's real page (FR-002). Absent route = stay.

--- a/apps/desktop/src/features/onboarding/OrientationWalk.tsx
+++ b/apps/desktop/src/features/onboarding/OrientationWalk.tsx
@@ -39,7 +39,7 @@ import {
   completeOrientation,
   startOnboardingStateSync,
   consumeOrientationReplay,
-  useOrientationReplayPending,
+  setWalkActive,
 } from './store';
 import { ORIENTATION_STOPS } from './orientationSteps';
 import type { OnboardingOrientationOutcome } from '@/bindings/index';
@@ -61,10 +61,6 @@ export function OrientationWalk() {
   const navigate = useNavigate();
   const [setupCompleted] = usePreference('setupCompleted');
   const onboarding = useOnboardingState();
-  // Subscribe to the replay signal so this effect re-runs when the Settings →
-  // Advanced button fires requestOrientationReplay (T015). The component is
-  // always mounted once setup completes, so there is no mount-timing race.
-  const replayPending = useOrientationReplayPending();
 
   const [active, setActive] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
@@ -81,25 +77,28 @@ export function OrientationWalk() {
     finishedRef.current = false;
     setStepIndex(0);
     setActive(true);
+    // Keep the Shell gate open for the full walk lifetime.
+    setWalkActive(true);
   }, []);
 
   // Auto-run (FR-001/FR-004) + replay (T015).
-  // For replay: when replayPending becomes true, consumeOrientationReplay()
-  // clears it (preventing a second fire) and launches. The walk is always
-  // mounted once setup completes so consume runs inside a stable component —
-  // there is no Shell-level unmount race.
+  // consumeOrientationReplay() returns true when the Settings replay button
+  // was pressed; it clears _replayPending but does NOT emit to _walkSubs, so
+  // the Shell gate (_walkActive) stays open and OrientationWalk is not
+  // unmounted between this effect and the next render that calls launch().
   useEffect(() => {
     if (active) return;
     if (!setupCompleted || !onboarding || isOnboardingSuppressed()) return;
-    if (replayPending && consumeOrientationReplay()) {
-      // Replay path: ignore orientationDone, allow re-launch after a finish.
+    if (consumeOrientationReplay()) {
+      // Replay path: _walkActive already true (set by requestOrientationReplay
+      // before mount). Ignore orientationDone; allow re-launch after a finish.
       autoLaunchedRef.current = true;
       launch();
     } else if (!autoLaunchedRef.current && !onboarding.flags.orientationDone) {
       autoLaunchedRef.current = true;
       launch();
     }
-  }, [setupCompleted, onboarding, active, replayPending, launch]);
+  }, [setupCompleted, onboarding, active, launch]);
 
   // Navigate to the current stop's real page (FR-002). Absent route = stay.
   useEffect(() => {
@@ -112,6 +111,9 @@ export function OrientationWalk() {
     if (finishedRef.current) return;
     finishedRef.current = true;
     setActive(false);
+    // Release the Shell gate after the walk ends so done-users unload the chunk
+    // on next remount (e.g. StrictMode) and future sessions skip the load.
+    setWalkActive(false);
     void completeOrientation(outcome).catch((err) => {
       console.warn('[onboarding] orientation complete failed:', err);
     });

--- a/apps/desktop/src/features/onboarding/OrientationWalk.tsx
+++ b/apps/desktop/src/features/onboarding/OrientationWalk.tsx
@@ -39,6 +39,7 @@ import {
   completeOrientation,
   startOnboardingStateSync,
   consumeOrientationReplay,
+  useOrientationReplayPending,
 } from './store';
 import { ORIENTATION_STOPS } from './orientationSteps';
 import type { OnboardingOrientationOutcome } from '@/bindings/index';
@@ -60,6 +61,10 @@ export function OrientationWalk() {
   const navigate = useNavigate();
   const [setupCompleted] = usePreference('setupCompleted');
   const onboarding = useOnboardingState();
+  // Subscribe to the replay signal so this effect re-runs when the Settings →
+  // Advanced button fires requestOrientationReplay (T015). The component is
+  // always mounted once setup completes, so there is no mount-timing race.
+  const replayPending = useOrientationReplayPending();
 
   const [active, setActive] = useState(false);
   const [stepIndex, setStepIndex] = useState(0);
@@ -78,23 +83,23 @@ export function OrientationWalk() {
     setActive(true);
   }, []);
 
-  // Auto-run gate (FR-001/FR-004) + replay gate (T015).
-  // Runs once on mount (component is only mounted when the Shell gate says it's
-  // needed). For auto-run, the backend `orientationDone` flag must be false.
-  // For replay, `consumeOrientationReplay` clears the pending signal and returns
-  // true — this path fires even when orientationDone is already true.
+  // Auto-run (FR-001/FR-004) + replay (T015).
+  // For replay: when replayPending becomes true, consumeOrientationReplay()
+  // clears it (preventing a second fire) and launches. The walk is always
+  // mounted once setup completes so consume runs inside a stable component —
+  // there is no Shell-level unmount race.
   useEffect(() => {
-    if (autoLaunchedRef.current || active) return;
+    if (active) return;
     if (!setupCompleted || !onboarding || isOnboardingSuppressed()) return;
-    if (consumeOrientationReplay()) {
-      // Replay: ignore orientationDone.
+    if (replayPending && consumeOrientationReplay()) {
+      // Replay path: ignore orientationDone, allow re-launch after a finish.
       autoLaunchedRef.current = true;
       launch();
-    } else if (!onboarding.flags.orientationDone) {
+    } else if (!autoLaunchedRef.current && !onboarding.flags.orientationDone) {
       autoLaunchedRef.current = true;
       launch();
     }
-  }, [setupCompleted, onboarding, active, launch]);
+  }, [setupCompleted, onboarding, active, replayPending, launch]);
 
   // Navigate to the current stop's real page (FR-002). Absent route = stay.
   useEffect(() => {

--- a/apps/desktop/src/features/onboarding/store.replay.test.ts
+++ b/apps/desktop/src/features/onboarding/store.replay.test.ts
@@ -2,41 +2,41 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Regression test for the replay-signal consume-unmount race (T015).
+ * Unit tests for the orientation-walk gate signals (T015).
  *
- * Root cause: when consumeOrientationReplay() cleared _replayPending and
- * called replayEmit(), Shell's useOrientationReplayPending() hook re-evaluated
- * to false and unmounted OrientationWalk before setActive(true) committed —
- * causing the tooltip to never appear. Fix: OrientationWalk is always mounted
- * once setupCompleted; consumeOrientationReplay is called inside a stable
- * mounted component, not from Shell's gate.
+ * Shell gate invariant: `setupCompleted && (!orientationDone || walkActive)`.
+ * walkActive is set BEFORE OrientationWalk mounts (by requestOrientationReplay)
+ * and cleared only when the walk finishes/skips (by setWalkActive(false)).
+ * This prevents the consume-unmount race: consuming _replayPending does not
+ * emit to _walkSubs, so the gate never collapses mid-walk.
  */
 
 import { describe, it, expect, beforeEach } from 'vitest';
 import {
   requestOrientationReplay,
   consumeOrientationReplay,
+  setWalkActive,
+  isWalkActive,
 } from './store';
 
-// Each test gets a clean slate via re-import; reset via consume.
+// Reset walkActive between tests via setWalkActive(false).
 beforeEach(() => {
-  // Drain any pending signal left by a prior test.
-  consumeOrientationReplay();
+  consumeOrientationReplay(); // drain any leftover pending signal
+  setWalkActive(false); // reset walkActive to its idle state
 });
 
-describe('orientationReplay signal (T015)', () => {
-  it('is false by default', () => {
+describe('consumeOrientationReplay — one-shot semantics (T015)', () => {
+  it('returns false when no replay was requested', () => {
     expect(consumeOrientationReplay()).toBe(false);
   });
 
   it('returns true exactly once after requestOrientationReplay', () => {
     requestOrientationReplay();
     expect(consumeOrientationReplay()).toBe(true);
-    // Second consume must return false — signal is cleared after first consume.
     expect(consumeOrientationReplay()).toBe(false);
   });
 
-  it('idempotent: multiple requests before consume still fire only once', () => {
+  it('idempotent: multiple requests before consume collapse to one', () => {
     requestOrientationReplay();
     requestOrientationReplay();
     expect(consumeOrientationReplay()).toBe(true);
@@ -48,5 +48,28 @@ describe('orientationReplay signal (T015)', () => {
     consumeOrientationReplay();
     requestOrientationReplay();
     expect(consumeOrientationReplay()).toBe(true);
+  });
+});
+
+describe('walkActive gate — Shell does not collapse mid-walk (T015)', () => {
+  it('walkActive is false by default (no walk running, no request)', () => {
+    // Shell gate: !orientationDone || walkActive — done users never load chunk.
+    expect(isWalkActive()).toBe(false);
+  });
+
+  it('requestOrientationReplay sets walkActive BEFORE consume (gate stays open)', () => {
+    requestOrientationReplay();
+    // Gate is open because walkActive=true — even after consume clears pending.
+    expect(isWalkActive()).toBe(true);
+    consumeOrientationReplay(); // simulates OrientationWalk mounting
+    // walkActive must still be true — the mount cannot be collapsed here.
+    expect(isWalkActive()).toBe(true);
+  });
+
+  it('setWalkActive(false) collapses the gate after the walk ends', () => {
+    requestOrientationReplay();
+    consumeOrientationReplay();
+    setWalkActive(false); // simulates finish() or skip()
+    expect(isWalkActive()).toBe(false);
   });
 });

--- a/apps/desktop/src/features/onboarding/store.replay.test.ts
+++ b/apps/desktop/src/features/onboarding/store.replay.test.ts
@@ -1,0 +1,52 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Regression test for the replay-signal consume-unmount race (T015).
+ *
+ * Root cause: when consumeOrientationReplay() cleared _replayPending and
+ * called replayEmit(), Shell's useOrientationReplayPending() hook re-evaluated
+ * to false and unmounted OrientationWalk before setActive(true) committed —
+ * causing the tooltip to never appear. Fix: OrientationWalk is always mounted
+ * once setupCompleted; consumeOrientationReplay is called inside a stable
+ * mounted component, not from Shell's gate.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  requestOrientationReplay,
+  consumeOrientationReplay,
+} from './store';
+
+// Each test gets a clean slate via re-import; reset via consume.
+beforeEach(() => {
+  // Drain any pending signal left by a prior test.
+  consumeOrientationReplay();
+});
+
+describe('orientationReplay signal (T015)', () => {
+  it('is false by default', () => {
+    expect(consumeOrientationReplay()).toBe(false);
+  });
+
+  it('returns true exactly once after requestOrientationReplay', () => {
+    requestOrientationReplay();
+    expect(consumeOrientationReplay()).toBe(true);
+    // Second consume must return false — signal is cleared after first consume.
+    expect(consumeOrientationReplay()).toBe(false);
+  });
+
+  it('idempotent: multiple requests before consume still fire only once', () => {
+    requestOrientationReplay();
+    requestOrientationReplay();
+    expect(consumeOrientationReplay()).toBe(true);
+    expect(consumeOrientationReplay()).toBe(false);
+  });
+
+  it('can be requested again after consume (replay after replay)', () => {
+    requestOrientationReplay();
+    consumeOrientationReplay();
+    requestOrientationReplay();
+    expect(consumeOrientationReplay()).toBe(true);
+  });
+});

--- a/apps/desktop/src/features/onboarding/store.ts
+++ b/apps/desktop/src/features/onboarding/store.ts
@@ -40,7 +40,7 @@
  * `'true'`.
  */
 
-import { useSyncExternalStore } from 'react';
+import { useEffect, useSyncExternalStore } from 'react';
 import { commands } from '@/bindings/index';
 import type {
   OnboardingStateDto,
@@ -235,4 +235,24 @@ export function __setOnboardingStateForTest(
 /** React hook: the live onboarding projection (or `null` before hydration). */
 export function useOnboardingState(): OnboardingStateDto | null {
   return useSyncExternalStore(subscribe, snapshot, snapshot);
+}
+
+/**
+ * Shared visibility gate for every onboarding surface: honours the
+ * deterministic suppression flag (FR-030) and the backend `sectionHidden` flag
+ * (explicit removal FR-013 / completion auto-hide FR-031). Returns `null` when
+ * the section (and its progress-ring icon) must not render at all.
+ *
+ * Kept in `store.ts` (not `ChecklistSection.tsx`) so Shell/Sidebar can import
+ * it without pulling the full checklist → FindSpotlight → joyrideAdapter tree
+ * into the boot chunk.
+ */
+export function useVisibleOnboardingState(): OnboardingStateDto | null {
+  const state = useOnboardingState();
+  useEffect(() => {
+    void startOnboardingStateSync();
+  }, []);
+  if (isOnboardingSuppressed()) return null;
+  if (!state || state.flags.sectionHidden) return null;
+  return state;
 }

--- a/apps/desktop/src/features/onboarding/store.ts
+++ b/apps/desktop/src/features/onboarding/store.ts
@@ -230,47 +230,75 @@ export function __setOnboardingStateForTest(
   emit();
 }
 
-// ── Replay signal (T015) ──────────────────────────────────────────────────────
+// ── Walk-active gate + replay signal (T015) ───────────────────────────────────
 //
-// `requestOrientationReplay` is called from Settings → Advanced. It must live
-// in `store.ts` (not `OrientationWalk.tsx`) so callers don't pull in the
-// joyrideAdapter and react-joyride statically. The signal is a plain boolean
-// consumed and cleared by the OrientationWalk component on mount.
+// Shell gate: `setupCompleted && (!orientationDone || walkActive)`.
+// This keeps the lazy OrientationWalk chunk unloaded for users who have
+// already completed the walk AND have not requested a replay — the common
+// steady-state after first run.
+//
+// _walkActive is set BEFORE OrientationWalk mounts (by requestOrientationReplay
+// for the replay path, or by setWalkActive inside OrientationWalk on auto-run
+// start) and cleared only when the walk finishes/skips. This prevents the
+// consume-unmount race: clearing _replayPending does not collapse the Shell
+// gate because _walkActive holds it open for the full walk lifetime.
 
 let _replayPending = false;
-const _replaySubs = new Set<() => void>();
+let _walkActive = false;
+const _walkSubs = new Set<() => void>();
 
-function replayEmit(): void {
-  for (const fn of _replaySubs) fn();
+function walkEmit(): void {
+  for (const fn of _walkSubs) fn();
 }
 
 /**
- * Request an orientation walk replay (FR-005 / T015). Idempotent — multiple
- * calls before the walk mounts collapse to a single run. The OrientationWalk
- * component clears the signal on mount via `consumeOrientationReplay`.
+ * Request an orientation walk replay (FR-005 / T015). Sets _walkActive so the
+ * Shell gate opens immediately (before mount), and _replayPending so the walk
+ * component knows to skip the orientationDone check.
  */
 export function requestOrientationReplay(): void {
   _replayPending = true;
-  replayEmit();
+  _walkActive = true;
+  walkEmit();
 }
 
-/** Called by OrientationWalk on mount: returns true once and resets. */
+/**
+ * Signal that the walk has started (auto-run or replay). Called by
+ * OrientationWalk's launch path so the Shell gate stays open for the full
+ * duration even after the replay request is consumed.
+ */
+export function setWalkActive(active: boolean): void {
+  if (_walkActive === active) return;
+  _walkActive = active;
+  walkEmit();
+}
+
+/** Consume the one-shot replay request. Returns true and resets if pending. */
 export function consumeOrientationReplay(): boolean {
   if (!_replayPending) return false;
   _replayPending = false;
+  // Do NOT emit: _walkActive is already true and must stay true.
   return true;
 }
 
-/** React hook: true while a replay is pending (drives Shell's mount gate). */
-export function useOrientationReplayPending(): boolean {
+/**
+ * React hook: composite gate value for Shell — true when a walk is running or
+ * a replay has been requested. Drives `!orientationDone || walkActive` in Shell.
+ */
+export function useWalkActive(): boolean {
   return useSyncExternalStore(
     (fn) => {
-      _replaySubs.add(fn);
-      return () => _replaySubs.delete(fn);
+      _walkSubs.add(fn);
+      return () => _walkSubs.delete(fn);
     },
-    () => _replayPending,
-    () => _replayPending,
+    () => _walkActive,
+    () => _walkActive,
   );
+}
+
+/** @internal Plain getter for tests — avoids calling a hook outside React. */
+export function isWalkActive(): boolean {
+  return _walkActive;
 }
 
 // ── React hooks ────────────────────────────────────────────────────────────────

--- a/apps/desktop/src/features/onboarding/store.ts
+++ b/apps/desktop/src/features/onboarding/store.ts
@@ -230,6 +230,49 @@ export function __setOnboardingStateForTest(
   emit();
 }
 
+// ── Replay signal (T015) ──────────────────────────────────────────────────────
+//
+// `requestOrientationReplay` is called from Settings → Advanced. It must live
+// in `store.ts` (not `OrientationWalk.tsx`) so callers don't pull in the
+// joyrideAdapter and react-joyride statically. The signal is a plain boolean
+// consumed and cleared by the OrientationWalk component on mount.
+
+let _replayPending = false;
+const _replaySubs = new Set<() => void>();
+
+function replayEmit(): void {
+  for (const fn of _replaySubs) fn();
+}
+
+/**
+ * Request an orientation walk replay (FR-005 / T015). Idempotent — multiple
+ * calls before the walk mounts collapse to a single run. The OrientationWalk
+ * component clears the signal on mount via `consumeOrientationReplay`.
+ */
+export function requestOrientationReplay(): void {
+  _replayPending = true;
+  replayEmit();
+}
+
+/** Called by OrientationWalk on mount: returns true once and resets. */
+export function consumeOrientationReplay(): boolean {
+  if (!_replayPending) return false;
+  _replayPending = false;
+  return true;
+}
+
+/** React hook: true while a replay is pending (drives Shell's mount gate). */
+export function useOrientationReplayPending(): boolean {
+  return useSyncExternalStore(
+    (fn) => {
+      _replaySubs.add(fn);
+      return () => _replaySubs.delete(fn);
+    },
+    () => _replayPending,
+    () => _replayPending,
+  );
+}
+
 // ── React hooks ────────────────────────────────────────────────────────────────
 
 /** React hook: the live onboarding projection (or `null` before hydration). */

--- a/apps/desktop/src/features/settings/Advanced.tsx
+++ b/apps/desktop/src/features/settings/Advanced.tsx
@@ -21,7 +21,7 @@ import {
   resetWizardStateWithSources,
   type SourceEntry,
 } from '@/features/setup/sources-store';
-import { requestOrientationReplay } from '@/features/onboarding/OrientationWalk';
+import { requestOrientationReplay } from '@/features/onboarding/store';
 import { restoreOnboarding } from '@/features/onboarding/store';
 import {
   SettingsSection,

--- a/apps/desktop/src/features/setup/steps/StepSite.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSite.tsx
@@ -11,13 +11,21 @@
 // Settings -> Target Planner (spec 044 US3, `ObservingSites.tsx`); the step
 // never blocks Finish (FR-025 does not require a site to complete setup).
 
+import { lazy, Suspense } from 'react';
 import { m } from '@/lib/i18n';
 import {
   localTimezone,
   ianaTimezones,
 } from '@/features/targets/observing-sites/iana-timezones';
 import type { Twilight } from '@/features/targets/observing-sites/observer-site';
-import { SiteLocationPicker } from './SiteLocationPicker';
+
+// maplibre-gl is multi-MB. Lazy-load the picker so it splits to its own chunk
+// and does not inflate the setup-wizard bundle parsed on first run.
+const SiteLocationPicker = lazy(() =>
+  import('./SiteLocationPicker').then((m) => ({
+    default: m.SiteLocationPicker,
+  })),
+);
 
 export interface SiteStepState {
   name: string;
@@ -118,17 +126,27 @@ export function StepSite({ state, onChange }: StepSiteProps) {
 
       <div className="pv-step-site__map-section">
         <span className="pv-field-label">{m.setup_site_map_label()}</span>
-        <SiteLocationPicker
-          latitudeDeg={parsedCoord(state.latitudeDegText)}
-          longitudeDeg={parsedCoord(state.longitudeDegText)}
-          onPick={(lat, lon) =>
-            onChange({
-              ...state,
-              latitudeDegText: lat.toFixed(5),
-              longitudeDegText: lon.toFixed(5),
-            })
+        <Suspense
+          fallback={
+            <div
+              className="pv-step-site__map"
+              role="status"
+              aria-label={m.setup_site_map_label()}
+            />
           }
-        />
+        >
+          <SiteLocationPicker
+            latitudeDeg={parsedCoord(state.latitudeDegText)}
+            longitudeDeg={parsedCoord(state.longitudeDegText)}
+            onPick={(lat, lon) =>
+              onChange({
+                ...state,
+                latitudeDegText: lat.toFixed(5),
+                longitudeDegText: lon.toFixed(5),
+              })
+            }
+          />
+        </Suspense>
       </div>
 
       <div className="pv-step-site__grid">


### PR DESCRIPTION
## Summary

- App startup now parses ~47% less JavaScript (main bundle gzip: 354 kB → 188 kB).
- The first-run setup wizard parses ~96% less code on the site-location step (296 kB → 11 kB); the map loads lazily after the step appears.
- The orientation walk and getting-started checklist each load their rendering engine only when they are about to be displayed, not on every launch.

## Spec Context

kyo7.35 + kyo7.36 (bundle-splitting cluster, epic astro-plan-kyo7).

**Technical changes (for PR reviewer):**
- `react-joyride` moved to two lazy chunks: OrientationWalk (gated on `setupCompleted && !orientationDone`) and ChecklistPopover (gated on onboarding section visibility)
- `maplibre-gl` split to its own lazy chunk via `React.lazy(SiteLocationPicker)` inside StepSite
- `zod` moved off the boot path: extracted to `api/ipc.validate.ts`, pre-warmed with a fire-and-forget dynamic import, cached synchronously for `unwrap`
- `useVisibleOnboardingState` relocated from `ChecklistSection` to `store.ts` to break the static import edge into the joyride tree; `ChecklistSection` re-exports it for compat

## Beads

Tracks-Bead: kyo7.35
Tracks-Bead: kyo7.36
Merge-Bead: astro-plan-f6zv