### PR TITLE
chore(deps): upgrade notify 7 -> 8.2 and add notify-debouncer-full

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1766,6 +1766,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "file-id"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1fc6a637b6dc58414714eddd9170ff187ecb0933d4c7024d1abbd23a3cc26e9"
+dependencies = [
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1912,6 +1921,7 @@ dependencies = [
  "domain_core",
  "fs_pathsafe",
  "notify",
+ "notify-debouncer-full",
  "serde",
  "serde_json",
  "tempfile",
@@ -2864,11 +2874,11 @@ dependencies = [
 
 [[package]]
 name = "inotify"
-version = "0.10.2"
+version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdd168d97690d0b8c412d6b6c10360277f4d7ee495c5d0d5d5fe0854923255cc"
+checksum = "153be1941a183ec9ccd095ddbe17a8b8d435ef6c76e9e02451b933c3999af2c8"
 dependencies = [
- "bitflags 1.3.2",
+ "bitflags 2.13.1",
  "inotify-sys",
  "libc",
 ]
@@ -2880,15 +2890,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c033f80b2c113cdf91ab7a33faa9cbc014726dcad99880c8609af2a370edf37d"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -3426,12 +3427,11 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "notify"
-version = "7.0.0"
+version = "8.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c533b4c39709f9ba5005d8002048266593c1cfaf3c5f0739d5b8ab0c6c504009"
+checksum = "4d3d07927151ff8575b7087f245456e549fea62edf0ec4e565a5ee50c8402bc3"
 dependencies = [
  "bitflags 2.13.1",
- "filetime",
  "fsevent-sys",
  "inotify",
  "kqueue",
@@ -3440,16 +3440,29 @@ dependencies = [
  "mio",
  "notify-types",
  "walkdir",
- "windows-sys 0.52.0",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "notify-debouncer-full"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c02b49179cfebc9932238d04d6079912d26de0379328872846118a0fa0dbb302"
+dependencies = [
+ "file-id",
+ "log",
+ "notify",
+ "notify-types",
+ "walkdir",
 ]
 
 [[package]]
 name = "notify-types"
-version = "1.0.1"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "585d3cb5e12e01aed9e8a1f70d5c6b5e86fe2a6e48fc8cd0b3e0b8df6f6eb174"
+checksum = "42b8cfee0e339a0337359f3c88165702ac6e600dc01c0cc9579a92d62b08477a"
 dependencies = [
- "instant",
+ "bitflags 2.13.1",
 ]
 
 [[package]]

--- a/crates/fs/inventory/Cargo.toml
+++ b/crates/fs/inventory/Cargo.toml
@@ -11,7 +11,8 @@ path = "src/lib.rs"
 camino = { workspace = true }
 domain_core = { path = "../../domain/core" }
 fs_pathsafe = { path = "../pathsafe" }
-notify = "7"
+notify = ">=8,<9"
+notify-debouncer-full = ">=0.7,<0.8"
 serde = { workspace = true }
 serde_json.workspace = true
 tokio = { workspace = true }

--- a/crates/fs/inventory/src/artifact_watcher.rs
+++ b/crates/fs/inventory/src/artifact_watcher.rs
@@ -4,22 +4,22 @@
 //! Artifact filesystem watcher service (spec 012, FR-009, spec 033 T028).
 //!
 //! Watches registered library-root paths for new or modified files.  Uses
-//! plain `notify 7` (already a workspace dep) and forwards every raw
-//! Create/Modify/Remove event downstream, undebounced, via a
-//! `tokio::sync::mpsc` channel.
+//! `notify 8` and forwards every raw Create/Modify/Remove event downstream,
+//! undebounced, via a `tokio::sync::mpsc` channel.
 //!
 //! ## Debounce strategy (deviation from D10)
 //!
-//! D10 specified `notify-debouncer-full 0.7.x`, but that crate requires
-//! `notify 8.x` while the rest of the workspace uses `notify 7`.  Adding
-//! `notify 8` as a second version would cause a duplicate-type conflict in
-//! `WatcherService` (which already uses `notify 7`).  The fallback described
-//! in D10 ("acceptable fallback — noted") is used here instead: this crate
-//! does NOT debounce — it stays a thin raw-event source. The stable-size
-//! debounce (default 2s, spec 012 edge case) is pure logic in
-//! `workflow_artifacts::watcher::check_stability`/`FileSnapshot`, applied by
-//! the consumer (`apps/desktop/src-tauri/src/watcher.rs`'s per-project
-//! forward task) against a `HashMap<PathBuf, FileSnapshot>` it owns.
+//! D10 specified `notify-debouncer-full 0.7.x`.  `notify-debouncer-full` is
+//! now a direct dep alongside `notify 8`, satisfying that design intent.
+//! However, wiring the debouncer into the event pipeline touches the same
+//! watcher files being refactored on branch `fix/watcher-robustness-cluster`
+//! (bead kyo7.74); to avoid a merge conflict, debouncer adoption is deferred
+//! to that branch.  This crate therefore stays a thin raw-event source for
+//! now.  The stable-size debounce (default 2s, spec 012 edge case) is pure
+//! logic in `workflow_artifacts::watcher::check_stability`/`FileSnapshot`,
+//! applied by the consumer (`apps/desktop/src-tauri/src/watcher.rs`'s
+//! per-project forward task) against a `HashMap<PathBuf, FileSnapshot>` it
+//! owns.
 
 use std::sync::Arc;
 


### PR DESCRIPTION
## Summary

- Upgrades `notify` from `7` to `8.2` in `crates/fs/inventory`
- Adds `notify-debouncer-full 0.7` as a direct dependency (same notify-rs org, official companion)
- No source changes needed: notify 8's `EventKind`/`RecommendedWatcher`/`RecursiveMode` API is backward-compatible with existing usage
- Debouncer wiring deferred to `fix/watcher-robustness-cluster` to avoid merge conflicts on watcher files; deviation note in `artifact_watcher.rs` updated accordingly

Merge-Bead: orc-26o
Tracks-Bead: astro-plan-kyo7.22
