### PR TITLE
fix: session lists no longer advertise a review state the backend never sends

### DIFF
--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -1008,6 +1008,105 @@ mod tests {
         assert_eq!(run.items_total, 2);
     }
 
+    /// Spec 025 T025: a rollback attempt is durably recorded on the
+    /// `plan_apply_events` row, not just reported in memory.
+    ///
+    /// The executor only attempts a rollback on the cross-volume
+    /// copy-then-delete path (`crates/fs/executor/src/ops/move_op.rs`), whose
+    /// failure injection is private to that crate, so this asserts the audit
+    /// write itself: the three `rollback_*` columns round-trip the outcome that
+    /// `plan_apply::callbacks` passes down when `rollback_attempted` is set.
+    #[tokio::test]
+    async fn append_event_persists_rollback_attempt() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        setup_with_approved_plan(&db, "p-rollback", 1).await;
+        cas_approved_to_applying(db.pool(), "p-rollback", "run-rb", "test-token", 1, 1)
+            .await
+            .unwrap();
+
+        let failure = EventFailure {
+            code: "copy_succeeded_delete_failed_rollback_failed",
+            message: "delete of source failed after copy; rollback also failed",
+            recoverable: false,
+        };
+        let rollback = EventRollback {
+            attempted: true,
+            outcome: "failed",
+            message: Some("could not remove the copied destination file"),
+        };
+
+        append_event(
+            db.pool(),
+            "ev-rb-1",
+            "run-rb",
+            "p-rollback",
+            Some("p-rollback-item-0"),
+            "applying",
+            "failed",
+            "2026-06-01T00:00:01Z",
+            Some(&failure),
+            Some(&rollback),
+        )
+        .await
+        .unwrap();
+
+        let (attempted, outcome, message): (Option<i64>, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT rollback_attempted, rollback_outcome, rollback_message \
+                 FROM plan_apply_events WHERE id = ?",
+            )
+            .bind("ev-rb-1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+        assert_eq!(attempted, Some(1), "rollback_attempted must persist as true");
+        assert_eq!(outcome.as_deref(), Some("failed"));
+        assert_eq!(message.as_deref(), Some("could not remove the copied destination file"));
+    }
+
+    /// A non-rollback event leaves all three `rollback_*` columns NULL, so a
+    /// reader can distinguish "no rollback was needed" from "rollback failed".
+    #[tokio::test]
+    async fn append_event_without_rollback_leaves_columns_null() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        setup_with_approved_plan(&db, "p-norb", 1).await;
+        cas_approved_to_applying(db.pool(), "p-norb", "run-norb", "test-token", 1, 1)
+            .await
+            .unwrap();
+
+        append_event(
+            db.pool(),
+            "ev-norb-1",
+            "run-norb",
+            "p-norb",
+            Some("p-norb-item-0"),
+            "applying",
+            "applied",
+            "2026-06-01T00:00:01Z",
+            None,
+            None,
+        )
+        .await
+        .unwrap();
+
+        let (attempted, outcome, message): (Option<i64>, Option<String>, Option<String>) =
+            sqlx::query_as(
+                "SELECT rollback_attempted, rollback_outcome, rollback_message \
+                 FROM plan_apply_events WHERE id = ?",
+            )
+            .bind("ev-norb-1")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+        assert_eq!(attempted, None);
+        assert_eq!(outcome, None);
+        assert_eq!(message, None);
+    }
+
     #[tokio::test]
     async fn cas_fails_if_not_approved() {
         let db = Database::in_memory().await.unwrap();

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -13,7 +13,7 @@
   },
   "scripts": {
     "build": "node scripts/build-schemas.mjs",
-    "test": "node tests/lifecycle.transition.errors.test.mjs && node tests/sourceview.generate.test.mjs && node tests/sourceview.verify.test.mjs && node tests/conformance-harness.mjs",
+    "test": "node tests/lifecycle.transition.errors.test.mjs && node tests/sourceview.generate.test.mjs && node tests/sourceview.verify.test.mjs && node tests/calibration.type.parity.test.mjs && node tests/conformance-harness.mjs",
     "typecheck": "tsc --noEmit"
   },
   "dependencies": {

--- a/packages/contracts/schemas/inventory.list.schema.json
+++ b/packages/contracts/schemas/inventory.list.schema.json
@@ -30,18 +30,6 @@
       "enum": ["light", "dark", "flat", "bias", "mixed"],
       "description": "dark_flat is reserved in the FrameType domain enum but is never returned in v1. mixed is a server-derived sentinel for post-promotion regressions."
     },
-    "SessionState": {
-      "type": "string",
-      "description": "Canonical spec 002 session state. No server-side presentational projection. UI maps display labels locally: discovered+candidate display as 'Needs review'.",
-      "enum": [
-        "discovered",
-        "candidate",
-        "needs_review",
-        "confirmed",
-        "rejected",
-        "ignored"
-      ]
-    },
     "ReviewFilter": {
       "type": "string",
       "description": "Filter token for the reviewFilter parameter. 'all' disables state filtering. 'ignored' surfaces ignored sessions that are otherwise excluded from the default ledger.",
@@ -156,8 +144,7 @@
         "type",
         "target",
         "filter",
-        "exposure",
-        "state"
+        "exposure"
       ],
       "additionalProperties": false,
       "properties": {
@@ -169,10 +156,6 @@
         "target": { "type": ["string", "null"] },
         "filter": { "type": ["string", "null"] },
         "exposure": { "type": ["string", "null"] },
-        "state": {
-          "$ref": "#/$defs/SessionState",
-          "description": "Canonical spec 002 state. UI maps display labels locally: discovered+candidate → 'Needs review'. ignored sessions only appear when reviewFilter='ignored'."
-        },
         "camera": { "type": "string" },
         "gain": { "type": "string" },
         "binning": { "type": "string" },

--- a/packages/contracts/scripts/build-schemas.mjs
+++ b/packages/contracts/scripts/build-schemas.mjs
@@ -1,10 +1,34 @@
-import { mkdirSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { existsSync, mkdirSync, readdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
 import { basename, join } from "node:path";
 import { spawnSync } from "node:child_process";
 
 const schemasDir = new URL("../schemas", import.meta.url).pathname;
 const specsDir = new URL("../../../specs", import.meta.url).pathname;
 const generatedDir = new URL("../src/generated", import.meta.url).pathname;
+const packageDir = new URL("..", import.meta.url).pathname;
+
+// `json2ts` is a dependency binary, not a global. `spawnSync` without a shell
+// does not consult the package-manager-injected PATH, so resolve the bin
+// explicitly: pnpm puts it in this package's node_modules, npm/hoisted layouts
+// in the workspace root. Without this every invocation failed with ENOENT,
+// which the old script reported as "json2ts failed on <schema>" — indis-
+// tinguishable from a genuine schema error.
+function resolveJson2Ts() {
+  const candidates = [
+    join(packageDir, "node_modules/.bin/json2ts"),
+    join(packageDir, "../../node_modules/.bin/json2ts"),
+    join(packageDir, "../../node_modules/.pnpm/node_modules/.bin/json2ts"),
+  ];
+  const found = candidates.find((path) => existsSync(path));
+  if (!found) {
+    console.error(
+      "json2ts binary not found. Install dependencies first (`pnpm install`).\nLooked in:\n" +
+        candidates.map((c) => `  ${c}`).join("\n"),
+    );
+    process.exit(1);
+  }
+  return found;
+}
 
 function findSchemas(dir) {
   return readdirSync(dir, { withFileTypes: true }).flatMap((entry) => {
@@ -59,35 +83,47 @@ function findSpecContracts() {
   });
 }
 
-rmSync(generatedDir, { recursive: true, force: true });
-mkdirSync(generatedDir, { recursive: true });
-
+const json2ts = resolveJson2Ts();
 const schemas = [...findSchemas(schemasDir), ...findSpecContracts()];
 
 if (schemas.length === 0) {
-  writeFileSync(
-    join(generatedDir, "contracts.d.ts"),
-    "export {};\n",
-    "utf8",
-  );
+  mkdirSync(generatedDir, { recursive: true });
+  writeFileSync(join(generatedDir, "contracts.d.ts"), "export {};\n", "utf8");
   console.log("No contract schemas found yet; wrote placeholder declarations.");
   process.exit(0);
 }
 
-let exitCode = 0;
+// Generate into a staging directory and swap it in only once every schema has
+// succeeded. The previous script deleted `src/generated` up front, so a failed
+// run left the tree empty — worse than before it started, and it destroyed the
+// only copy of types that could no longer be regenerated.
+const stagingDir = `${generatedDir}.staging`;
+rmSync(stagingDir, { recursive: true, force: true });
+mkdirSync(stagingDir, { recursive: true });
+
+const failures = [];
 for (const schema of schemas) {
   const stem = basename(schema, ".schema.json").replace(/\.json$/, "");
-  const output = join(generatedDir, `${stem}.d.ts`);
-  const result = spawnSync(
-    "json2ts",
-    ["-i", schema, "-o", output, "--unreachableDefinitions"],
-    { stdio: "inherit" },
-  );
+  const output = join(stagingDir, `${stem}.d.ts`);
+  const result = spawnSync(json2ts, ["-i", schema, "-o", output, "--unreachableDefinitions"], {
+    stdio: "inherit",
+  });
 
-  if (result.status !== 0) {
-    console.error(`json2ts failed on ${schema}`);
-    exitCode = result.status ?? 1;
+  if (result.error || result.status !== 0) {
+    failures.push(`${schema}${result.error ? ` (${result.error.message})` : ""}`);
   }
 }
 
-process.exit(exitCode);
+if (failures.length > 0) {
+  rmSync(stagingDir, { recursive: true, force: true });
+  console.error(
+    `\njson2ts failed on ${failures.length} of ${schemas.length} schema(s); ` +
+      `${generatedDir} left unchanged:\n` +
+      failures.map((f) => `  ${f}`).join("\n"),
+  );
+  process.exit(1);
+}
+
+rmSync(generatedDir, { recursive: true, force: true });
+renameSync(stagingDir, generatedDir);
+console.log(`Generated ${schemas.length} contract declaration file(s).`);

--- a/packages/contracts/src/generated/inventory.list.d.ts
+++ b/packages/contracts/src/generated/inventory.list.d.ts
@@ -71,10 +71,6 @@ export interface InventorySession {
   target: string | null;
   filter: string | null;
   exposure: string | null;
-  /**
-   * Canonical spec 002 state. UI maps display labels locally: discovered+candidate → 'Needs review'. ignored sessions only appear when reviewFilter='ignored'.
-   */
-  state: "discovered" | "candidate" | "needs_review" | "confirmed" | "rejected" | "ignored";
   camera?: string;
   gain?: string;
   binning?: string;

--- a/packages/contracts/tests/calibration.type.parity.test.mjs
+++ b/packages/contracts/tests/calibration.type.parity.test.mjs
@@ -1,0 +1,91 @@
+#!/usr/bin/env node
+// Spec 007 T040 — parity guard for the `CalibrationType` enum.
+//
+// The calibration type domain is duplicated across four places: the Rust
+// contract enum and the three suggest/assign JSON-Schema contracts. Nothing
+// stopped them drifting apart until this test existed.
+//
+// Validates that:
+// - all three spec-007 contracts define `$defs.CalibrationType`;
+// - each one enumerates exactly `dark`, `flat`, `bias`;
+// - `contracts_core::calibration_match::CalibrationType` enumerates the same
+//   three variants, parsed out of the Rust source;
+// - `dark_flat` appears in none of them (FR-001 / R-DarkFlat-Reserved reserves
+//   the name in the domain enum but never exposes it in v1 contracts).
+//
+// T040 originally read "…matches the canonical definition in spec 002 when
+// spec 002 adds it" and was deferred on that condition. Spec 002 never added a
+// CalibrationType enum — it has no calibration type surface at all — so the
+// canonical definition is the Rust contract enum, and that is what this guards.
+// If spec 002 ever does add one, add its schema to CONTRACTS below.
+//
+// Pure Node — no Vitest. Run via
+// `node packages/contracts/tests/calibration.type.parity.test.mjs`.
+
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, resolve } from "node:path";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, "../../..");
+
+const CANONICAL = ["dark", "flat", "bias"];
+const RESERVED_NEVER_EXPOSED = "dark_flat";
+
+const CONTRACTS = [
+  "specs/007-calibration-matching-rules/contracts/calibration.match.suggest.json",
+  "specs/007-calibration-matching-rules/contracts/calibration.match.suggest.batch.json",
+  "specs/007-calibration-matching-rules/contracts/calibration.match.assign.json",
+];
+
+const RUST_ENUM_SOURCE = "crates/contracts/core/src/calibration_match.rs";
+
+const failures = [];
+function assert(cond, msg) {
+  if (!cond) failures.push(msg);
+}
+
+function sameSet(actual, expected) {
+  if (!Array.isArray(actual) || actual.length !== expected.length) return false;
+  return expected.every((v) => actual.includes(v));
+}
+
+// 1. The three JSON-Schema contracts.
+for (const rel of CONTRACTS) {
+  const schema = JSON.parse(readFileSync(resolve(repoRoot, rel), "utf8"));
+  const def = schema.$defs?.CalibrationType;
+  assert(def, `${rel}: $defs.CalibrationType is defined`);
+  if (!def) continue;
+  assert(
+    sameSet(def.enum, CANONICAL),
+    `${rel}: CalibrationType enum is [${CANONICAL.join(", ")}], got [${(def.enum ?? []).join(", ")}]`,
+  );
+  assert(
+    !JSON.stringify(schema).includes(`"${RESERVED_NEVER_EXPOSED}"`),
+    `${rel}: ${RESERVED_NEVER_EXPOSED} is never exposed in a v1 contract`,
+  );
+}
+
+// 2. The Rust contract enum, parsed from source. Serde renames the variants
+//    snake_case, so `Dark` on the wire is `dark`.
+const rustSource = readFileSync(resolve(repoRoot, RUST_ENUM_SOURCE), "utf8");
+const enumBody = rustSource.match(/pub enum CalibrationType \{([^}]*)\}/);
+assert(enumBody, `${RUST_ENUM_SOURCE}: pub enum CalibrationType found`);
+if (enumBody) {
+  const variants = enumBody[1]
+    .split("\n")
+    .map((line) => line.replace(/\/\/.*$/, "").trim().replace(/,$/, ""))
+    .filter(Boolean)
+    .map((variant) => variant.replace(/([a-z0-9])([A-Z])/g, "$1_$2").toLowerCase());
+  assert(
+    sameSet(variants, CANONICAL),
+    `${RUST_ENUM_SOURCE}: CalibrationType variants are [${CANONICAL.join(", ")}], got [${variants.join(", ")}]`,
+  );
+}
+
+if (failures.length > 0) {
+  console.error("FAIL");
+  for (const f of failures) console.error(" -", f);
+  process.exit(1);
+}
+console.log(`OK — CalibrationType parity across ${CONTRACTS.length} contracts + Rust enum`);

--- a/specs/006-inventory-library-lifecycle/contracts/inventory.list.json
+++ b/specs/006-inventory-library-lifecycle/contracts/inventory.list.json
@@ -30,18 +30,6 @@
       "enum": ["light", "dark", "flat", "bias", "mixed"],
       "description": "dark_flat is reserved in the FrameType domain enum but is never returned in v1. mixed is a server-derived sentinel for post-promotion regressions."
     },
-    "SessionState": {
-      "type": "string",
-      "description": "Canonical spec 002 session state. No server-side presentational projection. UI maps display labels locally: discovered+candidate display as 'Needs review'.",
-      "enum": [
-        "discovered",
-        "candidate",
-        "needs_review",
-        "confirmed",
-        "rejected",
-        "ignored"
-      ]
-    },
     "ReviewFilter": {
       "type": "string",
       "description": "Filter token for the reviewFilter parameter. 'all' disables state filtering. 'ignored' surfaces ignored sessions that are otherwise excluded from the default ledger.",
@@ -146,8 +134,7 @@
         "type",
         "target",
         "filter",
-        "exposure",
-        "state"
+        "exposure"
       ],
       "additionalProperties": false,
       "properties": {
@@ -159,10 +146,6 @@
         "target": { "type": ["string", "null"] },
         "filter": { "type": ["string", "null"] },
         "exposure": { "type": ["string", "null"] },
-        "state": {
-          "$ref": "#/$defs/SessionState",
-          "description": "Canonical spec 002 state. UI maps display labels locally: discovered+candidate → 'Needs review'. ignored sessions only appear when reviewFilter='ignored'."
-        },
         "camera": { "type": "string" },
         "gain": { "type": "string" },
         "binning": { "type": "string" },

--- a/tests/contract/contract_jsonschema_roundtrip.rs
+++ b/tests/contract/contract_jsonschema_roundtrip.rs
@@ -231,27 +231,23 @@ fn inventory_list_request_with_filters_validates_against_inventory_list_schema()
     assert_validates(&validator, &instance, "InventoryListRequest (with filters)");
 }
 
-// ── PARITY DIVERGENCE (bead astro-plan-kyo7.23) ──────────────────────────────
+// ── PARITY RESOLVED (was bead astro-plan-kyo7.23) ────────────────────────────
 //
-// `inventory.list.schema.json §$defs.InventorySession` requires a `"state"`
-// field (the spec 002 six-value session state), but `contracts_core::inventory::
-// InventorySession` no longer has that field.  It was removed in spec 041
-// FR-051 (T076, Phase 13): sessions on this surface are derived,
-// already-confirmed inventory — the review-state machine was removed and the
-// field is now absent from the Rust type.
+// `inventory.list.schema.json §$defs.InventorySession` used to require a
+// `"state"` field (the spec 002 six-value session state) that
+// `contracts_core::inventory::InventorySession` no longer has: it was removed in
+// spec 041 FR-051 (T076, Phase 13), because sessions on this surface are
+// derived, already-confirmed inventory, so the review-state machine went away.
 //
-// The JSON Schema has not been updated to match.  This is the authoritative
-// record of the divergence.  Tracked for schema update as a follow-up to this
-// bead.
+// The schema was updated to match on 2026-07-28 (spec 006 T506): `state` is gone
+// from `InventorySession.required` and its properties, and the now-unreferenced
+// `$defs.SessionState` was deleted from this schema. `SessionState` still lives
+// in `inventory.session.review.schema.json`, where the review-state machine —
+// and its `priorState`/`newState` transitions — remain real.
 //
-// The test is `#[ignore]` so `cargo test` stays green while the divergence is
-// visible.  Run with `--include-ignored` to confirm the failing assertion:
-//   cargo test --test contract_jsonschema_roundtrip -- --include-ignored
+// The test is no longer `#[ignore]`, so this parity is now enforced on every run
+// rather than recorded in a comment.
 #[test]
-#[ignore = "SCHEMA DRIFT: inventory.list.schema.json InventorySession.state required \
-            but Rust InventorySession has no state field (removed spec 041 FR-051). \
-            Update packages/contracts/schemas/inventory.list.schema.json to remove \
-            the state field from InventorySession.required and $defs.SessionState."]
 fn inventory_list_response_validates_against_inventory_list_schema() {
     let validator = inventory_list_validator();
     let session = InventorySession {


### PR DESCRIPTION
## Summary

- The inventory session list contract required a `state` field that the backend stopped sending, so any consumer trusting the published contract would look for a value that is never there. Removed it, and turned the recorded mismatch into an enforced check.
- Calibration type values (`dark`/`flat`/`bias`) were spelled out in four separate places with nothing keeping them in agreement. Added a guard so a change to one has to be a change to all.
- Rollback bookkeeping on a failed file operation is now covered by tests, so an attempted-and-failed rollback stays distinguishable from one that was never needed.

No user-visible behaviour changes: the backend already behaved this way. What changed is that the published contracts now match it, and drift fails the build instead of being written down in a comment.

## Spec Context

Three findings from the 2026-07-28 spec audit, all the same class — a contract or audit column nothing asserted.

**spec 006 T506.** `inventory.list` required `state` on `InventorySession`; the Rust type dropped it in spec 041 FR-051, when sessions on this surface became derived and already-confirmed and the review-state machine was removed. The schema was never updated, so `inventory_list_response_validates_against_inventory_list_schema` carried an `#[ignore]` *recording* the drift rather than failing on it. Removed `state` and the now-unreferenced `$defs.SessionState` from both schema copies, dropped the field from the generated `.d.ts`, un-ignored the test. `SessionState` stays in `inventory.session.review.schema.json`, where the review-state machine and its `priorState`/`newState` transitions are still real.

**spec 007 T040.** New `packages/contracts/tests/calibration.type.parity.test.mjs` checks the three suggest/assign contracts and the Rust enum agree, and that `dark_flat` stays reserved-but-unexposed (FR-001). T040 originally deferred on *"when spec 002 adds it"* — spec 002 has no calibration type surface at all, so that condition was never going to fire. The Rust contract enum is the canonical definition, and is what the guard checks.

**spec 025 T025.** `plan_apply_events` has `rollback_attempted`/`outcome`/`message` columns whose write path had no test. The executor only attempts a rollback on the cross-volume copy-then-delete branch, and its failure injection is private to `fs_executor`, so this asserts at the persistence seam: a rollback attempt round-trips all three columns, and a normal event leaves them NULL. The task's deferral note was stale — `move_op.rs:319-397` has covered the executor branch since.

## Verification

- `cargo test --test contract_jsonschema_roundtrip` — 15 passed, **0 ignored** (was 14 + 1 ignored)
- `cargo test -p persistence_plans --features persistence_core/test-fixture --lib plan_apply` — 13 passed
- `packages/contracts` `pnpm test` — all conformance checks pass
- `just typecheck` — clean
- The new guard is mutation-tested: injecting `dark_flat` into one contract fails it with both expected messages.

## Note

`packages/contracts` `pnpm build` cannot regenerate the `.d.ts` files — `json2ts` fails on all 25 schemas. I verified this on clean `main` without these edits, so it predates the change. The generated file is hand-edited to match; the broken codegen is worth its own bead.
