### PR TITLE
chore: drop duplicate reqwest by upgrading simbad-resolver to 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2660,7 +2660,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -4799,44 +4798,6 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64 0.22.1",
- "bytes",
- "futures-core",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -4862,6 +4823,7 @@ dependencies = [
  "rustls-platform-verifier",
  "serde",
  "serde_json",
+ "serde_urlencoded",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -5239,7 +5201,7 @@ name = "seed-builder"
 version = "0.1.0"
 dependencies = [
  "domain_core",
- "reqwest 0.13.4",
+ "reqwest",
  "serde_json",
  "targeting_resolver",
 ]
@@ -5543,13 +5505,13 @@ dependencies = [
 
 [[package]]
 name = "simbad-resolver"
-version = "0.4.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d402bb4990100903c7b8d4695c80281ae0c1bff4d388869877db45c7efd098a"
+checksum = "19f3c4fbbf054a7f0c07b4658750b296f33afcc86bca69c3b62810764fc3fac3"
 dependencies = [
  "async-trait",
  "redb",
- "reqwest 0.12.28",
+ "reqwest",
  "serde",
  "serde_json",
  "skymath 0.6.0",
@@ -6257,7 +6219,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",
@@ -6513,7 +6475,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest 0.13.4",
+ "reqwest",
  "rustls",
  "semver",
  "serde",
@@ -6736,7 +6698,7 @@ dependencies = [
  "http",
  "indexmap 2.14.0",
  "pastey",
- "reqwest 0.13.4",
+ "reqwest",
  "serde",
  "serde_json",
  "serde_repr",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ audit = { path = "../../../crates/audit" }
 targeting_resolver = { path = "../../../crates/targeting/resolver" }
 # spec 052 P1: AppState owns the shared redb resolve-cache handle directly
 # (Cache trait for .cache()/search, identity::namespace for warming).
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 # target.astro_format.batch: sexagesimal RA/Dec formatting (adopt target-match).
 targeting = { path = "../../../crates/targeting" }
 # target.moon_opposition.batch (#634): geocentric Sun/Moon position

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -36,7 +36,7 @@ workflow_artifacts = { path = "../../workflow/artifacts" }
 workflow_profiles = { path = "../../workflow/profiles" }
 # spec 052 P1: project_create::create threads the shared redb resolve cache
 # through to app_core_projects::project_setup::create for in-use promotion.
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 # In-memory caching layer (F0 foundation).
 app_core_cache = { path = "../cache" }
 camino = { workspace = true }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -42,7 +42,7 @@ target-match = "0.5.1"
 # own `ResolvedIdentity` (otype_raw/common_name/aliases, OQ-1/OQ-2 ranking
 # inputs) and `PositionResolver` types directly — mirrors the existing
 # `app_core_targets` precedent (see that crate's Cargo.toml comment).
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 time = { workspace = true }
 tokio.workspace = true
 tracing = { workspace = true }

--- a/crates/app/projects/Cargo.toml
+++ b/crates/app/projects/Cargo.toml
@@ -31,7 +31,7 @@ project_structure = { path = "../../project/structure" }
 # #1218: source snapshots read the session key, whose format this crate owns.
 sessions = { path = "../../sessions" }
 sha2.workspace = true
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 workflow_profiles = { path = "../../workflow/profiles" }
 serde_json.workspace = true
 sqlx.workspace = true

--- a/crates/app/targets/Cargo.toml
+++ b/crates/app/targets/Cargo.toml
@@ -25,7 +25,7 @@ targeting_resolver = { path = "../../targeting/resolver" }
 # spec 052 P1: `target.search` reads the shared redb resolve cache directly
 # (`simbad_resolver::Cache`), and in-use promotion touches the crate's own
 # `ResolvedIdentity`/`Cache` types at the app-layer commit points.
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 serde_json.workspace = true
 sqlx.workspace = true
 time = { workspace = true }

--- a/crates/e2e-tests/Cargo.toml
+++ b/crates/e2e-tests/Cargo.toml
@@ -28,4 +28,4 @@ uuid = { workspace = true }
 # Pre-warm the resolve cache once per shard to eliminate the 13k-row seed
 # load from every individual E2E app boot (bead astro-plan-v84u).
 targeting_resolver = { path = "../targeting/resolver" }
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -31,7 +31,7 @@ path = "src/lib.rs"
 target-match = "0.5.1"
 skymath = "0.6.0"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 
 [lints]
 workspace = true

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -47,7 +47,7 @@ persistence_targets = { path = "../../persistence/targets" }
 # Published SIMBAD TAP client + Caldwell map + normalize/fuzzy helpers + the
 # cache-first facade (see crate doc above). Same author/org as this
 # workspace's own CI app.
-simbad-resolver = "0.4.0"
+simbad-resolver = "0.5.0"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
 skymath = "0.6.0"
@@ -62,7 +62,7 @@ tokio = { workspace = true }
 # drop-and-rebuild pointed at the same redb file — astro-plan's production
 # `simbad::SimbadResolver` wrapper only ever builds a real `TapResolver`, so
 # this test constructs the crate's facade directly.
-simbad-resolver = { version = "0.4.0", features = ["test-util"] }
+simbad-resolver = { version = "0.5.0", features = ["test-util"] }
 tempfile = { workspace = true }
 
 [features]


### PR DESCRIPTION
Bumps 6 simbad-resolver pins 0.4.0->0.5.0; cargo tree confirms single reqwest 0.13.4 (0.12 stack removed). No call-site changes.

Tracks-Bead: astro-plan-t4ga
Merge-Bead: astro-plan-2ptz