### PR TITLE
fix: command palette finds targets by alias again

### DIFF
--- a/apps/desktop/src/app/CommandPalette.test.tsx
+++ b/apps/desktop/src/app/CommandPalette.test.tsx
@@ -2,12 +2,8 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * CommandPalette T008 integration tests — alias-aware target search routing.
- *
- * Logic-layer tests validate:
- *   - search results are filtered/routed correctly
- *   - target results produced by searchGlobal have the right shape
- *   - the navigate call receives the verbatim route from the result
+ * CommandPalette tests — target search wiring, PAGES route guards, and rendered
+ * smoke coverage.
  *
  * Rendered smoke tests (#581 review) mount the real palette with a local
  * ResizeObserver/scrollIntoView stub (cmdk + @base-ui-components/react/dialog
@@ -15,27 +11,12 @@
  * the initialFocus fix, and ArrowDown+Enter keyboard navigation. Pixel-level
  * visual verification stays with Playwright (WSL constraint).
  *
- * Tests:
- *  1. Target search result routes start with /targets/
- *  2. Alias-matched result sublabel surfaces the matched alias
- *  3. Navigate receives the full /targets/<uuid> route string
- *  4. Non-target results are not routed to /targets/
- *  5. Empty query does not trigger searchGlobal
- *  6. Debounce: searchGlobal not called immediately on input change
- *  7. Real PAGES constant includes Targets (list page, not detail — T007)
- *  8. Real PAGES does not include a /targets/:id or /targets/$id pattern
- *  9. Real PAGES routes contain no path params
- * 10. Real PAGES label thunks resolve to non-empty strings
+ * PAGES tests import the constant directly from CommandPalette.tsx (not a
+ * hand-copied array) so a route rename/removal in production is caught here.
  *
- * Tests 7-10 import PAGES directly from CommandPalette.tsx (not a
- * hand-copied array) so a route rename/removal in production is actually
- * caught here.
- *
- * `buildTargetResults` tests (#581) exercise the client-side target matcher
- * against the REAL `matchesSearch`/`normalizeDesig` from TargetsPage.tsx (the
- * same import target-search.test.ts already uses as its source of truth) so a
- * regression in either the palette's wiring or the shared matcher is caught
- * here, not just at `/targets`.
+ * `buildTargetResults` tests cover ranking/shaping only: matching lives in the
+ * backend `target.list(search)` endpoint (kyo7.111), and the palette must not
+ * re-filter its rows.
  */
 
 import {
@@ -55,7 +36,6 @@ import {
   act,
 } from '@testing-library/react';
 import { CommandPalette, PAGES, buildTargetResults } from './CommandPalette';
-import { matchesSearch, normalizeDesig } from '@/features/targets/TargetsPage';
 import { commands } from '@/bindings/index';
 import type { TargetListItem } from '@/bindings/index';
 import { router } from './router';
@@ -175,15 +155,12 @@ describe('CommandPalette debounce contract', () => {
   });
 });
 
-// ── buildTargetResults (#581) ─────────────────────────────────────────────────
+// ── buildTargetResults (#581, kyo7.111) ───────────────────────────────────────
 //
-// Exercises the palette's client-side target matcher against the REAL
-// `matchesSearch`/`normalizeDesig` from TargetsPage.tsx — the same pairing
-// `target-search.test.ts` uses — so a regression in either the palette's
-// wiring or the shared matcher fails here, not just at `/targets`. This is
-// the exact bug from #581: the backend's SQL `LIKE` never matched "M31"
-// against a stored "M 31" designation; the fix routes through this matcher
-// instead of a second, drifting implementation.
+// `target.list(search)` owns matching (alias-aware, over the ~13k-alias
+// catalog); buildTargetResults only ranks and shapes the rows it is given. It
+// must NOT re-filter: aliases are absent from `TargetListItem`, so a
+// client-side filter would drop alias-only hits like "Caldwell 20" -> NGC 7000.
 
 function targetItem(
   id: string,
@@ -201,107 +178,67 @@ function targetItem(
   };
 }
 
-describe('buildTargetResults (#581 client-side target search via designation+label)', () => {
-  // Alias search moved to backend (GF-11 / DS-16); client-side matchesSearch
-  // matches only primaryDesignation and effectiveLabel.
+describe('buildTargetResults (ranks server-filtered target.list rows)', () => {
   const m31 = targetItem('t-m31', 'M 31', 'Andromeda Galaxy');
   const ngc7000 = targetItem('t-ngc7000', 'NGC 7000', 'North America Nebula');
   const targets = [m31, ngc7000];
 
   it('empty query short-circuits to no results (no crash on blank input)', () => {
-    expect(
-      buildTargetResults(targets, '', { matchesSearch, normalizeDesig }),
-    ).toEqual([]);
-    expect(
-      buildTargetResults(targets, '   ', { matchesSearch, normalizeDesig }),
-    ).toEqual([]);
+    expect(buildTargetResults(targets, '')).toEqual([]);
+    expect(buildTargetResults(targets, '   ')).toEqual([]);
   });
 
   it('exact match: "M 31" scores highest and routes to /targets/<id>', () => {
-    const results = buildTargetResults(targets, 'M 31', {
-      matchesSearch,
-      normalizeDesig,
-    });
+    const results = buildTargetResults([m31], 'M 31');
     expect(results).toHaveLength(1);
     expect(results[0].id).toBe('t-m31');
     expect(results[0].route).toBe('/targets/t-m31');
     expect(results[0].score).toBe(1);
   });
 
-  it('compact query "M31" matches the spaced designation "M 31" (#581 bug)', () => {
-    // This is the exact case the backend LIKE match missed: "M31" (no space)
-    // against a stored "M 31" designation.
-    const results = buildTargetResults(targets, 'M31', {
-      matchesSearch,
-      normalizeDesig,
-    });
-    expect(results.map((r) => r.id)).toContain('t-m31');
+  it('compact query "M31" still scores the spaced designation "M 31" as exact', () => {
+    // Whitespace-collapsing normalization: "M31" === "M 31" for scoring.
+    expect(buildTargetResults([m31], 'M31')[0].score).toBe(1);
   });
 
   it('prefix match scores above a plain contains match', () => {
-    const prefixResult = buildTargetResults(targets, 'NGC 70', {
-      matchesSearch,
-      normalizeDesig,
-    })[0];
-    const containsResult = buildTargetResults(targets, 'C 700', {
-      matchesSearch,
-      normalizeDesig,
-    })[0];
-    expect(prefixResult.id).toBe('t-ngc7000');
-    expect(containsResult.id).toBe('t-ngc7000');
+    const prefixResult = buildTargetResults([ngc7000], 'NGC 70')[0];
+    const containsResult = buildTargetResults([ngc7000], 'C 700')[0];
     expect(prefixResult.score ?? 0).toBeGreaterThan(containsResult.score ?? 0);
   });
 
-  it('"Andromeda" matches M 31 via effectiveLabel "Andromeda Galaxy" (not alias lookup)', () => {
-    // effectiveLabel = 'Andromeda Galaxy' → still matches "Andromeda" via label.
-    // Alias-only matches (no label, only alias entry) require backend search.
-    const results = buildTargetResults(targets, 'Andromeda', {
-      matchesSearch,
-      normalizeDesig,
-    });
-    expect(results.map((r) => r.id)).toContain('t-m31');
+  it('keeps an alias-only row the query text does not appear in (kyo7.111)', () => {
+    // The regression this fix undoes: "Caldwell 20" appears in neither NGC
+    // 7000's designation nor its label, so a client-side filter dropped the
+    // row the backend had already matched by alias.
+    const results = buildTargetResults([ngc7000], 'Caldwell 20');
+    expect(results.map((r) => r.id)).toEqual(['t-ngc7000']);
+    // Ranked below any designation/label match.
+    expect(results[0].score).toBe(0.6);
   });
 
-  it('"Caldwell 20" does not match on client — alias-only queries need backend search', () => {
-    // "Caldwell 20" is not in primaryDesignation ("NGC 7000") nor effectiveLabel
-    // ("North America Nebula") — alias lookup moved to backend (GF-11 / DS-16).
-    const results = buildTargetResults(targets, 'Caldwell 20', {
-      matchesSearch,
-      normalizeDesig,
-    });
-    expect(results).toHaveLength(0);
-  });
-
-  it('non-matching query returns no results', () => {
-    const results = buildTargetResults(targets, 'zzz-no-such-target', {
-      matchesSearch,
-      normalizeDesig,
-    });
-    expect(results).toEqual([]);
+  it('caps results at the per-kind budget of 8', () => {
+    const many = Array.from({ length: 12 }, (_, i) =>
+      targetItem(`t-${i}`, `NGC ${7000 + i}`),
+    );
+    expect(buildTargetResults(many, 'NGC')).toHaveLength(8);
   });
 
   it('sublabel carries the primary designation when it differs from the label', () => {
-    const results = buildTargetResults(targets, 'Andromeda', {
-      matchesSearch,
-      normalizeDesig,
-    });
-    expect(results[0].sublabel).toBe('M 31');
+    expect(buildTargetResults([m31], 'Andromeda')[0].sublabel).toBe('M 31');
   });
 
   it('sublabel is null when the designation equals the effective label', () => {
     const bare = targetItem('t-bare', 'Sh2-155', 'Sh2-155');
-    const results = buildTargetResults([bare], 'Sh2-155', {
-      matchesSearch,
-      normalizeDesig,
-    });
-    expect(results[0].sublabel).toBeNull();
+    expect(buildTargetResults([bare], 'Sh2-155')[0].sublabel).toBeNull();
   });
 
   it('results are sorted by descending score', () => {
-    const results = buildTargetResults(targets, 'NGC', {
-      matchesSearch,
-      normalizeDesig,
-    });
+    const results = buildTargetResults(
+      [ngc7000, targetItem('t-exact', 'NGC')],
+      'NGC',
+    );
+    expect(results[0].id).toBe('t-exact');
     for (let i = 1; i < results.length; i++) {
       expect(results[i - 1].score ?? 0).toBeGreaterThanOrEqual(
         results[i].score ?? 0,
@@ -405,48 +342,73 @@ describe('CommandPalette rendered smoke (#581)', () => {
   });
 });
 
-// ── targetList cache TTL (nJ09c/nJ10a carry-over) ──────────────────────────────
-//
-// The palette previously called `commands.targetList()` on every open. These
-// assert the cached-fetch fix: a re-open inside TARGET_CACHE_TTL_MS reuses the
-// cached catalog; a re-open after the TTL elapses refetches.
+// ── Server-side target search (kyo7.111) ──────────────────────────────────────
 
-describe('CommandPalette targetList cache TTL', () => {
+describe('CommandPalette server-side target search', () => {
   beforeEach(() => {
-    // Prior describe blocks in this file also mount + open the palette, so
-    // the mock's call count carries over — reset before each TTL assertion.
     vi.mocked(commands.targetList).mockClear();
   });
 
   afterEach(() => {
+    vi.useRealTimers();
     vi.restoreAllMocks();
   });
 
-  it('reopening within the TTL does not refetch targetList', async () => {
+  it('does not fetch targets until the user types', async () => {
     await openPalette();
-    await waitFor(() => {
-      expect(commands.targetList).toHaveBeenCalledTimes(1);
-    });
-    // Close and reopen — the toggle hotkey flips `open` back to false, then true.
-    fireEvent.keyDown(window, { key: 'k', code: 'KeyK', ctrlKey: true });
-    fireEvent.keyDown(window, { key: 'k', code: 'KeyK', ctrlKey: true });
-    await waitFor(() => {
-      expect(document.querySelector('.pv-palette')).not.toBeNull();
-    });
-    expect(commands.targetList).toHaveBeenCalledTimes(1);
+    expect(commands.targetList).not.toHaveBeenCalled();
   });
 
-  it('reopening after the TTL elapses refetches targetList', async () => {
+  it('forwards the query to target.list and shows an alias-only match', async () => {
+    // The regression: "Caldwell 20" is an alias of NGC 7000 and appears in
+    // neither its designation nor its label, so only the backend can match it.
+    vi.mocked(commands.targetList).mockResolvedValue({
+      status: 'ok',
+      data: [
+        {
+          id: 't-ngc7000',
+          effectiveLabel: 'North America Nebula',
+          primaryDesignation: 'NGC 7000',
+          objectType: 'other',
+          raDeg: 0,
+          decDeg: 0,
+          sessionCount: 0,
+        },
+      ],
+    } as Awaited<ReturnType<typeof commands.targetList>>);
+
     await openPalette();
+    const input = assertDefined(
+      document.querySelector<HTMLInputElement>('.pv-palette__input'),
+      'command palette search input',
+    );
+    fireEvent.change(input, { target: { value: 'Caldwell 20' } });
+
     await waitFor(() => {
-      expect(commands.targetList).toHaveBeenCalledTimes(1);
+      expect(commands.targetList).toHaveBeenCalledWith('Caldwell 20');
     });
-    const realNow = Date.now();
-    vi.spyOn(Date, 'now').mockReturnValue(realNow + 61_000);
-    fireEvent.keyDown(window, { key: 'k', code: 'KeyK', ctrlKey: true });
-    fireEvent.keyDown(window, { key: 'k', code: 'KeyK', ctrlKey: true });
     await waitFor(() => {
-      expect(commands.targetList).toHaveBeenCalledTimes(2);
+      expect(document.body.textContent).toContain('North America Nebula');
     });
+  });
+
+  it('debounces target.list by 200ms', async () => {
+    await openPalette();
+    const input = assertDefined(
+      document.querySelector<HTMLInputElement>('.pv-palette__input'),
+      'command palette search input',
+    );
+    vi.mocked(commands.targetList).mockClear();
+
+    vi.useFakeTimers();
+    fireEvent.change(input, { target: { value: 'M31' } });
+    await act(async () => {
+      vi.advanceTimersByTime(199);
+    });
+    expect(commands.targetList).not.toHaveBeenCalled();
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(commands.targetList).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/desktop/src/app/CommandPalette.tsx
+++ b/apps/desktop/src/app/CommandPalette.tsx
@@ -10,58 +10,22 @@ import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import { openInNewWindow } from '@/lib/window';
 import { useHotkeys } from '@/lib/useHotkeys';
+import { normalizeDesig } from '@/features/targets/target-search-helpers';
 import type { SearchResult } from '@/bindings/types';
 import type { TargetListItem } from '@/bindings/index';
-
-/** Matcher functions loaded from the Targets page (see {@link loadTargetMatcher}). */
-type MatchesSearchFn = (t: TargetListItem, query: string) => boolean;
-type NormalizeDesigFn = (s: string) => string;
-interface TargetMatcher {
-  matchesSearch: MatchesSearchFn;
-  normalizeDesig: NormalizeDesigFn;
-}
-
-/**
- * Loads the Targets page's alias-aware matcher (#581) via a dynamic import
- * rather than a static one. `TargetsPage.tsx` is route-lazy-loaded (see
- * `router.tsx`'s `lazyRouteComponent`) and pulls in the astronomy engine +
- * moon-phase calculations; CommandPalette is always mounted from `Shell`, so a
- * static import would drag that whole feature into the eager bundle. A
- * dynamic `import()` of the same specifier shares one chunk with the route's
- * own lazy import — it stays lazy either way, and there is still exactly one
- * implementation of the matcher (no forked copy to drift out of sync).
- */
-async function loadTargetMatcher(): Promise<TargetMatcher> {
-  const mod = await import('@/features/targets/TargetsPage');
-  return {
-    matchesSearch: mod.matchesSearch,
-    normalizeDesig: mod.normalizeDesig,
-  };
-}
 
 /** Max target results shown (mirrors the backend's per-kind result budget). */
 const MAX_TARGET_RESULTS = 8;
 
-/**
- * How long a cached `targetList()` fetch is considered fresh (nJ09c/nJ10a
- * review carry-over). The palette previously refetched the full catalog on
- * every open; there is no target-change event to invalidate on, so a short
- * TTL is the cheapest staleness signal that still keeps the list from going
- * stale for a whole session while cutting the IPC round-trip on rapid
- * re-opens (e.g. Cmd+K, Esc, Cmd+K again).
- */
-const TARGET_CACHE_TTL_MS = 60_000;
+/** Debounce applied to the palette's target/global search IPC calls. */
+const SEARCH_DEBOUNCE_MS = 200;
 
 /**
  * Scores a target match for ranking, mirroring the backend's exact >
  * prefix > contains heuristic (`crates/app/core/src/search.rs::score`) so
  * ordering feels consistent between the palette and `search_global`.
  */
-function scoreTarget(
-  t: TargetListItem,
-  qNorm: string,
-  normalizeDesig: NormalizeDesigFn,
-): number {
+function scoreTarget(t: TargetListItem, qNorm: string): number {
   const label = normalizeDesig(t.effectiveLabel);
   const desig = normalizeDesig(t.primaryDesignation);
   if (label === qNorm || desig === qNorm) return 1;
@@ -71,24 +35,24 @@ function scoreTarget(
 }
 
 /**
- * Client-side target search (#581): `search_global`'s SQL `LIKE` matches
- * `primary_designation` verbatim, so a compact query like "M31" never matches
- * a stored designation like "M 31" — the exact bug report (M31 finds nothing,
- * M finds many unrelated targets). Reusing the Targets page's tested
- * `matchesSearch`/`normalizeDesig` (whitespace/case-insensitive, alias-aware)
- * keeps this in lockstep with the real search users already rely on at
- * `/targets`, instead of hand-rolling a second matcher here.
+ * Ranks and shapes the already-filtered `target.list(search)` rows into palette
+ * results (#581, kyo7.111).
+ *
+ * The rows come from the backend, which matches designation, effective label,
+ * and aliases (`crates/app/targets/src/target_management/list.rs`). Filtering
+ * client-side would drop alias-only hits like "Caldwell 20" → NGC 7000, whose
+ * query text appears in neither the designation nor the label; the aliases are
+ * no longer serialized on `TargetListItem` (GF-11 / DS-16), so only the backend
+ * can make that match.
  */
 export function buildTargetResults(
   targets: TargetListItem[],
   query: string,
-  matcher: TargetMatcher,
 ): SearchResult[] {
   const q = query.trim();
   if (!q) return [];
-  const qNorm = matcher.normalizeDesig(q);
+  const qNorm = normalizeDesig(q);
   return targets
-    .filter((t) => matcher.matchesSearch(t, q))
     .map((t) => ({
       id: t.id,
       kind: 'target' as const,
@@ -96,7 +60,7 @@ export function buildTargetResults(
       sublabel:
         t.primaryDesignation !== t.effectiveLabel ? t.primaryDesignation : null,
       route: `/targets/${t.id}`,
-      score: scoreTarget(t, qNorm, matcher.normalizeDesig),
+      score: scoreTarget(t, qNorm),
     }))
     .sort((a, b) => (b.score ?? 0) - (a.score ?? 0))
     .slice(0, MAX_TARGET_RESULTS);
@@ -142,8 +106,6 @@ export function CommandPalette() {
   const [query, setQuery] = useState('');
   const [results, setResults] = useState<SearchResult[]>([]);
   const [devMode, setDevMode] = useState(false);
-  const [allTargets, setAllTargets] = useState<TargetListItem[]>([]);
-  const targetsFetchedAtRef = useRef(0);
   const navigate = useNavigate();
   const currentHref = useRouterState({ select: (s) => s.location.href });
   // Owns initial focus explicitly (base-ui `initialFocus`) instead of the
@@ -171,33 +133,6 @@ export function CommandPalette() {
     };
   }, []);
 
-  // Load the full target catalog when the palette opens (#581) so client-side
-  // matches are ready by the time the user types. Deferred to open (not
-  // mount) because CommandPalette lives in Shell — a mount-time fetch would
-  // pull the whole catalog on every app boot even if the palette is never
-  // used, and would go stale for targets added mid-session. Cached for
-  // TARGET_CACHE_TTL_MS (nJ09c/nJ10a carry-over): re-opening the palette
-  // within the TTL reuses `allTargets` instead of re-issuing the IPC call.
-  useEffect(() => {
-    if (!open) return;
-    if (Date.now() - targetsFetchedAtRef.current < TARGET_CACHE_TTL_MS) return;
-    let cancelled = false;
-    commands
-      .targetList(null)
-      .then(unwrap)
-      .then((items) => {
-        if (cancelled) return;
-        targetsFetchedAtRef.current = Date.now();
-        setAllTargets(items);
-      })
-      .catch(() => {
-        // Backend unavailable — palette falls back to sessions/projects only.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
-
   // ⌘/Ctrl+K toggles the palette. `$mod` resolves to Cmd on macOS, Ctrl
   // elsewhere — matching the prior `metaKey || ctrlKey` check. We opt out of the
   // form-field guard so the shortcut still fires while focus is in an input.
@@ -218,33 +153,33 @@ export function CommandPalette() {
       return;
     }
     const controller = new AbortController();
-    // Debounce search by 200ms to avoid excessive API calls
     const timeoutId = setTimeout(() => {
       void Promise.all([
-        loadTargetMatcher(),
+        commands.targetList(query.trim()).then(unwrap),
         commands.searchGlobal(query).then(unwrap),
       ])
-        .then(([matcher, backendResults]) => {
+        .then(([targets, backendResults]) => {
           if (controller.signal.aborted) return;
-          // Backend target matches are dropped in favor of the client-side,
-          // alias-aware matches above — see buildTargetResults for why.
+          // `search_global`'s target matches are dropped in favour of
+          // `target.list(search)`, which is alias-aware — see
+          // buildTargetResults.
           const nonTargetResults = backendResults.filter(
             (r) => r.kind !== 'target',
           );
           setResults([
-            ...buildTargetResults(allTargets, query, matcher),
+            ...buildTargetResults(targets, query),
             ...nonTargetResults,
           ]);
         })
         .catch(() => {
           if (!controller.signal.aborted) setResults([]);
         });
-    }, 200);
+    }, SEARCH_DEBOUNCE_MS);
     return () => {
       clearTimeout(timeoutId);
       controller.abort();
     };
-  }, [query, allTargets]);
+  }, [query]);
 
   const select = useCallback(
     (route: string) => {

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -6,7 +6,7 @@
 # rule's own `// eslint-disable-next-line alm/no-user-string -- <reason>`
 # for a genuinely non-user-facing string).
 # Regenerate with: node scripts/check-eslint-baseline.mjs --generate
-src/app/CommandPalette.tsx	280	alm/require-root-testid
+src/app/CommandPalette.tsx	215	alm/require-root-testid
 src/app/LogEntryRow.tsx	69	alm/require-root-testid
 src/app/LogPanel.tsx	201	alm/require-root-testid
 src/app/LogPanelContext.tsx	155	alm/require-root-testid


### PR DESCRIPTION
## Summary

- Alias-only queries in the command palette, such as "Caldwell 20" for NGC 7000, returned no results. The palette fetched the whole target catalog once per open and filtered it client-side against designation and label only; aliases are no longer serialized on `TargetListItem` (GF-11 / DS-16), so no client-side filter can see them.
- The palette now queries the `target.list(search)` endpoint on its existing 200 ms debounce, alongside `search_global`. That endpoint matches designation, label, and aliases in-process over the cached catalog (`crates/app/targets/src/target_management/list.rs:60`).
- `buildTargetResults` ranks and shapes the returned rows instead of filtering them; its matcher parameter is gone.
- The open-time full-catalog fetch and its 60 s TTL cache are removed: no IPC call fires until the user types.
- `scripts/eslint-alm-baseline.txt` records the pre-existing `alm/require-root-testid` violation at its shifted line number (280 to 215).

## Tests

`apps/desktop/src/app/CommandPalette.test.tsx`: the `buildTargetResults` block asserts ranking and that an alias-only row survives; a new `CommandPalette server-side target search` block asserts the query reaches `target.list`, the alias-only result renders, the call is debounced by 200 ms, and no fetch happens before the user types. Reverting `CommandPalette.tsx` to its base version fails 11 of the file's 22 tests.

## Verification

| Command | Result |
| --- | --- |
| `pnpm --dir apps/desktop exec vitest run src/app/CommandPalette.test.tsx` | 22 passed |
| `pnpm --dir apps/desktop run test` | 257 files, 2300 tests passed |
| `pnpm --dir apps/desktop exec tsc --noEmit` | clean |
| `pnpm --dir apps/desktop run lint` | biome, eslint baseline, tokens, i18n, mock baseline pass; `check-circular.mjs` fails on 3 cycles (TargetSearch, PlanPanel x2) that also fail on base commit 642328d5, unrelated to this diff |

## Spec Context

Tracks-Bead: astro-plan-ticm
Merge-Bead: astro-plan-sxay

Source bead: astro-plan-kyo7.111
