### PR TITLE
ci: always evaluate the dead-caller ratchet against main, not only on Rust-touching PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -763,3 +763,33 @@ jobs:
             exit 0
           fi
           [ "$RESULT" = "success" ] || exit 1
+
+  # Dead-caller ratchet — main-push guard.
+  #
+  # The `integration` job (above) evaluates the dead-caller ratchet only when
+  # the Rust or scripts lane is active. On a main push that touches neither
+  # (docs, workflow edits, spec files) the `integration` job is skipped via
+  # its job-level `if:`, and the ratchet never runs. A dead `pub fn` that
+  # landed via such a merge is then invisible until the next Rust-touching PR,
+  # where it fires on an unrelated author.
+  #
+  # This job closes that window by evaluating the ratchet against main after
+  # every merge, regardless of which paths changed. It is gated to main pushes
+  # only (`github.event_name == 'push'`) so it does not double-run alongside
+  # `integration` on Rust-touching PRs.
+  #
+  # The check is pure grep (no Rust toolchain, no compile) — just checkout +
+  # `just` — so it adds negligible wall-clock time to the post-merge queue.
+  # It is NOT a branch-protection required check; it is a canary that surfaces
+  # accumulated debt on main before it can block a contributor's PR.
+  dead-caller-main:
+    name: Dead-caller ratchet (main)
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: taiki-e/install-action@v2
+        with:
+          tool: just
+      - name: Dead-caller ratchet
+        run: just dead-callers


### PR DESCRIPTION
## Problem

The dead-caller ratchet step lives inside the `Unit + integration (L1+L2)` job in `ci.yml`. That job is path-gated: it runs only when the Rust or frontend lane is active. When a merge to main touches only docs, specs, or workflow files, the job is skipped at the job level and the ratchet never evaluates main.

Consequence: a dead `pub fn` can land on main via a no-Rust merge and remain invisible. The ratchet then fires on the next unrelated Rust-touching PR, blocking an author who did not introduce the defect. Confirmed on main run ad94453c — overall success, with "skipped Dead-caller ratchet".

## Fix

Add `dead-caller-main`: a standalone job in `ci.yml` that runs `just dead-callers` on every push to `main`, with no path filter.

- Gated to `github.event_name == 'push'` so it does not duplicate the ratchet on PRs (where `integration` already covers it when Rust changes).
- Pure grep — no Rust toolchain, no compile. Only needs checkout + `just`.
- Not a required branch-protection check; acts as a canary that surfaces accumulated debt on main before it can block a contributor.

## Gate logic

| Scenario | `integration` ratchet step | `dead-caller-main` job |
|---|---|---|
| PR — Rust changes | runs | skipped (`pull_request` event) |
| PR — frontend only | skipped (rust=false) | skipped (`pull_request` event) |
| Main push — Rust changes | runs | also runs (main verification) |
| Main push — docs/specs/workflows | `integration` skipped (job-level) | **runs** — gap closed |

## Sibling ratchets

`db-boundary`, `hot-read`, and `lifecycle-strings` share the same skip-on-main shape. They are not changed here and can follow the same pattern independently.

Tracks-Bead: astro-plan-6jip
Closes-Bead: astro-plan-6jip
Merge-Bead: astro-plan-wyyt