### PR TITLE
ci: trigger ci.yml on merge_group so queued PRs can resolve

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,14 @@ on:
   pull_request:
   push:
     branches: [main]
+  # Required for the merge queue. A queued PR waits on the same contexts branch
+  # protection requires; a workflow that does not trigger on `merge_group`
+  # publishes none of them, so the entry never resolves and the queue stalls
+  # instead of failing. The `changes` job needs no adjustment: dorny/paths-filter
+  # v4 handles this event by diffing `merge_group.base_sha..head_sha` (v3 has no
+  # merge_group branch at all), so path gating scopes to the queued changes
+  # rather than the whole tree.
+  merge_group:
 
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## Summary

- Adds a `merge_group:` trigger to `.github/workflows/ci.yml` so the four CI-owned required status checks run for merge-queue entries instead of never firing.

A pull request added to a merge queue waits on the same status checks branch protection requires. A workflow without a `merge_group` trigger publishes none of them for the queue entry, so the entry never resolves and the queue stalls rather than failing. This trigger makes the four CI-owned required contexts run for merge groups: `Detect changes (CI)`, `Unit + integration (L1+L2)` on ubuntu-latest and windows-latest, `UI mock-mode (Playwright)`, and `Supply chain (cargo-deny)`.

## Why the `changes` job is unchanged

`dorny/paths-filter@v4` has a `merge_group` case that diffs `merge_group.base_sha..merge_group.head_sha` (v4 `src/main.ts:126-135`; v3 contains no `merge_group` reference). Path gating therefore scopes to the queued changes instead of the whole tree, with no `base:` input required.

No job name or job-level `if:` in `ci.yml` reads the `pull_request` payload. `dead-caller-main` is gated to `github.event_name == 'push'` and is not a required check, so it stays out of merge groups by design. Job names are literal or `matrix.os`-derived, so the published context names are identical under `merge_group`.

## Verification

- `ci.yml` parses; triggers are `merge_group`, `pull_request`, `push`.
- `actionlint` output is byte-identical to the pre-change baseline apart from the line shift: one pre-existing `SC2086` at line 451 before, 459 after.

## Follow-up before the queue is enabled

`astro-plan-elar` (P1) records two remaining blockers, both outside this PR's scope:

- `.github/workflows/e2e.yml` has no `merge_group` trigger, and it owns the two `Real-UI journeys (L3)` required contexts.
- `scripts/branch-protection-main.json` disagrees with live branch protection on three context names and on `strict`.

## Spec Context

Tracks-Bead: astro-plan-6sgl
Merge-Bead: astro-plan-4q0q
