### PR TITLE
feat(scripts): detect declined CodeRabbit reviews instead of reading them as clean

### DIFF
--- a/scripts/check-coderabbit-review.sh
+++ b/scripts/check-coderabbit-review.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# CodeRabbit review-status scanner.
+#
+# Answers one question per PR: has CodeRabbit actually reviewed the current head,
+# or does it only LOOK reviewed? The distinction matters because CodeRabbit posts
+# an "Action performed / Review finished" acknowledgement even when it refused to
+# review — on a rate limit or a draft skip. Reading that marker as success is how
+# a review cycle records unreviewed PRs as "zero findings".
+#
+# A PR is REVIEWED only when a review body from coderabbitai[bot] exists for the
+# current head SHA. Acknowledgements never count as evidence.
+#
+# Statuses:
+#   REVIEWED      real review present for head; inline finding count reported
+#   RATE_LIMITED  bot declined — "Review limit reached" / fair-usage notice.
+#                 Reports when the window reopens as an absolute UTC time: the
+#                 bot's own "in N minutes" is relative to when it was posted and
+#                 is therefore stale on read.
+#   SKIPPED_DRAFT bot declined — draft PR and auto-review is off for drafts
+#   STALE         review exists, but only for an older commit than head
+#   PENDING       review in progress
+#   NOT_REVIEWED  no review and no explanatory notice
+#
+# Exit 0 when every scanned PR is REVIEWED; 1 otherwise. Only REVIEWED is a
+# green light to adjudicate findings — every other status means re-trigger.
+#
+# Usage:
+#   bash scripts/check-coderabbit-review.sh 1604 1605     # specific PRs
+#   bash scripts/check-coderabbit-review.sh --open        # every open PR
+#   bash scripts/check-coderabbit-review.sh --json 1604   # machine-readable
+set -euo pipefail
+
+BOT='coderabbitai[bot]'
+
+usage() {
+  cat >&2 <<'EOF'
+usage: check-coderabbit-review.sh [--json] (--open | <pr-number>...)
+
+  --open   scan every open PR in the current repository
+  --json   emit one JSON object per PR instead of aligned text
+
+Exits 0 only when every scanned PR has a real CodeRabbit review for its
+current head commit.
+EOF
+  exit 2
+}
+
+json_mode=0
+open_mode=0
+prs=()
+
+while (($# > 0)); do
+  case "$1" in
+    --json) json_mode=1 ;;
+    --open) open_mode=1 ;;
+    -h | --help) usage ;;
+    -*) printf 'unknown option: %s\n' "$1" >&2; usage ;;
+    *) prs+=("$1") ;;
+  esac
+  shift
+done
+
+command -v gh >/dev/null || { echo 'check-coderabbit-review: gh is required' >&2; exit 2; }
+
+if ((open_mode)); then
+  ((${#prs[@]} == 0)) || { echo 'check-coderabbit-review: --open takes no PR numbers' >&2; usage; }
+  mapfile -t prs < <(gh pr list --state open --limit 100 --json number --jq '.[].number')
+fi
+
+((${#prs[@]} > 0)) || usage
+
+# Report when the next review becomes available, given a rate-limit notice and
+# the time it was posted. The bot writes a relative figure ("in 31 minutes"),
+# which decays as the notice ages, so convert it to an absolute UTC instant and
+# subtract elapsed time. Echoes a human phrase, or nothing when the notice
+# carries no figure.
+wait_hint() { # $1 = notice created_at (ISO 8601), $2 = notice body
+  local created="$1" body="$2" minutes posted now deadline remaining
+
+  # "**Next review available in:** **31 minutes**" — also tolerate an hour form.
+  minutes=$(grep -oiE 'next review available in:?\**[[:space:]]*\**[[:space:]]*([0-9]+)[[:space:]]*(minute|hour)' <<<"$body" |
+    grep -oiE '[0-9]+[[:space:]]*(minute|hour)' | head -1 || true)
+  [[ -n "$minutes" ]] || return 0
+
+  local value unit
+  value=$(grep -oE '[0-9]+' <<<"$minutes" | head -1)
+  unit=$(grep -oiE '(minute|hour)' <<<"$minutes" | head -1 | tr '[:upper:]' '[:lower:]')
+  [[ "$unit" == hour ]] && value=$((value * 60))
+
+  # No created_at (or an unparseable one): fall back to the bot's own figure.
+  [[ -n "$created" ]] || { printf 'next review in ~%d min (per the notice)' "$value"; return 0; }
+
+  # GNU and BSD date disagree on ISO-8601 parsing; try both.
+  posted=$(date -u -d "$created" +%s 2>/dev/null ||
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$created" +%s 2>/dev/null || echo '')
+  [[ -n "$posted" ]] || { printf 'next review in ~%d min (per the notice)' "$value"; return 0; }
+
+  now=$(date -u +%s)
+  deadline=$((posted + value * 60))
+  remaining=$(((deadline - now + 59) / 60))
+
+  if ((remaining > 0)); then
+    printf 'next review in ~%d min (at %s UTC)' \
+      "$remaining" "$(date -u -r "$deadline" +%H:%M 2>/dev/null || date -u -d "@$deadline" +%H:%M)"
+  else
+    printf 'review window has reopened (elapsed %d min ago) — safe to re-trigger' \
+      "$((-remaining))"
+  fi
+}
+
+# Classify one PR. Echoes: status<TAB>head<TAB>inline_count<TAB>detail
+classify() {
+  local pr="$1" head reviews inline notices status detail count
+
+  head=$(gh pr view "$pr" --json headRefOid --jq '.headRefOid') || {
+    printf 'ERROR\t-\t0\tcannot read PR\n'; return
+  }
+
+  # Review bodies for the current head only. A review of an older commit does
+  # not vouch for what is on the branch now.
+  reviews=$(gh api "repos/:owner/:repo/pulls/$pr/reviews" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\")] | length" 2>/dev/null || echo 0)
+  local reviews_at_head
+  reviews_at_head=$(gh api "repos/:owner/:repo/pulls/$pr/reviews" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\" and .commit_id == \"$head\")] | length" 2>/dev/null || echo 0)
+
+  inline=$(gh api "repos/:owner/:repo/pulls/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\")] | length" 2>/dev/null || echo 0)
+
+  # Issue comments carry the bot's refusal notices. Match on the human-readable
+  # text as well as the machine marker, since either may change independently.
+  notices=$(gh api "repos/:owner/:repo/issues/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\") | .body] | join(\"\n\")" 2>/dev/null || echo '')
+
+  # The most recent notice that actually quotes a wait figure, with the time it
+  # was posted. "Next review available in: N minutes" is relative to when it was
+  # WRITTEN, so the raw number is stale on read — pair it with created_at to get
+  # a real wall-clock deadline. Selecting the *last* bot comment is wrong here:
+  # that is usually the bare "Review finished" ack, which carries no figure.
+  local latest
+  latest=$(gh api "repos/:owner/:repo/issues/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\" and (.body | test(\"[Nn]ext review available in\")))] | last | \"\(.created_at // \"\")\t\(.body // \"\")\"" \
+    2>/dev/null || printf '\t')
+
+  count="$inline"
+  if ((reviews_at_head > 0)); then
+    status=REVIEWED
+    detail="$inline inline finding(s)"
+  elif ((reviews > 0)); then
+    # A prior review exists but not for head — e.g. findings were addressed and
+    # pushed. This outranks the notice checks below, whose text may be left over
+    # from an earlier declined attempt on an older commit.
+    status=STALE
+    detail="review exists but not for head ${head:0:8} — re-trigger for the new commits"
+  elif grep -qE 'rate limited by coderabbit|Review limit reached|Fair Usage Limits' <<<"$notices"; then
+    status=RATE_LIMITED
+    local hint
+    hint=$(wait_hint "${latest%%$'\t'*}" "${latest#*$'\t'}")
+    detail="bot declined: review limit — ${hint:-re-trigger after the window}"
+    count=0
+  elif grep -qE 'skip review by coderabbit|Review skipped' <<<"$notices"; then
+    status=SKIPPED_DRAFT
+    detail='bot declined: draft skip — comment "@coderabbitai full review"'
+    count=0
+  elif grep -qE 'Review in progress|currently reviewing' <<<"$notices"; then
+    status=PENDING
+    detail='review in progress'
+    count=0
+  else
+    status=NOT_REVIEWED
+    detail='no review and no notice from the bot'
+    count=0
+  fi
+
+  # An acknowledgement with no review body is the exact trap this script exists
+  # to catch: flag it so the reason is visible in the output.
+  if [[ "$status" != REVIEWED ]] && grep -qE 'Review finished|Full review finished' <<<"$notices"; then
+    detail="$detail (bot posted 'Review finished' — NOT evidence of a review)"
+  fi
+
+  printf '%s\t%s\t%s\t%s\n' "$status" "$head" "$count" "$detail"
+}
+
+failed=0
+((json_mode)) || printf '%-8s %-14s %-10s %s\n' 'PR' 'STATUS' 'FINDINGS' 'DETAIL'
+
+for pr in "${prs[@]}"; do
+  IFS=$'\t' read -r status head count detail < <(classify "$pr")
+  [[ "$status" == REVIEWED ]] || failed=1
+
+  if ((json_mode)); then
+    printf '{"pr":%s,"status":"%s","head":"%s","inline_findings":%s,"detail":"%s"}\n' \
+      "$pr" "$status" "$head" "$count" "$detail"
+  else
+    printf '%-8s %-14s %-10s %s\n' "#$pr" "$status" "$count" "$detail"
+  fi
+done
+
+if ((failed)); then
+  ((json_mode)) || cat >&2 <<'EOF'
+
+Not every PR has a real CodeRabbit review. Do NOT record an unreviewed PR as
+clean: re-trigger with `@coderabbitai full review` and re-check.
+
+Note: CodeRabbit posts inline comments up to ~10 minutes after the review body,
+so a REVIEWED PR reporting 0 findings should be re-checked once before it is
+treated as genuinely clean.
+EOF
+  exit 1
+fi
+
+((json_mode)) || printf '\nAll %d PR(s) have a real CodeRabbit review for their current head.\n' "${#prs[@]}"

--- a/scripts/tests/check-coderabbit-review.bats
+++ b/scripts/tests/check-coderabbit-review.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+#
+# Regression tests for the CodeRabbit review-status scanner.
+#
+# The case that motivated the script: CodeRabbit posts an "Action performed /
+# Review finished" acknowledgement even when it declined to review (rate limit
+# or draft skip). A scanner that treats that marker as success reports an
+# unreviewed PR as clean. Every test below pins one classification so that
+# cannot regress.
+
+setup() {
+  export TEST_ROOT
+  TEST_ROOT=$(mktemp -d)
+  export SCRIPT="$BATS_TEST_DIRNAME/../check-coderabbit-review.sh"
+  export CR_HEAD="cafebabecafebabecafebabecafebabecafebabe"
+  export CR_REVIEWS="$TEST_ROOT/reviews.json"
+  export CR_INLINE="$TEST_ROOT/inline.json"
+  export CR_NOTICES="$TEST_ROOT/notices.json"
+
+  mkdir -p "$TEST_ROOT/bin"
+  export PATH="$TEST_ROOT/bin:$PATH"
+
+  printf '[]\n' >"$CR_REVIEWS"
+  printf '[]\n' >"$CR_INLINE"
+  printf '[]\n' >"$CR_NOTICES"
+
+  write_gh_stub
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+# Stub gh so the scanner's four API shapes read from fixture files. jq runs for
+# real, which keeps the --jq filters under test rather than mocked away.
+write_gh_stub() {
+  cat >"$TEST_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+filter=""
+for ((i = 1; i <= $#; i++)); do
+  if [[ "${!i}" == "--jq" ]]; then
+    next=$((i + 1))
+    filter="${!next}"
+  fi
+done
+
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf '%s\n' "$CR_HEAD"
+  exit 0
+fi
+
+if [[ "$1" == "api" ]]; then
+  case "$2" in
+    *"/reviews") jq -r "$filter" <"$CR_REVIEWS" ;;
+    *"/comments")
+      if [[ "$2" == *"/issues/"* ]]; then
+        jq -r "$filter" <"$CR_NOTICES"
+      else
+        jq -r "$filter" <"$CR_INLINE"
+      fi
+      ;;
+    *) echo "unexpected api path: $2" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$TEST_ROOT/bin/gh"
+}
+
+bot_review() { # $1 = commit_id
+  printf '[{"user":{"login":"coderabbitai[bot]"},"commit_id":"%s","body":"Actionable comments posted: 1"}]\n' \
+    "$1" >"$CR_REVIEWS"
+}
+
+bot_notice() { # $1 = body text
+  jq -n --arg b "$1" '[{"user":{"login":"coderabbitai[bot]"},"body":$b}]' >"$CR_NOTICES"
+}
+
+inline_count() { # $1 = how many inline comments
+  jq -n --argjson n "$1" \
+    '[range($n) | {user:{login:"coderabbitai[bot]"}, body:"finding"}]' >"$CR_INLINE"
+}
+
+@test "a real review for head is REVIEWED and exits 0" {
+  bot_review "$CR_HEAD"
+  inline_count 3
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *REVIEWED* ]]
+  [[ "$output" == *"3 inline finding(s)"* ]]
+}
+
+@test "a rate-limit notice is RATE_LIMITED, not clean" {
+  bot_notice 'Review limit reached — you have reached your PR review limit'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+}
+
+@test "a rate limit plus a Review finished ack is still RATE_LIMITED" {
+  # The exact shape that fooled the earlier review cycle.
+  bot_notice 'rate limited by coderabbit.ai — Review limit reached
+Action performed: Review finished.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" == *"NOT evidence of a review"* ]]
+}
+
+@test "a fair-usage notice is RATE_LIMITED" {
+  bot_notice 'Full review finished.
+
+Your included review limit is currently reached under our Fair Usage Limits Policy.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+}
+
+@test "a draft skip is SKIPPED_DRAFT" {
+  bot_notice 'skip review by coderabbit.ai — Review skipped. Draft detected.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *SKIPPED_DRAFT* ]]
+}
+
+@test "a review of an older commit is STALE, never REVIEWED" {
+  bot_review "0000000000000000000000000000000000000000"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *STALE* ]]
+}
+
+@test "a stale review outranks a leftover rate-limit notice" {
+  # Findings were addressed and pushed after an earlier declined attempt: the
+  # actionable state is 'needs a re-trigger for the new commits', not 'rate
+  # limited'.
+  bot_review "0000000000000000000000000000000000000000"
+  bot_notice 'Review limit reached'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *STALE* ]]
+  [[ "$output" != *RATE_LIMITED* ]]
+}
+
+@test "silence is NOT_REVIEWED" {
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *NOT_REVIEWED* ]]
+}
+
+@test "a bare Review finished ack with no review body is NOT_REVIEWED" {
+  bot_notice 'Action performed: Review finished.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *NOT_REVIEWED* ]]
+  [[ "$output" == *"NOT evidence of a review"* ]]
+}
+
+@test "a reviewed PR with zero findings still exits 0 but warns about late comments" {
+  bot_review "$CR_HEAD"
+  inline_count 0
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *REVIEWED* ]]
+  [[ "$output" == *"0 inline finding(s)"* ]]
+}
+
+@test "one declined PR fails a mixed batch" {
+  bot_review "$CR_HEAD"
+  run bash "$SCRIPT" 1234 5678
+  [ "$status" -eq 0 ]
+
+  bot_review "0000000000000000000000000000000000000000"
+  run bash "$SCRIPT" 1234 5678
+  [ "$status" -eq 1 ]
+}
+
+@test "--json emits one parseable object per PR" {
+  bot_review "$CR_HEAD"
+  inline_count 2
+  run bash "$SCRIPT" --json 1234
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.status == "REVIEWED" and .inline_findings == 2 and .pr == 1234'
+}
+
+@test "no arguments is a usage error" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+# --- wait-time reporting -----------------------------------------------------
+#
+# The bot writes "Next review available in: N minutes" relative to when the
+# notice was posted, so the figure decays. These pin the conversion to an
+# absolute deadline, which is the number a caller can actually act on.
+
+rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
+  jq -n --arg t "$1" --arg m "$2" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:("Review limit reached\n\n> **Next review available in:** **" + $m + " minutes**")}]' \
+    >"$CR_NOTICES"
+}
+
+@test "a still-closed window reports minutes remaining and a UTC time" {
+  # Posted 5 minutes ago quoting 30 → ~25 remaining.
+  rate_limit_notice_at "$(date -u -r "$(( $(date -u +%s) - 300 ))" +%Y-%m-%dT%H:%M:%SZ)" 30
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" =~ next\ review\ in\ ~2[0-9]\ min ]]
+  [[ "$output" == *"UTC)"* ]]
+}
+
+@test "an elapsed window reports that it has reopened" {
+  # Posted 2 hours ago quoting 30 minutes → long since reopened.
+  rate_limit_notice_at "$(date -u -r "$(( $(date -u +%s) - 7200 ))" +%Y-%m-%dT%H:%M:%SZ)" 30
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"has reopened"* ]]
+  [[ "$output" == *"safe to re-trigger"* ]]
+}
+
+@test "an hour-denominated figure is converted to minutes" {
+  jq -n --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Review limit reached\n\n> **Next review available in:** **1 hour**"}]' \
+    >"$CR_NOTICES"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ next\ review\ in\ ~(59|60)\ min ]]
+}
+
+@test "a rate limit with no quoted figure still reports actionable text" {
+  bot_notice 'Review limit reached — no figure given'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" == *"re-trigger after the window"* ]]
+}
+
+@test "the wait figure is read from the notice, not the trailing ack" {
+  # Real shape: the rate-limit notice comes first, a bare "Review finished" ack
+  # last. Reading only the last comment loses the figure entirely.
+  jq -n --arg t "$(date -u -r "$(( $(date -u +%s) - 60 ))" +%Y-%m-%dT%H:%M:%SZ)" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Review limit reached\n\n> **Next review available in:** **25 minutes**"},
+      {user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Action performed: Review finished."}]' >"$CR_NOTICES"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ next\ review\ in\ ~2[0-9]\ min ]]
+}


### PR DESCRIPTION
## Why

The serial CodeRabbit review cycle in `run-wjrz-20260727` recorded six PRs as
*"reviewed, re-swept, zero inline findings"* — #1569, #1572, #1600, #1603, #1604,
#1605. CodeRabbit had never reviewed any of them. Five were rate-limited and one
was skipped as a draft; in every case the bot posted a `✅ Action performed —
Review finished` acknowledgement alongside the refusal, and that marker was read
as success.

The cost was real. Re-running the reviews properly found that #1604 carried three
findings, one of them a CI gate that skipped both ratchets it had just been added
to enforce, and #1605 carried a diagnostic-masking bug whose fix then exposed that
the circular-dependency gate had never worked on Windows at all.

## What

`scripts/check-coderabbit-review.sh` treats a review body at the current head SHA
as the only evidence that a review happened, and names the reason otherwise:

| Status | Meaning |
|---|---|
| `REVIEWED` | real review for the current head; inline finding count reported |
| `RATE_LIMITED` | bot declined — review limit or fair-usage notice |
| `SKIPPED_DRAFT` | bot declined — draft PR, auto-review off for drafts |
| `STALE` | reviewed, but an older commit than head |
| `PENDING` | review in progress |
| `NOT_REVIEWED` | no review, no notice |

Exit 0 only when every scanned PR is `REVIEWED`. When a non-`REVIEWED` PR also
carries a `Review finished` ack, the output says so explicitly, so the trap is
visible rather than silent.

For a rate limit it reports when the window reopens as an **absolute UTC time**.
The bot's own `Next review available in: N minutes` is relative to when the notice
was posted, so the figure is stale by the time anyone reads it. The figure is read
from the notice that quotes it, not the last comment — that is usually the bare
acknowledgement and carries no figure.

```
$ bash scripts/check-coderabbit-review.sh 1596 1603 1605
PR       STATUS         FINDINGS   DETAIL
#1596    REVIEWED       1          1 inline finding(s)
#1603    RATE_LIMITED   0          bot declined: review limit — review window has reopened (elapsed 596 min ago) — safe to re-trigger (bot posted 'Review finished' — NOT evidence of a review)
#1605    STALE          1          review exists but not for head fb6c17a7 — re-trigger for the new commits
```

`--open` scans every open PR; `--json` emits one object per PR for scripting.

## Verification

- 18/18 bats tests pass (`scripts/tests/check-coderabbit-review.bats`), covering
  each classification, both wait-window directions, hour-denominated figures, and
  the exact notice shape that caused the original misread.
- `shellcheck` clean.
- The guard is load-bearing, verified by mutation: making the script trust a
  `Review finished` ack fails tests 3 and 9.
- Run against the live API on all ten PRs from the original cycle: it reproduces
  the failure exactly — the four genuinely-reviewed PRs report `REVIEWED` with
  their correct finding counts, and all six the handover called clean are flagged
  as declined.

Merge-Bead: astro-plan-6n93
