### PR TITLE
ci: enforce lifecycle-string and CSS-selector ratchets in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,17 +233,22 @@ jobs:
           } >> "$GITHUB_OUTPUT"
           echo "changes: rust=$rust frontend=$frontend frontend_full=$frontend_full docs_only=$docs_only scripts=${{ steps.filter.outputs.scripts }}"
 
-  # Two lanes share this matrix (Rust and frontend), each with its own step-level
-  # gate, so it is NOT split into two jobs: whenever either lane is active every
-  # OS leg still runs real work — `Rust tests` + `Generated contract/binding
-  # drift` are OS-agnostic under the Rust lane, as are the frontend lint / unit
-  # test / typecheck steps under the frontend lane. The job-level gate below
-  # therefore fires only when BOTH lanes are idle, which is exactly the case
-  # where the job had nothing to do and must not report `success`.
+  # Three lanes share this matrix (Rust, frontend, scripts), each with its own
+  # step-level gate, so it is NOT split into separate jobs: whenever any lane is
+  # active every OS leg still runs real work — `Rust tests` + `Generated
+  # contract/binding drift` are OS-agnostic under the Rust lane, as are the
+  # frontend lint / unit test / typecheck steps under the frontend lane, and the
+  # ratchet steps under the scripts lane. The job-level gate below therefore
+  # fires only when ALL lanes are idle, which is exactly the case where the job
+  # had nothing to do and must not report `success`.
+  #
+  # `scripts` must appear here as well as on the ratchet steps: those steps gate
+  # on it, so without it a scripts-only PR skips this job entirely and silently
+  # bypasses every ratchet it was meant to trigger.
   integration:
     name: Unit + integration (L1+L2) — ${{ matrix.os }}
     needs: changes
-    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true'
+    if: needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.scripts == 'true'
     strategy:
       fail-fast: false # report each platform distinctly (FR-011)
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -402,6 +402,22 @@ jobs:
         if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true')
         run: just hot-read
 
+      # Lifecycle string-comparison ratchet: sealed at zero raw
+      # `.lifecycle == "..."` comparisons in production Rust (#1534, #1556).
+      # Local-only until now, so raw comparisons could reach main through CI.
+      # Pure grep, no compile — same Linux-only gating as the ratchets above.
+      - name: Lifecycle string ratchet
+        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true')
+        run: just lifecycle-strings
+
+      # .pv-* selector ratchet: sealed at zero class selectors in e2e test
+      # files (Playwright TS under tests/e2e/ and Rust journeys under
+      # crates/e2e-tests/), which the eslint alm/require-root-testid rule
+      # cannot reach. Gated on frontend too, because tests/e2e/ is TS.
+      - name: .pv-* selector ratchet
+        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.scripts == 'true')
+        run: just pv-selector-ratchet
+
       # Compilation warnings/lints are OS-agnostic; running clippy on all 3 legs
       # is pure redundancy — the nextest step below builds the workspace anyway.
       - name: Clippy (workspace, all targets, deny warnings)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,9 +418,15 @@ jobs:
       # .pv-* selector ratchet: sealed at zero class selectors in e2e test
       # files (Playwright TS under tests/e2e/ and Rust journeys under
       # crates/e2e-tests/), which the eslint alm/require-root-testid rule
-      # cannot reach. Gated on frontend too, because tests/e2e/ is TS.
+      # cannot reach.
+      #
+      # Gated on rust/scripts only, NOT frontend: `just` is installed under the
+      # rust lane alone, so a `|| frontend` clause here makes a PR touching only
+      # apps/desktop/src/** run this step with no `just` on PATH. Both scanned
+      # trees (tests/e2e/, crates/e2e-tests/) match the `rust` filter via
+      # `tests/**` and `crates/**`, so the frontend clause added no coverage.
       - name: .pv-* selector ratchet
-        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.scripts == 'true')
+        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true')
         run: just pv-selector-ratchet
 
       # Compilation warnings/lints are OS-agnostic; running clippy on all 3 legs

--- a/apps/desktop/biome-plugins/no-bare-pv-radius.grit
+++ b/apps/desktop/biome-plugins/no-bare-pv-radius.grit
@@ -1,0 +1,22 @@
+// Replaces check 4 of scripts/check-tokens.sh: the suffix-less
+// `var(--pv-radius)` token is undefined (spec 028 R-4 regression pin). The
+// required closing paren is what keeps `var(--pv-radius-md)` passing.
+//
+// The bare-regex branch covers template literals, which the `string()` node
+// pattern does not reach; excluding quote and separator characters holds it to
+// one diagnostic per violation instead of one per enclosing node. The biome.json
+// override that loads this plugin excludes *.test.ts/tsx, which assert on the
+// literal this bans.
+language js
+
+or {
+  string() as $s,
+  r"[^`'\"=;]*var\(--pv-radius\)[^`'\"=;]*" as $s
+} where {
+  $s <: r"[^\n]*var\(--pv-radius\)[^\n]*",
+  register_diagnostic(
+    span = $s,
+    message = "`var(--pv-radius)` is undefined (spec 028 R-4). Use --pv-radius-sm, --pv-radius-md, or --pv-radius-lg.",
+    severity = "error"
+  )
+}

--- a/apps/desktop/biome-plugins/no-legacy-token-namespace.grit
+++ b/apps/desktop/biome-plugins/no-legacy-token-namespace.grit
@@ -1,0 +1,20 @@
+// Replaces check 3 of scripts/check-tokens.sh: `--mantine-color-*` and
+// `--pv-color-*` namespaces do not exist in tokens.css. The bare-regex branch
+// covers template literals, which the `string()` node pattern does not reach;
+// excluding quote and separator characters holds it to one diagnostic per
+// violation instead of one per enclosing node. The biome.json override that
+// loads this plugin excludes *.test.ts/tsx, which assert on banned literals.
+language js
+
+or {
+  string() as $s,
+  r"[^`'\"=;]*--mantine-color-[^`'\"=;]*" as $s,
+  r"[^`'\"=;]*--pv-color-[^`'\"=;]*" as $s
+} where {
+  $s <: or { r"[^\n]*--mantine-color-[^\n]*", r"[^\n]*--pv-color-[^\n]*" },
+  register_diagnostic(
+    span = $s,
+    message = "`--mantine-color-*` and `--pv-color-*` are not defined in tokens.css (spec 022). Use a real --pv-* token.",
+    severity = "error"
+  )
+}

--- a/apps/desktop/biome-plugins/no-raw-invoke.grit
+++ b/apps/desktop/biome-plugins/no-raw-invoke.grit
@@ -1,0 +1,21 @@
+// Replaces the SC-001 vitest guard from src/api/ipc-boundary.guard.test.ts:
+// a single-file pattern match for hand-written `invoke('cmd')` /
+// `invoke<T>('cmd')` calls. The generated bindings dispatch through the
+// distinct `__TAURI_INVOKE` identifier, so they never match this pattern.
+//
+// Loaded from a biome.json override rather than root `plugins`, because a root
+// entry applies everywhere and cannot be narrowed. The negated paths there are
+// src/api/ipc.ts (the dispatch switcher itself) plus the spec-062 feature-local
+// adapters sessionsGroupsIpc.ts and calibrationHandoffIpc.ts, whose raw invokes
+// are replaced once ic9h.20 generates their typed bindings.
+language js
+
+call_expression($function, $arguments) where {
+  $function <: `invoke`,
+  $arguments <: contains string(),
+  register_diagnostic(
+    span = $arguments,
+    message = "Hand-written `invoke('...')` calls are confined to the dispatch switcher (spec 037 SC-001). Call the generated `commands.*` bindings instead.",
+    severity = "error"
+  )
+}

--- a/apps/desktop/biome-plugins/no-raw-invoke.grit
+++ b/apps/desktop/biome-plugins/no-raw-invoke.grit
@@ -12,7 +12,10 @@ language js
 
 call_expression($function, $arguments) where {
   $function <: `invoke`,
-  $arguments <: contains string(),
+  // `string()` does not match template literals, so a backtick command name
+  // slips past a `contains string()`-only guard. The regex branch covers both
+  // the plain and the generic `invoke<T>(`cmd`)` forms.
+  $arguments <: or { contains string(), r"[^\n]*`[^`\n]*`[^\n]*" },
   register_diagnostic(
     span = $arguments,
     message = "Hand-written `invoke('...')` calls are confined to the dispatch switcher (spec 037 SC-001). Call the generated `commands.*` bindings instead.",

--- a/apps/desktop/biome-plugins/no-retired-commands-wrapper.grit
+++ b/apps/desktop/biome-plugins/no-retired-commands-wrapper.grit
@@ -1,0 +1,20 @@
+// Replaces the SC-005 vitest guard from src/api/ipc-boundary.guard.test.ts:
+// a single-file literal scan for references to the retired hand-written
+// `@/api/commands` wrapper (static import, dynamic import, or vi.mock).
+// Every caller goes through the generated `commands.*` bindings instead.
+//
+// A static import's module source is not a `string()` node in Biome's Grit JS
+// dialect, so the quote-anchored regex branch is what catches that form.
+language js
+
+or {
+  string() as $s,
+  r"['\"]@/api/commands['\"]" as $s
+} where {
+  $s <: r"['\"]@/api/commands['\"]",
+  register_diagnostic(
+    span = $s,
+    message = "The hand-written `@/api/commands` wrapper is retired (spec 037 SC-005). Import the generated `commands.*` bindings from `@/bindings` instead.",
+    severity = "error"
+  )
+}

--- a/apps/desktop/biome-plugins/no-retired-commands-wrapper.grit
+++ b/apps/desktop/biome-plugins/no-retired-commands-wrapper.grit
@@ -4,14 +4,16 @@
 // Every caller goes through the generated `commands.*` bindings instead.
 //
 // A static import's module source is not a `string()` node in Biome's Grit JS
-// dialect, so the quote-anchored regex branch is what catches that form.
+// dialect, so the quote-anchored regex branch is what catches that form. The
+// quote class includes a backtick because `import()` and `vi.mock()` accept a
+// template-literal specifier, which would otherwise slip through.
 language js
 
 or {
   string() as $s,
-  r"['\"]@/api/commands['\"]" as $s
+  r"['\"`]@/api/commands['\"`]" as $s
 } where {
-  $s <: r"['\"]@/api/commands['\"]",
+  $s <: r"['\"`]@/api/commands['\"`]",
   register_diagnostic(
     span = $s,
     message = "The hand-written `@/api/commands` wrapper is retired (spec 037 SC-005). Import the generated `commands.*` bindings from `@/bindings` instead.",

--- a/apps/desktop/biome.json
+++ b/apps/desktop/biome.json
@@ -41,6 +41,33 @@
       }
     }
   },
+  "plugins": [
+    "./biome-plugins/no-retired-commands-wrapper.grit"
+  ],
+  "overrides": [
+    {
+      "includes": [
+        "src/**",
+        "!src/api/ipc.ts",
+        "!src/features/sessions/sessionsGroupsIpc.ts",
+        "!src/features/calibration/calibrationHandoffIpc.ts"
+      ],
+      "plugins": [
+        "./biome-plugins/no-raw-invoke.grit"
+      ]
+    },
+    {
+      "includes": [
+        "src/**",
+        "!**/*.test.ts",
+        "!**/*.test.tsx"
+      ],
+      "plugins": [
+        "./biome-plugins/no-legacy-token-namespace.grit",
+        "./biome-plugins/no-bare-pv-radius.grit"
+      ]
+    }
+  ],
   "assist": {
     "enabled": false
   },

--- a/apps/desktop/src/api/ipc-boundary.guard.test.ts
+++ b/apps/desktop/src/api/ipc-boundary.guard.test.ts
@@ -2,19 +2,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 /**
- * Spec 037 IPC-boundary teardown guards (SC-001 + SC-005 + SC-006).
+ * Spec 037 IPC-boundary teardown guard (SC-006).
  *
- * These scan the whole `src` tree so the drift-bug class the migration removed
+ * SC-001 and SC-005 are Biome GritQL plugins instead — single-file literal
+ * patterns need no module graph:
+ * `apps/desktop/biome-plugins/no-raw-invoke.grit` and
+ * `apps/desktop/biome-plugins/no-retired-commands-wrapper.grit`.
+ *
+ * This scans the whole `src` tree so the drift-bug class the migration removed
  * cannot silently return:
  *
- * - SC-005: no module may import the retired hand-written `@/api/commands`
- *   wrapper (static import, dynamic `import()`, or `vi.mock`). Every caller goes
- *   through the generated `commands.*` bindings instead.
- * - SC-001: no hand-written `invoke('...')` string-literal call may exist
- *   outside the single dispatch switcher (`src/api/ipc.ts`). The generated
- *   bindings dispatch via the distinct `__TAURI_INVOKE` identifier (routed
- *   through the switcher), and `@tauri-apps/api/core`'s raw `invoke` is only
- *   reached inside the switcher.
  * - SC-006: no new file may call a `settingsIpc` wrapper function directly
  *   inside a `useEffect` (or a `useCallback` invoked from one). The correct
  *   pattern is React Query (`useQuery`/`useMutation`). Existing sites are
@@ -65,38 +62,6 @@ const files = Object.entries(raw)
 describe('spec 037 — IPC boundary guards', () => {
   it('has files to scan', () => {
     expect(files.length).toBeGreaterThan(100);
-  });
-
-  it('SC-005: nothing imports the retired @/api/commands wrapper', () => {
-    const re =
-      /(from\s*['"]@\/api\/commands['"])|(import\(\s*['"]@\/api\/commands['"])|(vi\.mock\(\s*['"]@\/api\/commands['"])/;
-    const offenders = files.filter((f) => re.test(f.src)).map((f) => f.path);
-    expect(offenders).toEqual([]);
-  });
-
-  it('SC-001: no hand-written invoke() string literal outside the dispatch switcher', () => {
-    // A hand-written call: `invoke('cmd'` / `invoke<T>("cmd"`. The generated
-    // bindings use the distinct `__TAURI_INVOKE` identifier, which this misses.
-    const re = /\binvoke\s*(<[^>]*>)?\(\s*['"`]/;
-    const offenders = files
-      .filter(
-        (f) =>
-          !f.path.endsWith('/api/ipc.ts') &&
-          !f.path.endsWith('/bindings/index.ts') &&
-          // 2026-07-24: spec-062 feature-local adapter — raw invokes are the
-          // intentional seam until ic9h.20 wires the Tauri commands and generates
-          // typed bindings; at that point every invoke() here is replaced by the
-          // generated commands.* call and this entry is removed.
-          !f.path.endsWith('/features/sessions/sessionsGroupsIpc.ts') &&
-          // 2026-07-25: spec-062 US4 feature-local adapter — raw invokes are the
-          // intentional seam until ic9h.20 wires the Tauri commands and generates
-          // typed bindings; at that point every invoke() here is replaced by the
-          // generated commands.* call and this entry is removed.
-          !f.path.endsWith('/features/calibration/calibrationHandoffIpc.ts'),
-      )
-      .filter((f) => re.test(f.src))
-      .map((f) => f.path);
-    expect(offenders).toEqual([]);
   });
 
   it('SC-006: no new file calls a settingsIpc wrapper inside useEffect (migrate to React Query)', () => {

--- a/justfile
+++ b/justfile
@@ -156,8 +156,8 @@ check-generated:
     git diff --exit-code specs/*/contracts/*.generated.json apps/desktop/src/bindings/
 
 # Full pre-merge gate: lint + tests + typecheck + generated-artifact drift +
-# DB/dead-caller/hot-read/lifecycle-strings boundary ratchets.
-check: lint test typecheck check-generated db-boundary dead-callers hot-read lifecycle-strings
+# DB/dead-caller/hot-read/lifecycle-strings/pv-selector boundary ratchets.
+check: lint test typecheck check-generated db-boundary dead-callers hot-read lifecycle-strings pv-selector-ratchet
 
 # Placeholder fixture check hook.
 fixtures-check:

--- a/scripts/check-tokens.sh
+++ b/scripts/check-tokens.sh
@@ -6,11 +6,15 @@
 #      (all colors must use --pv-* CSS variables).
 #   2. Raw `ms` values appear in components.css
 #      (motion durations must use --pv-transition-* variables).
-#   3. Legacy/non-PV token namespaces appear in TSX/TS source files
-#      (--mantine-color-* and --pv-color-* do not exist in tokens.css).
-#   4. Bare --pv-radius (without -sm/-md/-lg suffix) appears in TSX/TS
-#      source files — pin the R-4 regression fix (spec 028, 2026-06-17).
-#      Valid radius tokens: --pv-radius-sm, --pv-radius-md, --pv-radius-lg.
+#   5. A [data-theme] block omits a raw token another theme declares.
+#   6. A text/surface token pair falls below WCAG AA contrast.
+#   7. A var(--pv-*) reference in TS/TSX names a token that does not exist.
+#
+# Checks 3 and 4 are Biome GritQL plugins:
+# apps/desktop/biome-plugins/no-legacy-token-namespace.grit bans the
+# `--mantine-color-*` / `--pv-color-*` namespaces, and
+# apps/desktop/biome-plugins/no-bare-pv-radius.grit bans bare `var(--pv-radius)`.
+# Checks 5-7 keep their original numbers because docs and specs cite them.
 #
 # Exceptions documented in components.css policy comment (spec 022 T011):
 #   - Component-intrinsic geometry px values are intentionally raw.
@@ -24,7 +28,6 @@ REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 # partials under styles/components/. Scan the barrel AND every partial so the
 # token policy still covers all component CSS after the split.
 COMPONENTS_CSS=("$REPO_ROOT/apps/desktop/src/styles/components.css" "$REPO_ROOT"/apps/desktop/src/styles/components/*.css)
-SRC_DIR="$REPO_ROOT/apps/desktop/src"
 
 PASS=true
 
@@ -103,57 +106,6 @@ if [ -n "$MS_HITS" ]; then
   PASS=false
 else
   echo "  OK: No raw ms values."
-fi
-
-# ── Check 3: No legacy token namespaces in TSX/TS source ─────────────────────
-echo ""
-echo "3. Checking for legacy/non-PV token namespaces in source files..."
-# --mantine-color-* and --pv-color-* are not in tokens.css.
-# -E, not -P: this is a plain literal alternation, no PCRE feature in use —
-# BSD/macOS grep has no -P at all, so it errored on every invocation.
-LEGACY_HITS=$(
-  set +e
-  grep -rnE "(--mantine-color-|--pv-color-)" \
-    --include="*.tsx" --include="*.ts" \
-    "$SRC_DIR" | grep -v "\.test\." | grep -v "bindings/"
-  rc=("${PIPESTATUS[@]}")
-  set -e
-  fatal_if_grep_broken "while scanning for legacy token namespaces" "${rc[@]}"
-  exit 0
-)
-if [ -n "$LEGACY_HITS" ]; then
-  echo "FAIL: Legacy token references found (--mantine-color-* / --pv-color-* do not exist in tokens.css):"
-  echo "$LEGACY_HITS"
-  PASS=false
-else
-  echo "  OK: No legacy token namespaces."
-fi
-
-# ── Check 4: No bare --pv-radius (R-4 regression pin, spec 028) ─────────────
-echo ""
-echo "4. Checking for bare --pv-radius (undefined; use --pv-radius-{sm,md,lg}) in source files..."
-# Matches the literal substring var(--pv-radius) — the required immediate
-# closing paren is what excludes suffixed forms like var(--pv-radius-md):
-# a plain literal search, no regex needed at all, so -F (fixed string) is
-# both the most portable option and clearer than a lookaround would be.
-# (The pattern never used a lookahead despite what an earlier comment here
-# claimed; -F makes that explicit.)
-BARE_RADIUS_HITS=$(
-  set +e
-  grep -rnF "var(--pv-radius)" \
-    --include="*.tsx" --include="*.ts" \
-    "$SRC_DIR" | grep -v "\.test\." | grep -v "bindings/"
-  rc=("${PIPESTATUS[@]}")
-  set -e
-  fatal_if_grep_broken "while scanning for bare --pv-radius references" "${rc[@]}"
-  exit 0
-)
-if [ -n "$BARE_RADIUS_HITS" ]; then
-  echo "FAIL: Bare --pv-radius found (R-4 regression: token is undefined; use --pv-radius-md instead):"
-  echo "$BARE_RADIUS_HITS"
-  PASS=false
-else
-  echo "  OK: No bare --pv-radius references."
 fi
 
 # ── Check 5: Every [data-theme] block declares the full raw-token set ────────


### PR DESCRIPTION
## Summary

- Wires two existing ratchet scripts into CI. Both ran only locally, so raw `.lifecycle == "..."` comparisons and `.pv-*` e2e selectors reached main unchecked.
- Moves four literal-pattern lint checks out of a vitest guard and a shell script into Biome GritQL plugins.

Tracks-Bead: astro-plan-z4p8
Merge-Bead: astro-plan-qkmp

Source audit bead: astro-plan-kyo7.115. Run: run-wjrz-20260727.

## Changes

| Audit action | Result |
| --- | --- |
| 1. Fix check-lifecycle-strings.sh comment exclusion | Already correct at HEAD (`scripts/check-lifecycle-strings.sh:21`). No change needed. |
| 2. Wire `just lifecycle-strings` into CI | `.github/workflows/ci.yml:405` plus `just check` |
| 3. Wire check-pv-selector-ratchet.sh into justfile + CI | `.github/workflows/ci.yml:414` plus `just check`. #1542 did not carry the wiring. |
| 4. Migrate SC-001 + SC-005 to Biome GritQL | `apps/desktop/biome-plugins/no-raw-invoke.grit`, `no-retired-commands-wrapper.grit`. SC-006 stays in vitest. |
| 5. Migrate check-tokens.sh checks 3+4 | `apps/desktop/biome-plugins/no-legacy-token-namespace.grit`, `no-bare-pv-radius.grit`. CSS checks 1+2 and node checks 5-7 unchanged. |

Check numbers 5-7 in `check-tokens.sh` keep their original values because docs and specs cite them.

## Ratchet proofs

Each wired or migrated check was made to fail on a deliberate violation, then reverted to green.

| Check | Violation | Observed |
| --- | --- | --- |
| lifecycle-strings | `p.lifecycle == "active"` in `crates/app/core/src/lib.rs` | exit 1, 1 raw lifecycle string comparison found |
| pv-selector (TS) | `.pv-probe-thing` in `tests/e2e/add_target_focus.spec.ts` | exit 1, 1 `.pv-*` class selector found |
| pv-selector (Rust) | `By::Css(".pv-probe-thing")` in `crates/e2e-tests/tests/archive_journeys.rs` | exit 1, same message |
| SC-005 | static import, dynamic `import()`, and `vi.mock` of `@/api/commands` | 1 diagnostic each |
| SC-001 | `invoke('probe.cmd')` and `invoke<number>('probe.cmd')` | 1 diagnostic each |
| tokens 3 | `var(--pv-color-x)`, `var(--mantine-color-body)` | 1 diagnostic each |
| tokens 4 | `var(--pv-radius)` as string and as template literal | 1 diagnostic each; `var(--pv-radius-md)` passes |

Exemptions verified by the clean tree passing: `src/api/ipc.ts`, `src/features/sessions/sessionsGroupsIpc.ts`, and `src/features/calibration/calibrationHandoffIpc.ts` all contain raw `invoke('...')` calls and produce zero diagnostics.

## Gates

- `just lifecycle-strings`, `just pv-selector-ratchet`: pass.
- `bash scripts/check-tokens.sh`: pass.
- `biome lint apps/desktop` (646 files): 0 errors, 33 warnings, identical to the pre-change baseline.
- `biome format apps/desktop`: clean.
- `npx vitest run src/api/ipc-boundary.guard.test.ts`: 2 passed.
- `pnpm --filter @astro-plan/desktop run typecheck`: pass.
- `pnpm --filter @astro-plan/desktop run lint`: FAILS at `check-circular.mjs` with 3 cycles (`TargetSearch.tsx`, `PlanPanel.tsx` twice). Pre-existing: the identical failure reproduces on stashed HEAD. Not caused by this branch.

No Rust source changed, so cargo gates were not run.

## Biome 2.5.5 GritQL findings

- A root `plugins` entry applies to every linted file and cannot be narrowed. Per-path exemptions need an `overrides` entry with negated `includes` globs carrying the `plugins` key. Declaring a plugin inside an override is additive to root, not a replacement.
- A static import's module source is not a `string()` node, so SC-005 needs a quote-anchored regex branch for `from '@/api/commands'`.
- Template literals are not reached by `string()`, and no template node kind name compiles in this dialect. The token plugins add a regex branch excluding quote and separator characters, which yields one diagnostic per violation rather than one per enclosing node.
- The token plugins exclude `*.test.ts` and `*.test.tsx`, matching the original `grep -v '.test.'` filter: `NamingStructure.r4.test.ts` asserts on the literals they ban.
