### PR TITLE
ci: attest build provenance for published bundles

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -77,6 +77,10 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: write # tauri-action publishes the release and uploads bundles
+      id-token: write # OIDC identity that signs the attestation
+      attestations: write # publish the attestation to this repo
     steps:
       - uses: actions/checkout@v4
 
@@ -136,6 +140,7 @@ jobs:
       #   - assetNamePattern renamed to artifactNamePattern: we don't use it.
       #   - Tauri v1/unstable support dropped: we are on Tauri 2 stable.
       - name: Build, sign, and upload Tauri bundles
+        id: tauri
         uses: tauri-apps/tauri-action@v1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -163,6 +168,68 @@ jobs:
           prerelease: false
           uploadUpdaterJson: true
           updaterJsonPreferNsis: true
+
+      # Build provenance for the bundles this matrix leg produced: a signed statement of
+      # which workflow run, at which commit, built these exact bytes. Complements the
+      # minisign updater signatures rather than replacing them — those are what the
+      # auto-updater checks against the app's embedded public key, offline and with no
+      # GitHub dependency. Verified with `gh attestation verify`.
+      #
+      # IMPORTANT on Windows: when ENABLE_WINDOWS_SIGNING is on, the sign-windows job
+      # below replaces the .exe/.msi on the release with Authenticode-signed copies via
+      # `--clobber`. Signing rewrites the file, so its digest changes and an attestation
+      # made here would NOT match what a user downloads. Those two extensions are
+      # therefore excluded here and attested in sign-windows instead, after signing.
+      # With signing off nothing clobbers them, so they are attested here.
+      #
+      # tauri-action emits artifactPaths as a JSON array STRING (its src/index.ts does
+      # JSON.stringify(artifacts.map(a => a.path))), which actions/attest cannot consume
+      # directly — subject-path wants a newline-separated list. Converting here also
+      # avoids hardcoding bundle filenames, which carry the version and would drift on
+      # every release.
+      - name: Collect artifact paths for attestation
+        id: subjects
+        shell: bash
+        env:
+          ARTIFACT_PATHS: ${{ steps.tauri.outputs.artifactPaths }}
+          # Only exclude the clobbered extensions on the leg that actually clobbers them.
+          SKIP_WINDOWS_BUNDLES: ${{ runner.os == 'Windows' && vars.ENABLE_WINDOWS_SIGNING == 'true' }}
+        run: |
+          # Drop .sig sidecars (signatures over the bundles, not artifacts in their own
+          # right) and latest.json (a pointer regenerated on every release, so a
+          # provenance claim over it ages out immediately).
+          filter='.[] | select(endswith(".sig") or endswith("latest.json") | not)'
+          if [ "${SKIP_WINDOWS_BUNDLES}" = "true" ]; then
+            filter="${filter} | select(endswith(\".exe\") or endswith(\".msi\") | not)"
+          fi
+          subjects="$(printf '%s' "${ARTIFACT_PATHS:-[]}" | jq -r "${filter}")"
+
+          # Fail loud rather than silently attesting nothing. If tauri-action changes its
+          # output shape, an empty list would leave every bundle unattested while the job
+          # still went green — the release would look provenance-covered when it was not.
+          # The Windows+signing leg is the one legitimate empty case: its only bundles are
+          # the .exe/.msi that sign-windows attests after signing.
+          if [ -z "${subjects}" ]; then
+            if [ "${SKIP_WINDOWS_BUNDLES}" = "true" ]; then
+              echo "No non-Windows bundles on this leg; .exe/.msi are attested in sign-windows."
+            else
+              echo "::error::no bundles found in artifactPaths; refusing to attest an empty subject set"
+              echo "artifactPaths was: ${ARTIFACT_PATHS:-<unset>}"
+              exit 1
+            fi
+          fi
+
+          {
+            echo 'paths<<SUBJECTS_EOF'
+            echo "${subjects}"
+            echo 'SUBJECTS_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Attest build provenance
+        if: ${{ steps.subjects.outputs.paths != '' }}
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: ${{ steps.subjects.outputs.paths }}
 
       # Windows bundles above carry only the minisign updater signature, not an
       # Authenticode signature — Windows SmartScreen still shows "Unknown
@@ -197,6 +264,10 @@ jobs:
     needs: [release-please, build]
     if: ${{ needs.release-please.outputs.release_created == 'true' && vars.ENABLE_WINDOWS_SIGNING == 'true' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # gh release upload --clobber
+      id-token: write # OIDC identity that signs the attestation
+      attestations: write # publish the attestation to this repo
     steps:
       - name: Download unsigned Windows bundles
         uses: actions/download-artifact@v4
@@ -231,6 +302,18 @@ jobs:
           github-artifact-id: ${{ steps.upload-for-signing.outputs.artifact-id }}
           wait-for-completion: true
           output-artifact-directory: signed
+
+      # Attest the SIGNED bundles, and do it before the upload below. Authenticode
+      # signing rewrites the file, so these digests differ from the unsigned copies the
+      # build job produced — which is exactly why build/ skips .exe/.msi when this job is
+      # enabled. Attesting here means the provenance matches the bytes that actually end
+      # up on the release.
+      - name: Attest signed Windows bundles
+        uses: actions/attest@f7c74d28b9d84cb8768d0b8ca14a4bac6ef463e6 # v4.2.0
+        with:
+          subject-path: |
+            signed/*.exe
+            signed/*.msi
 
       # tauri-action already uploaded unsigned copies of these files to the
       # release in the `build` job; --clobber replaces them in place with the

--- a/README.md
+++ b/README.md
@@ -76,6 +76,25 @@ signed with an OS-level code-signing certificate yet, so:
   developer" — right-click the app → "Open", or clear the quarantine
   attribute (`xattr -d com.apple.quarantine PlateVault.app`).
 
+### Verifying a download
+
+Every published bundle carries a GitHub build provenance attestation — a signed
+statement of which workflow run, at which commit, produced those exact bytes. Check
+one with the [GitHub CLI](https://cli.github.com/):
+
+```bash
+gh attestation verify PlateVault_x64-setup.exe -R platevault/platevault
+gh attestation verify PlateVault_amd64.AppImage -R platevault/platevault
+```
+
+Verification contacts GitHub, since the attestation is stored with the repository
+rather than alongside the download. Add `--format json` for the full predicate.
+
+This is independent of the minisign signatures above: those are what the built-in
+auto-updater checks against the app's embedded public key, and they work offline. The
+attestation records where a build came from; the `.sig` establishes that an update is
+genuine. Neither replaces the other.
+
 ## Build from source
 
 Requires [pnpm](https://pnpm.io) and a [Rust](https://www.rust-lang.org)


### PR DESCRIPTION
Adds [GitHub artifact attestations](https://docs.github.com/en/actions/how-tos/secure-your-work/use-artifact-attestations/use-artifact-attestations) so every published bundle carries a signed statement of which workflow run, at which commit, produced those exact bytes.

```console
$ gh attestation verify PlateVault_x64-setup.exe  -R platevault/platevault
$ gh attestation verify PlateVault_amd64.AppImage -R platevault/platevault
```

## The attestation is split across two jobs, because signing changes the artifact

This is the part worth reviewing carefully. `sign-windows` replaces the `.exe`/`.msi` on the release with Authenticode-signed copies via `gh release upload --clobber`. **Signing rewrites the file, so its digest changes.** An attestation made in `build` would therefore describe bytes that no longer exist on the release — and the failure would be silent, because both jobs would still go green and `gh attestation verify` would only fail later, for a user.

So:

| Job | Attests |
|---|---|
| `build` | `.deb`, `.rpm`, `.AppImage`, `.dmg` — plus `.exe`/`.msi` **only when Authenticode signing is off** |
| `sign-windows` | the **signed** `.exe`/`.msi`, before the clobbering upload |

The exclusion in `build` is gated on the same `ENABLE_WINDOWS_SIGNING` variable as the signing job itself, so the two cannot disagree about which leg owns those files. With signing off, nothing clobbers them and `build` attests them normally.

Both jobs gain `id-token: write` + `attestations: write`. `actions/attest` is SHA-pinned to `f7c74d2` (v4.2.0).

## The artifactPaths conversion

`tauri-action` emits `artifactPaths` as a **JSON array string**, not a newline-separated list. Confirmed in its source rather than inferred — `src/index.ts` does:

```js
core.setOutput('artifactPaths', JSON.stringify(artifacts.map((a) => a.path)))
```

`subject-path` wants newlines, so a conversion step handles it. That also avoids hardcoding bundle filenames, which carry the version and would drift every release. Filtered out: `.sig` sidecars (signatures over the bundles, not artifacts in their own right) and `latest.json` (a pointer regenerated per release, so a provenance claim over it ages out immediately).

## It fails loud on an empty subject set

Without this, a future change to `tauri-action`'s output shape would leave bundles unattested while the job stayed green — the release would *look* provenance-covered when it was not. The one legitimate empty case (Windows with signing enabled, whose only bundles are the `.exe`/`.msi` that `sign-windows` attests) is handled explicitly rather than by suppressing the check.

## This does not touch minisign updater signing

Those `.sig` files are what the built-in auto-updater checks against the app's embedded public key, offline and without contacting GitHub. The attestation records where a build came from; the `.sig` establishes that an update is genuine. Neither replaces the other. The README's existing code-signing paragraph was extended rather than duplicated.

## Validation

- `actionlint` clean.
- The `jq` filter and fail-loud branch were simulated against realistic `artifactPaths` payloads for **all four** combinations: Windows + signing on (correctly empty, deferred to `sign-windows`), Windows + signing off (attests `.exe` + `.msi`), Linux (`.deb` / `.AppImage` / `.rpm`), and a broken-output case (exits 1).
- This repo's own `pre-commit` suite passes on the changed files (yaml, gitleaks, typos, whitespace).
- Attestation needs GitHub OIDC and cannot be exercised locally, so **the first release after merge is the real proof** — worth watching that run, particularly whether the Windows digests line up if `ENABLE_WINDOWS_SIGNING` is ever turned on.


Tracks-Bead: astro-plan-ey62
Merge-Bead: astro-plan-bn9f
