### PR TITLE
feat: sessions with 180-degree-equivalent camera rotation cluster into the same framing

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1068,45 +1068,16 @@ jobs:
         if: matrix.shard == 1
         shell: bash
         run: |
-          SHARD1='\
-            test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | \
-            test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | \
-            test(=inbox_ui_mixed_folder_splits_into_single_type_items) | \
-            test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | \
-            test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
-          SHARD2='\
-            test(=slow_archive_lifecycle_apply_trash_permanent_delete) | \
-            test(=targets_planner_real_astronomy_after_site_creation) | \
-            test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | \
-            binary(calibration_ui_journeys) | \
-            binary(lifecycle_ui_journeys) | \
-            binary(source_view_journeys) | \
-            test(=ingestion_sessions_search) | \
-            binary(sessions_journeys) | \
-            test(=plan_review_empty_archive_plan_refuses_apply) | \
-            test(=plan_review_apply_with_audit) | \
-            test(=lifecycle_integrity)'
-          SHARD3='\
-            test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | \
-            binary(smoke) | \
-            test(=targets_ui_add_target_no_duplicate_on_reconfirm) | \
-            binary(inventory_journeys) | \
-            test(=cleanup_plan_review) | \
-            test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | \
-            test(=plan_review_destructive_confirm_gate_and_apply) | \
-            test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | \
-            binary(onboarding_journey) | \
-            binary(cleanup_protection_gate_journey) | \
-            test(=first_run_resolve_create_project) | \
-            test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | \
-            test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
+          SHARD1='test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
+          SHARD2='test(=slow_archive_lifecycle_apply_trash_permanent_delete) | test(=targets_planner_real_astronomy_after_site_creation) | test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(source_view_journeys) | test(=ingestion_sessions_search) | binary(sessions_journeys) | test(=plan_review_empty_archive_plan_refuses_apply) | test(=plan_review_apply_with_audit) | test(=lifecycle_integrity)'
+          SHARD3='test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | binary(smoke) | test(=targets_ui_add_target_no_duplicate_on_reconfirm) | binary(inventory_journeys) | test(=cleanup_plan_review) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=plan_review_destructive_confirm_gate_and_apply) | test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(onboarding_journey) | binary(cleanup_protection_gate_journey) | test(=first_run_resolve_create_project) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
           TOTAL=$(cargo nextest list \
             --archive-file e2e-archive.tar.zst --workspace-remap . \
-            --run-ignored all --message-format oneline 2>/dev/null | wc -l)
+            --run-ignored all --message-format oneline | wc -l)
           UNION=$(cargo nextest list \
             --archive-file e2e-archive.tar.zst --workspace-remap . \
             --run-ignored all --message-format oneline \
-            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" 2>/dev/null | wc -l)
+            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" | wc -l)
           echo "Total tests: ${TOTAL}, covered by shard union: ${UNION}"
           if [ "${TOTAL}" != "${UNION}" ]; then
             echo "::error::Shard coverage gap: ${TOTAL} tests in archive but only ${UNION} covered by the three shard filters. Add the missing test(s) to an -E expression."

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ dependencies = [
  "sessions",
  "sha2 0.10.9",
  "simbad-resolver",
- "skymath",
+ "skymath 0.6.0",
  "sqlx",
  "target-match",
  "targeting",
@@ -815,7 +815,7 @@ version = "0.1.0"
 dependencies = [
  "serde",
  "serde_json",
- "skymath",
+ "skymath 0.7.1",
  "time",
 ]
 
@@ -1388,7 +1388,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath",
+ "skymath 0.6.0",
  "specta",
  "specta-typescript",
  "sqlx",
@@ -1787,7 +1787,7 @@ version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9f03c8e9bb8afa98de1186e5237a70d2e907b239a9c1f0d523131402cc0b326"
 dependencies = [
- "skymath",
+ "skymath 0.6.0",
  "thiserror 2.0.19",
  "time",
 ]
@@ -3287,7 +3287,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
- "skymath",
+ "skymath 0.6.0",
  "thiserror 2.0.19",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -5410,7 +5410,7 @@ name = "sessions"
 version = "0.1.0"
 dependencies = [
  "domain_core",
- "skymath",
+ "skymath 0.7.1",
  "thiserror 2.0.19",
  "time",
  "uuid",
@@ -5502,7 +5502,7 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
- "skymath",
+ "skymath 0.6.0",
  "thiserror 2.0.19",
  "time",
  "tokio",
@@ -5545,6 +5545,16 @@ name = "skymath"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a79e14882fa3b8890da09ab6c285953fc3ad0fa801bdb73bacf1492309091c"
+dependencies = [
+ "thiserror 2.0.19",
+ "time",
+]
+
+[[package]]
+name = "skymath"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fe8c5c80aca9d4212b3b0a5f743d8e9f5c945e221136f346c5b141149e68660"
 dependencies = [
  "thiserror 2.0.19",
  "time",
@@ -6133,7 +6143,7 @@ checksum = "23a0b58f5c23ca0507df3dd8ceb2a382a388acbdec8b8dd323f68dc5490fa796"
 dependencies = [
  "geo",
  "geo-types",
- "skymath",
+ "skymath 0.6.0",
  "thiserror 2.0.19",
 ]
 
@@ -6142,7 +6152,7 @@ name = "targeting"
 version = "0.1.0"
 dependencies = [
  "simbad-resolver",
- "skymath",
+ "skymath 0.6.0",
  "target-match",
  "uuid",
 ]
@@ -6158,7 +6168,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath",
+ "skymath 0.6.0",
  "sqlx",
  "targeting",
  "tempfile",
@@ -8313,7 +8323,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5946a5236693506e10bf909a69d249b62affc50d0fcc5e37fa08b12ee614e033"
 dependencies = [
  "quick-xml",
- "skymath",
+ "skymath 0.6.0",
  "thiserror 2.0.19",
  "time",
 ]

--- a/crates/app/inbox/src/attribution.rs
+++ b/crates/app/inbox/src/attribution.rs
@@ -60,7 +60,7 @@ use persistence_targets::repositories::framing as framing_repo;
 use persistence_targets::repositories::q_resolver;
 use sessions::{
     angular_separation_deg, optic_train_key as compute_optic_train_key,
-    rotation_circular_distance_deg, ToleranceParams,
+    rotation_axial_distance_deg, ToleranceParams,
 };
 use sqlx::SqlitePool;
 
@@ -367,7 +367,7 @@ fn best_matching_framing(
         }
         #[allow(clippy::cast_possible_truncation)]
         let f_rotation = f.rotation_deg as f32;
-        let rot_dist = rotation_circular_distance_deg(item_rotation, f_rotation);
+        let rot_dist = rotation_axial_distance_deg(item_rotation, f_rotation);
         if rot_dist > f64::from(rotation_tolerance_deg) {
             continue;
         }

--- a/crates/calibration/core/Cargo.toml
+++ b/crates/calibration/core/Cargo.toml
@@ -12,7 +12,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 # Issue #921: circular_distance replaces the hand-rolled `(a - b).abs()` flat
 # rotation delta, which max-penalized correct flats straddling the 0/360 seam.
-skymath = "0.6.0"
+skymath = "0.7.1"
 # spec 042 (T201): ISO-8601 date parsing + Julian-day arithmetic for
 # observing-night proximity (replaces the hand-rolled YMD parse + JDN math).
 time = { workspace = true }

--- a/crates/sessions/Cargo.toml
+++ b/crates/sessions/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 domain_core = { path = "../domain/core" }
-skymath = "0.6.0"
+skymath = "0.7.1"
 thiserror = { workspace = true }
 time = { workspace = true }
 

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -39,14 +39,16 @@
 //!   rotation are excluded from clustering and returned as `Unassigned`
 //!   (never zero-defaulted) — data-model.md §211, R11 "NULL-geometry
 //!   sessions are excluded" note.
-//! - **Rotation wraparound**: compared as a circular quantity modulo 360°
-//!   (shortest arc, range `[0, 180]`), matching the RA treatment. R11a's
-//!   rationale text ("meridian-flip camera-angle drift stays inside [the 3°
-//!   tolerance]") describes flip drift as small, not a ~180° jump — NINA-style
-//!   field derotators hold sky position angle across a flip — so plain mod-360
-//!   wraparound (not mod-180) is the correct model; a mod-180 model would
-//!   incorrectly treat a deliberately-rotated composition 180° away as the
-//!   same framing.
+//! - **Rotation wraparound**: compared as an *axial* quantity modulo 180°
+//!   (shortest arc between undirected image axes, range `[0, 90]`), per spec
+//!   062 FR-025. A rectangular sensor rotated 180° captures the identical sky
+//!   footprint — θ and θ+180° are the same framing, whether the half-turn
+//!   comes from a meridian flip, a rotator re-park, or independent sessions
+//!   that happen to land 180° apart. (An earlier revision used mod-360 on the
+//!   theory that a "deliberately-rotated composition 180° away" is a distinct
+//!   framing; it is not — rotating a composition 180° reproduces the same
+//!   composition.) Image parity (mirror flips) is not detectable from the
+//!   rotation angle at all and remains a separate evidence dimension.
 
 use std::collections::BTreeMap;
 
@@ -458,7 +460,7 @@ fn best_matching_group(
                 return None;
             }
             let rotation_distance =
-                rotation_circular_distance_deg(rotation_deg, group.representative_rotation_deg());
+                rotation_axial_distance_deg(rotation_deg, group.representative_rotation_deg());
             // Epsilon guards the inclusive boundary: skymath's circular
             // distance round-trips through radians, so a degree input exactly
             // at tolerance can come back ~1e-14° over (far below any real
@@ -493,7 +495,7 @@ struct GroupAccumulator {
     sum_sin_ra: f64,
     sum_cos_ra: f64,
     sum_dec: f64,
-    rotation_mean: skymath::CircularMean,
+    rotation_mean: skymath::AxialMean,
     count: u32,
     seed_used_fallback: bool,
     session_ids: Vec<EntityId>,
@@ -507,7 +509,7 @@ impl GroupAccumulator {
             sum_sin_ra: 0.0,
             sum_cos_ra: 0.0,
             sum_dec: 0.0,
-            rotation_mean: skymath::CircularMean::new(),
+            rotation_mean: skymath::AxialMean::new(),
             count: 0,
             seed_used_fallback: false,
             session_ids: Vec::new(),
@@ -545,7 +547,7 @@ impl GroupAccumulator {
         }
     }
 
-    // `CircularMean::mean` normalizes to [0, 360); an f64->f32 rotation angle
+    // `AxialMean::mean` normalizes to [0, 180); an f64->f32 rotation angle
     // never approaches f32's magnitude limits, so this narrows precision, not
     // range. `None` only when nothing was pushed — callers only call this
     // once `count > 0` (see `representative_pointing`'s doc comment).
@@ -594,11 +596,12 @@ fn to_equatorial(p: Pointing) -> skymath::Equatorial {
         .expect("ra normalized to [0, 360), dec clamped to [-90, 90]")
 }
 
-/// Shortest circular distance between two rotation angles, in degrees,
-/// modulo 360° (range `[0, 180]`). See module docs for why 360°, not 180°.
+/// Shortest axial distance between two rotation angles, in degrees, modulo
+/// 180° (range `[0, 90]`) — θ and θ+180° describe the same image axis. See
+/// module docs for why the axial model, not full-circle mod-360.
 #[must_use]
-pub fn rotation_circular_distance_deg(a: f32, b: f32) -> f64 {
-    skymath::circular_distance(
+pub fn rotation_axial_distance_deg(a: f32, b: f32) -> f64 {
+    skymath::axial_distance(
         skymath::Angle::from_degrees(f64::from(a)),
         skymath::Angle::from_degrees(f64::from(b)),
     )
@@ -881,35 +884,53 @@ mod tests {
     }
 
     #[test]
-    fn rotation_distance_wraps_at_360_not_180() {
-        // 359 and 1 degrees are 2deg apart circularly, not ~358.
-        assert!((rotation_circular_distance_deg(359.0, 1.0) - 2.0).abs() < 1e-9);
-        // A deliberate ~180deg re-framing must NOT be treated as equivalent.
-        assert!((rotation_circular_distance_deg(0.0, 180.0) - 180.0).abs() < 1e-9);
+    fn rotation_distance_wraps_at_the_seam() {
+        // 359 and 1 degrees are 2deg apart, not ~358.
+        assert!((rotation_axial_distance_deg(359.0, 1.0) - 2.0).abs() < 1e-9);
+        // A 180deg half-turn is the SAME image axis (identical sensor
+        // footprint) — spec 062 FR-025.
+        assert!(rotation_axial_distance_deg(0.0, 180.0).abs() < 1e-9);
     }
 
     #[test]
-    fn rotation_distance_shortest_arc_not_naive_diff() {
-        // 45 and 295 degrees are 110deg apart circularly (via the 350deg/0deg
-        // seam); a naive |a-b| would wrongly give 250.
-        assert!((rotation_circular_distance_deg(45.0, 295.0) - 110.0).abs() < 1e-9);
+    fn rotation_distance_treats_half_turn_as_equivalent() {
+        // 45 and 295 axes: doubled to 90 and 230, circular distance 140,
+        // halved to 70 — via the axial seam, not the naive |a-b| = 250 nor
+        // the full-circle 110.
+        assert!((rotation_axial_distance_deg(45.0, 295.0) - 70.0).abs() < 1e-9);
+        // Meridian-flip-style offsets vanish regardless of base angle.
+        assert!(rotation_axial_distance_deg(10.0, 190.0).abs() < 1e-9);
+        // Perpendicular axes are maximally distant.
+        assert!((rotation_axial_distance_deg(0.0, 90.0) - 90.0).abs() < 1e-9);
     }
 
     #[test]
     fn rotation_distance_property_bounded_and_correct() {
-        // Same shortest-arc formula the flat calibration rule relies on
-        // (calibration_core issue #921) — any pair of angles must land in
-        // [0, 180], never the naive `(a - b).abs()` this delegates away from.
+        // Axial shortest-arc: any pair of angles must land in [0, 90] and
+        // match the double-angle reference formula.
         let angles: [f32; 9] = [0.0, 0.1, 45.0, 90.0, 180.0, 270.0, 295.0, 359.0, 359.9];
         for &a in &angles {
             for &b in &angles {
-                let d = rotation_circular_distance_deg(a, b);
-                assert!((0.0..=180.0).contains(&d), "distance {d} out of [0,180] for ({a}, {b})");
-                let raw = (f64::from(a) - f64::from(b)).abs().rem_euclid(360.0);
-                let expected = raw.min(360.0 - raw);
+                let d = rotation_axial_distance_deg(a, b);
+                assert!((0.0..=90.0).contains(&d), "distance {d} out of [0,90] for ({a}, {b})");
+                let raw = (f64::from(a) - f64::from(b)).abs().rem_euclid(180.0);
+                let expected = raw.min(180.0 - raw);
                 assert!((d - expected).abs() < 1e-9, "({a}, {b}): got {d}, expected {expected}");
             }
         }
+    }
+
+    #[test]
+    fn sessions_180_degrees_apart_collapse_into_one_framing() {
+        // Same footprint captured in different sessions with the camera a
+        // half-turn apart (meridian flip, rotator re-park, or coincidence)
+        // must cluster together — spec 062 FR-025.
+        let sessions = vec![
+            geom(1, 10, "scope-a|cam-a", 100.0, 20.0, 1.0, Some(2.0)),
+            geom(2, 10, "scope-a|cam-a", 100.0, 20.0, 181.5, Some(2.0)),
+        ];
+        let result = derive_clustering(&sessions, &[], &params());
+        assert_eq!(result.new_framings.len(), 1);
     }
 
     // ── FOV fallback path ────────────────────────────────────────────────────

--- a/crates/sessions/src/lib.rs
+++ b/crates/sessions/src/lib.rs
@@ -11,7 +11,7 @@ pub mod optic_train;
 
 pub use clustering::{
     angular_separation_deg, circular_mean_deg, derive_clustering, fov_diagonal_deg,
-    rotation_circular_distance_deg, Assignment, ClusteringResult, ExistingFraming, NewFramingGroup,
+    rotation_axial_distance_deg, Assignment, ClusteringResult, ExistingFraming, NewFramingGroup,
     SessionGeometry, ToleranceParams, UnassignedReason,
 };
 pub use identity::{


### PR DESCRIPTION
## Summary

Two sessions of the same target with the camera a half-turn apart (meridian flip, rotator re-park, or plain coincidence across nights) were split into separate framings. A rectangular sensor rotated 180 degrees captures the identical sky footprint, so those sessions are the same framing and now cluster together.

## What's new

- Framing clustering and inbox attribution treat rotations 180 degrees apart as the same framing; sessions at, say, 1 and 181 degrees now group together instead of splitting.
- Group rotation representatives average correctly across the half-turn seam (axes at 1 and 181 degrees average to ~1 degree).
- Flat-calibration rotator matching is intentionally unchanged: vignetting and dust patterns are not 180-degree-symmetric, so a flat shot 180 degrees away must not match those lights.

## Notes

Existing libraries: framings previously split solely by a ~180-degree rotation difference will merge on the next clustering re-derivation. Clustering output is a review surface (suggestions are never auto-applied), so the merge shows up as a proposal, not a silent change. Image parity (mirror flips) is not derivable from rotation angles and remains a separate evidence dimension.

Uses skymath 0.7.1's new axial-angle statistics (`axial_distance`, `AxialMean`).

## Spec Context

Spec 062 FR-025: rotation comparison MUST treat 180-degree-equivalent image axes as equivalent, parity checked separately.

## Beads

Tracks-Bead: astro-plan-7rm1
Closes-Bead: astro-plan-7rm1
Merge-Bead: astro-plan-q7ul
