### PR TITLE
chore(deps): drop the mcp-repomix pin

### DIFF
--- a/apm.yml
+++ b/apm.yml
@@ -27,7 +27,6 @@ dependencies:
   - srobroek/agentic-packages/packages/mcp-playwright#main
   - srobroek/agentic-packages/packages/mcp-context7#main
   - srobroek/agentic-packages/packages/mcp-package-version#main
-  - srobroek/agentic-packages/packages/mcp-repomix#main
   - srobroek/agentic-packages/packages/mcp-tauri#main
   - wshobson/agents/plugins/database-design
   - srobroek/agentic-packages/packages/user-journeys#main


### PR DESCRIPTION
The `mcp-repomix` package is being removed from `srobroek/agentic-packages`. A pin to a deleted package fails `apm install` at resolution, so this lands first.

Why it is going: every MCP tool it exposed has a CLI equivalent, nothing in that repository called the tool names, and its refresh hook never packed anything. It passed `--directory` to repomix, which takes the directory positionally and rejects the flag, so the hook exited 1 on every run for its whole life. The marker directory it writes on success holds zero files.

Use the repomix CLI on demand instead:

| Need | Command |
|------|---------|
| pack the tree | `repomix .` |
| scope to what matters | `repomix . --include "src/**/*.ts"` |
| read without writing a file | `repomix . --stdout` |

Measured on agentic-packages: a full pack is 1.3s with no caching, and `--include` scoped to code cuts output 81 percent.