### PR TITLE
fix: intermittent inbox plan-listener test failure

### DIFF
--- a/crates/app/inbox/src/plan_listener.rs
+++ b/crates/app/inbox/src/plan_listener.rs
@@ -599,6 +599,29 @@ pub(crate) mod tests {
         .await;
     }
 
+    /// Poll until the `inbox_plan_links` row for `item_id` is gone, panic after
+    /// 2 s.
+    ///
+    /// `transition_via_plan_id` updates the item state and deletes the link as
+    /// two separate writes, so observing the new state does NOT imply the link
+    /// is already gone — asserting on it directly after `wait_item_state` is a
+    /// race that fails intermittently under load.
+    async fn wait_plan_link_deleted(pool: &sqlx::SqlitePool, item_id: &str) {
+        let owned_id = item_id.to_owned();
+        poll_until(
+            move || {
+                let id = owned_id.clone();
+                let pool = pool.clone();
+                async move {
+                    let link = inbox_repo::get_plan_link(&pool, &id).await.expect("poll plan link");
+                    link.is_none().then_some(())
+                }
+            },
+            &format!("plan link for inbox item {item_id} was never deleted"),
+        )
+        .await;
+    }
+
     fn make_bus(db: &Database) -> EventBus {
         EventBus::with_pool(db.pool().clone())
     }
@@ -682,8 +705,7 @@ pub(crate) mod tests {
         let item = inbox_repo::get_inbox_item(db.pool(), "item-t1").await.unwrap();
         assert_eq!(item.state, "resolved");
 
-        let link = inbox_repo::get_plan_link(db.pool(), "item-t1").await.unwrap();
-        assert!(link.is_none(), "plan link should be deleted after resolution");
+        wait_plan_link_deleted(db.pool(), "item-t1").await;
     }
 
     /// issue #1256: a `plan.applying.completed`("applied") event must trigger


### PR DESCRIPTION
## Summary

- `plan_listener::tests::applied_plan_transitions_to_resolved` failed intermittently with `plan link should be deleted after resolution`, breaking the coverage and integration legs on unrelated PRs (seen on #1605 and #1609).
- `transition_via_plan_id` does two separate writes: update the inbox item state, then delete the `inbox_plan_links` row. `wait_item_state` returning means only the first has landed, so asserting on the link immediately afterwards races the delete and fails whenever the runner is loaded enough to observe the two apart.
- Now polls for the deletion using the module own `poll_until` helper, which exists for exactly this reason.

Not a product bug: the listener ordering is correct and the link is always deleted. The test assumed an atomicity it never had.

## Verification

30 consecutive runs of the test pass; `cargo clippy -p app_core_inbox --all-targets -- -D warnings` clean.

Merge-Bead: astro-plan-8b8c