### PR TITLE
test(frontend): add user-event 14 and migrate exemplar interaction tests

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -77,6 +77,7 @@
     "@tauri-apps/cli": "^2.11.4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@testing-library/user-event": "^14.6.1",
     "@types/leaflet": "^1.9.21",
     "@types/node": "^26.1.1",
     "@types/react": "^19.2.17",

--- a/apps/desktop/src/app/AppErrorBoundary.test.tsx
+++ b/apps/desktop/src/app/AppErrorBoundary.test.tsx
@@ -13,8 +13,11 @@
  *  5. Non-throwing children render normally.
  */
 
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+// Convention: use userEvent for user-driven interactions; fireEvent for synthetic/edge cases.
+// See src/test/userEvent.ts for the project setup helper.
+import { setupUser } from '../test/userEvent';
 import { AppErrorBoundary } from './AppErrorBoundary';
 
 // Suppress console.error for expected errors in these tests.
@@ -64,7 +67,8 @@ describe('AppErrorBoundary', () => {
     expect(screen.getByText('Boom!')).toBeInTheDocument();
   });
 
-  it('3. "Try again" button resets the boundary', () => {
+  it('3. "Try again" button resets the boundary', async () => {
+    const user = setupUser();
     let shouldThrow = true;
 
     function MaybeThrow() {
@@ -87,7 +91,7 @@ describe('AppErrorBoundary', () => {
     shouldThrow = false;
 
     // Click reset
-    fireEvent.click(screen.getByTestId('app-error-boundary-reset'));
+    await user.click(screen.getByTestId('app-error-boundary-reset'));
 
     // Re-render to trigger the non-throwing path
     rerender(

--- a/apps/desktop/src/test/userEvent.ts
+++ b/apps/desktop/src/test/userEvent.ts
@@ -1,0 +1,29 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Interaction testing convention:
+ *
+ *   - Use `setupUser()` (and `await user.*`) for anything user-driven:
+ *     clicks, keyboard input, typing into fields, keyboard navigation.
+ *   - Use `fireEvent` only for synthetic/programmatic events that bypass the
+ *     pointer/keyboard stack — e.g. custom DOM events, simulating browser
+ *     internals, or components that cannot receive focus (mocks, portals).
+ *
+ * Why: userEvent simulates the full browser event sequence (pointerdown →
+ * mousedown → focus → click …), which catches focus-order bugs, keybinding
+ * regressions, and a11y issues that fireEvent's single-event shortcut misses.
+ */
+
+import userEvent from '@testing-library/user-event';
+
+/**
+ * Returns a pre-configured userEvent instance. Call once per test, then
+ * `await user.click(el)` / `await user.keyboard('{ArrowDown}')` etc.
+ *
+ * Options override the defaults for the rare test that needs them (e.g.
+ * `{ delay: null }` to skip artificial typing delays in CI).
+ */
+export function setupUser(options?: Parameters<typeof userEvent.setup>[0]) {
+  return userEvent.setup(options);
+}

--- a/apps/desktop/src/ui/RadioGroup.test.tsx
+++ b/apps/desktop/src/ui/RadioGroup.test.tsx
@@ -11,8 +11,11 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent, act } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { useState } from 'react';
+// Convention: use userEvent for user-driven interactions; fireEvent for synthetic/edge cases.
+// See src/test/userEvent.ts for the project setup helper.
+import { setupUser } from '../test/userEvent';
 import { RadioGroup, type RadioOption } from './RadioGroup';
 
 const settingsCss = readFileSync(
@@ -78,7 +81,8 @@ describe('RadioGroup a11y', () => {
     );
   });
 
-  it('calls onChange when a radio item is clicked', () => {
+  it('calls onChange when a radio item is clicked', async () => {
+    const user = setupUser();
     const onChange = vi.fn();
     render(
       <RadioGroup
@@ -88,17 +92,15 @@ describe('RadioGroup a11y', () => {
         aria-label="Destination"
       />,
     );
-    fireEvent.click(screen.getByRole('radio', { name: 'Trash' }));
+    await user.click(screen.getByRole('radio', { name: 'Trash' }));
     expect(onChange).toHaveBeenCalledWith('trash');
   });
 
   it('ArrowDown selects the next item, wrapping at the end', async () => {
+    const user = setupUser();
     render(<Harness initial="delete" />);
-    const item = screen.getByRole('radio', { name: 'Delete' });
-    await act(async () => {
-      item.focus();
-      fireEvent.keyDown(item, { key: 'ArrowDown' });
-    });
+    await user.click(screen.getByRole('radio', { name: 'Delete' }));
+    await user.keyboard('{ArrowDown}');
     expect(screen.getByRole('radio', { name: 'Archive' })).toHaveAttribute(
       'aria-checked',
       'true',
@@ -106,12 +108,10 @@ describe('RadioGroup a11y', () => {
   });
 
   it('ArrowUp selects the previous item, wrapping at the start', async () => {
+    const user = setupUser();
     render(<Harness initial="archive" />);
-    const item = screen.getByRole('radio', { name: 'Archive' });
-    await act(async () => {
-      item.focus();
-      fireEvent.keyDown(item, { key: 'ArrowUp' });
-    });
+    await user.click(screen.getByRole('radio', { name: 'Archive' }));
+    await user.keyboard('{ArrowUp}');
     expect(screen.getByRole('radio', { name: 'Delete' })).toHaveAttribute(
       'aria-checked',
       'true',

--- a/apps/desktop/src/ui/RadioGroup.test.tsx
+++ b/apps/desktop/src/ui/RadioGroup.test.tsx
@@ -11,7 +11,7 @@
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { describe, it, expect, vi } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { useState } from 'react';
 // Convention: use userEvent for user-driven interactions; fireEvent for synthetic/edge cases.
 // See src/test/userEvent.ts for the project setup helper.

--- a/apps/desktop/src/ui/Toggle.test.tsx
+++ b/apps/desktop/src/ui/Toggle.test.tsx
@@ -3,8 +3,11 @@
 
 import { readFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { fireEvent, render, screen } from '@testing-library/react';
+import { render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
+// Convention: use userEvent for user-driven interactions; fireEvent for synthetic/edge cases.
+// See src/test/userEvent.ts for the project setup helper.
+import { setupUser } from '../test/userEvent';
 import { Toggle } from './Toggle';
 
 const settingsCss = readFileSync(
@@ -34,14 +37,15 @@ describe('Toggle', () => {
     expect(focusRule).toContain('outline: 2px solid transparent');
   });
 
-  it('exposes checked state and preserves click changes', () => {
+  it('exposes checked state and preserves click changes', async () => {
+    const user = setupUser();
     const onChange = vi.fn();
     render(<Toggle checked onChange={onChange} aria-label="Auto scan" />);
 
     const checkbox = screen.getByRole('checkbox', { name: 'Auto scan' });
     expect(checkbox).toBeChecked();
 
-    fireEvent.click(checkbox);
+    await user.click(checkbox);
     expect(onChange).toHaveBeenCalledWith(false);
   });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -126,6 +126,9 @@ importers:
       '@testing-library/react':
         specifier: ^16.3.2
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/leaflet':
         specifier: ^1.9.21
         version: 1.9.21
@@ -1991,6 +1994,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@ts-graphviz/adapter@2.0.6':
     resolution: {integrity: sha512-kJ10lIMSWMJkLkkCG5gt927SnGZcBuG0s0HHswGzcHTgvtUe7yk5/3zTEr0bafzsodsOq5Gi6FhQeV775nC35Q==}
@@ -5821,6 +5830,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@ts-graphviz/adapter@2.0.6':
     dependencies:


### PR DESCRIPTION
## Summary

- Adds `@testing-library/user-event` 14 as a dev dependency alongside `@testing-library/react` 16
- Establishes the interaction testing convention: `userEvent` for user-driven interactions, `fireEvent` for synthetic/edge cases
- Adds `src/test/userEvent.ts` setup helper as the documented entry point for new tests
- Converts 3 representative test files as exemplars: Toggle (checkbox click), RadioGroup (keyboard navigation), AppErrorBoundary (button click)

## Test plan

- [ ] `pnpm exec vitest run` passes in apps/desktop
- [ ] `pnpm exec tsc --noEmit` passes in apps/desktop
- [ ] Converted tests use `await user.click()` / `await user.keyboard()` patterns
- [ ] src/test/userEvent.ts exports `setupUser` helper

Tracks-Bead: astro-plan-kyo7.26
Merge-Bead: astro-plan-r9ay

🤖 Generated with [Claude Code](https://claude.com/claude-code)