### PR TITLE
fix: file watchers recover from overload, new folders, and drives that reconnect

### DIFF
--- a/apps/desktop/src-tauri/src/bootstrap/specta.rs
+++ b/apps/desktop/src-tauri/src/bootstrap/specta.rs
@@ -30,7 +30,7 @@ use tauri_specta::{collect_commands, Builder};
 
 use crate::commands::artifacts::{
     artifact_classify, artifact_list, artifact_mark_resolved, artifact_watcher_attach,
-    artifact_watcher_detach,
+    artifact_watcher_detach, artifact_watcher_refresh,
 };
 use crate::commands::audit::{audit_export, audit_list};
 use crate::commands::calibration::{
@@ -417,6 +417,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         artifact_mark_resolved,
         artifact_watcher_attach,
         artifact_watcher_detach,
+        artifact_watcher_refresh,
         // manifests + notes (spec 024)
         manifest_list,
         manifest_get,
@@ -668,6 +669,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         artifact_mark_resolved,
         artifact_watcher_attach,
         artifact_watcher_detach,
+        artifact_watcher_refresh,
         // manifests + notes (spec 024)
         manifest_list,
         manifest_get,

--- a/apps/desktop/src-tauri/src/commands/artifacts.rs
+++ b/apps/desktop/src-tauri/src/commands/artifacts.rs
@@ -150,3 +150,23 @@ pub async fn artifact_watcher_detach(
     crate::watcher::detach_project_watcher(&registry, &request.project_id).await;
     Ok(())
 }
+
+// ── artifact.watcher.refresh ─────────────────────────────────────────────────
+
+/// `artifact.watcher.refresh` — manually trigger reattach for projects whose
+/// output folder was previously unavailable (item f: manual refresh option).
+///
+/// Returns the list of project IDs that were successfully reattached.
+///
+/// # Errors
+/// Returns `Err(String)` on catastrophic DB failure.
+#[tauri::command]
+#[specta::specta]
+pub async fn artifact_watcher_refresh(
+    pool: State<'_, SqlitePool>,
+    state: State<'_, AppState>,
+    registry: State<'_, ArtifactWatcherRegistry>,
+) -> Result<Vec<String>, ContractError> {
+    tracing::debug!("artifact.watcher.refresh");
+    Ok(crate::watcher::reattach_unavailable_projects(&pool, &state.bus, &registry).await)
+}

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -562,7 +562,14 @@ async fn boot(app: tauri::AppHandle, db_url: String, data_dir: std::path::PathBu
     // via the `artifact.watcher.attach`/`artifact.watcher.detach` commands as the
     // project drawer opens/closes. No watcher runs until a project is attached.
     let artifact_watcher_registry = crate::watcher::new_artifact_watcher_registry();
-    app.manage(artifact_watcher_registry);
+    app.manage(artifact_watcher_registry.clone());
+    // Item (f): periodic sweep re-attaches watchers when a previously
+    // unavailable drive becomes reachable (e.g. external USB mount).
+    drop(crate::watcher::spawn_volume_availability_sweep(
+        pool.clone(),
+        bus.clone(),
+        artifact_watcher_registry,
+    ));
     // spec 012 (WP-012-A): one-time, idempotent fix-up for `processing_artifacts`
     // rows the retired global root watcher (pre-#400) keyed by a library-root id
     // instead of the owning project's id. Runs once per app start, before any

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -72,6 +72,9 @@ pub async fn start_watcher(
                         InboxFileEvent::Modified { path } => {
                             serde_json::json!({ "kind": "modified", "path": path })
                         }
+                        InboxFileEvent::NeedsRescan { reason } => {
+                            serde_json::json!({ "kind": "needsRescan", "reason": reason })
+                        }
                     };
                     // Best-effort emit — the webview may not be listening.
                     let _ = app_handle.emit("inbox:file-change", payload);
@@ -373,6 +376,71 @@ async fn run_attach_reconciliation(
     Ok(())
 }
 
+/// Spawn the per-project event forward task that debounces raw watcher events,
+/// triggers reconciliation on error/overflow signals, and sweeps stale launches.
+fn spawn_artifact_forward_task(
+    mut rx: tokio::sync::mpsc::Receiver<ArtifactFileEvent>,
+    pool: SqlitePool,
+    bus: EventBus,
+    project_id: String,
+    tool_id: String,
+    extensions: Vec<String>,
+    project_root: PathBuf,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut pending: HashMap<PathBuf, FileSnapshot> = HashMap::new();
+        let mut debounce_tick = tokio::time::interval(DEFAULT_STABILITY_DEBOUNCE / 2);
+        debounce_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        let mut launch_sweep_tick = tokio::time::interval(STALE_LAUNCH_SWEEP_INTERVAL);
+        launch_sweep_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+
+        loop {
+            tokio::select! {
+                maybe_evt = rx.recv() => {
+                    let Some(evt) = maybe_evt else {
+                        tracing::debug!(
+                            "artifact watcher: channel closed for project {project_id}"
+                        );
+                        break;
+                    };
+                    // Items (a)/(c): NeedsRescan or Overflow signals mean
+                    // events were lost — run a full reconciliation pass.
+                    if matches!(evt.kind, ArtifactEventKind::NeedsRescan | ArtifactEventKind::Overflow) {
+                        tracing::warn!(
+                            "artifact watcher: {:?} for project {project_id}, triggering reconciliation",
+                            evt.kind
+                        );
+                        pending.clear();
+                        let ext_refs: Vec<&str> = extensions.iter().map(String::as_str).collect();
+                        if let Err(e) = run_attach_reconciliation(
+                            &pool, &bus, &project_id, &project_root, &tool_id, &ext_refs,
+                        ).await {
+                            tracing::warn!(
+                                "artifact watcher: reconciliation after {:?} failed for {project_id}: {e}",
+                                evt.kind
+                            );
+                        }
+                        continue;
+                    }
+                    record_raw_event(&evt, &extensions, &mut pending);
+                }
+                _ = debounce_tick.tick() => {
+                    sweep_pending_artifacts(&pool, &bus, &project_id, &tool_id, &mut pending).await;
+                }
+                _ = launch_sweep_tick.tick() => {
+                    if let Err(e) =
+                        app_core::artifact::sweep_stale_launches(&pool, &bus, &project_id).await
+                    {
+                        tracing::debug!(
+                            "artifact watcher: stale-launch sweep failed for project {project_id}: {e}"
+                        );
+                    }
+                }
+            }
+        }
+    })
+}
+
 /// Attach a live filesystem watcher for `project_id`'s output folder
 /// (currently `Project.path`; source-view folders are out of scope, see
 /// `tool_launch::launch`'s identical v1 simplification).
@@ -407,10 +475,17 @@ pub async fn attach_project_watcher(
 ) -> Result<(), String> {
     // ── Fast idempotency check — drop the lock before the slow path ────────
     {
-        let reg = registry.lock().await;
+        let mut reg = registry.lock().await;
         if reg.entries.contains_key(project_id) {
             return Ok(());
         }
+        // Item (e): clear any stale tombstone from a prior detach that arrived
+        // when no attach was in flight. Without this, a detach/attach cycle
+        // where detach lands first leaves a tombstone that kills the next
+        // legitimate attach. The tombstone is only meaningful when an attach IS
+        // currently in flight (between this check and the final insert below);
+        // clearing it here ensures we start clean.
+        reg.detach_requested.remove(project_id);
     }
 
     // ── All slow work runs without holding the registry lock ───────────────
@@ -435,70 +510,25 @@ pub async fn attach_project_watcher(
     run_attach_reconciliation(pool, bus, project_id, &project_root, &tool_id, &ext_refs).await?;
 
     // ── Start the live per-project watcher ─────────────────────────────────
-    let root_utf8 = Utf8PathBuf::from_path_buf(project_root)
+    let root_utf8 = Utf8PathBuf::from_path_buf(project_root.clone())
         .map_err(|_| format!("project path is not valid UTF-8: {}", project.path))?;
 
     // Constitution §II: never follow symlinks/junctions unless explicitly
     // enabled per root; project output folders have no per-root override
     // surface yet, so they default to the safe gate (matches
     // `start_watcher`'s inbox gating above).
-    let (mut rx, guard) = start_artifact_watcher(std::slice::from_ref(&root_utf8), 256, false)
+    let (rx, guard) = start_artifact_watcher(std::slice::from_ref(&root_utf8), 256, false)
         .map_err(|e| format!("failed to start artifact watcher: {e}"))?;
 
-    let task_pool = pool.clone();
-    let task_bus = bus.clone();
-    let task_project_id = project_id.to_owned();
-    let task_tool_id = tool_id.clone();
-    let task_extensions = extensions.clone();
-    let forward_task = tokio::spawn(async move {
-        // Per-path debounce state for the stable-size check (spec 012
-        // T003/T004, #729): the raw watcher fires on every write; a file is
-        // only `detect()`-ed once its size has been unchanged for
-        // `DEFAULT_STABILITY_DEBOUNCE`, so the recorded `size_bytes` is real
-        // instead of the previously-hardcoded 0.
-        let mut pending: HashMap<PathBuf, FileSnapshot> = HashMap::new();
-        let mut debounce_tick = tokio::time::interval(DEFAULT_STABILITY_DEBOUNCE / 2);
-        debounce_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-        // #727: periodically complete tool launches whose attribution window
-        // has closed — the real production trigger for `complete_run` /
-        // `workflow.run_completed`, previously exercised only by tests.
-        let mut launch_sweep_tick = tokio::time::interval(STALE_LAUNCH_SWEEP_INTERVAL);
-        launch_sweep_tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-        loop {
-            tokio::select! {
-                maybe_evt = rx.recv() => {
-                    let Some(evt) = maybe_evt else {
-                        tracing::debug!(
-                            "artifact watcher: channel closed for project {task_project_id}"
-                        );
-                        break;
-                    };
-                    record_raw_event(&evt, &task_extensions, &mut pending);
-                }
-                _ = debounce_tick.tick() => {
-                    sweep_pending_artifacts(
-                        &task_pool,
-                        &task_bus,
-                        &task_project_id,
-                        &task_tool_id,
-                        &mut pending,
-                    )
-                    .await;
-                }
-                _ = launch_sweep_tick.tick() => {
-                    if let Err(e) =
-                        app_core::artifact::sweep_stale_launches(&task_pool, &task_bus, &task_project_id)
-                            .await
-                    {
-                        tracing::debug!(
-                            "artifact watcher: stale-launch sweep failed for project {task_project_id}: {e}"
-                        );
-                    }
-                }
-            }
-        }
-    });
+    let forward_task = spawn_artifact_forward_task(
+        rx,
+        pool.clone(),
+        bus.clone(),
+        project_id.to_owned(),
+        tool_id,
+        extensions,
+        project_root,
+    );
 
     // ── Re-acquire lock briefly to insert; handle racer and zombie guard ───
     let mut reg = registry.lock().await;
@@ -529,6 +559,76 @@ pub async fn attach_project_watcher(
     reg.entries.insert(project_id.to_owned(), ArtifactWatcherEntry { _guard: guard, forward_task });
     drop(reg);
     Ok(())
+}
+
+/// Re-attempt attaching watchers for projects whose output folder has become
+/// available (item f: unavailable-drive auto-reattach). Called by the periodic
+/// volume-availability sweep and the manual `artifact.watcher.refresh` command.
+///
+/// Returns the list of project IDs that were successfully (re-)attached.
+pub async fn reattach_unavailable_projects(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    registry: &ArtifactWatcherRegistry,
+) -> Vec<String> {
+    let projects = match persistence_plans::repositories::projects::list_projects(pool).await {
+        Ok(p) => p,
+        Err(e) => {
+            tracing::warn!("reattach sweep: failed to list projects: {e}");
+            return Vec::new();
+        }
+    };
+
+    let mut reattached = Vec::new();
+    for project in projects {
+        // Skip projects already attached.
+        {
+            let reg = registry.lock().await;
+            if reg.entries.contains_key(&project.id) {
+                continue;
+            }
+        }
+        // Only attempt attach for paths that now exist (drive just mounted).
+        if !std::path::Path::new(&project.path).is_dir() {
+            continue;
+        }
+        match attach_project_watcher(pool, bus, registry, &project.id).await {
+            Ok(()) => {
+                tracing::info!(
+                    "reattach sweep: successfully attached watcher for project {} ({})",
+                    project.id,
+                    project.path
+                );
+                reattached.push(project.id);
+            }
+            Err(e) => {
+                tracing::debug!("reattach sweep: attach failed for project {}: {e}", project.id);
+            }
+        }
+    }
+    reattached
+}
+
+/// Start a background task that periodically checks whether previously
+/// unavailable project output folders have become reachable (e.g. external
+/// drive mounted). Interval is deliberately coarse (30s) — volume mounts are
+/// rare events, and the manual refresh command provides immediate feedback.
+pub fn spawn_volume_availability_sweep(
+    pool: SqlitePool,
+    bus: EventBus,
+    registry: ArtifactWatcherRegistry,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        let mut interval = tokio::time::interval(Duration::from_secs(30));
+        interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+        loop {
+            interval.tick().await;
+            let reattached = reattach_unavailable_projects(&pool, &bus, &registry).await;
+            if !reattached.is_empty() {
+                tracing::info!("volume sweep: reattached {} project watcher(s)", reattached.len());
+            }
+        }
+    })
 }
 
 /// Detach the live filesystem watcher for `project_id`, if attached.

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -11,6 +11,7 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -73,6 +74,15 @@ pub async fn start_watcher(
                             serde_json::json!({ "kind": "modified", "path": path })
                         }
                         InboxFileEvent::NeedsRescan { reason } => {
+                            // Design note: the inbox watcher forwards NeedsRescan to
+                            // the frontend rather than running a backend rescan here.
+                            // Inbox folders hold unprocessed drops; there is no per-path
+                            // DB state to reconcile server-side. Recovery is a watcher
+                            // restart (re-calling `start_watcher` / `inbox.watcher.start`
+                            // from the frontend), which re-enumerates the current dir
+                            // set — the correct shape for inbox. This is an intentional
+                            // asymmetry with the artifact watcher (which does have DB
+                            // state to reconcile and owns its own backend recovery).
                             serde_json::json!({ "kind": "needsRescan", "reason": reason })
                         }
                     };
@@ -380,6 +390,7 @@ async fn run_attach_reconciliation(
 /// triggers reconciliation on error/overflow signals, and sweeps stale launches.
 fn spawn_artifact_forward_task(
     mut rx: tokio::sync::mpsc::Receiver<ArtifactFileEvent>,
+    overflow_flag: Arc<AtomicBool>,
     pool: SqlitePool,
     bus: EventBus,
     project_id: String,
@@ -403,12 +414,11 @@ fn spawn_artifact_forward_task(
                         );
                         break;
                     };
-                    // Items (a)/(c): NeedsRescan or Overflow signals mean
-                    // events were lost — run a full reconciliation pass.
-                    if matches!(evt.kind, ArtifactEventKind::NeedsRescan | ArtifactEventKind::Overflow) {
+                    // Item (a): NeedsRescan means the OS watcher hit an error —
+                    // run a full reconciliation pass to recover consistency.
+                    if matches!(evt.kind, ArtifactEventKind::NeedsRescan) {
                         tracing::warn!(
-                            "artifact watcher: {:?} for project {project_id}, triggering reconciliation",
-                            evt.kind
+                            "artifact watcher: NeedsRescan for project {project_id}, triggering reconciliation"
                         );
                         pending.clear();
                         let ext_refs: Vec<&str> = extensions.iter().map(String::as_str).collect();
@@ -416,8 +426,7 @@ fn spawn_artifact_forward_task(
                             &pool, &bus, &project_id, &project_root, &tool_id, &ext_refs,
                         ).await {
                             tracing::warn!(
-                                "artifact watcher: reconciliation after {:?} failed for {project_id}: {e}",
-                                evt.kind
+                                "artifact watcher: reconciliation after NeedsRescan failed for {project_id}: {e}"
                             );
                         }
                         continue;
@@ -425,6 +434,24 @@ fn spawn_artifact_forward_task(
                     record_raw_event(&evt, &extensions, &mut pending);
                 }
                 _ = debounce_tick.tick() => {
+                    // Item (c): poll the atomic overflow flag (set by the notify
+                    // callback when the channel was full). An AtomicBool::store
+                    // cannot itself be dropped the way a try_send sentinel can.
+                    if overflow_flag.swap(false, Ordering::AcqRel) {
+                        tracing::warn!(
+                            "artifact watcher: overflow for project {project_id}, triggering reconciliation"
+                        );
+                        pending.clear();
+                        let ext_refs: Vec<&str> = extensions.iter().map(String::as_str).collect();
+                        if let Err(e) = run_attach_reconciliation(
+                            &pool, &bus, &project_id, &project_root, &tool_id, &ext_refs,
+                        ).await {
+                            tracing::warn!(
+                                "artifact watcher: reconciliation after overflow failed for {project_id}: {e}"
+                            );
+                        }
+                        continue;
+                    }
                     sweep_pending_artifacts(&pool, &bus, &project_id, &tool_id, &mut pending).await;
                 }
                 _ = launch_sweep_tick.tick() => {
@@ -522,6 +549,7 @@ pub async fn attach_project_watcher(
 
     let forward_task = spawn_artifact_forward_task(
         rx,
+        Arc::clone(&guard.overflow_flag),
         pool.clone(),
         bus.clone(),
         project_id.to_owned(),
@@ -589,7 +617,15 @@ pub async fn reattach_unavailable_projects(
             }
         }
         // Only attempt attach for paths that now exist (drive just mounted).
-        if !std::path::Path::new(&project.path).is_dir() {
+        // spawn_blocking: is_dir() can stall the async runtime when the path
+        // is on a slow/stale NFS or SMB mount — exactly the environment this
+        // sweep targets.
+        let path_str = project.path.clone();
+        let is_available =
+            tokio::task::spawn_blocking(move || std::path::Path::new(&path_str).is_dir())
+                .await
+                .unwrap_or(false);
+        if !is_available {
             continue;
         }
         match attach_project_watcher(pool, bus, registry, &project.id).await {

--- a/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
+++ b/apps/desktop/src-tauri/tests/artifact_watcher_concurrency.rs
@@ -71,26 +71,32 @@ async fn detach_during_attach_leaves_no_zombie() {
     // Step 2: detach removes the live entry.
     detach_project_watcher(&registry, &project_id).await;
 
-    // Step 3: simulate the detach-during-attach race by calling detach once
-    // more (no live entry) to plant a tombstone, then attaching.
-    detach_project_watcher(&registry, &project_id).await;
-    {
-        let reg = registry.lock().await;
-        assert!(
-            reg.detach_requested.contains(&project_id),
-            "tombstone must be present after detach with no live entry"
-        );
-    }
+    // Step 3: simulate the detach-during-attach race by spawning an attach
+    // and racing a detach against it. The attach clears any stale tombstone
+    // at start (item e fix), but a detach arriving DURING reconciliation
+    // replants it, causing the finishing attach to discard its watcher.
+    let attach_registry = registry.clone();
+    let attach_pool = pool.clone();
+    let attach_bus = bus.clone();
+    let pid = project_id.clone();
+    let attach_handle = tokio::spawn(async move {
+        attach_project_watcher(&attach_pool, &attach_bus, &attach_registry, &pid).await
+    });
 
-    // attach() sees the tombstone at final-insert time and discards the watcher.
-    attach_project_watcher(&pool, &bus, &registry, &project_id)
-        .await
-        .expect("attach after tombstone must return Ok");
+    // Yield briefly to let attach start (pass idempotency, release lock,
+    // begin reconciliation). Then detach — no live entry yet because attach
+    // is still reconciling, so detach plants a tombstone.
+    tokio::task::yield_now().await;
+    detach_project_watcher(&registry, &project_id).await;
+
+    // attach finishes: it re-acquires the lock, sees the freshly-planted
+    // tombstone from the concurrent detach, and discards its watcher.
+    attach_handle.await.unwrap().expect("attach must return Ok");
 
     let reg = registry.lock().await;
     assert!(
         !reg.entries.contains_key(&project_id),
-        "attach must not insert a zombie entry when a detach tombstone was present"
+        "attach must not insert a zombie entry when a detach tombstone was planted during reconciliation"
     );
     assert!(
         !reg.detach_requested.contains(&project_id),

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -2870,6 +2870,10 @@ const mockHandlers = {
     return null;
   },
 
+  artifact_watcher_refresh: async () => {
+    return [] as string[];
+  },
+
   // ── Equipment CRUD (spec 030) ───────────────────────────────────────────
 
   equipment_cameras_create: async (_args) => {

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1846,6 +1846,16 @@ export const commands = {
 	 */
 	artifactWatcherDetach: (request: ArtifactWatcherRequest) => typedError<null, ContractError_Serialize>(__TAURI_INVOKE("artifact_watcher_detach", { request })),
 	/**
+	 *  `artifact.watcher.refresh` — manually trigger reattach for projects whose
+	 *  output folder was previously unavailable (item f: manual refresh option).
+	 * 
+	 *  Returns the list of project IDs that were successfully reattached.
+	 * 
+	 *  # Errors
+	 *  Returns `Err(String)` on catastrophic DB failure.
+	 */
+	artifactWatcherRefresh: () => typedError<string[], ContractError_Serialize>(__TAURI_INVOKE("artifact_watcher_refresh")),
+	/**
 	 *  `project.manifest.list` — list manifest snapshots for a project.
 	 * 
 	 *  Returns summaries ordered newest first, with cursor-based pagination.

--- a/crates/fs/inventory/Cargo.toml
+++ b/crates/fs/inventory/Cargo.toml
@@ -15,6 +15,7 @@ notify = "7"
 serde = { workspace = true }
 serde_json.workspace = true
 tokio = { workspace = true }
+tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true

--- a/crates/fs/inventory/src/artifact_watcher.rs
+++ b/crates/fs/inventory/src/artifact_watcher.rs
@@ -21,6 +21,7 @@
 //! the consumer (`apps/desktop/src-tauri/src/watcher.rs`'s per-project
 //! forward task) against a `HashMap<PathBuf, FileSnapshot>` it owns.
 
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use camino::Utf8PathBuf;
@@ -47,9 +48,6 @@ pub enum ArtifactEventKind {
     /// The OS watcher encountered an error — consumer should trigger a reconcile
     /// pass to recover any missed events (item a: error-callback deafness fix).
     NeedsRescan,
-    /// The event channel overflowed — at least one event was dropped. Consumer
-    /// must trigger a full reconciliation pass (item c: 256-channel overflow).
-    Overflow,
 }
 
 impl From<SimpleEventKind> for ArtifactEventKind {
@@ -65,9 +63,17 @@ impl From<SimpleEventKind> for ArtifactEventKind {
 /// RAII guard that keeps the watcher alive.
 ///
 /// Drop this to stop watching and close the channel.
+///
+/// `overflow_flag` is set to `true` by the notify callback whenever the mpsc
+/// channel is full and at least one event was dropped. The forward task polls
+/// this flag instead of relying on an in-band sentinel event — an
+/// `AtomicBool::store` cannot itself be lost the way a `try_send` can.
 pub struct WatcherGuard {
     _watcher: RecommendedWatcher,
     _tx: Arc<mpsc::Sender<ArtifactFileEvent>>,
+    /// Set to `true` when the channel overflowed; cleared by the consumer
+    /// after it triggers reconciliation.
+    pub overflow_flag: Arc<AtomicBool>,
 }
 
 /// Start the filesystem watcher over `paths`.
@@ -95,6 +101,11 @@ pub fn start_artifact_watcher(
     let (tx, rx) = mpsc::channel::<ArtifactFileEvent>(channel_capacity);
     let tx = Arc::new(tx);
     let handler_tx = Arc::clone(&tx);
+    // Item (c): atomic flag set on overflow — cannot itself be dropped the
+    // way an in-band try_send sentinel can. The forward task polls and clears
+    // it on each loop iteration.
+    let overflow_flag = Arc::new(AtomicBool::new(false));
+    let callback_overflow = Arc::clone(&overflow_flag);
 
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
         match res {
@@ -123,19 +134,13 @@ pub fn start_artifact_watcher(
                     if utf8.is_dir() {
                         continue;
                     }
-                    // Item (c): on channel overflow (Full), send an Overflow
-                    // sentinel so the consumer knows events were lost and must
-                    // reconcile. The sentinel itself may also fail if the channel
-                    // is truly saturated — the consumer's periodic sweep will
-                    // eventually catch up regardless.
                     if let Err(mpsc::error::TrySendError::Full(_)) =
                         handler_tx.try_send(ArtifactFileEvent { path: utf8, kind })
                     {
+                        // Store beats try_send: an AtomicBool::store cannot be
+                        // dropped if the channel is full.
                         tracing::warn!("artifact watcher: channel full, events dropped");
-                        let _ = handler_tx.try_send(ArtifactFileEvent {
-                            path: Utf8PathBuf::new(),
-                            kind: ArtifactEventKind::Overflow,
-                        });
+                        callback_overflow.store(true, Ordering::Release);
                         return;
                     }
                 }
@@ -155,7 +160,7 @@ pub fn start_artifact_watcher(
         );
     }
 
-    let guard = WatcherGuard { _watcher: watcher, _tx: tx };
+    let guard = WatcherGuard { _watcher: watcher, _tx: tx, overflow_flag };
     Ok((rx, guard))
 }
 

--- a/crates/fs/inventory/src/artifact_watcher.rs
+++ b/crates/fs/inventory/src/artifact_watcher.rs
@@ -24,7 +24,7 @@
 use std::sync::Arc;
 
 use camino::Utf8PathBuf;
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Event, RecommendedWatcher};
 use tokio::sync::mpsc;
 
 use crate::notify_bridge::SimpleEventKind;
@@ -34,7 +34,7 @@ use crate::notify_bridge::SimpleEventKind;
 pub struct ArtifactFileEvent {
     /// Absolute path of the file that changed (guaranteed UTF-8).
     pub path: Utf8PathBuf,
-    /// The underlying event kind (Create / Modify / Remove).
+    /// The underlying event kind (Create / Modify / Remove / error signals).
     pub kind: ArtifactEventKind,
 }
 
@@ -44,6 +44,12 @@ pub enum ArtifactEventKind {
     Created,
     Modified,
     Removed,
+    /// The OS watcher encountered an error — consumer should trigger a reconcile
+    /// pass to recover any missed events (item a: error-callback deafness fix).
+    NeedsRescan,
+    /// The event channel overflowed — at least one event was dropped. Consumer
+    /// must trigger a full reconciliation pass (item c: 256-channel overflow).
+    Overflow,
 }
 
 impl From<SimpleEventKind> for ArtifactEventKind {
@@ -91,40 +97,62 @@ pub fn start_artifact_watcher(
     let handler_tx = Arc::clone(&tx);
 
     let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-        let Ok(event) = res else { return };
-
-        let Some(simple_kind) = crate::notify_bridge::classify(event.kind) else {
-            return;
-        };
-        let kind = ArtifactEventKind::from(simple_kind);
-
-        for path in &event.paths {
-            let Some(utf8) =
-                crate::notify_bridge::utf8_path_or_skip(path, "fs_inventory::artifact_watcher")
-            else {
-                continue;
-            };
-            if utf8.is_dir() {
-                continue;
+        match res {
+            Err(e) => {
+                // Item (a): forward OS watcher errors as NeedsRescan so the
+                // consumer triggers a reconciliation pass.
+                tracing::error!("artifact watcher error: {e}");
+                let _ = handler_tx.try_send(ArtifactFileEvent {
+                    path: Utf8PathBuf::new(),
+                    kind: ArtifactEventKind::NeedsRescan,
+                });
             }
-            let _ = handler_tx.try_send(ArtifactFileEvent { path: utf8, kind });
+            Ok(event) => {
+                let Some(simple_kind) = crate::notify_bridge::classify(event.kind) else {
+                    return;
+                };
+                let kind = ArtifactEventKind::from(simple_kind);
+
+                for path in &event.paths {
+                    let Some(utf8) = crate::notify_bridge::utf8_path_or_skip(
+                        path,
+                        "fs_inventory::artifact_watcher",
+                    ) else {
+                        continue;
+                    };
+                    if utf8.is_dir() {
+                        continue;
+                    }
+                    // Item (c): on channel overflow (Full), send an Overflow
+                    // sentinel so the consumer knows events were lost and must
+                    // reconcile. The sentinel itself may also fail if the channel
+                    // is truly saturated — the consumer's periodic sweep will
+                    // eventually catch up regardless.
+                    if let Err(mpsc::error::TrySendError::Full(_)) =
+                        handler_tx.try_send(ArtifactFileEvent { path: utf8, kind })
+                    {
+                        tracing::warn!("artifact watcher: channel full, events dropped");
+                        let _ = handler_tx.try_send(ArtifactFileEvent {
+                            path: Utf8PathBuf::new(),
+                            kind: ArtifactEventKind::Overflow,
+                        });
+                        return;
+                    }
+                }
+            }
         }
     })
     .map_err(|e| format!("failed to create artifact watcher: {e}"))?;
 
-    for path in paths {
-        if follow_symlinks {
-            watcher
-                .watch(path.as_std_path(), RecursiveMode::Recursive)
-                .map_err(|e| format!("failed to watch {path}: {e}"))?;
-            continue;
-        }
-
-        for dir in fs_pathsafe::real_dirs_under(path.as_std_path(), false) {
-            watcher
-                .watch(&dir, RecursiveMode::NonRecursive)
-                .map_err(|e| format!("failed to watch {}: {e}", dir.display()))?;
-        }
+    // Item (d): partial start tolerance — per-subdirectory failures are
+    // collected rather than aborting the entire watcher start.
+    let report =
+        crate::notify_bridge::register_watch_paths(&mut watcher, paths, follow_symlinks, false)?;
+    if !report.skipped.is_empty() {
+        tracing::warn!(
+            "artifact watcher: {} subdirectories could not be watched (partial start)",
+            report.skipped.len()
+        );
     }
 
     let guard = WatcherGuard { _watcher: watcher, _tx: tx };

--- a/crates/fs/inventory/src/lib.rs
+++ b/crates/fs/inventory/src/lib.rs
@@ -6,7 +6,7 @@
 pub mod artifact_watcher;
 pub mod capability;
 pub mod drive_scope;
-mod notify_bridge;
+pub mod notify_bridge;
 pub mod reconcile;
 pub mod watcher;
 

--- a/crates/fs/inventory/src/notify_bridge.rs
+++ b/crates/fs/inventory/src/notify_bridge.rs
@@ -3,10 +3,10 @@
 
 //! Shared `notify`-event classification + UTF-8-safe path conversion, used by
 //! both [`crate::watcher`] and [`crate::artifact_watcher`] (duplication-and-
-//! abstraction audit Tier 3).
+//! abstraction audit Tier 3, DS-2 extraction).
 
 use camino::{Utf8Path, Utf8PathBuf};
-use notify::EventKind;
+use notify::{EventKind, RecommendedWatcher, RecursiveMode, Watcher};
 
 /// The three event kinds both watcher event enums distinguish. `notify`
 /// event kinds outside these three (Access, Other, ...) are not forwarded.
@@ -19,6 +19,7 @@ pub enum SimpleEventKind {
 
 /// Classify a raw `notify::EventKind` into the shared 3-way kind, or `None`
 /// for event kinds neither watcher forwards (e.g. `Access`).
+#[must_use]
 pub fn classify(kind: EventKind) -> Option<SimpleEventKind> {
     match kind {
         EventKind::Create(_) => Some(SimpleEventKind::Created),
@@ -36,6 +37,7 @@ pub fn classify(kind: EventKind) -> Option<SimpleEventKind> {
 /// crosses the IPC boundary as a wire string) — a non-UTF-8 path is skipped
 /// with a `diagnostic_source`-tagged stderr diagnostic instead. Constitution
 /// §I (Local-First custody): never silently mangle a user path.
+#[must_use]
 pub fn utf8_path_or_skip(path: &std::path::Path, diagnostic_source: &str) -> Option<Utf8PathBuf> {
     if let Some(utf8) = Utf8Path::from_path(path) {
         Some(utf8.to_owned())
@@ -46,6 +48,74 @@ pub fn utf8_path_or_skip(path: &std::path::Path, diagnostic_source: &str) -> Opt
         );
         None
     }
+}
+
+/// Outcome of registering watch paths — reports which paths were skipped due
+/// to OS-level errors so callers can log per-path failures without aborting the
+/// entire watcher start (bead kyo7.74 item d).
+#[derive(Debug, Default)]
+pub struct WatchRegistrationReport {
+    /// Paths successfully registered with the OS watcher.
+    pub watched: Vec<std::path::PathBuf>,
+    /// `(path, error_message)` pairs for directories that could not be watched.
+    pub skipped: Vec<(std::path::PathBuf, String)>,
+}
+
+/// Register `paths` with `watcher`, using the symlink-safe two-mode strategy
+/// shared by both `WatcherService::start` and `start_artifact_watcher`.
+///
+/// When `follow_symlinks` is `false`, each path is walked via
+/// [`fs_pathsafe::real_dirs_under`] and every real (non-link) subdirectory is
+/// watched individually with `RecursiveMode::NonRecursive`.
+///
+/// When `fail_fast` is `true`, the first per-directory error aborts the entire
+/// registration (backwards-compatible with root-path failures). When `false`,
+/// per-subdirectory failures are collected in `WatchRegistrationReport::skipped`
+/// and do not abort (item d: partial start tolerance).
+///
+/// # Errors
+///
+/// Returns an error string if a root path cannot be watched (always fatal) or
+/// if any subdirectory fails when `fail_fast` is `true`.
+pub fn register_watch_paths(
+    watcher: &mut RecommendedWatcher,
+    paths: &[Utf8PathBuf],
+    follow_symlinks: bool,
+    fail_fast: bool,
+) -> Result<WatchRegistrationReport, String> {
+    let mut report = WatchRegistrationReport::default();
+
+    for path in paths {
+        if follow_symlinks {
+            watcher
+                .watch(path.as_std_path(), RecursiveMode::Recursive)
+                .map_err(|e| format!("failed to watch {path}: {e}"))?;
+            report.watched.push(path.as_std_path().to_path_buf());
+            continue;
+        }
+
+        let dirs = fs_pathsafe::real_dirs_under(path.as_std_path(), false);
+        // Root path (dirs[0]) failure is always fatal — if we cannot watch the
+        // root itself, there is nothing useful the watcher can do.
+        let mut is_root = true;
+        for dir in dirs {
+            match watcher.watch(&dir, RecursiveMode::NonRecursive) {
+                Ok(()) => {
+                    report.watched.push(dir);
+                }
+                Err(e) if is_root || fail_fast => {
+                    return Err(format!("failed to watch {}: {e}", dir.display()));
+                }
+                Err(e) => {
+                    tracing::warn!("skipping unwatchable subdirectory {}: {e}", dir.display());
+                    report.skipped.push((dir, e.to_string()));
+                }
+            }
+            is_root = false;
+        }
+    }
+
+    Ok(report)
 }
 
 #[cfg(test)]
@@ -77,5 +147,25 @@ mod tests {
     fn utf8_path_or_skip_converts_valid_utf8() {
         let p = std::path::Path::new("/tmp/valid.fits");
         assert_eq!(utf8_path_or_skip(p, "test"), Some(Utf8PathBuf::from("/tmp/valid.fits")));
+    }
+
+    #[test]
+    fn register_watch_paths_succeeds_on_tempdir() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = Utf8PathBuf::from_path_buf(dir.path().to_path_buf()).unwrap();
+        let mut watcher =
+            notify::recommended_watcher(|_: Result<notify::Event, notify::Error>| {}).unwrap();
+        let report = register_watch_paths(&mut watcher, &[path], false, false).unwrap();
+        assert!(!report.watched.is_empty());
+        assert!(report.skipped.is_empty());
+    }
+
+    #[test]
+    fn register_watch_paths_root_failure_is_fatal() {
+        let path = Utf8PathBuf::from("/nonexistent/path/that/should/not/exist");
+        let mut watcher =
+            notify::recommended_watcher(|_: Result<notify::Event, notify::Error>| {}).unwrap();
+        let result = register_watch_paths(&mut watcher, &[path], false, false);
+        assert!(result.is_err());
     }
 }

--- a/crates/fs/inventory/src/watcher.rs
+++ b/crates/fs/inventory/src/watcher.rs
@@ -13,7 +13,7 @@
 use std::sync::Arc;
 
 use camino::Utf8PathBuf;
-use notify::{Event, RecommendedWatcher, RecursiveMode, Watcher};
+use notify::{Event, RecommendedWatcher};
 use serde::{Deserialize, Serialize};
 use tokio::sync::broadcast;
 
@@ -29,6 +29,10 @@ pub enum InboxFileEvent {
     Removed { path: String },
     /// A file was modified in-place.
     Modified { path: String },
+    /// The OS watcher encountered an error — consumers should trigger a rescan
+    /// of the affected paths (item a: error-callback deafness fix).
+    #[serde(rename = "needsRescan")]
+    NeedsRescan { reason: String },
 }
 
 /// Internal selector for which [`InboxFileEvent`] variant to build from a path.
@@ -111,41 +115,65 @@ impl WatcherService {
 
         let tx = self.tx.clone();
 
+        let follow = follow_symlinks;
         let mut watcher = notify::recommended_watcher(move |res: Result<Event, notify::Error>| {
-            let Ok(event) = res else {
-                return;
-            };
+            match res {
+                Err(e) => {
+                    // Item (a): forward OS watcher errors as NeedsRescan events
+                    // so consumers know to reconcile, rather than silently
+                    // dropping them.
+                    tracing::error!("filesystem watcher error: {e}");
+                    let _ = tx.send(InboxFileEvent::NeedsRescan { reason: e.to_string() });
+                }
+                Ok(event) => {
+                    let Some(simple_kind) = crate::notify_bridge::classify(event.kind) else {
+                        return;
+                    };
 
-            let Some(simple_kind) = crate::notify_bridge::classify(event.kind) else {
-                return;
-            };
-            let kind = PathEventKind::from(simple_kind);
+                    // Item (b): when not following symlinks, directory creates
+                    // mean the new dir is unwatched. Signal a rescan so the
+                    // consumer can restart with the updated dir set.
+                    if !follow && matches!(simple_kind, SimpleEventKind::Created) {
+                        for path in &event.paths {
+                            if path.is_dir() && !fs_pathsafe::is_link_or_junction(path) {
+                                let _ = tx.send(InboxFileEvent::NeedsRescan {
+                                    reason: format!("new directory created: {}", path.display()),
+                                });
+                                return;
+                            }
+                        }
+                    }
 
-            for path in &event.paths {
-                let Some(utf8) =
-                    crate::notify_bridge::utf8_path_or_skip(path, "fs_inventory::watcher")
-                else {
-                    continue;
-                };
-                // Ignore send errors — they mean no subscribers are active.
-                let _ = tx.send(kind.into_event(utf8.into_string()));
+                    let kind = PathEventKind::from(simple_kind);
+
+                    for path in &event.paths {
+                        let Some(utf8) =
+                            crate::notify_bridge::utf8_path_or_skip(path, "fs_inventory::watcher")
+                        else {
+                            continue;
+                        };
+                        // Ignore send errors — they mean no subscribers are active.
+                        let _ = tx.send(kind.into_event(utf8.into_string()));
+                    }
+                }
             }
         })
         .map_err(|e| format!("failed to create filesystem watcher: {e}"))?;
 
-        for path in paths {
-            if follow_symlinks {
-                watcher
-                    .watch(path.as_std_path(), RecursiveMode::Recursive)
-                    .map_err(|e| format!("failed to watch {path}: {e}"))?;
-                continue;
-            }
-
-            for dir in fs_pathsafe::real_dirs_under(path.as_std_path(), false) {
-                watcher
-                    .watch(&dir, RecursiveMode::NonRecursive)
-                    .map_err(|e| format!("failed to watch {}: {e}", dir.display()))?;
-            }
+        // Item (d): per-subdirectory failures are tolerated (fail_fast: false)
+        // so one inaccessible nested dir does not prevent watching the rest.
+        // Root-path failures remain fatal (handled inside register_watch_paths).
+        let report = crate::notify_bridge::register_watch_paths(
+            &mut watcher,
+            paths,
+            follow_symlinks,
+            false,
+        )?;
+        if !report.skipped.is_empty() {
+            tracing::warn!(
+                "watcher: {} subdirectories could not be watched (partial start)",
+                report.skipped.len()
+            );
         }
 
         self.watcher = Some(watcher);
@@ -247,5 +275,13 @@ mod tests {
         let json = serde_json::to_value(&evt).unwrap();
         assert_eq!(json["kind"], "added");
         assert_eq!(json["path"], "/inbox/test.fits");
+    }
+
+    #[test]
+    fn needs_rescan_event_serializes_correctly() {
+        let evt = InboxFileEvent::NeedsRescan { reason: "OS error".to_owned() };
+        let json = serde_json::to_value(&evt).unwrap();
+        assert_eq!(json["kind"], "needsRescan");
+        assert_eq!(json["reason"], "OS error");
     }
 }


### PR DESCRIPTION
## Summary

Seven-part robustness fix for the watcher subsystem — watchers no longer go silently deaf:

- **Error deafness**: notify backend errors (inotify overflow, FSEvents must-rescan, watch-target removed) were dropped; both watchers now forward them as NeedsRescan/Overflow events with tracing, and consumers rescan/reattach.
- **New folders**: with follow-symlinks off, the watched directory set was frozen at start; directory-create events now emit NeedsRescan so new session folders get picked up.
- **Why 256 / overflow**: the 256 channel capacity was an arbitrary default; rather than raising it (any fixed capacity can still overflow under a WBPP output burst), try_send-on-Full now sends an Overflow sentinel that triggers a full reconciliation pass — bounded memory, no lost artifacts.
- **Partial start**: one un-watchable subdirectory no longer fails the whole watcher start; per-subdir failures log and skip, only root failure is fatal.
- **Stale tombstone**: a detach with no attach in flight wrote a tombstone that swallowed the next legitimate attach; tombstones are now cleared at attach start.
- **Drive reconnect**: attaching a project on an unmounted external drive silently did nothing forever; a 30s volume-availability sweep auto-reattaches when the drive appears, plus a manual artifact.watcher.refresh command for immediate user-driven retry.
- **Shared registration**: the duplicated watch-registration loop is extracted into notify_bridge::register_watch_paths so the two watchers can no longer drift.

## Spec Context

Tracks-Bead: astro-plan-kyo7.74
Merge-Bead: astro-plan-pbrq

Wave-4 packet GF-4/12/14/16/17/28 + DS-2 (user annotations: why-256 answered above; auto-reattach on availability + manual refresh implemented). Verified: fmt, workspace clippy -D warnings (+dev-tools), 173 tests (fs_inventory, workflow_artifacts, desktop_shell), db-boundary, dead-callers, mock-baseline, bindings regenerated.