### PR TITLE
fix: a retry you request is no longer silently reported as cancelled

### DIFF
--- a/crates/app/core/src/plan_apply/apply.rs
+++ b/crates/app/core/src/plan_apply/apply.rs
@@ -267,6 +267,57 @@ pub(super) async fn cumulative_counts(
     }
 }
 
+/// Reason code recorded on an item whose retry was accepted but whose run
+/// halted before executing it. Distinguishes it from a user cancellation for
+/// any surface that offers the retry again (astro-plan-ts1z window c).
+pub(super) const RETRY_NOT_EXECUTED_REASON: &str = "retry.not_executed";
+
+/// Put every retry this run accepted but never executed back to `failed`, and
+/// append an audit event naming why.
+///
+/// `execute_plan` closes the retry queue before returning, so this set is
+/// final: no further push can land. Restoring here — before the terminal
+/// handlers' `cancel_orphaned_applying_items` sweep — is what keeps a user's
+/// unexecuted retry retryable instead of terminal.
+pub(super) async fn restore_unexecuted_retries(
+    pool: &SqlitePool,
+    plan_id: &str,
+    run_id: &str,
+    retry_queue: &RetryQueue,
+) {
+    for item_id in retry_queue.take_orphaned() {
+        match apply_repo::item_retry_rollback_to_failed(pool, &item_id, plan_id).await {
+            Ok(()) => {
+                let _ = apply_repo::append_event(
+                    pool,
+                    &new_id(),
+                    run_id,
+                    plan_id,
+                    Some(&item_id),
+                    "applying",
+                    "failed",
+                    &Timestamp::now_iso(),
+                    Some(&apply_repo::EventFailure {
+                        code: RETRY_NOT_EXECUTED_REASON,
+                        message: "the run stopped before this retry was executed; \
+                                  the item was not retried and remains retryable",
+                        recoverable: true,
+                    }),
+                    None,
+                )
+                .await;
+            }
+            Err(e) => {
+                tracing::error!(
+                    error = %e, plan_id, item_id,
+                    "could not restore an unexecuted retry to 'failed'; it will be swept to \
+                     'cancelled' and must be retried at plan level"
+                );
+            }
+        }
+    }
+}
+
 /// Drive `execute_plan` to completion/cancellation/pause on a background
 /// task and persist the outcome (terminal state, audit trail, long-op
 /// projection). Extracted from `apply_plan`'s inline `tokio::spawn` block so
@@ -313,6 +364,15 @@ pub(super) fn spawn_executor_run(params: SpawnExecutorParams) {
         // Mandatory flush: drain any items buffered in the last partial window
         // before the outcome branches below read cumulative plan counters.
         callbacks.flush().await;
+
+        // Restore any retry accepted by this run but never executed (the
+        // executor halted on cancel or pause before draining it). Runs BEFORE
+        // the terminal handlers so their `cancel_orphaned_applying_items`
+        // sweep finds nothing to convert: the item reads `failed` — the
+        // truth, and retryable — instead of `cancelled`, which is
+        // indistinguishable from a cancellation the user asked for
+        // (astro-plan-ts1z, constitution II).
+        restore_unexecuted_retries(&pool, &plan_id, &run_id, &retry_queue).await;
 
         // Compute terminal state and persist via per-outcome handlers.
         match outcome {

--- a/crates/app/core/src/plan_apply/lifecycle.rs
+++ b/crates/app/core/src/plan_apply/lifecycle.rs
@@ -435,6 +435,13 @@ pub async fn resume_plan(
     // ones: the plan still owns its whole footprint for the run's
     // duration) before the executor can run again. Cancel/skip/retry state
     // does not carry over a pause boundary; a fresh set is correct here.
+    //
+    // The pre-pause run's queue is already closed by `execute_plan`, so a
+    // `retry_plan_item` call landing between here and the executor's start
+    // finds either no entry or a closed one, and is refused with the item left
+    // `failed` — never accepted onto a queue this registration is about to
+    // replace, which dropped it silently and let the completion sweep record it
+    // as `cancelled` (astro-plan-ts1z window b).
     let path_set = compute_plan_path_set(&item_rows, &root_map);
     let cancel_token = CancellationToken::new();
     let skip_set = SkipSet::new();
@@ -655,27 +662,28 @@ pub async fn retry_plan_item(
     // Transition item back to applying in DB (failed → applying).
     apply_repo::item_retry_applying(pool, item_id, plan_id).await.map_err(db_err)?;
 
-    // Enqueue for re-execution, and REFUSE if the run vanished in the meantime.
+    // Enqueue for re-execution, and REFUSE unless the queue accepts it.
     //
-    // The `active_runs()` check above closes the common case but not the window
-    // between it and here. Previously that window was swallowed: `if let
-    // Some(run)` simply did nothing when the run was gone, leaving the item
-    // `applying` in the DB with nothing that will ever execute it. Run
-    // completion then sweeps orphaned `applying` items to `cancelled`
-    // (`terminal.rs`), so the user's retry became a silent cancellation --
-    // file unmoved, audit trail reading `cancelled`, indistinguishable from a
+    // Two ways to lose here, both reported rather than swallowed:
+    //
+    // - No registry entry: the run finished (or `resume_plan` has not yet
+    //   registered the resumed one) between the check above and this point.
+    // - The entry's queue is closed: `execute_plan` closed it jointly with its
+    //   final drain, so this run will never read the id again.
+    //
+    // Previously both were swallowed -- `if let Some(run)` simply did nothing --
+    // leaving the item `applying` in the DB with nothing that will ever execute
+    // it. Run completion then sweeps orphaned `applying` items to `cancelled`
+    // (`terminal.rs`), so the user's retry became a silent cancellation: file
+    // unmoved, audit trail reading `cancelled`, indistinguishable from a
     // cancellation they asked for. That is a Tier-1 custody failure under
-    // constitution II: an approved action recorded terminal that never ran.
+    // constitution II -- an approved action recorded terminal that never ran.
     //
-    // Losing the race is now reported instead. The DB flip is rolled back
-    // first so the item stays `failed` -- retryable, and honest about not
-    // having run -- rather than stranded `applying`.
+    // The DB flip is rolled back first so the item stays `failed` -- retryable,
+    // and honest about not having run -- rather than stranded `applying`.
     let enqueued = {
         let registry = active_runs();
-        let queued = registry.get(plan_id).is_some_and(|run| {
-            run.retry_queue.push(item_id);
-            true
-        });
+        let queued = registry.get(plan_id).is_some_and(|run| run.retry_queue.push(item_id));
         drop(registry);
         queued
     };
@@ -697,9 +705,10 @@ pub async fn retry_plan_item(
         return Err(ContractError::new(
             ErrorCode::RunNotFound,
             format!(
-                "the run for plan {plan_id} finished while the retry of item {item_id} was \
-                 being accepted, so nothing re-executed it. The item was not retried. \
-                 Use plan.retry on the terminal plan."
+                "the run for plan {plan_id} stopped accepting retries while the retry of item \
+                 {item_id} was being accepted, so nothing re-executed it. The item was not \
+                 retried and is still failed; retry it again, or use plan.retry on the \
+                 terminal plan."
             ),
             ErrorSeverity::Blocking,
             true,

--- a/crates/app/core/src/plan_apply/tests.rs
+++ b/crates/app/core/src/plan_apply/tests.rs
@@ -851,6 +851,88 @@ async fn losing_the_retry_race_restores_the_item_to_failed_and_retryable() {
     );
 }
 
+/// astro-plan-ts1z window (c): a retry the run accepted but never executed
+/// must not be recorded as `cancelled`.
+///
+/// The completion sweep (`cancel_orphaned_applying_items`) turns any item left
+/// `applying` into `cancelled`, which reads identically to a cancellation the
+/// user asked for — the UI has nothing to distinguish them by and presents the
+/// item as done. `restore_unexecuted_retries` runs first and puts the item back
+/// to `failed` with a `retry.not_executed` audit event, so the item stays
+/// retryable and the reason is on the record.
+#[tokio::test]
+async fn an_accepted_but_unexecuted_retry_is_restored_to_failed_not_cancelled() {
+    let (db, _bus) = setup().await;
+    insert_approved_plan_with_items(&db, "p-orphan", 1).await;
+    // A real run row: the audit event's `run_id` is a foreign key, so a fake id
+    // would make the append silently fail and the reason never be recorded.
+    plans_repo::update_plan_state(db.pool(), "p-orphan", "approved").await.unwrap();
+    apply_repo::cas_approved_to_applying(db.pool(), "p-orphan", "run-orphan", "tok", 1, 1)
+        .await
+        .unwrap();
+    {
+        let mut conn = db.pool().acquire().await.unwrap();
+        apply_repo::batch_flush_item_states(
+            &mut conn,
+            "p-orphan",
+            &[apply_repo::BatchItemState {
+                item_id: "p-orphan-item-0",
+                new_state: "failed",
+                failure_reason: Some("permission.denied"),
+                is_stale: false,
+            }],
+            0,
+            1,
+            0,
+        )
+        .await
+        .unwrap();
+    }
+
+    // The state `execute_plan` leaves behind when it halts over an accepted
+    // retry: the item's row is `applying` and the queue reports it as an orphan.
+    let retry_queue = RetryQueue::new();
+    assert!(retry_queue.push("p-orphan-item-0"));
+    retry_queue.close();
+    apply_repo::item_retry_applying(db.pool(), "p-orphan-item-0", "p-orphan").await.unwrap();
+
+    super::apply::restore_unexecuted_retries(db.pool(), "p-orphan", "run-orphan", &retry_queue)
+        .await;
+
+    let items = plans_repo::list_plan_items(db.pool(), "p-orphan").await.unwrap();
+    let item = items.iter().find(|i| i.id == "p-orphan-item-0").unwrap();
+    assert_eq!(
+        item.item_state, "failed",
+        "an accepted retry that never ran must be FAILED — retryable — not left `applying` for \
+         the completion sweep to record as `cancelled`"
+    );
+
+    let reason: Option<String> = sqlx::query_scalar(
+        "SELECT failure_code FROM plan_apply_events \
+         WHERE plan_id = ? AND item_id = ? AND new_state = 'failed' \
+         ORDER BY rowid DESC LIMIT 1",
+    )
+    .bind("p-orphan")
+    .bind("p-orphan-item-0")
+    .fetch_one(db.pool())
+    .await
+    .unwrap();
+    assert_eq!(
+        reason.as_deref(),
+        Some(super::apply::RETRY_NOT_EXECUTED_REASON),
+        "the audit record must name WHY the retry did not run, so a surface can offer it again \
+         instead of presenting a cancellation the user never asked for"
+    );
+
+    // Now the sweep the terminal handlers run: it must find nothing, because
+    // the restore already happened.
+    let swept = apply_repo::cancel_orphaned_applying_items(db.pool(), "p-orphan").await.unwrap();
+    assert!(
+        swept.is_empty(),
+        "the restore runs before the sweep, so the sweep has no `applying` item to cancel"
+    );
+}
+
 #[tokio::test]
 async fn retry_plan_item_rejects_non_failed_item() {
     let (db, _bus) = setup().await;

--- a/crates/fs/executor/src/run/loop_.rs
+++ b/crates/fs/executor/src/run/loop_.rs
@@ -23,17 +23,39 @@ use super::{
 /// Returns `ApplyOutcome` when all items are resolved or a halt condition
 /// (cancel / pause) is observed.
 ///
+/// Owns `retry_queue`'s lifecycle: the queue is always closed by the time this
+/// returns, so a `retry_plan_item` call arriving after this run stopped
+/// draining is refused rather than accepted into a queue nobody will read
+/// (astro-plan-ts1z). Any id accepted but not executed is reported by
+/// [`RetryQueue::take_orphaned`] for the caller to restore.
+///
 /// The caller (app/core) is responsible for:
 /// - The CAS `approved → applying` transition before calling this.
 /// - Batch-cancelling pending items after `Cancelled` is returned.
 /// - Calling `pause_run` / `resume_run` on the DB on `Paused`.
 /// - Writing the terminal plan state on `Completed`.
+/// - Restoring the database rows of [`RetryQueue::take_orphaned`] ids.
+pub async fn execute_plan<C: ExecutorCallbacks>(
+    items: Vec<ExecutorItem>,
+    callbacks: &C,
+    cancel: &CancellationToken,
+    skip_set: &SkipSet,
+    retry_queue: &RetryQueue,
+) -> ApplyOutcome {
+    let outcome = drive_plan(items, callbacks, cancel, skip_set, retry_queue).await;
+    // Idempotent: the `Completed` path already closed the queue jointly with
+    // its final drain. This covers the cancel and pause exits, where remaining
+    // ids become orphans instead.
+    retry_queue.close();
+    outcome
+}
+
 #[allow(clippy::too_many_lines)]
 #[expect(
     clippy::cognitive_complexity,
     reason = "per-item executor loop with failure taxonomy, cancellation, and retry paths"
 )]
-pub async fn execute_plan<C: ExecutorCallbacks>(
+async fn drive_plan<C: ExecutorCallbacks>(
     items: Vec<ExecutorItem>,
     callbacks: &C,
     cancel: &CancellationToken,
@@ -90,39 +112,88 @@ pub async fn execute_plan<C: ExecutorCallbacks>(
         // every item — the same boundary already used for cancel/skip —
         // picks up a retry filed against ANY already-passed item, matching
         // this loop's "never mid-item" invariant.
-        for retry_id in retry_queue.drain_all() {
-            // Check cancellation between retry items too (same "never
-            // mid-item" semantics as the forward loop above). Any retry ids
-            // already drained but not yet reached here are dropped from the
-            // queue without executing — their DB row is already `applying`
-            // (flipped eagerly by `retry_plan_item`), so the caller sweeps
-            // them via `cancel_orphaned_applying_items` after `Cancelled` is
-            // returned (fs_executor has no DB dependency to do so itself).
-            if cancel.is_cancelled() {
+        match drain_retries(retry_queue, &item_by_id, callbacks, &mut counts, cancel).await {
+            DrainOutcome::Continue => {}
+            DrainOutcome::Cancelled => {
                 cancelled = true;
                 break 'items;
             }
-
-            let Some(retry_item) = item_by_id.get(retry_id.as_str()) else {
-                tracing::warn!(item_id = %retry_id, "retry queued for unknown item id; ignored");
-                continue;
-            };
-            // `retry_plan_item` already transitioned the DB row `failed ->
-            // applying` before queuing, so `on_item_start` (which would
-            // double-decrement `items_pending`) must NOT run again, and the
-            // gate/terminal events' prior_state is "applying", not "pending".
-            match process_single_item(retry_item, callbacks, &mut counts, "applying", false).await {
-                ItemOutcome::Pause(reason) => return ApplyOutcome::Paused { reason, counts },
-                ItemOutcome::Continue => {}
-            }
+            DrainOutcome::Pause(reason) => return ApplyOutcome::Paused { reason, counts },
         }
     }
 
     if cancelled {
-        ApplyOutcome::Cancelled(counts)
-    } else {
-        ApplyOutcome::Completed(counts)
+        return ApplyOutcome::Cancelled(counts);
     }
+
+    // Close the queue jointly with a final drain. A retry pushed at any point
+    // before the close is executed here; one arriving after is refused at
+    // `push`. There is no interval in which an accepted retry has no executor
+    // (astro-plan-ts1z windows b and c).
+    loop {
+        if retry_queue.close_if_empty() {
+            break;
+        }
+        match drain_retries(retry_queue, &item_by_id, callbacks, &mut counts, cancel).await {
+            DrainOutcome::Continue => {}
+            DrainOutcome::Cancelled => return ApplyOutcome::Cancelled(counts),
+            DrainOutcome::Pause(reason) => return ApplyOutcome::Paused { reason, counts },
+        }
+    }
+
+    ApplyOutcome::Completed(counts)
+}
+
+/// Outcome of one retry-queue drain pass.
+enum DrainOutcome {
+    Continue,
+    Cancelled,
+    Pause(String),
+}
+
+/// Drain the retry queue once and re-execute each drained item.
+///
+/// Cancellation is checked between retry items (same "never mid-item"
+/// semantics as the forward loop). A halt part-way through the batch hands the
+/// unprocessed remainder back as orphans: `drain_all` already removed them from
+/// the queue, and their database row is `applying`, so the caller must be able
+/// to see them (`fs_executor` has no database dependency to restore them
+/// itself). An id with no matching item is also an orphan — nothing in this run
+/// can execute it.
+async fn drain_retries<C: ExecutorCallbacks>(
+    retry_queue: &RetryQueue,
+    item_by_id: &HashMap<&str, &ExecutorItem>,
+    callbacks: &C,
+    counts: &mut TerminalCounts,
+    cancel: &CancellationToken,
+) -> DrainOutcome {
+    let drained = retry_queue.drain_all();
+    let mut remaining = drained.iter();
+
+    while let Some(retry_id) = remaining.next() {
+        if cancel.is_cancelled() {
+            retry_queue.orphan(std::iter::once(retry_id.clone()).chain(remaining.cloned()));
+            return DrainOutcome::Cancelled;
+        }
+
+        let Some(retry_item) = item_by_id.get(retry_id.as_str()) else {
+            tracing::warn!(item_id = %retry_id, "retry queued for unknown item id; ignored");
+            retry_queue.orphan(std::iter::once(retry_id.clone()));
+            continue;
+        };
+        // `retry_plan_item` already transitioned the DB row `failed ->
+        // applying` before queuing, so `on_item_start` (which would
+        // double-decrement `items_pending`) must NOT run again, and the
+        // gate/terminal events' prior_state is "applying", not "pending".
+        match process_single_item(retry_item, callbacks, counts, "applying", false).await {
+            ItemOutcome::Pause(reason) => {
+                retry_queue.orphan(remaining.cloned());
+                return DrainOutcome::Pause(reason);
+            }
+            ItemOutcome::Continue => {}
+        }
+    }
+    DrainOutcome::Continue
 }
 
 /// Outcome of processing a single item through the gate/execute pipeline.

--- a/crates/fs/executor/src/run/mod.rs
+++ b/crates/fs/executor/src/run/mod.rs
@@ -318,23 +318,58 @@ impl SkipSet {
 ///
 /// Access is synchronous for the same reason as [`SkipSet`]: the critical
 /// section is a single `HashSet` operation, never held across an `.await`.
-#[derive(Clone, Debug, Default)]
+///
+/// The queue has a one-way `open -> closed` lifecycle. While open, an
+/// enqueued id is guaranteed to be observed by a later [`RetryQueue::drain_all`]
+/// or to be reported by [`RetryQueue::take_orphaned`]. Once closed,
+/// [`RetryQueue::push`] refuses. The transition is what makes retry acceptance
+/// and executor readiness a single atomic step (astro-plan-ts1z): an id is
+/// either queued to a run that will drain it, or refused outright. Without it,
+/// a retry accepted for a run that had already stopped draining was swept to
+/// `cancelled` without ever executing — indistinguishable from a cancellation
+/// the user asked for.
+#[derive(Clone, Debug)]
 pub struct RetryQueue {
-    inner: Arc<Mutex<HashSet<String>>>,
+    inner: Arc<Mutex<RetryQueueInner>>,
+}
+
+#[derive(Debug)]
+struct RetryQueueInner {
+    /// `None` once closed.
+    queue: Option<HashSet<String>>,
+    /// Ids that were accepted while open but closed before any drain reached
+    /// them. Their database row is already `applying` (flipped by the caller
+    /// before the enqueue), so whoever closed the queue owns restoring them.
+    orphaned: Vec<String>,
 }
 
 impl RetryQueue {
     #[must_use]
     pub fn new() -> Self {
-        Self { inner: Arc::new(Mutex::new(HashSet::new())) }
+        Self {
+            inner: Arc::new(Mutex::new(RetryQueueInner {
+                queue: Some(HashSet::new()),
+                orphaned: Vec::new(),
+            })),
+        }
     }
 
-    /// Enqueue an item for retry.
+    /// Enqueue an item for retry. Returns `false` when the queue is closed,
+    /// meaning no executor will ever drain the id and the caller must refuse
+    /// the retry rather than report it as accepted.
     ///
     /// # Panics
     /// Panics if the internal mutex is poisoned.
-    pub fn push(&self, item_id: &str) {
-        self.inner.lock().expect("retry-queue mutex poisoned").insert(item_id.to_owned());
+    #[must_use]
+    pub fn push(&self, item_id: &str) -> bool {
+        let mut guard = self.inner.lock().expect("retry-queue mutex poisoned");
+        match guard.queue.as_mut() {
+            Some(set) => {
+                set.insert(item_id.to_owned());
+                true
+            }
+            None => false,
+        }
     }
 
     /// Remove and return true if the item is queued for retry.
@@ -343,7 +378,12 @@ impl RetryQueue {
     /// Panics if the internal mutex is poisoned.
     #[must_use]
     pub fn take(&self, item_id: &str) -> bool {
-        self.inner.lock().expect("retry-queue mutex poisoned").remove(item_id)
+        self.inner
+            .lock()
+            .expect("retry-queue mutex poisoned")
+            .queue
+            .as_mut()
+            .is_some_and(|set| set.remove(item_id))
     }
 
     /// Remove and return every queued item id (order unspecified).
@@ -357,6 +397,80 @@ impl RetryQueue {
     /// Panics if the internal mutex is poisoned.
     #[must_use]
     pub fn drain_all(&self) -> Vec<String> {
-        self.inner.lock().expect("retry-queue mutex poisoned").drain().collect()
+        self.inner
+            .lock()
+            .expect("retry-queue mutex poisoned")
+            .queue
+            .as_mut()
+            .map(|set| set.drain().collect())
+            .unwrap_or_default()
+    }
+
+    /// Close the queue only if nothing is queued. Returns `true` when it is
+    /// now closed.
+    ///
+    /// Checked and closed under one lock acquisition, so a concurrent
+    /// [`RetryQueue::push`] either lands before the close — reported here as
+    /// `false`, obliging the caller to drain again — or is refused after it.
+    /// No ordering exists in which a push succeeds and is then dropped.
+    ///
+    /// # Panics
+    /// Panics if the internal mutex is poisoned.
+    #[must_use]
+    pub fn close_if_empty(&self) -> bool {
+        let mut guard = self.inner.lock().expect("retry-queue mutex poisoned");
+        match guard.queue.as_ref() {
+            Some(set) if !set.is_empty() => false,
+            _ => {
+                guard.queue = None;
+                true
+            }
+        }
+    }
+
+    /// Close the queue unconditionally, moving anything still queued to the
+    /// orphan list for [`RetryQueue::take_orphaned`]. Idempotent.
+    ///
+    /// Used on the run-halting paths (cancel, pause), where remaining retries
+    /// will not be executed but the queue must stop accepting new ones in the
+    /// same instant.
+    ///
+    /// # Panics
+    /// Panics if the internal mutex is poisoned.
+    pub fn close(&self) {
+        let mut guard = self.inner.lock().expect("retry-queue mutex poisoned");
+        if let Some(set) = guard.queue.take() {
+            guard.orphaned.extend(set);
+        }
+    }
+
+    /// Record ids that were drained but not executed, so they are reported by
+    /// [`RetryQueue::take_orphaned`] rather than lost.
+    ///
+    /// [`RetryQueue::drain_all`] removes ids from the queue before executing
+    /// them; a halt part-way through the drained batch would otherwise drop the
+    /// remainder with their database row left `applying` and no record of why.
+    ///
+    /// # Panics
+    /// Panics if the internal mutex is poisoned.
+    pub fn orphan<I: IntoIterator<Item = String>>(&self, item_ids: I) {
+        self.inner.lock().expect("retry-queue mutex poisoned").orphaned.extend(item_ids);
+    }
+
+    /// Take the ids accepted but never executed, so their `applying` database
+    /// row can be restored. Draining, so two callers cannot both act on the
+    /// same id.
+    ///
+    /// # Panics
+    /// Panics if the internal mutex is poisoned.
+    #[must_use]
+    pub fn take_orphaned(&self) -> Vec<String> {
+        std::mem::take(&mut self.inner.lock().expect("retry-queue mutex poisoned").orphaned)
+    }
+}
+
+impl Default for RetryQueue {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/crates/fs/executor/src/run/tests.rs
+++ b/crates/fs/executor/src/run/tests.rs
@@ -255,7 +255,11 @@ impl ExecutorCallbacks for RetryOnFailureCallbacks {
         Box::pin(async move {
             if event.item_id == "item-1" && event.new_state == "failed" {
                 let _ = std::fs::remove_file(&conflicting_destination);
-                retry_queue.push("item-1");
+                // The run is still live here, so the queue must accept. Asserting
+                // rather than discarding keeps this fixture honest: a silently
+                // refused push is exactly the failure `push`'s return value now
+                // reports, and the test would otherwise pass without retrying.
+                assert!(retry_queue.push("item-1"), "queue must accept while the run is live");
             }
             events.lock().await.push(event);
         })
@@ -349,7 +353,10 @@ impl ExecutorCallbacks for CancelDuringRetryDrainCallbacks {
         let cancel = self.cancel.clone();
         Box::pin(async move {
             if event.item_id == "item-1" && event.new_state == "succeeded" {
-                retry_queue.push("item-2");
+                // Pushed BEFORE cancelling, so the queue is still open and must
+                // accept. Ordering matters: after `cancel()` the queue closes and
+                // this push would legitimately return false.
+                assert!(retry_queue.push("item-2"), "queue must accept before cancellation");
                 cancel.cancel();
             }
             events.lock().await.push(event);
@@ -442,4 +449,218 @@ fn cancellation_token_default_not_cancelled() {
     assert!(!tok.is_cancelled());
     tok.cancel();
     assert!(tok.is_cancelled());
+}
+
+// ── retry-queue lifecycle (astro-plan-ts1z) ───────────────────────────────
+
+#[test]
+fn a_closed_queue_refuses_pushes() {
+    let q = RetryQueue::new();
+    assert!(q.push("item-1"), "an open queue accepts");
+    assert_eq!(q.drain_all(), vec!["item-1".to_owned()]);
+
+    assert!(q.close_if_empty(), "an empty queue closes");
+    assert!(
+        !q.push("item-2"),
+        "a closed queue must REFUSE, not silently accept an id nothing will drain — \
+         a silently accepted retry is swept to 'cancelled' without executing"
+    );
+    assert!(q.drain_all().is_empty(), "the refused id must not be queued");
+    assert!(q.take_orphaned().is_empty(), "a refused push is not an orphan; it never became one");
+}
+
+#[test]
+fn close_if_empty_refuses_to_close_over_a_queued_retry() {
+    let q = RetryQueue::new();
+    assert!(q.push("item-1"));
+    assert!(
+        !q.close_if_empty(),
+        "closing over a queued retry would drop it; the caller must drain and re-try the close"
+    );
+    assert!(q.push("item-2"), "the queue is still open, so pushes still land");
+}
+
+#[test]
+fn unconditional_close_reports_undrained_ids_as_orphans() {
+    let q = RetryQueue::new();
+    assert!(q.push("item-1"));
+    q.close();
+
+    assert!(!q.push("item-2"), "close is a one-way door");
+    assert_eq!(
+        q.take_orphaned(),
+        vec!["item-1".to_owned()],
+        "an accepted-but-unexecuted retry must be reported so its DB row can be restored"
+    );
+    assert!(q.take_orphaned().is_empty(), "take_orphaned drains, so two callers cannot both act");
+}
+
+/// Callbacks that file a retry for `chained` while `first` is being
+/// re-executed from the retry queue.
+///
+/// `drain_retries` works from a snapshot of the queue, so an id pushed during a
+/// re-execution is NOT in the batch being drained. It can only run if something
+/// drains again after the forward loop is done — which is the joint
+/// close-with-final-drain.
+#[derive(Clone)]
+struct ChainedRetryCallbacks {
+    events: Arc<Mutex<Vec<ItemProgressEvent>>>,
+    retry_queue: RetryQueue,
+    /// Filed when the forward pass finishes this item.
+    first: String,
+    /// Filed while `first` is being re-executed from the queue.
+    chained: String,
+    accepted: Arc<Mutex<Vec<(String, bool)>>>,
+}
+
+impl ExecutorCallbacks for ChainedRetryCallbacks {
+    fn on_item_start(
+        &self,
+        _item_id: &str,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        Box::pin(async {})
+    }
+
+    fn on_item_progress(
+        &self,
+        event: ItemProgressEvent,
+    ) -> std::pin::Pin<Box<dyn std::future::Future<Output = ()> + Send + '_>> {
+        let events = self.events.clone();
+        let retry_queue = self.retry_queue.clone();
+        let first = self.first.clone();
+        let chained = self.chained.clone();
+        let accepted = self.accepted.clone();
+        Box::pin(async move {
+            if event.new_state == "succeeded" {
+                // The forward pass of the last plain item files the first retry.
+                if event.item_id == "item-forward" {
+                    let ok = retry_queue.push(&first);
+                    accepted.lock().await.push((first.clone(), ok));
+                }
+                // `first` re-executing means we are inside a drain batch that
+                // was already snapshotted, so this push lands outside it.
+                else if event.item_id == first && event.prior_state == "applying" {
+                    let ok = retry_queue.push(&chained);
+                    accepted.lock().await.push((chained.clone(), ok));
+                }
+            }
+            events.lock().await.push(event);
+        })
+    }
+}
+
+/// astro-plan-ts1z windows (b) and (c): a retry the queue ACCEPTED must be
+/// executed by the run that accepted it. There must be no interval in which
+/// acceptance succeeds and nothing drains the id.
+///
+/// `item-chained` is pushed while `item-first` is being re-executed, i.e. after
+/// `drain_retries` took its batch snapshot and after the forward loop's last
+/// drain point. Before the joint close-with-final-drain, that id sat in a queue
+/// nobody read again: the run completed, and the caller's completion sweep
+/// converted the item's `applying` row to `cancelled` without it ever running.
+///
+/// Both retry targets carry `current_state: "failed"` — a pre-pause failure a
+/// resumed run holds only for `item_by_id` lookup — so the forward loop skips
+/// them as terminal and the retry drain is the only path that can execute them.
+#[tokio::test]
+async fn a_retry_accepted_after_the_last_drain_snapshot_is_still_executed() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = utf8(dir.path());
+    let src_fwd = root.join("forward.fits");
+    let dst_fwd = root.join("forward_dst.fits");
+    let src_first = root.join("first.fits");
+    let dst_first = root.join("first_dst.fits");
+    let src_chained = root.join("chained.fits");
+    let dst_chained = root.join("chained_dst.fits");
+    for p in [&src_fwd, &src_first, &src_chained] {
+        std::fs::write(p, b"x").unwrap();
+    }
+
+    let forward = make_move_item("item-forward", &src_fwd, &dst_fwd);
+    let first = ExecutorItem {
+        current_state: "failed".to_owned(),
+        ..make_move_item("item-first", &src_first, &dst_first)
+    };
+    let chained = ExecutorItem {
+        current_state: "failed".to_owned(),
+        ..make_move_item("item-chained", &src_chained, &dst_chained)
+    };
+
+    let retry = RetryQueue::new();
+    let callbacks = ChainedRetryCallbacks {
+        events: Arc::new(Mutex::new(Vec::new())),
+        retry_queue: retry.clone(),
+        first: "item-first".to_owned(),
+        chained: "item-chained".to_owned(),
+        accepted: Arc::new(Mutex::new(Vec::new())),
+    };
+    let cancel = CancellationToken::new();
+    let skip = SkipSet::new();
+
+    let outcome =
+        execute_plan(vec![forward, first, chained], &callbacks, &cancel, &skip, &retry).await;
+
+    assert_eq!(
+        *callbacks.accepted.lock().await,
+        vec![("item-first".to_owned(), true), ("item-chained".to_owned(), true)],
+        "both retries were ACCEPTED, so both must be executed — an accepted retry that never \
+         runs is swept to 'cancelled' and reads as a cancellation the user asked for"
+    );
+    match outcome {
+        ApplyOutcome::Completed(counts) => assert_eq!(
+            counts.succeeded, 3,
+            "the forward item plus BOTH accepted retries; a chained retry accepted outside the \
+             drain snapshot must not be dropped"
+        ),
+        other => panic!("expected Completed, got {other:?}"),
+    }
+    assert!(!src_chained.exists(), "the chained retry's source really moved");
+    assert!(dst_chained.exists(), "the chained retry's destination really exists");
+    assert!(
+        retry.take_orphaned().is_empty(),
+        "an executed retry is not an orphan; nothing needs restoring"
+    );
+    assert!(
+        !retry.push("item-first"),
+        "execute_plan must leave the queue CLOSED, so a later retry is refused rather than \
+         accepted onto a queue nobody will read"
+    );
+}
+
+/// The halting paths (cancel, pause) must leave an accepted-but-unexecuted
+/// retry visible as an orphan rather than dropping it: its DB row is already
+/// `applying`, and only the caller can restore it.
+#[tokio::test]
+async fn a_retry_accepted_but_not_executed_before_a_cancel_becomes_an_orphan() {
+    let dir = tempfile::tempdir().unwrap();
+    let root = utf8(dir.path());
+    let src1 = root.join("a.fits");
+    let dst1 = root.join("a_dst.fits");
+    std::fs::write(&src1, b"a").unwrap();
+
+    let retry = RetryQueue::new();
+    assert!(retry.push("item-never-run"), "the retry is accepted before the run halts");
+
+    let cancel = CancellationToken::new();
+    cancel.cancel();
+    let callbacks = FakeCallbacks::default();
+    let skip = SkipSet::new();
+
+    let outcome = execute_plan(
+        vec![make_move_item("item-1", &src1, &dst1)],
+        &callbacks,
+        &cancel,
+        &skip,
+        &retry,
+    )
+    .await;
+
+    assert!(matches!(outcome, ApplyOutcome::Cancelled(_)), "got {outcome:?}");
+    assert_eq!(
+        retry.take_orphaned(),
+        vec!["item-never-run".to_owned()],
+        "the caller must be able to see the retry it accepted but never ran, or the item is \
+         swept to 'cancelled' with no record that a retry was owed"
+    );
+    assert!(!retry.push("late"), "a halted run's queue is closed");
 }


### PR DESCRIPTION
Closes two of the three windows recorded on `astro-plan-ts1z`. Window (a) landed
in #1647; this covers (b) and (c). The bead stays open pending review.

## What changed

`retry_plan_item` could accept a retry that no executor would ever drain. The
item's row stayed `applying`, and run completion swept it to `cancelled`: the
file unmoved, the audit trail reading as a cancellation the user asked for.

- `RetryQueue` has a one-way open to closed lifecycle. `push` returns whether the
  id was accepted; a closed queue refuses.
- `execute_plan` closes the queue on every exit path. On the completion path it
  closes jointly with a final drain: `close_if_empty` checks and closes under one
  lock acquisition, so a push either lands before the close and is executed, or
  is refused after it.
- `retry_plan_item` honors a refusal. It rolls the item back to `failed` and
  returns a recoverable error instead of reporting a retry it could not deliver.
- The cancel and pause paths close the queue and report undrained ids as orphans.
  `restore_unexecuted_retries` puts each row back to `failed` with a
  `retry.not_executed` audit reason before the completion sweep runs.

Window (b), a retry landing while `resume_plan` swaps the registry entry, is
closed: the pre-pause queue is already closed, so such a retry is refused with the
item left `failed` rather than accepted onto a queue the swap discards.

Window (c), a retry enqueued onto the live queue before the run completes, is
closed for the completion path by the joint close-with-final-drain. On the cancel
and pause paths the retry cannot execute, so the outcome is the distinguishable
one the bead names as the minimum: the item reads `failed` and retryable, with
`retry.not_executed` recording why, in place of `cancelled`.

Constitution II is unaffected. The item's `applying` row is still written before
any filesystem action is attempted.

## Test plan

- `cargo test -p fs_executor`: 123 pass, up from 118.
- `cargo test -p app_core --lib`: 352 pass, up from 351.
- `cargo test -p app_core --test plan_resume_integration`: 9 pass, 15 of 15
  consecutive runs, with no `nextest` retries and no sleep-based waits.
- `cargo clippy --workspace --all-targets -- -D warnings`: clean.
- `cargo fmt --all --check`: clean.

Each new test was mutation-verified by reinstating the defect. Every one failed on
an assertion:

| Mutation | Failure |
|---|---|
| Remove the joint close-with-final-drain | `succeeded left: 2, right: 3` |
| `push` always accepts | "a closed queue must REFUSE…" |
| `close` drops instead of orphaning | `left: [], right: ["item-1"]` |
| `close_if_empty` ignores contents | "closing over a queued retry would drop it" |
| `restore_unexecuted_retries` is a no-op | `item_state left: "applying", right: "failed"` |

`resume_then_retry_of_pre_pause_failed_item_reaches_terminal_state`, which timed
out on CI when the race fired, passed 15 of 15 locally. Local green is weak
evidence here: the bead records that the race never reproduced locally at all, so
CI on this branch is the real check.

Tracks-Bead: astro-plan-ts1z
Merge-Bead: astro-plan-ciqn
