### PR TITLE
feat: shared confirm dialog and three-state list gate components

### DIFF
--- a/apps/desktop/src/components/ConfirmModal.tsx
+++ b/apps/desktop/src/components/ConfirmModal.tsx
@@ -1,0 +1,109 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * ConfirmModal — shared confirmation dialog for destructive/reversible actions.
+ *
+ * Wraps `Modal` with the standard confirm-dialog chrome: a message body, an
+ * optional inline error, optional extra content (for disambiguation UI like a
+ * fallback-site selector), and a footer with Cancel + action button.
+ *
+ * Extracted from six duplicated confirm dialogs across Equipment, DataSources,
+ * ObservingSites, MasterArchiveFlow, and SessionDetail (C-13). All shared the
+ * same skeleton: size="sm", hideClose, footer with ghost Cancel + typed action
+ * button, optional inline field-error.
+ */
+
+import type { ReactNode } from 'react';
+import { Modal } from './Modal';
+import { Btn } from '@/ui';
+import { m } from '@/lib/i18n';
+
+export type ConfirmModalActionVariant = 'destructive' | 'danger';
+
+export interface ConfirmModalProps {
+  /** Controlled open state. */
+  open: boolean;
+  /** Called when the modal requests close (Cancel / Escape / backdrop). */
+  onClose: () => void;
+  /** Dialog title. */
+  title: ReactNode;
+  /**
+   * Body message shown below the title. Rendered inside
+   * `<p className="pv-modal__message">`.
+   */
+  message: ReactNode;
+  /** Label for the action (confirm) button. */
+  actionLabel: ReactNode;
+  /**
+   * Visual variant for the action button. Use `destructive` for irreversible
+   * actions (delete, archive) and `danger` for reversible ones (disable).
+   * DEFAULT `destructive`.
+   */
+  actionVariant?: ConfirmModalActionVariant;
+  /** Whether the action is in progress (disables both buttons). */
+  busy?: boolean;
+  /** Called when the user confirms the action. */
+  onConfirm: () => void;
+  /**
+   * Inline error text displayed below the message. Typically the error from
+   * a failed action attempt (e.g. `root.has_dependents`).
+   */
+  error?: string | null;
+  /**
+   * Optional extra content rendered between the message and the footer (e.g.
+   * a fallback destination picker when a delete requires choosing a replacement).
+   */
+  children?: ReactNode;
+  /** data-testid for the modal popup. */
+  'data-testid'?: string;
+}
+
+/**
+ * Standard two-button confirmation dialog. Intended for one-click destructive
+ * or reversible actions that need a confirmation step — not for multi-step
+ * flows or typed-confirmation patterns (use a bespoke Modal for those).
+ */
+export function ConfirmModal({
+  open,
+  onClose,
+  title,
+  message,
+  actionLabel,
+  actionVariant = 'destructive',
+  busy = false,
+  onConfirm,
+  error,
+  children,
+  'data-testid': testId,
+}: ConfirmModalProps) {
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      title={title}
+      size="sm"
+      hideClose
+      data-testid={testId}
+      footer={
+        <>
+          <Btn variant="ghost" onClick={onClose} disabled={busy}>
+            {m.common_cancel()}
+          </Btn>
+          <Btn
+            variant={actionVariant}
+            onClick={onConfirm}
+            disabled={busy}
+            data-testid={testId ? `${testId}-confirm-btn` : undefined}
+          >
+            {actionLabel}
+          </Btn>
+        </>
+      }
+    >
+      <p className="pv-modal__message">{message}</p>
+      {children}
+      {error && <span className="pv-field-error">{error}</span>}
+    </Modal>
+  );
+}

--- a/apps/desktop/src/components/TableStateGate.tsx
+++ b/apps/desktop/src/components/TableStateGate.tsx
@@ -1,0 +1,99 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * TableStateGate — shared three-state loading/error/empty gate for list pages.
+ *
+ * Renders a Skeleton while loading (with no data yet), an EmptyState on error,
+ * an EmptyState when the list is empty, or the `children` when there is data.
+ * Extracts a pattern that was hand-rolled in MastersTable, ProjectsTable,
+ * SessionsTable, TargetsTable, and ArchivePage (C-28).
+ *
+ * The "filtered empty" case (list has records, but the current filter matches
+ * none) is a separate variant that callers can opt into via `filteredEmpty`.
+ * When both `empty` and `filteredEmpty` nodes are given, `filteredEmpty` is
+ * shown only when `isEmpty` is true after loading.
+ */
+
+import type { ReactNode } from 'react';
+import { Skeleton, EmptyState } from '@/ui';
+
+export interface TableStateGateProps {
+  /** Whether the initial data load is in progress. */
+  loading: boolean;
+  /** Error from the data load. Pass a string or null/undefined. */
+  error?: string | null;
+  /** Whether the (loaded) result list is empty. */
+  isEmpty: boolean;
+  /** Number of skeleton rows to render while loading. DEFAULT 6. */
+  skeletonCount?: number;
+  /** Accessible label for the skeleton loader. */
+  skeletonLabel?: string;
+  /** EmptyState to render when the loaded list is empty (no filter applied). */
+  empty: ReactNode;
+  /**
+   * Alternative EmptyState to render when the list is empty due to a filter.
+   * When omitted, `empty` is shown for both cases.
+   */
+  filteredEmpty?: ReactNode;
+  /** Whether the current empty state is a filter-miss (uses filteredEmpty). */
+  isFilteredEmpty?: boolean;
+  /** EmptyState to render when there is a load error. Required when error is possible. */
+  errorEmpty?: ReactNode;
+  /**
+   * Extra wrapper class applied around the content area (Skeleton/EmptyState).
+   * Matches the per-feature wrapper element pattern (e.g. `pv-calib-table__status`).
+   */
+  wrapperClassName?: string;
+  /** data-testid for the wrapper element (set only when wrapperClassName is used). */
+  'data-testid'?: string;
+  /** The table content to render when loading is done and data is present. */
+  children: ReactNode;
+}
+
+/**
+ * Renders one of four states:
+ * 1. loading (and no data yet) → Skeleton
+ * 2. error → errorEmpty or a generic EmptyState
+ * 3. isEmpty (filtered miss) → filteredEmpty (if provided) or empty
+ * 4. isEmpty (truly empty) → empty
+ * 5. has data → children
+ */
+export function TableStateGate({
+  loading,
+  error,
+  isEmpty,
+  skeletonCount = 6,
+  skeletonLabel,
+  empty,
+  filteredEmpty,
+  isFilteredEmpty = false,
+  errorEmpty,
+  wrapperClassName,
+  'data-testid': testId,
+  children,
+}: TableStateGateProps) {
+  let content: ReactNode;
+
+  if (loading && isEmpty) {
+    content = (
+      <Skeleton variant="block" count={skeletonCount} label={skeletonLabel} />
+    );
+  } else if (error) {
+    content = errorEmpty ?? <EmptyState title={error} />;
+  } else if (isEmpty) {
+    content = isFilteredEmpty && filteredEmpty ? filteredEmpty : empty;
+  } else {
+    content = children;
+  }
+
+  if (wrapperClassName) {
+    return (
+      <div className={wrapperClassName} data-testid={testId}>
+        {content}
+      </div>
+    );
+  }
+
+  return <>{content}</>;
+}

--- a/apps/desktop/src/components/index.ts
+++ b/apps/desktop/src/components/index.ts
@@ -68,7 +68,10 @@ export type { ModalProps, ModalSize } from './Modal';
 
 // C-13: shared confirm dialog for delete/disable actions.
 export { ConfirmModal } from './ConfirmModal';
-export type { ConfirmModalProps, ConfirmModalActionVariant } from './ConfirmModal';
+export type {
+  ConfirmModalProps,
+  ConfirmModalActionVariant,
+} from './ConfirmModal';
 
 // C-28: shared loading/error/empty gate for list pages.
 export { TableStateGate } from './TableStateGate';

--- a/apps/desktop/src/components/index.ts
+++ b/apps/desktop/src/components/index.ts
@@ -66,6 +66,14 @@ export type { LifecycleProps } from './Lifecycle';
 export { Modal } from './Modal';
 export type { ModalProps, ModalSize } from './Modal';
 
+// C-13: shared confirm dialog for delete/disable actions.
+export { ConfirmModal } from './ConfirmModal';
+export type { ConfirmModalProps, ConfirmModalActionVariant } from './ConfirmModal';
+
+// C-28: shared loading/error/empty gate for list pages.
+export { TableStateGate } from './TableStateGate';
+export type { TableStateGateProps } from './TableStateGate';
+
 // Shared status indicator (dot + label).
 export { StatusTag } from './StatusTag';
 export type { StatusTagProps } from './StatusTag';

--- a/apps/desktop/src/features/archive/ArchivePage.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.tsx
@@ -25,8 +25,8 @@
 
 import { useRef, useState } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { ListPageLayout, PageTopBar, FilterToolbar, Modal } from '@/components';
-import { Btn, EmptyState, Skeleton } from '@/ui';
+import { ListPageLayout, PageTopBar, FilterToolbar, Modal, TableStateGate } from '@/components';
+import { Btn, EmptyState } from '@/ui';
 import { m } from '@/lib/i18n';
 import { useStaleSelectionCleanup } from '@/lib/use-stale-selection';
 import { revealLabel } from '@/lib/reveal-label';
@@ -272,18 +272,21 @@ export function ArchivePage() {
         detail={item != null ? <ArchiveDetail item={item} /> : undefined}
         onCloseDetail={item != null ? () => void clearSelection() : undefined}
       >
-        {loading ? (
-          <Skeleton variant="block" count={6} label={m.common_loading()} />
-        ) : error ? (
-          <EmptyState title={m.archive_load_error()} />
-        ) : entries.length === 0 ? (
-          <EmptyState
-            title={m.archive_empty_title()}
-            desc={m.archive_empty_desc()}
-          />
-        ) : filtered.length === 0 ? (
-          <EmptyState title={m.archive_no_match()} />
-        ) : (
+        <TableStateGate
+          loading={loading}
+          error={error ? error.message : null}
+          isEmpty={entries.length === 0}
+          isFilteredEmpty={filtered.length === 0}
+          skeletonLabel={m.common_loading()}
+          errorEmpty={<EmptyState title={m.archive_load_error()} />}
+          empty={
+            <EmptyState
+              title={m.archive_empty_title()}
+              desc={m.archive_empty_desc()}
+            />
+          }
+          filteredEmpty={<EmptyState title={m.archive_no_match()} />}
+        >
           <ArchiveTable
             entries={filtered}
             selected={selected ?? null}
@@ -291,7 +294,7 @@ export function ArchivePage() {
             sort={sort}
             onSort={handleSort}
           />
-        )}
+        </TableStateGate>
       </ListPageLayout>
 
       {item && (

--- a/apps/desktop/src/features/archive/ArchivePage.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.tsx
@@ -282,7 +282,11 @@ export function ArchivePage() {
           loading={loading}
           error={error ? error.message : null}
           isEmpty={filtered.length === 0}
-          isFilteredEmpty={search.trim().length > 0 && filtered.length === 0}
+          isFilteredEmpty={
+            entries.length > 0 &&
+            search.trim().length > 0 &&
+            filtered.length === 0
+          }
           skeletonLabel={m.common_loading()}
           errorEmpty={<EmptyState title={m.archive_load_error()} />}
           empty={

--- a/apps/desktop/src/features/archive/ArchivePage.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.tsx
@@ -25,7 +25,13 @@
 
 import { useRef, useState } from 'react';
 import { useNavigate, useSearch } from '@tanstack/react-router';
-import { ListPageLayout, PageTopBar, FilterToolbar, Modal, TableStateGate } from '@/components';
+import {
+  ListPageLayout,
+  PageTopBar,
+  FilterToolbar,
+  Modal,
+  TableStateGate,
+} from '@/components';
 import { Btn, EmptyState } from '@/ui';
 import { m } from '@/lib/i18n';
 import { useStaleSelectionCleanup } from '@/lib/use-stale-selection';

--- a/apps/desktop/src/features/archive/ArchivePage.tsx
+++ b/apps/desktop/src/features/archive/ArchivePage.tsx
@@ -281,8 +281,8 @@ export function ArchivePage() {
         <TableStateGate
           loading={loading}
           error={error ? error.message : null}
-          isEmpty={entries.length === 0}
-          isFilteredEmpty={filtered.length === 0}
+          isEmpty={filtered.length === 0}
+          isFilteredEmpty={search.trim().length > 0 && filtered.length === 0}
           skeletonLabel={m.common_loading()}
           errorEmpty={<EmptyState title={m.archive_load_error()} />}
           empty={

--- a/apps/desktop/src/features/calibration/MasterArchiveFlow.tsx
+++ b/apps/desktop/src/features/calibration/MasterArchiveFlow.tsx
@@ -10,8 +10,7 @@
  * gates the second (review/apply), and neither makes sense without the other.
  */
 
-import { Modal } from '@/components';
-import { Btn } from '@/ui';
+import { ConfirmModal } from '@/components';
 import { m } from '@/lib/i18n';
 import { PlanReviewOverlay } from '@/features/plans/PlanReviewOverlay';
 
@@ -44,29 +43,16 @@ export function MasterArchiveFlow({
   return (
     <>
       {/* #886: in-use warn + confirm gate before archiving (decisions.md). */}
-      <Modal
+      <ConfirmModal
         open={inUseConfirmOpen}
         onClose={onCloseConfirm}
         title={m.calibration_archive_in_use_confirm_title()}
-        size="sm"
-        ariaLabel={m.calibration_archive_in_use_confirm_title()}
-        footer={
-          <>
-            <Btn variant="ghost" onClick={onCloseConfirm}>
-              {m.common_cancel()}
-            </Btn>
-            <Btn
-              variant="destructive"
-              disabled={archivePending}
-              onClick={onConfirmArchiveInUse}
-            >
-              {m.calibration_action_archive()}
-            </Btn>
-          </>
-        }
-      >
-        <p>{m.calibration_archive_in_use_confirm_desc()}</p>
-      </Modal>
+        message={m.calibration_archive_in_use_confirm_desc()}
+        actionLabel={m.calibration_action_archive()}
+        busy={archivePending}
+        onConfirm={onConfirmArchiveInUse}
+        data-testid="master-archive-in-use-confirm"
+      />
 
       {/* Archive plan review overlay (#886): shares the same review → approve
           → apply kit every other plan-gated flow uses. */}

--- a/apps/desktop/src/features/sessions/SessionDetail.test.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.test.tsx
@@ -170,7 +170,7 @@ describe('SessionDetail calibration linkage — un-assign (#875)', () => {
     await screen.findByText('Remove this assignment?');
     expect(commands.calibrationMatchUnassign).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByTestId('session-calib-unassign-confirm-btn'));
+    fireEvent.click(screen.getByTestId('session-calib-unassign-confirm-confirm-btn'));
 
     await waitFor(() =>
       expect(commands.calibrationMatchUnassign).toHaveBeenCalledWith(

--- a/apps/desktop/src/features/sessions/SessionDetail.test.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.test.tsx
@@ -170,7 +170,9 @@ describe('SessionDetail calibration linkage — un-assign (#875)', () => {
     await screen.findByText('Remove this assignment?');
     expect(commands.calibrationMatchUnassign).not.toHaveBeenCalled();
 
-    fireEvent.click(screen.getByTestId('session-calib-unassign-confirm-confirm-btn'));
+    fireEvent.click(
+      screen.getByTestId('session-calib-unassign-confirm-confirm-btn'),
+    );
 
     await waitFor(() =>
       expect(commands.calibrationMatchUnassign).toHaveBeenCalledWith(

--- a/apps/desktop/src/features/sessions/SessionDetail.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.tsx
@@ -27,9 +27,9 @@ import type {
   SessionCalibrationMatch,
 } from '@/bindings/index';
 import {
+  ConfirmModal,
   DetailPane,
   DetailPanel,
-  Modal,
   PropertyTable,
   type PropertyDef,
 } from '@/components';
@@ -149,30 +149,16 @@ function CalibrationLinkage({
 
       {/* Confirm gate (#875, journey J11 "first-class action"): mirrors the
           calibration Archive in-use-confirm modal (MasterDetail.tsx). */}
-      <Modal
+      <ConfirmModal
         open={pendingUnassign !== null}
         onClose={() => setPendingUnassign(null)}
         title={m.sessions_calib_unassign_confirm_title()}
-        size="sm"
-        ariaLabel={m.sessions_calib_unassign_confirm_title()}
-        footer={
-          <>
-            <Btn variant="ghost" onClick={() => setPendingUnassign(null)}>
-              {m.common_cancel()}
-            </Btn>
-            <Btn
-              variant="destructive"
-              disabled={unassigning}
-              onClick={() => void handleConfirmUnassign()}
-              data-testid="session-calib-unassign-confirm-btn"
-            >
-              {m.sessions_calib_unassign_btn()}
-            </Btn>
-          </>
-        }
-      >
-        <p>{m.sessions_calib_unassign_confirm_desc()}</p>
-      </Modal>
+        message={m.sessions_calib_unassign_confirm_desc()}
+        actionLabel={m.sessions_calib_unassign_btn()}
+        busy={unassigning}
+        onConfirm={() => void handleConfirmUnassign()}
+        data-testid="session-calib-unassign-confirm"
+      />
     </>
   );
 }

--- a/apps/desktop/src/features/settings/Advanced.test.tsx
+++ b/apps/desktop/src/features/settings/Advanced.test.tsx
@@ -23,12 +23,12 @@ vi.mock('@tanstack/react-router', () => ({
   useNavigate: () => mockNavigate,
 }));
 
-const { mockGetSettings, mockRestartFirstRun } = vi.hoisted(() => ({
-  mockGetSettings: vi.fn().mockResolvedValue({ values: {} }),
+const { mockGetSettingsTyped, mockRestartFirstRun } = vi.hoisted(() => ({
+  mockGetSettingsTyped: vi.fn().mockResolvedValue({}),
   mockRestartFirstRun: vi.fn(),
 }));
 vi.mock('./settingsIpc', () => ({
-  getSettings: mockGetSettings,
+  getSettingsTyped: mockGetSettingsTyped,
   restartFirstRun: mockRestartFirstRun,
 }));
 
@@ -91,7 +91,7 @@ function makeResponse(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockGetSettings.mockResolvedValue({ values: {} });
+  mockGetSettingsTyped.mockResolvedValue({});
   mockNavigate.mockResolvedValue(undefined);
   mockGetUpdateSnapshot.mockReturnValue({ phase: 'idle' });
   mockSubscribeUpdate.mockReturnValue(() => {});

--- a/apps/desktop/src/features/settings/Advanced.tsx
+++ b/apps/desktop/src/features/settings/Advanced.tsx
@@ -13,7 +13,8 @@
 import { useState, useEffect, useSyncExternalStore } from 'react';
 import { useNavigate } from '@tanstack/react-router';
 import { Btn } from '@/ui';
-import { getSettings, restartFirstRun } from './settingsIpc';
+import { getSettingsTyped, restartFirstRun } from './settingsIpc';
+import { AdvancedSettingsSchema, type LOG_LEVELS } from './settingsSchemas';
 import { m } from '@/lib/i18n';
 import { errMessage } from '@/lib/errors';
 import { setPreference, resetPreferences } from '@/data/preferences';
@@ -42,7 +43,7 @@ interface AdvancedProps {
   save: (scope: string, values: Record<string, unknown>) => void;
 }
 
-type LogLevel = 'error' | 'warn' | 'info' | 'debug';
+type LogLevel = (typeof LOG_LEVELS)[number];
 
 const RESET_FEEDBACK_MS = 3000;
 
@@ -58,19 +59,22 @@ export function Advanced({ save }: AdvancedProps) {
   const [resetConfirming, setResetConfirming] = useState(false);
   const [resetDone, setResetDone] = useState(false);
 
+  // Callback used by RestoreDefaultsBtn.onRestored to re-apply values after a
+  // restore action (uses the same schema as the mount-time load).
   const applyValues = (vals: Record<string, unknown>) => {
-    if (vals?.logLevel && typeof vals.logLevel === 'string') {
-      setLogLevel(vals.logLevel as LogLevel);
+    const result = AdvancedSettingsSchema.safeParse(vals);
+    if (result.success && result.data.logLevel) {
+      setLogLevel(result.data.logLevel);
     }
   };
 
   // Load persisted logLevel from backend on mount (T015).
   useEffect(() => {
     let cancelled = false;
-    getSettings({ scope: 'advanced' })
-      .then((data) => {
+    getSettingsTyped('advanced', AdvancedSettingsSchema)
+      .then((vals) => {
         if (cancelled) return;
-        applyValues(data.values as Record<string, unknown>);
+        if (vals.logLevel) setLogLevel(vals.logLevel);
       })
       .catch(() => {
         // Backend unavailable — stay with in-code default.

--- a/apps/desktop/src/features/settings/DataSources.tsx
+++ b/apps/desktop/src/features/settings/DataSources.tsx
@@ -265,7 +265,9 @@ export function DataSources({ save: _save }: DataSourcesProps) {
         message={m.settings_datasources_delete_confirm_desc({
           path: deleteTarget?.path ?? '',
         })}
-        actionLabel={deletingId ? m.common_deleting() : m.settings_datasources_delete()}
+        actionLabel={
+          deletingId ? m.common_deleting() : m.settings_datasources_delete()
+        }
         busy={!!deletingId}
         onConfirm={() => void handleConfirmDelete()}
         error={deleteError}

--- a/apps/desktop/src/features/settings/DataSources.tsx
+++ b/apps/desktop/src/features/settings/DataSources.tsx
@@ -33,7 +33,7 @@ import { RemapRootDialog } from './RemapRootDialog';
 // explicit footers. SOURCES_KEYS (narrowed by #623) now lives in
 // `datasources-model`, and the per-root chrome/reveal/detection imports moved
 // with the markup into `RootCard`.
-import { Modal } from '@/components';
+import { ConfirmModal } from '@/components';
 import { categoryLabel, SOURCES_KEYS } from './datasources-model';
 import { RootCard } from './RootCard';
 import { useDataSources } from './useDataSources';
@@ -239,64 +239,38 @@ export function DataSources({ save: _save }: DataSourcesProps) {
       {/* Disable confirm (P6b) — re-enable applies immediately, no confirm needed.
           Disabling is reversible (re-enable is one click, no data is removed),
           so this stays on `danger`, not `destructive` (handoff 06). */}
-      <Modal
+      <ConfirmModal
         open={disableTarget != null}
         onClose={closeDisableConfirm}
         title={m.settings_datasources_disable_confirm_title()}
-        size="sm"
-        hideClose
-        footer={
-          <>
-            <Btn variant="ghost" onClick={closeDisableConfirm}>
-              {m.common_cancel()}
-            </Btn>
-            <Btn variant="danger" onClick={() => void handleConfirmDisable()}>
-              {togglingActiveId
-                ? m.common_disabling()
-                : m.settings_datasources_disable()}
-            </Btn>
-          </>
+        message={m.settings_datasources_disable_confirm_desc()}
+        actionVariant="danger"
+        actionLabel={
+          togglingActiveId
+            ? m.common_disabling()
+            : m.settings_datasources_disable()
         }
-      >
-        <p className="pv-modal__message">
-          {m.settings_datasources_disable_confirm_desc()}
-        </p>
-        {toggleActiveError && (
-          <span className="pv-field-error">{toggleActiveError}</span>
-        )}
-      </Modal>
+        busy={!!togglingActiveId}
+        onConfirm={() => void handleConfirmDisable()}
+        error={toggleActiveError}
+        data-testid="disable-root-confirm"
+      />
 
       {/* Delete confirm (P6b, decision D8) — surfaces the block reason inline
         (e.g. root.has_dependents) instead of closing the dialog on failure. */}
-      <Modal
+      <ConfirmModal
         open={deleteTarget != null}
         onClose={closeDeleteConfirm}
         title={m.settings_datasources_delete_confirm_title()}
-        size="sm"
-        hideClose
-        footer={
-          <>
-            <Btn variant="ghost" onClick={closeDeleteConfirm}>
-              {m.common_cancel()}
-            </Btn>
-            <Btn
-              variant="destructive"
-              onClick={() => void handleConfirmDelete()}
-            >
-              {deletingId
-                ? m.common_deleting()
-                : m.settings_datasources_delete()}
-            </Btn>
-          </>
-        }
-      >
-        <p className="pv-modal__message">
-          {m.settings_datasources_delete_confirm_desc({
-            path: deleteTarget?.path ?? '',
-          })}
-        </p>
-        {deleteError && <span className="pv-field-error">{deleteError}</span>}
-      </Modal>
+        message={m.settings_datasources_delete_confirm_desc({
+          path: deleteTarget?.path ?? '',
+        })}
+        actionLabel={deletingId ? m.common_deleting() : m.settings_datasources_delete()}
+        busy={!!deletingId}
+        onConfirm={() => void handleConfirmDelete()}
+        error={deleteError}
+        data-testid="delete-root-confirm"
+      />
     </>
   );
 }

--- a/apps/desktop/src/features/settings/Equipment.tsx
+++ b/apps/desktop/src/features/settings/Equipment.tsx
@@ -25,7 +25,7 @@
  */
 import { Btn, NumberField, Table } from '@/ui';
 import type { TableRow } from '@/ui';
-import { Modal } from '@/components';
+import { ConfirmModal } from '@/components';
 import { m } from '@/lib/i18n';
 import type { SensorType, FilterCategory } from './settingsIpc';
 import { SettingsSection, SettingsFormShell } from './SettingsKit';
@@ -816,33 +816,19 @@ export function Equipment({ save: _save }: EquipmentProps) {
         )}
       </SettingsSection>
 
-      <Modal
+      <ConfirmModal
         open={deleteTarget != null}
         onClose={closeDeleteConfirm}
         title={m.settings_equipment_delete_confirm_title({
           name: deleteTarget?.name ?? '',
         })}
-        size="sm"
-        hideClose
-        footer={
-          <>
-            <Btn variant="ghost" onClick={closeDeleteConfirm}>
-              {m.common_cancel()}
-            </Btn>
-            <Btn
-              variant="destructive"
-              onClick={() => void handleConfirmDelete()}
-            >
-              {deleteBusy ? m.common_removing() : m.common_remove()}
-            </Btn>
-          </>
-        }
-      >
-        <p className="pv-modal__message">
-          {m.settings_equipment_delete_confirm_desc()}
-        </p>
-        {deleteError && <span className="pv-field-error">{deleteError}</span>}
-      </Modal>
+        message={m.settings_equipment_delete_confirm_desc()}
+        actionLabel={deleteBusy ? m.common_removing() : m.common_remove()}
+        busy={deleteBusy}
+        onConfirm={() => void handleConfirmDelete()}
+        error={deleteError}
+        data-testid="equipment-delete-confirm"
+      />
     </>
   );
 }

--- a/apps/desktop/src/features/settings/settings.test.ts
+++ b/apps/desktop/src/features/settings/settings.test.ts
@@ -22,10 +22,12 @@ const {
   mockUpdateSettings,
   mockSettingsRestoreDefaults,
   mockSettingsSourceOverrideSet,
+  mockSettingsGet,
 } = vi.hoisted(() => ({
   mockUpdateSettings: vi.fn(),
   mockSettingsRestoreDefaults: vi.fn(),
   mockSettingsSourceOverrideSet: vi.fn(),
+  mockSettingsGet: vi.fn(),
 }));
 
 vi.mock('@/bindings/index', () => ({
@@ -33,14 +35,17 @@ vi.mock('@/bindings/index', () => ({
     settingsUpdate: mockUpdateSettings,
     settingsRestoreDefaults: mockSettingsRestoreDefaults,
     settingsSourceOverrideSet: mockSettingsSourceOverrideSet,
+    settingsGet: mockSettingsGet,
   },
 }));
 
 import { useAutoSave } from './useAutoSave';
 import {
+  getSettingsTyped,
   settingsRestoreDefaults,
   settingsSourceOverrideSet,
 } from './settingsIpc';
+import { AdvancedSettingsSchema } from './settingsSchemas';
 
 // ── useAutoSave ───────────────────────────────────────────────────────────────
 
@@ -261,5 +266,62 @@ describe('settingsSourceOverrideSet', () => {
       value: false,
     });
     expect(result).toEqual({ sourceId: 'root-uuid-1', key: 'hashOnScan' });
+  });
+});
+
+// ── getSettingsTyped ──────────────────────────────────────────────────────────
+
+describe('getSettingsTyped', () => {
+  beforeEach(() => {
+    mockSettingsGet.mockReset();
+  });
+
+  const respond = (values: Record<string, unknown>) => {
+    mockSettingsGet.mockResolvedValue({ status: 'ok', data: { values } });
+  };
+
+  it('returns every field when the whole object validates', async () => {
+    respond({ logLevel: 'debug', rememberFollowLogs: true, devMode: false });
+    await expect(
+      getSettingsTyped('advanced', AdvancedSettingsSchema),
+    ).resolves.toEqual({
+      logLevel: 'debug',
+      rememberFollowLogs: true,
+      devMode: false,
+    });
+  });
+
+  it('keeps the valid fields when one field is invalid', async () => {
+    // A stale enum member left by an older build must not discard its
+    // neighbours: whole-object safeParse would reject all three.
+    respond({
+      logLevel: 'verbose',
+      rememberFollowLogs: true,
+      devMode: false,
+    });
+    await expect(
+      getSettingsTyped('advanced', AdvancedSettingsSchema),
+    ).resolves.toEqual({ rememberFollowLogs: true, devMode: false });
+  });
+
+  it('drops unknown keys', async () => {
+    respond({ logLevel: 'info', somethingRetired: 'x' });
+    await expect(
+      getSettingsTyped('advanced', AdvancedSettingsSchema),
+    ).resolves.toEqual({ logLevel: 'info' });
+  });
+
+  it('returns an empty object when every field is invalid', async () => {
+    respond({ logLevel: 42, rememberFollowLogs: 'yes' });
+    await expect(
+      getSettingsTyped('advanced', AdvancedSettingsSchema),
+    ).resolves.toEqual({});
+  });
+
+  it('returns an empty object when the scope has no values', async () => {
+    respond({});
+    await expect(
+      getSettingsTyped('advanced', AdvancedSettingsSchema),
+    ).resolves.toEqual({});
   });
 });

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -123,9 +123,19 @@ export async function getSettings(args: {
 /**
  * Type-safe variant of `getSettings` (C-5). Calls `settingsGet` and passes
  * `data.values` through a Zod `.partial()` schema so callers receive a typed
- * object rather than `Record<string, unknown>`. Unknown/extra keys are dropped
- * by `.strip()`. Returns the schema defaults for missing or invalid fields
- * rather than throwing — settings reads are always best-effort.
+ * object rather than `Record<string, unknown>`. Unknown/extra keys are dropped.
+ * Never throws — settings reads are always best-effort.
+ *
+ * Validation is per field, not whole-object. `safeParse` on the whole object
+ * rejects it entirely when a single field is bad, which would discard every
+ * other valid persisted setting in the scope; a stale enum member left by an
+ * older build would silently reset the whole pane. Each key is validated
+ * against its own `schema.shape` entry instead, so a bad field is dropped and
+ * its neighbours survive.
+ *
+ * Note there is no "return the schema defaults" behaviour to fall back on: the
+ * per-scope schemas are `.partial()` with no `.default()`, so an absent field
+ * is simply absent and callers handle `undefined`.
  *
  * Usage:
  *   const vals = await getSettingsTyped('advanced', AdvancedSettingsSchema);
@@ -136,15 +146,30 @@ export async function getSettingsTyped<T extends Record<string, unknown>>(
   schema: ZodType<T>,
 ): Promise<T> {
   const data = await getSettings({ scope });
-  const result = schema.safeParse(data.values ?? {});
+  // Narrow to a plain object: a primitive or array here cannot carry named
+  // fields, and `in` is not valid against a primitive.
+  const raw: unknown = data.values;
+  const values: Record<string, unknown> =
+    typeof raw === 'object' && raw !== null && !Array.isArray(raw)
+      ? (raw as Record<string, unknown>)
+      : {};
+
+  const result = schema.safeParse(values);
   if (result.success) return result.data;
-  // On validation failure (e.g. backend schema changed), parse an empty object
-  // so callers get schema-defined defaults rather than throwing — settings reads
-  // are always best-effort. All per-scope schemas use .partial() so {} is valid.
-  const fallback = schema.safeParse({});
-  if (fallback.success) return fallback.data;
-  // If even {} fails (non-partial schema), return a cast rather than throwing.
-  return {} as T;
+
+  // Fall back to per-field salvage. `shape` exists on object schemas; if this
+  // is not one, there is nothing to iterate and the empty object is correct.
+  const shape = (schema as unknown as { shape?: Record<string, ZodType> })
+    .shape;
+  if (!shape) return {} as T;
+
+  const salvaged: Record<string, unknown> = {};
+  for (const [key, fieldSchema] of Object.entries(shape)) {
+    if (!(key in values)) continue;
+    const field = fieldSchema.safeParse(values[key]);
+    if (field.success) salvaged[key] = field.data;
+  }
+  return salvaged as T;
 }
 
 export async function updateSettings(args: {

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -13,6 +13,7 @@
  * imports from this one module.
  */
 
+import type { ZodType } from 'zod';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import { ipcArgs } from '@/lib/ipc-args';
@@ -117,6 +118,33 @@ export async function getSettings(args: {
   scope: string;
 }): Promise<SettingsData> {
   return unwrap(await commands.settingsGet(args.scope));
+}
+
+/**
+ * Type-safe variant of `getSettings` (C-5). Calls `settingsGet` and passes
+ * `data.values` through a Zod `.partial()` schema so callers receive a typed
+ * object rather than `Record<string, unknown>`. Unknown/extra keys are dropped
+ * by `.strip()`. Returns the schema defaults for missing or invalid fields
+ * rather than throwing — settings reads are always best-effort.
+ *
+ * Usage:
+ *   const vals = await getSettingsTyped('advanced', AdvancedSettingsSchema);
+ *   if (vals.logLevel) setLogLevel(vals.logLevel);
+ */
+export async function getSettingsTyped<T extends Record<string, unknown>>(
+  scope: string,
+  schema: ZodType<T>,
+): Promise<T> {
+  const data = await getSettings({ scope });
+  const result = schema.safeParse(data.values ?? {});
+  if (result.success) return result.data;
+  // On validation failure (e.g. backend schema changed), parse an empty object
+  // so callers get schema-defined defaults rather than throwing — settings reads
+  // are always best-effort. All per-scope schemas use .partial() so {} is valid.
+  const fallback = schema.safeParse({});
+  if (fallback.success) return fallback.data;
+  // If even {} fails (non-partial schema), return a cast rather than throwing.
+  return {} as T;
 }
 
 export async function updateSettings(args: {

--- a/apps/desktop/src/features/settings/settingsSchemas.ts
+++ b/apps/desktop/src/features/settings/settingsSchemas.ts
@@ -1,0 +1,84 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Per-scope Zod schemas for the Settings IPC surface (C-5).
+ *
+ * Each schema covers the keys a settings pane reads via `getSettings`. Using
+ * `.partial()` ensures fields are optional — the DB may return a subset,
+ * e.g. on first run before any value has been persisted. Unknown keys are
+ * stripped (`.strip()` is Zod's default).
+ *
+ * Callers use `getSettingsTyped(scope, schema)` from `./settingsIpc` to get
+ * a typed result instead of `Record<string, unknown>` with manual guards.
+ */
+
+import { z } from 'zod';
+
+// ── 'advanced' scope ──────────────────────────────────────────────────────────
+
+export const LOG_LEVELS = ['error', 'warn', 'info', 'debug'] as const;
+
+export const AdvancedSettingsSchema = z
+  .object({
+    logLevel: z.enum(LOG_LEVELS),
+    rememberFollowLogs: z.boolean(),
+    devMode: z.boolean(),
+  })
+  .partial();
+
+export type AdvancedSettings = z.infer<typeof AdvancedSettingsSchema>;
+
+// ── 'cleanup' scope ───────────────────────────────────────────────────────────
+
+export const DEFAULT_PROTECTION_LEVELS = [
+  'protected',
+  'standard',
+  'unprotected',
+] as const;
+
+export const CleanupSettingsSchema = z
+  .object({
+    blockPermanentDelete: z.boolean(),
+    defaultProtection: z.enum(DEFAULT_PROTECTION_LEVELS),
+  })
+  .partial();
+
+export type CleanupSettings = z.infer<typeof CleanupSettingsSchema>;
+
+// ── 'framing' scope ───────────────────────────────────────────────────────────
+
+export const FramingSettingsSchema = z
+  .object({
+    framingPointingFractionOfFov: z.number(),
+    framingPointingFallbackDeg: z.number(),
+    framingRotationToleranceDeg: z.number(),
+    framingMosaicEnvelopeFractionOfFov: z.number(),
+  })
+  .partial();
+
+export type FramingSettings = z.infer<typeof FramingSettingsSchema>;
+
+// ── 'sourceViews' scope ───────────────────────────────────────────────────────
+
+export const LINK_KINDS = ['symlink', 'hardlink', 'none'] as const;
+
+export const SourceViewsSettingsSchema = z
+  .object({
+    sourceViewLinkKindIntraDrive: z.enum(LINK_KINDS),
+    sourceViewLinkKindCrossDrive: z.enum(LINK_KINDS),
+  })
+  .partial();
+
+export type SourceViewsSettings = z.infer<typeof SourceViewsSettingsSchema>;
+
+// ── 'naming' scope ────────────────────────────────────────────────────────────
+
+export const NamingSettingsSchema = z
+  .object({
+    pattern: z.array(z.unknown()),
+    autoApplyPattern: z.boolean(),
+  })
+  .partial();
+
+export type NamingSettings = z.infer<typeof NamingSettingsSchema>;

--- a/apps/desktop/src/features/targets/observing-sites/ObservingSites.tsx
+++ b/apps/desktop/src/features/targets/observing-sites/ObservingSites.tsx
@@ -23,7 +23,7 @@
 import { lazy, Suspense, useState } from 'react';
 import { Btn, Table, Pill } from '@/ui';
 import type { TableRow } from '@/ui';
-import { Modal } from '@/components';
+import { ConfirmModal } from '@/components';
 import { m } from '@/lib/i18n';
 
 // Leaflet is ~240 KB raw. Lazy-load so it splits to its own chunk and only
@@ -537,31 +537,19 @@ export function ObservingSites() {
         </SettingsFormShell>
       )}
 
-      <Modal
+      <ConfirmModal
         open={deleteTarget != null}
         onClose={closeDeleteConfirm}
         title={m.settings_observing_sites_delete_confirm_title({
           name: deleteTarget?.name ?? '',
         })}
-        size="sm"
-        hideClose
-        footer={
-          <>
-            <Btn variant="ghost" onClick={closeDeleteConfirm}>
-              {m.common_cancel()}
-            </Btn>
-            <Btn
-              variant="destructive"
-              onClick={() => void handleConfirmDelete()}
-            >
-              {deleteBusy ? m.common_removing() : m.common_remove()}
-            </Btn>
-          </>
-        }
+        message={m.settings_observing_sites_delete_confirm_desc()}
+        actionLabel={deleteBusy ? m.common_removing() : m.common_remove()}
+        busy={deleteBusy}
+        onConfirm={() => void handleConfirmDelete()}
+        error={deleteError}
+        data-testid="observing-site-delete-confirm"
       >
-        <p className="pv-modal__message">
-          {m.settings_observing_sites_delete_confirm_desc()}
-        </p>
         {deleteNeedsFallbackChoice && (
           <div className="pv-stack-1">
             <label className="pv-field-label" htmlFor="observing-site-fallback">
@@ -585,8 +573,7 @@ export function ObservingSites() {
             </select>
           </div>
         )}
-        {deleteError && <span className="pv-field-error">{deleteError}</span>}
-      </Modal>
+      </ConfirmModal>
     </SettingsSection>
   );
 }

--- a/apps/desktop/src/lib/local-storage.test.ts
+++ b/apps/desktop/src/lib/local-storage.test.ts
@@ -66,19 +66,33 @@ describe('writeLocalStorage', () => {
   // string "undefined", which `readLocalStorage` then reports as corrupt
   // rather than absent.
   describe('values JSON cannot represent', () => {
-    let setItem: ReturnType<typeof vi.spyOn>;
-    let removeItem: ReturnType<typeof vi.spyOn>;
+    // Install a recording stub rather than spying on the ambient
+    // `localStorage`: which object that is varies by environment (jsdom's
+    // Storage, Node's experimental global, or vitest.setup.ts's Map-backed
+    // replacement), and a spy attached to the wrong one records nothing —
+    // which made an earlier version of these tests pass locally and fail in
+    // CI. Replacing the global makes the assertion environment-independent.
+    const setItem = vi.fn<(key: string, value: string) => void>();
+    const removeItem = vi.fn<(key: string) => void>();
+    let original: Storage;
 
     beforeEach(() => {
-      // Spy on the instance, not `Storage.prototype`: this environment's
-      // `localStorage` is not necessarily a `Storage` instance, so a prototype
-      // spy would never intercept.
-      setItem = vi.spyOn(localStorage, 'setItem');
-      removeItem = vi.spyOn(localStorage, 'removeItem');
+      setItem.mockClear();
+      removeItem.mockClear();
+      original = globalThis.localStorage;
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: { ...original, setItem, removeItem },
+        writable: true,
+        configurable: true,
+      });
     });
 
     afterEach(() => {
-      vi.restoreAllMocks();
+      Object.defineProperty(globalThis, 'localStorage', {
+        value: original,
+        writable: true,
+        configurable: true,
+      });
     });
 
     it('removes the key for undefined instead of calling setItem', () => {

--- a/apps/desktop/src/lib/local-storage.test.ts
+++ b/apps/desktop/src/lib/local-storage.test.ts
@@ -1,0 +1,60 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { z } from 'zod';
+import { readLocalStorage, writeLocalStorage } from './local-storage';
+
+const KEY = 'test.readLocalStorage';
+
+beforeEach(() => {
+  localStorage.removeItem(KEY);
+});
+
+describe('readLocalStorage', () => {
+  it('returns fallback when key is absent', () => {
+    const result = readLocalStorage(KEY, z.string(), 'default');
+    expect(result).toBe('default');
+  });
+
+  it('returns the parsed value when key is present and valid', () => {
+    localStorage.setItem(KEY, JSON.stringify('hello'));
+    const result = readLocalStorage(KEY, z.string(), 'default');
+    expect(result).toBe('hello');
+  });
+
+  it('returns fallback when JSON is corrupted', () => {
+    localStorage.setItem(KEY, 'not-valid-json{');
+    const result = readLocalStorage(KEY, z.string(), 'default');
+    expect(result).toBe('default');
+  });
+
+  it('returns fallback when the stored shape fails schema validation', () => {
+    // Stale storage: stored a number, schema expects string.
+    localStorage.setItem(KEY, JSON.stringify(42));
+    const result = readLocalStorage(KEY, z.string(), 'default');
+    expect(result).toBe('default');
+  });
+
+  it('works with object schemas', () => {
+    const schema = z.object({ count: z.number() });
+    localStorage.setItem(KEY, JSON.stringify({ count: 7 }));
+    const result = readLocalStorage(KEY, schema, { count: 0 });
+    expect(result).toEqual({ count: 7 });
+  });
+
+  it('returns fallback for partial object when schema requires all fields', () => {
+    const schema = z.object({ a: z.string(), b: z.number() });
+    localStorage.setItem(KEY, JSON.stringify({ a: 'x' })); // missing b
+    const result = readLocalStorage(KEY, schema, { a: '', b: 0 });
+    expect(result).toEqual({ a: '', b: 0 });
+  });
+});
+
+describe('writeLocalStorage', () => {
+  it('writes a JSON value that readLocalStorage can read back', () => {
+    writeLocalStorage(KEY, { x: 1 });
+    const result = readLocalStorage(KEY, z.object({ x: z.number() }), { x: 0 });
+    expect(result).toEqual({ x: 1 });
+  });
+});

--- a/apps/desktop/src/lib/local-storage.test.ts
+++ b/apps/desktop/src/lib/local-storage.test.ts
@@ -1,7 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { z } from 'zod';
 import { readLocalStorage, writeLocalStorage } from './local-storage';
 
@@ -56,5 +56,53 @@ describe('writeLocalStorage', () => {
     writeLocalStorage(KEY, { x: 1 });
     const result = readLocalStorage(KEY, z.object({ x: z.number() }), { x: 0 });
     expect(result).toEqual({ x: 1 });
+  });
+
+  // These assert on the storage CALLS rather than on a subsequent read: some
+  // storage backends (Node's built-in localStorage) already reject a
+  // non-string, so a read-back assertion passes either way and would not
+  // catch a regression. What must hold is that `setItem` is never handed a
+  // non-JSON value, because a backend that coerces it stores the literal
+  // string "undefined", which `readLocalStorage` then reports as corrupt
+  // rather than absent.
+  describe('values JSON cannot represent', () => {
+    let setItem: ReturnType<typeof vi.spyOn>;
+    let removeItem: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      // Spy on the instance, not `Storage.prototype`: this environment's
+      // `localStorage` is not necessarily a `Storage` instance, so a prototype
+      // spy would never intercept.
+      setItem = vi.spyOn(localStorage, 'setItem');
+      removeItem = vi.spyOn(localStorage, 'removeItem');
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('removes the key for undefined instead of calling setItem', () => {
+      writeLocalStorage(KEY, undefined);
+      expect(setItem).not.toHaveBeenCalled();
+      expect(removeItem).toHaveBeenCalledWith(KEY);
+    });
+
+    it('removes the key for a function instead of calling setItem', () => {
+      writeLocalStorage(KEY, () => 'not serializable');
+      expect(setItem).not.toHaveBeenCalled();
+      expect(removeItem).toHaveBeenCalledWith(KEY);
+    });
+
+    it('still persists falsy values that JSON can represent', () => {
+      writeLocalStorage(KEY, null);
+      writeLocalStorage(KEY, 0);
+      writeLocalStorage(KEY, false);
+      expect(setItem.mock.calls).toEqual([
+        [KEY, 'null'],
+        [KEY, '0'],
+        [KEY, 'false'],
+      ]);
+      expect(removeItem).not.toHaveBeenCalled();
+    });
   });
 });

--- a/apps/desktop/src/lib/local-storage.ts
+++ b/apps/desktop/src/lib/local-storage.ts
@@ -45,10 +45,21 @@ export function readLocalStorage<T>(
 /**
  * Write a JSON value to localStorage. Silently no-ops when storage is full or
  * unavailable (matching the convention across all existing write sites).
+ *
+ * A value JSON cannot represent (`undefined`, a function, a symbol) makes
+ * `JSON.stringify` return `undefined`, which `setItem` would coerce to the
+ * literal string `"undefined"` — a value `readLocalStorage` then treats as
+ * corrupt rather than absent. Remove the key instead, so a subsequent read
+ * reports a clean miss and returns its fallback.
  */
 export function writeLocalStorage<T>(key: string, value: T): void {
   try {
-    localStorage.setItem(key, JSON.stringify(value));
+    const serialized = JSON.stringify(value);
+    if (serialized === undefined) {
+      localStorage.removeItem(key);
+      return;
+    }
+    localStorage.setItem(key, serialized);
   } catch {
     // Storage full or unavailable — non-fatal.
   }

--- a/apps/desktop/src/lib/local-storage.ts
+++ b/apps/desktop/src/lib/local-storage.ts
@@ -1,0 +1,55 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Type-safe localStorage read helper (C-24).
+ *
+ * All four localStorage JSON-parsing sites (wizard draft, setup wizard state,
+ * sources store, preferences) followed the same try/catch + JSON.parse +
+ * fallback pattern but without schema validation. This helper consolidates
+ * that pattern and adds Zod parse so corrupted / stale storage values fall
+ * back to the default instead of propagating as silently-wrong shapes.
+ */
+
+import type { ZodType } from 'zod';
+
+/**
+ * Read and parse a JSON value from localStorage, validating with a Zod schema.
+ *
+ * Returns `fallback` when:
+ * - the key is absent
+ * - JSON.parse throws (corrupted value)
+ * - Zod validation fails (stale shape after a schema change)
+ * - localStorage is unavailable (SSR / unit-test environments that mock it)
+ *
+ * @param key      localStorage key
+ * @param schema   Zod schema; `.safeParse()` is called so errors never throw
+ * @param fallback value returned on miss or validation failure
+ */
+export function readLocalStorage<T>(
+  key: string,
+  schema: ZodType<T>,
+  fallback: T,
+): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw === null) return fallback;
+    const parsed: unknown = JSON.parse(raw);
+    const result = schema.safeParse(parsed);
+    return result.success ? result.data : fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+/**
+ * Write a JSON value to localStorage. Silently no-ops when storage is full or
+ * unavailable (matching the convention across all existing write sites).
+ */
+export function writeLocalStorage<T>(key: string, value: T): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(value));
+  } catch {
+    // Storage full or unavailable — non-fatal.
+  }
+}


### PR DESCRIPTION
## Summary

- Adds a shared confirmation dialog component used for all delete/disable actions (equipment, data sources, observing sites, calibration masters, session calibration unassignment). Each now uses a consistent layout with a Cancel + action button and an optional inline error.
- Adds a shared loading/error/empty gate component for list pages, adopted in the Archive page.
- Adds a type-safe localStorage read helper with Zod schema validation, so stale or corrupted stored values fall back to defaults instead of propagating as wrong shapes.
- Adds per-scope Zod schemas for settings panes (advanced, cleanup, framing, sourceViews, naming), eliminating `as Record<string, unknown>` casts and replacing them with typed parsed results.

## Spec Context

C-5/13/24/28 from the Wave-4 TS dedup packet.

Tracks-Bead: astro-plan-kyo7.89
Merge-Bead: astro-plan-y9o2