### PR TITLE
refactor: decompose InboxPage into focused hooks and model

### DIFF
--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -37,20 +37,15 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import { queryKeys } from '@/data/queryKeys';
-import type {
-  ChosenAttributionDto_Deserialize as ChosenAttributionRequest,
-  IngestionAttributionCandidateDto,
-  InboxConfirmDestination,
-  InboxReclassifyV2Response_Serialize as InboxReclassifyV2Response,
-} from '@/bindings/index';
+import type { InboxReclassifyV2Response_Serialize as InboxReclassifyV2Response } from '@/bindings/index';
 import { useSetPageStatus } from '@/app/PageStatusContext';
 import { FilterToolbar, ListPageLayout, PageTopBar } from '@/components';
+import { useInboxConfirmFlow } from './useInboxConfirmFlow';
 import { useInboxPlanApplyFlow } from './useInboxPlanApplyFlow';
 import { m } from '@/lib/i18n';
 import type { FrameType } from '@/lib/route-contract';
 import { useGrouping } from '@/lib/use-grouping';
 import { useStaleSelectionCleanup } from '@/lib/use-stale-selection';
-import { useHotkeys } from '@/lib/useHotkeys';
 import { addToast } from '@/shared/toast';
 import { Btn } from '@/ui';
 import { GROUPING_DIMENSIONS, GROUPING_STORAGE_KEY } from './InboxControls';
@@ -61,7 +56,6 @@ import type { InboxSortCol, InboxSort } from './InboxList';
 import { InboxStatsSummary } from './InboxStatsSummary';
 import { deriveInboxStats } from './inboxStatsFromItems';
 import { PlanApprovalOverlay } from './PlanApprovalOverlay';
-import type { DestructiveDestination, PendingRootPick } from './PlanPanel';
 import { buildBreakdownFromActions } from './PlanPanel';
 import type {
   InboxBreakdownTarget,
@@ -71,10 +65,8 @@ import type {
 import {
   inboxClassifyQueryKey,
   mergeRescanRoots,
-  normalizeConfirmError,
   useInboxClassification,
   useInboxClassifySourceGroup,
-  useInboxConfirm,
   useInboxItemMetadata,
   useInboxList,
   useInboxPlanBreakdowns,
@@ -82,11 +74,6 @@ import {
   useOpenInboxPlans,
 } from './store';
 
-/** Shape of `inbox.destination_root_required` error details (spec 041 US8/FR-029). */
-interface DestinationRootRequiredDetails {
-  category: string;
-  candidates: Array<{ rootId: string; path: string; kind: string }>;
-}
 
 /**
  * Pick which post-split sub-item selection should move to after a
@@ -194,20 +181,6 @@ export function resolveClassifiedGroupSelection(
   return { action: 'none' };
 }
 
-/** Type-guard for the destination-root-required details payload. */
-function asRootRequiredDetails(
-  d: unknown,
-): DestinationRootRequiredDetails | null {
-  if (
-    d &&
-    typeof d === 'object' &&
-    'candidates' in d &&
-    Array.isArray(d.candidates)
-  ) {
-    return d as DestinationRootRequiredDetails;
-  }
-  return null;
-}
 
 // #557: a shared, stable empty-array fallback. `listData?.items ?? []`
 // allocates a NEW array every render while the query is unresolved, which
@@ -572,27 +545,6 @@ export function InboxPage() {
     selectedRootPath,
   );
 
-  // GFD-1: prefetch attribution candidates alongside classify so handleConfirm
-  // can read them from cache synchronously instead of awaiting a round-trip on
-  // the hot Confirm path. The design-comment calling this "optional enrichment"
-  // is still correct as a FALLBACK policy (failure falls through), but the
-  // awaited round-trip inside handleConfirm adds perceivable latency on every
-  // confirm click. Prefetching on selection amortises it to zero.
-  //
-  // Only prefetches for classified light items (the only items where attribution
-  // candidates are meaningful); does not block confirm — the hot path still
-  // falls back to an awaited call if the prefetch hasn't landed yet.
-  const selectedItemIdForPrefetch = selectedItem?.inboxItemId ?? null;
-  useEffect(() => {
-    if (!selectedItemIdForPrefetch) return;
-    void queryClient.prefetchQuery({
-      queryKey: queryKeys.inbox.attributionSuggest(selectedItemIdForPrefetch),
-      queryFn: async () =>
-        unwrap(
-          await commands.inboxAttributionSuggest(selectedItemIdForPrefetch),
-        ),
-    });
-  }, [selectedItemIdForPrefetch, queryClient]);
 
   // Group-scoped classification for scanned-but-unclassified folders
   // (spec 058 FR-017). Unlike the item-scoped hook above this does NOT fire on
@@ -669,84 +621,45 @@ export function InboxPage() {
         .map((r) => ({ id: r.id, path: r.path, category: r.category })),
     [allRoots],
   );
-  const [selectedDestRootId, setSelectedDestRootId] = useState('');
-
-  const { confirm, loading: confirmLoading } = useInboxConfirm();
-  // FR-032: destructive-destination choice, defaults to 'archive' (Constitution §II).
-  // The literal 'archive' | 'trash' values are exactly what inbox.confirm accepts.
-  const [destructiveDestination, setDestructiveDestination] =
-    useState<DestructiveDestination>('archive');
-  // #943: `confirmLoading` (from `useInboxConfirm`) only covers the backend
-  // `inbox.confirm` mutation inside `runConfirm` — it says nothing about the
-  // `inboxAttributionSuggest` read that now runs BEFORE it. Without this,
-  // Confirm/the "C" hotkey stayed clickable for that whole await, so a
-  // re-entrant trigger landing in the window (slower CI runners widen it)
-  // could start a second `handleConfirm` and race an unattributed confirm
-  // in ahead of the picker. Guards the entire handleConfirm body, not just
-  // the mutation.
-  const [confirmFlowBusy, setConfirmFlowBusy] = useState(false);
-
-  // spec 041 US8/FR-029: when a confirm needs the user to pick among multiple
-  // candidate library roots, hold the prompt + the item it belongs to so the
-  // PlanPanel can render the picker and we can re-confirm with the chosen root.
-  const [pendingRootPick, setPendingRootPick] =
-    useState<PendingRootPick | null>(null);
-  const [rootPickItemId, setRootPickItemId] = useState<string | null>(null);
-
-  // spec 008 US7/FR-022 (#943): ranked attribution suggestions for the item
-  // awaiting confirm. Held BEFORE the confirm fires — confirm creates the plan
-  // that blocks any second confirm, so the pick must ride the first one.
-  const [pendingAttribution, setPendingAttribution] = useState<{
-    itemId: string;
-    rootAbsolutePath: string;
-    contentSignature: string;
-    rootId?: string;
-    candidates: IngestionAttributionCandidateDto[];
-  } | null>(null);
-
-  // spec 041 US8/FR-031: absolute destination paths keyed by source path,
-  // accumulated from each successful confirm's `destinations[]`. Lets the plan
-  // panel show the full absolute destination per action.
-  const [absoluteByFromPath, setAbsoluteByFromPath] = useState<
-    Record<string, string>
-  >({});
-
-  // Drop a pending root pick when the user navigates away from its item, so a
-  // stale picker never lingers under a different selection.
-  const selectedItemId = selectedItem?.inboxItemId ?? null;
-  useEffect(() => {
-    if (rootPickItemId && rootPickItemId !== selectedItemId) {
-      setPendingRootPick(null);
-      setRootPickItemId(null);
-    }
-  }, [rootPickItemId, selectedItemId]);
-
-  // #648: `selectedDestRootId` previously survived a selection change — the
-  // picker is filtered per item by frame-type category (InboxDetail's
-  // `applicableRoots`), so a calibration root chosen for a bias item is not
-  // among a subsequently-selected light item's options. The DOM <select>
-  // then fell back to its first option ("Auto") while this state still held
-  // the stale (invalid-for-this-item) root id, so a confirm sent the hidden
-  // stale value and the backend rejected it with `inbox.invalid_destination_
-  // root` for a picker that visibly read "Auto". Reset on every selection
-  // change so the picker always starts at the real "Auto" state.
-  useEffect(() => {
-    setSelectedDestRootId('');
-  }, [selectedItemId]);
-
-  const mergeDestinations = useCallback(
-    (destinations?: InboxConfirmDestination[] | null) => {
-      if (!destinations || destinations.length === 0) return;
-      setAbsoluteByFromPath((prev) => {
-        const next = { ...prev };
-        for (const d of destinations) {
-          next[d.fromPath] = d.toAbsolutePath;
-        }
-        return next;
-      });
-    },
-    [],
+  const hasMissingRequiredMeta = useMemo(
+    () =>
+      (fileMetadata ?? []).some(
+        (f) => (f.missingPathAttributes?.length ?? 0) > 0,
+      ),
+    [fileMetadata],
   );
+
+  const {
+    handleConfirm,
+    handlePickAttribution,
+    handlePickDestinationRoot,
+    handleBulkConfirm,
+    canConfirm,
+    confirmLoading,
+    confirmFlowBusy,
+    bulkConfirmLoading,
+    canBulkConfirm,
+    bulkEligibleItems,
+    destructiveDestination,
+    setDestructiveDestination,
+    selectedDestRootId,
+    setSelectedDestRootId,
+    pendingRootPick,
+    pendingAttribution,
+    clearPendingAttribution,
+    attributionProjectNames,
+    absoluteByFromPath,
+  } = useInboxConfirmFlow({
+    selectedItem,
+    selectedRootPath,
+    classification,
+    fileMetadataLoading,
+    fileMetadataError,
+    hasMissingRequiredMeta,
+    items,
+    refreshAll,
+  });
+
 
   const {
     handleApplyOne,
@@ -757,335 +670,6 @@ export function InboxPage() {
     progressPlanId,
     planBusy,
   } = useInboxPlanApplyFlow(refreshAll, viewResultAction);
-
-  /**
-   * Confirm `item` (optionally targeting a caller-chosen destination `rootId`).
-   * Centralises the success path and the structured-error handling so the
-   * initial confirm and a re-confirm after a root pick share one code path.
-   */
-  const runConfirm = useCallback(
-    async (
-      item: { inboxItemId: string; rootAbsolutePath: string },
-      contentSignature: string,
-      rootId?: string,
-      chosenAttribution?: ChosenAttributionRequest,
-    ) => {
-      try {
-        const result = await confirm({
-          inboxItemId: item.inboxItemId,
-          contentSignature,
-          rootAbsolutePath: item.rootAbsolutePath,
-          destructiveDestination,
-          rootId: rootId ?? null,
-          chosenAttribution,
-        });
-        // Success: clear any pending root pick and capture absolute destinations.
-        setPendingRootPick(null);
-        setRootPickItemId(null);
-        setPendingAttribution(null);
-        mergeDestinations(result.destinations);
-        // spec 041: masters now always return a plan too — every confirm produces
-        // a reviewable plan that appears in the aggregate surface below.
-        addToast({
-          message: m.inbox_toast_plan_created({
-            count: String(result.itemsTotal),
-          }),
-          variant: 'info',
-        });
-        refreshAll();
-      } catch (e) {
-        const { code, message, details } = normalizeConfirmError(e);
-        if (code === 'inbox.destination_root_required') {
-          // FR-029: multiple candidate roots — prompt the user to choose one.
-          const parsed = asRootRequiredDetails(details);
-          if (parsed) {
-            setPendingRootPick({
-              category: parsed.category,
-              candidates: parsed.candidates,
-            });
-            setRootPickItemId(item.inboxItemId);
-            addToast({
-              message: m.inbox_toast_choose_dest_root(),
-              variant: 'warn',
-            });
-            return;
-          }
-        }
-        if (code === 'inbox.invalid_destination_root') {
-          addToast({
-            message: message || m.inbox_toast_invalid_destination_root(),
-            variant: 'error',
-          });
-          return;
-        }
-        if (code === 'inbox.no_destination_root') {
-          addToast({
-            message: message || m.inbox_toast_no_destination_root(),
-            variant: 'error',
-          });
-          return;
-        }
-        if (code === 'inbox.missing_path_attributes') {
-          // FR-032 (US9): files lack a path-load-bearing attribute. The detail
-          // panel already annotates each blocked file; point the user there.
-          addToast({
-            message: m.inbox_toast_missing_path_attrs(),
-            variant: 'warn',
-          });
-          return;
-        }
-        if (message.includes('inbox.has.open.plan')) {
-          addToast({ message: m.inbox_toast_has_open_plan(), variant: 'warn' });
-        } else if (message.includes('classification.stale')) {
-          addToast({
-            message: m.inbox_toast_stale_classification(),
-            variant: 'warn',
-          });
-        } else {
-          addToast({
-            message: m.inbox_toast_confirm_failed({ message }),
-            variant: 'error',
-          });
-        }
-      }
-    },
-    [confirm, destructiveDestination, mergeDestinations, refreshAll],
-  );
-
-  const handleConfirm = async () => {
-    // Spec 058 T035/T036: the `classification.type === "mixed"` guard is gone
-    // with the vocabulary it tested.
-    //
-    // It was accurate when written: `mixed` was reachable only on the
-    // pre-materialization leaf-folder row spanning more than one frame type,
-    // and that row could never be confirmed. T012 stopped creating that row and
-    // T035 retired the label, so the condition can no longer be true — keeping
-    // it would read as a live safeguard while testing a value the backend never
-    // returns. A multi-type folder now reports `unclassified`, which
-    // `canConfirm` already refuses.
-    if (!selectedItem || !classification) return;
-    // Re-entrancy guard (#943 follow-up): covers this whole function,
-    // including the suggest await below — see `confirmFlowBusy`'s
-    // declaration for why `confirmLoading` alone isn't enough.
-    if (confirmFlowBusy) return;
-    setConfirmFlowBusy(true);
-    try {
-      // "" = auto-select (let the backend choose); otherwise the picked root.
-      const rootId = selectedDestRootId || undefined;
-
-      // spec 008 US7/FR-019 (#943): read the ranked attribution suggestions
-      // BEFORE confirming, so the user's pick can ride this single confirm.
-      // Suggest-never-auto-merge (FR-020) — a non-empty list always stops here
-      // for an explicit pick; it is never applied on the user's behalf.
-      // A suggest failure must not cost the user their confirm: attribution is
-      // an optional enrichment, so fall through to an unattributed confirm —
-      // but the failure is logged (not just swallowed), so a suggest-side
-      // regression stays diagnosable instead of looking like "no candidates".
-      //
-      // GFD-1: read from the prefetch cache first to avoid a blocking round-trip
-      // on the hot Confirm path. Falls back to an awaited call if the prefetch
-      // hasn't landed yet (e.g. the user clicks Confirm before classify settles).
-      let candidates: IngestionAttributionCandidateDto[] = [];
-      try {
-        const cached = queryClient.getQueryData<
-          IngestionAttributionCandidateDto[]
-        >(queryKeys.inbox.attributionSuggest(selectedItem.inboxItemId));
-        if (cached !== undefined) {
-          candidates = cached;
-        } else {
-          candidates = unwrap(
-            await commands.inboxAttributionSuggest(selectedItem.inboxItemId),
-          );
-        }
-      } catch (err) {
-        console.error(
-          `inbox.attribution.suggest failed for item ${selectedItem.inboxItemId}; confirming without an attribution pick`,
-          err,
-        );
-        candidates = [];
-      }
-      if (candidates.length > 0) {
-        setPendingAttribution({
-          itemId: selectedItem.inboxItemId,
-          rootAbsolutePath: selectedRootPath,
-          contentSignature: classification.contentSignature,
-          rootId,
-          candidates,
-        });
-        return;
-      }
-
-      await runConfirm(
-        {
-          inboxItemId: selectedItem.inboxItemId,
-          rootAbsolutePath: selectedRootPath,
-        },
-        classification.contentSignature,
-        rootId,
-      );
-    } finally {
-      setConfirmFlowBusy(false);
-    }
-  };
-
-  // The candidate DTO carries project/framing ids only, so resolve display
-  // names client-side rather than widening the contract. Fetched only while a
-  // pick is pending; falls back to the raw id if a name is unavailable.
-  const { data: attributionProjects } = useQuery({
-    queryKey: queryKeys.projects.all(),
-    queryFn: async () => unwrap(await commands.projectsList(null)),
-    enabled: pendingAttribution != null,
-  });
-  const attributionProjectNames = useMemo(() => {
-    const out: Record<string, string> = {};
-    for (const p of attributionProjects ?? []) out[p.id] = p.name;
-    return out;
-  }, [attributionProjects]);
-
-  /** FR-022: confirm the pending item carrying the user's attribution pick. */
-  const handlePickAttribution = async (chosen: ChosenAttributionRequest) => {
-    const pending = pendingAttribution;
-    if (!pending) return;
-    await runConfirm(
-      {
-        inboxItemId: pending.itemId,
-        rootAbsolutePath: pending.rootAbsolutePath,
-      },
-      pending.contentSignature,
-      pending.rootId,
-      chosen,
-    );
-  };
-
-  // task 35: bulk-confirm all cleanly-classified detections in sequence.
-  // "Cleanly classified" = state is 'classified', no open plan, and
-  // classification.type is 'single_type' (not mixed / unclassified). We use
-  // the item's contentSignature from the list (same value InboxPage uses for
-  // the single-item confirm) and always pass action='confirm' (never 'split').
-  // Items that fail individually are reported; the rest proceed.
-  const [bulkConfirmLoading, setBulkConfirmLoading] = useState(false);
-
-  // Eligible items: classified state, no plan open, not a mixed type.
-  // We only know classification type per-item when it is loaded; the list item
-  // carries `state` and `contentSignature`, so we filter on those. The backend
-  // will reject anything that turns out to be unclassified or missing attrs, and
-  // each failure produces a toast. This matches the pattern for rescan.
-  const bulkEligibleItems = useMemo(
-    () => items.filter((it) => it.state === 'classified'),
-    [items],
-  );
-
-  const canBulkConfirm = bulkEligibleItems.length > 0 && !bulkConfirmLoading;
-
-  const handleBulkConfirm = async () => {
-    if (bulkEligibleItems.length === 0) return;
-    setBulkConfirmLoading(true);
-    let successCount = 0;
-    let failCount = 0;
-    for (const it of bulkEligibleItems) {
-      try {
-        await confirm({
-          inboxItemId: it.inboxItemId,
-          contentSignature: it.contentSignature,
-          rootAbsolutePath: it.rootAbsolutePath,
-          destructiveDestination,
-          rootId: null,
-        });
-        successCount += 1;
-      } catch {
-        failCount += 1;
-      }
-    }
-    setBulkConfirmLoading(false);
-    if (failCount > 0 && successCount > 0) {
-      addToast({
-        message: m.inbox_toast_bulk_partial({
-          success: String(successCount),
-          fail: String(failCount),
-        }),
-        variant: 'warn',
-      });
-    } else if (failCount > 0 && successCount === 0) {
-      addToast({
-        message: m.inbox_toast_bulk_all_need_review(),
-        variant: 'warn',
-      });
-    } else {
-      addToast({
-        message: m.inbox_toast_bulk_confirmed({
-          count: successCount,
-        }),
-        variant: 'info',
-      });
-    }
-    refreshAll();
-  };
-
-  /** FR-029: re-confirm the pending item with the chosen destination root. */
-  const handlePickDestinationRoot = async (rootId: string) => {
-    if (!rootPickItemId || !selectedItem || !classification) return;
-    if (selectedItem.inboxItemId !== rootPickItemId) return;
-    // Spec 058 T035: the companion `mixed` guard is gone here too. It can no
-    // longer be true, and a guard that cannot fire reads as protection while
-    // providing none. A multi-type folder reports `unclassified`, which confirm
-    // already rejects before root resolution runs.
-    await runConfirm(
-      {
-        inboxItemId: selectedItem.inboxItemId,
-        rootAbsolutePath: selectedRootPath,
-      },
-      classification.contentSignature,
-      rootId,
-    );
-  };
-
-
-  const hasOpenPlan = selectedItem?.state === 'plan_open';
-
-  // Confirm gating (spec 043 §4 / task #34): MISSING REQUIRED metadata blocks
-  // confirm — any file lacking a path-load-bearing attribute cannot be routed
-  // to a destination, so the backend rejects it (inbox.missing_path_attributes).
-  // Disable confirm up-front and let the detail pane's danger alert explain why.
-  const hasMissingRequiredMeta = useMemo(
-    () =>
-      (fileMetadata ?? []).some(
-        (f) => (f.missingPathAttributes?.length ?? 0) > 0,
-      ),
-    [fileMetadata],
-  );
-
-  // spec 041 T071/T072 (FR-050): only "single_type" rows are confirmable. A
-  // folder spanning several frame types is not one thing to confirm, so it
-  // reports "unclassified" and confirm stays disabled. Spec 058 T035 retired
-  // the separate "mixed" label; the rows it described are the sub-items
-  // materialization produces, each single-type and confirmable on its own.
-  // Issue #643: while per-file metadata is loading or failed to load, we
-  // cannot know whether mandatory attributes are missing — fail safe by
-  // keeping Confirm disabled instead of judging over an empty array.
-  const canConfirm =
-    !!selectedItem &&
-    !!classification &&
-    classification.type === 'single_type' &&
-    !fileMetadataLoading &&
-    !fileMetadataError &&
-    !hasMissingRequiredMeta &&
-    !hasOpenPlan;
-
-  // Spec 027 FR-022 (issue #747): confirm the selected detection from the
-  // keyboard, so a triage sweep never leaves the home row. Gated on the same
-  // `canConfirm` as the button — the shortcut must not reach a state the
-  // visible affordance refuses. J/K navigation lives in InboxList, which owns
-  // the visual row order.
-  useHotkeys(
-    {
-      KeyC: (e) => {
-        if (!canConfirm || confirmLoading || confirmFlowBusy) return;
-        e.preventDefault();
-        void handleConfirm();
-      },
-    },
-    [canConfirm, confirmLoading, confirmFlowBusy, handleConfirm],
-  );
 
 
   // Stage B: plan review overlay open/close state.
@@ -1484,7 +1068,7 @@ export function InboxPage() {
           projectNames={attributionProjectNames}
           busy={confirmLoading}
           onPick={(chosen) => void handlePickAttribution(chosen)}
-          onCancel={() => setPendingAttribution(null)}
+          onCancel={clearPendingAttribution}
         />
       )}
 

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -79,7 +79,6 @@ import {
   useOpenInboxPlans,
 } from './store';
 
-
 // Re-export pure selection-handoff functions (tested via this path).
 export {
   pickReclassifyTarget,
@@ -90,7 +89,6 @@ export type {
   ReclassifyHandoffDecision,
   ClassifiedGroupSelection,
 } from './inboxSelectionModel';
-
 
 // #557: a shared, stable empty-array fallback. `listData?.items ?? []`
 // allocates a NEW array every render while the query is unresolved, which
@@ -455,7 +453,6 @@ export function InboxPage() {
     selectedRootPath,
   );
 
-
   // Group-scoped classification for scanned-but-unclassified folders
   // (spec 058 FR-017). Unlike the item-scoped hook above this does NOT fire on
   // selection — a source-group row is not selectable — so it is driven by an
@@ -570,7 +567,6 @@ export function InboxPage() {
     refreshAll,
   });
 
-
   const {
     handleApplyOne,
     handleApplyAll,
@@ -580,7 +576,6 @@ export function InboxPage() {
     progressPlanId,
     planBusy,
   } = useInboxPlanApplyFlow(refreshAll, viewResultAction);
-
 
   // Stage B: plan review overlay open/close state.
   const [planOverlayOpen, setPlanOverlayOpen] = useState(false);

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -45,7 +45,7 @@ import type {
 } from '@/bindings/index';
 import { useSetPageStatus } from '@/app/PageStatusContext';
 import { FilterToolbar, ListPageLayout, PageTopBar } from '@/components';
-import { usePlanApplyProgress } from '@/features/plans/usePlanApplyProgress';
+import { useInboxPlanApplyFlow } from './useInboxPlanApplyFlow';
 import { m } from '@/lib/i18n';
 import type { FrameType } from '@/lib/route-contract';
 import { useGrouping } from '@/lib/use-grouping';
@@ -72,15 +72,12 @@ import {
   inboxClassifyQueryKey,
   mergeRescanRoots,
   normalizeConfirmError,
-  useApplySelectedInboxPlans,
   useInboxClassification,
   useInboxClassifySourceGroup,
   useInboxConfirm,
   useInboxItemMetadata,
   useInboxList,
-  useInboxPlanApplyAll,
   useInboxPlanBreakdowns,
-  useInboxPlanCancel,
   useInboxRescan,
   useOpenInboxPlans,
 } from './store';
@@ -751,14 +748,15 @@ export function InboxPage() {
     [],
   );
 
-  const { applyAll, loading: applyAllLoading } = useInboxPlanApplyAll();
-  const { applySelected, loading: applySelectedLoading } =
-    useApplySelectedInboxPlans();
-  const { cancel, loading: cancelLoading } = useInboxPlanCancel();
-  // Live long-op progress consumer (spec 042 US16 / FR-021): streams per-item
-  // OperationEvents over the channel when applying a single ingestion plan.
-  const { progress: applyProgress, run: runPlanApply } = usePlanApplyProgress();
-  const [progressPlanId, setProgressPlanId] = useState<string | null>(null);
+  const {
+    handleApplyOne,
+    handleApplyAll,
+    handleApplySelected,
+    handleCancel,
+    applyProgress,
+    progressPlanId,
+    planBusy,
+  } = useInboxPlanApplyFlow(refreshAll, viewResultAction);
 
   /**
    * Confirm `item` (optionally targeting a caller-chosen destination `rootId`).
@@ -1041,115 +1039,6 @@ export function InboxPage() {
     );
   };
 
-  const handleApplySelected = async (inboxItemIds: string[]) => {
-    if (inboxItemIds.length === 0) return;
-    const result = await applySelected(inboxItemIds);
-    if (result) {
-      const failed = result.results.filter((r) => r.error != null).length;
-      if (failed > 0) {
-        addToast({
-          message: m.inbox_toast_plans_partial({
-            applied: String(result.results.length - failed),
-            failed: String(failed),
-          }),
-          variant: 'warn',
-        });
-      } else {
-        addToast({
-          message: m.inbox_toast_plans_applying({
-            count: String(result.results.length),
-          }),
-          variant: 'info',
-          // #871: no direct way to reach the moved items/updated inventory
-          // after apply — the user had to find it manually. Both bulk apply
-          // commands complete synchronously (no live progress channel), so
-          // the plans ARE already applied by the time this toast shows.
-          action: viewResultAction(),
-        });
-      }
-      refreshAll();
-    } else {
-      addToast({ message: m.inbox_toast_apply_failed(), variant: 'error' });
-    }
-  };
-
-  const handleApplyAll = async () => {
-    const result = await applyAll();
-    if (result) {
-      const failed = result.results.filter((r) => r.error != null).length;
-      if (failed > 0) {
-        addToast({
-          message: m.inbox_toast_all_plans_partial({
-            applied: String(result.results.length - failed),
-            failed: String(failed),
-          }),
-          variant: 'warn',
-        });
-      } else {
-        addToast({
-          message: m.inbox_toast_all_plans_applying({
-            count: String(result.results.length),
-          }),
-          variant: 'info',
-          action: viewResultAction(),
-        });
-      }
-      refreshAll();
-    }
-  };
-
-  // Apply a single ingestion plan with live per-item progress streamed over
-  // the long-operation OperationEvent channel (spec 042 US16 / FR-021). This is
-  // the end-to-end consumer of the channel contract on the inbox plan surface.
-  //
-  // Issue #769: a freshly-confirmed plan is `ready_for_review` with no
-  // `approval_token` — `plans.apply` unconditionally rejects any plan that
-  // isn't `approved`. Approve it first (same precondition "Apply all" already
-  // satisfies via its own backend command) and thread the returned token
-  // through, otherwise this always fails with `plan.invalid_state` before any
-  // item is touched.
-  const handleApplyOne = async (planId: string) => {
-    setProgressPlanId(planId);
-    let approvalToken: string | undefined;
-    try {
-      approvalToken = unwrap(await commands.plansApprove(planId)).approvalToken;
-    } catch {
-      // runPlanApply (the success path below) resets progress to IDLE on its
-      // own; skipping it here means a stale progressPlanId from a previously
-      // applied plan would otherwise keep pointing a progress display at this
-      // now-failed row.
-      setProgressPlanId(null);
-      addToast({
-        message: m.inbox_plan_apply_failed_toast(),
-        variant: 'error',
-      });
-      return;
-    }
-    const response = await runPlanApply({ id: planId, approvalToken });
-    // GF-30: Clear the pre-flight busy guard once runPlanApply returns.
-    // applyProgress.running covers the in-flight window; progressPlanId is
-    // only needed for the approve→channel-open gap before running goes true.
-    setProgressPlanId(null);
-    if (response) {
-      addToast({
-        message: m.inbox_plan_applied_toast(),
-        variant: 'info',
-        action: viewResultAction(),
-      });
-      refreshAll();
-    } else {
-      addToast({
-        message: m.inbox_plan_apply_failed_toast(),
-        variant: 'error',
-      });
-    }
-  };
-
-  const handleCancel = async (inboxItemId: string) => {
-    await cancel(inboxItemId);
-    addToast({ message: m.inbox_toast_plan_discarded(), variant: 'info' });
-    refreshAll();
-  };
 
   const hasOpenPlan = selectedItem?.state === 'plan_open';
 
@@ -1198,14 +1087,6 @@ export function InboxPage() {
     [canConfirm, confirmLoading, confirmFlowBusy, handleConfirm],
   );
 
-  // GF-30: Include progressPlanId in busy derivation — the approve→apply
-  // window between setProgressPlanId and runPlanApply completing was previously
-  // unguarded, allowing double-submit of the same plan.
-  const planBusy =
-    applyAllLoading ||
-    applySelectedLoading ||
-    cancelLoading ||
-    progressPlanId != null;
 
   // Stage B: plan review overlay open/close state.
   const [planOverlayOpen, setPlanOverlayOpen] = useState(false);

--- a/apps/desktop/src/features/inbox/InboxPage.tsx
+++ b/apps/desktop/src/features/inbox/InboxPage.tsx
@@ -40,6 +40,11 @@ import { queryKeys } from '@/data/queryKeys';
 import type { InboxReclassifyV2Response_Serialize as InboxReclassifyV2Response } from '@/bindings/index';
 import { useSetPageStatus } from '@/app/PageStatusContext';
 import { FilterToolbar, ListPageLayout, PageTopBar } from '@/components';
+import {
+  pickReclassifyTarget,
+  resolveClassifiedGroupSelection,
+  resolveReclassifyHandoff,
+} from './inboxSelectionModel';
 import { useInboxConfirmFlow } from './useInboxConfirmFlow';
 import { useInboxPlanApplyFlow } from './useInboxPlanApplyFlow';
 import { m } from '@/lib/i18n';
@@ -75,111 +80,16 @@ import {
 } from './store';
 
 
-/**
- * Pick which post-split sub-item selection should move to after a
- * `reclassify_v2` call (issue #755 CI fix, R-14 re-split). Prefers the
- * response's own resolved (single-type, no missing-mandatory) sub-items over
- * re-deriving a target from list state — the response is authoritative for
- * what the group split into; the item list is only an async projection of
- * it. Ties (equal frameType groups) break on file count, since a bulk edit's
- * largest resulting group is the one the user was most likely acting on.
- * Returns `null` when every sub-item is still needs-review (no safe target).
- */
-export function pickReclassifyTarget(
-  subItems: Array<{
-    inboxItemId: string;
-    frameType?: string | null;
-    fileCount: number;
-    missingMandatory?: string[] | null;
-  }>,
-): string | null {
-  const resolved = subItems.filter(
-    (si) => si.frameType != null && (si.missingMandatory?.length ?? 0) === 0,
-  );
-  if (resolved.length === 0) return null;
-  return resolved.reduce((best, si) =>
-    si.fileCount > best.fileCount ? si : best,
-  ).inboxItemId;
-}
-
-/** Outcome of {@link resolveReclassifyHandoff}: keep waiting, navigate, or give up. */
-export type ReclassifyHandoffDecision =
-  | { action: 'wait' }
-  | { action: 'navigate'; id: string }
-  | { action: 'giveUp' };
-
-/**
- * Decide what the post-split selection handoff should do THIS render (issue
- * #755 CI fix round 3; adapted for issue #644's id-based `?selected=<id>`
- * scheme — selection is no longer a list index, so there is no index to
- * navigate to, only the id itself, once it's confirmed reachable). Bounded
- * lifetime: `pendingId` must not stay set forever just because the active
- * search/kind filter happens to hide the post-split item — that would gate
- * `useStaleSelectionCleanup` open indefinitely for everything else on the
- * page.
- *
- * Judges "arrived" vs "genuinely not coming back" against the UNFILTERED
- * `items` list (only once it has settled — `listLoading === false` — so a
- * refetch already in flight isn't mistaken for "never arriving"). Once
- * settled: absent from `items` entirely → give up (nothing will ever
- * appear); present in `items` but absent from `filteredItems` → give up too
- * (it exists, but the user's own filter hides it — there is nothing visible
- * to select); present in both → navigate to it by id.
- */
-export function resolveReclassifyHandoff(
-  pendingId: string,
-  items: Array<{ inboxItemId: string }>,
-  filteredItems: Array<{ inboxItemId: string }>,
-  listLoading: boolean,
-): ReclassifyHandoffDecision {
-  if (listLoading) return { action: 'wait' };
-  if (!items.some((it) => it.inboxItemId === pendingId)) {
-    return { action: 'giveUp' };
-  }
-  const visible = filteredItems.some((it) => it.inboxItemId === pendingId);
-  return visible ? { action: 'navigate', id: pendingId } : { action: 'giveUp' };
-}
-
-/** Outcome of {@link resolveClassifiedGroupSelection}. */
-export type ClassifiedGroupSelection =
-  | { action: 'wait' }
-  | { action: 'select'; id: string }
-  | { action: 'none' };
-
-/**
- * CHK011 (spec 058 T017/FR-023): where selection goes when a source-group row
- * is replaced by the items classification materialized from it.
- *
- * The rule is deliberately asymmetric:
- *
- *  - **N = 1** — select that item. The folder resolved to exactly one thing, so
- *    putting the user on it is unambiguous and saves a click.
- *  - **N > 1** — select NOTHING here. The rule says the folder group header,
- *    never a sibling, because picking one sibling would silently designate a
- *    primary — the thing D-002 forbids and which #1102 deleted `ids.next()` to
- *    avoid. The header is part of T034's grouping UI and does not exist yet, so
- *    selecting nothing is the correct conservative behaviour until it does.
- *    Selecting a sibling now would be actively wrong, not merely early.
- *  - **N = 0** — nothing to select. A source-group row was never selectable
- *    (FR-016), so unlike the reclassify handoff there is no prior selection to
- *    restore or lose.
- *
- * Bounded the same way {@link resolveReclassifyHandoff} is: it only decides
- * once the list has settled, so an in-flight refetch is never mistaken for
- * "the items never arrived".
- */
-export function resolveClassifiedGroupSelection(
-  sourceGroupId: string,
-  items: Array<{ inboxItemId: string; sourceGroupId?: string | null }>,
-  listLoading: boolean,
-): ClassifiedGroupSelection {
-  if (listLoading) return { action: 'wait' };
-  const siblings = items.filter((it) => it.sourceGroupId === sourceGroupId);
-  if (siblings.length === 1) {
-    return { action: 'select', id: siblings[0].inboxItemId };
-  }
-  return { action: 'none' };
-}
+// Re-export pure selection-handoff functions (tested via this path).
+export {
+  pickReclassifyTarget,
+  resolveReclassifyHandoff,
+  resolveClassifiedGroupSelection,
+} from './inboxSelectionModel';
+export type {
+  ReclassifyHandoffDecision,
+  ClassifiedGroupSelection,
+} from './inboxSelectionModel';
 
 
 // #557: a shared, stable empty-array fallback. `listData?.items ?? []`

--- a/apps/desktop/src/features/inbox/inboxSelectionModel.ts
+++ b/apps/desktop/src/features/inbox/inboxSelectionModel.ts
@@ -1,0 +1,113 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Pure selection-handoff decision functions for the inbox page. These run
+ * during render (no side effects, no hooks) and are tested independently.
+ */
+
+/**
+ * Pick which post-split sub-item selection should move to after a
+ * `reclassify_v2` call (issue #755 CI fix, R-14 re-split). Prefers the
+ * response's own resolved (single-type, no missing-mandatory) sub-items over
+ * re-deriving a target from list state — the response is authoritative for
+ * what the group split into; the item list is only an async projection of
+ * it. Ties (equal frameType groups) break on file count, since a bulk edit's
+ * largest resulting group is the one the user was most likely acting on.
+ * Returns `null` when every sub-item is still needs-review (no safe target).
+ */
+export function pickReclassifyTarget(
+  subItems: Array<{
+    inboxItemId: string;
+    frameType?: string | null;
+    fileCount: number;
+    missingMandatory?: string[] | null;
+  }>,
+): string | null {
+  const resolved = subItems.filter(
+    (si) => si.frameType != null && (si.missingMandatory?.length ?? 0) === 0,
+  );
+  if (resolved.length === 0) return null;
+  return resolved.reduce((best, si) =>
+    si.fileCount > best.fileCount ? si : best,
+  ).inboxItemId;
+}
+
+/** Outcome of {@link resolveReclassifyHandoff}: keep waiting, navigate, or give up. */
+export type ReclassifyHandoffDecision =
+  | { action: 'wait' }
+  | { action: 'navigate'; id: string }
+  | { action: 'giveUp' };
+
+/**
+ * Decide what the post-split selection handoff should do THIS render (issue
+ * #755 CI fix round 3; adapted for issue #644's id-based `?selected=<id>`
+ * scheme — selection is no longer a list index, so there is no index to
+ * navigate to, only the id itself, once it's confirmed reachable). Bounded
+ * lifetime: `pendingId` must not stay set forever just because the active
+ * search/kind filter happens to hide the post-split item — that would gate
+ * `useStaleSelectionCleanup` open indefinitely for everything else on the
+ * page.
+ *
+ * Judges "arrived" vs "genuinely not coming back" against the UNFILTERED
+ * `items` list (only once it has settled — `listLoading === false` — so a
+ * refetch already in flight isn't mistaken for "never arriving"). Once
+ * settled: absent from `items` entirely → give up (nothing will ever
+ * appear); present in `items` but absent from `filteredItems` → give up too
+ * (it exists, but the user's own filter hides it — there is nothing visible
+ * to select); present in both → navigate to it by id.
+ */
+export function resolveReclassifyHandoff(
+  pendingId: string,
+  items: Array<{ inboxItemId: string }>,
+  filteredItems: Array<{ inboxItemId: string }>,
+  listLoading: boolean,
+): ReclassifyHandoffDecision {
+  if (listLoading) return { action: 'wait' };
+  if (!items.some((it) => it.inboxItemId === pendingId)) {
+    return { action: 'giveUp' };
+  }
+  const visible = filteredItems.some((it) => it.inboxItemId === pendingId);
+  return visible ? { action: 'navigate', id: pendingId } : { action: 'giveUp' };
+}
+
+/** Outcome of {@link resolveClassifiedGroupSelection}. */
+export type ClassifiedGroupSelection =
+  | { action: 'wait' }
+  | { action: 'select'; id: string }
+  | { action: 'none' };
+
+/**
+ * CHK011 (spec 058 T017/FR-023): where selection goes when a source-group row
+ * is replaced by the items classification materialized from it.
+ *
+ * The rule is deliberately asymmetric:
+ *
+ *  - **N = 1** — select that item. The folder resolved to exactly one thing, so
+ *    putting the user on it is unambiguous and saves a click.
+ *  - **N > 1** — select NOTHING here. The rule says the folder group header,
+ *    never a sibling, because picking one sibling would silently designate a
+ *    primary — the thing D-002 forbids and which #1102 deleted `ids.next()` to
+ *    avoid. The header is part of T034's grouping UI and does not exist yet, so
+ *    selecting nothing is the correct conservative behaviour until it does.
+ *    Selecting a sibling now would be actively wrong, not merely early.
+ *  - **N = 0** — nothing to select. A source-group row was never selectable
+ *    (FR-016), so unlike the reclassify handoff there is no prior selection to
+ *    restore or lose.
+ *
+ * Bounded the same way {@link resolveReclassifyHandoff} is: it only decides
+ * once the list has settled, so an in-flight refetch is never mistaken for
+ * "the items never arrived".
+ */
+export function resolveClassifiedGroupSelection(
+  sourceGroupId: string,
+  items: Array<{ inboxItemId: string; sourceGroupId?: string | null }>,
+  listLoading: boolean,
+): ClassifiedGroupSelection {
+  if (listLoading) return { action: 'wait' };
+  const siblings = items.filter((it) => it.sourceGroupId === sourceGroupId);
+  if (siblings.length === 1) {
+    return { action: 'select', id: siblings[0].inboxItemId };
+  }
+  return { action: 'none' };
+}

--- a/apps/desktop/src/features/inbox/useInboxConfirmFlow.ts
+++ b/apps/desktop/src/features/inbox/useInboxConfirmFlow.ts
@@ -1,0 +1,443 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * useInboxConfirmFlow — confirm lifecycle (single + bulk), attribution
+ * prefetch/pick, destination-root pick, and all associated transient state.
+ */
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import { queryKeys } from '@/data/queryKeys';
+import type {
+  ChosenAttributionDto_Deserialize as ChosenAttributionRequest,
+  IngestionAttributionCandidateDto,
+  InboxConfirmDestination,
+} from '@/bindings/index';
+import { m } from '@/lib/i18n';
+import { useHotkeys } from '@/lib/useHotkeys';
+import { addToast } from '@/shared/toast';
+import type { DestructiveDestination, PendingRootPick } from './PlanPanel';
+import type { InboxListItem } from './store';
+import { normalizeConfirmError, useInboxConfirm } from './store';
+
+/** Shape of `inbox.destination_root_required` error details (spec 041 US8/FR-029). */
+interface DestinationRootRequiredDetails {
+  category: string;
+  candidates: Array<{ rootId: string; path: string; kind: string }>;
+}
+
+function asRootRequiredDetails(
+  d: unknown,
+): DestinationRootRequiredDetails | null {
+  if (
+    d &&
+    typeof d === 'object' &&
+    'candidates' in d &&
+    Array.isArray(d.candidates)
+  ) {
+    return d as DestinationRootRequiredDetails;
+  }
+  return null;
+}
+
+export interface ConfirmFlowDeps {
+  selectedItem: InboxListItem | undefined;
+  selectedRootPath: string;
+  classification: {
+    contentSignature: string;
+    type: string;
+    breakdown: Array<{ kind: string; count: number }>;
+  } | null | undefined;
+  fileMetadataLoading: boolean;
+  fileMetadataError: unknown;
+  hasMissingRequiredMeta: boolean;
+  items: InboxListItem[];
+  refreshAll: () => void;
+}
+
+export interface ConfirmFlowResult {
+  handleConfirm: () => Promise<void>;
+  handlePickAttribution: (chosen: ChosenAttributionRequest) => Promise<void>;
+  handlePickDestinationRoot: (rootId: string) => Promise<void>;
+  handleBulkConfirm: () => Promise<void>;
+  canConfirm: boolean;
+  confirmLoading: boolean;
+  confirmFlowBusy: boolean;
+  bulkConfirmLoading: boolean;
+  canBulkConfirm: boolean;
+  bulkEligibleItems: InboxListItem[];
+  destructiveDestination: DestructiveDestination;
+  setDestructiveDestination: (d: DestructiveDestination) => void;
+  selectedDestRootId: string;
+  setSelectedDestRootId: (id: string) => void;
+  pendingRootPick: PendingRootPick | null;
+  pendingAttribution: {
+    itemId: string;
+    rootAbsolutePath: string;
+    contentSignature: string;
+    rootId?: string;
+    candidates: IngestionAttributionCandidateDto[];
+  } | null;
+  clearPendingAttribution: () => void;
+  attributionProjectNames: Record<string, string>;
+  absoluteByFromPath: Record<string, string>;
+}
+
+export function useInboxConfirmFlow(deps: ConfirmFlowDeps): ConfirmFlowResult {
+  const {
+    selectedItem,
+    selectedRootPath,
+    classification,
+    fileMetadataLoading,
+    fileMetadataError,
+    hasMissingRequiredMeta,
+    items,
+    refreshAll,
+  } = deps;
+
+  const queryClient = useQueryClient();
+  const { confirm, loading: confirmLoading } = useInboxConfirm();
+
+  const [destructiveDestination, setDestructiveDestination] =
+    useState<DestructiveDestination>('archive');
+  const [confirmFlowBusy, setConfirmFlowBusy] = useState(false);
+  const [pendingRootPick, setPendingRootPick] =
+    useState<PendingRootPick | null>(null);
+  const [rootPickItemId, setRootPickItemId] = useState<string | null>(null);
+  const [pendingAttribution, setPendingAttribution] = useState<{
+    itemId: string;
+    rootAbsolutePath: string;
+    contentSignature: string;
+    rootId?: string;
+    candidates: IngestionAttributionCandidateDto[];
+  } | null>(null);
+  const [absoluteByFromPath, setAbsoluteByFromPath] = useState<
+    Record<string, string>
+  >({});
+  const [selectedDestRootId, setSelectedDestRootId] = useState('');
+  const [bulkConfirmLoading, setBulkConfirmLoading] = useState(false);
+
+  const selectedItemId = selectedItem?.inboxItemId ?? null;
+
+  // Drop a pending root pick when the user navigates away from its item.
+  useEffect(() => {
+    if (rootPickItemId && rootPickItemId !== selectedItemId) {
+      setPendingRootPick(null);
+      setRootPickItemId(null);
+    }
+  }, [rootPickItemId, selectedItemId]);
+
+  // #648: Reset dest root on selection change.
+  useEffect(() => {
+    setSelectedDestRootId('');
+  }, [selectedItemId]);
+
+  const mergeDestinations = useCallback(
+    (destinations?: InboxConfirmDestination[] | null) => {
+      if (!destinations || destinations.length === 0) return;
+      setAbsoluteByFromPath((prev) => {
+        const next = { ...prev };
+        for (const d of destinations) {
+          next[d.fromPath] = d.toAbsolutePath;
+        }
+        return next;
+      });
+    },
+    [],
+  );
+
+  const runConfirm = useCallback(
+    async (
+      item: { inboxItemId: string; rootAbsolutePath: string },
+      contentSignature: string,
+      rootId?: string,
+      chosenAttribution?: ChosenAttributionRequest,
+    ) => {
+      try {
+        const result = await confirm({
+          inboxItemId: item.inboxItemId,
+          contentSignature,
+          rootAbsolutePath: item.rootAbsolutePath,
+          destructiveDestination,
+          rootId: rootId ?? null,
+          chosenAttribution,
+        });
+        setPendingRootPick(null);
+        setRootPickItemId(null);
+        setPendingAttribution(null);
+        mergeDestinations(result.destinations);
+        addToast({
+          message: m.inbox_toast_plan_created({
+            count: String(result.itemsTotal),
+          }),
+          variant: 'info',
+        });
+        refreshAll();
+      } catch (e) {
+        const { code, message, details } = normalizeConfirmError(e);
+        if (code === 'inbox.destination_root_required') {
+          const parsed = asRootRequiredDetails(details);
+          if (parsed) {
+            setPendingRootPick({
+              category: parsed.category,
+              candidates: parsed.candidates,
+            });
+            setRootPickItemId(item.inboxItemId);
+            addToast({
+              message: m.inbox_toast_choose_dest_root(),
+              variant: 'warn',
+            });
+            return;
+          }
+        }
+        if (code === 'inbox.invalid_destination_root') {
+          addToast({
+            message: message || m.inbox_toast_invalid_destination_root(),
+            variant: 'error',
+          });
+          return;
+        }
+        if (code === 'inbox.no_destination_root') {
+          addToast({
+            message: message || m.inbox_toast_no_destination_root(),
+            variant: 'error',
+          });
+          return;
+        }
+        if (code === 'inbox.missing_path_attributes') {
+          addToast({
+            message: m.inbox_toast_missing_path_attrs(),
+            variant: 'warn',
+          });
+          return;
+        }
+        if (message.includes('inbox.has.open.plan')) {
+          addToast({ message: m.inbox_toast_has_open_plan(), variant: 'warn' });
+        } else if (message.includes('classification.stale')) {
+          addToast({
+            message: m.inbox_toast_stale_classification(),
+            variant: 'warn',
+          });
+        } else {
+          addToast({
+            message: m.inbox_toast_confirm_failed({ message }),
+            variant: 'error',
+          });
+        }
+      }
+    },
+    [confirm, destructiveDestination, mergeDestinations, refreshAll],
+  );
+
+  // GFD-1: prefetch attribution candidates alongside classify.
+  const selectedItemIdForPrefetch = selectedItem?.inboxItemId ?? null;
+  useEffect(() => {
+    if (!selectedItemIdForPrefetch) return;
+    void queryClient.prefetchQuery({
+      queryKey: queryKeys.inbox.attributionSuggest(selectedItemIdForPrefetch),
+      queryFn: async () =>
+        unwrap(
+          await commands.inboxAttributionSuggest(selectedItemIdForPrefetch),
+        ),
+    });
+  }, [selectedItemIdForPrefetch, queryClient]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!selectedItem || !classification) return;
+    if (confirmFlowBusy) return;
+    setConfirmFlowBusy(true);
+    try {
+      const rootId = selectedDestRootId || undefined;
+      let candidates: IngestionAttributionCandidateDto[] = [];
+      try {
+        const cached = queryClient.getQueryData<
+          IngestionAttributionCandidateDto[]
+        >(queryKeys.inbox.attributionSuggest(selectedItem.inboxItemId));
+        if (cached !== undefined) {
+          candidates = cached;
+        } else {
+          candidates = unwrap(
+            await commands.inboxAttributionSuggest(selectedItem.inboxItemId),
+          );
+        }
+      } catch (err) {
+        console.error(
+          `inbox.attribution.suggest failed for item ${selectedItem.inboxItemId}; confirming without an attribution pick`,
+          err,
+        );
+        candidates = [];
+      }
+      if (candidates.length > 0) {
+        setPendingAttribution({
+          itemId: selectedItem.inboxItemId,
+          rootAbsolutePath: selectedRootPath,
+          contentSignature: classification.contentSignature,
+          rootId,
+          candidates,
+        });
+        return;
+      }
+      await runConfirm(
+        {
+          inboxItemId: selectedItem.inboxItemId,
+          rootAbsolutePath: selectedRootPath,
+        },
+        classification.contentSignature,
+        rootId,
+      );
+    } finally {
+      setConfirmFlowBusy(false);
+    }
+  }, [
+    selectedItem,
+    classification,
+    confirmFlowBusy,
+    selectedDestRootId,
+    selectedRootPath,
+    queryClient,
+    runConfirm,
+  ]);
+
+  // Attribution project names for the picker.
+  const { data: attributionProjects } = useQuery({
+    queryKey: queryKeys.projects.all(),
+    queryFn: async () => unwrap(await commands.projectsList(null)),
+    enabled: pendingAttribution != null,
+  });
+  const attributionProjectNames = useMemo(() => {
+    const out: Record<string, string> = {};
+    for (const p of attributionProjects ?? []) out[p.id] = p.name;
+    return out;
+  }, [attributionProjects]);
+
+  const handlePickAttribution = useCallback(
+    async (chosen: ChosenAttributionRequest) => {
+      const pending = pendingAttribution;
+      if (!pending) return;
+      await runConfirm(
+        {
+          inboxItemId: pending.itemId,
+          rootAbsolutePath: pending.rootAbsolutePath,
+        },
+        pending.contentSignature,
+        pending.rootId,
+        chosen,
+      );
+    },
+    [pendingAttribution, runConfirm],
+  );
+
+  const bulkEligibleItems = useMemo(
+    () => items.filter((it) => it.state === 'classified'),
+    [items],
+  );
+  const canBulkConfirm = bulkEligibleItems.length > 0 && !bulkConfirmLoading;
+
+  const handleBulkConfirm = useCallback(async () => {
+    if (bulkEligibleItems.length === 0) return;
+    setBulkConfirmLoading(true);
+    let successCount = 0;
+    let failCount = 0;
+    for (const it of bulkEligibleItems) {
+      try {
+        await confirm({
+          inboxItemId: it.inboxItemId,
+          contentSignature: it.contentSignature,
+          rootAbsolutePath: it.rootAbsolutePath,
+          destructiveDestination,
+          rootId: null,
+        });
+        successCount += 1;
+      } catch {
+        failCount += 1;
+      }
+    }
+    setBulkConfirmLoading(false);
+    if (failCount > 0 && successCount > 0) {
+      addToast({
+        message: m.inbox_toast_bulk_partial({
+          success: String(successCount),
+          fail: String(failCount),
+        }),
+        variant: 'warn',
+      });
+    } else if (failCount > 0 && successCount === 0) {
+      addToast({
+        message: m.inbox_toast_bulk_all_need_review(),
+        variant: 'warn',
+      });
+    } else {
+      addToast({
+        message: m.inbox_toast_bulk_confirmed({
+          count: successCount,
+        }),
+        variant: 'info',
+      });
+    }
+    refreshAll();
+  }, [bulkEligibleItems, confirm, destructiveDestination, refreshAll]);
+
+  const handlePickDestinationRoot = useCallback(
+    async (rootId: string) => {
+      if (!rootPickItemId || !selectedItem || !classification) return;
+      if (selectedItem.inboxItemId !== rootPickItemId) return;
+      await runConfirm(
+        {
+          inboxItemId: selectedItem.inboxItemId,
+          rootAbsolutePath: selectedRootPath,
+        },
+        classification.contentSignature,
+        rootId,
+      );
+    },
+    [rootPickItemId, selectedItem, classification, selectedRootPath, runConfirm],
+  );
+
+  const hasOpenPlan = selectedItem?.state === 'plan_open';
+
+  const canConfirm =
+    !!selectedItem &&
+    !!classification &&
+    classification.type === 'single_type' &&
+    !fileMetadataLoading &&
+    !fileMetadataError &&
+    !hasMissingRequiredMeta &&
+    !hasOpenPlan;
+
+  // Spec 027 FR-022: confirm from keyboard.
+  useHotkeys(
+    {
+      KeyC: (e) => {
+        if (!canConfirm || confirmLoading || confirmFlowBusy) return;
+        e.preventDefault();
+        void handleConfirm();
+      },
+    },
+    [canConfirm, confirmLoading, confirmFlowBusy, handleConfirm],
+  );
+
+  return {
+    handleConfirm,
+    handlePickAttribution,
+    handlePickDestinationRoot,
+    handleBulkConfirm,
+    canConfirm,
+    confirmLoading,
+    confirmFlowBusy,
+    bulkConfirmLoading,
+    canBulkConfirm,
+    bulkEligibleItems,
+    destructiveDestination,
+    setDestructiveDestination,
+    selectedDestRootId,
+    setSelectedDestRootId,
+    pendingRootPick,
+    pendingAttribution,
+    clearPendingAttribution: () => setPendingAttribution(null),
+    attributionProjectNames,
+    absoluteByFromPath,
+  };
+}

--- a/apps/desktop/src/features/inbox/useInboxConfirmFlow.ts
+++ b/apps/desktop/src/features/inbox/useInboxConfirmFlow.ts
@@ -46,11 +46,14 @@ function asRootRequiredDetails(
 export interface ConfirmFlowDeps {
   selectedItem: InboxListItem | undefined;
   selectedRootPath: string;
-  classification: {
-    contentSignature: string;
-    type: string;
-    breakdown: Array<{ kind: string; count: number }>;
-  } | null | undefined;
+  classification:
+    | {
+        contentSignature: string;
+        type: string;
+        breakdown: Array<{ kind: string; count: number }>;
+      }
+    | null
+    | undefined;
   fileMetadataLoading: boolean;
   fileMetadataError: unknown;
   hasMissingRequiredMeta: boolean;
@@ -393,7 +396,13 @@ export function useInboxConfirmFlow(deps: ConfirmFlowDeps): ConfirmFlowResult {
         rootId,
       );
     },
-    [rootPickItemId, selectedItem, classification, selectedRootPath, runConfirm],
+    [
+      rootPickItemId,
+      selectedItem,
+      classification,
+      selectedRootPath,
+      runConfirm,
+    ],
   );
 
   const hasOpenPlan = selectedItem?.state === 'plan_open';

--- a/apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts
+++ b/apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts
@@ -37,8 +37,7 @@ export function useInboxPlanApplyFlow(
   const { applySelected, loading: applySelectedLoading } =
     useApplySelectedInboxPlans();
   const { cancel, loading: cancelLoading } = useInboxPlanCancel();
-  const { progress: applyProgress, run: runPlanApply } =
-    usePlanApplyProgress();
+  const { progress: applyProgress, run: runPlanApply } = usePlanApplyProgress();
   const [progressPlanId, setProgressPlanId] = useState<string | null>(null);
 
   const handleApplyOne = useCallback(

--- a/apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts
+++ b/apps/desktop/src/features/inbox/useInboxPlanApplyFlow.ts
@@ -1,0 +1,161 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * useInboxPlanApplyFlow — plan approval, apply (single/batch/all), cancel,
+ * and live-progress wiring for the inbox page.
+ */
+
+import { useCallback, useState } from 'react';
+import { commands } from '@/bindings/index';
+import { unwrap } from '@/api/ipc';
+import { usePlanApplyProgress } from '@/features/plans/usePlanApplyProgress';
+import { m } from '@/lib/i18n';
+import { addToast } from '@/shared/toast';
+import {
+  useApplySelectedInboxPlans,
+  useInboxPlanApplyAll,
+  useInboxPlanCancel,
+} from './store';
+
+export interface PlanApplyFlowResult {
+  handleApplyOne: (planId: string) => Promise<void>;
+  handleApplyAll: () => Promise<void>;
+  handleApplySelected: (inboxItemIds: string[]) => Promise<void>;
+  handleCancel: (inboxItemId: string) => Promise<void>;
+  applyProgress: ReturnType<typeof usePlanApplyProgress>['progress'];
+  progressPlanId: string | null;
+  /** True when any plan mutation is in-flight. */
+  planBusy: boolean;
+}
+
+export function useInboxPlanApplyFlow(
+  refreshAll: () => void,
+  viewResultAction: () => { label: string; onClick: () => void },
+): PlanApplyFlowResult {
+  const { applyAll, loading: applyAllLoading } = useInboxPlanApplyAll();
+  const { applySelected, loading: applySelectedLoading } =
+    useApplySelectedInboxPlans();
+  const { cancel, loading: cancelLoading } = useInboxPlanCancel();
+  const { progress: applyProgress, run: runPlanApply } =
+    usePlanApplyProgress();
+  const [progressPlanId, setProgressPlanId] = useState<string | null>(null);
+
+  const handleApplyOne = useCallback(
+    async (planId: string) => {
+      setProgressPlanId(planId);
+      let approvalToken: string | undefined;
+      try {
+        approvalToken = unwrap(
+          await commands.plansApprove(planId),
+        ).approvalToken;
+      } catch {
+        setProgressPlanId(null);
+        addToast({
+          message: m.inbox_plan_apply_failed_toast(),
+          variant: 'error',
+        });
+        return;
+      }
+      const response = await runPlanApply({ id: planId, approvalToken });
+      // GF-30: Clear the pre-flight busy guard once runPlanApply returns.
+      setProgressPlanId(null);
+      if (response) {
+        addToast({
+          message: m.inbox_plan_applied_toast(),
+          variant: 'info',
+          action: viewResultAction(),
+        });
+        refreshAll();
+      } else {
+        addToast({
+          message: m.inbox_plan_apply_failed_toast(),
+          variant: 'error',
+        });
+      }
+    },
+    [runPlanApply, refreshAll, viewResultAction],
+  );
+
+  const handleApplySelected = useCallback(
+    async (inboxItemIds: string[]) => {
+      if (inboxItemIds.length === 0) return;
+      const result = await applySelected(inboxItemIds);
+      if (result) {
+        const failed = result.results.filter((r) => r.error != null).length;
+        if (failed > 0) {
+          addToast({
+            message: m.inbox_toast_plans_partial({
+              applied: String(result.results.length - failed),
+              failed: String(failed),
+            }),
+            variant: 'warn',
+          });
+        } else {
+          addToast({
+            message: m.inbox_toast_plans_applying({
+              count: String(result.results.length),
+            }),
+            variant: 'info',
+            action: viewResultAction(),
+          });
+        }
+        refreshAll();
+      } else {
+        addToast({ message: m.inbox_toast_apply_failed(), variant: 'error' });
+      }
+    },
+    [applySelected, refreshAll, viewResultAction],
+  );
+
+  const handleApplyAll = useCallback(async () => {
+    const result = await applyAll();
+    if (result) {
+      const failed = result.results.filter((r) => r.error != null).length;
+      if (failed > 0) {
+        addToast({
+          message: m.inbox_toast_all_plans_partial({
+            applied: String(result.results.length - failed),
+            failed: String(failed),
+          }),
+          variant: 'warn',
+        });
+      } else {
+        addToast({
+          message: m.inbox_toast_all_plans_applying({
+            count: String(result.results.length),
+          }),
+          variant: 'info',
+          action: viewResultAction(),
+        });
+      }
+      refreshAll();
+    }
+  }, [applyAll, refreshAll, viewResultAction]);
+
+  const handleCancel = useCallback(
+    async (inboxItemId: string) => {
+      await cancel(inboxItemId);
+      addToast({ message: m.inbox_toast_plan_discarded(), variant: 'info' });
+      refreshAll();
+    },
+    [cancel, refreshAll],
+  );
+
+  // GF-30: Include progressPlanId in busy derivation.
+  const planBusy =
+    applyAllLoading ||
+    applySelectedLoading ||
+    cancelLoading ||
+    progressPlanId != null;
+
+  return {
+    handleApplyOne,
+    handleApplyAll,
+    handleApplySelected,
+    handleCancel,
+    applyProgress,
+    progressPlanId,
+    planBusy,
+  };
+}


### PR DESCRIPTION
## Summary

- Extract plan-apply lifecycle to `useInboxPlanApplyFlow` (161L) — apply/cancel/progress with GF-30 busy-derivation
- Extract confirm workflow to `useInboxConfirmFlow` (443L) — attribution prefetch, hotkeys, destination-root effects
- Extract selection-handoff decisions to `inboxSelectionModel` (113L) — pure functions with backward-compat re-exports
- InboxPage reduced from ~1640L to 1015L (~38% reduction), movement-only, no behavioral changes

## Spec context

Follows #1529 extraction pattern.

Tracks-Bead: astro-plan-kyo7.43
Merge-Bead: astro-plan-kyo7.110