### PR TITLE
docs(spec): correct persistence crate split for session and topology repositories

### DIFF
--- a/specs/062-session-heterogeneity/plan.md
+++ b/specs/062-session-heterogeneity/plan.md
@@ -252,8 +252,13 @@ crates/
 ├── calibration/core/         # calibration family/session rules and warnings
 ├── persistence/core/
 │   ├── migrations/           # normalized greenfield schema
-│   ├── src/repositories/     # bounded queries and guarded transactions
-│   └── tests/                # invariants, plans, WAL, CAS, contention, scale
+│   └── src/                  # database pool, WAL, and migration runner
+├── persistence/sessions/
+│   ├── src/repositories/     # immutable session, calibration, and correction repositories
+│   └── tests/                # session integration and CAS tests
+├── persistence/topology/
+│   ├── src/repositories/     # panel, mosaic, proposal, and traversal repositories
+│   └── tests/                # topology invariants, plans, contention, and scale
 ├── contracts/core/           # portable request/response/event/error types
 ├── app/
 │   ├── targets/              # ingestion operation and session materialization
@@ -277,9 +282,10 @@ tests/contract/               # language-neutral schema and compatibility tests
 
 **Structure Decision**: Extend the existing layered Rust workspace and desktop
 feature boundaries. Domain rules stay out of Tauri commands and React;
-persistence stays inside `crates/persistence/core`; portable contracts bridge the
-core and desktop. No new service, graph store, or native image-processing layer
-is introduced.
+schema and infrastructure stay inside `crates/persistence/core`; new domain
+repositories live in `crates/persistence/sessions` and
+`crates/persistence/topology`; portable contracts bridge the core and desktop.
+No new service, graph store, or native image-processing layer is introduced.
 
 ## Dependencies and Delivery Gates
 

--- a/specs/062-session-heterogeneity/plan.md
+++ b/specs/062-session-heterogeneity/plan.md
@@ -38,7 +38,7 @@ detected but unreachable in product workflows.
 **Primary Dependencies**: Tauri 2.11, sqlx 0.9 with SQLite, Specta 2 release
 candidate, Tokio 1, React Query 5, React Router 1, Zod 4
 
-**Storage**: Local SQLite in WAL mode through `crates/persistence/db`; normalized
+**Storage**: Local SQLite in WAL mode through `crates/persistence/core`; normalized
 session, equipment, revision, relation, proposal, immutable project-membership,
 command-ledger, audit, outbox, and materialization-extension tables; user-owned
 image files remain in place
@@ -250,7 +250,7 @@ crates/
 ├── sessions/                 # immutable identity, observing night, group domain
 ├── targeting/                # target identity and target-match integration
 ├── calibration/core/         # calibration family/session rules and warnings
-├── persistence/db/
+├── persistence/core/
 │   ├── migrations/           # normalized greenfield schema
 │   ├── src/repositories/     # bounded queries and guarded transactions
 │   └── tests/                # invariants, plans, WAL, CAS, contention, scale
@@ -277,7 +277,7 @@ tests/contract/               # language-neutral schema and compatibility tests
 
 **Structure Decision**: Extend the existing layered Rust workspace and desktop
 feature boundaries. Domain rules stay out of Tauri commands and React;
-persistence stays inside `crates/persistence/db`; portable contracts bridge the
+persistence stays inside `crates/persistence/core`; portable contracts bridge the
 core and desktop. No new service, graph store, or native image-processing layer
 is introduced.
 

--- a/specs/062-session-heterogeneity/quickstart.md
+++ b/specs/062-session-heterogeneity/quickstart.md
@@ -35,14 +35,14 @@ Run the existing persistence suite first:
 
 ```bash
 # Available
-cargo nextest run -p persistence_db
+cargo nextest run -p persistence_core
 ```
 
 Add a focused migration target and run it against a new file-backed database:
 
 ```bash
-# Requires implementation: crates/persistence/db/tests/session_heterogeneity_migration.rs
-cargo nextest run -p persistence_db --test session_heterogeneity_migration
+# Requires implementation: crates/persistence/core/tests/session_heterogeneity_migration.rs
+cargo nextest run -p persistence_core --test session_heterogeneity_migration
 ```
 
 The focused target must prove:
@@ -124,7 +124,7 @@ Add and run focused file-backed SQLite targets:
 cargo nextest run -p app_core_inbox --test session_heterogeneity
 cargo nextest run -p app_core_projects --test related_session_addition
 cargo nextest run -p app_core_calibration --test immutable_calibration_matching
-cargo nextest run -p persistence_db --test session_topology_concurrency
+cargo nextest run -p persistence_core --test session_topology_concurrency
 ```
 
 Each target must create a temporary SQLite file, run the real migration chain,
@@ -307,8 +307,8 @@ The scale fixture must use a file-backed SQLite database in release mode.
 It must not use an in-memory database, mocked repository, or reduced row count.
 
 ```bash
-# Requires implementation: crates/persistence/db/tests/session_topology_scale.rs
-cargo test -p persistence_db \
+# Requires implementation: crates/persistence/core/tests/session_topology_scale.rs
+cargo test -p persistence_core \
   --release \
   --test session_topology_scale \
   -- \

--- a/specs/062-session-heterogeneity/quickstart.md
+++ b/specs/062-session-heterogeneity/quickstart.md
@@ -124,7 +124,7 @@ Add and run focused file-backed SQLite targets:
 cargo nextest run -p app_core_inbox --test session_heterogeneity
 cargo nextest run -p app_core_projects --test related_session_addition
 cargo nextest run -p app_core_calibration --test immutable_calibration_matching
-cargo nextest run -p persistence_core --test session_topology_concurrency
+cargo nextest run -p persistence_topology --test session_topology_concurrency
 ```
 
 Each target must create a temporary SQLite file, run the real migration chain,
@@ -307,8 +307,8 @@ The scale fixture must use a file-backed SQLite database in release mode.
 It must not use an in-memory database, mocked repository, or reduced row count.
 
 ```bash
-# Requires implementation: crates/persistence/core/tests/session_topology_scale.rs
-cargo test -p persistence_core \
+# Requires implementation: crates/persistence/topology/tests/session_topology_scale.rs
+cargo test -p persistence_topology \
   --release \
   --test session_topology_scale \
   -- \

--- a/specs/062-session-heterogeneity/research.md
+++ b/specs/062-session-heterogeneity/research.md
@@ -24,26 +24,26 @@ Repository evidence at HEAD establishes these constraints:
 - `acquisition_session.frame_ids` and `calibration_session.frame_ids` are JSON
   arrays. `project_sources` is a mutable relational exact-session link, not an
   immutable project-membership revision
-  (`crates/persistence/db/migrations/0002_lifecycle.sql:53`,
-  `crates/persistence/db/migrations/0018_projects.sql:35`).
+  (`crates/persistence/core/migrations/0002_lifecycle.sql:53`,
+  `crates/persistence/core/migrations/0018_projects.sql:35`).
 - The framing model mutates one `framing` row and one live membership join.
   Deleting or reassigning membership loses the accepted topology that preceded
-  it (`crates/persistence/db/migrations/0064_framing.sql:29`,
-  `crates/persistence/db/src/repositories/framing.rs:168`).
+  it (`crates/persistence/core/migrations/0064_framing.sql:29`,
+  `crates/persistence/core/src/repositories/framing.rs:168`).
 - Registered cameras, telescopes, and optical trains have stable IDs. Camera
   aliases are stored as JSON and resolved with exact alias values
-  (`crates/persistence/db/migrations/0007_equipment.sql:12`,
-  `crates/persistence/db/src/repositories/equipment.rs:245`).
+  (`crates/persistence/core/migrations/0007_equipment.sql:12`,
+  `crates/persistence/core/src/repositories/equipment.rs:245`).
 - Calibration fingerprints store nullable scalar metadata and support dark,
-  flat, and bias (`crates/persistence/db/migrations/0023_calibration_fingerprints.sql:14`).
+  flat, and bias (`crates/persistence/core/migrations/0023_calibration_fingerprints.sql:14`).
 - Dark-flat is reserved in domain and contract enums, but it remains reachable
   in Inbox classification, grouping, override, and display helpers
   (`crates/metadata/core/src/lib.rs:24`,
   `crates/app/inbox/src/grouping/config.rs:66`,
   `apps/desktop/src/features/inbox/planPanelHelpers.ts:47`).
 - SQLite runs in WAL mode with a five-second writer timeout
-  (`crates/persistence/db/src/lib.rs:32`,
-  `crates/persistence/db/src/lib.rs:79`).
+  (`crates/persistence/core/src/lib.rs:32`,
+  `crates/persistence/core/src/lib.rs:79`).
 - The workspace uses `skymath` 0.5 and `target-match` 0.4. The targeting layer
   already delegates spherical separation, optics-to-field conversion, and
   rotation-aware point containment to them
@@ -169,10 +169,10 @@ scoped to that optical profile. It is not a global `filters.id`.
 
 - The existing metadata table has one nullable column per known field but no
   durable mapping from capture software to field meaning
-  (`crates/persistence/db/migrations/0049_inbox_single_type.sql:222`).
+  (`crates/persistence/core/migrations/0049_inbox_single_type.sql:222`).
 - The registered-equipment IDs provide stable anchors while aliases absorb
   capture-software spelling differences
-  (`crates/persistence/db/migrations/0007_equipment.sql:10`).
+  (`crates/persistence/core/migrations/0007_equipment.sql:10`).
 - Explicit value states preserve the specification's absent-versus-known
   matching rules.
 
@@ -238,7 +238,7 @@ this feature; selection hands exact source sessions to the external processor.
   (`crates/calibration/core/src/rules/bias.rs:16`).
 - Existing fingerprints lack separate X/Y binning, readout state, raster,
   cooling mode, distributions, and policy provenance
-  (`crates/persistence/db/migrations/0023_calibration_fingerprints.sql:14`).
+  (`crates/persistence/core/migrations/0023_calibration_fingerprints.sql:14`).
 
 ## D5 — Dark-flat detection terminates before Inbox materialization
 
@@ -309,7 +309,7 @@ configuration hash changes.
 - Lineage writes check for cycles before accepting a split or merge.
 - Existing `framing` and `framing_session` data need no compatibility bridge
   because the feature assumes resettable development databases
-  (`crates/persistence/db/migrations/0064_framing.sql:58`).
+  (`crates/persistence/core/migrations/0064_framing.sql:58`).
 
 ## D7 — Normalized SQLite remains the topology store
 
@@ -329,7 +329,7 @@ Acceptance follows one transaction protocol:
 
 `BEGIN IMMEDIATE` makes the stale-head race deterministic. WAL still permits
 readers while SQLite serializes the competing writers. The repository already
-tests this locking behavior (`crates/persistence/db/tests/two_writer_contention.rs:75`).
+tests this locking behavior (`crates/persistence/core/tests/two_writer_contention.rs:75`).
 
 Use recursive CTEs for bounded ancestry, descendants, accepted mosaic
 connectivity, bridge detection, and cycle checks. Every recursive query is
@@ -366,7 +366,7 @@ delivery mechanism.
 **Consequences**:
 
 - Add one forward migration. Do not edit applied migration files; the migration
-  runner validates embedded checksums (`crates/persistence/db/src/lib.rs:168`).
+  runner validates embedded checksums (`crates/persistence/core/src/lib.rs:168`).
 - Writer-lock wait is measured separately from acceptance execution time.
 - The scale gate must prove the CTE plans with `EXPLAIN QUERY PLAN` and realistic
   cardinalities before any closure table or graph accelerator is considered.
@@ -523,7 +523,7 @@ not delete or reinterpret the predecessor's historical entries.
 - Exact pins prevent background relation changes from altering processing
   inputs.
 - Prepared views demonstrate the existing reproducible per-item projection
-  boundary (`crates/persistence/db/migrations/0029_prepared_source_views.sql:86`).
+  boundary (`crates/persistence/core/migrations/0029_prepared_source_views.sql:86`).
 - Extension tables preserve one executor and one set of filesystem safety
   semantics.
 


### PR DESCRIPTION
## Summary

- `plan.md` source-layout tree and structure-decision sentence now reflect the three-crate split: `persistence/core` owns schema/migrations/pool; `persistence/sessions` owns immutable session, calibration, and correction repositories; `persistence/topology` owns panel, mosaic, proposal, and traversal repositories.
- Two `quickstart.md` test commands that target topology tests (`session_topology_concurrency`, `session_topology_scale`) corrected to `-p persistence_topology`.
- `research.md` citations unchanged — all point at existing migration files and `src/lib.rs` paths in `persistence/core`, which is correct.

## Spec Context

Supersedes stale paths from the prior mechanical `db`→`core` rename; applies the orchestrator-approved crate mapping for spec 062.