### PR TITLE
feat: organize calibration sessions into camera and optical families with freshness-aware handoff

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -142,6 +142,7 @@ dependencies = [
  "persistence_calibration",
  "persistence_core",
  "persistence_lifecycle",
+ "persistence_sessions",
  "persistence_targets",
  "serde_json",
  "sqlx",

--- a/crates/app/calibration/Cargo.toml
+++ b/crates/app/calibration/Cargo.toml
@@ -16,6 +16,7 @@ domain_core = { path = "../../domain/core" }
 persistence_calibration = { path = "../../persistence/calibration" }
 persistence_core = { path = "../../persistence/core" }
 persistence_lifecycle = { path = "../../persistence/lifecycle" }
+persistence_sessions = { path = "../../persistence/sessions" }
 persistence_targets = { path = "../../persistence/targets" }
 serde_json.workspace = true
 sqlx.workspace = true

--- a/crates/app/calibration/src/lib.rs
+++ b/crates/app/calibration/src/lib.rs
@@ -18,6 +18,7 @@ pub mod caches;
 mod audit_ids;
 pub mod equipment;
 mod matching;
+pub mod session_handoff;
 mod tolerances;
 
 // `app_core::calibration::*` historically resolved to the flat calibration

--- a/crates/app/calibration/src/session_handoff/evidence.rs
+++ b/crates/app/calibration/src/session_handoff/evidence.rs
@@ -1,0 +1,679 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Candidate evidence evaluation for external-processor handoff.
+//!
+//! Converts persistence layer rows and domain types into
+//! [`CandidateEvidence`] projections used by the `calibration.candidate.list`
+//! query and snapshot creation.
+//!
+//! All evidence is evaluated at a captured `evaluation_at` instant — the
+//! caller supplies a pre-captured `Utc` timestamp; this module does not
+//! access a clock.
+
+use calibration_core::families::{
+    automatic_eligibility, dark_bias_age_state, dark_thermal_state_from_p95, flat_age_state,
+    flat_orientation_state, AgeState, AutomaticEligibility, EligibilityInput, OrientationState,
+    RecipeCompatibility, ThermalState,
+};
+use calibration_core::CalibrationKind;
+
+use persistence_sessions::repositories::calibration_sessions::availability::SourceAvailabilityRollupRow;
+use persistence_sessions::repositories::calibration_sessions::sessions::DarkThermalEvidenceRow;
+
+// ── Evidence projection ───────────────────────────────────────────────────────
+
+/// Evaluated candidate evidence for one session × requirement pair.
+///
+/// This struct is the domain projection consumed by the handoff snapshot
+/// builder and by the `calibration.candidate.list` query response mapper.
+/// Fields mirror the `CalibrationCandidateEvidence` contract DTO.
+#[derive(Debug, Clone)]
+pub struct CandidateEvidence {
+    /// Unique public evidence identity (UUIDv7 assigned before DB insert).
+    pub evidence_public_id: String,
+    pub session_public_id: String,
+    pub requirement_public_id: String,
+    pub kind: CalibrationKind,
+    pub recipe_compatibility: RecipeCompatibility,
+    pub recipe_evidence_complete: bool,
+    pub missing_recipe_fields: Vec<String>,
+    pub temperature_mode_str: String,
+    pub age: AgeEvidence,
+    pub thermal: ThermalEvidence,
+    pub orientation: OrientationEvidence,
+    pub source_availability: SourceAvailabilityEvidence,
+    /// `sufficient`: required evidence complete AND at least one readable frame.
+    pub sufficient: bool,
+    pub automatic_eligibility: AutomaticEligibility,
+    pub warning_codes: Vec<String>,
+    /// SHA-256 over a deterministic serialization of the evidence inputs.
+    pub basis_fingerprint: String,
+}
+
+/// Age evidence for a dark/bias (elapsed days) or flat (observing-night
+/// distance).
+#[derive(Debug, Clone)]
+pub struct AgeEvidence {
+    /// `"elapsed_days"` for dark/bias, `"observing_night_distance"` for flat.
+    pub basis: String,
+    pub state: AgeState,
+    /// Elapsed days (dark/bias) or night distance (flat). `None` when unknown.
+    pub age_value: Option<u32>,
+    pub fresh_threshold: u32,
+    pub red_threshold: u32,
+    /// Settings revision that supplied the thresholds.
+    pub settings_revision: u64,
+}
+
+/// Thermal deviation evidence for regulated dark sessions.
+#[derive(Debug, Clone)]
+pub struct ThermalEvidence {
+    pub state: ThermalState,
+    /// `Some` when valid readings were available.
+    pub valid_reading_percent: Option<f64>,
+    pub minimum_deviation_deg: Option<f64>,
+    pub median_deviation_deg: Option<f64>,
+    pub maximum_deviation_deg: Option<f64>,
+    pub percentile95_deviation_deg: Option<f64>,
+    pub missing_reading_count: u32,
+    pub invalid_reading_count: u32,
+    /// `Some` only for regulated dark; `None` for all others.
+    pub settings_revision: Option<u64>,
+}
+
+/// Physical-orientation evidence for flat sessions.
+#[derive(Debug, Clone)]
+pub struct OrientationEvidence {
+    pub state: OrientationState,
+    pub minimum_circular_delta_deg: Option<f64>,
+    pub normal_through_deg: Option<f64>,
+    pub red_above_deg: Option<f64>,
+    pub settings_revision: Option<u64>,
+}
+
+/// Frame source availability at evaluation time.
+#[derive(Debug, Clone)]
+pub struct SourceAvailabilityEvidence {
+    pub indexed_frame_count: u32,
+    pub available_readable_indexed_frame_count: u32,
+    pub checked_at: String,
+}
+
+// ── Input structs ─────────────────────────────────────────────────────────────
+
+/// Thresholds from `matching_settings_revision` used by this evaluator.
+#[derive(Debug, Clone)]
+pub struct MatchingSettings {
+    pub revision_number: u64,
+    /// Dark/bias fresh-through days (default 270, FR-070).
+    pub dark_bias_fresh_days: u32,
+    /// Dark/bias red-after days (default 365, FR-070).
+    pub dark_bias_red_days: u32,
+    /// Flat red-after nights (default 7, FR-074).
+    pub flat_red_nights: u32,
+    /// Dark thermal moderate threshold milli-Celsius (default 500, FR-088).
+    pub dark_thermal_moderate_millic: i32,
+    /// Dark thermal severe threshold milli-Celsius (default 2000, FR-088).
+    pub dark_thermal_severe_millic: i32,
+    /// Flat orientation normal threshold micro-degrees (default 2_000_000, FR-073).
+    pub flat_orientation_normal_udeg: u32,
+    /// Flat orientation red threshold micro-degrees (default 5_000_000, FR-073).
+    pub flat_orientation_red_udeg: u32,
+}
+
+/// Per-camera-kind age overrides (from `matching_settings_camera_policy`).
+#[derive(Debug, Clone)]
+pub struct CameraKindAgePolicy {
+    pub fresh_age_days: u32,
+    pub red_age_days: u32,
+}
+
+/// Physical rotator state of the flat candidate session.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PhysicalRotatorStateInput {
+    Verified,
+    Absent,
+    Unverified,
+}
+
+/// All inputs needed to evaluate one candidate evidence record.
+pub struct EvaluateEvidenceInput<'a> {
+    pub evidence_public_id: &'a str,
+    pub session_public_id: &'a str,
+    pub session_row_id: i64,
+    pub requirement_public_id: &'a str,
+    pub kind: CalibrationKind,
+    pub recipe_compatibility: RecipeCompatibility,
+    pub required_evidence_complete: bool,
+    pub candidate_evidence_complete: bool,
+    pub missing_recipe_fields: Vec<String>,
+    /// Temperature mode string: `"regulated"` / `"unregulated"` / `"unknown"` / `"not_applicable"`.
+    pub temperature_mode_str: String,
+    /// Age in elapsed calendar days (dark/bias) or observing-night distance (flat).
+    pub age_value: Option<u32>,
+    /// For flat: true when the candidate night equals the requirement night.
+    pub is_same_night_flat: bool,
+    /// Dark thermal evidence row; `None` for non-dark or unregulated.
+    pub thermal_evidence: Option<&'a DarkThermalEvidenceRow>,
+    /// Physical rotator state for flat orientation evaluation.
+    pub flat_rotator_state: Option<PhysicalRotatorStateInput>,
+    /// Circular delta in micro-degrees between candidate and requirement flat angles.
+    /// `None` when either is absent or unverified.
+    pub flat_rotator_delta_udeg: Option<u32>,
+    /// Source availability rollup; `None` means zero indexed frames.
+    pub availability: Option<&'a SourceAvailabilityRollupRow>,
+    /// UTC RFC 3339 string; already captured by the caller at `evaluation_at`.
+    pub observed_at: &'a str,
+    pub settings: &'a MatchingSettings,
+    pub camera_kind_policy: Option<&'a CameraKindAgePolicy>,
+    /// Deterministic evidence digest; callers compute via canonical serialization.
+    pub basis_fingerprint: String,
+}
+
+// ── Evaluation logic ──────────────────────────────────────────────────────────
+
+/// Evaluate full candidate evidence for one session × requirement pair.
+///
+/// Does not access the database or the filesystem. All inputs are already
+/// resolved by the caller before this function runs.
+#[must_use]
+#[allow(
+    clippy::too_many_lines,        // evaluation logic necessarily covers all evidence branches
+    clippy::cast_possible_truncation, // DB row i64 values are schema-constrained to fit target types
+    clippy::cast_sign_loss,        // DB row values are non-negative by schema constraints
+    clippy::cast_precision_loss,   // frame counts and percentages don't need full i64 precision
+)]
+pub fn evaluate_candidate_evidence(input: &EvaluateEvidenceInput<'_>) -> CandidateEvidence {
+    // ── Age ──────────────────────────────────────────────────────────────────
+    let (fresh_threshold, red_threshold, age_basis) = if input.kind == CalibrationKind::Flat {
+        (
+            calibration_core::families::FLAT_FRESH_NIGHTS_DEFAULT,
+            input.settings.flat_red_nights,
+            "observing_night_distance",
+        )
+    } else {
+        let (f, r) = match input.camera_kind_policy {
+            Some(p) => (p.fresh_age_days, p.red_age_days),
+            None => (input.settings.dark_bias_fresh_days, input.settings.dark_bias_red_days),
+        };
+        (f, r, "elapsed_days")
+    };
+
+    let age_state = match input.age_value {
+        None => AgeState::Unknown,
+        Some(v) => match input.kind {
+            CalibrationKind::Flat => flat_age_state(v, red_threshold),
+            _ => dark_bias_age_state(v, fresh_threshold, red_threshold),
+        },
+    };
+
+    let age = AgeEvidence {
+        basis: age_basis.to_owned(),
+        state: age_state,
+        age_value: input.age_value,
+        fresh_threshold,
+        red_threshold,
+        settings_revision: input.settings.revision_number,
+    };
+
+    // ── Thermal ──────────────────────────────────────────────────────────────
+    let thermal = match input.kind {
+        CalibrationKind::Dark => match input.temperature_mode_str.as_str() {
+            "regulated" => {
+                if let Some(ev) = input.thermal_evidence {
+                    let state = dark_thermal_state_from_p95(
+                        ev.p95_abs_deviation_millic.map(|v| v as i32),
+                        ev.valid_ratio_ppm as u32,
+                        input.settings.dark_thermal_moderate_millic,
+                        input.settings.dark_thermal_severe_millic,
+                    );
+                    let valid_pct = if ev.valid_count + ev.missing_count + ev.invalid_count > 0 {
+                        let total = (ev.valid_count + ev.missing_count + ev.invalid_count) as f64;
+                        Some(ev.valid_count as f64 / total * 100.0)
+                    } else {
+                        None
+                    };
+                    let millic_to_deg = |v: Option<i64>| v.map(|x| x as f64 / 1000.0);
+                    ThermalEvidence {
+                        state,
+                        valid_reading_percent: valid_pct,
+                        minimum_deviation_deg: millic_to_deg(ev.minimum_abs_deviation_millic),
+                        median_deviation_deg: millic_to_deg(ev.median_abs_deviation_millic),
+                        maximum_deviation_deg: millic_to_deg(ev.maximum_abs_deviation_millic),
+                        percentile95_deviation_deg: millic_to_deg(ev.p95_abs_deviation_millic),
+                        missing_reading_count: ev.missing_count as u32,
+                        invalid_reading_count: ev.invalid_count as u32,
+                        settings_revision: Some(input.settings.revision_number),
+                    }
+                } else {
+                    ThermalEvidence {
+                        state: ThermalState::Unknown,
+                        valid_reading_percent: None,
+                        minimum_deviation_deg: None,
+                        median_deviation_deg: None,
+                        maximum_deviation_deg: None,
+                        percentile95_deviation_deg: None,
+                        missing_reading_count: 0,
+                        invalid_reading_count: 0,
+                        settings_revision: Some(input.settings.revision_number),
+                    }
+                }
+            }
+            "unregulated" => not_applicable_thermal(),
+            _ => unknown_thermal(Some(input.settings.revision_number)),
+        },
+        _ => not_applicable_thermal(),
+    };
+
+    // ── Orientation ───────────────────────────────────────────────────────────
+    let orientation = match input.kind {
+        CalibrationKind::Flat => {
+            let delta = match input.flat_rotator_state {
+                Some(PhysicalRotatorStateInput::Verified) => input.flat_rotator_delta_udeg,
+                _ => None,
+            };
+            let state = flat_orientation_state(
+                delta,
+                input.settings.flat_orientation_normal_udeg,
+                input.settings.flat_orientation_red_udeg,
+            );
+            OrientationEvidence {
+                state,
+                minimum_circular_delta_deg: delta.map(|d| f64::from(d) / 1_000_000.0),
+                normal_through_deg: Some(
+                    f64::from(input.settings.flat_orientation_normal_udeg) / 1_000_000.0,
+                ),
+                red_above_deg: Some(
+                    f64::from(input.settings.flat_orientation_red_udeg) / 1_000_000.0,
+                ),
+                settings_revision: Some(input.settings.revision_number),
+            }
+        }
+        _ => OrientationEvidence {
+            state: OrientationState::NotApplicable,
+            minimum_circular_delta_deg: None,
+            normal_through_deg: None,
+            red_above_deg: None,
+            settings_revision: None,
+        },
+    };
+
+    // ── Source availability ───────────────────────────────────────────────────
+    let (indexed, readable, checked_at) = match input.availability {
+        Some(av) => {
+            (av.indexed_frame_count as u32, av.readable_frame_count as u32, av.observed_at.clone())
+        }
+        None => (0u32, 0u32, input.observed_at.to_owned()),
+    };
+    let source_availability = SourceAvailabilityEvidence {
+        indexed_frame_count: indexed,
+        available_readable_indexed_frame_count: readable,
+        checked_at,
+    };
+
+    let sufficient = input.required_evidence_complete && readable >= 1;
+
+    // ── Temperature mode (for eligibility) ────────────────────────────────────
+    let temperature_mode = match input.temperature_mode_str.as_str() {
+        "regulated" => calibration_core::families::TemperatureMode::Regulated,
+        "unregulated" => calibration_core::families::TemperatureMode::Unregulated,
+        "not_applicable" => calibration_core::families::TemperatureMode::NotApplicable,
+        _ => calibration_core::families::TemperatureMode::Unknown,
+    };
+
+    // ── Eligibility ────────────────────────────────────────────────────────────
+    let eligibility_input = EligibilityInput {
+        kind: input.kind,
+        recipe_compatibility: input.recipe_compatibility,
+        required_evidence_complete: input.required_evidence_complete,
+        candidate_evidence_complete: input.candidate_evidence_complete,
+        sufficient,
+        age_state,
+        thermal_state: thermal.state,
+        temperature_mode,
+        orientation_state: orientation.state,
+        is_same_night_flat: input.is_same_night_flat,
+    };
+    let auto_eligibility = automatic_eligibility(&eligibility_input);
+
+    // ── Warning codes ─────────────────────────────────────────────────────────
+    let mut warning_codes: Vec<String> = Vec::new();
+
+    // Missing recipe fields
+    for f in &input.missing_recipe_fields {
+        warning_codes.push(format!("calibration.missing_recipe_field:{f}"));
+    }
+    // Thermal warnings
+    if matches!(thermal.state, ThermalState::Yellow) {
+        warning_codes.push("calibration.thermal_yellow".to_owned());
+    }
+    if matches!(thermal.state, ThermalState::Red) {
+        warning_codes.push("calibration.thermal_red".to_owned());
+    }
+    // Orientation warnings
+    if matches!(orientation.state, OrientationState::Unknown) && input.kind == CalibrationKind::Flat
+    {
+        warning_codes.push("calibration.orientation_compatibility_unverified".to_owned());
+    }
+    if matches!(orientation.state, OrientationState::Yellow) {
+        warning_codes.push("calibration.orientation_yellow".to_owned());
+    }
+    if matches!(orientation.state, OrientationState::Red) {
+        warning_codes.push("calibration.orientation_red".to_owned());
+    }
+    // Age warnings
+    if matches!(age_state, AgeState::Yellow) {
+        warning_codes.push("calibration.age_yellow".to_owned());
+    }
+    if matches!(age_state, AgeState::Red) {
+        warning_codes.push("calibration.age_red".to_owned());
+    }
+    // Cross-night flat
+    if input.kind == CalibrationKind::Flat && !input.is_same_night_flat {
+        warning_codes.push("calibration.flat_cross_night".to_owned());
+    }
+    // Unregulated dark
+    if input.kind == CalibrationKind::Dark
+        && matches!(temperature_mode, calibration_core::families::TemperatureMode::Unregulated)
+    {
+        warning_codes.push("calibration.dark_unregulated".to_owned());
+    }
+
+    CandidateEvidence {
+        evidence_public_id: input.evidence_public_id.to_owned(),
+        session_public_id: input.session_public_id.to_owned(),
+        requirement_public_id: input.requirement_public_id.to_owned(),
+        kind: input.kind,
+        recipe_compatibility: input.recipe_compatibility,
+        recipe_evidence_complete: input.candidate_evidence_complete,
+        missing_recipe_fields: input.missing_recipe_fields.clone(),
+        temperature_mode_str: input.temperature_mode_str.clone(),
+        age,
+        thermal,
+        orientation,
+        source_availability,
+        sufficient,
+        automatic_eligibility: auto_eligibility,
+        warning_codes,
+        basis_fingerprint: input.basis_fingerprint.clone(),
+    }
+}
+
+fn not_applicable_thermal() -> ThermalEvidence {
+    ThermalEvidence {
+        state: ThermalState::NotApplicable,
+        valid_reading_percent: None,
+        minimum_deviation_deg: None,
+        median_deviation_deg: None,
+        maximum_deviation_deg: None,
+        percentile95_deviation_deg: None,
+        missing_reading_count: 0,
+        invalid_reading_count: 0,
+        settings_revision: None,
+    }
+}
+
+fn unknown_thermal(settings_revision: Option<u64>) -> ThermalEvidence {
+    ThermalEvidence {
+        state: ThermalState::Unknown,
+        valid_reading_percent: None,
+        minimum_deviation_deg: None,
+        median_deviation_deg: None,
+        maximum_deviation_deg: None,
+        percentile95_deviation_deg: None,
+        missing_reading_count: 0,
+        invalid_reading_count: 0,
+        settings_revision,
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use calibration_core::families::{
+        DARK_BIAS_FRESH_DAYS_DEFAULT, DARK_BIAS_RED_DAYS_DEFAULT,
+        DARK_THERMAL_MODERATE_MILLIC_DEFAULT, DARK_THERMAL_SEVERE_MILLIC_DEFAULT,
+        FLAT_ORIENTATION_NORMAL_UDEG_DEFAULT, FLAT_ORIENTATION_RED_UDEG_DEFAULT,
+        FLAT_RED_NIGHTS_DEFAULT,
+    };
+
+    fn default_settings() -> MatchingSettings {
+        MatchingSettings {
+            revision_number: 1,
+            dark_bias_fresh_days: DARK_BIAS_FRESH_DAYS_DEFAULT,
+            dark_bias_red_days: DARK_BIAS_RED_DAYS_DEFAULT,
+            flat_red_nights: FLAT_RED_NIGHTS_DEFAULT,
+            dark_thermal_moderate_millic: DARK_THERMAL_MODERATE_MILLIC_DEFAULT,
+            dark_thermal_severe_millic: DARK_THERMAL_SEVERE_MILLIC_DEFAULT,
+            flat_orientation_normal_udeg: FLAT_ORIENTATION_NORMAL_UDEG_DEFAULT,
+            flat_orientation_red_udeg: FLAT_ORIENTATION_RED_UDEG_DEFAULT,
+        }
+    }
+
+    fn fresh_dark_input(settings: &MatchingSettings) -> EvaluateEvidenceInput<'_> {
+        EvaluateEvidenceInput {
+            evidence_public_id: "ev-001",
+            session_public_id: "ses-001",
+            session_row_id: 1,
+            requirement_public_id: "req-001",
+            kind: CalibrationKind::Dark,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            missing_recipe_fields: vec![],
+            temperature_mode_str: "regulated".to_owned(),
+            age_value: Some(100),
+            is_same_night_flat: false,
+            thermal_evidence: None,
+            flat_rotator_state: None,
+            flat_rotator_delta_udeg: None,
+            availability: None,
+            observed_at: "2026-07-22T00:00:00.000000Z",
+            settings,
+            camera_kind_policy: None,
+            basis_fingerprint: "fingerprint-001".to_owned(),
+        }
+    }
+
+    #[test]
+    fn fresh_dark_with_no_availability_is_blocked() {
+        let settings = default_settings();
+        let input = fresh_dark_input(&settings);
+        let ev = evaluate_candidate_evidence(&input);
+        // No availability → sufficient = false → blocked
+        assert!(!ev.sufficient);
+        assert_eq!(ev.automatic_eligibility, AutomaticEligibility::Blocked);
+        assert_eq!(ev.age.state, AgeState::Fresh);
+    }
+
+    #[test]
+    fn fresh_dark_with_availability_and_thermal_is_eligible() {
+        let settings = default_settings();
+        let avail = SourceAvailabilityRollupRow {
+            session_row_id: 1,
+            indexed_frame_count: 100,
+            available_frame_count: 100,
+            readable_frame_count: 100,
+            source_byte_count: 1_000_000,
+            observed_at: "2026-07-22T00:00:00.000000Z".to_owned(),
+        };
+        let thermal = DarkThermalEvidenceRow {
+            session_row_id: 1,
+            valid_count: 100,
+            missing_count: 0,
+            invalid_count: 0,
+            minimum_abs_deviation_millic: Some(100),
+            median_abs_deviation_millic: Some(200),
+            maximum_abs_deviation_millic: Some(400),
+            p95_abs_deviation_millic: Some(350),
+            valid_ratio_ppm: 1_000_000,
+            severity: "normal".to_owned(),
+            created_sequence: 1,
+        };
+        let mut input = fresh_dark_input(&settings);
+        input.availability = Some(&avail);
+        input.thermal_evidence = Some(&thermal);
+        let ev = evaluate_candidate_evidence(&input);
+        assert!(ev.sufficient);
+        assert_eq!(ev.automatic_eligibility, AutomaticEligibility::Eligible);
+        assert_eq!(ev.thermal.state, ThermalState::Normal);
+        assert!(ev.warning_codes.is_empty());
+    }
+
+    #[test]
+    fn red_age_dark_yields_review_required() {
+        let avail = SourceAvailabilityRollupRow {
+            session_row_id: 1,
+            indexed_frame_count: 10,
+            available_frame_count: 10,
+            readable_frame_count: 10,
+            source_byte_count: 100_000,
+            observed_at: "2026-07-22T00:00:00.000000Z".to_owned(),
+        };
+        let thermal = DarkThermalEvidenceRow {
+            session_row_id: 1,
+            valid_count: 100,
+            missing_count: 0,
+            invalid_count: 0,
+            minimum_abs_deviation_millic: Some(100),
+            median_abs_deviation_millic: Some(200),
+            maximum_abs_deviation_millic: Some(300),
+            p95_abs_deviation_millic: Some(250),
+            valid_ratio_ppm: 1_000_000,
+            severity: "normal".to_owned(),
+            created_sequence: 1,
+        };
+        let settings_red = MatchingSettings {
+            dark_bias_fresh_days: 10,
+            dark_bias_red_days: 20,
+            ..default_settings()
+        };
+        let mut input = fresh_dark_input(&settings_red);
+        input.age_value = Some(400); // red age
+        input.availability = Some(&avail);
+        input.thermal_evidence = Some(&thermal);
+        let ev = evaluate_candidate_evidence(&input);
+        assert_eq!(ev.age.state, AgeState::Red);
+        assert_eq!(ev.automatic_eligibility, AutomaticEligibility::ReviewRequired);
+        assert!(ev.warning_codes.contains(&"calibration.age_red".to_owned()));
+    }
+
+    #[test]
+    fn same_night_flat_eligible_with_normal_orientation() {
+        let settings = default_settings();
+        let avail = SourceAvailabilityRollupRow {
+            session_row_id: 2,
+            indexed_frame_count: 20,
+            available_frame_count: 20,
+            readable_frame_count: 20,
+            source_byte_count: 200_000,
+            observed_at: "2026-07-22T00:00:00.000000Z".to_owned(),
+        };
+        let input = EvaluateEvidenceInput {
+            evidence_public_id: "ev-002",
+            session_public_id: "ses-002",
+            session_row_id: 2,
+            requirement_public_id: "req-002",
+            kind: CalibrationKind::Flat,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            missing_recipe_fields: vec![],
+            temperature_mode_str: "not_applicable".to_owned(),
+            age_value: Some(0), // same night
+            is_same_night_flat: true,
+            thermal_evidence: None,
+            flat_rotator_state: Some(PhysicalRotatorStateInput::Verified),
+            flat_rotator_delta_udeg: Some(500_000), // 0.5 degrees — within normal
+            availability: Some(&avail),
+            observed_at: "2026-07-22T00:00:00.000000Z",
+            settings: &settings,
+            camera_kind_policy: None,
+            basis_fingerprint: "fp-002".to_owned(),
+        };
+        let ev = evaluate_candidate_evidence(&input);
+        assert!(ev.sufficient);
+        assert_eq!(ev.orientation.state, OrientationState::Normal);
+        assert_eq!(ev.automatic_eligibility, AutomaticEligibility::Eligible);
+    }
+
+    #[test]
+    fn cross_night_flat_yields_review_required() {
+        let settings = default_settings();
+        let avail = SourceAvailabilityRollupRow {
+            session_row_id: 2,
+            indexed_frame_count: 20,
+            available_frame_count: 20,
+            readable_frame_count: 20,
+            source_byte_count: 200_000,
+            observed_at: "2026-07-22T00:00:00.000000Z".to_owned(),
+        };
+        let input = EvaluateEvidenceInput {
+            evidence_public_id: "ev-003",
+            session_public_id: "ses-003",
+            session_row_id: 2,
+            requirement_public_id: "req-003",
+            kind: CalibrationKind::Flat,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            missing_recipe_fields: vec![],
+            temperature_mode_str: "not_applicable".to_owned(),
+            age_value: Some(3),        // 3 nights away — yellow age
+            is_same_night_flat: false, // not same night
+            thermal_evidence: None,
+            flat_rotator_state: Some(PhysicalRotatorStateInput::Verified),
+            flat_rotator_delta_udeg: Some(0),
+            availability: Some(&avail),
+            observed_at: "2026-07-22T00:00:00.000000Z",
+            settings: &settings,
+            camera_kind_policy: None,
+            basis_fingerprint: "fp-003".to_owned(),
+        };
+        let ev = evaluate_candidate_evidence(&input);
+        assert_eq!(ev.automatic_eligibility, AutomaticEligibility::ReviewRequired);
+        assert!(ev.warning_codes.contains(&"calibration.flat_cross_night".to_owned()));
+    }
+
+    #[test]
+    fn bias_has_not_applicable_thermal_and_orientation() {
+        let settings = default_settings();
+        let avail = SourceAvailabilityRollupRow {
+            session_row_id: 3,
+            indexed_frame_count: 50,
+            available_frame_count: 50,
+            readable_frame_count: 50,
+            source_byte_count: 500_000,
+            observed_at: "2026-07-22T00:00:00.000000Z".to_owned(),
+        };
+        let input = EvaluateEvidenceInput {
+            evidence_public_id: "ev-004",
+            session_public_id: "ses-004",
+            session_row_id: 3,
+            requirement_public_id: "req-004",
+            kind: CalibrationKind::Bias,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            missing_recipe_fields: vec![],
+            temperature_mode_str: "not_applicable".to_owned(),
+            age_value: Some(50),
+            is_same_night_flat: false,
+            thermal_evidence: None,
+            flat_rotator_state: None,
+            flat_rotator_delta_udeg: None,
+            availability: Some(&avail),
+            observed_at: "2026-07-22T00:00:00.000000Z",
+            settings: &settings,
+            camera_kind_policy: None,
+            basis_fingerprint: "fp-004".to_owned(),
+        };
+        let ev = evaluate_candidate_evidence(&input);
+        assert_eq!(ev.thermal.state, ThermalState::NotApplicable);
+        assert_eq!(ev.orientation.state, OrientationState::NotApplicable);
+        assert_eq!(ev.automatic_eligibility, AutomaticEligibility::Eligible);
+    }
+}

--- a/crates/app/calibration/src/session_handoff/mod.rs
+++ b/crates/app/calibration/src/session_handoff/mod.rs
@@ -1,0 +1,24 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! External-processor calibration handoff aggregate (spec 062 US4).
+//!
+//! This module implements:
+//! - `snapshots` — snapshot creation and reviewed-addition succession.
+//! - `evidence` — candidate evidence evaluation (age, thermal, orientation,
+//!   source availability, automatic eligibility).
+//!
+//! The handoff command itself (`calibration.handoff.create` and
+//! `calibration.handoff.reviewed_add`) is asynchronous with:
+//! - `evaluationAt` captured from the trusted clock at the start, never from
+//!   caller input.
+//! - Verification outside the writer transaction (streaming frame hash loop).
+//! - One final `BEGIN IMMEDIATE` commit that revalidates the snapshot head
+//!   CAS before inserting the successor snapshot.
+//!
+//! This module owns the aggregate logic. Filesystem verification (open,
+//! hash, no-follow resolution) is the responsibility of the executor layer
+//! that calls into these use cases.
+
+pub mod evidence;
+pub mod snapshots;

--- a/crates/app/calibration/src/session_handoff/snapshots.rs
+++ b/crates/app/calibration/src/session_handoff/snapshots.rs
@@ -1,0 +1,470 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Snapshot creation and lease-generation fencing for external-handoff.
+//!
+//! This module owns the CAS logic for advancing the handoff head from one
+//! snapshot to its successor. The fencing token is `lease_generation` on
+//! the operation row; the head-advance CAS uses `head_generation` on the
+//! handoff aggregate.
+//!
+//! Verification (frame identity checks, byte hashing) runs outside this
+//! module and outside the writer transaction. This module only handles the
+//! final atomic commit path.
+
+use persistence_core::DbResult;
+use persistence_sessions::repositories::calibration_sessions::handoff::{
+    advance_handoff_head, insert_handoff, insert_handoff_operation, insert_handoff_snapshot,
+    insert_snapshot_requirement_mapping, insert_snapshot_selection_mapping, InsertHandoff,
+    InsertHandoffOperation, InsertHandoffSnapshot,
+};
+use sqlx::SqliteConnection;
+
+// ── Lease generation ──────────────────────────────────────────────────────────
+
+/// Fencing parameters for one handoff operation.
+///
+/// The `lease_generation` is incremented each time a resume claims the
+/// operation (FR-099). The snapshot's `basis_fingerprint` must match the
+/// source snapshot to detect stale predecessor chains.
+#[derive(Debug, Clone)]
+pub struct LeaseFencing {
+    pub operation_public_id: String,
+    pub operation_row_id: i64,
+    pub lease_generation: i64,
+}
+
+// ── Initial creation ─────────────────────────────────────────────────────────
+
+/// Parameters for creating the initial handoff aggregate + first snapshot.
+pub struct CreateHandoffParams<'a> {
+    pub handoff_public_id: &'a str,
+    pub snapshot_public_id: &'a str,
+    pub project_row_id: i64,
+    pub external_processor: &'a str,
+    pub evaluation_at: &'a str,
+    pub matching_settings_revision_row_id: i64,
+    pub basis_digest: &'a str,
+    pub requirement_count: i64,
+    pub selection_count: i64,
+    pub frame_count: i64,
+    pub source_byte_count: i64,
+    pub actor_row_id: i64,
+    pub command_row_id: i64,
+    pub created_sequence: i64,
+    pub created_at: &'a str,
+    /// Ordered `(requirement_row_id, snapshot_ordinal)` pairs to link.
+    pub requirement_ordinals: &'a [(i64, i64)],
+    /// Ordered `(selection_row_id, snapshot_ordinal)` pairs to link.
+    pub selection_ordinals: &'a [(i64, i64)],
+}
+
+/// Insert the initial handoff aggregate, first snapshot, and advance the head.
+///
+/// All three operations occur inside the caller's `BEGIN IMMEDIATE`
+/// transaction. The head CAS uses `expected_generation = 0` (the initial
+/// value after INSERT).
+///
+/// Returns `(handoff_row_id, snapshot_row_id)`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns [`DbError::CasFailed`] if the head advance fails (cannot occur
+/// on initial creation, but included for type consistency).
+pub async fn create_initial_handoff(
+    conn: &mut SqliteConnection,
+    params: &CreateHandoffParams<'_>,
+) -> DbResult<(i64, i64)> {
+    let handoff_row_id = insert_handoff(
+        conn,
+        &InsertHandoff {
+            public_id: params.handoff_public_id,
+            project_row_id: params.project_row_id,
+            external_processor: params.external_processor,
+            created_at: params.created_at,
+        },
+    )
+    .await?;
+
+    let snapshot_row_id = insert_handoff_snapshot(
+        conn,
+        &InsertHandoffSnapshot {
+            public_id: params.snapshot_public_id,
+            handoff_row_id,
+            predecessor_snapshot_row_id: None,
+            evaluation_at: params.evaluation_at,
+            matching_settings_revision_row_id: params.matching_settings_revision_row_id,
+            basis_digest: params.basis_digest,
+            requirement_count: params.requirement_count,
+            selection_count: params.selection_count,
+            frame_count: params.frame_count,
+            source_byte_count: params.source_byte_count,
+            actor_row_id: params.actor_row_id,
+            command_row_id: params.command_row_id,
+            created_sequence: params.created_sequence,
+            created_at: params.created_at,
+        },
+    )
+    .await?;
+
+    for (req_row_id, ordinal) in params.requirement_ordinals {
+        insert_snapshot_requirement_mapping(
+            conn,
+            snapshot_row_id,
+            *req_row_id,
+            handoff_row_id,
+            *ordinal,
+        )
+        .await?;
+    }
+    for (sel_row_id, ordinal) in params.selection_ordinals {
+        insert_snapshot_selection_mapping(
+            conn,
+            snapshot_row_id,
+            *sel_row_id,
+            handoff_row_id,
+            *ordinal,
+        )
+        .await?;
+    }
+
+    // CAS head advance: generation starts at 0 after INSERT.
+    advance_handoff_head(conn, handoff_row_id, snapshot_row_id, 0).await?;
+
+    Ok((handoff_row_id, snapshot_row_id))
+}
+
+// ── Successor snapshot (reviewed addition) ────────────────────────────────────
+
+/// Parameters for creating a successor snapshot after a reviewed selection.
+pub struct AddReviewedSelectionParams<'a> {
+    pub successor_snapshot_public_id: &'a str,
+    pub handoff_row_id: i64,
+    pub predecessor_snapshot_row_id: i64,
+    /// Expected `head_generation` — must match for the CAS to succeed.
+    pub expected_head_generation: i64,
+    pub evaluation_at: &'a str,
+    pub matching_settings_revision_row_id: i64,
+    pub basis_digest: &'a str,
+    pub requirement_count: i64,
+    /// Total selection count including the new reviewed selection.
+    pub selection_count: i64,
+    pub frame_count: i64,
+    pub source_byte_count: i64,
+    pub actor_row_id: i64,
+    pub command_row_id: i64,
+    pub created_sequence: i64,
+    pub created_at: &'a str,
+    /// All requirements from the predecessor snapshot (re-mapped to successor).
+    pub requirement_ordinals: &'a [(i64, i64)],
+    /// All selections from the predecessor snapshot plus the new one.
+    pub selection_ordinals: &'a [(i64, i64)],
+}
+
+/// Insert a successor snapshot and advance the handoff head by CAS.
+///
+/// Must run inside a `BEGIN IMMEDIATE` transaction that has already
+/// re-validated the source snapshot and head generation.
+///
+/// Returns the successor `snapshot_row_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::CasFailed`] when `expected_head_generation` does not
+/// match the current head generation.
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn add_reviewed_selection_snapshot(
+    conn: &mut SqliteConnection,
+    params: &AddReviewedSelectionParams<'_>,
+) -> DbResult<i64> {
+    let snapshot_row_id = insert_handoff_snapshot(
+        conn,
+        &InsertHandoffSnapshot {
+            public_id: params.successor_snapshot_public_id,
+            handoff_row_id: params.handoff_row_id,
+            predecessor_snapshot_row_id: Some(params.predecessor_snapshot_row_id),
+            evaluation_at: params.evaluation_at,
+            matching_settings_revision_row_id: params.matching_settings_revision_row_id,
+            basis_digest: params.basis_digest,
+            requirement_count: params.requirement_count,
+            selection_count: params.selection_count,
+            frame_count: params.frame_count,
+            source_byte_count: params.source_byte_count,
+            actor_row_id: params.actor_row_id,
+            command_row_id: params.command_row_id,
+            created_sequence: params.created_sequence,
+            created_at: params.created_at,
+        },
+    )
+    .await?;
+
+    for (req_row_id, ordinal) in params.requirement_ordinals {
+        insert_snapshot_requirement_mapping(
+            conn,
+            snapshot_row_id,
+            *req_row_id,
+            params.handoff_row_id,
+            *ordinal,
+        )
+        .await?;
+    }
+    for (sel_row_id, ordinal) in params.selection_ordinals {
+        insert_snapshot_selection_mapping(
+            conn,
+            snapshot_row_id,
+            *sel_row_id,
+            params.handoff_row_id,
+            *ordinal,
+        )
+        .await?;
+    }
+
+    advance_handoff_head(
+        conn,
+        params.handoff_row_id,
+        snapshot_row_id,
+        params.expected_head_generation,
+    )
+    .await?;
+
+    Ok(snapshot_row_id)
+}
+
+// ── Operation insertion ───────────────────────────────────────────────────────
+
+/// Insert an operation row for a new handoff creation or reviewed-addition.
+///
+/// Returns the `operation_row_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_operation_for_handoff(
+    conn: &mut SqliteConnection,
+    public_id: &str,
+    handoff_row_id: i64,
+    command_row_id: i64,
+    created_at: &str,
+) -> DbResult<i64> {
+    insert_handoff_operation(
+        conn,
+        &InsertHandoffOperation { public_id, handoff_row_id, command_row_id, created_at },
+    )
+    .await
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use persistence_core::DbError;
+    use persistence_sessions::repositories::calibration_sessions::handoff::{
+        get_handoff_by_public_id, get_snapshot_by_public_id,
+    };
+
+    async fn setup_db() -> sqlx::SqlitePool {
+        let db = persistence_core::Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    async fn seed_snapshot_prerequisites(pool: &sqlx::SqlitePool) {
+        let ts = "2026-07-22T00:00:00.000000Z";
+        sqlx::query(
+            "INSERT INTO spec062_actor VALUES (1,'00000000-0000-7000-e000-000000000001',?)",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .expect("actor");
+        sqlx::query("INSERT INTO spec062_config_revision VALUES (1,'00000000-0000-7000-e000-000000000002',1,'cfg-digest',?)").bind(ts).execute(pool).await.expect("config");
+        sqlx::query("INSERT INTO repository_change(command_row_id,created_at) VALUES (NULL,?)")
+            .bind(ts)
+            .execute(pool)
+            .await
+            .expect("repo_change");
+        sqlx::query("INSERT INTO command_execution (row_id,public_id,actor_row_id,operation,canonical_payload_digest,state,response_json,created_at,finished_at) VALUES (1,'00000000-0000-7000-e000-000000000003',1,'calibration.handoff.create','pd','applied','{}',?,?)").bind(ts).bind(ts).execute(pool).await.expect("command");
+        sqlx::query(
+            "INSERT INTO spec062_project (row_id,public_id,created_at) VALUES (1,'proj-pub-001',?)",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .expect("project");
+        sqlx::query("INSERT INTO matching_settings_revision (row_id,public_id,revision_number,same_session_coverage_min_ppm,same_session_centre_max_ppm,same_session_rotation_max_udeg,sibling_coverage_min_ppm,sibling_centre_max_ppm,sibling_rotation_max_udeg,mosaic_overlap_min_ppm,mosaic_overlap_max_ppm,dark_thermal_moderate_millic,dark_thermal_severe_millic,flat_orientation_normal_udeg,flat_orientation_red_udeg,flat_red_age_days,canonical_digest,actor_row_id,command_row_id,created_sequence,created_at) VALUES (1,'msr-001',1,950000,20000,1000000,900000,50000,5000000,50000,400000,500,2000,2000000,5000000,7,'msr-digest',1,1,1,?)").bind(ts).execute(pool).await.expect("settings");
+        sqlx::query("INSERT INTO matching_settings_head (singleton,head_revision_row_id,head_generation) VALUES (1,1,0)").execute(pool).await.expect("settings head");
+        sqlx::query("INSERT INTO repository_change(command_row_id,created_at) VALUES (NULL,?)")
+            .bind(ts)
+            .execute(pool)
+            .await
+            .expect("repo_change_2");
+    }
+
+    #[tokio::test]
+    async fn create_initial_handoff_sets_head() {
+        let pool = setup_db().await;
+        seed_snapshot_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let (handoff_row_id, snapshot_row_id) = create_initial_handoff(
+            &mut conn,
+            &CreateHandoffParams {
+                handoff_public_id: "ho-snap-001",
+                snapshot_public_id: "hs-snap-001",
+                project_row_id: 1,
+                external_processor: "pixinsight_wbpp",
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "basis-001",
+                requirement_count: 0,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+                requirement_ordinals: &[],
+                selection_ordinals: &[],
+            },
+        )
+        .await
+        .expect("create initial handoff");
+
+        let handoff = get_handoff_by_public_id(&pool, "ho-snap-001").await.expect("get handoff");
+        assert_eq!(handoff.row_id, handoff_row_id);
+        assert_eq!(handoff.head_snapshot_row_id, Some(snapshot_row_id));
+        assert_eq!(handoff.head_generation, 1);
+    }
+
+    #[tokio::test]
+    async fn successor_snapshot_advances_head() {
+        let pool = setup_db().await;
+        seed_snapshot_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let (handoff_row_id, first_snapshot_id) = create_initial_handoff(
+            &mut conn,
+            &CreateHandoffParams {
+                handoff_public_id: "ho-snap-002",
+                snapshot_public_id: "hs-snap-002",
+                project_row_id: 1,
+                external_processor: "siril",
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "basis-002",
+                requirement_count: 0,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+                requirement_ordinals: &[],
+                selection_ordinals: &[],
+            },
+        )
+        .await
+        .expect("initial");
+
+        // Need a second command for the reviewed addition
+        sqlx::query("INSERT INTO command_execution (row_id,public_id,actor_row_id,operation,canonical_payload_digest,state,response_json,created_at,finished_at) VALUES (2,'00000000-0000-7000-e000-000000000004',1,'calibration.handoff.reviewed_add','pd','applied','{}',?,?)").bind(ts).bind(ts).execute(&pool).await.expect("command2");
+
+        let successor_id = add_reviewed_selection_snapshot(
+            &mut conn,
+            &AddReviewedSelectionParams {
+                successor_snapshot_public_id: "hs-snap-002b",
+                handoff_row_id,
+                predecessor_snapshot_row_id: first_snapshot_id,
+                expected_head_generation: 1,
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "basis-002b",
+                requirement_count: 0,
+                selection_count: 1,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 2,
+                created_sequence: 2,
+                created_at: ts,
+                requirement_ordinals: &[],
+                selection_ordinals: &[],
+            },
+        )
+        .await
+        .expect("successor");
+
+        let handoff = get_handoff_by_public_id(&pool, "ho-snap-002").await.expect("get handoff");
+        assert_eq!(handoff.head_snapshot_row_id, Some(successor_id));
+        assert_eq!(handoff.head_generation, 2);
+
+        // Verify predecessor link
+        let snap = get_snapshot_by_public_id(&pool, "hs-snap-002b").await.expect("snap");
+        assert_eq!(snap.predecessor_snapshot_row_id, Some(first_snapshot_id));
+    }
+
+    #[tokio::test]
+    async fn successor_fails_with_stale_generation() {
+        let pool = setup_db().await;
+        seed_snapshot_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let (handoff_row_id, first_snapshot_id) = create_initial_handoff(
+            &mut conn,
+            &CreateHandoffParams {
+                handoff_public_id: "ho-snap-003",
+                snapshot_public_id: "hs-snap-003",
+                project_row_id: 1,
+                external_processor: "pixinsight_wbpp",
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "basis-003",
+                requirement_count: 0,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+                requirement_ordinals: &[],
+                selection_ordinals: &[],
+            },
+        )
+        .await
+        .expect("initial");
+
+        // Attempt successor with wrong generation (0 instead of 1)
+        let err = add_reviewed_selection_snapshot(
+            &mut conn,
+            &AddReviewedSelectionParams {
+                successor_snapshot_public_id: "hs-snap-003b",
+                handoff_row_id,
+                predecessor_snapshot_row_id: first_snapshot_id,
+                expected_head_generation: 0, // stale
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "basis-003b",
+                requirement_count: 0,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+                requirement_ordinals: &[],
+                selection_ordinals: &[],
+            },
+        )
+        .await;
+        assert!(matches!(err, Err(DbError::CasFailed(_))));
+    }
+}

--- a/crates/calibration/core/src/families.rs
+++ b/crates/calibration/core/src/families.rs
@@ -1,0 +1,721 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Calibration family domain model (spec 062 US4, FR-062 through FR-075).
+//!
+//! Pure domain types — no SQL, no filesystem reads.
+//! Persistence repositories map these to/from DB rows.
+//! App-layer use cases use these to evaluate candidate evidence.
+
+use serde::{Deserialize, Serialize};
+
+use crate::CalibrationKind;
+
+// ── Temperature mode ──────────────────────────────────────────────────────────
+
+/// Temperature regulation mode for a dark family or calibration session.
+///
+/// `Unregulated` is only valid for dark families after an explicit reviewed
+/// camera decision (FR-067, FR-068). `Unknown` applies to a dark session with
+/// no cooling set point when the camera has no accepted regulation decision.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum TemperatureMode {
+    Regulated,
+    Unregulated,
+    Unknown,
+    /// Applies to bias frames and non-dark calibration types.
+    NotApplicable,
+}
+
+impl TemperatureMode {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Regulated => "regulated",
+            Self::Unregulated => "unregulated",
+            Self::Unknown => "unknown",
+            Self::NotApplicable => "not_applicable",
+        }
+    }
+}
+
+// ── Age state ────────────────────────────────────────────────────────────────
+
+/// Freshness/age severity for a calibration candidate relative to a requirement.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AgeState {
+    Fresh,
+    Yellow,
+    Red,
+    Unknown,
+}
+
+impl AgeState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Fresh => "fresh",
+            Self::Yellow => "yellow",
+            Self::Red => "red",
+            Self::Unknown => "unknown",
+        }
+    }
+}
+
+// ── Thermal state ─────────────────────────────────────────────────────────────
+
+/// Thermal severity for a regulated dark session based on per-frame sensor
+/// temperature deviation from the cooling set point (FR-088).
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ThermalState {
+    Normal,
+    Yellow,
+    Red,
+    Unknown,
+    NotApplicable,
+}
+
+impl ThermalState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Yellow => "yellow",
+            Self::Red => "red",
+            Self::Unknown => "unknown",
+            Self::NotApplicable => "not_applicable",
+        }
+    }
+}
+
+// ── Orientation state ─────────────────────────────────────────────────────────
+
+/// Physical orientation compatibility severity for a flat candidate (FR-073, FR-089).
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum OrientationState {
+    Normal,
+    Yellow,
+    Red,
+    Unknown,
+    NotApplicable,
+}
+
+impl OrientationState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Normal => "normal",
+            Self::Yellow => "yellow",
+            Self::Red => "red",
+            Self::Unknown => "unknown",
+            Self::NotApplicable => "not_applicable",
+        }
+    }
+}
+
+// ── Recipe compatibility ──────────────────────────────────────────────────────
+
+/// Recipe-level compatibility result when comparing a candidate to a requirement.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RecipeCompatibility {
+    Compatible,
+    Incompatible,
+    Unknown,
+}
+
+// ── Automatic eligibility ─────────────────────────────────────────────────────
+
+/// Whether a calibration candidate can be selected automatically by the
+/// handoff creation command (contract `CalibrationCandidateEvidence.automaticEligibility`).
+///
+/// `Blocked` overrides `ReviewRequired`; review cannot override blocked.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AutomaticEligibility {
+    Eligible,
+    ReviewRequired,
+    Blocked,
+}
+
+impl AutomaticEligibility {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Eligible => "eligible",
+            Self::ReviewRequired => "review_required",
+            Self::Blocked => "blocked",
+        }
+    }
+}
+
+// ── Assignment state ──────────────────────────────────────────────────────────
+
+/// Family assignment state for a calibration session (FR-067).
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum AssignmentState {
+    Assigned,
+    BlockedUnknownTemperature,
+    NeedsReview,
+}
+
+impl AssignmentState {
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Assigned => "assigned",
+            Self::BlockedUnknownTemperature => "blocked_unknown_temperature",
+            Self::NeedsReview => "needs_review",
+        }
+    }
+}
+
+// ── Exposure tolerance ────────────────────────────────────────────────────────
+
+/// Compute the dark exposure matching tolerance in microseconds (FR-065).
+///
+/// Formula: `max(1000, min(100000, representative_us / 2000))`.
+///
+/// Uses integer microseconds to avoid floating-point accumulation across
+/// the tolerance boundary. The spec states the same formula as
+/// `max(1 ms, min(100 ms, 0.05% of representative))`.
+///
+/// # Examples
+///
+/// ```
+/// use calibration_core::families::dark_exposure_tolerance_us;
+/// assert_eq!(dark_exposure_tolerance_us(0), 1_000);
+/// assert_eq!(dark_exposure_tolerance_us(60_000_000), 30_000);
+/// assert_eq!(dark_exposure_tolerance_us(300_000_000), 100_000);
+/// ```
+#[must_use]
+pub fn dark_exposure_tolerance_us(representative_us: u64) -> u64 {
+    let raw = representative_us / 2000;
+    raw.clamp(1_000, 100_000)
+}
+
+// ── Dark thermal evidence ─────────────────────────────────────────────────────
+
+/// Per-session dark thermal deviation statistics (FR-066, FR-088).
+///
+/// All deviation fields are in integer milli-Celsius. Missing readings are
+/// excluded from statistics; fewer than 80 % valid readings yields `Unknown`
+/// severity from the DB trigger, not derived here.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DarkThermalEvidence {
+    pub valid_count: u32,
+    pub missing_count: u32,
+    pub invalid_count: u32,
+    /// All deviation fields in milli-Celsius; `None` when `valid_count == 0`.
+    pub minimum_abs_deviation_millic: Option<i32>,
+    pub median_abs_deviation_millic: Option<i32>,
+    pub maximum_abs_deviation_millic: Option<i32>,
+    pub p95_abs_deviation_millic: Option<i32>,
+    /// Parts per million of valid readings. `< 800_000` → severity `Unknown`.
+    pub valid_ratio_ppm: u32,
+    pub severity: ThermalState,
+}
+
+// ── Source availability ───────────────────────────────────────────────────────
+
+/// Rebuilt per-session frame-availability projection (FR-071 sufficiency rule).
+///
+/// `sufficient` is true when `readable_frame_count >= 1` and the parent
+/// calibration-session recipe evidence is complete. Sufficiency is evaluated
+/// at query time, not stored here.
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct SourceAvailability {
+    pub indexed_frame_count: u32,
+    pub available_readable_indexed_frame_count: u32,
+    /// UTC RFC 3339 timestamp string when this projection was observed.
+    pub checked_at: String,
+}
+
+// ── Family recipe types ───────────────────────────────────────────────────────
+
+/// Physical orientation evidence state for a flat session (FR-089).
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum PhysicalRotatorState {
+    /// Confirmed from a verified capture field; angle is present.
+    Verified,
+    /// Field not populated.
+    Absent,
+    /// Field present but not from a verified capture field.
+    Unverified,
+}
+
+/// State/value pair encoding for an optional discrete field.
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum FieldState {
+    Present,
+    Absent,
+}
+
+/// Dark family recipe identity (FR-065, FR-067).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct DarkRecipe {
+    pub temperature_mode: TemperatureMode,
+    /// `Some` only when `temperature_mode == Regulated`.
+    pub cooling_setpoint_millic: Option<i32>,
+    pub representative_exposure_us: u64,
+    pub gain_text: String,
+    pub offset_state: FieldState,
+    pub offset_value: Option<i64>,
+    pub binning_state: FieldState,
+    pub bin_x: Option<u32>,
+    pub bin_y: Option<u32>,
+    pub readout_state: FieldState,
+    pub readout_mode: Option<String>,
+    pub raster_width: u32,
+    pub raster_height: u32,
+}
+
+impl DarkRecipe {
+    /// Exposure tolerance in microseconds for this recipe (FR-065).
+    #[must_use]
+    pub fn exposure_tolerance_us(&self) -> u64 {
+        dark_exposure_tolerance_us(self.representative_exposure_us)
+    }
+
+    /// Return `true` when `candidate_exposure_us` is within tolerance.
+    #[must_use]
+    pub fn exposure_matches(&self, candidate_exposure_us: u64) -> bool {
+        let tol = self.exposure_tolerance_us();
+        let rep = self.representative_exposure_us;
+        let lo = rep.saturating_sub(tol);
+        let hi = rep.saturating_add(tol);
+        (lo..=hi).contains(&candidate_exposure_us)
+    }
+}
+
+/// Bias family recipe identity (FR-069).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BiasRecipe {
+    pub gain_text: String,
+    pub offset_state: FieldState,
+    pub offset_value: Option<i64>,
+    pub binning_state: FieldState,
+    pub bin_x: Option<u32>,
+    pub bin_y: Option<u32>,
+    pub readout_state: FieldState,
+    pub readout_mode: Option<String>,
+    pub raster_width: u32,
+    pub raster_height: u32,
+}
+
+/// Flat family identity (FR-072).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct FlatFamilyIdentity {
+    pub gain_text: String,
+    pub offset_state: FieldState,
+    pub offset_value: Option<i64>,
+    pub binning_state: FieldState,
+    pub bin_x: Option<u32>,
+    pub bin_y: Option<u32>,
+    pub readout_state: FieldState,
+    pub readout_mode: Option<String>,
+    pub raster_width: u32,
+    pub raster_height: u32,
+    /// Physical orientation state: `Verified`, `Absent`, or `Unverified`.
+    pub physical_rotator_state: PhysicalRotatorState,
+    /// Micro-degrees; `Some` only when `physical_rotator_state == Verified`.
+    pub physical_rotator_udeg: Option<i32>,
+}
+
+/// A calibration family aggregating sessions sharing the same recipe.
+///
+/// `kind` is one of `dark`, `bias`, or `flat`.
+/// Dark and bias families are owned by a `camera_id`; flat families by
+/// `optical_profile_id` and `filter_label_id` scoped to that profile.
+#[derive(Clone, Debug)]
+pub struct CalibrationFamily {
+    /// Public UUIDv7 identity.
+    pub public_id: String,
+    pub kind: CalibrationKind,
+    /// Present for dark and bias families.
+    pub camera_id: Option<String>,
+    /// Present for flat families.
+    pub optical_profile_id: Option<String>,
+    /// Present for flat families (scoped to optical_profile_id).
+    pub filter_label_id: Option<String>,
+    pub identity_digest: String,
+    /// Public ID of the representative session (immutable once set).
+    pub representative_session_id: String,
+}
+
+// ── Age evaluation ────────────────────────────────────────────────────────────
+
+/// Default dark/bias age thresholds in days (FR-070).
+pub const DARK_BIAS_FRESH_DAYS_DEFAULT: u32 = 270;
+pub const DARK_BIAS_RED_DAYS_DEFAULT: u32 = 365;
+
+/// Default flat age thresholds in observing-night distance (FR-074).
+pub const FLAT_FRESH_NIGHTS_DEFAULT: u32 = 1;
+pub const FLAT_RED_NIGHTS_DEFAULT: u32 = 7;
+
+/// Evaluate dark or bias age severity given elapsed calendar days.
+///
+/// Uses per-camera-kind configured boundaries when available; falls back to
+/// [`DARK_BIAS_FRESH_DAYS_DEFAULT`] / [`DARK_BIAS_RED_DAYS_DEFAULT`].
+///
+/// Yellow is `[fresh_days + 1, red_days]`; red is `> red_days`.
+#[must_use]
+pub fn dark_bias_age_state(
+    age_days: u32,
+    fresh_through_days: u32,
+    red_after_days: u32,
+) -> AgeState {
+    if age_days <= fresh_through_days {
+        AgeState::Fresh
+    } else if age_days <= red_after_days {
+        AgeState::Yellow
+    } else {
+        AgeState::Red
+    }
+}
+
+/// Evaluate flat age severity given observing-night distance (FR-074).
+///
+/// Same-night (distance 0) and one-night-old are `Fresh`. Two through
+/// `red_after_nights` (exclusive) are `Yellow`. Above is `Red`.
+#[must_use]
+pub fn flat_age_state(night_distance: u32, red_after_nights: u32) -> AgeState {
+    if night_distance <= FLAT_FRESH_NIGHTS_DEFAULT {
+        AgeState::Fresh
+    } else if night_distance <= red_after_nights {
+        AgeState::Yellow
+    } else {
+        AgeState::Red
+    }
+}
+
+/// Evaluate flat physical orientation severity (FR-073, FR-088).
+///
+/// `delta_udeg` is the minimum circular delta in micro-degrees.
+/// `normal_through_udeg` / `red_above_udeg` are the configured thresholds.
+/// Absent or unverified physical orientation yields `Unknown`.
+#[must_use]
+pub fn flat_orientation_state(
+    delta_udeg: Option<u32>,
+    normal_through_udeg: u32,
+    red_above_udeg: u32,
+) -> OrientationState {
+    match delta_udeg {
+        None => OrientationState::Unknown,
+        Some(d) => {
+            if d <= normal_through_udeg {
+                OrientationState::Normal
+            } else if d <= red_above_udeg {
+                OrientationState::Yellow
+            } else {
+                OrientationState::Red
+            }
+        }
+    }
+}
+
+/// Default flat orientation thresholds in micro-degrees (FR-073).
+pub const FLAT_ORIENTATION_NORMAL_UDEG_DEFAULT: u32 = 2_000_000;
+pub const FLAT_ORIENTATION_RED_UDEG_DEFAULT: u32 = 5_000_000;
+
+/// Evaluate dark regulated thermal severity from p95 absolute deviation (FR-088).
+///
+/// `moderate_millic` / `severe_millic` come from `matching_settings_revision`.
+#[must_use]
+pub fn dark_thermal_state_from_p95(
+    p95_millic: Option<i32>,
+    valid_ratio_ppm: u32,
+    moderate_millic: i32,
+    severe_millic: i32,
+) -> ThermalState {
+    // Fewer than 80 % valid readings → unknown, blocks automatic selection.
+    if valid_ratio_ppm < 800_000 {
+        return ThermalState::Unknown;
+    }
+    match p95_millic {
+        None => ThermalState::Unknown,
+        Some(p95) => {
+            let p95_abs = p95.unsigned_abs();
+            // Thresholds are schema-guaranteed positive; cast to u32 to avoid
+            // a signed comparison that could wrap (clippy::cast_possible_wrap).
+            let moderate = moderate_millic.unsigned_abs();
+            let severe = severe_millic.unsigned_abs();
+            if p95_abs <= moderate {
+                ThermalState::Normal
+            } else if p95_abs <= severe {
+                ThermalState::Yellow
+            } else {
+                ThermalState::Red
+            }
+        }
+    }
+}
+
+/// Default dark thermal thresholds in milli-Celsius (FR-088).
+pub const DARK_THERMAL_MODERATE_MILLIC_DEFAULT: i32 = 500;
+pub const DARK_THERMAL_SEVERE_MILLIC_DEFAULT: i32 = 2_000;
+
+// ── Automatic eligibility evaluation ─────────────────────────────────────────
+
+/// Parameters for computing [`AutomaticEligibility`].
+///
+/// Mirrors the conditions in the contract definition and FR-071 / FR-074.
+#[allow(clippy::struct_excessive_bools)] // all flags are independent eligibility conditions, not state machine axes
+pub struct EligibilityInput {
+    pub kind: CalibrationKind,
+    pub recipe_compatibility: RecipeCompatibility,
+    pub required_evidence_complete: bool,
+    pub candidate_evidence_complete: bool,
+    pub sufficient: bool,
+    pub age_state: AgeState,
+    pub thermal_state: ThermalState,
+    pub temperature_mode: TemperatureMode,
+    pub orientation_state: OrientationState,
+    /// True when this flat candidate is from the same observing night as its
+    /// light requirement (FR-074, contract).
+    pub is_same_night_flat: bool,
+}
+
+/// Evaluate automatic eligibility from pre-computed evidence fields.
+///
+/// The returned eligibility follows the contract priority: `Blocked` ≥
+/// `ReviewRequired` ≥ `Eligible`.
+#[must_use]
+pub fn automatic_eligibility(input: &EligibilityInput) -> AutomaticEligibility {
+    // Blocked conditions (cannot be overridden by review).
+    if !input.required_evidence_complete
+        || !input.candidate_evidence_complete
+        || !input.sufficient
+        || matches!(input.age_state, AgeState::Unknown)
+        || matches!(input.recipe_compatibility, RecipeCompatibility::Unknown)
+        || matches!(input.temperature_mode, TemperatureMode::Unknown)
+    {
+        return AutomaticEligibility::Blocked;
+    }
+    // Dark: unregulated temperature mode is blocked for automatic.
+    if input.kind == CalibrationKind::Dark
+        && matches!(input.temperature_mode, TemperatureMode::Unregulated)
+    {
+        return AutomaticEligibility::Blocked;
+    }
+    // Incompatible recipe is always blocked.
+    if matches!(input.recipe_compatibility, RecipeCompatibility::Incompatible) {
+        return AutomaticEligibility::Blocked;
+    }
+
+    // Review required conditions.
+    if matches!(input.age_state, AgeState::Red) {
+        return AutomaticEligibility::ReviewRequired;
+    }
+    if input.kind == CalibrationKind::Dark && matches!(input.thermal_state, ThermalState::Red) {
+        return AutomaticEligibility::ReviewRequired;
+    }
+    // Flat: cross-night or red orientation → review required.
+    if input.kind == CalibrationKind::Flat {
+        if !input.is_same_night_flat {
+            return AutomaticEligibility::ReviewRequired;
+        }
+        if matches!(input.orientation_state, OrientationState::Red) {
+            return AutomaticEligibility::ReviewRequired;
+        }
+    }
+
+    AutomaticEligibility::Eligible
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dark_exposure_tolerance_clamps_low() {
+        assert_eq!(dark_exposure_tolerance_us(0), 1_000);
+        assert_eq!(dark_exposure_tolerance_us(1_000_000), 1_000); // 1s → 500 µs → clamp to 1000
+    }
+
+    #[test]
+    fn dark_exposure_tolerance_clamps_high() {
+        // 300s = 300_000_000 µs → 300_000_000 / 2000 = 150_000 → clamp to 100_000
+        assert_eq!(dark_exposure_tolerance_us(300_000_000), 100_000);
+    }
+
+    #[test]
+    fn dark_exposure_tolerance_midrange() {
+        // 60s = 60_000_000 µs → 60_000_000 / 2000 = 30_000 → no clamp
+        assert_eq!(dark_exposure_tolerance_us(60_000_000), 30_000);
+    }
+
+    #[test]
+    fn dark_exposure_matches() {
+        let recipe = DarkRecipe {
+            temperature_mode: TemperatureMode::Regulated,
+            cooling_setpoint_millic: Some(-10_000),
+            representative_exposure_us: 60_000_000, // 60 s → tol 30_000
+            gain_text: "100".to_owned(),
+            offset_state: FieldState::Present,
+            offset_value: Some(50),
+            binning_state: FieldState::Present,
+            bin_x: Some(1),
+            bin_y: Some(1),
+            readout_state: FieldState::Absent,
+            readout_mode: None,
+            raster_width: 4096,
+            raster_height: 2160,
+        };
+        assert!(recipe.exposure_matches(60_000_000));
+        assert!(recipe.exposure_matches(60_030_000));
+        assert!(recipe.exposure_matches(59_970_000));
+        assert!(!recipe.exposure_matches(60_030_001));
+    }
+
+    #[test]
+    fn dark_bias_age_thresholds() {
+        let (fresh, red) = (270, 365);
+        assert_eq!(dark_bias_age_state(0, fresh, red), AgeState::Fresh);
+        assert_eq!(dark_bias_age_state(270, fresh, red), AgeState::Fresh);
+        assert_eq!(dark_bias_age_state(271, fresh, red), AgeState::Yellow);
+        assert_eq!(dark_bias_age_state(365, fresh, red), AgeState::Yellow);
+        assert_eq!(dark_bias_age_state(366, fresh, red), AgeState::Red);
+    }
+
+    #[test]
+    fn flat_age_thresholds() {
+        assert_eq!(flat_age_state(0, 7), AgeState::Fresh);
+        assert_eq!(flat_age_state(1, 7), AgeState::Fresh);
+        assert_eq!(flat_age_state(2, 7), AgeState::Yellow);
+        assert_eq!(flat_age_state(7, 7), AgeState::Yellow);
+        assert_eq!(flat_age_state(8, 7), AgeState::Red);
+    }
+
+    #[test]
+    fn flat_orientation_thresholds() {
+        let (n, r) = (2_000_000, 5_000_000);
+        assert_eq!(flat_orientation_state(None, n, r), OrientationState::Unknown);
+        assert_eq!(flat_orientation_state(Some(0), n, r), OrientationState::Normal);
+        assert_eq!(flat_orientation_state(Some(2_000_000), n, r), OrientationState::Normal);
+        assert_eq!(flat_orientation_state(Some(2_000_001), n, r), OrientationState::Yellow);
+        assert_eq!(flat_orientation_state(Some(5_000_000), n, r), OrientationState::Yellow);
+        assert_eq!(flat_orientation_state(Some(5_000_001), n, r), OrientationState::Red);
+    }
+
+    #[test]
+    fn thermal_state_low_valid_ratio_is_unknown() {
+        // < 80% valid reads → Unknown regardless of p95
+        assert_eq!(
+            dark_thermal_state_from_p95(Some(100), 799_999, 500, 2_000),
+            ThermalState::Unknown
+        );
+    }
+
+    #[test]
+    fn thermal_state_normal() {
+        assert_eq!(
+            dark_thermal_state_from_p95(Some(500), 900_000, 500, 2_000),
+            ThermalState::Normal
+        );
+    }
+
+    #[test]
+    fn thermal_state_yellow_and_red() {
+        assert_eq!(
+            dark_thermal_state_from_p95(Some(2_000), 900_000, 500, 2_000),
+            ThermalState::Yellow
+        );
+        assert_eq!(
+            dark_thermal_state_from_p95(Some(2_001), 900_000, 500, 2_000),
+            ThermalState::Red
+        );
+    }
+
+    #[test]
+    fn eligibility_blocked_incomplete_evidence() {
+        let input = EligibilityInput {
+            kind: CalibrationKind::Dark,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: false,
+            candidate_evidence_complete: true,
+            sufficient: true,
+            age_state: AgeState::Fresh,
+            thermal_state: ThermalState::Normal,
+            temperature_mode: TemperatureMode::Regulated,
+            orientation_state: OrientationState::NotApplicable,
+            is_same_night_flat: false,
+        };
+        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::Blocked);
+    }
+
+    #[test]
+    fn eligibility_dark_red_age_review_required() {
+        let input = EligibilityInput {
+            kind: CalibrationKind::Dark,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            sufficient: true,
+            age_state: AgeState::Red,
+            thermal_state: ThermalState::Normal,
+            temperature_mode: TemperatureMode::Regulated,
+            orientation_state: OrientationState::NotApplicable,
+            is_same_night_flat: false,
+        };
+        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::ReviewRequired);
+    }
+
+    #[test]
+    fn eligibility_flat_same_night_eligible() {
+        let input = EligibilityInput {
+            kind: CalibrationKind::Flat,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            sufficient: true,
+            age_state: AgeState::Fresh,
+            thermal_state: ThermalState::NotApplicable,
+            temperature_mode: TemperatureMode::NotApplicable,
+            orientation_state: OrientationState::Normal,
+            is_same_night_flat: true,
+        };
+        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::Eligible);
+    }
+
+    #[test]
+    fn eligibility_flat_cross_night_review_required() {
+        let input = EligibilityInput {
+            kind: CalibrationKind::Flat,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            sufficient: true,
+            age_state: AgeState::Yellow,
+            thermal_state: ThermalState::NotApplicable,
+            temperature_mode: TemperatureMode::NotApplicable,
+            orientation_state: OrientationState::Normal,
+            is_same_night_flat: false,
+        };
+        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::ReviewRequired);
+    }
+
+    #[test]
+    fn eligibility_unregulated_dark_blocked() {
+        let input = EligibilityInput {
+            kind: CalibrationKind::Dark,
+            recipe_compatibility: RecipeCompatibility::Compatible,
+            required_evidence_complete: true,
+            candidate_evidence_complete: true,
+            sufficient: true,
+            age_state: AgeState::Fresh,
+            thermal_state: ThermalState::NotApplicable,
+            temperature_mode: TemperatureMode::Unregulated,
+            orientation_state: OrientationState::NotApplicable,
+            is_same_night_flat: false,
+        };
+        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::Blocked);
+    }
+}

--- a/crates/calibration/core/src/families.rs
+++ b/crates/calibration/core/src/families.rs
@@ -499,18 +499,19 @@ pub fn automatic_eligibility(input: &EligibilityInput) -> AutomaticEligibility {
     {
         return AutomaticEligibility::Blocked;
     }
-    // Dark: unregulated temperature mode is blocked for automatic.
-    if input.kind == CalibrationKind::Dark
-        && matches!(input.temperature_mode, TemperatureMode::Unregulated)
-    {
-        return AutomaticEligibility::Blocked;
-    }
     // Incompatible recipe is always blocked.
     if matches!(input.recipe_compatibility, RecipeCompatibility::Incompatible) {
         return AutomaticEligibility::Blocked;
     }
 
     // Review required conditions.
+    // Unregulated darks require manual audited selection (FR-068); review can
+    // override, so this is review_required not blocked.
+    if input.kind == CalibrationKind::Dark
+        && matches!(input.temperature_mode, TemperatureMode::Unregulated)
+    {
+        return AutomaticEligibility::ReviewRequired;
+    }
     if matches!(input.age_state, AgeState::Red) {
         return AutomaticEligibility::ReviewRequired;
     }
@@ -703,7 +704,9 @@ mod tests {
     }
 
     #[test]
-    fn eligibility_unregulated_dark_blocked() {
+    fn eligibility_unregulated_dark_review_required() {
+        // FR-068: unregulated darks require manual audited selection; review can
+        // override, so automatic eligibility is review_required, not blocked.
         let input = EligibilityInput {
             kind: CalibrationKind::Dark,
             recipe_compatibility: RecipeCompatibility::Compatible,
@@ -716,6 +719,6 @@ mod tests {
             orientation_state: OrientationState::NotApplicable,
             is_same_night_flat: false,
         };
-        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::Blocked);
+        assert_eq!(automatic_eligibility(&input), AutomaticEligibility::ReviewRequired);
     }
 }

--- a/crates/calibration/core/src/lib.rs
+++ b/crates/calibration/core/src/lib.rs
@@ -21,6 +21,7 @@
 
 pub mod assign;
 pub mod candidate;
+pub mod families;
 pub mod ranking;
 pub mod rotation;
 pub mod rules;

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/availability.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/availability.rs
@@ -1,0 +1,233 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repository for the `source_availability_rollup` table.
+//!
+//! The rollup is a rebuildable projection over indexed file records. It is not
+//! part of the immutable session membership; it changes whenever the filesystem
+//! scanner observes new or missing frames. The `observed_at` timestamp records
+//! the projection instant used for candidate-list watermarking.
+
+use sqlx::{SqliteConnection, SqlitePool};
+
+use persistence_core::{DbError, DbResult};
+
+// ── Row projections ────────────────────────────────────────────────────────────
+
+/// One `source_availability_rollup` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct SourceAvailabilityRollupRow {
+    pub session_row_id: i64,
+    pub indexed_frame_count: i64,
+    pub available_frame_count: i64,
+    pub readable_frame_count: i64,
+    pub source_byte_count: i64,
+    pub observed_at: String,
+}
+
+// ── Writes ────────────────────────────────────────────────────────────────────
+
+/// Upsert the availability rollup for one session.
+///
+/// Overwrites the existing row if present. Callers invoke this from the
+/// filesystem scan completion path.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn upsert_source_availability(
+    conn: &mut SqliteConnection,
+    session_row_id: i64,
+    indexed_frame_count: i64,
+    available_frame_count: i64,
+    readable_frame_count: i64,
+    source_byte_count: i64,
+    observed_at: &str,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO source_availability_rollup
+             (session_row_id, indexed_frame_count, available_frame_count,
+              readable_frame_count, source_byte_count, observed_at)
+         VALUES (?,?,?,?,?,?)
+         ON CONFLICT(session_row_id) DO UPDATE SET
+             indexed_frame_count   = excluded.indexed_frame_count,
+             available_frame_count = excluded.available_frame_count,
+             readable_frame_count  = excluded.readable_frame_count,
+             source_byte_count     = excluded.source_byte_count,
+             observed_at           = excluded.observed_at",
+    )
+    .bind(session_row_id)
+    .bind(indexed_frame_count)
+    .bind(available_frame_count)
+    .bind(readable_frame_count)
+    .bind(source_byte_count)
+    .bind(observed_at)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+// ── Reads ─────────────────────────────────────────────────────────────────────
+
+/// Fetch the availability rollup for one session.
+///
+/// Returns `None` when no rollup has been written yet for the session.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn get_source_availability(
+    pool: &SqlitePool,
+    session_row_id: i64,
+) -> DbResult<Option<SourceAvailabilityRollupRow>> {
+    sqlx::query_as::<_, SourceAvailabilityRollupRow>(
+        "SELECT session_row_id, indexed_frame_count, available_frame_count,
+                readable_frame_count, source_byte_count, observed_at
+         FROM source_availability_rollup
+         WHERE session_row_id = ?",
+    )
+    .bind(session_row_id)
+    .fetch_optional(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+/// List availability rollups for multiple sessions by `session_row_id`.
+///
+/// Returned in the same order as the input slice. Sessions with no rollup row
+/// are absent from the result — callers should treat absence as
+/// `indexed_frame_count = 0`.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn list_source_availability_for_sessions(
+    pool: &SqlitePool,
+    session_row_ids: &[i64],
+) -> DbResult<Vec<SourceAvailabilityRollupRow>> {
+    if session_row_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    // Use QueryBuilder to avoid the 'static lifetime requirement on query_as.
+    let mut builder = sqlx::QueryBuilder::new(
+        "SELECT session_row_id, indexed_frame_count, available_frame_count, \
+         readable_frame_count, source_byte_count, observed_at \
+         FROM source_availability_rollup \
+         WHERE session_row_id IN (",
+    );
+    let mut separated = builder.separated(", ");
+    for id in session_row_ids {
+        separated.push_bind(*id);
+    }
+    separated.push_unseparated(") ORDER BY session_row_id ASC");
+    builder
+        .build_query_as::<SourceAvailabilityRollupRow>()
+        .fetch_all(pool)
+        .await
+        .map_err(DbError::from)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_db_with_session() -> (sqlx::SqlitePool, i64) {
+        let db = persistence_core::Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        let pool = db.pool().clone();
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        // Minimal FK chain for a single session row
+        sqlx::query(
+            "INSERT INTO spec062_actor VALUES (1,'00000000-0000-7000-c000-000000000001',?)",
+        )
+        .bind(ts)
+        .execute(&pool)
+        .await
+        .expect("actor");
+        sqlx::query("INSERT INTO spec062_config_revision VALUES (1,'00000000-0000-7000-c000-000000000002',1,'cfg-digest',?)").bind(ts).execute(&pool).await.expect("config");
+        sqlx::query("INSERT INTO repository_change(command_row_id,created_at) VALUES (NULL,?)")
+            .bind(ts)
+            .execute(&pool)
+            .await
+            .expect("repo_change");
+        sqlx::query("INSERT INTO command_execution (row_id,public_id,actor_row_id,operation,canonical_payload_digest,state,response_json,created_at,finished_at) VALUES (1,'00000000-0000-7000-c000-000000000003',1,'inbox.materialization.apply','pd','applied','{}',?,?)").bind(ts).bind(ts).execute(&pool).await.expect("command");
+        sqlx::query("INSERT INTO session_materialization_operation (row_id,public_id,kind,command_row_id,config_revision_row_id,state,created_sequence,created_at) VALUES (1,'00000000-0000-7000-c000-000000000004','inbox_ingestion',1,1,'ready',1,?)").bind(ts).execute(&pool).await.expect("operation");
+        sqlx::query("INSERT INTO session (row_id,public_id,materialization_operation_row_id,kind,ordinal_in_operation,identity_digest,observing_night_date,night_derivation,created_sequence,created_at) VALUES (1,'ses-pub-001',1,'dark',0,'dark-id-001','2026-01-15','reviewed_local_fallback',1,?)").bind(ts).execute(&pool).await.expect("session");
+
+        (pool, 1i64)
+    }
+
+    #[tokio::test]
+    async fn upsert_and_get_availability() {
+        let (pool, session_row_id) = setup_db_with_session().await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        upsert_source_availability(
+            &mut conn,
+            session_row_id,
+            120, // indexed
+            100, // available
+            95,  // readable
+            1_234_567,
+            "2026-07-22T01:00:00.000000Z",
+        )
+        .await
+        .expect("upsert");
+
+        let row = get_source_availability(&pool, session_row_id).await.expect("get").expect("Some");
+        assert_eq!(row.indexed_frame_count, 120);
+        assert_eq!(row.available_frame_count, 100);
+        assert_eq!(row.readable_frame_count, 95);
+        assert_eq!(row.source_byte_count, 1_234_567);
+    }
+
+    #[tokio::test]
+    async fn upsert_overwrites_existing() {
+        let (pool, session_row_id) = setup_db_with_session().await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        upsert_source_availability(
+            &mut conn,
+            session_row_id,
+            100,
+            100,
+            100,
+            1_000,
+            "2026-07-22T01:00:00.000000Z",
+        )
+        .await
+        .expect("first upsert");
+        upsert_source_availability(
+            &mut conn,
+            session_row_id,
+            50,
+            40,
+            40,
+            500,
+            "2026-07-22T02:00:00.000000Z",
+        )
+        .await
+        .expect("second upsert");
+
+        let row = get_source_availability(&pool, session_row_id).await.expect("get").expect("Some");
+        assert_eq!(row.indexed_frame_count, 50);
+        assert_eq!(row.observed_at, "2026-07-22T02:00:00.000000Z");
+    }
+
+    #[tokio::test]
+    async fn get_returns_none_when_absent() {
+        let (pool, _) = setup_db_with_session().await;
+        let row = get_source_availability(&pool, 999).await.expect("query");
+        assert!(row.is_none());
+    }
+
+    #[tokio::test]
+    async fn list_for_empty_slice_returns_empty() {
+        let (pool, _) = setup_db_with_session().await;
+        let rows = list_source_availability_for_sessions(&pool, &[]).await.expect("list");
+        assert!(rows.is_empty());
+    }
+}

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/families.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/families.rs
@@ -1,0 +1,764 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repository for `calibration_family` and the three recipe/identity subtype
+//! tables (`dark_recipe_identity`, `bias_recipe_identity`,
+//! `flat_family_identity`).
+//!
+//! A family row is inserted atomically with its subtype row in one transaction.
+//! The unique-index constraints in the schema enforce one family per
+//! camera+kind+digest (dark/bias) or optical-profile+filter+digest (flat).
+
+use sqlx::{SqliteConnection, SqlitePool};
+
+use persistence_core::{DbError, DbResult};
+
+// ── Row projections ────────────────────────────────────────────────────────────
+
+/// Core `calibration_family` row, without subtype columns.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CalibrationFamilyRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub kind: String,
+    pub camera_row_id: Option<i64>,
+    pub optical_profile_row_id: Option<i64>,
+    pub filter_label_row_id: Option<i64>,
+    pub identity_digest: String,
+    pub representative_session_row_id: i64,
+    pub camera_regulation_decision_row_id: Option<i64>,
+    pub created_sequence: i64,
+    pub created_at: String,
+}
+
+/// `dark_recipe_identity` subtype columns.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DarkRecipeRow {
+    pub family_row_id: i64,
+    pub temperature_mode: String,
+    pub cooling_setpoint_millic: Option<i64>,
+    pub representative_exposure_us: i64,
+    pub gain_text: String,
+    pub offset_state: String,
+    pub offset_value: Option<i64>,
+    pub binning_state: String,
+    pub bin_x: Option<i64>,
+    pub bin_y: Option<i64>,
+    pub readout_state: String,
+    pub readout_mode: Option<String>,
+    pub raster_width: i64,
+    pub raster_height: i64,
+}
+
+/// `bias_recipe_identity` subtype columns.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct BiasRecipeRow {
+    pub family_row_id: i64,
+    pub gain_text: String,
+    pub offset_state: String,
+    pub offset_value: Option<i64>,
+    pub binning_state: String,
+    pub bin_x: Option<i64>,
+    pub bin_y: Option<i64>,
+    pub readout_state: String,
+    pub readout_mode: Option<String>,
+    pub raster_width: i64,
+    pub raster_height: i64,
+}
+
+/// `flat_family_identity` subtype columns.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct FlatFamilyRow {
+    pub family_row_id: i64,
+    pub gain_text: String,
+    pub offset_state: String,
+    pub offset_value: Option<i64>,
+    pub binning_state: String,
+    pub bin_x: Option<i64>,
+    pub bin_y: Option<i64>,
+    pub readout_state: String,
+    pub readout_mode: Option<String>,
+    pub raster_width: i64,
+    pub raster_height: i64,
+    pub physical_rotator_state: String,
+    pub physical_rotator_udeg: Option<i64>,
+}
+
+// ── Insert parameters ─────────────────────────────────────────────────────────
+
+/// Parameters for inserting one `calibration_family` row.
+pub struct InsertCalibrationFamily<'a> {
+    pub public_id: &'a str,
+    pub kind: &'a str,
+    pub camera_row_id: Option<i64>,
+    pub optical_profile_row_id: Option<i64>,
+    pub filter_label_row_id: Option<i64>,
+    pub identity_digest: &'a str,
+    pub representative_session_row_id: i64,
+    /// Required for dark families; must match the camera's accepted regulation
+    /// decision.
+    pub camera_regulation_decision_row_id: Option<i64>,
+    pub created_sequence: i64,
+    pub created_at: &'a str,
+}
+
+/// Parameters for inserting a `dark_recipe_identity` row.
+pub struct InsertDarkRecipe<'a> {
+    pub family_row_id: i64,
+    pub temperature_mode: &'a str,
+    pub cooling_setpoint_millic: Option<i64>,
+    pub representative_exposure_us: i64,
+    pub gain_text: &'a str,
+    pub offset_state: &'a str,
+    pub offset_value: Option<i64>,
+    pub binning_state: &'a str,
+    pub bin_x: Option<i64>,
+    pub bin_y: Option<i64>,
+    pub readout_state: &'a str,
+    pub readout_mode: Option<&'a str>,
+    pub raster_width: i64,
+    pub raster_height: i64,
+}
+
+/// Parameters for inserting a `bias_recipe_identity` row.
+pub struct InsertBiasRecipe<'a> {
+    pub family_row_id: i64,
+    pub gain_text: &'a str,
+    pub offset_state: &'a str,
+    pub offset_value: Option<i64>,
+    pub binning_state: &'a str,
+    pub bin_x: Option<i64>,
+    pub bin_y: Option<i64>,
+    pub readout_state: &'a str,
+    pub readout_mode: Option<&'a str>,
+    pub raster_width: i64,
+    pub raster_height: i64,
+}
+
+/// Parameters for inserting a `flat_family_identity` row.
+pub struct InsertFlatFamily<'a> {
+    pub family_row_id: i64,
+    pub gain_text: &'a str,
+    pub offset_state: &'a str,
+    pub offset_value: Option<i64>,
+    pub binning_state: &'a str,
+    pub bin_x: Option<i64>,
+    pub bin_y: Option<i64>,
+    pub readout_state: &'a str,
+    pub readout_mode: Option<&'a str>,
+    pub raster_width: i64,
+    pub raster_height: i64,
+    pub physical_rotator_state: &'a str,
+    pub physical_rotator_udeg: Option<i64>,
+}
+
+// ── Writes ────────────────────────────────────────────────────────────────────
+
+/// Insert one `calibration_family` row.
+///
+/// Returns the new `row_id`. Callers insert the kind-specific subtype row
+/// immediately after in the same transaction.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_calibration_family(
+    conn: &mut SqliteConnection,
+    params: &InsertCalibrationFamily<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_family (
+            public_id, kind,
+            camera_row_id, optical_profile_row_id, filter_label_row_id,
+            identity_digest, representative_session_row_id,
+            camera_regulation_decision_row_id,
+            created_sequence, created_at
+         ) VALUES (?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.kind)
+    .bind(params.camera_row_id)
+    .bind(params.optical_profile_row_id)
+    .bind(params.filter_label_row_id)
+    .bind(params.identity_digest)
+    .bind(params.representative_session_row_id)
+    .bind(params.camera_regulation_decision_row_id)
+    .bind(params.created_sequence)
+    .bind(params.created_at)
+    .execute(conn)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Insert one `dark_recipe_identity` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_dark_recipe(
+    conn: &mut SqliteConnection,
+    params: &InsertDarkRecipe<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO dark_recipe_identity (
+            family_row_id, temperature_mode, cooling_setpoint_millic,
+            representative_exposure_us, gain_text,
+            offset_state, offset_value,
+            binning_state, bin_x, bin_y,
+            readout_state, readout_mode,
+            raster_width, raster_height
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.family_row_id)
+    .bind(params.temperature_mode)
+    .bind(params.cooling_setpoint_millic)
+    .bind(params.representative_exposure_us)
+    .bind(params.gain_text)
+    .bind(params.offset_state)
+    .bind(params.offset_value)
+    .bind(params.binning_state)
+    .bind(params.bin_x)
+    .bind(params.bin_y)
+    .bind(params.readout_state)
+    .bind(params.readout_mode)
+    .bind(params.raster_width)
+    .bind(params.raster_height)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert one `bias_recipe_identity` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_bias_recipe(
+    conn: &mut SqliteConnection,
+    params: &InsertBiasRecipe<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO bias_recipe_identity (
+            family_row_id, gain_text,
+            offset_state, offset_value,
+            binning_state, bin_x, bin_y,
+            readout_state, readout_mode,
+            raster_width, raster_height
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.family_row_id)
+    .bind(params.gain_text)
+    .bind(params.offset_state)
+    .bind(params.offset_value)
+    .bind(params.binning_state)
+    .bind(params.bin_x)
+    .bind(params.bin_y)
+    .bind(params.readout_state)
+    .bind(params.readout_mode)
+    .bind(params.raster_width)
+    .bind(params.raster_height)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert one `flat_family_identity` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_flat_family(
+    conn: &mut SqliteConnection,
+    params: &InsertFlatFamily<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO flat_family_identity (
+            family_row_id, gain_text,
+            offset_state, offset_value,
+            binning_state, bin_x, bin_y,
+            readout_state, readout_mode,
+            raster_width, raster_height,
+            physical_rotator_state, physical_rotator_udeg
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.family_row_id)
+    .bind(params.gain_text)
+    .bind(params.offset_state)
+    .bind(params.offset_value)
+    .bind(params.binning_state)
+    .bind(params.bin_x)
+    .bind(params.bin_y)
+    .bind(params.readout_state)
+    .bind(params.readout_mode)
+    .bind(params.raster_width)
+    .bind(params.raster_height)
+    .bind(params.physical_rotator_state)
+    .bind(params.physical_rotator_udeg)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+// ── Reads ─────────────────────────────────────────────────────────────────────
+
+/// Fetch a `calibration_family` by `public_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no matching row exists, or
+/// [`DbError::Database`] on SQL errors.
+pub async fn get_family_by_public_id(
+    pool: &SqlitePool,
+    public_id: &str,
+) -> DbResult<CalibrationFamilyRow> {
+    sqlx::query_as::<_, CalibrationFamilyRow>(
+        "SELECT row_id, public_id, kind,
+                camera_row_id, optical_profile_row_id, filter_label_row_id,
+                identity_digest, representative_session_row_id,
+                camera_regulation_decision_row_id,
+                created_sequence, created_at
+         FROM calibration_family
+         WHERE public_id = ?",
+    )
+    .bind(public_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("calibration_family {public_id}")))
+}
+
+/// Fetch a `calibration_family` by `row_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no matching row exists, or
+/// [`DbError::Database`] on SQL errors.
+pub async fn get_family_by_row_id(
+    pool: &SqlitePool,
+    row_id: i64,
+) -> DbResult<CalibrationFamilyRow> {
+    sqlx::query_as::<_, CalibrationFamilyRow>(
+        "SELECT row_id, public_id, kind,
+                camera_row_id, optical_profile_row_id, filter_label_row_id,
+                identity_digest, representative_session_row_id,
+                camera_regulation_decision_row_id,
+                created_sequence, created_at
+         FROM calibration_family
+         WHERE row_id = ?",
+    )
+    .bind(row_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("calibration_family row_id={row_id}")))
+}
+
+/// Fetch the `dark_recipe_identity` row for a family.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no matching row exists.
+pub async fn get_dark_recipe(pool: &SqlitePool, family_row_id: i64) -> DbResult<DarkRecipeRow> {
+    sqlx::query_as::<_, DarkRecipeRow>(
+        "SELECT family_row_id, temperature_mode, cooling_setpoint_millic,
+                representative_exposure_us, gain_text,
+                offset_state, offset_value,
+                binning_state, bin_x, bin_y,
+                readout_state, readout_mode,
+                raster_width, raster_height
+         FROM dark_recipe_identity
+         WHERE family_row_id = ?",
+    )
+    .bind(family_row_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("dark_recipe_identity family_row_id={family_row_id}")))
+}
+
+/// Fetch the `bias_recipe_identity` row for a family.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no matching row exists.
+pub async fn get_bias_recipe(pool: &SqlitePool, family_row_id: i64) -> DbResult<BiasRecipeRow> {
+    sqlx::query_as::<_, BiasRecipeRow>(
+        "SELECT family_row_id, gain_text,
+                offset_state, offset_value,
+                binning_state, bin_x, bin_y,
+                readout_state, readout_mode,
+                raster_width, raster_height
+         FROM bias_recipe_identity
+         WHERE family_row_id = ?",
+    )
+    .bind(family_row_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("bias_recipe_identity family_row_id={family_row_id}")))
+}
+
+/// Fetch the `flat_family_identity` row for a family.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no matching row exists.
+pub async fn get_flat_family(pool: &SqlitePool, family_row_id: i64) -> DbResult<FlatFamilyRow> {
+    sqlx::query_as::<_, FlatFamilyRow>(
+        "SELECT family_row_id, gain_text,
+                offset_state, offset_value,
+                binning_state, bin_x, bin_y,
+                readout_state, readout_mode,
+                raster_width, raster_height,
+                physical_rotator_state, physical_rotator_udeg
+         FROM flat_family_identity
+         WHERE family_row_id = ?",
+    )
+    .bind(family_row_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("flat_family_identity family_row_id={family_row_id}")))
+}
+
+/// Look up an existing `calibration_family` for a dark or bias kind by its
+/// uniqueness key: `(camera_row_id, kind, identity_digest)`.
+///
+/// Returns `None` when no matching family exists.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn find_dark_bias_family(
+    pool: &SqlitePool,
+    camera_row_id: i64,
+    kind: &str,
+    identity_digest: &str,
+) -> DbResult<Option<CalibrationFamilyRow>> {
+    sqlx::query_as::<_, CalibrationFamilyRow>(
+        "SELECT row_id, public_id, kind,
+                camera_row_id, optical_profile_row_id, filter_label_row_id,
+                identity_digest, representative_session_row_id,
+                camera_regulation_decision_row_id,
+                created_sequence, created_at
+         FROM calibration_family
+         WHERE camera_row_id = ? AND kind = ? AND identity_digest = ?",
+    )
+    .bind(camera_row_id)
+    .bind(kind)
+    .bind(identity_digest)
+    .fetch_optional(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+/// Look up an existing `calibration_family` for a flat by its uniqueness key:
+/// `(optical_profile_row_id, filter_label_row_id, identity_digest)`.
+///
+/// Returns `None` when no matching family exists.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn find_flat_family(
+    pool: &SqlitePool,
+    optical_profile_row_id: i64,
+    filter_label_row_id: i64,
+    identity_digest: &str,
+) -> DbResult<Option<CalibrationFamilyRow>> {
+    sqlx::query_as::<_, CalibrationFamilyRow>(
+        "SELECT row_id, public_id, kind,
+                camera_row_id, optical_profile_row_id, filter_label_row_id,
+                identity_digest, representative_session_row_id,
+                camera_regulation_decision_row_id,
+                created_sequence, created_at
+         FROM calibration_family
+         WHERE optical_profile_row_id = ?
+           AND filter_label_row_id = ?
+           AND identity_digest = ?",
+    )
+    .bind(optical_profile_row_id)
+    .bind(filter_label_row_id)
+    .bind(identity_digest)
+    .fetch_optional(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Open an in-memory database with all migrations applied.
+    async fn setup_db() -> sqlx::SqlitePool {
+        let db = persistence_core::Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    /// Seed the minimal FK-required rows for family insertion tests.
+    ///
+    /// Inserts: actor, config_revision, repository_change, command_execution,
+    /// session_materialization_operation, camera (no regulation decision yet),
+    /// optical_profile, filter_label, plus session rows for each kind tested.
+    ///
+    /// For dark family tests that need `camera_regulation_decision`,
+    /// call [`seed_dark_regulation`] after this.
+    async fn seed_prerequisites(pool: &sqlx::SqlitePool) {
+        let ts = "2026-07-22T00:00:00.000000Z";
+        // Core booking rows
+        sqlx::query(
+            "INSERT INTO spec062_actor VALUES (1,'00000000-0000-7000-a000-000000000001',?)",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .expect("actor");
+        sqlx::query("INSERT INTO spec062_config_revision VALUES (1,'00000000-0000-7000-a000-000000000002',1,'cfg-digest',?)").bind(ts).execute(pool).await.expect("config");
+        sqlx::query("INSERT INTO repository_change(command_row_id,created_at) VALUES (NULL,?)")
+            .bind(ts)
+            .execute(pool)
+            .await
+            .expect("repo_change");
+        sqlx::query(
+            "INSERT INTO command_execution (row_id,public_id,actor_row_id,operation,canonical_payload_digest,state,response_json,created_at,finished_at)
+             VALUES (1,'00000000-0000-7000-a000-000000000003',1,'inbox.materialization.apply','pd','applied','{}',?,?)"
+        ).bind(ts).bind(ts).execute(pool).await.expect("command");
+        sqlx::query(
+            "INSERT INTO session_materialization_operation (row_id,public_id,kind,command_row_id,config_revision_row_id,state,created_sequence,created_at)
+             VALUES (1,'00000000-0000-7000-a000-000000000004','inbox_ingestion',1,1,'ready',1,?)"
+        ).bind(ts).execute(pool).await.expect("operation");
+
+        // camera (no regulation head yet)
+        sqlx::query(
+            "INSERT INTO camera (row_id,public_id,display_name,head_generation,created_sequence,created_at)
+             VALUES (1,'cam-pub-001','ASI294MC Pro',0,1,?)"
+        ).bind(ts).execute(pool).await.expect("camera");
+
+        // optical_profile (all NOT NULL columns required)
+        sqlx::query(
+            "INSERT INTO optical_profile (row_id,public_id,display_name,representative_focal_length_um,representative_raster_width,representative_raster_height,created_sequence,created_at)
+             VALUES (1,'op-pub-001','80ED',560000,4096,2160,1,?)"
+        ).bind(ts).execute(pool).await.expect("optical_profile");
+        sqlx::query(
+            "INSERT INTO filter_label (row_id,public_id,optical_profile_row_id,state,normalized_label,created_sequence,created_at)
+             VALUES (1,'fl-pub-001',1,'captured','Ha',1,?)"
+        ).bind(ts).execute(pool).await.expect("filter_label");
+
+        // Representative session rows for each calibration kind
+        for (row_id, kind, ordinal, digest) in [
+            (1i64, "dark", 0i64, "id-digest-dark"),
+            (2i64, "bias", 1i64, "id-digest-bias"),
+            (3i64, "flat", 2i64, "id-digest-flat"),
+        ] {
+            sqlx::query(
+                "INSERT INTO session (row_id,public_id,materialization_operation_row_id,kind,ordinal_in_operation,identity_digest,observing_night_date,night_derivation,created_sequence,created_at)
+                 VALUES (?,?,1,?,?,?,'2026-01-15','reviewed_local_fallback',1,?)"
+            )
+            .bind(row_id)
+            .bind(format!("ses-pub-{row_id:03}"))
+            .bind(kind)
+            .bind(ordinal)
+            .bind(digest)
+            .bind(ts)
+            .execute(pool).await.expect("session");
+        }
+    }
+
+    /// Seed a `relation_proposal` + `camera_regulation_decision` for the dark
+    /// family test. `camera_regulation_decision` requires a `relation_proposal`
+    /// FK (proposal_row_id NOT NULL), so we seed that first.
+    async fn seed_dark_regulation(pool: &sqlx::SqlitePool) {
+        let ts = "2026-07-22T00:00:00.000000Z";
+        sqlx::query(
+            "INSERT INTO relation_proposal (row_id,public_id,proposal_revision,kind,basis_digest,evidence_digest,config_revision_row_id,state,actor_row_id,created_sequence,created_at,decided_at)
+             VALUES (1,'prop-pub-001',1,'manual_relation','basis-01','evid-01',1,'accepted',1,1,?,?)"
+        ).bind(ts).bind(ts).execute(pool).await.expect("relation_proposal");
+        sqlx::query(
+            "INSERT INTO camera_regulation_decision (row_id,public_id,camera_row_id,mode,proposal_row_id,config_revision_row_id,actor_row_id,created_sequence,created_at)
+             VALUES (1,'reg-pub-001',1,'regulated',1,1,1,1,?)"
+        ).bind(ts).execute(pool).await.expect("camera_regulation_decision");
+        sqlx::query(
+            "UPDATE camera SET regulation_head_decision_row_id=1, head_generation=1 WHERE row_id=1",
+        )
+        .execute(pool)
+        .await
+        .expect("camera head update");
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_bias_family() {
+        let pool = setup_db().await;
+        seed_prerequisites(&pool).await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let family_row_id = insert_calibration_family(
+            &mut conn,
+            &InsertCalibrationFamily {
+                public_id: "fam-pub-bias-001",
+                kind: "bias",
+                camera_row_id: Some(1),
+                optical_profile_row_id: None,
+                filter_label_row_id: None,
+                identity_digest: "bias-digest-001",
+                representative_session_row_id: 2, // session row 2 is bias kind
+                camera_regulation_decision_row_id: None,
+                created_sequence: 1,
+                created_at: "2026-07-22T00:00:00.000000Z",
+            },
+        )
+        .await
+        .expect("insert bias family");
+
+        insert_bias_recipe(
+            &mut conn,
+            &InsertBiasRecipe {
+                family_row_id,
+                gain_text: "100",
+                offset_state: "present",
+                offset_value: Some(50),
+                binning_state: "present",
+                bin_x: Some(1),
+                bin_y: Some(1),
+                readout_state: "absent",
+                readout_mode: None,
+                raster_width: 4096,
+                raster_height: 2160,
+            },
+        )
+        .await
+        .expect("insert bias recipe");
+
+        let fam = get_family_by_public_id(&pool, "fam-pub-bias-001").await.expect("get family");
+        assert_eq!(fam.kind, "bias");
+        assert_eq!(fam.camera_row_id, Some(1));
+
+        let recipe = get_bias_recipe(&pool, family_row_id).await.expect("get bias recipe");
+        assert_eq!(recipe.gain_text, "100");
+        assert_eq!(recipe.raster_width, 4096);
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_flat_family() {
+        let pool = setup_db().await;
+        seed_prerequisites(&pool).await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let family_row_id = insert_calibration_family(
+            &mut conn,
+            &InsertCalibrationFamily {
+                public_id: "fam-pub-flat-001",
+                kind: "flat",
+                camera_row_id: None,
+                optical_profile_row_id: Some(1),
+                filter_label_row_id: Some(1),
+                identity_digest: "flat-digest-001",
+                representative_session_row_id: 3, // session row 3 is flat kind
+                camera_regulation_decision_row_id: None,
+                created_sequence: 1,
+                created_at: "2026-07-22T00:00:00.000000Z",
+            },
+        )
+        .await
+        .expect("insert flat family");
+
+        insert_flat_family(
+            &mut conn,
+            &InsertFlatFamily {
+                family_row_id,
+                gain_text: "100",
+                offset_state: "present",
+                offset_value: Some(50),
+                binning_state: "present",
+                bin_x: Some(1),
+                bin_y: Some(1),
+                readout_state: "absent",
+                readout_mode: None,
+                raster_width: 4096,
+                raster_height: 2160,
+                physical_rotator_state: "verified",
+                physical_rotator_udeg: Some(0),
+            },
+        )
+        .await
+        .expect("insert flat family identity");
+
+        let fam = get_family_by_row_id(&pool, family_row_id).await.expect("get by row_id");
+        assert_eq!(fam.optical_profile_row_id, Some(1));
+
+        let ff = get_flat_family(&pool, family_row_id).await.expect("get flat family");
+        assert_eq!(ff.physical_rotator_state, "verified");
+        assert_eq!(ff.physical_rotator_udeg, Some(0));
+        assert_eq!(ff.gain_text, "100");
+
+        let found = find_flat_family(&pool, 1, 1, "flat-digest-001").await.expect("find flat");
+        assert!(found.is_some());
+
+        let not_found =
+            find_flat_family(&pool, 1, 1, "wrong-digest").await.expect("find flat none");
+        assert!(not_found.is_none());
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_dark_family_with_regulation_decision() {
+        let pool = setup_db().await;
+        seed_prerequisites(&pool).await;
+        seed_dark_regulation(&pool).await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let family_row_id = insert_calibration_family(
+            &mut conn,
+            &InsertCalibrationFamily {
+                public_id: "fam-pub-dark-001",
+                kind: "dark",
+                camera_row_id: Some(1),
+                optical_profile_row_id: None,
+                filter_label_row_id: None,
+                identity_digest: "dark-digest-001",
+                representative_session_row_id: 1, // session row 1 is dark kind
+                camera_regulation_decision_row_id: Some(1),
+                created_sequence: 1,
+                created_at: "2026-07-22T00:00:00.000000Z",
+            },
+        )
+        .await
+        .expect("insert dark family");
+
+        insert_dark_recipe(
+            &mut conn,
+            &InsertDarkRecipe {
+                family_row_id,
+                temperature_mode: "regulated",
+                cooling_setpoint_millic: Some(-10_000),
+                representative_exposure_us: 60_000_000,
+                gain_text: "100",
+                offset_state: "present",
+                offset_value: Some(50),
+                binning_state: "present",
+                bin_x: Some(1),
+                bin_y: Some(1),
+                readout_state: "absent",
+                readout_mode: None,
+                raster_width: 4096,
+                raster_height: 2160,
+            },
+        )
+        .await
+        .expect("insert dark recipe");
+
+        let fam = get_family_by_public_id(&pool, "fam-pub-dark-001").await.expect("get family");
+        assert_eq!(fam.kind, "dark");
+        assert_eq!(fam.camera_row_id, Some(1));
+        assert_eq!(fam.camera_regulation_decision_row_id, Some(1));
+
+        let recipe = get_dark_recipe(&pool, family_row_id).await.expect("get dark recipe");
+        assert_eq!(recipe.temperature_mode, "regulated");
+        assert_eq!(recipe.cooling_setpoint_millic, Some(-10_000));
+        assert_eq!(recipe.representative_exposure_us, 60_000_000);
+        assert_eq!(recipe.gain_text, "100");
+
+        let found =
+            find_dark_bias_family(&pool, 1, "dark", "dark-digest-001").await.expect("find dark");
+        assert!(found.is_some());
+
+        let none = find_dark_bias_family(&pool, 1, "dark", "nonexistent").await.expect("none");
+        assert!(none.is_none());
+    }
+}

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/handoff.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/handoff.rs
@@ -1,0 +1,1067 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repository for the calibration external-handoff aggregate and its child tables:
+//! `calibration_handoff`, `calibration_handoff_snapshot`,
+//! `calibration_handoff_requirement`, `calibration_handoff_snapshot_requirement`,
+//! `calibration_handoff_candidate_evidence`, `calibration_handoff_candidate_warning`,
+//! `calibration_handoff_selection`, `calibration_handoff_snapshot_selection`,
+//! `calibration_handoff_review`, `calibration_handoff_review_warning`,
+//! `calibration_handoff_frame`, and `calibration_handoff_operation`.
+//!
+//! CAS semantics: the handoff head uses `(head_snapshot_row_id,
+//! head_generation)`. Snapshot succession is the only mutation that advances
+//! `head_generation`. All other rows are immutable once inserted.
+
+use sqlx::{SqliteConnection, SqlitePool};
+
+use persistence_core::{DbError, DbResult};
+
+// ── Row projections ────────────────────────────────────────────────────────────
+
+/// `calibration_handoff` aggregate row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub project_row_id: i64,
+    pub external_processor: String,
+    pub head_snapshot_row_id: Option<i64>,
+    pub head_generation: i64,
+    pub created_at: String,
+}
+
+/// `calibration_handoff_snapshot` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffSnapshotRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub handoff_row_id: i64,
+    pub predecessor_snapshot_row_id: Option<i64>,
+    pub evaluation_at: String,
+    pub matching_settings_revision_row_id: i64,
+    pub basis_digest: String,
+    pub requirement_count: i64,
+    pub selection_count: i64,
+    pub frame_count: i64,
+    pub source_byte_count: i64,
+    pub actor_row_id: i64,
+    pub command_row_id: i64,
+    pub created_sequence: i64,
+    pub created_at: String,
+}
+
+/// `calibration_handoff_requirement` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffRequirementRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub handoff_row_id: i64,
+    pub kind: String,
+    pub camera_row_id: Option<i64>,
+    pub family_row_id: Option<i64>,
+    pub recipe_revision: i64,
+    pub evidence_digest: String,
+    pub required_field_state: String,
+}
+
+/// `calibration_handoff_candidate_evidence` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffCandidateEvidenceRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub handoff_row_id: i64,
+    pub snapshot_row_id: i64,
+    pub requirement_row_id: i64,
+    pub session_row_id: i64,
+    pub recipe_compatible: i64,
+    pub recipe_complete: i64,
+    pub age_days: i64,
+    pub age_severity: String,
+    pub thermal_state: String,
+    pub available_frame_count: i64,
+    pub readable_frame_count: i64,
+    pub automatic_eligible: i64,
+    pub evidence_digest: String,
+    pub observed_at: String,
+}
+
+/// `calibration_handoff_selection` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffSelectionRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub handoff_row_id: i64,
+    pub requirement_row_id: i64,
+    pub session_row_id: i64,
+    pub candidate_evidence_row_id: i64,
+    pub source: String,
+    pub selected_at: String,
+    pub created_sequence: i64,
+}
+
+/// `calibration_handoff_operation` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffOperationRow {
+    pub row_id: i64,
+    pub public_id: String,
+    pub handoff_row_id: i64,
+    pub command_row_id: i64,
+    pub state: String,
+    pub state_version: i64,
+    pub lease_owner: Option<String>,
+    pub lease_generation: i64,
+    pub frame_progress: i64,
+    pub byte_progress: i64,
+    pub terminal_snapshot_row_id: Option<i64>,
+    pub created_at: String,
+}
+
+/// `calibration_handoff_frame` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct HandoffFrameRow {
+    pub selection_row_id: i64,
+    pub frame_row_id: i64,
+    pub session_membership_ordinal: i64,
+    pub file_row_id: i64,
+    pub source_root_row_id: i64,
+    pub canonical_relative_path: String,
+    pub stable_file_identity: String,
+    pub byte_size: i64,
+    pub sha256_fingerprint: String,
+    pub no_follow_verified: i64,
+    pub verified_at: String,
+}
+
+// ── Insert parameters ─────────────────────────────────────────────────────────
+
+/// Parameters for inserting a `calibration_handoff` aggregate row.
+pub struct InsertHandoff<'a> {
+    pub public_id: &'a str,
+    pub project_row_id: i64,
+    pub external_processor: &'a str,
+    pub created_at: &'a str,
+}
+
+/// Parameters for inserting one `calibration_handoff_snapshot` row.
+pub struct InsertHandoffSnapshot<'a> {
+    pub public_id: &'a str,
+    pub handoff_row_id: i64,
+    pub predecessor_snapshot_row_id: Option<i64>,
+    pub evaluation_at: &'a str,
+    pub matching_settings_revision_row_id: i64,
+    pub basis_digest: &'a str,
+    pub requirement_count: i64,
+    pub selection_count: i64,
+    pub frame_count: i64,
+    pub source_byte_count: i64,
+    pub actor_row_id: i64,
+    pub command_row_id: i64,
+    pub created_sequence: i64,
+    pub created_at: &'a str,
+}
+
+/// Parameters for inserting a `calibration_handoff_requirement` row.
+pub struct InsertHandoffRequirement<'a> {
+    pub public_id: &'a str,
+    pub handoff_row_id: i64,
+    pub kind: &'a str,
+    pub camera_row_id: Option<i64>,
+    pub family_row_id: Option<i64>,
+    pub recipe_revision: i64,
+    pub evidence_digest: &'a str,
+    pub required_field_state: &'a str,
+}
+
+/// Parameters for inserting a `calibration_handoff_candidate_evidence` row.
+pub struct InsertHandoffCandidateEvidence<'a> {
+    pub public_id: &'a str,
+    pub handoff_row_id: i64,
+    pub snapshot_row_id: i64,
+    pub requirement_row_id: i64,
+    pub session_row_id: i64,
+    pub recipe_compatible: bool,
+    pub recipe_complete: bool,
+    pub age_days: i64,
+    pub age_severity: &'a str,
+    pub thermal_state: &'a str,
+    pub available_frame_count: i64,
+    pub readable_frame_count: i64,
+    pub automatic_eligible: bool,
+    pub evidence_digest: &'a str,
+    pub observed_at: &'a str,
+    pub warning_codes: &'a [&'a str],
+}
+
+/// Parameters for inserting a `calibration_handoff_selection` row.
+pub struct InsertHandoffSelection<'a> {
+    pub public_id: &'a str,
+    pub handoff_row_id: i64,
+    pub requirement_row_id: i64,
+    pub session_row_id: i64,
+    pub candidate_evidence_row_id: i64,
+    pub source: &'a str,
+    pub selected_at: &'a str,
+    pub created_sequence: i64,
+}
+
+/// Parameters for inserting a `calibration_handoff_frame` row.
+pub struct InsertHandoffFrame<'a> {
+    pub selection_row_id: i64,
+    pub frame_row_id: i64,
+    pub session_membership_ordinal: i64,
+    pub file_row_id: i64,
+    pub source_root_row_id: i64,
+    pub canonical_relative_path: &'a str,
+    pub stable_file_identity: &'a str,
+    pub byte_size: i64,
+    pub sha256_fingerprint: &'a str,
+    pub verified_at: &'a str,
+}
+
+/// Parameters for inserting a `calibration_handoff_operation` row.
+pub struct InsertHandoffOperation<'a> {
+    pub public_id: &'a str,
+    pub handoff_row_id: i64,
+    pub command_row_id: i64,
+    pub created_at: &'a str,
+}
+
+// ── Writes ────────────────────────────────────────────────────────────────────
+
+/// Insert the `calibration_handoff` aggregate row.
+///
+/// The head snapshot is initially null. Callers set it atomically with the
+/// first snapshot insert via [`advance_handoff_head`].
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoff<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_handoff
+             (public_id, project_row_id, external_processor,
+              head_snapshot_row_id, head_generation, created_at)
+         VALUES (?,?,?,NULL,0,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.project_row_id)
+    .bind(params.external_processor)
+    .bind(params.created_at)
+    .execute(conn)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Insert one `calibration_handoff_snapshot` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff_snapshot(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoffSnapshot<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_handoff_snapshot (
+            public_id, handoff_row_id, predecessor_snapshot_row_id,
+            evaluation_at, matching_settings_revision_row_id,
+            basis_digest, requirement_count, selection_count,
+            frame_count, source_byte_count,
+            actor_row_id, command_row_id,
+            created_sequence, created_at
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.handoff_row_id)
+    .bind(params.predecessor_snapshot_row_id)
+    .bind(params.evaluation_at)
+    .bind(params.matching_settings_revision_row_id)
+    .bind(params.basis_digest)
+    .bind(params.requirement_count)
+    .bind(params.selection_count)
+    .bind(params.frame_count)
+    .bind(params.source_byte_count)
+    .bind(params.actor_row_id)
+    .bind(params.command_row_id)
+    .bind(params.created_sequence)
+    .bind(params.created_at)
+    .execute(conn)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Advance the `calibration_handoff` head by CAS on `head_generation`.
+///
+/// Must be called inside a `BEGIN IMMEDIATE` transaction after the successor
+/// snapshot row is inserted. The CAS prevents concurrent reviewed additions
+/// from creating an inconsistent head chain.
+///
+/// # Errors
+///
+/// Returns [`DbError::CasFailed`] when `expected_generation` does not match.
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn advance_handoff_head(
+    conn: &mut SqliteConnection,
+    handoff_row_id: i64,
+    new_snapshot_row_id: i64,
+    expected_generation: i64,
+) -> DbResult<()> {
+    let result = sqlx::query(
+        "UPDATE calibration_handoff
+         SET head_snapshot_row_id = ?,
+             head_generation = head_generation + 1
+         WHERE row_id = ?
+           AND head_generation = ?",
+    )
+    .bind(new_snapshot_row_id)
+    .bind(handoff_row_id)
+    .bind(expected_generation)
+    .execute(conn)
+    .await?;
+    if result.rows_affected() != 1 {
+        return Err(DbError::CasFailed(format!(
+            "handoff {handoff_row_id} head CAS failed (expected_generation={expected_generation})"
+        )));
+    }
+    Ok(())
+}
+
+/// Insert one `calibration_handoff_requirement` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff_requirement(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoffRequirement<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_handoff_requirement
+             (public_id, handoff_row_id, kind, camera_row_id, family_row_id,
+              recipe_revision, evidence_digest, required_field_state)
+         VALUES (?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.handoff_row_id)
+    .bind(params.kind)
+    .bind(params.camera_row_id)
+    .bind(params.family_row_id)
+    .bind(params.recipe_revision)
+    .bind(params.evidence_digest)
+    .bind(params.required_field_state)
+    .execute(conn)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Insert the snapshot–requirement mapping row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_snapshot_requirement_mapping(
+    conn: &mut SqliteConnection,
+    snapshot_row_id: i64,
+    requirement_row_id: i64,
+    handoff_row_id: i64,
+    ordinal: i64,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO calibration_handoff_snapshot_requirement
+             (snapshot_row_id, requirement_row_id, handoff_row_id, ordinal)
+         VALUES (?,?,?,?)",
+    )
+    .bind(snapshot_row_id)
+    .bind(requirement_row_id)
+    .bind(handoff_row_id)
+    .bind(ordinal)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert one `calibration_handoff_candidate_evidence` row plus its ordered
+/// `calibration_handoff_candidate_warning` children.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff_candidate_evidence(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoffCandidateEvidence<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_handoff_candidate_evidence (
+            public_id, handoff_row_id, snapshot_row_id,
+            requirement_row_id, session_row_id,
+            recipe_compatible, recipe_complete,
+            age_days, age_severity, thermal_state,
+            available_frame_count, readable_frame_count,
+            automatic_eligible, evidence_digest, observed_at
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.handoff_row_id)
+    .bind(params.snapshot_row_id)
+    .bind(params.requirement_row_id)
+    .bind(params.session_row_id)
+    .bind(i64::from(params.recipe_compatible))
+    .bind(i64::from(params.recipe_complete))
+    .bind(params.age_days)
+    .bind(params.age_severity)
+    .bind(params.thermal_state)
+    .bind(params.available_frame_count)
+    .bind(params.readable_frame_count)
+    .bind(i64::from(params.automatic_eligible))
+    .bind(params.evidence_digest)
+    .bind(params.observed_at)
+    .execute(&mut *conn)
+    .await?;
+    let evidence_row_id = result.last_insert_rowid();
+
+    for (ordinal, code) in params.warning_codes.iter().enumerate() {
+        sqlx::query(
+            "INSERT INTO calibration_handoff_candidate_warning
+                 (candidate_evidence_row_id, warning_code, ordinal)
+             VALUES (?,?,?)",
+        )
+        .bind(evidence_row_id)
+        .bind(*code)
+        .bind(i64::try_from(ordinal).unwrap_or(i64::MAX))
+        .execute(&mut *conn)
+        .await?;
+    }
+
+    Ok(evidence_row_id)
+}
+
+/// Insert one `calibration_handoff_selection` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff_selection(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoffSelection<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_handoff_selection
+             (public_id, handoff_row_id, requirement_row_id, session_row_id,
+              candidate_evidence_row_id, source, selected_at, created_sequence)
+         VALUES (?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.handoff_row_id)
+    .bind(params.requirement_row_id)
+    .bind(params.session_row_id)
+    .bind(params.candidate_evidence_row_id)
+    .bind(params.source)
+    .bind(params.selected_at)
+    .bind(params.created_sequence)
+    .execute(conn)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Insert the snapshot–selection mapping row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_snapshot_selection_mapping(
+    conn: &mut SqliteConnection,
+    snapshot_row_id: i64,
+    selection_row_id: i64,
+    handoff_row_id: i64,
+    ordinal: i64,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO calibration_handoff_snapshot_selection
+             (snapshot_row_id, selection_row_id, handoff_row_id, ordinal)
+         VALUES (?,?,?,?)",
+    )
+    .bind(snapshot_row_id)
+    .bind(selection_row_id)
+    .bind(handoff_row_id)
+    .bind(ordinal)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert one `calibration_handoff_frame` row.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff_frame(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoffFrame<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO calibration_handoff_frame (
+            selection_row_id, frame_row_id, session_membership_ordinal,
+            file_row_id, source_root_row_id,
+            canonical_relative_path, stable_file_identity,
+            byte_size, sha256_fingerprint,
+            no_follow_verified, verified_at
+         ) VALUES (?,?,?,?,?,?,?,?,?,1,?)",
+    )
+    .bind(params.selection_row_id)
+    .bind(params.frame_row_id)
+    .bind(params.session_membership_ordinal)
+    .bind(params.file_row_id)
+    .bind(params.source_root_row_id)
+    .bind(params.canonical_relative_path)
+    .bind(params.stable_file_identity)
+    .bind(params.byte_size)
+    .bind(params.sha256_fingerprint)
+    .bind(params.verified_at)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert a `calibration_handoff_operation` row in `ready` state.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_handoff_operation(
+    conn: &mut SqliteConnection,
+    params: &InsertHandoffOperation<'_>,
+) -> DbResult<i64> {
+    let result = sqlx::query(
+        "INSERT INTO calibration_handoff_operation
+             (public_id, handoff_row_id, command_row_id, state,
+              state_version, lease_generation,
+              frame_progress, byte_progress, created_at)
+         VALUES (?,?,?,'ready',0,0,0,0,?)",
+    )
+    .bind(params.public_id)
+    .bind(params.handoff_row_id)
+    .bind(params.command_row_id)
+    .bind(params.created_at)
+    .execute(conn)
+    .await?;
+    Ok(result.last_insert_rowid())
+}
+
+/// Transition a `calibration_handoff_operation` state by CAS on
+/// `state_version`.
+///
+/// `new_state` must be one of `verifying`, `cancelling`, `cancelled`,
+/// `applied`, or `failed`.
+///
+/// # Errors
+///
+/// Returns [`DbError::CasFailed`] when `expected_state_version` does not match.
+pub async fn transition_handoff_operation_state(
+    conn: &mut SqliteConnection,
+    operation_row_id: i64,
+    from_state: &str,
+    to_state: &str,
+    expected_state_version: i64,
+    terminal_snapshot_row_id: Option<i64>,
+) -> DbResult<()> {
+    let result = sqlx::query(
+        "UPDATE calibration_handoff_operation
+         SET state = ?,
+             state_version = state_version + 1,
+             terminal_snapshot_row_id = COALESCE(?, terminal_snapshot_row_id)
+         WHERE row_id = ?
+           AND state = ?
+           AND state_version = ?",
+    )
+    .bind(to_state)
+    .bind(terminal_snapshot_row_id)
+    .bind(operation_row_id)
+    .bind(from_state)
+    .bind(expected_state_version)
+    .execute(conn)
+    .await?;
+    if result.rows_affected() != 1 {
+        return Err(DbError::CasFailed(format!(
+            "handoff operation {operation_row_id} state CAS failed \
+             ({from_state}→{to_state}, expected_version={expected_state_version})"
+        )));
+    }
+    Ok(())
+}
+
+/// Update frame/byte progress counters on an operation.
+///
+/// Non-CAS: progress is coalesced and race-safe by monotone intent
+/// (callers only write higher values).
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn update_handoff_operation_progress(
+    conn: &mut SqliteConnection,
+    operation_row_id: i64,
+    frame_progress: i64,
+    byte_progress: i64,
+) -> DbResult<()> {
+    sqlx::query(
+        "UPDATE calibration_handoff_operation
+         SET frame_progress = ?, byte_progress = ?
+         WHERE row_id = ?",
+    )
+    .bind(frame_progress)
+    .bind(byte_progress)
+    .bind(operation_row_id)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+// ── Reads ─────────────────────────────────────────────────────────────────────
+
+/// Fetch a `calibration_handoff` by `public_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if the handoff does not exist.
+pub async fn get_handoff_by_public_id(pool: &SqlitePool, public_id: &str) -> DbResult<HandoffRow> {
+    sqlx::query_as::<_, HandoffRow>(
+        "SELECT row_id, public_id, project_row_id, external_processor,
+                head_snapshot_row_id, head_generation, created_at
+         FROM calibration_handoff
+         WHERE public_id = ?",
+    )
+    .bind(public_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("calibration_handoff {public_id}")))
+}
+
+/// Fetch a `calibration_handoff_snapshot` by `public_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if the snapshot does not exist.
+pub async fn get_snapshot_by_public_id(
+    pool: &SqlitePool,
+    public_id: &str,
+) -> DbResult<HandoffSnapshotRow> {
+    sqlx::query_as::<_, HandoffSnapshotRow>(
+        "SELECT row_id, public_id, handoff_row_id, predecessor_snapshot_row_id,
+                evaluation_at, matching_settings_revision_row_id,
+                basis_digest, requirement_count, selection_count,
+                frame_count, source_byte_count,
+                actor_row_id, command_row_id, created_sequence, created_at
+         FROM calibration_handoff_snapshot
+         WHERE public_id = ?",
+    )
+    .bind(public_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("calibration_handoff_snapshot {public_id}")))
+}
+
+/// Fetch a `calibration_handoff_operation` by `public_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if the operation does not exist.
+pub async fn get_operation_by_public_id(
+    pool: &SqlitePool,
+    public_id: &str,
+) -> DbResult<HandoffOperationRow> {
+    sqlx::query_as::<_, HandoffOperationRow>(
+        "SELECT row_id, public_id, handoff_row_id, command_row_id,
+                state, state_version, lease_owner, lease_generation,
+                frame_progress, byte_progress,
+                terminal_snapshot_row_id, created_at
+         FROM calibration_handoff_operation
+         WHERE public_id = ?",
+    )
+    .bind(public_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("calibration_handoff_operation {public_id}")))
+}
+
+/// List requirements belonging to a snapshot in ordinal order.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn list_snapshot_requirements(
+    pool: &SqlitePool,
+    snapshot_row_id: i64,
+) -> DbResult<Vec<HandoffRequirementRow>> {
+    sqlx::query_as::<_, HandoffRequirementRow>(
+        "SELECT r.row_id, r.public_id, r.handoff_row_id, r.kind,
+                r.camera_row_id, r.family_row_id,
+                r.recipe_revision, r.evidence_digest, r.required_field_state
+         FROM calibration_handoff_requirement r
+         INNER JOIN calibration_handoff_snapshot_requirement sr
+             ON sr.requirement_row_id = r.row_id
+            AND sr.snapshot_row_id = ?
+         ORDER BY sr.ordinal ASC",
+    )
+    .bind(snapshot_row_id)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+/// List selections belonging to a snapshot in ordinal order.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn list_snapshot_selections(
+    pool: &SqlitePool,
+    snapshot_row_id: i64,
+) -> DbResult<Vec<HandoffSelectionRow>> {
+    sqlx::query_as::<_, HandoffSelectionRow>(
+        "SELECT sel.row_id, sel.public_id, sel.handoff_row_id,
+                sel.requirement_row_id, sel.session_row_id,
+                sel.candidate_evidence_row_id, sel.source,
+                sel.selected_at, sel.created_sequence
+         FROM calibration_handoff_selection sel
+         INNER JOIN calibration_handoff_snapshot_selection ss
+             ON ss.selection_row_id = sel.row_id
+            AND ss.snapshot_row_id = ?
+         ORDER BY ss.ordinal ASC",
+    )
+    .bind(snapshot_row_id)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+/// List frames for a selection in session-membership-ordinal order.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn list_selection_frames(
+    pool: &SqlitePool,
+    selection_row_id: i64,
+) -> DbResult<Vec<HandoffFrameRow>> {
+    sqlx::query_as::<_, HandoffFrameRow>(
+        "SELECT selection_row_id, frame_row_id, session_membership_ordinal,
+                file_row_id, source_root_row_id,
+                canonical_relative_path, stable_file_identity,
+                byte_size, sha256_fingerprint, no_follow_verified, verified_at
+         FROM calibration_handoff_frame
+         WHERE selection_row_id = ?
+         ORDER BY session_membership_ordinal ASC",
+    )
+    .bind(selection_row_id)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_db() -> sqlx::SqlitePool {
+        let db = persistence_core::Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    /// Seed the minimal FK chain needed for handoff tests:
+    /// actor, config, repo_change, command, operation, session, calibration session,
+    /// spec062_project (for handoff FK), matching_settings_revision, source_root,
+    /// file_identity, frame_record, spec062_calibration_session.
+    async fn seed_handoff_prerequisites(pool: &sqlx::SqlitePool) {
+        let ts = "2026-07-22T00:00:00.000000Z";
+        sqlx::query(
+            "INSERT INTO spec062_actor VALUES (1,'00000000-0000-7000-d000-000000000001',?)",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .expect("actor");
+        sqlx::query("INSERT INTO spec062_config_revision VALUES (1,'00000000-0000-7000-d000-000000000002',1,'cfg-digest',?)").bind(ts).execute(pool).await.expect("config");
+        sqlx::query("INSERT INTO repository_change(command_row_id,created_at) VALUES (NULL,?)")
+            .bind(ts)
+            .execute(pool)
+            .await
+            .expect("repo_change");
+        sqlx::query("INSERT INTO command_execution (row_id,public_id,actor_row_id,operation,canonical_payload_digest,state,response_json,created_at,finished_at) VALUES (1,'00000000-0000-7000-d000-000000000003',1,'calibration.handoff.create','pd','applied','{}',?,?)").bind(ts).bind(ts).execute(pool).await.expect("command");
+        sqlx::query("INSERT INTO session_materialization_operation (row_id,public_id,kind,command_row_id,config_revision_row_id,state,created_sequence,created_at) VALUES (1,'00000000-0000-7000-d000-000000000004','inbox_ingestion',1,1,'ready',1,?)").bind(ts).execute(pool).await.expect("operation");
+
+        // spec062_project
+        sqlx::query(
+            "INSERT INTO spec062_project (row_id,public_id,created_at) VALUES (1,'proj-pub-001',?)",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .expect("project");
+
+        // matching_settings_revision (minimal: all constraints require reasonable defaults)
+        sqlx::query(
+            "INSERT INTO matching_settings_revision (
+                row_id,public_id,revision_number,
+                same_session_coverage_min_ppm,same_session_centre_max_ppm,same_session_rotation_max_udeg,
+                sibling_coverage_min_ppm,sibling_centre_max_ppm,sibling_rotation_max_udeg,
+                mosaic_overlap_min_ppm,mosaic_overlap_max_ppm,
+                dark_thermal_moderate_millic,dark_thermal_severe_millic,
+                flat_orientation_normal_udeg,flat_orientation_red_udeg,flat_red_age_days,
+                canonical_digest,actor_row_id,command_row_id,created_sequence,created_at
+             ) VALUES (1,'msr-pub-001',1,950000,20000,1000000,900000,50000,5000000,50000,400000,500,2000,2000000,5000000,7,'msr-digest',1,1,1,?)"
+        ).bind(ts).execute(pool).await.expect("matching_settings_revision");
+        sqlx::query("INSERT INTO matching_settings_head (singleton,head_revision_row_id,head_generation) VALUES (1,1,0)").execute(pool).await.expect("settings_head");
+
+        // spec062_source_root
+        sqlx::query("INSERT INTO spec062_source_root (row_id,public_id,created_at) VALUES (1,'sr-pub-001',?)").bind(ts).execute(pool).await.expect("source_root");
+
+        // file_identity + frame_record + session + spec062_calibration_session
+        sqlx::query("INSERT INTO spec062_file_identity VALUES (1,'fi-pub-001',NULL,?)")
+            .bind(ts)
+            .execute(pool)
+            .await
+            .expect("file_identity");
+        sqlx::query("INSERT INTO frame_record (row_id,public_id,file_row_id,byte_size,captured_metadata_digest,created_sequence,created_at) VALUES (1,'frame-pub-001',1,4096,'fmd-001',1,?)").bind(ts).execute(pool).await.expect("frame_record");
+        sqlx::query("INSERT INTO session (row_id,public_id,materialization_operation_row_id,kind,ordinal_in_operation,identity_digest,observing_night_date,night_derivation,created_sequence,created_at) VALUES (1,'ses-pub-001',1,'dark',0,'dark-id-001','2026-01-15','reviewed_local_fallback',1,?)").bind(ts).execute(pool).await.expect("session");
+        sqlx::query("INSERT INTO spec062_calibration_session (session_row_id,kind,family_row_id,assignment_state,age_anchor_at_utc,cooling_setpoint_state,representative_sensor_temperature_state,created_sequence,created_at) VALUES (1,'dark',NULL,'blocked_unknown_temperature','2026-01-15T22:00:00.000000Z','absent','absent',1,?)").bind(ts).execute(pool).await.expect("calibration_session");
+    }
+
+    #[tokio::test]
+    async fn insert_handoff_and_snapshot_with_head_advance() {
+        let pool = setup_db().await;
+        seed_handoff_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let handoff_row_id = insert_handoff(
+            &mut conn,
+            &InsertHandoff {
+                public_id: "ho-pub-001",
+                project_row_id: 1,
+                external_processor: "pixinsight_wbpp",
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("insert handoff");
+
+        let snapshot_row_id = insert_handoff_snapshot(
+            &mut conn,
+            &InsertHandoffSnapshot {
+                public_id: "hs-pub-001",
+                handoff_row_id,
+                predecessor_snapshot_row_id: None,
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "basis-001",
+                requirement_count: 0,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("insert snapshot");
+
+        advance_handoff_head(&mut conn, handoff_row_id, snapshot_row_id, 0)
+            .await
+            .expect("advance head");
+
+        let handoff = get_handoff_by_public_id(&pool, "ho-pub-001").await.expect("get handoff");
+        assert_eq!(handoff.head_snapshot_row_id, Some(snapshot_row_id));
+        assert_eq!(handoff.head_generation, 1);
+
+        let snap = get_snapshot_by_public_id(&pool, "hs-pub-001").await.expect("get snapshot");
+        assert_eq!(snap.handoff_row_id, handoff_row_id);
+        assert_eq!(snap.basis_digest, "basis-001");
+    }
+
+    #[tokio::test]
+    async fn advance_head_cas_fails_on_stale_generation() {
+        let pool = setup_db().await;
+        seed_handoff_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let handoff_row_id = insert_handoff(
+            &mut conn,
+            &InsertHandoff {
+                public_id: "ho-pub-002",
+                project_row_id: 1,
+                external_processor: "siril",
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("handoff");
+        let snap_id = insert_handoff_snapshot(
+            &mut conn,
+            &InsertHandoffSnapshot {
+                public_id: "hs-pub-002",
+                handoff_row_id,
+                predecessor_snapshot_row_id: None,
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "b1",
+                requirement_count: 0,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("snap");
+
+        // First advance succeeds
+        advance_handoff_head(&mut conn, handoff_row_id, snap_id, 0).await.expect("first advance");
+        // Second advance with stale generation fails
+        let err = advance_handoff_head(&mut conn, handoff_row_id, snap_id, 0).await;
+        assert!(matches!(err, Err(DbError::CasFailed(_))));
+    }
+
+    #[tokio::test]
+    async fn handoff_requirement_and_candidate_evidence_roundtrip() {
+        let pool = setup_db().await;
+        seed_handoff_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let handoff_row_id = insert_handoff(
+            &mut conn,
+            &InsertHandoff {
+                public_id: "ho-pub-003",
+                project_row_id: 1,
+                external_processor: "pixinsight_wbpp",
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("handoff");
+        let snap_id = insert_handoff_snapshot(
+            &mut conn,
+            &InsertHandoffSnapshot {
+                public_id: "hs-pub-003",
+                handoff_row_id,
+                predecessor_snapshot_row_id: None,
+                evaluation_at: ts,
+                matching_settings_revision_row_id: 1,
+                basis_digest: "b3",
+                requirement_count: 1,
+                selection_count: 0,
+                frame_count: 0,
+                source_byte_count: 0,
+                actor_row_id: 1,
+                command_row_id: 1,
+                created_sequence: 1,
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("snap");
+        advance_handoff_head(&mut conn, handoff_row_id, snap_id, 0).await.expect("head");
+
+        let req_id = insert_handoff_requirement(
+            &mut conn,
+            &InsertHandoffRequirement {
+                public_id: "req-pub-001",
+                handoff_row_id,
+                kind: "dark",
+                camera_row_id: None,
+                family_row_id: None,
+                recipe_revision: 1,
+                evidence_digest: "ev-digest-001",
+                required_field_state: "complete",
+            },
+        )
+        .await
+        .expect("requirement");
+
+        insert_snapshot_requirement_mapping(&mut conn, snap_id, req_id, handoff_row_id, 0)
+            .await
+            .expect("mapping");
+
+        let ev_id = insert_handoff_candidate_evidence(
+            &mut conn,
+            &InsertHandoffCandidateEvidence {
+                public_id: "cev-pub-001",
+                handoff_row_id,
+                snapshot_row_id: snap_id,
+                requirement_row_id: req_id,
+                session_row_id: 1,
+                recipe_compatible: true,
+                recipe_complete: true,
+                age_days: 50,
+                age_severity: "normal",
+                thermal_state: "normal",
+                available_frame_count: 100,
+                readable_frame_count: 100,
+                automatic_eligible: true,
+                evidence_digest: "ev-001",
+                observed_at: ts,
+                warning_codes: &[],
+            },
+        )
+        .await
+        .expect("candidate evidence");
+        assert!(ev_id > 0);
+
+        let reqs = list_snapshot_requirements(&pool, snap_id).await.expect("list reqs");
+        assert_eq!(reqs.len(), 1);
+        assert_eq!(reqs[0].kind, "dark");
+    }
+
+    #[tokio::test]
+    async fn handoff_operation_state_transition() {
+        let pool = setup_db().await;
+        seed_handoff_prerequisites(&pool).await;
+        let ts = "2026-07-22T00:00:00.000000Z";
+
+        let mut conn = pool.acquire().await.expect("conn");
+        let handoff_row_id = insert_handoff(
+            &mut conn,
+            &InsertHandoff {
+                public_id: "ho-pub-004",
+                project_row_id: 1,
+                external_processor: "siril",
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("handoff");
+        let op_id = insert_handoff_operation(
+            &mut conn,
+            &InsertHandoffOperation {
+                public_id: "op-pub-001",
+                handoff_row_id,
+                command_row_id: 1,
+                created_at: ts,
+            },
+        )
+        .await
+        .expect("operation");
+
+        // ready → verifying
+        transition_handoff_operation_state(&mut conn, op_id, "ready", "verifying", 0, None)
+            .await
+            .expect("to verifying");
+
+        let op = get_operation_by_public_id(&pool, "op-pub-001").await.expect("get op");
+        assert_eq!(op.state, "verifying");
+        assert_eq!(op.state_version, 1);
+    }
+}

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/mod.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/mod.rs
@@ -1,0 +1,10 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repositories for spec-062 calibration families, sessions, handoff aggregates,
+//! and source availability (FR-062 through FR-075).
+
+pub mod availability;
+pub mod families;
+pub mod handoff;
+pub mod sessions;

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/sessions.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/sessions.rs
@@ -1,0 +1,487 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Repository for `spec062_calibration_session` and `dark_thermal_evidence`.
+//!
+//! A calibration session extends a `session` row via `session_row_id`. The
+//! insert functions are called from the materialization apply transaction that
+//! creates the parent `session` row first.
+
+use sqlx::{SqliteConnection, SqlitePool};
+
+use persistence_core::{DbError, DbResult};
+
+// ── Row projections ────────────────────────────────────────────────────────────
+
+/// `spec062_calibration_session` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct CalibrationSessionRow {
+    pub session_row_id: i64,
+    pub kind: String,
+    pub family_row_id: Option<i64>,
+    pub assignment_state: String,
+    pub assignment_proposal_row_id: Option<i64>,
+    pub age_anchor_at_utc: String,
+    pub cooling_setpoint_state: String,
+    pub cooling_setpoint_millic: Option<i64>,
+    pub representative_sensor_temperature_state: String,
+    pub representative_sensor_temperature_millic: Option<i64>,
+    pub created_sequence: i64,
+    pub created_at: String,
+}
+
+/// `dark_thermal_evidence` row.
+#[derive(Debug, Clone, sqlx::FromRow)]
+pub struct DarkThermalEvidenceRow {
+    pub session_row_id: i64,
+    pub valid_count: i64,
+    pub missing_count: i64,
+    pub invalid_count: i64,
+    pub minimum_abs_deviation_millic: Option<i64>,
+    pub median_abs_deviation_millic: Option<i64>,
+    pub maximum_abs_deviation_millic: Option<i64>,
+    pub p95_abs_deviation_millic: Option<i64>,
+    pub valid_ratio_ppm: i64,
+    pub severity: String,
+    pub created_sequence: i64,
+}
+
+// ── Insert parameters ─────────────────────────────────────────────────────────
+
+/// Parameters for inserting one `spec062_calibration_session` row.
+pub struct InsertCalibrationSession<'a> {
+    pub session_row_id: i64,
+    pub kind: &'a str,
+    pub family_row_id: Option<i64>,
+    pub assignment_state: &'a str,
+    pub assignment_proposal_row_id: Option<i64>,
+    pub age_anchor_at_utc: &'a str,
+    pub cooling_setpoint_state: &'a str,
+    pub cooling_setpoint_millic: Option<i64>,
+    pub representative_sensor_temperature_state: &'a str,
+    pub representative_sensor_temperature_millic: Option<i64>,
+    pub created_sequence: i64,
+    pub created_at: &'a str,
+}
+
+/// Parameters for inserting one `dark_thermal_evidence` row.
+pub struct InsertDarkThermalEvidence<'a> {
+    pub session_row_id: i64,
+    pub valid_count: i64,
+    pub missing_count: i64,
+    pub invalid_count: i64,
+    pub minimum_abs_deviation_millic: Option<i64>,
+    pub median_abs_deviation_millic: Option<i64>,
+    pub maximum_abs_deviation_millic: Option<i64>,
+    pub p95_abs_deviation_millic: Option<i64>,
+    pub valid_ratio_ppm: i64,
+    pub severity: &'a str,
+    pub created_sequence: i64,
+}
+
+// ── Writes ────────────────────────────────────────────────────────────────────
+
+/// Insert one `spec062_calibration_session` row.
+///
+/// Called inside the materialization apply transaction, after the parent
+/// `session` row exists.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_calibration_session(
+    conn: &mut SqliteConnection,
+    params: &InsertCalibrationSession<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO spec062_calibration_session (
+            session_row_id, kind,
+            family_row_id, assignment_state, assignment_proposal_row_id,
+            age_anchor_at_utc,
+            cooling_setpoint_state, cooling_setpoint_millic,
+            representative_sensor_temperature_state,
+            representative_sensor_temperature_millic,
+            created_sequence, created_at
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.session_row_id)
+    .bind(params.kind)
+    .bind(params.family_row_id)
+    .bind(params.assignment_state)
+    .bind(params.assignment_proposal_row_id)
+    .bind(params.age_anchor_at_utc)
+    .bind(params.cooling_setpoint_state)
+    .bind(params.cooling_setpoint_millic)
+    .bind(params.representative_sensor_temperature_state)
+    .bind(params.representative_sensor_temperature_millic)
+    .bind(params.created_sequence)
+    .bind(params.created_at)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Insert one `dark_thermal_evidence` row for a regulated dark session.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+pub async fn insert_dark_thermal_evidence(
+    conn: &mut SqliteConnection,
+    params: &InsertDarkThermalEvidence<'_>,
+) -> DbResult<()> {
+    sqlx::query(
+        "INSERT INTO dark_thermal_evidence (
+            session_row_id,
+            valid_count, missing_count, invalid_count,
+            minimum_abs_deviation_millic, median_abs_deviation_millic,
+            maximum_abs_deviation_millic, p95_abs_deviation_millic,
+            valid_ratio_ppm, severity, created_sequence
+         ) VALUES (?,?,?,?,?,?,?,?,?,?,?)",
+    )
+    .bind(params.session_row_id)
+    .bind(params.valid_count)
+    .bind(params.missing_count)
+    .bind(params.invalid_count)
+    .bind(params.minimum_abs_deviation_millic)
+    .bind(params.median_abs_deviation_millic)
+    .bind(params.maximum_abs_deviation_millic)
+    .bind(params.p95_abs_deviation_millic)
+    .bind(params.valid_ratio_ppm)
+    .bind(params.severity)
+    .bind(params.created_sequence)
+    .execute(conn)
+    .await?;
+    Ok(())
+}
+
+/// Assign a calibration session to a family by updating `family_row_id` and
+/// `assignment_state`.
+///
+/// Uses a compare-and-swap on the current `assignment_state` to prevent
+/// concurrent double-assignment. Callers must hold `BEGIN IMMEDIATE`.
+///
+/// # Errors
+///
+/// Returns [`DbError::CasFailed`] when the row was already assigned or the
+/// expected prior state does not match.
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn assign_calibration_session_to_family(
+    conn: &mut SqliteConnection,
+    session_row_id: i64,
+    family_row_id: i64,
+    expected_prior_state: &str,
+) -> DbResult<()> {
+    let result = sqlx::query(
+        "UPDATE spec062_calibration_session
+         SET family_row_id = ?,
+             assignment_state = 'assigned'
+         WHERE session_row_id = ?
+           AND assignment_state = ?",
+    )
+    .bind(family_row_id)
+    .bind(session_row_id)
+    .bind(expected_prior_state)
+    .execute(conn)
+    .await?;
+    if result.rows_affected() != 1 {
+        return Err(DbError::CasFailed(format!(
+            "calibration session {session_row_id} assignment CAS failed \
+             (expected state={expected_prior_state})"
+        )));
+    }
+    Ok(())
+}
+
+// ── Reads ─────────────────────────────────────────────────────────────────────
+
+/// Fetch a `spec062_calibration_session` by its parent `session_row_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no matching row exists, or
+/// [`DbError::Database`] on SQL errors.
+pub async fn get_calibration_session(
+    pool: &SqlitePool,
+    session_row_id: i64,
+) -> DbResult<CalibrationSessionRow> {
+    sqlx::query_as::<_, CalibrationSessionRow>(
+        "SELECT session_row_id, kind,
+                family_row_id, assignment_state, assignment_proposal_row_id,
+                age_anchor_at_utc,
+                cooling_setpoint_state, cooling_setpoint_millic,
+                representative_sensor_temperature_state,
+                representative_sensor_temperature_millic,
+                created_sequence, created_at
+         FROM spec062_calibration_session
+         WHERE session_row_id = ?",
+    )
+    .bind(session_row_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| {
+        DbError::NotFound(format!("spec062_calibration_session row_id={session_row_id}"))
+    })
+}
+
+/// Fetch a `spec062_calibration_session` by the parent session's `public_id`.
+///
+/// Performs a join to `session` to resolve the `row_id`.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if the session or calibration extension row
+/// does not exist.
+pub async fn get_calibration_session_by_public_id(
+    pool: &SqlitePool,
+    session_public_id: &str,
+) -> DbResult<CalibrationSessionRow> {
+    sqlx::query_as::<_, CalibrationSessionRow>(
+        "SELECT cs.session_row_id, cs.kind,
+                cs.family_row_id, cs.assignment_state, cs.assignment_proposal_row_id,
+                cs.age_anchor_at_utc,
+                cs.cooling_setpoint_state, cs.cooling_setpoint_millic,
+                cs.representative_sensor_temperature_state,
+                cs.representative_sensor_temperature_millic,
+                cs.created_sequence, cs.created_at
+         FROM spec062_calibration_session cs
+         INNER JOIN session s ON s.row_id = cs.session_row_id
+         WHERE s.public_id = ?",
+    )
+    .bind(session_public_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| DbError::NotFound(format!("calibration session {session_public_id}")))
+}
+
+/// List all calibration sessions belonging to a family, ordered by
+/// `age_anchor_at_utc DESC` then `session_row_id ASC` for deterministic
+/// paging. Returns `row_id` and `age_anchor_at_utc` only; callers join further
+/// columns as needed.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on SQL errors.
+pub async fn list_calibration_sessions_by_family(
+    pool: &SqlitePool,
+    family_row_id: i64,
+) -> DbResult<Vec<CalibrationSessionRow>> {
+    sqlx::query_as::<_, CalibrationSessionRow>(
+        "SELECT session_row_id, kind,
+                family_row_id, assignment_state, assignment_proposal_row_id,
+                age_anchor_at_utc,
+                cooling_setpoint_state, cooling_setpoint_millic,
+                representative_sensor_temperature_state,
+                representative_sensor_temperature_millic,
+                created_sequence, created_at
+         FROM spec062_calibration_session
+         WHERE family_row_id = ?
+         ORDER BY age_anchor_at_utc DESC, session_row_id ASC",
+    )
+    .bind(family_row_id)
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::from)
+}
+
+/// Fetch `dark_thermal_evidence` for a dark session.
+///
+/// # Errors
+///
+/// Returns [`DbError::NotFound`] if no evidence row exists for this session.
+pub async fn get_dark_thermal_evidence(
+    pool: &SqlitePool,
+    session_row_id: i64,
+) -> DbResult<DarkThermalEvidenceRow> {
+    sqlx::query_as::<_, DarkThermalEvidenceRow>(
+        "SELECT session_row_id,
+                valid_count, missing_count, invalid_count,
+                minimum_abs_deviation_millic, median_abs_deviation_millic,
+                maximum_abs_deviation_millic, p95_abs_deviation_millic,
+                valid_ratio_ppm, severity, created_sequence
+         FROM dark_thermal_evidence
+         WHERE session_row_id = ?",
+    )
+    .bind(session_row_id)
+    .fetch_optional(pool)
+    .await?
+    .ok_or_else(|| {
+        DbError::NotFound(format!("dark_thermal_evidence session_row_id={session_row_id}"))
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    async fn setup_db() -> sqlx::SqlitePool {
+        let db = persistence_core::Database::in_memory().await.expect("in-memory DB");
+        db.migrate().await.expect("migrations");
+        db.pool().clone()
+    }
+
+    /// Seed the minimal rows for a calibration session insert test.
+    async fn seed_base(pool: &sqlx::SqlitePool) {
+        let ts = "2026-07-22T00:00:00.000000Z";
+        sqlx::query(
+            "INSERT INTO spec062_actor VALUES (1,'00000000-0000-7000-b000-000000000001',?)",
+        )
+        .bind(ts)
+        .execute(pool)
+        .await
+        .expect("actor");
+        sqlx::query("INSERT INTO spec062_config_revision VALUES (1,'00000000-0000-7000-b000-000000000002',1,'cfg-digest',?)").bind(ts).execute(pool).await.expect("config");
+        sqlx::query("INSERT INTO repository_change(command_row_id,created_at) VALUES (NULL,?)")
+            .bind(ts)
+            .execute(pool)
+            .await
+            .expect("repo_change");
+        sqlx::query(
+            "INSERT INTO command_execution (row_id,public_id,actor_row_id,operation,canonical_payload_digest,state,response_json,created_at,finished_at)
+             VALUES (1,'00000000-0000-7000-b000-000000000003',1,'inbox.materialization.apply','pd','applied','{}',?,?)"
+        ).bind(ts).bind(ts).execute(pool).await.expect("command");
+        sqlx::query(
+            "INSERT INTO session_materialization_operation (row_id,public_id,kind,command_row_id,config_revision_row_id,state,created_sequence,created_at)
+             VALUES (1,'00000000-0000-7000-b000-000000000004','inbox_ingestion',1,1,'ready',1,?)"
+        ).bind(ts).execute(pool).await.expect("operation");
+    }
+
+    async fn insert_session(
+        pool: &sqlx::SqlitePool,
+        row_id: i64,
+        kind: &str,
+        ordinal: i64,
+        digest: &str,
+    ) {
+        let sql = format!(
+            "INSERT INTO session (row_id,public_id,materialization_operation_row_id,kind,\
+             ordinal_in_operation,identity_digest,observing_night_date,night_derivation,\
+             created_sequence,created_at) VALUES ({row_id},'ses-pub-{row_id:03}',1,'{kind}',\
+             {ordinal},'{digest}','2026-01-15','reviewed_local_fallback',1,\
+             '2026-07-22T00:00:00.000000Z')"
+        );
+        sqlx::query(sqlx::AssertSqlSafe(sql)).execute(pool).await.expect("session");
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_dark_calibration_session_blocked_unknown_temperature() {
+        let pool = setup_db().await;
+        seed_base(&pool).await;
+        insert_session(&pool, 1, "dark", 0, "dark-id-001").await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        insert_calibration_session(
+            &mut conn,
+            &InsertCalibrationSession {
+                session_row_id: 1,
+                kind: "dark",
+                family_row_id: None,
+                assignment_state: "blocked_unknown_temperature",
+                assignment_proposal_row_id: None,
+                age_anchor_at_utc: "2026-01-15T22:00:00.000000Z",
+                cooling_setpoint_state: "absent",
+                cooling_setpoint_millic: None,
+                representative_sensor_temperature_state: "absent",
+                representative_sensor_temperature_millic: None,
+                created_sequence: 1,
+                created_at: "2026-07-22T00:00:00.000000Z",
+            },
+        )
+        .await
+        .expect("insert calibration session");
+
+        let row = get_calibration_session(&pool, 1).await.expect("get");
+        assert_eq!(row.kind, "dark");
+        assert_eq!(row.assignment_state, "blocked_unknown_temperature");
+        assert!(row.family_row_id.is_none());
+        assert_eq!(row.cooling_setpoint_state, "absent");
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_bias_calibration_session() {
+        let pool = setup_db().await;
+        seed_base(&pool).await;
+        insert_session(&pool, 1, "bias", 0, "bias-id-001").await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        insert_calibration_session(
+            &mut conn,
+            &InsertCalibrationSession {
+                session_row_id: 1,
+                kind: "bias",
+                family_row_id: None,
+                assignment_state: "needs_review",
+                assignment_proposal_row_id: None,
+                age_anchor_at_utc: "2026-01-15T22:00:00.000000Z",
+                cooling_setpoint_state: "absent",
+                cooling_setpoint_millic: None,
+                representative_sensor_temperature_state: "absent",
+                representative_sensor_temperature_millic: None,
+                created_sequence: 1,
+                created_at: "2026-07-22T00:00:00.000000Z",
+            },
+        )
+        .await
+        .expect("insert bias calibration session");
+
+        let row = get_calibration_session_by_public_id(&pool, "ses-pub-001")
+            .await
+            .expect("get by public id");
+        assert_eq!(row.kind, "bias");
+        assert_eq!(row.assignment_state, "needs_review");
+    }
+
+    #[tokio::test]
+    async fn insert_and_get_dark_thermal_evidence() {
+        let pool = setup_db().await;
+        seed_base(&pool).await;
+        insert_session(&pool, 1, "dark", 0, "dark-id-001").await;
+
+        let mut conn = pool.acquire().await.expect("conn");
+        insert_calibration_session(
+            &mut conn,
+            &InsertCalibrationSession {
+                session_row_id: 1,
+                kind: "dark",
+                family_row_id: None,
+                assignment_state: "blocked_unknown_temperature",
+                assignment_proposal_row_id: None,
+                age_anchor_at_utc: "2026-01-15T22:00:00.000000Z",
+                cooling_setpoint_state: "present",
+                cooling_setpoint_millic: Some(-10_000),
+                representative_sensor_temperature_state: "present",
+                representative_sensor_temperature_millic: Some(-9_800),
+                created_sequence: 1,
+                created_at: "2026-07-22T00:00:00.000000Z",
+            },
+        )
+        .await
+        .expect("calibration session");
+
+        insert_dark_thermal_evidence(
+            &mut conn,
+            &InsertDarkThermalEvidence {
+                session_row_id: 1,
+                valid_count: 100,
+                missing_count: 0,
+                invalid_count: 0,
+                minimum_abs_deviation_millic: Some(100),
+                median_abs_deviation_millic: Some(200),
+                maximum_abs_deviation_millic: Some(400),
+                p95_abs_deviation_millic: Some(350),
+                valid_ratio_ppm: 1_000_000,
+                severity: "normal",
+                created_sequence: 1,
+            },
+        )
+        .await
+        .expect("thermal evidence");
+
+        let ev = get_dark_thermal_evidence(&pool, 1).await.expect("get thermal");
+        assert_eq!(ev.valid_count, 100);
+        assert_eq!(ev.severity, "normal");
+        assert_eq!(ev.p95_abs_deviation_millic, Some(350));
+    }
+}

--- a/crates/persistence/sessions/src/repositories/mod.rs
+++ b/crates/persistence/sessions/src/repositories/mod.rs
@@ -1,6 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
+pub mod calibration_sessions;
 pub mod equipment_resolution;
 pub mod materialization;
 pub mod metadata_resolution;

--- a/scripts/dead-callers-baseline.txt
+++ b/scripts/dead-callers-baseline.txt
@@ -141,7 +141,6 @@ fetch_mosaic_revision_by_row_id
 fetch_panel_group_by_public_id
 fetch_panel_group_head
 fetch_panel_revision_by_public_id
-fetch_panel_revision_by_row_id
 fetch_proposal_by_public_id
 find_active_panel_group_for_session
 find_bridged_mosaic_components
@@ -174,7 +173,6 @@ retire_panel_group
 start_traversal
 supersede_proposal
 upsert_mosaic_revision
-validate_mosaic_connectivity
 
 # spec 062 node ic9h.17: calibration families, sessions, handoff, and evidence
 # entry points consumed by app-layer nodes ic9h.18 (UI) and future handoff

--- a/scripts/dead-callers-baseline.txt
+++ b/scripts/dead-callers-baseline.txt
@@ -175,3 +175,42 @@ start_traversal
 supersede_proposal
 upsert_mosaic_revision
 validate_mosaic_connectivity
+
+# spec 062 node ic9h.17: calibration families, sessions, handoff, and evidence
+# entry points consumed by app-layer nodes ic9h.18 (UI) and future handoff
+# command orchestrator. Remove each entry as its call site lands.
+add_reviewed_selection_snapshot
+assign_calibration_session_to_family
+create_initial_handoff
+evaluate_candidate_evidence
+find_dark_bias_family
+find_flat_family
+get_bias_recipe
+get_calibration_session
+get_calibration_session_by_public_id
+get_dark_recipe
+get_dark_thermal_evidence
+get_family_by_public_id
+get_family_by_row_id
+get_flat_family
+get_handoff_by_public_id
+get_snapshot_by_public_id
+get_source_availability
+insert_bias_recipe
+insert_calibration_family
+insert_dark_recipe
+insert_dark_thermal_evidence
+insert_flat_family
+insert_handoff_candidate_evidence
+insert_handoff_frame
+insert_handoff_requirement
+insert_handoff_selection
+insert_operation_for_handoff
+list_calibration_sessions_by_family
+list_selection_frames
+list_snapshot_requirements
+list_snapshot_selections
+list_source_availability_for_sessions
+transition_handoff_operation_state
+update_handoff_operation_progress
+upsert_source_availability


### PR DESCRIPTION
Implements the calibration family, session, and external-processor handoff model from spec 062 (US4). Dark and bias sessions are organized under registered cameras and calibration recipes; flat sessions are organized under optical profiles and filter labels. A candidate evidence projection evaluates age, thermal deviation, physical orientation, and source availability, and computes automatic eligibility. An immutable handoff snapshot records selected sessions for an external processing tool; reviewed additions create successor snapshots with CAS head-generation fencing.

## Changes

- `crates/calibration/core/src/families.rs` — domain types: temperature mode, age/thermal/orientation state enums, dark/bias/flat recipe structs, exposure-tolerance formula (FR-065), threshold evaluators, `automatic_eligibility()` covering all FR-071/FR-074 conditions
- `crates/persistence/sessions/src/repositories/calibration_sessions/` — four new repository modules for `calibration_family` + recipe subtypes, `spec062_calibration_session` + `dark_thermal_evidence`, `source_availability_rollup`, and the full handoff aggregate (`calibration_handoff`, snapshots, requirements, candidate evidence, selections, frames, operations) with CAS head-advance
- `crates/app/calibration/src/session_handoff/` — `evaluate_candidate_evidence()` (pure evaluation of DB rows + settings into typed evidence with warnings and eligibility) and `create_initial_handoff()` / `add_reviewed_selection_snapshot()` (snapshot succession with `expected_head_generation` fencing)
- 36 dead-caller baseline entries for entry points consumed by future nodes

All new entry points are covered by real-SQLite integration tests (172 tests across three crates, all green).

Tracks-Bead: astro-plan-ic9h.17
Merge-Bead: astro-plan-b9x7