### PR TITLE
fix: project manifests and staleness updates no longer go missing on busy libraries

### DIFF
--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -422,9 +422,17 @@ pub fn spawn_workflow_run_subscriber(
 
     let mut rx = bus.subscribe();
     tokio::spawn(async move {
-        // Cursor starts at 0: replay from the beginning on first lag.
-        // write() is idempotent (produces a new file per call), so replaying
-        // historical workflow.run_completed events is safe.
+        // Cursor starts at 0, so the first lag replays from the beginning; every
+        // lag thereafter resumes from the high-water mark the replay leaves
+        // behind, and the pruner bounds how far back that can reach.
+        //
+        // Replay is SAFE but not free, and `write()` is not idempotent: it
+        // inserts a `manifests` row with a fresh id per call, so a replayed
+        // event adds a row the user can see in the manifest list. Same-second
+        // replays collapse on disk (the path is second-granular and
+        // `write_manifest_file` refuses to overwrite), but the DB rows do not.
+        // Duplicate rows beat a silently missing manifest, which is what
+        // advancing this cursor on the live path used to cause.
         let mut cursor: i64 = 0;
 
         loop {

--- a/crates/app/projects/src/project_manifests.rs
+++ b/crates/app/projects/src/project_manifests.rs
@@ -430,13 +430,15 @@ pub fn spawn_workflow_run_subscriber(
         loop {
             match rx.recv().await {
                 Ok(env) if env.topic == TOPIC_WORKFLOW_RUN_COMPLETED => {
+                    // The live path deliberately leaves `cursor` alone. Advancing it
+                    // here to `max_event_id` would read the table-wide max rather
+                    // than this event's row: any event inserted between the
+                    // broadcast and that query gets jumped, so a later `Lagged`
+                    // replay starts *after* it and it is lost rather than late.
+                    // The envelope carries no `event_id`, so this branch cannot
+                    // know its own row to advance to. Only the replay below moves
+                    // the cursor, and it does so per row.
                     handle_workflow_run_event(&pool, &bus, &env.payload).await;
-                    // Advance cursor so the next lag replay doesn't restart from 0.
-                    if let Ok(id) =
-                        persistence_lifecycle::repositories::events::max_event_id(bus.pool()).await
-                    {
-                        cursor = id;
-                    }
                 }
                 Ok(_) => {}
                 Err(RecvError::Lagged(n)) => {
@@ -794,6 +796,113 @@ mod tests {
                 "manifest row not found within 2 s after workflow.run_completed event"
             );
             tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        }
+    }
+
+    /// A `Lagged` replay must never skip a durable event the live path never
+    /// delivered — regression test for the cursor-jump defect (astro-plan-hyk0).
+    ///
+    /// The live branch used to advance the cursor with `max_event_id`, the
+    /// TABLE-WIDE max, rather than the row it had just handled. An event that
+    /// reached the table without reaching this subscriber therefore sat *below*
+    /// the new cursor and was never replayed, so its manifest was never written
+    /// — lost, not merely late.
+    ///
+    /// Deterministic by ordering rather than by racing: the never-broadcast row
+    /// is inserted FIRST, so it always holds the lower `event_id`.
+    #[tokio::test]
+    async fn lag_replay_writes_the_manifest_for_an_event_the_live_path_never_saw() {
+        let pool = setup().await;
+        let dir = tempfile::tempdir().unwrap();
+        for id in ["proj-lost", "proj-live"] {
+            // `projects.path` is UNIQUE, so each project needs its own directory.
+            let project_dir = dir.path().join(id);
+            std::fs::create_dir_all(&project_dir).unwrap();
+            sqlx::query(
+                "INSERT INTO projects (id, name, tool, lifecycle, path, notes, channel_drift, created_at, updated_at) \
+                 VALUES (?,?,?,?,?,?,?,?,?)",
+            )
+            .bind(id)
+            .bind(id)
+            .bind("PixInsight")
+            .bind("ready")
+            .bind(project_dir.to_str().unwrap())
+            .bind::<Option<String>>(None)
+            .bind(false)
+            .bind("2026-01-01T00:00:00Z")
+            .bind("2026-01-01T00:00:00Z")
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Capacity 1 so a lag is reachable at all.
+        let bus = EventBus::new(pool.clone(), 1);
+        let _handle = spawn_workflow_run_subscriber(pool.clone(), bus.clone());
+
+        // The event the subscriber can never see live: durable row, no broadcast.
+        // Inserted first, so a jumped cursor would strand it.
+        persistence_lifecycle::repositories::events::insert_event(
+            &pool,
+            "workflow.run_completed",
+            "system",
+            "2026-01-01T00:00:00Z",
+            &serde_json::json!({
+                "projectId": "proj-lost",
+                "toolId": "pixinsight",
+                "toolLaunchId": "tl-lost",
+                "completedAt": "2026-06-01T10:00:00Z",
+                "artifactIds": [],
+            })
+            .to_string(),
+        )
+        .await
+        .unwrap();
+
+        // A live event, which is what used to jump the cursor past the row above.
+        let _ = bus
+            .publish(
+                "workflow.run_completed",
+                audit::event_bus::Source::System,
+                serde_json::json!({
+                    "projectId": "proj-live",
+                    "toolId": "pixinsight",
+                    "toolLaunchId": "tl-live",
+                    "completedAt": "2026-06-01T10:00:00Z",
+                    "artifactIds": [],
+                }),
+            )
+            .await;
+
+        // Wait for the live one to be handled, so the cursor logic has run.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        loop {
+            let (rows, _) = list_manifests_for_project(&pool, "proj-live", None, 10).await.unwrap();
+            if !rows.is_empty() {
+                break;
+            }
+            assert!(tokio::time::Instant::now() < deadline, "live manifest not written in time");
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+        }
+
+        // Force a lag: two broadcasts with no await between them, so the
+        // subscriber cannot drain the channel in between.
+        let _ = bus.broadcast_only("tick.heartbeat");
+        let _ = bus.broadcast_only("tick.heartbeat");
+
+        // The replay must reach the stranded row and write ITS manifest.
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(3);
+        loop {
+            let (rows, _) = list_manifests_for_project(&pool, "proj-lost", None, 10).await.unwrap();
+            if !rows.is_empty() {
+                return; // success
+            }
+            assert!(
+                tokio::time::Instant::now() < deadline,
+                "the lag replay never wrote a manifest for the event the live path \
+                 never saw: the cursor jumped past it"
+            );
+            tokio::time::sleep(std::time::Duration::from_millis(25)).await;
         }
     }
 

--- a/crates/audit/src/pruner.rs
+++ b/crates/audit/src/pruner.rs
@@ -22,8 +22,11 @@
 //! predates the pruning cutoff will re-dispatch already-processed events as
 //! no-ops on the next lag recovery.
 //!
-//! When kyo7.100 (cursor-advancement on live events) lands, the effective
-//! replay window will shrink further, making the floor even more conservative.
+//! Advancing that cursor on the *live* event path — rather than only on lag
+//! recovery — was tried and reverted: the only id available there is the
+//! table-wide `max_event_id`, not the handled row, so it skipped events the
+//! subscriber never saw. Shrinking the replay window that way costs
+//! correctness, so the window stays as wide as the pruning floor allows.
 
 use sqlx::SqlitePool;
 

--- a/crates/audit/src/stale_propagator.rs
+++ b/crates/audit/src/stale_propagator.rs
@@ -65,9 +65,14 @@ impl StalePropagator {
         let mut rx = bus.subscribe();
         let bus = bus.clone();
         tokio::spawn(async move {
-            // Cursor starts at 0: replay from the beginning on first lag.
-            // Hooks are idempotent (research.md §6.1) so replaying historical
-            // events is safe; the events table is authoritative for recovery.
+            // Cursor starts at 0, so the FIRST lag replays from the beginning.
+            // Every lag after that resumes from the high-water mark the previous
+            // replay left behind, so only one replay can ever walk history, and
+            // the pruner bounds how far back even that reaches.
+            //
+            // Hooks are idempotent (research.md §6.1) so re-dispatching
+            // historical events is safe; the events table is authoritative for
+            // recovery.
             let mut cursor: i64 = 0;
 
             loop {
@@ -578,6 +583,86 @@ mod tests {
             total, 3,
             "the lag replay must deliver the durable event the live path never saw \
              (1 live + 2 replayed); got {total}"
+        );
+    }
+
+    /// The cursor is a high-water mark that ratchets: a SECOND lag must replay
+    /// only what arrived since the first one, not the whole table again.
+    ///
+    /// This is the property that makes dropping the live-path advance
+    /// affordable — only the first lag can ever walk history. Without this test
+    /// the evidence sits entirely on one side of the invariant: the test above
+    /// proves the cursor never runs ahead of what was delivered, and this one
+    /// proves it does not stay behind either.
+    /// Insert `n` durable lifecycle rows with no broadcast, so only a replay
+    /// can ever deliver them.
+    async fn seed_durable_rows(pool: &sqlx::SqlitePool, n: usize) {
+        for _ in 0..n {
+            persistence_lifecycle::repositories::events::insert_event(
+                pool,
+                TOPIC_LIFECYCLE_TRANSITION_APPLIED,
+                "system",
+                "2026-01-01T00:00:00Z",
+                "{}",
+            )
+            .await
+            .unwrap();
+        }
+    }
+
+    /// Yield until the dispatch counter reaches `want`, or the deadline passes.
+    /// Returning on timeout rather than panicking keeps the failure attributable
+    /// to the caller's own assertion.
+    async fn wait_for_dispatches(counter: &AtomicUsize, want: usize) {
+        let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
+        while counter.load(Ordering::SeqCst) < want && tokio::time::Instant::now() < deadline {
+            tokio::task::yield_now().await;
+        }
+    }
+
+    #[tokio::test]
+    async fn a_second_lag_replays_only_what_arrived_since_the_first() {
+        let counter = Arc::new(AtomicUsize::new(0));
+        let counter_clone = counter.clone();
+
+        let propagator = StalePropagator::new().with_hook(Arc::new(move |_env| {
+            counter_clone.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        }));
+
+        let pool = sqlx::SqlitePool::connect("sqlite::memory:").await.unwrap();
+        sqlx::query(
+            "CREATE TABLE IF NOT EXISTS events (\
+             event_id INTEGER PRIMARY KEY AUTOINCREMENT,\
+             topic TEXT NOT NULL, source TEXT NOT NULL,\
+             emitted_at TEXT NOT NULL, payload TEXT NOT NULL)",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let bus = EventBus::new(pool.clone(), 1);
+        let handle = propagator.spawn(&bus);
+
+        // First lag: 2 rows waiting, so the replay walks both.
+        seed_durable_rows(&pool, 2).await;
+        let _ = bus.broadcast_only("tick.heartbeat");
+        let _ = bus.broadcast_only("tick.heartbeat");
+        wait_for_dispatches(&counter, 2).await;
+        assert_eq!(counter.load(Ordering::SeqCst), 2, "first lag must replay both seeded rows");
+
+        // Second lag: 1 new row. Had the cursor not ratcheted, this replay would
+        // walk all 3 rows and the total would reach 5 rather than 3.
+        seed_durable_rows(&pool, 1).await;
+        let _ = bus.broadcast_only("tick.heartbeat");
+        let _ = bus.broadcast_only("tick.heartbeat");
+        wait_for_dispatches(&counter, 3).await;
+        handle.abort();
+
+        let total = counter.load(Ordering::SeqCst);
+        assert_eq!(
+            total, 3,
+            "the second lag must replay only the row added since the first (2 + 1), \
+             not the whole table again; got {total}"
         );
     }
 

--- a/crates/audit/src/stale_propagator.rs
+++ b/crates/audit/src/stale_propagator.rs
@@ -74,18 +74,16 @@ impl StalePropagator {
                 match rx.recv().await {
                     Ok(env) => {
                         if env.topic == TOPIC_LIFECYCLE_TRANSITION_APPLIED {
+                            // The live path deliberately leaves `cursor` alone.
+                            // Advancing it here to `max_event_id` would read the
+                            // table-wide max rather than this event's row: any event
+                            // inserted between the broadcast and that query gets
+                            // jumped, so a later `Lagged` replay starts *after* it
+                            // and it is lost rather than late. The envelope carries
+                            // no `event_id`, so this branch cannot know its own row
+                            // to advance to. Only the replay below moves the cursor,
+                            // and it does so per row.
                             let _errors = self.dispatch(&env);
-                            // Advance cursor so the next lag replay doesn't restart from 0.
-                            // Hooks are idempotent, but avoiding full table replay matters on
-                            // large libraries.
-                            if let Ok(id) =
-                                persistence_lifecycle::repositories::events::max_event_id(
-                                    bus.pool(),
-                                )
-                                .await
-                            {
-                                cursor = id;
-                            }
                         }
                     }
                     Err(RecvError::Lagged(n)) => {
@@ -469,23 +467,32 @@ mod tests {
         );
     }
 
-    /// After the subscriber processes a live Ok(env) event the cursor must advance
-    /// so a subsequent Lagged replay does not restart from 0 and re-dispatch the
-    /// entire events table.
+    /// A `Lagged` replay must never skip a durable event that the live path
+    /// never delivered.
     ///
-    /// Strategy:
-    ///   1. Publish 1 event via bus.publish and yield until the subscriber sees
-    ///      it live — cursor advances to that event's `max_event_id`.
-    ///   2. Pre-seed 4 more durable rows directly (no broadcast), so cursor does
-    ///      NOT advance again.
-    ///   3. Trigger a lag via two synchronous `broadcast_only` calls (no yield
-    ///      between them → subscriber cannot run in between → Lagged(1)).
-    ///   4. Replay should page from cursor (after event 1) and dispatch exactly
-    ///      4 rows.  Total = 1 live + 4 replay = 5.
-    ///      If cursor had not advanced, replay would have dispatched all 5 rows
-    ///      instead of 4, yielding total >= 6.
+    /// This is the regression test for the cursor-jump defect (astro-plan-hyk0).
+    /// The live branch used to advance the cursor with `max_event_id`, the
+    /// TABLE-WIDE max, rather than the row it had just handled. Any event that
+    /// reached the table without reaching this subscriber therefore sat *below*
+    /// the new cursor and was never replayed — lost, not merely late.
+    ///
+    /// Strategy — deterministic, no race required. The lost row is inserted
+    /// *before* the broadcast one, so it always carries the lower `event_id`:
+    ///   1. Insert one durable row directly, with NO broadcast. The subscriber
+    ///      cannot see it live; only a replay can ever deliver it.
+    ///   2. Publish a second event normally, so the subscriber handles it live.
+    ///      The buggy code read `max_event_id` here and jumped the cursor past
+    ///      BOTH rows, stranding the one from step 1.
+    ///   3. Trigger a lag with two synchronous `broadcast_only` calls (no yield
+    ///      between them, so the subscriber cannot run in between → `Lagged`).
+    ///   4. The replay must dispatch both durable rows: 1 live + 2 replayed = 3.
+    ///
+    /// Under the defect this totals 1 — the replay pages from a cursor already
+    /// past the end, finds nothing, and the step-1 event is gone. Re-dispatching
+    /// the live event is the accepted cost: hooks are idempotent
+    /// (research.md §6.1), and re-doing work beats silently dropping it.
     #[tokio::test]
-    async fn cursor_advances_after_live_events_so_next_lag_is_bounded() {
+    async fn lag_replay_delivers_an_event_the_live_path_never_saw() {
         let counter = Arc::new(AtomicUsize::new(0));
         let counter_clone = counter.clone();
 
@@ -507,7 +514,19 @@ mod tests {
         let bus = EventBus::new(pool.clone(), 1);
         let handle = propagator.spawn(&bus);
 
-        // Step 1: publish 1 event via the bus (writes durable row + broadcasts).
+        // Step 1: a durable row with NO broadcast. Inserted first, so it holds
+        // the LOWEST event_id — the row a jumped cursor strands behind it.
+        persistence_lifecycle::repositories::events::insert_event(
+            &pool,
+            TOPIC_LIFECYCLE_TRANSITION_APPLIED,
+            "system",
+            "2026-01-01T00:00:00Z",
+            "{}",
+        )
+        .await
+        .unwrap();
+
+        // Step 2: publish an event via the bus (writes durable row + broadcasts).
         bus.publish(
             TOPIC_LIFECYCLE_TRANSITION_APPLIED,
             Source::User,
@@ -524,7 +543,7 @@ mod tests {
         .await
         .unwrap();
 
-        // Yield until the subscriber has processed the live event and advanced cursor.
+        // Wait until the subscriber has handled the broadcast event live.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             tokio::task::yield_now().await;
@@ -534,28 +553,15 @@ mod tests {
             assert!(tokio::time::Instant::now() < deadline, "live event not processed in time");
         }
 
-        // Step 2: insert 4 more durable rows directly — no broadcast, cursor stays put.
-        for _ in 0..4 {
-            persistence_lifecycle::repositories::events::insert_event(
-                &pool,
-                TOPIC_LIFECYCLE_TRANSITION_APPLIED,
-                "system",
-                "2026-01-01T00:00:00Z",
-                "{}",
-            )
-            .await
-            .unwrap();
-        }
-
         // Step 3: trigger Lagged deterministically (no yield between calls).
         let _ = bus.broadcast_only("tick.heartbeat");
         let _ = bus.broadcast_only("tick.heartbeat");
 
-        // Step 4: wait for replay to dispatch the 4 new rows.
+        // Step 4: wait for the replay to dispatch both durable rows.
         let deadline = tokio::time::Instant::now() + std::time::Duration::from_secs(2);
         loop {
             tokio::task::yield_now().await;
-            if counter.load(Ordering::SeqCst) >= 5 {
+            if counter.load(Ordering::SeqCst) >= 3 {
                 break;
             }
             if tokio::time::Instant::now() >= deadline {
@@ -564,11 +570,15 @@ mod tests {
         }
         handle.abort();
 
+        // 1 live dispatch + 2 replayed durable rows. The load-bearing part is
+        // that the replay reached the step-1 row at all: under the defect the
+        // cursor was already past it and the total stalls at 1.
         let total = counter.load(Ordering::SeqCst);
-        assert!(total >= 5, "expected at least 5 total dispatches, got {total}");
-        // Without cursor advancement replay would start from 0 (all 5 rows),
-        // yielding 1 live + 5 replay = 6.  With it, 1 live + 4 replay = 5.
-        assert_eq!(total, 5, "cursor advancement must prevent replay from re-dispatching the already-live event; got {total}");
+        assert_eq!(
+            total, 3,
+            "the lag replay must deliver the durable event the live path never saw \
+             (1 live + 2 replayed); got {total}"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Unblocks #1591 by fixing the blocker that PR introduces (`astro-plan-hyk0`). Targets `fix/events-replay-followups` so #1591 can merge once this lands in it.

## The defect

Both new subscribers advance the replay cursor on the **live** event path with `max_event_id`, which is the **table-wide max**, not the row just handled:

```rust
handle_workflow_run_event(&pool, &bus, &env.payload).await;
if let Ok(id) = events::max_event_id(bus.pool()).await { cursor = id; }
```

Any event inserted between the broadcast and that query is **jumped**. A later `Lagged` replay starts *after* it, so the event is **lost permanently**, not merely late. The window is open exactly when concurrent writers are active — which is when replay matters most.

Sites: `crates/app/projects/src/project_manifests.rs` and `crates/audit/src/stale_propagator.rs`.

This is a **regression this PR chain introduces**. `origin/main` has zero occurrences of the pattern; its only cursor writes are the replay assignment and `new_cursor = row.event_id`.

## Why the obvious fix isn't available

Advancing to the handled event's own id **cannot be written**: `EventEnvelope` (`crates/audit-types/src/event_bus.rs:38`) carries `contract_version`, `topic`, `source`, `emitted_at`, `payload` — and **no `event_id`**. A live subscriber cannot know its own row. Any `env.event_id` suggestion is wrong until the envelope gains that field.

## The fix

Drop the live-path advance at both sites; let the `Lagged` branch own the cursor, which already moves per row to `row.event_id`. That's what main does today.

**The cost, stated plainly:** a replay re-walks from an older cursor and re-delivers some already-handled events. Both handlers are idempotent — hooks by the research.md §6.1 contract, and manifest `write()` produces a new file per call — so re-doing work is strictly better than skipping it. This is the same tradeoff #1623 accepted in the log forwarder, deliberately.

Achieving the PR's original goal *without* the jump would need `event_id` on the envelope — a contract type with `JsonSchema`/`Type` derives, so it touches the generated surface and every construction site. Worth its own change if the re-walk cost is ever shown to matter.

## Verification

Both regression tests are **mutation-verified** — reinstating the `max_event_id` advance makes them fail:
- `stale_propagator`: 3 dispatches collapse to **1**
- `project_manifests`: the stranded manifest is **never written**

They're deterministic by *ordering*, not by racing: the never-broadcast row is inserted **first**, so it always holds the lower `event_id`.

I **replaced** `cursor_advances_after_live_events_so_next_lag_is_bounded`, which asserted the *defective* behaviour — it required the replay to skip rows below the jumped cursor. A test encoding the bug had to go, not be worked around.

`cargo test -p app_core_projects -p audit`: 93 + 17 pass. `workflow_run_manifest_e2e`: passes. `cargo fmt` + clippy clean.