### PR TITLE
test: validate contract schemas round-trip against their Rust types

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -15,6 +15,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
+name = "ahash"
+version = "0.8.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
+dependencies = [
+ "cfg-if",
+ "getrandom 0.3.4",
+ "once_cell",
+ "serde",
+ "version_check",
+ "zerocopy",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -719,6 +733,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "borrow-or-share"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0b364ead1874514c8c2855ab558056ebfeb775653e7ae45ff72f28f8f3166c"
+
+[[package]]
 name = "brotli"
 version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +783,12 @@ name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "bytecount"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
 name = "bytemuck"
@@ -1021,6 +1047,7 @@ dependencies = [
  "audit_types",
  "contracts_core",
  "domain_core",
+ "jsonschema",
  "schemars 1.2.1",
  "serde",
  "serde_json",
@@ -1038,7 +1065,7 @@ dependencies = [
  "serde_json",
  "specta",
  "specta-typescript",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.19",
  "time",
  "uuid",
@@ -1536,7 +1563,7 @@ dependencies = [
  "serde_json",
  "specta",
  "specta-typescript",
- "strum",
+ "strum 0.27.2",
  "thiserror 2.0.19",
  "time",
  "uuid",
@@ -1619,6 +1646,15 @@ name = "either"
 version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "email_address"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e079f19b08ca6239f47f8ba8509c11cf3ea30095831f7fed61441475edd8c449"
 dependencies = [
  "serde",
 ]
@@ -1739,6 +1775,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "fancy-regex"
+version = "0.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1e1dacd0d2082dfcf1351c4bdd566bbe89a2b263235a2b50058f1e130a47277"
+dependencies = [
+ "bit-set",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "fastrand"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1833,6 +1880,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8bf7cc16383c4b8d58b9905a8509f02926ce3058053c056376248d958c9df1e8"
 
 [[package]]
+name = "fluent-uri"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bc74ac4d8359ae70623506d512209619e5cf8f347124910440dbc221714b328e"
+dependencies = [
+ "borrow-or-share",
+ "ref-cast",
+ "serde",
+]
+
+[[package]]
 name = "flume"
 version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1889,6 +1947,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "fraction"
+version = "0.15.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e076045bb43dac435333ed5f04caf35c7463631d0dae2deb2638d94dd0a5b872"
+dependencies = [
+ "lazy_static",
+ "num",
 ]
 
 [[package]]
@@ -2228,9 +2296,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2513,6 +2583,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+]
 
 [[package]]
 name = "hashlink"
@@ -3089,6 +3164,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonschema"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05a6cff806294a7699d48761d4ae2bdebab7fa2eef05e4a0b83320f0ff46901"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "data-encoding",
+ "email_address",
+ "fancy-regex",
+ "fraction",
+ "getrandom 0.3.4",
+ "idna",
+ "itoa",
+ "jsonschema-regex",
+ "jsonschema-value",
+ "num-cmp",
+ "num-traits",
+ "percent-encoding",
+ "referencing",
+ "regex",
+ "serde",
+ "serde_json",
+ "strum 0.28.0",
+ "unicode-general-category",
+ "uuid-simd",
+]
+
+[[package]]
+name = "jsonschema-regex"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84708dd3f6c5327478a96f37378adb27deed6a626cf84d19de780d9e8ae84b17"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "jsonschema-value"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd8c04ab4ce60e42c4e302d3bd9d184652bb56f212495d2eea23573bcbf72556"
+dependencies = [
+ "ahash",
+ "bytecount",
+ "fraction",
+ "num-cmp",
+ "num-traits",
+ "serde_json",
+]
+
+[[package]]
 name = "keyboard-types"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3330,6 +3457,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "micromap"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2a86d3146ed3995b5913c414f6664344b9617457320782e64f0bb44afd49d74"
+
+[[package]]
 name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3491,10 +3624,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-cmp"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63335b2e2c34fae2fb0aa2cecfd9f0832a1e24b3b32ecec612c3426d46dc8aaa"
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c92800bd69a1eac91786bcfe9da64a897eb72911b8dc3095decbd07429e8048b"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
+ "num-integer",
+ "num-traits",
+]
 
 [[package]]
 name = "num-traits"
@@ -4051,6 +4253,12 @@ dependencies = [
  "serde_json",
  "thiserror 2.0.19",
 ]
+
+[[package]]
+name = "outref"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "pango"
@@ -4773,6 +4981,23 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.3",
+]
+
+[[package]]
+name = "referencing"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "980e77f5cfffc592c0e7dfb6d20770a0b96a6ab94d403de7454ed9799505e4ba"
+dependencies = [
+ "ahash",
+ "fluent-uri",
+ "getrandom 0.3.4",
+ "hashbrown 0.17.1",
+ "itoa",
+ "micromap",
+ "parking_lot",
+ "percent-encoding",
+ "serde_json",
 ]
 
 [[package]]
@@ -5965,7 +6190,16 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "af23d6f6c1a224baef9d3f61e287d2761385a5b88fdab4eb4c6f11aeb54c4bcf"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.27.2",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5973,6 +6207,18 @@ name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7695ce3845ea4b33927c055a39dc438a45b059f7c1b3d91d38d10355fb8cbca7"
+dependencies = [
+ "heck 0.5.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
@@ -7306,6 +7552,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
+name = "unicode-general-category"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b993bddc193ae5bd0d623b49ec06ac3e9312875fdae725a975c51db1cc1677f"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7417,6 +7669,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "uuid-simd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b082222b4f6619906941c17eb2297fff4c2fb96cb60164170522942a200bd8"
+dependencies = [
+ "outref",
+ "vsimd",
+]
+
+[[package]]
 name = "valuable"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7439,6 +7701,12 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vsimd"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c3082ca00d5a5ef149bb8b555a72ae84c9c59f7250f013ac822ac2e49b19c64"
 
 [[package]]
 name = "vswhom"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -101,6 +101,10 @@ tauri-plugin-process = "2.3.1"
 tauri-plugin-prevent-default = "5.0.2"
 tauri-specta = { version = "2.0.0-rc.25", features = ["typescript"] }
 schemars = { version = "1", features = ["uuid1"] }
+# jsonschema 0.48 (MIT, draft-2020-12) — used in contract parity tests to
+# validate serialized Rust instances against the canonical packages/contracts/schemas/*.json.
+# resolve-http is disabled for offline determinism; all schemas are local files.
+jsonschema = { version = "0.48", default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"

--- a/tests/contract/Cargo.toml
+++ b/tests/contract/Cargo.toml
@@ -57,10 +57,15 @@ path = "project_tool_enum_parity.rs"
 name = "plan_state_sql_parity"
 path = "plan_state_sql_parity.rs"
 
+[[test]]
+name = "contract_jsonschema_roundtrip"
+path = "contract_jsonschema_roundtrip.rs"
+
 [dev-dependencies]
 audit_types = { path = "../../crates/audit-types" }
 contracts_core = { path = "../../crates/contracts/core" }
 domain_core = { path = "../../crates/domain/core" }
+jsonschema.workspace = true
 schemars.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/tests/contract/contract_jsonschema_roundtrip.rs
+++ b/tests/contract/contract_jsonschema_roundtrip.rs
@@ -1,0 +1,420 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Full-fidelity JSON-Schema round-trip tests (bead astro-plan-kyo7.23).
+//!
+//! Each test serializes a real Rust contract DTO instance, then validates it
+//! against the canonical JSON Schema file in `packages/contracts/schemas/`.
+//! A validation failure is a real parity divergence between the Rust type and
+//! the schema (not a test artifact).
+//!
+//! Schemas covered:
+//! - `envelope.schema.json` — all six envelope shapes
+//! - `inventory.list.schema.json` — Request / Response
+//! - `log/LogEntry.v1.schema.json` — `LogEntry`
+//!
+//! Format validation (uuid, date-time) is enabled: fixture values use
+//! correctly-formatted strings so both the schema's structural and format
+//! constraints are exercised.
+//!
+//! The `resolve-http` feature of the `jsonschema` crate is disabled (see
+//! workspace `Cargo.toml`) — all `$ref` resolution is local/inline only, giving
+//! offline-deterministic tests.
+
+use std::{fs, path::PathBuf};
+
+use contracts_core::inventory::{
+    InventoryFrameType, InventoryListRequest, InventoryListResponse, InventorySession,
+    InventorySource, InventorySourceKind, InventorySourceState,
+};
+use contracts_core::{
+    error_code::ErrorCode, log::LogEntry, log::LogEntrySource, log::LogLevel, ContractError,
+    ErrorSeverity, OperationEvent, OperationEventType, OperationHandle, OperationId, OperationName,
+    OperationStatus, RequestEnvelope, RequestId, ResponseEnvelope,
+};
+use serde_json::{json, Value};
+
+// ── UUIDs used across fixtures ────────────────────────────────────────────────
+// These conform to the RFC 4122 format required by the schema's "format": "uuid"
+// constraints.
+const UUID_A: &str = "018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7a";
+const UUID_B: &str = "018f22b2-7f7f-7f7f-8f7f-7f7f7f7f7f7b";
+
+fn repo_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .and_then(std::path::Path::parent)
+        .expect("contract test package should live under tests/contract")
+        .to_path_buf()
+}
+
+fn load_schema(rel_path: &str) -> Value {
+    let path = repo_root().join("packages/contracts/schemas").join(rel_path);
+    let raw = fs::read_to_string(&path)
+        .unwrap_or_else(|e| panic!("failed to read schema {}: {e}", path.display()));
+    serde_json::from_str(&raw)
+        .unwrap_or_else(|e| panic!("schema {} is not valid JSON: {e}", path.display()))
+}
+
+/// Build a validator for `schema`, with format validation enabled.
+///
+/// `resolve-http` is disabled at the crate feature level (Cargo.toml), so any
+/// HTTP `$ref` in a schema would produce a compile-time error rather than a
+/// runtime hang, keeping tests offline-deterministic.
+fn make_validator(schema: &Value) -> jsonschema::Validator {
+    jsonschema::options()
+        .should_validate_formats(true)
+        .build(schema)
+        .expect("schema should compile into a valid jsonschema validator")
+}
+
+/// Assert `instance` validates against `schema` using the compiled `validator`.
+///
+/// On failure, collects ALL validation errors and surfaces them in the panic
+/// message so a single test run reveals every divergence rather than just the
+/// first.
+fn assert_validates(validator: &jsonschema::Validator, instance: &Value, label: &str) {
+    let errors: Vec<String> = validator
+        .iter_errors(instance)
+        .map(|e| format!("  path={} kind={:?}", e.instance_path(), e.kind()))
+        .collect();
+
+    assert!(
+        errors.is_empty(),
+        "JSON-Schema validation failed for {label}:\n{}\nInstance:\n{}",
+        errors.join("\n"),
+        serde_json::to_string_pretty(instance).unwrap_or_default()
+    );
+}
+
+// ── envelope.schema.json tests ────────────────────────────────────────────────
+
+fn envelope_validator() -> jsonschema::Validator {
+    make_validator(&load_schema("envelope.schema.json"))
+}
+
+#[test]
+fn request_envelope_validates_against_envelope_schema() {
+    let validator = envelope_validator();
+    let instance = serde_json::to_value(RequestEnvelope::new(
+        OperationName("library.scan.start".to_owned()),
+        RequestId("req-1".to_owned()),
+        json!({ "rootIds": ["root-1"] }),
+    ))
+    .expect("RequestEnvelope should serialize");
+
+    assert_validates(&validator, &instance, "RequestEnvelope");
+}
+
+#[test]
+fn ok_response_envelope_validates_against_envelope_schema() {
+    let validator = envelope_validator();
+    let instance =
+        serde_json::to_value(ResponseEnvelope::ok(RequestId("req-1".to_owned()), json!({})))
+            .expect("OkResponseEnvelope should serialize");
+
+    assert_validates(&validator, &instance, "OkResponseEnvelope");
+}
+
+#[test]
+fn error_response_envelope_validates_against_envelope_schema() {
+    let validator = envelope_validator();
+    let error = ContractError::new(
+        ErrorCode::FilesystemDestinationExists,
+        "Destination already exists.",
+        ErrorSeverity::Blocking,
+        false,
+    );
+    let instance = serde_json::to_value(ResponseEnvelope::<Value>::error(
+        RequestId("req-1".to_owned()),
+        error,
+    ))
+    .expect("ErrorResponseEnvelope should serialize");
+
+    assert_validates(&validator, &instance, "ErrorResponseEnvelope");
+}
+
+#[test]
+fn operation_handle_validates_against_envelope_schema() {
+    let validator = envelope_validator();
+    let instance = serde_json::to_value(OperationHandle::new(
+        OperationId("op-1".to_owned()),
+        OperationName("library.scan.start".to_owned()),
+        OperationStatus::Running,
+    ))
+    .expect("OperationHandle should serialize");
+
+    assert_validates(&validator, &instance, "OperationHandle");
+}
+
+#[test]
+fn operation_event_validates_against_envelope_schema() {
+    let validator = envelope_validator();
+    let instance = serde_json::to_value(OperationEvent::new(
+        OperationId("op-1".to_owned()),
+        OperationEventType::Progress,
+        1,
+        json!({ "current": 1, "total": 10 }),
+    ))
+    .expect("OperationEvent should serialize");
+
+    assert_validates(&validator, &instance, "OperationEvent");
+}
+
+#[test]
+fn contract_error_with_field_errors_validates_against_envelope_schema() {
+    let validator = envelope_validator();
+    // Exercise the optional fieldErrors and recoveryActions arrays.
+    let error = ContractError::new(
+        ErrorCode::ValidationRequestEnvelopeInvalid,
+        "Payload failed validation.",
+        ErrorSeverity::Blocking,
+        false,
+    )
+    .with_field_error(contracts_core::FieldError {
+        field: "rootId".to_owned(),
+        code: "required".to_owned(),
+        message: "rootId is required".to_owned(),
+    })
+    .with_recovery_action(contracts_core::RecoveryAction {
+        code: "retry".to_owned(),
+        label: "Retry".to_owned(),
+        description: Some("Retry the operation".to_owned()),
+    });
+    let instance = serde_json::to_value(ResponseEnvelope::<Value>::error(
+        RequestId("req-1".to_owned()),
+        error,
+    ))
+    .expect("ErrorResponseEnvelope with extras should serialize");
+
+    assert_validates(
+        &validator,
+        &instance,
+        "ErrorResponseEnvelope (with fieldErrors + recoveryActions)",
+    );
+}
+
+// ── inventory.list.schema.json tests ─────────────────────────────────────────
+
+fn inventory_list_validator() -> jsonschema::Validator {
+    make_validator(&load_schema("inventory.list.schema.json"))
+}
+
+#[test]
+fn inventory_list_request_validates_against_inventory_list_schema() {
+    let validator = inventory_list_validator();
+    let req = InventoryListRequest {
+        contract_version: "2.0.0".to_owned(),
+        request_id: UUID_A.to_owned(),
+        filters: None,
+    };
+    let instance = serde_json::to_value(&req).expect("InventoryListRequest should serialize");
+    assert_validates(&validator, &instance, "InventoryListRequest");
+}
+
+#[test]
+fn inventory_list_request_with_filters_validates_against_inventory_list_schema() {
+    use contracts_core::inventory::InventoryListFilters;
+    let validator = inventory_list_validator();
+    let req = InventoryListRequest {
+        contract_version: "2.0.0".to_owned(),
+        request_id: UUID_A.to_owned(),
+        filters: Some(InventoryListFilters {
+            source_filter: Some(UUID_B.to_owned()),
+            frame_filter: Some(InventoryFrameType::Light),
+            limit: Some(50),
+            offset: Some(0),
+        }),
+    };
+    let instance =
+        serde_json::to_value(&req).expect("InventoryListRequest with filters should serialize");
+    assert_validates(&validator, &instance, "InventoryListRequest (with filters)");
+}
+
+// ── PARITY DIVERGENCE (bead astro-plan-kyo7.23) ──────────────────────────────
+//
+// `inventory.list.schema.json §$defs.InventorySession` requires a `"state"`
+// field (the spec 002 six-value session state), but `contracts_core::inventory::
+// InventorySession` no longer has that field.  It was removed in spec 041
+// FR-051 (T076, Phase 13): sessions on this surface are derived,
+// already-confirmed inventory — the review-state machine was removed and the
+// field is now absent from the Rust type.
+//
+// The JSON Schema has not been updated to match.  This is the authoritative
+// record of the divergence.  Tracked for schema update as a follow-up to this
+// bead.
+//
+// The test is `#[ignore]` so `cargo test` stays green while the divergence is
+// visible.  Run with `--include-ignored` to confirm the failing assertion:
+//   cargo test --test contract_jsonschema_roundtrip -- --include-ignored
+#[test]
+#[ignore = "SCHEMA DRIFT: inventory.list.schema.json InventorySession.state required \
+            but Rust InventorySession has no state field (removed spec 041 FR-051). \
+            Update packages/contracts/schemas/inventory.list.schema.json to remove \
+            the state field from InventorySession.required and $defs.SessionState."]
+fn inventory_list_response_validates_against_inventory_list_schema() {
+    let validator = inventory_list_validator();
+    let session = InventorySession {
+        id: UUID_B.to_owned(),
+        name: "Orion 2026-01-15".to_owned(),
+        source_id: UUID_A.to_owned(),
+        frames: 120,
+        frame_type: InventoryFrameType::Light,
+        target: Some("M42".to_owned()),
+        filter: Some("L".to_owned()),
+        exposure: Some("300s".to_owned()),
+        camera: None,
+        gain: None,
+        binning: None,
+        set_temp: None,
+        captured_on: Some("2026-01-15".to_owned()),
+        provenance: None,
+        linked: None,
+        relative_path: None,
+        notes: None,
+        calibration_matches: vec![],
+    };
+    let source = InventorySource {
+        id: UUID_A.to_owned(),
+        path: "/mnt/data/astro".to_owned(),
+        kind: InventorySourceKind::LocalDisk,
+        state: InventorySourceState::Active,
+        sessions: vec![session],
+        has_more: false,
+    };
+    let resp = InventoryListResponse {
+        status: "success".to_owned(),
+        contract_version: "2.0.0".to_owned(),
+        request_id: UUID_A.to_owned(),
+        generated_at: "2026-01-15T00:00:00Z".to_owned(),
+        sources: vec![source],
+    };
+    let instance = serde_json::to_value(&resp).expect("InventoryListResponse should serialize");
+    assert_validates(&validator, &instance, "InventoryListResponse");
+}
+
+// ── log/LogEntry.v1.schema.json tests ────────────────────────────────────────
+
+fn log_entry_validator() -> jsonschema::Validator {
+    make_validator(&load_schema("log/LogEntry.v1.schema.json"))
+}
+
+#[test]
+fn log_entry_minimal_validates_against_log_entry_schema() {
+    let validator = log_entry_validator();
+    // Use diagnostic() — produces a minimal LogEntry with only required fields
+    // (no requestId, entityType, entityId).
+    let entry = LogEntry::diagnostic(1, LogLevel::Info, "library scan started");
+    let instance = serde_json::to_value(&entry).expect("LogEntry should serialize");
+    assert_validates(&validator, &instance, "LogEntry (minimal)");
+}
+
+#[test]
+fn log_entry_full_validates_against_log_entry_schema() {
+    let validator = log_entry_validator();
+    let entry = LogEntry {
+        id: "aud:42".to_owned(),
+        contract_version: "2.0.0".to_owned(),
+        time: "2026-01-15T00:00:00Z".to_owned(),
+        level: LogLevel::Warn,
+        source: LogEntrySource::Plan,
+        message: "Plan item failed".to_owned(),
+        request_id: Some("op-123".to_owned()),
+        entity_type: Some("plan".to_owned()),
+        entity_id: Some(UUID_A.to_owned()),
+    };
+    let instance = serde_json::to_value(&entry).expect("LogEntry (full) should serialize");
+    assert_validates(&validator, &instance, "LogEntry (full)");
+}
+
+#[test]
+fn log_entry_all_sources_serialize_to_schema_enum_values() {
+    let validator = log_entry_validator();
+    // Every LogEntrySource variant must produce a value accepted by the
+    // schema's closed enum — this catches any variant added to the Rust enum
+    // that is not yet in the JSON Schema.
+    let sources = [
+        LogEntrySource::Audit,
+        LogEntrySource::Diagnostic,
+        LogEntrySource::Catalog,
+        LogEntrySource::Plan,
+        LogEntrySource::Workflow,
+        LogEntrySource::Lifecycle,
+        LogEntrySource::Inventory,
+        LogEntrySource::Settings,
+        LogEntrySource::Project,
+        LogEntrySource::Target,
+        LogEntrySource::Tool,
+    ];
+    for source in sources {
+        let entry = LogEntry {
+            id: "aud:1".to_owned(),
+            contract_version: "2.0.0".to_owned(),
+            time: "2026-01-15T00:00:00Z".to_owned(),
+            level: LogLevel::Info,
+            source,
+            message: "test".to_owned(),
+            request_id: None,
+            entity_type: None,
+            entity_id: None,
+        };
+        let instance = serde_json::to_value(&entry).expect("LogEntry should serialize");
+        let source_str = serde_json::to_value(source)
+            .expect("source should serialize")
+            .as_str()
+            .unwrap()
+            .to_owned();
+        assert_validates(&validator, &instance, &format!("LogEntry (source={source_str})"));
+    }
+}
+
+// ── Negative sentinel: schema rejects clearly invalid instances ───────────────
+//
+// Proves the validator is actually checking content, not vacuously passing.
+
+#[test]
+fn envelope_schema_rejects_missing_required_fields() {
+    let validator = envelope_validator();
+    // An empty object matches none of the oneOf branches.
+    let bad = json!({});
+    let errors: Vec<_> = validator.iter_errors(&bad).collect();
+    assert!(
+        !errors.is_empty(),
+        "envelope schema should reject an empty object but found no errors"
+    );
+}
+
+#[test]
+fn log_entry_schema_rejects_unknown_source_value() {
+    let validator = log_entry_validator();
+    let bad = json!({
+        "id": "aud:1",
+        "contractVersion": "2.0.0",
+        "time": "2026-01-15T00:00:00Z",
+        "level": "info",
+        "source": "unknown_source_xyz",
+        "message": "test"
+    });
+    let errors: Vec<_> = validator.iter_errors(&bad).collect();
+    assert!(
+        !errors.is_empty(),
+        "log entry schema should reject unknown source value 'unknown_source_xyz'"
+    );
+}
+
+#[test]
+fn log_entry_schema_rejects_missing_required_id() {
+    let validator = log_entry_validator();
+    let bad = json!({
+        "contractVersion": "2.0.0",
+        "time": "2026-01-15T00:00:00Z",
+        "level": "info",
+        "source": "audit",
+        "message": "test"
+    });
+    let errors: Vec<_> = validator.iter_errors(&bad).collect();
+    assert!(
+        !errors.is_empty(),
+        "log entry schema should reject instance missing required 'id' field"
+    );
+}

--- a/tests/contract/contract_jsonschema_roundtrip.rs
+++ b/tests/contract/contract_jsonschema_roundtrip.rs
@@ -412,9 +412,8 @@ fn log_entry_schema_rejects_missing_required_id() {
         "source": "audit",
         "message": "test"
     });
-    let errors: Vec<_> = validator.iter_errors(&bad).collect();
     assert!(
-        !errors.is_empty(),
+        validator.iter_errors(&bad).next().is_some(),
         "log entry schema should reject instance missing required 'id' field"
     );
 }

--- a/tests/contract/contract_jsonschema_roundtrip.rs
+++ b/tests/contract/contract_jsonschema_roundtrip.rs
@@ -377,9 +377,8 @@ fn envelope_schema_rejects_missing_required_fields() {
     let validator = envelope_validator();
     // An empty object matches none of the oneOf branches.
     let bad = json!({});
-    let errors: Vec<_> = validator.iter_errors(&bad).collect();
     assert!(
-        !errors.is_empty(),
+        validator.iter_errors(&bad).next().is_some(),
         "envelope schema should reject an empty object but found no errors"
     );
 }
@@ -395,9 +394,8 @@ fn log_entry_schema_rejects_unknown_source_value() {
         "source": "unknown_source_xyz",
         "message": "test"
     });
-    let errors: Vec<_> = validator.iter_errors(&bad).collect();
     assert!(
-        !errors.is_empty(),
+        validator.iter_errors(&bad).next().is_some(),
         "log entry schema should reject unknown source value 'unknown_source_xyz'"
     );
 }


### PR DESCRIPTION
Adds jsonschema round-trip validation for the generated contract schemas. Found a real parity divergence — inventory.list schema requires InventorySession.state but the type dropped that field in spec-041; the failing case is #[ignore]'d with the fix noted for follow-up.

Tracks-Bead: astro-plan-kyo7.23
Merge-Bead: astro-plan-d9wg