### PR TITLE
fix(ci): generated contract JSON stays LF so check-generated passes on Windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -28,6 +28,13 @@ apps/desktop/biome.json text eol=lf
 *.css text eol=lf
 apps/desktop/tokens/*.json text eol=lf
 
+# Generated contract JSON artifacts. `just check-generated` re-runs the
+# generator (which always emits LF) then diffs against the committed file
+# byte-for-byte. Without this a Windows checkout converts these to CRLF and
+# the gate fails there — and only there — with a spurious drift that is not
+# present in the actual source.
+specs/**/contracts/*.generated.json text eol=lf
+
 # Migration SQL and Rust test files must use LF so that the frozen baseline
 # checksum (SHA-384 of file bytes) is identical on all platforms.
 *.sql text eol=lf


### PR DESCRIPTION
## Summary

- `specs/**/contracts/*.generated.json` lacked a `text eol=lf` rule in `.gitattributes`; Windows checkouts converted these LF blobs to CRLF on disk.
- `just check-generated` diffs the freshly generated output (always LF) against the working-tree file byte-for-byte; the CRLF checkout caused spurious drift on every Rust-touching PR on Windows.
- Added `specs/**/contracts/*.generated.json text eol=lf` matching the existing design-token artifact rule style.
- `apps/desktop/src/bindings/*.ts` are already covered by the existing `*.ts text eol=lf` rule — no change needed there.
- `git add --renormalize` produced no diff; both blobs were already stored as LF in the repo.

Tracks-Bead: astro-plan-g45e
Merge-Bead: astro-plan-eerc
