### PR TITLE
feat: recover interrupted file operations after an unclean shutdown

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -501,22 +501,42 @@ async fn boot(app: tauri::AppHandle, db_url: String, data_dir: std::path::PathBu
     }
     let pool = db.pool().clone();
 
-    // Startup sweep: any plan left in 'applying' with no live executor (e.g.
-    // after a hard crash) is unreachable by `resume_plan` (which requires
-    // `paused` state). Flip them to `paused` with pause_reason='crash' so the
-    // user can resume or cancel them. The active_runs registry is always empty
+    // Startup sweep + boot reconciliation (constitution v1.1.0 §V). Any plan
+    // left in 'applying' with no live executor (e.g. after a hard crash) is
+    // unreachable by `resume_plan` (which requires `paused` state). Flip them to
+    // `paused` with pause_reason='crash', then reconcile each plan's
+    // intent-without-confirmed-outcome items against filesystem reality: heal
+    // the ones the filesystem shows completed, and flag ambiguous ones for the
+    // unclean-shutdown recovery prompt. The active_runs registry is always empty
     // at this point, so every applying plan qualifies.
     {
         let sweep_pool = pool.clone();
         tokio::spawn(async move {
-            match app_core::plan_apply::sweep_crashed_applying_plans(&sweep_pool).await {
-                Ok(ids) if !ids.is_empty() => tracing::info!(
-                    count = ids.len(),
-                    "startup: flipped {} applying plan(s) to paused (crash recovery)",
-                    ids.len()
+            let ids = match app_core::plan_apply::sweep_crashed_applying_plans(&sweep_pool).await {
+                Ok(ids) => {
+                    if !ids.is_empty() {
+                        tracing::info!(
+                            count = ids.len(),
+                            "startup: flipped {} applying plan(s) to paused (crash recovery)",
+                            ids.len()
+                        );
+                    }
+                    ids
+                }
+                Err(e) => {
+                    tracing::warn!("startup sweep for crashed applying plans failed: {e}");
+                    Vec::new()
+                }
+            };
+            match app_core::plan_apply::reconcile_crashed_plans(&sweep_pool, &ids).await {
+                Ok(report) if report.healed > 0 || report.needs_user_review() => tracing::info!(
+                    healed = report.healed,
+                    left_for_resume = report.left_for_resume,
+                    ambiguous_plans = report.ambiguous_plan_ids.len(),
+                    "startup: boot reconciliation classified crashed plan items"
                 ),
                 Ok(_) => {}
-                Err(e) => tracing::warn!("startup sweep for crashed applying plans failed: {e}"),
+                Err(e) => tracing::warn!("startup boot reconciliation failed: {e}"),
             }
         });
     }

--- a/crates/app/core/src/plan_apply.rs
+++ b/crates/app/core/src/plan_apply.rs
@@ -191,6 +191,7 @@ mod callbacks;
 mod finalizers;
 mod lifecycle;
 mod paths;
+mod reconcile;
 mod terminal;
 
 #[cfg(test)]
@@ -202,6 +203,7 @@ pub use lifecycle::{
     skip_plan_item, sweep_crashed_applying_plans,
 };
 pub(crate) use paths::resolve_root_path;
+pub use reconcile::{reconcile_crashed_plans, ReconcileReport};
 
 use apply::{spawn_executor_run, SpawnExecutorParams};
 use callbacks::{audit_item_cancelled, PlanApplyCallbacks};

--- a/crates/app/core/src/plan_apply/reconcile.rs
+++ b/crates/app/core/src/plan_apply/reconcile.rs
@@ -1,0 +1,195 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Boot reconciliation of filesystem-mutation intents (constitution v1.1.0 §V).
+//!
+//! Runs once at startup, after [`super::sweep_crashed_applying_plans`] has
+//! flipped crashed `applying` plans to `paused`. For every non-terminal item of
+//! those plans it resolves the source/destination paths (the same resolution
+//! the executor uses), probes filesystem reality via [`fs_executor::classify`],
+//! and persists the verdict:
+//!
+//! - **Completed** — the mutation is visible on disk; heal the record to
+//!   `succeeded` (unambiguous, re-derivable — auto-heal per constitution).
+//! - **NotStarted** — no effect on disk; leave the item for the user-approved
+//!   resume path to re-run.
+//! - **Ambiguous** — inconsistent or unresolvable; mark `failed` with a
+//!   `reconcile.ambiguous` reason so the unclean-shutdown prompt surfaces it for
+//!   an explicit user resume/repair decision.
+//!
+//! No new write-ahead journal is introduced: the intent is the existing plan
+//! `applying` state + `plan_apply_runs` row, and the outcome is the existing
+//! per-item `plan_items.item_state`. This pass only reads those and reconciles.
+
+use std::collections::HashMap;
+
+use camino::Utf8PathBuf;
+use domain_core::ids::{new_id, Timestamp};
+use sqlx::SqlitePool;
+
+use super::{apply_repo, resolve_root_path};
+use fs_executor::ops::lexical_normalize;
+use fs_executor::{classify, MutationShape, ReconcileVerdict};
+
+/// Outcome of the boot reconciliation pass, consumed by the unclean-shutdown
+/// recovery prompt (kyo7.48).
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct ReconcileReport {
+    /// Items healed to `succeeded` because the filesystem showed the mutation
+    /// completed.
+    pub healed: usize,
+    /// Items left `pending`/`applying` for the user-approved resume path.
+    pub left_for_resume: usize,
+    /// Ids of plans holding at least one item that needs an explicit user
+    /// resume/repair decision (ambiguous filesystem state).
+    pub ambiguous_plan_ids: Vec<String>,
+}
+
+impl ReconcileReport {
+    /// Whether any item requires the user's explicit resume/repair decision.
+    #[must_use]
+    pub fn needs_user_review(&self) -> bool {
+        !self.ambiguous_plan_ids.is_empty()
+    }
+}
+
+/// Map the persistence-layer action string to the executor's filesystem-effect
+/// shape. `link`/`mkdir`/`write_manifest` create a destination entry; `move`/
+/// `archive` relocate; `delete`/`trash` remove; `catalogue`/unknown have no
+/// filesystem effect to probe.
+fn shape_for(action: &str) -> MutationShape {
+    match action {
+        "move" | "archive" => MutationShape::Relocate,
+        "delete" | "trash" => MutationShape::Remove,
+        "mkdir" | "link" | "write_manifest" => MutationShape::Create,
+        _ => MutationShape::None,
+    }
+}
+
+/// Reconcile the intents of the just-swept crashed plans against the filesystem.
+///
+/// `plan_ids` is the list returned by [`super::sweep_crashed_applying_plans`].
+/// Returns a [`ReconcileReport`] summarising the classification.
+///
+/// # Errors
+///
+/// Returns [`persistence_core::DbError`] on connection failure. Path-resolution
+/// gaps for individual items are not fatal — they classify as ambiguous.
+pub async fn reconcile_crashed_plans(
+    pool: &SqlitePool,
+    plan_ids: &[String],
+) -> Result<ReconcileReport, persistence_core::DbError> {
+    let items = apply_repo::list_unreconciled_items(pool, plan_ids).await?;
+    if items.is_empty() {
+        return Ok(ReconcileReport::default());
+    }
+
+    // Resolve each referenced root once. A root that no longer resolves leaves
+    // its items' paths as None, which the classifier treats as ambiguous.
+    let mut root_map: HashMap<String, Utf8PathBuf> = HashMap::new();
+    for item in &items {
+        for rid in [item.from_root_id.as_ref(), item.to_root_id.as_ref()].into_iter().flatten() {
+            if !root_map.contains_key(rid) {
+                if let Some(path) = resolve_root_path(pool, rid).await {
+                    root_map.insert(rid.clone(), Utf8PathBuf::from(path));
+                }
+            }
+        }
+    }
+
+    let mut report = ReconcileReport::default();
+    let mut ambiguous: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+
+    for item in &items {
+        let shape = shape_for(&item.action);
+        let source = resolve(&root_map, item.from_root_id.as_deref(), &item.from_relative_path);
+        // Archive stores its destination in `archive_path` (root-relative when a
+        // from_root is set, else absolute); other relocates/creates use
+        // `to_relative_path` against the destination root.
+        let destination = if item.action == "archive" {
+            resolve_archive(&root_map, item)
+        } else {
+            resolve(&root_map, item.to_root_id.as_deref(), &item.to_relative_path)
+        };
+
+        let verdict = classify(shape, source.as_deref(), destination.as_deref());
+        match verdict {
+            ReconcileVerdict::Completed => {
+                let run_id = active_run_id(pool, &item.plan_id).await;
+                apply_repo::record_reconciled_outcome(
+                    pool,
+                    item,
+                    "pending",
+                    "succeeded",
+                    &run_id,
+                    None,
+                    &Timestamp::now_iso(),
+                    &new_id(),
+                )
+                .await?;
+                report.healed += 1;
+            }
+            ReconcileVerdict::NotStarted => {
+                report.left_for_resume += 1;
+            }
+            ReconcileVerdict::Ambiguous => {
+                let run_id = active_run_id(pool, &item.plan_id).await;
+                apply_repo::record_reconciled_outcome(
+                    pool,
+                    item,
+                    "pending",
+                    "failed",
+                    &run_id,
+                    Some("filesystem state ambiguous at boot; needs user resume/repair"),
+                    &Timestamp::now_iso(),
+                    &new_id(),
+                )
+                .await?;
+                ambiguous.insert(item.plan_id.clone());
+            }
+        }
+    }
+
+    report.ambiguous_plan_ids = ambiguous.into_iter().collect();
+    Ok(report)
+}
+
+/// Resolve a root-relative path to an absolute path, mirroring the executor's
+/// path resolution (`root.join(relative)` then lexical normalization). Returns
+/// `None` when the root is unresolved or the relative path is empty — either
+/// makes the item ambiguous.
+fn resolve(
+    root_map: &HashMap<String, Utf8PathBuf>,
+    root_id: Option<&str>,
+    relative: &str,
+) -> Option<Utf8PathBuf> {
+    if relative.is_empty() {
+        return None;
+    }
+    let root = root_id.and_then(|rid| root_map.get(rid))?;
+    Some(lexical_normalize(&root.join(relative)))
+}
+
+/// Resolve an archive item's destination from `archive_path`. When
+/// `from_root_id` is set the stored path is root-relative; otherwise it is
+/// already absolute (matching `archive_generator`'s two storage modes).
+fn resolve_archive(
+    root_map: &HashMap<String, Utf8PathBuf>,
+    item: &apply_repo::UnreconciledItem,
+) -> Option<Utf8PathBuf> {
+    let archive = item.archive_path.as_deref()?;
+    if archive.is_empty() {
+        return None;
+    }
+    match item.from_root_id.as_deref().and_then(|rid| root_map.get(rid)) {
+        Some(root) => Some(lexical_normalize(&root.join(archive))),
+        None => Some(lexical_normalize(Utf8PathBuf::from(archive).as_path())),
+    }
+}
+
+/// The crashed run id for a plan, used to link the reconciliation event. Falls
+/// back to an empty string when no run row is found (the event still records
+/// the transition; the run linkage is best-effort).
+async fn active_run_id(pool: &SqlitePool, plan_id: &str) -> String {
+    apply_repo::get_active_run(pool, plan_id).await.ok().flatten().map(|r| r.id).unwrap_or_default()
+}

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -2013,3 +2013,129 @@ async fn gfd2_completed_path_sweeps_orphaned_applying_items() {
         "GFD-2 sweep on Completed path must emit a durable audit row for the swept item"
     );
 }
+
+/// Boot reconciliation classifies each crashed-plan item against filesystem
+/// reality: a completed move heals to `succeeded`, an untouched move is left
+/// for resume, and an ambiguous (both endpoints present) move is flagged for
+/// user review. Exercises the real `resolve_root_path` + fs-probe path.
+#[tokio::test]
+async fn reconcile_crashed_plans_classifies_all_three_verdicts() {
+    use contracts_core::first_run::{
+        OrganizationState, RegisterSourceRequest, ScanDepth, SourceKind,
+    };
+
+    async fn item_state(db: &Database, id: &str) -> String {
+        sqlx::query_scalar::<_, String>("SELECT item_state FROM plan_items WHERE id = ?")
+            .bind(id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap()
+    }
+
+    let (db, bus) = setup().await;
+    let root = tempfile::tempdir().unwrap();
+    let root_path = root.path().to_str().unwrap().to_owned();
+
+    let reg = crate::first_run::register_source(
+        db.pool(),
+        &bus,
+        &RegisterSourceRequest {
+            kind: SourceKind::Project,
+            path: root_path.clone(),
+            kind_subtype: None,
+            scan_depth: ScanDepth::Recursive,
+            organization_state: OrganizationState::Organized,
+        },
+    )
+    .await
+    .unwrap();
+    let root_id = reg.source_id;
+
+    repo::insert_plan(
+        db.pool(),
+        &repo::InsertPlan {
+            id: "prc",
+            title: "Recover",
+            origin: "cleanup",
+            origin_path: None,
+            plan_type: "cleanup",
+            destructive_destination: "archive",
+            parent_plan_id: None,
+            total_bytes_required: 0,
+        },
+    )
+    .await
+    .unwrap();
+
+    // Three move items rooted at the tempdir. src/dst are root-relative.
+    let cases = [
+        ("done", "raw/done.fits", "out/done.fits"),
+        ("todo", "raw/todo.fits", "out/todo.fits"),
+        ("ambig", "raw/ambig.fits", "out/ambig.fits"),
+    ];
+    for (i, (name, from, to)) in cases.iter().enumerate() {
+        repo::insert_plan_item(
+            db.pool(),
+            &repo::InsertPlanItem {
+                id: &format!("prc-{name}"),
+                plan_id: "prc",
+                item_index: i64::try_from(i + 1).unwrap(),
+                name: "f.fits",
+                action: "move",
+                from_root_id: Some(&root_id),
+                from_relative_path: from,
+                to_root_id: Some(&root_id),
+                to_relative_path: to,
+                reason: "test",
+                protection: "normal",
+                linked_entity: None,
+                provenance_json: None,
+                archive_path: None,
+                source_id: None,
+                category: None,
+            },
+        )
+        .await
+        .unwrap();
+    }
+    repo::update_plan_state(db.pool(), "prc", "ready_for_review").await.unwrap();
+    repo::set_approved(db.pool(), "prc", "2026-06-01T00:00:00Z", "tok").await.unwrap();
+
+    // Drive to applying + simulate crash sweep.
+    let run_id = new_id();
+    apply_repo::cas_approved_to_applying(db.pool(), "prc", &run_id, "tok", 3, 3).await.unwrap();
+    let swept = sweep_crashed_applying_plans(db.pool()).await.unwrap();
+    assert_eq!(swept, vec!["prc".to_owned()]);
+
+    // Materialize filesystem states matching each verdict.
+    let mk = |rel: &str| {
+        let p = root.path().join(rel);
+        std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+        std::fs::write(&p, b"x").unwrap();
+    };
+    // done: source gone, destination present -> Completed
+    mk("out/done.fits");
+    // todo: source present, destination absent -> NotStarted
+    mk("raw/todo.fits");
+    // ambig: both present -> Ambiguous
+    mk("raw/ambig.fits");
+    mk("out/ambig.fits");
+
+    let report = reconcile_crashed_plans(db.pool(), &swept).await.unwrap();
+    assert_eq!(report.healed, 1, "the completed move heals to succeeded");
+    assert_eq!(report.left_for_resume, 1, "the untouched move is left for resume");
+    assert_eq!(report.ambiguous_plan_ids, vec!["prc".to_owned()]);
+    assert!(report.needs_user_review());
+
+    assert_eq!(item_state(&db, "prc-done").await, "succeeded");
+    assert_eq!(
+        item_state(&db, "prc-todo").await,
+        "pending",
+        "not-started item stays pending for resume"
+    );
+    assert_eq!(
+        item_state(&db, "prc-ambig").await,
+        "failed",
+        "ambiguous item is flagged failed for review"
+    );
+}

--- a/crates/fs/executor/src/lib.rs
+++ b/crates/fs/executor/src/lib.rs
@@ -20,9 +20,11 @@
 
 pub mod failure;
 pub mod ops;
+pub mod reconcile;
 pub mod run;
 
 pub use failure::{PlanItemFailure, RollbackOutcome};
+pub use reconcile::{classify, MutationShape, ReconcileVerdict};
 pub use run::{
     ApplyOutcome, CancellationToken, ExecutorCallbacks, ItemProgressEvent, RunConfig,
     TerminalCounts,

--- a/crates/fs/executor/src/reconcile.rs
+++ b/crates/fs/executor/src/reconcile.rs
@@ -1,0 +1,195 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Boot reconciliation of filesystem-mutation intents against filesystem
+//! reality (constitution v1.1.0 §V, unclean-shutdown recovery).
+//!
+//! After an unclean shutdown, a plan item may hold a committed *intent*
+//! (the plan is `applying`/`paused`) whose *outcome* was rewound under
+//! `synchronous = NORMAL`. This module classifies each such item by probing
+//! the filesystem for the effect the executor's operation would have left.
+//! It performs **no mutation** and touches no database — the caller resolves
+//! paths and persists the verdict.
+
+use camino::Utf8Path;
+
+/// The filesystem effect a plan item's action produces, abstracted away from
+/// the persistence-layer action string so this DB-free crate need not parse it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum MutationShape {
+    /// Source is relocated to a destination (`move`, `archive`).
+    Relocate,
+    /// Source is removed (`delete`, `trash`).
+    Remove,
+    /// A destination entry is created (`mkdir`, `link`, `write_manifest`).
+    Create,
+    /// No filesystem effect (`catalogue`, record-only).
+    None,
+}
+
+/// The reconciliation verdict for one intent-without-confirmed-outcome item.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum ReconcileVerdict {
+    /// The filesystem shows the mutation completed; heal the record to
+    /// `succeeded` — re-derivable state, unambiguous (auto-heal permitted).
+    Completed,
+    /// The filesystem shows the mutation never started; leave the item for the
+    /// user-approved resume path to re-run.
+    NotStarted,
+    /// The filesystem state is inconsistent (both endpoints present/absent) or
+    /// a required path could not be resolved; the item MUST be surfaced for an
+    /// explicit user resume/repair decision — never auto-healed.
+    Ambiguous,
+}
+
+/// Classify a single intent by probing the filesystem.
+///
+/// `source` and `destination` are the resolved absolute paths the executor
+/// would have operated on, or `None` when the caller could not resolve them
+/// (e.g. an unregistered root) — an unresolvable required path yields
+/// [`ReconcileVerdict::Ambiguous`] so custody defers to the user.
+///
+/// The truth tables are the inverse of each operation's post-condition:
+/// a relocate leaves the source gone and the destination present; a remove
+/// leaves the source gone; a create leaves the destination present.
+#[must_use]
+pub fn classify(
+    shape: MutationShape,
+    source: Option<&Utf8Path>,
+    destination: Option<&Utf8Path>,
+) -> ReconcileVerdict {
+    match shape {
+        MutationShape::None => ReconcileVerdict::Completed,
+        MutationShape::Relocate => match (source, destination) {
+            (Some(src), Some(dst)) => {
+                match (src.exists(), dst.exists()) {
+                    (false, true) => ReconcileVerdict::Completed,
+                    (true, false) => ReconcileVerdict::NotStarted,
+                    // Both present: a cross-volume copy that completed but whose
+                    // source delete did not, or an unrelated pre-existing dst —
+                    // either way the executor's own CAS gate must re-judge it.
+                    // Both absent: the source vanished with no destination — lost.
+                    _ => ReconcileVerdict::Ambiguous,
+                }
+            }
+            _ => ReconcileVerdict::Ambiguous,
+        },
+        MutationShape::Remove => match source {
+            Some(src) if !src.exists() => ReconcileVerdict::Completed,
+            Some(_) => ReconcileVerdict::NotStarted,
+            None => ReconcileVerdict::Ambiguous,
+        },
+        MutationShape::Create => match destination {
+            Some(dst) if dst.exists() => ReconcileVerdict::Completed,
+            Some(_) => ReconcileVerdict::NotStarted,
+            None => ReconcileVerdict::Ambiguous,
+        },
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use camino::Utf8PathBuf;
+
+    fn tmp() -> tempfile::TempDir {
+        tempfile::tempdir().unwrap()
+    }
+
+    fn touch(dir: &std::path::Path, name: &str) -> Utf8PathBuf {
+        let p = dir.join(name);
+        std::fs::write(&p, b"x").unwrap();
+        Utf8PathBuf::from_path_buf(p).unwrap()
+    }
+
+    fn absent(dir: &std::path::Path, name: &str) -> Utf8PathBuf {
+        Utf8PathBuf::from_path_buf(dir.join(name)).unwrap()
+    }
+
+    #[test]
+    fn relocate_completed_when_src_gone_dst_present() {
+        let d = tmp();
+        let src = absent(d.path(), "src");
+        let dst = touch(d.path(), "dst");
+        assert_eq!(
+            classify(MutationShape::Relocate, Some(&src), Some(&dst)),
+            ReconcileVerdict::Completed
+        );
+    }
+
+    #[test]
+    fn relocate_not_started_when_src_present_dst_absent() {
+        let d = tmp();
+        let src = touch(d.path(), "src");
+        let dst = absent(d.path(), "dst");
+        assert_eq!(
+            classify(MutationShape::Relocate, Some(&src), Some(&dst)),
+            ReconcileVerdict::NotStarted
+        );
+    }
+
+    #[test]
+    fn relocate_ambiguous_when_both_present() {
+        let d = tmp();
+        let src = touch(d.path(), "src");
+        let dst = touch(d.path(), "dst");
+        assert_eq!(
+            classify(MutationShape::Relocate, Some(&src), Some(&dst)),
+            ReconcileVerdict::Ambiguous
+        );
+    }
+
+    #[test]
+    fn relocate_ambiguous_when_both_absent() {
+        let d = tmp();
+        let src = absent(d.path(), "src");
+        let dst = absent(d.path(), "dst");
+        assert_eq!(
+            classify(MutationShape::Relocate, Some(&src), Some(&dst)),
+            ReconcileVerdict::Ambiguous
+        );
+    }
+
+    #[test]
+    fn relocate_ambiguous_when_path_unresolvable() {
+        let d = tmp();
+        let src = touch(d.path(), "src");
+        assert_eq!(
+            classify(MutationShape::Relocate, Some(&src), None),
+            ReconcileVerdict::Ambiguous
+        );
+    }
+
+    #[test]
+    fn remove_completed_when_src_gone() {
+        let d = tmp();
+        let src = absent(d.path(), "src");
+        assert_eq!(classify(MutationShape::Remove, Some(&src), None), ReconcileVerdict::Completed);
+    }
+
+    #[test]
+    fn remove_not_started_when_src_present() {
+        let d = tmp();
+        let src = touch(d.path(), "src");
+        assert_eq!(classify(MutationShape::Remove, Some(&src), None), ReconcileVerdict::NotStarted);
+    }
+
+    #[test]
+    fn create_completed_when_dst_present() {
+        let d = tmp();
+        let dst = touch(d.path(), "dst");
+        assert_eq!(classify(MutationShape::Create, None, Some(&dst)), ReconcileVerdict::Completed);
+    }
+
+    #[test]
+    fn create_not_started_when_dst_absent() {
+        let d = tmp();
+        let dst = absent(d.path(), "dst");
+        assert_eq!(classify(MutationShape::Create, None, Some(&dst)), ReconcileVerdict::NotStarted);
+    }
+
+    #[test]
+    fn none_shape_always_completed() {
+        assert_eq!(classify(MutationShape::None, None, None), ReconcileVerdict::Completed);
+    }
+}

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -19,6 +19,26 @@ use persistence_core::{DbError, DbResult};
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+/// Force the WAL contents into the main database file and fsync it.
+///
+/// Tier-1 durability escalation (constitution v1.1.0 §V): the connection pool
+/// runs `synchronous = NORMAL`, under which a WAL commit is durable only to the
+/// WAL file, and the WAL is fsynced at checkpoint — not at every commit. So a
+/// power loss between an intent commit and the next automatic checkpoint could
+/// rewind the just-committed `applying`/run row while the executor has already
+/// begun mutating the filesystem, violating "intent committed before the fs
+/// action." Calling `wal_checkpoint(TRUNCATE)` immediately after the intent
+/// commit syncs the database file, closing that window with native SQLite
+/// durability rather than a userspace write-ahead journal.
+///
+/// A failed checkpoint (e.g. a reader holding the WAL open) is not fatal: the
+/// intent is already committed to the WAL, boot reconciliation is the backstop,
+/// and the next automatic checkpoint will sync it. Callers log and proceed.
+async fn checkpoint_intent(conn: &mut SqliteConnection) -> DbResult<()> {
+    sqlx::query("PRAGMA wal_checkpoint(TRUNCATE)").execute(conn).await?;
+    Ok(())
+}
+
 // ── Row types ─────────────────────────────────────────────────────────────────
 
 /// Row returned from the `plan_apply_runs` table.
@@ -138,6 +158,15 @@ pub async fn cas_approved_to_applying(
     .await?;
 
     tx.commit().await?;
+
+    // Tier-1: sync the just-committed intent before the executor touches the
+    // filesystem (see `checkpoint_intent`). Best-effort: a failed checkpoint
+    // leaves the intent durable in the WAL, and boot reconciliation is the
+    // backstop, so the error is intentionally swallowed (the persistence layer
+    // carries no logging facade).
+    let mut conn = pool.acquire().await?;
+    let _ = checkpoint_intent(&mut conn).await;
+
     Ok(())
 }
 
@@ -281,6 +310,13 @@ pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbRes
     .await?;
 
     tx.commit().await?;
+
+    // Tier-1: resume re-enters `applying` and the executor re-runs remaining
+    // items, so the same intent-durability guarantee as apply-start applies.
+    // Best-effort (see `cas_approved_to_applying`).
+    let mut conn = pool.acquire().await?;
+    let _ = checkpoint_intent(&mut conn).await;
+
     Ok(())
 }
 
@@ -751,6 +787,158 @@ pub async fn sweep_crashed_applying_plans(pool: &SqlitePool) -> DbResult<Vec<Str
     Ok(ids)
 }
 
+// ── Boot reconciliation ───────────────────────────────────────────────────────
+
+/// A non-terminal plan item awaiting boot reconciliation against the filesystem.
+///
+/// After [`sweep_crashed_applying_plans`] flips a crashed `applying` plan to
+/// `paused`, its items may still be `pending` (never reached — the group-commit
+/// design drops the per-item `applying` write) or `applying` (a mid-run retry).
+/// Each such row is an intent whose outcome may have been rewound under
+/// `synchronous = NORMAL`; the caller probes the filesystem to classify it.
+#[derive(Clone, Debug)]
+pub struct UnreconciledItem {
+    pub id: String,
+    pub plan_id: String,
+    pub action: String,
+    pub from_root_id: Option<String>,
+    pub from_relative_path: String,
+    pub to_root_id: Option<String>,
+    pub to_relative_path: String,
+    pub archive_path: Option<String>,
+}
+
+/// List the non-terminal items of the given plans (typically the ids returned
+/// by [`sweep_crashed_applying_plans`]) so the caller can probe filesystem
+/// reality and reconcile each intent's outcome.
+///
+/// Returns only `pending`/`applying` items — terminal items already recorded
+/// their outcome and need no reconciliation.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn list_unreconciled_items(
+    pool: &SqlitePool,
+    plan_ids: &[String],
+) -> DbResult<Vec<UnreconciledItem>> {
+    if plan_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows = sqlx::query_as::<
+        _,
+        (String, String, String, Option<String>, String, Option<String>, String, Option<String>),
+    >(
+        "SELECT id, plan_id, action, from_root_id, from_relative_path, \
+                to_root_id, to_relative_path, archive_path \
+         FROM plan_items \
+         WHERE plan_id IN (SELECT value FROM json_each(?)) \
+           AND item_state IN ('pending', 'applying') \
+         ORDER BY plan_id ASC, item_index ASC",
+    )
+    .bind(serde_json::to_string(plan_ids).unwrap_or_default())
+    .fetch_all(pool)
+    .await?;
+
+    Ok(rows
+        .into_iter()
+        .map(
+            |(
+                id,
+                plan_id,
+                action,
+                from_root_id,
+                from_relative_path,
+                to_root_id,
+                to_relative_path,
+                archive_path,
+            )| {
+                UnreconciledItem {
+                    id,
+                    plan_id,
+                    action,
+                    from_root_id,
+                    from_relative_path,
+                    to_root_id,
+                    to_relative_path,
+                    archive_path,
+                }
+            },
+        )
+        .collect())
+}
+
+/// Persist the healed outcome of a boot-reconciled item.
+///
+/// `new_state` is a terminal `plan_items.item_state` (`succeeded` or `failed`);
+/// `failure_reason` carries the reconciliation verdict for ambiguous items. The
+/// per-plan counter is adjusted and an append-only `plan_apply_events` row is
+/// written recording the `prior_state -> new_state` transition with source
+/// `boot.reconcile`, so the audit trail shows recovery healed the row rather
+/// than the executor. `run_id` links the event to the crashed run.
+///
+/// # Errors
+///
+/// Returns [`DbError::Database`] on connection failure.
+pub async fn record_reconciled_outcome(
+    pool: &SqlitePool,
+    item: &UnreconciledItem,
+    prior_state: &str,
+    new_state: &str,
+    run_id: &str,
+    failure_reason: Option<&str>,
+    at: &str,
+    event_id: &str,
+) -> DbResult<()> {
+    let mut tx = pool.begin().await?;
+
+    sqlx::query("UPDATE plan_items SET item_state = ?, failure_reason = ? WHERE id = ?")
+        .bind(new_state)
+        .bind(failure_reason)
+        .bind(&item.id)
+        .execute(&mut *tx)
+        .await?;
+
+    let (d_applied, d_failed) = match new_state {
+        "succeeded" => (1_i64, 0_i64),
+        _ => (0, 1),
+    };
+    sqlx::query(
+        "UPDATE plans SET \
+           items_applied = items_applied + ?, \
+           items_failed  = items_failed  + ?, \
+           items_pending = MAX(0, items_pending - 1) \
+         WHERE id = ?",
+    )
+    .bind(d_applied)
+    .bind(d_failed)
+    .bind(&item.plan_id)
+    .execute(&mut *tx)
+    .await?;
+
+    let failure = failure_reason.map(|reason| EventFailure {
+        code: "reconcile.ambiguous",
+        message: reason,
+        recoverable: true,
+    });
+    append_event_conn(
+        &mut tx,
+        event_id,
+        run_id,
+        &item.plan_id,
+        Some(&item.id),
+        prior_state,
+        new_state,
+        at,
+        failure.as_ref(),
+        None,
+    )
+    .await?;
+
+    tx.commit().await?;
+    Ok(())
+}
+
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -1053,5 +1241,119 @@ mod tests {
         let found = get_last_stale_item(db.pool(), "ps1").await.unwrap();
         assert!(found.is_some(), "get_last_stale_item must find the stale item");
         assert_eq!(found.unwrap().id, "ps1-item-0");
+    }
+
+    #[tokio::test]
+    async fn list_unreconciled_returns_only_non_terminal_items() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        setup_with_approved_plan(&db, "pr1", 3).await;
+        cas_approved_to_applying(db.pool(), "pr1", "run-r1", "tok", 3, 3).await.unwrap();
+
+        // Flush one item to a terminal state; two remain pending.
+        let mut conn = db.pool().acquire().await.unwrap();
+        batch_flush_item_states(
+            &mut conn,
+            "pr1",
+            &[BatchItemState {
+                item_id: "pr1-item-0",
+                new_state: "succeeded",
+                failure_reason: None,
+                is_stale: false,
+            }],
+            1,
+            0,
+            0,
+        )
+        .await
+        .unwrap();
+        drop(conn);
+
+        let items = list_unreconciled_items(db.pool(), &["pr1".to_owned()]).await.unwrap();
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        assert_eq!(ids, vec!["pr1-item-1", "pr1-item-2"], "terminal items are excluded");
+        assert_eq!(items[0].action, "move");
+        assert_eq!(items[0].from_relative_path, "raw/file.fits");
+        assert_eq!(items[0].to_relative_path, "archive/file.fits");
+
+        // Empty plan-id list short-circuits to no rows.
+        assert!(list_unreconciled_items(db.pool(), &[]).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn record_reconciled_outcome_heals_and_appends_event() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        setup_with_approved_plan(&db, "pr2", 2).await;
+        cas_approved_to_applying(db.pool(), "pr2", "run-r2", "tok", 2, 2).await.unwrap();
+        sweep_crashed_applying_plans(db.pool()).await.unwrap();
+
+        let items = list_unreconciled_items(db.pool(), &["pr2".to_owned()]).await.unwrap();
+        assert_eq!(items.len(), 2);
+
+        // Heal the first item (filesystem showed the move completed).
+        record_reconciled_outcome(
+            db.pool(),
+            &items[0],
+            "pending",
+            "succeeded",
+            "run-r2",
+            None,
+            "2026-07-25T00:00:00Z",
+            "evt-heal-1",
+        )
+        .await
+        .unwrap();
+
+        // Flag the second item ambiguous.
+        record_reconciled_outcome(
+            db.pool(),
+            &items[1],
+            "pending",
+            "failed",
+            "run-r2",
+            Some("filesystem state ambiguous at boot; needs user resume/repair"),
+            "2026-07-25T00:00:01Z",
+            "evt-amb-1",
+        )
+        .await
+        .unwrap();
+
+        let healed: String = sqlx::query_scalar("SELECT item_state FROM plan_items WHERE id = ?")
+            .bind(&items[0].id)
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(healed, "succeeded");
+
+        let flagged: (String, Option<String>) =
+            sqlx::query_as("SELECT item_state, failure_reason FROM plan_items WHERE id = ?")
+                .bind(&items[1].id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(flagged.0, "failed");
+        assert!(flagged.1.unwrap().contains("ambiguous"));
+
+        let plan = plans_repo::get_plan(db.pool(), "pr2", false).await.unwrap();
+        assert_eq!(plan.items_applied, 1);
+        assert_eq!(plan.items_failed, 1);
+
+        // A boot.reconcile event was appended per item with the transition.
+        let events: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM plan_apply_events WHERE plan_id = ? AND prior_state = 'pending'",
+        )
+        .bind("pr2")
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(events, 2);
+
+        let ambiguous_code: Option<String> =
+            sqlx::query_scalar("SELECT failure_code FROM plan_apply_events WHERE id = 'evt-amb-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(ambiguous_code, Some("reconcile.ambiguous".to_owned()));
     }
 }


### PR DESCRIPTION
## Summary

After an unclean shutdown, PlateVault reconciles interrupted filesystem operations against what is actually on disk at the next boot. Operations that already completed are recorded as done; operations that never started are left ready to resume; operations in an inconsistent state are flagged for an explicit user resume/repair decision.

## What's new
- Boot-time reconciliation of interrupted plan operations against filesystem reality.
- Completed moves/archives/deletes/creates are healed automatically (no user action).
- Untouched operations are left for the existing resume flow.
- Inconsistent or unresolvable operations are flagged for review rather than silently applied or lost.
- Interrupted-plan intent records are fsynced before the file operation runs, so a power loss cannot leave a file operation with no record of intent.

## Implementation

Reuses the existing plan-apply intent (`applying` state + run row) and outcome (per-item state + append-only events) records; no new write-ahead journaling layer is added. A DB-free classifier inverts each operation's post-condition to decide completed / not-started / ambiguous.

708 touched-crate tests pass; fmt, clippy (`-D warnings`), db-boundary, and dead-callers gates green.

## Spec Context

Tracks-Bead: astro-plan-kyo7.49
Merge-Bead: astro-plan-6ao3
