### PR TITLE
refactor: source-view generation and command-ledger recovery split into focused phases

### DIFF
--- a/crates/app/projects/src/source_view_generate/generate.rs
+++ b/crates/app/projects/src/source_view_generate/generate.rs
@@ -223,7 +223,10 @@ async fn plan_source_frames(
     }
 
     // T028: partial calibration coverage detection.
-    detect_partial_calibration_coverage(&session_calibration_types, &mut sessions_without_calibration);
+    detect_partial_calibration_coverage(
+        &session_calibration_types,
+        &mut sessions_without_calibration,
+    );
 
     // FR-019: unresolved sources are skipped and flagged.
     if !unresolved_refs.is_empty() {
@@ -536,7 +539,8 @@ async fn persist_plan(
     let mut mkdir_dirs: BTreeSet<Utf8PathBuf> = BTreeSet::new();
     mkdir_dirs.insert(destination_root.to_path_buf());
     for item in planned {
-        if let Some(parent) = join_portable(destination_root, item.dest_relative.as_str()).parent() {
+        if let Some(parent) = join_portable(destination_root, item.dest_relative.as_str()).parent()
+        {
             mkdir_dirs.insert(parent.to_path_buf());
         }
     }

--- a/crates/app/projects/src/source_view_generate/generate.rs
+++ b/crates/app/projects/src/source_view_generate/generate.rs
@@ -37,6 +37,12 @@ struct PlannedLink {
     dest_relative: Utf8PathBuf,
 }
 
+/// Intermediate collection from the source-planning phase.
+struct SourcePlanResult {
+    planned: Vec<PlannedLink>,
+    warnings: Vec<GenerationWarning>,
+}
+
 /// Build a `prepared_view_generation` plan for `req.project_id`.
 ///
 /// Validates:
@@ -53,7 +59,6 @@ struct PlannedLink {
 /// Returns `project.not_found`, `lifecycle.read_only`, `no_selection`,
 /// `no_link_kind`, `destination.collision`, `destination.exists`, or an
 /// `internal.*` error on failure.
-#[allow(clippy::too_many_lines)] // linear validation/build pipeline (mirrors app_core::plan_apply)
 pub async fn generate_source_view(
     pool: &SqlitePool,
     req: &SourceViewGenerateRequest,
@@ -68,30 +73,11 @@ pub async fn generate_source_view(
         .await
         .map_err(|e| db_internal_ctx(e, "list project sources"))?;
 
-    let mut warnings: Vec<GenerationWarning> = Vec::new();
-    let mut planned: Vec<PlannedLink> = Vec::new();
-    let mut unresolved_refs: Vec<String> = Vec::new();
-    let mut sessions_without_calibration: Vec<String> = Vec::new();
-
-    // Profile-driven layout (spec 049 US2 T025/T026): an explicit
-    // `profile_id` on the request wins; otherwise resolve the project's own
-    // active tool (`projects.tool`, e.g. "PixInsight"); falls back to the
-    // WBPP/PixInsight default when neither matches a seeded profile.
+    // Profile-driven layout (spec 049 US2 T025/T026).
     let layout = workflow_profiles::seed::resolve_source_view_layout(
         req.profile_id.as_deref().or(Some(project.tool.as_str())),
     );
-    // T028: track which calibration types each session actually matched, to
-    // detect *partial* coverage (some but not all of the project's observed
-    // calibration types) in addition to the *zero* case already handled
-    // below (FR-010a/CL-7).
-    let mut session_calibration_types: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
 
-    // The generation destination is `<project>/source-views/<plan_id>/`
-    // (FR-021b). The plan id is generated up-front so it can double as the
-    // stable view-folder slug; the DB `PreparedSourceView.id` is a distinct
-    // identifier assigned at first-materialization (apply time) — the folder
-    // slug does not need to equal it, only to be stable and collision-free.
-    //
     // T041 precedence: per-generation `destinationOverride` (request) >
     // per-project persisted override (settings KV) > envelope default.
     let plan_id = new_id();
@@ -112,7 +98,66 @@ pub async fn generate_source_view(
             Utf8PathBuf::from,
         );
 
-    for src in &sources {
+    // 3. Plan source frames and calibration.
+    let SourcePlanResult { planned, mut warnings } =
+        plan_source_frames(pool, &sources, &layout, req.strict).await?;
+
+    // 4. No selection at all → refuse (nothing to generate).
+    if planned.is_empty() {
+        return Err(ContractError::new(
+            ErrorCode::NoSelection,
+            "project has no selected light frames to generate a source view from",
+            ErrorSeverity::Blocking,
+            false,
+        ));
+    }
+
+    // 5. Collision guard (FR-009a/FR-017).
+    guard_collisions(&planned)?;
+
+    // 6. Destination-exists guard (FR-016).
+    guard_destinations_exist(&planned, &destination_root)?;
+
+    // 7. Windows long-path warning (T042/FR-018).
+    if let Some(warning) = check_long_paths(&planned, &destination_root) {
+        warnings.push(warning);
+    }
+
+    // 8. Resolve link kind per item (FR-004/FR-022).
+    let (resolved_kinds, drift_warning) =
+        resolve_link_kinds(pool, &planned, &destination_root, &project.path, req.copy_opt_in)
+            .await?;
+    if let Some(warning) = drift_warning {
+        warnings.push(warning);
+    }
+
+    let used_copy_fallback = resolved_kinds.values().any(|kind| *kind == Materialization::Copy);
+
+    // 9. Persist the plan.
+    persist_plan(pool, &plan_id, &req.project_id, &planned, &resolved_kinds, &destination_root)
+        .await?;
+
+    Ok(SourceViewGenerateResponse { plan_id, warnings, used_copy_fallback })
+}
+
+// ── Phase: source frame planning ──────────────────────────────────────────────
+
+/// Iterate project sources and matched calibration, collecting planned links
+/// and surfacing unresolved/partial-coverage warnings.
+async fn plan_source_frames(
+    pool: &SqlitePool,
+    sources: &[projects_repo::ProjectSourceRow],
+    layout: &workflow_profiles::SourceViewLayout,
+    strict: bool,
+) -> Result<SourcePlanResult, ContractError> {
+    let mut planned: Vec<PlannedLink> = Vec::new();
+    let mut warnings: Vec<GenerationWarning> = Vec::new();
+    let mut unresolved_refs: Vec<String> = Vec::new();
+    let mut sessions_without_calibration: Vec<String> = Vec::new();
+    // T028: track which calibration types each session actually matched.
+    let mut session_calibration_types: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
+
+    for src in sources {
         let Some(session) =
             q_projects::get_acquisition_session_view(pool, &src.inventory_session_id)
                 .await
@@ -127,9 +172,7 @@ pub async fn generate_source_view(
             frame_ids: frame_ids_json,
         } = session;
 
-        // Resolve the light-frame destination directory once per session
-        // (session/night → filter → exposure grouping, US2 AS1): the
-        // metadata bundle is constant across every frame in the session.
+        // Resolve the light-frame destination directory once per session.
         let mut light_bundle: MetadataBundle = HashMap::new();
         light_bundle.insert("filter".to_owned(), src.filter_snapshot.clone());
         light_bundle.insert("exposure".to_owned(), src.exposure_snapshot.clone());
@@ -165,84 +208,26 @@ pub async fn generate_source_view(
             continue;
         }
 
-        // 3. Matched calibration (best-effort; not a generation prerequisite — FR-010a).
-        let assignments: Vec<(String, String)> =
-            q_projects::list_calibration_assignment_types(pool, &src.inventory_session_id)
-                .await
-                .unwrap_or_default();
-
-        if assignments.is_empty() {
-            sessions_without_calibration.push(src.inventory_session_id.clone());
-            continue;
-        }
-
-        session_calibration_types.insert(
-            src.inventory_session_id.clone(),
-            assignments.iter().map(|(t, _)| t.clone()).collect(),
-        );
-
-        for (cal_type, master_id) in assignments {
-            let Some((cal_root_id, cal_frame_ids_json)) =
-                q_projects::get_calibration_session_view(pool, &master_id).await.unwrap_or(None)
-            else {
-                unresolved_refs.push(master_id.clone());
-                continue;
-            };
-
-            // Calibration goes to the profile's expected calibration location
-            // (FR-010); every matched set still gets its own `master_id`
-            // subdirectory so two masters of the same type never collide
-            // (FR-009a/CL-5) without needing a `master_id` metadata token.
-            let mut cal_bundle: MetadataBundle = HashMap::new();
-            cal_bundle.insert("frame_type".to_owned(), cal_type.clone());
-            let cal_dir = join_portable(
-                &Utf8PathBuf::from(
-                    resolve_pattern_str(layout.calibration_pattern, &cal_bundle)
-                        .map_err(|e| layout_resolve_err(&e, &master_id))?
-                        .relative_path,
-                ),
-                &master_id,
-            );
-
-            let cal_frame_ids = parse_frame_ids(&cal_frame_ids_json);
-            let cal_frames = frames_for_ids(pool, &cal_frame_ids).await;
-            for frame in &cal_frames {
-                if frame.state == "missing" || frame.state == "rejected" {
-                    unresolved_refs.push(frame.id.clone());
-                    continue;
-                }
-                let basename = Utf8Path::new(&frame.relative_path)
-                    .file_name()
-                    .unwrap_or(&frame.relative_path)
-                    .to_owned();
-                planned.push(PlannedLink {
-                    inventory_item_id: frame.id.clone(),
-                    source_root_id: cal_root_id.clone(),
-                    source_relative_path: frame.relative_path.clone(),
-                    dest_relative: join_portable(&cal_dir, basename.as_str()),
-                });
-            }
-        }
+        // Matched calibration (best-effort; not a generation prerequisite — FR-010a).
+        plan_calibration_for_session(
+            pool,
+            src,
+            layout,
+            &root_id,
+            &mut planned,
+            &mut unresolved_refs,
+            &mut sessions_without_calibration,
+            &mut session_calibration_types,
+        )
+        .await?;
     }
 
-    // T028: partial calibration coverage — a session that matched *some* but
-    // not all of the calibration types seen elsewhere in this project still
-    // generates cleanly, but gets the same "no calibration applied" warning
-    // (FR-010a/CL-7 treats "no" and "partial" alike). A session is judged
-    // against the project's own observed types (not a hardcoded
-    // dark/flat/bias list) because not every setup uses every type.
-    let all_project_calibration_types: BTreeSet<String> =
-        session_calibration_types.values().flatten().cloned().collect();
-    for (session_id, types) in &session_calibration_types {
-        if !types.is_empty() && types != &all_project_calibration_types {
-            sessions_without_calibration.push(session_id.clone());
-        }
-    }
+    // T028: partial calibration coverage detection.
+    detect_partial_calibration_coverage(&session_calibration_types, &mut sessions_without_calibration);
 
-    // FR-019: unresolved sources are skipped and flagged, not a hard failure,
-    // unless `strict` is requested.
+    // FR-019: unresolved sources are skipped and flagged.
     if !unresolved_refs.is_empty() {
-        if req.strict {
+        if strict {
             return Err(ContractError::new(
                 ErrorCode::NoSelection,
                 format!(
@@ -274,23 +259,102 @@ pub async fn generate_source_view(
         });
     }
 
-    // 4. No selection at all → refuse (nothing to generate).
-    if planned.is_empty() {
-        return Err(ContractError::new(
-            ErrorCode::NoSelection,
-            "project has no selected light frames to generate a source view from",
-            ErrorSeverity::Blocking,
-            false,
-        ));
+    Ok(SourcePlanResult { planned, warnings })
+}
+
+/// Plan calibration links for a single source session.
+#[allow(clippy::too_many_arguments)]
+async fn plan_calibration_for_session(
+    pool: &SqlitePool,
+    src: &projects_repo::ProjectSourceRow,
+    layout: &workflow_profiles::SourceViewLayout,
+    _root_id: &str,
+    planned: &mut Vec<PlannedLink>,
+    unresolved_refs: &mut Vec<String>,
+    sessions_without_calibration: &mut Vec<String>,
+    session_calibration_types: &mut BTreeMap<String, BTreeSet<String>>,
+) -> Result<(), ContractError> {
+    let assignments: Vec<(String, String)> =
+        q_projects::list_calibration_assignment_types(pool, &src.inventory_session_id)
+            .await
+            .unwrap_or_default();
+
+    if assignments.is_empty() {
+        sessions_without_calibration.push(src.inventory_session_id.clone());
+        return Ok(());
     }
 
-    // 5. Collision guard (FR-009a/FR-017): impossible by construction because
-    // each session/calibration-set links into its own directory, but verify
-    // explicitly rather than assuming — refuse rather than silently suffix.
+    session_calibration_types.insert(
+        src.inventory_session_id.clone(),
+        assignments.iter().map(|(t, _)| t.clone()).collect(),
+    );
+
+    for (cal_type, master_id) in assignments {
+        let Some((cal_root_id, cal_frame_ids_json)) =
+            q_projects::get_calibration_session_view(pool, &master_id).await.unwrap_or(None)
+        else {
+            unresolved_refs.push(master_id.clone());
+            continue;
+        };
+
+        // Calibration goes to the profile's expected calibration location
+        // (FR-010); every matched set still gets its own `master_id`
+        // subdirectory so two masters of the same type never collide
+        // (FR-009a/CL-5).
+        let mut cal_bundle: MetadataBundle = HashMap::new();
+        cal_bundle.insert("frame_type".to_owned(), cal_type.clone());
+        let cal_dir = join_portable(
+            &Utf8PathBuf::from(
+                resolve_pattern_str(layout.calibration_pattern, &cal_bundle)
+                    .map_err(|e| layout_resolve_err(&e, &master_id))?
+                    .relative_path,
+            ),
+            &master_id,
+        );
+
+        let cal_frame_ids = parse_frame_ids(&cal_frame_ids_json);
+        let cal_frames = frames_for_ids(pool, &cal_frame_ids).await;
+        for frame in &cal_frames {
+            if frame.state == "missing" || frame.state == "rejected" {
+                unresolved_refs.push(frame.id.clone());
+                continue;
+            }
+            let basename = Utf8Path::new(&frame.relative_path)
+                .file_name()
+                .unwrap_or(&frame.relative_path)
+                .to_owned();
+            planned.push(PlannedLink {
+                inventory_item_id: frame.id.clone(),
+                source_root_id: cal_root_id.clone(),
+                source_relative_path: frame.relative_path.clone(),
+                dest_relative: join_portable(&cal_dir, basename.as_str()),
+            });
+        }
+    }
+    Ok(())
+}
+
+/// T028: a session that matched *some* but not all of the calibration types
+/// seen elsewhere in this project gets the "no calibration applied" warning.
+fn detect_partial_calibration_coverage(
+    session_calibration_types: &BTreeMap<String, BTreeSet<String>>,
+    sessions_without_calibration: &mut Vec<String>,
+) {
+    let all_project_calibration_types: BTreeSet<String> =
+        session_calibration_types.values().flatten().cloned().collect();
+    for (session_id, types) in session_calibration_types {
+        if !types.is_empty() && types != &all_project_calibration_types {
+            sessions_without_calibration.push(session_id.clone());
+        }
+    }
+}
+
+// ── Phase: guards ─────────────────────────────────────────────────────────────
+
+/// FR-009a/FR-017: case-insensitive collision guard.
+fn guard_collisions(planned: &[PlannedLink]) -> Result<(), ContractError> {
     let mut seen_dest: BTreeSet<String> = BTreeSet::new();
-    for item in &planned {
-        // Case-insensitive/case-preserving collision guard (FR-017): compare
-        // lowercased destination strings, not just exact matches.
+    for item in planned {
         let key = item.dest_relative.as_str().to_lowercase();
         if !seen_dest.insert(key) {
             return Err(ContractError::new(
@@ -301,11 +365,16 @@ pub async fn generate_source_view(
             ));
         }
     }
+    Ok(())
+}
 
-    // 6. Destination-exists guard (FR-016): never silently overwrite a path
-    // that already exists as a user file/folder.
-    for item in &planned {
-        let abs = join_portable(&destination_root, item.dest_relative.as_str());
+/// FR-016: never silently overwrite a path that already exists.
+fn guard_destinations_exist(
+    planned: &[PlannedLink],
+    destination_root: &Utf8Path,
+) -> Result<(), ContractError> {
+    for item in planned {
+        let abs = join_portable(destination_root, item.dest_relative.as_str());
         if abs.exists() {
             return Err(ContractError::new(
                 ErrorCode::DestinationExists,
@@ -315,33 +384,45 @@ pub async fn generate_source_view(
             ));
         }
     }
+    Ok(())
+}
 
-    // T042/FR-018: on Windows, a destination path exceeding the classic
-    // 260-character limit is surfaced as a warning (not a failure — some
-    // destinations opt into long-path support) rather than producing a
-    // truncated tree. Windows-specific: macOS/Linux filesystems don't share
-    // this constraint.
-    if cfg!(windows) {
-        let mut long_paths: BTreeSet<String> = BTreeSet::new();
-        for item in &planned {
-            let abs = join_portable(&destination_root, item.dest_relative.as_str());
-            if exceeds_windows_long_path_limit(abs.as_str()) {
-                long_paths.insert(abs.into_string());
-            }
-        }
-        if !long_paths.is_empty() {
-            warnings.push(GenerationWarning {
-                code: GenerationWarningCode::LongPath,
-                message: "one or more destination paths exceed the Windows 260-character limit"
-                    .to_owned(),
-                items: long_paths.into_iter().collect(),
-            });
+/// T042/FR-018: on Windows, surface long-path warnings.
+fn check_long_paths(
+    planned: &[PlannedLink],
+    destination_root: &Utf8Path,
+) -> Option<GenerationWarning> {
+    if !cfg!(windows) {
+        return None;
+    }
+    let mut long_paths: BTreeSet<String> = BTreeSet::new();
+    for item in planned {
+        let abs = join_portable(destination_root, item.dest_relative.as_str());
+        if exceeds_windows_long_path_limit(abs.as_str()) {
+            long_paths.insert(abs.into_string());
         }
     }
+    if long_paths.is_empty() {
+        return None;
+    }
+    Some(GenerationWarning {
+        code: GenerationWarningCode::LongPath,
+        message: "one or more destination paths exceed the Windows 260-character limit".to_owned(),
+        items: long_paths.into_iter().collect(),
+    })
+}
 
-    // 7. Resolve link kind per item (FR-004/FR-022): capability probed once
-    // against the project root (the nearest existing ancestor of the not-yet-
-    // created destination tree — they share a volume).
+// ── Phase: link kind resolution ───────────────────────────────────────────────
+
+/// Resolve link kind per item (FR-004/FR-022): capability probed once against
+/// the project root.
+async fn resolve_link_kinds(
+    pool: &SqlitePool,
+    planned: &[PlannedLink],
+    destination_root: &Utf8Path,
+    project_path: &str,
+    copy_opt_in: bool,
+) -> Result<(BTreeMap<usize, Materialization>, Option<GenerationWarning>), ContractError> {
     let settings = persistence_lifecycle::repositories::settings::load_settings(pool)
         .await
         .map_err(|e| db_internal_ctx(e, "load settings"))?;
@@ -353,7 +434,7 @@ pub async fn generate_source_view(
         &settings.source_view_link_kind_cross_drive,
     )
     .unwrap_or(Materialization::Symlink);
-    let capability = fs_inventory::capability::probe(Utf8Path::new(&project.path));
+    let capability = fs_inventory::capability::probe(Utf8Path::new(project_path));
 
     let mut drift_notices: BTreeSet<String> = BTreeSet::new();
     let mut resolved_kinds: BTreeMap<usize, Materialization> = BTreeMap::new();
@@ -374,14 +455,14 @@ pub async fn generate_source_view(
             ));
         };
         let source_abs = Utf8PathBuf::from(source_root_path).join(&item.source_relative_path);
-        let scope = fs_inventory::drive_scope::classify(&source_abs, &destination_root);
+        let scope = fs_inventory::drive_scope::classify(&source_abs, destination_root);
 
         let resolved = domain_core::source_view::resolve_link_kind(
             scope,
             intra_default,
             cross_default,
             capability,
-            req.copy_opt_in,
+            copy_opt_in,
         )
         .map_err(|_| {
             ContractError::new(
@@ -407,27 +488,40 @@ pub async fn generate_source_view(
         resolved_kinds.insert(idx, resolved.kind);
     }
 
-    let used_copy_fallback = resolved_kinds.values().any(|kind| *kind == Materialization::Copy);
-
-    if !drift_notices.is_empty() {
-        warnings.push(GenerationWarning {
+    let warning = if drift_notices.is_empty() {
+        None
+    } else {
+        Some(GenerationWarning {
             code: GenerationWarningCode::CapabilityDrift,
             message: "a saved link kind was not achievable and a documented fallback was applied"
                 .to_owned(),
             items: drift_notices.into_iter().collect(),
-        });
-    }
+        })
+    };
 
-    // 8. Persist the plan (origin `prepared_view_generation`, plan_type
-    // `source_view_generation` — FR-021a).
-    let title = format!("Generate source view for project {}", req.project_id);
+    Ok((resolved_kinds, warning))
+}
+
+// ── Phase: plan persistence ───────────────────────────────────────────────────
+
+/// Persist the generation plan (origin `prepared_view_generation`, plan_type
+/// `source_view_generation` — FR-021a) and advance to `ready_for_review`.
+async fn persist_plan(
+    pool: &SqlitePool,
+    plan_id: &str,
+    project_id: &str,
+    planned: &[PlannedLink],
+    resolved_kinds: &BTreeMap<usize, Materialization>,
+    destination_root: &Utf8Path,
+) -> Result<(), ContractError> {
+    let title = format!("Generate source view for project {project_id}");
     plans_repo::insert_plan(
         pool,
         &plans_repo::InsertPlan {
-            id: &plan_id,
+            id: plan_id,
             title: &title,
             origin: "prepared_view_generation",
-            origin_path: Some(&req.project_id),
+            origin_path: Some(project_id),
             plan_type: "source_view_generation",
             destructive_destination: "archive",
             parent_plan_id: None,
@@ -437,16 +531,12 @@ pub async fn generate_source_view(
     .await
     .map_err(|e| db_internal_ctx(e, "insert source view generation plan"))?;
 
-    // One mkdir action per distinct destination directory (idempotent —
-    // `mkdir_op::make_dir` creates missing parents), then one link action per
-    // planned item. Mkdirs are ordered first so link items never race an
-    // absent parent directory.
+    // Mkdir actions for each distinct destination directory.
     let mut item_index: i64 = 0;
     let mut mkdir_dirs: BTreeSet<Utf8PathBuf> = BTreeSet::new();
-    mkdir_dirs.insert(destination_root.clone());
-    for item in &planned {
-        if let Some(parent) = join_portable(&destination_root, item.dest_relative.as_str()).parent()
-        {
+    mkdir_dirs.insert(destination_root.to_path_buf());
+    for item in planned {
+        if let Some(parent) = join_portable(destination_root, item.dest_relative.as_str()).parent() {
             mkdir_dirs.insert(parent.to_path_buf());
         }
     }
@@ -457,7 +547,7 @@ pub async fn generate_source_view(
             pool,
             &plans_repo::InsertPlanItem {
                 id: &item_id,
-                plan_id: &plan_id,
+                plan_id,
                 item_index,
                 name: dir.as_str(),
                 action: "mkdir",
@@ -478,11 +568,12 @@ pub async fn generate_source_view(
         .map_err(|e| db_internal_ctx(e, "insert generation mkdir item"))?;
     }
 
+    // Link actions for each planned frame.
     for (idx, item) in planned.iter().enumerate() {
         item_index += 1;
         let item_id = new_id();
         let kind = resolved_kinds.get(&idx).copied().unwrap_or(Materialization::Symlink);
-        let dest_abs = join_portable(&destination_root, item.dest_relative.as_str());
+        let dest_abs = join_portable(destination_root, item.dest_relative.as_str());
         let provenance = serde_json::to_string(&serde_json::json!([
             {"label": "materialization", "value": kind.as_str()}
         ]))
@@ -492,7 +583,7 @@ pub async fn generate_source_view(
             pool,
             &plans_repo::InsertPlanItem {
                 id: &item_id,
-                plan_id: &plan_id,
+                plan_id,
                 item_index,
                 name: item.dest_relative.as_str(),
                 action: "link",
@@ -513,10 +604,10 @@ pub async fn generate_source_view(
         .map_err(|e| db_internal_ctx(e, "insert generation link item"))?;
     }
 
-    // 9. Advance to ready_for_review (same convention as spec 026 remove/regenerate).
-    plans_repo::update_plan_state(pool, &plan_id, "ready_for_review")
+    // Advance to ready_for_review.
+    plans_repo::update_plan_state(pool, plan_id, "ready_for_review")
         .await
         .map_err(|e| db_internal_ctx(e, "advance generation plan to ready_for_review"))?;
 
-    Ok(SourceViewGenerateResponse { plan_id, warnings, used_copy_fallback })
+    Ok(())
 }

--- a/crates/app/projects/src/source_view_generate/generate.rs
+++ b/crates/app/projects/src/source_view_generate/generate.rs
@@ -151,10 +151,8 @@ async fn plan_source_frames(
     strict: bool,
 ) -> Result<SourcePlanResult, ContractError> {
     let mut planned: Vec<PlannedLink> = Vec::new();
-    let mut warnings: Vec<GenerationWarning> = Vec::new();
     let mut unresolved_refs: Vec<String> = Vec::new();
     let mut sessions_without_calibration: Vec<String> = Vec::new();
-    // T028: track which calibration types each session actually matched.
     let mut session_calibration_types: BTreeMap<String, BTreeSet<String>> = BTreeMap::new();
 
     for src in sources {
@@ -166,54 +164,25 @@ async fn plan_source_frames(
             unresolved_refs.push(src.inventory_session_id.clone());
             continue;
         };
-        let q_projects::AcquisitionSessionViewRow {
-            root_id,
-            session_key,
-            frame_ids: frame_ids_json,
-        } = session;
 
-        // Resolve the light-frame destination directory once per session.
-        let mut light_bundle: MetadataBundle = HashMap::new();
-        light_bundle.insert("filter".to_owned(), src.filter_snapshot.clone());
-        light_bundle.insert("exposure".to_owned(), src.exposure_snapshot.clone());
-        light_bundle.insert("date".to_owned(), session_night(&session_key));
-        let light_dir = Utf8PathBuf::from(
-            resolve_pattern_str(layout.light_pattern, &light_bundle)
-                .map_err(|e| layout_resolve_err(&e, &src.inventory_session_id))?
-                .relative_path,
-        );
-
-        let frame_ids = parse_frame_ids(&frame_ids_json);
-        let frames = frames_for_ids(pool, &frame_ids).await;
-
-        let mut any_light_present = false;
-        for frame in &frames {
-            if frame.state == "missing" || frame.state == "rejected" {
-                unresolved_refs.push(frame.id.clone());
-                continue;
-            }
-            any_light_present = true;
-            let basename = Utf8Path::new(&frame.relative_path)
-                .file_name()
-                .unwrap_or(&frame.relative_path)
-                .to_owned();
-            planned.push(PlannedLink {
-                inventory_item_id: frame.id.clone(),
-                source_root_id: root_id.clone(),
-                source_relative_path: frame.relative_path.clone(),
-                dest_relative: join_portable(&light_dir, basename.as_str()),
-            });
-        }
-        if !any_light_present {
+        let any_light = plan_light_frames_for_session(
+            pool,
+            src,
+            &session,
+            layout,
+            &mut planned,
+            &mut unresolved_refs,
+        )
+        .await?;
+        if !any_light {
             continue;
         }
 
-        // Matched calibration (best-effort; not a generation prerequisite — FR-010a).
         plan_calibration_for_session(
             pool,
             src,
             layout,
-            &root_id,
+            &session.root_id,
             &mut planned,
             &mut unresolved_refs,
             &mut sessions_without_calibration,
@@ -222,13 +191,68 @@ async fn plan_source_frames(
         .await?;
     }
 
-    // T028: partial calibration coverage detection.
     detect_partial_calibration_coverage(
         &session_calibration_types,
         &mut sessions_without_calibration,
     );
 
-    // FR-019: unresolved sources are skipped and flagged.
+    let warnings = assemble_source_warnings(strict, unresolved_refs, sessions_without_calibration)?;
+
+    Ok(SourcePlanResult { planned, warnings })
+}
+
+/// Resolve and plan light frames for a single acquisition session.
+/// Returns whether any present light frame was found.
+async fn plan_light_frames_for_session(
+    pool: &SqlitePool,
+    src: &projects_repo::ProjectSourceRow,
+    session: &q_projects::AcquisitionSessionViewRow,
+    layout: &workflow_profiles::SourceViewLayout,
+    planned: &mut Vec<PlannedLink>,
+    unresolved_refs: &mut Vec<String>,
+) -> Result<bool, ContractError> {
+    let mut light_bundle: MetadataBundle = HashMap::new();
+    light_bundle.insert("filter".to_owned(), src.filter_snapshot.clone());
+    light_bundle.insert("exposure".to_owned(), src.exposure_snapshot.clone());
+    light_bundle.insert("date".to_owned(), session_night(&session.session_key));
+    let light_dir = Utf8PathBuf::from(
+        resolve_pattern_str(layout.light_pattern, &light_bundle)
+            .map_err(|e| layout_resolve_err(&e, &src.inventory_session_id))?
+            .relative_path,
+    );
+
+    let frame_ids = parse_frame_ids(&session.frame_ids);
+    let frames = frames_for_ids(pool, &frame_ids).await;
+
+    let mut any_light_present = false;
+    for frame in &frames {
+        if frame.state == "missing" || frame.state == "rejected" {
+            unresolved_refs.push(frame.id.clone());
+            continue;
+        }
+        any_light_present = true;
+        let basename = Utf8Path::new(&frame.relative_path)
+            .file_name()
+            .unwrap_or(&frame.relative_path)
+            .to_owned();
+        planned.push(PlannedLink {
+            inventory_item_id: frame.id.clone(),
+            source_root_id: session.root_id.clone(),
+            source_relative_path: frame.relative_path.clone(),
+            dest_relative: join_portable(&light_dir, basename.as_str()),
+        });
+    }
+    Ok(any_light_present)
+}
+
+/// Assemble warnings from accumulated unresolved refs and calibration gaps.
+fn assemble_source_warnings(
+    strict: bool,
+    unresolved_refs: Vec<String>,
+    sessions_without_calibration: Vec<String>,
+) -> Result<Vec<GenerationWarning>, ContractError> {
+    let mut warnings: Vec<GenerationWarning> = Vec::new();
+
     if !unresolved_refs.is_empty() {
         if strict {
             return Err(ContractError::new(
@@ -262,7 +286,7 @@ async fn plan_source_frames(
         });
     }
 
-    Ok(SourcePlanResult { planned, warnings })
+    Ok(warnings)
 }
 
 /// Plan calibration links for a single source session.

--- a/crates/app/projects/src/source_view_generate/generate.rs
+++ b/crates/app/projects/src/source_view_generate/generate.rs
@@ -63,46 +63,27 @@ pub async fn generate_source_view(
     pool: &SqlitePool,
     req: &SourceViewGenerateRequest,
 ) -> Result<SourceViewGenerateResponse, ContractError> {
-    // 1. Project + lifecycle gate (shared with spec 026 remove/regenerate).
+    // 1. Project + lifecycle gate.
     let project =
         projects_repo::get_project(pool, &req.project_id).await.map_err(project_db_err)?;
     check_project_lifecycle(pool, &req.project_id).await?;
 
-    // 2. Resolve project-linked sessions (session-level selection, CL-9 MVP fallback).
+    // 2. Resolve project-linked sessions.
     let sources = projects_repo::list_project_sources(pool, &req.project_id)
         .await
         .map_err(|e| db_internal_ctx(e, "list project sources"))?;
 
-    // Profile-driven layout (spec 049 US2 T025/T026).
+    // 3. Profile-driven layout + destination resolution.
     let layout = workflow_profiles::seed::resolve_source_view_layout(
         req.profile_id.as_deref().or(Some(project.tool.as_str())),
     );
-
-    // T041 precedence: per-generation `destinationOverride` (request) >
-    // per-project persisted override (settings KV) > envelope default.
     let plan_id = new_id();
-    let project_destination_override = if req.destination_override.is_some() {
-        None // per-generation override already wins; skip the DB read.
-    } else {
-        get_destination_override(pool, &req.project_id).await?
-    };
-    let destination_root: Utf8PathBuf = req
-        .destination_override
-        .as_deref()
-        .or(project_destination_override.as_deref())
-        .map_or_else(
-            || {
-                let root = Utf8PathBuf::from(&project.path);
-                join_portable(&join_portable(&root, "source-views"), &plan_id)
-            },
-            Utf8PathBuf::from,
-        );
+    let destination_root = resolve_destination_root(pool, req, &project.path, &plan_id).await?;
 
-    // 3. Plan source frames and calibration.
+    // 4. Plan source frames and calibration.
     let SourcePlanResult { planned, mut warnings } =
         plan_source_frames(pool, &sources, &layout, req.strict).await?;
 
-    // 4. No selection at all → refuse (nothing to generate).
     if planned.is_empty() {
         return Err(ContractError::new(
             ErrorCode::NoSelection,
@@ -112,32 +93,41 @@ pub async fn generate_source_view(
         ));
     }
 
-    // 5. Collision guard (FR-009a/FR-017).
+    // 5. Guards and warnings.
     guard_collisions(&planned)?;
-
-    // 6. Destination-exists guard (FR-016).
     guard_destinations_exist(&planned, &destination_root)?;
+    warnings.extend(check_long_paths(&planned, &destination_root));
 
-    // 7. Windows long-path warning (T042/FR-018).
-    if let Some(warning) = check_long_paths(&planned, &destination_root) {
-        warnings.push(warning);
-    }
-
-    // 8. Resolve link kind per item (FR-004/FR-022).
+    // 6. Resolve link kinds.
     let (resolved_kinds, drift_warning) =
         resolve_link_kinds(pool, &planned, &destination_root, &project.path, req.copy_opt_in)
             .await?;
-    if let Some(warning) = drift_warning {
-        warnings.push(warning);
-    }
+    warnings.extend(drift_warning);
 
     let used_copy_fallback = resolved_kinds.values().any(|kind| *kind == Materialization::Copy);
 
-    // 9. Persist the plan.
+    // 7. Persist the plan.
     persist_plan(pool, &plan_id, &req.project_id, &planned, &resolved_kinds, &destination_root)
         .await?;
 
     Ok(SourceViewGenerateResponse { plan_id, warnings, used_copy_fallback })
+}
+
+/// T041 precedence: per-generation override > per-project persisted override > default.
+async fn resolve_destination_root(
+    pool: &SqlitePool,
+    req: &SourceViewGenerateRequest,
+    project_path: &str,
+    plan_id: &str,
+) -> Result<Utf8PathBuf, ContractError> {
+    if let Some(dest) = req.destination_override.as_deref() {
+        return Ok(Utf8PathBuf::from(dest));
+    }
+    if let Some(dest) = get_destination_override(pool, &req.project_id).await? {
+        return Ok(Utf8PathBuf::from(dest));
+    }
+    let root = Utf8PathBuf::from(project_path);
+    Ok(join_portable(&join_portable(&root, "source-views"), plan_id))
 }
 
 // ── Phase: source frame planning ──────────────────────────────────────────────

--- a/crates/app/projects/src/source_view_generate/generate.rs
+++ b/crates/app/projects/src/source_view_generate/generate.rs
@@ -59,6 +59,7 @@ struct SourcePlanResult {
 /// Returns `project.not_found`, `lifecycle.read_only`, `no_selection`,
 /// `no_link_kind`, `destination.collision`, `destination.exists`, or an
 /// `internal.*` error on failure.
+// CCN 11 tolerated: linear pipeline orchestrator with early-return gates.
 pub async fn generate_source_view(
     pool: &SqlitePool,
     req: &SourceViewGenerateRequest,

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/finish.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/finish.rs
@@ -1,0 +1,221 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Extracted SQL phases for `CommandLedger::finish_at`.
+
+use uuid::Uuid;
+
+use super::{
+    append_repository_change, AuditOutcome, CommandLedgerError, CommandRow, OutboxInput, Result,
+    TerminalInput, TerminalState,
+};
+
+/// Guard: a live execution may only create its terminal evidence once.
+pub(super) async fn guard_no_prior_evidence(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row_id: i64,
+) -> Result<()> {
+    let audit_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM audit_event WHERE command_row_id = ?")
+            .bind(row_id)
+            .fetch_one(&mut **connection)
+            .await?;
+    let outbox_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM outbox_event WHERE command_row_id = ?")
+            .bind(row_id)
+            .fetch_one(&mut **connection)
+            .await?;
+    if audit_count.0 != 0 || outbox_count.0 != 0 {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    Ok(())
+}
+
+/// Write the recovery evidence marker (idempotency: if the process crashes
+/// after this but before the terminal commit, recovery can reconcile).
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn write_evidence_marker(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row: &CommandRow,
+    audit_outcome: AuditOutcome,
+    response_json: Option<&str>,
+    error_code: Option<&str>,
+    outbox_len: usize,
+    outbox_digest: &str,
+    lease_owner: &str,
+    lease_generation: i64,
+    now: &str,
+) -> Result<()> {
+    let evidence = sqlx::query(
+        "UPDATE command_execution
+         SET recovery_terminal_outcome = ?, recovery_response_json = ?,
+             recovery_error_code = ?, recovery_expected_outbox_count = ?,
+             recovery_expected_outbox_digest = ?
+         WHERE row_id = ? AND state = 'executing' AND lease_owner = ?
+           AND lease_generation = ? AND lease_expires_at > ?",
+    )
+    .bind(audit_outcome.as_str())
+    .bind(response_json)
+    .bind(error_code)
+    .bind(i64::try_from(outbox_len).map_err(|_| {
+        CommandLedgerError::InvalidInput("outbox sequence exceeds SQLite bounds".to_owned())
+    })?)
+    .bind(outbox_digest)
+    .bind(row.row_id)
+    .bind(lease_owner)
+    .bind(lease_generation)
+    .bind(now)
+    .execute(&mut **connection)
+    .await?;
+    if evidence.rows_affected() != 1 {
+        return Err(CommandLedgerError::StaleFence);
+    }
+    Ok(())
+}
+
+/// Write the single audit row and all outbox events.
+pub(super) async fn write_audit_and_outbox(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row: &CommandRow,
+    input: &TerminalInput,
+    audit_outcome: AuditOutcome,
+    audit_payload: Option<String>,
+    outbox_payloads: Vec<String>,
+    now: &str,
+) -> Result<i64> {
+    let change_sequence = append_repository_change(connection, row.row_id, now).await?;
+    let audit_public_id = Uuid::new_v4().to_string();
+    let values = input.audit.aggregate.values();
+    sqlx::query(
+        "INSERT INTO audit_event
+         (public_id, command_row_id, operation_row_id, proposal_row_id, session_row_id,
+          panel_group_row_id, mosaic_row_id, project_row_id, handoff_row_id, actor_row_id,
+          action, outcome, reason_code, payload_json, created_sequence, occurred_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+    )
+    .bind(&audit_public_id)
+    .bind(row.row_id)
+    .bind(values[0])
+    .bind(values[1])
+    .bind(values[2])
+    .bind(values[3])
+    .bind(values[4])
+    .bind(values[5])
+    .bind(values[6])
+    .bind(row.actor_row_id)
+    .bind(&input.audit.action)
+    .bind(audit_outcome.as_str())
+    .bind(&input.audit.reason_code)
+    .bind(audit_payload)
+    .bind(change_sequence)
+    .bind(now)
+    .execute(&mut **connection)
+    .await?;
+
+    write_outbox_events(connection, row.row_id, &input.outbox, outbox_payloads, change_sequence, now)
+        .await?;
+
+    Ok(change_sequence)
+}
+
+async fn write_outbox_events(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    command_row_id: i64,
+    outbox: &[OutboxInput],
+    payloads: Vec<String>,
+    change_sequence: i64,
+    now: &str,
+) -> Result<()> {
+    for (ordinal, (event, payload)) in outbox.iter().zip(payloads).enumerate() {
+        let values = event.aggregate.values();
+        sqlx::query(
+            "INSERT INTO outbox_event
+             (public_id, command_row_id, event_ordinal, operation_row_id, proposal_row_id,
+              session_row_id, panel_group_row_id, mosaic_row_id, project_row_id, handoff_row_id,
+              event_type, payload_json, created_sequence, occurred_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        )
+        .bind(Uuid::new_v4().to_string())
+        .bind(command_row_id)
+        .bind(i64::try_from(ordinal).map_err(|_| {
+            CommandLedgerError::InvalidInput("event ordinal overflow".to_owned())
+        })?)
+        .bind(values[0])
+        .bind(values[1])
+        .bind(values[2])
+        .bind(values[3])
+        .bind(values[4])
+        .bind(values[5])
+        .bind(values[6])
+        .bind(&event.event_type)
+        .bind(payload)
+        .bind(change_sequence)
+        .bind(now)
+        .execute(&mut **connection)
+        .await?;
+    }
+    Ok(())
+}
+
+/// Verify exactly one audit and the expected outbox count were written.
+pub(super) async fn verify_written_counts(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row_id: i64,
+    expected_outbox: usize,
+) -> Result<()> {
+    let written_audit_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM audit_event WHERE command_row_id = ?")
+            .bind(row_id)
+            .fetch_one(&mut **connection)
+            .await?;
+    let written_outbox_count: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM outbox_event WHERE command_row_id = ?")
+            .bind(row_id)
+            .fetch_one(&mut **connection)
+            .await?;
+    if written_audit_count.0 != 1
+        || written_outbox_count.0 != i64::try_from(expected_outbox).unwrap_or(i64::MAX)
+    {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    Ok(())
+}
+
+/// Commit the terminal state transition and clear recovery markers.
+#[allow(clippy::too_many_arguments)]
+pub(super) async fn commit_terminal_state(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row_id: i64,
+    state: TerminalState,
+    response_json: Option<&str>,
+    error_code: Option<&str>,
+    lease_owner: &str,
+    lease_generation: i64,
+    now: &str,
+) -> Result<()> {
+    let finished = TerminalState::as_str(state);
+    let update = sqlx::query(
+        "UPDATE command_execution
+         SET state = ?, state_version = state_version + 1, lease_owner = NULL,
+             lease_expires_at = NULL, heartbeat_at = NULL, response_json = ?,
+             error_code = ?, finished_at = ?, recovery_terminal_outcome = NULL,
+             recovery_response_json = NULL, recovery_error_code = NULL,
+             recovery_expected_outbox_count = NULL, recovery_expected_outbox_digest = NULL
+         WHERE row_id = ? AND state = 'executing' AND lease_owner = ?
+           AND lease_generation = ? AND lease_expires_at > ?",
+    )
+    .bind(finished)
+    .bind(response_json)
+    .bind(error_code)
+    .bind(now)
+    .bind(row_id)
+    .bind(lease_owner)
+    .bind(lease_generation)
+    .bind(now)
+    .execute(&mut **connection)
+    .await?;
+    if update.rows_affected() != 1 {
+        return Err(CommandLedgerError::StaleFence);
+    }
+    Ok(())
+}

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/finish.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/finish.rs
@@ -112,8 +112,15 @@ pub(super) async fn write_audit_and_outbox(
     .execute(&mut **connection)
     .await?;
 
-    write_outbox_events(connection, row.row_id, &input.outbox, outbox_payloads, change_sequence, now)
-        .await?;
+    write_outbox_events(
+        connection,
+        row.row_id,
+        &input.outbox,
+        outbox_payloads,
+        change_sequence,
+        now,
+    )
+    .await?;
 
     Ok(change_sequence)
 }
@@ -137,9 +144,11 @@ async fn write_outbox_events(
         )
         .bind(Uuid::new_v4().to_string())
         .bind(command_row_id)
-        .bind(i64::try_from(ordinal).map_err(|_| {
-            CommandLedgerError::InvalidInput("event ordinal overflow".to_owned())
-        })?)
+        .bind(
+            i64::try_from(ordinal).map_err(|_| {
+                CommandLedgerError::InvalidInput("event ordinal overflow".to_owned())
+            })?,
+        )
         .bind(values[0])
         .bind(values[1])
         .bind(values[2])

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
@@ -508,6 +508,7 @@ impl CommandLedger {
         self.finish_at(lease, input, &Timestamp::now_iso()).await
     }
 
+    // CCN 11 tolerated: transaction orchestrator with preparation + commit/rollback.
     pub async fn finish_at(
         &self,
         lease: &CommandLease,

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
@@ -19,7 +19,10 @@ use sha2::{Digest, Sha256};
 use sqlx::{FromRow, SqlitePool};
 use thiserror::Error;
 use time::{format_description::well_known::Rfc3339, Duration as TimeDuration, OffsetDateTime};
-use uuid::Uuid;
+
+mod finish;
+mod recovery;
+mod validate;
 
 const DEFAULT_LEASE_TTL: Duration = Duration::from_secs(30);
 /// Prevents an accidentally unbounded command response from becoming a row.
@@ -505,7 +508,6 @@ impl CommandLedger {
         self.finish_at(lease, input, &Timestamp::now_iso()).await
     }
 
-    #[allow(clippy::too_many_lines)]
     pub async fn finish_at(
         &self,
         lease: &CommandLease,
@@ -542,146 +544,58 @@ impl CommandLedger {
             return rollback_error(&mut connection, CommandLedgerError::LeaseExpired).await;
         }
 
-        // A live execution may only create its terminal evidence once.  Any
-        // pre-existing audit/outbox row indicates a discovered partial commit;
-        // recovery, not a worker retry, must reconcile it fail-closed.
-        let audit_count: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM audit_event WHERE command_row_id = ?")
-                .bind(row.row_id)
-                .fetch_one(&mut *connection)
-                .await?;
-        let outbox_count: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM outbox_event WHERE command_row_id = ?")
-                .bind(row.row_id)
-                .fetch_one(&mut *connection)
-                .await?;
-        if audit_count.0 != 0 || outbox_count.0 != 0 {
-            return rollback_error(&mut connection, CommandLedgerError::AmbiguousRecovery).await;
+        if let Err(e) = finish::guard_no_prior_evidence(&mut connection, row.row_id).await {
+            return rollback_error(&mut connection, e).await;
         }
-
-        let evidence = sqlx::query(
-            "UPDATE command_execution
-             SET recovery_terminal_outcome = ?, recovery_response_json = ?,
-                 recovery_error_code = ?, recovery_expected_outbox_count = ?,
-                 recovery_expected_outbox_digest = ?
-             WHERE row_id = ? AND state = 'executing' AND lease_owner = ?
-               AND lease_generation = ? AND lease_expires_at > ?",
+        if let Err(e) = finish::write_evidence_marker(
+            &mut connection,
+            &row,
+            audit_outcome,
+            response_json.as_deref(),
+            input.error_code.as_deref(),
+            input.outbox.len(),
+            &outbox_digest,
+            &lease.fence.lease_owner,
+            lease.fence.lease_generation,
+            now,
         )
-        .bind(audit_outcome.as_str())
-        .bind(&response_json)
-        .bind(&input.error_code)
-        .bind(i64::try_from(input.outbox.len()).map_err(|_| {
-            CommandLedgerError::InvalidInput("outbox sequence exceeds SQLite bounds".to_owned())
-        })?)
-        .bind(&outbox_digest)
-        .bind(row.row_id)
-        .bind(&lease.fence.lease_owner)
-        .bind(lease.fence.lease_generation)
-        .bind(now)
-        .execute(&mut *connection)
-        .await?;
-        if evidence.rows_affected() != 1 {
-            return rollback_error(&mut connection, CommandLedgerError::StaleFence).await;
-        }
-
-        let change_sequence = append_repository_change(&mut connection, row.row_id, now).await?;
-        let audit_public_id = Uuid::new_v4().to_string();
-        let values = input.audit.aggregate.values();
-        sqlx::query(
-            "INSERT INTO audit_event
-             (public_id, command_row_id, operation_row_id, proposal_row_id, session_row_id,
-              panel_group_row_id, mosaic_row_id, project_row_id, handoff_row_id, actor_row_id,
-              action, outcome, reason_code, payload_json, created_sequence, occurred_at)
-             VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-        )
-        .bind(&audit_public_id)
-        .bind(row.row_id)
-        .bind(values[0])
-        .bind(values[1])
-        .bind(values[2])
-        .bind(values[3])
-        .bind(values[4])
-        .bind(values[5])
-        .bind(values[6])
-        .bind(row.actor_row_id)
-        .bind(&input.audit.action)
-        .bind(audit_outcome.as_str())
-        .bind(&input.audit.reason_code)
-        .bind(audit_payload)
-        .bind(change_sequence)
-        .bind(now)
-        .execute(&mut *connection)
-        .await?;
-
-        for (ordinal, (event, payload)) in input.outbox.iter().zip(outbox_payloads).enumerate() {
-            let values = event.aggregate.values();
-            sqlx::query(
-                "INSERT INTO outbox_event
-                 (public_id, command_row_id, event_ordinal, operation_row_id, proposal_row_id,
-                  session_row_id, panel_group_row_id, mosaic_row_id, project_row_id, handoff_row_id,
-                  event_type, payload_json, created_sequence, occurred_at)
-                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-            )
-            .bind(Uuid::new_v4().to_string())
-            .bind(row.row_id)
-            .bind(i64::try_from(ordinal).map_err(|_| {
-                CommandLedgerError::InvalidInput("event ordinal overflow".to_owned())
-            })?)
-            .bind(values[0])
-            .bind(values[1])
-            .bind(values[2])
-            .bind(values[3])
-            .bind(values[4])
-            .bind(values[5])
-            .bind(values[6])
-            .bind(&event.event_type)
-            .bind(payload)
-            .bind(change_sequence)
-            .bind(now)
-            .execute(&mut *connection)
-            .await?;
-        }
-
-        let written_audit_count: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM audit_event WHERE command_row_id = ?")
-                .bind(row.row_id)
-                .fetch_one(&mut *connection)
-                .await?;
-        let written_outbox_count: (i64,) =
-            sqlx::query_as("SELECT COUNT(*) FROM outbox_event WHERE command_row_id = ?")
-                .bind(row.row_id)
-                .fetch_one(&mut *connection)
-                .await?;
-        if written_audit_count.0 != 1
-            || written_outbox_count.0 != i64::try_from(input.outbox.len()).unwrap_or(i64::MAX)
+        .await
         {
-            return rollback_error(&mut connection, CommandLedgerError::AmbiguousRecovery).await;
+            return rollback_error(&mut connection, e).await;
+        }
+        if let Err(e) = finish::write_audit_and_outbox(
+            &mut connection,
+            &row,
+            input,
+            audit_outcome,
+            audit_payload,
+            outbox_payloads,
+            now,
+        )
+        .await
+        {
+            return rollback_error(&mut connection, e).await;
+        }
+        if let Err(e) =
+            finish::verify_written_counts(&mut connection, row.row_id, input.outbox.len()).await
+        {
+            return rollback_error(&mut connection, e).await;
+        }
+        if let Err(e) = finish::commit_terminal_state(
+            &mut connection,
+            row.row_id,
+            input.state,
+            response_json.as_deref(),
+            input.error_code.as_deref(),
+            &lease.fence.lease_owner,
+            lease.fence.lease_generation,
+            now,
+        )
+        .await
+        {
+            return rollback_error(&mut connection, e).await;
         }
 
-        let finished = TerminalState::as_str(input.state);
-        let update = sqlx::query(
-            "UPDATE command_execution
-             SET state = ?, state_version = state_version + 1, lease_owner = NULL,
-                 lease_expires_at = NULL, heartbeat_at = NULL, response_json = ?,
-                 error_code = ?, finished_at = ?, recovery_terminal_outcome = NULL,
-                 recovery_response_json = NULL, recovery_error_code = NULL,
-                 recovery_expected_outbox_count = NULL, recovery_expected_outbox_digest = NULL
-             WHERE row_id = ? AND state = 'executing' AND lease_owner = ?
-               AND lease_generation = ? AND lease_expires_at > ?",
-        )
-        .bind(finished)
-        .bind(&response_json)
-        .bind(&input.error_code)
-        .bind(now)
-        .bind(row.row_id)
-        .bind(&lease.fence.lease_owner)
-        .bind(lease.fence.lease_generation)
-        .bind(now)
-        .execute(&mut *connection)
-        .await?;
-        if update.rows_affected() != 1 {
-            return rollback_error(&mut connection, CommandLedgerError::StaleFence).await;
-        }
         sqlx::query("COMMIT").execute(&mut *connection).await?;
         Ok(CommandTerminal {
             command_id: lease.fence.command_id.clone(),
@@ -867,7 +781,6 @@ async fn load_command(
     .await?)
 }
 
-#[allow(clippy::too_many_lines)]
 async fn recover_expired_row(
     connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
     row: &CommandRow,
@@ -875,211 +788,32 @@ async fn recover_expired_row(
     expiry: &str,
     now: &str,
 ) -> Result<ClaimOutcome> {
-    let audit_rows: Vec<(String,)> =
-        sqlx::query_as("SELECT outcome FROM audit_event WHERE command_row_id = ? ORDER BY row_id")
-            .bind(row.row_id)
-            .fetch_all(&mut **connection)
-            .await?;
-    let outbox_rows: Vec<RecoveryOutboxRow> = sqlx::query_as(
-        "SELECT event_ordinal, event_type, payload_json, operation_row_id, proposal_row_id,
-                session_row_id, panel_group_row_id, mosaic_row_id, project_row_id, handoff_row_id
-         FROM outbox_event WHERE command_row_id = ? ORDER BY event_ordinal",
-    )
-    .bind(row.row_id)
-    .fetch_all(&mut **connection)
-    .await?;
+    let evidence = recovery::load_recovery_evidence(connection, row.row_id).await?;
+    recovery::validate_evidence_shape(&evidence)?;
 
-    // The only recoverable shapes are an untouched execution (no evidence) or
-    // one complete audit row plus the exact event sequence recorded before the
-    // terminal write. Any other shape is a discovered partial commit and must
-    // not be guessed at.
-    if audit_rows.is_empty() && outbox_rows.is_empty() {
-        if row.response_json.is_some()
-            || row.error_code.is_some()
-            || row.recovery_terminal_outcome.is_some()
-            || row.recovery_response_json.is_some()
-            || row.recovery_error_code.is_some()
-            || row.recovery_expected_outbox_count.is_some()
-            || row.recovery_expected_outbox_digest.is_some()
-        {
-            return Err(CommandLedgerError::AmbiguousRecovery);
-        }
-    } else if audit_rows.len() != 1
-        || outbox_rows.len() > MAX_OUTBOX_EVENTS
-        || outbox_rows.iter().enumerate().any(|(ordinal, event)| {
-            event.event_ordinal != i64::try_from(ordinal).unwrap_or(i64::MAX)
-        })
-    {
-        return Err(CommandLedgerError::AmbiguousRecovery);
+    if evidence.audit_rows.is_empty() && evidence.outbox_rows.is_empty() {
+        recovery::validate_clean_execution(row)?;
     }
 
-    if !audit_rows.is_empty() {
-        let expected_count = row
-            .recovery_expected_outbox_count
-            .filter(|count| *count >= 0)
-            .and_then(|count| usize::try_from(count).ok())
-            .ok_or(CommandLedgerError::AmbiguousRecovery)?;
-        if expected_count != outbox_rows.len() {
-            return Err(CommandLedgerError::AmbiguousRecovery);
-        }
-        let expected_digest = row
-            .recovery_expected_outbox_digest
-            .as_deref()
-            .ok_or(CommandLedgerError::AmbiguousRecovery)?;
-        if recovery_outbox_digest(&outbox_rows)? != expected_digest {
-            return Err(CommandLedgerError::AmbiguousRecovery);
-        }
-        let recorded_outcome = &audit_rows[0].0;
-        let audit_outcome =
-            AuditOutcome::parse(recorded_outcome).ok_or(CommandLedgerError::AmbiguousRecovery)?;
-        let pending_outcome = row
-            .recovery_terminal_outcome
-            .as_deref()
-            .and_then(AuditOutcome::parse)
-            .ok_or(CommandLedgerError::AmbiguousRecovery)?;
-        if pending_outcome != audit_outcome {
-            return Err(CommandLedgerError::AmbiguousRecovery);
-        }
-        let state = audit_outcome.command_state();
-        let response_json = row.recovery_response_json.clone();
-        let error_code = row.recovery_error_code.clone();
-        if let Some(response) = response_json.as_deref() {
-            let parsed = serde_json::from_str::<Value>(response)
-                .map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
-            if canonical_json(&parsed).map_err(|_| CommandLedgerError::AmbiguousRecovery)?
-                != response
-            {
-                return Err(CommandLedgerError::AmbiguousRecovery);
-            }
-            if response.len() > MAX_RESPONSE_BYTES {
-                return Err(CommandLedgerError::AmbiguousRecovery);
-            }
-        }
-        if let Some(error) = error_code.as_deref() {
-            bounded_safe_string(error).map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
-        }
-        if (matches!(state, TerminalState::Applied) && error_code.is_some())
-            || (!matches!(state, TerminalState::Applied) && error_code.is_none())
-        {
-            return Err(CommandLedgerError::AmbiguousRecovery);
-        }
-        let update = sqlx::query(
-            "UPDATE command_execution
-             SET state = ?, state_version = state_version + 1, lease_owner = NULL,
-                 lease_expires_at = NULL, heartbeat_at = NULL, response_json = ?,
-                 error_code = ?, finished_at = ?, recovery_terminal_outcome = NULL,
-                 recovery_response_json = NULL, recovery_error_code = NULL,
-                 recovery_expected_outbox_count = NULL, recovery_expected_outbox_digest = NULL
-             WHERE row_id = ? AND state_version = ? AND lease_generation = ?",
-        )
-        .bind(state.as_str())
-        .bind(&response_json)
-        .bind(&error_code)
-        .bind(now)
-        .bind(row.row_id)
-        .bind(row.state_version)
-        .bind(row.lease_generation)
-        .execute(&mut **connection)
-        .await?;
-        if update.rows_affected() != 1 {
-            return Err(CommandLedgerError::AmbiguousRecovery);
-        }
-        return Ok(ClaimOutcome::Replayed(CommandTerminal {
-            command_id: row.public_id.clone(),
+    if !evidence.audit_rows.is_empty() {
+        let (state, response_json, error_code) =
+            recovery::reconcile_discovered_evidence(row, &evidence)?;
+        return recovery::commit_reconciled_terminal(
+            connection,
+            row,
             state,
-            response_json,
-            error_code,
-            finished_at: now.to_owned(),
-        }));
+            response_json.as_deref(),
+            error_code.as_deref(),
+            now,
+        )
+        .await;
     }
 
-    let update = sqlx::query(
-        "UPDATE command_execution
-         SET state = 'executing', state_version = state_version + 1,
-             lease_generation = lease_generation + 1, lease_owner = ?,
-             lease_expires_at = ?, heartbeat_at = ?, started_at = COALESCE(started_at, ?)
-         WHERE row_id = ? AND state IN ('received','executing')
-           AND state_version = ? AND lease_generation = ?
-           AND (lease_expires_at IS NULL OR lease_expires_at <= ?)",
-    )
-    .bind(worker_id)
-    .bind(expiry)
-    .bind(now)
-    .bind(now)
-    .bind(row.row_id)
-    .bind(row.state_version)
-    .bind(row.lease_generation)
-    .bind(now)
-    .execute(&mut **connection)
-    .await?;
-    if update.rows_affected() != 1 {
-        return Err(CommandLedgerError::InProgress);
-    }
-    Ok(ClaimOutcome::Claimed(CommandLease {
-        fence: CommandFence {
-            command_id: row.public_id.clone(),
-            lease_owner: worker_id.to_owned(),
-            lease_generation: row.lease_generation + 1,
-        },
-        state_version: row.state_version + 1,
-        lease_expires_at: expiry.to_owned(),
-        heartbeat_at: now.to_owned(),
-    }))
+    recovery::reclaim_expired_lease(connection, row, worker_id, expiry, now).await
 }
 
 fn validate_terminal(input: &TerminalInput) -> Result<()> {
-    if input.outbox.len() > MAX_OUTBOX_EVENTS {
-        return Err(CommandLedgerError::InvalidInput(format!(
-            "outbox sequence exceeds {MAX_OUTBOX_EVENTS} events"
-        )));
-    }
-    if matches!(input.state, TerminalState::Applied) && input.error_code.is_some() {
-        return Err(CommandLedgerError::InvalidInput(
-            "applied command cannot carry an error code".to_owned(),
-        ));
-    }
-    if !matches!(input.state, TerminalState::Applied) && input.error_code.is_none() {
-        return Err(CommandLedgerError::InvalidInput(
-            "refused and failed commands require an error code".to_owned(),
-        ));
-    }
-    if input.audit.action.is_empty() || input.audit.reason_code.is_empty() {
-        return Err(CommandLedgerError::InvalidInput(
-            "audit action and reason are required".to_owned(),
-        ));
-    }
-    let audit_outcome = input.audit.outcome.unwrap_or_else(|| default_audit_outcome(input.state));
-    let expected_outcome = default_audit_outcome(input.state);
-    if !audit_outcome_matches_state(audit_outcome, input.state)
-        || (matches!(input.state, TerminalState::Applied | TerminalState::Failed)
-            && audit_outcome != expected_outcome)
-    {
-        return Err(CommandLedgerError::InvalidInput(
-            "audit outcome does not match terminal command state".to_owned(),
-        ));
-    }
-    input.audit.aggregate.validate()?;
-    for event in &input.outbox {
-        if event.event_type.is_empty() {
-            return Err(CommandLedgerError::InvalidInput(
-                "outbox event type is required".to_owned(),
-            ));
-        }
-        bounded_safe_string(&event.event_type)?;
-        event.aggregate.validate()?;
-    }
-    if let Some(response) = &input.response {
-        let serialized = canonical_json(response)?;
-        if serialized.len() > MAX_RESPONSE_BYTES {
-            return Err(CommandLedgerError::InvalidInput(
-                "command response is too large".to_owned(),
-            ));
-        }
-    }
-    if let Some(payload) = &input.audit.payload {
-        let _ = safe_payload_json(payload)?;
-    }
-    Ok(())
+    validate::validate_terminal(input)
 }
 
 fn default_audit_outcome(state: TerminalState) -> AuditOutcome {
@@ -1174,48 +908,6 @@ fn aggregate_json(aggregate: AggregateRef) -> Value {
     )
 }
 
-#[derive(Debug, FromRow)]
-struct RecoveryOutboxRow {
-    event_ordinal: i64,
-    event_type: String,
-    payload_json: String,
-    operation_row_id: Option<i64>,
-    proposal_row_id: Option<i64>,
-    session_row_id: Option<i64>,
-    panel_group_row_id: Option<i64>,
-    mosaic_row_id: Option<i64>,
-    project_row_id: Option<i64>,
-    handoff_row_id: Option<i64>,
-}
-
-fn recovery_outbox_digest(rows: &[RecoveryOutboxRow]) -> Result<String> {
-    let mut manifest = Vec::with_capacity(rows.len());
-    for row in rows {
-        let payload = serde_json::from_str::<Value>(&row.payload_json)
-            .map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
-        let aggregate = Value::Array(
-            [
-                row.operation_row_id,
-                row.proposal_row_id,
-                row.session_row_id,
-                row.panel_group_row_id,
-                row.mosaic_row_id,
-                row.project_row_id,
-                row.handoff_row_id,
-            ]
-            .into_iter()
-            .map(|value| value.map_or(Value::Null, Value::from))
-            .collect(),
-        );
-        manifest.push(json!({
-            "ordinal": row.event_ordinal,
-            "aggregate": aggregate,
-            "eventType": row.event_type,
-            "payload": payload,
-        }));
-    }
-    digest_manifest(&Value::Array(manifest))
-}
 
 fn safe_payload_json(value: &Value) -> Result<String> {
     if !value.is_object() {
@@ -1398,6 +1090,7 @@ mod tests {
     use persistence_core::Database;
     use serde_json::json;
     use tokio::sync::Barrier;
+    use uuid::Uuid;
 
     async fn database() -> Database {
         let db = Database::in_memory().await.unwrap();

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
@@ -908,7 +908,6 @@ fn aggregate_json(aggregate: AggregateRef) -> Value {
     )
 }
 
-
 fn safe_payload_json(value: &Value) -> Result<String> {
     if !value.is_object() {
         return Err(CommandLedgerError::InvalidInput("event payload must be an object".to_owned()));

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
@@ -527,83 +527,27 @@ impl CommandLedger {
             input.audit.outcome.unwrap_or_else(|| default_audit_outcome(input.state));
         let mut connection = self.pool.acquire().await?;
         begin_immediate(&mut connection).await?;
-        let Some(row) = load_command(&mut connection, &lease.fence.command_id).await? else {
-            return rollback_error(&mut connection, CommandLedgerError::NotFound).await;
-        };
-        if let Some(terminal) = row.terminal() {
-            sqlx::query("COMMIT").execute(&mut *connection).await?;
-            return Ok(terminal);
-        }
-        if row.lease_owner.as_deref() != Some(&lease.fence.lease_owner)
-            || row.lease_generation != lease.fence.lease_generation
-            || row.state != "executing"
-        {
-            return rollback_error(&mut connection, CommandLedgerError::StaleFence).await;
-        }
-        if row.lease_expires_at.as_deref().is_none_or(|expiry| expiry <= now) {
-            return rollback_error(&mut connection, CommandLedgerError::LeaseExpired).await;
-        }
 
-        if let Err(e) = finish::guard_no_prior_evidence(&mut connection, row.row_id).await {
-            return rollback_error(&mut connection, e).await;
-        }
-        if let Err(e) = finish::write_evidence_marker(
+        let result = finish_transaction(
             &mut connection,
-            &row,
-            audit_outcome,
-            response_json.as_deref(),
-            input.error_code.as_deref(),
-            input.outbox.len(),
-            &outbox_digest,
-            &lease.fence.lease_owner,
-            lease.fence.lease_generation,
-            now,
-        )
-        .await
-        {
-            return rollback_error(&mut connection, e).await;
-        }
-        if let Err(e) = finish::write_audit_and_outbox(
-            &mut connection,
-            &row,
+            lease,
             input,
             audit_outcome,
+            response_json.as_deref(),
             audit_payload,
             outbox_payloads,
+            &outbox_digest,
             now,
         )
-        .await
-        {
-            return rollback_error(&mut connection, e).await;
-        }
-        if let Err(e) =
-            finish::verify_written_counts(&mut connection, row.row_id, input.outbox.len()).await
-        {
-            return rollback_error(&mut connection, e).await;
-        }
-        if let Err(e) = finish::commit_terminal_state(
-            &mut connection,
-            row.row_id,
-            input.state,
-            response_json.as_deref(),
-            input.error_code.as_deref(),
-            &lease.fence.lease_owner,
-            lease.fence.lease_generation,
-            now,
-        )
-        .await
-        {
-            return rollback_error(&mut connection, e).await;
-        }
+        .await;
 
-        sqlx::query("COMMIT").execute(&mut *connection).await?;
-        Ok(CommandTerminal {
-            command_id: lease.fence.command_id.clone(),
-            state: input.state,
-            response_json,
-            error_code: input.error_code.clone(),
-            finished_at: now.to_owned(),
-        })
+        match result {
+            Ok(terminal) => {
+                sqlx::query("COMMIT").execute(&mut *connection).await?;
+                Ok(terminal)
+            }
+            Err(e) => rollback_error(&mut connection, e).await,
+        }
     }
 
     /// Poll unpublished events in deterministic `(occurred_at, row_id)` order.
@@ -779,6 +723,86 @@ async fn load_command(
     .bind(command_id)
     .fetch_optional(&mut **connection)
     .await?)
+}
+
+/// Execute all finish steps within the open transaction. Returns the terminal
+/// on success or an error that the caller should rollback.
+#[allow(clippy::too_many_arguments)]
+async fn finish_transaction(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    lease: &CommandLease,
+    input: &TerminalInput,
+    audit_outcome: AuditOutcome,
+    response_json: Option<&str>,
+    audit_payload: Option<String>,
+    outbox_payloads: Vec<String>,
+    outbox_digest: &str,
+    now: &str,
+) -> Result<CommandTerminal> {
+    let Some(row) = load_command(connection, &lease.fence.command_id).await? else {
+        return Err(CommandLedgerError::NotFound);
+    };
+    if let Some(terminal) = row.terminal() {
+        return Ok(terminal);
+    }
+    validate_lease_preconditions(&row, lease, now)?;
+    finish::guard_no_prior_evidence(connection, row.row_id).await?;
+    finish::write_evidence_marker(
+        connection,
+        &row,
+        audit_outcome,
+        response_json,
+        input.error_code.as_deref(),
+        input.outbox.len(),
+        outbox_digest,
+        &lease.fence.lease_owner,
+        lease.fence.lease_generation,
+        now,
+    )
+    .await?;
+    finish::write_audit_and_outbox(
+        connection,
+        &row,
+        input,
+        audit_outcome,
+        audit_payload,
+        outbox_payloads,
+        now,
+    )
+    .await?;
+    finish::verify_written_counts(connection, row.row_id, input.outbox.len()).await?;
+    finish::commit_terminal_state(
+        connection,
+        row.row_id,
+        input.state,
+        response_json,
+        input.error_code.as_deref(),
+        &lease.fence.lease_owner,
+        lease.fence.lease_generation,
+        now,
+    )
+    .await?;
+    Ok(CommandTerminal {
+        command_id: lease.fence.command_id.clone(),
+        state: input.state,
+        response_json: response_json.map(str::to_owned),
+        error_code: input.error_code.clone(),
+        finished_at: now.to_owned(),
+    })
+}
+
+/// Validate that the loaded row matches the presented lease.
+fn validate_lease_preconditions(row: &CommandRow, lease: &CommandLease, now: &str) -> Result<()> {
+    if row.lease_owner.as_deref() != Some(&lease.fence.lease_owner)
+        || row.lease_generation != lease.fence.lease_generation
+        || row.state != "executing"
+    {
+        return Err(CommandLedgerError::StaleFence);
+    }
+    if row.lease_expires_at.as_deref().is_none_or(|expiry| expiry <= now) {
+        return Err(CommandLedgerError::LeaseExpired);
+    }
+    Ok(())
 }
 
 async fn recover_expired_row(

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/recovery.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/recovery.rs
@@ -93,6 +93,7 @@ pub(super) fn validate_clean_execution(row: &CommandRow) -> Result<()> {
 
 /// Reconcile a discovered audit + outbox evidence set against the row's
 /// recovery markers, returning the terminal result on success.
+// CCN 12 tolerated: flat sequential invariant checks that must all pass.
 pub(super) fn reconcile_discovered_evidence(
     row: &CommandRow,
     evidence: &RecoveryEvidence,

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/recovery.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/recovery.rs
@@ -10,12 +10,12 @@
 use serde_json::Value;
 use sqlx::FromRow;
 
-use super::{
-    bounded_safe_string, canonical_json, digest_manifest, AuditOutcome, ClaimOutcome,
-    CommandFence, CommandLease, CommandLedgerError, CommandRow, CommandTerminal, Result,
-    TerminalState, MAX_OUTBOX_EVENTS, MAX_RESPONSE_BYTES,
-};
 use super::validate::validate_state_error_consistency;
+use super::{
+    bounded_safe_string, canonical_json, digest_manifest, AuditOutcome, ClaimOutcome, CommandFence,
+    CommandLease, CommandLedgerError, CommandRow, CommandTerminal, Result, TerminalState,
+    MAX_OUTBOX_EVENTS, MAX_RESPONSE_BYTES,
+};
 
 #[derive(Debug, FromRow)]
 pub(super) struct RecoveryOutboxRow {

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/recovery.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/recovery.rs
@@ -1,0 +1,269 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Expired-lease recovery logic for the command ledger.
+//!
+//! Handles two recoverable shapes: (a) a clean untouched execution (no evidence
+//! rows exist) → re-claimed; (b) one audit + matching outbox sequence
+//! consistent with the evidence marker → reconciled as replayed terminal.
+
+use serde_json::Value;
+use sqlx::FromRow;
+
+use super::{
+    bounded_safe_string, canonical_json, digest_manifest, AuditOutcome, ClaimOutcome,
+    CommandFence, CommandLease, CommandLedgerError, CommandRow, CommandTerminal, Result,
+    TerminalState, MAX_OUTBOX_EVENTS, MAX_RESPONSE_BYTES,
+};
+use super::validate::validate_state_error_consistency;
+
+#[derive(Debug, FromRow)]
+pub(super) struct RecoveryOutboxRow {
+    pub event_ordinal: i64,
+    pub event_type: String,
+    pub payload_json: String,
+    pub operation_row_id: Option<i64>,
+    pub proposal_row_id: Option<i64>,
+    pub session_row_id: Option<i64>,
+    pub panel_group_row_id: Option<i64>,
+    pub mosaic_row_id: Option<i64>,
+    pub project_row_id: Option<i64>,
+    pub handoff_row_id: Option<i64>,
+}
+
+/// Loaded evidence from the database for recovery decisions.
+pub(super) struct RecoveryEvidence {
+    pub audit_rows: Vec<(String,)>,
+    pub outbox_rows: Vec<RecoveryOutboxRow>,
+}
+
+/// Load audit and outbox evidence rows for the given command.
+pub(super) async fn load_recovery_evidence(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row_id: i64,
+) -> Result<RecoveryEvidence> {
+    let audit_rows: Vec<(String,)> =
+        sqlx::query_as("SELECT outcome FROM audit_event WHERE command_row_id = ? ORDER BY row_id")
+            .bind(row_id)
+            .fetch_all(&mut **connection)
+            .await?;
+    let outbox_rows: Vec<RecoveryOutboxRow> = sqlx::query_as(
+        "SELECT event_ordinal, event_type, payload_json, operation_row_id, proposal_row_id,
+                session_row_id, panel_group_row_id, mosaic_row_id, project_row_id, handoff_row_id
+         FROM outbox_event WHERE command_row_id = ? ORDER BY event_ordinal",
+    )
+    .bind(row_id)
+    .fetch_all(&mut **connection)
+    .await?;
+    Ok(RecoveryEvidence { audit_rows, outbox_rows })
+}
+
+/// Validate that recovery evidence has a recognizable shape.
+/// Returns an error on any ambiguous partial-commit state.
+pub(super) fn validate_evidence_shape(evidence: &RecoveryEvidence) -> Result<()> {
+    if evidence.audit_rows.is_empty() && evidence.outbox_rows.is_empty() {
+        return Ok(());
+    }
+    if evidence.audit_rows.len() != 1
+        || evidence.outbox_rows.len() > MAX_OUTBOX_EVENTS
+        || evidence.outbox_rows.iter().enumerate().any(|(ordinal, event)| {
+            event.event_ordinal != i64::try_from(ordinal).unwrap_or(i64::MAX)
+        })
+    {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    Ok(())
+}
+
+/// For a row with no evidence (no audit, no outbox): verify it has no
+/// leftover recovery markers that would indicate a partial commit.
+pub(super) fn validate_clean_execution(row: &CommandRow) -> Result<()> {
+    if row.response_json.is_some()
+        || row.error_code.is_some()
+        || row.recovery_terminal_outcome.is_some()
+        || row.recovery_response_json.is_some()
+        || row.recovery_error_code.is_some()
+        || row.recovery_expected_outbox_count.is_some()
+        || row.recovery_expected_outbox_digest.is_some()
+    {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    Ok(())
+}
+
+/// Reconcile a discovered audit + outbox evidence set against the row's
+/// recovery markers, returning the terminal result on success.
+pub(super) fn reconcile_discovered_evidence(
+    row: &CommandRow,
+    evidence: &RecoveryEvidence,
+) -> Result<(TerminalState, Option<String>, Option<String>)> {
+    let expected_count = row
+        .recovery_expected_outbox_count
+        .filter(|count| *count >= 0)
+        .and_then(|count| usize::try_from(count).ok())
+        .ok_or(CommandLedgerError::AmbiguousRecovery)?;
+    if expected_count != evidence.outbox_rows.len() {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    let expected_digest = row
+        .recovery_expected_outbox_digest
+        .as_deref()
+        .ok_or(CommandLedgerError::AmbiguousRecovery)?;
+    if recovery_outbox_digest(&evidence.outbox_rows)? != expected_digest {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+
+    let recorded_outcome = &evidence.audit_rows[0].0;
+    let audit_outcome =
+        AuditOutcome::parse(recorded_outcome).ok_or(CommandLedgerError::AmbiguousRecovery)?;
+    let pending_outcome = row
+        .recovery_terminal_outcome
+        .as_deref()
+        .and_then(AuditOutcome::parse)
+        .ok_or(CommandLedgerError::AmbiguousRecovery)?;
+    if pending_outcome != audit_outcome {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+
+    let state = audit_outcome.command_state();
+    let response_json = row.recovery_response_json.clone();
+    let error_code = row.recovery_error_code.clone();
+
+    validate_recovered_response(response_json.as_deref())?;
+    validate_recovered_error_code(error_code.as_deref())?;
+    validate_state_error_consistency(state, error_code.as_deref())
+        .map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
+
+    Ok((state, response_json, error_code))
+}
+
+fn validate_recovered_response(response_json: Option<&str>) -> Result<()> {
+    let Some(response) = response_json else { return Ok(()) };
+    let parsed = serde_json::from_str::<Value>(response)
+        .map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
+    if canonical_json(&parsed).map_err(|_| CommandLedgerError::AmbiguousRecovery)? != response {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    if response.len() > MAX_RESPONSE_BYTES {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    Ok(())
+}
+
+fn validate_recovered_error_code(error_code: Option<&str>) -> Result<()> {
+    if let Some(error) = error_code {
+        bounded_safe_string(error).map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
+    }
+    Ok(())
+}
+
+/// Commit a reconciled terminal result to the command row.
+pub(super) async fn commit_reconciled_terminal(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row: &CommandRow,
+    state: TerminalState,
+    response_json: Option<&str>,
+    error_code: Option<&str>,
+    now: &str,
+) -> Result<ClaimOutcome> {
+    let update = sqlx::query(
+        "UPDATE command_execution
+         SET state = ?, state_version = state_version + 1, lease_owner = NULL,
+             lease_expires_at = NULL, heartbeat_at = NULL, response_json = ?,
+             error_code = ?, finished_at = ?, recovery_terminal_outcome = NULL,
+             recovery_response_json = NULL, recovery_error_code = NULL,
+             recovery_expected_outbox_count = NULL, recovery_expected_outbox_digest = NULL
+         WHERE row_id = ? AND state_version = ? AND lease_generation = ?",
+    )
+    .bind(state.as_str())
+    .bind(response_json)
+    .bind(error_code)
+    .bind(now)
+    .bind(row.row_id)
+    .bind(row.state_version)
+    .bind(row.lease_generation)
+    .execute(&mut **connection)
+    .await?;
+    if update.rows_affected() != 1 {
+        return Err(CommandLedgerError::AmbiguousRecovery);
+    }
+    Ok(ClaimOutcome::Replayed(CommandTerminal {
+        command_id: row.public_id.clone(),
+        state,
+        response_json: response_json.map(str::to_owned),
+        error_code: error_code.map(str::to_owned),
+        finished_at: now.to_owned(),
+    }))
+}
+
+/// Re-claim an expired lease for fresh execution.
+pub(super) async fn reclaim_expired_lease(
+    connection: &mut sqlx::pool::PoolConnection<sqlx::Sqlite>,
+    row: &CommandRow,
+    worker_id: &str,
+    expiry: &str,
+    now: &str,
+) -> Result<ClaimOutcome> {
+    let update = sqlx::query(
+        "UPDATE command_execution
+         SET state = 'executing', state_version = state_version + 1,
+             lease_generation = lease_generation + 1, lease_owner = ?,
+             lease_expires_at = ?, heartbeat_at = ?, started_at = COALESCE(started_at, ?)
+         WHERE row_id = ? AND state IN ('received','executing')
+           AND state_version = ? AND lease_generation = ?
+           AND (lease_expires_at IS NULL OR lease_expires_at <= ?)",
+    )
+    .bind(worker_id)
+    .bind(expiry)
+    .bind(now)
+    .bind(now)
+    .bind(row.row_id)
+    .bind(row.state_version)
+    .bind(row.lease_generation)
+    .bind(now)
+    .execute(&mut **connection)
+    .await?;
+    if update.rows_affected() != 1 {
+        return Err(CommandLedgerError::InProgress);
+    }
+    Ok(ClaimOutcome::Claimed(CommandLease {
+        fence: CommandFence {
+            command_id: row.public_id.clone(),
+            lease_owner: worker_id.to_owned(),
+            lease_generation: row.lease_generation + 1,
+        },
+        state_version: row.state_version + 1,
+        lease_expires_at: expiry.to_owned(),
+        heartbeat_at: now.to_owned(),
+    }))
+}
+
+/// Compute the recovery outbox digest from persisted outbox rows.
+pub(super) fn recovery_outbox_digest(rows: &[RecoveryOutboxRow]) -> Result<String> {
+    let mut manifest = Vec::with_capacity(rows.len());
+    for row in rows {
+        let payload = serde_json::from_str::<Value>(&row.payload_json)
+            .map_err(|_| CommandLedgerError::AmbiguousRecovery)?;
+        let aggregate = Value::Array(
+            [
+                row.operation_row_id,
+                row.proposal_row_id,
+                row.session_row_id,
+                row.panel_group_row_id,
+                row.mosaic_row_id,
+                row.project_row_id,
+                row.handoff_row_id,
+            ]
+            .into_iter()
+            .map(|value| value.map_or(Value::Null, Value::from))
+            .collect(),
+        );
+        manifest.push(serde_json::json!({
+            "ordinal": row.event_ordinal,
+            "aggregate": aggregate,
+            "eventType": row.event_type,
+            "payload": payload,
+        }));
+    }
+    digest_manifest(&Value::Array(manifest))
+}

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/validate.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/validate.rs
@@ -5,8 +5,8 @@
 
 use super::{
     audit_outcome_matches_state, bounded_safe_string, canonical_json, default_audit_outcome,
-    safe_payload_json, CommandLedgerError, Result, TerminalInput, TerminalState,
-    MAX_OUTBOX_EVENTS, MAX_RESPONSE_BYTES,
+    safe_payload_json, CommandLedgerError, Result, TerminalInput, TerminalState, MAX_OUTBOX_EVENTS,
+    MAX_RESPONSE_BYTES,
 };
 
 /// Validate all invariants required before persisting a terminal result.

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/validate.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/validate.rs
@@ -1,0 +1,104 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Terminal-input validation helpers for the command ledger.
+
+use super::{
+    audit_outcome_matches_state, bounded_safe_string, canonical_json, default_audit_outcome,
+    safe_payload_json, CommandLedgerError, Result, TerminalInput, TerminalState,
+    MAX_OUTBOX_EVENTS, MAX_RESPONSE_BYTES,
+};
+
+/// Validate all invariants required before persisting a terminal result.
+pub(super) fn validate_terminal(input: &TerminalInput) -> Result<()> {
+    validate_outbox_bounds(input)?;
+    validate_state_error_consistency(input.state, input.error_code.as_deref())?;
+    validate_audit_fields(input)?;
+    validate_audit_outcome_consistency(input)?;
+    validate_outbox_events(&input.outbox)?;
+    validate_response_bounds(input)?;
+    validate_audit_payload(input)?;
+    Ok(())
+}
+
+fn validate_outbox_bounds(input: &TerminalInput) -> Result<()> {
+    if input.outbox.len() > MAX_OUTBOX_EVENTS {
+        return Err(CommandLedgerError::InvalidInput(format!(
+            "outbox sequence exceeds {MAX_OUTBOX_EVENTS} events"
+        )));
+    }
+    Ok(())
+}
+
+/// Applied commands must not carry an error; refused/failed must.
+pub(super) fn validate_state_error_consistency(
+    state: TerminalState,
+    error_code: Option<&str>,
+) -> Result<()> {
+    if matches!(state, TerminalState::Applied) && error_code.is_some() {
+        return Err(CommandLedgerError::InvalidInput(
+            "applied command cannot carry an error code".to_owned(),
+        ));
+    }
+    if !matches!(state, TerminalState::Applied) && error_code.is_none() {
+        return Err(CommandLedgerError::InvalidInput(
+            "refused and failed commands require an error code".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_audit_fields(input: &TerminalInput) -> Result<()> {
+    if input.audit.action.is_empty() || input.audit.reason_code.is_empty() {
+        return Err(CommandLedgerError::InvalidInput(
+            "audit action and reason are required".to_owned(),
+        ));
+    }
+    input.audit.aggregate.validate()
+}
+
+fn validate_audit_outcome_consistency(input: &TerminalInput) -> Result<()> {
+    let audit_outcome = input.audit.outcome.unwrap_or_else(|| default_audit_outcome(input.state));
+    let expected_outcome = default_audit_outcome(input.state);
+    if !audit_outcome_matches_state(audit_outcome, input.state)
+        || (matches!(input.state, TerminalState::Applied | TerminalState::Failed)
+            && audit_outcome != expected_outcome)
+    {
+        return Err(CommandLedgerError::InvalidInput(
+            "audit outcome does not match terminal command state".to_owned(),
+        ));
+    }
+    Ok(())
+}
+
+fn validate_outbox_events(outbox: &[super::OutboxInput]) -> Result<()> {
+    for event in outbox {
+        if event.event_type.is_empty() {
+            return Err(CommandLedgerError::InvalidInput(
+                "outbox event type is required".to_owned(),
+            ));
+        }
+        bounded_safe_string(&event.event_type)?;
+        event.aggregate.validate()?;
+    }
+    Ok(())
+}
+
+fn validate_response_bounds(input: &TerminalInput) -> Result<()> {
+    if let Some(response) = &input.response {
+        let serialized = canonical_json(response)?;
+        if serialized.len() > MAX_RESPONSE_BYTES {
+            return Err(CommandLedgerError::InvalidInput(
+                "command response is too large".to_owned(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_audit_payload(input: &TerminalInput) -> Result<()> {
+    if let Some(payload) = &input.audit.payload {
+        let _ = safe_payload_json(payload)?;
+    }
+    Ok(())
+}


### PR DESCRIPTION
## Summary

God-function sweep, part A (CCN target: <10 norm, 10-20 justified):

| Function | Before | After |
|---|---|---|
| generate_source_view | CCN 48 | 11 (justified: pipeline orchestrator) |
| recover_expired_row | CCN 39 | 8 |
| finish_at | CCN 35 | 11 (justified) |
| validate_terminal | CCN 22 | 1 (delegates) |
| new helpers | — | 3–9 |

- `generate_source_view` decomposed into pipeline phases; `plan_source_frames` further extracted.
- command_ledger decomposed into `finish.rs`, `recovery.rs`, `validate.rs` modules (raw sqlx stays inside persistence).
- Justified exceptions carry in-code CCN comments (the pattern the upcoming clippy cognitive-complexity gate will formalize as #[expect]).

## Spec Context

Tracks-Bead: astro-plan-kyo7.113
Merge-Bead: astro-plan-sfd0

Verified: clippy -D warnings, app_core_projects 93 tests, persistence_lifecycle 125 tests.