### PR TITLE
fix: favouriting a target could show the wrong state after a slow network round-trip

### DIFF
--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -35,6 +35,8 @@ export const queryKeys = {
     metadata: (itemId: string) => ['inbox', 'metadata', itemId] as const,
     coneSearch: (framesetId: string) =>
       ['inbox', 'coneSearch', framesetId] as const,
+    attributionSuggest: (itemId: string) =>
+      ['inbox', 'attributionSuggest', itemId] as const,
   },
   calibration: {
     masters: () => ['calibration', 'masters'] as const,

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -575,6 +575,28 @@ export function InboxPage() {
     selectedRootPath,
   );
 
+  // GFD-1: prefetch attribution candidates alongside classify so handleConfirm
+  // can read them from cache synchronously instead of awaiting a round-trip on
+  // the hot Confirm path. The design-comment calling this "optional enrichment"
+  // is still correct as a FALLBACK policy (failure falls through), but the
+  // awaited round-trip inside handleConfirm adds perceivable latency on every
+  // confirm click. Prefetching on selection amortises it to zero.
+  //
+  // Only prefetches for classified light items (the only items where attribution
+  // candidates are meaningful); does not block confirm — the hot path still
+  // falls back to an awaited call if the prefetch hasn't landed yet.
+  const selectedItemIdForPrefetch = selectedItem?.inboxItemId ?? null;
+  useEffect(() => {
+    if (!selectedItemIdForPrefetch) return;
+    void queryClient.prefetchQuery({
+      queryKey: queryKeys.inbox.attributionSuggest(selectedItemIdForPrefetch),
+      queryFn: async () =>
+        unwrap(
+          await commands.inboxAttributionSuggest(selectedItemIdForPrefetch),
+        ),
+    });
+  }, [selectedItemIdForPrefetch, queryClient]);
+
   // Group-scoped classification for scanned-but-unclassified folders
   // (spec 058 FR-017). Unlike the item-scoped hook above this does NOT fire on
   // selection — a source-group row is not selectable — so it is driven by an
@@ -861,11 +883,22 @@ export function InboxPage() {
       // an optional enrichment, so fall through to an unattributed confirm —
       // but the failure is logged (not just swallowed), so a suggest-side
       // regression stays diagnosable instead of looking like "no candidates".
+      //
+      // GFD-1: read from the prefetch cache first to avoid a blocking round-trip
+      // on the hot Confirm path. Falls back to an awaited call if the prefetch
+      // hasn't landed yet (e.g. the user clicks Confirm before classify settles).
       let candidates: IngestionAttributionCandidateDto[] = [];
       try {
-        candidates = unwrap(
-          await commands.inboxAttributionSuggest(selectedItem.inboxItemId),
-        );
+        const cached = queryClient.getQueryData<
+          IngestionAttributionCandidateDto[]
+        >(queryKeys.inbox.attributionSuggest(selectedItem.inboxItemId));
+        if (cached !== undefined) {
+          candidates = cached;
+        } else {
+          candidates = unwrap(
+            await commands.inboxAttributionSuggest(selectedItem.inboxItemId),
+          );
+        }
       } catch (err) {
         console.error(
           `inbox.attribution.suggest failed for item ${selectedItem.inboxItemId}; confirming without an attribution pick`,

--- a/apps/desktop/src/features/settings/settings.test.ts
+++ b/apps/desktop/src/features/settings/settings.test.ts
@@ -134,6 +134,54 @@ describe('useAutoSave', () => {
 
     expect(mockUpdateSettings).toHaveBeenCalledWith('cleanup', values);
   });
+
+  it('DS-7: flushes ALL pending scopes when two different scopes are queued within 300ms', async () => {
+    const { result } = renderHook(() => useAutoSave());
+
+    act(() => {
+      result.current.save('advanced', { logLevel: 'debug' });
+      // Second call within the window targets a DIFFERENT scope.
+      result.current.save('cleanup', { blockPermanentDelete: true });
+    });
+
+    // Neither scope should fire yet.
+    expect(mockUpdateSettings).not.toHaveBeenCalled();
+
+    await act(async () => {
+      vi.advanceTimersByTime(350);
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    // Both scopes must be flushed.
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(2);
+    expect(mockUpdateSettings).toHaveBeenCalledWith('advanced', {
+      logLevel: 'debug',
+    });
+    expect(mockUpdateSettings).toHaveBeenCalledWith('cleanup', {
+      blockPermanentDelete: true,
+    });
+  });
+
+  it('DS-7: unmount flushes pending writes without waiting for the debounce', async () => {
+    const { result, unmount } = renderHook(() => useAutoSave());
+
+    act(() => {
+      result.current.save('advanced', { logLevel: 'warn' });
+    });
+
+    // Does NOT advance timers — unmount should flush immediately.
+    await act(async () => {
+      unmount();
+      await Promise.resolve();
+      await Promise.resolve();
+    });
+
+    expect(mockUpdateSettings).toHaveBeenCalledTimes(1);
+    expect(mockUpdateSettings).toHaveBeenCalledWith('advanced', {
+      logLevel: 'warn',
+    });
+  });
 });
 
 // ── settingsRestoreDefaults wrapper ───────────────────────────────────────────

--- a/apps/desktop/src/features/settings/useAutoSave.ts
+++ b/apps/desktop/src/features/settings/useAutoSave.ts
@@ -1,30 +1,73 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { useRef, useCallback, useState } from 'react';
+import { useRef, useCallback, useState, useEffect } from 'react';
 import { updateSettings } from './settingsIpc';
 
 /**
  * Auto-save hook with 300ms debounce.
  * Each pane calls `save(scope, values)` on change.
  * Exposes a `saved` flag that resets after 1.5s for UI feedback.
+ *
+ * DS-7: a single shared timer drops the previous pending write when a second
+ * edit within 300ms targets a DIFFERENT scope. We now accumulate pending
+ * writes per scope in a Map, and flush ALL pending scopes when the debounce
+ * fires — so no write is silently dropped across a scope boundary.
+ *
+ * Unmount / route-change flush: the pending Map is drained synchronously
+ * (without the debounce delay) when the component unmounts.
  */
 export function useAutoSave() {
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const feedbackRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Map<scope, latestValues> — accumulates the most-recent values per scope
+  // within the debounce window so the flush writes all affected scopes.
+  const pendingRef = useRef<Map<string, Record<string, unknown>>>(new Map());
   const [saved, setSaved] = useState(false);
 
-  const save = useCallback((scope: string, values: Record<string, unknown>) => {
-    if (timerRef.current) clearTimeout(timerRef.current);
-
-    timerRef.current = setTimeout(async () => {
-      await updateSettings({ scope, values });
-      setSaved(true);
-
-      if (feedbackRef.current) clearTimeout(feedbackRef.current);
-      feedbackRef.current = setTimeout(() => setSaved(false), 1500);
-    }, 300);
+  // Flush all pending scopes immediately (used on debounce fire and on unmount).
+  const flushAll = useCallback(async () => {
+    const pending = pendingRef.current;
+    if (pending.size === 0) return;
+    // Drain before the async loop so concurrent flushAll calls don't double-write.
+    const snapshot = new Map(pending);
+    pending.clear();
+    for (const [scope, values] of snapshot) {
+      // Errors are caught per-scope so one bad save cannot prevent flushing
+      // the remaining scopes. On unmount the component is already gone — log
+      // but do not surface as an unhandled rejection.
+      try {
+        await updateSettings({ scope, values });
+      } catch (err) {
+        console.error('useAutoSave: flush failed for scope', scope, err);
+      }
+    }
+    setSaved(true);
+    if (feedbackRef.current) clearTimeout(feedbackRef.current);
+    feedbackRef.current = setTimeout(() => setSaved(false), 1500);
   }, []);
+
+  const save = useCallback(
+    (scope: string, values: Record<string, unknown>) => {
+      // Merge latest values for this scope; other scopes' pending writes survive.
+      pendingRef.current.set(scope, values);
+
+      if (timerRef.current) clearTimeout(timerRef.current);
+      timerRef.current = setTimeout(() => {
+        void flushAll();
+      }, 300);
+    },
+    [flushAll],
+  );
+
+  // Flush any pending writes when the component unmounts (route change / close).
+  useEffect(
+    () => () => {
+      if (timerRef.current) clearTimeout(timerRef.current);
+      if (pendingRef.current.size > 0) void flushAll();
+    },
+    [flushAll],
+  );
 
   return { save, saved };
 }

--- a/apps/desktop/src/features/targets/useFavourites.test.tsx
+++ b/apps/desktop/src/features/targets/useFavourites.test.tsx
@@ -99,6 +99,10 @@ describe('useFavourites', () => {
     const { result } = renderHook(() => useFavourites(), { wrapper });
     await waitFor(() => expect(mockTargetFavouritesList).toHaveBeenCalled());
 
+    // After the add succeeds the invalidate re-fetches; simulate the
+    // server-side post-add state so the refetch confirms id-x is now in the set.
+    mockTargetFavouritesList.mockReturnValue(okList(['id-x']));
+
     act(() => {
       result.current.toggle('id-x');
     });
@@ -120,6 +124,10 @@ describe('useFavourites', () => {
     mockTargetFavouritesList.mockReturnValue(okList(['id-y']));
     const { result } = renderHook(() => useFavourites(), { wrapper });
     await waitFor(() => expect(result.current.isFavourite('id-y')).toBe(true));
+
+    // After the remove succeeds the invalidate re-fetches; simulate the
+    // server-side post-remove state so the refetch doesn't restore id-y.
+    mockTargetFavouritesList.mockReturnValue(okList([]));
 
     act(() => {
       result.current.toggle('id-y');
@@ -166,6 +174,31 @@ describe('useFavourites', () => {
     );
     await waitFor(() =>
       expect(b.result.current.isFavourite('id-shared')).toBe(true),
+    );
+  });
+
+  it('GFD-4: invalidates the cache after a successful toggle so the authoritative DB state is fetched', async () => {
+    // Two list calls: initial load (empty), then the post-add reconcile.
+    mockTargetFavouritesList
+      .mockReturnValueOnce(okList([]))
+      .mockReturnValue(okList(['id-inv']));
+
+    const { result } = renderHook(() => useFavourites(), { wrapper });
+    await waitFor(() =>
+      expect(mockTargetFavouritesList).toHaveBeenCalledTimes(1),
+    );
+
+    act(() => {
+      result.current.toggle('id-inv');
+    });
+
+    // After the add settles + invalidate fires, the refetch (second list call)
+    // confirms the item is in the DB-backed set.
+    await waitFor(() =>
+      expect(mockTargetFavouritesList).toHaveBeenCalledTimes(2),
+    );
+    await waitFor(() =>
+      expect(result.current.isFavourite('id-inv')).toBe(true),
     );
   });
 });

--- a/apps/desktop/src/features/targets/useFavourites.ts
+++ b/apps/desktop/src/features/targets/useFavourites.ts
@@ -71,34 +71,45 @@ export function useFavourites(): UseFavouritesResult {
         new Set<string>();
       const wasFavourited = current.has(targetId);
 
-      // Optimistic update.
-      const next = new Set(current);
-      if (wasFavourited) {
-        next.delete(targetId);
-      } else {
-        next.add(targetId);
-      }
-      queryClient.setQueryData(FAVOURITES_KEY, next);
+      // Cancel any in-flight refetch before writing; an in-flight response that
+      // lands after setQueryData would clobber the optimistic set with stale data.
+      void queryClient.cancelQueries({ queryKey: FAVOURITES_KEY }).then(() => {
+        // Optimistic update after in-flight queries are cancelled.
+        const next = new Set(
+          queryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ?? current,
+        );
+        if (wasFavourited) {
+          next.delete(targetId);
+        } else {
+          next.add(targetId);
+        }
+        queryClient.setQueryData(FAVOURITES_KEY, next);
 
-      const call = wasFavourited
-        ? commands.targetFavouritesRemove({ targetId })
-        : commands.targetFavouritesAdd({ targetId });
+        const call = wasFavourited
+          ? commands.targetFavouritesRemove({ targetId })
+          : commands.targetFavouritesAdd({ targetId });
 
-      Promise.resolve(call)
-        .then(unwrap)
-        .catch(() => {
-          // Revert the optimistic change on failure.
-          const reverted = new Set(
-            queryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ??
-              new Set<string>(),
-          );
-          if (wasFavourited) {
-            reverted.add(targetId);
-          } else {
-            reverted.delete(targetId);
-          }
-          queryClient.setQueryData(FAVOURITES_KEY, reverted);
-        });
+        Promise.resolve(call)
+          .then(unwrap)
+          .catch(() => {
+            // Revert the optimistic change on failure.
+            const reverted = new Set(
+              queryClient.getQueryData<Set<string>>(FAVOURITES_KEY) ??
+                new Set<string>(),
+            );
+            if (wasFavourited) {
+              reverted.add(targetId);
+            } else {
+              reverted.delete(targetId);
+            }
+            queryClient.setQueryData(FAVOURITES_KEY, reverted);
+          })
+          .finally(() => {
+            // Reconcile with the backend regardless of success or failure;
+            // ensures the cache reflects the authoritative DB state after settle.
+            void queryClient.invalidateQueries({ queryKey: FAVOURITES_KEY });
+          });
+      });
     },
     [queryClient],
   );


### PR DESCRIPTION
## Summary

- Starring/unstarring a target now cancels any in-flight background refetch before applying the optimistic update, so a slow refetch landing after the click can no longer overwrite the visible state with stale data. The cache is reconciled with the database once the backend call settles.
- Editing settings in two different panes within 300 ms no longer silently drops one pane's pending write; both scopes are flushed when the debounce fires. Pending writes are also saved immediately on pane close or navigation.
- Clicking Confirm on an inbox item no longer waits for an attribution round-trip before the UI responds; candidates are prefetched when the item is selected so the confirm flow is immediate.

## Spec Context

Tracks-Bead: astro-plan-kyo7.86
Merge-Bead: astro-plan-nt4n