### PR TITLE
feat(frontend): per-route error boundary and not-found pages

### DIFF
--- a/apps/desktop/messages/en-GB.json
+++ b/apps/desktop/messages/en-GB.json
@@ -2750,5 +2750,8 @@
   "sessions_rawcleanup_generate_btn": "Generate cleanup plan",
   "sessions_rawcleanup_generating": "Generating…",
   "sessions_rawcleanup_review_title": "Review raw sub-frame cleanup plan",
-  "sessions_rawcleanup_select_aria": "Select {path} for cleanup"
+  "sessions_rawcleanup_select_aria": "Select {path} for cleanup",
+  "route_not_found_heading": "Page not found",
+  "route_not_found_body": "The page you are looking for does not exist.",
+  "route_not_found_home": "Go to home"
 }

--- a/apps/desktop/messages/pt-BR.json
+++ b/apps/desktop/messages/pt-BR.json
@@ -2780,5 +2780,8 @@
   "onboarding_find_unavailable": "Ainda não há nada para indicar em \"{item}\" — o controle aparecerá quando houver algo nesta página para executar.",
   "onboarding_find_prerequisite_first": "\"{item}\" precisa ser concluído primeiro — veja onde fazer isso.",
   "onboarding_item_dismiss_label": "Dispensar: {item}",
-  "sessions_singular": "sessão"
+  "sessions_singular": "sessão",
+  "route_not_found_heading": "Página não encontrada",
+  "route_not_found_body": "A página que você está procurando não existe.",
+  "route_not_found_home": "Ir para o início"
 }

--- a/apps/desktop/src/app/RouteError.test.tsx
+++ b/apps/desktop/src/app/RouteError.test.tsx
@@ -14,7 +14,9 @@ describe('RouteError', () => {
   });
 
   it('shows the error message', () => {
-    render(<RouteError error={new Error('Something exploded')} reset={() => {}} />);
+    render(
+      <RouteError error={new Error('Something exploded')} reset={() => {}} />,
+    );
     expect(screen.getByText('Something exploded')).toBeInTheDocument();
   });
 

--- a/apps/desktop/src/app/RouteError.test.tsx
+++ b/apps/desktop/src/app/RouteError.test.tsx
@@ -1,0 +1,27 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RouteError } from './RouteError';
+
+describe('RouteError', () => {
+  it('renders with data-testid="route-error"', () => {
+    render(<RouteError error={new Error('boom')} reset={() => {}} />);
+    expect(screen.getByTestId('route-error')).toBeInTheDocument();
+  });
+
+  it('shows the error message', () => {
+    render(<RouteError error={new Error('Something exploded')} reset={() => {}} />);
+    expect(screen.getByText('Something exploded')).toBeInTheDocument();
+  });
+
+  it('calls reset when the retry button is clicked', () => {
+    const reset = vi.fn();
+    render(<RouteError error={new Error('err')} reset={reset} />);
+    fireEvent.click(screen.getByTestId('route-error-reset'));
+    expect(reset).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/desktop/src/app/RouteError.tsx
+++ b/apps/desktop/src/app/RouteError.tsx
@@ -1,0 +1,41 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * RouteError — TanStack Router errorComponent.
+ *
+ * Receives `{ error, reset }` from TanStack Router when a route throws during
+ * render. Reuses the AppErrorBoundary CSS classes so it is visually consistent
+ * with the app-level boundary without duplicating markup.
+ */
+
+import { m } from '@/lib/i18n';
+
+interface RouteErrorProps {
+  error: Error;
+  reset: () => void;
+}
+
+export function RouteError({ error, reset }: RouteErrorProps) {
+  return (
+    <div
+      role="alert"
+      data-testid="route-error"
+      className="pv-error-boundary__overlay"
+    >
+      <h1 className="pv-error-boundary__heading">{m.shell_error_heading()}</h1>
+      <p className="pv-error-boundary__body">{m.shell_error_body()}</p>
+      {error.message && (
+        <pre className="pv-error-boundary__detail">{error.message}</pre>
+      )}
+      <button
+        type="button"
+        onClick={reset}
+        data-testid="route-error-reset"
+        className="pv-error-boundary__reset-btn"
+      >
+        {m.common_try_again()}
+      </button>
+    </div>
+  );
+}

--- a/apps/desktop/src/app/RouteNotFound.test.tsx
+++ b/apps/desktop/src/app/RouteNotFound.test.tsx
@@ -10,11 +10,22 @@ import { RouteNotFound } from './RouteNotFound';
 // Link from @tanstack/react-router requires a router context; render it as a
 // plain anchor so the component is testable without a full RouterProvider.
 vi.mock('@tanstack/react-router', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  const actual =
+    await importOriginal<typeof import('@tanstack/react-router')>();
   return {
     ...actual,
-    Link: ({ to, children, className }: { to: string; children: React.ReactNode; className?: string }) => (
-      <a href={to} className={className}>{children}</a>
+    Link: ({
+      to,
+      children,
+      className,
+    }: {
+      to: string;
+      children: React.ReactNode;
+      className?: string;
+    }) => (
+      <a href={to} className={className}>
+        {children}
+      </a>
     ),
   };
 });

--- a/apps/desktop/src/app/RouteNotFound.test.tsx
+++ b/apps/desktop/src/app/RouteNotFound.test.tsx
@@ -1,0 +1,32 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/// <reference types="@testing-library/jest-dom" />
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+import { RouteNotFound } from './RouteNotFound';
+
+// Link from @tanstack/react-router requires a router context; render it as a
+// plain anchor so the component is testable without a full RouterProvider.
+vi.mock('@tanstack/react-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@tanstack/react-router')>();
+  return {
+    ...actual,
+    Link: ({ to, children, className }: { to: string; children: React.ReactNode; className?: string }) => (
+      <a href={to} className={className}>{children}</a>
+    ),
+  };
+});
+
+describe('RouteNotFound', () => {
+  it('renders with data-testid="route-not-found"', () => {
+    render(<RouteNotFound />);
+    expect(screen.getByTestId('route-not-found')).toBeInTheDocument();
+  });
+
+  it('shows "Page not found" text', () => {
+    render(<RouteNotFound />);
+    expect(screen.getByText(/page not found/i)).toBeInTheDocument();
+  });
+});

--- a/apps/desktop/src/app/RouteNotFound.tsx
+++ b/apps/desktop/src/app/RouteNotFound.tsx
@@ -1,0 +1,30 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * RouteNotFound — TanStack Router notFoundComponent.
+ *
+ * Rendered by TanStack Router when a navigation matches no registered route.
+ * Uses a Link to navigate home, avoiding the need for a useNavigate mock in tests.
+ */
+
+import { Link } from '@tanstack/react-router';
+import { m } from '@/lib/i18n';
+
+export function RouteNotFound() {
+  return (
+    <div
+      role="alert"
+      data-testid="route-not-found"
+      className="pv-error-boundary__overlay"
+    >
+      <h1 className="pv-error-boundary__heading">
+        {m.route_not_found_heading()}
+      </h1>
+      <p className="pv-error-boundary__body">{m.route_not_found_body()}</p>
+      <Link to="/" className="pv-error-boundary__reset-btn">
+        {m.route_not_found_home()}
+      </Link>
+    </div>
+  );
+}

--- a/apps/desktop/src/app/router.tsx
+++ b/apps/desktop/src/app/router.tsx
@@ -8,10 +8,11 @@ import {
   createRoute,
   lazyRouteComponent,
   redirect,
-  Navigate,
   Outlet,
 } from '@tanstack/react-router';
 import { Shell } from './Shell';
+import { RouteError } from './RouteError';
+import { RouteNotFound } from './RouteNotFound';
 import { checkFirstRunComplete } from './first-run';
 import {
   makeValidateSearch,
@@ -312,9 +313,11 @@ export const router = createRouter({
   routeTree,
   history: hashHistory,
   defaultPreload: 'intent',
-  // Unknown routes (stale deep links) fall through to the index resolver
-  // rather than flashing a blank not-found page (spec 020 US3 / T031).
-  defaultNotFoundComponent: () => <Navigate to="/" />,
+  // Scoped error panel instead of a blank app shell when any route throws.
+  defaultErrorComponent: RouteError,
+  // Unknown routes show a not-found page instead of silently redirecting to
+  // home; the index route's beforeLoad still handles first-run gating (T031).
+  defaultNotFoundComponent: RouteNotFound,
 });
 
 declare module '@tanstack/react-router' {


### PR DESCRIPTION
## Summary

- Adds `RouteError` component — scoped error panel shown when a route throws during render (`data-testid="route-error"`)
- Adds `RouteNotFound` component — 404 feedback page with a home link (`data-testid="route-not-found"`)
- Wires both into `createRouter()` via `defaultErrorComponent` and `defaultNotFoundComponent` so a single-route crash no longer blanks the whole app shell

## Test plan

- [ ] `pnpm exec vitest run` passes in apps/desktop
- [ ] `pnpm exec tsc --noEmit` passes in apps/desktop
- [ ] RouteError renders `data-testid="route-error"` and calls reset
- [ ] RouteNotFound renders `data-testid="route-not-found"`
- [ ] router.tsx uses `defaultErrorComponent: RouteError` and `defaultNotFoundComponent: RouteNotFound`

Tracks-Bead: astro-plan-kyo7.27
Merge-Bead: astro-plan-r66u

🤖 Generated with [Claude Code](https://claude.com/claude-code)