### PR TITLE
refactor: oversized backend functions split into focused, table-driven units

### DIFF
--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -191,6 +191,7 @@ mod callbacks;
 mod finalizers;
 mod lifecycle;
 mod paths;
+mod terminal;
 
 #[cfg(test)]
 mod tests;

--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -1,16 +1,11 @@
 use super::{
-    apply_repo, audit_item_cancelled, bus_err, check_overlap_and_register, compute_plan_path_set,
-    db_err, deterministic_entity_id, execute_plan, finalize_archive_lifecycle,
-    finalize_calibration_master_archive, finalize_calibration_master_restore,
-    finalize_project_create_manifest, finalize_restore_lifecycle, finalize_view_generation,
-    finalize_view_regeneration, finalize_view_removal, item_row_to_executor_item, json, new_id,
-    plans_repo, resolve_root_path, verify_approval_token, ActiveRun, ActiveRunGuard, ApplyOutcome,
-    AuditLogEntry, CancellationToken, ContractError, EntityType, ErrorCode, ErrorSeverity,
-    EventBus, ExecutorItem, HashMap, OpEventEmitter, OperationEventSink, OperationEventType,
-    OperationId, OperationStatus, Outcome, PlanApplyCallbacks, PlanApplyResponse,
-    PlanApplyingCompleted, PlanApplyingPaused, PlanApplyingStarted, RetryQueue, Severity, SkipSet,
-    Source, SqlitePool, TerminalCounts, Timestamp, Utf8PathBuf, TOPIC_PLAN_APPLYING_COMPLETED,
-    TOPIC_PLAN_APPLYING_PAUSED, TOPIC_PLAN_APPLYING_STARTED,
+    apply_repo, bus_err, check_overlap_and_register, compute_plan_path_set, db_err, execute_plan,
+    item_row_to_executor_item, json, new_id, plans_repo, resolve_root_path, verify_approval_token,
+    ActiveRun, ActiveRunGuard, ApplyOutcome, CancellationToken, ContractError, ErrorCode,
+    ErrorSeverity, EventBus, ExecutorItem, HashMap, OpEventEmitter, OperationEventSink,
+    OperationEventType, OperationId, OperationStatus, PlanApplyCallbacks, PlanApplyResponse,
+    PlanApplyingStarted, RetryQueue, SkipSet, Source, SqlitePool, TerminalCounts, Timestamp,
+    Utf8PathBuf, TOPIC_PLAN_APPLYING_STARTED,
 };
 
 // ── apply_plan ────────────────────────────────────────────────────────────────
@@ -319,414 +314,43 @@ pub(super) fn spawn_executor_run(params: SpawnExecutorParams) {
         // before the outcome branches below read cumulative plan counters.
         callbacks.flush().await;
 
-        // Compute terminal state and persist.
+        // Compute terminal state and persist via per-outcome handlers.
         match outcome {
             ApplyOutcome::Completed(counts) => {
-                let at = Timestamp::now_iso();
-
-                // GFD-2: Sweep items orphaned `applying` by a mid-run retry
-                // whose DB flip landed but whose re-execution never got picked
-                // up before the run completed (symmetric with the Cancelled
-                // path's identical sweep). Without this, a retry_plan_item call
-                // racing with run completion leaves the item permanently stuck
-                // in `applying` with no terminal audit record.
-                match apply_repo::cancel_orphaned_applying_items(&pool, &plan_id).await {
-                    Ok(orphaned_ids) => {
-                        for item_id in &orphaned_ids {
-                            audit_item_cancelled(
-                                &pool, &bus, &run_id, &plan_id, item_id, "applying", &at,
-                            )
-                            .await;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(error=%e, "failed to sweep orphaned applying items on completion");
-                    }
-                }
-
-                // `counts` covers only the items processed in THIS segment.
-                // After a resume (issue #575), that undercounts a prior
-                // pre-pause phase — use the plan's cumulative counters
-                // instead (see `cumulative_counts`). Fetched AFTER the orphan
-                // sweep above so swept items are included.
-                let counts = cumulative_counts(&pool, &plan_id, &counts).await;
-                let terminal = counts.terminal_state(false).to_owned();
-
-                // Spec 017 C5: on a fully-applied archive plan, drive the owning
-                // project into `archived` (the legitimate requires-plan closure).
-                // Only a clean `applied` terminal qualifies — a partial/failed
-                // apply leaves the project where it is.
-                if terminal == "applied" && plan_origin == "archive" {
-                    if let Some(project_id) = plan_project_id.as_deref() {
-                        finalize_archive_lifecycle(&pool, &bus, &plan_id, project_id).await;
-                    }
-                }
-
-                // #885: on a fully-applied restore (un-archive) plan, drive the
-                // owning project back out of `archived`. Only a clean `applied`
-                // terminal qualifies — a partial/failed apply leaves files only
-                // partly moved back, so the project must stay `archived` until a
-                // retry plan finishes the job (mirrors the archive closure guard).
-                if terminal == "applied" && plan_origin == "restore" {
-                    if let Some(project_id) = plan_project_id.as_deref() {
-                        finalize_restore_lifecycle(&pool, &bus, project_id).await;
-                    }
-                }
-
-                // #886: on a fully-applied calibration-master archive/restore
-                // plan, close the master's archived flag the same way the
-                // project archive/restore closures do above — only a clean
-                // `applied` terminal qualifies (a partial apply leaves the
-                // file only partly moved).
-                if terminal == "applied" && plan_origin == "calibration_master_archive" {
-                    if let Some(master_id) = plan_project_id.as_deref() {
-                        finalize_calibration_master_archive(&pool, &plan_id, master_id).await;
-                    }
-                }
-                if terminal == "applied" && plan_origin == "calibration_master_restore" {
-                    if let Some(master_id) = plan_project_id.as_deref() {
-                        finalize_calibration_master_restore(&pool, master_id).await;
-                    }
-                }
-
-                // #665: on a fully-applied project_create plan, fire the
-                // Created manifest trigger — see finalize_project_create_manifest
-                // for why origin_path is the project's PATH here, not its id.
-                if terminal == "applied" && plan_origin == "project" {
-                    if let Some(project_path) = plan_project_id.as_deref() {
-                        finalize_project_create_manifest(&pool, &bus, project_path).await;
-                    }
-                }
-
-                // Spec 049: on a successful (or partially-applied) generation
-                // plan apply, write the first-materialization
-                // `PreparedSourceView` (state `current`) from the succeeded
-                // link items. Failed/skipped items are simply omitted — a
-                // single missing source never blocks recording the rest of
-                // the view (FR-019).
-                if (terminal == "applied" || terminal == "partially_applied")
-                    && plan_origin == "prepared_view_generation"
-                {
-                    if let Some(project_id) = plan_project_id.as_deref() {
-                        finalize_view_generation(&pool, &plan_id, project_id).await;
-                    }
-                }
-
-                // Spec 026 T017/T018: on a (fully or partially) applied
-                // view-removal/regeneration plan, update the PreparedSourceView
-                // state to match reality — see `finalize_view_removal`/
-                // `finalize_view_regeneration` for why removal gets an explicit
-                // terminal write while regeneration rides the staleness sweep.
-                if terminal == "applied" || terminal == "partially_applied" {
-                    match plan_origin.as_str() {
-                        "prepared_view_removal" => {
-                            finalize_view_removal(&pool, &plan_id, &terminal).await;
-                        }
-                        "prepared_view_regeneration" => {
-                            finalize_view_regeneration(&pool, &plan_id).await;
-                        }
-                        _ => {}
-                    }
-                }
-
-                let _ = apply_repo::complete_run(
+                super::terminal::handle_completed(
                     &pool,
+                    &bus,
                     &plan_id,
                     &run_id,
-                    &terminal,
-                    counts.succeeded,
-                    counts.failed,
-                    counts.skipped,
-                    counts.cancelled,
+                    &plan_origin,
+                    plan_project_id.as_deref(),
+                    op_emitter.as_ref(),
+                    counts,
                 )
                 .await;
-
-                let _ = apply_repo::append_event(
-                    &pool,
-                    &new_id(),
-                    &run_id,
-                    &plan_id,
-                    None,
-                    "applying",
-                    &terminal,
-                    &at,
-                    None,
-                    None,
-                )
-                .await;
-
-                let _ = bus
-                    .publish(
-                        TOPIC_PLAN_APPLYING_COMPLETED,
-                        Source::System,
-                        PlanApplyingCompleted {
-                            plan_id: plan_id.clone(),
-                            run_id: run_id.clone(),
-                            terminal_state: terminal.clone(),
-                            items_applied: counts.succeeded,
-                            items_failed: counts.failed,
-                            items_skipped: counts.skipped,
-                            items_cancelled: counts.cancelled,
-                            at: at.clone(),
-                        },
-                    )
-                    .await;
-
-                // Long-op terminal event (spec 042 US16). `terminal` is
-                // "completed" unless any item failed, in which case it is
-                // "failed" — map that onto Completed/Failed event + status.
-                if let Some(emitter) = op_emitter.as_ref() {
-                    let failed_run = terminal == "failed";
-                    let (event_type, status) = if failed_run {
-                        (OperationEventType::Failed, OperationStatus::Failed)
-                    } else {
-                        (OperationEventType::Completed, OperationStatus::Completed)
-                    };
-                    let handle = emitter.handle(status);
-                    emitter.emit(
-                        event_type,
-                        json!({
-                            "handle": handle,
-                            "planId": plan_id,
-                            "runId": run_id,
-                            "terminalState": terminal,
-                            "itemsApplied": counts.succeeded,
-                            "itemsFailed": counts.failed,
-                            "itemsSkipped": counts.skipped,
-                            "itemsCancelled": counts.cancelled,
-                            "at": at,
-                        }),
-                    );
-                }
             }
-
             ApplyOutcome::Cancelled(counts) => {
-                let at = Timestamp::now_iso();
-
-                // Batch-cancel remaining pending items (T021: emit per-item audit row for EACH).
-                match apply_repo::list_pending_items(&pool, &plan_id).await {
-                    Ok(pending_ids) => {
-                        let _ = apply_repo::batch_cancel_pending_items(&pool, &plan_id).await;
-                        for item_id in &pending_ids {
-                            audit_item_cancelled(
-                                &pool, &bus, &run_id, &plan_id, item_id, "pending", &at,
-                            )
-                            .await;
-                        }
-                    }
-                    Err(e) => {
-                        // #750: `list_pending_items` failing here is assumed
-                        // transient (DB contention), not permanent — retry
-                        // once before degrading to a bulk-only cancel, so the
-                        // common case still gets full per-item audit rows.
-                        tracing::error!(error=%e, "failed to list pending items for per-item cancel audit; retrying once");
-                        match apply_repo::list_pending_items(&pool, &plan_id).await {
-                            Ok(pending_ids) => {
-                                let _ =
-                                    apply_repo::batch_cancel_pending_items(&pool, &plan_id).await;
-                                for item_id in &pending_ids {
-                                    audit_item_cancelled(
-                                        &pool, &bus, &run_id, &plan_id, item_id, "pending", &at,
-                                    )
-                                    .await;
-                                }
-                            }
-                            Err(e2) => {
-                                tracing::error!(error=%e2, "list_pending_items failed twice; falling back to a single aggregate cancel audit row");
-                                let cancelled_count =
-                                    apply_repo::batch_cancel_pending_items(&pool, &plan_id)
-                                        .await
-                                        .unwrap_or(0);
-                                // Degraded but non-silent: one aggregate durable
-                                // row instead of per-item rows, since item ids
-                                // are unavailable without changing
-                                // `batch_cancel_pending_items`'s return type
-                                // (persistence_db, out of this fix's scope).
-                                let entry = AuditLogEntry::new(
-                                    EntityType::FilesystemPlan,
-                                    deterministic_entity_id("plan_apply.bulk_cancel", &plan_id),
-                                    "plan.bulk_cancel_degraded",
-                                    "user",
-                                    Outcome::Refused,
-                                    Severity::Workflow,
-                                    domain_core::ids::EntityId::new(),
-                                )
-                                .with_reason_code("list_pending_items_unavailable")
-                                .with_payload(json!({
-                                    "planId": plan_id,
-                                    "runId": run_id,
-                                    "cancelledCount": cancelled_count,
-                                }));
-                                if let Err(e3) = bus
-                                    .write_audit(
-                                        entry,
-                                        TOPIC_PLAN_APPLYING_COMPLETED,
-                                        Source::System,
-                                        json!({"planId": plan_id, "cancelledCount": cancelled_count}),
-                                    )
-                                    .await
-                                {
-                                    tracing::error!(error=%e3, "durable fallback audit write failed for degraded bulk cancel");
-                                }
-                            }
-                        }
-                    }
-                }
-
-                // Sweep items orphaned `applying` by a mid-run retry whose
-                // DB flip (`retry_plan_item`) landed but whose re-execution
-                // never got picked up by the executor's retry-drain before
-                // cancellation was observed (review fix, #742 follow-up).
-                // `batch_cancel_pending_items` above only targets `pending`
-                // and would otherwise leave these permanently stuck with no
-                // terminal audit record.
-                match apply_repo::cancel_orphaned_applying_items(&pool, &plan_id).await {
-                    Ok(orphaned_ids) => {
-                        for item_id in &orphaned_ids {
-                            audit_item_cancelled(
-                                &pool, &bus, &run_id, &plan_id, item_id, "applying", &at,
-                            )
-                            .await;
-                        }
-                    }
-                    Err(e) => {
-                        tracing::error!(error=%e, "failed to sweep orphaned applying items for cancel audit");
-                    }
-                }
-
-                // Fetch cumulative counters (see `cumulative_counts`) AFTER
-                // the batch-cancel above so the just-cancelled items are
-                // included.
-                let counts = cumulative_counts(&pool, &plan_id, &counts).await;
-
-                let _ = apply_repo::complete_run(
+                super::terminal::handle_cancelled(
                     &pool,
+                    &bus,
                     &plan_id,
                     &run_id,
-                    "cancelled",
-                    counts.succeeded,
-                    counts.failed,
-                    counts.skipped,
-                    counts.cancelled,
+                    op_emitter.as_ref(),
+                    counts,
                 )
                 .await;
-
-                let _ = apply_repo::append_event(
-                    &pool,
-                    &new_id(),
-                    &run_id,
-                    &plan_id,
-                    None,
-                    "applying",
-                    "cancelled",
-                    &at,
-                    None,
-                    None,
-                )
-                .await;
-
-                let _ = bus
-                    .publish(
-                        TOPIC_PLAN_APPLYING_COMPLETED,
-                        Source::System,
-                        PlanApplyingCompleted {
-                            plan_id: plan_id.clone(),
-                            run_id: run_id.clone(),
-                            terminal_state: "cancelled".to_owned(),
-                            items_applied: counts.succeeded,
-                            items_failed: counts.failed,
-                            items_skipped: counts.skipped,
-                            items_cancelled: counts.cancelled,
-                            at: at.clone(),
-                        },
-                    )
-                    .await;
-
-                // Long-op terminal event for a cancelled run (spec 042 US16).
-                if let Some(emitter) = op_emitter.as_ref() {
-                    let handle = emitter.handle(OperationStatus::Cancelled);
-                    emitter.emit(
-                        OperationEventType::Completed,
-                        json!({
-                            "handle": handle,
-                            "planId": plan_id,
-                            "runId": run_id,
-                            "terminalState": "cancelled",
-                            "itemsApplied": counts.succeeded,
-                            "itemsFailed": counts.failed,
-                            "itemsSkipped": counts.skipped,
-                            "itemsCancelled": counts.cancelled,
-                            "at": at,
-                        }),
-                    );
-                }
             }
-
             ApplyOutcome::Paused { reason, counts } => {
-                let at = Timestamp::now_iso();
-                // See `cumulative_counts`: covers a prior pre-pause phase
-                // too, so a second pause after a resume doesn't regress the
-                // plan's counters.
-                let counts = cumulative_counts(&pool, &plan_id, &counts).await;
-
-                let _ = apply_repo::pause_run(
+                super::terminal::handle_paused(
                     &pool,
+                    &bus,
                     &plan_id,
                     &run_id,
                     &reason,
-                    counts.succeeded,
-                    counts.failed,
-                    counts.skipped,
-                    counts.cancelled,
-                    // items_pending: total - all resolved
-                    counts.succeeded + counts.failed + counts.skipped + counts.cancelled,
+                    op_emitter.as_ref(),
+                    counts,
                 )
                 .await;
-
-                let _ = apply_repo::append_event(
-                    &pool,
-                    &new_id(),
-                    &run_id,
-                    &plan_id,
-                    None,
-                    "applying",
-                    "paused",
-                    &at,
-                    None,
-                    None,
-                )
-                .await;
-
-                // Long-op non-terminal pause projection (spec 042 US16). The
-                // run is not terminal — the UI keeps the handle and waits for a
-                // resume to continue streaming. Status reflects "running" since
-                // the op is still alive (paused), not Completed/Failed.
-                if let Some(emitter) = op_emitter.as_ref() {
-                    let handle = emitter.handle(OperationStatus::Running);
-                    emitter.emit(
-                        OperationEventType::Warning,
-                        json!({
-                            "handle": handle,
-                            "planId": plan_id,
-                            "runId": run_id,
-                            "pauseReason": reason,
-                            "at": at,
-                        }),
-                    );
-                }
-
-                let _ = bus
-                    .publish(
-                        TOPIC_PLAN_APPLYING_PAUSED,
-                        Source::System,
-                        PlanApplyingPaused {
-                            plan_id: plan_id.clone(),
-                            run_id: run_id.clone(),
-                            pause_reason: reason,
-                            at,
-                        },
-                    )
-                    .await;
             }
         }
     });

--- a/crates/app/core/src/plan_apply/terminal.rs
+++ b/crates/app/core/src/plan_apply/terminal.rs
@@ -1,0 +1,377 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Per-terminal-outcome handlers for `spawn_executor_run`.
+//!
+//! Extracted from `apply.rs` to keep `spawn_executor_run` at a navigable size
+//! while preserving identical runtime behavior.
+
+use super::{
+    apply_repo, audit_item_cancelled, deterministic_entity_id, finalize_archive_lifecycle,
+    finalize_calibration_master_archive, finalize_calibration_master_restore,
+    finalize_project_create_manifest, finalize_restore_lifecycle, finalize_view_generation,
+    finalize_view_regeneration, finalize_view_removal, json, new_id, AuditLogEntry, EntityType,
+    EventBus, OpEventEmitter, OperationEventType, OperationStatus, Outcome, PlanApplyingCompleted,
+    PlanApplyingPaused, Severity, Source, SqlitePool, TerminalCounts, Timestamp,
+    TOPIC_PLAN_APPLYING_COMPLETED, TOPIC_PLAN_APPLYING_PAUSED,
+};
+
+use super::apply::cumulative_counts;
+
+/// Handle `ApplyOutcome::Completed`: finalize origin-specific side-effects,
+/// persist the terminal state, emit audit + bus + long-op events.
+pub(super) async fn handle_completed(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    plan_id: &str,
+    run_id: &str,
+    plan_origin: &str,
+    plan_project_id: Option<&str>,
+    op_emitter: Option<&OpEventEmitter>,
+    counts: TerminalCounts,
+) {
+    let counts = cumulative_counts(pool, plan_id, &counts).await;
+    let terminal = counts.terminal_state(false).to_owned();
+    let at = Timestamp::now_iso();
+
+    // Origin-specific lifecycle side-effects (only on clean terminals).
+    if terminal == "applied" {
+        match plan_origin {
+            "archive" => {
+                if let Some(project_id) = plan_project_id {
+                    finalize_archive_lifecycle(pool, bus, plan_id, project_id).await;
+                }
+            }
+            "restore" => {
+                if let Some(project_id) = plan_project_id {
+                    finalize_restore_lifecycle(pool, bus, project_id).await;
+                }
+            }
+            "calibration_master_archive" => {
+                if let Some(master_id) = plan_project_id {
+                    finalize_calibration_master_archive(pool, plan_id, master_id).await;
+                }
+            }
+            "calibration_master_restore" => {
+                if let Some(master_id) = plan_project_id {
+                    finalize_calibration_master_restore(pool, master_id).await;
+                }
+            }
+            "project" => {
+                if let Some(project_path) = plan_project_id {
+                    finalize_project_create_manifest(pool, bus, project_path).await;
+                }
+            }
+            _ => {}
+        }
+    }
+
+    // Source-view finalization (applied or partially_applied).
+    if terminal == "applied" || terminal == "partially_applied" {
+        match plan_origin {
+            "prepared_view_generation" => {
+                if let Some(project_id) = plan_project_id {
+                    finalize_view_generation(pool, plan_id, project_id).await;
+                }
+            }
+            "prepared_view_removal" => {
+                finalize_view_removal(pool, plan_id, &terminal).await;
+            }
+            "prepared_view_regeneration" => {
+                finalize_view_regeneration(pool, plan_id).await;
+            }
+            _ => {}
+        }
+    }
+
+    let _ = apply_repo::complete_run(
+        pool,
+        plan_id,
+        run_id,
+        &terminal,
+        counts.succeeded,
+        counts.failed,
+        counts.skipped,
+        counts.cancelled,
+    )
+    .await;
+
+    let _ = apply_repo::append_event(
+        pool,
+        &new_id(),
+        run_id,
+        plan_id,
+        None,
+        "applying",
+        &terminal,
+        &at,
+        None,
+        None,
+    )
+    .await;
+
+    let _ = bus
+        .publish(
+            TOPIC_PLAN_APPLYING_COMPLETED,
+            Source::System,
+            PlanApplyingCompleted {
+                plan_id: plan_id.to_owned(),
+                run_id: run_id.to_owned(),
+                terminal_state: terminal.clone(),
+                items_applied: counts.succeeded,
+                items_failed: counts.failed,
+                items_skipped: counts.skipped,
+                items_cancelled: counts.cancelled,
+                at: at.clone(),
+            },
+        )
+        .await;
+
+    if let Some(emitter) = op_emitter.as_ref() {
+        let failed_run = terminal == "failed";
+        let (event_type, status) = if failed_run {
+            (OperationEventType::Failed, OperationStatus::Failed)
+        } else {
+            (OperationEventType::Completed, OperationStatus::Completed)
+        };
+        let handle = emitter.handle(status);
+        emitter.emit(
+            event_type,
+            json!({
+                "handle": handle,
+                "planId": plan_id,
+                "runId": run_id,
+                "terminalState": terminal,
+                "itemsApplied": counts.succeeded,
+                "itemsFailed": counts.failed,
+                "itemsSkipped": counts.skipped,
+                "itemsCancelled": counts.cancelled,
+                "at": at,
+            }),
+        );
+    }
+}
+
+/// Handle `ApplyOutcome::Cancelled`: batch-cancel pending items, sweep orphans,
+/// persist terminal state, emit events.
+pub(super) async fn handle_cancelled(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    plan_id: &str,
+    run_id: &str,
+    op_emitter: Option<&OpEventEmitter>,
+    counts: TerminalCounts,
+) {
+    let at = Timestamp::now_iso();
+
+    // Batch-cancel remaining pending items (T021: per-item audit row for EACH).
+    cancel_pending_items(pool, bus, run_id, plan_id, &at).await;
+
+    // Sweep items orphaned `applying` by a mid-run retry whose DB flip landed
+    // but whose re-execution never got picked up before cancellation.
+    match apply_repo::cancel_orphaned_applying_items(pool, plan_id).await {
+        Ok(orphaned_ids) => {
+            for item_id in &orphaned_ids {
+                audit_item_cancelled(pool, bus, run_id, plan_id, item_id, "applying", &at).await;
+            }
+        }
+        Err(e) => {
+            tracing::error!(error=%e, "failed to sweep orphaned applying items for cancel audit");
+        }
+    }
+
+    // Fetch cumulative counters AFTER batch-cancel so cancelled items are counted.
+    let counts = cumulative_counts(pool, plan_id, &counts).await;
+
+    let _ = apply_repo::complete_run(
+        pool,
+        plan_id,
+        run_id,
+        "cancelled",
+        counts.succeeded,
+        counts.failed,
+        counts.skipped,
+        counts.cancelled,
+    )
+    .await;
+
+    let _ = apply_repo::append_event(
+        pool,
+        &new_id(),
+        run_id,
+        plan_id,
+        None,
+        "applying",
+        "cancelled",
+        &at,
+        None,
+        None,
+    )
+    .await;
+
+    let _ = bus
+        .publish(
+            TOPIC_PLAN_APPLYING_COMPLETED,
+            Source::System,
+            PlanApplyingCompleted {
+                plan_id: plan_id.to_owned(),
+                run_id: run_id.to_owned(),
+                terminal_state: "cancelled".to_owned(),
+                items_applied: counts.succeeded,
+                items_failed: counts.failed,
+                items_skipped: counts.skipped,
+                items_cancelled: counts.cancelled,
+                at: at.clone(),
+            },
+        )
+        .await;
+
+    if let Some(emitter) = op_emitter.as_ref() {
+        let handle = emitter.handle(OperationStatus::Cancelled);
+        emitter.emit(
+            OperationEventType::Completed,
+            json!({
+                "handle": handle,
+                "planId": plan_id,
+                "runId": run_id,
+                "terminalState": "cancelled",
+                "itemsApplied": counts.succeeded,
+                "itemsFailed": counts.failed,
+                "itemsSkipped": counts.skipped,
+                "itemsCancelled": counts.cancelled,
+                "at": at,
+            }),
+        );
+    }
+}
+
+/// Handle `ApplyOutcome::Paused`: persist pause state, emit events.
+pub(super) async fn handle_paused(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    plan_id: &str,
+    run_id: &str,
+    reason: &str,
+    op_emitter: Option<&OpEventEmitter>,
+    counts: TerminalCounts,
+) {
+    let at = Timestamp::now_iso();
+    let counts = cumulative_counts(pool, plan_id, &counts).await;
+
+    let _ = apply_repo::pause_run(
+        pool,
+        plan_id,
+        run_id,
+        reason,
+        counts.succeeded,
+        counts.failed,
+        counts.skipped,
+        counts.cancelled,
+        counts.succeeded + counts.failed + counts.skipped + counts.cancelled,
+    )
+    .await;
+
+    let _ = apply_repo::append_event(
+        pool,
+        &new_id(),
+        run_id,
+        plan_id,
+        None,
+        "applying",
+        "paused",
+        &at,
+        None,
+        None,
+    )
+    .await;
+
+    if let Some(emitter) = op_emitter.as_ref() {
+        let handle = emitter.handle(OperationStatus::Running);
+        emitter.emit(
+            OperationEventType::Warning,
+            json!({
+                "handle": handle,
+                "planId": plan_id,
+                "runId": run_id,
+                "pauseReason": reason,
+                "at": at,
+            }),
+        );
+    }
+
+    let _ = bus
+        .publish(
+            TOPIC_PLAN_APPLYING_PAUSED,
+            Source::System,
+            PlanApplyingPaused {
+                plan_id: plan_id.to_owned(),
+                run_id: run_id.to_owned(),
+                pause_reason: reason.to_owned(),
+                at,
+            },
+        )
+        .await;
+}
+
+// ── Internal helpers ─────────────────────────────────────────────────────────
+
+/// Batch-cancel pending items with retry-once resilience.
+async fn cancel_pending_items(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    run_id: &str,
+    plan_id: &str,
+    at: &str,
+) {
+    match apply_repo::list_pending_items(pool, plan_id).await {
+        Ok(pending_ids) => {
+            let _ = apply_repo::batch_cancel_pending_items(pool, plan_id).await;
+            for item_id in &pending_ids {
+                audit_item_cancelled(pool, bus, run_id, plan_id, item_id, "pending", at).await;
+            }
+        }
+        Err(e) => {
+            tracing::error!(error=%e, "failed to list pending items for per-item cancel audit; retrying once");
+            match apply_repo::list_pending_items(pool, plan_id).await {
+                Ok(pending_ids) => {
+                    let _ = apply_repo::batch_cancel_pending_items(pool, plan_id).await;
+                    for item_id in &pending_ids {
+                        audit_item_cancelled(pool, bus, run_id, plan_id, item_id, "pending", at)
+                            .await;
+                    }
+                }
+                Err(e2) => {
+                    tracing::error!(error=%e2, "list_pending_items failed twice; falling back to a single aggregate cancel audit row");
+                    let cancelled_count =
+                        apply_repo::batch_cancel_pending_items(pool, plan_id).await.unwrap_or(0);
+                    let entry = AuditLogEntry::new(
+                        EntityType::FilesystemPlan,
+                        deterministic_entity_id("plan_apply.bulk_cancel", plan_id),
+                        "plan.bulk_cancel_degraded",
+                        "user",
+                        Outcome::Refused,
+                        Severity::Workflow,
+                        domain_core::ids::EntityId::new(),
+                    )
+                    .with_reason_code("list_pending_items_unavailable")
+                    .with_payload(json!({
+                        "planId": plan_id,
+                        "runId": run_id,
+                        "cancelledCount": cancelled_count,
+                    }));
+                    if let Err(e3) = bus
+                        .write_audit(
+                            entry,
+                            TOPIC_PLAN_APPLYING_COMPLETED,
+                            Source::System,
+                            json!({"planId": plan_id, "cancelledCount": cancelled_count}),
+                        )
+                        .await
+                    {
+                        tracing::error!(error=%e3, "durable fallback audit write failed for degraded bulk cancel");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/crates/app/core/src/plan_apply/terminal.rs
+++ b/crates/app/core/src/plan_apply/terminal.rs
@@ -30,9 +30,27 @@ pub(super) async fn handle_completed(
     op_emitter: Option<&OpEventEmitter>,
     counts: TerminalCounts,
 ) {
+    let at = Timestamp::now_iso();
+
+    // GFD-2: Sweep items orphaned `applying` by a mid-run retry whose DB flip
+    // landed but whose re-execution never got picked up before the run
+    // completed (symmetric with the Cancelled path's identical sweep). Without
+    // this, a retry_plan_item call racing with run completion leaves the item
+    // permanently stuck in `applying` with no terminal audit record.
+    // cumulative_counts is called AFTER this sweep so swept items are counted.
+    match apply_repo::cancel_orphaned_applying_items(pool, plan_id).await {
+        Ok(orphaned_ids) => {
+            for item_id in &orphaned_ids {
+                audit_item_cancelled(pool, bus, run_id, plan_id, item_id, "applying", &at).await;
+            }
+        }
+        Err(e) => {
+            tracing::error!(error=%e, "failed to sweep orphaned applying items on completion");
+        }
+    }
+
     let counts = cumulative_counts(pool, plan_id, &counts).await;
     let terminal = counts.terminal_state(false).to_owned();
-    let at = Timestamp::now_iso();
 
     // Origin-specific lifecycle side-effects (only on clean terminals).
     if terminal == "applied" {

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -1940,3 +1940,76 @@ async fn gf29_skip_plan_item_rejects_when_no_active_run() {
         "skip with no ActiveRun must return run.not_found, not fabricate success"
     );
 }
+
+// ── GFD-2 regression: orphaned-applying sweep on Completed path ───────────────
+
+/// GFD-2 regression (PR #1527 symmetric): handle_completed must sweep items
+/// stuck in `applying` — items whose retry DB flip landed but whose
+/// re-execution never started before run completion. Without the sweep, those
+/// items are permanently stuck in `applying` with no terminal audit record.
+///
+/// Mirrors the Cancelled-path sweep; both now call
+/// `cancel_orphaned_applying_items` before `cumulative_counts` so swept items
+/// are included in the terminal counters.
+#[tokio::test]
+async fn gfd2_completed_path_sweeps_orphaned_applying_items() {
+    let (db, bus) = setup().await;
+    let plan_id = "p-gfd2-completed";
+    let run_id = "run-gfd2-completed";
+
+    insert_approved_plan_with_items(&db, plan_id, 2).await;
+
+    // Drive plan to applying + create a run (the token matches insert_approved helper).
+    apply_repo::cas_approved_to_applying(db.pool(), plan_id, run_id, "test-token", 2, 2)
+        .await
+        .unwrap();
+
+    // item-0 succeeded, item-1 stuck in `applying` (the GFD-2 race window:
+    // retry flip landed but executor never picked it up before completion).
+    sqlx::query("UPDATE plan_items SET item_state = 'succeeded' WHERE id = ?")
+        .bind(format!("{plan_id}-item-0"))
+        .execute(db.pool())
+        .await
+        .unwrap();
+    sqlx::query("UPDATE plan_items SET item_state = 'applying' WHERE id = ?")
+        .bind(format!("{plan_id}-item-1"))
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+    // Call handle_completed — it should sweep item-1 and emit a durable audit row.
+    super::terminal::handle_completed(
+        db.pool(),
+        &bus,
+        plan_id,
+        run_id,
+        "cleanup",
+        None,
+        None,
+        TerminalCounts { succeeded: 1, failed: 0, skipped: 0, cancelled: 0 },
+    )
+    .await;
+
+    // item-1 must now be `cancelled` (swept by GFD-2 path).
+    let item_state: String = sqlx::query_scalar("SELECT item_state FROM plan_items WHERE id = ?")
+        .bind(format!("{plan_id}-item-1"))
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+    assert_eq!(
+        item_state, "cancelled",
+        "orphaned applying item must be swept to cancelled on Completed path"
+    );
+
+    // A durable audit row for the sweep must exist.
+    let entries = list_audit_entries(
+        db.pool(),
+        &AuditLogFilter { entity_type: Some("filesystem_plan".to_owned()), ..Default::default() },
+    )
+    .await
+    .unwrap();
+    assert!(
+        entries.iter().any(|e| e.trigger == "plan_item.cancelled"),
+        "GFD-2 sweep on Completed path must emit a durable audit row for the swept item"
+    );
+}

--- a/crates/app/core/src/tool_launch.rs
+++ b/crates/app/core/src/tool_launch.rs
@@ -199,6 +199,217 @@ async fn signal_tool_unconfigured_block(
     }
 }
 
+/// Shorthand for building an early-exit error `ToolLaunchResponse`.
+fn error_response(code: &str, message: String) -> ToolLaunchResponse {
+    ToolLaunchResponse {
+        status: ToolLaunchStatus::Error,
+        launch_id: None,
+        pid: None,
+        launched_at: None,
+        working_dir: None,
+        audit_id: None,
+        prior_instance_alive: false,
+        error: Some(ToolLaunchError { code: code.to_owned(), message }),
+    }
+}
+
+/// Resolved tool configuration (steps 1-2 of the launch pipeline).
+struct ResolvedToolConfig {
+    project: persistence_plans::repositories::projects::ProjectRow,
+    profile: workflow_profiles::ToolProfile,
+    executable_path: String,
+}
+
+/// Load project and validate tool configuration (profile exists, enabled, path set).
+///
+/// Returns `Err(ToolLaunchResponse)` for user-facing validation failures.
+async fn resolve_tool_config(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    req: &ToolLaunchRequest,
+) -> Result<ResolvedToolConfig, ToolLaunchResponse> {
+    let project = proj_repo::get_project(pool, &req.project_id)
+        .await
+        .map_err(|e| error_response("project.not_found", format!("{e}")))?;
+
+    let Some(profile) = seed::find(&req.tool_id) else {
+        return Err(error_response(
+            "tool.not_configured",
+            format!("No tool profile found for '{}'", req.tool_id),
+        ));
+    };
+
+    let enabled = read_bool_setting(pool, &key_enabled(&req.tool_id), true).await;
+    if !enabled {
+        signal_tool_unconfigured_block(pool, bus, &req.project_id, &req.tool_id).await;
+        return Err(error_response(
+            "tool.not_configured",
+            format!("Tool '{}' is disabled in settings", req.tool_id),
+        ));
+    }
+
+    let executable_path = read_string_setting(pool, &key_executable_path(&req.tool_id)).await;
+    let Some(executable_path) = executable_path.filter(|s| !s.trim().is_empty()) else {
+        signal_tool_unconfigured_block(pool, bus, &req.project_id, &req.tool_id).await;
+        return Err(error_response(
+            "tool.not_configured",
+            format!("No executable path configured for tool '{}'", req.tool_id),
+        ));
+    };
+
+    Ok(ResolvedToolConfig { project, profile, executable_path })
+}
+
+/// Resolve working directory and verify library-root containment (steps 3-4).
+///
+/// Returns the canonical working-directory string, or `Err(ToolLaunchResponse)`
+/// when the resolved path falls outside all registered library roots.
+async fn resolve_and_check_working_dir(
+    pool: &SqlitePool,
+    project_path: &str,
+    project_id: &str,
+) -> Result<String, ToolLaunchResponse> {
+    let project_root = std::path::PathBuf::from(project_path);
+    let active_source_view = resolve_active_source_view_folder(pool, project_id).await;
+    let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref());
+
+    let canonical_cwd =
+        working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());
+    let all_roots = inv_repo::list_all_roots(pool)
+        .await
+        .map_err(|e| error_response("db.error", format!("{e}")))?;
+    let registered = first_run_repo::list_sources(pool)
+        .await
+        .map_err(|e| error_response("db.error", format!("{e}")))?;
+    let root_paths: Vec<std::path::PathBuf> = all_roots
+        .iter()
+        .map(|r| r.current_path.as_str())
+        .chain(registered.iter().map(|s| s.path.as_str()))
+        .map(|raw| {
+            let p = std::path::PathBuf::from(raw);
+            p.canonicalize().unwrap_or(p)
+        })
+        .collect();
+    let root_refs: Vec<&std::path::Path> =
+        root_paths.iter().map(std::path::PathBuf::as_path).collect();
+
+    if let Err(code) = verify_cwd_containment(&canonical_cwd, &root_refs) {
+        return Err(error_response(
+            code,
+            format!(
+                "Working directory '{}' is outside all registered library roots",
+                canonical_cwd.display()
+            ),
+        ));
+    }
+
+    Ok(canonical_cwd.to_string_lossy().into_owned())
+}
+
+/// Spawn the process, persist the launch row, and emit the audit event (steps 7-9).
+#[allow(clippy::too_many_arguments)]
+async fn spawn_and_record(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    spawner: &dyn ProcessSpawner,
+    req: &ToolLaunchRequest,
+    executable_path: &str,
+    argv: Vec<String>,
+    args_hash: String,
+    working_dir_str: &str,
+    bundle_id: Option<String>,
+) -> Result<ToolLaunchResponse, String> {
+    let spawn_req = SpawnRequest {
+        executable: executable_path.to_owned(),
+        args: argv,
+        working_dir: working_dir_str.to_owned(),
+        bundle_id,
+    };
+
+    let launch_id = new_id();
+    let audit_id = new_id();
+    let launched_at = Timestamp::now_iso();
+
+    let (outcome, pid, error_response_opt) = match spawner.spawn(spawn_req) {
+        Ok(result) => ("spawned", result.pid, None),
+        Err(LaunchError::MacOsQuarantine) => (
+            "spawn_failed",
+            None,
+            Some(ToolLaunchError {
+                code: "macos.quarantine.detected".to_owned(),
+                message:
+                    "macOS quarantined this app. Run `xattr -dr com.apple.quarantine <path>` and retry."
+                        .to_owned(),
+            }),
+        ),
+        Err(LaunchError::SpawnFailed(msg)) => (
+            "spawn_failed",
+            None,
+            Some(ToolLaunchError {
+                code: "launch.failed".to_owned(),
+                message: format!("OS error: {msg}"),
+            }),
+        ),
+    };
+
+    let _ = tl_repo::insert_tool_launch(
+        pool,
+        &tl_repo::InsertToolLaunch {
+            id: &launch_id,
+            project_id: &req.project_id,
+            tool_id: &req.tool_id,
+            pid,
+            working_dir: Some(working_dir_str),
+            args_hash: Some(&args_hash),
+            outcome,
+            audit_id: &audit_id,
+        },
+    )
+    .await
+    .map_err(|e| format!("{e}"))?;
+
+    let _ = bus
+        .publish(
+            TOPIC_TOOL_LAUNCH,
+            Source::User,
+            ToolLaunchEvent {
+                launch_id: launch_id.clone(),
+                project_id: req.project_id.clone(),
+                tool_id: req.tool_id.clone(),
+                working_dir: Some(working_dir_str.to_owned()),
+                args_hash: Some(args_hash),
+                outcome: outcome.to_owned(),
+                at: launched_at.clone(),
+            },
+        )
+        .await
+        .map_err(|e| format!("audit bus: {e}"));
+
+    if let Some(err) = error_response_opt {
+        return Ok(ToolLaunchResponse {
+            status: ToolLaunchStatus::Error,
+            launch_id: Some(launch_id),
+            pid: None,
+            launched_at: Some(launched_at),
+            working_dir: Some(working_dir_str.to_owned()),
+            audit_id: Some(audit_id),
+            prior_instance_alive: false,
+            error: Some(err),
+        });
+    }
+
+    Ok(ToolLaunchResponse {
+        status: ToolLaunchStatus::Success,
+        launch_id: Some(launch_id),
+        pid,
+        launched_at: Some(launched_at),
+        working_dir: Some(working_dir_str.to_owned()),
+        audit_id: Some(audit_id),
+        prior_instance_alive: false,
+        error: None,
+    })
+}
+
 // ── launch ────────────────────────────────────────────────────────────────────
 
 /// Launch the configured processing tool for the given project.
@@ -224,115 +435,18 @@ pub async fn launch(
     spawner: &dyn ProcessSpawner,
     req: ToolLaunchRequest,
 ) -> Result<ToolLaunchResponse, String> {
-    // ── Step 1: load project ──────────────────────────────────────────────────
-    let project =
-        proj_repo::get_project(pool, &req.project_id).await.map_err(|e| format!("{e}"))?;
-
-    // ── Step 2: load seed profile + settings ─────────────────────────────────
-    let Some(profile) = seed::find(&req.tool_id) else {
-        return Ok(ToolLaunchResponse {
-            status: ToolLaunchStatus::Error,
-            launch_id: None,
-            pid: None,
-            launched_at: None,
-            working_dir: None,
-            audit_id: None,
-            prior_instance_alive: false,
-            error: Some(ToolLaunchError {
-                code: "tool.not_configured".to_owned(),
-                message: format!("No tool profile found for '{}'", req.tool_id),
-            }),
-        });
+    // ── Steps 1-2: resolve tool configuration ────────────────────────────────
+    let config = match resolve_tool_config(pool, bus, &req).await {
+        Ok(c) => c,
+        Err(resp) => return Ok(resp),
     };
 
-    let enabled = read_bool_setting(pool, &key_enabled(&req.tool_id), true).await;
-    if !enabled {
-        signal_tool_unconfigured_block(pool, bus, &req.project_id, &req.tool_id).await;
-        return Ok(ToolLaunchResponse {
-            status: ToolLaunchStatus::Error,
-            launch_id: None,
-            pid: None,
-            launched_at: None,
-            working_dir: None,
-            audit_id: None,
-            prior_instance_alive: false,
-            error: Some(ToolLaunchError {
-                code: "tool.not_configured".to_owned(),
-                message: format!("Tool '{}' is disabled in settings", req.tool_id),
-            }),
-        });
-    }
-
-    let executable_path = read_string_setting(pool, &key_executable_path(&req.tool_id)).await;
-    let Some(executable_path) = executable_path.filter(|s| !s.trim().is_empty()) else {
-        signal_tool_unconfigured_block(pool, bus, &req.project_id, &req.tool_id).await;
-        return Ok(ToolLaunchResponse {
-            status: ToolLaunchStatus::Error,
-            launch_id: None,
-            pid: None,
-            launched_at: None,
-            working_dir: None,
-            audit_id: None,
-            prior_instance_alive: false,
-            error: Some(ToolLaunchError {
-                code: "tool.not_configured".to_owned(),
-                message: format!("No executable path configured for tool '{}'", req.tool_id),
-            }),
-        });
-    };
-
-    // ── Step 3: resolve working directory ────────────────────────────────────
-    // `project.path` is the project root. Prefer the project's active
-    // generated source-view folder when one exists (spec 049 restored real
-    // generation, #726); fall back to the project root otherwise.
-    let project_root = std::path::PathBuf::from(&project.path);
-    let active_source_view = resolve_active_source_view_folder(pool, &req.project_id).await;
-    let working_dir_path = resolve_working_folder(&project_root, active_source_view.as_deref());
-
-    // ── Step 4: canonicalize cwd + library-root containment check ────────────
-    let canonical_cwd =
-        working_dir_path.canonicalize().unwrap_or_else(|_| working_dir_path.clone());
-    let all_roots = inv_repo::list_all_roots(pool).await.map_err(|e| format!("{e}"))?;
-    // Roots added through the setup wizard live in `registered_sources` (the
-    // gen-3 source model) and are only mirrored into the legacy `library_root`
-    // table on ingest. Include them so launching from a project anchored under
-    // the registered project folder passes containment (same fallback as
-    // plan_apply root resolution).
-    let registered = first_run_repo::list_sources(pool).await.map_err(|e| format!("{e}"))?;
-    // Canonicalize roots the same way as `canonical_cwd` so containment compares
-    // like-for-like (e.g. macOS `/var` -> `/private/var`, symlinked roots).
-    let root_paths: Vec<std::path::PathBuf> = all_roots
-        .iter()
-        .map(|r| r.current_path.as_str())
-        .chain(registered.iter().map(|s| s.path.as_str()))
-        .map(|raw| {
-            let p = std::path::PathBuf::from(raw);
-            p.canonicalize().unwrap_or(p)
-        })
-        .collect();
-    let root_refs: Vec<&std::path::Path> =
-        root_paths.iter().map(std::path::PathBuf::as_path).collect();
-
-    if let Err(code) = verify_cwd_containment(&canonical_cwd, &root_refs) {
-        return Ok(ToolLaunchResponse {
-            status: ToolLaunchStatus::Error,
-            launch_id: None,
-            pid: None,
-            launched_at: None,
-            working_dir: None,
-            audit_id: None,
-            prior_instance_alive: false,
-            error: Some(ToolLaunchError {
-                code: code.to_owned(),
-                message: format!(
-                    "Working directory '{}' is outside all registered library roots",
-                    canonical_cwd.display()
-                ),
-            }),
-        });
-    }
-
-    let working_dir_str = canonical_cwd.to_string_lossy().into_owned();
+    // ── Steps 3-4: resolve working directory + containment ───────────────────
+    let working_dir_str =
+        match resolve_and_check_working_dir(pool, &config.project.path, &req.project_id).await {
+            Ok(dir) => dir,
+            Err(resp) => return Ok(resp),
+        };
 
     // ── Step 5: re-launch guard ───────────────────────────────────────────────
     if !req.force {
@@ -359,111 +473,35 @@ pub async fn launch(
 
     // ── Step 6: render args template ──────────────────────────────────────────
     let ctx = RenderContext {
-        folder: if profile.supports_open_folder { Some(working_dir_str.as_str()) } else { None },
+        folder: if config.profile.supports_open_folder {
+            Some(working_dir_str.as_str())
+        } else {
+            None
+        },
         file: None,
     };
-    let argv = render(&profile.args_template, &ctx);
-    let args_hash = compute_args_hash(&executable_path, &argv);
+    let argv = render(&config.profile.args_template, &ctx);
+    let args_hash = compute_args_hash(&config.executable_path, &argv);
 
     // bundle_id from Settings (override) or seeded default
     let bundle_id_key = format!("tools.{}.bundle_id", req.tool_id);
     let bundle_id = read_string_setting(pool, &bundle_id_key)
         .await
-        .or_else(|| profile.bundle_id.map(ToOwned::to_owned));
+        .or_else(|| config.profile.bundle_id.map(ToOwned::to_owned));
 
-    // ── Step 7: spawn ─────────────────────────────────────────────────────────
-    let spawn_req = SpawnRequest {
-        executable: executable_path.clone(),
-        args: argv.clone(),
-        working_dir: working_dir_str.clone(),
-        bundle_id: bundle_id.clone(),
-    };
-
-    let launch_id = new_id();
-    let audit_id = new_id();
-    let launched_at = Timestamp::now_iso();
-
-    let (outcome, pid, error_response) = match spawner.spawn(spawn_req) {
-        Ok(result) => ("spawned", result.pid, None),
-        Err(LaunchError::MacOsQuarantine) => (
-            "spawn_failed",
-            None,
-            Some(ToolLaunchError {
-                code: "macos.quarantine.detected".to_owned(),
-                message:
-                    "macOS quarantined this app. Run `xattr -dr com.apple.quarantine <path>` and retry."
-                        .to_owned(),
-            }),
-        ),
-        Err(LaunchError::SpawnFailed(msg)) => (
-            "spawn_failed",
-            None,
-            Some(ToolLaunchError {
-                code: "launch.failed".to_owned(),
-                message: format!("OS error: {msg}"),
-            }),
-        ),
-    };
-
-    // ── Step 8: persist tool_launches row ────────────────────────────────────
-    let _ = tl_repo::insert_tool_launch(
+    // ── Steps 7-9: spawn, persist, emit audit ────────────────────────────────
+    spawn_and_record(
         pool,
-        &tl_repo::InsertToolLaunch {
-            id: &launch_id,
-            project_id: &req.project_id,
-            tool_id: &req.tool_id,
-            pid,
-            working_dir: Some(&working_dir_str),
-            args_hash: Some(&args_hash),
-            outcome,
-            audit_id: &audit_id,
-        },
+        bus,
+        spawner,
+        &req,
+        &config.executable_path,
+        argv,
+        args_hash,
+        &working_dir_str,
+        bundle_id,
     )
     .await
-    .map_err(|e| format!("{e}"))?;
-
-    // ── Step 9: emit audit event ──────────────────────────────────────────────
-    let _ = bus
-        .publish(
-            TOPIC_TOOL_LAUNCH,
-            Source::User,
-            ToolLaunchEvent {
-                launch_id: launch_id.clone(),
-                project_id: req.project_id.clone(),
-                tool_id: req.tool_id.clone(),
-                working_dir: Some(working_dir_str.clone()),
-                args_hash: Some(args_hash.clone()),
-                outcome: outcome.to_owned(),
-                at: launched_at.clone(),
-            },
-        )
-        .await
-        .map_err(|e| format!("audit bus: {e}"));
-
-    // Return response
-    if let Some(err) = error_response {
-        return Ok(ToolLaunchResponse {
-            status: ToolLaunchStatus::Error,
-            launch_id: Some(launch_id),
-            pid: None,
-            launched_at: Some(launched_at),
-            working_dir: Some(working_dir_str),
-            audit_id: Some(audit_id),
-            prior_instance_alive: false,
-            error: Some(err),
-        });
-    }
-
-    Ok(ToolLaunchResponse {
-        status: ToolLaunchStatus::Success,
-        launch_id: Some(launch_id),
-        pid,
-        launched_at: Some(launched_at),
-        working_dir: Some(working_dir_str),
-        audit_id: Some(audit_id),
-        prior_instance_alive: false,
-        error: None,
-    })
 }
 
 // ── list_profiles ─────────────────────────────────────────────────────────────

--- a/crates/app/settings/src/descriptors.rs
+++ b/crates/app/settings/src/descriptors.rs
@@ -736,58 +736,9 @@ pub fn check_rule(
                 return Err(invalid("must be an array"));
             }
         }
-        ValidationRule::PatternsByType => {
-            let obj = value.as_object().ok_or_else(|| invalid("must be an object"))?;
-            for (class_name, pattern_value) in obj {
-                if patterns::FrameTypeClass::from_str_name(class_name).is_none() {
-                    return Err(invalid(&format!("unknown frame-type class: {class_name}")));
-                }
-                let pattern = pattern_value.as_str().ok_or_else(|| {
-                    invalid(&format!("pattern for {class_name} must be a string"))
-                })?;
-                if let Err(e) = patterns::validate_pattern_str(pattern) {
-                    return Err(invalid(&format!("invalid pattern for {class_name}: {e}")));
-                }
-            }
-        }
+        ValidationRule::PatternsByType => check_patterns_by_type(value, invalid)?,
         ValidationRule::ObserverSites => check_observer_sites(value, invalid)?,
-        ValidationRule::MoonAvoidanceBands => {
-            const BANDS: [&str; 7] = ["L", "R", "G", "B", "Ha", "SII", "OIII"];
-            let obj = value.as_object().ok_or_else(|| invalid("must be an object"))?;
-            // Reject unknown/extra keys.
-            for key in obj.keys() {
-                if !BANDS.contains(&key.as_str()) {
-                    return Err(invalid(&format!("unknown band key: {key}")));
-                }
-            }
-            // Require exactly the seven bands, each with valid ranges.
-            for band in BANDS {
-                let entry =
-                    obj.get(band).ok_or_else(|| invalid(&format!("missing band: {band}")))?;
-                let band_obj = entry
-                    .as_object()
-                    .ok_or_else(|| invalid(&format!("{band} must be an object")))?;
-                for extra in band_obj.keys() {
-                    if extra != "distanceDeg" && extra != "widthDays" {
-                        return Err(invalid(&format!("{band}.{extra} is not allowed")));
-                    }
-                }
-                let distance = band_obj
-                    .get("distanceDeg")
-                    .and_then(serde_json::Value::as_f64)
-                    .ok_or_else(|| invalid(&format!("{band}.distanceDeg must be a number")))?;
-                if !(0.0..=180.0).contains(&distance) {
-                    return Err(invalid(&format!("{band}.distanceDeg must be in [0, 180]")));
-                }
-                let width = band_obj
-                    .get("widthDays")
-                    .and_then(serde_json::Value::as_f64)
-                    .ok_or_else(|| invalid(&format!("{band}.widthDays must be a number")))?;
-                if !(0.5..=30.0).contains(&width) {
-                    return Err(invalid(&format!("{band}.widthDays must be in [0.5, 30]")));
-                }
-            }
-        }
+        ValidationRule::MoonAvoidanceBands => check_moon_avoidance_bands(value, invalid)?,
         ValidationRule::DevMode => {
             // In release builds (without dev-tools feature), devMode is always false.
             #[cfg(not(feature = "dev-tools"))]
@@ -844,6 +795,67 @@ fn check_cleanup_type_overrides(
             return Err(invalid(&format!(
                 "action for {id_str} must be \"Keep\", \"Archive\", or \"Delete\""
             )));
+        }
+    }
+    Ok(())
+}
+
+/// Validate `patternsByType`: JSON object mapping `FrameTypeClass` names to
+/// pattern strings (spec 041 FR-026b).
+fn check_patterns_by_type(
+    value: &Value,
+    invalid: &impl Fn(&str) -> ContractError,
+) -> Result<(), ContractError> {
+    let obj = value.as_object().ok_or_else(|| invalid("must be an object"))?;
+    for (class_name, pattern_value) in obj {
+        if patterns::FrameTypeClass::from_str_name(class_name).is_none() {
+            return Err(invalid(&format!("unknown frame-type class: {class_name}")));
+        }
+        let pattern = pattern_value
+            .as_str()
+            .ok_or_else(|| invalid(&format!("pattern for {class_name} must be a string")))?;
+        if let Err(e) = patterns::validate_pattern_str(pattern) {
+            return Err(invalid(&format!("invalid pattern for {class_name}: {e}")));
+        }
+    }
+    Ok(())
+}
+
+/// Validate `plannerMoonAvoidance`: JSON object with exactly seven fixed band
+/// keys, each with `distanceDeg` in [0,180] and `widthDays` in [0.5,30] (spec 047).
+fn check_moon_avoidance_bands(
+    value: &Value,
+    invalid: &impl Fn(&str) -> ContractError,
+) -> Result<(), ContractError> {
+    const BANDS: [&str; 7] = ["L", "R", "G", "B", "Ha", "SII", "OIII"];
+    let obj = value.as_object().ok_or_else(|| invalid("must be an object"))?;
+    for key in obj.keys() {
+        if !BANDS.contains(&key.as_str()) {
+            return Err(invalid(&format!("unknown band key: {key}")));
+        }
+    }
+    for band in BANDS {
+        let entry = obj.get(band).ok_or_else(|| invalid(&format!("missing band: {band}")))?;
+        let band_obj =
+            entry.as_object().ok_or_else(|| invalid(&format!("{band} must be an object")))?;
+        for extra in band_obj.keys() {
+            if extra != "distanceDeg" && extra != "widthDays" {
+                return Err(invalid(&format!("{band}.{extra} is not allowed")));
+            }
+        }
+        let distance = band_obj
+            .get("distanceDeg")
+            .and_then(serde_json::Value::as_f64)
+            .ok_or_else(|| invalid(&format!("{band}.distanceDeg must be a number")))?;
+        if !(0.0..=180.0).contains(&distance) {
+            return Err(invalid(&format!("{band}.distanceDeg must be in [0, 180]")));
+        }
+        let width = band_obj
+            .get("widthDays")
+            .and_then(serde_json::Value::as_f64)
+            .ok_or_else(|| invalid(&format!("{band}.widthDays must be a number")))?;
+        if !(0.5..=30.0).contains(&width) {
+            return Err(invalid(&format!("{band}.widthDays must be in [0.5, 30]")));
         }
     }
     Ok(())

--- a/crates/contracts/core/src/log.rs
+++ b/crates/contracts/core/src/log.rs
@@ -38,6 +38,25 @@ pub enum LogEntrySource {
     Tool,
 }
 
+/// Prefix-to-source mapping table for [`LogEntrySource::from_topic`].
+const TOPIC_PREFIX_TABLE: &[(&str, LogEntrySource)] = &[
+    ("catalog.", LogEntrySource::Catalog),
+    ("plan.", LogEntrySource::Plan),
+    ("archive.", LogEntrySource::Plan),
+    ("workflow.", LogEntrySource::Workflow),
+    ("artifact.", LogEntrySource::Workflow),
+    ("lifecycle.", LogEntrySource::Lifecycle),
+    ("inventory.", LogEntrySource::Inventory),
+    ("settings.", LogEntrySource::Settings),
+    ("project.", LogEntrySource::Project),
+    ("target.", LogEntrySource::Target),
+    ("tool.", LogEntrySource::Tool),
+    ("audit.", LogEntrySource::Audit),
+    ("native.", LogEntrySource::Audit),
+    ("first_run.", LogEntrySource::Audit),
+    ("protection.", LogEntrySource::Audit),
+];
+
 impl LogEntrySource {
     /// Derive the source tag from an event-bus topic string.
     ///
@@ -45,33 +64,10 @@ impl LogEntrySource {
     /// should fall back to `LogEntrySource::Audit`.
     #[must_use]
     pub fn from_topic(topic: &str) -> Option<Self> {
-        if topic.starts_with("catalog.") {
-            Some(Self::Catalog)
-        } else if topic.starts_with("plan.") || topic.starts_with("archive.") {
-            Some(Self::Plan)
-        } else if topic.starts_with("workflow.") || topic.starts_with("artifact.") {
-            Some(Self::Workflow)
-        } else if topic.starts_with("lifecycle.") {
-            Some(Self::Lifecycle)
-        } else if topic.starts_with("inventory.") {
-            Some(Self::Inventory)
-        } else if topic.starts_with("settings.") {
-            Some(Self::Settings)
-        } else if topic.starts_with("project.") {
-            Some(Self::Project)
-        } else if topic.starts_with("target.") {
-            Some(Self::Target)
-        } else if topic.starts_with("tool.") {
-            Some(Self::Tool)
-        } else if topic.starts_with("audit.")
-            || topic.starts_with("native.")
-            || topic.starts_with("first_run.")
-            || topic.starts_with("protection.")
-        {
-            Some(Self::Audit)
-        } else {
-            None
-        }
+        TOPIC_PREFIX_TABLE
+            .iter()
+            .find(|(prefix, _)| topic.starts_with(prefix))
+            .map(|(_, source)| *source)
     }
 }
 
@@ -103,27 +99,25 @@ impl LogLevel {
     /// Defaults to `Info` for unknown topics.
     #[must_use]
     pub fn from_topic_and_payload(topic: &str, payload: &serde_json::Value) -> Self {
-        // Error-indicator suffixes (dot-separated topic segments, not file extensions).
-        #[allow(clippy::case_sensitive_file_extension_comparisons)]
-        let is_error_topic =
-            topic.ends_with(".failed") || topic.ends_with(".error") || topic.ends_with(".denied");
-        if is_error_topic {
-            return Self::Error;
-        }
-        // Warn-indicator suffixes.
-        #[allow(clippy::case_sensitive_file_extension_comparisons)]
-        let is_warn_topic = topic.ends_with(".warn")
-            || topic.ends_with(".repair")
-            || topic.ends_with(".missing")
-            || topic.ends_with(".stale")
-            || topic.ends_with(".lagged")
-            || topic.ends_with(".invalid");
-        if is_warn_topic {
-            return Self::Warn;
-        }
-        // Debug-indicator suffixes.
-        if topic.ends_with(".progress") || topic.ends_with(".snapshot") {
-            return Self::Debug;
+        /// Suffix-to-level mapping; first match wins.
+        const SUFFIX_LEVEL_TABLE: &[(&str, LogLevel)] = &[
+            (".failed", LogLevel::Error),
+            (".error", LogLevel::Error),
+            (".denied", LogLevel::Error),
+            (".warn", LogLevel::Warn),
+            (".repair", LogLevel::Warn),
+            (".missing", LogLevel::Warn),
+            (".stale", LogLevel::Warn),
+            (".lagged", LogLevel::Warn),
+            (".invalid", LogLevel::Warn),
+            (".progress", LogLevel::Debug),
+            (".snapshot", LogLevel::Debug),
+        ];
+
+        for &(suffix, level) in SUFFIX_LEVEL_TABLE {
+            if topic.ends_with(suffix) {
+                return level;
+            }
         }
         // Check payload for explicit level fields.
         if let Some(level_str) = payload.get("level").and_then(|v| v.as_str()) {
@@ -244,6 +238,23 @@ fn extract_request_id(payload: &serde_json::Value) -> Option<String> {
     None
 }
 
+/// Well-known payload id fields: (`snake_case`, `camelCase`, `entity_type`).
+const ENTITY_ID_FIELDS: &[(&str, &str, &str)] = &[
+    ("plan_id", "planId", "plan"),
+    ("project_id", "projectId", "project"),
+    ("artifact_id", "artifactId", "artifact"),
+    ("catalog_id", "catalogId", "catalog"),
+];
+
+/// Topic-prefix to entity-type inference table.
+const ENTITY_TOPIC_PREFIXES: &[(&str, &str)] = &[
+    ("plan.", "plan"),
+    ("archive.", "plan"),
+    ("catalog.", "catalog"),
+    ("artifact.", "artifact"),
+    ("workflow.", "artifact"),
+];
+
 fn extract_entity(topic: &str, payload: &serde_json::Value) -> (Option<String>, Option<String>) {
     // Try explicit entity_type / entity_id first.
     let et = payload
@@ -261,36 +272,18 @@ fn extract_entity(topic: &str, payload: &serde_json::Value) -> (Option<String>, 
     }
 
     // Try well-known id fields.
-    let plan_id = payload.get("plan_id").or_else(|| payload.get("planId")).and_then(|v| v.as_str());
-    if let Some(id) = plan_id {
-        return (Some("plan".to_owned()), Some(id.to_owned()));
-    }
-    let project_id =
-        payload.get("project_id").or_else(|| payload.get("projectId")).and_then(|v| v.as_str());
-    if let Some(id) = project_id {
-        return (Some("project".to_owned()), Some(id.to_owned()));
-    }
-    let artifact_id =
-        payload.get("artifact_id").or_else(|| payload.get("artifactId")).and_then(|v| v.as_str());
-    if let Some(id) = artifact_id {
-        return (Some("artifact".to_owned()), Some(id.to_owned()));
-    }
-    let catalog_id =
-        payload.get("catalog_id").or_else(|| payload.get("catalogId")).and_then(|v| v.as_str());
-    if let Some(id) = catalog_id {
-        return (Some("catalog".to_owned()), Some(id.to_owned()));
+    for &(snake, camel, entity_type) in ENTITY_ID_FIELDS {
+        let id = payload.get(snake).or_else(|| payload.get(camel)).and_then(|v| v.as_str());
+        if let Some(id) = id {
+            return (Some(entity_type.to_owned()), Some(id.to_owned()));
+        }
     }
 
     // Fall back to topic-based inference.
-    let entity_type = if topic.starts_with("plan.") || topic.starts_with("archive.") {
-        Some("plan".to_owned())
-    } else if topic.starts_with("catalog.") {
-        Some("catalog".to_owned())
-    } else if topic.starts_with("artifact.") || topic.starts_with("workflow.") {
-        Some("artifact".to_owned())
-    } else {
-        None
-    };
+    let entity_type = ENTITY_TOPIC_PREFIXES
+        .iter()
+        .find(|(prefix, _)| topic.starts_with(prefix))
+        .map(|(_, et)| (*et).to_owned());
     (entity_type, None)
 }
 

--- a/crates/contracts/core/src/sessions/heterogeneity/settings.rs
+++ b/crates/contracts/core/src/sessions/heterogeneity/settings.rs
@@ -239,73 +239,42 @@ impl MatchingSettings {
     /// # Panics
     ///
     /// Panics only if the fixed set of validation rules produces more than 500 issues.
-    #[allow(clippy::too_many_lines)]
     pub fn validate(&self) -> SettingsValidation {
-        let mut issues = Vec::new();
-        check_range(
-            &mut issues,
-            "sameSession.coverageMinPercent",
+        /// (`field_path`, value index, min, max, optional warning boundary + direction)
+        const RANGE_CHECKS: &[(&str, usize, f64, f64, Option<(f64, bool)>)] = &[
+            ("sameSession.coverageMinPercent", 0, 90.0, 99.5, Some((93.0, false))),
+            ("sameSession.centerSeparationMaxPercent", 1, 0.5, 5.0, Some((3.0, true))),
+            ("sameSession.rotationMaxDeg", 2, 0.25, 3.0, Some((2.0, true))),
+            ("sibling.coverageMinPercent", 3, 80.0, 95.0, Some((85.0, false))),
+            ("sibling.centerSeparationMaxPercent", 4, 2.0, 15.0, Some((10.0, true))),
+            ("sibling.rotationMaxDeg", 5, 1.0, 15.0, Some((10.0, true))),
+            ("mosaic.overlapMinPercent", 6, 1.0, 20.0, Some((3.0, false))),
+            ("mosaic.overlapMaxPercent", 7, 20.0, 60.0, Some((50.0, true))),
+            ("darkThermal.moderateDeg", 8, 0.1, 2.0, Some((1.0, true))),
+            ("darkThermal.severeDeg", 9, 0.5, 5.0, Some((3.0, true))),
+            ("flatOrientation.normalThroughDeg", 10, 0.5, 5.0, Some((3.0, true))),
+            ("flatOrientation.redAboveDeg", 11, 0.5, 15.0, Some((8.0, true))),
+        ];
+
+        let values: [FiniteDecimal; 12] = [
             self.same_session.coverage_min_percent,
-            90.0,
-            99.5,
-            Some((93.0, false)),
-        );
-        check_range(
-            &mut issues,
-            "sameSession.centerSeparationMaxPercent",
             self.same_session.center_separation_max_percent,
-            0.5,
-            5.0,
-            Some((3.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "sameSession.rotationMaxDeg",
             self.same_session.rotation_max_deg,
-            0.25,
-            3.0,
-            Some((2.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "sibling.coverageMinPercent",
             self.sibling.coverage_min_percent,
-            80.0,
-            95.0,
-            Some((85.0, false)),
-        );
-        check_range(
-            &mut issues,
-            "sibling.centerSeparationMaxPercent",
             self.sibling.center_separation_max_percent,
-            2.0,
-            15.0,
-            Some((10.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "sibling.rotationMaxDeg",
             self.sibling.rotation_max_deg,
-            1.0,
-            15.0,
-            Some((10.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "mosaic.overlapMinPercent",
             self.mosaic.overlap_min_percent,
-            1.0,
-            20.0,
-            Some((3.0, false)),
-        );
-        check_range(
-            &mut issues,
-            "mosaic.overlapMaxPercent",
             self.mosaic.overlap_max_percent,
-            20.0,
-            60.0,
-            Some((50.0, true)),
-        );
+            self.dark_thermal.moderate_deg,
+            self.dark_thermal.severe_deg,
+            self.flat_orientation.normal_through_deg,
+            self.flat_orientation.red_above_deg,
+        ];
+
+        let mut issues = Vec::new();
+        for &(field, idx, min, max, warning) in RANGE_CHECKS {
+            check_range(&mut issues, field, values[idx], min, max, warning);
+        }
         if (self.mosaic.residual_sky_rotation_cap_deg.get() - 90.0).abs() > f64::EPSILON {
             issues.push(issue(
                 "settings.fixed_rule_changed",
@@ -313,38 +282,6 @@ impl MatchingSettings {
                 "mosaic.residualSkyRotationCapDeg",
             ));
         }
-        check_range(
-            &mut issues,
-            "darkThermal.moderateDeg",
-            self.dark_thermal.moderate_deg,
-            0.1,
-            2.0,
-            Some((1.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "darkThermal.severeDeg",
-            self.dark_thermal.severe_deg,
-            0.5,
-            5.0,
-            Some((3.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "flatOrientation.normalThroughDeg",
-            self.flat_orientation.normal_through_deg,
-            0.5,
-            5.0,
-            Some((3.0, true)),
-        );
-        check_range(
-            &mut issues,
-            "flatOrientation.redAboveDeg",
-            self.flat_orientation.red_above_deg,
-            0.5,
-            15.0,
-            Some((8.0, true)),
-        );
         if !(7..=365).contains(&self.flat_age.red_after_nights) {
             issues.push(issue(
                 "settings.out_of_bounds",

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -133,137 +133,71 @@ fn merge_with_defaults(stored: Vec<(String, Value)>) -> DbResult<SettingsState> 
     Ok(state)
 }
 
-/// Apply a single stored key/value pair to a `SettingsState`.
-///
-/// Returns `Err(DbError::Serialise)` if the stored JSON cannot be
-/// deserialised into the expected Rust type for that key.
-#[allow(clippy::too_many_lines)]
-fn apply_key_to_state(key: &str, value: Value, state: &mut SettingsState) -> DbResult<()> {
-    match key {
-        "pattern" => {
-            state.pattern = serde_json::from_value(value).map_err(DbError::Serialise)?;
+/// Generates `apply_key_to_state` from a flat (json_key, field) table.
+macro_rules! settings_key_table {
+    ( $( $json_key:expr => $field:ident ),+ $(,)? ) => {
+        /// Apply a single stored key/value pair to a `SettingsState`.
+        ///
+        /// Returns `Err(DbError::Serialise)` if the stored JSON cannot be
+        /// deserialised into the expected Rust type for that key.
+        fn apply_key_to_state(key: &str, value: Value, state: &mut SettingsState) -> DbResult<()> {
+            match key {
+                $( $json_key => {
+                    state.$field = serde_json::from_value(value).map_err(DbError::Serialise)?;
+                } )+
+                _ => {
+                    // Structured-path keys (tools.*, workflow_profile.*) are not in the
+                    // static SettingsState bag; they are readable via resolve_setting.
+                }
+            }
+            Ok(())
         }
-        "autoApplyPattern" => {
-            state.auto_apply_pattern = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "alwaysPreviewBeforePlan" => {
-            state.always_preview_before_plan =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "followSymlinks" => {
-            state.follow_symlinks = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "hashOnScan" => {
-            state.hash_on_scan = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "darkMatchTolerance" => {
-            state.dark_match_tolerance =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "flatMatching" => {
-            state.flat_matching = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "suggestCalibration" => {
-            state.suggest_calibration =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "logLevel" => {
-            state.log_level = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "rememberFollowLogs" => {
-            state.remember_follow_logs =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "defaultProtection" => {
-            state.default_protection = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "blockPermanentDelete" => {
-            state.block_permanent_delete =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "protectedCategories" => {
-            state.protected_categories =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "currentLibraryId" => {
-            state.current_library_id = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "devMode" => {
-            state.dev_mode = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "calibrationDarkTempTolerance" => {
-            state.calibration_dark_temp_tolerance =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "calibrationPrefillSuggestion" => {
-            state.calibration_prefill_suggestion =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "calibrationDarkOverridePenalty" => {
-            state.calibration_dark_override_penalty =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "calibrationFlatOverridePenalty" => {
-            state.calibration_flat_override_penalty =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "calibrationBiasOverridePenalty" => {
-            state.calibration_bias_override_penalty =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "imagetypNormalizationUserMappings" => {
-            state.imagetyp_normalization_user_mappings =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        PATTERNS_BY_TYPE_KEY => {
-            state.patterns_by_type = serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "toolWatchExtensions" => {
-            state.tool_watch_extensions =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "toolAttributionWindowHours" => {
-            state.tool_attribution_window_hours =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        // Spec 049 T006: these two keys were wired into `crates/app/settings`
-        // (the `settings.update` command path) but missed here — `load_settings`
-        // (which `sourceview.generate` calls directly, not through the Tauri
-        // command layer) silently ignored a stored override and always
-        // returned the in-code default. Found while writing the spec 049 US3
-        // regeneration integration test, which needs a non-default link kind
-        // to exercise the "hardlink unsupported" refusal path in
-        // `preparedview.regenerate`.
-        "sourceViewLinkKindIntraDrive" => {
-            state.source_view_link_kind_intra_drive =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "sourceViewLinkKindCrossDrive" => {
-            state.source_view_link_kind_cross_drive =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "framingPointingFractionOfFov" => {
-            state.framing_pointing_fraction_of_fov =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "framingPointingFallbackDeg" => {
-            state.framing_pointing_fallback_deg =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "framingRotationToleranceDeg" => {
-            state.framing_rotation_tolerance_deg =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        "framingMosaicEnvelopeFractionOfFov" => {
-            state.framing_mosaic_envelope_fraction_of_fov =
-                serde_json::from_value(value).map_err(DbError::Serialise)?;
-        }
-        _ => {
-            // Structured-path keys (tools.*, workflow_profile.*) are not in the
-            // static SettingsState bag; they are readable via resolve_setting.
-        }
-    }
-    Ok(())
+
+        /// All JSON key strings handled by `apply_key_to_state` (for parity tests).
+        #[cfg(test)]
+        const APPLY_KEYS: &[&str] = &[ $( $json_key ),+ ];
+    };
+}
+
+settings_key_table! {
+    "pattern" => pattern,
+    "autoApplyPattern" => auto_apply_pattern,
+    "alwaysPreviewBeforePlan" => always_preview_before_plan,
+    "followSymlinks" => follow_symlinks,
+    "hashOnScan" => hash_on_scan,
+    "darkMatchTolerance" => dark_match_tolerance,
+    "flatMatching" => flat_matching,
+    "suggestCalibration" => suggest_calibration,
+    "logLevel" => log_level,
+    "rememberFollowLogs" => remember_follow_logs,
+    "defaultProtection" => default_protection,
+    "blockPermanentDelete" => block_permanent_delete,
+    "protectedCategories" => protected_categories,
+    "currentLibraryId" => current_library_id,
+    "devMode" => dev_mode,
+    "calibrationDarkTempTolerance" => calibration_dark_temp_tolerance,
+    "calibrationPrefillSuggestion" => calibration_prefill_suggestion,
+    "calibrationDarkOverridePenalty" => calibration_dark_override_penalty,
+    "calibrationFlatOverridePenalty" => calibration_flat_override_penalty,
+    "calibrationBiasOverridePenalty" => calibration_bias_override_penalty,
+    "calibrationAgingThresholdDays" => calibration_aging_threshold_days,
+    "imagetypNormalizationUserMappings" => imagetyp_normalization_user_mappings,
+    "patternsByType" => patterns_by_type,
+    "toolWatchExtensions" => tool_watch_extensions,
+    "toolAttributionWindowHours" => tool_attribution_window_hours,
+    "observingSites" => observing_sites,
+    "observingDefaultSiteId" => observing_default_site_id,
+    "observingActiveSiteId" => observing_active_site_id,
+    "usableAltitudeDeg" => usable_altitude_deg,
+    "plannerMoonAvoidance" => planner_moon_avoidance,
+    "sourceViewLinkKindIntraDrive" => source_view_link_kind_intra_drive,
+    "sourceViewLinkKindCrossDrive" => source_view_link_kind_cross_drive,
+    "cleanupTypeOverrides" => cleanup_type_overrides,
+    "theme" => theme,
+    "framingPointingFractionOfFov" => framing_pointing_fraction_of_fov,
+    "framingPointingFallbackDeg" => framing_pointing_fallback_deg,
+    "framingRotationToleranceDeg" => framing_rotation_tolerance_deg,
+    "framingMosaicEnvelopeFractionOfFov" => framing_mosaic_envelope_fraction_of_fov,
 }
 
 // ── Per-frame-type destination patterns (spec 041 FR-026b) ────────────────
@@ -698,6 +632,35 @@ mod tests {
             .unwrap();
         let loaded = get_source_override_raw(db.pool(), "src-1", "followSymlinks").await.unwrap();
         assert_eq!(loaded, Some(serde_json::json!(true)));
+    }
+
+    /// C-12 parity guard: `APPLY_KEYS` (the persistence hydration table) must
+    /// match the SettingsState wire field names.
+    #[test]
+    fn apply_keys_cover_all_settings_state_wire_fields() {
+        let state = SettingsState {
+            current_library_id: Some("__probe__".to_owned()),
+            observing_default_site_id: Some("__probe__".to_owned()),
+            observing_active_site_id: Some("__probe__".to_owned()),
+            ..SettingsState::default()
+        };
+        let state_json = serde_json::to_value(&state).expect("SettingsState serialises");
+        let wire_fields: std::collections::BTreeSet<&str> =
+            state_json.as_object().unwrap().keys().map(String::as_str).collect();
+        let apply_set: std::collections::BTreeSet<&str> = APPLY_KEYS.iter().copied().collect();
+
+        for field in &wire_fields {
+            assert!(
+                apply_set.contains(field),
+                "SettingsState wire field '{field}' missing from apply_key_to_state table;                  add it to the settings_key_table! macro in this file"
+            );
+        }
+        for key in &apply_set {
+            assert!(
+                wire_fields.contains(key),
+                "apply_key_to_state handles '{key}' but it is not a SettingsState wire field;                  remove it from the settings_key_table! macro"
+            );
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

Seven oversized-function extractions across four crates (movement-preserving, no behavior change):

- **plan_apply**: `spawn_executor_run` (328 NLOC, CCN 35) → per-terminal handlers in new `plan_apply/terminal.rs` (finish_completed/finish_cancelled/finish_paused + origin-closure dispatch).
- **tool_launch**: 209-line `launch` → `resolve_tool_config` / `resolve_and_check_working_dir` / `spawn_and_record` per its step comments.
- **settings persistence**: `apply_key_to_state` 34-arm match → declarative macro table + parity test against the descriptor registry (guards the shipped sourceViewLinkKind drift class).
- **descriptors**: `check_rule` (CCN 48) → `check_moon_avoidance_bands` + `check_patterns_by_type` extractions.
- **contracts**: heterogeneity `validate` (151 NLOC) → data-table of range tuples + loop; `from_topic`/`from_topic_and_payload`/`extract_entity` → table-driven prefix/suffix maps.

## Spec Context

Tracks-Bead: astro-plan-kyo7.46
Merge-Bead: astro-plan-j3k6

Wave-4 census C-11/C-12 + CU-4/11/12/13/15. Verified: workspace clippy -D warnings, fmt, tests green in app_core/persistence_lifecycle/contracts_core/app_core_settings. Contract shape unchanged (tables are internal).