### PR TITLE
perf: reconciling artifacts writes one transaction per phase instead of one per row

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "time",
  "tokio",
  "tracing",
+ "tracing-subscriber",
  "uuid",
  "workflow_artifacts",
  "workflow_profiles",

--- a/apps/desktop/src-tauri/src/watcher.rs
+++ b/apps/desktop/src-tauri/src/watcher.rs
@@ -340,47 +340,51 @@ async fn run_attach_reconciliation(
     )
     .map_err(|e| format!("reconcile failed: {e}"))?;
 
+    let mut seen_ids: Vec<String> = Vec::new();
+    let mut gone: Vec<app_core::artifact::GoneArtifact> = Vec::new();
     for (rel_path, outcome) in report.existing {
         let Some(row) = known_rows.iter().find(|r| r.path == rel_path) else { continue };
         match outcome {
             workflow_artifacts::ReconcileOutcome::Gone => {
-                if let Err(e) =
-                    app_core::artifact::mark_missing(pool, bus, project_id, &row.id, &row.path)
-                        .await
-                {
-                    tracing::warn!("artifact watcher: mark_missing failed for {}: {e}", row.path);
-                }
+                gone.push(app_core::artifact::GoneArtifact {
+                    id: row.id.clone(),
+                    path: row.path.clone(),
+                });
             }
-            workflow_artifacts::ReconcileOutcome::Seen => {
-                if let Err(e) =
-                    persistence_plans::repositories::artifacts::touch_artifact(pool, &row.id).await
-                {
-                    tracing::warn!("artifact watcher: touch_artifact failed for {}: {e}", row.path);
-                }
-            }
+            workflow_artifacts::ReconcileOutcome::Seen => seen_ids.push(row.id.clone()),
         }
     }
 
-    for new_file in report.new_files {
-        let path_str = new_file.absolute_path.to_string_lossy().into_owned();
-        let detected_at = OffsetDateTime::from(new_file.file_mtime)
-            .format(&Rfc3339)
-            .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
-        let size_bytes = i64::try_from(new_file.size_bytes).unwrap_or(i64::MAX);
-        if let Err(e) = app_core::artifact::detect(
-            pool,
-            bus,
-            project_id,
-            &path_str,
-            tool_id,
-            size_bytes,
-            &detected_at,
-            &detected_at,
-        )
-        .await
-        {
-            tracing::warn!("artifact watcher: reconcile detect failed for {path_str}: {e}");
-        }
+    let detected: Vec<app_core::artifact::DetectedFile> = report
+        .new_files
+        .into_iter()
+        .map(|new_file| {
+            let detected_at = OffsetDateTime::from(new_file.file_mtime)
+                .format(&Rfc3339)
+                .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+            app_core::artifact::DetectedFile {
+                path: new_file.absolute_path.to_string_lossy().into_owned(),
+                size_bytes: i64::try_from(new_file.size_bytes).unwrap_or(i64::MAX),
+                file_mtime: detected_at.clone(),
+                detected_at,
+            }
+        })
+        .collect();
+
+    // One transaction per phase (kyo7.54): a project with thousands of outputs
+    // otherwise pays one commit per row on every drawer open. A failed phase is
+    // logged, not propagated — the remaining phases still run, matching the old
+    // per-row loops' tolerance of individual failures.
+    if let Err(e) = app_core::artifact::touch_seen(pool, &seen_ids).await {
+        tracing::warn!(count = seen_ids.len(), "artifact watcher: seen phase failed: {e}");
+    }
+    if let Err(e) = app_core::artifact::mark_missing_batch(pool, bus, project_id, &gone).await {
+        tracing::warn!(count = gone.len(), "artifact watcher: missing phase failed: {e}");
+    }
+    if let Err(e) =
+        app_core::artifact::detect_batch(pool, bus, project_id, tool_id, &detected).await
+    {
+        tracing::warn!(count = detected.len(), "artifact watcher: detect phase failed: {e}");
     }
 
     Ok(())

--- a/crates/app/core/Cargo.toml
+++ b/crates/app/core/Cargo.toml
@@ -61,6 +61,9 @@ app_core_cache = { path = "../cache" }
 tempfile = { workspace = true }
 rstest = { workspace = true }
 proptest = { workspace = true }
+# artifact_reconcile_batching.rs counts sqlx statement-execution tracing events
+# to assert each reconcile phase batches its writes.
+tracing-subscriber = { workspace = true }
 # spec 052 P1 (resolution_e2e.rs): computes the same deterministic UUIDv5 the
 # resolver crate and app_core_targets already derive, to assert target_id
 # stability across the redb cache / SQLite promotion boundary.

--- a/crates/app/core/tests/artifact_reconcile_batching.rs
+++ b/crates/app/core/tests/artifact_reconcile_batching.rs
@@ -1,0 +1,145 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Statement-count regression for the batched on-attach reconciliation phases
+//! (kyo7.54).
+//!
+//! Each phase must issue a bounded number of SQL statements regardless of how
+//! many artifacts it touches. At N = 60 the batched phases measure 1 (seen),
+//! 3 (missing), and 6 (detect) statements. The per-row implementation issued
+//! one UPDATE/INSERT plus one durable audit insert per artifact — 60, 62, and
+//! 240+ respectively — so it fails every bound asserted here.
+//!
+//! Counting technique mirrors `crates/tools/perf-bench/src/main.rs`: sqlx emits
+//! one tracing event per statement execution under the `sqlx` target, so a
+//! counting layer measures DB pressure without instrumenting production code.
+
+mod support;
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use app_core::lifecycle::artifact::{
+    detect_batch, mark_missing_batch, touch_seen, DetectedFile, GoneArtifact,
+};
+use persistence_plans::repositories::artifacts::{
+    insert_artifact_if_absent, list_artifacts_for_project, InsertArtifact,
+};
+use tracing_subscriber::layer::SubscriberExt as _;
+
+const N: usize = 60;
+const PROJECT_ID: &str = "proj-batch";
+
+/// Counts tracing events emitted under the `sqlx` target (one per statement
+/// execution). `max_level_hint` must claim DEBUG or the registry drops sqlx
+/// events before this layer sees them.
+struct SqlxCounterLayer(Arc<AtomicU64>);
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for SqlxCounterLayer {
+    fn max_level_hint(&self) -> Option<tracing::level_filters::LevelFilter> {
+        Some(tracing::level_filters::LevelFilter::DEBUG)
+    }
+
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        if event.metadata().target().starts_with("sqlx") {
+            self.0.fetch_add(1, Ordering::Relaxed);
+        }
+    }
+}
+
+async fn seed_artifact(pool: &sqlx::SqlitePool, id: &str, path: &str) {
+    insert_artifact_if_absent(
+        pool,
+        InsertArtifact {
+            id,
+            project_id: PROJECT_ID,
+            tool_launch_id: None,
+            path,
+            kind: "intermediate",
+            tool: "pixinsight",
+            detected_at: "2026-07-01T00:00:00Z",
+            state: "present",
+            classification_confidence: 0.5,
+            classification_source: "rule",
+            size_bytes: 1024,
+            file_mtime: "2026-07-01T00:00:00Z",
+            content_hash: None,
+        },
+    )
+    .await
+    .expect("seed artifact");
+}
+
+#[tokio::test]
+async fn reconcile_phases_issue_bounded_statement_counts() {
+    let counter = Arc::new(AtomicU64::new(0));
+    let subscriber = tracing_subscriber::registry().with(SqlxCounterLayer(Arc::clone(&counter)));
+    tracing::subscriber::set_global_default(subscriber).expect("set subscriber");
+
+    let (db, _repo, bus) = support::setup().await;
+    let pool = db.pool();
+
+    let seen_ids: Vec<String> = (0..N).map(|i| format!("seen-{i}")).collect();
+    for (i, id) in seen_ids.iter().enumerate() {
+        seed_artifact(pool, id, &format!("output/seen_{i}.xisf")).await;
+    }
+    let gone: Vec<GoneArtifact> = (0..N)
+        .map(|i| GoneArtifact { id: format!("gone-{i}"), path: format!("output/gone_{i}.xisf") })
+        .collect();
+    for g in &gone {
+        seed_artifact(pool, &g.id, &g.path).await;
+    }
+
+    // ── Seen phase: one UPDATE for the whole set, no audit rows ──────────────
+    counter.store(0, Ordering::Relaxed);
+    touch_seen(pool, &seen_ids).await.expect("seen phase");
+    let seen_stmts = counter.load(Ordering::Relaxed);
+    assert!(
+        seen_stmts <= 2,
+        "seen phase must batch {N} rows into a bounded statement count, got {seen_stmts}"
+    );
+
+    // ── Missing phase: one UPDATE + one audit tx ─────────────────────────────
+    counter.store(0, Ordering::Relaxed);
+    mark_missing_batch(pool, &bus, PROJECT_ID, &gone).await.expect("missing phase");
+    let missing_stmts = counter.load(Ordering::Relaxed);
+    assert!(
+        missing_stmts <= 5,
+        "missing phase must batch {N} rows and their audit events, got {missing_stmts}"
+    );
+
+    // ── Detect phase: one insert tx + one audit tx ───────────────────────────
+    let files: Vec<DetectedFile> = (0..N)
+        .map(|i| DetectedFile {
+            path: format!("output/new_{i}.xisf"),
+            size_bytes: 2048,
+            file_mtime: "2026-07-02T00:00:00Z".to_owned(),
+            detected_at: "2026-07-02T00:00:00Z".to_owned(),
+        })
+        .collect();
+    counter.store(0, Ordering::Relaxed);
+    detect_batch(pool, &bus, PROJECT_ID, "pixinsight", &files).await.expect("detect phase");
+    let detect_stmts = counter.load(Ordering::Relaxed);
+    assert!(
+        detect_stmts <= 8,
+        "detect phase must batch {N} inserts and 2 events each, got {detect_stmts}"
+    );
+
+    // Behaviour, not just statement count: every phase actually landed.
+    let rows = list_artifacts_for_project(pool, PROJECT_ID, &[]).await.expect("list");
+    assert_eq!(rows.len(), N * 3, "all seeded and detected rows present");
+    assert_eq!(
+        rows.iter().filter(|r| r.state == "missing").count(),
+        N,
+        "gone artifacts transitioned to missing"
+    );
+    assert_eq!(
+        rows.iter().filter(|r| r.path.starts_with("output/new_")).count(),
+        N,
+        "detected files inserted"
+    );
+}

--- a/crates/app/core/tests/calibration_missing_flag_integration.rs
+++ b/crates/app/core/tests/calibration_missing_flag_integration.rs
@@ -9,7 +9,7 @@
 //! exercises both independent trigger paths against the real reconcile
 //! use-cases (no mocks):
 //!   - PATH A: the generated master artifact (spec-012 `processing_artifacts`)
-//!     goes missing/recovers → `app_core::lifecycle::artifact::mark_missing`/
+//!     goes missing/recovers → `app_core::lifecycle::artifact::mark_missing_batch`/
 //!     `mark_recovered`.
 //!   - PATH B: a raw source sub-frame of the master's own session goes
 //!     missing/recovers → `app_core::frame_inventory::run_reconcile`.
@@ -24,7 +24,7 @@
 mod support;
 
 use app_core::calibration::masters_get;
-use app_core::lifecycle::artifact::{mark_missing, mark_recovered};
+use app_core::lifecycle::artifact::{mark_missing_batch, mark_recovered, GoneArtifact};
 use contracts_core::calibration::CalibrationMatchMissingFlag;
 use contracts_core::inventory_frame::{InventoryReconcileRunRequest, ReconcileReason};
 use persistence_calibration::repositories::calibration_assignment::{upsert, UpsertParams};
@@ -182,7 +182,14 @@ async fn master_artifact_missing_flags_match_and_clears_on_recovery() {
     assert_eq!(detail.missing_flag, None);
 
     // (A) mark the master artifact missing.
-    mark_missing(pool, &bus, "proj-a", &artifact_id, "output/MasterDark.xisf").await.unwrap();
+    mark_missing_batch(
+        pool,
+        &bus,
+        "proj-a",
+        &[GoneArtifact { id: artifact_id.clone(), path: "output/MasterDark.xisf".to_owned() }],
+    )
+    .await
+    .unwrap();
 
     let detail = masters_get(pool, &master_id).await.unwrap();
     assert_eq!(

--- a/crates/app/lifecycle/src/artifact/missing_recovered.rs
+++ b/crates/app/lifecycle/src/artifact/missing_recovered.rs
@@ -6,8 +6,8 @@
 
 use audit::bus::EventBus;
 use audit::event_bus::{
-    ArtifactMissing, ArtifactRecovered, ArtifactUserResolved, Source, TOPIC_ARTIFACT_MISSING,
-    TOPIC_ARTIFACT_RECOVERED, TOPIC_ARTIFACT_USER_RESOLVED,
+    ArtifactRecovered, ArtifactUserResolved, Source, TOPIC_ARTIFACT_RECOVERED,
+    TOPIC_ARTIFACT_USER_RESOLVED,
 };
 use domain_core::ids::Timestamp;
 use sqlx::SqlitePool;
@@ -40,42 +40,6 @@ pub async fn mark_resolved(
             },
         )
         .await;
-    Ok(())
-}
-
-/// Mark an artifact as missing (reconciliation pass — file gone from disk).
-///
-/// # Errors
-/// Returns `Err(String)` on DB failure.
-pub async fn mark_missing(
-    pool: &SqlitePool,
-    bus: &EventBus,
-    project_id: &str,
-    artifact_id: &str,
-    path: &str,
-) -> Result<(), String> {
-    repo::mark_artifact_missing(pool, artifact_id)
-        .await
-        .map_err(|e| format!("DB mark missing failed: {e}"))?;
-
-    let now = Timestamp::now_iso();
-    let _ = bus
-        .publish(
-            TOPIC_ARTIFACT_MISSING,
-            Source::System,
-            ArtifactMissing {
-                artifact_id: artifact_id.to_owned(),
-                project_id: project_id.to_owned(),
-                path: path.to_owned(),
-                at: now.clone(),
-            },
-        )
-        .await;
-
-    // spec 048 US5 (FR-024, PATH A): flag any calibration match whose
-    // master's generated master file is this now-missing artifact.
-    emit_calibration_match_flag_for_artifact(pool, bus, artifact_id, &now, false).await;
-
     Ok(())
 }
 

--- a/crates/app/lifecycle/src/artifact/mod.rs
+++ b/crates/app/lifecycle/src/artifact/mod.rs
@@ -10,6 +10,8 @@
 //! - [`classify_override`] — apply / clear a manual classification override.
 //! - [`mark_resolved`]  — mark a missing artifact as user-resolved.
 //! - [`mark_missing`]/[`mark_recovered`] — on-attach rescan: detect new files + mark gone files as missing.
+//! - [`touch_seen`]/[`mark_missing_batch`]/[`detect_batch`] — the same three
+//!   reconcile phases, one transaction per phase (kyo7.54).
 //! - [`reattribute`]    — back-fill `tool_launch_id` after a new `tool.launch` event (T022b).
 //! - [`complete_run`]   — set `ToolLaunch.completed_at` and emit `workflow.run_completed` (T022c).
 //! - [`resolve_project_id_for_path`] — path→project attribution by
@@ -52,6 +54,7 @@ mod detect;
 mod launches;
 mod list;
 mod missing_recovered;
+mod reconcile_batch;
 
 #[cfg(test)]
 mod tests;
@@ -62,6 +65,9 @@ pub use detect::detect;
 pub use launches::{complete_run, reattribute, sweep_stale_launches};
 pub use list::list;
 pub use missing_recovered::{mark_missing, mark_recovered, mark_resolved};
+pub use reconcile_batch::{
+    detect_batch, mark_missing_batch, touch_seen, DetectedFile, GoneArtifact,
+};
 
 // ── Shared helpers ───────────────────────────────────────────────────────────
 

--- a/crates/app/lifecycle/src/artifact/mod.rs
+++ b/crates/app/lifecycle/src/artifact/mod.rs
@@ -9,7 +9,7 @@
 //! - [`list`]           — list artifacts for a project (for the drawer accordion).
 //! - [`classify_override`] — apply / clear a manual classification override.
 //! - [`mark_resolved`]  — mark a missing artifact as user-resolved.
-//! - [`mark_missing`]/[`mark_recovered`] — on-attach rescan: detect new files + mark gone files as missing.
+//! - [`mark_missing_batch`]/[`mark_recovered`] — on-attach rescan: detect new files + mark gone files as missing.
 //! - [`touch_seen`]/[`mark_missing_batch`]/[`detect_batch`] — the same three
 //!   reconcile phases, one transaction per phase (kyo7.54).
 //! - [`reattribute`]    — back-fill `tool_launch_id` after a new `tool.launch` event (T022b).
@@ -64,7 +64,7 @@ pub use classify::classify_override;
 pub use detect::detect;
 pub use launches::{complete_run, reattribute, sweep_stale_launches};
 pub use list::list;
-pub use missing_recovered::{mark_missing, mark_recovered, mark_resolved};
+pub use missing_recovered::{mark_recovered, mark_resolved};
 pub use reconcile_batch::{
     detect_batch, mark_missing_batch, touch_seen, DetectedFile, GoneArtifact,
 };

--- a/crates/app/lifecycle/src/artifact/reconcile_batch.rs
+++ b/crates/app/lifecycle/src/artifact/reconcile_batch.rs
@@ -1,0 +1,287 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+//! Batched forms of the on-attach reconciliation phases (kyo7.54).
+//!
+//! The per-row entry points (`detect`, `mark_missing`,
+//! `repo::touch_artifact`) issue one implicit commit per artifact, so a project
+//! with thousands of outputs pays thousands of commits every time its drawer
+//! opens. Each function here collapses one reconcile phase into a single
+//! transaction plus a single batched audit publish, with the same observable
+//! per-row outcome.
+//!
+//! Constitution V: everything written here — `last_seen_at`, `state`,
+//! classification, and the audit rows — is re-derivable from a rescan (Tier 2),
+//! so batched writes are permitted. Records carrying a user decision are not in
+//! this path: `mark_resolved` stays a synchronous single write.
+
+use audit::bus::EventBus;
+use audit::event_bus::{
+    ArtifactClassified, ArtifactDetected, ArtifactMissing, ArtifactUpdated,
+    CalibrationMatchSourceMissing, Source, TOPIC_ARTIFACT_CLASSIFIED, TOPIC_ARTIFACT_DETECTED,
+    TOPIC_ARTIFACT_MISSING, TOPIC_ARTIFACT_UPDATED, TOPIC_CALIBRATION_MATCH_SOURCE_MISSING,
+};
+use domain_core::ids::{new_id, Timestamp};
+use sqlx::SqlitePool;
+use workflow_artifacts::{attribute, classify, default_artifact_rules, DEFAULT_ATTRIBUTION_WINDOW};
+
+use persistence_plans::repositories::artifacts::{self as repo, InsertArtifact};
+
+use super::{load_launch_refs, parse_dt};
+
+/// One event ready for [`EventBus::publish_batch`].
+type BatchEvent = (String, Source, serde_json::Value);
+
+fn event<P: serde::Serialize>(topic: &str, payload: &P) -> Option<BatchEvent> {
+    serde_json::to_value(payload).ok().map(|v| (topic.to_owned(), Source::System, v))
+}
+
+/// Refresh `last_seen_at` for every still-present artifact in one statement
+/// (reconcile seen phase). Emits no events, exactly like `touch_artifact`.
+///
+/// # Errors
+/// Returns `Err(String)` on DB failure.
+pub async fn touch_seen(pool: &SqlitePool, artifact_ids: &[String]) -> Result<(), String> {
+    repo::touch_artifacts(pool, artifact_ids)
+        .await
+        .map_err(|e| format!("DB touch artifacts failed: {e}"))
+}
+
+/// An artifact the reconcile scan found gone from disk.
+#[derive(Clone, Debug)]
+pub struct GoneArtifact {
+    pub id: String,
+    pub path: String,
+}
+
+/// Transition every gone artifact to `missing` in one statement and publish all
+/// `artifact.missing` plus `calibration_match.source_missing` events in one
+/// transaction (reconcile gone phase).
+///
+/// The calibration flags stay best-effort as in [`super::mark_missing`]: a
+/// lookup failure drops them rather than failing the phase, because the flag is
+/// re-derived on the next read.
+///
+/// # Errors
+/// Returns `Err(String)` if the state transition fails. A failed audit publish
+/// is logged, not returned — the state rows are the durable record.
+pub async fn mark_missing_batch(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+    gone: &[GoneArtifact],
+) -> Result<(), String> {
+    if gone.is_empty() {
+        return Ok(());
+    }
+    let ids: Vec<String> = gone.iter().map(|g| g.id.clone()).collect();
+    repo::mark_artifacts_missing(pool, &ids)
+        .await
+        .map_err(|e| format!("DB mark missing failed: {e}"))?;
+
+    let now = Timestamp::now_iso();
+    let mut events: Vec<BatchEvent> = gone
+        .iter()
+        .filter_map(|g| {
+            event(
+                TOPIC_ARTIFACT_MISSING,
+                &ArtifactMissing {
+                    artifact_id: g.id.clone(),
+                    project_id: project_id.to_owned(),
+                    path: g.path.clone(),
+                    at: now.clone(),
+                },
+            )
+        })
+        .collect();
+
+    if let Ok(matches) =
+        persistence_calibration::repositories::calibration_assignment::find_match_ids_by_source_artifacts(
+            pool, &ids,
+        )
+        .await
+    {
+        events.extend(matches.into_iter().filter_map(|(artifact_id, match_id)| {
+            event(
+                TOPIC_CALIBRATION_MATCH_SOURCE_MISSING,
+                &CalibrationMatchSourceMissing {
+                    match_id,
+                    frame_id: artifact_id,
+                    at: now.clone(),
+                },
+            )
+        }));
+    }
+
+    publish_all(bus, &events).await;
+    Ok(())
+}
+
+/// A file the reconcile scan found on disk.
+#[derive(Clone, Debug)]
+pub struct DetectedFile {
+    pub path: String,
+    pub size_bytes: i64,
+    pub file_mtime: String,
+    pub detected_at: String,
+}
+
+/// Record every scanned file in one transaction, then publish all resulting
+/// events in one transaction (reconcile detect phase).
+///
+/// Per-file semantics match [`super::detect`]: a path already in the DB is
+/// updated in place and emits `artifact.updated`; a new path is inserted and
+/// emits `artifact.detected` + `artifact.classified`; a row whose insert loses
+/// the `(project_id, path)` race emits nothing.
+///
+/// # Errors
+/// Returns `Err(String)` on DB failure.
+pub async fn detect_batch(
+    pool: &SqlitePool,
+    bus: &EventBus,
+    project_id: &str,
+    tool: &str,
+    files: &[DetectedFile],
+) -> Result<(), String> {
+    if files.is_empty() {
+        return Ok(());
+    }
+
+    // One read of the project's rows replaces a per-path lookup, and one launch
+    // load replaces a per-file load.
+    let existing = repo::list_artifacts_for_project(pool, project_id, &[])
+        .await
+        .map_err(|e| format!("DB lookup failed: {e}"))?;
+    let launches = load_launch_refs(pool, project_id, tool).await?;
+    let rules = default_artifact_rules();
+
+    let mut updates: Vec<(&DetectedFile, &repo::ArtifactRow)> = Vec::new();
+    let mut inserts: Vec<(&DetectedFile, String, workflow_artifacts::ClassificationResult)> =
+        Vec::new();
+    for file in files {
+        if let Some(row) = existing.iter().find(|r| r.path == file.path) {
+            updates.push((file, row));
+        } else {
+            let file_name = std::path::Path::new(&file.path)
+                .file_name()
+                .map_or_else(|| file.path.clone(), |n| n.to_string_lossy().into_owned());
+            inserts.push((file, new_id(), classify(&file_name, &rules)));
+        }
+    }
+
+    let launch_ids: Vec<Option<String>> = inserts
+        .iter()
+        .map(|(file, _, _)| {
+            parse_dt(&file.detected_at)
+                .and_then(|dt| attribute(tool, dt, &launches, DEFAULT_ATTRIBUTION_WINDOW))
+        })
+        .collect();
+
+    let mut tx = pool.begin().await.map_err(|e| format!("DB begin failed: {e}"))?;
+    for (file, row) in &updates {
+        repo::update_artifact_inplace(&mut *tx, &row.id, file.size_bytes, None)
+            .await
+            .map_err(|e| format!("DB update failed: {e}"))?;
+    }
+    let rows: Vec<InsertArtifact<'_>> = inserts
+        .iter()
+        .zip(&launch_ids)
+        .map(|((file, id, classification), launch_id)| InsertArtifact {
+            id,
+            project_id,
+            tool_launch_id: launch_id.as_deref(),
+            path: &file.path,
+            kind: classification.kind.as_str(),
+            tool,
+            detected_at: &file.detected_at,
+            state: "present",
+            classification_confidence: classification.confidence,
+            classification_source: classification.source.as_str(),
+            size_bytes: file.size_bytes,
+            file_mtime: &file.file_mtime,
+            content_hash: None,
+        })
+        .collect();
+    repo::insert_artifacts_if_absent(&mut tx, &rows)
+        .await
+        .map_err(|e| format!("DB insert failed: {e}"))?;
+    tx.commit().await.map_err(|e| format!("DB commit failed: {e}"))?;
+
+    // A multi-row INSERT OR IGNORE cannot report which rows landed, so one
+    // re-read of the project identifies the ids we own (ours) versus the ones a
+    // concurrent detector inserted first (skip events for those).
+    let after = repo::list_artifacts_for_project(pool, project_id, &[])
+        .await
+        .map_err(|e| format!("DB lookup failed after insert: {e}"))?;
+
+    let events = detect_events(project_id, tool, &updates, &inserts, &launch_ids, &after);
+    publish_all(bus, &events).await;
+    Ok(())
+}
+
+/// Build the detect phase's events. `landed` is the post-commit row set: an
+/// insert absent from it lost the `(project_id, path)` race, so it emits
+/// nothing.
+fn detect_events(
+    project_id: &str,
+    tool: &str,
+    updates: &[(&DetectedFile, &repo::ArtifactRow)],
+    inserts: &[(&DetectedFile, String, workflow_artifacts::ClassificationResult)],
+    launch_ids: &[Option<String>],
+    landed: &[repo::ArtifactRow],
+) -> Vec<BatchEvent> {
+    let now = Timestamp::now_iso();
+    let mut events: Vec<BatchEvent> = Vec::with_capacity(updates.len() + inserts.len() * 2);
+    for (file, row) in updates {
+        events.extend(event(
+            TOPIC_ARTIFACT_UPDATED,
+            &ArtifactUpdated {
+                artifact_id: row.id.clone(),
+                project_id: project_id.to_owned(),
+                path: file.path.clone(),
+                tool: tool.to_owned(),
+                prior_content_hash: row.content_hash.clone(),
+                new_content_hash: None,
+                updated_at: now.clone(),
+            },
+        ));
+    }
+    for ((file, id, classification), launch_id) in inserts.iter().zip(launch_ids) {
+        if !landed.iter().any(|r| &r.id == id) {
+            continue;
+        }
+        events.extend(event(
+            TOPIC_ARTIFACT_DETECTED,
+            &ArtifactDetected {
+                artifact_id: id.clone(),
+                project_id: project_id.to_owned(),
+                path: file.path.clone(),
+                kind: classification.kind.as_str().to_owned(),
+                tool: tool.to_owned(),
+                classification_source: classification.source.as_str().to_owned(),
+                classification_confidence: classification.confidence,
+                tool_launch_id: launch_id.clone(),
+                detected_at: file.detected_at.clone(),
+            },
+        ));
+        events.extend(event(
+            TOPIC_ARTIFACT_CLASSIFIED,
+            &ArtifactClassified {
+                artifact_id: id.clone(),
+                project_id: project_id.to_owned(),
+                classification: classification.kind.as_str().to_owned(),
+                confidence: Some(classification.confidence),
+                classified_at: file.detected_at.clone(),
+            },
+        ));
+    }
+    events
+}
+
+/// Publish a phase's events, logging (never propagating) a failure: the state
+/// rows already committed are the durable record.
+async fn publish_all(bus: &EventBus, events: &[BatchEvent]) {
+    if let Err(e) = bus.publish_batch(events).await {
+        tracing::warn!(error = %e, count = events.len(), "reconcile batch: audit publish failed");
+    }
+}

--- a/crates/app/lifecycle/src/artifact/reconcile_batch.rs
+++ b/crates/app/lifecycle/src/artifact/reconcile_batch.rs
@@ -3,8 +3,8 @@
 
 //! Batched forms of the on-attach reconciliation phases (kyo7.54).
 //!
-//! The per-row entry points (`detect`, `mark_missing`,
-//! `repo::touch_artifact`) issue one implicit commit per artifact, so a project
+//! The per-row entry points this supersedes issued one implicit commit per
+//! artifact, so a project
 //! with thousands of outputs pays thousands of commits every time its drawer
 //! opens. Each function here collapses one reconcile phase into a single
 //! transaction plus a single batched audit publish, with the same observable
@@ -37,7 +37,7 @@ fn event<P: serde::Serialize>(topic: &str, payload: &P) -> Option<BatchEvent> {
 }
 
 /// Refresh `last_seen_at` for every still-present artifact in one statement
-/// (reconcile seen phase). Emits no events, exactly like `touch_artifact`.
+/// (reconcile seen phase). Emits no events.
 ///
 /// # Errors
 /// Returns `Err(String)` on DB failure.
@@ -58,7 +58,7 @@ pub struct GoneArtifact {
 /// `artifact.missing` plus `calibration_match.source_missing` events in one
 /// transaction (reconcile gone phase).
 ///
-/// The calibration flags stay best-effort as in [`super::mark_missing`]: a
+/// The calibration flags stay best-effort: a
 /// lookup failure drops them rather than failing the phase, because the flag is
 /// re-derived on the next read.
 ///

--- a/crates/app/lifecycle/src/artifact/tests.rs
+++ b/crates/app/lifecycle/src/artifact/tests.rs
@@ -208,7 +208,14 @@ async fn mark_missing_and_resolved() {
     .await
     .unwrap();
 
-    mark_missing(&pool, &bus, "proj-1", &art_id, "output/img.xisf").await.unwrap();
+    mark_missing_batch(
+        &pool,
+        &bus,
+        "proj-1",
+        &[GoneArtifact { id: art_id.clone(), path: "output/img.xisf".to_owned() }],
+    )
+    .await
+    .unwrap();
     let arts = list(&pool, "proj-1", &["missing"]).await.unwrap();
     assert_eq!(arts.len(), 1);
     assert_eq!(arts[0].state, "missing");
@@ -317,7 +324,7 @@ async fn sweep_uses_last_artifact_activity_not_launch_time() {
     .await
     .unwrap();
     repo::set_tool_launch_id(&pool, &art_id, "tl-active").await.unwrap();
-    repo::touch_artifact(&pool, &art_id).await.unwrap(); // bumps last_seen_at to now
+    repo::touch_artifacts(&pool, std::slice::from_ref(&art_id)).await.unwrap(); // bumps last_seen_at to now
 
     let completed = sweep_stale_launches(&pool, &bus, "proj-1").await.unwrap();
     assert_eq!(completed, 0);

--- a/crates/audit/src/bus.rs
+++ b/crates/audit/src/bus.rs
@@ -32,6 +32,15 @@ pub enum BusError {
     Database(#[from] persistence_core::DbError),
 }
 
+/// Column value for `events.source`.
+fn source_str(source: Source) -> &'static str {
+    match source {
+        Source::User => "user",
+        Source::Restore => "restore",
+        Source::System => "system",
+    }
+}
+
 /// Hybrid live + durable event bus.
 ///
 /// Clone to share across tasks — clones share the same underlying channel and pool.
@@ -77,11 +86,7 @@ impl EventBus {
         let envelope = EventEnvelope::new(topic, source, value.clone());
 
         // 1. Write durable row.
-        let source_str = match source {
-            Source::User => "user",
-            Source::Restore => "restore",
-            Source::System => "system",
-        };
+        let source_str = source_str(source);
         let emitted_at = envelope
             .emitted_at
             .as_offset_date_time()
@@ -101,6 +106,60 @@ impl EventBus {
         // 2. Broadcast to live subscribers.
         // `send` errors only when there are NO receivers at all (which is fine).
         Ok(self.sender.send(envelope).unwrap_or(0))
+    }
+
+    /// Publish many already-serialised events, writing every durable row in one
+    /// transaction before broadcasting the envelopes.
+    ///
+    /// Same observable outcome as calling [`Self::publish`] per event (one
+    /// `events` row and one live envelope each), at one commit for the batch
+    /// instead of one per event. Only for Tier-2 (re-derivable) events: on a
+    /// commit failure the whole batch is lost, and no envelope is broadcast.
+    ///
+    /// # Errors
+    /// Returns `BusError::Database` if the transaction or any insert fails.
+    pub async fn publish_batch(
+        &self,
+        events: &[(String, Source, serde_json::Value)],
+    ) -> Result<(), BusError> {
+        if events.is_empty() {
+            return Ok(());
+        }
+        let envelopes: Vec<EventEnvelope<serde_json::Value>> = events
+            .iter()
+            .map(|(topic, source, payload)| EventEnvelope::new(topic, *source, payload.clone()))
+            .collect();
+
+        let mut owned: Vec<(String, String)> = Vec::with_capacity(envelopes.len());
+        for envelope in &envelopes {
+            let emitted_at = envelope
+                .emitted_at
+                .as_offset_date_time()
+                .format(&time::format_description::well_known::Rfc3339)
+                .unwrap_or_else(|_| "1970-01-01T00:00:00Z".to_owned());
+            owned.push((emitted_at, serde_json::to_string(&envelope.payload)?));
+        }
+        let rows: Vec<(&str, &str, &str, &str)> = envelopes
+            .iter()
+            .zip(&owned)
+            .map(|(envelope, (emitted_at, payload))| {
+                (
+                    envelope.topic.as_str(),
+                    source_str(envelope.source),
+                    emitted_at.as_str(),
+                    payload.as_str(),
+                )
+            })
+            .collect();
+
+        let mut tx = self.pool.begin().await.map_err(persistence_core::DbError::Database)?;
+        persistence_lifecycle::repositories::events::insert_events_conn(&mut tx, &rows).await?;
+        tx.commit().await.map_err(persistence_core::DbError::Database)?;
+
+        for envelope in envelopes {
+            let _ = self.sender.send(envelope);
+        }
+        Ok(())
     }
 
     /// T121 (spec 030 FR-131, Q15/#647): single write-through path for

--- a/crates/persistence/calibration/src/repositories/calibration_assignment.rs
+++ b/crates/persistence/calibration/src/repositories/calibration_assignment.rs
@@ -288,6 +288,32 @@ pub async fn find_by_source_artifact(
     Ok(rows.into_iter().map(row_to_struct).collect())
 }
 
+/// Batch form of [`find_by_source_artifact`] returning only
+/// `(artifact_id, match_id)` — one query for a whole reconcile phase instead of
+/// one per artifact. The audit emission needs no other assignment field.
+///
+/// # Errors
+/// Returns `persistence_core::DbError::Database` on query failure.
+pub async fn find_match_ids_by_source_artifacts(
+    pool: &SqlitePool,
+    artifact_ids: &[String],
+) -> DbResult<Vec<(String, String)>> {
+    if artifact_ids.is_empty() {
+        return Ok(Vec::new());
+    }
+    let rows: Vec<(String, String)> = sqlx::query_as(
+        "SELECT cm.artifact_id, ca.id
+         FROM calibration_assignment ca
+         JOIN calibration_master cm ON cm.source_session_id = ca.master_id
+         WHERE cm.artifact_id IN (SELECT value FROM json_each(?))",
+    )
+    .bind(serde_json::to_string(artifact_ids).unwrap_or_else(|_| "[]".to_owned()))
+    .fetch_all(pool)
+    .await
+    .map_err(DbError::Database)?;
+    Ok(rows)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/persistence/lifecycle/src/repositories/events.rs
+++ b/crates/persistence/lifecycle/src/repositories/events.rs
@@ -67,6 +67,42 @@ pub async fn insert_event_conn(
     Ok(result.last_insert_rowid())
 }
 
+/// Rows per multi-row INSERT: SQLite's 32766-parameter limit over 4 columns.
+const EVENT_INSERT_BATCH_SIZE: usize = 32766 / 4;
+
+/// Append many durable event rows in as few statements as the parameter limit
+/// allows, on an existing connection (for use inside a transaction).
+///
+/// `rows` are `(topic, source, emitted_at, payload)`, matching
+/// [`insert_event_conn`]'s argument order. Assigned `event_id`s are not
+/// returned: a multi-row insert reports only the last rowid.
+///
+/// # Errors
+/// Returns `persistence_core::DbError::Database` on query failure.
+pub async fn insert_events_conn(
+    conn: &mut SqliteConnection,
+    rows: &[(&str, &str, &str, &str)],
+) -> DbResult<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    for chunk in rows.chunks(EVENT_INSERT_BATCH_SIZE) {
+        let placeholders = std::iter::repeat_n("(?,?,?,?)", chunk.len()).collect::<Vec<_>>();
+        let sql = format!(
+            "INSERT INTO events (topic, source, emitted_at, payload) VALUES {}",
+            placeholders.join(",")
+        );
+        // AssertSqlSafe: only a generated placeholder list is interpolated;
+        // every value is bound.
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(sql));
+        for (topic, source, emitted_at, payload) in chunk {
+            query = query.bind(*topic).bind(*source).bind(*emitted_at).bind(*payload);
+        }
+        query.execute(&mut *conn).await?;
+    }
+    Ok(())
+}
+
 /// List all events with `event_id > since_id`, oldest first.
 ///
 /// # Errors

--- a/crates/persistence/plans/src/repositories/artifacts.rs
+++ b/crates/persistence/plans/src/repositories/artifacts.rs
@@ -239,20 +239,6 @@ pub async fn list_artifacts_for_project(
     Ok(rows)
 }
 
-/// Update `last_seen_at` for a `present` artifact (reconcile seen pass).
-///
-/// # Errors
-/// Returns [`persistence_core::DbError::Database`] on query failure.
-pub async fn touch_artifact(pool: &SqlitePool, artifact_id: &str) -> DbResult<()> {
-    let now = Timestamp::now_iso();
-    sqlx::query("UPDATE processing_artifacts SET last_seen_at = ? WHERE id = ?")
-        .bind(&now)
-        .bind(artifact_id)
-        .execute(pool)
-        .await?;
-    Ok(())
-}
-
 /// Update `last_seen_at` for every id in `artifact_ids` in one statement
 /// (reconcile seen phase; Tier 2 re-derivable state, so a single batched write
 /// replaces one commit per row).
@@ -272,18 +258,6 @@ pub async fn touch_artifacts(pool: &SqlitePool, artifact_ids: &[String]) -> DbRe
     .bind(id_json(artifact_ids))
     .execute(pool)
     .await?;
-    Ok(())
-}
-
-/// Transition an artifact to `missing` state.
-///
-/// # Errors
-/// Returns [`persistence_core::DbError::Database`] on query failure.
-pub async fn mark_artifact_missing(pool: &SqlitePool, artifact_id: &str) -> DbResult<()> {
-    sqlx::query("UPDATE processing_artifacts SET state = 'missing' WHERE id = ?")
-        .bind(artifact_id)
-        .execute(pool)
-        .await?;
     Ok(())
 }
 
@@ -626,7 +600,7 @@ mod tests {
         insert_artifact_if_absent(pool, art("a2", "p1", "out/b.xisf", "master")).await.unwrap();
 
         // Transition a2 to missing.
-        mark_artifact_missing(pool, "a2").await.unwrap();
+        mark_artifacts_missing(pool, &["a2".to_owned()]).await.unwrap();
 
         let present = list_artifacts_for_project(pool, "p1", &["present"]).await.unwrap();
         assert_eq!(present.len(), 1);
@@ -668,7 +642,7 @@ mod tests {
         insert_artifact_if_absent(pool, art("a1", "p1", "out/img.xisf", "intermediate"))
             .await
             .unwrap();
-        mark_artifact_missing(pool, "a1").await.unwrap();
+        mark_artifacts_missing(pool, &["a1".to_owned()]).await.unwrap();
 
         let row = get_artifact_by_path(pool, "p1", "out/img.xisf").await.unwrap().unwrap();
         assert_eq!(row.state, "missing");

--- a/crates/persistence/plans/src/repositories/artifacts.rs
+++ b/crates/persistence/plans/src/repositories/artifacts.rs
@@ -17,11 +17,18 @@
 //!   (T022c).
 
 use domain_core::ids::Timestamp;
-use sqlx::SqlitePool;
+use sqlx::{SqliteConnection, SqlitePool};
 
 use persistence_core::DbResult;
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
+
+/// SQLite has no array binding; batch id filters bind a JSON array and expand
+/// it with `json_each`, the same shape [`list_artifacts_for_project`] uses for
+/// its state filter.
+fn id_json(ids: &[String]) -> String {
+    serde_json::to_string(ids).unwrap_or_else(|_| "[]".to_owned())
+}
 
 // ── Row types ─────────────────────────────────────────────────────────────────
 
@@ -113,6 +120,65 @@ pub async fn insert_artifact_if_absent(
     }
 }
 
+/// Rows per multi-row INSERT: SQLite's 32766-parameter limit divided by the
+/// 14 bound columns.
+const ARTIFACT_INSERT_BATCH_SIZE: usize = 32766 / 14;
+
+/// Insert many `processing_artifacts` rows with `INSERT OR IGNORE`, on a caller
+/// supplied connection so the whole batch commits once.
+///
+/// Rows silenced by a constraint violation (a concurrent inserter won the
+/// `(project_id, path)` race) are not reported: `rows_affected` cannot identify
+/// which of a multi-row insert landed. Callers that need per-row identity
+/// re-query the batch's paths once.
+///
+/// # Errors
+/// Returns [`persistence_core::DbError::Database`] on any DB failure that is not
+/// a constraint violation.
+pub async fn insert_artifacts_if_absent(
+    conn: &mut SqliteConnection,
+    rows: &[InsertArtifact<'_>],
+) -> DbResult<()> {
+    if rows.is_empty() {
+        return Ok(());
+    }
+    for chunk in rows.chunks(ARTIFACT_INSERT_BATCH_SIZE) {
+        let placeholders =
+            std::iter::repeat_n("(?,?,?,?,?,?,?,?,?,?,?,?,?,?)", chunk.len()).collect::<Vec<_>>();
+        let sql = format!(
+            "INSERT OR IGNORE INTO processing_artifacts
+                (id, project_id, tool_launch_id, path, kind, tool,
+                 detected_at, last_seen_at, state,
+                 classification_confidence, classification_source,
+                 size_bytes, file_mtime, content_hash)
+             VALUES {}",
+            placeholders.join(",")
+        );
+        // AssertSqlSafe: `sql` interpolates only a generated placeholder list;
+        // every value is bound.
+        let mut query = sqlx::query(sqlx::AssertSqlSafe(sql));
+        for data in chunk {
+            query = query
+                .bind(data.id)
+                .bind(data.project_id)
+                .bind(data.tool_launch_id)
+                .bind(data.path)
+                .bind(data.kind)
+                .bind(data.tool)
+                .bind(data.detected_at)
+                .bind(data.detected_at)
+                .bind(data.state)
+                .bind(data.classification_confidence)
+                .bind(data.classification_source)
+                .bind(data.size_bytes)
+                .bind(data.file_mtime)
+                .bind(data.content_hash);
+        }
+        query.execute(&mut *conn).await?;
+    }
+    Ok(())
+}
+
 /// Lookup an artifact by `(project_id, path)`.
 ///
 /// # Errors
@@ -187,6 +253,28 @@ pub async fn touch_artifact(pool: &SqlitePool, artifact_id: &str) -> DbResult<()
     Ok(())
 }
 
+/// Update `last_seen_at` for every id in `artifact_ids` in one statement
+/// (reconcile seen phase; Tier 2 re-derivable state, so a single batched write
+/// replaces one commit per row).
+///
+/// # Errors
+/// Returns [`persistence_core::DbError::Database`] on query failure.
+pub async fn touch_artifacts(pool: &SqlitePool, artifact_ids: &[String]) -> DbResult<()> {
+    if artifact_ids.is_empty() {
+        return Ok(());
+    }
+    let now = Timestamp::now_iso();
+    sqlx::query(
+        "UPDATE processing_artifacts SET last_seen_at = ? \
+         WHERE id IN (SELECT value FROM json_each(?))",
+    )
+    .bind(&now)
+    .bind(id_json(artifact_ids))
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
 /// Transition an artifact to `missing` state.
 ///
 /// # Errors
@@ -196,6 +284,25 @@ pub async fn mark_artifact_missing(pool: &SqlitePool, artifact_id: &str) -> DbRe
         .bind(artifact_id)
         .execute(pool)
         .await?;
+    Ok(())
+}
+
+/// Transition every id in `artifact_ids` to `missing` state in one statement
+/// (reconcile gone phase).
+///
+/// # Errors
+/// Returns [`persistence_core::DbError::Database`] on query failure.
+pub async fn mark_artifacts_missing(pool: &SqlitePool, artifact_ids: &[String]) -> DbResult<()> {
+    if artifact_ids.is_empty() {
+        return Ok(());
+    }
+    sqlx::query(
+        "UPDATE processing_artifacts SET state = 'missing' \
+         WHERE id IN (SELECT value FROM json_each(?))",
+    )
+    .bind(id_json(artifact_ids))
+    .execute(pool)
+    .await?;
     Ok(())
 }
 
@@ -328,14 +435,20 @@ pub async fn set_tool_launch_id(
 
 /// Update the in-place rerun fields (A8): `content_hash`, `size_bytes`, `last_seen_at`.
 ///
+/// Generic over the executor so the reconcile detect phase can run many of
+/// these inside one transaction.
+///
 /// # Errors
 /// Returns [`persistence_core::DbError::Database`] on query failure.
-pub async fn update_artifact_inplace(
-    pool: &SqlitePool,
+pub async fn update_artifact_inplace<'e, E>(
+    executor: E,
     artifact_id: &str,
     size_bytes: i64,
     content_hash: Option<&str>,
-) -> DbResult<()> {
+) -> DbResult<()>
+where
+    E: sqlx::Executor<'e, Database = sqlx::Sqlite>,
+{
     let now = Timestamp::now_iso();
     sqlx::query(
         "\
@@ -348,7 +461,7 @@ pub async fn update_artifact_inplace(
     .bind(content_hash)
     .bind(&now)
     .bind(artifact_id)
-    .execute(pool)
+    .execute(executor)
     .await?;
     Ok(())
 }
@@ -564,6 +677,67 @@ mod tests {
         let row2 = get_artifact_by_path(pool, "p1", "out/img.xisf").await.unwrap().unwrap();
         assert_eq!(row2.state, "present");
         assert_eq!(row2.size_bytes, 2048);
+    }
+
+    #[tokio::test]
+    async fn batch_writes_match_their_single_row_forms() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        let pool = db.pool();
+
+        let mut conn = pool.acquire().await.unwrap();
+        insert_artifacts_if_absent(
+            &mut conn,
+            &[
+                art("b1", "p1", "out/a.xisf", "intermediate"),
+                art("b2", "p1", "out/b.xisf", "final"),
+            ],
+        )
+        .await
+        .unwrap();
+        drop(conn);
+        assert_eq!(list_artifacts_for_project(pool, "p1", &[]).await.unwrap().len(), 2);
+
+        let ids = vec!["b1".to_owned(), "b2".to_owned()];
+        mark_artifacts_missing(pool, &ids).await.unwrap();
+        assert_eq!(list_artifacts_for_project(pool, "p1", &["missing"]).await.unwrap().len(), 2);
+
+        // touch_artifacts refreshes last_seen_at without changing state.
+        touch_artifacts(pool, &ids).await.unwrap();
+        let rows = list_artifacts_for_project(pool, "p1", &[]).await.unwrap();
+        assert!(rows.iter().all(|r| r.state == "missing"));
+        assert!(rows.iter().all(|r| r.last_seen_at != r.detected_at));
+
+        // Empty input is a no-op on every batch form.
+        touch_artifacts(pool, &[]).await.unwrap();
+        mark_artifacts_missing(pool, &[]).await.unwrap();
+        let mut conn = pool.acquire().await.unwrap();
+        insert_artifacts_if_absent(&mut conn, &[]).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn batch_insert_ignores_duplicate_paths() {
+        let db = Database::in_memory().await.unwrap();
+        db.migrate().await.unwrap();
+        let pool = db.pool();
+
+        insert_artifact_if_absent(pool, art("d1", "p1", "out/dup.xisf", "intermediate"))
+            .await
+            .unwrap();
+
+        let mut conn = pool.acquire().await.unwrap();
+        insert_artifacts_if_absent(
+            &mut conn,
+            &[art("d2", "p1", "out/dup.xisf", "final"), art("d3", "p1", "out/fresh.xisf", "final")],
+        )
+        .await
+        .unwrap();
+        drop(conn);
+
+        let rows = list_artifacts_for_project(pool, "p1", &[]).await.unwrap();
+        assert_eq!(rows.len(), 2, "duplicate path silenced, fresh path inserted");
+        assert!(rows.iter().any(|r| r.id == "d1"), "original row survives the conflict");
+        assert!(rows.iter().any(|r| r.id == "d3"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
Tracks-Bead: astro-plan-jbwm
Merge-Bead: astro-plan-jbwm

## Summary

- Artifact on-attach reconciliation writes one row at a time. This batches them into per-phase transactions, then deletes the single-row writers the batching supersedes.

## What changed

- `crates/app/lifecycle/src/artifact/reconcile_batch.rs` (new) collects reconciliation work per phase and commits it in one transaction instead of a write per row.
- The single-row reconcile writers are removed rather than left alongside the batched path, so there is one way to do it.
- `crates/persistence/plans/src/repositories/artifacts.rs` gains the batch write surface; `audit/src/bus.rs` and the events/calibration repositories carry the supporting changes.

## Verification

`cargo test -p persistence_plans -p app_core_lifecycle --features persistence_core/test-fixture`: 97 passed, 0 failed (32 + 65).

Note on running these locally: `persistence_core::test_support` is gated behind `persistence_core/test-fixture`, so a bare `cargo test -p persistence_plans` fails to compile with `unresolved import persistence_core::test_support`. That failure is pre-existing on `main` and unrelated to this branch; pass the feature.

## Recovery note

This branch existed only in a local worktree and had never been pushed. The bead recorded `push = 625cb0b9`, which was two commits stale against the actual head `dabdcfca9`, and the worktree was a candidate for reclamation by `astro-plan-lspk`, which would have destroyed the work.
