### PR TITLE
fix(test): classify contract test follows runConfirm to useInboxConfirmFlow

### DIFF
--- a/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx
@@ -173,11 +173,12 @@ import { InboxDetail } from '../InboxDetail';
 import { InboxList } from '../InboxList';
 import { useInboxConfirm } from '../store';
 
-// Raw source of InboxPage.tsx (compile-time glob, mirrors anchors.test.ts's
-// technique) so the toast-wiring test below reads the REAL `runConfirm`
-// implementation rather than a hand-copied mirror.
+// Raw source of useInboxConfirmFlow.ts (compile-time glob, mirrors
+// anchors.test.ts's technique) so the toast-wiring test below reads the REAL
+// `runConfirm` implementation rather than a hand-copied mirror.
+// PR #1544 moved `runConfirm` from InboxPage.tsx into useInboxConfirmFlow.ts.
 const INBOX_PAGE_SOURCE = Object.values(
-  import.meta.glob('../InboxPage.tsx', { as: 'raw', eager: true }),
+  import.meta.glob('../useInboxConfirmFlow.ts', { as: 'raw', eager: true }),
 )[0] as string;
 
 function queryClientWrapper({ children }: { children: ReactNode }) {
@@ -460,7 +461,8 @@ describe('Confirm payload and toast', () => {
   // InboxPage.reclassifySelection.test.tsx's header comment: "no full-router
   // InboxPage render... per its own comment" — a full page tree here OOMs
   // the test worker). Instead this statically verifies the actual
-  // `runConfirm` success block in InboxPage.tsx: the plan-created toast
+  // `runConfirm` success block in useInboxConfirmFlow.ts (PR #1544 moved it
+  // out of InboxPage.tsx): the plan-created toast
   // fires unconditionally (no `if` between the confirm() call and the
   // addToast() call, and no remaining `registeredAsMaster` gate).
   it('runConfirm always toasts plan-created on success (masters now produce a plan too, no registeredAsMaster gate)', () => {


### PR DESCRIPTION
## What

PR #1544 moved `const runConfirm = useCallback(` from `InboxPage.tsx` into `useInboxConfirmFlow.ts` but did not update the raw-source glob in the toast-wiring contract test. The glob still pointed at `../InboxPage.tsx`, so `indexOf('const runConfirm = useCallback(')` returned `-1` and every downstream assertion on the success block failed.

Main-push CI skips the affected Vitest shards (ubuntu + macOS), so `main` appeared green while every PR merge-ref failed (e.g. jobs 89531421725 / 89531421754 on #1550).

## Change

Single file: `apps/desktop/src/features/inbox/__tests__/InboxPage.classify.test.tsx`

- Repoint `INBOX_PAGE_SOURCE` glob from `../InboxPage.tsx` to `../useInboxConfirmFlow.ts`.
- Update the inline comment to reference the new file and cite PR #1544.
- No assertion weakened; all `indexOf` anchors resolve correctly against the code now in `useInboxConfirmFlow.ts`.

## Verify

- Target test file: 9/9 pass.
- Full desktop suite: 243 test files / 2135 tests pass.

Tracks-Bead: astro-plan-ic9h
Merge-Bead: astro-plan-xhde
