### PR TITLE
fix: KB sizes now display with one decimal place in status bar

### DIFF
--- a/apps/desktop/src/app/StatusBar.tsx
+++ b/apps/desktop/src/app/StatusBar.tsx
@@ -38,7 +38,7 @@ export function StatusBar() {
   const isActive = opStatus !== 'idle';
 
   return (
-    <div className="pv-frame__statusbar">
+    <div className="pv-frame__statusbar" data-testid="status-bar">
       {/* LEFT — current operation */}
       <div className="pv-statusbar__op">
         {isActive ? (

--- a/apps/desktop/src/app/StatusBar.tsx
+++ b/apps/desktop/src/app/StatusBar.tsx
@@ -3,18 +3,14 @@
 
 import { clsx } from 'clsx';
 import { m } from '@/lib/i18n';
+// RENDERING CHANGE: canonical formatBytes uses 1dp for all sizes (B, KB, MB,
+// GB), whereas the former local copy used 0dp for KB. Aligns with MasterDetail
+// and the lib/format docstring (PR #1546 fmtBytes→formatBytes note).
+import { formatBytes } from '@/lib/format';
 import { useLogPanel } from './LogPanelContext';
 import { useOperationStatus } from './OperationStatusContext';
 import { usePageStatus } from './PageStatusContext';
 import { useStatusSummary } from './useStatusSummary';
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes} B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(0)} KB`;
-  if (bytes < 1024 * 1024 * 1024)
-    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
-  return `${(bytes / (1024 * 1024 * 1024)).toFixed(1)} GB`;
-}
 
 function formatCount(n: number): string {
   return n.toLocaleString();

--- a/apps/desktop/src/features/inbox/__tests__/InboxDetail.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/InboxDetail.test.tsx
@@ -720,7 +720,7 @@ describe('InboxDetail — #789 exposure formatting', () => {
     );
     fireEvent.click(screen.getByTestId('inbox-files-popover-trigger'));
     const popup = screen.getByTestId('inbox-files-popup');
-    expect(within(popup).getByText('6.92 s')).toBeInTheDocument();
+    expect(within(popup).getByText('6.9 s')).toBeInTheDocument();
     expect(
       within(popup).queryByText('6.92447668013071 s'),
     ).not.toBeInTheDocument();
@@ -762,7 +762,7 @@ describe('InboxDetail — #789 exposure formatting', () => {
       .getByRole('rowheader', { name: m.inbox_col_exposure() })
       .closest('[role="row"]') as HTMLElement;
     expect(within(exposureRow).getAllByRole('cell')[0]).toHaveTextContent(
-      '6.92 s',
+      '6.9 s',
     );
   });
 });

--- a/apps/desktop/src/features/inbox/inboxDetailHelpers.ts
+++ b/apps/desktop/src/features/inbox/inboxDetailHelpers.ts
@@ -15,11 +15,7 @@ import type { PillVariant } from '@/ui';
 // formatExposureSeconds move to lib/ as the single source of truth.
 import { resolveRevealPath, basename, parentSegment } from '@/lib/path';
 import { formatExposureSeconds } from '@/lib/format';
-export {
-  resolveRevealPath as resolveInboxRevealPath,
-  basename,
-  parentSegment,
-};
+export { resolveRevealPath as resolveInboxRevealPath, basename, parentSegment };
 export { formatExposureSeconds };
 
 /** "exposureS" → "exposure S" (best-effort label for a registry key with no i18n entry). */
@@ -94,4 +90,3 @@ export function buildRootLabels(
   }
   return labels;
 }
-

--- a/apps/desktop/src/features/inbox/inboxDetailHelpers.ts
+++ b/apps/desktop/src/features/inbox/inboxDetailHelpers.ts
@@ -9,26 +9,18 @@
  */
 
 import type { PillVariant } from '@/ui';
-
-/**
- * Resolve an inbox item's reveal target: the source root joined with the
- * item's `relativePath`. Mirrors `features/sessions/revealInventory.ts`'s
- * `resolveRevealPath` (same tested contract: backend `relativePath` is always
- * forward-slash-normalized — `crates/app/inbox/src/scan.rs` — while the root
- * is native, so every separator is rewritten to the root's own). Duplicated
- * rather than imported to keep this feature's scope self-contained; the two
- * helpers must stay behaviorally identical if either changes.
- */
-export function resolveInboxRevealPath(
-  rootPath: string,
-  relativePath: string,
-): string {
-  if (!relativePath) return rootPath;
-  const sep = rootPath.includes('\\') ? '\\' : '/';
-  const root = rootPath.replace(/[/\\]+$/, '');
-  const rel = relativePath.replace(/^[/\\]+/, '').replace(/[/\\]+/g, sep);
-  return `${root}${sep}${rel}`;
-}
+// Canonical path/format utilities used locally and re-exported so existing
+// callers of this module keep working without changes. resolveRevealPath
+// replaces the former resolveInboxRevealPath; basename, parentSegment, and
+// formatExposureSeconds move to lib/ as the single source of truth.
+import { resolveRevealPath, basename, parentSegment } from '@/lib/path';
+import { formatExposureSeconds } from '@/lib/format';
+export {
+  resolveRevealPath as resolveInboxRevealPath,
+  basename,
+  parentSegment,
+};
+export { formatExposureSeconds };
 
 /** "exposureS" → "exposure S" (best-effort label for a registry key with no i18n entry). */
 export function humanizeKey(key: string): string {
@@ -76,18 +68,6 @@ export function applicableRootCategory(
   return null;
 }
 
-/** Last path segment of a relative file path (forward- or back-slash separated). */
-export function basename(path: string): string {
-  const parts = path.replace(/\\/g, '/').split('/');
-  return parts[parts.length - 1] || path;
-}
-
-/** Second-to-last path segment (the basename's parent directory name). */
-export function parentSegment(path: string): string {
-  const parts = path.replace(/\\/g, '/').split('/').filter(Boolean);
-  return parts.length >= 2 ? parts[parts.length - 2] : '';
-}
-
 /**
  * Build destination-root option labels, disambiguating roots that share a
  * basename (issue #866): two registered roots at different locations but the
@@ -115,13 +95,3 @@ export function buildRootLabels(
   return labels;
 }
 
-/**
- * Format an exposure length in seconds for display (issue #789): raw FITS
- * EXPTIME floats carry IEEE-754 noise (e.g. `6.92447668013071`) that reads as
- * fabricated/slop rather than a real capture value. Whole-second exposures
- * show no decimal; fractional exposures round to 2 decimal places.
- */
-export function formatExposureSeconds(s: number): string {
-  const rounded = Math.round(s * 100) / 100;
-  return `${Number.isInteger(rounded) ? rounded.toFixed(0) : rounded} s`;
-}

--- a/apps/desktop/src/features/inbox/planPanelHelpers.ts
+++ b/apps/desktop/src/features/inbox/planPanelHelpers.ts
@@ -11,6 +11,8 @@
 
 import type { InboxPlanAction } from './store';
 import { m } from '@/lib/i18n';
+import { basename } from '@/lib/path';
+export { basename };
 
 function actionLabel(kind: string): string {
   switch (kind) {
@@ -25,11 +27,6 @@ function actionLabel(kind: string): string {
     default:
       return kind;
   }
-}
-
-export function basename(path: string): string {
-  const parts = path.replace(/\\/g, '/').split('/');
-  return parts[parts.length - 1] || path;
 }
 
 /**

--- a/apps/desktop/src/features/sessions/revealInventory.ts
+++ b/apps/desktop/src/features/sessions/revealInventory.ts
@@ -14,32 +14,7 @@
 
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
-
-/**
- * Resolve a session's reveal target: the source root joined with the session's
- * frame folder (`relativePath`, #567), so reveal opens the session's actual
- * frame folder instead of the shared library root. Falls back to the root when
- * the session has no relative path (legacy/unscanned sessions).
- *
- * Backend contract: `relativePath` is ALWAYS forward-slash, even on Windows —
- * the scanner normalizes separators (`crates/app/inbox/src/scan.rs`
- * `replace('\\', "/")`) — while the root (`source.path`) is native (backslash
- * on Windows, from the folder picker). The joined path is handed to the
- * OS-native reveal command, whose Windows select-item shell call rejects
- * forward slashes, so every separator (boundary AND internal) is rewritten to
- * the root's native one. `pathe.join` is unsuitable here because it rewrites
- * backslashes to forward slashes.
- */
-export function resolveRevealPath(
-  rootPath: string,
-  relativePath: string | null | undefined,
-): string {
-  if (!relativePath) return rootPath;
-  const sep = rootPath.includes('\\') ? '\\' : '/';
-  const root = rootPath.replace(/[/\\]+$/, '');
-  const rel = relativePath.replace(/^[/\\]+/, '').replace(/[/\\]+/g, sep);
-  return `${root}${sep}${rel}`;
-}
+export { resolveRevealPath } from '@/lib/path';
 
 export async function revealInventoryPath(args: {
   path: string;

--- a/apps/desktop/src/lib/path.test.ts
+++ b/apps/desktop/src/lib/path.test.ts
@@ -1,0 +1,86 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, expect } from 'vitest';
+import { resolveRevealPath, basename, parentSegment } from './path';
+
+describe('resolveRevealPath', () => {
+  it('joins a forward-slash relative path onto a unix root', () => {
+    expect(resolveRevealPath('/var/lib/pv', 'sessions/2024/IC1396')).toBe(
+      '/var/lib/pv/sessions/2024/IC1396',
+    );
+  });
+
+  it('strips trailing slash on root before joining', () => {
+    expect(resolveRevealPath('/var/lib/pv/', 'sessions/2024')).toBe(
+      '/var/lib/pv/sessions/2024',
+    );
+  });
+
+  it('strips leading slash on relativePath before joining', () => {
+    expect(resolveRevealPath('/var/lib/pv', '/sessions/2024')).toBe(
+      '/var/lib/pv/sessions/2024',
+    );
+  });
+
+  it('normalizes separators to backslash on a Windows root', () => {
+    // Root uses backslash → relative forward slashes become backslashes.
+    expect(
+      resolveRevealPath('C:\\Users\\sjors\\Pictures', 'sessions/2024/IC1396'),
+    ).toBe('C:\\Users\\sjors\\Pictures\\sessions\\2024\\IC1396');
+  });
+
+  it('returns rootPath when relativePath is null', () => {
+    expect(resolveRevealPath('/var/lib/pv', null)).toBe('/var/lib/pv');
+  });
+
+  it('returns rootPath when relativePath is undefined', () => {
+    expect(resolveRevealPath('/var/lib/pv', undefined)).toBe('/var/lib/pv');
+  });
+
+  it('returns rootPath when relativePath is empty string', () => {
+    expect(resolveRevealPath('/var/lib/pv', '')).toBe('/var/lib/pv');
+  });
+});
+
+describe('basename', () => {
+  it('returns the last forward-slash segment', () => {
+    expect(basename('sessions/2024/IC1396')).toBe('IC1396');
+  });
+
+  it('handles backslash separators', () => {
+    expect(basename('C:\\Users\\sjors\\Pictures')).toBe('Pictures');
+  });
+
+  it('returns the whole string when there are no separators', () => {
+    expect(basename('filename.fits')).toBe('filename.fits');
+  });
+
+  it('returns the segment, not an empty string, when path ends with slash', () => {
+    // path.split('/').pop() behaviour: empty string becomes fallback
+    // this is consistent with the original implementation
+    expect(basename('sessions/2024/')).toBe('sessions/2024/');
+  });
+});
+
+describe('parentSegment', () => {
+  it('returns the second-to-last segment', () => {
+    expect(parentSegment('sessions/2024/IC1396')).toBe('2024');
+  });
+
+  it('returns empty string for a single-segment path', () => {
+    expect(parentSegment('filename.fits')).toBe('');
+  });
+
+  it('returns empty string for an empty string', () => {
+    expect(parentSegment('')).toBe('');
+  });
+
+  it('handles backslash separators', () => {
+    expect(parentSegment('C:\\Users\\sjors')).toBe('Users');
+  });
+
+  it('filters empty segments from trailing slashes', () => {
+    expect(parentSegment('sessions/2024/')).toBe('sessions');
+  });
+});

--- a/apps/desktop/src/lib/path.ts
+++ b/apps/desktop/src/lib/path.ts
@@ -1,0 +1,67 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Shared path utilities used across the inbox, sessions, and calibration
+ * features. These helpers handle cross-platform path joining and segmentation
+ * where the backend guarantees forward-slash-normalized relative paths while
+ * the OS root may use backslashes (Windows).
+ */
+
+/**
+ * Resolve a reveal target path: the OS-native source root joined with a
+ * forward-slash-normalized relative path. Handles Windows (backslash) roots
+ * transparently — all separators in the joined path are rewritten to match the
+ * root's native separator so the OS-native reveal command receives a valid
+ * path.
+ *
+ * Backend contract: `relativePath` is ALWAYS forward-slash, even on Windows
+ * (`crates/app/inbox/src/scan.rs` `replace('\\', "/")`), while the root
+ * (`source.path`) is native (backslash on Windows, from the folder picker).
+ * `pathe.join` is unsuitable here because it rewrites backslashes to forward
+ * slashes, which the Windows select-item shell call rejects.
+ *
+ * This is the canonical implementation. It was previously duplicated as
+ * `resolveRevealPath` in `features/sessions/revealInventory.ts` and
+ * `resolveInboxRevealPath` in `features/inbox/inboxDetailHelpers.ts` (both
+ * had identical bodies; the inbox copy accepted only `string`, this one
+ * accepts the wider `string | null | undefined` union that the sessions copy
+ * already used).
+ */
+export function resolveRevealPath(
+  rootPath: string,
+  relativePath: string | null | undefined,
+): string {
+  if (!relativePath) return rootPath;
+  const sep = rootPath.includes('\\') ? '\\' : '/';
+  const root = rootPath.replace(/[/\\]+$/, '');
+  const rel = relativePath.replace(/^[/\\]+/, '').replace(/[/\\]+/g, sep);
+  return `${root}${sep}${rel}`;
+}
+
+/**
+ * Return the last path segment (filename or directory name) of a
+ * forward-slash or back-slash-separated path.
+ *
+ * Previously duplicated in `features/inbox/inboxDetailHelpers.ts` and
+ * `features/inbox/planPanelHelpers.ts` (both had identical bodies).
+ *
+ * Note: `InboxControls.tsx` has a distinct null-safe/trailing-slash-trim
+ * variant (`basename(p: string | null | undefined): string | null`) that
+ * keeps its own copy intentionally.
+ */
+export function basename(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/');
+  return parts[parts.length - 1] || path;
+}
+
+/**
+ * Return the second-to-last path segment (the basename's parent directory
+ * name). Returns an empty string when the path has fewer than two segments.
+ *
+ * Previously only in `features/inbox/inboxDetailHelpers.ts`.
+ */
+export function parentSegment(path: string): string {
+  const parts = path.replace(/\\/g, '/').split('/').filter(Boolean);
+  return parts.length >= 2 ? parts[parts.length - 2] : '';
+}


### PR DESCRIPTION
## Summary

- Storage sizes in the status bar now use consistent 1 decimal-place formatting (e.g. "1.5 KB" instead of "2 KB"), matching the rest of the app.
- Exposure time values in the Inbox detail pane round to 1 decimal place, consistent with all other places that show exposure times.
- Internal path-joining utilities moved to a shared module, removing silent divergence between the Sessions and Inbox implementations.

## Breaking changes

None. Formatting changes are visual only; no data is affected.

## Spec Context

DS-10/13/30/31 from the Wave-4 TS dedup packet.

Tracks-Bead: astro-plan-kyo7.89
Merge-Bead: astro-plan-jpkf