### PR TITLE
test: prove tool launches really start in the right folder with the right arguments

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8533,6 +8533,8 @@ name = "workflow_profiles"
 version = "0.1.0"
 dependencies = [
  "itertools",
+ "project_structure",
+ "tempfile",
  "winreg 0.56.0",
 ]
 

--- a/crates/workflow/profiles/Cargo.toml
+++ b/crates/workflow/profiles/Cargo.toml
@@ -7,10 +7,24 @@ license.workspace = true
 [lib]
 path = "src/lib.rs"
 
+# Child process for the real-spawn integration test (spec 011 T022). A fake
+# spawner only records intended argv; proving the OS honours cwd/argv needs a
+# real compiled child that reports what it received. Located at test runtime via
+# `CARGO_BIN_EXE_spawn-stub`.
+[[bin]]
+name = "spawn-stub"
+path = "src/bin/spawn-stub.rs"
+
 [dependencies]
 # spec 042 (T203): first-wins dedup of discovery results by tool id
 # (replaces the hand-rolled `HashSet`-insert filter).
 itertools = { workspace = true }
+
+[dev-dependencies]
+# Real-spawn integration test (spec 011 T022): disposable project roots, plus
+# the same working-folder resolution production launch uses.
+project_structure = { path = "../../project/structure" }
+tempfile = { workspace = true }
 
 [lints]
 workspace = true

--- a/crates/workflow/profiles/src/bin/spawn-stub.rs
+++ b/crates/workflow/profiles/src/bin/spawn-stub.rs
@@ -1,0 +1,30 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! `spawn-stub` — child process used by the real-spawn integration test
+//! (spec 011 T022). Not part of the shipped application.
+//!
+//! Spawns are detached, so the parent cannot read the child's state directly:
+//! the stub instead records what the OS actually handed it — its working
+//! directory and its full argv — into the file named by `argv[1]`.
+//!
+//! The record is written to a `.partial` sibling and renamed into place so a
+//! polling reader never observes a half-written record.
+
+fn main() {
+    let mut args = std::env::args();
+    args.next(); // argv[0]: this executable's own path
+    let record = args.next().expect("spawn-stub requires a record path as argv[1]");
+    let cwd = std::env::current_dir().expect("child has no readable working directory");
+
+    let mut out = format!("cwd\t{}\n", cwd.display());
+    for arg in args {
+        out += "arg\t";
+        out += &arg;
+        out += "\n";
+    }
+
+    let partial = format!("{record}.partial");
+    std::fs::write(&partial, out).expect("write partial record");
+    std::fs::rename(&partial, &record).expect("publish record");
+}

--- a/crates/workflow/profiles/tests/real_spawn_stub.rs
+++ b/crates/workflow/profiles/tests/real_spawn_stub.rs
@@ -1,0 +1,122 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Real-spawn integration tests (spec 011 T022).
+//!
+//! `FakeSpawner` only proves which `SpawnRequest` the launch path *intended*;
+//! it cannot prove the OS actually started a process in the requested working
+//! directory with the requested argv. These tests spawn the compiled
+//! `spawn-stub` binary through [`RealSpawner`] and read back what the child
+//! itself observed.
+//!
+//! Coverage boundary: `bundle_id` is `None` in every case, so the direct-exec
+//! path is exercised on all three platforms. macOS `open -b <bundle_id>`
+//! dispatch is deliberately not covered — it needs an installed `.app` bundle
+//! and Launch Services ignores the caller's `current_dir`, so there is no
+//! portable cwd/argv assertion to make against it.
+
+use std::path::Path;
+use std::time::{Duration, Instant};
+
+use project_structure::resolve_working_folder;
+use workflow_profiles::args::{render, RenderContext};
+use workflow_profiles::launch::{ProcessSpawner, RealSpawner, SpawnRequest};
+use workflow_profiles::{seed, ArgsToken};
+
+/// What the child process reported about its own environment.
+struct Observed {
+    cwd: String,
+    args: Vec<String>,
+}
+
+/// Spawn `spawn-stub` detached with `tool_args`, anchored at `working_dir`,
+/// and wait for the record it writes.
+fn spawn_and_observe(working_dir: &Path, tool_args: &[String], record: &Path) -> Observed {
+    let mut args = vec![record.to_string_lossy().into_owned()];
+    args.extend(tool_args.iter().cloned());
+
+    RealSpawner
+        .spawn(SpawnRequest {
+            executable: env!("CARGO_BIN_EXE_spawn-stub").to_owned(),
+            args,
+            working_dir: working_dir.to_string_lossy().into_owned(),
+            bundle_id: None,
+        })
+        .expect("real spawn of the stub binary");
+
+    read_record(record)
+}
+
+/// Poll for the stub's record file. The stub is detached, so there is no child
+/// handle to wait on.
+fn read_record(record: &Path) -> Observed {
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let raw = loop {
+        if let Ok(text) = std::fs::read_to_string(record) {
+            break text;
+        }
+        assert!(Instant::now() < deadline, "stub never wrote {}", record.display());
+        std::thread::sleep(Duration::from_millis(20));
+    };
+
+    let mut cwd = None;
+    let mut args = Vec::new();
+    for line in raw.lines() {
+        let (key, value) = line.split_once('\t').expect("record line is key<TAB>value");
+        match key {
+            "cwd" => cwd = Some(value.to_owned()),
+            "arg" => args.push(value.to_owned()),
+            other => panic!("unexpected record key {other}"),
+        }
+    }
+    Observed { cwd: cwd.expect("record carries a cwd line"), args }
+}
+
+/// The child's reported cwd and the expected path may differ by symlink
+/// resolution (`/tmp` → `/private/tmp` on macOS), so compare canonical forms.
+fn assert_same_dir(observed: &str, expected: &Path) {
+    let lhs = Path::new(observed).canonicalize().expect("canonicalize observed cwd");
+    let rhs = expected.canonicalize().expect("canonicalize expected cwd");
+    assert_eq!(lhs, rhs, "child cwd {observed} != {}", expected.display());
+}
+
+#[test]
+fn real_spawn_anchors_cwd_to_project_root_when_no_source_view() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_root = tmp.path().join("my_project");
+    std::fs::create_dir_all(&project_root).unwrap();
+
+    // PixInsight: supports_open_folder = false, so argv carries no folder and
+    // the project folder reaches the tool only as its cwd (R-CwdContain).
+    let profile = seed::find("pixinsight").unwrap();
+    assert!(!profile.supports_open_folder);
+    let working_dir = resolve_working_folder(&project_root, None);
+    let rendered = render(&profile.args_template, &RenderContext::default());
+
+    let observed = spawn_and_observe(&working_dir, &rendered, &tmp.path().join("pi.record"));
+
+    assert_same_dir(&observed.cwd, &project_root);
+    assert!(observed.args.is_empty(), "unexpected tool argv: {:?}", observed.args);
+}
+
+#[test]
+fn real_spawn_anchors_cwd_and_argv_to_source_view_folder() {
+    let tmp = tempfile::tempdir().unwrap();
+    let project_root = tmp.path().join("my_project");
+    let source_view = project_root.join("_source_view");
+    std::fs::create_dir_all(&source_view).unwrap();
+
+    // Siril: supports_open_folder = true, so the resolved source-view folder
+    // appears both as the cwd and as the rendered `{folder}` argument.
+    let profile = seed::find("siril").unwrap();
+    assert_eq!(profile.args_template, vec![ArgsToken::Folder]);
+    let working_dir = resolve_working_folder(&project_root, Some("_source_view"));
+    let folder = working_dir.to_string_lossy().into_owned();
+    let rendered =
+        render(&profile.args_template, &RenderContext { folder: Some(&folder), file: None });
+
+    let observed = spawn_and_observe(&working_dir, &rendered, &tmp.path().join("siril.record"));
+
+    assert_same_dir(&observed.cwd, &source_view);
+    assert_eq!(observed.args, vec![folder]);
+}


### PR DESCRIPTION
## Summary

- Launching an external processing tool now has a test that proves the child process really starts in the right folder with the right arguments, rather than only proving the app intended to.

Test-only change. No production behaviour was modified.

## Spec Context

Spec 011 T022. The launch path had only `FakeSpawner` coverage, which records the argv the app *intended* to pass. It cannot show that a real process starts in the right working directory, so a regression in the actual spawn call would pass every existing test. This is the PixInsight and Siril hand-off, where the product boundary depends on getting the folder right.

A compiled stub binary (`crates/workflow/profiles/src/bin/spawn-stub.rs`) is spawned through the production `RealSpawner`. Because launches are detached there is no child handle to wait on, so the stub records its own `current_dir()` and argv to a file named by `argv[1]`. It writes to a `.partial` sibling and renames into place, so the polling parent never reads a half-written record.

The cases mirror the R3 per-tool expectations:

- PixInsight seed, `supports_open_folder = false`: the child cwd is the project root and the tool argv is empty.
- Siril seed, `args_template = [Folder]` with a source view present: the child cwd and the rendered `{folder}` argument are both the source-view folder.

Both route through the production helpers `project_structure::resolve_working_folder` and `workflow_profiles::args::render`, so a regression in either surfaces here too.

The macOS `open -b <bundle_id>` arm is deliberately not covered, and the test module documents why. That arm needs an installed `.app` bundle and never calls `current_dir`, and Launch Services ignores the caller's working directory, so no cwd assertion could exist for it. The tests set `bundle_id: None` and exercise the direct-exec arm, which is identical on macOS and Linux and equivalent on Windows, so no `#[cfg]` gate is needed.

## Verification

- `cargo test -p workflow_profiles`: 34 unit and 2 integration tests pass.
- `cargo clippy -p workflow_profiles --all-targets -- -D warnings`: clean.
- Mutation-checked directly rather than taken on trust. Removing `.current_dir(&req.working_dir)` from the spawn call makes both tests fail, reporting the child's real cwd as the crate directory instead of the temp project. Restored and re-verified green. That mutation is invisible to the existing `FakeSpawner` tests, which is the gap this closes.

## Note

`[[bin]] spawn-stub` has no `required-features`, so `cargo build --workspace` compiles it into `target/`. It is absent from the Tauri bundle, so nothing ships, but the compilation is not gated. Worth a follow-up if that build cost matters.

The other half of the bead, T018's Playwright smoke for the Settings tool-workflow flow, is not in this PR. It is tracked as `astro-plan-4kbt`.
