### PR TITLE
docs: spec status lines no longer claim shipped work is unimplemented

### DIFF
--- a/specs/012-processing-artifact-observation/spec.md
+++ b/specs/012-processing-artifact-observation/spec.md
@@ -7,7 +7,12 @@
 **Feature Branch**: `012-processing-artifact-observation`  
 **Created**: 2026-05-09  
 **Last Updated**: 2026-05-22  
-**Status**: Draft  
+**Status**: Implemented (post-hoc record, verified 2026-07-28). Artifact
+observation ships at HEAD via `crates/workflow/artifacts` and the app-layer
+artifact use-cases. The two remaining unchecked boxes in `tasks.md` are a missing
+e2e mock fixture and a missing research doc, tracked as a bead; the underlying
+behaviour already has unit coverage. That file is legacy paper and task state
+lives in beads.  
 **Input**: User description: "Specify how the app observes outputs from PixInsight, Siril, planetary/lunar tools, and future workflow profiles without becoming the processing tool."
 
 ## Implementation Status: Substantially implemented (2026-07-03)

--- a/specs/038-wizard-scan-step/spec.md
+++ b/specs/038-wizard-scan-step/spec.md
@@ -4,7 +4,10 @@
 
 **Created**: 2026-06-19
 
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-07-28). The wizard scan
+step ships in `apps/desktop/src/features/setup/SetupWizard.tsx` (`SCAN_STEP` /
+`isOnScanStep`, around lines 555-609). This header claimed otherwise until the
+2026-07-28 spec audit corrected it.
 
 **Input**: As the last step in the setup wizard, perform the actual scan per registered source and show the status of the scan (what was detected per source). Ingestion-group approval for brownfield libraries happens in the Inbox afterward — the wizard step is scan + summary only and reuses the Inbox triage components for the summary view.
 

--- a/specs/042-stdlib-adoption/spec.md
+++ b/specs/042-stdlib-adoption/spec.md
@@ -2,7 +2,10 @@
 
 **Feature Branch**: `042-stdlib-adoption`
 **Created**: 2026-06-20
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-07-28). All substantive
+adoption work ships at HEAD. The remaining unchecked boxes in `tasks.md` are
+commit-bookkeeping checkpoints plus one manual Windows verification, not code
+gaps. That file is legacy paper; task state for this spec lives in beads.
 **Input**: User description: "Discover hand-rolled code across the repo (Rust + TS/React) that has a well-established standard-library replacement, then spec, plan, task, implement, and verify the migrations — anchored on replacing the homegrown desktop state store with TanStack Query. Maximal adoption appetite; harden the Rust↔TypeScript boundary; de-duplicate copy-pasted helpers; make narrow crate-structure fixes."
 
 ## Overview

--- a/specs/050-publishable-crate-extractions/spec.md
+++ b/specs/050-publishable-crate-extractions/spec.md
@@ -4,7 +4,12 @@
 
 **Created**: 2026-07-04
 
-**Status**: Approved plan-of-record (decisions final; no implementation yet)
+**Status**: Implemented (post-hoc record, verified 2026-07-28). All four crates
+are extracted and published, and the workspace consumes them as versioned
+external dependencies: `fits-header 0.4.2` (`crates/metadata/fits/Cargo.toml`),
+`xisf-header 0.4.3` (`crates/metadata/xisf/Cargo.toml`), `skymath 0.7.1` and
+`target-match 0.5.1` (`crates/targeting/Cargo.toml`). This header still read
+"no implementation yet" until the 2026-07-28 spec audit corrected it.
 
 **Input**: User description: "Record the approved publishable-crate extraction
 program — four crates identified by the crate-audit (2026-07-04) as

--- a/specs/052-simbad-caching-dual-lookup-cone-search/spec.md
+++ b/specs/052-simbad-caching-dual-lookup-cone-search/spec.md
@@ -4,7 +4,13 @@
 
 **Created**: 2026-07-12
 
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-07-28). The resolver
+facade, dual TAP/Sesame lookup, oid recovery, normalize choke-point, seed-builder
+`v_mag` column, cache-clear command, and cone search all ship at HEAD. The
+remaining unchecked boxes in `tasks.md` are legacy paper: `T002` asks to bump
+`simbad-resolver` 0.1.3 to 0.2.0, and the workspace is on 0.5.0. Task state for
+this spec lives in beads, not `tasks.md`. Outstanding process gates (speckit-verify
+run, Windows verification) are tracked separately.
 
 **Input**: User description: "SIMBAD resolver: persistent resolve cache, in-use-gated persistence, dual lookup (catalogue-first with a name-resolver fallback), and cone-search from plate-solved coordinates to suggest a target at Inbox ingest."
 

--- a/specs/057-branding-splash/spec.md
+++ b/specs/057-branding-splash/spec.md
@@ -4,7 +4,11 @@
 
 **Created**: 2026-07-19
 
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-07-28). The splash window
+ships in `apps/desktop/src/splash/main.ts`, with the minimum-display and
+boot-ready handshake in `apps/desktop/src-tauri/src/lib.rs` (around lines
+119-258). This header claimed otherwise until the 2026-07-28 spec audit
+corrected it.
 
 **Input**: User description: "PlateVault logo system + native splash screen + docs brand alignment. Native splashscreen window shown at launch while the main window stays hidden; startup work (database open + migrations) runs while the splash is visible; splash closes when startup is complete AND a minimum 800 ms has elapsed. Extensible splash content variants (mark-only / mark+wordmark+version / mark+live-status) with a live startup-status channel. New logo designed externally in Claude Design (single-color-capable master SVG); replace stock app icons, placeholder favicon, About dialog, README header; align docs-site brand assets (favicon, og-image, hero, stale org link). Bundle identifier change explicitly out of scope."
 

--- a/specs/058-inbox-drop-parent-items/spec.md
+++ b/specs/058-inbox-drop-parent-items/spec.md
@@ -4,7 +4,13 @@
 
 **Created**: 2026-07-19
 
-**Status**: Draft
+**Status**: Implemented (post-hoc record, verified 2026-07-28). Placeholder
+creation is removed, `inbox_classify_source_group` ships, source groups render
+with a Classify action, `"mixed"` is retired from the classifier, and the
+migration citations are corrected. The unchecked and `BLOCKED` annotations in
+`tasks.md` describe a state HEAD has since resolved; that file is legacy paper
+and task state lives in beads. Outstanding verification gates (`T030`, `T042`,
+`T048`) and the e2e helper split (`T014`-`T016`) are tracked as beads.
 
 **Input**: Product-owner decision: "Drop the concept of parent inbox items
 entirely. A folder produces one or more real inbox items, never a parent plus


### PR DESCRIPTION
## Summary

- A spec audit on 2026-07-28 checked 33 specs (456 legacy `tasks.md` checkboxes) against HEAD. Seven `spec.md` status lines said Draft or "no implementation yet" for capability that ships.
- Corrected each with the evidence found, so the headers describe what the repo does at HEAD.

| spec | said | ships at HEAD |
|---|---|---|
| 038 wizard scan step | Draft | `SetupWizard.tsx` `SCAN_STEP` / `isOnScanStep` |
| 057 branding splash | Draft | `src/splash/main.ts` + `lib.rs` boot handshake |
| 050 publishable crates | no implementation yet | all four extracted AND published: `fits-header 0.4.2`, `xisf-header 0.4.3`, `skymath 0.7.1`, `target-match 0.5.1` |
| 052 simbad caching | Draft | resolver facade, dual lookup, cone search |
| 058 inbox drop parent items | Draft | placeholder creation removed, source-group classify, `mixed` retired |
| 042 stdlib adoption | Draft | substantive work complete |
| 012 artifact observation | Draft | observation ships; 2 test/doc gaps remain |

Spec 052 is the sharpest example: its `T002` asks to bump `simbad-resolver` from 0.1.3 to 0.2.0, and the workspace is on 0.5.0.

## No tasks.md changes

Beads is authoritative for task state here, and the steering forbids authoring `tasks.md`. So the stale checkboxes are described as legacy paper in the status text, and the genuine gaps found by the audit are filed as beads rather than ticked off.

## Audit coverage

Four of the five auditors hit a stall watchdog and reported from memory, so 19 specs (~75 tasks) got no independent verification. That gap is tracked in `astro-plan-4nwk` and is deliberately not asserted either way here.

Merge-Bead: astro-plan-dpcu