### PR TITLE
fix: restore defaults could leave settings partially reset on error

### DIFF
--- a/crates/app/settings/src/writes.rs
+++ b/crates/app/settings/src/writes.rs
@@ -284,9 +284,17 @@ pub async fn restore_defaults(
         req.keys.clone()
     };
 
-    let mut restored = Vec::new();
+    // Read current values outside the transaction — reads are cheap and
+    // non-destructive; only the writes must be atomic.
+    struct PendingWrite {
+        key: String,
+        current_val: Value,
+        default_val: Value,
+        is_protection_default: bool,
+    }
+
+    let mut pending: Vec<PendingWrite> = Vec::new();
     let mut already_at_default = Vec::new();
-    let mut restored_protection_default = false;
 
     for key in &keys_to_restore {
         let default_val = default_value_for_key(key);
@@ -302,37 +310,52 @@ pub async fn restore_defaults(
 
         if settings_value_eq(&current_val, &default_val) {
             already_at_default.push(key.clone());
-            continue;
-        }
-
-        // Write the default value.
-        if is_protection_default {
-            protection_repo::set_protection_default(
-                pool,
-                GLOBAL_PROTECTION_DEFAULT_SCOPE,
-                key,
-                &default_val,
-            )
-            .await
-            .map_err(db_err)?;
         } else {
-            repo::set_raw(pool, key, &default_val).await.map_err(db_err)?;
+            pending.push(PendingWrite { key: key.clone(), current_val, default_val, is_protection_default });
         }
+    }
 
+    // Write all defaults in a single transaction — all-or-nothing.
+    if !pending.is_empty() {
+        let mut tx = pool.begin().await.map_err(|e| db_err(e.into()))?;
+        for pw in &pending {
+            if pw.is_protection_default {
+                protection_repo::set_protection_default_with_conn(
+                    &mut *tx,
+                    GLOBAL_PROTECTION_DEFAULT_SCOPE,
+                    &pw.key,
+                    &pw.default_val,
+                )
+                .await
+                .map_err(db_err)?;
+            } else {
+                repo::set_raw_with_conn(&mut *tx, &pw.key, &pw.default_val)
+                    .await
+                    .map_err(db_err)?;
+            }
+        }
+        tx.commit().await.map_err(|e| db_err(e.into()))?;
+    }
+
+    // Emit audit events after the commit (T027, FR-130).
+    let mut restored = Vec::new();
+    let mut restored_protection_default = false;
+
+    for pw in pending {
         // Write durable audit row + live event (even for noisy keys — restore
         // is an explicit action, FR-130).
         write_settings_applied_audit(
             bus,
-            is_protection_default,
+            pw.is_protection_default,
             "settings.restore_defaults",
-            key,
-            &current_val,
-            &default_val,
+            &pw.key,
+            &pw.current_val,
+            &pw.default_val,
         )
         .await?;
 
-        restored.push(key.clone());
-        if is_protection_default {
+        restored.push(pw.key);
+        if pw.is_protection_default {
             restored_protection_default = true;
         }
     }

--- a/crates/app/settings/src/writes.rs
+++ b/crates/app/settings/src/writes.rs
@@ -248,6 +248,15 @@ pub async fn write_settings_refusal(
 
 // ── restore_defaults ──────────────────────────────────────────────────────
 
+/// A settings key whose current value differs from its default, staged for the
+/// single all-or-nothing restore transaction in `restore_defaults`.
+struct PendingWrite {
+    key: String,
+    current_val: Value,
+    default_val: Value,
+    is_protection_default: bool,
+}
+
 /// Restore one or more settings keys to their in-code defaults (T027).
 ///
 /// - Empty `keys` slice restores all v1 keys.
@@ -286,13 +295,6 @@ pub async fn restore_defaults(
 
     // Read current values outside the transaction — reads are cheap and
     // non-destructive; only the writes must be atomic.
-    struct PendingWrite {
-        key: String,
-        current_val: Value,
-        default_val: Value,
-        is_protection_default: bool,
-    }
-
     let mut pending: Vec<PendingWrite> = Vec::new();
     let mut already_at_default = Vec::new();
 
@@ -311,7 +313,12 @@ pub async fn restore_defaults(
         if settings_value_eq(&current_val, &default_val) {
             already_at_default.push(key.clone());
         } else {
-            pending.push(PendingWrite { key: key.clone(), current_val, default_val, is_protection_default });
+            pending.push(PendingWrite {
+                key: key.clone(),
+                current_val,
+                default_val,
+                is_protection_default,
+            });
         }
     }
 
@@ -321,7 +328,7 @@ pub async fn restore_defaults(
         for pw in &pending {
             if pw.is_protection_default {
                 protection_repo::set_protection_default_with_conn(
-                    &mut *tx,
+                    &mut tx,
                     GLOBAL_PROTECTION_DEFAULT_SCOPE,
                     &pw.key,
                     &pw.default_val,
@@ -329,9 +336,7 @@ pub async fn restore_defaults(
                 .await
                 .map_err(db_err)?;
             } else {
-                repo::set_raw_with_conn(&mut *tx, &pw.key, &pw.default_val)
-                    .await
-                    .map_err(db_err)?;
+                repo::set_raw_with_conn(&mut tx, &pw.key, &pw.default_val).await.map_err(db_err)?;
             }
         }
         tx.commit().await.map_err(|e| db_err(e.into()))?;

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -13,6 +13,7 @@ use domain_core::settings::{SettingsState, SourceOverride};
 use patterns::{default_pattern, validate_pattern_str, FrameTypeClass};
 use serde_json::Value;
 use sqlx::types::Json;
+use sqlx::SqliteConnection;
 use sqlx::SqlitePool;
 
 use persistence_core::{DbError, DbResult};
@@ -58,6 +59,34 @@ pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()
     .bind(Json(value))
     .bind(&now)
     .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Write (upsert) a raw JSON value for a single key on an existing connection.
+///
+/// Accepts a bare `SqliteConnection` so callers can participate in an
+/// open transaction without needing a pool.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure.
+pub async fn set_raw_with_conn(
+    conn: &mut SqliteConnection,
+    key: &str,
+    value: &Value,
+) -> DbResult<()> {
+    let now = Timestamp::now_iso();
+
+    sqlx::query(
+        "INSERT INTO settings (key, value, updated_at) VALUES (?, ?, ?)
+         ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(key)
+    .bind(Json(value))
+    .bind(&now)
+    .execute(conn)
     .await?;
 
     Ok(())

--- a/crates/persistence/plans/src/repositories/source_protection.rs
+++ b/crates/persistence/plans/src/repositories/source_protection.rs
@@ -10,6 +10,7 @@
 use domain_core::ids::Timestamp;
 use serde_json::Value;
 use sqlx::types::Json;
+use sqlx::SqliteConnection;
 use sqlx::SqlitePool;
 
 use persistence_core::{DbError, DbResult};
@@ -259,6 +260,37 @@ pub async fn set_protection_default(
     .bind(Json(value))
     .bind(&now)
     .execute(pool)
+    .await?;
+
+    Ok(())
+}
+
+/// Write (upsert) a protection default on an existing connection.
+///
+/// Accepts a bare `SqliteConnection` so callers can participate in an
+/// open transaction without needing a pool.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`]
+/// on JSON encoding failure.
+pub async fn set_protection_default_with_conn(
+    conn: &mut SqliteConnection,
+    scope: &str,
+    key: &str,
+    value: &serde_json::Value,
+) -> DbResult<()> {
+    let now = Timestamp::now_iso();
+
+    sqlx::query(
+        "INSERT INTO protection_defaults (scope, key, value, updated_at) VALUES (?, ?, ?, ?)
+         ON CONFLICT(scope, key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at",
+    )
+    .bind(scope)
+    .bind(key)
+    .bind(Json(value))
+    .bind(&now)
+    .execute(conn)
     .await?;
 
     Ok(())


### PR DESCRIPTION
## Summary

- Wraps all per-key writes inside a single DB transaction so a mid-loop
  failure rolls back the entire restore instead of leaving settings in a
  partially-restored state.

## Spec Context

astro-plan-kyo7.55

Tracks-Bead: astro-plan-kyo7.55
Merge-Bead: astro-plan-wf3b