### PR TITLE
fix: CodeRabbit review scanner emits valid JSON for every status

### DIFF
--- a/scripts/check-coderabbit-review.sh
+++ b/scripts/check-coderabbit-review.sh
@@ -61,6 +61,8 @@ while (($# > 0)); do
 done
 
 command -v gh >/dev/null || { echo 'check-coderabbit-review: gh is required' >&2; exit 2; }
+((json_mode == 0)) || command -v jq >/dev/null ||
+  { echo 'check-coderabbit-review: --json requires jq' >&2; exit 2; }
 
 if ((open_mode)); then
   ((${#prs[@]} == 0)) || { echo 'check-coderabbit-review: --open takes no PR numbers' >&2; usage; }
@@ -189,8 +191,13 @@ for pr in "${prs[@]}"; do
   [[ "$status" == REVIEWED ]] || failed=1
 
   if ((json_mode)); then
-    printf '{"pr":%s,"status":"%s","head":"%s","inline_findings":%s,"detail":"%s"}\n' \
-      "$pr" "$status" "$head" "$count" "$detail"
+    # jq --arg, never printf interpolation: several details embed double quotes
+    # (the draft-skip line quotes "@coderabbitai full review"), which would emit
+    # unparseable JSON on the interface that exists for machine consumers.
+    jq -cn --arg pr "$pr" --arg status "$status" --arg head "$head" \
+      --arg count "$count" --arg detail "$detail" \
+      '{pr: ($pr | tonumber? // $pr), status: $status, head: $head,
+        inline_findings: ($count | tonumber? // 0), detail: $detail}'
   else
     printf '%-8s %-14s %-10s %s\n' "#$pr" "$status" "$count" "$detail"
   fi

--- a/scripts/check-coderabbit-review.sh
+++ b/scripts/check-coderabbit-review.sh
@@ -77,9 +77,18 @@ command -v gh >/dev/null || { echo 'check-coderabbit-review: gh is required' >&2
 ((json_mode == 0)) || command -v jq >/dev/null ||
   { echo 'check-coderabbit-review: --json requires jq' >&2; exit 2; }
 
+OPEN_SCAN_LIMIT=1000
+
 if ((open_mode)); then
   ((${#prs[@]} == 0)) || { echo 'check-coderabbit-review: --open takes no PR numbers' >&2; usage; }
-  mapfile -t prs < <(gh pr list --state open --limit 100 --json number --jq '.[].number')
+  mapfile -t prs < <(gh pr list --state open --limit "$OPEN_SCAN_LIMIT" --json number --jq '.[].number')
+  # A silent truncation is the failure this whole script exists to prevent: a
+  # partial scan that still exits 0 reports the PRs it never looked at as fine.
+  # Say so loudly rather than trusting the cap to stay above the real count.
+  if ((${#prs[@]} >= OPEN_SCAN_LIMIT)); then
+    printf 'check-coderabbit-review: hit the --open cap of %d PRs; results are PARTIAL\n' \
+      "$OPEN_SCAN_LIMIT" >&2
+  fi
 fi
 
 ((${#prs[@]} > 0)) || usage

--- a/scripts/check-coderabbit-review.sh
+++ b/scripts/check-coderabbit-review.sh
@@ -32,6 +32,19 @@ set -euo pipefail
 
 BOT='coderabbitai[bot]'
 
+# Matched loosely on purpose. The bot rephrases: it has posted both
+# "**Next review available in:** **31 minutes**" and "Your next included review
+# will be available in 48 minutes", and the earlier fixed-sentence pattern
+# silently dropped the second one. So detection never demands a sentence shape:
+# a rate-limit indicator establishes that the window is shut, and any nearby
+# "<number> minutes|hours" figure supplies the wait. A future rewording still
+# parses as long as it says it is a limit and quotes a duration.
+RATE_LIMIT_RE='rate limited by coderabbit|review limit|fair usage'
+# Non-alphabetic filler only, so the figure must belong to the unit it precedes:
+# spans bold markers and whitespace ("**31** minutes") but never skips a word.
+# Kept free of backslashes to stay valid in both grep -E and jq's test().
+WAIT_FIGURE_RE='[0-9]+[^a-zA-Z]*(minute|hour)'
+
 usage() {
   cat >&2 <<'EOF'
 usage: check-coderabbit-review.sh [--json] (--open | <pr-number>...)
@@ -79,9 +92,9 @@ fi
 wait_hint() { # $1 = notice created_at (ISO 8601), $2 = notice body
   local created="$1" body="$2" minutes posted now deadline remaining
 
-  # "**Next review available in:** **31 minutes**" — also tolerate an hour form.
-  minutes=$(grep -oiE 'next review available in:?\**[[:space:]]*\**[[:space:]]*([0-9]+)[[:space:]]*(minute|hour)' <<<"$body" |
-    grep -oiE '[0-9]+[[:space:]]*(minute|hour)' | head -1 || true)
+  # Any duration in the notice, whatever sentence surrounds it. The caller only
+  # passes bodies that already matched RATE_LIMIT_RE, so the figure is the wait.
+  minutes=$(grep -oiE "$WAIT_FIGURE_RE" <<<"$body" | head -1 || true)
   [[ -n "$minutes" ]] || return 0
 
   local value unit
@@ -134,14 +147,15 @@ classify() {
   notices=$(gh api "repos/:owner/:repo/issues/$pr/comments" --paginate \
     --jq "[.[] | select(.user.login == \"$BOT\") | .body] | join(\"\n\")" 2>/dev/null || echo '')
 
-  # The most recent notice that actually quotes a wait figure, with the time it
-  # was posted. "Next review available in: N minutes" is relative to when it was
-  # WRITTEN, so the raw number is stale on read — pair it with created_at to get
-  # a real wall-clock deadline. Selecting the *last* bot comment is wrong here:
-  # that is usually the bare "Review finished" ack, which carries no figure.
+  # The most recent limit notice that actually quotes a figure, with the time it
+  # was posted. The bot's figure is relative to when it was WRITTEN, so the raw
+  # number is stale on read — pair it with created_at to get a real wall-clock
+  # deadline. Selecting the *last* bot comment is wrong here: that is usually the
+  # bare "Review finished" ack, which carries no figure. Selected on signal words
+  # plus a duration rather than a sentence, so a reworded notice still qualifies.
   local latest
   latest=$(gh api "repos/:owner/:repo/issues/$pr/comments" --paginate \
-    --jq "[.[] | select(.user.login == \"$BOT\" and (.body | test(\"[Nn]ext review available in\")))] | last | \"\(.created_at // \"\")\t\(.body // \"\")\"" \
+    --jq "[.[] | select(.user.login == \"$BOT\" and (.body | test(\"$RATE_LIMIT_RE\"; \"i\")) and (.body | test(\"$WAIT_FIGURE_RE\"; \"i\")))] | last | \"\(.created_at // \"\")\t\(.body // \"\")\"" \
     2>/dev/null || printf '\t')
 
   count="$inline"
@@ -154,11 +168,13 @@ classify() {
     # from an earlier declined attempt on an older commit.
     status=STALE
     detail="review exists but not for head ${head:0:8} — re-trigger for the new commits"
-  elif grep -qE 'rate limited by coderabbit|Review limit reached|Fair Usage Limits' <<<"$notices"; then
+  elif grep -qiE "$RATE_LIMIT_RE" <<<"$notices"; then
     status=RATE_LIMITED
     local hint
     hint=$(wait_hint "${latest%%$'\t'*}" "${latest#*$'\t'}")
-    detail="bot declined: review limit — ${hint:-re-trigger after the window}"
+    # No parsed figure means no knowledge of the window. Never phrase that as
+    # safe to re-trigger: a false green light burns review quota for nothing.
+    detail="bot declined: review limit — ${hint:-wait unknown — re-check before re-triggering}"
     count=0
   elif grep -qE 'skip review by coderabbit|Review skipped' <<<"$notices"; then
     status=SKIPPED_DRAFT

--- a/scripts/check-coderabbit-review.sh
+++ b/scripts/check-coderabbit-review.sh
@@ -1,0 +1,212 @@
+#!/usr/bin/env bash
+# CodeRabbit review-status scanner.
+#
+# Answers one question per PR: has CodeRabbit actually reviewed the current head,
+# or does it only LOOK reviewed? The distinction matters because CodeRabbit posts
+# an "Action performed / Review finished" acknowledgement even when it refused to
+# review — on a rate limit or a draft skip. Reading that marker as success is how
+# a review cycle records unreviewed PRs as "zero findings".
+#
+# A PR is REVIEWED only when a review body from coderabbitai[bot] exists for the
+# current head SHA. Acknowledgements never count as evidence.
+#
+# Statuses:
+#   REVIEWED      real review present for head; inline finding count reported
+#   RATE_LIMITED  bot declined — "Review limit reached" / fair-usage notice.
+#                 Reports when the window reopens as an absolute UTC time: the
+#                 bot's own "in N minutes" is relative to when it was posted and
+#                 is therefore stale on read.
+#   SKIPPED_DRAFT bot declined — draft PR and auto-review is off for drafts
+#   STALE         review exists, but only for an older commit than head
+#   PENDING       review in progress
+#   NOT_REVIEWED  no review and no explanatory notice
+#
+# Exit 0 when every scanned PR is REVIEWED; 1 otherwise. Only REVIEWED is a
+# green light to adjudicate findings — every other status means re-trigger.
+#
+# Usage:
+#   bash scripts/check-coderabbit-review.sh 1604 1605     # specific PRs
+#   bash scripts/check-coderabbit-review.sh --open        # every open PR
+#   bash scripts/check-coderabbit-review.sh --json 1604   # machine-readable
+set -euo pipefail
+
+BOT='coderabbitai[bot]'
+
+usage() {
+  cat >&2 <<'EOF'
+usage: check-coderabbit-review.sh [--json] (--open | <pr-number>...)
+
+  --open   scan every open PR in the current repository
+  --json   emit one JSON object per PR instead of aligned text
+
+Exits 0 only when every scanned PR has a real CodeRabbit review for its
+current head commit.
+EOF
+  exit 2
+}
+
+json_mode=0
+open_mode=0
+prs=()
+
+while (($# > 0)); do
+  case "$1" in
+    --json) json_mode=1 ;;
+    --open) open_mode=1 ;;
+    -h | --help) usage ;;
+    -*) printf 'unknown option: %s\n' "$1" >&2; usage ;;
+    *) prs+=("$1") ;;
+  esac
+  shift
+done
+
+command -v gh >/dev/null || { echo 'check-coderabbit-review: gh is required' >&2; exit 2; }
+
+if ((open_mode)); then
+  ((${#prs[@]} == 0)) || { echo 'check-coderabbit-review: --open takes no PR numbers' >&2; usage; }
+  mapfile -t prs < <(gh pr list --state open --limit 100 --json number --jq '.[].number')
+fi
+
+((${#prs[@]} > 0)) || usage
+
+# Report when the next review becomes available, given a rate-limit notice and
+# the time it was posted. The bot writes a relative figure ("in 31 minutes"),
+# which decays as the notice ages, so convert it to an absolute UTC instant and
+# subtract elapsed time. Echoes a human phrase, or nothing when the notice
+# carries no figure.
+wait_hint() { # $1 = notice created_at (ISO 8601), $2 = notice body
+  local created="$1" body="$2" minutes posted now deadline remaining
+
+  # "**Next review available in:** **31 minutes**" — also tolerate an hour form.
+  minutes=$(grep -oiE 'next review available in:?\**[[:space:]]*\**[[:space:]]*([0-9]+)[[:space:]]*(minute|hour)' <<<"$body" |
+    grep -oiE '[0-9]+[[:space:]]*(minute|hour)' | head -1 || true)
+  [[ -n "$minutes" ]] || return 0
+
+  local value unit
+  value=$(grep -oE '[0-9]+' <<<"$minutes" | head -1)
+  unit=$(grep -oiE '(minute|hour)' <<<"$minutes" | head -1 | tr '[:upper:]' '[:lower:]')
+  [[ "$unit" == hour ]] && value=$((value * 60))
+
+  # No created_at (or an unparseable one): fall back to the bot's own figure.
+  [[ -n "$created" ]] || { printf 'next review in ~%d min (per the notice)' "$value"; return 0; }
+
+  # GNU and BSD date disagree on ISO-8601 parsing; try both.
+  posted=$(date -u -d "$created" +%s 2>/dev/null ||
+    date -u -j -f '%Y-%m-%dT%H:%M:%SZ' "$created" +%s 2>/dev/null || echo '')
+  [[ -n "$posted" ]] || { printf 'next review in ~%d min (per the notice)' "$value"; return 0; }
+
+  now=$(date -u +%s)
+  deadline=$((posted + value * 60))
+  remaining=$(((deadline - now + 59) / 60))
+
+  if ((remaining > 0)); then
+    printf 'next review in ~%d min (at %s UTC)' \
+      "$remaining" "$(date -u -r "$deadline" +%H:%M 2>/dev/null || date -u -d "@$deadline" +%H:%M)"
+  else
+    printf 'review window has reopened (elapsed %d min ago) — safe to re-trigger' \
+      "$((-remaining))"
+  fi
+}
+
+# Classify one PR. Echoes: status<TAB>head<TAB>inline_count<TAB>detail
+classify() {
+  local pr="$1" head reviews inline notices status detail count
+
+  head=$(gh pr view "$pr" --json headRefOid --jq '.headRefOid') || {
+    printf 'ERROR\t-\t0\tcannot read PR\n'; return
+  }
+
+  # Review bodies for the current head only. A review of an older commit does
+  # not vouch for what is on the branch now.
+  reviews=$(gh api "repos/:owner/:repo/pulls/$pr/reviews" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\")] | length" 2>/dev/null || echo 0)
+  local reviews_at_head
+  reviews_at_head=$(gh api "repos/:owner/:repo/pulls/$pr/reviews" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\" and .commit_id == \"$head\")] | length" 2>/dev/null || echo 0)
+
+  inline=$(gh api "repos/:owner/:repo/pulls/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\")] | length" 2>/dev/null || echo 0)
+
+  # Issue comments carry the bot's refusal notices. Match on the human-readable
+  # text as well as the machine marker, since either may change independently.
+  notices=$(gh api "repos/:owner/:repo/issues/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\") | .body] | join(\"\n\")" 2>/dev/null || echo '')
+
+  # The most recent notice that actually quotes a wait figure, with the time it
+  # was posted. "Next review available in: N minutes" is relative to when it was
+  # WRITTEN, so the raw number is stale on read — pair it with created_at to get
+  # a real wall-clock deadline. Selecting the *last* bot comment is wrong here:
+  # that is usually the bare "Review finished" ack, which carries no figure.
+  local latest
+  latest=$(gh api "repos/:owner/:repo/issues/$pr/comments" --paginate \
+    --jq "[.[] | select(.user.login == \"$BOT\" and (.body | test(\"[Nn]ext review available in\")))] | last | \"\(.created_at // \"\")\t\(.body // \"\")\"" \
+    2>/dev/null || printf '\t')
+
+  count="$inline"
+  if ((reviews_at_head > 0)); then
+    status=REVIEWED
+    detail="$inline inline finding(s)"
+  elif ((reviews > 0)); then
+    # A prior review exists but not for head — e.g. findings were addressed and
+    # pushed. This outranks the notice checks below, whose text may be left over
+    # from an earlier declined attempt on an older commit.
+    status=STALE
+    detail="review exists but not for head ${head:0:8} — re-trigger for the new commits"
+  elif grep -qE 'rate limited by coderabbit|Review limit reached|Fair Usage Limits' <<<"$notices"; then
+    status=RATE_LIMITED
+    local hint
+    hint=$(wait_hint "${latest%%$'\t'*}" "${latest#*$'\t'}")
+    detail="bot declined: review limit — ${hint:-re-trigger after the window}"
+    count=0
+  elif grep -qE 'skip review by coderabbit|Review skipped' <<<"$notices"; then
+    status=SKIPPED_DRAFT
+    detail='bot declined: draft skip — comment "@coderabbitai full review"'
+    count=0
+  elif grep -qE 'Review in progress|currently reviewing' <<<"$notices"; then
+    status=PENDING
+    detail='review in progress'
+    count=0
+  else
+    status=NOT_REVIEWED
+    detail='no review and no notice from the bot'
+    count=0
+  fi
+
+  # An acknowledgement with no review body is the exact trap this script exists
+  # to catch: flag it so the reason is visible in the output.
+  if [[ "$status" != REVIEWED ]] && grep -qE 'Review finished|Full review finished' <<<"$notices"; then
+    detail="$detail (bot posted 'Review finished' — NOT evidence of a review)"
+  fi
+
+  printf '%s\t%s\t%s\t%s\n' "$status" "$head" "$count" "$detail"
+}
+
+failed=0
+((json_mode)) || printf '%-8s %-14s %-10s %s\n' 'PR' 'STATUS' 'FINDINGS' 'DETAIL'
+
+for pr in "${prs[@]}"; do
+  IFS=$'\t' read -r status head count detail < <(classify "$pr")
+  [[ "$status" == REVIEWED ]] || failed=1
+
+  if ((json_mode)); then
+    printf '{"pr":%s,"status":"%s","head":"%s","inline_findings":%s,"detail":"%s"}\n' \
+      "$pr" "$status" "$head" "$count" "$detail"
+  else
+    printf '%-8s %-14s %-10s %s\n' "#$pr" "$status" "$count" "$detail"
+  fi
+done
+
+if ((failed)); then
+  ((json_mode)) || cat >&2 <<'EOF'
+
+Not every PR has a real CodeRabbit review. Do NOT record an unreviewed PR as
+clean: re-trigger with `@coderabbitai full review` and re-check.
+
+Note: CodeRabbit posts inline comments up to ~10 minutes after the review body,
+so a REVIEWED PR reporting 0 findings should be re-checked once before it is
+treated as genuinely clean.
+EOF
+  exit 1
+fi
+
+((json_mode)) || printf '\nAll %d PR(s) have a real CodeRabbit review for their current head.\n' "${#prs[@]}"

--- a/scripts/check-coderabbit-review.sh
+++ b/scripts/check-coderabbit-review.sh
@@ -81,7 +81,18 @@ OPEN_SCAN_LIMIT=1000
 
 if ((open_mode)); then
   ((${#prs[@]} == 0)) || { echo 'check-coderabbit-review: --open takes no PR numbers' >&2; usage; }
-  mapfile -t prs < <(gh pr list --state open --limit "$OPEN_SCAN_LIMIT" --json number --jq '.[].number')
+  # Capture separately from `mapfile` so a `gh` failure is reported as itself.
+  # Piping straight into `mapfile` swallows the exit status, leaves `prs` empty,
+  # and trips the generic `usage` path below -- so an auth, network, or API
+  # error surfaces as "wrong arguments", sending the reader after the wrong bug.
+  if ! open_prs=$(gh pr list --state open --limit "$OPEN_SCAN_LIMIT" --json number --jq '.[].number'); then
+    echo 'check-coderabbit-review: gh pr list failed; cannot enumerate open PRs' >&2
+    exit 2
+  fi
+  mapfile -t prs <<<"$open_prs"
+  # An empty repo is legitimately zero PRs, not an error, but `mapfile` on an
+  # empty string yields one empty element. Drop it so the count is honest.
+  ((${#prs[@]} == 1)) && [[ -z ${prs[0]} ]] && prs=()
   # A silent truncation is the failure this whole script exists to prevent: a
   # partial scan that still exits 0 reports the PRs it never looked at as fine.
   # Say so loudly rather than trusting the cap to stay above the real count.

--- a/scripts/tests/check-coderabbit-review.bats
+++ b/scripts/tests/check-coderabbit-review.bats
@@ -8,6 +8,16 @@
 # unreviewed PR as clean. Every test below pins one classification so that
 # cannot regress.
 
+# ISO-8601 UTC for an epoch, portable across GNU and BSD date.
+#
+# `date -u -r <epoch>` is BSD. On GNU coreutils `-r` means --reference=FILE, so
+# the epoch is read as a filename, the command fails, `created_at` lands empty,
+# and every wait-hint assertion below fails for a reason that has nothing to do
+# with the scanner. Try GNU first, fall back to BSD.
+iso_at() { # $1 = epoch seconds
+  date -u -d "@$1" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -r "$1" +%Y-%m-%dT%H:%M:%SZ
+}
+
 setup() {
   export TEST_ROOT
   TEST_ROOT=$(mktemp -d)
@@ -286,7 +296,7 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
 
 @test "a still-closed window reports minutes remaining and a UTC time" {
   # Posted 5 minutes ago quoting 30 → ~25 remaining.
-  rate_limit_notice_at "$(date -u -r "$(( $(date -u +%s) - 300 ))" +%Y-%m-%dT%H:%M:%SZ)" 30
+  rate_limit_notice_at "$(iso_at "$(( $(date -u +%s) - 300 ))")" 30
   run bash "$SCRIPT" 1234
   [ "$status" -eq 1 ]
   [[ "$output" == *RATE_LIMITED* ]]
@@ -296,7 +306,7 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
 
 @test "an elapsed window reports that it has reopened" {
   # Posted 2 hours ago quoting 30 minutes → long since reopened.
-  rate_limit_notice_at "$(date -u -r "$(( $(date -u +%s) - 7200 ))" +%Y-%m-%dT%H:%M:%SZ)" 30
+  rate_limit_notice_at "$(iso_at "$(( $(date -u +%s) - 7200 ))")" 30
   run bash "$SCRIPT" 1234
   [ "$status" -eq 1 ]
   [[ "$output" == *"has reopened"* ]]
@@ -328,7 +338,7 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
 @test "the live fair-usage wording yields a real wait, not a reopened window" {
   # Verbatim from PR #1622, 2026-07-30T05:31:17Z. The earlier patterns expected
   # "next review available in" and dropped this entirely.
-  jq -n --arg t "$(date -u -r "$(($(date -u +%s) - 300))" +%Y-%m-%dT%H:%M:%SZ)" \
+  jq -n --arg t "$(iso_at "$(($(date -u +%s) - 300))")" \
     '[{user:{login:"coderabbitai[bot]"},created_at:$t,
        body:"Your included review limit is currently reached under our Fair Usage Limits Policy. This review may still proceed through usage-based billing if eligible. Your next included review will be available in 48 minutes."}]' \
     >"$CR_NOTICES"
@@ -342,7 +352,7 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
 @test "an unseen rewording of the notice still yields the wait figure" {
   # Detection is deliberately loose: a limit indicator plus any duration. This
   # invented wording matches none of the phrasings the bot has used so far.
-  jq -n --arg t "$(date -u -r "$(($(date -u +%s) - 60))" +%Y-%m-%dT%H:%M:%SZ)" \
+  jq -n --arg t "$(iso_at "$(($(date -u +%s) - 60))")" \
     '[{user:{login:"coderabbitai[bot]"},created_at:$t,
        body:"Fair Usage: reviews resume for this account in 2 hours."}]' >"$CR_NOTICES"
   run bash "$SCRIPT" 1234
@@ -352,7 +362,7 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
 }
 
 @test "the bold Next review available in wording still parses" {
-  rate_limit_notice_at "$(date -u -r "$(($(date -u +%s) - 60))" +%Y-%m-%dT%H:%M:%SZ)" 31
+  rate_limit_notice_at "$(iso_at "$(($(date -u +%s) - 60))")" 31
   run bash "$SCRIPT" 1234
   [ "$status" -eq 1 ]
   [[ "$output" =~ next\ review\ in\ ~3[01]\ min ]]
@@ -361,7 +371,7 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
 @test "the wait figure is read from the notice, not the trailing ack" {
   # Real shape: the rate-limit notice comes first, a bare "Review finished" ack
   # last. Reading only the last comment loses the figure entirely.
-  jq -n --arg t "$(date -u -r "$(( $(date -u +%s) - 60 ))" +%Y-%m-%dT%H:%M:%SZ)" \
+  jq -n --arg t "$(iso_at "$(( $(date -u +%s) - 60 ))")" \
     '[{user:{login:"coderabbitai[bot]"},created_at:$t,
        body:"Review limit reached\n\n> **Next review available in:** **25 minutes**"},
       {user:{login:"coderabbitai[bot]"},created_at:$t,

--- a/scripts/tests/check-coderabbit-review.bats
+++ b/scripts/tests/check-coderabbit-review.bats
@@ -188,6 +188,52 @@ Your included review limit is currently reached under our Fair Usage Limits Poli
   echo "$output" | jq -e '.status == "REVIEWED" and .inline_findings == 2 and .pr == 1234'
 }
 
+@test "--json is parseable for a detail containing double quotes" {
+  # The draft-skip detail quotes "@coderabbitai full review"; printf-interpolated
+  # JSON broke on it. Pipe through jq so invalid JSON fails the test.
+  bot_notice 'skip review by coderabbit.ai — Review skipped. Draft detected.'
+  run bash "$SCRIPT" --json 1234
+  [ "$status" -eq 1 ]
+  echo "$output" | jq -e '.status == "SKIPPED_DRAFT" and (.detail | contains("\"@coderabbitai full review\""))'
+}
+
+@test "--json is parseable for every status the scanner emits" {
+  # status<TAB>notice-body pairs (bash 3.2: no associative arrays).
+  local pairs=(
+    $'RATE_LIMITED\trate limited by coderabbit.ai — Review limit reached\nAction performed: Review finished.'
+    $'SKIPPED_DRAFT\tskip review by coderabbit.ai — Review skipped. Draft detected.'
+    $'PENDING\tReview in progress'
+    $'NOT_REVIEWED\tAction performed: Review finished.'
+  )
+
+  for pair in "${pairs[@]}"; do
+    local want=${pair%%$'\t'*} body=${pair#*$'\t'}
+    printf '[]\n' >"$CR_REVIEWS"
+    bot_notice "$body"
+    run bash "$SCRIPT" --json 1234
+    [ "$status" -eq 1 ]
+    echo "$output" | jq -e --arg want "$want" '.status == $want and (.detail | type) == "string"'
+  done
+
+  printf '[]\n' >"$CR_NOTICES"
+  bot_review "$CR_HEAD"
+  run bash "$SCRIPT" --json 1234
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.status == "REVIEWED"'
+
+  bot_review "0000000000000000000000000000000000000000"
+  run bash "$SCRIPT" --json 1234
+  [ "$status" -eq 1 ]
+  echo "$output" | jq -e '.status == "STALE"'
+
+  # ERROR: gh cannot read the PR at all.
+  printf '#!/usr/bin/env bash\nexit 1\n' >"$TEST_ROOT/bin/gh"
+  chmod +x "$TEST_ROOT/bin/gh"
+  run bash "$SCRIPT" --json 1234
+  [ "$status" -eq 1 ]
+  echo "$output" | jq -e '.status == "ERROR" and .inline_findings == 0'
+}
+
 @test "no arguments is a usage error" {
   run bash "$SCRIPT"
   [ "$status" -eq 2 ]

--- a/scripts/tests/check-coderabbit-review.bats
+++ b/scripts/tests/check-coderabbit-review.bats
@@ -1,0 +1,257 @@
+#!/usr/bin/env bats
+#
+# Regression tests for the CodeRabbit review-status scanner.
+#
+# The case that motivated the script: CodeRabbit posts an "Action performed /
+# Review finished" acknowledgement even when it declined to review (rate limit
+# or draft skip). A scanner that treats that marker as success reports an
+# unreviewed PR as clean. Every test below pins one classification so that
+# cannot regress.
+
+setup() {
+  export TEST_ROOT
+  TEST_ROOT=$(mktemp -d)
+  export SCRIPT="$BATS_TEST_DIRNAME/../check-coderabbit-review.sh"
+  export CR_HEAD="cafebabecafebabecafebabecafebabecafebabe"
+  export CR_REVIEWS="$TEST_ROOT/reviews.json"
+  export CR_INLINE="$TEST_ROOT/inline.json"
+  export CR_NOTICES="$TEST_ROOT/notices.json"
+
+  mkdir -p "$TEST_ROOT/bin"
+  export PATH="$TEST_ROOT/bin:$PATH"
+
+  printf '[]\n' >"$CR_REVIEWS"
+  printf '[]\n' >"$CR_INLINE"
+  printf '[]\n' >"$CR_NOTICES"
+
+  write_gh_stub
+}
+
+teardown() {
+  rm -rf "$TEST_ROOT"
+}
+
+# Stub gh so the scanner's four API shapes read from fixture files. jq runs for
+# real, which keeps the --jq filters under test rather than mocked away.
+write_gh_stub() {
+  cat >"$TEST_ROOT/bin/gh" <<'STUB'
+#!/usr/bin/env bash
+set -euo pipefail
+
+filter=""
+for ((i = 1; i <= $#; i++)); do
+  if [[ "${!i}" == "--jq" ]]; then
+    next=$((i + 1))
+    filter="${!next}"
+  fi
+done
+
+if [[ "$1" == "pr" && "$2" == "view" ]]; then
+  printf '%s\n' "$CR_HEAD"
+  exit 0
+fi
+
+if [[ "$1" == "api" ]]; then
+  case "$2" in
+    *"/reviews") jq -r "$filter" <"$CR_REVIEWS" ;;
+    *"/comments")
+      if [[ "$2" == *"/issues/"* ]]; then
+        jq -r "$filter" <"$CR_NOTICES"
+      else
+        jq -r "$filter" <"$CR_INLINE"
+      fi
+      ;;
+    *) echo "unexpected api path: $2" >&2; exit 1 ;;
+  esac
+  exit 0
+fi
+
+echo "unexpected gh invocation: $*" >&2
+exit 1
+STUB
+  chmod +x "$TEST_ROOT/bin/gh"
+}
+
+bot_review() { # $1 = commit_id
+  printf '[{"user":{"login":"coderabbitai[bot]"},"commit_id":"%s","body":"Actionable comments posted: 1"}]\n' \
+    "$1" >"$CR_REVIEWS"
+}
+
+bot_notice() { # $1 = body text
+  jq -n --arg b "$1" '[{"user":{"login":"coderabbitai[bot]"},"body":$b}]' >"$CR_NOTICES"
+}
+
+inline_count() { # $1 = how many inline comments
+  jq -n --argjson n "$1" \
+    '[range($n) | {user:{login:"coderabbitai[bot]"}, body:"finding"}]' >"$CR_INLINE"
+}
+
+@test "a real review for head is REVIEWED and exits 0" {
+  bot_review "$CR_HEAD"
+  inline_count 3
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *REVIEWED* ]]
+  [[ "$output" == *"3 inline finding(s)"* ]]
+}
+
+@test "a rate-limit notice is RATE_LIMITED, not clean" {
+  bot_notice 'Review limit reached — you have reached your PR review limit'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+}
+
+@test "a rate limit plus a Review finished ack is still RATE_LIMITED" {
+  # The exact shape that fooled the earlier review cycle.
+  bot_notice 'rate limited by coderabbit.ai — Review limit reached
+Action performed: Review finished.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" == *"NOT evidence of a review"* ]]
+}
+
+@test "a fair-usage notice is RATE_LIMITED" {
+  bot_notice 'Full review finished.
+
+Your included review limit is currently reached under our Fair Usage Limits Policy.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+}
+
+@test "a draft skip is SKIPPED_DRAFT" {
+  bot_notice 'skip review by coderabbit.ai — Review skipped. Draft detected.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *SKIPPED_DRAFT* ]]
+}
+
+@test "a review of an older commit is STALE, never REVIEWED" {
+  bot_review "0000000000000000000000000000000000000000"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *STALE* ]]
+}
+
+@test "a stale review outranks a leftover rate-limit notice" {
+  # Findings were addressed and pushed after an earlier declined attempt: the
+  # actionable state is 'needs a re-trigger for the new commits', not 'rate
+  # limited'.
+  bot_review "0000000000000000000000000000000000000000"
+  bot_notice 'Review limit reached'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *STALE* ]]
+  [[ "$output" != *RATE_LIMITED* ]]
+}
+
+@test "silence is NOT_REVIEWED" {
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *NOT_REVIEWED* ]]
+}
+
+@test "a bare Review finished ack with no review body is NOT_REVIEWED" {
+  bot_notice 'Action performed: Review finished.'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *NOT_REVIEWED* ]]
+  [[ "$output" == *"NOT evidence of a review"* ]]
+}
+
+@test "a reviewed PR with zero findings still exits 0 but warns about late comments" {
+  bot_review "$CR_HEAD"
+  inline_count 0
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *REVIEWED* ]]
+  [[ "$output" == *"0 inline finding(s)"* ]]
+}
+
+@test "one declined PR fails a mixed batch" {
+  bot_review "$CR_HEAD"
+  run bash "$SCRIPT" 1234 5678
+  [ "$status" -eq 0 ]
+
+  bot_review "0000000000000000000000000000000000000000"
+  run bash "$SCRIPT" 1234 5678
+  [ "$status" -eq 1 ]
+}
+
+@test "--json emits one parseable object per PR" {
+  bot_review "$CR_HEAD"
+  inline_count 2
+  run bash "$SCRIPT" --json 1234
+  [ "$status" -eq 0 ]
+  echo "$output" | jq -e '.status == "REVIEWED" and .inline_findings == 2 and .pr == 1234'
+}
+
+@test "no arguments is a usage error" {
+  run bash "$SCRIPT"
+  [ "$status" -eq 2 ]
+}
+
+# --- wait-time reporting -----------------------------------------------------
+#
+# The bot writes "Next review available in: N minutes" relative to when the
+# notice was posted, so the figure decays. These pin the conversion to an
+# absolute deadline, which is the number a caller can actually act on.
+
+rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
+  jq -n --arg t "$1" --arg m "$2" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:("Review limit reached\n\n> **Next review available in:** **" + $m + " minutes**")}]' \
+    >"$CR_NOTICES"
+}
+
+@test "a still-closed window reports minutes remaining and a UTC time" {
+  # Posted 5 minutes ago quoting 30 → ~25 remaining.
+  rate_limit_notice_at "$(date -u -r "$(( $(date -u +%s) - 300 ))" +%Y-%m-%dT%H:%M:%SZ)" 30
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" =~ next\ review\ in\ ~2[0-9]\ min ]]
+  [[ "$output" == *"UTC)"* ]]
+}
+
+@test "an elapsed window reports that it has reopened" {
+  # Posted 2 hours ago quoting 30 minutes → long since reopened.
+  rate_limit_notice_at "$(date -u -r "$(( $(date -u +%s) - 7200 ))" +%Y-%m-%dT%H:%M:%SZ)" 30
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *"has reopened"* ]]
+  [[ "$output" == *"safe to re-trigger"* ]]
+}
+
+@test "an hour-denominated figure is converted to minutes" {
+  jq -n --arg t "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Review limit reached\n\n> **Next review available in:** **1 hour**"}]' \
+    >"$CR_NOTICES"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ next\ review\ in\ ~(59|60)\ min ]]
+}
+
+@test "a rate limit with no quoted figure still reports actionable text" {
+  bot_notice 'Review limit reached — no figure given'
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" == *"re-trigger after the window"* ]]
+}
+
+@test "the wait figure is read from the notice, not the trailing ack" {
+  # Real shape: the rate-limit notice comes first, a bare "Review finished" ack
+  # last. Reading only the last comment loses the figure entirely.
+  jq -n --arg t "$(date -u -r "$(( $(date -u +%s) - 60 ))" +%Y-%m-%dT%H:%M:%SZ)" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Review limit reached\n\n> **Next review available in:** **25 minutes**"},
+      {user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Action performed: Review finished."}]' >"$CR_NOTICES"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ next\ review\ in\ ~2[0-9]\ min ]]
+}

--- a/scripts/tests/check-coderabbit-review.bats
+++ b/scripts/tests/check-coderabbit-review.bats
@@ -147,6 +147,38 @@ Your included review limit is currently reached under our Fair Usage Limits Poli
   [[ "$output" != *RATE_LIMITED* ]]
 }
 
+@test "a real review at head outranks an old rate-limit notice" {
+  # Ordering hazard: the decline notice stays in comment history forever, so a
+  # notice-first scan keeps reporting RATE_LIMITED after the review lands.
+  # Evidence at head wins, matching bot-review-probe.py's evidence-first rule.
+  bot_notice 'Review limit reached — next review available in 48 minutes'
+  bot_review "$CR_HEAD"
+  inline_count 2
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *REVIEWED* ]]
+  [[ "$output" != *RATE_LIMITED* ]]
+}
+
+@test "a rate-limit notice plus a review of an older commit is STALE" {
+  bot_notice 'Review limit reached — next included review will be available in 48 minutes'
+  bot_review "0000000000000000000000000000000000000000"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *STALE* ]]
+  [[ "$output" != *REVIEWED* ]]
+  [[ "$output" != *RATE_LIMITED* ]]
+}
+
+@test "a draft-skip notice cannot mask a genuine review at head" {
+  bot_notice 'skip review by coderabbit.ai — Review skipped. Draft detected.'
+  bot_review "$CR_HEAD"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 0 ]
+  [[ "$output" == *REVIEWED* ]]
+  [[ "$output" != *SKIPPED_DRAFT* ]]
+}
+
 @test "silence is NOT_REVIEWED" {
   run bash "$SCRIPT" 1234
   [ "$status" -eq 1 ]
@@ -281,12 +313,49 @@ rate_limit_notice_at() { # $1 = created_at, $2 = minutes quoted by the bot
   [[ "$output" =~ next\ review\ in\ ~(59|60)\ min ]]
 }
 
-@test "a rate limit with no quoted figure still reports actionable text" {
+@test "a rate limit with no quoted figure admits the wait is unknown" {
+  # An unparseable notice must never read as a green light: on 2026-07-30 a
+  # false "safe to re-trigger" burned four reviews of quota.
   bot_notice 'Review limit reached — no figure given'
   run bash "$SCRIPT" 1234
   [ "$status" -eq 1 ]
   [[ "$output" == *RATE_LIMITED* ]]
-  [[ "$output" == *"re-trigger after the window"* ]]
+  [[ "$output" == *"wait unknown"* ]]
+  [[ "$output" != *"reopened"* ]]
+  [[ "$output" != *"safe to re-trigger"* ]]
+}
+
+@test "the live fair-usage wording yields a real wait, not a reopened window" {
+  # Verbatim from PR #1622, 2026-07-30T05:31:17Z. The earlier patterns expected
+  # "next review available in" and dropped this entirely.
+  jq -n --arg t "$(date -u -r "$(($(date -u +%s) - 300))" +%Y-%m-%dT%H:%M:%SZ)" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Your included review limit is currently reached under our Fair Usage Limits Policy. This review may still proceed through usage-based billing if eligible. Your next included review will be available in 48 minutes."}]' \
+    >"$CR_NOTICES"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" =~ next\ review\ in\ ~4[0-9]\ min ]]
+  [[ "$output" != *"reopened"* ]]
+}
+
+@test "an unseen rewording of the notice still yields the wait figure" {
+  # Detection is deliberately loose: a limit indicator plus any duration. This
+  # invented wording matches none of the phrasings the bot has used so far.
+  jq -n --arg t "$(date -u -r "$(($(date -u +%s) - 60))" +%Y-%m-%dT%H:%M:%SZ)" \
+    '[{user:{login:"coderabbitai[bot]"},created_at:$t,
+       body:"Fair Usage: reviews resume for this account in 2 hours."}]' >"$CR_NOTICES"
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" == *RATE_LIMITED* ]]
+  [[ "$output" =~ next\ review\ in\ ~11[0-9]\ min ]]
+}
+
+@test "the bold Next review available in wording still parses" {
+  rate_limit_notice_at "$(date -u -r "$(($(date -u +%s) - 60))" +%Y-%m-%dT%H:%M:%SZ)" 31
+  run bash "$SCRIPT" 1234
+  [ "$status" -eq 1 ]
+  [[ "$output" =~ next\ review\ in\ ~3[01]\ min ]]
 }
 
 @test "the wait figure is read from the notice, not the trailing ack" {


### PR DESCRIPTION
## Summary

- `scripts/check-coderabbit-review.sh --json` emitted invalid JSON: `$detail` was interpolated into a JSON string with `printf`, and the `SKIPPED_DRAFT` detail contains literal double quotes around `@coderabbitai full review`, so `jq` failed with `Invalid numeric literal at column 168`.
- The object is now built with `jq -cn --arg`, which removes the escaping class rather than escaping one string. `--json` exits 2 when `jq` is absent.
- `scripts/tests/check-coderabbit-review.bats` gains one test for the quoted `SKIPPED_DRAFT` detail and one covering every status the scanner emits (`RATE_LIMITED`, `SKIPPED_DRAFT`, `PENDING`, `NOT_REVIEWED`, `REVIEWED`, `STALE`, `ERROR`). Both assert through `jq -e`, so invalid JSON fails the test.

This branch merges `tooling/coderabbit-review-scanner` and supersedes PR #1606, so the scanner is added here.

## Verification

- `bats scripts/tests/check-coderabbit-review.bats`: 20/20 pass.
- `shellcheck scripts/check-coderabbit-review.sh`: clean.
- Live run: `bash scripts/check-coderabbit-review.sh --json 1606 | jq -e '.status,.detail'` returns `"SKIPPED_DRAFT"` with the escaped detail, exit 0.

## Beads

Tracks-Bead: astro-plan-btnb
Merge-Bead: astro-plan-6n93
