### PR TITLE
fix: coverage CI job no longer fails on cross-language contract tests

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -86,6 +86,24 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
+      # The workspace test run includes Rust tests that shell out to `node` for
+      # cross-language contract parity — `spec062_portable_contracts` spawns
+      # `packages/contracts/tests/utf8-byte-keywords.test.mjs`, which imports
+      # `ajv/dist/2020`. Without the JS deps installed those tests fail with
+      # MODULE_NOT_FOUND, so this job needs the same Node setup as ci.yml's
+      # integration job even though it is nominally Rust-only.
+      - uses: pnpm/action-setup@v6
+        with:
+          version: 11.17.0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install JS deps
+        run: pnpm install --frozen-lockfile
+
       - name: Collect coverage (workspace, all tests + doctests)
         run: |
           cargo llvm-cov \


### PR DESCRIPTION
## Summary

- The `Rust coverage (llvm-cov)` check failed on every PR that triggered it
  (seen on #1595, #1607, #1608).
- Root cause: the job runs the whole workspace test suite, and that suite
  includes cross-language contract-parity tests that shell out to `node`.
  `tests/contract/spec062_portable_contracts.rs` spawns
  `packages/contracts/tests/utf8-byte-keywords.test.mjs`, which imports
  `ajv/dist/2020`. The job had no Node or pnpm setup, being nominally Rust-only,
  so the test died with `MODULE_NOT_FOUND`.
- Adds the same `pnpm/action-setup` + `setup-node` + `pnpm install --frozen-lockfile`
  steps `ci.yml` already uses for its integration job.

## Verification

Reproduced locally by moving `packages/contracts/node_modules` aside, which
produces the identical failure:

```
Error: Cannot find module 'ajv/dist/2020'
  code: 'MODULE_NOT_FOUND',
```

With the deps present the test passes:

```
test spec062_portable_contracts::relative_path_schema_and_serde_share_utf8_byte_boundaries ... ok
```

## Note on earlier triage

An earlier triage pass attributed the llvm-cov failure to the event-loss bug
`astro-plan-9s0l` (a `stale_propagator` cursor test). That defect may well be
real and worth fixing on its own merits, but it is not what is failing this
check now: the current failure is this missing-dependency issue, and the job
never reaches a coverage measurement at all.

Merge-Bead: astro-plan-m3l5
