### PR TITLE
feat: hide the unfinished session-relations panels until their backend lands

### DIFF
--- a/apps/desktop/src/features/sessions/SessionDetail.tsx
+++ b/apps/desktop/src/features/sessions/SessionDetail.tsx
@@ -42,7 +42,6 @@ import { useCalibrationUnassign } from '@/features/calibration/useCalibration';
 import { SessionFrameInventory } from './SessionFrameInventory';
 import { SessionNotesSection } from './SessionNotesSection';
 import { RawFrameCleanupSection } from './RawFrameCleanupSection';
-import { SessionGroupBadge } from './SessionGroupBadge';
 import { sessionDisplayName } from './displayName';
 import { integrationSeconds } from './integration';
 import { formatIntegration } from '@/lib/format';
@@ -175,8 +174,6 @@ interface Props {
   revealVisible?: boolean;
   /** Open a linked project — wired by the page to navigation. */
   onOpenProject?: (projectId: string) => void;
-  /** Open a panel group detail view — spec 062. */
-  onOpenGroup?: (panelGroupId: string) => void;
   /** The session's owning source connectivity state (#889); `undefined` when
    * unknown (e.g. loading). A non-`active` state renders a chip explaining
    * why file-touching actions (Reveal) are unavailable. */
@@ -206,7 +203,6 @@ export function SessionDetail({
   onReveal,
   revealVisible = false,
   onOpenProject,
-  onOpenGroup,
   sourceState,
 }: Props) {
   if (!session) {
@@ -379,17 +375,11 @@ export function SessionDetail({
         }
       />
 
-      {/* Spec 062: panel group membership badge — light sessions only. Shows
-          the stable panel group this session belongs to, with a link to
-          the group detail. Hidden for calibration sessions (no panel group). */}
-      {session.type === 'light' && (
-        <Section title={m.sessions_panel_group_heading()} defaultOpen>
-          <SessionGroupBadge
-            sessionId={session.id}
-            onOpen={(id) => onOpenGroup?.(id)}
-          />
-        </Section>
-      )}
+      {/* Spec 062 US2 (astro-plan-6yep): the panel-group badge render site was
+          removed. `panel_group_list` has no Tauri command layer yet, and
+          SessionGroupBadge renders an empty state for both "no group" and a
+          failed call — an unreachable surface beats a silent wrong answer.
+          Restore this block when astro-plan-ic9h.20 wires the commands. */}
 
       {/* Calibration linkage (#772): the session's assigned calibration
           masters, or an explicit "no calibration match" state. */}

--- a/apps/desktop/src/features/sessions/SessionsPage.staleSelection.test.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.staleSelection.test.tsx
@@ -36,22 +36,10 @@ vi.mock('./SessionDetail', () => ({
   SessionDetail: () => <div data-testid="session-detail-stub" />,
 }));
 
-// Spec 062: RelationProposalList, ManualRelationDialog, PanelGroupView, and
-// MatchingSettingsPanel use TanStack Query; stub them so this test doesn't
-// need a QueryClientProvider (the gate under test is the stale-selection
-// wiring, not the groups surface).
-vi.mock('./RelationProposalList', () => ({
-  RelationProposalList: () => <div data-testid="proposal-list-stub" />,
-}));
-vi.mock('./ManualRelationDialog', () => ({
-  ManualRelationDialog: () => null,
-}));
-vi.mock('./PanelGroupView', () => ({
-  PanelGroupView: () => null,
-}));
-vi.mock('./MatchingSettingsPanel', () => ({
-  MatchingSettingsPanel: () => null,
-}));
+// The spec 062 US2 groups surface (RelationProposalList, ManualRelationDialog,
+// PanelGroupView, MatchingSettingsPanel) needed TanStack Query stubs here while
+// SessionsPage mounted it. Those render sites are gone until
+// astro-plan-ic9h.20 wires the Tauri commands; restore the stubs with them.
 
 const mockNavigate = vi.fn();
 const mockSelectedId = { current: undefined as string | undefined };

--- a/apps/desktop/src/features/sessions/SessionsPage.tsx
+++ b/apps/desktop/src/features/sessions/SessionsPage.tsx
@@ -52,12 +52,6 @@ import { addToast } from '@/shared/toast';
 import { m } from '@/lib/i18n';
 import { revealInventoryPath, resolveRevealPath } from './revealInventory';
 import { isSourceActionable } from './connectivity';
-import { RelationProposalList } from './RelationProposalList';
-import { RelationProposalDetail } from './RelationProposalDetail';
-import { ManualRelationDialog } from './ManualRelationDialog';
-import { PanelGroupView } from './PanelGroupView';
-import { MatchingSettingsPanel } from './MatchingSettingsPanel';
-import { Btn } from '@/ui';
 import type { InventoryFrameType, InventorySource } from '@/bindings/index';
 
 /**
@@ -131,16 +125,6 @@ export function SessionsPage() {
     validIds: ['target', 'filter', 'night', 'camera', 'month'],
     defaultDims: [],
   });
-
-  // Spec 062: proposal list/detail and panel group/mosaic side panels.
-  const [selectedProposalId, setSelectedProposalId] = useState<
-    string | undefined
-  >(undefined);
-  const [selectedPanelGroupId, setSelectedPanelGroupId] = useState<
-    string | undefined
-  >(undefined);
-  const [showManualRelationDialog, setShowManualRelationDialog] =
-    useState(false);
 
   // Group-by options share their labels with the table's grouping-hint footer.
   const SESSION_DIMENSIONS: FilterOption[] = Object.entries(
@@ -308,24 +292,8 @@ export function SessionsPage() {
     />
   );
 
-  // Spec 062: priority order for the detail pane:
-  //   1. panel group / mosaic view (triggered from SessionGroupBadge)
-  //   2. proposal detail (triggered from RelationProposalList)
-  //   3. session detail (default)
-  const panelGroupDetail =
-    selectedPanelGroupId != null ? (
-      <PanelGroupView panelGroupId={selectedPanelGroupId} />
-    ) : undefined;
-
-  const proposalDetail =
-    selectedProposalId != null ? (
-      <RelationProposalDetail proposalId={selectedProposalId} />
-    ) : undefined;
-
   const activeDetail =
-    panelGroupDetail ??
-    proposalDetail ??
-    (selectedSession != null ? (
+    selectedSession != null ? (
       <SessionDetail
         session={selectedSession}
         onReveal={() => void handleReveal()}
@@ -334,29 +302,13 @@ export function SessionsPage() {
         onOpenProject={(id) =>
           navigate({ to: '/projects', search: { selected: id } })
         }
-        onOpenGroup={(id) => {
-          setSelectedPanelGroupId(id);
-          setSelectedProposalId(undefined);
-        }}
       />
-    ) : undefined);
+    ) : undefined;
 
-  const handleCloseDetail = (() => {
-    if (selectedPanelGroupId != null)
-      return () => setSelectedPanelGroupId(undefined);
-    if (selectedProposalId != null)
-      return () => setSelectedProposalId(undefined);
-    if (selectedSession != null) return clearSelection;
-    return undefined;
-  })();
+  const handleCloseDetail =
+    selectedSession != null ? clearSelection : undefined;
 
-  const detailAriaLabel = (() => {
-    if (selectedPanelGroupId != null)
-      return m.cmp_listpage_close_proposal_details_aria();
-    if (selectedProposalId != null)
-      return m.cmp_listpage_close_proposal_details_aria();
-    return m.cmp_listpage_close_session_details_aria();
-  })();
+  const detailAriaLabel = m.cmp_listpage_close_session_details_aria();
 
   return (
     <ListPageLayout
@@ -373,11 +325,7 @@ export function SessionsPage() {
         <SessionsTable
           sources={sources}
           selected={selected ?? null}
-          onSelect={(id) => {
-            setSelectedProposalId(undefined);
-            setSelectedPanelGroupId(undefined);
-            void onSelect(id);
-          }}
+          onSelect={(id) => void onSelect(id)}
           loading={loading}
           sort={sort}
           onSort={handleSort}
@@ -385,46 +333,15 @@ export function SessionsPage() {
         />
       )}
 
-      {/* Spec 062: relation proposal list — shown beneath the session table
-          when no session is selected in the detail pane, or always visible
-          as a secondary disclosure zone. Keyboard-operable; selecting a
-          proposal opens RelationProposalDetail in the right panel. */}
-      <RelationProposalList
-        selectedId={selectedProposalId}
-        onSelect={(id) => {
-          setSelectedProposalId(id);
-          // Clear session selection so the detail panel shows the proposal.
-          void navigate({
-            search: (prev) => ({ ...prev, selected: undefined }),
-            replace: true,
-          });
-        }}
-        headerAction={
-          <Btn
-            variant="ghost"
-            size="sm"
-            onClick={() => setShowManualRelationDialog(true)}
-            aria-label={m.manual_relation_open_btn_aria()}
-            data-testid="open-manual-relation-btn"
-          >
-            {m.manual_relation_open_btn()}
-          </Btn>
-        }
-      />
-
-      {/* Spec 062: manual relation creation dialog. */}
-      <ManualRelationDialog
-        open={showManualRelationDialog}
-        onClose={() => setShowManualRelationDialog(false)}
-        defaultSubjectIds={selected != null ? [selected] : undefined}
-      />
-
-      {/* Spec 062: matching geometry and calibration settings.
-          TODO(ic9h.20): move this pane into SettingsPage as a new 'matching'
-          pane alongside 'cal' once the Tauri commands are wired — the seam is
-          SettingsPage.renderPane() in src/features/settings/SettingsPage.tsx.
-          Kept here so the surface is reachable and reviewable before .20. */}
-      <MatchingSettingsPanel />
+      {/* Spec 062 US2 (astro-plan-6yep): the RelationProposalList,
+          ManualRelationDialog, and MatchingSettingsPanel render sites were
+          removed. Their IPC commands (relation_proposal_list,
+          matching_settings_get, …) have no Tauri command layer yet, so
+          mounting them showed error panels on every visit. The components and
+          sessionsGroupsIpc.ts are intact — restore these render sites when
+          astro-plan-ic9h.20 wires the commands. MatchingSettingsPanel belongs
+          in SettingsPage.renderPane() as a new 'matching' pane alongside
+          'cal', not back here. */}
     </ListPageLayout>
   );
 }


### PR DESCRIPTION
## Summary

- The session-relations panels (relation proposals, manual relation creation,
  panel-group membership, matching settings) no longer appear on the Sessions
  page or in session details. Their backend commands do not exist, so the
  panels only ever showed errors — or, for panel-group membership, a blank
  "no group" state that hid the failure.

## What changed

Three render sites were removed:

| Site | Component | Command it invoked |
| --- | --- | --- |
| `SessionsPage.tsx:392` | `RelationProposalList` (+ its `ManualRelationDialog` opener) | `relation_proposal_list` |
| `SessionsPage.tsx:427` | `MatchingSettingsPanel` | `matching_settings_get` |
| `SessionDetail.tsx:385` | `SessionGroupBadge` | `panel_group_list` |

The `RelationProposalDetail` and `PanelGroupView` detail-pane branches and
their `selectedProposalId` / `selectedPanelGroupId` state went with the list:
the deleted list was the only writer of those ids.

## Why

`apps/desktop/src/features/sessions/sessionsGroupsIpc.ts` raw-`invoke`s 15
commands. No Rust `commands/` module defines them and none appears in
`bootstrap/specta.rs`. Two consequences on `main`:

- Every visit to the Sessions page rendered two `role="alert"` error panels,
  after TanStack Query retried each failed command three times with backoff.
- `SessionGroupBadge.tsx` returns `null` when `data?.items[0]` is absent, so a
  failed `panel_group_list` was indistinguishable from "this session has no
  panel group" — a silent wrong answer rather than a visible error.

## Approach

Deletion of the JSX, not a flag. The repo has no feature-flag convention
(`rg "VITE_FEATURE|isFeatureEnabled|featureFlag" apps/desktop/src` returns
nothing), and inventing one for a single surface adds a mechanism with one
consumer. The components, `useGroupsStore`, and `sessionsGroupsIpc.ts` are
untouched, so `astro-plan-ic9h.20` restores the surface by reinstating the
JSX. Each removal site carries a comment naming `astro-plan-ic9h.20` and
`astro-plan-6yep`, and keeps the prior `TODO(ic9h.20)` note that
`MatchingSettingsPanel` belongs in `SettingsPage.renderPane()` as a new
`matching` pane, not back on the Sessions page.

## Verification

| Gate | Result |
| --- | --- |
| `pnpm typecheck` | pass |
| `pnpm lint` | exit 0 (eslint: 722 files, 88 baselined violations — unchanged) |
| `pnpm test` (apps/desktop) | 267 files, 2376 tests passed |
| `pnpm lint:circular` | 0 new cycles, 3 allowlisted |
| `pnpm knip` | same 7 pre-existing `src/api/mocks/*` unused exports as `main`; no new findings |
| `pnpm test:e2e sessions_list_regressions` | 3 passed |

No baseline or allowlist entry was added.

`SessionsPage.staleSelection.test.tsx` dropped four `vi.mock` calls that
existed only to keep the removed components from needing a
`QueryClientProvider`. The test's own assertions are unchanged and still pass.
No test asserted that the surface renders.

## Spec Context

Spec 062 US2. Tracked by `astro-plan-6yep`; the blocked backend work is
`astro-plan-ic9h.20`. Neither bead is closed by this PR.
