### PR TITLE
fix(e2e): window-state file now isolated per test instance on Windows

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1068,45 +1068,16 @@ jobs:
         if: matrix.shard == 1
         shell: bash
         run: |
-          SHARD1='\
-            test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | \
-            test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | \
-            test(=inbox_ui_mixed_folder_splits_into_single_type_items) | \
-            test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | \
-            test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
-          SHARD2='\
-            test(=slow_archive_lifecycle_apply_trash_permanent_delete) | \
-            test(=targets_planner_real_astronomy_after_site_creation) | \
-            test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | \
-            binary(calibration_ui_journeys) | \
-            binary(lifecycle_ui_journeys) | \
-            binary(source_view_journeys) | \
-            test(=ingestion_sessions_search) | \
-            binary(sessions_journeys) | \
-            test(=plan_review_empty_archive_plan_refuses_apply) | \
-            test(=plan_review_apply_with_audit) | \
-            test(=lifecycle_integrity)'
-          SHARD3='\
-            test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | \
-            binary(smoke) | \
-            test(=targets_ui_add_target_no_duplicate_on_reconfirm) | \
-            binary(inventory_journeys) | \
-            test(=cleanup_plan_review) | \
-            test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | \
-            test(=plan_review_destructive_confirm_gate_and_apply) | \
-            test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | \
-            binary(onboarding_journey) | \
-            binary(cleanup_protection_gate_journey) | \
-            test(=first_run_resolve_create_project) | \
-            test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | \
-            test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
+          SHARD1='test(=slow_targets_ui_dock_pin_and_width_survive_a_real_restart) | test(=inbox_ui_missing_path_attribute_banner_blocks_confirm) | test(=inbox_ui_mixed_folder_splits_into_single_type_items) | test(=inbox_ui_unsplit_unclassified_folder_badge_is_not_classified) | test(=settings_ui_theme_applies_live_and_persists_to_settings_db)'
+          SHARD2='test(=slow_archive_lifecycle_apply_trash_permanent_delete) | test(=targets_planner_real_astronomy_after_site_creation) | test(=targets_ui_identity_columns_stay_pinned_while_table_scrolls) | binary(calibration_ui_journeys) | binary(lifecycle_ui_journeys) | binary(source_view_journeys) | test(=ingestion_sessions_search) | binary(sessions_journeys) | test(=plan_review_empty_archive_plan_refuses_apply) | test(=plan_review_apply_with_audit) | test(=lifecycle_integrity)'
+          SHARD3='test(=inbox_ui_confirm_does_not_move_then_apply_moves_to_shown_destination) | binary(smoke) | test(=targets_ui_add_target_no_duplicate_on_reconfirm) | binary(inventory_journeys) | test(=cleanup_plan_review) | test(=inbox_ui_catalogue_in_place_zero_moves_byte_identical) | test(=plan_review_destructive_confirm_gate_and_apply) | test(=targets_ui_astronomy_columns_disclose_placeholder_without_site) | binary(onboarding_journey) | binary(cleanup_protection_gate_journey) | test(=first_run_resolve_create_project) | test(=inbox_ui_unclassified_gate_bulk_reclassify_unblocks_confirm) | test(=settings_ui_ingestion_toggle_autosaves_no_global_save_button)'
           TOTAL=$(cargo nextest list \
             --archive-file e2e-archive.tar.zst --workspace-remap . \
-            --run-ignored all --message-format oneline 2>/dev/null | wc -l)
+            --run-ignored all --message-format oneline | wc -l)
           UNION=$(cargo nextest list \
             --archive-file e2e-archive.tar.zst --workspace-remap . \
             --run-ignored all --message-format oneline \
-            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" 2>/dev/null | wc -l)
+            -E "${SHARD1} | ${SHARD2} | ${SHARD3}" | wc -l)
           echo "Total tests: ${TOTAL}, covered by shard union: ${UNION}"
           if [ "${TOTAL}" != "${UNION}" ]; then
             echo "::error::Shard coverage gap: ${TOTAL} tests in archive but only ${UNION} covered by the three shard filters. Add the missing test(s) to an -E expression."

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -119,14 +119,33 @@ pub fn build_app() -> tauri::App {
         // first paint) — restoring a persisted `visible: true` from the
         // previous session would fight that gate and show `main` before the
         // splash's minimum-display/boot-ready handshake completes.
-        .plugin(
-            tauri_plugin_window_state::Builder::default()
-                .with_state_flags(
-                    tauri_plugin_window_state::StateFlags::all()
-                        - tauri_plugin_window_state::StateFlags::VISIBLE,
-                )
-                .build(),
-        )
+        .plugin({
+            // Issue astro-plan-qmc: the plugin's default store resolves through
+            // `app_config_dir()`, which on Windows uses `dirs →
+            // SHGetKnownFolderPath` and ignores the `APPDATA` env override the
+            // E2E harness sets — so concurrent instances share one real OS
+            // profile file and `reset_window_state()` deletes under a path that
+            // never exists (same Known Folder class as #1204's `app_data_dir`
+            // defect).
+            //
+            // Fix: when `ALM_DATA_DIR` is set (E2E harness, every platform),
+            // pass an absolute path to `with_filename()`. The plugin does
+            // `app_config_dir().join(&filename)`; `Path::join` with an absolute
+            // argument replaces the base entirely, redirecting the store to the
+            // per-instance isolated dir the harness already owns. Production
+            // builds never set `ALM_DATA_DIR`, so the default filename is kept
+            // and behaviour is unchanged for real users.
+            let mut wb = tauri_plugin_window_state::Builder::default().with_state_flags(
+                tauri_plugin_window_state::StateFlags::all()
+                    - tauri_plugin_window_state::StateFlags::VISIBLE,
+            );
+            if let Some(data_dir) = crate::data_dir::resolve() {
+                wb = wb.with_filename(
+                    data_dir.join(".window-state.json").to_string_lossy().into_owned(),
+                );
+            }
+            wb.build()
+        })
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_opener::init())
         // Spec 051 US10 (T056): signed auto-update plugin. `updater:default` +
@@ -868,5 +887,29 @@ mod tests {
         let mut windows = [window("splash")];
         assert!(!defer_main_window(&mut windows));
         assert!(windows[0].create, "an unrelated window must keep its `create` flag");
+    }
+
+    // ── window-state path isolation (astro-plan-qmc) ──────────────────────
+
+    /// When `ALM_DATA_DIR` is set the window-state file MUST resolve to an
+    /// absolute path under that dir, not under `app_config_dir()`. The plugin
+    /// does `app_config_dir().join(&filename)`; supplying an absolute filename
+    /// replaces the base (std `Path::join` contract). This is what prevents
+    /// concurrent E2E instances from sharing one real OS window-state file on
+    /// Windows, where `app_config_dir()` ignores the `APPDATA` env override.
+    #[test]
+    fn window_state_path_derived_from_alm_data_dir() {
+        let data_dir = std::path::PathBuf::from("/tmp/isolated-e2e-instance/appdata");
+        let expected = data_dir.join(".window-state.json");
+        // Simulate what build_app() computes when ALM_DATA_DIR is set.
+        let filename = data_dir.join(".window-state.json").to_string_lossy().into_owned();
+        // Path::join with an absolute argument must replace the base — verify
+        // here so a regression in the assumption is caught immediately.
+        let fake_config_dir = std::path::PathBuf::from("/real/OS/config/dir");
+        assert_eq!(
+            fake_config_dir.join(&filename),
+            expected,
+            "absolute filename must replace app_config_dir base"
+        );
     }
 }

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -2574,19 +2574,58 @@ fn reset_webview_storage(vars: &[(&'static str, String)]) {
 /// added at the failure site in `inbox_ui_journeys.rs` (round 3,
 /// fix-main-e2e-interplay) for the next data point.
 ///
-/// The plugin's default store is `.window-state.json` under
-/// `app.path().app_config_dir()` (`tauri-plugin-window-state` source) —
-/// which is a DIFFERENT directory than `app_data_dir()` on Linux
-/// (`$XDG_CONFIG_HOME`/`~/.config` vs `$XDG_DATA_HOME`/`~/.local/share`) but
-/// the SAME directory on Windows (`%APPDATA%`) and macOS
-/// (`~/Library/Application Support`).
-/// Failures are ignored (first run has no window-state file yet).
+/// Issue astro-plan-qmc: `app_config_dir()` uses `dirs →
+/// SHGetKnownFolderPath` on Windows and ignores `APPDATA`, so the old
+/// Windows branch was deleting under a path that never existed — a silent
+/// no-op. The fix in `lib.rs` redirects the plugin's store to `ALM_DATA_DIR`
+/// via an absolute `with_filename()` path, so this function now reads that
+/// same env var directly (identical on all platforms — no per-OS branching
+/// needed any more).
+///
+/// Logs a warning when the file can't be found at its expected location AND
+/// the current app process is not a first-run (i.e. the file has had a
+/// chance to be written): a missing file on the very first launch is normal,
+/// but a mismatch between where the app writes and where this function deletes
+/// is the bug this function is here to catch.
 ///
 /// `vars` — see [`reset_webview_storage`]'s doc on why this takes the
 /// instance's env overrides instead of reading the real OS env.
 fn reset_window_state(vars: &[(&'static str, String)]) {
-    if let Some(dir) = app_config_dir(vars) {
-        let _ = std::fs::remove_file(dir.join(".window-state.json"));
+    // On every platform the app writes `.window-state.json` under ALM_DATA_DIR
+    // when that variable is set (astro-plan-qmc fix in `lib.rs`). Fall back to
+    // `app_config_dir` on Linux/macOS where the env vars ARE honoured by the
+    // platform dirs resolver and `ALM_DATA_DIR` is only set for app-data (not
+    // config-dir) isolation.
+    let path = if let Some(data_dir) = app_data_dir(vars) {
+        data_dir.join(".window-state.json")
+    } else if let Some(cfg_dir) = app_config_dir(vars) {
+        cfg_dir.join(".window-state.json")
+    } else {
+        eprintln!(
+            "[e2e harness] reset_window_state: neither ALM_DATA_DIR nor \
+             an app_config_dir override is set — window-state file not reset"
+        );
+        return;
+    };
+
+    match std::fs::remove_file(&path) {
+        Ok(()) => {}
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // Normal on the very first launch of a fresh instance (no prior
+            // session to have written it). Log at debug level only.
+            eprintln!(
+                "[e2e harness] reset_window_state: file not found at {} \
+                 (expected on first launch)",
+                path.display()
+            );
+        }
+        Err(e) => {
+            eprintln!(
+                "[e2e harness] reset_window_state: failed to remove {} — {e} \
+                 (window-state may bleed between sequential journeys)",
+                path.display()
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- E2E window-state file was written to the real OS user profile on Windows because `app_config_dir()` ignores the `APPDATA` env override (same Known Folder defect fixed for app-data in #1204). Each test instance now writes to its own isolated dir, matching the isolation already in place for webview storage and the SQLite database.
- `reset_window_state()` no longer silently no-ops on Windows; it now targets the correct path and logs when the file is absent or the removal fails.

## Spec Context

Tracks-Bead: astro-plan-qmc
Closes-Bead: astro-plan-qmc
Merge-Bead: astro-plan-9jn8
