### PR TITLE
docs: make workspace rustdoc warning-clean under -D warnings

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -44,7 +44,7 @@ pub const MAIN_WINDOW_LABEL: &str = "main";
 // scope. `tests/bindings.rs` depends on `desktop_shell::specta_builder`.
 include!("bootstrap/specta.rs");
 
-/// Build the Tauri [`App`] **without** starting the event loop.
+/// Build the Tauri `App` **without** starting the event loop.
 ///
 /// The returned handle exposes the platform path resolver (needed to locate
 /// the default `SQLite` database path) while the caller retains full control
@@ -240,7 +240,7 @@ pub fn build_app() -> tauri::App {
 }
 
 /// Builds the compiled-in Tauri context and defers the main window's
-/// creation (see [`defer_main_window`]).
+/// creation (see `defer_main_window`).
 ///
 /// Per-instance webview isolation for the E2E harness (#1204) does **not**
 /// go through this context any more: it used to point each config-declared
@@ -303,7 +303,7 @@ fn instance_context() -> tauri::Context {
 /// Start the event loop first, then finish database startup behind the splash.
 ///
 /// The splash is the only window Tauri creates for itself (see
-/// [`defer_main_window`]), so it paints as soon as `app.run()` begins pumping.
+/// `defer_main_window`), so it paints as soon as `app.run()` begins pumping.
 /// Connecting, migrating, and wiring shared state all happen on a background
 /// task from there, and the main window is built only once that task has
 /// finished — so a long migration is visible instead of being a windowless

--- a/apps/desktop/src-tauri/src/resolve_cache.rs
+++ b/apps/desktop/src-tauri/src/resolve_cache.rs
@@ -29,7 +29,7 @@
 //! handle (cloned out before the swap, so it keeps warming the same
 //! underlying store regardless of what `AppState::resolve_cache` is swapped
 //! to next), plus a second clone of the whole [`ResolveCache`] (not just its
-//! erased `.cache()`) to call [`ResolveCache::flush`] on once both phases
+//! erased `.cache()`) to call `ResolveCache::flush` on once both phases
 //! finish — the one fsync that persists every `Eventual` chunk.
 //!
 //! Chunking each phase's warm means nothing in a given chunk is visible to a

--- a/apps/desktop/src/bindings/index.ts
+++ b/apps/desktop/src/bindings/index.ts
@@ -3120,7 +3120,7 @@ export type Camera = {
 	passband: string[] | null,
 	/**
 	 *  Pixel pitch in micrometres; `None` = not recorded. Square pixels are
-	 *  assumed on both axes, matching [`sessions::fov_diagonal_deg`].
+	 *  assumed on both axes, matching `sessions::fov_diagonal_deg`.
 	 */
 	pixelSizeUm?: number | null,
 	/**  Unbinned sensor width in pixels (FITS `NAXIS1`); `None` = not recorded. */
@@ -7277,7 +7277,7 @@ export type PathPatternPreviewResponse = {
  * 
  *  Re-exported from `crates/contracts/core` so the Tauri command layer can
  *  reference it without importing `crates/patterns` directly. The shape matches
- *  [`patterns::PatternPart`] exactly.
+ *  `patterns::PatternPart` exactly.
  */
 export type PatternPartDto = {
 	/**  Stable client-side identifier. */
@@ -7766,7 +7766,7 @@ export type PlanType = "split" | "restructure" | "cleanup" | "archive" | "source
 "source_view_generation";
 
 /**
- *  Coordinate-source quality for a derived [`Pointing`] (FR-012).
+ *  Coordinate-source quality for a derived pointing (FR-012).
  * 
  *  `Wcs` (plate-solved `CRVAL1/2`) is high confidence; `Mount` (`OBJCTRA`/
  *  `OBJCTDEC` or decimal `RA`/`DEC`) is medium; `None` means no reliable

--- a/crates/app/calibration/src/session_handoff/snapshots.rs
+++ b/crates/app/calibration/src/session_handoff/snapshots.rs
@@ -69,8 +69,8 @@ pub struct CreateHandoffParams<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
-/// Returns [`DbError::CasFailed`] if the head advance fails (cannot occur
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` if the head advance fails (cannot occur
 /// on initial creation, but included for type consistency).
 pub async fn create_initial_handoff(
     conn: &mut SqliteConnection,
@@ -171,9 +171,9 @@ pub struct AddReviewedSelectionParams<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] when `expected_head_generation` does not
+/// Returns `persistence_core::DbError::CasFailed` when `expected_head_generation` does not
 /// match the current head generation.
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn add_reviewed_selection_snapshot(
     conn: &mut SqliteConnection,
     params: &AddReviewedSelectionParams<'_>,
@@ -239,7 +239,7 @@ pub async fn add_reviewed_selection_snapshot(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_operation_for_handoff(
     conn: &mut SqliteConnection,
     public_id: &str,

--- a/crates/app/core/src/calibration_archive_generator.rs
+++ b/crates/app/core/src/calibration_archive_generator.rs
@@ -9,7 +9,7 @@
 //! [`crate::archive_generator`]'s whole-project archive/restore. This module
 //! mirrors that shape for a single calibration master instead of a whole
 //! project's artifacts, reusing the same [`crate::protection::generate_plan`]
-//! tail and (for restore) [`crate::archive_generator::generate_restore_generic`]
+//! tail and (for restore) `crate::archive_generator::generate_restore_generic`
 //! — never duplicating that machinery.
 //!
 //! ## Candidate resolution
@@ -28,7 +28,7 @@
 //!
 //! A master currently assigned to one or more sessions requires an explicit
 //! `confirm_in_use = true` to archive — mirrors `calibration.match.assign`'s
-//! `override` gate. [`generate`] returns `calibration.master_in_use` when
+//! `override` gate. `generate` returns `calibration.master_in_use` when
 //! the caller has not confirmed.
 //!
 //! ## Lifecycle closure
@@ -172,11 +172,11 @@ pub async fn generate(
 
 /// Materialise a reviewable restore (un-archive) plan for a previously
 /// applied master-archive plan (#886). Thin wrapper over the shared
-/// [`generate_restore_generic`] tail (#885's project restore extracted it).
+/// `generate_restore_generic` tail (#885's project restore extracted it).
 ///
 /// # Errors
 ///
-/// See [`generate_restore_generic`].
+/// See `generate_restore_generic`.
 pub async fn generate_restore(
     pool: &SqlitePool,
     archived_plan_id: &str,

--- a/crates/app/core/src/cleanup_generator/mod.rs
+++ b/crates/app/core/src/cleanup_generator/mod.rs
@@ -6,7 +6,7 @@
 //! Two-step flow (D11):
 //!   1. [`scan`] — pure, read-only preview. Enumerates a project's observed
 //!      processing artifacts, classifies each into a [`DataType`], applies the
-//!      persisted [`CleanupPolicy`], and returns candidate files plus reclaimable
+//!      persisted `CleanupPolicy`, and returns candidate files plus reclaimable
 //!      bytes. NO plan row is created and NO filesystem mutation occurs (FR-002).
 //!   2. [`generate`] — materialises a reviewable cleanup plan from the same
 //!      candidates by building `CleanupPlanItem`s and delegating to the spec-016
@@ -43,7 +43,7 @@
 //!
 //! ## Policy storage (D13)
 //!
-//! The [`CleanupPolicy`] is persisted through the existing generic
+//! The `CleanupPolicy` is persisted through the existing generic
 //! `protection_defaults` (scope, key, value-JSON) store (migration 0035) under
 //! `scope = "cleanup"`, `key = "policy"`. The policy serialises cleanly to JSON,
 //! so no new table or migration is required.

--- a/crates/app/core/src/first_run/mod.rs
+++ b/crates/app/core/src/first_run/mod.rs
@@ -12,10 +12,10 @@
 //! references it. `app_core` re-exports this crate at `app_core::first_run` so the
 //! public surface stays byte-identical.
 //!
-//! Split by responsibility (refactor sweep #975): [`sources`] is
-//! register/list/remove + the batch pipeline; [`wizard`] is the
-//! `first_run_state` singleton (get/complete/restart); [`root_remap`] is
-//! P6a (`roots.remap`/`.apply`); [`root_ops`] is P6b (active toggle +
+//! Split by responsibility (refactor sweep #975): `sources` is
+//! register/list/remove + the batch pipeline; `wizard` is the
+//! `first_run_state` singleton (get/complete/restart); `root_remap` is
+//! P6a (`roots.remap`/`.apply`); `root_ops` is P6b (active toggle +
 //! delete). Path validation, error mapping, and the shared audit-writing
 //! helpers used by more than one use case stay here.
 #![allow(clippy::doc_markdown)] // spec/domain terminology not appropriate for backticks

--- a/crates/app/core/src/first_run/root_remap.rs
+++ b/crates/app/core/src/first_run/root_remap.rs
@@ -160,7 +160,7 @@ async fn ensure_remap_verified(
 ///
 /// Re-validates `new_path` so an apply cannot silently succeed against a path
 /// that no longer exists between preview and apply (e.g. an unmounted drive).
-/// Also re-derives verification itself via [`compute_remap_verification`]
+/// Also re-derives verification itself via `compute_remap_verification`
 /// rather than trusting the caller-supplied `verified` flag: both the flag
 /// AND the freshly recomputed state must agree the remap is verified, so a
 /// stale preview or a direct IPC call can't bypass the gate.

--- a/crates/app/core/src/frame_inventory/mod.rs
+++ b/crates/app/core/src/frame_inventory/mod.rs
@@ -55,7 +55,7 @@ use contracts_core::inventory_frame::{
 ///
 /// # Errors
 ///
-/// Returns `ContractError` per [`reconcile::run_reconcile`]. A failed
+/// Returns `ContractError` per `reconcile::run_reconcile`. A failed
 /// project-health check is retried on the next reconcile for the same root,
 /// because the frame-state writes have already committed by then.
 pub async fn run_reconcile(

--- a/crates/app/core/src/inbox_plan.rs
+++ b/crates/app/core/src/inbox_plan.rs
@@ -4,11 +4,11 @@
 //! Inbox plan use-cases (spec 041, US1).
 //!
 //! Entry points:
-//! - [`get_inbox_plan`]       — fetch the plan linked to an inbox item as `InboxPlanView`.
-//! - [`apply_inbox_plan`]     — auto-approve then apply the linked plan; on
+//! - `get_inbox_plan`       — fetch the plan linked to an inbox item as `InboxPlanView`.
+//! - `apply_inbox_plan`     — auto-approve then apply the linked plan; on
 //!   success marks the inbox item `resolved`.
-//! - [`apply_all_inbox_plans`]— apply every `plan_open` item's plan; per-plan results.
-//! - [`cancel_inbox_plan`]    — discard the linked plan; item returns to `classified`.
+//! - `apply_all_inbox_plans`— apply every `plan_open` item's plan; per-plan results.
+//! - `cancel_inbox_plan`    — discard the linked plan; item returns to `classified`.
 //!
 //! FR-003 / FR-003a / FR-005 / FR-006 / FR-007.
 //!

--- a/crates/app/core/src/onboarding.rs
+++ b/crates/app/core/src/onboarding.rs
@@ -5,21 +5,21 @@
 //!
 //! Successor to the removed spec-010 first-project coach state machine.
 //! Three layers share this one backend:
-//! - L1 orientation walk: [`orientation_complete`] sets
+//! - L1 orientation walk: `orientation_complete` sets
 //!   `onboarding_flags.orientation_done_at`.
-//! - L2 checklists: [`get_state`]/[`set_item_state`]/[`section_set`] over
-//!   [`ITEM_REGISTRY`].
+//! - L2 checklists: `get_state`/`set_item_state`/`section_set` over
+//!   `ITEM_REGISTRY`.
 //! - L3 find-it spotlight: reads `anchor` from the registry; no backend use
 //!   case (UI-only).
 //!
 //! ## Item registry
 //!
-//! [`ITEM_REGISTRY`] is the single source of truth for the five FR-006
+//! `ITEM_REGISTRY` is the single source of truth for the five FR-006
 //! workflow pages (`inbox`, `sessions`, `calibration`, `targets`,
 //! `projects`), 2-4 items each. AUTOMATIC items (`completion_topic` +
 //! `seed_query` both set) are ticked by the live bus subscriber
 //! (`apps/desktop/src-tauri/src/commands/onboarding.rs`, T005) via
-//! [`tick_from_event`] and re-derived by seed/restore below; the rest are
+//! `tick_from_event` and re-derived by seed/restore below; the rest are
 //! manual (FR-017). `completion_topic`/`seed_query` pairs are drawn from the
 //! research R4 verified auto-tick inventory only — no new backend events are
 //! minted (decision record #2). Labels/tooltips/reasons are Paraglide keys
@@ -27,32 +27,32 @@
 //!
 //! ## Seed/restore derivation (FR-014/PQ-001)
 //!
-//! [`target_state_for`] computes "what should this item's state be given
+//! `target_state_for` computes "what should this item's state be given
 //! real recorded data" for every item — the one derivation routine backing
 //! both:
-//! - the lazy first-activation seed ([`ensure_seeded`], called from
-//!   [`get_state`]): only inserts rows that don't exist yet, via
+//! - the lazy first-activation seed (`ensure_seeded`, called from
+//!   `get_state`): only inserts rows that don't exist yet, via
 //!   `persistence_lifecycle::repositories::onboarding::insert_if_missing` — never
 //!   re-touches an existing row, so a mere read can never silently
 //!   auto-tick an item (that would bypass the bus subscriber, breaking
 //!   FR-021's backend-authoritative-via-subscriber-only invariant);
-//! - the explicit [`restore`] command: re-derives every AUTOMATIC item's row
+//! - the explicit `restore` command: re-derives every AUTOMATIC item's row
 //!   via `upsert_if_unsettled`, which is a no-op for settled
 //!   (`manually_checked`/`dismissed`) rows — user progress is never
 //!   discarded;
-//! - the once-per-startup [`reconcile_missed_events`] pass (PQ-005): the same
+//! - the once-per-startup `reconcile_missed_events` pass (PQ-005): the same
 //!   re-derivation narrowed to rows that are `unchecked` from a non-`user`
 //!   source, so a missed live event self-heals without ever undoing a
 //!   deliberate un-check.
 //!
 //! ## FR-031 settle path
 //!
-//! [`settle_and_maybe_hide`] runs after every write that could be a
-//! *settling* transition — a live-event tick ([`tick_from_event`]) or a
-//! manual check-off/dismiss ([`set_item_state`]) — never seed/restore, which
+//! `settle_and_maybe_hide` runs after every write that could be a
+//! *settling* transition — a live-event tick (`tick_from_event`) or a
+//! manual check-off/dismiss (`set_item_state`) — never seed/restore, which
 //! are derivations, not transitions. When it leaves zero `unchecked` rows
 //! across the whole registry, `onboarding_flags.section_hidden_at` is set.
-//! [`restore`] always clears that flag regardless of the resulting item
+//! `restore` always clears that flag regardless of the resulting item
 //! states (FR-014) — a still-complete section stays visible until a NEW
 //! settling transition or an explicit `section_set { hidden: true }`.
 
@@ -289,7 +289,7 @@ fn page_order(page: OnboardingPage) -> u8 {
 
 #[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
 pub enum OnboardingError {
-    /// `item.set_state` referenced an `item_id` not in [`ITEM_REGISTRY`].
+    /// `item.set_state` referenced an `item_id` not in `ITEM_REGISTRY`.
     #[error("unknown onboarding item id: {0}")]
     UnknownItem(String),
     /// An automatic item was manually marked complete. Automatic completion
@@ -605,8 +605,8 @@ pub async fn orientation_complete(
 
 /// `onboarding.section.set` — explicit remove (FR-013) and collapse
 /// persistence (FR-012). `hidden` accepts only `true`; unhiding is
-/// exclusively [`restore`]. The FR-031 completion auto-hide is written only
-/// by [`settle_and_maybe_hide`], never through this command.
+/// exclusively `restore`. The FR-031 completion auto-hide is written only
+/// by `settle_and_maybe_hide`, never through this command.
 ///
 /// # Errors
 ///
@@ -678,16 +678,16 @@ pub async fn tick_from_event(pool: &SqlitePool, item_id: &str) -> Result<(), Onb
 /// item stays `unchecked` forever unless the user happens to run the Settings
 /// restore, which nothing prompts them to do.
 ///
-/// Re-derives AUTOMATIC items via [`target_state_for`], but only for rows that
+/// Re-derives AUTOMATIC items via `target_state_for`, but only for rows that
 /// are currently `unchecked` from a non-user source. A deliberate PQ-002
 /// un-check must survive startup reconciliation.
 ///
-/// Items with no row yet are skipped, not seeded: [`ensure_seeded`] derives
+/// Items with no row yet are skipped, not seeded: `ensure_seeded` derives
 /// those correctly on the next `state.get`, so there is nothing to recover.
 ///
 /// This does NOT violate FR-021's backend-authoritative-via-subscriber-only
 /// invariant. The invariant that matters is that a mere READ must never
-/// auto-tick (why [`ensure_seeded`] uses `insert_if_missing`). This is a
+/// auto-tick (why `ensure_seeded` uses `insert_if_missing`). This is a
 /// distinct, explicit, once-per-startup write path deriving from real recorded
 /// data — not a read side effect. It runs the FR-031 settle path for the same
 /// reason: it stands in for the tick that was lost, so it must settle exactly

--- a/crates/app/core/src/path_set.rs
+++ b/crates/app/core/src/path_set.rs
@@ -7,11 +7,11 @@
 //! Two plans may apply concurrently only if their (source ∪ destination ∪
 //! archive) path sets are disjoint at subtree-prefix granularity. This module
 //! owns the pure comparison; the apply use case computes each plan's claimed
-//! paths and calls [`PlanPathSet::first_overlap`] before registering a run.
+//! paths and calls `PlanPathSet::first_overlap` before registering a run.
 //!
 //! Inputs are expected to be **lexically normalized** paths (no `.` / `..`
 //! components) that are absolute whenever the owning library root is known.
-//! Comparison is component-wise (via [`Utf8Path::starts_with`]), so sibling
+//! Comparison is component-wise (via `Utf8Path::starts_with`), so sibling
 //! names that share a string prefix (`/a/b` vs `/a/bc`) do NOT overlap.
 //! Comparison is case-sensitive; case-insensitive filesystem semantics are a
 //! documented future refinement (research R7).

--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -373,7 +373,7 @@ pub(super) fn spawn_executor_run(params: SpawnExecutorParams) {
 ///   Tauri-internal plumbing from a test, so the harness deliberately does
 ///   not. This variant is the supported route instead.
 /// - Any archive/cleanup UI surface that only needs a fire-and-poll apply
-///   (poll [`get_apply_status`] for the durable terminal counts) rather than
+///   (poll `get_apply_status` for the durable terminal counts) rather than
 ///   a live progress stream.
 ///
 /// This mirrors the auto-approve-then-apply pattern `inbox_plan::

--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -22,7 +22,7 @@ use super::{
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure (non-fatal at boot —
+/// Returns `persistence_core::DbError::Database` on connection failure (non-fatal at boot —
 /// caller should log and continue).
 pub async fn sweep_crashed_applying_plans(
     pool: &SqlitePool,
@@ -329,14 +329,14 @@ pub(super) async fn revalidate_pause_condition(
 /// Resume a paused plan apply run (R-Pause-1, T052).
 ///
 /// Re-validates the pause condition recorded on the run
-/// ([`revalidate_pause_condition`]) before transitioning back to
+/// (`revalidate_pause_condition`) before transitioning back to
 /// `applying`. If the condition is still present, resume is refused with
 /// the matching `*.still.*` code and the plan stays `paused` — it is never
 /// silently flipped to `applying` for a run that would immediately stall
 /// again (constitution §II, issue #575).
 ///
-/// On success, re-registers an [`ActiveRun`] (R-Concur-1) and re-spawns the
-/// executor (via [`spawn_executor_run`]) over the plan's remaining
+/// On success, re-registers an `ActiveRun` (R-Concur-1) and re-spawns the
+/// executor (via `spawn_executor_run`) over the plan's remaining
 /// `pending` items. Items already `failed` when the run paused — including
 /// the one that triggered the pause — stay terminal for this run; per-item
 /// retry is a separate affordance (`retry_plan_item`), not part of resume.

--- a/crates/app/inbox/src/classify.rs
+++ b/crates/app/inbox/src/classify.rs
@@ -1088,7 +1088,7 @@ pub fn mandatory_set_for(ft: FrameType) -> Vec<&'static str> {
 ///
 /// Single shared formula for the `target` arm of both mandatory-attribute
 /// gates — [`check_mandatory_missing`] here and
-/// [`crate::metadata::compute_missing_mandatory`] — so the two consumers
+/// `crate::metadata::compute_missing_mandatory` — so the two consumers
 /// agree on "target missing" **by construction**, not because every caller
 /// happens to pass the same `target_resolved` constant (issue #1132).
 ///

--- a/crates/app/inbox/src/grouping.rs
+++ b/crates/app/inbox/src/grouping.rs
@@ -30,9 +30,9 @@
 //!
 //! # Module layout
 //!
-//! Split by cohesion: [`metadata`] (input view), [`dimension`] (identity
-//! dimensions), [`config`] (per-type recipe + sentinel), [`result`] (output
-//! types), [`engine`] (the pure `group_file` computation + its unit tests).
+//! Split by cohesion: `metadata` (input view), `dimension` (identity
+//! dimensions), `config` (per-type recipe + sentinel), `result` (output
+//! types), `engine` (the pure `group_file` computation + its unit tests).
 #![allow(clippy::doc_markdown)] // spec/FITS terminology not appropriate for backticks
 
 mod config;

--- a/crates/app/inbox/src/grouping/engine.rs
+++ b/crates/app/inbox/src/grouping/engine.rs
@@ -16,7 +16,7 @@ use super::result::{GroupKey, GroupLabel, GroupResult, GroupWarning};
 ///
 /// The key is a canonical serialization of `frame_type` followed by each
 /// **enabled** dimension's normalized/bucketed value, rendered in the fixed
-/// [`Dimension::order`] order. A missing value for an enabled dimension renders
+/// `Dimension::order` order. A missing value for an enabled dimension renders
 /// [`SENTINEL_MISSING`]. Identical `(metadata, config)` always yields an
 /// identical key (FR-042) — there is no clock, hashing of floats, or map
 /// iteration involved.

--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -84,7 +84,7 @@ fn plan_completion_lock(plan_id: &str) -> Arc<Mutex<()>> {
 /// (`handle_plan_completed` → `ingest_light_frames`) can emit `target.resolved`
 /// events for inline cache hits. `resolve_cache` (also cheap to clone — an
 /// `Arc` handle) is threaded through to
-/// [`ingest_light_frames_if_applicable`], which uses it to trigger an
+/// `ingest_light_frames_if_applicable`, which uses it to trigger an
 /// immediate ingest-resolution drain pass after a plan's light frames are
 /// ingested (issue #1256) instead of waiting on the periodic backstop.
 pub fn start_inbox_plan_listener(pool: SqlitePool, bus: &EventBus, resolve_cache: ResolveCache) {
@@ -209,7 +209,7 @@ async fn handle_plan_completed(
 /// `Ok` — a propagated registration error leaves both the link and the
 /// `plan_open` state in place so the next sweep retries.
 ///
-/// [`ingest_light_frames_if_applicable`] deliberately does not participate in
+/// `ingest_light_frames_if_applicable` deliberately does not participate in
 /// that guard: it logs and swallows its errors (spec 035 US4/T042, R12), so a
 /// per-frame metadata/IO problem never strands the inbox item.
 pub(crate) async fn complete_applied_plan(

--- a/crates/app/inbox/src/repair.rs
+++ b/crates/app/inbox/src/repair.rs
@@ -22,7 +22,7 @@ use targeting_resolver::simbad::ResolveCache;
 /// deleting the now-stale `inbox_plan_links` row.
 ///
 /// An `applied` plan runs the full applied path via
-/// [`crate::plan_listener::complete_applied_plan`] — calibration-master
+/// `crate::plan_listener::complete_applied_plan` — calibration-master
 /// registration and light-frame ingest included. Resolving without them would
 /// delete the link row, which is the only record that the work is outstanding,
 /// so the master would never be registered and the frames never ingested.

--- a/crates/app/inbox/src/scan.rs
+++ b/crates/app/inbox/src/scan.rs
@@ -146,7 +146,7 @@ impl ScannedInboxItem {
     /// score 0 so `list_unclassified_source_groups` does not surface it as a
     /// scanned-but-unclassified row *in addition to* its master rows. The
     /// subtraction is sound only because `masters` is built by filtering
-    /// `fits_files ∪ xisf_files` (see [`scan_dir`]); it is saturating so a
+    /// `fits_files ∪ xisf_files` (see `scan_dir`); it is saturating so a
     /// future violation of that subset relation degrades to 0 rather than
     /// panicking.
     #[must_use]
@@ -187,7 +187,7 @@ pub struct ScanOptions {
     /// (see `crates/tools/perf-bench`).
     ///
     /// `Some(N)` where N > 1 enables the parallel path capped at
-    /// [`MAX_SCAN_WORKERS`]. Intended for rotational HDD libraries where
+    /// `MAX_SCAN_WORKERS`. Intended for rotational HDD libraries where
     /// per-file seek latency amortises across threads.
     pub workers: Option<usize>,
 }
@@ -327,7 +327,7 @@ struct LeafDir {
 /// # Panics
 ///
 /// Panics only if a scan worker thread panics due to an internal bug
-/// (e.g. a logic error in [`process_leaf`]). Per-file I/O failures
+/// (e.g. a logic error in `process_leaf`). Per-file I/O failures
 /// (unreadable files, parse errors) are silently skipped and do not panic.
 pub fn scan_root(root: &Path, options: &ScanOptions) -> Result<ScanOutput, String> {
     if !root.is_dir() {

--- a/crates/app/inbox/src/session_materialization/apply.rs
+++ b/crates/app/inbox/src/session_materialization/apply.rs
@@ -384,7 +384,7 @@ pub async fn run_apply(pool: &SqlitePool, params: ApplyParams<'_>) -> DbResult<S
 ///
 /// # Errors
 ///
-/// Returns [`DbError`] on SQL or constraint errors.
+/// Returns [`persistence_core::DbError`] on SQL or constraint errors.
 pub async fn insert_ready_operation(
     pool: &SqlitePool,
     operation_public_id: &str,
@@ -417,8 +417,8 @@ pub async fn insert_ready_operation(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on state-version mismatch, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns [`persistence_core::DbError::CasFailed`] on state-version mismatch, or
+/// [`persistence_core::DbError::Database`] on SQL errors.
 pub async fn mark_operation_failed(
     pool: &SqlitePool,
     operation_row_id: i64,

--- a/crates/app/inbox/src/session_materialization/progress.rs
+++ b/crates/app/inbox/src/session_materialization/progress.rs
@@ -20,7 +20,7 @@ pub struct MaterializationProgress {
     pub total_frames: i64,
     processed_sessions: AtomicI64,
     processed_frames: AtomicI64,
-    /// Set by [`cancel`] to signal the apply loop to stop after the current
+    /// Set by [`Self::request_cancel`] to signal the apply loop to stop after the current
     /// session commit.
     pub cancel_requested: AtomicBool,
 }

--- a/crates/app/lifecycle/src/artifact/mod.rs
+++ b/crates/app/lifecycle/src/artifact/mod.rs
@@ -29,10 +29,10 @@
 //! Constitution III: this module never opens, processes, or modifies observed files.
 //! Constitution V: the DB row is the durable record; the file index is reproducible.
 //!
-//! Split by responsibility (refactor sweep #980): [`attribution`] is the
+//! Split by responsibility (refactor sweep #980): `attribution` is the
 //! path→project resolver + startup fix-up; [`detect`] is the observe/insert
-//! pipeline; [`list`] is the read projection; [`classify`] is the manual
-//! override; [`missing_recovered`] handles the reconcile pass; [`launches`]
+//! pipeline; [`list`] is the read projection; `classify` is the manual
+//! override; `missing_recovered` handles the reconcile pass; `launches`
 //! covers re-attribution, run completion, and the stale-launch sweep.
 #![allow(clippy::doc_markdown)]
 

--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -7,7 +7,7 @@
 //!
 //! - [`list`]  — list manifest summaries for a project (newest first, paginated).
 //! - [`get`]   — fetch one manifest with its full structured body.
-//! - [`write`] — generate and persist a manifest snapshot (called by lifecycle
+//! - [`fn@write`] — generate and persist a manifest snapshot (called by lifecycle
 //!   triggers and the `workflow.run_completed` subscriber).
 //!
 //! ## Architecture
@@ -279,7 +279,7 @@ pub async fn write(
 /// Build the `source_map`/`calibration` snapshot for a manifest body from the
 /// project's currently-linked sources and their calibration assignments.
 ///
-/// FR-001 requires manifests to "document project source mappings [and]
+/// FR-001 requires manifests to "document project source mappings \[and\]
 /// calibration choices" — `spawn_workflow_run_subscriber` previously always
 /// passed `None` for both, the only trigger a real user ever exercises
 /// (#665 tracks the other 4 triggers being unwired).

--- a/crates/app/projects/src/project_setup/create.rs
+++ b/crates/app/projects/src/project_setup/create.rs
@@ -149,7 +149,7 @@ fn build_folder_plan_data(project_path: &str, tool_str: &str) -> FolderPlanData 
 /// Validates name (non-empty, ≤120 chars, unique), tool (canonical value),
 /// path (unique within library). A relative request path is anchored to the
 /// registered project folder before storage so `projects.path` is always an
-/// unambiguous absolute location (Constitution I; see [`anchor_project_path`]).
+/// unambiguous absolute location (Constitution I; see `anchor_project_path`).
 /// Persists the project in `setup_incomplete`,
 /// links any `initial_sources`, infers channels, checks the auto-ready trigger,
 /// and emits a `project.created` audit event.

--- a/crates/app/projects/src/project_setup/mod.rs
+++ b/crates/app/projects/src/project_setup/mod.rs
@@ -31,8 +31,8 @@
 //!
 //! Split by responsibility (refactor sweep #972): [`create`] owns path
 //! anchoring + the Constitution II folder plan builder; [`update`] is
-//! metadata-only; [`sources`] links/unlinks Inventory sessions and recomputes
-//! channels; [`channels`] handles the reinfer/dismiss-drift pair; [`read`]
+//! metadata-only; `sources` links/unlinks Inventory sessions and recomputes
+//! channels; `channels` handles the reinfer/dismiss-drift pair; `read`
 //! covers the `list`/`get` DTO projections. Helpers shared by more than one
 //! use case (error mapping, exposure/channel aggregation, the auto-transition
 //! seam, the source-change manifest trigger) stay here so siblings pull them

--- a/crates/app/projects/src/source_view_generate/mod.rs
+++ b/crates/app/projects/src/source_view_generate/mod.rs
@@ -42,8 +42,8 @@
 //!   function's calibration loop is the place to add masters-preferred
 //!   branching.
 //!
-//! Split by responsibility (refactor sweep #983): [`generate`] owns the
-//! `generate_source_view` pipeline; [`destination_override`] is the T041
+//! Split by responsibility (refactor sweep #983): `generate` owns the
+//! `generate_source_view` pipeline; `destination_override` is the T041
 //! per-project destination override KV read/write; the pure path/layout
 //! helpers below are shared by both.
 

--- a/crates/app/projects/src/source_view_verify.rs
+++ b/crates/app/projects/src/source_view_verify.rs
@@ -165,7 +165,7 @@ fn classify_item(
 
 /// Verify a `PreparedSourceView`'s links without mutating anything.
 ///
-/// See [`classify_item`] for the per-item resolution rules.
+/// See `classify_item` for the per-item resolution rules.
 ///
 /// # Errors
 ///
@@ -199,7 +199,7 @@ pub async fn verify_source_view(
 
 /// Stale-detection sweep (spec 026 US3, T014/T015): recompute every item's
 /// [`ItemObservedState`] from the live filesystem + inventory (same
-/// [`classify_item`] logic as [`verify_source_view`]) and persist it, then
+/// `classify_item` logic as [`verify_source_view`]) and persist it, then
 /// derive and persist the view's own `state` from the aggregate.
 ///
 /// Read-only on the filesystem — it only ever `stat`s paths, never writes,

--- a/crates/app/settings/src/migrate.rs
+++ b/crates/app/settings/src/migrate.rs
@@ -92,10 +92,10 @@ pub enum MigrateError {
 ///
 /// The migration applies three rules in key-declaration order:
 ///
-/// 1. **Drop** — keys in [`DROP_KEYS`] are deleted from the `settings` table.
-/// 2. **Reset** — keys in [`RESET_KEYS`] are deleted so the v2 in-code default
+/// 1. **Drop** — keys in `DROP_KEYS` are deleted from the `settings` table.
+/// 2. **Reset** — keys in `RESET_KEYS` are deleted so the v2 in-code default
 ///    applies on the next `get_settings` call.
-/// 3. **Retain** — all other v1 keys (from [`descriptors::all_keys`]) that are
+/// 3. **Retain** — all other v1 keys (from `descriptors::all_keys`) that are
 ///    actually stored in the DB are left unchanged.
 ///
 /// After applying the rules, exactly one `settings.migration` audit event is

--- a/crates/app/targets/src/ingest_sessions.rs
+++ b/crates/app/targets/src/ingest_sessions.rs
@@ -5,12 +5,12 @@
 //! (spec 035 US4, FR-016).
 //!
 //! When a reviewable inbox plan reaches `applied`, each light frame it moved or
-//! catalogued must be folded into an [`acquisition_session`] keyed by capture
+//! catalogued must be folded into an `acquisition_session` keyed by capture
 //! identity (`session_key`: target/OBJECT, filter, binning, gain,
 //! observing-night) and linked to its resolved canonical target. This module is
 //! the production entry point the plan-apply listener calls.
 //!
-//! ## Per-frame pipeline ([`ingest_light_frame`])
+//! ## Per-frame pipeline (`ingest_light_frame`)
 //!
 //! 1. **Resolve the destination root → `library_root` (R9).** Applied inbox
 //!    items store `to_root_id` as a `registered_sources` id, but

--- a/crates/app/targets/src/ingestion_operation/mod.rs
+++ b/crates/app/targets/src/ingestion_operation/mod.rs
@@ -5,8 +5,8 @@
 //! `inbox.materialization.apply` (Spec 062 §Ingestion).
 //!
 //! This module ties together the command ledger and the persistence-sessions
-//! materialization repositories. App-layer use cases call [`query_operation`]
-//! to read the current operation state and [`query_result_sessions`] to page
+//! materialization repositories. App-layer use cases call `query_operation`
+//! to read the current operation state and `query_result_sessions` to page
 //! through the result snapshot.
 
 pub mod operation_query;

--- a/crates/app/targets/src/target_management/mod.rs
+++ b/crates/app/targets/src/target_management/mod.rs
@@ -14,11 +14,11 @@
 //! - §III Metadata/identity only — no image processing.
 //! - §V SQLite (resolution cache / canonical_target) is the durable record.
 //!
-//! Split by responsibility (refactor sweep #986): [`detail`] is `target.get`;
-//! [`list`] is `target.list` (+ session-count enrichment); [`alias`] is
-//! `target.alias.add`/`.remove`; [`display_alias`] is `.set`/`.clear`;
-//! [`sessions_projects`] is spec 023 US2/US3 (`target.sessions.list` /
-//! `target.projects.list`); [`note`] is spec 023 US4 (`target.note.get`/
+//! Split by responsibility (refactor sweep #986): `detail` is `target.get`;
+//! [`list`] is `target.list` (+ session-count enrichment); `alias` is
+//! `target.alias.add`/`.remove`; `display_alias` is `.set`/`.clear`;
+//! `sessions_projects` is spec 023 US2/US3 (`target.sessions.list` /
+//! `target.projects.list`); `note` is spec 023 US4 (`target.note.get`/
 //! `.update`). Error mapping and DTO conversion helpers used by more than one
 //! use case stay here.
 

--- a/crates/app/targets/src/target_resolve.rs
+++ b/crates/app/targets/src/target_resolve.rs
@@ -16,7 +16,7 @@
 //! [`promote_by_id`], called from the app-layer commit points (add to
 //! project, link to session, favourite, Inbox-confirm) with the redb-cache id
 //! a prior `target.search`/`target.resolve` response already returned. The
-//! manual `override` path ([`apply_override`], FR-014/T032) is itself such a
+//! manual `override` path (`apply_override`, FR-014/T032) is itself such a
 //! commit — the user has explicitly bound a query to a chosen target — and
 //! keeps writing `canonical_target` directly.
 //!

--- a/crates/calibration/core/src/lib.rs
+++ b/crates/calibration/core/src/lib.rs
@@ -8,7 +8,7 @@
 //!
 //! Public surface:
 //! - [`CalibrationKind`] — dark / flat / bias (dark_flat reserved, not matched).
-//! - [`Dimension`] / [`SoftDimension`] / [`MatchingRuleConfig`] — rule configuration.
+//! - [`Dimension`] / [`MatchingRuleConfig`] — rule configuration.
 //! - [`CalibrationMatch`] — ranked suggestion with dimension breakdown.
 //! - [`SessionInfo`] / [`MasterInfo`] — pure-data input types (no DB row types).
 //! - [`suggest`] — fan-out dispatcher for single session.

--- a/crates/contracts/core/src/cone_search.rs
+++ b/crates/contracts/core/src/cone_search.rs
@@ -12,7 +12,7 @@ use specta::Type;
 
 use crate::targets::TargetObjectType;
 
-/// Coordinate-source quality for a derived [`Pointing`] (FR-012).
+/// Coordinate-source quality for a derived pointing (FR-012).
 ///
 /// `Wcs` (plate-solved `CRVAL1/2`) is high confidence; `Mount` (`OBJCTRA`/
 /// `OBJCTDEC` or decimal `RA`/`DEC`) is medium; `None` means no reliable

--- a/crates/contracts/core/src/patterns.rs
+++ b/crates/contracts/core/src/patterns.rs
@@ -25,7 +25,7 @@ use specta::Type;
 ///
 /// Re-exported from `crates/contracts/core` so the Tauri command layer can
 /// reference it without importing `crates/patterns` directly. The shape matches
-/// [`patterns::PatternPart`] exactly.
+/// `patterns::PatternPart` exactly.
 #[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize, Type)]
 #[serde(rename_all = "camelCase")]
 pub struct PatternPartDto {

--- a/crates/domain/core/src/equipment.rs
+++ b/crates/domain/core/src/equipment.rs
@@ -45,7 +45,7 @@ pub struct Camera {
     /// meaningful when `sensor_type` is `Osc`.
     pub passband: Option<Vec<String>>,
     /// Pixel pitch in micrometres; `None` = not recorded. Square pixels are
-    /// assumed on both axes, matching [`sessions::fov_diagonal_deg`].
+    /// assumed on both axes, matching `sessions::fov_diagonal_deg`.
     #[serde(default)]
     pub pixel_size_um: Option<f64>,
     /// Unbinned sensor width in pixels (FITS `NAXIS1`); `None` = not recorded.

--- a/crates/domain/core/src/lifecycle/action_review_requirement.rs
+++ b/crates/domain/core/src/lifecycle/action_review_requirement.rs
@@ -10,9 +10,9 @@
 //! `provenance.unreviewed` when any required field is not yet `reviewed`.
 //!
 //! Field-level review state is derived from each field's
-//! [`ProvenancedValue::origin`] — it is NOT a per-entity column. The
+//! `ProvenancedValue::origin` — it is NOT a per-entity column. The
 //! repository surface for that read is
-//! [`LifecycleRepository::field_origins`].
+//! `LifecycleRepository::field_origins`.
 //!
 //! Spec 041 FR-051 (T076, Phase 13): the only cells ever populated here gated
 //! the `AcquisitionSession`/`InventorySession` `candidate → confirmed` and

--- a/crates/domain/core/src/lifecycle/provenance.rs
+++ b/crates/domain/core/src/lifecycle/provenance.rs
@@ -1,7 +1,7 @@
 // Copyright (C) 2024-2026 Sjors Robroek
 // SPDX-License-Identifier: AGPL-3.0-only
 
-//! ProvenancedValue<T> — append-only value wrapper carrying observed/inferred/reviewed history.
+//! `ProvenancedValue<T>` — append-only value wrapper carrying observed/inferred/reviewed history.
 //!
 //! Priority rule: reviewed > inferred > observed > generated > planned > applied
 //! (spec 002 data-model.md §ProvenancedValue).

--- a/crates/domain/core/src/settings.rs
+++ b/crates/domain/core/src/settings.rs
@@ -156,13 +156,13 @@ pub struct SettingsState {
     /// Pre-fill the calibration assign dialog with the top candidate (spec 007 R-Prefill).
     pub calibration_prefill_suggestion: bool,
 
-    /// Confidence penalty when user overrides dark suggestion [0,1] (spec 007).
+    /// Confidence penalty when user overrides dark suggestion \[0,1\] (spec 007).
     pub calibration_dark_override_penalty: f64,
 
-    /// Confidence penalty when user overrides flat suggestion [0,1] (spec 007).
+    /// Confidence penalty when user overrides flat suggestion \[0,1\] (spec 007).
     pub calibration_flat_override_penalty: f64,
 
-    /// Confidence penalty when user overrides bias suggestion [0,1] (spec 007).
+    /// Confidence penalty when user overrides bias suggestion \[0,1\] (spec 007).
     pub calibration_bias_override_penalty: f64,
 
     /// Days after which a calibration master is considered aging (spec 007/018 FR-023).

--- a/crates/fs/executor/src/run/mod.rs
+++ b/crates/fs/executor/src/run/mod.rs
@@ -25,8 +25,8 @@
 //!
 //! Split by responsibility (refactor sweep #985): this file holds the
 //! shared public types (progress events, item/action model, cancellation +
-//! skip + retry coordination primitives); [`loop_`] is the `execute_plan`
-//! forward loop + per-item gate pipeline; [`dispatch`] is the pure
+//! skip + retry coordination primitives); `loop_` is the `execute_plan`
+//! forward loop + per-item gate pipeline; `dispatch` is the pure
 //! action→filesystem-op dispatch.
 
 use std::collections::HashSet;

--- a/crates/patterns/src/registry.rs
+++ b/crates/patterns/src/registry.rs
@@ -30,9 +30,9 @@ pub enum TokenTransform {
 /// Describes one token in the registry (data-model.md §TokenDefinition).
 #[derive(Clone, Debug)]
 pub struct TokenDefinition {
-    /// Token name as it appears in a [`PatternPart`] value, e.g. `"target"`.
+    /// Token name as it appears in a `PatternPart` value, e.g. `"target"`.
     pub name: &'static str,
-    /// The key in [`MetadataBundle`] that this token reads from.
+    /// The key in [`crate::resolver::MetadataBundle`] that this token reads from.
     pub source_field: &'static str,
     /// Value emitted when the source field is absent or sanitizes to empty.
     pub fallback: &'static str,

--- a/crates/persistence/calibration/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_assignment.rs
@@ -78,7 +78,7 @@ fn row_to_struct(
 /// Replaces any existing row for the same `(session_id, calibration_type)` pair.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure (including JSON encoding
+/// Returns `persistence_core::DbError::Database` on query failure (including JSON encoding
 /// of `mismatched_dimensions`, encoded via `sqlx::types::Json`).
 pub async fn upsert(pool: &SqlitePool, params: UpsertParams<'_>) -> DbResult<()> {
     let at = params.assigned_at.map_or_else(Timestamp::now_iso, str::to_owned);
@@ -119,7 +119,7 @@ pub async fn upsert(pool: &SqlitePool, params: UpsertParams<'_>) -> DbResult<()>
 /// Returns `true` when a row was deleted, `false` when none existed.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn delete(pool: &SqlitePool, session_id: &str, calibration_type: &str) -> DbResult<bool> {
     let result = sqlx::query(
         "DELETE FROM calibration_assignment WHERE session_id = ? AND calibration_type = ?",
@@ -137,7 +137,7 @@ pub async fn delete(pool: &SqlitePool, session_id: &str, calibration_type: &str)
 /// Returns `None` when no assignment exists.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get(
     pool: &SqlitePool,
     session_id: &str,
@@ -161,7 +161,7 @@ pub async fn get(
 /// List all assignments for a session.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_for_session(
     pool: &SqlitePool,
     session_id: &str,
@@ -199,7 +199,7 @@ pub async fn list_for_session(
 /// yet); `Some(state)` is one of `present` / `missing` / `user_resolved_missing`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn master_artifact_state(pool: &SqlitePool, master_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> = sqlx::query_as(
         "SELECT pa.state
@@ -219,7 +219,7 @@ pub async fn master_artifact_state(pool: &SqlitePool, master_id: &str) -> DbResu
 /// member frame (`frame_ids`) whose `file_record.state = 'missing'`?
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn master_has_missing_source_frame(pool: &SqlitePool, master_id: &str) -> DbResult<bool> {
     let (count,): (i64,) = sqlx::query_as(
         "SELECT COUNT(*)
@@ -242,7 +242,7 @@ pub async fn master_has_missing_source_frame(pool: &SqlitePool, master_id: &str)
 /// to exactly the assignments a raw-frame reconcile outcome affects.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_by_source_frame(
     pool: &SqlitePool,
     frame_id: &str,
@@ -269,7 +269,7 @@ pub async fn find_by_source_frame(
 /// artifact reconcile outcome affects.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_by_source_artifact(
     pool: &SqlitePool,
     artifact_id: &str,

--- a/crates/persistence/calibration/src/repositories/calibration_tolerances.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_tolerances.rs
@@ -31,7 +31,7 @@ pub struct CalibrationTolerancesRow {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure (including the unexpected
+/// Returns `persistence_core::DbError::Database` on query failure (including the unexpected
 /// case where the migration-0008 seed row is missing).
 pub async fn get(pool: &SqlitePool) -> DbResult<CalibrationTolerancesRow> {
     let row: (f64, f64, i64, i64, i64, i64, i64) = sqlx::query_as(
@@ -68,7 +68,7 @@ pub async fn get(pool: &SqlitePool) -> DbResult<CalibrationTolerancesRow> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update(
     pool: &SqlitePool,
     row: &CalibrationTolerancesRow,

--- a/crates/persistence/calibration/src/repositories/equipment.rs
+++ b/crates/persistence/calibration/src/repositories/equipment.rs
@@ -130,7 +130,7 @@ fn ensure_row_affected(rows_affected: u64, entity: &str, id: &str) -> DbResult<(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_cameras(pool: &SqlitePool) -> DbResult<Vec<Camera>> {
     let rows: Vec<CameraRow> = sqlx::query_as(
         "SELECT id, name, aliases, auto_detected, sensor_type, passband, \
@@ -147,7 +147,7 @@ pub async fn list_cameras(pool: &SqlitePool) -> DbResult<Vec<Camera>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation.
+/// Returns `persistence_core::DbError::Database` on constraint violation.
 pub async fn create_camera(pool: &SqlitePool, req: &CreateCamera) -> DbResult<Camera> {
     let id = Uuid::new_v4().to_string();
     let aliases_json = encode_aliases(&req.aliases);
@@ -246,7 +246,7 @@ pub async fn delete_camera(pool: &SqlitePool, id: &str) -> DbResult<()> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_camera_by_alias(pool: &SqlitePool, alias: &str) -> DbResult<Option<Camera>> {
     // SQLite JSON: match an exact alias value inside the aliases JSON array.
     // `EXISTS` rather than a `json_each` cross join so the selected columns
@@ -271,7 +271,7 @@ pub async fn find_camera_by_alias(pool: &SqlitePool, alias: &str) -> DbResult<Op
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_telescopes(pool: &SqlitePool) -> DbResult<Vec<Telescope>> {
     let rows: Vec<(String, String, String, Option<i32>, i32)> = sqlx::query_as(
         "SELECT id, name, aliases, focal_length_mm, auto_detected FROM telescopes ORDER BY name ASC",
@@ -295,7 +295,7 @@ pub async fn list_telescopes(pool: &SqlitePool) -> DbResult<Vec<Telescope>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation.
+/// Returns `persistence_core::DbError::Database` on constraint violation.
 pub async fn create_telescope(pool: &SqlitePool, req: &CreateTelescope) -> DbResult<Telescope> {
     let id = Uuid::new_v4().to_string();
     let aliases_json = encode_aliases(&req.aliases);
@@ -371,7 +371,7 @@ pub async fn delete_telescope(pool: &SqlitePool, id: &str) -> DbResult<()> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_telescope_by_alias(
     pool: &SqlitePool,
     alias: &str,
@@ -450,7 +450,7 @@ async fn fetch_train_fov_deg(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_optical_trains(pool: &SqlitePool) -> DbResult<Vec<OpticalTrain>> {
     // LEFT JOIN: a train with no camera, or a camera with no recorded
     // geometry, still lists — it just reports no FOV.
@@ -480,7 +480,7 @@ pub async fn list_optical_trains(pool: &SqlitePool) -> DbResult<Vec<OpticalTrain
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation.
+/// Returns `persistence_core::DbError::Database` on constraint violation.
 pub async fn create_optical_train(
     pool: &SqlitePool,
     req: &CreateOpticalTrain,
@@ -568,7 +568,7 @@ pub async fn delete_optical_train(pool: &SqlitePool, id: &str) -> DbResult<()> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_filters(pool: &SqlitePool) -> DbResult<Vec<Filter>> {
     let rows: Vec<(String, String, String, i32)> =
         sqlx::query_as("SELECT id, name, category, auto_detected FROM filters ORDER BY name ASC")
@@ -590,7 +590,7 @@ pub async fn list_filters(pool: &SqlitePool) -> DbResult<Vec<Filter>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation (e.g. duplicate name).
+/// Returns `persistence_core::DbError::Database` on constraint violation (e.g. duplicate name).
 pub async fn create_filter(pool: &SqlitePool, req: &CreateFilter) -> DbResult<Filter> {
     let id = Uuid::new_v4().to_string();
     let category_str = category_to_str(req.category);

--- a/crates/persistence/calibration/src/repositories/q_calibration.rs
+++ b/crates/persistence/calibration/src/repositories/q_calibration.rs
@@ -19,7 +19,7 @@ use persistence_core::DbResult;
 /// Mark a camera row as auto-detected (`cameras.auto_detected = 1`).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_camera_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<()> {
     sqlx::query("UPDATE cameras SET auto_detected = 1 WHERE id = ?").bind(id).execute(pool).await?;
     Ok(())
@@ -28,7 +28,7 @@ pub async fn mark_camera_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<
 /// Mark a telescope row as auto-detected (`telescopes.auto_detected = 1`).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_telescope_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<()> {
     sqlx::query("UPDATE telescopes SET auto_detected = 1 WHERE id = ?")
         .bind(id)
@@ -40,7 +40,7 @@ pub async fn mark_telescope_auto_detected(pool: &SqlitePool, id: &str) -> DbResu
 /// Mark a filter row as auto-detected (`filters.auto_detected = 1`).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_filter_auto_detected(pool: &SqlitePool, id: &str) -> DbResult<()> {
     sqlx::query("UPDATE filters SET auto_detected = 1 WHERE id = ?").bind(id).execute(pool).await?;
     Ok(())
@@ -116,7 +116,7 @@ pub struct CalibrationMasterViewRow {
 /// Whether an `acquisition_session` row exists for `session_id`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn acquisition_session_exists(pool: &SqlitePool, session_id: &str) -> DbResult<bool> {
     let row: Option<(String,)> = sqlx::query_as("SELECT id FROM acquisition_session WHERE id = ?")
         .bind(session_id)
@@ -128,7 +128,7 @@ pub async fn acquisition_session_exists(pool: &SqlitePool, session_id: &str) -> 
 /// Load the `acquisition_fingerprint` row for a session id, if present.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_acquisition_fingerprint(
     pool: &SqlitePool,
     session_id: &str,
@@ -152,7 +152,7 @@ pub async fn get_acquisition_fingerprint(
 /// a calibration master's "compatible sessions" list — #868).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_light_acquisition_fingerprints(
     pool: &SqlitePool,
 ) -> DbResult<Vec<AcquisitionFingerprintRow>> {
@@ -176,7 +176,7 @@ pub async fn list_light_acquisition_fingerprints(
 /// behavior: SQL restricts to the fixed dark/flat/bias set).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_calibration_fingerprints(
     pool: &SqlitePool,
 ) -> DbResult<Vec<CalibrationFingerprintRow>> {
@@ -197,7 +197,7 @@ pub async fn list_calibration_fingerprints(
 /// Load a single `calibration_fingerprint` row by id.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_calibration_fingerprint(
     pool: &SqlitePool,
     master_id: &str,
@@ -227,7 +227,7 @@ pub async fn get_calibration_fingerprint(
 /// [`get_calibration_master`] can still resolve an archived master's detail.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_calibration_masters(
     pool: &SqlitePool,
 ) -> DbResult<Vec<CalibrationMasterViewRow>> {
@@ -249,7 +249,7 @@ pub async fn list_calibration_masters(
 /// master, so its detail view / future unarchive can still see it.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_calibration_master(
     pool: &SqlitePool,
     master_id: &str,
@@ -271,7 +271,7 @@ pub async fn get_calibration_master(
 /// List `session_id`s from `calibration_assignment` rows assigned to a master.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_assignment_session_ids(
     pool: &SqlitePool,
     master_id: &str,
@@ -288,7 +288,7 @@ pub async fn list_assignment_session_ids(
 /// assigned a given calibration master.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_assignment_project_ids(
     pool: &SqlitePool,
     master_id: &str,
@@ -314,7 +314,7 @@ pub async fn list_assignment_project_ids(
 /// (Constitution II: reviewable-plan discipline).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_master_archived(
     pool: &SqlitePool,
     master_id: &str,
@@ -337,7 +337,7 @@ pub async fn set_master_archived(
 /// plan finishes applying.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn clear_master_archived(pool: &SqlitePool, master_id: &str) -> DbResult<()> {
     sqlx::query(
         "UPDATE calibration_session SET archived_at = NULL, archived_via_plan_id = NULL \
@@ -351,7 +351,7 @@ pub async fn clear_master_archived(pool: &SqlitePool, master_id: &str) -> DbResu
 
 /// One archived-master row for the Archive surface (#886), joined with the
 /// owning archive plan for the display reason + bytes moved — mirrors
-/// [`crate::repositories::projects::ArchivedProjectRow`].
+/// `crate::repositories::projects::ArchivedProjectRow`.
 #[derive(Debug, Clone)]
 pub struct ArchivedMasterRow {
     pub id: String,
@@ -367,7 +367,7 @@ pub struct ArchivedMasterRow {
 /// List every `calibration_master_view` row currently archived.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_archived_masters(pool: &SqlitePool) -> DbResult<Vec<ArchivedMasterRow>> {
     #[allow(clippy::type_complexity)]
     let rows: Vec<(

--- a/crates/persistence/core/src/lib.rs
+++ b/crates/persistence/core/src/lib.rs
@@ -98,7 +98,7 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns [`DbError::Database`] if the pool cannot connect to the given URL.
+    /// Returns `persistence_core::DbError::Database` if the pool cannot connect to the given URL.
     pub async fn connect(connection_string: &str) -> DbResult<Self> {
         let options = SqliteConnectOptions::from_str(connection_string)?
             .journal_mode(SqliteJournalMode::Wal)
@@ -125,7 +125,7 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns [`DbError::Database`] if the in-memory pool cannot be created.
+    /// Returns `persistence_core::DbError::Database` if the in-memory pool cannot be created.
     pub async fn in_memory() -> DbResult<Self> {
         let db_name = uuid::Uuid::new_v4().simple();
         let url = format!("sqlite:file:{db_name}?mode=memory&cache=shared");
@@ -147,7 +147,7 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns [`DbError::Database`] on an unexpected SQL error other than the
+    /// Returns `persistence_core::DbError::Database` on an unexpected SQL error other than the
     /// table-not-found case.
     pub async fn has_pending_migrations(&self) -> DbResult<bool> {
         let mut conn = self.pool.acquire().await?;
@@ -183,7 +183,7 @@ impl Database {
     ///
     /// # Errors
     ///
-    /// Returns [`DbError::Database`] if the statement fails (e.g. destination
+    /// Returns `persistence_core::DbError::Database` if the statement fails (e.g. destination
     /// already exists, or disk full).
     pub async fn backup_to(&self, dest: &std::path::Path) -> DbResult<()> {
         let dest_str = dest.display().to_string().replace('\'', "''");

--- a/crates/persistence/core/src/repositories/audit_writes.rs
+++ b/crates/persistence/core/src/repositories/audit_writes.rs
@@ -18,7 +18,7 @@ use crate::DbResult;
 /// which is best-effort.
 ///
 /// # Errors
-/// Returns [`crate::DbError`] if the insert fails.
+/// Returns `persistence_core::DbError` if the insert fails.
 pub async fn insert_audit_entry(pool: &SqlitePool, entry: &AuditLogEntry) -> DbResult<()> {
     let at_str = entry
         .at
@@ -56,7 +56,7 @@ pub async fn insert_audit_entry(pool: &SqlitePool, entry: &AuditLogEntry) -> DbR
 /// a transaction).
 ///
 /// # Errors
-/// Returns [`crate::DbError`] if the insert fails.
+/// Returns `persistence_core::DbError` if the insert fails.
 pub async fn insert_audit_entry_conn(
     conn: &mut SqliteConnection,
     entry: &AuditLogEntry,
@@ -97,7 +97,7 @@ pub async fn insert_audit_entry_conn(
 /// the pool.
 ///
 /// # Errors
-/// Returns [`crate::DbError`] on query failure.
+/// Returns `persistence_core::DbError` on query failure.
 pub async fn insert_project_auto_transition(
     pool: &SqlitePool,
     project_id: &str,
@@ -113,7 +113,7 @@ pub async fn insert_project_auto_transition(
 /// (for use inside a transaction).
 ///
 /// # Errors
-/// Returns [`crate::DbError`] on query failure.
+/// Returns `persistence_core::DbError` on query failure.
 pub async fn insert_project_auto_transition_conn(
     conn: &mut SqliteConnection,
     project_id: &str,
@@ -152,7 +152,7 @@ pub async fn insert_project_auto_transition_conn(
 /// Insert a target resolution audit row.
 ///
 /// # Errors
-/// Returns [`crate::DbError`] on query failure.
+/// Returns `persistence_core::DbError` on query failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_resolution_audit(
     pool: &SqlitePool,

--- a/crates/persistence/core/src/repositories/q_core.rs
+++ b/crates/persistence/core/src/repositories/q_core.rs
@@ -17,7 +17,7 @@ use crate::DbResult;
 /// `frame_ids` JSON string for an `acquisition_session`, if it exists.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_acquisition_session_frame_ids(
     pool: &SqlitePool,
     session_id: &str,
@@ -33,7 +33,7 @@ pub async fn get_acquisition_session_frame_ids(
 /// `(frame_ids, kind)` for a `calibration_session`, if it exists.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_calibration_session_frame_ids_and_kind(
     pool: &SqlitePool,
     session_id: &str,
@@ -60,7 +60,7 @@ pub struct FileRecordRow {
 /// without querying.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn file_records_by_ids(
     pool: &SqlitePool,
     ids: &[String],
@@ -83,7 +83,7 @@ pub async fn file_records_by_ids(
 /// `file_record` rows for a given root.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn file_records_by_root(
     pool: &SqlitePool,
     root_id: &str,
@@ -101,7 +101,7 @@ pub async fn file_records_by_root(
 /// given frame id, matched via `LIKE`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_acquisition_session_id_by_frame_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -118,7 +118,7 @@ pub async fn find_acquisition_session_id_by_frame_like(
 /// array contains a given frame id, matched via `LIKE`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_calibration_session_by_frame_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -136,7 +136,7 @@ pub async fn find_calibration_session_by_frame_like(
 /// untouched while still forming a valid `UPDATE`).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_file_record_missing(pool: &SqlitePool, id: &str) -> DbResult<()> {
     sqlx::query(
         "UPDATE file_record SET state = 'missing', last_seen_at = last_seen_at WHERE id = ?",
@@ -152,7 +152,7 @@ pub async fn mark_file_record_missing(pool: &SqlitePool, id: &str) -> DbResult<(
 /// T021 auto-reconcile membership drop).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn acquisition_sessions_by_frame_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -168,7 +168,7 @@ pub async fn acquisition_sessions_by_frame_like(
 /// Same as [`acquisition_sessions_by_frame_like`] for `calibration_session`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn calibration_sessions_by_frame_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -184,7 +184,7 @@ pub async fn calibration_sessions_by_frame_like(
 /// Overwrite an `acquisition_session`'s `frame_ids` JSON array.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_acquisition_session_frame_ids(
     pool: &SqlitePool,
     id: &str,
@@ -201,7 +201,7 @@ pub async fn update_acquisition_session_frame_ids(
 /// Overwrite a `calibration_session`'s `frame_ids` JSON array.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_calibration_session_frame_ids(
     pool: &SqlitePool,
     id: &str,
@@ -220,7 +220,7 @@ pub async fn update_calibration_session_frame_ids(
 /// does not.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_file_record_content_hash(pool: &SqlitePool, id: &str) -> DbResult<Option<String>> {
     let hash: Option<String> =
         sqlx::query_scalar("SELECT content_hash FROM file_record WHERE id = ?")
@@ -235,7 +235,7 @@ pub async fn get_file_record_content_hash(pool: &SqlitePool, id: &str) -> DbResu
 /// `classified` (spec 048 T025).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn relink_file_record(
     pool: &SqlitePool,
     id: &str,
@@ -273,7 +273,7 @@ pub struct TargetSearchRow {
 /// already wrapped in `%...%`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn search_targets_by_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -315,7 +315,7 @@ pub struct IdLabelRow {
 /// Most-recently-resolved `canonical_target` rows.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn recent_targets(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
     let rows = sqlx::query_as::<_, IdLabelRow>(
         "SELECT id, COALESCE(display_alias, primary_designation) AS label FROM canonical_target \
@@ -330,7 +330,7 @@ pub async fn recent_targets(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
 /// wrapped in `%...%`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn search_sessions_by_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -351,7 +351,7 @@ pub async fn search_sessions_by_like(
 /// Most-recently-created `acquisition_session` rows.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn recent_sessions(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
     let rows = sqlx::query_as::<_, IdLabelRow>(
         "SELECT id, session_key AS label
@@ -375,7 +375,7 @@ pub struct ProjectSearchRow {
 /// Search `projects` by `name`, `like_pattern` already wrapped in `%...%`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn search_projects_by_like(
     pool: &SqlitePool,
     like_pattern: &str,
@@ -396,7 +396,7 @@ pub async fn search_projects_by_like(
 /// Most-recently-created `projects` rows.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn recent_projects(pool: &SqlitePool) -> DbResult<Vec<IdLabelRow>> {
     let rows = sqlx::query_as::<_, IdLabelRow>(
         "SELECT id, name AS label FROM projects ORDER BY created_at DESC LIMIT 5",
@@ -424,7 +424,7 @@ pub struct SessionJoinRow {
 /// All `acquisition_session` rows, newest first.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_sessions_joined(pool: &SqlitePool) -> DbResult<Vec<SessionJoinRow>> {
     list_sessions_joined_paginated(pool, None, None).await
 }
@@ -432,7 +432,7 @@ pub async fn list_sessions_joined(pool: &SqlitePool) -> DbResult<Vec<SessionJoin
 /// Paginated variant of [`list_sessions_joined`].
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_sessions_joined_paginated(
     pool: &SqlitePool,
     limit: Option<u32>,
@@ -469,7 +469,7 @@ pub async fn list_sessions_joined_paginated(
 /// A single `acquisition_session` row by id.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_session_joined(pool: &SqlitePool, id: &str) -> DbResult<Option<SessionJoinRow>> {
     let row = sqlx::query_as::<_, SessionJoinRow>(
         "SELECT s.id, s.session_key, s.target_id, s.frame_ids, s.created_at,
@@ -515,7 +515,7 @@ pub struct FingerprintRow {
 /// `acquisition_fingerprint` row for a session, if present.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_fingerprint(
     pool: &SqlitePool,
     session_id: &str,
@@ -536,7 +536,7 @@ pub async fn get_fingerprint(
 /// `(0, 0)` without querying.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn active_frame_summary(pool: &SqlitePool, ids: &[String]) -> DbResult<(i64, i64)> {
     if ids.is_empty() {
         return Ok((0, 0));
@@ -569,7 +569,7 @@ pub async fn active_frame_summary(pool: &SqlitePool, ids: &[String]) -> DbResult
 /// single frame into multiple summed rows.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn active_frame_exposure_seconds(pool: &SqlitePool, ids: &[String]) -> DbResult<f64> {
     if ids.is_empty() {
         return Ok(0.0);
@@ -602,7 +602,7 @@ pub async fn active_frame_exposure_seconds(pool: &SqlitePool, ids: &[String]) ->
 /// whether a single per-sub value exists.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn active_frame_exposures(pool: &SqlitePool, ids: &[String]) -> DbResult<Vec<f64>> {
     if ids.is_empty() {
         return Ok(Vec::new());
@@ -634,7 +634,7 @@ pub async fn active_frame_exposures(pool: &SqlitePool, ids: &[String]) -> DbResu
 /// `project_id`s linked to a session via `project_sources`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn project_ids_for_session(pool: &SqlitePool, session_id: &str) -> DbResult<Vec<String>> {
     let ids = sqlx::query_scalar::<_, String>(
         "SELECT project_id FROM project_sources WHERE inventory_session_id = ?",
@@ -660,7 +660,7 @@ pub struct CalibrationAssignmentRow {
 /// Calibration matches assigned to a session.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn calibration_matches_for_session(
     pool: &SqlitePool,
     session_id: &str,
@@ -688,7 +688,7 @@ pub struct AuditHistoryRow {
 /// oldest first.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn session_history(
     pool: &SqlitePool,
     session_id: &str,
@@ -710,7 +710,7 @@ pub async fn session_history(
 /// All `(id, frame_ids)` pairs from `acquisition_session`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn all_acquisition_session_frame_ids(
     pool: &SqlitePool,
 ) -> DbResult<Vec<(String, String)>> {
@@ -722,7 +722,7 @@ pub async fn all_acquisition_session_frame_ids(
 /// All `(id, frame_ids, kind)` triples from `calibration_session`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn all_calibration_session_frame_ids(
     pool: &SqlitePool,
 ) -> DbResult<Vec<(String, String, String)>> {
@@ -749,7 +749,7 @@ pub struct KeyedFingerprintRow {
 /// Batch-load `acquisition_fingerprint` rows for multiple session ids.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_fingerprints_batch(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -774,7 +774,7 @@ pub async fn get_fingerprints_batch(
 /// Returns `(session_id, project_id)` pairs.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn project_ids_for_sessions_batch(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -825,7 +825,7 @@ pub async fn project_names_batch(
 /// Internally collects all frame IDs, runs one query, then re-attributes by session.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn active_frame_summaries_batch(
     pool: &SqlitePool,
     sessions_frame_ids: &[(String, Vec<String>)],
@@ -883,7 +883,7 @@ pub async fn active_frame_summaries_batch(
 /// per session. Returns `session_id -> total_exposure_s`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn active_frame_exposure_seconds_batch(
     pool: &SqlitePool,
     sessions_frame_ids: &[(String, Vec<String>)],

--- a/crates/persistence/inbox/src/repositories/inbox/classification.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/classification.rs
@@ -96,7 +96,7 @@ pub struct InsertEvidence<'a> {
 /// Upsert the `inbox_classifications` row for an item.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn upsert_classification(
     pool: &SqlitePool,
     c: &UpsertClassification<'_>,
@@ -107,7 +107,7 @@ pub async fn upsert_classification(
 /// Connection-level variant of [`upsert_classification`].
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn upsert_classification_conn(
     conn: &mut SqliteConnection,
     c: &UpsertClassification<'_>,
@@ -139,7 +139,7 @@ pub async fn upsert_classification_conn(
 /// Fetch the classification for an item, if any.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn get_classification(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -157,7 +157,7 @@ pub async fn get_classification(
 /// Insert a new evidence row.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_evidence(pool: &SqlitePool, ev: &InsertEvidence<'_>) -> DbResult<()> {
     insert_evidence_conn(pool.acquire().await?.as_mut(), ev).await
 }
@@ -165,7 +165,7 @@ pub async fn insert_evidence(pool: &SqlitePool, ev: &InsertEvidence<'_>) -> DbRe
 /// Connection-level variant of [`insert_evidence`].
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_evidence_conn(
     conn: &mut SqliteConnection,
     ev: &InsertEvidence<'_>,
@@ -204,7 +204,7 @@ const EVIDENCE_BATCH_SIZE: usize = 32766 / EVIDENCE_COLS;
 /// caller is expected to set `ev.id` before passing.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_evidence_batch(
     conn: &mut SqliteConnection,
     rows: &[InsertEvidence<'_>],
@@ -241,11 +241,11 @@ pub async fn insert_evidence_batch(
     Ok(())
 }
 
-/// Connection-level variant of [`delete_evidence_for_item`]. See [`insert_plan_conn`] in
+/// Connection-level variant of `delete_evidence_for_item`. See `insert_plan_conn` in
 /// `plans.rs` for the pattern.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn delete_evidence_for_item_conn(
     conn: &mut SqliteConnection,
     inbox_item_id: &str,
@@ -260,7 +260,7 @@ pub async fn delete_evidence_for_item_conn(
 /// Fetch all evidence rows for an item.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_evidence(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -338,7 +338,7 @@ pub async fn list_evidence(
 /// a proper source group and overrides can be re-applied via the UI.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn set_overrides(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -481,7 +481,7 @@ pub async fn set_overrides(
 /// evidence columns.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn set_file_override(
     pool: &SqlitePool,
     source_group_id: &str,
@@ -548,7 +548,7 @@ pub struct FileOverrideRow {
 /// they act on the staleness signal.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_file_overrides_for_group(
     pool: &SqlitePool,
     source_group_id: &str,
@@ -577,7 +577,7 @@ pub struct UpsertClassificationRow<'a> {
 /// Batch-upsert multiple classification rows in one statement per chunk.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn upsert_classification_batch(
     conn: &mut SqliteConnection,
     rows: &[UpsertClassificationRow<'_>],
@@ -621,7 +621,7 @@ pub async fn upsert_classification_batch(
 /// SQLite's parameter limit.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn delete_evidence_for_items(
     conn: &mut SqliteConnection,
     inbox_item_ids: &[&str],
@@ -644,7 +644,7 @@ pub async fn delete_evidence_for_items(
 /// override was recorded — spec 041 R-4).
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn mark_override_stale(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -671,7 +671,7 @@ pub async fn mark_override_stale(
 /// taking a single `property_key`.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn mark_file_override_stale(
     pool: &SqlitePool,
     source_group_id: &str,

--- a/crates/persistence/inbox/src/repositories/inbox/classification.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/classification.rs
@@ -96,7 +96,7 @@ pub struct InsertEvidence<'a> {
 /// Upsert the `inbox_classifications` row for an item.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn upsert_classification(
     pool: &SqlitePool,
     c: &UpsertClassification<'_>,
@@ -107,7 +107,7 @@ pub async fn upsert_classification(
 /// Connection-level variant of [`upsert_classification`].
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn upsert_classification_conn(
     conn: &mut SqliteConnection,
     c: &UpsertClassification<'_>,
@@ -139,7 +139,7 @@ pub async fn upsert_classification_conn(
 /// Fetch the classification for an item, if any.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn get_classification(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -157,7 +157,7 @@ pub async fn get_classification(
 /// Insert a new evidence row.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_evidence(pool: &SqlitePool, ev: &InsertEvidence<'_>) -> DbResult<()> {
     insert_evidence_conn(pool.acquire().await?.as_mut(), ev).await
 }
@@ -165,7 +165,7 @@ pub async fn insert_evidence(pool: &SqlitePool, ev: &InsertEvidence<'_>) -> DbRe
 /// Connection-level variant of [`insert_evidence`].
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_evidence_conn(
     conn: &mut SqliteConnection,
     ev: &InsertEvidence<'_>,
@@ -204,7 +204,7 @@ const EVIDENCE_BATCH_SIZE: usize = 32766 / EVIDENCE_COLS;
 /// caller is expected to set `ev.id` before passing.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_evidence_batch(
     conn: &mut SqliteConnection,
     rows: &[InsertEvidence<'_>],
@@ -245,7 +245,7 @@ pub async fn insert_evidence_batch(
 /// `plans.rs` for the pattern.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn delete_evidence_for_item_conn(
     conn: &mut SqliteConnection,
     inbox_item_id: &str,
@@ -260,7 +260,7 @@ pub async fn delete_evidence_for_item_conn(
 /// Fetch all evidence rows for an item.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_evidence(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -338,7 +338,7 @@ pub async fn list_evidence(
 /// a proper source group and overrides can be re-applied via the UI.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn set_overrides(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -481,7 +481,7 @@ pub async fn set_overrides(
 /// evidence columns.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn set_file_override(
     pool: &SqlitePool,
     source_group_id: &str,
@@ -548,7 +548,7 @@ pub struct FileOverrideRow {
 /// they act on the staleness signal.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_file_overrides_for_group(
     pool: &SqlitePool,
     source_group_id: &str,
@@ -577,7 +577,7 @@ pub struct UpsertClassificationRow<'a> {
 /// Batch-upsert multiple classification rows in one statement per chunk.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn upsert_classification_batch(
     conn: &mut SqliteConnection,
     rows: &[UpsertClassificationRow<'_>],
@@ -621,7 +621,7 @@ pub async fn upsert_classification_batch(
 /// SQLite's parameter limit.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn delete_evidence_for_items(
     conn: &mut SqliteConnection,
     inbox_item_ids: &[&str],
@@ -644,7 +644,7 @@ pub async fn delete_evidence_for_items(
 /// override was recorded — spec 041 R-4).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn mark_override_stale(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -671,7 +671,7 @@ pub async fn mark_override_stale(
 /// taking a single `property_key`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn mark_file_override_stale(
     pool: &SqlitePool,
     source_group_id: &str,

--- a/crates/persistence/inbox/src/repositories/inbox/items.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/items.rs
@@ -57,7 +57,7 @@ pub struct InsertInboxItem<'a> {
 /// Insert a new inbox item in `pending_classification` state.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn insert_inbox_item(pool: &SqlitePool, item: &InsertInboxItem<'_>) -> DbResult<()> {
     let now = Timestamp::now_iso();
     sqlx::query(
@@ -82,7 +82,7 @@ pub async fn insert_inbox_item(pool: &SqlitePool, item: &InsertInboxItem<'_>) ->
 /// Fetch an inbox item by ID. Returns `DbError::NotFound` if absent.
 ///
 /// # Errors
-/// Returns [`DbError::NotFound`] or [`DbError::Database`].
+/// Returns [`DbError::NotFound`] or `persistence_core::DbError::Database`.
 pub async fn get_inbox_item(pool: &SqlitePool, id: &str) -> DbResult<InboxItemRow> {
     sqlx::query_as::<_, InboxItemRow>("SELECT * FROM inbox_items WHERE id = ?")
         .bind(id)
@@ -94,7 +94,7 @@ pub async fn get_inbox_item(pool: &SqlitePool, id: &str) -> DbResult<InboxItemRo
 /// Update `state` and `last_scanned_at` for an inbox item.
 ///
 /// # Errors
-/// Returns [`DbError::NotFound`] if no row was updated, or [`DbError::Database`].
+/// Returns [`DbError::NotFound`] if no row was updated, or `persistence_core::DbError::Database`.
 pub async fn update_inbox_item_state(pool: &SqlitePool, id: &str, state: &str) -> DbResult<()> {
     update_inbox_item_state_conn(pool.acquire().await?.as_mut(), id, state).await
 }
@@ -102,7 +102,7 @@ pub async fn update_inbox_item_state(pool: &SqlitePool, id: &str, state: &str) -
 /// Connection-level variant of [`update_inbox_item_state`].
 ///
 /// # Errors
-/// Returns [`DbError::NotFound`] if no row was updated, or [`DbError::Database`].
+/// Returns [`DbError::NotFound`] if no row was updated, or `persistence_core::DbError::Database`.
 pub async fn update_inbox_item_state_conn(
     conn: &mut SqliteConnection,
     id: &str,
@@ -123,10 +123,10 @@ pub async fn update_inbox_item_state_conn(
     Ok(())
 }
 
-/// Connection-level variant of [`update_inbox_item_scan`].
+/// Connection-level variant of `update_inbox_item_scan`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn update_inbox_item_scan_conn(
     conn: &mut SqliteConnection,
     id: &str,
@@ -190,7 +190,7 @@ pub struct UpsertInboxSubItem<'a> {
 /// file_count, and state are refreshed.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_inbox_sub_item(
     pool: &SqlitePool,
     item: &UpsertInboxSubItem<'_>,
@@ -201,7 +201,7 @@ pub async fn upsert_inbox_sub_item(
 /// Connection-level variant of [`upsert_inbox_sub_item`].
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_inbox_sub_item_conn(
     conn: &mut SqliteConnection,
     item: &UpsertInboxSubItem<'_>,
@@ -255,10 +255,10 @@ pub async fn upsert_inbox_sub_item_conn(
     Ok(persisted_id)
 }
 
-/// Connection-level variant of [`delete_sub_item_if_unlinked`].
+/// Connection-level variant of `delete_sub_item_if_unlinked`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn delete_sub_item_if_unlinked_conn(
     conn: &mut SqliteConnection,
     id: &str,
@@ -283,7 +283,7 @@ pub async fn delete_sub_item_if_unlinked_conn(
 /// included correctly.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_inbox_sub_items(
     pool: &SqlitePool,
     source_group_id: &str,
@@ -293,11 +293,11 @@ pub async fn list_inbox_sub_items(
 
 /// Connection-level variant of [`list_inbox_sub_items`].
 ///
-/// Used by [`materialize_sub_items_tx`] to read existing sub-items within the
+/// Used by `materialize_sub_items_tx` to read existing sub-items within the
 /// same transaction so the orphan-cleanup step sees the current write state.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_inbox_sub_items_conn(
     conn: &mut SqliteConnection,
     source_group_id: &str,
@@ -322,7 +322,7 @@ pub async fn list_inbox_sub_items_conn(
 /// pre-T065 items).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn get_source_group_id_for_item(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -341,7 +341,7 @@ pub async fn get_source_group_id_for_item(
 /// `sourceGroupId` instead of an `inboxItemId`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_item_ids_for_source_group(
     pool: &SqlitePool,
     source_group_id: &str,
@@ -365,7 +365,7 @@ pub async fn list_item_ids_for_source_group(
 /// statement also rules out a read-then-write race with a concurrent classify.
 ///
 /// # Errors
-/// Returns [`DbError::NotFound`] if no row was updated, or [`DbError::Database`].
+/// Returns [`DbError::NotFound`] if no row was updated, or `persistence_core::DbError::Database`.
 pub async fn reset_inbox_item_to_unconfirmed(pool: &SqlitePool, id: &str) -> DbResult<()> {
     let now = Timestamp::now_iso();
     let rows = sqlx::query(

--- a/crates/persistence/inbox/src/repositories/inbox/metadata.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/metadata.rs
@@ -115,7 +115,7 @@ pub struct UpsertFileMetadata<'a> {
 /// Returns `None` when no row has been persisted yet (file not yet classified).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn get_file_metadata(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -133,10 +133,10 @@ pub async fn get_file_metadata(
 
 // ── Breakdown CRUD ────────────────────────────────────────────────────────────
 
-/// Connection-level variant of [`delete_breakdown_for_item`].
+/// Connection-level variant of `delete_breakdown_for_item`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn delete_breakdown_for_item_conn(
     conn: &mut SqliteConnection,
     inbox_item_id: &str,
@@ -151,7 +151,7 @@ pub async fn delete_breakdown_for_item_conn(
 /// Upsert a single breakdown row.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_breakdown_row(
     pool: &SqlitePool,
     id: &str,
@@ -176,7 +176,7 @@ pub async fn upsert_breakdown_row(
 /// Connection-level variant of [`upsert_breakdown_row`].
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_breakdown_row_conn(
     conn: &mut SqliteConnection,
     id: &str,
@@ -209,7 +209,7 @@ pub async fn upsert_breakdown_row_conn(
 /// Fetch breakdown rows for an item.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_breakdown(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -230,7 +230,7 @@ pub async fn list_breakdown(
 /// Called from the classify/reclassify loop alongside the evidence row.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_inbox_file_metadata(
     pool: &SqlitePool,
     m: &UpsertFileMetadata<'_>,
@@ -241,7 +241,7 @@ pub async fn upsert_inbox_file_metadata(
 /// Connection-level variant of [`upsert_inbox_file_metadata`].
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_inbox_file_metadata_conn(
     conn: &mut SqliteConnection,
     m: &UpsertFileMetadata<'_>,
@@ -334,7 +334,7 @@ const FILE_META_BATCH_SIZE: usize = 32766 / FILE_META_COLS;
 /// Chunks at `32766 / 32 = 1023` rows.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_inbox_file_metadata_batch(
     conn: &mut SqliteConnection,
     rows: &[UpsertFileMetadata<'_>],
@@ -436,7 +436,7 @@ pub async fn upsert_inbox_file_metadata_batch(
 /// Batch-delete file-metadata rows for a set of item ids.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn delete_file_metadata_for_items(
     conn: &mut SqliteConnection,
     inbox_item_ids: &[&str],
@@ -457,7 +457,7 @@ pub async fn delete_file_metadata_for_items(
 /// Batch-delete breakdown rows for a set of item ids.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn delete_breakdown_for_items(
     conn: &mut SqliteConnection,
     inbox_item_ids: &[&str],
@@ -476,10 +476,10 @@ pub async fn delete_breakdown_for_items(
     Ok(())
 }
 
-/// Connection-level variant of [`delete_file_metadata_for_item`].
+/// Connection-level variant of `delete_file_metadata_for_item`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn delete_file_metadata_for_item_conn(
     conn: &mut SqliteConnection,
     inbox_item_id: &str,
@@ -494,7 +494,7 @@ pub async fn delete_file_metadata_for_item_conn(
 /// Fetch all per-file metadata rows for an item, ordered by relative path.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_inbox_file_metadata(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -534,7 +534,7 @@ pub struct InboxAttributionGeometryRow {
 /// Read per-file attribution geometry for an inbox item (F-Framing-5).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_inbox_attribution_geometry(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -595,7 +595,7 @@ pub struct InboxPointingRow {
 /// `object` is carried as a display hint only.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_inbox_pointing(
     pool: &SqlitePool,
     inbox_item_id: &str,

--- a/crates/persistence/inbox/src/repositories/inbox/plan_links.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/plan_links.rs
@@ -22,10 +22,10 @@ pub struct InboxPlanLinkRow {
 
 /// Insert a plan link, establishing the "open plan" invariant.
 ///
-/// Fails with [`DbError::Database`] if a link already exists (PK conflict).
+/// Fails with `persistence_core::DbError::Database` if a link already exists (PK conflict).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn insert_plan_link(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -47,7 +47,7 @@ pub async fn insert_plan_link(
 /// Fetch the plan link for an item, if any.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn get_plan_link(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -63,7 +63,7 @@ pub async fn get_plan_link(
 /// Delete the plan link for an item (called when a plan closes).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn delete_plan_link(pool: &SqlitePool, inbox_item_id: &str) -> DbResult<()> {
     sqlx::query("DELETE FROM inbox_plan_links WHERE inbox_item_id = ?")
         .bind(inbox_item_id)
@@ -75,7 +75,7 @@ pub async fn delete_plan_link(pool: &SqlitePool, inbox_item_id: &str) -> DbResul
 /// Fetch the plan link row by plan ID (used by the plan listener).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn get_plan_link_by_plan_id(
     pool: &SqlitePool,
     plan_id: &str,
@@ -91,7 +91,7 @@ pub async fn get_plan_link_by_plan_id(
 /// Used by the background repair query. (Ref: R-PlanOpen)
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn find_orphaned_plan_links(
     pool: &SqlitePool,
 ) -> DbResult<Vec<(String, String, String)>> {

--- a/crates/persistence/inbox/src/repositories/inbox/projections.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/projections.rs
@@ -63,7 +63,7 @@ pub struct InboxStatsRow {
 /// Rows with NULL effective type (unclassified) are excluded.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn inbox_stats(pool: &SqlitePool) -> DbResult<Vec<InboxStatsRow>> {
     // sqlx does not derive FromRow for plain tuples with more than 3 elements
     // in some configurations, so we map manually via a named intermediate.
@@ -115,7 +115,7 @@ pub async fn inbox_stats(pool: &SqlitePool) -> DbResult<Vec<InboxStatsRow>> {
 /// [`list_unacknowledged_across_roots`].
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_distinct_inbox_folders(pool: &SqlitePool) -> DbResult<i64> {
     let sql = format!(
         "SELECT COUNT(DISTINCT i.id)
@@ -187,7 +187,7 @@ pub struct InboxListRow {
 /// Pass `limit` to cap the result set (FR-006 bounding).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_unacknowledged_across_roots(
     pool: &SqlitePool,
     limit: i64,
@@ -320,7 +320,7 @@ fn label_from_distinct(distinct: i64, value: Option<String>) -> Option<String> {
 /// `DATE-OBS` value truncated to its first 10 chars (`YYYY-MM-DD`).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn grouping_keys_for_items(
     pool: &SqlitePool,
     item_ids: &[String],

--- a/crates/persistence/inbox/src/repositories/inbox/source_groups.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/source_groups.rs
@@ -55,7 +55,7 @@ pub struct UpsertSourceGroup<'a> {
 /// (auto-commit) or `&mut Transaction` (batched commit).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn upsert_inbox_source_group<'e, E>(
     executor: E,
     group: &UpsertSourceGroup<'_>,
@@ -101,7 +101,7 @@ where
 /// rows (never scanned) are simply absent from the returned map.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn last_scanned_by_root(
     pool: &SqlitePool,
 ) -> DbResult<std::collections::HashMap<String, String>> {
@@ -115,10 +115,10 @@ pub async fn last_scanned_by_root(
 
 // ── InboxItem CRUD ────────────────────────────────────────────────────────────
 
-/// Connection-level variant of [`update_source_group_child_count`].
+/// Connection-level variant of `update_source_group_child_count`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn update_source_group_child_count_conn(
     conn: &mut SqliteConnection,
     source_group_id: &str,
@@ -172,7 +172,7 @@ pub struct InboxSourceGroupListRow {
 /// here.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn list_unclassified_source_groups(
     pool: &SqlitePool,
     limit: i64,

--- a/crates/persistence/inbox/src/repositories/plan_result.rs
+++ b/crates/persistence/inbox/src/repositories/plan_result.rs
@@ -98,7 +98,7 @@ pub async fn get_plan_snapshot_for_operation(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_proposed_sessions(
     pool: &SqlitePool,
     snapshot_row_id: i64,
@@ -120,7 +120,7 @@ pub async fn list_proposed_sessions(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_proposed_session_frames(
     pool: &SqlitePool,
     proposed_session_row_id: i64,

--- a/crates/persistence/inbox/src/repositories/q_inbox.rs
+++ b/crates/persistence/inbox/src/repositories/q_inbox.rs
@@ -23,7 +23,7 @@ use persistence_core::DbResult;
 /// `(root_id, relative_path)` natural key.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn get_source_group_by_id(
     pool: &SqlitePool,
     id: &str,
@@ -51,7 +51,7 @@ pub async fn get_source_group_by_id(
 /// inline query exactly.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn set_manual_override_reset_stale(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -102,7 +102,7 @@ pub struct InsertCalibrationFingerprint<'a> {
 /// row already reference this inbox item?
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on connection failure.
+/// Returns `persistence_core::DbError::Database` on connection failure.
 pub async fn calibration_session_exists_for_inbox_item(
     pool: &SqlitePool,
     inbox_item_id: &str,
@@ -118,7 +118,7 @@ pub async fn calibration_session_exists_for_inbox_item(
 /// Insert a `calibration_session` row registering a detected master.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn insert_calibration_session(
     pool: &SqlitePool,
     session: &InsertCalibrationSession<'_>,
@@ -143,7 +143,7 @@ pub async fn insert_calibration_session(
 /// `calibration_session`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn insert_calibration_fingerprint(
     pool: &SqlitePool,
     fp: &InsertCalibrationFingerprint<'_>,

--- a/crates/persistence/lifecycle/src/repositories/audit.rs
+++ b/crates/persistence/lifecycle/src/repositories/audit.rs
@@ -201,7 +201,7 @@ pub async fn count_audit_entries(pool: &SqlitePool, filter: &AuditLogFilter) -> 
 /// `request_id` UUIDs and the RFC3339 `at` timestamp.
 ///
 /// # Errors
-/// Returns [`DbError`](persistence_core::DbError) if the insert fails.
+/// Returns `persistence_core::DbError`(persistence_core::DbError) if the insert fails.
 pub async fn insert_project_auto_transition(
     pool: &SqlitePool,
     project_id: &str,
@@ -218,7 +218,7 @@ pub async fn insert_project_auto_transition(
 /// Delegates to [`persistence_core::repositories::audit_writes::insert_audit_entry`].
 ///
 /// # Errors
-/// Returns [`DbError`](persistence_core::DbError) if the insert fails.
+/// Returns `persistence_core::DbError`(persistence_core::DbError) if the insert fails.
 pub async fn insert_audit_entry(pool: &SqlitePool, entry: &AuditLogEntry) -> DbResult<()> {
     audit_writes::insert_audit_entry(pool, entry).await
 }

--- a/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/command_ledger/mod.rs
@@ -34,7 +34,7 @@ pub const MAX_OUTBOX_EVENTS: usize = 100;
 const MAX_SAFE_STRING_BYTES: usize = 1024;
 
 /// Errors returned by command-ledger operations.  Semantic errors are kept
-/// separate from [`crate::DbError`] so callers can project safe contract codes
+/// separate from `persistence_core::DbError` so callers can project safe contract codes
 /// without parsing SQLite's diagnostic text.
 #[derive(Debug, Error)]
 pub enum CommandLedgerError {

--- a/crates/persistence/lifecycle/src/repositories/events.rs
+++ b/crates/persistence/lifecycle/src/repositories/events.rs
@@ -25,7 +25,7 @@ pub struct EventRow {
 /// Append a durable event row. Returns the assigned `event_id`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_event(
     pool: &SqlitePool,
     topic: &str,
@@ -48,7 +48,7 @@ pub async fn insert_event(
 /// transaction). Returns the assigned `event_id`.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_event_conn(
     conn: &mut SqliteConnection,
     topic: &str,
@@ -70,7 +70,7 @@ pub async fn insert_event_conn(
 /// List all events with `event_id > since_id`, oldest first.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_since(pool: &SqlitePool, since_id: i64) -> DbResult<Vec<EventRow>> {
     let rows = sqlx::query_as::<_, EventRow>(
         "SELECT event_id, topic, emitted_at, payload \
@@ -85,7 +85,7 @@ pub async fn list_since(pool: &SqlitePool, since_id: i64) -> DbResult<Vec<EventR
 /// List events on a single topic with `event_id > since_id`, oldest first.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_since_by_topic(
     pool: &SqlitePool,
     since_id: i64,
@@ -107,7 +107,7 @@ pub async fn list_since_by_topic(
 /// `log_stream::recent_entries` query shape).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_recent_since(
     pool: &SqlitePool,
     since_id: i64,
@@ -129,7 +129,7 @@ pub async fn list_recent_since(
 /// query shape.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_by_emitted_at_range(
     pool: &SqlitePool,
     since: Option<&str>,
@@ -179,7 +179,7 @@ pub async fn list_by_emitted_at_range(
 /// live forwarder's cursor so only events emitted after subscribe are sent.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn max_event_id(pool: &SqlitePool) -> DbResult<i64> {
     let (max_id,): (i64,) =
         sqlx::query_as("SELECT COALESCE(MAX(event_id), 0) FROM events").fetch_one(pool).await?;
@@ -191,7 +191,7 @@ pub async fn max_event_id(pool: &SqlitePool) -> DbResult<i64> {
 /// row still on disk.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn min_event_id(pool: &SqlitePool) -> DbResult<Option<i64>> {
     let min_id: Option<i64> =
         sqlx::query_scalar("SELECT MIN(event_id) FROM events").fetch_one(pool).await?;
@@ -202,7 +202,7 @@ pub async fn min_event_id(pool: &SqlitePool) -> DbResult<Option<i64>> {
 /// decide whether a prune pass is warranted.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 #[allow(dead_code)] // retention pruner will call this; no production caller yet
 pub(crate) async fn count_events(pool: &SqlitePool) -> DbResult<i64> {
     let (count,): (i64,) = sqlx::query_as("SELECT COUNT(*) FROM events").fetch_one(pool).await?;
@@ -234,7 +234,7 @@ pub(crate) async fn count_events(pool: &SqlitePool) -> DbResult<i64> {
 /// Returns the number of rows deleted.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn prune_events_older_than(pool: &SqlitePool, older_than_iso: &str) -> DbResult<u64> {
     let result = sqlx::query("DELETE FROM events WHERE emitted_at < ?")
         .bind(older_than_iso)

--- a/crates/persistence/lifecycle/src/repositories/first_run/dependents.rs
+++ b/crates/persistence/lifecycle/src/repositories/first_run/dependents.rs
@@ -37,7 +37,7 @@ use persistence_core::DbResult;
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn relative_paths_for_root(pool: &SqlitePool, root_id: &str) -> DbResult<Vec<String>> {
     let rows: Vec<(String,)> = sqlx::query_as(
         "SELECT relative_path FROM file_record WHERE root_id = ? \
@@ -62,7 +62,7 @@ pub async fn relative_paths_for_root(pool: &SqlitePool, root_id: &str) -> DbResu
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_root_dependents(
     pool: &SqlitePool,
     root_id: &str,

--- a/crates/persistence/lifecycle/src/repositories/first_run/mod.rs
+++ b/crates/persistence/lifecycle/src/repositories/first_run/mod.rs
@@ -6,10 +6,10 @@
 //! Operates on `registered_sources` and `first_run_state` tables
 //! (migration 0006).
 //!
-//! Split by responsibility (refactor sweep #974): [`sources`] is
-//! register/list/find/remove; [`source_state`] is per-source organization
-//! state / path / active-flag get-set; [`dependents`] is the
-//! `roots.delete`/`roots.remap` dependency-counting pair; [`wizard_state`]
+//! Split by responsibility (refactor sweep #974): `sources` is
+//! register/list/find/remove; `source_state` is per-source organization
+//! state / path / active-flag get-set; `dependents` is the
+//! `roots.delete`/`roots.remap` dependency-counting pair; `wizard_state`
 //! is the `first_run_state` singleton (get/complete/restart).
 
 use domain_core::first_run::{OrganizationState, ScanDepth, SourceKind};

--- a/crates/persistence/lifecycle/src/repositories/first_run/source_state.rs
+++ b/crates/persistence/lifecycle/src/repositories/first_run/source_state.rs
@@ -18,7 +18,7 @@ use super::{organization_state_to_str, str_to_organization_state, str_to_source_
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_source_organization_state(
     pool: &SqlitePool,
     source_id: &str,
@@ -42,7 +42,7 @@ pub async fn get_source_organization_state(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_source_path(pool: &SqlitePool, source_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> = sqlx::query_as("SELECT path FROM registered_sources WHERE id = ?")
         .bind(source_id)
@@ -57,7 +57,7 @@ pub async fn get_source_path(pool: &SqlitePool, source_id: &str) -> DbResult<Opt
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_source_kind_and_path(
     pool: &SqlitePool,
     source_id: &str,
@@ -74,14 +74,14 @@ pub async fn get_source_kind_and_path(
 ///
 /// Enforces the invariant that `inbox`-kind sources are always `unorganized`:
 /// attempting to set an inbox source to `organized` returns
-/// [`DbError::CasFailed`] with the `source.invalid_organization_state` marker
+/// `persistence_core::DbError::CasFailed` with the `source.invalid_organization_state` marker
 /// in the message (the app/core use-case maps this to the contract error code).
 ///
 /// # Errors
 ///
 /// - [`DbError::NotFound`] when no source row matches `source_id`.
-/// - [`DbError::CasFailed`] when attempting to set an inbox source to organized.
-/// - [`DbError::Database`] on query failure.
+/// - `persistence_core::DbError::CasFailed` when attempting to set an inbox source to organized.
+/// - `persistence_core::DbError::Database` on query failure.
 pub async fn set_source_organization_state(
     pool: &SqlitePool,
     source_id: &str,
@@ -144,7 +144,7 @@ pub async fn set_source_path(pool: &SqlitePool, source_id: &str, new_path: &str)
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_active_flags(
     pool: &SqlitePool,
 ) -> DbResult<std::collections::HashMap<String, bool>> {

--- a/crates/persistence/lifecycle/src/repositories/first_run/sources.rs
+++ b/crates/persistence/lifecycle/src/repositories/first_run/sources.rs
@@ -22,7 +22,7 @@ use super::{
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_sources_by_path(
     pool: &SqlitePool,
     path: &str,
@@ -51,7 +51,7 @@ pub async fn find_sources_by_path(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation (e.g. duplicate
+/// Returns `persistence_core::DbError::Database` on constraint violation (e.g. duplicate
 /// kind+path).
 pub async fn register_source(
     pool: &SqlitePool,
@@ -104,7 +104,7 @@ pub async fn register_source(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] only for catastrophic connection failures.
+/// Returns `persistence_core::DbError::Database` only for catastrophic connection failures.
 /// Per-item errors are captured in the response.
 pub async fn register_source_batch(
     pool: &SqlitePool,
@@ -182,7 +182,7 @@ pub async fn register_source_batch(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_sources(pool: &SqlitePool) -> DbResult<Vec<RegisterSourceResponse>> {
     let rows: Vec<(String, String, String, String, String)> = sqlx::query_as(
         "SELECT id, kind, path, created_at, organization_state \

--- a/crates/persistence/lifecycle/src/repositories/first_run/wizard_state.rs
+++ b/crates/persistence/lifecycle/src/repositories/first_run/wizard_state.rs
@@ -20,7 +20,7 @@ use super::sources::list_sources;
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_first_run_state(pool: &SqlitePool) -> DbResult<FirstRunStateResponse> {
     let row: Option<(Option<String>, String)> = sqlx::query_as(
         "SELECT completed_at, last_step FROM first_run_state WHERE singleton_id = 'first_run'",
@@ -87,7 +87,7 @@ pub async fn complete_first_run(pool: &SqlitePool) -> DbResult<FirstRunCompleteR
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn restart_first_run(pool: &SqlitePool) -> DbResult<FirstRunRestartResponse> {
     let now = Timestamp::now_iso();
 

--- a/crates/persistence/lifecycle/src/repositories/onboarding.rs
+++ b/crates/persistence/lifecycle/src/repositories/onboarding.rs
@@ -61,7 +61,7 @@ pub enum UpsertOutcome {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn load_state(pool: &SqlitePool) -> DbResult<Vec<OnboardingStateRow>> {
     let rows: Vec<(String, String, String, String)> =
         sqlx::query_as("SELECT item_id, state, at, source FROM onboarding_state")
@@ -78,7 +78,7 @@ pub async fn load_state(pool: &SqlitePool) -> DbResult<Vec<OnboardingStateRow>> 
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn load_item(pool: &SqlitePool, item_id: &str) -> DbResult<Option<OnboardingStateRow>> {
     let row: Option<(String, String, String, String)> =
         sqlx::query_as("SELECT item_id, state, at, source FROM onboarding_state WHERE item_id = ?")
@@ -108,7 +108,7 @@ pub async fn load_item(pool: &SqlitePool, item_id: &str) -> DbResult<Option<Onbo
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn upsert_if_unsettled(
     pool: &SqlitePool,
     item_id: &str,
@@ -154,7 +154,7 @@ pub async fn upsert_if_unsettled(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn force_unchecked(pool: &SqlitePool, item_id: &str) -> DbResult<UpsertOutcome> {
     let now = Timestamp::now_iso();
     let result = sqlx::query(
@@ -186,7 +186,7 @@ pub async fn force_unchecked(pool: &SqlitePool, item_id: &str) -> DbResult<Upser
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_if_missing(
     pool: &SqlitePool,
     item_id: &str,
@@ -214,7 +214,7 @@ pub async fn insert_if_missing(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn all_items_settled(pool: &SqlitePool) -> DbResult<bool> {
     let unchecked_count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM onboarding_state WHERE state = 'unchecked'")
@@ -243,7 +243,7 @@ pub async fn all_items_settled(pool: &SqlitePool) -> DbResult<bool> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn has_confirmed_inbox_item(pool: &SqlitePool) -> DbResult<bool> {
     let exists: bool = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM inbox_items WHERE state IN ('plan_open', 'resolved'))",
@@ -258,7 +258,7 @@ pub async fn has_confirmed_inbox_item(pool: &SqlitePool) -> DbResult<bool> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn has_applied_plan(pool: &SqlitePool) -> DbResult<bool> {
     let exists: bool = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM plans WHERE state IN ('applied', 'partially_applied'))",
@@ -273,7 +273,7 @@ pub async fn has_applied_plan(pool: &SqlitePool) -> DbResult<bool> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn has_project(pool: &SqlitePool) -> DbResult<bool> {
     let exists: bool =
         sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM projects)").fetch_one(pool).await?;
@@ -285,7 +285,7 @@ pub async fn has_project(pool: &SqlitePool) -> DbResult<bool> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn has_spawned_tool_launch(pool: &SqlitePool) -> DbResult<bool> {
     let exists: bool =
         sqlx::query_scalar("SELECT EXISTS(SELECT 1 FROM tool_launches WHERE outcome = 'spawned')")
@@ -299,7 +299,7 @@ pub async fn has_spawned_tool_launch(pool: &SqlitePool) -> DbResult<bool> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn has_resolved_target(pool: &SqlitePool) -> DbResult<bool> {
     let exists: bool = sqlx::query_scalar(
         "SELECT EXISTS(SELECT 1 FROM ingest_resolution WHERE state = 'resolved')",
@@ -317,7 +317,7 @@ pub async fn has_resolved_target(pool: &SqlitePool) -> DbResult<bool> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn load_flags(pool: &SqlitePool) -> DbResult<OnboardingFlagsRow> {
     let row: Option<(Option<String>, Option<String>, i64)> = sqlx::query_as(
         "SELECT orientation_done_at, section_hidden_at, sidebar_collapsed \
@@ -341,7 +341,7 @@ pub async fn load_flags(pool: &SqlitePool) -> DbResult<OnboardingFlagsRow> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn upsert_flags(pool: &SqlitePool, row: &OnboardingFlagsRow) -> DbResult<()> {
     sqlx::query(
         "INSERT INTO onboarding_flags (singleton_id, orientation_done_at, section_hidden_at, sidebar_collapsed) \

--- a/crates/persistence/lifecycle/src/repositories/provenance.rs
+++ b/crates/persistence/lifecycle/src/repositories/provenance.rs
@@ -120,7 +120,7 @@ fn row_to_entry(row: &ProvenanceRow) -> DbResult<ProvenanceEntry<Value>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] for SQL failures (including a stored `value`
+/// Returns `persistence_core::DbError::Database` for SQL failures (including a stored `value`
 /// that cannot be parsed as JSON — decoded via `sqlx::types::Json` at fetch
 /// time) and [`DbError::NotFound`] when stored discriminants/UUIDs/timestamps
 /// cannot be decoded.

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -19,7 +19,7 @@ use sqlx::SqlitePool;
 use persistence_core::{DbError, DbResult};
 
 /// Settings key holding the per-frame-type destination pattern overrides
-/// (spec 041 FR-026b). Stored as a JSON object mapping a [`FrameTypeClass`]
+/// (spec 041 FR-026b). Stored as a JSON object mapping a [`patterns::FrameTypeClass`]
 /// name to a pattern string. Only explicit overrides are persisted; missing
 /// entries fall back to [`default_pattern`] on read.
 pub const PATTERNS_BY_TYPE_KEY: &str = "patternsByType";
@@ -32,7 +32,7 @@ pub const PATTERNS_BY_TYPE_KEY: &str = "patternsByType";
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_raw(pool: &SqlitePool, key: &str) -> DbResult<Option<Value>> {
     let row: Option<(Json<Value>,)> = sqlx::query_as("SELECT value FROM settings WHERE key = ?")
         .bind(key)
@@ -46,8 +46,8 @@ pub async fn get_raw(pool: &SqlitePool, key: &str) -> DbResult<Option<Value>> {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
-/// Returns [\ `persistence_core::DbError::Serialise`] if the value cannot be serialised.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Serialise`] if the value cannot be serialised.
 pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()> {
     let now = Timestamp::now_iso();
 
@@ -71,7 +71,7 @@ pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn set_raw_with_conn(
     conn: &mut SqliteConnection,
     key: &str,
@@ -98,7 +98,7 @@ pub async fn set_raw_with_conn(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn delete_key(pool: &SqlitePool, key: &str) -> DbResult<()> {
     sqlx::query("DELETE FROM settings WHERE key = ?").bind(key).execute(pool).await?;
     Ok(())
@@ -108,7 +108,7 @@ pub async fn delete_key(pool: &SqlitePool, key: &str) -> DbResult<()> {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
     let rows: Vec<(String, Json<Value>)> =
         sqlx::query_as("SELECT key, value FROM settings ORDER BY key ASC").fetch_all(pool).await?;
@@ -124,7 +124,7 @@ pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_all_by_prefix(pool: &SqlitePool, prefix: &str) -> DbResult<Vec<(String, Value)>> {
     // SQLite LIKE pattern: append '%' to the prefix. The prefix itself may
     // contain literal '%' or '_' — escape them so they are matched literally.
@@ -148,7 +148,7 @@ pub async fn get_all_by_prefix(pool: &SqlitePool, prefix: &str) -> DbResult<Vec<
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn load_settings(pool: &SqlitePool) -> DbResult<SettingsState> {
     let stored = get_all_raw(pool).await?;
     merge_with_defaults(stored)
@@ -241,7 +241,7 @@ settings_key_table! {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`] if
+/// Returns [`persistence_core::DbError::Database`] on query failure or [`persistence_core::DbError::Serialise`] if
 /// the stored value is not a string→string object.
 pub async fn get_patterns_by_type(pool: &SqlitePool) -> DbResult<BTreeMap<String, String>> {
     match get_raw(pool, PATTERNS_BY_TYPE_KEY).await? {
@@ -255,13 +255,13 @@ pub async fn get_patterns_by_type(pool: &SqlitePool) -> DbResult<BTreeMap<String
 /// built-in [`default_pattern`].
 ///
 /// Returns `None` only when `frame_type` does not map to a known
-/// [`FrameTypeClass`] (e.g. an unclassified frame). Callers (spec 041 confirm,
+/// [`patterns::FrameTypeClass`] (e.g. an unclassified frame). Callers (spec 041 confirm,
 /// T052) treat `None` as "no destination pattern" and surface it via the
 /// needs-review flow.
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`] if
+/// Returns [`persistence_core::DbError::Database`] on query failure or [`persistence_core::DbError::Serialise`] if
 /// the stored override map is malformed.
 pub async fn effective_pattern_for(
     pool: &SqlitePool,
@@ -286,7 +286,7 @@ pub async fn effective_pattern_for(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn set_source_override(
     pool: &SqlitePool,
     source_id: &str,
@@ -313,7 +313,7 @@ pub async fn set_source_override(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_source_override_raw(
     pool: &SqlitePool,
     source_id: &str,

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -32,7 +32,7 @@ pub const PATTERNS_BY_TYPE_KEY: &str = "patternsByType";
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_raw(pool: &SqlitePool, key: &str) -> DbResult<Option<Value>> {
     let row: Option<(Json<Value>,)> = sqlx::query_as("SELECT value FROM settings WHERE key = ?")
         .bind(key)
@@ -46,8 +46,8 @@ pub async fn get_raw(pool: &SqlitePool, key: &str) -> DbResult<Option<Value>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
-/// Returns [`DbError::Serialise`] if the value cannot be serialised.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Serialise`] if the value cannot be serialised.
 pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()> {
     let now = Timestamp::now_iso();
 
@@ -71,7 +71,7 @@ pub async fn set_raw(pool: &SqlitePool, key: &str, value: &Value) -> DbResult<()
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn set_raw_with_conn(
     conn: &mut SqliteConnection,
     key: &str,
@@ -98,7 +98,7 @@ pub async fn set_raw_with_conn(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn delete_key(pool: &SqlitePool, key: &str) -> DbResult<()> {
     sqlx::query("DELETE FROM settings WHERE key = ?").bind(key).execute(pool).await?;
     Ok(())
@@ -108,7 +108,7 @@ pub async fn delete_key(pool: &SqlitePool, key: &str) -> DbResult<()> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
     let rows: Vec<(String, Json<Value>)> =
         sqlx::query_as("SELECT key, value FROM settings ORDER BY key ASC").fetch_all(pool).await?;
@@ -124,7 +124,7 @@ pub async fn get_all_raw(pool: &SqlitePool) -> DbResult<Vec<(String, Value)>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_all_by_prefix(pool: &SqlitePool, prefix: &str) -> DbResult<Vec<(String, Value)>> {
     // SQLite LIKE pattern: append '%' to the prefix. The prefix itself may
     // contain literal '%' or '_' — escape them so they are matched literally.
@@ -148,7 +148,7 @@ pub async fn get_all_by_prefix(pool: &SqlitePool, prefix: &str) -> DbResult<Vec<
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn load_settings(pool: &SqlitePool) -> DbResult<SettingsState> {
     let stored = get_all_raw(pool).await?;
     merge_with_defaults(stored)
@@ -241,7 +241,7 @@ settings_key_table! {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`] if
+/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`] if
 /// the stored value is not a string→string object.
 pub async fn get_patterns_by_type(pool: &SqlitePool) -> DbResult<BTreeMap<String, String>> {
     match get_raw(pool, PATTERNS_BY_TYPE_KEY).await? {
@@ -261,7 +261,7 @@ pub async fn get_patterns_by_type(pool: &SqlitePool) -> DbResult<BTreeMap<String
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`] if
+/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`] if
 /// the stored override map is malformed.
 pub async fn effective_pattern_for(
     pool: &SqlitePool,
@@ -286,7 +286,7 @@ pub async fn effective_pattern_for(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn set_source_override(
     pool: &SqlitePool,
     source_id: &str,
@@ -313,7 +313,7 @@ pub async fn set_source_override(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_source_override_raw(
     pool: &SqlitePool,
     source_id: &str,

--- a/crates/persistence/plans/src/repositories/artifacts.rs
+++ b/crates/persistence/plans/src/repositories/artifacts.rs
@@ -73,7 +73,7 @@ pub struct InsertArtifact<'a> {
 /// - `Ok(None)` — constraint violation silenced the insert (no row written).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on any DB failure that is not a
+/// Returns [`persistence_core::DbError::Database`] on any DB failure that is not a
 /// constraint violation (e.g. I/O errors, schema mismatches).
 pub async fn insert_artifact_if_absent(
     pool: &SqlitePool,
@@ -116,7 +116,7 @@ pub async fn insert_artifact_if_absent(
 /// Lookup an artifact by `(project_id, path)`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_artifact_by_path(
     pool: &SqlitePool,
     project_id: &str,
@@ -137,7 +137,7 @@ pub async fn get_artifact_by_path(
 /// `include_states` filters by state; if empty, returns all states.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_artifacts_for_project(
     pool: &SqlitePool,
     project_id: &str,
@@ -176,7 +176,7 @@ pub async fn list_artifacts_for_project(
 /// Update `last_seen_at` for a `present` artifact (reconcile seen pass).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn touch_artifact(pool: &SqlitePool, artifact_id: &str) -> DbResult<()> {
     let now = Timestamp::now_iso();
     sqlx::query("UPDATE processing_artifacts SET last_seen_at = ? WHERE id = ?")
@@ -190,7 +190,7 @@ pub async fn touch_artifact(pool: &SqlitePool, artifact_id: &str) -> DbResult<()
 /// Transition an artifact to `missing` state.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn mark_artifact_missing(pool: &SqlitePool, artifact_id: &str) -> DbResult<()> {
     sqlx::query("UPDATE processing_artifacts SET state = 'missing' WHERE id = ?")
         .bind(artifact_id)
@@ -202,7 +202,7 @@ pub async fn mark_artifact_missing(pool: &SqlitePool, artifact_id: &str) -> DbRe
 /// Transition an artifact from `missing` back to `present` and refresh size/hash.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn mark_artifact_recovered(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -229,7 +229,7 @@ pub async fn mark_artifact_recovered(
 /// Mark a `missing` artifact as user-resolved.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn mark_artifact_user_resolved(pool: &SqlitePool, artifact_id: &str) -> DbResult<()> {
     sqlx::query(
         "UPDATE processing_artifacts SET state = 'user_resolved_missing' WHERE id = ? AND state = 'missing'"
@@ -243,7 +243,7 @@ pub async fn mark_artifact_user_resolved(pool: &SqlitePool, artifact_id: &str) -
 /// Update classification on an artifact (auto re-classification after override cleared, A6).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn update_classification(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -281,7 +281,7 @@ pub struct ArtifactIdentityRow {
 /// fix-up input; small enough table that a full scan is fine).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_all_artifact_identities(pool: &SqlitePool) -> DbResult<Vec<ArtifactIdentityRow>> {
     let rows = sqlx::query_as::<_, ArtifactIdentityRow>(
         "SELECT id, project_id, path FROM processing_artifacts",
@@ -295,7 +295,7 @@ pub async fn list_all_artifact_identities(pool: &SqlitePool) -> DbResult<Vec<Art
 /// fix-up). Leaves every other field untouched.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn set_project_id(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -312,7 +312,7 @@ pub async fn set_project_id(
 /// Update `tool_launch_id` for attribution (T022/T022b).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn set_tool_launch_id(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -329,7 +329,7 @@ pub async fn set_tool_launch_id(
 /// Update the in-place rerun fields (A8): `content_hash`, `size_bytes`, `last_seen_at`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn update_artifact_inplace(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -367,7 +367,7 @@ pub struct OverrideRow {
 /// Insert or replace a manual classification override (T014).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn upsert_override(
     pool: &SqlitePool,
     artifact_id: &str,
@@ -397,7 +397,7 @@ pub async fn upsert_override(
 /// Delete the manual override and return the deleted row if any (A6 clear path).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn clear_override(pool: &SqlitePool, artifact_id: &str) -> DbResult<Option<OverrideRow>> {
     let prior = sqlx::query_as::<_, OverrideRow>(
         "SELECT * FROM classification_overrides WHERE artifact_id = ?",
@@ -421,7 +421,7 @@ pub async fn clear_override(pool: &SqlitePool, artifact_id: &str) -> DbResult<Op
 /// is terminal (T022c). Only updates rows where `completed_at` is currently NULL.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn complete_tool_launch(
     pool: &SqlitePool,
     tool_launch_id: &str,
@@ -440,7 +440,7 @@ pub async fn complete_tool_launch(
 /// List artifact ids attributed to a given tool launch.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_artifact_ids_for_launch(
     pool: &SqlitePool,
     tool_launch_id: &str,

--- a/crates/persistence/plans/src/repositories/manifests.rs
+++ b/crates/persistence/plans/src/repositories/manifests.rs
@@ -45,7 +45,7 @@ pub struct InsertManifest<'a> {
 /// Insert a new manifest row.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_manifest(pool: &SqlitePool, data: InsertManifest<'_>) -> DbResult<String> {
     let ts = Timestamp::now_iso();
     sqlx::query(
@@ -75,7 +75,7 @@ pub async fn insert_manifest(pool: &SqlitePool, data: InsertManifest<'_>) -> DbR
 /// results exist beyond the returned page.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_manifests_for_project(
     pool: &SqlitePool,
     project_id: &str,

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -176,7 +176,7 @@ pub async fn cas_approved_to_applying(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn complete_run(
     pool: &SqlitePool,
     plan_id: &str,
@@ -234,7 +234,7 @@ pub async fn complete_run(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn pause_run(
     pool: &SqlitePool,
@@ -279,8 +279,8 @@ pub async fn pause_run(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] if plan is not in `paused` state.
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::CasFailed`] if plan is not in `paused` state.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbResult<()> {
     let mut tx = pool.begin().await?;
 
@@ -327,7 +327,7 @@ pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbRes
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn item_retry_applying(pool: &SqlitePool, item_id: &str, plan_id: &str) -> DbResult<()> {
     let mut tx = pool.begin().await?;
 
@@ -356,7 +356,7 @@ pub async fn item_retry_applying(pool: &SqlitePool, item_id: &str, plan_id: &str
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<String>> {
     let ids: Vec<String> = sqlx::query_scalar(
         "SELECT id FROM plan_items WHERE plan_id = ? AND item_state = 'pending' ORDER BY item_index ASC",
@@ -371,7 +371,7 @@ pub async fn list_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Ve
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn batch_cancel_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<i64> {
     let mut tx = pool.begin().await?;
 
@@ -418,7 +418,7 @@ pub async fn batch_cancel_pending_items(pool: &SqlitePool, plan_id: &str) -> DbR
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn cancel_orphaned_applying_items(
     pool: &SqlitePool,
     plan_id: &str,
@@ -460,7 +460,7 @@ pub async fn cancel_orphaned_applying_items(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn append_event(
     pool: &SqlitePool,
@@ -515,7 +515,7 @@ pub async fn append_event(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn get_active_run(pool: &SqlitePool, plan_id: &str) -> DbResult<Option<PlanApplyRunRow>> {
     Ok(sqlx::query_as(
         "SELECT * FROM plan_apply_runs \
@@ -538,7 +538,7 @@ pub async fn get_active_run(pool: &SqlitePool, plan_id: &str) -> DbResult<Option
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn get_last_stale_item(
     pool: &SqlitePool,
     plan_id: &str,
@@ -560,7 +560,7 @@ pub async fn get_last_stale_item(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn get_last_item_with_failure_prefix(
     pool: &SqlitePool,
     plan_id: &str,
@@ -606,7 +606,7 @@ pub struct BatchItemState<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn batch_flush_item_states(
     conn: &mut SqliteConnection,
     plan_id: &str,
@@ -666,7 +666,7 @@ pub async fn batch_flush_item_states(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn append_event_conn(
     conn: &mut SqliteConnection,
@@ -728,7 +728,7 @@ pub async fn append_event_conn(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn sweep_crashed_applying_plans(pool: &SqlitePool) -> DbResult<Vec<String>> {
     let mut tx = pool.begin().await?;
 
@@ -769,7 +769,7 @@ pub async fn sweep_crashed_applying_plans(pool: &SqlitePool) -> DbResult<Vec<Str
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_crash_interrupted_plans(pool: &SqlitePool) -> DbResult<Vec<String>> {
     Ok(sqlx::query_scalar(
         "SELECT p.id FROM plans p \
@@ -813,7 +813,7 @@ pub struct UnreconciledItem {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_unreconciled_items(
     pool: &SqlitePool,
     plan_ids: &[String],
@@ -875,7 +875,7 @@ pub async fn list_unreconciled_items(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn record_reconciled_outcome(
     pool: &SqlitePool,
     item: &UnreconciledItem,

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -176,7 +176,7 @@ pub async fn cas_approved_to_applying(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn complete_run(
     pool: &SqlitePool,
     plan_id: &str,
@@ -234,7 +234,7 @@ pub async fn complete_run(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn pause_run(
     pool: &SqlitePool,
@@ -279,8 +279,8 @@ pub async fn pause_run(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::CasFailed`] if plan is not in `paused` state.
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::CasFailed`] if plan is not in `paused` state.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbResult<()> {
     let mut tx = pool.begin().await?;
 
@@ -327,7 +327,7 @@ pub async fn resume_run(pool: &SqlitePool, plan_id: &str, run_id: &str) -> DbRes
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn item_retry_applying(pool: &SqlitePool, item_id: &str, plan_id: &str) -> DbResult<()> {
     let mut tx = pool.begin().await?;
 
@@ -356,7 +356,7 @@ pub async fn item_retry_applying(pool: &SqlitePool, item_id: &str, plan_id: &str
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<String>> {
     let ids: Vec<String> = sqlx::query_scalar(
         "SELECT id FROM plan_items WHERE plan_id = ? AND item_state = 'pending' ORDER BY item_index ASC",
@@ -371,7 +371,7 @@ pub async fn list_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Ve
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn batch_cancel_pending_items(pool: &SqlitePool, plan_id: &str) -> DbResult<i64> {
     let mut tx = pool.begin().await?;
 
@@ -418,7 +418,7 @@ pub async fn batch_cancel_pending_items(pool: &SqlitePool, plan_id: &str) -> DbR
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn cancel_orphaned_applying_items(
     pool: &SqlitePool,
     plan_id: &str,
@@ -460,7 +460,7 @@ pub async fn cancel_orphaned_applying_items(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn append_event(
     pool: &SqlitePool,
@@ -515,7 +515,7 @@ pub async fn append_event(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn get_active_run(pool: &SqlitePool, plan_id: &str) -> DbResult<Option<PlanApplyRunRow>> {
     Ok(sqlx::query_as(
         "SELECT * FROM plan_apply_runs \
@@ -538,7 +538,7 @@ pub async fn get_active_run(pool: &SqlitePool, plan_id: &str) -> DbResult<Option
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn get_last_stale_item(
     pool: &SqlitePool,
     plan_id: &str,
@@ -560,7 +560,7 @@ pub async fn get_last_stale_item(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn get_last_item_with_failure_prefix(
     pool: &SqlitePool,
     plan_id: &str,
@@ -606,7 +606,7 @@ pub struct BatchItemState<'a> {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn batch_flush_item_states(
     conn: &mut SqliteConnection,
     plan_id: &str,
@@ -666,7 +666,7 @@ pub async fn batch_flush_item_states(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn append_event_conn(
     conn: &mut SqliteConnection,
@@ -728,7 +728,7 @@ pub async fn append_event_conn(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn sweep_crashed_applying_plans(pool: &SqlitePool) -> DbResult<Vec<String>> {
     let mut tx = pool.begin().await?;
 
@@ -769,7 +769,7 @@ pub async fn sweep_crashed_applying_plans(pool: &SqlitePool) -> DbResult<Vec<Str
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_crash_interrupted_plans(pool: &SqlitePool) -> DbResult<Vec<String>> {
     Ok(sqlx::query_scalar(
         "SELECT p.id FROM plans p \
@@ -813,7 +813,7 @@ pub struct UnreconciledItem {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_unreconciled_items(
     pool: &SqlitePool,
     plan_ids: &[String],
@@ -875,7 +875,7 @@ pub async fn list_unreconciled_items(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn record_reconciled_outcome(
     pool: &SqlitePool,
     item: &UnreconciledItem,

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -121,7 +121,7 @@ pub struct InsertPlanItem<'a> {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i64> {
     let mut conn = pool.acquire().await?;
     insert_plan_conn(&mut conn, plan).await
@@ -135,7 +135,7 @@ pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub(crate) async fn insert_plan_conn(
     conn: &mut SqliteConnection,
     plan: &InsertPlan<'_>,
@@ -173,7 +173,7 @@ pub(crate) async fn insert_plan_conn(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> DbResult<()> {
     let mut conn = pool.acquire().await?;
     insert_plan_item_conn(&mut conn, item).await
@@ -183,7 +183,7 @@ pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> D
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
+/// Returns [`persistence_core::DbError::Database`] on constraint or connection failure.
 pub(crate) async fn insert_plan_item_conn(
     conn: &mut SqliteConnection,
     item: &InsertPlanItem<'_>,
@@ -234,8 +234,8 @@ pub(crate) async fn insert_plan_item_conn(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::NotFound`] if no matching row exists.
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::NotFound`] if no matching row exists.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn get_plan(
     pool: &SqlitePool,
     plan_id: &str,
@@ -263,7 +263,7 @@ pub async fn get_plan(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_plans(
     pool: &SqlitePool,
     state_filter: &[String],
@@ -314,7 +314,7 @@ pub async fn list_plans(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<PlanItemRow>> {
     Ok(sqlx::query_as("SELECT * FROM plan_items WHERE plan_id = ? ORDER BY item_index ASC")
         .bind(plan_id)
@@ -335,7 +335,7 @@ pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<P
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) -> DbResult<u64> {
     let result = sqlx::query(
         "UPDATE plan_items SET destructive_confirmed = 1 \
@@ -356,8 +356,8 @@ pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) ->
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::NotFound`] if no plan with `plan_id` exists.
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::NotFound`] if no plan with `plan_id` exists.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn update_plan_state(pool: &SqlitePool, plan_id: &str, state: &str) -> DbResult<()> {
     let mut conn = pool.acquire().await?;
     update_plan_state_conn(&mut conn, plan_id, state).await
@@ -367,8 +367,8 @@ pub async fn update_plan_state(pool: &SqlitePool, plan_id: &str, state: &str) ->
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::NotFound`] if no plan with `plan_id` exists.
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::NotFound`] if no plan with `plan_id` exists.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub(crate) async fn update_plan_state_conn(
     conn: &mut SqliteConnection,
     plan_id: &str,
@@ -392,7 +392,7 @@ pub(crate) async fn update_plan_state_conn(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn set_approved(
     pool: &SqlitePool,
     plan_id: &str,
@@ -419,7 +419,7 @@ pub async fn set_approved(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn set_chosen_framing_id(
     pool: &SqlitePool,
     plan_id: &str,
@@ -437,7 +437,7 @@ pub async fn set_chosen_framing_id(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn get_chosen_framing_id(pool: &SqlitePool, plan_id: &str) -> DbResult<Option<String>> {
     let row: Option<(Option<String>,)> =
         sqlx::query_as("SELECT chosen_framing_id FROM plans WHERE id = ?")
@@ -453,8 +453,8 @@ pub async fn get_chosen_framing_id(pool: &SqlitePool, plan_id: &str) -> DbResult
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::NotFound`] if no matching plan exists.
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::NotFound`] if no matching plan exists.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn soft_delete_plan(
     pool: &SqlitePool,
     plan_id: &str,
@@ -476,7 +476,7 @@ pub async fn soft_delete_plan(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
 pub async fn update_item_fs_snapshot(
     pool: &SqlitePool,
     item_id: &str,

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -121,7 +121,7 @@ pub struct InsertPlanItem<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i64> {
     let mut conn = pool.acquire().await?;
     insert_plan_conn(&mut conn, plan).await
@@ -135,7 +135,7 @@ pub async fn insert_plan(pool: &SqlitePool, plan: &InsertPlan<'_>) -> DbResult<i
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub(crate) async fn insert_plan_conn(
     conn: &mut SqliteConnection,
     plan: &InsertPlan<'_>,
@@ -173,7 +173,7 @@ pub(crate) async fn insert_plan_conn(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> DbResult<()> {
     let mut conn = pool.acquire().await?;
     insert_plan_item_conn(&mut conn, item).await
@@ -183,7 +183,7 @@ pub async fn insert_plan_item(pool: &SqlitePool, item: &InsertPlanItem<'_>) -> D
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on constraint or connection failure.
 pub(crate) async fn insert_plan_item_conn(
     conn: &mut SqliteConnection,
     item: &InsertPlanItem<'_>,
@@ -234,8 +234,8 @@ pub(crate) async fn insert_plan_item_conn(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::NotFound`] if no matching row exists.
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::NotFound`] if no matching row exists.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn get_plan(
     pool: &SqlitePool,
     plan_id: &str,
@@ -263,7 +263,7 @@ pub async fn get_plan(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_plans(
     pool: &SqlitePool,
     state_filter: &[String],
@@ -314,7 +314,7 @@ pub async fn list_plans(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<PlanItemRow>> {
     Ok(sqlx::query_as("SELECT * FROM plan_items WHERE plan_id = ? ORDER BY item_index ASC")
         .bind(plan_id)
@@ -335,7 +335,7 @@ pub async fn list_plan_items(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<P
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) -> DbResult<u64> {
     let result = sqlx::query(
         "UPDATE plan_items SET destructive_confirmed = 1 \
@@ -356,8 +356,8 @@ pub async fn confirm_plan_destructive_items(pool: &SqlitePool, plan_id: &str) ->
 ///
 /// # Errors
 ///
-/// Returns [`DbError::NotFound`] if no plan with `plan_id` exists.
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::NotFound`] if no plan with `plan_id` exists.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn update_plan_state(pool: &SqlitePool, plan_id: &str, state: &str) -> DbResult<()> {
     let mut conn = pool.acquire().await?;
     update_plan_state_conn(&mut conn, plan_id, state).await
@@ -367,8 +367,8 @@ pub async fn update_plan_state(pool: &SqlitePool, plan_id: &str, state: &str) ->
 ///
 /// # Errors
 ///
-/// Returns [`DbError::NotFound`] if no plan with `plan_id` exists.
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::NotFound`] if no plan with `plan_id` exists.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub(crate) async fn update_plan_state_conn(
     conn: &mut SqliteConnection,
     plan_id: &str,
@@ -392,7 +392,7 @@ pub(crate) async fn update_plan_state_conn(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn set_approved(
     pool: &SqlitePool,
     plan_id: &str,
@@ -419,7 +419,7 @@ pub async fn set_approved(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn set_chosen_framing_id(
     pool: &SqlitePool,
     plan_id: &str,
@@ -437,7 +437,7 @@ pub async fn set_chosen_framing_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn get_chosen_framing_id(pool: &SqlitePool, plan_id: &str) -> DbResult<Option<String>> {
     let row: Option<(Option<String>,)> =
         sqlx::query_as("SELECT chosen_framing_id FROM plans WHERE id = ?")
@@ -453,8 +453,8 @@ pub async fn get_chosen_framing_id(pool: &SqlitePool, plan_id: &str) -> DbResult
 ///
 /// # Errors
 ///
-/// Returns [`DbError::NotFound`] if no matching plan exists.
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::NotFound`] if no matching plan exists.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn soft_delete_plan(
     pool: &SqlitePool,
     plan_id: &str,
@@ -476,7 +476,7 @@ pub async fn soft_delete_plan(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on connection failure.
+/// Returns [\ `persistence_core::DbError::Database`] on connection failure.
 pub async fn update_item_fs_snapshot(
     pool: &SqlitePool,
     item_id: &str,

--- a/crates/persistence/plans/src/repositories/prepared_source_views.rs
+++ b/crates/persistence/plans/src/repositories/prepared_source_views.rs
@@ -67,7 +67,7 @@ pub struct InsertPreparedSourceViewItem<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn insert_view(pool: &SqlitePool, data: &InsertPreparedSourceView<'_>) -> DbResult<()> {
     let now = Timestamp::now_iso();
     sqlx::query(
@@ -89,7 +89,7 @@ pub async fn insert_view(pool: &SqlitePool, data: &InsertPreparedSourceView<'_>)
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint or connection failure.
+/// Returns `persistence_core::DbError::Database` on constraint or connection failure.
 pub async fn insert_view_item(
     pool: &SqlitePool,
     item: &InsertPreparedSourceViewItem<'_>,
@@ -116,7 +116,7 @@ pub async fn insert_view_item(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] when the row does not exist.
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_view(pool: &SqlitePool, view_id: &str) -> DbResult<PreparedSourceViewRow> {
     sqlx::query_as::<_, PreparedSourceViewRow>(
         "SELECT id, project_id, kind, state, created_at, removed_at
@@ -133,7 +133,7 @@ pub async fn get_view(pool: &SqlitePool, view_id: &str) -> DbResult<PreparedSour
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_view_items(
     pool: &SqlitePool,
     view_id: &str,
@@ -155,7 +155,7 @@ pub async fn list_view_items(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_views_for_project(
     pool: &SqlitePool,
     project_id: &str,
@@ -176,7 +176,7 @@ pub async fn list_views_for_project(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_view_state(pool: &SqlitePool, view_id: &str, new_state: &str) -> DbResult<()> {
     sqlx::query("UPDATE prepared_source_views SET state = ? WHERE id = ?")
         .bind(new_state)
@@ -191,7 +191,7 @@ pub async fn update_view_state(pool: &SqlitePool, view_id: &str, new_state: &str
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_view_removed(pool: &SqlitePool, view_id: &str) -> DbResult<()> {
     let now = Timestamp::now_iso();
     sqlx::query(
@@ -211,7 +211,7 @@ pub async fn mark_view_removed(pool: &SqlitePool, view_id: &str) -> DbResult<()>
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_item_observed_state(
     pool: &SqlitePool,
     item_id: &str,

--- a/crates/persistence/plans/src/repositories/project_notes.rs
+++ b/crates/persistence/plans/src/repositories/project_notes.rs
@@ -37,7 +37,7 @@ pub struct ProjectNoteRow {
 /// Returns the new `updated_at` timestamp.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn upsert_note(
     pool: &SqlitePool,
     id: &str,
@@ -69,7 +69,7 @@ pub async fn upsert_note(
 /// saved; callers treat this as empty content).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_note(pool: &SqlitePool, project_id: &str) -> DbResult<Option<ProjectNoteRow>> {
     let row: Option<ProjectNoteRow> = sqlx::query_as(
         "\
@@ -89,7 +89,7 @@ pub async fn get_note(pool: &SqlitePool, project_id: &str) -> DbResult<Option<Pr
 /// Returns `None` when no note has been saved yet.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_note_content(pool: &SqlitePool, project_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> =
         sqlx::query_as("SELECT content FROM project_notes WHERE project_id = ?")

--- a/crates/persistence/plans/src/repositories/projects/channels.rs
+++ b/crates/persistence/plans/src/repositories/projects/channels.rs
@@ -14,7 +14,7 @@ use super::ProjectChannelRow;
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on transaction failure.
+/// Returns `persistence_core::DbError::Database` on transaction failure.
 pub async fn replace_project_channels(
     pool: &SqlitePool,
     project_id: &str,
@@ -49,7 +49,7 @@ pub async fn replace_project_channels(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_project_channels(
     pool: &SqlitePool,
     project_id: &str,

--- a/crates/persistence/plans/src/repositories/projects/create_tx.rs
+++ b/crates/persistence/plans/src/repositories/projects/create_tx.rs
@@ -47,7 +47,7 @@ pub struct CreateProjectInput<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on constraint violation or query
+/// Returns `persistence_core::DbError::Database` on constraint violation or query
 /// failure. On error the transaction is rolled back and no rows from this
 /// call persist.
 pub async fn create_project_tx(pool: &SqlitePool, input: &CreateProjectInput<'_>) -> DbResult<()> {

--- a/crates/persistence/plans/src/repositories/projects/crud.rs
+++ b/crates/persistence/plans/src/repositories/projects/crud.rs
@@ -16,7 +16,7 @@ use super::{InsertProject, ProjectRow, ProjectRowTuple};
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation or query failure.
+/// Returns `persistence_core::DbError::Database` on constraint violation or query failure.
 pub async fn insert_project(pool: &SqlitePool, data: &InsertProject<'_>) -> DbResult<String> {
     let mut conn = pool.acquire().await?;
     insert_project_conn(&mut conn, data).await
@@ -29,7 +29,7 @@ pub async fn insert_project(pool: &SqlitePool, data: &InsertProject<'_>) -> DbRe
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation or query failure.
+/// Returns `persistence_core::DbError::Database` on constraint violation or query failure.
 pub(super) async fn insert_project_conn(
     conn: &mut SqliteConnection,
     data: &InsertProject<'_>,
@@ -59,7 +59,7 @@ pub(super) async fn insert_project_conn(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] when no project with the given id exists.
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_project(pool: &SqlitePool, id: &str) -> DbResult<ProjectRow> {
     let row: Option<ProjectRowTuple> = sqlx::query_as(
         "SELECT id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at,
@@ -107,7 +107,7 @@ pub async fn get_project(pool: &SqlitePool, id: &str) -> DbResult<ProjectRow> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_project_canonical_target_id(
     pool: &SqlitePool,
     id: &str,
@@ -140,7 +140,7 @@ pub struct ProjectCanonicalTargetRow {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_project_canonical_target(
     pool: &SqlitePool,
     id: &str,
@@ -176,7 +176,7 @@ pub async fn get_project_canonical_target(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_project_canonical_target_id(
     pool: &SqlitePool,
     id: &str,
@@ -199,7 +199,7 @@ pub async fn set_project_canonical_target_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_projects(pool: &SqlitePool) -> DbResult<Vec<ProjectRow>> {
     let rows: Vec<ProjectRowTuple> = sqlx::query_as(
         "SELECT id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at,
@@ -251,7 +251,7 @@ pub async fn list_projects(pool: &SqlitePool) -> DbResult<Vec<ProjectRow>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_projects_by_canonical_target_id(
     pool: &SqlitePool,
     canonical_target_id: &str,
@@ -306,7 +306,7 @@ pub async fn list_projects_by_canonical_target_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn name_exists(
     pool: &SqlitePool,
     name: &str,
@@ -334,7 +334,7 @@ pub async fn name_exists(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn path_exists(
     pool: &SqlitePool,
     path: &str,
@@ -364,7 +364,7 @@ pub async fn path_exists(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_project_fields(
     pool: &SqlitePool,
     id: &str,
@@ -401,7 +401,7 @@ pub async fn update_project_fields(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_project_lifecycle(
     pool: &SqlitePool,
     id: &str,
@@ -457,7 +457,7 @@ pub enum ProjectAutoBlockOutcome {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on update, audit, or transaction failure.
+/// Returns `persistence_core::DbError::Database` on update, audit, or transaction failure.
 pub async fn apply_project_auto_block(
     pool: &SqlitePool,
     id: &str,
@@ -522,7 +522,7 @@ pub async fn apply_project_auto_block(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_project_lifecycle_unblock(
     pool: &SqlitePool,
     id: &str,
@@ -549,7 +549,7 @@ pub async fn update_project_lifecycle_unblock(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_archived_via_plan_id(
     pool: &SqlitePool,
     project_id: &str,
@@ -570,7 +570,7 @@ pub async fn set_archived_via_plan_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn clear_archived_via_plan_id(pool: &SqlitePool, project_id: &str) -> DbResult<()> {
     sqlx::query("UPDATE projects SET archived_via_plan_id = NULL WHERE id = ?")
         .bind(project_id)
@@ -605,7 +605,7 @@ type ArchivedProjectTuple =
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_archived_projects(pool: &SqlitePool) -> DbResult<Vec<ArchivedProjectRow>> {
     let rows: Vec<ArchivedProjectTuple> = sqlx::query_as(
         "SELECT p.id, p.name, p.path, p.updated_at, p.archived_via_plan_id, \
@@ -638,7 +638,7 @@ pub async fn list_archived_projects(pool: &SqlitePool) -> DbResult<Vec<ArchivedP
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_channel_drift(pool: &SqlitePool, id: &str, has_drift: bool) -> DbResult<()> {
     let now = Timestamp::now_iso();
     sqlx::query("UPDATE projects SET channel_drift = ?, updated_at = ? WHERE id = ?")

--- a/crates/persistence/plans/src/repositories/projects/mod.rs
+++ b/crates/persistence/plans/src/repositories/projects/mod.rs
@@ -10,9 +10,9 @@
 //! Constitution V: SQLite is the durable record; snapshot fields on
 //! `project_sources` denormalize Inventory data at link time.
 //!
-//! Split by responsibility (refactor sweep #977): [`crud`] is the `projects`
-//! table CRUD; [`sources`] is `project_sources` CRUD; [`channels`] is
-//! `project_channels` CRUD; [`create_tx`] is the composite atomic create
+//! Split by responsibility (refactor sweep #977): `crud` is the `projects`
+//! table CRUD; `sources` is `project_sources` CRUD; `channels` is
+//! `project_channels` CRUD; `create_tx` is the composite atomic create
 //! (T2-a) that writes all three tables plus the Constitution II folder plan
 //! in one transaction. Row/insert types shared across siblings stay here.
 

--- a/crates/persistence/plans/src/repositories/projects/sources.rs
+++ b/crates/persistence/plans/src/repositories/projects/sources.rs
@@ -23,7 +23,7 @@ fn source_missing_health_operation_id(root_id: &str) -> String {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_project_ids_for_session(
     pool: &SqlitePool,
     inventory_session_id: &str,
@@ -46,7 +46,7 @@ pub async fn list_project_ids_for_session(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_blockable_missing_sources(pool: &SqlitePool) -> DbResult<Vec<(String, String)>> {
     let rows: Vec<(String, String)> = sqlx::query_as(
         "SELECT DISTINCT ps.project_id, ps.inventory_session_id
@@ -71,7 +71,7 @@ pub async fn find_blockable_missing_sources(pool: &SqlitePool) -> DbResult<Vec<(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn begin_source_missing_health_check(pool: &SqlitePool, root_id: &str) -> DbResult<bool> {
     let result = sqlx::query(
         "INSERT INTO operation_states (id, operation_type, status, updated_at)
@@ -90,7 +90,7 @@ pub async fn begin_source_missing_health_check(pool: &SqlitePool, root_id: &str)
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn clear_source_missing_health_check(pool: &SqlitePool, root_id: &str) -> DbResult<()> {
     sqlx::query("DELETE FROM operation_states WHERE id = ? AND operation_type = ?")
         .bind(source_missing_health_operation_id(root_id))
@@ -115,7 +115,7 @@ pub async fn clear_source_missing_health_check(pool: &SqlitePool, root_id: &str)
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn has_archived_raw_frames_for_project(
     pool: &SqlitePool,
     project_id: &str,
@@ -145,7 +145,7 @@ pub async fn has_archived_raw_frames_for_project(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation or query failure.
+/// Returns `persistence_core::DbError::Database` on constraint violation or query failure.
 pub async fn insert_project_source(
     pool: &SqlitePool,
     data: &InsertProjectSource<'_>,
@@ -159,7 +159,7 @@ pub async fn insert_project_source(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violation or query failure.
+/// Returns `persistence_core::DbError::Database` on constraint violation or query failure.
 pub(super) async fn insert_project_source_conn(
     conn: &mut SqliteConnection,
     data: &InsertProjectSource<'_>,
@@ -189,7 +189,7 @@ pub(super) async fn insert_project_source_conn(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn delete_project_source(
     pool: &SqlitePool,
     project_id: &str,
@@ -209,7 +209,7 @@ pub async fn delete_project_source(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_project_sources(
     pool: &SqlitePool,
     project_id: &str,

--- a/crates/persistence/plans/src/repositories/q_projects.rs
+++ b/crates/persistence/plans/src/repositories/q_projects.rs
@@ -15,7 +15,7 @@ use persistence_core::DbResult;
 /// Returns `None` when no row exists.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_file_record_path_and_state(
     pool: &SqlitePool,
     id: &str,
@@ -42,7 +42,7 @@ pub struct AcquisitionSessionViewRow {
 /// exists (an unresolved project-linked source, spec 049 FR-019).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_acquisition_session_view(
     pool: &SqlitePool,
     session_id: &str,
@@ -61,7 +61,7 @@ pub async fn get_acquisition_session_view(
 /// type into a set).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_calibration_assignment_types(
     pool: &SqlitePool,
     session_id: &str,
@@ -80,7 +80,7 @@ pub async fn list_calibration_assignment_types(
 /// Returns `None` when no row exists.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_calibration_session_view(
     pool: &SqlitePool,
     master_id: &str,

--- a/crates/persistence/plans/src/repositories/source_protection.rs
+++ b/crates/persistence/plans/src/repositories/source_protection.rs
@@ -73,7 +73,7 @@ fn parse_categories(json: Option<&str>) -> DbResult<Vec<String>> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`]
+/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
 /// on JSON encoding failure.
 pub async fn upsert_source_protection(
     pool: &SqlitePool,
@@ -114,7 +114,7 @@ pub async fn upsert_source_protection(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_source_protection_row(
     pool: &SqlitePool,
     source_id: &str,
@@ -139,7 +139,7 @@ pub async fn get_source_protection_row(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`]
+/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
 /// on JSON decode failure.
 pub async fn resolve_protection(
     pool: &SqlitePool,
@@ -193,7 +193,7 @@ pub async fn resolve_protection(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_protection_default(
     pool: &SqlitePool,
     scope: &str,
@@ -213,7 +213,7 @@ pub async fn get_protection_default(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`]
+/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
 /// on JSON encoding failure.
 pub async fn set_protection_default(
     pool: &SqlitePool,
@@ -244,7 +244,7 @@ pub async fn set_protection_default(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`]
+/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
 /// on JSON encoding failure.
 pub async fn set_protection_default_with_conn(
     conn: &mut SqliteConnection,

--- a/crates/persistence/plans/src/repositories/source_protection.rs
+++ b/crates/persistence/plans/src/repositories/source_protection.rs
@@ -73,7 +73,7 @@ fn parse_categories(json: Option<&str>) -> DbResult<Vec<String>> {
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
+/// Returns [`persistence_core::DbError::Database`] on query failure or [`persistence_core::DbError::Serialise`]
 /// on JSON encoding failure.
 pub async fn upsert_source_protection(
     pool: &SqlitePool,
@@ -114,7 +114,7 @@ pub async fn upsert_source_protection(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_source_protection_row(
     pool: &SqlitePool,
     source_id: &str,
@@ -139,7 +139,7 @@ pub async fn get_source_protection_row(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
+/// Returns [`persistence_core::DbError::Database`] on query failure or [`persistence_core::DbError::Serialise`]
 /// on JSON decode failure.
 pub async fn resolve_protection(
     pool: &SqlitePool,
@@ -193,7 +193,7 @@ pub async fn resolve_protection(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_protection_default(
     pool: &SqlitePool,
     scope: &str,
@@ -213,7 +213,7 @@ pub async fn get_protection_default(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
+/// Returns [`persistence_core::DbError::Database`] on query failure or [`persistence_core::DbError::Serialise`]
 /// on JSON encoding failure.
 pub async fn set_protection_default(
     pool: &SqlitePool,
@@ -244,7 +244,7 @@ pub async fn set_protection_default(
 ///
 /// # Errors
 ///
-/// Returns [\ `persistence_core::DbError::Database`] on query failure or [\ `persistence_core::DbError::Serialise`]
+/// Returns [`persistence_core::DbError::Database`] on query failure or [`persistence_core::DbError::Serialise`]
 /// on JSON encoding failure.
 pub async fn set_protection_default_with_conn(
     conn: &mut SqliteConnection,

--- a/crates/persistence/plans/src/repositories/tool_launches.rs
+++ b/crates/persistence/plans/src/repositories/tool_launches.rs
@@ -51,7 +51,7 @@ pub struct InsertToolLaunch<'a> {
 /// Insert a new `tool_launches` row.  Returns the row `id`.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_tool_launch(
     pool: &SqlitePool,
     data: &InsertToolLaunch<'_>,
@@ -81,7 +81,7 @@ pub async fn insert_tool_launch(
 /// Used by the re-launch guard (spec 011 T012).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 /// Internal FromRow helper to avoid type-complexity lint on tuple results.
 #[derive(sqlx::FromRow)]
 struct ToolLaunchRawRow {
@@ -119,7 +119,7 @@ impl From<ToolLaunchRawRow> for ToolLaunchRow {
 /// Used by the re-launch guard (spec 011 T012).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_latest_launch(
     pool: &SqlitePool,
     project_id: &str,
@@ -143,7 +143,7 @@ pub async fn get_latest_launch(
 /// List all `tool_launches` rows for a project, newest first.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_launches_for_project(
     pool: &SqlitePool,
     project_id: &str,

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/availability.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/availability.rs
@@ -34,7 +34,7 @@ pub struct SourceAvailabilityRollupRow {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn upsert_source_availability(
     conn: &mut SqliteConnection,
     session_row_id: i64,
@@ -75,7 +75,7 @@ pub async fn upsert_source_availability(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_source_availability(
     pool: &SqlitePool,
     session_row_id: i64,
@@ -100,7 +100,7 @@ pub async fn get_source_availability(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_source_availability_for_sessions(
     pool: &SqlitePool,
     session_row_ids: &[i64],

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/families.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/families.rs
@@ -161,7 +161,7 @@ pub struct InsertFlatFamily<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_calibration_family(
     conn: &mut SqliteConnection,
     params: &InsertCalibrationFamily<'_>,
@@ -194,7 +194,7 @@ pub async fn insert_calibration_family(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_dark_recipe(
     conn: &mut SqliteConnection,
     params: &InsertDarkRecipe<'_>,
@@ -232,7 +232,7 @@ pub async fn insert_dark_recipe(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_bias_recipe(
     conn: &mut SqliteConnection,
     params: &InsertBiasRecipe<'_>,
@@ -266,7 +266,7 @@ pub async fn insert_bias_recipe(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_flat_family(
     conn: &mut SqliteConnection,
     params: &InsertFlatFamily<'_>,
@@ -306,7 +306,7 @@ pub async fn insert_flat_family(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no matching row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_family_by_public_id(
     pool: &SqlitePool,
     public_id: &str,
@@ -331,7 +331,7 @@ pub async fn get_family_by_public_id(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no matching row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_family_by_row_id(
     pool: &SqlitePool,
     row_id: i64,
@@ -423,7 +423,7 @@ pub async fn get_flat_family(pool: &SqlitePool, family_row_id: i64) -> DbResult<
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn find_dark_bias_family(
     pool: &SqlitePool,
     camera_row_id: i64,
@@ -454,7 +454,7 @@ pub async fn find_dark_bias_family(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn find_flat_family(
     pool: &SqlitePool,
     optical_profile_row_id: i64,

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/handoff.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/handoff.rs
@@ -236,7 +236,7 @@ pub struct InsertHandoffOperation<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff(
     conn: &mut SqliteConnection,
     params: &InsertHandoff<'_>,
@@ -260,7 +260,7 @@ pub async fn insert_handoff(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff_snapshot(
     conn: &mut SqliteConnection,
     params: &InsertHandoffSnapshot<'_>,
@@ -302,8 +302,8 @@ pub async fn insert_handoff_snapshot(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] when `expected_generation` does not match.
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` when `expected_generation` does not match.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn advance_handoff_head(
     conn: &mut SqliteConnection,
     handoff_row_id: i64,
@@ -334,7 +334,7 @@ pub async fn advance_handoff_head(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff_requirement(
     conn: &mut SqliteConnection,
     params: &InsertHandoffRequirement<'_>,
@@ -362,7 +362,7 @@ pub async fn insert_handoff_requirement(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_snapshot_requirement_mapping(
     conn: &mut SqliteConnection,
     snapshot_row_id: i64,
@@ -389,7 +389,7 @@ pub async fn insert_snapshot_requirement_mapping(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff_candidate_evidence(
     conn: &mut SqliteConnection,
     params: &InsertHandoffCandidateEvidence<'_>,
@@ -443,7 +443,7 @@ pub async fn insert_handoff_candidate_evidence(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff_selection(
     conn: &mut SqliteConnection,
     params: &InsertHandoffSelection<'_>,
@@ -471,7 +471,7 @@ pub async fn insert_handoff_selection(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_snapshot_selection_mapping(
     conn: &mut SqliteConnection,
     snapshot_row_id: i64,
@@ -497,7 +497,7 @@ pub async fn insert_snapshot_selection_mapping(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff_frame(
     conn: &mut SqliteConnection,
     params: &InsertHandoffFrame<'_>,
@@ -530,7 +530,7 @@ pub async fn insert_handoff_frame(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_handoff_operation(
     conn: &mut SqliteConnection,
     params: &InsertHandoffOperation<'_>,
@@ -559,7 +559,7 @@ pub async fn insert_handoff_operation(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] when `expected_state_version` does not match.
+/// Returns `persistence_core::DbError::CasFailed` when `expected_state_version` does not match.
 pub async fn transition_handoff_operation_state(
     conn: &mut SqliteConnection,
     operation_row_id: i64,
@@ -600,7 +600,7 @@ pub async fn transition_handoff_operation_state(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn update_handoff_operation_progress(
     conn: &mut SqliteConnection,
     operation_row_id: i64,
@@ -691,7 +691,7 @@ pub async fn get_operation_by_public_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_snapshot_requirements(
     pool: &SqlitePool,
     snapshot_row_id: i64,
@@ -716,7 +716,7 @@ pub async fn list_snapshot_requirements(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_snapshot_selections(
     pool: &SqlitePool,
     snapshot_row_id: i64,
@@ -742,7 +742,7 @@ pub async fn list_snapshot_selections(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_selection_frames(
     pool: &SqlitePool,
     selection_row_id: i64,

--- a/crates/persistence/sessions/src/repositories/calibration_sessions/sessions.rs
+++ b/crates/persistence/sessions/src/repositories/calibration_sessions/sessions.rs
@@ -88,7 +88,7 @@ pub struct InsertDarkThermalEvidence<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_calibration_session(
     conn: &mut SqliteConnection,
     params: &InsertCalibrationSession<'_>,
@@ -125,7 +125,7 @@ pub async fn insert_calibration_session(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_dark_thermal_evidence(
     conn: &mut SqliteConnection,
     params: &InsertDarkThermalEvidence<'_>,
@@ -163,9 +163,9 @@ pub async fn insert_dark_thermal_evidence(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] when the row was already assigned or the
+/// Returns `persistence_core::DbError::CasFailed` when the row was already assigned or the
 /// expected prior state does not match.
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn assign_calibration_session_to_family(
     conn: &mut SqliteConnection,
     session_row_id: i64,
@@ -200,7 +200,7 @@ pub async fn assign_calibration_session_to_family(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no matching row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_calibration_session(
     pool: &SqlitePool,
     session_row_id: i64,
@@ -261,7 +261,7 @@ pub async fn get_calibration_session_by_public_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_calibration_sessions_by_family(
     pool: &SqlitePool,
     family_row_id: i64,

--- a/crates/persistence/sessions/src/repositories/equipment_resolution.rs
+++ b/crates/persistence/sessions/src/repositories/equipment_resolution.rs
@@ -68,7 +68,7 @@ pub struct InsertEquipmentResolution<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_equipment_resolution(
     conn: &mut SqliteConnection,
     params: &InsertEquipmentResolution<'_>,
@@ -114,7 +114,7 @@ pub async fn insert_equipment_resolution(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_equipment_resolution_head(
     conn: &mut SqliteConnection,
     session_row_id: i64,
@@ -135,13 +135,13 @@ pub async fn insert_equipment_resolution_head(
 /// Advance the equipment resolution head using CAS.
 ///
 /// Returns `Ok(())` when exactly one row was updated. Returns
-/// [`DbError::CasFailed`] when the current generation or head revision does not
+/// `persistence_core::DbError::CasFailed` when the current generation or head revision does not
 /// match the expected values (indicating a concurrent update).
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on optimistic-lock failure, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` on optimistic-lock failure, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn advance_equipment_resolution_head(
     conn: &mut SqliteConnection,
     session_row_id: i64,
@@ -176,7 +176,7 @@ pub async fn advance_equipment_resolution_head(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no head row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_equipment_resolution_head(
     pool: &SqlitePool,
     session_row_id: i64,
@@ -201,7 +201,7 @@ pub async fn get_equipment_resolution_head(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no head or revision exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_accepted_equipment_resolution(
     pool: &SqlitePool,
     session_row_id: i64,

--- a/crates/persistence/sessions/src/repositories/materialization.rs
+++ b/crates/persistence/sessions/src/repositories/materialization.rs
@@ -77,7 +77,7 @@ pub struct InsertMaterializationResultSnapshot<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_materialization_operation(
     conn: &mut SqliteConnection,
     params: &InsertMaterializationOperation<'_>,
@@ -104,8 +104,8 @@ pub async fn insert_materialization_operation(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on version mismatch, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` on version mismatch, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn transition_operation_to_applying(
     conn: &mut SqliteConnection,
     operation_row_id: i64,
@@ -153,8 +153,8 @@ pub struct ApplyOperationResult<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on version mismatch, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` on version mismatch, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn transition_operation_to_applied(
     conn: &mut SqliteConnection,
     params: &ApplyOperationResult<'_>,
@@ -196,8 +196,8 @@ pub async fn transition_operation_to_applied(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on version mismatch, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` on version mismatch, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn transition_operation_to_failed(
     conn: &mut SqliteConnection,
     operation_row_id: i64,
@@ -236,7 +236,7 @@ pub async fn transition_operation_to_failed(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_result_snapshot(
     conn: &mut SqliteConnection,
     params: &InsertMaterializationResultSnapshot<'_>,
@@ -268,7 +268,7 @@ pub async fn insert_result_snapshot(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no matching row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_operation_by_public_id(
     pool: &SqlitePool,
     public_id: &str,
@@ -292,7 +292,7 @@ pub async fn get_operation_by_public_id(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no snapshot exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_result_snapshot_by_operation_public_id(
     pool: &SqlitePool,
     operation_public_id: &str,
@@ -319,8 +319,8 @@ pub async fn get_result_snapshot_by_operation_public_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on version mismatch, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` on version mismatch, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn transition_operation_to_cancelled(
     conn: &mut SqliteConnection,
     operation_row_id: i64,
@@ -352,7 +352,7 @@ pub async fn transition_operation_to_cancelled(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no matching row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_operation_public_id_by_row_id(pool: &SqlitePool, row_id: i64) -> DbResult<String> {
     let row: (String,) =
         sqlx::query_as("SELECT public_id FROM session_materialization_operation WHERE row_id = ?")

--- a/crates/persistence/sessions/src/repositories/metadata_resolution.rs
+++ b/crates/persistence/sessions/src/repositories/metadata_resolution.rs
@@ -70,7 +70,7 @@ pub struct InsertMetadataResolutionFrame {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_metadata_resolution(
     conn: &mut SqliteConnection,
     params: &InsertMetadataResolution<'_>,
@@ -103,7 +103,7 @@ pub async fn insert_metadata_resolution(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_metadata_resolution_frame(
     conn: &mut SqliteConnection,
     params: &InsertMetadataResolutionFrame,
@@ -126,7 +126,7 @@ pub async fn insert_metadata_resolution_frame(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_metadata_resolution_head(
     conn: &mut SqliteConnection,
     session_row_id: i64,
@@ -146,13 +146,13 @@ pub async fn insert_metadata_resolution_head(
 
 /// Advance the metadata resolution head using CAS.
 ///
-/// Returns [`DbError::CasFailed`] when the current generation or head revision
+/// Returns `persistence_core::DbError::CasFailed` when the current generation or head revision
 /// does not match the expected values.
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] on optimistic-lock failure, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` on optimistic-lock failure, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn advance_metadata_resolution_head(
     conn: &mut SqliteConnection,
     session_row_id: i64,
@@ -187,7 +187,7 @@ pub async fn advance_metadata_resolution_head(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no head row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_metadata_resolution_head(
     pool: &SqlitePool,
     session_row_id: i64,
@@ -210,7 +210,7 @@ pub async fn get_metadata_resolution_head(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no head or revision exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_accepted_metadata_resolution(
     pool: &SqlitePool,
     session_row_id: i64,
@@ -235,7 +235,7 @@ pub async fn get_accepted_metadata_resolution(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_metadata_resolution_frames(
     pool: &SqlitePool,
     resolution_row_id: i64,

--- a/crates/persistence/sessions/src/repositories/sessions.rs
+++ b/crates/persistence/sessions/src/repositories/sessions.rs
@@ -135,7 +135,7 @@ pub struct SessionListCursor {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_session(
     conn: &mut SqliteConnection,
     params: &InsertSession<'_>,
@@ -169,7 +169,7 @@ pub async fn insert_session(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations.
+/// Returns `persistence_core::DbError::Database` on constraint violations.
 pub async fn insert_session_frame(
     conn: &mut SqliteConnection,
     params: &InsertSessionFrame<'_>,
@@ -198,7 +198,7 @@ pub async fn insert_session_frame(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations.
+/// Returns `persistence_core::DbError::Database` on constraint violations.
 pub async fn insert_light_session_identity(
     conn: &mut SqliteConnection,
     params: &InsertLightSessionIdentity<'_>,
@@ -244,7 +244,7 @@ pub async fn insert_light_session_identity(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if no matching row exists, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn get_session_by_public_id(pool: &SqlitePool, public_id: &str) -> DbResult<SessionRow> {
     sqlx::query_as::<_, SessionRow>(
         "SELECT row_id, public_id, materialization_operation_row_id, kind,
@@ -266,7 +266,7 @@ pub async fn get_session_by_public_id(pool: &SqlitePool, public_id: &str) -> DbR
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn current_change_sequence(pool: &SqlitePool) -> DbResult<i64> {
     let seq: (i64,) = sqlx::query_as("SELECT COALESCE(MAX(sequence), 0) FROM repository_change")
         .fetch_one(pool)
@@ -286,7 +286,7 @@ pub async fn current_change_sequence(pool: &SqlitePool) -> DbResult<i64> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 #[allow(clippy::too_many_arguments)]
 pub async fn list_sessions_at_watermark(
     pool: &SqlitePool,
@@ -366,7 +366,7 @@ pub async fn list_sessions_at_watermark(
 /// # Errors
 ///
 /// Returns [`DbError::NotFound`] if the session `public_id` does not exist, or
-/// [`DbError::Database`] on SQL errors.
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_session_frames(
     pool: &SqlitePool,
     session_public_id: &str,
@@ -392,7 +392,7 @@ pub async fn list_session_frames(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_session_visibility(
     conn: &mut SqliteConnection,
     session_row_id: i64,

--- a/crates/persistence/sessions/src/repositories/supersession.rs
+++ b/crates/persistence/sessions/src/repositories/supersession.rs
@@ -44,7 +44,7 @@ pub struct InsertSupersession<'a> {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on constraint violations or SQL errors.
+/// Returns `persistence_core::DbError::Database` on constraint violations or SQL errors.
 pub async fn insert_supersession(
     conn: &mut SqliteConnection,
     params: &InsertSupersession<'_>,
@@ -71,7 +71,7 @@ pub async fn insert_supersession(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_supersession_successors(
     pool: &SqlitePool,
     predecessor_session_row_id: i64,
@@ -93,7 +93,7 @@ pub async fn list_supersession_successors(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn list_supersession_predecessors(
     pool: &SqlitePool,
     replacement_session_row_id: i64,
@@ -117,7 +117,7 @@ pub async fn list_supersession_predecessors(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::Database` on SQL errors.
 pub async fn is_session_current(pool: &SqlitePool, session_row_id: i64) -> DbResult<bool> {
     let count: (i64,) = sqlx::query_as(
         "SELECT COUNT(*) FROM session_supersession
@@ -138,8 +138,8 @@ pub async fn is_session_current(pool: &SqlitePool, session_row_id: i64) -> DbRes
 ///
 /// # Errors
 ///
-/// Returns [`DbError::CasFailed`] when a cycle is detected, or
-/// [`DbError::Database`] on SQL errors.
+/// Returns `persistence_core::DbError::CasFailed` when a cycle is detected, or
+/// `persistence_core::DbError::Database` on SQL errors.
 pub async fn assert_no_supersession_cycle(
     conn: &mut SqliteConnection,
     predecessor_row_id: i64,

--- a/crates/persistence/targets/src/repositories/framing.rs
+++ b/crates/persistence/targets/src/repositories/framing.rs
@@ -72,7 +72,7 @@ pub struct InsertFraming<'a> {
 /// Insert a new framing row. Returns the `created_at`/`updated_at` timestamp.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint violation (e.g. unknown
+/// Returns `persistence_core::DbError::Database` on constraint violation (e.g. unknown
 /// `project_id`/`target_id`) or query failure.
 pub async fn insert_framing(pool: &SqlitePool, data: &InsertFraming<'_>) -> DbResult<String> {
     let now = Timestamp::now_iso();
@@ -105,7 +105,7 @@ pub async fn insert_framing(pool: &SqlitePool, data: &InsertFraming<'_>) -> DbRe
 ///
 /// # Errors
 /// Returns [`DbError::NotFound`] when no framing with the given id exists.
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_framing(pool: &SqlitePool, id: &str) -> DbResult<FramingRow> {
     sqlx::query_as::<_, FramingRow>(
         "SELECT id, project_id, target_id, optic_train_key,
@@ -123,7 +123,7 @@ pub async fn get_framing(pool: &SqlitePool, id: &str) -> DbResult<FramingRow> {
 /// List all framings for a project (creation order).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_framings_by_project(
     pool: &SqlitePool,
     project_id: &str,
@@ -147,7 +147,7 @@ pub async fn list_framings_by_project(
 /// target/mosaic checks in Rust — this is the coarse, cheap SQL-level cut.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_framings_by_optic_train_key(
     pool: &SqlitePool,
     optic_train_key: &str,
@@ -172,7 +172,7 @@ pub async fn list_framings_by_optic_train_key(
 /// framing back. Returns the new `updated_at` timestamp.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn update_framing_clustering(
     pool: &SqlitePool,
     id: &str,
@@ -194,7 +194,7 @@ pub async fn update_framing_clustering(
 /// survivor. No-op (not an error) when the id does not exist.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn delete_framing(pool: &SqlitePool, id: &str) -> DbResult<()> {
     sqlx::query("DELETE FROM framing WHERE id = ?").bind(id).execute(pool).await?;
     Ok(())
@@ -209,7 +209,7 @@ pub async fn delete_framing(pool: &SqlitePool, id: &str) -> DbResult<()> {
 /// prior membership before reassigning (F-Framing-3's `framing.reassign`).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on constraint violation (unknown ids, or the
+/// Returns `persistence_core::DbError::Database` on constraint violation (unknown ids, or the
 /// session is already a member of a framing) or query failure.
 pub async fn add_session_to_framing(
     pool: &SqlitePool,
@@ -230,7 +230,7 @@ pub async fn add_session_to_framing(
 /// when the pair does not exist.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn remove_session_from_framing(
     pool: &SqlitePool,
     framing_id: &str,
@@ -247,7 +247,7 @@ pub async fn remove_session_from_framing(
 /// List the member session ids of a framing, in the order they were added.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_session_ids_for_framing(
     pool: &SqlitePool,
     framing_id: &str,
@@ -265,7 +265,7 @@ pub async fn list_session_ids_for_framing(
 /// `framing_session.session_id` UNIQUE constraint).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_framing_id_for_session(
     pool: &SqlitePool,
     session_id: &str,
@@ -287,7 +287,7 @@ pub async fn get_framing_id_for_session(
 /// four fields `None`).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_session_geometry(
     pool: &SqlitePool,
     session_id: &str,
@@ -308,7 +308,7 @@ pub async fn get_session_geometry(
 /// sentinel for missing header data (Q16 FR-136 — "missing is missing").
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_session_geometry(
     pool: &SqlitePool,
     session_id: &str,

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -77,7 +77,7 @@ pub struct InventoryFilters {
 /// List all `LibraryRoot` rows that have at least one session under them.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn list_roots_with_sessions(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> {
     let rows = sqlx::query_as::<_, LibraryRootRow>(
         r"
@@ -103,7 +103,7 @@ pub async fn list_roots_with_sessions(pool: &SqlitePool) -> DbResult<Vec<Library
 /// Used by spec 011 cwd-containment check (R-CwdContain, FR-010).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn list_all_roots(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> {
     let rows = sqlx::query_as::<_, LibraryRootRow>(
         "SELECT id, current_path, kind, state FROM library_root ORDER BY current_path ASC",
@@ -129,7 +129,7 @@ pub async fn list_all_roots(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> 
 /// (spec 036, T007); the gen-3 `canonical_target` is the live store.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn list_sessions_for_root(
     pool: &SqlitePool,
     root_id: &str,
@@ -316,7 +316,7 @@ pub struct SessionContextRow {
 /// returned `Vec` — callers treat a missing id as "no context available".
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_session_context_by_ids(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -380,7 +380,7 @@ pub struct SessionCameraRow {
 /// Sessions whose frames resolve no metadata row are simply absent.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn list_session_cameras(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -437,7 +437,7 @@ pub async fn list_session_cameras(
 /// `session_id` matches neither (caller maps that to `session.not_found`).
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn set_session_notes(
     pool: &SqlitePool,
     session_id: &str,
@@ -483,7 +483,7 @@ pub struct SessionCalibrationLinkRow {
 /// input simply produce no rows.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn list_calibration_matches_for_sessions(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -514,7 +514,7 @@ pub async fn list_calibration_matches_for_sessions(
 /// Returns `Some(path_string)` when found, `None` when not found.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_library_root_path(pool: &SqlitePool, root_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> =
         sqlx::query_as("SELECT current_path FROM library_root WHERE id = ?")
@@ -529,7 +529,7 @@ pub async fn get_library_root_path(pool: &SqlitePool, root_id: &str) -> DbResult
 /// Returns `Some(state)` when found, `None` when not found.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_library_root_state(pool: &SqlitePool, root_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> = sqlx::query_as("SELECT state FROM library_root WHERE id = ?")
         .bind(root_id)
@@ -551,7 +551,7 @@ pub struct FileRecordLookupRow {
 /// read-only source-resolution step). Returns `None` when no row exists.
 ///
 /// # Errors
-/// Returns [`DbError::Database`] on query failure.
+/// Returns [\ `persistence_core::DbError::Database`] on query failure.
 pub async fn get_file_record_lookup(
     pool: &SqlitePool,
     file_record_id: &str,

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -77,7 +77,7 @@ pub struct InventoryFilters {
 /// List all `LibraryRoot` rows that have at least one session under them.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_roots_with_sessions(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> {
     let rows = sqlx::query_as::<_, LibraryRootRow>(
         r"
@@ -103,7 +103,7 @@ pub async fn list_roots_with_sessions(pool: &SqlitePool) -> DbResult<Vec<Library
 /// Used by spec 011 cwd-containment check (R-CwdContain, FR-010).
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_all_roots(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> {
     let rows = sqlx::query_as::<_, LibraryRootRow>(
         "SELECT id, current_path, kind, state FROM library_root ORDER BY current_path ASC",
@@ -129,7 +129,7 @@ pub async fn list_all_roots(pool: &SqlitePool) -> DbResult<Vec<LibraryRootRow>> 
 /// (spec 036, T007); the gen-3 `canonical_target` is the live store.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_sessions_for_root(
     pool: &SqlitePool,
     root_id: &str,
@@ -251,7 +251,7 @@ struct ProjectSourcesRow {
 /// expected cardinality (a few hundred sessions per root at most).
 ///
 /// # Errors
-/// Returns [`crate::DbResult`] on query failure.
+/// Returns [`DbResult`] on query failure.
 pub async fn list_project_links_for_sessions(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -316,7 +316,7 @@ pub struct SessionContextRow {
 /// returned `Vec` — callers treat a missing id as "no context available".
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_session_context_by_ids(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -380,7 +380,7 @@ pub struct SessionCameraRow {
 /// Sessions whose frames resolve no metadata row are simply absent.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_session_cameras(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -437,7 +437,7 @@ pub async fn list_session_cameras(
 /// `session_id` matches neither (caller maps that to `session.not_found`).
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn set_session_notes(
     pool: &SqlitePool,
     session_id: &str,
@@ -483,7 +483,7 @@ pub struct SessionCalibrationLinkRow {
 /// input simply produce no rows.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn list_calibration_matches_for_sessions(
     pool: &SqlitePool,
     session_ids: &[String],
@@ -514,7 +514,7 @@ pub async fn list_calibration_matches_for_sessions(
 /// Returns `Some(path_string)` when found, `None` when not found.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_library_root_path(pool: &SqlitePool, root_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> =
         sqlx::query_as("SELECT current_path FROM library_root WHERE id = ?")
@@ -529,7 +529,7 @@ pub async fn get_library_root_path(pool: &SqlitePool, root_id: &str) -> DbResult
 /// Returns `Some(state)` when found, `None` when not found.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_library_root_state(pool: &SqlitePool, root_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> = sqlx::query_as("SELECT state FROM library_root WHERE id = ?")
         .bind(root_id)
@@ -551,7 +551,7 @@ pub struct FileRecordLookupRow {
 /// read-only source-resolution step). Returns `None` when no row exists.
 ///
 /// # Errors
-/// Returns [\ `persistence_core::DbError::Database`] on query failure.
+/// Returns [`persistence_core::DbError::Database`] on query failure.
 pub async fn get_file_record_lookup(
     pool: &SqlitePool,
     file_record_id: &str,

--- a/crates/persistence/targets/src/repositories/q_desktop.rs
+++ b/crates/persistence/targets/src/repositories/q_desktop.rs
@@ -21,7 +21,7 @@ use persistence_core::DbResult;
 /// (auto-commit) or `&mut Transaction` (batched commit).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_inbox_master_item<'e, E>(
     executor: E,
@@ -80,7 +80,7 @@ pub struct InboxMasterItemRow {
 /// transaction that wrote the row.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_inbox_master_item_row<'e, E>(
     executor: E,
     root_id: &str,
@@ -117,7 +117,7 @@ where
 /// suppression on either side (FR-026, SC-007).
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_unacknowledged_inbox_items(pool: &SqlitePool) -> DbResult<i64> {
     let count: i64 = sqlx::query_scalar(
         "SELECT COUNT(*) FROM inbox_items i
@@ -132,7 +132,7 @@ pub async fn count_unacknowledged_inbox_items(pool: &SqlitePool) -> DbResult<i64
 /// Count all `acquisition_session` rows.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_acquisition_sessions(pool: &SqlitePool) -> DbResult<i64> {
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM acquisition_session").fetch_one(pool).await?;
@@ -142,7 +142,7 @@ pub async fn count_acquisition_sessions(pool: &SqlitePool) -> DbResult<i64> {
 /// Count all rows in the `calibration_master_view` projection.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_calibration_masters(pool: &SqlitePool) -> DbResult<i64> {
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM calibration_master_view").fetch_one(pool).await?;
@@ -155,7 +155,7 @@ pub use super::q_resolver::count_canonical_targets;
 /// Count all `projects` rows.
 ///
 /// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_projects(pool: &SqlitePool) -> DbResult<i64> {
     let count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM projects").fetch_one(pool).await?;
     Ok(count)

--- a/crates/persistence/targets/src/repositories/q_resolver.rs
+++ b/crates/persistence/targets/src/repositories/q_resolver.rs
@@ -86,7 +86,7 @@ pub struct ExistingTargetRow {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn select_canonical_target_by_id(
     pool: &SqlitePool,
     id: &str,
@@ -105,7 +105,7 @@ pub async fn select_canonical_target_by_id(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn select_canonical_target_by_simbad_oid(
     pool: &SqlitePool,
     simbad_oid: i64,
@@ -124,7 +124,7 @@ pub async fn select_canonical_target_by_simbad_oid(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn select_target_id_by_normalized_alias(
     pool: &SqlitePool,
     normalized: &str,
@@ -141,7 +141,7 @@ pub async fn select_target_id_by_normalized_alias(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn select_aliases_for_target(
     pool: &SqlitePool,
     target_id: &str,
@@ -164,7 +164,7 @@ pub async fn select_aliases_for_target(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_canonical_targets(pool: &SqlitePool) -> DbResult<Vec<TargetListQueryRow>> {
     let rows = sqlx::query_as::<_, TargetListQueryRow>(
         "SELECT id, primary_designation, display_alias, object_type,
@@ -182,7 +182,7 @@ pub async fn list_canonical_targets(pool: &SqlitePool) -> DbResult<Vec<TargetLis
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_all_target_aliases(pool: &SqlitePool) -> DbResult<Vec<TargetAliasPairRow>> {
     let rows = sqlx::query_as::<_, TargetAliasPairRow>(
         "SELECT target_id, alias
@@ -199,7 +199,7 @@ pub async fn list_all_target_aliases(pool: &SqlitePool) -> DbResult<Vec<TargetAl
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_canonical_targets(pool: &SqlitePool) -> DbResult<i64> {
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM canonical_target").fetch_one(pool).await?;
@@ -214,7 +214,7 @@ pub async fn count_canonical_targets(pool: &SqlitePool) -> DbResult<i64> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_user_alias(
     pool: &SqlitePool,
     alias_id: &str,
@@ -240,7 +240,7 @@ pub async fn insert_user_alias(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn select_alias_id_by_target_and_normalized(
     pool: &SqlitePool,
     target_id: &str,
@@ -260,7 +260,7 @@ pub async fn select_alias_id_by_target_and_normalized(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn delete_user_alias(pool: &SqlitePool, alias_id: &str) -> DbResult<bool> {
     let result = sqlx::query("DELETE FROM target_alias WHERE id = ? AND kind = 'user'")
         .bind(alias_id)
@@ -274,7 +274,7 @@ pub async fn delete_user_alias(pool: &SqlitePool, alias_id: &str) -> DbResult<bo
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_display_alias(
     pool: &SqlitePool,
     target_id: &str,
@@ -293,7 +293,7 @@ pub async fn set_display_alias(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn clear_display_alias(pool: &SqlitePool, target_id: &str) -> DbResult<bool> {
     let result = sqlx::query("UPDATE canonical_target SET display_alias = NULL WHERE id = ?")
         .bind(target_id)
@@ -312,7 +312,7 @@ pub async fn clear_display_alias(pool: &SqlitePool, target_id: &str) -> DbResult
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_existing_by_simbad_oid_conn(
     conn: &mut SqliteConnection,
     simbad_oid: i64,
@@ -331,7 +331,7 @@ pub async fn find_existing_by_simbad_oid_conn(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_existing_by_id_conn(
     conn: &mut SqliteConnection,
     id: &str,
@@ -353,7 +353,7 @@ pub async fn find_existing_by_id_conn(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn update_canonical_target_conn(
     conn: &mut SqliteConnection,
@@ -402,7 +402,7 @@ pub async fn update_canonical_target_conn(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_canonical_target_conn(
     conn: &mut SqliteConnection,
@@ -442,7 +442,7 @@ pub async fn insert_canonical_target_conn(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn delete_aliases_for_target_conn(
     conn: &mut SqliteConnection,
     target_id: &str,
@@ -460,7 +460,7 @@ pub async fn delete_aliases_for_target_conn(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_alias_conn(
     conn: &mut SqliteConnection,
     alias_id: &str,

--- a/crates/persistence/targets/src/repositories/q_targets_ingest.rs
+++ b/crates/persistence/targets/src/repositories/q_targets_ingest.rs
@@ -18,7 +18,7 @@
 //! to linked projects) stays in `app_core_targets`; this module is query/exec
 //! only. `library_root`/`registered_sources` root-path lookups reuse
 //! [`crate::repositories::inventory::get_library_root_path`] and
-//! [`crate::repositories::first_run::get_source_path`] rather than
+//! `crate::repositories::first_run::get_source_path` rather than
 //! duplicating them.
 //!
 //! Constitution §I: read/write SQLite metadata only; no filesystem mutations.
@@ -87,7 +87,7 @@ pub struct UnlinkedAcquisitionSessionRow {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn upsert_file_record(
     pool: &SqlitePool,
     root_id: &str,
@@ -146,7 +146,7 @@ pub async fn upsert_file_record(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_ingest_resolution_id(
     pool: &SqlitePool,
     image_id: &str,
@@ -169,7 +169,7 @@ pub async fn find_ingest_resolution_id(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_ingest_resolution(
     pool: &SqlitePool,
     id: &str,
@@ -196,7 +196,7 @@ pub async fn insert_ingest_resolution(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_ingest_resolution_resolved(
     pool: &SqlitePool,
     row_id: &str,
@@ -214,7 +214,7 @@ pub async fn mark_ingest_resolution_resolved(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn mark_ingest_resolution_unresolved(
     pool: &SqlitePool,
     row_id: &str,
@@ -233,7 +233,7 @@ pub async fn mark_ingest_resolution_unresolved(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_pending_ingest_resolutions(
     pool: &SqlitePool,
     limit: i64,
@@ -256,7 +256,7 @@ pub async fn list_pending_ingest_resolutions(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_resolved_ingest_resolutions(
     pool: &SqlitePool,
 ) -> DbResult<Vec<ResolvedIngestResolutionRow>> {
@@ -278,7 +278,7 @@ pub async fn list_resolved_ingest_resolutions(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_applied_light_plan_items(
     pool: &SqlitePool,
     plan_id: &str,
@@ -305,7 +305,7 @@ pub async fn list_applied_light_plan_items(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn insert_library_root_mirror(
     pool: &SqlitePool,
     root_id: &str,
@@ -332,7 +332,7 @@ pub async fn insert_library_root_mirror(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn find_acquisition_session_by_key(
     pool: &SqlitePool,
     key: &str,
@@ -352,7 +352,7 @@ pub async fn find_acquisition_session_by_key(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn append_acquisition_session_frames_with_target(
     pool: &SqlitePool,
     id: &str,
@@ -380,7 +380,7 @@ pub async fn append_acquisition_session_frames_with_target(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn append_acquisition_session_frames(
     pool: &SqlitePool,
     id: &str,
@@ -404,7 +404,7 @@ pub async fn append_acquisition_session_frames(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 #[allow(clippy::too_many_arguments)]
 pub async fn insert_acquisition_session(
     pool: &SqlitePool,
@@ -439,7 +439,7 @@ pub async fn insert_acquisition_session(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_unlinked_acquisition_sessions(
     pool: &SqlitePool,
 ) -> DbResult<Vec<UnlinkedAcquisitionSessionRow>> {
@@ -456,7 +456,7 @@ pub async fn list_unlinked_acquisition_sessions(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_acquisition_session_canonical_target_if_null(
     pool: &SqlitePool,
     session_id: &str,

--- a/crates/persistence/targets/src/repositories/q_targets_mgmt.rs
+++ b/crates/persistence/targets/src/repositories/q_targets_mgmt.rs
@@ -54,7 +54,7 @@ pub struct TargetAliasRow {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_resolver_settings(pool: &SqlitePool) -> DbResult<Option<ResolverSettingsRow>> {
     let row = sqlx::query_as::<_, ResolverSettingsRow>(
         "SELECT online_enabled, simbad_endpoint, debounce_ms, request_timeout_secs
@@ -71,7 +71,7 @@ pub async fn get_resolver_settings(pool: &SqlitePool) -> DbResult<Option<Resolve
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_resolver_settings_online(
     pool: &SqlitePool,
 ) -> DbResult<Option<ResolverSettingsOnlineRow>> {
@@ -88,7 +88,7 @@ pub async fn get_resolver_settings_online(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn upsert_resolver_settings(
     pool: &SqlitePool,
     online_enabled: i64,
@@ -121,7 +121,7 @@ pub async fn upsert_resolver_settings(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn target_exists(pool: &SqlitePool, target_id: &str) -> DbResult<bool> {
     let row: Option<(String,)> = sqlx::query_as("SELECT id FROM canonical_target WHERE id = ?")
         .bind(target_id)
@@ -134,7 +134,7 @@ pub async fn target_exists(pool: &SqlitePool, target_id: &str) -> DbResult<bool>
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_target_aliases(
     pool: &SqlitePool,
     target_id: &str,
@@ -158,7 +158,7 @@ pub async fn list_target_aliases(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_alias_kind(
     pool: &SqlitePool,
     alias_id: &str,
@@ -188,7 +188,7 @@ pub async fn get_alias_kind(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn session_counts_by_target(pool: &SqlitePool) -> DbResult<Vec<(String, i64)>> {
     let rows: Vec<(Option<String>, Option<String>)> =
         sqlx::query_as("SELECT target_id, canonical_target_id FROM acquisition_session")

--- a/crates/persistence/targets/src/repositories/target_favourites.rs
+++ b/crates/persistence/targets/src/repositories/target_favourites.rs
@@ -25,7 +25,7 @@ pub use super::q_targets_mgmt::target_exists;
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_favourited_at(pool: &SqlitePool, target_id: &str) -> DbResult<Option<String>> {
     let row: Option<(String,)> =
         sqlx::query_as("SELECT favourited_at FROM target_favourite WHERE target_id = ?")
@@ -40,7 +40,7 @@ pub async fn get_favourited_at(pool: &SqlitePool, target_id: &str) -> DbResult<O
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_favourites(pool: &SqlitePool) -> DbResult<Vec<String>> {
     let rows: Vec<(String,)> = sqlx::query_as(
         "SELECT target_id FROM target_favourite ORDER BY favourited_at DESC, target_id ASC",
@@ -57,7 +57,7 @@ pub async fn list_favourites(pool: &SqlitePool) -> DbResult<Vec<String>> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn count_favourites(pool: &SqlitePool) -> DbResult<i64> {
     let count: i64 =
         sqlx::query_scalar("SELECT COUNT(*) FROM target_favourite").fetch_one(pool).await?;
@@ -69,7 +69,7 @@ pub async fn count_favourites(pool: &SqlitePool) -> DbResult<i64> {
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure (including a foreign
+/// Returns `persistence_core::DbError::Database` on query failure (including a foreign
 /// key violation if `target_id` does not reference an existing
 /// `canonical_target` row, when foreign keys are enabled).
 pub async fn add_favourite(
@@ -93,7 +93,7 @@ pub async fn add_favourite(
 ///
 /// # Errors
 ///
-/// Returns [`crate::DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn remove_favourite(pool: &SqlitePool, target_id: &str) -> DbResult<()> {
     sqlx::query("DELETE FROM target_favourite WHERE target_id = ?")
         .bind(target_id)

--- a/crates/persistence/targets/src/repositories/targets.rs
+++ b/crates/persistence/targets/src/repositories/targets.rs
@@ -47,7 +47,7 @@ pub struct TargetProjectRow {
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_sessions_for_target(
     pool: &SqlitePool,
     target_id: &str,
@@ -72,7 +72,7 @@ pub async fn list_sessions_for_target(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn list_projects_for_target(
     pool: &SqlitePool,
     target_id: &str,
@@ -96,7 +96,7 @@ pub async fn list_projects_for_target(
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn get_target_notes(pool: &SqlitePool, target_id: &str) -> DbResult<Option<String>> {
     let row: Option<(Option<String>,)> =
         sqlx::query_as("SELECT notes FROM canonical_target WHERE id = ?")
@@ -114,7 +114,7 @@ pub async fn get_target_notes(pool: &SqlitePool, target_id: &str) -> DbResult<Op
 ///
 /// # Errors
 ///
-/// Returns [`DbError::Database`] on query failure.
+/// Returns `persistence_core::DbError::Database` on query failure.
 pub async fn set_target_notes(
     pool: &SqlitePool,
     target_id: &str,

--- a/crates/targeting/resolver/src/cache.rs
+++ b/crates/targeting/resolver/src/cache.rs
@@ -9,7 +9,7 @@
 //! SIMBAD resolution MUST NOT overwrite it (FR-014).
 //!
 //! These functions take a borrowed [`sqlx::SqlitePool`] rather than owning a
-//! connection, matching the spec-013 loader ([`crate::load`]) and the
+//! connection, matching the spec-013 loader (`crate::load`) and the
 //! `persistence_db` repositories. Raw SQL lives in
 //! `persistence_targets::repositories::q_resolver` (db-boundary-zero); this module
 //! keeps the dedup/precedence/ranking business logic and converts between the

--- a/crates/targeting/resolver/src/cone_search.rs
+++ b/crates/targeting/resolver/src/cone_search.rs
@@ -180,7 +180,7 @@ pub fn dedup_candidates(candidates: Vec<ConeCandidate>) -> Vec<ConeCandidate> {
 /// ranking. Order candidates by (not-excluded first, then prominence tier
 /// descending, then separation ascending) before truncating, so excluded/
 /// niche clutter can never crowd out a higher-tier candidate regardless of
-/// its raw separation; then guarantee `primary` — [`primary_index`]'s own
+/// its raw separation; then guarantee `primary` — `primary_index`'s own
 /// nearest-to-centre, prominence-tie-broken pick (OQ-1, unchanged by this
 /// function) — survives the cut even in the residual case where `limit`
 /// non-excluded, equal-or-higher-tier candidates all sit nearer to centre

--- a/crates/targeting/resolver/src/lib.rs
+++ b/crates/targeting/resolver/src/lib.rs
@@ -6,7 +6,7 @@
 //! Resolves astronomical target identities on demand against SIMBAD, backed by
 //! a bundled seed index and a local SQLite cache. This module owns the
 //! resolver seam (a testable [`Resolver`] trait — implemented later by
-//! `SimbadResolver` and a [`FakeResolver`]), the cache read/write layer, and
+//! `SimbadResolver` and a `FakeResolver`), the cache read/write layer, and
 //! the bundled-seed loader.
 //!
 //! This is metadata/identity resolution only — no image processing
@@ -24,7 +24,7 @@
 //! [`Resolver`] is the no-network-in-unit-tests seam, mirroring the retired
 //! `download::CatalogFetcher`/`FakeFetcher` pattern: production code uses the
 //! `reqwest`-backed `SimbadResolver` (see [`simbad`], T019); the search /
-//! resolve / ingest-queue logic is unit-tested offline with [`FakeResolver`].
+//! resolve / ingest-queue logic is unit-tested offline with `FakeResolver`.
 
 #![allow(clippy::doc_markdown)] // spec/domain terminology is not suited for backticks
 
@@ -357,7 +357,7 @@ pub enum ResolveError {
 /// `download::CatalogFetcher`.
 ///
 /// Production code uses the `reqwest`-backed `SimbadResolver` ([`simbad`],
-/// T019); unit tests use [`FakeResolver`] for fast, network-free coverage of
+/// T019); unit tests use `FakeResolver` for fast, network-free coverage of
 /// the search / resolve / ingest-queue logic.
 ///
 /// Methods are modelled on the `target.resolve.json` operation. Implementations
@@ -409,7 +409,7 @@ pub trait Resolver: Send + Sync {
 /// the ingest queue, typeahead) has no way to reach the Sesame fallback even
 /// by mistake — only code that explicitly asks for `ExplicitResolver` can.
 /// Implemented by the production `targeting_resolver::simbad::SimbadResolver`
-/// (TAP-first, Sesame-fallback-on-miss) and, for tests, [`FakeResolver`].
+/// (TAP-first, Sesame-fallback-on-miss) and, for tests, `FakeResolver`.
 #[async_trait::async_trait]
 pub trait ExplicitResolver: Resolver {
     /// Same contract as [`Resolver::resolve`], but permitted to consult a

--- a/crates/targeting/resolver/src/seed.rs
+++ b/crates/targeting/resolver/src/seed.rs
@@ -249,7 +249,7 @@ pub async fn is_first_run(cache: &dyn Cache) -> Result<bool, SeedError> {
 const SENTINEL_SIMBAD_OID: i64 = -1;
 
 /// Whether `simbad_oid` identifies the warm-complete sentinel row (see
-/// [`sentinel_identity`]) rather than a real cached target. The bundled seed
+/// `sentinel_identity`) rather than a real cached target. The bundled seed
 /// is stored in the SAME `Cache`-backed store any typeahead/cone-search
 /// query reads from (the crate exposes no separate metadata table), so any
 /// app-facing surface that reads broadly from the cache (`target.search`'s
@@ -315,7 +315,7 @@ async fn sentinel_matches(cache: &dyn Cache, seed: &SeedAsset) -> Result<bool, S
         .is_some_and(|row| row.common_name.as_deref() == Some(seed.generated_at.as_str())))
 }
 
-/// Chunk size for [`chunked_upsert_batch`] (spec 052 P4/#818 follow-up): one
+/// Chunk size for `chunked_upsert_batch` (spec 052 P4/#818 follow-up): one
 /// write transaction for the WHOLE seed leaves nothing visible to a reader
 /// until it all commits, so a `target.search` query racing a multi-second
 /// warm can miss an object the seed does contain simply because its part of
@@ -326,7 +326,7 @@ async fn sentinel_matches(cache: &dyn Cache, seed: &SeedAsset) -> Result<bool, S
 /// instead of 1 atomic transaction or ~13k per-entry ones pre-#695).
 const WARM_CHUNK_SIZE: usize = 1000;
 
-/// Upsert `identities` in [`WARM_CHUNK_SIZE`]-sized slices, one
+/// Upsert `identities` in `WARM_CHUNK_SIZE`-sized slices, one
 /// [`Cache::upsert_batch`] write transaction per chunk, summing the loaded
 /// count across chunks. Shared by [`warm_cache`] and
 /// [`warm_from_canonical_target`], which both build a full identity list up
@@ -351,9 +351,9 @@ async fn chunked_upsert_batch(
 
 /// Warm the redb cache from a seed asset, writing rows with `source = seed`.
 ///
-/// Entries are upserted via [`chunked_upsert_batch`] (one
+/// Entries are upserted via `chunked_upsert_batch` (one
 /// [`simbad_resolver::Cache::upsert_batch`] write transaction per
-/// [`WARM_CHUNK_SIZE`]-sized chunk, rather than one per entry — spec 052
+/// `WARM_CHUNK_SIZE`-sized chunk, rather than one per entry — spec 052
 /// P4/#695 — or one atomic transaction for the whole seed, which left
 /// nothing visible until it all committed — #818 follow-up), so the warm is
 /// idempotent: re-running it dedups by `simbad_oid` (or the
@@ -384,7 +384,7 @@ pub async fn warm_cache(
 /// Warm the redb cache from the bundled seed **only when it isn't already
 /// warmed for this exact seed version**.
 ///
-/// Gated on the warm-complete sentinel ([`sentinel_matches`]), not cache
+/// Gated on the warm-complete sentinel (`sentinel_matches`), not cache
 /// emptiness (spec 052 P4/#818 follow-up) — a crash partway through a
 /// chunked `Eventual` warm can leave a non-empty but partial cache (see
 /// [`is_first_run`]'s doc comment), which an emptiness check would mistake
@@ -687,8 +687,8 @@ mod tests {
 
     /// A real Messier-only slice of the committed bundled asset (~110 objects,
     /// including M 31/M 42) — fast enough for redb-touching tests. [`warm_cache`]
-    /// goes through [`chunked_upsert_batch`] (one [`simbad_resolver::Cache::
-    /// upsert_batch`] write transaction per [`WARM_CHUNK_SIZE`]-sized chunk —
+    /// goes through `chunked_upsert_batch` (one [`simbad_resolver::Cache::
+    /// upsert_batch`] write transaction per `WARM_CHUNK_SIZE`-sized chunk —
     /// spec 052 P4/#695, chunked by the first #818 follow-up), which on a
     /// `simbad_resolver::BatchDurability::Eventual` file-backed store
     /// (`crate::simbad::ResolveCache::open`'s production configuration since
@@ -838,7 +838,7 @@ mod tests {
     }
 
     /// Regression guard for the #818 follow-up (chunked batching,
-    /// [`WARM_CHUNK_SIZE`]): a seed spanning multiple chunks must warm
+    /// `WARM_CHUNK_SIZE`): a seed spanning multiple chunks must warm
     /// EVERY entry exactly once — no drop, duplicate, or corruption at a
     /// chunk boundary — proving `chunked_upsert_batch`'s per-chunk loop is
     /// equivalent to the old single whole-seed `upsert_batch` call for the

--- a/crates/targeting/resolver/src/simbad/mod.rs
+++ b/crates/targeting/resolver/src/simbad/mod.rs
@@ -5,7 +5,7 @@
 //! crate's own [`simbad_resolver::SimbadResolver`] cache-first facade (spec
 //! 052 P1, D1) rather than calling [`simbad_resolver::TapResolver`] directly.
 //!
-//! The facade owns cache-first resolution (persistent redb, [`cache::ResolveCache`]),
+//! The facade owns cache-first resolution (persistent redb, `cache::ResolveCache`),
 //! Caldwell translation, and (from 0.2.0) `v_mag` enrichment; this module is a
 //! thin boundary converting between astro-plan's stable local resolver types
 //! (unchanged public API since spec 035 — every existing call site keeps
@@ -13,34 +13,34 @@
 //!
 //! ## Cache lifetime (D2 — one global redb file, no TTL)
 //!
-//! [`cache::ResolveCache`] wraps the crate's [`simbad_resolver::Store`] (an `Arc`
+//! `cache::ResolveCache` wraps the crate's [`simbad_resolver::Store`] (an `Arc`
 //! handle over one open `redb::Database`) and is opened ONCE at app startup
-//! (`<app_data>/simbad-cache.redb`); every [`resolver::SimbadResolver`] built afterward
+//! (`<app_data>/simbad-cache.redb`); every `resolver::SimbadResolver` built afterward
 //! (settings changes rebuild the resolver, e.g. after `target.resolution
 //! .settings.update`) shares that same store via a cheap clone
-//! ([`CacheBackend::custom`]) instead of re-opening the file.
+//! (`CacheBackend::custom`) instead of re-opening the file.
 //!
 //! ## Dual lookup (spec 052 P2, D5 — TAP-first, Sesame fallback)
 //!
-//! [`resolver::SimbadResolver`] wraps TWO facade instances sharing the SAME
-//! [`cache::ResolveCache`]: `typeahead` (the [`Resolver`] trait impl — TAP +
+//! `resolver::SimbadResolver` wraps TWO facade instances sharing the SAME
+//! `cache::ResolveCache`: `typeahead` (the `Resolver` trait impl — TAP +
 //! cache only, used by the debounced as-you-type path) and
 //! `explicit` (consulted only by `resolve_explicit` — TAP
 //! first, [`simbad_resolver::SesameResolver`] fallback only on a TAP miss).
 //! This two-entrypoint split is what makes FR-009 ("the fallback MUST NOT
 //! fire during as-you-type suggestions") a structural guarantee rather than a
 //! runtime flag the typeahead call site could forget to pass: the typeahead
-//! path's resolver type ([`network_resolvers::EitherNetworkResolver`]) has no Sesame reference to
-//! call, at any query. Both facades share one [`cache::ResolveCache`], so a
+//! path's resolver type (`network_resolvers::EitherNetworkResolver`) has no Sesame reference to
+//! call, at any query. Both facades share one `cache::ResolveCache`, so a
 //! Sesame-recovered identity is cached/deduped exactly like a TAP hit.
 //!
-//! Split by responsibility (refactor sweep #993): [`cache`] is the durable
-//! resolve-cache handle; [`network_resolvers`] are the small `Resolver`
-//! compositions ([`network_resolvers::EitherNetworkResolver`],
-//! [`network_resolvers::DualLookupResolver`],
-//! [`network_resolvers::ExplicitNetworkResolver`]) `resolver::SimbadResolver`
-//! is built from; [`resolver`] is the production `SimbadResolver` facade
-//! itself plus [`resolver::OfflineResolver`]; [`convert`] holds the
+//! Split by responsibility (refactor sweep #993): `cache` is the durable
+//! resolve-cache handle; `network_resolvers` are the small `Resolver`
+//! compositions (`network_resolvers::EitherNetworkResolver`,
+//! `network_resolvers::DualLookupResolver`,
+//! `network_resolvers::ExplicitNetworkResolver`) `resolver::SimbadResolver`
+//! is built from; `resolver` is the production `SimbadResolver` facade
+//! itself plus `resolver::OfflineResolver`; `convert` holds the
 //! boundary conversions between astro-plan's local types and the upstream
 //! crate's types.
 
@@ -63,7 +63,7 @@ pub use simbad_resolver::wire::parse_basic_row;
 
 /// Default SIMBAD TAP sync endpoint (CDS). Must match
 /// [`simbad_resolver::SimbadConfig::default`]'s endpoint (asserted by
-/// [`tests::default_endpoint_matches_upstream_crate`]).
+/// `tests::default_endpoint_matches_upstream_crate`).
 pub const DEFAULT_TAP_ENDPOINT: &str = "https://simbad.cds.unistra.fr/simbad/sim-tap/sync";
 
 /// Polite identifying `User-Agent` (CDS norm) for astro-plan's own requests
@@ -73,7 +73,7 @@ pub const DEFAULT_USER_AGENT: &str = "astro-plan/0.1 (+https://github.com/; spec
 /// The id-namespace seed used to derive stable target ids from a designation.
 /// MUST match `targeting::identity`'s hardcoded `"astro-plan.targets"` seed
 /// exactly (asserted by
-/// [`tests::namespace_matches_sqlite_identity_derivation`]) so a redb-cache id
+/// `tests::namespace_matches_sqlite_identity_derivation`) so a redb-cache id
 /// and the SQLite id later written for the same designation by
 /// `crate::cache::upsert_resolved` are bit-identical — the in-use "promote
 /// from cache" write never needs to special-case ids.

--- a/crates/targeting/resolver/src/simbad/resolver.rs
+++ b/crates/targeting/resolver/src/simbad/resolver.rs
@@ -25,7 +25,7 @@ use super::{SimbadConfig, NAMESPACE_SEED};
 ///
 /// Wraps TWO instances of the crate's own cache-first
 /// [`simbad_resolver::SimbadResolver`] facade, sharing one [`ResolveCache`]
-/// (see the module doc, "Dual lookup"): [`Self::typeahead`]-backed
+/// (see the module doc, "Dual lookup"): `typeahead`-backed
 /// [`Resolver`] trait impl (TAP + cache only), `explicit`-backed
 /// [`Self::resolve_explicit`] (TAP-first, Sesame-fallback-on-miss).
 pub struct SimbadResolver {
@@ -227,7 +227,7 @@ impl Resolver for SimbadResolver {
 
 /// Makes the production resolver satisfy [`crate::ExplicitResolver`] (spec
 /// 052 P2), so the app layer's `resolve_explicit` use case can stay generic
-/// (testable with [`crate::FakeResolver`]) instead of hardcoding this concrete
+/// (testable with `FakeResolver`) instead of hardcoding this concrete
 /// type.
 #[async_trait]
 impl crate::ExplicitResolver for SimbadResolver {

--- a/crates/workflow/profiles/src/lib.rs
+++ b/crates/workflow/profiles/src/lib.rs
@@ -9,7 +9,7 @@
 //! - [`ToolProfile`]: static per-tool descriptor (name, args template, capabilities).
 //! - [`seed::all`]: seeded profiles for PixInsight, Siril, and Planetary Suite.
 //! - [`args::render`]: token-pattern substitution (`{folder}`, `{file}`).
-//! - [`launch`]: platform-specific detach helpers behind a [`ProcessSpawner`] trait.
+//! - [`launch`]: platform-specific detach helpers behind a [`launch::ProcessSpawner`] trait.
 //! - [`discover`]: per-OS executable auto-detection (pure filesystem reads).
 //!
 //! Constitution III: this crate NEVER processes images; it only models how to


### PR DESCRIPTION
## Summary

- Fixed ~95 broken/private intra-doc links across ~103 files so `RUSTDOCFLAGS="-D warnings" cargo doc --workspace --no-deps` exits 0 workspace-wide.
- Fixed 4 additional links in `session_materialization` (`DbError`/`DbError::CasFailed`/`DbError::Database` fully-qualified as `persistence_core::*`; stale `[cancel]` replaced with `[Self::request_cancel]`).
- Doc-comment changes only — no logic, no blanket `#[allow]` suppression.

Tracks-Bead: orc-7xf
Merge-Bead: orc-0xu
