### PR TITLE
fix: persistence_targets tests compile standalone again

### DIFF
--- a/crates/persistence/targets/Cargo.toml
+++ b/crates/persistence/targets/Cargo.toml
@@ -19,7 +19,7 @@ time.workspace = true
 uuid.workspace = true
 
 [dev-dependencies]
-persistence_core = { path = "../core", features = [] }
+persistence_core = { path = "../core", features = ["test-fixture"] }
 persistence_lifecycle = { path = "../lifecycle" }
 tempfile.workspace = true
 tokio.workspace = true


### PR DESCRIPTION
## Summary
- `cargo test -p persistence_targets` failed to compile: the dev-dependency on `persistence_core` declared `features = []`, but the tests import `persistence_core::test_support`, which is gated behind `#[cfg(any(test, feature = "test-fixture"))]`. That gate opens for persistence_core own test build, not for a dependent crate, so the import resolved to nothing.
- Adding the `test-fixture` feature to the dev-dep fixes it. One line, dev-dependencies only — no effect on release builds.

## Verification
- Before: 6 × `E0432: unresolved import persistence_core::test_support`.
- After: 64 tests pass.

Merge-Bead: astro-plan-220v