### PR TITLE
chore: remove orphaned functions superseded by called siblings

### DIFF
--- a/crates/app/core/src/native.rs
+++ b/crates/app/core/src/native.rs
@@ -158,12 +158,6 @@ pub fn reveal_success(selection: RevealSelection) -> RevealResponse {
     RevealResponse { revealed: true, selection }
 }
 
-/// Build a failure response for reveal (OS command failed).
-#[must_use]
-pub fn reveal_failed() -> RevealResponse {
-    RevealResponse { revealed: false, selection: RevealSelection::None }
-}
-
 // ── Tests ───────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -365,12 +359,5 @@ mod tests {
         let resp = reveal_success(RevealSelection::Target);
         assert!(resp.revealed);
         assert_eq!(resp.selection, RevealSelection::Target);
-    }
-
-    #[test]
-    fn reveal_failed_response() {
-        let resp = reveal_failed();
-        assert!(!resp.revealed);
-        assert_eq!(resp.selection, RevealSelection::None);
     }
 }

--- a/crates/app/core/src/sessions.rs
+++ b/crates/app/core/src/sessions.rs
@@ -8,10 +8,6 @@
 //!   `get_session`   -- backed by `acquisition_session` joined with related tables
 //!                      for calibration_matches and audit history.
 //!
-//! Stub placeholders (to be wired when domain logic is built):
-//!   `split_session` -- not yet implemented.
-//!   `merge_sessions` -- not yet implemented.
-//!
 //! # Architecture
 //!
 //! `acquisition_session` stores: id, session_key (pipe-delimited
@@ -232,32 +228,6 @@ pub async fn get_session(pool: &SqlitePool, id: &str) -> Result<SessionDetail, S
     })
 }
 
-// -- Stub placeholders --------------------------------------------------------
-
-/// Split a session by a given property, producing multiple new sessions.
-///
-/// # Errors
-///
-/// Currently returns a `NotImplemented` error.
-#[allow(clippy::unused_async)] // will await DB queries when wired
-pub async fn split_session(
-    _pool: &SqlitePool,
-    _session_id: &str,
-    _split_property: &str,
-) -> Result<Vec<String>, String> {
-    Err("session.split: not yet implemented".to_owned())
-}
-
-/// Merge multiple sessions into a single combined session.
-///
-/// # Errors
-///
-/// Currently returns a `NotImplemented` error.
-#[allow(clippy::unused_async)] // will await DB queries when wired
-pub async fn merge_sessions(_pool: &SqlitePool, _session_ids: &[String]) -> Result<String, String> {
-    Err("session.merge: not yet implemented".to_owned())
-}
-
 // -- Private helpers ----------------------------------------------------------
 
 /// Row from `acquisition_fingerprint` for supplementary metadata.
@@ -440,23 +410,6 @@ async fn load_history(
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[tokio::test]
-    async fn split_session_returns_not_implemented() {
-        let pool = SqlitePool::connect("sqlite::memory:").await.expect("in-memory pool");
-        let result = split_session(&pool, "ses-001", "filter").await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not yet implemented"));
-    }
-
-    #[tokio::test]
-    async fn merge_sessions_returns_not_implemented() {
-        let pool = SqlitePool::connect("sqlite::memory:").await.expect("in-memory pool");
-        let ids = vec!["ses-001".to_owned(), "ses-002".to_owned()];
-        let result = merge_sessions(&pool, &ids).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().contains("not yet implemented"));
-    }
 
     #[test]
     fn parse_session_key_falls_back_to_fingerprint() {

--- a/crates/app/core/tests/plan_resume_integration.rs
+++ b/crates/app/core/tests/plan_resume_integration.rs
@@ -26,6 +26,20 @@ use persistence_plans::repositories::plan_apply as apply_repo;
 use persistence_plans::repositories::plans as plans_repo;
 use uuid::Uuid;
 
+/// Fetch plan_apply_events rows for a plan as `(item_id, prior_state, new_state)`.
+async fn list_events_raw(
+    pool: &sqlx::SqlitePool,
+    plan_id: &str,
+) -> Vec<(Option<String>, String, String)> {
+    sqlx::query_as::<_, (Option<String>, String, String)>(
+        "SELECT item_id, prior_state, new_state FROM plan_apply_events WHERE plan_id = ? ORDER BY at ASC",
+    )
+    .bind(plan_id)
+    .fetch_all(pool)
+    .await
+    .expect("list_events_raw")
+}
+
 /// Seed one item into `failed` state without going through the executor.
 /// Replaces the deleted `item_start_applying` + `item_failed` pair —
 /// `batch_flush_item_states` goes pending → terminal in one step,
@@ -182,7 +196,7 @@ async fn resume_refused_while_item_still_stale() {
         .await
         .expect("get_active_run")
         .expect("a paused run must still have its run row");
-    let events_before = apply_repo::list_events(db.pool(), &plan_id).await.expect("list_events");
+    let events_before = list_events_raw(db.pool(), &plan_id).await;
 
     // The condition is NOT resolved (snapshot still mismatched) — resume must refuse.
     let err = app_core::plan_apply::resume_plan(db.pool(), &bus, &plan_id, &run_row.id)
@@ -193,7 +207,7 @@ async fn resume_refused_while_item_still_stale() {
     // State untouched: still paused, no new audit events, item 1 never ran.
     let plan_row = plans_repo::get_plan(db.pool(), &plan_id, false).await.expect("get_plan");
     assert_eq!(plan_row.state, "paused", "a refused resume must not flip state");
-    let events_after = apply_repo::list_events(db.pool(), &plan_id).await.expect("list_events");
+    let events_after = list_events_raw(db.pool(), &plan_id).await;
     assert_eq!(
         events_before.len(),
         events_after.len(),
@@ -270,13 +284,13 @@ async fn resume_succeeds_after_stale_item_resolved_and_drains_remaining_pending(
     assert_eq!(plan_row.items_failed, 1, "item 0 stays failed from the original pause");
 
     // Audit trail carries the resume transition.
-    let events = apply_repo::list_events(db.pool(), &plan_id).await.expect("list_events");
+    let events = list_events_raw(db.pool(), &plan_id).await;
     assert!(
-        events.iter().any(|e| e.prior_state == "paused" && e.new_state == "applying"),
+        events.iter().any(|e| e.1 == "paused" && e.2 == "applying"),
         "audit trail must record the paused -> applying resume transition"
     );
     assert!(
-        events.iter().any(|e| e.prior_state == "applying" && e.new_state == "partially_applied"),
+        events.iter().any(|e| e.1 == "applying" && e.2 == "partially_applied"),
         "audit trail must record the final terminal transition"
     );
 }
@@ -694,11 +708,11 @@ async fn resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state() {
 
     // A real terminal audit record landed for the retry (applying -> succeeded),
     // not silence.
-    let events = apply_repo::list_events(db.pool(), &plan_id).await.expect("list_events");
+    let events = list_events_raw(db.pool(), &plan_id).await;
     assert!(
-        events.iter().any(|e| e.item_id.as_deref() == Some(item0_id.as_str())
-            && e.prior_state == "applying"
-            && e.new_state == "succeeded"),
+        events.iter().any(|e| e.0.as_deref() == Some(item0_id.as_str())
+            && e.1 == "applying"
+            && e.2 == "succeeded"),
         "the retry must append a real terminal audit event for item 0, not leave it silent"
     );
 }

--- a/crates/app/core/tests/sessions_integration.rs
+++ b/crates/app/core/tests/sessions_integration.rs
@@ -5,9 +5,7 @@
 //! Layer-1 integration tests for the sessions coverage area — feature 037 (T???).
 //!
 //! Covers:
-//! 1. `sessions::merge_sessions` / `sessions::split_session` — stub error
-//!    contracts verified against the real in-memory pool.
-//! 2. `list_sessions` / `get_session` — real DB round-trips.
+//! 1. `list_sessions` / `get_session` — real DB round-trips.
 //!
 //! Spec 041 FR-051 (T076, Phase 13): the former `inventory::review_session`
 //! scenarios (session-not-found, same-state noop, discovered → candidate)
@@ -38,17 +36,7 @@ async fn insert_acquisition_session(pool: &sqlx::SqlitePool, id: &str) {
     .expect("insert acquisition_session");
 }
 
-// ── 1. sessions stub: merge and split return not-implemented errors ───────────
-//
-// `merge_and_split_stubs_return_not_implemented_errors` removed: it exactly
-// duplicated `split_session_returns_not_implemented` /
-// `merge_sessions_returns_not_implemented` in `src/sessions.rs`'s own unit
-// tests, with zero added value — both stubs take `_pool: &SqlitePool` and
-// ignore it entirely, so exercising them through a real DB pool here (vs. an
-// unconnected in-memory pool at the unit level) exercises no additional code
-// path.
-
-// ── 2. list_sessions: returns real rows, empty on fresh DB ───────────────────
+// ── 1. list_sessions: returns real rows, empty on fresh DB ───────────────────
 
 #[tokio::test]
 async fn list_sessions_returns_empty_on_fresh_db() {

--- a/crates/app/errors/src/lib.rs
+++ b/crates/app/errors/src/lib.rs
@@ -45,16 +45,6 @@ fn retry_action() -> RecoveryAction {
     }
 }
 
-/// Convert a `sqlx::Error` inline (command-handler shorthand).
-///
-/// Wraps the sqlx error as `persistence_core::DbError::Database` then delegates
-/// to `db_to_contract`.  Use this in command handlers that run inline sqlx
-/// queries instead of calling a repository function.
-#[must_use]
-pub fn sqlx_to_contract(e: sqlx::Error) -> ContractError {
-    db_to_contract(persistence_core::DbError::from(e))
-}
-
 /// Convert a database-layer error (`sqlx::Error` or
 /// [`persistence_core::DbError`]) to an `internal.database` `ContractError`
 /// while preserving the originating error and adding which operation failed.

--- a/crates/app/inbox/src/confirm.rs
+++ b/crates/app/inbox/src/confirm.rs
@@ -3019,10 +3019,10 @@ mod tests {
             None,
             Some(instrume),
         );
-        settings_repo::set_pattern_for(
+        settings_repo::set_raw(
             db.pool(),
-            patterns::FrameTypeClass::Light,
-            "{camera}/light/",
+            settings_repo::PATTERNS_BY_TYPE_KEY,
+            &serde_json::json!({"light": "{camera}/light/"}),
         )
         .await
         .unwrap();

--- a/crates/app/settings/src/ingestion.rs
+++ b/crates/app/settings/src/ingestion.rs
@@ -8,7 +8,7 @@
 //! the existing spec-018 settings key/value store
 //! (`persistence_lifecycle::repositories::settings::{get_raw,set_raw}`) — the same
 //! low-level mechanism `patternsByType` uses for its map (see
-//! `repositories::settings::get_patterns_by_type` / `set_pattern_for`).
+//! `repositories::settings::get_patterns_by_type` / `PATTERNS_BY_TYPE_KEY` + `set_raw`).
 //!
 //! This intentionally does **not** route through `SettingsState` / the
 //! per-key descriptor registry (`descriptors.rs`): that bag is validated,

--- a/crates/calibration/core/src/assign.rs
+++ b/crates/calibration/core/src/assign.rs
@@ -11,7 +11,6 @@
 //! The Tauri command layer hands the `AssignDecision` to the persistence
 //! repository to write the `calibration_assignment` row.
 
-use crate::candidate::MismatchedDim;
 use crate::ranking::MatchingRuleConfig;
 use crate::{CalibrationKind, Dimension, MasterInfo, SessionInfo};
 
@@ -179,12 +178,6 @@ fn compute_assign_confidence(
 }
 
 // ── Mismatch dim helper for assign response DTOs ──────────────────────────────
-
-/// Build `MismatchedDim` entries for the hard violations in an override assignment.
-#[must_use]
-pub fn hard_violations_to_mismatched(violations: &[Dimension]) -> Vec<MismatchedDim> {
-    violations.iter().map(|d| MismatchedDim::hard(*d)).collect()
-}
 
 /// Extract dimension name strings for contract DTOs.
 #[must_use]

--- a/crates/domain/core/src/lifecycle/project.rs
+++ b/crates/domain/core/src/lifecycle/project.rs
@@ -122,39 +122,6 @@ pub fn is_allowed(from: ProjectState, to: ProjectState) -> bool {
     TRANSITIONS.iter().any(|&(f, t)| f == from && t == to)
 }
 
-/// Default action label for a `(from, to)` edge per data-model.md §Transition Table (R2).
-#[must_use]
-pub fn default_label(from: ProjectState, to: ProjectState) -> &'static str {
-    match (from, to) {
-        (ProjectState::SetupIncomplete, ProjectState::Ready) => "Marked ready",
-        (
-            ProjectState::SetupIncomplete
-            | ProjectState::Ready
-            | ProjectState::Prepared
-            | ProjectState::Processing,
-            ProjectState::Blocked,
-        ) => "Marked blocked",
-        (ProjectState::Ready, ProjectState::Prepared) => "Marked prepared",
-        (ProjectState::Ready | ProjectState::Prepared, ProjectState::Processing) => {
-            "Marked processing"
-        }
-        (ProjectState::Prepared, ProjectState::Ready) => "Reverted to ready",
-        (ProjectState::Processing, ProjectState::Completed) => "Marked completed",
-        (ProjectState::Completed, ProjectState::Archived) => "Marked archived",
-        (ProjectState::Completed, ProjectState::Processing) => "Re-opened",
-        (ProjectState::Archived, ProjectState::Processing | ProjectState::Ready) => "Unarchived",
-        (
-            ProjectState::Blocked,
-            ProjectState::SetupIncomplete
-            | ProjectState::Ready
-            | ProjectState::Prepared
-            | ProjectState::Processing,
-        ) => "Resolved blocker",
-        (ProjectState::Blocked, ProjectState::Archived) => "Archived from blocked",
-        _ => "Transition applied",
-    }
-}
-
 /// Snapshot of `{label, at, actor}` recorded in the UI projection column.
 #[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize, JsonSchema, Type)]
 #[serde(rename_all = "camelCase")]
@@ -283,22 +250,5 @@ mod tests {
     #[test]
     fn archived_prepared_is_forbidden() {
         assert!(!is_allowed(ProjectState::Archived, ProjectState::Prepared));
-    }
-
-    /// Default label derivation for all 19 allowed edges.
-    #[test]
-    fn default_labels_match_spec() {
-        assert_eq!(
-            default_label(ProjectState::SetupIncomplete, ProjectState::Ready),
-            "Marked ready"
-        );
-        assert_eq!(default_label(ProjectState::Archived, ProjectState::Ready), "Unarchived");
-        assert_eq!(default_label(ProjectState::Archived, ProjectState::Processing), "Unarchived");
-        assert_eq!(
-            default_label(ProjectState::Blocked, ProjectState::Archived),
-            "Archived from blocked"
-        );
-        assert_eq!(default_label(ProjectState::Completed, ProjectState::Processing), "Re-opened");
-        assert_eq!(default_label(ProjectState::Blocked, ProjectState::Ready), "Resolved blocker");
     }
 }

--- a/crates/fs/executor/src/ops/archive_op.rs
+++ b/crates/fs/executor/src/ops/archive_op.rs
@@ -7,7 +7,9 @@
 //! destination. The archive path is pre-computed at plan generation time and
 //! stored in `plan_items.archive_path`.
 
-use camino::{Utf8Path, Utf8PathBuf};
+use camino::Utf8Path;
+#[cfg(test)]
+use camino::Utf8PathBuf;
 
 use crate::failure::PlanItemFailure;
 use crate::ops::move_op::{move_file, MoveResult};
@@ -28,21 +30,6 @@ pub fn archive_file(
     move_file(source, archive_destination)
 }
 
-/// Build the absolute archive destination from a library root path and the
-/// relative archive path stored in `plan_items.archive_path`.
-///
-/// Returns `None` if `archive_relative` is empty or the path cannot be joined.
-#[must_use]
-pub fn resolve_archive_destination(
-    library_root: &Utf8Path,
-    archive_relative: &str,
-) -> Option<Utf8PathBuf> {
-    if archive_relative.is_empty() {
-        return None;
-    }
-    Some(library_root.join(archive_relative))
-}
-
 // ── Tests ──────────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -61,19 +48,5 @@ mod tests {
 
         assert!(!src.exists());
         assert!(dst.exists());
-    }
-
-    #[test]
-    fn resolve_archive_destination_builds_path() {
-        let root = Utf8PathBuf::from("/mnt/library");
-        let rel = ".astro-plan-archive/p1/file.fits";
-        let resolved = resolve_archive_destination(&root, rel).unwrap();
-        assert_eq!(resolved, Utf8PathBuf::from("/mnt/library/.astro-plan-archive/p1/file.fits"));
-    }
-
-    #[test]
-    fn resolve_archive_destination_empty_relative_returns_none() {
-        let root = Utf8PathBuf::from("/mnt/library");
-        assert!(resolve_archive_destination(&root, "").is_none());
     }
 }

--- a/crates/metadata/video/src/lib.rs
+++ b/crates/metadata/video/src/lib.rs
@@ -13,8 +13,6 @@
 //! (Ref: R-Video-1, T-VideoLaneDocs)
 #![allow(clippy::doc_markdown)]
 
-use std::path::Path;
-
 /// A video file record discovered during an inbox scan.
 ///
 /// Contains path metadata only; no frame content is inspected here.
@@ -42,29 +40,6 @@ const VIDEO_EXTENSIONS: &[&str] = &["ser", "avi", "mp4", "mov"];
 pub fn is_video_extension(ext: &str) -> bool {
     let lower = ext.trim().to_ascii_lowercase();
     VIDEO_EXTENSIONS.contains(&lower.as_str())
-}
-
-/// Returns `true` if the file at `path` should be routed to the video lane,
-/// based purely on its extension.
-///
-/// Does not inspect the file contents; does not require the file to exist.
-#[must_use]
-pub fn is_video_file(path: &Path) -> bool {
-    path.extension().and_then(|e| e.to_str()).is_some_and(is_video_extension)
-}
-
-/// Build a [`VideoFileRecord`] from a path.
-///
-/// Returns `None` if the path does not have a recognized video extension.
-pub fn video_record(path: impl Into<std::path::PathBuf>) -> Option<VideoFileRecord> {
-    let path = path.into();
-    if !is_video_file(&path) {
-        return None;
-    }
-    let file_name = path.file_name().and_then(|n| n.to_str()).unwrap_or("").to_owned();
-    let extension = path.extension().and_then(|e| e.to_str()).unwrap_or("").to_ascii_lowercase();
-
-    Some(VideoFileRecord { path, file_name, extension })
 }
 
 // ── Tests ─────────────────────────────────────────────────────────────────────
@@ -95,25 +70,5 @@ mod tests {
         assert!(!is_video_extension("fits"));
         assert!(!is_video_extension("fit"));
         assert!(!is_video_extension("xisf"));
-    }
-
-    #[test]
-    fn is_video_file_checks_extension() {
-        assert!(is_video_file(Path::new("/astro/planetary/Jupiter_2025.ser")));
-        assert!(is_video_file(Path::new("capture.AVI")));
-        assert!(!is_video_file(Path::new("light_frame.fits")));
-        assert!(!is_video_file(Path::new("noext")));
-    }
-
-    #[test]
-    fn video_record_returns_none_for_non_video() {
-        assert!(video_record(Path::new("frame.fits")).is_none());
-    }
-
-    #[test]
-    fn video_record_builds_correctly() {
-        let rec = video_record(Path::new("/data/Jupiter.ser")).unwrap();
-        assert_eq!(rec.file_name, "Jupiter.ser");
-        assert_eq!(rec.extension, "ser");
     }
 }

--- a/crates/persistence/calibration/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_assignment.rs
@@ -181,14 +181,6 @@ pub async fn list_for_session(
     Ok(rows.into_iter().map(row_to_struct).collect())
 }
 
-/// Parse the JSON `mismatched_dimensions` column as a `Vec<String>`.
-///
-/// Returns an empty vec on parse failure (defensive — schema enforces valid JSON).
-#[must_use]
-pub fn parse_mismatched_dimensions(json: &str) -> Vec<String> {
-    serde_json::from_str::<Vec<String>>(json).unwrap_or_default()
-}
-
 // ── Missing-frame awareness (spec 048 US5, FR-024/025) ─────────────────────────
 //
 // A "master" here is always a `calibration_session` row (`master_id` ==
@@ -361,7 +353,8 @@ mod tests {
         assert_eq!(row.master_id, "master-002");
         assert!(row.was_override);
         // Round-trips through the `sqlx::types::Json` write-side codec.
-        assert_eq!(parse_mismatched_dimensions(&row.mismatched_dimensions), override_dims);
+        let got: Vec<String> = serde_json::from_str(&row.mismatched_dimensions).unwrap_or_default();
+        assert_eq!(got, override_dims);
     }
 
     #[tokio::test]
@@ -388,25 +381,5 @@ mod tests {
         let result =
             upsert(&pool, params("a-df", "ses-001", "dark_flat", "m-1", 1.0, false, &[])).await;
         assert!(result.is_err(), "dark_flat should be rejected by DB CHECK constraint");
-    }
-
-    #[tokio::test]
-    async fn parse_mismatched_dimensions_valid() {
-        let dims = parse_mismatched_dimensions(r#"["gain","filter"]"#);
-        assert_eq!(dims, vec!["gain".to_owned(), "filter".to_owned()]);
-    }
-
-    #[tokio::test]
-    async fn parse_mismatched_dimensions_empty() {
-        let dims = parse_mismatched_dimensions("[]");
-        assert!(dims.is_empty());
-    }
-
-    /// Graceful-degradation site (spec `n4_jsoncodec`): a corrupt
-    /// `mismatched_dimensions` cell must degrade to empty, not panic/propagate.
-    #[tokio::test]
-    async fn parse_mismatched_dimensions_corrupt_degrades_to_empty() {
-        let dims = parse_mismatched_dimensions("not valid json");
-        assert!(dims.is_empty());
     }
 }

--- a/crates/persistence/inbox/src/repositories/inbox/classification.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/classification.rs
@@ -319,31 +319,6 @@ pub async fn list_evidence(
     .await?)
 }
 
-/// Apply a manual override to one evidence row.
-///
-/// # Errors
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn set_manual_override(
-    pool: &SqlitePool,
-    inbox_item_id: &str,
-    relative_file_path: &str,
-    override_type: &str,
-) -> DbResult<bool> {
-    let rows = sqlx::query(
-        "UPDATE inbox_classification_evidence
-         SET manual_override = ?, evidence_source = 'manual_override'
-         WHERE inbox_item_id = ? AND relative_file_path = ?",
-    )
-    .bind(override_type)
-    .bind(inbox_item_id)
-    .bind(relative_file_path)
-    .execute(pool)
-    .await?
-    .rows_affected();
-
-    Ok(rows > 0)
-}
-
 /// Apply a full set of non-type overrides (filter, exposure, binning) and
 /// optionally a frame-type override.
 ///

--- a/crates/persistence/inbox/src/repositories/inbox/mod.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/mod.rs
@@ -26,8 +26,8 @@ mod tests;
 pub use classification::{
     delete_evidence_for_item_conn, delete_evidence_for_items, get_classification, insert_evidence,
     insert_evidence_batch, insert_evidence_conn, list_evidence, list_file_overrides_for_group,
-    mark_file_override_stale, mark_override_stale, set_file_override, set_manual_override,
-    set_overrides, upsert_classification, upsert_classification_batch, upsert_classification_conn,
+    mark_file_override_stale, mark_override_stale, set_file_override, set_overrides,
+    upsert_classification, upsert_classification_batch, upsert_classification_conn,
     FileOverrideRow, InboxClassificationRow, InboxEvidenceRow, InsertEvidence,
     UpsertClassification, UpsertClassificationRow,
 };

--- a/crates/persistence/inbox/src/repositories/inbox/tests.rs
+++ b/crates/persistence/inbox/src/repositories/inbox/tests.rs
@@ -103,33 +103,6 @@ async fn insert_and_list_evidence() {
 }
 
 #[tokio::test]
-async fn set_manual_override_updates_row() {
-    let db = test_db().await;
-    insert_inbox_item(db.pool(), &sample_item("item-5")).await.unwrap();
-
-    let ev = InsertEvidence {
-        id: "ev-2",
-        inbox_item_id: "item-5",
-        relative_file_path: "frame_002.fits",
-        frame_type: None,
-        evidence_source: "none",
-        raw_value: None,
-        unclassified: true,
-        manual_override: None,
-        is_master: false,
-        master_detector: None,
-    };
-    insert_evidence(db.pool(), &ev).await.unwrap();
-
-    let updated = set_manual_override(db.pool(), "item-5", "frame_002.fits", "dark").await.unwrap();
-    assert!(updated);
-
-    let rows = list_evidence(db.pool(), "item-5").await.unwrap();
-    assert_eq!(rows[0].manual_override, Some("dark".to_owned()));
-    assert_eq!(rows[0].evidence_source, "manual_override");
-}
-
-#[tokio::test]
 async fn plan_link_insert_and_get() {
     let db = test_db().await;
     insert_inbox_item(db.pool(), &sample_item("item-6")).await.unwrap();

--- a/crates/persistence/lifecycle/src/repositories/settings.rs
+++ b/crates/persistence/lifecycle/src/repositories/settings.rs
@@ -9,8 +9,8 @@
 use std::collections::BTreeMap;
 
 use domain_core::ids::Timestamp;
-use domain_core::settings::{SettingsState, SourceOverride};
-use patterns::{default_pattern, validate_pattern_str, FrameTypeClass};
+use domain_core::settings::SettingsState;
+use patterns::{default_pattern, validate_pattern_str};
 use serde_json::Value;
 use sqlx::types::Json;
 use sqlx::SqliteConnection;
@@ -280,48 +280,6 @@ pub async fn effective_pattern_for(
     Ok(Some(effective))
 }
 
-/// Set the destination pattern override for a single frame-type class.
-///
-/// The pattern is validated via [`validate_pattern_str`] before storage; an
-/// invalid (or empty) pattern is rejected with [`DbError::Serialise`] rather
-/// than persisted. To revert a class to its default, use [`reset_pattern_for`].
-///
-/// # Errors
-///
-/// Returns [`DbError::Serialise`] when `pattern` fails validation, or
-/// [`DbError::Database`] on query failure.
-pub async fn set_pattern_for(
-    pool: &SqlitePool,
-    class: FrameTypeClass,
-    pattern: &str,
-) -> DbResult<()> {
-    validate_pattern_str(pattern).map_err(|e| {
-        let err: serde_json::Error =
-            serde::de::Error::custom(format!("invalid pattern for {}: {e}", class.as_str()));
-        DbError::Serialise(err)
-    })?;
-    let mut overrides = get_patterns_by_type(pool).await?;
-    overrides.insert(class.as_str().to_owned(), pattern.to_owned());
-    let value = serde_json::to_value(&overrides).map_err(DbError::Serialise)?;
-    set_raw(pool, PATTERNS_BY_TYPE_KEY, &value).await
-}
-
-/// Reset a single frame-type class to its built-in default by removing its
-/// override entry. Idempotent — no error if no override exists.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on query failure or [`DbError::Serialise`] if
-/// the stored override map is malformed.
-pub async fn reset_pattern_for(pool: &SqlitePool, class: FrameTypeClass) -> DbResult<()> {
-    let mut overrides = get_patterns_by_type(pool).await?;
-    if overrides.remove(class.as_str()).is_none() {
-        return Ok(());
-    }
-    let value = serde_json::to_value(&overrides).map_err(DbError::Serialise)?;
-    set_raw(pool, PATTERNS_BY_TYPE_KEY, &value).await
-}
-
 // ── Per-source overrides ──────────────────────────────────────────────────
 
 /// Upsert a per-source override.
@@ -371,36 +329,10 @@ pub async fn get_source_override_raw(
     Ok(row.map(|(Json(v),)| v))
 }
 
-/// List all source overrides for a given source.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on query failure.
-pub async fn list_source_overrides(
-    pool: &SqlitePool,
-    source_id: &str,
-) -> DbResult<Vec<SourceOverride>> {
-    let rows: Vec<(String, Json<Value>, String)> = sqlx::query_as(
-        "SELECT key, value, updated_at FROM source_overrides WHERE source_id = ? ORDER BY key ASC",
-    )
-    .bind(source_id)
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows
-        .into_iter()
-        .map(|(key, Json(v), updated_at)| SourceOverride {
-            source_id: source_id.to_owned(),
-            key,
-            value: domain_core::JsonAny::from(v),
-            updated_at,
-        })
-        .collect())
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use patterns::FrameTypeClass;
     use persistence_core::test_support::setup_db;
 
     #[tokio::test]
@@ -558,7 +490,9 @@ mod tests {
     #[tokio::test]
     async fn patterns_by_type_override_read_back() {
         let db = setup_db().await;
-        set_pattern_for(db.pool(), FrameTypeClass::Dark, "custom/{gain}/").await.unwrap();
+        set_raw(db.pool(), PATTERNS_BY_TYPE_KEY, &serde_json::json!({"dark": "custom/{gain}/"}))
+            .await
+            .unwrap();
         let got = effective_pattern_for(db.pool(), "dark", false).await.unwrap();
         assert_eq!(got.as_deref(), Some("custom/{gain}/"));
         // Other classes are untouched.
@@ -569,23 +503,19 @@ mod tests {
     #[tokio::test]
     async fn patterns_by_type_master_routing() {
         let db = setup_db().await;
-        set_pattern_for(db.pool(), FrameTypeClass::MasterDark, "m/{exposure}/").await.unwrap();
+        set_raw(
+            db.pool(),
+            PATTERNS_BY_TYPE_KEY,
+            &serde_json::json!({"master_dark": "m/{exposure}/"}),
+        )
+        .await
+        .unwrap();
         // is_master = true selects the master class.
         let master = effective_pattern_for(db.pool(), "dark", true).await.unwrap();
         assert_eq!(master.as_deref(), Some("m/{exposure}/"));
         // raw dark still defaults.
         let raw = effective_pattern_for(db.pool(), "dark", false).await.unwrap();
         assert_eq!(raw.as_deref(), Some(default_pattern(FrameTypeClass::Dark)));
-    }
-
-    #[tokio::test]
-    async fn set_pattern_rejects_invalid() {
-        let db = setup_db().await;
-        assert!(set_pattern_for(db.pool(), FrameTypeClass::Bias, "{telescope}/").await.is_err());
-        assert!(set_pattern_for(db.pool(), FrameTypeClass::Bias, "").await.is_err());
-        // Nothing persisted on rejection → still the default.
-        let got = effective_pattern_for(db.pool(), "bias", false).await.unwrap();
-        assert_eq!(got.as_deref(), Some(default_pattern(FrameTypeClass::Bias)));
     }
 
     #[tokio::test]
@@ -605,12 +535,15 @@ mod tests {
     #[tokio::test]
     async fn reset_pattern_restores_default() {
         let db = setup_db().await;
-        set_pattern_for(db.pool(), FrameTypeClass::Light, "{target}/x/").await.unwrap();
-        reset_pattern_for(db.pool(), FrameTypeClass::Light).await.unwrap();
+        // Set an override for light, then clear all overrides via delete_key.
+        set_raw(db.pool(), PATTERNS_BY_TYPE_KEY, &serde_json::json!({"light": "{target}/x/"}))
+            .await
+            .unwrap();
+        delete_key(db.pool(), PATTERNS_BY_TYPE_KEY).await.unwrap();
         let got = effective_pattern_for(db.pool(), "light", false).await.unwrap();
         assert_eq!(got.as_deref(), Some(default_pattern(FrameTypeClass::Light)));
-        // reset is idempotent.
-        reset_pattern_for(db.pool(), FrameTypeClass::Light).await.unwrap();
+        // delete is idempotent.
+        delete_key(db.pool(), PATTERNS_BY_TYPE_KEY).await.unwrap();
     }
 
     #[tokio::test]
@@ -622,7 +555,9 @@ mod tests {
     #[tokio::test]
     async fn load_settings_applies_patterns_by_type() {
         let db = setup_db().await;
-        set_pattern_for(db.pool(), FrameTypeClass::Flat, "f/{filter}/").await.unwrap();
+        set_raw(db.pool(), PATTERNS_BY_TYPE_KEY, &serde_json::json!({"flat": "f/{filter}/"}))
+            .await
+            .unwrap();
         let state = load_settings(db.pool()).await.unwrap();
         assert_eq!(state.patterns_by_type.get("flat").map(String::as_str), Some("f/{filter}/"));
     }

--- a/crates/persistence/plans/src/repositories/artifacts.rs
+++ b/crates/persistence/plans/src/repositories/artifacts.rs
@@ -415,20 +415,6 @@ pub async fn clear_override(pool: &SqlitePool, artifact_id: &str) -> DbResult<Op
     Ok(prior)
 }
 
-/// Fetch the override row for an artifact, if any.
-///
-/// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
-pub async fn get_override(pool: &SqlitePool, artifact_id: &str) -> DbResult<Option<OverrideRow>> {
-    let row = sqlx::query_as::<_, OverrideRow>(
-        "SELECT * FROM classification_overrides WHERE artifact_id = ?",
-    )
-    .bind(artifact_id)
-    .fetch_optional(pool)
-    .await?;
-    Ok(row)
-}
-
 // ── tool_launches completion (T022c) ──────────────────────────────────────────
 
 /// Set `tool_launches.completed_at` when the attribution pass determines a run
@@ -548,19 +534,16 @@ mod tests {
             .unwrap();
         upsert_override(pool, "a1", "final", Some("manual inspection")).await.unwrap();
 
-        let ov = get_override(pool, "a1").await.unwrap().expect("override should exist");
-        assert_eq!(ov.kind, "final");
-
-        // Check the main row was updated too.
+        // Main row updated by upsert_override.
         let row = get_artifact_by_path(pool, "p1", "out/img.xisf").await.unwrap().unwrap();
         assert_eq!(row.kind, "final");
         assert_eq!(row.classification_source, "manual_override");
         assert!((row.classification_confidence - 1.0_f64).abs() < f64::EPSILON);
 
-        // Clear the override.
+        // Clear the override — clear_override returns the deleted row.
         let cleared = clear_override(pool, "a1").await.unwrap();
         assert!(cleared.is_some());
-        assert!(get_override(pool, "a1").await.unwrap().is_none());
+        assert_eq!(cleared.unwrap().kind, "final");
     }
 
     #[tokio::test]

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -509,21 +509,6 @@ pub async fn append_event(
 
 // ── Queries ───────────────────────────────────────────────────────────────────
 
-/// Fetch a plan apply run by id.
-///
-/// # Errors
-///
-/// Returns [`DbError::NotFound`] if no run matches.
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn get_run(pool: &SqlitePool, run_id: &str) -> DbResult<PlanApplyRunRow> {
-    let row: Option<PlanApplyRunRow> = sqlx::query_as("SELECT * FROM plan_apply_runs WHERE id = ?")
-        .bind(run_id)
-        .fetch_optional(pool)
-        .await?;
-
-    row.ok_or_else(|| DbError::NotFound(format!("run {run_id}")))
-}
-
 /// Fetch the most recent active (paused or applying) run for a plan.
 ///
 /// Returns `None` if no run is in-progress.
@@ -540,18 +525,6 @@ pub async fn get_active_run(pool: &SqlitePool, plan_id: &str) -> DbResult<Option
     .bind(plan_id)
     .fetch_optional(pool)
     .await?)
-}
-
-/// List all apply events for a plan in chronological order.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub async fn list_events(pool: &SqlitePool, plan_id: &str) -> DbResult<Vec<PlanApplyEventRow>> {
-    Ok(sqlx::query_as("SELECT * FROM plan_apply_events WHERE plan_id = ? ORDER BY at ASC")
-        .bind(plan_id)
-        .fetch_all(pool)
-        .await?)
 }
 
 /// Fetch the plan item whose CAS mismatch most recently triggered a pause
@@ -1030,7 +1003,7 @@ mod tests {
         let plan = plans_repo::get_plan(db.pool(), "p1", false).await.unwrap();
         assert_eq!(plan.state, "applying");
 
-        let run = get_run(db.pool(), "run-1").await.unwrap();
+        let run = get_active_run(db.pool(), "p1").await.unwrap().expect("run should exist");
         assert_eq!(run.plan_id, "p1");
         assert_eq!(run.items_total, 2);
     }
@@ -1127,34 +1100,6 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn append_and_list_events() {
-        let db = Database::in_memory().await.unwrap();
-        db.migrate().await.unwrap();
-        setup_with_approved_plan(&db, "p5", 1).await;
-        cas_approved_to_applying(db.pool(), "p5", "run-5", "tok", 1, 1).await.unwrap();
-
-        append_event(
-            db.pool(),
-            "evt-1",
-            "run-5",
-            "p5",
-            Some("p5-item-0"),
-            "pending",
-            "applying",
-            "2026-06-01T00:00:00Z",
-            None,
-            None,
-        )
-        .await
-        .unwrap();
-
-        let events = list_events(db.pool(), "p5").await.unwrap();
-        assert_eq!(events.len(), 1);
-        assert_eq!(events[0].prior_state, "pending");
-        assert_eq!(events[0].new_state, "applying");
-    }
-
-    #[tokio::test]
     async fn sweep_crashed_applying_plans_transitions_to_paused() {
         let db = Database::in_memory().await.unwrap();
         db.migrate().await.unwrap();
@@ -1171,7 +1116,7 @@ mod tests {
         let plan = plans_repo::get_plan(db.pool(), "pc1", false).await.unwrap();
         assert_eq!(plan.state, "paused", "crash-applying plan must become paused");
 
-        let run = get_run(db.pool(), "run-c1").await.unwrap();
+        let run = get_active_run(db.pool(), "pc1").await.unwrap().expect("run should exist");
         assert_eq!(run.terminal_state, Some("paused".to_owned()));
         assert_eq!(run.pause_reason, Some("crash".to_owned()));
     }
@@ -1191,7 +1136,7 @@ mod tests {
         let plan = plans_repo::get_plan(db.pool(), "pp1", false).await.unwrap();
         assert_eq!(plan.state, "paused");
         // pause_reason stays 'item.stale', not overwritten to 'crash'.
-        let run = get_run(db.pool(), "run-pp1").await.unwrap();
+        let run = get_active_run(db.pool(), "pp1").await.unwrap().expect("run should exist");
         assert_eq!(run.pause_reason, Some("item.stale".to_owned()));
     }
 
@@ -1208,8 +1153,12 @@ mod tests {
         assert_eq!(plan.state, "applied");
         assert_eq!(plan.items_applied, 2);
 
-        let run = get_run(db.pool(), "run-6").await.unwrap();
-        assert_eq!(run.terminal_state, Some("applied".to_owned()));
+        let terminal: Option<String> =
+            sqlx::query_scalar("SELECT terminal_state FROM plan_apply_runs WHERE id = 'run-6'")
+                .fetch_optional(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(terminal.as_deref(), Some("applied"));
     }
 
     /// batch_flush_item_states must set item_stale=1 for stale items so

--- a/crates/persistence/plans/src/repositories/plans.rs
+++ b/crates/persistence/plans/src/repositories/plans.rs
@@ -472,20 +472,6 @@ pub async fn soft_delete_plan(
     Ok(())
 }
 
-/// Update `approved_mtime` and `approved_size_bytes` on all pending items of a
-/// plan (R-FS-1). Called at approve time to snapshot the source filesystem state.
-///
-/// The actual per-item snapshots are written via [`update_item_fs_snapshot`].
-/// This function exists as a coordination point; callers iterate items and call
-/// `update_item_fs_snapshot` per item after performing the filesystem stat.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on connection failure.
-pub fn snapshot_item_fs_metadata_noop(_pool: &SqlitePool, _plan_id: &str, _approved_at: &str) {
-    // No-op: callers use update_item_fs_snapshot per-item (R-FS-1).
-}
-
 /// Update per-item FS snapshot fields (R-FS-1).
 ///
 /// # Errors

--- a/crates/persistence/plans/src/repositories/q_projects.rs
+++ b/crates/persistence/plans/src/repositories/q_projects.rs
@@ -10,19 +10,6 @@ use sqlx::SqlitePool;
 
 use persistence_core::DbResult;
 
-/// Whether a `file_record` row exists for `id` (spec 026 regenerate: checks
-/// inventory resolution before re-linking a prepared view item).
-///
-/// # Errors
-/// Returns [`crate::DbError::Database`] on query failure.
-pub async fn file_record_exists(pool: &SqlitePool, id: &str) -> DbResult<bool> {
-    let exists: bool = sqlx::query_scalar("SELECT COUNT(*) > 0 FROM file_record WHERE id = ?")
-        .bind(id)
-        .fetch_one(pool)
-        .await?;
-    Ok(exists)
-}
-
 /// `(relative_path, state)` for a `file_record` row (spec 049 generation:
 /// resolves a session's frame ids to their current path + presence state).
 /// Returns `None` when no row exists.

--- a/crates/persistence/plans/src/repositories/source_protection.rs
+++ b/crates/persistence/plans/src/repositories/source_protection.rs
@@ -49,12 +49,6 @@ pub struct ResolvedProtection {
     pub inherits_default: bool,
 }
 
-// ── Global defaults fallback ──────────────────────────────────────────────
-
-const DEFAULT_LEVEL: &str = "protected";
-const DEFAULT_BLOCK_PERMANENT_DELETE: bool = true;
-const DEFAULT_CATEGORIES: &[&str] = &["lights", "masters", "finals"];
-
 // ── Helpers ───────────────────────────────────────────────────────────────
 
 fn parse_categories(json: Option<&str>) -> DbResult<Vec<String>> {
@@ -135,19 +129,6 @@ pub async fn get_source_protection_row(
     Ok(row)
 }
 
-/// Delete the per-source override row, reverting to global default inheritance.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on query failure.
-pub async fn delete_source_protection(pool: &SqlitePool, source_id: &str) -> DbResult<()> {
-    sqlx::query("DELETE FROM source_protection_state WHERE source_id = ?")
-        .bind(source_id)
-        .execute(pool)
-        .await?;
-    Ok(())
-}
-
 /// Resolve effective protection for a source.
 ///
 /// Implements the precedence rule from data-model.md §Resolver:
@@ -204,15 +185,6 @@ pub async fn resolve_protection(
 }
 
 // ── Protection defaults (migration 0035, FR-018) ─────────────────────────
-
-/// Raw DB row from the `protection_defaults` table.
-#[derive(Clone, Debug, sqlx::FromRow)]
-pub struct ProtectionDefaultRow {
-    pub scope: String,
-    pub key: String,
-    pub value: String,
-    pub updated_at: String,
-}
 
 /// Get the raw JSON value for a specific (scope, key) protection default.
 ///
@@ -296,49 +268,6 @@ pub async fn set_protection_default_with_conn(
     Ok(())
 }
 
-/// List all protection defaults for a given scope.
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] on query failure.
-pub async fn list_protection_defaults(
-    pool: &SqlitePool,
-    scope: &str,
-) -> DbResult<Vec<ProtectionDefaultRow>> {
-    let rows: Vec<ProtectionDefaultRow> = sqlx::query_as(
-        "SELECT scope, key, value, updated_at FROM protection_defaults WHERE scope = ? ORDER BY key ASC",
-    )
-    .bind(scope)
-    .fetch_all(pool)
-    .await?;
-
-    Ok(rows)
-}
-
-/// Resolve effective protection using hard-coded fallback defaults.
-///
-/// Used when global settings row is absent (e.g. first run before migration).
-///
-/// # Errors
-///
-/// Returns [`DbError::Database`] or [`DbError::Serialise`] on failure.
-pub async fn resolve_protection_with_fallback(
-    pool: &SqlitePool,
-    source_id: &str,
-    category: Option<&str>,
-) -> DbResult<ResolvedProtection> {
-    let defaults: Vec<String> = DEFAULT_CATEGORIES.iter().map(|s| (*s).to_owned()).collect();
-    resolve_protection(
-        pool,
-        source_id,
-        category,
-        DEFAULT_LEVEL,
-        DEFAULT_BLOCK_PERMANENT_DELETE,
-        &defaults,
-    )
-    .await
-}
-
 // ── Tests ─────────────────────────────────────────────────────────────────
 
 #[cfg(test)]
@@ -384,20 +313,6 @@ mod tests {
 
         assert_eq!(row.level, "unprotected");
         assert_eq!(row.block_permanent_delete, Some(1));
-    }
-
-    #[tokio::test]
-    async fn delete_removes_row() {
-        let db = setup_db().await;
-        let source_id = "src-003";
-
-        upsert_source_protection(db.pool(), source_id, "unprotected", None, None, "user")
-            .await
-            .unwrap();
-        delete_source_protection(db.pool(), source_id).await.unwrap();
-
-        let row = get_source_protection_row(db.pool(), source_id).await.unwrap();
-        assert!(row.is_none());
     }
 
     #[tokio::test]

--- a/crates/persistence/targets/src/repositories/inventory.rs
+++ b/crates/persistence/targets/src/repositories/inventory.rs
@@ -426,52 +426,6 @@ pub async fn list_session_cameras(
     Ok(rows)
 }
 
-/// Set `root_id` on an `acquisition_session` row (T036, FR-012).
-///
-/// Called when the inbox confirm pipeline resolves the root for a session.
-/// Only updates rows where `root_id IS NULL` to avoid overwriting a correctly
-/// set root with a different one.
-///
-/// # Errors
-/// Returns [`DbError::Database`] on query failure.
-pub async fn update_acquisition_session_root_id(
-    pool: &SqlitePool,
-    session_id: &str,
-    root_id: &str,
-) -> DbResult<()> {
-    sqlx::query(
-        "UPDATE acquisition_session SET root_id = ? \
-         WHERE id = ? AND root_id IS NULL",
-    )
-    .bind(root_id)
-    .bind(session_id)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
-/// Set `root_id` on a `calibration_session` row (T036, FR-012).
-///
-/// See [`update_acquisition_session_root_id`] for semantics.
-///
-/// # Errors
-/// Returns [`DbError::Database`] on query failure.
-pub async fn update_calibration_session_root_id(
-    pool: &SqlitePool,
-    session_id: &str,
-    root_id: &str,
-) -> DbResult<()> {
-    sqlx::query(
-        "UPDATE calibration_session SET root_id = ? \
-         WHERE id = ? AND root_id IS NULL",
-    )
-    .bind(root_id)
-    .bind(session_id)
-    .execute(pool)
-    .await?;
-    Ok(())
-}
-
 /// Write `notes` to whichever session table owns `session_id` — an
 /// inventory session id is always exactly one of `acquisition_session` or
 /// `calibration_session` (spec 006 union), so this tries the acquisition

--- a/crates/targeting/src/coords.rs
+++ b/crates/targeting/src/coords.rs
@@ -12,21 +12,20 @@
 //! No DB, no I/O, no spatial-index dependency — a bounded linear scan over the
 //! (small) target catalog is sufficient (Constitution: keep dependencies
 //! deliberate; the target DB is small). The caller (`app_core_inbox`) is
-//! responsible for loading the pointing + catalog and for choosing the radius
-//! (FOV-aware via [`fov_radius_deg`], or the configurable fixed fallback).
+//! responsible for loading the pointing and the radius (FOV-aware via
+//! `field_from_optics`, or the configurable fixed fallback).
 //!
 //! # Why coordinates, never `OBJECT`
 //!
 //! R-17: the free-text `OBJECT`/`OBJCTNAME` header is set in capture software
 //! (NINA etc.) and is inconsistent. Matching is done **only** by sky position;
 //! `OBJECT` is carried by the caller as a display hint and never enters this
-//! module. There is deliberately no name parameter on [`TargetCoord`] beyond the
-//! display `name`, and nothing here compares names.
+//! module.
 
 #![allow(clippy::doc_markdown)] // domain terminology (RA/Dec, FOV) is not backtick-suited
 
 use skymath::Equatorial;
-use target_match::{Field, Optics, RadiusPolicy};
+use target_match::{Field, Optics};
 
 /// A sky pointing in ICRS J2000 decimal degrees.
 ///
@@ -50,36 +49,6 @@ impl Pointing {
     pub const fn new(ra_deg: f64, dec_deg: f64) -> Self {
         Self { ra_deg, dec_deg }
     }
-}
-
-/// One catalog entry to rank against a pointing.
-///
-/// `target_id` is the persisted `canonical_target.id` (a UUID string here so the
-/// pure crate stays free of the `uuid` dependency for ranking); `name` is the
-/// display designation. `ra_deg`/`dec_deg` are the catalog coordinates in
-/// decimal degrees.
-#[derive(Clone, Debug, PartialEq)]
-pub struct TargetCoord {
-    /// Persisted canonical-target id (opaque to this module).
-    pub target_id: String,
-    /// Display designation / effective label.
-    pub name: String,
-    /// Catalog right ascension, decimal degrees.
-    pub ra_deg: f64,
-    /// Catalog declination, decimal degrees.
-    pub dec_deg: f64,
-}
-
-/// A ranked recommendation: a catalog entry plus its angular separation (deg)
-/// from the queried pointing.
-#[derive(Clone, Debug, PartialEq)]
-pub struct Candidate {
-    /// Persisted canonical-target id.
-    pub target_id: String,
-    /// Display designation / effective label.
-    pub name: String,
-    /// Great-circle angular separation from the pointing, in decimal degrees.
-    pub separation_deg: f64,
 }
 
 /// Great-circle angular separation between two pointings, in decimal degrees.
@@ -151,74 +120,11 @@ pub fn field_from_optics(
     .ok()
 }
 
-/// Compute a FOV-aware search radius (decimal degrees) from optics + sensor.
-///
-/// The radius is **half the sensor diagonal field of view** (`target_match`'s
-/// [`RadiusPolicy::Circumscribed`]), so any catalog target whose true position
-/// lies anywhere on the frame is inside the radius regardless of where in the
-/// frame it sits. See [`field_from_optics`] for the underlying geometry.
-///
-/// Returns `None` when [`field_from_optics`] does (missing/non-positive input,
-/// or `naxis1`/`naxis2` overflowing `u32`), so the caller can fall back to the
-/// configurable fixed radius (R-17 C5).
-#[must_use]
-pub fn fov_radius_deg(
-    focal_length_mm: Option<f64>,
-    pixel_size_um: Option<f64>,
-    naxis1: Option<i64>,
-    naxis2: Option<i64>,
-) -> Option<f64> {
-    field_from_optics(focal_length_mm, pixel_size_um, naxis1, naxis2)
-        .map(|f| f.radius(RadiusPolicy::Circumscribed).degrees())
-}
-
-/// Rank catalog targets by angular separation from `pointing`, keeping only
-/// those within `radius_deg` (inclusive), ascending (nearest first).
-///
-/// Ties on separation break deterministically by `name` then `target_id` so the
-/// ordering is stable across runs. A non-finite or negative `radius_deg` yields
-/// an empty list. This is a bounded linear scan — no spatial index.
-#[must_use]
-pub fn rank_candidates(
-    pointing: Pointing,
-    targets: &[TargetCoord],
-    radius_deg: f64,
-) -> Vec<Candidate> {
-    if !radius_deg.is_finite() || radius_deg < 0.0 {
-        return Vec::new();
-    }
-
-    let mut hits: Vec<Candidate> = targets
-        .iter()
-        .filter_map(|t| {
-            let sep = angular_separation_deg(pointing, Pointing::new(t.ra_deg, t.dec_deg));
-            (sep <= radius_deg).then(|| Candidate {
-                target_id: t.target_id.clone(),
-                name: t.name.clone(),
-                separation_deg: sep,
-            })
-        })
-        .collect();
-
-    hits.sort_by(|a, b| {
-        a.separation_deg
-            .partial_cmp(&b.separation_deg)
-            .unwrap_or(std::cmp::Ordering::Equal)
-            .then_with(|| a.name.cmp(&b.name))
-            .then_with(|| a.target_id.cmp(&b.target_id))
-    });
-    hits
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
     const M31: Pointing = Pointing::new(10.684_708, 41.268_75);
-
-    fn target(id: &str, name: &str, ra: f64, dec: f64) -> TargetCoord {
-        TargetCoord { target_id: id.to_owned(), name: name.to_owned(), ra_deg: ra, dec_deg: dec }
-    }
 
     // ── angular_separation_deg ────────────────────────────────────────────────
 
@@ -267,121 +173,6 @@ mod tests {
         let b = Pointing::new(180.0, 0.0);
         let sep = angular_separation_deg(a, b);
         assert!((sep - 180.0).abs() < 1e-6, "expected 180°, got {sep}");
-    }
-
-    // ── fov_radius_deg ────────────────────────────────────────────────────────
-
-    #[test]
-    fn fov_radius_from_optics() {
-        // ASI2600 (3.76µm, 6248×4176) on an 800mm scope.
-        // pixel scale = 206.265*3.76/800 ≈ 0.9694"/px
-        // width ≈ 0.9694*6248/3600 ≈ 1.683°, height ≈ 0.9694*4176/3600 ≈ 1.125°
-        // radius = hypot(1.683,1.125)/2 ≈ 1.012°
-        let r = fov_radius_deg(Some(800.0), Some(3.76), Some(6248), Some(4176)).unwrap();
-        assert!((0.95..1.07).contains(&r), "expected ~1.01°, got {r}");
-    }
-
-    #[test]
-    fn fov_radius_none_when_pixel_size_absent() {
-        // R-17: pixel size unavailable ⇒ no FOV radius ⇒ caller uses fixed fallback.
-        assert!(fov_radius_deg(Some(800.0), None, Some(6248), Some(4176)).is_none());
-    }
-
-    #[test]
-    fn fov_radius_none_when_any_input_missing_or_nonpositive() {
-        assert!(fov_radius_deg(None, Some(3.76), Some(6248), Some(4176)).is_none());
-        assert!(fov_radius_deg(Some(800.0), Some(3.76), None, Some(4176)).is_none());
-        assert!(fov_radius_deg(Some(800.0), Some(3.76), Some(6248), None).is_none());
-        assert!(fov_radius_deg(Some(0.0), Some(3.76), Some(6248), Some(4176)).is_none());
-        assert!(fov_radius_deg(Some(800.0), Some(-1.0), Some(6248), Some(4176)).is_none());
-        assert!(fov_radius_deg(Some(800.0), Some(3.76), Some(0), Some(4176)).is_none());
-    }
-
-    // ── rank_candidates ───────────────────────────────────────────────────────
-
-    fn sample_catalog() -> Vec<TargetCoord> {
-        vec![
-            target("id-m31", "M 31", 10.684_708, 41.268_75),
-            target("id-m110", "M 110", 10.092_08, 41.685_28),
-            target("id-m33", "M 33", 23.462_1, 30.659_9), // ~14.7° away
-            target("id-m42", "M 42", 83.822_08, -5.391_11), // far side of sky
-        ]
-    }
-
-    #[test]
-    fn ranks_ascending_within_radius() {
-        let cat = sample_catalog();
-        // 2° radius keeps M31 (self, 0°) and M110 (~0.62°); excludes M33 & M42.
-        let out = rank_candidates(M31, &cat, 2.0);
-        assert_eq!(out.len(), 2, "only M31 + M110 within 2°, got {out:?}");
-        assert_eq!(out[0].target_id, "id-m31");
-        assert!(out[0].separation_deg < 1e-6, "nearest is the exact match");
-        assert_eq!(out[1].target_id, "id-m110");
-        assert!(out[0].separation_deg <= out[1].separation_deg, "ascending order");
-    }
-
-    #[test]
-    fn excludes_targets_outside_radius() {
-        let cat = sample_catalog();
-        // A tight 0.1° radius keeps only the exact-match M31.
-        let out = rank_candidates(M31, &cat, 0.1);
-        assert_eq!(out.len(), 1);
-        assert_eq!(out[0].target_id, "id-m31");
-    }
-
-    #[test]
-    fn radius_boundary_is_inclusive() {
-        let cat = vec![target("id-a", "A", 101.0, 0.0)];
-        let probe = Pointing::new(100.0, 0.0); // ~1° away
-                                               // Use the exact computed separation as the radius: sep <= radius must
-                                               // include it (boundary is inclusive). Comparing against a hand-written
-                                               // 1.0 would be brittle since haversine(1°) lands a few ULPs off 1.0.
-        let sep = angular_separation_deg(probe, Pointing::new(101.0, 0.0));
-        assert_eq!(rank_candidates(probe, &cat, sep).len(), 1, "sep == radius is included");
-        assert_eq!(
-            rank_candidates(probe, &cat, sep - 1e-9).len(),
-            0,
-            "just inside the radius excludes a target fractionally outside it"
-        );
-    }
-
-    #[test]
-    fn empty_when_radius_negative_or_nan() {
-        let cat = sample_catalog();
-        assert!(rank_candidates(M31, &cat, -1.0).is_empty());
-        assert!(rank_candidates(M31, &cat, f64::NAN).is_empty());
-    }
-
-    #[test]
-    fn empty_catalog_yields_no_candidates() {
-        assert!(rank_candidates(M31, &[], 10.0).is_empty());
-    }
-
-    #[test]
-    fn equal_separation_ties_break_by_name_then_id() {
-        // Two targets symmetric about the pointing → identical separation.
-        let probe = Pointing::new(50.0, 0.0);
-        let cat = vec![target("id-z", "Zeta", 51.0, 0.0), target("id-a", "Alpha", 49.0, 0.0)];
-        let out = rank_candidates(probe, &cat, 2.0);
-        assert_eq!(out.len(), 2);
-        // Equal separation → "Alpha" (id-a) sorts before "Zeta" (id-z).
-        assert_eq!(out[0].name, "Alpha");
-        assert_eq!(out[1].name, "Zeta");
-    }
-
-    /// OBJECT/name is NEVER a matching input: a catalog entry whose `name`
-    /// equals the (irrelevant) display string but whose coordinates are far
-    /// away is excluded by radius — only position decides membership.
-    #[test]
-    fn name_never_drives_matching_only_coordinates_do() {
-        // Catalog entry literally named "M 31" but parked at the wrong coords.
-        let mislabelled = target("id-wrong", "M 31", 200.0, -40.0);
-        let correct = target("id-right", "Some Galaxy", M31.ra_deg, M31.dec_deg);
-        let cat = vec![mislabelled, correct];
-
-        let out = rank_candidates(M31, &cat, 2.0);
-        assert_eq!(out.len(), 1, "the far 'M 31'-named entry must NOT match by name");
-        assert_eq!(out[0].target_id, "id-right", "only the coordinate match is returned");
     }
 
     // ── angular_separation_deg boundary / equivalence ────────────────────────

--- a/scripts/dead-callers-baseline.txt
+++ b/scripts/dead-callers-baseline.txt
@@ -4,21 +4,14 @@
 # Shrink-only. Removing a name (by wiring the function into its call path or
 # deleting it) is always fine. Adding one requires a comment explaining why the
 # function is legitimately unreferenced.
-default_label
-delete_source_protection
 emit_unarchive_transition
-file_record_exists
 # Uncalled by design pending epic astro-plan-v25w (#1370). Per PR #1364:
 # creating one equipment row per distinct header spelling mints sibling rows
 # for exactly the spellings an alias array exists to collapse.
 find_or_create_camera_by_alias
 find_or_create_filter_by_name
 find_or_create_telescope_by_alias
-fov_radius_deg
 get_library_root_state
-get_override
-get_run
-hard_violations_to_mismatched
 
 # astro-plan-xhj0: check-dead-callers.sh's corpus builder leaked out-of-line
 # `#[cfg(test)] mod name;` test files (sibling `name.rs` / `name/mod.rs`, no
@@ -33,26 +26,8 @@ insert_inbox_item
 # unreliable after a crashed partial warm (#818), so production gates on a
 # version sentinel instead. See crates/targeting/resolver/src/seed.rs:204-224.
 is_first_run
-list_events
-list_protection_defaults
-list_source_overrides
-merge_sessions
 parse_marker
-parse_mismatched_dimensions
-rank_candidates
-reset_pattern_for
-resolve_archive_destination
-resolve_protection_with_fallback
-reveal_failed
-set_manual_override
-set_pattern_for
-snapshot_item_fs_metadata_noop
-split_session
-sqlx_to_contract
-update_acquisition_session_root_id
-update_calibration_session_root_id
 validate_seeds
-video_record
 
 # astro-plan-bc4e: the pub-use-stripping fix to check-dead-callers.sh removed
 # a false "has a caller" signal that a `pub use` re-export line was producing


### PR DESCRIPTION
## Summary
- Deleted 25 dead functions (+is_video_file cascade), each superseded by a called sibling or a stub with no consumer; ~-799 lines.
- dead-callers baseline shrinks by 25; full cargo nextest --workspace (2940 passed, 0 failed) proves no live caller.

Tracks-Bead: astro-plan-paxd
Merge-Bead: astro-plan-ykbv