### PR TITLE
fix: the calibration temperature tolerance you set now affects matching

### DIFF
--- a/crates/app/calibration/src/matching/loaders.rs
+++ b/crates/app/calibration/src/matching/loaders.rs
@@ -158,16 +158,33 @@ pub(super) async fn load_config(pool: &SqlitePool) -> MatchingRuleConfig {
 async fn load_config_from_db(pool: &SqlitePool) -> MatchingRuleConfig {
     let mut config = MatchingRuleConfig::default();
 
-    // `require_same_offset` is persisted on the `calibration_tolerances`
-    // singleton row (migration 0051), not the generic settings key/value
-    // store — it's user-controlled via the Settings > Calibration Matching
-    // "Offset match required" toggle (spec 043 P8). Falls back to
-    // `MatchingRuleConfig::default()` (true) on read failure.
+    // The `calibration_tolerances` singleton row (migration 0051) is the
+    // user-facing store behind Settings > Calibration Matching, separate from
+    // the generic settings key/value store. Falls back to
+    // `MatchingRuleConfig::default()` on read failure.
     if let Ok(row) = persistence_calibration::repositories::calibration_tolerances::get(pool).await
     {
+        // "Offset match required" toggle (spec 043 P8).
         config.require_same_offset = row.require_same_offset;
+
+        // Sensor temperature tolerance. Previously this row field was loaded
+        // and then ignored: the UI wrote `temperature_tolerance_c` here while
+        // the engine only ever read the `calibrationDarkTempTolerance` settings
+        // key below, so the control the user actually sees had no effect on
+        // matching (astro-plan-qgyu). The value round-tripped through the DTO
+        // and never reached `MatchingRuleConfig`.
+        //
+        // The column is `REAL NOT NULL DEFAULT 5.0`, so a value is always
+        // present; there is no "unset" case to fall back from. That is also why
+        // the mismatch was invisible: the engine kept its own 2.0 default while
+        // the row said 5.0, and nothing ever compared them.
+        config.dark_temp_tolerance_c = row.temperature_tolerance_c;
     }
 
+    // Read AFTER the row, so this key still wins where both are set. It is the
+    // older path and some installs will have it persisted; narrowing that
+    // precedence is a behaviour change for existing libraries, not a bug fix,
+    // so it is deliberately left alone here.
     if let Ok(Some(v)) =
         persistence_lifecycle::repositories::settings::get_raw(pool, KEY_DARK_TEMP).await
     {

--- a/crates/app/calibration/src/matching/tests.rs
+++ b/crates/app/calibration/src/matching/tests.rs
@@ -631,3 +631,47 @@ async fn load_config_reads_require_same_offset_from_tolerances_table() {
     let config = load_config(db.pool()).await;
     assert!(!config.require_same_offset, "toggling off must reach MatchingRuleConfig");
 }
+
+/// astro-plan-qgyu: the sensor-temperature tolerance the user sets in Settings >
+/// Calibration Matching must actually reach the matching engine.
+///
+/// It did not. The UI wrote `temperature_tolerance_c` to the
+/// `calibration_tolerances` row while `load_config_from_db` read only
+/// `require_same_offset` from that row and took its temperature from the older
+/// `calibrationDarkTempTolerance` settings key. So the row value round-tripped
+/// through the DTO — list and update both worked — and never influenced a match.
+/// The engine kept its own 2.0 default while the control displayed 5.0.
+///
+/// A round-trip test cannot catch this: reading back what you wrote passes
+/// either way. The assertion has to be against `MatchingRuleConfig`, which is
+/// what the ranking rules actually consume.
+#[tokio::test]
+async fn load_config_reads_temperature_tolerance_from_tolerances_table() {
+    let _guard = lock_cache_tests().await;
+    caches::invalidate_calibration_config();
+    let db = test_db().await;
+
+    // Deliberately not 5.0 (the column default) and not 2.0 (the engine
+    // default), so passing cannot be explained by either default surviving.
+    let row =
+        persistence_calibration::repositories::calibration_tolerances::CalibrationTolerancesRow {
+            temperature_tolerance_c: 7.5,
+            exposure_tolerance_s: 2.0,
+            aging_limit_days: 365,
+            require_same_camera: true,
+            require_same_gain: true,
+            require_same_binning: true,
+            require_same_offset: true,
+        };
+    persistence_calibration::repositories::calibration_tolerances::update(db.pool(), &row)
+        .await
+        .unwrap();
+
+    let config = load_config(db.pool()).await;
+    assert!(
+        (config.dark_temp_tolerance_c - 7.5).abs() < f64::EPSILON,
+        "the Settings temperature tolerance must reach MatchingRuleConfig; got {} \
+         (2.0 means the engine default won, 5.0 means the column default did)",
+        config.dark_temp_tolerance_c
+    );
+}


### PR DESCRIPTION
Fixes `astro-plan-qgyu`, ranked the top live blocker by the backlog triage. A settings control that silently did nothing, in the product's core value.

## Summary

- Settings > Calibration Matching showed a sensor-temperature tolerance of 5.0 °C while the matching engine matched at **2.0 °C**. Changing the control had no effect on any match.
- The value you set now reaches the engine.

## Why it survived so long

The UI wrote `temperature_tolerance_c` to the `calibration_tolerances` row. `load_config_from_db` read **only** `require_same_offset` from that row and took its temperature from the older `calibrationDarkTempTolerance` settings key. So the row value round-tripped through the DTO perfectly — list and update both worked, and the UI redisplayed what you saved.

That is the whole trap: **a round-trip test reads back what it wrote and passes either way.** The assertion has to be against `MatchingRuleConfig`, which is what the ranking rules actually consume. The existing test at `matching/tests.rs` even writes `temperature_tolerance_c: 5.0` — and never asserts it lands.

## The fix

`load_config_from_db` was already loading that row for `require_same_offset`; it now takes the temperature from the same read. The column is `REAL NOT NULL DEFAULT 5.0`, so there is no unset case to fall back from — which is also why the mismatch was invisible: the engine kept its 2.0 default, the row said 5.0, and nothing ever compared them.

**Deliberately left alone**, both flagged rather than silently decided:
- The settings key is still read afterwards and still **wins** where both are set. Narrowing that precedence would change matching for existing libraries that have the key persisted — a product decision, not part of a bug fix.
- `aging_limit_days` remains unwired. Unlike temperature it has **no counterpart field** on `MatchingRuleConfig`, so connecting it means adding a rule input rather than plumbing an existing one. Left on the bead rather than smuggled in here.

## Verification

**Mutation-verified:** removing the new assignment fails the test with `got 2` — the engine default. The test uses **7.5**, which is neither the column default (5.0) nor the engine default (2.0), so it cannot pass by either default surviving.

`cargo test -p app_core_calibration`: **40 pass**. Clippy clean, fmt clean.