### PR TITLE
perf: session list loads in a handful of queries and audit exports stream to disk

### DIFF
--- a/apps/desktop/src-tauri/src/commands/audit.rs
+++ b/apps/desktop/src-tauri/src/commands/audit.rs
@@ -329,9 +329,7 @@ pub async fn audit_export(
             .write_all(b"\n")
             .map_err(|e| ContractError::internal(format!("write error: {e}")))?;
     }
-    writer
-        .flush()
-        .map_err(|e| ContractError::internal(format!("flush error: {e}")))?;
+    writer.flush().map_err(|e| ContractError::internal(format!("flush error: {e}")))?;
     drop(writer);
 
     let bytes = std::fs::metadata(&tmp_path).map_or(0, |m| m.len());
@@ -339,9 +337,5 @@ pub async fn audit_export(
     std::fs::rename(&tmp_path, dest)
         .map_err(|e| ContractError::internal(format!("rename error: {e}")))?;
 
-    Ok(AuditExportResponse {
-        file_path: dest.to_string_lossy().into_owned(),
-        count,
-        bytes,
-    })
+    Ok(AuditExportResponse { file_path: dest.to_string_lossy().into_owned(), count, bytes })
 }

--- a/apps/desktop/src-tauri/src/commands/audit.rs
+++ b/apps/desktop/src-tauri/src/commands/audit.rs
@@ -17,7 +17,9 @@
 //! IPC boundary does not leak the persistence-internal `AuditLogFilter` type.
 
 use app_core::errors::db_err;
-use contracts_core::audit::{AuditActor, AuditEntry, AuditListResponse, AuditOutcome};
+use contracts_core::audit::{
+    AuditActor, AuditEntry, AuditExportResponse, AuditListResponse, AuditOutcome,
+};
 use contracts_core::ContractError;
 use persistence_lifecycle::repositories::audit::{
     count_audit_entries, list_audit_entries, AuditLogFilter, AuditLogRow,
@@ -257,6 +259,9 @@ fn build_filter(
 
 /// `audit.list` — returns paginated audit entries read from `audit_log_entry`.
 ///
+/// Applies a server-side default limit clamp (1..=500, default 100) to prevent
+/// unbounded result sets over IPC.
+///
 /// # Errors
 /// Returns `Err(ContractError)` on database failure.
 #[tauri::command]
@@ -267,7 +272,9 @@ pub async fn audit_list(
     pagination: Option<AuditPaginationDto>,
 ) -> Result<AuditListResponse, ContractError> {
     let pool = state.repo.pool();
-    let filter = build_filter(filters, pagination);
+    let mut filter = build_filter(filters, pagination);
+    // Default limit clamp — same pattern as plans/read.rs:47.
+    filter.limit = Some(filter.limit.unwrap_or(100).clamp(1, 500));
 
     let rows = list_audit_entries(pool, &filter).await.map_err(db_err)?;
     let total = count_audit_entries(pool, &filter).await.map_err(db_err)?;
@@ -276,26 +283,65 @@ pub async fn audit_list(
     Ok(AuditListResponse { entries, total })
 }
 
-/// `audit.export` — export the filtered audit entries as newline-delimited
-/// JSON (one `AuditEntry` per line, matching `audit.list`'s entry shape).
-/// Ignores pagination — export is always the full filtered set.
+/// `audit.export` — export filtered audit entries as newline-delimited JSON to
+/// a file (mirrors `log.export`). Streams backend-side; only the path and count
+/// cross IPC.
 ///
 /// # Errors
-/// Returns `Err(ContractError)` on database failure.
+/// Returns `Err(ContractError)` on database or filesystem failure.
 #[tauri::command]
 #[specta::specta]
 pub async fn audit_export(
     state: State<'_, AppState>,
+    file_path: String,
     filters: Option<AuditFilterDto>,
-) -> Result<String, ContractError> {
+) -> Result<AuditExportResponse, ContractError> {
+    use std::io::Write;
+    use std::path::Path;
+
     let pool = state.repo.pool();
     let filter = build_filter(filters, None);
 
+    let dest = Path::new(&file_path);
+    let parent = dest.parent().ok_or_else(|| {
+        ContractError::internal(format!("No parent directory for path {}", dest.display()))
+    })?;
+    if !parent.exists() {
+        return Err(ContractError::internal(format!(
+            "Parent directory does not exist: {}",
+            parent.display()
+        )));
+    }
+
     let rows = list_audit_entries(pool, &filter).await.map_err(db_err)?;
-    let lines: Vec<String> = rows
-        .into_iter()
-        .map(row_to_entry)
-        .map(|e| serde_json::to_string(&e).unwrap_or_default())
-        .collect();
-    Ok(lines.join("\n"))
+    let entries: Vec<AuditEntry> = rows.into_iter().map(row_to_entry).collect();
+    let count = entries.len();
+
+    // Write to a sibling temp path, then rename atomically.
+    let tmp_path = parent.join(format!(".audit-export-{}.tmp", std::process::id()));
+    let file = std::fs::File::create(&tmp_path)
+        .map_err(|e| ContractError::internal(format!("failed to create temp file: {e}")))?;
+    let mut writer = std::io::BufWriter::new(file);
+    for entry in &entries {
+        serde_json::to_writer(&mut writer, entry)
+            .map_err(|e| ContractError::internal(format!("serialisation error: {e}")))?;
+        writer
+            .write_all(b"\n")
+            .map_err(|e| ContractError::internal(format!("write error: {e}")))?;
+    }
+    writer
+        .flush()
+        .map_err(|e| ContractError::internal(format!("flush error: {e}")))?;
+    drop(writer);
+
+    let bytes = std::fs::metadata(&tmp_path).map(|m| m.len()).unwrap_or(0);
+
+    std::fs::rename(&tmp_path, dest)
+        .map_err(|e| ContractError::internal(format!("rename error: {e}")))?;
+
+    Ok(AuditExportResponse {
+        file_path: dest.to_string_lossy().into_owned(),
+        count,
+        bytes,
+    })
 }

--- a/apps/desktop/src-tauri/src/commands/audit.rs
+++ b/apps/desktop/src-tauri/src/commands/audit.rs
@@ -334,7 +334,7 @@ pub async fn audit_export(
         .map_err(|e| ContractError::internal(format!("flush error: {e}")))?;
     drop(writer);
 
-    let bytes = std::fs::metadata(&tmp_path).map(|m| m.len()).unwrap_or(0);
+    let bytes = std::fs::metadata(&tmp_path).map_or(0, |m| m.len());
 
     std::fs::rename(&tmp_path, dest)
         .map_err(|e| ContractError::internal(format!("rename error: {e}")))?;

--- a/apps/desktop/src-tauri/src/commands/lifecycle.rs
+++ b/apps/desktop/src-tauri/src/commands/lifecycle.rs
@@ -301,6 +301,9 @@ impl From<LedgerRow> for LedgerRowDto {
 
 /// `lifecycle.ledger.list` Tauri command.
 ///
+/// Applies a server-side default limit clamp (1..=500, default 100) to prevent
+/// unbounded result sets over IPC.
+///
 /// # Errors
 /// Returns a stringified persistence error when the repository query fails
 /// (e.g. transient DB unavailability). Successful empty results are `Ok(vec![])`.
@@ -310,7 +313,10 @@ pub async fn lifecycle_ledger_list(
     state: State<'_, AppState>,
     filter: LedgerFilterDto,
 ) -> Result<Vec<LedgerRowDto>, String> {
-    list_assets_ledger(state.repo.as_ref(), filter.into_filter())
+    let mut f = filter.into_filter();
+    // Default limit clamp — same pattern as plans/read.rs:47.
+    f.limit = Some(f.limit.unwrap_or(100).clamp(1, 500));
+    list_assets_ledger(state.repo.as_ref(), f)
         .await
         .map(|rows| rows.into_iter().map(LedgerRowDto::from).collect())
         .map_err(|err| err.to_string())

--- a/apps/desktop/src-tauri/src/commands/sessions.rs
+++ b/apps/desktop/src-tauri/src/commands/sessions.rs
@@ -47,9 +47,14 @@ pub struct SessionSplitResult {
 #[specta::specta]
 pub async fn sessions_list(
     state: State<'_, AppState>,
+    limit: Option<u32>,
+    offset: Option<u32>,
 ) -> Result<Vec<AcquisitionSession>, ContractError> {
-    tracing::debug!("sessions.list");
-    sessions_uc::list_sessions(state.repo.pool()).await.map_err(ContractError::internal)
+    let limit = limit.map(|l| l.clamp(1, 500));
+    tracing::debug!("sessions.list limit={limit:?} offset={offset:?}");
+    sessions_uc::list_sessions_paginated(state.repo.pool(), limit, offset)
+        .await
+        .map_err(ContractError::internal)
 }
 
 /// `sessions.get` -- returns a single session detail from real DB rows.

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -47,7 +47,6 @@
 //! - `settings.restore-defaults`
 //! - `settings.source-override.set`
 
-use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use contracts_core::settings::{
@@ -163,23 +162,23 @@ pub async fn settings_get(
             persistence_lifecycle::repositories::settings::get_all_by_prefix(pool, "uiState.")
                 .await
                 .map_err(app_core::errors::db_to_contract)?;
-        let values: HashMap<String, Value> = rows.into_iter().collect();
+        let map: serde_json::Map<String, Value> = rows.into_iter().collect();
         return Ok(SettingsData {
             scope,
-            values: contracts_core::JsonAny::from(serde_json::to_value(values).unwrap_or_default()),
+            values: contracts_core::JsonAny(Value::Object(map)),
         });
     }
 
     let keys = scope_keys(&scope);
-    let mut values: HashMap<String, Value> = HashMap::with_capacity(keys.len());
+    let mut map = serde_json::Map::with_capacity(keys.len());
     for key in keys {
         let val = app_core::settings::resolve_setting(pool, key, None).await?;
-        values.insert((*key).to_owned(), val);
+        map.insert((*key).to_owned(), val);
     }
 
     Ok(SettingsData {
         scope,
-        values: contracts_core::JsonAny::from(serde_json::to_value(values).unwrap_or_default()),
+        values: contracts_core::JsonAny(Value::Object(map)),
     })
 }
 

--- a/apps/desktop/src-tauri/src/commands/settings.rs
+++ b/apps/desktop/src-tauri/src/commands/settings.rs
@@ -163,10 +163,7 @@ pub async fn settings_get(
                 .await
                 .map_err(app_core::errors::db_to_contract)?;
         let map: serde_json::Map<String, Value> = rows.into_iter().collect();
-        return Ok(SettingsData {
-            scope,
-            values: contracts_core::JsonAny(Value::Object(map)),
-        });
+        return Ok(SettingsData { scope, values: contracts_core::JsonAny(Value::Object(map)) });
     }
 
     let keys = scope_keys(&scope);
@@ -176,10 +173,7 @@ pub async fn settings_get(
         map.insert((*key).to_owned(), val);
     }
 
-    Ok(SettingsData {
-        scope,
-        values: contracts_core::JsonAny(Value::Object(map)),
-    })
+    Ok(SettingsData { scope, values: contracts_core::JsonAny(Value::Object(map)) })
 }
 
 /// `settings.update` — persists settings values for a given scope.

--- a/apps/desktop/src-tauri/tests/commands.rs
+++ b/apps/desktop/src-tauri/tests/commands.rs
@@ -429,13 +429,20 @@ async fn audit_list_filters_by_entity_type() {
 }
 
 #[tokio::test]
-async fn audit_export_returns_ndjson_of_real_rows() {
+async fn audit_export_writes_ndjson_file_of_real_rows() {
     let app = mock_lifecycle_app().await;
     let state = app.state::<AppState>();
     insert_audit_row(state.repo.pool(), "a1", "session", "ses-1", "Confirm session").await;
 
-    let res = audit_export(state, None).await.expect("audit_export ok");
-    let lines: Vec<&str> = res.lines().collect();
+    let tmp_dir = tempfile::tempdir().expect("tmp dir");
+    let file_path = tmp_dir.path().join("export.ndjson").to_string_lossy().into_owned();
+
+    let res = audit_export(state, file_path.clone(), None).await.expect("audit_export ok");
+    assert_eq!(res.count, 1);
+    assert_eq!(res.file_path, file_path);
+
+    let contents = std::fs::read_to_string(&file_path).expect("read exported file");
+    let lines: Vec<&str> = contents.lines().collect();
     assert_eq!(lines.len(), 1);
     let parsed: serde_json::Value = serde_json::from_str(lines[0]).expect("valid ndjson line");
     assert_eq!(parsed["id"], "a1");

--- a/apps/desktop/src/api/ipc.test.ts
+++ b/apps/desktop/src/api/ipc.test.ts
@@ -19,7 +19,7 @@ describe('generated bindings route through the IPC switcher (FR-002)', () => {
       calls.push(cmd);
       return Promise.resolve([]);
     });
-    const res = await commands.sessionsList();
+    const res = await commands.sessionsList(null, null);
     expect(calls).toContain('sessions_list');
     expect(res.status).toBe('ok');
   });

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1539,9 +1539,15 @@ const mockHandlers = {
     } satisfies AuditListResponse_Serialize;
   },
   audit_export: async (_args) => {
-    const args = _args as { filters?: AuditFilterDto | null } | undefined;
+    const args = _args as
+      | { filePath: string; filters?: AuditFilterDto | null }
+      | undefined;
     const filtered = filterMockAuditEntries(args?.filters);
-    return filtered.map((e) => JSON.stringify(e)).join('\n');
+    return {
+      filePath: args?.filePath ?? '/tmp/mock-audit-export.ndjson',
+      count: filtered.length,
+      bytes: 0,
+    };
   },
 
   // ── Archive commands (spec 017 WP-B) ──────────────────────────────────────

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -38,6 +38,9 @@ export const commands = {
 	/**
 	 *  `lifecycle.ledger.list` Tauri command.
 	 * 
+	 *  Applies a server-side default limit clamp (1..=500, default 100) to prevent
+	 *  unbounded result sets over IPC.
+	 * 
 	 *  # Errors
 	 *  Returns a stringified persistence error when the repository query fails
 	 *  (e.g. transient DB unavailability). Successful empty results are `Ok(vec![])`.
@@ -52,7 +55,7 @@ export const commands = {
 	 *  # Errors
 	 *  Returns `Err(String)` on database failure.
 	 */
-	sessionsList: () => typedError<AcquisitionSession_Serialize[], ContractError_Serialize>(__TAURI_INVOKE("sessions_list")),
+	sessionsList: (limit: number | null, offset: number | null) => typedError<AcquisitionSession_Serialize[], ContractError_Serialize>(__TAURI_INVOKE("sessions_list", { limit, offset })),
 	/**
 	 *  `sessions.get` -- returns a single session detail from real DB rows.
 	 * 
@@ -823,6 +826,9 @@ export const commands = {
 	/**
 	 *  `audit.list` — returns paginated audit entries read from `audit_log_entry`.
 	 * 
+	 *  Applies a server-side default limit clamp (1..=500, default 100) to prevent
+	 *  unbounded result sets over IPC.
+	 * 
 	 *  # Errors
 	 *  Returns `Err(ContractError)` on database failure.
 	 */
@@ -842,14 +848,14 @@ export const commands = {
 	offset?: number | null,
 } | null) => typedError<AuditListResponse_Serialize, ContractError_Serialize>(__TAURI_INVOKE("audit_list", { filters, pagination })),
 	/**
-	 *  `audit.export` — export the filtered audit entries as newline-delimited
-	 *  JSON (one `AuditEntry` per line, matching `audit.list`'s entry shape).
-	 *  Ignores pagination — export is always the full filtered set.
+	 *  `audit.export` — export filtered audit entries as newline-delimited JSON to
+	 *  a file (mirrors `log.export`). Streams backend-side; only the path and count
+	 *  cross IPC.
 	 * 
 	 *  # Errors
-	 *  Returns `Err(ContractError)` on database failure.
+	 *  Returns `Err(ContractError)` on database or filesystem failure.
 	 */
-	auditExport: (filters: {
+	auditExport: (filePath: string, filters: {
 	entityType?: string | null,
 	entityId?: string | null,
 	outcome?: AuditOutcome | null,
@@ -860,7 +866,7 @@ export const commands = {
 	from?: string | null,
 	/**  RFC 3339 upper bound on the entry timestamp (exclusive). */
 	to?: string | null,
-} | null) => typedError<string, ContractError_Serialize>(__TAURI_INVOKE("audit_export", { filters })),
+} | null) => typedError<AuditExportResponse, ContractError_Serialize>(__TAURI_INVOKE("audit_export", { filePath, filters })),
 	/**
 	 *  `log.recent` — return the most-recent log entries (initial hydration window).
 	 * 
@@ -2531,6 +2537,16 @@ export type AuditEntry_Serialize = {
 	 *  e.g. `{ "entityType": "project", "fromState": "ready", ... }`).
 	 */
 	detailParams?: { [key in string]: string } | null,
+};
+
+/**  Response for `audit.export` — mirrors `LogExportResponse`. */
+export type AuditExportResponse = {
+	/**  Absolute path of the written file. */
+	filePath: string,
+	/**  Number of entries written. */
+	count: number,
+	/**  Byte size of the written file. */
+	bytes: number,
 };
 
 /**

--- a/apps/desktop/src/dev/devSurface.release.test.ts
+++ b/apps/desktop/src/dev/devSurface.release.test.ts
@@ -66,7 +66,7 @@ describe('T072: release build dev surface gate', () => {
     // While an override is installed, a generated command dispatches through it
     // — the bindings route via the IPC switcher, not @tauri-apps/api/core.
     setInvokeOverride(overrideCall);
-    await commands.sessionsList();
+    await commands.sessionsList(null, null);
     expect(seen).toContain('sessions_list');
 
     // Clearing it (release-build state) must stop dispatching through the
@@ -74,7 +74,7 @@ describe('T072: release build dev surface gate', () => {
     // rejects here — the assertion is that it did NOT go through the override.
     setInvokeOverride(null);
     overrideCall.mockClear();
-    await commands.sessionsList().catch(() => {});
+    await commands.sessionsList(null, null).catch(() => {});
     expect(overrideCall).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -77,25 +77,119 @@ export function MasterDetail({
   agingThresholdDays,
 }: Props) {
   const {
-    detail,
-    matchSessionId,
-    suggestResponse,
-    suggestLoading,
-    suggestError,
-    assigning,
-    archiveReviewPlanId,
-    setArchiveReviewPlanId,
-    inUseConfirmOpen,
-    setInUseConfirmOpen,
-    archivePending,
-    revealTarget,
-    revealActionable,
-    handleAssign,
-    handleReveal,
-    handleArchive,
-    handleConfirmArchiveInUse,
-    handleArchivePlanApplied,
-  } = useMasterDetail(master);
+    response: suggestResponse,
+    loading: suggestLoading,
+    error: suggestError,
+    refresh: refreshSuggest,
+  } = useCalibrationSuggest(matchSessionId);
+  const { assigning, assign } = useCalibrationAssign();
+
+  const handleAssign = async (masterId: string, override: boolean) => {
+    if (!matchSessionId) {
+      return {
+        status: 'error',
+        error: {
+          code: 'no_session',
+          message: m.calibration_compatible_sessions_no_anchor_desc(),
+        },
+      };
+    }
+    const res = await assign(matchSessionId, masterId, override);
+    if (res.status === 'success') refreshSuggest();
+    // Normalize: the real response types `error`/`details` as `| null`, while
+    // the panel's prop type only allows the object or `undefined`.
+    return {
+      status: res.status,
+      error: res.error
+        ? {
+            code: res.error.code,
+            message: res.error.message,
+            details: res.error.details ?? undefined,
+          }
+        : undefined,
+    };
+  };
+
+  // Real `usedBySessionIds`/`compatibleSessions` (populated) come from a
+  // per-master detail fetch; `sessionsList()` cross-references both sets of
+  // ids to human-readable "{target} · {filter} · {night}" labels. Shares the
+  // `queryKeys.sessions.all()` cache entry with the rest of the app (e.g.
+  // `SessionSourcePicker`) rather than a private key.
+  const masterId = master?.id;
+  const masterDetailQuery = useQuery({
+    queryKey: queryKeys.calibration.master(masterId ?? '__none__'),
+    queryFn: async () =>
+      unwrap(await commands.calibrationMastersGet(masterId as string)),
+    enabled: !!masterId,
+  });
+  const sessionsQuery = useQuery({
+    queryKey: queryKeys.sessions.all(),
+    queryFn: async () => unwrap(await commands.sessionsList(null, null)),
+  });
+  // #642: shares the same inventory-sources query SessionsPage's Reveal
+  // action reads (`queryKeys.inventory.all`) — no private fetch.
+  const sourcesQuery = useInventorySources();
+
+  // #886: single-master archive plan generation + review/apply.
+  const generateArchivePlan = useGenerateMasterArchivePlan();
+  const invalidateMaster = useInvalidateCalibrationMaster();
+  const [archiveReviewPlanId, setArchiveReviewPlanId] = useState<string | null>(
+    null,
+  );
+  const [inUseConfirmOpen, setInUseConfirmOpen] = useState(false);
+
+  const detail: DetailState = useMemo(() => {
+    const empty: DetailState = {
+      confirmedNames: [],
+      compatibleNames: [],
+      loading: false,
+      missingFlag: null,
+    };
+    if (!masterId) return empty;
+    if (masterDetailQuery.isFetching || sessionsQuery.isFetching) {
+      return { ...empty, loading: true };
+    }
+    // Mirrors the pre-migration catch-and-swallow: a failed detail or
+    // sessions fetch degrades to the empty state rather than an error banner.
+    if (
+      masterDetailQuery.error ||
+      sessionsQuery.error ||
+      !masterDetailQuery.data
+    ) {
+      return empty;
+    }
+    const masterDetail = masterDetailQuery.data;
+    const idToName = new Map<string, string>();
+    // Defensive: guard against a non-array `sessionsList()` payload (the old
+    // effect's Promise.all().catch() silently swallowed this; a bare `for...of`
+    // here would otherwise throw synchronously during render).
+    const sessionsList = Array.isArray(sessionsQuery.data)
+      ? sessionsQuery.data
+      : [];
+    for (const s of sessionsList) {
+      const k = s.sessionKey;
+      idToName.set(s.id, `${k.target} · ${k.filter} · ${k.night}`);
+    }
+    return {
+      confirmedNames: masterDetail.usedBySessionIds
+        .map((id) => idToName.get(id) ?? id)
+        .filter(Boolean),
+      compatibleNames: masterDetail.compatibleSessions
+        .map((e) => idToName.get(e.sessionId) ?? e.sessionId)
+        .filter(Boolean),
+      loading: false,
+      missingFlag: masterDetail.missingFlag ?? null,
+    };
+  }, [
+    masterId,
+    masterDetailQuery.data,
+    masterDetailQuery.isFetching,
+    masterDetailQuery.error,
+    sessionsQuery.data,
+    sessionsQuery.isFetching,
+    sessionsQuery.error,
+  ]);
+
 
   if (!master) {
     return (

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -58,6 +58,7 @@ import { SessionListPopover } from './SessionListPopover';
 import { MatchCandidatesPanel } from './MatchCandidatesPanel';
 import { MasterArchiveFlow } from './MasterArchiveFlow';
 import { buildMasterTitle, buildFingerprintProps } from './master-detail-model';
+import { useMasterDetail } from './useMasterDetail';
 
 // ── Props ─────────────────────────────────────────────────────────────────────
 
@@ -76,118 +77,25 @@ export function MasterDetail({
   agingThresholdDays,
 }: Props) {
   const {
-    response: suggestResponse,
-    loading: suggestLoading,
-    error: suggestError,
-    refresh: refreshSuggest,
-  } = useCalibrationSuggest(matchSessionId);
-  const { assigning, assign } = useCalibrationAssign();
-
-  const handleAssign = async (masterId: string, override: boolean) => {
-    if (!matchSessionId) {
-      return {
-        status: 'error',
-        error: {
-          code: 'no_session',
-          message: m.calibration_compatible_sessions_no_anchor_desc(),
-        },
-      };
-    }
-    const res = await assign(matchSessionId, masterId, override);
-    if (res.status === 'success') refreshSuggest();
-    // Normalize: the real response types `error`/`details` as `| null`, while
-    // the panel's prop type only allows the object or `undefined`.
-    return {
-      status: res.status,
-      error: res.error
-        ? {
-            code: res.error.code,
-            message: res.error.message,
-            details: res.error.details ?? undefined,
-          }
-        : undefined,
-    };
-  };
-
-  // Real `usedBySessionIds`/`compatibleSessions` (populated) come from a
-  // per-master detail fetch; `sessionsList()` cross-references both sets of
-  // ids to human-readable "{target} · {filter} · {night}" labels. Shares the
-  // `queryKeys.sessions.all()` cache entry with the rest of the app (e.g.
-  // `SessionSourcePicker`) rather than a private key.
-  const masterId = master?.id;
-  const masterDetailQuery = useQuery({
-    queryKey: queryKeys.calibration.master(masterId ?? '__none__'),
-    queryFn: async () =>
-      unwrap(await commands.calibrationMastersGet(masterId as string)),
-    enabled: !!masterId,
-  });
-  const sessionsQuery = useQuery({
-    queryKey: queryKeys.sessions.all(),
-    queryFn: async () => unwrap(await commands.sessionsList(null, null)),
-  });
-  // #642: shares the same inventory-sources query SessionsPage's Reveal
-  // action reads (`queryKeys.inventory.all`) — no private fetch.
-  const _sourcesQuery = useInventorySources();
-
-  // #886: single-master archive plan generation + review/apply.
-  const _generateArchivePlan = useGenerateMasterArchivePlan();
-  const _invalidateMaster = useInvalidateCalibrationMaster();
-  const [archiveReviewPlanId, setArchiveReviewPlanId] = useState<string | null>(
-    null,
-  );
-  const [inUseConfirmOpen, setInUseConfirmOpen] = useState(false);
-
-  const detail: DetailState = useMemo(() => {
-    const empty: DetailState = {
-      confirmedNames: [],
-      compatibleNames: [],
-      loading: false,
-      missingFlag: null,
-    };
-    if (!masterId) return empty;
-    if (masterDetailQuery.isFetching || sessionsQuery.isFetching) {
-      return { ...empty, loading: true };
-    }
-    // Mirrors the pre-migration catch-and-swallow: a failed detail or
-    // sessions fetch degrades to the empty state rather than an error banner.
-    if (
-      masterDetailQuery.error ||
-      sessionsQuery.error ||
-      !masterDetailQuery.data
-    ) {
-      return empty;
-    }
-    const masterDetail = masterDetailQuery.data;
-    const idToName = new Map<string, string>();
-    // Defensive: guard against a non-array `sessionsList()` payload (the old
-    // effect's Promise.all().catch() silently swallowed this; a bare `for...of`
-    // here would otherwise throw synchronously during render).
-    const sessionsList = Array.isArray(sessionsQuery.data)
-      ? sessionsQuery.data
-      : [];
-    for (const s of sessionsList) {
-      const k = s.sessionKey;
-      idToName.set(s.id, `${k.target} · ${k.filter} · ${k.night}`);
-    }
-    return {
-      confirmedNames: masterDetail.usedBySessionIds
-        .map((id) => idToName.get(id) ?? id)
-        .filter(Boolean),
-      compatibleNames: masterDetail.compatibleSessions
-        .map((e) => idToName.get(e.sessionId) ?? e.sessionId)
-        .filter(Boolean),
-      loading: false,
-      missingFlag: masterDetail.missingFlag ?? null,
-    };
-  }, [
-    masterId,
-    masterDetailQuery.data,
-    masterDetailQuery.isFetching,
-    masterDetailQuery.error,
-    sessionsQuery.data,
-    sessionsQuery.isFetching,
-    sessionsQuery.error,
-  ]);
+    detail,
+    matchSessionId,
+    suggestResponse,
+    suggestLoading,
+    suggestError,
+    assigning,
+    archiveReviewPlanId,
+    setArchiveReviewPlanId,
+    inUseConfirmOpen,
+    setInUseConfirmOpen,
+    archivePending,
+    revealTarget,
+    revealActionable,
+    handleAssign,
+    handleReveal,
+    handleArchive,
+    handleConfirmArchiveInUse,
+    handleArchivePlanApplied,
+  } = useMasterDetail(master);
 
   if (!master) {
     return (

--- a/apps/desktop/src/features/calibration/MasterDetail.tsx
+++ b/apps/desktop/src/features/calibration/MasterDetail.tsx
@@ -56,7 +56,6 @@ import { m } from '@/lib/i18n';
 import { revealLabel } from '@/lib/reveal-label';
 import { SessionListPopover } from './SessionListPopover';
 import { MatchCandidatesPanel } from './MatchCandidatesPanel';
-import { useMasterDetail } from './useMasterDetail';
 import { MasterArchiveFlow } from './MasterArchiveFlow';
 import { buildMasterTitle, buildFingerprintProps } from './master-detail-model';
 
@@ -128,11 +127,11 @@ export function MasterDetail({
   });
   // #642: shares the same inventory-sources query SessionsPage's Reveal
   // action reads (`queryKeys.inventory.all`) — no private fetch.
-  const sourcesQuery = useInventorySources();
+  const _sourcesQuery = useInventorySources();
 
   // #886: single-master archive plan generation + review/apply.
-  const generateArchivePlan = useGenerateMasterArchivePlan();
-  const invalidateMaster = useInvalidateCalibrationMaster();
+  const _generateArchivePlan = useGenerateMasterArchivePlan();
+  const _invalidateMaster = useInvalidateCalibrationMaster();
   const [archiveReviewPlanId, setArchiveReviewPlanId] = useState<string | null>(
     null,
   );
@@ -189,7 +188,6 @@ export function MasterDetail({
     sessionsQuery.isFetching,
     sessionsQuery.error,
   ]);
-
 
   if (!master) {
     return (

--- a/apps/desktop/src/features/calibration/useMasterDetail.ts
+++ b/apps/desktop/src/features/calibration/useMasterDetail.ts
@@ -142,7 +142,7 @@ export function useMasterDetail(
   });
   const sessionsQuery = useQuery({
     queryKey: queryKeys.sessions.all(),
-    queryFn: async () => unwrap(await commands.sessionsList()),
+    queryFn: async () => unwrap(await commands.sessionsList(null, null)),
   });
   // #642: shares the same inventory-sources query SessionsPage's Reveal
   // action reads (`queryKeys.inventory.all`) — no private fetch.

--- a/apps/desktop/src/features/projects/SessionSourcePicker.tsx
+++ b/apps/desktop/src/features/projects/SessionSourcePicker.tsx
@@ -50,7 +50,7 @@ export function SessionSourcePicker({
 }: SessionSourcePickerProps) {
   const { data: allSessions, isFetching: loading } = useQuery({
     queryKey: queryKeys.sessions.all(),
-    queryFn: async () => unwrap(await commands.sessionsList()),
+    queryFn: async () => unwrap(await commands.sessionsList(null, null)),
   });
   const [filterTarget, setFilterTarget] = useState('');
   const [filterFilter, setFilterFilter] = useState('');

--- a/apps/desktop/src/features/projects/wizard/StepViews.tsx
+++ b/apps/desktop/src/features/projects/wizard/StepViews.tsx
@@ -48,7 +48,7 @@ export function StepViews({
 
   const { data: sessions } = useQuery({
     queryKey: queryKeys.sessions.all(),
-    queryFn: async () => unwrap(await commands.sessionsList()),
+    queryFn: async () => unwrap(await commands.sessionsList(null, null)),
   });
 
   const selected = (sessions ?? []).filter((s) =>

--- a/apps/desktop/src/features/projects/wizard/WizardPage.tsx
+++ b/apps/desktop/src/features/projects/wizard/WizardPage.tsx
@@ -52,7 +52,7 @@ async function assignWizardCalibrationSelections(
 
   let sessions: Array<{ id: string; sessionKey: { filter: string } }> = [];
   try {
-    sessions = unwrap(await commands.sessionsList()).filter((s) =>
+    sessions = unwrap(await commands.sessionsList(null, null)).filter((s) =>
       sessionIds.includes(s.id),
     );
   } catch {
@@ -217,7 +217,7 @@ export function WizardPage() {
   // the same `sessions.list` cache StepSources/StepViews already populate.
   const { data: allSessions } = useQuery({
     queryKey: queryKeys.sessions.all(),
-    queryFn: async () => unwrap(await commands.sessionsList()),
+    queryFn: async () => unwrap(await commands.sessionsList(null, null)),
   });
   useEffect(() => {
     if (!incomingTargetId || wizardData.name.target) return;

--- a/apps/desktop/src/features/settings/AuditLog.test.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.test.tsx
@@ -368,10 +368,7 @@ describe('AuditLog', () => {
     fireEvent.click(exportBtn);
 
     await waitFor(() =>
-      expect(mockExport).toHaveBeenCalledWith(
-        '/tmp/audit-export.ndjson',
-        null,
-      ),
+      expect(mockExport).toHaveBeenCalledWith('/tmp/audit-export.ndjson', null),
     );
   });
 

--- a/apps/desktop/src/features/settings/AuditLog.test.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.test.tsx
@@ -351,40 +351,28 @@ describe('AuditLog', () => {
     ).toBeInTheDocument();
   });
 
-  it('exports via auditExport with the current filters and triggers a download', async () => {
-    const createObjectURL = vi.fn(() => 'blob:mock-url');
-    const revokeObjectURL = vi.fn();
-    vi.stubGlobal('URL', { ...URL, createObjectURL, revokeObjectURL });
-    const clickSpy = vi.fn();
-    const originalCreateElement = document.createElement.bind(document);
-    vi.spyOn(document, 'createElement').mockImplementation((tag: string) => {
-      const el = originalCreateElement(tag);
-      if (tag === 'a') el.click = clickSpy;
-      return el;
-    });
+  it('exports via auditExport with a save dialog and the current filters', async () => {
+    // Mock @tauri-apps/plugin-dialog save function.
+    vi.mock('@tauri-apps/plugin-dialog', () => ({
+      save: vi.fn().mockResolvedValue('/tmp/audit-export.ndjson'),
+    }));
 
     render(<AuditLog />, { wrapper });
     await waitFor(() => expect(mockList).toHaveBeenCalled());
 
-    // The Export button is `disabled={exporting || loading}` (AuditLog.tsx),
-    // and `loading` only clears once auditList's promise RESOLVES — the
-    // waitFor above only proves the call was made. fireEvent.click on a
-    // disabled button is a silent no-op, so clicking synchronously here
-    // races the load on slow runners: auditExport is simply never invoked
-    // and the assertion below fails with "Number of calls: 0" (observed on
-    // macos-latest). Wait for the button to actually be enabled first.
+    // Wait for the button to be enabled (loading clears after auditList resolves).
     const exportBtn = await screen.findByRole('button', {
       name: 'Export audit events to a file',
     });
     await waitFor(() => expect(exportBtn).toBeEnabled());
     fireEvent.click(exportBtn);
 
-    await waitFor(() => expect(mockExport).toHaveBeenCalledWith(null));
-    await waitFor(() => expect(clickSpy).toHaveBeenCalled());
-    expect(revokeObjectURL).toHaveBeenCalledWith('blob:mock-url');
-
-    vi.unstubAllGlobals();
-    vi.restoreAllMocks();
+    await waitFor(() =>
+      expect(mockExport).toHaveBeenCalledWith(
+        '/tmp/audit-export.ndjson',
+        null,
+      ),
+    );
   });
 
   it('renders the state-change column (#749)', async () => {

--- a/apps/desktop/src/features/settings/AuditLog.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.tsx
@@ -275,17 +275,21 @@ export function AuditLog() {
     setExportError(null);
     setExporting(true);
     try {
-      const ndjson = await auditExport(filters);
-      const blob = new Blob([ndjson], { type: 'application/x-ndjson' });
-      const url = URL.createObjectURL(blob);
+      let filePath: string | null = null;
       try {
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = `audit-log-export-${Date.now()}.ndjson`;
-        link.click();
-      } finally {
-        URL.revokeObjectURL(url);
+        const { save: showSaveDialog } = await import(
+          '@tauri-apps/plugin-dialog'
+        );
+        filePath = await showSaveDialog({
+          title: 'Export Audit Log',
+          defaultPath: `audit-log-export-${Date.now()}.ndjson`,
+          filters: [{ name: 'NDJSON', extensions: ['ndjson', 'json'] }],
+        });
+      } catch {
+        filePath = null;
       }
+      if (!filePath) return;
+      await auditExport(filePath, filters);
     } catch (err: unknown) {
       setExportError(errMessage(err));
     } finally {

--- a/apps/desktop/src/features/settings/AuditLog.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.tsx
@@ -281,6 +281,7 @@ export function AuditLog() {
           '@tauri-apps/plugin-dialog'
         );
         filePath = await showSaveDialog({
+          // eslint-disable-next-line alm/no-user-string -- native OS file-picker chrome, not rendered in the app
           title: 'Export Audit Log',
           defaultPath: `audit-log-export-${Date.now()}.ndjson`,
           filters: [{ name: 'NDJSON', extensions: ['ndjson', 'json'] }],

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -68,6 +68,7 @@ import type {
   CreateFilter,
   UpdateFilter,
   RemapVerification,
+  AuditExportResponse,
   AuditListResponse,
   AuditFilterDto,
   AuditPaginationDto,
@@ -571,9 +572,10 @@ export async function auditList(
   return unwrap(await commands.auditList(filters, pagination));
 }
 
-/** `audit.export` — export the filtered audit entries as newline-delimited JSON. */
+/** `audit.export` — export filtered audit entries to a file (NDJSON). */
 export async function auditExport(
+  filePath: string,
   filters: AuditFilterDto | null,
-): Promise<string> {
-  return unwrap(await commands.auditExport(filters));
+): Promise<AuditExportResponse> {
+  return unwrap(await commands.auditExport(filePath, filters));
 }

--- a/crates/app/core/src/frame_inventory/list.rs
+++ b/crates/app/core/src/frame_inventory/list.rs
@@ -98,8 +98,7 @@ pub async fn list_frames(
             }
             let (session_id, frame_type) = frame_map
                 .get(&row.id)
-                .map(|(sid, ft)| (Some(sid.clone()), *ft))
-                .unwrap_or((None, RawFrameType::Light));
+                .map_or((None, RawFrameType::Light), |(sid, ft)| (Some(sid.clone()), *ft));
             frames.push(InventoryFrame {
                 frame_id: row.id,
                 root_id: row.root_id,

--- a/crates/app/core/src/frame_inventory/list.rs
+++ b/crates/app/core/src/frame_inventory/list.rs
@@ -13,7 +13,9 @@ use sqlx::SqlitePool;
 
 use app_core_errors::db_err;
 
-use super::{build_frame_session_map, raw_frame_type_from_calibration_kind, rows_by_ids, rows_by_root};
+use super::{
+    build_frame_session_map, raw_frame_type_from_calibration_kind, rows_by_ids, rows_by_root,
+};
 
 fn presence_state(state: &str) -> FramePresenceState {
     match state {

--- a/crates/app/core/src/frame_inventory/list.rs
+++ b/crates/app/core/src/frame_inventory/list.rs
@@ -13,9 +13,7 @@ use sqlx::SqlitePool;
 
 use app_core_errors::db_err;
 
-use super::{
-    owning_session_frame_type, raw_frame_type_from_calibration_kind, rows_by_ids, rows_by_root,
-};
+use super::{build_frame_session_map, raw_frame_type_from_calibration_kind, rows_by_ids, rows_by_root};
 
 fn presence_state(state: &str) -> FramePresenceState {
     match state {
@@ -91,12 +89,17 @@ pub async fn list_frames(
             });
         }
     } else if let Some(root_id) = &req.scope.root_id {
+        // DSD-8: batch-build the reverse map once instead of a per-frame LIKE scan.
+        let frame_map = build_frame_session_map(pool).await?;
         for row in rows_by_root(pool, root_id).await? {
             let state = presence_state(&row.state);
             if !include_missing && state == FramePresenceState::Missing {
                 continue;
             }
-            let (session_id, frame_type) = owning_session_frame_type(pool, &row.id).await?;
+            let (session_id, frame_type) = frame_map
+                .get(&row.id)
+                .map(|(sid, ft)| (Some(sid.clone()), *ft))
+                .unwrap_or((None, RawFrameType::Light));
             frames.push(InventoryFrame {
                 frame_id: row.id,
                 root_id: row.root_id,

--- a/crates/app/core/src/frame_inventory/mod.rs
+++ b/crates/app/core/src/frame_inventory/mod.rs
@@ -219,10 +219,9 @@ pub(crate) async fn build_frame_session_map(
     let mut map: HashMap<String, (String, RawFrameType)> = HashMap::new();
 
     // Acquisition sessions (light frames).
-    let acq_rows =
-        persistence_core::repositories::q_core::all_acquisition_session_frame_ids(pool)
-            .await
-            .map_err(db_err)?;
+    let acq_rows = persistence_core::repositories::q_core::all_acquisition_session_frame_ids(pool)
+        .await
+        .map_err(db_err)?;
 
     for (session_id, frame_ids_json) in acq_rows {
         let ids: Vec<String> = serde_json::from_str(&frame_ids_json).unwrap_or_default();
@@ -232,10 +231,9 @@ pub(crate) async fn build_frame_session_map(
     }
 
     // Calibration sessions (dark/flat/bias frames).
-    let cal_rows =
-        persistence_core::repositories::q_core::all_calibration_session_frame_ids(pool)
-            .await
-            .map_err(db_err)?;
+    let cal_rows = persistence_core::repositories::q_core::all_calibration_session_frame_ids(pool)
+        .await
+        .map_err(db_err)?;
 
     for (session_id, frame_ids_json, kind) in cal_rows {
         let frame_type = raw_frame_type_from_calibration_kind(&kind);

--- a/crates/app/core/src/frame_inventory/mod.rs
+++ b/crates/app/core/src/frame_inventory/mod.rs
@@ -206,6 +206,48 @@ pub(crate) async fn owning_session_frame_type(
     Ok((None, RawFrameType::Light))
 }
 
+/// Batch-build a reverse lookup from frame_id to (session_id, frame_type) for
+/// all sessions in the database. Replaces the per-frame LIKE full-table scan in
+/// the root-scoped list path (DSD-8). Callers that list frames by root can call
+/// this once and look up each frame in O(1) instead of issuing a LIKE query per
+/// frame.
+pub(crate) async fn build_frame_session_map(
+    pool: &sqlx::SqlitePool,
+) -> Result<std::collections::HashMap<String, (String, RawFrameType)>, ContractError> {
+    use std::collections::HashMap;
+
+    let mut map: HashMap<String, (String, RawFrameType)> = HashMap::new();
+
+    // Acquisition sessions (light frames).
+    let acq_rows =
+        persistence_core::repositories::q_core::all_acquisition_session_frame_ids(pool)
+            .await
+            .map_err(db_err)?;
+
+    for (session_id, frame_ids_json) in acq_rows {
+        let ids: Vec<String> = serde_json::from_str(&frame_ids_json).unwrap_or_default();
+        for fid in ids {
+            map.entry(fid).or_insert_with(|| (session_id.clone(), RawFrameType::Light));
+        }
+    }
+
+    // Calibration sessions (dark/flat/bias frames).
+    let cal_rows =
+        persistence_core::repositories::q_core::all_calibration_session_frame_ids(pool)
+            .await
+            .map_err(db_err)?;
+
+    for (session_id, frame_ids_json, kind) in cal_rows {
+        let frame_type = raw_frame_type_from_calibration_kind(&kind);
+        let ids: Vec<String> = serde_json::from_str(&frame_ids_json).unwrap_or_default();
+        for fid in ids {
+            map.entry(fid).or_insert_with(|| (session_id.clone(), frame_type));
+        }
+    }
+
+    Ok(map)
+}
+
 fn iso_now() -> String {
     time::OffsetDateTime::now_utc()
         .format(&time::format_description::well_known::Iso8601::DEFAULT)

--- a/crates/app/core/src/sessions.rs
+++ b/crates/app/core/src/sessions.rs
@@ -91,9 +91,8 @@ pub async fn list_sessions_paginated(
         .collect();
 
     // 3) Batch-load fingerprints (1 query instead of N).
-    let fp_rows = q_core::get_fingerprints_batch(pool, &session_ids)
-        .await
-        .map_err(|e| e.to_string())?;
+    let fp_rows =
+        q_core::get_fingerprints_batch(pool, &session_ids).await.map_err(|e| e.to_string())?;
     let fingerprints: HashMap<String, Fingerprint> = fp_rows
         .into_iter()
         .map(|r| {

--- a/crates/app/core/src/sessions.rs
+++ b/crates/app/core/src/sessions.rs
@@ -54,48 +54,101 @@ use std::collections::HashMap;
 /// # Errors
 /// Returns `Err(String)` on database failure.
 pub async fn list_sessions(pool: &SqlitePool) -> Result<Vec<AcquisitionSession>, String> {
-    // spec 035 US4/T044: LEFT JOIN the spec-035 canonical_target so a session's
-    // resolved target name (`primary_designation`) surfaces in the read path.
-    // `canonical_target_id` (migration 0046) is the spec-035 link; it coexists
-    // with the legacy `target_id` (→ old `target` table, left NULL by ingest).
-    let rows = persistence_core::repositories::q_core::list_sessions_joined(pool)
+    list_sessions_paginated(pool, None, None).await
+}
+
+/// Paginated `sessions.list` — accepts optional `limit`/`offset`.
+///
+/// Uses set-based batch queries (fingerprints, frame summaries, exposure, project
+/// links) instead of per-row N+1 loops.
+///
+/// # Errors
+/// Returns `Err(String)` on database failure.
+pub async fn list_sessions_paginated(
+    pool: &SqlitePool,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> Result<Vec<AcquisitionSession>, String> {
+    use persistence_core::repositories::q_core;
+
+    // 1) Fetch session rows (paginated).
+    let rows = q_core::list_sessions_joined_paginated(pool, limit, offset)
         .await
         .map_err(|e| e.to_string())?;
 
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    // 2) Collect session ids and parse frame_ids once per row.
+    let session_ids: Vec<String> = rows.iter().map(|r| r.id.clone()).collect();
+    let sessions_frame_ids: Vec<(String, Vec<String>)> = rows
+        .iter()
+        .map(|r| {
+            let ids: Vec<String> = serde_json::from_str(&r.frame_ids).unwrap_or_default();
+            (r.id.clone(), ids)
+        })
+        .collect();
+
+    // 3) Batch-load fingerprints (1 query instead of N).
+    let fp_rows = q_core::get_fingerprints_batch(pool, &session_ids)
+        .await
+        .map_err(|e| e.to_string())?;
+    let fingerprints: HashMap<String, Fingerprint> = fp_rows
+        .into_iter()
+        .map(|r| {
+            (
+                r.id.clone(),
+                Fingerprint {
+                    gain: r.gain,
+                    filter_name: r.filter_name,
+                    binning: r.binning,
+                    optic_train: r.optic_train,
+                    observing_night_date: r.observing_night_date,
+                },
+            )
+        })
+        .collect();
+
+    // 4) Batch-load active frame summaries (1 query instead of N).
+    let frame_summaries = q_core::active_frame_summaries_batch(pool, &sessions_frame_ids)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // 5) Batch-load exposure seconds (1 query instead of N).
+    let exposures = q_core::active_frame_exposure_seconds_batch(pool, &sessions_frame_ids)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // 6) Batch-load project ids (1 query instead of N).
+    let project_pairs = q_core::project_ids_for_sessions_batch(pool, &session_ids)
+        .await
+        .map_err(|e| e.to_string())?;
+    let mut project_map: HashMap<String, Vec<String>> = HashMap::new();
+    for (sid, pid) in project_pairs {
+        project_map.entry(sid).or_default().push(pid);
+    }
+
+    // 7) Assemble results.
     let mut sessions = Vec::with_capacity(rows.len());
     for row in rows {
         let id = row.id;
-        let fp = load_fingerprint(pool, &id).await?;
-        let mut sk = parse_session_key(&row.session_key, fp.as_ref());
-        // Prefer the canonical target's display designation when linked.
+        let fp = fingerprints.get(&id);
+        let mut sk = parse_session_key(&row.session_key, fp);
         if let Some(name) = row.canonical_target_name.filter(|n| !n.is_empty()) {
             sk.target = name;
         }
-        // Spec 041 FR-051: sessions are derived, already-confirmed inventory —
-        // there is no review state left to derive a confidence level from.
         let confidence = ConfidenceLevel::Confirmed;
-        // TODO(037): optical_train_id -- fingerprint stores name, not UUID.
-        let optical_train_id = fp.as_ref().and_then(|f| f.optic_train.clone()).unwrap_or_default();
-        // spec 048 US1: frame_count/total_size_bytes are the ACTIVE (non-missing)
-        // file_record members — honest counts/totals, not the raw array length
-        // (which may retain `missing` ids in flag-missing mode).
-        let (frame_count, total_size_bytes) = active_frame_summary(pool, &row.frame_ids).await?;
-        // #775: real sum of active frames' per-file exposure_s (inbox_file_metadata).
-        let total_integration_seconds = active_frame_exposure_seconds(pool, &row.frame_ids).await?;
-        // TODO(037): metadata -- not stored as structured provenance rows yet.
+        let optical_train_id = fp.and_then(|f| f.optic_train.clone()).unwrap_or_default();
+        let (count, total) = frame_summaries.get(&id).copied().unwrap_or((0, 0));
+        let frame_count = u32::try_from(count.max(0)).unwrap_or(0);
+        let total_size_bytes = u64::try_from(total.max(0)).unwrap_or(0);
+        let total_integration_seconds = exposures.get(&id).copied().unwrap_or(0.0);
         let metadata = HashMap::new();
-        // Surface the canonical target id (spec 035) when the legacy target_id is
-        // absent — ingested sessions link via canonical_target_id (R10).
-        // Shared precedence with q_targets_mgmt::session_counts_by_target — see
-        // resolve_session_target_id's doc (reviewer seq=277).
-        let target_ids = persistence_core::repositories::q_core::resolve_session_target_id(
-            row.target_id,
-            row.canonical_target_id,
-        )
-        .into_iter()
-        .collect();
-        let project_ids = load_project_ids(pool, &id).await?;
-        // TODO(037): warnings -- not stored; derive from fingerprint in future.
+        let target_ids = q_core::resolve_session_target_id(row.target_id, row.canonical_target_id)
+            .into_iter()
+            .collect();
+        let project_ids = project_map.remove(&id).unwrap_or_default();
         let warnings = Vec::new();
         sessions.push(AcquisitionSession {
             id,

--- a/crates/contracts/core/src/audit.rs
+++ b/crates/contracts/core/src/audit.rs
@@ -74,3 +74,15 @@ pub struct AuditListResponse {
     pub entries: Vec<AuditEntry>,
     pub total: u32,
 }
+
+/// Response for `audit.export` — mirrors `LogExportResponse`.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AuditExportResponse {
+    /// Absolute path of the written file.
+    pub file_path: String,
+    /// Number of entries written.
+    pub count: usize,
+    /// Byte size of the written file.
+    pub bytes: u64,
+}

--- a/crates/contracts/core/src/sessions.rs
+++ b/crates/contracts/core/src/sessions.rs
@@ -86,6 +86,17 @@ pub struct AcquisitionSession {
     pub warnings: Vec<String>,
 }
 
+/// Slim session summary for list views that only need identification and counts
+/// (GF-10: session pickers, label surfaces). Avoids transferring `metadata`,
+/// `warnings`, and `project_ids` over IPC when unused.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct SessionSummary {
+    pub id: String,
+    pub session_key: SessionKey,
+    pub frame_count: u32,
+}
+
 // ── Detail types ────────────────────────────────────────────────────────────
 
 /// A group of frames within a session (per-filter breakdown).

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -426,15 +426,44 @@ pub struct SessionJoinRow {
 /// # Errors
 /// Returns [`crate::DbError::Database`] on query failure.
 pub async fn list_sessions_joined(pool: &SqlitePool) -> DbResult<Vec<SessionJoinRow>> {
-    let rows = sqlx::query_as::<_, SessionJoinRow>(
-        "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at,
-                s.canonical_target_id, ct.primary_designation AS canonical_target_name
-         FROM acquisition_session s
-         LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id
-         ORDER BY s.created_at DESC",
-    )
-    .fetch_all(pool)
-    .await?;
+    list_sessions_joined_paginated(pool, None, None).await
+}
+
+/// Paginated variant of [`list_sessions_joined`].
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn list_sessions_joined_paginated(
+    pool: &SqlitePool,
+    limit: Option<u32>,
+    offset: Option<u32>,
+) -> DbResult<Vec<SessionJoinRow>> {
+    let sql = match (limit, offset) {
+        (Some(l), Some(o)) => format!(
+            "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at, \
+                    s.canonical_target_id, ct.primary_designation AS canonical_target_name \
+             FROM acquisition_session s \
+             LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id \
+             ORDER BY s.created_at DESC LIMIT {l} OFFSET {o}"
+        ),
+        (Some(l), None) => format!(
+            "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at, \
+                    s.canonical_target_id, ct.primary_designation AS canonical_target_name \
+             FROM acquisition_session s \
+             LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id \
+             ORDER BY s.created_at DESC LIMIT {l}"
+        ),
+        _ => "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at, \
+                    s.canonical_target_id, ct.primary_designation AS canonical_target_name \
+             FROM acquisition_session s \
+             LEFT JOIN canonical_target ct ON ct.id = s.canonical_target_id \
+             ORDER BY s.created_at DESC"
+            .to_owned(),
+    };
+    // AssertSqlSafe: limit/offset are u32 literals formatted directly — no user strings.
+    let rows = sqlx::query_as::<_, SessionJoinRow>(sqlx::AssertSqlSafe(sql))
+        .fetch_all(pool)
+        .await?;
     Ok(rows)
 }
 
@@ -675,6 +704,218 @@ pub async fn session_history(
     .fetch_all(pool)
     .await?;
     Ok(rows)
+}
+
+// ── Frame-session map (DSD-8 LIKE-scan inversion) ───────────────────────────
+
+/// All `(id, frame_ids)` pairs from `acquisition_session`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn all_acquisition_session_frame_ids(
+    pool: &SqlitePool,
+) -> DbResult<Vec<(String, String)>> {
+    let rows: Vec<(String, String)> =
+        sqlx::query_as("SELECT id, frame_ids FROM acquisition_session")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows)
+}
+
+/// All `(id, frame_ids, kind)` triples from `calibration_session`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn all_calibration_session_frame_ids(
+    pool: &SqlitePool,
+) -> DbResult<Vec<(String, String, String)>> {
+    let rows: Vec<(String, String, String)> =
+        sqlx::query_as("SELECT id, frame_ids, kind FROM calibration_session")
+            .fetch_all(pool)
+            .await?;
+    Ok(rows)
+}
+
+// ── Batch queries for sessions.list ──────────────────────────────────────────
+
+/// Keyed fingerprint row for batch loading.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct KeyedFingerprintRow {
+    pub id: String,
+    pub gain: Option<f64>,
+    pub filter_name: Option<String>,
+    pub binning: Option<String>,
+    pub optic_train: Option<String>,
+    pub observing_night_date: Option<String>,
+}
+
+/// Batch-load `acquisition_fingerprint` rows for multiple session ids.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn get_fingerprints_batch(
+    pool: &SqlitePool,
+    session_ids: &[String],
+) -> DbResult<Vec<KeyedFingerprintRow>> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT id, gain, filter_name, binning, optic_train, observing_night_date \
+         FROM acquisition_fingerprint WHERE id IN (",
+    );
+    let mut sep = builder.separated(", ");
+    for id in session_ids {
+        sep.push_bind(id);
+    }
+    sep.push_unseparated(")");
+    let rows: Vec<KeyedFingerprintRow> = builder.build_query_as().fetch_all(pool).await?;
+    Ok(rows)
+}
+
+/// Batch-load `project_id` values for multiple sessions via `project_sources`.
+/// Returns `(session_id, project_id)` pairs.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn project_ids_for_sessions_batch(
+    pool: &SqlitePool,
+    session_ids: &[String],
+) -> DbResult<Vec<(String, String)>> {
+    if session_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT inventory_session_id, project_id FROM project_sources \
+         WHERE inventory_session_id IN (",
+    );
+    let mut sep = builder.separated(", ");
+    for id in session_ids {
+        sep.push_bind(id);
+    }
+    sep.push_unseparated(")");
+    let rows: Vec<(String, String)> = builder.build_query_as().fetch_all(pool).await?;
+    Ok(rows)
+}
+
+/// Batch active frame summary: returns `(session_frame_ids_hash, count, total_size_bytes)`
+/// per session. Takes a slice of `(session_id, frame_ids_json)` pairs.
+/// Internally collects all frame IDs, runs one query, then re-attributes by session.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn active_frame_summaries_batch(
+    pool: &SqlitePool,
+    sessions_frame_ids: &[(String, Vec<String>)],
+) -> DbResult<std::collections::HashMap<String, (i64, i64)>> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut result: HashMap<String, (i64, i64)> = HashMap::new();
+    if sessions_frame_ids.is_empty() {
+        return Ok(result);
+    }
+
+    // Collect all unique frame ids and build reverse map (frame_id -> session_ids).
+    let mut all_ids: Vec<&String> = Vec::new();
+    let mut frame_to_session: HashMap<&str, &str> = HashMap::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+
+    for (session_id, frame_ids) in sessions_frame_ids {
+        result.insert(session_id.clone(), (0, 0));
+        for fid in frame_ids {
+            if seen.insert(fid.as_str()) {
+                all_ids.push(fid);
+                frame_to_session.insert(fid.as_str(), session_id.as_str());
+            }
+        }
+    }
+
+    if all_ids.is_empty() {
+        return Ok(result);
+    }
+
+    // Query all at once: id, state, size_bytes for the frame ids.
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT id, size_bytes FROM file_record WHERE state != 'missing' AND id IN (",
+    );
+    let mut sep = builder.separated(", ");
+    for id in &all_ids {
+        sep.push_bind(*id);
+    }
+    sep.push_unseparated(")");
+
+    let rows: Vec<(String, i64)> = builder.build_query_as().fetch_all(pool).await?;
+
+    for (frame_id, size_bytes) in rows {
+        if let Some(&sid) = frame_to_session.get(frame_id.as_str()) {
+            let entry = result.entry(sid.to_owned()).or_insert((0, 0));
+            entry.0 += 1;
+            entry.1 += size_bytes;
+        }
+    }
+
+    Ok(result)
+}
+
+/// Batch active frame exposure seconds: one query for all frame ids, re-attributed
+/// per session. Returns `session_id -> total_exposure_s`.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn active_frame_exposure_seconds_batch(
+    pool: &SqlitePool,
+    sessions_frame_ids: &[(String, Vec<String>)],
+) -> DbResult<std::collections::HashMap<String, f64>> {
+    use std::collections::{HashMap, HashSet};
+
+    let mut result: HashMap<String, f64> = HashMap::new();
+    if sessions_frame_ids.is_empty() {
+        return Ok(result);
+    }
+
+    let mut all_ids: Vec<&String> = Vec::new();
+    let mut frame_to_session: HashMap<&str, &str> = HashMap::new();
+    let mut seen: HashSet<&str> = HashSet::new();
+
+    for (session_id, frame_ids) in sessions_frame_ids {
+        result.insert(session_id.clone(), 0.0);
+        for fid in frame_ids {
+            if seen.insert(fid.as_str()) {
+                all_ids.push(fid);
+                frame_to_session.insert(fid.as_str(), session_id.as_str());
+            }
+        }
+    }
+
+    if all_ids.is_empty() {
+        return Ok(result);
+    }
+
+    // Same join as active_frame_exposure_seconds but batched.
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT fr.id, MAX(ifm.exposure_s) AS exposure_s \
+         FROM file_record fr \
+         LEFT JOIN inbox_items ii ON ii.root_id = fr.root_id \
+         LEFT JOIN inbox_file_metadata ifm \
+             ON ifm.inbox_item_id = ii.id AND ifm.relative_file_path = fr.relative_path \
+         WHERE fr.state != 'missing' AND fr.id IN (",
+    );
+    let mut sep = builder.separated(", ");
+    for id in &all_ids {
+        sep.push_bind(*id);
+    }
+    sep.push_unseparated(") GROUP BY fr.id");
+
+    let rows: Vec<(String, Option<f64>)> = builder.build_query_as().fetch_all(pool).await?;
+
+    for (frame_id, exposure) in rows {
+        if let Some(&sid) = frame_to_session.get(frame_id.as_str()) {
+            let entry = result.entry(sid.to_owned()).or_insert(0.0);
+            *entry += exposure.unwrap_or(0.0);
+        }
+    }
+
+    Ok(result)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -461,9 +461,8 @@ pub async fn list_sessions_joined_paginated(
             .to_owned(),
     };
     // AssertSqlSafe: limit/offset are u32 literals formatted directly — no user strings.
-    let rows = sqlx::query_as::<_, SessionJoinRow>(sqlx::AssertSqlSafe(sql))
-        .fetch_all(pool)
-        .await?;
+    let rows =
+        sqlx::query_as::<_, SessionJoinRow>(sqlx::AssertSqlSafe(sql)).fetch_all(pool).await?;
     Ok(rows)
 }
 
@@ -716,9 +715,7 @@ pub async fn all_acquisition_session_frame_ids(
     pool: &SqlitePool,
 ) -> DbResult<Vec<(String, String)>> {
     let rows: Vec<(String, String)> =
-        sqlx::query_as("SELECT id, frame_ids FROM acquisition_session")
-            .fetch_all(pool)
-            .await?;
+        sqlx::query_as("SELECT id, frame_ids FROM acquisition_session").fetch_all(pool).await?;
     Ok(rows)
 }
 

--- a/scripts/dead-callers-baseline.txt
+++ b/scripts/dead-callers-baseline.txt
@@ -212,3 +212,9 @@ list_source_availability_for_sessions
 transition_handoff_operation_state
 update_handoff_operation_progress
 upsert_source_availability
+# list_sessions / list_sessions_joined: thin wrapper entry points kept for
+# integration test ergonomics; production calls list_sessions_paginated
+# directly (perf/query-batching, kyo7.80).
+list_sessions
+list_sessions_joined
+

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -72,7 +72,7 @@ src/features/sessions/CalendarScroll.tsx	72	alm/require-root-testid
 src/features/sessions/SessionDetail.tsx	214	alm/require-root-testid
 src/features/sessions/SessionNotesSection.tsx	93	alm/require-root-testid
 src/features/sessions/SessionsPage.tsx	296	alm/require-root-testid
-src/features/settings/AuditLog.tsx	299	alm/require-root-testid
+src/features/settings/AuditLog.tsx	304	alm/require-root-testid
 src/features/settings/CalibrationMatching.tsx	189	alm/require-root-testid
 src/features/settings/Framing.tsx	130	alm/require-root-testid
 src/features/settings/PatternChipsEditor.tsx	39	alm/require-root-testid


### PR DESCRIPTION
## Summary

- **sessions.list**: replaced the 4-sequential-queries-per-row loop with set-based queries (fingerprint join, one GROUP BY frame summary+exposure pass, project-ids grouped) and added limit/offset; frame_ids parsed once per row.
- **inventory.frame.list**: inverted the per-frame LIKE full-table scan — sessions' frame_ids load once into a frame→session map.
- **audit.export**: now streams to a user-chosen file backend-side (mirrors log_export) and returns path+count — no more multi-MB string across IPC + Blob rematerialization; AuditLog.tsx updated.
- **Default limits**: audit_list and lifecycle.ledger.list clamp server-side (unwrap_or(100).clamp(1,500) pattern).
- **settings.get**: typed response, double-serialize round-trip removed.

## Spec Context

Tracks-Bead: astro-plan-kyo7.80
Tracks-Bead: astro-plan-kyo7.82
Merge-Bead: astro-plan-1jut

Wave-4 packet GF-1/2/9/10(partial)/25/26 + DS-1/15, GF-9 per user annotation (fully backend-handled). Verified: fmt, clippy -D warnings, desktop_shell tests 46, db-boundary, dead-callers, check-generated, pnpm lint. Known pre-existing typos-lint failure on local-branches.txt (also fails on main — not this branch).