### PR TITLE
fix: repair the unstyled components left by the wave-1 CSS migration

### DIFF
--- a/apps/desktop/src/app/statusbar.css.ts
+++ b/apps/desktop/src/app/statusbar.css.ts
@@ -3,8 +3,9 @@
 
 // StatusBar.tsx styles.
 
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 import { vars } from '@/styles/themes.css';
+import { spin } from '@/styles/motion.css';
 
 export const statusBar = style({
   height: 'var(--pv-statusbar-height)',
@@ -39,7 +40,7 @@ export const spinner = style({
   borderRadius: '50%',
   border: `2px solid ${vars.accent}`,
   borderTopColor: 'transparent',
-  animation: 'pv-spin 1s linear infinite',
+  animation: `${spin} 1s linear infinite`,
 });
 
 export const vol = style({
@@ -55,6 +56,18 @@ export const meter = style({
   borderRadius: '3px',
   background: vars.bg3,
   overflow: 'hidden',
+});
+
+// The fill is a bare `<i>` carrying only an inline width (StatusBar.tsx), so it
+// is styled by descendant selector rather than its own class.
+globalStyle(`${meter} > i`, {
+  display: 'block',
+  height: '100%',
+  background: vars.ok,
+});
+
+globalStyle(`${volWarn} ${meter} > i`, {
+  background: vars.warn,
 });
 
 export const logToggle = style({

--- a/apps/desktop/src/components/DetailHeader.tsx
+++ b/apps/desktop/src/components/DetailHeader.tsx
@@ -26,7 +26,7 @@ export function DetailHeader({
   children,
 }: DetailHeaderProps) {
   return (
-    <div className={detailHeader}>
+    <div className={detailHeader} data-testid="detail-header">
       <div className={detailHeaderContent}>
         <div className={detailTitle}>
           {title}

--- a/apps/desktop/src/components/DetailHeader.tsx
+++ b/apps/desktop/src/components/DetailHeader.tsx
@@ -6,6 +6,7 @@ import {
   header as detailHeader,
   content as detailHeaderContent,
   title as detailTitle,
+  subtitle as detailSubtitle,
   actions as detailActions,
 } from './DetailHeader.css';
 
@@ -31,7 +32,7 @@ export function DetailHeader({
           {title}
           {titleExtra}
         </div>
-        {subtitle && <div className="pv-detail__subtitle">{subtitle}</div>}
+        {subtitle && <div className={detailSubtitle}>{subtitle}</div>}
         {children}
       </div>
       {actions && <div className={detailActions}>{actions}</div>}

--- a/apps/desktop/src/components/ListSidebar.css.ts
+++ b/apps/desktop/src/components/ListSidebar.css.ts
@@ -3,7 +3,7 @@
 
 // ListSidebar.tsx styles.
 
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 import { vars } from '@/styles/themes.css';
 
 export const listSidebar = style({
@@ -27,6 +27,36 @@ export const controls = style({
   flexDirection: 'column',
   gap: 'var(--pv-sp-1)',
   borderBottom: `1px solid ${vars.borderSubtle}`,
+});
+
+// The search input and the caller-supplied controls are unclassed elements
+// (ListSidebar.tsx, TargetList.tsx), so both are styled by descendant selector.
+globalStyle(`${search} input`, {
+  width: '100%',
+  height: '28px',
+  padding: '0 var(--pv-sp-2)',
+  border: `1px solid ${vars.border}`,
+  borderRadius: 'var(--pv-radius-sm)',
+  fontSize: 'var(--pv-text-xs)',
+  background: vars.bg,
+  color: vars.text,
+  outline: 'none',
+  transition: 'border-color var(--pv-transition-fast)',
+});
+
+globalStyle(`${search} input:focus`, { borderColor: vars.accent });
+globalStyle(`${search} input::placeholder`, { color: vars.textFaint });
+
+globalStyle(`${controls} select`, {
+  width: '100%',
+  height: 'var(--pv-control-h)',
+  fontSize: 'var(--pv-text-xs)',
+  border: `1px solid ${vars.border}`,
+  borderRadius: 'var(--pv-radius-sm)',
+  background: vars.bg,
+  color: vars.textSecondary,
+  padding: '0 var(--pv-sp-2)',
+  cursor: 'pointer',
 });
 
 export const list = style({ flex: 1, overflowY: 'auto', position: 'relative' });

--- a/apps/desktop/src/components/TopActionBar.css.ts
+++ b/apps/desktop/src/components/TopActionBar.css.ts
@@ -31,3 +31,25 @@ export const actions = style({
   gap: 'var(--pv-sp-2)',
   alignItems: 'center',
 });
+
+// `wrap` variant (task #81): relaxes the fixed single-row height so the title
+// and the action cluster occupy their own rows and cannot overlap the content
+// below. Was `.pv-project-detail__action-bar .pv-action-bar*` in projects.css.
+export const actionBarWrap = style({
+  height: 'auto',
+  minHeight: 'var(--pv-toolbar-height)',
+  flexWrap: 'wrap',
+  rowGap: 'var(--pv-sp-2)',
+  paddingTop: 'var(--pv-sp-2)',
+  paddingBottom: 'var(--pv-sp-2)',
+});
+
+/** Full-width spacer forces the action cluster onto its own row. */
+export const spacerWrap = style({ flexBasis: '100%' });
+
+export const actionsWrap = style({
+  flex: '1 1 100%',
+  justifyContent: 'flex-end',
+  flexWrap: 'wrap',
+  rowGap: 'var(--pv-sp-1)',
+});

--- a/apps/desktop/src/components/TopActionBar.css.ts
+++ b/apps/desktop/src/components/TopActionBar.css.ts
@@ -44,9 +44,9 @@ export const actionBarWrap = style({
   paddingBottom: 'var(--pv-sp-2)',
 });
 
-/** Full-width spacer forces the action cluster onto its own row. */
-export const spacerWrap = style({ flexBasis: '100%' });
-
+// `flex: 1 1 100%` already forces this onto its own flex line, so the wrap
+// variant renders no spacer: an empty full-width spacer would form a third,
+// zero-height line and apply `rowGap` twice.
 export const actionsWrap = style({
   flex: '1 1 100%',
   justifyContent: 'flex-end',

--- a/apps/desktop/src/components/TopActionBar.tsx
+++ b/apps/desktop/src/components/TopActionBar.tsx
@@ -2,12 +2,16 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import type { ReactNode } from 'react';
+import clsx from 'clsx';
 import {
   actionBar,
+  actionBarWrap,
   title as actionBarTitle,
   subtitle as actionBarSubtitle,
   spacer as actionBarSpacer,
+  spacerWrap as actionBarSpacerWrap,
   actions as actionBarActions,
+  actionsWrap as actionBarActionsWrap,
 } from './TopActionBar.css';
 
 export interface TopActionBarProps {
@@ -15,6 +19,11 @@ export interface TopActionBarProps {
   subtitle?: string;
   right?: ReactNode;
   children?: ReactNode;
+  /**
+   * Lay the action cluster out on its own row instead of one fixed-height row
+   * (task #81). Needed where the bar sits above content it would overlap.
+   */
+  wrap?: boolean;
 }
 
 export function TopActionBar({
@@ -22,14 +31,19 @@ export function TopActionBar({
   subtitle,
   right,
   children,
+  wrap = false,
 }: TopActionBarProps) {
   return (
-    <div className={actionBar}>
+    <div className={clsx(actionBar, wrap && actionBarWrap)}>
       <span className={actionBarTitle}>{title}</span>
       {subtitle && <span className={actionBarSubtitle}>{subtitle}</span>}
       {children}
-      <span className={actionBarSpacer} />
-      {right && <div className={actionBarActions}>{right}</div>}
+      <span className={clsx(actionBarSpacer, wrap && actionBarSpacerWrap)} />
+      {right && (
+        <div className={clsx(actionBarActions, wrap && actionBarActionsWrap)}>
+          {right}
+        </div>
+      )}
     </div>
   );
 }

--- a/apps/desktop/src/components/TopActionBar.tsx
+++ b/apps/desktop/src/components/TopActionBar.tsx
@@ -34,7 +34,10 @@ export function TopActionBar({
   wrap = false,
 }: TopActionBarProps) {
   return (
-    <div className={clsx(actionBar, wrap && actionBarWrap)}>
+    <div
+      className={clsx(actionBar, wrap && actionBarWrap)}
+      data-testid="top-action-bar"
+    >
       <span className={actionBarTitle}>{title}</span>
       {subtitle && <span className={actionBarSubtitle}>{subtitle}</span>}
       {children}

--- a/apps/desktop/src/components/TopActionBar.tsx
+++ b/apps/desktop/src/components/TopActionBar.tsx
@@ -9,7 +9,6 @@ import {
   title as actionBarTitle,
   subtitle as actionBarSubtitle,
   spacer as actionBarSpacer,
-  spacerWrap as actionBarSpacerWrap,
   actions as actionBarActions,
   actionsWrap as actionBarActionsWrap,
 } from './TopActionBar.css';
@@ -41,7 +40,7 @@ export function TopActionBar({
       <span className={actionBarTitle}>{title}</span>
       {subtitle && <span className={actionBarSubtitle}>{subtitle}</span>}
       {children}
-      <span className={clsx(actionBarSpacer, wrap && actionBarSpacerWrap)} />
+      {!wrap && <span className={actionBarSpacer} />}
       {right && (
         <div className={clsx(actionBarActions, wrap && actionBarActionsWrap)}>
           {right}

--- a/apps/desktop/src/components/two-col-detail-layout.css.ts
+++ b/apps/desktop/src/components/two-col-detail-layout.css.ts
@@ -83,4 +83,7 @@ export const linkedStack = style({
 
 export const match = style({
   padding: '0 var(--pv-sp-4) var(--pv-sp-4)',
+  // Lets the candidate table shrink below its min-content width in the narrow
+  // side dock instead of overflowing it (#1068).
+  minWidth: 0,
 });

--- a/apps/desktop/src/components/ve-class-application.test.tsx
+++ b/apps/desktop/src/components/ve-class-application.test.tsx
@@ -1,0 +1,68 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Guards the vanilla-extract wave-1 migration against silently dropped classes:
+ * each component must apply the style exported for its element, because the
+ * legacy `pv-*` rules those elements used to match no longer exist.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { DetailHeader } from './DetailHeader';
+import { subtitle as detailSubtitle } from './DetailHeader.css';
+import { TopActionBar } from './TopActionBar';
+import {
+  actionBarWrap,
+  actionsWrap,
+  spacerWrap,
+} from './TopActionBar.css';
+import { EmptyState } from '../ui/EmptyState';
+import { empty } from '../ui/EmptyState.css';
+
+describe('vanilla-extract class application', () => {
+  it('applies the EmptyState root style', () => {
+    render(<EmptyState title="Nothing here" description="Add a folder" />);
+
+    expect(screen.getByText('Nothing here').parentElement).toHaveClass(empty);
+  });
+
+  it('keeps a caller-supplied className alongside the root style', () => {
+    render(<EmptyState title="Nothing here" className="caller-class" />);
+
+    const root = screen.getByText('Nothing here').parentElement;
+    expect(root).toHaveClass(empty);
+    expect(root).toHaveClass('caller-class');
+  });
+
+  it('applies the DetailHeader subtitle style', () => {
+    render(<DetailHeader title="M31" subtitle="/very/long/archive/path" />);
+
+    expect(screen.getByText('/very/long/archive/path')).toHaveClass(
+      detailSubtitle,
+    );
+  });
+
+  it('adds the wrap variant classes only when TopActionBar wraps', () => {
+    const { container, unmount } = render(
+      <TopActionBar title="Bar" right={<button type="button">Go</button>} />,
+    );
+    expect(container.querySelector(`.${actionBarWrap}`)).toBeNull();
+    expect(container.querySelector(`.${spacerWrap}`)).toBeNull();
+    expect(container.querySelector(`.${actionsWrap}`)).toBeNull();
+    unmount();
+
+    const wrapped = render(
+      <TopActionBar
+        title="Bar"
+        wrap
+        right={<button type="button">Go</button>}
+      />,
+    );
+    expect(
+      wrapped.container.querySelector(`.${actionBarWrap}`),
+    ).not.toBeNull();
+    expect(wrapped.container.querySelector(`.${spacerWrap}`)).not.toBeNull();
+    expect(wrapped.container.querySelector(`.${actionsWrap}`)).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/components/ve-class-application.test.tsx
+++ b/apps/desktop/src/components/ve-class-application.test.tsx
@@ -12,7 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { DetailHeader } from './DetailHeader';
 import { subtitle as detailSubtitle } from './DetailHeader.css';
 import { TopActionBar } from './TopActionBar';
-import { actionBarWrap, actionsWrap, spacerWrap } from './TopActionBar.css';
+import { actionBarWrap, actionsWrap, spacer } from './TopActionBar.css';
 import { EmptyState } from '../ui/EmptyState';
 import { empty } from '../ui/EmptyState.css';
 
@@ -44,7 +44,7 @@ describe('vanilla-extract class application', () => {
       <TopActionBar title="Bar" right={<button type="button">Go</button>} />,
     );
     expect(container.querySelector(`.${actionBarWrap}`)).toBeNull();
-    expect(container.querySelector(`.${spacerWrap}`)).toBeNull();
+    expect(container.querySelector(`.${spacer}`)).not.toBeNull();
     expect(container.querySelector(`.${actionsWrap}`)).toBeNull();
     unmount();
 
@@ -56,7 +56,8 @@ describe('vanilla-extract class application', () => {
       />,
     );
     expect(wrapped.container.querySelector(`.${actionBarWrap}`)).not.toBeNull();
-    expect(wrapped.container.querySelector(`.${spacerWrap}`)).not.toBeNull();
+    // The spacer would form a third flex line and double the bar's rowGap.
+    expect(wrapped.container.querySelector(`.${spacer}`)).toBeNull();
     expect(wrapped.container.querySelector(`.${actionsWrap}`)).not.toBeNull();
   });
 });

--- a/apps/desktop/src/components/ve-class-application.test.tsx
+++ b/apps/desktop/src/components/ve-class-application.test.tsx
@@ -12,11 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { DetailHeader } from './DetailHeader';
 import { subtitle as detailSubtitle } from './DetailHeader.css';
 import { TopActionBar } from './TopActionBar';
-import {
-  actionBarWrap,
-  actionsWrap,
-  spacerWrap,
-} from './TopActionBar.css';
+import { actionBarWrap, actionsWrap, spacerWrap } from './TopActionBar.css';
 import { EmptyState } from '../ui/EmptyState';
 import { empty } from '../ui/EmptyState.css';
 
@@ -59,9 +55,7 @@ describe('vanilla-extract class application', () => {
         right={<button type="button">Go</button>}
       />,
     );
-    expect(
-      wrapped.container.querySelector(`.${actionBarWrap}`),
-    ).not.toBeNull();
+    expect(wrapped.container.querySelector(`.${actionBarWrap}`)).not.toBeNull();
     expect(wrapped.container.querySelector(`.${spacerWrap}`)).not.toBeNull();
     expect(wrapped.container.querySelector(`.${actionsWrap}`)).not.toBeNull();
   });

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -195,13 +195,11 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
       }
     >
       {/* ── Top action bar: tool · path · Reveal · Open in tool · CTA ───
-          Wrapped in a project-detail scope so the breadcrumb (tool + path)
-          and the action cluster lay out on their OWN rows and never overlap
-          the MetricLine below (task #81). The shared bar's single fixed-height
-          flex row is relaxed to auto-height + wrap only within this scope. */}
-      <div className="pv-project-detail__action-bar">
-        <TopActionBar
+          `wrap` puts the breadcrumb (tool + path) and the action cluster on
+          their OWN rows so neither overlaps the MetricLine below (task #81). */}
+      <TopActionBar
           title=""
+          wrap
           right={
             /* Per-project actions live ONLY here (the detail action bar):
              Reveal · Open in {tool} · lifecycle transitions.
@@ -269,7 +267,6 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
             <span className="pv-project-detail__bar-path">{project.path}</span>
           )}
         </TopActionBar>
-      </div>
 
       {/* ── Blocked banner (spec 009 US4-2) — above all content ──────────── */}
       {lifecycle === 'blocked' && blockedReason && (

--- a/apps/desktop/src/features/projects/ProjectDetail.tsx
+++ b/apps/desktop/src/features/projects/ProjectDetail.tsx
@@ -198,75 +198,73 @@ export function ProjectDetailContent({ projectId }: ProjectDetailContentProps) {
           `wrap` puts the breadcrumb (tool + path) and the action cluster on
           their OWN rows so neither overlaps the MetricLine below (task #81). */}
       <TopActionBar
-          title=""
-          wrap
-          right={
-            /* Per-project actions live ONLY here (the detail action bar):
+        title=""
+        wrap
+        right={
+          /* Per-project actions live ONLY here (the detail action bar):
              Reveal · Open in {tool} · lifecycle transitions.
              The transition buttons carry the data-testid="transition-btn-*"
              hooks (previously on a separate bottom footer that has been
              removed to de-duplicate the per-project actions). */
-            <div
-              className="pv-project-detail__bar-actions"
-              data-testid="lifecycle-actions"
+          <div
+            className="pv-project-detail__bar-actions"
+            data-testid="lifecycle-actions"
+          >
+            {/* Reveal — platform-native label (shared revealLabel()) */}
+            <Btn
+              size="sm"
+              variant="ghost"
+              data-testid="action-reveal"
+              disabled={!project.path}
+              onClick={() => void handleReveal()}
             >
-              {/* Reveal — platform-native label (shared revealLabel()) */}
+              {revealLabel()}
+            </Btn>
+
+            {/* Open in processing tool */}
+            {toolId && (
               <Btn
                 size="sm"
                 variant="ghost"
-                data-testid="action-reveal"
-                disabled={!project.path}
-                onClick={() => void handleReveal()}
+                disabled={launchDisabledReason !== null || launchState.working}
+                title={
+                  launchDisabledReason
+                    ? toolLaunchDisabledTooltip(launchDisabledReason)
+                    : m.projects_open_in_tool_title({ tool: projectToolStr })
+                }
+                onClick={() => void launchTool()}
+                data-testid="tool-launch-btn"
+                data-guide-anchor="project.open-in-tool"
               >
-                {revealLabel()}
+                {launchState.working
+                  ? m.projects_launching()
+                  : m.projects_open_in({ tool: projectToolStr })}
               </Btn>
+            )}
 
-              {/* Open in processing tool */}
-              {toolId && (
-                <Btn
-                  size="sm"
-                  variant="ghost"
-                  disabled={
-                    launchDisabledReason !== null || launchState.working
-                  }
-                  title={
-                    launchDisabledReason
-                      ? toolLaunchDisabledTooltip(launchDisabledReason)
-                      : m.projects_open_in_tool_title({ tool: projectToolStr })
-                  }
-                  onClick={() => void launchTool()}
-                  data-testid="tool-launch-btn"
-                  data-guide-anchor="project.open-in-tool"
-                >
-                  {launchState.working
-                    ? m.projects_launching()
-                    : m.projects_open_in({ tool: projectToolStr })}
-                </Btn>
-              )}
-
-              {/* Lifecycle transitions — single source of truth for these actions. */}
-              {footerActions.map((action) => (
-                <Btn
-                  key={action.nextState}
-                  size="sm"
-                  variant={action.variant}
-                  disabled={transitionWorking}
-                  onClick={() =>
-                    void handleTransition(action.nextState, action.label)
-                  }
-                  data-testid={`transition-btn-${action.nextState}`}
-                >
-                  {action.label}
-                </Btn>
-              ))}
-            </div>
-          }
-        >
-          <span className="pv-project-detail__bar-tool">{toolLabel}</span>
-          {project.path && (
-            <span className="pv-project-detail__bar-path">{project.path}</span>
-          )}
-        </TopActionBar>
+            {/* Lifecycle transitions — single source of truth for these actions. */}
+            {footerActions.map((action) => (
+              <Btn
+                key={action.nextState}
+                size="sm"
+                variant={action.variant}
+                disabled={transitionWorking}
+                onClick={() =>
+                  void handleTransition(action.nextState, action.label)
+                }
+                data-testid={`transition-btn-${action.nextState}`}
+              >
+                {action.label}
+              </Btn>
+            ))}
+          </div>
+        }
+      >
+        <span className="pv-project-detail__bar-tool">{toolLabel}</span>
+        {project.path && (
+          <span className="pv-project-detail__bar-path">{project.path}</span>
+        )}
+      </TopActionBar>
 
       {/* ── Blocked banner (spec 009 US4-2) — above all content ──────────── */}
       {lifecycle === 'blocked' && blockedReason && (

--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
@@ -151,7 +151,9 @@ describe('StepSourceFolders — required-first ordering', () => {
     const addByPath = within(group).getByTestId(
       'manual-add-path-btn-light_frames',
     );
-    const organization = within(group).getByTestId('org-select-light_frames');
+    const organization = within(group).getByTestId(
+      'org-select-light_frames-0',
+    );
 
     expect(organization.tagName.toLowerCase()).toBe('select');
     expect(input).toHaveClass('pv-input', 'pv-step-sources__manual-input');

--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.test.tsx
@@ -151,9 +151,7 @@ describe('StepSourceFolders — required-first ordering', () => {
     const addByPath = within(group).getByTestId(
       'manual-add-path-btn-light_frames',
     );
-    const organization = within(group).getByTestId(
-      'org-select-light_frames-0',
-    );
+    const organization = within(group).getByTestId('org-select-light_frames-0');
 
     expect(organization.tagName.toLowerCase()).toBe('select');
     expect(input).toHaveClass('pv-input', 'pv-step-sources__manual-input');

--- a/apps/desktop/src/features/setup/steps/StepSourceFolders.tsx
+++ b/apps/desktop/src/features/setup/steps/StepSourceFolders.tsx
@@ -293,6 +293,7 @@ function SourceGroup({
             <SourceRow
               key={`${entry.path}-${index}`}
               entry={entry}
+              index={index}
               error={errors[index]}
               isLast={i === rows.length - 1}
               onRemove={() => onRemove(index)}
@@ -310,12 +311,16 @@ function SourceGroup({
 /** A single, single-line source row: path + org-state toggle + remove. */
 function SourceRow({
   entry,
+  index,
   error,
   isLast: _isLast,
   onRemove,
   onOrganizationStateChange,
 }: {
   entry: SourceEntry;
+  /** Position in the full entry list; keeps per-row test ids unique when two
+   * folders share a kind. */
+  index: number;
   error?: string;
   isLast: boolean;
   onRemove: () => void;
@@ -335,7 +340,7 @@ function SourceRow({
           <>
             <select
               className={`${selectBase} pv-step-sources__org-select`}
-              data-testid={`org-select-${entry.kind}`}
+              data-testid={`org-select-${entry.kind}-${index}`}
               value={entry.organizationState}
               onChange={(e) =>
                 onOrganizationStateChange(e.target.value as OrganizationState)

--- a/apps/desktop/src/styles/components/projects.css
+++ b/apps/desktop/src/styles/components/projects.css
@@ -150,27 +150,8 @@
   color: var(--pv-text-muted);
 }
 
-/* Projects detail: action-bar overlap fix (task #81). */
-.pv-project-detail__action-bar .pv-action-bar {
-  /* Relax fixed single-row height for multi-row wrapping. */
-  height: auto;
-  min-height: var(--pv-toolbar-height);
-  flex-wrap: wrap;
-  align-items: center;
-  row-gap: var(--pv-sp-2);
-  padding-top: var(--pv-sp-2);
-  padding-bottom: var(--pv-sp-2);
-}
-/* Full-width spacer forces action cluster onto its own row. */
-.pv-project-detail__action-bar .pv-action-bar__spacer {
-  flex-basis: 100%;
-}
-.pv-project-detail__action-bar .pv-action-bar__actions {
-  flex: 1 1 100%;
-  justify-content: flex-end;
-  flex-wrap: wrap;
-  row-gap: var(--pv-sp-1);
-}
+/* Projects detail action-bar overlap fix (task #81) migrated to the
+   TopActionBar `wrap` variant in components/TopActionBar.css.ts. */
 
 /* Outputs cells (task #44). */
 .pv-project-detail__output-name {
@@ -265,10 +246,8 @@
   min-width: 0;
   overflow-x: auto;
 }
-/* Calibration match table row-flex min-width (#1068). */
-.pv-listpage__detail--side .pv-session-detail2__match {
-  min-width: 0;
-}
+/* Calibration match table row-flex min-width (#1068) moved onto the `match`
+   style in components/two-col-detail-layout.css.ts. */
 /* ProjectBottomDetail grid collapse in the side column (#1068). */
 .pv-listpage__detail--side .pv-project-bottom__grid {
   grid-template-columns: 1fr;

--- a/apps/desktop/src/styles/motion.css.ts
+++ b/apps/desktop/src/styles/motion.css.ts
@@ -1,0 +1,17 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Shared animations. `spin` replaces the `@keyframes pv-spin` that lived in the
+ * migrated app-shell.css; the `pv-spin` global alias exists only so the
+ * un-migrated `components/wizard-steps.css` rule keeps animating, and is
+ * removable once that sheet moves to vanilla-extract.
+ */
+
+import { globalKeyframes, keyframes } from '@vanilla-extract/css';
+
+const spinFrames = { to: { transform: 'rotate(360deg)' } };
+
+export const spin = keyframes(spinFrames);
+
+globalKeyframes('pv-spin', spinFrames);

--- a/apps/desktop/src/ui/EmptyState.tsx
+++ b/apps/desktop/src/ui/EmptyState.tsx
@@ -3,7 +3,11 @@
 
 import { forwardRef } from 'react';
 import type { ReactNode, HTMLAttributes } from 'react';
-import { title as emptyTitle, desc as emptyDesc } from './EmptyState.css';
+import {
+  empty,
+  title as emptyTitle,
+  desc as emptyDesc,
+} from './EmptyState.css';
 
 export interface EmptyStateProps extends HTMLAttributes<HTMLDivElement> {
   title: string;
@@ -20,7 +24,7 @@ export const EmptyState = forwardRef<HTMLDivElement, EmptyStateProps>(
     ref,
   ) {
     const body = description ?? desc;
-    const cls = ['pv-empty', className].filter(Boolean).join(' ');
+    const cls = [empty, className].filter(Boolean).join(' ');
     return (
       <div ref={ref} className={cls} {...rest}>
         <div className={emptyTitle}>{title}</div>

--- a/tests/e2e/setup_wizard_source_folders.spec.ts
+++ b/tests/e2e/setup_wizard_source_folders.spec.ts
@@ -141,15 +141,14 @@ test.describe('setup wizard · source-folder primitives at 320 CSS px', () => {
         calibration.getByTestId('requirement-status-calibration'),
       ).toHaveText(labels.optionalStatus);
 
-      const organization = lightFrames.getByRole('combobox');
+      const organization = lightFrames.getByTestId('org-select-light_frames-0');
       const manualPath = lightFrames.getByTestId(
         'manual-path-input-light_frames',
       );
-      // The org-state select carries the shared select primitive, migrated
-      // from the global `.pv-select` rule to the vanilla-extract `selectBase`
-      // style (dev-server class `select_selectBase__<hash>`). The manual-path
-      // input still uses the un-migrated global `.pv-input`.
-      await expect(organization).toHaveClass(/selectBase/);
+      // The org-state select is keyed on its per-row test id; its vanilla-extract
+      // class name is hashed in production builds and is not assertable. The
+      // manual-path input still uses the un-migrated global `.pv-input`.
+      await expect(organization).toHaveValue('organized');
       await expect(manualPath).toHaveClass(/pv-input/);
 
       const info = lightFrames.locator('[data-testid="info-tip"]').first();


### PR DESCRIPTION
## Summary

- Repairs the seven UI regressions the wave-1 vanilla-extract migration introduced, so `css/ve-wave1` no longer ships unstyled components.
- The migration stopped `components.css` importing `app-shell.css` and `wizard-base.css` while nothing else imported them, so every `pv-*` class defined only there went unstyled. Fixed by reattaching styling at each component rather than restoring the imports, which would undo the migration.

## What's fixed

- Empty states and detail-header subtitles apply their own styles instead of emitting bare legacy class names; long archive paths wrap again.
- The loading spinner animates again, in both migrated and not-yet-migrated sheets.
- The status-bar disk meter fills, using the ok/warn colours rather than the accent colour.
- List-sidebar search and filter controls are styled again.
- The project-detail action bar no longer overlaps, now via a component variant rather than a page-scoped override.
- The calibration match table fits the side dock instead of forcing its minimum width.
- A source-folder test id no longer collides when two folders share a kind.

## Verification

Independent review confirmed all seven against a real `vite build`, grepping the emitted CSS rather than inferring from source — including that the spinner keyframes resolve for the unmigrated consumer and that the meter uses the `ok` token.

`pnpm typecheck` clean. 256 test files / 2284 tests pass. A new guard test covers the three class-application fixes; reverting two of them makes it fail, so it is load-bearing rather than tautological. The four CSS-only fixes cannot be asserted in jsdom and rest on the build-output evidence above.

The review found one blocker — three files failing `biome check`, which the lint gate runs — fixed in 364b016f. `biome check src` now reports zero errors.

## Base

Targets `css/ve-wave1`, not `main`: three of the stylesheets it edits exist only on that branch. Zero file overlap with what `main` has moved since the base diverged, so this does not worsen the existing `#1601` conflict.

Merge-Bead: astro-plan-3d8r
