### PR TITLE
chore: use structured tracing fields instead of format-string interpolation

### DIFF
--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -116,7 +116,7 @@ fn spawn_repair_sweep(pool: SqlitePool, bus: EventBus, resolve_cache: ResolveCac
         loop {
             ticker.tick().await;
             if let Err(e) = crate::repair::run_repair(&pool, &bus, &resolve_cache).await {
-                tracing::warn!("inbox repair sweep: {e}");
+                tracing::warn!(error = %e, "inbox repair sweep failed");
             }
         }
     });
@@ -134,7 +134,7 @@ async fn run_listener_loop(
         match rx.recv().await {
             Ok(envelope) => {
                 if let Err(e) = handle_event(&pool, &bus, &resolve_cache, &envelope).await {
-                    tracing::warn!("inbox plan_listener: error handling event: {e}");
+                    tracing::warn!(error = %e, "inbox plan_listener: error handling event");
                 }
             }
             Err(broadcast::error::RecvError::Lagged(n)) => {

--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -298,7 +298,7 @@ pub async fn build_source_calibration_snapshot(
     let sources = match projects_repo::list_project_sources(pool, project_id).await {
         Ok(s) => s,
         Err(e) => {
-            tracing::debug!("manifest snapshot: failed to list project sources: {e}");
+            tracing::debug!(error = %e, "manifest snapshot: failed to list project sources");
             return (None, None);
         }
     };
@@ -335,8 +335,9 @@ pub async fn build_source_calibration_snapshot(
             }
             Err(e) => {
                 tracing::debug!(
-                    "manifest snapshot: failed to list calibration for session {}: {e}",
-                    s.inventory_session_id
+                    session_id = s.inventory_session_id,
+                    error = %e,
+                    "manifest snapshot: failed to list calibration for session"
                 );
             }
         }
@@ -374,7 +375,7 @@ pub async fn write_lifecycle_manifest(
     let row = match persistence_plans::repositories::projects::get_project(pool, project_id).await {
         Ok(row) => row,
         Err(e) => {
-            tracing::debug!("manifest snapshot: could not load project {project_id}: {e}");
+            tracing::debug!(project_id, error = %e, "manifest snapshot: could not load project");
             return;
         }
     };
@@ -394,7 +395,7 @@ pub async fn write_lifecycle_manifest(
     )
     .await
     {
-        tracing::warn!("manifest write failed for project {project_id}: {e}");
+        tracing::warn!(project_id, error = %e, "manifest write failed");
     }
 }
 
@@ -484,7 +485,7 @@ async fn handle_workflow_run_event(pool: &SqlitePool, bus: &EventBus, payload: &
             )
             .await;
             if let Err(e) = result {
-                tracing::warn!("workflow_run manifest write failed for project {pid}: {e}");
+                tracing::warn!(project_id = pid, error = %e, "workflow_run manifest write failed");
             }
         }
     }
@@ -505,7 +506,7 @@ async fn replay_workflow_events_since(pool: &SqlitePool, bus: &EventBus, cursor:
     let rows = match rows {
         Ok(r) => r,
         Err(e) => {
-            tracing::error!("workflow_run_subscriber: replay query failed: {e}");
+            tracing::error!(error = %e, "workflow_run_subscriber: replay query failed");
             return cursor;
         }
     };

--- a/crates/app/projects/src/project_notes.rs
+++ b/crates/app/projects/src/project_notes.rs
@@ -129,7 +129,7 @@ pub async fn update_note_with_adapter(
     if let Some(root) = project_root {
         if let Err(e) = adapter.write(root, &req.content).await {
             // Non-fatal: DB is the durable record. Log but don't fail.
-            tracing::warn!("project_notes: disk write failed for project {}: {e}", req.project_id);
+            tracing::warn!(project_id = req.project_id, error = %e, "project_notes: disk write failed");
         }
     }
 
@@ -193,7 +193,7 @@ pub async fn sync_notes_to_disk(
 
     match content {
         None => {
-            tracing::debug!("sync_notes_to_disk: no notes for project {project_id}");
+            tracing::debug!(project_id, "sync_notes_to_disk: no notes for project");
             Ok(0)
         }
         Some(body) => {

--- a/crates/app/projects/src/project_setup/mod.rs
+++ b/crates/app/projects/src/project_setup/mod.rs
@@ -72,7 +72,7 @@ fn str_to_error_code(code: &str) -> ErrorCode {
         "name.too_long" => ErrorCode::NameTooLong,
         "tool.unknown" => ErrorCode::ToolUnknown,
         _ => {
-            tracing::warn!("unknown validation code '{code}', using InternalData");
+            tracing::warn!(code, "unknown validation code; using InternalData");
             ErrorCode::InternalData
         }
     }
@@ -183,7 +183,7 @@ fn parse_exposure_seconds(exposure: &str) -> u64 {
         #[allow(clippy::cast_sign_loss, clippy::cast_possible_truncation)]
         Ok(v) if v.is_finite() && v >= 0.0 => v as u64,
         _ => {
-            tracing::debug!("unparseable exposure snapshot '{exposure}', treating as 0s");
+            tracing::debug!(exposure, "unparseable exposure snapshot; treating as 0s");
             0
         }
     }

--- a/crates/audit/src/stale_propagator.rs
+++ b/crates/audit/src/stale_propagator.rs
@@ -104,7 +104,7 @@ impl StalePropagator {
         let rows = match rows {
             Ok(r) => r,
             Err(e) => {
-                tracing::error!("stale_propagator: replay query failed: {e}");
+                tracing::error!(error = %e, "stale_propagator: replay query failed");
                 return cursor;
             }
         };

--- a/crates/fs/inventory/src/artifact_watcher.rs
+++ b/crates/fs/inventory/src/artifact_watcher.rs
@@ -112,7 +112,7 @@ pub fn start_artifact_watcher(
             Err(e) => {
                 // Item (a): forward OS watcher errors as NeedsRescan so the
                 // consumer triggers a reconciliation pass.
-                tracing::error!("artifact watcher error: {e}");
+                tracing::error!(error = %e, "artifact watcher error");
                 let _ = handler_tx.try_send(ArtifactFileEvent {
                     path: Utf8PathBuf::new(),
                     kind: ArtifactEventKind::NeedsRescan,

--- a/crates/fs/inventory/src/notify_bridge.rs
+++ b/crates/fs/inventory/src/notify_bridge.rs
@@ -107,7 +107,7 @@ pub fn register_watch_paths(
                     return Err(format!("failed to watch {}: {e}", dir.display()));
                 }
                 Err(e) => {
-                    tracing::warn!("skipping unwatchable subdirectory {}: {e}", dir.display());
+                    tracing::warn!(dir = %dir.display(), error = %e, "skipping unwatchable subdirectory");
                     report.skipped.push((dir, e.to_string()));
                 }
             }

--- a/crates/fs/inventory/src/watcher.rs
+++ b/crates/fs/inventory/src/watcher.rs
@@ -122,7 +122,7 @@ impl WatcherService {
                     // Item (a): forward OS watcher errors as NeedsRescan events
                     // so consumers know to reconcile, rather than silently
                     // dropping them.
-                    tracing::error!("filesystem watcher error: {e}");
+                    tracing::error!(error = %e, "filesystem watcher error");
                     let _ = tx.send(InboxFileEvent::NeedsRescan { reason: e.to_string() });
                 }
                 Ok(event) => {

--- a/docs/development/tracing-conventions.md
+++ b/docs/development/tracing-conventions.md
@@ -1,0 +1,38 @@
+# Tracing conventions
+
+## Structured fields over format-string interpolation
+
+Use named fields instead of interpolating values into the message string:
+
+```rust
+// preferred
+tracing::warn!(project_id, error = %e, "manifest write failed");
+
+// avoid
+tracing::warn!("manifest write failed for project {project_id}: {e}");
+```
+
+**Why**: named fields are indexed and filterable in structured log viewers
+(`tracing-subscriber` JSON format, etc.).  A static message string also
+makes log aggregation and alerting easier — the message never changes between
+invocations, only field values do.
+
+## Field naming
+
+| Value type | Convention | Example |
+|---|---|---|
+| Error / display | `error = %e` | `tracing::warn!(error = %e, "…")` |
+| Debug-formatted | `error = ?e` | for types without `Display` |
+| Plain string or `&str` | bare field or `= value` | `tracing::info!(project_id, …)` |
+| Formatted display (path, URL) | `name = %value.display()` | `dir = %dir.display()` |
+
+## Lint / ratchet
+
+There is no automated clippy rule that catches tracing interpolation today.
+To verify the codebase has not regressed, run:
+
+```sh
+rg 'tracing::(info|warn|debug|error|trace)!\(".*\{[^:{}]' crates/
+```
+
+A clean result means no format-string interpolation remains in tracing calls.


### PR DESCRIPTION
## Summary
- Converts format-interpolated tracing calls to structured fields across audit/projects/inbox/fs-inventory for queryable logs.
- Adds docs/development/tracing-conventions.md.

## Spec Context
Tracks-Bead: astro-plan-kyo7.32
Merge-Bead: astro-plan-w47w

Verified: app_core_projects + app_core_inbox + fs_inventory 380 tests, clippy -D warnings, fmt.