### PR TITLE
docs: record why the app stays on Tauri rather than a Rust-native UI toolkit

### DIFF
--- a/docs/research/2026-08-17-gui-toolkit-evaluation.md
+++ b/docs/research/2026-08-17-gui-toolkit-evaluation.md
@@ -1,0 +1,511 @@
+# PlateVault UI toolkit assessment: Tauri vs Rust-native GUI
+
+Date: 2026-08-17. Evidence base: `origin/main` at fetch time; crates.io API; GitHub API; upstream READMEs/docs.
+
+Verdict: **stay on Tauri.** Two facts decide it, both verified below: no Rust-native
+toolkit currently meets the stated WCAG-AA/screen-reader bar with a shipped, tested
+implementation, and the migration would discard ~90k lines of non-test TS/TSX plus
+~55k lines of frontend tests. A third fact makes the question moot as a coupling
+problem: the core is already contract-separated, so Tauri is a replaceable shell,
+not an architectural commitment.
+
+---
+
+## 1. Verified requirements
+
+### Accessibility (decisive)
+
+`PRODUCT.md` "Accessibility & Inclusion": "Target WCAG AA. Support keyboard-first
+navigation for review workflows, visible focus states, reduced-motion operation,
+semantic status/error messaging, and clear differentiation that does not rely on
+color alone." This is a product-level commitment, not a nice-to-have.
+
+The frontend already implements against it: 541 `aria-*` attribute occurrences in
+non-test TS/TSX (`rg` count over `apps/desktop/src`), `eslint-plugin-jsx-a11y@6.10.2`
+in `apps/desktop/package.json`, a contrast checker at
+`apps/desktop/scripts/check-contrast.mjs`, and a dedicated journey
+`docs/journeys/J16-keyboard-first-navigation/journey.md` ("Drive PlateVault end to
+end without a pointer", version 4, last_reviewed 2026-07-14).
+
+Note: WCAG AA is a *web* conformance standard. It is authored against a DOM
+accessibility tree. A native toolkit can satisfy the intent (screen reader, focus,
+keyboard) but cannot be audited against WCAG the same way, and every existing
+axe/jsx-a11y check would become unrunnable. That is a requirements regression, not
+just a port.
+
+### Shell capabilities in use
+
+From `apps/desktop/src-tauri/Cargo.toml` and the registrations in
+`apps/desktop/src-tauri/src/lib.rs` (`plugin(` at lines 125, 166, 193, 194, 202,
+203, 217, 228, 239):
+
+| Capability | Plugin | Registration |
+| --- | --- | --- |
+| Single instance (guards canonical SQLite) | `tauri-plugin-single-instance` | lib.rs:125, gated by `bootstrap::single_instance_guard_enabled` |
+| Window geometry persistence | `tauri-plugin-window-state` | lib.rs:166 |
+| Native file/folder pickers | `tauri-plugin-dialog` | lib.rs:193 |
+| Reveal in OS / open URL | `tauri-plugin-opener` | lib.rs:194 |
+| Signed auto-update | `tauri-plugin-updater` | lib.rs:202 via `build_updater_plugin()` |
+| Restart/exit | `tauri-plugin-process` | lib.rs:203 |
+| Rotating file log | `tauri-plugin-log` | lib.rs:217 |
+| MCP bridge (dev) | `tauri-plugin-mcp-bridge` | lib.rs:228 |
+| WebDriver server (e2e feature) | `tauri-plugin-webdriver` 0.2 | lib.rs:239 |
+
+Corrections to the brief's assumed list: `tauri-plugin-notification` is **not** a
+dependency (audit `docs/research/tauri-plugin-api-audit-2026-07-05.md` recommends it
+as an unadopted item, ranked #5). There is no native-menu plugin. Two plugins the
+brief omitted are present: `mcp-bridge` and `webdriver`.
+
+Updater is real, not aspirational: `apps/desktop/src-tauri/tauri.conf.json` carries a
+minisign `pubkey`, `createUpdaterArtifacts: true`, and a GitHub releases endpoint.
+
+Splash/window handshake: main window ships `"visible": false` and the splash owns the
+reveal after a boot-ready handshake (lib.rs:162-165 comments).
+
+### Frontend surface (what a rewrite discards)
+
+Measured by extracting `apps/desktop/src` + `apps/desktop/tokens` from `origin/main`:
+
+| Metric | Count |
+| --- | --- |
+| Files under `apps/desktop/src` | 744 |
+| `.tsx` files | 397 |
+| `.ts` files | 300 |
+| Test/spec files | 271 |
+| Total TS/TSX lines | 145,704 |
+| — non-test | 90,419 |
+| — test | 55,285 |
+| `.css.ts` (vanilla-extract) files / lines | 28 / 2,071 |
+| Feature components (`features/**/*.tsx`, non-test) | 144 |
+| Shared components (`components/`) | 24 |
+| UI primitives (`ui/`) | 21 |
+| Design-token JSON files | ~19 incl. 6 themes, 2 density modes, 6 component groups |
+| i18n messages (`messages/en-GB.json`) | 2,254 keys |
+| Locales (`project.inlang/settings.json`) | 2 — `en-GB`, `pt-BR` |
+| Playwright specs (`tests/e2e/*.spec.ts`) | 35 |
+| Rust e2e journeys (`crates/e2e-tests/tests/`) | 16 test files |
+| Journey docs (`docs/journeys/`) | J01–J16+ |
+
+The vanilla-extract token pipeline (`style-dictionary@5.5.0` → `tokens/*.json` →
+`.css.ts`) is recent sunk cost, plus `size-limit` bundle guards
+(`specs/028-frontend-quality-hardening/tasks.md:120-126`).
+
+### Validation harness
+
+Two layers, both webview-dependent:
+
+- Layer 1: Playwright, 35 specs, mock-mode frontend. `tests/e2e/playwright.config.ts`
+  documents a dedicated e2e port because concurrent worktrees collide on 5173.
+- Layer 2: `crates/e2e-tests` — thirtyfour W3C client → `tauri-webdriver` CLI on :4444
+  → embedded `tauri-plugin-webdriver` on :4445, real backend, real SQLite
+  (`crates/e2e-tests/README.md`).
+
+A native toolkit destroys both. Replacements exist (`egui_kittest` 0.36.1,
+`iced_test` 0.14.0, `freya-testing` 0.4.1, `masonry-testing` 0.4.0) but they are
+in-process widget harnesses, not out-of-process app drivers. There is no
+`driver.click(selector)` equivalent that exercises the real shipped binary.
+
+### Backend scale (the counterweight)
+
+236 files under `crates/app`, 473 crate source files overall, 45 files in
+`packages/contracts`. Constitution Principle V already mandates language-neutral
+contracts with Tauri as "the first adapter". The UI is one adapter of a large,
+already-portable core — which is exactly why swapping it buys less than it appears to.
+
+---
+
+## 2. Candidate assessment
+
+All versions/dates from the crates.io API and GitHub API on 2026-08-17.
+
+### Not peers (stated as the brief asked)
+
+- **masonry** 0.4.0 (2025-10-29, Apache-2.0) is Xilem's widget layer, published from
+  the same repo `linebender/xilem`. Its own README: "Masonry is a toolkit for
+  building UI frameworks (including Xilem)". Scoring it separately would double-count.
+- **crux** (`crux_core` 0.20.0, 2026-08-07) is a core/shell architecture pattern with
+  no renderer. It is a *shape* PlateVault already substantially has via
+  `packages/contracts` + `crates/app`. It is assessed in §4 as a middle option, not
+  as a UI candidate.
+
+### iced 0.14.0 — 2025-12-07, MIT, 31.3k stars
+
+Wide widget inventory including `table.rs`, `pane_grid`, `combo_box`, `text_editor`,
+`lazy`/`keyed` (virtualisation primitives) — 49 modules in `widget/src`.
+
+**Accessibility: none shipped.** Verified: `iced 0.14.0` and `iced_winit 0.14.0` have
+zero `accesskit*` dependencies (crates.io dependency API). `iced-rs/iced#552`
+"Implement accessibility support" — open since 2020-10-05, last activity 2026-02-04,
+26 comments, still discussing whether AccessKit is the right start. PR #3111
+"draft: Accesskit integration" and #1849 "WIP: Iced accessibility" both open,
+last touched 2026-05-22. #489 (open, 2026-05-24): "In native UI, cannot focus most
+widgets, control them via keyboard, or tab between widgets."
+
+**USP for PlateVault:** the strongest table + pane-splitting widget set of any
+candidate, an Elm-style message architecture that maps cleanly onto the existing
+contract call/response shape, and `iced_test` for deterministic UI assertions.
+
+**Verdict: NOT-VIABLE.** Cannot tab between widgets. Fails the keyboard-first
+requirement at the framework level, not the app level.
+
+### egui 0.36.1 — 2026-08-07, MIT OR Apache-2.0, 30.1k stars
+
+Fastest cadence of any candidate (0.34.1 → 0.36.1 across 2026-03 to 2026-08).
+**Non-optional `accesskit ^0.24.1` dependency** — the only mature candidate where a11y
+is always compiled in, verified via crates.io deps (`optional: false`).
+
+Gaps: a11y is not on by default in the demo (emilk/egui#2960 open, 2026-03-04); live
+regions unimplemented (#2647 open since 2022-02-08) — that directly hits PRODUCT.md's
+"semantic status/error messaging". Immediate-mode retained state is a poor fit for
+144 stateful feature components with forms, wizards, and dialogs. No native menus,
+no text selection parity, and re-laying-out every frame is a battery/GPU cost on a
+desk app that is mostly static tables.
+
+**USP for PlateVault:** unmatched release cadence; a11y always-on rather than
+opt-in; `egui_kittest` gives snapshot-tested UI in-process; trivially embeds
+custom-drawn views (sky charts, coverage bars).
+
+**Verdict: VIABLE-WITH-GAPS** (missing live regions; immediate-mode misfit for
+form-heavy screens; no native menu).
+
+### xilem 0.4.0 / masonry 0.4.0 — 2025-10-29, Apache-2.0, 5.5k stars
+
+AccessKit is an explicit architectural pillar (README: "AccessKit for plugging into
+accessibility APIs"); `masonry 0.4.0` depends on `accesskit ^0.21.1`. Widget set is
+respectable for its age — 38 modules including `virtual_scroll.rs`, `grid.rs`,
+`split.rs`, `text_input.rs`, `radio_group.rs`, `collapse_panel.rs`.
+
+Killers: 9,795 lifetime downloads for `xilem` (vs 2.5M for iced, 21.6M for egui) —
+effectively no production user base to have found the bugs. Last release 2025-10-29,
+nearly 10 months before this assessment, on a 0.x line. No `table` widget. AccessKit
+pinned two majors behind current (0.21 vs 0.24.1).
+
+**USP for PlateVault:** the only candidate with a first-class retained widget tree
+*and* AccessKit designed in from the start, plus `virtual_scroll` built in and the
+Vello/Parley text stack (best text shaping of the native set — relevant for the
+typography rework, spec 055).
+
+**Verdict: VIABLE-WITH-GAPS** — technically the best-architected fit, but adopting a
+framework with 9.8k downloads for a product heading to release is taking on
+upstream maintenance you did not budget for.
+
+### dioxus 0.7.10 stable / 0.8.0-alpha.1 — 2026-07-31, MIT OR Apache-2.0, 38.8k stars
+
+Highest star count; strong cadence. But `dioxus-desktop 0.7.10` depends on `wry` —
+**it is a webview**, i.e. the same WebView2/WebKitGTK substrate as Tauri. Migrating
+to Dioxus desktop does not escape any webview problem; it trades React for RSX and
+loses the plugin ecosystem. Its native path is `blitz` (`blitz-dom 0.3.0-beta.1`,
+stable 0.2.4, AccessKit ^0.17 — three majors behind), which the Dioxus README itself
+labels "Experimental Native Renderer".
+
+**USP for PlateVault:** the only candidate offering an incremental, component-by-
+component port path from React (same reactive model, HTML/CSS styling, so the
+vanilla-extract tokens have a survivable analogue) with a future native escape hatch.
+
+**Verdict: NOT-VIABLE as a native migration** (webview-backed today, experimental
+native renderer). Would be VIABLE-WITH-GAPS purely as a React replacement — but that
+is a different, lower-value project.
+
+### slint 1.17.1 — 2026-07-07, 23.5k stars
+
+The only **1.x** candidate: real semver stability guarantees, an `accessibility`
+cargo feature, `accesskit` + `accesskit_winit` in `i-slint-backend-winit 1.17.1`
+(verified via crates.io deps), and the richest documented a11y vocabulary of any
+candidate — 21 `accessible-*` properties, 21 `AccessibleRole` values including
+`table`, `list-item`, `radio-group`, plus ARIA-style landmark roles and
+`accessible-live` (`off`/`polite`/`assertive`) for status announcements. That last
+one is the exact PRODUCT.md "semantic status/error messaging" requirement, and no
+other candidate documents it. `tree` role documented as not yet provided.
+
+**Licence problem.** Crate licence is
+`GPL-3.0-only OR LicenseRef-Slint-Royalty-free-2.0 OR LicenseRef-Slint-Software-3.0`.
+PlateVault is AGPL-3.0-only (SPDX headers throughout, e.g. `apps/desktop/src/lib/i18n.ts`).
+GPL-3.0-only is **not** compatible with AGPL-3.0-only in the direction needed: you
+cannot ship AGPL-3.0-only code linked against a GPL-3.0-only library without the
+combination being unlicensable, because AGPL-3.0-only lacks the §13 relicensing
+grant that AGPL-3.0-or-later would provide. The Royalty-free option is for
+*proprietary* apps and Slint requires per-seat licensing for everyone touching
+design/dev/test. **This requires a licence-policy decision, not an engineering one.**
+
+Also: a custom DSL (`.slint`) means the entire 90k-line TS surface is rewritten in a
+language with no ecosystem, and the DSL is compiled — no hot-swap of business logic.
+
+**USP for PlateVault:** the only 1.x-stable candidate; the only one with documented
+live-region support and a `table` accessible role; `system-testing` feature and a
+commercial GUI test framework; commercial support available.
+
+**Verdict: VIABLE-WITH-GAPS, blocked on licence.** Technically the closest match to
+the a11y requirement of any native candidate. Escalate the AGPL-3.0-only × GPL-3.0-only
+question before spending further effort.
+
+### gpui 0.2.2 — 2025-10-22, Apache-2.0, published from zed-industries/zed (88.7k stars)
+
+**Is it consumable standalone?** Partially, and newly so. `gpui` is on crates.io
+(`publish = true` in `crates/gpui/Cargo.toml` at Zed HEAD), first published
+2025-10-05, 0.2.2 on 2025-10-22 — no release in the ~10 months since. The README at
+HEAD documents a public API split into `gpui` + `gpui_platform`, so the published
+0.2.2 surface **already differs from HEAD** and the split is not in a release. The
+README states plainly: "GPUI is still in active development as we work on the Zed
+code editor, and is still pre-1.0. There will often be breaking changes between
+versions." That is the deciding practical fact: you would be tracking a monorepo's
+internal crate, on an API that changed shape since its last publish, with no
+release cadence.
+
+The existence of a third-party `gpui-unofficial 1.15.0` fork chain is itself
+evidence the official crate is not comfortably consumable.
+
+**Licence: Apache-2.0** for the `gpui` crate specifically (its own `Cargo.toml`
+declares `license = "Apache-2.0"`, distinct from the Zed repo's NOASSERTION mix).
+Apache-2.0 is inbound-compatible with AGPL-3.0-only. No licence blocker.
+
+**Accessibility:** better than I expected, and worse than the version numbers admit.
+gpui at HEAD has `accesskit.workspace = true` and a documented guide module
+`crates/gpui/src/_accessibility.rs`: "GPUI integrates with AccessKit to provide
+programmatic accessibility features", with an `examples/a11y` directory and a
+`tab_stop.rs` module. **But the published 0.2.2 has zero `accesskit*` dependencies**
+(verified via crates.io deps: 95 normal deps, none matching). So a11y exists only at
+git HEAD, in an unreleased API, documented as a guide rather than as an audited
+widget inventory. Do not extrapolate from Zed's polish: Zed's own a11y is a
+long-standing gap, and gpui exposes no accessible widget library — the entire
+`AccessibleRole` vocabulary Slint documents has no gpui equivalent.
+
+**Windows/Linux:** HEAD README documents Win32 + DirectWrite on Windows (no features
+needed) and Wayland/X11 features on Linux/FreeBSD, so both are real. But there is no
+widget library at all — gpui gives you `div()`, taffy flexbox layout, and text.
+`crates/gpui/src/platform` contains `app_menu.rs` (native menus exist) but no
+combobox, no date picker, no table, no dialog, no tree.
+
+**Do its strengths match this app?** Partly. GPU-rendered very-long virtualised lists
+are genuinely relevant to large astro libraries. But PlateVault is settings-heavy,
+form-heavy, wizard-heavy, dialog-heavy — 144 feature components and a `WizardShell`
+of 8.3 KB. You would hand-build every control from `div()`. That is the opposite of
+the widget inventory this app needs.
+
+**Verdict: NOT-VIABLE.** Deciding fact: the published 0.2.2 has no AccessKit at all,
+its API has already been restructured at HEAD without a release, and it ships no
+widget library for a form-heavy app.
+
+### azul — `azul` 1.0.0-alpha4 (2021-08-05), MIT, 6.1k stars
+
+The git repo is *very* active — `fschutt/azul` pushed 2026-08-17, commits that same
+day, and `azul-core 0.0.14` published 2026-08-17 (with `azul-layout 0.0.14` depending
+on `accesskit ^0.24`, the current major). So "dormant" is wrong as a repo claim.
+
+But the consumable story is the classic docs/reality gap, and worse than the brief
+feared. The `azul` façade crate's newest version is `1.0.0-alpha4` from **2021-08-05**;
+`max_stable_version` is `0.1.0` from 2018. `azul-desktop` last published 2020-05-14.
+Only the internal `azul-core`/`azul-layout` crates are being released in 2026. And
+the README at HEAD says it outright:
+
+> **This repository is currently under heavy development. Azul is NOT usable yet.**
+> APIs may change frequently and features may be incomplete or unstable. […]
+> The current release is from 2+ years ago.
+
+Its build path also runs a codegen multitool (`azul-doc codegen all`) to produce the
+public API — a bespoke pipeline, not `cargo add`.
+
+**Licence: MIT** — inbound-compatible with AGPL-3.0-only. No blocker. (Note the
+internal crates relicensed MPL-2.0 → MIT between 0.0.8 (2026-05-23) and 0.0.9
+(2026-07-14); both are fine inbound.)
+
+**USP for PlateVault:** an HTML/CSS-like DOM model with a language-neutral generated
+C API — in principle the least-alien port target for an existing CSS-styled app, and
+the AccessKit version it tracks is current. That is a real technical thesis.
+
+**Verdict: NOT-VIABLE.** Deciding fact: the project's own README at HEAD states it is
+not usable, and the consumable façade crate has not been published since 2021. Nothing
+about a11y, updaters, or tables needs evaluating past that.
+
+### cushy 0.4.0 — 2024-08-20, MIT OR Apache-2.0, 606 stars
+
+Last publish nearly two years ago; last repo push 2025-09-04; no `accesskit`
+dependency found in the AccessKit reverse-dependency list.
+**Verdict: NOT-VIABLE** (effectively unmaintained relative to a release timeline; no
+a11y). No USP that another candidate does not cover better.
+
+### freya 0.4.1 stable / 0.5.0-rc.3 — 2026-08-16, MIT, 3.0k stars
+
+Active (0.4.0 → 0.5.0-rc.3 in one month). `freya-core 0.4.1` depends on
+`accesskit ^0.24.0` — **current major**, matching egui. Has `freya-testing 0.4.1`.
+Skia renderer; Dioxus-style RSX components, so React-familiar.
+
+Gaps: 37.7k lifetime downloads, 44 open issues, 3.0k stars — smallest active
+community of the viable set. Rapid pre-1.0 churn (an rc every week). No table widget.
+No updater/single-instance/window-state story; also ships `freya-webview`, implying
+some things still need a webview.
+
+**USP for PlateVault:** the only candidate combining a *current* AccessKit major, a
+React-like component model (cheapest mental port from the existing 144 components),
+and a first-party testing crate.
+
+**Verdict: VIABLE-WITH-GAPS** (community size and pre-1.0 churn are the risk, not
+the a11y story).
+
+---
+
+## 3. Comparison table
+
+| Candidate | Version / date | Licence | Maturity | Accessibility | Required-capability gaps | Verdict |
+| --- | --- | --- | --- | --- | --- | --- |
+| **Tauri (incumbent)** | 2.11.5, 2026-07-01 | MIT/Apache-2.0 | 2.x stable, 26.1M dl | DOM a11y + platform screen readers; 541 aria uses in-repo | — (all 8 capabilities in use) | **BASELINE** |
+| iced | 0.14.0, 2025-12-07 | MIT | 0.x, 2.5M dl, 31.3k★ | **None.** #552 open since 2020; #489: cannot tab between widgets | a11y, updater, single-instance, window-state, notifications, native menus, out-of-proc e2e | **NOT-VIABLE** |
+| egui | 0.36.1, 2026-08-07 | MIT/Apache-2.0 | 0.x, 21.6M dl, 30.1k★ | AccessKit 0.24.1 **non-optional** | live regions (#2647), native menus, updater, single-instance, window-state, immediate-mode misfit for 144 form components | **VIABLE-WITH-GAPS** |
+| xilem (+ masonry) | 0.4.0, 2025-10-29 | Apache-2.0 | 0.x, **9.8k dl**, 5.5k★, 10mo since release | AccessKit 0.21.1 (2 majors behind), designed-in | table widget, updater, single-instance, window-state, notifications, community size | **VIABLE-WITH-GAPS** |
+| dioxus | 0.7.10, 2026-07-30 | MIT/Apache-2.0 | 0.x, 2.3M dl, 38.8k★ | via `wry` webview (same as Tauri); native path AccessKit ^0.17 | **is a webview** — solves no webview problem; native renderer "experimental" | **NOT-VIABLE** (as native migration) |
+| slint | 1.17.1, 2026-07-07 | **GPL-3.0-only** OR royalty-free OR commercial | **1.x stable**, 1.5M dl, 23.5k★ | Best documented: 21 `accessible-*` props, 21 roles, `accessible-live` | **licence × AGPL-3.0-only**, custom DSL discards 90k LOC of TS, `tree` role absent | **VIABLE-WITH-GAPS, licence-blocked** |
+| gpui | 0.2.2, 2025-10-22 | Apache-2.0 | pre-1.0, no release in 10mo; HEAD API ≠ published API | **None in 0.2.2**; AccessKit only at unreleased HEAD | **no widget library** (div + taffy only); no combobox/table/dialog/tree; updater; window-state | **NOT-VIABLE** |
+| azul | 1.0.0-alpha4, **2021-08-05** | MIT | README: "Azul is NOT usable yet" | AccessKit ^0.24 in `azul-layout` only | consumable crate 5 years stale; bespoke codegen build; everything else moot | **NOT-VIABLE** |
+| cushy | 0.4.0, 2024-08-20 | MIT/Apache-2.0 | 6.5k dl, 606★, repo idle since 2025-09 | none found | all | **NOT-VIABLE** |
+| freya | 0.4.1, 2026-08-02 (rc.3 2026-08-16) | MIT | 0.x, 37.7k dl, 3.0k★ | AccessKit **0.24.0** (current) | table widget, updater, single-instance, window-state, community size, weekly rc churn | **VIABLE-WITH-GAPS** |
+| *masonry* | 0.4.0 | Apache-2.0 | — | — | **Not a peer** — xilem's widget layer, same repo | n/a |
+| *crux* | `crux_core` 0.20.0, 2026-08-07 | Apache-2.0 | 339k dl | — | **Not a renderer** — architecture pattern; see §4 | n/a |
+
+Capability-replacement crates all exist if you did migrate: `rfd 0.17.2` (pickers),
+`muda 0.19.3` (menus), `notify-rust 4.18.0`, `tray-icon 0.24.2`,
+`accesskit_winit 0.33.2`, `self_update 0.44.0` / `cargo-packager-updater 0.2.3`.
+The weak one is `single-instance 0.3.3` — last published **2021-12-16**, and the
+canonical-SQLite guard depends on it.
+
+---
+
+## 4. What would migrating actually solve?
+
+### Real, repo-evidenced Tauri pain
+
+There is genuine pain, and it is all one thing: **two divergent webview engines**.
+
+- `docs/development/orchestration-2026-07-06.md` — 14 occurrences of
+  WebView2/WebKitGTK. Documented cases: a Tauri IPC error/race in Windows WebView2
+  that the debug bridge bypasses (:93); a WebView2 layout/virtualizer race on hard
+  refresh (:94); "a green run proves nothing about a fix" (:106); a portal race where
+  `Combobox.Portal` gates rendering (:177); WebView2's async localStorage flush lost
+  on forced process kill, with **different timing on WebKitGTK** (:212-223); storage
+  reset deleting WebView2's EBWebView profile but silently no-op-ing on Linux, so
+  "journeys share webview state on ubuntu" (:311-317).
+- `docs/memory/BUGS.md:61,67` — WSLg cannot render WebKitGTK, so Tauri windows do not
+  work there at all.
+- `docs/development/design-review-2026-07-11.md:286` — a WebView2-specific HWND
+  constraint the app must respect.
+
+That is the honest case *for* migrating: a single Rust renderer would eliminate an
+entire class of platform-divergence bugs and make e2e results mean the same thing on
+every OS. It is a real benefit and should not be waved away.
+
+### What migrating would NOT solve
+
+- **IPC and bindings.** The contract boundary is required by Constitution Principle V
+  independently of the UI toolkit. `specs/037-ipc-wrapper-removal` and
+  `specs/042-stdlib-adoption` (§D "Frontend — type safety & IPC boundary") show this
+  is being actively simplified *within* Tauri. A native UI removes serialisation but
+  the contract stays — and `packages/contracts` exists precisely to keep a future
+  remote backend possible.
+- **`dev-tools` feature gating.** Feature-gating a developer surface out of release
+  builds is a correctness requirement, not a Tauri artefact. It survives any toolkit.
+- **Mock-mode indirection.** Needed to test UI without a backend. Survives any toolkit.
+- **e2e port collisions.** Caused by concurrent worktrees sharing a dev-server port
+  (`tests/e2e/playwright.config.ts` comment), not by Tauri.
+- **Bundle size.** Guarded by `size-limit` and never recorded as a problem.
+
+So of six candidate motivations, exactly one is real, and it is webview divergence.
+
+### The middle options
+
+1. **Reduce IPC surface / keep Tauri.** Already in flight (specs 037, 042). Cheapest,
+   already funded.
+2. **Rust-native shell + existing web UI.** This is what Tauri already *is*. Building
+   your own wry/webview shell to keep the web UI would rebuild eight plugins to
+   arrive at the same substrate and the same WebView2/WebKitGTK divergence. No gain.
+3. **crux-style core/shell separation.** Constitution V arguably already mandates it
+   and `crates/app` + `packages/contracts` largely implement it. The valuable move
+   here is *tightening* that boundary — no UI feature reaching past the contract —
+   which makes any future toolkit swap a bounded project rather than a rewrite.
+   **This is the constructive version of the question.** It costs a fraction of a
+   migration and preserves the option.
+4. **Narrow the divergence instead of the toolkit.** The specific WebKitGTK/WebView2
+   storage and reset asymmetries are addressable directly, and Tauri is moving toward
+   a unified Servo/Verso backend upstream (not verified as production-ready here —
+   see §7).
+
+---
+
+## 5. Recommendation
+
+**Stay on Tauri. Do not migrate.** Instead spend a fraction of the migration budget
+tightening the contract boundary (option 3) so the decision stays reversible, and
+address the WebKitGTK/WebView2 storage-reset asymmetry directly, since that is the
+one Tauri-caused problem with evidence behind it.
+
+The three facts that drive it:
+
+1. **No candidate meets the a11y requirement with shipped, tested code.** The only
+   one whose documented a11y vocabulary actually matches PRODUCT.md — including
+   `accessible-live` for status messaging — is Slint, and Slint's GPL-3.0-only option
+   is incompatible with an AGPL-3.0-only app. iced cannot tab between widgets.
+   gpui's published crate has no AccessKit at all. Every other candidate has AccessKit
+   plumbing but no audited accessible widget inventory, and none has an equivalent of
+   `eslint-plugin-jsx-a11y` + axe + a contrast checker in CI.
+2. **The cost is 145,704 lines of TS/TSX (90,419 non-test), 189 components, 2,254
+   i18n keys across 2 locales, ~19 token files with 6 themes, 35 Playwright specs,
+   and a WebDriver-based real-binary e2e layer** — with no out-of-process journey
+   driver in any native toolkit to replace that last item.
+3. **Tauri is already a thin, replaceable adapter.** Contracts (45 files) and
+   `crates/app` (236 files) hold the value; the webview holds presentation. The
+   architecture the migration would be *for* is largely already there, which means
+   migrating buys portability you already own.
+
+Migration cost if you moved anyway: I would not estimate calendar time, but the
+discarded artefact set is quantified above, and it excludes the a11y remediation
+needed to reach parity on any candidate — which is unbounded, because no candidate
+has a shipped equivalent.
+
+## 6. Strongest argument against this recommendation
+
+**The webview divergence is not a bug class you can finish fixing, and it is already
+corrupting your validation signal.**
+
+`orchestration-2026-07-06.md:106` records that "a green run proves nothing about a
+fix". That is the most serious sentence in the repo for this question: it says the
+project's own e2e harness produced results that could not be trusted, because
+WebView2 and WebKitGTK behave differently in storage flushing, portal rendering, and
+virtualizer layout. The same file documents that a Linux storage reset silently
+no-ops, so ubuntu journeys **share state across journeys**. A test suite with
+undetected cross-test contamination on one of three target platforms is not a working
+suite, and 35 Playwright specs plus 16 Rust journey files are only as valuable as
+that trust.
+
+A single Rust renderer makes those bugs structurally impossible. One layout engine,
+one text stack, one storage story, identical on all three OSes. On that argument, the
+145k lines are not an asset — they are 145k lines written against two engines that
+disagree, and their test coverage partly measures webview quirks rather than product
+behaviour. Anyone who has spent multiple orchestration cycles chasing WebView2 races
+would tell you the sunk cost is exactly what is keeping the pain in place.
+
+The counter-counter — the reason I still land on "stay" — is that this argument
+justifies removing the *divergence*, not the *web platform*, and it does not answer
+the a11y point at all. You would trade a debuggable, documented class of engine
+differences for an undocumented class of missing accessibility, and PRODUCT.md
+commits to the latter in writing. But if the a11y bar were relaxed, or if Slint's
+licence question resolved favourably, this argument would win.
+
+## 7. What I could not determine
+
+- **Whether Tauri's Servo/Verso unified-webview work is production-viable.** This
+  would materially weaken the one real pro-migration argument. Not verified.
+- **Slint licence compatibility as a legal matter.** I established the SPDX conflict
+  (GPL-3.0-only vs AGPL-3.0-only) and that the royalty-free tier targets proprietary
+  apps. Whether a commercial Slint tier resolves it for an AGPL-3.0-only product is a
+  licensing question, not an engineering one. **This is the one open item worth
+  escalating** — Slint is otherwise the best a11y match in the field.
+- **Actual screen-reader behaviour of any candidate.** I read dependency graphs,
+  issue trackers, and docs. I did not run NVDA, VoiceOver, or Orca against any
+  toolkit. "Depends on accesskit" is not "works with NVDA"; treat every a11y column
+  entry as `untested` at the behavioural level.
+- **Current PlateVault a11y conformance.** 541 `aria-*` uses and a J16 journey show
+  intent; the journey is `status: draft` with open issues #747 (Inbox has zero
+  keyboard shortcuts) and #797 (sidebar lacks focus-visible). So the baseline is not
+  perfect either — but it is measurable and remediable, which is the difference.
+- **Whether `crates/e2e-tests` journeys could be reproduced in-process.** The
+  in-process harnesses exist; whether they can express a 16-file journey suite
+  against a real SQLite backend is unproven.
+- **gpui's `gpui_platform` split status.** Documented at HEAD, absent from published
+  0.2.2. I could not determine when or whether it will be released.

--- a/docs/research/2026-08-17-slint-vs-tauri.md
+++ b/docs/research/2026-08-17-slint-vs-tauri.md
@@ -1,0 +1,185 @@
+# Slint vs Tauri for platevault -- greenfield technical comparison
+
+Date: 2026-08-17. Slint version assessed: **1.17.1** (released 2026-07-07, `gh release list --repo slint-ui/slint`; `docs.rs/crate/slint/latest` = 1.17.1). Tauri surface assessed: **tauri 2.x** with plugin set from `apps/desktop/src-tauri/Cargo.toml` at `origin/main`.
+
+Scope per owner: greenfield choice. Migration cost excluded. Accessibility excluded.
+
+Verified vs claimed: statements marked **[verified]** come from a command result or a file at `origin/main`; **[docs]** come from Slint's own documentation or crates.io/GitHub metadata; **[inference]** is reasoning from those.
+
+## Licence -- settled, not re-litigated
+
+GPLv3 §13 permits combining a covered work with an AGPLv3 work into a single combined work, with the AGPL network clause governing the combination. platevault is AGPL-3.0-only (`apps/desktop/src/ui/index.ts:2` SPDX header) [verified]. Slint's free GPLv3 option is therefore compatible at zero cost. The earlier "licence blocks this" verdict was wrong. Slint also sells a Startup & Individual tier (owner reports ~$10/mo) relevant only if platevault were ever closed-sourced; the pricing page lists that tier's eligibility (≤10 employees, ≤2M EUR turnover, <5 years) but no figure in fetched content [docs].
+
+One licence-adjacent cost does exist: Slint's pricing page lists a **GUI Test Framework** as a paid add-on on lower tiers [docs]. The free introspection route is `i-slint-backend-testing`, triple-licensed `GPL-3.0-only OR ...` [docs], which is AGPL-compatible -- see §9.
+
+## 1. Renderers
+
+Slint ships four renderer paths [docs, backends_and_renderers]:
+
+| Renderer | Requirement | Documented tradeoff |
+|---|---|---|
+| Software | none; CPU only | "Runs anywhere, highly portable, and lightweight"; **no rotation/scaling, no `drop-shadow-*`, no `border-radius` with `clip: true`, no text stroking**; "Text rendering currently limited to western scripts" |
+| FemtoVG | OpenGL required (wgpu variant adds Metal/Vulkan/D3D) | "Text and path rendering quality sometimes sub-optimal" |
+| Skia | OpenGL/Metal/Vulkan/D3D | "Heavy disk-footprint compared to other renderers"; documented compile troubles (MSVC 2022 requirement, `BINDGEN_EXTRA_CLANG_ARGS` on ARMv7, Windows paths with spaces) |
+| Qt | Qt present at compile time | "only supports software rendering at the moment" |
+
+`SLINT_BACKEND=winit-software` selects software at runtime [docs].
+
+**Fit for this app.** platevault is table-and-form heavy but not static: it uses Leaflet maps (`apps/desktop/src/shared/observing-sites/SiteLocationPicker.tsx`) [verified], visx SVG charts (`@visx/*` in `apps/desktop/package.json:57-60`) [verified], and animated shells. The software renderer's "no drop-shadow, no scaling, western scripts only" limits are load-bearing: pt-BR is a shipping locale (`apps/desktop/project.inlang/settings.json`) [verified] -- Latin script, so western-only is survivable, but any future non-Latin locale is not. Elevation shadows and rotate transforms would have to be redesigned out.
+
+The GPU-variability argument is real but narrower than it sounds. A webview inherits the host WebView2/WKWebView/WebKitGTK compositor and its driver blocklists; Slint software rendering does eliminate that class of variability outright, at the cost of CPU-bound repaint. Skia reintroduces exactly the same GPU-driver surface the webview has, plus its own build fragility.
+
+I could **not** verify binary size, startup time, or battery numbers for any renderer -- no benchmark was run and Slint publishes none in the pages fetched. Treat all size/startup claims as unmeasured.
+
+**Verdict: Slint wins narrowly on the elimination-of-webview-variability axis (software renderer only), and that win is paid for in missing visual primitives. For a desktop app with maps and charts, Skia is the realistic choice, which forfeits the variability win entirely.** Effectively a draw.
+
+## 2. Internationalisation
+
+Repo baseline [verified]: `@inlang/paraglide-js` ^2.21.0, **2,254 keys in each of `apps/desktop/messages/en-GB.json` and `pt-BR.json`** (counted with a JSON key count, `$`-prefixed keys excluded), 188 lines containing `plural`/`match` in en-GB, compile step `paraglide-js compile --strategy custom-almSettings preferredLanguage baseLocale --emit-ts-declarations` (`apps/desktop/package.json:33`), runtime switching in `apps/desktop/src/data/locale.tsx`, and three CI guards: `check-i18n-catalog.mjs`, `check-i18n-locale-drift.mjs` (`apps/desktop/package.json:16`).
+
+Slint [docs, translations guide]: `@tr("...")` where "the first argument must be a plain string literal"; `{}` and `{0}` interpolation; plurals via `@tr("I have {n} item" | "I have {n} items" % count)`; context via `"ctx" =>` mapping to gettext `msgctx`; extraction with `slint-tr-extractor` → `.pot` → `.po` → `msgfmt` `.mo`.
+
+Two delivery modes, and the difference matters:
+
+- **Runtime gettext**: requires the `gettext` crate feature, catalogs at `dir/locale/LC_MESSAGES/domain.mo`, domain **must equal the Cargo package name**. "For gettext-based loading, locale comes from environment variables set by the OS, so no explicit runtime switch API is documented" [docs].
+- **Bundled**: `with_bundled_translations()`, and `slint::select_bundled_translation` does switch language at runtime [docs]. But "selecting a translation also selects its decimal separator" at compile time [docs].
+
+So in-app locale switching without restart exists only on the bundled path. Paraglide gives it unconditionally, plus typed message functions (`--emit-ts-declarations`) so a missing or renamed key is a **type error**. Slint's `@tr()` takes a literal string: a typo in the msgid silently falls back to the source text -- the exact failure mode paraglide's generated types remove. Gettext plurals cover only the two-form family well; ICU-style select/match in the current catalogue would need restructuring. Tooling: poedit/Lokalize/Transifex for Slint vs the inlang editor plus two custom drift checks already in CI.
+
+**Verdict: Tauri/paraglide wins clearly.** Typed keys, unconditional runtime switching, richer plural forms, and drift enforcement already automated.
+
+## 3. Widget inventory
+
+Slint Std-Widgets, complete list [docs, std-widgets overview]: Palette, StyleMetrics, Button, CheckBox, ComboBox, ProgressIndicator, RadioGroup, Slider, SpinBox, Spinner, StandardButton, Switch, LineEdit, ListView, ScrollView, StandardListView, StandardTableView, TabWidget, TextEdit, GridBox, GroupBox, HorizontalBox, VerticalBox, AboutSlint, **DatePickerPopup**, **TimePickerPopup**. Language-level: `MenuBar`, `ContextMenu` (added 1.10.0, 2025-02-28), `DragArea`/`DropArea` (1.17.0, 2026-06-24), `SystemTrayIcon` (1.17.0) [verified from `CHANGELOG.md` via GitHub API].
+
+Repo primitives exported from `apps/desktop/src/ui/index.ts` [verified]: Pill, Btn, Section, Box, KV, EmptyState, Skeleton, Table (+`tableIndent`), Banner, Toggle, NumberField, SegControl, RadioGroup, CoverageBar, Lock, DirPicker, WizardShell, ToastContainer, InfoTip, Tooltip, ResizeHandle, `useAdaptiveDock`. Plus app-level components on npm libraries: `cmdk` command palette (`apps/desktop/src/app/CommandPalette.tsx`), `@tanstack/react-virtual` in six places (`LogPanel.tsx`, `useFollowTail.ts`, `TargetSearch.tsx`, `useTargetSearch.ts`, `CalendarScroll.tsx`, `TargetList.tsx`), `react-joyride` tours, `react-hook-form` + `zod` forms, `@base-ui-components/react` for overlays [verified].
+
+Concrete gap table:
+
+| Need | Slint status | Work required |
+|---|---|---|
+| Virtualised long list | **Has it.** ListView: "elements are only instantiated if they are visible, which guarantees stable performance" with a "practically unlimited number of items" [docs] | none |
+| Virtualised table | Partial. StandardTableView reuses ListView optimisation (CHANGELOG 1.2.x "use `ListView` optimization for all styles" #3425) [verified] | see next row |
+| **Rich table cells** | **Missing.** StandardTableView rows are `StandardListViewItem` whose only documented field is `text` [docs] -- no per-cell buttons, pills, icons, progress bars | Hand-roll a table on ListView + layouts. This is the single largest build item; platevault's tables carry Pill/CoverageBar/Lock/Btn cells [verified via `ui/index.ts`] |
+| Tree / expandable rows | **Missing.** Issue #505 "TreeView Widget" open since 2021-09-15; #4218 "Datastructure that represents a tree" open [verified]. Third-party `slint-tree-view` 0.2.1 (2026-07-26) exists [verified crates.io] | hand-roll or take an unproven 0.2 crate |
+| ComboBox | Has it (text items) | none for plain; hand-roll for rich/searchable |
+| Date picker | Has `DatePickerPopup`/`TimePickerPopup` | none |
+| Modal / overlay | `PopupWindow`, `ContextMenu` | thin |
+| Toasts | **Missing** | hand-roll (overlay + timer queue); small |
+| Resizable split panes | **Missing** -- no Splitter widget in Std-Widgets | hand-roll on TouchArea drag; small-medium |
+| Command palette | **Missing**, and no fuzzy matcher | hand-roll: overlay + `nucleo`/`fuzzy-matcher` + keybinding. Medium |
+| Charts | **Missing** | `Path` elements hand-rolled, or `ruviz-slint` 0.11.0 (2026-08-16, brand-new) [verified crates.io] |
+| Interactive map | **Missing** | `slint-mapping` 0.1.0 (2026-05-18) [verified crates.io] -- 0.1, unproven. Leaflet has no equivalent |
+| Guided tour (joyride) | **Missing** | hand-roll |
+
+**Verdict: Tauri wins decisively.** Slint covers the primitive layer and virtualised lists well; it does not cover rich table cells, trees, maps, charts, or a palette, and those are not decoration in this app.
+
+## 4. Rust integration and the `.slint` DSL
+
+Mechanics [docs]: `.slint` files compile ahead of time via `slint-build` in `build.rs`, and `slint::include_modules!()` pulls the generated Rust into the crate; the `slint!` inline macro is the alternative. Generated per component: a struct with typed getters/setters per exported property and `on_<callback>` registration; models cross as `ModelRc`/`VecModel`. `docs.rs/slint/1.17.1` documents a `generated_code` pseudo-module and notes its "described structure is not really contained in the compiled crate" [docs].
+
+Costs, evidenced:
+- It is a real language with its own reactivity model -- Slint publishes a "reactivity-vs-react" page [verified in sitemap], which is itself an admission of the learning delta.
+- The `slint!` macro re-parses builtin widgets on every expansion, ~31% of expansion time (issue #12096, opened 2026-06-14, open) [verified].
+- `slint-updater` 1.16.1 exists as a tool to migrate `.slint` files across Slint versions [verified crates.io] -- the DSL has breaking syntax churn.
+
+Buys: LSP with editor plugins for VS Code, Kate, Qt Creator, Helix, Vim, Sublime, JetBrains, Zed [docs]; a formatter; and **live preview inside the real app** -- "runs inside your actual application with your real data and callbacks", "the application keeps running during reloads -- properties, callbacks, and models are preserved", errors non-fatal [docs]. Limit: renaming a property or callback used from Rust "may kill the app -- Recompile and restart" [docs].
+
+Versus JSX for these screens: JSX composes arbitrary expressions and hooks; `.slint` composes declarative elements with a constrained expression language. For form-heavy wizard screens (`WizardShell`, `SetupWizard`) the declarative form is arguably clearer. For anything computing layout from data (`useAdaptiveDock`, virtualised calendars) the logic moves to Rust and crosses a typed boundary each way.
+
+**Verdict: draw on ergonomics.** Slint's live preview is genuinely better than React Fast Refresh for pure-visual iteration because it preserves live state; the DSL's version churn and constrained expressions offset it.
+
+## 5. Compile-time safety -- the crux
+
+This is the section the decision should hinge on, so it is answered bug by bug, including the misses.
+
+Repo context that shapes every answer [verified]: the frontend is mid-migration to **vanilla-extract** -- 56 `.css.ts` files vs 24 remaining plain `.css` files under `apps/desktop/src`; commit `f736644bc` "migrate UI primitives and shared components to type-safe vanilla-extract styles (#1572)"; `eb8d2c5c5` "validate every CSS design-token reference (#1635)"; `8c0a8a6ac` "enforce lifecycle-string and CSS-selector ratchets in CI (#1604)"; guard scripts `scripts/check-pv-selector-ratchet.sh` (sealed at zero new `.pv-*` selectors in e2e), `scripts/check-tokens.sh`, `scripts/check-lifecycle-strings.sh`.
+
+### (a) Conditional `data-testid` broke 39 e2e specs while 2,376 unit tests passed
+
+**Slint would NOT have caught this.** `data-testid` is a test-affordance concept, not a type. The Slint analogue is `ElementHandle::find_by_accessible_label` / `find_by_element_id` [docs, `i-slint-backend-testing` 1.17.1], and `find_by_element_id` requires `SLINT_EMIT_DEBUG_INFO=1` at build time. A conditionally-set accessible label is just as invisible to the compiler as a conditional attribute. What changes is the *shape* of the failure: element ids in Slint derive from declared element names in the `.slint` source rather than from a hand-written string, so the "someone made the hook conditional" mistake is less natural to write. But the compiler does not reject it. **Verdict: NO -- mitigated by convention, not caught.**
+
+### (b) A removed CSS rule let sticky headers overlay a button
+
+**Slint would likely have caught this, structurally.** There is no `position: sticky` and no z-index stacking cascade in Slint; overlap is expressed by explicit layout containers (`VerticalBox`, `GridBox`) or explicit absolute coordinates. Deleting a property in a layout-managed tree changes geometry deterministically rather than un-suppressing an overlap. Two caveats: Slint does not "catch" it with an error message -- it just makes the class of bug much harder to construct; and if you *do* hand-place elements with absolute `x`/`y`, the overlap is fully expressible and uncaught. **Verdict: MOSTLY YES -- eliminated by construction in layout-managed code, not by a diagnostic.**
+
+### (c) Nine dead BEM selectors silently dropping styles
+
+**Slint would have caught this -- and so does vanilla-extract, which this repo is already adopting.** In `.slint`, styling is a property on an element; there is no selector to go stale, so the failure mode does not exist. Note the honest comparison: with 56 `.css.ts` files already migrated [verified] and `check-tokens.sh` plus #1635 in CI, the *current* stack has largely closed this too. A dead `style` export in vanilla-extract is caught by `knip` (`apps/desktop/package.json:35`) [verified]. **Verdict: YES -- but the delta against the repo's own trajectory is shrinking, not static.**
+
+### (d) A stale `className` rendering unstyled text
+
+**Slint would have caught this.** Same reason as (c): no string indirection between an element and its appearance. Under vanilla-extract, a renamed export is also a TS error; the bug was possible only in the not-yet-migrated plain-CSS remainder (24 files) [verified]. **Verdict: YES -- and the current stack catches it too, in migrated code only.**
+
+### (e) A token-emission bug bypassing the runtime type scale
+
+**Slint would NOT have caught this.** This is a generator producing wrong-but-well-typed output. Slint's equivalent design-token layer is a global singleton of properties, and a build step that emits a wrong value into a `global Tokens` block compiles cleanly and renders wrongly, identically. Only a value-level assertion catches it -- which is what `scripts/check-tokens.sh` and #1635 are [verified]. **Verdict: NO -- same class of bug, same required guard.**
+
+### Score and the honest read
+
+Three of five would be caught or structurally eliminated (b, c, d); two would not (a, e). Every one of the three is a **CSS-indirection** bug, and all three are the bugs the repo's vanilla-extract migration and token-validation CI already target. The two Slint would miss -- test-affordance drift and a bad generated value -- are the two that cost the most in this session.
+
+**Verdict on §5: Slint's compile-time safety is real but concentrated in exactly the area the repo is already fixing by other means.** Adopting a whole toolkit to close CSS indirection, when `.css.ts` + a token validator closes it at 56/80 files today, is not a proportionate trade. This weakens the strongest pro-Slint argument rather than strengthening it.
+
+## 6. Where Tauri + React genuinely wins
+
+- **Ecosystem, quantified.** In-use libraries with no Slint equivalent: `@tanstack/react-query` 5.101.2 (server-state cache, retry, invalidation), `@tanstack/react-router` 1.170.17, `@tanstack/react-virtual` 3.14.5, `cmdk` 1.1.1, `leaflet` 1.9.4, `@visx/*` 4.x, `react-hook-form` 7.81.0 + `zod` 4.4.3 + `@hookform/resolvers`, `react-joyride` 3.2.0, `astronomy-engine` 2.1.19, `date-fns` 4.4.0, `tinykeys` 4.0.0, `lucide-react` 1.24.0 [verified, `apps/desktop/package.json:44-74`]. Replacing TanStack Query alone means hand-writing request dedup, cache invalidation, and retry over the Tauri/IPC boundary.
+- **Design-token pipeline.** `style-dictionary` 5.5.0 → `build-tokens.mjs` → `gen-ve-themes.mjs` → typed vanilla-extract theme contract, with `--check` modes wired into `pnpm lint` [verified `package.json:16,28-32`]. Slint has a Figma variable exporter [docs] but nothing comparable to a token-source-of-truth build with CI drift checks.
+- **Restyling by a designer.** CSS is a skill market; `.slint` is not.
+- **Iteration loop.** Vite 7.2 HMR plus Vitest 4.1 in watch mode against jsdom. Slint's live preview preserves state better, but Rust recompiles for any logic change dominate the loop.
+- **Devtools.** Webview inspector gives computed styles, layout, network, profiler. Slint offers `debug()` to stderr, `SLINT_SLOW_ANIMATIONS`, `SLINT_SCALE_FACTOR` (FemtoVG/Skia only), `SLINT_DEBUG_PERFORMANCE`, and RenderDoc for GPU capture [docs]. That is a materially thinner inspection surface.
+
+## 7--8 + expansion: OS-integration capability parity
+
+Real plugin set at `origin/main` [verified, `apps/desktop/src-tauri/Cargo.toml:52-66` and plugin registration at `src/lib.rs:193-239`]: `tauri-plugin-dialog`, `tauri-plugin-opener`, `tauri-plugin-mcp-bridge`, `tauri-plugin-single-instance`, `tauri-plugin-window-state`, `tauri-plugin-log`, `tauri-plugin-updater`, `tauri-plugin-process`, plus `tauri-plugin-webdriver` 0.2 behind the `e2e` feature and `tauri-specta`.
+
+**Correction to the brief:** the brief's list omitted `tauri-plugin-mcp-bridge` and the `e2e`-gated `tauri-plugin-webdriver`. Also `tauri-plugin-notification` 2.3.3 is declared in the **workspace** `Cargo.toml:95` but is **not** registered in `lib.rs` [verified] -- consistent with `specs/SPEC_STATUS.md:93` recording US8 as not implemented. And `trash` 5.2 is already a plain crate at `Cargo.toml:112`, used by `crates/fs/executor` [verified] -- not a plugin at all, so it carries over to Slint unchanged.
+
+| Feature | Tauri today (evidence) | Slint equivalent | Gap |
+|---|---|---|---|
+| Signed auto-update | `tauri-plugin-updater`, minisign pubkey + GitHub `latest.json` endpoint in `tauri.conf.json:60-65`; staged flow in `src/data/updateSubscription.ts` (check → download+verify → deferred install), distinct `check-failed`/`download-failed`/`restart-failed` phases | `self_update` 0.44.0 (2026-07-16). Signature verification only via the non-default `signatures` feature using **zipsign**, and "Artifacts are assumed to have been signed using zipsign"; no checksum verification documented; **no relaunch API** [docs docs.rs]. Alternatives: Sparkle/WinSparkle via bindings (per-OS, two codebases), `cargo-dist` 0.32.0 installers | **HAND-ROLL** |
+| Update check / manifest / channels | Plugin defines the `latest.json` format and does the version compare; `PV_E2E_VERSION_OVERRIDE` test seam gated by `semver` (`Cargo.toml:44-47`) | Your own manifest format, fetch (`reqwest`, already in tree), semver compare, and "update available" UI. `self_update`'s GitHub backend does release listing; channels are yours | **HAND-ROLL** |
+| Folder / multi-file picker | `tauri-plugin-dialog` via `commands/native.rs:30,62` (`native_directory_pick`, `native_file_pick`) | `rfd` 0.17.2 (2026-01-12, 25.5M downloads) -- async API, Win/mac/Linux | **CRATE-EXISTS** |
+| Drop folders onto window | Tauri core emits `tauri://drag-drop` with paths (recorded in `docs/research/tauri-plugin-api-audit-2026-07-05.md:186`) | `DropArea` (1.17.0) accepts drops "from another application on platforms that support it"; **the docs never name the platforms, never mention files, and never mention file paths** [docs, droparea + drag-and-drop guide]. `data-transfer` "abstracts over the file-type transfer mechanisms supported by each platform"; only plain-text MIME helpers are documented. Open crash: #12437 "Crash when dragging file onto winit window" (2026-07-10, labelled `upstream`) [verified] | **UNAVAILABLE as verified** -- could not confirm path delivery on any platform; a live spike is required before trusting it |
+| Reveal in Finder/Explorer | `tauri-plugin-opener` `reveal_item_in_dir` + Linux `xdg-open` fallback + audit, `commands/native.rs:100-185` | `open` 5.4.1 / `opener` 0.8.5 open a path but, per the repo's own audit (`docs/research/tauri-plugin-api-audit-2026-07-05.md:208`), "neither reliably *selects/highlights* the item" | **HAND-ROLL** (per-OS: `open -R` on macOS, `explorer /select,` on Windows, DBus FileManager1 on Linux) |
+| Trash / recycle bin | `trash` 5.2 crate, `crates/fs/executor` | identical crate | **NONE** |
+| Filesystem watching | `notify` >=8,<9 + `notify-debouncer-full` in `crates/fs/inventory/Cargo.toml:14-15` | identical crates | **NONE** |
+| System tray icon | not used today (no tray reference in `src-tauri` [verified]) | `SystemTrayIcon` element, 1.17.0: `NSStatusItem`, `Shell_NotifyIcon`, StatusNotifierItem/AppIndicator. Limits: exactly one `Menu` child not inside `if`/`for`; `shortcut` bindings ignored; globals not shared with the Window; `title` no-op on Windows; on macOS `clicked` doesn't fire with a populated menu; "plain X11 system trays are not supported" [docs] | **NONE** (Slint is arguably ahead here) |
+| Native menu bar | `bootstrap/menu.rs:15-59` builds App/Edit/Window submenus from `PredefinedMenuItem::{about,quit,undo,redo,cut,copy,paste,select_all,minimize,close_window}` + `Settings…` with `CmdOrCtrl+,` | Slint `MenuBar` (1.10.0) with `shortcut` on `MenuItem` (1.16.x) [verified CHANGELOG]; winit path builds via **muda** (issue #9792 references "muda menubar build") [verified]. No documented predefined-item set equivalent to Tauri's -- standard Edit-menu roles are yours to declare, or drop to `muda` 0.19.3 directly | **CRATE-EXISTS / partial HAND-ROLL** |
+| Window state persistence | `tauri-plugin-window-state`; app adds `enforce_min_window_size` and `recenter_if_offscreen` with 11 unit tests (`bootstrap/window.rs:65,82`) | nothing. Serialise position/size/maximised yourself; Slint's window API exposes them. The offscreen/multi-monitor logic already lives in the app's own tested code and carries over | **HAND-ROLL** (small) |
+| Single instance | `tauri-plugin-single-instance`, registered `lib.rs`; **focuses the existing window** on second launch | `single-instance` 0.3.3 (last published **2021-12-16**, 862k downloads) or `fslock`; a raw lock blocks but does not focus. Focus-existing-window is per-OS IPC you write | **HAND-ROLL** |
+| Splash → main handshake | two windows declared in `tauri.conf.json:13-31` (`main` `visible:false`, `splash` transparent/undecorated/centred), driven from `src/splash/main.ts` | Slint supports multiple windows and undecorated/transparent windows; issue #11001 "Slint aggressively overrides window properties" (open, 2026-03-12) and #2521 custom-titlebar proposal (open since 2023) are the risk markers [verified] | **CRATE-EXISTS with risk** |
+| Taskbar progress / overlay badge, jump lists, Dock badge | not used today | nothing in Slint. Raw `windows` crate `ITaskbarList3` / `objc2` `NSDockTile` | **HAND-ROLL** |
+| OS notifications | `tauri-plugin-notification` 2.3.3 declared (`Cargo.toml:95`) but **not registered**; spec 051 US8 open per `specs/SPEC_STATUS.md:93` | `notify-rust` 4.18.0 (2026-06-16). The repo's own audit already rates it "viable" for backend-triggered notifications (`tauri-plugin-api-audit-2026-07-05.md:210`) | **CRATE-EXISTS** -- fair comparison, unbuilt on both sides |
+| Diagnostics log file | `tauri-plugin-log` + `tracing-appender` for the rotating file (`Cargo.toml:71`), `lib.rs:217` uses `skip_logger()` | `tracing` + `tracing-appender` unchanged -- the plugin is only the JS-side bridge | **NONE** |
+| Crash reporting | none today [verified: no sentry/crash crate in `Cargo.toml`] | `sentry` or `minidumper`/`crash-handler`, identical on both | **NONE** |
+| Packaging, notarisation, Authenticode | `cargo tauri build` + `@tauri-apps/cli` 2.11.4; signing pipeline merged (`SPEC_STATUS.md:93` cites `60732f2f`/#469) | `cargo-packager` 0.11.8 (2025-11-27, 165k downloads) is the closest and is by ex-Tauri authors; `cargo-dist` 0.32.0 (2026-05-22) does archives/installers/CI but is CLI-shaped; otherwise hand-rolled CI per platform | **HAND-ROLL** -- this is where the hidden cost lives |
+| E2E driving | `tauri-plugin-webdriver` 0.2 behind `e2e` feature + Playwright 1.61 over 35 spec files [verified] | `i-slint-backend-testing` 1.17.1: `find_by_accessible_label`, `find_by_element_id`, `single_click`/`double_click`, headless via `SLINT_BACKEND=headless`. Explicitly "should **not be used directly** by applications", "does not follow the semver convention", breaking changes "in any patch release", pin `=x.y.z`. **No documented keyboard API.** MCP server for agent-driven inspection (`SLINT_MCP_PORT`) | **CRATE-EXISTS with sharp edges** |
+| IPC contract typing | `tauri-specta` + `specta-typescript` generate the TS surface from Rust (`Cargo.toml:48-49,62`), contract parity tested | no boundary to cross -- the UI is Rust. This is the cleanest structural win for Slint | **NONE (Slint better)** |
+
+**Verdict 7--8: Tauri wins, and signed auto-update is the decisive item.** The current flow is check → download → minisign-verify → defer install → explicit relaunch, with three distinct failure phases and a test seam [verified in `updateSubscription.ts`]. The best Slint-side answer, `self_update` with the non-default `signatures` feature, verifies zipsign-signed archives and has no relaunch. Reproducing today's behaviour means: own the manifest format, own the signing (zipsign or minisign directly), own the atomic swap on three platforms, and own relaunch. Folder drag-and-drop is second: unverifiable from docs and with an open upstream crash.
+
+## Added dimension: contract boundary (the one real structural win)
+
+Going Slint deletes an entire layer: no `tauri-specta` codegen, no `contracts_core` → TypeScript projection, no JSON serialisation per call, no dual test stacks (Vitest 4.1 + Playwright 1.61 alongside `cargo test`). A UI callback becomes a Rust function call. Against that, the repo's Tier-1/Tier-2 durability model (constitution V) and all business logic already live in Rust crates -- the boundary is doing real architectural work today, not just ceremony.
+
+## Recommendation
+
+**Greenfield, for THIS app: Tauri + React.**
+
+The reasoning is concentrated, not diffuse. platevault is not a control panel; it is a table-and-data application with a Leaflet map, four visx chart families, a fuzzy command palette, guided tours, six virtualisation sites, and rich interactive table cells. Slint's Std-Widgets stop at text-only table cells, have no tree after five years of an open issue (#505), and have no chart or map story beyond 0.1-version third-party crates. Add signed auto-update, which Slint cannot match at any level, and unverifiable folder drop into the window on an app whose core loop is "point me at a folder".
+
+The compile-time-safety case -- the one genuinely strong argument for Slint -- turns out to target CSS indirection specifically, and the repo is 56/80 files into a vanilla-extract migration plus a token validator in CI that closes the same class. Two of the five real bugs would have shipped under Slint identically.
+
+## Strongest argument against my own recommendation
+
+**The bug ledger is the evidence, and it favours Slint.** In one session this stack produced five defects, three of them pure presentation-layer indirection, and one of them (the conditional `data-testid`) broke 39 of 35+ e2e spec files while 2,376 unit tests stayed green. That is not bad luck; it is what a stack with three uncoordinated naming systems -- CSS classes, test ids, and token strings -- produces structurally. Slint deletes two of the three. My counter-argument leans on the vanilla-extract migration *finishing* and the token validator *holding* -- a trajectory, not a state. If that migration stalls at 56/80, or if the widget gaps could be closed once by a competent Rust developer (a table on ListView, a palette on `nucleo`, charts on `Path`) and then never regress, then a Slint build trades a permanent class of runtime styling bugs for a bounded one-time widget build. That is a defensible trade, and someone who values eliminated bug classes over ecosystem breadth should make it.
+
+## What I could not determine
+
+1. **Binary size, startup time, and battery draw** for any Slint renderer -- no benchmark run, none published in the pages fetched. Every size/startup statement above is unmeasured.
+2. **Whether Slint's `DropArea` delivers OS file paths from a file-manager drop, on any platform.** The docs say drops from other applications work "on platforms that support it" and never name the platforms or mention files. Requires a spike on macOS, Windows, and Linux.
+3. **Whether `StandardTableView` supports user column-drag resizing.** `width`/`min_width`/`horizontal_stretch` exist; the docs never say the user can drag.
+4. **The Startup & Individual tier price.** The pricing page fetch returned no monetary figures; the owner's ~$10 is unconfirmed against the vendor page.
+5. **Whether the paid GUI Test Framework is required for practical e2e**, or whether `i-slint-backend-testing` suffices given its no-keyboard-API and patch-level-breakage caveats.
+6. **Slint's software-renderer text quality for pt-BR diacritics** -- "limited to western scripts" is documented; rendering fidelity was not evaluated.


### PR DESCRIPTION
Docs only — two research reports under `docs/research/`, no code changes.

## Summary

- Records the evaluation of ten Rust GUI toolkits against Tauri, and the decision to stay on Tauri.

## Why keep the reports rather than just the verdict

Two findings a future reader would otherwise have to rediscover:

**The licence correction.** The first pass concluded Slint was licence-blocked. That was **wrong**: GPLv3 §13 explicitly permits linking or combining with AGPLv3, and the AGPL network clause then governs the combination. Slint's free GPLv3 option was always compatible with this AGPL-3.0-only app, at zero cost.

**The counter-case.** Slint's compiler would have caught **three of five** real defects from a single session — nine dead BEM selectors, a stale `className` rendering unstyled, and (mostly) a removed CSS rule letting sticky headers overlay a button. All three are CSS-indirection bugs. It would **not** have caught the two expensive ones: a conditional `data-testid` that broke 39 e2e specs while 2,376 unit tests passed, and a token-emission bug that was a well-typed wrong value.

The rebuttal rests on the vanilla-extract migration *finishing* and the token validator *holding* — a trajectory, not a state. If either stalls, the decision is worth reopening.

## What decided it

Not migration cost or accessibility — both were excluded at the owner's instruction, which is what made this a genuine comparison rather than a defence of the status quo. It came down to: text-only tables and a TreeView issue open since 2021; **no signed-updater equivalent at any level** (`self_update` verifies only zipsign archives behind a non-default feature and has no relaunch API); and folder drag-and-drop file paths that could not be verified to work through Slint's `DropArea` on any platform — core to a local-first ingest app.

## Spec Context

Decision recorded on `astro-plan-8hng`.
