### PR TITLE
fix: pnpm lint no longer fails to start on custom ESLint rule files

### DIFF
--- a/apps/desktop/eslint.config.js
+++ b/apps/desktop/eslint.config.js
@@ -204,6 +204,11 @@ export default tseslint.config(
       'vite.config.ts',
       'vitest.config.ts',
       'eslint.config.js',
+      // Custom rule files are plain JS executed by ESLint, not app source —
+      // they are not in any tsconfig include, so type-aware rules cannot run
+      // on them. Excluding here is equivalent to how eslint.config.js itself
+      // is excluded.
+      'eslint-rules/**',
     ],
   },
 );


### PR DESCRIPTION
## Summary
- Custom ESLint rule files (apps/desktop/eslint-rules/*.js) were type-checked by typescript-eslint's global projectService but aren't in tsconfig include, causing a fatal "not found by the project service" parse error that blocked all JS lint.
- Added eslint-rules/** to the global ignores in eslint.config.js (same intent as the existing eslint.config.js exclusion). The no-user-string rule still applies to src/**.

Tracks-Bead: astro-plan-kwd
Merge-Bead: astro-plan-ipyz
