### PR TITLE
test: cover session size totals, catalogue-in-place records, and provenance projection

### DIFF
--- a/.claude/rules/21-astro-monorepo.md
+++ b/.claude/rules/21-astro-monorepo.md
@@ -16,7 +16,9 @@ Primary paths:
 - `crates/calibration/core/`: calibration matching and reuse policy model.
 - `crates/calibration/master-detect/`: heuristic detection of calibration
   master files (STACKCNT/NCOMBINE headers, tool-specific patterns).
-- `crates/workflow/profiles/`: processing tool/workflow profile model.
+- `crates/workflow/profiles/`: processing tool/workflow profile model, seeded
+  tool profiles, `{folder}`/`{file}` args-template rendering, per-OS executable
+  discovery, and the `ProcessSpawner` detach seam (spec 011).
 - `crates/workflow/artifacts/`: workflow artifact observation — rule-driven
   classifier, debounce watcher, reconciler, and tool-launch attribution.
 - `crates/project/structure/`: app-owned project envelope rules.
@@ -77,6 +79,17 @@ remote backend transport. Concrete schemas are produced during planning.
 SQLite is the canonical local store for metadata, relationships, rules,
 lifecycle, plans, and audit history. JSON Schema based operation contracts form
 the transport boundary, with Tauri as the first adapter.
+
+Tool launches are detached: the app spawns PixInsight, Siril, or a planetary
+tool and never supervises or kills the process (constitution III). Launch rows
+in `crates/app/core/src/tool_launch.rs` record `pid`, `launched_at`,
+`project_id`, and `tool_id`; `pid` is nullable because macOS `open -a` does not
+return one. `completed_at` is written by artifact observation
+(`crates/app/lifecycle/src/artifact/launches.rs`), not by the launch path. A
+prior `spawned` launch with a null `completed_at` and a live PID triggers the
+re-launch warning. Tests inject
+`workflow_profiles::launch::FakeSpawner` instead of spawning binaries. See
+[`specs/011-processing-tool-launch/research.md`](../../specs/011-processing-tool-launch/research.md).
 
 The workspace Cargo manifest defines a `dev-tools` feature (default off) that
 compile-time-gates the developer-mode surface from spec 021 (recording proxy,

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,6 +107,7 @@ dependencies = [
  "contracts_core",
  "dashmap",
  "domain_core",
+ "filetime",
  "fs_executor",
  "fs_inventory",
  "hex",

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -59,6 +59,9 @@ uuid = { version = "1", features = ["serde", "v4", "v5"] }
 [dev-dependencies]
 app_core_cache = { path = "../cache" }
 tempfile = { workspace = true }
+# spec 048 T010: forces two fixture frames to a single mtime so the
+# moved-vs-catalogued `file_record` comparison tests the writer, not the clock.
+filetime = "0.2"
 rstest = { workspace = true }
 proptest = { workspace = true }
 # spec 052 P1 (resolution_e2e.rs): computes the same deterministic UUIDv5 the

--- a/crates/app/core/src/inventory.rs
+++ b/crates/app/core/src/inventory.rs
@@ -645,6 +645,76 @@ mod tests {
         assert!(session.notes.is_none());
     }
 
+    // ── provenance summary (spec 006 T204) ───────────────────────────────────
+
+    /// A session key carrying neither target nor filter yields no provenance
+    /// summary at all, rather than an all-`None` object. The UI relies on the
+    /// absent object to skip the provenance fact rows entirely.
+    #[tokio::test]
+    async fn list_session_without_target_or_filter_has_no_provenance_summary() {
+        let db = setup().await;
+        let pool = db.pool();
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES ('root-np', 'Lib', 'local', '/lib', 'active', '2026-07-14T00:00:00Z')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO calibration_session (id, session_key, kind, root_id, frame_ids, created_at) \
+             VALUES ('cal-np', '||1x1|100|2026-01-01', 'dark', 'root-np', '[\"f1\"]', \
+                     '2026-07-14T00:00:00Z')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let sources = list(pool, None).await.unwrap();
+        let session = &sources[0].sessions[0];
+        assert!(session.target.is_none());
+        assert!(session.filter.is_none());
+        assert!(
+            session.provenance.is_none(),
+            "provenance must be absent when neither target nor filter is known"
+        );
+        // Binning/gain are still projected — they are not provenance inputs.
+        assert_eq!(session.binning.as_deref(), Some("1x1"));
+    }
+
+    /// The populated branch mirrors the same rule: `target`/`filter` are the
+    /// only fields the projection can derive. `inferred`/`confirmed_by` have no
+    /// source of truth (no writer populates `provenance_history_archive`, and
+    /// spec 041 FR-051 dropped the session review lifecycle), so they stay
+    /// `None` — see the T203 follow-up.
+    #[tokio::test]
+    async fn list_provenance_summary_carries_target_and_filter_only() {
+        let db = setup().await;
+        let pool = db.pool();
+        sqlx::query(
+            "INSERT INTO library_root (id, label, kind, current_path, state, created_at) \
+             VALUES ('root-pv', 'Lib', 'local', '/lib', 'active', '2026-07-14T00:00:00Z')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO acquisition_session (id, session_key, root_id, frame_ids, created_at) \
+             VALUES ('acq-pv', 'M 51|L|1x1|100|2025-05-03', 'root-pv', '[\"f1\"]', \
+                     '2026-07-14T00:00:00Z')",
+        )
+        .execute(pool)
+        .await
+        .unwrap();
+
+        let sources = list(pool, None).await.unwrap();
+        let prov = sources[0].sessions[0].provenance.as_ref().expect("provenance summary");
+        assert_eq!(prov.target.as_deref(), Some("M 51"));
+        assert_eq!(prov.filter.as_deref(), Some("L"));
+        assert!(prov.inferred.is_none());
+        assert!(prov.confirmed_by.is_none());
+    }
+
     #[tokio::test]
     async fn list_resolves_relative_frame_folder_from_first_frame() {
         let db = setup().await;

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -92,9 +92,18 @@ async fn register_source(pool: &sqlx::SqlitePool, id: &str, path: &str) {
     .unwrap();
 }
 
-/// Build an applied (state=applied) plan whose `move` items target `root_id` at
-/// the given relative paths, all marked `item_state='succeeded'`.
-async fn build_applied_plan(pool: &sqlx::SqlitePool, plan_id: &str, root_id: &str, rels: &[&str]) {
+/// Build an applied (state=applied) plan over `root_id`, one succeeded item per
+/// `(relative_path, action, has_destination)` triple.
+///
+/// `has_destination = false` writes the item with a NULL `to_root_id` and an
+/// empty `to_relative_path` — the catalogue-in-place row shape whose resolution
+/// must fall back to `from_root_id`/`from_relative_path` (spec 048 T013).
+async fn build_applied_plan(
+    pool: &sqlx::SqlitePool,
+    plan_id: &str,
+    root_id: &str,
+    items: &[(&str, &str, bool)],
+) {
     plans_repo::insert_plan(
         pool,
         &plans_repo::InsertPlan {
@@ -111,7 +120,7 @@ async fn build_applied_plan(pool: &sqlx::SqlitePool, plan_id: &str, root_id: &st
     .await
     .unwrap();
 
-    for (i, rel) in rels.iter().enumerate() {
+    for (i, (rel, action, has_destination)) in items.iter().enumerate() {
         let item_id = format!("{plan_id}-item-{i}");
         plans_repo::insert_plan_item(
             pool,
@@ -120,11 +129,11 @@ async fn build_applied_plan(pool: &sqlx::SqlitePool, plan_id: &str, root_id: &st
                 plan_id,
                 item_index: i64::try_from(i).unwrap(),
                 name: "[LIGHT] frame.fits",
-                action: "move",
+                action,
                 from_root_id: Some(root_id),
                 from_relative_path: rel,
-                to_root_id: Some(root_id),
-                to_relative_path: rel,
+                to_root_id: has_destination.then_some(root_id),
+                to_relative_path: if *has_destination { rel } else { "" },
                 reason: "inbox_split",
                 protection: "normal",
                 linked_entity: None,
@@ -203,7 +212,13 @@ async fn two_m31_frames_group_into_one_linked_session() {
         Some("2026-06-21T23:00:00"),
     );
 
-    build_applied_plan(pool, "plan-1", root_id, &["a.fits", "b.fits"]).await;
+    build_applied_plan(
+        pool,
+        "plan-1",
+        root_id,
+        &[("a.fits", "move", true), ("b.fits", "move", true)],
+    )
+    .await;
 
     app_core::inbox::plan_listener::start_inbox_plan_listener(
         pool.clone(),
@@ -255,6 +270,108 @@ async fn two_m31_frames_group_into_one_linked_session() {
     );
 }
 
+// ── spec 048 T010/T013: catalogue-in-place parity with a move ────────────────────
+
+/// The `file_record` columns a frame's own identity does not depend on. `id` and
+/// `relative_path` are excluded because they legitimately differ per frame;
+/// `first_seen_at`/`last_seen_at` are excluded because they are wall-clock write
+/// times, not properties of the frame.
+#[derive(Debug, Eq, PartialEq, sqlx::FromRow)]
+struct PathIndependentFrameRecord {
+    root_id: String,
+    size_bytes: i64,
+    mtime: String,
+    content_hash: Option<String>,
+    state: String,
+}
+
+async fn frame_record(
+    pool: &sqlx::SqlitePool,
+    relative_path: &str,
+) -> Option<PathIndependentFrameRecord> {
+    sqlx::query_as(
+        "SELECT root_id, size_bytes, mtime, content_hash, state
+         FROM file_record WHERE relative_path = ?",
+    )
+    .bind(relative_path)
+    .fetch_optional(pool)
+    .await
+    .unwrap()
+}
+
+/// Constitution §I (local-first custody): catalogue-in-place is the path a user
+/// with an already-organized library takes, so a catalogued frame MUST be
+/// recorded exactly as richly as a moved one — same real size, same mtime, same
+/// state, same root. A catalogue plan item carries no destination
+/// (`to_root_id IS NULL`), so its `file_record` is only written if resolution
+/// falls back to the source path (`plan_listener::resolve_applied_frame_path` /
+/// `ingest_sessions::ingest_light_frames`); a regression there records nothing
+/// at all, or records it with the `size_bytes = 0` placeholder spec 048 removed.
+#[tokio::test]
+async fn catalogued_frame_is_recorded_identically_to_a_moved_frame() {
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+    let tmp = tempfile::tempdir().unwrap();
+    let root_id = "src-raw";
+    register_source(pool, root_id, tmp.path().to_str().unwrap()).await;
+    upsert_resolved(pool, &m31()).await.unwrap();
+
+    // Byte-identical frames, so `size_bytes` is comparable. Their mtimes are
+    // then forced equal: two files created in sequence otherwise differ by the
+    // filesystem's timestamp granularity, which would make the mtime assertion
+    // test the clock rather than the writer.
+    for name in ["moved.fits", "catalogued.fits"] {
+        write_fits(
+            tmp.path(),
+            name,
+            "Light Frame",
+            Some("M 31"),
+            Some("Ha"),
+            Some("2026-06-21T22:00:00"),
+        );
+        filetime::set_file_mtime(
+            tmp.path().join(name),
+            filetime::FileTime::from_unix_time(1_750_000_000, 0),
+        )
+        .unwrap();
+    }
+
+    build_applied_plan(
+        pool,
+        "plan-parity",
+        root_id,
+        &[("moved.fits", "move", true), ("catalogued.fits", "catalogue", false)],
+    )
+    .await;
+
+    app_core::inbox::plan_listener::start_inbox_plan_listener(
+        pool.clone(),
+        &bus,
+        targeting_resolver::simbad::ResolveCache::in_memory().unwrap(),
+    );
+    publish_applied(&bus, "plan-parity").await;
+    support::poll_until(
+        || async {
+            let count: (i64,) =
+                sqlx::query_as("SELECT COUNT(*) FROM file_record").fetch_one(pool).await.unwrap();
+            (count.0 >= 2).then_some(())
+        },
+        "both frame records never appeared after plan-parity apply-completed event",
+    )
+    .await;
+
+    let moved = frame_record(pool, "moved.fits").await.expect("moved frame recorded");
+    let catalogued = frame_record(pool, "catalogued.fits")
+        .await
+        .expect("catalogued frame recorded — resolution must fall back to the source path");
+
+    assert_eq!(
+        catalogued, moved,
+        "catalogued and moved frames must agree on every path-independent field"
+    );
+    assert!(moved.size_bytes > 0, "real on-disk size, never the 0 placeholder (spec 048 FR-001)");
+}
+
 // ── T046: unknown OBJECT → pending → back-fill ───────────────────────────────────
 
 #[tokio::test]
@@ -274,7 +391,7 @@ async fn unknown_object_session_backfills_after_resolve() {
         Some("L"),
         Some("2026-06-21T22:00:00"),
     );
-    build_applied_plan(pool, "plan-2", root_id, &["u.fits"]).await;
+    build_applied_plan(pool, "plan-2", root_id, &[("u.fits", "move", true)]).await;
 
     app_core::inbox::plan_listener::start_inbox_plan_listener(
         pool.clone(),

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -319,3 +319,81 @@ async fn unknown_object_session_backfills_after_resolve() {
     let sessions = session_rows(pool).await;
     assert!(sessions[0].2.is_some(), "canonical_target_id back-filled after resolve");
 }
+
+// ── T008 (spec 048): real ingest path populates session size totals ──────────────
+
+/// The ingest path (`plan.apply` completion → frame records → session) must
+/// carry real on-disk sizes through to `total_size_bytes`. Frames get different
+/// sizes so a sum is distinguishable from `count * size` or a single frame's size.
+#[tokio::test]
+async fn ingested_session_total_size_is_sum_of_real_frame_sizes() {
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+    let tmp = tempfile::tempdir().unwrap();
+    let root_id = "src-raw";
+    register_source(pool, root_id, tmp.path().to_str().unwrap()).await;
+
+    write_fits(
+        tmp.path(),
+        "s1.fits",
+        "Light Frame",
+        Some("M 31"),
+        Some("Ha"),
+        Some("2026-06-21T22:00:00"),
+    );
+    write_fits(
+        tmp.path(),
+        "s2.fits",
+        "Light Frame",
+        Some("M 31"),
+        Some("Ha"),
+        Some("2026-06-21T23:00:00"),
+    );
+    // Pad the second frame by one FITS block so the two sizes differ.
+    std::fs::OpenOptions::new()
+        .append(true)
+        .open(tmp.path().join("s2.fits"))
+        .unwrap()
+        .write_all(&[0u8; 2880])
+        .unwrap();
+
+    let expected_total: u64 = ["s1.fits", "s2.fits"]
+        .iter()
+        .map(|name| std::fs::metadata(tmp.path().join(name)).unwrap().len())
+        .sum();
+
+    build_applied_plan(pool, "plan-3", root_id, &["s1.fits", "s2.fits"]).await;
+
+    app_core::inbox::plan_listener::start_inbox_plan_listener(
+        pool.clone(),
+        &bus,
+        targeting_resolver::simbad::ResolveCache::in_memory().unwrap(),
+    );
+    publish_applied(&bus, "plan-3").await;
+    support::poll_until(
+        || async {
+            let rows = session_rows(pool).await;
+            let ready = rows.iter().any(|(_id, frame_ids, _ct)| {
+                let frames: Vec<String> = serde_json::from_str(frame_ids).unwrap_or_default();
+                frames.len() >= 2
+            });
+            ready.then_some(())
+        },
+        "acquisition_session with 2 frames never appeared after plan-3 apply-completed event",
+    )
+    .await;
+
+    let listed = app_core::sessions::list_sessions(pool).await.unwrap();
+    assert_eq!(listed.len(), 1, "both frames share one capture identity");
+    assert_eq!(listed[0].frame_count, 2);
+    assert_eq!(
+        listed[0].total_size_bytes, expected_total,
+        "list total must be the sum of the real on-disk frame sizes"
+    );
+
+    let detail = app_core::sessions::get_session(pool, &listed[0].id).await.unwrap();
+    assert_eq!(
+        detail.total_size_bytes, expected_total,
+        "detail total must match the same real sum"
+    );
+}

--- a/crates/app/core/tests/ingest_sessions_integration.rs
+++ b/crates/app/core/tests/ingest_sessions_integration.rs
@@ -479,7 +479,13 @@ async fn ingested_session_total_size_is_sum_of_real_frame_sizes() {
         .map(|name| std::fs::metadata(tmp.path().join(name)).unwrap().len())
         .sum();
 
-    build_applied_plan(pool, "plan-3", root_id, &["s1.fits", "s2.fits"]).await;
+    build_applied_plan(
+        pool,
+        "plan-3",
+        root_id,
+        &[("s1.fits", "move", true), ("s2.fits", "move", true)],
+    )
+    .await;
 
     app_core::inbox::plan_listener::start_inbox_plan_listener(
         pool.clone(),

--- a/docs/research/025-plan-apply-decision-map.md
+++ b/docs/research/025-plan-apply-decision-map.md
@@ -1,0 +1,52 @@
+# Plan Apply: Research Decisions To Runtime Modules
+
+Maps each research decision in
+[`specs/025-filesystem-plan-application/research.md`](../../specs/025-filesystem-plan-application/research.md)
+to the code that enforces it. Use this when changing executor behaviour: the
+decision text states the invariant, the module is where a regression shows up.
+
+## Decision map
+
+| Decision | Enforced in |
+| --- | --- |
+| R1 same-volume rename, cross-volume copy-then-delete | `crates/fs/executor/src/ops/move_op.rs` |
+| R1 addendum cross-volume failure codes (`copy.succeeded.delete.failed`) | `crates/fs/executor/src/ops/move_op.rs`, `crates/fs/executor/src/failure.rs` |
+| R2 archive root routing | `crates/fs/executor/src/ops/archive_op.rs` |
+| R2 addendum OS trash per platform | `crates/fs/executor/src/ops/trash_op.rs` |
+| R3 failure taxonomy | `crates/fs/executor/src/failure.rs` |
+| R4 cancellation between items only | `crates/fs/executor/src/run/loop_.rs`, `crates/app/core/src/plan_apply/terminal.rs` |
+| R5 per-item retry | `crates/app/core/src/plan_apply/lifecycle.rs` (`retry_plan_item`) |
+| R6 re-apply rejection on non-approved state | `crates/app/core/src/plan_apply/apply.rs` |
+| R7 sequential run plus path-set overlap rejection | `crates/app/core/src/plan_apply/paths.rs` (`check_overlap_and_register`, `compute_plan_path_set`) |
+| R8 approval-token freshness | `crates/app/core/src/plan_apply/paths.rs` (`verify_approval_token`) |
+| R-FS-1 per-item mtime/size CAS | `crates/fs/executor/src/ops/cas_check.rs` |
+| R-Pause-1 pause and resume re-validation | `crates/fs/executor/src/run/loop_.rs`, `crates/fs/executor/src/ops/volume_check.rs` |
+| R-CAS-1 atomic plan-state CAS on apply start | `crates/persistence/plans/src/repositories/plan_apply.rs` |
+| Unclean-shutdown reconciliation | `crates/fs/executor/src/reconcile.rs`, `crates/app/core/src/plan_apply/reconcile.rs` |
+
+## Where runtime differs from the decision text
+
+R8 specifies an HMAC over `(planId, contentHash, approvedAt, serverSecret)`.
+The shipped token is a random opaque string,
+`format!("tok-{plan_id}-{uuid}")` in `crates/app/core/src/plans/approve.rs`,
+compared for equality against the stored column in `verify_approval_token`.
+No content hash is recomputed at apply time.
+
+Consequences of the shipped form:
+
+- Single-use and unforgeable-by-guessing hold: the token is a v4 UUID the
+  client cannot predict, and re-approval overwrites the stored column.
+- The R8 guarantee that an edit between approve and apply is rejected does not
+  come from the token. It comes from the per-item CAS in `cas_check.rs`, which
+  pauses the run when a source file's current `(mtime, size)` differs from the
+  snapshot `plan.approve` recorded.
+- A plan-body edit that adds items without touching any approved source file is
+  not caught by either mechanism.
+
+## Layering
+
+`crates/fs/executor` has no database, audit-bus, or Tauri dependency. The
+executor loop reaches persistence and audit only through `ExecutorCallbacks`
+(`crates/fs/executor/src/run/mod.rs`), which `crates/app/core/src/plan_apply/`
+supplies. A decision that needs a database read belongs in `app/core`, not in
+the executor.

--- a/docs/research/index.md
+++ b/docs/research/index.md
@@ -10,6 +10,7 @@ live in this directory; feature-scoped research lives under
 - [imagetyp-normalization.md](./imagetyp-normalization.md) — IMAGETYP → frame-type normalization.
 - [implementation-dependencies.md](./implementation-dependencies.md) — cross-feature implementation dependencies.
 - [lifecycle-state-model.md](./lifecycle-state-model.md) — data lifecycle state model.
+- [025-plan-apply-decision-map.md](./025-plan-apply-decision-map.md): spec 025 research decisions (R1 through R8, R-FS-1, R-Pause-1, R-CAS-1) mapped to the executor and `app/core` modules that enforce them, including where the approval-token implementation diverges from R8.
 - [044-frontend-astronomy-libraries.md](./044-frontend-astronomy-libraries.md) — astronomy/charting library selection for the planner (astronomy-engine, visx, react-table, moon filter model, FITS/XISF crate split); handover for spec 044 + orchestrator.
 
 ## Feature research decisions
@@ -18,9 +19,30 @@ Each active feature records its research in its spec folder. Notable:
 
 - Spec 017 — Cleanup And Archive Review Plans: [`specs/017-cleanup-archive-review-plans/research.md`](../../specs/017-cleanup-archive-review-plans/research.md) (plan review UX, state machine, archive destination convention, retry model).
 - Spec 018 — Settings Configuration Model: [`specs/018-settings-configuration-model/research.md`](../../specs/018-settings-configuration-model/research.md) (persistence shape, audit policy, override resolution, schema versioning).
+- Spec 019, Bottom Log Viewer: [`specs/019-bottom-log-viewer/research.md`](../../specs/019-bottom-log-viewer/research.md) (500-entry ring buffer, diagnostic vs workflow-significant emission paths, follow-tail scroll handoff, retention, cursor semantics).
+- Spec 020, Router And URL State: [`specs/020-router-url-state/research.md`](../../specs/020-router-url-state/research.md) (hash history for the Tauri origin, URL as the source of truth for filters and selection, per-route `validateSearch` tiers, deprecated-param migration).
 - Spec 021 — Developer Contract Diagnostics: [`specs/021-developer-contract-diagnostics/research.md`](../../specs/021-developer-contract-diagnostics/research.md) (recording proxy, `dev-tools` compile-time feature gate, replay safety, redaction).
+- Spec 025, Filesystem Plan Application: [`specs/025-filesystem-plan-application/research.md`](../../specs/025-filesystem-plan-application/research.md) (cross-platform move, archive vs trash, failure taxonomy, cancellation, pause/resume, concurrency). Decision-to-module map: [025-plan-apply-decision-map.md](./025-plan-apply-decision-map.md).
 
 For the full set, see `specs/*/research.md`.
+
+## Router history strategy (spec 020)
+
+`apps/desktop/src/app/router.tsx` builds the router on `createHashHistory()`.
+Every URL is `index.html#/route?search=…`, so a reload always fetches
+`index.html` and the route is parsed in JS. `createBrowserHistory` needs the
+host to serve arbitrary sub-paths, which the Tauri `file://` and `tauri://`
+origins do not; `createMemoryHistory` loses the URL on reload and breaks
+back/forward restore. A future web adapter swaps the history factory behind a
+build flag and leaves the route tree unchanged.
+
+URL state on the desktop buys in-session back/forward that restores filters and
+selection, multi-window views that each carry their own route, and tests that
+assert a view from a URL string. Address-bar sharing and bookmarking do not
+apply, because the shell has no address bar. Spec 020 was narrowed to those
+payoffs on 2026-06-10; the decision record is
+[`docs/development/autonomous-run-2026-06-decisions.md`](../development/autonomous-run-2026-06-decisions.md)
+(DV-006, D-007).
 
 ## Developer-mode entry point (spec 021)
 


### PR DESCRIPTION
## Summary

- Session size totals, catalogue-in-place frame records, and inventory provenance projection now have tests. In every case the behaviour already worked; what was missing was anything that would catch it breaking.
- Research index entries added for specs 019, 020, and 025, plus a decision-to-module map for plan application.

No behaviour changes. Tests and docs only.

## Spec Context

Four findings from the 2026-07-28 spec audit, each implemented in an isolated worktree and checked by an independent reviewer.

**spec 048 T008** -- nothing joined the real `inbox.confirm` to `plan.apply` to ingest path to a session size total. The only existing sum assertion ran against seeded rows. The new test writes two FITS frames of deliberately different sizes into a temp dir, derives the expected total from `std::fs::metadata` on the real files, and asserts on both read paths, since `list_sessions` and `get_session` compute the total independently.

**spec 048 T010** -- the move-versus-catalogue record symmetry was documented and implemented but untested. The new test drives one applied plan carrying both a `move` item and a `catalogue` item with a NULL destination, then compares the resulting `file_record` rows through a `PathIndependentFrameRecord` struct that names which columns must agree and which may legitimately differ.

**spec 006 T203/T204** -- T204 is delivered: two projection-level tests pin the provenance-summary rules. **T203 is blocked and filed as `astro-plan-457h`.** No record exists anywhere in the schema of who confirmed a session, so `confirmed_by` and its UI renderer are dead surface. That needs a product decision rather than code, and the subagent correctly declined to invent a value.

**docs** -- four of five index items were written. The fifth, a new diagram for an already-shipped projection, was skipped as not worth the maintenance. A follow-up bead `astro-plan-uuoe` records a genuine divergence found while writing the spec 025 map: the shipped approval-token design differs from what R8 describes, which is a real question about plan-body edits between approve and apply.

## Verification

- `cargo test -p app_core --test ingest_sessions_integration` -- 4 passed
- `cargo test -p app_core --lib inventory::` -- 34 passed, up from 32
- `cargo clippy -p app_core --all-targets -- -D warnings` -- clean
- `cargo fmt --all --check` -- clean
- Mutation-checked directly rather than taken on trust: forcing `size_bytes` to `0` at `crates/app/targets/src/ingest_sessions.rs:206` fails both new ingest tests while the two pre-existing tests in the file stay green. Restored and re-verified.

## Note

The two ingest beads were written in parallel against the same fixture helper. One changed `build_applied_plan`'s signature to support catalogue items while the other still called the older form, so they merged cleanly as text but did not compile. The final commit fixes that call site. Worth knowing for future parallel work on shared test fixtures.
