### PR TITLE
fix: CI required check fails on frontend-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -418,9 +418,15 @@ jobs:
       # .pv-* selector ratchet: sealed at zero class selectors in e2e test
       # files (Playwright TS under tests/e2e/ and Rust journeys under
       # crates/e2e-tests/), which the eslint alm/require-root-testid rule
-      # cannot reach. Gated on frontend too, because tests/e2e/ is TS.
+      # cannot reach.
+      #
+      # Gated on rust/scripts only, NOT frontend: `just` is installed under the
+      # rust lane alone, so a `|| frontend` clause here makes a PR touching only
+      # apps/desktop/src/** run this step with no `just` on PATH. Both scanned
+      # trees (tests/e2e/, crates/e2e-tests/) match the `rust` filter via
+      # `tests/**` and `crates/**`, so the frontend clause added no coverage.
       - name: .pv-* selector ratchet
-        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.frontend == 'true' || needs.changes.outputs.scripts == 'true')
+        if: runner.os == 'Linux' && (needs.changes.outputs.rust == 'true' || needs.changes.outputs.scripts == 'true')
         run: just pv-selector-ratchet
 
       # Compilation warnings/lints are OS-agnostic; running clippy on all 3 legs


### PR DESCRIPTION
## Summary

- The `.pv-*` selector ratchet in `.github/workflows/ci.yml` ran whenever the frontend lane was active, but `taiki-e/install-action` supplies `just` under the rust lane only. A PR touching only `apps/desktop/src/**` set `frontend=true, rust=false`, reached `run: just pv-selector-ratchet` with no `just` on `PATH`, and failed `Unit + integration (L1+L2) — ubuntu-latest`, a required context.
- Dropped `|| frontend` from the step gate. `scripts/check-pv-selector-ratchet.sh` scans only `tests/e2e/` and `crates/e2e-tests/tests/`, both matched by the `rust` filter through `tests/**` and `crates/**`, so the frontend clause covered no path the rust lane misses. The step now matches the four sibling ratchets at ci.yml:389, 399, 407, 415.
- Rejected the alternative of widening the install gate: it pulls `just,nextest` onto three OS legs for every frontend-only PR to run a step with nothing to scan.

Targets `orc/wjrz-kyo7-115` (#1604), which introduced the step, so it lands with the defect closed instead of duplicating the step onto `main`.

## Verification

- `actionlint .github/workflows/ci.yml`: one SC2086 info finding at line 478, identical before the edit (line 472 pre-edit).
- `bash scripts/check-pv-selector-ratchet.sh`: exit 0.
- This PR edits `.github/workflows/ci.yml`, which matches `force_full_shared`, so its own run sets both lanes true and cannot exercise `frontend=true, rust=false`. Proving that case needs a commit touching only `apps/desktop/src/**` (no `.ts`/`.tsx` elsewhere, no lockfile) and confirming `Detect changes (CI)` logs `rust=false frontend=true` with no ratchet-step failure.

Tracks-Bead: astro-plan-ovp5
Merge-Bead: astro-plan-yyjq
