### PR TITLE
ci: measure Rust test coverage in CI

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,105 @@
+name: Coverage
+
+# Rust test coverage via cargo-llvm-cov.
+#
+# Runs on every push to main and on pull requests that touch Rust sources.
+# Report-only: no threshold gate until a baseline is established.
+#
+# Linux-only: llvm-cov is OS-agnostic and the instrumented binaries are
+# significantly larger; running on one platform avoids triple disk pressure.
+# The job produces:
+#   - an lcov report (uploaded as an artifact)
+#   - a per-file summary in the job log
+#
+# cargo-llvm-cov wraps `cargo test`, so it covers unit tests, the real-SQLite
+# Layer-1 integration tests, and doctests in a single instrumented pass.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: coverage-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
+
+env:
+  CARGO_INCREMENTAL: 0
+  # Same debug-level policy as ci.yml: keep line tables for backtrace
+  # readability, drop type/variable info to keep artifact size bounded.
+  CARGO_PROFILE_DEV_DEBUG: line-tables-only
+  CARGO_PROFILE_TEST_DEBUG: line-tables-only
+
+jobs:
+  changes:
+    name: Detect changes (coverage)
+    runs-on: ubuntu-latest
+    outputs:
+      rust: ${{ steps.decide.outputs.rust }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v4
+        id: filter
+        with:
+          filters: |
+            rust:
+              - 'crates/**'
+              - 'apps/desktop/src-tauri/**'
+              - 'tests/**'
+              - '**/*.rs'
+              - '**/Cargo.toml'
+              - 'Cargo.lock'
+              - '.github/workflows/coverage.yml'
+      - id: decide
+        run: echo "rust=${{ steps.filter.outputs.rust }}" >> "$GITHUB_OUTPUT"
+
+  coverage:
+    name: Rust coverage (llvm-cov)
+    needs: changes
+    if: needs.changes.outputs.rust == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Tauri's desktop_shell crate needs system webview libs on Linux.
+      - name: Install Tauri Linux system deps
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev libgtk-3-dev librsvg2-dev \
+            libayatana-appindicator3-dev
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          # llvm-tools-preview provides the LLVM coverage instrumentation
+          # backend that cargo-llvm-cov links against at test time.
+          components: llvm-tools-preview
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          # Separate cache key: llvm-cov instrumented artifacts must not mix
+          # with the non-instrumented objects the ci.yml integration job uses.
+          # Sharing them produces miscounted or zeroed-out coverage data.
+          shared-key: "rust-coverage-ubuntu-v1"
+
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Collect coverage (workspace, all tests + doctests)
+        run: |
+          cargo llvm-cov \
+            --workspace \
+            --lcov \
+            --output-path lcov.info \
+            --doctests
+
+      - name: Print coverage summary
+        run: cargo llvm-cov report --summary-only
+
+      - name: Upload lcov report
+        uses: actions/upload-artifact@v4
+        with:
+          name: lcov-${{ github.sha }}
+          path: lcov.info
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -390,3 +390,4 @@ apps/desktop/.ds-css/
 .beads-credential-key
 .beads/proxieddb/
 crates/app/core/projects/
+lcov.info

--- a/justfile
+++ b/justfile
@@ -209,3 +209,12 @@ perf-bench:
 # Use --generate to record a fresh baseline after a justified query-count change.
 perf-check:
     bash scripts/check-perf-baseline.sh
+
+# Measure Rust test coverage via cargo-llvm-cov and print a per-file summary.
+# Requires cargo-llvm-cov and llvm-tools-preview:
+#   rustup component add llvm-tools-preview
+#   cargo install cargo-llvm-cov
+# Writes lcov.info to the workspace root (gitignored).
+coverage:
+    cargo llvm-cov --workspace --lcov --output-path lcov.info --doctests
+    cargo llvm-cov report --summary-only


### PR DESCRIPTION
## Summary

- Adds a CI coverage job that runs `cargo llvm-cov` over the full workspace (unit tests, real-SQLite integration tests, doctests) and uploads an lcov report as an artifact (30-day retention).
- Report-only for now; no threshold gate until a baseline is established.
- Adds `just coverage` for local use.

## Spec Context

Tracks-Bead: astro-plan-kyo7.34
Merge-Bead: astro-plan-wbyh