### PR TITLE
fix: concurrent E2E runs no longer load each other's frontend build

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -185,6 +185,15 @@ env:
   # in every shard job (ubuntu, windows, macOS) so a single bump here
   # invalidates the cached binary across all lanes at once.
   TAURI_WEBDRIVER_VERSION: "0.1.1"
+  # THE frontend URL for this workflow. Every "Serve frontend dist" step derives
+  # its `vite preview --port` from this value, the app binary reads it as its
+  # `devUrl` (`desktop_shell::DEV_URL_ENV`), and the harness reads it as its
+  # base URL (`crates/e2e-tests/tests/common/mod.rs::app_url`) — one value,
+  # three readers, so what is served and what is loaded cannot drift apart.
+  # Each job runs on its own GitHub-hosted VM, so the port only has to be
+  # unique per machine; concurrent LOCAL lanes export their own `PV_DEV_URL`
+  # (issue #1409).
+  PV_DEV_URL: "http://localhost:5173"
 
 jobs:
   # Cheap change-detection gate — mirrors ci.yml's `changes` job. Cross-workflow
@@ -746,9 +755,15 @@ jobs:
         shell: bash
         run: chmod +x "$APP_BIN"
 
-      - name: Serve frontend dist on :5173
+      - name: Serve frontend dist on $PV_DEV_URL
         shell: bash
-        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+        # Port comes from PV_DEV_URL (workflow `env`) — the same value the app
+        # binary and the harness read, so there is no second port literal to
+        # drift. --strictPort makes a taken port a loud failure instead of a
+        # silent fallback that leaves the app loading someone else's server.
+        run: |
+          pnpm --filter @astro-plan/desktop preview \
+            --port "${PV_DEV_URL##*:}" --strictPort &
 
       - name: Run L3 smoke (3 journeys via filter-expr)
         env:
@@ -898,11 +913,18 @@ jobs:
         shell: bash
         run: chmod +x "$APP_BIN"
 
-      # Serve built dist on :5173 in the background. The app binary reads the
-      # Tauri devUrl (:5173) and loads its frontend from there — real IPC.
-      - name: Serve frontend dist on :5173
+      # Serve built dist in the background. The app binary reads the same
+      # PV_DEV_URL as its Tauri devUrl and loads its frontend from there —
+      # real IPC.
+      - name: Serve frontend dist on $PV_DEV_URL
         shell: bash
-        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+        # Port comes from PV_DEV_URL (workflow `env`) — the same value the app
+        # binary and the harness read, so there is no second port literal to
+        # drift. --strictPort makes a taken port a loud failure instead of a
+        # silent fallback that leaves the app loading someone else's server.
+        run: |
+          pnpm --filter @astro-plan/desktop preview \
+            --port "${PV_DEV_URL##*:}" --strictPort &
 
       # Run the Layer-2 harness (real journeys, serial per .config/nextest.toml)
       # from the prebuilt archive, wrapped in xvfb-run for a headless display.
@@ -1052,9 +1074,15 @@ jobs:
         with:
           name: e2e-build-windows-latest
 
-      - name: Serve frontend dist on :5173
+      - name: Serve frontend dist on $PV_DEV_URL
         shell: bash
-        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+        # Port comes from PV_DEV_URL (workflow `env`) — the same value the app
+        # binary and the harness read, so there is no second port literal to
+        # drift. --strictPort makes a taken port a loud failure instead of a
+        # silent fallback that leaves the app loading someone else's server.
+        run: |
+          pnpm --filter @astro-plan/desktop preview \
+            --port "${PV_DEV_URL##*:}" --strictPort &
 
       # Shard-coverage integrity check (shard 1 only — runs once per push).
       # Lists all ignored tests from the archive, then lists the union of all
@@ -1207,9 +1235,15 @@ jobs:
         shell: bash
         run: chmod +x "$APP_BIN"
 
-      - name: Serve frontend dist on :5173
+      - name: Serve frontend dist on $PV_DEV_URL
         shell: bash
-        run: pnpm --filter @astro-plan/desktop preview --port 5173 &
+        # Port comes from PV_DEV_URL (workflow `env`) — the same value the app
+        # binary and the harness read, so there is no second port literal to
+        # drift. --strictPort makes a taken port a loud failure instead of a
+        # silent fallback that leaves the app loading someone else's server.
+        run: |
+          pnpm --filter @astro-plan/desktop preview \
+            --port "${PV_DEV_URL##*:}" --strictPort &
 
       - name: Run E2E
         shell: bash

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -297,7 +297,41 @@ fn instance_context() -> tauri::Context {
     // needed here any more (`crates/e2e-tests/tests/common/mod.rs`, refs
     // #1204).
 
+    #[cfg(feature = "e2e")]
+    apply_dev_url_override(&mut context);
+
     context
+}
+
+/// Environment variable that redirects the `devUrl` this instance loads its
+/// frontend from.
+///
+/// Read by the E2E harness (`crates/e2e-tests/tests/common/mod.rs`) and by
+/// `.github/workflows/e2e.yml`, which serve the built `dist` on the same port.
+pub const DEV_URL_ENV: &str = "PV_DEV_URL";
+
+/// Redirect `devUrl` at run time when [`DEV_URL_ENV`] is set.
+///
+/// `tauri.conf.json`'s `devUrl` is compiled into the binary by
+/// `generate_context!`, so without this override the served port is fixed at
+/// build time while the port a lane can actually claim is only known at run
+/// time. Two concurrent E2E lanes then resolve the same `localhost` port and
+/// each silently loads whichever lane's `vite preview` bound it first.
+///
+/// Compiled only under the `e2e` feature, so a release binary cannot have its
+/// frontend origin redirected by an environment variable (Constitution
+/// Principle V, mirrors `bootstrap::single_instance_guard_enabled`).
+///
+/// A malformed value aborts startup: a silently ignored override would load
+/// the baked port and reintroduce exactly that cross-lane contamination.
+#[cfg(feature = "e2e")]
+fn apply_dev_url_override(context: &mut tauri::Context) {
+    let Some(raw) = std::env::var_os(DEV_URL_ENV) else {
+        return;
+    };
+    let raw = raw.to_string_lossy();
+    let url = raw.parse().unwrap_or_else(|e| panic!("{DEV_URL_ENV}={raw} is not a valid URL: {e}"));
+    context.config_mut().build.dev_url = Some(url);
 }
 
 /// Start the event loop first, then finish database startup behind the splash.

--- a/crates/e2e-tests/README.md
+++ b/crates/e2e-tests/README.md
@@ -46,9 +46,9 @@ cargo nextest run -p e2e_tests --profile e2e --run-ignored all
 - thirtyfour (this crate's W3C client) connects to the CLI on `:4444` and
   sends `tauri:options.application` = the built `desktop_shell` binary path in
   the New Session capabilities. No `browserName` is set.
-- The app loads its own frontend from the Tauri `devUrl` (`:5173`)
-  automatically on launch; the harness does not call `driver.goto(...)` after
-  connecting.
+- The app loads its own frontend from the Tauri `devUrl` (`$PV_DEV_URL`, else
+  `build.devUrl`) automatically on launch; the harness does not call
+  `driver.goto(...)` after connecting.
 - `window.__PV_E2E__.invoke(...)` is the real-IPC invoke bridge exposed by
   the frontend when built with `VITE_E2E=1` (`apps/desktop/src/main.tsx`).
 
@@ -62,9 +62,31 @@ D10 and `quickstart.md`).
 - The `desktop_shell` binary must be **built with the `e2e` feature**:
   `cargo build -p desktop_shell --features e2e`. Override the binary the
   harness launches with `PV_E2E_APP_BIN=/path/to/binary`.
-- Vite dev server / `vite preview` running on `:5173` with:
+- Vite dev server / `vite preview` running on the port the app loads its
+  frontend from: `build.devUrl` in `apps/desktop/src-tauri/tauri.conf.json`,
+  or the `PV_DEV_URL` you export. `PV_DEV_URL` is read by the app binary and by
+  this harness, so exporting one value moves both. Concurrent lanes on one host
+  MUST each export a distinct `PV_DEV_URL`; otherwise the second lane's app
+  loads the first lane's frontend build (issue #1409). Serve with:
   - `VITE_USE_MOCKS=false` — real backend.
   - `VITE_E2E=1` — exposes the `window.__PV_E2E__` invoke bridge.
+
+## Running two lanes at once
+
+`just e2e-dev-url` prints a `PV_DEV_URL` whose port is derived from the
+checkout path: stable per worktree, distinct between worktrees. Export it in
+both halves of the run:
+
+```bash
+export PV_DEV_URL="$(just e2e-dev-url)"
+VITE_E2E=1 VITE_USE_MOCKS=false pnpm --filter @astro-plan/desktop preview \
+  --port "${PV_DEV_URL##*:}" --strictPort &
+cargo nextest run -p e2e_tests --profile e2e --run-ignored all
+```
+
+`--strictPort` exits 1 when the port is taken. Without it `vite preview` falls
+back to another port, the app keeps loading `PV_DEV_URL`, and the failure looks
+like a broken journey.
 
 ## Notes
 

--- a/crates/e2e-tests/tests/common/mod.rs
+++ b/crates/e2e-tests/tests/common/mod.rs
@@ -45,9 +45,10 @@
 //!   sends `tauri:options.application` = the built `desktop_shell` binary
 //!   path in the New Session capabilities. No `browserName` is set (see
 //!   `quickstart.md`).
-//! - The app loads its own frontend from the Tauri `devUrl` (`:5173`)
+//! - The app loads its own frontend from the Tauri `devUrl` ([`app_url`])
 //!   automatically on launch, so the harness does **not** call
-//!   `driver.goto(...)` after connecting.
+//!   `driver.goto(...)` after connecting. Export `PV_DEV_URL` to put concurrent
+//!   local lanes on separate ports (issue #1409).
 //! - `window.__PV_E2E__.invoke(...)` (exposed by the frontend when built
 //!   with `VITE_E2E=1`, see `apps/desktop/src/main.tsx`) is the real-IPC
 //!   invoke bridge used by [`E2eApp::invoke`].
@@ -305,20 +306,45 @@ fn pick_port_pair() -> Result<(u16, u16)> {
     Ok((proxy_port, native_port))
 }
 
-/// Vite dev-server / `vite preview` URL the app's Tauri `devUrl` points at
-/// (`apps/desktop/src-tauri/tauri.conf.json`). The app loads this URL on its
-/// own at launch — do NOT `driver.goto(APP_URL)` after connecting. Kept for
-/// journeys that need to assert the current URL or navigate within the SPA.
+/// Raw `tauri.conf.json` the app's `generate_context!` compiles in, embedded
+/// here so this harness and the app cannot disagree about the default `devUrl`.
+const TAURI_CONF_JSON: &str = include_str!("../../../../apps/desktop/src-tauri/tauri.conf.json");
+
+/// Environment variable that overrides the app's `devUrl`, read by
+/// `apps/desktop/src-tauri/src/lib.rs` (`desktop_shell::DEV_URL_ENV`).
+const DEV_URL_ENV: &str = "PV_DEV_URL";
+
+/// Vite dev-server / `vite preview` URL the app loads its frontend from:
+/// `$PV_DEV_URL` when the lane sets one, else `build.devUrl` from
+/// `tauri.conf.json`. The app resolves the same two sources in the same order,
+/// so a lane that serves `dist` on its own port only has to export the var.
 ///
-/// MUST be the `localhost` host form, byte-identical to `devUrl`: the app
-/// boots on `http://localhost:5173`, and `localhost` vs `127.0.0.1` are
-/// DIFFERENT web origins with separate localStorage. Navigating journeys to
-/// a `127.0.0.1` URL splits app state across two origins — preferences
-/// written on one (e.g. `setupCompleted`, `complete_first_run_gate`) are
-/// invisible on the other, which made `Shell`'s localStorage-based setup
-/// gate and `SetupPage`'s backend-based check ping-pong `/setup` ↔ `/inbox`
-/// indefinitely.
-pub const APP_URL: &str = "http://localhost:5173";
+/// The app loads this URL on its own at launch — do NOT `driver.goto(app_url())`
+/// after connecting. Kept for journeys that need to assert the current URL or
+/// navigate within the SPA.
+///
+/// MUST be the `localhost` host form, byte-identical to `devUrl`: `localhost`
+/// and `127.0.0.1` are DIFFERENT web origins with separate localStorage.
+/// Navigating journeys to a `127.0.0.1` URL splits app state across two origins
+/// — preferences written on one (e.g. `setupCompleted`,
+/// `complete_first_run_gate`) are invisible on the other, which made `Shell`'s
+/// localStorage-based setup gate and `SetupPage`'s backend-based check
+/// ping-pong `/setup` ↔ `/inbox` indefinitely.
+pub fn app_url() -> &'static str {
+    static URL: OnceLock<String> = OnceLock::new();
+    URL.get_or_init(|| {
+        if let Some(raw) = std::env::var_os(DEV_URL_ENV) {
+            return raw.to_string_lossy().trim_end_matches('/').to_string();
+        }
+        let conf: serde_json::Value = serde_json::from_str(TAURI_CONF_JSON)
+            .expect("apps/desktop/src-tauri/tauri.conf.json is not valid JSON");
+        conf["build"]["devUrl"]
+            .as_str()
+            .expect("tauri.conf.json declares no string `build.devUrl`")
+            .trim_end_matches('/')
+            .to_string()
+    })
+}
 
 /// Overall deadline for WebDriver session creation in [`E2eApp::launch`].
 ///
@@ -1007,7 +1033,7 @@ impl E2eApp {
     /// The router uses HASH history (`createHashHistory()`,
     /// `apps/desktop/src/app/router.tsx`): routes live in the URL fragment
     /// (`/#/inbox`) and the pathname is ignored entirely. Navigating to
-    /// `{APP_URL}{path}` therefore always lands on the index route `/`,
+    /// `{app_url()}{path}` therefore always lands on the index route `/`,
     /// whose first-run gate redirects a fresh DB to `/setup` — the target
     /// page never mounts (CI run 28751553798: Inbox's "Rescan all roots"
     /// deterministically never appeared on all three OSes). Navigate to the
@@ -1021,7 +1047,7 @@ impl E2eApp {
     /// stays on the target route, and fail with the URL it kept landing on —
     /// far more diagnosable in CI than a downstream "element never appeared".
     pub async fn goto_route(&self, path: &str) -> Result<()> {
-        let url = format!("{APP_URL}/#{path}");
+        let url = format!("{}/#{path}", app_url());
         let deadline = Instant::now() + Duration::from_secs(20);
         let mut last = String::new();
         loop {

--- a/crates/e2e-tests/tests/journeys.rs
+++ b/crates/e2e-tests/tests/journeys.rs
@@ -30,7 +30,8 @@
 //! Run (CI): `cargo nextest run -p e2e_tests --profile e2e
 //! --run-ignored all` (serial,
 //! `.config/nextest.toml`). Locally: build `desktop_shell --features e2e`,
-//! `cargo install tauri-webdriver --locked`, serve the frontend on :5173 with
+//! `cargo install tauri-webdriver --locked`, serve the frontend on the
+//! `tauri.conf.json` `devUrl` port (or a `PV_DEV_URL` of your own) with
 //! `VITE_E2E=1`, then run the same command — see `README.md`.
 
 mod common;

--- a/crates/e2e-tests/tests/sessions_journeys.rs
+++ b/crates/e2e-tests/tests/sessions_journeys.rs
@@ -78,7 +78,7 @@ async fn complete_first_run(app: &E2eApp) -> anyhow::Result<()> {
 /// Force a real reload of the CURRENTLY-loaded route rather than calling
 /// `E2eApp::goto_route` again with the identical URL.
 ///
-/// `goto_route` builds `{APP_URL}/#{path}` and calls `driver.goto(url)`; when
+/// `goto_route` builds `{app_url()}/#{path}` and calls `driver.goto(url)`; when
 /// the app is already sitting on that exact URL (no intervening navigation
 /// away from it), asking the browser to "navigate to" a byte-identical URL
 /// is a well-known no-op in several engines (no reload, no route remount, no

--- a/justfile
+++ b/justfile
@@ -202,6 +202,26 @@ test-integration:
 test-e2e:
     cd apps/desktop && pnpm test:e2e:real
 
+# Print a PV_DEV_URL whose port is derived from this checkout's absolute path.
+#
+# Export it in BOTH halves of a local Layer-2/Layer-3 run — the `vite preview`
+# that serves `dist` and the `cargo nextest` that launches the app — so two
+# worktrees never resolve the same frontend port. Without it both default to
+# `tauri.conf.json`'s devUrl and the second lane's app loads the first lane's
+# build, which surfaces as hanging or wrong-branch journeys rather than as a
+# port conflict (issue #1409).
+#
+# The port is a hash of the checkout path, so it is stable across runs of the
+# same worktree and differs between worktrees. Serve with `--strictPort` so a
+# hash collision fails loudly instead of silently sharing a port.
+e2e-dev-url:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    root="$(git rev-parse --show-toplevel)"
+    # 5200-5455: above vite's 5173 default and playwright.config.ts's 5183.
+    port=$(( 5200 + 0x$(printf %s "$root" | shasum | cut -c1-4) % 256 ))
+    echo "http://localhost:${port}"
+
 # Run the inbox perf measurement harness and print baseline JSON lines.
 # Set PERF_N to control fixture size (default 500; use 5000 for a deeper run).
 # Output is machine-readable JSON — one line per scenario — suitable for


### PR DESCRIPTION
## Summary

- Two concurrent local E2E lanes both loaded `localhost:5173`, so the second
  lane's app silently served the first lane's frontend build. The failures read
  as hanging or wrong-branch journeys rather than as a port conflict, which made
  every E2E-based verification result untrustworthy.
- The frontend URL is now a run-time value (`PV_DEV_URL`) instead of a value
  compiled into the app binary, so a lane can put its build and its app on a
  port it actually owns.

Closes #1409.

Tracks-Bead: astro-plan-8y3i
Merge-Bead: astro-plan-2l1c

## The build-time / run-time coupling

`devUrl` is compiled into `desktop_shell` by `generate_context!`, while the port
a lane can claim is only knowable at run time. Passing a different `--port` to
`vite preview` could not fix this on its own: the built app kept requesting the
baked `localhost:5173`.

## Mechanism

`instance_context()` (`apps/desktop/src-tauri/src/lib.rs:300`) already mutates
the generated config, so `devUrl` is overridden there from `PV_DEV_URL`.

One value, three readers, same resolution order:

| Reader | Site |
| --- | --- |
| app binary | `apps/desktop/src-tauri/src/lib.rs:322` |
| harness base URL | `crates/e2e-tests/tests/common/mod.rs::app_url` |
| `vite preview --port` | `.github/workflows/e2e.yml`, 4 serve steps |

`app_url()` falls back to `build.devUrl` parsed from an `include_str!` of
`tauri.conf.json`, not a second literal. `rg -n 5173` over `e2e.yml`,
`crates/e2e-tests/`, and `apps/desktop/src-tauri/` leaves `tauri.conf.json:8`
and the workflow `env` default.

`--strictPort` on every serve step turns a taken port into exit 1. Without it
`vite preview` picks a different port while the app keeps requesting
`PV_DEV_URL`.

`just e2e-dev-url` derives a per-checkout port, so running two local lanes does
not require hand-picking one.

The override is compiled only under the `e2e` feature, so a release binary's
frontend origin is not environment-redirectable (Constitution Principle V).

CI behaviour is unchanged: each job owns a GitHub-hosted VM, so its port only
has to be unique per machine, and the workflow default is the previous value.

## Verified locally

- `.github/workflows/e2e.yml` parses (`yaml.safe_load`, 13 jobs).
- `--strictPort` collision: a second `vite preview` on a bound port exits 1.
- `cargo clippy -p desktop_shell --features e2e`, `cargo clippy -p desktop_shell`
  (release feature shape), `cargo clippy -p e2e_tests --all-targets`: clean.
- `cargo fmt --all --check`: clean.
- `pnpm --filter @astro-plan/desktop build`: builds.
- `just e2e-dev-url` is stable per worktree and distinct across four real
  worktrees (5202 / 5347 / 5409 / 5428).

## Needs a real matrix run to confirm

The end-to-end claim is untested. A matrix run must show every shard green with
the app loading `$PV_DEV_URL`. The bead's negative direction (two lanes forced
onto ONE port must still collide, so the test is not vacuous) is also unrun;
`--strictPort` now makes that case exit 1 at serve time instead of producing a
phantom journey failure.

## Not fixed by this change

- A lane that does not export `PV_DEV_URL` keeps the `tauri.conf.json` default,
  so two such lanes still target one port. `--strictPort` makes the second
  serve fail loudly instead of contaminating the first.
- WSL/Windows port mirroring is addressed only insofar as the two sides pick
  different `PV_DEV_URL` values.
- WebView2 shared-localStorage is out of scope (handled by
  `WEBVIEW2_USER_DATA_FOLDER`).
- Hash-derived ports can collide; `--strictPort` surfaces that as exit 1.

## Spec Context

Spec 037 Layer-2/Layer-3 real-UI E2E harness.
