### PR TITLE
chore: add bacon background checker for live Rust feedback on save

### DIFF
--- a/bacon.toml
+++ b/bacon.toml
@@ -1,0 +1,36 @@
+# bacon.toml — background Rust checker for interactive development.
+#
+# Run via: just watch
+#
+# bacon watches source files and re-runs the configured job on every save.
+# Install: cargo install bacon
+# Docs: https://dystroy.org/bacon
+
+[jobs.check]
+command = ["cargo", "check", "--workspace", "--all-targets"]
+need_stdout = false
+
+[jobs.clippy]
+command = [
+    "cargo", "clippy",
+    "--workspace",
+    "--all-targets",
+    "--",
+    "-D", "warnings",
+]
+need_stdout = false
+
+[jobs.test]
+command = [
+    "cargo", "nextest", "run",
+    "--workspace",
+    "--no-fail-fast",
+]
+need_stdout = true
+
+[jobs.doc]
+command = ["cargo", "doc", "--workspace", "--no-deps"]
+need_stdout = false
+
+# Default job on `just watch` / bare `bacon`.
+default_job = "clippy"

--- a/justfile
+++ b/justfile
@@ -218,3 +218,10 @@ perf-check:
 coverage:
     cargo llvm-cov --workspace --lcov --output-path lcov.info --doctests
     cargo llvm-cov report --summary-only
+
+# Background Rust checker: re-runs clippy on every file save via bacon.
+# Install: cargo install bacon
+# Switch jobs interactively inside bacon with the job keys listed in bacon.toml
+# (check / clippy / test / doc).
+watch:
+    bacon


### PR DESCRIPTION
## Summary

- Adds `bacon.toml` with check/clippy/test/doc jobs (default: clippy) and a `just watch` recipe that starts bacon for live Rust feedback on file save.
- Dev-only convenience; no CI impact.

## Spec Context

Tracks-Bead: astro-plan-kyo7.59
Merge-Bead: astro-plan-6maq