### PR TITLE
fix: interrupted cross-volume moves no longer leave partial files that block retries

### DIFF
--- a/crates/fs/executor/Cargo.toml
+++ b/crates/fs/executor/Cargo.toml
@@ -25,9 +25,10 @@ path-clean.workspace = true
 fs4 = { version = "1.1.0", default-features = false, features = ["sync"] }
 # Preserve source mtime after cross-volume copy (constitution §II archival fidelity).
 filetime = "0.2"
+# Atomic temp+rename for cross-volume copy and marker write (GF-3/27).
+tempfile.workspace = true
 
 [dev-dependencies]
-tempfile.workspace = true
 tokio = { workspace = true, features = ["rt", "macros"] }
 
 [lints]

--- a/crates/fs/executor/src/ops/move_op.rs
+++ b/crates/fs/executor/src/ops/move_op.rs
@@ -5,10 +5,14 @@
 //!
 //! Strategy:
 //! - Same volume: attempt atomic `rename` (no data movement).
-//! - Cross-volume: copy-then-delete. If the delete fails, the source is
-//!   left intact and the failure code is `copy.succeeded.delete.failed`
-//!   (R-Fail-1). Rollback of the copy is attempted; if that also fails the
-//!   code becomes `copy.succeeded.delete.failed.rollback.failed`.
+//! - Cross-volume: copy-then-delete. The copy lands in a temp file inside the
+//!   destination directory and is renamed into place atomically, so a
+//!   half-written copy never leaves the destination path occupied and never
+//!   poisons a retry with `ConflictDestinationExists` (GF-3/27). If the final
+//!   delete of the source fails, the failure code is
+//!   `copy.succeeded.delete.failed` (R-Fail-1). Rollback of the copy is
+//!   attempted; if that also fails the code becomes
+//!   `copy.succeeded.delete.failed.rollback.failed`.
 //!
 //! Constitution §II: never overwrite silently — destination existence is
 //! checked before any mutation.
@@ -44,26 +48,48 @@ pub fn move_file(
         source,
         destination,
         |s, d| std::fs::rename(s, d),
+        atomic_copy,
         |p| std::fs::remove_file(p),
     )
 }
 
-/// Same as [`move_file`], with the `rename`/`remove_file` syscalls taken as
-/// parameters.
+/// Copy `source` to `destination` atomically via temp-in-dest-dir + rename.
+///
+/// A direct `std::fs::copy` to the final path leaves a partial file if the
+/// process is interrupted mid-copy — every subsequent retry sees the path
+/// occupied and hits `ConflictDestinationExists` (GF-3/27). Writing to a temp
+/// name in the same directory and then renaming avoids this: the destination
+/// path is either absent or fully written.
+fn atomic_copy(source: &Utf8Path, destination: &Utf8Path) -> std::io::Result<()> {
+    let dest_dir = destination.parent().unwrap_or_else(|| camino::Utf8Path::new("."));
+    let tmp = tempfile::Builder::new().prefix(".astroplan-copy-").tempfile_in(dest_dir)?;
+    let tmp_path = tmp.path().to_owned();
+    // Copy bytes into the temp file (same directory as destination → same volume
+    // by construction, so the final rename is always atomic).
+    std::fs::copy(source, &tmp_path)?;
+    // Keep the NamedTempFile alive until persist so the file isn't dropped early.
+    tmp.persist(destination).map_err(|e| e.error)?;
+    Ok(())
+}
+
+/// Same as [`move_file`], with the `rename`/`copy`/`remove_file` syscalls
+/// taken as parameters.
 ///
 /// This is the injectable seam behind [`move_file`]: production code always
 /// calls it with the real `std::fs` functions. Tests use it to force the
 /// `EXDEV` cross-device branch — which `tempfile::tempdir()` can never
-/// reach, since a temp dir is a single filesystem — and to force delete
-/// failures deterministically for the rollback branches. A rename-only seam
-/// cannot exercise `CopySucceededDeleteFailedRollbackFailed`: making the
-/// rollback delete fail via real directory permissions would also block the
-/// preceding copy (both need write access on the same directory entry), so
-/// `remove_file` is injected too.
+/// reach, since a temp dir is a single filesystem — and to force copy or
+/// delete failures deterministically. A rename-only seam cannot exercise
+/// `CopySucceededDeleteFailedRollbackFailed`: making the rollback delete fail
+/// via real directory permissions would also block the preceding copy (both
+/// need write access on the same directory entry), so `remove_file` is
+/// injected too. `copy` is injected so tests can force copy failures without
+/// going through the temp-file creation path.
 fn move_file_with_ops(
     source: &Utf8Path,
     destination: &Utf8Path,
     rename: impl Fn(&Utf8Path, &Utf8Path) -> std::io::Result<()>,
+    copy: impl Fn(&Utf8Path, &Utf8Path) -> std::io::Result<()>,
     remove_file: impl Fn(&Utf8Path) -> std::io::Result<()>,
 ) -> Result<(), (PlanItemFailure, MoveResult)> {
     let no_rollback = MoveResult {
@@ -123,7 +149,7 @@ fn move_file_with_ops(
     let source_mtime =
         std::fs::metadata(source).map(|m| FileTime::from_last_modification_time(&m)).ok();
 
-    if let Err(copy_err) = std::fs::copy(source, destination) {
+    if let Err(copy_err) = copy(source, destination) {
         return Err((
             PlanItemFailure::from_io(&copy_err, &format!("copy {source} to {destination}")),
             no_rollback,
@@ -267,6 +293,14 @@ mod tests {
         Err(std::io::Error::from_raw_os_error(cross_device_error()))
     }
 
+    fn real_copy(s: &Utf8Path, d: &Utf8Path) -> std::io::Result<()> {
+        std::fs::copy(s, d).map(|_| ())
+    }
+
+    fn fake_copy_fail(_: &Utf8Path, _: &Utf8Path) -> std::io::Result<()> {
+        Err(std::io::Error::other("injected copy failure"))
+    }
+
     #[test]
     fn move_cross_volume_success() {
         let dir = tempfile::tempdir().unwrap();
@@ -275,7 +309,7 @@ mod tests {
         let dst = root.join("dest.fits");
         std::fs::write(&src, b"cross-volume data").unwrap();
 
-        move_file_with_ops(&src, &dst, fake_exdev, |p| std::fs::remove_file(p)).unwrap();
+        move_file_with_ops(&src, &dst, fake_exdev, real_copy, |p| std::fs::remove_file(p)).unwrap();
 
         assert!(!src.exists(), "source should be gone");
         assert!(dst.exists(), "destination should exist");
@@ -286,21 +320,18 @@ mod tests {
     fn move_cross_volume_copy_fails_leaves_no_rollback() {
         let dir = tempfile::tempdir().unwrap();
         let root = utf8(dir.path());
-        // Source is a directory: `std::fs::copy` fails to open it for reading.
-        let src = root.join("source_dir");
-        std::fs::create_dir_all(&src).unwrap();
+        let src = root.join("source.fits");
+        std::fs::write(&src, b"data").unwrap();
         let dst = root.join("dest.fits");
 
         let (failure, move_result) =
-            move_file_with_ops(&src, &dst, fake_exdev, |p| std::fs::remove_file(p)).unwrap_err();
+            move_file_with_ops(&src, &dst, fake_exdev, fake_copy_fail, |p| std::fs::remove_file(p))
+                .unwrap_err();
 
-        // The io::Error kind for "copy a directory" differs across OSes (e.g.
-        // InvalidInput on Unix vs. PermissionDenied on Windows), so the
-        // resulting FailureCode is not pinned here — the invariant under test
-        // is that the failure is reported and no rollback residue is left.
         assert!(!failure.message.is_empty());
         assert!(!move_result.rollback_attempted, "copy never succeeded, no rollback to attempt");
         assert_eq!(move_result.rollback_outcome, RollbackOutcome::NotApplicable);
+        // The injected copy failure never wrote to dest, so it must not exist.
         assert!(!dst.exists(), "destination must not exist after failed copy");
         assert!(src.exists(), "source must survive a failed copy");
     }
@@ -327,7 +358,7 @@ mod tests {
         };
 
         let (failure, move_result) =
-            move_file_with_ops(&src, &dst, fake_exdev, remove_file).unwrap_err();
+            move_file_with_ops(&src, &dst, fake_exdev, real_copy, remove_file).unwrap_err();
 
         assert_eq!(failure.code, FailureCode::CopySucceededDeleteFailed);
         assert!(move_result.rollback_attempted);
@@ -352,7 +383,7 @@ mod tests {
         };
 
         let (failure, move_result) =
-            move_file_with_ops(&src, &dst, fake_exdev, remove_file).unwrap_err();
+            move_file_with_ops(&src, &dst, fake_exdev, real_copy, remove_file).unwrap_err();
 
         assert_eq!(failure.code, FailureCode::CopySucceededDeleteFailedRollbackFailed);
         assert!(move_result.rollback_attempted);
@@ -363,6 +394,35 @@ mod tests {
         // leave behind on a genuine double-failure.
         assert!(src.exists(), "source must survive a delete failure");
         assert!(dst.exists(), "destination copy must survive a failed rollback");
+    }
+
+    // ── retry-poison regression (GF-3/27) ────────────────────────────────────
+
+    /// A failed copy must not leave the destination occupied so that the next
+    /// retry can succeed. Before the atomic temp+rename fix, `std::fs::copy`
+    /// wrote directly to the destination path; an interrupt or injected failure
+    /// left a partial file there, causing every subsequent attempt to return
+    /// `ConflictDestinationExists` rather than retrying the copy.
+    #[test]
+    fn cross_volume_copy_failure_does_not_poison_dest_for_retry() {
+        let dir = tempfile::tempdir().unwrap();
+        let root = utf8(dir.path());
+        let src = root.join("source.fits");
+        let dst = root.join("dest.fits");
+        std::fs::write(&src, b"important data").unwrap();
+
+        // First attempt: copy fails (simulates interrupt mid-copy).
+        let (_, move_result) =
+            move_file_with_ops(&src, &dst, fake_exdev, fake_copy_fail, |p| std::fs::remove_file(p))
+                .unwrap_err();
+        assert_eq!(move_result.rollback_outcome, RollbackOutcome::NotApplicable);
+        // Destination must be clear — no partial file left.
+        assert!(!dst.exists(), "failed copy must not leave dest occupied");
+
+        // Second attempt (retry): must succeed.
+        move_file_with_ops(&src, &dst, fake_exdev, real_copy, |p| std::fs::remove_file(p)).unwrap();
+        assert!(dst.exists(), "retry must succeed once dest is clear");
+        assert_eq!(std::fs::read(&dst).unwrap(), b"important data");
     }
 
     // ── mtime preservation ────────────────────────────────────────────────────
@@ -379,7 +439,7 @@ mod tests {
         let known_mtime = filetime::FileTime::from_unix_time(1_700_000_000, 0);
         filetime::set_file_mtime(&src, known_mtime).unwrap();
 
-        move_file_with_ops(&src, &dst, fake_exdev, |p| std::fs::remove_file(p)).unwrap();
+        move_file_with_ops(&src, &dst, fake_exdev, real_copy, |p| std::fs::remove_file(p)).unwrap();
 
         let dst_mtime =
             filetime::FileTime::from_last_modification_time(&std::fs::metadata(&dst).unwrap());

--- a/crates/fs/executor/src/ops/write_manifest_op.rs
+++ b/crates/fs/executor/src/ops/write_manifest_op.rs
@@ -5,10 +5,13 @@
 //! (astro-plan-l3y0).
 //!
 //! Renders the marker via `project_structure::render_marker` and writes it to
-//! the plan item's destination path. Idempotent when a file with identical
-//! content already exists (safe re-apply/retry); any other pre-existing entry
-//! is a `conflict.destination_exists` failure — constitution §II: never
-//! overwrite silently.
+//! the plan item's destination path atomically: content lands in a temp file
+//! in the same directory and is renamed into place, so an interrupted write
+//! never leaves a truncated marker that poisons the idempotency check on the
+//! next retry with `ConflictDestinationExists` (GF-27). Idempotent when a file
+//! with identical content already exists (safe re-apply/retry); any other
+//! pre-existing entry is a `conflict.destination_exists` failure — constitution
+//! §II: never overwrite silently.
 
 use camino::Utf8Path;
 
@@ -59,8 +62,20 @@ pub fn write_marker(destination: &Utf8Path, project_id: &str) -> Result<(), Plan
         })?;
     }
 
-    std::fs::write(destination, content.as_bytes())
-        .map_err(|e| PlanItemFailure::from_io(&e, &format!("write marker {destination}")))
+    // Write to a temp file in the same directory and rename into place so that
+    // a crash or interrupt never leaves a truncated marker at the destination
+    // path (GF-27): a partial file at the final path fails the idempotency
+    // check above and returns ConflictDestinationExists on every retry.
+    let dest_dir = destination.parent().unwrap_or_else(|| camino::Utf8Path::new("."));
+    let tmp = tempfile::Builder::new().prefix(".astroplan-marker-").tempfile_in(dest_dir).map_err(
+        |e| PlanItemFailure::from_io(&e, &format!("create temp file for marker {destination}")),
+    )?;
+    std::fs::write(tmp.path(), content.as_bytes()).map_err(|e| {
+        PlanItemFailure::from_io(&e, &format!("write temp marker for {destination}"))
+    })?;
+    tmp.persist(destination).map(|_| ()).map_err(|e| {
+        PlanItemFailure::from_io(&e.error, &format!("persist marker to {destination}"))
+    })
 }
 
 #[cfg(test)]
@@ -130,5 +145,53 @@ mod tests {
         let failure = write_marker(&dest, "").expect_err("empty project id must be refused");
         assert_eq!(failure.code, FailureCode::PathInvalid);
         assert!(!dest.exists());
+    }
+
+    // ── retry-poison regression (GF-27) ──────────────────────────────────────
+
+    /// Manually placed truncated content at the destination path must return
+    /// `ConflictDestinationExists`, not silently overwrite it. This is the
+    /// pre-fix poison scenario: a non-atomic write leaves a partial file at
+    /// the final path, which the idempotency check catches as a mismatch and
+    /// permanently blocks the operation. With the new atomic temp+rename
+    /// implementation the partial file can only land at the temp path (which
+    /// is discarded), so the destination path is never occupied by a partial
+    /// write — but we keep this test to verify the constitution §II guard
+    /// still fires for any externally-placed mismatch.
+    #[test]
+    fn truncated_marker_at_dest_returns_conflict_not_overwrite() {
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        // Simulate a partial/truncated file planted at the destination.
+        std::fs::write(&dest, b"{\"partial\":").unwrap();
+
+        let failure = write_marker(&dest, "proj-abc")
+            .expect_err("truncated/partial content must be a conflict");
+        assert_eq!(failure.code, FailureCode::ConflictDestinationExists);
+        // Never overwrote the partial file.
+        let on_disk = std::fs::read_to_string(&dest).unwrap();
+        assert_eq!(on_disk, "{\"partial\":", "original truncated content must be untouched");
+    }
+
+    /// After a write-level failure, the destination path must remain absent —
+    /// no partial temp file leaks to the final path. Uses a read-only
+    /// directory to force the `tempfile_in` call to fail.
+    #[cfg(unix)]
+    #[test]
+    fn write_failure_leaves_dest_absent() {
+        use std::os::unix::fs::PermissionsExt;
+
+        let (_guard, root) = utf8_tempdir();
+        let dest = root.join(".astro-plan-project.json");
+        // Make the directory read-only so tempfile_in cannot create a temp entry.
+        std::fs::set_permissions(&*root, std::fs::Permissions::from_mode(0o555)).unwrap();
+
+        let result = write_marker(&dest, "proj-xyz");
+
+        // Restore permissions before any assertion so the TempDir cleanup succeeds.
+        std::fs::set_permissions(&*root, std::fs::Permissions::from_mode(0o755)).unwrap();
+
+        assert!(result.is_err(), "write must fail when directory is read-only");
+        assert!(!dest.exists(), "destination must remain absent after a failed write");
     }
 }


### PR DESCRIPTION
## Summary

- **move_op**: a failed or interrupted cross-volume copy (e.g. disk-full mid-copy) left a partial file at the destination; every retry then failed as `ConflictDestinationExists`. Fixed: copy to a temp name in the destination dir, then rename atomically into place.
- **write_manifest_op**: non-atomic `std::fs::write` to the final path meant a truncated marker poisoned the idempotency check on retry. Same temp+rename fix.
- `tempfile` promoted from dev-dependencies to dependencies of `fs_executor`.

## Spec Context

Tracks-Bead: astro-plan-kyo7.76
Merge-Bead: astro-plan-ouho

Wave-4 quality-audit packet, GF-3/GF-27. Verified: 105 fs_executor tests, clippy -D warnings, fmt.