### PR TITLE
fix: circular-dependency lint gate no longer fails on known type-only cycles

### DIFF
--- a/apps/desktop/scripts/check-circular.mjs
+++ b/apps/desktop/scripts/check-circular.mjs
@@ -76,6 +76,17 @@ let cycles;
 try {
   cycles = JSON.parse(madgeOut);
   if (!Array.isArray(cycles)) throw new Error('expected an array');
+  // Validate every entry here, not at the `.join` below: `[null]` satisfies
+  // `Array.isArray` and would then throw an uncaught TypeError, losing the
+  // controlled diagnostic this branch exists to print.
+  const bad = cycles.findIndex(
+    (c) => !Array.isArray(c) || c.some((m) => typeof m !== 'string'),
+  );
+  if (bad !== -1) {
+    throw new Error(
+      `entry ${bad} is not an array of strings: ${JSON.stringify(cycles[bad])}`,
+    );
+  }
 } catch (err) {
   process.stderr.write(
     `CIRCULAR DEP GATE FAILED — could not parse madge --json output: ${

--- a/apps/desktop/scripts/check-circular.mjs
+++ b/apps/desktop/scripts/check-circular.mjs
@@ -39,20 +39,26 @@ const ALLOWLIST = new Set([
 const listMode = process.argv.includes('--list');
 
 let madgeOut;
+/** @type {string} */
+let madgeErr = '';
 try {
   madgeOut = execSync(
     'node_modules/.bin/madge --circular --json --no-spinner --extensions ts,tsx src',
-    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
+    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
   );
 } catch (err) {
-  // madge exits 1 when cycles are found — capture stdout anyway.
+  // madge exits 1 when cycles are found — capture stdout anyway.  Keep stderr
+  // too: when stdout turns out to be unparseable, madge's own diagnostic is the
+  // only thing that explains why.
   madgeOut = /** @type {any} */ (err).stdout ?? '';
+  madgeErr = /** @type {any} */ (err).stderr ?? '';
 }
 
 // `--json` is the only stable machine format: madge's human output carries ANSI
 // styling even under `--no-color`, which defeats string comparison against the
-// allowlist.  Unparseable output means madge did not run (e.g. dependencies not
-// installed) — fail rather than report a vacuous pass.
+// allowlist.  Unparseable output means madge did not run — fail rather than
+// report a vacuous pass, and surface madge's own diagnostic so a genuine madge
+// failure is not misreported as a missing install.
 /** @type {string[][]} */
 let cycles;
 try {
@@ -62,8 +68,21 @@ try {
   process.stderr.write(
     `CIRCULAR DEP GATE FAILED — could not parse madge --json output: ${
       /** @type {Error} */ (err).message
-    }\nRun \`pnpm install\` in apps/desktop and retry.\n`,
+    }\n`,
   );
+  if (madgeErr.trim()) {
+    process.stderr.write(`madge stderr:\n${madgeErr.trimEnd()}\n`);
+  }
+  if (madgeOut.trim()) {
+    process.stderr.write(`madge stdout:\n${madgeOut.trimEnd().slice(0, 2000)}\n`);
+  } else {
+    // madge emitted no JSON at all, so it never ran to completion.  A missing
+    // install is the most common cause; the diagnostic above says which.
+    process.stderr.write(
+      'madge produced no JSON output — if it is not installed, run ' +
+        '`pnpm install` in apps/desktop and retry.\n',
+    );
+  }
   process.exit(1);
 }
 

--- a/apps/desktop/scripts/check-circular.mjs
+++ b/apps/desktop/scripts/check-circular.mjs
@@ -12,7 +12,8 @@
 //   node scripts/check-circular.mjs              # CI / lint gate
 //   node scripts/check-circular.mjs --list       # print all current cycles
 
-import { execSync } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
@@ -38,21 +39,32 @@ const ALLOWLIST = new Set([
 
 const listMode = process.argv.includes('--list');
 
-let madgeOut;
+// Resolve madge's CLI through Node rather than invoking `node_modules/.bin/madge`
+// through a shell: the bin shim is not executable by cmd.exe, so the shell form
+// fails on Windows with "'node_modules' is not recognized".  Running the real
+// entry point under the current node binary works identically on every platform.
 /** @type {string} */
-let madgeErr = '';
+let madgeCli;
 try {
-  madgeOut = execSync(
-    'node_modules/.bin/madge --circular --json --no-spinner --extensions ts,tsx src',
-    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+  madgeCli = createRequire(`${ROOT}/`).resolve('madge/bin/cli.js');
+} catch {
+  process.stderr.write(
+    'CIRCULAR DEP GATE FAILED — cannot resolve madge.\n' +
+      'Run `pnpm install` in apps/desktop and retry.\n',
   );
-} catch (err) {
-  // madge exits 1 when cycles are found — capture stdout anyway.  Keep stderr
-  // too: when stdout turns out to be unparseable, madge's own diagnostic is the
-  // only thing that explains why.
-  madgeOut = /** @type {any} */ (err).stdout ?? '';
-  madgeErr = /** @type {any} */ (err).stderr ?? '';
+  process.exit(1);
 }
+
+// madge exits 1 when cycles are found, so a non-zero status is expected — read
+// stdout regardless.  Capture stderr too: when stdout turns out to be
+// unparseable, madge's own diagnostic is the only thing that explains why.
+const madge = spawnSync(
+  process.execPath,
+  [madgeCli, '--circular', '--json', '--no-spinner', '--extensions', 'ts,tsx', 'src'],
+  { cwd: ROOT, encoding: 'utf8' },
+);
+const madgeOut = madge.stdout ?? '';
+const madgeErr = madge.error ? String(madge.error.message) : (madge.stderr ?? '');
 
 // `--json` is the only stable machine format: madge's human output carries ANSI
 // styling even under `--no-color`, which defeats string comparison against the

--- a/apps/desktop/scripts/check-circular.mjs
+++ b/apps/desktop/scripts/check-circular.mjs
@@ -41,19 +41,33 @@ const listMode = process.argv.includes('--list');
 let madgeOut;
 try {
   madgeOut = execSync(
-    'node_modules/.bin/madge --circular --no-spinner --no-color --extensions ts,tsx src',
-    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] },
+    'node_modules/.bin/madge --circular --json --no-spinner --extensions ts,tsx src',
+    { cwd: ROOT, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] },
   );
 } catch (err) {
   // madge exits 1 when cycles are found — capture stdout anyway.
   madgeOut = /** @type {any} */ (err).stdout ?? '';
 }
 
-// Parse "N) a/b.tsx > a/c.ts" lines from madge output.
-const cycleLines = madgeOut
-  .split('\n')
-  .map((l) => l.replace(/^\d+\)\s*/, '').trim())
-  .filter((l) => l.includes(' > '));
+// `--json` is the only stable machine format: madge's human output carries ANSI
+// styling even under `--no-color`, which defeats string comparison against the
+// allowlist.  Unparseable output means madge did not run (e.g. dependencies not
+// installed) — fail rather than report a vacuous pass.
+/** @type {string[][]} */
+let cycles;
+try {
+  cycles = JSON.parse(madgeOut);
+  if (!Array.isArray(cycles)) throw new Error('expected an array');
+} catch (err) {
+  process.stderr.write(
+    `CIRCULAR DEP GATE FAILED — could not parse madge --json output: ${
+      /** @type {Error} */ (err).message
+    }\nRun \`pnpm install\` in apps/desktop and retry.\n`,
+  );
+  process.exit(1);
+}
+
+const cycleLines = cycles.map((c) => c.join(' > '));
 
 if (listMode) {
   for (const c of cycleLines) process.stdout.write(`${c}\n`);


### PR DESCRIPTION
## Summary

- The circular-dependency lint gate reported its three known type-only cycles as new on every branch, including unmodified `main`, so `pnpm lint` was red everywhere.
- Root cause: `madge` writes ANSI styling to its human-readable output even with `--no-color`. The gate stripped `^\d+\)` from those lines and compared them to the allowlist with `Set.has`; the escape sequences defeated both, so no allowlist entry ever matched.
- Fix: `apps/desktop/scripts/check-circular.mjs` now reads `madge --circular --json` and joins each cycle array with `' > '`. JSON is the only ANSI-free machine format madge offers. The allowlist is unchanged and matching stays exact, so an unlisted cycle still fails.
- Secondary defect fixed: with `apps/desktop/node_modules` absent, `execSync` threw, `err.stdout` was empty, and the gate printed "0 new cycles" and exited 0 — a blind pass. Unparseable output now fails with an install hint.
- The three allowlisted reverse edges were re-confirmed `import type` only (`useTargetSearch.ts:31`, `PlanRootPicker.tsx:12`, and the equivalent import in `PlanDestructiveControl.tsx`). No component refactor needed.

## Verification

| Direction | Result |
| --- | --- |
| Gate on unmodified tree | exit 0, `0 new cycles (3 allowlisted type-import cycle(s))` |
| Gate with an injected real runtime cycle (two modules importing each other's values) | exit 1, names `zz-cycle-a.ts > zz-cycle-b.ts`; fixtures reverted |
| `pnpm --filter @astro-plan/desktop run lint` | exit 0 |

## Spec Context

Tracks-Bead: astro-plan-s5ae
Tracks-Bead: astro-plan-lyq1
Merge-Bead: astro-plan-rw23
