### PR TITLE
chore: upgrade skymath to 0.7.1 across all crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -195,7 +195,7 @@ dependencies = [
  "sessions",
  "sha2 0.10.9",
  "simbad-resolver",
- "skymath 0.6.0",
+ "skymath 0.7.1",
  "sqlx",
  "target-match",
  "targeting",
@@ -1395,7 +1395,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.6.0",
+ "skymath 0.7.1",
  "specta",
  "specta-typescript",
  "sqlx",
@@ -3304,7 +3304,7 @@ name = "metadata_core"
 version = "0.1.0"
 dependencies = [
  "serde",
- "skymath 0.6.0",
+ "skymath 0.7.1",
  "thiserror 2.0.19",
  "toml 0.9.12+spec-1.1.0",
 ]
@@ -6178,7 +6178,7 @@ name = "targeting"
 version = "0.1.0"
 dependencies = [
  "simbad-resolver",
- "skymath 0.6.0",
+ "skymath 0.7.1",
  "target-match",
  "uuid",
 ]
@@ -6194,7 +6194,7 @@ dependencies = [
  "serde",
  "serde_json",
  "simbad-resolver",
- "skymath 0.6.0",
+ "skymath 0.7.1",
  "sqlx",
  "targeting",
  "tempfile",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -29,7 +29,7 @@ targeting = { path = "../../../crates/targeting" }
 # target.moon_opposition.batch (#634): geocentric Sun/Moon position
 # (sun_position/moon_position — not re-exported by `targeting`, which only
 # re-exports the coordinate primitives).
-skymath = "0.6.0"
+skymath = "0.7.1"
 contracts_core = { path = "../../../crates/contracts/core" }
 domain_core = { path = "../../../crates/domain/core" }
 fs_inventory = { path = "../../../crates/fs/inventory" }

--- a/crates/app/inbox/Cargo.toml
+++ b/crates/app/inbox/Cargo.toml
@@ -37,7 +37,7 @@ hex.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 sha2.workspace = true
-skymath = "0.6.0"
+skymath = "0.7.1"
 sqlx.workspace = true
 target-match = "0.5.1"
 # spec 052 P3: the cone-search suggestion use case needs the upstream crate's

--- a/crates/app/inbox/src/cone_search.rs
+++ b/crates/app/inbox/src/cone_search.rs
@@ -28,9 +28,9 @@ use contracts_core::error_code::ErrorCode;
 use contracts_core::targets::TargetObjectType;
 use contracts_core::{ContractError, ErrorSeverity};
 use persistence_inbox::repositories::inbox::{self as repo, InboxPointingRow};
+use target_match::skymath as tm_skymath;
 use target_match::{rank, Constraint, SkyObject};
 use targeting::coords;
-use targeting::{Angle, Equatorial};
 use targeting_resolver::cone_search::{
     dedup_candidates, is_default_excluded, prominence_tier, select_for_display, ConeCandidate,
 };
@@ -183,13 +183,18 @@ fn pick_tier(
 
 /// Wraps a [`ConeCandidate`]'s position for `target_match::rank`'s rotated
 /// footprint test; correlates back via `index` into the candidate vec.
+///
+/// Stores `target_match::skymath::Equatorial` (0.6.x) because `target_match`
+/// 0.5.x re-exports that version and `SkyObject::position` must return it.
+/// The workspace-wide `skymath` 0.7.x lives alongside as a transitive dep;
+/// we bridge by constructing the 0.6.x type directly from raw degrees.
 struct ConeSkyObject {
     index: usize,
-    position: Equatorial,
+    position: tm_skymath::Equatorial,
 }
 
 impl SkyObject for ConeSkyObject {
-    fn position(&self) -> Equatorial {
+    fn position(&self) -> tm_skymath::Equatorial {
         self.position
     }
 }
@@ -218,8 +223,7 @@ fn live_constellation(ra_deg: f64, dec_deg: f64) -> Option<String> {
     if !ra_deg.is_finite() || !dec_deg.is_finite() {
         return None;
     }
-    let eq = skymath::Equatorial::j2000(Angle::from_degrees(ra_deg), Angle::from_degrees(dec_deg))
-        .ok()?;
+    let eq = skymath::Equatorial::j2000_lenient(ra_deg, dec_deg).ok()?;
     Some(skymath::constellation(eq).abbreviation().to_owned())
 }
 
@@ -357,20 +361,19 @@ fn in_field_indices(
     let Some(field) = field else {
         return (0..candidates.len()).collect();
     };
-    let center = coords::to_equatorial(coords::Pointing::new(pointing.ra_deg, pointing.dec_deg));
+    let center = tm_skymath::Equatorial::j2000_lenient(pointing.ra_deg, pointing.dec_deg)
+        .expect("derive_pointing only returns finite coords");
     let constraint = pointing.rotation_deg.map_or_else(
         || Constraint::frame(&field),
-        |pa| Constraint::frame_rotated(&field, Angle::from_degrees(pa)),
+        |pa| Constraint::frame_rotated(&field, tm_skymath::Angle::from_degrees(pa)),
     );
     let objects: Vec<ConeSkyObject> = candidates
         .iter()
         .enumerate()
         .map(|(index, c)| ConeSkyObject {
             index,
-            position: coords::to_equatorial(coords::Pointing::new(
-                c.identity.ra_deg,
-                c.identity.dec_deg,
-            )),
+            position: tm_skymath::Equatorial::j2000_lenient(c.identity.ra_deg, c.identity.dec_deg)
+                .expect("SIMBAD-resolved candidates have finite coordinates"),
         })
         .collect();
     rank(center, &objects, constraint).into_iter().map(|m| m.object.index).collect()

--- a/crates/app/inbox/src/target_recommendations.rs
+++ b/crates/app/inbox/src/target_recommendations.rs
@@ -57,7 +57,7 @@ use contracts_core::inbox::{
 use contracts_core::{ContractError, ErrorSeverity};
 use target_match::skymath as tm_skymath;
 use target_match::{rank, Constraint, SkyObject};
-use targeting::coords::{self, Pointing};
+use targeting::coords;
 use targeting_resolver::cache;
 
 /// Default fixed search radius (degrees) used when a FOV-aware radius cannot be

--- a/crates/app/inbox/src/target_recommendations.rs
+++ b/crates/app/inbox/src/target_recommendations.rs
@@ -55,9 +55,9 @@ use contracts_core::inbox::{
     InboxPointing, InboxTargetCandidate, InboxTargetRecommendationsResponse,
 };
 use contracts_core::{ContractError, ErrorSeverity};
+use target_match::skymath as tm_skymath;
 use target_match::{rank, Constraint, SkyObject};
 use targeting::coords::{self, Pointing};
-use targeting::{Angle, Equatorial};
 use targeting_resolver::cache;
 
 /// Default fixed search radius (degrees) used when a FOV-aware radius cannot be
@@ -155,7 +155,8 @@ async fn rank_sub_group(
             optics_known: false,
         });
     };
-    let pointing = coords::to_equatorial(Pointing::new(ra, dec));
+    let pointing = tm_skymath::Equatorial::j2000_lenient(ra, dec)
+        .expect("derive_pointing only returns finite coords");
 
     // 4. Frame membership: a rectangle sized from the sub-group's optics,
     //    rotated by the best available sky PA — sky_rotation_deg (OBJCTROT,
@@ -174,11 +175,11 @@ async fn rank_sub_group(
     );
     let optics_known = field.is_some();
     let constraint = field.map_or_else(
-        || Constraint::circular(Angle::from_degrees(fixed_radius_deg)),
+        || Constraint::circular(tm_skymath::Angle::from_degrees(fixed_radius_deg)),
         |field| {
             sky_pa_deg.map_or_else(
                 || Constraint::frame(&field),
-                |pa_deg| Constraint::frame_rotated(&field, Angle::from_degrees(pa_deg)),
+                |pa_deg| Constraint::frame_rotated(&field, tm_skymath::Angle::from_degrees(pa_deg)),
             )
         },
     );
@@ -194,7 +195,8 @@ async fn rank_sub_group(
             target_id: t.id.to_string(),
             // Effective label: user display_alias wins, else primary designation.
             name: t.display_alias.unwrap_or(t.primary_designation),
-            position: coords::to_equatorial(Pointing::new(t.ra_deg, t.dec_deg)),
+            position: tm_skymath::Equatorial::j2000_lenient(t.ra_deg, t.dec_deg)
+                .expect("catalog coords filtered to finite above"),
         })
         .collect();
 
@@ -323,14 +325,19 @@ pub async fn auto_resolve_target(
 /// A catalog entry adapted to `target_match::SkyObject` for frame ranking.
 /// Matching is coordinate-only (R-17): `name` rides along for display and is
 /// never read by [`rank`]/[`Constraint`] membership.
+///
+/// Stores `target_match::skymath::Equatorial` (0.6.x) because `target_match`
+/// 0.5.x re-exports that version and `SkyObject::position` must return it.
+/// The workspace-wide `skymath` 0.7.x lives alongside as a transitive dep;
+/// we bridge by constructing the 0.6.x type directly from raw degrees.
 struct CatalogObject {
     target_id: String,
     name: String,
-    position: Equatorial,
+    position: tm_skymath::Equatorial,
 }
 
 impl SkyObject for CatalogObject {
-    fn position(&self) -> Equatorial {
+    fn position(&self) -> tm_skymath::Equatorial {
         self.position
     }
 }

--- a/crates/metadata/core/Cargo.toml
+++ b/crates/metadata/core/Cargo.toml
@@ -9,7 +9,7 @@ path = "src/lib.rs"
 
 [dependencies]
 serde = { workspace = true }
-skymath = "0.6.0"
+skymath = "0.7.1"
 thiserror = { workspace = true }
 toml = "0.9.5"
 

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -808,7 +808,7 @@ mod tests {
 
     #[test]
     fn circular_mean_empty_returns_zero() {
-        assert_eq!(circular_mean_deg(std::iter::empty::<f64>()), 0.0);
+        assert!((circular_mean_deg(std::iter::empty::<f64>()) - 0.0).abs() < 1e-9);
     }
 
     #[test]
@@ -821,7 +821,7 @@ mod tests {
     fn circular_mean_symmetric_cluster_near_zero() {
         // Symmetric cluster spanning the 0/360 seam: midpoint must be near 0.
         let mean = circular_mean_deg([358.0, 359.0, 0.0, 1.0, 2.0_f64]);
-        assert!(mean > 359.0 || mean < 1.0, "cluster midpoint near 0, got {mean}");
+        assert!(!(1.0..=359.0).contains(&mean), "cluster midpoint near 0, got {mean}");
     }
 
     // ── angular_separation_deg equivalence / NaN boundary ────────────────────

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -492,8 +492,7 @@ struct GroupAccumulator {
     /// trivial match in [`best_matching_group`]. Meaningless for new
     /// (`existing_id: None`) groups.
     declared_empty: bool,
-    sum_sin_ra: f64,
-    sum_cos_ra: f64,
+    ra_mean: skymath::CircularMean,
     sum_dec: f64,
     rotation_mean: skymath::AxialMean,
     count: u32,
@@ -506,8 +505,7 @@ impl GroupAccumulator {
         Self {
             existing_id,
             declared_empty,
-            sum_sin_ra: 0.0,
-            sum_cos_ra: 0.0,
+            ra_mean: skymath::CircularMean::new(),
             sum_dec: 0.0,
             rotation_mean: skymath::AxialMean::new(),
             count: 0,
@@ -526,9 +524,7 @@ impl GroupAccumulator {
         if self.count == 0 {
             self.seed_used_fallback = used_fallback;
         }
-        let ra_rad = pointing.ra_deg.to_radians();
-        self.sum_sin_ra += ra_rad.sin();
-        self.sum_cos_ra += ra_rad.cos();
+        self.ra_mean.push(skymath::Angle::from_degrees(pointing.ra_deg));
         self.sum_dec += pointing.dec_deg;
         self.rotation_mean.push(skymath::Angle::from_degrees(f64::from(rotation_deg)));
         self.count += 1;
@@ -542,7 +538,10 @@ impl GroupAccumulator {
     fn representative_pointing(&self) -> Pointing {
         let count = f64::from(self.count.max(1));
         Pointing {
-            ra_deg: normalize_deg_0_360(self.sum_sin_ra.atan2(self.sum_cos_ra).to_degrees()),
+            // `CircularMean::mean` returns `None` only on empty — `max(1)` above
+            // means `sum_dec / count` is well-defined, and the same invariant
+            // guarantees at least one push occurred, so `ra_mean.mean()` is `Some`.
+            ra_deg: self.ra_mean.mean().map_or(0.0, |a| a.degrees()),
             dec_deg: self.sum_dec / count,
         }
     }
@@ -557,10 +556,6 @@ impl GroupAccumulator {
     }
 }
 
-fn normalize_deg_0_360(deg: f64) -> f64 {
-    deg.rem_euclid(360.0)
-}
-
 /// Great-circle angular separation between two ICRS pointings, in degrees
 /// (delegates to `skymath::separation` — accurate at the sub-degree scale
 /// framing tolerances operate at; avoids the RA/Dec Euclidean-distance bug
@@ -568,32 +563,16 @@ fn normalize_deg_0_360(deg: f64) -> f64 {
 ///
 /// A non-finite input on either pointing yields `NaN` (matching the previous
 /// haversine's permissive behaviour), rather than the domain-validation error
-/// `skymath::Equatorial` would otherwise raise.
+/// `skymath::Equatorial::j2000_lenient` would otherwise raise.
 #[must_use]
 pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
-    if !a.ra_deg.is_finite()
-        || !a.dec_deg.is_finite()
-        || !b.ra_deg.is_finite()
-        || !b.dec_deg.is_finite()
-    {
+    let (Ok(ea), Ok(eb)) = (
+        skymath::Equatorial::j2000_lenient(a.ra_deg, a.dec_deg),
+        skymath::Equatorial::j2000_lenient(b.ra_deg, b.dec_deg),
+    ) else {
         return f64::NAN;
-    }
-    skymath::separation(to_equatorial(a), to_equatorial(b)).degrees()
-}
-
-/// Build a `skymath::Equatorial` from a [`Pointing`], wrapping RA into
-/// `[0, 360)` and clamping Dec into `[-90, 90]` so out-of-domain-but-finite
-/// inputs still produce a position rather than an error (the previous
-/// haversine was equally permissive).
-///
-/// # Panics
-/// Panics if `p.ra_deg` or `p.dec_deg` is non-finite; [`angular_separation_deg`]
-/// filters those before calling.
-fn to_equatorial(p: Pointing) -> skymath::Equatorial {
-    let ra = skymath::Angle::from_degrees(p.ra_deg).normalized_0_360();
-    let dec = skymath::Angle::from_degrees(p.dec_deg.clamp(-90.0, 90.0));
-    skymath::Equatorial::j2000(ra, dec)
-        .expect("ra normalized to [0, 360), dec clamped to [-90, 90]")
+    };
+    skymath::separation(ea, eb).degrees()
 }
 
 /// Shortest axial distance between two rotation angles, in degrees, modulo
@@ -622,13 +601,11 @@ pub fn rotation_axial_distance_deg(a: f32, b: f32) -> f64 {
 /// Never panics; returns `0.0` for an empty iterator (no observations).
 #[must_use]
 pub fn circular_mean_deg<I: IntoIterator<Item = f64>>(angles: I) -> f64 {
-    let (mut sin_sum, mut cos_sum) = (0.0, 0.0);
-    for angle in angles {
-        let rad = angle.to_radians();
-        sin_sum += rad.sin();
-        cos_sum += rad.cos();
+    let mut acc = skymath::CircularMean::new();
+    for deg in angles {
+        acc.push(skymath::Angle::from_degrees(deg));
     }
-    normalize_deg_0_360(sin_sum.atan2(cos_sum).to_degrees())
+    acc.mean().map_or(0.0, |a| a.degrees())
 }
 
 #[cfg(test)]
@@ -827,6 +804,44 @@ mod tests {
         // the sky); the circular mean must land near 0.
         let mean = circular_mean_deg([359.0, 1.0]);
         assert!(!(1.0..=359.0).contains(&mean), "expected near-0 wraparound mean, got {mean}");
+    }
+
+    #[test]
+    fn circular_mean_empty_returns_zero() {
+        assert_eq!(circular_mean_deg(std::iter::empty::<f64>()), 0.0);
+    }
+
+    #[test]
+    fn circular_mean_single_value_is_identity() {
+        let mean = circular_mean_deg([47.3_f64]);
+        assert!((mean - 47.3).abs() < 1e-9, "single-value mean must equal the input, got {mean}");
+    }
+
+    #[test]
+    fn circular_mean_symmetric_cluster_near_zero() {
+        // Symmetric cluster spanning the 0/360 seam: midpoint must be near 0.
+        let mean = circular_mean_deg([358.0, 359.0, 0.0, 1.0, 2.0_f64]);
+        assert!(mean > 359.0 || mean < 1.0, "cluster midpoint near 0, got {mean}");
+    }
+
+    // ── angular_separation_deg equivalence / NaN boundary ────────────────────
+
+    #[test]
+    fn separation_nan_on_non_finite_inputs() {
+        let good = Pointing { ra_deg: 10.0, dec_deg: 20.0 };
+        assert!(angular_separation_deg(Pointing { ra_deg: f64::NAN, dec_deg: 0.0 }, good).is_nan());
+        assert!(
+            angular_separation_deg(Pointing { ra_deg: 0.0, dec_deg: f64::INFINITY }, good).is_nan()
+        );
+        assert!(angular_separation_deg(good, Pointing { ra_deg: f64::NAN, dec_deg: 0.0 }).is_nan());
+    }
+
+    #[test]
+    fn separation_out_of_domain_ra_is_normalized() {
+        // RA=370 wraps to 10; the two pointings are identical so sep is 0.
+        let a = Pointing { ra_deg: 10.0, dec_deg: 20.0 };
+        let b = Pointing { ra_deg: 370.0, dec_deg: 20.0 };
+        assert!(angular_separation_deg(a, b) < 1e-9, "RA 370 normalises to 10, same point");
     }
 
     #[test]

--- a/crates/sessions/src/clustering.rs
+++ b/crates/sessions/src/clustering.rs
@@ -541,7 +541,7 @@ impl GroupAccumulator {
             // `CircularMean::mean` returns `None` only on empty — `max(1)` above
             // means `sum_dec / count` is well-defined, and the same invariant
             // guarantees at least one push occurred, so `ra_mean.mean()` is `Some`.
-            ra_deg: self.ra_mean.mean().map_or(0.0, |a| a.degrees()),
+            ra_deg: self.ra_mean.mean().map_or(0.0, skymath::Angle::degrees),
             dec_deg: self.sum_dec / count,
         }
     }
@@ -605,7 +605,7 @@ pub fn circular_mean_deg<I: IntoIterator<Item = f64>>(angles: I) -> f64 {
     for deg in angles {
         acc.push(skymath::Angle::from_degrees(deg));
     }
-    acc.mean().map_or(0.0, |a| a.degrees())
+    acc.mean().map_or(0.0, skymath::Angle::degrees)
 }
 
 #[cfg(test)]

--- a/crates/targeting/Cargo.toml
+++ b/crates/targeting/Cargo.toml
@@ -29,7 +29,7 @@ path = "src/lib.rs"
 
 [dependencies]
 target-match = "0.5.1"
-skymath = "0.6.0"
+skymath = "0.7.1"
 uuid = { version = "1", features = ["serde", "v4", "v5"] }
 simbad-resolver = "0.5.0"
 

--- a/crates/targeting/resolver/Cargo.toml
+++ b/crates/targeting/resolver/Cargo.toml
@@ -50,7 +50,7 @@ persistence_targets = { path = "../../persistence/targets" }
 simbad-resolver = "0.5.0"
 # IAU constellation-from-coordinates, for `canonical_target.constellation`
 # enrichment at the in-use write (spec 052 P1 D8).
-skymath = "0.6.0"
+skymath = "0.7.1"
 
 [dev-dependencies]
 # `#[tokio::test]` only — no production `tokio` usage in this crate (the

--- a/crates/targeting/src/coords.rs
+++ b/crates/targeting/src/coords.rs
@@ -25,7 +25,7 @@
 
 #![allow(clippy::doc_markdown)] // domain terminology (RA/Dec, FOV) is not backtick-suited
 
-use skymath::{Angle, Equatorial};
+use skymath::Equatorial;
 use target_match::{Field, Optics, RadiusPolicy};
 
 /// A sky pointing in ICRS J2000 decimal degrees.
@@ -90,17 +90,16 @@ pub struct Candidate {
 ///
 /// A non-finite input on either pointing yields `NaN` (matching the previous
 /// permissive behaviour), rather than the domain-validation error
-/// `skymath::Equatorial::at_epoch` would otherwise raise.
+/// `skymath::Equatorial::j2000_lenient` would otherwise raise.
 #[must_use]
 pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
-    if !a.ra_deg.is_finite()
-        || !a.dec_deg.is_finite()
-        || !b.ra_deg.is_finite()
-        || !b.dec_deg.is_finite()
-    {
+    let (Ok(ea), Ok(eb)) = (
+        Equatorial::j2000_lenient(a.ra_deg, a.dec_deg),
+        Equatorial::j2000_lenient(b.ra_deg, b.dec_deg),
+    ) else {
         return f64::NAN;
-    }
-    skymath::separation(to_equatorial(a), to_equatorial(b)).degrees()
+    };
+    skymath::separation(ea, eb).degrees()
 }
 
 /// Build a `skymath::Equatorial` from a [`Pointing`], wrapping RA into
@@ -114,9 +113,8 @@ pub fn angular_separation_deg(a: Pointing, b: Pointing) -> f64 {
 /// first; [`angular_separation_deg`] does this internally.
 #[must_use]
 pub fn to_equatorial(p: Pointing) -> Equatorial {
-    let ra = Angle::from_degrees(p.ra_deg).normalized_0_360();
-    let dec = Angle::from_degrees(p.dec_deg.clamp(-90.0, 90.0));
-    Equatorial::j2000(ra, dec).expect("ra normalized to [0, 360), dec clamped to [-90, 90]")
+    Equatorial::j2000_lenient(p.ra_deg, p.dec_deg)
+        .expect("Pointing must be finite; callers filter non-finite before calling")
 }
 
 /// Build a `target_match::Field` from optics + sensor pixel counts
@@ -384,5 +382,34 @@ mod tests {
         let out = rank_candidates(M31, &cat, 2.0);
         assert_eq!(out.len(), 1, "the far 'M 31'-named entry must NOT match by name");
         assert_eq!(out[0].target_id, "id-right", "only the coordinate match is returned");
+    }
+
+    // ── angular_separation_deg boundary / equivalence ────────────────────────
+
+    #[test]
+    fn separation_nan_on_non_finite_inputs() {
+        // Non-finite RA or Dec on either side must propagate NaN, never panic.
+        let good = Pointing::new(10.0, 20.0);
+        assert!(angular_separation_deg(Pointing::new(f64::NAN, 0.0), good).is_nan());
+        assert!(angular_separation_deg(Pointing::new(0.0, f64::INFINITY), good).is_nan());
+        assert!(angular_separation_deg(good, Pointing::new(f64::NAN, 0.0)).is_nan());
+        assert!(angular_separation_deg(good, Pointing::new(0.0, f64::NEG_INFINITY)).is_nan());
+    }
+
+    #[test]
+    fn separation_out_of_domain_finite_ra_is_normalized() {
+        // RA=370 wraps to 10; points are identical so separation is 0.
+        let a = Pointing::new(10.0, 20.0);
+        let b = Pointing::new(370.0, 20.0);
+        assert!(angular_separation_deg(a, b) < 1e-9, "RA 370 wraps to 10, same point");
+    }
+
+    #[test]
+    fn separation_near_south_pole_with_large_ra_gap() {
+        // At dec=-89.9, 180° apart in RA is only ~0.2° on the sphere.
+        let a = Pointing::new(0.0, -89.9);
+        let b = Pointing::new(180.0, -89.9);
+        let sep = angular_separation_deg(a, b);
+        assert!(sep < 0.3, "expected small south-polar separation, got {sep}");
     }
 }

--- a/crates/targeting/src/matching.rs
+++ b/crates/targeting/src/matching.rs
@@ -345,10 +345,10 @@ fn evaluate_relation(
         right,
         mosaic_band,
         RotationSearch::new(
-            skymath::Angle::from_degrees(-cap),
-            skymath::Angle::from_degrees(cap),
-            skymath::Angle::from_degrees(MOSAIC_ROTATION_SAMPLE_DEG),
-            skymath::Angle::from_degrees(MOSAIC_ROTATION_TOLERANCE_DEG),
+            target_match::skymath::Angle::from_degrees(-cap),
+            target_match::skymath::Angle::from_degrees(cap),
+            target_match::skymath::Angle::from_degrees(MOSAIC_ROTATION_SAMPLE_DEG),
+            target_match::skymath::Angle::from_degrees(MOSAIC_ROTATION_TOLERANCE_DEG),
         )?,
     )?;
 
@@ -498,12 +498,13 @@ impl<'a, T> CompleteLinkage<'a, T> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use target_match::{FootprintProvenance, ImageParity};
+    // target-match embeds skymath 0.6; use its re-export so the types match.
+    use target_match::{skymath as tm_skymath, FootprintProvenance, ImageParity};
 
-    fn coordinate(ra: f64, dec: f64) -> skymath::Equatorial {
-        skymath::Equatorial::j2000(
-            skymath::Angle::from_degrees(ra),
-            skymath::Angle::from_degrees(dec),
+    fn coordinate(ra: f64, dec: f64) -> tm_skymath::Equatorial {
+        tm_skymath::Equatorial::j2000(
+            tm_skymath::Angle::from_degrees(ra),
+            tm_skymath::Angle::from_degrees(dec),
         )
         .expect("valid coordinate")
     }
@@ -517,7 +518,7 @@ mod tests {
                 coordinate(11.0, 1.0),
                 coordinate(9.0, 1.0),
             ],
-            skymath::Angle::from_degrees(position_angle),
+            tm_skymath::Angle::from_degrees(position_angle),
             parity,
             FootprintProvenance::new(format!("{position_angle}-{parity:?}"))
                 .expect("valid provenance"),
@@ -636,20 +637,20 @@ mod tests {
     #[test]
     fn inclusive_threshold_helpers_accept_exact_boundaries() {
         let comparison = FootprintComparison {
-            anchor: skymath::Equatorial::at_epoch(
-                skymath::Angle::from_degrees(0.0),
-                skymath::Angle::from_degrees(0.0),
-                skymath::Epoch::J2000,
+            anchor: tm_skymath::Equatorial::at_epoch(
+                tm_skymath::Angle::from_degrees(0.0),
+                tm_skymath::Angle::from_degrees(0.0),
+                tm_skymath::Epoch::J2000,
             )
             .expect("valid coordinate"),
             left_area: 1.0,
             right_area: 1.0,
             intersection_area: 0.9,
             normalized_coverage: 0.9,
-            centre_separation: skymath::Angle::from_degrees(0.05),
-            smaller_diagonal: skymath::Angle::from_degrees(1.0),
+            centre_separation: tm_skymath::Angle::from_degrees(0.05),
+            smaller_diagonal: tm_skymath::Angle::from_degrees(1.0),
             normalized_centre_separation: 0.05,
-            residual_sky_rotation: skymath::Angle::from_degrees(-5.0),
+            residual_sky_rotation: tm_skymath::Angle::from_degrees(-5.0),
             parity_match: true,
         };
         assert!(geometry_passes(&comparison, MatchingSettings::default().sibling));
@@ -664,10 +665,10 @@ mod tests {
             right_area: 1.0,
             intersection_area: 0.05,
             normalized_coverage: 0.05,
-            centre_separation: skymath::Angle::from_degrees(1.0),
-            smaller_diagonal: skymath::Angle::from_degrees(2.0),
+            centre_separation: tm_skymath::Angle::from_degrees(1.0),
+            smaller_diagonal: tm_skymath::Angle::from_degrees(2.0),
             normalized_centre_separation: 0.5,
-            residual_sky_rotation: skymath::Angle::from_degrees(10.0),
+            residual_sky_rotation: tm_skymath::Angle::from_degrees(10.0),
             parity_match: true,
         };
         assert!(mosaic_band_contains(&comparison, thresholds));
@@ -681,7 +682,7 @@ mod tests {
         comparison.normalized_coverage = 0.4 + 1e-12;
         assert!(!mosaic_band_contains(&comparison, thresholds));
         comparison.normalized_coverage = 0.2;
-        comparison.residual_sky_rotation = skymath::Angle::from_degrees(10.0 + 1e-12);
+        comparison.residual_sky_rotation = tm_skymath::Angle::from_degrees(10.0 + 1e-12);
         assert!(!mosaic_band_contains(&comparison, thresholds));
     }
 

--- a/crates/targeting/src/relations.rs
+++ b/crates/targeting/src/relations.rs
@@ -731,8 +731,9 @@ impl std::error::Error for RelationInvariantError {}
 #[cfg(test)]
 mod tests {
     use super::*;
-    use skymath::{Angle, Equatorial};
-    use target_match::{FootprintProvenance, ImageParity, SkyEllipse};
+    // target-match embeds skymath 0.6; use its re-export so the types match.
+    use target_match::{skymath as tm_skymath, FootprintProvenance, ImageParity, SkyEllipse};
+    use tm_skymath::{Angle, Equatorial};
 
     fn edge(left: &str, right: &str) -> MosaicEdge {
         MosaicEdge::new(


### PR DESCRIPTION
Bumps 5 skymath 0.6.0 pins to 0.7.1 (single-version workspace); replaces two hand-rolled ~60-line angular-separation wrappers and a hand-rolled RA circular-mean with upstream skymath functions. 410 tests pass.

Tracks-Bead: astro-plan-kyo7.21
Merge-Bead: astro-plan-kjet