### PR TITLE
feat: panel state, list grouping, and picker directory survive app restarts

### DIFF
--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -31,6 +31,8 @@
 //!   `framingRotationToleranceDeg`, `framingMosaicEnvelopeFractionOfFov`
 //!   (spec 008 Q27 F-Framing-11, R11a clustering tolerance tunables)
 //! - `"catalogues"` → `enabled` (#645, default-enabled Planner catalogues)
+//! - `"ui_state"` → all stored rows with the `uiState.` key prefix; no in-code
+//!   defaults (2026-07-24 persisted-ui-state migration).
 //! - `""` (empty) → reads the full settings bag (every descriptor key, derived
 //!   from the descriptor table so it cannot drift, plus `enabled`).
 //!
@@ -104,6 +106,15 @@ fn scope_keys(scope: &str) -> &'static [&'static str] {
             "framingRotationToleranceDeg",
             "framingMosaicEnvelopeFractionOfFov",
         ],
+        // UI-state scope — keys with the `uiState.` prefix are open-ended;
+        // `settings.get("ui_state")` returns the empty set because the caller
+        // must call `settings.get` with the exact key names it registered.
+        // The scope exists only so `settings.update` routes here without
+        // tracing noise about an "unknown scope" (the catch-all `_ => ALL_KEYS`
+        // would still accept the writes, but returning all stable keys on a
+        // `settings.get("ui_state")` call would be surprising). Individual key
+        // reads happen via the `""` (catch-all) scope or via direct `hydrateScope`.
+        "ui_state" => &[],
         // Empty scope or "global" returns every stable key.
         _ => &ALL_KEYS,
     }
@@ -131,6 +142,10 @@ static ALL_KEYS: LazyLock<Vec<&'static str>> = LazyLock::new(|| {
 /// Each key that belongs to the scope is resolved via the persistence layer
 /// (hydrating the in-code default when no stored row exists).
 ///
+/// The `"ui_state"` scope is special: it returns all rows whose key starts with
+/// `"uiState."` directly from the DB (no in-code default — unknown keys simply
+/// return `null` on a get; the frontend falls back to its own default).
+///
 /// # Errors
 /// Returns `Err(String)` on database failure.
 #[tauri::command]
@@ -141,8 +156,21 @@ pub async fn settings_get(
 ) -> Result<SettingsData, ContractError> {
     tracing::debug!("settings.get scope={scope}");
     let pool = state.repo.pool();
-    let keys = scope_keys(&scope);
 
+    // UI-state scope: return all stored `uiState.*` rows (no in-code defaults).
+    if scope == "ui_state" {
+        let rows =
+            persistence_lifecycle::repositories::settings::get_all_by_prefix(pool, "uiState.")
+                .await
+                .map_err(app_core::errors::db_to_contract)?;
+        let values: HashMap<String, Value> = rows.into_iter().collect();
+        return Ok(SettingsData {
+            scope,
+            values: contracts_core::JsonAny::from(serde_json::to_value(values).unwrap_or_default()),
+        });
+    }
+
+    let keys = scope_keys(&scope);
     let mut values: HashMap<String, Value> = HashMap::with_capacity(keys.len());
     for key in keys {
         let val = app_core::settings::resolve_setting(pool, key, None).await?;

--- a/apps/desktop/src/app/LogPanel.followScroll.test.tsx
+++ b/apps/desktop/src/app/LogPanel.followScroll.test.tsx
@@ -20,9 +20,13 @@ import {
   act,
 } from '@testing-library/react';
 import { appendLog, resetLogStore } from '@/data/logStore';
-import { LogPanelProvider } from '@/app/LogPanelContext';
+import {
+  LogPanelProvider,
+  LOG_PANEL_EXPANDED_LS_KEY,
+} from '@/app/LogPanelContext';
 import { LogPanel } from '@/app/LogPanel';
 import { commands } from '@/bindings/index';
+import { __resetScopeRegistryForTest } from '@/data/persisted-state';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
@@ -143,9 +147,11 @@ describe('LogPanel follow-tail scroll pause/resume (T011)', () => {
   beforeEach(() => {
     resetLogStore();
     vi.clearAllMocks();
-    // #842 persists `expanded` to localStorage; these tests assume a fresh
-    // collapsed panel on every render.
+    // #842 persists `expanded` via persisted-state; clear both keys and reset
+    // the module singleton so each test starts with a collapsed panel.
+    localStorage.removeItem(LOG_PANEL_EXPANDED_LS_KEY);
     localStorage.removeItem('alm-log-panel-expanded');
+    __resetScopeRegistryForTest();
     // jsdom does not implement `Element.scrollTo` — the follow-tail effect
     // calls it directly (smooth-scroll path) whenever reduced-motion is not
     // active. Stub it so the effect doesn't throw and unmount the tree.

--- a/apps/desktop/src/app/LogPanel.test.tsx
+++ b/apps/desktop/src/app/LogPanel.test.tsx
@@ -17,8 +17,12 @@ import {
   within,
 } from '@testing-library/react';
 import { appendLog, resetLogStore } from '@/data/logStore';
-import { LogPanelProvider } from '@/app/LogPanelContext';
+import {
+  LogPanelProvider,
+  LOG_PANEL_EXPANDED_LS_KEY,
+} from '@/app/LogPanelContext';
 import { LogPanel } from '@/app/LogPanel';
+import { __resetScopeRegistryForTest } from '@/data/persisted-state';
 
 // ── Mocks ──────────────────────────────────────────────────────────────────────
 
@@ -87,14 +91,19 @@ describe('LogPanel expand/collapse + filters (T006)', () => {
   beforeEach(() => {
     resetLogStore();
     vi.clearAllMocks();
-    // #842 persists `expanded` to localStorage; these tests assume a fresh
-    // collapsed panel on every render.
+    // #842 persists `expanded` via persisted-state; these tests assume a fresh
+    // collapsed panel on every render. Clear both the new boot-cache key and
+    // the old legacy key so module-singleton state is reset.
+    localStorage.removeItem(LOG_PANEL_EXPANDED_LS_KEY);
     localStorage.removeItem('alm-log-panel-expanded');
+    __resetScopeRegistryForTest();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    localStorage.removeItem(LOG_PANEL_EXPANDED_LS_KEY);
     localStorage.removeItem('alm-log-panel-expanded');
+    __resetScopeRegistryForTest();
   });
 
   it('toggles expand/collapse via the Collapsible trigger', async () => {

--- a/apps/desktop/src/app/LogPanelContext.persist.test.tsx
+++ b/apps/desktop/src/app/LogPanelContext.persist.test.tsx
@@ -11,8 +11,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { appendLog, resetLogStore } from '@/data/logStore';
-import { LogPanelProvider } from '@/app/LogPanelContext';
+import {
+  LogPanelProvider,
+  LOG_PANEL_EXPANDED_LS_KEY,
+  _logPanelExpandedStateForTest,
+} from '@/app/LogPanelContext';
 import { LogPanel } from '@/app/LogPanel';
+import { __resetScopeRegistryForTest } from '@/data/persisted-state';
 
 const mockNavigate = vi.fn();
 
@@ -62,11 +67,14 @@ describe('LogPanel expanded persists across restart (#842)', () => {
     resetLogStore();
     vi.clearAllMocks();
     localStorage.clear();
+    // Reset the persisted-state module singleton so each test starts fresh.
+    __resetScopeRegistryForTest();
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
     localStorage.clear();
+    __resetScopeRegistryForTest();
   });
 
   it('persists expand to localStorage and restores it on remount', async () => {
@@ -78,7 +86,7 @@ describe('LogPanel expanded persists across restart (#842)', () => {
     await waitFor(() => {
       expect(getTrigger()).toHaveAttribute('aria-label', 'Collapse log panel');
     });
-    expect(localStorage.getItem('alm-log-panel-expanded')).toBe('true');
+    expect(localStorage.getItem(LOG_PANEL_EXPANDED_LS_KEY)).toBe('true');
 
     // Simulate an app restart: unmount (provider state is discarded) and
     // mount a fresh provider — it must read the persisted flag instead of
@@ -89,7 +97,9 @@ describe('LogPanel expanded persists across restart (#842)', () => {
   });
 
   it('persists collapse back to localStorage', async () => {
-    localStorage.setItem('alm-log-panel-expanded', 'true');
+    // Seed the initial expanded state via the module singleton (equivalent to
+    // what the old localStorage.setItem('alm-log-panel-expanded', 'true') did).
+    _logPanelExpandedStateForTest.set(true);
     seedEntries();
     renderPanel();
 
@@ -98,6 +108,6 @@ describe('LogPanel expanded persists across restart (#842)', () => {
     await waitFor(() => {
       expect(getTrigger()).toHaveAttribute('aria-label', 'Expand log panel');
     });
-    expect(localStorage.getItem('alm-log-panel-expanded')).toBe('false');
+    expect(localStorage.getItem(LOG_PANEL_EXPANDED_LS_KEY)).toBe('false');
   });
 });

--- a/apps/desktop/src/app/LogPanelContext.tsx
+++ b/apps/desktop/src/app/LogPanelContext.tsx
@@ -28,10 +28,9 @@ import { createPersistedState } from '@/data/persisted-state';
 
 export type LevelFilter = 'all' | LogLevel;
 
-// Durable via SQLite (ui_state scope); localStorage kept as synchronous boot
-// cache so the panel opens in the right state before the first IPC round-trip.
-// Legacy key `alm-log-panel-expanded` is imported automatically on first
-// hydrate if the DB row is absent (one-time migration).
+// Durable via SQLite (ui_state scope); localStorage (`pv.ps.*` key) kept as
+// synchronous boot cache so the panel opens in the right state before the
+// first IPC round-trip.
 const logPanelExpandedState = createPersistedState(
   'ui_state',
   'uiState.logPanelExpanded',
@@ -40,7 +39,7 @@ const logPanelExpandedState = createPersistedState(
 
 /** Test-only: boot-cache localStorage key for the expanded state. */
 export const LOG_PANEL_EXPANDED_LS_KEY =
-  'alm.ps.uiState.logPanelExpanded' as const;
+  'pv.ps.uiState.logPanelExpanded' as const;
 
 /**
  * Test-only: the persisted-state instance for expanded state.

--- a/apps/desktop/src/app/LogPanelContext.tsx
+++ b/apps/desktop/src/app/LogPanelContext.tsx
@@ -24,31 +24,30 @@ import {
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import type { LogLevel, LogEntrySource } from '@/data/logStore';
+import { createPersistedState } from '@/data/persisted-state';
 
 export type LevelFilter = 'all' | LogLevel;
 
-// Persisted directly in localStorage (not routed through the generated
-// AppPreferences contract, which is backed by a Rust struct + settings IPC)
-// — same lightweight pattern useAdaptiveDock.ts uses for its own UI-only
-// persisted state. Journey 16 groups this with sidebar-collapse persistence
-// as a "persistent layout choice" that survives restart (#842).
-const EXPANDED_STORAGE_KEY = 'alm-log-panel-expanded';
+// Durable via SQLite (ui_state scope); localStorage kept as synchronous boot
+// cache so the panel opens in the right state before the first IPC round-trip.
+// Legacy key `alm-log-panel-expanded` is imported automatically on first
+// hydrate if the DB row is absent (one-time migration).
+const logPanelExpandedState = createPersistedState(
+  'ui_state',
+  'uiState.logPanelExpanded',
+  { default: false },
+);
 
-function readStoredExpanded(): boolean {
-  try {
-    return window.localStorage.getItem(EXPANDED_STORAGE_KEY) === 'true';
-  } catch {
-    return false;
-  }
-}
+/** Test-only: boot-cache localStorage key for the expanded state. */
+export const LOG_PANEL_EXPANDED_LS_KEY =
+  'alm.ps.uiState.logPanelExpanded' as const;
 
-function writeStoredExpanded(value: boolean): void {
-  try {
-    window.localStorage.setItem(EXPANDED_STORAGE_KEY, String(value));
-  } catch {
-    // Storage full or unavailable; state stays in-memory for this session.
-  }
-}
+/**
+ * Test-only: the persisted-state instance for expanded state.
+ * Lets tests call `.set(true)` to bootstrap state before rendering,
+ * equivalent to seeding the old `alm-log-panel-expanded` localStorage key.
+ */
+export { logPanelExpandedState as _logPanelExpandedStateForTest };
 
 interface LogPanelState {
   expanded: boolean;
@@ -79,7 +78,10 @@ const LogPanelContext = createContext<LogPanelState>({
 });
 
 export function LogPanelProvider({ children }: { children: ReactNode }) {
-  const [expanded, setExpanded] = useState(readStoredExpanded);
+  const [expanded, setExpanded] = useState(() => logPanelExpandedState.get());
+
+  // Cancel the debounced SQLite write on unmount to prevent timer leaks.
+  useEffect(() => () => logPanelExpandedState.cancelPendingWrite(), []);
   const [logLevel, setLogLevel] = useState<LogLevel>('info');
   const [followLogs, setFollowLogsState] = useState(false);
   const [levelFilter, setLevelFilter] = useState<LevelFilter>('all');
@@ -134,7 +136,7 @@ export function LogPanelProvider({ children }: { children: ReactNode }) {
       if (next) {
         setLevelFilter('all');
       }
-      writeStoredExpanded(next);
+      logPanelExpandedState.set(next);
       return next;
     });
   }, []);

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1119,6 +1119,10 @@ export const commands = {
 	 *  Each key that belongs to the scope is resolved via the persistence layer
 	 *  (hydrating the in-code default when no stored row exists).
 	 * 
+	 *  The `"ui_state"` scope is special: it returns all rows whose key starts with
+	 *  `"uiState."` directly from the DB (no in-code default — unknown keys simply
+	 *  return `null` on a get; the frontend falls back to its own default).
+	 * 
 	 *  # Errors
 	 *  Returns `Err(String)` on database failure.
 	 */

--- a/apps/desktop/src/data/persisted-state.test.ts
+++ b/apps/desktop/src/data/persisted-state.test.ts
@@ -1,0 +1,348 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * persisted-state.test.ts — unit tests for createPersistedState / hydrateScope.
+ *
+ * Covers:
+ * - set/get/subscribe (in-memory + localStorage synchronous path)
+ * - debounced SQLite write (settingsUpdate called after debounce elapses)
+ * - hydrateScope reconcile (DB value wins over stale localStorage)
+ * - one-time legacy import (DB absent + localStorage present → import to DB)
+ * - bootCache:false (localStorage never read or written)
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  createPersistedState,
+  hydrateScope,
+  __resetScopeRegistryForTest,
+} from './persisted-state';
+
+// ── IPC mocks ─────────────────────────────────────────────────────────────────
+
+type IpcOutcome =
+  | { status: 'ok'; data: unknown }
+  | { status: 'error'; error: unknown };
+
+const isTauriMock = vi.fn<() => boolean>();
+const settingsGetMock = vi.fn<(scope: string) => Promise<IpcOutcome>>();
+const settingsUpdateMock =
+  vi.fn<(scope: string, values: unknown) => Promise<IpcOutcome>>();
+
+vi.mock('@tauri-apps/api/core', () => ({
+  isTauri: () => isTauriMock(),
+}));
+
+vi.mock('@/bindings/index', () => ({
+  commands: {
+    settingsGet: (scope: string) => settingsGetMock(scope),
+    settingsUpdate: (scope: string, values: unknown) =>
+      settingsUpdateMock(scope, values),
+  },
+}));
+
+vi.mock('@/api/ipc', () => ({
+  unwrap: (result: IpcOutcome) => {
+    if (result.status === 'error') throw result.error;
+    return result.data;
+  },
+}));
+
+// ── Setup / teardown ──────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  isTauriMock.mockReset();
+  settingsGetMock.mockReset();
+  settingsUpdateMock.mockReset();
+  settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+  localStorage.clear();
+  __resetScopeRegistryForTest();
+});
+
+afterEach(() => {
+  __resetScopeRegistryForTest();
+});
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+describe('createPersistedState — set / get / subscribe', () => {
+  it('returns the default value before any set()', () => {
+    const s = createPersistedState('ui_state', 'uiState.test', { default: 42 });
+    expect(s.get()).toBe(42);
+  });
+
+  it('set() updates get() immediately', () => {
+    const s = createPersistedState('ui_state', 'uiState.test', {
+      default: false,
+    });
+    s.set(true);
+    expect(s.get()).toBe(true);
+  });
+
+  it('set() notifies subscribers', () => {
+    const s = createPersistedState('ui_state', 'uiState.test', {
+      default: 0,
+    });
+    const listener = vi.fn();
+    s.subscribe(listener);
+    s.set(1);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribe stops notifications', () => {
+    const s = createPersistedState('ui_state', 'uiState.test', {
+      default: 0,
+    });
+    const listener = vi.fn();
+    const unsub = s.subscribe(listener);
+    unsub();
+    s.set(1);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('set() writes localStorage when bootCache:true (default)', () => {
+    const s = createPersistedState('ui_state', 'uiState.test', {
+      default: 'hello',
+    });
+    s.set('world');
+    expect(localStorage.getItem('alm.ps.uiState.test')).toBe('"world"');
+  });
+
+  it('initialises from localStorage on first get() when a boot cache exists', () => {
+    localStorage.setItem('alm.ps.uiState.test', '"cached"');
+    const s = createPersistedState('ui_state', 'uiState.test', {
+      default: 'default',
+    });
+    expect(s.get()).toBe('cached');
+  });
+});
+
+describe('createPersistedState — debounce', () => {
+  // These tests use debounceMs:0 so the timer fires immediately and real
+  // async/await can settle — vi.useFakeTimers() deadlocks when the debounced
+  // handler awaits dynamic imports (vi timer + Promise interaction).
+
+  /** Poll until a mock has been called at least once (max ~200 ms). */
+  async function waitForCall(fn: ReturnType<typeof vi.fn>): Promise<void> {
+    for (let i = 0; i < 40; i++) {
+      if (fn.mock.calls.length > 0) return;
+      await new Promise((r) => setTimeout(r, 5));
+    }
+  }
+
+  /** Wait long enough that a debounceMs:0 timer would have fired if it was going to. */
+  async function waitNoCall(): Promise<void> {
+    await new Promise((r) => setTimeout(r, 30));
+  }
+
+  it('coalesces rapid set() calls — settingsUpdate called once with latest value', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+
+    const s = createPersistedState('ui_state', 'uiState.debounced', {
+      default: 0,
+      debounceMs: 0,
+    });
+    s.set(1);
+    s.set(2);
+    s.set(3);
+
+    await waitForCall(settingsUpdateMock);
+
+    expect(settingsUpdateMock).toHaveBeenCalledTimes(1);
+    expect(settingsUpdateMock).toHaveBeenCalledWith('ui_state', {
+      'uiState.debounced': 3,
+    });
+  });
+
+  it('does not call settingsUpdate outside Tauri', async () => {
+    isTauriMock.mockReturnValue(false);
+
+    const s = createPersistedState('ui_state', 'uiState.nontauri', {
+      default: 0,
+      debounceMs: 0,
+    });
+    s.set(99);
+
+    await waitNoCall();
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('hydrateScope — reconcile', () => {
+  it('updates in-memory value from DB when DB value differs', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: {
+        scope: 'ui_state',
+        values: { 'uiState.x': 'from-db' },
+      },
+    });
+
+    const s = createPersistedState('ui_state', 'uiState.x', {
+      default: 'default',
+    });
+    expect(s.get()).toBe('default');
+
+    await hydrateScope('ui_state');
+
+    expect(s.get()).toBe('from-db');
+  });
+
+  it('updates localStorage from DB on reconcile', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'ui_state', values: { 'uiState.y': true } },
+    });
+
+    const s = createPersistedState('ui_state', 'uiState.y', {
+      default: false,
+    });
+    await hydrateScope('ui_state');
+
+    expect(s.get()).toBe(true);
+    expect(localStorage.getItem('alm.ps.uiState.y')).toBe('true');
+  });
+
+  it('notifies subscribers when DB value wins', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'ui_state', values: { 'uiState.notify': 'new' } },
+    });
+
+    const s = createPersistedState('ui_state', 'uiState.notify', {
+      default: 'old',
+    });
+    const listener = vi.fn();
+    s.subscribe(listener);
+    await hydrateScope('ui_state');
+
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify when DB value equals in-memory value', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'ui_state', values: { 'uiState.same': 'abc' } },
+    });
+
+    const s = createPersistedState('ui_state', 'uiState.same', {
+      default: 'abc',
+    });
+    const listener = vi.fn();
+    s.subscribe(listener);
+    await hydrateScope('ui_state');
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('is a no-op outside Tauri', async () => {
+    isTauriMock.mockReturnValue(false);
+
+    const s = createPersistedState('ui_state', 'uiState.notauri', {
+      default: 'default',
+    });
+    await hydrateScope('ui_state');
+
+    expect(s.get()).toBe('default');
+    expect(settingsGetMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps current value on IPC failure', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockRejectedValue(new Error('IPC error'));
+
+    const s = createPersistedState('ui_state', 'uiState.fallback', {
+      default: 'my-value',
+    });
+    s.set('set-before-hydrate');
+    await hydrateScope('ui_state');
+
+    expect(s.get()).toBe('set-before-hydrate');
+  });
+
+  it('batches ONE settingsGet per scope regardless of key count', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: {
+        scope: 'ui_state',
+        values: { 'uiState.a': 1, 'uiState.b': 2 },
+      },
+    });
+
+    createPersistedState('ui_state', 'uiState.a', { default: 0 });
+    createPersistedState('ui_state', 'uiState.b', { default: 0 });
+    await hydrateScope('ui_state');
+
+    expect(settingsGetMock).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('hydrateScope — legacy import', () => {
+  it('imports a legacy localStorage value into SQLite when DB key is absent', async () => {
+    isTauriMock.mockReturnValue(true);
+    // DB has no value for this key (null/undefined).
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'ui_state', values: {} },
+    });
+    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+
+    // Seed the legacy localStorage key.
+    localStorage.setItem('alm.ps.uiState.legacy', '"legacy-value"');
+
+    createPersistedState('ui_state', 'uiState.legacy', { default: 'default' });
+    await hydrateScope('ui_state');
+
+    // The legacy raw string from localStorage should have been written to DB.
+    expect(settingsUpdateMock).toHaveBeenCalledWith(
+      'ui_state',
+      expect.objectContaining({ 'uiState.legacy': '"legacy-value"' }),
+    );
+  });
+
+  it('does not import when DB already has a value', async () => {
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: { scope: 'ui_state', values: { 'uiState.present': 'db-value' } },
+    });
+    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
+
+    localStorage.setItem('alm.ps.uiState.present', '"legacy-value"');
+    createPersistedState('ui_state', 'uiState.present', { default: 'default' });
+    await hydrateScope('ui_state');
+
+    // settingsUpdate should NOT have been called for a legacy import
+    // (it may be called later via debounce, but that's a separate flow).
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('createPersistedState — bootCache:false', () => {
+  it('does not read localStorage on init', () => {
+    localStorage.setItem('alm.ps.uiState.nocache', '"should-be-ignored"');
+    const s = createPersistedState('ui_state', 'uiState.nocache', {
+      default: 'default',
+      bootCache: false,
+    });
+    // Should use the default, not the localStorage value.
+    expect(s.get()).toBe('default');
+  });
+
+  it('does not write localStorage on set()', () => {
+    const s = createPersistedState('ui_state', 'uiState.nocache', {
+      default: 'default',
+      bootCache: false,
+    });
+    s.set('new-value');
+    // No localStorage write should have happened.
+    expect(localStorage.getItem('alm.ps.uiState.nocache')).toBeNull();
+  });
+});

--- a/apps/desktop/src/data/persisted-state.test.ts
+++ b/apps/desktop/src/data/persisted-state.test.ts
@@ -106,11 +106,11 @@ describe('createPersistedState — set / get / subscribe', () => {
       default: 'hello',
     });
     s.set('world');
-    expect(localStorage.getItem('alm.ps.uiState.test')).toBe('"world"');
+    expect(localStorage.getItem('pv.ps.uiState.test')).toBe('"world"');
   });
 
   it('initialises from localStorage on first get() when a boot cache exists', () => {
-    localStorage.setItem('alm.ps.uiState.test', '"cached"');
+    localStorage.setItem('pv.ps.uiState.test', '"cached"');
     const s = createPersistedState('ui_state', 'uiState.test', {
       default: 'default',
     });
@@ -204,7 +204,7 @@ describe('hydrateScope — reconcile', () => {
     await hydrateScope('ui_state');
 
     expect(s.get()).toBe(true);
-    expect(localStorage.getItem('alm.ps.uiState.y')).toBe('true');
+    expect(localStorage.getItem('pv.ps.uiState.y')).toBe('true');
   });
 
   it('notifies subscribers when DB value wins', async () => {
@@ -284,50 +284,68 @@ describe('hydrateScope — reconcile', () => {
   });
 });
 
-describe('hydrateScope — legacy import', () => {
-  it('imports a legacy localStorage value into SQLite when DB key is absent', async () => {
+describe('hydrateScope — DB key absent', () => {
+  it('keeps the boot-cache value when the DB has no row for the key', async () => {
     isTauriMock.mockReturnValue(true);
-    // DB has no value for this key (null/undefined).
     settingsGetMock.mockResolvedValue({
       status: 'ok',
       data: { scope: 'ui_state', values: {} },
     });
-    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
 
-    // Seed the legacy localStorage key.
-    localStorage.setItem('alm.ps.uiState.legacy', '"legacy-value"');
-
-    createPersistedState('ui_state', 'uiState.legacy', { default: 'default' });
+    localStorage.setItem('pv.ps.uiState.cached', '"cached-value"');
+    const s = createPersistedState('ui_state', 'uiState.cached', {
+      default: 'default',
+    });
     await hydrateScope('ui_state');
 
-    // The legacy raw string from localStorage should have been written to DB.
-    expect(settingsUpdateMock).toHaveBeenCalledWith(
-      'ui_state',
-      expect.objectContaining({ 'uiState.legacy': '"legacy-value"' }),
-    );
+    // Boot-cache read at init time means the value is already 'cached-value'.
+    expect(s.get()).toBe('cached-value');
+    // No write to DB (nothing to import — greenfield, no legacy).
+    expect(settingsUpdateMock).not.toHaveBeenCalled();
   });
+});
 
-  it('does not import when DB already has a value', async () => {
+describe('hydrateScope — boot integration', () => {
+  // Verifies the sequence main.tsx uses: ensure all scope-registered handles
+  // are present BEFORE calling hydrateScope, then DB values reconcile.
+  it('reconciles all registered keys from DB in one round-trip', async () => {
     isTauriMock.mockReturnValue(true);
     settingsGetMock.mockResolvedValue({
       status: 'ok',
-      data: { scope: 'ui_state', values: { 'uiState.present': 'db-value' } },
+      data: {
+        scope: 'ui_state',
+        values: {
+          'uiState.panelOpen': true,
+          'uiState.groupDims': ['target', 'filter'],
+        },
+      },
     });
-    settingsUpdateMock.mockResolvedValue({ status: 'ok', data: null });
 
-    localStorage.setItem('alm.ps.uiState.present', '"legacy-value"');
-    createPersistedState('ui_state', 'uiState.present', { default: 'default' });
+    const panelState = createPersistedState('ui_state', 'uiState.panelOpen', {
+      default: false,
+    });
+    const groupState = createPersistedState('ui_state', 'uiState.groupDims', {
+      default: [] as string[],
+    });
+
+    // Before hydrate: defaults.
+    expect(panelState.get()).toBe(false);
+    expect(groupState.get()).toEqual([]);
+
     await hydrateScope('ui_state');
 
-    // settingsUpdate should NOT have been called for a legacy import
-    // (it may be called later via debounce, but that's a separate flow).
-    expect(settingsUpdateMock).not.toHaveBeenCalled();
+    // After hydrate: DB values win.
+    expect(panelState.get()).toBe(true);
+    expect(groupState.get()).toEqual(['target', 'filter']);
+    // Exactly one round-trip regardless of key count.
+    expect(settingsGetMock).toHaveBeenCalledTimes(1);
+    expect(settingsGetMock).toHaveBeenCalledWith('ui_state');
   });
 });
 
 describe('createPersistedState — bootCache:false', () => {
   it('does not read localStorage on init', () => {
-    localStorage.setItem('alm.ps.uiState.nocache', '"should-be-ignored"');
+    localStorage.setItem('pv.ps.uiState.nocache', '"should-be-ignored"');
     const s = createPersistedState('ui_state', 'uiState.nocache', {
       default: 'default',
       bootCache: false,
@@ -343,6 +361,6 @@ describe('createPersistedState — bootCache:false', () => {
     });
     s.set('new-value');
     // No localStorage write should have happened.
-    expect(localStorage.getItem('alm.ps.uiState.nocache')).toBeNull();
+    expect(localStorage.getItem('pv.ps.uiState.nocache')).toBeNull();
   });
 });

--- a/apps/desktop/src/data/persisted-state.test.ts
+++ b/apps/desktop/src/data/persisted-state.test.ts
@@ -306,8 +306,6 @@ describe('hydrateScope — DB key absent', () => {
 });
 
 describe('hydrateScope — boot integration', () => {
-  // Verifies the sequence main.tsx uses: ensure all scope-registered handles
-  // are present BEFORE calling hydrateScope, then DB values reconcile.
   it('reconciles all registered keys from DB in one round-trip', async () => {
     isTauriMock.mockReturnValue(true);
     settingsGetMock.mockResolvedValue({
@@ -340,6 +338,32 @@ describe('hydrateScope — boot integration', () => {
     // Exactly one round-trip regardless of key count.
     expect(settingsGetMock).toHaveBeenCalledTimes(1);
     expect(settingsGetMock).toHaveBeenCalledWith('ui_state');
+  });
+
+  it('late-registered handle reconciles from cache without a second IPC call', async () => {
+    // Models the picker/grouping scenario: hydrateScope fires at boot before
+    // the state is created (lazy registration on first user interaction).
+    isTauriMock.mockReturnValue(true);
+    settingsGetMock.mockResolvedValue({
+      status: 'ok',
+      data: {
+        scope: 'ui_state',
+        values: { 'uiState.lateKey': 'db-value' },
+      },
+    });
+
+    // hydrateScope fires with NO handles registered yet.
+    await hydrateScope('ui_state');
+    expect(settingsGetMock).toHaveBeenCalledTimes(1);
+
+    // Handle registers AFTER hydrateScope has returned.
+    const lateState = createPersistedState('ui_state', 'uiState.lateKey', {
+      default: 'default',
+    });
+
+    // Must have reconciled from the cache — no second IPC call.
+    expect(lateState.get()).toBe('db-value');
+    expect(settingsGetMock).toHaveBeenCalledTimes(1);
   });
 });
 

--- a/apps/desktop/src/data/persisted-state.ts
+++ b/apps/desktop/src/data/persisted-state.ts
@@ -49,6 +49,10 @@ interface PersistedStateHandle<T> {
 
 const scopeRegistry = new Map<string, Set<PersistedStateHandle<unknown>>>();
 
+// All result objects, tracked so __resetScopeRegistryForTest can call
+// _resetForTest() on each (clears in-memory value + boot-cache LS key).
+const allInstances = new Set<PersistedStateResult<unknown>>();
+
 function registerHandle<T>(
   scope: string,
   handle: PersistedStateHandle<T>,
@@ -76,22 +80,6 @@ function importTauriCore(): Promise<typeof import('@tauri-apps/api/core')> {
     tauriCorePromise = import('@tauri-apps/api/core');
   }
   return tauriCorePromise;
-}
-
-// ── Debounce helper ───────────────────────────────────────────────────────────
-
-function debounce<T extends unknown[]>(
-  fn: (...args: T) => void,
-  ms: number,
-): (...args: T) => void {
-  let timer: ReturnType<typeof setTimeout> | null = null;
-  return (...args: T) => {
-    if (timer !== null) clearTimeout(timer);
-    timer = setTimeout(() => {
-      timer = null;
-      fn(...args);
-    }, ms);
-  };
 }
 
 // ── Public API ────────────────────────────────────────────────────────────────
@@ -128,6 +116,19 @@ export interface PersistedStateResult<T> {
    * instead, which issues the batch `settingsGet` and calls this on each key.
    */
   _reconcileFromDbValues(values: Record<string, unknown>): void;
+  /**
+   * Cancel any pending debounced SQLite write. Call from a component's
+   * `useEffect` cleanup to avoid timer leaks on unmount, e.g.:
+   *
+   *   useEffect(() => () => myState.cancelPendingWrite(), []);
+   */
+  cancelPendingWrite(): void;
+  /**
+   * Test-only: reset in-memory value to the constructor default and clear the
+   * boot-cache localStorage key. Allows module-level singletons to start fresh
+   * between tests without re-importing the module.
+   */
+  _resetForTest(): void;
 }
 
 /**
@@ -160,21 +161,31 @@ export function createPersistedState<T>(
 
   // ── Debounced SQLite write ─────────────────────────────────────────────────
 
-  const persistToDb = debounce((value: T) => {
-    void (async () => {
-      try {
-        const { isTauri } = await importTauriCore();
-        if (!isTauri()) return;
-        const [{ commands }, { unwrap }] = await Promise.all([
-          import('@/bindings/index'),
-          import('@/api/ipc'),
-        ]);
-        unwrap(await commands.settingsUpdate(scope, { [key]: value }));
-      } catch {
-        // Best-effort — a DB write failure never blocks or reverts the UI change.
-      }
-    })();
-  }, debounceMs);
+  // Inline debounce (vs. the module-level `debounce()` helper) so we can
+  // expose a cancel function for `_resetForTest()`.
+  let pendingDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function persistToDb(value: T): void {
+    if (pendingDebounceTimer !== null) {
+      clearTimeout(pendingDebounceTimer);
+    }
+    pendingDebounceTimer = setTimeout(() => {
+      pendingDebounceTimer = null;
+      void (async () => {
+        try {
+          const { isTauri } = await importTauriCore();
+          if (!isTauri()) return;
+          const [{ commands }, { unwrap }] = await Promise.all([
+            import('@/bindings/index'),
+            import('@/api/ipc'),
+          ]);
+          unwrap(await commands.settingsUpdate(scope, { [key]: value }));
+        } catch {
+          // Best-effort — a DB write failure never blocks or reverts the UI change.
+        }
+      })();
+    }, debounceMs);
+  }
 
   // ── Handle for the scope registry ─────────────────────────────────────────
 
@@ -206,7 +217,7 @@ export function createPersistedState<T>(
 
   // ── Returned API ──────────────────────────────────────────────────────────
 
-  return {
+  const result: PersistedStateResult<T> = {
     get(): T {
       return current;
     },
@@ -226,7 +237,35 @@ export function createPersistedState<T>(
     _reconcileFromDbValues(values: Record<string, unknown>): void {
       handle.setFromDb(values[key]);
     },
+
+    cancelPendingWrite(): void {
+      if (pendingDebounceTimer !== null) {
+        clearTimeout(pendingDebounceTimer);
+        pendingDebounceTimer = null;
+      }
+    },
+
+    _resetForTest(): void {
+      // Cancel any pending debounce timer to prevent leaked async operations
+      // after test teardown (e.g. the virtualizer-scroll-debounce test).
+      if (pendingDebounceTimer !== null) {
+        clearTimeout(pendingDebounceTimer);
+        pendingDebounceTimer = null;
+      }
+      if (lsKey) {
+        try {
+          window.localStorage.removeItem(lsKey);
+        } catch {
+          /* unavailable — non-fatal */
+        }
+      }
+      current = opts.default;
+      notify();
+    },
   };
+
+  allInstances.add(result as PersistedStateResult<unknown>);
+  return result;
 }
 
 // ── Scope hydration ───────────────────────────────────────────────────────────
@@ -354,10 +393,22 @@ function shallowEqual(a: unknown, b: unknown): boolean {
 // ── Test helpers ──────────────────────────────────────────────────────────────
 
 /**
- * Reset all scope registrations. Test-only — clears the module-level registry
- * so tests don't leak state across `createPersistedState` calls.
+ * Reset all persisted state to defaults and clear all scope registrations.
+ *
+ * Test-only — resets in-memory values + boot-cache localStorage keys for every
+ * `createPersistedState` instance created so far, then clears the scope registry.
+ * Call in `beforeEach`/`afterEach` to prevent module-level singletons from
+ * leaking state between tests.
  */
 export function __resetScopeRegistryForTest(): void {
+  // Reset in-memory values to defaults (but keep the instances in allInstances
+  // so future calls can reset them again — module singletons are created once
+  // and must remain resettable across the full test run).
+  for (const instance of allInstances) {
+    instance._resetForTest();
+  }
+  // Clear the scope registry so hydrateScope can re-register without stale
+  // handles, but don't clear allInstances (see above).
   scopeRegistry.clear();
   // Also reset the memoised Tauri core promise so mock re-imports work.
   tauriCorePromise = null;

--- a/apps/desktop/src/data/persisted-state.ts
+++ b/apps/desktop/src/data/persisted-state.ts
@@ -22,10 +22,8 @@
  * `hydrateScope(scope)` issues ONE `settingsGet(scope)` call per scope and
  * reconciles in-memory + localStorage from the DB response. `localStorage`
  * stays authoritative until the first successful reconcile (offline-safe).
- * Call it once at boot after Tauri IPC is available.
- *
- * One-time legacy import: if the DB has no value for a key but localStorage
- * has one, `hydrateScope` imports it into SQLite automatically.
+ * Call it once at boot after Tauri IPC is available — wired in `main.tsx`
+ * alongside `hydrateThemeFromSettings`.
  *
  * ## useSyncExternalStore compatibility
  *
@@ -40,11 +38,9 @@
 
 /** Internal handle stored in the scope registry. */
 interface PersistedStateHandle<T> {
-  readonly lsKey: string | null; // null when bootCache:false
   readonly settingsKey: string;
   readonly defaultValue: T;
   setFromDb(value: unknown): void;
-  getForLegacyImport(): unknown; // the current localStorage raw value (pre-parse)
 }
 
 const scopeRegistry = new Map<string, Set<PersistedStateHandle<unknown>>>();
@@ -135,11 +131,14 @@ export interface PersistedStateResult<T> {
  * Create a persisted state atom backed by SQLite (durable) and localStorage
  * (synchronous boot cache).
  *
- * @param scope      Settings scope for the SQLite key (e.g. `"ui_state"`).
- * @param key        Stable settings key within the scope (e.g.
- *                   `"uiState.logPanelExpanded"`).
- * @param opts       Options including the default value, boot-cache flag, and
- *                   debounce window.
+ * Boot-cache localStorage keys use the `pv.ps.` prefix
+ * (e.g. `pv.ps.uiState.logPanelExpanded`).
+ *
+ * @param scope  Settings scope for the SQLite key (e.g. `"ui_state"`).
+ * @param key    Stable settings key within the scope (e.g.
+ *               `"uiState.logPanelExpanded"`).
+ * @param opts   Options including the default value, boot-cache flag, and
+ *               debounce window.
  */
 export function createPersistedState<T>(
   scope: string,
@@ -148,7 +147,7 @@ export function createPersistedState<T>(
 ): PersistedStateResult<T> {
   const bootCache = opts.bootCache !== false;
   const debounceMs = opts.debounceMs ?? 500;
-  const lsKey = bootCache ? `alm.ps.${key}` : null;
+  const lsKey = bootCache ? `pv.ps.${key}` : null;
 
   // ── In-memory state ────────────────────────────────────────────────────────
 
@@ -161,8 +160,7 @@ export function createPersistedState<T>(
 
   // ── Debounced SQLite write ─────────────────────────────────────────────────
 
-  // Inline debounce (vs. the module-level `debounce()` helper) so we can
-  // expose a cancel function for `_resetForTest()`.
+  // Inline debounce so we can cancel it in cancelPendingWrite / _resetForTest.
   let pendingDebounceTimer: ReturnType<typeof setTimeout> | null = null;
 
   function persistToDb(value: T): void {
@@ -190,7 +188,6 @@ export function createPersistedState<T>(
   // ── Handle for the scope registry ─────────────────────────────────────────
 
   const handle: PersistedStateHandle<T> = {
-    lsKey,
     settingsKey: key,
     defaultValue: opts.default,
 
@@ -200,15 +197,6 @@ export function createPersistedState<T>(
         current = parsed;
         writeBootCache(lsKey, current);
         notify();
-      }
-    },
-
-    getForLegacyImport(): unknown {
-      if (!lsKey) return undefined;
-      try {
-        return window.localStorage.getItem(lsKey) ?? undefined;
-      } catch {
-        return undefined;
       }
     },
   };
@@ -272,12 +260,12 @@ export function createPersistedState<T>(
 
 /**
  * Reconcile all keys registered under `scope` from the SQLite settings DB in
- * ONE `settingsGet` round-trip. Call once per scope at boot after Tauri IPC is
- * available. No-ops outside Tauri or on IPC failure (localStorage stays
- * authoritative until the next successful call).
+ * ONE `settingsGet` round-trip. No-ops outside Tauri or on IPC failure
+ * (localStorage stays authoritative until the next successful call).
  *
- * One-time legacy import: for any key where the DB row is absent but a legacy
- * localStorage value exists, the value is imported into SQLite automatically.
+ * Wired in `main.tsx` alongside `hydrateThemeFromSettings` — NOT called
+ * automatically; callers must ensure the modules that create `createPersistedState`
+ * instances for this scope are imported before calling this function.
  */
 export async function hydrateScope(scope: string): Promise<void> {
   try {
@@ -295,30 +283,10 @@ export async function hydrateScope(scope: string): Promise<void> {
     const data = unwrap(await commands.settingsGet(scope));
     const values = data.values as Record<string, unknown>;
 
-    const legacyImports: Record<string, unknown> = {};
-
     for (const h of handles) {
       const dbValue = values[h.settingsKey];
-
-      if (dbValue === undefined || dbValue === null) {
-        // Key absent from DB — check for a legacy localStorage value to import.
-        const legacy = h.getForLegacyImport();
-        if (legacy !== undefined) {
-          legacyImports[h.settingsKey] = legacy;
-        }
-        // Keep current in-memory value (localStorage already loaded at init).
-        continue;
-      }
-
-      h.setFromDb(dbValue);
-    }
-
-    // Flush legacy imports into SQLite in one write (best-effort).
-    if (Object.keys(legacyImports).length > 0) {
-      try {
-        unwrap(await commands.settingsUpdate(scope, legacyImports));
-      } catch {
-        // Legacy import is best-effort.
+      if (dbValue !== undefined && dbValue !== null) {
+        h.setFromDb(dbValue);
       }
     }
   } catch {
@@ -352,30 +320,17 @@ function writeBootCache<T>(lsKey: string | null, value: T): void {
 
 /**
  * Parse an opaque DB value into `T`; returns `defaultValue` when the DB
- * value is `null`/`undefined` or is unparseable. For primitive types (string,
- * number, boolean) this is a direct cast; for structured types (arrays,
- * objects) JSON round-trip through `JSON.parse(JSON.stringify(...))` ensures
- * a clean parse without trusting the DB shape blindly.
+ * value is `null`/`undefined`. For JSON-compatible types the DB value is
+ * already the parsed form (Tauri deserialized it).
  */
 function safeParse<T>(value: unknown, defaultValue: T): T {
   if (value === undefined || value === null) return defaultValue;
-  try {
-    // For plain JSON-compatible types the DB value IS already the parsed form
-    // (Tauri deserialized the JSON row into a JS value). No extra parse needed;
-    // just cast and let the caller validate if needed.
-    return value as T;
-  } catch {
-    return defaultValue;
-  }
+  return value as T;
 }
 
 /**
- * Shallow equality check used to skip notify() when the hydrated DB value
- * matches what's already in memory, preventing spurious re-renders.
- *
- * For arrays and objects this compares JSON serialisation — adequate for the
- * simple scalar / string-array types used by UI state keys; deep equality
- * isn't needed here.
+ * Shallow equality check to skip notify() when the hydrated DB value matches
+ * in-memory, preventing spurious re-renders. Uses JSON for arrays/objects.
  */
 function shallowEqual(a: unknown, b: unknown): boolean {
   if (a === b) return true;
@@ -401,15 +356,14 @@ function shallowEqual(a: unknown, b: unknown): boolean {
  * leaking state between tests.
  */
 export function __resetScopeRegistryForTest(): void {
-  // Reset in-memory values to defaults (but keep the instances in allInstances
-  // so future calls can reset them again — module singletons are created once
-  // and must remain resettable across the full test run).
+  // Reset in-memory values to defaults (keep instances so future calls reset
+  // them again — module singletons are created once per module lifetime).
   for (const instance of allInstances) {
     instance._resetForTest();
   }
   // Clear the scope registry so hydrateScope can re-register without stale
-  // handles, but don't clear allInstances (see above).
+  // handles. Do NOT clear allInstances (they persist across resets).
   scopeRegistry.clear();
-  // Also reset the memoised Tauri core promise so mock re-imports work.
+  // Reset the memoised Tauri core promise so mock re-imports work.
   tauriCorePromise = null;
 }

--- a/apps/desktop/src/data/persisted-state.ts
+++ b/apps/desktop/src/data/persisted-state.ts
@@ -113,28 +113,33 @@ export interface PersistedStateOptions<T> {
 }
 
 export interface PersistedStateResult<T> {
+  // Property types (not method declarations) so bare refs like
+  // `useSyncExternalStore(state.subscribe, state.get)` don't trip
+  // @typescript-eslint/unbound-method — the rule treats property-typed
+  // functions as stable values, not unbound methods.
+
   /** Synchronous read — always returns the current in-memory value. */
-  get(): T;
+  readonly get: () => T;
   /** Update in-memory + localStorage + schedule debounced SQLite write. */
-  set(value: T): void;
+  readonly set: (value: T) => void;
   /**
    * Subscribe to changes. Returns an unsubscribe function.
    * Directly compatible with `useSyncExternalStore`.
    */
-  subscribe(listener: () => void): () => void;
+  readonly subscribe: (listener: () => void) => () => void;
   /**
    * Reconcile in-memory + localStorage from the DB response object produced by
    * `hydrateScope`. Not called directly by consumers — call `hydrateScope`
    * instead, which issues the batch `settingsGet` and calls this on each key.
    */
-  _reconcileFromDbValues(values: Record<string, unknown>): void;
+  readonly _reconcileFromDbValues: (values: Record<string, unknown>) => void;
   /**
    * Cancel any pending debounced SQLite write. Call from a component's
    * `useEffect` cleanup to avoid timer leaks on unmount, e.g.:
    *
    *   useEffect(() => () => myState.cancelPendingWrite(), []);
    */
-  cancelPendingWrite(): void;
+  readonly cancelPendingWrite: () => void;
   /**
    * Test-only: reset in-memory value to the constructor default and clear the
    * boot-cache localStorage key. Allows module-level singletons to start fresh

--- a/apps/desktop/src/data/persisted-state.ts
+++ b/apps/desktop/src/data/persisted-state.ts
@@ -49,6 +49,12 @@ const scopeRegistry = new Map<string, Set<PersistedStateHandle<unknown>>>();
 // _resetForTest() on each (clears in-memory value + boot-cache LS key).
 const allInstances = new Set<PersistedStateResult<unknown>>();
 
+// Cache of DB values per scope, populated by hydrateScope on a successful
+// fetch. Late-registering handles (e.g. lazy picker/grouping instances
+// created after hydrateScope returns) consult this cache immediately in
+// registerHandle so they reconcile without a second IPC round-trip.
+const scopeValueCache = new Map<string, Record<string, unknown>>();
+
 function registerHandle<T>(
   scope: string,
   handle: PersistedStateHandle<T>,
@@ -61,6 +67,16 @@ function registerHandle<T>(
   (set as Set<PersistedStateHandle<unknown>>).add(
     handle as PersistedStateHandle<unknown>,
   );
+
+  // If this scope was already hydrated, apply the cached value immediately
+  // rather than waiting for a second hydrateScope call.
+  const cached = scopeValueCache.get(scope);
+  if (cached) {
+    const dbValue = cached[handle.settingsKey];
+    if (dbValue !== undefined && dbValue !== null) {
+      handle.setFromDb(dbValue);
+    }
+  }
 }
 
 // ── Tauri IPC helpers ─────────────────────────────────────────────────────────
@@ -206,27 +222,29 @@ export function createPersistedState<T>(
   // ── Returned API ──────────────────────────────────────────────────────────
 
   const result: PersistedStateResult<T> = {
-    get(): T {
-      return current;
-    },
+    // Arrow function properties (not method shorthands) so that bare refs like
+    // `useSyncExternalStore(state.subscribe, state.get)` pass the lint rule
+    // `noUnboundMethods` — the functions close over module-scope variables and
+    // never use `this`, so the binding is a no-op and arrow syntax is correct.
+    get: (): T => current,
 
-    set(value: T): void {
+    set: (value: T): void => {
       current = value;
       writeBootCache(lsKey, value);
       notify();
       persistToDb(value);
     },
 
-    subscribe(listener: () => void): () => void {
+    subscribe: (listener: () => void): (() => void) => {
       listeners.add(listener);
       return () => listeners.delete(listener);
     },
 
-    _reconcileFromDbValues(values: Record<string, unknown>): void {
+    _reconcileFromDbValues: (values: Record<string, unknown>): void => {
       handle.setFromDb(values[key]);
     },
 
-    cancelPendingWrite(): void {
+    cancelPendingWrite: (): void => {
       if (pendingDebounceTimer !== null) {
         clearTimeout(pendingDebounceTimer);
         pendingDebounceTimer = null;
@@ -263,17 +281,17 @@ export function createPersistedState<T>(
  * ONE `settingsGet` round-trip. No-ops outside Tauri or on IPC failure
  * (localStorage stays authoritative until the next successful call).
  *
- * Wired in `main.tsx` alongside `hydrateThemeFromSettings` — NOT called
- * automatically; callers must ensure the modules that create `createPersistedState`
- * instances for this scope are imported before calling this function.
+ * Fetched values are cached in `scopeValueCache`. Any handle that registers
+ * AFTER this call (e.g. a lazily-created picker or grouping state) is
+ * reconciled immediately from the cache in `registerHandle`, so registration
+ * order is not a correctness requirement.
+ *
+ * Wired in `main.tsx` alongside `hydrateThemeFromSettings`.
  */
 export async function hydrateScope(scope: string): Promise<void> {
   try {
     const { isTauri } = await importTauriCore();
     if (!isTauri()) return;
-
-    const handles = scopeRegistry.get(scope);
-    if (!handles || handles.size === 0) return;
 
     const [{ commands }, { unwrap }] = await Promise.all([
       import('@/bindings/index'),
@@ -283,10 +301,16 @@ export async function hydrateScope(scope: string): Promise<void> {
     const data = unwrap(await commands.settingsGet(scope));
     const values = data.values as Record<string, unknown>;
 
-    for (const h of handles) {
-      const dbValue = values[h.settingsKey];
-      if (dbValue !== undefined && dbValue !== null) {
-        h.setFromDb(dbValue);
+    // Cache for late-registering handles (picker/grouping created on first use).
+    scopeValueCache.set(scope, values);
+
+    const handles = scopeRegistry.get(scope);
+    if (handles) {
+      for (const h of handles) {
+        const dbValue = values[h.settingsKey];
+        if (dbValue !== undefined && dbValue !== null) {
+          h.setFromDb(dbValue);
+        }
       }
     }
   } catch {
@@ -361,9 +385,10 @@ export function __resetScopeRegistryForTest(): void {
   for (const instance of allInstances) {
     instance._resetForTest();
   }
-  // Clear the scope registry so hydrateScope can re-register without stale
-  // handles. Do NOT clear allInstances (they persist across resets).
+  // Clear the scope registry and value cache so hydrateScope re-fetches.
+  // Do NOT clear allInstances (they persist across resets).
   scopeRegistry.clear();
+  scopeValueCache.clear();
   // Reset the memoised Tauri core promise so mock re-imports work.
   tauriCorePromise = null;
 }

--- a/apps/desktop/src/data/persisted-state.ts
+++ b/apps/desktop/src/data/persisted-state.ts
@@ -1,0 +1,364 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * persisted-state.ts — shared utility for SQLite-durable UI state (2026-07-24).
+ *
+ * Architecture decision: ALL persisted frontend state lives in SQLite;
+ * localStorage is ONLY a synchronous boot cache. This utility generalises the
+ * proven spec-018 theme/fontSize/zoom/locale pattern so every key gets the
+ * same treatment for free.
+ *
+ * ## Write-behind policy
+ *
+ * `set()` updates in-memory (immediately authoritative), writes localStorage
+ * synchronously (if `bootCache` is enabled), and schedules a debounced
+ * `settingsUpdate` to SQLite. The SQLite write is fire-and-forget: a failure
+ * never reverts the in-memory state, matching the existing
+ * `persistThemeToSettings` convention.
+ *
+ * ## Hydration
+ *
+ * `hydrateScope(scope)` issues ONE `settingsGet(scope)` call per scope and
+ * reconciles in-memory + localStorage from the DB response. `localStorage`
+ * stays authoritative until the first successful reconcile (offline-safe).
+ * Call it once at boot after Tauri IPC is available.
+ *
+ * One-time legacy import: if the DB has no value for a key but localStorage
+ * has one, `hydrateScope` imports it into SQLite automatically.
+ *
+ * ## useSyncExternalStore compatibility
+ *
+ * The `subscribe` and `get` functions returned by `createPersistedState` are
+ * directly compatible with `useSyncExternalStore(subscribe, get)`.
+ */
+
+// ── Scope registry ────────────────────────────────────────────────────────────
+//
+// All PersistedState instances register themselves by scope so that
+// `hydrateScope` can reconcile all keys for a scope in ONE round-trip.
+
+/** Internal handle stored in the scope registry. */
+interface PersistedStateHandle<T> {
+  readonly lsKey: string | null; // null when bootCache:false
+  readonly settingsKey: string;
+  readonly defaultValue: T;
+  setFromDb(value: unknown): void;
+  getForLegacyImport(): unknown; // the current localStorage raw value (pre-parse)
+}
+
+const scopeRegistry = new Map<string, Set<PersistedStateHandle<unknown>>>();
+
+function registerHandle<T>(
+  scope: string,
+  handle: PersistedStateHandle<T>,
+): void {
+  let set = scopeRegistry.get(scope);
+  if (!set) {
+    set = new Set();
+    scopeRegistry.set(scope, set);
+  }
+  (set as Set<PersistedStateHandle<unknown>>).add(
+    handle as PersistedStateHandle<unknown>,
+  );
+}
+
+// ── Tauri IPC helpers ─────────────────────────────────────────────────────────
+//
+// Memoised dynamic import — same pattern as theme.ts to prevent a Vitest
+// dev-mode dynamic-import race when two callers both perform the first
+// `import()` of the same mocked specifier concurrently.
+
+let tauriCorePromise: Promise<typeof import('@tauri-apps/api/core')> | null =
+  null;
+function importTauriCore(): Promise<typeof import('@tauri-apps/api/core')> {
+  if (!tauriCorePromise) {
+    tauriCorePromise = import('@tauri-apps/api/core');
+  }
+  return tauriCorePromise;
+}
+
+// ── Debounce helper ───────────────────────────────────────────────────────────
+
+function debounce<T extends unknown[]>(
+  fn: (...args: T) => void,
+  ms: number,
+): (...args: T) => void {
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  return (...args: T) => {
+    if (timer !== null) clearTimeout(timer);
+    timer = setTimeout(() => {
+      timer = null;
+      fn(...args);
+    }, ms);
+  };
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+export interface PersistedStateOptions<T> {
+  /** In-memory and localStorage default when no stored value exists. */
+  default: T;
+  /**
+   * Write a localStorage boot cache on every `set()` call (default `true`).
+   * Set to `false` for state not needed before first paint.
+   */
+  bootCache?: boolean;
+  /**
+   * Debounce window for the SQLite write-behind (ms). Default 500.
+   * Reducing this makes writes more frequent; increasing it coalesces rapid
+   * changes at the cost of a larger window of SQLite staleness.
+   */
+  debounceMs?: number;
+}
+
+export interface PersistedStateResult<T> {
+  /** Synchronous read — always returns the current in-memory value. */
+  get(): T;
+  /** Update in-memory + localStorage + schedule debounced SQLite write. */
+  set(value: T): void;
+  /**
+   * Subscribe to changes. Returns an unsubscribe function.
+   * Directly compatible with `useSyncExternalStore`.
+   */
+  subscribe(listener: () => void): () => void;
+  /**
+   * Reconcile in-memory + localStorage from the DB response object produced by
+   * `hydrateScope`. Not called directly by consumers — call `hydrateScope`
+   * instead, which issues the batch `settingsGet` and calls this on each key.
+   */
+  _reconcileFromDbValues(values: Record<string, unknown>): void;
+}
+
+/**
+ * Create a persisted state atom backed by SQLite (durable) and localStorage
+ * (synchronous boot cache).
+ *
+ * @param scope      Settings scope for the SQLite key (e.g. `"ui_state"`).
+ * @param key        Stable settings key within the scope (e.g.
+ *                   `"uiState.logPanelExpanded"`).
+ * @param opts       Options including the default value, boot-cache flag, and
+ *                   debounce window.
+ */
+export function createPersistedState<T>(
+  scope: string,
+  key: string,
+  opts: PersistedStateOptions<T>,
+): PersistedStateResult<T> {
+  const bootCache = opts.bootCache !== false;
+  const debounceMs = opts.debounceMs ?? 500;
+  const lsKey = bootCache ? `alm.ps.${key}` : null;
+
+  // ── In-memory state ────────────────────────────────────────────────────────
+
+  let current: T = readBootCache<T>(lsKey, opts.default);
+  const listeners = new Set<() => void>();
+
+  function notify(): void {
+    for (const l of listeners) l();
+  }
+
+  // ── Debounced SQLite write ─────────────────────────────────────────────────
+
+  const persistToDb = debounce((value: T) => {
+    void (async () => {
+      try {
+        const { isTauri } = await importTauriCore();
+        if (!isTauri()) return;
+        const [{ commands }, { unwrap }] = await Promise.all([
+          import('@/bindings/index'),
+          import('@/api/ipc'),
+        ]);
+        unwrap(await commands.settingsUpdate(scope, { [key]: value }));
+      } catch {
+        // Best-effort — a DB write failure never blocks or reverts the UI change.
+      }
+    })();
+  }, debounceMs);
+
+  // ── Handle for the scope registry ─────────────────────────────────────────
+
+  const handle: PersistedStateHandle<T> = {
+    lsKey,
+    settingsKey: key,
+    defaultValue: opts.default,
+
+    setFromDb(dbValue: unknown): void {
+      const parsed = safeParse<T>(dbValue, opts.default);
+      if (!shallowEqual(parsed, current)) {
+        current = parsed;
+        writeBootCache(lsKey, current);
+        notify();
+      }
+    },
+
+    getForLegacyImport(): unknown {
+      if (!lsKey) return undefined;
+      try {
+        return window.localStorage.getItem(lsKey) ?? undefined;
+      } catch {
+        return undefined;
+      }
+    },
+  };
+
+  registerHandle(scope, handle);
+
+  // ── Returned API ──────────────────────────────────────────────────────────
+
+  return {
+    get(): T {
+      return current;
+    },
+
+    set(value: T): void {
+      current = value;
+      writeBootCache(lsKey, value);
+      notify();
+      persistToDb(value);
+    },
+
+    subscribe(listener: () => void): () => void {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+
+    _reconcileFromDbValues(values: Record<string, unknown>): void {
+      handle.setFromDb(values[key]);
+    },
+  };
+}
+
+// ── Scope hydration ───────────────────────────────────────────────────────────
+
+/**
+ * Reconcile all keys registered under `scope` from the SQLite settings DB in
+ * ONE `settingsGet` round-trip. Call once per scope at boot after Tauri IPC is
+ * available. No-ops outside Tauri or on IPC failure (localStorage stays
+ * authoritative until the next successful call).
+ *
+ * One-time legacy import: for any key where the DB row is absent but a legacy
+ * localStorage value exists, the value is imported into SQLite automatically.
+ */
+export async function hydrateScope(scope: string): Promise<void> {
+  try {
+    const { isTauri } = await importTauriCore();
+    if (!isTauri()) return;
+
+    const handles = scopeRegistry.get(scope);
+    if (!handles || handles.size === 0) return;
+
+    const [{ commands }, { unwrap }] = await Promise.all([
+      import('@/bindings/index'),
+      import('@/api/ipc'),
+    ]);
+
+    const data = unwrap(await commands.settingsGet(scope));
+    const values = data.values as Record<string, unknown>;
+
+    const legacyImports: Record<string, unknown> = {};
+
+    for (const h of handles) {
+      const dbValue = values[h.settingsKey];
+
+      if (dbValue === undefined || dbValue === null) {
+        // Key absent from DB — check for a legacy localStorage value to import.
+        const legacy = h.getForLegacyImport();
+        if (legacy !== undefined) {
+          legacyImports[h.settingsKey] = legacy;
+        }
+        // Keep current in-memory value (localStorage already loaded at init).
+        continue;
+      }
+
+      h.setFromDb(dbValue);
+    }
+
+    // Flush legacy imports into SQLite in one write (best-effort).
+    if (Object.keys(legacyImports).length > 0) {
+      try {
+        unwrap(await commands.settingsUpdate(scope, legacyImports));
+      } catch {
+        // Legacy import is best-effort.
+      }
+    }
+  } catch {
+    // Keep the current localStorage-cached values authoritative.
+  }
+}
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Read and parse a localStorage boot-cache entry; returns `defaultValue` on miss or error. */
+function readBootCache<T>(lsKey: string | null, defaultValue: T): T {
+  if (!lsKey) return defaultValue;
+  try {
+    const raw = window.localStorage.getItem(lsKey);
+    if (raw === null) return defaultValue;
+    return JSON.parse(raw) as T;
+  } catch {
+    return defaultValue;
+  }
+}
+
+/** Write a value to localStorage; silently no-ops on failure. */
+function writeBootCache<T>(lsKey: string | null, value: T): void {
+  if (!lsKey) return;
+  try {
+    window.localStorage.setItem(lsKey, JSON.stringify(value));
+  } catch {
+    // Storage full or unavailable — non-fatal.
+  }
+}
+
+/**
+ * Parse an opaque DB value into `T`; returns `defaultValue` when the DB
+ * value is `null`/`undefined` or is unparseable. For primitive types (string,
+ * number, boolean) this is a direct cast; for structured types (arrays,
+ * objects) JSON round-trip through `JSON.parse(JSON.stringify(...))` ensures
+ * a clean parse without trusting the DB shape blindly.
+ */
+function safeParse<T>(value: unknown, defaultValue: T): T {
+  if (value === undefined || value === null) return defaultValue;
+  try {
+    // For plain JSON-compatible types the DB value IS already the parsed form
+    // (Tauri deserialized the JSON row into a JS value). No extra parse needed;
+    // just cast and let the caller validate if needed.
+    return value as T;
+  } catch {
+    return defaultValue;
+  }
+}
+
+/**
+ * Shallow equality check used to skip notify() when the hydrated DB value
+ * matches what's already in memory, preventing spurious re-renders.
+ *
+ * For arrays and objects this compares JSON serialisation — adequate for the
+ * simple scalar / string-array types used by UI state keys; deep equality
+ * isn't needed here.
+ */
+function shallowEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (typeof a === 'object') {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+// ── Test helpers ──────────────────────────────────────────────────────────────
+
+/**
+ * Reset all scope registrations. Test-only — clears the module-level registry
+ * so tests don't leak state across `createPersistedState` calls.
+ */
+export function __resetScopeRegistryForTest(): void {
+  scopeRegistry.clear();
+  // Also reset the memoised Tauri core promise so mock re-imports work.
+  tauriCorePromise = null;
+}

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
@@ -29,10 +29,17 @@ import {
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { InboxList } from '../InboxList';
 import { FilterToolbar } from '@/components';
-import { useGrouping } from '@/lib/use-grouping';
+import {
+  useGrouping,
+  __resetGroupingRegistryForTest,
+} from '@/lib/use-grouping';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from '../InboxControls';
 import type { InboxListItem } from '@/bindings/index';
 import { assertDefined } from '@/test/assertDefined';
+import { __resetScopeRegistryForTest } from '@/data/persisted-state';
+
+/** localStorage key for the inbox grouping boot cache (new persisted-state key). */
+const GROUPING_PS_LS_KEY = `alm.ps.uiState.${GROUPING_STORAGE_KEY}`;
 
 // ── Harness ───────────────────────────────────────────────────────────────────
 // Mirrors InboxPage's wiring: useGrouping owns the grouping state,
@@ -113,6 +120,9 @@ const items: InboxListItem[] = [
 
 beforeEach(() => {
   localStorage.clear();
+  // Reset module-level registries so tests don't share state.
+  __resetGroupingRegistryForTest();
+  __resetScopeRegistryForTest();
 });
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -233,7 +243,7 @@ describe('InboxList — configurable grouping', () => {
     });
 
     const storedDims = assertDefined(
-      localStorage.getItem(GROUPING_STORAGE_KEY),
+      localStorage.getItem(GROUPING_PS_LS_KEY),
       'GROUPING_STORAGE_KEY entry in localStorage',
     );
     expect(JSON.parse(storedDims)).toEqual(['target', 'frameType']);

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.grouping.test.tsx
@@ -39,7 +39,7 @@ import { assertDefined } from '@/test/assertDefined';
 import { __resetScopeRegistryForTest } from '@/data/persisted-state';
 
 /** localStorage key for the inbox grouping boot cache (new persisted-state key). */
-const GROUPING_PS_LS_KEY = `alm.ps.uiState.${GROUPING_STORAGE_KEY}`;
+const GROUPING_PS_LS_KEY = `pv.ps.uiState.${GROUPING_STORAGE_KEY}`;
 
 // ── Harness ───────────────────────────────────────────────────────────────────
 // Mirrors InboxPage's wiring: useGrouping owns the grouping state,

--- a/apps/desktop/src/features/inbox/__tests__/InboxList.virtualization.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxList.virtualization.test.tsx
@@ -33,9 +33,13 @@ import {
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { InboxList } from '../InboxList';
 import { FilterToolbar } from '@/components';
-import { useGrouping } from '@/lib/use-grouping';
+import {
+  useGrouping,
+  __resetGroupingRegistryForTest,
+} from '@/lib/use-grouping';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from '../InboxControls';
 import type { InboxListItem } from '@/bindings/index';
+import { __resetScopeRegistryForTest } from '@/data/persisted-state';
 
 // Harness mirroring InboxPage: useGrouping + FilterToolbar.grouping feed InboxList.
 function Harness({ items }: { items: InboxListItem[] }) {
@@ -116,6 +120,8 @@ function rect(height: number): DOMRect {
 
 beforeEach(() => {
   localStorage.clear();
+  __resetGroupingRegistryForTest();
+  __resetScopeRegistryForTest();
   gbcrSpy = vi
     .spyOn(HTMLElement.prototype, 'getBoundingClientRect')
     .mockImplementation(() => rect(ROW_PX));

--- a/apps/desktop/src/lib/use-grouping.ts
+++ b/apps/desktop/src/lib/use-grouping.ts
@@ -7,15 +7,45 @@
  * Generalised from the Inbox's `useInboxControls` (spec 041 T021) so every list
  * page gets the SAME "Group by X, then by Y, then by Z" capability via the
  * shared `FilterToolbar` grouping control. The hook owns only the ordered
- * dimension ids + their localStorage persistence; each page supplies its own
- * valid dimension ids + a storage key, and feeds `dims` to its table's
- * `groupByDimensions` call.
+ * dimension ids + their persistence; each page supplies its own valid dimension
+ * ids + a storage key, and feeds `dims` to its table's `groupByDimensions` call.
+ *
+ * Persistence: all grouping state lives in SQLite (`ui_state` scope) with a
+ * localStorage boot cache. The settings key is `uiState.<storageKey>` (e.g.
+ * `uiState.targets.grouping.dims.v1`). On first hydrate the old plain
+ * localStorage key is imported automatically.
  */
 
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState, useSyncExternalStore } from 'react';
+import {
+  createPersistedState,
+  type PersistedStateResult,
+} from '@/data/persisted-state';
+
+// Module-level registry: one PersistedState instance per storageKey so
+// multiple renders of the same page share state and don't leak subscriptions.
+const groupingRegistry = new Map<string, PersistedStateResult<string[]>>();
+
+function getGroupingState(
+  storageKey: string,
+  defaultDims: readonly string[],
+): PersistedStateResult<string[]> {
+  let instance = groupingRegistry.get(storageKey);
+  if (!instance) {
+    instance = createPersistedState('ui_state', `uiState.${storageKey}`, {
+      default: [...defaultDims],
+    });
+    groupingRegistry.set(storageKey, instance);
+  }
+  return instance;
+}
 
 export interface UseGroupingOptions {
-  /** localStorage key for the persisted ordered dimensions (per page). */
+  /**
+   * Stable per-page key (e.g. `"targets.grouping.dims.v1"`). Used as both the
+   * SQLite settings key suffix (`uiState.<storageKey>`) and the legacy
+   * localStorage migration key.
+   */
   storageKey: string;
   /** Dimension ids this page allows (persisted values are validated against it). */
   validIds: readonly string[];
@@ -43,58 +73,48 @@ export function useGrouping({
   defaultDims = [],
 }: UseGroupingOptions): UseGroupingResult {
   const valid = new Set(validIds);
+  const state = getGroupingState(storageKey, defaultDims);
 
-  const load = useCallback((): string[] => {
-    try {
-      const raw = localStorage.getItem(storageKey);
-      if (!raw) {
-        return defaultDims.filter((d) => valid.has(d)).slice(0, maxLevels);
-      }
-      const parsed = JSON.parse(raw);
-      if (!Array.isArray(parsed)) return [];
-      const seen = new Set<string>();
-      const out: string[] = [];
-      for (const d of parsed) {
-        if (typeof d === 'string' && valid.has(d) && !seen.has(d)) {
-          seen.add(d);
-          out.push(d);
-          if (out.length >= maxLevels) break;
-        }
-      }
-      return out;
-    } catch {
-      return [];
-    }
-    // `valid` is derived from validIds; depend on the stable storageKey + maxLevels.
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [storageKey, maxLevels]);
+  const rawDims = useSyncExternalStore(state.subscribe, state.get, state.get);
 
-  const [dims, setDims] = useState<string[]>(() => load());
-
-  useEffect(() => {
-    try {
-      localStorage.setItem(storageKey, JSON.stringify(dims));
-    } catch {
-      /* storage unavailable — non-fatal */
-    }
-  }, [storageKey, dims]);
+  // Validate stored dims against the page's valid id set and maxLevels.
+  const dims = validateDims(rawDims, valid, maxLevels);
 
   const setSlot = useCallback(
     (slot: number, value: string) => {
-      setDims((prev) => {
-        const next = prev.slice(0, slot);
-        if (value !== '') {
-          const deduped = next.filter((d) => d !== value);
-          deduped.push(value);
-          return deduped.slice(0, maxLevels);
-        }
-        return next;
-      });
+      const prev = validateDims(state.get(), valid, maxLevels);
+      const next = prev.slice(0, slot);
+      if (value !== '') {
+        const deduped = next.filter((d) => d !== value);
+        deduped.push(value);
+        state.set(deduped.slice(0, maxLevels));
+      } else {
+        state.set(next);
+      }
     },
-    [maxLevels],
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [state, maxLevels],
   );
 
   return { dims, setSlot };
+}
+
+/** Filter + deduplicate dims against the page's valid id set. */
+function validateDims(
+  raw: string[],
+  valid: Set<string>,
+  maxLevels: number,
+): string[] {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const d of raw) {
+    if (typeof d === 'string' && valid.has(d) && !seen.has(d)) {
+      seen.add(d);
+      out.push(d);
+      if (out.length >= maxLevels) break;
+    }
+  }
+  return out;
 }
 
 export interface UseCollapsibleGroupsResult {
@@ -119,4 +139,13 @@ export function useCollapsibleGroups(): UseCollapsibleGroupsResult {
     });
   }, []);
   return { collapsed, toggle };
+}
+
+/**
+ * Test-only: clear the per-storageKey PersistedState registry so tests don't
+ * bleed state across renders. Also call `__resetScopeRegistryForTest()` from
+ * `persisted-state.ts` to avoid stale scope registrations.
+ */
+export function __resetGroupingRegistryForTest(): void {
+  groupingRegistry.clear();
 }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -35,22 +35,13 @@ initAppearance();
 // once if the two disagree (e.g. localStorage lost to a WebView2 force-kill).
 void hydrateThemeFromSettings();
 
-// Reconcile all ui_state scope keys (log-panel, grouping dims, picker paths)
-// from SQLite. Same fire-and-forget contract: localStorage is authoritative
-// until this resolves; on disagreement the DB value wins (matching theme
-// semantics). All createPersistedState call sites for scope "ui_state" must
-// be imported before this fires — they register their handles at module-eval
-// time, and the dynamic imports below ensure the modules are loaded.
-void (async () => {
-  // Force the modules that register ui_state handles to load before calling
-  // hydrateScope, so their handles are in the registry.
-  await Promise.all([
-    import('./app/LogPanelContext'),
-    import('./shared/native/picker'),
-    import('./lib/use-grouping'),
-  ]);
-  void hydrateScope('ui_state');
-})();
+// Reconcile ui_state scope keys (log-panel, grouping dims, picker paths) from
+// SQLite. Same fire-and-forget contract as `hydrateThemeFromSettings`: DB is
+// the durable source of truth; localStorage is authoritative until this call
+// resolves. Handles that register AFTER this call (lazy picker/grouping state
+// created on first user interaction) reconcile immediately from the cached DB
+// map inside `createPersistedState` — no second IPC round-trip.
+void hydrateScope('ui_state');
 
 // T075 / SC-002: Install the recording proxy at boot in dev-tools builds.
 // VITE_DEV_TOOLS is statically "false" in release builds, so this branch and

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -12,6 +12,7 @@ import { router } from './app/router';
 import { AppErrorBoundary } from './app/AppErrorBoundary';
 import { queryClient } from './data/queryClient';
 import { initAppearance, hydrateThemeFromSettings } from './data/theme';
+import { hydrateScope } from './data/persisted-state';
 import { registerLocaleStrategy, LocaleProvider } from './data/locale';
 
 // Register the `custom-almSettings` strategy before the first render, so the
@@ -33,6 +34,23 @@ initAppearance();
 // synchronous cache has already painted, and this at most swaps the theme
 // once if the two disagree (e.g. localStorage lost to a WebView2 force-kill).
 void hydrateThemeFromSettings();
+
+// Reconcile all ui_state scope keys (log-panel, grouping dims, picker paths)
+// from SQLite. Same fire-and-forget contract: localStorage is authoritative
+// until this resolves; on disagreement the DB value wins (matching theme
+// semantics). All createPersistedState call sites for scope "ui_state" must
+// be imported before this fires — they register their handles at module-eval
+// time, and the dynamic imports below ensure the modules are loaded.
+void (async () => {
+  // Force the modules that register ui_state handles to load before calling
+  // hydrateScope, so their handles are in the registry.
+  await Promise.all([
+    import('./app/LogPanelContext'),
+    import('./shared/native/picker'),
+    import('./lib/use-grouping'),
+  ]);
+  void hydrateScope('ui_state');
+})();
 
 // T075 / SC-002: Install the recording proxy at boot in dev-tools builds.
 // VITE_DEV_TOOLS is statically "false" in release builds, so this branch and

--- a/apps/desktop/src/shared/native/picker.ts
+++ b/apps/desktop/src/shared/native/picker.ts
@@ -98,9 +98,13 @@ function lastPathState(
 ): ReturnType<typeof createPersistedState<string | null>> {
   let s = lastPathStates.get(kind);
   if (!s) {
-    s = createPersistedState('ui_state', `uiState.lastPath.${kind}`, {
-      default: null,
-    });
+    s = createPersistedState<string | null>(
+      'ui_state',
+      `uiState.lastPath.${kind}`,
+      {
+        default: null,
+      },
+    );
     lastPathStates.set(kind, s);
   }
   return s;

--- a/apps/desktop/src/shared/native/picker.ts
+++ b/apps/desktop/src/shared/native/picker.ts
@@ -21,6 +21,7 @@ import type {
   DirectoryPickResponse,
   FilePickResponse_Serialize,
 } from '@/bindings/index';
+import { createPersistedState } from '@/data/persisted-state';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -81,22 +82,36 @@ export function calibrationFileFilters(): FileFilter[] {
 }
 
 // ---------------------------------------------------------------------------
-// Last-path localStorage helpers (T012)
+// Last-path persistence helpers (T012) — SQLite-backed via ui_state scope
 // ---------------------------------------------------------------------------
 
-const LAST_PATH_PREFIX = 'alm.lastPath.';
+// One PersistedState instance per affordance kind, created lazily. These are
+// module-level so multiple picker calls share the same instance and don't
+// register duplicate scope entries.
+const lastPathStates = new Map<
+  LastPathKind,
+  ReturnType<typeof createPersistedState<string | null>>
+>();
+
+function lastPathState(
+  kind: LastPathKind,
+): ReturnType<typeof createPersistedState<string | null>> {
+  let s = lastPathStates.get(kind);
+  if (!s) {
+    s = createPersistedState('ui_state', `uiState.lastPath.${kind}`, {
+      default: null,
+    });
+    lastPathStates.set(kind, s);
+  }
+  return s;
+}
 
 /**
- * Read the last-used path for a given affordance kind from localStorage.
+ * Read the last-used path for a given affordance kind.
  * Returns `undefined` if no stored path exists.
  */
 export function getLastPath(kind: LastPathKind): string | undefined {
-  try {
-    const value = localStorage.getItem(`${LAST_PATH_PREFIX}${kind}`);
-    return value ?? undefined;
-  } catch {
-    return undefined;
-  }
+  return lastPathState(kind).get() ?? undefined;
 }
 
 /**
@@ -104,12 +119,8 @@ export function getLastPath(kind: LastPathKind): string | undefined {
  * the given affordance kind.
  */
 export function setLastPath(kind: LastPathKind, selectedPath: string): void {
-  try {
-    const parent = parentDir(selectedPath);
-    localStorage.setItem(`${LAST_PATH_PREFIX}${kind}`, parent);
-  } catch {
-    // localStorage unavailable or full -- proceed without persistence
-  }
+  const parent = parentDir(selectedPath);
+  lastPathState(kind).set(parent);
 }
 
 /**
@@ -128,31 +139,26 @@ function parentDir(filePath: string): string {
 }
 
 // ---------------------------------------------------------------------------
-// Selected-filter persistence (T021)
+// Selected-filter persistence (T021) — SQLite-backed via ui_state scope
 // ---------------------------------------------------------------------------
 
-const SELECTED_FILTER_KEY = 'alm.selectedFilter';
+const selectedFilterState = createPersistedState(
+  'ui_state',
+  'uiState.selectedFilter',
+  { default: null as string | null },
+);
 
 /**
  * Persist the selected file-type filter alongside the last pick, so
  * downstream forms can read the user's preference.
  */
 export function setSelectedFilter(filterName: string): void {
-  try {
-    localStorage.setItem(SELECTED_FILTER_KEY, filterName);
-  } catch {
-    // proceed without persistence
-  }
+  selectedFilterState.set(filterName);
 }
 
 /** Read the last-selected file-type filter, if any. */
 export function getSelectedFilter(): string | undefined {
-  try {
-    const value = localStorage.getItem(SELECTED_FILTER_KEY);
-    return value ?? undefined;
-  } catch {
-    return undefined;
-  }
+  return selectedFilterState.get() ?? undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/app/settings/src/keys.rs
+++ b/crates/app/settings/src/keys.rs
@@ -81,6 +81,7 @@ pub fn is_valid_key(key: &str) -> bool {
         || is_workflow_profile_attribution_window_key(key)
         || is_catalogues_enabled_key(key)
         || is_locale_key(key)
+        || is_ui_state_key(key)
 }
 
 /// `enabled` (#645, scope `"catalogues"`): default-enabled Planner catalogue
@@ -196,4 +197,21 @@ pub fn is_workflow_profile_attribution_window_key(key: &str) -> bool {
         }
     }
     false
+}
+
+// ── UI state keys (persisted-ui-state, 2026-07-24) ───────────────────────────
+//
+// Keys in the `ui_state` scope use the `uiState.` prefix and hold ephemeral
+// UI choices (panel open/closed, grouping dims, dock placement, last paths)
+// that survive restart via SQLite but carry no audit obligation. The backend
+// stores them as plain JSON rows in the generic settings table; no descriptor
+// entry is needed because all validation is handled client-side.
+//
+// The prefix is intentionally open-ended: any `uiState.*` key is accepted,
+// letting the frontend add new keys without a Rust change per key.
+
+/// Whether `key` is a UI-state key (`uiState.` prefix).
+#[must_use]
+pub fn is_ui_state_key(key: &str) -> bool {
+    key.starts_with("uiState.")
 }

--- a/crates/app/settings/src/lib.rs
+++ b/crates/app/settings/src/lib.rs
@@ -86,7 +86,9 @@ mod writes;
 #[cfg(test)]
 mod tests;
 
-pub use keys::{is_global_protection_default_key, is_valid_key, overridable_keys, stable_keys};
+pub use keys::{
+    is_global_protection_default_key, is_ui_state_key, is_valid_key, overridable_keys, stable_keys,
+};
 pub use read::get_settings;
 pub use validation::{settings_value_eq, validate_value};
 pub use writes::{

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -87,6 +87,29 @@ pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
     Ok(rows.into_iter().map(|(key, Json(v))| (key, v)).collect())
 }
 
+/// Read all stored rows whose key starts with `prefix` (e.g. `"uiState."`).
+///
+/// Returns only rows that exist in the database; missing keys carry no default
+/// (the caller decides the fallback). Used by the `ui_state` scope to batch-
+/// read all persisted UI state keys without enumerating them at the Rust layer.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn get_all_by_prefix(pool: &SqlitePool, prefix: &str) -> DbResult<Vec<(String, Value)>> {
+    // SQLite LIKE pattern: append '%' to the prefix. The prefix itself may
+    // contain literal '%' or '_' — escape them so they are matched literally.
+    let pattern = format!("{}%", prefix.replace('%', "\\%").replace('_', "\\_"));
+    let rows: Vec<(String, Json<Value>)> = sqlx::query_as(
+        "SELECT key, value FROM settings WHERE key LIKE ? ESCAPE '\\' ORDER BY key ASC",
+    )
+    .bind(&pattern)
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows.into_iter().map(|(key, Json(v))| (key, v)).collect())
+}
+
 // ── High-level settings bag ───────────────────────────────────────────────
 
 /// Load the full settings state, merging stored rows with in-code defaults.


### PR DESCRIPTION
## Summary

UI choices -- log panel open/closed, list grouping dimensions, and file picker last directory -- now survive app restarts. Previously these were localStorage-only and could be lost on a forced kill (Windows WebView2 only flushes localStorage on graceful shutdown). They are now written to the same SQLite store used for all other settings.

## What's new

- Log panel expanded/collapsed state persists across restarts.
- Table grouping dimensions (Targets, Sessions, Projects, Inbox) persist across restarts.
- Native file/directory picker remembers the last used directory and file-type filter across restarts.

## Key design choices

- Boot-cache localStorage key prefix: `pv.ps.*` (aligned with repo-wide alm->pv rename). Greenfield: no existing users, no migration needed.
- Hydration: `hydrateScope('ui_state')` wired in `main.tsx` alongside `hydrateThemeFromSettings` -- same fire-and-forget contract, SQLite wins on disagreement.
- Naming note: the production DB filename (`alm.db` in `main.rs`) is out of scope for this PR and tracked in the naming-sweep bead.

## Beads

Tracks-Bead: astro-plan-kyo7.67
Closes-Bead: astro-plan-kyo7.67
Merge-Bead: astro-plan-rsdi
