### PR TITLE
fix: settings panes stop re-reading the same values on every visit

### DIFF
--- a/apps/desktop/src/data/queryKeys.ts
+++ b/apps/desktop/src/data/queryKeys.ts
@@ -97,4 +97,10 @@ export const queryKeys = {
   roots: {
     all: () => ['roots'] as const,
   },
+  settings: {
+    // Distinct from `calibration.settings`, which keys the calibration
+    // tolerances store rather than a `settings.get` scope.
+    all: () => ['settings'] as const,
+    scope: (scope: string) => ['settings', scope] as const,
+  },
 } as const;

--- a/apps/desktop/src/features/inbox/__tests__/inbox.affordances.test.tsx
+++ b/apps/desktop/src/features/inbox/__tests__/inbox.affordances.test.tsx
@@ -20,7 +20,8 @@
  * coverage of the removal either.
  */
 
-import { render, screen } from '@testing-library/react';
+import { screen } from '@testing-library/react';
+import { renderWithQuery as render } from '@/test/renderWithQuery';
 import { describe, it, expect, vi } from 'vitest';
 import { InboxControls } from '../InboxControls';
 

--- a/apps/desktop/src/features/projects/GenerateSourceViewDialog.test.tsx
+++ b/apps/desktop/src/features/projects/GenerateSourceViewDialog.test.tsx
@@ -16,7 +16,8 @@
  *    whether files were linked or copied without opening the plan.
  */
 
-import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+import { screen, waitFor, fireEvent } from '@testing-library/react';
+import { renderWithQuery as render } from '@/test/renderWithQuery';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 const { mockGenerate, mockGetSettings } = vi.hoisted(() => ({

--- a/apps/desktop/src/features/projects/GenerateSourceViewDialog.tsx
+++ b/apps/desktop/src/features/projects/GenerateSourceViewDialog.tsx
@@ -23,13 +23,14 @@
  * `SourceViewsSection`'s remove/regenerate toast convention.
  */
 
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Modal } from '@/components';
 import { Btn, Banner } from '@/ui';
 import { m } from '@/lib/i18n';
 import { addToast } from '@/shared/toast';
 import { generateSourceView } from './source-views';
-import { getSettings } from '@/features/settings/settingsIpc';
+import { settingsQueryOptions } from '@/features/settings/settingsQueries';
 import { errMessage } from '@/lib/errors';
 
 interface SourceViewLinkKindSettings {
@@ -54,25 +55,14 @@ export function GenerateSourceViewDialog({
   const [copyOptIn, setCopyOptIn] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [linkKinds, setLinkKinds] = useState<SourceViewLinkKindSettings | null>(
-    null,
-  );
-
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    void getSettings({ scope: 'sourceViews' })
-      .then((data) => {
-        if (!cancelled) setLinkKinds(data.values ?? {});
-      })
-      .catch(() => {
-        // Best-effort display only — generation still works without it.
-        if (!cancelled) setLinkKinds(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open]);
+  // Best-effort display only — generation still works without it, so a failed
+  // read renders the same "unknown" state as a pending one.
+  const { data } = useQuery({
+    ...settingsQueryOptions('sourceViews'),
+    enabled: open,
+  });
+  const linkKinds: SourceViewLinkKindSettings | null =
+    (data?.values as SourceViewLinkKindSettings | undefined) ?? null;
 
   if (!open) return null;
 

--- a/apps/desktop/src/features/settings/Advanced.test.tsx
+++ b/apps/desktop/src/features/settings/Advanced.test.tsx
@@ -12,7 +12,8 @@
  * buffer, clear the `setupCompleted` cache, and navigate to `/setup`.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithQuery as render } from '@/test/renderWithQuery';
 import { Advanced } from './Advanced';
 import type { FirstRunRestartResponse } from './settingsIpc';
 

--- a/apps/desktop/src/features/settings/Advanced.tsx
+++ b/apps/desktop/src/features/settings/Advanced.tsx
@@ -12,8 +12,10 @@
 // firstrun.restart was fully wired on the backend but had no UI caller).
 import { useState, useEffect, useSyncExternalStore } from 'react';
 import { useNavigate } from '@tanstack/react-router';
+import { useQuery } from '@tanstack/react-query';
 import { Btn } from '@/ui';
-import { getSettingsTyped, restartFirstRun } from './settingsIpc';
+import { parseSettingsValues, restartFirstRun } from './settingsIpc';
+import { settingsQueryOptions } from './settingsQueries';
 import { AdvancedSettingsSchema, type LOG_LEVELS } from './settingsSchemas';
 import { m } from '@/lib/i18n';
 import { errMessage } from '@/lib/errors';
@@ -76,22 +78,16 @@ export function Advanced({ save }: AdvancedProps) {
     }
   };
 
-  // Load persisted logLevel from backend on mount (T015).
+  // A read failure leaves the in-code default in place; this pane surfaces no
+  // error for it, so `error` is deliberately unused.
+  const { data } = useQuery(settingsQueryOptions('advanced'));
+
   useEffect(() => {
-    let cancelled = false;
-    getSettingsTyped('advanced', AdvancedSettingsSchema)
-      .then((vals) => {
-        if (cancelled) return;
-        if (vals.logLevel) setLogLevel(vals.logLevel);
-      })
-      .catch(() => {
-        // Backend unavailable — stay with in-code default.
-      });
-    return () => {
-      cancelled = true;
-    };
+    if (data === undefined) return;
+    const vals = parseSettingsValues(data.values, AdvancedSettingsSchema);
+    if (vals.logLevel) setLogLevel(vals.logLevel);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [data]);
 
   // Running app semver, independent of update state (#845).
   useEffect(() => {

--- a/apps/desktop/src/features/settings/Cleanup.test.tsx
+++ b/apps/desktop/src/features/settings/Cleanup.test.tsx
@@ -14,13 +14,8 @@
  * Covers: load, per-type round-trip, auto-on-completion round-trip, the
  * protected-category warning, restore-defaults, and the stale-fetch race.
  */
-import {
-  render,
-  screen,
-  fireEvent,
-  waitFor,
-  within,
-} from '@testing-library/react';
+import { screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { renderWithQuery as render } from '@/test/renderWithQuery';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ZodType } from 'zod';
 

--- a/apps/desktop/src/features/settings/Cleanup.tsx
+++ b/apps/desktop/src/features/settings/Cleanup.tsx
@@ -12,9 +12,10 @@
 // `cleanupTypeOverrides` blob no scan path ever consulted — it looked like the
 // cleanup configuration surface while having zero effect on cleanup.
 import { useState, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Toggle, SegControl, Pill, Banner } from '@/ui';
+import { settingsQueryOptions } from './settingsQueries';
 import {
-  getSettingsTyped,
   parseSettingsValues,
   cleanupPolicyGet,
   cleanupPolicyUpdate,
@@ -136,22 +137,15 @@ export function Cleanup({ save }: CleanupProps) {
   // before applying its (now-outdated) snapshot.
   const editedRef = useRef(false);
 
-  // Load persisted values from backend on mount (T015).
+  // A read failure leaves the in-code defaults in place; this pane has no error
+  // surface of its own, so `error` is deliberately unused.
+  const { data } = useQuery(settingsQueryOptions('cleanup'));
+
   useEffect(() => {
-    let cancelled = false;
-    getSettingsTyped('cleanup', CleanupSettingsSchema)
-      .then((vals) => {
-        if (cancelled || editedRef.current) return;
-        applyTyped(vals);
-      })
-      .catch(() => {
-        // Backend unavailable — stay with in-code defaults.
-      });
-    return () => {
-      cancelled = true;
-    };
+    if (data === undefined || editedRef.current) return;
+    applyTyped(parseSettingsValues(data.values, CleanupSettingsSchema));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [data]);
 
   // Policy has its own store and its own in-flight guard: a slow policy fetch
   // must not clobber a policy edit, independent of the settings-scope fetch.

--- a/apps/desktop/src/features/settings/Framing.test.tsx
+++ b/apps/desktop/src/features/settings/Framing.test.tsx
@@ -14,7 +14,8 @@
  * back to the fetched one. The subsequent blur then reads that clobbered DOM
  * value and persists it, permanently losing the edit.
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithQuery as render } from '@/test/renderWithQuery';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ZodType } from 'zod';
 

--- a/apps/desktop/src/features/settings/Framing.tsx
+++ b/apps/desktop/src/features/settings/Framing.tsx
@@ -13,8 +13,10 @@
  * fallback values below.
  */
 import { useState, useEffect, useRef } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { m } from '@/lib/i18n';
-import { getSettingsTyped, parseSettingsValues } from './settingsIpc';
+import { parseSettingsValues } from './settingsIpc';
+import { settingsQueryOptions } from './settingsQueries';
 import { FramingSettingsSchema, type FramingSettings } from './settingsSchemas';
 import {
   SettingsSection,
@@ -92,20 +94,15 @@ export function Framing({ save }: FramingProps) {
     applyTyped(parseSettingsValues(values, FramingSettingsSchema));
   }
 
+  // A read failure leaves the in-code R11a defaults in place; the pane has no
+  // error surface of its own, so `error` is deliberately unused.
+  const { data } = useQuery(settingsQueryOptions(FRAMING_SCOPE));
+
   useEffect(() => {
-    let cancelled = false;
-    getSettingsTyped(FRAMING_SCOPE, FramingSettingsSchema)
-      .then((values) => {
-        if (cancelled || editedRef.current) return;
-        applyTyped(values);
-      })
-      .catch(() => {
-        // Backend unavailable — stay with in-code R11a defaults.
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
+    if (data === undefined || editedRef.current) return;
+    applyTyped(parseSettingsValues(data.values, FramingSettingsSchema));
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [data]);
 
   // Marks the mount-time fetch stale as soon as the user starts typing, not
   // only once they blur/Enter to commit. Without this, the fetch can resolve

--- a/apps/desktop/src/features/settings/SourceViews.test.tsx
+++ b/apps/desktop/src/features/settings/SourceViews.test.tsx
@@ -12,7 +12,8 @@
  *   3. Changing a select calls `save('sourceViews', { ... })` with the new value.
  *   4. The cross-drive select never offers `hardlink` (FR-004a).
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { screen, fireEvent, waitFor } from '@testing-library/react';
+import { renderWithQuery as render } from '@/test/renderWithQuery';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { ZodType } from 'zod';
 

--- a/apps/desktop/src/features/settings/SourceViews.tsx
+++ b/apps/desktop/src/features/settings/SourceViews.tsx
@@ -19,7 +19,9 @@
  * a pre-select achievability check.
  */
 import { useState, useEffect, useRef } from 'react';
-import { getSettingsTyped, parseSettingsValues } from './settingsIpc';
+import { useQuery } from '@tanstack/react-query';
+import { parseSettingsValues } from './settingsIpc';
+import { settingsQueryOptions } from './settingsQueries';
 import {
   SourceViewsSettingsSchema,
   INTRA_DRIVE_LINK_KINDS,
@@ -81,21 +83,15 @@ export function SourceViews({ save }: SourceViewsProps) {
     }
   }
 
+  // A read failure leaves the in-code defaults in place; the pane has no error
+  // surface of its own, so `error` is deliberately unused.
+  const { data } = useQuery(settingsQueryOptions('sourceViews'));
+
   useEffect(() => {
-    let cancelled = false;
-    getSettingsTyped('sourceViews', SourceViewsSettingsSchema)
-      .then((values) => {
-        if (cancelled || editedRef.current) return;
-        applyTyped(values);
-      })
-      .catch(() => {
-        // Backend unavailable — stay with in-code defaults.
-      });
-    return () => {
-      cancelled = true;
-    };
+    if (data === undefined || editedRef.current) return;
+    applyTyped(parseSettingsValues(data.values, SourceViewsSettingsSchema));
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  }, [data]);
 
   return (
     <SettingsSection

--- a/apps/desktop/src/features/settings/settingsIpc.ts
+++ b/apps/desktop/src/features/settings/settingsIpc.ts
@@ -17,6 +17,8 @@ import type { ZodType } from 'zod';
 import { commands } from '@/bindings/index';
 import { unwrap } from '@/api/ipc';
 import { ipcArgs } from '@/lib/ipc-args';
+import { queryClient } from '@/data/queryClient';
+import { queryKeys } from '@/data/queryKeys';
 // `LibraryRoot` is a plain `_Serialize` re-export in `@/bindings/types` (the
 // facade every settings pane already imports it through), NOT the wider
 // `LibraryRoot_Serialize | LibraryRoot_Deserialize` union `@/bindings/index`
@@ -191,6 +193,9 @@ export async function updateSettings(args: {
   values: Record<string, unknown>;
 }): Promise<void> {
   unwrap(await commands.settingsUpdate(args.scope, args.values));
+  await queryClient.invalidateQueries({
+    queryKey: queryKeys.settings.scope(args.scope),
+  });
 }
 
 /**
@@ -200,7 +205,11 @@ export async function updateSettings(args: {
 export async function settingsRestoreDefaults(
   keys: string[],
 ): Promise<RestoreDefaultsResponse> {
-  return unwrap(await commands.settingsRestoreDefaults({ keys }));
+  const response = unwrap(await commands.settingsRestoreDefaults({ keys }));
+  // Restore is key-scoped, not scope-scoped (an empty `keys` restores
+  // everything), so the affected scopes cannot be derived here.
+  await queryClient.invalidateQueries({ queryKey: queryKeys.settings.all() });
+  return response;
 }
 
 /**

--- a/apps/desktop/src/features/settings/settingsQueries.ts
+++ b/apps/desktop/src/features/settings/settingsQueries.ts
@@ -1,0 +1,28 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * TanStack Query options for the generic `settings.get` scope reads.
+ *
+ * `staleTime: Infinity` is safe only because every write path through
+ * `updateSettings` / `settingsRestoreDefaults` invalidates
+ * `queryKeys.settings.all()`. A writer that calls `commands.settingsUpdate`
+ * directly (see `data/theme.ts`, `data/locale.tsx`, `data/persisted-state.ts`,
+ * `shared/observing-sites/site-store.ts`, `shared/planner/*-settings.ts`)
+ * bypasses that invalidation — those modules own scopes no `useQuery` caller
+ * reads, and a new caller for one of their scopes must add invalidation there
+ * first.
+ */
+
+import { queryOptions } from '@tanstack/react-query';
+import { queryKeys } from '@/data/queryKeys';
+import { getSettings } from './settingsIpc';
+import type { SettingsData } from '@/bindings/index';
+
+export function settingsQueryOptions(scope: string) {
+  return queryOptions<SettingsData>({
+    queryKey: queryKeys.settings.scope(scope),
+    queryFn: () => getSettings({ scope }),
+    staleTime: Number.POSITIVE_INFINITY,
+  });
+}

--- a/apps/desktop/src/test/renderWithQuery.tsx
+++ b/apps/desktop/src/test/renderWithQuery.tsx
@@ -1,0 +1,25 @@
+// Copyright (C) 2024-2026 Sjors Robroek
+// SPDX-License-Identifier: AGPL-3.0-only
+
+/**
+ * `render` for components that call `useQuery`/`useQueryClient`.
+ *
+ * Each call gets a fresh `QueryClient` so cached data cannot leak between
+ * tests, and `retry: false` so a rejected `queryFn` surfaces on the first
+ * attempt instead of after the default backoff.
+ */
+
+import type { ReactElement } from 'react';
+import { render as rtlRender } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+export function renderWithQuery(ui: ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return rtlRender(ui, {
+    wrapper: ({ children }) => (
+      <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    ),
+  });
+}

--- a/scripts/eslint-alm-baseline.txt
+++ b/scripts/eslint-alm-baseline.txt
@@ -63,7 +63,7 @@ src/features/sessions/CalendarScroll.tsx	72	alm/require-root-testid
 src/features/sessions/SessionNotesSection.tsx	93	alm/require-root-testid
 src/features/settings/AuditLog.tsx	308	alm/require-root-testid
 src/features/settings/CalibrationMatching.tsx	189	alm/require-root-testid
-src/features/settings/Framing.tsx	137	alm/require-root-testid
+src/features/settings/Framing.tsx	134	alm/require-root-testid
 src/features/settings/ObservingSites.tsx	293	alm/require-root-testid
 src/features/settings/PatternChipsEditor.tsx	39	alm/require-root-testid
 src/features/settings/PerTypePatternChipsEditor.tsx	90	alm/require-root-testid
@@ -74,7 +74,7 @@ src/features/settings/SettingsKit.tsx	33	alm/require-root-testid
 src/features/settings/SettingsPage.tsx	187	alm/require-root-testid
 src/features/settings/SourceProtectionOverride.tsx	139	alm/require-root-testid
 src/features/settings/SourceViewStrategy.tsx	60	alm/require-root-testid
-src/features/settings/SourceViews.tsx	101	alm/require-root-testid
+src/features/settings/SourceViews.tsx	97	alm/require-root-testid
 src/features/setup/SetupPage.tsx	48	alm/require-root-testid
 src/features/setup/SetupWizard.tsx	244	alm/require-root-testid
 src/features/setup/steps/StepCatalogs.tsx	168	alm/require-root-testid


### PR DESCRIPTION
## What changed

Settings panes now read their scope through one shared TanStack Query cache entry instead of each issuing its own fetch on mount.

- `apps/desktop/src/data/queryKeys.ts` gains a top-level `settings` namespace (`settings.all()`, `settings.scope(scope)`), alongside the 11 existing namespaces. The pre-existing `calibration.settings` key is unrelated: it keys the calibration tolerances store, not a `settings.get` scope.
- `settingsQueryOptions(scope)` in `apps/desktop/src/features/settings/settingsQueries.ts` wraps `getSettings({ scope })` with `staleTime: Infinity`, keyed off the registry rather than a literal tuple.
- `updateSettings` and `settingsRestoreDefaults` invalidate the key. Invalidation sits in `settingsIpc.ts` at the two write chokepoints, not at each call site, so a future writer cannot forget it. `settingsRestoreDefaults` restores by key list rather than by scope (an empty list restores everything), so it invalidates the whole `settings` prefix.
- `Framing.tsx`, `Advanced.tsx`, `SourceViews.tsx`, `Cleanup.tsx`, and `projects/GenerateSourceViewDialog.tsx` drop their hand-rolled `useEffect` + `cancelled` guard.
- `apps/desktop/src/test/renderWithQuery.tsx` provides a `QueryClientProvider` wrapper for the six test files whose components now need one. Each render gets a fresh client, so cache state cannot leak across tests.

No `data-testid` value changed.

### Write paths that do not invalidate

These modules each own a settings scope and call `commands.settingsUpdate` directly, bypassing `updateSettings`:

| Module | Scope |
|---|---|
| `data/theme.ts` | `general` |
| `data/locale.tsx` | `general` |
| `data/persisted-state.ts` | `ui_state` |
| `shared/observing-sites/site-store.ts` | `observing` |
| `shared/planner/guidance-settings.ts` | `planner` |
| `shared/planner/catalogue-settings.ts` | `catalogues` |

None of those scopes has a `useQuery` reader, so no cache entry exists to go stale. A reader added for one of those scopes must add invalidation in that module first. The constraint is recorded in the `settingsQueries.ts` docstring.

### Not migrated

`features/settings/PerTypeDestinationPatterns.tsx` keeps its manual fetch. Its load resolves a `loaded` flag that sequences a second per-class preview effect, and it writes through its own path so it can surface the backend `value.invalid` rejection inline. Converting the read alone would split one flow across two mechanisms.

## Why

Both decisions are owner-approved.

**Key through the registry, not a literal.** `queryKeys.ts` exists so prefix-based invalidation works across the 34 files that use it. A second key source for settings would be exactly the drift that file prevents.

**`staleTime: Infinity` requires invalidation at the write.** Settings change only through explicit writes, so time-based staleness buys nothing. A cache that never expires and never invalidates would be worse than the per-mount fetch it replaces. That is why invalidation went in at the IPC chokepoint, and why the bypassing writers are enumerated above rather than left implicit.

Supersedes #1596, which bundled the same query work with an `ObservingSites` move to `shared/`. #1624 merged that move separately, so this branch is the query change alone.

## Test plan

- `pnpm lint` passes. `scripts/eslint-alm-baseline.txt` regenerated with `node scripts/check-eslint-baseline.mjs --generate`; the two changed entries are line shifts in `Framing.tsx` and `SourceViews.tsx`, not new violations.
- `pnpm typecheck` passes.
- `pnpm lint:circular` reports 0 new cycles (3 allowlisted type-import cycles).
- `apps/desktop` vitest: 2376 tests in 267 files, all passing.
- Playwright: 25 tests across `settings_framing`, `settings_appearance_i18n`, `settings_update_check`, `cleanup_review`, and the source-view specs, all passing.

Tracks-Bead: astro-plan-noot
Merge-Bead: astro-plan-8qjr
