### PR TITLE
fix: action bar with a wrapped action row no longer shows a double gap

### DIFF
--- a/apps/desktop/src/components/TopActionBar.css.ts
+++ b/apps/desktop/src/components/TopActionBar.css.ts
@@ -44,9 +44,9 @@ export const actionBarWrap = style({
   paddingBottom: 'var(--pv-sp-2)',
 });
 
-/** Full-width spacer forces the action cluster onto its own row. */
-export const spacerWrap = style({ flexBasis: '100%' });
-
+// `flex: 1 1 100%` already forces this onto its own flex line, so the wrap
+// variant renders no spacer: an empty full-width spacer would form a third,
+// zero-height line and apply `rowGap` twice.
 export const actionsWrap = style({
   flex: '1 1 100%',
   justifyContent: 'flex-end',

--- a/apps/desktop/src/components/TopActionBar.tsx
+++ b/apps/desktop/src/components/TopActionBar.tsx
@@ -9,7 +9,6 @@ import {
   title as actionBarTitle,
   subtitle as actionBarSubtitle,
   spacer as actionBarSpacer,
-  spacerWrap as actionBarSpacerWrap,
   actions as actionBarActions,
   actionsWrap as actionBarActionsWrap,
 } from './TopActionBar.css';
@@ -41,7 +40,7 @@ export function TopActionBar({
       <span className={actionBarTitle}>{title}</span>
       {subtitle && <span className={actionBarSubtitle}>{subtitle}</span>}
       {children}
-      <span className={clsx(actionBarSpacer, wrap && actionBarSpacerWrap)} />
+      {!wrap && <span className={actionBarSpacer} />}
       {right && (
         <div className={clsx(actionBarActions, wrap && actionBarActionsWrap)}>
           {right}

--- a/apps/desktop/src/components/ve-class-application.test.tsx
+++ b/apps/desktop/src/components/ve-class-application.test.tsx
@@ -12,7 +12,7 @@ import { describe, expect, it } from 'vitest';
 import { DetailHeader } from './DetailHeader';
 import { subtitle as detailSubtitle } from './DetailHeader.css';
 import { TopActionBar } from './TopActionBar';
-import { actionBarWrap, actionsWrap, spacerWrap } from './TopActionBar.css';
+import { actionBarWrap, actionsWrap, spacer } from './TopActionBar.css';
 import { EmptyState } from '../ui/EmptyState';
 import { empty } from '../ui/EmptyState.css';
 
@@ -44,7 +44,7 @@ describe('vanilla-extract class application', () => {
       <TopActionBar title="Bar" right={<button type="button">Go</button>} />,
     );
     expect(container.querySelector(`.${actionBarWrap}`)).toBeNull();
-    expect(container.querySelector(`.${spacerWrap}`)).toBeNull();
+    expect(container.querySelector(`.${spacer}`)).not.toBeNull();
     expect(container.querySelector(`.${actionsWrap}`)).toBeNull();
     unmount();
 
@@ -56,7 +56,8 @@ describe('vanilla-extract class application', () => {
       />,
     );
     expect(wrapped.container.querySelector(`.${actionBarWrap}`)).not.toBeNull();
-    expect(wrapped.container.querySelector(`.${spacerWrap}`)).not.toBeNull();
+    // The spacer would form a third flex line and double the bar's rowGap.
+    expect(wrapped.container.querySelector(`.${spacer}`)).toBeNull();
     expect(wrapped.container.querySelector(`.${actionsWrap}`)).not.toBeNull();
   });
 });


### PR DESCRIPTION
## Summary

- `TopActionBar` in wrap mode applied its `rowGap` twice. The spacer took `flex-basis: 100%` and became a zero-height flex line between the title row and the action row, so the bar gained one gap above the spacer line and another above the actions line.
- The wrap variant now renders no spacer. `actionsWrap` carries `flex: 1 1 100%`, which already forces the action cluster onto its own line, so wrap mode has two flex lines and one gap. The `spacerWrap` style is deleted.
- Non-wrapped rendering is unchanged: the spacer still renders with `flex: 1`.

This clears the last CodeRabbit finding on #1618 (`TopActionBar.css.ts:48`, empty flex row in wrapped action bars).

## Test plan

- `pnpm typecheck` passes.
- `pnpm test` passes, 256 files / 2284 tests.
- `pnpm lint` passes.
- `apps/desktop/src/components/ve-class-application.test.tsx` asserts the spacer element is present unwrapped and absent wrapped.

## Base

Targets `fix/ve-wave1-regressions`, not `main`: `TopActionBar.css.ts` exists only on that chain.

Tracks-Bead: astro-plan-5md3

Merge-Bead: astro-plan-qx1k

Coverage gap: no test measures rendered wrap-mode spacing. jsdom performs no flexbox layout, so the one-gap result is asserted structurally rather than visually.
