### PR TITLE
fix: coverage job no longer fails on a nightly-only flag

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -11,8 +11,13 @@ name: Coverage
 #   - an lcov report (uploaded as an artifact)
 #   - a per-file summary in the job log
 #
-# cargo-llvm-cov wraps `cargo test`, so it covers unit tests, the real-SQLite
-# Layer-1 integration tests, and doctests in a single instrumented pass.
+# cargo-llvm-cov wraps `cargo test`, so it covers unit tests and the
+# real-SQLite Layer-1 integration tests in a single instrumented pass.
+#
+# Doctests are excluded on purpose. Instrumenting them makes rustdoc take
+# `-Z persist-doctests`, which only nightly accepts, so passing `--doctests`
+# here hard-fails the job. The workspace has no executable doctests to
+# measure either. Re-add it behind `cargo +nightly llvm-cov` if that changes.
 
 on:
   pull_request:
@@ -104,13 +109,12 @@ jobs:
       - name: Install JS deps
         run: pnpm install --frozen-lockfile
 
-      - name: Collect coverage (workspace, all tests + doctests)
+      - name: Collect coverage (workspace, unit + integration tests)
         run: |
           cargo llvm-cov \
             --workspace \
             --lcov \
-            --output-path lcov.info \
-            --doctests
+            --output-path lcov.info
 
       - name: Print coverage summary
         run: cargo llvm-cov report --summary-only


### PR DESCRIPTION
## Summary

- The coverage job pins the stable toolchain but passed `--doctests`, which makes cargo-llvm-cov hand rustdoc `-Z persist-doctests`. Only nightly accepts that, so the run failed with "2 nightly options were parsed" after every test had already passed.
- The flag also measured nothing. The workspace has 26 doc code fences but zero executable doctests, so no coverage line was ever attributed to one.
- Coverage has therefore never once completed. Before #1609 it died earlier on a missing ajv module, which hid this second fault behind the first.

## Evidence

Confirmed on today's `main` run for `9b962fe8`:

    error: the option `Z` is only accepted on the nightly compiler
    error: the option `persist-doctests` is only accepted on the nightly compiler
    error: 2 nightly options were parsed

`cargo test --workspace --doc` locally reports `0 passed` for every crate, so dropping the flag loses no measurement.

## Why not add nightly instead

Keeping doctest coverage would mean pinning a nightly toolchain in CI, an ongoing maintenance cost for a metric with nothing behind it today. If executable doctests are added later, re-add the flag behind `cargo +nightly llvm-cov`. The header comment now says so.

## Verification

`actionlint` clean, YAML parses, both jobs intact. `cargo-llvm-cov` is not installed locally, so the run itself is the proof. This check going green for the first time is the signal to watch.

Note that `Rust coverage (llvm-cov)` is not a required check, so nothing was blocked by the failure. The cost was subtler: a permanently red check trains reviewers to ignore it.

Refs astro-plan-svo0
Merge-Bead: astro-plan-t9g1
