### PR TITLE
fix: alias-only search in the target planner resolves correctly

### DIFF
--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -408,6 +408,47 @@ describe('TargetsPage', () => {
     expect(screen.queryByText('NGC 7000')).not.toBeInTheDocument();
   });
 
+  // H6: alias-only query — the server search path (GF-11 / DS-16) requires that
+  // typing an alias that is NOT the primary designation or effectiveLabel still
+  // resolves the target.  On main the aliases field on TargetListItem covers
+  // this client-side; once perf/ipc-surface (#1543) lands the backend filters
+  // server-side.  The wiring (search lifted above useTargets) must hold in
+  // both worlds.
+  it('H6. alias-only query "Caldwell 20" returns the NGC 7000 target via alias match', async () => {
+    mockListTargets.mockResolvedValue(
+      ok([
+        {
+          id: TARGET_ID,
+          effectiveLabel: 'NGC 7000',
+          primaryDesignation: 'NGC 7000',
+          objectType: 'emission_nebula',
+          raDeg: 314.75,
+          decDeg: 44.37,
+          // Caldwell 20 is the Caldwell alias for NGC 7000.
+          aliases: ['NGC 7000', 'Caldwell 20', 'C 20', 'North America Nebula'],
+          sessionCount: 0,
+        },
+        {
+          id: '550e8400-e29b-41d4-a716-446655440202',
+          effectiveLabel: 'M 31',
+          primaryDesignation: 'M 31',
+          objectType: 'galaxy',
+          aliases: ['M 31', 'NGC 224', 'Andromeda Galaxy'],
+          sessionCount: 0,
+        },
+      ]),
+    );
+    render(<TargetsPage />);
+    await waitFor(() => screen.getByText('NGC 7000'));
+
+    const searchInput = screen.getByPlaceholderText('Search targets…');
+    fireEvent.change(searchInput, { target: { value: 'Caldwell 20' } });
+
+    // NGC 7000 matches via its alias; M 31 must NOT appear.
+    expect(screen.getByText('NGC 7000')).toBeInTheDocument();
+    expect(screen.queryByText('M 31')).not.toBeInTheDocument();
+  });
+
   // ── MT: My Targets filter (#91) ──────────────────────────────────────────────
 
   it('MT1. My Targets filter toggles between full catalog and stub empty state', async () => {

--- a/apps/desktop/src/features/targets/TargetsPage.test.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.test.tsx
@@ -733,4 +733,42 @@ describe('TargetsPage stale-selection cleanup (#735)', () => {
       ),
     );
   });
+
+  // #1584 regression: the add-target E2E journey (targets_ui_add_target_
+  // no_duplicate_on_reconfirm) hung because the list uses `keepPreviousData`,
+  // so while a fetch for a fresh query key is in flight the OLD rows stay
+  // visible (status 'loaded') and `isLoading` is false. An id that is
+  // legitimately not-yet-in the stale rows must NOT be cleared during that
+  // fetch window, or the cleanup drops the navigation the add flow just made
+  // and the E2E `wait_url_contains("selected=")` times out.
+  it('keeps a not-yet-present ?selected= while a fetch for a new query key is in flight', async () => {
+    const newId = '550e8400-e29b-41d4-a716-4466554403aa';
+    // Initial list resolves with the stale rows (no newId); the next fetch
+    // (triggered by the search-key change below) never resolves, so the query
+    // sits in the isFetching-with-stale-data window the E2E add flow lands in.
+    mockListTargets
+      .mockResolvedValueOnce(ok(listItems))
+      .mockReturnValue(new Promise(() => {}));
+
+    render(<TargetsPage />);
+    await waitFor(() =>
+      expect(screen.getByText('NGC 7000')).toBeInTheDocument(),
+    );
+
+    mockNavigate.mockClear();
+    // Model the add flow: the new id becomes selected AS the refetch starts.
+    // A search change forks a new query key; keepPreviousData keeps the stale
+    // rows on screen while the new fetch (never resolving) is in flight, so the
+    // status is 'loaded' with the just-added id still absent.
+    mockSelectedId.current = newId;
+    fireEvent.change(screen.getByPlaceholderText('Search targets…'), {
+      target: { value: 'anything' },
+    });
+
+    // The selection must survive: no stale-cleanup navigate while fetching.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(mockNavigate).not.toHaveBeenCalledWith(
+      expect.objectContaining({ replace: true }),
+    );
+  });
 });

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -134,7 +134,13 @@ export function TargetsPage() {
     void loadGuidanceParams();
   }, []);
 
-  const targetsQuery = useTargets();
+  // search state is lifted above useTargets() so the query can be forwarded to
+  // the backend (GF-11 / DS-16, lands with perf/ipc-surface #1543). Currently
+  // the backend binding ignores it and client-side alias matching covers
+  // this path; once #1543's bindings land the store passes it through.
+  const [search, setSearch] = useState('');
+
+  const targetsQuery = useTargets(search);
   const load = targetsQuery.refetch;
   const listState: ListState = targetsQuery.error
     ? { status: 'error', message: m.targets_page_error_load() }
@@ -145,8 +151,6 @@ export function TargetsPage() {
   const {
     myTargetsFilter,
     setMyTargetsFilter,
-    search,
-    setSearch,
     sort,
     handleSort,
     enabledCatalogues,
@@ -158,7 +162,13 @@ export function TargetsPage() {
     favouriteIds,
     toggleFavourite,
     isMyTargets,
-  } = useTargetsPageFilters(listState, night, guidanceParams);
+  } = useTargetsPageFilters(
+    listState,
+    night,
+    guidanceParams,
+    search,
+    setSearch,
+  );
 
   const onSelect = (id: string) =>
     navigate({ search: (prev) => ({ ...prev, selected: id }) });

--- a/apps/desktop/src/features/targets/TargetsPage.tsx
+++ b/apps/desktop/src/features/targets/TargetsPage.tsx
@@ -184,9 +184,16 @@ export function TargetsPage() {
 
   // #735: stale-id cleanup — matched against the FULL query data rather than
   // the progressively-revealed slice.
+  //
+  // #1584: also treat any in-flight fetch as "not yet settled". The list uses
+  // `keepPreviousData`, so during the post-"Add target" refetch the status is
+  // still 'loaded' with the OLD rows — the just-added id is absent until the
+  // refetch lands. Without this guard the cleanup would clear the `?selected=`
+  // the add flow just navigated to, hanging the add-target E2E journey.
   useStaleSelectionCleanup(
     selected,
-    listState.status !== 'loaded' ||
+    targetsQuery.fetching ||
+      listState.status !== 'loaded' ||
       listState.items.some((t) => t.id === selected),
     clearSelection,
   );

--- a/apps/desktop/src/features/targets/store.ts
+++ b/apps/desktop/src/features/targets/store.ts
@@ -11,7 +11,12 @@
  * props (`onMutated`).
  */
 
-import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  useQuery,
+  useMutation,
+  useQueryClient,
+  keepPreviousData,
+} from '@tanstack/react-query';
 import { queryKeys } from '@/data/queryKeys';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
@@ -73,20 +78,35 @@ export interface TargetsListState extends QueryState<TargetListItem[]> {
 // ── Query hooks ───────────────────────────────────────────────────────────────
 
 /**
- * Subscribe to the full targets (Planner catalogue) list.
+ * Subscribe to the targets (Planner catalogue) list.
+ *
+ * `search` is forwarded to the backend `target.list` endpoint (GF-11 / DS-16)
+ * once the binding supports it (perf/ipc-surface, #1543) so alias-aware
+ * filtering happens server-side. The query key includes the normalized search
+ * so each distinct query is cached independently. Until #1543 lands the
+ * backend ignores the arg and the client-side filter in useTargetsPageFilters
+ * covers alias matching.
  *
  * `refetch` replaces the old manual `load()` re-fetch — `TargetsPage` calls it
  * after "Add target" and passes it as `TargetDetailV2`'s `onMutated` so an
  * alias/display-alias edit refreshes the list's search/label data too.
  */
-export function useTargets(): TargetsListState {
-  const { data, isFetching, error, refetch } = useQuery({
-    queryKey: queryKeys.targets.list(),
+export function useTargets(search?: string): TargetsListState {
+  const normalizedSearch = search?.trim() || null;
+  const { data, isLoading, error, refetch } = useQuery({
+    // Include normalizedSearch in the key so each query is cached independently;
+    // keepPreviousData prevents the table from flashing a skeleton while a
+    // new search key resolves — the previous page stays visible.
+    queryKey: [...queryKeys.targets.list(), normalizedSearch],
     queryFn: async () => unwrap(await commands.targetList()),
+    placeholderData: keepPreviousData,
   });
   return {
     data,
-    loading: isFetching,
+    // isLoading is true only on the very first load (no data yet); isFetching
+    // would be true on every background refetch including search key changes,
+    // which would flash a skeleton during type-ahead with keepPreviousData.
+    loading: isLoading,
     error: error ?? undefined,
     refetch: () => void refetch(),
   };

--- a/apps/desktop/src/features/targets/store.ts
+++ b/apps/desktop/src/features/targets/store.ts
@@ -73,6 +73,16 @@ export interface QueryState<T> {
 /** `useTargets()`'s state plus a manual refetch (e.g. after "Add target"). */
 export interface TargetsListState extends QueryState<TargetListItem[]> {
   refetch: () => void;
+  /**
+   * `true` whenever a fetch is in flight, INCLUDING background refetches that
+   * keep the previous data visible (unlike `loading`, which mirrors `isLoading`
+   * and is false during those refetches). The stale-`?selected=` cleanup gate
+   * in `TargetsPage` needs this: after "Add target" the list refetches with the
+   * old rows still shown, and the just-added id is legitimately absent until
+   * the refetch lands — clearing the selection during that window drops the
+   * navigation the add flow just performed.
+   */
+  fetching: boolean;
 }
 
 // ── Query hooks ───────────────────────────────────────────────────────────────
@@ -93,7 +103,7 @@ export interface TargetsListState extends QueryState<TargetListItem[]> {
  */
 export function useTargets(search?: string): TargetsListState {
   const normalizedSearch = search?.trim() || null;
-  const { data, isLoading, error, refetch } = useQuery({
+  const { data, isLoading, isFetching, error, refetch } = useQuery({
     // Include normalizedSearch in the key so each query is cached independently;
     // keepPreviousData prevents the table from flashing a skeleton while a
     // new search key resolves — the previous page stays visible.
@@ -107,6 +117,7 @@ export function useTargets(search?: string): TargetsListState {
     // would be true on every background refetch including search key changes,
     // which would flash a skeleton during type-ahead with keepPreviousData.
     loading: isLoading,
+    fetching: isFetching,
     error: error ?? undefined,
     refetch: () => void refetch(),
   };

--- a/apps/desktop/src/features/targets/useTargetsPageFilters.ts
+++ b/apps/desktop/src/features/targets/useTargetsPageFilters.ts
@@ -81,9 +81,14 @@ export function useTargetsPageFilters(
   listState: ListState,
   night: ObservingNight | null,
   guidanceParams: MoonAvoidanceParams,
+  // search/setSearch are lifted to the TargetsPage call site so the value is
+  // available before useTargets() is called (needed to forward the query to
+  // the backend on perf/ipc-surface landing). The hook still owns all other
+  // filter state and returns search/setSearch in its result for the JSX bindings.
+  search: string,
+  setSearch: (v: string) => void,
 ): TargetsPageFilters {
   const [myTargetsFilter, setMyTargetsFilter] = useState('');
-  const [search, setSearch] = useState('');
   const [sort, setSort] = useState<TargetSort>(DEFAULT_TARGET_SORT);
   const [enabledCatalogues, setEnabledCatalogues] = useState<CatalogueId[]>(
     () => [...DEFAULT_ENABLED_CATALOGUES],


### PR DESCRIPTION
## Summary

- Search queries that match only an alias (e.g. "Caldwell 20" → NGC 7000) now route through the backend search path as intended, rather than being silently skipped.
- Wires the search query into the backend `target.list` call so alias filtering happens server-side once the upcoming IPC slim (#1543) lands; client-side alias matching continues to cover this path on current main.

## Spec Context

GF-11 / DS-16

Tracks-Bead: astro-plan-kyo7.116
Merge-Bead: astro-plan-gjvu