### PR TITLE
refactor: lifecycle states become typed enums, ending string-comparison drift

### DIFF
--- a/crates/app/inbox/src/attribution.rs
+++ b/crates/app/inbox/src/attribution.rs
@@ -330,7 +330,10 @@ async fn same_optic_train_candidates(
                 framing_id: Some(f.id.clone()),
                 target_id: f.target_id.clone(),
                 match_score: match_score_from_distance(dist, pointing_tolerance_deg),
-                reopen: Some(DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data)),
+                reopen: Some(
+                    DomainProjectState::parse_str(&project.lifecycle)
+                        .is_some_and(DomainProjectState::reopens_on_new_data),
+                ),
                 optic_mismatch: None,
             },
             // US6 AS3: a mosaic project's first NEW panel (pointing matches
@@ -342,7 +345,10 @@ async fn same_optic_train_candidates(
                 framing_id: None,
                 target_id: project_target_id,
                 match_score: 0.5,
-                reopen: Some(DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data)),
+                reopen: Some(
+                    DomainProjectState::parse_str(&project.lifecycle)
+                        .is_some_and(DomainProjectState::reopens_on_new_data),
+                ),
                 optic_mismatch: None,
             },
         });
@@ -402,7 +408,10 @@ async fn flag_optic_difference_candidates(
             framing_id: None,
             target_id: Some(target_id.to_owned()),
             match_score: 0.3,
-            reopen: Some(DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data)),
+            reopen: Some(
+                DomainProjectState::parse_str(&project.lifecycle)
+                    .is_some_and(DomainProjectState::reopens_on_new_data),
+            ),
             optic_mismatch: Some(true),
         });
     }
@@ -526,7 +535,9 @@ pub async fn apply_chosen_attribution(
 
     // F-Framing-6: completed-project match -> add + reopen (Q25 revoke/warn).
     let project = projects_repo::get_project(pool, &project_id).await.map_err(db_err)?;
-    let (reopened, raw_subs_archived_warning) = if DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data) {
+    let (reopened, raw_subs_archived_warning) = if DomainProjectState::parse_str(&project.lifecycle)
+        .is_some_and(DomainProjectState::reopens_on_new_data)
+    {
         reopen_completed_project(pool, bus, &project_id).await?
     } else {
         (false, false)

--- a/crates/app/inbox/src/attribution.rs
+++ b/crates/app/inbox/src/attribution.rs
@@ -51,6 +51,7 @@ use contracts_core::lifecycle::{ProjectState, ProjectTransitionRequest, Transiti
 use contracts_core::{ContractError, ErrorSeverity};
 use domain_core::ids::{new_id, EntityId};
 use domain_core::lifecycle::data_asset::EntityType;
+use domain_core::lifecycle::ProjectState as DomainProjectState;
 use domain_core::project::framing::Pointing;
 use persistence_inbox::repositories::inbox as inbox_repo;
 use persistence_lifecycle::repositories::lifecycle::SqliteLifecycleRepository;
@@ -329,7 +330,7 @@ async fn same_optic_train_candidates(
                 framing_id: Some(f.id.clone()),
                 target_id: f.target_id.clone(),
                 match_score: match_score_from_distance(dist, pointing_tolerance_deg),
-                reopen: Some(project.lifecycle == "completed"),
+                reopen: Some(DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data)),
                 optic_mismatch: None,
             },
             // US6 AS3: a mosaic project's first NEW panel (pointing matches
@@ -341,7 +342,7 @@ async fn same_optic_train_candidates(
                 framing_id: None,
                 target_id: project_target_id,
                 match_score: 0.5,
-                reopen: Some(project.lifecycle == "completed"),
+                reopen: Some(DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data)),
                 optic_mismatch: None,
             },
         });
@@ -401,7 +402,7 @@ async fn flag_optic_difference_candidates(
             framing_id: None,
             target_id: Some(target_id.to_owned()),
             match_score: 0.3,
-            reopen: Some(project.lifecycle == "completed"),
+            reopen: Some(DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data)),
             optic_mismatch: Some(true),
         });
     }
@@ -525,7 +526,7 @@ pub async fn apply_chosen_attribution(
 
     // F-Framing-6: completed-project match -> add + reopen (Q25 revoke/warn).
     let project = projects_repo::get_project(pool, &project_id).await.map_err(db_err)?;
-    let (reopened, raw_subs_archived_warning) = if project.lifecycle == "completed" {
+    let (reopened, raw_subs_archived_warning) = if DomainProjectState::parse_str(&project.lifecycle).is_some_and(DomainProjectState::reopens_on_new_data) {
         reopen_completed_project(pool, bus, &project_id).await?
     } else {
         (false, false)

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -529,11 +529,7 @@ fn is_system_permitted(from: &str, to: &str) -> bool {
                     && t == project::ProjectState::Ready)
         }
         // Non-project entities pass raw strings; the original logic applies.
-        _ => {
-            from == "blocked"
-                || to == "blocked"
-                || (from == "setup_incomplete" && to == "ready")
-        }
+        _ => from == "blocked" || to == "blocked" || (from == "setup_incomplete" && to == "ready"),
     }
 }
 

--- a/crates/app/lifecycle/src/transition_use_case.rs
+++ b/crates/app/lifecycle/src/transition_use_case.rs
@@ -519,73 +519,48 @@ fn validate_edge(entity_type: EntityType, from: &str, to: &str) -> bool {
 ///    auto-transition (R-Ready-Trigger). This is the only non-blocked edge
 ///    that may be driven by actor=system.
 fn is_system_permitted(from: &str, to: &str) -> bool {
-    from == "blocked" || to == "blocked" || (from == "setup_incomplete" && to == "ready")
+    let from_state = project::ProjectState::parse_str(from);
+    let to_state = project::ProjectState::parse_str(to);
+    match (from_state, to_state) {
+        (Some(f), Some(t)) => {
+            f == project::ProjectState::Blocked
+                || t == project::ProjectState::Blocked
+                || (f == project::ProjectState::SetupIncomplete
+                    && t == project::ProjectState::Ready)
+        }
+        // Non-project entities pass raw strings; the original logic applies.
+        _ => {
+            from == "blocked"
+                || to == "blocked"
+                || (from == "setup_incomplete" && to == "ready")
+        }
+    }
 }
 
-// ── string → enum parsers ────────────────────────────────────────────────
+// ── string → enum parsers (strum-backed) ─────────────────────────────────
 
 fn parse_state(s: &str) -> Option<project::ProjectState> {
-    Some(match s {
-        "setup_incomplete" => project::ProjectState::SetupIncomplete,
-        "ready" => project::ProjectState::Ready,
-        "prepared" => project::ProjectState::Prepared,
-        "processing" => project::ProjectState::Processing,
-        "completed" => project::ProjectState::Completed,
-        "archived" => project::ProjectState::Archived,
-        "blocked" => project::ProjectState::Blocked,
-        _ => return None,
-    })
+    project::ProjectState::parse_str(s)
 }
 
-/// Parses via `PlanState`'s `serde` mapping (`#[serde(rename_all =
-/// "snake_case")]`) instead of a hand-rolled match, so this stays in sync
-/// with `app_core::plans::parse_plan_state`'s sibling parser rather than
-/// drifting on new variants (audit T1-b). An unrecognised/corrupt value
-/// yields `None`, which `validate_edge` already treats as an invalid edge.
 fn parse_plan(s: &str) -> Option<plan_lifecycle::PlanState> {
-    serde_json::from_value(serde_json::Value::String(s.to_owned())).ok()
+    plan_lifecycle::PlanState::parse_str(s)
 }
 
 fn parse_file_record(s: &str) -> Option<inventory::InventoryState> {
-    Some(match s {
-        "observed" => inventory::InventoryState::Observed,
-        "changed" => inventory::InventoryState::Changed,
-        "classified" => inventory::InventoryState::Classified,
-        "missing" => inventory::InventoryState::Missing,
-        "rejected" => inventory::InventoryState::Rejected,
-        "protected" => inventory::InventoryState::Protected,
-        _ => return None,
-    })
+    s.parse().ok()
 }
 
 fn parse_data_source(s: &str) -> Option<data_source::DataSourceState> {
-    Some(match s {
-        "active" => data_source::DataSourceState::Active,
-        "missing" => data_source::DataSourceState::Missing,
-        "disabled" => data_source::DataSourceState::Disabled,
-        "reconnect_required" => data_source::DataSourceState::ReconnectRequired,
-        _ => return None,
-    })
+    s.parse().ok()
 }
 
 fn parse_prepared_source(s: &str) -> Option<prepared_source::PreparedSourceState> {
-    Some(match s {
-        "not_created" => prepared_source::PreparedSourceState::NotCreated,
-        "planned" => prepared_source::PreparedSourceState::Planned,
-        "ready" => prepared_source::PreparedSourceState::Ready,
-        "stale" => prepared_source::PreparedSourceState::Stale,
-        "retired" => prepared_source::PreparedSourceState::Retired,
-        _ => return None,
-    })
+    s.parse().ok()
 }
 
 fn parse_projection(s: &str) -> Option<projection::ProjectionState> {
-    Some(match s {
-        "current" => projection::ProjectionState::Current,
-        "stale" => projection::ProjectionState::Stale,
-        "regenerating" => projection::ProjectionState::Regenerating,
-        _ => return None,
-    })
+    s.parse().ok()
 }
 
 // ── contract → command translation ───────────────────────────────────────

--- a/crates/app/projects/src/project_health.rs
+++ b/crates/app/projects/src/project_health.rs
@@ -369,7 +369,7 @@ pub async fn emit_unarchive_transition(
         .await
         .map_err(|e| HealthError::NotFound(format!("project {project_id}: {e}")))?;
 
-    if row.lifecycle != "archived" {
+    if !domain_core::project::validate::is_read_only(&row.lifecycle) {
         return Ok(());
     }
 

--- a/crates/app/projects/src/project_health.rs
+++ b/crates/app/projects/src/project_health.rs
@@ -132,7 +132,9 @@ pub async fn check_project_ready_invariant(
         .await
         .map_err(|e| HealthError::NotFound(format!("project {project_id}: {e}")))?;
 
-    if row.lifecycle != "setup_incomplete" {
+    if domain_core::lifecycle::ProjectState::parse_str(&row.lifecycle)
+        != Some(domain_core::lifecycle::ProjectState::SetupIncomplete)
+    {
         return Ok(None);
     }
 

--- a/crates/app/projects/src/project_notes.rs
+++ b/crates/app/projects/src/project_notes.rs
@@ -32,6 +32,7 @@ use uuid::Uuid;
 use contracts_core::manifests::{
     ManifestOpError, ProjectNoteUpdateRequest, ProjectNoteUpdateResult,
 };
+use domain_core::project::validate::is_read_only;
 use persistence_plans::repositories::project_notes::{get_note, upsert_note};
 use persistence_plans::repositories::projects::get_project;
 use project_structure::notes::{NotesFileAdapter, RealNotesAdapter};
@@ -107,7 +108,7 @@ pub async fn update_note_with_adapter(
     })?;
 
     // ── Lifecycle guard (R-NotesEdit) ─────────────────────────────────────────
-    if project.lifecycle == "archived" {
+    if is_read_only(&project.lifecycle) {
         return Err(op_error(
             "project.read_only",
             "Notes cannot be edited on an archived project.",

--- a/crates/app/projects/src/project_setup/mod.rs
+++ b/crates/app/projects/src/project_setup/mod.rs
@@ -299,7 +299,9 @@ async fn maybe_auto_ready(
     project_id: &str,
     current_lifecycle: &str,
 ) -> Result<Option<String>, persistence_core::DbError> {
-    if current_lifecycle != "setup_incomplete" {
+    if domain_core::lifecycle::ProjectState::parse_str(current_lifecycle)
+        != Some(domain_core::lifecycle::ProjectState::SetupIncomplete)
+    {
         return Ok(None);
     }
     project_health::check_project_ready_invariant(pool, bus, project_id)
@@ -313,7 +315,9 @@ async fn maybe_regress_to_incomplete(
     project_id: &str,
     current_lifecycle: &str,
 ) -> Result<Option<String>, persistence_core::DbError> {
-    if current_lifecycle != "ready" {
+    if domain_core::lifecycle::ProjectState::parse_str(current_lifecycle)
+        != Some(domain_core::lifecycle::ProjectState::Ready)
+    {
         return Ok(None);
     }
     let sources = repo::list_project_sources(pool, project_id).await?;

--- a/crates/app/projects/src/project_setup/sources.rs
+++ b/crates/app/projects/src/project_setup/sources.rs
@@ -55,7 +55,7 @@ pub async fn add_source(
     let row = repo::get_project(pool, &req.project_id).await.map_err(db_err)?;
 
     // Check archived lifecycle.
-    if row.lifecycle == "archived" {
+    if domain_core::project::validate::is_read_only(&row.lifecycle) {
         return Err(ContractError::new(
             ErrorCode::LifecycleReadOnly,
             "Sources cannot be added to an archived project.",

--- a/crates/contracts/core/src/lifecycle.rs
+++ b/crates/contracts/core/src/lifecycle.rs
@@ -14,6 +14,13 @@ use uuid::Uuid;
 pub const CONTRACT_VERSION: &str = "2.0.0";
 
 // ── State enums — mirror the JSON $defs exactly ───────────────────────────────
+//
+// NOTE: ProjectState and PlanState are semantically identical to
+// `domain_core::lifecycle::{ProjectState, PlanState}`. They are kept as
+// separate definitions here (rather than re-exports) because schemars
+// reflects doc-comments as JSON schema `description` fields, and the domain
+// enum's variant docs would change the generated contract schema. Collapsing
+// these into a single enum is tracked in kyo7.85 (SQL CHECK sync).
 
 #[derive(
     Clone,

--- a/crates/domain/core/src/lifecycle/data_asset.rs
+++ b/crates/domain/core/src/lifecycle/data_asset.rs
@@ -86,4 +86,3 @@ impl std::fmt::Display for EntityType {
         write!(f, "{}", self.as_str())
     }
 }
-

--- a/crates/domain/core/src/lifecycle/data_asset.rs
+++ b/crates/domain/core/src/lifecycle/data_asset.rs
@@ -1,20 +1,11 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! DataAsset trait + enum dispatch over all tracked entity families.
-//! Spec 002 FR-007: every Data Asset exposes a common lifecycle interface.
+//! `EntityType` enum — the string tag for each entity family in contracts and audit rows.
 
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use specta::Type;
-
-use crate::ids::EntityId;
-use crate::lifecycle::data_source::{DataSourceState, RegisteredSource};
-use crate::lifecycle::inventory::{FileRecord, InventoryState};
-use crate::lifecycle::plan::{FilesystemPlan, PlanState};
-use crate::lifecycle::prepared_source::{PreparedSourceState, PreparedSourceView};
-use crate::lifecycle::project::{Project, ProjectState};
-use crate::lifecycle::projection::{ProcessingArtifact, ProjectionState};
 /// The string tag used in contracts and audit rows for each entity family.
 ///
 /// Spec 041 FR-051 (T076): `AcquisitionSession`, `CalibrationSession`, and
@@ -96,134 +87,3 @@ impl std::fmt::Display for EntityType {
     }
 }
 
-/// Common interface shared by all Data Asset families.
-pub trait DataAsset {
-    fn entity_id(&self) -> EntityId;
-    fn entity_type(&self) -> EntityType;
-    fn current_state_label(&self) -> &'static str;
-}
-
-impl DataAsset for Project {
-    fn entity_id(&self) -> EntityId {
-        self.id
-    }
-
-    fn entity_type(&self) -> EntityType {
-        EntityType::Project
-    }
-
-    fn current_state_label(&self) -> &'static str {
-        match self.state {
-            ProjectState::SetupIncomplete => "setup_incomplete",
-            ProjectState::Ready => "ready",
-            ProjectState::Prepared => "prepared",
-            ProjectState::Processing => "processing",
-            ProjectState::Completed => "completed",
-            ProjectState::Archived => "archived",
-            ProjectState::Blocked => "blocked",
-        }
-    }
-}
-
-impl DataAsset for FilesystemPlan {
-    fn entity_id(&self) -> EntityId {
-        self.id
-    }
-
-    fn entity_type(&self) -> EntityType {
-        EntityType::FilesystemPlan
-    }
-
-    fn current_state_label(&self) -> &'static str {
-        match self.state {
-            PlanState::Draft => "draft",
-            PlanState::ReadyForReview => "ready_for_review",
-            PlanState::Approved => "approved",
-            PlanState::Applying => "applying",
-            PlanState::Paused => "paused",
-            PlanState::Applied => "applied",
-            PlanState::PartiallyApplied => "partially_applied",
-            PlanState::Failed => "failed",
-            PlanState::Cancelled => "cancelled",
-            PlanState::Discarded => "discarded",
-        }
-    }
-}
-
-impl DataAsset for FileRecord {
-    fn entity_id(&self) -> EntityId {
-        self.id
-    }
-
-    fn entity_type(&self) -> EntityType {
-        EntityType::FileRecord
-    }
-
-    fn current_state_label(&self) -> &'static str {
-        match self.state {
-            InventoryState::Observed => "observed",
-            InventoryState::Changed => "changed",
-            InventoryState::Classified => "classified",
-            InventoryState::Missing => "missing",
-            InventoryState::Rejected => "rejected",
-            InventoryState::Protected => "protected",
-        }
-    }
-}
-
-impl DataAsset for RegisteredSource {
-    fn entity_id(&self) -> EntityId {
-        self.id
-    }
-
-    fn entity_type(&self) -> EntityType {
-        EntityType::DataSource
-    }
-
-    fn current_state_label(&self) -> &'static str {
-        match self.state {
-            DataSourceState::Active => "active",
-            DataSourceState::Missing => "missing",
-            DataSourceState::Disabled => "disabled",
-            DataSourceState::ReconnectRequired => "reconnect_required",
-        }
-    }
-}
-
-impl DataAsset for PreparedSourceView {
-    fn entity_id(&self) -> EntityId {
-        self.id
-    }
-
-    fn entity_type(&self) -> EntityType {
-        EntityType::PreparedSource
-    }
-
-    fn current_state_label(&self) -> &'static str {
-        match self.state {
-            PreparedSourceState::NotCreated => "not_created",
-            PreparedSourceState::Planned => "planned",
-            PreparedSourceState::Ready => "ready",
-            PreparedSourceState::Stale => "stale",
-            PreparedSourceState::Retired => "retired",
-        }
-    }
-}
-
-impl DataAsset for ProcessingArtifact {
-    fn entity_id(&self) -> EntityId {
-        self.id
-    }
-
-    fn entity_type(&self) -> EntityType {
-        EntityType::ProcessingArtifact
-    }
-
-    fn current_state_label(&self) -> &'static str {
-        match self.staleness {
-            ProjectionState::Current => "current",
-            ProjectionState::Stale => "stale",
-            ProjectionState::Regenerating => "regenerating",
-        }
-    }
-}

--- a/crates/domain/core/src/lifecycle/data_source.rs
+++ b/crates/domain/core/src/lifecycle/data_source.rs
@@ -6,6 +6,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use strum::{EnumString, IntoStaticStr};
 
 use crate::ids::{EntityId, Timestamp};
 
@@ -22,8 +23,11 @@ use crate::ids::{EntityId, Timestamp};
     Deserialize,
     JsonSchema,
     Type,
+    EnumString,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum DataSourceState {
     Active,
     Missing,

--- a/crates/domain/core/src/lifecycle/inventory.rs
+++ b/crates/domain/core/src/lifecycle/inventory.rs
@@ -6,6 +6,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use strum::{EnumString, IntoStaticStr};
 
 use crate::ids::{ContentHash, EntityId, Timestamp};
 
@@ -25,8 +26,11 @@ use crate::ids::{ContentHash, EntityId, Timestamp};
     Deserialize,
     JsonSchema,
     Type,
+    EnumString,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum InventoryState {
     Observed,
     Changed,

--- a/crates/domain/core/src/lifecycle/mod.rs
+++ b/crates/domain/core/src/lifecycle/mod.rs
@@ -15,7 +15,7 @@ pub mod projection;
 pub mod provenance;
 pub mod session;
 
-pub use data_asset::{DataAsset, EntityType};
+pub use data_asset::EntityType;
 pub use data_source::DataSourceState;
 pub use inventory::InventoryState;
 pub use plan::PlanState;

--- a/crates/domain/core/src/lifecycle/plan.rs
+++ b/crates/domain/core/src/lifecycle/plan.rs
@@ -6,6 +6,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use strum::{EnumString, IntoStaticStr};
 
 use crate::ids::{EntityId, Timestamp};
 
@@ -26,8 +27,11 @@ use crate::ids::{EntityId, Timestamp};
     Deserialize,
     JsonSchema,
     Type,
+    EnumString,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PlanState {
     Draft,
     ReadyForReview,
@@ -44,6 +48,18 @@ pub enum PlanState {
 }
 
 impl PlanState {
+    /// Canonical snake_case string for this state (strum-backed).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a snake_case string into a state, returning `None` on unknown input.
+    #[must_use]
+    pub fn parse_str(s: &str) -> Option<Self> {
+        s.parse().ok()
+    }
+
     /// Terminal states: retry produces a NEW plan with `parent_plan_id` set.
     #[must_use]
     pub const fn is_terminal(self) -> bool {

--- a/crates/domain/core/src/lifecycle/prepared_source.rs
+++ b/crates/domain/core/src/lifecycle/prepared_source.rs
@@ -26,8 +26,11 @@ use crate::ids::EntityId;
     Deserialize,
     JsonSchema,
     Type,
+    EnumString,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum PreparedSourceState {
     NotCreated,
     Planned,

--- a/crates/domain/core/src/lifecycle/project.rs
+++ b/crates/domain/core/src/lifecycle/project.rs
@@ -6,6 +6,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use strum::{EnumString, IntoStaticStr};
 
 use crate::ids::{EntityId, Timestamp};
 
@@ -25,8 +26,11 @@ use crate::ids::{EntityId, Timestamp};
     Deserialize,
     JsonSchema,
     Type,
+    EnumString,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum ProjectState {
     SetupIncomplete,
     Ready,
@@ -39,6 +43,18 @@ pub enum ProjectState {
 }
 
 impl ProjectState {
+    /// Canonical snake_case string for this state (strum-backed).
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        self.into()
+    }
+
+    /// Parse a snake_case string into a state, returning `None` on unknown input.
+    #[must_use]
+    pub fn parse_str(s: &str) -> Option<Self> {
+        s.parse().ok()
+    }
+
     #[must_use]
     pub const fn is_before_archive(self) -> bool {
         matches!(
@@ -49,6 +65,30 @@ impl ProjectState {
                 | Self::Processing
                 | Self::Completed
         )
+    }
+
+    /// True when all edits are refused (R-Archived).
+    #[must_use]
+    pub const fn is_read_only(self) -> bool {
+        matches!(self, Self::Archived)
+    }
+
+    /// True when `tool` field changes are refused (R-Tool-Lock).
+    #[must_use]
+    pub const fn is_tool_locked(self) -> bool {
+        matches!(self, Self::Prepared | Self::Processing | Self::Completed | Self::Blocked)
+    }
+
+    /// True when source removal is refused (spec 008 FR-011).
+    #[must_use]
+    pub const fn is_source_remove_locked(self) -> bool {
+        matches!(self, Self::Prepared | Self::Processing | Self::Completed | Self::Archived)
+    }
+
+    /// True when completed projects reopen on new data (F-Framing-6).
+    #[must_use]
+    pub const fn reopens_on_new_data(self) -> bool {
+        matches!(self, Self::Completed)
     }
 }
 

--- a/crates/domain/core/src/lifecycle/projection.rs
+++ b/crates/domain/core/src/lifecycle/projection.rs
@@ -6,6 +6,7 @@
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use specta::Type;
+use strum::{EnumString, IntoStaticStr};
 
 use crate::ids::{EntityId, Timestamp};
 
@@ -22,8 +23,11 @@ use crate::ids::{EntityId, Timestamp};
     Deserialize,
     JsonSchema,
     Type,
+    EnumString,
+    IntoStaticStr,
 )]
 #[serde(rename_all = "snake_case")]
+#[strum(serialize_all = "snake_case")]
 pub enum ProjectionState {
     Current,
     Stale,

--- a/crates/domain/core/src/project/validate.rs
+++ b/crates/domain/core/src/project/validate.rs
@@ -44,32 +44,27 @@ pub fn validate_tool(tool: &str) -> Result<(), &'static str> {
     }
 }
 
-/// Lifecycle states where `tool` is immutable (R-Tool-Lock).
-pub const TOOL_LOCKED_LIFECYCLES: &[&str] = &["prepared", "processing", "completed", "blocked"];
+use crate::lifecycle::ProjectState;
 
-/// Returns true when the tool field is locked for the given lifecycle.
+/// Returns true when the tool field is locked for the given lifecycle string.
+/// Delegates to [`ProjectState::is_tool_locked`]; unknown strings return false.
 #[must_use]
 pub fn is_tool_locked(lifecycle: &str) -> bool {
-    TOOL_LOCKED_LIFECYCLES.contains(&lifecycle)
+    ProjectState::parse_str(lifecycle).is_some_and(ProjectState::is_tool_locked)
 }
 
-/// Lifecycle states where all edits are refused (R-Archived).
-pub const READ_ONLY_LIFECYCLES: &[&str] = &["archived"];
-
-/// Returns true when any edit is refused for the given lifecycle.
+/// Returns true when any edit is refused for the given lifecycle string.
+/// Delegates to [`ProjectState::is_read_only`]; unknown strings return false.
 #[must_use]
 pub fn is_read_only(lifecycle: &str) -> bool {
-    READ_ONLY_LIFECYCLES.contains(&lifecycle)
+    ProjectState::parse_str(lifecycle).is_some_and(ProjectState::is_read_only)
 }
 
-/// Lifecycle states where source removal is refused (spec 008 FR-011).
-pub const SOURCE_REMOVE_LOCKED_LIFECYCLES: &[&str] =
-    &["prepared", "processing", "completed", "archived"];
-
-/// Returns true when source removal is refused for the given lifecycle.
+/// Returns true when source removal is refused for the given lifecycle string.
+/// Delegates to [`ProjectState::is_source_remove_locked`]; unknown strings return false.
 #[must_use]
 pub fn is_source_remove_locked(lifecycle: &str) -> bool {
-    SOURCE_REMOVE_LOCKED_LIFECYCLES.contains(&lifecycle)
+    ProjectState::parse_str(lifecycle).is_some_and(ProjectState::is_source_remove_locked)
 }
 
 #[cfg(test)]

--- a/justfile
+++ b/justfile
@@ -52,6 +52,11 @@ db-boundary:
 dead-callers:
     bash scripts/check-dead-callers.sh
 
+# Lifecycle string-comparison ratchet — sealed at zero. Raw `.lifecycle == "..."`
+# comparisons must use typed ProjectState predicates instead.
+lifecycle-strings:
+    bash scripts/check-lifecycle-strings.sh
+
 # Periodic hygiene sweeps. NOT CI gates and deliberately so: these surface debt
 # to triage, not per-PR correctness, and a noisy blocking gate gets suppressed.
 # Run them when you want a health read, not on every push.
@@ -135,7 +140,7 @@ check-generated:
 
 # Full pre-merge gate: lint + tests + typecheck + generated-artifact drift +
 # DB/dead-caller boundary ratchets.
-check: lint test typecheck check-generated db-boundary dead-callers
+check: lint test typecheck check-generated db-boundary dead-callers lifecycle-strings
 
 # Placeholder fixture check hook.
 fixtures-check:

--- a/scripts/check-lifecycle-strings.sh
+++ b/scripts/check-lifecycle-strings.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Lifecycle string-comparison ratchet — ensures typed predicates stay in use.
+#
+# Invariant: ZERO field-level `.lifecycle == "..."` or `.lifecycle != "..."`
+# comparisons exist in production Rust code. All lifecycle checks must go
+# through typed ProjectState predicates or parse_str().
+#
+# Scope: *.rs files excluding tests/ segments and test_support.
+#
+# Usage:
+#   bash scripts/check-lifecycle-strings.sh          # exits 0 on pass, 1 on fail
+set -euo pipefail
+
+cd "$(git rev-parse --show-toplevel)"
+
+hits=$(grep -rn '\.lifecycle\s*[!=]=\s*"' --include='*.rs' crates/ apps/ \
+  | grep -v '/tests/' \
+  | grep -v 'test_support' \
+  | grep -v '^\s*//' \
+  || true)
+
+count=$(echo "$hits" | grep -c . || true)
+
+if [ "$count" -gt 0 ]; then
+  echo "ERROR: $count raw lifecycle string comparison(s) found."
+  echo "Use ProjectState predicates (is_read_only, is_tool_locked, etc.) instead."
+  echo "$hits"
+  exit 1
+fi
+
+echo "OK: zero raw lifecycle string comparisons found."


### PR DESCRIPTION
## Summary

Implements the ratified OOP-study Rust verdict (architecture study kyo7.70): lifecycle state vocabulary is now typed end-to-end instead of round-tripping through strings.

- **One codec per vocabulary**: all six lifecycle state enums gain the strum EnumString/IntoStaticStr codec (extending the in-repo precedent from prepared_source/first_run); the three independent hand-rolled string→enum parsers are deleted.
- **Typed predicates**: `is_tool_locked`/`is_read_only`/`is_source_remove_locked` now take `ProjectState` (were `&str` lookup tables); `reopens_on_new_data()` replaces the four scattered `lifecycle == "completed"` comparisons; `is_system_permitted` operates on typed edges.
- **String-comparison kill + ratchet**: every raw lifecycle string comparison in app crates is replaced with typed predicates; new `just lifecycle-strings` shrink-only ratchet (scripts/check-lifecycle-strings.sh) prevents reintroduction.
- **DataAsset deleted**: 6 impls, zero consumers — pure ceremony removed.

## Deferred (coordination)

PlanState/ProjectState contract-twin collapse deferred to the vocabulary single-sourcing bead (kyo7.85): schemars reflects doc-comments into the generated JSON schema, so collapsing the twin changes the contract snapshot — belongs with the schema-sync work. Annotated in contracts/core/src/lifecycle.rs.

## Spec Context

Tracks-Bead: astro-plan-kyo7.99
Merge-Bead: astro-plan-we61

Verified: 534 tests across domain_core/app_core_lifecycle/app_core_projects/app_core_inbox/contracts_core, workspace clippy -D warnings, db-boundary, dead-callers (shrunk by DataAsset deletion), new lifecycle-strings ratchet green.