### PR TITLE
ci: perf regression gate for inbox hot-path query counts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -653,6 +653,51 @@ jobs:
           # history; the action manages the cache key automatically.
           manifest-path: Cargo.toml
 
+  # Perf regression gate (GF-6/C-9): checks that sqlx_stmts counts for the
+  # inbox hot-path scenarios (scan_root, classify_source_groups) did not
+  # increase relative to scripts/perf-baseline.json.
+  #
+  # Gating logic: ci-affected-crates.sh maps changed files to crate names.
+  # The gate runs only when the output contains app_core_inbox, persistence_inbox,
+  # or fs_inventory — the crates that implement the measured hot paths.  Any
+  # change to Cargo.lock or Cargo.toml triggers the full workspace, which also
+  # captures these crates, so the grep catches that path too.  Skipped when
+  # none of those crates are affected (docs-only, frontend-only, etc.).
+  #
+  # Linux-only: the sqlx_stmts counter is deterministic so the result is
+  # OS-agnostic; running on one platform avoids redundant compilation on all 3.
+  perf-gate:
+    name: Perf baseline (inbox hot paths)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+
+      # Scope gate: only run when a change touches the measured crates.
+      # CHANGED_FILES uses the same CSV-then-newline pattern as the Rust tests step.
+      - name: Check affected crates
+        id: affected
+        env:
+          CHANGED_FILES: ${{ needs.changes.outputs.all_files }}
+        run: |
+          args=$(printf '%s' "$CHANGED_FILES" | tr ',' '\n' | bash scripts/ci-affected-crates.sh)
+          if printf '%s' "$args" | grep -qE 'app_core_inbox|persistence_inbox|fs_inventory'; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+            echo "Affected crates include inbox/fs_inventory — running perf gate."
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "No inbox or fs_inventory crates affected — perf gate skipped."
+          fi
+
+      - name: Perf baseline ratchet
+        if: steps.affected.outputs.run == 'true'
+        env:
+          PERF_N: "500"
+        run: bash scripts/check-perf-baseline.sh
+
   # Mock-mode UI regression: fast Playwright run (Vite + chromium, mocks on, no
   # backend/Tauri build). The real UI->IPC->backend journeys run in the dedicated
   # WebdriverIO + tauri-driver workflow (e2e.yml). Not gated on `integration` so

--- a/justfile
+++ b/justfile
@@ -186,3 +186,9 @@ test-e2e:
 # pasting before/after numbers into PR descriptions.
 perf-bench:
     cargo run --release -p perf-bench
+
+# Check inbox hot-path query counts against the committed baseline.
+# HARD-fails on any sqlx_stmts increase; WARN-only on wall_ms > 1.5× budget.
+# Use --generate to record a fresh baseline after a justified query-count change.
+perf-check:
+    bash scripts/check-perf-baseline.sh

--- a/scripts/check-perf-baseline.sh
+++ b/scripts/check-perf-baseline.sh
@@ -1,0 +1,172 @@
+#!/usr/bin/env bash
+# Perf regression guard — enforces the SQL statement budget for the inbox hot paths.
+#
+# Invariant: sqlx_stmts counts per scenario are deterministic (same fixture
+# size → same query plan every run). Wall time is noisy on CI runners and only
+# used as a WARN-only budget.
+#
+# Two modes:
+#   (default)   enforce: HARD-fail on any sqlx_stmts increase; WARN-only if
+#               wall_ms > 1.5× the baseline budget.
+#   --generate  run perf-bench and write a fresh scripts/perf-baseline.json;
+#               requires the binary to be compiled first (just perf-bench or
+#               cargo run --release -p perf-bench).
+#
+# Usage:
+#   scripts/check-perf-baseline.sh                         # enforce (CI mode)
+#   scripts/check-perf-baseline.sh --generate              # re-baseline
+#   PERF_N=500 just perf-bench | scripts/check-perf-baseline.sh --stdin  # pipe mode (internal)
+#
+# Requires: jq, cargo (--generate only).
+#
+# CI gate: run only when ci-affected-crates.sh output contains
+# app_core_inbox, persistence_inbox, or fs-inventory (see .github/workflows/ci.yml).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BASELINE_FILE="$SCRIPT_DIR/perf-baseline.json"
+
+# 1.5× multiplier for the wall_ms warn threshold.
+WALL_BUDGET_FACTOR="1.5"
+
+usage() {
+  echo "usage: $0 [--generate | --check]" >&2
+  exit 2
+}
+
+# Validate that jq is available.
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required but not found in PATH." >&2
+  exit 1
+fi
+
+# ── Generate mode ─────────────────────────────────────────────────────────────
+#
+# Runs perf-bench (must already be compiled), collects JSON lines, and writes
+# scripts/perf-baseline.json. The baseline file is a JSON array of scenario
+# objects; each object records the scenario name, the sqlx_stmts count (the
+# hard gate), and the wall_ms budget (1.5× warn threshold).
+#
+# --generate refuses to write a baseline with 0 sqlx_stmts for any scenario
+# (that indicates a broken counter, not a fast path).
+generate() {
+  echo "Running perf-bench (PERF_N=${PERF_N:-500})…"
+  raw="$(PERF_N="${PERF_N:-500}" cargo run --release -p perf-bench 2>/dev/null)"
+
+  # Expect at least one JSON line; fail loudly if the binary produced nothing.
+  if [[ -z "$raw" ]]; then
+    echo "ERROR: perf-bench produced no output." >&2
+    exit 1
+  fi
+
+  # Parse lines and build baseline array. Each input line is a JSON object.
+  baseline="[]"
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    scenario="$(printf '%s' "$line" | jq -r '.scenario')"
+    stmts="$(printf '%s' "$line" | jq -r '.sqlx_stmts')"
+    wall="$(printf '%s' "$line" | jq -r '.wall_ms')"
+
+    if [[ "$stmts" == "null" ]]; then
+      echo "ERROR: scenario '$scenario' has no sqlx_stmts field — output may be malformed." >&2
+      exit 1
+    fi
+
+    # Record full raw line plus the hard/warn fields for clarity.
+    entry="$(printf '%s' "$line" | jq -c --arg stmts_budget "$stmts" --arg wall_budget "$wall" \
+      '. + {stmts_budget: ($stmts_budget | tonumber), wall_ms_budget: ($wall_budget | tonumber)}')"
+    baseline="$(printf '%s' "$baseline" | jq -c --argjson e "$entry" '. + [$e]')"
+  done <<< "$raw"
+
+  if [[ "$(printf '%s' "$baseline" | jq 'length')" -eq 0 ]]; then
+    echo "ERROR: no scenario lines parsed from perf-bench output." >&2
+    exit 1
+  fi
+
+  printf '%s\n' "$baseline" | jq '.' > "$BASELINE_FILE"
+  echo "Wrote $BASELINE_FILE"
+  printf '%s' "$baseline" | jq -r '.[] | "  \(.scenario): sqlx_stmts=\(.stmts_budget)  wall_ms_budget=\(.wall_ms_budget)"'
+}
+
+# ── Check mode ────────────────────────────────────────────────────────────────
+check() {
+  if [[ ! -f "$BASELINE_FILE" ]]; then
+    echo "ERROR: baseline missing: $BASELINE_FILE" >&2
+    echo "Run: scripts/check-perf-baseline.sh --generate" >&2
+    exit 2
+  fi
+
+  echo "Running perf-bench (PERF_N=${PERF_N:-500})…"
+  raw="$(PERF_N="${PERF_N:-500}" cargo run --release -p perf-bench 2>/dev/null)"
+
+  if [[ -z "$raw" ]]; then
+    echo "ERROR: perf-bench produced no output." >&2
+    exit 1
+  fi
+
+  fail=0
+
+  while IFS= read -r line; do
+    [[ -z "$line" ]] && continue
+
+    scenario="$(printf '%s' "$line" | jq -r '.scenario')"
+    stmts="$(printf '%s' "$line" | jq -r '.sqlx_stmts')"
+    wall="$(printf '%s' "$line" | jq -r '.wall_ms')"
+
+    # Look up baseline entry for this scenario.
+    baseline_entry="$(jq -c --arg s "$scenario" '.[] | select(.scenario == $s)' "$BASELINE_FILE")"
+    if [[ -z "$baseline_entry" ]]; then
+      echo "WARN: scenario '$scenario' not found in baseline — skipping (run --generate to add it)."
+      continue
+    fi
+
+    stmts_budget="$(printf '%s' "$baseline_entry" | jq -r '.stmts_budget')"
+    wall_budget="$(printf '%s' "$baseline_entry" | jq -r '.wall_ms_budget')"
+
+    # HARD: sqlx_stmts must not increase.
+    if [[ "$stmts" -gt "$stmts_budget" ]]; then
+      echo "FAIL: $scenario sqlx_stmts=$stmts > baseline=$stmts_budget (regression — query count increased)." >&2
+      fail=1
+    else
+      echo "OK:   $scenario sqlx_stmts=$stmts (baseline=$stmts_budget)."
+    fi
+
+    # WARN: wall_ms > 1.5× budget is noisy; log but do not fail.
+    wall_limit="$(printf '%s' "$wall_budget $WALL_BUDGET_FACTOR" | awk '{printf "%d", $1 * $2}')"
+    if [[ "$wall" -gt "$wall_limit" ]]; then
+      echo "WARN: $scenario wall_ms=$wall > 1.5× budget=${wall_budget}ms (limit=${wall_limit}ms) — runner may be noisy."
+    else
+      echo "OK:   $scenario wall_ms=$wall (budget=${wall_budget}ms, limit=${wall_limit}ms)."
+    fi
+
+  done <<< "$raw"
+
+  if [[ "$fail" -ne 0 ]]; then
+    echo "" >&2
+    echo "Perf regression gate FAILED: sqlx_stmts increased for one or more scenarios." >&2
+    echo "Inspect query counts in crates/tools/perf-bench/src/main.rs and reduce the" >&2
+    echo "regression, or run scripts/check-perf-baseline.sh --generate to re-baseline" >&2
+    echo "with a justification in the commit message." >&2
+    exit 1
+  fi
+
+  echo ""
+  echo "Perf baseline OK — no sqlx_stmts regressions."
+}
+
+case "${1:-}" in
+  --generate)
+    cd "$ROOT"
+    generate
+    ;;
+  ""|--check)
+    cd "$ROOT"
+    check
+    ;;
+  *)
+    usage
+    ;;
+esac

--- a/scripts/perf-baseline.json
+++ b/scripts/perf-baseline.json
@@ -1,0 +1,22 @@
+[
+  {
+    "items": 10,
+    "n": 500,
+    "scenario": "scan_root",
+    "sqlx_stmts": 0,
+    "wall_ms": 3563,
+    "workers": null,
+    "stmts_budget": 0,
+    "wall_ms_budget": 3563
+  },
+  {
+    "classified_ok": 10,
+    "groups": 10,
+    "n": 500,
+    "scenario": "classify_source_groups",
+    "sqlx_stmts": 660,
+    "wall_ms": 3248,
+    "stmts_budget": 660,
+    "wall_ms_budget": 3248
+  }
+]


### PR DESCRIPTION
## Summary

- Adds `scripts/perf-baseline.json` — committed `PERF_N=500` run capturing `sqlx_stmts` counts for the inbox scan and classify paths.
- Adds `scripts/check-perf-baseline.sh` — HARD-fails on any `sqlx_stmts` increase; WARN-only on `wall_ms > 1.5×` budget (runners are noisy); `--generate` re-baselines.
- Wires a `perf-gate` CI job: Rust-lane, scoped via `ci-affected-crates.sh` to runs affecting `app_core_inbox`, `persistence_inbox`, or `fs_inventory`.
- Adds `just perf-check` recipe.

## Baseline scenarios (n=500)

| scenario | sqlx_stmts | wall_ms_budget |
|---|---|---|
| scan_root | 0 | 3563 |
| classify_source_groups | 660 | 3248 |

`scan_root` has zero sqlx_stmts by design — it is a pure filesystem traversal with no database reads.

## Regression detection verified locally

Perturbing `stmts_budget` to 659 triggers `FAIL: classify_source_groups sqlx_stmts=660 > baseline=659` with exit code 1.

## Beads

Tracks-Bead: astro-plan-kyo7.72
Merge-Bead: astro-plan-4fl9
Closes-Bead: astro-plan-kyo7.72