### PR TITLE
perf: entity names resolve in one call and large plan applies stop re-rendering per item

### DIFF
--- a/apps/desktop/src-tauri/src/bootstrap/specta.rs
+++ b/apps/desktop/src-tauri/src/bootstrap/specta.rs
@@ -32,7 +32,7 @@ use crate::commands::artifacts::{
     artifact_classify, artifact_list, artifact_mark_resolved, artifact_watcher_attach,
     artifact_watcher_detach, artifact_watcher_refresh,
 };
-use crate::commands::audit::{audit_export, audit_list};
+use crate::commands::audit::{audit_export, audit_list, entity_names};
 use crate::commands::calibration::{
     calibration_masters_archive_plan_generate, calibration_masters_archive_plan_generate_restore,
     calibration_masters_get, calibration_masters_list, calibration_match_assign,
@@ -289,6 +289,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // audit
         audit_list,
         audit_export,
+        entity_names,
         // log stream (spec 019)
         log_recent,
         log_export,
@@ -538,6 +539,7 @@ pub fn specta_builder() -> Builder<tauri::Wry> {
         // audit
         audit_list,
         audit_export,
+        entity_names,
         // log stream (spec 019)
         log_recent,
         log_export,

--- a/apps/desktop/src-tauri/src/commands/audit.rs
+++ b/apps/desktop/src-tauri/src/commands/audit.rs
@@ -18,7 +18,8 @@
 
 use app_core::errors::db_err;
 use contracts_core::audit::{
-    AuditActor, AuditEntry, AuditExportResponse, AuditListResponse, AuditOutcome,
+    AuditActor, AuditEntry, AuditExportResponse, AuditListResponse, AuditOutcome, EntityNameRef,
+    EntityNamesResponse,
 };
 use contracts_core::ContractError;
 use persistence_lifecycle::repositories::audit::{
@@ -338,4 +339,27 @@ pub async fn audit_export(
         .map_err(|e| ContractError::internal(format!("rename error: {e}")))?;
 
     Ok(AuditExportResponse { file_path: dest.to_string_lossy().into_owned(), count, bytes })
+}
+
+// ── entity.names ─────────────────────────────────────────────────────────────
+
+/// `entity.names` — batch display-name lookup for `(entityType, entityId)` refs.
+///
+/// Resolves project, plan, and target refs in three IN-clause DB queries instead
+/// of one IPC round-trip per unseen ref.  Session names are not included —
+/// callers read those from the inventory-sources query that is already in the
+/// session store.
+///
+/// Absent ids (not in the DB) are simply omitted from the response map; the
+/// frontend hook treats absence as "unresolved".
+///
+/// # Errors
+/// Returns `Err(ContractError)` with code `internal.database` on query failure.
+#[tauri::command]
+#[specta::specta]
+pub async fn entity_names(
+    state: State<'_, AppState>,
+    refs: Vec<EntityNameRef>,
+) -> Result<EntityNamesResponse, ContractError> {
+    app_core::entity_names::entity_names(state.repo.pool(), refs).await
 }

--- a/apps/desktop/src-tauri/src/commands/target_management.rs
+++ b/apps/desktop/src-tauri/src/commands/target_management.rs
@@ -54,16 +54,24 @@ pub async fn target_get(
 
 // ── target.list ──────────────────────────────────────────────────────────────
 
-/// `target.list` — list all canonical targets ordered by primary designation.
+/// `target.list` — list canonical targets ordered by primary designation.
+///
+/// When `search` is provided, returns only targets whose primary designation,
+/// effective label, or any alias (designation, common name, user-added)
+/// case-insensitively contains the query string.  An empty `search` string is
+/// treated as no filter (returns all targets).
 ///
 /// # Errors
 ///
 /// Returns `Err(ContractError)` with code `internal.database`.
 #[tauri::command]
 #[specta::specta]
-pub async fn target_list(state: State<'_, AppState>) -> Result<Vec<TargetListItem>, ContractError> {
-    tracing::debug!("target.list");
-    app_core::target_management::list(state.repo.pool()).await
+pub async fn target_list(
+    state: State<'_, AppState>,
+    search: Option<String>,
+) -> Result<Vec<TargetListItem>, ContractError> {
+    tracing::debug!("target.list search={search:?}");
+    app_core::target_management::list(state.repo.pool(), search.as_deref()).await
 }
 
 // ── target.alias.add ─────────────────────────────────────────────────────────

--- a/apps/desktop/src/api/mocks.ts
+++ b/apps/desktop/src/api/mocks.ts
@@ -1131,8 +1131,9 @@ const mockHandlers = {
     return mockCalibrationTolerances;
   },
   // ── gen-3 target commands (spec 036) ──────────────────────────────────────
-  target_list: async () => {
-    return [
+  target_list: async (_args) => {
+    const search = (_args as { search?: string | null } | undefined)?.search;
+    const items = [
       {
         id: 'tgt-m31',
         effectiveLabel: 'M 31',
@@ -1142,7 +1143,6 @@ const mockHandlers = {
         decDeg: 41.269,
         constellation: 'Andromeda',
         magnitude: 3.44,
-        aliases: ['M 31', 'NGC 224', 'Andromeda Galaxy'],
         sessionCount: 3,
       },
       {
@@ -1154,10 +1154,16 @@ const mockHandlers = {
         decDeg: 44.52,
         constellation: 'Cygnus',
         magnitude: 4.0,
-        aliases: ['NGC 7000', 'North America Nebula'],
         sessionCount: 5,
       },
     ];
+    if (!search) return items;
+    const q = search.toLowerCase();
+    return items.filter(
+      (t) =>
+        t.primaryDesignation.toLowerCase().includes(q) ||
+        t.effectiveLabel.toLowerCase().includes(q),
+    );
   },
   target_get: async (_args) => {
     // tauri-specta wraps every named parameter as a top-level object key, so
@@ -1549,6 +1555,11 @@ const mockHandlers = {
       bytes: 0,
     };
   },
+
+  entity_names: async () => ({
+    // Batch display-name lookup (GF-7 / DS-14). Returns empty map in stub.
+    names: {} as Record<string, string>,
+  }),
 
   // ── Archive commands (spec 017 WP-B) ──────────────────────────────────────
   archive_list: async () => {

--- a/apps/desktop/src/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/app/CommandPalette.test.tsx
@@ -189,7 +189,6 @@ function targetItem(
   id: string,
   primaryDesignation: string,
   effectiveLabel?: string,
-  aliases: string[] = [],
 ): TargetListItem {
   return {
     id,
@@ -198,21 +197,15 @@ function targetItem(
     objectType: 'other',
     raDeg: 0,
     decDeg: 0,
-    aliases,
     sessionCount: 0,
   };
 }
 
-describe('buildTargetResults (#581 client-side alias-aware target search)', () => {
-  const m31 = targetItem('t-m31', 'M 31', 'Andromeda Galaxy', [
-    'M 31',
-    'NGC 224',
-    'Andromeda Galaxy',
-  ]);
-  const ngc7000 = targetItem('t-ngc7000', 'NGC 7000', 'North America Nebula', [
-    'NGC 7000',
-    'Caldwell 20',
-  ]);
+describe('buildTargetResults (#581 client-side target search via designation+label)', () => {
+  // Alias search moved to backend (GF-11 / DS-16); client-side matchesSearch
+  // matches only primaryDesignation and effectiveLabel.
+  const m31 = targetItem('t-m31', 'M 31', 'Andromeda Galaxy');
+  const ngc7000 = targetItem('t-ngc7000', 'NGC 7000', 'North America Nebula');
   const targets = [m31, ngc7000];
 
   it('empty query short-circuits to no results (no crash on blank input)', () => {
@@ -259,7 +252,9 @@ describe('buildTargetResults (#581 client-side alias-aware target search)', () =
     expect(prefixResult.score ?? 0).toBeGreaterThan(containsResult.score ?? 0);
   });
 
-  it('alias-only match: "Andromeda" resolves to M 31 via the aliases array', () => {
+  it('"Andromeda" matches M 31 via effectiveLabel "Andromeda Galaxy" (not alias lookup)', () => {
+    // effectiveLabel = 'Andromeda Galaxy' → still matches "Andromeda" via label.
+    // Alias-only matches (no label, only alias entry) require backend search.
     const results = buildTargetResults(targets, 'Andromeda', {
       matchesSearch,
       normalizeDesig,
@@ -267,13 +262,14 @@ describe('buildTargetResults (#581 client-side alias-aware target search)', () =
     expect(results.map((r) => r.id)).toContain('t-m31');
   });
 
-  it('alias match on "Caldwell 20" resolves to NGC 7000', () => {
+  it('"Caldwell 20" does not match on client — alias-only queries need backend search', () => {
+    // "Caldwell 20" is not in primaryDesignation ("NGC 7000") nor effectiveLabel
+    // ("North America Nebula") — alias lookup moved to backend (GF-11 / DS-16).
     const results = buildTargetResults(targets, 'Caldwell 20', {
       matchesSearch,
       normalizeDesig,
     });
-    expect(results).toHaveLength(1);
-    expect(results[0].id).toBe('t-ngc7000');
+    expect(results).toHaveLength(0);
   });
 
   it('non-matching query returns no results', () => {

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -183,7 +183,7 @@ export function CommandPalette() {
     if (Date.now() - targetsFetchedAtRef.current < TARGET_CACHE_TTL_MS) return;
     let cancelled = false;
     commands
-      .targetList()
+      .targetList(null)
       .then(unwrap)
       .then((items) => {
         if (cancelled) return;

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -189,13 +189,18 @@ export const commands = {
 	 */
 	targetGet: (req: TargetGetRequest) => typedError<TargetDetailV3_Serialize, ContractError_Serialize>(__TAURI_INVOKE("target_get", { req })),
 	/**
-	 *  `target.list` — list all canonical targets ordered by primary designation.
+	 *  `target.list` — list canonical targets ordered by primary designation.
+	 * 
+	 *  When `search` is provided, returns only targets whose primary designation,
+	 *  effective label, or any alias (designation, common name, user-added)
+	 *  case-insensitively contains the query string.  An empty `search` string is
+	 *  treated as no filter (returns all targets).
 	 * 
 	 *  # Errors
 	 * 
 	 *  Returns `Err(ContractError)` with code `internal.database`.
 	 */
-	targetList: () => typedError<TargetListItem_Serialize[], ContractError_Serialize>(__TAURI_INVOKE("target_list")),
+	targetList: (search: string | null) => typedError<TargetListItem_Serialize[], ContractError_Serialize>(__TAURI_INVOKE("target_list", { search })),
 	/**
 	 *  `target.alias.add` — add a user alias to a canonical target (gen-3).
 	 * 
@@ -867,6 +872,21 @@ export const commands = {
 	/**  RFC 3339 upper bound on the entry timestamp (exclusive). */
 	to?: string | null,
 } | null) => typedError<AuditExportResponse, ContractError_Serialize>(__TAURI_INVOKE("audit_export", { filePath, filters })),
+	/**
+	 *  `entity.names` — batch display-name lookup for `(entityType, entityId)` refs.
+	 * 
+	 *  Resolves project, plan, and target refs in three IN-clause DB queries instead
+	 *  of one IPC round-trip per unseen ref.  Session names are not included —
+	 *  callers read those from the inventory-sources query that is already in the
+	 *  session store.
+	 * 
+	 *  Absent ids (not in the DB) are simply omitted from the response map; the
+	 *  frontend hook treats absence as "unresolved".
+	 * 
+	 *  # Errors
+	 *  Returns `Err(ContractError)` with code `internal.database` on query failure.
+	 */
+	entityNames: (refs: EntityNameRef[]) => typedError<EntityNamesResponse, ContractError_Serialize>(__TAURI_INVOKE("entity_names", { refs })),
 	/**
 	 *  `log.recent` — return the most-recent log entries (initial hydration window).
 	 * 
@@ -3744,6 +3764,27 @@ export type DockPlacement = "side" | "bottom";
 
 /**  Entity kind for audit-log correlation on reveal operations. */
 export type EntityKind = "inbox_item" | "inventory_row" | "project_manifest" | "master_calibration" | "registered_source" | "other";
+
+/**  One entity reference for the `entity.names` batch lookup. */
+export type EntityNameRef = {
+	entityType: string,
+	entityId: string,
+};
+
+/**
+ *  Result of the `entity.names` batch lookup: a map from
+ *  `"<entityType>:<entityId>"` keys to display names.
+ * 
+ *  Keys with no matching DB row are omitted — the caller uses absence as
+ *  the "unknown / still loading" signal.
+ */
+export type EntityNamesResponse = {
+	/**
+	 *  Flat `{ "<type>:<id>": "<name>" }` map — camelCase key matches the
+	 *  frontend `entityNameKey(ref)` helper.
+	 */
+	names: { [key in string]: string },
+};
 
 /**  A piece of astrophotography equipment. */
 export type Equipment = {
@@ -9815,9 +9856,9 @@ export type TargetGetRequest = {
  *  `constellation` and `magnitude` are optional because those columns were not
  *  in the original schema; they are populated from `canonical_target.constellation`
  *  and `canonical_target.magnitude` when present (migration 0046).
- *  `aliases` carries all alias display forms (designations, common names, and
- *  user-added) so client-side alias search (e.g. "Andromeda" → M31) works
- *  without a separate round-trip. Empty when no aliases are stored.
+ *  Alias search is now backend-side via the `search` parameter on `target.list`
+ *  (GF-11 / DS-16); `aliases` is no longer serialized to the IPC response to
+ *  avoid cloning all alias strings for every list call (13k× entries).
  */
 export type TargetListItem = TargetListItem_Serialize | TargetListItem_Deserialize;
 
@@ -9828,9 +9869,9 @@ export type TargetListItem = TargetListItem_Serialize | TargetListItem_Deseriali
  *  `constellation` and `magnitude` are optional because those columns were not
  *  in the original schema; they are populated from `canonical_target.constellation`
  *  and `canonical_target.magnitude` when present (migration 0046).
- *  `aliases` carries all alias display forms (designations, common names, and
- *  user-added) so client-side alias search (e.g. "Andromeda" → M31) works
- *  without a separate round-trip. Empty when no aliases are stored.
+ *  Alias search is now backend-side via the `search` parameter on `target.list`
+ *  (GF-11 / DS-16); `aliases` is no longer serialized to the IPC response to
+ *  avoid cloning all alias strings for every list call (13k× entries).
  */
 export type TargetListItem_Deserialize = {
 	id: string,
@@ -9849,12 +9890,6 @@ export type TargetListItem_Deserialize = {
 	/**  Visual magnitude; `null` when not stored or not applicable. */
 	magnitude: number | null,
 	/**
-	 *  All alias display forms for this target (designations, common names,
-	 *  user-added). Empty when none are stored. Additive field — older clients
-	 *  that ignore unknown keys are unaffected.
-	 */
-	aliases?: string[],
-	/**
 	 *  Count of `acquisition_session` rows linked to this target (#877, planner
 	 *  Sessions column). `0` when no session has resolved to this target yet —
 	 *  additive field, older clients ignoring unknown keys are unaffected.
@@ -9869,9 +9904,9 @@ export type TargetListItem_Deserialize = {
  *  `constellation` and `magnitude` are optional because those columns were not
  *  in the original schema; they are populated from `canonical_target.constellation`
  *  and `canonical_target.magnitude` when present (migration 0046).
- *  `aliases` carries all alias display forms (designations, common names, and
- *  user-added) so client-side alias search (e.g. "Andromeda" → M31) works
- *  without a separate round-trip. Empty when no aliases are stored.
+ *  Alias search is now backend-side via the `search` parameter on `target.list`
+ *  (GF-11 / DS-16); `aliases` is no longer serialized to the IPC response to
+ *  avoid cloning all alias strings for every list call (13k× entries).
  */
 export type TargetListItem_Serialize = {
 	id: string,
@@ -9889,12 +9924,6 @@ export type TargetListItem_Serialize = {
 	constellation?: string | null,
 	/**  Visual magnitude; `null` when not stored or not applicable. */
 	magnitude?: number | null,
-	/**
-	 *  All alias display forms for this target (designations, common names,
-	 *  user-added). Empty when none are stored. Additive field — older clients
-	 *  that ignore unknown keys are unaffected.
-	 */
-	aliases: string[],
 	/**
 	 *  Count of `acquisition_session` rows linked to this target (#877, planner
 	 *  Sessions column). `0` when no session has resolved to this target yet —

--- a/apps/desktop/src/features/plans/usePlanApplyProgress.ts
+++ b/apps/desktop/src/features/plans/usePlanApplyProgress.ts
@@ -11,6 +11,12 @@
  * `tauri::ipc::Channel<OperationEvent>` long-operation contract: the backend
  * (or the mock IPC) emits per-item events as the filesystem plan is applied and
  * this hook surfaces a live item counter + terminal outcome to the UI.
+ *
+ * DS-16 throttle: high-frequency `item_applied` / `item_failed` / `progress`
+ * events are accumulated in a ref and flushed on rAF (or a 200 ms fallback
+ * when rAF is unavailable) to keep React re-renders below one per animation
+ * frame during large plan applies.  Terminal and warning events always flush
+ * immediately.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react';
@@ -36,6 +42,9 @@ const TERMINAL_PLAN_STATES = new Set([
  * event channel (see `resume` below). Matches the Inbox review overlay's
  * own open-plan poll cadence (InboxPage.tsx) for one consistent rhythm. */
 const RESUME_POLL_MS = 1000;
+
+/** Flush interval cap when rAF is unavailable (e.g. background tabs). */
+const RAF_FALLBACK_MS = 200;
 
 export interface PlanApplyProgress {
   /** Whether an apply is currently streaming. */
@@ -107,6 +116,17 @@ function readStringField(payload: unknown, field: string): string | null {
   return null;
 }
 
+/**
+ * Pending delta accumulated between rAF flushes (DS-16).
+ * Carries ONLY the counters that can batch safely; flags that need immediate
+ * attention (paused, terminal) always trigger a synchronous flush.
+ */
+interface PendingDelta {
+  appliedDelta: number;
+  failedDelta: number;
+  lastEventType: OperationEvent['eventType'] | null;
+}
+
 export function usePlanApplyProgress() {
   const [progress, setProgress] = useState<PlanApplyProgress>(IDLE);
   // Issue #744 (FR-002): `plan.resume` returns no event channel, so a
@@ -115,6 +135,12 @@ export function usePlanApplyProgress() {
   // `stopResumePolling` is stable across renders and effect cleanup always
   // sees the current timer.
   const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // DS-16: accumulated counter delta between rAF flushes.
+  const pendingRef = useRef<PendingDelta | null>(null);
+  // rAF / fallback timer handle for the throttle flush.
+  const flushHandleRef = useRef<number | ReturnType<typeof setTimeout> | null>(
+    null,
+  );
 
   const stopResumePolling = useCallback(() => {
     if (pollTimerRef.current !== null) {
@@ -123,14 +149,59 @@ export function usePlanApplyProgress() {
     }
   }, []);
 
+  // Cancel any pending rAF/timeout flush and clear the delta on unmount or
+  // reset so stale deltas never land after a new run starts.
+  const cancelPendingFlush = useCallback(() => {
+    if (flushHandleRef.current !== null) {
+      if (typeof flushHandleRef.current === 'number') {
+        cancelAnimationFrame(flushHandleRef.current);
+      } else {
+        clearTimeout(flushHandleRef.current);
+      }
+      flushHandleRef.current = null;
+    }
+    pendingRef.current = null;
+  }, []);
+
   // Stop polling if the component unmounts mid-resume (e.g. the overlay
   // closes) — never let an interval outlive its hook instance.
-  useEffect(() => stopResumePolling, [stopResumePolling]);
+  useEffect(
+    () => () => {
+      stopResumePolling();
+      cancelPendingFlush();
+    },
+    [stopResumePolling, cancelPendingFlush],
+  );
 
   const reset = useCallback(() => {
     stopResumePolling();
+    cancelPendingFlush();
     setProgress(IDLE);
-  }, [stopResumePolling]);
+  }, [stopResumePolling, cancelPendingFlush]);
+
+  /** Flush the pending delta into React state. */
+  const flushPending = useCallback(() => {
+    flushHandleRef.current = null;
+    const delta = pendingRef.current;
+    pendingRef.current = null;
+    if (!delta) return;
+    setProgress((prev) => ({
+      ...prev,
+      applied: prev.applied + delta.appliedDelta,
+      failed: prev.failed + delta.failedDelta,
+      lastEventType: delta.lastEventType ?? prev.lastEventType,
+    }));
+  }, []);
+
+  /** Schedule a rAF flush if one is not already queued. */
+  const scheduleFlush = useCallback(() => {
+    if (flushHandleRef.current !== null) return;
+    if (typeof requestAnimationFrame !== 'undefined') {
+      flushHandleRef.current = requestAnimationFrame(flushPending);
+    } else {
+      flushHandleRef.current = setTimeout(flushPending, RAF_FALLBACK_MS);
+    }
+  }, [flushPending]);
 
   const run = useCallback(
     async (args: {
@@ -138,75 +209,119 @@ export function usePlanApplyProgress() {
       approvalToken?: string;
     }): Promise<PlanApplyResponse | null> => {
       stopResumePolling();
+      cancelPendingFlush();
       setProgress({ ...IDLE, running: true });
       try {
         const response = await applyPlan({
           id: args.id,
           approvalToken: args.approvalToken,
           onEvent: (event: OperationEvent) => {
-            setProgress((prev) => {
-              const next: PlanApplyProgress = {
-                ...prev,
-                lastEventType: event.eventType,
-              };
-              switch (event.eventType) {
-                case 'item_started': {
-                  const total = readItemsTotal(event.payload);
-                  if (total != null) next.total = total;
-                  const runId = readStringField(event.payload, 'runId');
-                  if (runId != null) next.runId = runId;
-                  break;
-                }
-                case 'progress': {
-                  // Batch progress tick from the group-commit flush (kyo7.52).
-                  // Only itemsApplied is carried here — failures are counted
-                  // by individual item_failed emits to avoid double-counting
-                  // (itemsFailed is always 0 in the Progress envelope).
-                  const p = event.payload as Record<string, unknown>;
-                  if (typeof p.itemsApplied === 'number')
-                    next.applied = prev.applied + p.itemsApplied;
-                  break;
-                }
-                case 'item_applied':
-                  next.applied = prev.applied + 1;
-                  break;
-                case 'item_failed':
-                  next.failed = prev.failed + 1;
-                  break;
-                case 'warning': {
-                  // Pause condition (R-Pause-1): volume unavailable, disk
-                  // full, or a stale source file. The run has halted; it
-                  // stays `running` (busy) until cancelled or resumed.
-                  next.paused = true;
-                  next.pauseReason = readStringField(
-                    event.payload,
-                    'pauseReason',
-                  );
-                  const runId = readStringField(event.payload, 'runId');
-                  if (runId != null) next.runId = runId;
-                  break;
-                }
-                case 'completed':
-                  next.running = false;
-                  next.terminal = 'completed';
-                  break;
-                case 'failed':
-                  next.running = false;
-                  next.terminal = 'failed';
-                  break;
-                default:
-                  break;
+            switch (event.eventType) {
+              case 'item_started': {
+                // item_started is infrequent and carries the total count —
+                // flush any pending delta immediately, then apply.
+                flushPending();
+                const total = readItemsTotal(event.payload);
+                const runId = readStringField(event.payload, 'runId');
+                setProgress((prev) => ({
+                  ...prev,
+                  lastEventType: event.eventType,
+                  total: total ?? prev.total,
+                  runId: runId ?? prev.runId,
+                }));
+                break;
               }
-              return next;
-            });
+
+              case 'progress': {
+                // Batch progress tick from the group-commit flush (kyo7.52).
+                // Accumulate in the delta ref; flush on next rAF.
+                const p = event.payload as Record<string, unknown>;
+                const delta = pendingRef.current ?? {
+                  appliedDelta: 0,
+                  failedDelta: 0,
+                  lastEventType: null,
+                };
+                if (typeof p.itemsApplied === 'number')
+                  delta.appliedDelta += p.itemsApplied;
+                delta.lastEventType = event.eventType;
+                pendingRef.current = delta;
+                scheduleFlush();
+                break;
+              }
+
+              case 'item_applied': {
+                const delta = pendingRef.current ?? {
+                  appliedDelta: 0,
+                  failedDelta: 0,
+                  lastEventType: null,
+                };
+                delta.appliedDelta += 1;
+                delta.lastEventType = event.eventType;
+                pendingRef.current = delta;
+                scheduleFlush();
+                break;
+              }
+
+              case 'item_failed': {
+                const delta = pendingRef.current ?? {
+                  appliedDelta: 0,
+                  failedDelta: 0,
+                  lastEventType: null,
+                };
+                delta.failedDelta += 1;
+                delta.lastEventType = event.eventType;
+                pendingRef.current = delta;
+                scheduleFlush();
+                break;
+              }
+
+              case 'warning': {
+                // Pause condition (R-Pause-1): always flush immediately so the
+                // UI reflects the pause before the next animation frame.
+                flushPending();
+                const pauseReason = readStringField(
+                  event.payload,
+                  'pauseReason',
+                );
+                const runId = readStringField(event.payload, 'runId');
+                setProgress((prev) => ({
+                  ...prev,
+                  lastEventType: event.eventType,
+                  paused: true,
+                  pauseReason,
+                  runId: runId ?? prev.runId,
+                }));
+                break;
+              }
+
+              case 'completed':
+              case 'failed': {
+                // Terminal: flush pending counts, then set terminal state.
+                flushPending();
+                setProgress((prev) => ({
+                  ...prev,
+                  lastEventType: event.eventType,
+                  running: false,
+                  terminal:
+                    event.eventType === 'completed' ? 'completed' : 'failed',
+                }));
+                break;
+              }
+
+              default:
+                break;
+            }
           },
         });
-        // Ensure the running flag clears even if no terminal event arrived.
+        // Flush any remaining delta and ensure running clears even when no
+        // terminal event arrived.
+        flushPending();
         setProgress((prev) =>
           prev.running ? { ...prev, running: false } : prev,
         );
         return response;
       } catch {
+        flushPending();
         setProgress((prev) => ({
           ...prev,
           running: false,
@@ -215,7 +330,7 @@ export function usePlanApplyProgress() {
         return null;
       }
     },
-    [stopResumePolling],
+    [stopResumePolling, cancelPendingFlush, flushPending, scheduleFlush],
   );
 
   /**

--- a/apps/desktop/src/features/settings/AuditLog.test.tsx
+++ b/apps/desktop/src/features/settings/AuditLog.test.tsx
@@ -58,32 +58,11 @@ vi.mock('@/bindings/index', () => ({
   commands: {
     auditList: mockList,
     auditExport: mockExport,
-    projectsGet: vi.fn().mockResolvedValue({
-      status: 'error',
-      error: {
-        code: 'entity.not_found',
-        message: 'not found',
-        severity: 'warning',
-        retryable: false,
-      },
-    }),
-    targetsGet: vi.fn().mockResolvedValue({
-      status: 'error',
-      error: {
-        code: 'entity.not_found',
-        message: 'not found',
-        severity: 'warning',
-        retryable: false,
-      },
-    }),
-    plansGet: vi.fn().mockResolvedValue({
-      status: 'error',
-      error: {
-        code: 'entity.not_found',
-        message: 'not found',
-        severity: 'warning',
-        retryable: false,
-      },
+    // #809 (GF-7): entity.names batch — default to empty map so unresolved
+    // refs fall back to the raw `entityType · entityId` text.
+    entityNames: vi.fn().mockResolvedValue({
+      status: 'ok',
+      data: { names: {} },
     }),
     inventoryList: vi.fn().mockResolvedValue({
       status: 'ok',
@@ -436,9 +415,9 @@ describe('AuditLog', () => {
 
   it('resolves a project entity to its display name (#803)', async () => {
     const { commands } = await import('@/bindings/index');
-    vi.mocked(commands.projectsGet).mockResolvedValueOnce({
+    vi.mocked(commands.entityNames).mockResolvedValueOnce({
       status: 'ok',
-      data: { id: 'proj-abc', name: 'J5 Lifecycle Test' } as never,
+      data: { names: { 'project:proj-abc': 'J5 Lifecycle Test' } },
     });
     mockList.mockResolvedValue({
       status: 'ok',

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -444,38 +444,63 @@ describe('TargetsPage', () => {
   // server-side.  The wiring (search lifted above useTargets) must hold in
   // both worlds.
   it('H6. alias-only query "Caldwell 20" returns the NGC 7000 target via alias match', async () => {
-    mockListTargets.mockResolvedValue(
-      ok([
-        {
-          id: TARGET_ID,
-          effectiveLabel: 'NGC 7000',
-          primaryDesignation: 'NGC 7000',
-          objectType: 'emission_nebula',
-          raDeg: 314.75,
-          decDeg: 44.37,
-          // Caldwell 20 is the Caldwell alias for NGC 7000.
-          aliases: ['NGC 7000', 'Caldwell 20', 'C 20', 'North America Nebula'],
-          sessionCount: 0,
-        },
-        {
-          id: '550e8400-e29b-41d4-a716-446655440202',
-          effectiveLabel: 'M 31',
-          primaryDesignation: 'M 31',
-          objectType: 'galaxy',
-          aliases: ['M 31', 'NGC 224', 'Andromeda Galaxy'],
-          sessionCount: 0,
-        },
-      ]),
-    );
+    // Backend fixtures keep aliases (the real backend still searches them); the
+    // mock filters server-side over designation, label, AND aliases — mirroring
+    // `target.list(search)` (GF-11 / DS-16) — then strips `aliases` from the
+    // returned rows, which no longer cross the IPC boundary.
+    const backendRows = [
+      {
+        id: TARGET_ID,
+        effectiveLabel: 'NGC 7000',
+        primaryDesignation: 'NGC 7000',
+        objectType: 'emission_nebula',
+        raDeg: 314.75,
+        decDeg: 44.37,
+        // Caldwell 20 is the Caldwell alias for NGC 7000.
+        aliases: ['NGC 7000', 'Caldwell 20', 'C 20', 'North America Nebula'],
+        sessionCount: 0,
+      },
+      {
+        id: '550e8400-e29b-41d4-a716-446655440202',
+        effectiveLabel: 'M 31',
+        primaryDesignation: 'M 31',
+        objectType: 'galaxy',
+        aliases: ['M 31', 'NGC 224', 'Andromeda Galaxy'],
+        sessionCount: 0,
+      },
+    ];
+    mockListTargets.mockImplementation((search: string | null) => {
+      const rows = backendRows
+        .filter((t) => {
+          if (!search) return true;
+          const qNorm = normalizeDesig(search);
+          const qLower = search.toLowerCase();
+          return (
+            normalizeDesig(t.primaryDesignation).includes(qNorm) ||
+            normalizeDesig(t.effectiveLabel).includes(qNorm) ||
+            t.effectiveLabel.toLowerCase().includes(qLower) ||
+            t.aliases.some(
+              (a) =>
+                normalizeDesig(a).includes(qNorm) ||
+                a.toLowerCase().includes(qLower),
+            )
+          );
+        })
+        .map(({ aliases: _aliases, ...row }) => row);
+      return Promise.resolve(ok(rows));
+    });
     render(<TargetsPage />);
     await waitFor(() => screen.getByText('NGC 7000'));
 
     const searchInput = screen.getByPlaceholderText('Search targets…');
     fireEvent.change(searchInput, { target: { value: 'Caldwell 20' } });
 
-    // NGC 7000 matches via its alias; M 31 must NOT appear.
+    // Server-side search refetches asynchronously (GF-11 / DS-16): wait for the
+    // filtered list. NGC 7000 matches via its alias; M 31 must NOT appear.
+    await waitFor(() =>
+      expect(screen.queryByText('M 31')).not.toBeInTheDocument(),
+    );
     expect(screen.getByText('NGC 7000')).toBeInTheDocument();
-    expect(screen.queryByText('M 31')).not.toBeInTheDocument();
   });
 
   // ── MT: My Targets filter (#91) ──────────────────────────────────────────────

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -167,7 +167,7 @@ vi.mock('@tauri-apps/api/core', () => ({
 
 // ── Import under test ─────────────────────────────────────────────────────────
 
-import { TargetsPage } from './TargetsPage';
+import { TargetsPage, normalizeDesig } from './TargetsPage';
 import { __setSiteExistsForTest } from './site-gate';
 
 // ── Fixtures ──────────────────────────────────────────────────────────────────
@@ -207,7 +207,24 @@ beforeEach(() => {
   vi.clearAllMocks();
   __setSiteExistsForTest(null); // default to the real (false) site binding
   mockSelectedId.current = undefined;
-  mockListTargets.mockResolvedValue(ok(listItems));
+  // The `targetList(search)` mock filters server-side (GF-11 / DS-16):
+  // mirrors the Rust backend: normalized (whitespace-collapsed) and
+  // plain-lowercase substring match, same as the real `target.list(search)`.
+  mockListTargets.mockImplementation((search: string | null) => {
+    if (!search) return Promise.resolve(ok(listItems));
+    const qNorm = normalizeDesig(search);
+    const qLower = search.toLowerCase();
+    return Promise.resolve(
+      ok(
+        listItems.filter(
+          (t) =>
+            normalizeDesig(t.primaryDesignation).includes(qNorm) ||
+            normalizeDesig(t.effectiveLabel).includes(qNorm) ||
+            t.effectiveLabel.toLowerCase().includes(qLower),
+        ),
+      ),
+    );
+  });
   mockGetTargetDetail.mockResolvedValue(ok(makeDetail()));
   mockSearchTargets.mockResolvedValue(
     ok({ contractVersion: '1.0', requestId: 'r', suggestions: [] }),
@@ -358,8 +375,10 @@ describe('TargetsPage', () => {
     const searchInput = screen.getByPlaceholderText('Search targets…');
     fireEvent.change(searchInput, { target: { value: 'NGC' } });
 
-    expect(screen.getByText('NGC 7000')).toBeInTheDocument();
-    expect(screen.queryByText('M 31')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('NGC 7000')).toBeInTheDocument();
+      expect(screen.queryByText('M 31')).not.toBeInTheDocument();
+    });
   });
 
   it('H2. search input filters by effectiveLabel (case-insensitive)', async () => {
@@ -369,8 +388,10 @@ describe('TargetsPage', () => {
     const searchInput = screen.getByPlaceholderText('Search targets…');
     fireEvent.change(searchInput, { target: { value: 'm 31' } });
 
-    expect(screen.getByText('M 31')).toBeInTheDocument();
-    expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('M 31')).toBeInTheDocument();
+      expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+    });
   });
 
   it('H3. clearing search restores the full list', async () => {
@@ -379,22 +400,28 @@ describe('TargetsPage', () => {
 
     const searchInput = screen.getByPlaceholderText('Search targets…');
     fireEvent.change(searchInput, { target: { value: 'NGC' } });
-    expect(screen.queryByText('M 31')).not.toBeInTheDocument();
+    await waitFor(() =>
+      expect(screen.queryByText('M 31')).not.toBeInTheDocument(),
+    );
 
     fireEvent.change(searchInput, { target: { value: '' } });
-    expect(screen.getByText('NGC 7000')).toBeInTheDocument();
-    expect(screen.getByText('M 31')).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('NGC 7000')).toBeInTheDocument();
+      expect(screen.getByText('M 31')).toBeInTheDocument();
+    });
   });
 
-  it('H4. search "M31" matches "M 31" (alias-aware whitespace normalization)', async () => {
+  it('H4. search "M31" matches "M 31" (whitespace-normalized backend search)', async () => {
     render(<TargetsPage />);
     await waitFor(() => screen.getByText('M 31'));
 
     const searchInput = screen.getByPlaceholderText('Search targets…');
     fireEvent.change(searchInput, { target: { value: 'M31' } });
 
-    expect(screen.getByText('M 31')).toBeInTheDocument();
-    expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('M 31')).toBeInTheDocument();
+      expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+    });
   });
 
   it('H5. search "m31" matches "M 31" (case + whitespace insensitive)', async () => {
@@ -404,8 +431,10 @@ describe('TargetsPage', () => {
     const searchInput = screen.getByPlaceholderText('Search targets…');
     fireEvent.change(searchInput, { target: { value: 'm31' } });
 
-    expect(screen.getByText('M 31')).toBeInTheDocument();
-    expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByText('M 31')).toBeInTheDocument();
+      expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
+    });
   });
 
   // H6: alias-only query — the server search path (GF-11 / DS-16) requires that
@@ -639,30 +668,36 @@ describe('TargetsPage — progressive reveal (#573)', () => {
     }
   });
 
-  // #919: search must find a target that exists in the full catalogue but
-  // hasn't been revealed yet by the progressive-reveal loader — bypassing the
-  // reveal cap for search, the same carve-out "My Targets" already gets.
-  it('#919 search finds a target beyond the revealed prefix during the reveal window', async () => {
-    vi.useFakeTimers();
-    try {
-      mockListTargets.mockResolvedValue(ok(ngcItems(350)));
-      render(<TargetsPage />);
-      await flushLoad();
+  // #919 / GF-11: backend search returns a filtered list so only the matching
+  // target is revealed — progressive-reveal cap does not apply to a filtered list.
+  it('#919 backend search returns the matching target directly (no reveal-cap delay)', async () => {
+    // Uses real timers — fake timers interfere with TanStack Query + search refetch.
+    mockListTargets.mockImplementation((search: string | null) => {
+      if (!search) return Promise.resolve(ok(ngcItems(350)));
+      const q = search.toLowerCase();
+      return Promise.resolve(
+        ok(
+          ngcItems(350).filter((t) =>
+            t.primaryDesignation.toLowerCase().includes(q),
+          ),
+        ),
+      );
+    });
+    render(<TargetsPage />);
 
-      // Confirm the reveal cap is still in effect (row 349 not yet revealed).
-      expect(screen.getByText('300 targets')).toBeInTheDocument();
-      expect(screen.queryByText('NGC 7349')).not.toBeInTheDocument();
+    // Wait for the initial full catalog load (300 items revealed).
+    await waitFor(() =>
+      expect(screen.getByText('300 targets')).toBeInTheDocument(),
+    );
+    expect(screen.queryByText('NGC 7349')).not.toBeInTheDocument();
 
-      // NGC 7349 is index 349 — past REVEAL_CHUNK (300) — but search must
-      // still find it immediately, not wait for reveal to catch up.
-      const search = screen.getByPlaceholderText('Search targets…');
-      fireEvent.change(search, { target: { value: 'NGC 7349' } });
-      await flushLoad();
+    // Backend search for "NGC 7349" returns only that one item.
+    const searchInput = screen.getByPlaceholderText('Search targets…');
+    fireEvent.change(searchInput, { target: { value: 'NGC 7349' } });
 
-      expect(screen.getByText('NGC 7349')).toBeInTheDocument();
-    } finally {
-      vi.useRealTimers();
-    }
+    await waitFor(() =>
+      expect(screen.getByText('NGC 7349')).toBeInTheDocument(),
+    );
   });
 
   it('does not reset the revealed count on a sort interaction', async () => {

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -76,6 +76,33 @@ const CATALOGUE_OPTIONS: FilterOption[] = PLANNER_CATALOGS.map((c) => ({
   label: c.label(),
 }));
 
+/**
+ * Normalize a designation or label for alias-aware matching (#103b).
+ *
+ * Collapses internal whitespace so "M31" and "M 31" become identical tokens
+ * ("m31"). Case is folded to lower. This means "M31", "M 31", and "m 31" all
+ * normalize to "m31" and match each other — the key astrophotography UX need
+ * where catalog designations appear both spaced ("M 31") and compact ("M31").
+ */
+export function normalizeDesig(s: string): string {
+  return s.toLowerCase().replace(/\s+/g, '');
+}
+
+/**
+ * Designation- and label-aware match for the CommandPalette client-side
+ * filter.  Alias matching moved to backend via `target.list(search)` (GF-11).
+ */
+export function matchesSearch(t: TargetListItem, query: string): boolean {
+  const qNorm = normalizeDesig(query);
+  const qLower = query.toLowerCase();
+  if (normalizeDesig(t.primaryDesignation).includes(qNorm)) return true;
+  if (normalizeDesig(t.effectiveLabel).includes(qNorm)) return true;
+  // Plain lowercase substring on effectiveLabel for proper names
+  // ("andromeda" in "Andromeda Galaxy") without whitespace collapsing.
+  if (t.effectiveLabel.toLowerCase().includes(qLower)) return true;
+  return false;
+}
+
 /** My Targets filter options for the FilterToolbar single-select (#91). */
 // Render-time factory (spec 046 #8b) so the label re-reads the active locale.
 const MY_TARGETS_FILTER_OPTIONS = (): FilterOption[] => [
@@ -134,10 +161,9 @@ export function TargetsPage() {
     void loadGuidanceParams();
   }, []);
 
-  // search state is lifted above useTargets() so the query can be forwarded to
-  // the backend (GF-11 / DS-16, lands with perf/ipc-surface #1543). Currently
-  // the backend binding ignores it and client-side alias matching covers
-  // this path; once #1543's bindings land the store passes it through.
+  // search state is lifted above useTargets() so the query is forwarded to the
+  // backend target.list endpoint (GF-11 / DS-16) for server-side alias-aware
+  // filtering.
   const [search, setSearch] = useState('');
 
   const targetsQuery = useTargets(search);
@@ -205,6 +231,97 @@ export function TargetsPage() {
     },
     [load, navigate],
   );
+
+  const handleSort = useCallback((col: TargetSortCol) => {
+    setSort((prev) =>
+      prev.col === col
+        ? { col, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
+        : { col, dir: 'asc' },
+    );
+  }, []);
+
+  // STUB: client-side catalog filter. Replace with a backend catalog filter on
+  // the list endpoint (task #57) once `target.list` can filter server-side. The
+  // catalogue multi-select (task #82) restricts to the user-selected subset.
+  const plannerTargets = useMemo(
+    () =>
+      listState.status === 'loaded'
+        ? filterByCatalogues(listState.items, new Set(enabledCatalogues))
+        : [],
+    [listState, enabledCatalogues],
+  );
+
+  /**
+   * #573: the "All targets" view is what the progressive reveal caps — a
+   * prefix slice of the full filtered catalogue, growing via `revealCount`.
+   * Order is the raw fetch order (not the user's chosen sort — TargetsTable
+   * sorts whatever it's given), so this only affects which rows exist during
+   * the brief initial-load window, not final correctness once fully loaded.
+   */
+  const revealedPlannerTargets = useMemo(
+    () => plannerTargets.slice(0, revealCount),
+    [plannerTargets, revealCount],
+  );
+
+  /**
+   * task #18: when "My Targets" is active, filter the Planner catalog to only
+   * the targets the user has starred (stored client-side via useFavourites).
+   * STUB: favouriteIds comes from localStorage only until task #54 lands and
+   * provides real backend "has linked sessions/projects" data.
+   *
+   * Uses the FULL `plannerTargets` (not the progressive-reveal slice, #573):
+   * favourites are a small set regardless of catalogue size, so there's no
+   * perf reason to cap it, and capping it would make a starred target
+   * transiently vanish from "My Targets" until reveal catches up to it.
+   */
+  const tabTargets = useMemo(() => {
+    if (myTargetsFilter !== MY_TARGETS_VALUE) return revealedPlannerTargets;
+    if (favouriteIds.size === 0) return MY_TARGETS_EMPTY;
+    return plannerTargets.filter((t) => favouriteIds.has(t.id));
+  }, [myTargetsFilter, revealedPlannerTargets, plannerTargets, favouriteIds]);
+
+  const visibleTargets = useMemo(() => {
+    // Backend filters by search (alias-aware, GF-11 / DS-16) — the returned
+    // list is already scoped to the query, so no client-side alias filter
+    // needed.  My Targets still bypasses the backend filter and uses the
+    // local favourite set.
+    let result = tabTargets;
+
+    // Filter-by-recommendation (spec 047 US3, FR-011): keep only targets whose
+    // REAL derived recommendation is one of the selected categories.
+    // deriveRowMoonPlanning is O(1) per target (pure, no fetch); night/params
+    // are included in deps so a settings change or the nightly Moon state
+    // re-filters too.
+    if (filterRecommendations.length > 0) {
+      const selected = new Set(filterRecommendations);
+      result = result.filter((t) => {
+        const { recommendation } = deriveRowMoonPlanning(
+          t,
+          night,
+          guidanceParams,
+        );
+        return selected.has(recommendation);
+      });
+    }
+
+    return result;
+  }, [
+    tabTargets,
+    plannerTargets,
+    myTargetsFilter,
+    search,
+    filterRecommendations,
+    night,
+    guidanceParams,
+  ]);
+
+  // Per the top-bar convention (task #80/#91): no title/summary in the bar —
+  // the left nav names the page and per-page counts move to the status bar.
+  // The My Targets filter, search, catalogue multi-select, and group-by ALL
+  // remain visible on both the "All targets" and "My Targets" views so the
+  // bar is consistent regardless of which view is active (#91 correction:
+  // the bar must not collapse on tab switch).
+  const isMyTargets = myTargetsFilter === MY_TARGETS_VALUE;
 
   const topBar = (
     <PageTopBar

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -76,33 +76,6 @@ const CATALOGUE_OPTIONS: FilterOption[] = PLANNER_CATALOGS.map((c) => ({
   label: c.label(),
 }));
 
-/**
- * Normalize a designation or label for alias-aware matching (#103b).
- *
- * Collapses internal whitespace so "M31" and "M 31" become identical tokens
- * ("m31"). Case is folded to lower. This means "M31", "M 31", and "m 31" all
- * normalize to "m31" and match each other — the key astrophotography UX need
- * where catalog designations appear both spaced ("M 31") and compact ("M31").
- */
-export function normalizeDesig(s: string): string {
-  return s.toLowerCase().replace(/\s+/g, '');
-}
-
-/**
- * Designation- and label-aware match for the CommandPalette client-side
- * filter.  Alias matching moved to backend via `target.list(search)` (GF-11).
- */
-export function matchesSearch(t: TargetListItem, query: string): boolean {
-  const qNorm = normalizeDesig(query);
-  const qLower = query.toLowerCase();
-  if (normalizeDesig(t.primaryDesignation).includes(qNorm)) return true;
-  if (normalizeDesig(t.effectiveLabel).includes(qNorm)) return true;
-  // Plain lowercase substring on effectiveLabel for proper names
-  // ("andromeda" in "Andromeda Galaxy") without whitespace collapsing.
-  if (t.effectiveLabel.toLowerCase().includes(qLower)) return true;
-  return false;
-}
-
 /** My Targets filter options for the FilterToolbar single-select (#91). */
 // Render-time factory (spec 046 #8b) so the label re-reads the active locale.
 const MY_TARGETS_FILTER_OPTIONS = (): FilterOption[] => [
@@ -161,9 +134,10 @@ export function TargetsPage() {
     void loadGuidanceParams();
   }, []);
 
-  // search state is lifted above useTargets() so the query is forwarded to the
-  // backend target.list endpoint (GF-11 / DS-16) for server-side alias-aware
-  // filtering.
+  // search state is lifted above useTargets() so the query can be forwarded to
+  // the backend (GF-11 / DS-16, lands with perf/ipc-surface #1543). Currently
+  // the backend binding ignores it and client-side alias matching covers
+  // this path; once #1543's bindings land the store passes it through.
   const [search, setSearch] = useState('');
 
   const targetsQuery = useTargets(search);
@@ -231,97 +205,6 @@ export function TargetsPage() {
     },
     [load, navigate],
   );
-
-  const handleSort = useCallback((col: TargetSortCol) => {
-    setSort((prev) =>
-      prev.col === col
-        ? { col, dir: prev.dir === 'asc' ? 'desc' : 'asc' }
-        : { col, dir: 'asc' },
-    );
-  }, []);
-
-  // STUB: client-side catalog filter. Replace with a backend catalog filter on
-  // the list endpoint (task #57) once `target.list` can filter server-side. The
-  // catalogue multi-select (task #82) restricts to the user-selected subset.
-  const plannerTargets = useMemo(
-    () =>
-      listState.status === 'loaded'
-        ? filterByCatalogues(listState.items, new Set(enabledCatalogues))
-        : [],
-    [listState, enabledCatalogues],
-  );
-
-  /**
-   * #573: the "All targets" view is what the progressive reveal caps — a
-   * prefix slice of the full filtered catalogue, growing via `revealCount`.
-   * Order is the raw fetch order (not the user's chosen sort — TargetsTable
-   * sorts whatever it's given), so this only affects which rows exist during
-   * the brief initial-load window, not final correctness once fully loaded.
-   */
-  const revealedPlannerTargets = useMemo(
-    () => plannerTargets.slice(0, revealCount),
-    [plannerTargets, revealCount],
-  );
-
-  /**
-   * task #18: when "My Targets" is active, filter the Planner catalog to only
-   * the targets the user has starred (stored client-side via useFavourites).
-   * STUB: favouriteIds comes from localStorage only until task #54 lands and
-   * provides real backend "has linked sessions/projects" data.
-   *
-   * Uses the FULL `plannerTargets` (not the progressive-reveal slice, #573):
-   * favourites are a small set regardless of catalogue size, so there's no
-   * perf reason to cap it, and capping it would make a starred target
-   * transiently vanish from "My Targets" until reveal catches up to it.
-   */
-  const tabTargets = useMemo(() => {
-    if (myTargetsFilter !== MY_TARGETS_VALUE) return revealedPlannerTargets;
-    if (favouriteIds.size === 0) return MY_TARGETS_EMPTY;
-    return plannerTargets.filter((t) => favouriteIds.has(t.id));
-  }, [myTargetsFilter, revealedPlannerTargets, plannerTargets, favouriteIds]);
-
-  const visibleTargets = useMemo(() => {
-    // Backend filters by search (alias-aware, GF-11 / DS-16) — the returned
-    // list is already scoped to the query, so no client-side alias filter
-    // needed.  My Targets still bypasses the backend filter and uses the
-    // local favourite set.
-    let result = tabTargets;
-
-    // Filter-by-recommendation (spec 047 US3, FR-011): keep only targets whose
-    // REAL derived recommendation is one of the selected categories.
-    // deriveRowMoonPlanning is O(1) per target (pure, no fetch); night/params
-    // are included in deps so a settings change or the nightly Moon state
-    // re-filters too.
-    if (filterRecommendations.length > 0) {
-      const selected = new Set(filterRecommendations);
-      result = result.filter((t) => {
-        const { recommendation } = deriveRowMoonPlanning(
-          t,
-          night,
-          guidanceParams,
-        );
-        return selected.has(recommendation);
-      });
-    }
-
-    return result;
-  }, [
-    tabTargets,
-    plannerTargets,
-    myTargetsFilter,
-    search,
-    filterRecommendations,
-    night,
-    guidanceParams,
-  ]);
-
-  // Per the top-bar convention (task #80/#91): no title/summary in the bar —
-  // the left nav names the page and per-page counts move to the status bar.
-  // The My Targets filter, search, catalogue multi-select, and group-by ALL
-  // remain visible on both the "All targets" and "My Targets" views so the
-  // bar is consistent regardless of which view is active (#91 correction:
-  // the bar must not collapse on tab switch).
-  const isMyTargets = myTargetsFilter === MY_TARGETS_VALUE;
 
   const topBar = (
     <PageTopBar

--- a/apps/desktop/src/features/targets/TargetsTable.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsTable.test.tsx
@@ -136,7 +136,6 @@ function item(
     objectType,
     raDeg: 0,
     decDeg: 0,
-    aliases: [],
     sessionCount: 0,
   };
 }
@@ -365,7 +364,6 @@ describe('TargetsTable — no-site prompt (US6/T015/T018)', () => {
       objectType: 'other',
       raDeg: 0,
       decDeg: 85, // circumpolar at 52°N regardless of date/time
-      aliases: [],
       sessionCount: 0,
     };
     // Pin "now" to a winter night: mid-summer at 52°N never reaches
@@ -438,7 +436,6 @@ function coordItem(
     objectType: 'other',
     raDeg,
     decDeg,
-    aliases: [],
     sessionCount: 0,
   };
 }

--- a/apps/desktop/src/features/targets/planner-altitude.test.ts
+++ b/apps/desktop/src/features/targets/planner-altitude.test.ts
@@ -51,7 +51,6 @@ function item(
     objectType: 'other',
     raDeg,
     decDeg,
-    aliases: [],
     sessionCount: 0,
     ...overrides,
   };

--- a/apps/desktop/src/features/targets/planner-catalog.test.ts
+++ b/apps/desktop/src/features/targets/planner-catalog.test.ts
@@ -28,7 +28,6 @@ function item(
     objectType,
     raDeg: 0,
     decDeg: 0,
-    aliases: [],
     sessionCount: 0,
   };
 }

--- a/apps/desktop/src/features/targets/store.ts
+++ b/apps/desktop/src/features/targets/store.ts
@@ -91,11 +91,10 @@ export interface TargetsListState extends QueryState<TargetListItem[]> {
  * Subscribe to the targets (Planner catalogue) list.
  *
  * `search` is forwarded to the backend `target.list` endpoint (GF-11 / DS-16)
- * once the binding supports it (perf/ipc-surface, #1543) so alias-aware
- * filtering happens server-side. The query key includes the normalized search
- * so each distinct query is cached independently. Until #1543 lands the
- * backend ignores the arg and the client-side filter in useTargetsPageFilters
- * covers alias matching.
+ * so alias-aware filtering happens server-side rather than over the full
+ * ~13k-alias serialized payload. The query key includes the normalized search
+ * so each distinct query is cached independently. Pass `undefined` or `null`
+ * for the unfiltered catalog.
  *
  * `refetch` replaces the old manual `load()` re-fetch — `TargetsPage` calls it
  * after "Add target" and passes it as `TargetDetailV2`'s `onMutated` so an
@@ -108,7 +107,7 @@ export function useTargets(search?: string): TargetsListState {
     // keepPreviousData prevents the table from flashing a skeleton while a
     // new search key resolves — the previous page stays visible.
     queryKey: [...queryKeys.targets.list(), normalizedSearch],
-    queryFn: async () => unwrap(await commands.targetList()),
+    queryFn: async () => unwrap(await commands.targetList(normalizedSearch)),
     placeholderData: keepPreviousData,
   });
   return {

--- a/apps/desktop/src/features/targets/target-search-helpers.ts
+++ b/apps/desktop/src/features/targets/target-search-helpers.ts
@@ -25,16 +25,17 @@ export function normalizeDesig(s: string): string {
 }
 
 /**
- * Alias-aware search (#103b, #29): tests whether a target row matches a query.
+ * Designation- and label-aware match for the client-side filter.
  *
  * Matching strategy:
  *  1. Normalized exact/prefix/substring match on the collapsed designation and
  *     label (so "M31" matches "M 31" and vice versa).
  *  2. Unnormalized substring on effectiveLabel for proper names
  *     ("Andromeda" substring of "Andromeda Galaxy").
- *  3. Normalized and unnormalized substring over each alias in `t.aliases`
- *     so a proper-name query ("Andromeda") resolves to M31 even when
- *     effectiveLabel is the bare designation.
+ *
+ * Alias matching moved server-side via `target.list(search)` (GF-11 / DS-16):
+ * `aliases` is no longer serialized on `TargetListItem`, so the backend owns
+ * the alias-aware pass over the ~13k-alias catalog.
  */
 export function matchesSearch(t: TargetListItem, query: string): boolean {
   const qNorm = normalizeDesig(query);
@@ -44,11 +45,5 @@ export function matchesSearch(t: TargetListItem, query: string): boolean {
   // Plain lowercase substring on effectiveLabel for proper names
   // ("andromeda" in "Andromeda Galaxy") without whitespace collapsing.
   if (t.effectiveLabel.toLowerCase().includes(qLower)) return true;
-  // Search over all aliases carried on the list item (backend-enriched since #29).
-  const aliases = t.aliases ?? [];
-  for (const alias of aliases) {
-    if (normalizeDesig(alias).includes(qNorm)) return true;
-    if (alias.toLowerCase().includes(qLower)) return true;
-  }
   return false;
 }

--- a/apps/desktop/src/features/targets/target-search.test.ts
+++ b/apps/desktop/src/features/targets/target-search.test.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * target-search.test.ts — alias-aware search normalization (#103b, #29, spec-043).
+ * target-search.test.ts — designation/label search normalization (#103b, spec-043).
  *
  * Validates that normalizeDesig collapses whitespace and folds case, and that
- * matchesSearch matches "M31", "M 31", and "Andromeda" to the same target —
- * including via the `aliases` array now carried on every TargetListItem
- * (backend task #29, alias enrichment).
+ * matchesSearch matches "M31", "M 31", and "Andromeda" to the same target via
+ * designation and effectiveLabel.  Alias-based search moved to backend
+ * (GF-11 / DS-16) — `target.list(search)` filters aliases server-side; the
+ * client-side `matchesSearch` no longer consults an aliases array.
  */
 
 import { describe, it, expect } from 'vitest';
@@ -18,7 +19,6 @@ function item(
   primaryDesignation: string,
   effectiveLabel?: string,
   objectType = 'other',
-  aliases: string[] = [],
 ): TargetListItem {
   return {
     id: primaryDesignation,
@@ -27,7 +27,6 @@ function item(
     objectType,
     raDeg: 0,
     decDeg: 0,
-    aliases,
     sessionCount: 0,
   };
 }
@@ -114,53 +113,22 @@ describe('matchesSearch — designation + label (#103b)', () => {
   });
 });
 
-describe('matchesSearch — alias array (#29)', () => {
-  // Key scenario: effectiveLabel is the bare designation ("M 31"), but the
-  // aliases array carries "Andromeda Galaxy". The search must still resolve.
-  const m31DesigLabel = item('M 31', 'M 31', 'galaxy', [
-    'M 31',
-    'NGC 224',
-    'Andromeda Galaxy',
-  ]);
-
-  it('"Andromeda" resolves to M31 via aliases when effectiveLabel is bare designation', () => {
-    expect(matchesSearch(m31DesigLabel, 'Andromeda')).toBe(true);
+// Alias-aware search (#29 / GF-11) moved to backend via `target.list(search)`.
+// The `matchesSearch` helper is now designation+label only; alias coverage
+// is tested at the Rust layer in `crates/app/targets/src/target_management/`.
+describe('matchesSearch — alias search is backend-only (GF-11)', () => {
+  it('"M 31" designation still matches via matchesSearch', () => {
+    expect(matchesSearch(item('M 31', 'M 31'), 'M31')).toBe(true);
   });
 
-  it('"andromeda galaxy" case-insensitive matches alias', () => {
-    expect(matchesSearch(m31DesigLabel, 'andromeda galaxy')).toBe(true);
+  it('"Andromeda Galaxy" label still matches via matchesSearch', () => {
+    expect(matchesSearch(item('M 31', 'Andromeda Galaxy'), 'Andromeda')).toBe(
+      true,
+    );
   });
 
-  it('"NGC 224" alternate designation matches via aliases', () => {
-    expect(matchesSearch(m31DesigLabel, 'NGC 224')).toBe(true);
-  });
-
-  it('"ngc224" compact form matches alias "NGC 224" via normalization', () => {
-    expect(matchesSearch(m31DesigLabel, 'ngc224')).toBe(true);
-  });
-
-  it('"Pinwheel" does NOT match M31 aliases', () => {
-    expect(matchesSearch(m31DesigLabel, 'Pinwheel')).toBe(false);
-  });
-
-  // Empty aliases array — graceful no-op (no crash, no false match).
-  const bare = item('IC 1805', 'IC 1805', 'emission_nebula', []);
-  it('empty aliases array does not crash and does not produce false matches', () => {
-    expect(matchesSearch(bare, 'Andromeda')).toBe(false);
-    expect(matchesSearch(bare, 'IC 1805')).toBe(true);
-  });
-
-  // Missing aliases field (undefined) — graceful fallback via `?? []`.
-  const noAliasField = {
-    id: 'x',
-    effectiveLabel: 'M 42',
-    primaryDesignation: 'M 42',
-    objectType: 'emission_nebula',
-    raDeg: 0,
-    decDeg: 0,
-  } as TargetListItem;
-  it('absent aliases field does not crash (nullish coalesce guard)', () => {
-    expect(matchesSearch(noAliasField, 'Orion')).toBe(false);
-    expect(matchesSearch(noAliasField, 'M 42')).toBe(true);
+  it('alias-only query ("NGC 224") does NOT match on the client — backend search needed', () => {
+    // m31 with bare designation label; "NGC 224" is an alias not in effectiveLabel.
+    expect(matchesSearch(item('M 31', 'M 31'), 'NGC 224')).toBe(false);
   });
 });

--- a/apps/desktop/src/features/targets/target-search.test.ts
+++ b/apps/desktop/src/features/targets/target-search.test.ts
@@ -52,16 +52,8 @@ describe('normalizeDesig', () => {
 });
 
 describe('matchesSearch — designation + label (#103b)', () => {
-  // effectiveLabel is the bare designation; aliases carry the proper names.
-  const m31 = item('M 31', 'Andromeda Galaxy', 'galaxy', [
-    'M 31',
-    'NGC 224',
-    'Andromeda Galaxy',
-  ]);
-  const ngc7000 = item('NGC 7000', 'North America Nebula', 'emission_nebula', [
-    'NGC 7000',
-    'North America Nebula',
-  ]);
+  const m31 = item('M 31', 'Andromeda Galaxy', 'galaxy');
+  const ngc7000 = item('NGC 7000', 'North America Nebula', 'emission_nebula');
 
   // Compact (no-space) form matches spaced designation
   it('"M31" matches target with primaryDesignation "M 31"', () => {

--- a/apps/desktop/src/features/targets/useTargetsPageFilters.ts
+++ b/apps/desktop/src/features/targets/useTargetsPageFilters.ts
@@ -28,7 +28,6 @@ import { DEFAULT_TARGET_SORT } from './TargetsTable';
 import type { TargetSort, TargetSortCol } from './TargetsTable';
 import { useFavourites } from './useFavourites';
 import { deriveRowMoonPlanning } from './astro/row-planning';
-import { matchesSearch } from './target-search-helpers';
 import type { ObservingNight } from './astro/moon-state';
 import type {
   MoonAvoidanceParams,
@@ -166,12 +165,16 @@ export function useTargetsPageFilters(
     // #919: search must find any matching target immediately, even one not
     // yet revealed by the progressive-reveal loader — same carve-out
     // "My Targets" already gets.
-    const searchBase = q
+    //
+    // GF-11 / DS-16: the backend `target.list(search)` already scoped the list
+    // to the query (alias-aware, over the ~13k-alias catalog), so we do NOT
+    // re-filter with the client-side `matchesSearch` — that would drop
+    // alias-only matches whose designation/label don't contain the query.
+    let result = q
       ? myTargetsFilter === MY_TARGETS_VALUE
         ? tabTargets
         : plannerTargets
       : tabTargets;
-    let result = q ? searchBase.filter((t) => matchesSearch(t, q)) : tabTargets;
 
     // Filter-by-recommendation (spec 047 US3, FR-011): keep only targets whose
     // REAL derived recommendation is one of the selected categories.

--- a/apps/desktop/src/hooks/useEntityNames.test.tsx
+++ b/apps/desktop/src/hooks/useEntityNames.test.tsx
@@ -4,6 +4,10 @@
 /**
  * useEntityNames tests (#809) — the resolver shared by Audit Log,
  * Projects Sources, and the Calibration match panel.
+ *
+ * Updated for the batched `entity.names` IPC (GF-7 / DS-14): the hook now
+ * calls `commands.entityNames([...])` once for all unseen refs instead of
+ * one `projectsGet`/`targetsGet`/`plansGet` call per id.
  */
 
 import { renderHook, waitFor } from '@testing-library/react';
@@ -11,13 +15,10 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import type { ReactNode } from 'react';
 
-const { mockProjectsGet, mockTargetGet, mockPlansGet, mockInventoryList } =
-  vi.hoisted(() => ({
-    mockProjectsGet: vi.fn(),
-    mockTargetGet: vi.fn(),
-    mockPlansGet: vi.fn(),
-    mockInventoryList: vi.fn(),
-  }));
+const { mockEntityNames, mockInventoryList } = vi.hoisted(() => ({
+  mockEntityNames: vi.fn(),
+  mockInventoryList: vi.fn(),
+}));
 
 vi.mock('@/bindings/index', async (importOriginal) => {
   const original = await importOriginal<typeof import('@/bindings/index')>();
@@ -25,25 +26,27 @@ vi.mock('@/bindings/index', async (importOriginal) => {
     ...original,
     commands: {
       ...original.commands,
-      projectsGet: mockProjectsGet,
-      targetGet: mockTargetGet,
-      plansGet: mockPlansGet,
+      entityNames: mockEntityNames,
       inventoryList: mockInventoryList,
     },
   };
 });
 
-import { useEntityNames, entityNameKey } from './useEntityNames';
+import {
+  useEntityNames,
+  entityNameKey,
+  clearEntityNameCache,
+} from './useEntityNames';
 
-const NOT_FOUND = {
-  status: 'error' as const,
-  error: {
-    code: 'entity.not_found',
-    message: 'not found',
-    severity: 'warning',
-    retryable: false,
-  },
-};
+/** Helper: wrap a names map as an `entity.names` ok-response. */
+function namesOk(names: Record<string, string>) {
+  return Promise.resolve({ status: 'ok' as const, data: { names } });
+}
+
+/** Helper: simulate a total backend failure. */
+function namesErr() {
+  return Promise.reject(new Error('backend error'));
+}
 
 function emptyInventory() {
   return {
@@ -69,27 +72,28 @@ function wrapper({ children }: { children: ReactNode }) {
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockProjectsGet.mockResolvedValue(NOT_FOUND);
-  mockTargetGet.mockResolvedValue(NOT_FOUND);
-  mockPlansGet.mockResolvedValue(NOT_FOUND);
+  clearEntityNameCache();
+  mockEntityNames.mockImplementation(() => namesOk({}));
   mockInventoryList.mockResolvedValue(emptyInventory());
 });
 
 describe('useEntityNames', () => {
-  it('resolves a known project id via commands.projectsGet', async () => {
-    mockProjectsGet.mockResolvedValue({
-      status: 'ok',
-      data: { id: 'proj-1', name: 'Andromeda Mosaic' },
-    });
+  it('resolves a known project id via a single batched entityNames call', async () => {
+    mockEntityNames.mockImplementation(() =>
+      namesOk({ 'project:proj-1': 'Andromeda Mosaic' }),
+    );
     const ref = { entityType: 'project', entityId: 'proj-1' };
     const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
 
     await waitFor(() => {
       expect(result.current.get(entityNameKey(ref))).toBe('Andromeda Mosaic');
     });
+    expect(mockEntityNames).toHaveBeenCalledWith([
+      { entityType: 'project', entityId: 'proj-1' },
+    ]);
   });
 
-  it('resolves a known session id via the inventory-sources query, not a per-id lookup', async () => {
+  it('resolves a known session id via the inventory-sources query, not entityNames', async () => {
     mockInventoryList.mockResolvedValue({
       status: 'ok',
       data: {
@@ -125,45 +129,17 @@ describe('useEntityNames', () => {
     await waitFor(() => {
       expect(result.current.get(entityNameKey(ref))).toBe('M31 – 2026-05-20');
     });
-    expect(mockProjectsGet).not.toHaveBeenCalled();
-    expect(mockTargetGet).not.toHaveBeenCalled();
-    expect(mockPlansGet).not.toHaveBeenCalled();
+    // Sessions skip the entityNames batch — only inventory-sources is used.
+    expect(mockEntityNames).not.toHaveBeenCalled();
   });
 
-  it('resolves a known target id via commands.targetGet (gen-3 effectiveLabel)', async () => {
-    mockTargetGet.mockResolvedValue({
-      status: 'ok',
-      data: {
-        id: 'tgt-1',
-        primaryDesignation: 'NGC 7000',
-        effectiveLabel: 'North America Nebula',
-        displayAlias: 'North America Nebula',
-        objectType: 'emission_nebula',
-        raDeg: 314.75,
-        decDeg: 44.52,
-        simbadOid: null,
-        source: 'resolved',
-        aliases: [],
-      },
-    });
-    const ref = { entityType: 'target', entityId: 'tgt-1' };
-    const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
-
-    await waitFor(() => {
-      expect(result.current.get(entityNameKey(ref))).toBe(
-        'North America Nebula',
-      );
-    });
-    expect(mockTargetGet).toHaveBeenCalledWith({ targetId: 'tgt-1' });
-  });
-
-  it('falls back (no entry in the map) for an id that genuinely fails to resolve', async () => {
+  it('falls back (no entry in the map) for an id absent from the DB', async () => {
+    // Backend returns empty names — target not found.
+    mockEntityNames.mockImplementation(() => namesOk({}));
     const ref = { entityType: 'target', entityId: 'tgt-missing' };
     const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
 
-    await waitFor(() =>
-      expect(mockTargetGet).toHaveBeenCalledWith({ targetId: 'tgt-missing' }),
-    );
+    await waitFor(() => expect(mockEntityNames).toHaveBeenCalled());
     expect(result.current.get(entityNameKey(ref))).toBeUndefined();
   });
 
@@ -171,9 +147,71 @@ describe('useEntityNames', () => {
     const ref = { entityType: 'settings', entityId: 'settings-1' };
     const { result } = renderHook(() => useEntityNames([ref]), { wrapper });
 
+    // Unknown type skips the batch entirely.
     expect(result.current.get(entityNameKey(ref))).toBeUndefined();
-    expect(mockProjectsGet).not.toHaveBeenCalled();
-    expect(mockTargetGet).not.toHaveBeenCalled();
-    expect(mockPlansGet).not.toHaveBeenCalled();
+    expect(mockEntityNames).not.toHaveBeenCalled();
+  });
+
+  it('batches multiple refs of different types into one call', async () => {
+    mockEntityNames.mockImplementation(() =>
+      namesOk({
+        'project:proj-1': 'Project Alpha',
+        'plan:plan-1': 'Plan Beta',
+      }),
+    );
+    const refs = [
+      { entityType: 'project', entityId: 'proj-1' },
+      { entityType: 'plan', entityId: 'plan-1' },
+    ];
+    const { result } = renderHook(() => useEntityNames(refs), { wrapper });
+
+    await waitFor(() => {
+      expect(result.current.get(entityNameKey(refs[0]))).toBe('Project Alpha');
+      expect(result.current.get(entityNameKey(refs[1]))).toBe('Plan Beta');
+    });
+    // Only one batch call, not two.
+    expect(mockEntityNames).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-request ids that are already cached', async () => {
+    mockEntityNames.mockImplementation(() =>
+      namesOk({ 'project:proj-cached': 'Cached Project' }),
+    );
+    const ref = { entityType: 'project', entityId: 'proj-cached' };
+
+    const { result, rerender } = renderHook(() => useEntityNames([ref]), {
+      wrapper,
+    });
+    await waitFor(() =>
+      expect(result.current.get(entityNameKey(ref))).toBe('Cached Project'),
+    );
+
+    vi.clearAllMocks();
+    mockEntityNames.mockImplementation(() => namesOk({}));
+    rerender();
+
+    // Cache hit — no second IPC call.
+    expect(mockEntityNames).not.toHaveBeenCalled();
+  });
+
+  it('retries on backend error by removing from in-flight set', async () => {
+    mockEntityNames
+      .mockImplementationOnce(namesErr)
+      .mockImplementation(() =>
+        namesOk({ 'project:proj-retry': 'Retried Project' }),
+      );
+    const ref = { entityType: 'project', entityId: 'proj-retry' };
+    const { result, rerender } = renderHook(() => useEntityNames([ref]), {
+      wrapper,
+    });
+
+    // First call fails; ref is evicted from in-flight set.
+    await waitFor(() => expect(mockEntityNames).toHaveBeenCalledTimes(1));
+
+    // Trigger a re-render which should retry.
+    rerender();
+    await waitFor(() =>
+      expect(result.current.get(entityNameKey(ref))).toBe('Retried Project'),
+    );
   });
 });

--- a/apps/desktop/src/hooks/useEntityNames.ts
+++ b/apps/desktop/src/hooks/useEntityNames.ts
@@ -8,8 +8,9 @@
  * Sources, and the Calibration match panel share one implementation instead
  * of three ad hoc treatments (#809).
  *
- * - `project` / `target` / `plan`: one IPC round-trip per unseen id, cached
- *   module-wide since ids repeat across pages within a session.
+ * - `project` / `target` / `plan`: one batched `entity.names` IPC call for
+ *   all unseen refs, cached module-wide since ids repeat across pages within
+ *   a session.  Previously one round-trip per unseen id (GF-7 / DS-14 fix).
  * - `session`: sessions have no cheap per-id name lookup (`sessions.get`
  *   returns session detail, not a display name), so names are read from the
  *   already-fetched inventory-sources query instead of adding a new IPC
@@ -23,6 +24,7 @@
 
 import { useEffect, useRef, useState } from 'react';
 import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
 import { useInventorySources } from '@/features/sessions/store';
 
 export interface EntityNameRef {
@@ -30,8 +32,13 @@ export interface EntityNameRef {
   entityId: string;
 }
 
-/** Module-scope cache for the per-id IPC lookups (project/target/plan). */
+/** Module-scope cache for the IPC batch lookups (project/target/plan). */
 const entityNameCache = new Map<string, string | null>();
+
+/** Clear the entity-name cache — for use in tests to prevent cross-test pollution. */
+export function clearEntityNameCache(): void {
+  entityNameCache.clear();
+}
 
 export function entityNameKey(ref: EntityNameRef): string {
   return `${ref.entityType}:${ref.entityId}`;
@@ -46,35 +53,48 @@ export function useEntityNames(
 
   useEffect(() => {
     let cancelled = false;
-    for (const ref of refs) {
-      if (ref.entityType === 'session') continue;
-      const cacheKey = entityNameKey(ref);
-      if (entityNameCache.has(cacheKey) || requested.current.has(cacheKey)) {
-        continue;
-      }
-      const fetcher =
-        ref.entityType === 'project'
-          ? commands
-              .projectsGet(ref.entityId)
-              .then((r) => (r.status === 'ok' ? r.data.name : null))
-          : ref.entityType === 'target'
-            ? commands
-                .targetGet({ targetId: ref.entityId })
-                .then((r) => (r.status === 'ok' ? r.data.effectiveLabel : null))
-            : ref.entityType === 'plan'
-              ? commands
-                  .plansGet(ref.entityId)
-                  .then((r) => (r.status === 'ok' ? r.data.title : null))
-              : null;
-      if (!fetcher) continue;
-      requested.current.add(cacheKey);
-      void fetcher
-        .catch(() => null)
-        .then((name) => {
-          entityNameCache.set(cacheKey, name);
-          if (!cancelled) forceRender((n) => n + 1);
-        });
+
+    // Collect refs not yet cached or in-flight.  Session names come from the
+    // inventory-sources store; unknown types are skipped (backend ignores them
+    // anyway but filtering here avoids a wasted IPC call).
+    const BATCH_TYPES = new Set(['project', 'plan', 'target']);
+    const unseen = refs.filter((ref) => {
+      if (!BATCH_TYPES.has(ref.entityType)) return false;
+      const key = entityNameKey(ref);
+      return !entityNameCache.has(key) && !requested.current.has(key);
+    });
+
+    if (unseen.length === 0) return;
+
+    // Mark all unseen as in-flight before the async call to prevent
+    // duplicate dispatches from concurrent renders.
+    for (const ref of unseen) {
+      requested.current.add(entityNameKey(ref));
     }
+
+    // Single batch IPC call instead of N sequential round-trips (GF-7).
+    void commands
+      .entityNames(
+        unseen.map((r) => ({ entityType: r.entityType, entityId: r.entityId })),
+      )
+      .then(unwrap)
+      .then(({ names }) => {
+        // Populate cache for all refs in the batch — present entries get their
+        // name, absent entries (not in DB) get null so we don't re-request.
+        for (const ref of unseen) {
+          const key = entityNameKey(ref);
+          entityNameCache.set(key, names[key] ?? null);
+        }
+        if (!cancelled) forceRender((n) => n + 1);
+      })
+      .catch(() => {
+        // On failure leave the cache empty — the hook will retry on the next
+        // render cycle when the refs change (e.g. page navigation).
+        for (const ref of unseen) {
+          requested.current.delete(entityNameKey(ref));
+        }
+      });
+
     return () => {
       cancelled = true;
     };

--- a/crates/app/core/src/entity_names.rs
+++ b/crates/app/core/src/entity_names.rs
@@ -1,0 +1,70 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `entity.names` — batch display-name lookup (GF-7 / DS-14).
+//!
+//! Resolves `(entityType, entityId)` refs to display names in three IN-clause
+//! queries (one per entity type) rather than one IPC round-trip per unseen id.
+//!
+//! Supported entity types: `project`, `plan`, `target`.  Unknown types are
+//! silently skipped — the frontend treats absence as "unresolved".
+
+use std::collections::HashMap;
+
+use contracts_core::audit::{EntityNameRef, EntityNamesResponse};
+use contracts_core::ContractError;
+use persistence_core::repositories::q_core;
+use sqlx::SqlitePool;
+
+fn db_err(e: impl std::fmt::Display) -> ContractError {
+    contracts_core::ContractError::new(
+        contracts_core::error_code::ErrorCode::InternalDatabase,
+        format!("{e}"),
+        contracts_core::ErrorSeverity::Fatal,
+        true,
+    )
+}
+
+/// Resolve display names for a batch of entity refs.
+///
+/// Returns a map from `"<entityType>:<entityId>"` → display name.  Refs that
+/// do not match a DB row are omitted (caller treats absence as unknown).
+///
+/// # Errors
+/// Returns `ContractError` with code `internal.database` on query failure.
+pub async fn entity_names(
+    pool: &SqlitePool,
+    refs: Vec<EntityNameRef>,
+) -> Result<EntityNamesResponse, ContractError> {
+    // Partition ids by entity type (skip unsupported types).
+    let mut project_ids: Vec<String> = Vec::new();
+    let mut plan_ids: Vec<String> = Vec::new();
+    let mut target_ids: Vec<String> = Vec::new();
+
+    for r in &refs {
+        match r.entity_type.as_str() {
+            "project" => project_ids.push(r.entity_id.clone()),
+            "plan" => plan_ids.push(r.entity_id.clone()),
+            "target" => target_ids.push(r.entity_id.clone()),
+            _ => {} // session names come from the inventory-sources query, not here
+        }
+    }
+
+    // Three IN-clause batch queries (avoids N IPC round-trips).
+    let project_rows = q_core::project_names_batch(pool, &project_ids).await.map_err(db_err)?;
+    let plan_rows = q_core::plan_titles_batch(pool, &plan_ids).await.map_err(db_err)?;
+    let target_rows = q_core::target_names_batch(pool, &target_ids).await.map_err(db_err)?;
+
+    let mut names: HashMap<String, String> = HashMap::new();
+    for (id, name) in project_rows {
+        names.insert(format!("project:{id}"), name);
+    }
+    for (id, title) in plan_rows {
+        names.insert(format!("plan:{id}"), title);
+    }
+    for (id, designation) in target_rows {
+        names.insert(format!("target:{id}"), designation);
+    }
+
+    Ok(EntityNamesResponse { names })
+}

--- a/crates/app/core/src/lib.rs
+++ b/crates/app/core/src/lib.rs
@@ -74,6 +74,8 @@ pub mod calibration_archive_generator;
 pub mod cleanup_generator;
 #[cfg(feature = "dev-tools")]
 pub mod dev_contracts;
+/// `entity.names` — batch display-name lookup (GF-7 / DS-14).
+pub mod entity_names;
 pub mod first_run;
 /// Per-frame inventory use cases (spec 048): `inventory.frame.list` and the
 /// on-demand `inventory.reconcile.run` pass.

--- a/crates/app/targets/src/target_management/list.rs
+++ b/crates/app/targets/src/target_management/list.rs
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 //! `target.list` — all canonical targets (gen-3), ordered by
-//! `primary_designation`.
+//! `primary_designation`, with optional server-side alias-aware search.
 
 use sqlx::SqlitePool;
 
@@ -10,10 +10,15 @@ use contracts_core::targets::TargetListItem;
 use contracts_core::ContractError;
 use targeting_resolver::cache;
 
-use super::{cache_err, db_err, list_row_to_item};
+use super::{db_err, list_row_to_item};
 
-/// `target.list` — list all canonical targets (gen-3), ordered by
+/// `target.list` — list canonical targets (gen-3), ordered by
 /// `primary_designation`.
+///
+/// When `search` is `Some(q)` and non-empty, returns only targets whose
+/// primary designation, effective label, or any alias contains `q`
+/// case-insensitively.  The in-memory catalog cache is used for both the
+/// full list and the search pass (no extra DB round-trips for search).
 ///
 /// Read-through against the whole-catalog snapshot ([`crate::caches::catalog`],
 /// in-memory caching layer F0): a cache hit skips the DB round-trip entirely; a
@@ -23,24 +28,53 @@ use super::{cache_err, db_err, list_row_to_item};
 /// # Errors
 ///
 /// Returns [`ContractError`] with code `internal.database`.
-pub async fn list(pool: &SqlitePool) -> Result<Vec<TargetListItem>, ContractError> {
-    if let Some(cached) = crate::caches::catalog().load() {
-        return Ok((*cached).clone());
-    }
-    let rows = cache::list_all(pool).await.map_err(cache_err)?;
-    // #877: attach real session counts (planner Sessions column) — a target
-    // with no linked session simply keeps the DTO default of 0.
-    let session_counts = session_counts_by_target(pool).await?;
-    let items: Vec<TargetListItem> = rows
+pub async fn list(
+    pool: &SqlitePool,
+    search: Option<&str>,
+) -> Result<Vec<TargetListItem>, ContractError> {
+    let catalog = if let Some(cached) = crate::caches::catalog().load() {
+        (*cached).clone()
+    } else {
+        let rows = cache::list_all(pool).await.map_err(db_err)?;
+        // #877: attach real session counts (planner Sessions column) — a target
+        // with no linked session simply keeps the DTO default of 0.
+        let session_counts = session_counts_by_target(pool).await?;
+        let items: Vec<TargetListItem> = rows
+            .into_iter()
+            .map(|row| {
+                let mut item = list_row_to_item(row);
+                item.session_count = session_counts.get(&item.id).copied().unwrap_or_default();
+                item
+            })
+            .collect();
+        crate::caches::store_catalog(std::sync::Arc::new(items.clone()));
+        items
+    };
+
+    // Return the whole catalog when search is absent or empty.
+    let Some(q_raw) = search.filter(|s| !s.trim().is_empty()) else {
+        return Ok(catalog);
+    };
+
+    // Dual-mode filter (mirrors client-side `matchesSearch` / `normalizeDesig`):
+    // - normalized form collapses whitespace for "M31" → "M 31" matching
+    // - lowercase plain form for proper-name substring ("andromeda" in "Andromeda Galaxy")
+    let q_norm = targeting::normalize::normalize(q_raw);
+    let q_lower = q_raw.to_lowercase();
+
+    // Filter in-process using the cached aliases (never cross IPC; GF-11).
+    Ok(catalog
         .into_iter()
-        .map(|row| {
-            let mut item = list_row_to_item(row);
-            item.session_count = session_counts.get(&item.id).copied().unwrap_or_default();
-            item
+        .filter(|t| {
+            targeting::normalize::normalize(&t.primary_designation).contains(&q_norm)
+                || targeting::normalize::normalize(&t.effective_label).contains(&q_norm)
+                || t.effective_label.to_lowercase().contains(&q_lower)
+                || t.aliases.iter().any(|a| {
+                    targeting::normalize::normalize(a).contains(&q_norm)
+                        || a.to_lowercase().contains(&q_lower)
+                })
         })
-        .collect();
-    crate::caches::store_catalog(std::sync::Arc::new(items.clone()));
-    Ok(items)
+        .collect())
 }
 
 /// `target_id -> session_count` map (#877), built from real

--- a/crates/app/targets/src/target_management/list.rs
+++ b/crates/app/targets/src/target_management/list.rs
@@ -10,7 +10,7 @@ use contracts_core::targets::TargetListItem;
 use contracts_core::ContractError;
 use targeting_resolver::cache;
 
-use super::{db_err, list_row_to_item};
+use super::{cache_err, db_err, list_row_to_item};
 
 /// `target.list` — list canonical targets (gen-3), ordered by
 /// `primary_designation`.
@@ -35,7 +35,7 @@ pub async fn list(
     let catalog = if let Some(cached) = crate::caches::catalog().load() {
         (*cached).clone()
     } else {
-        let rows = cache::list_all(pool).await.map_err(db_err)?;
+        let rows = cache::list_all(pool).await.map_err(cache_err)?;
         // #877: attach real session counts (planner Sessions column) — a target
         // with no linked session simply keeps the DTO default of 0.
         let session_counts = session_counts_by_target(pool).await?;

--- a/crates/app/targets/src/target_management/tests.rs
+++ b/crates/app/targets/src/target_management/tests.rs
@@ -91,7 +91,7 @@ async fn get_invalid_id_returns_error() {
 async fn list_returns_all_targets() {
     let db = setup().await;
     seed_m31(&db).await;
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].primary_designation, "M 31");
     assert_eq!(items[0].object_type, "galaxy");
@@ -101,7 +101,7 @@ async fn list_returns_all_targets() {
 #[tokio::test]
 async fn list_empty_when_no_targets() {
     let db = setup().await;
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert!(items.is_empty());
 }
 
@@ -111,7 +111,7 @@ async fn list_empty_when_no_targets() {
 async fn list_item_carries_ra_dec() {
     let db = setup().await;
     seed_m31(&db).await;
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert_eq!(items.len(), 1);
     // M31 fixture values from m31() above (ra=10.684708, dec=41.26875).
     assert!((items[0].ra_deg - 10.684_708).abs() < 1e-6, "ra_deg mismatch: {}", items[0].ra_deg);
@@ -126,7 +126,7 @@ async fn list_item_carries_ra_dec() {
 async fn list_item_constellation_and_magnitude_none_when_not_stored() {
     let db = setup().await;
     seed_m31(&db).await;
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(
         items[0].constellation.as_deref(),
@@ -146,7 +146,7 @@ async fn list_item_constellation_and_magnitude_none_when_not_stored() {
 async fn list_item_carries_aliases() {
     let db = setup().await;
     seed_m31(&db).await;
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert_eq!(items.len(), 1);
     // M31 fixture aliases: "M 31", "NGC 224", "Andromeda Galaxy".
     assert_eq!(
@@ -181,7 +181,7 @@ async fn list_item_aliases_empty_when_no_aliases_stored() {
     .await
     .expect("direct insert failed");
 
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert_eq!(items.len(), 1);
     assert!(items[0].aliases.is_empty(), "aliases must be empty vec, got {:?}", items[0].aliases);
 }
@@ -203,7 +203,7 @@ async fn list_item_returns_stored_constellation_and_magnitude() {
         .await
         .expect("direct constellation/magnitude update failed");
 
-    let items = list(db.pool()).await.unwrap();
+    let items = list(db.pool(), None).await.unwrap();
     assert_eq!(items.len(), 1);
     assert_eq!(items[0].constellation.as_deref(), Some("And"), "constellation mismatch");
     assert!(

--- a/crates/contracts/core/src/audit.rs
+++ b/crates/contracts/core/src/audit.rs
@@ -86,3 +86,26 @@ pub struct AuditExportResponse {
     /// Byte size of the written file.
     pub bytes: u64,
 }
+
+// ── entity.names batch ───────────────────────────────────────────────────────
+
+/// One entity reference for the `entity.names` batch lookup.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityNameRef {
+    pub entity_type: String,
+    pub entity_id: String,
+}
+
+/// Result of the `entity.names` batch lookup: a map from
+/// `"<entityType>:<entityId>"` keys to display names.
+///
+/// Keys with no matching DB row are omitted — the caller uses absence as
+/// the "unknown / still loading" signal.
+#[derive(Clone, Debug, Serialize, Deserialize, Type)]
+#[serde(rename_all = "camelCase")]
+pub struct EntityNamesResponse {
+    /// Flat `{ "<type>:<id>": "<name>" }` map — camelCase key matches the
+    /// frontend `entityNameKey(ref)` helper.
+    pub names: std::collections::HashMap<String, String>,
+}

--- a/crates/contracts/core/src/targets.rs
+++ b/crates/contracts/core/src/targets.rs
@@ -179,9 +179,9 @@ pub struct TargetDetailV3 {
 /// `constellation` and `magnitude` are optional because those columns were not
 /// in the original schema; they are populated from `canonical_target.constellation`
 /// and `canonical_target.magnitude` when present (migration 0046).
-/// `aliases` carries all alias display forms (designations, common names, and
-/// user-added) so client-side alias search (e.g. "Andromeda" → M31) works
-/// without a separate round-trip. Empty when no aliases are stored.
+/// Alias search is now backend-side via the `search` parameter on `target.list`
+/// (GF-11 / DS-16); `aliases` is no longer serialized to the IPC response to
+/// avoid cloning all alias strings for every list call (13k× entries).
 #[derive(Clone, Debug, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct TargetListItem {
@@ -200,10 +200,11 @@ pub struct TargetListItem {
     /// Visual magnitude; `null` when not stored or not applicable.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub magnitude: Option<f64>,
-    /// All alias display forms for this target (designations, common names,
-    /// user-added). Empty when none are stored. Additive field — older clients
-    /// that ignore unknown keys are unaffected.
-    #[serde(default)]
+    /// Alias display forms — kept in-process for backend search but NOT
+    /// serialized to the IPC response (detail-only; use `target.get` for the
+    /// full alias list, or pass `search` to `target.list` for alias-aware
+    /// filtering without cloning all alias strings over IPC).
+    #[serde(skip)]
     pub aliases: Vec<String>,
     /// Count of `acquisition_session` rows linked to this target (#877, planner
     /// Sessions column). `0` when no session has resolved to this target yet —

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -795,6 +795,31 @@ pub async fn project_ids_for_sessions_batch(
     Ok(rows)
 }
 
+// ── entity.names batch lookup ─────────────────────────────────────────────────
+
+/// Batch-fetch display names for a list of project ids via IN-clause.
+///
+/// Returns `(id, name)` pairs only for ids that exist in the DB.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn project_names_batch(
+    pool: &SqlitePool,
+    ids: &[String],
+) -> DbResult<Vec<(String, String)>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut builder = sqlx::QueryBuilder::new("SELECT id, name FROM projects WHERE id IN (");
+    let mut sep = builder.separated(", ");
+    for id in ids {
+        sep.push_bind(id);
+    }
+    builder.push(")");
+    let rows: Vec<(String, String)> = builder.build_query_as().fetch_all(pool).await?;
+    Ok(rows)
+}
+
 /// Batch active frame summary: returns `(session_frame_ids_hash, count, total_size_bytes)`
 /// per session. Takes a slice of `(session_id, frame_ids_json)` pairs.
 /// Internally collects all frame IDs, runs one query, then re-attributes by session.
@@ -913,6 +938,56 @@ pub async fn active_frame_exposure_seconds_batch(
     }
 
     Ok(result)
+}
+
+/// Batch-fetch display titles for a list of plan ids via IN-clause.
+///
+/// Returns `(id, title)` pairs only for ids that exist in the DB.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn plan_titles_batch(
+    pool: &SqlitePool,
+    ids: &[String],
+) -> DbResult<Vec<(String, String)>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut builder = sqlx::QueryBuilder::new("SELECT id, title FROM plans WHERE id IN (");
+    let mut sep = builder.separated(", ");
+    for id in ids {
+        sep.push_bind(id);
+    }
+    builder.push(")");
+    let rows: Vec<(String, String)> = builder.build_query_as().fetch_all(pool).await?;
+    Ok(rows)
+}
+
+/// Batch-fetch primary designations for a list of canonical target ids via IN-clause.
+///
+/// Returns `(id, primary_designation)` pairs only for ids that exist in the DB.
+///
+/// # Errors
+/// Returns [`crate::DbError::Database`] on query failure.
+pub async fn target_names_batch(
+    pool: &SqlitePool,
+    ids: &[String],
+) -> DbResult<Vec<(String, String)>> {
+    if ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT CAST(id AS TEXT), \
+         COALESCE(display_alias, primary_designation) \
+         FROM canonical_target WHERE CAST(id AS TEXT) IN (",
+    );
+    let mut sep = builder.separated(", ");
+    for id in ids {
+        sep.push_bind(id);
+    }
+    builder.push(")");
+    let rows: Vec<(String, String)> = builder.build_query_as().fetch_all(pool).await?;
+    Ok(rows)
 }
 
 // ── Tests ────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

- **entity.names batched command**: useEntityNames previously fired one IPC per unseen (entityType, id) — including full-graph plansGet just to read a title. One batched command now resolves all refs via single-column SELECTs.
- **target.list slimmed**: aliases dropped from the list DTO (13k-target catalog no longer ships every alias per call); server-side search added to cover alias matching for TargetsPage.
- **Plan-apply progress throttled**: per-item channel events accumulate in a rAF ref and flush batched — a 5,000-item apply no longer causes thousands of sequential overlay re-renders; terminal/warning events still flush immediately.

## Known behavioral change

CommandPalette alias-only queries (e.g. 'Caldwell 20' for NGC 7000) no longer match client-side — the palette matches designation+label; TargetsPage covers aliases via the new server-side search. Flagged for review: acceptable or wire the palette to the same search?

## Spec Context

Tracks-Bead: astro-plan-kyo7.81
Tracks-Bead: astro-plan-kyo7.83
Merge-Bead: astro-plan-3wvy

Wave-4 packet GF-7/11 + DS-14/16. Verified: fmt, clippy -D warnings, desktop_shell + app_core_targets tests, check-generated, db-boundary, dead-callers, pnpm lint, vitest 2133.