### PR TITLE
fix(e2e): gate identity-columns assertion on settled dock width

### DIFF
--- a/crates/e2e-tests/tests/targets_journeys.rs
+++ b/crates/e2e-tests/tests/targets_journeys.rs
@@ -892,40 +892,60 @@ async fn targets_ui_identity_columns_stay_pinned_while_table_scrolls() -> anyhow
     )
     .await?;
 
-    // Poll until the table overflows by >= MIN_SCROLL, retrying set_viewport
-    // if the geometry is still wrong. Two failure modes are observed on CI:
+    // Gate: wait for the side dock to settle to its seeded 420px width AND for
+    // the table to have sufficient horizontal overflow before asserting on column
+    // positions. Two failure modes are observed on CI:
     //
-    // (a) Dock-width transient: `useAdaptiveDock` initialises correctly from
-    //     storage (width=420), but the flex layout reports a narrower
-    //     clientWidth (~880 = dock ~300px) for a few seconds while WebKit
-    //     settles the CSS variable after a SPA navigation. Retrying set_viewport
-    //     nudges the layout engine to recompute.
+    // (a) Dock-width transient (the root cause): `useAdaptiveDock` reads
+    //     width=420 from preferences synchronously on first render, setting the
+    //     `--pv-side-detail-w` CSS variable immediately. However WebKit's flex
+    //     layout can take several seconds to commit the CSS-variable reflow after
+    //     a SPA navigation — `rendered_side_width` reads back ~300px while the
+    //     reflow is in flight. Polling dock width directly is the settle signal;
+    //     calling `set_viewport` nudges the layout engine to recompute.
     //
-    // (b) Viewport didn't converge: set_viewport returned (1400, 900) but the
-    //     webview snapped back to the xvfb screen default (1600x1200) after the
-    //     seed_preference refresh(). At 1600px the dock IS 420px but the table
-    //     is ~960px wide and overflows by only 40px — below MIN_SCROLL. A
-    //     second set_viewport call inside this loop corrects the window size and
-    //     causes the layout to remount at 1400px with the expected ~760px table.
-    let before = {
+    // (b) Viewport drift: `seed_preference` calls `driver.refresh()`, which can
+    //     snap the WebView back to the xvfb screen default (1600px). At 1600px
+    //     the dock IS 420px (correctly read from preferences) but the table gets
+    //     ~960px and overflows by only ~40px — below MIN_SCROLL. `set_viewport`
+    //     corrects the window size, which also triggers the layout reflow from (a).
+    //
+    // The gate checks BOTH conditions: dock_w >= SEEDED_WIDTH-tolerance (primary:
+    // guards (a)) and overflow >= MIN_SCROLL (secondary: guards (b)). This bails
+    // with a specific diagnostic on timeout instead of silently falling through
+    // to an assert — distinguishing "dock never settled" from "viewport drifted".
+    {
+        const SEEDED_WIDTH: i64 = 420;
+        const SETTLE_TOLERANCE: i64 = 20;
         const DOCK_SETTLE_TIMEOUT: Duration = Duration::from_secs(15);
         let deadline = tokio::time::Instant::now() + DOCK_SETTLE_TIMEOUT;
-        let mut last = measure_pinned_columns(&app).await?;
         loop {
-            let overflow = px(&last, "scrollWidth")? - px(&last, "clientWidth")?;
-            if overflow >= MIN_SCROLL {
-                break last;
+            let dock_w = rendered_side_width(&app).await?;
+            let cols = measure_pinned_columns(&app).await?;
+            let overflow = px(&cols, "scrollWidth")? - px(&cols, "clientWidth")?;
+            if dock_w >= SEEDED_WIDTH - SETTLE_TOLERANCE && overflow >= MIN_SCROLL {
+                break;
             }
             if tokio::time::Instant::now() >= deadline {
-                break last; // let the assertion below produce the diagnostic
+                anyhow::bail!(
+                    "dock did not settle within {DOCK_SETTLE_TIMEOUT:?}: \
+                     dock_w={dock_w}px (need >= {}), overflow={overflow}px \
+                     (need >= {MIN_SCROLL}). \
+                     Failure mode (a) if dock_w is low: WebKit has not yet \
+                     committed the CSS-variable flex reflow after SPA navigation \
+                     (bead astro-plan-l3rw). \
+                     Failure mode (b) if dock_w is correct but overflow is low: \
+                     seed_preference refresh() snapped innerWidth back to the xvfb \
+                     screen default. viewport={viewport_w}x{viewport_h}. cols={cols}",
+                    SEEDED_WIDTH - SETTLE_TOLERANCE
+                );
             }
-            // Re-assert the viewport on every other poll: covers both the
-            // dock-settle transient and the viewport-didn't-converge case.
             let _ = app.set_viewport(1400, 900).await;
             tokio::time::sleep(Duration::from_millis(500)).await;
-            last = measure_pinned_columns(&app).await?;
         }
-    };
+    }
+
+    let before = measure_pinned_columns(&app).await?;
     let overflow = px(&before, "scrollWidth")? - px(&before, "clientWidth")?;
     anyhow::ensure!(
         overflow >= MIN_SCROLL,


### PR DESCRIPTION
## Problem

`targets_ui_identity_columns_stay_pinned_while_table_scrolls` was flaky on
Ubuntu CI. The settle loop added in #1509 polled `overflow >= MIN_SCROLL`
as the settle signal — the downstream symptom — rather than the dock width
that is the root cause.

**Root cause:** `useAdaptiveDock` reads `width=420` from preferences
synchronously on first render and sets `--pv-side-detail-w` immediately, but
WebKit's flex reflow of that CSS variable after a SPA navigation can lag
several seconds. During that window `rendered_side_width` reads ~300px, so
`clientWidth` is inflated and `scrollWidth - clientWidth < MIN_SCROLL`. The
assertion fired on transient geometry.

## Fix

Replaces the overflow-only poll with a two-condition settle gate:

1. `rendered_side_width >= 400px` (seeded 420 minus 20px tolerance) — the
   primary signal; directly observes the CSS-variable reflow rather than
   its effect on overflow.
2. `overflow >= MIN_SCROLL` — secondary guard for the viewport-drift
   failure mode where `seed_preference`'s `refresh()` snaps `innerWidth`
   back to the xvfb screen default.

On timeout the gate now bails with a diagnostic naming which condition did
not meet its threshold, so CI logs distinguish "WebKit flex reflow still in
flight" from "viewport snapped back to xvfb default."

`rendered_side_width` was already defined in the same file (`targets_journeys.rs:1023`).
No product code changed. No new helpers added.

## Scope

- Single file: `crates/e2e-tests/tests/targets_journeys.rs`
- Test-only change; the L2 journey is `#[ignore]` and does not run in unit test suites
- `cargo fmt`, `cargo clippy -p e2e_tests`, `cargo check -p e2e_tests` clean

Tracks-Bead: astro-plan-l3rw
Merge-Bead: astro-plan-1ayk