### PR TITLE
refactor: add frame type to inbox plan actions and fix naming pattern tokens

### DIFF
--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -1557,7 +1557,7 @@ export const commands = {
 	 *  - `inbox.item.no_plan`   — item exists but has no linked plan.
 	 *  - `plan.not_found`       — link is present but plan row missing.
 	 */
-	inboxPlan: (inboxItemId: string) => typedError<InboxPlanView, string>(__TAURI_INVOKE("inbox_plan", { inboxItemId })),
+	inboxPlan: (inboxItemId: string) => typedError<InboxPlanView_Serialize, string>(__TAURI_INVOKE("inbox_plan", { inboxItemId })),
 	/**
 	 *  `inbox.plan.apply` — approve + apply the plan for a single inbox item.
 	 * 
@@ -1626,7 +1626,7 @@ export const commands = {
 	 *  # Errors
 	 *  Returns a string error only if the underlying list/plan queries fail.
 	 */
-	inboxPlanListOpen: () => typedError<InboxOpenPlansResponse, string>(__TAURI_INVOKE("inbox_plan_list_open")),
+	inboxPlanListOpen: () => typedError<InboxOpenPlansResponse_Serialize, string>(__TAURI_INVOKE("inbox_plan_list_open")),
 	/**
 	 *  `inbox.property_registry` — return the typed property registry.
 	 * 
@@ -5180,19 +5180,43 @@ export type InboxListResponse_Serialize = {
 };
 
 /**  One open plan in the aggregate inbox plan surface (spec 041, US2). */
-export type InboxOpenPlan = {
+export type InboxOpenPlan = InboxOpenPlan_Serialize | InboxOpenPlan_Deserialize;
+
+/**  One open plan in the aggregate inbox plan surface (spec 041, US2). */
+export type InboxOpenPlan_Deserialize = {
 	inboxItemId: string,
 	/**  Display label for the ingestion group (the item's relative path / folder name). */
 	itemName: string,
 	planId: string,
 	state: string,
 	stale: boolean,
-	actions: InboxPlanAction[],
+	actions: InboxPlanAction_Deserialize[],
+};
+
+/**  One open plan in the aggregate inbox plan surface (spec 041, US2). */
+export type InboxOpenPlan_Serialize = {
+	inboxItemId: string,
+	/**  Display label for the ingestion group (the item's relative path / folder name). */
+	itemName: string,
+	planId: string,
+	state: string,
+	stale: boolean,
+	actions: InboxPlanAction_Serialize[],
 };
 
 /**  Response from `inbox.plan.list_open` — all open plans across roots (spec 041, US2). */
-export type InboxOpenPlansResponse = {
-	plans: InboxOpenPlan[],
+export type InboxOpenPlansResponse = InboxOpenPlansResponse_Serialize | InboxOpenPlansResponse_Deserialize;
+
+/**  Response from `inbox.plan.list_open` — all open plans across roots (spec 041, US2). */
+export type InboxOpenPlansResponse_Deserialize = {
+	plans: InboxOpenPlan_Deserialize[],
+	/**  Sum of actions across all plans (for the surface header count). */
+	totalActions: number,
+};
+
+/**  Response from `inbox.plan.list_open` — all open plans across roots (spec 041, US2). */
+export type InboxOpenPlansResponse_Serialize = {
+	plans: InboxOpenPlan_Serialize[],
 	/**  Sum of actions across all plans (for the surface header count). */
 	totalActions: number,
 };
@@ -5202,7 +5226,14 @@ export type InboxOpenPlansResponse = {
  * 
  *  `action` is `"move"` | `"catalogue"` | `"archive"` | `"trash"`.
  */
-export type InboxPlanAction = {
+export type InboxPlanAction = InboxPlanAction_Serialize | InboxPlanAction_Deserialize;
+
+/**
+ *  One plan action entry in the in-context plan panel.
+ * 
+ *  `action` is `"move"` | `"catalogue"` | `"archive"` | `"trash"`.
+ */
+export type InboxPlanAction_Deserialize = {
 	/**  1-based ordinal within the plan. */
 	index: number,
 	/**  `"move"` | `"catalogue"` | `"archive"` | `"trash"` */
@@ -5218,8 +5249,35 @@ export type InboxPlanAction = {
 	requiresDestructiveConfirm: boolean,
 	/**
 	 *  Frame type of the file being acted on (e.g. `"light"`, `"dark"`, `"flat"`,
-	 *  `"bias"`, `"master_flat"`, etc.). `null` for legacy plans or catalogue/archive/trash
-	 *  actions without a classification.
+	 *  `"bias"`, `"master_flat"`, etc.). `None` for legacy plans that pre-date this
+	 *  field or for catalogue / archive / trash actions without a classification.
+	 */
+	frameType: string | null,
+};
+
+/**
+ *  One plan action entry in the in-context plan panel.
+ * 
+ *  `action` is `"move"` | `"catalogue"` | `"archive"` | `"trash"`.
+ */
+export type InboxPlanAction_Serialize = {
+	/**  1-based ordinal within the plan. */
+	index: number,
+	/**  `"move"` | `"catalogue"` | `"archive"` | `"trash"` */
+	action: string,
+	fromPath: string,
+	toPath: string,
+	/**
+	 *  Human-readable resolved destination preview
+	 *  (equals `from_path` for catalogue actions).
+	 */
+	destinationPreview: string,
+	/**  True when this action requires explicit destructive confirmation before apply. */
+	requiresDestructiveConfirm: boolean,
+	/**
+	 *  Frame type of the file being acted on (e.g. `"light"`, `"dark"`, `"flat"`,
+	 *  `"bias"`, `"master_flat"`, etc.). `None` for legacy plans that pre-date this
+	 *  field or for catalogue / archive / trash actions without a classification.
 	 */
 	frameType?: string | null,
 };
@@ -5245,7 +5303,15 @@ export type InboxPlanCancelResponse = {
  *  Read via `inbox_plan_links` so the inbox surface can show plan detail
  *  without navigating to the Archive page (FR-004).
  */
-export type InboxPlanView = {
+export type InboxPlanView = InboxPlanView_Serialize | InboxPlanView_Deserialize;
+
+/**
+ *  Response from `inbox.plan` — plan(s) linked to an inbox item (spec 041).
+ * 
+ *  Read via `inbox_plan_links` so the inbox surface can show plan detail
+ *  without navigating to the Archive page (FR-004).
+ */
+export type InboxPlanView_Deserialize = {
 	planId: string,
 	state: string,
 	/**
@@ -5255,7 +5321,26 @@ export type InboxPlanView = {
 	 *  to re-classify and re-confirm.
 	 */
 	stale: boolean,
-	actions: InboxPlanAction[],
+	actions: InboxPlanAction_Deserialize[],
+};
+
+/**
+ *  Response from `inbox.plan` — plan(s) linked to an inbox item (spec 041).
+ * 
+ *  Read via `inbox_plan_links` so the inbox surface can show plan detail
+ *  without navigating to the Archive page (FR-004).
+ */
+export type InboxPlanView_Serialize = {
+	planId: string,
+	state: string,
+	/**
+	 *  True when the executor's CAS detected that one or more source files
+	 *  changed since the plan was created (FR-007 / T011).
+	 *  When `stale` is true the UI should disable Apply and prompt the user
+	 *  to re-classify and re-confirm.
+	 */
+	stale: boolean,
+	actions: InboxPlanAction_Serialize[],
 };
 
 /**  The sky pointing a recommendation set was computed from (decimal degrees). */

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -5216,6 +5216,12 @@ export type InboxPlanAction = {
 	destinationPreview: string,
 	/**  True when this action requires explicit destructive confirmation before apply. */
 	requiresDestructiveConfirm: boolean,
+	/**
+	 *  Frame type of the file being acted on (e.g. `"light"`, `"dark"`, `"flat"`,
+	 *  `"bias"`, `"master_flat"`, etc.). `null` for legacy plans or catalogue/archive/trash
+	 *  actions without a classification.
+	 */
+	frameType?: string | null,
 };
 
 /**  Per-plan result from `inbox.plan.apply_all` (spec 041, FR-003a). */

--- a/apps/desktop/src/features/inbox/planPanelHelpers.ts
+++ b/apps/desktop/src/features/inbox/planPanelHelpers.ts
@@ -113,22 +113,23 @@ function shortDestination(path: string): string {
 
 /**
  * Resolve the frame-type label for one action (spec 043 #75). Priority:
- *   1. a frame keyword present in the destination OR source path (handles split
- *      plans where each type lands in its own typed folder), then
- *   2. the per-ingestion hint from the inbox item's classification/breakdown
+ *   1. `action.frameType` from the backend (set at plan creation since kyo7.85),
+ *   2. a frame keyword present in the destination OR source path (handles split
+ *      plans where each type lands in its own typed folder — legacy fallback),
+ *   3. the per-ingestion hint from the inbox item's classification/breakdown
  *      (`itemFrameType` — e.g. a single-type catalogue folder of darks whose
  *      in-place destination carries no frame keyword), then
- *   3. the action kind (e.g. "catalogue") as a last resort.
- *
- * Putting the path keyword first lets a MIXED/split plan still distinguish
- * per-type buckets, while the item hint rescues single-type catalogue plans
- * from degenerating to one line per file.
+ *   4. the action kind (e.g. "catalogue") as a last resort.
  */
 export function frameTypeLabel(
   action: InboxPlanAction,
   destination: string,
   itemFrameType?: string,
 ): string {
+  // Prefer the backend-supplied frame type (no path inference needed).
+  if (action.frameType) return normalizeFrameTypeHint(action.frameType);
+
+  // Legacy path: infer from destination/source path keywords (pre-kyo7.85 plans).
   const segments = [
     ...pathSegments(destination),
     ...pathSegments(action.fromPath),

--- a/apps/desktop/src/features/projects/wizard/StepLayout.tsx
+++ b/apps/desktop/src/features/projects/wizard/StepLayout.tsx
@@ -17,13 +17,13 @@ export interface StepLayoutProps {
   onChange: (data: StepLayoutData) => void;
 }
 
-const DEFAULT_PATTERN = '{target}_{filter}_{exposure}s_{sequence:04d}';
+// Default matches the v1 token registry — no {sequence} which is not a registered token.
+const DEFAULT_PATTERN = '{target}_{filter}_{exposure}s';
 
 const AVAILABLE_TOKENS = [
   { token: '{target}', example: 'NGC7000' },
   { token: '{filter}', example: 'Ha' },
   { token: '{exposure}', example: '600' },
-  { token: '{sequence:04d}', example: '0001' },
   { token: '{date}', example: '2026-04-15' },
   { token: '{gain}', example: '100' },
   { token: '{binning}', example: '1x1' },
@@ -50,10 +50,11 @@ export function StepLayout({
       .replace('{target}', 'NGC7000')
       .replace('{filter}', 'Ha')
       .replace('{exposure}', '600')
-      .replace('{sequence:04d}', '0001')
       .replace('{date}', '2026-04-15')
       .replace('{gain}', '100')
-      .replace('{binning}', '1x1');
+      .replace('{binning}', '1x1')
+      .replace('{set_temp}', '-10C')
+      .replace('{frame_type}', 'light');
 
     return {
       root: base,

--- a/crates/app/core/src/inbox_plan.rs
+++ b/crates/app/core/src/inbox_plan.rs
@@ -73,6 +73,9 @@ fn map_plan_actions(item_rows: Vec<plans_repo::PlanItemRow>) -> Vec<InboxPlanAct
                 to_path: r.to_relative_path,
                 destination_preview: dest_preview,
                 requires_destructive_confirm: r.requires_destructive_confirm.unwrap_or(0) != 0,
+                // `category` carries the per-file frame type for inbox confirm plans
+                // (stored at plan creation; `None` for legacy rows and other plan types).
+                frame_type: r.category,
             }
         })
         .collect()

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -430,6 +430,7 @@ async fn resolve_per_file_plan_items(
                     action: "catalogue",
                     to_root_id: ctx.item_root_id.to_owned(),
                     provenance: freeze_confirm_provenance(&bundle, is_master, None),
+                    frame_type: Some(ft.to_owned()),
                 });
             }
             OrganizationState::Unorganized => {
@@ -511,6 +512,7 @@ async fn resolve_per_file_plan_items(
                     action: "move",
                     to_root_id: dest_root.root_id,
                     provenance: freeze_confirm_provenance(&bundle, is_master, Some(&pattern)),
+                    frame_type: Some(ft.to_owned()),
                 });
             }
         }
@@ -555,7 +557,8 @@ async fn insert_plan_items_batch(
             provenance_json: row.provenance.as_deref(),
             archive_path: None,
             source_id: None,
-            category: None,
+            // Store frame type in category so InboxPlanAction::frame_type is populated.
+            category: row.frame_type.as_deref(),
         };
 
         plans_repo::insert_plan_item(pool, &plan_item)
@@ -589,6 +592,10 @@ struct ResolvedRow {
     to_root_id: String,
     /// Frozen inferred context at approval time (`freeze_confirm_provenance`).
     provenance: Option<String>,
+    /// Frame-type class string (e.g. `"light"`, `"dark_flat"`) stored in the
+    /// `category` column so `InboxPlanAction::frame_type` can be populated
+    /// without a new column.
+    frame_type: Option<String>,
 }
 
 /// A chosen destination library root (id + absolute path) for inbox moves.

--- a/crates/contracts/core/src/inbox.rs
+++ b/crates/contracts/core/src/inbox.rs
@@ -747,6 +747,11 @@ pub struct InboxPlanAction {
     pub destination_preview: String,
     /// True when this action requires explicit destructive confirmation before apply.
     pub requires_destructive_confirm: bool,
+    /// Frame type of the file being acted on (e.g. `"light"`, `"dark"`, `"flat"`,
+    /// `"bias"`, `"master_flat"`, etc.). `None` for legacy plans that pre-date this
+    /// field or for catalogue / archive / trash actions without a classification.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub frame_type: Option<String>,
 }
 
 /// Response from `inbox.plan` — plan(s) linked to an inbox item (spec 041).

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -62,7 +62,7 @@ src/features/projects/edit/ChannelDriftBanner.tsx	31	alm/require-root-testid
 src/features/projects/edit/EditProjectPane.tsx	156	alm/require-root-testid
 src/features/projects/edit/EditProjectSourcesPanel.tsx	60	alm/require-root-testid
 src/features/projects/wizard/StepCalibration.tsx	193	alm/require-root-testid
-src/features/projects/wizard/StepLayout.tsx	75	alm/require-root-testid
+src/features/projects/wizard/StepLayout.tsx	76	alm/require-root-testid
 src/features/projects/wizard/StepName.tsx	122	alm/require-root-testid
 src/features/projects/wizard/StepReview.tsx	48	alm/require-root-testid
 src/features/projects/wizard/StepSources.tsx	28	alm/require-root-testid


### PR DESCRIPTION
## Summary

- Plan action entries now carry the frame type (light, dark, flat, bias, etc.) set by the backend at plan creation, so the inbox panel no longer needs to infer it from destination path keywords.
- Path-keyword inference is kept as a fallback for plans created before this change.
- The project wizard naming pattern no longer shows a fabricated sequence token that had no backend support; the default pattern and available token chips now match the registered token vocabulary.

## Spec Context

DSD-6, DS-12 (kyo7.85).

Tracks-Bead: astro-plan-kyo7.85
Merge-Bead: astro-plan-hmwx