### PR TITLE
feat: write frontend errors and unhandled rejections to the diagnostics log

### DIFF
--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -47,6 +47,7 @@
     "@tanstack/react-virtual": "3.14.5",
     "@tauri-apps/api": "^2.11.1",
     "@tauri-apps/plugin-dialog": "^2.7.1",
+    "@tauri-apps/plugin-log": "^2.9.0",
     "@tauri-apps/plugin-opener": "^2.5.4",
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.10.1",

--- a/apps/desktop/src/app/AppErrorBoundary.test.tsx
+++ b/apps/desktop/src/app/AppErrorBoundary.test.tsx
@@ -16,6 +16,11 @@
 import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { AppErrorBoundary } from './AppErrorBoundary';
+import { logError } from '@/lib/diagnosticLog';
+
+vi.mock('@/lib/diagnosticLog', () => ({
+  logError: vi.fn(),
+}));
 
 // Suppress console.error for expected errors in these tests.
 let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
@@ -123,6 +128,15 @@ describe('AppErrorBoundary', () => {
     expect(
       screen.queryByTestId('app-error-boundary-fallback'),
     ).not.toBeInTheDocument();
+  });
+
+  it('6. forwards render errors to the diagnostics log', () => {
+    render(
+      <AppErrorBoundary>
+        <ThrowingChild message="log-me" />
+      </AppErrorBoundary>,
+    );
+    expect(logError).toHaveBeenCalledWith(expect.stringContaining('log-me'));
   });
 
   it('5. non-throwing children render normally', () => {

--- a/apps/desktop/src/app/AppErrorBoundary.tsx
+++ b/apps/desktop/src/app/AppErrorBoundary.tsx
@@ -17,6 +17,7 @@
 import { Component } from 'react';
 import type { ReactNode, ErrorInfo } from 'react';
 import { m } from '@/lib/i18n';
+import { logError } from '@/lib/diagnosticLog';
 
 interface Props {
   children: ReactNode;
@@ -45,6 +46,9 @@ export class AppErrorBoundary extends Component<Props, State> {
       '[AppErrorBoundary] Uncaught render error:',
       error,
       info.componentStack,
+    );
+    logError(
+      `[AppErrorBoundary] ${error.name}: ${error.message}${info.componentStack ?? ''}`,
     );
   }
 

--- a/apps/desktop/src/lib/diagnosticLog.test.ts
+++ b/apps/desktop/src/lib/diagnosticLog.test.ts
@@ -1,0 +1,34 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * diagnosticLog tests.
+ *
+ * isTauri() returns false in vitest (no window.__TAURI_INTERNALS__ set),
+ * so logError/logWarn must be no-ops — the plugin must never be invoked.
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+
+vi.mock('@tauri-apps/plugin-log', () => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+}));
+
+import { logError, logWarn } from './diagnosticLog';
+
+describe('diagnosticLog', () => {
+  it('logError is a no-op outside Tauri (isTauri()=false in vitest)', async () => {
+    const { error } = await import('@tauri-apps/plugin-log');
+    logError('test error');
+    await Promise.resolve();
+    expect(error).not.toHaveBeenCalled();
+  });
+
+  it('logWarn is a no-op outside Tauri', async () => {
+    const { warn } = await import('@tauri-apps/plugin-log');
+    logWarn('test warn');
+    await Promise.resolve();
+    expect(warn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/lib/diagnosticLog.ts
+++ b/apps/desktop/src/lib/diagnosticLog.ts
@@ -1,0 +1,33 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Forward frontend errors to the Rust rotating diagnostics log (spec 051 US7).
+ *
+ * @tauri-apps/plugin-log routes through the ambient tracing subscriber
+ * (tracing-appender) since the backend installs the plugin with skip_logger().
+ * No-op in non-Tauri environments (vitest, browser dev, mock mode).
+ *
+ * isTauri() is evaluated once at module load so subsequent calls are
+ * synchronous guards — consistent with window.ts T008 pattern.
+ */
+
+import { isTauri } from '@tauri-apps/api/core';
+
+const IN_TAURI = isTauri();
+
+/** Forward an error-level message to the rotating diagnostics log. */
+export function logError(message: string): void {
+  if (!IN_TAURI) return;
+  void import('@tauri-apps/plugin-log')
+    .then(({ error }) => error(message))
+    .catch(() => {});
+}
+
+/** Forward a warn-level message to the rotating diagnostics log. */
+export function logWarn(message: string): void {
+  if (!IN_TAURI) return;
+  void import('@tauri-apps/plugin-log')
+    .then(({ warn }) => warn(message))
+    .catch(() => {});
+}

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -14,6 +14,7 @@ import { queryClient } from './data/queryClient';
 import { initAppearance, hydrateThemeFromSettings } from './data/theme';
 import { hydrateScope } from './data/persisted-state';
 import { registerLocaleStrategy, LocaleProvider } from './data/locale';
+import { logError } from './lib/diagnosticLog';
 
 // Register the `custom-almSettings` strategy before the first render, so the
 // very first `getLocale()` already consults the stored choice. Without this
@@ -112,6 +113,18 @@ const unsubscribeBootReady = router.subscribe('onRendered', () => {
   void import('@tauri-apps/api/event').then(({ emit }) =>
     emit('app:boot-ready').catch(() => {}),
   );
+});
+
+// Forward uncaught errors to the rotating diagnostics log for crash forensics.
+// logError() is a no-op outside a Tauri host — safe in all non-production envs.
+// Parallel to (not replacing) the VITE_E2E buffer above.
+window.addEventListener('error', (event) => {
+  logError(
+    `[window.onerror] ${event.message} at ${event.filename}:${event.lineno}`,
+  );
+});
+window.addEventListener('unhandledrejection', (event) => {
+  logError(`[unhandledrejection] ${String(event.reason)}`);
 });
 
 const root = document.getElementById('root');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,9 @@ importers:
       '@tauri-apps/plugin-dialog':
         specifier: ^2.7.1
         version: 2.7.1
+      '@tauri-apps/plugin-log':
+        specifier: ^2.9.0
+        version: 2.9.0
       '@tauri-apps/plugin-opener':
         specifier: ^2.5.4
         version: 2.5.4
@@ -1959,6 +1962,9 @@ packages:
 
   '@tauri-apps/plugin-dialog@2.7.1':
     resolution: {integrity: sha512-OK1UBXYt+ojcmxMktzzuyonYIFta8CmAASpX+CA+DTGK24KlHjhYI6x2iOJ/TjZF4N7/ACK1oFmEOjIY9IhzOQ==}
+
+  '@tauri-apps/plugin-log@2.9.0':
+    resolution: {integrity: sha512-Ql8okrnsguk0eDq1GvRfttFV5KaeW/7vcao6bdbkXCRJ1+2sWE15ZJvJVEKVANrOKy1mRngqC3IFIAP+wP5qSw==}
 
   '@tauri-apps/plugin-opener@2.5.4':
     resolution: {integrity: sha512-1HnPkb+AmgO29HBazm4uPLKB+r7zzcTBW1d0fyYp1uP+jwtpoiNDGKMMzz58SFp49nOIrxdE3aUJtT57lfO9CQ==}
@@ -5777,6 +5783,10 @@ snapshots:
       '@tauri-apps/cli-win32-x64-msvc': 2.11.4
 
   '@tauri-apps/plugin-dialog@2.7.1':
+    dependencies:
+      '@tauri-apps/api': 2.11.1
+
+  '@tauri-apps/plugin-log@2.9.0':
     dependencies:
       '@tauri-apps/api': 2.11.1
 


### PR DESCRIPTION
## Summary
- Uncaught JavaScript errors, unhandled promise rejections, and React render errors are now forwarded to the rotating diagnostics log alongside Rust-side entries
- No-op outside a Tauri host (browser dev, vitest, E2E mock mode) — no behaviour change in non-desktop environments

## Spec Context
Spec 051 US7.

Tracks-Bead: astro-plan-kyo7.31
Merge-Bead: astro-plan-r5v5