### PR TITLE
chore: remove duplicate command list in desktop backend

### DIFF
--- a/apps/desktop/src-tauri/src/bootstrap/specta.rs
+++ b/apps/desktop/src-tauri/src/bootstrap/specta.rs
@@ -181,515 +181,297 @@ fn base_builder() -> Builder<tauri::Wry> {
         .typ::<contracts_core::targets::ResolverSettingsResponse>()
 }
 
+// `collect_commands!` uses `$b:ident $(:: …)*` patterns — it cannot accept a
+// nested macro invocation, nor a `:path`-captured metavariable (fragment
+// specifier mismatch).  This macro uses the callback pattern with `:tt`
+// capture: the caller passes a macro name as `$mac:ident`; `app_commands!`
+// splices the full production command list (plus any `$extra` token trees) into
+// `$mac![…]`.  `:tt` passes tokens through verbatim so `collect_commands!` can
+// re-match them against its own `$b:ident` rule.
+//
+// The production list lives in the single `($mac:ident, $($extra:tt)*)` arm.
+// The no-extra arm `($mac:ident)` delegates to it so the list is never
+// duplicated.
+//
+// Usage:
+//   `app_commands!(collect_commands)`                  — production build
+//   `app_commands!(collect_commands, a, b, c,)`        — appends extras (dev-tools)
+macro_rules! app_commands {
+    // No-extra arm: delegates to the variadic arm with an empty extra list.
+    ($mac:ident) => {
+        app_commands!($mac,)
+    };
+    // Canonical arm: production list + optional extras (as raw token trees), via $mac![…].
+    ($mac:ident, $($extra:tt)*) => {
+        $mac![
+            // lifecycle (spec 002)
+            provenance_read,
+            lifecycle_transition_apply,
+            lifecycle_transition_preview,
+            lifecycle_ledger_list,
+            // sessions
+            sessions_list,
+            sessions_get,
+            sessions_calendar,
+            sessions_split,
+            sessions_merge,
+            // calibration (spec 029 stubs)
+            calibration_masters_list,
+            calibration_masters_get,
+            calibration_matches,
+            // calibration matching (spec 007)
+            calibration_match_suggest,
+            calibration_match_assign,
+            calibration_match_suggest_batch,
+            calibration_match_unassign,
+            // calibration master archive (#886)
+            calibration_masters_archive_plan_generate,
+            calibration_masters_archive_plan_generate_restore,
+            // target management (spec 036 — gen-3, canonical_target model)
+            target_mgmt_cmds::target_get,
+            target_mgmt_cmds::target_list,
+            target_mgmt_cmds::target_alias_add,
+            target_mgmt_cmds::target_alias_remove,
+            target_mgmt_cmds::target_display_alias_set,
+            target_mgmt_cmds::target_display_alias_clear,
+            // target history + notes (spec 023 US2/US3/US4)
+            target_mgmt_cmds::target_sessions_list,
+            target_mgmt_cmds::target_projects_list,
+            target_mgmt_cmds::target_note_get,
+            target_mgmt_cmds::target_note_update,
+            // target favourites (spec 051 US2)
+            target_favourites_list,
+            target_favourites_add,
+            target_favourites_remove,
+            // target resolve (spec 035 — SIMBAD cache-first resolution)
+            target_resolve,
+            // target resolve — explicit entrypoint, TAP-first/Sesame-fallback (spec 052 P2)
+            target_resolve_explicit,
+            // target search (spec 035, US1)
+            target_search,
+            // target in-use promotion + resolve-cache clear (spec 052 P1)
+            target_adopt,
+            target_cache_clear,
+            // cone-search suggestion at Inbox ingest (spec 052 P3)
+            target_cone_search_suggest,
+            target_cone_search_confirm,
+            // resolver settings (spec 035, US5)
+            target_resolution_settings,
+            target_resolution_settings_update,
+            // sexagesimal RA/Dec formatting (adopt target-match)
+            target_astro_format_batch,
+            // moon separation + opposition batch (#634)
+            target_moon_opposition_batch,
+            // projects (spec 008)
+            projects_list,
+            projects_get,
+            projects_create,
+            projects_update,
+            projects_source_add,
+            projects_source_remove,
+            projects_channels_reinfer,
+            projects_channels_dismiss_drift,
+            projects_framing_list,
+            projects_framing_merge,
+            projects_framing_split,
+            projects_framing_reassign,
+            projects_create_plan,
+            // plans (spec 017)
+            plans_list,
+            plans_get,
+            plans_free_space_estimate,
+            plans_approve,
+            plans_discard,
+            plans_retry,
+            archive_send_to_trash,
+            archive_permanently_delete,
+            archive_list,
+            archive_plan_generate,
+            archive_plan_generate_restore,
+            // plan apply (spec 025)
+            plans_apply_real,
+            // channel-free plan apply variant (spec 037)
+            plans_apply_direct,
+            plans_cancel,
+            plans_resume,
+            plans_item_skip,
+            plans_item_retry,
+            plans_apply_status,
+            plans_confirm_destructive,
+            // unclean-shutdown recovery (astro-plan-kyo7.48)
+            recovery_status,
+            // audit
+            audit_list,
+            audit_export,
+            entity_names,
+            // log stream (spec 019)
+            log_recent,
+            log_export,
+            // review
+            review_queue,
+            // roots & scan & equipment
+            roots_list,
+            roots_register,
+            roots_register_batch,
+            roots_remap,
+            roots_remap_apply,
+            roots_delete,
+            scan_start,
+            equipment_list,
+            sources_set_organization_state,
+            sources_set_active,
+            // first-run wizard (spec 003)
+            firstrun_state,
+            firstrun_complete,
+            firstrun_restart,
+            // pattern resolver (spec 015)
+            pattern_validate,
+            pattern_resolve,
+            pattern_preview,
+            pattern_path_preview,
+            // source protection (spec 016 US2–US4)
+            source_protection_get,
+            source_protection_set,
+            plan_protection_check_cmd,
+            protection_plan_acknowledged,
+            // settings (spec 018)
+            settings_get,
+            settings_update,
+            settings_restore_defaults,
+            settings_source_override_set,
+            settings_overridable_keys,
+            // preferences
+            preferences_get,
+            preferences_set,
+            // search
+            search_global,
+            // onboarding (spec 056)
+            onboarding_state_get,
+            onboarding_item_set_state,
+            onboarding_orientation_complete,
+            onboarding_section_set,
+            onboarding_restore,
+            // native filesystem controls (spec 004)
+            native_directory_pick,
+            native_file_pick,
+            native_reveal,
+            // equipment CRUD (spec 030)
+            equipment_cameras_list,
+            equipment_cameras_create,
+            equipment_cameras_update,
+            equipment_cameras_delete,
+            equipment_telescopes_list,
+            equipment_telescopes_create,
+            equipment_telescopes_update,
+            equipment_telescopes_delete,
+            equipment_trains_list,
+            equipment_trains_create,
+            equipment_trains_update,
+            equipment_trains_delete,
+            equipment_filters_list,
+            equipment_filters_create,
+            equipment_filters_update,
+            equipment_filters_delete,
+            // status (spec 030)
+            status_summary,
+            // cleanup policy & scan (spec 030)
+            cleanup_policy_get,
+            cleanup_policy_update,
+            cleanup_scan,
+            cleanup_plan_generate,
+            cleanup_raw_frames_scan,
+            cleanup_raw_frames_generate,
+            // calibration tolerances (spec 030)
+            calibration_tolerances_get,
+            calibration_tolerances_update,
+            // inbox (spec 005 + 030 + 039 + 041)
+            inbox_scan,
+            inbox_scan_folder,
+            inbox_classify,
+            inbox_classify_source_group,
+            inbox_confirm,
+            inbox_reclassify,
+            inbox_reclassify_v2,
+            inbox_item_metadata,
+            inbox_list,
+            inbox_plan,
+            inbox_plan_apply,
+            inbox_plan_apply_all,
+            inbox_plan_apply_selected,
+            inbox_plan_cancel,
+            inbox_stats,
+            inbox_plan_list_open,
+            inbox_property_registry,
+            inbox_target_recommendations,
+            inbox_attribution_suggest,
+            // inventory (spec 006)
+            inventory_list,
+            inventory_session_notes_update,
+            // per-frame inventory (spec 048)
+            inventory_frame_list,
+            inventory_reconcile_run,
+            inventory_frame_relink,
+            inventory_root_config_get,
+            inventory_root_config_set,
+            // ingestion settings (spec 030)
+            ingestion_settings_get,
+            ingestion_settings_update,
+            // tools (spec 011/030)
+            tools_launch,
+            tools_list,
+            tools_update,
+            tools_validate_path,
+            tools_discover,
+            // artifacts (spec 012)
+            artifact_list,
+            artifact_classify,
+            artifact_mark_resolved,
+            artifact_watcher_attach,
+            artifact_watcher_detach,
+            artifact_watcher_refresh,
+            // manifests + notes (spec 024)
+            manifest_list,
+            manifest_get,
+            note_get,
+            note_update,
+            manifest_reveal_in_os,
+            // prepared source views (spec 026)
+            preparedview_list,
+            preparedview_remove,
+            preparedview_regenerate,
+            // source view generation (spec 049)
+            sourceview_generate,
+            sourceview_verify,
+            sourceview_destination_get,
+            sourceview_destination_set,
+            // developer diagnostics (spec 021) — dev-tools build only
+            $($extra)*
+        ]
+    };
+}
+
 /// Build the tauri-specta [`Builder`] populated with every typed command.
 ///
 /// Reused by `run` (production) and `tests/bindings.rs` (TS emission).
-///
-/// When the `dev-tools` feature is enabled this function includes the
-/// `dev.contracts.list`, `dev.calls.list`, and `dev.export` commands.
-/// Without the feature those commands are absent from the binary entirely.
 #[must_use]
-#[allow(clippy::too_many_lines)]
 #[cfg(not(feature = "dev-tools"))]
 pub fn specta_builder() -> Builder<tauri::Wry> {
-    base_builder().commands(collect_commands![
-        // lifecycle (spec 002)
-        provenance_read,
-        lifecycle_transition_apply,
-        lifecycle_transition_preview,
-        lifecycle_ledger_list,
-        // sessions
-        sessions_list,
-        sessions_get,
-        sessions_calendar,
-        sessions_split,
-        sessions_merge,
-        // calibration (spec 029 stubs)
-        calibration_masters_list,
-        calibration_masters_get,
-        calibration_matches,
-        // calibration matching (spec 007)
-        calibration_match_suggest,
-        calibration_match_assign,
-        calibration_match_suggest_batch,
-        calibration_match_unassign,
-        // calibration master archive (#886)
-        calibration_masters_archive_plan_generate,
-        calibration_masters_archive_plan_generate_restore,
-        // target management (spec 036 — gen-3, canonical_target model)
-        target_mgmt_cmds::target_get,
-        target_mgmt_cmds::target_list,
-        target_mgmt_cmds::target_alias_add,
-        target_mgmt_cmds::target_alias_remove,
-        target_mgmt_cmds::target_display_alias_set,
-        target_mgmt_cmds::target_display_alias_clear,
-        // target history + notes (spec 023 US2/US3/US4)
-        target_mgmt_cmds::target_sessions_list,
-        target_mgmt_cmds::target_projects_list,
-        target_mgmt_cmds::target_note_get,
-        target_mgmt_cmds::target_note_update,
-        // target favourites (spec 051 US2)
-        target_favourites_list,
-        target_favourites_add,
-        target_favourites_remove,
-        // target resolve (spec 035 — SIMBAD cache-first resolution)
-        target_resolve,
-        // target resolve — explicit entrypoint, TAP-first/Sesame-fallback (spec 052 P2)
-        target_resolve_explicit,
-        // target search (spec 035, US1)
-        target_search,
-        // target in-use promotion + resolve-cache clear (spec 052 P1)
-        target_adopt,
-        target_cache_clear,
-        // cone-search suggestion at Inbox ingest (spec 052 P3)
-        target_cone_search_suggest,
-        target_cone_search_confirm,
-        // resolver settings (spec 035, US5)
-        target_resolution_settings,
-        target_resolution_settings_update,
-        // sexagesimal RA/Dec formatting (adopt target-match)
-        target_astro_format_batch,
-        // moon separation + opposition batch (#634)
-        target_moon_opposition_batch,
-        // projects (spec 008)
-        projects_list,
-        projects_get,
-        projects_create,
-        projects_update,
-        projects_source_add,
-        projects_source_remove,
-        projects_channels_reinfer,
-        projects_channels_dismiss_drift,
-        projects_framing_list,
-        projects_framing_merge,
-        projects_framing_split,
-        projects_framing_reassign,
-        projects_create_plan,
-        // plans (spec 017)
-        plans_list,
-        plans_get,
-        plans_free_space_estimate,
-        plans_approve,
-        plans_discard,
-        plans_retry,
-        archive_send_to_trash,
-        archive_permanently_delete,
-        archive_list,
-        archive_plan_generate,
-        archive_plan_generate_restore,
-        // plan apply (spec 025)
-        plans_apply_real,
-        // channel-free plan apply variant (spec 037)
-        plans_apply_direct,
-        plans_cancel,
-        plans_resume,
-        plans_item_skip,
-        plans_item_retry,
-        plans_apply_status,
-        plans_confirm_destructive,
-        // unclean-shutdown recovery (astro-plan-kyo7.48)
-        recovery_status,
-        // audit
-        audit_list,
-        audit_export,
-        entity_names,
-        // log stream (spec 019)
-        log_recent,
-        log_export,
-        // review
-        review_queue,
-        // roots & scan & equipment
-        roots_list,
-        roots_register,
-        roots_register_batch,
-        roots_remap,
-        roots_remap_apply,
-        roots_delete,
-        scan_start,
-        equipment_list,
-        sources_set_organization_state,
-        sources_set_active,
-        // first-run wizard (spec 003)
-        firstrun_state,
-        firstrun_complete,
-        firstrun_restart,
-        // pattern resolver (spec 015)
-        pattern_validate,
-        pattern_resolve,
-        pattern_preview,
-        pattern_path_preview,
-        // source protection (spec 016 US2–US4)
-        source_protection_get,
-        source_protection_set,
-        plan_protection_check_cmd,
-        protection_plan_acknowledged,
-        // settings (spec 018)
-        settings_get,
-        settings_update,
-        settings_restore_defaults,
-        settings_source_override_set,
-        settings_overridable_keys,
-        // preferences
-        preferences_get,
-        preferences_set,
-        // search
-        search_global,
-        // onboarding (spec 056)
-        onboarding_state_get,
-        onboarding_item_set_state,
-        onboarding_orientation_complete,
-        onboarding_section_set,
-        onboarding_restore,
-        // native filesystem controls (spec 004)
-        native_directory_pick,
-        native_file_pick,
-        native_reveal,
-        // equipment CRUD (spec 030)
-        equipment_cameras_list,
-        equipment_cameras_create,
-        equipment_cameras_update,
-        equipment_cameras_delete,
-        equipment_telescopes_list,
-        equipment_telescopes_create,
-        equipment_telescopes_update,
-        equipment_telescopes_delete,
-        equipment_trains_list,
-        equipment_trains_create,
-        equipment_trains_update,
-        equipment_trains_delete,
-        equipment_filters_list,
-        equipment_filters_create,
-        equipment_filters_update,
-        equipment_filters_delete,
-        // status (spec 030)
-        status_summary,
-        // cleanup policy & scan (spec 030)
-        cleanup_policy_get,
-        cleanup_policy_update,
-        cleanup_scan,
-        cleanup_plan_generate,
-        cleanup_raw_frames_scan,
-        cleanup_raw_frames_generate,
-        // calibration tolerances (spec 030)
-        calibration_tolerances_get,
-        calibration_tolerances_update,
-        // inbox (spec 005 + 030 + 039 + 041)
-        inbox_scan,
-        inbox_scan_folder,
-        inbox_classify,
-        inbox_classify_source_group,
-        inbox_confirm,
-        inbox_reclassify,
-        inbox_reclassify_v2,
-        inbox_item_metadata,
-        inbox_list,
-        inbox_plan,
-        inbox_plan_apply,
-        inbox_plan_apply_all,
-        inbox_plan_apply_selected,
-        inbox_plan_cancel,
-        inbox_stats,
-        inbox_plan_list_open,
-        inbox_property_registry,
-        inbox_target_recommendations,
-        inbox_attribution_suggest,
-        // inventory (spec 006)
-        inventory_list,
-        inventory_session_notes_update,
-        // per-frame inventory (spec 048)
-        inventory_frame_list,
-        inventory_reconcile_run,
-        inventory_frame_relink,
-        inventory_root_config_get,
-        inventory_root_config_set,
-        // ingestion settings (spec 030)
-        ingestion_settings_get,
-        ingestion_settings_update,
-        // tools (spec 011/030)
-        tools_launch,
-        tools_list,
-        tools_update,
-        tools_validate_path,
-        tools_discover,
-        // artifacts (spec 012)
-        artifact_list,
-        artifact_classify,
-        artifact_mark_resolved,
-        artifact_watcher_attach,
-        artifact_watcher_detach,
-        artifact_watcher_refresh,
-        // manifests + notes (spec 024)
-        manifest_list,
-        manifest_get,
-        note_get,
-        note_update,
-        manifest_reveal_in_os,
-        // prepared source views (spec 026)
-        preparedview_list,
-        preparedview_remove,
-        preparedview_regenerate,
-        // source view generation (spec 049)
-        sourceview_generate,
-        sourceview_verify,
-        sourceview_destination_get,
-        sourceview_destination_set,
-    ])
+    base_builder().commands(app_commands!(collect_commands))
 }
 
-/// `dev-tools` variant: identical to the production builder plus the three
+/// `dev-tools` variant: identical to the production builder plus the five
 /// developer-diagnostics commands (spec 021).
 ///
 /// Release binaries MUST NOT be compiled with the `dev-tools` feature.
 #[must_use]
-#[allow(clippy::too_many_lines)]
 #[cfg(feature = "dev-tools")]
 pub fn specta_builder() -> Builder<tauri::Wry> {
-    base_builder().commands(collect_commands![
-        // lifecycle (spec 002)
-        provenance_read,
-        lifecycle_transition_apply,
-        lifecycle_transition_preview,
-        lifecycle_ledger_list,
-        // sessions
-        sessions_list,
-        sessions_get,
-        sessions_calendar,
-        sessions_split,
-        sessions_merge,
-        // calibration (spec 029 stubs)
-        calibration_masters_list,
-        calibration_masters_get,
-        calibration_matches,
-        // calibration matching (spec 007)
-        calibration_match_suggest,
-        calibration_match_assign,
-        calibration_match_suggest_batch,
-        calibration_match_unassign,
-        // calibration master archive (#886)
-        calibration_masters_archive_plan_generate,
-        calibration_masters_archive_plan_generate_restore,
-        // target management (spec 036 — gen-3, canonical_target model)
-        target_mgmt_cmds::target_get,
-        target_mgmt_cmds::target_list,
-        target_mgmt_cmds::target_alias_add,
-        target_mgmt_cmds::target_alias_remove,
-        target_mgmt_cmds::target_display_alias_set,
-        target_mgmt_cmds::target_display_alias_clear,
-        // target history + notes (spec 023 US2/US3/US4)
-        target_mgmt_cmds::target_sessions_list,
-        target_mgmt_cmds::target_projects_list,
-        target_mgmt_cmds::target_note_get,
-        target_mgmt_cmds::target_note_update,
-        // target favourites (spec 051 US2)
-        target_favourites_list,
-        target_favourites_add,
-        target_favourites_remove,
-        // target resolve (spec 035 — SIMBAD cache-first resolution)
-        target_resolve,
-        // target resolve — explicit entrypoint, TAP-first/Sesame-fallback (spec 052 P2)
-        target_resolve_explicit,
-        // target search (spec 035, US1)
-        target_search,
-        // target in-use promotion + resolve-cache clear (spec 052 P1)
-        target_adopt,
-        target_cache_clear,
-        // cone-search suggestion at Inbox ingest (spec 052 P3)
-        target_cone_search_suggest,
-        target_cone_search_confirm,
-        // resolver settings (spec 035, US5)
-        target_resolution_settings,
-        target_resolution_settings_update,
-        // sexagesimal RA/Dec formatting (adopt target-match)
-        target_astro_format_batch,
-        // moon separation + opposition batch (#634)
-        target_moon_opposition_batch,
-        // projects (spec 008)
-        projects_list,
-        projects_get,
-        projects_create,
-        projects_update,
-        projects_source_add,
-        projects_source_remove,
-        projects_channels_reinfer,
-        projects_channels_dismiss_drift,
-        projects_framing_list,
-        projects_framing_merge,
-        projects_framing_split,
-        projects_framing_reassign,
-        projects_create_plan,
-        // plans (spec 017)
-        plans_list,
-        plans_get,
-        plans_free_space_estimate,
-        plans_approve,
-        plans_discard,
-        plans_retry,
-        archive_send_to_trash,
-        archive_permanently_delete,
-        archive_list,
-        archive_plan_generate,
-        archive_plan_generate_restore,
-        // plan apply (spec 025)
-        plans_apply_real,
-        // channel-free plan apply variant (spec 037)
-        plans_apply_direct,
-        plans_cancel,
-        plans_resume,
-        plans_item_skip,
-        plans_item_retry,
-        plans_apply_status,
-        plans_confirm_destructive,
-        // unclean-shutdown recovery (astro-plan-kyo7.48)
-        recovery_status,
-        // audit
-        audit_list,
-        audit_export,
-        entity_names,
-        // log stream (spec 019)
-        log_recent,
-        log_export,
-        // review
-        review_queue,
-        // roots & scan & equipment
-        roots_list,
-        roots_register,
-        roots_register_batch,
-        roots_remap,
-        roots_remap_apply,
-        roots_delete,
-        scan_start,
-        equipment_list,
-        sources_set_organization_state,
-        sources_set_active,
-        // first-run wizard (spec 003)
-        firstrun_state,
-        firstrun_complete,
-        firstrun_restart,
-        // pattern resolver (spec 015)
-        pattern_validate,
-        pattern_resolve,
-        pattern_preview,
-        pattern_path_preview,
-        // source protection (spec 016 US2–US4)
-        source_protection_get,
-        source_protection_set,
-        plan_protection_check_cmd,
-        protection_plan_acknowledged,
-        // settings (spec 018)
-        settings_get,
-        settings_update,
-        settings_restore_defaults,
-        settings_source_override_set,
-        settings_overridable_keys,
-        // preferences
-        preferences_get,
-        preferences_set,
-        // search
-        search_global,
-        // onboarding (spec 056)
-        onboarding_state_get,
-        onboarding_item_set_state,
-        onboarding_orientation_complete,
-        onboarding_section_set,
-        onboarding_restore,
-        // native filesystem controls (spec 004)
-        native_directory_pick,
-        native_file_pick,
-        native_reveal,
-        // equipment CRUD (spec 030)
-        equipment_cameras_list,
-        equipment_cameras_create,
-        equipment_cameras_update,
-        equipment_cameras_delete,
-        equipment_telescopes_list,
-        equipment_telescopes_create,
-        equipment_telescopes_update,
-        equipment_telescopes_delete,
-        equipment_trains_list,
-        equipment_trains_create,
-        equipment_trains_update,
-        equipment_trains_delete,
-        equipment_filters_list,
-        equipment_filters_create,
-        equipment_filters_update,
-        equipment_filters_delete,
-        // status (spec 030)
-        status_summary,
-        // cleanup policy & scan (spec 030)
-        cleanup_policy_get,
-        cleanup_policy_update,
-        cleanup_scan,
-        cleanup_plan_generate,
-        cleanup_raw_frames_scan,
-        cleanup_raw_frames_generate,
-        // calibration tolerances (spec 030)
-        calibration_tolerances_get,
-        calibration_tolerances_update,
-        // inbox (spec 005 + 030 + 039 + 041)
-        inbox_scan,
-        inbox_scan_folder,
-        inbox_classify,
-        inbox_classify_source_group,
-        inbox_confirm,
-        inbox_reclassify,
-        inbox_reclassify_v2,
-        inbox_item_metadata,
-        inbox_list,
-        inbox_plan,
-        inbox_plan_apply,
-        inbox_plan_apply_all,
-        inbox_plan_apply_selected,
-        inbox_plan_cancel,
-        inbox_stats,
-        inbox_plan_list_open,
-        inbox_property_registry,
-        inbox_target_recommendations,
-        inbox_attribution_suggest,
-        // inventory (spec 006)
-        inventory_list,
-        inventory_session_notes_update,
-        // per-frame inventory (spec 048)
-        inventory_frame_list,
-        inventory_reconcile_run,
-        inventory_frame_relink,
-        inventory_root_config_get,
-        inventory_root_config_set,
-        // ingestion settings (spec 030)
-        ingestion_settings_get,
-        ingestion_settings_update,
-        // tools (spec 011/030)
-        tools_launch,
-        tools_list,
-        tools_update,
-        tools_validate_path,
-        tools_discover,
-        // artifacts (spec 012)
-        artifact_list,
-        artifact_classify,
-        artifact_mark_resolved,
-        artifact_watcher_attach,
-        artifact_watcher_detach,
-        artifact_watcher_refresh,
-        // manifests + notes (spec 024)
-        manifest_list,
-        manifest_get,
-        note_get,
-        note_update,
-        manifest_reveal_in_os,
-        // prepared source views (spec 026)
-        preparedview_list,
-        preparedview_remove,
-        preparedview_regenerate,
-        // source view generation (spec 049)
-        sourceview_generate,
-        sourceview_verify,
-        sourceview_destination_get,
-        sourceview_destination_set,
-        // developer diagnostics (spec 021) — dev-tools build only
+    base_builder().commands(app_commands!(
+        collect_commands,
         dev_contracts_list,
         dev_calls_list,
         dev_calls_push,
         dev_export,
         dev_schema_get,
-    ])
+    ))
 }


### PR DESCRIPTION
## Summary

Removes 217 lines from `bootstrap/specta.rs` by replacing the two identical `collect_commands![...]` lists (production and dev-tools) with a single `macro_rules! app_commands` macro.

- Production: `base_builder().commands(app_commands!(collect_commands))`
- Dev-tools: `base_builder().commands(app_commands!(collect_commands, dev_contracts_list, dev_calls_list, dev_calls_push, dev_export, dev_schema_get,))`

The macro uses a callback pattern (`$mac:ident, $($extra:tt)*`) so `collect_commands!` still receives raw ident tokens as required. The two `#[allow(clippy::too_many_lines)]` attributes are removed as no longer needed.

## Spec Context

Tracks-Bead: astro-plan-kyo7.90
Merge-Bead: astro-plan-6u10