### PR TITLE
docs: record why the display font token has no in-app reference

### DIFF
--- a/apps/desktop/src/styles/tokens.css
+++ b/apps/desktop/src/styles/tokens.css
@@ -55,7 +55,7 @@
 
 :root {
   --pv-font-sans: 'Inter', system-ui, -apple-system, sans-serif; /** Fonts */
-  --pv-font-display: 'Space Grotesk Variable', 'Inter Variable', system-ui, sans-serif;
+  --pv-font-display: 'Space Grotesk Variable', 'Inter Variable', system-ui, sans-serif; /** Display/heading font stack. NOT an orphan despite having no in-app reference: platevault.github.io consumes it through the vendored foundation, so an orphan-token audit will flag it and deleting it would break the docs site. Keep it. */
   --pv-text-xs: 0.7857rem; /** Type scale — rem, derived from a 14px root. */
   --pv-text-sm: 0.8571rem; /** 11px @14 (floor) */
   --pv-text-base: 1rem; /** 12px @14 */

--- a/apps/desktop/tokens/foundation.json
+++ b/apps/desktop/tokens/foundation.json
@@ -4,7 +4,8 @@
     "$description": "Fonts"
   },
   "font-display": {
-    "$value": "'Space Grotesk Variable', 'Inter Variable', system-ui, sans-serif"
+    "$value": "'Space Grotesk Variable', 'Inter Variable', system-ui, sans-serif",
+    "$description": "Display/heading font stack. NOT an orphan despite having no in-app reference: platevault.github.io consumes it through the vendored foundation, so an orphan-token audit will flag it and deleting it would break the docs site. Keep it."
   },
   "text-xs": {
     "$value": "0.7857rem",

--- a/packages/tokens/tokens-docs.css
+++ b/packages/tokens/tokens-docs.css
@@ -8,7 +8,7 @@
 
 :root {
   --pv-font-sans: 'Inter', system-ui, -apple-system, sans-serif; /** Fonts */
-  --pv-font-display: 'Space Grotesk Variable', 'Inter Variable', system-ui, sans-serif;
+  --pv-font-display: 'Space Grotesk Variable', 'Inter Variable', system-ui, sans-serif; /** Display/heading font stack. NOT an orphan despite having no in-app reference: platevault.github.io consumes it through the vendored foundation, so an orphan-token audit will flag it and deleting it would break the docs site. Keep it. */
   --pv-text-xs: 0.7857rem; /** Type scale — rem, derived from a 14px root. */
   --pv-text-sm: 0.8571rem; /** 11px @14 (floor) */
   --pv-text-base: 1rem; /** 12px @14 */


### PR DESCRIPTION
## Summary

- `--pv-font-display` is the only token an orphan audit flags as defined-but-never-referenced (93 defined, 92 referenced). It is not an orphan, and this records why at the line where someone would delete it.

## Why it matters

`platevault.github.io` consumes it through the vendored foundation. Deleting it would read as obvious cleanup and would break the docs site.

The `$description` propagates into `packages/tokens/tokens-docs.css`, the generated artifact the docs site actually vendors, so the warning sits inline rather than in a bead nobody reads first.

## Verification

`node scripts/build-tokens.mjs --check` passes: 3 generated artifacts match their DTCG sources across 6 themes.

Closes the second acceptance clause of `astro-plan-olh3`, which an audit found unmet: `check-tokens.sh` has no orphan/allowlist logic, so nothing else carries this warning.