### PR TITLE
fix: retrying a failed item no longer silently reports it as cancelled

### DIFF
--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -655,14 +655,55 @@ pub async fn retry_plan_item(
     // Transition item back to applying in DB (failed → applying).
     apply_repo::item_retry_applying(pool, item_id, plan_id).await.map_err(db_err)?;
 
-    // Register in the retry queue so the executor re-executes it.
-    {
+    // Enqueue for re-execution, and REFUSE if the run vanished in the meantime.
+    //
+    // The `active_runs()` check above closes the common case but not the window
+    // between it and here. Previously that window was swallowed: `if let
+    // Some(run)` simply did nothing when the run was gone, leaving the item
+    // `applying` in the DB with nothing that will ever execute it. Run
+    // completion then sweeps orphaned `applying` items to `cancelled`
+    // (`terminal.rs`), so the user's retry became a silent cancellation --
+    // file unmoved, audit trail reading `cancelled`, indistinguishable from a
+    // cancellation they asked for. That is a Tier-1 custody failure under
+    // constitution II: an approved action recorded terminal that never ran.
+    //
+    // Losing the race is now reported instead. The DB flip is rolled back
+    // first so the item stays `failed` -- retryable, and honest about not
+    // having run -- rather than stranded `applying`.
+    let enqueued = {
         let registry = active_runs();
-        if let Some(run) = registry.get(plan_id) {
+        let queued = registry.get(plan_id).is_some_and(|run| {
             run.retry_queue.push(item_id);
-            drop(run);
-        }
+            true
+        });
         drop(registry);
+        queued
+    };
+
+    if !enqueued {
+        // Best-effort restore. If this fails the item is left `applying` and
+        // the completion sweep will cancel it -- the pre-existing behaviour --
+        // so log loudly and still return the error: the caller must not be
+        // told a retry was accepted when it was not.
+        if let Err(e) = apply_repo::item_retry_rollback_to_failed(pool, item_id, plan_id).await {
+            tracing::error!(
+                error = %e,
+                plan_id,
+                item_id,
+                "retry lost the race with run completion AND could not restore the item to \
+                 'failed'; it will be swept to 'cancelled' and must be retried at plan level"
+            );
+        }
+        return Err(ContractError::new(
+            ErrorCode::RunNotFound,
+            format!(
+                "the run for plan {plan_id} finished while the retry of item {item_id} was \
+                 being accepted, so nothing re-executed it. The item was not retried. \
+                 Use plan.retry on the terminal plan."
+            ),
+            ErrorSeverity::Blocking,
+            true,
+        ));
     }
 
     Ok(PlanItemRetryResponse { item_id: item_id.to_owned(), new_state: "applying".to_owned() })

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -766,6 +766,91 @@ async fn retry_plan_item_rejects_when_no_active_run() {
     assert_eq!(item.item_state, "failed", "rejected retry must not mutate item state");
 }
 
+/// astro-plan-ts1z: the rollback that makes losing the retry race honest.
+///
+/// `retry_plan_item` flips the item to `applying` and only then enqueues it. If
+/// the run disappears in that window, the enqueue finds no run and the item is
+/// left `applying` with nothing that will ever execute it — and run completion
+/// sweeps orphaned `applying` items to `cancelled` (`terminal.rs`). The user's
+/// retry then reads as a cancellation they asked for: file unmoved, audit trail
+/// saying cancelled. A Tier-1 custody failure (constitution II).
+///
+/// The window itself lives inside one function and cannot be opened from a test
+/// without adding a production seam purely for testing, which is a worse trade.
+/// So this drives the repair path directly: after a DB flip to `applying` with
+/// no run to receive it, the rollback must restore `failed` AND the plan's
+/// `items_failed` count, leaving the item genuinely retryable.
+#[tokio::test]
+async fn losing_the_retry_race_restores_the_item_to_failed_and_retryable() {
+    let (db, _bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-retry-race", 1).await;
+    plans_repo::update_plan_state(db.pool(), "p-retry-race", "applying").await.unwrap();
+    {
+        let mut conn = db.pool().acquire().await.unwrap();
+        apply_repo::batch_flush_item_states(
+            &mut conn,
+            "p-retry-race",
+            &[apply_repo::BatchItemState {
+                item_id: "p-retry-race-item-0",
+                new_state: "failed",
+                failure_reason: Some("permission.denied"),
+                is_stale: false,
+            }],
+            0,
+            1,
+            0,
+        )
+        .await
+        .unwrap();
+    }
+
+    let failed_before =
+        plans_repo::get_plan(db.pool(), "p-retry-race", false).await.unwrap().items_failed;
+
+    // The accepted-then-orphaned state: item flipped to `applying`, no run.
+    apply_repo::item_retry_applying(db.pool(), "p-retry-race-item-0", "p-retry-race")
+        .await
+        .unwrap();
+    let items = plans_repo::list_plan_items(db.pool(), "p-retry-race").await.unwrap();
+    assert_eq!(
+        items.iter().find(|i| i.id == "p-retry-race-item-0").unwrap().item_state,
+        "applying",
+        "precondition: the item is stranded `applying`, which is what the sweep would cancel"
+    );
+
+    apply_repo::item_retry_rollback_to_failed(db.pool(), "p-retry-race-item-0", "p-retry-race")
+        .await
+        .unwrap();
+
+    let items = plans_repo::list_plan_items(db.pool(), "p-retry-race").await.unwrap();
+    let item = items.iter().find(|i| i.id == "p-retry-race-item-0").unwrap();
+    assert_eq!(
+        item.item_state, "failed",
+        "a retry that could not be handed to an executor must leave the item FAILED — \
+         retryable and honest — not stranded `applying` for the sweep to cancel"
+    );
+
+    let failed_after =
+        plans_repo::get_plan(db.pool(), "p-retry-race", false).await.unwrap().items_failed;
+    assert_eq!(
+        failed_after, failed_before,
+        "items_failed must return to its pre-retry value, or the plan's terminal state is \
+         computed from a wrong count"
+    );
+
+    // Idempotent: a second rollback must not inflate the counter. This matters
+    // because the rollback is best-effort and could be reached twice.
+    apply_repo::item_retry_rollback_to_failed(db.pool(), "p-retry-race-item-0", "p-retry-race")
+        .await
+        .unwrap();
+    let failed_twice =
+        plans_repo::get_plan(db.pool(), "p-retry-race", false).await.unwrap().items_failed;
+    assert_eq!(
+        failed_twice, failed_before,
+        "rollback is guarded on item_state='applying', so repeating it must be a no-op"
+    );
+}
+
 #[tokio::test]
 async fn retry_plan_item_rejects_non_failed_item() {
     let (db, _bus) = setup().await;

--- a/crates/persistence/plans/src/repositories/plan_apply.rs
+++ b/crates/persistence/plans/src/repositories/plan_apply.rs
@@ -350,6 +350,56 @@ pub async fn item_retry_applying(pool: &SqlitePool, item_id: &str, plan_id: &str
     Ok(())
 }
 
+/// Undo [`item_retry_applying`]: put the item back to `failed` and restore the
+/// plan's `items_failed` count.
+///
+/// Used when a retry is accepted in the DB but cannot actually be handed to an
+/// executor — the run finished in between. Without this the item is stranded
+/// `applying` and the completion sweep converts it to `cancelled`, which reads
+/// as a cancellation the user asked for rather than a retry that never ran.
+///
+/// Guarded on `item_state = 'applying'` so it cannot clobber an item the
+/// executor did pick up and has since moved on: if the retry really did run,
+/// this is a no-op.
+///
+/// `failure_reason` is deliberately left NULL. The previous reason described the
+/// original failure, which this retry did not reproduce, so restoring it would
+/// attribute a failure the app did not observe. The item is `failed` and
+/// retryable, which is the true state.
+///
+/// # Errors
+///
+/// Returns [`persistence_core::DbError::Database`] on connection failure.
+pub async fn item_retry_rollback_to_failed(
+    pool: &SqlitePool,
+    item_id: &str,
+    plan_id: &str,
+) -> DbResult<()> {
+    let mut tx = pool.begin().await?;
+
+    let restored = sqlx::query(
+        "UPDATE plan_items SET item_state = 'failed' \
+         WHERE id = ? AND plan_id = ? AND item_state = 'applying'",
+    )
+    .bind(item_id)
+    .bind(plan_id)
+    .execute(&mut *tx)
+    .await?
+    .rows_affected();
+
+    // Only re-increment when this call actually moved the row, so a no-op
+    // cannot inflate the counter past the number of failed items.
+    if restored > 0 {
+        sqlx::query("UPDATE plans SET items_failed = items_failed + 1 WHERE id = ?")
+            .bind(plan_id)
+            .execute(&mut *tx)
+            .await?;
+    }
+
+    tx.commit().await?;
+    Ok(())
+}
+
 /// List the IDs of all `pending` items for a plan.
 ///
 /// Used to emit per-item audit rows before batch-cancelling (FR-005, T021).


### PR DESCRIPTION
Fixes `astro-plan-ts1z` (P1). A **Tier-1 custody failure** under constitution II: an approved action recorded as terminal that never happened.

## Summary

- Retrying a failed plan item could silently become a **cancellation** — the file never moved, and the audit trail read `cancelled`, indistinguishable from a cancellation the user had asked for.
- Losing that race is now reported as a recoverable error, and the item is left `failed` so it can genuinely be retried again.

## The defect

`retry_plan_item` flipped the item to `applying` and only then enqueued it for the executor:

```rust
apply_repo::item_retry_applying(pool, item_id, plan_id).await?;
let registry = active_runs();
if let Some(run) = registry.get(plan_id) {   // <-- run gone? do nothing.
    run.retry_queue.push(item_id);
}
```

If the run finished in that window, the `if let Some` did nothing and the item was left `applying` with **nothing that would ever execute it**. Run completion then sweeps orphaned `applying` items to `cancelled` (`terminal.rs`), converting the user’s retry into a silent cancellation.

The pre-existing `active_runs()` check closes the common case, and its own comment acknowledged it could not close this window. The window is now handled rather than swallowed.

## The fix

Roll the DB flip back before returning an error, via the new `item_retry_rollback_to_failed`. The item stays `failed` — retryable, and honest about not having run — instead of stranded `applying`. The error is marked **recoverable** and names plan-level retry as the way forward.

Details that matter for correctness:
- **`items_failed` is restored too**, since the plan’s terminal state is computed from that count.
- **Guarded on `item_state = applying`**, so it cannot clobber an item the executor did pick up — if the retry really ran, the rollback is a no-op.
- **Only re-increments when it actually moved the row**, so repeating it cannot inflate the counter. The test asserts this idempotence directly.
- **`failure_reason` left NULL deliberately.** The old reason described the original failure, which this retry did not reproduce; restoring it would attribute a failure the app never observed.
- If the rollback itself fails, it logs loudly and **still returns the error** — the caller must never be told a retry was accepted when it was not.

## Verification

**Mutation-verified:** making the rollback leave the item `applying` fails the new test on exactly the stranded state the sweep would cancel (`left: "applying", right: "failed"`).

`cargo test -p app_core --lib`: **351 pass**. Clippy clean on `app_core` and `persistence_plans`. `cargo fmt` clean.

**Bounding what the test proves, plainly:** the race window lives inside one function and cannot be opened from a test without adding a production seam purely for testing — a worse trade. So the test drives the repair path directly rather than winning a race. It proves the rollback is correct and idempotent; it does not reproduce the interleaving.

Related: `astro-plan-9lkf` (the test flake that led here, fixed in #1645).