### PR TITLE
fix: dev settings loading padding, spotlight fallback delay, and dev call-list column alignment

### DIFF
--- a/apps/desktop/src/app/sidebar.css.ts
+++ b/apps/desktop/src/app/sidebar.css.ts
@@ -81,7 +81,9 @@ export const item = style({
   display: 'flex',
   alignItems: 'center',
   gap: 'var(--pv-sp-2)',
-  padding: '6px var(--pv-sp-3)',
+  // 6px is off the base-4 spacing scale, so it is composed from tokens rather
+  // than hardcoded; the rendered value is unchanged.
+  padding: 'calc(var(--pv-sp-1) + var(--pv-sp-0)) var(--pv-sp-3)',
   margin: '1px var(--pv-sp-1)',
   cursor: 'pointer',
   color: vars.textSecondary,

--- a/apps/desktop/src/dev/CallList.tsx
+++ b/apps/desktop/src/dev/CallList.tsx
@@ -20,6 +20,7 @@ import {
   tdContract as callsTdContract,
   tdStarted as callsTdStarted,
   tdActions as callsTdActions,
+  actions as callsActions,
   truncated as callsTruncated,
   outcomeVariants as callsOutcomeVariants,
   replayBtnVariants as callsReplayBtnVariants,
@@ -116,33 +117,35 @@ export function CallList({
                 )}
               </td>
               <td className={callsTdActions}>
-                <button
-                  type="button"
-                  className="pv-btn pv-btn--xs"
-                  onClick={() => onViewSchema(call)}
-                  aria-label={`View schema for ${call.contract} v${call.contractVersion}`}
-                >
-                  Schema
-                </button>
-                <button
-                  type="button"
-                  className={`pv-btn pv-btn--xs ${isReplaySafe ? callsReplayBtnVariants.safe : callsReplayBtnVariants.unsafe}`}
-                  onClick={() => onReplay(call)}
-                  disabled={!isReplaySafe}
-                  title={
-                    isReplaySafe
-                      ? `Replay ${call.contract}`
-                      : 'Replay disabled: write contract'
-                  }
-                  aria-label={
-                    isReplaySafe
-                      ? `Replay call to ${call.contract}`
-                      : `Replay disabled for write contract ${call.contract}`
-                  }
-                  aria-disabled={!isReplaySafe}
-                >
-                  Replay
-                </button>
+                <div className={callsActions}>
+                  <button
+                    type="button"
+                    className="pv-btn pv-btn--xs"
+                    onClick={() => onViewSchema(call)}
+                    aria-label={`View schema for ${call.contract} v${call.contractVersion}`}
+                  >
+                    Schema
+                  </button>
+                  <button
+                    type="button"
+                    className={`pv-btn pv-btn--xs ${isReplaySafe ? callsReplayBtnVariants.safe : callsReplayBtnVariants.unsafe}`}
+                    onClick={() => onReplay(call)}
+                    disabled={!isReplaySafe}
+                    title={
+                      isReplaySafe
+                        ? `Replay ${call.contract}`
+                        : 'Replay disabled: write contract'
+                    }
+                    aria-label={
+                      isReplaySafe
+                        ? `Replay call to ${call.contract}`
+                        : `Replay disabled for write contract ${call.contract}`
+                    }
+                    aria-disabled={!isReplaySafe}
+                  >
+                    Replay
+                  </button>
+                </div>
               </td>
             </tr>
           );

--- a/apps/desktop/src/dev/call-list.css.ts
+++ b/apps/desktop/src/dev/call-list.css.ts
@@ -38,6 +38,10 @@ export const tdStarted = style({
 });
 export const tdActions = style({
   padding: 'var(--pv-sp-1) var(--pv-sp-2)',
+});
+// `display: flex` belongs on a wrapper, not the `<td>`: a flex cell leaves table
+// layout, so its column stops contributing to width and baseline alignment.
+export const actions = style({
   display: 'flex',
   gap: 'var(--pv-sp-1)',
 });

--- a/apps/desktop/src/dev/dev-settings-page.css.ts
+++ b/apps/desktop/src/dev/dev-settings-page.css.ts
@@ -24,4 +24,7 @@ export const error = style({
   color: vars.danger,
   fontSize: 'var(--pv-text-sm)',
 });
-export const loading = style({ color: vars.textMuted });
+export const loading = style({
+  padding: 'var(--pv-sp-7)',
+  color: vars.textMuted,
+});

--- a/apps/desktop/src/features/onboarding/FindSpotlight.arrival.test.tsx
+++ b/apps/desktop/src/features/onboarding/FindSpotlight.arrival.test.tsx
@@ -1,0 +1,159 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * Which signal starts the spotlight's short anchor deadline (spec 056 FR-022).
+ *
+ * Two budgets share one resolve loop: a 3s pre-arrival navigation grace, and a
+ * 1.5s post-arrival anchor wait restarted from the moment the target route is on
+ * screen. Recording arrival on the wrong signal silently converts legitimate
+ * navigation time into anchor-wait time and shows the unavailable callout while
+ * the app is still navigating, so each case below pins WHICH deadline governs by
+ * checking whether the callout has appeared at 2s — past the short deadline,
+ * short of the long one.
+ *
+ * The anchor never exists in these runs (nothing renders a `data-guide-anchor`),
+ * so the loop always ends in the callout; only its timing is under test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { act, render, screen } from '@testing-library/react';
+import type { OnboardingItemDto, OnboardingPage } from '@/bindings/index';
+import {
+  FindSpotlight,
+  toggleFind,
+  clearFind,
+  useActiveFindItem,
+} from './FindSpotlight';
+
+let pathname = '/sessions';
+
+vi.mock('@tanstack/react-router', () => ({
+  useNavigate: () => vi.fn(),
+  useRouterState: ({ select }: { select: (s: unknown) => unknown }) =>
+    select({ location: { pathname } }),
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+  useQueryClient: () => ({}),
+}));
+
+vi.mock('./joyrideAdapter', () => ({
+  OnboardingJoyride: () => null,
+}));
+
+const mockFirstSessionId = vi.fn<() => Promise<string | null>>();
+vi.mock('@/features/sessions/store', () => ({
+  fetchFirstSessionId: () => mockFirstSessionId(),
+}));
+
+function item(itemId: string, page: OnboardingPage): OnboardingItemDto {
+  return {
+    itemId,
+    page,
+    state: 'unchecked',
+    at: '2026-01-01T00:00:00Z',
+    source: 'seed',
+    prerequisite: null,
+    hasAutoTick: false,
+  };
+}
+
+/** Exposes the toggle-store state so dismissal is observable from the DOM. */
+function Harness(): React.ReactElement {
+  const active = useActiveFindItem();
+  return (
+    <>
+      <span data-testid="active-item">{active?.itemId ?? 'none'}</span>
+      <FindSpotlight />
+    </>
+  );
+}
+
+/**
+ * Mount the spotlight for `item` and let the one-shot resolve effect settle.
+ *
+ * Returns a `navigate` that pushes a new pathname: the mocked `useRouterState`
+ * has no subscription, so the re-render has to be driven explicitly.
+ */
+async function mountFind(
+  active: OnboardingItemDto,
+): Promise<(to: string) => Promise<void>> {
+  toggleFind(active);
+  const { rerender } = render(<Harness />);
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return async (to: string) => {
+    pathname = to;
+    await act(async () => {
+      rerender(<Harness />);
+    });
+  };
+}
+
+async function advance(ms: number): Promise<void> {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(ms);
+  });
+}
+
+const unavailable = () => screen.queryByTestId('onb-spotlight-unavailable');
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  pathname = '/sessions';
+  mockFirstSessionId.mockResolvedValue('session-1');
+});
+
+afterEach(() => {
+  clearFind();
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+});
+
+describe('FindSpotlight arrival tracking', () => {
+  it('does not start the anchor deadline while only the BASE route is on screen', async () => {
+    // `sessions.note-field` resolves to `/sessions/session-1`; `/sessions` is
+    // the list page the deep link navigates away from, not the destination.
+    await mountFind(item('sessions.add_note', 'sessions'));
+
+    await advance(2000);
+
+    expect(unavailable()).toBeNull();
+  });
+
+  it('falls back once the pre-arrival navigation grace expires', async () => {
+    await mountFind(item('sessions.add_note', 'sessions'));
+
+    await advance(3200);
+
+    expect(unavailable()).not.toBeNull();
+  });
+
+  it('starts the anchor deadline once the pathname reaches the RESOLVED path', async () => {
+    const navigate = await mountFind(item('sessions.add_note', 'sessions'));
+    await navigate('/sessions/session-1');
+
+    await advance(2000);
+
+    expect(unavailable()).not.toBeNull();
+  });
+
+  it('starts the anchor deadline immediately when the resolved path IS the base route', async () => {
+    pathname = '/projects';
+    await mountFind(item('projects.create_first', 'projects'));
+
+    await advance(2000);
+
+    expect(unavailable()).not.toBeNull();
+  });
+
+  it('dismisses on navigation away from the page even when the deep link never resolved', async () => {
+    const navigate = await mountFind(item('sessions.add_note', 'sessions'));
+
+    await navigate('/projects');
+
+    expect(screen.getByTestId('active-item')).toHaveTextContent('none');
+  });
+});

--- a/apps/desktop/src/features/onboarding/FindSpotlight.tsx
+++ b/apps/desktop/src/features/onboarding/FindSpotlight.tsx
@@ -211,7 +211,11 @@ function SpotlightFor({
   // has a real path to compare against while the apology callout is showing.
   const targetPath = ONBOARDING_PAGE_PATHS[target?.page ?? item.page];
   const [status, setStatus] = useState<ResolveStatus>('pending');
-  /** When the target page first came on screen; `null` until it does. */
+  /** The route {@link resolveSpotlightPath} chose; `null` until it resolves. */
+  const [resolvedPath, setResolvedPath] = useState<string | null>(null);
+  /** True once the target PAGE has been on screen — drives away-dismissal. */
+  const visitedRef = useRef(false);
+  /** When the RESOLVED route came on screen; `null` until it does. */
   const arrivedAtRef = useRef<number | null>(null);
 
   // Navigate to the target's page once (FR-022). Items with no resolvable
@@ -227,6 +231,7 @@ function SpotlightFor({
         setStatus('missing');
         return;
       }
+      setResolvedPath(path);
       // Deep links (path !== basePath) navigate even when already on the page:
       // being on `/sessions` is not the same as having a session selected.
       if (!pathname.startsWith(targetPath) || path !== targetPath) {
@@ -278,13 +283,25 @@ function SpotlightFor({
 
   // Dismiss on navigation AWAY from the target page (FR-023). Arriving at the
   // target page is not a dismissal; leaving it after arrival is.
+  //
+  // The anchor deadline keys off the RESOLVED route, not the page: for a deep
+  // link (`sessions.note-field` ⇒ `/sessions/<id>`) the list route is on screen
+  // long before the selected session is, and recording arrival there burns the
+  // short post-arrival budget on legitimate navigation. `/sessions/$id`
+  // redirects to `/sessions?selected=<id>`, so that pathname never matches and
+  // deep links keep the generous pre-arrival grace instead — which is the
+  // correct budget while a record is still loading. Dismissal stays on the page
+  // path so leaving the page still closes the spotlight in both cases.
   useEffect(() => {
     if (pathname.startsWith(targetPath)) {
-      arrivedAtRef.current ??= Date.now();
-    } else if (arrivedAtRef.current !== null) {
+      visitedRef.current = true;
+      if (resolvedPath !== null && pathname.startsWith(resolvedPath)) {
+        arrivedAtRef.current ??= Date.now();
+      }
+    } else if (visitedRef.current) {
       clearFind();
     }
-  }, [pathname, targetPath]);
+  }, [pathname, targetPath, resolvedPath]);
 
   // Pulse the outline for the first seconds, then static (FR-022). Signalled via
   // a root data-attribute the spotlight CSS keys off — portal-safe and

--- a/apps/desktop/src/features/onboarding/FindSpotlight.tsx
+++ b/apps/desktop/src/features/onboarding/FindSpotlight.tsx
@@ -152,10 +152,13 @@ export function useActiveFindItem(): OnboardingItemDto | null {
 // ── Spotlight ─────────────────────────────────────────────────────────────────
 
 const PULSE_MS = 2500;
-// Cross-page navigation + React hydration under full-suite Playwright load can
-// take up to ~2s; 3s gives the poll enough headroom without visibly delaying
-// the unavailable-target fallback for genuinely absent anchors.
-const RESOLVE_TIMEOUT_MS = 3000;
+// Two budgets, because waiting for a route to land and waiting for an anchor on
+// the page already shown are different problems. Cross-page navigation plus
+// React hydration under full-suite Playwright load can take ~2s, so the
+// pre-arrival budget is generous; once the target page is on screen an absent
+// anchor is absent, and the user should not wait 3s for the explanation.
+const NAVIGATION_GRACE_MS = 3000;
+const ARRIVED_TIMEOUT_MS = 1500;
 const RESOLVE_POLL_MS = 60;
 
 // react-joyride wire strings (enum imports stay in the adapter — mirrored here).
@@ -208,7 +211,8 @@ function SpotlightFor({
   // has a real path to compare against while the apology callout is showing.
   const targetPath = ONBOARDING_PAGE_PATHS[target?.page ?? item.page];
   const [status, setStatus] = useState<ResolveStatus>('pending');
-  const arrivedRef = useRef(false);
+  /** When the target page first came on screen; `null` until it does. */
+  const arrivedAtRef = useRef<number | null>(null);
 
   // Navigate to the target's page once (FR-022). Items with no resolvable
   // control skip this and fall straight to the unavailable state, as do
@@ -243,13 +247,22 @@ function SpotlightFor({
     }
     let cancelled = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
-    const deadline = Date.now() + RESOLVE_TIMEOUT_MS;
+    const startedAt = Date.now();
+    const navigationDeadline = startedAt + NAVIGATION_GRACE_MS;
     const tick = () => {
       if (cancelled) return;
       if (document.querySelector(selector)) {
         setStatus('found');
         return;
       }
+      // Before arrival the navigation grace applies; arrival restarts the clock
+      // on the shorter anchor wait, so a genuinely absent control is reported
+      // ~1.5s after the page is visible instead of ~3s after activation.
+      const arrivedAt = arrivedAtRef.current;
+      const deadline =
+        arrivedAt === null
+          ? navigationDeadline
+          : arrivedAt + ARRIVED_TIMEOUT_MS;
       if (Date.now() > deadline) {
         setStatus('missing');
         return;
@@ -267,8 +280,8 @@ function SpotlightFor({
   // target page is not a dismissal; leaving it after arrival is.
   useEffect(() => {
     if (pathname.startsWith(targetPath)) {
-      arrivedRef.current = true;
-    } else if (arrivedRef.current) {
+      arrivedAtRef.current ??= Date.now();
+    } else if (arrivedAtRef.current !== null) {
       clearFind();
     }
   }, [pathname, targetPath]);

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -36,7 +36,7 @@ src/features/inbox/InboxDetail.tsx	347	alm/require-root-testid
 src/features/inbox/InboxNeedsReview.tsx	104	alm/require-root-testid
 src/features/inbox/PlanDestructiveControl.tsx	32	alm/require-root-testid
 src/features/onboarding/ChecklistPopover.tsx	110	alm/require-root-testid
-src/features/onboarding/FindSpotlight.tsx	170	alm/require-root-testid
+src/features/onboarding/FindSpotlight.tsx	173	alm/require-root-testid
 src/features/onboarding/OrientationWalk.tsx	160	alm/require-root-testid
 src/features/onboarding/joyrideAdapter.tsx	209	alm/require-root-testid
 src/features/plans/PlanProtectionGate.tsx	116	alm/require-root-testid

--- a/tests/e2e/onboarding_control_contrast.spec.ts
+++ b/tests/e2e/onboarding_control_contrast.spec.ts
@@ -15,16 +15,20 @@ const THEMES = [
 test('shared form controls use the dedicated boundary token in every theme', async ({
   page,
 }) => {
-  // Land on a page that renders a real shared select so the probe can reuse
-  // its live class: the select primitive migrated from the global `.pv-select`
-  // rule to the vanilla-extract `selectBase` style, whose class is hashed at
-  // build time and cannot be hard-coded here (Settings → General renders one).
+  // Land on a page that renders a real shared select so the probe can reuse its
+  // live class: the select primitive is a vanilla-extract style whose class is
+  // hashed at build time and cannot be hard-coded here (Settings → General
+  // renders one). Only a non-empty class matters -- the token itself is not a
+  // contract.
   await landOnMockRoute(page, '/#/settings/general');
   const selectClass = await page
     .locator('[data-testid="settings-row"] select')
     .first()
     .getAttribute('class');
-  expect(selectClass, 'shared selectBase class').toContain('selectBase');
+  expect(
+    selectClass?.trim(),
+    'shared select carries a style class',
+  ).toBeTruthy();
 
   const samples = await page.evaluate(
     ([themes, selectClass]) => {


### PR DESCRIPTION
## Summary

- The Dev Settings loading text renders padded again, not flush against the panel edge.
- The Find-It spotlight explains an absent control about 1.5s after its page appears, instead of 3s after activation.
- The dev call-list actions column keeps its width and baseline alignment.
- The sidebar item padding comes from spacing tokens; rendering is unchanged.
- The onboarding contrast test asserts a non-empty class instead of a generated vanilla-extract class name.

Fixes five of the nine open CodeRabbit findings on #1601. The other four are already fixed on #1618, which targets the same base branch; re-implementing them here would only create conflicts.

## Fixed

| Finding | Fix |
| --- | --- |
| `dev-settings-page.css.ts:27` dropped `padding: var(--pv-sp-7)` | Restored, matching the pre-split shared dev style (`9e512de00^:apps/desktop/src/dev/dev.css.ts:243`). |
| `FindSpotlight.tsx:158` missing-target fallback waits 3s | Split into a 3s pre-arrival navigation grace and a 1.5s post-arrival anchor wait. |
| `call-list.css.ts:43` `display: flex` on a `<td>` | Flex row moved to a wrapper inside the cell; `CallList.tsx` updated. |
| `sidebar.css.ts:84` raw `6px` padding | Composed as `calc(var(--pv-sp-1) + var(--pv-sp-0))`; rendered value unchanged. |
| `onboarding_control_contrast.spec.ts:27` asserts the `selectBase` token | Probe still reads the live class; the assertion is now non-empty-class. |

A `<td>` with `display: flex` leaves table layout, so its column stops contributing to column width and baseline alignment. Only `CallList.tsx` renders that cell, behind the compile-time `dev-tools` feature.

The `6px` sidebar padding has no single-token equivalent: the scale is base-4 (`--pv-sp-1: 4px`, `--pv-sp-2: 8px`). `--pv-sp-0` is 2px, so the sum is exact. `apps/desktop/src/styles/components/settings.css:23` uses the same composition pattern.

## Already fixed on #1618

| Finding | Where |
| --- | --- |
| `statusbar.css.ts:58` missing disk-meter fill | `55198e99f` adds the meter child-`<i>` global rule. |
| `DetailHeader.tsx:34` renders legacy `pv-detail__subtitle` | `55198e99f` applies the generated `subtitle` class. |
| `StepSourceFolders.tsx:338` duplicate `data-testid` | `55198e99f` appends the row index and updates the test. |
| `setup_wizard_source_folders.spec.ts:152` asserts `selectBase` | `55198e99f` asserts the per-row test id and value. |

## Verification

- `pnpm typecheck` from `apps/desktop`: pass.
- `pnpm test` from `apps/desktop`: 257 files, 2300 tests, pass.
- `pnpm lint` from `apps/desktop`: pass. `scripts/eslint-alm-baseline.txt` regenerated with `node scripts/check-eslint-baseline.mjs --generate`; the single change is a line number that shifted behind an added comment.

## Spec Context

Tracks-Bead: astro-plan-85d7
Merge-Bead: astro-plan-0s7f
